### PR TITLE
Modulation Vectors Collated When Using CombinePeaksWorkspaces

### DIFF
--- a/Framework/Crystal/test/CombinePeaksWorkspacesTest.h
+++ b/Framework/Crystal/test/CombinePeaksWorkspacesTest.h
@@ -297,4 +297,55 @@ public:
     TS_ASSERT_EQUALS(outWs->sample().getOrientedLattice().getModVec(2)[1], 0);
     TS_ASSERT_EQUALS(outWs->sample().getOrientedLattice().getModVec(2)[2], 0.5);
   }
+
+  void test_duplicate_workspaces_are_not_combined() {
+    using namespace Mantid::API;
+    using namespace Mantid::DataObjects;
+    using namespace Mantid::Crystal;
+
+    PeaksWorkspace_sptr peaksWs =
+        WorkspaceCreationHelper::createPeaksWorkspace(3, true);
+
+    Mantid::Crystal::PredictFractionalPeaks predictAlg;
+    predictAlg.initialize();
+    predictAlg.setProperty("Peaks", peaksWs);
+    predictAlg.setProperty("ModVector1", "0.5, 0, 0.5");
+    predictAlg.setProperty("ModVector2", "0.5, 0, 0.5");
+    predictAlg.setProperty("FracPeaks", "frac_vec1");
+    predictAlg.setProperty("MaxOrder", 1);
+    predictAlg.execute();
+
+    predictAlg.initialize();
+    predictAlg.setProperty("Peaks", peaksWs);
+    predictAlg.setProperty("ModVector1", "0.5, 0, 0.5");
+    predictAlg.setProperty("FracPeaks", "frac_vec2");
+    predictAlg.setProperty("MaxOrder", 1);
+    predictAlg.execute();
+
+    CombinePeaksWorkspaces alg;
+
+    TS_ASSERT_THROWS_NOTHING(alg.initialize());
+    TS_ASSERT_THROWS_NOTHING(alg.setProperty("LHSWorkspace", "frac_vec1"));
+    TS_ASSERT_THROWS_NOTHING(alg.setProperty("RHSWorkspace", "frac_vec2"));
+    TS_ASSERT_THROWS_NOTHING(
+        alg.setPropertyValue("OutputWorkspace", "frac_vec_1and2"));
+    TS_ASSERT_THROWS_NOTHING(alg.execute());
+
+    IPeaksWorkspace_const_sptr outWs;
+    TS_ASSERT_THROWS_NOTHING(
+        outWs = AnalysisDataService::Instance().retrieveWS<IPeaksWorkspace>(
+            "frac_vec_1and2"));
+
+    TS_ASSERT_EQUALS(outWs->sample().getOrientedLattice().getModVec(0)[0], 0.5);
+    TS_ASSERT_EQUALS(outWs->sample().getOrientedLattice().getModVec(0)[1], 0);
+    TS_ASSERT_EQUALS(outWs->sample().getOrientedLattice().getModVec(0)[2], 0.5);
+
+    TS_ASSERT_EQUALS(outWs->sample().getOrientedLattice().getModVec(1)[0], 0.5);
+    TS_ASSERT_EQUALS(outWs->sample().getOrientedLattice().getModVec(1)[1], 0);
+    TS_ASSERT_EQUALS(outWs->sample().getOrientedLattice().getModVec(1)[2], 0.5);
+
+    TS_ASSERT_EQUALS(outWs->sample().getOrientedLattice().getModVec(2)[0], 0);
+    TS_ASSERT_EQUALS(outWs->sample().getOrientedLattice().getModVec(2)[1], 0);
+    TS_ASSERT_EQUALS(outWs->sample().getOrientedLattice().getModVec(2)[2], 0);
+  }
 };

--- a/Framework/Crystal/test/CombinePeaksWorkspacesTest.h
+++ b/Framework/Crystal/test/CombinePeaksWorkspacesTest.h
@@ -8,8 +8,11 @@
 
 #include <cxxtest/TestSuite.h>
 
+#include "MantidAPI/Sample.h"
 #include "MantidCrystal/CombinePeaksWorkspaces.h"
+#include "MantidCrystal/PredictFractionalPeaks.h"
 #include "MantidDataObjects/PeaksWorkspace.h"
+#include "MantidGeometry/Crystal/OrientedLattice.h"
 #include "MantidTestHelpers/WorkspaceCreationHelper.h"
 
 using Mantid::Crystal::CombinePeaksWorkspaces;
@@ -188,5 +191,110 @@ public:
 
     // Remove workspace from the data service.
     AnalysisDataService::Instance().remove(outWSName);
+  }
+
+  void test_modulation_vectors_are_combined() {
+    using namespace Mantid::API;
+    using namespace Mantid::DataObjects;
+    using namespace Mantid::Crystal;
+
+    PeaksWorkspace_sptr peaksWs =
+        WorkspaceCreationHelper::createPeaksWorkspace(3, true);
+
+    Mantid::Crystal::PredictFractionalPeaks predictAlg;
+    predictAlg.initialize();
+    predictAlg.setProperty("Peaks", peaksWs);
+    predictAlg.setProperty("ModVector1", "0.5, 0, 0.5");
+    predictAlg.setProperty("FracPeaks", "frac_vec1");
+    predictAlg.setProperty("MaxOrder", 1);
+    predictAlg.execute();
+
+    predictAlg.initialize();
+    predictAlg.setProperty("Peaks", peaksWs);
+    predictAlg.setProperty("ModVector1", "-0.5, -0.5, -0.5");
+    predictAlg.setProperty("FracPeaks", "frac_vec2");
+    predictAlg.setProperty("MaxOrder", 1);
+    predictAlg.execute();
+
+    CombinePeaksWorkspaces alg;
+
+    TS_ASSERT_THROWS_NOTHING(alg.initialize());
+    TS_ASSERT_THROWS_NOTHING(alg.setProperty("LHSWorkspace", "frac_vec1"));
+    TS_ASSERT_THROWS_NOTHING(alg.setProperty("RHSWorkspace", "frac_vec2"));
+    TS_ASSERT_THROWS_NOTHING(
+        alg.setPropertyValue("OutputWorkspace", "frac_vec_1and2"));
+    TS_ASSERT_THROWS_NOTHING(alg.execute());
+
+    IPeaksWorkspace_const_sptr outWs;
+    TS_ASSERT_THROWS_NOTHING(
+        outWs = AnalysisDataService::Instance().retrieveWS<IPeaksWorkspace>(
+            "frac_vec_1and2"));
+
+    TS_ASSERT_EQUALS(outWs->sample().getOrientedLattice().getModVec(0)[0], 0.5);
+    TS_ASSERT_EQUALS(outWs->sample().getOrientedLattice().getModVec(0)[1], 0);
+    TS_ASSERT_EQUALS(outWs->sample().getOrientedLattice().getModVec(0)[2], 0.5);
+
+    TS_ASSERT_EQUALS(outWs->sample().getOrientedLattice().getModVec(1)[0],
+                     -0.5);
+    TS_ASSERT_EQUALS(outWs->sample().getOrientedLattice().getModVec(1)[1],
+                     -0.5);
+    TS_ASSERT_EQUALS(outWs->sample().getOrientedLattice().getModVec(1)[2],
+                     -0.5);
+
+    TS_ASSERT_EQUALS(outWs->sample().getOrientedLattice().getModVec(2)[0], 0);
+    TS_ASSERT_EQUALS(outWs->sample().getOrientedLattice().getModVec(2)[1], 0);
+    TS_ASSERT_EQUALS(outWs->sample().getOrientedLattice().getModVec(2)[2], 0);
+  }
+
+  void test_lhs_modulation_vectors_are_used_when_too_many() {
+    using namespace Mantid::API;
+    using namespace Mantid::DataObjects;
+    using namespace Mantid::Crystal;
+
+    PeaksWorkspace_sptr peaksWs =
+        WorkspaceCreationHelper::createPeaksWorkspace(3, true);
+
+    Mantid::Crystal::PredictFractionalPeaks predictAlg;
+    predictAlg.initialize();
+    predictAlg.setProperty("Peaks", peaksWs);
+    predictAlg.setProperty("ModVector1", "0.5, 0, 0.5");
+    predictAlg.setProperty("ModVector2", "0.5, 0, 0.5");
+    predictAlg.setProperty("ModVector3", "0.5, 0, 0.5");
+    predictAlg.setProperty("FracPeaks", "frac_vec1");
+    predictAlg.setProperty("MaxOrder", 1);
+    predictAlg.execute();
+
+    predictAlg.initialize();
+    predictAlg.setProperty("Peaks", peaksWs);
+    predictAlg.setProperty("ModVector1", "-0.5, -0.5, -0.5");
+    predictAlg.setProperty("FracPeaks", "frac_vec2");
+    predictAlg.setProperty("MaxOrder", 1);
+    predictAlg.execute();
+
+    CombinePeaksWorkspaces alg;
+
+    TS_ASSERT_THROWS_NOTHING(alg.initialize());
+    TS_ASSERT_THROWS_NOTHING(alg.setProperty("LHSWorkspace", "frac_vec1"));
+    TS_ASSERT_THROWS_NOTHING(alg.setProperty("RHSWorkspace", "frac_vec2"));
+    TS_ASSERT_THROWS_NOTHING(
+        alg.setPropertyValue("OutputWorkspace", "frac_vec_1and2"));
+    TS_ASSERT_THROWS_NOTHING(alg.execute());
+
+    IPeaksWorkspace_const_sptr outWs;
+    TS_ASSERT_THROWS_NOTHING(
+        outWs = AnalysisDataService::Instance().retrieveWS<IPeaksWorkspace>(
+            "frac_vec_1and2"));
+
+    TS_ASSERT_EQUALS(outWs->sample().getOrientedLattice().getModVec(0)[0], 0.5);
+    TS_ASSERT_EQUALS(outWs->sample().getOrientedLattice().getModVec(0)[1], 0);
+    TS_ASSERT_EQUALS(outWs->sample().getOrientedLattice().getModVec(0)[2], 0.5);
+
+    TS_ASSERT_EQUALS(outWs->sample().getOrientedLattice().getModVec(1)[0], 0.5);
+    TS_ASSERT_EQUALS(outWs->sample().getOrientedLattice().getModVec(1)[1], 0);
+    TS_ASSERT_EQUALS(outWs->sample().getOrientedLattice().getModVec(1)[2], 0.5);
+
+    TS_ASSERT_EQUALS(outWs->sample().getOrientedLattice().getModVec(2)[0], 0.5);
+    TS_ASSERT_EQUALS(outWs->sample().getOrientedLattice().getModVec(2)[1], 0);
+    TS_ASSERT_EQUALS(outWs->sample().getOrientedLattice().getModVec(2)[2], 0.5);
   }
 };

--- a/docs/source/release/v5.1.0/diffraction.rst
+++ b/docs/source/release/v5.1.0/diffraction.rst
@@ -30,6 +30,9 @@ Improvements
 
 Single Crystal Diffraction
 --------------------------
+Improvements
+^^^^^^^^^^^^
+- :ref:`CombinePeaksWorkspaces <algm-CombinePeaksWorkspaces>` now combines the modulation vectors present in the two workspaces, provided the total number of vectors is less than 3.
 - New instrument geometry for MaNDi instrument at SNS
 
 Imaging


### PR DESCRIPTION
**Description of work.**
Combine peaks workspaces now collates any modulation vectors present in the two workspaces being combined.
Note: A PeaksWorkspace can currently only support up to 3 modulation vectors due to it's imlementaiton, and changing that seemed beyond the scope of this issue. The changes in this PR will default to the original behaviour of using the vectors from the LHS if the total number of vectors after running the algorithm would be >3. 

**To test:**
1. Run this script:
```
# import mantid algorithms, numpy and matplotlib
from mantid.simpleapi import *
import matplotlib.pyplot as plt
import numpy as np

LoadNexusProcessed(Filename='/home/conor/MantidDataFiles/WISH_45319_peaks (1).nxs', OutputWorkspace='peaks')
IndexPeaks(PeaksWorkspace='peaks')
PredictFractionalPeaks(Peaks='peaks', RequirePeaksOnDetector=False, ModVector1='0.5,0,0.5', MaxOrder=1, FracPeaks='frac_vec1')
PredictFractionalPeaks(Peaks='peaks', RequirePeaksOnDetector=False, ModVector1='-0.5,0,0.5', MaxOrder=1, FracPeaks='frac_vec2')
CombinePeaksWorkspaces(LHSWorkspace='frac_vec1', RHSWorkspace='frac_vec2', OutputWorkspace='frac_vec1_and_vec2')
SaveReflections('frac_vec1_and_vec2',Filename='test_jana.hkl',Format='Jana')
```
2. Check that the modulation vectors have been saved to the output files. 

Fixes #27626 


---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
