### PR TITLE
Makes clang-format parallel where possible

### DIFF
--- a/buildconfig/Jenkins/clangformat
+++ b/buildconfig/Jenkins/clangformat
@@ -22,12 +22,19 @@ if [ "$(git config user.email)" == "" ]; then
   git config user.email "mantid-buildserver@mantidproject.org"
 fi
 
-# sources to format
-sources=`find Framework MantidPlot qt \( -name '*.cpp' -o -name '*.h' -o -name '*.tcc' \)`
 sha=`git rev-parse --short HEAD`
 
+if [ -x "$(command -v parallel)" ]; then
+  echo "Using GNU parallel"
+  runner="parallel ${CLANG_FORMAT} -i {}"
+else
+  echo "Using xargs"
+  runner="xargs ${CLANG_FORMAT} -i"
+fi
+
 # format
-${CLANG_FORMAT} -i $sources
+find Framework MantidPlot qt \( -name '*.cpp' -o -name '*.h' -o -name '*.tcc' \) | ${runner}
+
 git add -A
 echo
 if git diff --cached --quiet


### PR DESCRIPTION
**Description of work.**
Sets clang-format to run in parallel on build servers where the parallel
package exists. I've been running this locally whilst working cppcheck fixes, so it makes sense to add it to the project

**To test:**
- Check clang-format build passes

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
