### PR TITLE
Fix MonitorLiveData unreliable test

### DIFF
--- a/Framework/LiveData/test/MonitorLiveDataTest.h
+++ b/Framework/LiveData/test/MonitorLiveDataTest.h
@@ -200,9 +200,7 @@ public:
         AnalysisDataService::Instance().retrieveWS<EventWorkspace>("fake1");
     TS_ASSERT_EQUALS(ws->getNumberEvents(), 200);
 
-    Kernel::Timer timer;
-    while (alg1->isRunning() && timer.elapsed_no_reset() < 0.5) {
-    }
+    Poco::Thread::sleep(500);
   }
 
   //--------------------------------------------------------------------------------------------
@@ -241,8 +239,6 @@ public:
     TS_ASSERT(ws2->monitorWorkspace());
     TS_ASSERT_EQUALS(ws2->monitorWorkspace()->readY(0)[0], 1);
 
-    Kernel::Timer timer;
-    while (alg1->isRunning() && timer.elapsed_no_reset() < 0.5) {
-    }
+    Poco::Thread::sleep(500);
   }
 };


### PR DESCRIPTION
**Description of work.**
This PR fixes the `MonitorLiveDataTest` unreliable [test](https://builds.mantidproject.org/job/pull_requests-ubuntu/36021/). It was segfaulting with a `heap-use-after-free` error.

**To test:**
Run `MonitorLiveDataTest` 100 times and it should not fail. 
Note: I was not able to reproduce this on windows so it should be tested on a different os.

*There is no associated issue.*

*This does not require release notes* because **it is an internal change**

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
