### PR TITLE
Workbench: Add non-orthogonal axes support to slice viewer

### DIFF
--- a/Framework/PythonInterface/mantid/plots/axesfunctions.py
+++ b/Framework/PythonInterface/mantid/plots/axesfunctions.py
@@ -28,12 +28,44 @@ from mantid.plots.utility import MantidAxType
 # Used for initializing searches of max, min values
 _LARGEST, _SMALLEST = float(sys.maxsize), -sys.maxsize
 
-
 # ================================================
 # Private 2D Helper functions
 # ================================================
 
-def _setLabels1D(axes, workspace, indices=None, normalize_by_bin_width=True,
+
+def _pcolormesh_nonortho(axes, workspace, to_display, *args, **kwargs):
+    '''
+    Essentially the same as :meth:`matplotlib.axes.Axes.pcolormesh` and adds arguments related to
+    plotting slices on nonorthogonal axes. It requires a non-standard Axes type. See
+    https://matplotlib.org/examples/axes_grid/demo_curvelinear_grid.html.
+
+    NOTE: Do NOT make this part of the public API until a discussion has been had about whether this
+    api is sensible. It is placed here for testing purposes and is used in the sliceviewer.
+
+    :param axes:      :class:`matplotlib.axes.Axes` object that will do the plotting
+    :param workspace: :class:`mantid.api.MatrixWorkspace` or :class:`mantid.api.IMDHistoWorkspace`
+                      to extract the data from
+    :param to_display: Callable accepting two numpy arrays to transfrom from nonorthogonal
+                       coordinates to orthogonal display
+    :param transpose: ``bool`` to transpose the x and y axes of the plotted dimensions of an MDHistoWorkspace
+    '''
+    transpose = kwargs.pop('transpose', False)
+    (normalization, kwargs) = get_normalization(workspace, **kwargs)
+    indices, kwargs = get_indices(workspace, **kwargs)
+    x, y, z = get_md_data2d_bin_bounds(workspace,
+                                       indices=indices,
+                                       normalization=normalization,
+                                       transpose=transpose)
+    X, Y = numpy.meshgrid(x, y)
+    xx, yy = to_display(X, Y)
+    _setLabels2D(axes, workspace, indices, transpose)
+    return axes.pcolormesh(xx, yy, z, *args, **kwargs)
+
+
+def _setLabels1D(axes,
+                 workspace,
+                 indices=None,
+                 normalize_by_bin_width=True,
                  axis=MantidAxType.SPECTRUM):
     '''
     helper function to automatically set axes labels for 1D plots
@@ -44,8 +76,12 @@ def _setLabels1D(axes, workspace, indices=None, normalize_by_bin_width=True,
     axes.set_ylabel(labels[0])
 
 
-def _setLabels2D(axes, workspace, indices=None, transpose=False,
-                 xscale=None, normalize_by_bin_width=True):
+def _setLabels2D(axes,
+                 workspace,
+                 indices=None,
+                 transpose=False,
+                 xscale=None,
+                 normalize_by_bin_width=True):
     '''
     helper function to automatically set axes labels for 2D plots
     '''
@@ -72,16 +108,16 @@ def _get_data_for_plot(axes, workspace, kwargs, with_dy=False, with_dx=False):
         axis = None
     else:
         axis = MantidAxType(kwargs.pop("axis", MantidAxType.SPECTRUM))
-        normalize_by_bin_width, kwargs = get_normalize_by_bin_width(
-            workspace, axes, **kwargs)
-        workspace_index, distribution, kwargs = get_wksp_index_dist_and_label(workspace, axis, **kwargs)
+        normalize_by_bin_width, kwargs = get_normalize_by_bin_width(workspace, axes, **kwargs)
+        workspace_index, distribution, kwargs = get_wksp_index_dist_and_label(
+            workspace, axis, **kwargs)
         if axis == MantidAxType.BIN:
             # Overwrite any user specified xlabel
             axes.set_xlabel("Spectrum")
             x, y, dy, dx = get_bins(workspace, workspace_index, with_dy)
         elif axis == MantidAxType.SPECTRUM:
-            x, y, dy, dx = get_spectrum(workspace, workspace_index,
-                                        normalize_by_bin_width, with_dy, with_dx)
+            x, y, dy, dx = get_spectrum(workspace, workspace_index, normalize_by_bin_width, with_dy,
+                                        with_dx)
         else:
             raise ValueError("Axis {} is not a valid axis number.".format(axis))
         indices = None
@@ -91,6 +127,7 @@ def _get_data_for_plot(axes, workspace, kwargs, with_dy=False, with_dx=False):
 # ========================================================
 # Plot functions
 # ========================================================
+
 
 def _plot_impl(axes, workspace, args, kwargs):
     """
@@ -108,12 +145,14 @@ def _plot_impl(axes, workspace, args, kwargs):
             axes.set_xlabel('Time')
         kwargs['drawstyle'] = 'steps-post'
     else:
-        normalize_by_bin_width, kwargs = get_normalize_by_bin_width(
-            workspace, axes, **kwargs)
+        normalize_by_bin_width, kwargs = get_normalize_by_bin_width(workspace, axes, **kwargs)
         x, y, _, _, indices, axis, kwargs = _get_data_for_plot(axes, workspace, kwargs)
         if kwargs.pop('update_axes_labels', True):
-            _setLabels1D(axes, workspace, indices,
-                         normalize_by_bin_width=normalize_by_bin_width, axis=axis)
+            _setLabels1D(axes,
+                         workspace,
+                         indices,
+                         normalize_by_bin_width=normalize_by_bin_width,
+                         axis=axis)
     kwargs.pop('normalize_by_bin_width', None)
     return x, y, args, kwargs
 
@@ -209,13 +248,18 @@ def errorbar(axes, workspace, *args, **kwargs):
     keyword for MDHistoWorkspaces. These type of workspaces have to have exactly one non integrated
     dimension
     """
-    normalize_by_bin_width, kwargs = get_normalize_by_bin_width(
-        workspace, axes, **kwargs)
-    x, y, dy, dx, indices, axis, kwargs = _get_data_for_plot(
-        axes, workspace, kwargs, with_dy=True, with_dx=False)
+    normalize_by_bin_width, kwargs = get_normalize_by_bin_width(workspace, axes, **kwargs)
+    x, y, dy, dx, indices, axis, kwargs = _get_data_for_plot(axes,
+                                                             workspace,
+                                                             kwargs,
+                                                             with_dy=True,
+                                                             with_dx=False)
     if kwargs.pop('update_axes_labels', True):
-        _setLabels1D(axes, workspace, indices,
-                     normalize_by_bin_width=normalize_by_bin_width, axis=axis)
+        _setLabels1D(axes,
+                     workspace,
+                     indices,
+                     normalize_by_bin_width=normalize_by_bin_width,
+                     axis=axis)
     kwargs.pop('normalize_by_bin_width', None)
 
     return axes.errorbar(x, y, dy, dx, *args, **kwargs)
@@ -300,7 +344,10 @@ def contour(axes, workspace, *args, **kwargs):
         _setLabels2D(axes, workspace, indices, transpose)
     else:
         (distribution, kwargs) = get_distribution(workspace, **kwargs)
-        (x, y, z) = get_matrix_2d_data(workspace, distribution, histogram2D=False, transpose=transpose)
+        (x, y, z) = get_matrix_2d_data(workspace,
+                                       distribution,
+                                       histogram2D=False,
+                                       transpose=transpose)
         _setLabels2D(axes, workspace, transpose=transpose)
     return axes.contour(x, y, z, *args, **kwargs)
 
@@ -339,7 +386,10 @@ def contourf(axes, workspace, *args, **kwargs):
         _setLabels2D(axes, workspace, indices, transpose)
     else:
         (distribution, kwargs) = get_distribution(workspace, **kwargs)
-        (x, y, z) = get_matrix_2d_data(workspace, distribution, histogram2D=False, transpose=transpose)
+        (x, y, z) = get_matrix_2d_data(workspace,
+                                       distribution,
+                                       histogram2D=False,
+                                       transpose=transpose)
         _setLabels2D(axes, workspace, transpose=transpose)
     return axes.contourf(x, y, z, *args, **kwargs)
 
@@ -431,8 +481,14 @@ def pcolor(axes, workspace, *args, **kwargs):
             kwargs['pcolortype'] = ''
             return _pcolorpieces(axes, workspace, distribution, *args, **kwargs)
         else:
-            (x, y, z) = get_matrix_2d_data(workspace, distribution, histogram2D=True, transpose=transpose)
-            _setLabels2D(axes, workspace, transpose=transpose, normalize_by_bin_width=normalize_by_bin_width)
+            (x, y, z) = get_matrix_2d_data(workspace,
+                                           distribution,
+                                           histogram2D=True,
+                                           transpose=transpose)
+            _setLabels2D(axes,
+                         workspace,
+                         transpose=transpose,
+                         normalize_by_bin_width=normalize_by_bin_width)
     return axes.pcolor(x, y, z, *args, **kwargs)
 
 
@@ -476,8 +532,14 @@ def pcolorfast(axes, workspace, *args, **kwargs):
             kwargs['pcolortype'] = 'fast'
             return _pcolorpieces(axes, workspace, distribution, *args, **kwargs)
         else:
-            (x, y, z) = get_matrix_2d_data(workspace, distribution, histogram2D=True, transpose=transpose)
-        _setLabels2D(axes, workspace, transpose=transpose, normalize_by_bin_width=normalize_by_bin_width)
+            (x, y, z) = get_matrix_2d_data(workspace,
+                                           distribution,
+                                           histogram2D=True,
+                                           transpose=transpose)
+        _setLabels2D(axes,
+                     workspace,
+                     transpose=transpose,
+                     normalize_by_bin_width=normalize_by_bin_width)
     return axes.pcolorfast(x, y, z, *args, **kwargs)
 
 
@@ -521,8 +583,14 @@ def pcolormesh(axes, workspace, *args, **kwargs):
             kwargs['pcolortype'] = 'mesh'
             return _pcolorpieces(axes, workspace, distribution, *args, **kwargs)
         else:
-            (x, y, z) = get_matrix_2d_data(workspace, distribution, histogram2D=True, transpose=transpose)
-        _setLabels2D(axes, workspace, transpose=transpose, normalize_by_bin_width=normalize_by_bin_width)
+            (x, y, z) = get_matrix_2d_data(workspace,
+                                           distribution,
+                                           histogram2D=True,
+                                           transpose=transpose)
+        _setLabels2D(axes,
+                     workspace,
+                     transpose=transpose,
+                     normalize_by_bin_width=normalize_by_bin_width)
     return axes.pcolormesh(x, y, z, *args, **kwargs)
 
 
@@ -563,10 +631,19 @@ def imshow(axes, workspace, *args, **kwargs):
         (normalize_by_bin_width, kwargs) = get_normalize_by_bin_width(workspace, axes, **kwargs)
         (distribution, kwargs) = get_distribution(workspace, **kwargs)
         if aligned:
-            (x, y, z) = get_matrix_2d_ragged(workspace, normalize_by_bin_width, histogram2D=True, transpose=transpose)
+            (x, y, z) = get_matrix_2d_ragged(workspace,
+                                             normalize_by_bin_width,
+                                             histogram2D=True,
+                                             transpose=transpose)
         else:
-            (x, y, z) = get_matrix_2d_data(workspace, distribution=distribution, histogram2D=True, transpose=transpose)
-        _setLabels2D(axes, workspace, transpose=transpose, normalize_by_bin_width=normalize_by_bin_width)
+            (x, y, z) = get_matrix_2d_data(workspace,
+                                           distribution=distribution,
+                                           histogram2D=True,
+                                           transpose=transpose)
+        _setLabels2D(axes,
+                     workspace,
+                     transpose=transpose,
+                     normalize_by_bin_width=normalize_by_bin_width)
     if 'extent' not in kwargs:
         if x.ndim == 2 and y.ndim == 2:
             kwargs['extent'] = [x[0, 0], x[0, -1], y[0, 0], y[-1, 0]]
@@ -612,7 +689,10 @@ def tripcolor(axes, workspace, *args, **kwargs):
         _setLabels2D(axes, workspace, indices, transpose)
     else:
         (distribution, kwargs) = get_distribution(workspace, **kwargs)
-        (x, y, z) = get_matrix_2d_data(workspace, distribution, histogram2D=False, transpose=transpose)
+        (x, y, z) = get_matrix_2d_data(workspace,
+                                       distribution,
+                                       histogram2D=False,
+                                       transpose=transpose)
         _setLabels2D(axes, workspace, transpose=transpose)
     return axes.tripcolor(x.ravel(), y.ravel(), z.ravel(), *args, **kwargs)
 
@@ -655,7 +735,10 @@ def tricontour(axes, workspace, *args, **kwargs):
         _setLabels2D(axes, workspace, indices, transpose)
     else:
         (distribution, kwargs) = get_distribution(workspace, **kwargs)
-        (x, y, z) = get_matrix_2d_data(workspace, distribution, histogram2D=False, transpose=transpose)
+        (x, y, z) = get_matrix_2d_data(workspace,
+                                       distribution,
+                                       histogram2D=False,
+                                       transpose=transpose)
         _setLabels2D(axes, workspace, transpose=transpose)
     # tricontour segfaults if many z values are not finite
     # https://github.com/matplotlib/matplotlib/issues/10167
@@ -707,7 +790,10 @@ def tricontourf(axes, workspace, *args, **kwargs):
         _setLabels2D(axes, workspace, indices, transpose)
     else:
         (distribution, kwargs) = get_distribution(workspace, **kwargs)
-        (x, y, z) = get_matrix_2d_data(workspace, distribution, histogram2D=False, transpose=transpose)
+        (x, y, z) = get_matrix_2d_data(workspace,
+                                       distribution,
+                                       histogram2D=False,
+                                       transpose=transpose)
         _setLabels2D(axes, workspace, transpose=transpose)
     # tricontourf segfaults if many z values are not finite
     # https://github.com/matplotlib/matplotlib/issues/10167

--- a/qt/python/CMakeLists.txt
+++ b/qt/python/CMakeLists.txt
@@ -19,162 +19,164 @@ if(ENABLE_WORKBENCH OR ENABLE_WORKBENCH)
   endif()
   # Configure the file necessary for DEVELOPMENT builds to run and detect Qt's
   # plugins
-  configure_file(mantidqt/utils/qt/plugins.py.in
-                 ${CMAKE_CURRENT_SOURCE_DIR}/mantidqt/utils/qt/plugins.py)
+  configure_file(
+    mantidqt/utils/qt/plugins.py.in
+    ${CMAKE_CURRENT_SOURCE_DIR}/mantidqt/utils/qt/plugins.py
+  )
   if(APPLE)
     set(_install_lib_dirs "${LIB_DIR};${WORKBENCH_LIB_DIR}")
   else()
     set(_install_lib_dirs "${WORKBENCH_LIB_DIR}")
   endif()
-  add_python_package(mantidqt
-    INSTALL_LIB_DIRS ${_install_lib_dirs})
+  add_python_package(mantidqt INSTALL_LIB_DIRS ${_install_lib_dirs})
 
   # Configure resources data in place for ease of development. The output file
   # is added to the toplevel gitignore
   set(_qrc_file ${CMAKE_CURRENT_LIST_DIR}/resources.qrc)
   set(_output_res_py ${CMAKE_CURRENT_LIST_DIR}/mantidqt/resources.py)
   configure_file(create_resources.cmake.in create_resources.cmake @ONLY)
-  add_custom_command(OUTPUT ${_output_res_py}
-                     COMMAND ${CMAKE_COMMAND} -P create_resources.cmake
-                     COMMENT "Generating mantidqt resources module"
-                     DEPENDS ${_qrc_file})
+  add_custom_command(
+    OUTPUT ${_output_res_py}
+    COMMAND ${CMAKE_COMMAND} -P create_resources.cmake
+    COMMENT "Generating mantidqt resources module"
+    DEPENDS ${_qrc_file}
+  )
   add_custom_target(mantidqt_resources ALL DEPENDS ${_output_res_py})
 
   # Now add any compiled sip targets
   add_subdirectory(mantidqt)
 
   # Setup dependency chain
-  add_dependencies(mantidqt
-                   mantidqt_resources
-                   PythonInterface)
+  add_dependencies(mantidqt mantidqt_resources PythonInterface)
 
   if(ENABLE_MANTIDPLOT)
     add_dependencies(mantidqt mantidqt_commonqt4 mantidqt_iconsqt4)
   endif()
   if(ENABLE_WORKBENCH)
-    add_dependencies(mantidqt
-                     mantidqt_commonqt5
-                     mantidqt_instrumentviewqt5
-                     mantidqt_iconsqt5)
+    add_dependencies(
+      mantidqt mantidqt_commonqt5 mantidqt_instrumentviewqt5 mantidqt_iconsqt5
+    )
     if(MSVC)
       # Debug builds need libraries that are linked with MSVC debug runtime
       add_custom_command(
         TARGET mantidqt POST_BUILD
-        COMMAND if 1==$<CONFIG:Debug> ${CMAKE_COMMAND} -E copy_directory
-                ${MSVC_PYTHON_EXECUTABLE_DIR}/msvc-site-packages/debug/PyQt5
-                ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${CMAKE_CFG_INTDIR}/PyQt5
-        COMMENT "Copying debug PyQt5 to bin/Debug")
+        COMMAND
+          if 1==$<CONFIG:Debug> ${CMAKE_COMMAND} -E copy_directory
+          ${MSVC_PYTHON_EXECUTABLE_DIR}/msvc-site-packages/debug/PyQt5
+          ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${CMAKE_CFG_INTDIR}/PyQt5
+        COMMENT "Copying debug PyQt5 to bin/Debug"
+      )
     endif()
   endif()
 
   # Testing
   add_dependencies(GUITests mantidqt)
   # ctest targets
-  set(
-    PYTHON_TEST_FILES
-    mantidqt/test/test_algorithm_observer.py
-    mantidqt/test/test_import.py
-    mantidqt/dialogs/test/test_algorithm_dialog.py
-    mantidqt/dialogs/test/test_spectraselectiondialog.py
-    mantidqt/dialogs/test/test_spectraselectorutils.py
-    mantidqt/plotting/test/test_figuretype.py
-    mantidqt/plotting/test/test_functions.py
-    mantidqt/plotting/test/test_tiledplots.py
-    mantidqt/project/test/test_plotssaver.py
-    mantidqt/project/test/test_plotsloader.py
-    mantidqt/project/test/test_project.py
-    mantidqt/project/test/test_projectloader.py
-    mantidqt/project/test/test_projectsaver.py
-    mantidqt/project/test/test_workspaceloader.py
-    mantidqt/project/test/test_workspacesaver.py
-    mantidqt/utils/test/test_async.py
-    mantidqt/utils/test/test_modal_tester.py
-    mantidqt/utils/test/test_qt_utils.py
-    mantidqt/utils/test/test_writetosignal.py
-    mantidqt/widgets/test/test_messagedisplay.py
-    mantidqt/widgets/test/test_fitpropertybrowser.py
-    mantidqt/widgets/test/test_fitpropertybrowserbase.py
-    mantidqt/widgets/test/test_functionbrowser.py
-    mantidqt/widgets/samplelogs/test/test_samplelogs_model.py
-    mantidqt/widgets/samplelogs/test/test_samplelogs_presenter.py
-    mantidqt/widgets/observers/test/test_ads_observer.py
-    mantidqt/widgets/observers/test/test_observing_presenter.py
-    mantidqt/widgets/observers/test/test_observing_view.py
-    mantidqt/widgets/embedded_find_replace_dialog/test/test_embedded_find_replace_dialog_presenter.py
-    )
+  set(PYTHON_TEST_FILES
+      mantidqt/test/test_algorithm_observer.py
+      mantidqt/test/test_import.py
+      mantidqt/dialogs/test/test_algorithm_dialog.py
+      mantidqt/dialogs/test/test_spectraselectiondialog.py
+      mantidqt/dialogs/test/test_spectraselectorutils.py
+      mantidqt/plotting/test/test_figuretype.py
+      mantidqt/plotting/test/test_functions.py
+      mantidqt/plotting/test/test_tiledplots.py
+      mantidqt/project/test/test_plotssaver.py
+      mantidqt/project/test/test_plotsloader.py
+      mantidqt/project/test/test_project.py
+      mantidqt/project/test/test_projectloader.py
+      mantidqt/project/test/test_projectsaver.py
+      mantidqt/project/test/test_workspaceloader.py
+      mantidqt/project/test/test_workspacesaver.py
+      mantidqt/utils/test/test_async.py
+      mantidqt/utils/test/test_modal_tester.py
+      mantidqt/utils/test/test_qt_utils.py
+      mantidqt/utils/test/test_writetosignal.py
+      mantidqt/widgets/test/test_messagedisplay.py
+      mantidqt/widgets/test/test_fitpropertybrowser.py
+      mantidqt/widgets/test/test_fitpropertybrowserbase.py
+      mantidqt/widgets/test/test_functionbrowser.py
+      mantidqt/widgets/samplelogs/test/test_samplelogs_model.py
+      mantidqt/widgets/samplelogs/test/test_samplelogs_presenter.py
+      mantidqt/widgets/observers/test/test_ads_observer.py
+      mantidqt/widgets/observers/test/test_observing_presenter.py
+      mantidqt/widgets/observers/test/test_observing_view.py
+      mantidqt/widgets/embedded_find_replace_dialog/test/test_embedded_find_replace_dialog_presenter.py
+  )
 
   if(ENABLE_WORKBENCH)
-    # ctest target for widgets that only get tested in qt5, because they are only
-    # used in the workbench
-    set(
-      PYTHON_WIDGET_QT5_ONLY_TESTS
-      mantidqt/widgets/algorithmselector/test/observer_test.py
-      mantidqt/widgets/algorithmselector/test/test_algorithmselector.py
-      mantidqt/widgets/codeeditor/test/test_codeeditor.py
-      mantidqt/widgets/codeeditor/test/test_completion.py
-      mantidqt/widgets/codeeditor/test/test_execution.py
-      mantidqt/widgets/codeeditor/test/test_errorformatter.py
-      mantidqt/widgets/codeeditor/test/test_interpreter.py
-      mantidqt/widgets/codeeditor/test/test_interpreter_view.py
-      mantidqt/widgets/codeeditor/test/test_multifileinterpreter.py
-      mantidqt/widgets/codeeditor/test/test_multifileinterpreter_view.py
-      mantidqt/widgets/codeeditor/tab_widget/test/test_codeeditor_tab_presenter.py
-      mantidqt/widgets/codeeditor/tab_widget/test/test_codeeditor_tab_view.py
-      mantidqt/widgets/fitpropertybrowser/addfunctiondialog/test/test_addfunctiondialogpresenter.py
-      mantidqt/widgets/instrumentview/test/test_instrumentview_io.py
-      mantidqt/widgets/instrumentview/test/test_instrumentview_view.py
-      mantidqt/widgets/plotconfigdialog/axestabwidget/test/test_axestabwidgetpresenter.py
-      mantidqt/widgets/plotconfigdialog/curvestabwidget/test/test_curveproperties.py
-      mantidqt/widgets/plotconfigdialog/curvestabwidget/test/test_curvestabwidgetpresenter.py
-      mantidqt/widgets/plotconfigdialog/test/test_apply_all_properties.py
-      mantidqt/widgets/plotconfigdialog/imagestabwidget/test/test_imagestabwidgetpresenter.py
-      mantidqt/widgets/plotconfigdialog/test/test_plotconfigdialogpresenter.py
-      mantidqt/widgets/samplelogs/test/test_samplelogs_view.py
-      mantidqt/widgets/sliceviewer/test/test_sliceviewer_model.py
-      mantidqt/widgets/sliceviewer/test/test_sliceviewer_presenter.py
-      mantidqt/widgets/sliceviewer/test/test_sliceviewer_sliceinfo.py
-      mantidqt/widgets/sliceviewer/test/test_sliceviewer_view.py
-      mantidqt/widgets/sliceviewer/peaksviewer/test/test_peaksviewer_model.py
-      mantidqt/widgets/sliceviewer/peaksviewer/test/test_peaksviewer_presenter.py
-      mantidqt/widgets/sliceviewer/peaksviewer/test/test_peaksviewer_peaksviewercollectionpresenter.py
-      mantidqt/widgets/sliceviewer/peaksviewer/test/test_peaksviewer_peaksworkspaceselectormodel.py
-      mantidqt/widgets/sliceviewer/peaksviewer/test/test_peaksviewer_peaksworkspaceselectorpresenter.py
-      mantidqt/widgets/sliceviewer/peaksviewer/representation/test/test_peaksviewer_representation_alpha.py
-      mantidqt/widgets/sliceviewer/peaksviewer/representation/test/test_peaksviewer_representation_draw.py
-      mantidqt/widgets/sliceviewer/peaksviewer/representation/test/test_peaksviewer_representation_painter.py
-      mantidqt/widgets/sliceviewer/peaksviewer/representation/test/test_peaksviewer_representation_nonintegrated.py
-      mantidqt/widgets/sliceviewer/peaksviewer/representation/test/test_peaksviewer_representation_ellipsoid.py
-      mantidqt/widgets/sliceviewer/peaksviewer/representation/test/test_peaksviewer_representation_spherical.py
-      mantidqt/widgets/test/test_jupyterconsole.py
-      mantidqt/widgets/workspacedisplay/test/test_data_copier.py
-      mantidqt/widgets/workspacedisplay/test/test_user_notifier.py
-      mantidqt/widgets/workspacedisplay/matrix/test/test_matrixworkspacedisplay_model.py
-      mantidqt/widgets/workspacedisplay/matrix/test/test_matrixworkspacedisplay_presenter.py
-      mantidqt/widgets/workspacedisplay/matrix/test/test_matrixworkspacedisplay_table_view_model.py
-      mantidqt/widgets/workspacedisplay/matrix/test/test_matrixworkspacedisplay_view.py
-      mantidqt/widgets/workspacedisplay/matrix/test/test_matrixworkspacedisplay_io.py
-      mantidqt/widgets/workspacedisplay/table/test/test_tableworkspacedisplay_error_column.py
-      mantidqt/widgets/workspacedisplay/table/test/test_tableworkspacedisplay_marked_columns.py
-      mantidqt/widgets/workspacedisplay/table/test/test_tableworkspacedisplay_workbench_table_widget_item.py
-      mantidqt/widgets/workspacedisplay/table/test/test_tableworkspacedisplay_model.py
-      mantidqt/widgets/workspacedisplay/table/test/test_tableworkspacedisplay_presenter.py
-      mantidqt/widgets/workspacedisplay/table/test/test_tableworkspacedisplay_view.py
-      mantidqt/widgets/workspacedisplay/table/test/test_tableworkspacedisplay_io.py
-      mantidqt/widgets/workspacewidget/test/test_workspacetreewidget.py
-      mantidqt/icons/test/test_icons.py
-  )
+    # ctest target for widgets that only get tested in qt5, because they are
+    # only used in the workbench
+    set(PYTHON_WIDGET_QT5_ONLY_TESTS
+        mantidqt/widgets/algorithmselector/test/observer_test.py
+        mantidqt/widgets/algorithmselector/test/test_algorithmselector.py
+        mantidqt/widgets/codeeditor/test/test_codeeditor.py
+        mantidqt/widgets/codeeditor/test/test_completion.py
+        mantidqt/widgets/codeeditor/test/test_execution.py
+        mantidqt/widgets/codeeditor/test/test_errorformatter.py
+        mantidqt/widgets/codeeditor/test/test_interpreter.py
+        mantidqt/widgets/codeeditor/test/test_interpreter_view.py
+        mantidqt/widgets/codeeditor/test/test_multifileinterpreter.py
+        mantidqt/widgets/codeeditor/test/test_multifileinterpreter_view.py
+        mantidqt/widgets/codeeditor/tab_widget/test/test_codeeditor_tab_presenter.py
+        mantidqt/widgets/codeeditor/tab_widget/test/test_codeeditor_tab_view.py
+        mantidqt/widgets/fitpropertybrowser/addfunctiondialog/test/test_addfunctiondialogpresenter.py
+        mantidqt/widgets/instrumentview/test/test_instrumentview_io.py
+        mantidqt/widgets/instrumentview/test/test_instrumentview_view.py
+        mantidqt/widgets/plotconfigdialog/axestabwidget/test/test_axestabwidgetpresenter.py
+        mantidqt/widgets/plotconfigdialog/curvestabwidget/test/test_curveproperties.py
+        mantidqt/widgets/plotconfigdialog/curvestabwidget/test/test_curvestabwidgetpresenter.py
+        mantidqt/widgets/plotconfigdialog/test/test_apply_all_properties.py
+        mantidqt/widgets/plotconfigdialog/imagestabwidget/test/test_imagestabwidgetpresenter.py
+        mantidqt/widgets/plotconfigdialog/test/test_plotconfigdialogpresenter.py
+        mantidqt/widgets/samplelogs/test/test_samplelogs_view.py
+        mantidqt/widgets/sliceviewer/test/test_sliceviewer_model.py
+        mantidqt/widgets/sliceviewer/test/test_sliceviewer_presenter.py
+        mantidqt/widgets/sliceviewer/test/test_sliceviewer_sliceinfo.py
+        mantidqt/widgets/sliceviewer/test/test_sliceviewer_transform.py
+        mantidqt/widgets/sliceviewer/test/test_sliceviewer_view.py
+        mantidqt/widgets/sliceviewer/peaksviewer/test/test_peaksviewer_model.py
+        mantidqt/widgets/sliceviewer/peaksviewer/test/test_peaksviewer_presenter.py
+        mantidqt/widgets/sliceviewer/peaksviewer/test/test_peaksviewer_peaksviewercollectionpresenter.py
+        mantidqt/widgets/sliceviewer/peaksviewer/test/test_peaksviewer_peaksworkspaceselectormodel.py
+        mantidqt/widgets/sliceviewer/peaksviewer/test/test_peaksviewer_peaksworkspaceselectorpresenter.py
+        mantidqt/widgets/sliceviewer/peaksviewer/representation/test/test_peaksviewer_representation_alpha.py
+        mantidqt/widgets/sliceviewer/peaksviewer/representation/test/test_peaksviewer_representation_draw.py
+        mantidqt/widgets/sliceviewer/peaksviewer/representation/test/test_peaksviewer_representation_painter.py
+        mantidqt/widgets/sliceviewer/peaksviewer/representation/test/test_peaksviewer_representation_nonintegrated.py
+        mantidqt/widgets/sliceviewer/peaksviewer/representation/test/test_peaksviewer_representation_ellipsoid.py
+        mantidqt/widgets/sliceviewer/peaksviewer/representation/test/test_peaksviewer_representation_spherical.py
+        mantidqt/widgets/test/test_jupyterconsole.py
+        mantidqt/widgets/workspacedisplay/test/test_data_copier.py
+        mantidqt/widgets/workspacedisplay/test/test_user_notifier.py
+        mantidqt/widgets/workspacedisplay/matrix/test/test_matrixworkspacedisplay_model.py
+        mantidqt/widgets/workspacedisplay/matrix/test/test_matrixworkspacedisplay_presenter.py
+        mantidqt/widgets/workspacedisplay/matrix/test/test_matrixworkspacedisplay_table_view_model.py
+        mantidqt/widgets/workspacedisplay/matrix/test/test_matrixworkspacedisplay_view.py
+        mantidqt/widgets/workspacedisplay/matrix/test/test_matrixworkspacedisplay_io.py
+        mantidqt/widgets/workspacedisplay/table/test/test_tableworkspacedisplay_error_column.py
+        mantidqt/widgets/workspacedisplay/table/test/test_tableworkspacedisplay_marked_columns.py
+        mantidqt/widgets/workspacedisplay/table/test/test_tableworkspacedisplay_workbench_table_widget_item.py
+        mantidqt/widgets/workspacedisplay/table/test/test_tableworkspacedisplay_model.py
+        mantidqt/widgets/workspacedisplay/table/test/test_tableworkspacedisplay_presenter.py
+        mantidqt/widgets/workspacedisplay/table/test/test_tableworkspacedisplay_view.py
+        mantidqt/widgets/workspacedisplay/table/test/test_tableworkspacedisplay_io.py
+        mantidqt/widgets/workspacewidget/test/test_workspacetreewidget.py
+        mantidqt/icons/test/test_icons.py
+    )
 
     # Tests
     set(PYUNITTEST_QT_API pyqt5)
-    pyunittest_add_test(${CMAKE_CURRENT_SOURCE_DIR}
-                        mantidqt_qt5
-                        ${PYTHON_TEST_FILES}
-                        ${PYTHON_WIDGET_QT5_ONLY_TESTS})
+    pyunittest_add_test(
+      ${CMAKE_CURRENT_SOURCE_DIR} mantidqt_qt5 ${PYTHON_TEST_FILES}
+      ${PYTHON_WIDGET_QT5_ONLY_TESTS}
+    )
   endif()
   if(ENABLE_MANTIDPLOT)
     set(PYUNITTEST_QT_API pyqt)
-    pyunittest_add_test(${CMAKE_CURRENT_SOURCE_DIR} mantidqt_qt4
-                        ${PYTHON_TEST_FILES})
+    pyunittest_add_test(
+      ${CMAKE_CURRENT_SOURCE_DIR} mantidqt_qt4 ${PYTHON_TEST_FILES}
+    )
     unset(PYUNITTEST_QT_API)
   endif()
 endif()

--- a/qt/python/mantidqt/widgets/sliceviewer/dimensionwidget.py
+++ b/qt/python/mantidqt/widgets/sliceviewer/dimensionwidget.py
@@ -36,7 +36,6 @@ class DimensionWidget(QWidget):
     window.show()
     app.exec_()
     """
-
     def __init__(self, dims_info, parent=None):
         super().__init__(parent)
 
@@ -105,22 +104,6 @@ class DimensionWidget(QWidget):
             d.name.setMinimumWidth(max_name_width)
             d.units.setMinimumWidth(max_unit_width)
 
-    def get_indices(self):
-        """
-        :return: a list of 3 elements, [X, Y, Z], where X,Y,Z give the index that is set as that dimension.
-        """
-        xdim, ydim, zdim = None, None, None
-        for index, dimension in enumerate(self.dims):
-            state = dimension.get_state()
-            if state == State.X:
-                xdim = index
-            elif state == State.Y:
-                ydim = index
-            elif state == State.NONE:
-                zdim = index
-
-        return [xdim, ydim, zdim]
-
     def get_slicepoint(self):
         """:return: a list of 3 elements where None indicates a non-slice dimension and a
           float indicates the current slice point in that dimension.
@@ -165,7 +148,6 @@ class Dimension(QWidget):
     window.show()
     app.exec_()
     """
-
     def __init__(self, dim_info, number=0, state=State.NONE, parent=None):
         super().__init__(parent)
 
@@ -299,7 +281,6 @@ class DimensionMDE(Dimension):
     window.show()
     app.exec_()
     """
-
     def __init__(self, dim_info, number=0, state=State.NONE, parent=None):
 
         # hack in a number_of_bins for MDEventWorkspace

--- a/qt/python/mantidqt/widgets/sliceviewer/model.py
+++ b/qt/python/mantidqt/widgets/sliceviewer/model.py
@@ -7,11 +7,18 @@
 #  This file is part of the mantid workbench.
 #
 from enum import Enum
+from typing import Dict, List
 
+from mantid.api import MatrixWorkspace, MultipleExperimentInfos, SpecialCoordinateSystem
 from mantid.plots.datafunctions import get_indices
-from mantid.api import MatrixWorkspace, MultipleExperimentInfos
 from mantid.simpleapi import BinMD
 import numpy as np
+
+from .sliceinfo import SliceInfo
+from .transform import NonOrthogonalTransform
+
+# Constants
+PROJ_MATRIX_LOG_NAME = "W_MATRIX"
 
 
 class WS_TYPE(Enum):
@@ -20,9 +27,8 @@ class WS_TYPE(Enum):
     MATRIX = 2
 
 
-class SliceViewerModel(object):
+class SliceViewerModel:
     """Store the workspace to be plotted. Can be MatrixWorkspace, MDEventWorkspace or MDHistoWorkspace"""
-
     def __init__(self, ws):
         if isinstance(ws, MatrixWorkspace):
             if ws.getNumberHistograms() < 2:
@@ -48,10 +54,31 @@ class SliceViewerModel(object):
             self.get_ws = self._get_ws
             self.get_data = self.get_data_MDH
 
-    def _get_ws(self):
-        return self._ws
+    def can_normalize_workspace(self) -> bool:
+        if self.get_ws_type() == WS_TYPE.MATRIX and not self._get_ws().isDistribution():
+            return True
+        return False
 
-    def get_frame(self):
+    def can_support_nonorthogonal_axes(self) -> bool:
+        """
+        Query if the workspace can support non-orthogonal axes.
+        Workspace must be an MD workspace, in HKL coordinate system
+        and have a defined oriented lattice on the first experiment info.
+        """
+        ws_type = self.get_ws_type()
+        if ws_type == WS_TYPE.MDE or ws_type == WS_TYPE.MDH:
+            if self.get_frame() != SpecialCoordinateSystem.HKL:
+                return False
+
+            sample = self._get_ws().getExperimentInfo(0).sample()
+            if not sample.hasOrientedLattice():
+                return False
+
+            return True
+        else:
+            return False
+
+    def get_frame(self) -> SpecialCoordinateSystem:
         """Return the coordinate system of the workspace"""
         return self._ws.getSpecialCoordinateSystem()
 
@@ -67,10 +94,9 @@ class SliceViewerModel(object):
                 params['AlignedDim{}'.format(n)] = '{},{},{},{}'.format(
                     self._get_ws().getDimension(n).name, slicepoint[n] - bin_params[n] / 2,
                     slicepoint[n] + bin_params[n] / 2, 1)
-        return BinMD(
-            InputWorkspace=self._get_ws(),
-            OutputWorkspace=self._get_ws().name() + '_rebinned',
-            **params)
+        return BinMD(InputWorkspace=self._get_ws(),
+                     OutputWorkspace=self._get_ws().name() + '_rebinned',
+                     **params)
 
     def get_data_MDH(self, slicepoint, transpose=False):
         indices, _ = get_indices(self.get_ws(), slicepoint=slicepoint)
@@ -87,7 +113,7 @@ class SliceViewerModel(object):
             return np.ma.masked_invalid(
                 self.get_ws_MDE(slicepoint, bin_params).getSignalArray().squeeze())
 
-    def get_dim_info(self, n):
+    def get_dim_info(self, n: int) -> dict:
         """
         returns dict of (minimum, maximun, number_of_bins, width, name, units) for dimension n
         """
@@ -102,13 +128,13 @@ class SliceViewerModel(object):
             'type': self.get_ws_type().name
         }
 
-    def get_dimensions_info(self):
+    def get_dimensions_info(self) -> List[Dict]:
         """
-        returns a list of dict for each dimension conainting dim_info
+        returns a list of dict for each dimension containing dim_info
         """
         return [self.get_dim_info(n) for n in range(self._get_ws().getNumDims())]
 
-    def get_ws_type(self):
+    def get_ws_type(self) -> WS_TYPE:
         if isinstance(self._get_ws(), MatrixWorkspace):
             return WS_TYPE.MATRIX
         elif isinstance(self._get_ws(), MultipleExperimentInfos):
@@ -119,7 +145,29 @@ class SliceViewerModel(object):
         else:
             raise ValueError("Unsupported workspace type")
 
-    def can_normalize_workspace(self):
-        if self.get_ws_type() == WS_TYPE.MATRIX and not self._get_ws().isDistribution():
-            return True
-        return False
+    def create_nonorthogonal_transform(self, slice_info: SliceInfo):
+        """
+        Calculate the transform object for nonorthogonal axes.
+        :param slice_info: SliceInfoType object giving information on the slice
+        :raises: RuntimeError if model does not support nonorthogonal axes
+        """
+        if not self.can_support_nonorthogonal_axes():
+            raise RuntimeError("Workspace cannot support non-orthogonal axes view")
+
+        expt_info = self._get_ws().getExperimentInfo(0)
+        lattice = expt_info.sample().getOrientedLattice()
+        try:
+            proj_matrix = np.array(expt_info.run().get(PROJ_MATRIX_LOG_NAME).value)
+            proj_matrix = proj_matrix.reshape(3, 3)
+        except KeyError:
+            # assume orthogonal projection
+            proj_matrix = np.diag([1., 1., 1.])
+
+        display_indices = slice_info.transform([0, 1, 2])
+        return NonOrthogonalTransform.from_lattice(lattice,
+                                                   x_proj=proj_matrix[:, display_indices[0]],
+                                                   y_proj=proj_matrix[:, display_indices[1]])
+
+    # private api
+    def _get_ws(self):
+        return self._ws

--- a/qt/python/mantidqt/widgets/sliceviewer/peaksviewer/test/test_peaksviewer_model.py
+++ b/qt/python/mantidqt/widgets/sliceviewer/peaksviewer/test/test_peaksviewer_model.py
@@ -13,7 +13,6 @@ from mantid.api import MatrixWorkspace, SpecialCoordinateSystem
 from mantid.dataobjects import PeaksWorkspace
 
 # local imports
-from mantidqt.widgets.sliceviewer.sliceinfo import SliceInfo
 from mantidqt.widgets.sliceviewer.peaksviewer.model import PeaksViewerModel, create_peaksviewermodel
 from mantidqt.widgets.sliceviewer.peaksviewer.test.modeltesthelpers import create_peaks_viewer_model, draw_peaks  # noqa
 
@@ -49,8 +48,10 @@ class PeaksViewerModelTest(unittest.TestCase):
         # create 2 peaks: 1 visible, 1 not (far outside Z range)
         visible_peak_center, invisible_center = (0.5, 0.2, 0.25), (0.4, 0.3, 25)
 
-        _, mock_painter = draw_peaks(
-            (visible_peak_center, invisible_center), fg_color, slice_value=0.5, slice_width=30)
+        _, mock_painter = draw_peaks((visible_peak_center, invisible_center),
+                                     fg_color,
+                                     slice_value=0.5,
+                                     slice_width=30)
 
         self.assertEqual(1, mock_painter.cross.call_count)
         call_args, call_kwargs = mock_painter.cross.call_args
@@ -63,8 +64,10 @@ class PeaksViewerModelTest(unittest.TestCase):
     def test_clear_peaks_removes_all_drawn(self):
         # create 2 peaks: 1 visible, 1 not (far outside Z range)
         visible_peak_center, invisible_center = (0.5, 0.2, 0.25), (0.4, 0.3, 25)
-        model, mock_painter = draw_peaks(
-            (visible_peak_center, invisible_center), fg_color='r', slice_value=0.5, slice_width=30)
+        model, mock_painter = draw_peaks((visible_peak_center, invisible_center),
+                                         fg_color='r',
+                                         slice_value=0.5,
+                                         slice_width=30)
 
         model.clear_peak_representations()
 
@@ -72,9 +75,12 @@ class PeaksViewerModelTest(unittest.TestCase):
 
     def test_slice_center_transforms_center_to_correct_frame_and_order(self):
         peak_center = (1, 2, 3)
-        frame = SpecialCoordinateSystem.QSample
         model = create_peaks_viewer_model(centers=[peak_center], fg_color="red")
-        slice_info = SliceInfo(indices=(2, 1, 0), frame=frame, point=0.25, range=(15, 15))
+        slice_info = MagicMock()
+        slice_info.transform.side_effect = lambda p: [
+            peak_center[2], peak_center[1], peak_center[0]
+        ]
+        slice_info.frame = SpecialCoordinateSystem.QSample
 
         slice_center = model.slice_center(0, slice_info)
 
@@ -86,8 +92,10 @@ class PeaksViewerModelTest(unittest.TestCase):
 
     def test_zoom_to(self):
         visible_peak_center, invisible_center = (0.5, 0.2, 0.25), (0.4, 0.3, 25)
-        model, mock_painter = draw_peaks(
-            (visible_peak_center, invisible_center), fg_color='r', slice_value=0.5, slice_width=30)
+        model, mock_painter = draw_peaks((visible_peak_center, invisible_center),
+                                         fg_color='r',
+                                         slice_value=0.5,
+                                         slice_width=30)
 
         model.zoom_to(0)
 

--- a/qt/python/mantidqt/widgets/sliceviewer/presenter.py
+++ b/qt/python/mantidqt/widgets/sliceviewer/presenter.py
@@ -47,6 +47,8 @@ class SliceViewer(object):
         if self.model.can_normalize_workspace():
             self.view.data_view.norm_opts.currentTextChanged.connect(self.normalization_changed)
             self.view.data_view.set_normalization(ws)
+        if not self.model.can_support_nonorthogonal_axes():
+            self.view.data_view.disable_nonorthogonal_axes_button()
 
         self.new_plot()
 
@@ -61,9 +63,8 @@ class SliceViewer(object):
         Tell the view to display a new plot of an MDEventWorkspace
         """
         self.view.data_view.plot_MDH(
-            self.model.get_ws(
-                slicepoint=self.get_slicepoint(),
-                bin_params=self.view.data_view.dimensions.get_bin_params()))
+            self.model.get_ws(slicepoint=self.get_slicepoint(),
+                              bin_params=self.view.data_view.dimensions.get_bin_params()))
 
     def new_plot_matrix(self):
         """Tell the view to display a new plot of an MatrixWorkspace"""
@@ -71,11 +72,11 @@ class SliceViewer(object):
 
     def get_sliceinfo(self):
         """Returns a SliceInfo object describing the current slice"""
-        return SliceInfo(
-            indices=self.view.data_view.dimensions.get_indices(),
-            frame=self.model.get_frame(),
-            point=self.view.data_view.dimensions.get_slicepoint(),
-            range=self.view.data_view.dimensions.get_slicerange())
+        data_view = self.view.data_view
+        return SliceInfo(frame=self.model.get_frame(),
+                         point=data_view.dimensions.get_slicepoint(),
+                         transpose=data_view.dimensions.transpose,
+                         range=data_view.dimensions.get_slicerange())
 
     def get_slicepoint(self):
         """Returns the current slicepoint as a list of 3 elements.
@@ -90,6 +91,11 @@ class SliceViewer(object):
 
     def dimensions_changed(self):
         """Indicates that the dimensions have changed"""
+        data_view = self.view.data_view
+        if data_view.nonorthogonal_mode:
+            # axes need to be recreated to have the correct transform associated
+            data_view.create_axes_nonorthogonal(
+                self.model.create_nonorthogonal_transform(self.get_sliceinfo()))
         self.new_plot()
         self._peaks_view_presenter.notify(PeaksViewerPresenter.Event.OverlayPeaks)
 
@@ -110,10 +116,9 @@ class SliceViewer(object):
         Update the view to display an updated MDEventWorkspace slice/cut
         """
         self.view.data_view.update_plot_data(
-            self.model.get_data(
-                self.get_slicepoint(),
-                bin_params=self.view.data_view.dimensions.get_bin_params(),
-                transpose=self.view.data_view.dimensions.transpose))
+            self.model.get_data(self.get_slicepoint(),
+                                bin_params=self.view.data_view.dimensions.get_bin_params(),
+                                transpose=self.view.data_view.dimensions.transpose))
 
     def update_plot_data_matrix(self):
         # should never be called, since this workspace type is only 2D the plot dimensions never change
@@ -128,6 +133,25 @@ class SliceViewer(object):
             self.view.data_view.add_line_plots()
         else:
             self.view.data_view.remove_line_plots()
+
+    def nonorthogonal_axes(self, state: bool):
+        """
+        Toggle non-orthogonal axes on current view
+        :param state: If true a request is being made to turn them on, else they should be turned off
+        """
+        data_view = self.view.data_view
+        data_view.remove_line_plots()
+        if state:
+            data_view.disable_lineplots_button()
+            data_view.disable_peaks_button()
+            data_view.create_axes_nonorthogonal(
+                self.model.create_nonorthogonal_transform(self.get_sliceinfo()))
+            self.new_plot()
+        else:
+            data_view.create_axes_orthogonal()
+            data_view.enable_lineplots_button()
+            data_view.enable_peaks_button()
+            self.new_plot()
 
     def normalization_changed(self, norm_type):
         """

--- a/qt/python/mantidqt/widgets/sliceviewer/sliceinfo.py
+++ b/qt/python/mantidqt/widgets/sliceviewer/sliceinfo.py
@@ -5,34 +5,40 @@
 #   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
 # SPDX - License - Identifier: GPL - 3.0 +
 #  This file is part of the mantidqt.
-
 # std imports
-from collections import namedtuple
+from typing import Tuple, Sequence, Union
 
 # 3rd party
 import numpy as np
 
-# Encapsulate information current slice paramters
-_SliceInfoBase = namedtuple("SliceInfo", ("indices", "frame", "point", "range"))
+# Types
+SlicePointType = Sequence[Union[None, float]]
+SliceRange = Tuple[float, float]
 
 
-class SliceInfo(_SliceInfoBase):
+class SliceInfo:
     """
-    Keep information regarding the current slice of data. Allows transforming a point
+    Keep information regarding the current slice of data. Allows for transforming a point
     to the slice coordinate system.
 
     Fields:
-        indices: A list of 3 indices, (a,b,c),
-                 where a=index of displayed X dimension,
-                 b=index of displayed Y dimension and c=index of out of plane slicing dimension
         frame: A str indicating the frame of the slice
-        point: A float storing the current slice point
+        point: A list where None indicates a non-integrated dimension and
+               a float gives the current value of a slice at this dimension
+        transpose: A bool indicating if the displayed dimensions are swapped
         range: A 2-tuple giving the range of the slice in the slicing dimension
     """
+    def __init__(self, *, frame: str, point: SlicePointType, transpose: bool, range: SliceRange):
+        assert 3 == len(
+            point), f"Expected a length 3 array for slice point, found length={len(point)}"
+        self.frame = frame
+        self.slicepoint = point
+        self.range = range
+        self._display_x, self._display_y, self._display_z = self._create_display_mapping(transpose)
 
     @property
     def value(self):
-        return self.point[self.indices[2]]
+        return self.slicepoint[self._display_z]
 
     @property
     def width(self):
@@ -44,5 +50,29 @@ class SliceInfo(_SliceInfoBase):
         and Z is the out of place coordinate
         :param point: A 3D point in the slice frame
         """
-        dimindices = self.indices
-        return np.array((point[dimindices[0]], point[dimindices[1]], point[dimindices[2]]))
+        return np.array((point[self._display_x], point[self._display_y], point[self._display_z]))
+
+    # private api
+    def _create_display_mapping(self, transpose):
+        """
+        Set values of the display indexes into a point in data space for coordinates X,Y,Z in display space
+        For example,  slicepoint = [None,0.5,None] and transpose=True gives
+
+            x_index=2, y_index=0, z_index=1
+        :param transpose: If True then X,Y dimensions should be swapped
+        :return: A list of 3 indices corresponding to the display mapping
+        """
+        x_index, y_index, z_index = None, None, None
+        for index, pt in enumerate(self.slicepoint):
+            if pt is None:
+                if x_index is None:
+                    x_index = index
+                else:
+                    y_index = index
+            else:
+                z_index = index
+
+        if transpose:
+            x_index, y_index = y_index, x_index
+
+        return x_index, y_index, z_index

--- a/qt/python/mantidqt/widgets/sliceviewer/test/test_sliceviewer_model.py
+++ b/qt/python/mantidqt/widgets/sliceviewer/test/test_sliceviewer_model.py
@@ -7,47 +7,69 @@
 #  This file is part of the mantid workbench.
 #
 #
+import unittest
+from unittest.mock import MagicMock, patch
+
+from mantid.api import MatrixWorkspace, IMDEventWorkspace, IMDHistoWorkspace, \
+    SpecialCoordinateSystem
 from mantid.simpleapi import CreateMDHistoWorkspace, CreateWorkspace, CreateMDWorkspace, \
     FakeMDEventData
 from mantidqt.widgets.sliceviewer.model import SliceViewerModel, WS_TYPE
 from numpy.testing import assert_equal, assert_allclose
 import numpy as np
-import unittest
+
+
+class ArraysEqual:
+    def __init__(self, expected):
+        self._expected = expected
+
+    def __eq__(self, other):
+        return np.all(self._expected == other)
+
+    def __repr__(self):
+        return f"{self._expected}"
+
+
+def create_mock_sliceinfo(indices):
+    slice_info = MagicMock()
+    slice_info.transform.side_effect = lambda x: [x[indices[0]], x[indices[1]], x[indices[2]]]
+    return slice_info
 
 
 class SliceViewerModelTest(unittest.TestCase):
     @classmethod
     def setUpClass(self):
-        self.ws_MD_3D = CreateMDHistoWorkspace(
-            Dimensionality=3,
-            Extents='-3,3,-10,10,-1,1',
-            SignalInput=range(100),
-            ErrorInput=range(100),
-            NumberOfBins='5,5,4',
-            Names='Dim1,Dim2,Dim3',
-            Units='MomentumTransfer,EnergyTransfer,Angstrom',
-            OutputWorkspace='ws_MD_3D')
-        self.ws_MDE_3D = CreateMDWorkspace(
-            Dimensions='3',
-            Extents='-3,3,-4,4,-5,5',
-            Names='h,k,l',
-            Units='rlu,rlu,rlu',
-            SplitInto='4',
-            OutputWorkspace='ws_MDE_3D')
-        FakeMDEventData(
-            'ws_MDE_3D', PeakParams='100000,0,0,0,0.1', RandomSeed='63759', RandomizeSignal='1')
-        FakeMDEventData(
-            'ws_MDE_3D', PeakParams='40000,1,0,0,0.1', RandomSeed='63759', RandomizeSignal='1')
-        self.ws2d_histo = CreateWorkspace(
-            DataX=[10, 20, 30, 10, 20, 30],
-            DataY=[2, 3, 4, 5],
-            DataE=[1, 2, 3, 4],
-            NSpec=2,
-            Distribution=True,
-            UnitX='Wavelength',
-            VerticalAxisUnit='DeltaE',
-            VerticalAxisValues=[4, 6, 8],
-            OutputWorkspace='ws2d_histo')
+        self.ws_MD_3D = CreateMDHistoWorkspace(Dimensionality=3,
+                                               Extents='-3,3,-10,10,-1,1',
+                                               SignalInput=range(100),
+                                               ErrorInput=range(100),
+                                               NumberOfBins='5,5,4',
+                                               Names='Dim1,Dim2,Dim3',
+                                               Units='MomentumTransfer,EnergyTransfer,Angstrom',
+                                               OutputWorkspace='ws_MD_3D')
+        self.ws_MDE_3D = CreateMDWorkspace(Dimensions='3',
+                                           Extents='-3,3,-4,4,-5,5',
+                                           Names='h,k,l',
+                                           Units='rlu,rlu,rlu',
+                                           SplitInto='4',
+                                           OutputWorkspace='ws_MDE_3D')
+        FakeMDEventData('ws_MDE_3D',
+                        PeakParams='100000,0,0,0,0.1',
+                        RandomSeed='63759',
+                        RandomizeSignal='1')
+        FakeMDEventData('ws_MDE_3D',
+                        PeakParams='40000,1,0,0,0.1',
+                        RandomSeed='63759',
+                        RandomizeSignal='1')
+        self.ws2d_histo = CreateWorkspace(DataX=[10, 20, 30, 10, 20, 30],
+                                          DataY=[2, 3, 4, 5],
+                                          DataE=[1, 2, 3, 4],
+                                          NSpec=2,
+                                          Distribution=True,
+                                          UnitX='Wavelength',
+                                          VerticalAxisUnit='DeltaE',
+                                          VerticalAxisValues=[4, 6, 8],
+                                          OutputWorkspace='ws2d_histo')
 
     def test_model_MDH(self):
         model = SliceViewerModel(self.ws_MD_3D)
@@ -128,13 +150,11 @@ class SliceViewerModelTest(unittest.TestCase):
         self.assertEqual(d2.getMinimum(), -5)
         self.assertEqual(d2.getMaximum(), 5)
 
-        assert_allclose(
-            model.get_data((None, 0, None), (3, 0.001, 3)),
-            [[0, 0, 0], [0, 692.237618, 0], [0, 118.362777, 0]])
+        assert_allclose(model.get_data((None, 0, None), (3, 0.001, 3)),
+                        [[0, 0, 0], [0, 692.237618, 0], [0, 118.362777, 0]])
 
-        assert_allclose(
-            model.get_data((None, 0, None), (3, 0.001, 3), transpose=True),
-            [[0, 0, 0], [0, 692.237618, 118.362777], [0, 0, 0]])
+        assert_allclose(model.get_data((None, 0, None), (3, 0.001, 3), transpose=True),
+                        [[0, 0, 0], [0, 692.237618, 118.362777], [0, 0, 0]])
 
     def test_model_matrix(self):
         model = SliceViewerModel(self.ws2d_histo)
@@ -164,13 +184,12 @@ class SliceViewerModelTest(unittest.TestCase):
         self.assertEqual(dim_info['type'], 'MATRIX')
 
     def test_matrix_workspace_can_be_normalized_if_not_a_distribution(self):
-        ws2d = CreateWorkspace(
-            DataX=[10, 20, 30, 10, 20, 30],
-            DataY=[2, 3, 4, 5],
-            DataE=[1, 2, 3, 4],
-            NSpec=2,
-            Distribution=False,
-            OutputWorkspace='ws2d')
+        ws2d = CreateWorkspace(DataX=[10, 20, 30, 10, 20, 30],
+                               DataY=[2, 3, 4, 5],
+                               DataE=[1, 2, 3, 4],
+                               NSpec=2,
+                               Distribution=False,
+                               OutputWorkspace='ws2d')
         model = SliceViewerModel(ws2d)
         self.assertTrue(model.can_normalize_workspace())
 
@@ -185,6 +204,129 @@ class SliceViewerModelTest(unittest.TestCase):
     def test_MDE_workspaces_cannot_be_normalized(self):
         model = SliceViewerModel(self.ws_MDE_3D)
         self.assertFalse(model.can_normalize_workspace())
+
+    def test_MDH_workspace_in_hkl_supports_non_orthogonal_axes(self):
+        self._assert_supports_non_orthogonal_axes(True,
+                                                  ws_type=IMDHistoWorkspace,
+                                                  units=SpecialCoordinateSystem.HKL,
+                                                  has_oriented_lattice=True)
+
+    def test_MDE_workspace_in_hkl_supports_non_orthogonal_axes(self):
+        self._assert_supports_non_orthogonal_axes(True,
+                                                  ws_type=IMDEventWorkspace,
+                                                  units=SpecialCoordinateSystem.HKL,
+                                                  has_oriented_lattice=True)
+
+    def test_matrix_workspace_cannot_support_non_orthogonal_axes(self):
+        self._assert_supports_non_orthogonal_axes(False,
+                                                  ws_type=MatrixWorkspace,
+                                                  units=SpecialCoordinateSystem.HKL,
+                                                  has_oriented_lattice=None)
+
+    def test_MDH_workspace_in_hkl_without_lattice_cannot_support_non_orthogonal_axes(self):
+        self._assert_supports_non_orthogonal_axes(False,
+                                                  ws_type=IMDHistoWorkspace,
+                                                  units=SpecialCoordinateSystem.HKL,
+                                                  has_oriented_lattice=False)
+
+    def test_MDE_workspace_in_hkl_without_lattice_cannot_support_non_orthogonal_axes(self):
+        self._assert_supports_non_orthogonal_axes(False,
+                                                  ws_type=IMDEventWorkspace,
+                                                  units=SpecialCoordinateSystem.HKL,
+                                                  has_oriented_lattice=False)
+
+    def test_MDH_workspace_in_non_hkl_cannot_support_non_orthogonal_axes(self):
+        self._assert_supports_non_orthogonal_axes(False,
+                                                  ws_type=IMDHistoWorkspace,
+                                                  units=SpecialCoordinateSystem.QLab,
+                                                  has_oriented_lattice=False)
+        self._assert_supports_non_orthogonal_axes(False,
+                                                  ws_type=IMDHistoWorkspace,
+                                                  units=SpecialCoordinateSystem.QLab,
+                                                  has_oriented_lattice=True)
+
+    def test_MDE_workspace_in_non_hkl_cannot_support_non_orthogonal_axes(self):
+        self._assert_supports_non_orthogonal_axes(False,
+                                                  ws_type=IMDEventWorkspace,
+                                                  units=SpecialCoordinateSystem.QLab,
+                                                  has_oriented_lattice=False)
+        self._assert_supports_non_orthogonal_axes(False,
+                                                  ws_type=IMDEventWorkspace,
+                                                  units=SpecialCoordinateSystem.QLab,
+                                                  has_oriented_lattice=True)
+
+    def test_create_non_orthogonal_transform_raises_error_if_not_supported(self):
+        model = SliceViewerModel(
+            self._create_mock_workspace(MatrixWorkspace,
+                                        SpecialCoordinateSystem.QLab,
+                                        has_oriented_lattice=False))
+
+        self.assertRaises(RuntimeError, model.create_nonorthogonal_transform, (0, 1, 2))
+
+    @patch("mantidqt.widgets.sliceviewer.model.NonOrthogonalTransform")
+    def test_create_non_orthogonal_transform_uses_W_if_avilable(self, mock_nonortho_trans):
+        ws = self._create_mock_workspace(IMDEventWorkspace,
+                                         SpecialCoordinateSystem.HKL,
+                                         has_oriented_lattice=True)
+        w_prop = MagicMock()
+        w_prop.value = [0, 1, 1, 0, 0, 1, 1, 0, 0]
+        run = MagicMock()
+        run.get.return_value = w_prop
+        ws.getExperimentInfo().run.return_value = run
+        lattice = MagicMock()
+        ws.getExperimentInfo().sample().getOrientedLattice.return_value = lattice
+        model = SliceViewerModel(ws)
+
+        model.create_nonorthogonal_transform(create_mock_sliceinfo([1, 2, 0]))
+
+        mock_nonortho_trans.from_lattice.assert_called_once_with(
+            lattice,
+            x_proj=ArraysEqual(np.array([1, 0, 0])),
+            y_proj=ArraysEqual(np.array([1, 1, 0])))
+
+    @patch("mantidqt.widgets.sliceviewer.model.NonOrthogonalTransform")
+    def test_create_non_orthogonal_transform_uses_identity_if_W_unavilable(
+            self, mock_nonortho_trans):
+        ws = self._create_mock_workspace(IMDEventWorkspace,
+                                         SpecialCoordinateSystem.HKL,
+                                         has_oriented_lattice=True)
+        lattice = MagicMock()
+        ws.getExperimentInfo().sample().getOrientedLattice.return_value = lattice
+        run = MagicMock()
+        run.get.side_effect = KeyError
+        ws.getExperimentInfo().run.return_value = run
+        model = SliceViewerModel(ws)
+
+        model.create_nonorthogonal_transform(create_mock_sliceinfo([1, 2, 0]))
+
+        mock_nonortho_trans.from_lattice.assert_called_once_with(
+            lattice,
+            x_proj=ArraysEqual(np.array([0, 1, 0])),
+            y_proj=ArraysEqual(np.array([0, 0, 1])))
+
+    # private
+    def _assert_supports_non_orthogonal_axes(self, expectation, ws_type, units,
+                                             has_oriented_lattice):
+        model = SliceViewerModel(self._create_mock_workspace(ws_type, units, has_oriented_lattice))
+        self.assertEqual(expectation, model.can_support_nonorthogonal_axes())
+
+    def _create_mock_workspace(self, ws_type, units, has_oriented_lattice):
+        ws = MagicMock(spec=ws_type)
+        if hasattr(ws, 'getExperimentInfo'):
+            ws.getSpecialCoordinateSystem.return_value = units
+            ws.getNonIntegratedDimensions.return_value = [MagicMock(), MagicMock()]
+            expt_info = MagicMock()
+            sample = MagicMock()
+            sample.hasOrientedLattice.return_value = has_oriented_lattice
+            expt_info.sample.return_value = sample
+            ws.getExperimentInfo.return_value = expt_info
+        elif hasattr(ws, 'getNumberHistograms'):
+            ws.getNumberHistograms.return_value = 3
+            mock_dimension = MagicMock()
+            mock_dimension.getNBins.return_value = 3
+            ws.getDimension.return_value = mock_dimension
+
+        return ws
 
 
 if __name__ == '__main__':

--- a/qt/python/mantidqt/widgets/sliceviewer/test/test_sliceviewer_sliceinfo.py
+++ b/qt/python/mantidqt/widgets/sliceviewer/test/test_sliceviewer_sliceinfo.py
@@ -14,17 +14,34 @@ from mantidqt.widgets.sliceviewer.sliceinfo import SliceInfo
 
 class SliceInfoTest(unittest.TestCase):
     def test_construction_with_named_fields(self):
-        indices, frame, point, dimrange = (0, 1, 2), "HKL", (None, None, 0.5), (-15, 15)
-        info = SliceInfo(indices=indices, frame=frame, point=point, range=dimrange)
+        frame, point, transpose, dimrange = "HKL", (None, None, 0.5), False, (-15, 15)
+        info = SliceInfo(frame=frame, point=point, transpose=transpose, range=dimrange)
 
-        self.assertEqual(indices, info.indices)
         self.assertEqual(frame, info.frame)
-        self.assertEqual(point, info.point)
+        self.assertEqual(point, info.slicepoint)
         self.assertEqual(dimrange, info.range)
+        self.assertEqual(point[2], info.value)
 
-    def test_transform_uses_indices_to_transform_to_slice_frame(self):
+    def test_transform_selects_dimensions_correctly_when_not_transposed(self):
+        # Set slice info such that display(X,Y) = data(Y,Z)
+        slice_pt = 0.5
+        info = SliceInfo(frame="HKL",
+                         point=(slice_pt, None, None),
+                         transpose=False,
+                         range=(-15, 15))
+
+        frame_point = (0.5, 1.0, -1.5)
+        slice_frame = info.transform(frame_point)
+
+        self.assertEqual(frame_point[1], slice_frame[0])
+        self.assertEqual(frame_point[2], slice_frame[1])
+        self.assertEqual(frame_point[0], slice_frame[2])
+        self.assertEqual(slice_pt, info.value)
+
+    def test_transform_selects_dimensions_correctly_when_transposed(self):
         # Set slice info such that display(X,Y) = data(Z,Y)
-        info = SliceInfo(indices=(2, 1, 0), frame="HKL", point=(None, None, 0.5), range=(-15, 15))
+        slice_pt = 0.5
+        info = SliceInfo(frame="HKL", point=(slice_pt, None, None), transpose=True, range=(-15, 15))
 
         frame_point = (0.5, 1.0, -1.5)
         slice_frame = info.transform(frame_point)
@@ -32,6 +49,15 @@ class SliceInfoTest(unittest.TestCase):
         self.assertEqual(frame_point[2], slice_frame[0])
         self.assertEqual(frame_point[1], slice_frame[1])
         self.assertEqual(frame_point[0], slice_frame[2])
+        self.assertEqual(slice_pt, info.value)
+
+    def test_slicepoint_not_length_three_raises_errors(self):
+        self.assertRaises(AssertionError,
+                          SliceInfo,
+                          frame="HKL",
+                          point=(1, None, None, 4),
+                          transpose=True,
+                          range=(-15, 15))
 
 
 if __name__ == '__main__':

--- a/qt/python/mantidqt/widgets/sliceviewer/test/test_sliceviewer_transform.py
+++ b/qt/python/mantidqt/widgets/sliceviewer/test/test_sliceviewer_transform.py
@@ -1,0 +1,67 @@
+# Mantid Repository : https://github.com/mantidproject/mantid
+#
+# Copyright &copy; 2018 ISIS Rutherford Appleton Laboratory UKRI,
+#   NScD Oak Ridge National Laboratory, European Spallation Source,
+#   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+# SPDX - License - Identifier: GPL - 3.0 +
+#  This file is part of the mantid workbench.
+import unittest
+
+from mantid.geometry import OrientedLattice
+from mantidqt.widgets.sliceviewer.transform import NonOrthogonalTransform
+from numpy.testing import assert_allclose
+import numpy as np
+
+
+class TransformTest(unittest.TestCase):
+    def test_create_nonorthogonal_transform_with_orthogonal_lattice_and_projections(self):
+        lattice = OrientedLattice()  # default angle=90 degrees
+        transform = NonOrthogonalTransform.from_lattice(lattice, x_proj=(1, 0, 0), y_proj=(0, 1, 0))
+
+        self.assertAlmostEqual(transform.angle, 0.5 * np.pi)
+
+    def test_create_nonorthogonal_transform_with_orthogonal_lattice_and_nonorthogonal_projections(
+            self):
+        lattice = OrientedLattice()  # default angle=90 degrees
+        transform = NonOrthogonalTransform.from_lattice(lattice, x_proj=(1, 0, 0), y_proj=(1, 1, 0))
+
+        self.assertAlmostEqual(transform.angle, 0.25 * np.pi)
+
+    def test_create_nonorthogonal_transform_with_nonorthogonal_lattice_and_orthogonal_projections(
+            self):
+        lattice = OrientedLattice(1, 1, 2, 90, 90, 120.)
+        x_proj, y_proj = (1, 0, 0), (0, 1, 0)
+        transform = NonOrthogonalTransform.from_lattice(lattice, x_proj, y_proj)
+
+        self.assertAlmostEqual(transform.angle, np.radians(lattice.recAngle(*x_proj, *y_proj)))
+
+    def test_create_nonorthogonal_transform_with_nonorthogonal_lattice_and_nonorthogonal_projections(
+            self):
+        lattice = OrientedLattice(1, 1, 2, 90, 90, 120.)
+        x_proj, y_proj = (1, 0, 0), (1, 1, 0)
+        transform = NonOrthogonalTransform.from_lattice(lattice, x_proj, y_proj)
+
+        self.assertAlmostEqual(transform.angle, np.radians(lattice.recAngle(*x_proj, *y_proj)))
+
+    def test_nonorthogonal_transform_skews_as_expected(self):
+        transform = NonOrthogonalTransform(angle=np.radians(45.))  # 45deg
+
+        x = np.array([0, 1])
+        y = np.array([1, 0])
+        xp, yp = transform.tr(x, y)
+
+        assert_allclose(xp, np.array([1. / np.sqrt(2.), 1.]))
+        assert_allclose(yp, np.array([1. / np.sqrt(2.), 0.]))
+
+    def test_nonorthogonal_transform_round_trip(self):
+        transform = NonOrthogonalTransform(angle=np.radians(40.))
+        x, y = np.array([1., 2., 3.]), np.array([4., 5., 6.])
+        xp, yp = transform.tr(x, y)
+        xpinv, ypinv = transform.inv_tr(xp, yp)
+
+        assert_allclose(x, xpinv)
+        assert_allclose(y, ypinv)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/qt/python/mantidqt/widgets/sliceviewer/toolbar.py
+++ b/qt/python/mantidqt/widgets/sliceviewer/toolbar.py
@@ -5,8 +5,6 @@
 #   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
 # SPDX - License - Identifier: GPL - 3.0 +
 #    This file is part of the mantid workbench.
-#
-#
 
 from mantidqt.MPLwidgets import NavigationToolbar2QT
 from mantidqt.icons import get_icon
@@ -14,25 +12,42 @@ from qtpy.QtCore import Signal, Qt, QSize
 from qtpy.QtWidgets import QLabel, QSizePolicy
 
 
+class ToolItemText:
+    HOME = 'Home'
+    PAN = 'Pan'
+    ZOOM = 'Zoom'
+    GRID = 'Grid'
+    LINEPLOTS = 'LinePlots'
+    OVERLAYPEAKS = 'OverlayPeaks'
+    NONORTHOGONAL_AXES = 'NonOrthogonalAxes'
+    SAVE = 'Save'
+    CUSTOMIZE = 'Customize'
+
+
 class SliceViewerNavigationToolbar(NavigationToolbar2QT):
 
     gridClicked = Signal()
     linePlotsClicked = Signal(bool)
+    nonOrthogonalClicked = Signal(bool)
     peaksOverlayClicked = Signal(bool)
     plotOptionsChanged = Signal()
 
     toolitems = (
-        ('Home', 'Reset original view', 'mdi.home', 'home', None),
-        ('Pan', 'Pan axes with left mouse, zoom with right', 'mdi.arrow-all', 'pan', False),
-        ('Zoom', 'Zoom to rectangle', 'mdi.magnify', 'zoom', False),
+        (ToolItemText.HOME, 'Reset original view', 'mdi.home', 'home', None),
+        (ToolItemText.PAN, 'Pan axes with left mouse, zoom with right', 'mdi.arrow-all', 'pan',
+         False),
+        (ToolItemText.ZOOM, 'Zoom to rectangle', 'mdi.magnify', 'zoom', False),
         (None, None, None, None, None),
-        ('Grid', 'Toggle grid on/off', 'mdi.grid', 'gridClicked', None),
-        ('LinePlots', 'Toggle lineplots on/off', 'mdi.chart-bell-curve', 'linePlotsClicked', False),
-        ('OverlayPeaks', 'Add peaks overlays on/off', 'mdi.chart-bubble', 'peaksOverlayClicked',
-         None),
-        ('Save', 'Save the figure', 'mdi.content-save', 'save_figure', None),
+        (ToolItemText.GRID, 'Toggle grid on/off', 'mdi.grid', 'gridClicked', None),
+        (ToolItemText.LINEPLOTS, 'Toggle lineplots on/off', 'mdi.chart-bell-curve',
+         'linePlotsClicked', False),
+        (ToolItemText.OVERLAYPEAKS, 'Add peaks overlays on/off', 'mdi.chart-bubble',
+         'peaksOverlayClicked', None),
+        (ToolItemText.NONORTHOGONAL_AXES, 'Toggle nonorthogonal axes on/off', 'mdi.axis',
+         'nonOrthogonalClicked', False),
         (None, None, None, None, None),
-        ('Customize', 'Configure plot options', 'mdi.settings', 'edit_parameters', None),
+        (ToolItemText.SAVE, 'Save the figure', 'mdi.content-save', 'save_figure', None),
+        (ToolItemText.CUSTOMIZE, 'Configure plot options', 'mdi.settings', 'edit_parameters', None),
     )
 
     def _init_toolbar(self):
@@ -67,3 +82,14 @@ class SliceViewerNavigationToolbar(NavigationToolbar2QT):
     def edit_parameters(self):
         NavigationToolbar2QT.edit_parameters(self)
         self.plotOptionsChanged.emit()
+
+    def set_action_enabled(self, text: str, state: bool):
+        """
+        Sets the enabled/disabled state of action with the given text
+        :param text: Text on the action
+        :param state: Enabled if True else it is disabled
+        """
+        actions = self.actions()
+        for action in actions:
+            if action.text() == text:
+                action.setEnabled(state)

--- a/qt/python/mantidqt/widgets/sliceviewer/transform.py
+++ b/qt/python/mantidqt/widgets/sliceviewer/transform.py
@@ -1,0 +1,58 @@
+# Mantid Repository : https://github.com/mantidproject/mantid
+#
+# Copyright &copy; 2020 ISIS Rutherford Appleton Laboratory UKRI,
+#   NScD Oak Ridge National Laboratory, European Spallation Source,
+#   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+# SPDX - License - Identifier: GPL - 3.0 +
+#  This file is part of the mantidqt.
+# std imports
+from typing import Sequence
+
+# thirdparty
+from mantid.geometry import OrientedLattice
+import numpy as np
+
+
+class NonOrthogonalTransform:
+    """
+    Defines transformations to move between an orthogonal system and a non-orthogonal system
+    defined by the lattice and projection vectors.
+    """
+    @classmethod
+    def from_lattice(cls, lattice: OrientedLattice, x_proj: Sequence, y_proj: Sequence):
+        """
+        :param lattice: An OrientedLattice object defining the unit cell
+        :param x_proj: Projection vector of dimension associated with X coordinate
+        :param y_proj: Projection vector of dimension associated with Y coordinate
+        """
+        return cls(np.radians(lattice.recAngle(*x_proj, *y_proj)))
+
+    def __init__(self, angle: float):
+        """
+        :param angle: Angle in radians of skewed. Angle increases anti-clockwise from X
+        """
+        self._angle = angle
+
+    @property
+    def angle(self):
+        return self._angle
+
+    def tr(self, x, y):
+        """Transform coordinate arrays from the non-orthogonal frame
+            aligned with the crystal to the orthogonal display frame
+        :param x: Numpy array of X coordinates in non-orthogonal frame
+        :param y: Numpy array of Y coordinates in non-orthogonal frame
+        :return: (x, y) of transformed coordinates. lengths of arrays match input
+        """
+        angle = self._angle
+        return x + np.cos(angle) * y, np.sin(angle) * y
+
+    def inv_tr(self, x, y):
+        """Transform coordinate arrays from the orthogonal display frame
+        to the non-orthogonal frame aligned with the crystal
+        :param x: Numpy array of X coordinates in orthogonal display frame
+        :param y: Numpy array of Y coordinates in orthogonal display frame
+        :return: (x, y) of transformed coordinates. lengths of arrays match input
+        """
+        angle = self._angle
+        return x - y / np.tan(angle), y / np.sin(angle)

--- a/qt/python/mantidqt/widgets/sliceviewer/view.py
+++ b/qt/python/mantidqt/widgets/sliceviewer/view.py
@@ -5,41 +5,44 @@
 #   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
 # SPDX - License - Identifier: GPL - 3.0 +
 #  This file is part of the mantid workbench.
-#
-#
+# 3rd party imports
+
+import mantid.api
+from mantid.plots.axesfunctions import _pcolormesh_nonortho as pcolormesh_nonorthogonal
+from mantid.plots.datafunctions import get_normalize_by_bin_width
 from matplotlib import gridspec
 from matplotlib.figure import Figure
 from matplotlib.transforms import Bbox, BboxTransform
+from mpl_toolkits.axisartist import Subplot as CurveLinearSubPlot
+from mpl_toolkits.axisartist.grid_helper_curvelinear import GridHelperCurveLinear
+import numpy as np
+from qtpy.QtCore import Qt
+from qtpy.QtWidgets import QComboBox, QGridLayout, QLabel, QHBoxLayout, QSplitter, QVBoxLayout, QWidget
 
-import mantid.api
-from mantid.plots.datafunctions import get_normalize_by_bin_width
+# local imports
 from mantidqt.MPLwidgets import FigureCanvas
 from mantidqt.widgets.colorbar.colorbar import ColorbarWidget
 from .dimensionwidget import DimensionWidget
 from .samplingimage import imshow_sampling
-from .toolbar import SliceViewerNavigationToolbar
+from .toolbar import SliceViewerNavigationToolbar, ToolItemText
 from .peaksviewer.workspaceselection import \
     (PeaksWorkspaceSelectorModel, PeaksWorkspaceSelectorPresenter,
      PeaksWorkspaceSelectorView)
 from .peaksviewer.view import PeaksViewerCollectionView
 from .peaksviewer.representation.painter import MplPainter
 
-import numpy as np
-
-from qtpy.QtCore import Qt
-from qtpy.QtWidgets import QComboBox, QGridLayout, QLabel, QHBoxLayout, QSplitter, QVBoxLayout, QWidget
-
 
 class SliceViewerDataView(QWidget):
     """The view for the data portion of the sliceviewer"""
-
     def __init__(self, presenter, dims_info, can_normalise, parent=None):
         super().__init__(parent)
 
         self.presenter = presenter
 
+        self.image = None
         self.line_plots = False
         self.can_normalise = can_normalise
+        self.nonortho_tr = None
 
         # Dimension widget
         self.dimensions_layout = QHBoxLayout()
@@ -65,10 +68,11 @@ class SliceViewerDataView(QWidget):
         self.mpl_layout = QHBoxLayout()
         self.fig = Figure()
         self.ax = None
+        self._grid_on = False
         self.fig.set_facecolor(self.palette().window().color().getRgbF())
         self.canvas = FigureCanvas(self.fig)
         self.canvas.mpl_connect('motion_notify_event', self.mouse_move)
-        self.create_axes()
+        self.create_axes_orthogonal()
         self.mpl_layout.addWidget(self.canvas)
         self.colorbar = ColorbarWidget(self)
         self.colorbar_layout.addWidget(self.colorbar)
@@ -81,6 +85,7 @@ class SliceViewerDataView(QWidget):
         self.mpl_toolbar.gridClicked.connect(self.toggle_grid)
         self.mpl_toolbar.linePlotsClicked.connect(self.line_plots_toggle)
         self.mpl_toolbar.plotOptionsChanged.connect(self.colorbar.mappable_changed)
+        self.mpl_toolbar.nonOrthogonalClicked.connect(self.non_orthogonal_axes_toggle)
 
         # layout
         self.layout = QGridLayout(self)
@@ -88,11 +93,38 @@ class SliceViewerDataView(QWidget):
         self.layout.addWidget(self.mpl_toolbar, 1, 0)
         self.layout.addLayout(self.mpl_layout, 2, 0)
 
-    def create_axes(self):
-        self.fig.clf()
+    @property
+    def grid_on(self):
+        return self._grid_on
+
+    @property
+    def nonorthogonal_mode(self):
+        return self.nonortho_tr is not None
+
+    def create_axes_orthogonal(self):
+        self.clear_figure()
+        self.nonortho_tr = None
         self.ax = self.fig.add_subplot(111, projection='mantid')
+        if self.grid_on:
+            self.ax.grid()
         if self.line_plots:
             self.add_line_plots()
+        self.plot_MDH = self.plot_MDH_orthogonal
+
+        self.canvas.draw_idle()
+
+    def create_axes_nonorthogonal(self, transform):
+        self.clear_figure()
+        self.set_nonorthogonal_transform(transform)
+        self.ax = CurveLinearSubPlot(self.fig,
+                                     1,
+                                     1,
+                                     1,
+                                     grid_helper=GridHelperCurveLinear(
+                                         (self.nonortho_tr, transform.inv_tr)))
+        self.set_grid_on()
+        self.fig.add_subplot(self.ax)
+        self.plot_MDH = self.plot_MDH_nonorthogonal
 
         self.canvas.draw_idle()
 
@@ -107,8 +139,12 @@ class SliceViewerDataView(QWidget):
             return
 
         # Create a new GridSpec and reposition the existing image Axes
-        gs = gridspec.GridSpec(
-            2, 2, width_ratios=[1, 4], height_ratios=[4, 1], wspace=0.0, hspace=0.0)
+        gs = gridspec.GridSpec(2,
+                               2,
+                               width_ratios=[1, 4],
+                               height_ratios=[4, 1],
+                               wspace=0.0,
+                               hspace=0.0)
         image_axes.set_position(gs[1].get_position(self.fig))
         image_axes.xaxis.set_visible(False)
         image_axes.yaxis.set_visible(False)
@@ -145,40 +181,63 @@ class SliceViewerDataView(QWidget):
         self.mpl_toolbar.update()  # sync list of axes in navstack
         self.canvas.draw_idle()
 
-    def plot_MDH(self, ws, **kwargs):
+    def plot_MDH_orthogonal(self, ws, **kwargs):
         """
         clears the plot and creates a new one using a MDHistoWorkspace
         """
-        self.ax.clear()
-        self.im = self.ax.imshow(
-            ws,
-            origin='lower',
-            aspect='auto',
-            transpose=self.dimensions.transpose,
-            norm=self.colorbar.get_norm(),
-            **kwargs)
+        self.clear_image()
+        self.image = self.ax.imshow(ws,
+                                    origin='lower',
+                                    aspect='auto',
+                                    transpose=self.dimensions.transpose,
+                                    norm=self.colorbar.get_norm(),
+                                    **kwargs)
+        self.draw_plot()
+
+    def plot_MDH_nonorthogonal(self, ws, **kwargs):
+        self.clear_image()
+        self.image = pcolormesh_nonorthogonal(self.ax,
+                                              ws,
+                                              self.nonortho_tr,
+                                              transpose=self.dimensions.transpose,
+                                              norm=self.colorbar.get_norm(),
+                                              **kwargs)
+        # pcolormesh clears any grid that was previously visible
+        if self.grid_on:
+            self.ax.grid()
         self.draw_plot()
 
     def plot_matrix(self, ws, **kwargs):
         """
         clears the plot and creates a new one using a MatrixWorkspace
         """
-        self.ax.clear()
-        self.im = imshow_sampling(
-            self.ax,
-            ws,
-            origin='lower',
-            aspect='auto',
-            interpolation='none',
-            transpose=self.dimensions.transpose,
-            norm=self.colorbar.get_norm(),
-            **kwargs)
-        self.im._resample_image()
+        self.clear_image()
+        self.image = imshow_sampling(self.ax,
+                                     ws,
+                                     origin='lower',
+                                     aspect='auto',
+                                     interpolation='none',
+                                     transpose=self.dimensions.transpose,
+                                     norm=self.colorbar.get_norm(),
+                                     **kwargs)
+        self.image._resample_image()
         self.draw_plot()
+
+    def clear_image(self):
+        """Removes any image from the axes"""
+        if self.image is not None:
+            self.image.remove()
+            self.image = None
+
+    def clear_figure(self):
+        """Removes everything from the figure"""
+        self.image = None
+        self._grid_on = False
+        self.fig.clf()
 
     def draw_plot(self):
         self.ax.set_title('')
-        self.colorbar.set_mappable(self.im)
+        self.colorbar.set_mappable(self.image)
         self.colorbar.update_clim()
         self.mpl_toolbar.update()  # clear nav stack
         self.clear_line_plots()
@@ -188,12 +247,51 @@ class SliceViewerDataView(QWidget):
         """
         This just updates the plot data without creating a new plot
         """
-        self.im.set_data(data.T)
+        if self.nonortho_tr:
+            self.image.set_array(data.T.ravel())
+        else:
+            self.image.set_data(data.T)
         self.colorbar.update_clim()
 
     def line_plots_toggle(self, state):
         self.presenter.line_plots(state)
         self.line_plots = state
+
+    def non_orthogonal_axes_toggle(self, state):
+        """
+        Switch state of the non-orthognal axes on/off
+        """
+        self.presenter.nonorthogonal_axes(state)
+
+    def enable_lineplots_button(self):
+        """
+        Enables line plots functionality
+        """
+        self.mpl_toolbar.set_action_enabled(ToolItemText.LINEPLOTS, True)
+
+    def disable_lineplots_button(self):
+        """
+        Disabled line plots functionality
+        """
+        self.mpl_toolbar.set_action_enabled(ToolItemText.LINEPLOTS, False)
+
+    def enable_peaks_button(self):
+        """
+        Enables line plots functionality
+        """
+        self.mpl_toolbar.set_action_enabled(ToolItemText.OVERLAYPEAKS, True)
+
+    def disable_peaks_button(self):
+        """
+        Disables line plots functionality
+        """
+        self.mpl_toolbar.set_action_enabled(ToolItemText.OVERLAYPEAKS, False)
+
+    def disable_nonorthogonal_axes_button(self):
+        """
+        Disables non-orthorognal axes functionality
+        """
+        self.mpl_toolbar.set_action_enabled(ToolItemText.NONORTHOGONAL_AXES, False)
 
     def clear_line_plots(self):
         try:  # clear old plots
@@ -203,7 +301,7 @@ class SliceViewerDataView(QWidget):
             pass
 
     def update_data_clim(self):
-        self.im.set_clim(self.colorbar.colorbar.mappable.get_clim())
+        self.image.set_clim(self.colorbar.colorbar.mappable.get_clim())
         self.canvas.draw_idle()
 
     def update_line_plot_limits(self):
@@ -211,8 +309,27 @@ class SliceViewerDataView(QWidget):
             self.axx.set_ylim(self.colorbar.cmin_value, self.colorbar.cmax_value)
             self.axy.set_xlim(self.colorbar.cmin_value, self.colorbar.cmax_value)
 
+    def set_grid_on(self):
+        """
+        If not visible sets the grid visibility
+        """
+        if not self._grid_on:
+            self.toggle_grid()
+
+    def set_nonorthogonal_transform(self, transform):
+        """
+        Set the transform for nonorthogonal axes mode
+        :param transform: An object with a tr method to transform from nonorthognal
+                          coordinates to display coordinates
+        """
+        self.nonortho_tr = transform.tr
+
     def toggle_grid(self):
+        """
+        Toggle the visibility of the grid on the axes
+        """
         self.ax.grid()
+        self._grid_on = not self._grid_on
         self.canvas.draw_idle()
 
     def mouse_move(self, event):
@@ -240,8 +357,8 @@ class SliceViewerDataView(QWidget):
         self.canvas.draw_idle()
 
     def update_line_plots(self, x, y):
-        xmin, xmax, ymin, ymax = self.im.get_extent()
-        arr = self.im.get_array()
+        xmin, xmax, ymin, ymax = self.image.get_extent()
+        arr = self.image.get_array()
         data_extent = Bbox([[ymin, xmin], [ymax, xmax]])
         array_extent = Bbox([[0, 0], arr.shape[:2]])
         trans = BboxTransform(boxin=data_extent, boxout=array_extent)
@@ -267,7 +384,6 @@ class SliceViewerDataView(QWidget):
 
 class SliceViewerView(QWidget):
     """Combines the data view for the slice viewer with the optional peaks viewer."""
-
     def __init__(self, presenter, dims_info, can_normalise, parent=None):
         super().__init__(parent)
 
@@ -303,8 +419,8 @@ class SliceViewerView(QWidget):
     def peaks_view(self):
         """Lazily instantiates PeaksViewer and returns it"""
         if self._peaks_view is None:
-            self._peaks_view = PeaksViewerCollectionView(
-                MplPainter(self.data_view.ax), self.presenter)
+            self._peaks_view = PeaksViewerCollectionView(MplPainter(self.data_view.ax),
+                                                         self.presenter)
             self._splitter.addWidget(self._peaks_view)
 
         return self._peaks_view
@@ -325,8 +441,8 @@ class SliceViewerView(QWidget):
         :param current_overlayed_names: A list of names that are currently overlayed
         :returns: A list of workspace names to overlay on the display
         """
-        model = PeaksWorkspaceSelectorModel(
-            mantid.api.AnalysisDataService.Instance(), checked_names=current_overlayed_names)
+        model = PeaksWorkspaceSelectorModel(mantid.api.AnalysisDataService.Instance(),
+                                            checked_names=current_overlayed_names)
         view = PeaksWorkspaceSelectorView(self)
         presenter = PeaksWorkspaceSelectorPresenter(view, model)
         return presenter.select_peaks_workspaces()


### PR DESCRIPTION
**Description of work.**

Adds a button to toggle display of non-orthogonal axes in the workbench slice viewer. This first cut disables both line-plots and the peaks overlay that will be dealt with in future issues.

**To test:**

```python
from mantid.simpleapi import *

SXD23767 = Load(Filename='SXD23767.raw', LoadMonitors='Exclude')
# Set some UB with angles we can play with
SetUB(SXD23767, 1,1,2,90,90,120)
mdws = ConvertToDiffractionMDWorkspace(InputWorkspace='SXD23767',
                                       OutputDimensions='HKL')
```

Refs #27464

*This does not require release notes* because **I think it is worth making release notes for the work once it is more complete so we can make proper screenshots before it goes into 5.1**


---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
