### PR TITLE
Fix Plot Type being in context menu on plot with only one line

### DIFF
--- a/qt/applications/workbench/workbench/plotting/figureinteraction.py
+++ b/qt/applications/workbench/workbench/plotting/figureinteraction.py
@@ -300,11 +300,18 @@ class FigureInteraction(object):
             self.add_error_bars_menu(menu, event.inaxes)
             self._add_marker_option_menu(menu, event)
 
+        # Error bar caps are considered lines so they are removed before checking the number of lines on the axes so
+        # they aren't confused for "actual" lines.
+        error_bar_caps = datafunctions.remove_and_return_errorbar_cap_lines(event.inaxes)
+
         # Able to change the plot type to waterfall if there is only one axes, it is a MantidAxes, and there is more
         # than one line on the axes.
         if len(event.inaxes.get_figure().get_axes()) == 1 and isinstance(event.inaxes, MantidAxes)\
                 and len(event.inaxes.get_lines()) > 1:
             self._add_plot_type_option_menu(menu, event.inaxes)
+
+        # Re-add error bar caps
+        event.inaxes.lines += error_bar_caps
 
         menu.exec_(QCursor.pos())
 

--- a/qt/applications/workbench/workbench/plotting/figureinteraction.py
+++ b/qt/applications/workbench/workbench/plotting/figureinteraction.py
@@ -299,19 +299,7 @@ class FigureInteraction(object):
                 self._add_normalization_option_menu(menu, event.inaxes)
             self.add_error_bars_menu(menu, event.inaxes)
             self._add_marker_option_menu(menu, event)
-
-        # Error bar caps are considered lines so they are removed before checking the number of lines on the axes so
-        # they aren't confused for "actual" lines.
-        error_bar_caps = datafunctions.remove_and_return_errorbar_cap_lines(event.inaxes)
-
-        # Able to change the plot type to waterfall if there is only one axes, it is a MantidAxes, and there is more
-        # than one line on the axes.
-        if len(event.inaxes.get_figure().get_axes()) == 1 and isinstance(event.inaxes, MantidAxes)\
-                and len(event.inaxes.get_lines()) > 1:
             self._add_plot_type_option_menu(menu, event.inaxes)
-
-        # Re-add error bar caps
-        event.inaxes.lines += error_bar_caps
 
         menu.exec_(QCursor.pos())
 
@@ -448,6 +436,18 @@ class FigureInteraction(object):
         menu.addMenu(marker_menu)
 
     def _add_plot_type_option_menu(self, menu, ax):
+        # Error bar caps are considered lines so they are removed before checking the number of lines on the axes so
+        # they aren't confused for "actual" lines.
+        error_bar_caps = datafunctions.remove_and_return_errorbar_cap_lines(ax)
+
+        # Able to change the plot type to waterfall if there is only one axes, it is a MantidAxes, and there is more
+        # than one line on the axes.
+        if len(ax.get_figure().get_axes()) > 1 or not isinstance(ax, MantidAxes) or len(ax.get_lines()) <= 1:
+            return
+
+        # Re-add error bar caps
+        ax.lines += error_bar_caps
+
         plot_type_menu = QMenu("Plot Type", menu)
         plot_type_action_group = QActionGroup(plot_type_menu)
         standard = plot_type_menu.addAction("1D", lambda: self._change_plot_type(

--- a/qt/applications/workbench/workbench/plotting/test/test_figureinteraction.py
+++ b/qt/applications/workbench/workbench/plotting/test/test_figureinteraction.py
@@ -358,7 +358,7 @@ class FigureInteractionTest(unittest.TestCase):
         return fig_manager
 
     def _create_mock_right_click(self):
-        mouse_event = MagicMock(inaxes=MagicMock(spec=MantidAxes, collections = [], creation_args = [{}]))
+        mouse_event = MagicMock(inaxes=MagicMock(spec=MantidAxes, collections = [], creation_args = [{}], lines=[]))
         type(mouse_event).button = PropertyMock(return_value=3)
         return mouse_event
 

--- a/qt/applications/workbench/workbench/plotting/test/test_figureinteraction.py
+++ b/qt/applications/workbench/workbench/plotting/test/test_figureinteraction.py
@@ -296,6 +296,35 @@ class FigureInteractionTest(unittest.TestCase):
         self.assertTrue(
             any(FigureInteraction.HIDE_ERROR_BARS_BUTTON_TEXT == child.text() for child in added_menu.children()))
 
+    def test_context_menu_includes_plot_type_if_plot_has_multiple_lines(self):
+        fig, self.ax = plt.subplots(subplot_kw={'projection': 'mantid'})
+        self.ax.plot([0, 1], [0, 1])
+        self.ax.plot([0, 1], [0, 1])
+
+        main_menu = QMenu()
+        # QMenu always seems to have 1 child when empty,
+        # but just making sure the count as expected at this point in the test
+        self.assertEqual(1, len(main_menu.children()))
+
+        self.interactor._add_plot_type_option_menu(main_menu, self.ax)
+
+        added_menu = main_menu.children()[1]
+        self.assertEqual(added_menu.children()[0].text(), "Plot Type")
+
+    def test_context_menu_does_not_include_plot_type_if_plot_has_one_line(self):
+        fig, self.ax = plt.subplots(subplot_kw={'projection': 'mantid'})
+        self.ax.errorbar([0, 1], [0, 1], capsize=1)
+
+        main_menu = QMenu()
+        # QMenu always seems to have 1 child when empty,
+        # but just making sure the count as expected at this point in the test
+        self.assertEqual(1, len(main_menu.children()))
+
+        self.interactor._add_plot_type_option_menu(main_menu, self.ax)
+
+        # Number of children should remain unchanged
+        self.assertEqual(1, len(main_menu.children()))
+
     def test_scripted_plot_show_and_hide_all(self):
         self.ax.plot([0, 15000], [0, 15000], label='MyLabel')
         self.ax.errorbar([0, 15000], [0, 14000], yerr=[10, 10000], label='MyLabel 2')
@@ -358,7 +387,7 @@ class FigureInteractionTest(unittest.TestCase):
         return fig_manager
 
     def _create_mock_right_click(self):
-        mouse_event = MagicMock(inaxes=MagicMock(spec=MantidAxes, collections = [], creation_args = [{}], lines=[]))
+        mouse_event = MagicMock(inaxes=MagicMock(spec=MantidAxes, collections = [], creation_args = [{}]))
         type(mouse_event).button = PropertyMock(return_value=3)
         return mouse_event
 


### PR DESCRIPTION
**Description of work.**
A regular plot can only be converted to a waterfall plot if it has more than one line. Matplotlib considers errorbar caps to be lines in their own right and so the option to convert the plot to a waterfall plot would wrongly appear in the context menu if you had a plot with just one line but with errorbar caps enabled. This PR fixes that.

**To test:**
Run this script:
```
from mantid.simpleapi import *
import matplotlib.pyplot as plt
import numpy as np

ws = CreateSampleWorkspace()

fig, axes = plt.subplots(edgecolor='#ffffff', num='ws-1', subplot_kw={'projection': 'mantid'})
axes.errorbar(ws, capsize=1.0, color='#1f77b4', elinewidth=1.0, label='ws: spec 1', linewidth=1.0, specNum=1)
axes.set_title('ws')
axes.set_xlabel('Time-of-flight ($\mu s$)')
axes.set_ylabel('Counts')
axes.legend().set_draggable(True)

fig.show()
```

Right-click the figure and there should be no Plot Type option.

No associated issue.

No release notes because waterfall plots are not in a release.

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
