### PR TITLE
LoadEventNexus file loader speed up by caching and reusing metadata

### DIFF
--- a/Framework/API/inc/MantidAPI/NexusFileLoader.h
+++ b/Framework/API/inc/MantidAPI/NexusFileLoader.h
@@ -29,6 +29,9 @@ public:
   virtual void
   setFileInfo(std::shared_ptr<Mantid::Kernel::NexusHDF5Descriptor> fileInfo);
 
+  virtual int
+  confidence(Kernel::NexusHDF5Descriptor &descriptor) const override = 0;
+
 private:
   std::shared_ptr<Mantid::Kernel::NexusHDF5Descriptor> m_fileInfo;
 };

--- a/Framework/API/inc/MantidAPI/NexusFileLoader.h
+++ b/Framework/API/inc/MantidAPI/NexusFileLoader.h
@@ -29,6 +29,11 @@ public:
   virtual void
   setFileInfo(std::shared_ptr<Mantid::Kernel::NexusHDF5Descriptor> fileInfo);
 
+  /// Required to pass m_fileInfo to static functions
+  /// Keeping it shared_ptr to match setFileInfo signature (although passing
+  /// ownership is not the main goal).
+  virtual std::shared_ptr<Mantid::Kernel::NexusHDF5Descriptor> getFileInfo();
+
   virtual int
   confidence(Kernel::NexusHDF5Descriptor &descriptor) const override = 0;
 

--- a/Framework/API/inc/MantidAPI/NexusFileLoader.h
+++ b/Framework/API/inc/MantidAPI/NexusFileLoader.h
@@ -32,7 +32,8 @@ public:
   /// Required to pass m_fileInfo to static functions
   /// Keeping it shared_ptr to match setFileInfo signature (although passing
   /// ownership is not the main goal).
-  virtual std::shared_ptr<Mantid::Kernel::NexusHDF5Descriptor> getFileInfo();
+  virtual const std::shared_ptr<Mantid::Kernel::NexusHDF5Descriptor>
+  getFileInfo() const noexcept;
 
   virtual int
   confidence(Kernel::NexusHDF5Descriptor &descriptor) const override = 0;

--- a/Framework/API/inc/MantidAPI/NexusFileLoader.h
+++ b/Framework/API/inc/MantidAPI/NexusFileLoader.h
@@ -20,7 +20,8 @@ public:
   virtual void execLoader() = 0; // what would normally be called exec
   // the name of the property that the NexusHDF5Descriptor should be created
   // against
-  virtual std::string getFilenamePropertyName() const = 0;
+
+  virtual std::string getFilenamePropertyName() const;
   std::shared_ptr<Algorithm> createChildAlgorithm(
       const std::string &name, const double startProgress = -1.,
       const double endProgress = -1., const bool enableLogging = true,

--- a/Framework/API/inc/MantidAPI/RegisterFileLoader.h
+++ b/Framework/API/inc/MantidAPI/RegisterFileLoader.h
@@ -38,3 +38,18 @@
            Mantid::API::FileLoaderRegistryImpl::Nexus),                        \
        0));                                                                    \
   }
+
+/**
+ * DECLARE_NEXUS_HDF5_FILELOADER_ALGORITHM should be used in place of the
+ * standard DECLARE_ALGORITHM macro when writing a file loading algorithm that
+ * loads data using the Nexus API
+ * It both registers the algorithm as usual and subscribes it to the
+ * registry.
+ */
+#define DECLARE_NEXUS_HDF5_FILELOADER_ALGORITHM(classname)                     \
+  namespace {                                                                  \
+  Mantid::Kernel::RegistrationHelper reg_hdf_loader_##classname(               \
+      (Mantid::API::FileLoaderRegistry::Instance().subscribe<classname>(       \
+           Mantid::API::FileLoaderRegistryImpl::NexusHDF5),                    \
+       0));                                                                    \
+  }

--- a/Framework/API/src/NexusFileLoader.cpp
+++ b/Framework/API/src/NexusFileLoader.cpp
@@ -36,4 +36,31 @@ void NexusFileLoader::setFileInfo(
     std::shared_ptr<Mantid::Kernel::NexusHDF5Descriptor> fileInfo) {
   m_fileInfo = std::move(fileInfo);
 }
+
+std::string NexusFileLoader::getFilenamePropertyName() const {
+  return "Filename";
+}
+
+//----------------------------------------------------------------------------------------------
+/**
+ * Return the confidence with with this algorithm can load the file
+ * @param descriptor A descriptor for the file
+ * @returns An integer specifying the confidence level. 0 indicates it will not
+ * be used
+ */
+int NexusFileLoader::confidence(Kernel::NexusHDF5Descriptor &descriptor) const {
+
+  int confidence = 0;
+  const std::map<std::string, std::set<std::string>> &allEntries =
+      descriptor.getAllEntries();
+  if (allEntries.count("NXevent_data") == 1) {
+    if (descriptor.isClassEntry("NXentry", "/entry") ||
+        descriptor.isClassEntry("NXentry", "/raw_data_1")) {
+      confidence = 80;
+    }
+  }
+
+  return confidence;
+}
+
 } // namespace Mantid::API

--- a/Framework/API/src/NexusFileLoader.cpp
+++ b/Framework/API/src/NexusFileLoader.cpp
@@ -37,8 +37,8 @@ void NexusFileLoader::setFileInfo(
   m_fileInfo = std::move(fileInfo);
 }
 
-std::shared_ptr<Mantid::Kernel::NexusHDF5Descriptor>
-NexusFileLoader::getFileInfo() {
+const std::shared_ptr<Mantid::Kernel::NexusHDF5Descriptor>
+NexusFileLoader::getFileInfo() const noexcept {
   return m_fileInfo;
 }
 

--- a/Framework/API/src/NexusFileLoader.cpp
+++ b/Framework/API/src/NexusFileLoader.cpp
@@ -37,6 +37,11 @@ void NexusFileLoader::setFileInfo(
   m_fileInfo = std::move(fileInfo);
 }
 
+std::shared_ptr<Mantid::Kernel::NexusHDF5Descriptor>
+NexusFileLoader::getFileInfo() {
+  return m_fileInfo;
+}
+
 std::string NexusFileLoader::getFilenamePropertyName() const {
   return "Filename";
 }

--- a/Framework/API/src/NexusFileLoader.cpp
+++ b/Framework/API/src/NexusFileLoader.cpp
@@ -41,26 +41,4 @@ std::string NexusFileLoader::getFilenamePropertyName() const {
   return "Filename";
 }
 
-//----------------------------------------------------------------------------------------------
-/**
- * Return the confidence with with this algorithm can load the file
- * @param descriptor A descriptor for the file
- * @returns An integer specifying the confidence level. 0 indicates it will not
- * be used
- */
-int NexusFileLoader::confidence(Kernel::NexusHDF5Descriptor &descriptor) const {
-
-  int confidence = 0;
-  const std::map<std::string, std::set<std::string>> &allEntries =
-      descriptor.getAllEntries();
-  if (allEntries.count("NXevent_data") == 1) {
-    if (descriptor.isEntry("/entry", "NXentry") ||
-        descriptor.isEntry("/raw_data_1", "NXentry")) {
-      confidence = 80;
-    }
-  }
-
-  return confidence;
-}
-
 } // namespace Mantid::API

--- a/Framework/API/src/NexusFileLoader.cpp
+++ b/Framework/API/src/NexusFileLoader.cpp
@@ -54,8 +54,8 @@ int NexusFileLoader::confidence(Kernel::NexusHDF5Descriptor &descriptor) const {
   const std::map<std::string, std::set<std::string>> &allEntries =
       descriptor.getAllEntries();
   if (allEntries.count("NXevent_data") == 1) {
-    if (descriptor.isClassEntry("NXentry", "/entry") ||
-        descriptor.isClassEntry("NXentry", "/raw_data_1")) {
+    if (descriptor.isEntry("/entry", "NXentry") ||
+        descriptor.isEntry("/raw_data_1", "NXentry")) {
       confidence = 80;
     }
   }

--- a/Framework/DataHandling/inc/MantidDataHandling/LoadEventNexus.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/LoadEventNexus.h
@@ -7,6 +7,7 @@
 #pragma once
 
 #include "MantidAPI/IFileLoader.h"
+#include "MantidAPI/NexusFileLoader.h"
 #include "MantidAPI/WorkspaceGroup.h"
 #include "MantidDataHandling/BankPulseTimes.h"
 #include "MantidDataHandling/EventWorkspaceCollection.h"
@@ -15,7 +16,7 @@
 #include "MantidDataObjects/Events.h"
 #include "MantidGeometry/Instrument.h"
 #include "MantidGeometry/Instrument/ParameterMap.h"
-#include "MantidKernel/NexusDescriptor.h"
+#include "MantidKernel/NexusHDF5Descriptor.h"
 #include "MantidKernel/OptionalBool.h"
 #include "MantidKernel/TimeSeriesProperty.h"
 
@@ -68,8 +69,7 @@ bool exists(const std::map<std::string, std::string> &entries,
 
   @date Sep 27, 2010
   */
-class DLLExport LoadEventNexus
-    : public API::IFileLoader<Kernel::NexusDescriptor> {
+class DLLExport LoadEventNexus : public API::NexusFileLoader {
 
 public:
   LoadEventNexus();
@@ -91,9 +91,6 @@ public:
 
   /// Category
   const std::string category() const override { return "DataHandling\\Nexus"; }
-
-  /// Returns a confidence value that this algorithm can load a file
-  int confidence(Kernel::NexusDescriptor &descriptor) const override;
 
   template <typename T>
   static std::shared_ptr<BankPulseTimes> runLoadNexusLogs(
@@ -194,7 +191,7 @@ private:
   void init() override;
 
   /// Execution code
-  void exec() override;
+  void execLoader() override;
 
   LoadEventNexus::LoaderType
   defineLoaderType(const bool haveWeights, const bool oldNeXusFileNames,

--- a/Framework/DataHandling/inc/MantidDataHandling/LoadEventNexus.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/LoadEventNexus.h
@@ -375,7 +375,7 @@ void makeTimeOfFlightDataFuzzy(::NeXus::File &file, T localWorkspace,
  *modified.
  * @param entry_name :: An NXentry tag in the file
  * @param classType :: The type of the events: either detector or monitor
- * @param desciptor :: input descriptor carrying metadata information
+ * @param descriptor :: input descriptor carrying metadata information
  */
 template <typename T>
 void adjustTimeOfFlightISISLegacy(

--- a/Framework/DataHandling/inc/MantidDataHandling/LoadEventNexus.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/LoadEventNexus.h
@@ -113,11 +113,10 @@ public:
   /// Load instrument from Nexus file if possible, else from IDF spacified by
   /// Nexus file
   template <typename T>
-  static bool loadInstrument(
-      const std::string &nexusfilename, T localWorkspace,
-      const std::string &top_entry_name, Algorithm *alg,
-      const std::shared_ptr<Kernel::NexusHDF5Descriptor> &descriptor =
-          std::shared_ptr<Kernel::NexusHDF5Descriptor>());
+  static bool
+  loadInstrument(const std::string &nexusfilename, T localWorkspace,
+                 const std::string &top_entry_name, Algorithm *alg,
+                 const Kernel::NexusHDF5Descriptor *descriptor = nullptr);
 
   /// Load instrument for Nexus file
   template <typename T>
@@ -127,11 +126,10 @@ public:
 
   /// Load instrument from IDF file specified by Nexus file
   template <typename T>
-  static bool runLoadInstrument(
-      const std::string &nexusfilename, T localWorkspace,
-      const std::string &top_entry_name, Algorithm *alg,
-      const std::shared_ptr<Kernel::NexusHDF5Descriptor> &descriptor =
-          std::shared_ptr<Kernel::NexusHDF5Descriptor>());
+  static bool
+  runLoadInstrument(const std::string &nexusfilename, T localWorkspace,
+                    const std::string &top_entry_name, Algorithm *alg,
+                    const Kernel::NexusHDF5Descriptor *descriptor = nullptr);
 
   static void loadSampleDataISIScompatibility(::NeXus::File &file,
                                               EventWorkspaceCollection &WS);
@@ -487,14 +485,14 @@ template <typename T>
 bool LoadEventNexus::runLoadInstrument(
     const std::string &nexusfilename, T localWorkspace,
     const std::string &top_entry_name, Algorithm *alg,
-    const std::shared_ptr<Kernel::NexusHDF5Descriptor> &descriptor) {
+    const Kernel::NexusHDF5Descriptor *descriptor) {
   std::string instrument;
   std::string instFilename;
 
   const bool isNexus =
-      descriptor
-          ? LoadGeometry::isNexus(nexusfilename, descriptor->getAllEntries())
-          : LoadGeometry::isNexus(nexusfilename);
+      (descriptor == nullptr)
+          ? LoadGeometry::isNexus(nexusfilename)
+          : LoadGeometry::isNexus(nexusfilename, descriptor->getAllEntries());
 
   // Check if the geometry can be loaded directly from the Nexus file
   if (isNexus) {
@@ -753,7 +751,7 @@ template <typename T>
 bool LoadEventNexus::loadInstrument(
     const std::string &nexusfilename, T localWorkspace,
     const std::string &top_entry_name, Algorithm *alg,
-    const std::shared_ptr<Kernel::NexusHDF5Descriptor> &descriptor) {
+    const Kernel::NexusHDF5Descriptor *descriptor) {
 
   bool loadNexusInstrumentXML = true;
   if (alg->existsProperty("LoadNexusInstrumentXML"))

--- a/Framework/DataHandling/inc/MantidDataHandling/LoadEventNexus.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/LoadEventNexus.h
@@ -208,7 +208,6 @@ private:
       const std::vector<std::string> &bankNames = std::vector<std::string>());
   void deleteBanks(const EventWorkspaceCollection_sptr &workspace,
                    const std::vector<std::string> &bankNames);
-  bool hasEventMonitors();
   void runLoadMonitors();
   /// Set the filters on TOF.
   void setTimeFilters(const bool monitors);

--- a/Framework/DataHandling/inc/MantidDataHandling/LoadEventNexus.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/LoadEventNexus.h
@@ -603,10 +603,8 @@ void LoadEventNexus::loadEntryMetadata(
   ::NeXus::File file(nexusfilename);
   file.openGroup(entry_name, "NXentry");
 
-  const std::map<std::string, std::string> entriesNxentry = file.getEntries();
-
   // get the title
-  if (descriptor.isEntry("/" + entry_name + "/title", "NXentry")) {
+  if (descriptor.isEntry("/" + entry_name + "/title", "SDS")) {
     file.openData("title");
     if (file.getInfo().type == ::NeXus::CHAR) {
       std::string title = file.getStrData();
@@ -617,7 +615,7 @@ void LoadEventNexus::loadEntryMetadata(
   }
 
   // get the notes
-  if (descriptor.isEntry("/" + entry_name + "/notes", "NXentry")) {
+  if (descriptor.isEntry("/" + entry_name + "/notes", "SDS")) {
     file.openData("notes");
     if (file.getInfo().type == ::NeXus::CHAR) {
       std::string notes = file.getStrData();
@@ -628,7 +626,7 @@ void LoadEventNexus::loadEntryMetadata(
   }
 
   // Get the run number
-  if (descriptor.isEntry("/" + entry_name + "/run_number", "NXentry")) {
+  if (descriptor.isEntry("/" + entry_name + "/run_number", "SDS")) {
     file.openData("run_number");
     std::string run;
     if (file.getInfo().type == ::NeXus::CHAR) {
@@ -647,8 +645,7 @@ void LoadEventNexus::loadEntryMetadata(
   }
 
   // get the experiment identifier
-  if (descriptor.isEntry("/" + entry_name + "/experiment_identifier",
-                         "NXentry")) {
+  if (descriptor.isEntry("/" + entry_name + "/experiment_identifier", "SDS")) {
     file.openData("experiment_identifier");
     std::string expId;
     if (file.getInfo().type == ::NeXus::CHAR) {
@@ -662,10 +659,10 @@ void LoadEventNexus::loadEntryMetadata(
 
   // get the sample name - nested try/catch to leave the handle in an
   // appropriate state
-  if (descriptor.isEntry("/" + entry_name + "/sample", "NXentry")) {
+  if (descriptor.isEntry("/" + entry_name + "/sample", "NXsample")) {
     file.openGroup("sample", "NXsample");
     try {
-      if (exists(file, "name")) {
+      if (descriptor.isEntry("/" + entry_name + "/sample/name", "SDS")) {
         file.openData("name");
         const auto info = file.getInfo();
         std::string name;
@@ -693,7 +690,7 @@ void LoadEventNexus::loadEntryMetadata(
   }
 
   // get the duration
-  if (descriptor.isEntry("/" + entry_name + "/duration", "NXentry")) {
+  if (descriptor.isEntry("/" + entry_name + "/duration", "SDS")) {
     file.openData("duration");
     std::vector<double> duration;
     file.getDataCoerce(duration);

--- a/Framework/DataHandling/inc/MantidDataHandling/LoadEventNexus.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/LoadEventNexus.h
@@ -107,7 +107,8 @@ public:
 
   template <typename T>
   static void loadEntryMetadata(const std::string &nexusfilename, T WS,
-                                const std::string &entry_name);
+                                const std::string &entry_name,
+                                const Kernel::NexusHDF5Descriptor &descriptor);
 
   /// Load instrument from Nexus file if possible, else from IDF spacified by
   /// Nexus file
@@ -595,8 +596,9 @@ bool LoadEventNexus::runLoadInstrument(const std::string &nexusfilename,
 //-----------------------------------------------------------------------------
 /** Load the run number and other meta data from the given bank */
 template <typename T>
-void LoadEventNexus::loadEntryMetadata(const std::string &nexusfilename, T WS,
-                                       const std::string &entry_name) {
+void LoadEventNexus::loadEntryMetadata(
+    const std::string &nexusfilename, T WS, const std::string &entry_name,
+    const Kernel::NexusHDF5Descriptor &descriptor) {
   // Open the file
   ::NeXus::File file(nexusfilename);
   file.openGroup(entry_name, "NXentry");
@@ -605,7 +607,7 @@ void LoadEventNexus::loadEntryMetadata(const std::string &nexusfilename, T WS,
   const std::map<std::string, std::string> entriesNxentry = file.getEntries();
 
   // get the title
-  if (exists(entriesNxentry, "title")) {
+  if (descriptor.isEntry("/" + entry_name + "/title", "NXentry")) {
     file.openData("title");
     if (file.getInfo().type == ::NeXus::CHAR) {
       std::string title = file.getStrData();
@@ -616,7 +618,7 @@ void LoadEventNexus::loadEntryMetadata(const std::string &nexusfilename, T WS,
   }
 
   // get the notes
-  if (exists(entriesNxentry, "notes")) {
+  if (descriptor.isEntry("/" + entry_name + "/title", "NXentry")) {
     file.openData("notes");
     if (file.getInfo().type == ::NeXus::CHAR) {
       std::string notes = file.getStrData();
@@ -627,7 +629,7 @@ void LoadEventNexus::loadEntryMetadata(const std::string &nexusfilename, T WS,
   }
 
   // Get the run number
-  if (exists(entriesNxentry, "run_number")) {
+  if (descriptor.isEntry("/" + entry_name + "/run_number", "NXentry")) {
     file.openData("run_number");
     std::string run;
     if (file.getInfo().type == ::NeXus::CHAR) {
@@ -646,7 +648,8 @@ void LoadEventNexus::loadEntryMetadata(const std::string &nexusfilename, T WS,
   }
 
   // get the experiment identifier
-  if (exists(entriesNxentry, "experiment_identifier")) {
+  if (descriptor.isEntry("/" + entry_name + "/experiment_identifier",
+                         "NXentry")) {
     file.openData("experiment_identifier");
     std::string expId;
     if (file.getInfo().type == ::NeXus::CHAR) {
@@ -660,10 +663,11 @@ void LoadEventNexus::loadEntryMetadata(const std::string &nexusfilename, T WS,
 
   // get the sample name - nested try/catch to leave the handle in an
   // appropriate state
-  if (exists(entriesNxentry, "sample")) {
+  if (descriptor.isEntry("/" + entry_name + "/sample", "NXentry")) {
     file.openGroup("sample", "NXsample");
     try {
-      if (exists(file, "name")) {
+    
+      if (descriptor.isEntry("/" + entry_name + "/sample/name")) {
         file.openData("name");
         const auto info = file.getInfo();
         std::string name;
@@ -691,7 +695,7 @@ void LoadEventNexus::loadEntryMetadata(const std::string &nexusfilename, T WS,
   }
 
   // get the duration
-  if (exists(entriesNxentry, "duration")) {
+  if (descriptor.isEntry("/" + entry_name + "/duration", "NXentry")) {
     file.openData("duration");
     std::vector<double> duration;
     file.getDataCoerce(duration);

--- a/Framework/DataHandling/inc/MantidDataHandling/LoadEventNexus.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/LoadEventNexus.h
@@ -110,8 +110,16 @@ public:
                                 const std::string &entry_name,
                                 const Kernel::NexusHDF5Descriptor &descriptor);
 
-  /// Load instrument from Nexus file if possible, else from IDF spacified by
-  /// Nexus file
+  /**
+   * Load instrument from Nexus file if possible, else from IDF spacified by
+   * Nexus file
+   * @param nexusfilename input nexus file name
+   * @param localWorkspace input
+   * @param top_entry_name e.g. /entry
+   * @param alg input algorithm executing this task
+   * @param descriptor input descriptor
+   * @return true: success, false: failure
+   */
   template <typename T>
   static bool
   loadInstrument(const std::string &nexusfilename, T localWorkspace,
@@ -124,7 +132,15 @@ public:
   runLoadIDFFromNexus(const std::string &nexusfilename, T localWorkspace,
                       const std::string &top_entry_name, Algorithm *alg);
 
-  /// Load instrument from IDF file specified by Nexus file
+  /**
+   * Load instrument from IDF file specified by Nexus file
+   * @param nexusfilename input nexus file name
+   * @param localWorkspace input
+   * @param top_entry_name e.g. /entry
+   * @param alg input algorithm executing this task
+   * @param descriptor input descriptor
+   * @return true: success, false: failure
+   */
   template <typename T>
   static bool
   runLoadInstrument(const std::string &nexusfilename, T localWorkspace,
@@ -359,20 +375,20 @@ void makeTimeOfFlightDataFuzzy(::NeXus::File &file, T localWorkspace,
  *modified.
  * @param entry_name :: An NXentry tag in the file
  * @param classType :: The type of the events: either detector or monitor
+ * @param desciptor :: input descriptor carrying metadata information
  */
 template <typename T>
 void adjustTimeOfFlightISISLegacy(
     ::NeXus::File &file, T localWorkspace, const std::string &entry_name,
     const std::string &classType,
-    const std::shared_ptr<Kernel::NexusHDF5Descriptor> &descriptor =
-        std::shared_ptr<Kernel::NexusHDF5Descriptor>()) {
+    const Kernel::NexusHDF5Descriptor *descriptor = nullptr) {
   bool done = false;
   // Go to the root, and then top entry
   file.openPath("/");
   file.openGroup(entry_name, "NXentry");
 
   // NexusHDF5Descriptor
-  if (descriptor) {
+  if (descriptor != nullptr) {
     // not an ISIS file
     if (!descriptor->isEntry("/" + entry_name + "/detector_1_events")) {
       return;

--- a/Framework/DataHandling/inc/MantidDataHandling/LoadEventNexus.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/LoadEventNexus.h
@@ -113,8 +113,11 @@ public:
   /// Load instrument from Nexus file if possible, else from IDF spacified by
   /// Nexus file
   template <typename T>
-  static bool loadInstrument(const std::string &nexusfilename, T localWorkspace,
-                             const std::string &top_entry_name, Algorithm *alg);
+  static bool loadInstrument(
+      const std::string &nexusfilename, T localWorkspace,
+      const std::string &top_entry_name, Algorithm *alg,
+      const std::shared_ptr<Kernel::NexusHDF5Descriptor> &descriptor =
+          std::shared_ptr<Kernel::NexusHDF5Descriptor>());
 
   /// Load instrument for Nexus file
   template <typename T>
@@ -124,9 +127,11 @@ public:
 
   /// Load instrument from IDF file specified by Nexus file
   template <typename T>
-  static bool
-  runLoadInstrument(const std::string &nexusfilename, T localWorkspace,
-                    const std::string &top_entry_name, Algorithm *alg);
+  static bool runLoadInstrument(
+      const std::string &nexusfilename, T localWorkspace,
+      const std::string &top_entry_name, Algorithm *alg,
+      const std::shared_ptr<Kernel::NexusHDF5Descriptor> &descriptor =
+          std::shared_ptr<Kernel::NexusHDF5Descriptor>());
 
   static void loadSampleDataISIScompatibility(::NeXus::File &file,
                                               EventWorkspaceCollection &WS);
@@ -469,15 +474,20 @@ void adjustTimeOfFlightISISLegacy(::NeXus::File &file, T localWorkspace,
  *  @return true if successful
  */
 template <typename T>
-bool LoadEventNexus::runLoadInstrument(const std::string &nexusfilename,
-                                       T localWorkspace,
-                                       const std::string &top_entry_name,
-                                       Algorithm *alg) {
+bool LoadEventNexus::runLoadInstrument(
+    const std::string &nexusfilename, T localWorkspace,
+    const std::string &top_entry_name, Algorithm *alg,
+    const std::shared_ptr<Kernel::NexusHDF5Descriptor> &descriptor) {
   std::string instrument;
   std::string instFilename;
 
+  const bool isNexus =
+      descriptor
+          ? LoadGeometry::isNexus(nexusfilename, descriptor->getAllEntries())
+          : LoadGeometry::isNexus(nexusfilename);
+
   // Check if the geometry can be loaded directly from the Nexus file
-  if (LoadGeometry::isNexus(nexusfilename)) {
+  if (isNexus) {
     instFilename = nexusfilename;
   } else {
     // Get the instrument name
@@ -730,10 +740,10 @@ void LoadEventNexus::loadEntryMetadata(
  *  @return true if successful
  */
 template <typename T>
-bool LoadEventNexus::loadInstrument(const std::string &nexusfilename,
-                                    T localWorkspace,
-                                    const std::string &top_entry_name,
-                                    Algorithm *alg) {
+bool LoadEventNexus::loadInstrument(
+    const std::string &nexusfilename, T localWorkspace,
+    const std::string &top_entry_name, Algorithm *alg,
+    const std::shared_ptr<Kernel::NexusHDF5Descriptor> &descriptor) {
 
   bool loadNexusInstrumentXML = true;
   if (alg->existsProperty("LoadNexusInstrumentXML"))
@@ -745,7 +755,7 @@ bool LoadEventNexus::loadInstrument(const std::string &nexusfilename,
                                              top_entry_name, alg);
   if (!foundInstrument)
     foundInstrument = runLoadInstrument<T>(nexusfilename, localWorkspace,
-                                           top_entry_name, alg);
+                                           top_entry_name, alg, descriptor);
   return foundInstrument;
 }
 

--- a/Framework/DataHandling/inc/MantidDataHandling/LoadEventNexus.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/LoadEventNexus.h
@@ -92,6 +92,8 @@ public:
   /// Category
   const std::string category() const override { return "DataHandling\\Nexus"; }
 
+  int confidence(Kernel::NexusHDF5Descriptor &descriptor) const override;
+
   template <typename T>
   static std::shared_ptr<BankPulseTimes> runLoadNexusLogs(
       const std::string &nexusfilename, T localWorkspace, Algorithm &alg,

--- a/Framework/DataHandling/inc/MantidDataHandling/LoadEventNexus.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/LoadEventNexus.h
@@ -363,13 +363,23 @@ void makeTimeOfFlightDataFuzzy(::NeXus::File &file, T localWorkspace,
  * @param classType :: The type of the events: either detector or monitor
  */
 template <typename T>
-void adjustTimeOfFlightISISLegacy(::NeXus::File &file, T localWorkspace,
-                                  const std::string &entry_name,
-                                  const std::string &classType) {
+void adjustTimeOfFlightISISLegacy(
+    ::NeXus::File &file, T localWorkspace, const std::string &entry_name,
+    const std::string &classType,
+    const std::shared_ptr<Kernel::NexusHDF5Descriptor> &descriptor =
+        std::shared_ptr<Kernel::NexusHDF5Descriptor>()) {
   bool done = false;
   // Go to the root, and then top entry
   file.openPath("/");
   file.openGroup(entry_name, "NXentry");
+
+  // NexusHDF5Descriptor
+  if (descriptor) {
+    // not an ISIS file
+    if (!descriptor->isEntry("/" + entry_name + "/detector_1_events")) {
+      return;
+    }
+  }
 
   using string_map_t = std::map<std::string, std::string>;
   string_map_t entries = file.getEntries();

--- a/Framework/DataHandling/inc/MantidDataHandling/LoadEventNexus.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/LoadEventNexus.h
@@ -603,7 +603,6 @@ void LoadEventNexus::loadEntryMetadata(
   ::NeXus::File file(nexusfilename);
   file.openGroup(entry_name, "NXentry");
 
-  // only generating the entriesMap once
   const std::map<std::string, std::string> entriesNxentry = file.getEntries();
 
   // get the title
@@ -618,7 +617,7 @@ void LoadEventNexus::loadEntryMetadata(
   }
 
   // get the notes
-  if (descriptor.isEntry("/" + entry_name + "/title", "NXentry")) {
+  if (descriptor.isEntry("/" + entry_name + "/notes", "NXentry")) {
     file.openData("notes");
     if (file.getInfo().type == ::NeXus::CHAR) {
       std::string notes = file.getStrData();
@@ -666,8 +665,7 @@ void LoadEventNexus::loadEntryMetadata(
   if (descriptor.isEntry("/" + entry_name + "/sample", "NXentry")) {
     file.openGroup("sample", "NXsample");
     try {
-    
-      if (descriptor.isEntry("/" + entry_name + "/sample/name")) {
+      if (exists(file, "name")) {
         file.openData("name");
         const auto info = file.getInfo();
         std::string name;

--- a/Framework/DataHandling/inc/MantidDataHandling/LoadGeometry.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/LoadGeometry.h
@@ -6,6 +6,8 @@
 // SPDX - License - Identifier: GPL - 3.0 +
 #pragma once
 
+#include <map>
+#include <set>
 #include <string>
 #include <vector>
 
@@ -23,6 +25,10 @@ namespace LoadGeometry {
 bool isIDF(const std::string &filename);
 /// Determine if the Geometry file type is Nexus
 bool isNexus(const std::string &filename);
+/// Determine if the Geometry file type is Nexus
+/// version that reuses the metadata container
+bool isNexus(const std::string &filename,
+             const std::map<std::string, std::set<std::string>> &allEntries);
 /// List allowed file extensions for geometry
 const std::vector<std::string> validExtensions();
 

--- a/Framework/DataHandling/inc/MantidDataHandling/LoadNexusLogs.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/LoadNexusLogs.h
@@ -6,7 +6,6 @@
 // SPDX - License - Identifier: GPL - 3.0 +
 #pragma once
 
-
 #include "MantidAPI/NexusFileLoader.h"
 #include <nexus/NeXusFile.hpp>
 

--- a/Framework/DataHandling/inc/MantidDataHandling/LoadNexusLogs.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/LoadNexusLogs.h
@@ -90,7 +90,6 @@ private:
    * Load an IXseblock entry
    * @param file input Nexus file handler
    * @param absolute_entry_name full entry name in Nexus
-   * @param entry_class type of the entry (NXlog)
    * @param workspace input workspace
    */
   void loadSELog(::NeXus::File &file, const std::string &absolute_entry_name,

--- a/Framework/DataHandling/inc/MantidDataHandling/LoadNexusLogs.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/LoadNexusLogs.h
@@ -63,16 +63,37 @@ private:
   void init() override;
   /// Overwrites Algorithm method
   void execLoader() override;
-  /// Load log data from a group
-  void loadLogs(::NeXus::File &file, const std::string &entry_name,
+
+  /**
+   * Load log data from a group
+   * @param file input Nexus file handler
+   * @param absolute_entry_name full entry name in Nexus
+   * @param entry_class type of the entry (NXlog)
+   * @param workspace input workspace
+   */
+  void loadLogs(::NeXus::File &file, const std::string &absolute_entry_name,
                 const std::string &entry_class,
                 const std::shared_ptr<API::MatrixWorkspace> &workspace) const;
-  /// Load an NXlog entry
-  void loadNXLog(::NeXus::File &file, const std::string &entry_name,
+
+  /**
+   * Load an NXlog entry
+   * @param file input Nexus file handler
+   * @param absolute_entry_name full entry name in Nexus
+   * @param entry_class type of the entry (NXlog)
+   * @param workspace input workspace
+   */
+  void loadNXLog(::NeXus::File &file, const std::string &absolute_entry_name,
                  const std::string &entry_class,
                  const std::shared_ptr<API::MatrixWorkspace> &workspace) const;
-  /// Load an IXseblock entry
-  void loadSELog(::NeXus::File &file, const std::string &entry_name,
+
+  /**
+   * Load an IXseblock entry
+   * @param file input Nexus file handler
+   * @param absolute_entry_name full entry name in Nexus
+   * @param entry_class type of the entry (NXlog)
+   * @param workspace input workspace
+   */
+  void loadSELog(::NeXus::File &file, const std::string &absolute_entry_name,
                  const std::shared_ptr<API::MatrixWorkspace> &workspace) const;
   void
   loadVetoPulses(::NeXus::File &file,

--- a/Framework/DataHandling/inc/MantidDataHandling/LoadNexusLogs.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/LoadNexusLogs.h
@@ -6,7 +6,8 @@
 // SPDX - License - Identifier: GPL - 3.0 +
 #pragma once
 
-#include "MantidAPI/DistributedAlgorithm.h"
+
+#include "MantidAPI/NexusFileLoader.h"
 #include <nexus/NeXusFile.hpp>
 
 namespace Mantid {
@@ -32,7 +33,7 @@ data.</LI>
 
 @author Martyn Gigg, Tessella plc
 */
-class DLLExport LoadNexusLogs : public API::DistributedAlgorithm {
+class DLLExport LoadNexusLogs : public API::NexusFileLoader {
 public:
   /// Default constructor
   LoadNexusLogs();
@@ -54,11 +55,15 @@ public:
     return "DataHandling\\Logs;DataHandling\\Nexus";
   }
 
+  int confidence(Kernel::NexusHDF5Descriptor & /*descriptor*/) const override {
+    return 0;
+  }
+
 private:
   /// Overwrites Algorithm method.
   void init() override;
   /// Overwrites Algorithm method
-  void exec() override;
+  void execLoader() override;
   /// Load log data from a group
   void loadLogs(::NeXus::File &file, const std::string &entry_name,
                 const std::string &entry_class,

--- a/Framework/DataHandling/inc/MantidDataHandling/LoadTOFRawNexus.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/LoadTOFRawNexus.h
@@ -10,6 +10,7 @@
 // Includes
 //----------------------------------------------------------------------
 #include "MantidAPI/IFileLoader.h"
+#include "MantidAPI/NexusFileLoader.h"
 #include "MantidAPI/Sample.h"
 #include "MantidAPI/SpectraDetectorTypes.h"
 #include "MantidDataObjects/Workspace2D.h"
@@ -26,8 +27,7 @@ namespace DataHandling {
  Loads a NeXus file that conforms to the TOFRaw instrument definition format and
  stores it in a 2D workspace.
  */
-class DLLExport LoadTOFRawNexus
-    : public API::IFileLoader<Kernel::NexusDescriptor> {
+class DLLExport LoadTOFRawNexus : public API::NexusFileLoader {
 public:
   /// Default Constructor
   LoadTOFRawNexus();
@@ -52,7 +52,7 @@ public:
   static std::string getEntryName(const std::string &filename);
 
   /// Returns a confidence value that this algorithm can load a file
-  int confidence(Kernel::NexusDescriptor &descriptor) const override;
+  int confidence(Kernel::NexusHDF5Descriptor &descriptor) const override;
 
   void countPixels(const std::string &nexusfilename,
                    const std::string &entry_name,
@@ -66,7 +66,7 @@ public:
 
 protected:
   void init() override;
-  void exec() override;
+  void execLoader() override;
 
   /// Validate the optional input properties
   void checkOptionalProperties();

--- a/Framework/DataHandling/inc/MantidDataHandling/LoadTOFRawNexus.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/LoadTOFRawNexus.h
@@ -10,7 +10,6 @@
 // Includes
 //----------------------------------------------------------------------
 #include "MantidAPI/IFileLoader.h"
-#include "MantidAPI/NexusFileLoader.h"
 #include "MantidAPI/Sample.h"
 #include "MantidAPI/SpectraDetectorTypes.h"
 #include "MantidDataObjects/Workspace2D.h"
@@ -27,7 +26,8 @@ namespace DataHandling {
  Loads a NeXus file that conforms to the TOFRaw instrument definition format and
  stores it in a 2D workspace.
  */
-class DLLExport LoadTOFRawNexus : public API::NexusFileLoader {
+class DLLExport LoadTOFRawNexus
+    : public API::IFileLoader<Kernel::NexusDescriptor> {
 public:
   /// Default Constructor
   LoadTOFRawNexus();
@@ -52,7 +52,7 @@ public:
   static std::string getEntryName(const std::string &filename);
 
   /// Returns a confidence value that this algorithm can load a file
-  int confidence(Kernel::NexusHDF5Descriptor &descriptor) const override;
+  int confidence(Kernel::NexusDescriptor &descriptor) const override;
 
   void countPixels(const std::string &nexusfilename,
                    const std::string &entry_name,
@@ -66,7 +66,7 @@ public:
 
 protected:
   void init() override;
-  void execLoader() override;
+  void exec() override;
 
   /// Validate the optional input properties
   void checkOptionalProperties();

--- a/Framework/DataHandling/src/LoadEventNexus.cpp
+++ b/Framework/DataHandling/src/LoadEventNexus.cpp
@@ -500,7 +500,7 @@ firstLastPulseTimes(::NeXus::File &file, Kernel::Logger &logger) {
  * This variable will be changed if the field is not there.
  * @param oldNeXusFileNames Whether to try using old names. This variable will
  * be changed if it is determined that old names are being used.
- *
+ * @param descriptor input containing metadata information
  * @return The number of events.
  */
 std::size_t numEvents(::NeXus::File &file, bool &hasTotalCounts,
@@ -1115,7 +1115,8 @@ void LoadEventNexus::loadEvents(API::Progress *const prog,
     m_ws->setAllX(HistogramData::BinEdges{0.0, 1.0});
 
   // if there is time_of_flight load it
-  adjustTimeOfFlightISISLegacy(*m_file, m_ws, m_top_entry_name, classType);
+  adjustTimeOfFlightISISLegacy(*m_file, m_ws, m_top_entry_name, classType,
+                               descriptor.get());
 }
 
 //-----------------------------------------------------------------------------
@@ -1177,6 +1178,7 @@ LoadEventNexus::readInstrumentFromISIS_VMSCompat(::NeXus::File &hFile) {
  *geometry
  *  @param top_entry_name :: entry name at the top of the NXS file
  *  @param alg :: Handle of the algorithm
+ *  @param descriptor :: input containing metadata information
  *  @return true if successful
  */
 template <>

--- a/Framework/DataHandling/src/LoadEventNexus.cpp
+++ b/Framework/DataHandling/src/LoadEventNexus.cpp
@@ -80,6 +80,28 @@ LoadEventNexus::LoadEventNexus()
       loadlogs(false), event_id_is_spec(false) {}
 
 //----------------------------------------------------------------------------------------------
+/**
+ * Return the confidence with with this algorithm can load the file
+ * @param descriptor A descriptor for the file
+ * @returns An integer specifying the confidence level. 0 indicates it will not
+ * be used
+ */
+int LoadEventNexus::confidence(Kernel::NexusHDF5Descriptor &descriptor) const {
+
+  int confidence = 0;
+  const std::map<std::string, std::set<std::string>> &allEntries =
+      descriptor.getAllEntries();
+  if (allEntries.count("NXevent_data") == 1) {
+    if (descriptor.isEntry("/entry", "NXentry") ||
+        descriptor.isEntry("/raw_data_1", "NXentry")) {
+      confidence = 80;
+    }
+  }
+
+  return confidence;
+}
+
+//----------------------------------------------------------------------------------------------
 /** Initialisation method.
  */
 void LoadEventNexus::init() {

--- a/Framework/DataHandling/src/LoadEventNexus.cpp
+++ b/Framework/DataHandling/src/LoadEventNexus.cpp
@@ -816,8 +816,8 @@ void LoadEventNexus::loadEvents(API::Progress *const prog,
     // This may not be needed in the future if both LoadEventNexus and
     // LoadInstrument are made to use the same Nexus/HDF5 library
     m_file->close();
-    m_instrument_loaded_correctly =
-        loadInstrument(m_filename, m_ws, m_top_entry_name, this, descriptor);
+    m_instrument_loaded_correctly = loadInstrument(
+        m_filename, m_ws, m_top_entry_name, this, descriptor.get());
 
     if (!m_instrument_loaded_correctly)
       throw std::runtime_error("Instrument was not initialized correctly! "
@@ -867,8 +867,9 @@ void LoadEventNexus::loadEvents(API::Progress *const prog,
         }
         // get the number of events
         const std::string prefix = "/" + m_top_entry_name + "/" + entry_name;
-        std::size_t num =
-            numEvents(*m_file, true, oldNeXusFileNames, prefix, *descriptor);
+        bool hasTotalCounts = true;
+        std::size_t num = numEvents(*m_file, hasTotalCounts, oldNeXusFileNames,
+                                    prefix, *descriptor);
         bankNames.emplace_back(entry_name);
         bankNumEvents.emplace_back(num);
 
@@ -1183,7 +1184,7 @@ bool LoadEventNexus::runLoadInstrument<EventWorkspaceCollection_sptr>(
     const std::string &nexusfilename,
     EventWorkspaceCollection_sptr localWorkspace,
     const std::string &top_entry_name, Algorithm *alg,
-    const std::shared_ptr<NexusHDF5Descriptor> &descriptor) {
+    const Kernel::NexusHDF5Descriptor *descriptor) {
   auto ws = localWorkspace->getSingleHeldWorkspace();
   auto hasLoaded = runLoadInstrument<MatrixWorkspace_sptr>(
       nexusfilename, ws, top_entry_name, alg, descriptor);

--- a/Framework/DataHandling/src/LoadEventNexus.cpp
+++ b/Framework/DataHandling/src/LoadEventNexus.cpp
@@ -837,7 +837,6 @@ void LoadEventNexus::loadEvents(API::Progress *const prog,
   std::string classType = monitors ? "NXmonitor" : "NXevent_data";
   ::NeXus::Info info;
   bool oldNeXusFileNames(false);
-  bool hasTotalCounts(true);
   bool haveWeights = false;
   auto firstPulseT = DateAndTime::maximum();
 
@@ -868,8 +867,8 @@ void LoadEventNexus::loadEvents(API::Progress *const prog,
         }
         // get the number of events
         const std::string prefix = "/" + m_top_entry_name + "/" + entry_name;
-        std::size_t num = numEvents(*m_file, hasTotalCounts, oldNeXusFileNames,
-                                    prefix, *descriptor);
+        std::size_t num =
+            numEvents(*m_file, true, oldNeXusFileNames, prefix, *descriptor);
         bankNames.emplace_back(entry_name);
         bankNumEvents.emplace_back(num);
 

--- a/Framework/DataHandling/src/LoadEventNexus.cpp
+++ b/Framework/DataHandling/src/LoadEventNexus.cpp
@@ -40,7 +40,7 @@ using namespace ::NeXus;
 namespace Mantid {
 namespace DataHandling {
 
-DECLARE_NEXUS_FILELOADER_ALGORITHM(LoadEventNexus)
+DECLARE_NEXUS_HDF5_FILELOADER_ALGORITHM(LoadEventNexus)
 
 using namespace Kernel;
 using namespace DateAndTimeHelpers;

--- a/Framework/DataHandling/src/LoadEventNexus.cpp
+++ b/Framework/DataHandling/src/LoadEventNexus.cpp
@@ -785,8 +785,10 @@ void LoadEventNexus::loadEvents(API::Progress *const prog,
   try {
     // this is a static method that is why it is passing the
     // file object and the file path
-    loadEntryMetadata<EventWorkspaceCollection_sptr>(m_filename, m_ws,
-                                                     m_top_entry_name);
+    const std::shared_ptr<NexusHDF5Descriptor> descriptor = getFileInfo();
+
+    loadEntryMetadata<EventWorkspaceCollection_sptr>(
+        m_filename, m_ws, m_top_entry_name, *descriptor);
   } catch (std::runtime_error &e) {
     // Missing metadata is not a fatal error. Log and go on with your life
     g_log.error() << "Error loading metadata: " << e.what() << '\n';

--- a/Framework/DataHandling/src/LoadEventNexus.cpp
+++ b/Framework/DataHandling/src/LoadEventNexus.cpp
@@ -817,7 +817,7 @@ void LoadEventNexus::loadEvents(API::Progress *const prog,
     // LoadInstrument are made to use the same Nexus/HDF5 library
     m_file->close();
     m_instrument_loaded_correctly =
-        loadInstrument(m_filename, m_ws, m_top_entry_name, this);
+        loadInstrument(m_filename, m_ws, m_top_entry_name, this, descriptor);
 
     if (!m_instrument_loaded_correctly)
       throw std::runtime_error("Instrument was not initialized correctly! "
@@ -1183,10 +1183,11 @@ template <>
 bool LoadEventNexus::runLoadInstrument<EventWorkspaceCollection_sptr>(
     const std::string &nexusfilename,
     EventWorkspaceCollection_sptr localWorkspace,
-    const std::string &top_entry_name, Algorithm *alg) {
+    const std::string &top_entry_name, Algorithm *alg,
+    const std::shared_ptr<NexusHDF5Descriptor> &descriptor) {
   auto ws = localWorkspace->getSingleHeldWorkspace();
-  auto hasLoaded = runLoadInstrument<MatrixWorkspace_sptr>(nexusfilename, ws,
-                                                           top_entry_name, alg);
+  auto hasLoaded = runLoadInstrument<MatrixWorkspace_sptr>(
+      nexusfilename, ws, top_entry_name, alg, descriptor);
   localWorkspace->setInstrument(ws->getInstrument());
   return hasLoaded;
 }

--- a/Framework/DataHandling/src/LoadEventNexus.cpp
+++ b/Framework/DataHandling/src/LoadEventNexus.cpp
@@ -500,6 +500,7 @@ firstLastPulseTimes(::NeXus::File &file, Kernel::Logger &logger) {
  * This variable will be changed if the field is not there.
  * @param oldNeXusFileNames Whether to try using old names. This variable will
  * be changed if it is determined that old names are being used.
+ * @param prefix current entry name prefix (e.g. /entry)
  * @param descriptor input containing metadata information
  * @return The number of events.
  */

--- a/Framework/DataHandling/src/LoadEventNexus.cpp
+++ b/Framework/DataHandling/src/LoadEventNexus.cpp
@@ -80,24 +80,6 @@ LoadEventNexus::LoadEventNexus()
       loadlogs(false), event_id_is_spec(false) {}
 
 //----------------------------------------------------------------------------------------------
-/**
- * Return the confidence with with this algorithm can load the file
- * @param descriptor A descriptor for the file
- * @returns An integer specifying the confidence level. 0 indicates it will not
- * be used
- */
-int LoadEventNexus::confidence(Kernel::NexusDescriptor &descriptor) const {
-  int confidence(0);
-  if (descriptor.classTypeExists("NXevent_data")) {
-    if (descriptor.pathOfTypeExists("/entry", "NXentry") ||
-        descriptor.pathOfTypeExists("/raw_data_1", "NXentry")) {
-      confidence = 80;
-    }
-  }
-  return confidence;
-}
-
-//----------------------------------------------------------------------------------------------
 /** Initialisation method.
  */
 void LoadEventNexus::init() {
@@ -373,7 +355,7 @@ void LoadEventNexus::filterDuringPause<EventWorkspaceCollection_sptr>(
 /** Executes the algorithm. Reading in the file and creating and populating
  *  the output workspace
  */
-void LoadEventNexus::exec() {
+void LoadEventNexus::execLoader() {
   // Retrieve the filename from the properties
   m_filename = getPropertyValue("Filename");
 

--- a/Framework/DataHandling/src/LoadGeometry.cpp
+++ b/Framework/DataHandling/src/LoadGeometry.cpp
@@ -33,6 +33,20 @@ bool LoadGeometry::isNexus(const std::string &filename) {
   return false;
 }
 
+bool LoadGeometry::isNexus(
+    const std::string &filename,
+    const std::map<std::string, std::set<std::string>> &allEntries) {
+  if (!filename.empty() &&
+      !Mantid::Kernel::FileDescriptor(filename).isAscii(filename)) {
+    Mantid::Kernel::NexusDescriptor descriptor(filename, false);
+    return descriptor.isReadable(filename) &&
+           (allEntries.count("NXcylindrical_geometry") == 1 ||
+            allEntries.count("NXoff_geometry") == 1 ||
+            allEntries.count("NXtransformations") == 1);
+  }
+  return false;
+}
+
 /// List allowed file extensions for geometry
 const std::vector<std::string> LoadGeometry::validExtensions() {
   return {".xml", ".nxs", ".hdf5"};

--- a/Framework/DataHandling/src/LoadNexusLogs.cpp
+++ b/Framework/DataHandling/src/LoadNexusLogs.cpp
@@ -671,7 +671,7 @@ void LoadNexusLogs::loadNPeriods(
  * Load log entries from the given group
  * @param file :: A reference to the NeXus file handle opened such that the
  * next call can be to open the named group
- * @param entry_name :: The name of the log entry
+ * @param absolute_entry_name :: The name of the log entry
  * @param entry_class :: The class type of the log entry
  * @param workspace :: A pointer to the workspace to store the logs
  */
@@ -722,7 +722,7 @@ void LoadNexusLogs::loadLogs(
  * Load an NX log entry a group type that has value and time entries.
  * @param file :: A reference to the NeXus file handle opened at the parent
  * group
- * @param entry_name :: The name of the log entry
+ * @param absolute_entry_name :: The name of the log entry
  * @param entry_class :: The type of the entry
  * @param workspace :: A pointer to the workspace to store the logs
  */
@@ -785,7 +785,7 @@ void LoadNexusLogs::loadNXLog(
  * Load an SE log entry
  * @param file :: A reference to the NeXus file handle opened at the parent
  * group
- * @param entry_name :: The name of the log entry
+ * @param absolute_entry_name :: The name of the log entry
  * @param workspace :: A pointer to the workspace to store the logs
  */
 void LoadNexusLogs::loadSELog(

--- a/Framework/DataHandling/src/LoadNexusLogs.cpp
+++ b/Framework/DataHandling/src/LoadNexusLogs.cpp
@@ -366,7 +366,7 @@ void LoadNexusLogs::init() {
  *  @throw std::invalid_argument If the optional properties are set to invalid
  *values
  */
-void LoadNexusLogs::exec() {
+void LoadNexusLogs::execLoader() {
   std::string filename = getPropertyValue("Filename");
   MatrixWorkspace_sptr workspace = getProperty("Workspace");
 

--- a/Framework/DataHandling/src/LoadNexusLogs.cpp
+++ b/Framework/DataHandling/src/LoadNexusLogs.cpp
@@ -729,16 +729,10 @@ void LoadNexusLogs::loadLogs(
 void LoadNexusLogs::loadNXLog(
     ::NeXus::File &file, const std::string &absolute_entry_name,
     const std::string &entry_class,
-<<<<<<< HEAD
     const std::shared_ptr<API::MatrixWorkspace> &workspace) const {
-  g_log.debug() << "processing " << entry_name << ":" << entry_class << "\n";
-=======
-    const boost::shared_ptr<API::MatrixWorkspace> &workspace) const {
->>>>>>> Refactored LoadNexusLogs
 
   const std::string entry_name =
       absolute_entry_name.substr(absolute_entry_name.find_last_of("/") + 1);
-
   g_log.debug() << "processing " << entry_name << ":" << entry_class << "\n";
   file.openGroup(entry_name, entry_class);
   // Validate the NX log class.
@@ -795,17 +789,12 @@ void LoadNexusLogs::loadNXLog(
  * @param workspace :: A pointer to the workspace to store the logs
  */
 void LoadNexusLogs::loadSELog(
-<<<<<<< HEAD
-    ::NeXus::File &file, const std::string &entry_name,
+    ::NeXus::File &file, const std::string &absolute_entry_name,
     const std::shared_ptr<API::MatrixWorkspace> &workspace) const {
   // Open the entry
-=======
-    ::NeXus::File &file, const std::string &absolute_entry_name,
-    const boost::shared_ptr<API::MatrixWorkspace> &workspace) const {
-
   const std::string entry_name =
       absolute_entry_name.substr(absolute_entry_name.find_last_of("/") + 1);
->>>>>>> Refactored LoadNexusLogs
+
   file.openGroup(entry_name, "IXseblock");
   std::string propName = entry_name;
   if (workspace->run().hasProperty(propName)) {

--- a/Framework/DataHandling/src/LoadNexusLogs.cpp
+++ b/Framework/DataHandling/src/LoadNexusLogs.cpp
@@ -781,13 +781,6 @@ void LoadNexusLogs::loadNXLog(
   file.closeGroup();
 }
 
-/**
- * Load an SE log entry
- * @param file :: A reference to the NeXus file handle opened at the parent
- * group
- * @param absolute_entry_name :: The name of the log entry
- * @param workspace :: A pointer to the workspace to store the logs
- */
 void LoadNexusLogs::loadSELog(
     ::NeXus::File &file, const std::string &absolute_entry_name,
     const std::shared_ptr<API::MatrixWorkspace> &workspace) const {

--- a/Framework/DataHandling/src/LoadNexusMonitors2.cpp
+++ b/Framework/DataHandling/src/LoadNexusMonitors2.cpp
@@ -165,6 +165,9 @@ void LoadNexusMonitors2::exec() {
   }
 
   m_top_entry_name = this->getPropertyValue("NXentryName");
+  // must be done here before the NeXus::File, HDF5 files can't have 2
+  // simultaneous handlers
+  Kernel::NexusHDF5Descriptor descriptor(m_filename);
 
   // top level file information
   ::NeXus::File file(m_filename);
@@ -329,7 +332,7 @@ void LoadNexusMonitors2::exec() {
   g_log.debug() << "Loading metadata\n";
   try {
     LoadEventNexus::loadEntryMetadata<API::MatrixWorkspace_sptr>(
-        m_filename, m_workspace, m_top_entry_name);
+        m_filename, m_workspace, m_top_entry_name, descriptor);
   } catch (std::exception &e) {
     g_log.warning() << "Error while loading meta data: " << e.what() << '\n';
   }

--- a/Framework/DataHandling/src/LoadTOFRawNexus.cpp
+++ b/Framework/DataHandling/src/LoadTOFRawNexus.cpp
@@ -73,21 +73,28 @@ void LoadTOFRawNexus::init() {
  * @returns An integer specifying the confidence level. 0 indicates it will not
  * be used
  */
-int LoadTOFRawNexus::confidence(Kernel::NexusDescriptor &descriptor) const {
+int LoadTOFRawNexus::confidence(Kernel::NexusHDF5Descriptor &descriptor) const {
   int confidence(0);
-  if (descriptor.pathOfTypeExists("/entry", "NXentry") ||
-      descriptor.pathOfTypeExists("/entry-state0", "NXentry")) {
-    const bool hasEventData = descriptor.classTypeExists("NXevent_data");
-    const bool hasData = descriptor.classTypeExists("NXdata");
-    if (hasData && hasEventData)
+
+  const std::map<std::string, std::set<std::string>> &allEntries =
+      descriptor.getAllEntries();
+
+  if (descriptor.isEntry("/entry", "NXentry") ||
+      descriptor.isEntry("/entry-state0", "NXentry")) {
+
+    const bool hasEventData =
+        (allEntries.count("NXevent_data") == 1) ? true : false;
+    const bool hasData = (allEntries.count("NXdata") == 1) ? true : false;
+    if (hasData && hasEventData) {
       // Event data = this is event NXS
       confidence = 20;
-    else if (hasData && !hasEventData)
+    } else if (hasData && !hasEventData) {
       // No event data = this is the one
       confidence = 80;
-    else
+    } else {
       // No data ?
       confidence = 10;
+    }
   }
   return confidence;
 }
@@ -475,7 +482,7 @@ std::string LoadTOFRawNexus::getEntryName(const std::string &filename) {
  *  @throw std::invalid_argument If the optional properties are set to invalid
  *values
  */
-void LoadTOFRawNexus::exec() {
+void LoadTOFRawNexus::execLoader() {
   // The input properties
   std::string filename = getPropertyValue("Filename");
   m_signalNo = getProperty("Signal");
@@ -520,7 +527,8 @@ void LoadTOFRawNexus::exec() {
   prog->report("Loading metadata");
   g_log.debug() << "Loading metadata\n";
   try {
-    LoadEventNexus::loadEntryMetadata(filename, WS, entry_name);
+
+    LoadEventNexus::loadEntryMetadata(filename, WS, entry_name, *m_fileInfo);
   } catch (std::exception &e) {
     g_log.warning() << "Error while loading meta data: " << e.what() << '\n';
   }

--- a/Framework/DataHandling/src/UpdateInstrumentFromFile.cpp
+++ b/Framework/DataHandling/src/UpdateInstrumentFromFile.cpp
@@ -99,10 +99,15 @@ void UpdateInstrumentFromFile::exec() {
   if (NexusDescriptor::isReadable(filename)) {
     LoadISISNexus2 isisNexus;
     LoadEventNexus eventNexus;
-    boost::scoped_ptr<Kernel::NexusDescriptor> descriptor(
-        new Kernel::NexusDescriptor(filename));
+
+    // we open and close the HDF5 file.
+    // there is an issue with how HDF5 files are opened (only one at a time)
+    // swap the order of descriptors
     boost::scoped_ptr<Kernel::NexusHDF5Descriptor> descriptorNexusHDF5(
         new Kernel::NexusHDF5Descriptor(filename));
+
+    boost::scoped_ptr<Kernel::NexusDescriptor> descriptor(
+        new Kernel::NexusDescriptor(filename));
 
     if (isisNexus.confidence(*descriptor) > 0 ||
         eventNexus.confidence(*descriptorNexusHDF5) > 0) {

--- a/Framework/DataHandling/src/UpdateInstrumentFromFile.cpp
+++ b/Framework/DataHandling/src/UpdateInstrumentFromFile.cpp
@@ -101,8 +101,11 @@ void UpdateInstrumentFromFile::exec() {
     LoadEventNexus eventNexus;
     boost::scoped_ptr<Kernel::NexusDescriptor> descriptor(
         new Kernel::NexusDescriptor(filename));
+    boost::scoped_ptr<Kernel::NexusHDF5Descriptor> descriptorNexusHDF5(
+        new Kernel::NexusHDF5Descriptor(filename));
+
     if (isisNexus.confidence(*descriptor) > 0 ||
-        eventNexus.confidence(*descriptor) > 0) {
+        eventNexus.confidence(*descriptorNexusHDF5) > 0) {
       auto &nxFile = descriptor->data();
       const auto &rootEntry = descriptor->firstEntryNameType();
       nxFile.openGroup(rootEntry.first, rootEntry.second);

--- a/Framework/Kernel/inc/MantidKernel/NexusDescriptor.h
+++ b/Framework/Kernel/inc/MantidKernel/NexusDescriptor.h
@@ -47,7 +47,7 @@ public:
 
 public:
   /// Constructor accepting a filename
-  NexusDescriptor(const std::string &filename);
+  NexusDescriptor(const std::string &filename, const bool init = true);
   /// Destructor
   ~NexusDescriptor();
 

--- a/Framework/Kernel/inc/MantidKernel/NexusDescriptor.h
+++ b/Framework/Kernel/inc/MantidKernel/NexusDescriptor.h
@@ -46,7 +46,12 @@ public:
                          const Version version = AnyVersion);
 
 public:
-  /// Constructor accepting a filename
+  /**
+   * Constructor accepting a filename
+   * @param filename input filename
+   * @param init true: expensive init including walking through the file, false:
+   * don't init
+   */
   NexusDescriptor(const std::string &filename, const bool init = true);
   /// Destructor
   ~NexusDescriptor();

--- a/Framework/Kernel/inc/MantidKernel/NexusHDF5Descriptor.h
+++ b/Framework/Kernel/inc/MantidKernel/NexusHDF5Descriptor.h
@@ -59,8 +59,15 @@ public:
    * @param entryName full path for an entry name /entry/NXlogs
    * @return true: entryName exists for a groupClass, otherwise false
    */
-  bool isClassEntry(const std::string &groupClass,
-                    const std::string &entryName) const noexcept;
+  bool isEntry(const std::string &entryName,
+               const std::string &groupClass) const noexcept;
+
+  /**
+   * Checks if a full-path entry exists in a Nexus dataset
+   * @param entryName full path for an entry name /entry/NXlogs
+   * @return true: entryName exists, otherwise false
+   */
+  bool isEntry(const std::string &entryName) const noexcept;
 
 private:
   /**

--- a/Framework/Kernel/inc/MantidKernel/NexusHDF5Descriptor.h
+++ b/Framework/Kernel/inc/MantidKernel/NexusHDF5Descriptor.h
@@ -87,7 +87,7 @@ private:
    *          (e.g. /entry/log)
    * </pre>
    */
-  std::map<std::string, std::set<std::string>> m_allEntries;
+  const std::map<std::string, std::set<std::string>> m_allEntries;
 };
 
 } // namespace Mantid::Kernel

--- a/Framework/Kernel/inc/MantidKernel/NexusHDF5Descriptor.h
+++ b/Framework/Kernel/inc/MantidKernel/NexusHDF5Descriptor.h
@@ -52,6 +52,16 @@ public:
   const std::map<std::string, std::set<std::string>> &getAllEntries() const
       noexcept;
 
+  /**
+   * Checks if a full-path entry exists for a particular groupClass in a Nexus
+   * dataset
+   * @param groupClass e.g. NxLog , Nexus entry attribute
+   * @param entryName full path for an entry name /entry/NXlogs
+   * @return true: entryName exists for a groupClass, otherwise false
+   */
+  bool isClassEntry(const std::string &groupClass,
+                    const std::string &entryName) const noexcept;
+
 private:
   /**
    * Sets m_allEntries, called in HDF5 constructor.

--- a/Framework/Kernel/src/NexusDescriptor.cpp
+++ b/Framework/Kernel/src/NexusDescriptor.cpp
@@ -120,7 +120,7 @@ bool NexusDescriptor::isReadable(const std::string &filename,
  * involves simply checking for the signature if a HDF file at the start of the
  * file
  */
-NexusDescriptor::NexusDescriptor(const std::string &filename)
+NexusDescriptor::NexusDescriptor(const std::string &filename, const bool init)
     : m_filename(), m_extension(), m_firstEntryNameType(), m_rootAttrs(),
       m_pathsToTypes(), m_file(nullptr) {
   if (filename.empty()) {
@@ -131,12 +131,16 @@ NexusDescriptor::NexusDescriptor(const std::string &filename)
     throw std::invalid_argument("NexusDescriptor() - File '" + filename +
                                 "' does not exist");
   }
-  try {
-    initialize(filename);
-  } catch (::NeXus::Exception &e) {
-    throw std::invalid_argument(
-        "NexusDescriptor::initialize - File '" + filename +
-        "' does not look like a HDF file.\n Error was: " + e.what());
+
+  if (init) {
+    try {
+      // this is very expesive as it walk the entire file
+      initialize(filename);
+    } catch (::NeXus::Exception &e) {
+      throw std::invalid_argument(
+          "NexusDescriptor::initialize - File '" + filename +
+          "' does not look like a HDF file.\n Error was: " + e.what());
+    }
   }
 }
 

--- a/Framework/Kernel/src/NexusHDF5Descriptor.cpp
+++ b/Framework/Kernel/src/NexusHDF5Descriptor.cpp
@@ -224,8 +224,8 @@ NexusHDF5Descriptor::initAllEntries() {
   return allEntries;
 }
 
-bool NexusHDF5Descriptor::isClassEntry(const std::string &groupClass,
-                                       const std::string &entryName) const
+bool NexusHDF5Descriptor::isEntry(const std::string &entryName,
+                                  const std::string &groupClass) const
     noexcept {
 
   auto itClass = m_allEntries.find(groupClass);
@@ -237,6 +237,17 @@ bool NexusHDF5Descriptor::isClassEntry(const std::string &groupClass,
     return true;
   }
 
+  return false;
+}
+
+bool NexusHDF5Descriptor::isEntry(const std::string &entryName) const noexcept {
+
+  for (auto itClass = m_allEntries.cbegin(); itClass != m_allEntries.cend();
+       ++itClass) {
+    if (itClass->second.count(entryName) == 1) {
+      return true;
+    }
+  }
   return false;
 }
 

--- a/Framework/Kernel/src/NexusHDF5Descriptor.cpp
+++ b/Framework/Kernel/src/NexusHDF5Descriptor.cpp
@@ -246,7 +246,7 @@ bool NexusHDF5Descriptor::isEntry(const std::string &entryName,
 
 bool NexusHDF5Descriptor::isEntry(const std::string &entryName) const noexcept {
 
-  for (auto itClass = m_allEntries.cbegin(); itClass != m_allEntries.cend();
+  for (auto itClass = m_allEntries.rbegin(); itClass != m_allEntries.rend();
        ++itClass) {
     if (itClass->second.count(entryName) == 1) {
       return true;

--- a/Framework/Kernel/src/NexusHDF5Descriptor.cpp
+++ b/Framework/Kernel/src/NexusHDF5Descriptor.cpp
@@ -205,11 +205,15 @@ NexusHDF5Descriptor::getAllEntries() const noexcept {
 std::map<std::string, std::set<std::string>>
 NexusHDF5Descriptor::initAllEntries() {
 
-  hid_t fileID = H5Fopen(m_filename.c_str(), H5F_ACC_RDONLY, H5P_DEFAULT);
+  hid_t fapl = H5Pcreate(H5P_FILE_ACCESS);
+  H5Pset_fclose_degree(fapl, H5F_CLOSE_STRONG);
+
+  hid_t fileID = H5Fopen(m_filename.c_str(), H5F_ACC_RDONLY, fapl);
   if (fileID < 0) {
+
     throw std::invalid_argument(
         "ERROR: Kernel::NexusHDF5Descriptor couldn't open hdf5 file " +
-        m_filename + "\n");
+        m_filename + " with fapl " + std::to_string(fapl) + "\n");
   }
 
   hid_t groupID = H5Gopen2(fileID, "/", H5P_DEFAULT);

--- a/Framework/Kernel/src/NexusHDF5Descriptor.cpp
+++ b/Framework/Kernel/src/NexusHDF5Descriptor.cpp
@@ -6,6 +6,9 @@
 // SPDX - License - Identifier: GPL - 3.0 +
 
 #include "MantidKernel/NexusHDF5Descriptor.h"
+
+#include <boost/multi_index/detail/index_matcher.hpp>
+
 #include "MantidKernel/NexusDescriptor.h"
 
 #include <hdf5.h>
@@ -13,6 +16,8 @@
 #include <cstdlib>   // malloc, calloc
 #include <cstring>   // strcpy
 #include <stdexcept> // std::invalid_argument
+
+using boost::multi_index::detail::index_matcher::entry;
 
 namespace Mantid::Kernel {
 
@@ -217,6 +222,22 @@ NexusHDF5Descriptor::initAllEntries() {
 
   // rely on move semantics
   return allEntries;
+}
+
+bool NexusHDF5Descriptor::isClassEntry(const std::string &groupClass,
+                                       const std::string &entryName) const
+    noexcept {
+
+  auto itClass = m_allEntries.find(groupClass);
+  if (itClass == m_allEntries.end()) {
+    return false;
+  }
+
+  if (itClass->second.count(entryName) == 1) {
+    return true;
+  }
+
+  return false;
 }
 
 } // namespace Mantid::Kernel

--- a/Framework/Kernel/test/NexusHDF5DescriptorTest.h
+++ b/Framework/Kernel/test/NexusHDF5DescriptorTest.h
@@ -42,6 +42,9 @@ public:
 
     TS_ASSERT_EQUALS(filename, nexusHDF5Descriptor.getFilename());
 
+    TS_ASSERT_EQUALS(
+        nexusHDF5Descriptor.isClassEntry("NXentry", "/entry/DASlogs"), true);
+
     const std::map<std::string, std::set<std::string>> &allEntries =
         nexusHDF5Descriptor.getAllEntries();
 

--- a/Framework/Kernel/test/NexusHDF5DescriptorTest.h
+++ b/Framework/Kernel/test/NexusHDF5DescriptorTest.h
@@ -42,8 +42,10 @@ public:
 
     TS_ASSERT_EQUALS(filename, nexusHDF5Descriptor.getFilename());
 
-    TS_ASSERT_EQUALS(
-        nexusHDF5Descriptor.isClassEntry("NXentry", "/entry/DASlogs"), true);
+    TS_ASSERT_EQUALS(nexusHDF5Descriptor.isEntry("NXentry", "/entry/DASlogs"),
+                     true);
+
+    TS_ASSERT_EQUALS(nexusHDF5Descriptor.isEntry("/entry/DASlogs"), true);
 
     const std::map<std::string, std::set<std::string>> &allEntries =
         nexusHDF5Descriptor.getAllEntries();

--- a/Framework/Kernel/test/NexusHDF5DescriptorTest.h
+++ b/Framework/Kernel/test/NexusHDF5DescriptorTest.h
@@ -42,7 +42,8 @@ public:
 
     TS_ASSERT_EQUALS(filename, nexusHDF5Descriptor.getFilename());
 
-    TS_ASSERT_EQUALS(nexusHDF5Descriptor.isEntry("NXentry", "/entry/DASlogs"),
+    TS_ASSERT_EQUALS(nexusHDF5Descriptor.isEntry(
+                         "/entry/instrument/bank39/total_counts", "SDS"),
                      true);
 
     TS_ASSERT_EQUALS(nexusHDF5Descriptor.isEntry("/entry/DASlogs"), true);


### PR DESCRIPTION
**Description of work.**
Cache metadata from Nexus HDF5 file to speed up LoadEventNexus by preventing hierarchical retrieval of metadata. 
Results show a consistent speed up of 25%-35% in cases using `LoadEventNexus`.
`ctest -R DataHandlingTest_LoadEventNexusTest` goes from 43s to 28s (~35% faster) on my local desktop system.

**Report to:**
@peterfpeterson @quantumsteve @martyngigg 

**To test:**
It's an internal refactoring, new functionality should be already in CI. It must pass all current tests.

Related to issue #27952 and subtask #28405 follows improvements in PR #28137 and PR #28432 

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
