### PR TITLE
Improve tooltips on the reflectometry GUI

### DIFF
--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Experiment/ExperimentWidget.ui
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Experiment/ExperimentWidget.ui
@@ -75,7 +75,7 @@
         </size>
        </property>
        <property name="text">
-        <string>Output Stitch Params</string>
+        <string>Output Stitch Properties</string>
        </property>
       </widget>
      </item>

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Experiment/QtExperimentView.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Experiment/QtExperimentView.cpp
@@ -269,7 +269,6 @@ void QtExperimentView::registerExperimentSettingsWidgets(
   registerSettingWidget(*m_ui.transStitchParamsEdit, "Params", alg);
   registerSettingWidget(*m_ui.transScaleRHSCheckBox, "ScaleRHSWorkspace", alg);
   registerSettingWidget(*m_ui.polCorrCheckBox, "PolarizationAnalysis", alg);
-  registerSettingWidget(stitchOptionsLineEdit(), "Params", alg);
   registerSettingWidget(*m_ui.reductionTypeComboBox, "ReductionType", alg);
   registerSettingWidget(*m_ui.summationTypeComboBox, "SummationType", alg);
   registerSettingWidget(*m_ui.includePartialBinsCheckBox, "IncludePartialBins",
@@ -277,6 +276,12 @@ void QtExperimentView::registerExperimentSettingsWidgets(
   registerSettingWidget(*m_ui.floodCorComboBox, "FloodCorrection", alg);
   registerSettingWidget(*m_ui.floodWorkspaceWsSelector, "FloodWorkspace", alg);
   registerSettingWidget(*m_ui.debugCheckBox, "Debug", alg);
+
+  registerSettingWidget(stitchOptionsLineEdit(),
+                        "Properties to use for stitching the output workspaces "
+                        "in Q. Only required for groups containing multiple "
+                        "rows. Start typing to see property hints or see "
+                        "Stitch1DMany for details.");
 }
 
 void QtExperimentView::connectExperimentSettingsWidgets() {
@@ -347,6 +352,12 @@ void QtExperimentView::registerSettingWidget(
     Widget &widget, std::string const &propertyName,
     const Mantid::API::IAlgorithm_sptr &alg) {
   setToolTipAsPropertyDocumentation(widget, propertyName, alg);
+}
+
+template <typename Widget>
+void QtExperimentView::registerSettingWidget(Widget &widget,
+                                             std::string const &tooltip) {
+  widget.setToolTip(QString::fromStdString(tooltip));
 }
 
 void QtExperimentView::setToolTipAsPropertyDocumentation(

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Experiment/QtExperimentView.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Experiment/QtExperimentView.h
@@ -141,6 +141,8 @@ private:
   template <typename Widget>
   void registerSettingWidget(Widget &widget, std::string const &propertyName,
                              const Mantid::API::IAlgorithm_sptr &alg);
+  template <typename Widget>
+  void registerSettingWidget(Widget &widget, std::string const &tooltip);
   void connectSettingsChange(QLineEdit &edit);
   void connectSettingsChange(QComboBox &edit);
   void connectSettingsChange(QCheckBox &edit);


### PR DESCRIPTION
This PR improves a misleading tooltip and widget label. It also adds a function to be able to set the tooltip manually rather than using an algorithm property (as per all the other inputs). This is because the stitch properties input is for the entire algorithm, not for any specific property.

**Report to:** Max at ISIS

**To test:**

- Open the ISIS Reflectometry GUI
- Check that the label and tooltip make sense for the Output Stitch Properties widget.

*There is no associated issue.*

*This does not require release notes* because **it is a very minor change**

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
