### PR TITLE
Disable peaks overlay button on Sliceviewer if workspace cannot support it

### DIFF
--- a/qt/python/mantidqt/widgets/sliceviewer/model.py
+++ b/qt/python/mantidqt/widgets/sliceviewer/model.py
@@ -78,6 +78,18 @@ class SliceViewerModel:
         else:
             return False
 
+    def can_support_peaks_overlays(self) -> bool:
+        """
+        Check if the given workspace can support peaks overlay
+        """
+        try:
+            if self._get_ws().getNumDims() > 2:
+                return True
+        except AttributeError:
+            pass
+
+        return False
+
     def get_frame(self) -> SpecialCoordinateSystem:
         """Return the coordinate system of the workspace"""
         return self._ws.getSpecialCoordinateSystem()

--- a/qt/python/mantidqt/widgets/sliceviewer/peaksviewer/model.py
+++ b/qt/python/mantidqt/widgets/sliceviewer/peaksviewer/model.py
@@ -38,7 +38,6 @@ class PeaksViewerModel(TableWorkspaceDisplayModel):
     """View model for PeaksViewer
     Extends PeaksWorkspace functionality to include color selection
     """
-
     def __init__(self, peaks_ws, fg_color, bg_color):
         """
         :param peaks_ws: A pointer to the PeaksWorkspace
@@ -129,10 +128,9 @@ def create_peaksviewermodel(peaks_ws_name):
     :return: A new PeaksViewerModel object
     :raises ValueError: if the workspace referred to by the name is not a PeaksWorkspace
     """
-    return PeaksViewerModel(
-        _get_peaksworkspace(peaks_ws_name),
-        fg_color=next(FG_COLORS)['fg_color'],
-        bg_color=DEFAULT_BG_COLOR)
+    return PeaksViewerModel(_get_peaksworkspace(peaks_ws_name),
+                            fg_color=next(FG_COLORS)['fg_color'],
+                            bg_color=DEFAULT_BG_COLOR)
 
 
 # Private

--- a/qt/python/mantidqt/widgets/sliceviewer/presenter.py
+++ b/qt/python/mantidqt/widgets/sliceviewer/presenter.py
@@ -47,6 +47,8 @@ class SliceViewer(object):
         if self.model.can_normalize_workspace():
             self.view.data_view.norm_opts.currentTextChanged.connect(self.normalization_changed)
             self.view.data_view.set_normalization(ws)
+        if not self.model.can_support_peaks_overlays():
+            self.view.data_view.disable_peaks_button()
         if not self.model.can_support_nonorthogonal_axes():
             self.view.data_view.disable_nonorthogonal_axes_button()
 

--- a/qt/python/mantidqt/widgets/sliceviewer/test/test_sliceviewer_presenter.py
+++ b/qt/python/mantidqt/widgets/sliceviewer/test/test_sliceviewer_presenter.py
@@ -123,6 +123,22 @@ class SliceViewerTest(unittest.TestCase):
         self.view.data_view.plot_matrix.assert_called_with(
             self.model.get_ws(), normalize=mantid.api.MDNormalization.VolumeNormalization)
 
+    def peaks_button_disabled_if_model_cannot_support_it(self):
+        self.model.get_ws_type = mock.Mock(return_value=WS_TYPE.MATRIX)
+        self.model.can_support_peaks_overlay.return_value = False
+
+        SliceViewer(None, model=self.model, view=self.view)
+
+        self.view.data_view.disable_peaks_button.assert_called_once()
+
+    def peaks_button_not_disabled_if_model_can_support_it(self):
+        self.model.get_ws_type = mock.Mock(return_value=WS_TYPE.MATRIX)
+        self.model.can_support_peaks_overlay.return_value = True
+
+        SliceViewer(None, model=self.model, view=self.view)
+
+        self.view.data_view.disable_peaks_button.assert_not_called()
+
     def test_non_orthogonal_axes_toggled_on(self):
         self.model.get_ws_type = mock.Mock(return_value=WS_TYPE.MATRIX)
         data_view_mock = self.view.data_view


### PR DESCRIPTION
**Description of work.**

Only enable the peaks overlay button if the underlying workspace can support displaying them.

**To test:**

* Use the scripts in #28683 to generate a MatrixWorkspace and MDWorkspace.
* The peaks button should be disabled for the MatrixWorkspace.
* It should still allow overlay of the peaks workspace for the MD workspace.

Fixes #28687

*This does not require release notes* because **as peaks could not previously be viewed.**

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
