### PR TITLE
Fix axis scale settings applying to the wrong axis

### DIFF
--- a/docs/source/release/v5.1.0/mantidworkbench.rst
+++ b/docs/source/release/v5.1.0/mantidworkbench.rst
@@ -37,6 +37,7 @@ Bugfixes
 - The scale of the color bars on colorfill plots of ragged workspaces now uses the maximum and minimum values of the data.
 - Fixed a bug where setting columns to Y error in table workspaces wasn't working. The links between the Y error and Y columns weren't being set up properly
 - Opening figure options on a plot with an empty legend no longer causes an unhandled exception.
-- Fixed being able to zoom in and out of colorbars on colorfill plots. 
+- Fixed being able to zoom in and out of colorbars on colorfill plots.
+- Fixed the default axis scale settings applying to the wrong axis.
 
 :ref:`Release 5.1.0 <v5.1.0>`

--- a/qt/applications/workbench/workbench/widgets/settings/plots/section_plots.ui
+++ b/qt/applications/workbench/workbench/widgets/settings/plots/section_plots.ui
@@ -109,7 +109,7 @@
                </widget>
               </item>
               <item>
-               <widget class="QComboBox" name="y_axes_scale">
+               <widget class="QComboBox" name="x_axes_scale">
                 <property name="sizePolicy">
                  <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
                   <horstretch>0</horstretch>
@@ -139,7 +139,7 @@
                </widget>
               </item>
               <item>
-               <widget class="QComboBox" name="x_axes_scale">
+               <widget class="QComboBox" name="y_axes_scale">
                 <property name="sizePolicy">
                  <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
                   <horstretch>0</horstretch>


### PR DESCRIPTION
**Description of work.**
This PR fixes a bug where changing the default x-axis scale in the settings would change the y-axis and vice versa. 

**To test:**
1. Go to File -> Settings and go to the Plots tab.
2. Change the default x or y axis scale.
3. Load a workspace and make a plot.
4. Check that the axis scales are correct.

Fixes #28470 

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
