### PR TITLE
Fix test_fitpropertybrowser unreliable test

### DIFF
--- a/qt/python/mantidqt/widgets/fitpropertybrowser/fitpropertybrowser.py
+++ b/qt/python/mantidqt/widgets/fitpropertybrowser/fitpropertybrowser.py
@@ -38,7 +38,6 @@ class FitPropertyBrowser(FitPropertyBrowserBase):
 
     def __init__(self, canvas, toolbar_manager, parent=None):
         super(FitPropertyBrowser, self).__init__(parent)
-        self.init()
         self.setFeatures(self.DockWidgetMovable)
         self.canvas = canvas
         # The toolbar state manager to be passed to the peak editing tool

--- a/qt/widgets/common/src/FitPropertyBrowser.cpp
+++ b/qt/widgets/common/src/FitPropertyBrowser.cpp
@@ -711,7 +711,20 @@ void FitPropertyBrowser::executeSetupManageMenu(const QString &item) {
 }
 
 /// Destructor
-FitPropertyBrowser::~FitPropertyBrowser() { m_compositeFunction.reset(); }
+FitPropertyBrowser::~FitPropertyBrowser() {
+  m_compositeFunction.reset();
+  m_browser->unsetFactoryForManager(m_enumManager);
+  m_browser->unsetFactoryForManager(m_boolManager);
+  m_browser->unsetFactoryForManager(m_intManager);
+  m_browser->unsetFactoryForManager(m_doubleManager);
+  m_browser->unsetFactoryForManager(m_stringManager);
+  m_browser->unsetFactoryForManager(m_filenameManager);
+  m_browser->unsetFactoryForManager(m_formulaManager);
+  m_browser->unsetFactoryForManager(m_columnManager);
+  m_browser->unsetFactoryForManager(m_vectorSizeManager);
+  m_browser->unsetFactoryForManager(m_vectorDoubleManager);
+  m_browser->unsetFactoryForManager(m_parameterManager);
+}
 
 /// Get handler to the root composite function
 PropertyHandler *FitPropertyBrowser::getHandler() const {


### PR DESCRIPTION
**Description of work.**
This PR fixes the `test_fitpropertybrowser` unreliable test.

The `fitpropertybrowser` was segfaulting when creating the [editors](https://github.com/mantidproject/mantid/blob/master/qt/widgets/common/src/FitPropertyBrowser.cpp#L604). This is because it creates maps containing pointers to the property managers and factories. These are not cleared in the browser destructor as the properties can still be used elsewhere. In the testing however these are not cleared and results in the pointers to the managers and factories remaining even though the manager has been deleted.
This PR clears these maps after each test so it should not fail unreliably.

**To test:**
Run the test multiple times to ensure it does not fail. 
You can use the ctest command line argument`--repeat-until-fail` to do this 
e.g. for windows:  `ctest -C Release --repeat-until-fail 100 -R test_fitpropertybrowser`

*There is no associated issue.*

*This does not require release notes* because **it is fixing tests**

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
