### PR TITLE
Add check to handle delete observer

### DIFF
--- a/Framework/PythonInterface/mantid/plots/mantidaxes.py
+++ b/Framework/PythonInterface/mantid/plots/mantidaxes.py
@@ -285,7 +285,7 @@ class MantidAxes(Axes):
         Remove the artists reference by this workspace (if any) and return True
         if the axes is then empty
         :param workspace: A Workspace object
-        :return: True if the axes is empty, false if artists remain or this workspace is not associated here
+        :return: True is an artist was removed False if one was not
         """
         try:
             # pop to ensure we don't hold onto an artist reference
@@ -296,7 +296,7 @@ class MantidAxes(Axes):
         for workspace_artist in artist_info:
             workspace_artist.remove(self)
 
-        return self.is_empty(self)
+        return True
 
     def remove_artists_if(self, unary_predicate):
         """

--- a/Framework/PythonInterface/test/python/mantid/plots/plots__init__Test.py
+++ b/Framework/PythonInterface/test/python/mantid/plots/plots__init__Test.py
@@ -76,14 +76,15 @@ class Plots__init__Test(unittest.TestCase):
 
     def test_remove_workspace_artist_for_known_workspace_removes_plot(self):
         self.ax.plot(self.ws2d_histo, specNum=2, linewidth=6)
-        is_empty = self.ax.remove_workspace_artists(self.ws2d_histo)
-        self.assertEqual(True, is_empty)
+        workspace_removed = self.ax.remove_workspace_artists(self.ws2d_histo)
+        self.assertEqual(True, workspace_removed)
         self.assertEqual(0, len(self.ax.lines))
 
     def test_remove_workspace_artist_for_unknown_workspace_does_nothing(self):
         self.ax.plot(self.ws2d_histo, specNum=2, linewidth=6)
         unknown_ws = CreateSampleWorkspace()
-        self.ax.remove_workspace_artists(unknown_ws)
+        workspace_removed  = self.ax.remove_workspace_artists(unknown_ws)
+        self.assertEqual(False, workspace_removed)
         self.assertEqual(1, len(self.ax.lines))
 
     def test_remove_workspace_artist_for_removes_only_specified_workspace(self):
@@ -92,7 +93,8 @@ class Plots__init__Test(unittest.TestCase):
         line_second_ws = self.ax.plot(second_ws, specNum=5)[0]
         self.assertEqual(2, len(self.ax.lines))
 
-        self.ax.remove_workspace_artists(self.ws2d_histo)
+        workspace_removed = self.ax.remove_workspace_artists(self.ws2d_histo)
+        self.assertEqual(True, workspace_removed)
         self.assertEqual(1, len(self.ax.lines))
         self.assertTrue(line_ws2d_histo not in self.ax.lines)
         self.assertTrue(line_second_ws in self.ax.lines)

--- a/docs/source/release/v5.1.0/mantidworkbench.rst
+++ b/docs/source/release/v5.1.0/mantidworkbench.rst
@@ -9,6 +9,7 @@ Improvements
 ############
 
 - Tile plots are now reloaded correctly by project recovery.
+- Fixed an issue where some scripts were running slower if a  plot was open at the same time.
 
 
 Bugfixes

--- a/qt/applications/workbench/workbench/plotting/figuremanager.py
+++ b/qt/applications/workbench/workbench/plotting/figuremanager.py
@@ -92,9 +92,12 @@ class FigureManagerADSObserver(AnalysisDataServiceObserver):
         # managed via a workspace.
         # See https://github.com/mantidproject/mantid/issues/25135.
         empty_axes = []
+        redraw = False
         for ax in all_axes:
             if isinstance(ax, MantidAxes):
-                ax.remove_workspace_artists(workspace)
+                to_redraw = ax.remove_workspace_artists(workspace)
+            else:
+                to_redraw = False
             # We check for axes type below as a pseudo check for an axes being
             # a colorbar. Creating a colorfill plot creates 2 axes: one linked
             # to a workspace, the other a colorbar. Deleting the workspace
@@ -104,10 +107,11 @@ class FigureManagerADSObserver(AnalysisDataServiceObserver):
             # Axes object being closed.
             if type(ax) is not Axes:
                 empty_axes.append(MantidAxes.is_empty(ax))
+            redraw = redraw | to_redraw
 
         if all(empty_axes):
             self.window.emit_close()
-        else:
+        elif redraw:
             self.canvas.draw()
 
     @_catch_exceptions


### PR DESCRIPTION
**Description of work.**

The handleWorkspaceDeleted observer of the workbench plots did not check that anything had changed before re-plotting. This led to some scripts which created and deleted workspaces running slower if unconnected plots were open. This PR adds a check in to prevent this. See commit messages for further details.

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

**To test:**
  * A script and data which demonstrate the issue can be found in #28194
  * Check that the script runs in approximately the same time whether or not any plots are open.

<!-- Instructions for testing. -->

Fixes #28434  <!-- and fix #xxxx or close #xxxx xor resolves #xxxx -->
<!-- alternative
*There is no associated issue.*
-->

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
-->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
