### PR TITLE
Stop importing plotly with mantid.simpleapi

### DIFF
--- a/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/SavePlot1D.py
+++ b/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/SavePlot1D.py
@@ -189,6 +189,7 @@ class SavePlot1D(mantid.api.PythonAlgorithm):
             return str(div)
 
     def toScatterAndLabels(self, wksp, spectraNames):
+        import plotly.graph_objs as go
         data = []
         for i in range(wksp.getNumberHistograms()):
             if len(spectraNames) > i:

--- a/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/SavePlot1D.py
+++ b/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/SavePlot1D.py
@@ -8,14 +8,7 @@
 import mantid
 from mantid.kernel import Direction, IntArrayProperty, StringArrayProperty, StringListValidator
 import sys
-
-try:
-    from plotly import tools as toolsly
-    from plotly.offline import plot
-    import plotly.graph_objs as go
-    have_plotly = True
-except ImportError:
-    have_plotly = False
+import importlib
 
 
 class SavePlot1D(mantid.api.PythonAlgorithm):
@@ -49,6 +42,7 @@ class SavePlot1D(mantid.api.PythonAlgorithm):
                                                      action=mantid.api.FileAction.OptionalSave,
                                                      extensions=['.png']),
                              doc='Name of the image file to savefile.')
+        have_plotly = importlib.util.find_spec("plotly") is not None
         if have_plotly:
             outputTypes = ['image', 'plotly', 'plotly-full']
         else:
@@ -142,6 +136,9 @@ class SavePlot1D(mantid.api.PythonAlgorithm):
         return (xlabel, ylabel)
 
     def savePlotly(self, fullPage):
+        from plotly import tools as toolsly
+        from plotly.offline import plot
+        import plotly.graph_objs as go
         spectraNames = self.getProperty('SpectraNames').value
 
         if isinstance(self._wksp, mantid.api.WorkspaceGroup):


### PR DESCRIPTION
**Description of work.**

Plotly is only used by SavePlot1D, but imported every time one imports mantid.simpleapi. This adds up to 4s on our instrument computers with network filesystems.

**To test:**

<!-- Instructions for testing. -->

Verify that the builds still pass

*There is no associated issue.*

*This does not require release notes* because no change to functionality

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
