### PR TITLE
GCC-9 Warnings

### DIFF
--- a/Framework/API/inc/MantidAPI/AlgorithmProperty.h
+++ b/Framework/API/inc/MantidAPI/AlgorithmProperty.h
@@ -44,6 +44,8 @@ public:
                     Kernel::IValidator_sptr validator =
                         Kernel::IValidator_sptr(new Kernel::NullValidator),
                     unsigned int direction = Kernel::Direction::Input);
+
+  AlgorithmProperty(const AlgorithmProperty &);
   // Unhide base class member that would be hidden by implicitly declared
   // assignment operator
   using Kernel::PropertyWithValue<HeldType>::operator=;

--- a/Framework/API/inc/MantidAPI/AlgorithmProperty.h
+++ b/Framework/API/inc/MantidAPI/AlgorithmProperty.h
@@ -10,6 +10,8 @@
 #include "MantidKernel/NullValidator.h"
 #include "MantidKernel/PropertyWithValue.h"
 
+#include <memory>
+
 namespace Mantid {
 namespace API {
 //-------------------------------------------------------------------------

--- a/Framework/API/inc/MantidAPI/AlgorithmProperty.h
+++ b/Framework/API/inc/MantidAPI/AlgorithmProperty.h
@@ -47,7 +47,7 @@ public:
                         Kernel::IValidator_sptr(new Kernel::NullValidator),
                     unsigned int direction = Kernel::Direction::Input);
 
-  AlgorithmProperty(const AlgorithmProperty &);
+  AlgorithmProperty(const AlgorithmProperty &) = default;
   // Unhide base class member that would be hidden by implicitly declared
   // assignment operator
   using Kernel::PropertyWithValue<HeldType>::operator=;

--- a/Framework/API/inc/MantidAPI/Axis.h
+++ b/Framework/API/inc/MantidAPI/Axis.h
@@ -92,9 +92,6 @@ protected:
   Axis(const Axis &) = default;
 
 private:
-  /// Private, undefined copy assignment operator
-  const Axis &operator=(const Axis &) = delete;
-
   /// The user-defined title for this axis
   std::string m_title;
   /// The unit for this axis

--- a/Framework/API/inc/MantidAPI/Axis.h
+++ b/Framework/API/inc/MantidAPI/Axis.h
@@ -90,6 +90,7 @@ public:
 
 protected:
   Axis(const Axis &) = default;
+  Axis &operator=(const Axis &) = default;
 
 private:
   /// The user-defined title for this axis

--- a/Framework/API/inc/MantidAPI/BinEdgeAxis.h
+++ b/Framework/API/inc/MantidAPI/BinEdgeAxis.h
@@ -29,10 +29,6 @@ public:
   std::vector<double> createBinBoundaries() const override;
   void setValue(const std::size_t &index, const double &value) override;
   size_t indexOfValue(const double value) const override;
-
-private:
-  /// Private, undefined copy assignment operator
-  const BinEdgeAxis &operator=(const BinEdgeAxis &);
 };
 
 } // namespace API

--- a/Framework/API/inc/MantidAPI/FileProperty.h
+++ b/Framework/API/inc/MantidAPI/FileProperty.h
@@ -73,6 +73,8 @@ public:
                unsigned int action, std::initializer_list<std::string> exts,
                unsigned int direction = Kernel::Direction::Input);
 
+  FileProperty(const FileProperty &);
+
   /// 'Virtual copy constructor
   FileProperty *clone() const override { return new FileProperty(*this); }
 

--- a/Framework/API/inc/MantidAPI/FileProperty.h
+++ b/Framework/API/inc/MantidAPI/FileProperty.h
@@ -73,7 +73,8 @@ public:
                unsigned int action, std::initializer_list<std::string> exts,
                unsigned int direction = Kernel::Direction::Input);
 
-  FileProperty(const FileProperty &);
+  FileProperty(const FileProperty &) = default;
+  FileProperty &operator=(const FileProperty &) = default;
 
   /// 'Virtual copy constructor
   FileProperty *clone() const override { return new FileProperty(*this); }
@@ -119,9 +120,6 @@ private:
   std::string m_oldLoadPropValue;
   /// Last value of foundFile used in FileProperty::setLoadProperty
   std::string m_oldLoadFoundFile;
-
-  /// Private, unimplemented copy assignment operator
-  FileProperty &operator=(const FileProperty &right);
 };
 
 #ifdef _WIN32

--- a/Framework/API/inc/MantidAPI/IFunction.h
+++ b/Framework/API/inc/MantidAPI/IFunction.h
@@ -242,10 +242,6 @@ public:
     explicit Attribute(const std::vector<double> &v)
         : m_data(v), m_quoteValue(false) {}
 
-    Attribute(const Attribute &o) : m_data(o.m_data), m_quoteValue(false) {}
-    /// Copy assignment
-    Attribute &operator=(const Attribute attr);
-
     /// Apply an attribute visitor
     template <typename T> T apply(AttributeVisitor<T> &v) {
       return boost::apply_visitor(v, m_data);
@@ -289,6 +285,11 @@ public:
     void setBool(const bool &);
     /// Sets new value if attribute is a vector
     void setVector(const std::vector<double> &);
+    template <typename T>
+    // Set value
+    void setValue(const T &v) {
+      m_data = v;
+    }
     /// Set value from a string.
     void fromString(const std::string &str);
 
@@ -503,7 +504,11 @@ public:
   /// Set an attribute value
   template <typename T>
   void setAttributeValue(const std::string &attName, const T &value) {
-    setAttribute(attName, Attribute(value));
+    // Since we can't know T and we would rather not create a universal setter
+    // copy and replace in-place
+    auto attr = getAttribute(attName);
+    attr.setValue(value);
+    setAttribute(attName, attr);
   }
   void setAttributeValue(const std::string &attName, const char *value);
   void setAttributeValue(const std::string &attName, const std::string &value);

--- a/Framework/API/inc/MantidAPI/IFunction.h
+++ b/Framework/API/inc/MantidAPI/IFunction.h
@@ -241,8 +241,10 @@ public:
     /// Create vector attribute
     explicit Attribute(const std::vector<double> &v)
         : m_data(v), m_quoteValue(false) {}
+
+    Attribute(const Attribute &o) : m_data(o.m_data), m_quoteValue(false) {}
     /// Copy assignment
-    Attribute &operator=(const Attribute &attr);
+    Attribute &operator=(const Attribute attr);
 
     /// Apply an attribute visitor
     template <typename T> T apply(AttributeVisitor<T> &v) {
@@ -295,7 +297,7 @@ public:
     mutable boost::variant<std::string, int, double, bool, std::vector<double>>
         m_data;
     /// Flag indicating if the string value should be returned quoted
-    bool m_quoteValue;
+    bool m_quoteValue = false;
   };
 
   //---------------------------------------------------------//

--- a/Framework/API/inc/MantidAPI/IndexProperty.h
+++ b/Framework/API/inc/MantidAPI/IndexProperty.h
@@ -34,6 +34,7 @@ public:
                 const IndexTypeProperty &indexTypeProp,
                 const Kernel::IValidator_sptr &validator =
                     Kernel::IValidator_sptr(new Kernel::NullValidator));
+  IndexProperty(const IndexProperty &);
 
   IndexProperty *clone() const override;
 

--- a/Framework/API/inc/MantidAPI/IndexProperty.h
+++ b/Framework/API/inc/MantidAPI/IndexProperty.h
@@ -34,7 +34,9 @@ public:
                 const IndexTypeProperty &indexTypeProp,
                 const Kernel::IValidator_sptr &validator =
                     Kernel::IValidator_sptr(new Kernel::NullValidator));
-  IndexProperty(const IndexProperty &);
+
+  IndexProperty(const IndexProperty &) = default;
+  IndexProperty &operator=(const IndexProperty &) = default;
 
   IndexProperty *clone() const override;
 

--- a/Framework/API/inc/MantidAPI/MultipleFileProperty.h
+++ b/Framework/API/inc/MantidAPI/MultipleFileProperty.h
@@ -141,8 +141,8 @@ public:
   std::string getDefaultExt() const { return m_defaultExt; }
 
   // Unhide the PropertyWithValue assignment operator
-  using Kernel::PropertyWithValue<
-      std::vector<std::vector<std::string>>>::operator=;
+  using Kernel::PropertyWithValue<std::vector<std::vector<std::string>>>::
+  operator=;
 
 private:
   /// Returns a string depending on whether an empty value is valid

--- a/Framework/API/inc/MantidAPI/MultipleFileProperty.h
+++ b/Framework/API/inc/MantidAPI/MultipleFileProperty.h
@@ -123,6 +123,8 @@ public:
       const std::string &name,
       const std::vector<std::string> &exts = std::vector<std::string>());
 
+  MultipleFileProperty(const MultipleFileProperty &);
+
   MultipleFileProperty *clone() const override {
     return new MultipleFileProperty(*this);
   }
@@ -139,8 +141,8 @@ public:
   std::string getDefaultExt() const { return m_defaultExt; }
 
   // Unhide the PropertyWithValue assignment operator
-  using Kernel::PropertyWithValue<std::vector<std::vector<std::string>>>::
-  operator=;
+  using Kernel::PropertyWithValue<
+      std::vector<std::vector<std::string>>>::operator=;
 
 private:
   /// Returns a string depending on whether an empty value is valid

--- a/Framework/API/inc/MantidAPI/MultipleFileProperty.h
+++ b/Framework/API/inc/MantidAPI/MultipleFileProperty.h
@@ -123,7 +123,8 @@ public:
       const std::string &name,
       const std::vector<std::string> &exts = std::vector<std::string>());
 
-  MultipleFileProperty(const MultipleFileProperty &);
+  MultipleFileProperty(const MultipleFileProperty &) = default;
+  MultipleFileProperty &operator=(const MultipleFileProperty &) = default;
 
   MultipleFileProperty *clone() const override {
     return new MultipleFileProperty(*this);

--- a/Framework/API/inc/MantidAPI/NumericAxis.h
+++ b/Framework/API/inc/MantidAPI/NumericAxis.h
@@ -62,10 +62,6 @@ protected:
 
   /// A vector holding the centre values.
   std::vector<double> m_values;
-
-private:
-  /// Private, undefined copy assignment operator
-  const NumericAxis &operator=(const NumericAxis &);
 };
 
 } // namespace API

--- a/Framework/API/inc/MantidAPI/Progress.h
+++ b/Framework/API/inc/MantidAPI/Progress.h
@@ -34,7 +34,6 @@ public:
 private:
   /// Owning algorithm
   Algorithm *const m_alg;
-  Progress &operator=(const Progress &);
 };
 
 } // namespace API

--- a/Framework/API/inc/MantidAPI/TextAxis.h
+++ b/Framework/API/inc/MantidAPI/TextAxis.h
@@ -60,8 +60,6 @@ public:
   double getMax() const override;
 
 private:
-  /// Private, undefined copy assignment operator
-  const TextAxis &operator=(const TextAxis &);
   /// A vector holding the axis values for the axis.
   std::vector<std::string> m_values;
 };

--- a/Framework/API/inc/MantidAPI/WorkspaceHistory.h
+++ b/Framework/API/inc/MantidAPI/WorkspaceHistory.h
@@ -37,11 +37,11 @@ public:
   /// Default constructor
   WorkspaceHistory();
   /// Destructor
-  virtual ~WorkspaceHistory();
+  virtual ~WorkspaceHistory() = default;
   /// Copy constructor
-  WorkspaceHistory(const WorkspaceHistory &);
+  WorkspaceHistory(const WorkspaceHistory &) = default;
   /// Deleted copy assignment operator
-  WorkspaceHistory &operator=(const WorkspaceHistory &) = delete;
+  WorkspaceHistory &operator=(const WorkspaceHistory &) = default;
   /// Retrieve the algorithm history list
   const AlgorithmHistories &getAlgorithmHistories() const;
   /// Retrieve the environment history

--- a/Framework/API/src/AlgorithmProperty.cpp
+++ b/Framework/API/src/AlgorithmProperty.cpp
@@ -13,6 +13,7 @@
 
 #include <json/value.h>
 
+#include <memory>
 #include <utility>
 
 namespace Mantid {
@@ -37,7 +38,7 @@ AlgorithmProperty::AlgorithmProperty(const std::string &propName,
       m_algmStr() {}
 
 AlgorithmProperty::AlgorithmProperty(const AlgorithmProperty &other)
-    : Kernel::PropertyWithValue<boost::shared_ptr<IAlgorithm>>(other),
+    : Kernel::PropertyWithValue<std::shared_ptr<IAlgorithm>>(other),
       m_algmStr(other.m_algmStr) {}
 
 /**

--- a/Framework/API/src/AlgorithmProperty.cpp
+++ b/Framework/API/src/AlgorithmProperty.cpp
@@ -9,6 +9,7 @@
 //-----------------------------------------------------------------------------
 #include "MantidAPI/AlgorithmProperty.h"
 #include "MantidAPI/Algorithm.h"
+#include "MantidKernel/PropertyWithValue.h"
 
 #include <json/value.h>
 
@@ -34,6 +35,10 @@ AlgorithmProperty::AlgorithmProperty(const std::string &propName,
     : Kernel::PropertyWithValue<HeldType>(propName, HeldType(),
                                           std::move(validator), direction),
       m_algmStr() {}
+
+AlgorithmProperty::AlgorithmProperty(const AlgorithmProperty &other)
+    : Kernel::PropertyWithValue<boost::shared_ptr<IAlgorithm>>(other),
+      m_algmStr(other.m_algmStr) {}
 
 /**
  * Return the algorithm as string

--- a/Framework/API/src/AlgorithmProperty.cpp
+++ b/Framework/API/src/AlgorithmProperty.cpp
@@ -37,10 +37,6 @@ AlgorithmProperty::AlgorithmProperty(const std::string &propName,
                                           std::move(validator), direction),
       m_algmStr() {}
 
-AlgorithmProperty::AlgorithmProperty(const AlgorithmProperty &other)
-    : Kernel::PropertyWithValue<std::shared_ptr<IAlgorithm>>(other),
-      m_algmStr(other.m_algmStr) {}
-
 /**
  * Return the algorithm as string
  * @returns The algorithm serialized as a string

--- a/Framework/API/src/Citation.cpp
+++ b/Framework/API/src/Citation.cpp
@@ -8,6 +8,8 @@
 
 #include <nexus/NeXusFile.hpp>
 
+#include <stdexcept>
+
 namespace Mantid {
 namespace API {
 

--- a/Framework/API/src/FileProperty.cpp
+++ b/Framework/API/src/FileProperty.cpp
@@ -10,6 +10,7 @@
 #include "MantidKernel/ConfigService.h"
 #include "MantidKernel/DirectoryValidator.h"
 #include "MantidKernel/FacilityInfo.h"
+#include "MantidKernel/PropertyWithValue.h"
 #include "MantidKernel/Strings.h"
 
 #include <Poco/File.h>
@@ -202,6 +203,12 @@ FileProperty::FileProperty(const std::string &name,
                            unsigned int direction)
     : FileProperty(name, default_value, action, std::vector<std::string>(exts),
                    direction) {}
+
+FileProperty::FileProperty(const FileProperty &other)
+    : Kernel::PropertyWithValue<std::string>(other), m_action(other.m_action),
+      m_defaultExt(other.m_defaultExt), m_runFileProp(other.m_runFileProp),
+      m_oldLoadPropValue(other.m_oldLoadPropValue),
+      m_oldLoadFoundFile(other.m_oldLoadFoundFile) {}
 
 /**
  * Check if this is a load property

--- a/Framework/API/src/FileProperty.cpp
+++ b/Framework/API/src/FileProperty.cpp
@@ -204,12 +204,6 @@ FileProperty::FileProperty(const std::string &name,
     : FileProperty(name, default_value, action, std::vector<std::string>(exts),
                    direction) {}
 
-FileProperty::FileProperty(const FileProperty &other)
-    : Kernel::PropertyWithValue<std::string>(other), m_action(other.m_action),
-      m_defaultExt(other.m_defaultExt), m_runFileProp(other.m_runFileProp),
-      m_oldLoadPropValue(other.m_oldLoadPropValue),
-      m_oldLoadFoundFile(other.m_oldLoadFoundFile) {}
-
 /**
  * Check if this is a load property
  * @returns True if the property is a Load property and false otherwise

--- a/Framework/API/src/IFunction.cpp
+++ b/Framework/API/src/IFunction.cpp
@@ -658,15 +658,6 @@ private:
 };
 } // namespace
 
-/// @param attr :: The attribute to copy from.
-IFunction::Attribute &IFunction::Attribute::operator=(const Attribute attr) {
-  // This uses copy and swap as the copy constructor does the right
-  // thing of not copying m_quoteValue
-  std::swap(m_data, attr.m_data);
-  m_quoteValue = attr.m_quoteValue;
-  return *this;
-}
-
 std::string IFunction::Attribute::value() const {
   AttValue tmp(m_quoteValue);
   return apply(tmp);

--- a/Framework/API/src/IFunction.cpp
+++ b/Framework/API/src/IFunction.cpp
@@ -658,10 +658,12 @@ private:
 };
 } // namespace
 
-/// Copy assignment. Do not copy m_quoteValue flag.
 /// @param attr :: The attribute to copy from.
-IFunction::Attribute &IFunction::Attribute::operator=(const Attribute &attr) {
-  m_data = attr.m_data;
+IFunction::Attribute &IFunction::Attribute::operator=(const Attribute attr) {
+  // This uses copy and swap as the copy constructor does the right
+  // thing of not copying m_quoteValue
+  std::swap(m_data, attr.m_data);
+  m_quoteValue = attr.m_quoteValue;
   return *this;
 }
 

--- a/Framework/API/src/IndexProperty.cpp
+++ b/Framework/API/src/IndexProperty.cpp
@@ -23,6 +23,12 @@ IndexProperty::IndexProperty(const std::string &name,
       m_workspaceProp(workspaceProp), m_indexTypeProp(indexTypeProp),
       m_indices(0), m_indicesExtracted(false) {}
 
+IndexProperty::IndexProperty(const IndexProperty &other)
+    : Kernel::ArrayProperty<int64_t>(other),
+      m_workspaceProp(other.m_workspaceProp),
+      m_indexTypeProp(other.m_indexTypeProp), m_indices(other.m_indices),
+      m_validString(other.m_validString) {}
+
 IndexProperty *IndexProperty::clone() const { return new IndexProperty(*this); }
 
 bool IndexProperty::isDefault() const { return m_value.empty(); }

--- a/Framework/API/src/IndexProperty.cpp
+++ b/Framework/API/src/IndexProperty.cpp
@@ -23,12 +23,6 @@ IndexProperty::IndexProperty(const std::string &name,
       m_workspaceProp(workspaceProp), m_indexTypeProp(indexTypeProp),
       m_indices(0), m_indicesExtracted(false) {}
 
-IndexProperty::IndexProperty(const IndexProperty &other)
-    : Kernel::ArrayProperty<int64_t>(other),
-      m_workspaceProp(other.m_workspaceProp),
-      m_indexTypeProp(other.m_indexTypeProp), m_indices(other.m_indices),
-      m_validString(other.m_validString) {}
-
 IndexProperty *IndexProperty::clone() const { return new IndexProperty(*this); }
 
 bool IndexProperty::isDefault() const { return m_value.empty(); }

--- a/Framework/API/src/MultipleFileProperty.cpp
+++ b/Framework/API/src/MultipleFileProperty.cpp
@@ -107,6 +107,15 @@ MultipleFileProperty::MultipleFileProperty(const std::string &name,
                                            const std::vector<std::string> &exts)
     : MultipleFileProperty(name, FileProperty::Load, exts) {}
 
+MultipleFileProperty::MultipleFileProperty(const MultipleFileProperty &other)
+    : Kernel::PropertyWithValue<std::vector<std::vector<std::string>>>(other),
+      m_multiFileLoadingEnabled(other.m_multiFileLoadingEnabled),
+      m_exts(other.m_exts), m_parser(other.m_parser),
+      m_defaultExt(other.m_defaultExt), m_action(other.m_action),
+      m_oldPropValue(other.m_oldPropValue),
+      m_oldFoundValue(other.m_oldFoundValue),
+      m_allowEmptyTokens(other.m_allowEmptyTokens) {}
+
 /**
  * Check if this property is optional
  * @returns True if the property is optinal, false otherwise

--- a/Framework/API/src/MultipleFileProperty.cpp
+++ b/Framework/API/src/MultipleFileProperty.cpp
@@ -107,15 +107,6 @@ MultipleFileProperty::MultipleFileProperty(const std::string &name,
                                            const std::vector<std::string> &exts)
     : MultipleFileProperty(name, FileProperty::Load, exts) {}
 
-MultipleFileProperty::MultipleFileProperty(const MultipleFileProperty &other)
-    : Kernel::PropertyWithValue<std::vector<std::vector<std::string>>>(other),
-      m_multiFileLoadingEnabled(other.m_multiFileLoadingEnabled),
-      m_exts(other.m_exts), m_parser(other.m_parser),
-      m_defaultExt(other.m_defaultExt), m_action(other.m_action),
-      m_oldPropValue(other.m_oldPropValue),
-      m_oldFoundValue(other.m_oldFoundValue),
-      m_allowEmptyTokens(other.m_allowEmptyTokens) {}
-
 /**
  * Check if this property is optional
  * @returns True if the property is optinal, false otherwise

--- a/Framework/API/src/WorkspaceHistory.cpp
+++ b/Framework/API/src/WorkspaceHistory.cpp
@@ -61,18 +61,6 @@ struct AlgorithmHistoryComparator {
 /// Default Constructor
 WorkspaceHistory::WorkspaceHistory() : m_environment() {}
 
-/// Destructor
-WorkspaceHistory::~WorkspaceHistory() = default;
-
-/**
-  Standard Copy Constructor
-  @param A :: WorkspaceHistory Item to copy
- */
-WorkspaceHistory::WorkspaceHistory(const WorkspaceHistory &A)
-    : m_environment(A.m_environment) {
-  m_algorithms = A.m_algorithms;
-}
-
 /// Returns a const reference to the algorithmHistory
 const Mantid::API::AlgorithmHistories &
 WorkspaceHistory::getAlgorithmHistories() const {
@@ -160,8 +148,8 @@ WorkspaceHistory::getAlgorithmHistory(const size_t index) const {
  * @returns A pointer to an AlgorithmHistory object
  * @throws std::out_of_range error if the index is invalid
  */
-AlgorithmHistory_const_sptr WorkspaceHistory::
-operator[](const size_t index) const {
+AlgorithmHistory_const_sptr
+    WorkspaceHistory::operator[](const size_t index) const {
   return getAlgorithmHistory(index);
 }
 

--- a/Framework/API/src/WorkspaceHistory.cpp
+++ b/Framework/API/src/WorkspaceHistory.cpp
@@ -148,8 +148,8 @@ WorkspaceHistory::getAlgorithmHistory(const size_t index) const {
  * @returns A pointer to an AlgorithmHistory object
  * @throws std::out_of_range error if the index is invalid
  */
-AlgorithmHistory_const_sptr
-    WorkspaceHistory::operator[](const size_t index) const {
+AlgorithmHistory_const_sptr WorkspaceHistory::
+operator[](const size_t index) const {
   return getAlgorithmHistory(index);
 }
 

--- a/Framework/API/test/DetectorInfoTest.h
+++ b/Framework/API/test/DetectorInfoTest.h
@@ -454,7 +454,7 @@ private:
       if (i % 2 == 0)
         detInfo.setMasked(i, true);
     }
-    return std::move(ws);
+    return ws;
   }
 };
 

--- a/Framework/API/test/SpectrumInfoTest.h
+++ b/Framework/API/test/SpectrumInfoTest.h
@@ -597,7 +597,7 @@ private:
     for (size_t i = 0; i < ws->getNumberHistograms(); ++i)
       if (i % 2 == 0)
         detectorInfo.setMasked(i, true);
-    return std::move(ws);
+    return ws;
   }
 
   WorkspaceTester makeDefaultWorkspace() {

--- a/Framework/Algorithms/inc/MantidAlgorithms/SampleCorrections/DetectorGridDefinition.h
+++ b/Framework/Algorithms/inc/MantidAlgorithms/SampleCorrections/DetectorGridDefinition.h
@@ -9,6 +9,7 @@
 #include "MantidAlgorithms/DllConfig.h"
 
 #include <array>
+#include <cstddef>
 
 namespace Mantid {
 namespace Algorithms {

--- a/Framework/Algorithms/src/CreateSampleWorkspace.cpp
+++ b/Framework/Algorithms/src/CreateSampleWorkspace.cpp
@@ -413,7 +413,7 @@ EventWorkspace_sptr CreateSampleWorkspace::createEventWorkspace(
     workspaceIndex++;
   }
 
-  return std::move(retVal);
+  return retVal;
 }
 //----------------------------------------------------------------------------------------------
 /**

--- a/Framework/Algorithms/src/DetectorDiagnostic.cpp
+++ b/Framework/Algorithms/src/DetectorDiagnostic.cpp
@@ -532,7 +532,7 @@ DataObjects::MaskWorkspace_sptr DetectorDiagnostic::generateEmptyMask(
       create<DataObjects::MaskWorkspace>(*inputWS, HistogramData::Points(1));
   maskWS->setTitle(inputWS->getTitle());
 
-  return std::move(maskWS);
+  return maskWS;
 }
 
 std::vector<std::vector<size_t>>

--- a/Framework/Algorithms/src/MaxEnt/MaxentTransformFourier.cpp
+++ b/Framework/Algorithms/src/MaxEnt/MaxentTransformFourier.cpp
@@ -9,6 +9,7 @@
 
 #include <gsl/gsl_fft_complex.h>
 #include <memory>
+#include <stdexcept>
 
 namespace Mantid {
 namespace Algorithms {

--- a/Framework/Algorithms/src/MaxEnt/MaxentTransformMultiFourier.cpp
+++ b/Framework/Algorithms/src/MaxEnt/MaxentTransformMultiFourier.cpp
@@ -7,6 +7,7 @@
 #include "MantidAlgorithms/MaxEnt/MaxentTransformMultiFourier.h"
 #include <gsl/gsl_fft_complex.h>
 
+#include <stdexcept>
 #include <utility>
 
 namespace Mantid {

--- a/Framework/Algorithms/src/Q1D2.cpp
+++ b/Framework/Algorithms/src/Q1D2.cpp
@@ -389,7 +389,7 @@ Q1D2::setUpOutputWorkspace(const std::vector<double> &binParams) const {
   outputWS->getSpectrum(0).clearDetectorIDs();
   outputWS->getSpectrum(0).setSpectrumNo(1);
 
-  return std::move(outputWS);
+  return outputWS;
 }
 
 /** Calculate the normalization term for each output bin

--- a/Framework/Algorithms/src/SampleCorrections/DetectorGridDefinition.cpp
+++ b/Framework/Algorithms/src/SampleCorrections/DetectorGridDefinition.cpp
@@ -7,6 +7,7 @@
 #include "MantidAlgorithms/SampleCorrections/DetectorGridDefinition.h"
 
 #include <cmath>
+#include <stdexcept>
 
 namespace Mantid {
 namespace Algorithms {

--- a/Framework/Algorithms/src/WorkspaceJoiners.cpp
+++ b/Framework/Algorithms/src/WorkspaceJoiners.cpp
@@ -157,7 +157,7 @@ WorkspaceJoiners::execEvent(const DataObjects::EventWorkspace &eventWs1,
 
   fixSpectrumNumbers(eventWs1, eventWs2, *output);
 
-  return std::move(output);
+  return output;
 }
 
 /** Checks that the two input workspace have common size and the same

--- a/Framework/Algorithms/test/CreatePSDBleedMaskTest.h
+++ b/Framework/Algorithms/test/CreatePSDBleedMaskTest.h
@@ -117,7 +117,7 @@ private:
     const int failedTube(1);
     // Set a high value to tip that tube over the max count rate
     testWS->mutableY(failedTube * nPixelsPerTube + 1)[0] = 100.0;
-    return std::move(testWS);
+    return testWS;
   }
 
   Mantid::Algorithms::CreatePSDBleedMask diagnostic;

--- a/Framework/Algorithms/test/DetectorEfficiencyCorTest.h
+++ b/Framework/Algorithms/test/DetectorEfficiencyCorTest.h
@@ -155,6 +155,6 @@ private:
       pmap.add("double", detector, "TubePressure", 10.0);
       pmap.add("double", detector, "TubeThickness", 0.0008);
     }
-    return std::move(space2D);
+    return space2D;
   }
 };

--- a/Framework/Algorithms/test/ExtractSpectra2Test.h
+++ b/Framework/Algorithms/test/ExtractSpectra2Test.h
@@ -50,7 +50,7 @@ std::shared_ptr<Workspace2D> createWorkspace() {
   ws->setHistogram(2, Points{2.0}, Counts{1.0});
   ws->setHistogram(3, Points{3.0}, Counts{1.0});
   ws->setHistogram(4, Points{4.0}, Counts{1.0});
-  return std::move(ws);
+  return ws;
 }
 } // namespace
 

--- a/Framework/Algorithms/test/StripVanadiumPeaks2Test.h
+++ b/Framework/Algorithms/test/StripVanadiumPeaks2Test.h
@@ -708,6 +708,6 @@ private:
                 0.06281112, 0.06287284, 0.06251089, 0.06240202, 0.06257857}));
     space2D->getAxis(0)->unit() =
         Mantid::Kernel::UnitFactory::Instance().create("dSpacing");
-    return std::move(space2D);
+    return space2D;
   }
 };

--- a/Framework/CurveFitting/src/Functions/CrystalFieldControl.cpp
+++ b/Framework/CurveFitting/src/Functions/CrystalFieldControl.cpp
@@ -74,11 +74,11 @@ void CrystalFieldControl::setAttribute(const std::string &name,
           m_fwhmY[i].clear();
           if (nSpec > 1) {
             auto &control = *getFunction(i);
-            control.setAttribute("FWHMX", Attribute(std::vector<double>()));
-            control.setAttribute("FWHMY", Attribute(std::vector<double>()));
+            control.setAttributeValue("FWHMX", std::vector<double>());
+            control.setAttributeValue("FWHMY", std::vector<double>());
           } else {
-            setAttribute("FWHMX", Attribute(std::vector<double>()));
-            setAttribute("FWHMY", Attribute(std::vector<double>()));
+            API::IFunction::setAttributeValue("FWHMX", std::vector<double>());
+            API::IFunction::setAttributeValue("FWHMY", std::vector<double>());
           }
         }
       }
@@ -94,7 +94,7 @@ void CrystalFieldControl::setAttribute(const std::string &name,
 /// Parse a comma-separated list attribute
 /// @param attName :: A name of the attribute to parse.
 /// @param value :: A value to parse.
-/// @param cache :: A vector to chache the parsed values.
+/// @param cache :: A vector to cache the parsed values.
 void CrystalFieldControl::parseStringListAttribute(
     const std::string &attName, const std::string &value,
     std::vector<std::string> &cache) {
@@ -104,8 +104,11 @@ void CrystalFieldControl::parseStringListAttribute(
   cache.clear();
   cache.insert(cache.end(), tokenizer.begin(), tokenizer.end());
   auto attrValue = Kernel::Strings::join(cache.begin(), cache.end(), ",");
-  // Store back the trimmed names
-  API::IFunction::setAttribute(attName, Attribute(attrValue));
+  // Store back the trimmed names - we can't use setAttributeValue as it will
+  // call this setAttribute
+  auto attrCopy = getAttribute(attName);
+  attrCopy.setString(attrValue);
+  API::IFunction::setAttribute(attName, attrCopy);
 }
 
 /// Cache function attributes.

--- a/Framework/CurveFitting/src/Functions/CrystalFieldMultiSpectrum.cpp
+++ b/Framework/CurveFitting/src/Functions/CrystalFieldMultiSpectrum.cpp
@@ -166,7 +166,9 @@ void CrystalFieldMultiSpectrum::setAttribute(const std::string &name,
         }
       }
     }
-    FunctionGenerator::setAttribute("FWHMs", Attribute(new_fwhm));
+    Attribute newVal = attr;
+    newVal.setVector(new_fwhm);
+    FunctionGenerator::setAttribute("FWHMs", newVal);
     for (size_t iSpec = 0; iSpec < nSpec; ++iSpec) {
       const auto suffix = std::to_string(iSpec);
       declareAttribute("FWHMX" + suffix, Attribute(m_fwhmX[iSpec]));
@@ -392,7 +394,7 @@ API::IFunction_sptr CrystalFieldMultiSpectrum::buildPhysprop(
     IFunction_sptr retval = IFunction_sptr(new CrystalFieldMagnetisation);
     auto &spectrum = dynamic_cast<CrystalFieldMagnetisation &>(*retval);
     spectrum.setHamiltonian(ham, nre);
-    spectrum.setAttribute("Temperature", Attribute(temperature));
+    spectrum.setAttributeValue("Temperature", temperature);
     const auto suffix = std::to_string(iSpec);
     spectrum.setAttribute("Unit", getAttribute("Unit" + suffix));
     spectrum.setAttribute("Hdir", getAttribute("Hdir" + suffix));

--- a/Framework/CurveFitting/src/Functions/FunctionQDepends.cpp
+++ b/Framework/CurveFitting/src/Functions/FunctionQDepends.cpp
@@ -74,7 +74,10 @@ void FunctionQDepends::setAttribute(const std::string &attName,
         attValue.asInt())}; // ah!, the "joys" of C++ strong typing.
     if (!m_vQ.empty() && wi < m_vQ.size()) {
       Mantid::API::IFunction::setAttribute(attName, attValue);
-      Mantid::API::IFunction::setAttribute("Q", Attribute(m_vQ.at(wi)));
+      auto qAttr = getAttribute("Q");
+      qAttr.setDouble(m_vQ.at(wi));
+      // Can't call setAttributeValue, as it will recurse back into here
+      Mantid::API::IFunction::setAttribute("Q", qAttr);
     }
   }
   // Q can be manually changed by user only if list of Q values is empty
@@ -102,8 +105,8 @@ void FunctionQDepends::setMatrixWorkspace(
   UNUSED_ARG(endX);
   // reset attributes if new workspace is passed
   if (!m_vQ.empty()) {
-    Mantid::API::IFunction::setAttribute("WorkspaceIndex", Attr(EMPTY_INT()));
-    Mantid::API::IFunction::setAttribute("Q", Attr(EMPTY_DBL()));
+    Mantid::API::IFunction::setAttributeValue("WorkspaceIndex", EMPTY_INT());
+    Mantid::API::IFunction::setAttributeValue("Q", EMPTY_DBL());
   }
   // Obtain Q values from the passed workspace, if possible. m_vQ will be
   // cleared if unsuccessful.
@@ -111,7 +114,7 @@ void FunctionQDepends::setMatrixWorkspace(
     m_vQ = this->extractQValues(*workspace);
   }
   if (!m_vQ.empty()) {
-    this->setAttribute("WorkspaceIndex", Attr(static_cast<int>(wi)));
+    this->setAttributeValue("WorkspaceIndex", static_cast<int>(wi));
   }
 }
 

--- a/Framework/DataHandling/test/SetBeamTest.h
+++ b/Framework/DataHandling/test/SetBeamTest.h
@@ -103,7 +103,7 @@ private:
     alg->setChild(true);
     alg->setRethrows(true);
     alg->initialize();
-    return std::move(alg);
+    return alg;
   }
 
   Mantid::Kernel::PropertyManager_sptr createRectangularBeamProps() {

--- a/Framework/DataHandling/test/SetSampleTest.h
+++ b/Framework/DataHandling/test/SetSampleTest.h
@@ -929,7 +929,7 @@ private:
     if (inputWS) {
       alg->setProperty("InputWorkspace", inputWS);
     }
-    return std::move(alg);
+    return alg;
   }
 
   bool validateErrorProduced(Mantid::API::IAlgorithm &alg,

--- a/Framework/DataObjects/inc/MantidDataObjects/WorkspaceCreation.h
+++ b/Framework/DataObjects/inc/MantidDataObjects/WorkspaceCreation.h
@@ -198,7 +198,7 @@ create(const std::shared_ptr<const Geometry::Instrument> &instrument,
   auto ws = std::make_unique<T>();
   ws->setInstrument(std::move(instrument));
   ws->initialize(indexArg, HistogramData::Histogram(histArg));
-  return std::move(ws);
+  return ws;
 }
 
 template <class T, class P,

--- a/Framework/DataObjects/test/EventListTest.h
+++ b/Framework/DataObjects/test/EventListTest.h
@@ -1536,7 +1536,7 @@ public:
       this->fake_uniform_time_data();
       el.switchTo(static_cast<EventType>(this_type));
       // Do convert
-      TS_ASSERT_THROWS(this->el.addPulsetimes(offsets), std::runtime_error);
+      TS_ASSERT_THROWS(this->el.addPulsetimes(offsets), std::runtime_error &);
     }
   }
 

--- a/Framework/Geometry/src/Instrument/InstrumentVisitor.cpp
+++ b/Framework/Geometry/src/Instrument/InstrumentVisitor.cpp
@@ -37,7 +37,7 @@ makeDetIdToIndexMap(const std::vector<detid_t> &detIds) {
   for (size_t i = 0; i < nDetIds; ++i) {
     (*detIdToIndex)[detIds[i]] = i;
   }
-  return std::move(detIdToIndex);
+  return detIdToIndex;
 }
 
 void clearLegacyParameters(ParameterMap *pmap, const IComponent &comp) {

--- a/Framework/Geometry/test/RulesTest.h
+++ b/Framework/Geometry/test/RulesTest.h
@@ -138,6 +138,6 @@ private:
     Right->setLeaves(std::move(C), std::move(A));
 
     Root->setLeaves(std::move(Left), std::move(Right));
-    return std::move(Root);
+    return Root;
   }
 };

--- a/Framework/HistogramData/inc/MantidHistogramData/FixedLengthVector.h
+++ b/Framework/HistogramData/inc/MantidHistogramData/FixedLengthVector.h
@@ -36,8 +36,6 @@ public:
   FixedLengthVector(std::initializer_list<double> init) : m_data(init) {
     Validator<T>::checkValidity(m_data);
   }
-  FixedLengthVector(const FixedLengthVector &) = default;
-  FixedLengthVector(FixedLengthVector &&) = default;
   FixedLengthVector(const std::vector<double> &other) : m_data(other) {}
   FixedLengthVector(std::vector<double> &&other) : m_data(std::move(other)) {}
   template <class InputIt>
@@ -58,26 +56,12 @@ public:
     m_data.assign(count, value);
   }
 
-  FixedLengthVector &operator=(const FixedLengthVector &rhs) {
-    checkAssignmentSize(rhs);
-    m_data = rhs.m_data;
-    return *this;
-  }
-  FixedLengthVector &operator=(FixedLengthVector &&rhs) {
-    checkAssignmentSize(rhs);
-    m_data = std::move(rhs.m_data);
-    return *this;
-  }
   FixedLengthVector &operator=(const std::vector<double> &rhs) {
     checkAssignmentSize(rhs);
     m_data = rhs;
     return *this;
   }
-  FixedLengthVector &operator=(std::vector<double> &&rhs) {
-    checkAssignmentSize(rhs);
-    m_data = std::move(rhs);
-    return *this;
-  }
+
   FixedLengthVector &operator=(std::initializer_list<double> ilist) {
     checkAssignmentSize(ilist);
     Validator<T>::checkValidity(ilist);

--- a/Framework/HistogramData/inc/MantidHistogramData/FixedLengthVector.h
+++ b/Framework/HistogramData/inc/MantidHistogramData/FixedLengthVector.h
@@ -30,6 +30,7 @@ namespace detail {
 */
 template <class T> class FixedLengthVector {
 public:
+  // Ctors
   FixedLengthVector() = default;
   FixedLengthVector(size_t count, const double &value) : m_data(count, value) {}
   explicit FixedLengthVector(size_t count) : m_data(count) {}
@@ -47,13 +48,18 @@ public:
     std::generate(m_data.begin(), m_data.end(), g);
   }
 
-  template <class InputIt> void assign(InputIt first, InputIt last) & {
-    checkAssignmentSize(static_cast<size_t>(std::distance(first, last)));
-    m_data.assign(first, last);
+  FixedLengthVector(const FixedLengthVector &) = default;
+
+  FixedLengthVector &operator=(FixedLengthVector rhs) {
+    checkAssignmentSize(rhs);
+
+    swap(*this, rhs);
+    return *this;
   }
-  void assign(size_t count, const double &value) & {
-    checkAssignmentSize(count);
-    m_data.assign(count, value);
+
+  friend void swap(FixedLengthVector &lhs, FixedLengthVector &rhs) {
+    using std::swap;
+    swap(lhs.m_data, rhs.m_data);
   }
 
   FixedLengthVector &operator=(const std::vector<double> &rhs) {
@@ -71,6 +77,15 @@ public:
   FixedLengthVector &operator=(const double value) {
     m_data.assign(m_data.size(), value);
     return *this;
+  }
+
+  template <class InputIt> void assign(InputIt first, InputIt last) & {
+    checkAssignmentSize(static_cast<size_t>(std::distance(first, last)));
+    m_data.assign(first, last);
+  }
+  void assign(size_t count, const double &value) & {
+    checkAssignmentSize(count);
+    m_data.assign(count, value);
   }
 
   bool operator==(const FixedLengthVector<T> &rhs) const {
@@ -104,10 +119,6 @@ protected:
    * Note that this is not available in the public interface, since that would
    * allow for length modifications, which we need to prevent. */
   std::vector<double> &mutableRawData() { return m_data; }
-
-  // This is used as base class only, cannot delete polymorphically, so
-  // destructor is protected.
-  ~FixedLengthVector() = default;
 
 private:
   template <class Other> void checkAssignmentSize(const Other &other) const {

--- a/Framework/HistogramData/test/FixedLengthVectorTest.h
+++ b/Framework/HistogramData/test/FixedLengthVectorTest.h
@@ -84,7 +84,6 @@ public:
     FixedLengthVectorTester src(2, 0.1);
     TS_ASSERT_EQUALS(src.size(), 2);
     const FixedLengthVectorTester dest(std::move(src));
-    TS_ASSERT_EQUALS(src.size(), 0);
     TS_ASSERT_EQUALS(dest[0], 0.1);
     TS_ASSERT_EQUALS(dest[1], 0.1);
   }
@@ -167,25 +166,28 @@ public:
     TS_ASSERT_EQUALS(dest[1], 0.1);
   }
 
-  void test_copy_assignment_fail() {
+  void test_assignment() {
     const FixedLengthVectorTester src(2, 0.1);
-    FixedLengthVectorTester dest(1);
-    TS_ASSERT_THROWS(dest = src, const std::logic_error &);
-  }
-
-  void test_move_assignment() {
-    FixedLengthVectorTester src(2, 0.1);
-    FixedLengthVectorTester dest(2);
-    dest = std::move(src);
-    TS_ASSERT_EQUALS(src.size(), 0);
+    FixedLengthVectorTester dest = src;
+    TS_ASSERT_EQUALS(dest.size(), 2);
     TS_ASSERT_EQUALS(dest[0], 0.1);
     TS_ASSERT_EQUALS(dest[1], 0.1);
   }
 
-  void test_move_assignment_fail() {
+  void test_move_rval_ref() {
     FixedLengthVectorTester src(2, 0.1);
-    FixedLengthVectorTester dest(1);
-    TS_ASSERT_THROWS(dest = std::move(src), const std::logic_error &);
+    FixedLengthVectorTester dest(2);
+    dest = std::move(src);
+    TS_ASSERT_EQUALS(dest[0], 0.1);
+    TS_ASSERT_EQUALS(dest[1], 0.1);
+  }
+
+  void test_move_assignment() {
+    FixedLengthVectorTester src(2, 0.1);
+    FixedLengthVectorTester dest = std::move(src);
+    TS_ASSERT_EQUALS(dest.size(), 2);
+    TS_ASSERT_EQUALS(dest[0], 0.1);
+    TS_ASSERT_EQUALS(dest[1], 0.1);
   }
 
   void test_initializer_list_assignment() {
@@ -239,7 +241,6 @@ public:
     std::vector<double> vector{0.1, 0.2};
     FixedLengthVectorTester values(2);
     TS_ASSERT_THROWS_NOTHING(values = std::move(vector));
-    TS_ASSERT_EQUALS(vector.size(), 0);
     TS_ASSERT_EQUALS(values.size(), 2);
     TS_ASSERT_EQUALS(values[0], 0.1);
     TS_ASSERT_EQUALS(values[1], 0.2);

--- a/Framework/ICat/src/GSoap/stdsoap2.cpp
+++ b/Framework/ICat/src/GSoap/stdsoap2.cpp
@@ -13,6 +13,7 @@ GNU_DIAG_OFF("format-overflow")
 GNU_DIAG_OFF("format-truncation")
 GNU_DIAG_OFF("implicit-fallthrough")
 GNU_DIAG_OFF("cast-align")
+GNU_DIAG_OFF("deprecated-copy")
 
 /*
   stdsoap2.c[pp] 2.8.15
@@ -16591,3 +16592,4 @@ GNU_DIAG_ON("format-overflow")
 GNU_DIAG_ON("format-truncation")
 GNU_DIAG_ON("implicit-fallthrough")
 GNU_DIAG_ON("cast-align")
+GNU_DIAG_OFF("deprecated-copy")

--- a/Framework/Kernel/inc/MantidKernel/ArrayProperty.h
+++ b/Framework/Kernel/inc/MantidKernel/ArrayProperty.h
@@ -41,6 +41,8 @@ public:
       const IValidator_sptr &validator = IValidator_sptr(new NullValidator),
       const unsigned int direction = Direction::Input);
 
+  ArrayProperty(const ArrayProperty &);
+
   ArrayProperty<T> *clone() const override;
 
   // Unhide the base class assignment operator

--- a/Framework/Kernel/inc/MantidKernel/EnvironmentHistory.h
+++ b/Framework/Kernel/inc/MantidKernel/EnvironmentHistory.h
@@ -31,10 +31,6 @@ public:
   std::string osVersion() const;
   /// print contents of object
   void printSelf(std::ostream &, const int indent = 0) const;
-
-private:
-  /// Private, unimplemented copy assignment operator
-  EnvironmentHistory &operator=(const EnvironmentHistory &);
 };
 
 MANTID_KERNEL_DLL std::ostream &operator<<(std::ostream &,

--- a/Framework/Kernel/inc/MantidKernel/MaskedProperty.h
+++ b/Framework/Kernel/inc/MantidKernel/MaskedProperty.h
@@ -35,6 +35,9 @@ public:
   /// Constructor with a validator without validation
   MaskedProperty(const std::string &name, const TYPE &defaultvalue,
                  const unsigned int direction);
+
+  MaskedProperty(const MaskedProperty &);
+
   /// "virtual" copy constructor
   MaskedProperty *clone() const override;
 

--- a/Framework/Kernel/inc/MantidKernel/MaskedProperty.h
+++ b/Framework/Kernel/inc/MantidKernel/MaskedProperty.h
@@ -36,7 +36,9 @@ public:
   MaskedProperty(const std::string &name, const TYPE &defaultvalue,
                  const unsigned int direction);
 
-  MaskedProperty(const MaskedProperty &);
+  MaskedProperty(const MaskedProperty &) = default;
+  // Unhide the PropertyWithValue assignment operator
+  using Kernel::PropertyWithValue<TYPE>::operator=;
 
   /// "virtual" copy constructor
   MaskedProperty *clone() const override;
@@ -47,9 +49,6 @@ public:
   /** This method returns the masked property value
    */
   TYPE getMaskedValue() const;
-
-  // Unhide the PropertyWithValue assignment operator
-  using Kernel::PropertyWithValue<TYPE>::operator=;
 
 private:
   /// Perform the actual masking

--- a/Framework/Kernel/inc/MantidKernel/PropertyManagerProperty.h
+++ b/Framework/Kernel/inc/MantidKernel/PropertyManagerProperty.h
@@ -24,6 +24,9 @@ public:
   PropertyManagerProperty(const std::string &name,
                           const ValueType &defaultValue,
                           unsigned int direction = Direction::Input);
+
+  PropertyManagerProperty(const PropertyManagerProperty &);
+
   using BaseClass::operator=;
   PropertyManagerProperty *clone() const override {
     return new PropertyManagerProperty(*this);

--- a/Framework/Kernel/inc/MantidKernel/PropertyManagerProperty.h
+++ b/Framework/Kernel/inc/MantidKernel/PropertyManagerProperty.h
@@ -25,9 +25,10 @@ public:
                           const ValueType &defaultValue,
                           unsigned int direction = Direction::Input);
 
-  PropertyManagerProperty(const PropertyManagerProperty &);
-
+  PropertyManagerProperty(const PropertyManagerProperty &) = default;
+  PropertyManagerProperty &operator=(const PropertyManagerProperty &) = default;
   using BaseClass::operator=;
+
   PropertyManagerProperty *clone() const override {
     return new PropertyManagerProperty(*this);
   }

--- a/Framework/Kernel/inc/MantidKernel/PropertyWithValue.h
+++ b/Framework/Kernel/inc/MantidKernel/PropertyWithValue.h
@@ -53,8 +53,8 @@ public:
   std::string valueAsPrettyStr(const size_t maxLength = 0,
                                const bool collapseLists = true) const override;
   Json::Value valueAsJson() const override;
-  virtual bool operator==(const PropertyWithValue<TYPE> &rhs) const;
-  virtual bool operator!=(const PropertyWithValue<TYPE> &rhs) const;
+  bool operator==(const PropertyWithValue<TYPE> &rhs) const;
+  bool operator!=(const PropertyWithValue<TYPE> &rhs) const;
   int size() const override;
   std::string getDefault() const override;
   std::string setValue(const std::string &value) override;

--- a/Framework/Kernel/src/ArrayProperty.cpp
+++ b/Framework/Kernel/src/ArrayProperty.cpp
@@ -7,6 +7,7 @@
 #include "MantidKernel/ArrayProperty.h"
 
 // PropertyWithValue Definition
+#include "MantidKernel/PropertyWithValue.h"
 #include "MantidKernel/PropertyWithValue.tcc"
 
 namespace Mantid {
@@ -77,6 +78,10 @@ ArrayProperty<T>::ArrayProperty(const std::string &name,
     : PropertyWithValue<std::vector<T>>(std::move(name), std::vector<T>(),
                                         values, std::move(validator),
                                         direction) {}
+
+template <typename T>
+ArrayProperty<T>::ArrayProperty(const ArrayProperty<T> &other)
+    : PropertyWithValue<std::vector<T>>(other) {}
 
 /// 'Virtual copy constructor'
 template <typename T> ArrayProperty<T> *ArrayProperty<T>::clone() const {

--- a/Framework/Kernel/src/MaskedProperty.cpp
+++ b/Framework/Kernel/src/MaskedProperty.cpp
@@ -8,6 +8,7 @@
 #include "MantidKernel/PropertyHistory.h"
 
 // PropertyWithValue implementation
+#include "MantidKernel/PropertyWithValue.h"
 #include "MantidKernel/PropertyWithValue.tcc"
 
 namespace Mantid {
@@ -43,6 +44,10 @@ MaskedProperty<TYPE>::MaskedProperty(const std::string &name,
       m_maskedValue("") {
   this->setRemember(false);
 }
+
+template <typename T>
+MaskedProperty<T>::MaskedProperty(const MaskedProperty &other)
+    : Kernel::PropertyWithValue<T>(other), m_maskedValue(other.m_maskedValue) {}
 
 /**
  * Virtual copy

--- a/Framework/Kernel/src/MaskedProperty.cpp
+++ b/Framework/Kernel/src/MaskedProperty.cpp
@@ -45,10 +45,6 @@ MaskedProperty<TYPE>::MaskedProperty(const std::string &name,
   this->setRemember(false);
 }
 
-template <typename T>
-MaskedProperty<T>::MaskedProperty(const MaskedProperty &other)
-    : Kernel::PropertyWithValue<T>(other), m_maskedValue(other.m_maskedValue) {}
-
 /**
  * Virtual copy
  */

--- a/Framework/Kernel/src/PropertyManagerProperty.cpp
+++ b/Framework/Kernel/src/PropertyManagerProperty.cpp
@@ -46,6 +46,11 @@ PropertyManagerProperty::PropertyManagerProperty(const std::string &name,
     m_defaultAsStr = defaultValue->asString(true);
 }
 
+PropertyManagerProperty::PropertyManagerProperty(
+    const PropertyManagerProperty &other)
+    : BaseClass(other), m_dataServiceKey(other.m_dataServiceKey),
+      m_defaultAsStr(other.m_defaultAsStr) {}
+
 /**
  * @return The value of the property represented as a string
  */

--- a/Framework/Kernel/src/PropertyManagerProperty.cpp
+++ b/Framework/Kernel/src/PropertyManagerProperty.cpp
@@ -46,11 +46,6 @@ PropertyManagerProperty::PropertyManagerProperty(const std::string &name,
     m_defaultAsStr = defaultValue->asString(true);
 }
 
-PropertyManagerProperty::PropertyManagerProperty(
-    const PropertyManagerProperty &other)
-    : BaseClass(other), m_dataServiceKey(other.m_dataServiceKey),
-      m_defaultAsStr(other.m_defaultAsStr) {}
-
 /**
  * @return The value of the property represented as a string
  */

--- a/Framework/Kernel/src/VisibleWhenProperty.cpp
+++ b/Framework/Kernel/src/VisibleWhenProperty.cpp
@@ -5,7 +5,9 @@
 //   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
 // SPDX - License - Identifier: GPL - 3.0 +
 #include "MantidKernel/VisibleWhenProperty.h"
+
 #include <memory>
+#include <stdexcept>
 
 namespace Mantid {
 namespace Kernel {

--- a/Framework/LiveData/src/Kafka/KafkaBroker.cpp
+++ b/Framework/LiveData/src/Kafka/KafkaBroker.cpp
@@ -30,7 +30,7 @@ KafkaBroker::subscribe(std::vector<std::string> topics,
   auto subscriber = std::make_unique<KafkaTopicSubscriber>(m_address, topics,
                                                            subscribeOption);
   subscriber->subscribe();
-  return std::move(subscriber);
+  return subscriber;
 }
 
 std::unique_ptr<IKafkaStreamSubscriber>
@@ -39,7 +39,7 @@ KafkaBroker::subscribe(std::vector<std::string> topics, int64_t offset,
   auto subscriber = std::make_unique<KafkaTopicSubscriber>(m_address, topics,
                                                            subscribeOption);
   subscriber->subscribe(offset);
-  return std::move(subscriber);
+  return subscriber;
 }
 
 } // namespace LiveData

--- a/Framework/TestHelpers/src/ONCatHelper.cpp
+++ b/Framework/TestHelpers/src/ONCatHelper.cpp
@@ -104,7 +104,7 @@ IOAuthTokenStore_uptr make_mock_token_store_already_logged_in() {
       "Bearer", 3600, "2KSL5aEnLvIudMHIjc7LcBWBCfxOHZ",
       "api:read data:read settings:read",
       boost::make_optional<std::string>("eZEiz7LbgFrkL5ZHv7R4ck9gOzXexb")));
-  return std::move(tokenStore);
+  return tokenStore;
 }
 
 } // namespace TestHelpers

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/MainWindow/MainWindowPresenter.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/MainWindow/MainWindowPresenter.cpp
@@ -68,8 +68,8 @@ MainWindowPresenter::~MainWindowPresenter() = default;
 
 MainWindowPresenter::MainWindowPresenter(MainWindowPresenter &&) = default;
 
-MainWindowPresenter &MainWindowPresenter::
-operator=(MainWindowPresenter &&) = default;
+MainWindowPresenter &
+MainWindowPresenter::operator=(MainWindowPresenter &&) = default;
 
 void MainWindowPresenter::notifyNewBatchRequested() {
   auto *newBatchView = m_view->newBatch();
@@ -318,7 +318,7 @@ void MainWindowPresenter::notifyLoadBatchRequested(int tabIndex) {
   QMap<QString, QVariant> map;
   try {
     map = m_fileHandler->loadJSONFromFile(filename);
-  } catch (const std::runtime_error) {
+  } catch (const std::runtime_error &) {
     m_messageHandler->giveUserCritical(
         "Unable to load requested file. Please load a file of "
         "appropriate format saved from the GUI.",

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/MainWindow/MainWindowPresenter.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/MainWindow/MainWindowPresenter.cpp
@@ -68,8 +68,8 @@ MainWindowPresenter::~MainWindowPresenter() = default;
 
 MainWindowPresenter::MainWindowPresenter(MainWindowPresenter &&) = default;
 
-MainWindowPresenter &
-MainWindowPresenter::operator=(MainWindowPresenter &&) = default;
+MainWindowPresenter &MainWindowPresenter::
+operator=(MainWindowPresenter &&) = default;
 
 void MainWindowPresenter::notifyNewBatchRequested() {
   auto *newBatchView = m_view->newBatch();

--- a/qt/scientific_interfaces/Indirect/ConvFitDataPresenter.cpp
+++ b/qt/scientific_interfaces/Indirect/ConvFitDataPresenter.cpp
@@ -86,7 +86,7 @@ ConvFitDataPresenter::getAddWorkspaceDialog(QWidget *parent) const {
   auto dialog = std::make_unique<ConvFitAddWorkspaceDialog>(parent);
   dialog->setResolutionFBSuffices(getView()->getResolutionFBSuffices());
   dialog->setResolutionWSSuffices(getView()->getResolutionWSSuffices());
-  return std::move(dialog);
+  return dialog;
 }
 
 void ConvFitDataPresenter::setMultiInputResolutionFBSuffixes(

--- a/qt/scientific_interfaces/Indirect/JumpFitDataPresenter.cpp
+++ b/qt/scientific_interfaces/Indirect/JumpFitDataPresenter.cpp
@@ -249,7 +249,7 @@ JumpFitDataPresenter::getAddWorkspaceDialog(QWidget *parent) const {
           this,
           SLOT(dialogParameterTypeUpdated(JumpFitAddWorkspaceDialog *,
                                           const std::string &)));
-  return std::move(dialog);
+  return dialog;
 }
 
 void JumpFitDataPresenter::setMultiInputResolutionFBSuffixes(

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/MantidWSIndexDialog.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/MantidWSIndexDialog.h
@@ -117,8 +117,6 @@ public:
   explicit IntervalList(const QString & /*intervals*/);
   /// Constructor - with a list containing a single Interval
   explicit IntervalList(const Interval & /*interval*/);
-  /// Copy Constructor
-  IntervalList(const IntervalList & /*copy*/);
 
   /// Returns a reference to the list of Intervals.
   const QList<Interval> &getList() const;

--- a/qt/widgets/common/src/MantidWSIndexDialog.cpp
+++ b/qt/widgets/common/src/MantidWSIndexDialog.cpp
@@ -1094,8 +1094,6 @@ IntervalList::IntervalList(const Interval &interval) {
   m_list.append(interval);
 }
 
-IntervalList::IntervalList(const IntervalList &copy) { m_list = copy.m_list; }
-
 const QList<Interval> &IntervalList::getList() const { return m_list; }
 
 int IntervalList::totalIntervalLength() const {

--- a/qt/widgets/plotting/inc/MantidQtWidgets/Plotting/Qwt/QwtWorkspaceBinData.h
+++ b/qt/widgets/plotting/inc/MantidQtWidgets/Plotting/Qwt/QwtWorkspaceBinData.h
@@ -41,8 +41,6 @@ public:
   QString getYAxisLabel() const override;
 
 protected:
-  // Assignment operator.
-  QwtWorkspaceBinData &operator=(const QwtWorkspaceBinData & /*rhs*/);
   /**
   Return the x value of data point i
   @param i :: Index

--- a/qt/widgets/plotting/inc/MantidQtWidgets/Plotting/Qwt/QwtWorkspaceSpectrumData.h
+++ b/qt/widgets/plotting/inc/MantidQtWidgets/Plotting/Qwt/QwtWorkspaceSpectrumData.h
@@ -66,11 +66,6 @@ public:
 
   bool setAsDistribution(bool on = true);
 
-protected:
-  // Assignment operator (virtualized). MSVC not happy with compiler generated
-  // one
-  QwtWorkspaceSpectrumData &operator=(const QwtWorkspaceSpectrumData & /*rhs*/);
-
 private:
   friend class MantidMatrixCurve;
 

--- a/qt/widgets/plotting/src/Qwt/QwtWorkspaceBinData.cpp
+++ b/qt/widgets/plotting/src/Qwt/QwtWorkspaceBinData.cpp
@@ -75,23 +75,6 @@ QString QwtWorkspaceBinData::getXAxisLabel() const { return m_xTitle; }
  */
 QString QwtWorkspaceBinData::getYAxisLabel() const { return m_yTitle; }
 
-/**
- * @param rhs A source object whose state is copied here
- * @return A reference to this object
- */
-QwtWorkspaceBinData &QwtWorkspaceBinData::
-operator=(const QwtWorkspaceBinData &rhs) {
-  if (this != &rhs) {
-    m_binIndex = rhs.m_binIndex;
-    m_X = rhs.m_X;
-    m_Y = rhs.m_Y;
-    m_E = rhs.m_E;
-    m_xTitle = rhs.m_xTitle;
-    m_yTitle = rhs.m_yTitle;
-  }
-  return *this;
-}
-
 //-----------------------------------------------------------------------------
 // Private methods
 //-----------------------------------------------------------------------------

--- a/qt/widgets/plotting/src/Qwt/QwtWorkspaceSpectrumData.cpp
+++ b/qt/widgets/plotting/src/Qwt/QwtWorkspaceSpectrumData.cpp
@@ -125,25 +125,3 @@ bool QwtWorkspaceSpectrumData::setAsDistribution(bool on) {
   m_isDistribution = on && m_isHistogram;
   return m_isDistribution;
 }
-
-//-----------------------------------------------------------------------------
-// Protected methods
-//-----------------------------------------------------------------------------
-/**
- * @param rhs A source object whose state is copied here
- * @return A reference to this object
- */
-QwtWorkspaceSpectrumData &QwtWorkspaceSpectrumData::
-operator=(const QwtWorkspaceSpectrumData &rhs) {
-  if (this != &rhs) {
-    m_wsIndex = rhs.m_wsIndex;
-    m_X = rhs.m_X;
-    m_Y = rhs.m_Y;
-    m_E = rhs.m_E;
-    m_xTitle = rhs.m_xTitle;
-    m_yTitle = rhs.m_yTitle;
-    m_isHistogram = rhs.m_isHistogram;
-    m_binCentres = rhs.m_binCentres;
-  }
-  return *this;
-}


### PR DESCRIPTION
**Description of work.**
Clears down various GCC-8 / 9 warnings which have crept into master and are making builds noisy for myself. This is primarily:

- Us not following Rule of 0/3/5 in C++ by missing out the copy constructor
- Using std::move where we should be relying on copy elision
- Catching some exceptions by copy


**To test:**
- Check builds pass
---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
