### PR TITLE
Fix Being Able to Zoom In and Out of Colorbars on Colourfill Plots. 

### DIFF
--- a/docs/source/release/v5.1.0/mantidworkbench.rst
+++ b/docs/source/release/v5.1.0/mantidworkbench.rst
@@ -37,5 +37,6 @@ Bugfixes
 - The scale of the color bars on colorfill plots of ragged workspaces now uses the maximum and minimum values of the data.
 - Fixed a bug where setting columns to Y error in table workspaces wasn't working. The links between the Y error and Y columns weren't being set up properly
 - Opening figure options on a plot with an empty legend no longer causes an unhandled exception.
+- Fixed being able to zoom in and out of colorbars on colorfill plots. 
 
 :ref:`Release 5.1.0 <v5.1.0>`

--- a/qt/applications/workbench/workbench/plotting/figureinteraction.py
+++ b/qt/applications/workbench/workbench/plotting/figureinteraction.py
@@ -102,7 +102,8 @@ class FigureInteraction(object):
     def on_scroll(self, event):
         """Respond to scroll events: zoom in/out"""
         self.canvas.toolbar.push_current()
-        if not getattr(event, 'inaxes', None) or isinstance(event.inaxes, Axes3D):
+        if not getattr(event, 'inaxes', None) or isinstance(event.inaxes, Axes3D) or \
+                len(event.inaxes.images) == 0 and len(event.inaxes.lines) == 0:
             return
         zoom_factor = 1.05 + abs(event.step)/6
         if event.button == 'up':  # zoom in


### PR DESCRIPTION
**Description of work.**
Adds a check for if there are any lines or images on an axis before allowing the user to scroll to zoom. This stops the user from being able to zoom in and out of the colourbar, which could break it. 

**To test:**
1. Plot a colorfill plot
2. Check that the main plot can be zoomed in and out of
3. Check that scrolling on the colorbar does nothing. 

Fixes #27208 

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
