### PR TITLE
Instrument View: Ignores NaN and infinite values when integrating a workspace

### DIFF
--- a/Framework/API/src/MatrixWorkspace.cpp
+++ b/Framework/API/src/MatrixWorkspace.cpp
@@ -44,15 +44,15 @@ using Mantid::Types::Core::DateAndTime;
 
 namespace {
 /** Simple method which will accumulate a value as long as it is Finite */
-auto accumulate_if_finite = [](const double accumulator, const double newValue) {
+auto accumulate_if_finite = [](const double accumulator,
+                               const double newValue) {
   if (std::isfinite(newValue)) {
     return accumulator + newValue;
   } else {
     return accumulator;
   }
 };
-}
-
+} // namespace
 
 namespace Mantid {
 namespace API {
@@ -795,7 +795,8 @@ void MatrixWorkspace::getIntegratedSpectra(std::vector<double> &out,
       double sum(0.0);
       if (distmin <= distmax) {
         // Integrate
-        sum = std::accumulate(y.begin() + distmin, y.begin() + distmax, 0.0, accumulate_if_finite);
+        sum = std::accumulate(y.begin() + distmin, y.begin() + distmax, 0.0,
+                              accumulate_if_finite);
       }
       // Save it in the vector
       out[wksp_index] = sum;

--- a/Framework/API/src/MatrixWorkspace.cpp
+++ b/Framework/API/src/MatrixWorkspace.cpp
@@ -42,6 +42,18 @@
 using Mantid::Kernel::TimeSeriesProperty;
 using Mantid::Types::Core::DateAndTime;
 
+namespace {
+/** Simple method which will accumulate a value as long as it is Finite */
+auto accumulate_if_finite = [](const double accumulator, const double newValue) {
+  if (std::isfinite(newValue)) {
+    return accumulator + newValue;
+  } else {
+    return accumulator;
+  }
+};
+}
+
+
 namespace Mantid {
 namespace API {
 using std::size_t;
@@ -731,6 +743,7 @@ void MatrixWorkspace::getXMinMax(double &xmin, double &xmax) const {
 }
 
 /** Integrate all the spectra in the matrix workspace within the range given.
+ * NaN and Infinite values are ignored.
  * Default implementation, can be overridden by base classes if they know
  *something smarter!
  *
@@ -782,7 +795,7 @@ void MatrixWorkspace::getIntegratedSpectra(std::vector<double> &out,
       double sum(0.0);
       if (distmin <= distmax) {
         // Integrate
-        sum = std::accumulate(y.begin() + distmin, y.begin() + distmax, 0.0);
+        sum = std::accumulate(y.begin() + distmin, y.begin() + distmax, 0.0, accumulate_if_finite);
       }
       // Save it in the vector
       out[wksp_index] = sum;

--- a/Framework/API/test/MatrixWorkspaceTest.h
+++ b/Framework/API/test/MatrixWorkspaceTest.h
@@ -2068,8 +2068,9 @@ public:
     WorkspaceTester workspace;
     workspace.initialize(5, 5, 4);
     MantidVec xValues = {1., 2., 3., 4., 5.};
-    //set some values
-    for (size_t wsIndex = 0; wsIndex < workspace.getNumberHistograms(); wsIndex++) {
+    // set some values
+    for (size_t wsIndex = 0; wsIndex < workspace.getNumberHistograms();
+         wsIndex++) {
       for (size_t binIndex = 0; binIndex < workspace.blocksize(); binIndex++) {
         // incrementing numbers
         double fillValue = static_cast<double>(binIndex + 1);
@@ -2089,11 +2090,12 @@ public:
         }
         workspace.mutableY(wsIndex)[binIndex] = fillValue;
       }
-      //set the x values
-      std::copy(xValues.begin(), xValues.end(), workspace.mutableX(wsIndex).begin());
+      // set the x values
+      std::copy(xValues.begin(), xValues.end(),
+                workspace.mutableX(wsIndex).begin());
     }
     MantidVec integratedValues;
-    //the enitre range
+    // the enitre range
     workspace.getIntegratedSpectra(integratedValues, 0, 0, true);
     MantidVec expected = {10., 0., 0., 4., 6.};
     TS_ASSERT_EQUALS(integratedValues, expected);

--- a/docs/source/release/v5.1.0/framework.rst
+++ b/docs/source/release/v5.1.0/framework.rst
@@ -43,6 +43,7 @@ Data Objects
 ------------
 
 - Added MatrixWorkspace::findY to find the histogram and bin with a given value
+- Matrix Workspaces now ignore non-finite values when integrating values for the instrument view.  Please note this is different from the :ref:`Integration <algm-Integration>` algorithm.
 
 Python
 ------

--- a/docs/source/release/v5.1.0/mantidworkbench.rst
+++ b/docs/source/release/v5.1.0/mantidworkbench.rst
@@ -31,6 +31,7 @@ Improvements
 - The workspace sample logs interface now responds to keyboard input from the cursor keys to move between logs.
 
 - Surface plots no longer spill over the axes when their limits are reduced.
+- The instrument view now ignores non-finite (infinity and NaN) values and should now display workspaces containing those values.
 
 Bugfixes
 ########


### PR DESCRIPTION

**Description of work.**

This is for the instrument view, allowing it to display workspaces with

Changes the integration method on workspaces to ignore non-finite values.

**To test:**
``` python
from mantid.simpleapi import *
ws = Load("MAR11060")
for i in range(100,150):
    ws.dataY(i)[2] = 'NaN'
for i in range(150,200):
    for j in range(len(ws.dataY(i))):
        ws.dataY(i)[j] = 'NaN'
```
1. Create this workspace, open the instrument view
1. Some detecotrs should show as 0 value, others have a single NaN value  within them
1. Test the various aspects of the instrument view

Fixes #27642


---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
