### PR TITLE
Add option for butterworth filter in polaris create_total_scattering_pdf

### DIFF
--- a/docs/source/release/v5.1.0/diffraction.rst
+++ b/docs/source/release/v5.1.0/diffraction.rst
@@ -13,8 +13,9 @@ Powder Diffraction
 ------------------
 
 - Polaris.create_total_scattering_pdf output workspaces now have the run number in the names.
-- Polaris.create_total_scattering_pdf no longer takes `output_binning` as a parameter, instead binning of the output pdf can be controlled with `delta_r`
-- Polaris.create_total_scattering_pdf can rebin the Q space workspace before calculating the PDF by being given an input `delta_q`
+- Polaris.create_total_scattering_pdf no longer takes `output_binning` as a parameter, instead binning of the output pdf can be controlled with `delta_r`.
+- Polaris.create_total_scattering_pdf can rebin the Q space workspace before calculating the PDF by being given an input `delta_q`.
+- Polaris.create_total_scattering_pdf fourier filter can be performed using the butterworth filter by calling with `bw_order`.
 
 Engineering Diffraction
 -----------------------

--- a/docs/source/techniques/ISISPowder-Polaris-v1.rst
+++ b/docs/source/techniques/ISISPowder-Polaris-v1.rst
@@ -194,7 +194,9 @@ The output PDF can be customized with the following parameters:
 - By calling with `delta_r` which will calculate the PDF with bin width of `delta_q`.
 - By calling with `freq_params` a fourier filter will be performed on the focused signal removing any
   components from atomic distances outside of the parameters. The parameters must be given as list:
-  [lower], or [lower, upper].
+  [lower], or [lower, upper]. By default this produces a sharp cut off that can produce artifacts in
+  the PDF around the cutoff points, by also calling with `bw_order` a butterworth filter will be
+  performed with the specified order.
 
 Example
 =======

--- a/scripts/Diffraction/isis_powder/polaris.py
+++ b/scripts/Diffraction/isis_powder/polaris.py
@@ -66,7 +66,8 @@ class Polaris(AbstractInst):
                                                   delta_r=self._inst_settings.delta_r,
                                                   delta_q=self._inst_settings.delta_q,
                                                   pdf_type=self._inst_settings.pdf_type,
-                                                  freq_params=self._inst_settings.freq_params)
+                                                  freq_params=self._inst_settings.freq_params,
+                                                  bw_order=self._inst_settings.bw_order)
         return pdf_output
 
     def set_sample_details(self, **kwargs):

--- a/scripts/Diffraction/isis_powder/polaris_routines/polaris_algs.py
+++ b/scripts/Diffraction/isis_powder/polaris_routines/polaris_algs.py
@@ -9,6 +9,7 @@ import math
 
 import mantid.simpleapi as mantid
 from mantid.api import WorkspaceGroup
+from mantid.kernel import logger
 from isis_powder.routines import absorb_corrections, common
 from isis_powder.routines.common_enums import WORKSPACE_UNITS
 from isis_powder.routines.run_details import create_run_details_object, get_cal_mapping_dict
@@ -80,7 +81,7 @@ def save_unsplined_vanadium(vanadium_ws, output_path):
 
 
 def generate_ts_pdf(run_number, focus_file_path, merge_banks=False, q_lims=None, cal_file_name=None,
-                    sample_details=None, delta_r=None, delta_q=None, pdf_type="G(r)", freq_params=None):
+                    sample_details=None, delta_r=None, delta_q=None, pdf_type="G(r)", freq_params=None, bw_order=None):
     focused_ws = _obtain_focused_run(run_number, focus_file_path)
     focused_ws = mantid.ConvertUnits(InputWorkspace=focused_ws, Target="MomentumTransfer", EMode='Elastic')
 
@@ -108,12 +109,12 @@ def generate_ts_pdf(run_number, focus_file_path, merge_banks=False, q_lims=None,
         q_min, q_max = _load_qlims(q_lims)
         merged_ws = mantid.MatchAndMergeWorkspaces(InputWorkspaces=focused_ws, XMin=q_min, XMax=q_max,
                                                    CalculateScale=False)
-        fast_fourier_filter(merged_ws, freq_params)
+        fast_fourier_filter(merged_ws, freq_params=freq_params, bw_order=bw_order)
         pdf_output = mantid.PDFFourierTransform(Inputworkspace="merged_ws", InputSofQType="S(Q)-1", PDFType=pdf_type,
                                                 Filter=True, DeltaR=delta_r)
     else:
         for ws in focused_ws:
-            fast_fourier_filter(ws, freq_params)
+            fast_fourier_filter(ws, freq_params=freq_params, bw_order=bw_order)
         pdf_output = mantid.PDFFourierTransform(Inputworkspace='focused_ws', InputSofQType="S(Q)-1", PDFType=pdf_type,
                                                 Filter=True, DeltaR=delta_r)
         pdf_output = mantid.RebinToWorkspace(WorkspaceToRebin=pdf_output, WorkspaceToMatch=pdf_output[4],
@@ -121,7 +122,7 @@ def generate_ts_pdf(run_number, focus_file_path, merge_banks=False, q_lims=None,
     common.remove_intermediate_workspace('self_scattering_correction')
     # Rename output ws
     if 'merged_ws' in locals():
-        mantid.RenameWorkspace(InputWorkspace=merged_ws, OutputWorkspace=run_number + '_merged_Q')
+        mantid.RenameWorkspace(InputWorkspace='merged_ws', OutputWorkspace=run_number + '_merged_Q')
     mantid.RenameWorkspace(InputWorkspace='focused_ws', OutputWorkspace=run_number+'_focused_Q')
     if isinstance(focused_ws, WorkspaceGroup):
         for i in range(len(focused_ws)):
@@ -196,12 +197,13 @@ def _determine_chopper_mode(ws):
         raise ValueError("Chopper frequency not in log data. Please specify a chopper mode")
 
 
-def fast_fourier_filter(ws, freq_params=None):
+def fast_fourier_filter(ws, freq_params=None, bw_order=None):
     if not freq_params:
+        if bw_order:
+            logger.warning('bw_order set but no freq_params, freq_params must be set for filter to be performed.')
         return
     # This is a simple fourier filter using the FFTSmooth to get a WS with only the low radius components, then
     # subtracting that from the merged WS
-
     x_range = ws.dataX(0)
     # The param p in FFTSmooth defined such that if the input ws has Nx bins then in the fourier space ws it will cut of
     # all frequencies in bins nk=Nk/p and above, calculated by p = pi/(k_c*dQ) when k_c is the cutoff frequency desired.
@@ -215,10 +217,19 @@ def fast_fourier_filter(ws, freq_params=None):
     lower_freq_param = round(np.pi / (freq_params[0] * (x_range[1] - x_range[0])))
     # This is giving the FFTSmooth the data in the form of S(Q)-1, later we use PDFFourierTransform with Q(S(Q)-1)
     # it does not matter which we use in this case.
-    tmp = mantid.FFTSmooth(InputWorkspace=ws, Filter="Zeroing", Params=str(lower_freq_param), StoreInADS=False,
-                           IgnoreXBins=True)
+    if bw_order:
+        tmp = mantid.FFTSmooth(InputWorkspace=ws, Filter="Butterworth", Params=str(lower_freq_param)+','+str(bw_order),
+                               StoreInADS=False, IgnoreXBins=True)
+    else:
+        tmp = mantid.FFTSmooth(InputWorkspace=ws, Filter="Zeroing", Params=str(lower_freq_param), StoreInADS=False,
+                               IgnoreXBins=True)
     mantid.Minus(LHSWorkspace=ws, RHSWorkspace=tmp, OutputWorkspace=ws)
+
     if len(freq_params) > 1:
         upper_freq_param = round(np.pi / (freq_params[1] * (x_range[1] - x_range[0])))
-        mantid.FFTSmooth(InputWorkspace=ws, OutputWorkspace=ws, Filter="Zeroing",
-                         Params=str(upper_freq_param), IgnoreXBins=True)
+        if bw_order:
+            mantid.FFTSmooth(InputWorkspace=ws, OutputWorkspace=ws, Filter="Butterworth",
+                             Params=str(upper_freq_param)+','+str(bw_order), IgnoreXBins=True)
+        else:
+            mantid.FFTSmooth(InputWorkspace=ws, OutputWorkspace=ws, Filter="Zeroing",
+                             Params=str(upper_freq_param), IgnoreXBins=True)

--- a/scripts/Diffraction/isis_powder/polaris_routines/polaris_param_mapping.py
+++ b/scripts/Diffraction/isis_powder/polaris_routines/polaris_param_mapping.py
@@ -11,6 +11,7 @@ from isis_powder.polaris_routines.polaris_enums import POLARIS_CHOPPER_MODES
 
 #                 Maps friendly user name (ext_name) -> script name (int_name)
 attr_mapping = [
+    ParamMapEntry(ext_name="bw_order", int_name="bw_order", optional=True),
     ParamMapEntry(ext_name="calibration_directory", int_name="calibration_dir"),
     ParamMapEntry(ext_name="calibration_mapping_file", int_name="cal_mapping_path"),
     ParamMapEntry(ext_name="config_file", int_name="config_file"),


### PR DESCRIPTION
**Description of work.**

This PR adds the option for the fourier filter in polaris pdf to be performed using the butterworth filter in FFTSmooth. Previously when the fourier filter was performed in create_total_scattering_pdf the sharp cutoff in fourier space would result in a jaged peak around the cutoff, the butterworth filter instead uses a gradiet, so the peak is reduced.

**To test:**
This required configuration files I can provide over slack. The script below will produce an output pdf with a small peak around 1.5A, run with `bw_order` not commented out and the peak should shrink. Try the script with `bw_order` but no `freq_params` and a warning should be made in the log and the pdf should be made with no filtering.

```
from mantid.simpleapi import *

import numpy as np
import matplotlib.pyplot as plt
from isis_powder import polaris, SampleDetails

config_file_path = r"C:/Users/wey38795/Documents/polaris-calculate-pdf/polaris_config_example.yaml"
polaris = polaris.Polaris(config_file=config_file_path, user_name="Test", mode="PDF")  

sample_details = SampleDetails(height=4.0, radius=0.2985, center=[0, 0, 0], shape='cylinder')
sample_details.set_material(chemical_formula='Si', number_density=0.123, crystal_density=0.246)
polaris.set_sample_details(sample=sample_details)

polaris.create_vanadium(first_cycle_run_no="98532",
                        multiple_scattering=False)
polaris.focus(run_number="98533", input_mode='Summed')

q_lim = [[2.5, 3, 4, 6, 7], [3.5, 5, 7, 11, 40]]
polaris.create_total_scattering_pdf(run_number='98533', 
                                    merge_banks=True, 
                                    q_lims=q_lim,
                                    freq_params=[1.5],
                                    # bw_order=2
                                    )

```


Fixes #28417

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
