### PR TITLE
IndirectReduction GUI slowing processing on workbench when open.

### DIFF
--- a/docs/source/release/v5.1.0/indirect_geometry.rst
+++ b/docs/source/release/v5.1.0/indirect_geometry.rst
@@ -5,8 +5,9 @@ Indirect Geometry Changes
 .. contents:: Table of Contents
    :local:
 
-.. warning:: **Developers:** Sort changes under appropriate heading
-    putting new features at the top of the section, followed by
-    improvements, followed by bug fixes.
+Improvements
+############
+
+- An issue with IndirectDataReduction causing it to slow down processing when open has been resolved.
 
 :ref:`Release 5.1.0 <v5.1.0>`

--- a/qt/widgets/plotting/src/Mpl/ContourPreviewPlot.cpp
+++ b/qt/widgets/plotting/src/Mpl/ContourPreviewPlot.cpp
@@ -68,11 +68,15 @@ void ContourPreviewPlot::onWorkspaceRemoved(
   if (auto workspace =
           boost::dynamic_pointer_cast<MatrixWorkspace>(nf->object())) {
     // If the artist has already been removed, ignore.
+    bool workspaceRemoved = false;
     try {
-      m_canvas->gca<MantidAxes>().removeWorkspaceArtists(workspace);
+      workspaceRemoved =
+          m_canvas->gca<MantidAxes>().removeWorkspaceArtists(workspace);
     } catch (Mantid::PythonInterface::PythonException &) {
     }
-    m_canvas->draw();
+    if (workspaceRemoved) {
+      m_canvas->draw();
+    }
   }
 }
 
@@ -86,8 +90,9 @@ void ContourPreviewPlot::onWorkspaceReplaced(
           boost::dynamic_pointer_cast<MatrixWorkspace>(nf->oldObject())) {
     if (auto newWorkspace =
             boost::dynamic_pointer_cast<MatrixWorkspace>(nf->newObject())) {
-      m_canvas->gca<MantidAxes>().replaceWorkspaceArtists(newWorkspace);
-      m_canvas->draw();
+      if (m_canvas->gca<MantidAxes>().replaceWorkspaceArtists(newWorkspace)) {
+        m_canvas->draw();
+      }
     }
   }
 }


### PR DESCRIPTION
**Description of work.**

The script in #28194 runs more slowly in workbench when the Indirect reduction interface is open than when it is not. Upon investigation this was due to the 2D contour plot in the interface redrawing whenever a workspace was changed in the ADS. To solve this checks have been added that a relevant workspace has changed before a re-draw is done.

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

**To test:**
* Run the script from #28194 with and without the IndirectDataReduction interface open. Check that it takes approximately the same amount of time in each case.

<!-- Instructions for testing. -->

Fixes #28436  <!-- and fix #xxxx or close #xxxx xor resolves #xxxx -->
<!-- alternative
*There is no associated issue.*
-->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
