### PR TITLE
Replace header guards in qt/icons and qt/paraview_ext with pragma once

### DIFF
--- a/qt/icons/inc/MantidQtIcons/CharIconEngine.h
+++ b/qt/icons/inc/MantidQtIcons/CharIconEngine.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTIDQT_ICONS_CHARICONENGINE_H_
-#define MANTIDQT_ICONS_CHARICONENGINE_H_
+#pragma once
 
 #include "DllOption.h"
 
@@ -55,5 +54,3 @@ private:
 
 } // namespace Icons
 } // namespace MantidQt
-
-#endif /* MANTIDQT_WIDGETS_ICONS_CHARICONENGINE_H_ */

--- a/qt/icons/inc/MantidQtIcons/CharIconPainter.h
+++ b/qt/icons/inc/MantidQtIcons/CharIconPainter.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTIDQT_ICONS_CHARICONPAINTER_H_
-#define MANTIDQT_ICONS_CHARICONPAINTER_H_
+#pragma once
 
 #include "DllOption.h"
 
@@ -40,5 +39,3 @@ private:
 
 } // namespace Icons
 } // namespace MantidQt
-
-#endif /* MANTIDQT_WIDGETS_ICONS_CHARICONPAINTER_H_ */

--- a/qt/icons/inc/MantidQtIcons/DllOption.h
+++ b/qt/icons/inc/MantidQtIcons/DllOption.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTIDQT_ICONS_DLLOPTION_H_
-#define MANTIDQT_ICONS_DLLOPTION_H_
+#pragma once
 
 #include "MantidKernel/System.h"
 
@@ -16,5 +15,3 @@
 #define EXPORT_OPT_MANTIDQT_ICONS DLLImport
 #define EXTERN_MANTIDQT_ICONS extern
 #endif /* IN_MANTIDQT_ICONS */
-
-#endif // MANTIDQT_ICONS_DLLOPTION_H_

--- a/qt/icons/inc/MantidQtIcons/Icon.h
+++ b/qt/icons/inc/MantidQtIcons/Icon.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTIDQT_ICONS_ICONLOADER_H_
-#define MANTIDQT_ICONS_ICONLOADER_H_
+#pragma once
 
 #include "MantidQtIcons/CharIconEngine.h"
 #include "MantidQtIcons/CharIconPainter.h"
@@ -58,5 +57,3 @@ private:
 
 } // namespace Icons
 } // namespace MantidQt
-
-#endif /* MANTIDQT_ICONS_ICONLOADER_H_ */

--- a/qt/icons/test/IconTest.h
+++ b/qt/icons/test/IconTest.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTIDQT_ICONS_ICONTEST_H
-#define MANTIDQT_ICONS_ICONTEST_H
+#pragma once
 
 #include "MantidQtIcons/Icon.h"
 
@@ -60,5 +59,3 @@ public:
                      const std::invalid_argument &);
   }
 };
-
-#endif

--- a/qt/icons/test/IconsTestInitialization.h
+++ b/qt/icons/test/IconsTestInitialization.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef ICONSTESTINITIALIZATION_H
-#define ICONSTESTINITIALIZATION_H
+#pragma once
 
 #include "MantidQtWidgets/Common/Testing/QApplicationGlobalFixture.h"
 
@@ -16,5 +15,3 @@
 // statements do not cause multiple-definition errors.
 //------------------------------------------------------------------------------
 static QApplicationGlobalFixture MAIN_QAPPLICATION;
-
-#endif // ICONSTESTINITIALIZATION_H

--- a/qt/paraview_ext/PVPlugins/Filters/PeaksFilter/vtkPeaksFilter.h
+++ b/qt/paraview_ext/PVPlugins/Filters/PeaksFilter/vtkPeaksFilter.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef _VTKPEAKSFILTER_h
-#define _VTKPEAKSFILTER_h
+#pragma once
 #include "MantidAPI/IPeaksWorkspace_fwd.h"
 #include "MantidGeometry/Crystal/PeakShape.h"
 #include "MantidKernel/StringTokenizer.h"
@@ -48,4 +47,3 @@ private:
   boost::scoped_ptr<Mantid::VATES::MetadataJsonManager> m_metadataJsonManager;
   boost::scoped_ptr<Mantid::VATES::VatesConfigurations> m_vatesConfigurations;
 };
-#endif

--- a/qt/paraview_ext/PVPlugins/Filters/ScaleWorkspace/vtkScaleWorkspace.h
+++ b/qt/paraview_ext/PVPlugins/Filters/ScaleWorkspace/vtkScaleWorkspace.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef _vtkScaleWorkspace_h
-#define _vtkScaleWorkspace_h
+#pragma once
 #include "MantidVatesAPI/MetadataJsonManager.h"
 #include "MantidVatesAPI/VatesConfigurations.h"
 #include "vtkPointSetAlgorithm.h"
@@ -47,4 +46,3 @@ private:
   boost::scoped_ptr<Mantid::VATES::MetadataJsonManager> m_metadataJsonManager;
   boost::scoped_ptr<Mantid::VATES::VatesConfigurations> m_vatesConfigurations;
 };
-#endif

--- a/qt/paraview_ext/PVPlugins/Filters/SplatterPlot/vtkSplatterPlot.h
+++ b/qt/paraview_ext/PVPlugins/Filters/SplatterPlot/vtkSplatterPlot.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef _vtkSplatterPlot_h
-#define _vtkSplatterPlot_h
+#pragma once
 
 #include "vtkUnstructuredGridAlgorithm.h"
 #include <string>
@@ -53,4 +52,3 @@ private:
   /// Time.
   double m_time;
 };
-#endif

--- a/qt/paraview_ext/PVPlugins/Readers/MDEWNexusReader/vtkMDEWNexusReader.h
+++ b/qt/paraview_ext/PVPlugins/Readers/MDEWNexusReader/vtkMDEWNexusReader.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef _vtkMDEWNexusReader_h
-#define _vtkMDEWNexusReader_h
+#pragma once
 
 #include "MantidVatesAPI/MDEWEventNexusLoadingPresenter.h"
 #include "MantidVatesAPI/Normalization.h"
@@ -76,4 +75,3 @@ private:
 
   Mantid::VATES::VisualNormalization m_normalization;
 };
-#endif

--- a/qt/paraview_ext/PVPlugins/Readers/MDEWNexusReader/vtkMDEWReader.h
+++ b/qt/paraview_ext/PVPlugins/Readers/MDEWNexusReader/vtkMDEWReader.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef _vtkMDEWNexusReader_h
-#define _vtkMDEWNexusReader_h
+#pragma once
 #include "MantidGeometry/MDGeometry/IMDDimension.h"
 #include "MantidGeometry/MDGeometry/MDGeometryXMLBuilder.h"
 #include "MantidKernel/MultiThreaded.h"
@@ -165,4 +164,3 @@ private:
   /// Mutex for thread-safe progress reporting.
   Mantid::Kernel::Mutex progressMutex;
 };
-#endif

--- a/qt/paraview_ext/PVPlugins/Readers/MDHWNexusReader/vtkMDHWNexusReader.h
+++ b/qt/paraview_ext/PVPlugins/Readers/MDHWNexusReader/vtkMDHWNexusReader.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef _vtkMDHWNexusReader_h
-#define _vtkMDHWNexusReader_h
+#pragma once
 
 #include "MantidVatesAPI/MDHWNexusLoadingPresenter.h"
 #include "MantidVatesAPI/Normalization.h"
@@ -77,4 +76,3 @@ private:
   /// Normalization Option
   Mantid::VATES::VisualNormalization m_normalizationOption;
 };
-#endif

--- a/qt/paraview_ext/PVPlugins/Readers/NexusPeaksReader/vtkNexusPeaksReader.h
+++ b/qt/paraview_ext/PVPlugins/Readers/NexusPeaksReader/vtkNexusPeaksReader.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef _vtkEventNexusReader_h
-#define _vtkEventNexusReader_h
+#pragma once
 #include "MantidAPI/IPeaksWorkspace_fwd.h"
 #include "MantidVatesAPI/vtkPolyDataAlgorithm_Silent.h"
 
@@ -61,4 +60,3 @@ private:
   /// Int representing an enum for q_lab, etc.
   int m_dimensions;
 };
-#endif

--- a/qt/paraview_ext/PVPlugins/Readers/PeaksReader/vtkPeaksReader.h
+++ b/qt/paraview_ext/PVPlugins/Readers/PeaksReader/vtkPeaksReader.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef _vtkEventNexusReader_h
-#define _vtkEventNexusReader_h
+#pragma once
 #include "MantidAPI/IPeaksWorkspace_fwd.h"
 #include "MantidVatesAPI/vtkPolyDataAlgorithm_Silent.h"
 
@@ -62,4 +61,3 @@ private:
   /// Int representing an enum for q_lab, etc.
   int m_dimensions;
 };
-#endif

--- a/qt/paraview_ext/PVPlugins/Representations/AlignedCutter.h
+++ b/qt/paraview_ext/PVPlugins/Representations/AlignedCutter.h
@@ -48,8 +48,7 @@
  * vtkImplicitFunction vtkClipPolyData
  */
 
-#ifndef AlignedCutter_h
-#define AlignedCutter_h
+#pragma once
 
 #include "vtkCutter.h"
 
@@ -77,5 +76,3 @@ private:
   void operator=(const AlignedCutter &) VTK_DELETE_FUNCTION;
 };
 //@}
-
-#endif

--- a/qt/paraview_ext/PVPlugins/Representations/AlignedThreeSliceFilter.h
+++ b/qt/paraview_ext/PVPlugins/Representations/AlignedThreeSliceFilter.h
@@ -33,8 +33,7 @@
  * - 3: Output of the third internal vtkCutter filter
  */
 
-#ifndef AlignedThreeSliceFilter_h
-#define AlignedThreeSliceFilter_h
+#pragma once
 
 #include "vtkPVClientServerCoreRenderingModule.h" //needed for exports
 #include "vtkThreeSliceFilter.h"
@@ -56,5 +55,3 @@ private:
   AlignedThreeSliceFilter(const AlignedThreeSliceFilter &) VTK_DELETE_FUNCTION;
   void operator=(const AlignedThreeSliceFilter &) VTK_DELETE_FUNCTION;
 };
-
-#endif

--- a/qt/paraview_ext/PVPlugins/Representations/vtkAlignedGeometrySliceRepresentation.h
+++ b/qt/paraview_ext/PVPlugins/Representations/vtkAlignedGeometrySliceRepresentation.h
@@ -28,8 +28,7 @@
  * vtkPVOrthographicSliceView.
  */
 
-#ifndef vtkAlignedGeometrySliceRepresentation_h
-#define vtkAlignedGeometrySliceRepresentation_h
+#pragma once
 
 #include "vtkGeometryRepresentation.h"
 
@@ -79,5 +78,3 @@ private:
   int Mode;
   bool ShowOutline;
 };
-
-#endif

--- a/qt/paraview_ext/PVPlugins/Sources/MDEWSource/vtkMDEWSource.h
+++ b/qt/paraview_ext/PVPlugins/Sources/MDEWSource/vtkMDEWSource.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef _vtkMDEWSource_h
-#define _vtkMDEWSource_h
+#pragma once
 
 #include "MantidVatesAPI/Normalization.h"
 #include "MantidVatesAPI/vtkDataSetFactory.h"
@@ -85,4 +84,3 @@ private:
   Mantid::VATES::VisualNormalization m_normalization;
   void setTimeRange(vtkInformationVector *outputVector);
 };
-#endif

--- a/qt/paraview_ext/PVPlugins/Sources/MDHWSource/vtkMDHWSource.h
+++ b/qt/paraview_ext/PVPlugins/Sources/MDHWSource/vtkMDHWSource.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef _vtkMDHWSource_h
-#define _vtkMDHWSource_h
+#pragma once
 
 #include "MantidVatesAPI/Normalization.h"
 #include "vtkStructuredGridAlgorithm.h"
@@ -81,4 +80,3 @@ private:
 
   void setTimeRange(vtkInformationVector *outputVector);
 };
-#endif

--- a/qt/paraview_ext/PVPlugins/Sources/PeaksSource/vtkPeaksSource.h
+++ b/qt/paraview_ext/PVPlugins/Sources/PeaksSource/vtkPeaksSource.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef _vtkPeaksSource_h
-#define _vtkPeaksSource_h
+#pragma once
 
 #include "MantidAPI/IPeaksWorkspace_fwd.h"
 #include "MantidVatesAPI/vtkPeakMarkerFactory.h"
@@ -70,4 +69,3 @@ private:
   /// Instrument name.
   std::string m_instrument;
 };
-#endif

--- a/qt/paraview_ext/PVPlugins/Sources/SinglePeakMarkerSource/vtkSinglePeakMarkerSource.h
+++ b/qt/paraview_ext/PVPlugins/Sources/SinglePeakMarkerSource/vtkSinglePeakMarkerSource.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef _vtkSinglePeakMarkerSource_h
-#define _vtkSinglePeakMarkerSource_h
+#pragma once
 #include "vtkPolyDataAlgorithm.h"
 
 /**
@@ -46,4 +45,3 @@ private:
   double m_position3;
   double m_radius;
 };
-#endif

--- a/qt/paraview_ext/VatesAPI/inc/MantidVatesAPI/ADSWorkspaceProvider.h
+++ b/qt/paraview_ext/VatesAPI/inc/MantidVatesAPI/ADSWorkspaceProvider.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_VATESAPI_ADSWORKSPACEPROVIDER_H
-#define MANTID_VATESAPI_ADSWORKSPACEPROVIDER_H
+#pragma once
 
 #include "MantidVatesAPI/WorkspaceProvider.h"
 
@@ -35,5 +34,3 @@ private:
 };
 } // namespace VATES
 } // namespace Mantid
-
-#endif

--- a/qt/paraview_ext/VatesAPI/inc/MantidVatesAPI/BoxInfo.h
+++ b/qt/paraview_ext/VatesAPI/inc/MantidVatesAPI/BoxInfo.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_VATESAPI_BOXINFO_H
-#define MANTID_VATESAPI_BOXINFO_H
+#pragma once
 
 #include "MantidKernel/System.h"
 #include "MantidVatesAPI/WorkspaceProvider.h"
@@ -30,5 +29,3 @@ boost::optional<int> DLLExport findRecursionDepthForTopLevelSplitting(
     const WorkspaceProvider &workspaceProvider);
 } // namespace VATES
 } // namespace Mantid
-
-#endif

--- a/qt/paraview_ext/VatesAPI/inc/MantidVatesAPI/ColorScaleGuard.h
+++ b/qt/paraview_ext/VatesAPI/inc/MantidVatesAPI/ColorScaleGuard.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_VATES_API_COLOR_SCALE_LOCK_H
-#define MANTID_VATES_API_COLOR_SCALE_LOCK_H
+#pragma once
 #include "MantidKernel/Logger.h"
 #include "MantidKernel/System.h"
 
@@ -44,4 +43,3 @@ private:
 };
 } // namespace VATES
 } // namespace Mantid
-#endif

--- a/qt/paraview_ext/VatesAPI/inc/MantidVatesAPI/Common.h
+++ b/qt/paraview_ext/VatesAPI/inc/MantidVatesAPI/Common.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_VATES_COMMON_H_
-#define MANTID_VATES_COMMON_H_
+#pragma once
 #include <boost/shared_ptr.hpp>
 #include <string>
 #include <vector>
@@ -48,5 +47,3 @@ void setAxisLabel(const std::string &metadataLabel,
                   const std::string &labelString, vtkFieldData *fieldData);
 } // namespace VATES
 } // namespace Mantid
-
-#endif

--- a/qt/paraview_ext/VatesAPI/inc/MantidVatesAPI/CompositePeaksPresenterVsi.h
+++ b/qt/paraview_ext/VatesAPI/inc/MantidVatesAPI/CompositePeaksPresenterVsi.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_VATES_COMPOSITE_PEAKS_PRESENTER_VSI_H
-#define MANTID_VATES_COMPOSITE_PEAKS_PRESENTER_VSI_H
+#pragma once
 
 #include "MantidAPI/IPeaksWorkspace_fwd.h"
 #include "MantidGeometry/Crystal/PeakShape.h"
@@ -54,4 +53,3 @@ private:
 };
 } // namespace VATES
 } // namespace Mantid
-#endif

--- a/qt/paraview_ext/VatesAPI/inc/MantidVatesAPI/ConcretePeaksPresenterVsi.h
+++ b/qt/paraview_ext/VatesAPI/inc/MantidVatesAPI/ConcretePeaksPresenterVsi.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_VATES_CONCRETE_PEAKS_PRESENTER_VSI_H
-#define MANTID_VATES_CONCRETE_PEAKS_PRESENTER_VSI_H
+#pragma once
 
 #include "MantidAPI/IPeaksWorkspace_fwd.h"
 #include "MantidGeometry/Crystal/PeakShape.h"
@@ -50,4 +49,3 @@ private:
 };
 } // namespace VATES
 } // namespace Mantid
-#endif

--- a/qt/paraview_ext/VatesAPI/inc/MantidVatesAPI/DimensionViewFactory.h
+++ b/qt/paraview_ext/VatesAPI/inc/MantidVatesAPI/DimensionViewFactory.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef _DIMENSION_VIEW_FACTORY_H
-#define _DIMENSION_VIEW_FACTORY_H
+#pragma once
 
 #include "MantidVatesAPI/DimensionView.h"
 namespace Mantid {
@@ -20,5 +19,3 @@ public:
 };
 } // namespace VATES
 } // namespace Mantid
-
-#endif

--- a/qt/paraview_ext/VatesAPI/inc/MantidVatesAPI/EventNexusLoadingPresenter.h
+++ b/qt/paraview_ext/VatesAPI/inc/MantidVatesAPI/EventNexusLoadingPresenter.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_VATES_EVENT_NEXUS_LOADING_PRESENTER
-#define MANTID_VATES_EVENT_NEXUS_LOADING_PRESENTER
+#pragma once
 
 #include "MantidVatesAPI/MDEWLoadingPresenter.h"
 
@@ -39,5 +38,3 @@ private:
 };
 } // namespace VATES
 } // namespace Mantid
-
-#endif

--- a/qt/paraview_ext/VatesAPI/inc/MantidVatesAPI/FactoryChains.h
+++ b/qt/paraview_ext/VatesAPI/inc/MantidVatesAPI/FactoryChains.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_VATES_FACTORY_CHAINS_H
-#define MANTID_VATES_FACTORY_CHAINS_H
+#pragma once
 
 #include "MantidKernel/System.h"
 
@@ -45,5 +44,3 @@ vtkSmartPointer<vtkPVClipDataSet>
 std::string DLLExport createTimeStampedName(const std::string &name);
 } // namespace VATES
 } // namespace Mantid
-
-#endif

--- a/qt/paraview_ext/VatesAPI/inc/MantidVatesAPI/FieldDataToMetadata.h
+++ b/qt/paraview_ext/VatesAPI/inc/MantidVatesAPI/FieldDataToMetadata.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef FIELDDATA_TO_METADATA_H_
-#define FIELDDATA_TO_METADATA_H_
+#pragma once
 
 #include "MantidKernel/System.h"
 #include <functional>
@@ -32,5 +31,3 @@ public:
 };
 } // namespace VATES
 } // namespace Mantid
-
-#endif

--- a/qt/paraview_ext/VatesAPI/inc/MantidVatesAPI/FilteringUpdateProgressAction.h
+++ b/qt/paraview_ext/VatesAPI/inc/MantidVatesAPI/FilteringUpdateProgressAction.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef PARAVIEWPROGRESSACTION_H_
-#define PARAVIEWPROGRESSACTION_H_
+#pragma once
 
 #include "MantidKernel/System.h"
 #include "MantidVatesAPI/ProgressAction.h"
@@ -44,5 +43,3 @@ private:
 };
 } // namespace VATES
 } // namespace Mantid
-
-#endif /* PARAVIEWPROGRESSACTION_H_ */

--- a/qt/paraview_ext/VatesAPI/inc/MantidVatesAPI/GeometryView.h
+++ b/qt/paraview_ext/VatesAPI/inc/MantidVatesAPI/GeometryView.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef GEOMETRY_VIEW_H
-#define GEOMETRY_VIEW_H
+#pragma once
 #include "MantidKernel/System.h"
 #include "MantidVatesAPI/DimensionView.h"
 #include "MantidVatesAPI/DimensionViewFactory.h"
@@ -30,5 +29,3 @@ public:
 };
 } // namespace VATES
 } // namespace Mantid
-
-#endif

--- a/qt/paraview_ext/VatesAPI/inc/MantidVatesAPI/IMDDimensionComparitor.h
+++ b/qt/paraview_ext/VatesAPI/inc/MantidVatesAPI/IMDDimensionComparitor.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef IMD_DIMENSION_COMPARITOR_H
-#define IMD_DIMENSION_COMPARITOR_H
+#pragma once
 
 #include "MantidAPI/AnalysisDataService.h"
 #include "MantidAPI/IMDWorkspace.h"
@@ -46,5 +45,3 @@ private:
 };
 } // namespace VATES
 } // namespace Mantid
-
-#endif

--- a/qt/paraview_ext/VatesAPI/inc/MantidVatesAPI/MDEWEventNexusLoadingPresenter.h
+++ b/qt/paraview_ext/VatesAPI/inc/MantidVatesAPI/MDEWEventNexusLoadingPresenter.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_VATES_MDEW_EVENT_NEXUS_LOADING_PRESENTER
-#define MANTID_VATES_MDEW_EVENT_NEXUS_LOADING_PRESENTER
+#pragma once
 
 #include "MantidVatesAPI/MDEWLoadingPresenter.h"
 
@@ -37,5 +36,3 @@ private:
 };
 } // namespace VATES
 } // namespace Mantid
-
-#endif

--- a/qt/paraview_ext/VatesAPI/inc/MantidVatesAPI/MDEWInMemoryLoadingPresenter.h
+++ b/qt/paraview_ext/VatesAPI/inc/MantidVatesAPI/MDEWInMemoryLoadingPresenter.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_VATES_MDEW_IN_MEMORY_LOADING_PRESENTER
-#define MANTID_VATES_MDEW_IN_MEMORY_LOADING_PRESENTER
+#pragma once
 
 #include "MantidVatesAPI/MDEWLoadingPresenter.h"
 #include <boost/scoped_ptr.hpp>
@@ -50,5 +49,3 @@ private:
 };
 } // namespace VATES
 } // namespace Mantid
-
-#endif

--- a/qt/paraview_ext/VatesAPI/inc/MantidVatesAPI/MDEWLoadingPresenter.h
+++ b/qt/paraview_ext/VatesAPI/inc/MantidVatesAPI/MDEWLoadingPresenter.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_VATES_MDEW_LOADING_PRESENTER
-#define MANTID_VATES_MDEW_LOADING_PRESENTER
+#pragma once
 
 #include "MantidAPI/IMDEventWorkspace_fwd.h"
 #include "MantidGeometry/MDGeometry/IMDDimension.h"
@@ -69,5 +68,3 @@ protected:
 };
 } // namespace VATES
 } // namespace Mantid
-
-#endif

--- a/qt/paraview_ext/VatesAPI/inc/MantidVatesAPI/MDHWInMemoryLoadingPresenter.h
+++ b/qt/paraview_ext/VatesAPI/inc/MantidVatesAPI/MDHWInMemoryLoadingPresenter.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_VATES_MDHW_IN_MEMORY_LOADING_PRESENTER
-#define MANTID_VATES_MDHW_IN_MEMORY_LOADING_PRESENTER
+#pragma once
 
 #include "MantidVatesAPI/MDHWLoadingPresenter.h"
 #include <boost/scoped_ptr.hpp>
@@ -60,5 +59,3 @@ private:
 };
 } // namespace VATES
 } // namespace Mantid
-
-#endif

--- a/qt/paraview_ext/VatesAPI/inc/MantidVatesAPI/MDHWLoadingPresenter.h
+++ b/qt/paraview_ext/VatesAPI/inc/MantidVatesAPI/MDHWLoadingPresenter.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_VATES_MDHW_LOADING_PRESENTER
-#define MANTID_VATES_MDHW_LOADING_PRESENTER
+#pragma once
 
 #include "MantidAPI/IMDHistoWorkspace_fwd.h"
 #include "MantidGeometry/MDGeometry/IMDDimension.h"
@@ -73,5 +72,3 @@ protected:
 };
 } // namespace VATES
 } // namespace Mantid
-
-#endif

--- a/qt/paraview_ext/VatesAPI/inc/MantidVatesAPI/MDHWNexusLoadingPresenter.h
+++ b/qt/paraview_ext/VatesAPI/inc/MantidVatesAPI/MDHWNexusLoadingPresenter.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_VATES_MDHW_NEXUS_LOADING_PRESENTER
-#define MANTID_VATES_MDHW_NEXUS_LOADING_PRESENTER
+#pragma once
 
 #include "MantidVatesAPI/MDHWLoadingPresenter.h"
 #include <vector>
@@ -42,5 +41,3 @@ private:
 };
 } // namespace VATES
 } // namespace Mantid
-
-#endif

--- a/qt/paraview_ext/VatesAPI/inc/MantidVatesAPI/MDLoadingPresenter.h
+++ b/qt/paraview_ext/VatesAPI/inc/MantidVatesAPI/MDLoadingPresenter.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_VATES_MD_LOADING_PRESENTER
-#define MANTID_VATES_MD_LOADING_PRESENTER
+#pragma once
 
 #include "MantidAPI/IMDWorkspace.h"
 #include "MantidKernel/Logger.h"
@@ -57,5 +56,3 @@ public:
 };
 } // namespace VATES
 } // namespace Mantid
-
-#endif

--- a/qt/paraview_ext/VatesAPI/inc/MantidVatesAPI/MDLoadingView.h
+++ b/qt/paraview_ext/VatesAPI/inc/MantidVatesAPI/MDLoadingView.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_VATES_MD_LOADING_VIEW
-#define MANTID_VATES_MD_LOADING_VIEW
+#pragma once
 
 #include "MantidKernel/System.h"
 
@@ -27,5 +26,3 @@ public:
 };
 } // namespace VATES
 } // namespace Mantid
-
-#endif

--- a/qt/paraview_ext/VatesAPI/inc/MantidVatesAPI/MDLoadingViewAdapter.h
+++ b/qt/paraview_ext/VatesAPI/inc/MantidVatesAPI/MDLoadingViewAdapter.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_VATES_MD_LOADING_VIEW_ADAPTER_H
-#define MANTID_VATES_MD_LOADING_VIEW_ADAPTER_H
+#pragma once
 
 #include "MantidVatesAPI/MDLoadingView.h"
 
@@ -39,5 +38,3 @@ public:
 };
 } // namespace VATES
 } // namespace Mantid
-
-#endif

--- a/qt/paraview_ext/VatesAPI/inc/MantidVatesAPI/MDLoadingViewSimple.h
+++ b/qt/paraview_ext/VatesAPI/inc/MantidVatesAPI/MDLoadingViewSimple.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_VATES_MD_LOADING_VIEW_SIMPLE_H
-#define MANTID_VATES_MD_LOADING_VIEW_SIMPLE_H
+#pragma once
 
 #include "MantidVatesAPI/MDLoadingView.h"
 
@@ -34,5 +33,3 @@ private:
 };
 } // namespace VATES
 } // namespace Mantid
-
-#endif

--- a/qt/paraview_ext/VatesAPI/inc/MantidVatesAPI/MetaDataExtractorUtils.h
+++ b/qt/paraview_ext/VatesAPI/inc/MantidVatesAPI/MetaDataExtractorUtils.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_VATES_METADATAEXTRACTORUTILS_H_
-#define MANTID_VATES_METADATAEXTRACTORUTILS_H_
+#pragma once
 
 #include "MantidAPI/IMDIterator.h"
 #include "MantidAPI/IMDWorkspace.h"
@@ -37,4 +36,3 @@ public:
 };
 } // namespace VATES
 } // namespace Mantid
-#endif

--- a/qt/paraview_ext/VatesAPI/inc/MantidVatesAPI/MetadataJsonManager.h
+++ b/qt/paraview_ext/VatesAPI/inc/MantidVatesAPI/MetadataJsonManager.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef METADATA_JSON_MANAGER_H
-#define METADATA_JSON_MANAGER_H
+#pragma once
 
 #include "MantidKernel/System.h"
 #include <json/json.h>
@@ -38,4 +37,3 @@ private:
 };
 } // namespace VATES
 } // namespace Mantid
-#endif

--- a/qt/paraview_ext/VatesAPI/inc/MantidVatesAPI/MetadataToFieldData.h
+++ b/qt/paraview_ext/VatesAPI/inc/MantidVatesAPI/MetadataToFieldData.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef METADATATOFIELDDATA_H_
-#define METADATATOFIELDDATA_H_
+#pragma once
 
 #include "MantidKernel/System.h"
 #include <functional>
@@ -33,5 +32,3 @@ public:
 };
 } // namespace VATES
 } // namespace Mantid
-
-#endif

--- a/qt/paraview_ext/VatesAPI/inc/MantidVatesAPI/Normalization.h
+++ b/qt/paraview_ext/VatesAPI/inc/MantidVatesAPI/Normalization.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_VATES_NORMALIZATION_H_
-#define MANTID_VATES_NORMALIZATION_H_
+#pragma once
 
 #include "MantidAPI/DllConfig.h"
 #include "MantidGeometry/MDGeometry/MDTypes.h"
@@ -63,5 +62,3 @@ createIteratorWithNormalization(const VisualNormalization normalizationOption,
                                 Mantid::API::IMDWorkspace const *const ws);
 } // namespace VATES
 } // namespace Mantid
-
-#endif /*MANTID_VATES_NORMALIZATION_H_*/

--- a/qt/paraview_ext/VatesAPI/inc/MantidVatesAPI/NullPeaksPresenterVsi.h
+++ b/qt/paraview_ext/VatesAPI/inc/MantidVatesAPI/NullPeaksPresenterVsi.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_VATES_NULL_PEAKS_PRESENTER
-#define MANTID_VATES_NULL_PEAKS_PRESENTER
+#pragma once
 
 #include "MantidAPI/IPeaksWorkspace_fwd.h"
 #include "MantidKernel/SpecialCoordinateSystem.h"
@@ -48,5 +47,3 @@ public:
 };
 } // namespace VATES
 } // namespace Mantid
-
-#endif

--- a/qt/paraview_ext/VatesAPI/inc/MantidVatesAPI/PeaksPresenterVsi.h
+++ b/qt/paraview_ext/VatesAPI/inc/MantidVatesAPI/PeaksPresenterVsi.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_VATES_PEAKS_PRESENTER_VSI_H
-#define MANTID_VATES_PEAKS_PRESENTER_VSI_H
+#pragma once
 
 #include "MantidAPI/IPeaksWorkspace_fwd.h"
 #include "MantidKernel/SpecialCoordinateSystem.h"
@@ -39,4 +38,3 @@ using PeaksPresenterVsi_sptr = boost::shared_ptr<PeaksPresenterVsi>;
 using PeaksPresenterVsi_const_sptr = boost::shared_ptr<const PeaksPresenterVsi>;
 } // namespace VATES
 } // namespace Mantid
-#endif

--- a/qt/paraview_ext/VatesAPI/inc/MantidVatesAPI/PrecompiledHeader.h
+++ b/qt/paraview_ext/VatesAPI/inc/MantidVatesAPI/PrecompiledHeader.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_VATES_PRECOMPILEDHEADER_H_
-#define MANTID_VATES_PRECOMPILEDHEADER_H_
+#pragma once
 
 #include "MantidAPI/Algorithm.h"
 #include "MantidGeometry/MDGeometry/IMDDimension.h"
@@ -19,5 +18,3 @@
 #include <set>
 #include <string>
 #include <vector>
-
-#endif // MANTID_VATES_PRECOMPILEDHEADER_H_

--- a/qt/paraview_ext/VatesAPI/inc/MantidVatesAPI/PresenterFactories.h
+++ b/qt/paraview_ext/VatesAPI/inc/MantidVatesAPI/PresenterFactories.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_VATES_PRESENTER_FACTORIES_H
-#define MANTID_VATES_PRESENTER_FACTORIES_H
+#pragma once
 
 #include "MantidAPI/IMDWorkspace.h"
 
@@ -53,4 +52,3 @@ public:
 };
 } // namespace VATES
 } // namespace Mantid
-#endif

--- a/qt/paraview_ext/VatesAPI/inc/MantidVatesAPI/ProgressAction.h
+++ b/qt/paraview_ext/VatesAPI/inc/MantidVatesAPI/ProgressAction.h
@@ -5,8 +5,7 @@
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
 
-#ifndef _EVENT_HANDLER_H_
-#define _EVENT_HANDLER_H_
+#pragma once
 
 #include "MantidAPI/Algorithm.h"
 #include <Poco/ActiveMethod.h>
@@ -37,4 +36,3 @@ public:
 };
 } // namespace VATES
 } // namespace Mantid
-#endif

--- a/qt/paraview_ext/VatesAPI/inc/MantidVatesAPI/SQWLoadingPresenter.h
+++ b/qt/paraview_ext/VatesAPI/inc/MantidVatesAPI/SQWLoadingPresenter.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef SQW_LOADING_PRESENTER_H_
-#define SQW_LOADING_PRESENTER_H_
+#pragma once
 
 #include "MantidVatesAPI/MDEWLoadingPresenter.h"
 
@@ -37,5 +36,3 @@ private:
 };
 } // namespace VATES
 } // namespace Mantid
-
-#endif

--- a/qt/paraview_ext/VatesAPI/inc/MantidVatesAPI/SingleWorkspaceProvider.h
+++ b/qt/paraview_ext/VatesAPI/inc/MantidVatesAPI/SingleWorkspaceProvider.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef VATES_API_SINGLE_WORKSPACE_PROVIDER_H_
-#define VATES_API_SINGLE_WORKSPACE_PROVIDER_H_
+#pragma once
 
 #include "MantidAPI/Workspace_fwd.h"
 #include "WorkspaceProvider.h"
@@ -28,5 +27,3 @@ private:
 };
 } // namespace VATES
 } // namespace Mantid
-
-#endif

--- a/qt/paraview_ext/VatesAPI/inc/MantidVatesAPI/TimeStepToTimeStep.h
+++ b/qt/paraview_ext/VatesAPI/inc/MantidVatesAPI/TimeStepToTimeStep.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_PARAVIEW_TIMESTEP_TO_TIMESTEP
-#define MANTID_PARAVIEW_TIMESTEP_TO_TIMESTEP
+#pragma once
 
 #include "MantidKernel/System.h"
 
@@ -34,5 +33,3 @@ public:
 };
 } // namespace VATES
 } // namespace Mantid
-
-#endif

--- a/qt/paraview_ext/VatesAPI/inc/MantidVatesAPI/TimeToTimeStep.h
+++ b/qt/paraview_ext/VatesAPI/inc/MantidVatesAPI/TimeToTimeStep.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_PARAVIEW_TIME_TO_TIMESTEP
-#define MANTID_PARAVIEW_TIME_TO_TIMESTEP
+#pragma once
 
 #include "MantidKernel/System.h"
 
@@ -46,5 +45,3 @@ public:
 };
 } // namespace VATES
 } // namespace Mantid
-
-#endif

--- a/qt/paraview_ext/VatesAPI/inc/MantidVatesAPI/VatesConfigurations.h
+++ b/qt/paraview_ext/VatesAPI/inc/MantidVatesAPI/VatesConfigurations.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef VATES_CONFIGURATION_H
-#define VATES_CONFIGURATION_H
+#pragma once
 
 #include "MantidKernel/System.h"
 #include <string>
@@ -38,4 +37,3 @@ private:
 };
 } // namespace VATES
 } // namespace Mantid
-#endif

--- a/qt/paraview_ext/VatesAPI/inc/MantidVatesAPI/VatesKnowledgeSerializer.h
+++ b/qt/paraview_ext/VatesAPI/inc/MantidVatesAPI/VatesKnowledgeSerializer.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef VATES_KNOWLEDGE_SERIALIZER_H
-#define VATES_KNOWLEDGE_SERIALIZER_H
+#pragma once
 
 #include "MantidKernel/System.h"
 #include <boost/shared_ptr.hpp>
@@ -81,4 +80,3 @@ public:
 };
 } // namespace VATES
 } // namespace Mantid
-#endif

--- a/qt/paraview_ext/VatesAPI/inc/MantidVatesAPI/VatesXMLDefinitions.h
+++ b/qt/paraview_ext/VatesAPI/inc/MantidVatesAPI/VatesXMLDefinitions.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef VATESXMLDEFINITIONS_H_
-#define VATESXMLDEFINITIONS_H_
+#pragma once
 
 #include "MantidKernel/System.h"
 #include <string>
@@ -109,4 +108,3 @@ public:
 };
 } // namespace VATES
 } // namespace Mantid
-#endif

--- a/qt/paraview_ext/VatesAPI/inc/MantidVatesAPI/ViewFrustum.h
+++ b/qt/paraview_ext/VatesAPI/inc/MantidVatesAPI/ViewFrustum.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_PARAVIEW_VIEWFRUSTUM
-#define MANTID_PARAVIEW_VIEWFRUSTUM
+#pragma once
 
 #include "MantidKernel/Matrix.h"
 #include "MantidKernel/System.h"
@@ -167,4 +166,3 @@ using ViewFrustum_const_sptr =
     boost::shared_ptr<const Mantid::VATES::ViewFrustum>;
 } // namespace VATES
 } // namespace Mantid
-#endif

--- a/qt/paraview_ext/VatesAPI/inc/MantidVatesAPI/WorkspaceProvider.h
+++ b/qt/paraview_ext/VatesAPI/inc/MantidVatesAPI/WorkspaceProvider.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_VATESAPI_WORKSPACE_PROVIDER_H
-#define MANTID_VATESAPI_WORKSPACE_PROVIDER_H
+#pragma once
 
 #include "MantidAPI/Workspace_fwd.h"
 #include "MantidKernel/System.h"
@@ -35,5 +34,3 @@ public:
 };
 } // namespace VATES
 } // namespace Mantid
-
-#endif

--- a/qt/paraview_ext/VatesAPI/inc/MantidVatesAPI/vtkDataSetFactory.h
+++ b/qt/paraview_ext/VatesAPI/inc/MantidVatesAPI/vtkDataSetFactory.h
@@ -5,8 +5,7 @@
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
 
-#ifndef MANTID_VATES_VTKDATASETFACTORY_H_
-#define MANTID_VATES_VTKDATASETFACTORY_H_
+#pragma once
 
 #include "MantidAPI/IMDWorkspace.h"
 #include "MantidAPI/Workspace_fwd.h"
@@ -234,5 +233,3 @@ using vtkDataSetFactory_sptr = boost::shared_ptr<vtkDataSetFactory>;
 using vtkDataSetFactory_uptr = std::unique_ptr<vtkDataSetFactory>;
 } // namespace VATES
 } // namespace Mantid
-
-#endif

--- a/qt/paraview_ext/VatesAPI/inc/MantidVatesAPI/vtkDataSetToGeometry.h
+++ b/qt/paraview_ext/VatesAPI/inc/MantidVatesAPI/vtkDataSetToGeometry.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef VTKDATASET_TO_GEOMETRY_H_
-#define VTKDATASET_TO_GEOMETRY_H_
+#pragma once
 
 #include "MantidGeometry/MDGeometry/IMDDimension.h"
 #include "MantidGeometry/MDGeometry/MDGeometryXMLParser.h"
@@ -43,5 +42,3 @@ public:
 };
 } // namespace VATES
 } // namespace Mantid
-
-#endif

--- a/qt/paraview_ext/VatesAPI/inc/MantidVatesAPI/vtkDataSetToImplicitFunction.h
+++ b/qt/paraview_ext/VatesAPI/inc/MantidVatesAPI/vtkDataSetToImplicitFunction.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef VTKDATASET_TO_IMPLICIT_FUNCTION_H_
-#define VTKDATASET_TO_IMPLICIT_FUNCTION_H_
+#pragma once
 
 #include "MantidKernel/System.h"
 
@@ -41,5 +40,3 @@ private:
 };
 } // namespace VATES
 } // namespace Mantid
-
-#endif

--- a/qt/paraview_ext/VatesAPI/inc/MantidVatesAPI/vtkDataSetToNonOrthogonalDataSet.h
+++ b/qt/paraview_ext/VatesAPI/inc/MantidVatesAPI/vtkDataSetToNonOrthogonalDataSet.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_VATES_VTKDATASETTONONORTHOGONALDATASET_H_
-#define MANTID_VATES_VTKDATASETTONONORTHOGONALDATASET_H_
+#pragma once
 
 #include "MantidGeometry/MDGeometry/MDTypes.h"
 #include "MantidKernel/Matrix.h"
@@ -80,5 +79,3 @@ private:
 
 } // namespace VATES
 } // namespace Mantid
-
-#endif /* MANTID_VATES_VTKDATASETTONONORTHOGONALDATASET_H_ */

--- a/qt/paraview_ext/VatesAPI/inc/MantidVatesAPI/vtkDataSetToPeaksFilteredDataSet.h
+++ b/qt/paraview_ext/VatesAPI/inc/MantidVatesAPI/vtkDataSetToPeaksFilteredDataSet.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_VATES_PeaksFilter_H
-#define MANTID_VATES_PeaksFilter_H
+#pragma once
 
 #include "MantidAPI/IPeaksWorkspace.h"
 #include "MantidDataObjects/PeakShapeBase.h"
@@ -67,4 +66,3 @@ private:
 };
 } // namespace VATES
 } // namespace Mantid
-#endif

--- a/qt/paraview_ext/VatesAPI/inc/MantidVatesAPI/vtkDataSetToScaledDataSet.h
+++ b/qt/paraview_ext/VatesAPI/inc/MantidVatesAPI/vtkDataSetToScaledDataSet.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_VATES_VTKDATASETTOSCALEDDATASET_H_
-#define MANTID_VATES_VTKDATASETTOSCALEDDATASET_H_
+#pragma once
 
 #include "MantidKernel/System.h"
 
@@ -45,5 +44,3 @@ private:
 
 } // namespace VATES
 } // namespace Mantid
-
-#endif // MANTID_VATES_VTKDATASETTOSCALEDDATASET_H_

--- a/qt/paraview_ext/VatesAPI/inc/MantidVatesAPI/vtkDataSetToWsLocation.h
+++ b/qt/paraview_ext/VatesAPI/inc/MantidVatesAPI/vtkDataSetToWsLocation.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef VTKDATASET_TO_WS_LOCATION_H
-#define VTKDATASET_TO_WS_LOCATION_H
+#pragma once
 
 #include "MantidKernel/System.h"
 #include <string>
@@ -37,5 +36,3 @@ private:
 };
 } // namespace VATES
 } // namespace Mantid
-
-#endif

--- a/qt/paraview_ext/VatesAPI/inc/MantidVatesAPI/vtkDataSetToWsName.h
+++ b/qt/paraview_ext/VatesAPI/inc/MantidVatesAPI/vtkDataSetToWsName.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef VTKDATASET_TO_WS_NAME_H
-#define VTKDATASET_TO_WS_NAME_H
+#pragma once
 
 #include "MantidKernel/System.h"
 #include <string>
@@ -36,5 +35,3 @@ private:
 };
 } // namespace VATES
 } // namespace Mantid
-
-#endif

--- a/qt/paraview_ext/VatesAPI/inc/MantidVatesAPI/vtkGlyph3D_Silent.h
+++ b/qt/paraview_ext/VatesAPI/inc/MantidVatesAPI/vtkGlyph3D_Silent.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef VTKGLYPH3D_SILENT_H
-#define VTKGLYPH3D_SILENT_H
+#pragma once
 
 #if defined(__GNUC__) && !(defined(__INTEL_COMPILER))
 #if (__GNUC__ >= 4 && __GNUC_MINOR__ >= 8)
@@ -19,5 +18,3 @@
 #pragma GCC diagnostic pop
 #endif
 #endif
-
-#endif // VTKGLYPH3D_SILENT_H

--- a/qt/paraview_ext/VatesAPI/inc/MantidVatesAPI/vtkImageData_Silent.h
+++ b/qt/paraview_ext/VatesAPI/inc/MantidVatesAPI/vtkImageData_Silent.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef VTKIMAGEDATA_SILENT_H
-#define VTKIMAGEDATA_SILENT_H
+#pragma once
 
 #if defined(__GNUC__) && !(defined(__INTEL_COMPILER))
 #if (__GNUC__ >= 4 && __GNUC_MINOR__ >= 6)
@@ -19,5 +18,3 @@
 #pragma GCC diagnostic pop
 #endif
 #endif
-
-#endif // VTKIMAGEDATA_SILENT_H

--- a/qt/paraview_ext/VatesAPI/inc/MantidVatesAPI/vtkMD0DFactory.h
+++ b/qt/paraview_ext/VatesAPI/inc/MantidVatesAPI/vtkMD0DFactory.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_VATES_VTK_MD_0D_FACTORY_H_
-#define MANTID_VATES_VTK_MD_0D_FACTORY_H_
+#pragma once
 
 #include "MantidAPI/IMDWorkspace.h"
 #include "MantidKernel/System.h"
@@ -38,4 +37,3 @@ protected:
 };
 } // namespace VATES
 } // namespace Mantid
-#endif

--- a/qt/paraview_ext/VatesAPI/inc/MantidVatesAPI/vtkMDHexFactory.h
+++ b/qt/paraview_ext/VatesAPI/inc/MantidVatesAPI/vtkMDHexFactory.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_VATES_VTK_MD_HEX_FACTORY_H_
-#define MANTID_VATES_VTK_MD_HEX_FACTORY_H_
+#pragma once
 
 #include "MantidAPI/IMDEventWorkspace_fwd.h"
 #include "MantidDataObjects/MDEventFactory.h"
@@ -102,5 +101,3 @@ private:
 };
 } // namespace VATES
 } // namespace Mantid
-
-#endif

--- a/qt/paraview_ext/VatesAPI/inc/MantidVatesAPI/vtkMDHistoHex4DFactory.h
+++ b/qt/paraview_ext/VatesAPI/inc/MantidVatesAPI/vtkMDHistoHex4DFactory.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_VATES_VTK_MD_HISTO_HEX4D_FACTORY_H_
-#define MANTID_VATES_VTK_MD_HISTO_HEX4D_FACTORY_H_
+#pragma once
 
 /** Concrete implementation of vtkDataSetFactory. Creates a vtkUnStructuredGrid.
  Uses Thresholding technique
@@ -71,5 +70,3 @@ private:
 };
 } // namespace VATES
 } // namespace Mantid
-
-#endif

--- a/qt/paraview_ext/VatesAPI/inc/MantidVatesAPI/vtkMDHistoHexFactory.h
+++ b/qt/paraview_ext/VatesAPI/inc/MantidVatesAPI/vtkMDHistoHexFactory.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_VATES_VTK_MD_HISTO_HEX_FACTORY_H_
-#define MANTID_VATES_VTK_MD_HISTO_HEX_FACTORY_H_
+#pragma once
 
 /** Concrete implementation of vtkDataSetFactory. Creates a vtkUnStructuredGrid.
  Uses Thresholding technique
@@ -69,5 +68,3 @@ protected:
 };
 } // namespace VATES
 } // namespace Mantid
-
-#endif

--- a/qt/paraview_ext/VatesAPI/inc/MantidVatesAPI/vtkMDHistoLineFactory.h
+++ b/qt/paraview_ext/VatesAPI/inc/MantidVatesAPI/vtkMDHistoLineFactory.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_VATES_VTK_MD_HISTO_LINE_FACTORY_H_
-#define MANTID_VATES_VTK_MD_HISTO_LINE_FACTORY_H_
+#pragma once
 
 #include "MantidAPI/IMDWorkspace.h"
 #include "MantidDataObjects/MDHistoWorkspace.h"
@@ -60,4 +59,3 @@ private:
 };
 } // namespace VATES
 } // namespace Mantid
-#endif

--- a/qt/paraview_ext/VatesAPI/inc/MantidVatesAPI/vtkMDHistoQuadFactory.h
+++ b/qt/paraview_ext/VatesAPI/inc/MantidVatesAPI/vtkMDHistoQuadFactory.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_VATES_VTK_MD_HISTO_QUAD_FACTORY_H_
-#define MANTID_VATES_VTK_MD_HISTO_QUAD_FACTORY_H_
+#pragma once
 
 #include "MantidKernel/System.h"
 #include "MantidVatesAPI/Normalization.h"
@@ -65,4 +64,3 @@ private:
 };
 } // namespace VATES
 } // namespace Mantid
-#endif

--- a/qt/paraview_ext/VatesAPI/inc/MantidVatesAPI/vtkMDLineFactory.h
+++ b/qt/paraview_ext/VatesAPI/inc/MantidVatesAPI/vtkMDLineFactory.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef VATES_MD_LINE_FACTORY
-#define VATES_MD_LINE_FACTORY
+#pragma once
 
 #include "MantidVatesAPI/Normalization.h"
 #include "MantidVatesAPI/vtkDataSetFactory.h"
@@ -52,5 +51,3 @@ private:
 };
 } // namespace VATES
 } // namespace Mantid
-
-#endif

--- a/qt/paraview_ext/VatesAPI/inc/MantidVatesAPI/vtkMDQuadFactory.h
+++ b/qt/paraview_ext/VatesAPI/inc/MantidVatesAPI/vtkMDQuadFactory.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef VATES_MD_QUAD_FACTORY
-#define VATES_MD_QUAD_FACTORY
+#pragma once
 
 #include "MantidVatesAPI/Normalization.h"
 #include "MantidVatesAPI/vtkDataSetFactory.h"
@@ -53,5 +52,3 @@ private:
 };
 } // namespace VATES
 } // namespace Mantid
-
-#endif

--- a/qt/paraview_ext/VatesAPI/inc/MantidVatesAPI/vtkNullStructuredGrid.h
+++ b/qt/paraview_ext/VatesAPI/inc/MantidVatesAPI/vtkNullStructuredGrid.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef VATES_VTK_STRUCTURED_GRID_NULL_DATA_SET
-#define VATES_VTK_STRUCTURED_GRID_NULL_DATA_SET
+#pragma once
 
 #include "MantidKernel/System.h"
 
@@ -31,4 +30,3 @@ public:
 };
 } // namespace VATES
 } // namespace Mantid
-#endif

--- a/qt/paraview_ext/VatesAPI/inc/MantidVatesAPI/vtkNullUnstructuredGrid.h
+++ b/qt/paraview_ext/VatesAPI/inc/MantidVatesAPI/vtkNullUnstructuredGrid.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef VATES_VTK_NULL_DATA_SET
-#define VATES_VTK_NULL_DATA_SET
+#pragma once
 
 #include "MantidKernel/System.h"
 
@@ -32,4 +31,3 @@ public:
 };
 } // namespace VATES
 } // namespace Mantid
-#endif

--- a/qt/paraview_ext/VatesAPI/inc/MantidVatesAPI/vtkPeakMarkerFactory.h
+++ b/qt/paraview_ext/VatesAPI/inc/MantidVatesAPI/vtkPeakMarkerFactory.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_VATES_VTKPEAKMARKER_FACTORY_H_
-#define MANTID_VATES_VTKPEAKMARKER_FACTORY_H_
+#pragma once
 
 /**
   Create markers that will highlight the position of a Peak
@@ -92,5 +91,3 @@ private:
 };
 } // namespace VATES
 } // namespace Mantid
-
-#endif

--- a/qt/paraview_ext/VatesAPI/inc/MantidVatesAPI/vtkPolyDataAlgorithm_Silent.h
+++ b/qt/paraview_ext/VatesAPI/inc/MantidVatesAPI/vtkPolyDataAlgorithm_Silent.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef VTKPOLYDATAALGORITHM_SILENT_H
-#define VTKPOLYDATAALGORITHM_SILENT_H
+#pragma once
 
 #if defined(__GNUC__) && !(defined(__INTEL_COMPILER))
 #if (__GNUC__ >= 4 && __GNUC_MINOR__ >= 8)
@@ -19,5 +18,3 @@
 #pragma GCC diagnostic pop
 #endif
 #endif
-
-#endif // VTKPOLYDATAALGORITHM_SILENT_H

--- a/qt/paraview_ext/VatesAPI/inc/MantidVatesAPI/vtkRectilinearGrid_Silent.h
+++ b/qt/paraview_ext/VatesAPI/inc/MantidVatesAPI/vtkRectilinearGrid_Silent.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef VTKRECTILINEARGRID_SILENT_H
-#define VTKRECTILINEARGRID_SILENT_H
+#pragma once
 
 #if defined(__GNUC__) && !(defined(__INTEL_COMPILER))
 #if (__GNUC__ >= 4 && __GNUC_MINOR__ >= 6)
@@ -19,5 +18,3 @@
 #pragma GCC diagnostic pop
 #endif
 #endif
-
-#endif // VTKRECTILINEARGRID_SILENT_H

--- a/qt/paraview_ext/VatesAPI/inc/MantidVatesAPI/vtkSinglePeakMarker.h
+++ b/qt/paraview_ext/VatesAPI/inc/MantidVatesAPI/vtkSinglePeakMarker.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_VATES_SINGLEPEAKMARKER_H_
-#define MANTID_VATES_SINGLEPEAKMARKER_H_
+#pragma once
 
 #include "MantidKernel/System.h"
 /**
@@ -27,4 +26,3 @@ public:
 };
 } // namespace VATES
 } // namespace Mantid
-#endif

--- a/qt/paraview_ext/VatesAPI/inc/MantidVatesAPI/vtkSplatterPlotFactory.h
+++ b/qt/paraview_ext/VatesAPI/inc/MantidVatesAPI/vtkSplatterPlotFactory.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_VATES_vtkSplatterPlotFactory_H_
-#define MANTID_VATES_vtkSplatterPlotFactory_H_
+#pragma once
 
 #include "MantidAPI/IMDEventWorkspace_fwd.h"
 #include "MantidAPI/IMDHistoWorkspace_fwd.h"
@@ -147,5 +146,3 @@ private:
 };
 } // namespace VATES
 } // namespace Mantid
-
-#endif

--- a/qt/paraview_ext/VatesAPI/inc/MantidVatesAPI/vtkStructuredGrid_Silent.h
+++ b/qt/paraview_ext/VatesAPI/inc/MantidVatesAPI/vtkStructuredGrid_Silent.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef VTKSTRUCTUREDGRID_SILENT_H
-#define VTKSTRUCTUREDGRID_SILENT_H
+#pragma once
 
 #if defined(__GNUC__) && !(defined(__INTEL_COMPILER))
 #if (__GNUC__ >= 4 && __GNUC_MINOR__ >= 6)
@@ -19,5 +18,3 @@
 #pragma GCC diagnostic pop
 #endif
 #endif
-
-#endif // VTKSTRUCTUREDGRID_SILENT_H

--- a/qt/paraview_ext/VatesAPI/inc/MantidVatesAPI/vtkStructuredPoints_Silent.h
+++ b/qt/paraview_ext/VatesAPI/inc/MantidVatesAPI/vtkStructuredPoints_Silent.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef VTKSTRUCTUREDPOINTS_SILENT_H
-#define VTKSTRUCTUREDPOINTS_SILENT_H
+#pragma once
 
 #if defined(__GNUC__) && !(defined(__INTEL_COMPILER))
 #if (__GNUC__ >= 4 && __GNUC_MINOR__ >= 6)
@@ -19,5 +18,3 @@
 #pragma GCC diagnostic pop
 #endif
 #endif
-
-#endif // VTKSTRUCTUREDPOINTS_SILENT_H

--- a/qt/paraview_ext/VatesAPI/test/ADSWorkspaceProviderTest.h
+++ b/qt/paraview_ext/VatesAPI/test/ADSWorkspaceProviderTest.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef ADS_WORKSPACE_PROVIDER_TEST_H_
-#define ADS_WORKSPACE_PROVIDER_TEST_H_
+#pragma once
 
 #include "MantidAPI/AnalysisDataService.h"
 #include "MantidAPI/IMDEventWorkspace.h"
@@ -67,5 +66,3 @@ public:
                                wsProvider.fetchWorkspace("WS"));
   }
 };
-
-#endif

--- a/qt/paraview_ext/VatesAPI/test/BoxInfoTest.h
+++ b/qt/paraview_ext/VatesAPI/test/BoxInfoTest.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef VATES_API_BOX_INFO_TEST_H_
-#define VATES_API_BOX_INFO_TEST_H_
+#pragma once
 
 #include <cxxtest/TestSuite.h>
 
@@ -84,5 +83,3 @@ public:
     AnalysisDataService::Instance().remove(wsName);
   }
 };
-
-#endif

--- a/qt/paraview_ext/VatesAPI/test/CompositePeaksPresenterVsiTest.h
+++ b/qt/paraview_ext/VatesAPI/test/CompositePeaksPresenterVsiTest.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef COMOPOSITE_PEAKS_PRESENTER_VSI_TEST_H_
-#define COMOPOSITE_PEAKS_PRESENTER_VSI_TEST_H_
+#pragma once
 
 #include "MantidAPI/IPeaksWorkspace.h"
 #include "MantidDataObjects/PeaksWorkspace.h"
@@ -130,5 +129,3 @@ public:
     TSM_ASSERT_EQUALS("Should have two entries", ws.size(), 2);
   }
 };
-
-#endif

--- a/qt/paraview_ext/VatesAPI/test/ConcretePeaksPresenterVsiTest.h
+++ b/qt/paraview_ext/VatesAPI/test/ConcretePeaksPresenterVsiTest.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef CONCRETE_PEAKS_PRESENTER_VSI_TEST_H_
-#define CONCRETE_PEAKS_PRESENTER_VSI_TEST_H_
+#pragma once
 
 #include "MantidAPI/IPeaksWorkspace.h"
 #include "MantidDataObjects/NoShape.h"
@@ -119,5 +118,3 @@ public:
     TSM_ASSERT_EQUALS("Should have the same coordinate", coord, coordinate);
   }
 };
-
-#endif

--- a/qt/paraview_ext/VatesAPI/test/EventNexusLoadingPresenterTest.h
+++ b/qt/paraview_ext/VatesAPI/test/EventNexusLoadingPresenterTest.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef EVENT_NEXUS_LOADING_PRESENTER_TEST_H_
-#define EVENT_NEXUS_LOADING_PRESENTER_TEST_H_
+#pragma once
 
 #include <cxxtest/TestSuite.h>
 #include <vtkSmartPointer.h>
@@ -152,4 +151,3 @@ public:
                       presenter.getWorkspaceTypeName());
   }
 };
-#endif

--- a/qt/paraview_ext/VatesAPI/test/FieldDataToMetadataTest.h
+++ b/qt/paraview_ext/VatesAPI/test/FieldDataToMetadataTest.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef FIELDDATATOMETADATATEST_H_
-#define FIELDDATATOMETADATATEST_H_
+#pragma once
 
 #include "MantidVatesAPI/FieldDataToMetadata.h"
 #include <cxxtest/TestSuite.h>
@@ -81,5 +80,3 @@ public:
                       const std::runtime_error &);
   }
 };
-
-#endif

--- a/qt/paraview_ext/VatesAPI/test/FilteringUpdateProgressActionTest.h
+++ b/qt/paraview_ext/VatesAPI/test/FilteringUpdateProgressActionTest.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef FILTERING_UPDATE_PROGRESS_ACTION_TEST
-#define FILTERING_UPDATE_PROGRESS_ACTION_TEST
+#pragma once
 
 #include "MantidVatesAPI/FilteringUpdateProgressAction.h"
 #include <cxxtest/TestSuite.h>
@@ -55,4 +54,3 @@ public:
         "message", view.Message);
   }
 };
-#endif

--- a/qt/paraview_ext/VatesAPI/test/MDEWEventNexusLoadingPresenterTest.h
+++ b/qt/paraview_ext/VatesAPI/test/MDEWEventNexusLoadingPresenterTest.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MDEW_EVENT_NEXUS_LOADING_PRESENTER_TEST_H_
-#define MDEW_EVENT_NEXUS_LOADING_PRESENTER_TEST_H_
+#pragma once
 
 #include <cxxtest/TestSuite.h>
 #include <vtkSmartPointer.h>
@@ -231,4 +230,3 @@ public:
     TS_ASSERT(Mock::VerifyAndClearExpectations(&factory));
   }
 };
-#endif

--- a/qt/paraview_ext/VatesAPI/test/MDEWInMemoryLoadingPresenterTest.h
+++ b/qt/paraview_ext/VatesAPI/test/MDEWInMemoryLoadingPresenterTest.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MDEW_IN_MEMORY_LOADING_PRESENTER_TEST_H
-#define MDEW_IN_MEMORY_LOADING_PRESENTER_TEST_H
+#pragma once
 
 #include "MantidAPI/FileFinder.h"
 #include "MockObjects.h"
@@ -249,5 +248,3 @@ public:
                       presenter.getSpecialCoordinates());
   }
 };
-
-#endif

--- a/qt/paraview_ext/VatesAPI/test/MDEWLoadingPresenterTest.h
+++ b/qt/paraview_ext/VatesAPI/test/MDEWLoadingPresenterTest.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MDEW_LOADING_PRESENTER_TEST_H_
-#define MDEW_LOADING_PRESENTER_TEST_H_
+#pragma once
 
 #include <cxxtest/TestSuite.h>
 #include <vtkSmartPointer.h>
@@ -253,5 +252,3 @@ public:
                !presenter.canLoadFileBasedOnExtension("somefile.nx", ".nxs"));
   }
 };
-
-#endif

--- a/qt/paraview_ext/VatesAPI/test/MDHWInMemoryLoadingPresenterTest.h
+++ b/qt/paraview_ext/VatesAPI/test/MDHWInMemoryLoadingPresenterTest.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MDHW_IN_MEMORY_LOADING_PRESENTER_TEST_H
-#define MDHW_IN_MEMORY_LOADING_PRESENTER_TEST_H
+#pragma once
 
 #include "MockObjects.h"
 #include <cxxtest/TestSuite.h>
@@ -245,5 +244,3 @@ public:
                       presenter.getSpecialCoordinates());
   }
 };
-
-#endif

--- a/qt/paraview_ext/VatesAPI/test/MDHWLoadingPresenterTest.h
+++ b/qt/paraview_ext/VatesAPI/test/MDHWLoadingPresenterTest.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MDHW_LOADING_PRESENTER_TEST_H_
-#define MDHW_LOADING_PRESENTER_TEST_H_
+#pragma once
 
 #include <cxxtest/TestSuite.h>
 #include <vtkUnstructuredGrid.h>
@@ -288,5 +287,3 @@ public:
                       inWs->getDimension(2)->getName());
   }
 };
-
-#endif

--- a/qt/paraview_ext/VatesAPI/test/MDHWNexusLoadingPresenterTest.h
+++ b/qt/paraview_ext/VatesAPI/test/MDHWNexusLoadingPresenterTest.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MDHW_NEXUS_LOADING_PRESENTER_TEST_H_
-#define MDHW_NEXUS_LOADING_PRESENTER_TEST_H_
+#pragma once
 
 #include "MantidVatesAPI/ADSWorkspaceProvider.h"
 #include "MantidVatesAPI/TimeToTimeStep.h"
@@ -352,4 +351,3 @@ public:
     TS_ASSERT(Mock::VerifyAndClearExpectations(&factory));
   }
 };
-#endif

--- a/qt/paraview_ext/VatesAPI/test/MDLoadingPresenterTest.h
+++ b/qt/paraview_ext/VatesAPI/test/MDLoadingPresenterTest.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef VATES_API_MD_LOADING_PRESENTER_TEST_H
-#define VATES_API_MD_LOADING_PRESENTER_TEST_H
+#pragma once
 
 #include "MantidTestHelpers/MDEventsTestHelper.h"
 #include "MantidVatesAPI/MDLoadingPresenter.h"
@@ -109,5 +108,3 @@ public:
     TS_ASSERT_EQUALS(10.0, bounds[5]);
   }
 };
-
-#endif

--- a/qt/paraview_ext/VatesAPI/test/MDLoadingViewAdapterTest.h
+++ b/qt/paraview_ext/VatesAPI/test/MDLoadingViewAdapterTest.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MD_LOADING_VIEW_ADAPTER_TEST_H
-#define MD_LOADING_VIEW_ADAPTER_TEST_H
+#pragma once
 
 #include "MantidVatesAPI/MDLoadingViewAdapter.h"
 
@@ -43,5 +42,3 @@ public:
                Mock::VerifyAndClearExpectations(&view));
   }
 };
-
-#endif

--- a/qt/paraview_ext/VatesAPI/test/MDLoadingViewSimpleTest.h
+++ b/qt/paraview_ext/VatesAPI/test/MDLoadingViewSimpleTest.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MD_LOADING_VIEW_SIMPLE_TEST_H
-#define MD_LOADING_VIEW_SIMPLE_TEST_H
+#pragma once
 
 #include "MantidVatesAPI/MDLoadingViewSimple.h"
 
@@ -45,5 +44,3 @@ public:
                       view.getLoadInMemory(), loadingInMemory);
   }
 };
-
-#endif

--- a/qt/paraview_ext/VatesAPI/test/MetaDataExtractorUtilsTest.h
+++ b/qt/paraview_ext/VatesAPI/test/MetaDataExtractorUtilsTest.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef METADATAEXTRACTORUTILS_TEST_H
-#define METADATAEXTRACTORUTILS_TEST_H
+#pragma once
 
 #ifdef _MSC_VER
 // Disabling Json warnings regarding non-export of Json::Reader and Json::Writer
@@ -68,5 +67,3 @@ public:
                instrument.empty())
   }
 };
-
-#endif

--- a/qt/paraview_ext/VatesAPI/test/MetadataJsonManagerTest.h
+++ b/qt/paraview_ext/VatesAPI/test/MetadataJsonManagerTest.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef METADATA_JSON_MANAGER_TEST
-#define METADATA_JSON_MANAGER_TEST
+#pragma once
 
 #ifdef _MSC_VER
 // Disabling Json warnings regarding non-export of Json::Reader and Json::Writer
@@ -93,4 +92,3 @@ public:
                       container["instrument"].asString());
   }
 };
-#endif

--- a/qt/paraview_ext/VatesAPI/test/MetadataToFieldDataTest.h
+++ b/qt/paraview_ext/VatesAPI/test/MetadataToFieldDataTest.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef METADATATOFIELDDATATEST_H_
-#define METADATATOFIELDDATATEST_H_
+#pragma once
 
 #include "MantidVatesAPI/MetadataToFieldData.h"
 #include <boost/algorithm/string.hpp>
@@ -70,5 +69,3 @@ public:
         testData, convertCharArrayToString(carry));
   }
 };
-
-#endif

--- a/qt/paraview_ext/VatesAPI/test/MockObjects.h
+++ b/qt/paraview_ext/VatesAPI/test/MockObjects.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef VATESAPI_TEST_MOCKOBJECTS_H
-#define VATESAPI_TEST_MOCKOBJECTS_H
+#pragma once
 
 //#include "MantidMDAlgorithms/CreateMDWorkspace.h"
 #include "MantidAPI/AlgorithmManager.h"
@@ -460,5 +459,3 @@ GNU_UNUSED_FUNCTION std::string getStringFieldDataValue(vtkDataSet *ds,
 }
 
 } // namespace
-
-#endif

--- a/qt/paraview_ext/VatesAPI/test/NormalizationTest.h
+++ b/qt/paraview_ext/VatesAPI/test/NormalizationTest.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef NORMALIZATIONTEST_H_
-#define NORMALIZATIONTEST_H_
+#pragma once
 
 #include "MantidAPI/IMDWorkspace.h"
 #include "MantidVatesAPI/Normalization.h"
@@ -26,5 +25,3 @@ public:
                      static_cast<int>(Mantid::VATES::NumEventsNormalization));
   }
 };
-
-#endif

--- a/qt/paraview_ext/VatesAPI/test/NullPeaksPresenterVsiTest.h
+++ b/qt/paraview_ext/VatesAPI/test/NullPeaksPresenterVsiTest.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef NULL_PEAKS_PRESENTER_VSI_TEST_H_
-#define NULL_PEAKS_PRESENTER_VSI_TEST_H_
+#pragma once
 
 #include "MantidAPI/IPeaksWorkspace.h"
 #include "MantidKernel/SpecialCoordinateSystem.h"
@@ -51,4 +50,3 @@ public:
         const std::runtime_error &);
   }
 };
-#endif

--- a/qt/paraview_ext/VatesAPI/test/PrecompiledHeader.h
+++ b/qt/paraview_ext/VatesAPI/test/PrecompiledHeader.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef VATESAPITEST_PRECOMPILEDHEADER_H_
-#define VATESAPITEST_PRECOMPILEDHEADER_H_
+#pragma once
 
 // cxxtest
 #include <cxxtest/WrappedTestSuite.h>
@@ -14,5 +13,3 @@
 #include <set>
 #include <string>
 #include <vector>
-
-#endif // VATESAPITEST_PRECOMPILEDHEADER_H_

--- a/qt/paraview_ext/VatesAPI/test/PresenterUtilitiesTest.h
+++ b/qt/paraview_ext/VatesAPI/test/PresenterUtilitiesTest.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef VATES_API_PRESENTER_UTILITIES_TEST_H_
-#define VATES_API_PRESENTER_UTILITIES_TEST_H_
+#pragma once
 
 #include "MantidVatesAPI/FactoryChains.h"
 #include <cxxtest/TestSuite.h>
@@ -24,4 +23,3 @@ public:
                timeStampedName.find(name) == 0);
   }
 };
-#endif

--- a/qt/paraview_ext/VatesAPI/test/SQWLoadingPresenterTest.h
+++ b/qt/paraview_ext/VatesAPI/test/SQWLoadingPresenterTest.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef SQW_LOADING_PRESENTER_TEST_H_
-#define SQW_LOADING_PRESENTER_TEST_H_
+#pragma once
 
 #include <cxxtest/TestSuite.h>
 #include <vtkSmartPointer.h>
@@ -281,5 +280,3 @@ public:
                Mock::VerifyAndClearExpectations(&mockLoadingProgressAction));
   }
 };
-
-#endif

--- a/qt/paraview_ext/VatesAPI/test/SingleWorkspaceProviderTest.h
+++ b/qt/paraview_ext/VatesAPI/test/SingleWorkspaceProviderTest.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef VATES_API_SINGLE_WORKSPACE_PROVIDER_TEST_H_
-#define VATES_API_SINGLE_WORKSPACE_PROVIDER_TEST_H_
+#pragma once
 
 #include "MantidAPI/IMDHistoWorkspace.h"
 #include "MantidTestHelpers/MDEventsTestHelper.h"
@@ -49,5 +48,3 @@ public:
                    fetchedWorkspace));
   }
 };
-
-#endif

--- a/qt/paraview_ext/VatesAPI/test/TimeStepToTimeStepTest.h
+++ b/qt/paraview_ext/VatesAPI/test/TimeStepToTimeStepTest.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef TIMESTEP_TO_TIMESTEP_TEST_H_
-#define TIMESTEP_TO_TIMESTEP_TEST_H_
+#pragma once
 
 #include "MantidVatesAPI/TimeStepToTimeStep.h"
 #include <cxxtest/TestSuite.h>
@@ -22,5 +21,3 @@ public:
         proxy(argument));
   }
 };
-
-#endif

--- a/qt/paraview_ext/VatesAPI/test/TimeToTimeStepTest.h
+++ b/qt/paraview_ext/VatesAPI/test/TimeToTimeStepTest.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef TIME_TO_TIMESTEP_TEST_H_
-#define TIME_TO_TIMESTEP_TEST_H_
+#pragma once
 
 #include "MantidVatesAPI/TimeToTimeStep.h"
 #include <cxxtest/TestSuite.h>
@@ -116,5 +115,3 @@ public:
         converter(1), const std::runtime_error &);
   }
 };
-
-#endif

--- a/qt/paraview_ext/VatesAPI/test/VatesKnowledgeSerializerTest.h
+++ b/qt/paraview_ext/VatesAPI/test/VatesKnowledgeSerializerTest.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef REBINNING_XML_GENERATOR_TEST_H
-#define REBINNING_XML_GENERATOR_TEST_H
+#pragma once
 
 #include "MantidAPI/AnalysisDataService.h"
 #include "MantidAPI/IMDWorkspace.h"
@@ -172,5 +171,3 @@ public:
                       true, withFullGeometryAndWSInfo.hasGeometryInfo());
   }
 };
-
-#endif

--- a/qt/paraview_ext/VatesAPI/test/ViewFrustumTest.h
+++ b/qt/paraview_ext/VatesAPI/test/ViewFrustumTest.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef VIEWFRUSTUM_TEST_H_
-#define VIEWFRUSTUM_TEST_H_
+#pragma once
 
 #include "MantidVatesAPI/ViewFrustum.h"
 #include <cxxtest/TestSuite.h>
@@ -106,5 +105,3 @@ public:
                       frustum.toExtents(), const std::runtime_error &);
   }
 };
-
-#endif

--- a/qt/paraview_ext/VatesAPI/test/vtkDataSetFactoryTest.h
+++ b/qt/paraview_ext/VatesAPI/test/vtkDataSetFactoryTest.h
@@ -5,8 +5,7 @@
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
 
-#ifndef VTKDATASETFACTORYTEST_H_
-#define VTKDATASETFACTORYTEST_H_
+#pragma once
 
 #include "MantidAPI/IMDHistoWorkspace.h"
 #include "MantidAPI/IMDWorkspace.h"
@@ -132,5 +131,3 @@ public:
     TS_ASSERT(Mock::VerifyAndClearExpectations(&factory));
   }
 };
-
-#endif

--- a/qt/paraview_ext/VatesAPI/test/vtkDataSetToGeometryTest.h
+++ b/qt/paraview_ext/VatesAPI/test/vtkDataSetToGeometryTest.h
@@ -5,8 +5,7 @@
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
 
-#ifndef VTKDATASET_TO_GEOMETRY_TEST_H_
-#define VTKDATASET_TO_GEOMETRY_TEST_H_
+#pragma once
 
 #include "MantidVatesAPI/vtkDataSetToGeometry.h"
 
@@ -317,5 +316,3 @@ public:
         A.getNonMappedDimensions().size(), B.getNonMappedDimensions().size());
   }
 };
-
-#endif

--- a/qt/paraview_ext/VatesAPI/test/vtkDataSetToImplicitFunctionTest.h
+++ b/qt/paraview_ext/VatesAPI/test/vtkDataSetToImplicitFunctionTest.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef VTK_DATASET_TO_WS_IMPLICITFUNCTION_TEST
-#define VTK_DATASET_TO_WS_IMPLICITFUNCTION_TEST
+#pragma once
 
 #include "MantidGeometry/MDGeometry/MDImplicitFunction.h"
 #include "MantidVatesAPI/vtkDataSetToImplicitFunction.h"
@@ -52,5 +51,3 @@ public:
     TS_ASSERT_EQUALS("NullImplicitFunction", func->getName());
   }
 };
-
-#endif

--- a/qt/paraview_ext/VatesAPI/test/vtkDataSetToNonOrthogonalDataSetTest.h
+++ b/qt/paraview_ext/VatesAPI/test/vtkDataSetToNonOrthogonalDataSetTest.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_VATES_VTKDATASETTONONORTHOGONALDATASETTEST_H_
-#define MANTID_VATES_VTKDATASETTONONORTHOGONALDATASETTEST_H_
+#pragma once
 
 #include "MantidAPI/AlgorithmManager.h"
 #include "MantidAPI/ExperimentInfo.h"
@@ -385,5 +384,3 @@ public:
     TS_ASSERT_DELTA(basisMatrix[index++], 1.0, eps);
   }
 };
-
-#endif /* MANTID_VATESAPI_VTKDATASETTONONORTHOGONALDATASETTEST_H_ */

--- a/qt/paraview_ext/VatesAPI/test/vtkDataSetToPeaksFilteredDataSetTest.h
+++ b/qt/paraview_ext/VatesAPI/test/vtkDataSetToPeaksFilteredDataSetTest.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_VATESAPI_VTKDATASETTOPEAKSFILTEREDDATASETTEST_H_
-#define MANTID_VATESAPI_VTKDATASETTOPEAKSFILTEREDDATASETTEST_H_
+#pragma once
 
 #include "MantidAPI/IPeaksWorkspace.h"
 #include "MantidDataObjects/NoShape.h"
@@ -392,4 +391,3 @@ public:
     do_test_peaks(in, out, peakData);
   }
 };
-#endif

--- a/qt/paraview_ext/VatesAPI/test/vtkDataSetToScaledDataSetTest.h
+++ b/qt/paraview_ext/VatesAPI/test/vtkDataSetToScaledDataSetTest.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_VATESAPI_VTKDATASETTOSCALEDDATASETTEST_H_
-#define MANTID_VATESAPI_VTKDATASETTOSCALEDDATASETTEST_H_
+#pragma once
 
 #include "MantidAPI/IMDWorkspace.h"
 #include "MantidTestHelpers/MDEventsTestHelper.h"
@@ -224,5 +223,3 @@ public:
     TS_ASSERT_EQUALS(10.0, bounds[5]);
   }
 };
-
-#endif /* MANTID_VATESAPI_VTKDATASETTOSCALEDDATASETTEST_H_ */

--- a/qt/paraview_ext/VatesAPI/test/vtkDataSetToWsLocationTest.h
+++ b/qt/paraview_ext/VatesAPI/test/vtkDataSetToWsLocationTest.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef VTK_DATASET_TO_WS_LOCATION_TEST
-#define VTK_DATASET_TO_WS_LOCATION_TEST
+#pragma once
 
 #include "MantidVatesAPI/vtkDataSetToWsLocation.h"
 #include "MantidVatesAPI/vtkStructuredGrid_Silent.h"
@@ -54,5 +53,3 @@ public:
                      vtkDataSetToWsLocation::exec(ds.GetPointer()));
   }
 };
-
-#endif

--- a/qt/paraview_ext/VatesAPI/test/vtkDataSetToWsNameTest.h
+++ b/qt/paraview_ext/VatesAPI/test/vtkDataSetToWsNameTest.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef VTK_DATASET_TO_WS_NAME_TEST
-#define VTK_DATASET_TO_WS_NAME_TEST
+#pragma once
 
 #include "MantidVatesAPI/vtkDataSetToWsName.h"
 #include "MantidVatesAPI/vtkStructuredGrid_Silent.h"
@@ -52,5 +51,3 @@ public:
     TS_ASSERT_EQUALS("WS_NAME", vtkDataSetToWsName::exec(ds.GetPointer()));
   }
 };
-
-#endif

--- a/qt/paraview_ext/VatesAPI/test/vtkMD0DFactoryTest.h
+++ b/qt/paraview_ext/VatesAPI/test/vtkMD0DFactoryTest.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef VTK_MD_0D_FACTORY_TEST
-#define VTK_MD_0D_FACTORY_TEST
+#pragma once
 #include <cxxtest/TestSuite.h>
 
 #include "MantidVatesAPI/vtkMD0DFactory.h"
@@ -32,5 +31,3 @@ public:
                dataSet->GetNumberOfCells() == 1);
   }
 };
-
-#endif

--- a/qt/paraview_ext/VatesAPI/test/vtkMDHWSignalArrayTest.h
+++ b/qt/paraview_ext/VatesAPI/test/vtkMDHWSignalArrayTest.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef VTKNULLMDHWSIGNALARRAY_TEST_H_
-#define VTKNULLMDHWSIGNALARRAY_TEST_H_
+#pragma once
 
 #include "MantidDataObjects/MDHistoWorkspace.h"
 #include "MantidDataObjects/MDHistoWorkspaceIterator.h"
@@ -233,5 +232,3 @@ public:
     }
   }
 };
-
-#endif

--- a/qt/paraview_ext/VatesAPI/test/vtkMDHexFactoryTest.h
+++ b/qt/paraview_ext/VatesAPI/test/vtkMDHexFactoryTest.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef VTK_MD_HEX_FACTORY_TEST
-#define VTK_MD_HEX_FACTORY_TEST
+#pragma once
 
 #include "MantidAPI/AnalysisDataService.h"
 #include "MantidAPI/IMDEventWorkspace.h"
@@ -380,5 +379,3 @@ public:
                       product->GetCellData()->GetArray(0)->GetSize());
   }
 };
-
-#endif

--- a/qt/paraview_ext/VatesAPI/test/vtkMDHistoHex4DFactoryTest.h
+++ b/qt/paraview_ext/VatesAPI/test/vtkMDHistoHex4DFactoryTest.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef VTK_MD_HEX_4D_FACTORY_TEST_H_
-#define VTK_MD_HEX_4D_FACTORY_TEST_H_
+#pragma once
 
 #include "MantidAPI/IMDWorkspace.h"
 #include "MantidDataObjects/MDHistoWorkspace.h"
@@ -226,5 +225,3 @@ public:
     TS_ASSERT_THROWS_NOTHING(factory.create(progressUpdate));
   }
 };
-
-#endif

--- a/qt/paraview_ext/VatesAPI/test/vtkMDHistoHexFactoryTest.h
+++ b/qt/paraview_ext/VatesAPI/test/vtkMDHistoHexFactoryTest.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef VTK_MD_HISTO_HEX_FACTORY_TEST_H_
-#define VTK_MD_HISTO_HEX_FACTORY_TEST_H_
+#pragma once
 
 #include "MantidDataObjects/MDHistoWorkspace.h"
 
@@ -210,5 +209,3 @@ public:
     TS_ASSERT_THROWS_NOTHING(factory.create(progressUpdate));
   }
 };
-
-#endif

--- a/qt/paraview_ext/VatesAPI/test/vtkMDHistoLineFactoryTest.h
+++ b/qt/paraview_ext/VatesAPI/test/vtkMDHistoLineFactoryTest.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef VTK_MD_HISTO_LINE_FACTORY_TEST_H_
-#define VTK_MD_HISTO_LINE_FACTORY_TEST_H_
+#pragma once
 
 #include "MantidAPI/IMDIterator.h"
 
@@ -179,5 +178,3 @@ public:
     TS_ASSERT_THROWS_NOTHING(factory.create(progressUpdate));
   }
 };
-
-#endif

--- a/qt/paraview_ext/VatesAPI/test/vtkMDHistoQuadFactoryTest.h
+++ b/qt/paraview_ext/VatesAPI/test/vtkMDHistoQuadFactoryTest.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef VTK_MD_QUAD_FACTORY_TEST_H_
-#define VTK_MD_QUAD_FACTORY_TEST_H_
+#pragma once
 
 #include "MantidAPI/IMDIterator.h"
 
@@ -202,5 +201,3 @@ public:
     TS_ASSERT_THROWS_NOTHING(factory.create(progressUpdate));
   }
 };
-
-#endif

--- a/qt/paraview_ext/VatesAPI/test/vtkMDLineFactoryTest.h
+++ b/qt/paraview_ext/VatesAPI/test/vtkMDLineFactoryTest.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef VTK_MD_LINE_FACTORY_TEST
-#define VTK_MD_LINE_FACTORY_TEST
+#pragma once
 
 #include "MantidAPI/AnalysisDataService.h"
 #include "MantidDataObjects/TableWorkspace.h"
@@ -172,5 +171,3 @@ public:
     TS_ASSERT_EQUALS(400000, product->GetNumberOfPoints());
   }
 };
-
-#endif

--- a/qt/paraview_ext/VatesAPI/test/vtkMDQuadFactoryTest.h
+++ b/qt/paraview_ext/VatesAPI/test/vtkMDQuadFactoryTest.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef VTK_MD_QUAD_FACTORY_TEST
-#define VTK_MD_QUAD_FACTORY_TEST
+#pragma once
 
 #include "MantidAPI/AnalysisDataService.h"
 #include "MantidDataObjects/TableWorkspace.h"
@@ -175,5 +174,3 @@ public:
     TS_ASSERT_EQUALS(640000, product->GetNumberOfPoints());
   }
 };
-
-#endif

--- a/qt/paraview_ext/VatesAPI/test/vtkNullStructuredGridTest.h
+++ b/qt/paraview_ext/VatesAPI/test/vtkNullStructuredGridTest.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef VTKNULLSTRUCTUREDGRID_TEST_H_
-#define VTKNULLSTRUCTUREDGRID_TEST_H_
+#pragma once
 
 #include "MantidVatesAPI/vtkNullStructuredGrid.h"
 #include "MockObjects.h"
@@ -39,4 +38,3 @@ public:
     TSM_ASSERT("X should be in the center", coord[2] == 0.0);
   }
 };
-#endif

--- a/qt/paraview_ext/VatesAPI/test/vtkNullUnstructuredGridTest.h
+++ b/qt/paraview_ext/VatesAPI/test/vtkNullUnstructuredGridTest.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef VTKNULLUNSTRUCTUREDGRID_TEST_H_
-#define VTKNULLUNSTRUCTUREDGRID_TEST_H_
+#pragma once
 
 #include "MantidVatesAPI/vtkNullUnstructuredGrid.h"
 #include "MockObjects.h"
@@ -39,4 +38,3 @@ public:
     TSM_ASSERT("X should be in the center", coord[2] == 0.0);
   }
 };
-#endif

--- a/qt/paraview_ext/VatesAPI/test/vtkPeakMarkerFactoryTest.h
+++ b/qt/paraview_ext/VatesAPI/test/vtkPeakMarkerFactoryTest.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef VTKPEAKMARKERFACTORY_TEST_H_
-#define VTKPEAKMARKERFACTORY_TEST_H_
+#pragma once
 
 #include "MantidAPI/IPeaksWorkspace.h"
 #include "MantidAPI/Run.h"
@@ -324,5 +323,3 @@ public:
     }
   }
 };
-
-#endif

--- a/qt/paraview_ext/VatesAPI/test/vtkSplatterPlotFactoryTest.h
+++ b/qt/paraview_ext/VatesAPI/test/vtkSplatterPlotFactoryTest.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef VTK_SPLATTERPLOT_FACTORY_TEST
-#define VTK_SPLATTERPLOT_FACTORY_TEST
+#pragma once
 
 #include "MantidAPI/IMDEventWorkspace.h"
 #include "MantidDataObjects/MDEventFactory.h"
@@ -238,5 +237,3 @@ public:
                manager.getInstrument().empty());
   }
 };
-
-#endif

--- a/qt/paraview_ext/VatesAlgorithms/inc/MantidVatesAlgorithms/LoadVTK.h
+++ b/qt/paraview_ext/VatesAlgorithms/inc/MantidVatesAlgorithms/LoadVTK.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef LOADVTK_H_
-#define LOADVTK_H_
+#pragma once
 
 #include "MantidAPI/IFileLoader.h"
 #include "MantidDataObjects/MDEventWorkspace.h"
@@ -60,5 +59,3 @@ private:
 };
 } // namespace VATES
 } // namespace Mantid
-
-#endif

--- a/qt/paraview_ext/VatesAlgorithms/inc/MantidVatesAlgorithms/SaveMDWorkspaceToVTK.h
+++ b/qt/paraview_ext/VatesAlgorithms/inc/MantidVatesAlgorithms/SaveMDWorkspaceToVTK.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef VATES_API_SAVE_MD_WORKSPACE_TO_VTK_H_
-#define VATES_API_SAVE_MD_WORKSPACE_TO_VTK_H_
+#pragma once
 #include "MantidAPI/Algorithm.h"
 #include "MantidKernel/System.h"
 #include <map>
@@ -38,4 +37,3 @@ private:
 };
 } // namespace VATES
 } // namespace Mantid
-#endif

--- a/qt/paraview_ext/VatesAlgorithms/inc/MantidVatesAlgorithms/SaveMDWorkspaceToVTKImpl.h
+++ b/qt/paraview_ext/VatesAlgorithms/inc/MantidVatesAlgorithms/SaveMDWorkspaceToVTKImpl.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef VATES_API_SAVE_MD_WORKSPACE_TO_VTK_IMPL_H_
-#define VATES_API_SAVE_MD_WORKSPACE_TO_VTK_IMPL_H_
+#pragma once
 
 #include "MantidAPI/IMDWorkspace.h"
 #include "MantidAPI/Progress.h"
@@ -71,5 +70,3 @@ private:
 };
 } // namespace VATES
 } // namespace Mantid
-
-#endif

--- a/qt/paraview_ext/VatesAlgorithms/test/LoadVTKTest.h
+++ b/qt/paraview_ext/VatesAlgorithms/test/LoadVTKTest.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef LOADVTK_TEST_H_
-#define LOADVTK_TEST_H_
+#pragma once
 
 #include "MantidAPI/AlgorithmManager.h"
 #include "MantidAPI/AnalysisDataService.h"
@@ -202,5 +201,3 @@ public:
             outWSName));
   }
 };
-
-#endif

--- a/qt/paraview_ext/VatesAlgorithms/test/SaveMDWorkspaceToVTKImplTest.h
+++ b/qt/paraview_ext/VatesAlgorithms/test/SaveMDWorkspaceToVTKImplTest.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef VATES_API_SAVE_MD_WORKSPACE_TO_VTK_IMPL_TEST_H_
-#define VATES_API_SAVE_MD_WORKSPACE_TO_VTK_IMPL_TEST_H_
+#pragma once
 
 #include "MantidKernel/ConfigService.h"
 #include "MantidTestHelpers/MDEventsTestHelper.h"
@@ -220,4 +219,3 @@ private:
     return Poco::File(filename).exists();
   }
 };
-#endif

--- a/qt/paraview_ext/VatesAlgorithms/test/SaveMDWorkspaceToVTKTest.h
+++ b/qt/paraview_ext/VatesAlgorithms/test/SaveMDWorkspaceToVTKTest.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef VATES_API_SAVE_MD_WORKSPACE_TO_VTK_TEST_H_
-#define VATES_API_SAVE_MD_WORKSPACE_TO_VTK_TEST_H_
+#pragma once
 
 #include "MantidTestHelpers/MDEventsTestHelper.h"
 #include "MantidTestHelpers/WorkspaceCreationHelper.h"
@@ -119,4 +118,3 @@ private:
     return Poco::File(filename).exists();
   }
 };
-#endif

--- a/qt/paraview_ext/VatesSimpleGui/QtWidgets/inc/MantidVatesSimpleGuiQtWidgets/AxisInformation.h
+++ b/qt/paraview_ext/VatesSimpleGui/QtWidgets/inc/MantidVatesSimpleGuiQtWidgets/AxisInformation.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef AXISINFORMATION_H_
-#define AXISINFORMATION_H_
+#pragma once
 
 #include "MantidVatesSimpleGuiQtWidgets/WidgetDllOption.h"
 
@@ -68,5 +67,3 @@ private:
 } // namespace SimpleGui
 } // namespace Vates
 } // namespace Mantid
-
-#endif // AXISINFORMATION_H_

--- a/qt/paraview_ext/VatesSimpleGui/QtWidgets/inc/MantidVatesSimpleGuiQtWidgets/GeometryParser.h
+++ b/qt/paraview_ext/VatesSimpleGui/QtWidgets/inc/MantidVatesSimpleGuiQtWidgets/GeometryParser.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef GEOMETRYPARSER_H_
-#define GEOMETRYPARSER_H_
+#pragma once
 
 #include "MantidVatesSimpleGuiQtWidgets/WidgetDllOption.h"
 
@@ -62,5 +61,3 @@ private:
 } // namespace SimpleGui
 } // namespace Vates
 } // namespace Mantid
-
-#endif // GEOMETRYPARSER_H_

--- a/qt/paraview_ext/VatesSimpleGui/QtWidgets/inc/MantidVatesSimpleGuiQtWidgets/ModeControlWidget.h
+++ b/qt/paraview_ext/VatesSimpleGui/QtWidgets/inc/MantidVatesSimpleGuiQtWidgets/ModeControlWidget.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MODECONTROLWIDGET_H_
-#define MODECONTROLWIDGET_H_
+#pragma once
 
 #include "MantidVatesSimpleGuiQtWidgets/WidgetDllOption.h"
 #include "ui_ModeControlWidget.h"
@@ -97,5 +96,3 @@ private:
 } // namespace SimpleGui
 } // namespace Vates
 } // namespace Mantid
-
-#endif // MODECONTROLWIDGET_H_

--- a/qt/paraview_ext/VatesSimpleGui/QtWidgets/inc/MantidVatesSimpleGuiQtWidgets/RotationPointDialog.h
+++ b/qt/paraview_ext/VatesSimpleGui/QtWidgets/inc/MantidVatesSimpleGuiQtWidgets/RotationPointDialog.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef ROTATIONPOINTDIALOG_H
-#define ROTATIONPOINTDIALOG_H
+#pragma once
 
 #include "MantidVatesSimpleGuiQtWidgets/WidgetDllOption.h"
 #include "ui_RotationPointDialog.h"
@@ -50,5 +49,3 @@ private:
 } // namespace SimpleGui
 } // namespace Vates
 } // namespace Mantid
-
-#endif // ROTATIONPOINTDIALOG_H

--- a/qt/paraview_ext/VatesSimpleGui/QtWidgets/inc/MantidVatesSimpleGuiQtWidgets/WidgetDllOption.h
+++ b/qt/paraview_ext/VatesSimpleGui/QtWidgets/inc/MantidVatesSimpleGuiQtWidgets/WidgetDllOption.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTIDVATES_SIMPLEGUI_QTWIDGETS_DLLOPTION_H_
-#define MANTIDVATES_SIMPLEGUI_QTWIDGETS_DLLOPTION_H_
+#pragma once
 
 #include "MantidKernel/System.h"
 
@@ -14,5 +13,3 @@
 #else
 #define EXPORT_OPT_MANTIDVATES_SIMPLEGUI_QTWIDGETS DLLImport
 #endif // IN_MANTID_VATES_SIMPLEGUI_QTWIDGETS
-
-#endif // MANTIDVATES_SIMPLEGUI_QTWIDGETS_DLLOPTION_H_

--- a/qt/paraview_ext/VatesSimpleGui/ViewWidgets/inc/MantidVatesSimpleGuiViewWidgets/AutoScaleRangeGenerator.h
+++ b/qt/paraview_ext/VatesSimpleGui/ViewWidgets/inc/MantidVatesSimpleGuiViewWidgets/AutoScaleRangeGenerator.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef AUTOSCALERANGEGENERATOR_H
-#define AUTOSCALERANGEGENERATOR_H
+#pragma once
 
 /**
     Generates information for the color scale, e.g. minimum level, maximum
@@ -85,4 +84,3 @@ private:
 } // namespace SimpleGui
 } // namespace Vates
 } // namespace Mantid
-#endif

--- a/qt/paraview_ext/VatesSimpleGui/ViewWidgets/inc/MantidVatesSimpleGuiViewWidgets/BackgroundRgbProvider.h
+++ b/qt/paraview_ext/VatesSimpleGui/ViewWidgets/inc/MantidVatesSimpleGuiViewWidgets/BackgroundRgbProvider.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef BACKGROUNDRGB_PROVIDER_H_
-#define BACKGROUNDRGB_PROVIDER_H_
+#pragma once
 
 #include "MantidQtWidgets/Common/MdSettings.h"
 #include "MantidVatesSimpleGuiViewWidgets/WidgetDllOption.h"
@@ -98,4 +97,3 @@ private:
 } // namespace SimpleGui
 } // namespace Vates
 } // namespace Mantid
-#endif

--- a/qt/paraview_ext/VatesSimpleGui/ViewWidgets/inc/MantidVatesSimpleGuiViewWidgets/CameraManager.h
+++ b/qt/paraview_ext/VatesSimpleGui/ViewWidgets/inc/MantidVatesSimpleGuiViewWidgets/CameraManager.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef CAMERAMANAGER_H_
-#define CAMERAMANAGER_H_
+#pragma once
 
 #include "MantidVatesAPI/ViewFrustum.h"
 #include "MantidVatesSimpleGuiViewWidgets/WidgetDllOption.h"
@@ -34,5 +33,3 @@ public:
 } // namespace SimpleGui
 } // namespace Vates
 } // namespace Mantid
-
-#endif

--- a/qt/paraview_ext/VatesSimpleGui/ViewWidgets/inc/MantidVatesSimpleGuiViewWidgets/ColorMapEditorPanel.h
+++ b/qt/paraview_ext/VatesSimpleGui/ViewWidgets/inc/MantidVatesSimpleGuiViewWidgets/ColorMapEditorPanel.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef COLORMAPEDITORPANEL_H
-#define COLORMAPEDITORPANEL_H
+#pragma once
 
 #include "MantidVatesSimpleGuiViewWidgets/WidgetDllOption.h"
 #include "ui_ColorMapEditorPanel.h"
@@ -50,5 +49,3 @@ private:
 } // namespace SimpleGui
 } // namespace Vates
 } // namespace Mantid
-
-#endif // COLORMAPEDITORPANEL_H

--- a/qt/paraview_ext/VatesSimpleGui/ViewWidgets/inc/MantidVatesSimpleGuiViewWidgets/ColorSelectionWidget.h
+++ b/qt/paraview_ext/VatesSimpleGui/ViewWidgets/inc/MantidVatesSimpleGuiViewWidgets/ColorSelectionWidget.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef COLORSELECTIONWIDGET_H_
-#define COLORSELECTIONWIDGET_H_
+#pragma once
 
 #include "MantidQtWidgets/Common/MdConstants.h"
 #include "MantidQtWidgets/Common/MdSettings.h"
@@ -150,5 +149,3 @@ private:
 } // namespace SimpleGui
 } // namespace Vates
 } // namespace Mantid
-
-#endif // COLORSELECTIONWIDGET_H_

--- a/qt/paraview_ext/VatesSimpleGui/ViewWidgets/inc/MantidVatesSimpleGuiViewWidgets/ColorUpdater.h
+++ b/qt/paraview_ext/VatesSimpleGui/ViewWidgets/inc/MantidVatesSimpleGuiViewWidgets/ColorUpdater.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef COLORUPDATER_H_
-#define COLORUPDATER_H_
+#pragma once
 
 #include "MantidVatesSimpleGuiViewWidgets/AutoScaleRangeGenerator.h"
 #include "MantidVatesSimpleGuiViewWidgets/WidgetDllOption.h"
@@ -108,5 +107,3 @@ private:
 } // namespace SimpleGui
 } // namespace Vates
 } // namespace Mantid
-
-#endif // COLORUPDATER_H_

--- a/qt/paraview_ext/VatesSimpleGui/ViewWidgets/inc/MantidVatesSimpleGuiViewWidgets/MdViewerWidget.h
+++ b/qt/paraview_ext/VatesSimpleGui/ViewWidgets/inc/MantidVatesSimpleGuiViewWidgets/MdViewerWidget.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MDVIEWERWIDGET_H_
-#define MDVIEWERWIDGET_H_
+#pragma once
 
 #include "MantidQtWidgets/Common/MdConstants.h"
 #include "MantidQtWidgets/Common/MdSettings.h"
@@ -277,5 +276,3 @@ private:
 } // namespace SimpleGui
 } // namespace Vates
 } // namespace Mantid
-
-#endif // MDVIEWERWIDGET_H_

--- a/qt/paraview_ext/VatesSimpleGui/ViewWidgets/inc/MantidVatesSimpleGuiViewWidgets/MultisliceView.h
+++ b/qt/paraview_ext/VatesSimpleGui/ViewWidgets/inc/MantidVatesSimpleGuiViewWidgets/MultisliceView.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MULTISLICEVIEW_H_
-#define MULTISLICEVIEW_H_
+#pragma once
 
 #include "MantidKernel/VMD.h"
 #include "MantidVatesSimpleGuiViewWidgets/ViewBase.h"
@@ -109,5 +108,3 @@ private:
 } // namespace SimpleGui
 } // namespace Vates
 } // namespace Mantid
-
-#endif // MULTISLICEVIEW_H_

--- a/qt/paraview_ext/VatesSimpleGui/ViewWidgets/inc/MantidVatesSimpleGuiViewWidgets/PeaksTabWidget.h
+++ b/qt/paraview_ext/VatesSimpleGui/ViewWidgets/inc/MantidVatesSimpleGuiViewWidgets/PeaksTabWidget.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef VSI_PEAKSTABWIDGET_H
-#define VSI_PEAKSTABWIDGET_H
+#pragma once
 
 #include "MantidAPI/IPeaksWorkspace_fwd.h"
 #include "MantidVatesSimpleGuiViewWidgets/WidgetDllOption.h"
@@ -71,4 +70,3 @@ private:
 } // namespace SimpleGui
 } // namespace Vates
 } // namespace Mantid
-#endif // PEAKSWORKSPACEWIDGET_H

--- a/qt/paraview_ext/VatesSimpleGui/ViewWidgets/inc/MantidVatesSimpleGuiViewWidgets/PeaksTableControllerVsi.h
+++ b/qt/paraview_ext/VatesSimpleGui/ViewWidgets/inc/MantidVatesSimpleGuiViewWidgets/PeaksTableControllerVsi.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef PeaksTableControllerVSI_H_
-#define PeaksTableControllerVSI_H_
+#pragma once
 
 #include "MantidGeometry/Crystal/PeakShape.h"
 #include "MantidGeometry/Crystal/PeakTransformSelector.h"
@@ -81,4 +80,3 @@ private:
 } // namespace SimpleGui
 } // namespace Vates
 } // namespace Mantid
-#endif

--- a/qt/paraview_ext/VatesSimpleGui/ViewWidgets/inc/MantidVatesSimpleGuiViewWidgets/PeaksWidget.h
+++ b/qt/paraview_ext/VatesSimpleGui/ViewWidgets/inc/MantidVatesSimpleGuiViewWidgets/PeaksWidget.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef VSI_PEAKSWORKWIDGET_H
-#define VSI_PEAKSWORKWIDGET_H
+#pragma once
 
 #include "MantidAPI/IPeaksWorkspace_fwd.h"
 #include "MantidVatesSimpleGuiViewWidgets/WidgetDllOption.h"
@@ -50,4 +49,3 @@ private:
 } // namespace SimpleGui
 } // namespace Vates
 } // namespace Mantid
-#endif // PEAKSWORKSPACEWIDGET_H

--- a/qt/paraview_ext/VatesSimpleGui/ViewWidgets/inc/MantidVatesSimpleGuiViewWidgets/RebinAlgorithmDialogProvider.h
+++ b/qt/paraview_ext/VatesSimpleGui/ViewWidgets/inc/MantidVatesSimpleGuiViewWidgets/RebinAlgorithmDialogProvider.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef REBINALGORITHMDIALOGPROVIDER_H_
-#define REBINALGORITHMDIALOGPROVIDER_H_
+#pragma once
 
 #include "MantidVatesSimpleGuiViewWidgets/WidgetDllOption.h"
 
@@ -67,5 +66,3 @@ private:
 } // namespace SimpleGui
 } // namespace Vates
 } // namespace Mantid
-
-#endif

--- a/qt/paraview_ext/VatesSimpleGui/ViewWidgets/inc/MantidVatesSimpleGuiViewWidgets/RebinnedSourcesManager.h
+++ b/qt/paraview_ext/VatesSimpleGui/ViewWidgets/inc/MantidVatesSimpleGuiViewWidgets/RebinnedSourcesManager.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef REBINNEDSOURCESMANAGER_H_
-#define REBINNEDSOURCESMANAGER_H_
+#pragma once
 
 #include "MantidAPI/Workspace_fwd.h"
 #include "MantidQtWidgets/Common/WorkspaceObserver.h"
@@ -157,5 +156,3 @@ private:
 } // namespace SimpleGui
 } // namespace Vates
 } // namespace Mantid
-
-#endif

--- a/qt/paraview_ext/VatesSimpleGui/ViewWidgets/inc/MantidVatesSimpleGuiViewWidgets/SplatterPlotView.h
+++ b/qt/paraview_ext/VatesSimpleGui/ViewWidgets/inc/MantidVatesSimpleGuiViewWidgets/SplatterPlotView.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef SPLATTERPLOTVIEW_H_
-#define SPLATTERPLOTVIEW_H_
+#pragma once
 
 #include "MantidVatesSimpleGuiViewWidgets/CameraManager.h"
 #include "MantidVatesSimpleGuiViewWidgets/PeaksTableControllerVsi.h"
@@ -168,5 +167,3 @@ private:
 } // namespace SimpleGui
 } // namespace Vates
 } // namespace Mantid
-
-#endif // SPLATTERPLOTVIEW_H_

--- a/qt/paraview_ext/VatesSimpleGui/ViewWidgets/inc/MantidVatesSimpleGuiViewWidgets/StandardView.h
+++ b/qt/paraview_ext/VatesSimpleGui/ViewWidgets/inc/MantidVatesSimpleGuiViewWidgets/StandardView.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef STANDARDVIEW_H_
-#define STANDARDVIEW_H_
+#pragma once
 
 #include "MantidVatesSimpleGuiViewWidgets/ViewBase.h"
 #include "MantidVatesSimpleGuiViewWidgets/WidgetDllOption.h"
@@ -132,5 +131,3 @@ private:
 } // namespace SimpleGui
 } // namespace Vates
 } // namespace Mantid
-
-#endif // STANDARDVIEW_H_

--- a/qt/paraview_ext/VatesSimpleGui/ViewWidgets/inc/MantidVatesSimpleGuiViewWidgets/ThreesliceView.h
+++ b/qt/paraview_ext/VatesSimpleGui/ViewWidgets/inc/MantidVatesSimpleGuiViewWidgets/ThreesliceView.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef THREESLICEVIEW_H_
-#define THREESLICEVIEW_H_
+#pragma once
 
 #include "MantidVatesSimpleGuiViewWidgets/ViewBase.h"
 #include "MantidVatesSimpleGuiViewWidgets/WidgetDllOption.h"
@@ -87,5 +86,3 @@ private:
 } // namespace SimpleGui
 } // namespace Vates
 } // namespace Mantid
-
-#endif // THREESLICEVIEW_H_

--- a/qt/paraview_ext/VatesSimpleGui/ViewWidgets/inc/MantidVatesSimpleGuiViewWidgets/TimeControlWidget.h
+++ b/qt/paraview_ext/VatesSimpleGui/ViewWidgets/inc/MantidVatesSimpleGuiViewWidgets/TimeControlWidget.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef TIMECONTROLWIDGET_H_
-#define TIMECONTROLWIDGET_H_
+#pragma once
 
 #include "MantidVatesSimpleGuiViewWidgets/WidgetDllOption.h"
 
@@ -50,5 +49,3 @@ private:
 } // namespace SimpleGui
 } // namespace Vates
 } // namespace Mantid
-
-#endif // TIMECONTROLWIDGET_H_

--- a/qt/paraview_ext/VatesSimpleGui/ViewWidgets/inc/MantidVatesSimpleGuiViewWidgets/VatesParaViewApplication.h
+++ b/qt/paraview_ext/VatesSimpleGui/ViewWidgets/inc/MantidVatesSimpleGuiViewWidgets/VatesParaViewApplication.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef VATESPARAVIEWAPPLICATION_H_
-#define VATESPARAVIEWAPPLICATION_H_
+#pragma once
 
 #include "MantidKernel/Logger.h"
 #include "MantidVatesSimpleGuiViewWidgets/WidgetDllOption.h"
@@ -45,4 +44,3 @@ private:
 } // namespace SimpleGui
 } // namespace Vates
 } // namespace Mantid
-#endif

--- a/qt/paraview_ext/VatesSimpleGui/ViewWidgets/inc/MantidVatesSimpleGuiViewWidgets/ViewBase.h
+++ b/qt/paraview_ext/VatesSimpleGui/ViewWidgets/inc/MantidVatesSimpleGuiViewWidgets/ViewBase.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef VIEWBASE_H_
-#define VIEWBASE_H_
+#pragma once
 
 #include "MantidVatesAPI/ColorScaleGuard.h"
 #include "MantidVatesSimpleGuiQtWidgets/ModeControlWidget.h"
@@ -264,5 +263,3 @@ private:
 } // namespace SimpleGui
 } // namespace Vates
 } // namespace Mantid
-
-#endif // VIEWBASE_H_

--- a/qt/paraview_ext/VatesSimpleGui/ViewWidgets/inc/MantidVatesSimpleGuiViewWidgets/VisibleAxesColor.h
+++ b/qt/paraview_ext/VatesSimpleGui/ViewWidgets/inc/MantidVatesSimpleGuiViewWidgets/VisibleAxesColor.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_VISIBLEAXESCOLOR_H_
-#define MANTID_VISIBLEAXESCOLOR_H_
+#pragma once
 #include "MantidVatesSimpleGuiViewWidgets/WidgetDllOption.h"
 #include "pqRenderView.h"
 
@@ -32,5 +31,3 @@ private:
 } // namespace SimpleGui
 } // namespace Vates
 } // namespace Mantid
-
-#endif // MANTID_VISIBLEAXESCOLOR_H_

--- a/qt/paraview_ext/VatesSimpleGui/ViewWidgets/inc/MantidVatesSimpleGuiViewWidgets/VsiApplyBehaviour.h
+++ b/qt/paraview_ext/VatesSimpleGui/ViewWidgets/inc/MantidVatesSimpleGuiViewWidgets/VsiApplyBehaviour.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_VATES_SIMPLEGUIVIEWWIDGETS_VSI_APPLY_BEHAVIOUR_H
-#define MANTID_VATES_SIMPLEGUIVIEWWIDGETS_VSI_APPLY_BEHAVIOUR_H
+#pragma once
 
 #include "MantidVatesAPI/ColorScaleGuard.h"
 #include <QObject>
@@ -39,4 +38,3 @@ private:
 } // namespace SimpleGui
 } // namespace Vates
 } // namespace Mantid
-#endif

--- a/qt/paraview_ext/VatesSimpleGui/ViewWidgets/inc/MantidVatesSimpleGuiViewWidgets/WidgetDllOption.h
+++ b/qt/paraview_ext/VatesSimpleGui/ViewWidgets/inc/MantidVatesSimpleGuiViewWidgets/WidgetDllOption.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTIDVATES_SIMPLEGUI_VIEWWIDGETS_DLLOPTION_H_
-#define MANTIDVATES_SIMPLEGUI_VIEWWIDGETS_DLLOPTION_H_
+#pragma once
 
 #include "MantidKernel/System.h"
 
@@ -14,5 +13,3 @@
 #else
 #define EXPORT_OPT_MANTIDVATES_SIMPLEGUI_VIEWWIDGETS DLLImport
 #endif // IN_MANTID_VATES_SIMPLEGUI_VIEWWIDGETS
-
-#endif // MANTIDVATES_SIMPLEGUI_VIEWWIDGETS_DLLOPTION_H_

--- a/qt/paraview_ext/VatesSimpleGui/ViewWidgets/inc/MantidVatesSimpleGuiViewWidgets/pqCameraReactionNonOrthogonalAxes.h
+++ b/qt/paraview_ext/VatesSimpleGui/ViewWidgets/inc/MantidVatesSimpleGuiViewWidgets/pqCameraReactionNonOrthogonalAxes.h
@@ -42,8 +42,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  @date 19/04/2017
 */
 
-#ifndef pqCameraReactionNonOrthogonalAxes_h
-#define pqCameraReactionNonOrthogonalAxes_h
+#pragma once
 
 #include "MantidVatesSimpleGuiViewWidgets/WidgetDllOption.h"
 #include "pqReaction.h"
@@ -104,5 +103,3 @@ protected:
 private:
   Mode ReactionMode;
 };
-
-#endif

--- a/qt/paraview_ext/VatesSimpleGui/ViewWidgets/inc/MantidVatesSimpleGuiViewWidgets/pqCameraToolbarNonOrthogonalAxes.h
+++ b/qt/paraview_ext/VatesSimpleGui/ViewWidgets/inc/MantidVatesSimpleGuiViewWidgets/pqCameraToolbarNonOrthogonalAxes.h
@@ -42,8 +42,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  @date 19/04/2017
 */
 
-#ifndef pqCameraToolbarNonOrthogonalAxes_h
-#define pqCameraToolbarNonOrthogonalAxes_h
+#pragma once
 
 #include "MantidVatesSimpleGuiViewWidgets/WidgetDllOption.h"
 #include "pqApplicationComponentsModule.h"
@@ -80,5 +79,3 @@ private:
   void constructor();
   QAction *ZoomToDataAction;
 };
-
-#endif


### PR DESCRIPTION
This PR replaces all header guards in qt/icons and qt/paraview_ext with #pragma once.

**To test:**

Any issues in this PR should be caught by jenkins. just code review to check that no definitions or endifs have been removed by mistake

This pr is a part of #28200

*This does not require release notes* because **it is an internal change to the codebase.**

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
