### PR TITLE
Do not read zero length arrays from nexus files

### DIFF
--- a/Framework/Nexus/inc/MantidNexus/NexusIOHelper.h
+++ b/Framework/Nexus/inc/MantidNexus/NexusIOHelper.h
@@ -101,14 +101,17 @@ std::vector<T> readNexusAnyVector(::NeXus::File &file, size_t size,
         "Downcasting is forbidden in NeXusIOHelper::readNexusAnyVector");
   } else if (std::is_same<T, U>::value) {
     std::vector<T> buf(size);
-    callGetData(file, buf, close_file);
+    if (size > 0)
+      callGetData(file, buf, close_file);
     return buf;
   } else {
-    std::vector<U> buf(size);
     std::vector<T> vec(size);
-    callGetData(file, buf, close_file);
-    std::transform(buf.begin(), buf.end(), vec.begin(),
-                   [](U a) -> T { return static_cast<T>(a); });
+    if (size > 0) {
+      std::vector<U> buf(size);
+      callGetData(file, buf, close_file);
+      std::transform(buf.begin(), buf.end(), vec.begin(),
+                     [](U a) -> T { return static_cast<T>(a); });
+    }
     return vec;
   }
 }
@@ -127,14 +130,17 @@ readNexusAnySlab(::NeXus::File &file, const std::vector<int64_t> &start,
         "Downcasting is forbidden in NeXusIOHelper::readNexusAnySlab");
   } else if (std::is_same<T, U>::value) {
     std::vector<T> buf(size[0]);
-    callGetSlab(file, buf, start, size, close_file);
+    if (size[0] > 0)
+      callGetSlab(file, buf, start, size, close_file);
     return buf;
   } else {
-    std::vector<U> buf(size[0]);
     std::vector<T> vec(size[0]);
-    callGetSlab(file, buf, start, size, close_file);
-    std::transform(buf.begin(), buf.end(), vec.begin(),
-                   [](U a) -> T { return static_cast<T>(a); });
+    if (size[0] > 0) {
+      std::vector<U> buf(size[0]);
+      callGetSlab(file, buf, start, size, close_file);
+      std::transform(buf.begin(), buf.end(), vec.begin(),
+                     [](U a) -> T { return static_cast<T>(a); });
+    }
     return vec;
   }
 }

--- a/docs/source/release/v5.1.0/framework.rst
+++ b/docs/source/release/v5.1.0/framework.rst
@@ -18,7 +18,7 @@ Algorithms
 - Add specialization to :ref:`SetUncertainties <algm-SetUncertainties>` for the
    case where InputWorkspace == OutputWorkspace. Where possible, avoid the
    cost of cloning the inputWorkspace.
-- Adjusted :ref:`AddPeak <algm-AddPeak>` to only allow peaks from the same instrument as the peaks worksapce to be added to that workspace. 
+- Adjusted :ref:`AddPeak <algm-AddPeak>` to only allow peaks from the same instrument as the peaks worksapce to be added to that workspace.
 
 Data Handling
 -------------
@@ -35,11 +35,15 @@ The sample environment xml file now supports the geometry being supplied in the 
 Data Objects
 ------------
 
-- Added MatrixWorkspace::findY to find the histogram and bin with a given value 
+- Added MatrixWorkspace::findY to find the histogram and bin with a given value
 
 Python
 ------
-- A list of spectrum numbers can be got by calling getSpectrumNumbers on a 
+- A list of spectrum numbers can be got by calling getSpectrumNumbers on a
   workspace. For example: spec_nums = ws.getSpectrumNumbers()
+
+Bugfixes
+--------
+- Fix an uncaught exception when loading empty fields from NeXus files. Now returns an empty vector.
 
 :ref:`Release 5.1.0 <v5.1.0>`


### PR DESCRIPTION
This was discovered while using `LoadNexusMonitors` on `CNCS_335658` which has zero events in monitor 1. The fix returns the correct length array without actually touching the file.

**Report to:** CNCS team

**To test:**

```python
from mantid.simpleapi import LoadNexusMonitors
LoadNexusMonitors(Filename='/SNS/CNCS/IPTS-25820/nexus/CNCS_335658.nxs.h5',
                  OutputWorkspace='CNCS_335658')
```

*There is no associated issue.*

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
