### PR TITLE
Make plot toolbar suitable for 3D plots

### DIFF
--- a/Framework/PythonInterface/mantid/plots/datafunctions.py
+++ b/Framework/PythonInterface/mantid/plots/datafunctions.py
@@ -14,6 +14,7 @@ from matplotlib.collections import PolyCollection
 from matplotlib.container import ErrorbarContainer
 from matplotlib.colors import LogNorm
 from matplotlib.ticker import LogLocator
+from mpl_toolkits.mplot3d.axes3d import Axes3D
 from scipy.interpolate import interp1d
 
 import mantid.api
@@ -1030,3 +1031,7 @@ def update_colorbar_scale(figure, image, scale, vmin, vmax):
                 mantid.kernel.logger.warning("Minor ticks on colorbar scale cannot be shown "
                                              "as the range between min value and max value is too large")
         figure.colorbar(image, ticks=locator)
+
+
+def figure_contains_only_3d_plots(fig) -> bool:
+    return all(isinstance(ax, Axes3D) for ax in fig.get_axes())

--- a/Framework/PythonInterface/mantid/plots/surfacecontourplots.py
+++ b/Framework/PythonInterface/mantid/plots/surfacecontourplots.py
@@ -38,9 +38,6 @@ def plot(plot_type: SpectraSelection, plot_index: int, axis_name: str, log_name:
 
             fig.colorbar(surface)
 
-            # grid is enabled by default so set the toolbar button to be checked
-            fig.canvas.toolbar._actions['toggle_grid'].setChecked(True)
-
             fig.show()
         elif plot_type == SpectraSelection.Contour:
             fig = pcolormesh([matrix_ws])

--- a/docs/source/release/v5.1.0/mantidworkbench.rst
+++ b/docs/source/release/v5.1.0/mantidworkbench.rst
@@ -24,7 +24,7 @@ Improvements
 - The Help Menu now has an About screen that will pop up automatically on startup to provide links to the release notes and various other resources, and allow you to set some important setting such as Facility, instrument and accept usage tracing.
   You can choose to hide it until the next release.
 - The axes tab in the figure options can now be used to set the limits, label, and scale of the z-axis on 3D plots.
-
+- The plot toolbar now shows the correct buttons for 3D plots.
 - On 3D plots you can now double-click on the z-axis to change its limits or label.
 
 

--- a/qt/applications/workbench/workbench/plotting/figuremanager.py
+++ b/qt/applications/workbench/workbench/plotting/figuremanager.py
@@ -16,6 +16,7 @@ from matplotlib._pylab_helpers import Gcf
 from matplotlib.axes import Axes
 from matplotlib.backend_bases import FigureManagerBase
 from matplotlib.backends.backend_qt5agg import FigureCanvasQTAgg
+from mpl_toolkits.mplot3d.axes3d import Axes3D
 from qtpy.QtCore import QObject, Qt
 from qtpy.QtWidgets import QApplication, QLabel, QFileDialog
 
@@ -297,9 +298,9 @@ class FigureManagerWorkbench(FigureManagerBase, QObject):
                 or self.toolbar is not None and len(self.canvas.figure.get_axes()) > 1:
             self._set_fit_enabled(False)
 
-        # For plot-to-script button to show, we must have a MantidAxes with lines in it
+        # For plot-to-script button to show, every axis must be a MantidAxes with lines in it
         # Plot-to-script currently doesn't work with waterfall plots so the button is hidden for that plot type.
-        if not any((isinstance(ax, MantidAxes) and curve_in_ax(ax))
+        if not all((isinstance(ax, MantidAxes) and curve_in_ax(ax))
                    for ax in self.canvas.figure.get_axes()) or self.canvas.figure.get_axes(
         )[0].is_waterfall():
             self.toolbar.set_generate_plot_script_enabled(False)
@@ -308,6 +309,9 @@ class FigureManagerWorkbench(FigureManagerBase, QObject):
         if not isinstance(self.canvas.figure.get_axes()[0], MantidAxes) or \
                 not self.canvas.figure.get_axes()[0].is_waterfall():
             self.toolbar.set_waterfall_options_enabled(False)
+
+        if datafunctions.figure_contains_only_3d_plots(self.canvas.figure):
+            self.toolbar.adjust_for_3d_plots()
 
     def destroy(self, *args):
         # check for qApp first, as PySide deletes it in its atexit handler
@@ -423,6 +427,8 @@ class FigureManagerWorkbench(FigureManagerBase, QObject):
                 if type(ax) is not Axes:
                     if ax.lines:  # Relim causes issues with colour plots, which have no lines.
                         ax.relim()
+                    elif isinstance(ax, Axes3D):
+                        ax.view_init()
                     ax.autoscale()
 
             self.canvas.draw()

--- a/qt/applications/workbench/workbench/plotting/toolbar.py
+++ b/qt/applications/workbench/workbench/plotting/toolbar.py
@@ -145,14 +145,16 @@ class WorkbenchNavigationToolbar(NavigationToolbar2QT):
             toolbar_action.setEnabled(on)
             toolbar_action.setVisible(on)
 
+        # show/hide separator
+        fit_action = self._actions['toggle_fit']
+        self.toggle_separator_visibility(fit_action, on)
+
     def set_generate_plot_script_enabled(self, enabled):
         action = self._actions['generate_plot_script']
         action.setEnabled(enabled)
         action.setVisible(enabled)
         # Show/hide the separator between this button and the "Fit" button
-        for i, toolbar_action in enumerate(self.actions()):
-            if toolbar_action == action:
-                self.actions()[i+1].setVisible(enabled)
+        self.toggle_separator_visibility(action, enabled)
 
     def waterfall_offset_amount(self):
         self.sig_waterfall_offset_amount_triggered.emit()
@@ -162,6 +164,24 @@ class WorkbenchNavigationToolbar(NavigationToolbar2QT):
 
     def waterfall_fill_area(self):
         self.sig_waterfall_fill_area_triggered.emit()
+
+    def adjust_for_3d_plots(self):
+        self._actions['toggle_grid'].setChecked(True)
+
+        for action in ['back', 'forward', 'pan', 'zoom']:
+            toolbar_action = self._actions[action]
+            toolbar_action.setEnabled(False)
+            toolbar_action.setVisible(False)
+
+        action = self._actions['forward']
+        self.toggle_separator_visibility(action, False)
+
+    def toggle_separator_visibility(self, action, enabled):
+        # shows/hides the separator positioned immediately after the action
+        for i, toolbar_action in enumerate(self.actions()):
+            if toolbar_action == action:
+                self.actions()[i+1].setVisible(enabled)
+                break
 
 
 class ToolbarStateManager(object):


### PR DESCRIPTION
**Description of work.**
This PR removes the buttons from the plot toolbar that (currently) do nothing/don't work correctly for 3D plots. The behaviour of the home button has been changed for 3D plots.

**To test:**
Run:
```
from mantid.simpleapi import *
import matplotlib.pyplot as plt

ws = CreateSampleWorkspace()

fig, ax = plt.subplots(subplot_kw={'projection':'mantid3d'})
ax.plot_surface(ws)

fig.show()
```
The toolbar should only contain Home, Toggle Grid, Save, Print, and Figure Options.
Since currently you can't zoom on 3D plots, the Home button instead returns the plot view to the default position. If you click and drag on the plot to rotate it and then click the 🏠 button you should see this behaviour.
The grid button should be checked by default.

Fixes #28496 

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
