### PR TITLE
Clean up internal workspace caches within an Algorithm object

### DIFF
--- a/Framework/API/inc/MantidAPI/Algorithm.h
+++ b/Framework/API/inc/MantidAPI/Algorithm.h
@@ -416,7 +416,10 @@ private:
   void doSetInputProperties(const std::string &name, const T1 &wksp,
                             IndexType type, const T2 &list);
   void lockWorkspaces();
+
   void unlockWorkspaces();
+
+  void clearWorkspaceCaches();
 
   void linkHistoryWithLastChild();
 


### PR DESCRIPTION
**Description of work.**

See commit message for more detail. This has been an issue for some time but removing the AlgorithmProxy in #28409 made the problems with keeping the references alive a real issue. It manifested itself a failing system test on Windows:

<details>
<summary>PlusMDTest (expand to see detailed log) </summary>

```
ConfigService-[Information] This is Mantid version 5.0.20200424.1452 revision g7f1afbc7e
ConfigService-[Information] running on NDW1850 starting 2020-04-26T09:14Z
ConfigService-[Information] Properties file(s) loaded: C:\MantidNightlyInstall\bin\Mantid.properties, C:\MantidNightlyInstall\bin\Mantid.user.properties
FrameworkManager-[Notice] Welcome to Mantid 5.0.20200424.1452
FrameworkManager-[Notice] Please cite: http://dx.doi.org/10.1016/j.nima.2014.07.029 and this release: http://dx.doi.org/10.5286/Software/Mantid
FrameworkManager-[Information] Instrument updates disabled - cannot update instrument definitions.
FrameworkManager-[Information] Version check disabled.
MDWorkspaceTests-[Notice] Failed to remove C:/Jenkins/workspace/master_systemtests-windows/build/Testing/SystemTests/scripts\cncs.nxs
MDWorkspaceTests-[Notice] Failed to remove C:/Jenkins/workspace/master_systemtests-windows/build/Testing/SystemTests/scripts\cncs.nxs
FileFinder-[Information] found path = C:\Jenkins\workspace\master_systemtests-windows\build\ExternalData\Testing\Data\SystemTest\CNCS_7860_event.nxs
LoadEventNexus-[Notice] LoadEventNexus started
LoadEventNexus-[Information] Algorithm: LoadEventNexus v1
LoadEventNexus-[Information] Execution Date: 2020-04-26 09:14:33.820879000
LoadEventNexus-[Information] Execution Duration: -1 seconds
LoadEventNexus-[Information] UUID: 40f23efd-f922-421b-867b-dde039ccc4c0
LoadEventNexus-[Information] Parameters:
LoadEventNexus-[Information]   Name: Filename, Value: C:\Jenkins\worksp ... CS_7860_event.nxs, Default?: No, Direction: Input
LoadEventNexus-[Information]   Name: OutputWorkspace, Value: cncs_nxs, Default?: No, Direction: Output
LoadEventNexus-[Information]   Name: NXentryName, Value: , Default?: Yes, Direction: Input
LoadEventNexus-[Information]   Name: FilterByTofMin, Value: 8.9884656743115785e+307, Default?: Yes, Direction: Input
LoadEventNexus-[Information]   Name: FilterByTofMax, Value: 8.9884656743115785e+307, Default?: Yes, Direction: Input
LoadEventNexus-[Information]   Name: FilterByTimeStart, Value: 8.9884656743115785e+307, Default?: Yes, Direction: Input
LoadEventNexus-[Information]   Name: FilterByTimeStop, Value: 8.9884656743115785e+307, Default?: Yes, Direction: Input
LoadEventNexus-[Information]   Name: BankName, Value: , Default?: Yes, Direction: Input
LoadEventNexus-[Information]   Name: SingleBankPixelsOnly, Value: 1, Default?: Yes, Direction: Input
LoadEventNexus-[Information]   Name: Precount, Value: 1, Default?: Yes, Direction: Input
LoadEventNexus-[Information]   Name: CompressTolerance, Value: -1, Default?: Yes, Direction: Input
LoadEventNexus-[Information]   Name: ChunkNumber, Value: 2147483647, Default?: Yes, Direction: Input
LoadEventNexus-[Information]   Name: TotalChunks, Value: 2147483647, Default?: Yes, Direction: Input
LoadEventNexus-[Information]   Name: LoadMonitors, Value: 0, Default?: Yes, Direction: Input
LoadEventNexus-[Information]   Name: MonitorsLoadOnly, Value: , Default?: Yes, Direction: Input
LoadEventNexus-[Information]   Name: FilterMonByTofMin, Value: 8.9884656743115785e+307, Default?: Yes, Direction: Input
LoadEventNexus-[Information]   Name: FilterMonByTofMax, Value: 8.9884656743115785e+307, Default?: Yes, Direction: Input
LoadEventNexus-[Information]   Name: FilterMonByTimeStart, Value: 8.9884656743115785e+307, Default?: Yes, Direction: Input
LoadEventNexus-[Information]   Name: FilterMonByTimeStop, Value: 8.9884656743115785e+307, Default?: Yes, Direction: Input
LoadEventNexus-[Information]   Name: SpectrumMin, Value: 2147483647, Default?: Yes, Direction: Input
LoadEventNexus-[Information]   Name: SpectrumMax, Value: 2147483647, Default?: Yes, Direction: Input
LoadEventNexus-[Information]   Name: SpectrumList, Value: , Default?: Yes, Direction: Input
LoadEventNexus-[Information]   Name: MetaDataOnly, Value: 0, Default?: Yes, Direction: Input
LoadEventNexus-[Information]   Name: LoadLogs, Value: 1, Default?: Yes, Direction: Input
LoadEventNexus-[Information]   Name: LoadType, Value: Default, Default?: Yes, Direction: Input
LoadEventNexus-[Information]   Name: LoadNexusInstrumentXML, Value: 1, Default?: Yes, Direction: Input
LoadEventNexus-[Information]   Name: NumberOfBins, Value: 500, Default?: Yes, Direction: Input
LoadEventNexus-[Information] Loading logs from NeXus file...
LoadEventNexus-[Information] No instrument XML definition found in C:\Jenkins\workspace\master_systemtests-windows\build\ExternalData\Testing\Data\SystemTest\CNCS_7860_event.nxs at entry/instrument
InstrumentDefinitionParser-[Information] Loading geometry cache from C:\Users\builder\AppData\Roaming\mantidproject\mantid\instrument\geometryCache\CNCS3a48021559512a3bf3be857ebc93fed7c9d918a7.vtp
LoadParameterFile-[Information] Parsing from XML file: C:\MantidNightlyInstall\instrument\CNCS_Parameters_1-35154.xml
LoadEventNexus-[Information] Read 112266 events. Shortest TOF: 44163.6 microsec; longest TOF: 60829.2 microsec.
LoadEventNexus-[Notice] LoadEventNexus successful, Duration 0.84 seconds
ConvertToDiffractionMDWorkspace-[Notice] ConvertToDiffractionMDWorkspace started
ConvertToDiffractionMDWorkspace-[Information] Algorithm: ConvertToDiffractionMDWorkspace v3
ConvertToDiffractionMDWorkspace-[Information] Execution Date: 2020-04-26 09:14:34.656649000
ConvertToDiffractionMDWorkspace-[Information] Execution Duration: -1 seconds
ConvertToDiffractionMDWorkspace-[Information] UUID: badc847d-91da-4f5d-9b94-7ee12ea99047
ConvertToDiffractionMDWorkspace-[Information] Parameters:
ConvertToDiffractionMDWorkspace-[Information]   Name: InputWorkspace, Value: cncs_nxs, Default?: No, Direction: Input
ConvertToDiffractionMDWorkspace-[Information]   Name: OutputWorkspace, Value: cncs_original, Default?: No, Direction: Output
ConvertToDiffractionMDWorkspace-[Information]   Name: Append, Value: 0, Default?: Yes, Direction: Input
ConvertToDiffractionMDWorkspace-[Information]   Name: ClearInputWorkspace, Value: 0, Default?: Yes, Direction: Input
ConvertToDiffractionMDWorkspace-[Information]   Name: OneEventPerBin, Value: 1, Default?: Yes, Direction: Input
ConvertToDiffractionMDWorkspace-[Information]   Name: OutputDimensions, Value: Q (lab frame), Default?: Yes, Direction: Input
ConvertToDiffractionMDWorkspace-[Information]   Name: LorentzCorrection, Value: 0, Default?: Yes, Direction: Input
ConvertToDiffractionMDWorkspace-[Information]   Name: SplitInto, Value: 2, Default?: Yes, Direction: Input
ConvertToDiffractionMDWorkspace-[Information]   Name: SplitThreshold, Value: 1500, Default?: Yes, Direction: Input
ConvertToDiffractionMDWorkspace-[Information]   Name: MaxRecursionDepth, Value: 20, Default?: Yes, Direction: Input
ConvertToDiffractionMDWorkspace-[Information]   Name: MinRecursionDepth, Value: 1, Default?: Yes, Direction: Input
ConvertToDiffractionMDWorkspace-[Information]   Name: Extents, Value: , Default?: Yes, Direction: Input
MDWSTransform-[Information] Can not obtain transformation matrix from the input workspace: cncs_nxs as no oriented lattice has been defined. 
MDWSTransform-[Information] Will use unit transformation matrix.
PreprocessDetectorsToMD-[Information] Preprocessing detector locations in a target reciprocal space
PreprocessDetectorsToMD-[Information] Finished preprocessing detector locations. Found: 51200 detectors out of: 51200 histograms
MDWSTransform-[Information] Can not obtain transformation matrix from the input workspace: cncs_nxs as no oriented lattice has been defined. 
MDWSTransform-[Information] Will use unit transformation matrix.
PreprocessDetectorsToMD-[Information] Preprocessing detector locations in a target reciprocal space
PreprocessDetectorsToMD-[Information] Finished preprocessing detector locations. Found: 51200 detectors out of: 51200 histograms
ConvertToMD-[Information]  conversion started
ConvertToDiffractionMDWorkspace-[Notice] ConvertToDiffractionMDWorkspace successful, Duration 0.15 seconds
SaveMD-[Notice] SaveMD started
SaveMD-[Information] Algorithm: SaveMD v2
SaveMD-[Information] Execution Date: 2020-04-26 09:14:34.810267000
SaveMD-[Information] Execution Duration: -1 seconds
SaveMD-[Information] UUID: 080e0f17-1352-4308-86f2-427bfd9c7770
SaveMD-[Information] Parameters:
SaveMD-[Information]   Name: InputWorkspace, Value: cncs_original, Default?: No, Direction: Input
SaveMD-[Information]   Name: Filename, Value: C:\Jenkins\worksp ... \scripts\cncs.nxs, Default?: No, Direction: Input
SaveMD-[Information]   Name: UpdateFileBackEnd, Value: 0, Default?: Yes, Direction: Input
SaveMD-[Information]   Name: MakeFileBacked, Value: 0, Default?: Yes, Direction: Input
SaveMD-[Information]   Name: SaveHistory, Value: 1, Default?: Yes, Direction: Input
SaveMD-[Information]   Name: SaveInstrument, Value: 1, Default?: Yes, Direction: Input
SaveMD-[Information]   Name: SaveSample, Value: 1, Default?: Yes, Direction: Input
SaveMD-[Information]   Name: SaveLogs, Value: 1, Default?: Yes, Direction: Input
SaveMD-[Notice] SaveMD successful, Duration 0.10 seconds
BinMD-[Notice] BinMD started
BinMD-[Information] Algorithm: BinMD v1
BinMD-[Information] Execution Date: 2020-04-26 09:14:34.907132000
BinMD-[Information] Execution Duration: -1 seconds
BinMD-[Information] UUID: a804d5f9-33b4-4f7e-a994-1cb9a43e677c
BinMD-[Information] Parameters:
BinMD-[Information]   Name: InputWorkspace, Value: cncs_original, Default?: No, Direction: Input
BinMD-[Information]   Name: AxisAligned, Value: 1, Default?: Yes, Direction: Input
BinMD-[Information]   Name: AlignedDim0, Value: Q_lab_x, -3, 3, 100, Default?: No, Direction: Input
BinMD-[Information]   Name: AlignedDim1, Value: Q_lab_y, -3, 3, 100, Default?: No, Direction: Input
BinMD-[Information]   Name: AlignedDim2, Value: Q_lab_z, -3, 3, 100, Default?: No, Direction: Input
BinMD-[Information]   Name: AlignedDim3, Value: , Default?: Yes, Direction: Input
BinMD-[Information]   Name: AlignedDim4, Value: , Default?: Yes, Direction: Input
BinMD-[Information]   Name: AlignedDim5, Value: , Default?: Yes, Direction: Input
BinMD-[Information]   Name: BasisVector0, Value: , Default?: Yes, Direction: Input
BinMD-[Information]   Name: BasisVector1, Value: , Default?: Yes, Direction: Input
BinMD-[Information]   Name: BasisVector2, Value: , Default?: Yes, Direction: Input
BinMD-[Information]   Name: BasisVector3, Value: , Default?: Yes, Direction: Input
BinMD-[Information]   Name: BasisVector4, Value: , Default?: Yes, Direction: Input
BinMD-[Information]   Name: BasisVector5, Value: , Default?: Yes, Direction: Input
BinMD-[Information]   Name: Translation, Value: , Default?: Yes, Direction: Input
BinMD-[Information]   Name: OutputExtents, Value: , Default?: Yes, Direction: Input
BinMD-[Information]   Name: OutputBins, Value: , Default?: Yes, Direction: Input
BinMD-[Information]   Name: NormalizeBasisVectors, Value: 1, Default?: Yes, Direction: Input
BinMD-[Information]   Name: ForceOrthogonal, Value: 1, Default?: No, Direction: Input
BinMD-[Information]   Name: ImplicitFunctionXML, Value: , Default?: Yes, Direction: Input
BinMD-[Information]   Name: IterateEvents, Value: 1, Default?: Yes, Direction: Input
BinMD-[Information]   Name: Parallel, Value: 0, Default?: Yes, Direction: Input
BinMD-[Information]   Name: TemporaryDataWorkspace, Value: , Default?: Yes, Direction: Input
BinMD-[Information]   Name: OutputWorkspace, Value: cncs_original_binned, Default?: No, Direction: Output
BinMD-[Notice] BinMD successful, Duration 0.01 seconds
CreateSingleValuedWorkspace-[Notice] CreateSingleValuedWorkspace started
CreateSingleValuedWorkspace-[Information] Algorithm: CreateSingleValuedWorkspace v1
CreateSingleValuedWorkspace-[Information] Execution Date: 2020-04-26 09:14:34.921095000
CreateSingleValuedWorkspace-[Information] Execution Duration: -1 seconds
CreateSingleValuedWorkspace-[Information] UUID: 13616a32-a4df-4e22-8d07-823358ea76b2
CreateSingleValuedWorkspace-[Information] Parameters:
CreateSingleValuedWorkspace-[Information]   Name: OutputWorkspace, Value: __python_binary_op_single_value, Default?: No, Direction: Output
CreateSingleValuedWorkspace-[Information]   Name: DataValue, Value: 2, Default?: No, Direction: Input
CreateSingleValuedWorkspace-[Information]   Name: ErrorValue, Value: 0, Default?: Yes, Direction: Input
CreateSingleValuedWorkspace-[Notice] CreateSingleValuedWorkspace successful, Duration 0.00 seconds
MultiplyMD-[Notice] MultiplyMD started
MultiplyMD-[Information] Algorithm: MultiplyMD v1
MultiplyMD-[Information] Execution Date: 2020-04-26 09:14:34.921095000
MultiplyMD-[Information] Execution Duration: -1 seconds
MultiplyMD-[Information] UUID: daaafbdb-548a-43af-9d95-c3d30e311781
MultiplyMD-[Information] Parameters:
MultiplyMD-[Information]   Name: LHSWorkspace, Value: cncs_original_binned, Default?: No, Direction: Input
MultiplyMD-[Information]   Name: RHSWorkspace, Value: __python_binary_op_single_value, Default?: No, Direction: Input
MultiplyMD-[Information]   Name: OutputWorkspace, Value: cncs_original_binned, Default?: No, Direction: Output
MultiplyMD-[Notice] MultiplyMD successful, Duration 0.00 seconds
FileFinder-[Information] found path = C:\Jenkins\workspace\master_systemtests-windows\build\Testing\SystemTests\scripts\cncs.nxs
LoadMD-[Notice] LoadMD started
LoadMD-[Information] Algorithm: LoadMD v1
LoadMD-[Information] Execution Date: 2020-04-26 09:14:34.926081000
LoadMD-[Information] Execution Duration: -1 seconds
LoadMD-[Information] UUID: aff9ba32-d840-4277-8cb5-eab2f348e033
LoadMD-[Information] Parameters:
LoadMD-[Information]   Name: Filename, Value: C:\Jenkins\worksp ... \scripts\cncs.nxs, Default?: No, Direction: Input
LoadMD-[Information]   Name: MetadataOnly, Value: 0, Default?: Yes, Direction: Input
LoadMD-[Information]   Name: BoxStructureOnly, Value: 0, Default?: Yes, Direction: Input
LoadMD-[Information]   Name: FileBackEnd, Value: 0, Default?: Yes, Direction: Input
LoadMD-[Information]   Name: Memory, Value: 100, Default?: No, Direction: Input
LoadMD-[Information]   Name: LoadHistory, Value: 1, Default?: Yes, Direction: Input
LoadMD-[Information]   Name: OutputWorkspace, Value: cncs_mem, Default?: No, Direction: Output
LoadMD-[Information] LoadMD: Encountered a legacy file which has a mismatch between its MDFrames and its Special Coordinate System. Attempting to convert MDFrames.
LoadMD-[Information] Convention for Q in Preferences is Inelastic; Convention of Q in NeXus file is Inelastic
LoadMD-[Notice] LoadMD successful, Duration 0.03 seconds
FileFinder-[Information] found path = C:\Jenkins\workspace\master_systemtests-windows\build\Testing\SystemTests\scripts\cncs.nxs
LoadMD-[Notice] LoadMD started
LoadMD-[Information] Algorithm: LoadMD v1
LoadMD-[Information] Execution Date: 2020-04-26 09:14:34.957995000
LoadMD-[Information] Execution Duration: -1 seconds
LoadMD-[Information] UUID: 196becb5-0f8a-480b-9197-fb20c25f2104
LoadMD-[Information] Parameters:
LoadMD-[Information]   Name: Filename, Value: C:\Jenkins\worksp ... \scripts\cncs.nxs, Default?: No, Direction: Input
LoadMD-[Information]   Name: MetadataOnly, Value: 0, Default?: Yes, Direction: Input
LoadMD-[Information]   Name: BoxStructureOnly, Value: 0, Default?: Yes, Direction: Input
LoadMD-[Information]   Name: FileBackEnd, Value: 0, Default?: Yes, Direction: Input
LoadMD-[Information]   Name: Memory, Value: -1, Default?: Yes, Direction: Input
LoadMD-[Information]   Name: LoadHistory, Value: 1, Default?: Yes, Direction: Input
LoadMD-[Information]   Name: OutputWorkspace, Value: cncs_mem2, Default?: No, Direction: Output
LoadMD-[Information] LoadMD: Encountered a legacy file which has a mismatch between its MDFrames and its Special Coordinate System. Attempting to convert MDFrames.
LoadMD-[Information] Convention for Q in Preferences is Inelastic; Convention of Q in NeXus file is Inelastic
LoadMD-[Notice] LoadMD successful, Duration 0.03 seconds
PlusMD-[Notice] PlusMD started
PlusMD-[Information] Algorithm: PlusMD v1
PlusMD-[Information] Execution Date: 2020-04-26 09:14:34.992902000
PlusMD-[Information] Execution Duration: -1 seconds
PlusMD-[Information] UUID: dac91610-2f28-4ac3-9e77-fc5e9d4b9b71
PlusMD-[Information] Parameters:
PlusMD-[Information]   Name: LHSWorkspace, Value: cncs_mem2, Default?: No, Direction: Input
PlusMD-[Information]   Name: RHSWorkspace, Value: cncs_mem, Default?: No, Direction: Input
PlusMD-[Information]   Name: OutputWorkspace, Value: cncs_mem2, Default?: No, Direction: Output
PlusMD-[Notice] PlusMD successful, Duration 0.01 seconds
BinMD-[Notice] BinMD started
BinMD-[Information] Algorithm: BinMD v1
BinMD-[Information] Execution Date: 2020-04-26 09:14:35.005895000
BinMD-[Information] Execution Duration: -1 seconds
BinMD-[Information] UUID: 865c37fc-b136-4a6b-ae89-1f6611a50c20
BinMD-[Information] Parameters:
BinMD-[Information]   Name: InputWorkspace, Value: cncs_mem2, Default?: No, Direction: Input
BinMD-[Information]   Name: AxisAligned, Value: 1, Default?: Yes, Direction: Input
BinMD-[Information]   Name: AlignedDim0, Value: Q_lab_x, -3, 3, 100, Default?: No, Direction: Input
BinMD-[Information]   Name: AlignedDim1, Value: Q_lab_y, -3, 3, 100, Default?: No, Direction: Input
BinMD-[Information]   Name: AlignedDim2, Value: Q_lab_z, -3, 3, 100, Default?: No, Direction: Input
BinMD-[Information]   Name: AlignedDim3, Value: , Default?: Yes, Direction: Input
BinMD-[Information]   Name: AlignedDim4, Value: , Default?: Yes, Direction: Input
BinMD-[Information]   Name: AlignedDim5, Value: , Default?: Yes, Direction: Input
BinMD-[Information]   Name: BasisVector0, Value: , Default?: Yes, Direction: Input
BinMD-[Information]   Name: BasisVector1, Value: , Default?: Yes, Direction: Input
BinMD-[Information]   Name: BasisVector2, Value: , Default?: Yes, Direction: Input
BinMD-[Information]   Name: BasisVector3, Value: , Default?: Yes, Direction: Input
BinMD-[Information]   Name: BasisVector4, Value: , Default?: Yes, Direction: Input
BinMD-[Information]   Name: BasisVector5, Value: , Default?: Yes, Direction: Input
BinMD-[Information]   Name: Translation, Value: , Default?: Yes, Direction: Input
BinMD-[Information]   Name: OutputExtents, Value: , Default?: Yes, Direction: Input
BinMD-[Information]   Name: OutputBins, Value: , Default?: Yes, Direction: Input
BinMD-[Information]   Name: NormalizeBasisVectors, Value: 1, Default?: Yes, Direction: Input
BinMD-[Information]   Name: ForceOrthogonal, Value: 1, Default?: No, Direction: Input
BinMD-[Information]   Name: ImplicitFunctionXML, Value: , Default?: Yes, Direction: Input
BinMD-[Information]   Name: IterateEvents, Value: 1, Default?: Yes, Direction: Input
BinMD-[Information]   Name: Parallel, Value: 0, Default?: Yes, Direction: Input
BinMD-[Information]   Name: TemporaryDataWorkspace, Value: , Default?: Yes, Direction: Input
BinMD-[Information]   Name: OutputWorkspace, Value: test_binned, Default?: No, Direction: Output
BinMD-[Notice] BinMD successful, Duration 0.04 seconds
EqualToMD-[Notice] EqualToMD started
EqualToMD-[Information] Algorithm: EqualToMD v1
EqualToMD-[Information] Execution Date: 2020-04-26 09:14:35.043768000
EqualToMD-[Information] Execution Duration: -1 seconds
EqualToMD-[Information] UUID: 59ca77f8-ee0a-4103-9382-1c78e8dc10eb
EqualToMD-[Information] Parameters:
EqualToMD-[Information]   Name: LHSWorkspace, Value: test_binned, Default?: No, Direction: Input
EqualToMD-[Information]   Name: RHSWorkspace, Value: cncs_original_binned, Default?: No, Direction: Input
EqualToMD-[Information]   Name: OutputWorkspace, Value: comparison, Default?: No, Direction: Output
EqualToMD-[Information]   Name: Tolerance, Value: 1.0000000000000001e-05, Default?: Yes, Direction: Input
EqualToMD-[Notice] EqualToMD successful, Duration 0.01 seconds
DeleteWorkspace-[Notice] DeleteWorkspace started
DeleteWorkspace-[Information] Algorithm: DeleteWorkspace v1
DeleteWorkspace-[Information] Execution Date: 2020-04-26 09:14:35.512515000
DeleteWorkspace-[Information] Execution Duration: -1 seconds
DeleteWorkspace-[Information] UUID: bec6d607-fa0d-4ee8-97a6-a269d2c57adf
DeleteWorkspace-[Information] Parameters:
DeleteWorkspace-[Information]   Name: Workspace, Value: cncs_mem2, Default?: No, Direction: Input
DeleteWorkspace-[Notice] DeleteWorkspace successful, Duration 0.00 seconds
FileFinder-[Information] found path = C:\Jenkins\workspace\master_systemtests-windows\build\Testing\SystemTests\scripts\cncs.nxs
LoadMD-[Notice] LoadMD started
LoadMD-[Information] Algorithm: LoadMD v1
LoadMD-[Information] Execution Date: 2020-04-26 09:14:35.514510000
LoadMD-[Information] Execution Duration: -1 seconds
LoadMD-[Information] UUID: c2410012-b40b-466a-afa2-ecc6be39246f
LoadMD-[Information] Parameters:
LoadMD-[Information]   Name: Filename, Value: C:\Jenkins\worksp ... \scripts\cncs.nxs, Default?: No, Direction: Input
LoadMD-[Information]   Name: MetadataOnly, Value: 0, Default?: Yes, Direction: Input
LoadMD-[Information]   Name: BoxStructureOnly, Value: 0, Default?: Yes, Direction: Input
LoadMD-[Information]   Name: FileBackEnd, Value: 1, Default?: No, Direction: Input
LoadMD-[Information]   Name: Memory, Value: 100, Default?: No, Direction: Input
LoadMD-[Information]   Name: LoadHistory, Value: 1, Default?: Yes, Direction: Input
LoadMD-[Information]   Name: OutputWorkspace, Value: cncs_file, Default?: No, Direction: Output
LoadMD-[Information] Setting a DiskBuffer cache size of 100 MB, or 3744915 events.
LoadMD-[Information] LoadMD: Encountered a legacy file which has a mismatch between its MDFrames and its Special Coordinate System. Attempting to convert MDFrames.
LoadMD-[Information] Convention for Q in Preferences is Inelastic; Convention of Q in NeXus file is Inelastic
LoadMD-[Notice] LoadMD successful, Duration 0.01 seconds
PlusMD-[Notice] PlusMD started
PlusMD-[Information] Algorithm: PlusMD v1
PlusMD-[Information] Execution Date: 2020-04-26 09:14:35.525481000
PlusMD-[Information] Execution Duration: -1 seconds
PlusMD-[Information] UUID: 5693ff4f-1c82-4374-849a-6f0b185fa464
PlusMD-[Information] Parameters:
PlusMD-[Information]   Name: LHSWorkspace, Value: cncs_file, Default?: No, Direction: Input
PlusMD-[Information]   Name: RHSWorkspace, Value: cncs_mem, Default?: No, Direction: Input
PlusMD-[Information]   Name: OutputWorkspace, Value: cncs_file, Default?: No, Direction: Output
PlusMD-[Notice] PlusMD successful, Duration 0.01 seconds
BinMD-[Notice] BinMD started
BinMD-[Information] Algorithm: BinMD v1
BinMD-[Information] Execution Date: 2020-04-26 09:14:35.538447000
BinMD-[Information] Execution Duration: -1 seconds
BinMD-[Information] UUID: 27b6aa99-1ba7-468c-b1fe-fb172acbe0af
BinMD-[Information] Parameters:
BinMD-[Information]   Name: InputWorkspace, Value: cncs_file, Default?: No, Direction: Input
BinMD-[Information]   Name: AxisAligned, Value: 1, Default?: Yes, Direction: Input
BinMD-[Information]   Name: AlignedDim0, Value: Q_lab_x, -3, 3, 100, Default?: No, Direction: Input
BinMD-[Information]   Name: AlignedDim1, Value: Q_lab_y, -3, 3, 100, Default?: No, Direction: Input
BinMD-[Information]   Name: AlignedDim2, Value: Q_lab_z, -3, 3, 100, Default?: No, Direction: Input
BinMD-[Information]   Name: AlignedDim3, Value: , Default?: Yes, Direction: Input
BinMD-[Information]   Name: AlignedDim4, Value: , Default?: Yes, Direction: Input
BinMD-[Information]   Name: AlignedDim5, Value: , Default?: Yes, Direction: Input
BinMD-[Information]   Name: BasisVector0, Value: , Default?: Yes, Direction: Input
BinMD-[Information]   Name: BasisVector1, Value: , Default?: Yes, Direction: Input
BinMD-[Information]   Name: BasisVector2, Value: , Default?: Yes, Direction: Input
BinMD-[Information]   Name: BasisVector3, Value: , Default?: Yes, Direction: Input
BinMD-[Information]   Name: BasisVector4, Value: , Default?: Yes, Direction: Input
BinMD-[Information]   Name: BasisVector5, Value: , Default?: Yes, Direction: Input
BinMD-[Information]   Name: Translation, Value: , Default?: Yes, Direction: Input
BinMD-[Information]   Name: OutputExtents, Value: , Default?: Yes, Direction: Input
BinMD-[Information]   Name: OutputBins, Value: , Default?: Yes, Direction: Input
BinMD-[Information]   Name: NormalizeBasisVectors, Value: 1, Default?: Yes, Direction: Input
BinMD-[Information]   Name: ForceOrthogonal, Value: 1, Default?: No, Direction: Input
BinMD-[Information]   Name: ImplicitFunctionXML, Value: , Default?: Yes, Direction: Input
BinMD-[Information]   Name: IterateEvents, Value: 1, Default?: Yes, Direction: Input
BinMD-[Information]   Name: Parallel, Value: 0, Default?: Yes, Direction: Input
BinMD-[Information]   Name: TemporaryDataWorkspace, Value: , Default?: Yes, Direction: Input
BinMD-[Information]   Name: OutputWorkspace, Value: test_binned, Default?: No, Direction: Output
BinMD-[Notice] BinMD successful, Duration 0.05 seconds
EqualToMD-[Notice] EqualToMD started
EqualToMD-[Information] Algorithm: EqualToMD v1
EqualToMD-[Information] Execution Date: 2020-04-26 09:14:35.588319000
EqualToMD-[Information] Execution Duration: -1 seconds
EqualToMD-[Information] UUID: f9aea5e8-1b2f-42d9-bb60-034accff5a90
EqualToMD-[Information] Parameters:
EqualToMD-[Information]   Name: LHSWorkspace, Value: test_binned, Default?: No, Direction: Input
EqualToMD-[Information]   Name: RHSWorkspace, Value: cncs_original_binned, Default?: No, Direction: Input
EqualToMD-[Information]   Name: OutputWorkspace, Value: comparison, Default?: No, Direction: Output
EqualToMD-[Information]   Name: Tolerance, Value: 1.0000000000000001e-05, Default?: Yes, Direction: Input
EqualToMD-[Notice] EqualToMD successful, Duration 0.01 seconds
SaveMD-[Notice] SaveMD started
SaveMD-[Information] Algorithm: SaveMD v2
SaveMD-[Information] Execution Date: 2020-04-26 09:14:36.059057000
SaveMD-[Information] Execution Duration: -1 seconds
SaveMD-[Information] UUID: 5f651d08-e37e-4c23-af74-de8a8b3b628b
SaveMD-[Information] Parameters:
SaveMD-[Information]   Name: InputWorkspace, Value: cncs_file, Default?: No, Direction: Input
SaveMD-[Information]   Name: Filename, Value: , Default?: Yes, Direction: Input
SaveMD-[Information]   Name: UpdateFileBackEnd, Value: 1, Default?: No, Direction: Input
SaveMD-[Information]   Name: MakeFileBacked, Value: 0, Default?: Yes, Direction: Input
SaveMD-[Information]   Name: SaveHistory, Value: 1, Default?: Yes, Direction: Input
SaveMD-[Information]   Name: SaveInstrument, Value: 1, Default?: Yes, Direction: Input
SaveMD-[Information]   Name: SaveSample, Value: 1, Default?: Yes, Direction: Input
SaveMD-[Information]   Name: SaveLogs, Value: 1, Default?: Yes, Direction: Input
SaveMD-[Notice] SaveMD successful, Duration 0.03 seconds
BinMD-[Notice] BinMD started
BinMD-[Information] Algorithm: BinMD v1
BinMD-[Information] Execution Date: 2020-04-26 09:14:36.091001000
BinMD-[Information] Execution Duration: -1 seconds
BinMD-[Information] UUID: ae1d67b0-4e77-4c6e-a4c4-c043e0cd3f36
BinMD-[Information] Parameters:
BinMD-[Information]   Name: InputWorkspace, Value: cncs_file, Default?: No, Direction: Input
BinMD-[Information]   Name: AxisAligned, Value: 1, Default?: Yes, Direction: Input
BinMD-[Information]   Name: AlignedDim0, Value: Q_lab_x, -3, 3, 100, Default?: No, Direction: Input
BinMD-[Information]   Name: AlignedDim1, Value: Q_lab_y, -3, 3, 100, Default?: No, Direction: Input
BinMD-[Information]   Name: AlignedDim2, Value: Q_lab_z, -3, 3, 100, Default?: No, Direction: Input
BinMD-[Information]   Name: AlignedDim3, Value: , Default?: Yes, Direction: Input
BinMD-[Information]   Name: AlignedDim4, Value: , Default?: Yes, Direction: Input
BinMD-[Information]   Name: AlignedDim5, Value: , Default?: Yes, Direction: Input
BinMD-[Information]   Name: BasisVector0, Value: , Default?: Yes, Direction: Input
BinMD-[Information]   Name: BasisVector1, Value: , Default?: Yes, Direction: Input
BinMD-[Information]   Name: BasisVector2, Value: , Default?: Yes, Direction: Input
BinMD-[Information]   Name: BasisVector3, Value: , Default?: Yes, Direction: Input
BinMD-[Information]   Name: BasisVector4, Value: , Default?: Yes, Direction: Input
BinMD-[Information]   Name: BasisVector5, Value: , Default?: Yes, Direction: Input
BinMD-[Information]   Name: Translation, Value: , Default?: Yes, Direction: Input
BinMD-[Information]   Name: OutputExtents, Value: , Default?: Yes, Direction: Input
BinMD-[Information]   Name: OutputBins, Value: , Default?: Yes, Direction: Input
BinMD-[Information]   Name: NormalizeBasisVectors, Value: 1, Default?: Yes, Direction: Input
BinMD-[Information]   Name: ForceOrthogonal, Value: 1, Default?: No, Direction: Input
BinMD-[Information]   Name: ImplicitFunctionXML, Value: , Default?: Yes, Direction: Input
BinMD-[Information]   Name: IterateEvents, Value: 1, Default?: Yes, Direction: Input
BinMD-[Information]   Name: Parallel, Value: 0, Default?: Yes, Direction: Input
BinMD-[Information]   Name: TemporaryDataWorkspace, Value: , Default?: Yes, Direction: Input
BinMD-[Information]   Name: OutputWorkspace, Value: test_binned, Default?: No, Direction: Output
BinMD-[Notice] BinMD successful, Duration 0.03 seconds
EqualToMD-[Notice] EqualToMD started
EqualToMD-[Information] Algorithm: EqualToMD v1
EqualToMD-[Information] Execution Date: 2020-04-26 09:14:36.125912000
EqualToMD-[Information] Execution Duration: -1 seconds
EqualToMD-[Information] UUID: 02f477e4-da53-451b-8ea3-88b43cf80db7
EqualToMD-[Information] Parameters:
EqualToMD-[Information]   Name: LHSWorkspace, Value: test_binned, Default?: No, Direction: Input
EqualToMD-[Information]   Name: RHSWorkspace, Value: cncs_original_binned, Default?: No, Direction: Input
EqualToMD-[Information]   Name: OutputWorkspace, Value: comparison, Default?: No, Direction: Output
EqualToMD-[Information]   Name: Tolerance, Value: 1.0000000000000001e-05, Default?: Yes, Direction: Input
EqualToMD-[Notice] EqualToMD successful, Duration 0.01 seconds
DeleteWorkspace-[Notice] DeleteWorkspace started
DeleteWorkspace-[Information] Algorithm: DeleteWorkspace v1
DeleteWorkspace-[Information] Execution Date: 2020-04-26 09:14:36.597739000
DeleteWorkspace-[Information] Execution Duration: -1 seconds
DeleteWorkspace-[Information] UUID: 74e9fd09-6593-45cd-ad64-9df4f2d61ac8
DeleteWorkspace-[Information] Parameters:
DeleteWorkspace-[Information]   Name: Workspace, Value: cncs_file, Default?: No, Direction: Input
DeleteWorkspace-[Notice] DeleteWorkspace successful, Duration 0.00 seconds
SaveMD-[Notice] SaveMD started
SaveMD-[Information] Algorithm: SaveMD v2
SaveMD-[Information] Execution Date: 2020-04-26 09:14:36.598736000
SaveMD-[Information] Execution Duration: -1 seconds
SaveMD-[Information] UUID: 73a42243-79c5-4e6a-a630-267c1a84b56a
SaveMD-[Information] Parameters:
SaveMD-[Information]   Name: InputWorkspace, Value: cncs_original, Default?: No, Direction: Input
SaveMD-[Information]   Name: Filename, Value: C:\Jenkins\worksp ... \scripts\cncs.nxs, Default?: No, Direction: Input
SaveMD-[Information]   Name: UpdateFileBackEnd, Value: 0, Default?: Yes, Direction: Input
SaveMD-[Information]   Name: MakeFileBacked, Value: 0, Default?: Yes, Direction: Input
SaveMD-[Information]   Name: SaveHistory, Value: 1, Default?: Yes, Direction: Input
SaveMD-[Information]   Name: SaveInstrument, Value: 1, Default?: Yes, Direction: Input
SaveMD-[Information]   Name: SaveSample, Value: 1, Default?: Yes, Direction: Input
SaveMD-[Information]   Name: SaveLogs, Value: 1, Default?: Yes, Direction: Input
SaveMD-[Error] Error in execution of algorithm SaveMD:
SaveMD-[Error] File access error
SaveMD-[Error] Error in execution of algorithm SaveMD:
SaveMD-[Error] File access error
Traceback (most recent call last):

  File "C:\Users\builder\AppData\Local\Temp\tmplpsk16gc", line 24, in <module>

    systest.execute()

  File "C:\Jenkins\workspace\master_systemtests-windows\Testing\SystemTests\lib\systemtests\systemtesting.py", line 222, in execute

    self.runTest()

  File "C:/Jenkins/workspace/master_systemtests-windows/Testing/SystemTests/tests/analysis\MDWorkspaceTests.py", line 77, in runTest

    SaveMD(InputWorkspace='cncs_original', Filename='cncs.nxs')

  File "C:\MantidNightlyInstall\bin\mantid\simpleapi.py", line 1136, in algorithm_wrapper

    algm.execute()

RuntimeError: File access error
```
</details>

**To test:**

Review changes and check new unit test to understand what should be happening. This should also fix the PlusMD system test so try running that and it should pass whereas before it failed with a File access error.

*There is no associated issue.*

*This does not require release notes* because **this is an internal change**

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
