### PR TITLE
Performance improvement in contains_algorithm

### DIFF
--- a/Framework/PythonInterface/mantid/kernel/plugins.py
+++ b/Framework/PythonInterface/mantid/kernel/plugins.py
@@ -248,19 +248,18 @@ def contains_algorithm(filename):
     """
         Inspects the file to look for an algorithm registration line
     """
-    if _sys.version_info[0] < 3:
-        def readlines_reversed(f):
-            return reversed(f.readlines())
-    else:
-        def readlines_reversed(f):
-            return reversed(list(f.readlines()))
-    #endif
     alg_found = True
     try:
         from io import open
         with open(filename,'r', encoding='UTF-8') as plugin_file:
-            for line in readlines_reversed(plugin_file):
-                if 'AlgorithmFactory.subscribe' in line:
+            # linear search through file
+            # looking from the bottom would be better, but searching from the top doesn't appear to
+            # affect performance
+            for line in plugin_file:
+                if 'class' in line and 'Algorithm' in line:
+                    alg_found = True
+                    break
+                elif 'AlgorithmFactory.subscribe' in line:
                     alg_found = True
                     break
     except Exception as exc:


### PR DESCRIPTION
During `import mantid.simpleapi`, `plugins.contains_algorithm` gets called against each python file. Improving its speed will improve startup time.

This removes the python2 compatibility and searches through the file in the forward direction so the whole file won't be in memory at once. Unfortunately, this has negligible effect on performance.

**To test:**

`time mantidpython --classic -c "import mantid.simpleapi"` should be faster.

*There is no associated issue.*


*This does not require release notes* because it is internal for starting up the mantid framework.

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
