### PR TITLE
Addition of an external plot button to the Muon GUI

### DIFF
--- a/docs/source/release/v5.1.0/muon.rst
+++ b/docs/source/release/v5.1.0/muon.rst
@@ -20,5 +20,8 @@ New Features
 - When the user switches to the fitting tab, the workspace present in the fit display box is plotted.
   To switch back to a view of all the data, the user can switch to the home, grouping or phase table tabs.
 - The sequential fitting table now allows multiple selections to be made.
+- Addition of an external plotting button to the Muon Analysis 2 GUI.
+  This allows the user to create a standalone Workbench (or MantidPlot) plot of the displayed data.
+  The user may then perform standard operations on the plot, e.g drag and drop workspaces onto the figure.
 
 :ref:`Release 5.1.0 <v5.1.0>`

--- a/qt/applications/workbench/workbench/app/mainwindow.py
+++ b/qt/applications/workbench/workbench/app/mainwindow.py
@@ -379,13 +379,6 @@ class MainWindow(QMainWindow):
     def launch_custom_python_gui(self, filename):
         self.interface_executor.execute(open(filename).read(), filename)
 
-        # If Muon Analysis 2 window set parent manually
-        python_filename = filename.split('/')[-1]
-        if python_filename == "Muon_Analysis.py":
-            window = find_window("MuonAnalysis2", None)
-            window.setParent(self, window.windowFlags())
-            window.show()
-
     def launch_custom_cpp_gui(self, interface_name, submenu=None):
         """Create a new interface window if one does not already exist,
         else show existing window"""

--- a/qt/applications/workbench/workbench/app/mainwindow.py
+++ b/qt/applications/workbench/workbench/app/mainwindow.py
@@ -379,6 +379,13 @@ class MainWindow(QMainWindow):
     def launch_custom_python_gui(self, filename):
         self.interface_executor.execute(open(filename).read(), filename)
 
+        # If Muon Analysis 2 window set parent manually
+        python_filename = filename.split('/')[-1]
+        if python_filename == "Muon_Analysis.py":
+            window = find_window("MuonAnalysis2", None)
+            window.setParent(self, window.windowFlags())
+            window.show()
+
     def launch_custom_cpp_gui(self, interface_name, submenu=None):
         """Create a new interface window if one does not already exist,
         else show existing window"""

--- a/scripts/Muon/GUI/Common/plotting_widget/external_plotting_model.py
+++ b/scripts/Muon/GUI/Common/plotting_widget/external_plotting_model.py
@@ -1,0 +1,29 @@
+# Mantid Repository : https://github.com/mantidproject/mantid
+#
+# Copyright &copy; 2020 ISIS Rutherford Appleton Laboratory UKRI,
+#   NScD Oak Ridge National Laboratory, European Spallation Source,
+#   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+# SPDX - License - Identifier: GPL - 3.0 +
+from typing import NamedTuple, List
+from mantid.dataobjects import Workspace2D
+
+
+class PlotInformation(NamedTuple):
+    workspace: Workspace2D
+    specNum: int
+    axis: int
+    normalised: bool
+
+
+class ExternalPlottingModel(object):
+
+    def get_plotted_workspaces_and_indices_from_axes(self, axes) -> List[PlotInformation]:
+        plotted_data = []
+        for i, axis in enumerate(axes):
+            artists = axis.get_tracked_artists()
+            for artist in artists:
+                is_normalised = axis.get_artist_normalization_state(artist)
+                workspace, index = axis.get_artists_workspace_and_spec_num(artist)
+                plotted_data.append(PlotInformation(workspace=workspace, specNum=index, axis=i,
+                                                    normalised=is_normalised))
+        return plotted_data

--- a/scripts/Muon/GUI/Common/plotting_widget/external_plotting_view.py
+++ b/scripts/Muon/GUI/Common/plotting_widget/external_plotting_view.py
@@ -9,7 +9,7 @@ from math import sqrt, ceil, floor
 
 from distutils.version import LooseVersion
 
-from qtpy import QT_VERSION
+from qtpy import QT_VERSION, QtGui
 
 from Muon.GUI.Common.plotting_widget.external_plotting_model import PlotInformation
 from mantid.plots.utility import legend_set_draggable
@@ -95,16 +95,18 @@ class ExternalPlottingView(object):
     # private Mantidplot methods
     def _plot_data_mantidplot(self, fig_window, data):
         from mantidplot import plotSpectrum
-        for plot_info in data:
+        for i, plot_info in enumerate(data):
             distr_state = self._get_distr_state_mantid_plot(plot_info.normalised)
             if self.number_of_axes == 1:
                 plotSpectrum(plot_info.workspace, plot_info.specNum - 1,
                              distribution=distr_state, window=fig_window)
             else:
-                row, col = self._get_row_and_col_number(plot_info.axis)
-                window = fig_window.getWidget(row, col)
+                lay = fig_window.layer(plot_info.axis + 1)
+                fig_window.setActiveLayer(lay)
                 plotSpectrum(plot_info.workspace, plot_info.specNum - 1,
-                             distribution=distr_state, window=window)
+                             distribution=distr_state, window=fig_window, type=0)
+        if self.number_of_axes != 1:
+            fig_window.arrangeLayers(False, False)
 
     def _create_external_mantidplot_fig_window(self):
         from mantidplot import newGraph
@@ -116,13 +118,14 @@ class ExternalPlottingView(object):
         return graph_window
 
     def _create_tiled_external_mantidplot_fig_window(self):
-        from mantidplot import newTiledWindow, newGraph
+        from mantidplot import newGraph
         ncols = ceil(sqrt(self.number_of_axes))
-        graph_window = newTiledWindow(ncols=ncols)
-        for fig_number in range(self.number_of_axes):
-            window = newGraph(layers=1)
-            row, col = self._get_row_and_col_number(fig_number)
-            graph_window.insertWidget(window, row, col)
+        nrows = ceil(self.number_of_axes / ncols)
+        graph_window = newGraph()
+        graph_window.setCols(ncols)
+        graph_window.setRows(nrows)
+        graph_window.setLayerCanvasSize(100, 100)
+        graph_window.setNumLayers(self.number_of_axes)
 
         return graph_window
 
@@ -134,12 +137,17 @@ class ExternalPlottingView(object):
 
     def _copy_axes_setup_mantidplot(self, fig_window, internal_axes):
         if self.number_of_axes == 1:
+            # remove old legend as we are going to make a new one
+            fig_window.activeLayer().removeLegend()
             self._set_mantid_plot_axis_display(fig_window, internal_axes[0])
             return
         for i, internal_axis in enumerate(internal_axes):  # else tiled plot
-            row, col = self._get_row_and_col_number(i)
-            window = fig_window.getWidget(row, col)
-            self._set_mantid_plot_axis_display(window, internal_axis)
+            layer = fig_window.layer(i + 1)
+            if i == 0:
+                layer.removeLegend()
+            fig_window.setActiveLayer(layer)
+            self._set_mantid_plot_axis_display(fig_window, internal_axis)
+        fig_window.arrangeLayers(False, False)
 
     @staticmethod
     def _set_mantid_plot_axis_display(window, internal_axis):
@@ -148,10 +156,14 @@ class ExternalPlottingView(object):
         title = internal_axis.get_title()
         ylim = internal_axis.get_ylim()
         active_layer = window.activeLayer()
+        active_layer.setAxisTitleFont(0, QtGui.QFont("normal", 8))
+        active_layer.setAxisTitleFont(2, QtGui.QFont("normal", 8))
+        active_layer.setTitleFont(QtGui.QFont("normal", 8))
         active_layer.setAutoScale()
         active_layer.setAxisScale(Layer.Bottom, xlim[0], xlim[1])
         active_layer.setAxisScale(Layer.Left, ylim[0], ylim[1])
         active_layer.setTitle(title)
+        active_layer.newLegend("")
 
     @staticmethod
     def _get_distr_state_mantid_plot(is_normalised):

--- a/scripts/Muon/GUI/Common/plotting_widget/external_plotting_view.py
+++ b/scripts/Muon/GUI/Common/plotting_widget/external_plotting_view.py
@@ -153,7 +153,6 @@ class ExternalPlottingView(object):
         active_layer.setAxisScale(Layer.Left, ylim[0], ylim[1])
         active_layer.setTitle(title)
 
-
     @staticmethod
     def _get_distr_state_mantid_plot(is_normalised):
         from mantidplot import DistrFlag

--- a/scripts/Muon/GUI/Common/plotting_widget/external_plotting_view.py
+++ b/scripts/Muon/GUI/Common/plotting_widget/external_plotting_view.py
@@ -1,0 +1,163 @@
+# Mantid Repository : https://github.com/mantidproject/mantid
+#
+# Copyright &copy; 2020 ISIS Rutherford Appleton Laboratory UKRI,
+#   NScD Oak Ridge National Laboratory, European Spallation Source,
+#   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+# SPDX - License - Identifier: GPL - 3.0 +
+from typing import List
+from math import sqrt, ceil, floor
+
+from distutils.version import LooseVersion
+
+from qtpy import QT_VERSION
+
+from Muon.GUI.Common.plotting_widget.external_plotting_model import PlotInformation
+from mantid.plots.utility import legend_set_draggable
+
+
+class ExternalPlottingView(object):
+
+    def __init__(self):
+        self.number_of_axes = 0
+
+    def create_external_plot_window(self, internal_axes):
+        """
+        Handles the external_plot request and delegates appropriately to either the Workbench
+        or Mantidplot plotting functions to create a plot window.
+        :param internal_axes, The internal axes that will be replicated in the new figure
+        :return A new figure window:
+        """
+        self.number_of_axes = len(internal_axes)
+        if QT_VERSION < LooseVersion("5"):
+            external_fig_window = self._create_external_mantidplot_fig_window()
+
+        else:
+            external_fig_window = self._create_external_workbench_fig_window()
+
+        return external_fig_window
+
+    def copy_axes_setup(self, fig_window, internal_axes):
+        """
+        Sets the axis setup of the new figure window to match the internal axis
+        e.g axis limits and title
+        :param fig_window, The new figure window
+        :param internal_axes, The internal axes that will be replicated in the new figure
+        """
+        if QT_VERSION < LooseVersion("5"):
+            self._copy_axes_setup_mantidplot(fig_window, internal_axes)
+        else:
+            self._copy_axes_setup_workbench(fig_window, internal_axes)
+
+    def plot_data(self, fig_window, data: List[PlotInformation]):
+        """
+        Handles the plotting of the input data into the new fig window
+        :param fig_window, The new figure window
+        :param data, The data to be plotted in the new figure window
+        """
+        if QT_VERSION < LooseVersion("5"):
+            self._plot_data_mantidplot(fig_window, data)
+        else:
+            self._plot_data_workbench(fig_window, data)
+
+    def show(self, fig_window):
+        """
+        Raises the new figure window, for Mantidplot this function call does nothing
+        :param fig_window, The new figure window
+        """
+        if QT_VERSION < LooseVersion("5"):
+            pass  # do nothing
+        else:
+            fig_window.show()
+
+    # private workbench and MantidPlot methods
+    # private workbench methods
+    def _plot_data_workbench(self, fig_window, data):
+        external_axes = fig_window.axes
+        for plot_info in data:
+            external_axis = external_axes[plot_info.axis]
+            external_axis.plot(plot_info.workspace, specNum=plot_info.specNum, autoscale_on_update=True,
+                               distribution=not plot_info.normalised)
+            legend_set_draggable(external_axis.legend(), True)
+        fig_window.show()
+
+    def _create_external_workbench_fig_window(self):
+        from mantid.plots.plotfunctions import get_plot_fig
+        external_fig, _ = get_plot_fig(axes_num=self.number_of_axes)
+        return external_fig
+
+    def _copy_axes_setup_workbench(self, fig_window, internal_axes):
+        for internal_axis, external_axis in zip(internal_axes, fig_window.axes):
+            xlim = internal_axis.get_xlim()
+            ylim = internal_axis.get_ylim()
+            external_axis.set_xlim(xlim[0], xlim[1])
+            external_axis.set_ylim(ylim[0], ylim[1])
+
+    # private Mantidplot methods
+    def _plot_data_mantidplot(self, fig_window, data):
+        from mantidplot import plotSpectrum
+        for plot_info in data:
+            distr_state = self._get_distr_state_mantid_plot(plot_info.normalised)
+            if self.number_of_axes == 1:
+                plotSpectrum(plot_info.workspace, plot_info.specNum - 1,
+                             distribution=distr_state, window=fig_window)
+            else:
+                row, col = self._get_row_and_col_number(plot_info.axis)
+                window = fig_window.getWidget(row, col)
+                plotSpectrum(plot_info.workspace, plot_info.specNum - 1,
+                             distribution=distr_state, window=window)
+
+    def _create_external_mantidplot_fig_window(self):
+        from mantidplot import newGraph
+        if self.number_of_axes == 1:
+            graph_window = newGraph(layers=1)
+        else:
+            graph_window = self._create_tiled_external_mantidplot_fig_window()
+
+        return graph_window
+
+    def _create_tiled_external_mantidplot_fig_window(self):
+        from mantidplot import newTiledWindow, newGraph
+        ncols = ceil(sqrt(self.number_of_axes))
+        graph_window = newTiledWindow(ncols=ncols)
+        for fig_number in range(self.number_of_axes):
+            window = newGraph(layers=1)
+            row, col = self._get_row_and_col_number(fig_number)
+            graph_window.insertWidget(window, row, col)
+
+        return graph_window
+
+    def _get_row_and_col_number(self, plot_number):
+        ncols = ceil(sqrt(self.number_of_axes))
+        row = floor(plot_number / ncols)
+        col = plot_number - row * (ncols)
+        return row, col
+
+    def _copy_axes_setup_mantidplot(self, fig_window, internal_axes):
+        if self.number_of_axes == 1:
+            self._set_mantid_plot_axis_display(fig_window, internal_axes[0])
+            return
+        for i, internal_axis in enumerate(internal_axes):  # else tiled plot
+            row, col = self._get_row_and_col_number(i)
+            window = fig_window.getWidget(row, col)
+            self._set_mantid_plot_axis_display(window, internal_axis)
+
+    @staticmethod
+    def _set_mantid_plot_axis_display(window, internal_axis):
+        from mantidplot import Layer
+        xlim = internal_axis.get_xlim()
+        title = internal_axis.get_title()
+        ylim = internal_axis.get_ylim()
+        active_layer = window.activeLayer()
+        active_layer.setAutoScale()
+        active_layer.setAxisScale(Layer.Bottom, xlim[0], xlim[1])
+        active_layer.setAxisScale(Layer.Left, ylim[0], ylim[1])
+        active_layer.setTitle(title)
+
+
+    @staticmethod
+    def _get_distr_state_mantid_plot(is_normalised):
+        from mantidplot import DistrFlag
+        if is_normalised:
+            return DistrFlag.DistrTrue
+        else:
+            return DistrFlag.DistrFalse

--- a/scripts/Muon/GUI/Common/plotting_widget/plotting_widget.py
+++ b/scripts/Muon/GUI/Common/plotting_widget/plotting_widget.py
@@ -10,8 +10,8 @@ from Muon.GUI.Common.plotting_widget.plotting_widget_model import PlotWidgetMode
 
 
 class PlottingWidget(object):
-    def __init__(self, context=None):
-        self.view = PlotWidgetView(parent=None)
+    def __init__(self, context=None, parent=None):
+        self.view = PlotWidgetView(parent=parent)
         self.model = PlotWidgetModel()
         self.presenter = PlotWidgetPresenter(self.view,
                                              self.model,

--- a/scripts/Muon/GUI/Common/plotting_widget/plotting_widget_model.py
+++ b/scripts/Muon/GUI/Common/plotting_widget/plotting_widget_model.py
@@ -20,20 +20,10 @@ class PlotWidgetModel(object):
         self._plotted_workspaces_inverse_binning = {}
         self._plotted_fit_workspaces = []
         self.tiled_plot_positions = {}
-        self._number_of_axes = 1
 
     # ------------------------------------------------------------------------------------------------------------------
     # Properties
     # ------------------------------------------------------------------------------------------------------------------
-
-    @property
-    def number_of_axes(self):
-        """
-        This property is needed as the view will generate an even number of axes, which can exceed the number of axes
-        required by the model
-        """
-        return self._number_of_axes
-
     @property
     def plotted_workspaces(self):
         """
@@ -55,13 +45,6 @@ class PlotWidgetModel(object):
     # ------------------------------------------------------------------------------------------------------------------
     # Setters
     # ------------------------------------------------------------------------------------------------------------------
-
-    @number_of_axes.setter
-    def number_of_axes(self, number_of_axes):
-        if number_of_axes > 1:
-            self._number_of_axes = number_of_axes
-        else:
-            self._number_of_axes = 1
 
     @plotted_workspaces.setter
     def plotted_workspaces(self, workspaces):
@@ -135,7 +118,7 @@ class PlotWidgetModel(object):
         except RuntimeError:
             return
 
-        for i in range(self.number_of_axes):
+        for i in range(len(axes)):
             ax = axes[i]
             ax.remove_workspace_artists(workspace)
             self._update_legend(ax)
@@ -157,7 +140,7 @@ class PlotWidgetModel(object):
         if workspace_name not in self.plotted_workspaces + self.plotted_fit_workspaces:
             return
 
-        for i in range(self.number_of_axes):
+        for i in range(len(axes)):
             ax = axes[i]
             ax.remove_workspace_artists(workspace)
             self._update_legend(ax)
@@ -272,7 +255,7 @@ class PlotWidgetModel(object):
             ax.legend("")
 
     def get_axes_titles(self, axes):
-        titles = [None] * self.number_of_axes
-        for i in range(self.number_of_axes):
+        titles = [None] * len(axes)
+        for i in range(len(axes)):
             titles[i] = axes[i].get_title()
         return titles

--- a/scripts/Muon/GUI/Common/plotting_widget/plotting_widget_presenter.py
+++ b/scripts/Muon/GUI/Common/plotting_widget/plotting_widget_presenter.py
@@ -251,11 +251,10 @@ class PlotWidgetPresenter(HomeTabSubWidget):
         if state == 2:  # tiled plot
             num_axes = self.update_model_tile_plot_positions()
             self.new_plot_figure(num_axes)
-            self.plot_all_selected_workspaces(autoscale=True)
         if state == 0:  # not tiled plot
             self.new_plot_figure(num_axes=1)
-            self.plot_all_selected_workspaces(autoscale=True)
 
+        self.plot_data_and_fit_workspaces(data_workspaces, fit_workspaces)
         self.connect_xlim_changed_in_figure_view(self.handle_x_axis_limits_changed_in_figure_view)
         self.connect_ylim_changed_in_figure_view(self.handle_y_axis_limits_changed_in_figure_view)
 
@@ -373,7 +372,7 @@ class PlotWidgetPresenter(HomeTabSubWidget):
             else:
                 num_axes = self.update_model_tile_plot_positions()
             self.new_plot_figure(num_axes)
-            self.plot_all_selected_workspaces(autoscale=True)
+            self.plot_data_and_fit_workspaces(data_workspaces, fit_workspaces)
             self.connect_xlim_changed_in_figure_view(self.handle_x_axis_limits_changed_in_figure_view)
             self.connect_ylim_changed_in_figure_view(self.handle_y_axis_limits_changed_in_figure_view)
 

--- a/scripts/Muon/GUI/Common/plotting_widget/plotting_widget_view.py
+++ b/scripts/Muon/GUI/Common/plotting_widget/plotting_widget_view.py
@@ -30,6 +30,7 @@ class PlotWidgetView(QtWidgets.QWidget):
         self.plot_selector = None
         self.tile_type_selector = None
         self.tiled_type_label = None
+        self.external_plot_button = None
         self.plot_type_selector = None
         self.group_selector = None
         self.horizontal_layout = None
@@ -39,6 +40,7 @@ class PlotWidgetView(QtWidgets.QWidget):
         self.toolBar = None
         self.group = None
         self.widget_layout = None
+        self._number_of_axes = 0
 
         self.setup_interface()
 
@@ -73,6 +75,9 @@ class PlotWidgetView(QtWidgets.QWidget):
         self.tile_type_selector.setObjectName("tileTypeSelector")
         self.tile_type_selector.addItems(["Group/Pair", "Run"])
 
+        self.external_plot_button = QtWidgets.QPushButton(self)
+        self.external_plot_button.setText("External plot")
+
         self.horizontal_layout = QtWidgets.QHBoxLayout()
         self.horizontal_layout.setObjectName("horizontalLayout")
         self.horizontal_layout.addWidget(self.plot_label)
@@ -86,6 +91,7 @@ class PlotWidgetView(QtWidgets.QWidget):
         self.horizontal_layout.addStretch(0)
         self.horizontal_layout.addWidget(self.raw)
         self.horizontal_layout.addStretch(0)
+        self.horizontal_layout.addWidget(self.external_plot_button)
         self.horizontal_layout.addSpacing(50)
 
         # plotting options
@@ -120,6 +126,7 @@ class PlotWidgetView(QtWidgets.QWidget):
         # Create a set of Mantid axis for the figure
         self.fig, axes = get_plot_fig(overplot=False, ax_properties=None, axes_num=1,
                                       fig=self.fig)
+        self._number_of_axes = 1
 
         self.widget_layout = QtWidgets.QVBoxLayout(self)
         self.widget_layout.addWidget(self.group)
@@ -172,12 +179,16 @@ class PlotWidgetView(QtWidgets.QWidget):
     def on_plot_tiled_changed(self, slot):
         self.plot_type_selector.stateChanged.connect(slot)
 
+    def on_external_plot_pressed(self, slot):
+        self.external_plot_button.clicked.connect(slot)
+
     def new_plot_figure(self, num_axes):
         self.fig.clf()
         if num_axes < 1:
             num_axes = 1
         self.fig, axes = get_plot_fig(overplot=False, ax_properties=None, axes_num=num_axes,
                                       fig=self.fig)
+        self._number_of_axes = num_axes
         self.fig.tight_layout()
         self.fig.canvas.draw()
 
@@ -188,7 +199,10 @@ class PlotWidgetView(QtWidgets.QWidget):
         return self.fig
 
     def get_axes(self):
-        return self.fig.axes
+        return self.fig.axes[0:self.num_axes()]
+
+    def num_axes(self):
+        return self._number_of_axes
 
     def set_fig_titles(self, titles):
         for i, title in enumerate(titles):

--- a/scripts/Muon/GUI/MuonAnalysis/muon_analysis_2.py
+++ b/scripts/Muon/GUI/MuonAnalysis/muon_analysis_2.py
@@ -323,5 +323,7 @@ class MuonAnalysisGui(QtWidgets.QMainWindow):
             self.dockable_plot_widget.presenter.plot_guess_observer)
 
     def closeEvent(self, event):
+        self.removeDockWidget(self.dockable_plot_widget_window)
+        self.tabs.closeEvent(event)
         self.context.ads_observer = None
         super(MuonAnalysisGui, self).closeEvent(event)

--- a/scripts/Muon/GUI/MuonAnalysis/muon_analysis_2.py
+++ b/scripts/Muon/GUI/MuonAnalysis/muon_analysis_2.py
@@ -61,6 +61,7 @@ class MuonAnalysisGui(QtWidgets.QMainWindow):
     def __init__(self, parent=None):
         super(MuonAnalysisGui, self).__init__(parent)
         self.setFocusPolicy(QtCore.Qt.StrongFocus)
+        self.setObjectName("MuonAnalysis2")
 
         try:
             check_facility()
@@ -84,7 +85,7 @@ class MuonAnalysisGui(QtWidgets.QMainWindow):
                                    workspace_suffix=' MA')
 
         # create the dockable widget
-        self.dockable_plot_widget = PlottingWidget(self.context)
+        self.dockable_plot_widget = PlottingWidget(self.context, parent=self)
         self.dockable_plot_widget_window = PlottingDockWidget(parent=self,
                                                               plotting_widget=self.dockable_plot_widget.view)
         self.dockable_plot_widget_window.setMinimumWidth(575)
@@ -322,8 +323,5 @@ class MuonAnalysisGui(QtWidgets.QMainWindow):
             self.dockable_plot_widget.presenter.plot_guess_observer)
 
     def closeEvent(self, event):
-        self.tabs.closeEvent(event)
-        self.dockable_plot_widget_window.widget().close()
-        self.removeDockWidget(self.dockable_plot_widget_window)
-        super(MuonAnalysisGui, self).closeEvent(event)
         self.context.ads_observer = None
+        super(MuonAnalysisGui, self).closeEvent(event)

--- a/scripts/test/Muon/CMakeLists.txt
+++ b/scripts/test/Muon/CMakeLists.txt
@@ -18,6 +18,7 @@ set ( TEST_PY_FILES
    plotting_widget_tiled_test.py
    plotting_widget_freq_test.py
    plotting_widget_model_test.py
+   external_plotting_model_test.py
    workspace_finder_test.py
    home_runinfo_presenter_test.py
    list_selector/list_selector_view_test.py
@@ -99,6 +100,7 @@ set ( TEST_PY_FILES_QT4
    plotting_widget_test.py
    plotting_widget_tiled_test.py
    plotting_widget_freq_test.py
+   external_plotting_model_test.py
    workspace_finder_test.py
    home_runinfo_presenter_test.py
    list_selector/list_selector_view_test.py

--- a/scripts/test/Muon/external_plotting_model_test.py
+++ b/scripts/test/Muon/external_plotting_model_test.py
@@ -1,0 +1,62 @@
+# Mantid Repository : https://github.com/mantidproject/mantid
+#
+# Copyright &copy; 2020 ISIS Rutherford Appleton Laboratory UKRI,
+#   NScD Oak Ridge National Laboratory, European Spallation Source,
+#   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+# SPDX - License - Identifier: GPL - 3.0 +
+import unittest
+from unittest import mock
+
+from Muon.GUI.Common.plotting_widget.external_plotting_model import ExternalPlottingModel, PlotInformation
+from mantid.plots import MantidAxes
+
+NUM_AXES = 2
+EXAMPLE_DATA = [["MUSR62260; Group; top; Asymmetry; MA", 1], ["MUSR62260; Group; bot; Asymmetry; MA", 1]]
+NORMALISATION_STATE = False
+
+
+class ExternalPlottingModelTest(unittest.TestCase):
+
+    def setUp(self):
+        self.external_plotting_model = ExternalPlottingModel()
+        self.mock_artist = mock.NonCallableMock()
+
+    def create_mock_mantid_axes(self):
+        mock_axes = []
+        for i in range(NUM_AXES):
+            mock_axis = mock.Mock(spec=MantidAxes)
+            mock_axis.get_artist_normalization_state.return_value = NORMALISATION_STATE
+            mock_axis.get_artists_workspace_and_spec_num.return_value = EXAMPLE_DATA[i]
+            mock_axis.get_tracked_artists.return_value = [self.mock_artist]
+            mock_axes.append(mock_axis)
+        return mock_axes
+
+    def create_plot_information(self):
+        plot_information = []
+        for i in range(NUM_AXES):
+            ws = EXAMPLE_DATA[i][0]
+            index = EXAMPLE_DATA[i][1]
+            plot_information.append(PlotInformation(workspace=ws, specNum=index, axis=i,
+                                                    normalised=NORMALISATION_STATE))
+        return plot_information
+
+    def test_get_plotted_workspace_and_indicies_from_axes_calls_correct_functions(self):
+        axes = self.create_mock_mantid_axes()
+
+        self.external_plotting_model.get_plotted_workspaces_and_indices_from_axes(axes)
+        for ax in axes:
+            ax.get_tracked_artists.assert_called_once()
+            ax.get_artists_workspace_and_spec_num.assert_called_once_with(self.mock_artist)
+
+    def test_get_plotted_workspaces_and_indicies_from_axes_returns_correctly(self):
+        axes = self.create_mock_mantid_axes()
+        expected_plot_information = self.create_plot_information()
+
+        return_plot_information = self.external_plotting_model.get_plotted_workspaces_and_indices_from_axes(axes)
+
+        for return_plot_info, expected_plot_info in zip(return_plot_information, expected_plot_information):
+            self.assertEqual(return_plot_info, expected_plot_info)
+
+
+if __name__ == '__main__':
+    unittest.main(buffer=False, verbosity=2)

--- a/scripts/test/Muon/plotting_widget_test.py
+++ b/scripts/test/Muon/plotting_widget_test.py
@@ -5,8 +5,10 @@
 #   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
 # SPDX - License - Identifier: GPL - 3.0 +
 import unittest
-
 from unittest import mock
+
+from Muon.GUI.Common.plotting_widget.external_plotting_model import ExternalPlottingModel
+from Muon.GUI.Common.plotting_widget.external_plotting_view import ExternalPlottingView
 from mantidqt.utils.qt.testing import start_qapplication
 
 from Muon.GUI.Common.plotting_widget.plotting_widget_presenter import PlotWidgetPresenter
@@ -22,13 +24,17 @@ class PlottingWidgetPresenterTest(unittest.TestCase):
         self.context.fitting_context.number_of_fits = 1
         self.view = mock.MagicMock()
         self.model = mock.MagicMock()
+        self.plotting_model = mock.Mock(spec=ExternalPlottingModel)
+        self.plotting_view = mock.Mock(spec=ExternalPlottingView)
         self.workspace_list = ['MUSR62260; Group; bottom; Asymmetry; MA',
                                'MUSR62261; Group; bottom; Asymmetry; MA']
         self.context.data_context.instrument = "MUSR"
         self.context.group_pair_context.selected_groups = ['bottom']
         self.context.group_pair_context.selected_pairs = []
 
-        self.presenter = PlotWidgetPresenter(self.view, self.model, self.context)
+        self.presenter = PlotWidgetPresenter(view=self.view, model=self.model, context=self.context,
+                                             plotting_view=self.plotting_view, plotting_model=self.plotting_model)
+
         self.presenter.get_plot_title = mock.MagicMock(return_value='MUSR62260-62261 bottom')
         self.view.is_tiled_plot = mock.MagicMock(return_value=False)
         self.view.plot_options.get_errors = mock.MagicMock(return_value=True)
@@ -208,7 +214,6 @@ class PlottingWidgetPresenterTest(unittest.TestCase):
         self.context.fitting_context.plot_guess = True
         self.context.fitting_context.guess_ws = 'ws_guess'
         self.model.plotted_fit_workspaces = ['ws1', 'ws2_guess', 'ws3_guess', 'ws4', 'ws_guess']
-        self.model.number_of_axes = 1
         plot_kwargs = {'distribution': True, 'autoscale_on_update': False, 'label': 'Fit Function Guess'}
 
         self.presenter.handle_plot_guess_changed()
@@ -224,7 +229,6 @@ class PlottingWidgetPresenterTest(unittest.TestCase):
         self.context.fitting_context.plot_guess = True
         self.context.fitting_context.guess_ws = 'ws_guess'
         self.model.plotted_fit_workspaces = ['ws1', 'ws2_guess', 'ws3_guess', 'ws4']
-        self.model.number_of_axes = 1
         plot_kwargs = {'distribution': True, 'autoscale_on_update': False, 'label': 'Fit Function Guess'}
 
         self.presenter.handle_plot_guess_changed()
@@ -353,40 +357,18 @@ class PlottingWidgetPresenterTest(unittest.TestCase):
         self.model.replot_workspace.assert_any_call(workspaces[0], self.view.get_axes()[0], errors, mock.ANY)
         self.model.replot_workspace.assert_called_with(workspaces[1], self.view.get_axes()[0], errors, mock.ANY)
 
-    def test_handle_plot_all_data_and_fit_workspaces_calls_add_plot_correctly(self):
-        workspaces = ["fwd", "bwd"]
-        self.presenter.get_workspace_legend_label = mock.MagicMock(return_value='label')
+    def test_handle_external_plot_pressed(self):
+        expected_axes = mock.NonCallableMock()
+        self.view.get_axes.return_value = expected_axes
 
-        self.presenter.plot_data_and_fit_workspaces(workspace_list=workspaces, fit_workspace_list=[])
+        self.presenter.handle_external_plot_requested()
 
-        self.assertEqual(self.model.add_workspace_to_plot.call_count, len(workspaces))
-        self.model.add_workspace_to_plot.assert_any_call(self.view.get_axes()[0], workspaces[0], [0], errors=True,
-                                                         plot_kwargs=mock.ANY)
-        self.model.add_workspace_to_plot.assert_called_with(self.view.get_axes()[0], workspaces[1], [0], errors=True,
-                                                            plot_kwargs=mock.ANY)
-
-    def test_handle_plot_all_data_and_fit_workspaces_adds_fit_workspaces_correctly(self):
-        fit_workspaces = ['MUSR62260; Group; bottom; Asymmetry; MA; Fitted;']
-
-        self.presenter.plot_data_and_fit_workspaces(workspace_list=[], fit_workspace_list=fit_workspaces)
-
-        # check fit and diff workspaces plotted correctly
-        self.assertEqual(self.model.add_workspace_to_plot.call_count, 2)
-        self.model.add_workspace_to_plot.assert_any_call(self.view.get_axes()[0],
-                                                         'MUSR62260; Group; bottom; Asymmetry; MA; Fitted;', [1],
-                                                         errors=False, plot_kwargs=mock.ANY)
-        self.model.add_workspace_to_plot.assert_called_with(self.view.get_axes()[0],
-                                                            'MUSR62260; Group; bottom; Asymmetry; MA; Fitted;', [2],
-                                                            errors=False, plot_kwargs=mock.ANY)
-
-    def test_handle_plot_all_data_and_fit_workspaces_does_not_replot_existing_data(self):
-        workspaces = ["fwd", "bwd"]
-        self.model.plotted_workspaces = ["fwd", "bwd"]
-        self.presenter.get_workspace_legend_label = mock.MagicMock(return_value='label')
-
-        self.presenter.plot_data_and_fit_workspaces(workspace_list=workspaces, fit_workspace_list=[])
-
-        self.model.add_workspace_to_plot.assert_not_called()
+        self.view.get_axes.assert_called_once()
+        self.plotting_view.create_external_plot_window.assert_called_once_with(expected_axes)
+        self.plotting_model.get_plotted_workspaces_and_indices_from_axes.assert_called_once_with(expected_axes)
+        self.plotting_view.plot_data.assert_called_once()
+        self.plotting_view.copy_axes_setup.assert_called_once()
+        self.plotting_view.show.assert_called_once()
 
 
 if __name__ == '__main__':

--- a/scripts/test/Muon/plotting_widget_tiled_test.py
+++ b/scripts/test/Muon/plotting_widget_tiled_test.py
@@ -75,7 +75,7 @@ class PlottingWidgetPresenterTestTiled(unittest.TestCase):
         for i in range(num_axes):
             axes[i] = mock.MagicMock()
         self.view.get_axes.return_value = axes
-        self.model.number_of_axes = num_axes
+        self.view.num_axes.return_value = num_axes
 
     def test_handle_tiled_plot_by_group_creates_figure_correctly(self):
         self.view.get_tiled_by_type.return_value = 'group'
@@ -149,8 +149,8 @@ class PlottingWidgetPresenterTestTiled(unittest.TestCase):
 
         self.presenter.handle_plot_guess_changed()
 
-        self.assertEqual(self.model.number_of_axes, self.model.add_workspace_to_plot.call_count)
-        for i in range(self.model.number_of_axes):
+        self.assertEqual(self.view.num_axes(), self.model.add_workspace_to_plot.call_count)
+        for i in range(self.view.num_axes()):
             self.model.add_workspace_to_plot.assert_any_call(self.view.get_axes()[i], 'ws_guess',
                                                              workspace_indices=[1], errors=False,
                                                              plot_kwargs=plot_kwargs)
@@ -186,7 +186,7 @@ class PlottingWidgetPresenterTestTiled(unittest.TestCase):
         self.presenter.handle_data_updated()
 
         # check each workspace was plotted to the correct axis
-        self.assertEqual(self.model.add_workspace_to_plot.call_count, self.model.number_of_axes)
+        self.assertEqual(self.model.add_workspace_to_plot.call_count, self.view.num_axes())
 
         for i, ws in enumerate(workspace_list):
             self.model.add_workspace_to_plot.assert_any_call(self.view.get_axes()[i],
@@ -210,7 +210,7 @@ class PlottingWidgetPresenterTestTiled(unittest.TestCase):
         self.presenter.handle_plot_type_changed()
 
         # check each workspace was plotted to the correct axis
-        self.assertEqual(self.model.add_workspace_to_plot.call_count, self.model.number_of_axes)
+        self.assertEqual(self.model.add_workspace_to_plot.call_count, self.view.num_axes())
 
         for i, ws in enumerate(workspace_list):
             self.model.add_workspace_to_plot.assert_any_call(self.view.get_axes()[i],


### PR DESCRIPTION
**Description of work.**
This PR adds an external plotting button to the Muon GUI. The objective / use of this button is to open up the displayed data in a standalone figure, which can be easily modified. For instance the standard Mantid operation of dragging an dropping workspaces onto the figure can be performed. This PR also makes the GUI a child of the main workbench window, as otherwise the GUI was being sent to the back when the external plot button was pressed.

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

**To test:**

1. Test for both MantidPlot and Workbench.
2. Open the Muon Analysis 2 GUI
3. Plot some data, e.g MUSR 62260
4. Press external plot - The data should be duplicated and now you can perform any operations on the figure you desire (test some)
5. Change to tiled plot (using the checkbox in GUI)
6. Generate an external plot (an appropriate plot should be generated)


<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
-->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
