### PR TITLE
Add validation for input CommonUBForAll in IndexPeaks

### DIFF
--- a/Framework/Crystal/src/IndexPeaks.cpp
+++ b/Framework/Crystal/src/IndexPeaks.cpp
@@ -412,6 +412,23 @@ std::map<std::string, std::string> IndexPeaks::validateInputs() {
     helpMsgs[Prop::PEAKSWORKSPACE] = exc.what();
   }
 
+  // get all runs which have peaksin the table
+  bool commonUB = this->getProperty(Prop::COMMONUB);
+  if (commonUB) {
+    auto &allPeaks = ws->getPeaks();
+    std::unordered_map<int, int> peaksPerRun;
+    auto it = allPeaks.begin();
+    while (peaksPerRun.size() < 2 && it != allPeaks.end()) {
+      peaksPerRun[it->getRunNumber()] = 1;
+      ++it;
+    };
+    if (peaksPerRun.size() < 2) {
+      helpMsgs[Prop::COMMONUB] =
+          "CommonUBForAll can only be True if there are peaks from more"
+          "than one run present in the peaks worksapce";
+    };
+  };
+
   return helpMsgs;
 }
 

--- a/Framework/Crystal/src/IndexPeaks.cpp
+++ b/Framework/Crystal/src/IndexPeaks.cpp
@@ -413,18 +413,18 @@ std::map<std::string, std::string> IndexPeaks::validateInputs() {
   }
 
   // get all runs which have peaksin the table
-  bool commonUB = this->getProperty(Prop::COMMONUB);
+  const bool commonUB = this->getProperty(Prop::COMMONUB);
   if (commonUB) {
-    auto &allPeaks = ws->getPeaks();
+    const auto &allPeaks = ws->getPeaks();
     std::unordered_map<int, int> peaksPerRun;
-    auto it = allPeaks.begin();
-    while (peaksPerRun.size() < 2 && it != allPeaks.end()) {
+    auto it = allPeaks.cbegin();
+    while (peaksPerRun.size() < 2 && it != allPeaks.cend()) {
       peaksPerRun[it->getRunNumber()] = 1;
       ++it;
     };
     if (peaksPerRun.size() < 2) {
       helpMsgs[Prop::COMMONUB] =
-          "CommonUBForAll can only be True if there are peaks from more"
+          "CommonUBForAll can only be True if there are peaks from more "
           "than one run present in the peaks worksapce";
     };
   };


### PR DESCRIPTION
**Description of work.**
Ensure CommonUBForAll cannot be used if there are peaks from only one run passed to the algorithm IndexPeaks. 

**To test:**
(1) Run the following script with .nxs and .txt (UB) from the original issue
```
from mantid.simpleapi import *
Load(Filename='unindexed-peaks.nxs', OutputWorkspace='sx_peaks_comUB_True')
LoadIsawUB(InputWorkspace='sx_peaks_comUB_True', Filename='pr-26807.txt')
IndexPeaks(PeaksWorkspace='sx_peaks_comUB_True', Tolerance=0.1, ToleranceForSatellite=0.1,
    RoundHKLS=False, CommonUBForAll=True)
```
It should not execute IndexPeaks but throw an error saying that the CommonUBForAll cannot be true in this case

Fixes #27146

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
