### PR TITLE
Fix TBB Threading issue

### DIFF
--- a/Framework/API/src/FrameworkManager.cpp
+++ b/Framework/API/src/FrameworkManager.cpp
@@ -22,12 +22,22 @@
 #include <nexus/NeXusFile.hpp>
 
 #include <Poco/ActiveResult.h>
-#include <tbb/task_scheduler_init.h>
 
 #include <clocale>
 #include <cstdarg>
 #include <memory>
+
+// The below can be replaced with global_control when all platforms
+// have 2019U4
+#include "tbb/tbb_stddef.h"
+
+#if TBB_INTERFACE_VERSION_MAJOR < 11
+#include "tbb/task_scheduler_init.h"
 #include <thread>
+#else
+#define TBB_HAS_GLOBAL_CONTROL
+#include "tbb/global_control.h"
+#endif
 
 #ifdef _WIN32
 #include <winsock2.h>
@@ -43,10 +53,11 @@
 #endif
 
 namespace {
-// This must be thread local, as TBB will try to destroy a process wide handle
-// despite individual threads (such as Python multi-processing) having already
-// cleaned up
-thread_local std::unique_ptr<tbb::task_scheduler_init> tbb_handle;
+#ifdef TBB_HAS_GLOBAL_CONTROL
+std::unique_ptr<tbb::global_control> m_globalTbbControl;
+#else
+thread_local std::unique_ptr<tbb::task_scheduler_init> m_globalTbbControl;
+#endif
 } // namespace
 
 namespace Mantid {
@@ -179,12 +190,17 @@ void FrameworkManagerImpl::setNumOMPThreadsToConfigValue() {
 void FrameworkManagerImpl::setNumOMPThreads(const int nthreads) {
   g_log.debug() << "Setting maximum number of threads to " << nthreads << "\n";
   PARALLEL_SET_NUM_THREADS(nthreads);
-  if (tbb_handle) {
-    tbb_handle
+  if (m_globalTbbControl) {
+    m_globalTbbControl
         .reset(); // Have to reset to change the number of threads at runtime
   }
 
-  tbb_handle = std::make_unique<tbb::task_scheduler_init>(nthreads);
+#ifdef TBB_HAS_GLOBAL_CONTROL
+  m_globalTbbControl = std::make_unique<tbb::global_control>(
+      tbb::global_control::max_allowed_parallelism, nthreads);
+#else
+  m_globalTbbControl = std::make_unique<tbb::task_scheduler_init>(nthreads);
+#endif
 }
 
 /**
@@ -210,7 +226,7 @@ void FrameworkManagerImpl::clear() {
 void FrameworkManagerImpl::shutdown() {
   Kernel::UsageService::Instance().shutdown();
   // Ensure we don't run into static init ordering issues with TBB
-  tbb_handle.reset();
+  m_globalTbbControl.reset();
   clear();
 }
 

--- a/buildconfig/CMake/Bootstrap.cmake
+++ b/buildconfig/CMake/Bootstrap.cmake
@@ -17,7 +17,7 @@ if(MSVC)
   set(THIRD_PARTY_GIT_URL
       "https://github.com/mantidproject/thirdparty-msvc2015.git"
   )
-  set(THIRD_PARTY_GIT_SHA1 5a0617ecb9a99712b72276a92d6f400257132e2f)
+  set(THIRD_PARTY_GIT_SHA1 b996c8e248a00fd5b388e603aca888f6dd53d985)
   set(THIRD_PARTY_DIR ${EXTERNAL_ROOT}/src/ThirdParty)
   # Generates a script to do the clone/update in tmp
   set(_project_name ThirdParty)


### PR DESCRIPTION
The text below / in the commit is more for anyone else searching this error message, since apart from us and the ospray project, nobody else has seen this assert.

-----

Fixes the following assertion thrown by TBB:

	Attempt to terminate non-local scheduler instance

This took a significant amount of time to track down due to a number of
factors. If your looking for a quick fix; set your
tbb::task_scheduler_init to use thread local storage.

This is caused by using Python multi-processing (in our case for the
system tests). The process will spawn correctly (Windows), however
Python will helpfully create seperate thread(s). I assume to observe. In
this case the task_scheduler_init handle would then belong to one of
these threads, as the act of importing our Python module would init the
framework and TBB implicitly.

When the tests run and TBBs scheduling is required it will "sign_on" in
tbb's governor.cpp to handle scheduling. This works because the
scheduler_init handle
is process wide. However internally they then use thread local storage
(TLS) for tracking the scheduler.

As the main process goes to destruct it assumes that we must have
a scheduler instance, since at process level we have done the init.

But we cannot see any schedulers since they belong to a different
thread. We have been getting away with this as the TLS returns NULL
which effectively nops the destruction. But the assert correctly points
out were getting this wrong.

Marking each handle to the scheduler as thread local effectively ties
the destruction of the thread to its init status. For most threads this
effectively means we create a unique_ptr which isn't used. But for our
main threads and weird edge case worker threads it keeps the thread
state consistent.

We've used a unique_ptr since we have an API which allows us to change
the number of threads TBB can spin up. However, anyone else facing this
issue would probably be fine with a thread local object allocated on the
stack.

-----

**To test:**
- Ensure `Testing/SystemTests/lib/systemtests` is in your PYTHONPATH
- Run the following minimum reproducer and check it does not throw an assert
```python
from multiprocessing import Manager

def main():
    from systemtesting import TestSuite

    # reproduced from tmgr.loadTestsFromDir then loadTestsFromModule
    # i.e. loading a TestSuite in systemtesting.py
    with Manager() as m:
        tests_dict = m.dict()

        # Is this TestSuite in a different thread? Either way BOOM!
        tests_dict['0'] = TestSuite(None, None, None, None)
        tests_dict['0'] = None

if __name__ == "__main__":
    main()
```
- Run the following system test `.\systemtest.bat -C Debug -R OSIRISConv`

Fixes #26703 . 

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
