### PR TITLE
Restrict Peaks that Can be Added to a PeaksWorkspace to the Same Instrument

### DIFF
--- a/Framework/Algorithms/src/AddPeak.cpp
+++ b/Framework/Algorithms/src/AddPeak.cpp
@@ -50,6 +50,17 @@ void AddPeak::exec() {
   PeaksWorkspace_sptr peaksWS = getProperty("PeaksWorkspace");
   MatrixWorkspace_sptr runWS = getProperty("RunWorkspace");
 
+  // Check the instruments match before attempting to add a peak.
+  auto runInst = runWS->getInstrument()->getName();
+  auto peakInst = peaksWS->getInstrument()->getName();
+  if (peaksWS->getNumberPeaks() > 0 && (runInst != peakInst)) {
+    throw std::runtime_error("The peak from " + runWS->getName() +
+                             " comes from a different instrument (" + runInst +
+                             ") to the peaks "
+                             "already in the table (" +
+                             peakInst + "). It could not be added.");
+  }
+
   const int detID = getProperty("DetectorID");
   double tof = getProperty("TOF");
   const double height = getProperty("Height");

--- a/Framework/Algorithms/test/AddPeakTest.h
+++ b/Framework/Algorithms/test/AddPeakTest.h
@@ -7,7 +7,9 @@
 #pragma once
 
 #include "MantidAPI/MatrixWorkspace.h"
+#include "MantidAlgorithms/AddPeak.h"
 #include "MantidAlgorithms/CreatePeaksWorkspace.h"
+#include "MantidAlgorithms/CreateSampleWorkspace.h"
 #include "MantidDataObjects/PeaksWorkspace.h"
 #include "MantidDataObjects/Workspace2D.h"
 #include "MantidKernel/Timer.h"
@@ -59,5 +61,53 @@ public:
 
     // Remove workspace from the data service.
     AnalysisDataService::Instance().remove(outWSName);
+  }
+
+  void test_exec_with_incorrect_instrument() {
+    // Name of the output workspace.
+    std::string outWSName("AddPeakTest_PeakWS");
+
+    Workspace2D_sptr instws =
+        WorkspaceCreationHelper::create2DWorkspaceWithFullInstrument(2, 10);
+
+    CreatePeaksWorkspace alg;
+    TS_ASSERT_THROWS_NOTHING(alg.initialize())
+    TS_ASSERT(alg.isInitialized())
+    TS_ASSERT_THROWS_NOTHING(
+        alg.setProperty("InstrumentWorkspace",
+                        boost::dynamic_pointer_cast<MatrixWorkspace>(instws)));
+    TS_ASSERT_THROWS_NOTHING(
+        alg.setPropertyValue("OutputWorkspace", outWSName));
+    TS_ASSERT_THROWS_NOTHING(alg.execute();)
+    TS_ASSERT(alg.isExecuted());
+
+    // Retrieve the workspace from data service.
+    PeaksWorkspace_sptr ws;
+    TS_ASSERT_THROWS_NOTHING(
+        ws = AnalysisDataService::Instance().retrieveWS<PeaksWorkspace>(
+            outWSName));
+    TS_ASSERT_EQUALS(ws->getNumberPeaks(), 1);
+
+    auto run_ws = WorkspaceCreationHelper::create2DWorkspaceWithFullInstrument(
+        10, 10, false, false, true, "something_else");
+    AddPeak add_alg;
+    add_alg.setRethrows(true);
+    TS_ASSERT_THROWS_NOTHING(add_alg.initialize())
+    TS_ASSERT(add_alg.isInitialized())
+    add_alg.setProperty("PeaksWorkspace", ws);
+    add_alg.setProperty("RunWorkspace", run_ws);
+    auto err_string = "The peak from " + run_ws->getName() +
+                      " comes from a different instrument (" +
+                      run_ws->getInstrument()->getName() +
+                      ") to the peaks "
+                      "already in the table (" +
+                      ws->getInstrument()->getName() +
+                      "). It could not be added.";
+    TS_ASSERT_THROWS_EQUALS(add_alg.execute(), std::runtime_error & e, e.what(),
+                            err_string)
+
+    // Remove workspace from the data service.
+    AnalysisDataService::Instance().remove(outWSName);
+    AnalysisDataService::Instance().clear();
   }
 };

--- a/docs/source/release/v5.1.0/framework.rst
+++ b/docs/source/release/v5.1.0/framework.rst
@@ -18,6 +18,7 @@ Algorithms
 - Add specialization to :ref:`SetUncertainties <algm-SetUncertainties>` for the
    case where InputWorkspace == OutputWorkspace. Where possible, avoid the
    cost of cloning the inputWorkspace.
+- Adjusted :ref:`AddPeak <algm-AddPeak>` to only allow peaks from the same instrument as the peaks worksapce to be added to that workspace. 
 
 Data Handling
 -------------


### PR DESCRIPTION
**Description of work.**
Attempting to add a peak from a different instrument would result in some of the values present in the table being incorrect (such as d-spacing due to incorrect TOF conversions). This PR adds a check to AddPeaks to restrict peaks being added if they are from a different instrument to peaks already in the workspace. 

**To test:**
(1) Load in two .raw files from two different instruments
(2) Add some peaks on the instrument view of one instrument workspace. 
(3) Add a peak from a different instrument (by default the peaks are added to a workspace SingleCrystalPeakTable if no other PeaksWorkspace) has been dragged onto the instrument view.
(4) You should find that attempting to add the peak from the second instrument results in an error and nothing is added to the table. 

Overlapping detector IDs in peaks can be found here:
(i) A peak at d~3Ang in SXD23767 (as shown in this screenshot)
![image](https://user-images.githubusercontent.com/55979119/68756484-19c0fa00-0602-11ea-83b7-f43b1c74e429.png)

(ii) A peak at d~5Ang in MAR11015 on the wide-angle bank W1-1 (shown in screenshot with cylindrical X view)

![image](https://user-images.githubusercontent.com/55979119/68756711-8b00ad00-0602-11ea-90c7-449518c82409.png)


Fixes #27365 

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
