### PR TITLE
Use if constexpr where possible in NexusIOHelper

### DIFF
--- a/Framework/Nexus/inc/MantidNexus/NexusIOHelper.h
+++ b/Framework/Nexus/inc/MantidNexus/NexusIOHelper.h
@@ -94,12 +94,12 @@ void callGetSlab(::NeXus::File &file, std::vector<T> &buf,
 template <typename T, typename U>
 std::vector<T> readNexusAnyVector(::NeXus::File &file, size_t size,
                                   bool close_file) {
-  if (sizeof(T) < sizeof(U)) {
+  if constexpr (sizeof(T) < sizeof(U)) {
     if (close_file)
       file.closeData();
     throw std::runtime_error(
         "Downcasting is forbidden in NeXusIOHelper::readNexusAnyVector");
-  } else if (std::is_same<T, U>::value) {
+  } else if constexpr (std::is_same<T, U>::value) {
     std::vector<T> buf(size);
     if (size > 0)
       callGetData(file, buf, close_file);
@@ -123,12 +123,12 @@ template <typename T, typename U>
 std::vector<T>
 readNexusAnySlab(::NeXus::File &file, const std::vector<int64_t> &start,
                  const std::vector<int64_t> &size, bool close_file) {
-  if (sizeof(T) < sizeof(U)) {
+  if constexpr (sizeof(T) < sizeof(U)) {
     if (close_file)
       file.closeData();
     throw std::runtime_error(
         "Downcasting is forbidden in NeXusIOHelper::readNexusAnySlab");
-  } else if (std::is_same<T, U>::value) {
+  } else if constexpr (std::is_same<T, U>::value) {
     std::vector<T> buf(size[0]);
     if (size[0] > 0)
       callGetSlab(file, buf, start, size, close_file);
@@ -147,12 +147,12 @@ readNexusAnySlab(::NeXus::File &file, const std::vector<int64_t> &start,
 
 template <typename T, typename U>
 T readNexusAnyVariable(::NeXus::File &file, bool close_file) {
-  if (sizeof(T) < sizeof(U)) {
+  if constexpr (sizeof(T) < sizeof(U)) {
     if (close_file)
       file.closeData();
     throw std::runtime_error(
         "Downcasting is forbidden in NeXusIOHelper::readAnyVariable");
-  } else if (std::is_same<T, U>::value) {
+  } else if constexpr (std::is_same<T, U>::value) {
     T buf;
     callGetData(file, buf, close_file);
     return buf;


### PR DESCRIPTION
**Description of work.**

Makes several branches constexpr.

Changed downcasting check to use std::numeric_limits<T>::max() and std::numberic_limits<T>::lowest().

**To test:**

<!-- Instructions for testing. -->

This is a minor update to PR #28592

*This does not require release notes* because minor change.

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
