### PR TITLE
Add Remote Working Links to IDE Documentation

### DIFF
--- a/dev-docs/source/PyCharm.rst
+++ b/dev-docs/source/PyCharm.rst
@@ -1,7 +1,7 @@
-.. _GettingStartedWithPyCharm:
+.. _PyCharm:
 
-Getting Started with PyCharm
-============================
+PyCharm
+=======
 
 PyCharm can be installed from `here <https://jetbrains.com/pycharm/download/>`_.
 
@@ -222,3 +222,12 @@ The following non-default plugins are things our team has found useful for Manti
 - **CMD Support** - Syntax highlighting for ``.BAT`` ~scripts
 
 Please add to this list if you find a useful plugin of your own
+
+Remote Development
+##################
+
+Note: Requires PyCharm Professional.
+
+PyCharm supports deployment and syncronisation of written code to a remote server via SSH.
+
+Open a local copy of the project and then follow the the guides here for `configuring the remote interpreter <https://www.jetbrains.com/help/pycharm/configuring-remote-interpreters-via-ssh.html>`_ and `creating a deployment configuration <https://www.jetbrains.com/help/pycharm/creating-a-remote-server-configuration.html>`_. 

--- a/dev-docs/source/VSCode.rst
+++ b/dev-docs/source/VSCode.rst
@@ -421,6 +421,12 @@ Reference" and hit Enter.
 | Launch            | F5            | F5            | F5            |
 +-------------------+---------------+---------------+---------------+
 
+Remote Development
+------------------
+VSCode supports the ability to open and work from directories on a remote machine using SSH. 
+
+Detailed instructions on how to set this up can be found `here <https://code.visualstudio.com/docs/remote/ssh>`_.
+
 (Advanced) Getting Live Warnings and Errors with Clangd
 =======================================================
 (Linux only)

--- a/dev-docs/source/index.rst
+++ b/dev-docs/source/index.rst
@@ -115,7 +115,7 @@ Tools
    ProfilingWithValgrind
    FlowchartCreation
    VisualStudioBuildImpact
-   GettingStartedWithPyCharm
+   PyCharm
    VSCode
    Eclipse
 
@@ -131,7 +131,7 @@ Tools
 :doc:`VisualStudioBuildImpact`
    Provides a script to reduce the impact of Visual Studio on machine performance.
 
-:doc:`GettingStartedWithPyCharm`
+:doc:`PyCharm`
    Describes how to set up the PyCharm interpreter, and debug python code (Windows/Linux only).
 
 :doc:`VSCode`


### PR DESCRIPTION
**Description of work.**
Add links to documentation for setting up remote development in VSCode and PyCharm. 

Also simplfies the naming of the PyCharm docs to match the rest of the tool documentation. 



*There is no associated issue.*

*This does not require release notes* because **it only concerns documentation.**

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
