### PR TITLE
Make KafkaDecoder tests run lockstep to fix races

### DIFF
--- a/Framework/LiveData/CMakeLists.txt
+++ b/Framework/LiveData/CMakeLists.txt
@@ -87,7 +87,8 @@ if(LIBRDKAFKA_FOUND)
       ${TEST_FILES}
       KafkaEventStreamDecoderTest.h
       KafkaHistoStreamDecoderTest.h
-      KafkaTopicSubscriberTest.h)
+      KafkaTopicSubscriberTest.h
+      )
 endif()
 
 if(COVERALLS)

--- a/Framework/LiveData/inc/MantidLiveData/Kafka/IKafkaStreamDecoder.h
+++ b/Framework/LiveData/inc/MantidLiveData/Kafka/IKafkaStreamDecoder.h
@@ -36,7 +36,15 @@ public:
     using FnType = std::function<void()>;
 
     Callback(const Callback::FnType &callback) : m_mutex(), m_callback() {
-      setFunction(std::move(callback));
+      setFunction(callback);
+    }
+
+    Callback(Callback &&other) {
+      {
+        // We must lock the other obj - not ourself
+        std::lock_guard lck(other.m_mutex);
+        m_callback = std::move(other.m_callback);
+      }
     }
 
     inline void operator()() {
@@ -64,6 +72,8 @@ public:
   virtual ~IKafkaStreamDecoder();
   IKafkaStreamDecoder(const IKafkaStreamDecoder &) = delete;
   IKafkaStreamDecoder &operator=(const IKafkaStreamDecoder &) = delete;
+
+  IKafkaStreamDecoder(IKafkaStreamDecoder &&) noexcept;
 
 public:
   ///@name Start/stop

--- a/Framework/LiveData/inc/MantidLiveData/Kafka/KafkaEventStreamDecoder.h
+++ b/Framework/LiveData/inc/MantidLiveData/Kafka/KafkaEventStreamDecoder.h
@@ -46,6 +46,8 @@ public:
   KafkaEventStreamDecoder(const KafkaEventStreamDecoder &) = delete;
   KafkaEventStreamDecoder &operator=(const KafkaEventStreamDecoder &) = delete;
 
+  KafkaEventStreamDecoder(KafkaEventStreamDecoder &&) noexcept;
+
 public:
   ///@name Querying
   ///@{

--- a/Framework/LiveData/inc/MantidLiveData/Kafka/KafkaHistoStreamDecoder.h
+++ b/Framework/LiveData/inc/MantidLiveData/Kafka/KafkaHistoStreamDecoder.h
@@ -1,6 +1,6 @@
 // Mantid Repository : https://github.com/mantidproject/mantid
 //
-// Copyright &copy; 2008 ISIS Rutherford Appleton Laboratory UKRI,
+// Copyright &copy; 2020 ISIS Rutherford Appleton Laboratory UKRI,
 //   NScD Oak Ridge National Laboratory, European Spallation Source,
 //   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
 // SPDX - License - Identifier: GPL - 3.0 +
@@ -29,8 +29,12 @@ public:
                           const std::string &sampleEnvTopic,
                           const std::string &chopperTopic);
   ~KafkaHistoStreamDecoder();
+  // Disable copies since multiple subscribers will cause problems
   KafkaHistoStreamDecoder(const KafkaHistoStreamDecoder &) = delete;
   KafkaHistoStreamDecoder &operator=(const KafkaHistoStreamDecoder &) = delete;
+
+  // Allow moves though, since we only keep one copy still
+  KafkaHistoStreamDecoder(KafkaHistoStreamDecoder &&) noexcept;
 
   bool hasData() const noexcept override;
   bool hasReachedEndOfRun() noexcept override { return !m_capturing; }

--- a/Framework/LiveData/src/Kafka/IKafkaStreamDecoder.cpp
+++ b/Framework/LiveData/src/Kafka/IKafkaStreamDecoder.cpp
@@ -63,6 +63,22 @@ IKafkaStreamDecoder::IKafkaStreamDecoder(std::shared_ptr<IKafkaBroker> broker,
       m_runStart(), m_runId(""), m_thread(), m_capturing(false), m_exception(),
       m_extractWaiting(false), m_cbIterationEnd([] {}), m_cbError([] {}) {}
 
+IKafkaStreamDecoder::IKafkaStreamDecoder(IKafkaStreamDecoder &&o) noexcept
+    : m_broker(std::move(o.m_broker)), m_streamTopic(o.m_streamTopic),
+      m_runInfoTopic(o.m_runInfoTopic), m_spDetTopic(std::move(o.m_spDetTopic)),
+      m_sampleEnvTopic(o.m_sampleEnvTopic), m_chopperTopic(o.m_chopperTopic),
+      m_monitorTopic(o.m_monitorTopic), m_interrupt(o.m_interrupt.load()),
+      m_specToIdx(std::move(o.m_specToIdx)),
+      m_runStart(std::move(o.m_runStart)), m_runId(std::move(o.m_runId)),
+      m_thread(std::move(o.m_thread)), m_capturing(o.m_capturing.load()),
+      m_exception(std::move(o.m_exception)),
+      m_cbIterationEnd(std::move(o.m_cbIterationEnd)),
+      m_cbError(std::move(o.m_cbError)) {
+  std::scoped_lock lck(m_runStatusMutex, m_waitMutex, m_mutex);
+  m_runStatusSeen = o.m_runStatusSeen;
+  m_extractWaiting = o.m_extractWaiting.load();
+}
+
 /**
  * Destructor.
  * Stops capturing from the stream
@@ -70,11 +86,10 @@ IKafkaStreamDecoder::IKafkaStreamDecoder(std::shared_ptr<IKafkaBroker> broker,
 IKafkaStreamDecoder::~IKafkaStreamDecoder() { stopCapture(); }
 
 /**
- * Start capturing from the stream on a separate thread. This is a non-blocking
- * call and will return after the thread has started
+ * Start capturing from the stream on a separate thread. This is a
+ * non-blocking call and will return after the thread has started
  */
 void IKafkaStreamDecoder::startCapture(bool startNow) {
-
   // If we are not starting now, then we want to start at the start of the run
   if (!startNow) {
     // Get last two messages in run topic to ensure we get a runStart message
@@ -107,8 +122,8 @@ void IKafkaStreamDecoder::startCapture(bool startNow) {
     m_spDetStream =
         m_broker->subscribe({m_spDetTopic}, SubscribeAtOption::LASTONE);
   } catch (const std::runtime_error &) {
-    g_log.debug()
-        << "No detector-spectrum map message found, will assume a 1:1 mapping.";
+    g_log.debug() << "No detector-spectrum map message found, will assume a "
+                     "1:1 mapping.";
   }
 
   m_thread = std::thread([this]() { this->captureImpl(); });
@@ -227,7 +242,6 @@ void IKafkaStreamDecoder::captureImpl() noexcept {
 void IKafkaStreamDecoder::checkIfAllStopOffsetsReached(
     const std::unordered_map<std::string, std::vector<bool>> &reachedEnd,
     bool &checkOffsets) {
-
   if (std::all_of(reachedEnd.cbegin(), reachedEnd.cend(),
                   [](const std::pair<std::string, std::vector<bool>> &kv) {
                     return std::all_of(
@@ -529,7 +543,8 @@ void IKafkaStreamDecoder::checkRunEnd(
 }
 
 int IKafkaStreamDecoder::runNumber() const noexcept {
-  /* If the run ID is empty or if any non-digit char was found in the string */
+  /* If the run ID is empty or if any non-digit char was found in the string
+   */
   if (m_runId.empty() ||
       (std::find_if_not(m_runId.cbegin(), m_runId.cend(), [](const char c) {
          return std::isdigit(c);

--- a/Framework/LiveData/src/Kafka/KafkaEventStreamDecoder.cpp
+++ b/Framework/LiveData/src/Kafka/KafkaEventStreamDecoder.cpp
@@ -157,6 +157,17 @@ KafkaEventStreamDecoder::~KafkaEventStreamDecoder() {
   stopCapture();
 }
 
+KafkaEventStreamDecoder::KafkaEventStreamDecoder(
+    KafkaEventStreamDecoder &&o) noexcept
+    : IKafkaStreamDecoder(std::move(o)),
+      m_intermediateBufferFlushThreshold(o.m_intermediateBufferFlushThreshold) {
+
+  std::scoped_lock lck(m_intermediateBufferMutex, m_mutex);
+  m_localEvents = std::move(o.m_localEvents);
+  m_receivedEventBuffer = std::move(o.m_receivedEventBuffer);
+  m_receivedPulseBuffer = std::move(o.m_receivedPulseBuffer);
+}
+
 /**
  * Check if there is data available to extract
  * @return True if data has been accumulated so that extractData()

--- a/Framework/LiveData/src/Kafka/KafkaHistoStreamDecoder.cpp
+++ b/Framework/LiveData/src/Kafka/KafkaHistoStreamDecoder.cpp
@@ -71,6 +71,15 @@ KafkaHistoStreamDecoder::KafkaHistoStreamDecoder(
  */
 KafkaHistoStreamDecoder::~KafkaHistoStreamDecoder() = default;
 
+KafkaHistoStreamDecoder::KafkaHistoStreamDecoder(
+    KafkaHistoStreamDecoder &&rval) noexcept
+    : IKafkaStreamDecoder(std::move(rval)) {
+  {
+    std::lock_guard lck(m_mutex);
+    m_buffer = std::move(rval.m_buffer);
+  }
+}
+
 /**
  * Check if there is data available to extract
  * @return True if data has been accumulated so that extractData()

--- a/Framework/LiveData/test/CMakeLists.txt
+++ b/Framework/LiveData/test/CMakeLists.txt
@@ -9,6 +9,7 @@ if(CXXTEST_FOUND)
   # file so doesn't need un-setting
   set(TESTHELPER_SRCS
       KafkaTesting.h
+      KafkaTestThreadHelper.h
       TestDataListener.cpp
       TestGroupDataListener.cpp
       ../../TestHelpers/src/TearDownWorld.cpp

--- a/Framework/LiveData/test/KafkaEventStreamDecoderTest.h
+++ b/Framework/LiveData/test/KafkaEventStreamDecoderTest.h
@@ -1,14 +1,14 @@
 // Mantid Repository : https://github.com/mantidproject/mantid
 //
-// Copyright &copy; 2018 ISIS Rutherford Appleton Laboratory UKRI,
+// Copyright &copy; 2020 ISIS Rutherford Appleton Laboratory UKRI,
 //   NScD Oak Ridge National Laboratory, European Spallation Source,
 //   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
 // SPDX - License - Identifier: GPL - 3.0 +
 #pragma once
 
-#include <cxxtest/TestSuite.h>
-
+#include "KafkaTestThreadHelper.h"
 #include "KafkaTesting.h"
+
 #include "MantidAPI/Run.h"
 #include "MantidAPI/WorkspaceGroup.h"
 #include "MantidGeometry/Instrument.h"
@@ -19,6 +19,7 @@
 
 #include <Poco/Path.h>
 #include <condition_variable>
+#include <cxxtest/TestSuite.h>
 #include <iostream>
 #include <thread>
 
@@ -26,13 +27,6 @@ using Mantid::LiveData::KafkaEventStreamDecoder;
 
 class KafkaEventStreamDecoderTest : public CxxTest::TestSuite {
 public:
-  // This pair of boilerplate methods prevent the suite being created statically
-  // This means the constructor isn't called when running other tests
-  static KafkaEventStreamDecoderTest *createSuite() {
-    return new KafkaEventStreamDecoderTest();
-  }
-  static void destroySuite(KafkaEventStreamDecoderTest *suite) { delete suite; }
-
   void setUp() override {
     // Temporarily change the instrument directory to the testing one
     using Mantid::Kernel::ConfigService;
@@ -72,19 +66,21 @@ public:
         .WillOnce(Return(new FakeISISEventSubscriber(1)))
         .WillOnce(Return(new FakeRunInfoStreamSubscriber(1)))
         .WillOnce(Return(new FakeISISSpDetStreamSubscriber));
-    auto decoder = createTestDecoder(mockBroker);
-    TSM_ASSERT("Decoder should not have create data buffers yet",
-               !decoder->hasData());
-    startCapturing(*decoder, 1);
+    auto testWrapper = createTestInstance(mockBroker);
+    TSM_ASSERT("testInstance should not have create data buffers yet",
+               !testWrapper->hasData());
+
+    testWrapper.runKafkaOneStep(); // Start up
 
     // Checks
     Workspace_sptr workspace;
-    TSM_ASSERT("Decoder's data buffers should be created now",
-               decoder->hasData());
-    TS_ASSERT_THROWS_NOTHING(decoder->stopCapture());
-    TS_ASSERT(!decoder->isCapturing());
+    TSM_ASSERT("testInstance's data buffers should be created now",
+               testWrapper->hasData());
 
-    TS_ASSERT_THROWS_NOTHING(workspace = decoder->extractData());
+    TS_ASSERT_THROWS_NOTHING(testWrapper.stopCapture());
+    TS_ASSERT(!testWrapper->isCapturing());
+
+    TS_ASSERT_THROWS_NOTHING(workspace = testWrapper->extractData());
 
     // -- Workspace checks --
     TSM_ASSERT("Expected non-null workspace pointer from extractData()",
@@ -115,17 +111,19 @@ public:
         .WillOnce(Return(new FakeISISEventSubscriber(2)))
         .WillOnce(Return(new FakeRunInfoStreamSubscriber(2)))
         .WillOnce(Return(new FakeISISSpDetStreamSubscriber));
-    auto decoder = createTestDecoder(mockBroker);
+    auto testInstance = createTestInstance(mockBroker);
     // Need 2 full loops to get both periods
     // Note: Only 2 iterations required as FakeISISEventSubscriber does not send
     // start/stop messages
-    startCapturing(*decoder, 2);
+
+    testInstance.runKafkaOneStep();
+    testInstance.runKafkaOneStep();
 
     Workspace_sptr workspace;
-    TS_ASSERT_THROWS_NOTHING(decoder->stopCapture());
-    TS_ASSERT(!decoder->isCapturing());
+    TS_ASSERT_THROWS_NOTHING(testInstance.stopCapture());
+    TS_ASSERT(!testInstance->isCapturing());
 
-    TS_ASSERT_THROWS_NOTHING(workspace = decoder->extractData());
+    TS_ASSERT_THROWS_NOTHING(workspace = testInstance->extractData());
 
     // --- Workspace checks ---
     TSM_ASSERT("Expected non-null workspace pointer from extractData()",
@@ -159,34 +157,48 @@ public:
     using namespace Mantid::LiveData;
 
     auto mockBroker = std::make_shared<MockKafkaBroker>();
+
+    constexpr size_t nCallsOne = 3;
+    constexpr size_t nCallsTwo = 2;
+
     EXPECT_CALL(*mockBroker, subscribe_(_, _))
-        .Times(Exactly(3))
+        .Times(Exactly(nCallsOne))
         .WillOnce(Return(new FakeVariablePeriodSubscriber(0))) // 1st run
         .WillOnce(Return(new FakeRunInfoStreamSubscriberVaryingNPeriods))
         .WillOnce(Return(new FakeISISSpDetStreamSubscriber));
     EXPECT_CALL(*mockBroker, subscribe_(_, _, _))
-        .Times(Exactly(2))
+        .Times(Exactly(nCallsTwo))
         .WillOnce(Return(new FakeVariablePeriodSubscriber(4))) // 2nd run
         .WillOnce(
             Return(new FakeISISSpDetStreamSubscriber)); // det-spec for 2nd run
 
-    auto decoder = createTestDecoder(mockBroker);
-    TSM_ASSERT("Decoder should not have create data buffers yet",
-               !decoder->hasData());
-    // Run start, Event, Run stop, Run start (2 period)
-    startCapturing(*decoder, 4);
+    auto testInstance = createTestInstance(mockBroker);
+    TSM_ASSERT("testInstance should not have create data buffers yet",
+               !testInstance->hasData());
+    // Run start, Event, Run stop, Run start, (2 period)
+    for (size_t i = 0; i < (nCallsOne + 1); i++) {
+      testInstance.runKafkaOneStep();
+    }
+
+    testInstance.runStepWithoutBlocking();
+
     Workspace_sptr workspace;
-    // Extract the data from single period and inform the decoder
-    TS_ASSERT_THROWS_NOTHING(workspace = decoder->extractData());
-    TS_ASSERT(decoder->hasReachedEndOfRun());
+    // Extract the data from single period and inform the testWrapper
+    TS_ASSERT_THROWS_NOTHING(workspace = testInstance->extractData());
+    TS_ASSERT(testInstance->hasReachedEndOfRun());
     // Continue to capture multi period data
     // (one extra iteration to ensure stop signal is acted on before data
     // extraction)
-    continueCapturing(*decoder, 7);
-    TS_ASSERT_THROWS_NOTHING(workspace = decoder->extractData());
-    TS_ASSERT(decoder->hasReachedEndOfRun());
-    TS_ASSERT_THROWS_NOTHING(decoder->stopCapture());
-    TS_ASSERT(!decoder->isCapturing());
+
+    for (size_t i = 0; i < (nCallsTwo + 1); i++) {
+      testInstance.runKafkaOneStep();
+    }
+    testInstance.runStepWithoutBlocking();
+
+    TS_ASSERT_THROWS_NOTHING(workspace = testInstance->extractData());
+    TS_ASSERT(testInstance->hasReachedEndOfRun());
+    TS_ASSERT_THROWS_NOTHING(testInstance.stopCapture());
+    TS_ASSERT(!testInstance->isCapturing());
 
     // --- Workspace checks ---
     TSM_ASSERT("Expected non-null workspace pointer from extractData()",
@@ -220,18 +232,23 @@ public:
         .WillOnce(Return(new FakeDataStreamSubscriber(1)))
         .WillOnce(Return(new FakeRunInfoStreamSubscriber(1)))
         .WillOnce(Return(new FakeISISSpDetStreamSubscriber));
-    auto decoder = createTestDecoder(mockBroker);
-    TSM_ASSERT("Decoder should not have create data buffers yet",
-               !decoder->hasData());
+    auto testInstance = createTestInstance(mockBroker);
+    TSM_ASSERT("testInstance should not have create data buffers yet",
+               !testInstance->hasData());
     // 3 iterations to get first run, consisting of a run start message, an
     // event message and a run stop message
-    startCapturing(*decoder, 3);
+    for (int i = 0; i < 3; i++) {
+      testInstance.runKafkaOneStep();
+    }
+
+    testInstance.runStepWithoutBlocking();
+
     Workspace_sptr workspace;
     // Extract data should only get data from the first run
-    TS_ASSERT_THROWS_NOTHING(workspace = decoder->extractData());
-    TS_ASSERT(decoder->hasReachedEndOfRun());
-    TS_ASSERT_THROWS_NOTHING(decoder->stopCapture());
-    TS_ASSERT(!decoder->isCapturing());
+    TS_ASSERT_THROWS_NOTHING(workspace = testInstance->extractData());
+    TS_ASSERT(testInstance->hasReachedEndOfRun());
+    TS_ASSERT_THROWS_NOTHING(testInstance.stopCapture());
+    TS_ASSERT(!testInstance->isCapturing());
 
     // -- Workspace checks --
     TSM_ASSERT("Expected non-null workspace pointer from extractData()",
@@ -259,18 +276,23 @@ public:
         .WillOnce(Return(new FakeDataStreamSubscriber(3)))
         .WillOnce(Return(new FakeRunInfoStreamSubscriber(1)))
         .WillOnce(Return(new FakeISISSpDetStreamSubscriber));
-    auto decoder = createTestDecoder(mockBroker);
-    TSM_ASSERT("Decoder should not have create data buffers yet",
-               !decoder->hasData());
+    auto testInstance = createTestInstance(mockBroker);
+    TSM_ASSERT("testInstance should not have create data buffers yet",
+               !testInstance->hasData());
     // 4 iterations to get first run, consisting of a run start message, an
     // event message, a run stop message, lastly another event message
-    startCapturing(*decoder, 4);
+    for (int i = 0; i < 4; i++) {
+      testInstance.runKafkaOneStep();
+    }
+
+    testInstance.runStepWithoutBlocking();
+
     Workspace_sptr workspace;
     // Extract data should only get data from the first run
-    TS_ASSERT_THROWS_NOTHING(workspace = decoder->extractData());
-    TS_ASSERT(decoder->hasReachedEndOfRun());
-    TS_ASSERT_THROWS_NOTHING(decoder->stopCapture());
-    TS_ASSERT(!decoder->isCapturing());
+    TS_ASSERT_THROWS_NOTHING(workspace = testInstance->extractData());
+    TS_ASSERT(testInstance->hasReachedEndOfRun());
+    TS_ASSERT_THROWS_NOTHING(testInstance.stopCapture());
+    TS_ASSERT(!testInstance->isCapturing());
 
     // -- Workspace checks --
     TSM_ASSERT("Expected non-null workspace pointer from extractData()",
@@ -297,14 +319,14 @@ public:
         .WillOnce(Return(new FakeSampleEnvironmentSubscriber))
         .WillOnce(Return(new FakeRunInfoStreamSubscriber(1)))
         .WillOnce(Return(new FakeISISSpDetStreamSubscriber));
-    auto decoder = createTestDecoder(mockBroker);
-    TSM_ASSERT("Decoder should not have create data buffers yet",
-               !decoder->hasData());
-    startCapturing(*decoder, 1);
+    auto testInstance = createTestInstance(mockBroker);
+    TSM_ASSERT("testInstance should not have create data buffers yet",
+               !testInstance->hasData());
+    testInstance.runKafkaOneStep();
     Workspace_sptr workspace;
-    TS_ASSERT_THROWS_NOTHING(workspace = decoder->extractData());
-    TS_ASSERT_THROWS_NOTHING(decoder->stopCapture());
-    TS_ASSERT(!decoder->isCapturing());
+    TS_ASSERT_THROWS_NOTHING(workspace = testInstance->extractData());
+    TS_ASSERT_THROWS_NOTHING(testInstance.stopCapture());
+    TS_ASSERT(!testInstance->isCapturing());
 
     // -- Workspace checks --
     TSM_ASSERT("Expected non-null workspace pointer from extractData()",
@@ -327,12 +349,12 @@ public:
         .WillOnce(Return(new FakeEmptyStreamSubscriber))
         .WillOnce(Return(new FakeRunInfoStreamSubscriber(1)))
         .WillOnce(Return(new FakeISISSpDetStreamSubscriber));
-    auto decoder = createTestDecoder(mockBroker);
-    startCapturing(*decoder, 1);
+    auto testInstance = createTestInstance(mockBroker);
+    testInstance.runKafkaOneStep();
 
-    TS_ASSERT_THROWS_NOTHING(decoder->extractData());
-    TS_ASSERT_THROWS_NOTHING(decoder->stopCapture());
-    TS_ASSERT(!decoder->isCapturing());
+    TS_ASSERT_THROWS_NOTHING(testInstance->extractData());
+    TS_ASSERT_THROWS_NOTHING(testInstance.stopCapture());
+    TS_ASSERT(!testInstance->isCapturing());
   }
 
   void
@@ -348,12 +370,15 @@ public:
         .WillOnce(Return(new FakeEventSubscriber))
         .WillOnce(Return(new FakeRunInfoStreamSubscriber(1)))
         .WillOnce(Return(new FakeISISSpDetStreamSubscriber));
-    auto decoder = createTestDecoder(mockBroker);
-    startCapturing(*decoder, 2);
+    auto testInstance = createTestInstance(mockBroker);
+
+    testInstance.runKafkaOneStep(); // Init
+    testInstance.runKafkaOneStep(); // Process
+
     Workspace_sptr workspace;
-    TS_ASSERT_THROWS_NOTHING(decoder->stopCapture());
-    TS_ASSERT(!decoder->isCapturing());
-    TS_ASSERT_THROWS_NOTHING(workspace = decoder->extractData());
+    TS_ASSERT_THROWS_NOTHING(testInstance.stopCapture());
+    TS_ASSERT(!testInstance->isCapturing());
+    TS_ASSERT_THROWS_NOTHING(workspace = testInstance->extractData());
 
     // Check we did process the event message and extract the events
     TSM_ASSERT("Expected non-null workspace pointer from extractData()",
@@ -485,12 +510,12 @@ public:
         .WillOnce(Return(new FakeExceptionThrowingStreamSubscriber))
         .WillOnce(Return(new FakeExceptionThrowingStreamSubscriber))
         .WillOnce(Return(new FakeExceptionThrowingStreamSubscriber));
-    auto decoder = createTestDecoder(mockBroker);
-    startCapturing(*decoder, 1);
+    auto testInstance = createTestInstance(mockBroker);
+    testInstance.runKafkaOneStep();
 
-    TS_ASSERT_THROWS(decoder->extractData(), const std::runtime_error &);
-    TS_ASSERT_THROWS_NOTHING(decoder->stopCapture());
-    TS_ASSERT(!decoder->isCapturing());
+    TS_ASSERT_THROWS(testInstance->extractData(), const std::runtime_error &);
+    TS_ASSERT_THROWS_NOTHING(testInstance.stopCapture());
+    TS_ASSERT(!testInstance->isCapturing());
   }
 
   void test_Empty_RunInfo_Stream_Throws_Error_On_ExtractData() {
@@ -503,69 +528,22 @@ public:
         .WillOnce(Return(new FakeISISEventSubscriber(1)))
         .WillOnce(Return(new FakeEmptyStreamSubscriber))
         .WillOnce(Return(new FakeISISSpDetStreamSubscriber));
-    auto decoder = createTestDecoder(mockBroker);
-    startCapturing(*decoder, 1);
-    TS_ASSERT_THROWS(decoder->extractData(), const std::runtime_error &);
-    TS_ASSERT_THROWS_NOTHING(decoder->stopCapture());
-    TS_ASSERT(!decoder->isCapturing());
+    auto testInstance = createTestInstance(mockBroker);
+    testInstance.runKafkaOneStep();
+    TS_ASSERT_THROWS(testInstance->extractData(), const std::runtime_error &);
+    TS_ASSERT_THROWS_NOTHING(testInstance.stopCapture());
+    TS_ASSERT(!testInstance->isCapturing());
   }
 
 private:
-  // Start decoding and wait until we have gathered enough data to test
-  void startCapturing(Mantid::LiveData::KafkaEventStreamDecoder &decoder,
-                      uint8_t maxIterations) {
-    // Register callback to know when a whole loop as been iterated through
-    m_maxIterations = maxIterations;
-    m_niterations = 0;
-    decoder.registerIterationEndCb([this]() { this->iterationCallback(); });
-
-    decoder.registerErrorCb([this, &decoder]() { errCallback(decoder); });
-    TS_ASSERT_THROWS_NOTHING(decoder.startCapture());
-    continueCapturing(decoder, maxIterations);
-  }
-
-  void iterationCallback() {
-    std::unique_lock<std::mutex> lock(this->m_callbackMutex);
-    this->m_niterations++;
-    if (this->m_niterations == m_maxIterations) {
-      lock.unlock();
-      this->m_callbackCondition.notify_one();
-    }
-  }
-
-  void errCallback(KafkaEventStreamDecoder &decoder) {
-    try {
-      // Get the stored exception by calling extract data again
-      decoder.extractData();
-    } catch (std::exception &e) {
-      // We could try to port the exception from this child thread to the main
-      // thread, or just print it here which is significantly easier
-      std::cerr << "Exception: " << e.what() << "\n";
-      // Always keep incrementing so we don't deadlock
-      iterationCallback();
-    }
-  }
-
-  void continueCapturing(KafkaEventStreamDecoder &decoder,
-                         uint8_t maxIterations) {
-    m_maxIterations = maxIterations;
-
-    // Re-register callback with the (potentially) new value of maxIterations
-    decoder.registerIterationEndCb([this]() { this->iterationCallback(); });
-    decoder.registerErrorCb([this, &decoder]() { errCallback(decoder); });
-
-    {
-      std::unique_lock<std::mutex> lk(m_callbackMutex);
-      this->m_callbackCondition.wait(
-          lk, [this]() { return this->m_niterations == m_maxIterations; });
-    }
-  }
-
-  std::unique_ptr<Mantid::LiveData::KafkaEventStreamDecoder> createTestDecoder(
+  KafkaTesting::KafkaTestThreadHelper<Mantid::LiveData::KafkaEventStreamDecoder>
+  createTestInstance(
       const std::shared_ptr<Mantid::LiveData::IKafkaBroker> &broker) {
     using namespace Mantid::LiveData;
-    return std::make_unique<KafkaEventStreamDecoder>(broker, "", "", "", "", "",
-                                                     "", 0);
+
+    KafkaEventStreamDecoder testInstance(broker, "", "", "", "", "", "", 0);
+    return KafkaTesting::KafkaTestThreadHelper<KafkaEventStreamDecoder>(
+        std::move(testInstance));
   }
 
   void
@@ -606,10 +584,4 @@ private:
       TS_ASSERT_EQUALS(log->firstValue(), 42)
     }
   }
-
-private:
-  std::mutex m_callbackMutex;
-  std::condition_variable m_callbackCondition;
-  uint8_t m_niterations = 0;
-  std::atomic<uint8_t> m_maxIterations = 0;
 };

--- a/Framework/LiveData/test/KafkaEventStreamDecoderTest.h
+++ b/Framework/LiveData/test/KafkaEventStreamDecoderTest.h
@@ -176,11 +176,9 @@ public:
     TSM_ASSERT("testInstance should not have create data buffers yet",
                !testInstance->hasData());
     // Run start, Event, Run stop, Run start, (2 period)
-    for (size_t i = 0; i < (nCallsOne + 1); i++) {
+    for (size_t i = 0; i < 5; i++) {
       testInstance.runKafkaOneStep();
     }
-
-    testInstance.runStepWithoutBlocking();
 
     Workspace_sptr workspace;
     // Extract the data from single period and inform the testWrapper
@@ -190,10 +188,9 @@ public:
     // (one extra iteration to ensure stop signal is acted on before data
     // extraction)
 
-    for (size_t i = 0; i < (nCallsTwo + 1); i++) {
+    for (size_t i = 0; i < 4; i++) {
       testInstance.runKafkaOneStep();
     }
-    testInstance.runStepWithoutBlocking();
 
     TS_ASSERT_THROWS_NOTHING(workspace = testInstance->extractData());
     TS_ASSERT(testInstance->hasReachedEndOfRun());
@@ -241,7 +238,7 @@ public:
       testInstance.runKafkaOneStep();
     }
 
-    testInstance.runStepWithoutBlocking();
+    testInstance.runKafkaOneStep(); // End of run
 
     Workspace_sptr workspace;
     // Extract data should only get data from the first run
@@ -281,11 +278,9 @@ public:
                !testInstance->hasData());
     // 4 iterations to get first run, consisting of a run start message, an
     // event message, a run stop message, lastly another event message
-    for (int i = 0; i < 4; i++) {
+    for (int i = 0; i < 5; i++) {
       testInstance.runKafkaOneStep();
     }
-
-    testInstance.runStepWithoutBlocking();
 
     Workspace_sptr workspace;
     // Extract data should only get data from the first run

--- a/Framework/LiveData/test/KafkaTestThreadHelper.h
+++ b/Framework/LiveData/test/KafkaTestThreadHelper.h
@@ -1,0 +1,143 @@
+// Mantid Repository : https://github.com/mantidproject/mantid
+//
+// Copyright &copy; 2020 ISIS Rutherford Appleton Laboratory UKRI,
+//   NScD Oak Ridge National Laboratory, European Spallation Source,
+//   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+// SPDX - License - Identifier: GPL - 3.0 +
+#pragma once
+
+#include "KafkaTesting.h"
+#include "MantidAPI/Workspace_fwd.h"
+
+#include <chrono>
+#include <condition_variable>
+#include <mutex>
+#include <thread>
+
+/**
+ * Wrapper for KafkaHisto/Event stream classes that
+ * handles thread stepping to prevent race conditions in the unit tests.
+ *
+ * Either the main thread or Kafka thread is allowed to continue, with
+ * the other blocking until either: an iteration is done in Kafka or
+ * the test thread explicitly calls to unblock Kafka, whilst blocking.
+ *
+ * This class also contains deadlock detection, for if you haven't send
+ * Kafka through enough iterations or if you use the API incorrectly.
+ *
+ * Important!: All methods on Kafka are usable on the Kafka instance except
+ * start/stop capture. Use runKafkaOneStep() or stopCapture() respectively
+ * in this class to handle spinning up and down the Kafka threads or you'll
+ * deadlock!
+ *
+ * @author David Fairbrother
+ * @date 2020/04/04
+ */
+
+namespace KafkaTesting {
+
+template <typename KafkaT> class KafkaTestThreadHelper {
+public:
+  KafkaTestThreadHelper(KafkaT &&testInstance)
+      : instance(std::move(testInstance)) {
+    instance.registerIterationEndCb([this] { callback(); });
+    instance.registerErrorCb([this]() { errCallback(); });
+  }
+
+  ~KafkaTestThreadHelper() {
+    {
+      std::unique_lock lock(mutex);
+      blockedThread = Threads::NONE;
+    }
+    cv.notify_all();
+  }
+
+  KafkaT *operator->() { return &instance; }
+
+  void runKafkaOneStep() {
+    std::unique_lock lock(mutex);
+    if (!isCapturing) {
+      instance.startCapture();
+      isCapturing = true;
+    }
+
+    blockedThread = Threads::TEST;
+
+    cv.notify_one();
+    // Make test wait until were told Kafka shouldn't be blocked
+    cv.wait_for(lock, DEADLOCK_TIMEOUT,
+                [this] { return blockedThread != Threads::TEST; });
+
+    assert(blockedThread != Threads::TEST &&
+           "Deadlock was detected as test thread was not unblocked");
+
+    // Kafka is now blocked test can resume
+  }
+
+  void runStepWithoutBlocking() {
+    assert(isCapturing);
+    {
+      std::unique_lock lock(mutex);
+      blockedThread = Threads::NONE;
+    }
+    cv.notify_all();
+  }
+
+  void stopCapture() {
+    // Kafka uses a blocking call on the test thread whilst waiting for
+    // its worker thread, which we currently have paused. We can't use
+    // the callback mechanism either. So we need to mark both threads
+    // free to avoid deadlock. So it's a bit race-y here.
+    {
+      std::unique_lock lock(mutex);
+      blockedThread = Threads::NONE;
+    }
+    cv.notify_all();
+    isCapturing = false;
+    instance.stopCapture(); // Blocks test thread until we exit out
+  }
+
+private:
+  enum class Threads { NONE, KAFKA, TEST };
+
+  void callback() { holdKafkaForTestClass(); }
+
+  void errCallback() {
+    try {
+      // Get the stored exception by calling extract data again
+      instance.extractData();
+    } catch (std::exception &e) {
+      // We could try to port the exception from this child thread to the main
+      // thread, or just print it here which is significantly easier
+      std::cerr << "Exception: " << e.what() << "\n";
+    }
+    // Always keep incrementing so we don't deadlock
+    holdKafkaForTestClass();
+  }
+
+  void holdKafkaForTestClass() {
+    std::unique_lock lock(mutex);
+
+    cv.notify_one();
+    blockedThread = Threads::KAFKA;
+    cv.wait_for(lock, DEADLOCK_TIMEOUT,
+                [this] { return blockedThread != Threads::KAFKA; });
+
+    assert(blockedThread != Threads::KAFKA &&
+           "Deadlock was detected as test thread was not unblocked");
+  }
+
+  // After ~2 minutes we almost certainly are deadlocked and not just
+  // waiting for a really slow machine to run the full test
+  const std::chrono::seconds DEADLOCK_TIMEOUT{120};
+
+  KafkaT instance;
+  bool isCapturing = false;
+
+  std::mutex mutex;
+  std::condition_variable cv;
+
+  Threads blockedThread = Threads::NONE;
+};
+
+} // namespace KafkaTesting


### PR DESCRIPTION
**Description of work.**

Converts the Kafka[Event/Histo]StreamDecoder tests to run in lockstep
whenever possible. The previous version held the unit test for n number
of Kafka steps then let both threads run free. Special thanks to Martyn for
figuring out a reproducer which was the final piece of this puzzle.

This fixes numerous races resulting in flakey tests, for example is
HistoStreamDecoder we waited for 1 iteration whereas three was required.
Rather than just tweaking the values and hoping this new mechanism will
deadlock if the threads get into a race-y condition. A timeout ensures
that after 2 minutes we fail with an abort stating we deadlocked.

This flushed out multiple races in the StreamDecoder too, however some
tests which rely on the EndOfRunStream have to run unsyncronised: The
the thread will block and the Kafka thread waits for ExtractData to be
called, causing a deadlock. If we are having problems in the future that
would be the first place to look, however for this commit it's out of
scope.

**To test:**
- Check unit tests pass
- Run the LiveDataTest using `ctest -R DecoderTest -E Mantid -VV` and check it doesn't deadlock (the CPU will be at 0% and the tests wont make progress)

There is no associated issue - part of flaky test work

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
