### PR TITLE
Remove a matplotlib deprecation warning from the log viewer

### DIFF
--- a/Framework/PythonInterface/mantid/plots/axesfunctions.py
+++ b/Framework/PythonInterface/mantid/plots/axesfunctions.py
@@ -106,7 +106,7 @@ def _plot_impl(axes, workspace, args, kwargs):
             axes.xaxis_date()
             axes.xaxis.set_major_formatter(mdates.DateFormatter('%H:%M:%S\n%b-%d'))
             axes.set_xlabel('Time')
-        kwargs['linestyle'] = 'steps-post'
+        kwargs['drawstyle'] = 'steps-post'
     else:
         normalize_by_bin_width, kwargs = get_normalize_by_bin_width(
             workspace, axes, **kwargs)


### PR DESCRIPTION
**Description of work.**
The current nightly spits this warning out for every log data plot it creates.
![image](https://user-images.githubusercontent.com/1017173/80117758-77794b00-857f-11ea-8369-8461c3bbc394.png)

This stops that specific warning.  Others may still happen, I've seen one about the units and unicode, but that would be a separate thing.


**To test:**
Open and workspace in worknech, show the logs, and click over a few, if you don't get this warning, all is good.

```
Passing the drawstyle with the linestyle as a single string is deprecated since Matplotlib 3.1 and support will be removed in 3.3; please pass the drawstyle separately using the drawstyle keyword argument to Line2D or set_drawstyle() method (or ds/set_ds()).
```



*There is no associated issue.*



---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
