### PR TITLE
Dynamically resize wb splash screen image based on screen resolution

### DIFF
--- a/qt/applications/workbench/workbench/app/mainwindow.py
+++ b/qt/applications/workbench/workbench/app/mainwindow.py
@@ -133,6 +133,7 @@ def _get_splash_image():
                                                                 Qt.KeepAspectRatio,
                                                                 Qt.SmoothTransformation)
 
+
 SPLASH = QSplashScreen(_get_splash_image(),
                        Qt.WindowStaysOnTopHint)
 SPLASH.show()

--- a/qt/applications/workbench/workbench/app/mainwindow.py
+++ b/qt/applications/workbench/workbench/app/mainwindow.py
@@ -121,17 +121,19 @@ MAIN_APP = qapplication()
 atexit.register(qCleanupResources)
 
 
-def _get_splash_image_name():
+def _get_splash_image():
     # gets the width of the screen where the main window was initialised
     width = QGuiApplication.primaryScreen().size().width()
+    height = QGuiApplication.primaryScreen().size().height()
 
-    if width > 2048:
-        return ':/images/MantidSplashScreen_4k.jpg'
-    else:
-        return ':/images/MantidSplashScreen.png'
+    # the proportion of the whole window size for the splash screen
+    splash_screen_scaling = 0.2
+    return QPixmap(':/images/MantidSplashScreen_4k.jpg').scaled(width * splash_screen_scaling,
+                                                                height * splash_screen_scaling,
+                                                                Qt.KeepAspectRatio,
+                                                                Qt.SmoothTransformation)
 
-
-SPLASH = QSplashScreen(QPixmap(_get_splash_image_name()),
+SPLASH = QSplashScreen(_get_splash_image(),
                        Qt.WindowStaysOnTopHint)
 SPLASH.show()
 SPLASH.showMessage("Starting...", Qt.AlignBottom | Qt.AlignLeft


### PR DESCRIPTION
This should resolve some of the Huge splash screens we get with the workbench sometimes.

It also means we only have to maintain one splash screen image and not two resolutions of the same thing.

**Description of work.**
It sets the splash screen size to be 20% of the available window size.

**To test:**
1. start workbench check that the size of the splash screen is reasonable
1. Change your screen resolution and repeat



*There is no associated issue.*

*This does not require release notes* because *this is a very minor improvement*


---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
