### PR TITLE
Allow z-axis limits and label to be changed by double-clicking on it in 3D plots.

### DIFF
--- a/Framework/PythonInterface/mantid/plots/mantidaxes.py
+++ b/Framework/PythonInterface/mantid/plots/mantidaxes.py
@@ -1128,6 +1128,13 @@ class MantidAxes3D(Axes3D):
 
     name = 'mantid3d'
 
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+        # Remove the connection for when you click on the plot as this is dealt with in figureinteraction.py to stop
+        # it interfering with double-clicking on the axes.
+        self.figure.canvas.mpl_disconnect(self._cids[1])
+
     def plot(self, *args, **kwargs):
         """
         If the **mantid3d** projection is chosen, it can be

--- a/docs/source/release/v5.1.0/mantidworkbench.rst
+++ b/docs/source/release/v5.1.0/mantidworkbench.rst
@@ -17,6 +17,8 @@ Improvements
   This is similar to what Mantidplot does, and should result in the script stopping much sooner.
 - Fixed an issue where some scripts were running slower if a  plot was open at the same time.
 
+- On 3D plots you can now double-click on the z-axis to change its limits or label.
+
 
 Bugfixes
 ########

--- a/qt/applications/workbench/workbench/plotting/figureinteraction.py
+++ b/qt/applications/workbench/workbench/plotting/figureinteraction.py
@@ -31,7 +31,7 @@ from mantidqt.widgets.plotconfigdialog.curvestabwidget import curve_has_errors, 
 from workbench.plotting.figureerrorsmanager import FigureErrorsManager
 from workbench.plotting.propertiesdialog import (LabelEditor, XAxisEditor, YAxisEditor,
                                                  SingleMarkerEditor, GlobalMarkerEditor,
-                                                 ColorbarAxisEditor)
+                                                 ColorbarAxisEditor, ZAxisEditor)
 from workbench.plotting.style import VALID_LINE_STYLE, VALID_COLORS
 from workbench.plotting.toolbar import ToolbarStateManager
 
@@ -227,6 +227,12 @@ class FigureInteraction(object):
                     move_and_show(YAxisEditor(canvas, ax))
                 else:
                     move_and_show(ColorbarAxisEditor(canvas, ax))
+            if hasattr(ax, 'zaxis'):
+                if ax.zaxis.label.contains(event)[0]:
+                    move_and_show(LabelEditor(canvas, ax.zaxis.label))
+                elif (ax.zaxis.contains(event)[0]
+                      or any(tick.contains(event)[0] for tick in ax.get_zticklabels())):
+                    move_and_show(ZAxisEditor(canvas, ax))
 
     def _show_markers_menu(self, markers, event):
         """
@@ -765,5 +771,6 @@ class FigureInteraction(object):
         for ax in self.canvas.figure.get_axes():
             images = ax.get_images() + [col for col in ax.collections if isinstance(col, Collection)]
             for image in images:
-                datafunctions.update_colorbar_scale(self.canvas.figure, image, scale_type, image.norm.vmin, image.norm.vmax)
+                datafunctions.update_colorbar_scale(self.canvas.figure, image, scale_type, image.norm.vmin,
+                                                    image.norm.vmax)
         self.canvas.draw_idle()

--- a/qt/applications/workbench/workbench/plotting/figureinteraction.py
+++ b/qt/applications/workbench/workbench/plotting/figureinteraction.py
@@ -20,6 +20,7 @@ from qtpy.QtGui import QCursor
 from qtpy.QtWidgets import QActionGroup, QMenu, QApplication
 from matplotlib.colors import LogNorm, Normalize
 from matplotlib.collections import Collection
+from mpl_toolkits.mplot3d.axes3d import Axes3D
 
 # third party imports
 from mantid.api import AnalysisDataService as ads
@@ -152,6 +153,8 @@ class FigureInteraction(object):
                         self.canvas.toolbar.press_pan(event)
                     finally:
                         event.button = 3
+        elif isinstance(event.inaxes, Axes3D):
+            event.inaxes._button_press(event)
 
     def on_mouse_button_release(self, event):
         """ Stop moving the markers when the mouse button is released """

--- a/qt/applications/workbench/workbench/plotting/propertiesdialog.py
+++ b/qt/applications/workbench/workbench/plotting/propertiesdialog.py
@@ -189,6 +189,13 @@ class YAxisEditor(AxisEditor):
         self.create_model()
 
 
+class ZAxisEditor(AxisEditor):
+
+    def __init__(self, canvas, axes):
+        super(ZAxisEditor, self).__init__(canvas, axes, 'z')
+        self.create_model()
+
+
 class ColorbarAxisEditor(AxisEditor):
 
     def __init__(self, canvas, axes):


### PR DESCRIPTION
**Description of work.**
This PR makes it so that you can double-click on the z-axis on 3D plots in order to change its limits or label, in the same way you can do so with the x and y axis.

**To test:**
```
from mantid.simpleapi import *
import matplotlib.pyplot as plt

ws = CreateSampleWorkspace()

fig, ax = plt.subplots(subplot_kw={'projection':'mantid3d'})
ax.plot_surface(ws)

fig.show()
```

Double-click on the z-axis (the numbers to change the limits and the label to change the label) and check it works as you'd expect.

If you run the script on master and double-click on the x or y axis, you will find that after closing the dialog the plot will rotate when you move your mouse. This has also been stopped.

Fixes #28464 

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
