### PR TITLE
Replace header guards in qt/scientific_interfaces with pragma once

### DIFF
--- a/qt/scientific_interfaces/Direct/ALFCustomInstrumentModel.h
+++ b/qt/scientific_interfaces/Direct/ALFCustomInstrumentModel.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTIDQT_CUSTOMINTERFACES_ALFCUSTOMINSTRUMENTMODEL_H_
-#define MANTIDQT_CUSTOMINTERFACES_ALFCUSTOMINSTRUMENTMODEL_H_
+#pragma once
 
 #include "MantidAPI/CompositeFunction.h"
 #include "MantidAPI/FunctionFactory.h"
@@ -41,5 +40,3 @@ private:
 
 } // namespace CustomInterfaces
 } // namespace MantidQt
-
-#endif /* MANTIDQT_CUSTOMINTERFACES_ALFCUSTOMINSTRUMENTMODEL_H_ */

--- a/qt/scientific_interfaces/Direct/ALFCustomInstrumentPresenter.h
+++ b/qt/scientific_interfaces/Direct/ALFCustomInstrumentPresenter.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTIDQT_CUSTOMINTERFACES_ALFCUSTOMINSTRUMENTPRESENTER_H_
-#define MANTIDQT_CUSTOMINTERFACES_ALFCUSTOMINSTRUMENTPRESENTER_H_
+#pragma once
 
 #include "MantidQtWidgets/InstrumentView/BaseCustomInstrumentPresenter.h"
 #include "MantidQtWidgets/InstrumentView/PlotFitAnalysisPanePresenter.h"
@@ -56,5 +55,3 @@ private:
 };
 } // namespace CustomInterfaces
 } // namespace MantidQt
-
-#endif /* MANTIDQT_CUSTOMINTERFACES_ALFCUSTOMINSTRUMENTPRESENTER_H_ */

--- a/qt/scientific_interfaces/Direct/ALFCustomInstrumentView.h
+++ b/qt/scientific_interfaces/Direct/ALFCustomInstrumentView.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTIDQT_CUSTOMINTERFACES_ALFCustomInstrumentView_H_
-#define MANTIDQT_CUSTOMINTERFACES_ALFCustomInstrumentView_H_
+#pragma once
 
 #include "DllConfig.h"
 #include "MantidQtWidgets/Common/MWRunFiles.h"
@@ -52,5 +51,3 @@ private:
 };
 } // namespace CustomInterfaces
 } // namespace MantidQt
-
-#endif /* MANTIDQT_CUSTOMINTERFACES_ALFCustomInstrumentView_H_ */

--- a/qt/scientific_interfaces/Direct/ALFView.h
+++ b/qt/scientific_interfaces/Direct/ALFView.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTIDQT_CUSTOMINTERFACES_ALFVIEW_H_
-#define MANTIDQT_CUSTOMINTERFACES_ALFVIEW_H_
+#pragma once
 
 #include "ALFCustomInstrumentModel.h"
 #include "ALFCustomInstrumentPresenter.h"
@@ -39,5 +38,3 @@ private:
 };
 } // namespace CustomInterfaces
 } // namespace MantidQt
-
-#endif /* MANTIDQT_CUSTOMINTERFACES_ALFVIEW_H_ */

--- a/qt/scientific_interfaces/Direct/DllConfig.h
+++ b/qt/scientific_interfaces/Direct/DllConfig.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTIDQT_DIRECT_DLLCONFIG_H_
-#define MANTIDQT_DIRECT_DLLCONFIG_H_
+#pragma once
 
 #include "MantidKernel/System.h"
 
@@ -20,5 +19,3 @@
 #define MANTIDQT_DIRECT_DLL DLLImport
 #define EXTERN_MANTIDQT_DIRECT EXTERN_IMPORT
 #endif
-
-#endif // MANTIDQT_DIRECT_DLLCONFIG_H_

--- a/qt/scientific_interfaces/DynamicPDF/DPDFBackgroundRemover.h
+++ b/qt/scientific_interfaces/DynamicPDF/DPDFBackgroundRemover.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTIDQTCUSTOMINTERFACES_DYNAMICPDF_BACKGROUNDREMOVER_H_
-#define MANTIDQTCUSTOMINTERFACES_DYNAMICPDF_BACKGROUNDREMOVER_H_
+#pragma once
 
 // Mantid Coding standars <http://www.mantidproject.org/Coding_Standards>
 // Mantid Headers from the same project
@@ -71,5 +70,3 @@ private:
 } // namespace DynamicPDF
 } // namespace CustomInterfaces
 } // namespace MantidQt
-
-#endif // MANTIDQTCUSTOMINTERFACES_DYNAMICPDF_BACKGROUNDREMOVER_H_

--- a/qt/scientific_interfaces/DynamicPDF/DPDFDisplayControl.h
+++ b/qt/scientific_interfaces/DynamicPDF/DPDFDisplayControl.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTIDQTCUSTOMINTERFACES_DYNAMICPDF_DISPLAYCONTROL_H_
-#define MANTIDQTCUSTOMINTERFACES_DYNAMICPDF_DISPLAYCONTROL_H_
+#pragma once
 
 // Mantid Coding standars <http://www.mantidproject.org/Coding_Standards>
 // Mantid Headers from the same project
@@ -73,5 +72,3 @@ private:
 } // namespace DynamicPDF
 } // namespace CustomInterfaces
 } // namespace MantidQt
-
-#endif // MANTIDQTCUSTOMINTERFACES_DYNAMICPDF_INPUTDATACONTROL_H_

--- a/qt/scientific_interfaces/DynamicPDF/DPDFFitControl.h
+++ b/qt/scientific_interfaces/DynamicPDF/DPDFFitControl.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTIDQTCUSTOMINTERFACES_DYNAMICPDF_FITCONTROL_H_
-#define MANTIDQTCUSTOMINTERFACES_DYNAMICPDF_FITCONTROL_H_
+#pragma once
 
 // Mantid Coding standars <http://www.mantidproject.org/Coding_Standards>
 // Mantid Headers from the same project
@@ -119,4 +118,3 @@ private:
 } // namespace DynamicPDF
 } // namespace CustomInterfaces
 } // namespace MantidQt
-#endif // MANTIDQTCUSTOMINTERFACES_DYNAMICPDF_FITCONTROL_H_

--- a/qt/scientific_interfaces/DynamicPDF/DPDFFitOptionsBrowser.h
+++ b/qt/scientific_interfaces/DynamicPDF/DPDFFitOptionsBrowser.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTIDQTCUSTOMINTERFACES_DYNAMICPDF_DPDFFITOPTIONSBROWSER_H_
-#define MANTIDQTCUSTOMINTERFACES_DYNAMICPDF_DPDFFITOPTIONSBROWSER_H_
+#pragma once
 
 // Mantid Coding standars <http://www.mantidproject.org/Coding_Standards>
 // Mantid Headers from the same project
@@ -46,5 +45,3 @@ private:
 } // namespace DynamicPDF
 } // namespace CustomInterfaces
 } // namespace MantidQt
-
-#endif // MANTIDQTCUSTOMINTERFACES_DYNAMICPDF_DPDFFITOPTIONSBROWSER_H_

--- a/qt/scientific_interfaces/DynamicPDF/DPDFFourierTransform.h
+++ b/qt/scientific_interfaces/DynamicPDF/DPDFFourierTransform.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTIDQTCUSTOMINTERFACES_DYNAMICPDF_FOURIERTRANSFORM_H_
-#define MANTIDQTCUSTOMINTERFACES_DYNAMICPDF_FOURIERTRANSFORM_H_
+#pragma once
 
 // Mantid Coding standars <http://www.mantidproject.org/Coding_Standards>
 // Mantid Headers from the same project
@@ -112,4 +111,3 @@ private:
 } // namespace DynamicPDF
 } // namespace CustomInterfaces
 } // namespace MantidQt
-#endif // MANTIDQTCUSTOMINTERFACES_DYNAMICPDF_FOURIERTRANSFORM_H_

--- a/qt/scientific_interfaces/DynamicPDF/DPDFInputDataControl.h
+++ b/qt/scientific_interfaces/DynamicPDF/DPDFInputDataControl.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTIDQTCUSTOMINTERFACES_DYNAMICPDF_INPUTDATACONTROL_H_
-#define MANTIDQTCUSTOMINTERFACES_DYNAMICPDF_INPUTDATACONTROL_H_
+#pragma once
 
 // Mantid Coding standars <http://www.mantidproject.org/Coding_Standards>
 // Mantid Headers from the same project
@@ -77,5 +76,3 @@ private:
 } // namespace DynamicPDF
 } // namespace CustomInterfaces
 } // namespace MantidQt
-
-#endif // MANTIDQTCUSTOMINTERFACES_DYNAMICPDF_INPUTDATACONTROL_H_

--- a/qt/scientific_interfaces/DynamicPDF/DllConfig.h
+++ b/qt/scientific_interfaces/DynamicPDF/DllConfig.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTIDQT_DYNAMICPDF_DLLCONFIG_H_
-#define MANTIDQT_DYNAMICPDF_DLLCONFIG_H_
+#pragma once
 
 #include "MantidKernel/System.h"
 
@@ -20,5 +19,3 @@
 #define MANTIDQT_DYNAMICPDF_DLL DLLImport
 #define EXTERN_MANTIDQT_DYNAMICPDF EXTERN_IMPORT
 #endif
-
-#endif // MANTIDQT_DYNAMICPDF_DLLCONFIG_H_

--- a/qt/scientific_interfaces/DynamicPDF/PrecompiledHeader.h
+++ b/qt/scientific_interfaces/DynamicPDF/PrecompiledHeader.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTIDQT_CUSTOMINTERFACES_PRECOMPILEDHEADER_H_
-#define MANTIDQT_CUSTOMINTERFACES_PRECOMPILEDHEADER_H_
+#pragma once
 
 // Mantid
 #include "MantidAPI/Algorithm.h"
@@ -22,5 +21,3 @@
 #include <set>
 #include <string>
 #include <vector>
-
-#endif // MANTIDQT_CUSTOMINTERFACES_PRECOMPILEDHEADER_H_

--- a/qt/scientific_interfaces/DynamicPDF/SliceSelector.h
+++ b/qt/scientific_interfaces/DynamicPDF/SliceSelector.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTIDQTCUSTOMINTERFACES_DYNAMICPDF_SLICESELECTOR_H_
-#define MANTIDQTCUSTOMINTERFACES_DYNAMICPDF_SLICESELECTOR_H_
+#pragma once
 
 // Mantid Coding standars <http://www.mantidproject.org/Coding_Standards>
 // Mantid Headers from the same project
@@ -95,4 +94,3 @@ private:
 } // namespace DynamicPDF
 } // namespace CustomInterfaces
 } // namespace MantidQt
-#endif // MANTIDQTCUSTOMINTERFACES_DYNAMICPDF_SLICESELECTOR_H_

--- a/qt/scientific_interfaces/EnggDiffraction/DllConfig.h
+++ b/qt/scientific_interfaces/EnggDiffraction/DllConfig.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTIDQT_ENGGDIFFRACTION_DLLCONFIG_H_
-#define MANTIDQT_ENGGDIFFRACTION_DLLCONFIG_H_
+#pragma once
 
 #include "MantidKernel/System.h"
 
@@ -20,5 +19,3 @@
 #define MANTIDQT_ENGGDIFFRACTION_DLL DLLImport
 #define EXTERN_MANTIDQT_ENGGDIFFRACTION EXTERN_IMPORT
 #endif
-
-#endif // MANTIDQT_ENGGDIFFRACTION_DLLCONFIG_H_

--- a/qt/scientific_interfaces/EnggDiffraction/EnggDiffCalibSettings.h
+++ b/qt/scientific_interfaces/EnggDiffraction/EnggDiffCalibSettings.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTIDQTCUSTOMINTERFACES_ENGGDIFFRACTION_ENGGDIFFCALIBSETTINGS_H_
-#define MANTIDQTCUSTOMINTERFACES_ENGGDIFFRACTION_ENGGDIFFCALIBSETTINGS_H_
+#pragma once
 
 #include <string>
 
@@ -27,5 +26,3 @@ struct EnggDiffCalibSettings {
 
 } // namespace CustomInterfaces
 } // namespace MantidQt
-
-#endif // MANTIDQTCUSTOMINTERFACES_ENGGDIFFRACTION_ENGGDIFFCALIBSETTINGS_H_

--- a/qt/scientific_interfaces/EnggDiffraction/EnggDiffFittingModel.h
+++ b/qt/scientific_interfaces/EnggDiffraction/EnggDiffFittingModel.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTIDQTCUSTOMINTERFACES_ENGGDIFFRACTION_ENGGDIFFFITTINGMODEL_H_
-#define MANTIDQTCUSTOMINTERFACES_ENGGDIFFRACTION_ENGGDIFFFITTINGMODEL_H_
+#pragma once
 
 #include "DllConfig.h"
 #include "IEnggDiffFittingModel.h"
@@ -149,5 +148,3 @@ private:
 
 } // namespace CustomInterfaces
 } // namespace MantidQt
-
-#endif // MANTIDQTCUSTOMINTERFACES_ENGGDIFFRACTION_ENGGDIFFFITTINGMODEL_H_

--- a/qt/scientific_interfaces/EnggDiffraction/EnggDiffFittingPresWorker.h
+++ b/qt/scientific_interfaces/EnggDiffraction/EnggDiffFittingPresWorker.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTIDQTCUSTOMINTERFACES_ENGGDIFFRACTION_ENGGDIFFFITTINGPRESWORKER_H_
-#define MANTIDQTCUSTOMINTERFACES_ENGGDIFFRACTION_ENGGDIFFFITTINGPRESWORKER_H_
+#pragma once
 
 #include "EnggDiffFittingPresenter.h"
 #include "MantidKernel/Logger.h"
@@ -57,5 +56,3 @@ private:
 
 } // namespace CustomInterfaces
 } // namespace MantidQt
-
-#endif // MANTIDQTCUSTOMINTERFACES_ENGGDIFFRACTION_ENGGDIFFFITTINGPRESWORKER_H_

--- a/qt/scientific_interfaces/EnggDiffraction/EnggDiffFittingPresenter.h
+++ b/qt/scientific_interfaces/EnggDiffraction/EnggDiffFittingPresenter.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTIDQTCUSTOMINTERFACES_ENGGDIFFRACTION_ENGGDIFFFITTINGPRESENTER_H_
-#define MANTIDQTCUSTOMINTERFACES_ENGGDIFFRACTION_ENGGDIFFFITTINGPRESENTER_H_
+#pragma once
 
 #include "DllConfig.h"
 #include "IEnggDiffFittingModel.h"
@@ -141,4 +140,3 @@ private:
 
 } // namespace CustomInterfaces
 } // namespace MantidQt
-#endif // MANTIDQTCUSTOMINTERFACES_ENGGDIFFRACTION_ENGGDIFFFITTINGPRESENTER_H_

--- a/qt/scientific_interfaces/EnggDiffraction/EnggDiffFittingViewQtWidget.h
+++ b/qt/scientific_interfaces/EnggDiffraction/EnggDiffFittingViewQtWidget.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTIDQTCUSTOMINTERFACES_ENGGDIFFRACTION_IENGGDIFFFITTINGVIEWQTWIDGET_H_
-#define MANTIDQTCUSTOMINTERFACES_ENGGDIFFRACTION_IENGGDIFFFITTINGVIEWQTWIDGET_H_
+#pragma once
 
 #include "DllConfig.h"
 #include "IEnggDiffFittingPresenter.h"
@@ -223,5 +222,3 @@ private:
 
 } // namespace CustomInterfaces
 } // namespace MantidQt
-
-#endif // MANTIDQTCUSTOMINTERFACES_ENGGDIFFRACTION_IENGGDIFFFITTINGVIEWQTWIDGET_H_

--- a/qt/scientific_interfaces/EnggDiffraction/EnggDiffGSASFittingModel.h
+++ b/qt/scientific_interfaces/EnggDiffraction/EnggDiffGSASFittingModel.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTIDQTCUSTOMINTERFACES_ENGGDIFFRACTION_GSASFITTINGMODEL_H_
-#define MANTIDQTCUSTOMINTERFACES_ENGGDIFFRACTION_GSASFITTINGMODEL_H_
+#pragma once
 
 #include "DllConfig.h"
 #include "EnggDiffGSASFittingWorker.h"
@@ -131,5 +130,3 @@ private:
 
 } // namespace CustomInterfaces
 } // namespace MantidQt
-
-#endif // MANTIDQTCUSTOMINTERFACES_ENGGDIFFRACTION_GSASFITTINGMODEL_H_

--- a/qt/scientific_interfaces/EnggDiffraction/EnggDiffGSASFittingPresenter.h
+++ b/qt/scientific_interfaces/EnggDiffraction/EnggDiffGSASFittingPresenter.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTIDQTCUSTOMINTERFACES_ENGGDIFFRACTION_ENGGDIFFGSASFITTINGPRESENTER_H_
-#define MANTIDQTCUSTOMINTERFACES_ENGGDIFFRACTION_ENGGDIFFGSASFITTINGPRESENTER_H_
+#pragma once
 
 #include "DllConfig.h"
 #include "GSASIIRefineFitPeaksOutputProperties.h"
@@ -99,5 +98,3 @@ private:
 
 } // namespace CustomInterfaces
 } // namespace MantidQt
-
-#endif // MANTIDQTCUSTOMINTERFACES_ENGGDIFFRACTION_ENGGDIFFGSASFITTINGPRESENTER_H_

--- a/qt/scientific_interfaces/EnggDiffraction/EnggDiffGSASFittingViewQtWidget.h
+++ b/qt/scientific_interfaces/EnggDiffraction/EnggDiffGSASFittingViewQtWidget.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTIDQTCUSTOMINTERFACES_ENGGDIFFRACTION_IENGGDIFFGSASFITTINGVIEWQTWIDGET_H_
-#define MANTIDQTCUSTOMINTERFACES_ENGGDIFFRACTION_IENGGDIFFGSASFITTINGVIEWQTWIDGET_H_
+#pragma once
 
 #include "DllConfig.h"
 #include "EnggDiffMultiRunFittingQtWidget.h"
@@ -117,5 +116,3 @@ private:
 
 } // namespace CustomInterfaces
 } // namespace MantidQt
-
-#endif // MANTIDQTCUSTOMINTERFACES_ENGGDIFFRACTION_IENGGDIFFGSASFITTINGVIEWQTWIDGET_H_

--- a/qt/scientific_interfaces/EnggDiffraction/EnggDiffGSASFittingWorker.h
+++ b/qt/scientific_interfaces/EnggDiffraction/EnggDiffGSASFittingWorker.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTIDQTCUSTOMINTERFACES_ENGGDIFFRACTION_ENGGDIFFGSASFITTINGWORKER_H_
-#define MANTIDQTCUSTOMINTERFACES_ENGGDIFFRACTION_ENGGDIFFGSASFITTINGWORKER_H_
+#pragma once
 
 #include "GSASIIRefineFitPeaksOutputProperties.h"
 #include "GSASIIRefineFitPeaksParameters.h"
@@ -54,5 +53,3 @@ private:
 
 } // namespace CustomInterfaces
 } // namespace MantidQt
-
-#endif // MANTIDQTCUSTOMINTERFACES_ENGGDIFFRACTION_ENGGDIFFGSASFITTINGWORKER_H_

--- a/qt/scientific_interfaces/EnggDiffraction/EnggDiffGSASRefinementMethod.h
+++ b/qt/scientific_interfaces/EnggDiffraction/EnggDiffGSASRefinementMethod.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTIDQTCUSTOMINTERFACES_ENGGDIFFRACTION_GSASREFINEMENTMETHOD_H_
-#define MANTIDQTCUSTOMINTERFACES_ENGGDIFFRACTION_GSASREFINEMENTMETHOD_H_
+#pragma once
 
 namespace MantidQt {
 namespace CustomInterfaces {
@@ -13,5 +12,3 @@ namespace CustomInterfaces {
 enum class GSASRefinementMethod { PAWLEY, RIETVELD };
 }
 } // namespace MantidQt
-
-#endif // MANTIDQTCUSTOMINTERFACES_ENGGDIFFRACTION_GSASREFINEMENTMETHOD_H_

--- a/qt/scientific_interfaces/EnggDiffraction/EnggDiffMultiRunFittingQtWidget.h
+++ b/qt/scientific_interfaces/EnggDiffraction/EnggDiffMultiRunFittingQtWidget.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTIDQT_CUSTOMINTERFACES_ENGGDIFFMULTIRUNFITTINGQTWIDGET_H_
-#define MANTIDQT_CUSTOMINTERFACES_ENGGDIFFMULTIRUNFITTINGQTWIDGET_H_
+#pragma once
 
 #include "DllConfig.h"
 #include "IEnggDiffMultiRunFittingWidgetPresenter.h"
@@ -105,5 +104,3 @@ private:
 
 } // namespace CustomInterfaces
 } // namespace MantidQt
-
-#endif // MANTIDQT_CUSTOMINTERFACES_ENGGDIFFMULTIRUNFITTINGQTWIDGET_H_

--- a/qt/scientific_interfaces/EnggDiffraction/EnggDiffMultiRunFittingWidgetAdder.h
+++ b/qt/scientific_interfaces/EnggDiffraction/EnggDiffMultiRunFittingWidgetAdder.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTIDQT_CUSTOMINTERFACES_ENGGDIFFMULTIRUNFITTINGWIDGETADDER_H_
-#define MANTIDQT_CUSTOMINTERFACES_ENGGDIFFMULTIRUNFITTINGWIDGETADDER_H_
+#pragma once
 
 #include "IEnggDiffMultiRunFittingWidgetAdder.h"
 
@@ -33,5 +32,3 @@ private:
 
 } // namespace CustomInterfaces
 } // namespace MantidQt
-
-#endif // MANTIDQT_CUSTOMINTERFACES_ENGGDIFFMULTIRUNFITTINGWIDGETADDER_H_

--- a/qt/scientific_interfaces/EnggDiffraction/EnggDiffMultiRunFittingWidgetModel.h
+++ b/qt/scientific_interfaces/EnggDiffraction/EnggDiffMultiRunFittingWidgetModel.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTIDQT_CUSTOMINTERFACES_ENGGDIFFMULTIRUNFITTINGWIDGETMODEL_H_
-#define MANTIDQT_CUSTOMINTERFACES_ENGGDIFFMULTIRUNFITTINGWIDGETMODEL_H_
+#pragma once
 
 #include "DllConfig.h"
 #include "IEnggDiffMultiRunFittingWidgetModel.h"
@@ -45,5 +44,3 @@ private:
 
 } // namespace CustomInterfaces
 } // namespace MantidQt
-
-#endif // MANTIDQT_CUSTOMINTERFACES_ENGGDIFFMULTIRUNFITTINGWIDGETMODEL_H_

--- a/qt/scientific_interfaces/EnggDiffraction/EnggDiffMultiRunFittingWidgetPresenter.h
+++ b/qt/scientific_interfaces/EnggDiffraction/EnggDiffMultiRunFittingWidgetPresenter.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTIDQT_CUSTOMINTERFACES_ENGGDIFFMULTIRUNFITTINGWIDGETPRESENTER_H_
-#define MANTIDQT_CUSTOMINTERFACES_ENGGDIFFMULTIRUNFITTINGWIDGETPRESENTER_H_
+#pragma once
 
 #include "DllConfig.h"
 #include "IEnggDiffMultiRunFittingWidgetModel.h"
@@ -66,5 +65,3 @@ private:
 
 } // namespace CustomInterfaces
 } // namespace MantidQt
-
-#endif // MANTIDQT_CUSTOMINTERFACES_ENGGDIFFMULTIRUNFITTINGWIDGETPRESENTER_H_

--- a/qt/scientific_interfaces/EnggDiffraction/EnggDiffractionPresWorker.h
+++ b/qt/scientific_interfaces/EnggDiffraction/EnggDiffractionPresWorker.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTIDQTCUSTOMINTERFACES_ENGGDIFFRACTION_ENGGDIFFRACTIONPRESWORKER_H_
-#define MANTIDQTCUSTOMINTERFACES_ENGGDIFFRACTION_ENGGDIFFRACTIONPRESWORKER_H_
+#pragma once
 
 #include "EnggDiffractionPresenter.h"
 
@@ -117,5 +116,3 @@ private:
 
 } // namespace CustomInterfaces
 } // namespace MantidQt
-
-#endif // MANTIDQTCUSTOMINTERFACES_ENGGDIFFRACTION_ENGGDIFFRACTIONPRESWORKER_H_

--- a/qt/scientific_interfaces/EnggDiffraction/EnggDiffractionPresenter.h
+++ b/qt/scientific_interfaces/EnggDiffraction/EnggDiffractionPresenter.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTIDQTCUSTOMINTERFACES_ENGGDIFFRACTION_ENGGDIFFRACTIONPRESENTER_H_
-#define MANTIDQTCUSTOMINTERFACES_ENGGDIFFRACTION_ENGGDIFFRACTIONPRESENTER_H_
+#pragma once
 
 #include "DllConfig.h"
 #include "IEnggDiffractionCalibration.h"
@@ -351,4 +350,3 @@ private:
 
 } // namespace CustomInterfaces
 } // namespace MantidQt
-#endif // MANTIDQTCUSTOMINTERFACES_ENGGDIFFRACTION_ENGGDIFFRACTIONPRESENTER_H_

--- a/qt/scientific_interfaces/EnggDiffraction/EnggDiffractionViewQtGUI.h
+++ b/qt/scientific_interfaces/EnggDiffraction/EnggDiffractionViewQtGUI.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTIDQTCUSTOMINTERFACES_ENGGDIFFRACTION_IENGGDIFFRACTIONVIEWQTGUI_H_
-#define MANTIDQTCUSTOMINTERFACES_ENGGDIFFRACTION_IENGGDIFFRACTIONVIEWQTGUI_H_
+#pragma once
 
 #include "DllConfig.h"
 #include "EnggDiffFittingViewQtWidget.h"
@@ -300,5 +299,3 @@ private:
 
 } // namespace CustomInterfaces
 } // namespace MantidQt
-
-#endif // MANTIDQTCUSTOMINTERFACES_ENGGDIFFRACTION_IENGGDIFFRACTIONVIEWQTGUI_H_

--- a/qt/scientific_interfaces/EnggDiffraction/EnggVanadiumCorrectionsModel.h
+++ b/qt/scientific_interfaces/EnggDiffraction/EnggVanadiumCorrectionsModel.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTIDQT_CUSTOMINTERFACES_ENGGVANADIUMCORRECTIONSMODEL_H_
-#define MANTIDQT_CUSTOMINTERFACES_ENGGVANADIUMCORRECTIONSMODEL_H_
+#pragma once
 
 #include "DllConfig.h"
 #include "IEnggVanadiumCorrectionsModel.h"
@@ -82,5 +81,3 @@ private:
 
 } // namespace CustomInterfaces
 } // namespace MantidQt
-
-#endif // MANTIDQT_CUSTOMINTERFACES_ENGGVANADIUMCORRECTIONSMODEL_H_

--- a/qt/scientific_interfaces/EnggDiffraction/GSASIIRefineFitPeaksOutputProperties.h
+++ b/qt/scientific_interfaces/EnggDiffraction/GSASIIRefineFitPeaksOutputProperties.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTIDQTCUSTOMINTERFACES_ENGGDIFFRACTION_GSASIIREFINEFITPEAKSOUTPUTPROPERTIES_H_
-#define MANTIDQTCUSTOMINTERFACES_ENGGDIFFRACTION_GSASIIREFINEFITPEAKSOUTPUTPROPERTIES_H_
+#pragma once
 
 #include "DllConfig.h"
 #include "RunLabel.h"
@@ -48,5 +47,3 @@ operator!=(const GSASIIRefineFitPeaksOutputProperties &lhs,
 
 Q_DECLARE_METATYPE(
     MantidQt::CustomInterfaces::GSASIIRefineFitPeaksOutputProperties)
-
-#endif // MANTIDQTCUSTOMINTERFACES_ENGGDIFFRACTION_GSASIIREFINEFITPEAKSOUTPUTPROPERTIES_H_

--- a/qt/scientific_interfaces/EnggDiffraction/GSASIIRefineFitPeaksParameters.h
+++ b/qt/scientific_interfaces/EnggDiffraction/GSASIIRefineFitPeaksParameters.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTIDQTCUSTOMINTERFACES_ENGGDIFFRACTION_GSASIIREFINEFITPEAKSPARAMETERS_H_
-#define MANTIDQTCUSTOMINTERFACES_ENGGDIFFRACTION_GSASIIREFINEFITPEAKSPARAMETERS_H_
+#pragma once
 
 #include "DllConfig.h"
 #include "EnggDiffGSASRefinementMethod.h"
@@ -57,5 +56,3 @@ operator!=(const GSASIIRefineFitPeaksParameters &lhs,
 
 } // namespace CustomInterfaces
 } // namespace MantidQt
-
-#endif // MANTIDQTCUSTOMINTERFACES_ENGGDIFFRACTION_GSASIIREFINEFITPEAKSPARAMETERS_H_

--- a/qt/scientific_interfaces/EnggDiffraction/IEnggDiffFittingModel.h
+++ b/qt/scientific_interfaces/EnggDiffraction/IEnggDiffFittingModel.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTIDQTCUSTOMINTERFACES_ENGGDIFFRACTION_IENGGDIFFFITTINGMODEL_H_
-#define MANTIDQTCUSTOMINTERFACES_ENGGDIFFRACTION_IENGGDIFFFITTINGMODEL_H_
+#pragma once
 
 #include "RunLabel.h"
 
@@ -68,5 +67,3 @@ public:
 
 } // namespace CustomInterfaces
 } // namespace MantidQt
-
-#endif // MANTIDQTCUSTOMINTERFACES_ENGGDIFFRACTION_IENGGDIFFFITTINGMODEL_H_

--- a/qt/scientific_interfaces/EnggDiffraction/IEnggDiffFittingPresenter.h
+++ b/qt/scientific_interfaces/EnggDiffraction/IEnggDiffFittingPresenter.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTIDQTCUSTOMINTERFACES_ENGGDIFFRACTION_IENGGDIFFFITTINGPRESENTER_H_
-#define MANTIDQTCUSTOMINTERFACES_ENGGDIFFRACTION_IENGGDIFFFITTINGPRESENTER_H_
+#pragma once
 
 #include "IEnggDiffractionCalibration.h"
 #include "IEnggDiffractionParam.h"
@@ -51,5 +50,3 @@ public:
 
 } // namespace CustomInterfaces
 } // namespace MantidQt
-
-#endif // MANTIDQTCUSTOMINTERFACES_ENGGDIFFRACTION_IENGGDIFFFITTINGPRESENTER_H_

--- a/qt/scientific_interfaces/EnggDiffraction/IEnggDiffFittingView.h
+++ b/qt/scientific_interfaces/EnggDiffraction/IEnggDiffFittingView.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTIDQTCUSTOMINTERFACES_ENGGDIFFRACTION_IENGGDIFFFITTINGVIEW_H_
-#define MANTIDQTCUSTOMINTERFACES_ENGGDIFFRACTION_IENGGDIFFFITTINGVIEW_H_
+#pragma once
 
 #include "IEnggDiffractionPythonRunner.h"
 #include "IEnggDiffractionSettings.h"
@@ -234,5 +233,3 @@ public:
 
 } // namespace CustomInterfaces
 } // namespace MantidQt
-
-#endif // MANTIDQTCUSTOMINTERFACES_ENGGDIFFRACTION_IENGGDIFFFITTINGVIEW_H_

--- a/qt/scientific_interfaces/EnggDiffraction/IEnggDiffGSASFittingModel.h
+++ b/qt/scientific_interfaces/EnggDiffraction/IEnggDiffGSASFittingModel.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTIDQTCUSTOMINTERFACES_ENGGDIFFRACTION_IENGGDIFFGSASFITTINGMODEL_H_
-#define MANTIDQTCUSTOMINTERFACES_ENGGDIFFRACTION_IENGGDIFFGSASFITTINGMODEL_H_
+#pragma once
 
 #include "GSASIIRefineFitPeaksParameters.h"
 #include "IEnggDiffGSASFittingObserver.h"
@@ -96,5 +95,3 @@ public:
 
 } // namespace CustomInterfaces
 } // namespace MantidQt
-
-#endif // MANTIDQTCUSTOMINTERFACES_ENGGDIFFRACTION_IENGGDIFFGSASFITTINGMODEL_H_

--- a/qt/scientific_interfaces/EnggDiffraction/IEnggDiffGSASFittingObserver.h
+++ b/qt/scientific_interfaces/EnggDiffraction/IEnggDiffGSASFittingObserver.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTIDQTCUSTOMINTERFACES_ENGGDIFFRACTION_GSASFITTINGOBSERVER_H_
-#define MANTIDQTCUSTOMINTERFACES_ENGGDIFFRACTION_GSASFITTINGOBSERVER_H_
+#pragma once
 
 #include "GSASIIRefineFitPeaksOutputProperties.h"
 
@@ -39,5 +38,3 @@ public:
 
 } // namespace CustomInterfaces
 } // namespace MantidQt
-
-#endif // MANTIDQTCUSTOMINTERFACES_ENGGDIFFRACTION_GSASFITTINGOBSERVER_H_

--- a/qt/scientific_interfaces/EnggDiffraction/IEnggDiffGSASFittingPresenter.h
+++ b/qt/scientific_interfaces/EnggDiffraction/IEnggDiffGSASFittingPresenter.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTIDQTCUSTOMINTERFACES_ENGGDIFFRACTION_IENGGDIFFGSASFITTINGPRESENTER_H_
-#define MANTIDQTCUSTOMINTERFACES_ENGGDIFFRACTION_IENGGDIFFGSASFITTINGPRESENTER_H_
+#pragma once
 
 #include "IEnggDiffGSASFittingObserver.h"
 
@@ -55,5 +54,3 @@ public:
 
 } // namespace CustomInterfaces
 } // namespace MantidQt
-
-#endif // MANTIDQTCUSTOMINTERFACES_ENGGDIFFRACTION_IENGGDIFFGSASFITTINGPRESENTER_H_

--- a/qt/scientific_interfaces/EnggDiffraction/IEnggDiffGSASFittingView.h
+++ b/qt/scientific_interfaces/EnggDiffraction/IEnggDiffGSASFittingView.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTIDQTCUSTOMINTERFACES_ENGGDIFFRACTION_IENGGDIFFGSASFITTINGVIEW_H_
-#define MANTIDQTCUSTOMINTERFACES_ENGGDIFFRACTION_IENGGDIFFGSASFITTINGVIEW_H_
+#pragma once
 
 #include "EnggDiffGSASRefinementMethod.h"
 #include "IEnggDiffMultiRunFittingWidgetOwner.h"
@@ -134,5 +133,3 @@ public:
 
 } // namespace CustomInterfaces
 } // namespace MantidQt
-
-#endif // MANTIDQTCUSTOMINTERFACES_ENGGDIFFRACTION_IENGGDIFFGSASFITTINGVIEW_H_

--- a/qt/scientific_interfaces/EnggDiffraction/IEnggDiffMultiRunFittingWidgetAdder.h
+++ b/qt/scientific_interfaces/EnggDiffraction/IEnggDiffMultiRunFittingWidgetAdder.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTIDQT_CUSTOMINTERFACES_IENGGDIFFMULTIRUNFITTINGWIDGETADDER_H_
-#define MANTIDQT_CUSTOMINTERFACES_IENGGDIFFMULTIRUNFITTINGWIDGETADDER_H_
+#pragma once
 
 #include "IEnggDiffMultiRunFittingWidgetOwner.h"
 
@@ -21,5 +20,3 @@ public:
 
 } // namespace CustomInterfaces
 } // namespace MantidQt
-
-#endif // MANTIDQT_CUSTOMINTERFACES_IENGGDIFFMULTIRUNFITTINGWIDGETADDER_H_

--- a/qt/scientific_interfaces/EnggDiffraction/IEnggDiffMultiRunFittingWidgetModel.h
+++ b/qt/scientific_interfaces/EnggDiffraction/IEnggDiffMultiRunFittingWidgetModel.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTIDQT_CUSTOMINTERFACES_IENGGDIFFMULTIRUNFITTINGWIDGETMODEL_H_
-#define MANTIDQT_CUSTOMINTERFACES_IENGGDIFFMULTIRUNFITTINGWIDGETMODEL_H_
+#pragma once
 
 #include "RunLabel.h"
 
@@ -68,5 +67,3 @@ public:
 
 } // namespace CustomInterfaces
 } // namespace MantidQt
-
-#endif // MANTIDQT_CUSTOMINTERFACES_IENGGDIFFMULTIRUNFITTINGWIDGETMODEL_H_

--- a/qt/scientific_interfaces/EnggDiffraction/IEnggDiffMultiRunFittingWidgetOwner.h
+++ b/qt/scientific_interfaces/EnggDiffraction/IEnggDiffMultiRunFittingWidgetOwner.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTIDQT_CUSTOMINTERFACES_ENGGDIFFMULTIRUNFITTINGWIDGETOWNER_H_
-#define MANTIDQT_CUSTOMINTERFACES_ENGGDIFFMULTIRUNFITTINGWIDGETOWNER_H_
+#pragma once
 
 #include <boost/shared_ptr.hpp>
 
@@ -23,5 +22,3 @@ public:
 
 } // namespace CustomInterfaces
 } // namespace MantidQt
-
-#endif // MANTIDQT_CUSTOMINTERFACES_ENGGDIFFMULTIRUNFITTINGWIDGETOWNER_H_

--- a/qt/scientific_interfaces/EnggDiffraction/IEnggDiffMultiRunFittingWidgetPresenter.h
+++ b/qt/scientific_interfaces/EnggDiffraction/IEnggDiffMultiRunFittingWidgetPresenter.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTIDQT_CUSTOMINTERFACES_IENGGDIFFMULTIRUNFITTINGWIDGETPRESENTER_H_
-#define MANTIDQT_CUSTOMINTERFACES_IENGGDIFFMULTIRUNFITTINGWIDGETPRESENTER_H_
+#pragma once
 
 #include "IEnggDiffMultiRunFittingWidgetAdder.h"
 #include "RunLabel.h"
@@ -87,5 +86,3 @@ public:
 
 } // namespace CustomInterfaces
 } // namespace MantidQt
-
-#endif // MANTIDQT_CUSTOMINTERFACES_IENGGDIFFMULTIRUNFITTINGWIDGETPRESENTER_H_

--- a/qt/scientific_interfaces/EnggDiffraction/IEnggDiffMultiRunFittingWidgetView.h
+++ b/qt/scientific_interfaces/EnggDiffraction/IEnggDiffMultiRunFittingWidgetView.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTIDQT_CUSTOMINTERFACES_IENGGDIFFMULTIRUNFITTINGWIDGETVIEW_H_
-#define MANTIDQT_CUSTOMINTERFACES_IENGGDIFFMULTIRUNFITTINGWIDGETVIEW_H_
+#pragma once
 
 #include "IEnggDiffMultiRunFittingWidgetPresenter.h"
 #include "IEnggDiffractionUserMsg.h"
@@ -87,5 +86,3 @@ public:
 
 } // namespace CustomInterfaces
 } // namespace MantidQt
-
-#endif // MANTIDQT_CUSTOMINTERFACES_IENGGDIFFMULTIRUNFITTINGWIDGETVIEW_H_

--- a/qt/scientific_interfaces/EnggDiffraction/IEnggDiffractionCalibration.h
+++ b/qt/scientific_interfaces/EnggDiffraction/IEnggDiffractionCalibration.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTIDQTCUSTOMINTERFACES_ENGGDIFFRACTION_IENGGDIFFRACTIONCALIBRATION_H_
-#define MANTIDQTCUSTOMINTERFACES_ENGGDIFFRACTION_IENGGDIFFRACTIONCALIBRATION_H_
+#pragma once
 
 #include <vector>
 
@@ -45,5 +44,3 @@ public:
 
 } // namespace CustomInterfaces
 } // namespace MantidQt
-
-#endif // MANTIDQTCUSTOMINTERFACES_ENGGDIFFRACTION_IENGGDIFFRACTIOPYTHONRUNNER_H_

--- a/qt/scientific_interfaces/EnggDiffraction/IEnggDiffractionParam.h
+++ b/qt/scientific_interfaces/EnggDiffraction/IEnggDiffractionParam.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTIDQTCUSTOMINTERFACES_ENGGDIFFRACTION_IENGGDIFFRACTIONPARAM_H_
-#define MANTIDQTCUSTOMINTERFACES_ENGGDIFFRACTION_IENGGDIFFRACTIONPARAM_H_
+#pragma once
 
 #include "RunLabel.h"
 
@@ -40,5 +39,3 @@ public:
 
 } // namespace CustomInterfaces
 } // namespace MantidQt
-
-#endif // MANTIDQTCUSTOMINTERFACES_ENGGDIFFRACTION_IENGGDIFFRACTIOPYTHONRUNNER_H_

--- a/qt/scientific_interfaces/EnggDiffraction/IEnggDiffractionPresenter.h
+++ b/qt/scientific_interfaces/EnggDiffraction/IEnggDiffractionPresenter.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTIDQTCUSTOMINTERFACES_ENGGDIFFRACTION_IENGGDIFFRACTIONPRESENTER_H_
-#define MANTIDQTCUSTOMINTERFACES_ENGGDIFFRACTION_IENGGDIFFRACTIONPRESENTER_H_
+#pragma once
 
 namespace MantidQt {
 namespace CustomInterfaces {
@@ -53,5 +52,3 @@ public:
 
 } // namespace CustomInterfaces
 } // namespace MantidQt
-
-#endif // MANTIDQTCUSTOMINTERFACES_ENGGDIFFRACTION_IENGGDIFFRACTIONPRESENTER_H_

--- a/qt/scientific_interfaces/EnggDiffraction/IEnggDiffractionPythonRunner.h
+++ b/qt/scientific_interfaces/EnggDiffraction/IEnggDiffractionPythonRunner.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTIDQTCUSTOMINTERFACES_ENGGDIFFRACTION_IENGGDIFFRACTIONPYTHONRUNNER_H_
-#define MANTIDQTCUSTOMINTERFACES_ENGGDIFFRACTION_IENGGDIFFRACTIONPYTHONRUNNER_H_
+#pragma once
 
 namespace MantidQt {
 namespace CustomInterfaces {
@@ -37,5 +36,3 @@ public:
 
 } // namespace CustomInterfaces
 } // namespace MantidQt
-
-#endif // MANTIDQTCUSTOMINTERFACES_ENGGDIFFRACTION_IENGGDIFFRACTIOPYTHONRUNNER_H_

--- a/qt/scientific_interfaces/EnggDiffraction/IEnggDiffractionSettings.h
+++ b/qt/scientific_interfaces/EnggDiffraction/IEnggDiffractionSettings.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTIDQTCUSTOMINTERFACES_ENGGDIFFRACTION_IENGGDIFFRACTIONSETTINGS_H_
-#define MANTIDQTCUSTOMINTERFACES_ENGGDIFFRACTION_IENGGDIFFRACTIONSETTINGS_H_
+#pragma once
 
 #include <string>
 
@@ -34,5 +33,3 @@ public:
 
 } // namespace CustomInterfaces
 } // namespace MantidQt
-
-#endif // MANTIDQTCUSTOMINTERFACES_ENGGDIFFRACTION_IENGGDIFFRACTIONSETTINGS_H_

--- a/qt/scientific_interfaces/EnggDiffraction/IEnggDiffractionUserMsg.h
+++ b/qt/scientific_interfaces/EnggDiffraction/IEnggDiffractionUserMsg.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTIDQTCUSTOMINTERFACES_ENGGDIFFRACTION_IENGGDIFFRACTIONUSERMSG_H_
-#define MANTIDQTCUSTOMINTERFACES_ENGGDIFFRACTION_IENGGDIFFRACTIONUSERMSG_H_
+#pragma once
 
 #include <string>
 #include <vector>
@@ -73,5 +72,3 @@ public:
 
 } // namespace CustomInterfaces
 } // namespace MantidQt
-
-#endif // MANTIDQTCUSTOMINTERFACES_ENGGDIFFRACTION_IENGGDIFFRACTIONUSERMSG_H_

--- a/qt/scientific_interfaces/EnggDiffraction/IEnggDiffractionView.h
+++ b/qt/scientific_interfaces/EnggDiffraction/IEnggDiffractionView.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTIDQTCUSTOMINTERFACES_ENGGDIFFRACTION_IENGGDIFFRACTIONVIEW_H_
-#define MANTIDQTCUSTOMINTERFACES_ENGGDIFFRACTION_IENGGDIFFRACTIONVIEW_H_
+#pragma once
 
 #include <string>
 #include <vector>
@@ -350,5 +349,3 @@ public:
 
 } // namespace CustomInterfaces
 } // namespace MantidQt
-
-#endif // MANTIDQTCUSTOMINTERFACES_ENGGDIFFRACTION_IENGGDIFFRACTIONVIEW_H_

--- a/qt/scientific_interfaces/EnggDiffraction/IEnggVanadiumCorrectionsModel.h
+++ b/qt/scientific_interfaces/EnggDiffraction/IEnggVanadiumCorrectionsModel.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTIDQT_CUSTOMINTERFACES_IENGGVANADIUMCORRECTIONSMODEL_H_
-#define MANTIDQT_CUSTOMINTERFACES_IENGGVANADIUMCORRECTIONSMODEL_H_
+#pragma once
 
 #include "EnggDiffCalibSettings.h"
 
@@ -36,5 +35,3 @@ public:
 
 } // namespace CustomInterfaces
 } // namespace MantidQt
-
-#endif // MANTIDQT_CUSTOMINTERFACES_IENGGVANADIUMCORRECTIONSMODEL_H_

--- a/qt/scientific_interfaces/EnggDiffraction/PrecompiledHeader.h
+++ b/qt/scientific_interfaces/EnggDiffraction/PrecompiledHeader.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTIDQT_CUSTOMINTERFACES_PRECOMPILEDHEADER_H_
-#define MANTIDQT_CUSTOMINTERFACES_PRECOMPILEDHEADER_H_
+#pragma once
 
 // Mantid
 #include "MantidAPI/Algorithm.h"
@@ -22,5 +21,3 @@
 #include <set>
 #include <string>
 #include <vector>
-
-#endif // MANTIDQT_CUSTOMINTERFACES_PRECOMPILEDHEADER_H_

--- a/qt/scientific_interfaces/EnggDiffraction/RunLabel.h
+++ b/qt/scientific_interfaces/EnggDiffraction/RunLabel.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTIDQT_CUSTOMINTERFACES_ENGGDIFFRUNLABEL_H_
-#define MANTIDQT_CUSTOMINTERFACES_ENGGDIFFRUNLABEL_H_
+#pragma once
 
 #include "DllConfig.h"
 #include <cstddef>
@@ -37,5 +36,3 @@ MANTIDQT_ENGGDIFFRACTION_DLL bool operator<(const RunLabel &lhs,
 
 } // namespace CustomInterfaces
 } // namespace MantidQt
-
-#endif // MANTIDQT_CUSTOMINTERFACES_ENGGDIFFRUNLABEL_H_

--- a/qt/scientific_interfaces/EnggDiffraction/RunMap.h
+++ b/qt/scientific_interfaces/EnggDiffraction/RunMap.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTIDQTCUSTOMINTERFACES_ENGGDIFFRACTION_RUNMAP_H_
-#define MANTIDQTCUSTOMINTERFACES_ENGGDIFFRACTION_RUNMAP_H_
+#pragma once
 
 #include "RunLabel.h"
 
@@ -58,5 +57,3 @@ private:
 } // namespace MantidQt
 
 #include "RunMap.tpp"
-
-#endif

--- a/qt/scientific_interfaces/General/DataComparison.h
+++ b/qt/scientific_interfaces/General/DataComparison.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTIDQTCUSTOMINTERFACES_DATACOMPARISON_H_
-#define MANTIDQTCUSTOMINTERFACES_DATACOMPARISON_H_
+#pragma once
 
 //----------------------
 // Includes
@@ -111,5 +110,3 @@ private:
 };
 } // namespace CustomInterfaces
 } // namespace MantidQt
-
-#endif // MANTIDQTCUSTOMINTERFACES_DATACOMPARISON_H_

--- a/qt/scientific_interfaces/General/DllConfig.h
+++ b/qt/scientific_interfaces/General/DllConfig.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTIDQTINTERFACESGENERAL_DLLCONFIG_H_
-#define MANTIDQTINTERFACESGENERAL_DLLCONFIG_H_
+#pragma once
 
 #include "MantidKernel/System.h"
 
@@ -20,5 +19,3 @@
 #define MANTIDQT_INTERFACESGENERAL_DLL DLLImport
 #define EXTERN_MANTIDQT_INTERFACESGENERAL EXTERN_IMPORT
 #endif
-
-#endif // MANTIDQTINTERFACESGENERAL_DLLCONFIG_H_

--- a/qt/scientific_interfaces/General/LatticePresenter.h
+++ b/qt/scientific_interfaces/General/LatticePresenter.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTIDQTCUSTOMINTERFACES_LATTICE_PRESENTER_H
-#define MANTIDQTCUSTOMINTERFACES_LATTICE_PRESENTER_H
+#pragma once
 
 #include "MantidQtCustomInterfaces/Updateable.h"
 
@@ -35,4 +34,3 @@ private:
 };
 } // namespace CustomInterfaces
 } // namespace MantidQt
-#endif

--- a/qt/scientific_interfaces/General/LatticeView.h
+++ b/qt/scientific_interfaces/General/LatticeView.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTIDQTCUSTOMINTERFACES_LATTICE_VIEW_H
-#define MANTIDQTCUSTOMINTERFACES_LATTICE_VIEW_H
+#pragma once
 
 namespace MantidQt {
 namespace CustomInterfaces {
@@ -30,5 +29,3 @@ public:
 };
 } // namespace CustomInterfaces
 } // namespace MantidQt
-
-#endif

--- a/qt/scientific_interfaces/General/MantidEV.h
+++ b/qt/scientific_interfaces/General/MantidEV.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTIDQTCUSTOMINTERFACES_MANTID_EV_H_
-#define MANTIDQTCUSTOMINTERFACES_MANTID_EV_H_
+#pragma once
 
 #include <Poco/NObserver.h>
 #include <QActionGroup>
@@ -435,5 +434,3 @@ private:
 
 } // namespace CustomInterfaces
 } // namespace MantidQt
-
-#endif // MANTIDQTCUSTOMINTERFACES_MANTID_EV_H_

--- a/qt/scientific_interfaces/General/MantidEVWorker.h
+++ b/qt/scientific_interfaces/General/MantidEVWorker.h
@@ -9,8 +9,7 @@
 #include "MantidKernel/V3D.h"
 #include <vector>
 
-#ifndef INTERFACES_MANTID_EV_WORKER_H
-#define INTERFACES_MANTID_EV_WORKER_H
+#pragma once
 
 /**
    @class MantidEVWorker
@@ -168,5 +167,3 @@ private:
 
 } // namespace CustomInterfaces
 } // namespace MantidQt
-
-#endif // INTERFACES_MANTID_EV_WORKER_H

--- a/qt/scientific_interfaces/General/PrecompiledHeader.h
+++ b/qt/scientific_interfaces/General/PrecompiledHeader.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTIDQT_CUSTOMINTERFACES_PRECOMPILEDHEADER_H_
-#define MANTIDQT_CUSTOMINTERFACES_PRECOMPILEDHEADER_H_
+#pragma once
 
 // Mantid
 #include "MantidAPI/Algorithm.h"
@@ -22,5 +21,3 @@
 #include <set>
 #include <string>
 #include <vector>
-
-#endif // MANTIDQT_CUSTOMINTERFACES_PRECOMPILEDHEADER_H_

--- a/qt/scientific_interfaces/General/SampleTransmission.h
+++ b/qt/scientific_interfaces/General/SampleTransmission.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTIDQTCUSTOMINTERFACES_SAMPLETRANSMISSION_H_
-#define MANTIDQTCUSTOMINTERFACES_SAMPLETRANSMISSION_H_
+#pragma once
 
 //----------------------
 // Includes
@@ -53,5 +52,3 @@ private:
 };
 } // namespace CustomInterfaces
 } // namespace MantidQt
-
-#endif // MANTIDQTCUSTOMINTERFACES_SAMPLETRANSMISSION_H_

--- a/qt/scientific_interfaces/General/StepScan.h
+++ b/qt/scientific_interfaces/General/StepScan.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTIDQTCUSTOMINTERFACES_ROCKINGCURVE_H_
-#define MANTIDQTCUSTOMINTERFACES_ROCKINGCURVE_H_
+#pragma once
 
 //----------------------
 // Includes
@@ -86,5 +85,3 @@ private:
 
 } // namespace CustomInterfaces
 } // namespace MantidQt
-
-#endif // MANTIDQTCUSTOMINTERFACES_ROCKINGCURVE_H_

--- a/qt/scientific_interfaces/General/Updateable.h
+++ b/qt/scientific_interfaces/General/Updateable.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTIDQTCUSTOMINTERFACES_UPDATABLE_H
-#define MANTIDQTCUSTOMINTERFACES_UPDATABLE_H
+#pragma once
 
 #include "MantidKernel/System.h"
 
@@ -22,5 +21,3 @@ public:
 };
 } // namespace CustomInterfaces
 } // namespace MantidQt
-
-#endif

--- a/qt/scientific_interfaces/ISISReflectometry/Common/Clipboard.h
+++ b/qt/scientific_interfaces/ISISReflectometry/Common/Clipboard.h
@@ -5,8 +5,7 @@
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
 
-#ifndef MANTID_CUSTOMINTERFACES_CLIPBOARD_H_
-#define MANTID_CUSTOMINTERFACES_CLIPBOARD_H_
+#pragma once
 
 #include "DllConfig.h"
 #include "MantidQtWidgets/Common/Batch/RowLocation.h"
@@ -72,4 +71,3 @@ bool MANTIDQT_ISISREFLECTOMETRY_DLL containsGroups(Clipboard const &clipboard);
 } // namespace ISISReflectometry
 } // namespace CustomInterfaces
 } // namespace MantidQt
-#endif // MANTID_CUSTOMINTERFACES_CLIPBOARD_H_

--- a/qt/scientific_interfaces/ISISReflectometry/Common/DllConfig.h
+++ b/qt/scientific_interfaces/ISISReflectometry/Common/DllConfig.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTIDQT_ISISREFLECTOMETRY_DLLCONFIG_H_
-#define MANTIDQT_ISISREFLECTOMETRY_DLLCONFIG_H_
+#pragma once
 
 #include "MantidKernel/System.h"
 
@@ -20,5 +19,3 @@
 #define MANTIDQT_ISISREFLECTOMETRY_DLL DLLImport
 #define EXTERN_MANTIDQT_ISISREFLECTOMETRY EXTERN_IMPORT
 #endif
-
-#endif // MANTIDQT_ISISREFLECTOMETRY_DLLCONFIG_H_

--- a/qt/scientific_interfaces/ISISReflectometry/Common/First.h
+++ b/qt/scientific_interfaces/ISISReflectometry/Common/First.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_ISISREFLECTOMETRY_FIRST_H
-#define MANTID_ISISREFLECTOMETRY_FIRST_H
+#pragma once
 #include <boost/optional.hpp>
 #include <boost/variant.hpp>
 #include <vector>
@@ -43,4 +42,3 @@ public:
 } // namespace ISISReflectometry
 } // namespace CustomInterfaces
 } // namespace MantidQt
-#endif // MANTID_ISISREFLECTOMETRY_FIRST_H

--- a/qt/scientific_interfaces/ISISReflectometry/Common/GetInstrumentParameter.h
+++ b/qt/scientific_interfaces/ISISReflectometry/Common/GetInstrumentParameter.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_ISISREFLECTOMETRY_GETINSTRUMENTPARAMETER_H
-#define MANTID_ISISREFLECTOMETRY_GETINSTRUMENTPARAMETER_H
+#pragma once
 #include "MantidGeometry/Instrument.h"
 #include <boost/variant.hpp>
 #include <string>
@@ -135,4 +134,3 @@ auto getInstrumentParameter(Mantid::Geometry::Instrument_const_sptr instrument,
 } // namespace ISISReflectometry
 } // namespace CustomInterfaces
 } // namespace MantidQt
-#endif // MANTID_ISISREFLECTOMETRY_GETINSTRUMENTPARAMETER_H

--- a/qt/scientific_interfaces/ISISReflectometry/Common/IndexOf.h
+++ b/qt/scientific_interfaces/ISISReflectometry/Common/IndexOf.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_ISISREFLECTOMETRY_INDEXOF_H
-#define MANTID_ISISREFLECTOMETRY_INDEXOF_H
+#pragma once
 #include <algorithm>
 #include <boost/optional.hpp>
 #include <iterator>
@@ -34,4 +33,3 @@ boost::optional<int> indexOfValue(Container const &container, ValueType value) {
 } // namespace ISISReflectometry
 } // namespace CustomInterfaces
 } // namespace MantidQt
-#endif // MANTID_ISISREFLECTOMETRY_INDEXOF_H

--- a/qt/scientific_interfaces/ISISReflectometry/Common/InstrumentParameters.h
+++ b/qt/scientific_interfaces/ISISReflectometry/Common/InstrumentParameters.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_ISISREFLECTOMETRY_INSTRUMENTPARAMETERS_H
-#define MANTID_ISISREFLECTOMETRY_INSTRUMENTPARAMETERS_H
+#pragma once
 #include "Common/First.h"
 #include "Common/ValueOr.h"
 #include "GetInstrumentParameter.h"
@@ -137,4 +136,3 @@ private:
 } // namespace ISISReflectometry
 } // namespace CustomInterfaces
 } // namespace MantidQt
-#endif // MANTID_ISISREFLECTOMETRY_INSTRUMENTPARAMETERS_H

--- a/qt/scientific_interfaces/ISISReflectometry/Common/Map.h
+++ b/qt/scientific_interfaces/ISISReflectometry/Common/Map.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_ISISREFLECTOMETRY_MAP_H
-#define MANTID_ISISREFLECTOMETRY_MAP_H
+#pragma once
 #include <algorithm>
 #include <boost/optional.hpp>
 #include <iterator>
@@ -46,4 +45,3 @@ std::string optionalToString(boost::optional<T> maybeValue) {
 } // namespace ISISReflectometry
 } // namespace CustomInterfaces
 } // namespace MantidQt
-#endif // MANTID_ISISREFLECTOMETRY_MAP_H

--- a/qt/scientific_interfaces/ISISReflectometry/Common/OptionDefaults.h
+++ b/qt/scientific_interfaces/ISISReflectometry/Common/OptionDefaults.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_ISISREFLECTOMETRY_OPTIONDEFAULTS_H
-#define MANTID_ISISREFLECTOMETRY_OPTIONDEFAULTS_H
+#pragma once
 #include "Common/DllConfig.h"
 #include "MantidAPI/BoostOptionalToAlgorithmProperty.h"
 #include "MantidGeometry/Instrument_fwd.h"
@@ -82,4 +81,3 @@ T OptionDefaults::getValue(std::string const &propertyName,
 } // namespace ISISReflectometry
 } // namespace CustomInterfaces
 } // namespace MantidQt
-#endif // MANTID_ISISREFLECTOMETRY_OPTIONDEFAULTS_H

--- a/qt/scientific_interfaces/ISISReflectometry/Common/Parse.h
+++ b/qt/scientific_interfaces/ISISReflectometry/Common/Parse.h
@@ -5,8 +5,7 @@
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
 
-#ifndef MANTID_CUSTOMINTERFACES_PARSE_H_
-#define MANTID_CUSTOMINTERFACES_PARSE_H_
+#pragma once
 #include "DllConfig.h"
 #include <boost/algorithm/string.hpp>
 #include <boost/optional.hpp>
@@ -60,4 +59,3 @@ parseList(std::string commaSeparatedValues, ParseItemFunction parseItem) {
 } // namespace ISISReflectometry
 } // namespace CustomInterfaces
 } // namespace MantidQt
-#endif // MANTID_CUSTOMINTERFACES_PARSE_H_

--- a/qt/scientific_interfaces/ISISReflectometry/Common/QWidgetGroup.h
+++ b/qt/scientific_interfaces/ISISReflectometry/Common/QWidgetGroup.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_ISISREFLECTOMETRY_QWIDGETGROUP_H
-#define MANTID_ISISREFLECTOMETRY_QWIDGETGROUP_H
+#pragma once
 #include <QWidget>
 #include <array>
 #include <cstddef>
@@ -40,4 +39,3 @@ QWidgetGroup<sizeof...(Ts)> makeQWidgetGroup(Ts... widgets) {
 } // namespace ISISReflectometry
 } // namespace CustomInterfaces
 } // namespace MantidQt
-#endif // MANTID_ISISREFLECTOMETRY_QWIDGETGROUP_H

--- a/qt/scientific_interfaces/ISISReflectometry/Common/ValidationResult.h
+++ b/qt/scientific_interfaces/ISISReflectometry/Common/ValidationResult.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_ISISREFLECTOMETRY_RESULT_H
-#define MANTID_ISISREFLECTOMETRY_RESULT_H
+#pragma once
 #include <boost/optional.hpp>
 #include <boost/variant.hpp>
 
@@ -73,4 +72,3 @@ ValidationResult<Validated, Error>::validElseNone() const {
 } // namespace ISISReflectometry
 } // namespace CustomInterfaces
 } // namespace MantidQt
-#endif // MANTID_ISISREFLECTOMETRY_RESULT_H

--- a/qt/scientific_interfaces/ISISReflectometry/Common/ValueOr.h
+++ b/qt/scientific_interfaces/ISISReflectometry/Common/ValueOr.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_ISISREFLECTOMETRY_VALUEOR_H
-#define MANTID_ISISREFLECTOMETRY_VALUEOR_H
+#pragma once
 #include <boost/optional.hpp>
 
 /**
@@ -20,5 +19,3 @@ template <typename T, typename U>
 T value_or(boost::optional<T> const &value, U &&ifEmpty) {
   return value.get_value_or(ifEmpty);
 }
-
-#endif // MANTID_ISISREFLECTOMETRY_VALUEOR_H

--- a/qt/scientific_interfaces/ISISReflectometry/Common/ZipRange.h
+++ b/qt/scientific_interfaces/ISISReflectometry/Common/ZipRange.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_ISISREFLECTOMETRY_ZIPRANGE_H
-#define MANTID_ISISREFLECTOMETRY_ZIPRANGE_H
+#pragma once
 #include <boost/iterator/zip_iterator.hpp>
 #include <boost/range/iterator_range.hpp>
 
@@ -24,4 +23,3 @@ auto zip_range(Containers &... containers)
 } // namespace ISISReflectometry
 } // namespace CustomInterfaces
 } // namespace MantidQt
-#endif // MANTID_ISISREFLECTOMETRY_ZIPRANGE_H

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Batch/AlgorithmProperties.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Batch/AlgorithmProperties.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_CUSTOMINTERFACES_ALGORITHMPROPERTIES_H_
-#define MANTID_CUSTOMINTERFACES_ALGORITHMPROPERTIES_H_
+#pragma once
 
 #include "MantidAPI/IAlgorithm_fwd.h"
 #include "MantidKernel/Strings.h"
@@ -65,5 +64,3 @@ void update(std::string const &property, std::vector<VALUE_TYPE> const &values,
 } // namespace ISISReflectometry
 } // namespace CustomInterfaces
 } // namespace MantidQt
-
-#endif // MANTID_CUSTOMINTERFACES_ALGORITHMPROPERTIES_H_

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Batch/BatchJobAlgorithm.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Batch/BatchJobAlgorithm.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_CUSTOMINTERFACES_BATCHJOBALGORITHM_H_
-#define MANTID_CUSTOMINTERFACES_BATCHJOBALGORITHM_H_
+#pragma once
 
 #include "Common/DllConfig.h"
 #include "IBatchJobAlgorithm.h"
@@ -45,5 +44,3 @@ using BatchJobAlgorithm_sptr = boost::shared_ptr<BatchJobAlgorithm>;
 } // namespace ISISReflectometry
 } // namespace CustomInterfaces
 } // namespace MantidQt
-
-#endif // MANTID_CUSTOMINTERFACES_BATCHJOBALGORITHM_H_

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Batch/BatchJobRunner.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Batch/BatchJobRunner.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_CUSTOMINTERFACES_BATCHJOBRUNNER_H_
-#define MANTID_CUSTOMINTERFACES_BATCHJOBRUNNER_H_
+#pragma once
 
 #include "Common/DllConfig.h"
 #include "IBatchJobRunner.h"
@@ -84,5 +83,3 @@ private:
 } // namespace ISISReflectometry
 } // namespace CustomInterfaces
 } // namespace MantidQt
-
-#endif // MANTID_CUSTOMINTERFACES_BATCHJOBRUNNER_H_

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Batch/BatchPresenter.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Batch/BatchPresenter.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_ISISREFLECTOMETRY_BATCHPRESENTER_H
-#define MANTID_ISISREFLECTOMETRY_BATCHPRESENTER_H
+#pragma once
 
 #include "Common/DllConfig.h"
 #include "GUI/Event/IEventPresenter.h"
@@ -122,4 +121,3 @@ protected:
 } // namespace ISISReflectometry
 } // namespace CustomInterfaces
 } // namespace MantidQt
-#endif /* MANTID_ISISREFLECTOMETRY_BATCHPRESENTER_H */

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Batch/BatchPresenterFactory.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Batch/BatchPresenterFactory.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_ISISREFLECTOMETRY_BATCHPRESENTERFACTORY_H
-#define MANTID_ISISREFLECTOMETRY_BATCHPRESENTERFACTORY_H
+#pragma once
 #include "BatchPresenter.h"
 #include "Common/DllConfig.h"
 #include "GUI/Event/EventPresenterFactory.h"
@@ -66,4 +65,3 @@ private:
 } // namespace ISISReflectometry
 } // namespace CustomInterfaces
 } // namespace MantidQt
-#endif // MANTID_ISISREFLECTOMETRY_BATCHPRESENTERFACTORY_H

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Batch/GroupProcessingAlgorithm.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Batch/GroupProcessingAlgorithm.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_CUSTOMINTERFACES_GROUPPROCESSINGALGORITHM_H_
-#define MANTID_CUSTOMINTERFACES_GROUPPROCESSINGALGORITHM_H_
+#pragma once
 
 #include "Common/DllConfig.h"
 #include "MantidQtWidgets/Common/BatchAlgorithmRunner.h"
@@ -30,5 +29,3 @@ createAlgorithmRuntimeProps(Batch const &model, Group const &group);
 } // namespace ISISReflectometry
 } // namespace CustomInterfaces
 } // namespace MantidQt
-
-#endif // MANTID_CUSTOMINTERFACES_GROUPPROCESSINGALGORITHM_H_

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Batch/IBatchJobAlgorithm.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Batch/IBatchJobAlgorithm.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_CUSTOMINTERFACES_IBATCHJOBALGORITHM_H_
-#define MANTID_CUSTOMINTERFACES_IBATCHJOBALGORITHM_H_
+#pragma once
 
 #include "Common/DllConfig.h"
 #include "IBatchJobAlgorithm.h"
@@ -32,5 +31,3 @@ public:
 } // namespace ISISReflectometry
 } // namespace CustomInterfaces
 } // namespace MantidQt
-
-#endif // MANTID_CUSTOMINTERFACES_IBATCHJOBALGORITHM_H_

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Batch/IBatchJobRunner.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Batch/IBatchJobRunner.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_CUSTOMINTERFACES_IBATCHJOBRUNNER_H_
-#define MANTID_CUSTOMINTERFACES_IBATCHJOBRUNNER_H_
+#pragma once
 
 #include "Common/DllConfig.h"
 #include "GUI/Batch/RowProcessingAlgorithm.h"
@@ -50,5 +49,3 @@ public:
 } // namespace ISISReflectometry
 } // namespace CustomInterfaces
 } // namespace MantidQt
-
-#endif // MANTID_CUSTOMINTERFACES_IBATCHJOBRUNNER_H_

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Batch/IBatchPresenter.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Batch/IBatchPresenter.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_ISISREFLECTOMETRY_IBATCHPRESENTER_H
-#define MANTID_ISISREFLECTOMETRY_IBATCHPRESENTER_H
+#pragma once
 
 #include "GUI/Batch/RowProcessingAlgorithm.h"
 #include "MantidGeometry/Instrument_fwd.h"
@@ -63,4 +62,3 @@ public:
 } // namespace ISISReflectometry
 } // namespace CustomInterfaces
 } // namespace MantidQt
-#endif /* MANTID_ISISREFLECTOMETRY_IBATCHPRESENTER_H */

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Batch/IBatchPresenterFactory.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Batch/IBatchPresenterFactory.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_ISISREFLECTOMETRY_IBATCHPRESENTERFACTORY_H
-#define MANTID_ISISREFLECTOMETRY_IBATCHPRESENTERFACTORY_H
+#pragma once
 
 #include <memory>
 
@@ -23,4 +22,3 @@ public:
 } // namespace ISISReflectometry
 } // namespace CustomInterfaces
 } // namespace MantidQt
-#endif // MANTID_ISISREFLECTOMETRY_IBATCHPRESENTERFACTORY_H

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Batch/IBatchView.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Batch/IBatchView.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_ISISREFLECTOMETRY_IBATCHVIEW_H
-#define MANTID_ISISREFLECTOMETRY_IBATCHVIEW_H
+#pragma once
 
 #include "GUI/Event/IEventView.h"
 #include "GUI/Experiment/IExperimentView.h"
@@ -61,4 +60,3 @@ public:
 } // namespace ISISReflectometry
 } // namespace CustomInterfaces
 } // namespace MantidQt
-#endif /* MANTID_ISISREFLECTOMETRY_IBATCHVIEW_H */

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Batch/QtBatchView.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Batch/QtBatchView.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_ISISREFLECTOMETRY_QTBATCHVIEW_H
-#define MANTID_ISISREFLECTOMETRY_QTBATCHVIEW_H
+#pragma once
 
 #include "GUI/Event/QtEventView.h"
 #include "GUI/Experiment/QtExperimentView.h"
@@ -75,4 +74,3 @@ private:
 } // namespace ISISReflectometry
 } // namespace CustomInterfaces
 } // namespace MantidQt
-#endif /* MANTID_ISISREFLECTOMETRY_QTBATCHVIEW_H */

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Batch/RowProcessingAlgorithm.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Batch/RowProcessingAlgorithm.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_CUSTOMINTERFACES_ROWPROCESSINGALGORITHM_H_
-#define MANTID_CUSTOMINTERFACES_ROWPROCESSINGALGORITHM_H_
+#pragma once
 
 #include "Common/DllConfig.h"
 #include "MantidQtWidgets/Common/BatchAlgorithmRunner.h"
@@ -33,5 +32,3 @@ createAlgorithmRuntimeProps(Batch const &model);
 } // namespace ISISReflectometry
 } // namespace CustomInterfaces
 } // namespace MantidQt
-
-#endif // MANTID_CUSTOMINTERFACES_ROWPROCESSINGALGORITHM_H_

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Common/Decoder.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Common/Decoder.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_ISISREFLECTOMETRY_DECODER_H
-#define MANTID_ISISREFLECTOMETRY_DECODER_H
+#pragma once
 
 #include "../../Common/DllConfig.h"
 #include "../../Reduction/ReductionOptionsMap.h"
@@ -95,5 +94,3 @@ private:
 } // namespace ISISReflectometry
 } // namespace CustomInterfaces
 } // namespace MantidQt
-
-#endif /* MANTID_ISISREFLECTOMETRY_DECODER_H */

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Common/Encoder.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Common/Encoder.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_ISISREFLECTOMETRY_ENCODER_H
-#define MANTID_ISISREFLECTOMETRY_ENCODER_H
+#pragma once
 
 #include "../../Common/DllConfig.h"
 #include "../../Reduction/ReductionOptionsMap.h"
@@ -87,4 +86,3 @@ private:
 } // namespace ISISReflectometry
 } // namespace CustomInterfaces
 } // namespace MantidQt
-#endif /* MANTID_ISISREFLECTOMETRY_ENCODER_H */

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Common/IDecoder.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Common/IDecoder.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_ISISREFLECTOMETRY_IDECODER_H
-#define MANTID_ISISREFLECTOMETRY_IDECODER_H
+#pragma once
 
 #include <QMap>
 #include <QString>
@@ -31,4 +30,3 @@ public:
 } // namespace ISISReflectometry
 } // namespace CustomInterfaces
 } // namespace MantidQt
-#endif

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Common/IEncoder.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Common/IEncoder.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_ISISREFLECTOMETRY_IENCODER_H
-#define MANTID_ISISREFLECTOMETRY_IENCODER_H
+#pragma once
 
 #include <QMap>
 #include <QString>
@@ -32,4 +31,3 @@ public:
 } // namespace ISISReflectometry
 } // namespace CustomInterfaces
 } // namespace MantidQt
-#endif

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Common/IFileHandler.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Common/IFileHandler.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_ISISREFLECTOMETRY_IFILEHANDLER_H
-#define MANTID_ISISREFLECTOMETRY_IFILEHANDLER_H
+#pragma once
 
 #include <QMap>
 #include <QString>
@@ -30,4 +29,3 @@ public:
 } // namespace ISISReflectometry
 } // namespace CustomInterfaces
 } // namespace MantidQt
-#endif

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Common/IMessageHandler.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Common/IMessageHandler.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_ISISREFLECTOMETRY_IMESSAGEHANDLER_H
-#define MANTID_ISISREFLECTOMETRY_IMESSAGEHANDLER_H
+#pragma once
 
 #include <string>
 namespace MantidQt {
@@ -30,4 +29,3 @@ public:
 } // namespace ISISReflectometry
 } // namespace CustomInterfaces
 } // namespace MantidQt
-#endif

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Common/IPlotter.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Common/IPlotter.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_ISISREFLECTOMETRY_IPLOTTER_H
-#define MANTID_ISISREFLECTOMETRY_IPLOTTER_H
+#pragma once
 
 #include "Common/DllConfig.h"
 
@@ -25,5 +24,3 @@ public:
 } // namespace ISISReflectometry
 } // namespace CustomInterfaces
 } // namespace MantidQt
-
-#endif /* MANTID_ISISREFLECTOMETRY_IPLOTTER_H */

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Common/IPythonRunner.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Common/IPythonRunner.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_ISISREFLECTOMETRY_IPYTHONRUNNER_H
-#define MANTID_ISISREFLECTOMETRY_IPYTHONRUNNER_H
+#pragma once
 
 #include <string>
 
@@ -27,4 +26,3 @@ public:
 } // namespace ISISReflectometry
 } // namespace CustomInterfaces
 } // namespace MantidQt
-#endif

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Common/Plotter.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Common/Plotter.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_ISISREFLECTOMETRY_PLOTTER_H
-#define MANTID_ISISREFLECTOMETRY_PLOTTER_H
+#pragma once
 
 #include "Common/DllConfig.h"
 #include "IPlotter.h"
@@ -40,5 +39,3 @@ private:
 } // namespace ISISReflectometry
 } // namespace CustomInterfaces
 } // namespace MantidQt
-
-#endif /* MANTID_ISISREFLECTOMETRY_PLOTTER_H */

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Event/EventPresenter.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Event/EventPresenter.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_ISISREFLECTOMETRY_REFLEVENTPRESENTER_H
-#define MANTID_ISISREFLECTOMETRY_REFLEVENTPRESENTER_H
+#pragma once
 
 #include "../../Reduction/Slicing.h"
 #include "Common/DllConfig.h"
@@ -62,4 +61,3 @@ private:
 } // namespace ISISReflectometry
 } // namespace CustomInterfaces
 } // namespace MantidQt
-#endif /* MANTID_ISISREFLECTOMETRY_REFLEVENTPRESENTER_H */

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Event/EventPresenterFactory.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Event/EventPresenterFactory.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_ISISREFLECTOMETRY_REFLEVENTPRESENTERFACTORY_H
-#define MANTID_ISISREFLECTOMETRY_REFLEVENTPRESENTERFACTORY_H
+#pragma once
 #include "Common/DllConfig.h"
 #include "EventPresenter.h"
 #include "IEventPresenter.h"
@@ -25,4 +24,3 @@ public:
 } // namespace ISISReflectometry
 } // namespace CustomInterfaces
 } // namespace MantidQt
-#endif // MANTID_ISISREFLECTOMETRY_REFLEVENTPRESENTERFACTORY_H

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Event/IEventPresenter.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Event/IEventPresenter.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_ISISREFLECTOMETRY_IREFLEVENTPRESENTER_H
-#define MANTID_ISISREFLECTOMETRY_IREFLEVENTPRESENTER_H
+#pragma once
 
 #include "GUI/Batch/IBatchPresenter.h"
 #include "Reduction/Slicing.h"
@@ -34,4 +33,3 @@ public:
 } // namespace ISISReflectometry
 } // namespace CustomInterfaces
 } // namespace MantidQt
-#endif /* MANTID_ISISREFLECTOMETRY_IREFLEVENTPRESENTER_H */

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Event/IEventView.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Event/IEventView.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_ISISREFLECTOMETRY_IREFLEVENTVIEW_H
-#define MANTID_ISISREFLECTOMETRY_IREFLEVENTVIEW_H
+#pragma once
 
 #include "Common/DllConfig.h"
 #include <string>
@@ -58,4 +57,3 @@ public:
 } // namespace ISISReflectometry
 } // namespace CustomInterfaces
 } // namespace MantidQt
-#endif // MANTID_ISISREFLECTOMETRY_IREFLEVENTVIEW_H

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Event/QtEventView.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Event/QtEventView.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_CUSTOMINTERFACES_QTEVENTVIEW_H_
-#define MANTID_CUSTOMINTERFACES_QTEVENTVIEW_H_
+#pragma once
 
 #include "Common/QWidgetGroup.h"
 #include "IEventView.h"
@@ -87,5 +86,3 @@ private:
 } // namespace ISISReflectometry
 } // namespace CustomInterfaces
 } // namespace MantidQt
-
-#endif /* MANTID_CUSTOMINTERFACES_QTEVENTVIEW_H_ */

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Experiment/ExperimentOptionDefaults.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Experiment/ExperimentOptionDefaults.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_ISISREFLECTOMETRY_EXPERIMENTOPTIONDEFAULTS_H
-#define MANTID_ISISREFLECTOMETRY_EXPERIMENTOPTIONDEFAULTS_H
+#pragma once
 #include "Common/DllConfig.h"
 #include "MantidGeometry/Instrument_fwd.h"
 #include "Reduction/Experiment.h"
@@ -34,4 +33,3 @@ public:
 } // namespace ISISReflectometry
 } // namespace CustomInterfaces
 } // namespace MantidQt
-#endif // MANTID_ISISREFLECTOMETRY_EXPERIMENTOPTIONDEFAULTS_H

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Experiment/ExperimentPresenter.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Experiment/ExperimentPresenter.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_ISISREFLECTOMETRY_EXPERIMENTPRESENTER_H
-#define MANTID_ISISREFLECTOMETRY_EXPERIMENTPRESENTER_H
+#pragma once
 
 #include "Common/DllConfig.h"
 #include "Common/ValidationResult.h"
@@ -107,4 +106,3 @@ private:
 } // namespace ISISReflectometry
 } // namespace CustomInterfaces
 } // namespace MantidQt
-#endif // MANTID_ISISREFLECTOMETRY_EXPERIMENTPRESENTER_H

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Experiment/ExperimentPresenterFactory.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Experiment/ExperimentPresenterFactory.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_ISISREFLECTOMETRY_EXPERIMENTPRESENTERFACTORY_H
-#define MANTID_ISISREFLECTOMETRY_EXPERIMENTPRESENTERFACTORY_H
+#pragma once
 #include "../../Reduction/Experiment.h"
 #include "Common/DllConfig.h"
 #include "ExperimentPresenter.h"
@@ -33,4 +32,3 @@ private:
 } // namespace ISISReflectometry
 } // namespace CustomInterfaces
 } // namespace MantidQt
-#endif // MANTID_ISISREFLECTOMETRY_EXPERIMENTPRESENTERFACTORY_H

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Experiment/IExperimentPresenter.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Experiment/IExperimentPresenter.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_ISISREFLECTOMETRY_IEXPERIMENTPRESENTER_H
-#define MANTID_ISISREFLECTOMETRY_IEXPERIMENTPRESENTER_H
+#pragma once
 
 #include "GUI/Batch/IBatchPresenter.h"
 #include "MantidGeometry/Instrument_fwd.h"
@@ -33,4 +32,3 @@ public:
 } // namespace ISISReflectometry
 } // namespace CustomInterfaces
 } // namespace MantidQt
-#endif /* MANTID_ISISREFLECTOMETRY_IEXPERIMENTPRESENTER_H */

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Experiment/IExperimentView.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Experiment/IExperimentView.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_ISISREFLECTOMETRY_IEXPERIMENTVIEW_H
-#define MANTID_ISISREFLECTOMETRY_IEXPERIMENTVIEW_H
+#pragma once
 
 #include "Common/DllConfig.h"
 #include "Common/GetInstrumentParameter.h"
@@ -121,4 +120,3 @@ public:
 } // namespace ISISReflectometry
 } // namespace CustomInterfaces
 } // namespace MantidQt
-#endif /* MANTID_ISISREFLECTOMETRY_IEXPERIMENTVIEW_H */

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Experiment/InvalidDefaultsError.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Experiment/InvalidDefaultsError.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_ISISREFLECTOMETRY_INVALIDDEFAULTSERROR_H
-#define MANTID_ISISREFLECTOMETRY_INVALIDDEFAULTSERROR_H
+#pragma once
 #include "Common/DllConfig.h"
 #include <vector>
 
@@ -31,4 +30,3 @@ MANTIDQT_ISISREFLECTOMETRY_DLL bool operator!=(InvalidDefaultsError const &lhs,
 } // namespace ISISReflectometry
 } // namespace CustomInterfaces
 } // namespace MantidQt
-#endif // MANTID_ISISREFLECTOMETRY_INVALIDDEFAULTSERROR_H

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Experiment/PerThetaDefaultsTableValidationError.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Experiment/PerThetaDefaultsTableValidationError.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_ISISREFLECTOMETRY_PERTHETADEFAULTSTABLEVALIDATIONERROR_H
-#define MANTID_ISISREFLECTOMETRY_PERTHETADEFAULTSTABLEVALIDATIONERROR_H
+#pragma once
 #include "../../Reduction/PerThetaDefaults.h"
 #include "InvalidDefaultsError.h"
 #include "ThetaValuesValidationError.h"
@@ -32,4 +31,3 @@ private:
 } // namespace ISISReflectometry
 } // namespace CustomInterfaces
 } // namespace MantidQt
-#endif // MANTID_ISISREFLECTOMETRY_PERTHETADEFAULTSTABLEVALIDATIONERROR_H

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Experiment/PerThetaDefaultsTableValidator.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Experiment/PerThetaDefaultsTableValidator.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_ISISREFLECTOMETRY_PERTHETADEFAULTSTABLEVALIDATOR_H
-#define MANTID_ISISREFLECTOMETRY_PERTHETADEFAULTSTABLEVALIDATOR_H
+#pragma once
 #include "Common/ValidationResult.h"
 #include "PerThetaDefaultsTableValidationError.h"
 #include "Reduction/PerThetaDefaults.h"
@@ -48,4 +47,3 @@ public:
 } // namespace ISISReflectometry
 } // namespace CustomInterfaces
 } // namespace MantidQt
-#endif // MANTID_ISISREFLECTOMETRY_PERTHETADEFAULTSTABLEVALIDATOR_H

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Experiment/QtExperimentView.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Experiment/QtExperimentView.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_CUSTOMINTERFACES_QTEXPERIMENTVIEW_H_
-#define MANTID_CUSTOMINTERFACES_QTEXPERIMENTVIEW_H_
+#pragma once
 
 #include "Common/DllConfig.h"
 #include "IExperimentView.h"
@@ -189,5 +188,3 @@ private:
 } // namespace ISISReflectometry
 } // namespace CustomInterfaces
 } // namespace MantidQt
-
-#endif /* MANTID_CUSTOMINTERFACES_QTEXPERIMENTVIEW_H_ */

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Experiment/ThetaValuesValidationError.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Experiment/ThetaValuesValidationError.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_ISISREFLECTOMETRY_THETAVALUESVALIDATIONERROR_H
-#define MANTID_ISISREFLECTOMETRY_THETAVALUESVALIDATIONERROR_H
+#pragma once
 namespace MantidQt {
 namespace CustomInterfaces {
 namespace ISISReflectometry {
@@ -14,4 +13,3 @@ enum class ThetaValuesValidationError { MultipleWildcards, NonUniqueTheta };
 } // namespace ISISReflectometry
 } // namespace CustomInterfaces
 } // namespace MantidQt
-#endif // MANTID_ISISREFLECTOMETRY_THETAVALUESVALIDATIONERROR_H

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Instrument/IInstrumentPresenter.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Instrument/IInstrumentPresenter.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_ISISREFLECTOMETRY_IINSTRUMENTPRESENTER_H
-#define MANTID_ISISREFLECTOMETRY_IINSTRUMENTPRESENTER_H
+#pragma once
 
 #include "MantidGeometry/Instrument_fwd.h"
 #include "Reduction/Instrument.h"
@@ -38,4 +37,3 @@ public:
 } // namespace ISISReflectometry
 } // namespace CustomInterfaces
 } // namespace MantidQt
-#endif /* MANTID_ISISREFLECTOMETRY_IINSTRUMENTPRESENTER_H */

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Instrument/IInstrumentView.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Instrument/IInstrumentView.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_ISISREFLECTOMETRY_IINSTRUMENTVIEW_H
-#define MANTID_ISISREFLECTOMETRY_IINSTRUMENTVIEW_H
+#pragma once
 
 #include "Common/DllConfig.h"
 #include "Common/InstrumentParameters.h"
@@ -75,4 +74,3 @@ public:
 } // namespace ISISReflectometry
 } // namespace CustomInterfaces
 } // namespace MantidQt
-#endif /* MANTID_ISISREFLECTOMETRY_IINSTRUMENTVIEW_H */

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Instrument/InstrumentOptionDefaults.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Instrument/InstrumentOptionDefaults.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_ISISREFLECTOMETRY_INSTRUMENTOPTIONDEFAULTS_H
-#define MANTID_ISISREFLECTOMETRY_INSTRUMENTOPTIONDEFAULTS_H
+#pragma once
 #include "Common/DllConfig.h"
 #include "MantidAPI/BoostOptionalToAlgorithmProperty.h"
 #include "MantidGeometry/Instrument_fwd.h"
@@ -36,4 +35,3 @@ public:
 } // namespace ISISReflectometry
 } // namespace CustomInterfaces
 } // namespace MantidQt
-#endif // MANTID_ISISREFLECTOMETRY_INSTRUMENTOPTIONDEFAULTS_H

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Instrument/InstrumentPresenter.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Instrument/InstrumentPresenter.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_ISISREFLECTOMETRY_INSTRUMENTPRESENTER_H
-#define MANTID_ISISREFLECTOMETRY_INSTRUMENTPRESENTER_H
+#pragma once
 
 #include "../../Reduction/Instrument.h"
 #include "Common/DllConfig.h"
@@ -71,4 +70,3 @@ private:
 } // namespace ISISReflectometry
 } // namespace CustomInterfaces
 } // namespace MantidQt
-#endif // MANTID_ISISREFLECTOMETRY_INSTRUMENTPRESENTER_H

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Instrument/InstrumentPresenterFactory.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Instrument/InstrumentPresenterFactory.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_ISISREFLECTOMETRY_INSTRUMENTPRESENTERFACTORY_H
-#define MANTID_ISISREFLECTOMETRY_INSTRUMENTPRESENTERFACTORY_H
+#pragma once
 #include "../../Reduction/Instrument.h"
 #include "Common/DllConfig.h"
 #include "IInstrumentPresenter.h"
@@ -28,4 +27,3 @@ public:
 } // namespace ISISReflectometry
 } // namespace CustomInterfaces
 } // namespace MantidQt
-#endif // MANTID_ISISREFLECTOMETRY_INSTRUMENTPRESENTERFACTORY_H

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Instrument/QtInstrumentView.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Instrument/QtInstrumentView.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_CUSTOMINTERFACES_QTINSTRUMENTVIEW_H_
-#define MANTID_CUSTOMINTERFACES_QTINSTRUMENTVIEW_H_
+#pragma once
 
 #include "Common/DllConfig.h"
 #include "IInstrumentView.h"
@@ -119,5 +118,3 @@ private:
 } // namespace ISISReflectometry
 } // namespace CustomInterfaces
 } // namespace MantidQt
-
-#endif /* MANTID_CUSTOMINTERFACES_QTINSTRUMENTVIEW_H_ */

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/MainWindow/IMainWindowPresenter.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/MainWindow/IMainWindowPresenter.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_ISISREFLECTOMETRY_IMAINWINDOWPRESENTER_H
-#define MANTID_ISISREFLECTOMETRY_IMAINWINDOWPRESENTER_H
+#pragma once
 
 #include "IMainWindowView.h"
 #include <string>
@@ -38,4 +37,3 @@ public:
 } // namespace ISISReflectometry
 } // namespace CustomInterfaces
 } // namespace MantidQt
-#endif /* MANTID_ISISREFLECTOMETRY_IMAINWINDOWPRESENTER_H */

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/MainWindow/IMainWindowView.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/MainWindow/IMainWindowView.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_ISISREFLECTOMETRY_IREFLWINDOWVIEW_H
-#define MANTID_ISISREFLECTOMETRY_IREFLWINDOWVIEW_H
+#pragma once
 
 #include "GUI/Batch/IBatchView.h"
 #include <string>
@@ -48,4 +47,3 @@ public:
 } // namespace ISISReflectometry
 } // namespace CustomInterfaces
 } // namespace MantidQt
-#endif /* MANTID_ISISREFLECTOMETRY_IREFLWINDOWVIEW_H */

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/MainWindow/MainWindowPresenter.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/MainWindow/MainWindowPresenter.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_ISISREFLECTOMETRY_MAINWINDOWPRESENTER_H
-#define MANTID_ISISREFLECTOMETRY_MAINWINDOWPRESENTER_H
+#pragma once
 
 #include "Common/DllConfig.h"
 #include "GUI/Batch/IBatchPresenter.h"
@@ -103,4 +102,3 @@ private:
 } // namespace ISISReflectometry
 } // namespace CustomInterfaces
 } // namespace MantidQt
-#endif /* MANTID_ISISREFLECTOMETRY_MAINWINDOWPRESENTER_H */

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/MainWindow/QtMainWindowView.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/MainWindow/QtMainWindowView.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_ISISREFLECTOMETRY_QTMAINWINDOWVIEW_H
-#define MANTID_ISISREFLECTOMETRY_QTMAINWINDOWVIEW_H
+#pragma once
 
 #include "GUI/Common/IFileHandler.h"
 #include "GUI/Common/IMessageHandler.h"
@@ -103,4 +102,3 @@ private:
 } // namespace ISISReflectometry
 } // namespace CustomInterfaces
 } // namespace MantidQt
-#endif /* MANTID_ISISREFLECTOMETRY_QTMAINWINDOWVIEW_H */

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Runs/CatalogRunNotifier.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Runs/CatalogRunNotifier.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_ISISREFLECTOMETRY_CATALOGRUNNOTIFIER_H
-#define MANTID_ISISREFLECTOMETRY_CATALOGRUNNOTIFIER_H
+#pragma once
 
 #include "Common/DllConfig.h"
 #include "IRunNotifier.h"
@@ -43,4 +42,3 @@ private:
 } // namespace ISISReflectometry
 } // namespace CustomInterfaces
 } // namespace MantidQt
-#endif

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Runs/IRunNotifier.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Runs/IRunNotifier.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_ISISREFLECTOMETRY_IREFLRUNNOTIFIER_H
-#define MANTID_ISISREFLECTOMETRY_IREFLRUNNOTIFIER_H
+#pragma once
 
 #include <string>
 
@@ -33,4 +32,3 @@ public:
 } // namespace ISISReflectometry
 } // namespace CustomInterfaces
 } // namespace MantidQt
-#endif

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Runs/IRunsPresenter.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Runs/IRunsPresenter.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_ISISREFLECTOMETRY_IREFLRUNSPRESENTER_H
-#define MANTID_ISISREFLECTOMETRY_IREFLRUNSPRESENTER_H
+#pragma once
 
 #include "Reduction/RunsTable.h"
 #include <string>
@@ -62,4 +61,3 @@ public:
 } // namespace ISISReflectometry
 } // namespace CustomInterfaces
 } // namespace MantidQt
-#endif /* MANTID_ISISREFLECTOMETRY_IREFLRUNSPRESENTER_H */

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Runs/IRunsView.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Runs/IRunsView.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_ISISREFLECTOMETRY_IRUNSVIEW_H
-#define MANTID_ISISREFLECTOMETRY_IRUNSVIEW_H
+#pragma once
 
 #include "Common/DllConfig.h"
 #include "GUI/RunsTable/IRunsTableView.h"
@@ -113,4 +112,3 @@ public:
 } // namespace ISISReflectometry
 } // namespace CustomInterfaces
 } // namespace MantidQt
-#endif /* MANTID_ISISREFLECTOMETRY_IRUNSVIEW_H */

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Runs/ISearchModel.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Runs/ISearchModel.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_ISISREFLECTOMETRY_ISEARCHMODEL_H_
-#define MANTID_ISISREFLECTOMETRY_ISEARCHMODEL_H_
+#pragma once
 
 #include "Common/DllConfig.h"
 #include "MantidAPI/ITableWorkspace_fwd.h"
@@ -31,5 +30,3 @@ using ISearchModel_sptr = boost::shared_ptr<ISearchModel>;
 } // namespace ISISReflectometry
 } // namespace CustomInterfaces
 } // namespace MantidQt
-
-#endif /* MANTID_ISISREFLECTOMETRY_ISEARCHMODEL_H_ */

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Runs/ISearcher.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Runs/ISearcher.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_ISISREFLECTOMETRY_IREFLSEARCHER_H
-#define MANTID_ISISREFLECTOMETRY_IREFLSEARCHER_H
+#pragma once
 
 #include <string>
 
@@ -50,4 +49,3 @@ public:
 } // namespace ISISReflectometry
 } // namespace CustomInterfaces
 } // namespace MantidQt
-#endif

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Runs/QtCatalogSearcher.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Runs/QtCatalogSearcher.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_ISISREFLECTOMETRY_QTCATALOGSEARCHER_H
-#define MANTID_ISISREFLECTOMETRY_QTCATALOGSEARCHER_H
+#pragma once
 
 #include "GUI/Runs/IRunsView.h"
 #include "ISearcher.h"
@@ -79,4 +78,3 @@ bool hasActiveCatalogSession();
 } // namespace ISISReflectometry
 } // namespace CustomInterfaces
 } // namespace MantidQt
-#endif /* MANTID_ISISREFLECTOMETRY_QTCATALOGSEARCHER_H */

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Runs/QtRunsView.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Runs/QtRunsView.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_ISISREFLECTOMETRY_QTRUNSVIEW_H_
-#define MANTID_ISISREFLECTOMETRY_QTRUNSVIEW_H_
+#pragma once
 
 #include "Common/DllConfig.h"
 #include "GUI/RunsTable/QtRunsTableView.h"
@@ -130,5 +129,3 @@ private slots:
 } // namespace ISISReflectometry
 } // namespace CustomInterfaces
 } // namespace MantidQt
-
-#endif /* MANTID_ISISREFLECTOMETRY_QTRUNSVIEW_H_ */

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Runs/QtSearchModel.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Runs/QtSearchModel.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_ISISREFLECTOMETRY_QTSEARCHMODEL_H_
-#define MANTID_ISISREFLECTOMETRY_QTSEARCHMODEL_H_
+#pragma once
 
 #include "Common/DllConfig.h"
 #include "ISearchModel.h"
@@ -63,5 +62,3 @@ private:
 } // namespace ISISReflectometry
 } // namespace CustomInterfaces
 } // namespace MantidQt
-
-#endif /* MANTID_ISISREFLECTOMETRY_QTSEARCHMODEL_H_ */

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Runs/RunsPresenter.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Runs/RunsPresenter.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_ISISREFLECTOMETRY_RUNSPRESENTER_H
-#define MANTID_ISISREFLECTOMETRY_RUNSPRESENTER_H
+#pragma once
 
 #include "CatalogRunNotifier.h"
 #include "Common/DllConfig.h"
@@ -191,4 +190,3 @@ private:
 } // namespace ISISReflectometry
 } // namespace CustomInterfaces
 } // namespace MantidQt
-#endif /* MANTID_ISISREFLECTOMETRY_RUNSPRESENTER_H */

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Runs/RunsPresenterFactory.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Runs/RunsPresenterFactory.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_ISISREFLECTOMETRY_RUNSPRESENTERFACTORY_H
-#define MANTID_ISISREFLECTOMETRY_RUNSPRESENTERFACTORY_H
+#pragma once
 #include "Common/DllConfig.h"
 #include "GUI/RunsTable/RunsTablePresenterFactory.h"
 #include "IRunsPresenter.h"
@@ -44,4 +43,3 @@ private:
 } // namespace ISISReflectometry
 } // namespace CustomInterfaces
 } // namespace MantidQt
-#endif // MANTID_ISISREFLECTOMETRY_RUNSPRESENTERFACTORY_H

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Runs/SearchResult.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Runs/SearchResult.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_ISISREFLECTOMETRY_SEARCHRESULT_H
-#define MANTID_ISISREFLECTOMETRY_SEARCHRESULT_H
+#pragma once
 #include "Common/DllConfig.h"
 #include <string>
 
@@ -44,4 +43,3 @@ MANTIDQT_ISISREFLECTOMETRY_DLL bool operator!=(SearchResult const &lhs,
 } // namespace ISISReflectometry
 } // namespace CustomInterfaces
 } // namespace MantidQt
-#endif // MANTID_ISISREFLECTOMETRY_SEARCHRESULT_H

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/RunsTable/IRunsTablePresenter.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/RunsTable/IRunsTablePresenter.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_ISISREFLECTOMETRY_IREFLRUNSTABLEPRESENTER_H
-#define MANTID_ISISREFLECTOMETRY_IREFLRUNSTABLEPRESENTER_H
+#pragma once
 
 #include "GUI/Batch/IBatchPresenter.h"
 
@@ -53,4 +52,3 @@ public:
 } // namespace ISISReflectometry
 } // namespace CustomInterfaces
 } // namespace MantidQt
-#endif /* MANTID_ISISREFLECTOMETRY_IREFLRUNSTABLEPRESENTER_H */

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/RunsTable/IRunsTableView.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/RunsTable/IRunsTableView.h
@@ -5,8 +5,7 @@
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
 
-#ifndef MANTID_CUSTOMINTERFACES_IBATCHVIEW_H_
-#define MANTID_CUSTOMINTERFACES_IBATCHVIEW_H_
+#pragma once
 #include "Common/DllConfig.h"
 #include "MantidQtWidgets/Common/Batch/IJobTreeView.h"
 
@@ -85,4 +84,3 @@ public:
 } // namespace ISISReflectometry
 } // namespace CustomInterfaces
 } // namespace MantidQt
-#endif // MANTID_CUSTOMINTERFACES_IBATCHVIEW_H_

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/RunsTable/JobsViewUpdater.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/RunsTable/JobsViewUpdater.h
@@ -5,8 +5,7 @@
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
 
-#ifndef MANTID_ISISREFLECTOMETRY_JOBVIEWUPDATER_H
-#define MANTID_ISISREFLECTOMETRY_JOBVIEWUPDATER_H
+#pragma once
 #include "Common/Map.h"
 #include "MantidQtWidgets/Common/Batch/IJobTreeView.h"
 #include "MantidQtWidgets/Common/ParseKeyValueString.h"
@@ -100,4 +99,3 @@ private:
 } // namespace ISISReflectometry
 } // namespace CustomInterfaces
 } // namespace MantidQt
-#endif // MANTID_ISISREFLECTOMETRY_JOBVIEWUPDATER_H

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/RunsTable/QtRunsTableView.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/RunsTable/QtRunsTableView.h
@@ -5,8 +5,7 @@
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
 
-#ifndef MANTID_CUSTOMINTERFACES_QTRUNSTABLEVIEW_H_
-#define MANTID_CUSTOMINTERFACES_QTRUNSTABLEVIEW_H_
+#pragma once
 #include "Common/DllConfig.h"
 #include "IRunsTableView.h"
 #include "MantidQtWidgets/Common/Batch/JobTreeView.h"
@@ -94,4 +93,3 @@ private:
 } // namespace ISISReflectometry
 } // namespace CustomInterfaces
 } // namespace MantidQt
-#endif // MANTID_CUSTOMINTERFACES_QTRUNSTABLEVIEW_H_

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/RunsTable/RegexRowFilter.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/RunsTable/RegexRowFilter.h
@@ -5,8 +5,7 @@
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
 
-#ifndef MANTID_CUSTOMINTERFACES_ROWFILTER_H_
-#define MANTID_CUSTOMINTERFACES_ROWFILTER_H_
+#pragma once
 
 #include "MantidQtWidgets/Common/Batch/IJobTreeView.h"
 #include "MantidQtWidgets/Common/Batch/RowPredicate.h"
@@ -41,5 +40,3 @@ filterFromRegexString(std::string const &regex,
 } // namespace ISISReflectometry
 } // namespace CustomInterfaces
 } // namespace MantidQt
-
-#endif // MANTID_CUSTOMINTERFACES_ROWFILTER_H_

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/RunsTable/RunsTablePresenter.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/RunsTable/RunsTablePresenter.h
@@ -5,8 +5,7 @@
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
 
-#ifndef MANTID_CUSTOMINTERFACES_RUNSTABLEPRESENTER_H_
-#define MANTID_CUSTOMINTERFACES_RUNSTABLEPRESENTER_H_
+#pragma once
 #include "../Runs/IRunsPresenter.h"
 #include "Common/Clipboard.h"
 #include "Common/DllConfig.h"
@@ -177,4 +176,3 @@ private:
 } // namespace ISISReflectometry
 } // namespace CustomInterfaces
 } // namespace MantidQt
-#endif // MANTID_CUSTOMINTERFACES_RUNSTABLEPRESENTER_H_

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/RunsTable/RunsTablePresenterFactory.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/RunsTable/RunsTablePresenterFactory.h
@@ -5,8 +5,7 @@
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
 
-#ifndef MANTID_CUSTOMINTERFACES_BATCHPRESENTERFACTORY_H_
-#define MANTID_CUSTOMINTERFACES_BATCHPRESENTERFACTORY_H_
+#pragma once
 #include "Common/DllConfig.h"
 #include "GUI/Common/Plotter.h"
 #include "IRunsTablePresenter.h"
@@ -35,4 +34,3 @@ protected:
 } // namespace ISISReflectometry
 } // namespace CustomInterfaces
 } // namespace MantidQt
-#endif // MANTID_CUSTOMINTERFACES_BATCHPRESENTERFACTORY_H_

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Save/AsciiSaver.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Save/AsciiSaver.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_ISISREFLECTOMETRY_ASCIISAVER_H
-#define MANTID_ISISREFLECTOMETRY_ASCIISAVER_H
+#pragma once
 #include "IAsciiSaver.h"
 #include "MantidAPI/IAlgorithm_fwd.h"
 #include "MantidAPI/Workspace_fwd.h"
@@ -47,4 +46,3 @@ private:
 } // namespace ISISReflectometry
 } // namespace CustomInterfaces
 } // namespace MantidQt
-#endif // MANTID_ISISREFLECTOMETRY_ASCIISAVER_H

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Save/IAsciiSaver.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Save/IAsciiSaver.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_ISISREFLECTOMETRY_IASCIISAVER_H
-#define MANTID_ISISREFLECTOMETRY_IASCIISAVER_H
+#pragma once
 #include "Common/DllConfig.h"
 #include "MantidAPI/IAlgorithm_fwd.h"
 #include "MantidAPI/MatrixWorkspace_fwd.h"
@@ -79,4 +78,3 @@ public:
 } // namespace ISISReflectometry
 } // namespace CustomInterfaces
 } // namespace MantidQt
-#endif // MANTID_ISISREFLECTOMETRY_IASCIISAVER_H

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Save/ISavePresenter.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Save/ISavePresenter.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_ISISREFLECTOMETRY_ISAVEPRESENTER_H
-#define MANTID_ISISREFLECTOMETRY_ISAVEPRESENTER_H
+#pragma once
 
 namespace MantidQt {
 namespace CustomInterfaces {
@@ -36,4 +35,3 @@ public:
 } // namespace ISISReflectometry
 } // namespace CustomInterfaces
 } // namespace MantidQt
-#endif /* MANTID_ISISREFLECTOMETRY_ISAVEPRESENTER_H */

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Save/ISaveView.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Save/ISaveView.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_ISISREFLECTOMETRY_ISAVEVIEW_H
-#define MANTID_ISISREFLECTOMETRY_ISAVEVIEW_H
+#pragma once
 
 #include "Common/DllConfig.h"
 #include <string>
@@ -74,4 +73,3 @@ public:
 } // namespace ISISReflectometry
 } // namespace CustomInterfaces
 } // namespace MantidQt
-#endif /* MANTID_ISISREFLECTOMETRY_ISAVEVIEW_H */

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Save/QtSaveView.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Save/QtSaveView.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_CUSTOMINTERFACES_QTSAVEVIEW_H_
-#define MANTID_CUSTOMINTERFACES_QTSAVEVIEW_H_
+#pragma once
 
 #include "ISaveView.h"
 #include "ui_SaveWidget.h"
@@ -114,5 +113,3 @@ private:
 } // namespace ISISReflectometry
 } // namespace CustomInterfaces
 } // namespace MantidQt
-
-#endif /* MANTID_CUSTOMINTERFACES_QTSAVEVIEW_H_ */

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Save/SavePresenter.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Save/SavePresenter.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_CUSTOMINTERFACES_SAVEPRESENTER_H
-#define MANTID_CUSTOMINTERFACES_SAVEPRESENTER_H
+#pragma once
 
 #include "Common/DllConfig.h"
 #include "IAsciiSaver.h"
@@ -88,4 +87,3 @@ private:
 } // namespace ISISReflectometry
 } // namespace CustomInterfaces
 } // namespace MantidQt
-#endif /* MANTID_CUSTOMINTERFACES_SAVEPRESENTER_H */

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Save/SavePresenterFactory.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Save/SavePresenterFactory.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_ISISREFLECTOMETRY_SAVEPRESENTERFACTORY_H
-#define MANTID_ISISREFLECTOMETRY_SAVEPRESENTERFACTORY_H
+#pragma once
 #include "AsciiSaver.h"
 #include "Common/DllConfig.h"
 #include "ISavePresenter.h"
@@ -27,4 +26,3 @@ public:
 } // namespace ISISReflectometry
 } // namespace CustomInterfaces
 } // namespace MantidQt
-#endif // MANTID_ISISREFLECTOMETRY_SAVEPRESENTERFACTORY_H

--- a/qt/scientific_interfaces/ISISReflectometry/PrecompiledHeader.h
+++ b/qt/scientific_interfaces/ISISReflectometry/PrecompiledHeader.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTIDQT_MUON_PRECOMPILEDHEADER_H_
-#define MANTIDQT_MUON_PRECOMPILEDHEADER_H_
+#pragma once
 
 // Mantid
 #include "MantidAPI/Algorithm.h"
@@ -22,5 +21,3 @@
 #include <set>
 #include <string>
 #include <vector>
-
-#endif // MANTIDQT_MUON_PRECOMPILEDHEADER_H_

--- a/qt/scientific_interfaces/ISISReflectometry/Reduction/AllInitialized.h
+++ b/qt/scientific_interfaces/ISISReflectometry/Reduction/AllInitialized.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_CUSTOMINTERFACES_ALLINITIALIZED_H_
-#define MANTID_CUSTOMINTERFACES_ALLINITIALIZED_H_
+#pragma once
 #include <boost/optional.hpp>
 
 namespace MantidQt {
@@ -36,4 +35,3 @@ makeIfAllInitialized(boost::optional<Params> const &... params) {
 } // namespace ISISReflectometry
 } // namespace CustomInterfaces
 } // namespace MantidQt
-#endif // MANTID_CUSTOMINTERFACES_ALLINITIALIZED_H_

--- a/qt/scientific_interfaces/ISISReflectometry/Reduction/AnalysisMode.h
+++ b/qt/scientific_interfaces/ISISReflectometry/Reduction/AnalysisMode.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_CUSTOMINTERFACES_ANALYSISMODE_H_
-#define MANTID_CUSTOMINTERFACES_ANALYSISMODE_H_
+#pragma once
 #include <stdexcept>
 #include <string>
 namespace MantidQt {
@@ -34,4 +33,3 @@ inline std::string analysisModeToString(AnalysisMode analysisMode) {
 } // namespace ISISReflectometry
 } // namespace CustomInterfaces
 } // namespace MantidQt
-#endif // MANTID_CUSTOMINTERFACES_ANALYSISMODE_H_

--- a/qt/scientific_interfaces/ISISReflectometry/Reduction/Batch.h
+++ b/qt/scientific_interfaces/ISISReflectometry/Reduction/Batch.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_CUSTOMINTERFACES_BATCH_H_
-#define MANTID_CUSTOMINTERFACES_BATCH_H_
+#pragma once
 
 #include "Common/DllConfig.h"
 #include "Experiment.h"
@@ -61,4 +60,3 @@ bool Batch::isInSelection(T const &item,
 } // namespace ISISReflectometry
 } // namespace CustomInterfaces
 } // namespace MantidQt
-#endif // MANTID_CUSTOMINTERFACES_BATCH_H_

--- a/qt/scientific_interfaces/ISISReflectometry/Reduction/DetectorCorrections.h
+++ b/qt/scientific_interfaces/ISISReflectometry/Reduction/DetectorCorrections.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_CUSTOMINTERFACES_DETECTORCORRECTIONS_H_
-#define MANTID_CUSTOMINTERFACES_DETECTORCORRECTIONS_H_
+#pragma once
 #include "Common/DllConfig.h"
 #include <stdexcept>
 #include <string>
@@ -64,4 +63,3 @@ MANTIDQT_ISISREFLECTOMETRY_DLL bool operator!=(DetectorCorrections const &lhs,
 } // namespace ISISReflectometry
 } // namespace CustomInterfaces
 } // namespace MantidQt
-#endif // MANTID_CUSTOMINTERFACES_DETECTORCORRECTIONS_H_

--- a/qt/scientific_interfaces/ISISReflectometry/Reduction/Experiment.h
+++ b/qt/scientific_interfaces/ISISReflectometry/Reduction/Experiment.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_CUSTOMINTERFACES_EXPERIMENT_H_
-#define MANTID_CUSTOMINTERFACES_EXPERIMENT_H_
+#pragma once
 
 #include "AnalysisMode.h"
 #include "Common/DllConfig.h"
@@ -78,4 +77,3 @@ MANTIDQT_ISISREFLECTOMETRY_DLL bool operator!=(Experiment const &lhs,
 } // namespace ISISReflectometry
 } // namespace CustomInterfaces
 } // namespace MantidQt
-#endif // MANTID_CUSTOMINTERFACES_EXPERIMENT_H_

--- a/qt/scientific_interfaces/ISISReflectometry/Reduction/FloodCorrections.h
+++ b/qt/scientific_interfaces/ISISReflectometry/Reduction/FloodCorrections.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_CUSTOMINTERFACES_FLOODCORRECTIONS_H_
-#define MANTID_CUSTOMINTERFACES_FLOODCORRECTIONS_H_
+#pragma once
 #include "Common/DllConfig.h"
 #include <boost/optional.hpp>
 #include <string>
@@ -64,4 +63,3 @@ MANTIDQT_ISISREFLECTOMETRY_DLL bool operator!=(FloodCorrections const &lhs,
 } // namespace ISISReflectometry
 } // namespace CustomInterfaces
 } // namespace MantidQt
-#endif // MANTID_CUSTOMINTERFACES_FLOODCORRECTIONS_H_

--- a/qt/scientific_interfaces/ISISReflectometry/Reduction/Group.h
+++ b/qt/scientific_interfaces/ISISReflectometry/Reduction/Group.h
@@ -5,8 +5,7 @@
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
 
-#ifndef MANTID_CUSTOMINTERFACES_GROUP_H_
-#define MANTID_CUSTOMINTERFACES_GROUP_H_
+#pragma once
 #include "Common/DllConfig.h"
 #include "Item.h"
 #include "Row.h"
@@ -103,4 +102,3 @@ MANTIDQT_ISISREFLECTOMETRY_DLL bool operator==(Group const &lhs,
 } // namespace ISISReflectometry
 } // namespace CustomInterfaces
 } // namespace MantidQt
-#endif // MANTID_CUSTOMINTERFACES_GROUP_H_

--- a/qt/scientific_interfaces/ISISReflectometry/Reduction/Instrument.h
+++ b/qt/scientific_interfaces/ISISReflectometry/Reduction/Instrument.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_CUSTOMINTERFACES_INSTRUMENT_H_
-#define MANTID_CUSTOMINTERFACES_INSTRUMENT_H_
+#pragma once
 
 #include "Common/DllConfig.h"
 #include "DetectorCorrections.h"
@@ -52,4 +51,3 @@ MANTIDQT_ISISREFLECTOMETRY_DLL bool operator!=(Instrument const &lhs,
 } // namespace ISISReflectometry
 } // namespace CustomInterfaces
 } // namespace MantidQt
-#endif // MANTID_CUSTOMINTERFACES_INSTRUMENT_H_

--- a/qt/scientific_interfaces/ISISReflectometry/Reduction/Item.h
+++ b/qt/scientific_interfaces/ISISReflectometry/Reduction/Item.h
@@ -5,8 +5,7 @@
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
 
-#ifndef MANTID_CUSTOMINTERFACES_ITEM_H_
-#define MANTID_CUSTOMINTERFACES_ITEM_H_
+#pragma once
 #include "Common/DllConfig.h"
 #include "ItemState.h"
 #include <string>
@@ -61,4 +60,3 @@ protected:
 } // namespace ISISReflectometry
 } // namespace CustomInterfaces
 } // namespace MantidQt
-#endif // MANTID_CUSTOMINTERFACE_ITEM_H_

--- a/qt/scientific_interfaces/ISISReflectometry/Reduction/ItemState.h
+++ b/qt/scientific_interfaces/ISISReflectometry/Reduction/ItemState.h
@@ -5,8 +5,7 @@
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
 
-#ifndef MANTID_CUSTOMINTERFACES_STATE_H_
-#define MANTID_CUSTOMINTERFACES_STATE_H_
+#pragma once
 #include "Common/DllConfig.h"
 #include <boost/optional.hpp>
 #include <string>
@@ -56,4 +55,3 @@ private:
 } // namespace ISISReflectometry
 } // namespace CustomInterfaces
 } // namespace MantidQt
-#endif // MANTID_CUSTOMINTERFACE_STATE_H_

--- a/qt/scientific_interfaces/ISISReflectometry/Reduction/MonitorCorrections.h
+++ b/qt/scientific_interfaces/ISISReflectometry/Reduction/MonitorCorrections.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_CUSTOMINTERFACES_MONITORCORRECTIONS_H_
-#define MANTID_CUSTOMINTERFACES_MONITORCORRECTIONS_H_
+#pragma once
 #include "Common/DllConfig.h"
 #include "RangeInLambda.h"
 #include <boost/optional.hpp>
@@ -43,4 +42,3 @@ MANTIDQT_ISISREFLECTOMETRY_DLL bool operator==(MonitorCorrections const &lhs,
 } // namespace ISISReflectometry
 } // namespace CustomInterfaces
 } // namespace MantidQt
-#endif // MANTID_CUSTOMINTERFACES_MONITORCORRECTIONS_H_

--- a/qt/scientific_interfaces/ISISReflectometry/Reduction/ParseReflectometryStrings.h
+++ b/qt/scientific_interfaces/ISISReflectometry/Reduction/ParseReflectometryStrings.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_CUSTOMINTERFACES_PARSEREFLECTOMETRYSTRINGS_H_
-#define MANTID_CUSTOMINTERFACES_PARSEREFLECTOMETRYSTRINGS_H_
+#pragma once
 #include "Common/DllConfig.h"
 #include "RangeInQ.h"
 #include "TransmissionRunPair.h"
@@ -56,4 +55,3 @@ parseProcessingInstructions(std::string const &instructions);
 } // namespace ISISReflectometry
 } // namespace CustomInterfaces
 } // namespace MantidQt
-#endif // MANTID_CUSTOMINTERFACES_PARSEREFLECTOMETRYSTRINGS_H_

--- a/qt/scientific_interfaces/ISISReflectometry/Reduction/PerThetaDefaults.h
+++ b/qt/scientific_interfaces/ISISReflectometry/Reduction/PerThetaDefaults.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_CUSTOMINTERFACES_PERTHETADEFAULTS_H_
-#define MANTID_CUSTOMINTERFACES_PERTHETADEFAULTS_H_
+#pragma once
 #include "Common/DllConfig.h"
 #include "ProcessingInstructions.h"
 #include "RangeInQ.h"
@@ -89,4 +88,3 @@ perThetaDefaultsToArray(PerThetaDefaults const &perThetaDefaults);
 } // namespace ISISReflectometry
 } // namespace CustomInterfaces
 } // namespace MantidQt
-#endif // MANTID_CUSTOMINTERFACES_PERTHETADEFAULTS_H_

--- a/qt/scientific_interfaces/ISISReflectometry/Reduction/PolarizationCorrections.h
+++ b/qt/scientific_interfaces/ISISReflectometry/Reduction/PolarizationCorrections.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_CUSTOMINTERFACES_POLARIZATIONCORRECTIONS_H_
-#define MANTID_CUSTOMINTERFACES_POLARIZATIONCORRECTIONS_H_
+#pragma once
 #include "Common/DllConfig.h"
 #include <boost/optional.hpp>
 #include <stdexcept>
@@ -62,4 +61,3 @@ operator!=(PolarizationCorrections const &lhs,
 } // namespace ISISReflectometry
 } // namespace CustomInterfaces
 } // namespace MantidQt
-#endif // MANTID_CUSTOMINTERFACES_POLARIZATIONCORRECTIONS_H_

--- a/qt/scientific_interfaces/ISISReflectometry/Reduction/ProcessingInstructions.h
+++ b/qt/scientific_interfaces/ISISReflectometry/Reduction/ProcessingInstructions.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_CUSTOMINTERFACES_PROCESSINGINSTRUCTIONS_H_
-#define MANTID_CUSTOMINTERFACES_PROCESSINGINSTRUCTIONS_H_
+#pragma once
 
 #include "Common/DllConfig.h"
 #include <boost/optional.hpp>
@@ -20,4 +19,3 @@ using ProcessingInstructions = std::string;
 } // namespace ISISReflectometry
 } // namespace CustomInterfaces
 } // namespace MantidQt
-#endif // MANTID_CUSTOMINTERFACES_PROCESSINGINSTRUCTIONS_H_

--- a/qt/scientific_interfaces/ISISReflectometry/Reduction/RangeInLambda.h
+++ b/qt/scientific_interfaces/ISISReflectometry/Reduction/RangeInLambda.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_CUSTOMINTERFACES_RANGEINLAMBDA_H_
-#define MANTID_CUSTOMINTERFACES_RANGEINLAMBDA_H_
+#pragma once
 #include "Common/DllConfig.h"
 namespace MantidQt {
 namespace CustomInterfaces {
@@ -34,4 +33,3 @@ MANTIDQT_ISISREFLECTOMETRY_DLL bool operator!=(RangeInLambda const &lhs,
 } // namespace ISISReflectometry
 } // namespace CustomInterfaces
 } // namespace MantidQt
-#endif // MANTID_CUSTOMINTERFACES_RANGEINLAMBDA_H_

--- a/qt/scientific_interfaces/ISISReflectometry/Reduction/RangeInQ.h
+++ b/qt/scientific_interfaces/ISISReflectometry/Reduction/RangeInQ.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_CUSTOMINTERFACES_RANGEINQ_H_
-#define MANTID_CUSTOMINTERFACES_RANGEINQ_H_
+#pragma once
 #include "Common/DllConfig.h"
 #include <boost/optional.hpp>
 
@@ -36,4 +35,3 @@ MANTIDQT_ISISREFLECTOMETRY_DLL bool operator!=(RangeInQ const &lhs,
 } // namespace ISISReflectometry
 } // namespace CustomInterfaces
 } // namespace MantidQt
-#endif // MANTID_CUSTOMINTERFACES_RANGEINQ_H_

--- a/qt/scientific_interfaces/ISISReflectometry/Reduction/ReductionJobs.h
+++ b/qt/scientific_interfaces/ISISReflectometry/Reduction/ReductionJobs.h
@@ -5,8 +5,7 @@
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
 
-#ifndef MANTID_CUSTOMINTERFACES_REDUCTIONJOBS_H_
-#define MANTID_CUSTOMINTERFACES_REDUCTIONJOBS_H_
+#pragma once
 #include "Common/DllConfig.h"
 #include "MantidQtWidgets/Common/Batch/RowLocation.h"
 #include <boost/optional.hpp>
@@ -120,5 +119,3 @@ void mergeJobsInto(ReductionJobs &intoHere, ReductionJobs const &fromHere,
 } // namespace ISISReflectometry
 } // namespace CustomInterfaces
 } // namespace MantidQt
-
-#endif // MANTID_CUSTOMINTERFACES_REDUCTIONJOBS_H_

--- a/qt/scientific_interfaces/ISISReflectometry/Reduction/ReductionOptionsMap.h
+++ b/qt/scientific_interfaces/ISISReflectometry/Reduction/ReductionOptionsMap.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_CUSTOMINTERFACES_REDUCTIONOPTIONSMAP_H_
-#define MANTID_CUSTOMINTERFACES_REDUCTIONOPTIONSMAP_H_
+#pragma once
 #include <map>
 namespace MantidQt {
 namespace CustomInterfaces {
@@ -18,4 +17,3 @@ using ReductionOptionsMap = std::map<std::string, std::string>;
 } // namespace ISISReflectometry
 } // namespace CustomInterfaces
 } // namespace MantidQt
-#endif // MANTID_CUSTOMINTERFACES_REDUCTIONOPTIONSMAP_H_

--- a/qt/scientific_interfaces/ISISReflectometry/Reduction/ReductionType.h
+++ b/qt/scientific_interfaces/ISISReflectometry/Reduction/ReductionType.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_CUSTOMINTERFACES_REDUCTIONTYPE_H_
-#define MANTID_CUSTOMINTERFACES_REDUCTIONTYPE_H_
+#pragma once
 #include "Common/DllConfig.h"
 #include <boost/optional.hpp>
 namespace MantidQt {
@@ -41,4 +40,3 @@ inline std::string reductionTypeToString(ReductionType reductionType) {
 } // namespace ISISReflectometry
 } // namespace CustomInterfaces
 } // namespace MantidQt
-#endif // MANTID_CUSTOMINTERFACES_REDUCTIONTYPE_H_

--- a/qt/scientific_interfaces/ISISReflectometry/Reduction/ReductionWorkspaces.h
+++ b/qt/scientific_interfaces/ISISReflectometry/Reduction/ReductionWorkspaces.h
@@ -5,8 +5,7 @@
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
 
-#ifndef MANTID_CUSTOMINTERFACES_REDUCTIONWORKSPACES_H_
-#define MANTID_CUSTOMINTERFACES_REDUCTIONWORKSPACES_H_
+#pragma once
 
 #include "Common/DllConfig.h"
 #include "TransmissionRunPair.h"
@@ -68,4 +67,3 @@ MANTIDQT_ISISREFLECTOMETRY_DLL std::string postprocessedWorkspaceName(
 } // namespace ISISReflectometry
 } // namespace CustomInterfaces
 } // namespace MantidQt
-#endif // MANTID_CUSTOMINTERFACES_REDUCTIONWORKSPACES_H_

--- a/qt/scientific_interfaces/ISISReflectometry/Reduction/Row.h
+++ b/qt/scientific_interfaces/ISISReflectometry/Reduction/Row.h
@@ -5,8 +5,7 @@
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
 
-#ifndef MANTID_CUSTOMINTERFACES_RUN_H_
-#define MANTID_CUSTOMINTERFACES_RUN_H_
+#pragma once
 #include "Common/DllConfig.h"
 #include "Item.h"
 #include "RangeInQ.h"
@@ -75,4 +74,3 @@ MANTIDQT_ISISREFLECTOMETRY_DLL Row mergedRow(Row const &rowA, Row const &rowB);
 } // namespace ISISReflectometry
 } // namespace CustomInterfaces
 } // namespace MantidQt
-#endif // MANTID_CUSTOMINTERFACE_RUN_H_

--- a/qt/scientific_interfaces/ISISReflectometry/Reduction/RowLocation.h
+++ b/qt/scientific_interfaces/ISISReflectometry/Reduction/RowLocation.h
@@ -5,8 +5,7 @@
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
 
-#ifndef MANTID_ISISREFLECTOMETRY_ROWLOCATION_H
-#define MANTID_ISISREFLECTOMETRY_ROWLOCATION_H
+#pragma once
 #include "MantidQtWidgets/Common/Batch/RowLocation.h"
 #include "MantidQtWidgets/Common/Batch/Subtree.h"
 
@@ -32,4 +31,3 @@ bool containsPath(
 } // namespace ISISReflectometry
 } // namespace CustomInterfaces
 } // namespace MantidQt
-#endif // MANTID_ISISREFLECTOMETRY_ROWLOCATION_H

--- a/qt/scientific_interfaces/ISISReflectometry/Reduction/RunsTable.h
+++ b/qt/scientific_interfaces/ISISReflectometry/Reduction/RunsTable.h
@@ -5,8 +5,7 @@
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
 
-#ifndef MANTID_CUSTOMINTERFACES_RUNSTABLE_H_
-#define MANTID_CUSTOMINTERFACES_RUNSTABLE_H_
+#pragma once
 
 #include "MantidQtWidgets/Common/Batch/RowLocation.h"
 #include "ReductionJobs.h"
@@ -68,4 +67,3 @@ bool RunsTable::isInSelection(
 } // namespace ISISReflectometry
 } // namespace CustomInterfaces
 } // namespace MantidQt
-#endif // MANTID_CUSTOMINTERFACES_RUNSTABLE_H_

--- a/qt/scientific_interfaces/ISISReflectometry/Reduction/Slicing.h
+++ b/qt/scientific_interfaces/ISISReflectometry/Reduction/Slicing.h
@@ -5,8 +5,7 @@
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
 
-#ifndef MANTID_CUSTOMINTERFACES_SLICING_H_
-#define MANTID_CUSTOMINTERFACES_SLICING_H_
+#pragma once
 #include "Common/DllConfig.h"
 #include <boost/variant.hpp>
 #include <ostream>
@@ -101,5 +100,3 @@ MANTIDQT_ISISREFLECTOMETRY_DLL bool isNoSlicing(Slicing const &slicing);
 } // namespace ISISReflectometry
 } // namespace CustomInterfaces
 } // namespace MantidQt
-
-#endif // MANTID_CUSTOMINTERFACES_SLICING_H_

--- a/qt/scientific_interfaces/ISISReflectometry/Reduction/SummationType.h
+++ b/qt/scientific_interfaces/ISISReflectometry/Reduction/SummationType.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_CUSTOMINTERFACES_SUMMATIONTYPE_H_
-#define MANTID_CUSTOMINTERFACES_SUMMATIONTYPE_H_
+#pragma once
 #include <boost/optional.hpp>
 #include <stdexcept>
 #include <string>
@@ -40,4 +39,3 @@ inline std::string summationTypeToString(SummationType summationType) {
 } // namespace ISISReflectometry
 } // namespace CustomInterfaces
 } // namespace MantidQt
-#endif // MANTID_CUSTOMINTERFACES_SUMMATIONTYPE_H_

--- a/qt/scientific_interfaces/ISISReflectometry/Reduction/TransmissionRunPair.h
+++ b/qt/scientific_interfaces/ISISReflectometry/Reduction/TransmissionRunPair.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_CUSTOMINTERFACES_TRANSMISSIONRUNPAIR_H_
-#define MANTID_CUSTOMINTERFACES_TRANSMISSIONRUNPAIR_H_
+#pragma once
 #include "Common/DllConfig.h"
 #include <string>
 #include <utility>
@@ -45,4 +44,3 @@ MANTIDQT_ISISREFLECTOMETRY_DLL bool operator!=(TransmissionRunPair const &lhs,
 } // namespace ISISReflectometry
 } // namespace CustomInterfaces
 } // namespace MantidQt
-#endif // MANTID_CUSTOMINTERFACES_TRANSMISSIONRUNPAIR_H_

--- a/qt/scientific_interfaces/ISISReflectometry/Reduction/TransmissionStitchOptions.h
+++ b/qt/scientific_interfaces/ISISReflectometry/Reduction/TransmissionStitchOptions.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_CUSTOMINTERFACES_TRANSMISSIONSTITCHOPTIONS_H_
-#define MANTID_CUSTOMINTERFACES_TRANSMISSIONSTITCHOPTIONS_H_
+#pragma once
 #include "Common/DllConfig.h"
 #include "ProcessingInstructions.h"
 #include "RangeInLambda.h"
@@ -50,4 +49,3 @@ operator!=(TransmissionStitchOptions const &lhs,
 } // namespace ISISReflectometry
 } // namespace CustomInterfaces
 } // namespace MantidQt
-#endif // MANTID_CUSTOMINTERFACES_TRANSMISSIONSTITCHOPTIONS_H_

--- a/qt/scientific_interfaces/ISISReflectometry/Reduction/ValidatePerThetaDefaults.h
+++ b/qt/scientific_interfaces/ISISReflectometry/Reduction/ValidatePerThetaDefaults.h
@@ -5,8 +5,7 @@
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
 
-#ifndef MANTID_CUSTOMINTERFACES_PERTHETADEFAUTSVALIDATOR_H_
-#define MANTID_CUSTOMINTERFACES_PERTHETADEFAUTSVALIDATOR_H_
+#pragma once
 #include "Common/DllConfig.h"
 #include "Common/ValidationResult.h"
 #include "ParseReflectometryStrings.h"
@@ -54,4 +53,3 @@ validatePerThetaDefaults(PerThetaDefaults::ValueArray const &cellText);
 } // namespace ISISReflectometry
 } // namespace CustomInterfaces
 } // namespace MantidQt
-#endif // MANTID_CUSTOMINTERFACES_PERTHETADEFAUTSVALIDATOR_H_

--- a/qt/scientific_interfaces/ISISReflectometry/Reduction/ValidateRow.h
+++ b/qt/scientific_interfaces/ISISReflectometry/Reduction/ValidateRow.h
@@ -5,8 +5,7 @@
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
 
-#ifndef MANTID_CUSTOMINTERFACES_VALIDATEROW_H_
-#define MANTID_CUSTOMINTERFACES_VALIDATEROW_H_
+#pragma once
 #include "Common/DllConfig.h"
 #include "Common/ValidationResult.h"
 #include "ParseReflectometryStrings.h"
@@ -53,4 +52,3 @@ boost::optional<Row> validateRowFromRunAndTheta(std::string const &run,
 } // namespace ISISReflectometry
 } // namespace CustomInterfaces
 } // namespace MantidQt
-#endif // MANTID_CUSTOMINTERFACES_VALIDATEROW_H_

--- a/qt/scientific_interfaces/ISISReflectometry/TestHelpers/ModelCreationHelper.h
+++ b/qt/scientific_interfaces/ISISReflectometry/TestHelpers/ModelCreationHelper.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_CUSTOMINTERFACES_MODELCREATIONHELPER_H_
-#define MANTID_CUSTOMINTERFACES_MODELCREATIONHELPER_H_
+#pragma once
 
 #include "../../ISISReflectometry/Reduction/Experiment.h"
 #include "../../ISISReflectometry/Reduction/Instrument.h"
@@ -106,4 +105,3 @@ MANTIDQT_ISISREFLECTOMETRY_DLL Instrument makeEmptyInstrument();
 } // namespace ISISReflectometry
 } // namespace CustomInterfaces
 } // namespace MantidQt
-#endif // MANTID_CUSTOMINTERFACES_MODELCREATIONHELPER_H_

--- a/qt/scientific_interfaces/ISISSANS/DllConfig.h
+++ b/qt/scientific_interfaces/ISISSANS/DllConfig.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTIDQT_ISISSANS_DLLCONFIG_H_
-#define MANTIDQT_ISISSANS_DLLCONFIG_H_
+#pragma once
 
 #include "MantidKernel/System.h"
 
@@ -20,5 +19,3 @@
 #define MANTIDQT_ISISSANS_DLL DLLImport
 #define EXTERN_MANTIDQT_ISISSANS EXTERN_IMPORT
 #endif
-
-#endif // MANTIDQT_ISISSANS_DLLCONFIG_H_

--- a/qt/scientific_interfaces/ISISSANS/PrecompiledHeader.h
+++ b/qt/scientific_interfaces/ISISSANS/PrecompiledHeader.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTIDQT_CUSTOMINTERFACES_PRECOMPILEDHEADER_H_
-#define MANTIDQT_CUSTOMINTERFACES_PRECOMPILEDHEADER_H_
+#pragma once
 
 // Mantid
 #include "MantidAPI/Algorithm.h"
@@ -22,5 +21,3 @@
 #include <set>
 #include <string>
 #include <vector>
-
-#endif // MANTIDQT_CUSTOMINTERFACES_PRECOMPILEDHEADER_H_

--- a/qt/scientific_interfaces/ISISSANS/SANSAddFiles.h
+++ b/qt/scientific_interfaces/ISISSANS/SANSAddFiles.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTIDQTCUSTOMINTERFACES_SANSADDFILES_H_
-#define MANTIDQTCUSTOMINTERFACES_SANSADDFILES_H_
+#pragma once
 
 #include "MantidKernel/ConfigService.h"
 #include "MantidQtWidgets/Common/UserSubWindow.h"
@@ -106,5 +105,3 @@ private slots:
 };
 } // namespace CustomInterfaces
 } // namespace MantidQt
-
-#endif // MANTIDQTCUSTOMINTERFACES_SANSADDFILES_H_

--- a/qt/scientific_interfaces/ISISSANS/SANSBackgroundCorrectionSettings.h
+++ b/qt/scientific_interfaces/ISISSANS/SANSBackgroundCorrectionSettings.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTIDQT_CUSTOMINTERFACES_SANSBACKGROUNDCORRECTIONSETTINGS_H_
-#define MANTIDQT_CUSTOMINTERFACES_SANSBACKGROUNDCORRECTIONSETTINGS_H_
+#pragma once
 
 #include "DllConfig.h"
 #include "MantidKernel/System.h"
@@ -40,5 +39,3 @@ private:
 
 } // namespace CustomInterfaces
 } // namespace MantidQt
-
-#endif /*  MANTIDQT_CUSTOMINTERFACES_SANSBACKGROUNDCORRECTIONSETTINGS_H_ */

--- a/qt/scientific_interfaces/ISISSANS/SANSBackgroundCorrectionWidget.h
+++ b/qt/scientific_interfaces/ISISSANS/SANSBackgroundCorrectionWidget.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTIDQT_CUSTOMINTERFACES_SANSBACKGROUNDCORRECTIONWIDGET_H_
-#define MANTIDQT_CUSTOMINTERFACES_SANSBACKGROUNDCORRECTIONWIDGET_H_
+#pragma once
 
 #include "DllConfig.h"
 #include "MantidKernel/System.h"
@@ -58,5 +57,3 @@ private:
 
 } // namespace CustomInterfaces
 } // namespace MantidQt
-
-#endif /*  MANTIDQT_CUSTOMINTERFACES_SANSBACKGROUNDCORRECTIONWIDGET_H_ */

--- a/qt/scientific_interfaces/ISISSANS/SANSConstants.h
+++ b/qt/scientific_interfaces/ISISSANS/SANSConstants.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTIDQTCUSTOMINTERFACES_SANSCONSTANTS_H_
-#define MANTIDQTCUSTOMINTERFACES_SANSCONSTANTS_H_
+#pragma once
 
 #include <QString>
 
@@ -35,5 +34,3 @@ public:
 };
 } // namespace CustomInterfaces
 } // namespace MantidQt
-
-#endif // MANTIDQTCUSTOMINTERFACES_SANSADDFILES_H_

--- a/qt/scientific_interfaces/ISISSANS/SANSDiagnostics.h
+++ b/qt/scientific_interfaces/ISISSANS/SANSDiagnostics.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTIDQTCUSTOMINTERFACES_SANSDIAGNOSTICS_H_
-#define MANTIDQTCUSTOMINTERFACES_SANSDIAGNOSTICS_H_
+#pragma once
 
 #include "MantidAPI/MatrixWorkspace_fwd.h"
 #include "MantidAPI/Workspace_fwd.h"
@@ -223,5 +222,3 @@ private slots:
 };
 } // namespace CustomInterfaces
 } // namespace MantidQt
-
-#endif // MANTIDQTCUSTOMINTERFACES_SANSADDFILES_H_

--- a/qt/scientific_interfaces/ISISSANS/SANSEventSlicing.h
+++ b/qt/scientific_interfaces/ISISSANS/SANSEventSlicing.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTIDQTCUSTOMINTERFACES_SANSEVENTSLICING_H_
-#define MANTIDQTCUSTOMINTERFACES_SANSEVENTSLICING_H_
+#pragma once
 
 #include "MantidQtWidgets/Common/UserSubWindow.h"
 #include "ui_SANSEventSlicing.h"
@@ -56,5 +55,3 @@ private:
 };
 } // namespace CustomInterfaces
 } // namespace MantidQt
-
-#endif // MANTIDQTCUSTOMINTERFACES_SANSEVENTSLICING_H_

--- a/qt/scientific_interfaces/ISISSANS/SANSPlotSpecial.h
+++ b/qt/scientific_interfaces/ISISSANS/SANSPlotSpecial.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTIDQTCUSTOMINTERFACES_SANS_DISPLAY_TAB
-#define MANTIDQTCUSTOMINTERFACES_SANS_DISPLAY_TAB
+#pragma once
 
 #include "ui_SANSPlotSpecial.h"
 #include <QFrame>
@@ -130,5 +129,3 @@ private:
 };
 } // namespace CustomInterfaces
 } // namespace MantidQt
-
-#endif

--- a/qt/scientific_interfaces/ISISSANS/SANSRunWindow.h
+++ b/qt/scientific_interfaces/ISISSANS/SANSRunWindow.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTIDQTCUSTOMINTERFACES_SANSRUNWINDOW_H_
-#define MANTIDQTCUSTOMINTERFACES_SANSRUNWINDOW_H_
+#pragma once
 
 //----------------------
 // Includes
@@ -512,5 +511,3 @@ private:
 };
 } // namespace CustomInterfaces
 } // namespace MantidQt
-
-#endif // MANTIDQTCUSTOMINTERFACES_SANSRUNWINDOW_H_

--- a/qt/scientific_interfaces/Indirect/AbsorptionCorrections.h
+++ b/qt/scientific_interfaces/Indirect/AbsorptionCorrections.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTIDQTCUSTOMINTERFACESIDA_ABSORPTIONCORRECTIONS_H_
-#define MANTIDQTCUSTOMINTERFACESIDA_ABSORPTIONCORRECTIONS_H_
+#pragma once
 
 #include "CorrectionsTab.h"
 #include "ui_AbsorptionCorrections.h"
@@ -101,5 +100,3 @@ private:
 };
 } // namespace CustomInterfaces
 } // namespace MantidQt
-
-#endif /* MANTIDQTCUSTOMINTERFACESIDA_ABSORPTIONCORRECTIONS_H_ */

--- a/qt/scientific_interfaces/Indirect/ApplyAbsorptionCorrections.h
+++ b/qt/scientific_interfaces/Indirect/ApplyAbsorptionCorrections.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTIDQTCUSTOMINTERFACESIDA_APPLYABSORPTIONCORRECTIONS_H_
-#define MANTIDQTCUSTOMINTERFACESIDA_APPLYABSORPTIONCORRECTIONS_H_
+#pragma once
 
 #include "CorrectionsTab.h"
 #include "MantidAPI/MatrixWorkspace_fwd.h"
@@ -74,5 +73,3 @@ private:
 
 } // namespace CustomInterfaces
 } // namespace MantidQt
-
-#endif /* MANTIDQTCUSTOMINTERFACESIDA_APPLYABSORPTIONCORRECTIONS_H_ */

--- a/qt/scientific_interfaces/Indirect/CalculatePaalmanPings.h
+++ b/qt/scientific_interfaces/Indirect/CalculatePaalmanPings.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTIDQTCUSTOMINTERFACESIDA_CALCULATEPAALMANPINGS_H_
-#define MANTIDQTCUSTOMINTERFACESIDA_CALCULATEPAALMANPINGS_H_
+#pragma once
 
 #include "CorrectionsTab.h"
 #include "ui_CalculatePaalmanPings.h"
@@ -84,5 +83,3 @@ private:
 
 } // namespace CustomInterfaces
 } // namespace MantidQt
-
-#endif /* MANTIDQTCUSTOMINTERFACESIDA_CALCULATEPAALMANPINGS_H_ */

--- a/qt/scientific_interfaces/Indirect/ContainerSubtraction.h
+++ b/qt/scientific_interfaces/Indirect/ContainerSubtraction.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTIDQTCUSTOMINTERFACESIDA_CONTAINERSUBTRACTION_H_
-#define MANTIDQTCUSTOMINTERFACESIDA_CONTAINERSUBTRACTION_H_
+#pragma once
 
 #include "CorrectionsTab.h"
 #include "ui_ContainerSubtraction.h"
@@ -110,5 +109,3 @@ private:
 
 } // namespace CustomInterfaces
 } // namespace MantidQt
-
-#endif /* MANTIDQTCUSTOMINTERFACESIDA_CONTAINERSUBTRACTION_H_ */

--- a/qt/scientific_interfaces/Indirect/ConvFit.h
+++ b/qt/scientific_interfaces/Indirect/ConvFit.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTIDQTCUSTOMINTERFACESIDA_CONVFIT_H_
-#define MANTIDQTCUSTOMINTERFACESIDA_CONVFIT_H_
+#pragma once
 
 #include "ConvFitModel.h"
 #include "IndirectFitAnalysisTab.h"
@@ -57,5 +56,3 @@ private:
 } // namespace IDA
 } // namespace CustomInterfaces
 } // namespace MantidQt
-
-#endif /* MANTIDQTCUSTOMINTERFACESIDA_CONVFIT_H_ */

--- a/qt/scientific_interfaces/Indirect/ConvFitAddWorkspaceDialog.h
+++ b/qt/scientific_interfaces/Indirect/ConvFitAddWorkspaceDialog.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTIDQTCUSTOMINTERFACES_CONVFITADDWORKSPACEDIALOG_H_
-#define MANTIDQTCUSTOMINTERFACES_CONVFITADDWORKSPACEDIALOG_H_
+#pragma once
 
 #include "IAddWorkspaceDialog.h"
 #include "ui_ConvFitAddWorkspaceDialog.h"
@@ -44,5 +43,3 @@ private:
 } // namespace IDA
 } // namespace CustomInterfaces
 } // namespace MantidQt
-
-#endif /* MANTIDQTCUSTOMINTERFACES_CONVFITADDWORKSPACEDIALOG_H_ */

--- a/qt/scientific_interfaces/Indirect/ConvFitDataPresenter.h
+++ b/qt/scientific_interfaces/Indirect/ConvFitDataPresenter.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTIDQTCUSTOMINTERFACESIDA_CONVFITDATAPRESENTER_H_
-#define MANTIDQTCUSTOMINTERFACESIDA_CONVFITDATAPRESENTER_H_
+#pragma once
 
 #include "ConvFitModel.h"
 #include "IndirectFitDataPresenter.h"
@@ -50,5 +49,3 @@ private:
 } // namespace IDA
 } // namespace CustomInterfaces
 } // namespace MantidQt
-
-#endif /* MANTIDQTCUSTOMINTERFACESIDA_CONVFITDATAPRESENTER_H_ */

--- a/qt/scientific_interfaces/Indirect/ConvFitDataTablePresenter.h
+++ b/qt/scientific_interfaces/Indirect/ConvFitDataTablePresenter.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTIDQTCUSTOMINTERFACES_CONVFITDATATABLEPRESENTER_H_
-#define MANTIDQTCUSTOMINTERFACES_CONVFITDATATABLEPRESENTER_H_
+#pragma once
 
 #include "ConvFitModel.h"
 #include "IndirectDataTablePresenter.h"
@@ -46,5 +45,3 @@ private:
 } // namespace IDA
 } // namespace CustomInterfaces
 } // namespace MantidQt
-
-#endif /* MANTIDQTCUSTOMINTERFACES_CONVFITDATATABLEPRESENTER_H_ */

--- a/qt/scientific_interfaces/Indirect/ConvFitModel.h
+++ b/qt/scientific_interfaces/Indirect/ConvFitModel.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTIDQTCUSTOMINTERFACESIDA_CONVFITMODEL_H_
-#define MANTIDQTCUSTOMINTERFACESIDA_CONVFITMODEL_H_
+#pragma once
 
 #include "IndirectFittingModel.h"
 
@@ -106,5 +105,3 @@ private:
 } // namespace IDA
 } // namespace CustomInterfaces
 } // namespace MantidQt
-
-#endif

--- a/qt/scientific_interfaces/Indirect/CorrectionsTab.h
+++ b/qt/scientific_interfaces/Indirect/CorrectionsTab.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTIDQTCUSTOMINTERFACESIDA_CORRECTIONSTAB_H_
-#define MANTIDQTCUSTOMINTERFACESIDA_CORRECTIONSTAB_H_
+#pragma once
 
 #include "IndirectPlotOptionsPresenter.h"
 #include "IndirectTab.h"
@@ -119,5 +118,3 @@ private:
 };
 } // namespace CustomInterfaces
 } // namespace MantidQt
-
-#endif /* MANTIDQTCUSTOMINTERFACESIDA_CORRECTIONSTAB_H_ */

--- a/qt/scientific_interfaces/Indirect/DensityOfStates.h
+++ b/qt/scientific_interfaces/Indirect/DensityOfStates.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTIDQTCUSTOMINTERFACES_DENSITYOFSTATES_H_
-#define MANTIDQTCUSTOMINTERFACES_DENSITYOFSTATES_H_
+#pragma once
 
 #include "IndirectSimulationTab.h"
 #include "ui_DensityOfStates.h"
@@ -47,5 +46,3 @@ private:
 };
 } // namespace CustomInterfaces
 } // namespace MantidQt
-
-#endif // MANTIDQTCUSTOMINTERFACES_DENSITYOFSTATES_H_

--- a/qt/scientific_interfaces/Indirect/DllConfig.h
+++ b/qt/scientific_interfaces/Indirect/DllConfig.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTIDQT_INDIRECT_DLLCONFIG_H_
-#define MANTIDQT_INDIRECT_DLLCONFIG_H_
+#pragma once
 
 #include "MantidKernel/System.h"
 
@@ -20,5 +19,3 @@
 #define MANTIDQT_INDIRECT_DLL DLLImport
 #define EXTERN_MANTIDQT_INDIRECT EXTERN_IMPORT
 #endif
-
-#endif // MANTIDQT_INDIRECT_DLLCONFIG_H_

--- a/qt/scientific_interfaces/Indirect/Elwin.h
+++ b/qt/scientific_interfaces/Indirect/Elwin.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTIDQTCUSTOMINTERFACESIDA_ELWIN_H_
-#define MANTIDQTCUSTOMINTERFACESIDA_ELWIN_H_
+#pragma once
 
 #include "IndirectDataAnalysisTab.h"
 #include "MantidAPI/MatrixWorkspace_fwd.h"
@@ -61,5 +60,3 @@ private:
 } // namespace IDA
 } // namespace CustomInterfaces
 } // namespace MantidQt
-
-#endif /* MANTIDQTCUSTOMINTERFACESIDA_ELWIN_H_ */

--- a/qt/scientific_interfaces/Indirect/FunctionTemplateBrowser.h
+++ b/qt/scientific_interfaces/Indirect/FunctionTemplateBrowser.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef INDIRECT_FUNCTIONTEMPLATEBROWSER_H_
-#define INDIRECT_FUNCTIONTEMPLATEBROWSER_H_
+#pragma once
 
 #include "DllConfig.h"
 #include "IndexTypes.h"
@@ -109,5 +108,3 @@ protected:
 } // namespace IDA
 } // namespace CustomInterfaces
 } // namespace MantidQt
-
-#endif /*INDIRECT_FUNCTIONTEMPLATEBROWSER_H_*/

--- a/qt/scientific_interfaces/Indirect/IAddWorkspaceDialog.h
+++ b/qt/scientific_interfaces/Indirect/IAddWorkspaceDialog.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTIDQTCUSTOMINTERFACES_IADDWORKSPACEDIALOG_H_
-#define MANTIDQTCUSTOMINTERFACES_IADDWORKSPACEDIALOG_H_
+#pragma once
 
 #include <QDialog>
 #include <QObject>
@@ -32,5 +31,3 @@ signals:
 } // namespace IDA
 } // namespace CustomInterfaces
 } // namespace MantidQt
-
-#endif /* MANTIDQTCUSTOMINTERFACES_IADDWORKSPACEDIALOG_H_ */

--- a/qt/scientific_interfaces/Indirect/IFQFitObserver.h
+++ b/qt/scientific_interfaces/Indirect/IFQFitObserver.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTIDQTCUSTOMINTERFACES_IFQFITOBSERVER_H_
-#define MANTIDQTCUSTOMINTERFACES_IFQFITOBSERVER_H_
+#pragma once
 
 enum DataType {
   WIDTH,
@@ -19,5 +18,3 @@ public:
   virtual void updateDataType(DataType) = 0;
   virtual void spectrumChanged(int) = 0;
 };
-
-#endif

--- a/qt/scientific_interfaces/Indirect/IIndirectFitDataView.h
+++ b/qt/scientific_interfaces/Indirect/IIndirectFitDataView.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTIDQTCUSTOMINTERFACESIDA_IINDIRECTFITDATAVIEW_H_
-#define MANTIDQTCUSTOMINTERFACESIDA_IINDIRECTFITDATAVIEW_H_
+#pragma once
 
 #include "DllConfig.h"
 #include "MantidQtWidgets/Common/UserInputValidator.h"
@@ -72,5 +71,3 @@ signals:
 } // namespace IDA
 } // namespace CustomInterfaces
 } // namespace MantidQt
-
-#endif

--- a/qt/scientific_interfaces/Indirect/IIndirectFitDataViewLegacy.h
+++ b/qt/scientific_interfaces/Indirect/IIndirectFitDataViewLegacy.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTIDQTCUSTOMINTERFACESIDA_IIndirectFitDataViewLegacy_H_
-#define MANTIDQTCUSTOMINTERFACESIDA_IIndirectFitDataViewLegacy_H_
+#pragma once
 
 #include "DllConfig.h"
 #include "MantidQtWidgets/Common/UserInputValidator.h"
@@ -66,5 +65,3 @@ signals:
 } // namespace IDA
 } // namespace CustomInterfaces
 } // namespace MantidQt
-
-#endif

--- a/qt/scientific_interfaces/Indirect/IIndirectFitOutputOptionsModel.h
+++ b/qt/scientific_interfaces/Indirect/IIndirectFitOutputOptionsModel.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTIDQTCUSTOMINTERFACESIDA_IINDIRECTFITOUTPUTOPTIONSMODEL_H_
-#define MANTIDQTCUSTOMINTERFACESIDA_IINDIRECTFITOUTPUTOPTIONSMODEL_H_
+#pragma once
 
 #include "DllConfig.h"
 #include "MantidAPI/WorkspaceGroup.h"
@@ -59,5 +58,3 @@ public:
 } // namespace IDA
 } // namespace CustomInterfaces
 } // namespace MantidQt
-
-#endif

--- a/qt/scientific_interfaces/Indirect/IIndirectFitOutputOptionsView.h
+++ b/qt/scientific_interfaces/Indirect/IIndirectFitOutputOptionsView.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTIDQTCUSTOMINTERFACESIDA_IINDIRECTFITOUTPUTOPTIONSVIEW_H_
-#define MANTIDQTCUSTOMINTERFACESIDA_IINDIRECTFITOUTPUTOPTIONSVIEW_H_
+#pragma once
 
 #include "DllConfig.h"
 #include "MantidQtWidgets/Common/MantidWidget.h"
@@ -63,5 +62,3 @@ signals:
 } // namespace IDA
 } // namespace CustomInterfaces
 } // namespace MantidQt
-
-#endif

--- a/qt/scientific_interfaces/Indirect/IIndirectFitPlotView.h
+++ b/qt/scientific_interfaces/Indirect/IIndirectFitPlotView.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTIDQTCUSTOMINTERFACESIDA_IINDIRECTFITPLOTVIEW_H_
-#define MANTIDQTCUSTOMINTERFACESIDA_IINDIRECTFITPLOTVIEW_H_
+#pragma once
 
 #include "DllConfig.h"
 #include "IndexTypes.h"
@@ -105,5 +104,3 @@ signals:
 } // namespace IDA
 } // namespace CustomInterfaces
 } // namespace MantidQt
-
-#endif

--- a/qt/scientific_interfaces/Indirect/IIndirectFitPlotViewLegacy.h
+++ b/qt/scientific_interfaces/Indirect/IIndirectFitPlotViewLegacy.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTIDQTCUSTOMINTERFACESIDA_IINDIRECTFITPLOTVIEWLEGACY_H_
-#define MANTIDQTCUSTOMINTERFACESIDA_IINDIRECTFITPLOTVIEWLEGACY_H_
+#pragma once
 
 #include "DllConfig.h"
 #include "MantidAPI/MatrixWorkspace.h"
@@ -105,5 +104,3 @@ signals:
 } // namespace IDA
 } // namespace CustomInterfaces
 } // namespace MantidQt
-
-#endif

--- a/qt/scientific_interfaces/Indirect/IIndirectSettingsView.h
+++ b/qt/scientific_interfaces/Indirect/IIndirectSettingsView.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTIDQTCUSTOMINTERFACESIDA_IINDIRECTSETTINGSVIEW_H_
-#define MANTIDQTCUSTOMINTERFACESIDA_IINDIRECTSETTINGSVIEW_H_
+#pragma once
 
 #include "DllConfig.h"
 
@@ -44,5 +43,3 @@ signals:
 
 } // namespace CustomInterfaces
 } // namespace MantidQt
-
-#endif /* MANTIDQTCUSTOMINTERFACESIDA_IINDIRECTSETTINGSVIEW_H_ */

--- a/qt/scientific_interfaces/Indirect/ILLEnergyTransfer.h
+++ b/qt/scientific_interfaces/Indirect/ILLEnergyTransfer.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTIDQTCUSTOMINTERFACES_ILLENERGYTRANSFER_H_
-#define MANTIDQTCUSTOMINTERFACES_ILLENERGYTRANSFER_H_
+#pragma once
 
 #include "IndirectDataReductionTab.h"
 
@@ -55,5 +54,3 @@ private:
 };
 } // namespace CustomInterfaces
 } // namespace MantidQt
-
-#endif // MANTIDQTCUSTOMINTERFACES_ILLENERGYTRANSFER_H_

--- a/qt/scientific_interfaces/Indirect/IPythonRunner.h
+++ b/qt/scientific_interfaces/Indirect/IPythonRunner.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_INDIRECT_IPYRUNNER_H
-#define MANTID_INDIRECT_IPYRUNNER_H
+#pragma once
 
 #include <string>
 
@@ -24,5 +23,3 @@ public:
 
 } // namespace CustomInterfaces
 } // namespace MantidQt
-
-#endif /* MANTID_INDIRECT_IPYRUNNER_H */

--- a/qt/scientific_interfaces/Indirect/ISISCalibration.h
+++ b/qt/scientific_interfaces/Indirect/ISISCalibration.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTIDQTCUSTOMINTERFACES_ISISCALIBRATION_H_
-#define MANTIDQTCUSTOMINTERFACES_ISISCALIBRATION_H_
+#pragma once
 
 #include "IndirectDataReductionTab.h"
 #include "MantidKernel/System.h"
@@ -99,5 +98,3 @@ private:
 };
 } // namespace CustomInterfaces
 } // namespace MantidQt
-
-#endif // MANTIDQTCUSTOMINTERFACES_ISISCALIBRATION_H_

--- a/qt/scientific_interfaces/Indirect/ISISDiagnostics.h
+++ b/qt/scientific_interfaces/Indirect/ISISDiagnostics.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTIDQTCUSTOMINTERFACES_ISISDIAGNOSTICS_H_
-#define MANTIDQTCUSTOMINTERFACES_ISISDIAGNOSTICS_H_
+#pragma once
 
 #include "IndirectDataReductionTab.h"
 #include "MantidAPI/MatrixWorkspace_fwd.h"
@@ -91,5 +90,3 @@ private:
 };
 } // namespace CustomInterfaces
 } // namespace MantidQt
-
-#endif // MANTIDQTCUSTOMINTERFACES_ISISDIAGNOSTICS_H_

--- a/qt/scientific_interfaces/Indirect/ISISEnergyTransfer.h
+++ b/qt/scientific_interfaces/Indirect/ISISEnergyTransfer.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTIDQTCUSTOMINTERFACES_ISISENERGYTRANSFER_H_
-#define MANTIDQTCUSTOMINTERFACES_ISISENERGYTRANSFER_H_
+#pragma once
 
 #include "IndirectDataReductionTab.h"
 
@@ -101,5 +100,3 @@ private:
 };
 } // namespace CustomInterfaces
 } // namespace MantidQt
-
-#endif // MANTIDQTCUSTOMINTERFACES_ISISENERGYTRANSFER_H_

--- a/qt/scientific_interfaces/Indirect/IndexTypes.h
+++ b/qt/scientific_interfaces/Indirect/IndexTypes.h
@@ -8,8 +8,7 @@
 // This file contains the implimentation of type safe indices for use
 // in the indirect interface code.
 // TODO merge this to use the generic index framework from IndexType.h
-#ifndef MANTIDQTCUSTOMINTERFACESIDA_INDEXTYPE_H_
-#define MANTIDQTCUSTOMINTERFACESIDA_INDEXTYPE_H_
+#pragma once
 
 #include <QMetaType>
 #include <ostream>
@@ -133,5 +132,3 @@ operator<<(std::ostream &out,
 Q_DECLARE_METATYPE(MantidQt::CustomInterfaces::IDA::TableRowIndex)
 Q_DECLARE_METATYPE(MantidQt::CustomInterfaces::IDA::WorkspaceIndex)
 Q_DECLARE_METATYPE(MantidQt::CustomInterfaces::IDA::WorkspaceGroupIndex)
-
-#endif /* MANTIDQTCUSTOMINTERFACESIDA_INDEXTYPE_H_ */

--- a/qt/scientific_interfaces/Indirect/IndirectAddWorkspaceDialog.h
+++ b/qt/scientific_interfaces/Indirect/IndirectAddWorkspaceDialog.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTIDQTCUSTOMINTERFACES_INDIRECTADDWORKSPACEDIALOG_H_
-#define MANTIDQTCUSTOMINTERFACES_INDIRECTADDWORKSPACEDIALOG_H_
+#pragma once
 
 #include "IAddWorkspaceDialog.h"
 #include "ui_IndirectAddWorkspaceDialog.h"
@@ -41,5 +40,3 @@ private:
 } // namespace IDA
 } // namespace CustomInterfaces
 } // namespace MantidQt
-
-#endif /* MANTIDQTCUSTOMINTERFACES_INDIRECTADDWORKSPACEDIALOG_H_ */

--- a/qt/scientific_interfaces/Indirect/IndirectBayes.h
+++ b/qt/scientific_interfaces/Indirect/IndirectBayes.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTIDQTCUSTOMINTERFACES_INDIRECTBAYES_H_
-#define MANTIDQTCUSTOMINTERFACES_INDIRECTBAYES_H_
+#pragma once
 #include "ui_IndirectBayes.h"
 
 #include "IndirectBayesTab.h"
@@ -65,5 +64,3 @@ private:
 };
 } // namespace CustomInterfaces
 } // namespace MantidQt
-
-#endif

--- a/qt/scientific_interfaces/Indirect/IndirectBayesTab.h
+++ b/qt/scientific_interfaces/Indirect/IndirectBayesTab.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_CUSTOMINTERFACES_INDIRECTBAYESTAB_H_
-#define MANTID_CUSTOMINTERFACES_INDIRECTBAYESTAB_H_
+#pragma once
 
 #include "IndirectTab.h"
 #include <QSettings>
@@ -76,5 +75,3 @@ private:
 
 } // namespace CustomInterfaces
 } // namespace MantidQt
-
-#endif

--- a/qt/scientific_interfaces/Indirect/IndirectCorrections.h
+++ b/qt/scientific_interfaces/Indirect/IndirectCorrections.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTIDQTCUSTOMINTERFACES_INDIRECTCORRECTIONS_H_
-#define MANTIDQTCUSTOMINTERFACES_INDIRECTCORRECTIONS_H_
+#pragma once
 
 #include "IndirectInterface.h"
 #include "IndirectTab.h"
@@ -91,5 +90,3 @@ private:
 };
 } // namespace CustomInterfaces
 } // namespace MantidQt
-
-#endif /* MANTIDQTCUSTOMINTERFACES_INDIRECTCORRECTIONS_H_ */

--- a/qt/scientific_interfaces/Indirect/IndirectDataAnalysis.h
+++ b/qt/scientific_interfaces/Indirect/IndirectDataAnalysis.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTIDQTCUSTOMINTERFACES_INDIRECTANALYSIS_H_
-#define MANTIDQTCUSTOMINTERFACES_INDIRECTANALYSIS_H_
+#pragma once
 #include "ui_IndirectDataAnalysis.h"
 
 #include "IndirectInterface.h"
@@ -98,5 +97,3 @@ private:
 } // namespace IDA
 } // namespace CustomInterfaces
 } // namespace MantidQt
-
-#endif /* MANTIDQTCUSTOMINTERFACES_INDIRECTANALYSIS_H_ */

--- a/qt/scientific_interfaces/Indirect/IndirectDataAnalysisTab.h
+++ b/qt/scientific_interfaces/Indirect/IndirectDataAnalysisTab.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTIDQTCUSTOMINTERFACESIDA_IDATAB_H_
-#define MANTIDQTCUSTOMINTERFACESIDA_IDATAB_H_
+#pragma once
 
 #include "IndirectDataAnalysis.h"
 #include "IndirectPlotOptionsPresenter.h"
@@ -178,5 +177,3 @@ private:
 } // namespace IDA
 } // namespace CustomInterfaces
 } // namespace MantidQt
-
-#endif /* MANTIDQTCUSTOMINTERFACESIDA_IDATABLEGACY_H_ */

--- a/qt/scientific_interfaces/Indirect/IndirectDataReduction.h
+++ b/qt/scientific_interfaces/Indirect/IndirectDataReduction.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTIDQTCUSTOMINTERFACES_INDIRECTDATAREDUCTION_H_
-#define MANTIDQTCUSTOMINTERFACES_INDIRECTDATAREDUCTION_H_
+#pragma once
 #include "ui_IndirectDataReduction.h"
 
 #include "IndirectDataReductionTab.h"
@@ -167,5 +166,3 @@ private:
 
 } // namespace CustomInterfaces
 } // namespace MantidQt
-
-#endif // MANTIDQTCUSTOMINTERFACES_INDIRECTDATAREDUCTION_H_

--- a/qt/scientific_interfaces/Indirect/IndirectDataReductionTab.h
+++ b/qt/scientific_interfaces/Indirect/IndirectDataReductionTab.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_CUSTOMINTERFACES_INDIRECTDATAREDUCTIONTAB_H_
-#define MANTID_CUSTOMINTERFACES_INDIRECTDATAREDUCTIONTAB_H_
+#pragma once
 
 #include "IndirectInstrumentConfig.h"
 #include "IndirectPlotOptionsPresenter.h"
@@ -102,5 +101,3 @@ private:
 };
 } // namespace CustomInterfaces
 } // namespace MantidQt
-
-#endif /* MANTID_CUSTOMINTERFACES_INDIRECTDATAREDUCTIONTAB_H_ */

--- a/qt/scientific_interfaces/Indirect/IndirectDataTablePresenter.h
+++ b/qt/scientific_interfaces/Indirect/IndirectDataTablePresenter.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTIDQTCUSTOMINTERFACES_INDIRECTDATATABLEPRESENTER_H_
-#define MANTIDQTCUSTOMINTERFACES_INDIRECTDATATABLEPRESENTER_H_
+#pragma once
 
 #include "IndexTypes.h"
 #include "IndirectFittingModel.h"
@@ -141,5 +140,3 @@ private:
 } // namespace IDA
 } // namespace CustomInterfaces
 } // namespace MantidQt
-
-#endif /* MANTIDQTCUSTOMINTERFACES_INDIRECTDATATABLEPRESENTER_H_ */

--- a/qt/scientific_interfaces/Indirect/IndirectDataTablePresenterLegacy.h
+++ b/qt/scientific_interfaces/Indirect/IndirectDataTablePresenterLegacy.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTIDQTCUSTOMINTERFACES_INDIRECTDATATABLEPRESENTERLEGACY_H_
-#define MANTIDQTCUSTOMINTERFACES_INDIRECTDATATABLEPRESENTERLEGACY_H_
+#pragma once
 
 #include "IndirectFittingModelLegacy.h"
 
@@ -127,5 +126,3 @@ private:
 } // namespace IDA
 } // namespace CustomInterfaces
 } // namespace MantidQt
-
-#endif /* MANTIDQTCUSTOMINTERFACES_INDIRECTDATATABLEPRESENTERLEGACY_H_ */

--- a/qt/scientific_interfaces/Indirect/IndirectDataValidationHelper.h
+++ b/qt/scientific_interfaces/Indirect/IndirectDataValidationHelper.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_CUSTOMINTERFACES_INDIRECTDATAVALIDATIONHELPER_H_
-#define MANTID_CUSTOMINTERFACES_INDIRECTDATAVALIDATIONHELPER_H_
+#pragma once
 
 #include "MantidQtWidgets/Common/UserInputValidator.h"
 
@@ -45,5 +44,3 @@ bool validateDataIsACorrectionsFile(
     std::string const &inputType, bool silent = false);
 
 } // namespace IndirectDataValidationHelper
-
-#endif /* MANTID_CUSTOMINTERFACES_INDIRECTDATAVALIDATIONHELPER_H_ */

--- a/qt/scientific_interfaces/Indirect/IndirectDiffractionReduction.h
+++ b/qt/scientific_interfaces/Indirect/IndirectDiffractionReduction.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTIDQTCUSTOMINTERFACES_INDIRECTDIFFRACTIONREDUCTION_H_
-#define MANTIDQTCUSTOMINTERFACES_INDIRECTDIFFRACTIONREDUCTION_H_
+#pragma once
 
 #include "IPythonRunner.h"
 #include "IndirectInterface.h"
@@ -104,5 +103,3 @@ private:
 };
 } // namespace CustomInterfaces
 } // namespace MantidQt
-
-#endif // MANTIDQTCUSTOMINTERFACES_INDIRECTDIFFRACTIONREDUCTION_H_

--- a/qt/scientific_interfaces/Indirect/IndirectEditResultsDialog.h
+++ b/qt/scientific_interfaces/Indirect/IndirectEditResultsDialog.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTIDQTCUSTOMINTERFACES_INDIRECTADDWORKSPACEDIALOG_H_
-#define MANTIDQTCUSTOMINTERFACES_INDIRECTADDWORKSPACEDIALOG_H_
+#pragma once
 
 #include "ui_IndirectEditResultsDialog.h"
 
@@ -45,5 +44,3 @@ private:
 } // namespace IDA
 } // namespace CustomInterfaces
 } // namespace MantidQt
-
-#endif /* MANTIDQTCUSTOMINTERFACES_INDIRECTADDWORKSPACEDIALOG_H_ */

--- a/qt/scientific_interfaces/Indirect/IndirectFitAnalysisTab.h
+++ b/qt/scientific_interfaces/Indirect/IndirectFitAnalysisTab.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTIDQTCUSTOMINTERFACESIDA_IFATAB_H_
-#define MANTIDQTCUSTOMINTERFACESIDA_IFATAB_H_
+#pragma once
 
 #include "IndirectDataAnalysisTab.h"
 #include "IndirectFitDataPresenter.h"
@@ -167,5 +166,3 @@ private:
 } // namespace IDA
 } // namespace CustomInterfaces
 } // namespace MantidQt
-
-#endif /* MANTIDQTCUSTOMINTERFACESIDA_IFATAB_H_ */

--- a/qt/scientific_interfaces/Indirect/IndirectFitAnalysisTabLegacy.h
+++ b/qt/scientific_interfaces/Indirect/IndirectFitAnalysisTabLegacy.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTIDQTCUSTOMINTERFACESIDA_IFATABLEGACY_H_
-#define MANTIDQTCUSTOMINTERFACESIDA_IFATABLEGACY_H_
+#pragma once
 
 #include "IndirectDataAnalysisTab.h"
 #include "IndirectFitDataPresenterLegacy.h"
@@ -240,5 +239,3 @@ private:
 } // namespace IDA
 } // namespace CustomInterfaces
 } // namespace MantidQt
-
-#endif /* MANTIDQTCUSTOMINTERFACESIDA_IFATABLEGACY_H_ */

--- a/qt/scientific_interfaces/Indirect/IndirectFitData.h
+++ b/qt/scientific_interfaces/Indirect/IndirectFitData.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTIDQTCUSTOMINTERFACESIDA_INDIRECTFITDATALEGACY_H_
-#define MANTIDQTCUSTOMINTERFACESIDA_INDIRECTFITDATALEGACY_H_
+#pragma once
 
 #include "DllConfig.h"
 #include "IndexTypes.h"
@@ -164,5 +163,3 @@ private:
 } // namespace IDA
 } // namespace CustomInterfaces
 } // namespace MantidQt
-
-#endif

--- a/qt/scientific_interfaces/Indirect/IndirectFitDataLegacy.h
+++ b/qt/scientific_interfaces/Indirect/IndirectFitDataLegacy.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTIDQTCUSTOMINTERFACESIDA_INDIRECTFITDATA_H_
-#define MANTIDQTCUSTOMINTERFACESIDA_INDIRECTFITDATA_H_
+#pragma once
 
 #include "DllConfig.h"
 #include "MantidAPI/MatrixWorkspace.h"
@@ -197,5 +196,3 @@ private:
 } // namespace IDA
 } // namespace CustomInterfaces
 } // namespace MantidQt
-
-#endif

--- a/qt/scientific_interfaces/Indirect/IndirectFitDataPresenter.h
+++ b/qt/scientific_interfaces/Indirect/IndirectFitDataPresenter.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTIDQTCUSTOMINTERFACESIDA_INDIRECTFITDATAPRESENTER_H_
-#define MANTIDQTCUSTOMINTERFACESIDA_INDIRECTFITDATAPRESENTER_H_
+#pragma once
 
 #include "IAddWorkspaceDialog.h"
 #include "IIndirectFitDataView.h"
@@ -122,5 +121,3 @@ private:
 } // namespace IDA
 } // namespace CustomInterfaces
 } // namespace MantidQt
-
-#endif /* MANTIDQTCUSTOMINTERFACESIDA_INDIRECTFITDATAPRESENTER_H_ */

--- a/qt/scientific_interfaces/Indirect/IndirectFitDataPresenterLegacy.h
+++ b/qt/scientific_interfaces/Indirect/IndirectFitDataPresenterLegacy.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTIDQTCUSTOMINTERFACESIDA_INDIRECTFITDATAPRESENTERLEGACY_H_
-#define MANTIDQTCUSTOMINTERFACESIDA_INDIRECTFITDATAPRESENTERLEGACY_H_
+#pragma once
 
 #include "IAddWorkspaceDialog.h"
 #include "IIndirectFitDataViewLegacy.h"
@@ -112,5 +111,3 @@ private:
 } // namespace IDA
 } // namespace CustomInterfaces
 } // namespace MantidQt
-
-#endif /* MANTIDQTCUSTOMINTERFACESIDA_INDIRECTFITDATAPRESENTERLEGACY_H_ */

--- a/qt/scientific_interfaces/Indirect/IndirectFitDataView.h
+++ b/qt/scientific_interfaces/Indirect/IndirectFitDataView.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTIDQTCUSTOMINTERFACES_INDIRECTFITDATAVIEW_H_
-#define MANTIDQTCUSTOMINTERFACES_INDIRECTFITDATAVIEW_H_
+#pragma once
 
 #include "ui_IndirectFitDataView.h"
 
@@ -74,5 +73,3 @@ private:
 } // namespace IDA
 } // namespace CustomInterfaces
 } // namespace MantidQt
-
-#endif /* MANTIDQTCUSTOMINTERFACES_INDIRECTFITDATAVIEW_H_ */

--- a/qt/scientific_interfaces/Indirect/IndirectFitDataViewLegacy.h
+++ b/qt/scientific_interfaces/Indirect/IndirectFitDataViewLegacy.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTIDQTCUSTOMINTERFACES_INDIRECTFITDATAVIEWLEGACY_H_
-#define MANTIDQTCUSTOMINTERFACES_INDIRECTFITDATAVIEWLEGACY_H_
+#pragma once
 
 #include "ui_IndirectFitDataView.h"
 
@@ -71,5 +70,3 @@ private:
 } // namespace IDA
 } // namespace CustomInterfaces
 } // namespace MantidQt
-
-#endif /* MANTIDQTCUSTOMINTERFACES_INDIRECTFITDATAVIEW_H_ */

--- a/qt/scientific_interfaces/Indirect/IndirectFitOutput.h
+++ b/qt/scientific_interfaces/Indirect/IndirectFitOutput.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTIDQTCUSTOMINTERFACESIDA_INDIRECTFITOUTPUTLEGACY_H_
-#define MANTIDQTCUSTOMINTERFACESIDA_INDIRECTFITOUTPUTLEGACY_H_
+#pragma once
 
 #include "IndirectFitData.h"
 
@@ -124,5 +123,3 @@ private:
 } // namespace IDA
 } // namespace CustomInterfaces
 } // namespace MantidQt
-
-#endif

--- a/qt/scientific_interfaces/Indirect/IndirectFitOutputLegacy.h
+++ b/qt/scientific_interfaces/Indirect/IndirectFitOutputLegacy.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTIDQTCUSTOMINTERFACESIDA_INDIRECTFITOUTPUT_H_
-#define MANTIDQTCUSTOMINTERFACESIDA_INDIRECTFITOUTPUT_H_
+#pragma once
 
 #include "IndirectFitDataLegacy.h"
 
@@ -128,5 +127,3 @@ private:
 } // namespace IDA
 } // namespace CustomInterfaces
 } // namespace MantidQt
-
-#endif

--- a/qt/scientific_interfaces/Indirect/IndirectFitOutputOptionsModel.h
+++ b/qt/scientific_interfaces/Indirect/IndirectFitOutputOptionsModel.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_CUSTOMINTERFACES_INDIRECTFITOUTPUTOPTIONSMODEL_H_
-#define MANTID_CUSTOMINTERFACES_INDIRECTFITOUTPUTOPTIONSMODEL_H_
+#pragma once
 
 #include "IIndirectFitOutputOptionsModel.h"
 
@@ -89,5 +88,3 @@ private:
 } // namespace IDA
 } // namespace CustomInterfaces
 } // namespace MantidQt
-
-#endif

--- a/qt/scientific_interfaces/Indirect/IndirectFitOutputOptionsPresenter.h
+++ b/qt/scientific_interfaces/Indirect/IndirectFitOutputOptionsPresenter.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_CUSTOMINTERFACES_INDIRECTFITOUTPUTOPTIONSPRESENTER_H_
-#define MANTID_CUSTOMINTERFACES_INDIRECTFITOUTPUTOPTIONSPRESENTER_H_
+#pragma once
 
 #include "IIndirectFitOutputOptionsView.h"
 #include "IndirectEditResultsDialog.h"
@@ -84,5 +83,3 @@ private:
 } // namespace IDA
 } // namespace CustomInterfaces
 } // namespace MantidQt
-
-#endif

--- a/qt/scientific_interfaces/Indirect/IndirectFitOutputOptionsView.h
+++ b/qt/scientific_interfaces/Indirect/IndirectFitOutputOptionsView.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_CUSTOMINTERFACES_INDIRECTFITOUTPUTOPTIONSVIEW_H_
-#define MANTID_CUSTOMINTERFACES_INDIRECTFITOUTPUTOPTIONSVIEW_H_
+#pragma once
 
 #include "ui_IndirectFitOutputOptions.h"
 
@@ -69,4 +68,3 @@ private:
 } // namespace IDA
 } // namespace CustomInterfaces
 } // namespace MantidQt
-#endif

--- a/qt/scientific_interfaces/Indirect/IndirectFitPlotModel.h
+++ b/qt/scientific_interfaces/Indirect/IndirectFitPlotModel.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTIDQTCUSTOMINTERFACESIDA_INDIRECTFITPLOTMODEL_H_
-#define MANTIDQTCUSTOMINTERFACESIDA_INDIRECTFITPLOTMODEL_H_
+#pragma once
 
 #include "IndexTypes.h"
 #include "IndirectFittingModel.h"
@@ -103,5 +102,3 @@ private:
 } // namespace IDA
 } // namespace CustomInterfaces
 } // namespace MantidQt
-
-#endif /* MANTIDQTCUSTOMINTERFACESIDA_INDIRECTFITPLOTMODEL_H_ */

--- a/qt/scientific_interfaces/Indirect/IndirectFitPlotModelLegacy.h
+++ b/qt/scientific_interfaces/Indirect/IndirectFitPlotModelLegacy.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTIDQTCUSTOMINTERFACESIDA_INDIRECTFITPLOTMODELLEGACY_H_
-#define MANTIDQTCUSTOMINTERFACESIDA_INDIRECTFITPLOTMODELLEGACY_H_
+#pragma once
 
 #include "IndirectFittingModelLegacy.h"
 
@@ -101,5 +100,3 @@ private:
 } // namespace IDA
 } // namespace CustomInterfaces
 } // namespace MantidQt
-
-#endif /* MANTIDQTCUSTOMINTERFACESIDA_INDIRECTFITPLOTMODELLEGACY_H_ */

--- a/qt/scientific_interfaces/Indirect/IndirectFitPlotPresenter.h
+++ b/qt/scientific_interfaces/Indirect/IndirectFitPlotPresenter.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTIDQTCUSTOMINTERFACESIDA_INDIRECTFITPLOTPRESENTER_H_
-#define MANTIDQTCUSTOMINTERFACESIDA_INDIRECTFITPLOTPRESENTER_H_
+#pragma once
 
 #include "DllConfig.h"
 
@@ -123,5 +122,3 @@ private:
 } // namespace IDA
 } // namespace CustomInterfaces
 } // namespace MantidQt
-
-#endif

--- a/qt/scientific_interfaces/Indirect/IndirectFitPlotPresenterLegacy.h
+++ b/qt/scientific_interfaces/Indirect/IndirectFitPlotPresenterLegacy.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTIDQTCUSTOMINTERFACESIDA_INDIRECTFITPLOTPRESENTERLEGACY_H_
-#define MANTIDQTCUSTOMINTERFACESIDA_INDIRECTFITPLOTPRESENTERLEGACY_H_
+#pragma once
 
 #include "DllConfig.h"
 
@@ -114,5 +113,3 @@ private:
 } // namespace IDA
 } // namespace CustomInterfaces
 } // namespace MantidQt
-
-#endif

--- a/qt/scientific_interfaces/Indirect/IndirectFitPlotView.h
+++ b/qt/scientific_interfaces/Indirect/IndirectFitPlotView.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTIDQTCUSTOMINTERFACESIDA_INDIRECTFITPLOTVIEW_H_
-#define MANTIDQTCUSTOMINTERFACESIDA_INDIRECTFITPLOTVIEW_H_
+#pragma once
 
 #include "ui_IndirectFitPreviewPlot.h"
 
@@ -167,5 +166,3 @@ private:
 } // namespace IDA
 } // namespace CustomInterfaces
 } // namespace MantidQt
-
-#endif

--- a/qt/scientific_interfaces/Indirect/IndirectFitPlotViewLegacy.h
+++ b/qt/scientific_interfaces/Indirect/IndirectFitPlotViewLegacy.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTIDQTCUSTOMINTERFACESIDA_INDIRECTFITPLOTVIEWLEGACY_H_
-#define MANTIDQTCUSTOMINTERFACESIDA_INDIRECTFITPLOTVIEWLEGACY_H_
+#pragma once
 
 #include "ui_IndirectFitPreviewPlot.h"
 
@@ -165,5 +164,3 @@ private:
 } // namespace IDA
 } // namespace CustomInterfaces
 } // namespace MantidQt
-
-#endif

--- a/qt/scientific_interfaces/Indirect/IndirectFitPropertyBrowser.h
+++ b/qt/scientific_interfaces/Indirect/IndirectFitPropertyBrowser.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef INDIRECTFITPROPERTYBROWSER_H_
-#define INDIRECTFITPROPERTYBROWSER_H_
+#pragma once
 
 #include "DllConfig.h"
 #include "IndexTypes.h"
@@ -117,5 +116,3 @@ private:
 } // namespace IDA
 } // namespace CustomInterfaces
 } // namespace MantidQt
-
-#endif /*INDIRECTFITPROPERTYBROWSER_H_*/

--- a/qt/scientific_interfaces/Indirect/IndirectFittingModel.h
+++ b/qt/scientific_interfaces/Indirect/IndirectFittingModel.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTIDQTCUSTOMINTERFACESIDA_INDIRECTFITTINGMODEL_H_
-#define MANTIDQTCUSTOMINTERFACESIDA_INDIRECTFITTINGMODEL_H_
+#pragma once
 
 #include "IndexTypes.h"
 #include "IndirectFitData.h"
@@ -243,5 +242,3 @@ void IndirectFittingModel::applySpectra(TableDatasetIndex index,
 } // namespace IDA
 } // namespace CustomInterfaces
 } // namespace MantidQt
-
-#endif

--- a/qt/scientific_interfaces/Indirect/IndirectFittingModelLegacy.h
+++ b/qt/scientific_interfaces/Indirect/IndirectFittingModelLegacy.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTIDQTCUSTOMINTERFACESIDA_INDIRECTFITTINGMODELLEGACY_H_
-#define MANTIDQTCUSTOMINTERFACESIDA_INDIRECTFITTINGMODELLEGACY_H_
+#pragma once
 
 #include "IndirectFitDataLegacy.h"
 #include "IndirectFitOutputLegacy.h"
@@ -224,5 +223,3 @@ void IndirectFittingModelLegacy::applySpectra(std::size_t index,
 } // namespace IDA
 } // namespace CustomInterfaces
 } // namespace MantidQt
-
-#endif

--- a/qt/scientific_interfaces/Indirect/IndirectFunctionBrowser/ConvFunctionModel.h
+++ b/qt/scientific_interfaces/Indirect/IndirectFunctionBrowser/ConvFunctionModel.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTIDQT_INDIRECT_CONVFUNCTIONMODEL_H_
-#define MANTIDQT_INDIRECT_CONVFUNCTIONMODEL_H_
+#pragma once
 
 #include "ConvTypes.h"
 #include "DllConfig.h"
@@ -154,5 +153,3 @@ private:
 } // namespace IDA
 } // namespace CustomInterfaces
 } // namespace MantidQt
-
-#endif /* MANTIDQT_INDIRECT_CONVFUNCTIONMODEL_H_ */

--- a/qt/scientific_interfaces/Indirect/IndirectFunctionBrowser/ConvTemplateBrowser.h
+++ b/qt/scientific_interfaces/Indirect/IndirectFunctionBrowser/ConvTemplateBrowser.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef INDIRECT_CONVTEMPLATEBROWSER_H_
-#define INDIRECT_CONVTEMPLATEBROWSER_H_
+#pragma once
 
 #include "ConvTemplatePresenter.h"
 #include "ConvTypes.h"
@@ -113,5 +112,3 @@ private:
 } // namespace IDA
 } // namespace CustomInterfaces
 } // namespace MantidQt
-
-#endif /*INDIRECT_CONVTEMPLATEBROWSER_H_*/

--- a/qt/scientific_interfaces/Indirect/IndirectFunctionBrowser/ConvTemplatePresenter.h
+++ b/qt/scientific_interfaces/Indirect/IndirectFunctionBrowser/ConvTemplatePresenter.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef INDIRECT_CONVTEMPLATEPRESENTER_H_
-#define INDIRECT_CONVTEMPLATEPRESENTER_H_
+#pragma once
 
 #include "ConvFunctionModel.h"
 #include "DllConfig.h"
@@ -85,5 +84,3 @@ private:
 } // namespace IDA
 } // namespace CustomInterfaces
 } // namespace MantidQt
-
-#endif /*INDIRECT_CONVTEMPLATEPRESENTER_H_*/

--- a/qt/scientific_interfaces/Indirect/IndirectFunctionBrowser/ConvTypes.h
+++ b/qt/scientific_interfaces/Indirect/IndirectFunctionBrowser/ConvTypes.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTIDQT_INDIRECT_CONVTYPES_H_
-#define MANTIDQT_INDIRECT_CONVTYPES_H_
+#pragma once
 
 #include "DllConfig.h"
 #include "MantidAPI/FunctionFactory.h"
@@ -213,5 +212,3 @@ void applyToTemp(TempCorrectionType tempCorrectionType,
 } // namespace IDA
 } // namespace CustomInterfaces
 } // namespace MantidQt
-
-#endif /* MANTIDQT_INDIRECT_CONVTYPES_H_ */

--- a/qt/scientific_interfaces/Indirect/IndirectFunctionBrowser/FQFunctionModel.h
+++ b/qt/scientific_interfaces/Indirect/IndirectFunctionBrowser/FQFunctionModel.h
@@ -5,8 +5,7 @@
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
 
-#ifndef MANTID_FQFUNCTIONMODEL_H
-#define MANTID_FQFUNCTIONMODEL_H
+#pragma once
 
 #include "DllConfig.h"
 #include "IFQFitObserver.h"
@@ -55,5 +54,3 @@ private:
 } // namespace IDA
 } // namespace CustomInterfaces
 } // namespace MantidQt
-
-#endif // MANTID_FQFUNCTIONMODEL_H

--- a/qt/scientific_interfaces/Indirect/IndirectFunctionBrowser/FQTemplateBrowser.h
+++ b/qt/scientific_interfaces/Indirect/IndirectFunctionBrowser/FQTemplateBrowser.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef INDIRECT_FQTEMPLATEBROWSER_H_
-#define INDIRECT_FQTEMPLATEBROWSER_H_
+#pragma once
 
 #include "DllConfig.h"
 #include "FQTemplatePresenter.h"
@@ -96,5 +95,3 @@ private:
 } // namespace IDA
 } // namespace CustomInterfaces
 } // namespace MantidQt
-
-#endif /*INDIRECT_FQTEMPLATEBROWSER_H_*/

--- a/qt/scientific_interfaces/Indirect/IndirectFunctionBrowser/FQTemplatePresenter.h
+++ b/qt/scientific_interfaces/Indirect/IndirectFunctionBrowser/FQTemplatePresenter.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef INDIRECT_FQTEMPLATEPRESENTER_H_
-#define INDIRECT_FQTEMPLATEPRESENTER_H_
+#pragma once
 
 #include "DllConfig.h"
 #include "FQFunctionModel.h"
@@ -82,5 +81,3 @@ private:
 } // namespace IDA
 } // namespace CustomInterfaces
 } // namespace MantidQt
-
-#endif /*INDIRECT_FQTEMPLATEPRESENTER_H_*/

--- a/qt/scientific_interfaces/Indirect/IndirectFunctionBrowser/IqtFunctionModel.h
+++ b/qt/scientific_interfaces/Indirect/IndirectFunctionBrowser/IqtFunctionModel.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTIDQT_INDIRECT_IQTFUNCTIONMODEL_H_
-#define MANTIDQT_INDIRECT_IQTFUNCTIONMODEL_H_
+#pragma once
 
 #include "DllConfig.h"
 #include "MantidAPI/IFunction_fwd.h"
@@ -137,5 +136,3 @@ private:
 } // namespace IDA
 } // namespace CustomInterfaces
 } // namespace MantidQt
-
-#endif /* MANTIDQT_INDIRECT_IQTFUNCTIONMODEL_H_ */

--- a/qt/scientific_interfaces/Indirect/IndirectFunctionBrowser/IqtTemplateBrowser.h
+++ b/qt/scientific_interfaces/Indirect/IndirectFunctionBrowser/IqtTemplateBrowser.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef INDIRECT_IQTTEMPLATEBROWSER_H_
-#define INDIRECT_IQTTEMPLATEBROWSER_H_
+#pragma once
 
 #include "DllConfig.h"
 #include "FunctionTemplateBrowser.h"
@@ -120,5 +119,3 @@ private:
 } // namespace IDA
 } // namespace CustomInterfaces
 } // namespace MantidQt
-
-#endif /*INDIRECT_IQTTEMPLATEBROWSER_H_*/

--- a/qt/scientific_interfaces/Indirect/IndirectFunctionBrowser/IqtTemplatePresenter.h
+++ b/qt/scientific_interfaces/Indirect/IndirectFunctionBrowser/IqtTemplatePresenter.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef INDIRECT_IQTTEMPLATEPRESENTER_H_
-#define INDIRECT_IQTTEMPLATEPRESENTER_H_
+#pragma once
 
 #include "DllConfig.h"
 #include "IqtFunctionModel.h"
@@ -88,5 +87,3 @@ private:
 } // namespace IDA
 } // namespace CustomInterfaces
 } // namespace MantidQt
-
-#endif /*INDIRECT_IQTTEMPLATEPRESENTER_H_*/

--- a/qt/scientific_interfaces/Indirect/IndirectFunctionBrowser/MSDFunctionModel.h
+++ b/qt/scientific_interfaces/Indirect/IndirectFunctionBrowser/MSDFunctionModel.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTIDQT_INDIRECT_MSDFUNCTIONMODEL_H_
-#define MANTIDQT_INDIRECT_MSDFUNCTIONMODEL_H_
+#pragma once
 
 #include "DllConfig.h"
 #include "IndexTypes.h"
@@ -130,5 +129,3 @@ private:
 } // namespace IDA
 } // namespace CustomInterfaces
 } // namespace MantidQt
-
-#endif /* MANTIDQT_INDIRECT_MSDFUNCTIONMODEL_H_ */

--- a/qt/scientific_interfaces/Indirect/IndirectFunctionBrowser/MSDTemplateBrowser.h
+++ b/qt/scientific_interfaces/Indirect/IndirectFunctionBrowser/MSDTemplateBrowser.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef INDIRECT_MSDTEMPLATEBROWSER_H_
-#define INDIRECT_MSDTEMPLATEBROWSER_H_
+#pragma once
 
 #include "DllConfig.h"
 #include "FunctionTemplateBrowser.h"
@@ -109,5 +108,3 @@ private:
 } // namespace IDA
 } // namespace CustomInterfaces
 } // namespace MantidQt
-
-#endif /*INDIRECT_MSDTEMPLATEBROWSER_H_*/

--- a/qt/scientific_interfaces/Indirect/IndirectFunctionBrowser/MSDTemplatePresenter.h
+++ b/qt/scientific_interfaces/Indirect/IndirectFunctionBrowser/MSDTemplatePresenter.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef INDIRECT_MSDTEMPLATEPRESENTER_H_
-#define INDIRECT_MSDTEMPLATEPRESENTER_H_
+#pragma once
 
 #include "DllConfig.h"
 #include "MSDFunctionModel.h"
@@ -84,5 +83,3 @@ private:
 } // namespace IDA
 } // namespace CustomInterfaces
 } // namespace MantidQt
-
-#endif /*INDIRECT_MSDTEMPLATEPRESENTER_H_*/

--- a/qt/scientific_interfaces/Indirect/IndirectInstrumentConfig.h
+++ b/qt/scientific_interfaces/Indirect/IndirectInstrumentConfig.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTIDQTMANTIDWIDGETS_INDIRECTINSTRUMENTCONFIG_H_
-#define MANTIDQTMANTIDWIDGETS_INDIRECTINSTRUMENTCONFIG_H_
+#pragma once
 
 #include "DllConfig.h"
 #include "ui_IndirectInstrumentConfig.h"
@@ -118,5 +117,3 @@ private:
 
 } /* namespace MantidWidgets */
 } /* namespace MantidQt */
-
-#endif /* INDIRECTINSTRUMENTCONFIG_H_ */

--- a/qt/scientific_interfaces/Indirect/IndirectInterface.h
+++ b/qt/scientific_interfaces/Indirect/IndirectInterface.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTIDQTCUSTOMINTERFACES_INDIRECTINTERFACE_H_
-#define MANTIDQTCUSTOMINTERFACES_INDIRECTINTERFACE_H_
+#pragma once
 
 #include "IndirectSettings.h"
 
@@ -44,5 +43,3 @@ private:
 
 } // namespace CustomInterfaces
 } // namespace MantidQt
-
-#endif /* MANTIDQTCUSTOMINTERFACES_INDIRECTINTERFACE_H_ */

--- a/qt/scientific_interfaces/Indirect/IndirectLoadILL.h
+++ b/qt/scientific_interfaces/Indirect/IndirectLoadILL.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTIDQTCUSTOMINTERFACES_INDIRECTLOADILL_H_
-#define MANTIDQTCUSTOMINTERFACES_INDIRECTLOADILL_H_
+#pragma once
 
 #include "IndirectToolsTab.h"
 #include "ui_IndirectLoadILL.h"
@@ -48,5 +47,3 @@ private:
 };
 } // namespace CustomInterfaces
 } // namespace MantidQt
-
-#endif

--- a/qt/scientific_interfaces/Indirect/IndirectMolDyn.h
+++ b/qt/scientific_interfaces/Indirect/IndirectMolDyn.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTIDQTCUSTOMINTERFACES_INDIRECTMOLDYN_H_
-#define MANTIDQTCUSTOMINTERFACES_INDIRECTMOLDYN_H_
+#pragma once
 
 #include "IndirectSimulationTab.h"
 #include "ui_IndirectMolDyn.h"
@@ -44,5 +43,3 @@ private:
 };
 } // namespace CustomInterfaces
 } // namespace MantidQt
-
-#endif

--- a/qt/scientific_interfaces/Indirect/IndirectMoments.h
+++ b/qt/scientific_interfaces/Indirect/IndirectMoments.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_CUSTOMINTERFACES_INDIRECTMOMENTS_H_
-#define MANTID_CUSTOMINTERFACES_INDIRECTMOMENTS_H_
+#pragma once
 
 #include "IndirectDataReductionTab.h"
 
@@ -63,5 +62,3 @@ private:
 };
 } // namespace CustomInterfaces
 } // namespace MantidQt
-
-#endif /* MANTID_CUSTOMINTERFACES_INDIRECTMOMENTS_H_ */

--- a/qt/scientific_interfaces/Indirect/IndirectPlotOptionsModel.h
+++ b/qt/scientific_interfaces/Indirect/IndirectPlotOptionsModel.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTIDQTCUSTOMINTERFACES_INDIRECTPLOTOPTIONSMODEL_H_
-#define MANTIDQTCUSTOMINTERFACES_INDIRECTPLOTOPTIONSMODEL_H_
+#pragma once
 
 #include "IPythonRunner.h"
 #include "IndirectPlotter.h"
@@ -80,5 +79,3 @@ private:
 
 } // namespace CustomInterfaces
 } // namespace MantidQt
-
-#endif /* MANTIDQTCUSTOMINTERFACES_INDIRECTPLOTOPTIONSMODEL_H_ */

--- a/qt/scientific_interfaces/Indirect/IndirectPlotOptionsPresenter.h
+++ b/qt/scientific_interfaces/Indirect/IndirectPlotOptionsPresenter.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTIDQTCUSTOMINTERFACES_INDIRECTPLOTOPTIONSPRESENTER_H_
-#define MANTIDQTCUSTOMINTERFACES_INDIRECTPLOTOPTIONSPRESENTER_H_
+#pragma once
 
 #include "IPythonRunner.h"
 #include "IndirectInterface.h"
@@ -83,5 +82,3 @@ private:
 
 } // namespace CustomInterfaces
 } // namespace MantidQt
-
-#endif /* MANTIDQTCUSTOMINTERFACES_INDIRECTPLOTOPTIONSPRESENTER_H_ */

--- a/qt/scientific_interfaces/Indirect/IndirectPlotOptionsView.h
+++ b/qt/scientific_interfaces/Indirect/IndirectPlotOptionsView.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTIDQTCUSTOMINTERFACES_INDIRECTPLOTOPTIONSVIEW_H_
-#define MANTIDQTCUSTOMINTERFACES_INDIRECTPLOTOPTIONSVIEW_H_
+#pragma once
 
 #include "ui_IndirectPlotOptions.h"
 
@@ -88,5 +87,3 @@ private:
 
 } // namespace CustomInterfaces
 } // namespace MantidQt
-
-#endif /* MANTIDQTCUSTOMINTERFACES_INDIRECTPLOTOPTIONSVIEW_H_ */

--- a/qt/scientific_interfaces/Indirect/IndirectPlotter.h
+++ b/qt/scientific_interfaces/Indirect/IndirectPlotter.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_INDIRECTPLOTTER_H
-#define MANTID_INDIRECTPLOTTER_H
+#pragma once
 
 #include "IPythonRunner.h"
 
@@ -72,5 +71,3 @@ private:
 
 } // namespace CustomInterfaces
 } // namespace MantidQt
-
-#endif /* MANTID_INDIRECTPLOTTER_H */

--- a/qt/scientific_interfaces/Indirect/IndirectSassena.h
+++ b/qt/scientific_interfaces/Indirect/IndirectSassena.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTIDQTCUSTOMINTERFACES_INDIRECTSASSENA_H_
-#define MANTIDQTCUSTOMINTERFACES_INDIRECTSASSENA_H_
+#pragma once
 
 #include "IndirectSimulationTab.h"
 #include "ui_IndirectSassena.h"
@@ -44,5 +43,3 @@ private:
 };
 } // namespace CustomInterfaces
 } // namespace MantidQt
-
-#endif // MANTIDQTCUSTOMINTERFACES_INDIRECTSASSENA_H_

--- a/qt/scientific_interfaces/Indirect/IndirectSettings.h
+++ b/qt/scientific_interfaces/Indirect/IndirectSettings.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_CUSTOMINTERFACES_INDIRECTSETTINGS_H_
-#define MANTID_CUSTOMINTERFACES_INDIRECTSETTINGS_H_
+#pragma once
 
 #include "ui_IndirectSettings.h"
 
@@ -62,5 +61,3 @@ private:
 
 } // namespace CustomInterfaces
 } // namespace MantidQt
-
-#endif /* MANTID_CUSTOMINTERFACES_INDIRECTSETTINGS_H_ */

--- a/qt/scientific_interfaces/Indirect/IndirectSettingsHelper.h
+++ b/qt/scientific_interfaces/Indirect/IndirectSettingsHelper.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_INDIRECTSETTINGSHELPER_H
-#define MANTID_INDIRECTSETTINGSHELPER_H
+#pragma once
 
 namespace MantidQt {
 namespace CustomInterfaces {
@@ -20,5 +19,3 @@ bool externalPlotErrorBars();
 } // namespace IndirectSettingsHelper
 } // namespace CustomInterfaces
 } // namespace MantidQt
-
-#endif /* MANTID_INDIRECTSETTINGSHELPER_H */

--- a/qt/scientific_interfaces/Indirect/IndirectSettingsModel.h
+++ b/qt/scientific_interfaces/Indirect/IndirectSettingsModel.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_CUSTOMINTERFACES_INDIRECTSETTINGSMODEL_H_
-#define MANTID_CUSTOMINTERFACES_INDIRECTSETTINGSMODEL_H_
+#pragma once
 
 #include "DllConfig.h"
 
@@ -26,5 +25,3 @@ public:
 
 } // namespace CustomInterfaces
 } // namespace MantidQt
-
-#endif /* MANTID_CUSTOMINTERFACES_INDIRECTSETTINGSMODEL_H_ */

--- a/qt/scientific_interfaces/Indirect/IndirectSettingsPresenter.h
+++ b/qt/scientific_interfaces/Indirect/IndirectSettingsPresenter.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_CUSTOMINTERFACES_INDIRECTSETTINGSPRESENTER_H_
-#define MANTID_CUSTOMINTERFACES_INDIRECTSETTINGSPRESENTER_H_
+#pragma once
 
 #include "DllConfig.h"
 #include "IndirectSettingsModel.h"
@@ -53,5 +52,3 @@ private:
 
 } // namespace CustomInterfaces
 } // namespace MantidQt
-
-#endif /* MANTID_CUSTOMINTERFACES_INDIRECTSETTINGSPRESENTER_H_ */

--- a/qt/scientific_interfaces/Indirect/IndirectSettingsView.h
+++ b/qt/scientific_interfaces/Indirect/IndirectSettingsView.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_CUSTOMINTERFACES_INDIRECTSETTINGSVIEW_H_
-#define MANTID_CUSTOMINTERFACES_INDIRECTSETTINGSVIEW_H_
+#pragma once
 
 #include "ui_IndirectInterfaceSettings.h"
 
@@ -54,5 +53,3 @@ private:
 
 } // namespace CustomInterfaces
 } // namespace MantidQt
-
-#endif /* MANTID_CUSTOMINTERFACES_INDIRECTSETTINGSVIEW_H_ */

--- a/qt/scientific_interfaces/Indirect/IndirectSimulation.h
+++ b/qt/scientific_interfaces/Indirect/IndirectSimulation.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTIDQTCUSTOMINTERFACES_INDIRECTSIMULATION_H_
-#define MANTIDQTCUSTOMINTERFACES_INDIRECTSIMULATION_H_
+#pragma once
 #include "ui_IndirectSimulation.h"
 
 #include "IndirectInterface.h"
@@ -66,5 +65,3 @@ private:
 };
 } // namespace CustomInterfaces
 } // namespace MantidQt
-
-#endif

--- a/qt/scientific_interfaces/Indirect/IndirectSimulationTab.h
+++ b/qt/scientific_interfaces/Indirect/IndirectSimulationTab.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_CUSTOMINTERFACES_INDIRECTSIMULATIONTAB_H_
-#define MANTID_CUSTOMINTERFACES_INDIRECTSIMULATIONTAB_H_
+#pragma once
 
 #include "IndirectPlotOptionsPresenter.h"
 #include "IndirectTab.h"
@@ -49,5 +48,3 @@ private:
 };
 } // namespace CustomInterfaces
 } // namespace MantidQt
-
-#endif

--- a/qt/scientific_interfaces/Indirect/IndirectSpectrumSelectionPresenter.h
+++ b/qt/scientific_interfaces/Indirect/IndirectSpectrumSelectionPresenter.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_CUSTOMINTERFACES_INDIRECTSPECTRUMSELECTIONPRESENTER_H_
-#define MANTID_CUSTOMINTERFACES_INDIRECTSPECTRUMSELECTIONPRESENTER_H_
+#pragma once
 
 #include "IndirectFittingModel.h"
 #include "IndirectSpectrumSelectionView.h"
@@ -73,5 +72,3 @@ private:
 } // namespace IDA
 } // namespace CustomInterfaces
 } // namespace MantidQt
-
-#endif

--- a/qt/scientific_interfaces/Indirect/IndirectSpectrumSelectionPresenterLegacy.h
+++ b/qt/scientific_interfaces/Indirect/IndirectSpectrumSelectionPresenterLegacy.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_CUSTOMINTERFACES_INDIRECTSPECTRUMSELECTIONPRESENTERLEGACY_H_
-#define MANTID_CUSTOMINTERFACES_INDIRECTSPECTRUMSELECTIONPRESENTERLEGACY_H_
+#pragma once
 
 #include "IndirectFittingModelLegacy.h"
 #include "IndirectSpectrumSelectionViewLegacy.h"
@@ -73,5 +72,3 @@ private:
 } // namespace IDA
 } // namespace CustomInterfaces
 } // namespace MantidQt
-
-#endif

--- a/qt/scientific_interfaces/Indirect/IndirectSpectrumSelectionView.h
+++ b/qt/scientific_interfaces/Indirect/IndirectSpectrumSelectionView.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_CUSTOMINTERFACES_INDIRECTSPECTRUMSELECTIONVIEW_H_
-#define MANTID_CUSTOMINTERFACES_INDIRECTSPECTRUMSELECTIONVIEW_H_
+#pragma once
 
 #include "IndexTypes.h"
 #include "ui_IndirectSpectrumSelector.h"
@@ -104,5 +103,3 @@ private:
 } // namespace IDA
 } // namespace CustomInterfaces
 } // namespace MantidQt
-
-#endif

--- a/qt/scientific_interfaces/Indirect/IndirectSpectrumSelectionViewLegacy.h
+++ b/qt/scientific_interfaces/Indirect/IndirectSpectrumSelectionViewLegacy.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_CUSTOMINTERFACES_INDIRECTSPECTRUMSELECTIONVIEWLEGACY_H_
-#define MANTID_CUSTOMINTERFACES_INDIRECTSPECTRUMSELECTIONVIEWLEGACY_H_
+#pragma once
 
 #include "ui_IndirectSpectrumSelector.h"
 
@@ -101,5 +100,3 @@ private:
 } // namespace IDA
 } // namespace CustomInterfaces
 } // namespace MantidQt
-
-#endif

--- a/qt/scientific_interfaces/Indirect/IndirectSqw.h
+++ b/qt/scientific_interfaces/Indirect/IndirectSqw.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTIDQTCUSTOMINTERFACES_INDIRECTSQW_H_
-#define MANTIDQTCUSTOMINTERFACES_INDIRECTSQW_H_
+#pragma once
 
 #include "IndirectDataReductionTab.h"
 
@@ -58,5 +57,3 @@ private:
 };
 } // namespace CustomInterfaces
 } // namespace MantidQt
-
-#endif // MANTIDQTCUSTOMINTERFACES_INDIRECTSQW_H_

--- a/qt/scientific_interfaces/Indirect/IndirectSymmetrise.h
+++ b/qt/scientific_interfaces/Indirect/IndirectSymmetrise.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTIDQTCUSTOMINTERFACES_INDIRECTSYMMETRISE_H_
-#define MANTIDQTCUSTOMINTERFACES_INDIRECTSYMMETRISE_H_
+#pragma once
 
 #include "IndirectDataReductionTab.h"
 
@@ -81,5 +80,3 @@ private:
 };
 } // namespace CustomInterfaces
 } // namespace MantidQt
-
-#endif // MANTIDQTCUSTOMINTERFACES_INDIRECTSYMMETRISE_H_

--- a/qt/scientific_interfaces/Indirect/IndirectTab.h
+++ b/qt/scientific_interfaces/Indirect/IndirectTab.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_CUSTOMINTERFACES_INDIRECTTAB_H_
-#define MANTID_CUSTOMINTERFACES_INDIRECTTAB_H_
+#pragma once
 
 #include "DllConfig.h"
 #include "IPythonRunner.h"
@@ -241,5 +240,3 @@ private:
 };
 } // namespace CustomInterfaces
 } // namespace MantidQt
-
-#endif /* MANTID_CUSTOMINTERFACES_INDIRECTTAB_H_ */

--- a/qt/scientific_interfaces/Indirect/IndirectTools.h
+++ b/qt/scientific_interfaces/Indirect/IndirectTools.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTIDQTCUSTOMINTERFACES_INDIRECTTOOLS_H_
-#define MANTIDQTCUSTOMINTERFACES_INDIRECTTOOLS_H_
+#pragma once
 #include "ui_IndirectTools.h"
 
 #include "IndirectInterface.h"
@@ -69,5 +68,3 @@ private:
 };
 } // namespace CustomInterfaces
 } // namespace MantidQt
-
-#endif

--- a/qt/scientific_interfaces/Indirect/IndirectToolsTab.h
+++ b/qt/scientific_interfaces/Indirect/IndirectToolsTab.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_CUSTOMINTERFACES_INDIRECTTOOLSTAB_H_
-#define MANTID_CUSTOMINTERFACES_INDIRECTTOOLSTAB_H_
+#pragma once
 
 #include "IndirectTab.h"
 #include "MantidKernel/System.h"
@@ -47,5 +46,3 @@ protected:
 };
 } // namespace CustomInterfaces
 } // namespace MantidQt
-
-#endif

--- a/qt/scientific_interfaces/Indirect/IndirectTransmission.h
+++ b/qt/scientific_interfaces/Indirect/IndirectTransmission.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_CUSTOMINTERFACES_INDIRECTTRANSMISSION_H_
-#define MANTID_CUSTOMINTERFACES_INDIRECTTRANSMISSION_H_
+#pragma once
 
 #include "IndirectDataReductionTab.h"
 #include "MantidKernel/System.h"
@@ -56,5 +55,3 @@ private:
 
 } // namespace CustomInterfaces
 } // namespace MantidQt
-
-#endif /* MANTID_CUSTOMINTERFACES_INDIRECTTRANSMISSION_H_ */

--- a/qt/scientific_interfaces/Indirect/IndirectTransmissionCalc.h
+++ b/qt/scientific_interfaces/Indirect/IndirectTransmissionCalc.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTIDQTCUSTOMINTERFACES_INDIRECTTRANSMISSIONCALC_H_
-#define MANTIDQTCUSTOMINTERFACES_INDIRECTTRANSMISSIONCALC_H_
+#pragma once
 
 #include "IndirectToolsTab.h"
 #include "MantidAPI/ExperimentInfo.h"
@@ -47,5 +46,3 @@ private:
 };
 } // namespace CustomInterfaces
 } // namespace MantidQt
-
-#endif

--- a/qt/scientific_interfaces/Indirect/Iqt.h
+++ b/qt/scientific_interfaces/Indirect/Iqt.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTIDQTCUSTOMINTERFACESIDA_IQT_H_
-#define MANTIDQTCUSTOMINTERFACESIDA_IQT_H_
+#pragma once
 
 #include "IndirectDataAnalysisTab.h"
 #include "ui_Iqt.h"
@@ -55,5 +54,3 @@ private:
 } // namespace IDA
 } // namespace CustomInterfaces
 } // namespace MantidQt
-
-#endif /* MANTIDQTCUSTOMINTERFACESIDA_IQT_H_ */

--- a/qt/scientific_interfaces/Indirect/IqtFit.h
+++ b/qt/scientific_interfaces/Indirect/IqtFit.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTIDQTCUSTOMINTERFACESIDA_IQTFIT_H_
-#define MANTIDQTCUSTOMINTERFACESIDA_IQTFIT_H_
+#pragma once
 
 #include "IndirectFitAnalysisTab.h"
 #include "IqtFitModel.h"
@@ -59,5 +58,3 @@ private:
 } // namespace IDA
 } // namespace CustomInterfaces
 } // namespace MantidQt
-
-#endif /* MANTIDQTCUSTOMINTERFACESIDA_IQTFIT_H_ */

--- a/qt/scientific_interfaces/Indirect/IqtFitModel.h
+++ b/qt/scientific_interfaces/Indirect/IqtFitModel.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTIDQTCUSTOMINTERFACESIDA_IQTFITMODEL_H_
-#define MANTIDQTCUSTOMINTERFACESIDA_IQTFITMODEL_H_
+#pragma once
 
 #include "IndirectFittingModel.h"
 
@@ -43,5 +42,3 @@ private:
 } // namespace IDA
 } // namespace CustomInterfaces
 } // namespace MantidQt
-
-#endif

--- a/qt/scientific_interfaces/Indirect/JumpFit.h
+++ b/qt/scientific_interfaces/Indirect/JumpFit.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTIDQTCUSTOMINTERFACES_JUMPFIT_H_
-#define MANTIDQTCUSTOMINTERFACES_JUMPFIT_H_
+#pragma once
 
 #include "IndirectFitAnalysisTab.h"
 #include "JumpFitModel.h"
@@ -46,5 +45,3 @@ private:
 } // namespace IDA
 } // namespace CustomInterfaces
 } // namespace MantidQt
-
-#endif

--- a/qt/scientific_interfaces/Indirect/JumpFitAddWorkspaceDialog.h
+++ b/qt/scientific_interfaces/Indirect/JumpFitAddWorkspaceDialog.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTIDQTCUSTOMINTERFACES_JUMPFITADDWORKSPACEDIALOG_H_
-#define MANTIDQTCUSTOMINTERFACES_JUMPFITADDWORKSPACEDIALOG_H_
+#pragma once
 
 #include "IAddWorkspaceDialog.h"
 #include "ui_JumpFitAddWorkspaceDialog.h"
@@ -50,5 +49,3 @@ private:
 } // namespace IDA
 } // namespace CustomInterfaces
 } // namespace MantidQt
-
-#endif /* MANTIDQTCUSTOMINTERFACES_JUMPFITADDWORKSPACEDIALOG_H_ */

--- a/qt/scientific_interfaces/Indirect/JumpFitDataPresenter.h
+++ b/qt/scientific_interfaces/Indirect/JumpFitDataPresenter.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTIDQTCUSTOMINTERFACESIDA_JUMPFITDATAPRESENTER_H_
-#define MANTIDQTCUSTOMINTERFACESIDA_JUMPFITDATAPRESENTER_H_
+#pragma once
 
 #include "IFQFitObserver.h"
 #include "IndirectFitDataPresenter.h"
@@ -85,5 +84,3 @@ private:
 } // namespace IDA
 } // namespace CustomInterfaces
 } // namespace MantidQt
-
-#endif /* MANTIDQTCUSTOMINTERFACESIDA_JUMPFITDATAPRESENTER_H_ */

--- a/qt/scientific_interfaces/Indirect/JumpFitDataTablePresenter.h
+++ b/qt/scientific_interfaces/Indirect/JumpFitDataTablePresenter.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTIDQTCUSTOMINTERFACES_JUMPFITDATATABLEPRESENTER_H_
-#define MANTIDQTCUSTOMINTERFACES_JUMPFITDATATABLEPRESENTER_H_
+#pragma once
 
 #include "IndirectDataTablePresenter.h"
 #include "JumpFitModel.h"
@@ -45,5 +44,3 @@ private:
 } // namespace IDA
 } // namespace CustomInterfaces
 } // namespace MantidQt
-
-#endif /* MANTIDQTCUSTOMINTERFACES_JUMPFITDATATABLEPRESENTER_H_ */

--- a/qt/scientific_interfaces/Indirect/JumpFitModel.h
+++ b/qt/scientific_interfaces/Indirect/JumpFitModel.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTIDQTCUSTOMINTERFACESIDA_JUMPFITMODEL_H_
-#define MANTIDQTCUSTOMINTERFACESIDA_JUMPFITMODEL_H_
+#pragma once
 
 #include "IndirectFittingModel.h"
 
@@ -70,5 +69,3 @@ private:
 } // namespace IDA
 } // namespace CustomInterfaces
 } // namespace MantidQt
-
-#endif

--- a/qt/scientific_interfaces/Indirect/LazyAsyncRunner.h
+++ b/qt/scientific_interfaces/Indirect/LazyAsyncRunner.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTIDQTCUSTOMINTERFACES_LAZYASYNCRUNNER_H_
-#define MANTIDQTCUSTOMINTERFACES_LAZYASYNCRUNNER_H_
+#pragma once
 
 #include "DllConfig.h"
 
@@ -82,5 +81,3 @@ private:
 } // namespace IDA
 } // namespace CustomInterfaces
 } // namespace MantidQt
-
-#endif /* MANTIDQTCUSTOMINTERFACES_INDIRECTFITDATAPRESENTER_H_ */

--- a/qt/scientific_interfaces/Indirect/MSDFit.h
+++ b/qt/scientific_interfaces/Indirect/MSDFit.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTIDQTCUSTOMINTERFACESIDA_MSDFIT_H_
-#define MANTIDQTCUSTOMINTERFACESIDA_MSDFIT_H_
+#pragma once
 
 #include "IndirectFitAnalysisTab.h"
 #include "MSDFitModel.h"
@@ -42,5 +41,3 @@ private:
 } // namespace IDA
 } // namespace CustomInterfaces
 } // namespace MantidQt
-
-#endif /* MANTIDQTCUSTOMINTERFACESIDA_MSDFIT_H_ */

--- a/qt/scientific_interfaces/Indirect/MSDFitModel.h
+++ b/qt/scientific_interfaces/Indirect/MSDFitModel.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTIDQTCUSTOMINTERFACESIDA_MSDFITMODEL_H_
-#define MANTIDQTCUSTOMINTERFACESIDA_MSDFITMODEL_H_
+#pragma once
 
 #include "IndirectFittingModel.h"
 
@@ -29,5 +28,3 @@ private:
 } // namespace IDA
 } // namespace CustomInterfaces
 } // namespace MantidQt
-
-#endif

--- a/qt/scientific_interfaces/Indirect/Notifier.h
+++ b/qt/scientific_interfaces/Indirect/Notifier.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTIDQTCUSTOMINTERFACES_NOTIFIER_H_
-#define MANTIDQTCUSTOMINTERFACES_NOTIFIER_H_
+#pragma once
 
 template <class T> class Notifier {
 public:
@@ -19,5 +18,3 @@ public:
 private:
   std::vector<T *> m_subscribers;
 };
-
-#endif

--- a/qt/scientific_interfaces/Indirect/ParameterEstimation.h
+++ b/qt/scientific_interfaces/Indirect/ParameterEstimation.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTIDQTCUSTOMINTERFACESIDA_PARAMETERESTIMATION_H_
-#define MANTIDQTCUSTOMINTERFACESIDA_PARAMETERESTIMATION_H_
+#pragma once
 
 #include "MantidKernel/cow_ptr.h"
 #include <functional>
@@ -28,5 +27,3 @@ using EstimationDataSelector = std::function<DataForParameterEstimation(
 } // namespace IDA
 } // namespace CustomInterfaces
 } // namespace MantidQt
-
-#endif /* MANTIDQTCUSTOMINTERFACESIDA_PARAMETERESTIMATION_H_ */

--- a/qt/scientific_interfaces/Indirect/PrecompiledHeader.h
+++ b/qt/scientific_interfaces/Indirect/PrecompiledHeader.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTIDQT_MUON_PRECOMPILEDHEADER_H_
-#define MANTIDQT_MUON_PRECOMPILEDHEADER_H_
+#pragma once
 
 // Mantid
 #include "MantidAPI/Algorithm.h"
@@ -22,5 +21,3 @@
 #include <set>
 #include <string>
 #include <vector>
-
-#endif // MANTIDQT_MUON_PRECOMPILEDHEADER_H_

--- a/qt/scientific_interfaces/Indirect/Quasi.h
+++ b/qt/scientific_interfaces/Indirect/Quasi.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTIDQTCUSTOMINTERFACES_QUASI_H_
-#define MANTIDQTCUSTOMINTERFACES_QUASI_H_
+#pragma once
 
 #include "IndirectBayesTab.h"
 #include "ui_Quasi.h"
@@ -72,5 +71,3 @@ private:
 };
 } // namespace CustomInterfaces
 } // namespace MantidQt
-
-#endif

--- a/qt/scientific_interfaces/Indirect/ResNorm.h
+++ b/qt/scientific_interfaces/Indirect/ResNorm.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTIDQTCUSTOMINTERFACES_RESNORM_H_
-#define MANTIDQTCUSTOMINTERFACES_RESNORM_H_
+#pragma once
 
 #include "IndirectBayesTab.h"
 #include "MantidAPI/MatrixWorkspace.h"
@@ -76,5 +75,3 @@ private:
 };
 } // namespace CustomInterfaces
 } // namespace MantidQt
-
-#endif

--- a/qt/scientific_interfaces/Indirect/Stretch.h
+++ b/qt/scientific_interfaces/Indirect/Stretch.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTIDQTCUSTOMINTERFACES_STRETCH_H_
-#define MANTIDQTCUSTOMINTERFACES_STRETCH_H_
+#pragma once
 
 #include "IndirectBayesTab.h"
 #include "MantidAPI/WorkspaceGroup_fwd.h"
@@ -73,5 +72,3 @@ private:
 };
 } // namespace CustomInterfaces
 } // namespace MantidQt
-
-#endif

--- a/qt/scientific_interfaces/Indirect/test/ConvFitDataPresenterTest.h
+++ b/qt/scientific_interfaces/Indirect/test/ConvFitDataPresenterTest.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTIDQT_CONVFITDATAPRESENTERTEST_H_
-#define MANTIDQT_CONVFITDATAPRESENTERTEST_H_
+#pragma once
 
 #include <cxxtest/TestSuite.h>
 #include <gmock/gmock.h>
@@ -154,4 +153,3 @@ private:
   std::unique_ptr<MockConvFitModel> m_model;
   std::unique_ptr<ConvFitDataPresenter> m_presenter;
 };
-#endif

--- a/qt/scientific_interfaces/Indirect/test/ConvFitModelTest.h
+++ b/qt/scientific_interfaces/Indirect/test/ConvFitModelTest.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTIDQT_CONVFITMODELTEST_H_
-#define MANTIDQT_CONVFITMODELTEST_H_
+#pragma once
 
 #include <cxxtest/TestSuite.h>
 
@@ -261,5 +260,3 @@ private:
   std::unique_ptr<SetUpADSWithWorkspace> m_ads;
   std::unique_ptr<ConvFitModel> m_model;
 };
-
-#endif /* MANTIDQT_CONVFITMODELTEST_H_ */

--- a/qt/scientific_interfaces/Indirect/test/ConvFunctionModelTest.h
+++ b/qt/scientific_interfaces/Indirect/test/ConvFunctionModelTest.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTIDQT_CONVFUNCTIONMODELTEST_H_
-#define MANTIDQT_CONVFUNCTIONMODELTEST_H_
+#pragma once
 
 #include <cxxtest/TestSuite.h>
 
@@ -174,5 +173,3 @@ public:
 private:
   std::unique_ptr<MantidQt::CustomInterfaces::IDA::ConvFunctionModel> m_model;
 };
-
-#endif /* MANTIDQT_CONVFUNCTIONMODELTEST_H_ */

--- a/qt/scientific_interfaces/Indirect/test/IndirectDataTablePresenterTest.h
+++ b/qt/scientific_interfaces/Indirect/test/IndirectDataTablePresenterTest.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTIDQT_INDIRECTDATATABLEPRESENTERTEST_H_
-#define MANTIDQT_INDIRECTDATATABLEPRESENTERTEST_H_
+#pragma once
 
 #include <cxxtest/TestSuite.h>
 #include <gmock/gmock.h>
@@ -370,5 +369,3 @@ private:
   std::unique_ptr<MockIndirectDataTableModel> m_model;
   std::unique_ptr<IndirectDataTablePresenterLegacy> m_presenter;
 };
-
-#endif

--- a/qt/scientific_interfaces/Indirect/test/IndirectDataValidationHelperTest.h
+++ b/qt/scientific_interfaces/Indirect/test/IndirectDataValidationHelperTest.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_CUSTOMINTERFACES_INDIRECTDATAVALIDATIONHELPERTEST_H_
-#define MANTID_CUSTOMINTERFACES_INDIRECTDATAVALIDATIONHELPERTEST_H_
+#pragma once
 
 #include <cxxtest/TestSuite.h>
 #include <gmock/gmock.h>
@@ -303,5 +302,3 @@ private:
   std::unique_ptr<UserInputValidator> m_uiv;
   std::unique_ptr<MockDataSelector> m_dataSelector;
 };
-
-#endif /* MANTID_CUSTOMINTERFACES_INDIRECTDATAVALIDATIONHELPERTEST_H_ */

--- a/qt/scientific_interfaces/Indirect/test/IndirectFitAnalysisTabTest.h
+++ b/qt/scientific_interfaces/Indirect/test/IndirectFitAnalysisTabTest.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTIDQT_INDIRECTFITANALYSISTABTEST_H_
-#define MANTIDQT_INDIRECTFITANALYSISTABTEST_H_
+#pragma once
 
 #include "IndirectFitAnalysisTab.h"
 #include "MantidAPI/FunctionFactory.h"
@@ -68,5 +67,3 @@ public:
     TS_ASSERT_EQUALS(occurances, 4);
   }
 };
-
-#endif // MANTIDQT_INDIRECTFITANALYSISTABTEST_H_

--- a/qt/scientific_interfaces/Indirect/test/IndirectFitDataPresenterTest.h
+++ b/qt/scientific_interfaces/Indirect/test/IndirectFitDataPresenterTest.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTIDQT_INDIRECTFITDATAPRESENTERTEST_H_
-#define MANTIDQT_INDIRECTFITDATAPRESENTERTEST_H_
+#pragma once
 
 #include <cxxtest/TestSuite.h>
 #include <gmock/gmock.h>
@@ -320,5 +319,3 @@ private:
 
   SetUpADSWithWorkspace *m_ads;
 };
-
-#endif

--- a/qt/scientific_interfaces/Indirect/test/IndirectFitDataTest.h
+++ b/qt/scientific_interfaces/Indirect/test/IndirectFitDataTest.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_INDIRECTFITDATATEST_H_
-#define MANTID_INDIRECTFITDATATEST_H_
+#pragma once
 
 #include <cxxtest/TestSuite.h>
 
@@ -472,5 +471,3 @@ public:
         boost::apply_visitor(AreSpectraEqual(), combinedData.spectra(), spec));
   }
 };
-
-#endif

--- a/qt/scientific_interfaces/Indirect/test/IndirectFitOutputOptionsModelTest.h
+++ b/qt/scientific_interfaces/Indirect/test/IndirectFitOutputOptionsModelTest.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTIDQT_INDIRECTFITOUTPUTOPTIONSMODELTEST_H_
-#define MANTIDQT_INDIRECTFITOUTPUTOPTIONSMODELTEST_H_
+#pragma once
 
 #include <cxxtest/TestSuite.h>
 
@@ -312,5 +311,3 @@ private:
   WorkspaceGroup_sptr m_groupWorkspace;
   std::unique_ptr<IndirectFitOutputOptionsModel> m_model;
 };
-
-#endif

--- a/qt/scientific_interfaces/Indirect/test/IndirectFitOutputOptionsPresenterTest.h
+++ b/qt/scientific_interfaces/Indirect/test/IndirectFitOutputOptionsPresenterTest.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTIDQT_INDIRECTFITOUTPUTOPTIONSPRESENTERTEST_H_
-#define MANTIDQT_INDIRECTFITOUTPUTOPTIONSPRESENTERTEST_H_
+#pragma once
 
 #include <cxxtest/TestSuite.h>
 #include <gmock/gmock.h>
@@ -481,4 +480,3 @@ private:
   std::unique_ptr<MockIndirectFitOutputOptionsModel> m_model;
   std::unique_ptr<IndirectFitOutputOptionsPresenter> m_presenter;
 };
-#endif

--- a/qt/scientific_interfaces/Indirect/test/IndirectFitOutputTest.h
+++ b/qt/scientific_interfaces/Indirect/test/IndirectFitOutputTest.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_INDIRECTFITOUTPUTTEST_H_
-#define MANTID_INDIRECTFITOUTPUTTEST_H_
+#pragma once
 
 #include <cxxtest/TestSuite.h>
 
@@ -341,5 +340,3 @@ private:
   std::unique_ptr<IndirectFitDataLegacy> m_fitData;
   std::unique_ptr<SetUpADSWithWorkspace> m_ads;
 };
-
-#endif // MANTID_INDIRECTFITOUTPUTTEST_H

--- a/qt/scientific_interfaces/Indirect/test/IndirectFitPlotModelTest.h
+++ b/qt/scientific_interfaces/Indirect/test/IndirectFitPlotModelTest.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_INDIRECTFITPLOTMODELTEST_H_
-#define MANTID_INDIRECTFITPLOTMODELTEST_H_
+#pragma once
 
 #include <cxxtest/TestSuite.h>
 
@@ -425,5 +424,3 @@ public:
     TS_ASSERT_THROWS_NOTHING(model.deleteExternalGuessWorkspace());
   }
 };
-
-#endif

--- a/qt/scientific_interfaces/Indirect/test/IndirectFitPlotPresenterTest.h
+++ b/qt/scientific_interfaces/Indirect/test/IndirectFitPlotPresenterTest.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTIDQT_INDIRECTFITPLOTPRESENTERTEST_H_
-#define MANTIDQT_INDIRECTFITPLOTPRESENTERTEST_H_
+#pragma once
 
 #include <cxxtest/TestSuite.h>
 #include <gmock/gmock.h>
@@ -608,5 +607,3 @@ private:
 
   SetUpADSWithWorkspace *m_ads;
 };
-
-#endif

--- a/qt/scientific_interfaces/Indirect/test/IndirectFittingModelTest.h
+++ b/qt/scientific_interfaces/Indirect/test/IndirectFittingModelTest.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_INDIRECTFITTINGMODELTEST_H_
-#define MANTID_INDIRECTFITTINGMODELTEST_H_
+#pragma once
 
 #include <cxxtest/TestSuite.h>
 
@@ -749,5 +748,3 @@ public:
     TS_ASSERT(!ads.doesExist("__ConvolutionFitSequential_ws1"));
   }
 };
-
-#endif // MANTID_INDIRECTFITTINGMODELTEST_H

--- a/qt/scientific_interfaces/Indirect/test/IndirectPlotOptionsModelTest.h
+++ b/qt/scientific_interfaces/Indirect/test/IndirectPlotOptionsModelTest.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTIDQT_INDIRECTPLOTOPTIONSMODELTEST_H_
-#define MANTIDQT_INDIRECTPLOTOPTIONSMODELTEST_H_
+#pragma once
 
 #include <cxxtest/TestSuite.h>
 #include <gmock/gmock.h>
@@ -393,5 +392,3 @@ private:
   std::unique_ptr<IndirectPlotOptionsModel> m_model;
   MockIndirectPlotter *m_plotter;
 };
-
-#endif /* MANTIDQT_INDIRECTPLOTOPTIONSMODELTEST_H_ */

--- a/qt/scientific_interfaces/Indirect/test/IndirectPlotOptionsPresenterTest.h
+++ b/qt/scientific_interfaces/Indirect/test/IndirectPlotOptionsPresenterTest.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTIDQT_INDIRECTPLOTOPTIONSPRESENTERTEST_H_
-#define MANTIDQT_INDIRECTPLOTOPTIONSPRESENTERTEST_H_
+#pragma once
 
 #include <cxxtest/TestSuite.h>
 #include <gmock/gmock.h>
@@ -345,5 +344,3 @@ private:
   MockIndirectPlotOptionsModel *m_model;
   std::unique_ptr<IndirectPlotOptionsPresenter> m_presenter;
 };
-
-#endif /* MANTIDQT_INDIRECTPLOTOPTIONSPRESENTERTEST_H_ */

--- a/qt/scientific_interfaces/Indirect/test/IndirectPlotterTest.h
+++ b/qt/scientific_interfaces/Indirect/test/IndirectPlotterTest.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTIDQT_INDIRECTPLOTTERTEST_H_
-#define MANTIDQT_INDIRECTPLOTTERTEST_H_
+#pragma once
 
 #include <cxxtest/TestSuite.h>
 #include <gmock/gmock.h>
@@ -170,5 +169,3 @@ private:
   std::unique_ptr<MockIPyRunner> m_pyRunner;
   std::unique_ptr<IndirectPlotter> m_plotter;
 };
-
-#endif /* MANTIDQT_INDIRECTPLOTTERTEST_H_ */

--- a/qt/scientific_interfaces/Indirect/test/IndirectSettingsModelTest.h
+++ b/qt/scientific_interfaces/Indirect/test/IndirectSettingsModelTest.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTIDQT_INDIRECTSETTINGSMODELTEST_H_
-#define MANTIDQT_INDIRECTSETTINGSMODELTEST_H_
+#pragma once
 
 #include <cxxtest/TestSuite.h>
 #include <memory>
@@ -36,5 +35,3 @@ public:
 private:
   std::unique_ptr<IndirectSettingsModel> m_model;
 };
-
-#endif /* MANTIDQT_INDIRECTSETTINGSMODELTEST_H_ */

--- a/qt/scientific_interfaces/Indirect/test/IndirectSettingsPresenterTest.h
+++ b/qt/scientific_interfaces/Indirect/test/IndirectSettingsPresenterTest.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTIDQT_INDIRECTSETTINGSPRESENTERTEST_H_
-#define MANTIDQT_INDIRECTSETTINGSPRESENTERTEST_H_
+#pragma once
 
 #include <cxxtest/TestSuite.h>
 #include <gmock/gmock.h>
@@ -163,5 +162,3 @@ private:
   MockIndirectSettingsModel *m_model;
   std::unique_ptr<IndirectSettingsPresenter> m_presenter;
 };
-
-#endif /* MANTIDQT_INDIRECTSETTINGSPRESENTERTEST_H_ */

--- a/qt/scientific_interfaces/Indirect/test/IndirectSpectrumSelectionPresenterTest.h
+++ b/qt/scientific_interfaces/Indirect/test/IndirectSpectrumSelectionPresenterTest.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTIDQT_INDIRECTSPECTRUMSELECTIONPRESENTERTEST_H_
-#define MANTIDQT_INDIRECTSPECTRUMSELECTIONPRESENTERTEST_H_
+#pragma once
 
 #include <cxxtest/TestSuite.h>
 #include <gmock/gmock.h>
@@ -365,5 +364,3 @@ private:
   std::unique_ptr<MockIndirectSpectrumSelectionModel> m_model;
   std::unique_ptr<IndirectSpectrumSelectionPresenterLegacy> m_presenter;
 };
-
-#endif

--- a/qt/scientific_interfaces/Indirect/test/IqtFitModelTest.h
+++ b/qt/scientific_interfaces/Indirect/test/IqtFitModelTest.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTIDQT_IQTFITMODELTEST_H_
-#define MANTIDQT_IQTFITMODELTEST_H_
+#pragma once
 
 #include <cxxtest/TestSuite.h>
 
@@ -63,5 +62,3 @@ private:
   std::unique_ptr<SetUpADSWithWorkspace> m_ads;
   std::unique_ptr<IqtFitModel> m_model;
 };
-
-#endif /* MANTIDQT_IQTFITMODELTEST_H_ */

--- a/qt/scientific_interfaces/Indirect/test/JumpFitDataPresenterTest.h
+++ b/qt/scientific_interfaces/Indirect/test/JumpFitDataPresenterTest.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTIDQT_JUMPFITDATAPRESENTERTEST_H_
-#define MANTIDQT_JUMPFITDATAPRESENTERTEST_H_
+#pragma once
 
 #include <cxxtest/TestSuite.h>
 #include <gmock/gmock.h>
@@ -217,4 +216,3 @@ private:
   std::unique_ptr<MockJumpFitModel> m_model;
   std::unique_ptr<JumpFitDataPresenter> m_presenter;
 };
-#endif

--- a/qt/scientific_interfaces/Indirect/test/JumpFitModelTest.h
+++ b/qt/scientific_interfaces/Indirect/test/JumpFitModelTest.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTIDQT_JUMPFITMODELTEST_H_
-#define MANTIDQT_JUMPFITMODELTEST_H_
+#pragma once
 
 #include <cxxtest/TestSuite.h>
 
@@ -317,5 +316,3 @@ private:
   std::unique_ptr<SetUpADSWithWorkspace> m_ads;
   std::unique_ptr<JumpFitModel> m_model;
 };
-
-#endif /* MANTIDQT_JUMPFITMODELTEST_H_ */

--- a/qt/scientific_interfaces/MultiDatasetFit/DllConfig.h
+++ b/qt/scientific_interfaces/MultiDatasetFit/DllConfig.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTIDQTMULTIDATASETFIT_DLLCONFIG_H_
-#define MANTIDQTMULTIDATASETFIT_DLLCONFIG_H_
+#pragma once
 
 #include "MantidKernel/System.h"
 
@@ -20,5 +19,3 @@
 #define MANTIDQT_MULTIDATASETFIT_DLL DLLImport
 #define EXTERN_MANTIDQT_MULTIDATASETFIT EXTERN_IMPORT
 #endif
-
-#endif // MANTIDQTMULTIDATASETFIT_DLLCONFIG_H_

--- a/qt/scientific_interfaces/MultiDatasetFit/MDFAddWorkspaceDialog.h
+++ b/qt/scientific_interfaces/MultiDatasetFit/MDFAddWorkspaceDialog.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MDFADDWORKSPACEDIALOG_H_
-#define MDFADDWORKSPACEDIALOG_H_
+#pragma once
 
 #include "ui_MDFAddWorkspaceDialog.h"
 #include <QDialog>
@@ -44,5 +43,3 @@ private:
 } // namespace MDF
 } // namespace CustomInterfaces
 } // namespace MantidQt
-
-#endif /*MDFADDWORKSPACEDIALOG_H_*/

--- a/qt/scientific_interfaces/MultiDatasetFit/MDFDataController.h
+++ b/qt/scientific_interfaces/MultiDatasetFit/MDFDataController.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MDFDATACONTROLLER_H_
-#define MDFDATACONTROLLER_H_
+#pragma once
 
 #include "MantidKernel/Statistics.h"
 #include <QObject>
@@ -85,5 +84,3 @@ private:
 } // namespace MDF
 } // namespace CustomInterfaces
 } // namespace MantidQt
-
-#endif /*MDFDATACONTROLLER_H_*/

--- a/qt/scientific_interfaces/MultiDatasetFit/MDFDatasetPlotData.h
+++ b/qt/scientific_interfaces/MultiDatasetFit/MDFDatasetPlotData.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MDFDATASETPLOTDATA_H_
-#define MDFDATASETPLOTDATA_H_
+#pragma once
 
 #include <QString>
 
@@ -66,5 +65,3 @@ private:
 } // namespace MDF
 } // namespace CustomInterfaces
 } // namespace MantidQt
-
-#endif /*MDFDATASETPLOTDATA_H_*/

--- a/qt/scientific_interfaces/MultiDatasetFit/MDFFunctionPlotData.h
+++ b/qt/scientific_interfaces/MultiDatasetFit/MDFFunctionPlotData.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MDFFUNCTIONPLOTDATA_H_
-#define MDFFUNCTIONPLOTDATA_H_
+#pragma once
 
 #include <QString>
 
@@ -60,5 +59,3 @@ private:
 } // namespace MDF
 } // namespace CustomInterfaces
 } // namespace MantidQt
-
-#endif /*MDFFUNCTIONPLOTDATA_H_*/

--- a/qt/scientific_interfaces/MultiDatasetFit/MDFPlotController.h
+++ b/qt/scientific_interfaces/MultiDatasetFit/MDFPlotController.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MDFPLOTCONTROLLER_H_
-#define MDFPLOTCONTROLLER_H_
+#pragma once
 
 #include <QMap>
 #include <QObject>
@@ -128,5 +127,3 @@ private:
 } // namespace MDF
 } // namespace CustomInterfaces
 } // namespace MantidQt
-
-#endif /*MDFPLOTCONTROLLER_H_*/

--- a/qt/scientific_interfaces/MultiDatasetFit/MultiDatasetFit.h
+++ b/qt/scientific_interfaces/MultiDatasetFit/MultiDatasetFit.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MULTIDATASETFIT_H_
-#define MULTIDATASETFIT_H_
+#pragma once
 
 #include "DllConfig.h"
 #include "MantidKernel/Statistics.h"
@@ -149,5 +148,3 @@ private:
 
 } // namespace CustomInterfaces
 } // namespace MantidQt
-
-#endif /*MULTIDATASETFITDIALOG_H_*/

--- a/qt/scientific_interfaces/MultiDatasetFit/PrecompiledHeader.h
+++ b/qt/scientific_interfaces/MultiDatasetFit/PrecompiledHeader.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTIDQT_CUSTOMINTERFACES_PRECOMPILEDHEADER_H_
-#define MANTIDQT_CUSTOMINTERFACES_PRECOMPILEDHEADER_H_
+#pragma once
 
 // Mantid
 #include "MantidAPI/Algorithm.h"
@@ -22,5 +21,3 @@
 #include <set>
 #include <string>
 #include <vector>
-
-#endif // MANTIDQT_CUSTOMINTERFACES_PRECOMPILEDHEADER_H_

--- a/qt/scientific_interfaces/Muon/ALCBaselineModellingModel.h
+++ b/qt/scientific_interfaces/Muon/ALCBaselineModellingModel.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_CUSTOMINTERFACES_ALCBASELINEMODELLINGMODEL_H_
-#define MANTID_CUSTOMINTERFACES_ALCBASELINEMODELLINGMODEL_H_
+#pragma once
 
 #include "DllConfig.h"
 #include "MantidKernel/System.h"
@@ -91,5 +90,3 @@ private:
 
 } // namespace CustomInterfaces
 } // namespace MantidQt
-
-#endif /* MANTID_CUSTOMINTERFACES_ALCBASELINEMODELLINGMODEL_H_ */

--- a/qt/scientific_interfaces/Muon/ALCBaselineModellingPresenter.h
+++ b/qt/scientific_interfaces/Muon/ALCBaselineModellingPresenter.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTIDQT_CUSTOMINTERFACES_ALCBASELINEMODELLINGPRESENTER_H_
-#define MANTIDQT_CUSTOMINTERFACES_ALCBASELINEMODELLINGPRESENTER_H_
+#pragma once
 
 #include "MantidKernel/System.h"
 
@@ -68,5 +67,3 @@ private:
 
 } // namespace CustomInterfaces
 } // namespace MantidQt
-
-#endif /* MANTIDQT_CUSTOMINTERFACES_ALCBASELINEMODELLINGPRESENTER_H_ */

--- a/qt/scientific_interfaces/Muon/ALCBaselineModellingView.h
+++ b/qt/scientific_interfaces/Muon/ALCBaselineModellingView.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTIDQT_CUSTOMINTERFACES_ALCBASELINEMODELLINGVIEW_H_
-#define MANTIDQT_CUSTOMINTERFACES_ALCBASELINEMODELLINGVIEW_H_
+#pragma once
 
 #include "MantidKernel/System.h"
 
@@ -84,5 +83,3 @@ private:
 
 } // namespace CustomInterfaces
 } // namespace MantidQt
-
-#endif /* MANTIDQT_CUSTOMINTERFACES_ALCBASELINEMODELLINGVIEW_H_ */

--- a/qt/scientific_interfaces/Muon/ALCDataLoadingPresenter.h
+++ b/qt/scientific_interfaces/Muon/ALCDataLoadingPresenter.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTIDQT_CUSTOMINTERFACES_ALCDATALOADINGPRESENTER_H_
-#define MANTIDQT_CUSTOMINTERFACES_ALCDATALOADINGPRESENTER_H_
+#pragma once
 
 #include "DllConfig.h"
 #include "IALCDataLoadingView.h"
@@ -105,5 +104,3 @@ private:
 
 } // namespace CustomInterfaces
 } // namespace MantidQt
-
-#endif /* MANTIDQT_CUSTOMINTERFACES_ALCDATALOADINGPRESENTER_H_ */

--- a/qt/scientific_interfaces/Muon/ALCDataLoadingView.h
+++ b/qt/scientific_interfaces/Muon/ALCDataLoadingView.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTIDQT_CUSTOMINTERFACES_ALCDATALOADINGVIEW_H_
-#define MANTIDQT_CUSTOMINTERFACES_ALCDATALOADINGVIEW_H_
+#pragma once
 
 #include "MantidKernel/System.h"
 
@@ -98,5 +97,3 @@ private:
 
 } // namespace CustomInterfaces
 } // namespace MantidQt
-
-#endif /* MANTIDQT_CUSTOMINTERFACES_ALCDATALOADINGVIEW_H_ */

--- a/qt/scientific_interfaces/Muon/ALCInterface.h
+++ b/qt/scientific_interfaces/Muon/ALCInterface.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTIDQT_CUSTOMINTERFACES_ALCINTERFACE_H_
-#define MANTIDQT_CUSTOMINTERFACES_ALCINTERFACE_H_
+#pragma once
 
 #include "MantidKernel/System.h"
 
@@ -81,5 +80,3 @@ private:
 
 } // namespace CustomInterfaces
 } // namespace MantidQt
-
-#endif /* MANTIDQT_CUSTOMINTERFACES_ALCINTERFACE_H_ */

--- a/qt/scientific_interfaces/Muon/ALCLatestFileFinder.h
+++ b/qt/scientific_interfaces/Muon/ALCLatestFileFinder.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_CUSTOMINTERFACES_ALCLATESTFILEFINDER_H_
-#define MANTID_CUSTOMINTERFACES_ALCLATESTFILEFINDER_H_
+#pragma once
 
 #include "DllConfig.h"
 #include <string>
@@ -35,5 +34,3 @@ private:
 
 } // namespace CustomInterfaces
 } // namespace MantidQt
-
-#endif /* MANTID_CUSTOMINTERFACES_ALCLATESTFILEFINDER_H_ */

--- a/qt/scientific_interfaces/Muon/ALCPeakFittingModel.h
+++ b/qt/scientific_interfaces/Muon/ALCPeakFittingModel.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_CUSTOMINTERFACES_ALCPEAKFITTINGMODEL_H_
-#define MANTID_CUSTOMINTERFACES_ALCPEAKFITTINGMODEL_H_
+#pragma once
 
 #include "MantidKernel/System.h"
 
@@ -64,5 +63,3 @@ private:
 
 } // namespace CustomInterfaces
 } // namespace MantidQt
-
-#endif /* MANTID_CUSTOMINTERFACES_ALCPEAKFITTINGMODEL_H_ */

--- a/qt/scientific_interfaces/Muon/ALCPeakFittingPresenter.h
+++ b/qt/scientific_interfaces/Muon/ALCPeakFittingPresenter.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTIDQT_CUSTOMINTERFACES_ALCPEAKFITTINGPRESENTER_H_
-#define MANTIDQT_CUSTOMINTERFACES_ALCPEAKFITTINGPRESENTER_H_
+#pragma once
 
 #include "MantidKernel/System.h"
 
@@ -66,5 +65,3 @@ private:
 
 } // namespace CustomInterfaces
 } // namespace MantidQt
-
-#endif /* MANTIDQT_CUSTOMINTERFACES_ALCPEAKFITTINGPRESENTER_H_ */

--- a/qt/scientific_interfaces/Muon/ALCPeakFittingView.h
+++ b/qt/scientific_interfaces/Muon/ALCPeakFittingView.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTIDQT_CUSTOMINTERFACES_ALCPEAKFITTINGVIEW_H_
-#define MANTIDQT_CUSTOMINTERFACES_ALCPEAKFITTINGVIEW_H_
+#pragma once
 
 #include "MantidKernel/System.h"
 
@@ -69,5 +68,3 @@ private:
 
 } // namespace CustomInterfaces
 } // namespace MantidQt
-
-#endif /* MANTIDQT_CUSTOMINTERFACES_ALCPEAKFITTINGVIEW_H_ */

--- a/qt/scientific_interfaces/Muon/DllConfig.h
+++ b/qt/scientific_interfaces/Muon/DllConfig.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTIDQTCUSTOMINTERFACES_DLLCONFIG_H_
-#define MANTIDQTCUSTOMINTERFACES_DLLCONFIG_H_
+#pragma once
 
 #include "MantidKernel/System.h"
 
@@ -20,5 +19,3 @@
 #define MANTIDQT_MUONINTERFACE_DLL DLLImport
 #define EXTERN_MANTIDQT_MUONINTERFACE EXTERN_IMPORT
 #endif
-
-#endif // MANTIDQTCUSTOMINTERFACES_DLLCONFIG_H_

--- a/qt/scientific_interfaces/Muon/IALCBaselineModellingModel.h
+++ b/qt/scientific_interfaces/Muon/IALCBaselineModellingModel.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_CUSTOMINTERFACES_IALCBASELINEMODELLINGMODEL_H_
-#define MANTID_CUSTOMINTERFACES_IALCBASELINEMODELLINGMODEL_H_
+#pragma once
 
 #include "MantidKernel/System.h"
 
@@ -71,5 +70,3 @@ signals:
 
 } // namespace CustomInterfaces
 } // namespace MantidQt
-
-#endif /* MANTID_CUSTOMINTERFACES_IALCBASELINEMODELLINGMODEL_H_ */

--- a/qt/scientific_interfaces/Muon/IALCBaselineModellingView.h
+++ b/qt/scientific_interfaces/Muon/IALCBaselineModellingView.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTIDQT_CUSTOMINTERFACES_IALCBASELINEMODELLINGVIEW_H_
-#define MANTIDQT_CUSTOMINTERFACES_IALCBASELINEMODELLINGVIEW_H_
+#pragma once
 
 #include "MantidKernel/System.h"
 
@@ -154,5 +153,3 @@ signals:
 
 } // namespace CustomInterfaces
 } // namespace MantidQt
-
-#endif /* MANTIDQT_CUSTOMINTERFACES_IALCBASELINEMODELLINGVIEW_H_ */

--- a/qt/scientific_interfaces/Muon/IALCDataLoadingView.h
+++ b/qt/scientific_interfaces/Muon/IALCDataLoadingView.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTIDQT_CUSTOMINTERFACES_IALCDATALOADINGVIEW_H_
-#define MANTIDQT_CUSTOMINTERFACES_IALCDATALOADINGVIEW_H_
+#pragma once
 
 #include "MantidAPI/MatrixWorkspace_fwd.h"
 
@@ -141,5 +140,3 @@ signals:
 
 } // namespace CustomInterfaces
 } // namespace MantidQt
-
-#endif /* MANTIDQT_CUSTOMINTERFACES_IALCDATALOADINGVIEW_H_ */

--- a/qt/scientific_interfaces/Muon/IALCPeakFittingModel.h
+++ b/qt/scientific_interfaces/Muon/IALCPeakFittingModel.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_CUSTOMINTERFACES_IALCPEAKFITTINGMODEL_H_
-#define MANTID_CUSTOMINTERFACES_IALCPEAKFITTINGMODEL_H_
+#pragma once
 
 #include "DllConfig.h"
 #include "MantidKernel/System.h"
@@ -63,5 +62,3 @@ signals:
 
 } // namespace CustomInterfaces
 } // namespace MantidQt
-
-#endif /* MANTID_CUSTOMINTERFACES_IALCPEAKFITTINGMODEL_H_ */

--- a/qt/scientific_interfaces/Muon/IALCPeakFittingView.h
+++ b/qt/scientific_interfaces/Muon/IALCPeakFittingView.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTIDQT_CUSTOMINTERFACES_IALCPEAKFITTINGVIEW_H_
-#define MANTIDQT_CUSTOMINTERFACES_IALCPEAKFITTINGVIEW_H_
+#pragma once
 
 #include "MantidAPI/IPeakFunction.h"
 #include "MantidAPI/MatrixWorkspace_fwd.h"
@@ -117,5 +116,3 @@ signals:
 
 } // namespace CustomInterfaces
 } // namespace MantidQt
-
-#endif /* MANTIDQT_CUSTOMINTERFACES_IALCPEAKFITTINGVIEW_H_ */

--- a/qt/scientific_interfaces/Muon/IO_MuonGrouping.h
+++ b/qt/scientific_interfaces/Muon/IO_MuonGrouping.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTIDQTCUSTOMINTERFACES_MUONANALYSIS_IO_GROUPING_H_
-#define MANTIDQTCUSTOMINTERFACES_MUONANALYSIS_IO_GROUPING_H_
+#pragma once
 
 //----------------------
 // Includes
@@ -57,5 +56,3 @@ private:
 } // namespace Muon
 } // namespace CustomInterfaces
 } // namespace MantidQt
-
-#endif // MANTIDQTCUSTOMINTERFACES_MUONANALYSIS_IO_GROUPING_H_

--- a/qt/scientific_interfaces/Muon/MuonAnalysis.h
+++ b/qt/scientific_interfaces/Muon/MuonAnalysis.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTIDQTCUSTOMINTERFACES_MUONANALYSIS_H_
-#define MANTIDQTCUSTOMINTERFACES_MUONANALYSIS_H_
+#pragma once
 
 //----------------------
 // Includes
@@ -572,5 +571,3 @@ private:
 };
 } // namespace CustomInterfaces
 } // namespace MantidQt
-
-#endif // MANTIDQTCUSTOMINTERFACES_MUONANALYSIS_H_

--- a/qt/scientific_interfaces/Muon/MuonAnalysisDataLoader.h
+++ b/qt/scientific_interfaces/Muon/MuonAnalysisDataLoader.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTIDQT_CUSTOMINTERFACES_MUONANALYSISDATALOADER_H_
-#define MANTIDQT_CUSTOMINTERFACES_MUONANALYSISDATALOADER_H_
+#pragma once
 
 #include "DllConfig.h"
 #include "MantidAPI/GroupingLoader.h"
@@ -119,5 +118,3 @@ private:
 
 } // namespace CustomInterfaces
 } // namespace MantidQt
-
-#endif /* MANTIDQt_CUSTOMINTERFACES_MUONANALYSISDATALOADER_H_ */

--- a/qt/scientific_interfaces/Muon/MuonAnalysisFitDataPresenter.h
+++ b/qt/scientific_interfaces/Muon/MuonAnalysisFitDataPresenter.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_CUSTOMINTERFACES_MUONANALYSISFITDATAPRESENTER_H_
-#define MANTID_CUSTOMINTERFACES_MUONANALYSISFITDATAPRESENTER_H_
+#pragma once
 
 #include "DllConfig.h"
 #include "MantidQtWidgets/Common/IMuonFitDataSelector.h"
@@ -185,5 +184,3 @@ private:
 };
 } // namespace CustomInterfaces
 } // namespace MantidQt
-
-#endif /* MANTID_CUSTOMINTERFACES_MUONANALYSISFITDATAPRESENTER_H_ */

--- a/qt/scientific_interfaces/Muon/MuonAnalysisFitDataTab.h
+++ b/qt/scientific_interfaces/Muon/MuonAnalysisFitDataTab.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTIDQTCUSTOMINTERFACES_MUONANALYSISFITDATATAB_H_
-#define MANTIDQTCUSTOMINTERFACES_MUONANALYSISFITDATATAB_H_
+#pragma once
 
 //----------------------
 // Includes
@@ -60,5 +59,3 @@ private slots:
 } // namespace Muon
 } // namespace CustomInterfaces
 } // namespace MantidQt
-
-#endif // MANTIDQTCUSTOMINTERFACES_MUONANALYSISFITDATATAB_H_

--- a/qt/scientific_interfaces/Muon/MuonAnalysisFitFunctionPresenter.h
+++ b/qt/scientific_interfaces/Muon/MuonAnalysisFitFunctionPresenter.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_CUSTOMINTERFACES_MUONANALYSISFITFUNCTIONPRESENTER_H_
-#define MANTID_CUSTOMINTERFACES_MUONANALYSISFITFUNCTIONPRESENTER_H_
+#pragma once
 
 #include "DllConfig.h"
 #include "MantidQtWidgets/Common/IFunctionBrowser.h"
@@ -69,5 +68,3 @@ private:
 
 } // namespace CustomInterfaces
 } // namespace MantidQt
-
-#endif /* MANTID_CUSTOMINTERFACES_MUONANALYSISFITFUNCTIONPRESENTER_H_ */

--- a/qt/scientific_interfaces/Muon/MuonAnalysisHelper.h
+++ b/qt/scientific_interfaces/Muon/MuonAnalysisHelper.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTIDQT_CUSTOMINTERFACES_MUONANALYSISHELPER_H_
-#define MANTIDQT_CUSTOMINTERFACES_MUONANALYSISHELPER_H_
+#pragma once
 
 #include "DllConfig.h"
 #include "MantidAPI/ITableWorkspace_fwd.h"
@@ -223,5 +222,3 @@ public:
 } // namespace MuonAnalysisHelper
 } // namespace CustomInterfaces
 } // namespace MantidQt
-
-#endif /* MANTIDQT_CUSTOMINTERFACES_MUONANALYSISHELPER_H_ */

--- a/qt/scientific_interfaces/Muon/MuonAnalysisOptionTab.h
+++ b/qt/scientific_interfaces/Muon/MuonAnalysisOptionTab.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTIDQTCUSTOMINTERFACES_MUONANALYSISOPTIONTAB_H_
-#define MANTIDQTCUSTOMINTERFACES_MUONANALYSISOPTIONTAB_H_
+#pragma once
 
 //----------------------
 // Includes
@@ -114,5 +113,3 @@ private slots:
 } // namespace Muon
 } // namespace CustomInterfaces
 } // namespace MantidQt
-
-#endif // MANTIDQTCUSTOMINTERFACES_MUONANALYSISOPTIONTAB_H_

--- a/qt/scientific_interfaces/Muon/MuonAnalysisResultTableCreator.h
+++ b/qt/scientific_interfaces/Muon/MuonAnalysisResultTableCreator.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTIDQT_CUSTOMINTERFACES_MUONANALYSISRESULTTABLECREATOR_H_
-#define MANTIDQT_CUSTOMINTERFACES_MUONANALYSISRESULTTABLECREATOR_H_
+#pragma once
 
 #include "DllConfig.h"
 #include "MantidAPI/ITableWorkspace_fwd.h"
@@ -108,5 +107,3 @@ private:
 
 } // namespace CustomInterfaces
 } // namespace MantidQt
-
-#endif /* MANTIDQT_CUSTOMINTERFACES_MUONANALYSISRESULTTABLECREATOR_H_ */

--- a/qt/scientific_interfaces/Muon/MuonAnalysisResultTableTab.h
+++ b/qt/scientific_interfaces/Muon/MuonAnalysisResultTableTab.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTIDQTCUSTOMINTERFACES_MUONANALYSISRESULTTABLETAB_H_
-#define MANTIDQTCUSTOMINTERFACES_MUONANALYSISRESULTTABLETAB_H_
+#pragma once
 
 //----------------------
 // Includes
@@ -135,5 +134,3 @@ private:
 } // namespace Muon
 } // namespace CustomInterfaces
 } // namespace MantidQt
-
-#endif // MANTIDQTCUSTOMINTERFACES_MUONANALYSISRESULTTABLETAB_H_

--- a/qt/scientific_interfaces/Muon/MuonSequentialFitDialog.h
+++ b/qt/scientific_interfaces/Muon/MuonSequentialFitDialog.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_CUSTOMINTERFACES_MUONSEQUENTIALFITDIALOG_H_
-#define MANTID_CUSTOMINTERFACES_MUONSEQUENTIALFITDIALOG_H_
+#pragma once
 
 #include "ui_MuonSequentialFitDialog.h"
 
@@ -124,5 +123,3 @@ private slots:
 
 } // namespace CustomInterfaces
 } // namespace MantidQt
-
-#endif /* MANTID_CUSTOMINTERFACES_MUONSEQUENTIALFITDIALOG_H_ */

--- a/qt/scientific_interfaces/Muon/PrecompiledHeader.h
+++ b/qt/scientific_interfaces/Muon/PrecompiledHeader.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTIDQT_MUON_PRECOMPILEDHEADER_H_
-#define MANTIDQT_MUON_PRECOMPILEDHEADER_H_
+#pragma once
 
 // Mantid
 #include "MantidAPI/Algorithm.h"
@@ -22,5 +21,3 @@
 #include <set>
 #include <string>
 #include <vector>
-
-#endif // MANTIDQT_MUON_PRECOMPILEDHEADER_H_

--- a/qt/scientific_interfaces/test/ALCBaselineModellingModelTest.h
+++ b/qt/scientific_interfaces/test/ALCBaselineModellingModelTest.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_CUSTOMINTERFACES_ALCBASELINEMODELLINGMODELTEST_H_
-#define MANTID_CUSTOMINTERFACES_ALCBASELINEMODELLINGMODELTEST_H_
+#pragma once
 
 #include <cxxtest/TestSuite.h>
 
@@ -149,5 +148,3 @@ public:
     TS_ASSERT_THROWS_NOTHING(m_model->correctedData());
   }
 };
-
-#endif /* MANTID_CUSTOMINTERFACES_ALCBASELINEMODELLINGMODELTEST_H_ */

--- a/qt/scientific_interfaces/test/ALCBaselineModellingPresenterTest.h
+++ b/qt/scientific_interfaces/test/ALCBaselineModellingPresenterTest.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTIDQT_CUSTOMINTERFACES_ALCBASELINEMODELLINGTEST_H_
-#define MANTIDQT_CUSTOMINTERFACES_ALCBASELINEMODELLINGTEST_H_
+#pragma once
 
 #include <cxxtest/TestSuite.h>
 #include <gmock/gmock.h>
@@ -365,5 +364,3 @@ public:
     m_view->help();
   }
 };
-
-#endif /* MANTIDQT_CUSTOMINTERFACES_ALCBASELINEMODELLINGTEST_H_ */

--- a/qt/scientific_interfaces/test/ALCDataLoadingPresenterTest.h
+++ b/qt/scientific_interfaces/test/ALCDataLoadingPresenterTest.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_CUSTOMINTERFACES_ALCDATALOADINGTEST_H_
-#define MANTID_CUSTOMINTERFACES_ALCDATALOADINGTEST_H_
+#pragma once
 
 #include "MantidAPI/FrameworkManager.h"
 #include "MantidAPI/MatrixWorkspace.h"
@@ -352,5 +351,3 @@ public:
     m_view->help();
   }
 };
-
-#endif /* MANTID_CUSTOMINTERFACES_ALCDATALOADINGTEST_H_ */

--- a/qt/scientific_interfaces/test/ALCLatestFileFinderTest.h
+++ b/qt/scientific_interfaces/test/ALCLatestFileFinderTest.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_CUSTOMINTERFACES_ALCLATESTFILEFINDERTEST_H_
-#define MANTID_CUSTOMINTERFACES_ALCLATESTFILEFINDERTEST_H_
+#pragma once
 
 #include <cxxtest/TestSuite.h>
 
@@ -270,5 +269,3 @@ private:
   std::vector<TestFile> m_files;
   std::string m_mostRecent;
 };
-
-#endif /* MANTID_CUSTOMINTERFACES_ALCLATESTFILEFINDERTEST_H_ */

--- a/qt/scientific_interfaces/test/ALCPeakFittingModelTest.h
+++ b/qt/scientific_interfaces/test/ALCPeakFittingModelTest.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_CUSTOMINTERFACES_ALCPEAKFITTINGMODELTEST_H_
-#define MANTID_CUSTOMINTERFACES_ALCPEAKFITTINGMODELTEST_H_
+#pragma once
 
 #include <cxxtest/TestSuite.h>
 
@@ -102,5 +101,3 @@ public:
     TS_ASSERT_THROWS_NOTHING(m_model->exportWorkspace());
   }
 };
-
-#endif /* MANTID_CUSTOMINTERFACES_ALCPEAKFITTINGMODELTEST_H_ */

--- a/qt/scientific_interfaces/test/ALCPeakFittingPresenterTest.h
+++ b/qt/scientific_interfaces/test/ALCPeakFittingPresenterTest.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTIDQT_CUSTOMINTERFACES_ALCPEAKFITTINGTEST_H_
-#define MANTIDQT_CUSTOMINTERFACES_ALCPEAKFITTINGTEST_H_
+#pragma once
 
 #include <cxxtest/TestSuite.h>
 #include <gmock/gmock.h>
@@ -373,4 +372,3 @@ public:
   }
 };
 GNU_DIAG_ON_SUGGEST_OVERRIDE
-#endif /* MANTIDQT_CUSTOMINTERFACES_ALCPEAKFITTINGTEST_H_ */

--- a/qt/scientific_interfaces/test/EnggDiffFittingModelMock.h
+++ b/qt/scientific_interfaces/test/EnggDiffFittingModelMock.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_CUSTOM_INTERFACES_ENGGDIFFFITTINGMODELMOCK_H
-#define MANTID_CUSTOM_INTERFACES_ENGGDIFFFITTINGMODELMOCK_H
+#pragma once
 
 #include "IEnggDiffractionCalibration.h"
 #include "MantidAPI/ITableWorkspace.h"
@@ -68,5 +67,3 @@ public:
 };
 
 GNU_DIAG_ON_SUGGEST_OVERRIDE
-
-#endif // MANTID_CUSTOM_INTERFACES_ENGGDIFFFITTINGMODELMOCK_H

--- a/qt/scientific_interfaces/test/EnggDiffFittingModelTest.h
+++ b/qt/scientific_interfaces/test/EnggDiffFittingModelTest.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_CUSTOMINTERFACES_ENGGDIFFFITTINGMODELTEST_H_
-#define MANTID_CUSTOMINTERFACES_ENGGDIFFFITTINGMODELTEST_H_
+#pragma once
 
 #include "MantidAPI/FrameworkManager.h"
 #include "MantidAPI/ITableWorkspace.h"
@@ -310,5 +309,3 @@ const std::string EnggDiffFittingModelTest::FOCUSED_WS_FILENAME =
 
 const RunLabel EnggDiffFittingModelTest::FOCUSED_WS_RUN_LABEL =
     RunLabel("277208", 2);
-
-#endif

--- a/qt/scientific_interfaces/test/EnggDiffFittingPresenterTest.h
+++ b/qt/scientific_interfaces/test/EnggDiffFittingPresenterTest.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_CUSTOMINTERFACES_ENGGDIFFFITTINGPRESENTERTEST_H
-#define MANTID_CUSTOMINTERFACES_ENGGDIFFFITTINGPRESENTERTEST_H
+#pragma once
 
 #include "../EnggDiffraction/EnggDiffFittingPresenter.h"
 #include "MantidAPI/FrameworkManager.h"
@@ -760,5 +759,3 @@ const std::string EnggDiffFittingPresenterTest::g_focusedFittingRunNo =
     "241391-241394";
 
 const std::string EnggDiffFittingPresenterTest::EMPTY = "";
-
-#endif // MANTID_CUSTOMINTERFACES_ENGGDIFFFITTINGPRESENTERTEST_H

--- a/qt/scientific_interfaces/test/EnggDiffFittingViewMock.h
+++ b/qt/scientific_interfaces/test/EnggDiffFittingViewMock.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_CUSTOMINTERFACES_ENGGDIFFFITTINGVIEWMOCK_H
-#define MANTID_CUSTOMINTERFACES_ENGGDIFFFITTINGVIEWMOCK_H
+#pragma once
 
 #include "../EnggDiffraction/IEnggDiffFittingView.h"
 #include "MantidKernel/WarningSuppressions.h"
@@ -168,5 +167,3 @@ public:
 };
 
 GNU_DIAG_ON_SUGGEST_OVERRIDE
-
-#endif // MANTID_CUSTOMINTERFACES_ENGGDIFFFITTINGVIEWMOCK_H

--- a/qt/scientific_interfaces/test/EnggDiffGSASFittingModelMock.h
+++ b/qt/scientific_interfaces/test/EnggDiffGSASFittingModelMock.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_CUSTOM_INTERFACES_ENGGDIFFFITTINGMODELMOCK_H_
-#define MANTID_CUSTOM_INTERFACES_ENGGDIFFFITTINGMODELMOCK_H_
+#pragma once
 
 #include "../EnggDiffraction/IEnggDiffGSASFittingModel.h"
 #include "MantidKernel/WarningSuppressions.h"
@@ -51,5 +50,3 @@ public:
 };
 
 GNU_DIAG_ON_SUGGEST_OVERRIDE
-
-#endif // MANTID_CUSTOM_INTERFACES_ENGGDIFFFITTINGMODELMOCK_H_

--- a/qt/scientific_interfaces/test/EnggDiffGSASFittingModelTest.h
+++ b/qt/scientific_interfaces/test/EnggDiffGSASFittingModelTest.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTIDQT_CUSTOMINTERFACES_ENGGDIFFGSASFITTINGMODELTEST_H_
-#define MANTIDQT_CUSTOMINTERFACES_ENGGDIFFGSASFITTINGMODELTEST_H_
+#pragma once
 
 #include "../EnggDiffraction/EnggDiffGSASFittingModel.h"
 
@@ -286,5 +285,3 @@ public:
     API::AnalysisDataService::Instance().clear();
   }
 };
-
-#endif // MANTIDQT_CUSTOMINTERFACES_ENGGDIFFGSASFITTINGMODELTEST_H_

--- a/qt/scientific_interfaces/test/EnggDiffGSASFittingPresenterTest.h
+++ b/qt/scientific_interfaces/test/EnggDiffGSASFittingPresenterTest.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_CUSTOM_INTERFACES_ENGGDIFFGSASFITTINGPRESENTERTEST_H_
-#define MANTID_CUSTOM_INTERFACES_ENGGDIFFGSASFITTINGPRESENTERTEST_H_
+#pragma once
 
 #include "../EnggDiffraction/EnggDiffGSASFittingPresenter.h"
 #include "EnggDiffGSASFittingModelMock.h"
@@ -432,5 +431,3 @@ private:
         .WillOnce(Return(params.refineGamma));
   }
 };
-
-#endif // MANTID_CUSTOM_INTERFACES_ENGGDIFFGSASFITTINGPRESENTERTEST_H_

--- a/qt/scientific_interfaces/test/EnggDiffGSASFittingViewMock.h
+++ b/qt/scientific_interfaces/test/EnggDiffGSASFittingViewMock.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_CUSTOMINTERFACES_ENGGDIFFGSASFITTINGVIEWMOCK_H_
-#define MANTID_CUSTOMINTERFACES_ENGGDIFFGSASFITTINGVIEWMOCK_H_
+#pragma once
 
 #include "../EnggDiffraction/IEnggDiffFittingView.h"
 #include "MantidKernel/WarningSuppressions.h"
@@ -79,5 +78,3 @@ public:
 };
 
 GNU_DIAG_ON_SUGGEST_OVERRIDE
-
-#endif // MANTID_CUSTOMINTERFACES_ENGGDIFFGSASFITTINGVIEWMOCK_H_

--- a/qt/scientific_interfaces/test/EnggDiffMultiRunFittingWidgetAdderFake.h
+++ b/qt/scientific_interfaces/test/EnggDiffMultiRunFittingWidgetAdderFake.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTIDQT_CUSTOMINTERFACES_ENGGDIFFMULTIRUNFITTINGWIDGETADDER_H_
-#define MANTIDQT_CUSTOMINTERFACES_ENGGDIFFMULTIRUNFITTINGWIDGETADDER_H_
+#pragma once
 
 #include "../EnggDiffraction/IEnggDiffMultiRunFittingWidgetAdder.h"
 
@@ -25,5 +24,3 @@ operator()(IEnggDiffMultiRunFittingWidgetOwner &owner) {
 
 } // namespace CustomInterfaces
 } // namespace MantidQt
-
-#endif // MANTIDQT_CUSTOMINTERFACES_ENGGDIFFMULTIRUNFITTINGWIDGETADDER_H_

--- a/qt/scientific_interfaces/test/EnggDiffMultiRunFittingWidgetModelMock.h
+++ b/qt/scientific_interfaces/test/EnggDiffMultiRunFittingWidgetModelMock.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTIDQT_CUSTOMINTERFACES_ENGGDIFFMULTIRUNFITTINGWIDGETMODELMOCK_H_
-#define MANTIDQT_CUSTOMINTERFACES_ENGGDIFFMULTIRUNFITTINGWIDGETMODELMOCK_H_
+#pragma once
 
 #include "../EnggDiffraction/IEnggDiffMultiRunFittingWidgetModel.h"
 #include "MantidKernel/WarningSuppressions.h"
@@ -43,5 +42,3 @@ public:
 };
 
 GNU_DIAG_ON_SUGGEST_OVERRIDE
-
-#endif // MANTIDQT_CUSTOMINTERFACES_ENGGDIFFMULTIRUNFITTINGWIDGETMODELMOCK_H_

--- a/qt/scientific_interfaces/test/EnggDiffMultiRunFittingWidgetModelTest.h
+++ b/qt/scientific_interfaces/test/EnggDiffMultiRunFittingWidgetModelTest.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTIDQT_CUSTOMINTERFACES_ENGGDIFFMULTIRUNFITTINGWIDGETMODELTEST_H_
-#define MANTIDQT_CUSTOMINTERFACES_ENGGDIFFMULTIRUNFITTINGWIDGETMODELTEST_H_
+#pragma once
 
 #include "../EnggDiffraction/EnggDiffMultiRunFittingWidgetModel.h"
 
@@ -101,5 +100,3 @@ public:
     TS_ASSERT_THROWS_ANYTHING(model.removeRun(RunLabel("456", 2)));
   }
 };
-
-#endif // MANTIDQT_CUSTOMINTERFACES_ENGGDIFFMULTIRUNFITTINGWIDGETMODELTEST_H_

--- a/qt/scientific_interfaces/test/EnggDiffMultiRunFittingWidgetPresenterMock.h
+++ b/qt/scientific_interfaces/test/EnggDiffMultiRunFittingWidgetPresenterMock.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTIDQT_CUSTOMINTERFACES_ENGGDIFFMULTIRUNFITTINGWIDGETPRESENTERMOCK_H_
-#define MANTIDQT_CUSTOMINTERFACES_ENGGDIFFMULTIRUNFITTINGWIDGETPRESENTERMOCK_H_
+#pragma once
 
 #include "../EnggDiffraction/IEnggDiffMultiRunFittingWidgetPresenter.h"
 #include "EnggDiffMultiRunFittingWidgetAdderFake.h"
@@ -55,5 +54,3 @@ MockEnggDiffMultiRunFittingWidgetPresenter::getWidgetAdder() const {
 }
 
 GNU_DIAG_ON_SUGGEST_OVERRIDE
-
-#endif // MANTIDQT_CUSTOMINTERFACES_ENGGDIFFMULTIRUNFITTINGWIDGETPRESENTERMOCK_H_

--- a/qt/scientific_interfaces/test/EnggDiffMultiRunFittingWidgetPresenterTest.h
+++ b/qt/scientific_interfaces/test/EnggDiffMultiRunFittingWidgetPresenterTest.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTIDQT_CUSTOMINTERFACES_ENGGDIFFMULTIRUNFITTINGWIDGETPRESENTERTEST_H_
-#define MANTIDQT_CUSTOMINTERFACES_ENGGDIFFMULTIRUNFITTINGWIDGETPRESENTERTEST_H_
+#pragma once
 
 #include "../EnggDiffraction/EnggDiffMultiRunFittingWidgetPresenter.h"
 #include "EnggDiffMultiRunFittingWidgetModelMock.h"
@@ -392,5 +391,3 @@ private:
     }
   }
 };
-
-#endif // MANTIDQT_CUSTOMINTERFACES_ENGGDIFFMULTIRUNFITTINGWIDGETPRESENTERTEST_H_

--- a/qt/scientific_interfaces/test/EnggDiffMultiRunFittingWidgetViewMock.h
+++ b/qt/scientific_interfaces/test/EnggDiffMultiRunFittingWidgetViewMock.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTIDQT_CUSTOMINTERFACES_ENGGDIFFMULTIRUNFITTINGWIDGETVIEWMOCK_H_
-#define MANTIDQT_CUSTOMINTERFACES_ENGGDIFFMULTIRUNFITTINGWIDGETVIEWMOCK_H_
+#pragma once
 
 #include "../EnggDiffraction/IEnggDiffMultiRunFittingWidgetView.h"
 #include "MantidKernel/WarningSuppressions.h"
@@ -60,5 +59,3 @@ public:
 };
 
 GNU_DIAG_ON_SUGGEST_OVERRIDE
-
-#endif // MANTIDQT_CUSTOMINTERFACES_ENGGDIFFMULTIRUNFITTINGWIDGETVIEWMOCK_H_

--- a/qt/scientific_interfaces/test/EnggDiffractionParamMock.h
+++ b/qt/scientific_interfaces/test/EnggDiffractionParamMock.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTIDQTCUSTOMINTERFACES_ENGGDIFFRACTION_IENGGDIFFRACTIONPARAMMOCK_H_
-#define MANTIDQTCUSTOMINTERFACES_ENGGDIFFRACTION_IENGGDIFFRACTIONPARAMMOCK_H_
+#pragma once
 
 #include "../EnggDiffraction/IEnggDiffractionParam.h"
 #include "MantidKernel/WarningSuppressions.h"
@@ -28,5 +27,3 @@ public:
 };
 
 GNU_DIAG_ON_SUGGEST_OVERRIDE
-
-#endif // MANTIDQTCUSTOMINTERFACES_ENGGDIFFRACTION_IENGGDIFFRACTIONPARAMMOCK_H_

--- a/qt/scientific_interfaces/test/EnggDiffractionPresenterTest.h
+++ b/qt/scientific_interfaces/test/EnggDiffractionPresenterTest.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_CUSTOMINTERFACES_ENGGDIFFRACTIONPRESENTERTEST_H
-#define MANTID_CUSTOMINTERFACES_ENGGDIFFRACTIONPRESENTERTEST_H
+#pragma once
 
 #include "../EnggDiffraction/EnggDiffractionPresenter.h"
 #include "MantidAPI/FileFinder.h"
@@ -1512,5 +1511,3 @@ const std::string EnggDiffractionPresenterTest::g_eventModeRunNo =
     "ENGINX00228061"; // could also be given as "ENGINX228061"
 
 const std::string EnggDiffractionPresenterTest::g_validRunNo = "228061";
-
-#endif // MANTID_CUSTOMINTERFACES_ENGGDIFFRACTIONPRESENTERTEST_H

--- a/qt/scientific_interfaces/test/EnggDiffractionViewMock.h
+++ b/qt/scientific_interfaces/test/EnggDiffractionViewMock.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_CUSTOMINTERFACES_ENGGDIFFRACTIONVIEWMOCK_H
-#define MANTID_CUSTOMINTERFACES_ENGGDIFFRACTIONVIEWMOCK_H
+#pragma once
 
 #include "../EnggDiffraction/IEnggDiffractionView.h"
 #include "MantidKernel/WarningSuppressions.h"
@@ -191,5 +190,3 @@ public:
   MOCK_METHOD1(updateTabsInstrument, void(const std::string &newInstrument));
 };
 GNU_DIAG_ON_SUGGEST_OVERRIDE
-
-#endif // MANTID_CUSTOMINTERFACES_ENGGDIFFRACTIONVIEWMOCK_H

--- a/qt/scientific_interfaces/test/EnggVanadiumCorrectionsModelTest.h
+++ b/qt/scientific_interfaces/test/EnggVanadiumCorrectionsModelTest.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTIDQT_CUSTOMINTERFACES_ENGGVANADIUMCORRECTIONSMODELTEST_H_
-#define MANTIDQT_CUSTOMINTERFACES_ENGGVANADIUMCORRECTIONSMODELTEST_H_
+#pragma once
 
 #include "../EnggDiffraction/EnggVanadiumCorrectionsModel.h"
 
@@ -205,5 +204,3 @@ const std::string EnggVanadiumCorrectionsModelTest::CURRENT_INSTRUMENT =
 
 const std::string EnggVanadiumCorrectionsModelTest::INPUT_DIR_NAME(
     "EnggVanadiumCorrectionsModelTestData");
-
-#endif // MANTIDQT_CUSTOMINTERFACES_ENGGVANADIUMCORRECTIONSMODELTEST_H_

--- a/qt/scientific_interfaces/test/IO_MuonGroupingTest.h
+++ b/qt/scientific_interfaces/test/IO_MuonGroupingTest.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_CUSTOMINTERFACES_IO_MUONGROUPINGTEST_H_
-#define MANTID_CUSTOMINTERFACES_IO_MUONGROUPINGTEST_H_
+#pragma once
 
 #include <numeric>
 
@@ -111,5 +110,3 @@ private:
     return result;
   }
 };
-
-#endif /* MANTID_CUSTOMINTERFACES_IO_MUONGROUPINGTEST_H_ */

--- a/qt/scientific_interfaces/test/ISISReflectometry/Batch/BatchJobRunnerProcessingTest.h
+++ b/qt/scientific_interfaces/test/ISISReflectometry/Batch/BatchJobRunnerProcessingTest.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_CUSTOMINTERFACES_BATCHJOBRUNNERPROCESSINGTEST_H_
-#define MANTID_CUSTOMINTERFACES_BATCHJOBRUNNERPROCESSINGTEST_H_
+#pragma once
 
 #include "BatchJobRunnerTest.h"
 
@@ -135,5 +134,3 @@ public:
     verifyAndClear();
   }
 };
-
-#endif // MANTID_CUSTOMINTERFACES_BATCHJOBRUNNERPROCESSINGTEST_H_

--- a/qt/scientific_interfaces/test/ISISReflectometry/Batch/BatchJobRunnerProgressBarTest.h
+++ b/qt/scientific_interfaces/test/ISISReflectometry/Batch/BatchJobRunnerProgressBarTest.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_CUSTOMINTERFACES_BATCHJOBRUNNERPROGRESBARTEST_H_
-#define MANTID_CUSTOMINTERFACES_BATCHJOBRUNNERPROGRESBARTEST_H_
+#pragma once
 
 #include "BatchJobRunnerTest.h"
 
@@ -327,5 +326,3 @@ public:
     TS_ASSERT_EQUALS(jobRunner.percentComplete(), 33);
   }
 };
-
-#endif // MANTID_CUSTOMINTERFACES_BATCHJOBRUNNERPROGRESSBARTEST_H_

--- a/qt/scientific_interfaces/test/ISISReflectometry/Batch/BatchJobRunnerTest.h
+++ b/qt/scientific_interfaces/test/ISISReflectometry/Batch/BatchJobRunnerTest.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_CUSTOMINTERFACES_BATCHJOBRUNNERTEST_H_
-#define MANTID_CUSTOMINTERFACES_BATCHJOBRUNNERTEST_H_
+#pragma once
 
 #include "../../../ISISReflectometry/GUI/Batch/BatchJobRunner.h"
 #include "../../../ISISReflectometry/TestHelpers/ModelCreationHelper.h"
@@ -114,5 +113,3 @@ protected:
         MantidQt::MantidWidgets::Batch::RowPath{groupIndex, rowIndex});
   }
 };
-
-#endif // MANTID_CUSTOMINTERFACES_BATCHJOBRUNNERTEST_H_

--- a/qt/scientific_interfaces/test/ISISReflectometry/Batch/BatchJobRunnerWorkspacesTest.h
+++ b/qt/scientific_interfaces/test/ISISReflectometry/Batch/BatchJobRunnerWorkspacesTest.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_CUSTOMINTERFACES_BATCHJOBRUNNERWORKSPACESTEST_H_
-#define MANTID_CUSTOMINTERFACES_BATCHJOBRUNNERWORKSPACESTEST_H_
+#pragma once
 
 #include "BatchJobRunnerTest.h"
 
@@ -209,5 +208,3 @@ public:
     verifyAndClear();
   }
 };
-
-#endif // MANTID_CUSTOMINTERFACES_BATCHJOBRUNNERWORKSPACESTEST_H_

--- a/qt/scientific_interfaces/test/ISISReflectometry/Batch/BatchPresenterTest.h
+++ b/qt/scientific_interfaces/test/ISISReflectometry/Batch/BatchPresenterTest.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_CUSTOMINTERFACES_BATCHPRESENTERTEST_H_
-#define MANTID_CUSTOMINTERFACES_BATCHPRESENTERTEST_H_
+#pragma once
 
 #include "../../../ISISReflectometry/GUI/Batch/BatchPresenter.h"
 #include "../../../ISISReflectometry/TestHelpers/ModelCreationHelper.h"
@@ -569,5 +568,3 @@ private:
     EXPECT_CALL(m_view, executeAlgorithmQueue()).Times(1);
   }
 };
-
-#endif // MANTID_CUSTOMINTERFACES_BATCHPRESENTERTEST_H_

--- a/qt/scientific_interfaces/test/ISISReflectometry/Batch/GroupProcessingAlgorithmTest.h
+++ b/qt/scientific_interfaces/test/ISISReflectometry/Batch/GroupProcessingAlgorithmTest.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_CUSTOMINTERFACES_GROUPPROCESSINGALGORITHMTEST_H_
-#define MANTID_CUSTOMINTERFACES_GROUPPROCESSINGALGORITHMTEST_H_
+#pragma once
 #include "../../../ISISReflectometry/GUI/Batch/GroupProcessingAlgorithm.h"
 #include "../../../ISISReflectometry/Reduction/Batch.h"
 #include "../../../ISISReflectometry/TestHelpers/ModelCreationHelper.h"
@@ -139,4 +138,3 @@ private:
   RunsTable m_runsTable;
   Slicing m_slicing;
 };
-#endif // MANTID_CUSTOMINTERFACES_GROUPPROCESSINGALGORITHMTEST_H_

--- a/qt/scientific_interfaces/test/ISISReflectometry/Batch/RowProcessingAlgorithmTest.h
+++ b/qt/scientific_interfaces/test/ISISReflectometry/Batch/RowProcessingAlgorithmTest.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_CUSTOMINTERFACES_ROWPROCESSINGALGORITHMTEST_H_
-#define MANTID_CUSTOMINTERFACES_ROWPROCESSINGALGORITHMTEST_H_
+#pragma once
 #include "../../../ISISReflectometry/GUI/Batch/RowProcessingAlgorithm.h"
 #include "../../../ISISReflectometry/Reduction/Batch.h"
 #include "../../../ISISReflectometry/TestHelpers/ModelCreationHelper.h"
@@ -225,4 +224,3 @@ private:
   RunsTable m_runsTable;
   Slicing m_slicing;
 };
-#endif // MANTID_CUSTOMINTERFACES_ROWPROCESSINGALGORITHMTEST_H_

--- a/qt/scientific_interfaces/test/ISISReflectometry/Common/CoderCommonTester.h
+++ b/qt/scientific_interfaces/test/ISISReflectometry/Common/CoderCommonTester.h
@@ -5,8 +5,7 @@
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
 
-#ifndef CODER_COMMON_TESTER_H_
-#define CODER_COMMON_TESTER_H_
+#pragma once
 
 #include "../../../ISISReflectometry/GUI/Batch/BatchPresenter.h"
 #include "../../../ISISReflectometry/GUI/Batch/QtBatchView.h"
@@ -331,5 +330,3 @@ private:
 } // namespace ISISReflectometry
 } // namespace CustomInterfaces
 } // namespace MantidQt
-
-#endif /* CODER_COMMON_TESTER_H_ */

--- a/qt/scientific_interfaces/test/ISISReflectometry/Common/DecoderTest.h
+++ b/qt/scientific_interfaces/test/ISISReflectometry/Common/DecoderTest.h
@@ -5,8 +5,7 @@
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
 
-#ifndef ISISREFLECTOMETRY_TEST_DECODER_TEST_H_
-#define ISISREFLECTOMETRY_TEST_DECODER_TEST_H_
+#pragma once
 
 #include "../../../ISISReflectometry/GUI/Common/Decoder.h"
 #include "../ReflMockObjects.h"
@@ -197,5 +196,3 @@ public:
 } // namespace ISISReflectometry
 } // namespace CustomInterfaces
 } // namespace MantidQt
-
-#endif /* ISISREFLECTOMETRY_TEST_DECODER_TEST_H_ */

--- a/qt/scientific_interfaces/test/ISISReflectometry/Common/EncoderTest.h
+++ b/qt/scientific_interfaces/test/ISISReflectometry/Common/EncoderTest.h
@@ -5,8 +5,7 @@
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
 
-#ifndef ISISREFLECTOMETRY_TEST_ENCODER_TEST_H_
-#define ISISREFLECTOMETRY_TEST_ENCODER_TEST_H_
+#pragma once
 
 #include "../../../ISISReflectometry/GUI/Common/Encoder.h"
 #include "../ReflMockObjects.h"
@@ -58,5 +57,3 @@ public:
 } // namespace ISISReflectometry
 } // namespace CustomInterfaces
 } // namespace MantidQt
-
-#endif /* ISISREFLECTOMETRY_TEST_ENCODER_TEST_H_ */

--- a/qt/scientific_interfaces/test/ISISReflectometry/Event/EventPresenterTest.h
+++ b/qt/scientific_interfaces/test/ISISReflectometry/Event/EventPresenterTest.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_CUSTOMINTERFACES_REFLEVENTPRESENTERTEST_H_
-#define MANTID_CUSTOMINTERFACES_REFLEVENTPRESENTERTEST_H_
+#pragma once
 
 #include "../../../ISISReflectometry/GUI/Event/EventPresenter.h"
 #include "../ReflMockObjects.h"
@@ -238,4 +237,3 @@ private:
     EXPECT_CALL(m_view, enableSliceType(newSliceType)).Times(1);
   }
 };
-#endif // MANTID_CUSTOMINTERFACES_REFLEVENTPRESENTERTEST_H_

--- a/qt/scientific_interfaces/test/ISISReflectometry/Experiment/ExperimentOptionDefaultsTest.h
+++ b/qt/scientific_interfaces/test/ISISReflectometry/Experiment/ExperimentOptionDefaultsTest.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_CUSTOMINTERFACES_EXPERIMENTOPTIONDEFAULTSTEST_H_
-#define MANTID_CUSTOMINTERFACES_EXPERIMENTOPTIONDEFAULTSTEST_H_
+#pragma once
 
 #include "../../../ISISReflectometry/GUI/Experiment/ExperimentOptionDefaults.h"
 #include "MantidAPI/FrameworkManager.h"
@@ -175,5 +174,3 @@ private:
                      const std::invalid_argument &);
   }
 };
-
-#endif // MANTID_CUSTOMINTERFACES_EXPERIMENTOPTIONDEFAULTSTEST_H_

--- a/qt/scientific_interfaces/test/ISISReflectometry/Experiment/ExperimentPresenterTest.h
+++ b/qt/scientific_interfaces/test/ISISReflectometry/Experiment/ExperimentPresenterTest.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_CUSTOMINTERFACES_EXPERIMENTPRESENTERTEST_H_
-#define MANTID_CUSTOMINTERFACES_EXPERIMENTPRESENTERTEST_H_
+#pragma once
 
 #include "../../../ISISReflectometry/GUI/Experiment/ExperimentPresenter.h"
 #include "../../../ISISReflectometry/TestHelpers/ModelCreationHelper.h"
@@ -954,5 +953,3 @@ private:
 };
 
 GNU_DIAG_ON("missing-braces")
-
-#endif // MANTID_CUSTOMINTERFACES_EXPERIMENTPRESENTERTEST_H_

--- a/qt/scientific_interfaces/test/ISISReflectometry/Experiment/PerThetaDefaultsTableValidatorTest.h
+++ b/qt/scientific_interfaces/test/ISISReflectometry/Experiment/PerThetaDefaultsTableValidatorTest.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_CUSTOMINTERFACES_PERTHETADEFAULTSTABLEVALIDATORTEST_H_
-#define MANTID_CUSTOMINTERFACES_PERTHETADEFAULTSTABLEVALIDATORTEST_H_
+#pragma once
 #include "../../../ISISReflectometry/GUI/Experiment/PerThetaDefaultsTableValidator.h"
 #include "../../../ISISReflectometry/Reduction/TransmissionRunPair.h"
 #include "MantidKernel/WarningSuppressions.h"
@@ -212,5 +211,3 @@ private:
 };
 
 GNU_DIAG_ON("missing-braces")
-
-#endif // MANTID_CUSTOMINTERFACES_PERTHETADEFAULTSTABLEVALIDATORTEST_H_

--- a/qt/scientific_interfaces/test/ISISReflectometry/Instrument/InstrumentOptionDefaultsTest.h
+++ b/qt/scientific_interfaces/test/ISISReflectometry/Instrument/InstrumentOptionDefaultsTest.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_CUSTOMINTERFACES_INSTRUMENTOPTIONDEFAULTSTEST_H_
-#define MANTID_CUSTOMINTERFACES_INSTRUMENTOPTIONDEFAULTSTEST_H_
+#pragma once
 
 #include "../../../ISISReflectometry/GUI/Instrument/InstrumentOptionDefaults.h"
 #include "MantidAPI/FrameworkManager.h"
@@ -143,5 +142,3 @@ private:
                      const std::invalid_argument &);
   }
 };
-
-#endif // MANTID_CUSTOMINTERFACES_INSTRUMENTOPTIONDEFAULTSTEST_H_

--- a/qt/scientific_interfaces/test/ISISReflectometry/Instrument/InstrumentPresenterTest.h
+++ b/qt/scientific_interfaces/test/ISISReflectometry/Instrument/InstrumentPresenterTest.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_CUSTOMINTERFACES_INSTRUMENTPRESENTERTEST_H_
-#define MANTID_CUSTOMINTERFACES_INSTRUMENTPRESENTERTEST_H_
+#pragma once
 
 #include "../../../ISISReflectometry/GUI/Instrument/InstrumentPresenter.h"
 #include "../../../ISISReflectometry/TestHelpers/ModelCreationHelper.h"
@@ -482,5 +481,3 @@ private:
     verifyAndClear();
   }
 };
-
-#endif // MANTID_CUSTOMINTERFACES_INSTRUMENTPRESENTERTEST_H_

--- a/qt/scientific_interfaces/test/ISISReflectometry/MainWindow/MainWindowPresenterTest.h
+++ b/qt/scientific_interfaces/test/ISISReflectometry/MainWindow/MainWindowPresenterTest.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_CUSTOMINTERFACES_MAINWINDOWPRESENTERTEST_H_
-#define MANTID_CUSTOMINTERFACES_MAINWINDOWPRESENTERTEST_H_
+#pragma once
 
 #include "../../../ISISReflectometry/GUI/MainWindow/MainWindowPresenter.h"
 #include "../../../ISISReflectometry/TestHelpers/ModelCreationHelper.h"
@@ -513,5 +512,3 @@ private:
   std::string backup_facility;
   std::string backup_instrument;
 };
-
-#endif // MANTID_CUSTOMINTERFACES_MAINWINDOWPRESENTERTEST_H_

--- a/qt/scientific_interfaces/test/ISISReflectometry/Reduction/GroupTest.h
+++ b/qt/scientific_interfaces/test/ISISReflectometry/Reduction/GroupTest.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_CUSTOMINTERFACES_GROUPTEST_H_
-#define MANTID_CUSTOMINTERFACES_GROUPTEST_H_
+#pragma once
 #include "../../../ISISReflectometry/Reduction/Group.h"
 #include "../../../ISISReflectometry/Reduction/ReductionWorkspaces.h"
 #include <cxxtest/TestSuite.h>
@@ -36,4 +35,3 @@ public:
     TS_ASSERT_EQUALS(run.runNumbers(), group[0].get().runNumbers());
   }
 };
-#endif // MANTID_CUSTOMINTERFACES_GROUPTEST_H_

--- a/qt/scientific_interfaces/test/ISISReflectometry/Reduction/ParseReflectometryStringsTest.h
+++ b/qt/scientific_interfaces/test/ISISReflectometry/Reduction/ParseReflectometryStringsTest.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_CUSTOMINTERFACES_PARSEREFLECTOMETRYSTRINGSTEST_H_
-#define MANTID_CUSTOMINTERFACES_PARSEREFLECTOMETRYSTRINGSTEST_H_
+#pragma once
 #include "../../../ISISReflectometry/Reduction/ParseReflectometryStrings.h"
 #include <cxxtest/TestSuite.h>
 
@@ -268,4 +267,3 @@ public:
 private:
   enum { VALUE, ERROR };
 };
-#endif // MANTID_CUSTOMINTERFACES_PARSEREFLECTOMETRYSTRINGSTEST_H_

--- a/qt/scientific_interfaces/test/ISISReflectometry/Reduction/ReductionJobsMergeTest.h
+++ b/qt/scientific_interfaces/test/ISISReflectometry/Reduction/ReductionJobsMergeTest.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_CUSTOMINTERFACES_REDUCTIONJOBSMERGETEST_H_
-#define MANTID_CUSTOMINTERFACES_REDUCTIONJOBSMERGETEST_H_
+#pragma once
 #include "../../../ISISReflectometry/TestHelpers/ModelCreationHelper.h"
 #include "Common/ZipRange.h"
 #include "Reduction/ReductionJobs.h"
@@ -338,4 +337,3 @@ public:
 private:
   double m_thetaTolerance;
 };
-#endif // MANTID_CUSTOMINTERFACES_REDUCTIONJOBSMERGETEST_H_

--- a/qt/scientific_interfaces/test/ISISReflectometry/Reduction/ValidatePerThetaDefaultsTest.h
+++ b/qt/scientific_interfaces/test/ISISReflectometry/Reduction/ValidatePerThetaDefaultsTest.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_CUSTOMINTERFACES_VALIDATEPERTHETADEFAULTSTEST_H_
-#define MANTID_CUSTOMINTERFACES_VALIDATEPERTHETADEFAULTSTEST_H_
+#pragma once
 #include "../../../ISISReflectometry/Reduction/ValidatePerThetaDefaults.h"
 #include "MantidKernel/WarningSuppressions.h"
 #include <cxxtest/TestSuite.h>
@@ -136,5 +135,3 @@ public:
 };
 
 GNU_DIAG_ON("missing-braces")
-
-#endif // MANTID_CUSTOMINTERFACES_VALIDATEPERTHETADEFAULTSTEST_H_

--- a/qt/scientific_interfaces/test/ISISReflectometry/Reduction/ValidateRowTest.h
+++ b/qt/scientific_interfaces/test/ISISReflectometry/Reduction/ValidateRowTest.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_CUSTOMINTERFACES_VALIDATEROWTEST_H_
-#define MANTID_CUSTOMINTERFACES_VALIDATEROWTEST_H_
+#pragma once
 #include "../../../ISISReflectometry/Common/Parse.h"
 #include "../../../ISISReflectometry/Reduction/ValidateRow.h"
 #include <cxxtest/TestSuite.h>
@@ -236,4 +235,3 @@ public:
     TS_ASSERT_EQUALS(expected, result);
   }
 };
-#endif // MANTID_CUSTOMINTERFACES_VALIDATEROWTEST_H_

--- a/qt/scientific_interfaces/test/ISISReflectometry/ReflMockObjects.h
+++ b/qt/scientific_interfaces/test/ISISReflectometry/ReflMockObjects.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_CUSTOMINTERFACES_REFLMOCKOBJECTS_H
-#define MANTID_CUSTOMINTERFACES_REFLMOCKOBJECTS_H
+#pragma once
 
 #include "GUI/Batch/IBatchJobAlgorithm.h"
 #include "GUI/Batch/IBatchJobRunner.h"
@@ -333,5 +332,3 @@ public:
 };
 
 GNU_DIAG_ON_SUGGEST_OVERRIDE
-
-#endif /*MANTID_CUSTOMINTERFACES_REFLMOCKOBJECTS_H*/

--- a/qt/scientific_interfaces/test/ISISReflectometry/Runs/MockRunsView.h
+++ b/qt/scientific_interfaces/test/ISISReflectometry/Runs/MockRunsView.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_CUSTOMINTERFACES_MOCKRUNSVIEW_H_
-#define MANTID_CUSTOMINTERFACES_MOCKRUNSVIEW_H_
+#pragma once
 #include "GUI/Runs/IRunsView.h"
 #include "GUI/RunsTable/IRunsTableView.h"
 #include "MantidKernel/WarningSuppressions.h"
@@ -64,4 +63,3 @@ public:
 } // namespace CustomInterfaces
 } // namespace MantidQt
 GNU_DIAG_ON_SUGGEST_OVERRIDE
-#endif // MANTID_CUSTOMINTERFACES_MOCKRUNSVIEW_H_

--- a/qt/scientific_interfaces/test/ISISReflectometry/Runs/RunsPresenterTest.h
+++ b/qt/scientific_interfaces/test/ISISReflectometry/Runs/RunsPresenterTest.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_CUSTOMINTERFACES_RUNSPRESENTERTEST_H
-#define MANTID_CUSTOMINTERFACES_RUNSPRESENTERTEST_H
+#pragma once
 
 #include "../../../ISISReflectometry/GUI/Runs/RunsPresenter.h"
 #include "../../../ISISReflectometry/Reduction/RunsTable.h"
@@ -1067,5 +1066,3 @@ private:
   std::string m_searchString;
   SearchResult m_searchResult;
 };
-
-#endif /* MANTID_CUSTOMINTERFACES_RUNSPRESENTERTEST_H */

--- a/qt/scientific_interfaces/test/ISISReflectometry/RunsTable/MockRunsTablePresenter.h
+++ b/qt/scientific_interfaces/test/ISISReflectometry/RunsTable/MockRunsTablePresenter.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_CUSTOMINTERFACES_MOCKBATCHPRESENTER_H_
-#define MANTID_CUSTOMINTERFACES_MOCKBATCHPRESENTER_H_
+#pragma once
 #include "../../../ISISReflectometry/GUI/Common/Plotter.h"
 #include "../../../ISISReflectometry/GUI/RunsTable/RunsTablePresenter.h"
 #include "MantidKernel/WarningSuppressions.h"
@@ -43,4 +42,3 @@ public:
 } // namespace CustomInterfaces
 } // namespace MantidQt
 GNU_DIAG_ON_SUGGEST_OVERRIDE
-#endif // MANTID_CUSTOMINTERFACES_MOCKRUNSTABLEPRESENTER_H_

--- a/qt/scientific_interfaces/test/ISISReflectometry/RunsTable/MockRunsTableView.h
+++ b/qt/scientific_interfaces/test/ISISReflectometry/RunsTable/MockRunsTableView.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_CUSTOMINTERFACES_MOCKRUNSTABLEVIEW_H_
-#define MANTID_CUSTOMINTERFACES_MOCKRUNSTABLEVIEW_H_
+#pragma once
 #include "GUI/RunsTable/IRunsTableView.h"
 #include "MantidKernel/WarningSuppressions.h"
 #include <gmock/gmock.h>
@@ -43,4 +42,3 @@ public:
 } // namespace CustomInterfaces
 } // namespace MantidQt
 GNU_DIAG_ON_SUGGEST_OVERRIDE
-#endif // MANTID_CUSTOMINTERFACES_MOCKRUNSTABLEVIEW_H_

--- a/qt/scientific_interfaces/test/ISISReflectometry/RunsTable/RunsTablePresenterDisplayTest.h
+++ b/qt/scientific_interfaces/test/ISISReflectometry/RunsTable/RunsTablePresenterDisplayTest.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_CUSTOMINTERFACES_RUNSTABLEPRESENTERDISPLAYTEST_H_
-#define MANTID_CUSTOMINTERFACES_RUNSTABLEPRESENTERDISPLAYTEST_H_
+#pragma once
 
 #include "../../../ISISReflectometry/GUI/RunsTable/RunsTablePresenter.h"
 #include "RunsTablePresenterTest.h"
@@ -268,4 +267,3 @@ private:
         .WillRepeatedly(Return(defaultCell));
   }
 };
-#endif // MANTID_CUSTOMINTERFACES_RUNSTABLEPRESENTERDISPLAYTEST_H_

--- a/qt/scientific_interfaces/test/ISISReflectometry/RunsTable/RunsTablePresenterGroupDeletionTest.h
+++ b/qt/scientific_interfaces/test/ISISReflectometry/RunsTable/RunsTablePresenterGroupDeletionTest.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_CUSTOMINTERFACES_REFLRUNSTABLEPRESENTERGROUPDELETETEST_H_
-#define MANTID_CUSTOMINTERFACES_REFLRUNSTABLEPRESENTERGROUPDELETETEST_H_
+#pragma once
 
 #include "../../../ISISReflectometry/GUI/RunsTable/RunsTablePresenter.h"
 #include "../../../ISISReflectometry/Reduction/ReductionWorkspaces.h"
@@ -152,5 +151,3 @@ public:
     TS_ASSERT_EQUALS(1, groups[0].rows().size());
   }
 };
-
-#endif // MANTID_CUSTOMINTERFACES_REFLRUNSTABLEPRESENTERGROUPDELETETEST_H_

--- a/qt/scientific_interfaces/test/ISISReflectometry/RunsTable/RunsTablePresenterGroupInsertionTest.h
+++ b/qt/scientific_interfaces/test/ISISReflectometry/RunsTable/RunsTablePresenterGroupInsertionTest.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_CUSTOMINTERFACES_REFLRUNSTABLEPRESENTERGROUPINSERTTEST_H_
-#define MANTID_CUSTOMINTERFACES_REFLRUNSTABLEPRESENTERGROUPINSERTTEST_H_
+#pragma once
 
 #include "../../../ISISReflectometry/GUI/RunsTable/RunsTablePresenter.h"
 #include "RunsTablePresenterTest.h"
@@ -147,5 +146,3 @@ public:
     verifyAndClearExpectations();
   }
 };
-
-#endif // MANTID_CUSTOMINTERFACES_REFLRUNSTABLEPRESENTERGROUPINSERTTEST_H_

--- a/qt/scientific_interfaces/test/ISISReflectometry/RunsTable/RunsTablePresenterMergeJobsTest.h
+++ b/qt/scientific_interfaces/test/ISISReflectometry/RunsTable/RunsTablePresenterMergeJobsTest.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_CUSTOMINTERFACES_REFLRUNSTABLEPRESENTERMERGEJOBSTEST_H_
-#define MANTID_CUSTOMINTERFACES_REFLRUNSTABLEPRESENTERMERGEJOBSTEST_H_
+#pragma once
 
 #include "../../../ISISReflectometry/GUI/RunsTable/RunsTablePresenter.h"
 #include "../../../ISISReflectometry/TestHelpers/ModelCreationHelper.h"
@@ -97,5 +96,3 @@ public:
     TS_ASSERT_EQUALS(result, oneGroupWithTwoRunsInARowModel());
   }
 };
-
-#endif // MANTID_CUSTOMINTERFACES_REFLRUNSTABLEPRESENTERMERGEJOBSTEST_H_

--- a/qt/scientific_interfaces/test/ISISReflectometry/RunsTable/RunsTablePresenterProcessingTest.h
+++ b/qt/scientific_interfaces/test/ISISReflectometry/RunsTable/RunsTablePresenterProcessingTest.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_CUSTOMINTERFACES_REFLRUNSTABLEPRESENTERPROCESSINGTEST_H_
-#define MANTID_CUSTOMINTERFACES_REFLRUNSTABLEPRESENTERPROCESSINGTEST_H_
+#pragma once
 
 #include "../../../ISISReflectometry/GUI/RunsTable/RunsTablePresenter.h"
 #include "../../../ISISReflectometry/TestHelpers/ModelCreationHelper.h"
@@ -412,5 +411,3 @@ private:
     expectTableEditingEnabled(true);
   }
 };
-
-#endif // MANTID_CUSTOMINTERFACES_REFLRUNSTABLEPRESENTERPROCESSINGTEST_H_

--- a/qt/scientific_interfaces/test/ISISReflectometry/RunsTable/RunsTablePresenterRowDeletionTest.h
+++ b/qt/scientific_interfaces/test/ISISReflectometry/RunsTable/RunsTablePresenterRowDeletionTest.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_CUSTOMINTERFACES_REFLRUNSTABLEPRESENTERGROUPDELETETEST_H_
-#define MANTID_CUSTOMINTERFACES_REFLRUNSTABLEPRESENTERGROUPDELETETEST_H_
+#pragma once
 
 #include "../../../ISISReflectometry/GUI/RunsTable/RunsTablePresenter.h"
 #include "../../../ISISReflectometry/Reduction/ReductionWorkspaces.h"
@@ -116,5 +115,3 @@ public:
     verifyAndClearExpectations();
   }
 };
-
-#endif // MANTID_CUSTOMINTERFACES_REFLRUNSTABLEPRESENTERGROUPDELETETEST_H_

--- a/qt/scientific_interfaces/test/ISISReflectometry/RunsTable/RunsTablePresenterRowInsertionTest.h
+++ b/qt/scientific_interfaces/test/ISISReflectometry/RunsTable/RunsTablePresenterRowInsertionTest.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_CUSTOMINTERFACES_REFLRUNSTABLEPRESENTERGROUPINSERTTEST_H_
-#define MANTID_CUSTOMINTERFACES_REFLRUNSTABLEPRESENTERGROUPINSERTTEST_H_
+#pragma once
 
 #include "../../../ISISReflectometry/GUI/RunsTable/RunsTablePresenter.h"
 #include "RunsTablePresenterTest.h"
@@ -192,5 +191,3 @@ public:
     verifyAndClearExpectations();
   }
 };
-
-#endif // MANTID_CUSTOMINTERFACES_REFLRUNSTABLEPRESENTERGROUPINSERTTEST_H_

--- a/qt/scientific_interfaces/test/ISISReflectometry/RunsTable/RunsTablePresenterTest.h
+++ b/qt/scientific_interfaces/test/ISISReflectometry/RunsTable/RunsTablePresenterTest.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_CUSTOMINTERFACES_REFLRUNSTABLEPRESENTERTEST_H_
-#define MANTID_CUSTOMINTERFACES_REFLRUNSTABLEPRESENTERTEST_H_
+#pragma once
 
 #include "../../../ISISReflectometry/GUI/Common/Plotter.h"
 #include "../../../ISISReflectometry/GUI/RunsTable/RunsTablePresenter.h"
@@ -134,4 +133,3 @@ protected:
   NiceMock<MockRunsPresenter> m_mainPresenter;
   NiceMock<MockPlotter> m_plotter;
 };
-#endif // MANTID_CUSTOMINTERFACES_REFLRUNSTABLEPRESENTERTEST_H_

--- a/qt/scientific_interfaces/test/ISISReflectometry/Save/SavePresenterTest.h
+++ b/qt/scientific_interfaces/test/ISISReflectometry/Save/SavePresenterTest.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_CUSTOMINTERFACES_SAVEPRESENTERTEST_H_
-#define MANTID_CUSTOMINTERFACES_SAVEPRESENTERTEST_H_
+#pragma once
 
 #include "../ReflMockObjects.h"
 #include "GUI/Save/IAsciiSaver.h"
@@ -484,4 +483,3 @@ private:
   std::string m_separator;
   bool m_includeQResolution;
 };
-#endif // MANTID_CUSTOMINTERFACES_SAVEPRESENTERTEST_H_

--- a/qt/scientific_interfaces/test/MuonAnalysisDataLoaderTest.h
+++ b/qt/scientific_interfaces/test/MuonAnalysisDataLoaderTest.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTIDQT_CUSTOMINTERFACES_MUONANALYSISDATALOADERTEST_H_
-#define MANTIDQT_CUSTOMINTERFACES_MUONANALYSISDATALOADERTEST_H_
+#pragma once
 
 #include <Poco/File.h>
 #include <Poco/Path.h>
@@ -374,4 +373,3 @@ private:
     }
   }
 };
-#endif /* MANTIDQT_CUSTOMINTERFACES_MUONANALYSISDATALOADERTEST_H_ */

--- a/qt/scientific_interfaces/test/MuonAnalysisFitDataPresenterTest.h
+++ b/qt/scientific_interfaces/test/MuonAnalysisFitDataPresenterTest.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_CUSTOMINTERFACES_MUONANALYSISFITDATAPRESENTERTEST_H_
-#define MANTID_CUSTOMINTERFACES_MUONANALYSISFITDATAPRESENTERTEST_H_
+#pragma once
 
 #include <algorithm>
 #include <cxxtest/TestSuite.h>
@@ -1112,5 +1111,3 @@ private:
   MuonAnalysisFitDataPresenter *m_presenter;
   MuonAnalysisDataLoader m_dataLoader;
 };
-
-#endif /* MANTID_CUSTOMINTERFACES_MUONANALYSISFITDATAPRESENTERTEST_H_ */

--- a/qt/scientific_interfaces/test/MuonAnalysisFitFunctionPresenterTest.h
+++ b/qt/scientific_interfaces/test/MuonAnalysisFitFunctionPresenterTest.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_CUSTOMINTERFACES_MUONANALYSISFITFUNCTIONPRESENTERTEST_H_
-#define MANTID_CUSTOMINTERFACES_MUONANALYSISFITFUNCTIONPRESENTERTEST_H_
+#pragma once
 
 #include <cxxtest/TestSuite.h>
 #include <gmock/gmock.h>
@@ -284,5 +283,3 @@ private:
   MockFitFunctionControl *m_fitBrowser;
   MuonAnalysisFitFunctionPresenter *m_presenter;
 };
-
-#endif /* MANTID_CUSTOMINTERFACES_MUONANALYSISFITFUNCTIONPRESENTERTEST_H_ */

--- a/qt/scientific_interfaces/test/MuonAnalysisHelperTest.h
+++ b/qt/scientific_interfaces/test/MuonAnalysisHelperTest.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_CUSTOMINTERFACES_MUONANALYSISHELPERTEST_H_
-#define MANTID_CUSTOMINTERFACES_MUONANALYSISHELPERTEST_H_
+#pragma once
 
 #include <cxxtest/TestSuite.h>
 
@@ -806,5 +805,3 @@ private:
     return table;
   }
 };
-
-#endif /* MANTID_CUSTOMINTERFACES_MUONANALYSISHELPERTEST_H_ */

--- a/qt/scientific_interfaces/test/MuonAnalysisResultTableCreatorTest.h
+++ b/qt/scientific_interfaces/test/MuonAnalysisResultTableCreatorTest.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTIDQT_CUSTOMINTERFACES_MUONANALYSISRESULTTABLECREATORTEST_H_
-#define MANTIDQT_CUSTOMINTERFACES_MUONANALYSISRESULTTABLECREATORTEST_H_
+#pragma once
 
 #include "../Muon/MuonAnalysisResultTableCreator.h"
 #include "MantidAPI/AlgorithmManager.h"
@@ -576,5 +575,3 @@ private:
   LogValuesMap m_logValues;
   int m_firstStart_sec, m_startDiff_sec, m_firstRun;
 };
-
-#endif /* MANTIDQT_CUSTOMINTERFACES_MUONANALYSISRESULTTABLECREATORTEST_H_ */

--- a/qt/scientific_interfaces/test/RunMapTest.h
+++ b/qt/scientific_interfaces/test/RunMapTest.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTIDQTCUSTOMINTERFACES_ENGGDIFFRACTION_RUNMAPTEST_H_
-#define MANTIDQTCUSTOMINTERFACES_ENGGDIFFRACTION_RUNMAPTEST_H_
+#pragma once
 
 #include "../EnggDiffraction/RunMap.h"
 
@@ -99,5 +98,3 @@ public:
     TS_ASSERT_EQUALS(runMap.size(), 4);
   }
 };
-
-#endif // MANTIDQTCUSTOMINTERFACES_ENGGDIFFRACTION_RUNMAPTEST_H_

--- a/qt/scientific_interfaces/test/ScientificInterfacesTestInitialization.h
+++ b/qt/scientific_interfaces/test/ScientificInterfacesTestInitialization.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef REFLMPLCPPTESTGLOBALINITIALIZATION_H
-#define REFLMPLCPPTESTGLOBALINITIALIZATION_H
+#pragma once
 
 #include "MantidPythonInterface/core/Testing/PythonInterpreterGlobalFixture.h"
 
@@ -16,5 +15,3 @@
 // statements do not cause multiple-definition errors.
 //------------------------------------------------------------------------------
 static PythonInterpreterGlobalFixture PYTHON_INTERPRETER;
-
-#endif // REFLMPLCPPTESTGLOBALINITIALIZATION_H


### PR DESCRIPTION
This PR replaces all header guards in qt/scientific_interfaces with #pragma once.

**To test:**

Any issues in this PR should be caught by jenkins. just code review to check that no definitions or endifs have been removed by mistake

This pr is a part of #28200

*This does not require release notes* because **it is an internal change to the codebase.**

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
