### PR TITLE
Wrap mantiddoc Sphinx logger usage for version 1.2

### DIFF
--- a/docs/sphinxext/mantiddoc/__init__.py
+++ b/docs/sphinxext/mantiddoc/__init__.py
@@ -4,3 +4,20 @@
 #     NScD Oak Ridge National Laboratory, European Spallation Source
 #     & Institut Laue - Langevin
 # SPDX - License - Identifier: GPL - 3.0 +
+
+
+def get_logger(name, app):
+    """
+    Compatability layer between Sphinx v1.2 & latest
+    to wrap changes in logging
+    :param name: The name of the logger (unused in Sphinx < v2)
+    :param app: The application object (unused in Sphinx > v2)
+    :return:
+    """
+    try:
+        # Sphinx > v2
+        from sphinx.util import logging
+
+        return logging.getLogger(name)
+    except ImportError:
+        return app

--- a/docs/sphinxext/mantiddoc/directives/__init__.py
+++ b/docs/sphinxext/mantiddoc/directives/__init__.py
@@ -23,6 +23,7 @@ import mantiddoc.directives.relatedalgorithms
 import mantiddoc.directives.sourcelink
 import mantiddoc.directives.summary
 
+
 def setup(app):
     """
     Setup the directives when the extension is activated

--- a/docs/sphinxext/mantiddoc/directives/base.py
+++ b/docs/sphinxext/mantiddoc/directives/base.py
@@ -5,14 +5,15 @@
 #     & Institut Laue - Langevin
 # SPDX - License - Identifier: GPL - 3.0 +
 from docutils import statemachine
-from docutils.parsers.rst import Directive #pylint: disable=unused-import
+from docutils.parsers.rst import Directive  # pylint: disable=unused-import
 import re
-from sphinx.util import logging
+from mantiddoc import get_logger
 
 ALG_DOCNAME_RE = re.compile(r'^([A-Z][a-zA-Z0-9]+)-v([0-9][0-9]*)$')
 FIT_DOCNAME_RE = re.compile(r'^([A-Z][a-zA-Z0-9]+)$')
 
-#----------------------------------------------------------------------------------------
+
+# ----------------------------------------------------------------------------------------
 def algorithm_name_and_version(docname):
     """
     Returns the name and version of an algorithm based on the name of the
@@ -36,7 +37,8 @@ def algorithm_name_and_version(docname):
     if is_alg:
         match = ALG_DOCNAME_RE.match(docname)
         if not match or len(match.groups()) != 2:
-            raise RuntimeError("Document filename '%s.rst' does not match the expected format: AlgorithmName-vX.rst" % docname)
+            raise RuntimeError(
+                "Document filename '%s.rst' does not match the expected format: AlgorithmName-vX.rst" % docname)
 
         grps = match.groups()
         return (str(grps[0]), int(grps[1]))
@@ -45,16 +47,17 @@ def algorithm_name_and_version(docname):
     if is_fit:
         match = FIT_DOCNAME_RE.match(docname)
         if not match or len(match.groups()) != 1:
-            raise RuntimeError("Document filename '%s.rst' does not match the expected format: FitFunctionName.rst" % docname)
+            raise RuntimeError(
+                "Document filename '%s.rst' does not match the expected format: FitFunctionName.rst" % docname)
 
         return (str(match.groups()[0]), None)
 
     # fail now
     raise RuntimeError("Failed to find name from document filename ")
 
-#----------------------------------------------------------------------------------------
-class BaseDirective(Directive):
 
+# ----------------------------------------------------------------------------------------
+class BaseDirective(Directive):
     """
     Contains shared functionality for Mantid custom directives.
     """
@@ -101,13 +104,13 @@ class BaseDirective(Directive):
         Returns:
           str: ReST formatted header with algorithm_name as content.
         """
-        level_dict = {1:"=", 2:"-", 3:"#", 4:"^"}
+        level_dict = {1: "=", 2: "-", 3: "#", 4: "^"}
 
         if pagetitle:
             level = 1
         if level not in level_dict:
             env = self.state.document.settings.env
-            env.app.warn('base.make_header - Did not understand level ' +str(level))
+            env.app.warn('base.make_header - Did not understand level ' + str(level))
             level = 2
 
         line = "\n" + level_dict[level] * (len(name)) + "\n"
@@ -117,7 +120,8 @@ class BaseDirective(Directive):
         else:
             return name + line
 
-#----------------------------------------------------------------------------------------
+
+# ----------------------------------------------------------------------------------------
 
 class AlgorithmBaseDirective(BaseDirective):
     """
@@ -162,7 +166,7 @@ class AlgorithmBaseDirective(BaseDirective):
 
         name, version = self.algorithm_name(), self.algorithm_version()
         msg = ""
-        if version is None: # it is a fit function
+        if version is None:  # it is a fit function
             if name in FunctionFactory.getFunctionNames():
                 return ""
             else:
@@ -175,7 +179,7 @@ class AlgorithmBaseDirective(BaseDirective):
 
         # warn the user
         if len(msg) > 0:
-            logger = logging.getLogger(__name__)
+            logger = get_logger(__name__, self.state.document.settings.env.app)
             logger.verbose(msg)
         return msg
 

--- a/docs/sphinxext/mantiddoc/doctest.py
+++ b/docs/sphinxext/mantiddoc/doctest.py
@@ -130,11 +130,12 @@
     0 failures in cleanup code
 """
 import re
+
 try:
     import lxml.etree as ElementTree
 except ImportError:
     import xml.etree.ElementTree as ElementTree
-from sphinx.util import logging
+from mantiddoc import get_logger
 
 # Name of file produced by doctest target. It is assumed that it is created
 # in app.outdir
@@ -148,15 +149,15 @@ TEST_FAILURE_TYPE = "UsageFailure"
 PACKAGE_NAME = "docs"
 
 # No Test found error message
-NO_TEST_ERROR = "\n*************************************************\n"\
-                "* No test code has been found in given file(s). * \n"\
+NO_TEST_ERROR = "\n*************************************************\n" \
+                "* No test code has been found in given file(s). * \n" \
                 "*************************************************"
 
-#-------------------------------------------------------------------------------
+# -------------------------------------------------------------------------------
 # Define parts of lines that denote a document
 DOCTEST_DOCUMENT_BEGIN = "Document:"
 DOCTEST_SUMMARY_TITLE = "Doctest summary"
-FAILURE_MARKER = "*"*70
+FAILURE_MARKER = "*" * 70
 
 # Regexes
 ALLPASS_TEST_NAMES_RE = re.compile(r"^\s+(\d+) tests in (.+)$")
@@ -167,7 +168,8 @@ TEST_FAILED_END_RE = re.compile(r"\*\*\*Test Failed\*\*\* (\d+) failures.")
 FAILURE_LOC_RE = re.compile(r"^File \"(.+)\",\s+line\s+(\d+),\s+in\s+(\S+)(\s\((setup|cleanup) code\))?$")
 MIX_FAIL_RE = re.compile(r'^\s+(\d+)\s+of\s+(\d+)\s+in\s+(\w+)$')
 
-#-------------------------------------------------------------------------------
+
+# -------------------------------------------------------------------------------
 class TestSuiteReport(object):
 
     def __init__(self, name, cases, package=None):
@@ -193,7 +195,8 @@ class TestSuiteReport(object):
     def npassed(self):
         return self.ntests - self.nfailed
 
-#-------------------------------------------------------------------------------
+
+# -------------------------------------------------------------------------------
 class TestCaseReport(object):
 
     def __init__(self, classname, name, failure_descr):
@@ -221,14 +224,15 @@ class TestCaseReport(object):
     def iscleanup(self):
         return "cleanup code" in self.failure_descr
 
-#-------------------------------------------------------------------------------
+
+# -------------------------------------------------------------------------------
 class DocTestOutputParser(object):
     """
     Process a doctest output file and convert it
     to a different format
     """
 
-    def __init__(self, doctest_output, isfile = True):
+    def __init__(self, doctest_output, isfile=True):
         """
         Parses the given doctest output
 
@@ -239,7 +243,7 @@ class DocTestOutputParser(object):
                           as a filename
         """
         if isfile:
-            with open(doctest_output,'r') as results:
+            with open(doctest_output, 'r') as results:
                 self.testsuite = self.__parse(results)
         else:
             self.testsuite = self.__parse(doctest_output.splitlines())
@@ -293,7 +297,7 @@ class DocTestOutputParser(object):
                 document_txt = [line]
                 in_doc = True
                 continue
-            if line.startswith(DOCTEST_SUMMARY_TITLE): # end of tests
+            if line.startswith(DOCTEST_SUMMARY_TITLE):  # end of tests
                 in_doc = False
                 if document_txt:
                     cases.extend(self.__parse_document(document_txt))
@@ -318,10 +322,10 @@ class DocTestOutputParser(object):
         """
         fullname = self.__extract_fullname(results[0])
         if not results[1].startswith("-"):
-            raise ValueError("Invalid second line of output: '%s'. "\
+            raise ValueError("Invalid second line of output: '%s'. " \
                              "Expected a title underline."
                              % text[1])
-        results = results[2:] # trim off top two lines of header information
+        results = results[2:]  # trim off top two lines of header information
         maintests, cleanup = self.__split_on_cleanup(results)
         overall_success = not maintests[0] == FAILURE_MARKER
 
@@ -361,13 +365,13 @@ class DocTestOutputParser(object):
         summaryline_idx = None
         for idx, line in enumerate(results):
             if TEST_PASSED_END_RE.match(line) or \
-               TEST_FAILED_END_RE.match(line):
+                    TEST_FAILED_END_RE.match(line):
                 summaryline_idx = idx
                 break
 
         if summaryline_idx:
             # +1 includes the summary line itself
-            return (results[:summaryline_idx+1], results[summaryline_idx+1:])
+            return (results[:summaryline_idx + 1], results[summaryline_idx + 1:])
         else:
             return results
 
@@ -389,7 +393,7 @@ class DocTestOutputParser(object):
         classname = self.__create_classname(fullname)
         nitems = int(match.group(1))
         cases = []
-        for line in results[1:1+nitems]:
+        for line in results[1:1 + nitems]:
             match = ALLPASS_TEST_NAMES_RE.match(line)
             if not match:
                 raise ValueError("Unexpected information line in "
@@ -397,7 +401,7 @@ class DocTestOutputParser(object):
             ntests, name = int(match.group(1)), match.group(2)
             for idx in range(ntests):
                 cases.append(TestCaseReport(classname, name, failure_descr=None))
-        #endfor
+        # endfor
         return cases
 
     def __parse_failures(self, fullname, results):
@@ -433,7 +437,7 @@ class DocTestOutputParser(object):
         nmarkers = len(fail_markers)
         failcases = []
         for i in range(0, nmarkers - 1):
-            start, end = fail_markers[i] + 1, fail_markers[i+1]
+            start, end = fail_markers[i] + 1, fail_markers[i + 1]
             failcases.append(self.__create_failure_report(classname,
                                                           results[start:end]))
 
@@ -449,7 +453,7 @@ class DocTestOutputParser(object):
 
         # The final puzzle piece is that some tests that have failed
         # may have the same names as those that have passed.
-        for line in results[end+1:]:
+        for line in results[end + 1:]:
             match = MIX_FAIL_RE.match(line)
             if not match:
                 continue
@@ -511,13 +515,14 @@ class DocTestOutputParser(object):
                 for maincase in passes:
                     if case.name == maincase.name:
                         maincase.failure_descr = case.failure_descr
-                        break # only do the first match
+                        break  # only do the first match
             else:
                 merged.append(case)
 
         return merged
 
-#-------------------------------------------------------------------------------
+
+# -------------------------------------------------------------------------------
 
 def doctest_to_xunit(app, exception):
     """
@@ -530,7 +535,7 @@ def doctest_to_xunit(app, exception):
       exception: (Exception): If an exception was raised then it is given here.
                               It is simply re-raised if an error occurred
     """
-    logger = logging.getLogger(__name__)
+    logger = get_logger(__name__, app)
 
     if exception:
         import traceback
@@ -549,7 +554,8 @@ def doctest_to_xunit(app, exception):
 
     doctests.as_xunit(xunit_file)
 
-#-------------------------------------------------------------------------------
+
+# -------------------------------------------------------------------------------
 
 def setup(app):
     """


### PR DESCRIPTION
**Description of work.**

The sphinx.util.logging framework was not available
in version 1.2 that is currently used by RHEL 7. This wraps
the calls and chooses an appropriate implementation.

This is currently broken on master. The builds on the #28289  that changed this decided not to build the documentation for some reason so this slipped through.

**To test:**

RHEL7 & Ubuntu both build the docs so both builds should pass.

*There is no associated issue.*

*This does not require release notes* because **it is an internal change.**

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
