### PR TITLE
reduce a error log message to warning when changing colour bar to log

### DIFF
--- a/Framework/PythonInterface/mantid/plots/datafunctions.py
+++ b/Framework/PythonInterface/mantid/plots/datafunctions.py
@@ -1015,11 +1015,11 @@ def update_colorbar_scale(figure, image, scale, vmin, vmax):
     """
     if vmin <= 0 and scale == LogNorm:
         vmin = 0.0001  # Avoid 0 log scale error
-        mantid.kernel.logger.error("Scale is set to logarithmic so non-positive min value has been changed to 0.0001.")
+        mantid.kernel.logger.warning("Scale is set to logarithmic so non-positive min value has been changed to 0.0001.")
 
     if vmax <= 0 and scale == LogNorm:
         vmax = 1  # Avoid 0 log scale error
-        mantid.kernel.logger.error("Scale is set to logarithmic so non-positive max value has been changed to 1.")
+        mantid.kernel.logger.warning("Scale is set to logarithmic so non-positive max value has been changed to 1.")
 
     image.set_norm(scale(vmin=vmin, vmax=vmax))
     if image.colorbar:


### PR DESCRIPTION
**Description of work.**

Just reduced a  couple of log messages from error to warning.

**To test:**

1. Open workbench
1. Load MAR11060
1. Plot -> colour fill
1. Right clight colour bar -> Log
1. You will get a log message of ```Scale is set to logarithmic so non-positive min value has been changed to 0.0001.```
1. It should now be orange, and you should not get a notification.


*There is no associated issue.*

*This does not require release notes* because **it is a very minor log reclassification**


---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
