### PR TITLE
Remove Python 2 dependencies from developer packages 

### DIFF
--- a/buildconfig/dev-packages/deb/mantid-developer/ns-control
+++ b/buildconfig/dev-packages/deb/mantid-developer/ns-control
@@ -3,15 +3,17 @@ Priority: optional
 Standards-Version: 3.9.2
 
 Package: mantid-developer
-Version: 1.6
+Version: 2.0
 Maintainer: Mantid Project <mantid-tech@mantidproject.org>
 Priority: optional
 Architecture: all
 Depends: git,
   g++,
   clang-format-6.0,
-  cmake-qt-gui(>=3.5),
-  ninja-build,
+  cmake-qt-gui(>=3.13),
+  dvipng,
+  doxygen,
+  graphviz,
   libtbb-dev,
   libgoogle-perftools-dev,
   libboost-all-dev,
@@ -38,34 +40,15 @@ Depends: git,
   libqt5x11extras5-dev,
   libqt5opengl5-dev,
   libqt5scintilla2-dev,
-  libpython-dev,
-  python-setuptools,
-  python-numpy,
-  python-scipy,
-  python-qt4-dev,
-  python-qt4-dbg,
-  pyqt5-dev,
-  pyqt5-dev-tools,
-  python-dateutil,
-  python-h5py,
-  python-matplotlib,
-  python-mock,
-  python-psutil,
-  python-qtpy,
-  python-requests,
-  python-sphinx,
-  python-sphinx-bootstrap-theme,
-  python-yaml,
-  ipython-qtconsole (>=1.2.0),
-  texlive,
-  texlive-latex-extra,
-  dvipng,
-  graphviz,
-  doxygen,
+  libpython3-dev,
+  ninja-build,
   python3-setuptools,
   python3-sip-dev,
   python3-pyqt4,
+  python-qt4-dev,
   python3-pyqt5,
+  pyqt5-dev,
+  pyqt5-dev-tools,
   python3-qtpy,
   python3-numpy,
   python3-scipy,
@@ -79,7 +62,9 @@ Depends: git,
   python3-psutil,
   python3-requests,
   python3-toml,
-  python3-yaml
+  python3-yaml,
+  texlive,
+  texlive-latex-extra
 Description: Installs all packages required for a Mantid developer
  A metapackage which requires all the dependencies and tools that are
  required for Mantid development. It works for Ubuntu 18.04.

--- a/buildconfig/dev-packages/rpm/mantid-developer/mantid-developer.spec
+++ b/buildconfig/dev-packages/rpm/mantid-developer/mantid-developer.spec
@@ -1,11 +1,5 @@
-%if 0%{?fedora} || 0%{?rhel} >= 7
-  %global with_python3 1
-%else
-  %global with_python3 0
-%endif
-
 Name:           mantid-developer
-Version:        1.39
+Version:        1.40
 Release:        1%{?dist}
 Summary:        Meta Package to install dependencies for Mantid Development
 
@@ -18,9 +12,8 @@ BuildRoot:      %{_tmppath}/%{name}-%{version}-%{release}-root-%(%{__id_u} -n)
 %{?rhel:Requires: epel-release}
 %{?fedora:Requires: cmake-gui}
 %{?rhel:Requires: cmake3-gui}
-%{?fedora:Requires: python2-qtconsole}
 Requires: boost169-devel
-Requires: boost169-python2-devel
+Requires: boost169-python3-devel
 Requires: clang
 Requires: doxygen
 Requires: dvipng
@@ -43,25 +36,27 @@ Requires: ninja-build
 Requires: numpy
 Requires: OCE-devel
 Requires: openssl-devel
+Requires: python%{python3_pkgversion}-dateutil
+Requires: python%{python3_pkgversion}-h5py
+Requires: python%{python3_pkgversion}-ipython
+Requires: python%{python3_pkgversion}-ipython-gui
+Requires: python%{python3_pkgversion}-matplotlib-qt5
+Requires: python%{python3_pkgversion}-matplotlib-qt4
+Requires: python%{python3_pkgversion}-numpy
+Requires: python%{python3_pkgversion}-psutil
+%{?fedora:Requires: python%{python3_pkgversion}-PyQt4-devel}
+Requires: python%{python3_pkgversion}-PyYAML
+Requires: python%{python3_pkgversion}-qt5-devel
+%{?fedora:Requires: python%{python3_pkgversion}-qtconsole}
+Requires: python%{python3_pkgversion}-QtPy
+Requires: python%{python3_pkgversion}-requests
+Requires: python%{python3_pkgversion}-scipy
+Requires: python%{python3_pkgversion}-setuptools
+Requires: python%{python3_pkgversion}-sphinx
+Requires: python%{python3_pkgversion}-sphinx-bootstrap-theme
+Requires: python%{python3_pkgversion}-toml
+Requires: python%{python3_pkgversion}-PyYAML
 Requires: poco-devel >= 1.4.6
-Requires: PyQt4-devel
-Requires: python2-h5py >= 2.3.1
-Requires: python2-matplotlib
-Requires: python2-matplotlib-qt4
-Requires: python2-mock
-Requires: python2-psutil
-Requires: python2-qt5-devel
-%{?fedora:Requires: python2-qtconsole}
-Requires: python2-sphinx-bootstrap-theme
-Requires: python-devel
-Requires: python-enum34
-Requires: python-ipython >= 1.1
-Requires: python-pip
-Requires: python-QtPy
-Requires: python-requests
-Requires: python-setuptools
-Requires: python-sphinx
-Requires: PyYAML
 Requires: qscintilla-devel
 Requires: qscintilla-qt5-devel
 Requires: qt5-qtbase-devel
@@ -89,30 +84,6 @@ Requires: texlive-was
 Requires: tex-preview
 Requires: zeromq
 
-%if %{with_python3}
-Requires: boost169-python3-devel
-Requires: python%{python3_pkgversion}-dateutil
-Requires: python%{python3_pkgversion}-h5py
-Requires: python%{python3_pkgversion}-ipython
-Requires: python%{python3_pkgversion}-ipython-gui
-Requires: python%{python3_pkgversion}-matplotlib-qt5
-Requires: python%{python3_pkgversion}-matplotlib-qt4
-Requires: python%{python3_pkgversion}-numpy
-Requires: python%{python3_pkgversion}-psutil
-%{?fedora:Requires: python%{python3_pkgversion}-PyQt4-devel}
-Requires: python%{python3_pkgversion}-PyYAML
-Requires: python%{python3_pkgversion}-qt5-devel
-%{?fedora:Requires: python%{python3_pkgversion}-qtconsole}
-Requires: python%{python3_pkgversion}-QtPy
-Requires: python%{python3_pkgversion}-requests
-Requires: python%{python3_pkgversion}-scipy
-Requires: python%{python3_pkgversion}-setuptools
-Requires: python%{python3_pkgversion}-sphinx
-Requires: python%{python3_pkgversion}-sphinx-bootstrap-theme
-Requires: python%{python3_pkgversion}-toml
-Requires: python%{python3_pkgversion}-PyYAML
-%endif
-
 BuildArch: noarch
 
 %description
@@ -134,11 +105,14 @@ required for Mantid development.
 %files
 
 %changelog
+* Mon Mar 16 2020 Martyn Gigg <martyn.gigg@stfc.ac.uk>
+- Remove Python 2 dependencies
+
 * Mon Jan 28 2020 David Fairbrother <david.fairbrother@stfc.ac.uk>
 - Added Python TOML library
 
 * Fri Jan 24 2020 Martyn Gigg <martyn.gigg@stfc.ac.uk>
-- Att matplotlib backend for Python 3
+- Add matplotlib backend for Python 3
 
 * Thu Jan 16 2020 Martyn Gigg <martyn.gigg@stfc.ac.uk>
 - Merge fedora and rhel python 3 packages using python3_pkgversion

--- a/buildconfig/dev-packages/rpm/mantid-developer/mantid-developer.spec
+++ b/buildconfig/dev-packages/rpm/mantid-developer/mantid-developer.spec
@@ -1,5 +1,5 @@
 Name:           mantid-developer
-Version:        1.40
+Version:        2.0
 Release:        1%{?dist}
 Summary:        Meta Package to install dependencies for Mantid Development
 


### PR DESCRIPTION
**Description of work.**

Removes the Python 2 packages from the rpm/deb mantid-developer packages.

**To test:**

Code review.
To be thorough, build the packages locally and test they install correctly.

Refs #27722

*This does not require release notes* because **it is an internal change.**

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
