### PR TITLE
Replace header guards in TestHelpers and Types with pragma once

### DIFF
--- a/Framework/TestHelpers/inc/MantidTestHelpers/BinaryOperationMDTestHelper.h
+++ b/Framework/TestHelpers/inc/MantidTestHelpers/BinaryOperationMDTestHelper.h
@@ -9,8 +9,7 @@
  *
  *  This header MAY ONLY be included from a test in the MDAlgorithms package.
  *********************************************************************************/
-#ifndef MANTID_MDALGORITHMS_BINARYOPERATIONMDTESTHELPER_H_
-#define MANTID_MDALGORITHMS_BINARYOPERATIONMDTESTHELPER_H_
+#pragma once
 
 #include "MantidDataObjects/MDHistoWorkspace.h"
 
@@ -31,5 +30,3 @@ doTest(std::string algoName, std::string inName, std::string outName,
        std::string otherPropValue = "");
 
 } // namespace UnaryOperationMDTestHelper
-
-#endif

--- a/Framework/TestHelpers/inc/MantidTestHelpers/BoxControllerDummyIO.h
+++ b/Framework/TestHelpers/inc/MantidTestHelpers/BoxControllerDummyIO.h
@@ -14,8 +14,7 @@
  *  than API (e.g. any algorithm or concrete workspace), even if via the
  *factory.
  *********************************************************************************/
-#ifndef MANTID_TESTHELPERS_BOXCONTROLLER_DUMMUY_IO_H
-#define MANTID_TESTHELPERS_BOXCONTROLLER_DUMMUY_IO_H
+#pragma once
 
 #include "MantidAPI/BoxController.h"
 #include "MantidAPI/IBoxControllerIO.h"
@@ -95,4 +94,3 @@ private:
   bool m_isOpened;
 };
 } // namespace MantidTestHelpers
-#endif

--- a/Framework/TestHelpers/inc/MantidTestHelpers/ComponentCreationHelper.h
+++ b/Framework/TestHelpers/inc/MantidTestHelpers/ComponentCreationHelper.h
@@ -13,8 +13,7 @@
  *a
  *  package higher than Geometry (e.g. API, DataObjects, ...)
  *********************************************************************************/
-#ifndef COMPONENTCREATIONHELPER_H_
-#define COMPONENTCREATIONHELPER_H_
+#pragma once
 
 #include "MantidGeometry/Instrument.h"
 #include "MantidGeometry/Instrument/Detector.h"
@@ -258,5 +257,3 @@ createInstrumentWithPSDTubes(const size_t nTubes = 3,
                              const size_t nPixelsPerTube = 50,
                              const bool mirrorTubes = false);
 } // namespace ComponentCreationHelper
-
-#endif // COMPONENTCREATIONHELPERS_H_

--- a/Framework/TestHelpers/inc/MantidTestHelpers/DataProcessorTestHelper.h
+++ b/Framework/TestHelpers/inc/MantidTestHelpers/DataProcessorTestHelper.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef DATAPROCESSORTESTHELPER_H
-#define DATAPROCESSORTESTHELPER_H
+#pragma once
 
 #include "MantidKernel/System.h"
 
@@ -42,5 +41,3 @@ makeRowData(const std::vector<std::string> &list,
             const std::vector<std::string> &prefixes = {"TOF_", "", "TRANS_"},
             const size_t numSlices = 0);
 } // namespace DataProcessorTestHelper
-
-#endif /*DATAPROCESSORTESTHELPER_H*/

--- a/Framework/TestHelpers/inc/MantidTestHelpers/FacilityHelper.h
+++ b/Framework/TestHelpers/inc/MantidTestHelpers/FacilityHelper.h
@@ -10,8 +10,7 @@
  *  This file MAY NOT be modified to use anything from a package other than
  *Kernel.
  *********************************************************************************/
-#ifndef TESTHELPERS_FACILITYHELPER_H_
-#define TESTHELPERS_FACILITYHELPER_H_
+#pragma once
 
 #include "MantidKernel/ConfigService.h"
 #include "MantidKernel/FacilityInfo.h"
@@ -51,5 +50,3 @@ private:
   std::string defFacilityOnStart;
 };
 } // namespace FacilityHelper
-
-#endif /* TESTHELPERS_FACILITYHELPER_H_ */

--- a/Framework/TestHelpers/inc/MantidTestHelpers/FakeObjects.h
+++ b/Framework/TestHelpers/inc/MantidTestHelpers/FakeObjects.h
@@ -14,8 +14,7 @@
  *  than API (e.g. any algorithm or concrete workspace), even if via the
  *factory.
  *********************************************************************************/
-#ifndef FAKEOBJECTS_H_
-#define FAKEOBJECTS_H_
+#pragma once
 
 /*
  * FakeObjects.h: Fake Tester objects for APITest
@@ -755,4 +754,3 @@ class VariableBinThrowingTester : public AxeslessWorkspaceTester {
     return 0;
   }
 };
-#endif /* FAKEOBJECTS_H_ */

--- a/Framework/TestHelpers/inc/MantidTestHelpers/FileComparisonHelper.h
+++ b/Framework/TestHelpers/inc/MantidTestHelpers/FileComparisonHelper.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef FILECOMPARISONHELPER_H_
-#define FILECOMPARISONHELPER_H_
+#pragma once
 
 #include <iosfwd>
 #include <iterator>
@@ -48,5 +47,3 @@ bool areFileStreamsEqual(std::ifstream &referenceFileStream,
 bool isEqualToReferenceFile(const std::string &referenceFileName,
                             const std::string &outFileFullPath);
 } // Namespace FileComparisonHelper
-
-#endif // FILECOMPARISONHELPER_H_

--- a/Framework/TestHelpers/inc/MantidTestHelpers/FileResource.h
+++ b/Framework/TestHelpers/inc/MantidTestHelpers/FileResource.h
@@ -12,8 +12,7 @@
  * @date 06/08/2019
  */
 
-#ifndef MANTID_NEXUSGEOMETRY_FILERESOURCE_H_
-#define MANTID_NEXUSGEOMETRY_FILERESOURCE_H_
+#pragma once
 
 #include <boost/filesystem.hpp>
 #include <iostream>
@@ -35,5 +34,3 @@ protected:
   static void *operator new(std::size_t); // prevent heap allocation of scalar.
   static void *operator new[](std::size_t); // prevent heap allocation of array.
 };
-
-#endif /* MANTID_NEXUSGEOMETRYY_FILERESOURCE_H_ */

--- a/Framework/TestHelpers/inc/MantidTestHelpers/FunctionCreationHelper.h
+++ b/Framework/TestHelpers/inc/MantidTestHelpers/FunctionCreationHelper.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_TESTHELPERS_FUNCTIONCREATIONHELPER_H_
-#define MANTID_TESTHELPERS_FUNCTIONCREATIONHELPER_H_
+#pragma once
 
 #include "MantidAPI/IFunction1D.h"
 #include "MantidAPI/ParamFunction.h"
@@ -33,5 +32,3 @@ protected:
 
 } // namespace TestHelpers
 } // namespace Mantid
-
-#endif // MANTID_TESTHELPERS_FUNCTIONCREATIONHELPER_H_

--- a/Framework/TestHelpers/inc/MantidTestHelpers/IndirectFitDataCreationHelper.h
+++ b/Framework/TestHelpers/inc/MantidTestHelpers/IndirectFitDataCreationHelper.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_INDIRECTFITDATACREATIONHELPER_H_
-#define MANTID_INDIRECTFITDATACREATIONHELPER_H_
+#pragma once
 
 #include "MantidAPI/AnalysisDataService.h"
 #include "MantidAPI/MatrixWorkspace_fwd.h"
@@ -113,5 +112,3 @@ struct AreSpectraEqual : public boost::static_visitor<bool> {
 
 } // namespace IndirectFitDataCreationHelper
 } // namespace Mantid
-
-#endif // MANTID_INDIRECTFITDATACREATIONHELPER_H

--- a/Framework/TestHelpers/inc/MantidTestHelpers/InstrumentCreationHelper.h
+++ b/Framework/TestHelpers/inc/MantidTestHelpers/InstrumentCreationHelper.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef INSTRUMENTCREATIONHELPER_H_
-#define INSTRUMENTCREATIONHELPER_H_
+#pragma once
 
 #include "MantidTestHelpers/ComponentCreationHelper.h"
 
@@ -34,5 +33,3 @@ void addDetector(Mantid::Geometry::Instrument_sptr &instrument,
                  const Mantid::Kernel::V3D &position, const int ID,
                  const std::string &name);
 } // namespace InstrumentCreationHelper
-
-#endif /* INSTRUMENTCREATIONHELPER_H_ */

--- a/Framework/TestHelpers/inc/MantidTestHelpers/JSONGeometryParserTestHelper.h
+++ b/Framework/TestHelpers/inc/MantidTestHelpers/JSONGeometryParserTestHelper.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_TESTHELPERS_JSONGEOMETRYPARSERTESTHELPER_H_
-#define MANTID_TESTHELPERS_JSONGEOMETRYPARSERTESTHELPER_H_
+#pragma once
 
 #ifdef _MSC_VER
 // JSON: non-DLL-interface classkey 'identifier' used as base for
@@ -149,5 +148,3 @@ std::string getFullJSONInstrumentSimpleWithZPixelOffset();
 
 } // namespace TestHelpers
 } // namespace Mantid
-
-#endif // MANTID_TESTHELPERS_JSONGEOMETRYPARSERTESTHELPER_H_

--- a/Framework/TestHelpers/inc/MantidTestHelpers/MDAlgorithmsTestHelper.h
+++ b/Framework/TestHelpers/inc/MantidTestHelpers/MDAlgorithmsTestHelper.h
@@ -9,8 +9,7 @@
  *
  *  This header MAY ONLY be included in the MDalgorithms package
  *********************************************************************************/
-#ifndef MDALGORITHMSTESTHELPER_H
-#define MDALGORITHMSTESTHELPER_H
+#pragma once
 
 #include "MantidDataObjects/MDEventFactory.h"
 
@@ -32,5 +31,3 @@ DataObjects::MDEventWorkspace3Lean::sptr makeFileBackedMDEWwithMDFrame(
 } // namespace MDAlgorithmsTestHelper
 } // namespace MDAlgorithms
 } // namespace Mantid
-
-#endif

--- a/Framework/TestHelpers/inc/MantidTestHelpers/MDEventsTestHelper.h
+++ b/Framework/TestHelpers/inc/MantidTestHelpers/MDEventsTestHelper.h
@@ -11,8 +11,7 @@
  *of
  *  DataObjects (e.g. Kernel, Geometry, API).
  *********************************************************************************/
-#ifndef MDEVENTSTEST_HELPER_H
-#define MDEVENTSTEST_HELPER_H
+#pragma once
 
 #include "MantidAPI/AnalysisDataService.h"
 #include "MantidAPI/BoxController.h"
@@ -510,5 +509,3 @@ void checkAndDeleteFile(std::string filename);
 } // namespace MDEventsTestHelper
 } // namespace DataObjects
 } // namespace Mantid
-
-#endif

--- a/Framework/TestHelpers/inc/MantidTestHelpers/MultiDomainFunctionHelper.h
+++ b/Framework/TestHelpers/inc/MantidTestHelpers/MultiDomainFunctionHelper.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_TESTHELPERS_MULTIDOMAINFUNCTIONHELPER_H_
-#define MANTID_TESTHELPERS_MULTIDOMAINFUNCTIONHELPER_H_
+#pragma once
 
 #include "MantidAPI/IFunction1D.h"
 #include "MantidAPI/JointDomain.h"
@@ -46,5 +45,3 @@ Mantid::API::MatrixWorkspace_sptr makeMultiDomainWorkspace3();
 
 } // namespace TestHelpers
 } // namespace Mantid
-
-#endif // MANTID_TESTHELPERS_MULTIDOMAINFUNCTIONHELPER_H_

--- a/Framework/TestHelpers/inc/MantidTestHelpers/MuonGroupingXMLHelper.h
+++ b/Framework/TestHelpers/inc/MantidTestHelpers/MuonGroupingXMLHelper.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MUONGROUPINGXMLHELPER_H_
-#define MUONGROUPINGXMLHELPER_H_
+#pragma once
 
 #include "MantidAPI/GroupingLoader.h"
 #include "MantidTestHelpers/ScopedFileHelper.h"
@@ -36,5 +35,3 @@ createXMLwithPairsAndGroups(const int &nGroups = 1,
 DLLExport std::string groupingToXML(const Mantid::API::Grouping &grouping);
 
 } // namespace MuonGroupingXMLHelper
-
-#endif /*MUONGROUPINGXMLHELPER_H_*/

--- a/Framework/TestHelpers/inc/MantidTestHelpers/MuonWorkspaceCreationHelper.h
+++ b/Framework/TestHelpers/inc/MantidTestHelpers/MuonWorkspaceCreationHelper.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MUONWORKSPACECREATIONHELPER_H_
-#define MUONWORKSPACECREATIONHELPER_H_
+#pragma once
 
 #include "MantidAPI/MatrixWorkspace.h"
 #include "MantidAPI/WorkspaceGroup.h"
@@ -130,5 +129,3 @@ createWorkspaceGroupConsecutiveDetectorIDs(const int &nWorkspaces, size_t nspec,
                                            const std::string &wsGroupName);
 
 } // namespace MuonWorkspaceCreationHelper
-
-#endif /*MUONWORKSPACECREATIONHELPER_H_*/

--- a/Framework/TestHelpers/inc/MantidTestHelpers/NexusFileReader.h
+++ b/Framework/TestHelpers/inc/MantidTestHelpers/NexusFileReader.h
@@ -5,8 +5,7 @@
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
 
-#ifndef MANTID_NEXUSGEOMETRY_NEXUSFILEREADER_H_
-#define MANTID_NEXUSGEOMETRY_NEXUSFILEREADER_H_
+#pragma once
 
 #include "MantidNexusGeometry/H5ForwardCompatibility.h"
 #include "MantidNexusGeometry/NexusGeometryDefinitions.h"
@@ -417,4 +416,3 @@ private:
 }; // NexusFileReader
 } // namespace NexusGeometry
 } // namespace Mantid
-#endif

--- a/Framework/TestHelpers/inc/MantidTestHelpers/NexusGeometryTestHelpers.h
+++ b/Framework/TestHelpers/inc/MantidTestHelpers/NexusGeometryTestHelpers.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef NEXUSGEOMETRYTESTHELPERS_H
-#define NEXUSGEOMETRYTESTHELPERS_H
+#pragma once
 
 #include <boost/shared_ptr.hpp>
 #include <vector>
@@ -24,5 +23,3 @@ Pixels generateCoLinearPixels();
 Pixels generateNonCoLinearPixels();
 std::vector<int> getFakeDetIDs();
 } // namespace NexusGeometryTestHelpers
-
-#endif // NEXUSGEOMETRYTESTHELPERS_H

--- a/Framework/TestHelpers/inc/MantidTestHelpers/NexusTestHelper.h
+++ b/Framework/TestHelpers/inc/MantidTestHelpers/NexusTestHelper.h
@@ -10,8 +10,7 @@
  *  This file MAY NOT be modified to use anything from a package other than
  *Kernel.
  *********************************************************************************/
-#ifndef MANTID_NEXUSCPP_NEXUSTESTHELPER_H_
-#define MANTID_NEXUSCPP_NEXUSTESTHELPER_H_
+#pragma once
 
 #include <memory>
 #include <string>
@@ -41,5 +40,3 @@ public:
   /// Do you delete when finished?
   bool deleteFile;
 };
-
-#endif /* MANTID_NEXUSCPP_NEXUSTESTHELPER_H_ */

--- a/Framework/TestHelpers/inc/MantidTestHelpers/ONCatHelper.h
+++ b/Framework/TestHelpers/inc/MantidTestHelpers/ONCatHelper.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_TESTHELPERS_ONCATHELPER_H_
-#define MANTID_TESTHELPERS_ONCATHELPER_H_
+#pragma once
 
 #include "MantidCatalog/ONCat.h"
 #include "MantidKernel/Exception.h"
@@ -74,5 +73,3 @@ IOAuthTokenStore_uptr make_mock_token_store_already_logged_in();
 
 } // namespace TestHelpers
 } // namespace Mantid
-
-#endif // MANTID_TESTHELPERS_ONCATHELPER_H_

--- a/Framework/TestHelpers/inc/MantidTestHelpers/ParallelAlgorithmCreation.h
+++ b/Framework/TestHelpers/inc/MantidTestHelpers/ParallelAlgorithmCreation.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef PARALLELALGORITHMCREATION_H_
-#define PARALLELALGORITHMCREATION_H_
+#pragma once
 
 #include "MantidAPI/IWorkspaceProperty.h"
 #include "MantidKernel/Property.h"
@@ -47,5 +46,3 @@ std::unique_ptr<T> create(const Mantid::Parallel::Communicator &comm) {
 }
 
 } // namespace ParallelTestHelpers
-
-#endif /*PARALLELALGORITHMCREATION_H_*/

--- a/Framework/TestHelpers/inc/MantidTestHelpers/ParallelRunner.h
+++ b/Framework/TestHelpers/inc/MantidTestHelpers/ParallelRunner.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_TESTHELPERS_PARALLELRUNNER_H_
-#define MANTID_TESTHELPERS_PARALLELRUNNER_H_
+#pragma once
 
 #include "MantidParallel/Communicator.h"
 #include "MantidParallel/DllConfig.h"
@@ -65,5 +64,3 @@ template <class... Args> void runParallel(Args &&... args) {
 }
 
 } // namespace ParallelTestHelpers
-
-#endif /* MANTID_TESTHELPERS_PARALLELRUNNER_H_ */

--- a/Framework/TestHelpers/inc/MantidTestHelpers/ReflectometryHelper.h
+++ b/Framework/TestHelpers/inc/MantidTestHelpers/ReflectometryHelper.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_TESTHELPERS_REFLECTOMETRYHELPER_H_
-#define MANTID_TESTHELPERS_REFLECTOMETRYHELPER_H_
+#pragma once
 
 #include "MantidAPI/MatrixWorkspace_fwd.h"
 #include "MantidAPI/WorkspaceGroup_fwd.h"
@@ -64,5 +63,3 @@ MatrixWorkspace_sptr createWorkspaceSingle(const double startX = 1,
                                            const double deltaX = 1);
 } // namespace TestHelpers
 } // namespace Mantid
-
-#endif // MANTID_TESTHELPERS_REFLECTOMETRYHELPER_H_

--- a/Framework/TestHelpers/inc/MantidTestHelpers/SANSInstrumentCreationHelper.h
+++ b/Framework/TestHelpers/inc/MantidTestHelpers/SANSInstrumentCreationHelper.h
@@ -13,8 +13,7 @@
  *  I.e. It can only be used by plugin/algorithm-level packages (e.g.
  *DataHandling)
  *********************************************************************************/
-#ifndef SANSINSTRUMENTCREATIONHELPER_H_
-#define SANSINSTRUMENTCREATIONHELPER_H_
+#pragma once
 
 #include "MantidDataObjects/Workspace2D.h"
 
@@ -52,5 +51,3 @@ public:
   runLoadMappingTable(Mantid::DataObjects::Workspace2D_sptr workspace,
                       int nxbins, int nybins);
 };
-
-#endif // SANSINSTRUMENTCREATIONHELPER_H_

--- a/Framework/TestHelpers/inc/MantidTestHelpers/ScopedFileHelper.h
+++ b/Framework/TestHelpers/inc/MantidTestHelpers/ScopedFileHelper.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef SCOPEDFILEHELPER_H_
-#define SCOPEDFILEHELPER_H_
+#pragma once
 //------------------------------------------------------------------------------
 // Includes
 //------------------------------------------------------------------------------
@@ -47,4 +46,3 @@ private:
   void operator delete[](void *);
 };
 } // namespace ScopedFileHelper
-#endif

--- a/Framework/TestHelpers/inc/MantidTestHelpers/SingleCrystalDiffractionTestHelper.h
+++ b/Framework/TestHelpers/inc/MantidTestHelpers/SingleCrystalDiffractionTestHelper.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef SINGLECRYSTALDIFFRACTIONHELPER_H_
-#define SINGLECRYSTALDIFFRACTIONHELPER_H_
+#pragma once
 
 #include "MantidAPI/MatrixWorkspace.h"
 #include "MantidDataObjects/EventWorkspace.h"
@@ -111,5 +110,3 @@ private:
 };
 } // namespace SingleCrystalDiffractionTestHelper
 } // namespace Mantid
-
-#endif

--- a/Framework/TestHelpers/inc/MantidTestHelpers/TearDownWorld.h
+++ b/Framework/TestHelpers/inc/MantidTestHelpers/TearDownWorld.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef TEARDOWNWORLD_H_
-#define TEARDOWNWORLD_H_
+#pragma once
 
 #include <cxxtest/GlobalFixture.h>
 
@@ -40,5 +39,3 @@ class ClearADS : public CxxTest::GlobalFixture {
 class ClearPropertyManagerDataService : public CxxTest::GlobalFixture {
   bool tearDownWorld() override;
 };
-
-#endif // TEARDOWNWORLD_H_

--- a/Framework/TestHelpers/inc/MantidTestHelpers/WorkspaceCreationHelper.h
+++ b/Framework/TestHelpers/inc/MantidTestHelpers/WorkspaceCreationHelper.h
@@ -14,8 +14,7 @@
  *  package higher than DataObjects (e.g. any algorithm), even if via the
  *factory.
  *********************************************************************************/
-#ifndef WORKSPACECREATIONHELPER_H_
-#define WORKSPACECREATIONHELPER_H_
+#pragma once
 
 #include "MantidAPI/Algorithm.h"
 #include "MantidAPI/AnalysisDataService.h"
@@ -444,5 +443,3 @@ Mantid::API::ITableWorkspace_sptr
 createEPPTableWorkspace(const std::vector<EPPTableRow> &rows);
 
 } // namespace WorkspaceCreationHelper
-
-#endif /*WORKSPACECREATIONHELPER_H_*/

--- a/Framework/Types/inc/MantidTypes/Core/DateAndTime.h
+++ b/Framework/Types/inc/MantidTypes/Core/DateAndTime.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_TYPES_DATE_AND_TIME_H
-#define MANTID_TYPES_DATE_AND_TIME_H
+#pragma once
 
 #include "MantidTypes/DllConfig.h"
 #ifndef Q_MOC_RUN
@@ -198,5 +197,3 @@ inline int64_t DateAndTime::nanosecondsFromSeconds(double sec) {
 } // namespace Core
 } // namespace Types
 } // namespace Mantid
-
-#endif // MANTID_TYPES_DATE_AND_TIME_H

--- a/Framework/Types/inc/MantidTypes/Core/DateAndTimeHelpers.h
+++ b/Framework/Types/inc/MantidTypes/Core/DateAndTimeHelpers.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_TYPES_CORE_DATEANDTIMEHELPERS_H_
-#define MANTID_TYPES_CORE_DATEANDTIMEHELPERS_H_
+#pragma once
 
 #include "MantidTypes/DllConfig.h"
 
@@ -21,5 +20,3 @@ MANTID_TYPES_DLL bool stringIsPosix(const std::string &date);
 } // namespace Core
 } // namespace Types
 } // namespace Mantid
-
-#endif /* MANTID_TYPES_CORE_DATEANDTIMEHELPERS_H_ */

--- a/Framework/Types/inc/MantidTypes/Event/TofEvent.h
+++ b/Framework/Types/inc/MantidTypes/Event/TofEvent.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_TYPES_TOFEVENT_H
-#define MANTID_TYPES_TOFEVENT_H
+#pragma once
 
 #include "MantidTypes/Core/DateAndTime.h"
 #include "MantidTypes/DllConfig.h"
@@ -138,4 +137,3 @@ inline double TofEvent::errorSquared() const { return 1.0; }
 } // namespace Event
 } // namespace Types
 } // namespace Mantid
-#endif // MANTID_TYPES_TOFEVENT_H

--- a/Framework/Types/inc/MantidTypes/SpectrumDefinition.h
+++ b/Framework/Types/inc/MantidTypes/SpectrumDefinition.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_TYPES_SPECTRUMDEFINITION_H_
-#define MANTID_TYPES_SPECTRUMDEFINITION_H_
+#pragma once
 
 #include <algorithm>
 #include <utility>
@@ -69,5 +68,3 @@ public:
 };
 
 } // namespace Mantid
-
-#endif /* MANTID_TYPES_SPECTRUMDEFINITION_H_ */

--- a/Framework/Types/test/DateAndTimeHelpersTest.h
+++ b/Framework/Types/test/DateAndTimeHelpersTest.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_TYPES_CORE_DATEANDTIMEHELPERSTEST_H_
-#define MANTID_TYPES_CORE_DATEANDTIMEHELPERSTEST_H_
+#pragma once
 
 #include "MantidTypes/Core/DateAndTimeHelpers.h"
 #include <cxxtest/TestSuite.h>
@@ -76,5 +75,3 @@ public:
     TS_ASSERT(!stringIsPosix("1990-Jan-40 03:04:02"))
   }
 };
-
-#endif /* MANTID_TYPES_CORE_DATEANDTIMEHELPERSTEST_H_ */

--- a/Framework/Types/test/DateAndTimeTest.h
+++ b/Framework/Types/test/DateAndTimeTest.h
@@ -11,8 +11,7 @@
  *      Author: janik
  */
 
-#ifndef DATEANDTIMETEST_H_
-#define DATEANDTIMETEST_H_
+#pragma once
 
 #include "MantidTypes/Core/DateAndTime.h"
 #include <ctime>
@@ -471,5 +470,3 @@ public:
     }
   }
 };
-
-#endif /* DATEANDTIMETEST_H_ */

--- a/Framework/Types/test/SpectrumDefinitionTest.h
+++ b/Framework/Types/test/SpectrumDefinitionTest.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_TYPES_SPECTRUMDEFINITIONTEST_H_
-#define MANTID_TYPES_SPECTRUMDEFINITIONTEST_H_
+#pragma once
 
 #include <cxxtest/TestSuite.h>
 
@@ -107,5 +106,3 @@ public:
     TS_ASSERT_EQUALS(*(def.cbegin()), (std::pair<size_t, size_t>(1, 0)));
   }
 };
-
-#endif /* MANTID_TYPES_SPECTRUMDEFINITIONTEST_H_ */

--- a/Framework/Types/test/TofEventTest.h
+++ b/Framework/Types/test/TofEventTest.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef TOFEVENTTEST_H_
-#define TOFEVENTTEST_H_ 1
+#pragma once
 
 #include "MantidTypes/Event/TofEvent.h"
 #include <cmath>
@@ -51,5 +50,3 @@ public:
     TS_ASSERT_EQUALS(e3.pulseTime(), 321);
   }
 };
-
-#endif


### PR DESCRIPTION
This PR replaces all header guards in TestHelpers and Types with #pragma once.

**To test:**

Any issues in this PR should be caught by jenkins. just code review to check that no definitions or endifs have been removed by mistake

This pr is a part of #28200

*This does not require release notes* because **it is an internal change to the codebase.**

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
