### PR TITLE
Change boost::dynamic_pointer_cast to std::dynamic_pointer_cast in AddPeakTest

### DIFF
--- a/Framework/Algorithms/test/AddPeakTest.h
+++ b/Framework/Algorithms/test/AddPeakTest.h
@@ -75,7 +75,7 @@ public:
     TS_ASSERT(alg.isInitialized())
     TS_ASSERT_THROWS_NOTHING(
         alg.setProperty("InstrumentWorkspace",
-                        boost::dynamic_pointer_cast<MatrixWorkspace>(instws)));
+                        std::dynamic_pointer_cast<MatrixWorkspace>(instws)));
     TS_ASSERT_THROWS_NOTHING(
         alg.setPropertyValue("OutputWorkspace", outWSName));
     TS_ASSERT_THROWS_NOTHING(alg.execute();)


### PR DESCRIPTION
**Description of work.**

Fix problem with master due to left over use of boost::dynamic_pointer_cast instead of std version. PR that had passed Jenkins tests a few days ago was merged earlier: (https://github.com/mantidproject/mantid/pull/28467)

**To test:**

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
