### PR TITLE
Re-add commented out python 3 test code

### DIFF
--- a/Framework/Algorithms/test/ReflectometryBackgroundSubtractionTest.py
+++ b/Framework/Algorithms/test/ReflectometryBackgroundSubtractionTest.py
@@ -135,15 +135,13 @@ class ReflectometryBackgroundSubtractionTest(unittest.TestCase):
                 'OutputWorkspace': 'output'}
         self._assert_run_algorithm_throws(args)
 
-    # TODO: This test fails in python 2. It can be re-added when we
-    # move fully to python 3.
-    #def test_AveragePixelFit_error_peakRange_outside_spectra(self):
-    #    args = {'InputWorkspace' : 'workspace_with_peak',
-    #            'ProcessingInstructions' : '1-7',
-    #            'BackgroundCalculationMethod' : 'AveragePixelFit',
-    #            'PeakRange' : '3-9',
-    #            'OutputWorkspace': 'output'}
-    #    self._assert_run_algorithm_invalid_property(args)
+    def test_AveragePixelFit_error_peakRange_outside_spectra(self):
+        args = {'InputWorkspace' : 'workspace_with_peak',
+                'ProcessingInstructions' : '1-7',
+                'BackgroundCalculationMethod' : 'AveragePixelFit',
+                'PeakRange' : '3-9',
+                'OutputWorkspace': 'output'}
+        self._assert_run_algorithm_invalid_property(args)
 
     def test_AveragePixelFit_error_peakRange_two_ranges(self):
         args = {'InputWorkspace' : 'workspace_with_peak',


### PR DESCRIPTION
**Description of work.**
`ReflectometryBackgroundSubtractionTest.py` had a commented out test due to failing on python 2 builds. This has now been un-commented since we will fully move to python 3 after 5.0 is released.

**To test:**
Run `ctest -C Debug -VV -R ReflectometryBackgroundSubtractionTest.test_AveragePixelFit_error_peakRange_outside_spectra` and check it passes

Fixes #27995 

*This does not require release notes* because **it is an internal change**

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
