### PR TITLE
Redesign axes tab in figure options to accommodate both 2D and 3D plots

### DIFF
--- a/docs/source/release/v5.1.0/mantidworkbench.rst
+++ b/docs/source/release/v5.1.0/mantidworkbench.rst
@@ -16,6 +16,7 @@ Improvements
 - When you stop a script running in workbench it will now automatically attempt to cancel the algorithm the script is running, rather than wait for the current algorthm to end.
   This is similar to what Mantidplot does, and should result in the script stopping much sooner.
 - Fixed an issue where some scripts were running slower if a  plot was open at the same time.
+- The axes tab in the figure options can now be used to set the limits, label, and scale of the z-axis on 3D plots.
 
 
 Bugfixes

--- a/qt/python/mantidqt/widgets/plotconfigdialog/axestabwidget/__init__.py
+++ b/qt/python/mantidqt/widgets/plotconfigdialog/axestabwidget/__init__.py
@@ -6,6 +6,7 @@
 # SPDX - License - Identifier: GPL - 3.0 +
 #  This file is part of the mantid workbench.
 
+from mpl_toolkits.mplot3d import Axes3D
 
 class AxProperties(dict):
     """
@@ -29,16 +30,22 @@ class AxProperties(dict):
         props['ylim'] = ax.get_ylim()
         props['ylabel'] = ax.get_ylabel()
         props['yscale'] = ax.get_yscale().title()
+
+        if isinstance(ax, Axes3D):
+            props['zlim'] = ax.get_zlim()
+            props['zlabel'] = ax.get_zlabel()
+            props['zscale'] = ax.get_zscale().title()
+
         return cls(props)
 
     @classmethod
     def from_view(cls, view):
         props = dict()
         props['title'] = view.get_title()
-        props['xlim'] = (view.get_xlower_limit(), view.get_xupper_limit())
-        props['ylim'] = (view.get_ylower_limit(), view.get_yupper_limit())
-        props['xlabel'] = view.get_xlabel()
-        props['xscale'] = view.get_xscale()
-        props['ylabel'] = view.get_ylabel()
-        props['yscale'] = view.get_yscale()
+
+        ax = view.get_axis()
+        props[f'{ax}lim'] = (view.get_lower_limit(), view.get_upper_limit())
+        props[f'{ax}label'] = view.get_label()
+        props[f'{ax}scale'] = view.get_scale()
+
         return cls(props)

--- a/qt/python/mantidqt/widgets/plotconfigdialog/axestabwidget/__init__.py
+++ b/qt/python/mantidqt/widgets/plotconfigdialog/axestabwidget/__init__.py
@@ -8,6 +8,7 @@
 
 from mpl_toolkits.mplot3d import Axes3D
 
+
 class AxProperties(dict):
     """
     An object to store the properties that can be set in the Axes

--- a/qt/python/mantidqt/widgets/plotconfigdialog/axestabwidget/axes_tab_widget.ui
+++ b/qt/python/mantidqt/widgets/plotconfigdialog/axestabwidget/axes_tab_widget.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>381</width>
+    <width>387</width>
     <height>586</height>
    </rect>
   </property>
@@ -14,6 +14,23 @@
    <string>Form</string>
   </property>
   <layout class="QGridLayout" name="gridLayout_3">
+   <item row="0" column="0">
+    <layout class="QVBoxLayout" name="axes_selector_layout">
+     <property name="topMargin">
+      <number>5</number>
+     </property>
+     <item>
+      <widget class="QLabel" name="label">
+       <property name="text">
+        <string>Select a set of axes</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QComboBox" name="select_axes_combo_box"/>
+     </item>
+    </layout>
+   </item>
    <item row="1" column="0">
     <spacer name="verticalSpacer_6">
      <property name="orientation">
@@ -39,36 +56,6 @@
       </size>
      </property>
     </spacer>
-   </item>
-   <item row="5" column="0">
-    <spacer name="verticalSpacer_2">
-     <property name="orientation">
-      <enum>Qt::Vertical</enum>
-     </property>
-     <property name="sizeHint" stdset="0">
-      <size>
-       <width>20</width>
-       <height>40</height>
-      </size>
-     </property>
-    </spacer>
-   </item>
-   <item row="0" column="0">
-    <layout class="QVBoxLayout" name="axes_selector_layout">
-     <property name="topMargin">
-      <number>5</number>
-     </property>
-     <item>
-      <widget class="QLabel" name="label">
-       <property name="text">
-        <string>Select a set of axes</string>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QComboBox" name="select_axes_combo_box"/>
-     </item>
-    </layout>
    </item>
    <item row="2" column="0">
     <layout class="QHBoxLayout" name="horizontalLayout">
@@ -125,7 +112,47 @@
      </item>
     </layout>
    </item>
-   <item row="4" column="0">
+   <item row="5" column="0">
+    <layout class="QHBoxLayout" name="horizontalLayout_2">
+     <item alignment="Qt::AlignHCenter">
+      <widget class="QRadioButton" name="x_radio_button">
+       <property name="text">
+        <string>x</string>
+       </property>
+       <property name="checked">
+        <bool>true</bool>
+       </property>
+       <attribute name="buttonGroup">
+        <string notr="true">axis_button_group</string>
+       </attribute>
+      </widget>
+     </item>
+     <item alignment="Qt::AlignHCenter">
+      <widget class="QRadioButton" name="y_radio_button">
+       <property name="text">
+        <string>y</string>
+       </property>
+       <attribute name="buttonGroup">
+        <string notr="true">axis_button_group</string>
+       </attribute>
+      </widget>
+     </item>
+     <item alignment="Qt::AlignHCenter">
+      <widget class="QRadioButton" name="z_radio_button">
+       <property name="enabled">
+        <bool>false</bool>
+       </property>
+       <property name="text">
+        <string>z</string>
+       </property>
+       <attribute name="buttonGroup">
+        <string notr="true">axis_button_group</string>
+       </attribute>
+      </widget>
+     </item>
+    </layout>
+   </item>
+   <item row="14" column="0">
     <layout class="QGridLayout" name="gridLayout">
      <property name="topMargin">
       <number>4</number>
@@ -133,82 +160,7 @@
      <property name="bottomMargin">
       <number>4</number>
      </property>
-     <item row="1" column="2">
-      <widget class="QLineEdit" name="xlower_limit_line_edit"/>
-     </item>
-     <item row="2" column="0">
-      <widget class="QLabel" name="x_right_limit_label">
-       <property name="sizePolicy">
-        <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
-         <horstretch>0</horstretch>
-         <verstretch>0</verstretch>
-        </sizepolicy>
-       </property>
-       <property name="text">
-        <string>Upper Limit</string>
-       </property>
-      </widget>
-     </item>
-     <item row="4" column="0">
-      <widget class="QLabel" name="x_scale_label">
-       <property name="sizePolicy">
-        <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
-         <horstretch>0</horstretch>
-         <verstretch>0</verstretch>
-        </sizepolicy>
-       </property>
-       <property name="text">
-        <string>Scale</string>
-       </property>
-      </widget>
-     </item>
-     <item row="4" column="2">
-      <widget class="QComboBox" name="xscale_combo_box">
-       <property name="sizePolicy">
-        <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-         <horstretch>0</horstretch>
-         <verstretch>0</verstretch>
-        </sizepolicy>
-       </property>
-       <item>
-        <property name="text">
-         <string>Linear</string>
-        </property>
-       </item>
-       <item>
-        <property name="text">
-         <string>Log</string>
-        </property>
-       </item>
-       <item>
-        <property name="text">
-         <string>Symlog</string>
-        </property>
-       </item>
-       <item>
-        <property name="text">
-         <string>Logit</string>
-        </property>
-       </item>
-      </widget>
-     </item>
-     <item row="4" column="1">
-      <spacer name="horizontalSpacer_5">
-       <property name="orientation">
-        <enum>Qt::Horizontal</enum>
-       </property>
-       <property name="sizeType">
-        <enum>QSizePolicy::Fixed</enum>
-       </property>
-       <property name="sizeHint" stdset="0">
-        <size>
-         <width>58</width>
-         <height>20</height>
-        </size>
-       </property>
-      </spacer>
-     </item>
-     <item row="3" column="1">
+     <item row="2" column="1">
       <spacer name="horizontalSpacer_4">
        <property name="orientation">
         <enum>Qt::Horizontal</enum>
@@ -224,49 +176,7 @@
        </property>
       </spacer>
      </item>
-     <item row="0" column="0">
-      <widget class="QLabel" name="x_axis_label">
-       <property name="font">
-        <font>
-         <weight>75</weight>
-         <bold>true</bold>
-        </font>
-       </property>
-       <property name="text">
-        <string>X-Axis</string>
-       </property>
-      </widget>
-     </item>
-     <item row="3" column="0">
-      <widget class="QLabel" name="x_label_label">
-       <property name="sizePolicy">
-        <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
-         <horstretch>0</horstretch>
-         <verstretch>0</verstretch>
-        </sizepolicy>
-       </property>
-       <property name="text">
-        <string>Label</string>
-       </property>
-      </widget>
-     </item>
-     <item row="3" column="2">
-      <widget class="QLineEdit" name="xlabel_line_edit">
-       <property name="sizePolicy">
-        <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-         <horstretch>0</horstretch>
-         <verstretch>0</verstretch>
-        </sizepolicy>
-       </property>
-       <property name="minimumSize">
-        <size>
-         <width>211</width>
-         <height>20</height>
-        </size>
-       </property>
-      </widget>
-     </item>
-     <item row="1" column="1">
+     <item row="0" column="1">
       <spacer name="horizontalSpacer_2">
        <property name="orientation">
         <enum>Qt::Horizontal</enum>
@@ -282,7 +192,20 @@
        </property>
       </spacer>
      </item>
-     <item row="2" column="1">
+     <item row="3" column="0">
+      <widget class="QLabel" name="scale_label">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="text">
+        <string>Scale</string>
+       </property>
+      </widget>
+     </item>
+     <item row="1" column="1">
       <spacer name="horizontalSpacer_3">
        <property name="orientation">
         <enum>Qt::Horizontal</enum>
@@ -298,118 +221,8 @@
        </property>
       </spacer>
      </item>
-     <item row="1" column="0">
-      <widget class="QLabel" name="x_left_limit_label">
-       <property name="sizePolicy">
-        <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
-         <horstretch>0</horstretch>
-         <verstretch>0</verstretch>
-        </sizepolicy>
-       </property>
-       <property name="text">
-        <string>Lower Limit</string>
-       </property>
-      </widget>
-     </item>
-     <item row="2" column="2">
-      <widget class="QLineEdit" name="xupper_limit_line_edit"/>
-     </item>
-    </layout>
-   </item>
-   <item row="6" column="0">
-    <layout class="QGridLayout" name="gridLayout_2">
-     <property name="topMargin">
-      <number>4</number>
-     </property>
-     <property name="bottomMargin">
-      <number>4</number>
-     </property>
-     <item row="0" column="0">
-      <widget class="QLabel" name="y_axis_label">
-       <property name="font">
-        <font>
-         <weight>75</weight>
-         <bold>true</bold>
-        </font>
-       </property>
-       <property name="text">
-        <string>Y-Axis</string>
-       </property>
-      </widget>
-     </item>
-     <item row="1" column="0">
-      <widget class="QLabel" name="y_left_limit_label">
-       <property name="sizePolicy">
-        <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
-         <horstretch>0</horstretch>
-         <verstretch>0</verstretch>
-        </sizepolicy>
-       </property>
-       <property name="text">
-        <string>Lower Limit</string>
-       </property>
-      </widget>
-     </item>
-     <item row="2" column="0">
-      <widget class="QLabel" name="y_right_limit_label">
-       <property name="sizePolicy">
-        <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
-         <horstretch>0</horstretch>
-         <verstretch>0</verstretch>
-        </sizepolicy>
-       </property>
-       <property name="text">
-        <string>Upper Limit</string>
-       </property>
-      </widget>
-     </item>
-     <item row="2" column="1">
-      <spacer name="horizontalSpacer_7">
-       <property name="orientation">
-        <enum>Qt::Horizontal</enum>
-       </property>
-       <property name="sizeType">
-        <enum>QSizePolicy::Fixed</enum>
-       </property>
-       <property name="sizeHint" stdset="0">
-        <size>
-         <width>58</width>
-         <height>20</height>
-        </size>
-       </property>
-      </spacer>
-     </item>
      <item row="3" column="2">
-      <widget class="QLineEdit" name="ylabel_line_edit">
-       <property name="sizePolicy">
-        <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-         <horstretch>0</horstretch>
-         <verstretch>0</verstretch>
-        </sizepolicy>
-       </property>
-       <property name="minimumSize">
-        <size>
-         <width>211</width>
-         <height>20</height>
-        </size>
-       </property>
-      </widget>
-     </item>
-     <item row="4" column="0">
-      <widget class="QLabel" name="y_scale_label">
-       <property name="sizePolicy">
-        <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
-         <horstretch>0</horstretch>
-         <verstretch>0</verstretch>
-        </sizepolicy>
-       </property>
-       <property name="text">
-        <string>Scale</string>
-       </property>
-      </widget>
-     </item>
-     <item row="4" column="2">
-      <widget class="QComboBox" name="yscale_combo_box">
+      <widget class="QComboBox" name="scale_combo_box">
        <property name="sizePolicy">
         <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
          <horstretch>0</horstretch>
@@ -438,24 +251,8 @@
        </item>
       </widget>
      </item>
-     <item row="4" column="1">
-      <spacer name="horizontalSpacer_9">
-       <property name="orientation">
-        <enum>Qt::Horizontal</enum>
-       </property>
-       <property name="sizeType">
-        <enum>QSizePolicy::Fixed</enum>
-       </property>
-       <property name="sizeHint" stdset="0">
-        <size>
-         <width>58</width>
-         <height>20</height>
-        </size>
-       </property>
-      </spacer>
-     </item>
-     <item row="3" column="0">
-      <widget class="QLabel" name="y_label_label">
+     <item row="2" column="0">
+      <widget class="QLabel" name="label_label">
        <property name="sizePolicy">
         <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
          <horstretch>0</horstretch>
@@ -467,48 +264,74 @@
        </property>
       </widget>
      </item>
-     <item row="3" column="1">
-      <spacer name="horizontalSpacer_8">
-       <property name="orientation">
-        <enum>Qt::Horizontal</enum>
-       </property>
-       <property name="sizeType">
-        <enum>QSizePolicy::Fixed</enum>
-       </property>
-       <property name="sizeHint" stdset="0">
-        <size>
-         <width>58</width>
-         <height>20</height>
-        </size>
-       </property>
-      </spacer>
-     </item>
-     <item row="1" column="1">
-      <spacer name="horizontalSpacer_10">
-       <property name="orientation">
-        <enum>Qt::Horizontal</enum>
-       </property>
-       <property name="sizeType">
-        <enum>QSizePolicy::Fixed</enum>
-       </property>
-       <property name="sizeHint" stdset="0">
-        <size>
-         <width>58</width>
-         <height>20</height>
-        </size>
-       </property>
-      </spacer>
-     </item>
      <item row="1" column="2">
-      <widget class="QLineEdit" name="ylower_limit_line_edit"/>
+      <widget class="QLineEdit" name="upper_limit_line_edit"/>
+     </item>
+     <item row="1" column="0">
+      <widget class="QLabel" name="right_limit_label">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="text">
+        <string>Upper Limit</string>
+       </property>
+      </widget>
      </item>
      <item row="2" column="2">
-      <widget class="QLineEdit" name="yupper_limit_line_edit"/>
+      <widget class="QLineEdit" name="label_line_edit">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="minimumSize">
+        <size>
+         <width>211</width>
+         <height>20</height>
+        </size>
+       </property>
+      </widget>
+     </item>
+     <item row="0" column="2">
+      <widget class="QLineEdit" name="lower_limit_line_edit"/>
+     </item>
+     <item row="3" column="1">
+      <spacer name="horizontalSpacer_5">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="sizeType">
+        <enum>QSizePolicy::Fixed</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>58</width>
+         <height>20</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+     <item row="0" column="0">
+      <widget class="QLabel" name="left_limit_label">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="text">
+        <string>Lower Limit</string>
+       </property>
+      </widget>
      </item>
     </layout>
    </item>
-   <item row="7" column="0">
-    <spacer name="verticalSpacer_3">
+   <item row="15" column="0">
+    <spacer name="verticalSpacer_2">
      <property name="orientation">
       <enum>Qt::Vertical</enum>
      </property>
@@ -525,11 +348,12 @@
  <tabstops>
   <tabstop>select_axes_combo_box</tabstop>
   <tabstop>axes_title_line_edit</tabstop>
-  <tabstop>xlabel_line_edit</tabstop>
-  <tabstop>xscale_combo_box</tabstop>
-  <tabstop>ylabel_line_edit</tabstop>
-  <tabstop>yscale_combo_box</tabstop>
+  <tabstop>label_line_edit</tabstop>
+  <tabstop>scale_combo_box</tabstop>
  </tabstops>
  <resources/>
  <connections/>
+ <buttongroups>
+  <buttongroup name="axis_button_group"/>
+ </buttongroups>
 </ui>

--- a/qt/python/mantidqt/widgets/plotconfigdialog/axestabwidget/presenter.py
+++ b/qt/python/mantidqt/widgets/plotconfigdialog/axestabwidget/presenter.py
@@ -101,10 +101,17 @@ class AxesTabWidgetPresenter:
 
     def update_view(self):
         """Update the properties in the view from the selected axes"""
+        self.current_view_props.clear()
         ax_props = self.get_selected_ax_properties()
 
+        plot_is_3d = "zlim" in ax_props
+
         # Enable the z-axis option if the plot is 3D.
-        self.view.z_radio_button.setEnabled("zlim" in ax_props)
+        self.view.z_radio_button.setEnabled(plot_is_3d)
+
+        # For tiled plots
+        if not plot_is_3d and self.view.z_radio_button.isChecked():
+            self.view.x_radio_button.click()
 
         # Changing the axis scale doesn't work with 3D plots, this is a known matplotlib issue,
         # so the scale option is disabled.
@@ -137,4 +144,10 @@ class AxesTabWidgetPresenter:
             self.view.set_label(self.current_view_props[f"{new_ax}label"])
             self.view.set_scale(self.current_view_props[f"{new_ax}scale"])
         else:
-            self.update_view()
+            ax_props = self.get_selected_ax_properties()
+            ax = self.view.get_axis()
+            lim = ax_props[f"{ax}lim"]
+            self.view.set_lower_limit(lim[0])
+            self.view.set_upper_limit(lim[1])
+            self.view.set_label(ax_props[f"{ax}label"])
+            self.view.set_scale(ax_props[f"{ax}scale"])

--- a/qt/python/mantidqt/widgets/plotconfigdialog/axestabwidget/presenter.py
+++ b/qt/python/mantidqt/widgets/plotconfigdialog/axestabwidget/presenter.py
@@ -130,6 +130,7 @@ class AxesTabWidgetPresenter:
     def axis_changed(self):
         ax = self.current_axis
 
+        self.current_view_props['title'] = self.view.get_title()
         self.current_view_props[f"{ax}lim"] = (self.view.get_lower_limit(), self.view.get_upper_limit())
         self.current_view_props[f"{ax}label"] = self.view.get_label()
         self.current_view_props[f"{ax}scale"] = self.view.get_scale()

--- a/qt/python/mantidqt/widgets/plotconfigdialog/axestabwidget/presenter.py
+++ b/qt/python/mantidqt/widgets/plotconfigdialog/axestabwidget/presenter.py
@@ -6,8 +6,6 @@
 # SPDX - License - Identifier: GPL - 3.0 +
 #  This file is part of the mantid workbench.
 
-from mpl_toolkits.mplot3d import Axes3D
-
 from mantidqt.widgets.plotconfigdialog import generate_ax_name, get_axes_names_dict
 from mantidqt.widgets.plotconfigdialog.axestabwidget import AxProperties
 from mantidqt.widgets.plotconfigdialog.axestabwidget.view import AxesTabWidgetView

--- a/qt/python/mantidqt/widgets/plotconfigdialog/axestabwidget/presenter.py
+++ b/qt/python/mantidqt/widgets/plotconfigdialog/axestabwidget/presenter.py
@@ -6,6 +6,8 @@
 # SPDX - License - Identifier: GPL - 3.0 +
 #  This file is part of the mantid workbench.
 
+from mpl_toolkits.mplot3d import Axes3D
+
 from mantidqt.widgets.plotconfigdialog import generate_ax_name, get_axes_names_dict
 from mantidqt.widgets.plotconfigdialog.axestabwidget import AxProperties
 from mantidqt.widgets.plotconfigdialog.axestabwidget.view import AxesTabWidgetView
@@ -23,7 +25,9 @@ class AxesTabWidgetPresenter:
         # Store a copy of the current view props. This allows us to tell if any
         # properties have been changed by the user; especially solving issues
         # with x and y axis limits interfering with figure autoscaling
-        self.current_view_props = None
+        self.current_view_props = {}
+
+        self.current_axis = "x"
 
         # Dictionary mapping ax name to Axes object
         self.axes_names_dict = get_axes_names_dict(self.fig)
@@ -35,29 +39,34 @@ class AxesTabWidgetPresenter:
         # Signals
         self.view.select_axes_combo_box.currentIndexChanged.connect(
             self.update_view)
+        self.view.axis_button_group.buttonClicked.connect(
+            self.axis_changed)
 
     def apply_properties(self):
         """Update the axes with the user inputted properties"""
+        # Make sure current_view_props is up to date if values have been changed
+        self.axis_changed()
+
         ax = self.get_selected_ax()
-        try:
-            new_props = self.view.get_properties()
-        except ValueError as e:
-            self.view.error_occurred(str(e))
-        else:
-            self.set_ax_title(ax, new_props.title)
-            ax.set_xlabel(new_props.xlabel)
-            ax.set_xscale(new_props.xscale)
-            if new_props.xscale == 'Log' and new_props.xlim[0] < 0:
-                ax.set_xlim(new_props.xlim[1]*0.01, new_props.xlim[1])
-            else:
-                ax.set_xlim(new_props.xlim)
-            ax.set_ylabel(new_props.ylabel)
-            ax.set_yscale(new_props.yscale)
-            if new_props.yscale == 'Log' and new_props.ylim[0] < 0:
-                ax.set_ylim(new_props.ylim[1]*0.01, new_props.ylim[1])
-            else:
-                ax.set_ylim(new_props.ylim)
-            self.update_view()
+
+        self.set_ax_title(ax, self.current_view_props['title'])
+
+        if "xlabel" in self.current_view_props:
+            ax.set_xlabel(self.current_view_props['xlabel'])
+            ax.set_xscale(self.current_view_props['xscale'])
+            ax.set_xlim(self.current_view_props['xlim'])
+
+        if "ylabel" in self.current_view_props:
+            ax.set_ylabel(self.current_view_props['ylabel'])
+            ax.set_yscale(self.current_view_props['yscale'])
+            ax.set_ylim(self.current_view_props['ylim'])
+
+        if "zlabel" in self.current_view_props:
+            ax.set_zlabel(self.current_view_props['zlabel'])
+            ax.set_zscale(self.current_view_props['zscale'])
+            ax.set_zlim(self.current_view_props['zlim'])
+
+        self.update_view()
 
     def get_selected_ax(self):
         """Get Axes object of selected axes"""
@@ -95,13 +104,39 @@ class AxesTabWidgetPresenter:
     def update_view(self):
         """Update the properties in the view from the selected axes"""
         ax_props = self.get_selected_ax_properties()
+
+        # Enable the z-axis option if the plot is 3D.
+        self.view.z_radio_button.setEnabled("zlim" in ax_props)
+
+        # Changing the axis scale doesn't work with 3D plots, this is a known matplotlib issue,
+        # so the scale option is disabled.
+        self.view.scale_combo_box.setEnabled("zlim" not in ax_props)
+
+        ax = self.view.get_axis()
         self.view.set_title(ax_props.title)
-        self.view.set_xlower_limit(ax_props.xlim[0])
-        self.view.set_xupper_limit(ax_props.xlim[1])
-        self.view.set_xlabel(ax_props.xlabel)
-        self.view.set_xscale(ax_props.xscale)
-        self.view.set_ylower_limit(ax_props.ylim[0])
-        self.view.set_yupper_limit(ax_props.ylim[1])
-        self.view.set_ylabel(ax_props.ylabel)
-        self.view.set_yscale(ax_props.yscale)
-        self.current_view_props = AxProperties.from_view(self.view)
+        lim = ax_props[f"{ax}lim"]
+        self.view.set_lower_limit(lim[0])
+        self.view.set_upper_limit(lim[1])
+        self.view.set_label(ax_props[f"{ax}label"])
+        self.view.set_scale(ax_props[f"{ax}scale"])
+
+        self.current_view_props.update(self.view.get_properties())
+
+    def axis_changed(self):
+        ax = self.current_axis
+
+        self.current_view_props[f"{ax}lim"] = (self.view.get_lower_limit(), self.view.get_upper_limit())
+        self.current_view_props[f"{ax}label"] = self.view.get_label()
+        self.current_view_props[f"{ax}scale"] = self.view.get_scale()
+
+        new_ax = self.view.get_axis()
+        self.current_axis = new_ax
+
+        if f"{new_ax}lim" in self.current_view_props:
+            lim = self.current_view_props[f"{new_ax}lim"]
+            self.view.set_lower_limit(lim[0])
+            self.view.set_upper_limit(lim[1])
+            self.view.set_label(self.current_view_props[f"{new_ax}label"])
+            self.view.set_scale(self.current_view_props[f"{new_ax}scale"])
+        else:
+            self.update_view()

--- a/qt/python/mantidqt/widgets/plotconfigdialog/axestabwidget/test/test_axestabwidgetpresenter.py
+++ b/qt/python/mantidqt/widgets/plotconfigdialog/axestabwidget/test/test_axestabwidgetpresenter.py
@@ -53,24 +53,25 @@ class AxesTabWidgetPresenterTest(unittest.TestCase):
         ax_mock = mock.MagicMock()
         presenter = self._generate_presenter()
         with mock.patch.object(presenter, 'get_selected_ax', lambda: ax_mock):
-            presenter.current_view_props = presenter.get_selected_ax_properties()
-            presenter.apply_properties()
-            # Mock properties object and view then test that the view's setters
-            # are called with the correct property values
-            ax_mock.set_title.assert_called_once_with(
-                presenter.current_view_props.title)
-            ax_mock.set_xlim.assert_called_once_with(
-                presenter.current_view_props.xlim)
-            ax_mock.set_xlabel.assert_called_once_with(
-                presenter.current_view_props.xlabel)
-            ax_mock.set_xscale.assert_called_once_with(
-                presenter.current_view_props.xscale)
-            ax_mock.set_ylim.assert_called_once_with(
-                presenter.current_view_props.ylim)
-            ax_mock.set_ylabel.assert_called_once_with(
-                presenter.current_view_props.ylabel)
-            ax_mock.set_yscale.assert_called_once_with(
-                presenter.current_view_props.yscale)
+            with mock.patch.object(presenter, 'update_view', lambda: None):
+                presenter.current_view_props = presenter.get_selected_ax_properties()
+                presenter.apply_properties()
+                # Mock properties object and view then test that the view's setters
+                # are called with the correct property values
+                ax_mock.set_title.assert_called_once_with(
+                    presenter.current_view_props.title)
+                ax_mock.set_xlim.assert_called_once_with(
+                    presenter.current_view_props.xlim)
+                ax_mock.set_xlabel.assert_called_once_with(
+                    presenter.current_view_props.xlabel)
+                ax_mock.set_xscale.assert_called_once_with(
+                    presenter.current_view_props.xscale)
+                ax_mock.set_ylim.assert_called_once_with(
+                    presenter.current_view_props.ylim)
+                ax_mock.set_ylabel.assert_called_once_with(
+                    presenter.current_view_props.ylabel)
+                ax_mock.set_yscale.assert_called_once_with(
+                    presenter.current_view_props.yscale)
 
     def test_get_axes_names_dict(self):
         actual_dict = get_axes_names_dict(self.fig)

--- a/qt/python/mantidqt/widgets/plotconfigdialog/axestabwidget/test/test_axestabwidgetpresenter.py
+++ b/qt/python/mantidqt/widgets/plotconfigdialog/axestabwidget/test/test_axestabwidgetpresenter.py
@@ -38,7 +38,9 @@ class AxesTabWidgetPresenterTest(unittest.TestCase):
         ax2.plot([-1000000, 10000], [10, 12], 'rx')
 
     def _generate_presenter(self):
-        mock_view = mock.Mock(get_selected_ax_name=lambda: "My Axes: (0, 0)")
+        mock_view = mock.Mock(get_selected_ax_name=lambda: "My Axes: (0, 0)",
+                              get_axis=lambda: "x",
+                              get_properties=lambda: {})
         return Presenter(self.fig, view=mock_view)
 
     def test_generate_ax_name_returns_correct_name(self):
@@ -51,26 +53,24 @@ class AxesTabWidgetPresenterTest(unittest.TestCase):
         ax_mock = mock.MagicMock()
         presenter = self._generate_presenter()
         with mock.patch.object(presenter, 'get_selected_ax', lambda: ax_mock):
+            presenter.current_view_props = presenter.get_selected_ax_properties()
             presenter.apply_properties()
             # Mock properties object and view then test that the view's setters
             # are called with the correct property values
-            view_mock = presenter.view
-            get_props_mock = view_mock.get_properties
-            view_mock.get_properties.assert_called_once_with()
             ax_mock.set_title.assert_called_once_with(
-                get_props_mock().title)
+                presenter.current_view_props.title)
             ax_mock.set_xlim.assert_called_once_with(
-                get_props_mock().xlim)
+                presenter.current_view_props.xlim)
             ax_mock.set_xlabel.assert_called_once_with(
-                get_props_mock().xlabel)
+                presenter.current_view_props.xlabel)
             ax_mock.set_xscale.assert_called_once_with(
-                get_props_mock().xscale)
+                presenter.current_view_props.xscale)
             ax_mock.set_ylim.assert_called_once_with(
-                get_props_mock().ylim)
+                presenter.current_view_props.ylim)
             ax_mock.set_ylabel.assert_called_once_with(
-                get_props_mock().ylabel)
+                presenter.current_view_props.ylabel)
             ax_mock.set_yscale.assert_called_once_with(
-                get_props_mock().yscale)
+                presenter.current_view_props.yscale)
 
     def test_get_axes_names_dict(self):
         actual_dict = get_axes_names_dict(self.fig)
@@ -130,41 +130,19 @@ class AxesTabWidgetPresenterTest(unittest.TestCase):
 
     def test_update_view_calls_correct_setters_with_correct_values(self):
         presenter = self._generate_presenter()
-        new_view_mock = mock.Mock(get_selected_ax_name=lambda: "My Axes: (0, 0)")
+        new_view_mock = mock.Mock(get_selected_ax_name=lambda: "My Axes: (0, 0)",
+                                  get_axis=lambda: "x",
+                                  get_properties=lambda: {})
         ax = self.fig.get_axes()[0]
-        setters = ['set_title', 'set_xlower_limit', 'set_xupper_limit',
-                   'set_ylower_limit', 'set_yupper_limit', 'set_xlabel',
-                   'set_ylabel', 'set_xscale', 'set_yscale']
+        setters = ['set_title', 'set_lower_limit', 'set_upper_limit',
+                   'set_label', 'set_scale']
         expected_vals = [self.title,
-                         ax.get_xlim()[0], ax.get_xlim()[1], ax.get_ylim()[0],
-                         ax.get_ylim()[1], self.x_label, self.y_label,
-                         self.x_scale, self.y_scale]
+                         ax.get_xlim()[0], ax.get_xlim()[1],
+                         self.x_label, self.x_scale]
         with mock.patch.object(presenter, 'view', new_view_mock):
             presenter.update_view()
             for setter, value in zip(setters, expected_vals):
                 getattr(new_view_mock, setter).assert_called_once_with(value)
-
-    def test_apply_properties_correctly_handles_negative_axis_when_changing_to_log_scale(self):
-        fig = figure()
-        ax = fig.add_subplot(111)
-        ax.plot([0, 1], [10, 12], 'rx')
-        ax.set_title("My Axes")
-        mock_view = mock.Mock(get_selected_ax_name=lambda: "My Axes: (0, 0)")
-        presenter = Presenter(fig, view=mock_view)
-
-        ax_properties = AxProperties.from_ax_object(ax)
-        min_limit = -10
-        max_limit = 10
-        ax_properties.xscale = 'Log'
-        ax_properties.xlim = (min_limit, max_limit)
-        ax_properties.yscale = 'Log'
-        ax_properties.ylim = (min_limit, max_limit)
-        presenter.view.get_properties.return_value = ax_properties
-
-        presenter.apply_properties()
-
-        self.assertEqual(ax.get_xlim(), (0.01*max_limit, max_limit))
-        self.assertEqual(ax.get_ylim(), (0.01*max_limit, max_limit))
 
 
 if __name__ == '__main__':

--- a/qt/python/mantidqt/widgets/plotconfigdialog/axestabwidget/view.py
+++ b/qt/python/mantidqt/widgets/plotconfigdialog/axestabwidget/view.py
@@ -25,11 +25,10 @@ class AxesTabWidgetView(QWidget):
         self.setAttribute(Qt.WA_DeleteOnClose, True)
 
         # Set validator for the axis limit spin boxes
-        for axis in ['x', 'y']:
-            for limit in ['upper', 'lower']:
-                line_edit = getattr(self, '%s%s_limit_line_edit' % (axis, limit))
-                validator = QDoubleValidator()
-                line_edit.setValidator(validator)
+        for limit in ['upper', 'lower']:
+            line_edit = getattr(self, f'{limit}_limit_line_edit')
+            validator = QDoubleValidator()
+            line_edit.setValidator(validator)
 
     def populate_select_axes_combo_box(self, axes_names):
         self.select_axes_combo_box.addItems(axes_names)
@@ -51,57 +50,29 @@ class AxesTabWidgetView(QWidget):
     def set_title(self, title):
         self.axes_title_line_edit.setText(title)
 
-    # X-Axis getters
-    def get_xlower_limit(self):
-        return float(self.xlower_limit_line_edit.text())
+    def get_lower_limit(self):
+        return float(self.lower_limit_line_edit.text())
 
-    def get_xupper_limit(self):
-        return float(self.xupper_limit_line_edit.text())
+    def get_upper_limit(self):
+        return float(self.upper_limit_line_edit.text())
 
-    def get_xlabel(self):
-        return self.xlabel_line_edit.text()
+    def get_label(self):
+        return self.label_line_edit.text()
 
-    def get_xscale(self):
-        return self.xscale_combo_box.currentText()
+    def get_scale(self):
+        return self.scale_combo_box.currentText()
 
-    # Y-Axis getters
-    def get_ylower_limit(self):
-        return float(self.ylower_limit_line_edit.text())
+    def set_lower_limit(self, limit):
+        self.lower_limit_line_edit.setText(str(limit))
 
-    def get_yupper_limit(self):
-        return float(self.yupper_limit_line_edit.text())
+    def set_upper_limit(self, limit):
+        self.upper_limit_line_edit.setText(str(limit))
 
-    def get_ylabel(self):
-        return self.ylabel_line_edit.text()
+    def set_label(self, label):
+        self.label_line_edit.setText(label)
 
-    def get_yscale(self):
-        return self.yscale_combo_box.currentText()
+    def set_scale(self, scale):
+        self.scale_combo_box.setCurrentText(scale.title())
 
-    # X-Axis setters
-    def set_xlower_limit(self, limit):
-        self.xlower_limit_line_edit.setText(str(limit))
-
-    def set_xupper_limit(self, limit):
-        self.xupper_limit_line_edit.setText(str(limit))
-
-    def set_xlabel(self, label):
-        self.xlabel_line_edit.setText(label)
-
-    def set_xscale(self, scale):
-        self.xscale_combo_box.setCurrentText(scale.title())
-
-    # Y-Axis setters
-    def set_ylower_limit(self, limit):
-        self.ylower_limit_line_edit.setText(str(limit))
-
-    def set_yupper_limit(self, limit):
-        self.yupper_limit_line_edit.setText(str(limit))
-
-    def set_ylabel(self, label):
-        self.ylabel_line_edit.setText(label)
-
-    def set_yscale(self, scale):
-        self.yscale_combo_box.setCurrentText(scale.title())
-
-    def error_occurred(self, exception):
-        QMessageBox.critical(self, 'Error', exception)
+    def get_axis(self):
+        return self.axis_button_group.checkedButton().text()

--- a/qt/python/mantidqt/widgets/plotconfigdialog/axestabwidget/view.py
+++ b/qt/python/mantidqt/widgets/plotconfigdialog/axestabwidget/view.py
@@ -8,7 +8,7 @@
 
 from qtpy.QtCore import Qt
 from qtpy.QtGui import QDoubleValidator
-from qtpy.QtWidgets import QWidget, QMessageBox
+from qtpy.QtWidgets import QWidget
 
 from mantidqt.utils.qt import load_ui
 from mantidqt.widgets.plotconfigdialog.axestabwidget import AxProperties

--- a/qt/python/mantidqt/widgets/plotconfigdialog/test/test_apply_all_properties.py
+++ b/qt/python/mantidqt/widgets/plotconfigdialog/test/test_apply_all_properties.py
@@ -10,6 +10,7 @@ import unittest
 
 import matplotlib
 from matplotlib import use as mpl_use
+
 mpl_use('Agg')  # noqa
 from matplotlib.colors import LogNorm
 from matplotlib.patches import BoxStyle
@@ -19,6 +20,7 @@ from mantid.plots.legend import LegendProperties
 from unittest.mock import Mock, patch
 from mantidqt.widgets.plotconfigdialog.colorselector import convert_color_to_hex
 from mantidqt.widgets.plotconfigdialog.axestabwidget import AxProperties
+from mantidqt.widgets.plotconfigdialog.axestabwidget.presenter import AxesTabWidgetPresenter
 from mantidqt.widgets.plotconfigdialog.imagestabwidget import ImageProperties
 from mantidqt.widgets.plotconfigdialog.curvestabwidget import CurveProperties
 from mantidqt.widgets.plotconfigdialog.presenter import PlotConfigDialogPresenter
@@ -27,7 +29,6 @@ AX_VIEW = 'mantidqt.widgets.plotconfigdialog.axestabwidget.presenter.AxesTabWidg
 CURVE_VIEW = 'mantidqt.widgets.plotconfigdialog.curvestabwidget.presenter.CurvesTabWidgetView'
 IMAGE_VIEW = 'mantidqt.widgets.plotconfigdialog.imagestabwidget.presenter.ImagesTabWidgetView'
 LEGEND_VIEW = 'mantidqt.widgets.plotconfigdialog.legendtabwidget.presenter.LegendTabWidgetView'
-
 
 new_ax_view_props = {
     'title': 'New Title',
@@ -88,15 +89,23 @@ new_legend_props = {
     'marker_label_padding': 1.0}
 
 
+def mock_axes_tab_presenter_update_view(presenter):
+    presenter.current_view_props = new_ax_view_props
+
+
 def _run_apply_properties_on_figure_with_curve():
     fig = figure()
     ax = fig.add_subplot(111)
     ax.errorbar([0, 1], [0, 1], yerr=[0.1, 0.2], label='old label')
-    presenter = PlotConfigDialogPresenter(fig, view=Mock())
+
+    with patch.object(AxesTabWidgetPresenter, 'update_view', mock_axes_tab_presenter_update_view):
+        presenter = PlotConfigDialogPresenter(fig, view=Mock())
     presenter.tab_widget_views[1][0].select_curve_combo_box.currentIndex.return_value = 0
     with patch.object(presenter.tab_widget_presenters[1], 'update_view',
                       lambda: None):
-        presenter.apply_properties()
+        with patch.object(presenter.tab_widget_presenters[1], 'axis_changed',
+                          lambda: None):
+            presenter.apply_properties()
     return ax
 
 
@@ -104,23 +113,30 @@ def _run_apply_properties_on_figure_with_image():
     img_fig = figure()
     img_ax = img_fig.add_subplot(111)
     img_ax.imshow([[0, 1], [0, 1]], label='old label')
-    presenter = PlotConfigDialogPresenter(img_fig, view=Mock())
+
+    with patch.object(AxesTabWidgetPresenter, 'update_view', mock_axes_tab_presenter_update_view):
+        presenter = PlotConfigDialogPresenter(img_fig, view=Mock())
     with patch.object(presenter.tab_widget_presenters[1], 'update_view',
                       lambda: None):
-        presenter.apply_properties()
+        with patch.object(presenter.tab_widget_presenters[1], 'axis_changed',
+                          lambda: None):
+            presenter.apply_properties()
     return img_ax
 
 
 def _run_apply_properties_on_figure_with_legend():
     fig = figure()
     ax = fig.add_subplot(111)
-    ax.plot([1,2,3], label='old label')
+    ax.plot([1, 2, 3], label='old label')
     legend = ax.legend()
     legend.get_frame().set_alpha(0.5)
-    presenter = PlotConfigDialogPresenter(fig, view=Mock())
+    with patch.object(AxesTabWidgetPresenter, 'update_view', mock_axes_tab_presenter_update_view):
+        presenter = PlotConfigDialogPresenter(fig, view=Mock())
     with patch.object(presenter.tab_widget_presenters[1], 'update_view',
                       lambda: None):
-        presenter.apply_properties()
+        with patch.object(presenter.tab_widget_presenters[1], 'axis_changed',
+                          lambda: None):
+            presenter.apply_properties()
     return ax
 
 
@@ -262,7 +278,7 @@ class ApplyAllPropertiesTest(unittest.TestCase):
 
     def test_apply_properties_on_figure_with_curve_sets_cap_size(self):
         self.assertEqual(new_curve_view_props['capsize'],
-                         self.new_curve[1][0].get_markersize()/2)
+                         self.new_curve[1][0].get_markersize() / 2)
 
     def test_apply_properties_on_figure_with_curve_sets_cap_thickness(self):
         self.assertEqual(new_curve_view_props['capthick'],


### PR DESCRIPTION
**Description of work.**
This PR changes the axes tab in the figure options so that if the plot is 3D the limits and label can be changed on the z-axis as well as the x and y.

![image](https://user-images.githubusercontent.com/52415735/78258387-1536a880-74f3-11ea-865e-721a96d841fd.png)


**To test:**
Run this script:
```
from mantid.simpleapi import *
import matplotlib.pyplot as plt

ws = CreateSampleWorkspace()

fig, ax = plt.subplots(subplot_kw={'projection':'mantid3d'})
ax.plot_surface(ws)

fig.show()
```
Open figure options and in the axes tab you should be able to switch between configuring the x, y, and z axis.
If you change a value for one axis, then switch to another axis and change a value, and then click apply, both changes should apply.
For 3D the axis scale input is disabled as there is an issue with matplotlib where changing the axis scale on a 3D plot doesn't work properly.

Run this script:
```
from mantid.simpleapi import *
import matplotlib.pyplot as plt

ws = CreateSampleWorkspace()

fig, ax = plt.subplots(subplot_kw={'projection':'mantid'})
ax.plot(ws, wkspIndex=0)

fig.show()
```
Open figure options and the z-axis option should be disabled.

For good measure, run this script:
```
from mantid.simpleapi import *
import matplotlib.pyplot as plt

ws = CreateSampleWorkspace()

fig = plt.figure()

ax1 = fig.add_subplot(121, projection='mantid')
ax1.plot(ws, wkspIndex=0)

ax2 = fig.add_subplot(122, projection='mantid3d')
ax2.plot_surface(ws)

fig.show()
```
And make sure everything in the axes tab works as expected.

Refs #28464 
(doesn't fix because I still need to add a dialog for changing the axis limits when you double-click on the z-axis)

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
