### PR TITLE
Keyboard movement in workbench sample logs gui

### DIFF
--- a/docs/source/release/v5.1.0/mantidworkbench.rst
+++ b/docs/source/release/v5.1.0/mantidworkbench.rst
@@ -26,7 +26,7 @@ Improvements
 - The axes tab in the figure options can now be used to set the limits, label, and scale of the z-axis on 3D plots.
 
 - On 3D plots you can now double-click on the z-axis to change its limits or label.
-
+- The workspace sample logs interface now responds to keyboard input from the cursor keys to move between logs.
 
 Bugfixes
 ########

--- a/qt/python/mantidqt/widgets/samplelogs/presenter.py
+++ b/qt/python/mantidqt/widgets/samplelogs/presenter.py
@@ -24,8 +24,14 @@ class SampleLogs(object):
                                                      self.model.getNumExperimentInfo())
         self.setup_table()
 
-    def clicked(self):
-        """When a log is clicked update stats with selected log and replot the
+    def selectionChanged(self, selected, deselected):
+        """When the selection is changed update stats with selected log and replot the
+                logs
+                """
+        self.update()
+
+    def update(self):
+        """Update stats with selected log and replot the
         logs
         """
         self.update_stats()

--- a/qt/python/mantidqt/widgets/samplelogs/presenter.py
+++ b/qt/python/mantidqt/widgets/samplelogs/presenter.py
@@ -24,12 +24,6 @@ class SampleLogs(object):
                                                      self.model.getNumExperimentInfo())
         self.setup_table()
 
-    def selectionChanged(self, selected, deselected):
-        """When the selection is changed update stats with selected log and replot the
-                logs
-                """
-        self.update()
-
     def update(self):
         """Update stats with selected log and replot the
         logs

--- a/qt/python/mantidqt/widgets/samplelogs/test/test_samplelogs_presenter.py
+++ b/qt/python/mantidqt/widgets/samplelogs/test/test_samplelogs_presenter.py
@@ -72,7 +72,7 @@ class SampleLogsTest(unittest.TestCase):
         self.model.reset_mock()
         self.view.reset_mock()
 
-        presenter.clicked()
+        presenter.update()
         self.assertEqual(self.view.get_selected_row_indexes.call_count, 2)
 
         # plot clicked

--- a/qt/python/mantidqt/widgets/samplelogs/view.py
+++ b/qt/python/mantidqt/widgets/samplelogs/view.py
@@ -16,7 +16,6 @@ from matplotlib.backends.backend_qt5agg import FigureCanvas
 from matplotlib.figure import Figure
 import matplotlib.pyplot as plt
 
-
 class SampleLogsView(QSplitter):
     """Sample Logs View
 
@@ -35,7 +34,6 @@ class SampleLogsView(QSplitter):
         # Create sample log table
         self.table = QTableView()
         self.table.setSelectionBehavior(QAbstractItemView.SelectRows)
-        self.table.clicked.connect(self.presenter.clicked)
         self.table.doubleClicked.connect(self.presenter.doubleClicked)
         self.table.contextMenuEvent = self.tableMenu
         self.addWidget(self.table)
@@ -107,6 +105,7 @@ class SampleLogsView(QSplitter):
         self.table.setModel(self.model)
         self.table.resizeColumnsToContents()
         self.table.horizontalHeader().setSectionResizeMode(2, QHeaderView.Stretch)
+        self.table.selectionModel().selectionChanged.connect(self.presenter.selectionChanged)
 
     def plot_selected_logs(self, ws, exp, rows):
         """Update the plot with the selected rows"""

--- a/qt/python/mantidqt/widgets/samplelogs/view.py
+++ b/qt/python/mantidqt/widgets/samplelogs/view.py
@@ -106,7 +106,7 @@ class SampleLogsView(QSplitter):
         self.table.setModel(self.model)
         self.table.resizeColumnsToContents()
         self.table.horizontalHeader().setSectionResizeMode(2, QHeaderView.Stretch)
-        self.table.selectionModel().selectionChanged.connect(self.presenter.selectionChanged)
+        self.table.selectionModel().selectionChanged.connect(self.presenter.update)
 
     def plot_selected_logs(self, ws, exp, rows):
         """Update the plot with the selected rows"""

--- a/qt/python/mantidqt/widgets/samplelogs/view.py
+++ b/qt/python/mantidqt/widgets/samplelogs/view.py
@@ -16,6 +16,7 @@ from matplotlib.backends.backend_qt5agg import FigureCanvas
 from matplotlib.figure import Figure
 import matplotlib.pyplot as plt
 
+
 class SampleLogsView(QSplitter):
     """Sample Logs View
 


### PR DESCRIPTION
**Description of work.**
Changed the sample logs view to update on selectionChanged rather than just clicked


**To test:**

1. in workbench load a file with some logs
1. Show Sample Logs
1. Check that you can both click on a log and also move between them with the cursor keys and the plot and stats update.
1. check that multiple selection still works.

refs #28569


---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
