### PR TITLE
Fix Colorfill Plots and Filled Lines Not Being Removed When Workspace is Deleted

### DIFF
--- a/Framework/PythonInterface/mantid/plots/datafunctions.py
+++ b/Framework/PythonInterface/mantid/plots/datafunctions.py
@@ -1037,7 +1037,8 @@ def update_colorbar_scale(figure, image, scale, vmin, vmax):
                 locator = LogLocator()
                 mantid.kernel.logger.warning("Minor ticks on colorbar scale cannot be shown "
                                              "as the range between min value and max value is too large")
-        figure.colorbar(image, ticks=locator)
+        figure.subplots_adjust(wspace=0.5, hspace=0.5)
+        figure.colorbar(image, ax=figure.axes, ticks=locator, pad=0.06)
 
 
 def figure_contains_only_3d_plots(fig) -> bool:

--- a/Framework/PythonInterface/mantid/plots/mantidaxes.py
+++ b/Framework/PythonInterface/mantid/plots/mantidaxes.py
@@ -13,8 +13,6 @@ except ImportError:
 import copy
 import numpy as np
 
-from copy import copy
-
 from matplotlib.axes import Axes
 from matplotlib.collections import Collection, PolyCollection
 from matplotlib.colors import Colormap
@@ -309,8 +307,8 @@ class MantidAxes(Axes):
         :param predicate: A unary predicate used to select artists.
         :return: The output of the inner function.
         """
-        waterfall_x_offset = copy(self.waterfall_x_offset)
-        waterfall_y_offset = copy(self.waterfall_y_offset)
+        waterfall_x_offset = copy.copy(self.waterfall_x_offset)
+        waterfall_y_offset = copy.copy(self.waterfall_y_offset)
         has_fills = self.waterfall_has_fill()
 
         self.update_waterfall(0, 0)

--- a/docs/source/release/v5.1.0/mantidworkbench.rst
+++ b/docs/source/release/v5.1.0/mantidworkbench.rst
@@ -41,6 +41,7 @@ Bugfixes
 - Fixed a bug where setting columns to Y error in table workspaces wasn't working. The links between the Y error and Y columns weren't being set up properly
 - Opening figure options on a plot with an empty legend no longer causes an unhandled exception.
 - Fixed being able to zoom in and out of colorbars on colorfill plots.
+- Deleting a workspace now correctly deletes colorfill plots and waterfall plots that have been filled in.
 - Fixed the default axis scale settings applying to the wrong axis.
 - Performing an overplot by dragging workspaces onto colorfill plots now correctly replaces the workspace.
 - Removed gridlines from the colorbar on colorfill plots.

--- a/qt/applications/workbench/workbench/plotting/figuremanager.py
+++ b/qt/applications/workbench/workbench/plotting/figuremanager.py
@@ -98,14 +98,14 @@ class FigureManagerADSObserver(AnalysisDataServiceObserver):
                 to_redraw = ax.remove_workspace_artists(workspace)
             else:
                 to_redraw = False
-            # We check for axes type below as a pseudo check for an axes being
+            # We check for images and lines below as a pseudo check for an axes being
             # a colorbar. Creating a colorfill plot creates 2 axes: one linked
             # to a workspace, the other a colorbar. Deleting the workspace
             # deletes the colorfill, but the plot remains open due to the
             # non-empty colorbar. This solution seems to work for the majority
             # of cases but could lead to unmanaged figures only containing an
             # Axes object being closed.
-            if type(ax) is not Axes:
+            if len(ax.images) != 0 or len(ax.lines) != 0:
                 empty_axes.append(MantidAxes.is_empty(ax))
             redraw = redraw | to_redraw
 

--- a/qt/applications/workbench/workbench/plotting/figuremanager.py
+++ b/qt/applications/workbench/workbench/plotting/figuremanager.py
@@ -96,9 +96,12 @@ class FigureManagerADSObserver(AnalysisDataServiceObserver):
         for ax in all_axes:
             if isinstance(ax, MantidAxes):
                 to_redraw = ax.remove_workspace_artists(workspace)
-                if ax.is_waterfall() and ax.waterfall_has_fill():
-                    datafunctions.waterfall_update_fill(ax)
-
+                if ax.is_waterfall():
+                    if len(ax.lines) == 1:  # Can't have waterfall plots with only one line.
+                        ax.set_waterfall(False)
+                    else:
+                        if ax.waterfall_has_fill():
+                            datafunctions.waterfall_update_fill(ax)
             else:
                 to_redraw = False
             # We check for images and lines below as a pseudo check for an axes being

--- a/qt/applications/workbench/workbench/plotting/figuremanager.py
+++ b/qt/applications/workbench/workbench/plotting/figuremanager.py
@@ -96,6 +96,9 @@ class FigureManagerADSObserver(AnalysisDataServiceObserver):
         for ax in all_axes:
             if isinstance(ax, MantidAxes):
                 to_redraw = ax.remove_workspace_artists(workspace)
+                if ax.is_waterfall() and ax.waterfall_has_fill():
+                    datafunctions.waterfall_update_fill(ax)
+
             else:
                 to_redraw = False
             # We check for images and lines below as a pseudo check for an axes being

--- a/qt/applications/workbench/workbench/plotting/figuremanager.py
+++ b/qt/applications/workbench/workbench/plotting/figuremanager.py
@@ -11,7 +11,6 @@
 import copy
 import sys
 from functools import wraps
-
 import matplotlib
 from matplotlib._pylab_helpers import Gcf
 from matplotlib.axes import Axes
@@ -96,12 +95,6 @@ class FigureManagerADSObserver(AnalysisDataServiceObserver):
         for ax in all_axes:
             if isinstance(ax, MantidAxes):
                 to_redraw = ax.remove_workspace_artists(workspace)
-                if ax.is_waterfall():
-                    if len(ax.lines) == 1:  # Can't have waterfall plots with only one line.
-                        ax.set_waterfall(False)
-                    else:
-                        if ax.waterfall_has_fill():
-                            datafunctions.waterfall_update_fill(ax)
             else:
                 to_redraw = False
             # We check for images and lines below as a pseudo check for an axes being

--- a/qt/applications/workbench/workbench/plotting/figuremanager.py
+++ b/qt/applications/workbench/workbench/plotting/figuremanager.py
@@ -97,14 +97,7 @@ class FigureManagerADSObserver(AnalysisDataServiceObserver):
                 to_redraw = ax.remove_workspace_artists(workspace)
             else:
                 to_redraw = False
-            # We check for images and lines below as a pseudo check for an axes being
-            # a colorbar. Creating a colorfill plot creates 2 axes: one linked
-            # to a workspace, the other a colorbar. Deleting the workspace
-            # deletes the colorfill, but the plot remains open due to the
-            # non-empty colorbar. This solution seems to work for the majority
-            # of cases but could lead to unmanaged figures only containing an
-            # Axes object being closed.
-            if len(ax.images) != 0 or len(ax.lines) != 0:
+            if type(ax) is not Axes:  # Solution for filtering out colorbar axes. Works most of the time.
                 empty_axes.append(MantidAxes.is_empty(ax))
             redraw = redraw | to_redraw
 

--- a/qt/python/mantidqt/widgets/plotconfigdialog/curvestabwidget/presenter.py
+++ b/qt/python/mantidqt/widgets/plotconfigdialog/curvestabwidget/presenter.py
@@ -6,7 +6,6 @@
 # SPDX - License - Identifier: GPL - 3.0 +
 #  This file is part of the mantid workbench.
 
-from matplotlib.collections import PolyCollection
 from matplotlib.lines import Line2D
 
 from mantid.plots.legend import LegendProperties
@@ -187,35 +186,10 @@ class CurvesTabWidgetPresenter:
         if ax.legend_:
             self.legend_props = LegendProperties.from_legend(ax.legend_)
 
-        waterfall = False
-        if isinstance(ax, MantidAxes):
-            waterfall = ax.is_waterfall()
-
-        if waterfall:
-            # Waterfall plots are reset so they can be reconverted after the curve is removed.
-            x, y = ax.waterfall_x_offset, ax.waterfall_y_offset
-            ax.update_waterfall(0, 0)
-
-            # If the curves have a fill, the one which corresponds to the curve being removed also needs to be removed.
-            current_curve_index = self.view.select_curve_combo_box.currentIndex()
-            i = 0
-            for collection in ax.collections:
-                if isinstance(collection, PolyCollection):
-                    if current_curve_index == i:
-                        ax.collections.remove(collection)
-                        break
-                    i = i + 1
-
         # Remove curve from ax and remove from curve names dictionary
         remove_curve_from_ax(self.get_selected_curve())
         self.curve_names_dict.pop(self.view.get_selected_curve_name())
         self.set_apply_to_all_buttons_enabled()
-
-        # If there is now only one curve on a waterfall plot, the plot becomes non-waterfall.
-        if waterfall:
-            ax.update_waterfall(x, y)
-            if len(ax.get_lines()) <= 1:
-                ax.set_waterfall(False)
 
         ax = self.get_selected_ax()
         # Update the legend and redraw


### PR DESCRIPTION
**Description of work.**
- Fixed Colorfill and filled waterfall plots not being removed when the last workspace is deleted.
- FIxed fills staying on the plot when one of the workpaces used to make the plot is deleted. 

**To test:**
Colorfills:
1. Create a colorfill plot.
2. Double click the scale and change it. 
3. Delete the workspace used to make the colorfill. 
4. The colorfill plot window should disappear as it is deleted. 

Filled Waterfall:
1. Start with two workspaces
2. Plot one workspace with a waterfall.
3. Overplot with the other workspace. 
4. Click the paint bucket and enable fill on the plot.
5. Delete one of the workspaces.
6. The lines and fills from that workspace should be removed. 
7. Delete the other workspace.
8. The plot should be closed. 

Fixes #28251

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
