### PR TITLE
3D plots in Workbench via right-click menu

### DIFF
--- a/Framework/PythonInterface/mantid/plots/datafunctions.py
+++ b/Framework/PythonInterface/mantid/plots/datafunctions.py
@@ -1040,11 +1040,3 @@ def update_colorbar_scale(figure, image, scale, vmin, vmax):
                                              "as the range between min value and max value is too large")
         figure.subplots_adjust(wspace=0.5, hspace=0.5)
         figure.colorbar(image, ax=figure.axes, ticks=locator, pad=0.06)
-
-
-def figure_contains_only_3d_plots(fig) -> bool:
-    for ax in fig.get_axes():
-        # any Axes that is not an Axes3D must be a colorbar (containing a QuadMesh)
-        if not isinstance(ax, Axes3D) and not any(isinstance(col, QuadMesh) for col in ax.collections):
-            return False
-    return True

--- a/Framework/PythonInterface/mantid/plots/datafunctions.py
+++ b/Framework/PythonInterface/mantid/plots/datafunctions.py
@@ -1028,6 +1028,7 @@ def update_colorbar_scale(figure, image, scale, vmin, vmax):
         mantid.kernel.logger.warning("Scale is set to logarithmic so non-positive max value has been changed to 1.")
 
     image.set_norm(scale(vmin=vmin, vmax=vmax))
+
     if image.colorbar:
         image.colorbar.remove()
         locator = None

--- a/Framework/PythonInterface/mantid/plots/datafunctions.py
+++ b/Framework/PythonInterface/mantid/plots/datafunctions.py
@@ -10,11 +10,10 @@
 import datetime
 
 import numpy as np
-from matplotlib.collections import PolyCollection, QuadMesh
+from matplotlib.collections import PolyCollection
 from matplotlib.container import ErrorbarContainer
 from matplotlib.colors import LogNorm
 from matplotlib.ticker import LogLocator
-from mpl_toolkits.mplot3d.axes3d import Axes3D
 from scipy.interpolate import interp1d
 
 import mantid.api

--- a/Framework/PythonInterface/mantid/plots/datafunctions.py
+++ b/Framework/PythonInterface/mantid/plots/datafunctions.py
@@ -10,7 +10,7 @@
 import datetime
 
 import numpy as np
-from matplotlib.collections import PolyCollection
+from matplotlib.collections import PolyCollection, QuadMesh
 from matplotlib.container import ErrorbarContainer
 from matplotlib.colors import LogNorm
 from matplotlib.ticker import LogLocator
@@ -1043,4 +1043,8 @@ def update_colorbar_scale(figure, image, scale, vmin, vmax):
 
 
 def figure_contains_only_3d_plots(fig) -> bool:
-    return all(isinstance(ax, Axes3D) for ax in fig.get_axes())
+    for ax in fig.get_axes():
+        # any Axes that is not an Axes3D must be a colorbar (containing a QuadMesh)
+        if not isinstance(ax, Axes3D) and not any(isinstance(col, QuadMesh) for col in ax.collections):
+            return False
+    return True

--- a/Framework/PythonInterface/mantid/plots/mantidaxes.py
+++ b/Framework/PythonInterface/mantid/plots/mantidaxes.py
@@ -1182,8 +1182,7 @@ class MantidAxes3D(Axes3D):
     def set_title(self, *args, **kwargs):
         # The set_title function in Axes3D also moves the title downwards for some reason so the Axes function is called
         # instead.
-        title = super(Axes3D, self).set_title(*args, **kwargs)
-        return title
+        return Axes.set_title(self, *args, **kwargs)
 
     def set_xlim3d(self, *args):
         min, max = super().set_xlim3d(*args)

--- a/Framework/PythonInterface/mantid/plots/mantidaxes.py
+++ b/Framework/PythonInterface/mantid/plots/mantidaxes.py
@@ -1179,6 +1179,12 @@ class MantidAxes3D(Axes3D):
         # it interfering with double-clicking on the axes.
         self.figure.canvas.mpl_disconnect(self._cids[1])
 
+    def set_title(self, *args, **kwargs):
+        # The set_title function in Axes3D also moves the title downwards for some reason so the Axes function is called
+        # instead.
+        title = super(Axes3D, self).set_title(*args, **kwargs)
+        return title
+
     def set_xlim3d(self, *args):
         min, max = super().set_xlim3d(*args)
 

--- a/Framework/PythonInterface/mantid/plots/mantidaxes.py
+++ b/Framework/PythonInterface/mantid/plots/mantidaxes.py
@@ -1186,7 +1186,6 @@ class MantidAxes3D(Axes3D):
 
     def set_xlim3d(self, *args):
         min, max = super().set_xlim3d(*args)
-
         self._set_overflowing_data_to_nan(min, max, 0)
 
     def set_ylim3d(self, *args):

--- a/Framework/PythonInterface/mantid/plots/surfacecontourplots.py
+++ b/Framework/PythonInterface/mantid/plots/surfacecontourplots.py
@@ -16,7 +16,7 @@ import numpy as np
 from mantid.api import MatrixWorkspace, NumericAxis, Workspace, WorkspaceFactory
 from mantid.plots.utility import get_single_workspace_log_value
 from mantidqt.dialogs.spectraselectordialog import SpectraSelection
-from mantidqt.plotting.functions import pcolormesh
+from mantidqt.plotting.functions import plot_contour, plot_surface
 
 
 def plot(plot_type: SpectraSelection, plot_index: int, axis_name: str, log_name: str, custom_log_values: List[float],
@@ -28,19 +28,16 @@ def plot(plot_type: SpectraSelection, plot_index: int, axis_name: str, log_name:
         title = _construct_title(workspace_names, plot_index)
 
         if plot_type == SpectraSelection.Surface:
-            fig, ax = plt.subplots(subplot_kw={'projection': 'mantid3d'})
-            surface = ax.plot_surface(matrix_ws, cmap='viridis')
+            fig = plot_surface([matrix_ws])
+            ax = fig.get_axes()[0]
 
             ax.set_title("Surface" + title)
             ax.set_ylabel(axis_name)
 
             fig.canvas.set_window_title("Surface" + title)
-
-            fig.colorbar(surface)
-
             fig.show()
         elif plot_type == SpectraSelection.Contour:
-            fig = pcolormesh([matrix_ws], contour=True)
+            fig = plot_contour([matrix_ws])
             ax = fig.get_axes()[0]
 
             ax.set_ylabel(axis_name)

--- a/Framework/PythonInterface/mantid/plots/surfacecontourplots.py
+++ b/Framework/PythonInterface/mantid/plots/surfacecontourplots.py
@@ -40,10 +40,8 @@ def plot(plot_type: SpectraSelection, plot_index: int, axis_name: str, log_name:
 
             fig.show()
         elif plot_type == SpectraSelection.Contour:
-            fig = pcolormesh([matrix_ws])
+            fig = pcolormesh([matrix_ws], contour=True)
             ax = fig.get_axes()[0]
-
-            ax.contour(matrix_ws, levels=2, colors='k', linewidths=0.5)
 
             ax.set_ylabel(axis_name)
             ax.set_title("Contour" + title)

--- a/docs/source/release/v5.1.0/mantidworkbench.rst
+++ b/docs/source/release/v5.1.0/mantidworkbench.rst
@@ -23,6 +23,7 @@ Improvements
 - Fixed an issue where some scripts were running slower if a  plot was open at the same time.
 - The Help Menu now has an About screen that will pop up automatically on startup to provide links to the release notes and various other resources, and allow you to set some important setting such as Facility, instrument and accept usage tracing.
   You can choose to hide it until the next release.
+- There is now an option to create a 3D plot (surface, wireframe, contour) when you right-click a workspace.
 - The Sample Logs Dialog now lets you view the complete log data as well as filtered data which only includes values for the current period, the running status, and with invalid values removed.  Just click the "Filtered Data" checkbox to swap between them.
 - The axes tab in the figure options can now be used to set the limits, label, and scale of the z-axis on 3D plots.
 - The "Show sample logs" dialog will now hide the plot and statistics display if there are no suitable logs in the workspace that need it.  This is particularly applicable for some of the reactor based instruments.

--- a/qt/applications/workbench/workbench/plotting/figureinteraction.py
+++ b/qt/applications/workbench/workbench/plotting/figureinteraction.py
@@ -23,11 +23,12 @@ from qtpy.QtGui import QCursor
 from qtpy.QtWidgets import QActionGroup, QMenu, QApplication
 from matplotlib.colors import LogNorm, Normalize
 from matplotlib.collections import Collection
+from mpl_toolkits.mplot3d.art3d import Poly3DCollection
 from mpl_toolkits.mplot3d.axes3d import Axes3D
 
 # mantid imports
 from mantid.api import AnalysisDataService as ads
-from mantid.plots import datafunctions, MantidAxes
+from mantid.plots import datafunctions, MantidAxes, MantidAxes3D
 from mantid.plots.utility import zoom, MantidAxType
 from mantidqt.plotting.figuretype import FigureType, figure_type
 from mantidqt.plotting.markers import SingleMarker
@@ -300,6 +301,9 @@ class FigureInteraction(object):
             if isinstance(event.inaxes, MantidAxes):
                 self._add_axes_scale_menu(menu, event.inaxes)
                 self._add_normalization_option_menu(menu, event.inaxes)
+                self._add_colorbar_axes_scale_menu(menu, event.inaxes)
+            elif isinstance(event.inaxes, MantidAxes3D) and isinstance(event.inaxes.collections[0], Poly3DCollection):
+                # Surface plots
                 self._add_colorbar_axes_scale_menu(menu, event.inaxes)
         else:
             if self.fit_browser.tool is not None:

--- a/qt/applications/workbench/workbench/plotting/figureinteraction.py
+++ b/qt/applications/workbench/workbench/plotting/figureinteraction.py
@@ -721,7 +721,13 @@ class FigureInteraction(object):
 
                         # This check is to prevent the contour lines being re-plotted using the colorfill plot args.
                         if isinstance(ws_artist._artists[0], QuadContourSet):
+                            contour_line_colour = ws_artist._artists[0].collections[0].get_color()
+
                             ws_artist.replace_data(workspace, None)
+
+                            # Re-apply the contour line colour
+                            for col in ws_artist._artists[0].collections:
+                                col.set_color(contour_line_colour)
                         else:
                             ws_artist.replace_data(workspace, arg_set_copy)
 

--- a/qt/applications/workbench/workbench/plotting/figureinteraction.py
+++ b/qt/applications/workbench/workbench/plotting/figureinteraction.py
@@ -234,7 +234,7 @@ class FigureInteraction(object):
                     move_and_show(YAxisEditor(canvas, ax))
                 else:
                     move_and_show(ColorbarAxisEditor(canvas, ax))
-            if hasattr(ax, 'zaxis'):
+            elif hasattr(ax, 'zaxis'):
                 if ax.zaxis.label.contains(event)[0]:
                     move_and_show(LabelEditor(canvas, ax.zaxis.label))
                 elif (ax.zaxis.contains(event)[0]

--- a/qt/applications/workbench/workbench/plotting/figuremanager.py
+++ b/qt/applications/workbench/workbench/plotting/figuremanager.py
@@ -501,7 +501,6 @@ class FigureManagerWorkbench(FigureManagerBase, QObject):
         button.setPopupMode(QToolButton.InstantPopup)
 
     def change_line_collection_colour(self, colour):
-        from matplotlib.collections import LineCollection
         for col in self.canvas.figure.get_axes()[0].collections:
             if isinstance(col, LineCollection):
                 col.set_color(colour.name())

--- a/qt/applications/workbench/workbench/plotting/figuremanager.py
+++ b/qt/applications/workbench/workbench/plotting/figuremanager.py
@@ -469,7 +469,12 @@ class FigureManagerWorkbench(FigureManagerBase, QObject):
         self.toolbar.set_generate_plot_script_enabled(not is_waterfall)
 
     def set_up_color_selector_toolbar_button(self):
+        # check if the action is already in the toolbar
+        if self.toolbar._actions.get('line_colour'):
+            return
+
         a = self.toolbar.addAction(get_icon('mdi.palette'), "Line Colour", lambda: None)
+        self.toolbar._actions['line_colour'] = a
 
         ax_collections = self.canvas.figure.get_axes()[0].collections
         if any(isinstance(col, Line3DCollection) for col in ax_collections):

--- a/qt/applications/workbench/workbench/plotting/figuremanager.py
+++ b/qt/applications/workbench/workbench/plotting/figuremanager.py
@@ -479,11 +479,10 @@ class FigureManagerWorkbench(FigureManagerBase, QObject):
 
         line_collection = next(col for col in ax_collections if isinstance(col, LineCollection))
         initial_colour = convert_color_to_hex(line_collection.get_color()[0])
-        initial_q_colour = QColor(initial_colour)
 
-        colour_dialog = QColorDialog()
+        colour_dialog = QColorDialog(QColor(initial_colour))
         colour_dialog.setOption(QColorDialog.NoButtons)
-        colour_dialog.setCurrentColor(initial_q_colour)
+        colour_dialog.setOption(QColorDialog.DontUseNativeDialog)
         colour_dialog.currentColorChanged.connect(self.change_line_collection_colour)
 
         button = [child for child in self.toolbar.children() if isinstance(child, QToolButton)][-1]

--- a/qt/applications/workbench/workbench/plotting/figurewindow.py
+++ b/qt/applications/workbench/workbench/plotting/figurewindow.py
@@ -12,9 +12,6 @@
 import weakref
 
 # 3rdparty imports
-from matplotlib.collections import LineCollection, QuadMesh
-from mpl_toolkits.mplot3d.axes3d import Axes3D
-from mpl_toolkits.mplot3d.art3d import Line3DCollection, Poly3DCollection
 from qtpy.QtCore import QEvent, Qt, Signal, Slot
 from qtpy.QtGui import QIcon
 from qtpy.QtWidgets import QMainWindow
@@ -124,27 +121,18 @@ class FigureWindow(QMainWindow, ObservingView):
         if len(names) == 0:
             return
         # local import to avoid circular import with FigureManager
-        from mantidqt.plotting.functions import pcolormesh, plot_from_names, plot_surface, plot_wireframe
+        from mantidqt.plotting.functions import pcolormesh, plot_from_names, plot_surface, plot_wireframe, plot_contour
 
         fig = self._canvas.figure
         fig_type = figure_type(fig, ax)
         if fig_type == FigureType.Image:
-            # if the axes that a workspace has been dragged onto is a colorbar (a colorbar is identified by having a
-            # QuadMesh), find the other axes on the figure that the colorbar 'belongs' to, so the plot type can be
-            # determined.
-            if any(isinstance(col, QuadMesh) for col in ax.collections):
-                for axes in fig.get_axes():
-                    if not any(isinstance(col, QuadMesh) for col in axes.collections):
-                        ax = axes
-                        break
-
-            if isinstance(ax, Axes3D):
-                if any(isinstance(col, Poly3DCollection) for col in ax.collections):
-                    plot_surface(names, fig=fig)
-                elif any(isinstance(col, Line3DCollection) for col in ax.collections):
-                    plot_wireframe(names, fig=fig)
-            else:
-                pcolormesh(names, fig=fig, contour=any(isinstance(col, LineCollection) for col in ax.collections))
+            pcolormesh(names, fig=fig)
+        elif fig_type == FigureType.Surface:
+            plot_surface(names, fig=fig)
+        elif fig_type == FigureType.Wireframe:
+            plot_wireframe(names, fig=fig)
+        elif fig_type == FigureType.Contour:
+            plot_contour(names, fig=fig)
         else:
             plot_from_names(names, errors=(fig_type == FigureType.Errorbar),
                             overplot=ax, fig=fig)

--- a/qt/applications/workbench/workbench/plotting/propertiesdialog.py
+++ b/qt/applications/workbench/workbench/plotting/propertiesdialog.py
@@ -115,7 +115,8 @@ class AxisEditor(PropertiesEditorBase):
         # Ensure that only floats can be entered
         self.ui.editor_min.setValidator(QDoubleValidator())
         self.ui.editor_max.setValidator(QDoubleValidator())
-        if figure_type(canvas.figure) == FigureType.Image:
+        if figure_type(canvas.figure) in [FigureType.Image, FigureType.Contour,
+                                          FigureType.Surface, FigureType.Wireframe]:
             self.ui.logBox.hide()
             self.ui.gridBox.hide()
 

--- a/qt/applications/workbench/workbench/plotting/propertiesdialog.py
+++ b/qt/applications/workbench/workbench/plotting/propertiesdialog.py
@@ -115,8 +115,7 @@ class AxisEditor(PropertiesEditorBase):
         # Ensure that only floats can be entered
         self.ui.editor_min.setValidator(QDoubleValidator())
         self.ui.editor_max.setValidator(QDoubleValidator())
-        if figure_type(canvas.figure) in [FigureType.Image, FigureType.Contour,
-                                          FigureType.Surface, FigureType.Wireframe]:
+        if figure_type(canvas.figure) in [FigureType.Surface, FigureType.Wireframe]:
             self.ui.logBox.hide()
             self.ui.gridBox.hide()
 
@@ -209,6 +208,8 @@ class ColorbarAxisEditor(AxisEditor):
     def __init__(self, canvas, axes):
         super(ColorbarAxisEditor, self).__init__(canvas, axes, 'y')
 
+        self.ui.gridBox.hide()
+
         self.images = self.canvas.figure.gca().images
         if len(self.images) == 0:
             self.images = [col for col in self.canvas.figure.gca().collections if isinstance(col, QuadMesh)
@@ -221,9 +222,7 @@ class ColorbarAxisEditor(AxisEditor):
 
         limit_min, limit_max = float(self.ui.editor_min.text()), float(self.ui.editor_max.text())
 
-        scale = Normalize
-        if isinstance(self.images[0].norm, LogNorm):
-            scale = LogNorm
+        scale = LogNorm if self.ui.logBox.isChecked() else Normalize
 
         if scale == LogNorm and (limit_min <= 0 or limit_max <= 0):
             raise ValueError("Limits must be positive\nwhen scale is logarithmic.")
@@ -235,7 +234,7 @@ class ColorbarAxisEditor(AxisEditor):
         memento = AxisEditorModel()
         self._memento = memento
         memento.min, memento.max = self.images[0].get_clim()
-        memento.log = False
+        memento.log = isinstance(self.images[0].norm, LogNorm)
         memento.grid = False
 
         self._fill(memento)

--- a/qt/applications/workbench/workbench/plotting/test/test_figureinteraction.py
+++ b/qt/applications/workbench/workbench/plotting/test/test_figureinteraction.py
@@ -614,10 +614,10 @@ class FigureInteractionTest(unittest.TestCase):
         self.assertEqual(1, self.interactor.redraw_annotations.call_count)
 
     def test_toggle_normalisation_on_contour_plot_maintains_contour_line_colour(self):
-        from mantidqt.plotting.functions import pcolormesh
+        from mantidqt.plotting.functions import plot_contour
         from mantid.plots.legend import convert_color_to_hex
         ws = CreateWorkspace(DataX=[1, 2, 3, 4, 2, 4, 6, 8], DataY=[2] * 8, NSpec=2, OutputWorkspace="test_ws")
-        fig = pcolormesh([ws], contour=True)
+        fig = plot_contour([ws])
 
         for col in fig.get_axes()[0].collections:
             col.set_color("#ff9900")

--- a/qt/applications/workbench/workbench/plotting/test/test_figureinteraction.py
+++ b/qt/applications/workbench/workbench/plotting/test/test_figureinteraction.py
@@ -613,6 +613,23 @@ class FigureInteractionTest(unittest.TestCase):
         self.interactor.mpl_redraw_annotations(event)
         self.assertEqual(1, self.interactor.redraw_annotations.call_count)
 
+    def test_toggle_normalisation_on_contour_plot_maintains_contour_line_colour(self):
+        from mantidqt.plotting.functions import pcolormesh
+        from mantid.plots.legend import convert_color_to_hex
+        ws = CreateWorkspace(DataX=[1, 2, 3, 4, 2, 4, 6, 8], DataY=[2] * 8, NSpec=2, OutputWorkspace="test_ws")
+        fig = pcolormesh([ws], contour=True)
+
+        for col in fig.get_axes()[0].collections:
+            col.set_color("#ff9900")
+
+        mock_canvas = MagicMock(figure=fig)
+        fig_manager_mock = MagicMock(canvas=mock_canvas)
+        fig_interactor = FigureInteraction(fig_manager_mock)
+        fig_interactor._toggle_normalization(fig.axes[0])
+
+        self.assertTrue(all(convert_color_to_hex(col.get_color()[0]) == "#ff9900"
+                            for col in fig.get_axes()[0].collections))
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/qt/applications/workbench/workbench/plugins/test/test_workspacewidget.py
+++ b/qt/applications/workbench/workbench/plugins/test/test_workspacewidget.py
@@ -65,18 +65,18 @@ class WorkspaceWidgetTest(unittest.TestCase, QtWidgetFinder):
         self.assert_widget_type_exists(MATRIXWORKSPACE_DISPLAY_TYPE)
 
     @mock.patch('workbench.plugins.workspacewidget.plot', autospec=True)
-    def test_plot_with_plot_bin(self,mock_plot):
+    def test_plot_with_plot_bin(self, mock_plot):
         self.ws_widget._do_plot_bin([self.ws_names[0]], False, False)
         mock_plot.assert_called_once_with(mock.ANY,errors=False, overplot=False, wksp_indices=[0],
                                           plot_kwargs={'axis': MantidAxType.BIN})
 
     @mock.patch('workbench.plugins.workspacewidget.plot_from_names', autospec=True)
-    def test_plot_with_plot_spectrum(self,mock_plot_from_names):
+    def test_plot_with_plot_spectrum(self, mock_plot_from_names):
         self.ws_widget._do_plot_spectrum([self.ws_names[0]], False, False)
         mock_plot_from_names.assert_called_once_with([self.ws_names[0]], False, False, advanced=False)
 
     @mock.patch('workbench.plugins.workspacewidget.pcolormesh', autospec=True)
-    def test_plot_with_plot_colorfill(self,mock_plot_colorfill):
+    def test_plot_with_plot_colorfill(self, mock_plot_colorfill):
         self.ws_widget._do_plot_colorfill([self.ws_names[0]])
         mock_plot_colorfill.assert_called_once_with(mock.ANY)
 
@@ -84,6 +84,21 @@ class WorkspaceWidgetTest(unittest.TestCase, QtWidgetFinder):
     def test_plot_with_plot_advanced(self, mock_plot_from_names):
         self.ws_widget._do_plot_spectrum([self.ws_names[0]], False, False, advanced=True)
         mock_plot_from_names.assert_called_once_with([self.ws_names[0]], False, False, advanced=True)
+
+    @mock.patch('workbench.plugins.workspacewidget.pcolormesh', autospec=True)
+    def test_plot_with_plot_contour(self, mock_plot_colorfill):
+        self.ws_widget._do_plot_colorfill([self.ws_names[0]], contour=True)
+        mock_plot_colorfill.assert_called_once_with([self.ws_names[0]], fig=None, contour=True)
+
+    @mock.patch('mantidqt.plotting.functions.plot_surface', autospec=True)
+    def test_plot_with_plot_surface(self, mock_plot_surface):
+        self.ws_widget._do_plot_3D([self.ws_names[0]], plot_type='surface')
+        mock_plot_surface.assert_called_once_with([self.ws_names[0]])
+
+    @mock.patch('mantidqt.plotting.functions.plot_wireframe', autospec=True)
+    def test_plot_with_plot_wireframe(self, mock_plot_wireframe):
+        self.ws_widget._do_plot_3D([self.ws_names[0]], plot_type='wireframe')
+        mock_plot_wireframe.assert_called_once_with([self.ws_names[0]])
 
 
 if __name__ == '__main__':

--- a/qt/applications/workbench/workbench/plugins/test/test_workspacewidget.py
+++ b/qt/applications/workbench/workbench/plugins/test/test_workspacewidget.py
@@ -78,17 +78,17 @@ class WorkspaceWidgetTest(unittest.TestCase, QtWidgetFinder):
     @mock.patch('workbench.plugins.workspacewidget.pcolormesh', autospec=True)
     def test_plot_with_plot_colorfill(self, mock_plot_colorfill):
         self.ws_widget._do_plot_colorfill([self.ws_names[0]])
-        mock_plot_colorfill.assert_called_once_with(mock.ANY, contour=False)
+        mock_plot_colorfill.assert_called_once_with(mock.ANY)
 
     @mock.patch('workbench.plugins.workspacewidget.plot_from_names', autospec=True)
     def test_plot_with_plot_advanced(self, mock_plot_from_names):
         self.ws_widget._do_plot_spectrum([self.ws_names[0]], False, False, advanced=True)
         mock_plot_from_names.assert_called_once_with([self.ws_names[0]], False, False, advanced=True)
 
-    @mock.patch('workbench.plugins.workspacewidget.pcolormesh', autospec=True)
-    def test_plot_with_plot_contour(self, mock_plot_colorfill):
-        self.ws_widget._do_plot_colorfill([self.ws_names[0]], contour=True)
-        mock_plot_colorfill.assert_called_once_with([self.ws_names[0]], contour=True)
+    @mock.patch('mantidqt.plotting.functions.plot_contour', autospec=True)
+    def test_plot_with_plot_contour(self, mock_plot_contour):
+        self.ws_widget._do_plot_3D([self.ws_names[0]], plot_type='contour')
+        mock_plot_contour.assert_called_once_with([self.ws_names[0]])
 
     @mock.patch('mantidqt.plotting.functions.plot_surface', autospec=True)
     def test_plot_with_plot_surface(self, mock_plot_surface):

--- a/qt/applications/workbench/workbench/plugins/test/test_workspacewidget.py
+++ b/qt/applications/workbench/workbench/plugins/test/test_workspacewidget.py
@@ -78,7 +78,7 @@ class WorkspaceWidgetTest(unittest.TestCase, QtWidgetFinder):
     @mock.patch('workbench.plugins.workspacewidget.pcolormesh', autospec=True)
     def test_plot_with_plot_colorfill(self, mock_plot_colorfill):
         self.ws_widget._do_plot_colorfill([self.ws_names[0]])
-        mock_plot_colorfill.assert_called_once_with(mock.ANY)
+        mock_plot_colorfill.assert_called_once_with(mock.ANY, contour=False)
 
     @mock.patch('workbench.plugins.workspacewidget.plot_from_names', autospec=True)
     def test_plot_with_plot_advanced(self, mock_plot_from_names):
@@ -88,7 +88,7 @@ class WorkspaceWidgetTest(unittest.TestCase, QtWidgetFinder):
     @mock.patch('workbench.plugins.workspacewidget.pcolormesh', autospec=True)
     def test_plot_with_plot_contour(self, mock_plot_colorfill):
         self.ws_widget._do_plot_colorfill([self.ws_names[0]], contour=True)
-        mock_plot_colorfill.assert_called_once_with([self.ws_names[0]], fig=None, contour=True)
+        mock_plot_colorfill.assert_called_once_with([self.ws_names[0]], contour=True)
 
     @mock.patch('mantidqt.plotting.functions.plot_surface', autospec=True)
     def test_plot_with_plot_surface(self, mock_plot_surface):

--- a/qt/applications/workbench/workbench/plugins/workspacewidget.py
+++ b/qt/applications/workbench/workbench/plugins/workspacewidget.py
@@ -62,7 +62,7 @@ class WorkspaceWidget(PluginWidget):
                                                                  errors=False, overplot=False, advanced=True))
         self.workspacewidget.plotSurfaceClicked.connect(partial(self._do_plot_3D, plot_type='surface'))
         self.workspacewidget.plotWireframeClicked.connect(partial(self._do_plot_3D, plot_type='wireframe'))
-        self.workspacewidget.plotContourClicked.connect(partial(self._do_plot_colorfill, contour=True))
+        self.workspacewidget.plotContourClicked.connect(partial(self._do_plot_3D, plot_type='contour'))
 
         self.workspacewidget.workspaceDoubleClicked.connect(self._action_double_click_workspace)
 
@@ -121,7 +121,7 @@ class WorkspaceWidget(PluginWidget):
         plot(self._ads.retrieveWorkspaces(names, unrollGroups=True), errors=errors,
              overplot=overplot,wksp_indices=[0], plot_kwargs=plot_kwargs)
 
-    def _do_plot_colorfill(self, names, contour=False):
+    def _do_plot_colorfill(self, names):
         """
         Plot a colorfill from the selected workspaces
 
@@ -129,7 +129,7 @@ class WorkspaceWidget(PluginWidget):
         :param contour: An optional bool for whether to draw contour lines.
         """
         try:
-            pcolormesh(names, contour=contour)
+            pcolormesh(names)
         except BaseException:
             import traceback
             traceback.print_exc()
@@ -139,7 +139,7 @@ class WorkspaceWidget(PluginWidget):
         Make a 3D plot from the selected workspace.
 
         :param workspaces: A list of workspace names.
-        :param plot_type: The type of 3D plot, either 'surface' or 'wireframe'.
+        :param plot_type: The type of 3D plot, either 'surface', 'wireframe', or 'contour'.
         """
         plot_function = getattr(functions, f'plot_{plot_type}', None)
 

--- a/qt/applications/workbench/workbench/plugins/workspacewidget.py
+++ b/qt/applications/workbench/workbench/plugins/workspacewidget.py
@@ -62,7 +62,7 @@ class WorkspaceWidget(PluginWidget):
                                                                  errors=False, overplot=False, advanced=True))
         self.workspacewidget.plotSurfaceClicked.connect(partial(self._do_plot_3D, plot_type='surface'))
         self.workspacewidget.plotWireframeClicked.connect(partial(self._do_plot_3D, plot_type='wireframe'))
-        self.workspacewidget.plotContourClicked.connect(partial(self._do_plot_3D, plot_type='contour'))
+        self.workspacewidget.plotContourClicked.connect(partial(self._do_plot_colorfill, contour=True))
 
         self.workspacewidget.workspaceDoubleClicked.connect(self._action_double_click_workspace)
 
@@ -121,14 +121,15 @@ class WorkspaceWidget(PluginWidget):
         plot(self._ads.retrieveWorkspaces(names, unrollGroups=True), errors=errors,
              overplot=overplot,wksp_indices=[0], plot_kwargs=plot_kwargs)
 
-    def _do_plot_colorfill(self, names):
+    def _do_plot_colorfill(self, names, contour=False):
         """
         Plot a colorfill from the selected workspaces
 
         :param names: A list of workspace names
+        :param contour: An optional bool for whether to draw contour lines.
         """
         try:
-            pcolormesh(self._ads.retrieveWorkspaces(names, unrollGroups=True))
+            pcolormesh(names, contour=contour)
         except BaseException:
             import traceback
             traceback.print_exc()
@@ -138,7 +139,7 @@ class WorkspaceWidget(PluginWidget):
         Make a 3D plot from the selected workspace.
 
         :param workspaces: A list of workspace names.
-        :param plot_type: The type of 3D plot, either 'surface', 'wireframe', or 'contour'.
+        :param plot_type: The type of 3D plot, either 'surface' or 'wireframe'.
         """
         plot_function = getattr(functions, f'plot_{plot_type}', None)
 

--- a/qt/applications/workbench/workbench/plugins/workspacewidget.py
+++ b/qt/applications/workbench/workbench/plugins/workspacewidget.py
@@ -11,6 +11,7 @@ from qtpy.QtWidgets import QApplication, QMessageBox, QVBoxLayout
 
 from mantid.api import AnalysisDataService, WorkspaceGroup
 from mantid.kernel import logger
+from mantidqt.plotting import functions
 from mantidqt.plotting.functions import can_overplot, pcolormesh, plot, plot_from_names
 from mantid.plots.utility import MantidAxType
 from mantid.simpleapi import CreateDetectorTable
@@ -59,6 +60,9 @@ class WorkspaceWidget(PluginWidget):
         self.workspacewidget.showDetectorsClicked.connect(self._do_show_detectors)
         self.workspacewidget.plotAdvancedClicked.connect(partial(self._do_plot_spectrum,
                                                                  errors=False, overplot=False, advanced=True))
+        self.workspacewidget.plotSurfaceClicked.connect(partial(self._do_plot_3D, plot_type='surface'))
+        self.workspacewidget.plotWireframeClicked.connect(partial(self._do_plot_3D, plot_type='wireframe'))
+        self.workspacewidget.plotContourClicked.connect(partial(self._do_plot_3D, plot_type='contour'))
 
         self.workspacewidget.workspaceDoubleClicked.connect(self._action_double_click_workspace)
 
@@ -128,6 +132,23 @@ class WorkspaceWidget(PluginWidget):
         except BaseException:
             import traceback
             traceback.print_exc()
+
+    def _do_plot_3D(self, workspaces, plot_type):
+        """
+        Make a 3D plot from the selected workspace.
+
+        :param workspaces: A list of workspace names.
+        :param plot_type: The type of 3D plot, either 'surface', 'wireframe', or 'contour'.
+        """
+        plot_function = getattr(functions, f'plot_{plot_type}', None)
+
+        if plot_function is None:
+            return
+
+        try:
+            plot_function(workspaces)
+        except RuntimeError as re:
+            logger.error(str(re))
 
     def _do_sample_logs(self, names):
         """

--- a/qt/python/mantidqt/plotting/figuretype.py
+++ b/qt/python/mantidqt/plotting/figuretype.py
@@ -12,7 +12,11 @@ Provides facilities to check plot types
 """
 # third party
 from enum import Enum
+from matplotlib.axes import Axes
+from matplotlib.collections import LineCollection
 from matplotlib.container import ErrorbarContainer
+from mpl_toolkits.mplot3d.axes3d import Axes3D
+from mpl_toolkits.mplot3d.art3d import Line3DCollection, Poly3DCollection
 
 
 class FigureType(Enum):
@@ -27,6 +31,12 @@ class FigureType(Enum):
     Errorbar = 2
     # An image plot from imshow, pcolor, pcolormesh
     Image = 3
+    # A 3D surface plot
+    Surface = 4
+    # A 3D wireframe plot
+    Wireframe = 5
+    # A contour plot
+    Contour = 6
     # Any other type of plot
     Other = 100
 
@@ -44,8 +54,16 @@ def axes_type(ax):
         axtype = FigureType.Errorbar
     elif len(ax.lines) > 0:
         axtype = FigureType.Line
+    elif isinstance(ax, Axes3D):
+        if any(isinstance(col, Poly3DCollection) for col in ax.collections):
+            axtype = FigureType.Surface
+        elif any(isinstance(col, Line3DCollection) for col in ax.collections):
+            axtype = FigureType.Wireframe
     elif len(ax.images) > 0 or len(ax.collections) > 0:
-        axtype = FigureType.Image
+        if any(isinstance(col, LineCollection) for col in ax.collections):
+            axtype = FigureType.Contour
+        else:
+            axtype = FigureType.Image
 
     return axtype
 
@@ -61,10 +79,11 @@ def figure_type(fig, ax=None):
     if len(fig.get_axes()) == 0:
         return FigureType.Empty
     else:
-        ax_types = [axes_type(axis) for axis in fig.axes]
-        if any([type == FigureType.Image for type in ax_types]):
-            return FigureType.Image
-        elif ax:
+        if ax:
+            # If ax is a colorbar then find a non-colorbar axes on the figure so the plot type can be determined.
+            if type(ax) == Axes:
+                ax = next(axes for axes in fig.get_axes() if not type(axes) == Axes)
+
             return axes_type(ax)
         else:
             return axes_type(fig.axes[0])

--- a/qt/python/mantidqt/plotting/functions.py
+++ b/qt/python/mantidqt/plotting/functions.py
@@ -15,6 +15,7 @@ our custom window.
 import numpy as np
 
 # 3rd party imports
+import matplotlib.pyplot as plt
 try:
     from matplotlib.cm import viridis as DEFAULT_CMAP
 except ImportError:
@@ -246,3 +247,30 @@ def pcolormesh_on_axis(ax, ws):
 def _validate_pcolormesh_inputs(workspaces):
     """Raises a ValueError if any arguments have the incorrect types"""
     raise_if_not_sequence(workspaces, 'workspaces', MatrixWorkspace)
+
+
+@manage_workspace_names
+def plot_surface(workspaces):
+    fig, ax = plt.subplots(subplot_kw={'projection': 'mantid3d'})
+    ws = workspaces[0]
+    surface = ax.plot_surface(ws, cmap=DEFAULT_CMAP)
+    ax.set_title(ws.name())
+    fig.colorbar(surface)
+    fig.show()
+
+
+@manage_workspace_names
+def plot_wireframe(workspaces):
+    fig, ax = plt.subplots(subplot_kw={'projection': 'mantid3d'})
+    ws = workspaces[0]
+    ax.plot_wireframe(ws)
+    ax.set_title(ws.name())
+    fig.show()
+
+
+@manage_workspace_names
+def plot_contour(workspaces):
+    ws = workspaces[0]
+    fig = pcolormesh([ws])
+    ax = fig.get_axes()[0]
+    ax.contour(ws, levels=2, colors='k', linewidths=0.5)

--- a/qt/python/mantidqt/plotting/functions.py
+++ b/qt/python/mantidqt/plotting/functions.py
@@ -251,26 +251,26 @@ def _validate_pcolormesh_inputs(workspaces):
 
 @manage_workspace_names
 def plot_surface(workspaces):
-    fig, ax = plt.subplots(subplot_kw={'projection': 'mantid3d'})
-    ws = workspaces[0]
-    surface = ax.plot_surface(ws, cmap=DEFAULT_CMAP)
-    ax.set_title(ws.name())
-    fig.colorbar(surface)
-    fig.show()
+    for ws in workspaces:
+        fig, ax = plt.subplots(subplot_kw={'projection': 'mantid3d'})
+        surface = ax.plot_surface(ws, cmap=DEFAULT_CMAP)
+        ax.set_title(ws.name())
+        fig.colorbar(surface)
+        fig.show()
 
 
 @manage_workspace_names
 def plot_wireframe(workspaces):
-    fig, ax = plt.subplots(subplot_kw={'projection': 'mantid3d'})
-    ws = workspaces[0]
-    ax.plot_wireframe(ws)
-    ax.set_title(ws.name())
-    fig.show()
+    for ws in workspaces:
+        fig, ax = plt.subplots(subplot_kw={'projection': 'mantid3d'})
+        ax.plot_wireframe(ws)
+        ax.set_title(ws.name())
+        fig.show()
 
 
 @manage_workspace_names
 def plot_contour(workspaces):
-    ws = workspaces[0]
-    fig = pcolormesh([ws])
-    ax = fig.get_axes()[0]
-    ax.contour(ws, levels=2, colors='k', linewidths=0.5)
+    for ws in workspaces:
+        fig = pcolormesh([ws])
+        ax = fig.get_axes()[0]
+        ax.contour(ws, levels=2, colors='k', linewidths=0.5)

--- a/qt/python/mantidqt/plotting/functions.py
+++ b/qt/python/mantidqt/plotting/functions.py
@@ -15,7 +15,6 @@ our custom window.
 import numpy as np
 
 # 3rd party imports
-import matplotlib.pyplot as plt
 try:
     from matplotlib.cm import viridis as DEFAULT_CMAP
 except ImportError:
@@ -261,6 +260,8 @@ def _validate_pcolormesh_inputs(workspaces):
 
 @manage_workspace_names
 def plot_surface(workspaces):
+    # Imported here to prevent pyplot being imported before matplotlib.use() is called when Workbench is opened.
+    import matplotlib.pyplot as plt
     for ws in workspaces:
         fig, ax = plt.subplots(subplot_kw={'projection': 'mantid3d'})
         surface = ax.plot_surface(ws, cmap=DEFAULT_CMAP)
@@ -271,6 +272,7 @@ def plot_surface(workspaces):
 
 @manage_workspace_names
 def plot_wireframe(workspaces):
+    import matplotlib.pyplot as plt
     for ws in workspaces:
         fig, ax = plt.subplots(subplot_kw={'projection': 'mantid3d'})
         ax.plot_wireframe(ws)

--- a/qt/python/mantidqt/plotting/functions.py
+++ b/qt/python/mantidqt/plotting/functions.py
@@ -287,6 +287,7 @@ def plot_wireframe(workspaces, fig=None):
 
     return fig
 
+
 @manage_workspace_names
 def plot_contour(workspaces, fig=None):
     for ws in workspaces:

--- a/qt/python/mantidqt/plotting/functions.py
+++ b/qt/python/mantidqt/plotting/functions.py
@@ -178,7 +178,7 @@ def use_imshow(ws):
 
 
 @manage_workspace_names
-def pcolormesh(workspaces, fig=None, contour=False):
+def pcolormesh(workspaces, fig=None):
     """
     Create a figure containing pcolor subplots
 
@@ -211,12 +211,6 @@ def pcolormesh(workspaces, fig=None, contour=False):
             else:
                 row_idx += 1
                 col_idx = 0
-
-            if contour:
-                ax.contour(ws, levels=DEFAULT_CONTOUR_LEVELS,
-                           colors=DEFAULT_CONTOUR_COLOUR,
-                           linewidths=DEFAULT_CONTOUR_WIDTH)
-
         else:
             # nothing here
             ax.axis('off')
@@ -271,8 +265,10 @@ def plot_surface(workspaces, fig=None):
 
         surface = ax.plot_surface(ws, cmap=DEFAULT_CMAP)
         ax.set_title(ws.name())
-        fig.colorbar(surface)
+        fig.colorbar(surface, ax=[ax])
         fig.show()
+
+    return fig
 
 
 @manage_workspace_names
@@ -288,3 +284,20 @@ def plot_wireframe(workspaces, fig=None):
         ax.plot_wireframe(ws)
         ax.set_title(ws.name())
         fig.show()
+
+    return fig
+
+@manage_workspace_names
+def plot_contour(workspaces, fig=None):
+    for ws in workspaces:
+        fig = pcolormesh(workspaces, fig)
+        ax = fig.get_axes()[0]
+
+        ax.contour(ws, levels=DEFAULT_CONTOUR_LEVELS,
+                   colors=DEFAULT_CONTOUR_COLOUR,
+                   linewidths=DEFAULT_CONTOUR_WIDTH)
+
+        ax.set_title(ws.name())
+        fig.show()
+
+    return fig

--- a/qt/python/mantidqt/plotting/functions.py
+++ b/qt/python/mantidqt/plotting/functions.py
@@ -39,6 +39,9 @@ SUBPLOT_HSPACE = 0.5
 COLORPLOT_MIN_WIDTH = 8
 COLORPLOT_MIN_HEIGHT = 7
 LOGGER = Logger("workspace.plotting.functions")
+DEFAULT_CONTOUR_LEVELS = 2
+DEFAULT_CONTOUR_COLOUR = 'k'
+DEFAULT_CONTOUR_WIDTH = 0.5
 
 # -----------------------------------------------------------------------------
 # 'Public' Functions
@@ -176,12 +179,13 @@ def use_imshow(ws):
 
 
 @manage_workspace_names
-def pcolormesh(workspaces, fig=None):
+def pcolormesh(workspaces, fig=None, contour=False):
     """
     Create a figure containing pcolor subplots
 
     :param workspaces: A list of workspace handles
     :param fig: An optional figure to contain the new plots. Its current contents will be cleared
+    :param contour: An optional bool for whether to draw contour lines.
     :returns: The figure containing the plots
     """
     # check inputs
@@ -208,6 +212,12 @@ def pcolormesh(workspaces, fig=None):
             else:
                 row_idx += 1
                 col_idx = 0
+
+            if contour:
+                ax.contour(ws, levels=DEFAULT_CONTOUR_LEVELS,
+                           colors=DEFAULT_CONTOUR_COLOUR,
+                           linewidths=DEFAULT_CONTOUR_WIDTH)
+
         else:
             # nothing here
             ax.axis('off')
@@ -265,13 +275,4 @@ def plot_wireframe(workspaces):
         fig, ax = plt.subplots(subplot_kw={'projection': 'mantid3d'})
         ax.plot_wireframe(ws)
         ax.set_title(ws.name())
-        fig.show()
-
-
-@manage_workspace_names
-def plot_contour(workspaces):
-    for ws in workspaces:
-        fig = pcolormesh([ws])
-        ax = fig.get_axes()[0]
-        ax.contour(ws, levels=2, colors='k', linewidths=0.5)
         fig.show()

--- a/qt/python/mantidqt/plotting/functions.py
+++ b/qt/python/mantidqt/plotting/functions.py
@@ -184,7 +184,6 @@ def pcolormesh(workspaces, fig=None):
 
     :param workspaces: A list of workspace handles
     :param fig: An optional figure to contain the new plots. Its current contents will be cleared
-    :param contour: An optional bool for whether to draw contour lines.
     :returns: The figure containing the plots
     """
     # check inputs

--- a/qt/python/mantidqt/plotting/functions.py
+++ b/qt/python/mantidqt/plotting/functions.py
@@ -265,7 +265,7 @@ def plot_surface(workspaces, fig=None):
     for ws in workspaces:
         if fig:
             fig.clf()
-            ax = fig.add_subplot(projection='mantid3d')
+            ax = fig.add_subplot(111, projection='mantid3d')
         else:
             fig, ax = plt.subplots(subplot_kw={'projection': 'mantid3d'})
 
@@ -281,7 +281,7 @@ def plot_wireframe(workspaces, fig=None):
     for ws in workspaces:
         if fig:
             fig.clf()
-            ax = fig.add_subplot(projection='mantid3d')
+            ax = fig.add_subplot(111, projection='mantid3d')
         else:
             fig, ax = plt.subplots(subplot_kw={'projection': 'mantid3d'})
 

--- a/qt/python/mantidqt/plotting/functions.py
+++ b/qt/python/mantidqt/plotting/functions.py
@@ -274,3 +274,4 @@ def plot_contour(workspaces):
         fig = pcolormesh([ws])
         ax = fig.get_axes()[0]
         ax.contour(ws, levels=2, colors='k', linewidths=0.5)
+        fig.show()

--- a/qt/python/mantidqt/plotting/functions.py
+++ b/qt/python/mantidqt/plotting/functions.py
@@ -259,11 +259,16 @@ def _validate_pcolormesh_inputs(workspaces):
 
 
 @manage_workspace_names
-def plot_surface(workspaces):
+def plot_surface(workspaces, fig=None):
     # Imported here to prevent pyplot being imported before matplotlib.use() is called when Workbench is opened.
     import matplotlib.pyplot as plt
     for ws in workspaces:
-        fig, ax = plt.subplots(subplot_kw={'projection': 'mantid3d'})
+        if fig:
+            fig.clf()
+            ax = fig.add_subplot(projection='mantid3d')
+        else:
+            fig, ax = plt.subplots(subplot_kw={'projection': 'mantid3d'})
+
         surface = ax.plot_surface(ws, cmap=DEFAULT_CMAP)
         ax.set_title(ws.name())
         fig.colorbar(surface)
@@ -271,10 +276,15 @@ def plot_surface(workspaces):
 
 
 @manage_workspace_names
-def plot_wireframe(workspaces):
+def plot_wireframe(workspaces, fig=None):
     import matplotlib.pyplot as plt
     for ws in workspaces:
-        fig, ax = plt.subplots(subplot_kw={'projection': 'mantid3d'})
+        if fig:
+            fig.clf()
+            ax = fig.add_subplot(projection='mantid3d')
+        else:
+            fig, ax = plt.subplots(subplot_kw={'projection': 'mantid3d'})
+
         ax.plot_wireframe(ws)
         ax.set_title(ws.name())
         fig.show()

--- a/qt/python/mantidqt/plotting/test/test_figuretype.py
+++ b/qt/python/mantidqt/plotting/test/test_figuretype.py
@@ -16,6 +16,7 @@ from unittest import TestCase, main
 import matplotlib
 matplotlib.use('AGG')  # noqa
 import matplotlib.pyplot as plt
+import numpy as np
 
 # local imports
 from mantidqt.plotting.figuretype import figure_type, FigureType
@@ -44,6 +45,24 @@ class FigureTypeTest(TestCase):
         ax = plt.subplot(111)
         ax.imshow([[1], [1]])
         self.assertEqual(FigureType.Image, figure_type(ax.figure))
+
+    def test_surface_plot_returns_surface(self):
+        a = np.array([[1]])
+        ax = plt.subplot(111, projection='3d')
+        ax.plot_surface(a, a, a)
+        self.assertEqual(FigureType.Surface, figure_type(ax.figure))
+
+    def test_wireframe_plot_returns_wireframe(self):
+        a = np.array([[1]])
+        ax = plt.subplot(111, projection='3d')
+        ax.plot_wireframe(a, a, a)
+        self.assertEqual(FigureType.Wireframe, figure_type(ax.figure))
+
+    def test_contour_plot_returns_contour(self):
+        ax = plt.subplot(111)
+        ax.imshow([[1], [1]])
+        ax.contour([[1, 1], [1, 1]])
+        self.assertEqual(FigureType.Contour, figure_type(ax.figure))
 
 
 if __name__ == '__main__':

--- a/qt/python/mantidqt/plotting/test/test_functions.py
+++ b/qt/python/mantidqt/plotting/test/test_functions.py
@@ -269,6 +269,15 @@ class FunctionsTest(TestCase):
 
         self.assertEqual(len(fills), 3)
 
+    def test_pcolormesh_with_contour_true_draws_contour_lines(self):
+        from mantidqt.plotting.functions import pcolormesh
+        from matplotlib.collections import LineCollection
+        ws = self._test_ws
+        pcolormesh([ws], contour=True)
+        ax = plt.gca()
+
+        self.assertTrue(any(isinstance(col, LineCollection) for col in ax.collections))
+
     # ------------- Failure tests -------------
 
     def test_plot_from_names_with_non_plottable_workspaces_returns_None(self):

--- a/qt/python/mantidqt/plotting/test/test_functions.py
+++ b/qt/python/mantidqt/plotting/test/test_functions.py
@@ -269,15 +269,6 @@ class FunctionsTest(TestCase):
 
         self.assertEqual(len(fills), 3)
 
-    def test_pcolormesh_with_contour_true_draws_contour_lines(self):
-        from mantidqt.plotting.functions import pcolormesh
-        from matplotlib.collections import LineCollection
-        ws = self._test_ws
-        pcolormesh([ws], contour=True)
-        ax = plt.gca()
-
-        self.assertTrue(any(isinstance(col, LineCollection) for col in ax.collections))
-
     # ------------- Failure tests -------------
 
     def test_plot_from_names_with_non_plottable_workspaces_returns_None(self):

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/WorkspacePresenter/WorkspaceTreeWidgetSimple.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/WorkspacePresenter/WorkspaceTreeWidgetSimple.h
@@ -54,6 +54,9 @@ signals:
   void showAlgorithmHistoryClicked(const QStringList &workspaceNames);
   void showDetectorsClicked(const QStringList &workspaceNames);
   void plotAdvancedClicked(const QStringList &workspaceNames);
+  void plotSurfaceClicked(const QStringList &workspaceNames);
+  void plotWireframeClicked(const QStringList &workspaceNames);
+  void plotContourClicked(const QStringList &workspaceNames);
 
   void workspaceDoubleClicked(const QString &workspaceName);
   void treeSelectionChanged();
@@ -72,12 +75,16 @@ private slots:
   void onShowAlgorithmHistoryClicked();
   void onShowDetectorsClicked();
   void onPlotAdvancedClicked();
+  void onPlotSurfaceClicked();
+  void onPlotWireframeClicked();
+  void onPlotContourClicked();
 
 private:
   QAction *m_plotSpectrum, *m_plotBin, *m_overplotSpectrum,
       *m_plotSpectrumWithErrs, *m_overplotSpectrumWithErrs, *m_plotColorfill,
       *m_sampleLogs, *m_sliceViewer, *m_showInstrument, *m_showData,
-      *m_showAlgorithmHistory, *m_showDetectors, *m_plotAdvanced;
+      *m_showAlgorithmHistory, *m_showDetectors, *m_plotAdvanced,
+      *m_plotSurface, *m_plotWireframe, *m_plotContour;
 };
 } // namespace MantidWidgets
 } // namespace MantidQt

--- a/qt/widgets/common/src/WorkspacePresenter/WorkspaceTreeWidgetSimple.cpp
+++ b/qt/widgets/common/src/WorkspacePresenter/WorkspaceTreeWidgetSimple.cpp
@@ -43,7 +43,10 @@ WorkspaceTreeWidgetSimple::WorkspaceTreeWidgetSimple(bool viewOnly,
       m_showData(new QAction("Show Data", this)),
       m_showAlgorithmHistory(new QAction("Show History", this)),
       m_showDetectors(new QAction("Show Detectors", this)),
-      m_plotAdvanced(new QAction("Advanced...", this)) {
+      m_plotAdvanced(new QAction("Advanced...", this)),
+      m_plotSurface(new QAction("Surface", this)),
+      m_plotWireframe(new QAction("Wireframe", this)),
+      m_plotContour(new QAction("Contour", this)) {
 
   // Replace the double click action on the MantidTreeWidget
   m_tree->m_doubleClickAction = [&](const QString &wsName) {
@@ -75,6 +78,12 @@ WorkspaceTreeWidgetSimple::WorkspaceTreeWidgetSimple(bool viewOnly,
           SLOT(onShowDetectorsClicked()));
   connect(m_plotAdvanced, SIGNAL(triggered()), this,
           SLOT(onPlotAdvancedClicked()));
+  connect(m_plotSurface, SIGNAL(triggered()), this,
+          SLOT(onPlotSurfaceClicked()));
+  connect(m_plotWireframe, SIGNAL(triggered()), this,
+          SLOT(onPlotWireframeClicked()));
+  connect(m_plotContour, SIGNAL(triggered()), this,
+          SLOT(onPlotContourClicked()));
 }
 
 WorkspaceTreeWidgetSimple::~WorkspaceTreeWidgetSimple() {}
@@ -134,6 +143,16 @@ void WorkspaceTreeWidgetSimple::popupContextMenu() {
 
       plotSubMenu->addSeparator();
       plotSubMenu->addAction(m_plotColorfill);
+
+      if (multipleBins) {
+        QMenu *plot3DSubMenu(new QMenu("3D", menu));
+        plot3DSubMenu->addAction(m_plotSurface);
+        plot3DSubMenu->addAction(m_plotWireframe);
+        plot3DSubMenu->addAction(m_plotContour);
+
+        plotSubMenu->addMenu(plot3DSubMenu);
+      }
+
       menu->addMenu(plotSubMenu);
       menu->addSeparator();
       menu->addAction(m_showData);
@@ -257,6 +276,18 @@ void WorkspaceTreeWidgetSimple::onShowDetectorsClicked() {
 
 void WorkspaceTreeWidgetSimple::onPlotAdvancedClicked() {
   emit plotAdvancedClicked(getSelectedWorkspaceNamesAsQList());
+}
+
+void WorkspaceTreeWidgetSimple::onPlotSurfaceClicked() {
+  emit plotSurfaceClicked(getSelectedWorkspaceNamesAsQList());
+}
+
+void WorkspaceTreeWidgetSimple::onPlotWireframeClicked() {
+  emit plotWireframeClicked(getSelectedWorkspaceNamesAsQList());
+}
+
+void WorkspaceTreeWidgetSimple::onPlotContourClicked() {
+  emit plotContourClicked(getSelectedWorkspaceNamesAsQList());
 }
 
 } // namespace MantidWidgets


### PR DESCRIPTION
**Description of work.**
This PR makes it so that you can create 3D plots in Workbench without using a script, by right-clicking on a workspace in the workspace widget.

**To test:**
Load a workspace.
Right-click it and go to Plot, there should now be a '3D' sub-menu with Surface, Wireframe, and Contour options. Check that each of these produces the correct plot.
Contour and Wireframe plots should have an additional option in the toolbar to change the colour of the lines.
You should be able to right-click Surface plots to change the colorbar scale.
Basically play around and make sure nothing is broken.
Not all of the toolbar options will work correctly, this is addressed in #28537.

Fixes #27470 

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
