### PR TITLE
Replace final header guards with pragma once

### DIFF
--- a/Framework/API/inc/MantidAPI/IFunction.h
+++ b/Framework/API/inc/MantidAPI/IFunction.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_API_IFUNCTION_H_
-#define MANTID_API_IFUNCTION_H_
+#pragma once
 
 //----------------------------------------------------------------------
 // Includes
@@ -650,5 +649,3 @@ protected:
 
 } // namespace API
 } // namespace Mantid
-
-#endif /*MANTID_API_IFUNCTION_H_*/

--- a/Framework/Kernel/inc/MantidKernel/GitHubApiHelper.h.in
+++ b/Framework/Kernel/inc/MantidKernel/GitHubApiHelper.h.in
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_KERNEL_GitHubApiHelper_H_
-#define MANTID_KERNEL_GitHubApiHelper_H_
+#pragma once
 
 #include "MantidKernel/InternetHelper.h"
 
@@ -49,5 +48,3 @@ private:
 
 } // namespace Kernel
 } // namespace Mantid
-
-#endif /* MANTID_KERNEL_GitHubApiHelper_H_ */

--- a/Framework/Kernel/inc/MantidKernel/PocoVersion.h.in
+++ b/Framework/Kernel/inc/MantidKernel/PocoVersion.h.in
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_KERNEL_POCOVERSION_H_
-#define MANTID_KERNEL_POCOVERSION_H_
+#pragma once
 
 /**  Macros defining Poco version used to compile Mantid.
  */
@@ -15,4 +14,3 @@
 #define POCO_VERSION_MINOR @POCO_VERSION_MINOR@
 /// Patch version of Poco used to build Mantid.
 #define POCO_VERSION_PATCH @POCO_VERSION_PATCH@
-#endif /* MANTID_KERNEL_POCOVERSION_H_ */


### PR DESCRIPTION
This commit removes the final header guard that had been missed by the auto replacer.

Fixes #28200

**To test:**
Any issues in this PR should be caught by jenkins. As this is the final replacement run a check on all `.h`, `.tpp`, or `.cpp` files for any header guards 
```
#ifndef GUARD_ID
#define GUARD_ID

/. some code ./

#endif
```
Any remaining should be: 
 - required parts of setting up tests.
 - part of a exturnal library
 - autogenerated

*This does not require release notes* because **It is an internal change to the codebase.**

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
