### PR TITLE
Fix unhandled exceptions on plots with one line with errorbar caps

### DIFF
--- a/qt/applications/workbench/workbench/plotting/test/test_figureinteraction.py
+++ b/qt/applications/workbench/workbench/plotting/test/test_figureinteraction.py
@@ -164,6 +164,7 @@ class FigureInteractionTest(unittest.TestCase):
         mouse_event = self._create_mock_right_click()
         mouse_event.inaxes.get_xlim.return_value = (1, 2)
         mouse_event.inaxes.get_ylim.return_value = (1, 2)
+        mouse_event.inaxes.lines = []
         mocked_figure_type.return_value = FigureType.Line
 
         # Expect a call to QMenu() for the outer menu followed by two more calls


### PR DESCRIPTION
**To test:**
Run this script:
```
from mantid.simpleapi import *
import matplotlib.pyplot as plt

ws = CreateSampleWorkspace()
fig, axes = plt.subplots(edgecolor='#ffffff', num='ws-1', subplot_kw={'projection': 'mantid'})
axes.errorbar(ws, capsize=1.0, color='#1f77b4', elinewidth=1.0, label='ws: spec 1', linewidth=1.0, specNum=1)
axes.set_title('ws')
axes.set_xlabel('Time-of-flight ($\mu s$)')
axes.set_ylabel('Counts')
axes.set_ylim([-0.2, 10.8])
axes.legend().set_draggable(True)

fig.show()
```

In the plot produced, right-click the figure and check that you can toggle errorbars and change the normalisation.

*There is no associated issue.*

No release notes because the bug wasn't present in the last release.

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
