### PR TITLE
Change behavior of MatrixWorkspace::findY when value=NaN

### DIFF
--- a/Framework/API/src/MatrixWorkspace.cpp
+++ b/Framework/API/src/MatrixWorkspace.cpp
@@ -1950,7 +1950,6 @@ MatrixWorkspace::findY(double value,
   } else {
     for (int64_t i = idx.first; i < numHists; ++i) {
       const auto &Y = this->y(i);
-      // cppcheck-suppress syntaxError
       if (auto it = std::find(std::next(Y.begin(), idx.second), Y.end(), value);
           it != Y.end()) {
         out = {i, std::distance(Y.begin(), it)};

--- a/Framework/API/src/MatrixWorkspace.cpp
+++ b/Framework/API/src/MatrixWorkspace.cpp
@@ -1936,13 +1936,26 @@ MatrixWorkspace::findY(double value,
                        const std::pair<int64_t, int64_t> &idx) const {
   std::pair<int64_t, int64_t> out(-1, -1);
   const int64_t numHists = static_cast<int64_t>(this->getNumberHistograms());
-  for (int64_t i = idx.first; i < numHists; ++i) {
-    const auto &Y = this->y(i);
-    // cppcheck-suppress syntaxError
-    if (auto it = std::find(std::next(Y.begin(), idx.second), Y.end(), value);
-        it != Y.end()) {
-      out = {i, std::distance(Y.begin(), it)};
-      break;
+  if (std::isnan(value)) {
+    for (int64_t i = idx.first; i < numHists; ++i) {
+      const auto &Y = this->y(i);
+      // cppcheck-suppress syntaxError
+      if (auto it = std::find_if(std::next(Y.begin(), idx.second), Y.end(),
+                                 [](double v) { return std::isnan(v); });
+          it != Y.end()) {
+        out = {i, std::distance(Y.begin(), it)};
+        break;
+      }
+    }
+  } else {
+    for (int64_t i = idx.first; i < numHists; ++i) {
+      const auto &Y = this->y(i);
+      // cppcheck-suppress syntaxError
+      if (auto it = std::find(std::next(Y.begin(), idx.second), Y.end(), value);
+          it != Y.end()) {
+        out = {i, std::distance(Y.begin(), it)};
+        break;
+      }
     }
   }
   return out;

--- a/Framework/API/test/MatrixWorkspaceTest.h
+++ b/Framework/API/test/MatrixWorkspaceTest.h
@@ -2061,8 +2061,8 @@ public:
     TS_ASSERT_EQUALS(idx.second, 1);
     ws->mutableY(1) = NAN;
     idx = ws->findY(NAN, {0, 0});
-    TS_ASSERT_EQUALS(idx.first,1);
-    TS_ASSERT_EQUALS(idx.second,0);
+    TS_ASSERT_EQUALS(idx.first, 1);
+    TS_ASSERT_EQUALS(idx.second, 0);
   }
 
 private:

--- a/Framework/API/test/MatrixWorkspaceTest.h
+++ b/Framework/API/test/MatrixWorkspaceTest.h
@@ -2059,6 +2059,10 @@ public:
     idx = ws->findY(2., {1, 1});
     TS_ASSERT_EQUALS(idx.first, 1);
     TS_ASSERT_EQUALS(idx.second, 1);
+    ws->mutableY(1) = NAN;
+    idx = ws->findY(NAN, {0, 0});
+    TS_ASSERT_EQUALS(idx.first,1);
+    TS_ASSERT_EQUALS(idx.second,0);
   }
 
 private:


### PR DESCRIPTION
**Description of work.**

Discovered that `MatrixWorkspace::findY` can't be used to find NaN. This adds a branch to check for NaN and use `std::isnan`.

**To test:**

<!-- Instructions for testing. -->

Check added unit test

*There is no associated issue.*

*This does not require release notes* because this member function was added in v5.1.0

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
