### PR TITLE
Fix unhandled exception when toggling error bars on a line with markers

### DIFF
--- a/qt/python/mantidqt/widgets/plotconfigdialog/curvestabwidget/__init__.py
+++ b/qt/python/mantidqt/widgets/plotconfigdialog/curvestabwidget/__init__.py
@@ -119,6 +119,12 @@ class CurveProperties(dict):
             if k not in ['hide', 'hide_errors']:
                 kwargs[k] = v
         kwargs['visible'] = not self.hide
+
+        # If the long form of the marker name is currently being used, it is changed to the short form which is
+        # understood by matplotlib.
+        if kwargs['marker'] in MARKER_MAP:
+            kwargs['marker'] = MARKER_MAP[kwargs['marker']]
+
         return kwargs
 
     @classmethod

--- a/qt/python/mantidqt/widgets/plotconfigdialog/curvestabwidget/test/test_curveproperties.py
+++ b/qt/python/mantidqt/widgets/plotconfigdialog/curvestabwidget/test/test_curveproperties.py
@@ -97,7 +97,7 @@ class CurvePropertiesTest(unittest.TestCase):
                          'label': 'ax0',
                          'linestyle': 'dashdot',
                          'linewidth': 4.0,
-                         'marker': 'triangle_down',
+                         'marker': 'v',
                          'markeredgecolor': '#008000',
                          'markerfacecolor': '#000000',
                          'markersize': 10.0,


### PR DESCRIPTION
**Description of work.**
See title.

**To test:**
This can be tested in two ways, take your pick:

1. a. File -> Settings.
b. In the settings, go to the Plots tab and change Marker Style to something other than None.
c. Load a workspace, right-click it and select Plot->Spectrum with errors...
d. Making the plot should not cause an unhandled exception. The plot should have markers and errorbars.

2. a. Load a workspace, double-click it, and create a plot.
b. Go to figure options and change the marker style on a line so it isn't None.
c. Right-click the figure and select Error Bars -> Show All Errors. There should be no unhandled exception.

Fixes #28286 
Fixes #27401

Release notes have been added in #28268 to avoid a conflict.

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
