### PR TITLE
Eventlist: reserve capacity of the specified event type

### DIFF
--- a/Framework/DataObjects/src/EventList.cpp
+++ b/Framework/DataObjects/src/EventList.cpp
@@ -932,16 +932,27 @@ void EventList::clearData() { this->clear(false); }
  */
 void EventList::setMRU(EventWorkspaceMRU *newMRU) { mru = newMRU; }
 
-/** Reserve a certain number of entries in the (NOT-WEIGHTED) event list. Do NOT
- *call
- * on weighted events!
+/** Reserve a certain number of entries in  event list of the specified
+ *eventType
  *
  * Calls std::vector<>::reserve() in order to pre-allocate the length of the
  *event list vector.
  *
  * @param num :: number of events that will be in this EventList
  */
-void EventList::reserve(size_t num) { this->events.reserve(num); }
+void EventList::reserve(size_t num) {
+  switch (this->eventType) {
+  case TOF:
+    this->events.reserve(num);
+    break;
+  case WEIGHTED:
+    this->weightedEvents.reserve(num);
+    break;
+  case WEIGHTED_NOTIME:
+    this->weightedEventsNoTime.reserve(num);
+    break;
+  }
+}
 
 // ==============================================================================================
 // --- Sorting functions -----------------------------------------------------

--- a/Framework/DataObjects/src/EventList.cpp
+++ b/Framework/DataObjects/src/EventList.cpp
@@ -932,8 +932,7 @@ void EventList::clearData() { this->clear(false); }
  */
 void EventList::setMRU(EventWorkspaceMRU *newMRU) { mru = newMRU; }
 
-/** Reserve a certain number of entries in  event list of the specified
- *eventType
+/** Reserve a certain number of entries in event list of the specified eventType
  *
  * Calls std::vector<>::reserve() in order to pre-allocate the length of the
  *event list vector.

--- a/Framework/Types/inc/MantidTypes/Core/DateAndTime.h
+++ b/Framework/Types/inc/MantidTypes/Core/DateAndTime.h
@@ -151,14 +151,10 @@ inline DateAndTime::DateAndTime() : _nanoseconds(0) {}
 /** Construct a date from nanoseconds.
  * @param total_nanoseconds :: nanoseconds since Jan 1, 1990 (our epoch).
  */
-inline DateAndTime::DateAndTime(const int64_t total_nanoseconds) {
+inline DateAndTime::DateAndTime(const int64_t total_nanoseconds)
+    : _nanoseconds{
+          std::clamp(total_nanoseconds, MIN_NANOSECONDS, MAX_NANOSECONDS)} {
   // Make sure that you cannot construct a date that is beyond the limits...
-  if (total_nanoseconds > MAX_NANOSECONDS)
-    _nanoseconds = MAX_NANOSECONDS;
-  else if (total_nanoseconds < MIN_NANOSECONDS)
-    _nanoseconds = MIN_NANOSECONDS;
-  else
-    _nanoseconds = total_nanoseconds;
 }
 
 /** + operator to add time.


### PR DESCRIPTION
**Description of work.**

Noticed that `EventList::reserve` only works on the (NOT-WEIGHTED) event list. In practice, this restriction doesn't appear to be considered. [LoadNexusProcessed.cpp#L746](https://github.com/mantidproject/mantid/blob/15f91f2865245f4ff9123ef0fcc0d8ebf2b72b3b/Framework/DataHandling/src/LoadNexusProcessed.cpp#L746)

I think choosing which container could be done by checking the `eventType`.

**To test:**

<!-- Instructions for testing. -->

*There is no associated issue.*

*This does not require release notes* because internal change


---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
