### PR TITLE
Fix being unable to open plot figure options

### DIFF
--- a/qt/python/mantidqt/widgets/plotconfigdialog/axestabwidget/presenter.py
+++ b/qt/python/mantidqt/widgets/plotconfigdialog/axestabwidget/presenter.py
@@ -6,7 +6,6 @@
 # SPDX - License - Identifier: GPL - 3.0 +
 #  This file is part of the mantid workbench.
 
-from mantid.plots import MantidAxes3D
 from mantidqt.widgets.plotconfigdialog import generate_ax_name, get_axes_names_dict
 from mantidqt.widgets.plotconfigdialog.axestabwidget import AxProperties
 from mantidqt.widgets.plotconfigdialog.axestabwidget.view import AxesTabWidgetView

--- a/qt/python/mantidqt/widgets/plotconfigdialog/axestabwidget/presenter.py
+++ b/qt/python/mantidqt/widgets/plotconfigdialog/axestabwidget/presenter.py
@@ -128,11 +128,6 @@ class AxesTabWidgetPresenter:
 
         self.current_view_props.update(self.view.get_properties())
 
-        # Currently changing the axis scale doesn't work correctly for 3D plots so those options are disabled.
-        enable_scale = not isinstance(self.get_selected_ax(), MantidAxes3D)
-        self.view.yscale_combo_box.setEnabled(enable_scale)
-        self.view.xscale_combo_box.setEnabled(enable_scale)
-
     def axis_changed(self):
         ax = self.current_axis
 


### PR DESCRIPTION
**Description of work.**
In #28390 I added disabling the options to change the axes scales from the axis tab of the figure options as they didn't work properly with surface plots. Then in #28473 I removed the combo boxes being called so now you can't open the figure options. Oops.

**To test:**
```
from mantid.simpleapi import *
import matplotlib.pyplot as plt

ws = CreateSampleWorkspace()

fig = plt.figure()

ax1 = fig.add_subplot(121, projection='mantid')
ax1.plot(ws, wkspIndex=0)

ax2 = fig.add_subplot(122, projection='mantid3d')
ax2.plot_surface(ws)

fig.show()
```

Make sure you can open figure options, and when you have the 2D axis selected the scale option is enabled and it becomes disabled when you switch to the 3D axis.

*There is no associated issue.*

No release notes because the bug isn't in a release.

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
