### PR TITLE
Stop surface plots spilling out of the axes when axis limits are changed

### DIFF
--- a/Framework/PythonInterface/mantid/plots/mantidaxes.py
+++ b/Framework/PythonInterface/mantid/plots/mantidaxes.py
@@ -10,6 +10,8 @@ try:
 except ImportError:
    # check Python 2 location
    from collections import Iterable
+import copy
+import numpy as np
 
 from matplotlib.axes import Axes
 from matplotlib.collections import Collection, PolyCollection
@@ -1133,31 +1135,31 @@ class MantidAxes3D(Axes3D):
         self.figure.canvas.mpl_disconnect(self._cids[1])
 
     def set_xlim3d(self, *args):
-        import numpy as np
         min, max = super().set_xlim3d(*args)
 
-        x = self.original_data[0].copy()
-        x[np.less(x, min, where=~np.isnan(x))] = np.nan
-        x[np.greater(x, max, where=~np.isnan(x))] = np.nan
-        self.collections[0]._vec[0] = x
+        if hasattr(self, 'original_data'):
+            x = self.original_data[0].copy()
+            x[np.less(x, min, where=~np.isnan(x))] = np.nan
+            x[np.greater(x, max, where=~np.isnan(x))] = np.nan
+            self.collections[0]._vec[0] = x
 
     def set_ylim3d(self, *args):
-        import numpy as np
         min, max = super().set_ylim3d(*args)
 
-        y = self.original_data[1].copy()
-        y[np.less(y, min, where=~np.isnan(y))] = np.nan
-        y[np.greater(y, max, where=~np.isnan(y))] = np.nan
-        self.collections[0]._vec[1] = y
+        if hasattr(self, 'original_data'):
+            y = self.original_data[1].copy()
+            y[np.less(y, min, where=~np.isnan(y))] = np.nan
+            y[np.greater(y, max, where=~np.isnan(y))] = np.nan
+            self.collections[0]._vec[1] = y
 
     def set_zlim3d(self, *args):
-        import numpy as np
         min, max = super().set_zlim3d(*args)
 
-        z = self.original_data[2].copy()
-        z[np.less(z, min, where=~np.isnan(z))] = np.nan
-        z[np.greater(z, max, where=~np.isnan(z))] = np.nan
-        self.collections[0]._vec[2] = z
+        if hasattr(self, 'original_data'):
+            z = self.original_data[2].copy()
+            z[np.less(z, min, where=~np.isnan(z))] = np.nan
+            z[np.greater(z, max, where=~np.isnan(z))] = np.nan
+            self.collections[0]._vec[2] = z
 
     def plot(self, *args, **kwargs):
         """
@@ -1255,9 +1257,14 @@ class MantidAxes3D(Axes3D):
         """
         if datafunctions.validate_args(*args):
             logger.debug('using plotfunctions3D')
-            return axesfunctions3D.plot_surface(self, *args, **kwargs)
+            polyc = axesfunctions3D.plot_surface(self, *args, **kwargs)
         else:
-            return Axes3D.plot_surface(self, *args, **kwargs)
+            polyc = Axes3D.plot_surface(self, *args, **kwargs)
+
+        # Create a copy of the original data points because data are set to nan when the axis limits are changed.
+        self.original_data = copy.deepcopy(polyc._vec)
+
+        return polyc
 
     def contour(self, *args, **kwargs):
         """

--- a/Framework/PythonInterface/mantid/plots/mantidaxes.py
+++ b/Framework/PythonInterface/mantid/plots/mantidaxes.py
@@ -1137,8 +1137,8 @@ class MantidAxes3D(Axes3D):
         min, max = super().set_xlim3d(*args)
 
         x = self.original_data[0].copy()
-        x[x < min] = np.nan
-        x[x > max] = np.nan
+        x[np.less(x, min, where=~np.isnan(x))] = np.nan
+        x[np.greater(x, max, where=~np.isnan(x))] = np.nan
         self.collections[0]._vec[0] = x
 
     def set_ylim3d(self, *args):
@@ -1146,8 +1146,8 @@ class MantidAxes3D(Axes3D):
         min, max = super().set_ylim3d(*args)
 
         y = self.original_data[1].copy()
-        y[y < min] = np.nan
-        y[y > max] = np.nan
+        y[np.less(y, min, where=~np.isnan(y))] = np.nan
+        y[np.greater(y, max, where=~np.isnan(y))] = np.nan
         self.collections[0]._vec[1] = y
 
     def set_zlim3d(self, *args):
@@ -1155,8 +1155,8 @@ class MantidAxes3D(Axes3D):
         min, max = super().set_zlim3d(*args)
 
         z = self.original_data[2].copy()
-        z[z < min] = np.nan
-        z[z > max] = np.nan
+        z[np.less(z, min, where=~np.isnan(z))] = np.nan
+        z[np.greater(z, max, where=~np.isnan(z))] = np.nan
         self.collections[0]._vec[2] = z
 
     def plot(self, *args, **kwargs):

--- a/Framework/PythonInterface/mantid/plots/mantidaxes.py
+++ b/Framework/PythonInterface/mantid/plots/mantidaxes.py
@@ -1137,29 +1137,31 @@ class MantidAxes3D(Axes3D):
     def set_xlim3d(self, *args):
         min, max = super().set_xlim3d(*args)
 
-        if hasattr(self, 'original_data'):
-            x = self.original_data[0].copy()
-            x[np.less(x, min, where=~np.isnan(x))] = np.nan
-            x[np.greater(x, max, where=~np.isnan(x))] = np.nan
-            self.collections[0]._vec[0] = x
+        self._set_overflowing_data_to_nan(min, max, 0)
 
     def set_ylim3d(self, *args):
         min, max = super().set_ylim3d(*args)
 
-        if hasattr(self, 'original_data'):
-            y = self.original_data[1].copy()
-            y[np.less(y, min, where=~np.isnan(y))] = np.nan
-            y[np.greater(y, max, where=~np.isnan(y))] = np.nan
-            self.collections[0]._vec[1] = y
+        self._set_overflowing_data_to_nan(min, max, 1)
 
     def set_zlim3d(self, *args):
         min, max = super().set_zlim3d(*args)
 
+        self._set_overflowing_data_to_nan(min, max, 2)
+
+    def _set_overflowing_data_to_nan(self, min, max, axis_index):
+        """
+        Sets any data for the given axis that is less than min or greater than max to nan so only the parts of the plot
+        that are within the axes are visible.
+        :param min: the lower axis limit.
+        :param max: the upper axis limit.
+        :param axis_index: the index of the axis being edited, 0 for x, 1 for y, 2 for z.
+        """
         if hasattr(self, 'original_data'):
-            z = self.original_data[2].copy()
-            z[np.less(z, min, where=~np.isnan(z))] = np.nan
-            z[np.greater(z, max, where=~np.isnan(z))] = np.nan
-            self.collections[0]._vec[2] = z
+            axis_data = self.original_data[axis_index].copy()
+            axis_data[np.less(axis_data, min, where=~np.isnan(axis_data))] = np.nan
+            axis_data[np.greater(axis_data, max, where=~np.isnan(axis_data))] = np.nan
+            self.collections[0]._vec[axis_index] = axis_data
 
     def plot(self, *args, **kwargs):
         """

--- a/Framework/PythonInterface/mantid/plots/mantidaxes.py
+++ b/Framework/PythonInterface/mantid/plots/mantidaxes.py
@@ -1132,6 +1132,33 @@ class MantidAxes3D(Axes3D):
         # it interfering with double-clicking on the axes.
         self.figure.canvas.mpl_disconnect(self._cids[1])
 
+    def set_xlim3d(self, *args):
+        import numpy as np
+        min, max = super().set_xlim3d(*args)
+
+        x = self.original_data[0].copy()
+        x[x < min] = np.nan
+        x[x > max] = np.nan
+        self.collections[0]._vec[0] = x
+
+    def set_ylim3d(self, *args):
+        import numpy as np
+        min, max = super().set_ylim3d(*args)
+
+        y = self.original_data[1].copy()
+        y[y < min] = np.nan
+        y[y > max] = np.nan
+        self.collections[0]._vec[1] = y
+
+    def set_zlim3d(self, *args):
+        import numpy as np
+        min, max = super().set_zlim3d(*args)
+
+        z = self.original_data[2].copy()
+        z[z < min] = np.nan
+        z[z > max] = np.nan
+        self.collections[0]._vec[2] = z
+
     def plot(self, *args, **kwargs):
         """
         If the **mantid3d** projection is chosen, it can be

--- a/docs/source/release/v5.1.0/mantidworkbench.rst
+++ b/docs/source/release/v5.1.0/mantidworkbench.rst
@@ -29,6 +29,8 @@ Improvements
 - On 3D plots you can now double-click on the z-axis to change its limits or label.
 - The workspace sample logs interface now responds to keyboard input from the cursor keys to move between logs.
 
+- Surface plots no longer spill over the axes when their limits are reduced.
+
 Bugfixes
 ########
 

--- a/qt/applications/workbench/workbench/plotting/figuremanager.py
+++ b/qt/applications/workbench/workbench/plotting/figuremanager.py
@@ -8,6 +8,7 @@
 #
 #
 """Provides our custom figure manager to wrap the canvas, window and our custom toolbar"""
+import copy
 import sys
 from functools import wraps
 
@@ -428,8 +429,10 @@ class FigureManagerWorkbench(FigureManagerBase, QObject):
                     if ax.lines:  # Relim causes issues with colour plots, which have no lines.
                         ax.relim()
                     elif isinstance(ax, Axes3D):
-                        import copy
-                        ax.collections[0]._vec = copy.deepcopy(ax.original_data)
+                        if hasattr(ax, 'original_data'):
+                            ax.collections[0]._vec = copy.deepcopy(ax.original_data)
+                        else:
+                            ax.view_init()
 
                     ax.autoscale()
 

--- a/qt/applications/workbench/workbench/plotting/figuremanager.py
+++ b/qt/applications/workbench/workbench/plotting/figuremanager.py
@@ -428,7 +428,9 @@ class FigureManagerWorkbench(FigureManagerBase, QObject):
                     if ax.lines:  # Relim causes issues with colour plots, which have no lines.
                         ax.relim()
                     elif isinstance(ax, Axes3D):
-                        ax.view_init()
+                        import copy
+                        ax.collections[0]._vec = copy.deepcopy(ax.original_data)
+
                     ax.autoscale()
 
             self.canvas.draw()

--- a/qt/applications/workbench/workbench/plotting/propertiesdialog.py
+++ b/qt/applications/workbench/workbench/plotting/propertiesdialog.py
@@ -16,6 +16,7 @@ from mantidqt.utils.qt import load_ui
 from matplotlib.collections import QuadMesh
 from matplotlib.colors import LogNorm, Normalize
 from mpl_toolkits.mplot3d.art3d import Poly3DCollection
+from mpl_toolkits.mplot3d.axes3d import Axes3D
 from qtpy.QtGui import QDoubleValidator, QIcon
 from qtpy.QtWidgets import QDialog, QWidget
 
@@ -121,8 +122,6 @@ class AxisEditor(PropertiesEditorBase):
         self.axes = axes
         self.axis_id = axis_id
         self.lim_getter = getattr(axes, 'get_{}lim'.format(axis_id))
-
-        from mpl_toolkits.mplot3d.axes3d import Axes3D
 
         if isinstance(axes, Axes3D):
             self.lim_setter = getattr(axes, 'set_{}lim3d'.format(axis_id))

--- a/qt/applications/workbench/workbench/plotting/propertiesdialog.py
+++ b/qt/applications/workbench/workbench/plotting/propertiesdialog.py
@@ -121,7 +121,14 @@ class AxisEditor(PropertiesEditorBase):
         self.axes = axes
         self.axis_id = axis_id
         self.lim_getter = getattr(axes, 'get_{}lim'.format(axis_id))
-        self.lim_setter = getattr(axes, 'set_{}lim'.format(axis_id))
+
+        from mpl_toolkits.mplot3d.axes3d import Axes3D
+
+        if isinstance(axes, Axes3D):
+            self.lim_setter = getattr(axes, 'set_{}lim3d'.format(axis_id))
+        else:
+            self.lim_setter = getattr(axes, 'set_{}lim'.format(axis_id))
+
         self.scale_setter = getattr(axes, 'set_{}scale'.format(axis_id))
         self.nonposkw = 'nonpos' + axis_id
         # Grid has no direct accessor from the axes

--- a/qt/python/mantidqt/widgets/plotconfigdialog/axestabwidget/presenter.py
+++ b/qt/python/mantidqt/widgets/plotconfigdialog/axestabwidget/presenter.py
@@ -6,6 +6,8 @@
 # SPDX - License - Identifier: GPL - 3.0 +
 #  This file is part of the mantid workbench.
 
+from mpl_toolkits.mplot3d.axes3d import Axes3D
+
 from mantidqt.widgets.plotconfigdialog import generate_ax_name, get_axes_names_dict
 from mantidqt.widgets.plotconfigdialog.axestabwidget import AxProperties
 from mantidqt.widgets.plotconfigdialog.axestabwidget.view import AxesTabWidgetView
@@ -52,17 +54,25 @@ class AxesTabWidgetPresenter:
         if "xlabel" in self.current_view_props:
             ax.set_xlabel(self.current_view_props['xlabel'])
             ax.set_xscale(self.current_view_props['xscale'])
-            ax.set_xlim(self.current_view_props['xlim'])
+
+            if isinstance(ax, Axes3D):
+                ax.set_xlim3d(self.current_view_props['xlim'])
+            else:
+                ax.set_xlim(self.current_view_props['xlim'])
 
         if "ylabel" in self.current_view_props:
             ax.set_ylabel(self.current_view_props['ylabel'])
             ax.set_yscale(self.current_view_props['yscale'])
-            ax.set_ylim(self.current_view_props['ylim'])
+
+            if isinstance(ax, Axes3D):
+                ax.set_ylim3d(self.current_view_props['ylim'])
+            else:
+                ax.set_ylim(self.current_view_props['ylim'])
 
         if "zlabel" in self.current_view_props:
             ax.set_zlabel(self.current_view_props['zlabel'])
             ax.set_zscale(self.current_view_props['zscale'])
-            ax.set_zlim(self.current_view_props['zlim'])
+            ax.set_zlim3d(self.current_view_props['zlim'])
 
         self.update_view()
 


### PR DESCRIPTION
**Description of work.**
Previously if the axis limits on a surface plot were reduced, the entire plot was still drawn and it would overflow out of the axes. This PR makes it so that only the parts of the plot that are within the axes limits are drawn.

**To test:**
```
from mantid.simpleapi import *
import matplotlib.pyplot as plt

EMU00020884 = Load('EMU00020884.nxs')
ws = mtd['EMU00020884']

fig, ax = plt.subplots(subplot_kw={'projection':'mantid3d'})
ax.plot_surface(ws)

fig.show()
```
Change the axis limits by double-clicking on the axes and using the figure options. Compare with master and see that only the parts of the plot that are within the axes limits are shown. Clicking the Home button should still show the whole plot.

Refs #28534 

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
