### PR TITLE
Fix GUI launch script execute error

### DIFF
--- a/qt/python/mantidqt/widgets/codeeditor/execution.py
+++ b/qt/python/mantidqt/widgets/codeeditor/execution.py
@@ -114,7 +114,7 @@ class PythonCodeExecution(QObject):
         # Stack is chopped on error to avoid the  AsyncTask.run->self.execute calls appearing
         # as these are not useful for the user in this context
         if not blocking:
-            task = AsyncTask(self.execute, args=(code_str, line_offset, filename),
+            task = AsyncTask(self.execute, args=(code_str, filename, line_offset),
                              success_cb=self._on_success, error_cb=self._on_error)
             task.start()
             self._task = task

--- a/qt/python/mantidqt/widgets/codeeditor/execution.py
+++ b/qt/python/mantidqt/widgets/codeeditor/execution.py
@@ -120,12 +120,12 @@ class PythonCodeExecution(QObject):
             self._task = task
             return task
         else:
-            self._task = BlockingAsyncTaskWithCallback(self.execute, args=(code_str, line_offset, filename),
+            self._task = BlockingAsyncTaskWithCallback(self.execute, args=(code_str, filename, line_offset),
                                                        success_cb=self._on_success, error_cb=self._on_error,
                                                        blocking_cb=QApplication.processEvents)
             return self._task.start()
 
-    def execute(self, code_str,  line_offset, filename=None):
+    def execute(self, code_str, filename=None, line_offset=0):
         """Execute the given code on the calling thread
         within the provided context.
 

--- a/qt/python/mantidqt/widgets/codeeditor/test/test_execution.py
+++ b/qt/python/mantidqt/widgets/codeeditor/test/test_execution.py
@@ -105,7 +105,7 @@ class PythonCodeExecutionTest(unittest.TestCase):
             mocked_executor = Mock()
             patched_constructor.return_value = mocked_executor
 
-            executor.execute(code, offset)
+            executor.execute(code, line_offset=offset)
             self.assertTrue(mocked_executor.execute.called)
             args, _ = mocked_executor.execute.call_args_list[0]
             self.assertTrue(offset in args, "Line offset was not passed in")

--- a/qt/python/mantidqt/widgets/codeeditor/test/test_execution.py
+++ b/qt/python/mantidqt/widgets/codeeditor/test/test_execution.py
@@ -200,9 +200,9 @@ foo()
     # -------------------------------------------------------------------------
     # Helpers
     # -------------------------------------------------------------------------
-    def _verify_serial_execution_successful(self, code, line_offset=0):
+    def _verify_serial_execution_successful(self, code):
         executor = PythonCodeExecution()
-        executor.execute(code, line_offset)
+        executor.execute(code)
         return executor.globals_ns
 
     def _verify_async_execution_successful(self, code, line_offset=0):
@@ -211,9 +211,9 @@ foo()
         task.join()
         return executor.globals_ns
 
-    def _verify_failed_serial_execute(self, expected_exc_type, code, line_offset=0):
+    def _verify_failed_serial_execute(self, expected_exc_type, code):
         executor = PythonCodeExecution()
-        self.assertRaises(expected_exc_type, executor.execute, code, line_offset)
+        self.assertRaises(expected_exc_type, executor.execute, code)
 
     def _run_async_code(self, code, filename=None, line_no=0):
         executor = PythonCodeExecution()


### PR DESCRIPTION
**Description of work.**
The GUI execute script was failing due to a filename being interpreted as an offset. This has been fixed by reversing the function arguments, to leave the offset as the last entry. 

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

**To test:**
Open Workbench
Launch a GUI 
Should open as normal
<!-- Instructions for testing. -->


<!-- alternative
*There is no associated issue.*
-->

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
-->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
