### PR TITLE
Add extra lib3mf dll into list for windows install

### DIFF
--- a/buildconfig/CMake/WindowsNSIS.cmake
+++ b/buildconfig/CMake/WindowsNSIS.cmake
@@ -100,6 +100,7 @@ set ( MISC_CORE_DIST_DLLS
     hdf5_hl.dll
     hdf5.dll
     jsoncpp.dll
+    lib3mf.dll
     libeay32.dll
     libNeXus-0.dll
     libNeXusCPP-0.dll


### PR DESCRIPTION
**Description of work.**

Windows nightly build was failing because a new 3rd party dll hadn't been added into the NSIS installer process. This change adds the new dll (lib3mf.dll) into the list of dlls that are installed.

The absence of this dll means that the MantidDataHandling.dll can't be loaded properly

**To test:**

Full test would involve building the "PACKAGE" target to create a Windows installer, installing Mantid using that installer and check it starts up OK. Simple change though so depending on urgency could just code review.

Without this fix Mantid fails to start up with an error about "Unable to create algorithm DownloadInstrument...". The error is a bit more descriptive if you run from the command line and gives an earlier error about being unable to load MantidDataHandling.dll which is a bit closer to the actual problem.

Need NSIS installed to build the Windows installer - I am only able to build the installer properly with NSIS v3.04 (the latest version v3.05 doesn't work for me for some reason)

Fixes #28576 .

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
