### PR TITLE
Create new tab names correctly on KDE

### DIFF
--- a/docs/source/release/v5.1.0/ui.rst
+++ b/docs/source/release/v5.1.0/ui.rst
@@ -19,6 +19,7 @@ See :doc:`mantidplot`.
 
 MantidWorkbench
 ---------------
+- Fixed new tab names not incrementing correctly on KDE display environments (i.e. KUbuntu).
 
 See :doc:`mantidworkbench`.
 

--- a/qt/python/mantidqt/widgets/codeeditor/multifileinterpreter.py
+++ b/qt/python/mantidqt/widgets/codeeditor/multifileinterpreter.py
@@ -69,7 +69,7 @@ class MultiPythonFileInterpreter(QWidget):
         if filename is None:
             title = NEW_TAB_TITLE
             i = 1
-            while title in self.tab_titles:
+            while title in self.stripped_tab_titles:
                 title = "{} ({})".format(NEW_TAB_TITLE, i)
                 i += 1
             return title, title
@@ -77,8 +77,13 @@ class MultiPythonFileInterpreter(QWidget):
             return osp.basename(filename), filename
 
     @property
-    def tab_titles(self):
-        return [self._tabs.tabText(i).rstrip('*') for i in range(self.editor_count)]
+    def stripped_tab_titles(self):
+        tab_text = [self._tabs.tabText(i) for i in range(self.editor_count)]
+        tab_text = [txt.rstrip('*') for txt in tab_text]
+        # Some DEs (such as KDE) will automatically assign keyboard shortcuts using the Qt & annotation
+        # see Qt Docs - qtabwidget#addTab
+        tab_text = [txt.replace('&', '') for txt in tab_text]
+        return tab_text
 
     def closeEvent(self, event):
         self.deleteLater()


### PR DESCRIPTION
**Description of work.**
Creates new tab names correctly on non-GNOME enrionvments for Ubuntu.
KDE automatically binds keyboard shortcuts, which Qt represents with &x
(where x is the shortcut). This breaks the name lookup as &New != New in
"New Tab".

We now strip out these characters when looking up the names fixing the
names not incrementing correctly.

**To test:**
- Check tab names still increment correctly
- Either take my word they are fixed, or install Kubuntu/KDE DE and try it out

Fixes #28445 . 
---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
