### PR TITLE
Fix a bug loading old "-add" files

### DIFF
--- a/docs/source/release/v5.1.0/sans.rst
+++ b/docs/source/release/v5.1.0/sans.rst
@@ -5,6 +5,13 @@ SANS Changes
 .. contents:: Table of Contents
    :local:
 
+.. warning:: **Developers:** Sort changes under appropriate heading
+    putting new features at the top of the section, followed by
+    improvements, followed by bug fixes.
+
+Algorithms and instruments
+--------------------------
+
 Bug Fixed
 #########
 
@@ -14,8 +21,12 @@ Bug Fixed
 - :ref:`SANSILLReduction <algm-SANSILLIntegration>` could fail if the detector was
   not aligned with the beam. The integration will now use another algorithm in this case.
 
-.. warning:: **Developers:** Sort changes under appropriate heading
-    putting new features at the top of the section, followed by
-    improvements, followed by bug fixes.
+ISIS SANS Interface
+-------------------
+
+Fixed
+#####
+
+- A bug has been fixed where processing old data could fail if it involves -add files produced from 2013 or earlier.
 
 :ref:`Release 5.1.0 <v5.1.0>`

--- a/scripts/SANS/sans/common/file_information.py
+++ b/scripts/SANS/sans/common/file_information.py
@@ -446,8 +446,8 @@ def get_added_nexus_information(file_name):  # noqa
     def check_if_event_mode(entry):
         return "event_workspace" in list(entry.keys())
 
-    def get_workspace_name(entry):
-        return entry["workspace_name"][0].decode("utf-8")
+    def get_workspace_name(entry, file_name):
+        return entry[WORKSPACE_NAME][0].decode("utf-8") if WORKSPACE_NAME in entry else file_name
 
     def has_same_number_of_entries(workspace_names, monitor_workspace_names):
         return len(workspace_names) == len(monitor_workspace_names)
@@ -462,7 +462,7 @@ def get_added_nexus_information(file_name):  # noqa
         altered_names = [ws_name.replace(ADDED_SUFFIX, ADDED_MONITOR_SUFFIX) for ws_name in workspace_names]
         return all([ws_name in monitor_workspace_names for ws_name in altered_names])
 
-    def get_added_event_info(h5_file_handle, key_collection):
+    def get_added_event_info(h5_file_handle, key_collection, file_name):
         """
         We expect to find one event workspace and one histogram workspace per period
         """
@@ -471,7 +471,7 @@ def get_added_nexus_information(file_name):  # noqa
         for key in key_collection:
             entry = h5_file_handle[key]
             is_event_mode = check_if_event_mode(entry)
-            workspace_name = get_workspace_name(entry)
+            workspace_name = get_workspace_name(entry, file_name)
             if is_event_mode:
                 workspace_names.append(workspace_name)
             else:
@@ -516,7 +516,7 @@ def get_added_nexus_information(file_name):  # noqa
 
                 # Check if entries are added event data, if we don't have a hit, then it can always be
                 # added histogram data
-                is_added_event_file, number_of_periods_event = get_added_event_info(h5_file, top_level_keys)
+                is_added_event_file, number_of_periods_event = get_added_event_info(h5_file, top_level_keys, file_name)
                 is_added_histogram_file, number_of_periods_histogram = get_added_histogram_info(h5_file, top_level_keys)
 
                 if is_added_event_file:


### PR DESCRIPTION
**Report to:** Steve King

This PR removes an assumption that a `workspace_name` entry exists in SANS `-add` files. Old data produced from mid-2013 and earlier do not have this entry and the SANS GUI was throwing due to this assumption. The fix is to use the file name instead if the workspace_name does not exist, although it is somewhat irrelevant what is used because the check is only to see whether it is event data and I don't believe we would have generated event data `-add` files from before 2013 (see discussion on the issue).

Fixes #28652

**To test:**

Follow the steps in the linked issue. The reduction should now complete successfully (the rows in the GUI will go green to indicate success, instead of blue).

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
