### PR TITLE
Allow extracted sample log plots to be converted to python script

### DIFF
--- a/Framework/PythonInterface/mantid/plots/mantidaxes.py
+++ b/Framework/PythonInterface/mantid/plots/mantidaxes.py
@@ -199,6 +199,18 @@ class MantidAxes(Axes):
                         return ads.retrieve(ws_name), ws_artists.spec_num
         raise ValueError("Artist: '{}' not tracked by axes.".format(artist))
 
+    def get_artists_sample_log_plot_details(self, artist):
+        """Retrieve the sample log plot details of the given artist"""
+        for ws_name, ws_artists_list in self.tracked_workspaces.items():
+            for ws_artists in ws_artists_list:
+                for ws_artist in ws_artists._artists:
+                    if artist == ws_artist:
+                        if ws_artists.log_name is not None:
+                            return (ws_artists.log_name, ws_artists.filtered, ws_artists.expt_info_index)
+                        else:
+                            return None
+        raise ValueError("Artist: '{}' not tracked by axes.".format(artist))
+
     def get_artist_normalization_state(self, artist):
         for ws_name, ws_artists_list in self.tracked_workspaces.items():
             for ws_artists in ws_artists_list:
@@ -212,7 +224,10 @@ class MantidAxes(Axes):
                                data_replace_cb=None,
                                spec_num=None,
                                is_normalized=None,
-                               is_spec=True):
+                               is_spec=True,
+                               log_name=None,
+                               filtered=True,
+                               expt_info_index=None):
         """
         Add the given workspace's name to the list of workspaces
         displayed on this Axes instance
@@ -225,6 +240,11 @@ class MantidAxes(Axes):
             This can be from either a distribution workspace or a workspace being
             plotted as a distribution
         :param is_spec: bool. True if spec_num represents a spectrum, and False if it is a bin index
+        :param log_name: string. The name of the plotted log, the
+        :param filtered: bool. True if log plotted was filtered, and False if unfiltered.
+            This only has meaning if log_name is not None.
+        :param expt_info_index: Integer. The index of the experiment info for this plotted log.
+            This only has meaning if log_name is not None.
         :returns: The artists variable as it was passed in.
         """
         name = workspace.name()
@@ -238,7 +258,8 @@ class MantidAxes(Axes):
             artist_info = self.tracked_workspaces.setdefault(name, [])
 
             artist_info.append(
-                _WorkspaceArtists(artists, data_replace_cb, is_normalized, name, spec_num, is_spec))
+                _WorkspaceArtists(artists, data_replace_cb, is_normalized, name, spec_num, is_spec,
+                                  log_name, filtered, expt_info_index))
             self.check_axes_distribution_consistency()
         return artists
 
@@ -548,7 +569,10 @@ class MantidAxes(Axes):
                                                      axesfunctions.plot(self, normalize_by_bin_width = is_normalized,
                                                                         *args, **kwargs),
                                                      _data_update, spec_num, is_normalized,
-                                                     MantidAxes.is_axis_of_type(MantidAxType.SPECTRUM, kwargs))
+                                                     MantidAxes.is_axis_of_type(MantidAxType.SPECTRUM, kwargs),
+                                                     kwargs.get('LogName', None),
+                                                     kwargs.get('Filtered', None),
+                                                     kwargs.get('ExperimentInfo', None))
             return artist
         else:
             return Axes.plot(self, *args, **kwargs)
@@ -1294,7 +1318,10 @@ class _WorkspaceArtists(object):
                  is_normalized,
                  workspace_name=None,
                  spec_num=None,
-                 is_spec=True):
+                 is_spec=True,
+                 log_name=None,
+                 filtered=True,
+                 expt_info_index=None):
         """
         Initialize an instance
         :param artists: A reference to a list of artists "attached" to a workspace
@@ -1303,6 +1330,11 @@ class _WorkspaceArtists(object):
         :param workspace_name: String. The name of the associated workspace
         :param spec_num: The spectrum number of the spectrum used to plot the artist
         :param is_spec: True if spec_num represents a spectrum rather than a bin
+        :param log_name: string. The name of the plotted log, the
+        :param filtered: bool. True if log plotted was filtered, and False if unfiltered.
+            This only has meaning if log_name is not None.
+        :param expt_info_index: Integer. The index of the experiment info for this plotted log.
+            This only has meaning if log_name is not None.
         """
         self._set_artists(artists)
         self._data_replace_cb = data_replace_cb
@@ -1311,6 +1343,9 @@ class _WorkspaceArtists(object):
         self.is_spec = is_spec
         self.workspace_index = self._get_workspace_index()
         self.is_normalized = is_normalized
+        self.log_name = log_name
+        self.filtered = filtered
+        self.expt_info_index = expt_info_index
 
     def _get_workspace_index(self):
         """Get the workspace index (spectrum or bin index) of the workspace artist"""

--- a/docs/source/release/v5.1.0/mantidworkbench.rst
+++ b/docs/source/release/v5.1.0/mantidworkbench.rst
@@ -26,6 +26,7 @@ Improvements
 - The axes tab in the figure options can now be used to set the limits, label, and scale of the z-axis on 3D plots.
 - The plot toolbar now shows the correct buttons for 3D plots.
 - On 3D plots you can now double-click on the z-axis to change its limits or label.
+- Plots extracted from "Show Sample Logs" by double clicking the plot can now be converted to a python script, just like other workbnehc plots.
 - The workspace sample logs interface now responds to keyboard input from the cursor keys to move between logs.
 
 Bugfixes

--- a/qt/applications/workbench/workbench/plotting/plotscriptgenerator/lines.py
+++ b/qt/applications/workbench/workbench/plotting/plotscriptgenerator/lines.py
@@ -144,4 +144,3 @@ def _get_mantid_specific_plot_kwargs(artist):
         if sample_log_plot_details[2] is not None:
             sample_log_details_map['ExperimentInfo'] = sample_log_plot_details[2]
         return sample_log_details_map
-

--- a/qt/applications/workbench/workbench/plotting/plotscriptgenerator/lines.py
+++ b/qt/applications/workbench/workbench/plotting/plotscriptgenerator/lines.py
@@ -131,7 +131,17 @@ def _get_mantid_specific_plot_kwargs(artist):
     ax = get_ax_from_curve(artist)
     if artist not in ax.get_tracked_artists():
         return dict()
-    return {
-        'specNum': ax.get_artists_workspace_and_spec_num(artist)[1],
-        'distribution': not ax.get_artist_normalization_state(artist)
-    }
+    sample_log_plot_details = ax.get_artists_sample_log_plot_details(artist)
+    if sample_log_plot_details is None:
+        return {
+            'specNum': ax.get_artists_workspace_and_spec_num(artist)[1],
+            'distribution': not ax.get_artist_normalization_state(artist)
+        }
+    else:
+        sample_log_details_map =  {'LogName': sample_log_plot_details[0]}
+        if sample_log_plot_details[1] is not None:
+            sample_log_details_map['Filtered'] = sample_log_plot_details[1]
+        if sample_log_plot_details[2] is not None:
+            sample_log_details_map['ExperimentInfo'] = sample_log_plot_details[2]
+        return sample_log_details_map
+

--- a/qt/applications/workbench/workbench/plotting/plotscriptgenerator/test/test_plotscriptgeneratorlines.py
+++ b/qt/applications/workbench/workbench/plotting/plotscriptgenerator/test/test_plotscriptgeneratorlines.py
@@ -100,6 +100,7 @@ class PlotScriptGeneratorLinesTest(unittest.TestCase):
         output = generate_plot_command(line)
         expected_command = ("plot({}, {})".format(self.test_ws.name(),
                                                   convert_args_to_string(None, kwargs)))
+        self.maxDiff = None
         self.assertEqual(expected_command, output)
 
     def test_get_errorbar_specific_plot_kwargs_returns_dict_with_correct_properties(self):

--- a/qt/applications/workbench/workbench/plotting/plotscriptgenerator/test/test_plotscriptgeneratorlines.py
+++ b/qt/applications/workbench/workbench/plotting/plotscriptgenerator/test/test_plotscriptgeneratorlines.py
@@ -91,7 +91,7 @@ class PlotScriptGeneratorLinesTest(unittest.TestCase):
 
     def test_generate_plot_command_returns_correct_string_for_sample_log(self):
         kwargs = copy(LINE2D_KWARGS)
-        kwargs.update({"LogName":"my_log","ExptInfo":0})
+        kwargs.update({"LogName":"my_log","ExperimentInfo":0})
         # add a log
         AddTimeSeriesLog(self.test_ws, Name="my_log", Time="2010-01-01T00:00:00", Value=100)
         AddTimeSeriesLog(self.test_ws, Name="my_log", Time="2010-01-01T00:30:00", Value=15)

--- a/qt/applications/workbench/workbench/plotting/plotscriptgenerator/test/test_plotscriptgeneratorlines.py
+++ b/qt/applications/workbench/workbench/plotting/plotscriptgenerator/test/test_plotscriptgeneratorlines.py
@@ -92,7 +92,7 @@ class PlotScriptGeneratorLinesTest(unittest.TestCase):
     def test_generate_plot_command_returns_correct_string_for_sample_log(self):
         kwargs = copy(LINE2D_KWARGS)
         kwargs["drawstyle"] = 'steps-post'
-        kwargs.update({"LogName":"my_log","ExperimentInfo":0,"Filtered"=True})
+        kwargs.update({"LogName":"my_log","ExperimentInfo":0,"Filtered":True})
         # add a log
         AddTimeSeriesLog(self.test_ws, Name="my_log", Time="2010-01-01T00:00:00", Value=100)
         AddTimeSeriesLog(self.test_ws, Name="my_log", Time="2010-01-01T00:30:00", Value=15)

--- a/qt/applications/workbench/workbench/plotting/plotscriptgenerator/test/test_plotscriptgeneratorlines.py
+++ b/qt/applications/workbench/workbench/plotting/plotscriptgenerator/test/test_plotscriptgeneratorlines.py
@@ -91,7 +91,8 @@ class PlotScriptGeneratorLinesTest(unittest.TestCase):
 
     def test_generate_plot_command_returns_correct_string_for_sample_log(self):
         kwargs = copy(LINE2D_KWARGS)
-        kwargs.update({"LogName":"my_log","ExperimentInfo":0})
+        kwargs["drawstyle"] = 'steps-post'
+        kwargs.update({"LogName":"my_log","ExperimentInfo":0,"Filtered"=True})
         # add a log
         AddTimeSeriesLog(self.test_ws, Name="my_log", Time="2010-01-01T00:00:00", Value=100)
         AddTimeSeriesLog(self.test_ws, Name="my_log", Time="2010-01-01T00:30:00", Value=15)

--- a/qt/applications/workbench/workbench/plotting/plotscriptgenerator/test/test_plotscriptgeneratorlines.py
+++ b/qt/applications/workbench/workbench/plotting/plotscriptgenerator/test/test_plotscriptgeneratorlines.py
@@ -15,7 +15,7 @@ from copy import copy
 from matplotlib.container import ErrorbarContainer
 
 from unittest.mock import Mock, patch
-from mantid.simpleapi import CreateWorkspace
+from mantid.simpleapi import CreateWorkspace, AddTimeSeriesLog
 from workbench.plotting.plotscriptgenerator.lines import (_get_plot_command_kwargs_from_line2d,
                                                           _get_errorbar_specific_plot_kwargs,
                                                           generate_plot_command,
@@ -83,6 +83,19 @@ class PlotScriptGeneratorLinesTest(unittest.TestCase):
     def test_generate_plot_command_returns_correct_string_for_line2d(self):
         kwargs = copy(LINE2D_KWARGS)
         kwargs.update(MANTID_ONLY_KWARGS)
+        line = self.ax.plot(self.test_ws, **kwargs)[0]
+        output = generate_plot_command(line)
+        expected_command = ("plot({}, {})".format(self.test_ws.name(),
+                                                  convert_args_to_string(None, kwargs)))
+        self.assertEqual(expected_command, output)
+
+    def test_generate_plot_command_returns_correct_string_for_sample_log(self):
+        kwargs = copy(LINE2D_KWARGS)
+        kwargs.update({"LogName":"my_log","ExptInfo":0})
+        # add a log
+        AddTimeSeriesLog(self.test_ws, Name="my_log", Time="2010-01-01T00:00:00", Value=100)
+        AddTimeSeriesLog(self.test_ws, Name="my_log", Time="2010-01-01T00:30:00", Value=15)
+        AddTimeSeriesLog(self.test_ws, Name="my_log", Time="2010-01-01T00:50:00", Value=100.2)
         line = self.ax.plot(self.test_ws, **kwargs)[0]
         output = generate_plot_command(line)
         expected_command = ("plot({}, {})".format(self.test_ws.name(),


### PR DESCRIPTION
**Description of work.**

This involves storing the sample log plotting details, and extracting them like other args while building the script.

**To test:**

1. Open Workbench load a file with some logs ``` ts_logs = Load("ENGINX00228061")```
1. Workspace->show sample logs
1. pick a log with a plot you would recognize (w has a square wave pattern)
1. Double click on the plot to open it externally
1. on the created plot click the Script icon (don't click the cog or right click as this will crash - that is a different issue)
1. Paste the script into a python window and execute it to check it recreates the same plot.
1. Now check that other plot types that could be scripted still work.

Fixes #28635



---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
