### PR TITLE
Replace header guards in ScriptRepository and SINQ with pragma once

### DIFF
--- a/Framework/SINQ/inc/MantidSINQ/DllConfig.h
+++ b/Framework/SINQ/inc/MantidSINQ/DllConfig.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_SINQ_DLLCONFIG_H_
-#define MANTID_SINQ_DLLCONFIG_H_
+#pragma once
 
 /*
     This file contains the DLLExport/DLLImport linkage configuration for the
@@ -20,5 +19,3 @@
 #define MANTID_SINQ_DLL DLLImport
 #define EXTERN_MANTID_SINQ EXTERN_IMPORT
 #endif /* IN_MANTID_SINQ */
-
-#endif // MANTID_SINQ_DLLCONFIG_H_

--- a/Framework/SINQ/inc/MantidSINQ/InvertMDDim.h
+++ b/Framework/SINQ/inc/MantidSINQ/InvertMDDim.h
@@ -13,8 +13,7 @@
  *
  *
  */
-#ifndef INVERTMDDIM_H_
-#define INVERTMDDIM_H_
+#pragma once
 
 #include "MantidAPI/Algorithm.h"
 #include "MantidAPI/IMDHistoWorkspace_fwd.h"
@@ -55,5 +54,3 @@ private:
   unsigned int calcInvertedIndex(Mantid::API::IMDHistoWorkspace_sptr ws,
                                  int *dim);
 };
-
-#endif /*INVERTMDDIM_H_*/

--- a/Framework/SINQ/inc/MantidSINQ/LoadFlexiNexus.h
+++ b/Framework/SINQ/inc/MantidSINQ/LoadFlexiNexus.h
@@ -24,8 +24,7 @@
  *
  */
 
-#ifndef FLEXINEXUSLOADER_H_
-#define FLEXINEXUSLOADER_H_
+#pragma once
 
 #include "MantidAPI/Algorithm.h"
 #include "MantidSINQ/DllConfig.h"
@@ -88,5 +87,3 @@ private:
   int calculateCAddress(int *pos, int *dim, int rank);
   int calculateF77Address(int *pos, int rank);
 };
-
-#endif /*FLEXINEXUSLOADER_H_*/

--- a/Framework/SINQ/inc/MantidSINQ/MDHistoToWorkspace2D.h
+++ b/Framework/SINQ/inc/MantidSINQ/MDHistoToWorkspace2D.h
@@ -13,8 +13,7 @@
  *
  *
  */
-#ifndef MDHISTOTOWORKSPACE2D_H_
-#define MDHISTOTOWORKSPACE2D_H_
+#pragma once
 
 #include "MantidAPI/Algorithm.h"
 #include "MantidAPI/IMDHistoWorkspace_fwd.h"
@@ -62,5 +61,3 @@ private:
   void copyMetaData(Mantid::API::IMDHistoWorkspace_sptr inWS,
                     Mantid::DataObjects::Workspace2D_sptr outWS);
 };
-
-#endif /*MDHISTOTOWORKSPACE2D_H_*/

--- a/Framework/SINQ/inc/MantidSINQ/PoldiAnalyseResiduals.h
+++ b/Framework/SINQ/inc/MantidSINQ/PoldiAnalyseResiduals.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_SINQ_POLDIANALYSERESIDUALS_H_
-#define MANTID_SINQ_POLDIANALYSERESIDUALS_H_
+#pragma once
 
 #include "MantidAPI/Algorithm.h"
 #include "MantidSINQ/DllConfig.h"
@@ -64,5 +63,3 @@ private:
 
 } // namespace Poldi
 } // namespace Mantid
-
-#endif /* MANTID_SINQ_POLDIANALYSERESIDUALS_H_ */

--- a/Framework/SINQ/inc/MantidSINQ/PoldiAutoCorrelation5.h
+++ b/Framework/SINQ/inc/MantidSINQ/PoldiAutoCorrelation5.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_DATAHANDLING_PoldiAutoCorrelation5_H_
-#define MANTID_DATAHANDLING_PoldiAutoCorrelation5_H_
+#pragma once
 
 //----------------------------------------------------------------------
 // Includes
@@ -72,5 +71,3 @@ private:
 
 } // namespace Poldi
 } // namespace Mantid
-
-#endif /* MANTID_DATAHANDLING_PoldiAutoCorrelation5_H_*/

--- a/Framework/SINQ/inc/MantidSINQ/PoldiCreatePeaksFromCell.h
+++ b/Framework/SINQ/inc/MantidSINQ/PoldiCreatePeaksFromCell.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_SINQ_POLDICREATEPEAKSFROMCELL_H_
-#define MANTID_SINQ_POLDICREATEPEAKSFROMCELL_H_
+#pragma once
 
 #include "MantidAPI/Algorithm.h"
 #include "MantidSINQ/DllConfig.h"
@@ -61,5 +60,3 @@ private:
 
 } // namespace Poldi
 } // namespace Mantid
-
-#endif /* MANTID_SINQ_POLDICREATEPEAKSFROMCELL_H_ */

--- a/Framework/SINQ/inc/MantidSINQ/PoldiFitPeaks1D.h
+++ b/Framework/SINQ/inc/MantidSINQ/PoldiFitPeaks1D.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_SINQ_POLDIFITPEAKS1D_H_
-#define MANTID_SINQ_POLDIFITPEAKS1D_H_
+#pragma once
 
 #include "MantidAPI/Algorithm.h"
 #include "MantidKernel/System.h"
@@ -67,5 +66,3 @@ private:
 
 } // namespace Poldi
 } // namespace Mantid
-
-#endif /* MANTID_SINQ_POLDIFITPEAKS1D_H_ */

--- a/Framework/SINQ/inc/MantidSINQ/PoldiFitPeaks1D2.h
+++ b/Framework/SINQ/inc/MantidSINQ/PoldiFitPeaks1D2.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_SINQ_POLDIFITPEAKS1D2_H_
-#define MANTID_SINQ_POLDIFITPEAKS1D2_H_
+#pragma once
 
 #include "MantidAPI/Algorithm.h"
 #include "MantidKernel/System.h"
@@ -131,5 +130,3 @@ private:
 
 } // namespace Poldi
 } // namespace Mantid
-
-#endif /* MANTID_SINQ_POLDIFITPEAKS1D2_H_ */

--- a/Framework/SINQ/inc/MantidSINQ/PoldiFitPeaks2D.h
+++ b/Framework/SINQ/inc/MantidSINQ/PoldiFitPeaks2D.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_SINQ_POLDICALCULATESPECTRUM2D_H_
-#define MANTID_SINQ_POLDICALCULATESPECTRUM2D_H_
+#pragma once
 
 #include "MantidAPI/Algorithm.h"
 #include "MantidAPI/IFunction.h"
@@ -160,5 +159,3 @@ private:
 
 } // namespace Poldi
 } // namespace Mantid
-
-#endif /* MANTID_SINQ_POLDICALCULATESPECTRUM2D_H_ */

--- a/Framework/SINQ/inc/MantidSINQ/PoldiIndexKnownCompounds.h
+++ b/Framework/SINQ/inc/MantidSINQ/PoldiIndexKnownCompounds.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_SINQ_POLDIINDEXKNOWNCOMPOUNDS_H_
-#define MANTID_SINQ_POLDIINDEXKNOWNCOMPOUNDS_H_
+#pragma once
 
 #include "MantidAPI/Algorithm.h"
 #include "MantidSINQ/DllConfig.h"
@@ -152,5 +151,3 @@ private:
 
 } // namespace Poldi
 } // namespace Mantid
-
-#endif /* MANTID_SINQ_POLDIINDEXKNOWNCOMPOUNDS_H_ */

--- a/Framework/SINQ/inc/MantidSINQ/PoldiPeakSearch.h
+++ b/Framework/SINQ/inc/MantidSINQ/PoldiPeakSearch.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_SINQ_POLDIPEAKSEARCH_H_
-#define MANTID_SINQ_POLDIPEAKSEARCH_H_
+#pragma once
 
 #include "MantidSINQ/DllConfig.h"
 
@@ -121,5 +120,3 @@ private:
 
 } // namespace Poldi
 } // namespace Mantid
-
-#endif /* MANTID_SINQ_POLDIPEAKSEARCH_H_ */

--- a/Framework/SINQ/inc/MantidSINQ/PoldiPeakSummary.h
+++ b/Framework/SINQ/inc/MantidSINQ/PoldiPeakSummary.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_POLDI_POLDIPEAKSUMMARY_H_
-#define MANTID_POLDI_POLDIPEAKSUMMARY_H_
+#pragma once
 
 #include "MantidAPI/Algorithm.h"
 #include "MantidSINQ/DllConfig.h"
@@ -48,5 +47,3 @@ private:
 
 } // namespace Poldi
 } // namespace Mantid
-
-#endif /* MANTID_POLDI_POLDIPEAKSUMMARY_H_ */

--- a/Framework/SINQ/inc/MantidSINQ/PoldiTruncateData.h
+++ b/Framework/SINQ/inc/MantidSINQ/PoldiTruncateData.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_SINQ_POLDITRUNCATEDATA_H_
-#define MANTID_SINQ_POLDITRUNCATEDATA_H_
+#pragma once
 
 #include "MantidAPI/Algorithm.h"
 #include "MantidKernel/System.h"
@@ -81,5 +80,3 @@ private:
 
 } // namespace Poldi
 } // namespace Mantid
-
-#endif /* MANTID_SINQ_POLDITRUNCATEDATA_H_ */

--- a/Framework/SINQ/inc/MantidSINQ/PoldiUtilities/IPoldiFunction1D.h
+++ b/Framework/SINQ/inc/MantidSINQ/PoldiUtilities/IPoldiFunction1D.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_SINQ_IPOLDIFUNCTION1D_H_
-#define MANTID_SINQ_IPOLDIFUNCTION1D_H_
+#pragma once
 
 #include "MantidAPI/FunctionDomain1D.h"
 #include "MantidAPI/FunctionValues.h"
@@ -41,5 +40,3 @@ public:
 
 } // namespace Poldi
 } // namespace Mantid
-
-#endif /* MANTID_SINQ_IPOLDIFUNCTION1D_H_ */

--- a/Framework/SINQ/inc/MantidSINQ/PoldiUtilities/MillerIndices.h
+++ b/Framework/SINQ/inc/MantidSINQ/PoldiUtilities/MillerIndices.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_SINQ_MILLERINDICES_H
-#define MANTID_SINQ_MILLERINDICES_H
+#pragma once
 
 #include "MantidKernel/V3D.h"
 #include "MantidSINQ/DllConfig.h"
@@ -52,5 +51,3 @@ private:
 };
 } // namespace Poldi
 } // namespace Mantid
-
-#endif // MANTID_SINQ_MILLERINDICES_H

--- a/Framework/SINQ/inc/MantidSINQ/PoldiUtilities/MillerIndicesIO.h
+++ b/Framework/SINQ/inc/MantidSINQ/PoldiUtilities/MillerIndicesIO.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_SINQ_MILLERINDICESIO_H
-#define MANTID_SINQ_MILLERINDICESIO_H
+#pragma once
 
 #include "MantidSINQ/DllConfig.h"
 #include "MantidSINQ/PoldiUtilities/MillerIndices.h"
@@ -49,5 +48,3 @@ private:
 };
 } // namespace Poldi
 } // namespace Mantid
-
-#endif // MANTID_SINQ_MILLERINDICESIO_H

--- a/Framework/SINQ/inc/MantidSINQ/PoldiUtilities/Poldi2DFunction.h
+++ b/Framework/SINQ/inc/MantidSINQ/PoldiUtilities/Poldi2DFunction.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_SINQ_POLDI2DFUNCTION_H_
-#define MANTID_SINQ_POLDI2DFUNCTION_H_
+#pragma once
 
 #include "MantidAPI/CompositeFunction.h"
 #include "MantidAPI/IFunction1DSpectrum.h"
@@ -53,5 +52,3 @@ using Poldi2DFunction_sptr = boost::shared_ptr<Poldi2DFunction>;
 
 } // namespace Poldi
 } // namespace Mantid
-
-#endif /* MANTID_SINQ_POLDI2DFUNCTION_H_ */

--- a/Framework/SINQ/inc/MantidSINQ/PoldiUtilities/PoldiAbstractChopper.h
+++ b/Framework/SINQ/inc/MantidSINQ/PoldiUtilities/PoldiAbstractChopper.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef POLDIABSTRACTCHOPPER_H
-#define POLDIABSTRACTCHOPPER_H
+#pragma once
 
 #include "MantidSINQ/DllConfig.h"
 
@@ -49,5 +48,3 @@ protected:
 using PoldiAbstractChopper_sptr = boost::shared_ptr<PoldiAbstractChopper>;
 } // namespace Poldi
 } // namespace Mantid
-
-#endif // POLDIABSTRACTCHOPPER_H

--- a/Framework/SINQ/inc/MantidSINQ/PoldiUtilities/PoldiAbstractDetector.h
+++ b/Framework/SINQ/inc/MantidSINQ/PoldiUtilities/PoldiAbstractDetector.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef POLDIABSTRACTDETECTOR_H
-#define POLDIABSTRACTDETECTOR_H
+#pragma once
 
 #include "MantidSINQ/DllConfig.h"
 
@@ -55,4 +54,3 @@ protected:
 using PoldiAbstractDetector_sptr = boost::shared_ptr<PoldiAbstractDetector>;
 } // namespace Poldi
 } // namespace Mantid
-#endif // POLDIABSTRACTDETECTOR_H

--- a/Framework/SINQ/inc/MantidSINQ/PoldiUtilities/PoldiAutoCorrelationCore.h
+++ b/Framework/SINQ/inc/MantidSINQ/PoldiUtilities/PoldiAutoCorrelationCore.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_SINQ_POLDIAUTOCORRELATIONCORE_H_
-#define MANTID_SINQ_POLDIAUTOCORRELATIONCORE_H_
+#pragma once
 
 #include "MantidKernel/System.h"
 
@@ -124,5 +123,3 @@ protected:
 
 } // namespace Poldi
 } // namespace Mantid
-
-#endif /* MANTID_SINQ_POLDIAUTOCORRELATIONCORE_H_ */

--- a/Framework/SINQ/inc/MantidSINQ/PoldiUtilities/PoldiBasicChopper.h
+++ b/Framework/SINQ/inc/MantidSINQ/PoldiUtilities/PoldiBasicChopper.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_SINQ_POLDIBASICCHOPPER_H_
-#define MANTID_SINQ_POLDIBASICCHOPPER_H_
+#pragma once
 
 #include "MantidKernel/System.h"
 
@@ -67,5 +66,3 @@ protected:
 
 } // namespace Poldi
 } // namespace Mantid
-
-#endif /* MANTID_SINQ_POLDIBASICCHOPPER_H_ */

--- a/Framework/SINQ/inc/MantidSINQ/PoldiUtilities/PoldiChopperFactory.h
+++ b/Framework/SINQ/inc/MantidSINQ/PoldiUtilities/PoldiChopperFactory.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_SINQ_POLDICHOPPERFACTORY_H_
-#define MANTID_SINQ_POLDICHOPPERFACTORY_H_
+#pragma once
 
 #include "MantidKernel/System.h"
 
@@ -31,5 +30,3 @@ public:
 
 } // namespace Poldi
 } // namespace Mantid
-
-#endif /* MANTID_SINQ_POLDICHOPPERFACTORY_H_ */

--- a/Framework/SINQ/inc/MantidSINQ/PoldiUtilities/PoldiConversions.h
+++ b/Framework/SINQ/inc/MantidSINQ/PoldiUtilities/PoldiConversions.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_SINQ_POLDICONVERSIONS_H
-#define MANTID_SINQ_POLDICONVERSIONS_H
+#pragma once
 
 #include "MantidSINQ/DllConfig.h"
 
@@ -29,5 +28,3 @@ double MANTID_SINQ_DLL radToDeg(double radians);
 } // namespace Conversions
 } // namespace Poldi
 } // namespace Mantid
-
-#endif // MANTID_SINQ_POLDICONVERSIONS_H

--- a/Framework/SINQ/inc/MantidSINQ/PoldiUtilities/PoldiDGrid.h
+++ b/Framework/SINQ/inc/MantidSINQ/PoldiUtilities/PoldiDGrid.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_SINQ_POLDIDGRID_H
-#define MANTID_SINQ_POLDIDGRID_H
+#pragma once
 
 #include "MantidSINQ/DllConfig.h"
 
@@ -61,5 +60,3 @@ protected:
 };
 } // namespace Poldi
 } // namespace Mantid
-
-#endif // MANTID_SINQ_POLDIDGRID_H

--- a/Framework/SINQ/inc/MantidSINQ/PoldiUtilities/PoldiDeadWireDecorator.h
+++ b/Framework/SINQ/inc/MantidSINQ/PoldiUtilities/PoldiDeadWireDecorator.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_SINQ_POLDIDEADWIREDECORATOR_H_
-#define MANTID_SINQ_POLDIDEADWIREDECORATOR_H_
+#pragma once
 
 #include "MantidKernel/System.h"
 
@@ -56,5 +55,3 @@ protected:
 
 } // namespace Poldi
 } // namespace Mantid
-
-#endif /* MANTID_SINQ_POLDIDEADWIREDECORATOR_H_ */

--- a/Framework/SINQ/inc/MantidSINQ/PoldiUtilities/PoldiDetectorDecorator.h
+++ b/Framework/SINQ/inc/MantidSINQ/PoldiUtilities/PoldiDetectorDecorator.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_SINQ_POLDIDETECTORDECORATOR_H_
-#define MANTID_SINQ_POLDIDETECTORDECORATOR_H_
+#pragma once
 
 #include "MantidKernel/System.h"
 #include "MantidSINQ/DllConfig.h"
@@ -57,5 +56,3 @@ protected:
 
 } // namespace Poldi
 } // namespace Mantid
-
-#endif /* MANTID_SINQ_POLDIDETECTORDECORATOR_H_ */

--- a/Framework/SINQ/inc/MantidSINQ/PoldiUtilities/PoldiDetectorFactory.h
+++ b/Framework/SINQ/inc/MantidSINQ/PoldiUtilities/PoldiDetectorFactory.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_SINQ_POLDIDETECTORFACTORY_H_
-#define MANTID_SINQ_POLDIDETECTORFACTORY_H_
+#pragma once
 
 #include "MantidSINQ/DllConfig.h"
 
@@ -37,5 +36,3 @@ protected:
 
 } // namespace Poldi
 } // namespace Mantid
-
-#endif /* MANTID_SINQ_POLDIDETECTORFACTORY_H_ */

--- a/Framework/SINQ/inc/MantidSINQ/PoldiUtilities/PoldiHeliumDetector.h
+++ b/Framework/SINQ/inc/MantidSINQ/PoldiUtilities/PoldiHeliumDetector.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef POLDIHELIUMDETECTOR_H
-#define POLDIHELIUMDETECTOR_H
+#pragma once
 
 #include "MantidSINQ/DllConfig.h"
 #include "MantidSINQ/PoldiUtilities/PoldiAbstractDetector.h"
@@ -76,5 +75,3 @@ protected:
 };
 } // namespace Poldi
 } // namespace Mantid
-
-#endif // POLDIHELIUMDETECTOR_H

--- a/Framework/SINQ/inc/MantidSINQ/PoldiUtilities/PoldiInstrumentAdapter.h
+++ b/Framework/SINQ/inc/MantidSINQ/PoldiUtilities/PoldiInstrumentAdapter.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_SINQ_POLDIINSTRUMENTADAPTER_H_
-#define MANTID_SINQ_POLDIINSTRUMENTADAPTER_H_
+#pragma once
 
 #include "MantidAPI/MatrixWorkspace_fwd.h"
 #include "MantidAPI/Run.h"
@@ -139,5 +138,3 @@ using PoldiInstrumentAdapter_sptr = boost::shared_ptr<PoldiInstrumentAdapter>;
 
 } // namespace Poldi
 } // namespace Mantid
-
-#endif /* MANTID_SINQ_POLDIINSTRUMENTADAPTER_H_ */

--- a/Framework/SINQ/inc/MantidSINQ/PoldiUtilities/PoldiMockInstrumentHelpers.h
+++ b/Framework/SINQ/inc/MantidSINQ/PoldiUtilities/PoldiMockInstrumentHelpers.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef POLDIMOCKINSTRUMENTHELPERS_H
-#define POLDIMOCKINSTRUMENTHELPERS_H
+#pragma once
 
 #include "MantidSINQ/DllConfig.h"
 #include "MantidSINQ/PoldiUtilities/PoldiAbstractChopper.h"
@@ -551,4 +550,3 @@ public:
 };
 } // namespace Poldi
 } // namespace Mantid
-#endif // POLDIMOCKINSTRUMENTHELPERS_H

--- a/Framework/SINQ/inc/MantidSINQ/PoldiUtilities/PoldiPeak.h
+++ b/Framework/SINQ/inc/MantidSINQ/PoldiUtilities/PoldiPeak.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_SINQ_POLDIPEAK_H
-#define MANTID_SINQ_POLDIPEAK_H
+#pragma once
 
 #include "MantidSINQ/DllConfig.h"
 #include "MantidSINQ/PoldiUtilities/MillerIndices.h"
@@ -84,5 +83,3 @@ private:
 };
 } // namespace Poldi
 } // namespace Mantid
-
-#endif // MANTID_SINQ_POLDIPEAK_H

--- a/Framework/SINQ/inc/MantidSINQ/PoldiUtilities/PoldiPeakCollection.h
+++ b/Framework/SINQ/inc/MantidSINQ/PoldiUtilities/PoldiPeakCollection.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_SINQ_POLDIPEAKCOLLECTION_H
-#define MANTID_SINQ_POLDIPEAKCOLLECTION_H
+#pragma once
 
 #include "MantidDataObjects/TableWorkspace.h"
 #include "MantidGeometry/Crystal/CrystalStructure.h"
@@ -107,5 +106,3 @@ protected:
 };
 } // namespace Poldi
 } // namespace Mantid
-
-#endif // MANTID_SINQ_POLDIPEAKCOLLECTION_H

--- a/Framework/SINQ/inc/MantidSINQ/PoldiUtilities/PoldiResidualCorrelationCore.h
+++ b/Framework/SINQ/inc/MantidSINQ/PoldiUtilities/PoldiResidualCorrelationCore.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_SINQ_POLDIRESIDUALCORRELATIONCORE_H_
-#define MANTID_SINQ_POLDIRESIDUALCORRELATIONCORE_H_
+#pragma once
 
 #include "MantidSINQ/DllConfig.h"
 #include "MantidSINQ/PoldiUtilities/PoldiAutoCorrelationCore.h"
@@ -58,5 +57,3 @@ protected:
 
 } // namespace Poldi
 } // namespace Mantid
-
-#endif /* MANTID_SINQ_POLDIRESIDUALCORRELATIONCORE_H_ */

--- a/Framework/SINQ/inc/MantidSINQ/PoldiUtilities/PoldiSourceSpectrum.h
+++ b/Framework/SINQ/inc/MantidSINQ/PoldiUtilities/PoldiSourceSpectrum.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_SINQ_POLDISOURCESPECTRUM_H
-#define MANTID_SINQ_POLDISOURCESPECTRUM_H
+#pragma once
 
 #include "MantidGeometry/Instrument.h"
 #include "MantidKernel/Interpolation.h"
@@ -50,5 +49,3 @@ using PoldiSourceSpectrum_const_sptr =
     boost::shared_ptr<const PoldiSourceSpectrum>;
 } // namespace Poldi
 } // namespace Mantid
-
-#endif // MANTID_SINQ_POLDISOURCESPECTRUM_H

--- a/Framework/SINQ/inc/MantidSINQ/PoldiUtilities/PoldiSpectrumConstantBackground.h
+++ b/Framework/SINQ/inc/MantidSINQ/PoldiUtilities/PoldiSpectrumConstantBackground.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_SINQ_POLDISPECTRUMCONSTANTBACKGROUND_H_
-#define MANTID_SINQ_POLDISPECTRUMCONSTANTBACKGROUND_H_
+#pragma once
 
 #include "MantidAPI/IFunction1D.h"
 #include "MantidAPI/ParamFunction.h"
@@ -62,5 +61,3 @@ protected:
 
 } // namespace Poldi
 } // namespace Mantid
-
-#endif /* MANTID_SINQ_POLDISPECTRUMCONSTANTBACKGROUND_H_ */

--- a/Framework/SINQ/inc/MantidSINQ/PoldiUtilities/PoldiSpectrumDomainFunction.h
+++ b/Framework/SINQ/inc/MantidSINQ/PoldiUtilities/PoldiSpectrumDomainFunction.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_SINQ_POLDISPECTRUMDOMAINFUNCTION_H_
-#define MANTID_SINQ_POLDISPECTRUMDOMAINFUNCTION_H_
+#pragma once
 
 #include "MantidAPI/FunctionDomain1D.h"
 #include "MantidAPI/FunctionParameterDecorator.h"
@@ -266,5 +265,3 @@ protected:
 
 } // namespace Poldi
 } // namespace Mantid
-
-#endif /* MANTID_SINQ_POLDISPECTRUMDOMAINFUNCTION_H_ */

--- a/Framework/SINQ/inc/MantidSINQ/PoldiUtilities/PoldiSpectrumLinearBackground.h
+++ b/Framework/SINQ/inc/MantidSINQ/PoldiUtilities/PoldiSpectrumLinearBackground.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_SINQ_POLDISPECTRUMLINEARBACKGROUND_H_
-#define MANTID_SINQ_POLDISPECTRUMLINEARBACKGROUND_H_
+#pragma once
 
 #include "MantidAPI/IFunction1DSpectrum.h"
 #include "MantidAPI/ParamFunction.h"
@@ -57,5 +56,3 @@ protected:
 
 } // namespace Poldi
 } // namespace Mantid
-
-#endif /* MANTID_SINQ_POLDISPECTRUMLINEARBACKGROUND_H_ */

--- a/Framework/SINQ/inc/MantidSINQ/PoldiUtilities/PoldiSpectrumPawleyFunction.h
+++ b/Framework/SINQ/inc/MantidSINQ/PoldiUtilities/PoldiSpectrumPawleyFunction.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_SINQ_POLDISPECTRUMPAWLEYFUNCTION_H_
-#define MANTID_SINQ_POLDISPECTRUMPAWLEYFUNCTION_H_
+#pragma once
 
 #include "MantidAPI/IPawleyFunction.h"
 #include "MantidSINQ/DllConfig.h"
@@ -45,5 +44,3 @@ protected:
 
 } // namespace Poldi
 } // namespace Mantid
-
-#endif /* MANTID_SINQ_POLDISPECTRUMPAWLEYFUNCTION_H_ */

--- a/Framework/SINQ/inc/MantidSINQ/PoldiUtilities/PoldiTimeTransformer.h
+++ b/Framework/SINQ/inc/MantidSINQ/PoldiUtilities/PoldiTimeTransformer.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_SINQ_POLDITIMETRANSFORMER_H_
-#define MANTID_SINQ_POLDITIMETRANSFORMER_H_
+#pragma once
 
 #include "MantidKernel/System.h"
 #include "MantidSINQ/DllConfig.h"
@@ -118,5 +117,3 @@ using PoldiTimeTransformer_sptr = boost::shared_ptr<PoldiTimeTransformer>;
 
 } // namespace Poldi
 } // namespace Mantid
-
-#endif /* MANTID_SINQ_POLDITIMETRANSFORMER_H_ */

--- a/Framework/SINQ/inc/MantidSINQ/PoldiUtilities/UncertainValue.h
+++ b/Framework/SINQ/inc/MantidSINQ/PoldiUtilities/UncertainValue.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef UNCERTAINVALUE_H
-#define UNCERTAINVALUE_H
+#pragma once
 
 #include "MantidSINQ/DllConfig.h"
 #include <cmath>
@@ -59,5 +58,3 @@ UncertainValue MANTID_SINQ_DLL operator+(double d, const UncertainValue &v);
 UncertainValue MANTID_SINQ_DLL operator-(double d, const UncertainValue &v);
 } // namespace Poldi
 } // namespace Mantid
-
-#endif // UNCERTAINVALUE_H

--- a/Framework/SINQ/inc/MantidSINQ/PoldiUtilities/UncertainValueIO.h
+++ b/Framework/SINQ/inc/MantidSINQ/PoldiUtilities/UncertainValueIO.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_SINQ_UNCERTAINVALUEIO_H
-#define MANTID_SINQ_UNCERTAINVALUEIO_H
+#pragma once
 
 #include "MantidSINQ/DllConfig.h"
 #include "MantidSINQ/PoldiUtilities/UncertainValue.h"
@@ -68,5 +67,3 @@ private:
 };
 } // namespace Poldi
 } // namespace Mantid
-
-#endif // MANTID_SINQ_UNCERTAINVALUEIO_H

--- a/Framework/SINQ/inc/MantidSINQ/PrecompiledHeader.h
+++ b/Framework/SINQ/inc/MantidSINQ/PrecompiledHeader.h
@@ -4,13 +4,10 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_SINQ_PRECOMPILEDHEADER_H_
-#define MANTID_SINQ_PRECOMPILEDHEADER_H_
+#pragma once
 
 #include "MantidAPI/Algorithm.h"
 #include "MantidKernel/Exception.h"
 
 // Boost
 #include <boost/shared_ptr.hpp>
-
-#endif // MANTID_SINQ_PRECOMPILEDHEADER_H_

--- a/Framework/SINQ/inc/MantidSINQ/ProjectMD.h
+++ b/Framework/SINQ/inc/MantidSINQ/ProjectMD.h
@@ -12,8 +12,7 @@
  *
  *
  */
-#ifndef PROJECTMD_H_
-#define PROJECTMD_H_
+#pragma once
 
 #include "MantidAPI/Algorithm.h"
 #include "MantidAPI/IMDHistoWorkspace_fwd.h"
@@ -55,5 +54,3 @@ private:
   void putValue(Mantid::API::IMDHistoWorkspace_sptr ws, int *dim, double val);
   unsigned int calcIndex(Mantid::API::IMDHistoWorkspace_sptr ws, int *dim);
 };
-
-#endif /*PROJECTMD_H_*/

--- a/Framework/SINQ/inc/MantidSINQ/SINQHMListener.h
+++ b/Framework/SINQ/inc/MantidSINQ/SINQHMListener.h
@@ -15,8 +15,7 @@
  *
  */
 
-#ifndef SINQHMLISTENER_H_
-#define SINQHMLISTENER_H_
+#pragma once
 
 #include "MantidAPI/IMDHistoWorkspace_fwd.h"
 #include "MantidAPI/LiveListener.h"
@@ -63,5 +62,3 @@ private:
 
   ILiveListener::RunStatus oldStatus;
 };
-
-#endif /* SINQHMLISTENER_H_ */

--- a/Framework/SINQ/inc/MantidSINQ/SINQTranspose3D.h
+++ b/Framework/SINQ/inc/MantidSINQ/SINQTranspose3D.h
@@ -19,8 +19,7 @@
  *
  *
  */
-#ifndef TRANSPOSE3D_H_
-#define TRANSPOSE3D_H_
+#pragma once
 
 #include "MantidAPI/Algorithm.h"
 #include "MantidAPI/DeprecatedAlgorithm.h"
@@ -63,5 +62,3 @@ private:
   void copyMetaData(Mantid::API::IMDHistoWorkspace_sptr inws,
                     Mantid::API::IMDHistoWorkspace_sptr outws);
 };
-
-#endif /*TRANSPOSE3D_H_*/

--- a/Framework/SINQ/inc/MantidSINQ/SliceMDHisto.h
+++ b/Framework/SINQ/inc/MantidSINQ/SliceMDHisto.h
@@ -12,8 +12,7 @@
  *
  *
  */
-#ifndef SLICEMDHISTO_H_
-#define SLICEMDHISTO_H_
+#pragma once
 
 #include "MantidAPI/Algorithm.h"
 #include "MantidAPI/IMDHistoWorkspace_fwd.h"
@@ -57,5 +56,3 @@ private:
   void copyMetaData(Mantid::API::IMDHistoWorkspace_sptr inws,
                     Mantid::API::IMDHistoWorkspace_sptr outws);
 };
-
-#endif /*SLICEMDHISTO_H_*/

--- a/Framework/SINQ/test/InvertMDDimTest.h
+++ b/Framework/SINQ/test/InvertMDDimTest.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef __INVERTMDTEST
-#define __INVERTMDTEST
+#pragma once
 
 #include "MantidAPI/AnalysisDataService.h"
 #include "MantidAPI/IMDHistoWorkspace.h"
@@ -138,5 +137,3 @@ private:
     return outWS;
   }
 };
-
-#endif

--- a/Framework/SINQ/test/LoadFlexiNexusTest.h
+++ b/Framework/SINQ/test/LoadFlexiNexusTest.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef __LOADFLEXINEXUSTEST
-#define __LOADFLEXINEXUSTEST
+#pragma once
 
 #include "MantidAPI/AnalysisDataService.h"
 #include "MantidAPI/IMDHistoWorkspace.h"
@@ -126,4 +125,3 @@ public:
     AnalysisDataService::Instance().clear();
   }
 };
-#endif

--- a/Framework/SINQ/test/MDHistoToWorkspace2DTest.h
+++ b/Framework/SINQ/test/MDHistoToWorkspace2DTest.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef __MDHISTOTOWORKSPACE2DTEST
-#define __MDHISTOTOWORKSPACE2DTEST
+#pragma once
 
 #include "MantidAPI/AnalysisDataService.h"
 #include "MantidAPI/IMDHistoWorkspace.h"
@@ -105,5 +104,3 @@ private:
     return outWS;
   }
 };
-
-#endif

--- a/Framework/SINQ/test/MillerIndicesIOTest.h
+++ b/Framework/SINQ/test/MillerIndicesIOTest.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_SINQ_MILLERINDICESIOTEST_H
-#define MANTID_SINQ_MILLERINDICESIOTEST_H
+#pragma once
 
 #include "MantidSINQ/PoldiUtilities/MillerIndicesIO.h"
 #include "boost/lexical_cast.hpp"
@@ -65,5 +64,3 @@ public:
         "1 3 4");
   }
 };
-
-#endif // MANTID_SINQ_MILLERINDICESIOTEST_H

--- a/Framework/SINQ/test/MillerIndicesTest.h
+++ b/Framework/SINQ/test/MillerIndicesTest.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_SINQ_MILLERINDICESTEST_H
-#define MANTID_SINQ_MILLERINDICESTEST_H
+#pragma once
 
 #include "MantidKernel/V3D.h"
 #include "MantidSINQ/PoldiUtilities/MillerIndices.h"
@@ -120,5 +119,3 @@ public:
     TS_ASSERT_DIFFERS(hklOne, hklThree);
   }
 };
-
-#endif // MANTID_SINQ_MILLERINDICESTEST_H

--- a/Framework/SINQ/test/Poldi2DFunctionTest.h
+++ b/Framework/SINQ/test/Poldi2DFunctionTest.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_SINQ_POLDI2DFUNCTIONTEST_H_
-#define MANTID_SINQ_POLDI2DFUNCTIONTEST_H_
+#pragma once
 
 #include <boost/make_shared.hpp>
 #include <cxxtest/TestSuite.h>
@@ -156,5 +155,3 @@ private:
     }
   };
 };
-
-#endif /* MANTID_SINQ_POLDI2DFUNCTIONTEST_H_ */

--- a/Framework/SINQ/test/PoldiAnalyseResidualsTest.h
+++ b/Framework/SINQ/test/PoldiAnalyseResidualsTest.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_SINQ_POLDIANALYSERESIDUALSTEST_H_
-#define MANTID_SINQ_POLDIANALYSERESIDUALSTEST_H_
+#pragma once
 
 #include <cxxtest/TestSuite.h>
 
@@ -204,5 +203,3 @@ private:
     ~TestablePoldiAnalyseResiduals() override {}
   };
 };
-
-#endif /* MANTID_SINQ_POLDIANALYSERESIDUALSTEST_H_ */

--- a/Framework/SINQ/test/PoldiAutoCorrelationCoreTest.h
+++ b/Framework/SINQ/test/PoldiAutoCorrelationCoreTest.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_SINQ_POLDIAUTOCORRELATIONCORETEST_H_
-#define MANTID_SINQ_POLDIAUTOCORRELATIONCORETEST_H_
+#pragma once
 
 #include <cxxtest/TestSuite.h>
 #include <gmock/gmock.h>
@@ -348,5 +347,3 @@ public:
 private:
   Mantid::Kernel::Logger m_log;
 };
-
-#endif /* MANTID_SINQ_POLDIAUTOCORRELATIONCORETEST_H_ */

--- a/Framework/SINQ/test/PoldiBasicChopperTest.h
+++ b/Framework/SINQ/test/PoldiBasicChopperTest.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_SINQ_POLDIBASICCHOPPERTEST_H_
-#define MANTID_SINQ_POLDIBASICCHOPPERTEST_H_
+#pragma once
 
 #include "MantidAPI/TableRow.h"
 #include "MantidSINQ/PoldiUtilities/PoldiBasicChopper.h"
@@ -78,5 +77,3 @@ public:
     TS_ASSERT_DELTA(slitTimes[1], 243.234, 1e-3)
   }
 };
-
-#endif /* MANTID_SINQ_POLDIBASICCHOPPERTEST_H_ */

--- a/Framework/SINQ/test/PoldiChopperFactoryTest.h
+++ b/Framework/SINQ/test/PoldiChopperFactoryTest.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_SINQ_POLDICHOPPERFACTORYTEST_H_
-#define MANTID_SINQ_POLDICHOPPERFACTORYTEST_H_
+#pragma once
 
 #include <cxxtest/TestSuite.h>
 
@@ -39,5 +38,3 @@ public:
     delete chopper;
   }
 };
-
-#endif /* MANTID_SINQ_POLDICHOPPERFACTORYTEST_H_ */

--- a/Framework/SINQ/test/PoldiConversionsTest.h
+++ b/Framework/SINQ/test/PoldiConversionsTest.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef POLDICONVERSIONSTEST_H
-#define POLDICONVERSIONSTEST_H
+#pragma once
 
 #include "MantidSINQ/PoldiUtilities/PoldiConversions.h"
 #include <cxxtest/TestSuite.h>
@@ -61,5 +60,3 @@ public:
                      degree);
   }
 };
-
-#endif // POLDICONVERSIONSTEST_H

--- a/Framework/SINQ/test/PoldiCreatePeaksFromCellTest.h
+++ b/Framework/SINQ/test/PoldiCreatePeaksFromCellTest.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_SINQ_POLDICREATEPEAKSFROMCELLTEST_H_
-#define MANTID_SINQ_POLDICREATEPEAKSFROMCELLTEST_H_
+#pragma once
 
 #include <cxxtest/TestSuite.h>
 
@@ -204,5 +203,3 @@ private:
     friend class PoldiCreatePeaksFromCellTest;
   };
 };
-
-#endif /* MANTID_SINQ_POLDICREATEPEAKSFROMCELLTEST_H_ */

--- a/Framework/SINQ/test/PoldiDGridTest.h
+++ b/Framework/SINQ/test/PoldiDGridTest.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef POLDIDGRIDTEST_H
-#define POLDIDGRIDTEST_H
+#pragma once
 
 #include <cxxtest/TestSuite.h>
 #include <gmock/gmock.h>
@@ -130,5 +129,3 @@ public:
     TS_ASSERT_EQUALS(grid.m_hasCachedCalculation, true);
   }
 };
-
-#endif // POLDIDGRIDTEST_H

--- a/Framework/SINQ/test/PoldiDeadWireDecoratorTest.h
+++ b/Framework/SINQ/test/PoldiDeadWireDecoratorTest.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_SINQ_POLDIDEADWIREDECORATORTEST_H_
-#define MANTID_SINQ_POLDIDEADWIREDECORATORTEST_H_
+#pragma once
 
 #include <cxxtest/TestSuite.h>
 
@@ -76,5 +75,3 @@ public:
                      const std::runtime_error &);
   }
 };
-
-#endif /* MANTID_SINQ_POLDIDEADWIREDECORATORTEST_H_ */

--- a/Framework/SINQ/test/PoldiDetectorDecoratorTest.h
+++ b/Framework/SINQ/test/PoldiDetectorDecoratorTest.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_SINQ_POLDIDETECTORDECORATORTEST_H_
-#define MANTID_SINQ_POLDIDETECTORDECORATORTEST_H_
+#pragma once
 
 #include <cxxtest/TestSuite.h>
 #include <gmock/gmock.h>
@@ -79,5 +78,3 @@ public:
     TS_ASSERT_THROWS(decorator.qLimits(1.0, 5.0), const std::runtime_error &);
   }
 };
-
-#endif /* MANTID_SINQ_POLDIDETECTORDECORATORTEST_H_ */

--- a/Framework/SINQ/test/PoldiDetectorFactoryTest.h
+++ b/Framework/SINQ/test/PoldiDetectorFactoryTest.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_SINQ_POLDIDETECTORFACTORYTEST_H_
-#define MANTID_SINQ_POLDIDETECTORFACTORYTEST_H_
+#pragma once
 
 #include <cxxtest/TestSuite.h>
 
@@ -57,5 +56,3 @@ public:
     TS_ASSERT(!newDetector);
   }
 };
-
-#endif /* MANTID_SINQ_POLDIDETECTORFACTORYTEST_H_ */

--- a/Framework/SINQ/test/PoldiDetectorTest.h
+++ b/Framework/SINQ/test/PoldiDetectorTest.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef POLDIDETECTORTEST_H
-#define POLDIDETECTORTEST_H
+#pragma once
 
 #include "MantidAPI/TableRow.h"
 #include "MantidSINQ/PoldiUtilities/PoldiAbstractDetector.h"
@@ -99,5 +98,3 @@ public:
     TS_ASSERT_EQUALS(availableElements.back(), 399);
   }
 };
-
-#endif // POLDIDETECTORTEST_H

--- a/Framework/SINQ/test/PoldiFitPeaks1D2Test.h
+++ b/Framework/SINQ/test/PoldiFitPeaks1D2Test.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_SINQ_POLDIFITPEAKS1D2TEST_H_
-#define MANTID_SINQ_POLDIFITPEAKS1D2TEST_H_
+#pragma once
 
 #include <cxxtest/TestSuite.h>
 
@@ -331,5 +330,3 @@ private:
   std::string m_profileTestFunction;
   IFunction_sptr m_backgroundTestFunction;
 };
-
-#endif /* MANTID_SINQ_POLDIFITPEAKS1D2TEST_H_ */

--- a/Framework/SINQ/test/PoldiFitPeaks1DTest.h
+++ b/Framework/SINQ/test/PoldiFitPeaks1DTest.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_SINQ_POLDIFITPEAKS1DTEST_H_
-#define MANTID_SINQ_POLDIFITPEAKS1DTEST_H_
+#pragma once
 
 #include <cxxtest/TestSuite.h>
 
@@ -125,5 +124,3 @@ private:
   std::string m_profileTestFunction;
   IFunction_sptr m_backgroundTestFunction;
 };
-
-#endif /* MANTID_SINQ_POLDIFITPEAKS1DTEST_H_ */

--- a/Framework/SINQ/test/PoldiFitPeaks2DTest.h
+++ b/Framework/SINQ/test/PoldiFitPeaks2DTest.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_SINQ_POLDICALCULATESPECTRUM2DTEST_H_
-#define MANTID_SINQ_POLDICALCULATESPECTRUM2DTEST_H_
+#pragma once
 
 #include <cxxtest/TestSuite.h>
 
@@ -509,5 +508,3 @@ private:
     ~TestablePoldiFitPeaks2D() override {}
   };
 };
-
-#endif // MANTID_SINQ_POLDICALCULATESPECTRUM2DTEST_H_

--- a/Framework/SINQ/test/PoldiIndexKnownCompoundsTest.h
+++ b/Framework/SINQ/test/PoldiIndexKnownCompoundsTest.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_SINQ_POLDIINDEXKNOWNCOMPOUNDSTEST_H_
-#define MANTID_SINQ_POLDIINDEXKNOWNCOMPOUNDSTEST_H_
+#pragma once
 
 #include <cxxtest/TestSuite.h>
 
@@ -710,5 +709,3 @@ private:
     return stringVector;
   }
 };
-
-#endif /* MANTID_SINQ_POLDIINDEXKNOWNCOMPOUNDSTEST_H_ */

--- a/Framework/SINQ/test/PoldiInstrumentAdapterTest.h
+++ b/Framework/SINQ/test/PoldiInstrumentAdapterTest.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_SINQ_POLDIINSTRUMENTADAPTERTEST_H_
-#define MANTID_SINQ_POLDIINSTRUMENTADAPTERTEST_H_
+#pragma once
 
 #include <cxxtest/TestSuite.h>
 #include <gmock/gmock.h>
@@ -261,5 +260,3 @@ private:
     ~TestablePoldiInstrumentAdapter() override {}
   };
 };
-
-#endif // MANTID_SINQ_POLDIINSTRUMENTADAPTERTEST_H_

--- a/Framework/SINQ/test/PoldiPeakCollectionTest.h
+++ b/Framework/SINQ/test/PoldiPeakCollectionTest.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_SINQ_POLDIPEAKCOLLECTIONTEST_H
-#define MANTID_SINQ_POLDIPEAKCOLLECTIONTEST_H
+#pragma once
 
 #include "MantidSINQ/PoldiUtilities/PoldiPeak.h"
 #include "MantidSINQ/PoldiUtilities/PoldiPeakCollection.h"
@@ -410,5 +409,3 @@ private:
 
   TableWorkspace_sptr m_dummyData;
 };
-
-#endif // MANTID_SINQ_POLDIPEAKCOLLECTIONTEST_H

--- a/Framework/SINQ/test/PoldiPeakSearchTest.h
+++ b/Framework/SINQ/test/PoldiPeakSearchTest.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_SINQ_POLDIPEAKSEARCHTEST_H_
-#define MANTID_SINQ_POLDIPEAKSEARCHTEST_H_
+#pragma once
 
 #include <cxxtest/TestSuite.h>
 
@@ -278,5 +277,3 @@ public:
                      13.5);
   }
 };
-
-#endif /* MANTID_SINQ_POLDIPEAKSEARCHTEST_H_ */

--- a/Framework/SINQ/test/PoldiPeakSummaryTest.h
+++ b/Framework/SINQ/test/PoldiPeakSummaryTest.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_SINQ_POLDIPEAKSUMMARYTEST_H_
-#define MANTID_SINQ_POLDIPEAKSUMMARYTEST_H_
+#pragma once
 
 #include <cxxtest/TestSuite.h>
 
@@ -102,5 +101,3 @@ private:
     friend class PoldiPeakSummaryTest;
   };
 };
-
-#endif /* MANTID_SINQ_POLDIPEAKSUMMARYTEST_H_ */

--- a/Framework/SINQ/test/PoldiPeakTest.h
+++ b/Framework/SINQ/test/PoldiPeakTest.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_SINQ_POLDIPEAKTEST_H
-#define MANTID_SINQ_POLDIPEAKTEST_H
+#pragma once
 
 #include "MantidSINQ/PoldiUtilities/MillerIndices.h"
 #include "MantidSINQ/PoldiUtilities/PoldiPeak.h"
@@ -186,5 +185,3 @@ public:
     TS_ASSERT_EQUALS(peak->hkl(), clone->hkl());
   }
 };
-
-#endif // MANTID_SINQ_POLDIPEAKTEST_H

--- a/Framework/SINQ/test/PoldiResidualCorrelationCoreTest.h
+++ b/Framework/SINQ/test/PoldiResidualCorrelationCoreTest.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_SINQ_POLDIRESIDUALCORRELATIONCORETEST_H_
-#define MANTID_SINQ_POLDIRESIDUALCORRELATIONCORETEST_H_
+#pragma once
 
 #include <cxxtest/TestSuite.h>
 
@@ -152,5 +151,3 @@ private:
         : PoldiResidualCorrelationCore(logger) {}
   };
 };
-
-#endif /* MANTID_SINQ_POLDIRESIDUALCORRELATIONCORETEST_H_ */

--- a/Framework/SINQ/test/PoldiSourceSpectrumTest.h
+++ b/Framework/SINQ/test/PoldiSourceSpectrumTest.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef POLDISOURCESPECTRUMTEST_H
-#define POLDISOURCESPECTRUMTEST_H
+#pragma once
 
 #include "MantidGeometry/IComponent.h"
 #include "MantidKernel/Interpolation.h"
@@ -105,5 +104,3 @@ private:
         : PoldiSourceSpectrum(poldiInstrument) {}
   };
 };
-
-#endif // POLDISOURCESPECTRUMTEST_H

--- a/Framework/SINQ/test/PoldiSpectrumConstantBackgroundTest.h
+++ b/Framework/SINQ/test/PoldiSpectrumConstantBackgroundTest.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_SINQ_POLDISPECTRUMCONSTANTBACKGROUNDTEST_H_
-#define MANTID_SINQ_POLDISPECTRUMCONSTANTBACKGROUNDTEST_H_
+#pragma once
 
 #include <cxxtest/TestSuite.h>
 
@@ -83,5 +82,3 @@ public:
     }
   }
 };
-
-#endif /* MANTID_SINQ_POLDISPECTRUMCONSTANTBACKGROUNDTEST_H_ */

--- a/Framework/SINQ/test/PoldiSpectrumDomainFunctionTest.h
+++ b/Framework/SINQ/test/PoldiSpectrumDomainFunctionTest.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_SINQ_POLDISPECTRUMDOMAINFUNCTIONTEST_H_
-#define MANTID_SINQ_POLDISPECTRUMDOMAINFUNCTIONTEST_H_
+#pragma once
 
 #include "MantidAPI/FunctionFactory.h"
 #include "MantidAPI/MultiDomainFunction.h"
@@ -285,5 +284,3 @@ private:
 
   PoldiInstrumentAdapter_sptr m_instrument;
 };
-
-#endif /* MANTID_SINQ_POLDISPECTRUMDOMAINFUNCTIONTEST_H_ */

--- a/Framework/SINQ/test/PoldiSpectrumLinearBackgroundTest.h
+++ b/Framework/SINQ/test/PoldiSpectrumLinearBackgroundTest.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_SINQ_POLDISPECTRUMLINEARBACKGROUNDTEST_H_
-#define MANTID_SINQ_POLDISPECTRUMLINEARBACKGROUNDTEST_H_
+#pragma once
 
 #include "MantidSINQ/PoldiUtilities/PoldiSpectrumLinearBackground.h"
 
@@ -146,5 +145,3 @@ public:
 private:
   std::vector<double> m_xValues;
 };
-
-#endif /* MANTID_SINQ_POLDISPECTRUMLINEARBACKGROUNDTEST_H_ */

--- a/Framework/SINQ/test/PoldiSpectrumPawleyFunctionTest.h
+++ b/Framework/SINQ/test/PoldiSpectrumPawleyFunctionTest.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_SINQ_POLDISPECTRUMPAWLEYFUNCTIONTEST_H_
-#define MANTID_SINQ_POLDISPECTRUMPAWLEYFUNCTIONTEST_H_
+#pragma once
 
 #include <cxxtest/TestSuite.h>
 
@@ -181,5 +180,3 @@ private:
 
   PoldiInstrumentAdapter_sptr m_instrument;
 };
-
-#endif /* MANTID_SINQ_POLDISPECTRUMPAWLEYFUNCTIONTEST_H_ */

--- a/Framework/SINQ/test/PoldiTimeTransformerTest.h
+++ b/Framework/SINQ/test/PoldiTimeTransformerTest.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_SINQ_POLDITIMETRANSFORMERTEST_H_
-#define MANTID_SINQ_POLDITIMETRANSFORMERTEST_H_
+#pragma once
 
 #include <cxxtest/TestSuite.h>
 #include <gmock/gmock.h>
@@ -133,5 +132,3 @@ private:
 
   PoldiInstrumentAdapter_sptr m_instrument;
 };
-
-#endif /* MANTID_SINQ_POLDITIMETRANSFORMERTEST_H_ */

--- a/Framework/SINQ/test/PoldiTruncateDataTest.h
+++ b/Framework/SINQ/test/PoldiTruncateDataTest.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_SINQ_POLDITRUNCATEDATATEST_H_
-#define MANTID_SINQ_POLDITRUNCATEDATATEST_H_
+#pragma once
 
 #include <cxxtest/TestSuite.h>
 #include <gmock/gmock.h>
@@ -319,5 +318,3 @@ private:
     ~TestablePoldiTruncateData() override {}
   };
 };
-
-#endif /* MANTID_SINQ_POLDITRUNCATEDATATEST_H_ */

--- a/Framework/SINQ/test/ProjectMDTest.h
+++ b/Framework/SINQ/test/ProjectMDTest.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef __PROJECTMDTEST
-#define __PROJECTMDTEST
+#pragma once
 
 #include "MantidAPI/AnalysisDataService.h"
 #include "MantidAPI/IMDHistoWorkspace.h"
@@ -256,5 +255,3 @@ private:
     return outWS;
   }
 };
-
-#endif

--- a/Framework/SINQ/test/SliceMDHistoTest.h
+++ b/Framework/SINQ/test/SliceMDHistoTest.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef __SLICEMDHISTO
-#define __SLICEMDHISTO
+#pragma once
 
 #include "MantidAPI/AnalysisDataService.h"
 #include "MantidAPI/IMDHistoWorkspace.h"
@@ -122,5 +121,3 @@ private:
     return outWS;
   }
 };
-
-#endif

--- a/Framework/SINQ/test/UncertainValueIOTest.h
+++ b/Framework/SINQ/test/UncertainValueIOTest.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef UNCERTAINVALUEIOTEST_H
-#define UNCERTAINVALUEIOTEST_H
+#pragma once
 
 #include "MantidSINQ/PoldiUtilities/UncertainValue.h"
 #include "MantidSINQ/PoldiUtilities/UncertainValueIO.h"
@@ -69,4 +68,3 @@ public:
     TS_ASSERT_EQUALS(convertedValue.error(), uncertainValue.error());
   }
 };
-#endif // UNCERTAINVALUEIOTEST_H

--- a/Framework/SINQ/test/UncertainValueTest.h
+++ b/Framework/SINQ/test/UncertainValueTest.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef UNCERTAINVALUETEST_H
-#define UNCERTAINVALUETEST_H
+#pragma once
 
 #include "MantidSINQ/PoldiUtilities/UncertainValue.h"
 #include <cxxtest/TestSuite.h>
@@ -150,5 +149,3 @@ public:
     TS_ASSERT_EQUALS(newerValue.error(), 0.0);
   }
 };
-
-#endif // UNCERTAINVALUETEST_H

--- a/Framework/ScriptRepository/inc/MantidScriptRepository/DllConfig.h
+++ b/Framework/ScriptRepository/inc/MantidScriptRepository/DllConfig.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_MANTIDSCRIPTREPOSITORY_DLLCONFIG_H_
-#define MANTID_MANTIDSCRIPTREPOSITORY_DLLCONFIG_H_
+#pragma once
 
 #include "MantidKernel/System.h"
 
@@ -24,5 +23,3 @@
 #else
 #define SCRIPT_DLL_EXPORT
 #endif
-
-#endif // MANTID_DATAOBJECTS_DLLCONFIG_H_

--- a/Framework/ScriptRepository/inc/MantidScriptRepository/ScriptRepositoryImpl.h
+++ b/Framework/ScriptRepository/inc/MantidScriptRepository/ScriptRepositoryImpl.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef _MANTIDSCRIPTREPOSITORY_SCRIPTREPOSITORYIMPL_H_
-#define _MANTIDSCRIPTREPOSITORY_SCRIPTREPOSITORYIMPL_H_
+#pragma once
 
 #include "MantidAPI/ScriptRepository.h"
 #include "MantidKernel/DateAndTime.h"
@@ -180,5 +179,3 @@ private:
 
 } // namespace API
 } // namespace Mantid
-
-#endif // _MANTIDSCRIPTREPOSITORY_SCRIPTREPOSITORYIMPL_H_

--- a/Framework/ScriptRepository/test/ScriptRepositoryFactoryTest.h
+++ b/Framework/ScriptRepository/test/ScriptRepositoryFactoryTest.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef FUNCTIONFACTORYTEST_H_
-#define FUNCTIONFACTORYTEST_H_
+#pragma once
 
 #include <cxxtest/TestSuite.h>
 
@@ -33,5 +32,3 @@ public:
     TS_ASSERT(script);
   }
 };
-
-#endif /*SCRIPTREPOSITORYFACTORYTEST_H_*/

--- a/Framework/ScriptRepository/test/ScriptRepositoryTestImpl.h
+++ b/Framework/ScriptRepository/test/ScriptRepositoryTestImpl.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef SCRIPTREPOSITORYIMPLTEST_H_
-#define SCRIPTREPOSITORYIMPLTEST_H_
+#pragma once
 
 #include "MantidKernel/ConfigService.h"
 #include "MantidScriptRepository/ScriptRepositoryImpl.h"
@@ -955,5 +954,3 @@ public:
     TS_ASSERT(repo->fileStatus(file_name) == Mantid::API::REMOTE_ONLY);
   }
 };
-
-#endif


### PR DESCRIPTION
This PR replaces all header guards in ScriptRepository and SINQ with #pragma once

**To test:**

Any issues in this PR should be caught by jenkins. just code review to check that no definitions or endifs have been removed by mistake

This pr is a part of #28200

*This does not require release notes* because **it is an internal change to the codebase.**

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
