### PR TITLE
Fix Colorfills Scaling Differently if Done From Figure Options or the Context Menu

### DIFF
--- a/docs/source/release/v5.1.0/mantidworkbench.rst
+++ b/docs/source/release/v5.1.0/mantidworkbench.rst
@@ -44,5 +44,6 @@ Bugfixes
 - Fixed the default axis scale settings applying to the wrong axis.
 - Performing an overplot by dragging workspaces onto colorfill plots now correctly replaces the workspace.
 - Removed gridlines from the colorbar on colorfill plots.
+- Changing the axis scale on a colourfill plot now has the same result if it is done from either the context menu or figure options.
 
 :ref:`Release 5.1.0 <v5.1.0>`

--- a/qt/applications/workbench/workbench/plotting/figureinteraction.py
+++ b/qt/applications/workbench/workbench/plotting/figureinteraction.py
@@ -767,9 +767,12 @@ class FigureInteraction(object):
         # not rescaled properly because the vertical marker artists were
         # included in the last computation of the data limits and
         # set_xscale/set_yscale only autoscale the view
-        ax.relim()
+        xlim = copy(ax.get_xlim())
+        ylim = copy(ax.get_ylim())
         ax.set_xscale(scale_types[0])
         ax.set_yscale(scale_types[1])
+        ax.set_xlim(xlim)
+        ax.set_ylim(ylim)
 
         self.canvas.draw_idle()
 


### PR DESCRIPTION
**Description of work.**
Maintains the scale limits when the colorfill scale is changed from the context menu, meaning it copies the behaviour of the figure options. 

**To test:**
1. Plot two colourfill plots.
2. Change the scale of one of the plots to log/log using the context menu. 
3. Do the same with the figure options. 
4. Check that various options (such as the home button) do the same thing on both plots. 

Fixes #28364

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
