### PR TITLE
fix importing string values from log parameters (no ticket)

### DIFF
--- a/Framework/DataHandling/inc/MantidDataHandling/LoadBBY.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/LoadBBY.h
@@ -75,9 +75,11 @@ private:
   void createInstrument(ANSTO::Tar::File &tarFile,
                         InstrumentInfo &instrumentInfo,
                         std::map<std::string, double> &logParams,
+                        std::map<std::string, std::string> &logStrings,
                         std::map<std::string, std::string> &allParams);
   void loadInstrumentParameters(NeXus::NXEntry &entry,
                                 std::map<std::string, double> &logParams,
+                                std::map<std::string, std::string> &logStrings,
                                 std::map<std::string, std::string> &allParams);
 
   // load nx dataset

--- a/Framework/DataHandling/src/LoadBBY.cpp
+++ b/Framework/DataHandling/src/LoadBBY.cpp
@@ -498,7 +498,7 @@ void LoadBBY::loadInstrumentParameters(
       try {
         auto stag = boost::algorithm::trim_copy(tag);
         size_t sz = 0;
-        auto value = std::stod(stag, &sz);
+        std::stod(stag, &sz);
         return sz > 0 && stag.size() == sz;
       } catch (const std::invalid_argument &) {
         return false;

--- a/Framework/DataHandling/src/LoadBBY.cpp
+++ b/Framework/DataHandling/src/LoadBBY.cpp
@@ -498,8 +498,8 @@ void LoadBBY::loadInstrumentParameters(
       try {
         auto stag = boost::algorithm::trim_copy(tag);
         size_t sz = 0;
-        std::stod(stag, &sz);
-        return sz > 0 && stag.size() == sz;
+        auto value = std::stod(stag, &sz);
+        return sz > 0 && stag.size() == sz && isfinite(value);
       } catch (const std::invalid_argument &) {
         return false;
       }

--- a/Framework/DataHandling/src/LoadBBY.cpp
+++ b/Framework/DataHandling/src/LoadBBY.cpp
@@ -545,8 +545,8 @@ void LoadBBY::loadInstrumentParameters(
             else
               logStrings[logTag] = details[2];
             if (!hdfTag.empty())
-              g_log.warning() << "Cannot find hdf parameter "
-                              << hdfTag << ", using default.\n";
+              g_log.warning() << "Cannot find hdf parameter " << hdfTag
+                              << ", using default.\n";
           }
         } catch (std::invalid_argument &) {
           g_log.warning() << "Invalid format for BILBY parameter " << x.first

--- a/Framework/DataHandling/src/LoadBBY.cpp
+++ b/Framework/DataHandling/src/LoadBBY.cpp
@@ -522,7 +522,7 @@ void LoadBBY::loadInstrumentParameters(
         }
         auto hdfTag = boost::algorithm::trim_copy(details[0]);
         try {
-          // extract the parameter and add it to the parameter dictionary
+          // extract the parameter and add it to the parameter dictionary,
           // check the default for value numeric and string
           auto updateOk = false;
           if (!hdfTag.empty()) {

--- a/Framework/DataHandling/src/LoadBBY.cpp
+++ b/Framework/DataHandling/src/LoadBBY.cpp
@@ -532,11 +532,9 @@ void LoadBBY::loadInstrumentParameters(
                 logParams[logTag] = factor * tmpFloat;
                 updateOk = true;
               }
-            } else {
-              if (loadNXString(entry, hdfTag, tmpString)) {
-                logStrings[logTag] = tmpString;
-                updateOk = true;
-              }
+            } else if (loadNXString(entry, hdfTag, tmpString)) {
+              logStrings[logTag] = tmpString;
+              updateOk = true;
             }
           }
           if (!updateOk) {
@@ -548,7 +546,7 @@ void LoadBBY::loadInstrumentParameters(
               g_log.warning() << "Cannot find hdf parameter " << hdfTag
                               << ", using default.\n";
           }
-        } catch (std::invalid_argument &) {
+        } catch (const std::invalid_argument &) {
           g_log.warning() << "Invalid format for BILBY parameter " << x.first
                           << std::endl;
         }

--- a/Framework/DataHandling/test/LoadBBYTest.h
+++ b/Framework/DataHandling/test/LoadBBYTest.h
@@ -83,6 +83,10 @@ public:
     TS_ASSERT_DELTA(run.getPropertyValueAsType<double>("bm_counts"), 0.0800,
                     1.0e-5);
 
+    // test string log properties
+    TS_ASSERT(run.getProperty("rough_40")->value().compare("moving") == 0);
+    TS_ASSERT(run.getProperty("rough_100")->value().compare("moving") == 0);
+
     // test instrument setup
     TS_ASSERT_DELTA(dynamic_cast<TimeSeriesProperty<double> *>(
                         run.getProperty("L1_chopper_value"))

--- a/instrument/BILBY_Parameters.xml
+++ b/instrument/BILBY_Parameters.xml
@@ -13,10 +13,9 @@
 
 	<!-- following parameters are saved to the run log,
 	     parameters are entered as log_[log_name] and the 
-	     and the value is: "hdf_tag,scale[,def_value]"
-       if the default value is not included and the
-       parameter is not in the hdf file no log value is
-       recorded-->
+	     and the value is: "hdf_tag,scale,def_value"
+		the default value determines if the value is
+		interpreted as a numeric or string-->
     <parameter name="log_sample_aperture" type="string">
       <value val="sample/sample_aperture, 1.0, 0.0"/>
     </parameter>		 
@@ -52,9 +51,8 @@
     <parameter name="log_L2_det_value" type="string">
       <value val="instrument/L2_det, 0.001, 33.1562"/>
     </parameter>	
-    <!-- no valid default value --> 
     <parameter name="log_Ltof_det_value" type="string">
-      <value val="instrument/Ltof_det, 0.001"/>
+      <value val="instrument/Ltof_det, 0.001, 0.0"/>
     </parameter>	
     <parameter name="log_L1" type="string">
       <value val="instrument/L1, 0.001, 16.671"/>
@@ -84,6 +82,13 @@
     </parameter>
 	<parameter name="log_D_curtaind_value" type="string">
       <value val="instrument/detector/curtaind, 0.001, 0.3978"/>
+    </parameter>
+
+	<parameter name="log_rough_40" type="string">
+      <value val="instrument/shutters/rough_40, 1, in"/>
+    </parameter>	
+	<parameter name="log_rough_100" type="string">
+      <value val="instrument/shutters/rough_100, 1, in"/>
     </parameter>
 	
 	<!-- parameter to be added to log that is not in the hdf file -->


### PR DESCRIPTION
**Description of work.**
Fixed an issue importing string values from the hdf file that are listed in the parameters file for the instrument.

**To test:**

The unit tested has been updated to included string values - previously only needed numerical values.


<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
-->
The fix does not affect the documentation or needs to be documented.

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
