### PR TITLE
Replace WorkflowAlgorithms and class maker header guards

### DIFF
--- a/Framework/WorkflowAlgorithms/inc/MantidWorkflowAlgorithms/AlignAndFocusPowder.h
+++ b/Framework/WorkflowAlgorithms/inc/MantidWorkflowAlgorithms/AlignAndFocusPowder.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_ALGORITHM_AlignAndFocusPowder_H_
-#define MANTID_ALGORITHM_AlignAndFocusPowder_H_
+#pragma once
 
 #include "MantidAPI/DataProcessorAlgorithm.h"
 #include "MantidAPI/MatrixWorkspace_fwd.h"
@@ -140,5 +139,3 @@ private:
 
 } // namespace WorkflowAlgorithms
 } // namespace Mantid
-
-#endif /*MANTID_ALGORITHM_AlignAndFocusPowder_H_*/

--- a/Framework/WorkflowAlgorithms/inc/MantidWorkflowAlgorithms/ComputeSensitivity.h
+++ b/Framework/WorkflowAlgorithms/inc/MantidWorkflowAlgorithms/ComputeSensitivity.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_ALGORITHMS_COMPUTESENSITIVITY_H_
-#define MANTID_ALGORITHMS_COMPUTESENSITIVITY_H_
+#pragma once
 
 //----------------------------------------------------------------------
 // Includes
@@ -41,5 +40,3 @@ private:
 
 } // namespace WorkflowAlgorithms
 } // namespace Mantid
-
-#endif /*MANTID_ALGORITHMS_COMPUTESENSITIVITY_H_*/

--- a/Framework/WorkflowAlgorithms/inc/MantidWorkflowAlgorithms/DgsAbsoluteUnitsReduction.h
+++ b/Framework/WorkflowAlgorithms/inc/MantidWorkflowAlgorithms/DgsAbsoluteUnitsReduction.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_WORKFLOWALGORITHMS_DGSABSOLUTEUNITSREDUCTION_H_
-#define MANTID_WORKFLOWALGORITHMS_DGSABSOLUTEUNITSREDUCTION_H_
+#pragma once
 
 #include "MantidAPI/Algorithm.h"
 #include "MantidKernel/System.h"
@@ -35,5 +34,3 @@ private:
 
 } // namespace WorkflowAlgorithms
 } // namespace Mantid
-
-#endif /* MANTID_WORKFLOWALGORITHMS_DGSABSOLUTEUNITSREDUCTION_H_ */

--- a/Framework/WorkflowAlgorithms/inc/MantidWorkflowAlgorithms/DgsConvertToEnergyTransfer.h
+++ b/Framework/WorkflowAlgorithms/inc/MantidWorkflowAlgorithms/DgsConvertToEnergyTransfer.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_WORKFLOWALGORITHMS_DGSCONVERTTOENERGYTRANSFER_H_
-#define MANTID_WORKFLOWALGORITHMS_DGSCONVERTTOENERGYTRANSFER_H_
+#pragma once
 
 #include "MantidAPI/Algorithm.h"
 #include "MantidKernel/System.h"
@@ -35,5 +34,3 @@ private:
 
 } // namespace WorkflowAlgorithms
 } // namespace Mantid
-
-#endif /* MANTID_WORKFLOWALGORITHMS_DGSCONVERTTOENERGYTRANSFER_H_ */

--- a/Framework/WorkflowAlgorithms/inc/MantidWorkflowAlgorithms/DgsDiagnose.h
+++ b/Framework/WorkflowAlgorithms/inc/MantidWorkflowAlgorithms/DgsDiagnose.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_WORKFLOWALGORITHMS_DGSDIAGNOSE_H_
-#define MANTID_WORKFLOWALGORITHMS_DGSDIAGNOSE_H_
+#pragma once
 
 #include "MantidAPI/Algorithm.h"
 #include "MantidKernel/System.h"
@@ -35,5 +34,3 @@ private:
 
 } // namespace WorkflowAlgorithms
 } // namespace Mantid
-
-#endif /* MANTID_WORKFLOWALGORITHMS_DGSDIAGNOSE_H_ */

--- a/Framework/WorkflowAlgorithms/inc/MantidWorkflowAlgorithms/DgsPreprocessData.h
+++ b/Framework/WorkflowAlgorithms/inc/MantidWorkflowAlgorithms/DgsPreprocessData.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_WORKFLOWALGORITHMS_DGSPREPROCESSDATA_H_
-#define MANTID_WORKFLOWALGORITHMS_DGSPREPROCESSDATA_H_
+#pragma once
 
 #include "MantidAPI/Algorithm.h"
 #include "MantidKernel/System.h"
@@ -37,5 +36,3 @@ private:
 
 } // namespace WorkflowAlgorithms
 } // namespace Mantid
-
-#endif /* MANTID_WORKFLOWALGORITHMS_DGSPREPROCESSDATA_H_ */

--- a/Framework/WorkflowAlgorithms/inc/MantidWorkflowAlgorithms/DgsProcessDetectorVanadium.h
+++ b/Framework/WorkflowAlgorithms/inc/MantidWorkflowAlgorithms/DgsProcessDetectorVanadium.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_WORKFLOWALGORITHMS_DGSPROCESSDETECTORVANADIUM_H_
-#define MANTID_WORKFLOWALGORITHMS_DGSPROCESSDETECTORVANADIUM_H_
+#pragma once
 
 #include "MantidAPI/Algorithm.h"
 #include "MantidKernel/System.h"
@@ -39,5 +38,3 @@ private:
 
 } // namespace WorkflowAlgorithms
 } // namespace Mantid
-
-#endif /* MANTID_WORKFLOWALGORITHMS_DGSPROCESSDETECTORVANADIUM_H_ */

--- a/Framework/WorkflowAlgorithms/inc/MantidWorkflowAlgorithms/DgsReduction.h
+++ b/Framework/WorkflowAlgorithms/inc/MantidWorkflowAlgorithms/DgsReduction.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_WORKFLOWALGORITHMS_DGSREDUCTION_H_
-#define MANTID_WORKFLOWALGORITHMS_DGSREDUCTION_H_
+#pragma once
 
 #include "MantidAPI/DataProcessorAlgorithm.h"
 #include "MantidKernel/PropertyManager.h"
@@ -45,5 +44,3 @@ private:
 
 } // namespace WorkflowAlgorithms
 } // namespace Mantid
-
-#endif /* MANTID_WORKFLOWALGORITHMS_DGSREDUCTION_H_ */

--- a/Framework/WorkflowAlgorithms/inc/MantidWorkflowAlgorithms/DgsRemap.h
+++ b/Framework/WorkflowAlgorithms/inc/MantidWorkflowAlgorithms/DgsRemap.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_WORKFLOWALGORITHMS_DGSREMAP_H_
-#define MANTID_WORKFLOWALGORITHMS_DGSREMAP_H_
+#pragma once
 
 #include "MantidAPI/Algorithm.h"
 #include "MantidKernel/System.h"
@@ -38,5 +37,3 @@ private:
 
 } // namespace WorkflowAlgorithms
 } // namespace Mantid
-
-#endif /* MANTID_WORKFLOWALGORITHMS_DGSREMAP_H_ */

--- a/Framework/WorkflowAlgorithms/inc/MantidWorkflowAlgorithms/EQSANSDarkCurrentSubtraction.h
+++ b/Framework/WorkflowAlgorithms/inc/MantidWorkflowAlgorithms/EQSANSDarkCurrentSubtraction.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_ALGORITHMS_EQSANSDARKCURRENTSUBTRACTION_H_
-#define MANTID_ALGORITHMS_EQSANSDARKCURRENTSUBTRACTION_H_
+#pragma once
 
 //----------------------------------------------------------------------
 // Includes
@@ -63,5 +62,3 @@ private:
 
 } // namespace WorkflowAlgorithms
 } // namespace Mantid
-
-#endif /*MANTID_ALGORITHMS_EQSANSDARKCURRENTSUBTRACTION_H_*/

--- a/Framework/WorkflowAlgorithms/inc/MantidWorkflowAlgorithms/EQSANSDarkCurrentSubtraction2.h
+++ b/Framework/WorkflowAlgorithms/inc/MantidWorkflowAlgorithms/EQSANSDarkCurrentSubtraction2.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_ALGORITHMS_EQSANSDarkCurrentSubtraction2_H_
-#define MANTID_ALGORITHMS_EQSANSDarkCurrentSubtraction2_H_
+#pragma once
 
 //----------------------------------------------------------------------
 // Includes
@@ -63,5 +62,3 @@ private:
 
 } // namespace WorkflowAlgorithms
 } // namespace Mantid
-
-#endif /*MANTID_ALGORITHMS_EQSANSDarkCurrentSubtraction2_H_*/

--- a/Framework/WorkflowAlgorithms/inc/MantidWorkflowAlgorithms/EQSANSInstrument.h
+++ b/Framework/WorkflowAlgorithms/inc/MantidWorkflowAlgorithms/EQSANSInstrument.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_ALGORITHMS_EQSANSINSTRUMENT_H_
-#define MANTID_ALGORITHMS_EQSANSINSTRUMENT_H_
+#pragma once
 
 //----------------------------------------------------------------------
 // Includes
@@ -40,5 +39,3 @@ void getDefaultBeamCenter(API::MatrixWorkspace_sptr dataWS, double &pixel_x,
 } // namespace EQSANSInstrument
 } // namespace WorkflowAlgorithms
 } // namespace Mantid
-
-#endif /*MANTID_ALGORITHMS_EQSANSINSTRUMENT_H_*/

--- a/Framework/WorkflowAlgorithms/inc/MantidWorkflowAlgorithms/EQSANSLoad.h
+++ b/Framework/WorkflowAlgorithms/inc/MantidWorkflowAlgorithms/EQSANSLoad.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_ALGORITHMS_EQSANSLOAD_H_
-#define MANTID_ALGORITHMS_EQSANSLOAD_H_
+#pragma once
 
 //----------------------------------------------------------------------
 // Includes
@@ -77,5 +76,3 @@ private:
 
 } // namespace WorkflowAlgorithms
 } // namespace Mantid
-
-#endif /*MANTID_ALGORITHMS_EQSANSLOAD_H_*/

--- a/Framework/WorkflowAlgorithms/inc/MantidWorkflowAlgorithms/EQSANSMonitorTOF.h
+++ b/Framework/WorkflowAlgorithms/inc/MantidWorkflowAlgorithms/EQSANSMonitorTOF.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_ALGORITHMS_EQSANSMONITORTOF_H_
-#define MANTID_ALGORITHMS_EQSANSMONITORTOF_H_
+#pragma once
 
 //----------------------------------------------------------------------
 // Includes
@@ -59,5 +58,3 @@ private:
 
 } // namespace WorkflowAlgorithms
 } // namespace Mantid
-
-#endif /*MANTID_ALGORITHMS_EQSANSMONITORTOF_H_*/

--- a/Framework/WorkflowAlgorithms/inc/MantidWorkflowAlgorithms/EQSANSPatchSensitivity.h
+++ b/Framework/WorkflowAlgorithms/inc/MantidWorkflowAlgorithms/EQSANSPatchSensitivity.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_ALGORITHMS_EQSANSPATCHSENSITIVITY_H_
-#define MANTID_ALGORITHMS_EQSANSPATCHSENSITIVITY_H_
+#pragma once
 
 //----------------------------------------------------------------------
 // Includes
@@ -40,5 +39,3 @@ private:
 
 } // namespace WorkflowAlgorithms
 } // namespace Mantid
-
-#endif /*MANTID_ALGORITHMS_EQSANSPATCHSENSITIVITY_H_*/

--- a/Framework/WorkflowAlgorithms/inc/MantidWorkflowAlgorithms/EQSANSQ2D.h
+++ b/Framework/WorkflowAlgorithms/inc/MantidWorkflowAlgorithms/EQSANSQ2D.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_ALGORITHMS_EQSANSQ2D_H_
-#define MANTID_ALGORITHMS_EQSANSQ2D_H_
+#pragma once
 
 //----------------------------------------------------------------------
 // Includes
@@ -47,5 +46,3 @@ private:
 
 } // namespace WorkflowAlgorithms
 } // namespace Mantid
-
-#endif /*MANTID_ALGORITHMS_EQSANSQ2D_H_*/

--- a/Framework/WorkflowAlgorithms/inc/MantidWorkflowAlgorithms/ExtractQENSMembers.h
+++ b/Framework/WorkflowAlgorithms/inc/MantidWorkflowAlgorithms/ExtractQENSMembers.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_ALGORITHMS_EXRACTMEMBERS_H_
-#define MANTID_ALGORITHMS_EXRACTMEMBERS_H_
+#pragma once
 
 #include "MantidAPI/DataProcessorAlgorithm.h"
 #include "MantidAPI/MatrixWorkspace.h"
@@ -70,5 +69,3 @@ private:
 
 } // namespace Algorithms
 } // namespace Mantid
-
-#endif /* MANTID_ALGORITHMS_EXRACTMEMBERS_H_ */

--- a/Framework/WorkflowAlgorithms/inc/MantidWorkflowAlgorithms/HFIRDarkCurrentSubtraction.h
+++ b/Framework/WorkflowAlgorithms/inc/MantidWorkflowAlgorithms/HFIRDarkCurrentSubtraction.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_ALGORITHMS_HFIRDARKCURRENTSUBTRACTION_H_
-#define MANTID_ALGORITHMS_HFIRDARKCURRENTSUBTRACTION_H_
+#pragma once
 
 //----------------------------------------------------------------------
 // Includes
@@ -68,5 +67,3 @@ private:
 
 } // namespace WorkflowAlgorithms
 } // namespace Mantid
-
-#endif /*MANTID_ALGORITHMS_HFIRDarkCurrentSubtraction_H_*/

--- a/Framework/WorkflowAlgorithms/inc/MantidWorkflowAlgorithms/HFIRInstrument.h
+++ b/Framework/WorkflowAlgorithms/inc/MantidWorkflowAlgorithms/HFIRInstrument.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_ALGORITHMS_HFIRINSTRUMENT_H_
-#define MANTID_ALGORITHMS_HFIRINSTRUMENT_H_
+#pragma once
 
 //----------------------------------------------------------------------
 // Includes
@@ -37,5 +36,3 @@ double getSourceToSampleDistance(API::MatrixWorkspace_sptr dataWS);
 } // namespace HFIRInstrument
 } // namespace WorkflowAlgorithms
 } // namespace Mantid
-
-#endif /*MANTID_ALGORITHMS_HFIRINSTRUMENT_H_*/

--- a/Framework/WorkflowAlgorithms/inc/MantidWorkflowAlgorithms/HFIRLoad.h
+++ b/Framework/WorkflowAlgorithms/inc/MantidWorkflowAlgorithms/HFIRLoad.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_ALGORITHMS_HFIRLOAD_H_
-#define MANTID_ALGORITHMS_HFIRLOAD_H_
+#pragma once
 
 //----------------------------------------------------------------------
 // Includes
@@ -73,5 +72,3 @@ private:
 
 } // namespace WorkflowAlgorithms
 } // namespace Mantid
-
-#endif /*MANTID_ALGORITHMS_HFIRLOAD_H_*/

--- a/Framework/WorkflowAlgorithms/inc/MantidWorkflowAlgorithms/HFIRSANSNormalise.h
+++ b/Framework/WorkflowAlgorithms/inc/MantidWorkflowAlgorithms/HFIRSANSNormalise.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_ALGORITHMS_HFIRSANSNORMALISE_H_
-#define MANTID_ALGORITHMS_HFIRSANSNORMALISE_H_
+#pragma once
 
 //----------------------------------------------------------------------
 // Includes
@@ -37,5 +36,3 @@ private:
 
 } // namespace WorkflowAlgorithms
 } // namespace Mantid
-
-#endif /*MANTID_ALGORITHMS_HFIRSANSNORMALISE_H_*/

--- a/Framework/WorkflowAlgorithms/inc/MantidWorkflowAlgorithms/IMuonAsymmetryCalculator.h
+++ b/Framework/WorkflowAlgorithms/inc/MantidWorkflowAlgorithms/IMuonAsymmetryCalculator.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_WORKFLOWALGORITHMS_IMUONASYMMETRYCALCULATOR_H_
-#define MANTID_WORKFLOWALGORITHMS_IMUONASYMMETRYCALCULATOR_H_
+#pragma once
 
 #include "MantidAPI/AlgorithmManager.h"
 #include "MantidAPI/MatrixWorkspace.h"
@@ -54,5 +53,3 @@ protected:
 
 } // namespace WorkflowAlgorithms
 } // namespace Mantid
-
-#endif /* MANTID_WORKFLOWALGORITHMS_IMUONASYMMETRYCALCULATOR_H_ */

--- a/Framework/WorkflowAlgorithms/inc/MantidWorkflowAlgorithms/LoadEventAndCompress.h
+++ b/Framework/WorkflowAlgorithms/inc/MantidWorkflowAlgorithms/LoadEventAndCompress.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_WORKFLOWALGORITHMS_LOADEVENTANDCOMPRESS_H_
-#define MANTID_WORKFLOWALGORITHMS_LOADEVENTANDCOMPRESS_H_
+#pragma once
 
 #include "MantidAPI/DataProcessorAlgorithm.h"
 #include "MantidAPI/ITableWorkspace_fwd.h"
@@ -46,5 +45,3 @@ private:
 
 } // namespace WorkflowAlgorithms
 } // namespace Mantid
-
-#endif /* MANTID_WORKFLOWALGORITHMS_LOADEVENTANDCOMPRESS_H_ */

--- a/Framework/WorkflowAlgorithms/inc/MantidWorkflowAlgorithms/MuonGroupAsymmetryCalculator.h
+++ b/Framework/WorkflowAlgorithms/inc/MantidWorkflowAlgorithms/MuonGroupAsymmetryCalculator.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_WORKFLOWALGORITHMS_MUONGROUPASYMMETRYCALCULATOR_H_
-#define MANTID_WORKFLOWALGORITHMS_MUONGROUPASYMMETRYCALCULATOR_H_
+#pragma once
 
 #include "MantidWorkflowAlgorithms/MuonGroupCalculator.h"
 
@@ -36,5 +35,3 @@ private:
 double getStoredNorm();
 } // namespace WorkflowAlgorithms
 } // namespace Mantid
-
-#endif /* MANTID_WORKFLOWALGORITHMS_MUONGROUPASYMMETRYCALCULATOR_H_ */

--- a/Framework/WorkflowAlgorithms/inc/MantidWorkflowAlgorithms/MuonGroupCalculator.h
+++ b/Framework/WorkflowAlgorithms/inc/MantidWorkflowAlgorithms/MuonGroupCalculator.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_WORKFLOWALGORITHMS_MUONGROUPCALCULATOR_H_
-#define MANTID_WORKFLOWALGORITHMS_MUONGROUPCALCULATOR_H_
+#pragma once
 
 #include "MantidWorkflowAlgorithms/IMuonAsymmetryCalculator.h"
 
@@ -33,5 +32,3 @@ protected:
 
 } // namespace WorkflowAlgorithms
 } // namespace Mantid
-
-#endif /* MANTID_WORKFLOWALGORITHMS_MUONGROUPCALCULATOR_H_ */

--- a/Framework/WorkflowAlgorithms/inc/MantidWorkflowAlgorithms/MuonGroupCountsCalculator.h
+++ b/Framework/WorkflowAlgorithms/inc/MantidWorkflowAlgorithms/MuonGroupCountsCalculator.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_WORKFLOWALGORITHMS_MUONGROUPCOUNTSCALCULATOR_H_
-#define MANTID_WORKFLOWALGORITHMS_MUONGROUPCOUNTSCALCULATOR_H_
+#pragma once
 
 #include "MantidWorkflowAlgorithms/MuonGroupCalculator.h"
 
@@ -27,5 +26,3 @@ public:
 
 } // namespace WorkflowAlgorithms
 } // namespace Mantid
-
-#endif /* MANTID_WORKFLOWALGORITHMS_MUONGROUPCOUNTSCALCULATOR_H_ */

--- a/Framework/WorkflowAlgorithms/inc/MantidWorkflowAlgorithms/MuonPairAsymmetryCalculator.h
+++ b/Framework/WorkflowAlgorithms/inc/MantidWorkflowAlgorithms/MuonPairAsymmetryCalculator.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_WORKFLOWALGORITHMS_MUONPAIRASYMMETRYCALCULATOR_H_
-#define MANTID_WORKFLOWALGORITHMS_MUONPAIRASYMMETRYCALCULATOR_H_
+#pragma once
 
 #include "MantidWorkflowAlgorithms/IMuonAsymmetryCalculator.h"
 
@@ -44,5 +43,3 @@ private:
 
 } // namespace WorkflowAlgorithms
 } // namespace Mantid
-
-#endif /* MANTID_WORKFLOWALGORITHMS_MUONPAIRASYMMETRYCALCULATOR_H_ */

--- a/Framework/WorkflowAlgorithms/inc/MantidWorkflowAlgorithms/MuonProcess.h
+++ b/Framework/WorkflowAlgorithms/inc/MantidWorkflowAlgorithms/MuonProcess.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_WORKFLOWALGORITHMS_MUONPROCESS_H_
-#define MANTID_WORKFLOWALGORITHMS_MUONPROCESS_H_
+#pragma once
 
 #include "MantidAPI/DataProcessorAlgorithm.h"
 #include "MantidAPI/WorkspaceGroup_fwd.h"
@@ -62,5 +61,3 @@ private:
 
 } // namespace WorkflowAlgorithms
 } // namespace Mantid
-
-#endif /* MANTID_WORKFLOWALGORITHMS_MUONPROCESS_H_ */

--- a/Framework/WorkflowAlgorithms/inc/MantidWorkflowAlgorithms/PrecompiledHeader.h
+++ b/Framework/WorkflowAlgorithms/inc/MantidWorkflowAlgorithms/PrecompiledHeader.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_WORKFLOWALGORITHMS_PRECOMPILEDHEADER_H_
-#define MANTID_WORKFLOWALGORITHMS_PRECOMPILEDHEADER_H_
+#pragma once
 
 // Mantid
 #include "MantidAPI/Algorithm.h"
@@ -13,5 +12,3 @@
 
 // Boost
 #include <boost/shared_ptr.hpp>
-
-#endif

--- a/Framework/WorkflowAlgorithms/inc/MantidWorkflowAlgorithms/ProcessIndirectFitParameters.h
+++ b/Framework/WorkflowAlgorithms/inc/MantidWorkflowAlgorithms/ProcessIndirectFitParameters.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_ALGORITHMS_PROCESSINDIRECTFITPARAMETERS_H_
-#define MANTID_ALGORITHMS_PROCESSINDIRECTFITPARAMETERS_H_
+#pragma once
 
 #include "MantidAPI/Algorithm.h"
 #include "MantidAPI/MatrixWorkspace.h"
@@ -36,5 +35,3 @@ private:
 };
 } // namespace Algorithms
 } // namespace Mantid
-
-#endif /* MANTID_ALGORITHMS_PROCESSINDIRECTFITPARAMETERS_H_ */

--- a/Framework/WorkflowAlgorithms/inc/MantidWorkflowAlgorithms/RefRoi.h
+++ b/Framework/WorkflowAlgorithms/inc/MantidWorkflowAlgorithms/RefRoi.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_ALGORITHMS_RefRoi_H_
-#define MANTID_ALGORITHMS_RefRoi_H_
+#pragma once
 
 //----------------------------------------------------------------------
 // Includes
@@ -59,5 +58,3 @@ private:
 
 } // namespace WorkflowAlgorithms
 } // namespace Mantid
-
-#endif /*MANTID_ALGORITHMS_RefRoi_H_*/

--- a/Framework/WorkflowAlgorithms/inc/MantidWorkflowAlgorithms/SANSBeamFinder.h
+++ b/Framework/WorkflowAlgorithms/inc/MantidWorkflowAlgorithms/SANSBeamFinder.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_ALGORITHMS_SANSBEAMFINDER_H_
-#define MANTID_ALGORITHMS_SANSBEAMFINDER_H_
+#pragma once
 
 //----------------------------------------------------------------------
 // Includes
@@ -51,5 +50,3 @@ private:
 
 } // namespace WorkflowAlgorithms
 } // namespace Mantid
-
-#endif /*MANTID_ALGORITHMS_SANSBEAMFINDER_H_*/

--- a/Framework/WorkflowAlgorithms/inc/MantidWorkflowAlgorithms/SANSBeamFluxCorrection.h
+++ b/Framework/WorkflowAlgorithms/inc/MantidWorkflowAlgorithms/SANSBeamFluxCorrection.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_ALGORITHMS_SANSBEAMFLUXCORRECTION_H_
-#define MANTID_ALGORITHMS_SANSBEAMFLUXCORRECTION_H_
+#pragma once
 
 //----------------------------------------------------------------------
 // Includes
@@ -52,5 +51,3 @@ private:
 
 } // namespace WorkflowAlgorithms
 } // namespace Mantid
-
-#endif /*MANTID_ALGORITHMS_SANSBEAMFLUXCORRECTION_H_*/

--- a/Framework/WorkflowAlgorithms/inc/MantidWorkflowAlgorithms/SANSSensitivityCorrection.h
+++ b/Framework/WorkflowAlgorithms/inc/MantidWorkflowAlgorithms/SANSSensitivityCorrection.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_ALGORITHMS_SANSSENSITIVITYCORRECTION_H_
-#define MANTID_ALGORITHMS_SANSSENSITIVITYCORRECTION_H_
+#pragma once
 
 //----------------------------------------------------------------------
 // Includes
@@ -48,5 +47,3 @@ private:
 
 } // namespace WorkflowAlgorithms
 } // namespace Mantid
-
-#endif /*MANTID_ALGORITHMS_SANSSENSITIVITYCORRECTION_H_*/

--- a/Framework/WorkflowAlgorithms/inc/MantidWorkflowAlgorithms/SANSSolidAngleCorrection.h
+++ b/Framework/WorkflowAlgorithms/inc/MantidWorkflowAlgorithms/SANSSolidAngleCorrection.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_ALGORITHMS_SANSSOLIDANGLECORRECTION_H_
-#define MANTID_ALGORITHMS_SANSSOLIDANGLECORRECTION_H_
+#pragma once
 
 //----------------------------------------------------------------------
 // Includes
@@ -71,5 +70,3 @@ private:
 
 } // namespace WorkflowAlgorithms
 } // namespace Mantid
-
-#endif /*MANTID_ALGORITHMS_SANSSOLIDANGLECORRECTION_H_*/

--- a/Framework/WorkflowAlgorithms/inc/MantidWorkflowAlgorithms/SetupEQSANSReduction.h
+++ b/Framework/WorkflowAlgorithms/inc/MantidWorkflowAlgorithms/SetupEQSANSReduction.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_ALGORITHMS_SETUPEQSANSREDUCTION_H_
-#define MANTID_ALGORITHMS_SETUPEQSANSREDUCTION_H_
+#pragma once
 
 //----------------------------------------------------------------------
 // Includes
@@ -50,5 +49,3 @@ private:
 
 } // namespace WorkflowAlgorithms
 } // namespace Mantid
-
-#endif /*MANTID_ALGORITHMS_SETUPEQSANSREDUCTION_H_*/

--- a/Framework/WorkflowAlgorithms/inc/MantidWorkflowAlgorithms/SetupHFIRReduction.h
+++ b/Framework/WorkflowAlgorithms/inc/MantidWorkflowAlgorithms/SetupHFIRReduction.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_ALGORITHMS_SETUPHFIRREDUCTION_H_
-#define MANTID_ALGORITHMS_SETUPHFIRREDUCTION_H_
+#pragma once
 
 //----------------------------------------------------------------------
 // Includes
@@ -50,5 +49,3 @@ private:
 
 } // namespace WorkflowAlgorithms
 } // namespace Mantid
-
-#endif /*MANTID_ALGORITHMS_SETUPHFIRREDUCTION_H_*/

--- a/Framework/WorkflowAlgorithms/inc/MantidWorkflowAlgorithms/SofTwoThetaTOF.h
+++ b/Framework/WorkflowAlgorithms/inc/MantidWorkflowAlgorithms/SofTwoThetaTOF.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_WORKFLOWALGORITHMS_SOFTWOTHETATOF_H_
-#define MANTID_WORKFLOWALGORITHMS_SOFTWOTHETATOF_H_
+#pragma once
 
 #include "MantidAPI/DataProcessorAlgorithm.h"
 
@@ -38,5 +37,3 @@ private:
 
 } // namespace WorkflowAlgorithms
 } // namespace Mantid
-
-#endif /* MANTID_WORKFLOWALGORITHMS_SOFTWOTHETATOF_H_ */

--- a/Framework/WorkflowAlgorithms/inc/MantidWorkflowAlgorithms/StepScan.h
+++ b/Framework/WorkflowAlgorithms/inc/MantidWorkflowAlgorithms/StepScan.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_WORKFLOWALGORITHMS_ROCKINGCURVE_H_
-#define MANTID_WORKFLOWALGORITHMS_ROCKINGCURVE_H_
+#pragma once
 
 #include "MantidAPI/Algorithm.h"
 #include "MantidDataObjects/EventWorkspace.h"
@@ -47,5 +46,3 @@ private:
 
 } // namespace WorkflowAlgorithms
 } // namespace Mantid
-
-#endif /* MANTID_WORKFLOWALGORITHMS_ROCKINGCURVE_H_ */

--- a/Framework/WorkflowAlgorithms/inc/MantidWorkflowAlgorithms/WorkflowAlgorithmHelpers.h
+++ b/Framework/WorkflowAlgorithms/inc/MantidWorkflowAlgorithms/WorkflowAlgorithmHelpers.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef WORKFLOWALGORITHMHELPERS_H_
-#define WORKFLOWALGORITHMHELPERS_H_
+#pragma once
 
 #include "MantidAPI/MatrixWorkspace_fwd.h"
 #include "MantidKernel/EmptyValues.h"
@@ -34,5 +33,3 @@ bool getBoolPropOrParam(const std::string &pmProp,
                         Mantid::API::MatrixWorkspace_sptr &ws,
                         const bool overrideValue = false);
 } // namespace WorkflowAlgorithmHelpers
-
-#endif /* WORKFLOWALGORITHMHELPERS_H_ */

--- a/Framework/WorkflowAlgorithms/test/AlignAndFocusPowderTest.h
+++ b/Framework/WorkflowAlgorithms/test/AlignAndFocusPowderTest.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef ALIGNANDFOCUSPOWDERTEST_H_
-#define ALIGNANDFOCUSPOWDERTEST_H_
+#pragma once
 
 #include "MantidTestHelpers/WorkspaceCreationHelper.h"
 #include <cxxtest/TestSuite.h>
@@ -816,5 +815,3 @@ private:
   bool m_useGroupAll{true};
   bool m_useResamplex{true};
 };
-
-#endif /*ALIGNANDFOCUSPOWDERTEST_H_*/

--- a/Framework/WorkflowAlgorithms/test/ExtractQENSMembersTest.h
+++ b/Framework/WorkflowAlgorithms/test/ExtractQENSMembersTest.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_ALGORITHMS_EXTRACTQENSMEMBERSTEST_H_
-#define MANTID_ALGORITHMS_EXTRACTQENSMEMBERSTEST_H_
+#pragma once
 
 #include <cxxtest/TestSuite.h>
 
@@ -282,5 +281,3 @@ private:
     return data;
   }
 };
-
-#endif /* MANTID_ALGORITHMS_EXTRACTQENSMEMBERSTEST_H_ */

--- a/Framework/WorkflowAlgorithms/test/HFIRLoadTest.h
+++ b/Framework/WorkflowAlgorithms/test/HFIRLoadTest.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef HFIRLOADTEST_H_
-#define HFIRLOADTEST_H_
+#pragma once
 
 #include "MantidWorkflowAlgorithms/HFIRLoad.h"
 #include <cxxtest/TestSuite.h>
@@ -190,5 +189,3 @@ public:
 private:
   std::string filename = "BioSANS_exp61_scan0004_0001.xml";
 };
-
-#endif /*HFIRLOADTEST_H_*/

--- a/Framework/WorkflowAlgorithms/test/IMuonAsymmetryCalculatorTest.h
+++ b/Framework/WorkflowAlgorithms/test/IMuonAsymmetryCalculatorTest.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_WORKFLOWALGORITHMS_IMUONASYMMETRYCALCULATORTEST_H_
-#define MANTID_WORKFLOWALGORITHMS_IMUONASYMMETRYCALCULATORTEST_H_
+#pragma once
 
 #include <cxxtest/TestSuite.h>
 
@@ -641,5 +640,3 @@ private:
     return ws;
   }
 };
-
-#endif /* MANTID_WORKFLOWALGORITHMS_IMUONASYMMETRYCALCULATORTEST_H_ */

--- a/Framework/WorkflowAlgorithms/test/LoadEventAndCompressTest.h
+++ b/Framework/WorkflowAlgorithms/test/LoadEventAndCompressTest.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_WORKFLOWALGORITHMS_LOADEVENTANDCOMPRESSTEST_H_
-#define MANTID_WORKFLOWALGORITHMS_LOADEVENTANDCOMPRESSTEST_H_
+#pragma once
 
 #include <cxxtest/TestSuite.h>
 
@@ -133,5 +132,3 @@ public:
     AnalysisDataService::Instance().remove(WS_NAME);
   }
 };
-
-#endif /* MANTID_WORKFLOWALGORITHMS_LOADEVENTANDCOMPRESSTEST_H_ */

--- a/Framework/WorkflowAlgorithms/test/MuonProcessTest.h
+++ b/Framework/WorkflowAlgorithms/test/MuonProcessTest.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_WORKFLOWALGORITHMS_MUONPROCESSTEST_H_
-#define MANTID_WORKFLOWALGORITHMS_MUONPROCESSTEST_H_
+#pragma once
 
 #include <cxxtest/TestSuite.h>
 
@@ -635,5 +634,3 @@ private:
     return loadData("MUSR00015189.nxs");
   }
 };
-
-#endif /* MANTID_WORKFLOWALGORITHMS_MUONPROCESSTEST_H_ */

--- a/Framework/WorkflowAlgorithms/test/PrecompiledHeader.h
+++ b/Framework/WorkflowAlgorithms/test/PrecompiledHeader.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_WORKFLOWALGORITHMSTEST_PRECOMPILEDHEADER_H_
-#define MANTID_WORKFLOWALGORITHMSTEST_PRECOMPILEDHEADER_H_
+#pragma once
 
 // cxxtest
 #include <cxxtest/WrappedTestSuite.h>
@@ -14,5 +13,3 @@
 #include <set>
 #include <string>
 #include <vector>
-
-#endif // MANTID_WORKFLOWALGORITHMS

--- a/Framework/WorkflowAlgorithms/test/ProcessIndirectFitParametersTest.h
+++ b/Framework/WorkflowAlgorithms/test/ProcessIndirectFitParametersTest.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_ALGORITHMS_PROCESSINDIRECTFITPARAMETERSTEST_H_
-#define MANTID_ALGORITHMS_PROCESSINDIRECTFITPARAMETERSTEST_H_
+#pragma once
 
 #include <cxxtest/TestSuite.h>
 
@@ -251,5 +250,3 @@ public:
     AnalysisDataService::Instance().remove(outputName);
   }
 };
-
-#endif /* MANTID_ALGORITHMS_PROCESSINDIRECTFITPARAMETERSTEST_H_ */

--- a/Framework/WorkflowAlgorithms/test/SANSSolidAngleCorrectionTest.h
+++ b/Framework/WorkflowAlgorithms/test/SANSSolidAngleCorrectionTest.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef SANSSOLIDANGLECORRECTIONTEST_H_
-#define SANSSOLIDANGLECORRECTIONTEST_H_
+#pragma once
 
 #include "MantidAPI/AnalysisDataService.h"
 #include "MantidAPI/Axis.h"
@@ -113,5 +112,3 @@ private:
   Mantid::WorkflowAlgorithms::SANSSolidAngleCorrection correction;
   std::string inputWS;
 };
-
-#endif /*SANSSOLIDANGLECORRECTIONTEST_H_*/

--- a/Framework/WorkflowAlgorithms/test/SofTwoThetaTOFTest.h
+++ b/Framework/WorkflowAlgorithms/test/SofTwoThetaTOFTest.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_WORKFLOWALGORITHMS_SOFTWOTHETATOFTEST_H_
-#define MANTID_WORKFLOWALGORITHMS_SOFTWOTHETATOFTEST_H_
+#pragma once
 
 #include <cxxtest/TestSuite.h>
 
@@ -161,5 +160,3 @@ public:
     }
   }
 };
-
-#endif /* MANTID_WORKFLOWALGORITHMS_SOFTWOTHETATOFTEST_H_ */

--- a/Framework/WorkflowAlgorithms/test/StepScanTest.h
+++ b/Framework/WorkflowAlgorithms/test/StepScanTest.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_WORKFLOWALGORITHMS_ROCKINGCURVETEST_H_
-#define MANTID_WORKFLOWALGORITHMS_ROCKINGCURVETEST_H_
+#pragma once
 
 #include <cxxtest/TestSuite.h>
 
@@ -148,5 +147,3 @@ private:
   IAlgorithm_sptr stepScan;
   const std::string outWSName;
 };
-
-#endif /* MANTID_WORKFLOWALGORITHMS_ROCKINGCURVETEST_H_ */

--- a/buildconfig/class_maker.py
+++ b/buildconfig/class_maker.py
@@ -59,8 +59,7 @@ private:
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef {guard}
-#define {guard}
+#pragma once
 
 #include "Mantid{subproject}/DllConfig.h"
 {alg_include}
@@ -75,11 +74,8 @@ public:{algorithm_header}}};
 
 }} // namespace {subproject}
 }} // namespace Mantid
-
-#endif /* {guard} */""".format(guard=guard, subproject=subproject,
-       alg_include=alg_include, classname=classname,
-       year=get_year(), subproject_upper=subproject_upper,
-       alg_class_declare=alg_class_declare, algorithm_header=algorithm_header)
+""".format(guard=guard, subproject=subproject, alg_include=alg_include, classname=classname, year=get_year(),
+           subproject_upper=subproject_upper, alg_class_declare=alg_class_declare, algorithm_header=algorithm_header)
 
     f.write(s)
     f.close()
@@ -158,8 +154,8 @@ namespace {subproject} {{
 }} // namespace {subproject}
 }} // namespace Mantid
 """.format(
-        year=get_year(), subproject=subproject, subfolder=args.subfolder, classname=classname, algorithm_top=algorithm_top,
-        algorithm_source=algorithm_source)
+        year=get_year(), subproject=subproject, subfolder=args.subfolder, classname=classname,
+        algorithm_top=algorithm_top, algorithm_source=algorithm_source)
     f.write(s)
     f.close()
 
@@ -213,8 +209,7 @@ def write_test(subproject, classname, filename, args):
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef {guard}
-#define {guard}
+#pragma once
 
 #include <cxxtest/TestSuite.h>
 
@@ -237,11 +232,8 @@ public:
 
 
 }};
-
-
-#endif /* {guard} */""".format(year=get_year(),
-          guard=guard, subproject=subproject, subfolder=args.subfolder, classname=classname,
-          algorithm_test=algorithm_test)
+""".format(year=get_year(), guard=guard, subproject=subproject, subfolder=args.subfolder, classname=classname,
+           algorithm_test=algorithm_test)
     f.write(s)
     f.close()
 

--- a/dev-docs/source/Standards/CPPStandards.rst
+++ b/dev-docs/source/Standards/CPPStandards.rst
@@ -57,6 +57,7 @@ Layout of Header File
 The contents of the header file should be arranged in the following
 order:
 
+- ``#pragma once`` header guard to prevent duplicate imports.
 - ``#include`` directives in the following order, where each section shold be
   sorted alphabetically:
 

--- a/dev-docs/source/WritingAnAlgorithm.rst
+++ b/dev-docs/source/WritingAnAlgorithm.rst
@@ -39,8 +39,7 @@ boilerplate C++ code (changing each occurrence of 'MyAlg' to your chosen algorit
 
 .. code-block:: cpp
 
-    #ifndef MYALG_H_
-    #define MYALG_H_
+    #pragma once
     
     #include "MantidAPI/Algorithm.h"
     
@@ -64,8 +63,6 @@ boilerplate C++ code (changing each occurrence of 'MyAlg' to your chosen algorit
       /// Execution code
       void exec();
     };
- 
-    #endif /*MYALG_H_*/
 
 **Source file (MyAlg.cpp)**:
 


### PR DESCRIPTION
This PR removes all uses of #ifndef in headers in WorkflowAlgorithms and `class_maker` and replaces them with pragma once.
This PR also includes a line in the `CPPStandards` dev-doc instruciting for `#pragma once` to be used.

**To test:**

Any issues in this PR should be caught by jenkins.

This pr is a part of #28200

*This does not require release notes* because It is an internal change to the codebase.

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
