### PR TITLE
Remove use of logger in plotfunctions

### DIFF
--- a/Framework/PythonInterface/mantid/plots/plotfunctions.py
+++ b/Framework/PythonInterface/mantid/plots/plotfunctions.py
@@ -16,7 +16,7 @@ from matplotlib.legend import Legend
 
 # local imports
 from mantid.api import AnalysisDataService, MatrixWorkspace
-from mantid.kernel import ConfigService, Logger
+from mantid.kernel import ConfigService
 from mantid.plots import datafunctions, MantidAxes
 
 # -----------------------------------------------------------------------------
@@ -36,8 +36,6 @@ MARKER_MAP = {'square': 's', 'plus (filled)': 'P', 'point': '.', 'tickdown': 3,
               'plus': '+', 'triangle_down': 'v', 'triangle_up': '^', 'x': 'x',
               'caretup': 6, 'caretup (centered at base)': 10,
               'caretdown (centered at base)': 11, 'None': 'None'}
-
-LOGGER = Logger("plotfunctions")
 
 # -----------------------------------------------------------------------------
 # Decorators
@@ -113,9 +111,6 @@ def plot(workspaces, spectrum_nums=None, wksp_indices=None, errors=False,
         plot_kwargs = {}
     _validate_plot_inputs(workspaces, spectrum_nums, wksp_indices, tiled, overplot)
     workspaces = [ws for ws in workspaces if isinstance(ws, MatrixWorkspace)]
-    
-    if not workspaces:
-        return
 
     if spectrum_nums is not None:
         kw, nums = 'specNum', spectrum_nums
@@ -246,12 +241,7 @@ def raise_if_not_sequence(value, seq_name, element_type=None):
     if element_type is not None:
         def raise_if_not_type(x):
             if not isinstance(x, element_type):
-                if element_type == MatrixWorkspace:
-                    # If the workspace is the wrong type, log the error and remove it from the list so that the other
-                    # workspaces can still be plotted.
-                    LOGGER.warning("{} has unexpected type '{}'".format(x, x.__class__.__name__))
-                else:
-                    raise ValueError("Unexpected type: '{}'".format(x.__class__.__name__))
+                raise ValueError(f"{x} has unexpected type: '{x.__class__.__name__}'")
 
         # Map in Python3 is an iterator, so ValueError will not be raised unless the values are yielded.
         # converting to a list forces yielding

--- a/Framework/PythonInterface/mantid/plots/plotfunctions.py
+++ b/Framework/PythonInterface/mantid/plots/plotfunctions.py
@@ -16,7 +16,7 @@ from matplotlib.legend import Legend
 
 # local imports
 from mantid.api import AnalysisDataService, MatrixWorkspace
-from mantid.kernel import ConfigService
+from mantid.kernel import ConfigService, Logger
 from mantid.plots import datafunctions, MantidAxes
 
 # -----------------------------------------------------------------------------
@@ -36,6 +36,8 @@ MARKER_MAP = {'square': 's', 'plus (filled)': 'P', 'point': '.', 'tickdown': 3,
               'plus': '+', 'triangle_down': 'v', 'triangle_up': '^', 'x': 'x',
               'caretup': 6, 'caretup (centered at base)': 10,
               'caretdown (centered at base)': 11, 'None': 'None'}
+
+LOGGER = Logger("plotfunctions")
 
 # -----------------------------------------------------------------------------
 # Decorators
@@ -111,6 +113,9 @@ def plot(workspaces, spectrum_nums=None, wksp_indices=None, errors=False,
         plot_kwargs = {}
     _validate_plot_inputs(workspaces, spectrum_nums, wksp_indices, tiled, overplot)
     workspaces = [ws for ws in workspaces if isinstance(ws, MatrixWorkspace)]
+    
+    if not workspaces:
+        return
 
     if spectrum_nums is not None:
         kw, nums = 'specNum', spectrum_nums


### PR DESCRIPTION
**Description of work.**
The LOGGER definition in plotfunctions.py was removed which meant that if you attempted to plot a non-MatrixWorkspace, instead of a useful warning you would just get "name LOGGER is not defined". In fixing this I also discovered that if you attempted to plot a non-MatrixWorkspace, the warning would output but it would still attempt to make a plot so you'd get a different error afterwards.

**To test:**
Run this script:
```
ws = CreateSampleWorkspace()
table = CreateDetectorTable(ws)
plotSpectrum([table], [0])
```

You should get a warning in the log saying table is the wrong type and no plot should be created.

*There is no associated issue.*

No release notes because this wasn't a problem in the last release.

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
