### PR TITLE
Equality for sample run

### DIFF
--- a/Framework/API/inc/MantidAPI/LogManager.h
+++ b/Framework/API/inc/MantidAPI/LogManager.h
@@ -182,6 +182,9 @@ public:
   /// Clear the logs
   void clearLogs();
 
+  bool operator==(const LogManager &other) const;
+  bool operator!=(const LogManager &other) const;
+
 protected:
   /// Load the run from a NeXus file with a given group name
   void loadNexus(::NeXus::File *file,

--- a/Framework/API/inc/MantidAPI/Run.h
+++ b/Framework/API/inc/MantidAPI/Run.h
@@ -41,6 +41,8 @@ public:
   Run(const Run &other);
   ~Run();
   Run &operator=(const Run &other);
+  bool operator==(const Run &other);
+  bool operator!=(const Run &other);
 
   /// Clone
   boost::shared_ptr<Run> clone();

--- a/Framework/API/inc/MantidAPI/Sample.h
+++ b/Framework/API/inc/MantidAPI/Sample.h
@@ -116,6 +116,9 @@ public:
   /// Delete the oriented lattice
   void clearOrientedLattice();
 
+  bool operator==(const Sample &other) const;
+  bool operator!=(const Sample &other) const;
+
 private:
   /// The sample name
   std::string m_name;

--- a/Framework/API/src/LogManager.cpp
+++ b/Framework/API/src/LogManager.cpp
@@ -549,6 +549,14 @@ void LogManager::loadNexus(::NeXus::File *file,
  */
 void LogManager::clearLogs() { m_manager->clear(); }
 
+bool LogManager::operator==(const LogManager &other) const {
+  return *m_manager == *(other.m_manager);
+}
+
+bool LogManager::operator!=(const LogManager &other) const {
+  return *m_manager != *(other.m_manager);
+}
+
 //-----------------------------------------------------------------------------------------------------------------------
 // Private methods
 //-----------------------------------------------------------------------------------------------------------------------

--- a/Framework/API/src/Run.cpp
+++ b/Framework/API/src/Run.cpp
@@ -62,6 +62,14 @@ Run &Run::operator=(const Run &other) {
   return *this;
 }
 
+bool Run::operator==(const Run &other) {
+  return *m_goniometer == *other.m_goniometer &&
+         LogManager::operator==(other) &&
+         this->m_histoBins == other.m_histoBins;
+}
+
+bool Run::operator!=(const Run &other) { return !this->operator==(other); }
+
 boost::shared_ptr<Run> Run::clone() {
   auto clone = boost::make_shared<Run>();
   for (auto property : this->m_manager->getProperties()) {

--- a/Framework/API/src/Sample.cpp
+++ b/Framework/API/src/Sample.cpp
@@ -423,5 +423,37 @@ void Sample::clearOrientedLattice() {
     m_lattice.reset(nullptr);
   }
 }
+
+bool Sample::operator==(const Sample &other) const {
+  if (m_samples.size() != other.m_samples.size())
+    return false;
+  for (size_t i = 0; i < m_samples.size(); ++i) {
+    if (*m_samples[i] != *other.m_samples[i])
+      return false;
+  }
+  auto compare = [](const auto &a, const auto &b, auto call_on) {
+    // both null or both not null
+    if (bool(a) ^ bool(b))
+      return false;
+    if (a)
+      return call_on(a) == call_on(b);
+    else
+      return true;
+
+  };
+  return *m_lattice == *other.m_lattice && this->m_name == other.m_name &&
+         this->m_height == other.m_height && this->m_width == other.m_width &&
+         this->m_thick == other.m_thick && m_geom_id == other.m_geom_id &&
+         compare(m_environment, other.m_environment,
+                 [](const auto &x) { return x->name(); }) &&
+         compare(m_shape, other.m_shape,
+                 [](const auto &x) { return x->shape(); }) &&
+         compare(m_crystalStructure, other.m_crystalStructure,
+                 [](const auto &x) { return *(x->spaceGroup()); });
+}
+
+bool Sample::operator!=(const Sample &other) const {
+  return !this->operator==(other);
+}
 } // namespace API
 } // namespace Mantid

--- a/Framework/API/src/Sample.cpp
+++ b/Framework/API/src/Sample.cpp
@@ -439,7 +439,6 @@ bool Sample::operator==(const Sample &other) const {
       return call_on(a) == call_on(b);
     else
       return true;
-
   };
   return *m_lattice == *other.m_lattice && this->m_name == other.m_name &&
          this->m_height == other.m_height && this->m_width == other.m_width &&

--- a/Framework/API/test/LogManagerTest.h
+++ b/Framework/API/test/LogManagerTest.h
@@ -28,6 +28,7 @@ namespace {
 class ConcreteProperty : public Property {
 public:
   ConcreteProperty() : Property("Test", typeid(int)) {}
+  ConcreteProperty(std::string name) : Property(name, typeid(int)) {}
   ConcreteProperty *clone() const override {
     return new ConcreteProperty(*this);
   }
@@ -35,15 +36,21 @@ public:
   std::string getDefault() const override {
     return "getDefault() is not implemented in this class";
   }
-  std::string value() const override { return "Nothing"; }
+  std::string value() const override { return m_value; }
   Json::Value valueAsJson() const override { return Json::Value(); }
-  std::string setValue(const std::string &) override { return ""; }
+  std::string setValue(const std::string &value) override {
+    m_value = value;
+    return m_value;
+  }
   std::string setValueFromJson(const Json::Value &) override { return ""; }
   std::string setValueFromProperty(const Property &) override { return ""; }
   std::string setDataItem(const boost::shared_ptr<DataItem>) override {
     return "";
   }
   Property &operator+=(Property const *) override { return *this; }
+
+private:
+  std::string m_value = "Nothing";
 };
 
 template <typename T>
@@ -185,7 +192,7 @@ public:
     runInfo.addProperty(p);
 
     TS_ASSERT_EQUALS(runInfo.getMemorySize(),
-                     sizeof(ConcreteProperty) + sizeof(void *));
+                     p->getMemorySize() + sizeof(Property *));
   }
 
   void test_GetTimeSeriesProperty_Returns_TSP_When_Log_Exists() {
@@ -528,6 +535,48 @@ public:
     th.file->openGroup("sample", "NXsample");
     LogManager run3;
     run3.loadNexus(th.file.get(), "");
+  }
+
+  void test_operator_equals() {
+    LogManager a;
+    LogManager b;
+    a.addProperty(std::make_unique<ConcreteProperty>());
+    b.addProperty(std::make_unique<ConcreteProperty>());
+    TS_ASSERT_EQUALS(a, b);
+    TS_ASSERT(!(a != b));
+  }
+
+  void test_not_equals_when_number_of_entries_differ() {
+    LogManager a;
+    LogManager b;
+    a.addProperty(std::make_unique<ConcreteProperty>("a1"));
+    b.addProperty(std::make_unique<ConcreteProperty>("b1"));
+    b.addProperty(std::make_unique<ConcreteProperty>("b2"));
+    TS_ASSERT_DIFFERS(a, b);
+    TS_ASSERT(!(a == b));
+  }
+
+  void test_not_equals_when_values_differ() {
+    LogManager a;
+    LogManager b;
+    auto prop1 = std::make_unique<ConcreteProperty>();
+    auto prop2 = std::make_unique<ConcreteProperty>();
+    prop2->setValue("another_value");
+    a.addProperty(std::move(prop1));
+    b.addProperty(std::move(prop2));
+    TS_ASSERT_DIFFERS(a, b);
+    TS_ASSERT(!(a == b));
+  }
+
+  void test_not_equals_when_keys_differ() {
+    LogManager a;
+    LogManager b;
+    auto prop1 = std::make_unique<ConcreteProperty>("Temp");
+    auto prop2 = std::make_unique<ConcreteProperty>("Pressure");
+    a.addProperty(std::move(prop1));
+    b.addProperty(std::move(prop2));
+    TS_ASSERT_DIFFERS(a, b);
+    TS_ASSERT(!(a == b));
   }
 
 private:

--- a/Framework/API/test/RunTest.h
+++ b/Framework/API/test/RunTest.h
@@ -609,6 +609,65 @@ public:
     TS_ASSERT_DELTA(run3.getProtonCharge(), 1.234, 1e-5);
   }
 
+  void test_equals_when_runs_empty() {
+    Run a{};
+    Run b{a};
+    TS_ASSERT_EQUALS(a, b);
+  }
+
+  void test_equals_when_runs_identical() {
+    Run a{};
+    a.addProperty(std::make_unique<ConcreteProperty>());
+    const DblMatrix rotation_x{
+        {1, 0, 0, 0, 0, -1, 0, 1, 0}}; // 90 degrees around x axis
+    a.setGoniometer(Goniometer{rotation_x}, false /*do not use log angles*/);
+    a.storeHistogramBinBoundaries({1, 2, 3, 4});
+    Run b{a};
+    TS_ASSERT_EQUALS(a, b);
+    TS_ASSERT(!(a != b));
+  }
+
+  void test_not_equal_when_histogram_bin_boundaries_differ() {
+    Run a{};
+    a.addProperty(std::make_unique<ConcreteProperty>());
+    DblMatrix rotation_x{
+        {1, 0, 0, 0, 0, -1, 0, 1, 0}}; // 90 degrees around x axis
+    a.setGoniometer(Goniometer{rotation_x}, false /*do not use log angles*/);
+    a.storeHistogramBinBoundaries({1, 2, 3, 4});
+    Run b{a};
+    b.storeHistogramBinBoundaries({0, 2, 3, 4});
+    TS_ASSERT_DIFFERS(a, b);
+    TS_ASSERT(!(a == b));
+  }
+
+  void test_not_equal_when_properties_differ() {
+    Run a{};
+    a.addProperty(std::make_unique<ConcreteProperty>());
+    DblMatrix rotation_x{
+        {1, 0, 0, 0, 0, -1, 0, 1, 0}}; // 90 degrees around x axis
+    a.setGoniometer(Goniometer{rotation_x}, false /*do not use log angles*/);
+    a.storeHistogramBinBoundaries({1, 2, 3, 4});
+    Run b{a};
+    b.removeProperty("Test");
+    TS_ASSERT_DIFFERS(a, b);
+    TS_ASSERT(!(a == b));
+  }
+
+  void test_not_equal_when_goniometer_differ() {
+    Run a{};
+    a.addProperty(std::make_unique<ConcreteProperty>());
+    DblMatrix rotation_x{
+        {1, 0, 0, 0, 0, -1, 0, 1, 0}}; // 90 degrees around x axis
+    a.setGoniometer(Goniometer{rotation_x}, false /*do not use log angles*/);
+    a.storeHistogramBinBoundaries({1, 2, 3, 4});
+    Run b{a};
+    Mantid::Kernel::DblMatrix rotation_y{
+        {0, 0, 1, 0, 1, 0, -1, 0, 0}}; // 90 degrees around y axis
+    b.setGoniometer(Goniometer{rotation_y}, false /*do not use log angles*/);
+    TS_ASSERT_DIFFERS(a, b);
+    TS_ASSERT(!(a == b));
+  }
+
 private:
   /// Testing bins
   std::vector<double> m_test_energy_bins;

--- a/Framework/API/test/SampleTest.h
+++ b/Framework/API/test/SampleTest.h
@@ -359,4 +359,126 @@ public:
 
     TS_ASSERT(loaded.getName().empty());
   }
+
+  void test_equal_when_sample_identical() {
+    Sample a;
+    Sample b;
+    TS_ASSERT_EQUALS(a, b);
+  }
+
+  void test_not_equal_when_sample_differs_in_extents() {
+    Sample a;
+    auto b = a;
+    a.setHeight(10);
+    TS_ASSERT_DIFFERS(a, b);
+    TS_ASSERT(!(a == b));
+    b = a;
+    a.setWidth(10);
+    TS_ASSERT_DIFFERS(a, b);
+    TS_ASSERT(!(a == b));
+    b = a;
+    a.setThickness(10);
+    TS_ASSERT_DIFFERS(a, b);
+    TS_ASSERT(!(a == b));
+  }
+
+  void test_not_equal_when_sample_differs_in_geom_id() {
+    Sample a;
+    auto b = a;
+    TS_ASSERT_EQUALS(a, b);
+    a.setGeometryFlag(1);
+    b.setGeometryFlag(2);
+    TS_ASSERT_DIFFERS(a, b);
+    TS_ASSERT(!(a == b));
+  }
+  void test_not_equal_when_sample_differs_in_name() {
+    Sample a;
+    auto b = a;
+    b.setName("something");
+    TS_ASSERT_DIFFERS(a, b);
+    TS_ASSERT(!(a == b));
+  }
+
+  void test_not_equal_when_sample_differs_in_environment() {
+    auto kit1 = std::make_unique<SampleEnvironment>(
+        "Env", boost::make_shared<const Container>(""));
+
+    auto kit2 = std::make_unique<SampleEnvironment>(
+        "Env2", boost::make_shared<const Container>(""));
+
+    // same as kit1
+    auto kit3 = std::make_unique<SampleEnvironment>(
+        kit1->name(), boost::make_shared<const Container>(""));
+
+    Sample a;
+    auto b = a;
+    b.setEnvironment(std::move(kit1));
+    // A has no environment
+    TS_ASSERT_DIFFERS(a, b);
+    TS_ASSERT(!(a == b));
+
+    // A has valid but different same environment
+    a.setEnvironment(std::move(kit2));
+    TS_ASSERT_DIFFERS(a, b);
+    TS_ASSERT(!(a == b));
+
+    // A has valid but different same environment
+    a.setEnvironment(std::move(kit3));
+    TS_ASSERT_EQUALS(a, b);
+    TS_ASSERT(!(a != b));
+  }
+
+  void test_not_equal_when_sample_differs_in_shape() {
+    IObject_sptr shape1 = ComponentCreationHelper::createCappedCylinder(
+        0.0127, 1.0, V3D(), V3D(0.0, 1.0, 0.0), "cyl");
+
+    IObject_sptr shape2 = ComponentCreationHelper::createCappedCylinder(
+        0.0137, 1.0, V3D(), V3D(0.0, 0.0, 0.0), "cyl");
+
+    Sample a;
+    auto b = a;
+    a.setShape(shape1);
+    // b has no shape
+    TS_ASSERT_DIFFERS(a, b);
+    TS_ASSERT(!(a == b));
+
+    // b has different shape
+    b.setShape(shape2);
+    TS_ASSERT_DIFFERS(a, b);
+    TS_ASSERT(!(a == b));
+
+    // b has same shape
+    b.setShape(IObject_sptr(shape1->clone()));
+    TS_ASSERT_EQUALS(a, b);
+    TS_ASSERT(!(a != b));
+  }
+
+  void test_not_equal_when_sample_differs_in_space_group() {
+    CrystalStructure structure1("3 4 5 90 90 90", "C m m m",
+                                "Fe 0.12 0.23 0.121");
+    // Same as above
+    CrystalStructure structure2("3 4 5 90 90 90", "C m m m",
+                                "Fe 0.12 0.23 0.121");
+    // Different
+    CrystalStructure structure3("5.431 5.431 5.431", "F d -3 m",
+                                "Si 0 0 0 1.0 0.02");
+
+    Sample a;
+    auto b = a;
+    // b has no structure
+    a.setCrystalStructure(structure1);
+    TS_ASSERT_DIFFERS(a, b);
+    TS_ASSERT(!(a == b));
+
+    // b has different structure
+    b.setCrystalStructure(structure3);
+    TS_ASSERT_DIFFERS(a, b);
+    TS_ASSERT(!(a == b));
+
+    // b has same structure
+    b = Sample{};
+    b.setCrystalStructure(structure2);
+    TS_ASSERT_EQUALS(a, b);
+    TS_ASSERT(!(a != b));
+  }
 };

--- a/Framework/Geometry/inc/MantidGeometry/Crystal/OrientedLattice.h
+++ b/Framework/Geometry/inc/MantidGeometry/Crystal/OrientedLattice.h
@@ -67,6 +67,9 @@ public:
   static bool GetABC(const Kernel::DblMatrix &UB, Kernel::V3D &a_dir,
                      Kernel::V3D &b_dir, Kernel::V3D &c_dir);
 
+  bool operator==(const OrientedLattice &other) const;
+  bool operator!=(const OrientedLattice &other) const;
+
 private:
   Kernel::DblMatrix U;
   Kernel::DblMatrix UB;

--- a/Framework/Geometry/inc/MantidGeometry/Crystal/SpaceGroup.h
+++ b/Framework/Geometry/inc/MantidGeometry/Crystal/SpaceGroup.h
@@ -77,6 +77,8 @@ public:
 
   PointGroup_sptr getPointGroup() const;
   Group_const_sptr getSiteSymmetryGroup(const Kernel::V3D &position) const;
+  bool operator==(const SpaceGroup &other) const;
+  bool operator!=(const SpaceGroup &other) const;
 
 protected:
   size_t m_number;

--- a/Framework/Geometry/inc/MantidGeometry/Crystal/SpaceGroup.h
+++ b/Framework/Geometry/inc/MantidGeometry/Crystal/SpaceGroup.h
@@ -77,8 +77,6 @@ public:
 
   PointGroup_sptr getPointGroup() const;
   Group_const_sptr getSiteSymmetryGroup(const Kernel::V3D &position) const;
-  bool operator==(const SpaceGroup &other) const;
-  bool operator!=(const SpaceGroup &other) const;
 
 protected:
   size_t m_number;

--- a/Framework/Geometry/inc/MantidGeometry/Crystal/UnitCell.h
+++ b/Framework/Geometry/inc/MantidGeometry/Crystal/UnitCell.h
@@ -161,6 +161,8 @@ public:
   double volume() const;
   double recVolume() const;
   virtual void recalculateFromGstar(const Kernel::Matrix<double> &NewGstar);
+  bool operator==(const UnitCell &other) const;
+  bool operator!=(const UnitCell &other) const;
 
 protected:
   /// Lattice parameter a,b,c,alpha,beta,gamma (in \f$ \mbox{ \AA } \f$ and

--- a/Framework/Geometry/inc/MantidGeometry/Instrument/Goniometer.h
+++ b/Framework/Geometry/inc/MantidGeometry/Instrument/Goniometer.h
@@ -97,6 +97,8 @@ public:
   void loadNexus(::NeXus::File *file, const std::string &group);
   /// the method reports if the goniometer was defined with some parameters
   bool isDefined() const;
+  bool operator==(const Goniometer &other) const;
+  bool operator!=(const Goniometer &other) const;
 
 private:
   /// Global rotation matrix of the goniometer

--- a/Framework/Geometry/src/Crystal/OrientedLattice.cpp
+++ b/Framework/Geometry/src/Crystal/OrientedLattice.cpp
@@ -344,5 +344,11 @@ void OrientedLattice::recalculate() {
   UnitCell::recalculate();
   UB = U * getB();
 }
+bool OrientedLattice::operator==(const OrientedLattice &other) const {
+  return UB == other.UB;
+}
+bool OrientedLattice::operator!=(const OrientedLattice &other) const {
+  return UB != other.UB;
+}
 } // Namespace Geometry
 } // Namespace Mantid

--- a/Framework/Geometry/src/Crystal/SpaceGroup.cpp
+++ b/Framework/Geometry/src/Crystal/SpaceGroup.cpp
@@ -114,15 +114,6 @@ Group_const_sptr SpaceGroup::getSiteSymmetryGroup(const V3D &position) const {
   return GroupFactory::create<Group>(siteSymmetryOps);
 }
 
-bool SpaceGroup::operator==(const SpaceGroup &other) const {
-  return Group::operator==(other) && this->m_number == other.m_number &&
-         this->m_hmSymbol == other.hmSymbol();
-}
-
-bool SpaceGroup::operator!=(const SpaceGroup &other) const {
-  return !this->operator==(other);
-}
-
 std::ostream &operator<<(std::ostream &stream, const SpaceGroup &self) {
   stream << "Space group with Hermann-Mauguin symbol: " << self.hmSymbol();
   return stream;

--- a/Framework/Geometry/src/Crystal/SpaceGroup.cpp
+++ b/Framework/Geometry/src/Crystal/SpaceGroup.cpp
@@ -114,6 +114,15 @@ Group_const_sptr SpaceGroup::getSiteSymmetryGroup(const V3D &position) const {
   return GroupFactory::create<Group>(siteSymmetryOps);
 }
 
+bool SpaceGroup::operator==(const SpaceGroup &other) const {
+  return Group::operator==(other) && this->m_number == other.m_number &&
+         this->m_hmSymbol == other.hmSymbol();
+}
+
+bool SpaceGroup::operator!=(const SpaceGroup &other) const {
+  return !this->operator==(other);
+}
+
 std::ostream &operator<<(std::ostream &stream, const SpaceGroup &self) {
   stream << "Space group with Hermann-Mauguin symbol: " << self.hmSymbol();
   return stream;

--- a/Framework/Geometry/src/Crystal/UnitCell.cpp
+++ b/Framework/Geometry/src/Crystal/UnitCell.cpp
@@ -880,6 +880,13 @@ void UnitCell::recalculateFromGstar(const DblMatrix &NewGstar) {
   calculateB();
 }
 
+bool UnitCell::operator==(const UnitCell &other) const {
+  return da == other.da; // da error not used in comparison
+}
+bool UnitCell::operator!=(const UnitCell &other) const {
+  return !this->operator==(other);
+}
+
 std::ostream &operator<<(std::ostream &out, const UnitCell &unitCell) {
   // always show the lattice constants
   out << "Lattice Parameters:" << std::fixed << std::setprecision(6)

--- a/Framework/Geometry/src/Instrument/Goniometer.cpp
+++ b/Framework/Geometry/src/Instrument/Goniometer.cpp
@@ -92,6 +92,14 @@ void Goniometer::setR(Kernel::DblMatrix rot) {
 /// Function reports if the goniometer is defined
 bool Goniometer::isDefined() const { return initFromR || (!motors.empty()); }
 
+bool Goniometer::operator==(const Goniometer &other) const {
+  return this->R == other.R;
+}
+
+bool Goniometer::operator!=(const Goniometer &other) const {
+  return this->R != other.R;
+}
+
 /// Return information about axes.
 /// @return str :: string that contains on each line one motor information (axis
 /// name, direction, sense, angle)

--- a/Framework/Geometry/test/GoniometerTest.h
+++ b/Framework/Geometry/test/GoniometerTest.h
@@ -255,4 +255,24 @@ public:
     // Rotation matrices should be the same after loading
     TS_ASSERT_EQUALS(G2.getR(), G.getR());
   }
+
+  void test_equals_when_identical() {
+    Mantid::Kernel::DblMatrix rotation_x{
+        {1, 0, 0, 0, 0, -1, 0, 1, 0}}; // 90 degrees around x axis
+    Goniometer a(rotation_x);
+    Goniometer b(rotation_x);
+    TS_ASSERT_EQUALS(a, b);
+    TS_ASSERT(!(a != b));
+  }
+
+  void test_not_equals_when_not_identical() {
+    Mantid::Kernel::DblMatrix rotation_x{
+        {1, 0, 0, 0, 0, -1, 0, 1, 0}}; // 90 degrees around x axis
+    Mantid::Kernel::DblMatrix rotation_y{
+        {0, 0, 1, 0, 1, 0, -1, 0, 0}}; // 90 degrees around y axis
+    Goniometer a(rotation_x);
+    Goniometer b(rotation_y);
+    TS_ASSERT_DIFFERS(a, b);
+    TS_ASSERT(!(a == b));
+  }
 };

--- a/Framework/Geometry/test/OrientedLatticeTest.h
+++ b/Framework/Geometry/test/OrientedLatticeTest.h
@@ -300,4 +300,29 @@ public:
     TSM_ASSERT_EQUALS(" should be along the y direction", V3D(0, 1, 0), ey);
     TSM_ASSERT_EQUALS("y direction is", V3D(0, -1, 0), eyPrime);
   }
+  void test_equals_when_orientedlattice_identical() {
+    OrientedLattice a(1.0, 2.0, 3.0, 90.0, 90.0,
+                      90.0); // create via lattice parameters
+    OrientedLattice b{a};
+    TS_ASSERT_EQUALS(a, b);
+    TS_ASSERT(!(a != b));
+  }
+
+  void test_not_equals_when_orientedlattice_different_b() {
+    OrientedLattice a(1.0, 2.0, 3.0, 90.0, 90.0,
+                      90.0); // create via lattice parameters
+    OrientedLattice b{a};
+    b.seta(10); // Results in B change
+    TS_ASSERT_DIFFERS(a, b);
+    TS_ASSERT(!(a == b));
+  }
+
+  void test_not_equals_when_orientedlattice_different_u() {
+    OrientedLattice a(1.0, 2.0, 3.0, 90.0, 90.0,
+                      90.0); // create via lattice parameters
+    OrientedLattice b{a};
+    b.setUFromVectors(V3D(0, 1, 0), V3D(1, 0, 0)); // Different U
+    TS_ASSERT_DIFFERS(a, b);
+    TS_ASSERT(!(a == b));
+  }
 };

--- a/Framework/Geometry/test/UnitCellTest.h
+++ b/Framework/Geometry/test/UnitCellTest.h
@@ -170,4 +170,53 @@ public:
     TS_ASSERT_DIFFERS(precisionLimit.c(), precisionLimitOther.c());
     TS_ASSERT_DELTA(precisionLimit.c(), precisionLimitOther.c(), 1e-9);
   }
+
+  void test_equals_when_unitcell_identical() {
+    const UnitCell a(2.0, 4.0, 5.0, 90.0, 100.0, 102.0);
+    const UnitCell b(a);
+    TS_ASSERT_EQUALS(a, b);
+    TS_ASSERT(!(a != b));
+  }
+
+  void test_not_equals_when_unitcell_differs_in_a() {
+    const UnitCell a(1.0, 1.0, 1.0, 90.0, 90.0, 90.0);
+    UnitCell b(a);
+    b.seta(2.0);
+    TS_ASSERT_DIFFERS(a, b);
+  }
+
+  void test_not_equals_when_unitcell_differs_in_b() {
+    const UnitCell a(1.0, 1.0, 1.0, 90.0, 90.0, 90.0);
+    UnitCell b(a);
+    b.setb(2.0);
+    TS_ASSERT_DIFFERS(a, b);
+  }
+
+  void test_not_equals_when_unitcell_differs_in_c() {
+    const UnitCell a(1.0, 1.0, 1.0, 90.0, 90.0, 90.0);
+    UnitCell b(a);
+    b.setc(2.0);
+    TS_ASSERT_DIFFERS(a, b);
+  }
+
+  void test_not_equals_when_unitcell_differs_in_alpha() {
+    const UnitCell a(1.0, 1.0, 1.0, 90.0, 90.0, 90.0);
+    UnitCell b(a);
+    b.setalpha(100);
+    TS_ASSERT_DIFFERS(a, b);
+  }
+
+  void test_not_equals_when_unitcell_differs_in_beta() {
+    const UnitCell a(1.0, 1.0, 1.0, 90.0, 90.0, 90.0);
+    UnitCell b(a);
+    b.setbeta(100);
+    TS_ASSERT_DIFFERS(a, b);
+  }
+
+  void test_not_equals_when_unitcell_differs_in_gamma() {
+    const UnitCell a(1.0, 1.0, 1.0, 90.0, 90.0, 90.0);
+    UnitCell b(a);
+    b.setgamma(100);
+    TS_ASSERT_DIFFERS(a, b);
+  }
 };

--- a/Framework/Kernel/inc/MantidKernel/PropertyManager.h
+++ b/Framework/Kernel/inc/MantidKernel/PropertyManager.h
@@ -108,6 +108,9 @@ public:
   /// Return the property manager serialized as a json object.
   ::Json::Value asJson(bool withDefaultValues = false) const override;
 
+  bool operator==(const PropertyManager &other) const;
+  bool operator!=(const PropertyManager &other) const;
+
 protected:
   friend class PropertyManagerOwner;
 

--- a/Framework/Kernel/src/PropertyManager.cpp
+++ b/Framework/Kernel/src/PropertyManager.cpp
@@ -583,6 +583,22 @@ std::string PropertyManager::asString(bool withDefaultValues) const {
   return jsonMap;
 }
 
+bool PropertyManager::operator==(const PropertyManager &other) const {
+  if (other.m_properties.size() != m_properties.size())
+    return false;
+  for (const auto & [ key, value ] : m_properties) {
+    if (other.m_properties.count(key) != 1)
+      return false;
+    if (*other.m_properties.at(key) != *value)
+      return false;
+  }
+  return true;
+}
+
+bool PropertyManager::operator!=(const PropertyManager &other) const {
+  return !this->operator==(other);
+}
+
 //-----------------------------------------------------------------------------------------------
 /** Get a property by name
  *  @param name :: The name of the property (case insensitive)

--- a/Framework/Kernel/src/PropertyManager.cpp
+++ b/Framework/Kernel/src/PropertyManager.cpp
@@ -586,7 +586,7 @@ std::string PropertyManager::asString(bool withDefaultValues) const {
 bool PropertyManager::operator==(const PropertyManager &other) const {
   if (other.m_properties.size() != m_properties.size())
     return false;
-  for (const auto & [ key, value ] : m_properties) {
+  for (const auto &[key, value] : m_properties) {
     if (other.m_properties.count(key) != 1)
       return false;
     if (*other.m_properties.at(key) != *value)

--- a/Framework/Kernel/test/PropertyManagerTest.h
+++ b/Framework/Kernel/test/PropertyManagerTest.h
@@ -659,6 +659,43 @@ public:
     TS_ASSERT_EQUALS(i, 33);
   }
 
+  void test_operator_equals_same_contents() {
+    PropertyManager a;
+    PropertyManager b;
+
+    a.declareProperty("Prop1", 10);
+    b.declareProperty("Prop1", 10);
+    TS_ASSERT_EQUALS(a, b);
+    TS_ASSERT(!(a != b));
+  }
+
+  void test_operator_not_equals_different_sizes() {
+    PropertyManager a;
+    PropertyManager b;
+
+    b.declareProperty("Prop1", 10);
+    TSM_ASSERT_DIFFERS("Unequal sizes", a, b);
+    TSM_ASSERT("Unequal sizes", !(a == b));
+  }
+
+  void test_operator_not_equals_different_keys() {
+    PropertyManager a;
+    PropertyManager b;
+    a.declareProperty("Prop1", 1);
+    b.declareProperty("Prop2", 1);
+    TSM_ASSERT_DIFFERS("Different Keys", a, b);
+    TSM_ASSERT("Different Keys", !(a == b));
+  }
+
+  void test_operator_not_equals_different_vaues() {
+    PropertyManager a;
+    PropertyManager b;
+    a.declareProperty("Prop1", 1);
+    b.declareProperty("Prop1", 2);
+    TSM_ASSERT_DIFFERS("Different Values", a, b);
+    TSM_ASSERT("Different Values", !(a == b));
+  }
+
 private:
   std::unique_ptr<PropertyManagerHelper> manager;
 };

--- a/Framework/PythonInterface/mantid/api/src/Exports/Run.cpp
+++ b/Framework/PythonInterface/mantid/api/src/Exports/Run.cpp
@@ -243,5 +243,6 @@ void export_Run() {
       .def("__setitem__", &addOrReplaceProperty,
            (arg("self"), arg("name"), arg("value")))
       .def("__copy__", &Mantid::PythonInterface::generic__copy__<Run>)
-      .def("__deepcopy__", &Mantid::PythonInterface::generic__deepcopy__<Run>);
+      .def("__deepcopy__", &Mantid::PythonInterface::generic__deepcopy__<Run>)
+      .def("__eq__", &Run::operator==, arg("self"), arg("other"));
 }

--- a/Framework/PythonInterface/mantid/api/src/Exports/Sample.cpp
+++ b/Framework/PythonInterface/mantid/api/src/Exports/Sample.cpp
@@ -87,5 +87,6 @@ void export_Sample() {
            return_internal_reference<>())
       .def("__copy__", &Mantid::PythonInterface::generic__copy__<Sample>)
       .def("__deepcopy__",
-           &Mantid::PythonInterface::generic__deepcopy__<Sample>);
+           &Mantid::PythonInterface::generic__deepcopy__<Sample>)
+      .def("__eq__", &Sample::operator==,(arg("self"), arg("other")));
 }

--- a/Framework/PythonInterface/test/python/mantid/api/RunTest.py
+++ b/Framework/PythonInterface/test/python/mantid/api/RunTest.py
@@ -155,6 +155,12 @@ class RunTest(unittest.TestCase):
     def test_deep_copyable(self):
         self.do_test_copyable(copy.deepcopy)
 
+    def test_equals(self):
+        other = copy.deepcopy(self._run)
+        self.assertEqual(self._run, other)
+        other.addProperty("pressure", 1, True)
+        self.assertNotEqual(self._run, other)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/Framework/PythonInterface/test/python/mantid/api/SampleTest.py
+++ b/Framework/PythonInterface/test/python/mantid/api/SampleTest.py
@@ -124,8 +124,12 @@ class SampleTest(unittest.TestCase):
     def test_deep_copyable(self):
         self.do_test_copyable(copy.deepcopy)
 
-
-
+    def test_equals(self):
+        a = Sample()
+        b = Sample()
+        self.assertEqual(a, b)
+        b.setThickness(10)
+        self.assertNotEqual(a, b)
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
`Run` and `Sample` missing overloads for `operator==` and `operator!=`. There are quite a lot of dependent types that need to provide support functionality to allow this to work.

* Add overloads
* Export to python
