### PR TITLE
Fix being unable to plot in Workbench

### DIFF
--- a/qt/applications/workbench/workbench/plotting/figuremanager.py
+++ b/qt/applications/workbench/workbench/plotting/figuremanager.py
@@ -368,7 +368,7 @@ class FigureManagerWorkbench(FigureManagerBase, QObject):
         self.toolbar.hold()
 
     def get_window_title(self):
-        return isinstance(self.window.windowTitle(), str)
+        return self.window.windowTitle()
 
     def set_window_title(self, title):
         self.window.setWindowTitle(title)

--- a/qt/applications/workbench/workbench/plotting/test/test_figuremanager.py
+++ b/qt/applications/workbench/workbench/plotting/test/test_figuremanager.py
@@ -23,6 +23,14 @@ class FigureManagerWorkbenchTest(unittest.TestCase):
         fig_mgr = FigureManagerWorkbench(canvas, 1)
         self.assertNotEqual(fig_mgr, None)
 
+    @patch("workbench.plotting.figuremanager.QAppThreadCall")
+    def test_window_title(self, mock_qappthread):
+        mock_qappthread.return_value = mock_qappthread
+        fig = MagicMock()
+        canvas = FigureCanvasQTAgg(fig)
+        fig_mgr = FigureManagerWorkbench(canvas, 1)
+        self.assertEqual(fig_mgr.get_window_title(), "Figure 1")
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
**Description of work.**
This PR fixes the `get_window_title` function in the `FigureManagerWorkbench` class so that it correctly returns a string instead of a bool. Now you should be able to create plots.

**To test:**
Plot something

Fixes #28460 

No release notes because the bug is not present in a release.

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
