### PR TITLE
Fix HFIR 4Circle interface open failure

### DIFF
--- a/scripts/HFIR_4Circle_Reduction/MainWindow.ui
+++ b/scripts/HFIR_4Circle_Reduction/MainWindow.ui
@@ -5733,6 +5733,4 @@ p, li { white-space: pre-wrap; }
    </property>
   </action>
  </widget>
- <resources/>
- <connections/>
 </ui>

--- a/scripts/HFIR_4Circle_Reduction/reduce4circleGUI.py
+++ b/scripts/HFIR_4Circle_Reduction/reduce4circleGUI.py
@@ -283,7 +283,7 @@ class MainWindow(QMainWindow):
         self._baseTitle = 'Title is not initialized'
 
         # Timing and thread 'global'
-        self._startMeringScans = time.clock()
+        self._startMeringScans = time.process_time()
         self._errorMessageEnsemble = ''
 
         # QSettings


### PR DESCRIPTION
**Description of work.**
This PR fixes the interface error by removing some unmatched tags in `MainWindow.ui` which subsequently uncovered an issue with the deprecated `time.clock()`.

**To test:**
Open Workbench and check that the interface now opens (**Windows only**).

Fixes #28243 

*This does not require release notes* because *it was not an issue before the move to python 3*

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
