### PR TITLE
Adjust autoscaling behaviour in Muon Analysis

### DIFF
--- a/scripts/Muon/GUI/Common/plotting_widget/plotting_widget_presenter.py
+++ b/scripts/Muon/GUI/Common/plotting_widget/plotting_widget_presenter.py
@@ -291,10 +291,10 @@ class PlotWidgetPresenter(HomeTabSubWidget):
         """
         Handles a group or pair being removed in grouping widget analysis table
         """
-        if self._view.is_tiled_plot() and self._view.get_tiled_by_type():
+        if self._view.is_tiled_plot() and self._view.get_tiled_by_type() == 'group':
             self.update_model_tile_plot_positions()
             self.new_plot_figure(self._model.number_of_axes)
-            self.plot_all_selected_workspaces(autoscale=False)
+            self.plot_all_selected_workspaces(autoscale=True)
             self.connect_xlim_changed_in_figure_view(self.handle_x_axis_limits_changed_in_figure_view)
             self.connect_ylim_changed_in_figure_view(self.handle_y_axis_limits_changed_in_figure_view)
             return

--- a/scripts/Muon/GUI/Common/plotting_widget/plotting_widget_presenter.py
+++ b/scripts/Muon/GUI/Common/plotting_widget/plotting_widget_presenter.py
@@ -455,7 +455,7 @@ class PlotWidgetPresenter(HomeTabSubWidget):
         self._model.clear_plot_model(self._view.get_axes())
         self._view.new_plot_figure(num_axes)
         xlims = self.get_x_limits()
-        ylims = self.get_y_limts()
+        ylims = self.get_y_limits()
         for ax in self._view.get_axes():
             self._model.set_axis_xlim(ax, xlims)
             self._model.set_axis_ylim(ax, ylims)
@@ -547,7 +547,7 @@ class PlotWidgetPresenter(HomeTabSubWidget):
         else:
             return default_xlimits[self.get_domain()]
 
-    def get_y_limts(self):
+    def get_y_limits(self):
         ylims = self._view.plot_options.get_plot_y_range()
         if ylims[1] - ylims[0] > 0:
             return ylims

--- a/scripts/Muon/GUI/Common/plotting_widget/plotting_widget_presenter.py
+++ b/scripts/Muon/GUI/Common/plotting_widget/plotting_widget_presenter.py
@@ -454,6 +454,11 @@ class PlotWidgetPresenter(HomeTabSubWidget):
     def new_plot_figure(self, num_axes):
         self._model.clear_plot_model(self._view.get_axes())
         self._view.new_plot_figure(num_axes)
+        xlims = self.get_x_limits()
+        ylims = self.get_y_limts()
+        for ax in self._view.get_axes():
+            self._model.set_axis_xlim(ax, xlims)
+            self._model.set_axis_ylim(ax, ylims)
 
     def get_plot_title(self):
         """
@@ -541,6 +546,13 @@ class PlotWidgetPresenter(HomeTabSubWidget):
             return xlims
         else:
             return default_xlimits[self.get_domain()]
+
+    def get_y_limts(self):
+        ylims = self._view.plot_options.get_plot_y_range()
+        if ylims[1] - ylims[0] > 0:
+            return ylims
+        else:
+            return [0, 1]
 
     def get_selected_axes(self):
         subplots = self._view.plot_options.get_selection()

--- a/scripts/test/Muon/plotting_widget_tiled_test.py
+++ b/scripts/test/Muon/plotting_widget_tiled_test.py
@@ -41,6 +41,7 @@ class PlottingWidgetPresenterTestTiled(unittest.TestCase):
                                                   ['62264'], ['62265'], ['62266'], ['62267']]
         self.view.plot_options.get_errors = mock.MagicMock(return_value=True)
         self.presenter.get_x_limits = mock.MagicMock(return_value=[0, 15])
+        self.presenter.get_y_limits = mock.MagicMock(return_value=[0, 1])
         self.presenter.get_x_lim_from_subplot = mock.MagicMock(return_value=[0, 15])
         self.presenter.get_y_lim_from_subplot = mock.MagicMock(return_value=[-1, 1])
 


### PR DESCRIPTION
Previously, when any new data was plotted in the Muon Analysis GUI, the axes would autoscale to fit the new data. This behavior is unwanted sometimes and in most cases is unnecessary as an autoscale button exists within the GUI. This PR adjusts the behavior of the autoscaling, such that it is now only performed when it was is truly necessary, e.g the plot type changes.


**Report to:** [Adrian Hillier]


**To test:**

1. Open the Muon Analysis 2 GUI
2. Load some data (e.g MUSR62260)
3. Increment the run (the y axis shouldn't change)
4. Change the plot type to counts (the y axis should now autoscale to the new data)
5. Change to tiled plotting (the graphs should all autoscale to the same y axis)
6. Check the other functionality works. 

<!-- Instructions for testing. -->

Fixes #xxxx. <!-- and fix #xxxx or close #xxxx xor resolves #xxxx -->
<!-- alternative
*There is no associated issue.*
-->

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
-->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
