### PR TITLE
28303 ill tof channel

### DIFF
--- a/Framework/DataHandling/inc/MantidDataHandling/LoadILLTOF2.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/LoadILLTOF2.h
@@ -70,6 +70,7 @@ private:
   static double calculateError(double in) { return sqrt(in); }
 
   API::MatrixWorkspace_sptr m_localWorkspace;
+  bool m_convertToTOF;
 
   std::string m_instrumentName = ""; ///< Name of the instrument
   std::string m_instrumentPath = ""; ///< Name of the instrument path

--- a/Framework/DataHandling/inc/MantidDataHandling/LoadILLTOF2.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/LoadILLTOF2.h
@@ -59,7 +59,8 @@ private:
 
   void loadTimeDetails(NeXus::NXEntry &entry);
   void loadDataIntoTheWorkSpace(NeXus::NXEntry &entry,
-                                const std::vector<std::vector<int>> &);
+                                const std::vector<std::vector<int>> &,
+                                bool convertToTOF);
   void loadSpectra(size_t &spec, const size_t numberOfTubes,
                    const std::vector<Mantid::detid_t> &detectorIDs,
                    const NeXus::NXInt &data, Mantid::API::Progress &progress);
@@ -70,7 +71,6 @@ private:
   static double calculateError(double in) { return sqrt(in); }
 
   API::MatrixWorkspace_sptr m_localWorkspace;
-  bool m_convertToTOF;
 
   std::string m_instrumentName = ""; ///< Name of the instrument
   std::string m_instrumentPath = ""; ///< Name of the instrument path

--- a/Framework/DataHandling/src/LoadILLTOF2.cpp
+++ b/Framework/DataHandling/src/LoadILLTOF2.cpp
@@ -81,7 +81,7 @@ void LoadILLTOF2::init() {
 void LoadILLTOF2::exec() {
   // Retrieve filename
   const std::string filenameData = getPropertyValue("Filename");
-  m_convertToTOF = getProperty("convertToTOF");
+  bool convertToTOF = getProperty("convertToTOF");
 
   // open the root node
   NeXus::NXRoot dataRoot(filenameData);
@@ -99,7 +99,7 @@ void LoadILLTOF2::exec() {
 
   runLoadInstrument(); // just to get IDF contents
 
-  loadDataIntoTheWorkSpace(dataFirstEntry, monitors);
+  loadDataIntoTheWorkSpace(dataFirstEntry, monitors, convertToTOF);
 
   addEnergyToRun();
   addPulseInterval();
@@ -355,9 +355,12 @@ void LoadILLTOF2::addPulseInterval() {
  *
  * @param entry The Nexus entry
  * @param monitors List of monitor data
+ * @param convertToTOF Should the bin edges be converted to time of flight or
+ * keep the channel indexes
  */
 void LoadILLTOF2::loadDataIntoTheWorkSpace(
-    NeXus::NXEntry &entry, const std::vector<std::vector<int>> &monitors) {
+    NeXus::NXEntry &entry, const std::vector<std::vector<int>> &monitors,
+    bool convertToTOF) {
 
   g_log.debug() << "Loading data into the workspace...\n";
   // read in the data
@@ -371,7 +374,7 @@ void LoadILLTOF2::loadDataIntoTheWorkSpace(
   // Put tof in an array
   auto &X0 = m_localWorkspace->mutableX(0);
   if (monitor.containsDataSet("time_of_flight")) {
-    if (m_convertToTOF) {
+    if (convertToTOF) {
       for (size_t i = 0; i < m_numberOfChannels + 1; ++i) {
         X0[i] = m_timeOfFlightDelay + m_channelWidth * static_cast<double>(i) -
                 m_channelWidth / 2; // to make sure the bin centre is correct

--- a/Framework/DataHandling/src/LoadILLTOF2.cpp
+++ b/Framework/DataHandling/src/LoadILLTOF2.cpp
@@ -72,7 +72,8 @@ void LoadILLTOF2::init() {
   declareProperty(std::make_unique<WorkspaceProperty<>>("OutputWorkspace", "",
                                                         Direction::Output),
                   "The name to use for the output workspace");
-  declareProperty("ConvertToTOF", false, Direction::Input);
+  declareProperty("ConvertToTOF", false,
+                  "Convert the bin edges to time-of-flight", Direction::Input);
 }
 
 /**

--- a/Framework/DataHandling/src/LoadILLTOF2.cpp
+++ b/Framework/DataHandling/src/LoadILLTOF2.cpp
@@ -72,6 +72,7 @@ void LoadILLTOF2::init() {
   declareProperty(std::make_unique<WorkspaceProperty<>>("OutputWorkspace", "",
                                                         Direction::Output),
                   "The name to use for the output workspace");
+  declareProperty("convertToTOF", false, Direction::Input);
 }
 
 /**
@@ -80,6 +81,7 @@ void LoadILLTOF2::init() {
 void LoadILLTOF2::exec() {
   // Retrieve filename
   const std::string filenameData = getPropertyValue("Filename");
+  m_convertToTOF = getProperty("convertToTOF");
 
   // open the root node
   NeXus::NXRoot dataRoot(filenameData);
@@ -369,9 +371,15 @@ void LoadILLTOF2::loadDataIntoTheWorkSpace(
   // Put tof in an array
   auto &X0 = m_localWorkspace->mutableX(0);
   if (monitor.containsDataSet("time_of_flight")) {
-    for (size_t i = 0; i < m_numberOfChannels + 1; ++i) {
-      X0[i] = m_timeOfFlightDelay + m_channelWidth * static_cast<double>(i) -
-              m_channelWidth / 2; // to make sure the bin centre is correct
+    if (m_convertToTOF) {
+      for (size_t i = 0; i < m_numberOfChannels + 1; ++i) {
+        X0[i] = m_timeOfFlightDelay + m_channelWidth * static_cast<double>(i) -
+                m_channelWidth / 2; // to make sure the bin centre is correct
+      }
+    } else {
+      for (size_t i = 0; i < m_numberOfChannels + 1; ++i) {
+        X0[i] = static_cast<double>(i); // just take the channel index
+      }
     }
   } else {
     // Diffraction PANTHER

--- a/Framework/DataHandling/src/LoadILLTOF2.cpp
+++ b/Framework/DataHandling/src/LoadILLTOF2.cpp
@@ -72,7 +72,7 @@ void LoadILLTOF2::init() {
   declareProperty(std::make_unique<WorkspaceProperty<>>("OutputWorkspace", "",
                                                         Direction::Output),
                   "The name to use for the output workspace");
-  declareProperty("convertToTOF", false, Direction::Input);
+  declareProperty("ConvertToTOF", false, Direction::Input);
 }
 
 /**

--- a/Framework/DataHandling/test/LoadILLTOF2Test.h
+++ b/Framework/DataHandling/test/LoadILLTOF2Test.h
@@ -125,9 +125,10 @@ public:
     const size_t channelCount = 512;
     const size_t histogramCount = 397;
     const size_t monitorCount = 1;
+    const bool convertToTOF = true;
     MatrixWorkspace_sptr ws =
         loadDataFile("ILL/IN4/084446.nxs", histogramCount, monitorCount,
-                     channelCount, tofDelay, tofChannelWidth, true);
+                     channelCount, tofDelay, tofChannelWidth, convertToTOF);
 
     const double pulseInterval =
         ws->run().getLogAsSingleValue("pulse_interval");
@@ -141,8 +142,9 @@ public:
     const size_t channelCount = 512;
     const size_t histogramCount = 98305;
     const size_t monitorCount = 1;
+    const bool convertToTOF = true;
     loadDataFile("ILL/IN5/104007.nxs", histogramCount, monitorCount,
-                 channelCount, tofDelay, tofChannelWidth, true);
+                 channelCount, tofDelay, tofChannelWidth, convertToTOF);
   }
 
   void test_IN6_load() {
@@ -152,9 +154,10 @@ public:
     const size_t channelCount = 1024;
     const size_t histogramCount = 340;
     const size_t monitorCount = 3;
+    const bool convertToTOF = true;
     MatrixWorkspace_sptr ws =
         loadDataFile("ILL/IN6/164192.nxs", histogramCount, monitorCount,
-                     channelCount, tofDelay, tofChannelWidth, true);
+                     channelCount, tofDelay, tofChannelWidth, convertToTOF);
 
     const double pulseInterval =
         ws->run().getLogAsSingleValue("pulse_interval");
@@ -227,8 +230,9 @@ public:
     const size_t channelCount = 512;
     const size_t histogramCount = 73729;
     const size_t monitorCount = 1;
+    const bool convertToTOF = false;
     loadDataFile("ILL/PANTHER/001723.nxs", histogramCount, monitorCount,
-                 channelCount, tofDelay, tofChannelWidth, false);
+                 channelCount, tofDelay, tofChannelWidth, convertToTOF);
   }
 
   void test_convertToTOF() {
@@ -238,8 +242,9 @@ public:
     const size_t channelCount = 512;
     const size_t histogramCount = 98305;
     const size_t monitorCount = 1;
+    const bool convertToTOF = false;
     loadDataFile("ILL/IN5/104007.nxs", histogramCount, monitorCount,
-                 channelCount, tofDelay, tofChannelWidth, false);
+                 channelCount, tofDelay, tofChannelWidth, convertToTOF);
   }
 };
 

--- a/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/DirectILLCollectData.py
+++ b/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/DirectILLCollectData.py
@@ -734,7 +734,7 @@ class DirectILLCollectData(DataProcessorAlgorithm):
         if inputFiles:
             mergedWSName = self._names.withSuffix('merged')
             mainWS = LoadAndMerge(Filename=inputFiles, OutputWorkspace=mergedWSName,
-                                  LoaderName='LoadILLTOF', LoaderOptions={"convertToTOF": True}, EnableLogging=self._subalgLogging)
+                                  LoaderName='LoadILLTOF', LoaderOptions={"ConvertToTOF": True}, EnableLogging=self._subalgLogging)
         else:
             mainWS = self.getProperty(common.PROP_INPUT_WS).value
             self._cleanup.protect(mainWS)

--- a/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/DirectILLCollectData.py
+++ b/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/DirectILLCollectData.py
@@ -734,7 +734,7 @@ class DirectILLCollectData(DataProcessorAlgorithm):
         if inputFiles:
             mergedWSName = self._names.withSuffix('merged')
             mainWS = LoadAndMerge(Filename=inputFiles, OutputWorkspace=mergedWSName,
-                                  LoaderName='LoadILLTOF', EnableLogging=self._subalgLogging)
+                                  LoaderName='LoadILLTOF', LoaderOptions={"convertToTOF": True}, EnableLogging=self._subalgLogging)
         else:
             mainWS = self.getProperty(common.PROP_INPUT_WS).value
             self._cleanup.protect(mainWS)

--- a/Testing/SystemTests/tests/analysis/ILLDirectGeometryReductionTest.py
+++ b/Testing/SystemTests/tests/analysis/ILLDirectGeometryReductionTest.py
@@ -210,9 +210,9 @@ class IN6(systemtesting.MantidSystemTest):
 class IN5_Tube_Background(systemtesting.MantidSystemTest):
 
     def runTest(self):
-        Load(Filename='ILL/IN5/Epp.nxs', OutputWorkspace='Epp')
-        Load(Filename='ILL/IN5/Sample.nxs', OutputWorkspace='Sample')
-        Load(Filename='ILL/IN5/Vmask.nxs', OutputWorkspace='Vmask')
+        Load(Filename='ILL/IN5/Epp.nxs', OutputWorkspace='Epp', convertToTOF=True)
+        Load(Filename='ILL/IN5/Sample.nxs', OutputWorkspace='Sample', convertToTOF=True)
+        Load(Filename='ILL/IN5/Vmask.nxs', OutputWorkspace='Vmask', convertToTOF=True)
         args = {'InputWorkspace':'Sample',
                 'DiagnosticsWorkspace':'Vmask',
                 'EPPWorkspace':'Epp',
@@ -249,7 +249,7 @@ class IN5_Mask_Non_Overlapping_Bins(systemtesting.MantidSystemTest):
             OutputEPPWorkspace='Epp'
         )
 
-        ws = Load(run)
+        ws = Load(run, convertToTOF=True)
         self.ecrase(ws)
 
         DirectILLCollectData(

--- a/Testing/SystemTests/tests/analysis/ILLDirectGeometryReductionTest.py
+++ b/Testing/SystemTests/tests/analysis/ILLDirectGeometryReductionTest.py
@@ -210,9 +210,9 @@ class IN6(systemtesting.MantidSystemTest):
 class IN5_Tube_Background(systemtesting.MantidSystemTest):
 
     def runTest(self):
-        Load(Filename='ILL/IN5/Epp.nxs', OutputWorkspace='Epp', convertToTOF=True)
-        Load(Filename='ILL/IN5/Sample.nxs', OutputWorkspace='Sample', convertToTOF=True)
-        Load(Filename='ILL/IN5/Vmask.nxs', OutputWorkspace='Vmask', convertToTOF=True)
+        Load(Filename='ILL/IN5/Epp.nxs', OutputWorkspace='Epp', ConvertToTOF=True)
+        Load(Filename='ILL/IN5/Sample.nxs', OutputWorkspace='Sample', ConvertToTOF=True)
+        Load(Filename='ILL/IN5/Vmask.nxs', OutputWorkspace='Vmask', ConvertToTOF=True)
         args = {'InputWorkspace':'Sample',
                 'DiagnosticsWorkspace':'Vmask',
                 'EPPWorkspace':'Epp',
@@ -249,7 +249,7 @@ class IN5_Mask_Non_Overlapping_Bins(systemtesting.MantidSystemTest):
             OutputEPPWorkspace='Epp'
         )
 
-        ws = Load(run, convertToTOF=True)
+        ws = Load(run, ConvertToTOF=True)
         self.ecrase(ws)
 
         DirectILLCollectData(

--- a/docs/source/algorithms/DirectILLCollectData-v1.rst
+++ b/docs/source/algorithms/DirectILLCollectData-v1.rst
@@ -140,7 +140,7 @@ For usage of this algorithm as part of the direct geometry data reduction, check
     # It is recommended to use DirectILLCollectData over the basic Load
     preprocessed = DirectILLCollectData('ILL/IN4/087294+087295.nxs')
     # Compare to simply loading the data
-    raw = Load('ILL/IN4/087294+087295.nxs', convertToTOF=true)
+    raw = Load('ILL/IN4/087294+087295.nxs', ConvertToTOF=true)
     # The workspace loaded by 'Load' includes monitor data which
     # makes 2D plotting difficult
     nRaw = raw.getNumberHistograms()

--- a/docs/source/algorithms/DirectILLCollectData-v1.rst
+++ b/docs/source/algorithms/DirectILLCollectData-v1.rst
@@ -140,7 +140,7 @@ For usage of this algorithm as part of the direct geometry data reduction, check
     # It is recommended to use DirectILLCollectData over the basic Load
     preprocessed = DirectILLCollectData('ILL/IN4/087294+087295.nxs')
     # Compare to simply loading the data
-    raw = Load('ILL/IN4/087294+087295.nxs', ConvertToTOF=true)
+    raw = Load('ILL/IN4/087294+087295.nxs', ConvertToTOF=True)
     # The workspace loaded by 'Load' includes monitor data which
     # makes 2D plotting difficult
     nRaw = raw.getNumberHistograms()

--- a/docs/source/algorithms/DirectILLCollectData-v1.rst
+++ b/docs/source/algorithms/DirectILLCollectData-v1.rst
@@ -140,7 +140,7 @@ For usage of this algorithm as part of the direct geometry data reduction, check
     # It is recommended to use DirectILLCollectData over the basic Load
     preprocessed = DirectILLCollectData('ILL/IN4/087294+087295.nxs')
     # Compare to simply loading the data
-    raw = Load('ILL/IN4/087294+087295.nxs')
+    raw = Load('ILL/IN4/087294+087295.nxs', convertToTOF=true)
     # The workspace loaded by 'Load' includes monitor data which
     # makes 2D plotting difficult
     nRaw = raw.getNumberHistograms()

--- a/docs/source/algorithms/LoadILLTOF-v2.rst
+++ b/docs/source/algorithms/LoadILLTOF-v2.rst
@@ -14,7 +14,9 @@ the given name.
 
 To date this algorithm only supports: IN4, IN5, IN6 and PANTHER.
 
-This algorithm also supports diffraction mode. In this case, the unit of the output workspace will be wavelength instead of time-of-flight.
+By default, this algorithm loads the data indexed by channels. To convert to time-of-flight, use the ConvertToTOF option.
+
+This algorithm also supports diffraction mode. In this case, the unit of the output workspace will be wavelength instead of time-of-flight or channel.
 
 .. note::
     The initial time-of-flight axis is set up using the 'time_of_flight' field in the NeXus file. Therefore the conversion from 'TOF' to 'DeltaE' may not give the correct zero-energy transfer.

--- a/docs/source/release/v5.1.0/direct_geometry.rst
+++ b/docs/source/release/v5.1.0/direct_geometry.rst
@@ -12,6 +12,7 @@ Direct Geometry Changes
 Improvements
 ############
 
-For ILL time-of-flight instruments, :ref:`LoadILLTOF <algm-LoadILLTOF-v2>` now allows bin edges determined by channel number rather than time-of-flight values.
+For ILL time-of-flight instruments, :ref:`LoadILLTOF <algm-LoadILLTOF-v2>` now allows bin edges determined by channel
+number by default, but you can still convert to time-of-flight using the `ConvertToTOF` property.
 
 :ref:`Release 5.1.0 <v5.1.0>`

--- a/docs/source/release/v5.1.0/direct_geometry.rst
+++ b/docs/source/release/v5.1.0/direct_geometry.rst
@@ -12,6 +12,6 @@ Direct Geometry Changes
 Improvements
 ############
 
-For ILL time-of-flight instruments, :ref:`LoadILLTOF <alg-LoadILLTOF-v2>` now allows bin edges determined by channel number rather than time-of-flight values.
+For ILL time-of-flight instruments, :ref:`LoadILLTOF <algm-LoadILLTOF-v2>` now allows bin edges determined by channel number rather than time-of-flight values.
 
 :ref:`Release 5.1.0 <v5.1.0>`

--- a/docs/source/release/v5.1.0/direct_geometry.rst
+++ b/docs/source/release/v5.1.0/direct_geometry.rst
@@ -9,4 +9,9 @@ Direct Geometry Changes
     putting new features at the top of the section, followed by
     improvements, followed by bug fixes.
 
+Improvements
+############
+
+For ILL time-of-flight instruments, :ref:`LoadILLTOF <alg-LoadILLTOF-v2>` now allows bin edges determined by channel number rather than time-of-flight values.
+
 :ref:`Release 5.1.0 <v5.1.0>`


### PR DESCRIPTION
**Description of work.**
This PR adds an option to LoadILLTOF to load with bin edges determined by channel number rather than by TOF value, and changes uses of this loader accordingly in algorithms.

Important : this changes the default behavior of the loader for ILL TOF files !
<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

**To test:**
Load a file from an ILL TOF instrument (e.g. IN5) and check the correctness of the behavior of the convertToTOF option.
<!-- Instructions for testing. -->

Fixes #28303 . <!-- and fix #xxxx or close #xxxx xor resolves #xxxx -->
<!-- alternative
*There is no associated issue.*
-->

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
-->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
