### PR TITLE
Switch docs to recommend debugpy over ptvsd for VSCode

### DIFF
--- a/dev-docs/source/VSCode.rst
+++ b/dev-docs/source/VSCode.rst
@@ -336,32 +336,28 @@ Then pass as an argument the specific test you want to be debugging. As an examp
 
 Debugging Python
 -----------------
-Visual Studio Code can be remotely attached to any running Python targets 
-using `ptvsd`.
+Visual Studio Code can be remotely attached to any running Python targets
+using `debugpy`.
 Whilst this "just works" for the majority of cases, it will not allow you to
 debug both C++ and Python at the same time. It also will not work with
 PyQt listeners, as the debugger must be attached to the main thread.
 
-**Setting up ptvsd**
+**Setting up debugpy**
 
 *Linux/OSX*
 
-Install `ptvsd` using pip within the terminal
+Install `debugpy` using pip within the terminal
 
 .. code-block:: bash
 
-    pip install ptvsd
-    # Or if using Python 3
-    pip3 install ptvsd
+   python3 -m pip install --user debugpy
 
 *Windows*
 
-`ptvsd` needs to be installed into each source folder:
-
 - Go to your source folder with Mantid (not the build folder)
-- Go to external/src/ThirdParty/lib/python2.7
+- Go to external/src/ThirdParty/lib/python3.8
 - Open a command prompt here (shift + right click in empty space)
-- Run the following: `python -m pip install ptvsd`
+- Run the following: `python -m pip install --user debugpy`
 
 **Setting up VS Code**
 - Ensure the Python extension is installed
@@ -384,18 +380,16 @@ Install `ptvsd` using pip within the terminal
 
 .. code-block:: python
 
-    import ptvsd
-    ptvsd.enable_attach(address=('127.0.0.1', 5678), redirect_output=True)
-    ptvsd.wait_for_attach()
-    ptvsd.break_into_debugger()
+    import debugpy
+    debugpy.listen(('127.0.0.1', 5678))
+    debugpy.wait_for_client()
+    debugpy.breakpoint()
 
-- When Mantid appears to freeze. Open the debug tab and start the Python 
-  Attach Target
-- Any additional breakpoints using the IDE are added automatically 
-  (i.e. don't add `ptvsd.break_into_debugger()`
+- When Mantid appears to freeze. Open the debug tab and start the "Python Attach" Target
+- Any additional breakpoints using the IDE are added automatically
+  (i.e. don't add `debugpy.breakpoint()`
 - If you'd like the code to not break at that location, but would like the
-  debugger to attach only remove `wait_for_attach()`
-
+  debugger to attach only remove `wait_for_client()`
 
 
 Keybindings
@@ -423,7 +417,7 @@ Reference" and hit Enter.
 
 Remote Development
 ------------------
-VSCode supports the ability to open and work from directories on a remote machine using SSH. 
+VSCode supports the ability to open and work from directories on a remote machine using SSH.
 
 Detailed instructions on how to set this up can be found `here <https://code.visualstudio.com/docs/remote/ssh>`_.
 
@@ -472,7 +466,3 @@ work.
   appears.
 - Any errors about unknown types can usually be resolved by briefly opening
   that header to force clangd to parse the type.
-
-
-
-


### PR DESCRIPTION
**Description of work.**

Recent releases of [VSCode](https://devblogs.microsoft.com/python/python-in-visual-studio-code-march-2020-release/) have included a new debugger with improved functionality and performance.

These changes update our docs to recommend the new debugger.

**To test:**

* Build the `dev-docs-html` target
* Check against https://github.com/microsoft/debugpy/wiki/Switching-over-from-%60ptvsd%60-to-%60debugpy%60 to confirm the new examples are correct w.r.t the new API.

*There is no associated issue.*

*This does not require release notes* because **it is an internal change.**

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
