### PR TITLE
Remove unused context variable in Sphinx categories processing

### DIFF
--- a/docs/source/_templates/algorithmcategories.html
+++ b/docs/source/_templates/algorithmcategories.html
@@ -14,8 +14,6 @@
 
 {%- block body -%}
     <h1> {{ title }} </h1>
-    {% set header_file = text_page %}
-    {% include header_file ignore missing %}
     <p>Mantid contains many algorithms for loading, saving and performing operations on a wide variety of data.  The categories below should help you find the algorithm you need.  To help with ensuring the Algorithms are found in the most sensible places, they can be in more than one category.  If you prefer to search, or know the name you can use the <a href='categories/AlgorithmIndex.html'>Algorithms Index</a>.</p>
     {% if parentcategory %}
     <p> {{ parentcategory }} </p>
@@ -25,19 +23,19 @@
     {{ list_to_definition_list(generalcategories) }}
     <hr>
     {% endif %}
-    
+
     {% if techniquecategories %}
     <h2> Technique Specific Algorithms  </h2>
     {{ list_to_definition_list(techniquecategories) }}
     <hr>
-    {% endif %}    
-    
+    {% endif %}
+
     {% if facilitycategories %}
     <h2> Facility Specific Algorithms  </h2>
     {{ list_to_definition_list(facilitycategories) }}
     <hr>
     {% endif %}
-    
+
     <p><b>Complete Index:</b> <a href='categories/AlgorithmIndex.html'>Algorithms Index</a></p>
 
 {%- endblock -%}

--- a/docs/source/_templates/category.html
+++ b/docs/source/_templates/category.html
@@ -43,8 +43,6 @@
 
 {%- block body -%}
     <h1> Category: {{ title }} </h1>
-    {% set header_file = text_page %}
-    {% include header_file ignore missing %}
     {% if subcategories %}
     <br>
     <h2> Subcategories </h2>
@@ -64,7 +62,7 @@
         {{ list_to_single_column(pages) }}
       {% endif %}
     {% endif %}
-    
+
     {% if parentcategory %}
     <p> {{ parentcategory }} </p>
     {% endif %}

--- a/docs/sphinxext/mantiddoc/directives/categories.py
+++ b/docs/sphinxext/mantiddoc/directives/categories.py
@@ -388,9 +388,9 @@ def create_category_pages(app):
             # index in document directory
             document_dir = posixpath.dirname(category_html_dir)
             category_html_path_noext = posixpath.join(document_dir, 'index')
-            context['outpath'] = category_html_path_noext + '.html'        
+            context['outpath'] = category_html_path_noext + '.html'
             yield (category_html_path_noext, context, template)
-      
+
     #create the top level algorithm category
     yield create_top_algorithm_category(categories)
 # enddef
@@ -428,20 +428,19 @@ def create_top_algorithm_category(categories):
             else:
                 top_category.additional_text = ''
             all_top_categories.append(top_category)
-    
+
     #split the full list into subsections
     general_categories = all_top_categories
     technique_categories = extract_matching_categories(general_categories,posixpath.join(category_src_dir, 'techniquecategories') + '.txt')
     facility_categories = extract_matching_categories(general_categories,posixpath.join(category_src_dir, 'facilitycategories') + '.txt')
     hidden_categories = extract_matching_categories(general_categories,posixpath.join(category_src_dir, 'hiddencategories') + '.txt')
-    
+
     # create the page
     top_context = {}
     top_html_path_noext = ""
     top_category_html_path_noext = posixpath.join('algorithms', 'index')
     top_context['outpath'] = top_category_html_path_noext + '.html'
     #set the content
-    top_context["text_page"] = "algorithm_categories.html"
     top_context["pages"] = []
     top_context["generalcategories"] = sorted(general_categories, key = lambda x: x.name)
     top_context["techniquecategories"] = sorted(technique_categories, key = lambda x: x.name)
@@ -466,11 +465,11 @@ def extract_matching_categories(input_categories,filepath):
     if os.path.isfile(filepath):
         with open(filepath) as f:
             name_list = [line.strip() for line in f]
-      
+
         extracted_list = [category for category in input_categories if category.name in name_list]
         #overwrite input_categories
-        input_categories[:] = [category for category in input_categories if category.name not in name_list] 
-    
+        input_categories[:] = [category for category in input_categories if category.name not in name_list]
+
     return extracted_list
 
 


### PR DESCRIPTION
**Description of work.**

Some builders have had Jinja updated to 2.11.2. This now causes an error in the docs build:
```
  File /usr/lib/python3.6/site-packages/sphinx_bootstrap_theme/bootstrap/layout.html, line 24, in top-level template code
    {% if theme_bootstrap_version == 3 %}
  File /usr/lib/python3.6/site-packages/sphinx/themes/basic/layout.html, line 65, in top-level template code
    {#- old style sidebars: using blocks -- should be deprecated #}
  File /usr/lib/python3.6/site-packages/sphinx_bootstrap_theme/bootstrap/layout.html, line 47, in block content
    {%- endmacro %}
  File /home/builder/jenkins-linode/workspace/pull_requests-rhel7/docs/source/_templates/category.html, line 40, in block body
    {%- endfor -%}
  File /usr/lib/python3.6/site-packages/sphinx/jinja2glue.py, line 145, in get_source
    if template.startswith('!'):
jinja2.exceptions.UndefinedError: 'text_page' is undefined```
```

This PR updates the templates to remove the requirement for the `text_page` context variable that is causing the error and was apparently unused anyway.

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

**To test:**

* Upgrade Jinja2:
  * Windows: Open mantid command prompt,run `python -m pip install -U jinja==2.11.2`
  * macOS: `python3 -m pip install -U jinja2==2.11.2
  * Linux: Use a virtualenv:
```
python3 -m virtualenv -p /usr/bin/python3 --system-site-packages ~/.virtualenvs/jinja2
source ~/.virtualenvs/jinja2/bin/activate
python -m pip install jinja==2.11.2
```
* Build the `docs-qthelp` target and it should pass.
* Linux: `deactivate` to get out of the `virtualenv`.

A tip for speeding up the docs build. Remove the following directories:
```
api/ concepts/ fitting/ interfaces/ plotting/ techniques/ tutorials workbench/
```

and most of the documents in `algorithms` but leave a few to be processed.

*This does not require release notes* because **it is an internal change**

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
