### PR TITLE
Make incremental builds work for docs-qthelp target

### DIFF
--- a/docs/CMakeLists.txt
+++ b/docs/CMakeLists.txt
@@ -28,7 +28,9 @@ if(QT_QCOLLECTIONGENERATOR_EXECUTABLE)
   set(BUILDER qthelp)
   configure_file(runsphinx.py.in runsphinx_qthelp.py @ONLY)
 
-  add_custom_command(OUTPUT qthelp/MantidProject.qhcp qthelp/MantidProject.qhp
+  set_source_files_properties(dummyoutput_alwaysrun PROPERTIES SYMBOLIC 1)
+
+  add_custom_command(OUTPUT qthelp/MantidProject.qhcp qthelp/MantidProject.qhp dummyoutput_alwaysrun
                      COMMAND ${DOCS_RUNNER_EXE} -xq runsphinx_qthelp.py
                      DEPENDS Framework AllQt4
                              ${CMAKE_CURRENT_BINARY_DIR}/runsphinx_qthelp.py


### PR DESCRIPTION
**Description of work.**

cmake add_custom_command is only run if any of the listed outputs is missing
or if any of the dependencies are out of date. If any of the documentation
.rst files is changed this didn't cause the custom command to run.
I've changed this so the command always runs by adding an extra dummy output
file that doesn't ever get created. The sphinx builder has some incremental
build functionality inside it so this will identify whether any .rst files
have changed
Note - I also had to set the cmake source file property to SYMBOLIC to avoid the
following Visual Studio warning which was added in Visual Studio 2019 (v16.4):

warning MSB8065: Custom build for item XXXX succeeded, but specified output
"c:\mantid\build\docs\dummyoutput_alwaysrun" has not been created. This may cause
 incremental build to work incorrectly.

**To test:**

1. Build the docs-qthelp target
2. Change one of the .rst files in docs\source\ eg algorithms/Abins-v1.rst
3. Build the docs-qthelp target again and observe that the sphinx builder does some work:

6>Running Sphinx v1.6.7
6>CUSTOMBUILD : warning : sphinx.ext.pngmath has been deprecated. Please use sphinx.ext.imgmath instead.
6>loading pickled environment... done
6>building [mo]: targets for 0 po files that are out of date
**6>building [qthelp]: targets for 1 source files that are out of date**
6>updating environment: 0 added, 9 changed, 0 removed
6>reading sources... [ 11%] algorithms/Abins-v1
6>reading sources... [ 22%] api/python/mantidplot/ArrowMarker
6>reading sources... [ 33%] api/python/mantidplot/GraphOptions
6>reading sources... [ 44%] api/python/mantidplot/ImageMarker
6>reading sources... [ 55%] api/python/mantidplot/ImageSymbol
6>reading sources... [ 66%] api/python/mantidplot/InstrumentView
6>reading sources... [ 77%] api/python/mantidplot/Layer
6>reading sources... [ 88%] api/python/mantidplot/PlotSymbol
6>reading sources... [100%] api/python/mantidplot/Qt

Due to some errors related to C++ enumerated types in the Sphinx build you will see in step 3) that more than just the file you edited is rebuilt. However the main point is that Sphinx does some work at all - before this change it would do nothing on step 3

Fixes #28385 .

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
-->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
