### PR TITLE
Fix Overplotting with Colorfill Plots

### DIFF
--- a/docs/source/release/v5.1.0/mantidworkbench.rst
+++ b/docs/source/release/v5.1.0/mantidworkbench.rst
@@ -37,6 +37,7 @@ Bugfixes
 - The scale of the color bars on colorfill plots of ragged workspaces now uses the maximum and minimum values of the data.
 - Fixed a bug where setting columns to Y error in table workspaces wasn't working. The links between the Y error and Y columns weren't being set up properly
 - Opening figure options on a plot with an empty legend no longer causes an unhandled exception.
-- Fixed being able to zoom in and out of colorbars on colorfill plots. 
+- Fixed being able to zoom in and out of colorbars on colorfill plots.
+- Performing an overplot by dragging workspaces onto colorfill plots now correctly replaces the workspace.
 
 :ref:`Release 5.1.0 <v5.1.0>`

--- a/qt/applications/workbench/workbench/plotting/figurewindow.py
+++ b/qt/applications/workbench/workbench/plotting/figurewindow.py
@@ -126,7 +126,7 @@ class FigureWindow(QMainWindow, ObservingView):
         fig = self._canvas.figure
         fig_type = figure_type(fig, ax)
         if fig_type == FigureType.Image:
-            pcolormesh_from_names(names, fig=fig, ax=ax)
+            pcolormesh_from_names(names, fig=fig)
         else:
             plot_from_names(names, errors=(fig_type == FigureType.Errorbar),
                             overplot=ax, fig=fig)


### PR DESCRIPTION
**Description of work.**
Fixes overplotting by dragging a workspace over a colorfill so that it replaces the existing plot correctly. Originally the figure options would no longer open properly. 

**To test:**
1. Load any two workspaces (I used MAR11060 and MAR11015)
2. Create a colorfill plot of one of the workspaces.
3. Drag the other workspace over the shown colorfill plot, it should be replaced. 
4. Check that any other colorfill functionality works as expected. 

Fixes #28052 

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
