### PR TITLE
Make python targets runnable on MSVC IDE

### DIFF
--- a/buildconfig/CMake/Bootstrap.cmake
+++ b/buildconfig/CMake/Bootstrap.cmake
@@ -113,6 +113,7 @@ if(MSVC)
         "The location of the pythonw executable. This suppresses the new terminal window on startup"
         FORCE
   )
+
   set(THIRD_PARTY_BIN
       "${THIRD_PARTY_DIR}/bin;${THIRD_PARTY_DIR}/lib/qt4/bin;${THIRD_PARTY_DIR}/lib/qt5/bin;${MSVC_PYTHON_EXECUTABLE_DIR}"
   )

--- a/dev-docs/source/SystemTests.rst
+++ b/dev-docs/source/SystemTests.rst
@@ -201,6 +201,22 @@ fixed when running CMake, e.g.
    cd build
    systemtest
 
+
+Selecting Tests to Run From IDE
+-------------------------------
+
+System tests can be ran from the MSVC IDE using the ``SystemTests`` target,
+which behaves in a similar way to unit test targets. One key advantage is
+that it allows you to start Mantid in a debug environment rather than attach
+to one midway through.
+
+To select an individual test, or range of tests, go to the ``SystemTests``
+properties, go to ```Command Arguments``` and append flags as appropriate.
+
+For example, adding ``-R ISIS`` will run any tests which match the regular
+expression ``ISIS``.
+
+
 Selecting Tests To Run
 ----------------------
 
@@ -216,6 +232,7 @@ e.g.
    systemtest -C <cfg> -R SNS
 
 would run all of the tests whose name contains SNS.
+
 
 Running the tests on multiple cores
 -----------------------------------

--- a/qt/applications/workbench/CMakeLists.txt
+++ b/qt/applications/workbench/CMakeLists.txt
@@ -12,6 +12,12 @@ add_python_package(workbench
   INSTALL_BIN_DIR "${WORKBENCH_BIN_DIR}"
 )
 
+set_target_properties(workbench PROPERTIES
+                      VS_DEBUGGER_COMMAND $<$<BOOL:${WIN32}>:${PYTHON_EXECUTABLE}>
+                      VS_DEBUGGER_COMMAND_ARGUMENTS $<$<BOOL:${WIN32}>:${MSVC_BIN_DIR}/workbench-script.pyw>
+                      VS_DEBUGGER_ENVIRONMENT $<$<BOOL:${WIN32}>:${MSVC_IDE_ENV}>
+                      )
+
 set(_images_qrc_file ${CMAKE_CURRENT_LIST_DIR}/resources.qrc)
 
 if (WIN32)


### PR DESCRIPTION
**Description of work.**
As part of the TBB work I made targets for system tests and workbench runnable

**To test:**
- On MSVC
- Re-generate the CMake project
- Check that a `SystemTest` target appears
- Set both the `SystemTest` then `Workbench` target to startup and hit run in the IDE, they should launch (like MantidPlot)

*There is no associated issue.*


---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
