### PR TITLE
Remove Bash 4.2 feature breaking Mac OSX

### DIFF
--- a/buildconfig/Jenkins/buildscript
+++ b/buildconfig/Jenkins/buildscript
@@ -312,8 +312,6 @@ fi
 # Figure out if were doing a sanitizer build and setup any steps we need
 ###############################################################################
 
-SANITIZER_FLAGS=''
-
 if [[ ${JOB_NAME} == *address* ]]; then
     SANITIZER_FLAGS="-DUSE_SANITIZER=Address"
     
@@ -327,7 +325,7 @@ elif [[ ${JOB_NAME} == *undefined* ]]; then
     SANITIZER_FLAGS="-DUSE_SANITIZER=undefined"
 fi
 
-if [[ -v ${SANITIZER_FLAGS} ]]; then
+if [[ -n "${SANITIZER_FLAGS}" ]]; then
     # Force build to RelWithDebInfo
     BUILD_CONFIG="RelWithDebInfo"
 fi


### PR DESCRIPTION
**Description of work.**
Removes a check that uses the -v flag, this was introduced in BASH 4.2,
so apparently breaks certain Mac builders

**To test:**
- Check Mac builders pass
- Check that the job did not run in `RelWithDebMode`, this can be seen in the `-DCMAKE_BUILD_TYPE` variable

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
