### PR TITLE
Update logging calls so they work in sphinx v2.3

### DIFF
--- a/docs/sphinxext/mantiddoc/directives/base.py
+++ b/docs/sphinxext/mantiddoc/directives/base.py
@@ -7,6 +7,7 @@
 from docutils import statemachine
 from docutils.parsers.rst import Directive #pylint: disable=unused-import
 import re
+from sphinx.util import logging
 
 ALG_DOCNAME_RE = re.compile(r'^([A-Z][a-zA-Z0-9]+)-v([0-9][0-9]*)$')
 FIT_DOCNAME_RE = re.compile(r'^([A-Z][a-zA-Z0-9]+)$')
@@ -174,8 +175,8 @@ class AlgorithmBaseDirective(BaseDirective):
 
         # warn the user
         if len(msg) > 0:
-            env = self.state.document.settings.env
-            env.app.verbose(msg)
+            logger = logging.getLogger(__name__)
+            logger.verbose(msg)
         return msg
 
     def algorithm_name(self):

--- a/docs/sphinxext/mantiddoc/doctest.py
+++ b/docs/sphinxext/mantiddoc/doctest.py
@@ -134,6 +134,7 @@ try:
     import lxml.etree as ElementTree
 except ImportError:
     import xml.etree.ElementTree as ElementTree
+from sphinx.util import logging
 
 # Name of file produced by doctest target. It is assumed that it is created
 # in app.outdir
@@ -529,19 +530,21 @@ def doctest_to_xunit(app, exception):
       exception: (Exception): If an exception was raised then it is given here.
                               It is simply re-raised if an error occurred
     """
+    logger = logging.getLogger(__name__)
+
     if exception:
         import traceback
         traceback.print_exc()
     if app.builder.name != "doctest":
-        app.debug("Skipping xunit parsing for builder '%s'" % app.builder.name)
+        logger.debug("Skipping xunit parsing for builder '%s'" % app.builder.name)
         return
 
     import os
 
     doctest_file = os.path.join(app.builder.outdir, DOCTEST_OUTPUT)
-    app.debug("Parsing doctest output file '%s'" % doctest_file)
+    logger.debug("Parsing doctest output file '%s'" % doctest_file)
     doctests = DocTestOutputParser(doctest_file)
-    app.debug("Saving doctest as xunit to file '%s'" % doctest_file)
+    logger.debug("Saving doctest as xunit to file '%s'" % doctest_file)
     xunit_file = os.path.join(app.builder.outdir, XUNIT_OUTPUT)
 
     doctests.as_xunit(xunit_file)


### PR DESCRIPTION
**Description of work.**

The docs didn't build with Sphinx v2.3 due to some changes to the way logging is done in Sphinx between the current version (1.6) and version 2.3 This affected a small number of logging calls in the Mantid docs code.

Changes have been made so that Mantid docs build in both versions 1.6 and 2.3. The Sphinx version used by Mantid hasn't been moved on yet

**To test:**

Since the Sphinx version hasn't been moved on yet in the Mantid builds, testing this requires you to locally\temporarily move your sphinx version on to 2.3. You can check your currently installed version by running:

sphinx-build --version

The sphinx install that is used in the Mantid docs build can be moved forward to 2.x by running

easy_install -U Sphinx==2.3
(for some reason I had to run "easy_install-3 -U Sphinx==2.3" on Windows to avoid an error about a missing positional argument - but possible that's just me)

Build the docs (targets docs-html and docs-qthelp) and check the builds succeed

Fixes #27792

*This does not require release notes* because it's an internal technical change that doesn't have any external functional change

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
