### PR TITLE
Improve extrapolation beyond range of supplied attenuation profile

### DIFF
--- a/Framework/Kernel/inc/MantidKernel/AttenuationProfile.h
+++ b/Framework/Kernel/inc/MantidKernel/AttenuationProfile.h
@@ -1,8 +1,8 @@
 // Mantid Repository : https://github.com/mantidproject/mantid
 //
 // Copyright &copy; 2020 ISIS Rutherford Appleton Laboratory UKRI,
-//     NScD Oak Ridge National Laboratory, European Spallation Source
-//     & Institut Laue - Langevin
+//     NScD Oak Ridge National Laboratory, European Spallation Source,
+//     Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
 // SPDX - License - Identifier: GPL - 3.0 +
 #pragma once
 
@@ -13,10 +13,13 @@
 namespace Mantid {
 namespace Kernel {
 
+class Material;
+
 class MANTID_KERNEL_DLL AttenuationProfile {
 public:
   AttenuationProfile(const std::string &inputFileName,
-                     const std::string &searchPath);
+                     const std::string &searchPath,
+                     Material *extrapolationMaterial = nullptr);
   double getAttenuationCoefficient(const double lambda) const;
 
 private:

--- a/Framework/Kernel/inc/MantidKernel/Material.h
+++ b/Framework/Kernel/inc/MantidKernel/Material.h
@@ -30,6 +30,8 @@ class Atom;
 
 namespace Kernel {
 
+class AttenuationProfile;
+
 /**
   A material is defined as being composed of a given element, defined as a
   PhysicalConstants::NeutronAtom, with the following properties:
@@ -104,6 +106,7 @@ public:
   double
   absorbXSection(const double lambda =
                      PhysicalConstants::NeutronAtom::ReferenceLambda) const;
+  double attenuationCoefficient(const double lambda) const;
   /// Compute the attenuation at a given wavelength over the given distance
   double attenuation(const double distance,
                      const double lambda =

--- a/Framework/Kernel/src/AttenuationProfile.cpp
+++ b/Framework/Kernel/src/AttenuationProfile.cpp
@@ -1,12 +1,13 @@
 // Mantid Repository : https://github.com/mantidproject/mantid
 //
 // Copyright &copy; 2020 ISIS Rutherford Appleton Laboratory UKRI,
-//     NScD Oak Ridge National Laboratory, European Spallation Source
-//     & Institut Laue - Langevin
+//     NScD Oak Ridge National Laboratory, European Spallation Source,
+//     Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
 // SPDX - License - Identifier: GPL - 3.0 +
 #include "MantidKernel/AttenuationProfile.h"
 #include "MantidKernel/ConfigService.h"
 #include "MantidKernel/Exception.h"
+#include "MantidKernel/Material.h"
 #include <Poco/File.h>
 #include <Poco/Path.h>
 #include <fstream>
@@ -14,14 +15,22 @@
 namespace Mantid {
 namespace Kernel {
 
+namespace {
+constexpr auto LARGE_LAMBDA = 100; // Lambda likely to be beyond max lambda in
+                                   // any measured spectra. In Angstroms
+}
+
 /**
  * Construct an attenuation profile object
  * @param inputFileName :: The name of the file containing the attenuation
  * profile data. Filename can be a full path or just file name
  * @param searchPath :: Path to search for the input file
+ * @param extrapolationMaterial :: Material whose properties will be used to
+ * extrapolate beyond the lambda range of the supplied profile
  */
 AttenuationProfile::AttenuationProfile(const std::string &inputFileName,
-                                       const std::string &searchPath) {
+                                       const std::string &searchPath,
+                                       Material *extrapolationMaterial) {
   Poco::Path suppliedFileName(inputFileName);
   Poco::Path inputFilePath;
   std::string fileExt = suppliedFileName.getExtension();
@@ -55,13 +64,33 @@ AttenuationProfile::AttenuationProfile(const std::string &inputFileName,
     std::ifstream input(inputFilePath.toString(), std::ios_base::in);
     if (input) {
       std::string line;
+      double minLambda = std::numeric_limits<double>::max();
+      double maxLambda = std::numeric_limits<double>::min();
       while (std::getline(input, line)) {
         double lambda, alpha, error;
         if (std::stringstream(line) >> lambda >> alpha >> error) {
+          minLambda = std::min(lambda, minLambda);
+          maxLambda = std::max(lambda, maxLambda);
           m_Interpolator.addPoint(lambda, 1000 * alpha);
         }
       }
       input.close();
+      // Assist the extrapolation outside the supplied lambda range to better
+      // handle noisy data. Add two surrounding points using the attenuation
+      // calculated from tabulated absorption\scattering cross sections
+      if (m_Interpolator.containData() && extrapolationMaterial) {
+        if ((minLambda > 0) &&
+            (minLambda < std::numeric_limits<double>::max())) {
+          m_Interpolator.addPoint(
+              0, extrapolationMaterial->attenuationCoefficient(0));
+        }
+        if ((maxLambda < LARGE_LAMBDA) &&
+            (maxLambda > std::numeric_limits<double>::min())) {
+          m_Interpolator.addPoint(
+              LARGE_LAMBDA,
+              extrapolationMaterial->attenuationCoefficient(LARGE_LAMBDA));
+        }
+      }
     } else {
       throw Exception::FileError("Error reading attenuation profile file",
                                  inputFileName);

--- a/Framework/Kernel/src/MaterialBuilder.cpp
+++ b/Framework/Kernel/src/MaterialBuilder.cpp
@@ -259,7 +259,8 @@ Material MaterialBuilder::build() const {
   }
   if (m_attenuationProfileFileName) {
     AttenuationProfile materialAttenuation(m_attenuationProfileFileName.get(),
-                                           m_attenuationFileSearchPath);
+                                           m_attenuationFileSearchPath,
+                                           material.get());
     material->setAttenuationProfile(materialAttenuation);
   }
   return *material;

--- a/Framework/Kernel/test/AttenuationProfileTest.h
+++ b/Framework/Kernel/test/AttenuationProfileTest.h
@@ -1,14 +1,15 @@
 // Mantid Repository : https://github.com/mantidproject/mantid
 //
 // Copyright &copy; 2020 ISIS Rutherford Appleton Laboratory UKRI,
-//     NScD Oak Ridge National Laboratory, European Spallation Source
-//     & Institut Laue - Langevin
+//     NScD Oak Ridge National Laboratory, European Spallation Source,
+//     Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
 // SPDX - License - Identifier: GPL - 3.0 +
 #pragma once
 
 #include "MantidKernel/AttenuationProfile.h"
 #include "MantidKernel/ConfigService.h"
 #include "MantidKernel/Exception.h"
+#include "MantidKernel/Material.h"
 #include <ctime>
 #include <cxxtest/TestSuite.h>
 
@@ -27,21 +28,38 @@ public:
   void testLoadAttenuationFile() {
     std::string path = Mantid::Kernel::ConfigService::Instance().getFullPath(
         "AttenuationProfile.DAT", false, 0);
-    TS_ASSERT_THROWS_NOTHING(auto loader = AttenuationProfile(path, ""));
+    TS_ASSERT_THROWS_NOTHING(auto profile = AttenuationProfile(path, ""));
   }
 
   void testLoadInvalidAttenuationFile() {
     std::string path = Mantid::Kernel::ConfigService::Instance().getFullPath(
         "INVALID.DAT", false, 0);
-    TS_ASSERT_THROWS(auto loader = AttenuationProfile(path, ""),
+    TS_ASSERT_THROWS(auto profile = AttenuationProfile(path, ""),
                      Mantid::Kernel::Exception::FileError &);
   }
 
   void testGetAttenuationCoefficient() {
     std::string path = Mantid::Kernel::ConfigService::Instance().getFullPath(
         "AttenuationProfile.DAT", false, 0);
-    auto loader = AttenuationProfile(path, "");
-    TS_ASSERT_EQUALS(loader.getAttenuationCoefficient(0.10027009),
+    auto profile = AttenuationProfile(path, "");
+    TS_ASSERT_EQUALS(profile.getAttenuationCoefficient(0.10027009),
                      1000 * 0.82631156E-01);
+  }
+
+  void testGetAttenuationCoefficientBeyondRange() {
+    Material::ChemicalFormula formula;
+    formula = Material::parseChemicalFormula("C");
+    auto testMaterial =
+        std::make_unique<Material>("test", formula, 3.51); // diamond
+    std::string path = Mantid::Kernel::ConfigService::Instance().getFullPath(
+        "AttenuationProfile.DAT", false, 0);
+    auto profile = AttenuationProfile(path, "", testMaterial.get());
+    auto profileWithEmptyMaterial = AttenuationProfile(path, "");
+    TS_ASSERT_EQUALS(profile.getAttenuationCoefficient(0),
+                     testMaterial->attenuationCoefficient(0));
+    // double check the supplied attenuation profile didn't happen to have
+    // a value at zero matching the coefficient from the material
+    TS_ASSERT_DIFFERS(profileWithEmptyMaterial.getAttenuationCoefficient(0),
+                      testMaterial->attenuationCoefficient(0));
   }
 };


### PR DESCRIPTION
**Description of work.**

Previously, if an attenuation factor was requested for a lambda that is outside the range of an explicit attenuation profile the code extrapolated based on the gradient of the two most extreme points.
If the data was noisy this gave some poor results. Improve this by falling back on the tabulated linear absorption coefficient of an optional ExtrapolationMaterial
This functionality is used in absorption correction calculations.

**To test:**
This takes a lot of describing but hopefully not too long to actually run. Give me a shout if it's not clear.

The following python script runs an absorption correction calculation on the Pearl environment that results in the type of call into AttenuationProfile that is the subject of this PR. One part of the environment is made of Sintered Diamond which is a mix of Diamond and Cobalt and this has an explicit attenuation profile specified in the Pearl environment definition file (instrument\sampleenvironments\ISIS\Pearl.xml). Attenuation factors are requested for wavelengths that are lower and higher than the range in the explicit attenuation profile (the wavelength range is 0.1 to 5.5 Angstroms but the calculation requests an attenuation factor for 0.029 Angstroms for example).

I suggest you run it before (nightly build)\after(this PR) and observe that the resulting spectrum in sample_env_mesh_abscorr changes at low wavelengths eg in the 0.029 Angstroms bin (this spectrum is an absorption correction):
```
from __future__ import print_function, division, unicode_literals

from mantid.simpleapi import (ConvertUnits, Load, LoadSampleShape, MonteCarloAbsorption, SetSample, GroupDetectors)
import matplotlib.pyplot as plt

# Grab some data. This happens to be a run with a 10mm vanadium sphere

# select spectra for detector id 1040
sample_env_mesh = Load(Filename='PEARL00073987.raw', SpectrumList='48')
# MonteCarloAbsorption works in wavelength
sample_env_mesh = ConvertUnits(InputWorkspace=sample_env_mesh, Target='Wavelength')

SetSample(InputWorkspace=sample_env_mesh, Environment={'Name':'Pearl'},Material={'ChemicalFormula': 'Ni'})

sample_env_mesh_abscorr = MonteCarloAbsorption(InputWorkspace=sample_env_mesh, EventsPerPoint=100)
```


Fixes #28446 .

*This does not require release notes* because it's an extension to an earlier pull request (#28408) that already added a comment about the explicit attenuation profile feature in the release notes

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
