### PR TITLE
Add a short delay before algorithm garbage collection

### DIFF
--- a/Framework/API/inc/MantidAPI/Algorithm.h
+++ b/Framework/API/inc/MantidAPI/Algorithm.h
@@ -11,6 +11,7 @@
 #include "MantidAPI/DllConfig.h"
 #include "MantidAPI/IAlgorithm.h"
 #include "MantidAPI/IndexTypeProperty.h"
+#include "MantidKernel/DateAndTime.h"
 #include "MantidKernel/IValidator.h"
 #include "MantidKernel/PropertyManagerOwner.h"
 
@@ -226,6 +227,7 @@ public:
   bool isInitialized() const override;
   bool isExecuted() const override;
   bool isRunning() const override;
+  bool isReadyForGarbageCollection() const override;
 
   using Kernel::PropertyManagerOwner::getProperty;
 
@@ -504,6 +506,9 @@ private:
 
   /// (MPI) communicator used when executing the algorithm.
   std::unique_ptr<Parallel::Communicator> m_communicator;
+
+  /// The earliest this class should be considered for garbage collection
+  Mantid::Types::Core::DateAndTime m_gcTime;
 };
 
 /// Typedef for a shared pointer to an Algorithm

--- a/Framework/API/inc/MantidAPI/IAlgorithm.h
+++ b/Framework/API/inc/MantidAPI/IAlgorithm.h
@@ -132,6 +132,9 @@ public:
   /// True if the algorithm is running.
   virtual bool isRunning() const = 0;
 
+  /// True if the algorithm is ready for garbage collection.
+  virtual bool isReadyForGarbageCollection() const = 0;
+
   /// To query whether algorithm is a child. Default to false
   virtual bool isChild() const = 0;
 

--- a/Framework/API/src/Algorithm.cpp
+++ b/Framework/API/src/Algorithm.cpp
@@ -769,7 +769,7 @@ bool Algorithm::executeInternal() {
   }
   // Only gets to here if algorithm ended normally
   notificationCenter().postNotification(
-    new FinishedNotification(this, isExecuted()));
+      new FinishedNotification(this, isExecuted()));
 
   return isExecuted();
 }

--- a/Framework/API/src/Algorithm.cpp
+++ b/Framework/API/src/Algorithm.cpp
@@ -50,8 +50,8 @@ namespace {
 /// Separator for workspace types in workspaceMethodOnTypes member
 const std::string WORKSPACE_TYPES_SEPARATOR = ";";
 
-/// The minimum number of seconds after execution that the algorithm should be kept alive
-/// before garbage collection
+/// The minimum number of seconds after execution that the algorithm should be
+/// kept alive before garbage collection
 const size_t DELAY_BEFORE_GC = 5;
 
 class WorkspacePropertyValueIs {
@@ -111,7 +111,7 @@ Algorithm::Algorithm()
       m_communicator(std::make_unique<Parallel::Communicator>()) {}
 
 /// Virtual destructor
- Algorithm::~Algorithm() {}
+Algorithm::~Algorithm() {}
 
 //=============================================================================================
 //================================== Simple Getters/Setters
@@ -200,12 +200,12 @@ bool Algorithm::isRunning() const {
 }
 
 /// True if the algorithm is ready for garbage collection.
-bool Algorithm::isReadyForGarbageCollection() const { 
-    if ((executionState() == ExecutionState::Finished) && 
-        (Mantid::Types::Core::DateAndTime::getCurrentTime() > m_gcTime)) {
-        return true; 
-    }
-    return false; 
+bool Algorithm::isReadyForGarbageCollection() const {
+  if ((executionState() == ExecutionState::Finished) &&
+      (Mantid::Types::Core::DateAndTime::getCurrentTime() > m_gcTime)) {
+    return true;
+  }
+  return false;
 }
 
 //---------------------------------------------------------------------------------------------

--- a/Framework/API/src/Algorithm.cpp
+++ b/Framework/API/src/Algorithm.cpp
@@ -765,10 +765,10 @@ bool Algorithm::executeInternal() {
   m_gcTime = Mantid::Types::Core::DateAndTime::getCurrentTime() +=
       (Mantid::Types::Core::DateAndTime::ONE_SECOND * DELAY_BEFORE_GC);
   if (algIsExecuted) {
-      setResultState(ResultState::Success);
-      // Only gets to here if algorithm ended normally
-      notificationCenter().postNotification(
-          new FinishedNotification(this, isExecuted()));
+    setResultState(ResultState::Success);
+    // Only gets to here if algorithm ended normally
+    notificationCenter().postNotification(
+        new FinishedNotification(this, isExecuted()));
   }
   return isExecuted();
 }

--- a/Framework/API/src/Algorithm.cpp
+++ b/Framework/API/src/Algorithm.cpp
@@ -660,10 +660,6 @@ bool Algorithm::executeInternal() {
       if (m_alwaysStoreInADS)
         this->store();
 
-      // just cache the value internally, it is set at the very end of this
-      // method
-      algIsExecuted = true;
-
       // Log that execution has completed.
       getLogger().debug(
           "Time to validate properties: " +
@@ -741,11 +737,9 @@ bool Algorithm::executeInternal() {
 
   // Only gets to here if algorithm ended normally
   notificationCenter().postNotification(
-      new FinishedNotification(this, algIsExecuted));
-  if (algIsExecuted) {
-    setResultState(ResultState::Success);
-  }
-  return algIsExecuted;
+      new FinishedNotification(this, true));
+  setResultState(ResultState::Success);
+  return true;
 }
 
 //---------------------------------------------------------------------------------------------

--- a/Framework/API/src/Algorithm.cpp
+++ b/Framework/API/src/Algorithm.cpp
@@ -766,10 +766,11 @@ bool Algorithm::executeInternal() {
       (Mantid::Types::Core::DateAndTime::ONE_SECOND * DELAY_BEFORE_GC);
   if (algIsExecuted) {
     setResultState(ResultState::Success);
-    // Only gets to here if algorithm ended normally
-    notificationCenter().postNotification(
-        new FinishedNotification(this, isExecuted()));
   }
+  // Only gets to here if algorithm ended normally
+  notificationCenter().postNotification(
+    new FinishedNotification(this, isExecuted()));
+
   return isExecuted();
 }
 

--- a/Framework/API/src/AlgorithmManager.cpp
+++ b/Framework/API/src/AlgorithmManager.cpp
@@ -193,7 +193,7 @@ size_t AlgorithmManagerImpl::removeFinishedAlgorithms() {
   std::copy_if(
       m_managed_algs.cbegin(), m_managed_algs.cend(),
       std::back_inserter(theCompletedInstances), [](const auto &algorithm) {
-        return (algorithm->executionState() == ExecutionState::Finished);
+        return (algorithm->isReadyForGarbageCollection());
       });
   for (auto completedAlg : theCompletedInstances) {
     auto itend = m_managed_algs.end();

--- a/Framework/API/src/AlgorithmManager.cpp
+++ b/Framework/API/src/AlgorithmManager.cpp
@@ -190,11 +190,11 @@ void AlgorithmManagerImpl::cancelAll() {
 /// place
 size_t AlgorithmManagerImpl::removeFinishedAlgorithms() {
   std::vector<IAlgorithm_const_sptr> theCompletedInstances;
-  std::copy_if(
-      m_managed_algs.cbegin(), m_managed_algs.cend(),
-      std::back_inserter(theCompletedInstances), [](const auto &algorithm) {
-        return (algorithm->isReadyForGarbageCollection());
-      });
+  std::copy_if(m_managed_algs.cbegin(), m_managed_algs.cend(),
+               std::back_inserter(theCompletedInstances),
+               [](const auto &algorithm) {
+                 return (algorithm->isReadyForGarbageCollection());
+               });
   for (auto completedAlg : theCompletedInstances) {
     auto itend = m_managed_algs.end();
     for (auto it = m_managed_algs.begin(); it != itend; ++it) {

--- a/Framework/Algorithms/CMakeLists.txt
+++ b/Framework/Algorithms/CMakeLists.txt
@@ -1083,6 +1083,7 @@ add_subdirectory(test)
 
 # Auto-generate exports header
 target_include_directories(Algorithms PUBLIC ${CMAKE_BINARY_DIR}/Framework/Algorithms)
+target_include_directories(Algorithms PUBLIC ${CMAKE_BINARY_DIR}/Framework/Types)
 generate_mantid_export_header(Algorithms FALSE)
 
 # Installation settings

--- a/Framework/Kernel/inc/MantidKernel/NexusHDF5Descriptor.h
+++ b/Framework/Kernel/inc/MantidKernel/NexusHDF5Descriptor.h
@@ -12,7 +12,8 @@
 #include <set>
 #include <string>
 
-namespace Mantid::Kernel {
+namespace Mantid {
+namespace Kernel {
 
 class MANTID_KERNEL_DLL NexusHDF5Descriptor {
 
@@ -73,4 +74,5 @@ private:
   std::map<std::string, std::set<std::string>> m_allEntries;
 };
 
-} // namespace Mantid::Kernel
+} // namespace Kernel
+} // namespace Mantid

--- a/Framework/PythonInterface/test/cpp/CMakeLists.txt
+++ b/Framework/PythonInterface/test/cpp/CMakeLists.txt
@@ -24,6 +24,8 @@ if(CXXTEST_FOUND)
     set_target_properties(${_pythoninterface_test_target_name}
                           PROPERTIES COMPILE_FLAGS "/w44244")
   endif()
+
+  target_include_directories(${_pythoninterface_test_target_name} PUBLIC ${CMAKE_BINARY_DIR}/Framework/Types)
   target_link_libraries(${_pythoninterface_test_target_name}
                         LINK_PRIVATE
                         ${TCMALLOC_LIBRARIES_LINKTIME}

--- a/Framework/RemoteAlgorithms/test/CMakeLists.txt
+++ b/Framework/RemoteAlgorithms/test/CMakeLists.txt
@@ -4,6 +4,7 @@ if(CXXTEST_FOUND)
 )
 
   cxxtest_add_test(RemoteAlgorithmsTest ${TEST_FILES})
+  target_include_directories(RemoteAlgorithmsTest PUBLIC ${CMAKE_BINARY_DIR}/Framework/Types)
   target_link_libraries(RemoteAlgorithmsTest
                         LINK_PRIVATE
                         ${TCMALLOC_LIBRARIES_LINKTIME}


### PR DESCRIPTION
**Description of work.**

Add a 5-second delay after completion of the algorithm before deletion

This is all handled through a isReadyForGarbageCollection() method on Algorithm.
This can be overloaded in specific algorithms if needed.

**Report to:** @gemmaguest 

**To test:**
1. Open the ISIS reflectometry GUI
1. Enter some text in the Investigation Id box and click Search
1. Log in to ICat (test both valid and invalid logins) and OK. 
1. Then it should **no longer** crash


*There is no associated issue.*


*This does not require release notes* because **it was introduced in this sprint**


---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
