### PR TITLE
Properly Update Colorfill Interpolation Option

### DIFF
--- a/docs/source/release/v5.1.0/mantidworkbench.rst
+++ b/docs/source/release/v5.1.0/mantidworkbench.rst
@@ -47,6 +47,7 @@ Bugfixes
 - Fixed the default axis scale settings applying to the wrong axis.
 - Performing an overplot by dragging workspaces onto colorfill plots now correctly replaces the workspace.
 - Removed gridlines from the colorbar on colorfill plots.
+- The correct interpolation now appears in the plot figure options for colorfill plots.
 - Changing the axis scale on a colourfill plot now has the same result if it is done from either the context menu or figure options.
 
 :ref:`Release 5.1.0 <v5.1.0>`

--- a/qt/python/mantidqt/widgets/plotconfigdialog/imagestabwidget/view.py
+++ b/qt/python/mantidqt/widgets/plotconfigdialog/imagestabwidget/view.py
@@ -115,7 +115,11 @@ class ImagesTabWidgetView(QWidget):
         return self.interpolation_combo_box.currentText()
 
     def set_interpolation(self, interpolation):
-        self.interpolation_combo_box.setCurrentText(interpolation)
+        index = self.interpolation_combo_box.findText(interpolation, flags=Qt.MatchFixedString)
+        if index >= 0:  # -1 indicates the value was not found.
+            self.interpolation_combo_box.setCurrentIndex(index)
+        else:
+            self.interpolation_combo_box.setCurrentIndex(0)
 
     def get_scale(self):
         return self.scale_combo_box.currentText()


### PR DESCRIPTION
**Description of work.**
The figure options for colorfill plots should now contain the correct setting for interpolation when they are opened. 

**To test:**
1. Plot a colorfill.
2. Open the figure options. 
3. Switch to the images tab
4. Change the interpolation setting and make a note of what it was changed to. 
5. Click Okay.
6. Re-Open the figure options. The interpolation setting should be the same as what it was set to in step 4. 

Fixes #27879 

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
