### PR TITLE
Move FileDescriptor and NexusDescriptor includes to derived classes

### DIFF
--- a/Framework/API/inc/MantidAPI/FileLoaderRegistry.h
+++ b/Framework/API/inc/MantidAPI/FileLoaderRegistry.h
@@ -8,6 +8,8 @@
 
 #include "MantidAPI/AlgorithmFactory.h"
 #include "MantidAPI/IFileLoader.h"
+#include "MantidKernel/FileDescriptor.h"
+#include "MantidKernel/NexusDescriptor.h"
 #include "MantidKernel/SingletonHolder.h"
 
 #ifndef Q_MOC_RUN

--- a/Framework/API/inc/MantidAPI/IFileLoader.h
+++ b/Framework/API/inc/MantidAPI/IFileLoader.h
@@ -7,8 +7,6 @@
 #pragma once
 
 #include "MantidAPI/ParallelAlgorithm.h"
-#include "MantidKernel/FileDescriptor.h"
-#include "MantidKernel/NexusDescriptor.h"
 
 namespace Mantid {
 namespace API {

--- a/Framework/Crystal/inc/MantidCrystal/LoadIsawPeaks.h
+++ b/Framework/Crystal/inc/MantidCrystal/LoadIsawPeaks.h
@@ -10,6 +10,7 @@
 #include "MantidCrystal/DllConfig.h"
 #include "MantidDataObjects/PeaksWorkspace.h"
 #include "MantidGeometry/Instrument/DetectorInfo.h"
+#include "MantidKernel/FileDescriptor.h"
 
 namespace Mantid {
 namespace Crystal {

--- a/Framework/DataHandling/inc/MantidDataHandling/FilterEventsByLogValuePreNexus.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/FilterEventsByLogValuePreNexus.h
@@ -11,6 +11,7 @@
 #include "MantidDataObjects/EventWorkspace.h"
 #include "MantidDataObjects/Events.h"
 #include "MantidKernel/BinaryFile.h"
+#include "MantidKernel/FileDescriptor.h"
 #include <fstream>
 #include <string>
 #include <vector>

--- a/Framework/DataHandling/inc/MantidDataHandling/LoadAscii.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/LoadAscii.h
@@ -8,6 +8,7 @@
 
 #include "MantidAPI/DeprecatedAlgorithm.h"
 #include "MantidAPI/IFileLoader.h"
+#include "MantidKernel/FileDescriptor.h"
 
 #include <list>
 

--- a/Framework/DataHandling/inc/MantidDataHandling/LoadAscii2.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/LoadAscii2.h
@@ -9,6 +9,7 @@
 #include "MantidAPI/IFileLoader.h"
 #include "MantidAPI/MatrixWorkspace_fwd.h"
 #include "MantidDataObjects/Histogram1D.h"
+#include "MantidKernel/FileDescriptor.h"
 
 #include <list>
 

--- a/Framework/DataHandling/inc/MantidDataHandling/LoadBBY.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/LoadBBY.h
@@ -14,6 +14,7 @@
 #include "MantidAPI/IFileLoader.h"
 #include "MantidDataObjects/EventWorkspace.h"
 #include "MantidGeometry/Instrument.h"
+#include "MantidKernel/FileDescriptor.h"
 #include "MantidNexus/NexusClasses.h"
 
 namespace Mantid {

--- a/Framework/DataHandling/inc/MantidDataHandling/LoadCanSAS1D.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/LoadCanSAS1D.h
@@ -9,6 +9,8 @@
 #include "MantidAPI/IFileLoader.h"
 #include "MantidAPI/WorkspaceGroup_fwd.h"
 #include "MantidDataObjects/Workspace2D.h"
+#include "MantidKernel/FileDescriptor.h"
+
 #include <Poco/DOM/Element.h>
 #include <Poco/DOM/Node.h>
 

--- a/Framework/DataHandling/inc/MantidDataHandling/LoadDaveGrp.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/LoadDaveGrp.h
@@ -11,6 +11,7 @@
 #include <vector>
 
 #include "MantidAPI/IFileLoader.h"
+#include "MantidKernel/FileDescriptor.h"
 #include "MantidKernel/cow_ptr.h"
 
 namespace Mantid {

--- a/Framework/DataHandling/inc/MantidDataHandling/LoadEMU.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/LoadEMU.h
@@ -10,6 +10,8 @@
 #include "MantidAPI/LogManager.h"
 #include "MantidDataObjects/EventWorkspace.h"
 #include "MantidGeometry/Instrument.h"
+#include "MantidKernel/FileDescriptor.h"
+#include "MantidKernel/NexusDescriptor.h"
 #include "MantidNexus/NexusClasses.h"
 
 namespace Mantid {

--- a/Framework/DataHandling/inc/MantidDataHandling/LoadEmptyInstrument.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/LoadEmptyInstrument.h
@@ -11,6 +11,7 @@
 //----------------------------------------------------------------------
 #include "MantidAPI/IFileLoader.h"
 #include "MantidDataObjects/Workspace2D.h"
+#include "MantidKernel/FileDescriptor.h"
 
 namespace Mantid {
 namespace DataHandling {

--- a/Framework/DataHandling/inc/MantidDataHandling/LoadEventNexus.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/LoadEventNexus.h
@@ -15,6 +15,7 @@
 #include "MantidDataObjects/Events.h"
 #include "MantidGeometry/Instrument.h"
 #include "MantidGeometry/Instrument/ParameterMap.h"
+#include "MantidKernel/NexusDescriptor.h"
 #include "MantidKernel/OptionalBool.h"
 #include "MantidKernel/TimeSeriesProperty.h"
 

--- a/Framework/DataHandling/inc/MantidDataHandling/LoadEventPreNexus2.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/LoadEventPreNexus2.h
@@ -10,6 +10,7 @@
 #include "MantidDataObjects/EventWorkspace.h"
 #include "MantidDataObjects/Events.h"
 #include "MantidKernel/BinaryFile.h"
+#include "MantidKernel/FileDescriptor.h"
 #include <fstream>
 #include <string>
 #include <vector>

--- a/Framework/DataHandling/inc/MantidDataHandling/LoadFITS.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/LoadFITS.h
@@ -16,6 +16,7 @@
 
 #include "MantidAPI/IFileLoader.h"
 #include "MantidDataObjects/Workspace2D.h"
+#include "MantidKernel/FileDescriptor.h"
 
 namespace Mantid {
 namespace DataHandling {

--- a/Framework/DataHandling/inc/MantidDataHandling/LoadGSS.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/LoadGSS.h
@@ -10,6 +10,7 @@
 // Includes
 //---------------------------------------------------
 #include "MantidAPI/IFileLoader.h"
+#include "MantidKernel/FileDescriptor.h"
 
 namespace Mantid {
 namespace DataHandling {

--- a/Framework/DataHandling/inc/MantidDataHandling/LoadHFIRSANS.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/LoadHFIRSANS.h
@@ -10,6 +10,8 @@
 #include "MantidDataHandling/XmlHandler.h"
 #include "MantidDataObjects/Workspace2D.h"
 #include "MantidKernel/DateAndTime.h"
+#include "MantidKernel/FileDescriptor.h"
+
 #include <map>
 #include <string>
 #include <utility>

--- a/Framework/DataHandling/inc/MantidDataHandling/LoadILLDiffraction.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/LoadILLDiffraction.h
@@ -10,6 +10,7 @@
 #include "MantidDataHandling/DllConfig.h"
 #include "MantidDataHandling/LoadHelper.h"
 #include "MantidKernel/DateAndTime.h"
+#include "MantidKernel/NexusDescriptor.h"
 #include "MantidKernel/V3D.h"
 #include "MantidNexus/NexusClasses.h"
 

--- a/Framework/DataHandling/inc/MantidDataHandling/LoadILLIndirect2.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/LoadILLIndirect2.h
@@ -8,6 +8,7 @@
 
 #include "MantidAPI/IFileLoader.h"
 #include "MantidDataHandling/LoadHelper.h"
+#include "MantidKernel/NexusDescriptor.h"
 #include "MantidNexus/NexusClasses.h"
 
 namespace Mantid {

--- a/Framework/DataHandling/inc/MantidDataHandling/LoadILLReflectometry.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/LoadILLReflectometry.h
@@ -9,6 +9,7 @@
 #include "MantidAPI/IFileLoader.h"
 #include "MantidAPI/MatrixWorkspace_fwd.h"
 #include "MantidDataHandling/LoadHelper.h"
+#include "MantidKernel/NexusDescriptor.h"
 #include "MantidNexus/NexusClasses.h"
 
 namespace Mantid {

--- a/Framework/DataHandling/inc/MantidDataHandling/LoadILLSANS.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/LoadILLSANS.h
@@ -8,6 +8,7 @@
 
 #include "MantidAPI/IFileLoader.h"
 #include "MantidDataHandling/LoadHelper.h"
+#include "MantidKernel/NexusDescriptor.h"
 #include "MantidKernel/System.h"
 #include "MantidNexus/NexusClasses.h"
 

--- a/Framework/DataHandling/inc/MantidDataHandling/LoadILLTOF2.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/LoadILLTOF2.h
@@ -9,6 +9,7 @@
 #include "MantidAPI/IFileLoader.h"
 #include "MantidDataHandling/LoadHelper.h"
 #include "MantidGeometry/IDTypes.h"
+#include "MantidKernel/NexusDescriptor.h"
 #include "MantidNexus/NexusClasses.h"
 
 namespace Mantid {

--- a/Framework/DataHandling/inc/MantidDataHandling/LoadISISNexus2.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/LoadISISNexus2.h
@@ -15,6 +15,7 @@
 #include "MantidDataHandling/DataBlockComposite.h"
 #include "MantidDataHandling/ISISRunLogs.h"
 #include "MantidDataObjects/Workspace2D.h"
+#include "MantidKernel/NexusDescriptor.h"
 #include "MantidNexus/NexusClasses.h"
 #include <nexus/NeXusFile.hpp>
 

--- a/Framework/DataHandling/inc/MantidDataHandling/LoadLLB.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/LoadLLB.h
@@ -9,6 +9,7 @@
 #include "MantidAPI/IFileLoader.h"
 #include "MantidDataHandling/LoadHelper.h"
 #include "MantidHistogramData/Histogram.h"
+#include "MantidKernel/NexusDescriptor.h"
 #include "MantidKernel/System.h"
 #include "MantidNexus/NexusClasses.h"
 

--- a/Framework/DataHandling/inc/MantidDataHandling/LoadMLZ.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/LoadMLZ.h
@@ -11,6 +11,7 @@
 //---------------------------------------------------
 #include "MantidAPI/IFileLoader.h"
 #include "MantidDataHandling/LoadHelper.h"
+#include "MantidKernel/NexusDescriptor.h"
 #include "MantidNexus/NexusClasses.h"
 
 namespace Mantid {

--- a/Framework/DataHandling/inc/MantidDataHandling/LoadMcStas.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/LoadMcStas.h
@@ -9,6 +9,7 @@
 #include "MantidAPI/Algorithm.h"
 #include "MantidAPI/IEventWorkspace.h"
 #include "MantidAPI/IFileLoader.h"
+#include "MantidKernel/NexusDescriptor.h"
 #include "MantidKernel/System.h"
 
 #include "MantidAPI/WorkspaceGroup_fwd.h"

--- a/Framework/DataHandling/inc/MantidDataHandling/LoadMcStasNexus.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/LoadMcStasNexus.h
@@ -7,6 +7,7 @@
 #pragma once
 
 #include "MantidAPI/IFileLoader.h"
+#include "MantidKernel/NexusDescriptor.h"
 #include "MantidKernel/System.h"
 
 namespace Mantid {

--- a/Framework/DataHandling/inc/MantidDataHandling/LoadMuonNexus.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/LoadMuonNexus.h
@@ -11,6 +11,7 @@
 //----------------------------------------------------------------------
 #include "MantidAPI/IFileLoader.h"
 #include "MantidDataObjects/Workspace2D.h"
+#include "MantidKernel/NexusDescriptor.h"
 #include "MantidKernel/System.h"
 
 //----------------------------------------------------------------------

--- a/Framework/DataHandling/inc/MantidDataHandling/LoadNGEM.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/LoadNGEM.h
@@ -9,6 +9,7 @@
 
 #include "MantidAPI/IFileLoader.h"
 #include "MantidDataObjects/EventWorkspace.h"
+#include "MantidKernel/FileDescriptor.h"
 
 namespace Mantid {
 namespace DataHandling {

--- a/Framework/DataHandling/inc/MantidDataHandling/LoadNXSPE.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/LoadNXSPE.h
@@ -8,6 +8,7 @@
 
 #include "MantidAPI/IFileLoader.h"
 #include "MantidGeometry/Objects/CSGObject.h"
+#include "MantidKernel/NexusDescriptor.h"
 #include "MantidKernel/System.h"
 
 namespace Mantid {

--- a/Framework/DataHandling/inc/MantidDataHandling/LoadNXcanSAS.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/LoadNXcanSAS.h
@@ -8,6 +8,7 @@
 
 #include "MantidAPI/IFileLoader.h"
 #include "MantidDataHandling/DllConfig.h"
+#include "MantidKernel/NexusDescriptor.h"
 
 namespace H5 {
 class Group;

--- a/Framework/DataHandling/inc/MantidDataHandling/LoadNexusProcessed.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/LoadNexusProcessed.h
@@ -13,6 +13,7 @@
 #include "MantidAPI/ITableWorkspace_fwd.h"
 #include "MantidAPI/MatrixWorkspace_fwd.h"
 #include "MantidHistogramData/BinEdges.h"
+#include "MantidKernel/NexusDescriptor.h"
 #include "MantidKernel/cow_ptr.h"
 #include "MantidNexus/NexusClasses.h"
 #include <map>

--- a/Framework/DataHandling/inc/MantidDataHandling/LoadPDFgetNFile.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/LoadPDFgetNFile.h
@@ -8,6 +8,7 @@
 
 #include "MantidAPI/IFileLoader.h"
 #include "MantidDataObjects/Workspace2D.h"
+#include "MantidKernel/FileDescriptor.h"
 #include "MantidKernel/System.h"
 
 namespace Mantid {

--- a/Framework/DataHandling/inc/MantidDataHandling/LoadPLN.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/LoadPLN.h
@@ -16,6 +16,7 @@
 #include "MantidAPI/LogManager.h"
 #include "MantidDataObjects/EventWorkspace.h"
 #include "MantidGeometry/Instrument.h"
+#include "MantidKernel/NexusDescriptor.h"
 #include "MantidNexus/NexusClasses.h"
 
 namespace Mantid {

--- a/Framework/DataHandling/inc/MantidDataHandling/LoadPSIMuonBin.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/LoadPSIMuonBin.h
@@ -10,6 +10,7 @@
 #include "MantidDataHandling/LoadRawHelper.h"
 #include "MantidDataObjects/Workspace2D.h"
 #include "MantidKernel/BinaryStreamReader.h"
+#include "MantidKernel/FileDescriptor.h"
 #include <cstdint>
 
 /** LoadPSIMuonBin : Loads a bin file from the PSI facility for muon

--- a/Framework/DataHandling/inc/MantidDataHandling/LoadPreNexus.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/LoadPreNexus.h
@@ -8,6 +8,7 @@
 
 #include "MantidAPI/IEventWorkspace_fwd.h"
 #include "MantidAPI/IFileLoader.h"
+#include "MantidKernel/FileDescriptor.h"
 #include "MantidKernel/System.h"
 #include <string>
 #include <vector>

--- a/Framework/DataHandling/inc/MantidDataHandling/LoadQKK.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/LoadQKK.h
@@ -10,6 +10,7 @@
 // Includes
 //---------------------------------------------------
 #include "MantidAPI/IFileLoader.h"
+#include "MantidKernel/NexusDescriptor.h"
 
 namespace Mantid {
 namespace DataHandling {

--- a/Framework/DataHandling/inc/MantidDataHandling/LoadRKH.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/LoadRKH.h
@@ -11,6 +11,7 @@
 //---------------------------------------------------
 #include "MantidAPI/IFileLoader.h"
 #include "MantidHistogramData/Histogram.h"
+#include "MantidKernel/FileDescriptor.h"
 #include "MantidKernel/cow_ptr.h"
 
 #include <fstream>

--- a/Framework/DataHandling/inc/MantidDataHandling/LoadRawHelper.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/LoadRawHelper.h
@@ -11,6 +11,8 @@
 #include "MantidAPI/WorkspaceGroup_fwd.h"
 #include "MantidDataHandling/ISISRunLogs.h"
 #include "MantidDataObjects/Workspace2D.h"
+#include "MantidKernel/FileDescriptor.h"
+
 #include <climits>
 #include <list>
 #include <memory>

--- a/Framework/DataHandling/inc/MantidDataHandling/LoadSESANS.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/LoadSESANS.h
@@ -8,6 +8,7 @@
 
 #include "MantidAPI/IFileLoader.h"
 #include "MantidDataHandling/DllConfig.h"
+#include "MantidKernel/FileDescriptor.h"
 
 #include <unordered_map>
 

--- a/Framework/DataHandling/inc/MantidDataHandling/LoadSINQFocus.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/LoadSINQFocus.h
@@ -12,6 +12,7 @@
 #include "MantidAPI/DeprecatedAlgorithm.h"
 #include "MantidAPI/IFileLoader.h"
 #include "MantidDataHandling/LoadHelper.h"
+#include "MantidKernel/NexusDescriptor.h"
 #include "MantidNexus/NexusClasses.h"
 
 namespace Mantid {

--- a/Framework/DataHandling/inc/MantidDataHandling/LoadSNSspec.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/LoadSNSspec.h
@@ -11,6 +11,7 @@
 //----------------------------------------------------------------------
 #include "MantidAPI/DeprecatedAlgorithm.h"
 #include "MantidAPI/IFileLoader.h"
+#include "MantidKernel/FileDescriptor.h"
 
 namespace Mantid {
 namespace DataHandling {

--- a/Framework/DataHandling/inc/MantidDataHandling/LoadSPE.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/LoadSPE.h
@@ -10,6 +10,7 @@
 // Includes
 //---------------------------------------------------
 #include "MantidAPI/IFileLoader.h"
+#include "MantidKernel/FileDescriptor.h"
 
 namespace Mantid {
 namespace DataHandling {

--- a/Framework/DataHandling/inc/MantidDataHandling/LoadSassena.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/LoadSassena.h
@@ -12,6 +12,8 @@
 #include "MantidAPI/IFileLoader.h"
 #include "MantidAPI/WorkspaceGroup_fwd.h"
 #include "MantidDataObjects/Workspace2D.h"
+#include "MantidKernel/NexusDescriptor.h"
+
 #include <hdf5.h>
 
 namespace Mantid {

--- a/Framework/DataHandling/inc/MantidDataHandling/LoadSpice2D.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/LoadSpice2D.h
@@ -10,6 +10,7 @@
 #include "MantidDataHandling/XmlHandler.h"
 #include "MantidDataObjects/Workspace2D.h"
 #include "MantidKernel/DateAndTime.h"
+#include "MantidKernel/FileDescriptor.h"
 #include <map>
 #include <string>
 #include <utility>

--- a/Framework/DataHandling/inc/MantidDataHandling/LoadSwans.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/LoadSwans.h
@@ -10,6 +10,7 @@
 #include "MantidAPI/IFileLoader.h"
 #include "MantidDataHandling/DllConfig.h"
 #include "MantidDataObjects/EventWorkspace.h"
+#include "MantidKernel/FileDescriptor.h"
 #include <map>
 
 namespace Mantid {

--- a/Framework/DataHandling/inc/MantidDataHandling/LoadTBL.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/LoadTBL.h
@@ -11,6 +11,7 @@
 //----------------------------------------------------------------------
 #include "MantidAPI/IFileLoader.h"
 #include "MantidDataObjects/TableWorkspace.h"
+#include "MantidKernel/FileDescriptor.h"
 
 namespace Mantid {
 namespace DataHandling {

--- a/Framework/DataHandling/inc/MantidDataHandling/LoadTOFRawNexus.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/LoadTOFRawNexus.h
@@ -14,6 +14,7 @@
 #include "MantidAPI/SpectraDetectorTypes.h"
 #include "MantidDataObjects/Workspace2D.h"
 #include "MantidKernel/DateAndTime.h"
+#include "MantidKernel/NexusDescriptor.h"
 #include "MantidNexus/NexusClasses.h"
 
 #include <mutex>

--- a/Framework/DataHandling/inc/MantidDataHandling/ProcessBankData.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/ProcessBankData.h
@@ -8,6 +8,7 @@
 
 #include "MantidDataHandling/BankPulseTimes.h"
 #include "MantidGeometry/IDTypes.h"
+#include "MantidKernel/NexusDescriptor.h"
 #include "MantidKernel/Task.h"
 #include "MantidKernel/Timer.h"
 

--- a/Framework/MDAlgorithms/inc/MantidMDAlgorithms/LoadDNSSCD.h
+++ b/Framework/MDAlgorithms/inc/MantidMDAlgorithms/LoadDNSSCD.h
@@ -10,6 +10,7 @@
 #include "MantidAPI/IFileLoader.h"
 #include "MantidAPI/IMDEventWorkspace_fwd.h"
 #include "MantidDataObjects/MDEventWorkspace.h"
+#include "MantidKernel/FileDescriptor.h"
 #include "MantidKernel/Matrix.h"
 #include "MantidKernel/System.h"
 #include "MantidKernel/V3D.h"

--- a/Framework/MDAlgorithms/inc/MantidMDAlgorithms/LoadMD.h
+++ b/Framework/MDAlgorithms/inc/MantidMDAlgorithms/LoadMD.h
@@ -10,7 +10,9 @@
 #include "MantidAPI/IFileLoader.h"
 #include "MantidAPI/IMDEventWorkspace_fwd.h"
 #include "MantidDataObjects/MDEventWorkspace.h"
+#include "MantidKernel/NexusDescriptor.h"
 #include "MantidKernel/System.h"
+
 #include <boost/optional.hpp>
 #include <boost/scoped_ptr.hpp>
 

--- a/Framework/MDAlgorithms/inc/MantidMDAlgorithms/LoadSQW2.h
+++ b/Framework/MDAlgorithms/inc/MantidMDAlgorithms/LoadSQW2.h
@@ -10,7 +10,7 @@
 #include "MantidDataObjects/MDEvent.h"
 #include "MantidDataObjects/MDEventWorkspace.h"
 #include "MantidKernel/BinaryStreamReader.h"
-
+#include "MantidKernel/FileDescriptor.h"
 #include <fstream>
 
 namespace Mantid {

--- a/qt/paraview_ext/VatesAlgorithms/inc/MantidVatesAlgorithms/LoadVTK.h
+++ b/qt/paraview_ext/VatesAlgorithms/inc/MantidVatesAlgorithms/LoadVTK.h
@@ -9,6 +9,7 @@
 #include "MantidAPI/IFileLoader.h"
 #include "MantidDataObjects/MDEventWorkspace.h"
 #include "MantidGeometry/MDGeometry/MDHistoDimension.h"
+#include "MantidKernel/FileDescriptor.h"
 #include "MantidKernel/System.h"
 
 class vtkUnsignedShortArray;


### PR DESCRIPTION
**Description of work.**

One doesn't need to include the headers of all descriptors alongside `IFileLoader`. Move the include to the class derived from IFileLoader.

**To test:**

<!-- Instructions for testing. -->

Check that Mantid still builds

*There is no associated issue.*

*This does not require release notes* because internal change


---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
