### PR TITLE
Deprecate simpleapi *Dialog functions

### DIFF
--- a/Framework/PythonInterface/mantid/simpleapi.py
+++ b/Framework/PythonInterface/mantid/simpleapi.py
@@ -166,6 +166,16 @@ def _create_generic_signature_legacy(algm_object):
     return "\b%s" % arg_str, "\b\bVersion=%d" % algm_object.version()
 
 
+def _show_dialog_fn_deprecation_warning(name):
+    """Raise a deprecation warning for a *Dialog being used.
+    """
+    import warnings
+    help_msg = "{} has been deprecated. " \
+               "All Dialog functions will be removed in a future release.".format(name)
+    warnings.warn(help_msg, UserWarning)
+    logger.warning(help_msg)
+
+
 def Load(*args, **kwargs):
     """
     Load is a more flexible algorithm than other Mantid algorithms.
@@ -261,6 +271,8 @@ def LoadDialog(*args, **kwargs):
       - Disable :: A CSV list of properties to disable in the dialog
       - Message :: An optional message string
     """
+    _show_dialog_fn_deprecation_warning("LoadDialog")
+
     arguments = {}
     filename = None
     wkspace = None
@@ -1333,6 +1345,8 @@ def _create_algorithm_dialog(algorithm, version, _algm_object):
     """
 
     def algorithm_wrapper(*args, **kwargs):
+        _show_dialog_fn_deprecation_warning("{}Dialog".format(algorithm))
+
         _version = version
         if "Version" in kwargs:
             _version = kwargs["Version"]

--- a/docs/source/release/v5.0.0/framework.rst
+++ b/docs/source/release/v5.0.0/framework.rst
@@ -61,5 +61,8 @@ Python
 ------
 
 - :py:meth:`mantid.api.Run.getTimeAveragedStd` method has been added to the :py:obj:`mantid.api.Run` object.
+- All simpleapi Dialog functions that raised the corresponding algorithm dialog from a
+  script have been deprecated. They had low to zero usage and will not work in the future workbench.
+  They will be deleted in a future release.
 
 :ref:`Release 5.0.0 <v5.0.0>`


### PR DESCRIPTION
**Description of work.**

See commit message for description of work.

It would be good to put this into this release so that users are aware of this as soon as possible.

**To test:**

* Start MantidPlot and open the script window.
* Try running any algorithm function but append the word `Dialog` with no arguments, e.g.
`LoadDialog()`
* A dialog should be raised but a warning about deprecation should be printed.
* Try a few different algorithms.

*There is no associated issue.*


---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
