### PR TITLE
Speed up writing out of sample log averages

### DIFF
--- a/Framework/API/src/LogManager.cpp
+++ b/Framework/API/src/LogManager.cpp
@@ -55,7 +55,7 @@ bool convertTimeSeriesToDouble(const Property *property, double &value,
       value = static_cast<double>(log->minValue());
       break;
     case Math::Mean:
-      value = log->getStatistics().mean;
+      value = static_cast<double>(log->mean());
       break;
     case Math::Median:
       value = log->getStatistics().median;

--- a/Framework/DataHandling/src/LoadNexusLogs.cpp
+++ b/Framework/DataHandling/src/LoadNexusLogs.cpp
@@ -282,12 +282,9 @@ std::unique_ptr<Kernel::Property> createTimeSeries(::NeXus::File &file,
 }
 
 /**
- * Appends an additional entry to a TimeSeriesProperty which is at the end
- * time of the run and contains the last value of the property recorded before
- * the end time.
- *
- * This is a workaround to ensure that time series averaging of log values works
- * correctly for instruments who do not record log values for the entire run.
+ * Templated method to append an additional entry to a TimeSeriesProperty at
+ * the end time of the run containing the last value of the property recorded
+ * before the end time.
  *
  * If the run does not have an end time or if the last time of the time series
  * log is the same as the end time the property is left unmodified.
@@ -295,9 +292,11 @@ std::unique_ptr<Kernel::Property> createTimeSeries(::NeXus::File &file,
  * @param prop :: a pointer to a TimeSeriesProperty to modify
  * @param run :: handle to the run object containing the end time.
  */
+
+template <typename T>
 void appendEndTimeLog(Kernel::Property *prop, const API::Run &run) {
   try {
-    auto tsLog = dynamic_cast<TimeSeriesProperty<double> *>(prop);
+    auto tsLog = dynamic_cast<TimeSeriesProperty<T> *>(prop);
     const auto endTime = run.endTime();
 
     // First check if it is valid to add a additional log entry
@@ -311,6 +310,22 @@ void appendEndTimeLog(Kernel::Property *prop, const API::Run &run) {
   } catch (const std::runtime_error &) {
     // pass
   }
+}
+
+/**
+ * Appends an additional entry to a TimeSeriesProperty which is at the end
+ * time of the run and contains the last value of the property recorded before
+ * the end time. Do this for float and integer time series
+ *
+ * This is a workaround to ensure that time series averaging of log values works
+ * correctly for instruments who do not record log values for the entire run.
+ *
+ * @param prop :: a pointer to a TimeSeriesProperty to modify
+ * @param run :: handle to the run object containing the end time.
+ */
+void appendEndTimeLog(Kernel::Property *prop, const API::Run &run) {
+  appendEndTimeLog<double>(prop, run);
+  appendEndTimeLog<int>(prop, run);
 }
 
 /**

--- a/Framework/DataHandling/src/LoadNexusLogs.cpp
+++ b/Framework/DataHandling/src/LoadNexusLogs.cpp
@@ -282,9 +282,12 @@ std::unique_ptr<Kernel::Property> createTimeSeries(::NeXus::File &file,
 }
 
 /**
- * Templated method to append an additional entry to a TimeSeriesProperty at
- * the end time of the run containing the last value of the property recorded
- * before the end time.
+ * Appends an additional entry to a TimeSeriesProperty which is at the end
+ * time of the run and contains the last value of the property recorded before
+ * the end time.
+ *
+ * This is a workaround to ensure that time series averaging of log values works
+ * correctly for instruments who do not record log values for the entire run.
  *
  * If the run does not have an end time or if the last time of the time series
  * log is the same as the end time the property is left unmodified.
@@ -292,11 +295,9 @@ std::unique_ptr<Kernel::Property> createTimeSeries(::NeXus::File &file,
  * @param prop :: a pointer to a TimeSeriesProperty to modify
  * @param run :: handle to the run object containing the end time.
  */
-
-template <typename T>
 void appendEndTimeLog(Kernel::Property *prop, const API::Run &run) {
   try {
-    auto tsLog = dynamic_cast<TimeSeriesProperty<T> *>(prop);
+    auto tsLog = dynamic_cast<TimeSeriesProperty<double> *>(prop);
     const auto endTime = run.endTime();
 
     // First check if it is valid to add a additional log entry
@@ -310,22 +311,6 @@ void appendEndTimeLog(Kernel::Property *prop, const API::Run &run) {
   } catch (const std::runtime_error &) {
     // pass
   }
-}
-
-/**
- * Appends an additional entry to a TimeSeriesProperty which is at the end
- * time of the run and contains the last value of the property recorded before
- * the end time. Do this for float and integer time series
- *
- * This is a workaround to ensure that time series averaging of log values works
- * correctly for instruments who do not record log values for the entire run.
- *
- * @param prop :: a pointer to a TimeSeriesProperty to modify
- * @param run :: handle to the run object containing the end time.
- */
-void appendEndTimeLog(Kernel::Property *prop, const API::Run &run) {
-  appendEndTimeLog<double>(prop, run);
-  appendEndTimeLog<int>(prop, run);
 }
 
 /**

--- a/Framework/Kernel/inc/MantidKernel/TimeSeriesProperty.h
+++ b/Framework/Kernel/inc/MantidKernel/TimeSeriesProperty.h
@@ -228,6 +228,8 @@ public:
   TYPE minValue() const;
   /// Returns the maximum value found in the series
   TYPE maxValue() const;
+  /// Returns the mean value found in the series
+  double mean() const;
 
   /// Returns the number of values at UNIQUE time intervals in the time series
   int size() const override;

--- a/Framework/Kernel/src/TimeSeriesProperty.cpp
+++ b/Framework/Kernel/src/TimeSeriesProperty.cpp
@@ -1269,6 +1269,12 @@ template <typename TYPE> TYPE TimeSeriesProperty<TYPE>::maxValue() const {
       ->value();
 }
 
+template <typename TYPE> double TimeSeriesProperty<TYPE>::mean() const {
+  Mantid::Kernel::Statistics raw_stats = Mantid::Kernel::getStatistics(
+      this->filteredValuesAsVector(), StatOptions::Mean);
+  return raw_stats.mean;
+}
+
 /// Returns the number of values at UNIQUE time intervals in the time series
 /// @returns The number of unique time interfaces
 template <typename TYPE> int TimeSeriesProperty<TYPE>::size() const {

--- a/Framework/PythonInterface/mantid/api/src/Exports/Run.cpp
+++ b/Framework/PythonInterface/mantid/api/src/Exports/Run.cpp
@@ -9,6 +9,7 @@
 #include "MantidKernel/WarningSuppressions.h"
 #include "MantidPythonInterface/core/Copyable.h"
 #include "MantidPythonInterface/core/GetPointer.h"
+#include "MantidPythonInterface/core/ReleaseGlobalInterpreterLock.h"
 #include "MantidPythonInterface/kernel/Registry/PropertyWithValueFactory.h"
 
 #include <boost/python/class.hpp>
@@ -40,6 +41,12 @@ namespace bpl = boost::python;
  */
 double getPropertyAsSingleValueWithDefaultStatistic(Run &self,
                                                     const std::string &name) {
+  //   Before calling the function we need to release the GIL,
+  //   drop the Python threadstate and reset anything installed
+  //   via PyEval_SetTrace while we execute the C++ code -
+  //   ReleaseGlobalInterpreter does this for us
+  Mantid::PythonInterface::ReleaseGlobalInterpreterLock
+      releaseGlobalInterpreterLock;
   return self.getPropertyAsSingleValue(name);
 }
 

--- a/Framework/Types/src/Core/DateAndTime.cpp
+++ b/Framework/Types/src/Core/DateAndTime.cpp
@@ -672,7 +672,8 @@ DateAndTime &DateAndTime::operator-=(const double sec) {
  * @return a time_duration
  */
 time_duration DateAndTime::operator-(const DateAndTime &rhs) const {
-  return this->to_ptime() - rhs.to_ptime();
+  return durationFromNanoseconds(_nanoseconds) -
+         durationFromNanoseconds(rhs.totalNanoseconds());
 }
 
 //------------------------------------------------------------------------------------------------


### PR DESCRIPTION
**Description of work.**

These changes were motivated by improving the performance of the focus screen in the Engineering Diffraction UI - it writes out some text files containing the average value of any numeric log entries and this was taking several minutes when run in debug before these changes. The UI blocks during this process so the slow run time was giving the appearance of the UI hanging.

Three improvements have been made:
- change to DateAndTime::operator- to avoid unnecessary calls to to_ptime. The function to_ptime calls the operator+ to add a time offset onto the constant GPS_EPOCH. This was done for both arguments to the - operator which was unnecessary. The + operation was quite costly in debug
- change to convertTimeSeriesToDouble for function=Math::Mean. Previously the code was calculating all the metrics (mean, stddev, time averaged means etc) and then just returning the mean. The code now only calculates the mean
- the API call getPropertyAsSingleValue now releases the GIL in the C++ code. This prevents the call blocking the Mantid UI while each log average is being calculated

**To test:**

Run a calibration and a focus action using the instructions and run numbers described on the attached issue. Do this before\after these code changes. You should see a speed up. For me the time spent calculating the sample log averages during the Focus step went down from 6-7 minutes to about 50 seconds. Note - the overall Focus processing time will be longer than this.

The sample log averages are written to a file called ENGINX_307521_sample_logs.csv in ~/Engineering_Mantid/Focus/
You can measure the time taken doing the sample log processing by comparing the datetime stamp of this file to the other files produced in the same folder which are produced immediately before in the engineering diffraction Focus process.

Fixes #28455.

*This does not require release notes* because the problem only existed in the debug build of Mantid that the end users won't ever use

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
