### PR TITLE
Remove extra indents that were causing Flake8 Jenkins failure

### DIFF
--- a/tools/Copyright/copyrightupdate.py
+++ b/tools/Copyright/copyrightupdate.py
@@ -253,8 +253,8 @@ if not args.noreport:
     #write out reporting files
     for reporting_filename, reporting_dict in reporting_dictionaries.items():
         with open(reporting_filename,"w") as reporting_file:
-                for key, value in reporting_dict.items():
-                    reporting_file.write("{0}\t{1}{2}".format(key,value,os.linesep))
+            for key, value in reporting_dict.items():
+                reporting_file.write("{0}\t{1}{2}".format(key,value,os.linesep))
 
 # Final comments
 print()


### PR DESCRIPTION
**Description of work.**

There were some extra unwanted indents in copyrightupdate.py that were causing a Jenkins failure in Flake8. On node isis-ndw903 specifically. This is perhaps a python 3 flake 8 warning? Not sure if we're supposed to be running python 3 checks yet? Jenkins log shows:

17:53:15 + rm -f flake8.log
17:53:15 + flake8 --version
17:53:15 3.7.9 (mccabe: 0.6.1, pycodestyle: 2.5.0, pyflakes: 2.1.1) CPython 3.5.3 on Linux

**To test:**

Check Jenkins tests pass

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
