### PR TITLE
Speed up workbench preview plots

### DIFF
--- a/qt/widgets/mplcpp/inc/MantidQtWidgets/MplCpp/MantidAxes.h
+++ b/qt/widgets/mplcpp/inc/MantidQtWidgets/MplCpp/MantidAxes.h
@@ -47,8 +47,8 @@ public:
 
   /// @name Artist removal/replacement
   ///@{
-  void removeWorkspaceArtists(const Mantid::API::MatrixWorkspace_sptr &ws);
-  void replaceWorkspaceArtists(const Mantid::API::MatrixWorkspace_sptr &newWS);
+  bool removeWorkspaceArtists(const Mantid::API::MatrixWorkspace_sptr &ws);
+  bool replaceWorkspaceArtists(const Mantid::API::MatrixWorkspace_sptr &newWS);
   ///@}
 };
 

--- a/qt/widgets/mplcpp/src/MantidAxes.cpp
+++ b/qt/widgets/mplcpp/src/MantidAxes.cpp
@@ -96,25 +96,27 @@ void MantidAxes::pcolormesh(
  * @param ws A reference to a workspace whose name is used to
  * lookup any artists for removal
  */
-void MantidAxes::removeWorkspaceArtists(
+bool MantidAxes::removeWorkspaceArtists(
     const Mantid::API::MatrixWorkspace_sptr &ws) {
   GlobalInterpreterLock lock;
+  bool removed = false;
   try {
-    pyobj().attr("remove_workspace_artists")(
+    removed = pyobj().attr("remove_workspace_artists")(
         Python::NewRef(MatrixWorkpaceToPython()(ws)));
   } catch (Python::ErrorAlreadySet &) {
     throw Mantid::PythonInterface::PythonException();
   }
+  return removed;
 }
 
 /**
  * Replace the artists on this axes instance that are based off this workspace
  * @param newWS A reference to the new workspace containing the data
  */
-void MantidAxes::replaceWorkspaceArtists(
+bool MantidAxes::replaceWorkspaceArtists(
     const Mantid::API::MatrixWorkspace_sptr &newWS) {
   GlobalInterpreterLock lock;
-  pyobj().attr("replace_workspace_artists")(
+  return pyobj().attr("replace_workspace_artists")(
       Python::NewRef(MatrixWorkpaceToPython()(newWS)));
 }
 

--- a/qt/widgets/mplcpp/test/MantidAxesTest.h
+++ b/qt/widgets/mplcpp/test/MantidAxesTest.h
@@ -56,8 +56,9 @@ public:
     const std::string wsName{"myname"};
     const auto ws = createWorkspaceInADS(wsName, {1, 2, 4});
     axes.plot(ws, 0, "red", "mylabel");
-    axes.removeWorkspaceArtists(ws);
+    auto removed = axes.removeWorkspaceArtists(ws);
 
+    TS_ASSERT_EQUALS(removed, true);
     TS_ASSERT_EQUALS(0, Python::Len(axes.pyobj().attr("lines")));
     AnalysisDataService::Instance().remove(wsName);
   }
@@ -68,11 +69,43 @@ public:
     const auto wsOld = createWorkspaceInADS(wsName, {1, 2, 4});
     axes.plot(wsOld, 0, "red", "mylabel");
     const auto wsNew = createWorkspaceInADS(wsName, {2, 3, 5});
-    axes.replaceWorkspaceArtists(wsNew);
+    auto replaces = axes.replaceWorkspaceArtists(wsNew);
 
     auto newLine = axes.pyobj().attr("lines")[0];
     TS_ASSERT_EQUALS(2.5, newLine.attr("get_xdata")()[0]);
     TS_ASSERT_EQUALS("red", newLine.attr("get_color")());
+    TS_ASSERT_EQUALS(replaces, true);
+
+    AnalysisDataService::Instance().remove(wsName);
+  }
+
+  void testRemovingWorkspaceNotOnPlotReturnsFalse() {
+    MantidAxes axes{pyAxes()};
+    const std::string wsName{"myname"};
+    const std::string wsName2{"mynamenotPlotted"};
+    const auto ws = createWorkspaceInADS(wsName, {1, 2, 4});
+    const auto wsNotPlotted = createWorkspaceInADS(wsName2, {1, 2, 4});
+    axes.plot(ws, 0, "red", "mylabel");
+    auto removed = axes.removeWorkspaceArtists(wsNotPlotted);
+
+    TS_ASSERT_EQUALS(removed, false);
+    TS_ASSERT_EQUALS(1, Python::Len(axes.pyobj().attr("lines")));
+    AnalysisDataService::Instance().remove(wsName);
+  }
+
+  void testReplacingWorkspaceNotOnPlotReturnsFalse() {
+    MantidAxes axes{pyAxes()};
+    const std::string wsName{"myname"};
+    const std::string wsName2{"myname2"};
+    const auto wsOld = createWorkspaceInADS(wsName, {2, 3, 5});
+    axes.plot(wsOld, 0, "red", "mylabel");
+    const auto wsNew = createWorkspaceInADS(wsName2, {1, 2, 4});
+    auto replaces = axes.replaceWorkspaceArtists(wsNew);
+
+    auto newLine = axes.pyobj().attr("lines")[0];
+    TS_ASSERT_EQUALS(2.5, newLine.attr("get_xdata")()[0]);
+    TS_ASSERT_EQUALS("red", newLine.attr("get_color")());
+    TS_ASSERT_EQUALS(replaces, false);
 
     AnalysisDataService::Instance().remove(wsName);
   }

--- a/qt/widgets/plotting/src/Mpl/PreviewPlot.cpp
+++ b/qt/widgets/plotting/src/Mpl/PreviewPlot.cpp
@@ -588,15 +588,21 @@ QStringList PreviewPlot::linesWithErrors() const {
  */
 void PreviewPlot::onWorkspaceRemoved(
     Mantid::API::WorkspacePreDeleteNotification_ptr nf) {
+  if (m_lines.isEmpty()) {
+    return;
+  }
   // Ignore non matrix workspaces
   if (auto ws = boost::dynamic_pointer_cast<MatrixWorkspace>(nf->object())) {
     // the artist may have already been removed. ignore the event is that is the
     // case
+    bool removed = false;
     try {
-      m_canvas->gca<MantidAxes>().removeWorkspaceArtists(ws);
+      removed = m_canvas->gca<MantidAxes>().removeWorkspaceArtists(ws);
     } catch (Mantid::PythonInterface::PythonException &) {
     }
-    this->replot();
+    if (removed) {
+      this->replot();
+    }
   }
 }
 
@@ -606,13 +612,17 @@ void PreviewPlot::onWorkspaceRemoved(
  */
 void PreviewPlot::onWorkspaceReplaced(
     Mantid::API::WorkspaceBeforeReplaceNotification_ptr nf) {
+  if (m_lines.isEmpty()) {
+    return;
+  }
   // Ignore non matrix workspaces
   if (auto oldWS =
           boost::dynamic_pointer_cast<MatrixWorkspace>(nf->oldObject())) {
     if (auto newWS =
             boost::dynamic_pointer_cast<MatrixWorkspace>(nf->newObject())) {
-      m_canvas->gca<MantidAxes>().replaceWorkspaceArtists(newWS);
-      this->replot();
+      if (m_canvas->gca<MantidAxes>().replaceWorkspaceArtists(newWS)) {
+        this->replot();
+      }
     }
   }
 }


### PR DESCRIPTION
**Description of work.**

On workbench if you had any of the C++ interfaces open changes the ADS could take a long time. This was at least partially becuase preview plot was replotting far more than neccecary. This updates the ADSwatchers in preview plot so that it only replots if a relevant workspace changes.

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

**To test:**
See the discussion in #28194 for how to test this issue.

<!-- Instructions for testing. -->

Fixes #28194  <!-- and fix #xxxx or close #xxxx xor resolves #xxxx -->
<!-- alternative
*There is no associated issue.*
-->

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
-->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
