### PR TITLE
Support building with Homebrew HEAD

### DIFF
--- a/Framework/Kernel/inc/MantidKernel/ConfigService.h
+++ b/Framework/Kernel/inc/MantidKernel/ConfigService.h
@@ -15,7 +15,6 @@
 #include <boost/optional/optional.hpp>
 
 #include <map>
-#include <memory>
 #include <set>
 #include <string>
 #include <vector>
@@ -126,7 +125,7 @@ public:
   /// Returns a list of all full keys in the config
   std::vector<std::string> keys() const;
   /// Removes the value from a selected keyName
-  void remove(const std::string &rootName) const;
+  void remove(const std::string &rootName);
   /// Checks to see whether a key has a value assigned to it
   bool hasProperty(const std::string &rootName) const;
   /// Checks to see whether the target passed is an executable file
@@ -285,12 +284,10 @@ private:
   void getKeysRecursive(const std::string &root,
                         std::vector<std::string> &allKeys) const;
 
-  // Forward declaration of inner class
-  template <class T> class WrappedObject;
   /// the POCO file config object
-  std::unique_ptr<WrappedObject<Poco::Util::PropertyFileConfiguration>> m_pConf;
+  Poco::AutoPtr<Poco::Util::PropertyFileConfiguration> m_pConf;
   /// the POCO system Config Object
-  std::unique_ptr<WrappedObject<Poco::Util::SystemConfiguration>> m_pSysConfig;
+  Poco::AutoPtr<Poco::Util::SystemConfiguration> m_pSysConfig;
 
   /// A set of property keys that have been changed
   mutable std::set<std::string> m_changed_keys;

--- a/Framework/PythonInterface/mantid/plots/plotfunctions.py
+++ b/Framework/PythonInterface/mantid/plots/plotfunctions.py
@@ -8,7 +8,7 @@
 # std imports
 import math
 import numpy as np
-import collections
+from collections.abc import Sequence
 
 # 3rd party imports
 from matplotlib.gridspec import GridSpec
@@ -74,7 +74,7 @@ def figure_title(workspaces, fig_num):
     def wsname(w):
         return w.name() if hasattr(w, 'name') else w
 
-    if isinstance(workspaces, str) or not isinstance(workspaces, collections.Sequence):
+    if isinstance(workspaces, str) or not isinstance(workspaces, Sequence):
         # assume a single workspace
         first = workspaces
     else:

--- a/dev-docs/source/BuildingOnOSX.rst
+++ b/dev-docs/source/BuildingOnOSX.rst
@@ -46,31 +46,15 @@ In order to be able to 'tap' the ``mantidproject/mantid`` 'tap' we need to have 
    brew cask install xquartz
    brew cask install mactex
 
-5. Reset brew formula repo back to before Python 2 removal for required packages
+5. Install ``mantid-developer`` formula (this may take a while depending on your network speed)
 
 .. code-block:: sh
 
-   cd /usr/local/Homebrew/Library/Taps/homebrew/homebrew-core
-   git reset --hard 8f1d612d9e179c0d91ecd09853854e42281bd313
-   cd -
+   brew install mantid-developer
 
-6. Disable homebrew update and install ``mantid-developer`` formula (this may take a while depending on your network speed)
+6. Homebrew can stop early for reasons that are unclear. Repeat the above command until Homebrew states: *Warning: mantidproject/mantid/mantid-developer ?.? is already installed and up-to-date*.
 
-.. code-block:: sh
-
-   HOMEBREW_NO_AUTO_UPDATE=1 brew install mantid-developer
-
-7. Homebrew can stop early for reasons that are unclear. Repeat the above command until Homebrew states: *Warning: mantidproject/mantid/mantid-developer ?.? is already installed and up-to-date*.
-
-8. Pin libraries that depend on Python 2 and libmxml and NeXus is not compatible with v3:
-
-.. code-block:: sh
-
-   brew pin libmxml
-   brew pin sip
-   brew pin pyqt
-
-9. Unlink ``qt@4`` from ``/usr/local`` to avoid cross talk with Qt5 and ensure the webkit can be found when not linked
+7. Unlink ``qt@4`` from ``/usr/local`` to avoid cross talk with Qt5 and ensure the webkit can be found when not linked
 
 .. code-block:: sh
 
@@ -79,9 +63,9 @@ In order to be able to 'tap' the ``mantidproject/mantid`` 'tap' we need to have 
    ln -s /usr/local/opt/qt-webkit@2.3/include/QtWebKit /usr/local/opt/qt@4/include/QtWebKit
    ln -s /usr/local/opt/qt-webkit@2.3/lib/QtWebKit.framework /usr/local/opt/qt@4/lib/QtWebKit.framework
 
-10. Check that ``which python`` returns a Python in ``/usr/local`` and not system Python.
+8. Check that ``which python`` returns a Python in ``/usr/local`` and not system Python.
 
-11. Install python requirements
+10. Install python requirements
 
 .. code-block:: sh
 

--- a/qt/scientific_interfaces/Indirect/test/CMakeLists.txt
+++ b/qt/scientific_interfaces/Indirect/test/CMakeLists.txt
@@ -26,6 +26,9 @@ set(
   JumpFitModelTest.h
 )
 
+set(CXXTEST_EXTRA_HEADER_INCLUDE
+    ${CMAKE_CURRENT_LIST_DIR}/InterfacesIndirectTestInitialization.h)
+
 mtd_add_qt_tests(
   TARGET_NAME MantidQtInterfacesIndirectTest
   QT_VERSION 4

--- a/qt/scientific_interfaces/Indirect/test/IndirectSpectrumSelectionPresenterTest.h
+++ b/qt/scientific_interfaces/Indirect/test/IndirectSpectrumSelectionPresenterTest.h
@@ -24,27 +24,6 @@ using namespace MantidQt::CustomInterfaces;
 using namespace MantidQt::CustomInterfaces::IDA;
 using namespace testing;
 
-/// This QApplication object is required to construct the view
-class QApplicationHolder : CxxTest::GlobalFixture {
-public:
-  bool setUpWorld() override {
-    int argc(0);
-    char **argv = {};
-    m_app = new QApplication(argc, argv);
-    return true;
-  }
-
-  bool tearDownWorld() override {
-    delete m_app;
-    return true;
-  }
-
-private:
-  QApplication *m_app;
-};
-
-static QApplicationHolder MAIN_QAPPLICATION;
-
 GNU_DIAG_OFF_SUGGEST_OVERRIDE
 
 /// Mock object to mock the view

--- a/qt/scientific_interfaces/Indirect/test/InterfacesIndirectTestInitialization.h
+++ b/qt/scientific_interfaces/Indirect/test/InterfacesIndirectTestInitialization.h
@@ -6,7 +6,6 @@
 // SPDX - License - Identifier: GPL - 3.0 +
 #pragma once
 
-#include "MantidPythonInterface/core/Testing/PythonInterpreterGlobalFixture.h"
 #include "MantidQtWidgets/Common/Testing/QApplicationGlobalFixture.h"
 
 //------------------------------------------------------------------------------
@@ -15,5 +14,4 @@
 // We rely on cxxtest only including this file once so that the following
 // statements do not cause multiple-definition errors.
 //------------------------------------------------------------------------------
-static PythonInterpreterGlobalFixture PYTHON_INTERPRETER;
 static QApplicationGlobalFixture MAIN_QAPPLICATION;

--- a/qt/scientific_interfaces/test/ISISReflectometry/Common/DecoderTest.h
+++ b/qt/scientific_interfaces/test/ISISReflectometry/Common/DecoderTest.h
@@ -412,37 +412,6 @@ const static QString MAINWINDOW_JSON_STRING{
     QString("\"tag\": \"ISIS Reflectometry\"}")};
 } // namespace
 
-/**
- * QApplication
- *
- * Uses setUpWorld/tearDownWorld to initialize & finalize
- * QApplication object
- */
-class QApplicationHolder : CxxTest::GlobalFixture {
-public:
-  bool setUpWorld() override {
-    m_app = new QApplication(m_argc, m_argv);
-
-    qRegisterMetaType<std::string>("StdString");
-    qRegisterMetaType<Mantid::API::Workspace_sptr>("Workspace");
-
-    return true;
-  }
-
-  bool tearDownWorld() override {
-    delete m_app;
-    return true;
-  }
-
-  int m_argc = 1;
-  GNU_DIAG_OFF("pedantic")
-  char *m_argv[1] = {"DecoderTest"};
-  GNU_DIAG_ON("pedantic")
-  QApplication *m_app;
-};
-
-static QApplicationHolder MAIN_QAPPLICATION;
-
 namespace MantidQt {
 namespace CustomInterfaces {
 namespace ISISReflectometry {


### PR DESCRIPTION
**Description of work.**

Adds various fixes to support building against the HEAD versions of Homebrew packages. The biggest change is with Poco 1.10 as their api has changed in a couple of key classes and brew now has Python 3.8. OpenMP is now supported too.

**To test:**

* The installation instructions from a clean machine have been updated in dev-docs
* For existing installations a few [additional steps](https://gist.github.com/martyngigg/517648235f9b7eeb13921ef241be7364) are required to prepare for the brew upgrade.
* Build as normal and check MantidPlot/Workbench works.

Fixes #28423 

*This does not require release notes* because **the builders have not been updated yet so the changes are not visible.**

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
