### PR TITLE
Fix normalise by bin width setting

### DIFF
--- a/Framework/PythonInterface/mantid/plots/datafunctions.py
+++ b/Framework/PythonInterface/mantid/plots/datafunctions.py
@@ -87,10 +87,7 @@ def get_normalize_by_bin_width(workspace, axes, **kwargs):
                 [artist[0].is_normalized for artist in current_artists])
             normalization = current_normalization
         else:
-            if mantid.kernel.config['graph1d.autodistribution'].lower() == 'on':
-                normalization = True
-            else:
-                normalization, _ = check_resample_to_regular_grid(workspace, **kwargs)
+            normalization = mantid.kernel.config['graph1d.autodistribution'].lower() == 'on'
     return normalization, kwargs
 
 

--- a/Framework/PythonInterface/test/python/mantid/plots/plots__init__Test.py
+++ b/Framework/PythonInterface/test/python/mantid/plots/plots__init__Test.py
@@ -316,21 +316,21 @@ class Plots__init__Test(unittest.TestCase):
         self.assertFalse(self.ax.tracked_workspaces[non_dist_ws.name()][0].is_normalized)
         del self.ax.tracked_workspaces[non_dist_ws.name()]
 
-        self.ax.plot(non_dist_ws, specNum=1)
         auto_dist = (config['graph1d.autodistribution'] == 'On')
+        self.ax.plot(non_dist_ws, specNum=1)
         self.assertEqual(auto_dist, self.ax.tracked_workspaces[non_dist_ws.name()][0].is_normalized)
         del self.ax.tracked_workspaces[non_dist_ws.name()]
 
-    def test_artists_normalization_state_labeled_correctly_for_non_dist_workspace_with_uneven_spectra(self):
+    def test_artists_normalization_state_labeled_correctly_for_non_dist_workspace_and_global_setting_off(self):
         non_dist_ws = CreateWorkspace(DataX=[10, 20, 25, 30],
                                       DataY=[2, 3, 4, 5],
                                       DataE=[1, 2, 1, 2],
                                       NSpec=1,
                                       Distribution=False,
                                       OutputWorkspace='non_dist_workpace')
-        self.ax.plot(non_dist_ws, specNum=1)
         config['graph1d.autodistribution'] = 'Off'
-        self.assertTrue(self.ax.tracked_workspaces[non_dist_ws.name()][0].is_normalized)
+        self.ax.plot(non_dist_ws, specNum=1)
+        self.assertFalse(self.ax.tracked_workspaces[non_dist_ws.name()][0].is_normalized)
         del self.ax.tracked_workspaces[non_dist_ws.name()]
 
     def test_artists_normalization_state_labeled_correctly_for_2d_plots_of_dist_workspace(self):
@@ -392,13 +392,13 @@ class Plots__init__Test(unittest.TestCase):
                                          Distribution=False,
                                          OutputWorkspace='non_dist_workpace')
         for plot_func in plot_funcs:
+            auto_dist = (config['graph1d.autodistribution'] == 'On')
             func = getattr(self.ax, plot_func)
             func(non_dist_2d_ws)
-            auto_dist = (config['graph1d.autodistribution'] == 'On')
             self.assertEqual(auto_dist, self.ax.tracked_workspaces[non_dist_2d_ws.name()][0].is_normalized)
             del self.ax.tracked_workspaces[non_dist_2d_ws.name()]
 
-    def test_artists_normalization_state_labeled_correctly_for_2d_plots_of_non_dist_workspace_with_uneven_spectra(self):
+    def test_artists_normalization_labeled_correctly_for_2d_plots_of_non_dist_workspace_and_global_setting_off(self):
         plot_funcs = ['imshow', 'pcolor', 'pcolormesh', 'pcolorfast', 'tripcolor',
                       'contour', 'contourf', 'tricontour', 'tricontourf']
         non_dist_2d_ws = CreateWorkspace(DataX=[10, 20, 25, 30, 10, 20, 25, 30],
@@ -408,10 +408,10 @@ class Plots__init__Test(unittest.TestCase):
                                          Distribution=False,
                                          OutputWorkspace='non_dist_workpace')
         for plot_func in plot_funcs:
+            config['graph1d.autodistribution'] = 'Off'
             func = getattr(self.ax, plot_func)
             func(non_dist_2d_ws)
-            config['graph1d.autodistribution'] = 'Off'
-            self.assertTrue(self.ax.tracked_workspaces[non_dist_2d_ws.name()][0].is_normalized)
+            self.assertFalse(self.ax.tracked_workspaces[non_dist_2d_ws.name()][0].is_normalized)
             del self.ax.tracked_workspaces[non_dist_2d_ws.name()]
 
     def test_check_axes_distribution_consistency_mixed_normalization(self):


### PR DESCRIPTION
**Description of work.**
This PR fixes the normalize by bin width setting to work as expected. It removes one of the checks to see if the workspace has uneven bin widths as this was causing workspaces to be normalized even if the setting is off.

**To test:**

Open workbench
Go to `File` -> `Settings`->`Plots`
Tick `Normalize by bin width on 1D and 2D plots`
Load a workspace
Do a plot, the plot should be normalized
Close the plot
Open settings again and untick the normalization
Do another plot, this should not be normalized by default 

Fixes #28269 

*This does not require release notes* because **this is a regression**

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
