### PR TITLE
Improve test reliability of jupyter console test

### DIFF
--- a/qt/applications/workbench/workbench/plugins/test/test_jupyterconsole.py
+++ b/qt/applications/workbench/workbench/plugins/test/test_jupyterconsole.py
@@ -28,6 +28,10 @@ class JupyterConsoleTest(unittest.TestCase):
         widget = JupyterConsole(main_window)
         self.assertTrue(hasattr(widget, "console"))
         self.assertTrue(isinstance(widget.console, InProcessJupyterConsole))
+        console = widget.console
+        console.kernel_manager.shutdown_kernel()
+        widget.console = None
+        del console
 
 
 if __name__ == '__main__':

--- a/qt/python/mantidqt/widgets/test/test_jupyterconsole.py
+++ b/qt/python/mantidqt/widgets/test/test_jupyterconsole.py
@@ -33,12 +33,14 @@ class InProcessJupyterConsoleTest(unittest.TestCase):
         self.assertTrue(hasattr(widget, "kernel_client"))
         self.assertGreater(len(widget.banner), 0)
         self._pre_delete_console_cleanup(widget)
+        widget.kernel_manager.shutdown_kernel()
         del widget
 
     def test_construction_with_startup_code_adds_to_banner_and_executes(self):
         widget = InProcessJupyterConsole(startup_code="x = 1")
         self.assertEqual(1, widget.kernel_manager.kernel.shell.user_ns['x'])
         self._pre_delete_console_cleanup(widget)
+        widget.kernel_manager.shutdown_kernel()
         del widget
 
     def _pre_delete_console_cleanup(self, console):


### PR DESCRIPTION
**Description of work.**

Adds shutdown code to the jupyter kernel in the workbench test so the kernel shuts down before the garbage collector kicks in.

**To test:**

I ran the whole test suite many times and before this the workbench jupyter test would fall over randomly. With this fix it seems more stable.

*There is no associated issue.*

*This does not require release notes* because **it is a test fix.**

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
