### PR TITLE
Improve Status Information in Eng Diff GUI

### DIFF
--- a/docs/source/interfaces/Engineering Diffraction.rst
+++ b/docs/source/interfaces/Engineering Diffraction.rst
@@ -39,9 +39,22 @@ Settings
 Close
     Close the interface.
 
+Other Information
+^^^^^^^^^^^^^^^^^
+
 Red Stars
     Red stars next to browse boxes and other fields indicate that the file
     could not be found. Hover over the star to see more information.
+
+Status Bar
+    The status bar shows the calibration run numbers the GUI is currently using.
+
+Saved File Outputs
+    The location of files saved by the GUI during processing will be shown in the mantid
+    messages log.
+
+    *Note*: The locations are shown at "Notice" level, so may not appear if the messages log
+    is on the incorrect setting.
 
 Calibration
 -----------

--- a/docs/source/release/v5.1.0/diffraction.rst
+++ b/docs/source/release/v5.1.0/diffraction.rst
@@ -20,6 +20,8 @@ Improvements
 ^^^^^^^^^^^^
 - TOPAS files (`.abc`) have replaced the `.dat` files generated when focusing using the GUI.
 - Focusing with the GUI will now generate a CSV containing the averaged values of all numerical sample logs.
+- The currently loaded calibration is now shown at the bottom of the GUI.
+- The location of the saved output files from the GUI is now shown in the messages log.
 
 Single Crystal Diffraction
 --------------------------

--- a/scripts/Engineering/gui/engineering_diffraction/engineering_diffraction.py
+++ b/scripts/Engineering/gui/engineering_diffraction/engineering_diffraction.py
@@ -10,6 +10,8 @@ from qtpy import QtCore, QtWidgets
 from .tabs.calibration.model import CalibrationModel
 from .tabs.calibration.view import CalibrationView
 from .tabs.calibration.presenter import CalibrationPresenter
+from .tabs.common import CalibrationObserver
+from .tabs.common.path_handling import get_run_number_from_path
 from .tabs.focus.model import FocusModel
 from .tabs.focus.view import FocusView
 from .tabs.focus.presenter import FocusPresenter
@@ -42,10 +44,15 @@ class EngineeringDiffractionGui(QtWidgets.QMainWindow, Ui_main_window):
         self.focus_presenter = None
         self.fitting_presenter = None
         self.settings_presenter = None
+        self.calibration_observer = CalibrationObserver(self)
         self.set_on_help_clicked(self.open_help_window)
 
         self.set_on_settings_clicked(self.open_settings)
         self.btn_settings.setIcon(get_icon("mdi.settings", "black", 1.2))
+
+        # Setup status bar
+        self.status_label = QtWidgets.QLabel()
+        self.setup_statusbar()
 
         # Setup Elements
         self.setup_settings()
@@ -96,6 +103,11 @@ class EngineeringDiffractionGui(QtWidgets.QMainWindow, Ui_main_window):
     def setup_calibration_notifier(self):
         self.calibration_presenter.calibration_notifier.add_subscriber(
             self.focus_presenter.calibration_observer)
+        self.calibration_presenter.calibration_notifier.add_subscriber(self.calibration_observer)
+
+    def setup_statusbar(self):
+        self.statusbar.addWidget(self.status_label)
+        self.set_statusbar_text("No Calibration Loaded.")
 
     def set_on_help_clicked(self, slot):
         self.pushButton_help.clicked.connect(slot)
@@ -118,3 +130,12 @@ class EngineeringDiffractionGui(QtWidgets.QMainWindow, Ui_main_window):
 
     def get_rb_no(self):
         return self.lineEdit_RBNumber.text()
+
+    def update_calibration(self, calibration):
+        instrument = calibration.get_instrument()
+        van_no = get_run_number_from_path(calibration.get_vanadium(), instrument)
+        sample_no = get_run_number_from_path(calibration.get_sample(), instrument)
+        self.set_statusbar_text(f"V: {van_no}, CeO2: {sample_no}, Instrument: {instrument}")
+
+    def set_statusbar_text(self, text):
+        self.status_label.setText(text)

--- a/scripts/Engineering/gui/engineering_diffraction/tabs/calibration/model.py
+++ b/scripts/Engineering/gui/engineering_diffraction/tabs/calibration/model.py
@@ -316,6 +316,7 @@ class CalibrationModel(object):
         elif bank is None:  # Custom cropped files use the north bank template.
             north_kwargs()
             generate_output_file([difa[0]], [difc[0]], [tzero[0]], "cropped", kwargs)
+        logger.notice(f"\n\nCalibration files saved to: \"{calibration_dir}\"\n\n")
 
     @staticmethod
     def get_info_from_file(file_path):

--- a/scripts/Engineering/gui/engineering_diffraction/tabs/common/__init__.py
+++ b/scripts/Engineering/gui/engineering_diffraction/tabs/common/__init__.py
@@ -8,6 +8,7 @@
 Holds some common constants across all tabs.
 """
 from qtpy.QtWidgets import QMessageBox
+from mantidqt.utils.observer_pattern import Observer
 
 # Dictionary of indexes for instruments.
 INSTRUMENT_DICT = {0: "ENGINX", 1: "IMAT"}
@@ -15,3 +16,12 @@ INSTRUMENT_DICT = {0: "ENGINX", 1: "IMAT"}
 
 def create_error_message(parent, message):
     QMessageBox.warning(parent, "Engineering Diffraction - Error", str(message))
+
+
+class CalibrationObserver(Observer):
+    def __init__(self, outer):
+        Observer.__init__(self)
+        self.outer = outer
+
+    def update(self, observable, calibration):
+        self.outer.update_calibration(calibration)

--- a/scripts/Engineering/gui/engineering_diffraction/tabs/focus/model.py
+++ b/scripts/Engineering/gui/engineering_diffraction/tabs/focus/model.py
@@ -130,6 +130,9 @@ class FocusModel(object):
         self._save_focused_output_files_as_topas_xye(instrument, sample_path, bank, sample_workspace,
                                                      rb_num)
         logger.notice(f"\n\nFocus files saved to: \"{path.join(path_handling.get_output_path(), 'Focus')}\"\n\n")
+        if rb_num:
+            output_path = path.join(path_handling.get_output_path(), 'User', rb_num, 'Focus')
+            logger.notice(f"\n\nFocus files saved to: \"{output_path}\"\n\n")
 
     def _save_focused_output_files_as_gss(self, instrument, sample_path, bank, sample_workspace,
                                           rb_num):

--- a/scripts/Engineering/gui/engineering_diffraction/tabs/focus/model.py
+++ b/scripts/Engineering/gui/engineering_diffraction/tabs/focus/model.py
@@ -129,6 +129,7 @@ class FocusModel(object):
                                                rb_num)
         self._save_focused_output_files_as_topas_xye(instrument, sample_path, bank, sample_workspace,
                                                      rb_num)
+        logger.notice(f"\n\nFocus files saved to: \"{path.join(path_handling.get_output_path(), 'Focus')}\"\n\n")
 
     def _save_focused_output_files_as_gss(self, instrument, sample_path, bank, sample_workspace,
                                           rb_num):

--- a/scripts/Engineering/gui/engineering_diffraction/tabs/focus/presenter.py
+++ b/scripts/Engineering/gui/engineering_diffraction/tabs/focus/presenter.py
@@ -5,12 +5,12 @@
 #   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
 # SPDX - License - Identifier: GPL - 3.0 +
 # pylint: disable=invalid-name
-from Engineering.gui.engineering_diffraction.tabs.common import INSTRUMENT_DICT, create_error_message
+from Engineering.gui.engineering_diffraction.tabs.common import INSTRUMENT_DICT, create_error_message, \
+    CalibrationObserver
 from Engineering.gui.engineering_diffraction.tabs.common.calibration_info import CalibrationInfo
 from Engineering.gui.engineering_diffraction.tabs.common.vanadium_corrections import check_workspaces_exist
 from Engineering.gui.engineering_diffraction.tabs.common.cropping.cropping_widget import CroppingWidget
 from mantidqt.utils.asynchronous import AsyncTask
-from mantidqt.utils.observer_pattern import Observer
 
 from qtpy.QtWidgets import QMessageBox
 
@@ -20,7 +20,7 @@ class FocusPresenter(object):
         self.model = model
         self.view = view
         self.worker = None
-        self.calibration_observer = self.CalibrationObserver(self)
+        self.calibration_observer = CalibrationObserver(self)
 
         # Connect view signals to local methods.
         self.view.set_on_focus_clicked(self.on_focus_clicked)
@@ -132,14 +132,3 @@ class FocusPresenter(object):
 
     def show_cropping(self, visible):
         self.view.set_cropping_widget_visibility(visible)
-
-    # -----------------------
-    # Observers / Observables
-    # -----------------------
-    class CalibrationObserver(Observer):
-        def __init__(self, outer):
-            Observer.__init__(self)
-            self.outer = outer
-
-        def update(self, observable, calibration):
-            self.outer.update_calibration(calibration)


### PR DESCRIPTION
**Description of work.**
- Location of output files is now shown in the messages log. 
- The currently loaded calibration is now shown in the status bar at the bottom of the GUI. 

**To test:**
1. Open the GUI (Interfaces -> Diffraction -> Engineering Diffraction)
2. Load a calibration (V: 307521 CeO2: 305768)
2. Check that the run numbers are shown at the bottom of the main window. 
3. Check that the location of the saved files has been shown in the messages log at the "Notice" level. 
4. Switch to the focus tab and run something (307521)
5. Check the location is output to the messages log. 

Fixes #28355 

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
