### PR TITLE
Improve Outputs When Focusing in Eng Diff 2 GUI

### DIFF
--- a/docs/source/interfaces/Engineering Diffraction.rst
+++ b/docs/source/interfaces/Engineering Diffraction.rst
@@ -121,7 +121,8 @@ a plot for each bank and cropped focusing generates a plot for the single bank o
 Clicking the focus button will begin the focusing algorithm for the selected run files. The button and plotting checkbox
 will be disabled until the fitting algorithm is complete.
 
-The focused output files are saved in NeXus, GSS, and raw XYE format to:
+The focused output files are saved in NeXus, GSS, and TOPAS format. The process will also output a CSV file containing
+all numerical sample logs. All of these files are saved to:
 
 `<CHOSEN_OUTPUT_DIRECTORY>/Focus/`
 

--- a/docs/source/release/v5.1.0/diffraction.rst
+++ b/docs/source/release/v5.1.0/diffraction.rst
@@ -14,6 +14,10 @@ Powder Diffraction
 
 Engineering Diffraction
 -----------------------
+Improvements
+^^^^^^^^^^^^
+- TOPAS files (`.abc`) have replaced the `.dat` files generated when focusing using the GUI.
+- Focusing with the GUI will now generate a CSV containing the averaged values of all numerical sample logs.
 
 Single Crystal Diffraction
 --------------------------

--- a/scripts/Engineering/gui/engineering_diffraction/tabs/focus/model.py
+++ b/scripts/Engineering/gui/engineering_diffraction/tabs/focus/model.py
@@ -127,8 +127,8 @@ class FocusModel(object):
                                                  rb_num)
         self._save_focused_output_files_as_gss(instrument, sample_path, bank, sample_workspace,
                                                rb_num)
-        self._save_focused_output_files_as_xye(instrument, sample_path, bank, sample_workspace,
-                                               rb_num)
+        self._save_focused_output_files_as_topas_xye(instrument, sample_path, bank, sample_workspace,
+                                                     rb_num)
 
     def _save_focused_output_files_as_gss(self, instrument, sample_path, bank, sample_workspace,
                                           rb_num):
@@ -154,19 +154,23 @@ class FocusModel(object):
                 self._generate_output_file_name(instrument, sample_path, bank, ".nxs"))
             SaveNexus(InputWorkspace=sample_workspace, Filename=nexus_output_path)
 
-    def _save_focused_output_files_as_xye(self, instrument, sample_path, bank, sample_workspace,
-                                          rb_num):
+    def _save_focused_output_files_as_topas_xye(self, instrument, sample_path, bank,
+                                                sample_workspace, rb_num):
         xye_output_path = path.join(
             path_handling.get_output_path(), "Focus",
-            self._generate_output_file_name(instrument, sample_path, bank, ".dat"))
-        SaveFocusedXYE(InputWorkspace=sample_workspace, Filename=xye_output_path, SplitFiles=False)
+            self._generate_output_file_name(instrument, sample_path, bank, ".abc"))
+        SaveFocusedXYE(InputWorkspace=sample_workspace,
+                       Filename=xye_output_path,
+                       SplitFiles=False,
+                       Format="TOPAS")
         if rb_num:
             xye_output_path = path.join(
                 path_handling.get_output_path(), "User", rb_num, "Focus",
-                self._generate_output_file_name(instrument, sample_path, bank, ".dat"))
+                self._generate_output_file_name(instrument, sample_path, bank, ".abc"))
             SaveFocusedXYE(InputWorkspace=sample_workspace,
                            Filename=xye_output_path,
-                           SplitFiles=False)
+                           SplitFiles=False,
+                           Format="TOPAS")
 
     @staticmethod
     def _generate_output_file_name(instrument, sample_path, bank, suffix):

--- a/scripts/Engineering/gui/engineering_diffraction/tabs/focus/model.py
+++ b/scripts/Engineering/gui/engineering_diffraction/tabs/focus/model.py
@@ -178,8 +178,8 @@ class FocusModel(object):
     @staticmethod
     def _output_sample_logs(instrument, run_number, workspace, rb_num):
         def write_to_file():
-            with open(output_path, "w", newline="") as f:
-                writer = csv.writer(f, ["Sample Log", "Avg Value"])
+            with open(output_path, "w", newline="") as logfile:
+                writer = csv.writer(logfile, ["Sample Log", "Avg Value"])
                 for log in output_dict:
                     writer.writerow([log, output_dict[log]])
 

--- a/scripts/Engineering/gui/engineering_diffraction/tabs/focus/model.py
+++ b/scripts/Engineering/gui/engineering_diffraction/tabs/focus/model.py
@@ -193,15 +193,16 @@ class FocusModel(object):
             except ValueError:
                 logger.information(f"Could not convert {name} to a numerical value. It will not be included in the "
                                    f"sample logs output file.")
-
-        makedirs(path.join(path_handling.get_output_path(), "Focus"))
-        output_path = path.join(path_handling.get_output_path(), "Focus",
-                                (instrument + "_" + run_number + "_sample_logs.csv"))
+        focus_dir = path.join(path_handling.get_output_path(), "Focus")
+        if not path.exists(focus_dir):
+            makedirs(focus_dir)
+        output_path = path.join(focus_dir, (instrument + "_" + run_number + "_sample_logs.csv"))
         write_to_file()
         if rb_num:
-            makedirs(path.join(path_handling.get_output_path(), "User", rb_num, "Focus"))
-            output_path = path.join(path_handling.get_output_path(), "User", rb_num, "Focus",
-                                    (instrument + "_" + run_number + "_sample_logs.csv"))
+            focus_user_dir = path.join(path_handling.get_output_path(), "User", rb_num, "Focus")
+            if not path.exists(focus_user_dir):
+                makedirs(focus_user_dir)
+            output_path = path.join(focus_user_dir, (instrument + "_" + run_number + "_sample_logs.csv"))
             write_to_file()
 
     @staticmethod

--- a/scripts/Engineering/gui/engineering_diffraction/tabs/focus/test/test_focus_model.py
+++ b/scripts/Engineering/gui/engineering_diffraction/tabs/focus/test/test_focus_model.py
@@ -32,11 +32,12 @@ class FocusModelTest(unittest.TestCase):
         self.model.focus_run("307593", ["1", "2"], False, "ENGINX", "0", None)
         self.assertEqual(load.call_count, 0)
 
+    @patch(file_path + ".FocusModel._output_sample_logs")
     @patch(file_path + ".Ads")
     @patch(file_path + ".FocusModel._save_output")
     @patch(file_path + ".FocusModel._run_focus")
     @patch(file_path + ".path_handling.load_workspace")
-    def test_focus_run_for_each_bank(self, load_focus, run_focus, output, ads):
+    def test_focus_run_for_each_bank(self, load_focus, run_focus, output, ads, logs):
         ads.retrieve.return_value = "test_wsp"
         banks = ["1", "2"]
         load_focus.return_value = "mocked_sample"
@@ -48,11 +49,12 @@ class FocusModelTest(unittest.TestCase):
                                      "305761_" + model.FOCUSED_OUTPUT_WORKSPACE_NAME + banks[-1],
                                      "test_wsp", "test_wsp", banks[-1], None)
 
+    @patch(file_path + ".FocusModel._output_sample_logs")
     @patch(file_path + ".Ads")
     @patch(file_path + ".FocusModel._save_output")
     @patch(file_path + ".FocusModel._run_focus")
     @patch(file_path + ".path_handling.load_workspace")
-    def test_focus_run_for_custom_spectra(self, load_focus, run_focus, output, ads):
+    def test_focus_run_for_custom_spectra(self, load_focus, run_focus, output, ads, logs):
         ads.retrieve.return_value = "test_wsp"
         spectra = "20-50"
         load_focus.return_value = "mocked_sample"
@@ -64,6 +66,7 @@ class FocusModelTest(unittest.TestCase):
                                      "305761_" + model.FOCUSED_OUTPUT_WORKSPACE_NAME + "cropped",
                                      "test_wsp", "test_wsp", None, None, spectra)
 
+    @patch(file_path + ".FocusModel._output_sample_logs")
     @patch(file_path + ".Ads")
     @patch(file_path + ".FocusModel._save_output")
     @patch(file_path + ".FocusModel._plot_focused_workspaces")
@@ -71,7 +74,7 @@ class FocusModelTest(unittest.TestCase):
     @patch(file_path + ".path_handling.load_workspace")
     @patch(file_path + ".vanadium_corrections.fetch_correction_workspaces")
     def test_focus_plotted_when_checked(self, fetch_van, load_focus, run_focus, plot_focus, output,
-                                        ads):
+                                        ads, logs):
         ads.doesExist.return_value = True
         fetch_van.return_value = ("mocked_integ", "mocked_curves")
         banks = ["1", "2"]
@@ -81,6 +84,7 @@ class FocusModelTest(unittest.TestCase):
 
         self.assertEqual(1, plot_focus.call_count)
 
+    @patch(file_path + ".FocusModel._output_sample_logs")
     @patch(file_path + ".Ads")
     @patch(file_path + ".FocusModel._save_output")
     @patch(file_path + ".FocusModel._plot_focused_workspaces")
@@ -88,7 +92,7 @@ class FocusModelTest(unittest.TestCase):
     @patch(file_path + ".path_handling.load_workspace")
     @patch(file_path + ".vanadium_corrections.fetch_correction_workspaces")
     def test_focus_not_plotted_when_not_checked(self, fetch_van, load_focus, run_focus, plot_focus,
-                                                output, ads):
+                                                output, ads, logs):
         fetch_van.return_value = ("mocked_integ", "mocked_curves")
         banks = ["1", "2"]
         load_focus.return_value = "mocked_sample"


### PR DESCRIPTION
**Description of work.**
- Replaced the output of `.dat` files with TOPAS compatible `.abc` files. 
- Made focusing output averaged values of all numerical sample logs into a CSV file. 

**To test:**
1. Interfaces -> Diffraction -> Engineering Diffraction
1. Load or create a Calibration V#: 307521 CeO2#: 305738
2. Set an RB number
2. Focus some run files. Anything in the range 305500-308000 should work. 
3. Check that for each bank and run there is a `.gss`, `.nxs`, and `.abc` file. 
4. Check that for each run there is a sample log `.csv`


Fixes #28360 

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
