### PR TITLE
Added <algorithm> include to CompositeValidator to fix Conda builds

### DIFF
--- a/Framework/Kernel/inc/MantidKernel/CompositeValidator.h
+++ b/Framework/Kernel/inc/MantidKernel/CompositeValidator.h
@@ -11,6 +11,7 @@
 
 #include <memory>
 
+#include <algorithm>
 #include <list>
 #include <string>
 #include <vector>


### PR DESCRIPTION
**Description of work.**
In trying to build the conda package, we have had the following error when trying to build the framework since version `5.0.20200408` on commit `a3b2809` (build worked on `5.0.20200407` commit `a01b868`):
```
[11/1859] Building CXX object Framework/Kernel/CMakeFiles/Kernel.dir/src/CompositeValidator.cpp.o
FAILED: Framework/Kernel/CMakeFiles/Kernel.dir/src/CompositeValidator.cpp.o 
$PREFIX/bin/x86_64-conda_cos6-linux-gnu-c++  -DBOOST_ALL_DYN_LINK -DBOOST_ALL_NO_LIB -DBOOST_DATE_TIME_POSIX_TIME_STD_CONFIG -DHAVE_STDINT_H -DIN_MANTID_KERNEL -DKernel_EXPORTS -DPOCO_ENABLE_CPP11 -DPSAPI_VERSION=1 -D_SILENCE_CXX17_OLD_ALLOCATOR_MEMBERS_DEPRECATION_WARNING -I../Framework/Types/inc -I../Framework/Kernel/inc -IFramework/Types -I_deps/span-src/include -isystem $PREFIX/include/nexus -isystem $PREFIX/include/eigen3 -fvisibility-inlines-hidden -std=c++17 -fmessage-length=0 -march=nocona -mtune=haswell -ftree-vectorize -fPIC -fstack-protector-strong -fno-plt -O2 -ffunction-sections -pipe -isystem $PREFIX/include -fdebug-prefix-map=$SRC_DIR=/usr/local/src/conda/mantid-framework-5.0.20200505.1444 -fdebug-prefix-map=$PREFIX=/usr/local/src/conda-prefix -O3 -DNDEBUG -fPIC -fvisibility=hidden   -Wall -Wextra -Wconversion -Winit-self -Wpointer-arith -Wcast-qual -Wcast-align -fno-common -Wno-deprecated -Wno-write-strings -Wno-unused-result -Woverloaded-virtual -fno-operator-names -Wpedantic -Wsuggest-override -Wimplicit-fallthrough=0 -fdiagnostics-color=always -fopenmp -std=gnu++1z -MD -MT Framework/Kernel/CMakeFiles/Kernel.dir/src/CompositeValidator.cpp.o -MF Framework/Kernel/CMakeFiles/Kernel.dir/src/CompositeValidator.cpp.o.d -o Framework/Kernel/CMakeFiles/Kernel.dir/src/CompositeValidator.cpp.o -c ../Framework/Kernel/src/CompositeValidator.cpp
../Framework/Kernel/src/CompositeValidator.cpp: In member function 'std::__cxx11::string Mantid::Kernel::CompositeValidator::checkAny(const boost::any&) const':
../Framework/Kernel/src/CompositeValidator.cpp:121:12: error: 'any_of' is not a member of 'std'
       std::any_of(m_children.begin(), m_children.end(), checkIfValid);
```

Specifically, we are getting `error: 'any_of' is not a member of 'std'`. [`std:any_of` is defined in `<algorithm>`](https://en.cppreference.com/w/cpp/algorithm/all_any_none_of) but was not explicitly included in `CompositeValidator.h`.

I **believe** it came from the change [here](https://github.com/mantidproject/mantid/commit/11994bc33fb4003170b44277446c38c0c8684c94#diff-40998c10e5f96fdbecf2cd6fa244eda6L12-L13) to remove `#include <boost/make_shared.hpp>` from `CompositeValidator.h`, which was implicitly including `algorithm`

Why? Because [`make_shared` includes `make_shared_object`](https://github.com/boostorg/smart_ptr/blob/develop/include/boost/smart_ptr/make_shared.hpp#L14) which [includes `shared_ptr`](https://github.com/boostorg/smart_ptr/blob/43d1fe12c559cad70d7d2c8d88db910c0dfa5603/include/boost/smart_ptr/make_shared_object.hpp#L17) which [includes `algorithm`](https://github.com/boostorg/smart_ptr/blob/develop/include/boost/smart_ptr/shared_ptr.hpp#L39)

**To test:**

I used [@DanNixon's conda recipe for mantid framework](https://github.com/DanNixon/mantid_framework_conda_recipe) + docker to do conda builds.

Specifically, you will reproduce the error if you:
  1) Clone Dan's repo
  2) Replace the top-level version and git commit with either the one below or a newer version:
```
{% set version = "5.0.20200408.1533" %}
{% set git_rev = "a3b28090e6f2189c261d323bacd43a083573c2e8" %}
```
  3) Spin up a docker container interactively:
```
docker run -it -v $(pwd):/conda-recipes -w /conda-recipes continuumio/miniconda3 bash 
```
  4) Run the following in the container to build (and see the failure:
```
conda config --add channels conda-forge
conda config --set always_yes yes
conda install conda-build
conda build .
```

To reproduce the success of this branch, do the same but for step 2, replace the top of the `meta.yml` part:
```
{% set version = "5.0.20200505.1444" %}
{% set git_rev = "de77bd79a20148d1616c85791cc8a17e49bd3bc4" %}

package:
  name: mantid-framework
  version: {{ version }}

source:
  git_rev: {{ git_rev }}
  git_url: https://github.com/mantidproject/mantid.git
```

With the git tag as the name of this branch (`conda_testing_for_fixing_builds`):
```
package:
  name: mantid-framework
  version: 5.1

source:
  git_tag: conda_testing_for_fixing_builds
  git_url: https://github.com/mantidproject/mantid.git
```
*There is no associated issue.*

*This does not require release notes* 
---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
