### PR TITLE
Fix unhandled exception when you enable filled areas more than once on a waterfall plot

### DIFF
--- a/Framework/PythonInterface/mantid/plots/datafunctions.py
+++ b/Framework/PythonInterface/mantid/plots/datafunctions.py
@@ -949,6 +949,9 @@ def waterfall_fill_is_line_colour(ax):
 
 
 def waterfall_create_fill(ax):
+    if ax.waterfall_has_fill():
+        return
+
     errorbar_cap_lines = remove_and_return_errorbar_cap_lines(ax)
 
     for i, line in enumerate(ax.get_lines()):

--- a/Framework/PythonInterface/mantid/plots/mantidaxes.py
+++ b/Framework/PythonInterface/mantid/plots/mantidaxes.py
@@ -1024,7 +1024,7 @@ class MantidAxes(Axes):
         else:
             if bool(x_offset) or bool(y_offset) or fill:
                 raise RuntimeError("You have set waterfall to false but have given a non-zero value for the offset or "
-                                "set fill to true.")
+                                   "set fill to true.")
 
             if not self.is_waterfall():
                 # Nothing needs to be changed.

--- a/Framework/PythonInterface/test/python/mantid/plots/plots__init__Test.py
+++ b/Framework/PythonInterface/test/python/mantid/plots/plots__init__Test.py
@@ -649,6 +649,21 @@ class Plots__init__Test(unittest.TestCase):
         # Check that there are now three filled areas and the new fill colour matches the others.
         self.assertTrue((ax.collections[2].get_facecolor() == [1, 0, 0, 1]).all())
 
+    def test_fills_not_created_if_waterfall_plot_already_has_filled_areas(self):
+        fig, ax = plt.subplots(subplot_kw={'projection': 'mantid'})
+        ax.plot([0, 1], [0, 1])
+        ax.plot([0, 1], [0, 1])
+
+        # Make a waterfall plot
+        ax.set_waterfall(True)
+
+        # Add filled areas twice
+        ax.set_waterfall_fill(True)
+        ax.set_waterfall_fill(True)
+
+        # There should still be only two filled areas (one for each line)
+        self.assertEqual(len(datafunctions.get_waterfall_fills(ax)), 2)
+
     def _run_check_axes_distribution_consistency(self, normalization_states):
         mock_tracked_workspaces = {
             'ws': [


### PR DESCRIPTION
**To test:**
Check that this script runs:
```
fig, ax = plt.subplots(subplot_kw={'projection':'mantid'})
ax.plot([0,1],[0,1])
ax.plot([0,1],[0,1])
ax.set_waterfall(True, fill=True)
ax.set_waterfall_fill(True)
fig.show()
```
In the plot produced, check you can open the fill options dialog (paint-bucket icon in the toolbar).

Fixes #28308 

No release notes because waterfall plots aren't in a release yet.

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
