### PR TITLE
Prevent a Debug assertion failure when showing the instrument of CreateSampleWorkspace

### DIFF
--- a/qt/widgets/instrumentview/src/BankRenderingHelpers.cpp
+++ b/qt/widgets/instrumentview/src/BankRenderingHelpers.cpp
@@ -457,8 +457,18 @@ void renderRectangularBank(const Mantid::Geometry::ComponentInfo &compInfo,
   auto bank = compInfo.quadrilateralComponent(index);
   const auto &detShape = compInfo.shape(bank.bottomLeft);
   const auto &shapeInfo = detShape.getGeometryHandler()->shapeInfo();
-  auto xstep = shapeInfo.points()[0].X() - shapeInfo.points()[1].X();
-  auto ystep = shapeInfo.points()[1].Y() - shapeInfo.points()[2].Y();
+  double xstep;
+  double ystep;
+  if (shapeInfo.points().size() > 2) {
+    //cuboids
+    xstep = shapeInfo.points()[0].X() - shapeInfo.points()[1].X();
+    ystep = shapeInfo.points()[1].Y() - shapeInfo.points()[2].Y();
+  } else
+  {
+    // cylnders, etc
+    xstep = shapeInfo.points()[0].X() - shapeInfo.points()[1].X();
+    ystep = shapeInfo.points()[0].Y() - shapeInfo.points()[1].Y();
+  }
 
   try {
     render2DTexture(c, bank.nX, bank.nY,

--- a/qt/widgets/instrumentview/src/BankRenderingHelpers.cpp
+++ b/qt/widgets/instrumentview/src/BankRenderingHelpers.cpp
@@ -460,11 +460,10 @@ void renderRectangularBank(const Mantid::Geometry::ComponentInfo &compInfo,
   double xstep;
   double ystep;
   if (shapeInfo.points().size() > 2) {
-    //cuboids
+    // cuboids
     xstep = shapeInfo.points()[0].X() - shapeInfo.points()[1].X();
     ystep = shapeInfo.points()[1].Y() - shapeInfo.points()[2].Y();
-  } else
-  {
+  } else {
     // cylnders, etc
     xstep = shapeInfo.points()[0].X() - shapeInfo.points()[1].X();
     ystep = shapeInfo.points()[0].Y() - shapeInfo.points()[1].Y();


### PR DESCRIPTION
**Description of work.**
Check the size of the point array before accessing

This allows the instrumentView to work with CreateSampleWorkspace in Debug

**To test:**
1. in a debug build (I saw this in visual studio)
1. CreateSampleWorkspace
1. Show the instrument (if the window appears then this is a success.


*There is no associated issue.*


*This does not require release notes* because **it only occurs in debug**

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
