### PR TITLE
Add quotes to Span patching step, in case there are spaces

### DIFF
--- a/buildconfig/CMake/Span.cmake
+++ b/buildconfig/CMake/Span.cmake
@@ -9,8 +9,8 @@ FetchContent_Declare(
   span
   GIT_REPOSITORY https://github.com/tcbrindle/span.git
   GIT_TAG        08cb4bf0e06c0e36f7e2b64e488ede711a8bb5ad
-  PATCH_COMMAND     ${GIT_EXECUTABLE} reset --hard ${_tag}
-    COMMAND ${GIT_EXECUTABLE} apply ${_apply_flags} ${CMAKE_SOURCE_DIR}/buildconfig/CMake/span_disable_testing.patch
+  PATCH_COMMAND     "${GIT_EXECUTABLE}" reset --hard ${_tag}
+    COMMAND "${GIT_EXECUTABLE}" apply ${_apply_flags} "${CMAKE_SOURCE_DIR}/buildconfig/CMake/span_disable_testing.patch"
 )
 
 FetchContent_GetProperties(span)


### PR DESCRIPTION
**Description of work.**

Adds quotes to the patching step for span in case there are spaces in
the path causing it to fail. This isn't the direct cause, but it's good to do for safety.

**To test:**
- Check all builds pass and span tests don't appear

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
