### PR TITLE
Fix TOFTOF reduction script execution

### DIFF
--- a/scripts/Interface/reduction_gui/reduction/scripter.py
+++ b/scripts/Interface/reduction_gui/reduction/scripter.py
@@ -337,7 +337,8 @@ def execute_script_async(script, error_cb=None):
         executioner.sig_exec_error.connect(on_error)
     else:
         executioner.sig_exec_error.connect(error_cb)
-    executioner.execute_async(script, '<string>')
+
+    executioner.execute_async(script, 0)
 
 
 class BaseReductionScripter(object):


### PR DESCRIPTION
**Description of work.**

Minor bugfix to repare script execution in TOFTOF data reduction GUI in workbench.

**To test:**

1. Start workbench
2. Run TOFTOF data reduction GUI via `Interfaces`->`Direct`->`DGS Reduction` (choose facility `MLZ` and instrument `TOFTOF`)
3. Use test data 
[testdata.zip](https://github.com/mantidproject/mantid/files/4319122/testdata.zip) and xml file with data reduction settings
4. Press the `Reduce` button. Data reduction should run.
5. Test that nothing else got broken.


<!-- Instructions for testing. -->
Fixes #28344 

*This does not require release notes* because **it is a minor bugfix**

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
