### PR TITLE
Support nonorthogonal axes on > 3D workspaces.

### DIFF
--- a/Framework/PythonInterface/mantid/api/src/Exports/IMDWorkspace.cpp
+++ b/Framework/PythonInterface/mantid/api/src/Exports/IMDWorkspace.cpp
@@ -26,7 +26,7 @@ void export_IMDWorkspace() {
 
   boost::python::enum_<Mantid::Kernel::SpecialCoordinateSystem>(
       "SpecialCoordinateSystem")
-      .value("None", Mantid::Kernel::None)
+      .value("NONE", Mantid::Kernel::None)
       .value("QLab", Mantid::Kernel::QLab)
       .value("QSample", Mantid::Kernel::QSample)
       .value("HKL", Mantid::Kernel::HKL);

--- a/qt/python/mantidqt/widgets/sliceviewer/dimensionwidget.py
+++ b/qt/python/mantidqt/widgets/sliceviewer/dimensionwidget.py
@@ -40,8 +40,9 @@ class DimensionWidget(QWidget):
         super().__init__(parent)
 
         self.layout = QVBoxLayout(self)
-        self.dims = []
+        self.dims, self.qflags = [], []
         for n, dim in enumerate(dims_info):
+            self.qflags.append(dim['qdim'])
             if dim['type'] == 'MDE':
                 self.dims.append(DimensionMDE(dim, number=n, parent=self))
             else:
@@ -105,16 +106,20 @@ class DimensionWidget(QWidget):
             d.units.setMinimumWidth(max_unit_width)
 
     def get_slicepoint(self):
-        """:return: a list of 3 elements where None indicates a non-slice dimension and a
+        """:return: A list of elements where None indicates a non-slice dimension and a
           float indicates the current slice point in that dimension.
         """
         return [None if d.get_state() in (State.X, State.Y) else d.get_value() for d in self.dims]
 
     def get_slicerange(self):
-        for d in self.dims:
-            if d.get_state() == State.NONE:
-                spinbox = d.spinbox
-                return (spinbox.minimum(), spinbox.maximum())
+        """
+        :return: A list of enumerating the range in each slice dimension. None indicates a non-slice
+        dimension and are in the same positions as the list returned from get_slicepoint
+        """
+        return [
+            None if d.get_state() in (State.X, State.Y) else
+            (d.spinbox.minimum(), d.spinbox.maximum()) for d in self.dims
+        ]
 
     def get_bin_params(self):
         return [
@@ -122,13 +127,14 @@ class DimensionWidget(QWidget):
             for d in self.dims
         ]
 
-    def set_slicevalue(self, value):
+    def set_slicepoint(self, point):
         """
-        Set the value of the slice point in the slice dimension
+        Set the value of the slice point
+        :param point: New value of the slice point
         """
-        for d in self.dims:
-            if d.get_state() == State.NONE:
-                d.set_value(value)
+        for index, value in enumerate(point):
+            if value is not None:
+                self.dims[index].set_value(value)
 
 
 class Dimension(QWidget):

--- a/qt/python/mantidqt/widgets/sliceviewer/model.py
+++ b/qt/python/mantidqt/widgets/sliceviewer/model.py
@@ -129,7 +129,8 @@ class SliceViewerModel:
         """
         returns dict of (minimum, maximun, number_of_bins, width, name, units) for dimension n
         """
-        dim = self._get_ws().getDimension(n)
+        workspace = self._get_ws()
+        dim = workspace.getDimension(n)
         return {
             'minimum': dim.getMinimum(),
             'maximum': dim.getMaximum(),
@@ -137,7 +138,8 @@ class SliceViewerModel:
             'width': dim.getBinWidth(),
             'name': dim.name,
             'units': dim.getUnits(),
-            'type': self.get_ws_type().name
+            'type': self.get_ws_type().name,
+            'qdim': dim.getMDFrame().isQ()
         }
 
     def get_dimensions_info(self) -> List[Dict]:

--- a/qt/python/mantidqt/widgets/sliceviewer/peaksviewer/model.py
+++ b/qt/python/mantidqt/widgets/sliceviewer/peaksviewer/model.py
@@ -90,7 +90,7 @@ class PeaksViewerModel(TableWorkspaceDisplayModel):
 
         self._representations = representations
 
-    def slice_center(self, selected_index, slice_info):
+    def slicepoint(self, selected_index, slice_info):
         """
         Return the value of the center in the slice dimension for the peak at the given index
         :param selected_index: Index of a peak in the table
@@ -98,7 +98,10 @@ class PeaksViewerModel(TableWorkspaceDisplayModel):
         """
         frame_to_slice_fn = self._frame_to_slice_fn(slice_info.frame)
         peak = self.ws.getPeak(selected_index)
-        return slice_info.transform(getattr(peak, frame_to_slice_fn)())[2]
+        slicepoint = slice_info.slicepoint
+        slicepoint[slice_info.z_index] = getattr(peak, frame_to_slice_fn)()[slice_info.z_index]
+
+        return slicepoint
 
     def zoom_to(self, index):
         """

--- a/qt/python/mantidqt/widgets/sliceviewer/peaksviewer/presenter.py
+++ b/qt/python/mantidqt/widgets/sliceviewer/peaksviewer/presenter.py
@@ -19,7 +19,6 @@ class PeaksViewerPresenter(object):
     """Controls a PeaksViewerView with a given model to display
     the peaks table and interaction controls for single workspace.
     """
-
     class Event(Enum):
         PeaksListChanged = 1
         OverlayPeaks = 2
@@ -94,7 +93,7 @@ class PeaksViewerPresenter(object):
         if selected_index is None:
             return
 
-        self._view.set_slicepoint(self.model.slice_center(selected_index, self._view.sliceinfo))
+        self._view.set_slicepoint(self.model.slicepoint(selected_index, self._view.sliceinfo))
         self.model.zoom_to(selected_index)
 
     # private api
@@ -110,7 +109,6 @@ class PeaksViewerPresenter(object):
 class PeaksViewerCollectionPresenter(object):
     """Controls a widget comprising of multiple PeasViewerViews to display and
     interact with multiple PeaksWorkspaces"""
-
     def __init__(self, view):
         """
         :param view: View displaying the model information

--- a/qt/python/mantidqt/widgets/sliceviewer/peaksviewer/representation/ellipsoid.py
+++ b/qt/python/mantidqt/widgets/sliceviewer/peaksviewer/representation/ellipsoid.py
@@ -18,7 +18,6 @@ from .painter import Painted
 class EllipsoidalIntergratedPeakRepresentation(object):
     """Provide methods to display a representation of a slice through an
     Ellipsoidally intgerated region around a Peak"""
-
     @classmethod
     def draw(cls, peak_origin, peak_shape, slice_info, painter, fg_color, bg_color):
         """
@@ -37,11 +36,11 @@ class EllipsoidalIntergratedPeakRepresentation(object):
         peak_origin = slice_info.transform(peak_origin)
 
         slice_origin, major_radius, minor_radius, angle = slice_ellipsoid(
-            peak_origin, *axes, *signal_radii, slice_info.value)
+            peak_origin, *axes, *signal_radii, slice_info.z_value)
         if not np.any(np.isfinite((major_radius, minor_radius))):
             # slice not possible
             return None
-        alpha = compute_alpha(slice_origin[2], slice_info.value, slice_info.width)
+        alpha = compute_alpha(slice_origin[2], slice_info.z_value, slice_info.z_width)
         if alpha < 0.0:
             return None
 
@@ -49,7 +48,7 @@ class EllipsoidalIntergratedPeakRepresentation(object):
         # add background shell
         a, b, c, shell_thick = _bkgd_ellipsoid_info(shape_info, slice_info.transform)
         _, major_radius, minor_radius, angle = slice_ellipsoid(peak_origin, *axes, a, b, c,
-                                                               slice_info.value)
+                                                               slice_info.z_value)
         bkgd_width, bkgd_height = 2 * major_radius, 2 * minor_radius
 
         # yapf: disable
@@ -95,7 +94,6 @@ def _signal_ellipsoid_info(shape_info, transform):
     :param shape_info: A dictionary of ellipsoid properties
     :param transform: Transform function to move to the slice frame
     """
-
     def to_ndarray(axis_field):
         s = shape_info[axis_field]
         return np.array([float(x) for x in s.split()], dtype=float)
@@ -234,7 +232,7 @@ def slice_ellipsoid_matrix(origin, zp, ellipMatrix):
     major_axis = eigvectors[:, 1]
     angle = np.rad2deg(np.arctan2(major_axis[1], major_axis[0]))
     slice_origin_xy = -0.5 * linalg.inv(A) @ B
-    slice_origin = np.array((slice_origin_xy[0] + origin[0], slice_origin_xy[1] + origin[1],
-                             z + origin[2]))
+    slice_origin = np.array(
+        (slice_origin_xy[0] + origin[0], slice_origin_xy[1] + origin[1], z + origin[2]))
 
     return slice_origin, major_radius, minor_radius, angle

--- a/qt/python/mantidqt/widgets/sliceviewer/peaksviewer/representation/noshape.py
+++ b/qt/python/mantidqt/widgets/sliceviewer/peaksviewer/representation/noshape.py
@@ -29,10 +29,10 @@ class NonIntegratedPeakRepresentation(object):
         """
         peak_origin = slice_info.transform(peak_origin)
         x, y, z = peak_origin
-        alpha = compute_alpha(z, slice_info.value, slice_info.width)
+        alpha = compute_alpha(z, slice_info.z_value, slice_info.z_width)
         painted = None
         if alpha > 0.0:
-            effective_radius = slice_info.width * cls.VIEW_FRACTION
+            effective_radius = slice_info.z_width * cls.VIEW_FRACTION
             painted = Painted(
                 painter, (painter.cross(x, y, effective_radius, alpha=alpha, color=fg_color), ))
 

--- a/qt/python/mantidqt/widgets/sliceviewer/peaksviewer/representation/spherical.py
+++ b/qt/python/mantidqt/widgets/sliceviewer/peaksviewer/representation/spherical.py
@@ -20,7 +20,6 @@ from .painter import Painted
 class SphericallyIntergratedPeakRepresentation(object):
     """Provide methods to display a representation of a slice through an
     Spherically intgerated region around a Peak"""
-
     @classmethod
     def draw(cls, peak_origin, peak_shape, slice_info, painter, fg_color, bg_color):
         """
@@ -37,11 +36,11 @@ class SphericallyIntergratedPeakRepresentation(object):
         signal_radius = _signal_radius_info(shape_info)
         peak_origin = slice_info.transform(peak_origin)
 
-        slice_origin, signal_radius = slice_sphere(peak_origin, signal_radius, slice_info.value)
+        slice_origin, signal_radius = slice_sphere(peak_origin, signal_radius, slice_info.z_value)
         if not np.any(np.isfinite((signal_radius, ))):
             # slice not possible
             return None
-        alpha = compute_alpha(slice_origin[2], slice_info.value, slice_info.width)
+        alpha = compute_alpha(slice_origin[2], slice_info.z_value, slice_info.z_width)
         if alpha < 0.0:
             return None
 
@@ -71,7 +70,7 @@ class SphericallyIntergratedPeakRepresentation(object):
         bkgd_radius_thick = _bkgd_radius_info(shape_info)
         if bkgd_radius_thick is not None:
             bkgd_outer_radius, thickness = bkgd_radius_thick
-            _, bkgd_circle_radius = slice_sphere(peak_origin, bkgd_outer_radius, slice_info.value)
+            _, bkgd_circle_radius = slice_sphere(peak_origin, bkgd_outer_radius, slice_info.z_value)
             # yapf: disable
             artists.append(
                 painter.shell(

--- a/qt/python/mantidqt/widgets/sliceviewer/peaksviewer/representation/test/test_peaksviewer_representation_draw.py
+++ b/qt/python/mantidqt/widgets/sliceviewer/peaksviewer/representation/test/test_peaksviewer_representation_draw.py
@@ -30,8 +30,8 @@ def draw_shape(shape_name, shape_info=None):
         peak_shape.toJSON.return_value = shape_info
     # identity transform
     slice_info.transform.side_effect = lambda x: x
-    slice_info.value = 5.
-    slice_info.width = 10.
+    slice_info.z_value = 5.
+    slice_info.z_width = 10.
 
     draw_peak_representation(peak_origin, peak_shape, slice_info, painter, fg_color, bg_color)
 

--- a/qt/python/mantidqt/widgets/sliceviewer/peaksviewer/test/modeltesthelpers.py
+++ b/qt/python/mantidqt/widgets/sliceviewer/peaksviewer/test/modeltesthelpers.py
@@ -62,6 +62,6 @@ def create_slice_info(transform_side_effect,
     slice_info = MagicMock()
     slice_info.frame = frame
     slice_info.transform.side_effect = transform_side_effect
-    slice_info.value = slice_value
-    slice_info.width = slice_width
+    slice_info.z_value = slice_value
+    slice_info.z_width = slice_width
     return slice_info

--- a/qt/python/mantidqt/widgets/sliceviewer/peaksviewer/test/test_peaksviewer_model.py
+++ b/qt/python/mantidqt/widgets/sliceviewer/peaksviewer/test/test_peaksviewer_model.py
@@ -73,22 +73,21 @@ class PeaksViewerModelTest(unittest.TestCase):
 
         mock_painter.remove.assert_called_once()
 
-    def test_slice_center_transforms_center_to_correct_frame_and_order(self):
+    def test_slicepoint_transforms_center_to_correct_frame_and_order(self):
         peak_center = (1, 2, 3)
         model = create_peaks_viewer_model(centers=[peak_center], fg_color="red")
         slice_info = MagicMock()
-        slice_info.transform.side_effect = lambda p: [
-            peak_center[2], peak_center[1], peak_center[0]
-        ]
+        slice_info.slicepoint = [0.5, None, None]
+        slice_info.z_index = 0
         slice_info.frame = SpecialCoordinateSystem.QSample
 
-        slice_center = model.slice_center(0, slice_info)
+        slicepoint = model.slicepoint(0, slice_info)
 
         peak0 = model.ws.getPeak(0)
         peak0.getQSampleFrame.assert_called_once()
         peak0.getQLabFrame.assert_not_called()
         peak0.getHKL.assert_not_called()
-        self.assertEqual(peak_center[0], slice_center)
+        self.assertEqual([1, None, None], slicepoint)
 
     def test_zoom_to(self):
         visible_peak_center, invisible_center = (0.5, 0.2, 0.25), (0.4, 0.3, 25)

--- a/qt/python/mantidqt/widgets/sliceviewer/peaksviewer/view.py
+++ b/qt/python/mantidqt/widgets/sliceviewer/peaksviewer/view.py
@@ -15,7 +15,6 @@ from mantidqt.widgets.workspacedisplay.table.view import TableWorkspaceDisplayVi
 
 class PeaksWorkspaceTableView(TableWorkspaceDisplayView):
     """Specialization of a table view to display peaks"""
-
     def keyPressEvent(self, event):
         QTableWidget.keyPressEvent(self, event)
 
@@ -73,7 +72,7 @@ class PeaksViewerView(QWidget):
         Set the slice point to the given value
         :param value: Float giving the current slice value
         """
-        self._sliceinfo_provider.set_slicevalue(value)
+        self._sliceinfo_provider.set_slicepoint(value)
 
     def set_title(self, name):
         """
@@ -140,7 +139,6 @@ class PeaksViewerView(QWidget):
 class PeaksViewerCollectionView(QWidget):
     """Display a collection of PeaksViewerView objects in a scrolling view.
     """
-
     def __init__(self, painter, sliceinfo_provider, parent=None):
         """
         :param painter: An object responsible for draw the peaks representations

--- a/qt/python/mantidqt/widgets/sliceviewer/sliceinfo.py
+++ b/qt/python/mantidqt/widgets/sliceviewer/sliceinfo.py
@@ -9,11 +9,13 @@
 from typing import Tuple, Sequence, Union
 
 # 3rd party
+from mantid.api import SpecialCoordinateSystem
 import numpy as np
 
 # Types
 SlicePointType = Sequence[Union[None, float]]
-SliceRange = Tuple[float, float]
+DimensionRange = Tuple[float, float]
+DimensionRangeCollection = Sequence[DimensionRange]
 
 
 class SliceInfo:
@@ -22,29 +24,49 @@ class SliceInfo:
     to the slice coordinate system.
 
     Fields:
-        frame: A str indicating the frame of the slice
+        frame: A SpecialCoordinateSystem enum indicating the frame of the slice
         point: A list where None indicates a non-integrated dimension and
                a float gives the current value of a slice at this dimension
         transpose: A bool indicating if the displayed dimensions are swapped
-        range: A 2-tuple giving the range of the slice in the slicing dimension
+        range: A list of 2-tuple giving the range of the slice in the slicing dimension
+               or None for a non-slice dimension
+        qflags: A list of booleans indicating if a dimension is a Q dimension or not.
+                There can only be a maximum of 3 dimensions flagged.
     """
-    def __init__(self, *, frame: str, point: SlicePointType, transpose: bool, range: SliceRange):
-        assert 3 == len(
-            point), f"Expected a length 3 array for slice point, found length={len(point)}"
+    def __init__(self, *, frame: SpecialCoordinateSystem, point: SlicePointType, transpose: bool,
+                 range: DimensionRangeCollection, qflags: Sequence[bool]):
+        assert len(point) == len(qflags)
+        assert 3 >= sum(1 for i in filter(lambda x: x is True, qflags)
+                        ), "A maximum of 3 spatial dimensions can be specified"
         self.frame = frame
         self.slicepoint = point
         self.range = range
-        self._display_x, self._display_y, self._display_z = self._create_display_mapping(transpose)
+        self._slicevalue_z, self._slicewidth_z = (None, ) * 2
+        self._display_x, self._display_y, self._display_z = (None, ) * 3
+        self._init(transpose, qflags)
 
     @property
-    def value(self):
-        return self.slicepoint[self._display_z]
+    def z_index(self) -> float:
+        """Return the index of the dimension treated as the out of plane index"""
+        return self._display_z
 
     @property
-    def width(self):
-        return self.range[1] - self.range[0]
+    def z_value(self) -> float:
+        """Return the value of the slice point in the dimension assigned as Z"""
+        return self._slicevalue_z
 
-    def transform(self, point):
+    @property
+    def z_width(self) -> float:
+        """Return the width of the slice in the dimension assigned as Z. Can be None if there is no Z"""
+        return self._slicewidth_z
+
+    def can_support_nonorthogonal_axes(self) -> bool:
+        """Return boolean indicating if the current slice selection can support nonorthogonal viewing.
+        Both display axes must be spatial for this to be supported.
+        """
+        return self._nonorthogonal_axes_supported
+
+    def transform(self, point) -> np.ndarray:
         """Transform a point to the slice frame.
         It returns a ndarray(X,Y,Z) where X,Y are coordinates of X,Y of the display
         and Z is the out of place coordinate
@@ -53,26 +75,35 @@ class SliceInfo:
         return np.array((point[self._display_x], point[self._display_y], point[self._display_z]))
 
     # private api
-    def _create_display_mapping(self, transpose):
+    def _init(self, transpose: bool, qflags: Sequence[bool]):
         """
         Set values of the display indexes into a point in data space for coordinates X,Y,Z in display space
         For example,  slicepoint = [None,0.5,None] and transpose=True gives
 
             x_index=2, y_index=0, z_index=1
-        :param transpose: If True then X,Y dimensions should be swapped
+
+        For parameter descriptions see __init__
         :return: A list of 3 indices corresponding to the display mapping
         """
         x_index, y_index, z_index = None, None, None
-        for index, pt in enumerate(self.slicepoint):
+        for index, (pt, is_spatial) in enumerate(zip(self.slicepoint, qflags)):
             if pt is None:
                 if x_index is None:
                     x_index = index
                 else:
                     y_index = index
-            else:
+            elif is_spatial:
                 z_index = index
 
         if transpose:
             x_index, y_index = y_index, x_index
 
-        return x_index, y_index, z_index
+        self._nonorthogonal_axes_supported = (self.frame == SpecialCoordinateSystem.HKL
+                                              and qflags[x_index] and qflags[y_index])
+
+        if z_index is not None:
+            self._slicevalue_z = self.slicepoint[z_index]
+            z_range = self.range[z_index]
+            self._slicewidth_z = z_range[1] - z_range[0]
+
+        self._display_x, self._display_y, self._display_z = x_index, y_index, z_index

--- a/qt/python/mantidqt/widgets/sliceviewer/test/test_sliceviewer_sliceinfo.py
+++ b/qt/python/mantidqt/widgets/sliceviewer/test/test_sliceviewer_sliceinfo.py
@@ -8,27 +8,71 @@
 # std imports
 import unittest
 
+# 3rd party
+from mantid.api import SpecialCoordinateSystem
+
 # local imports
 from mantidqt.widgets.sliceviewer.sliceinfo import SliceInfo
 
 
 class SliceInfoTest(unittest.TestCase):
     def test_construction_with_named_fields(self):
-        frame, point, transpose, dimrange = "HKL", (None, None, 0.5), False, (-15, 15)
-        info = SliceInfo(frame=frame, point=point, transpose=transpose, range=dimrange)
+        frame, point, transpose, = SpecialCoordinateSystem.HKL, (None, None, 0.5), False
+        dimrange, spatial = (None, None, (-15, 15)), [True] * 3
+        info = SliceInfo(frame=frame,
+                         point=point,
+                         transpose=transpose,
+                         range=dimrange,
+                         qflags=spatial)
 
         self.assertEqual(frame, info.frame)
         self.assertEqual(point, info.slicepoint)
         self.assertEqual(dimrange, info.range)
-        self.assertEqual(point[2], info.value)
+        self.assertEqual(2, info.z_index)
+        self.assertEqual(point[2], info.z_value)
+        self.assertEqual(dimrange[2][1] - dimrange[2][0], info.z_width)
+
+    def test_no_spatial_dimensions_sets_z_properties_None(self):
+        frame, point, transpose, = SpecialCoordinateSystem.HKL, (None, None, 0.5), False
+        dimrange, spatial = (None, None, (-15, 15)), [False] * 3
+        info = SliceInfo(frame=frame,
+                         point=point,
+                         transpose=transpose,
+                         range=dimrange,
+                         qflags=spatial)
+
+        self.assertTrue(info.z_index is None)
+        self.assertTrue(info.z_value is None)
+        self.assertTrue(info.z_width is None)
+
+    def test_non_HKL_workspace_cannot_support_nonorthogonal_axes(self):
+        self._assert_can_support_nonorthogonal_axes(False,
+                                                    SpecialCoordinateSystem.QLab,
+                                                    qflags=[True] * 3)
+
+    def test_HKL_workspace_with_one_slice_spatial_dimension_cannot_support_nonorthogonal_axes(self):
+        self._assert_can_support_nonorthogonal_axes(False,
+                                                    SpecialCoordinateSystem.HKL,
+                                                    qflags=[True, False, False])
+
+    def test_HKL_workspace_with_no_slice_spatial_dimension_cannot_support_nonorthogonal_axes(self):
+        self._assert_can_support_nonorthogonal_axes(False,
+                                                    SpecialCoordinateSystem.HKL,
+                                                    qflags=[False] * 3)
+
+    def test_HKL_workspace_with_two_slice_spatial_dimensions_can_support_nonorthogonal_axes(self):
+        self._assert_can_support_nonorthogonal_axes(True,
+                                                    SpecialCoordinateSystem.HKL,
+                                                    qflags=[True, True, False])
 
     def test_transform_selects_dimensions_correctly_when_not_transposed(self):
         # Set slice info such that display(X,Y) = data(Y,Z)
         slice_pt = 0.5
-        info = SliceInfo(frame="HKL",
+        info = SliceInfo(frame=SpecialCoordinateSystem.HKL,
                          point=(slice_pt, None, None),
                          transpose=False,
-                         range=(-15, 15))
+                         range=[(-15, 15), None, None],
+                         qflags=[True, True, True])
 
         frame_point = (0.5, 1.0, -1.5)
         slice_frame = info.transform(frame_point)
@@ -36,12 +80,16 @@ class SliceInfoTest(unittest.TestCase):
         self.assertEqual(frame_point[1], slice_frame[0])
         self.assertEqual(frame_point[2], slice_frame[1])
         self.assertEqual(frame_point[0], slice_frame[2])
-        self.assertEqual(slice_pt, info.value)
+        self.assertEqual(slice_pt, info.z_value)
 
     def test_transform_selects_dimensions_correctly_when_transposed(self):
         # Set slice info such that display(X,Y) = data(Z,Y)
         slice_pt = 0.5
-        info = SliceInfo(frame="HKL", point=(slice_pt, None, None), transpose=True, range=(-15, 15))
+        info = SliceInfo(frame=SpecialCoordinateSystem.HKL,
+                         point=(slice_pt, None, None),
+                         transpose=True,
+                         range=[(-15, 15), None, None],
+                         qflags=[True, True, True])
 
         frame_point = (0.5, 1.0, -1.5)
         slice_frame = info.transform(frame_point)
@@ -49,15 +97,29 @@ class SliceInfoTest(unittest.TestCase):
         self.assertEqual(frame_point[2], slice_frame[0])
         self.assertEqual(frame_point[1], slice_frame[1])
         self.assertEqual(frame_point[0], slice_frame[2])
-        self.assertEqual(slice_pt, info.value)
+        self.assertEqual(slice_pt, info.z_value)
 
-    def test_slicepoint_not_length_three_raises_errors(self):
+    def test_slicepoint_with_greater_than_three_qflags_true_raises_errors(self):
         self.assertRaises(AssertionError,
                           SliceInfo,
-                          frame="HKL",
+                          frame=SpecialCoordinateSystem.HKL,
                           point=(1, None, None, 4),
                           transpose=True,
-                          range=(-15, 15))
+                          range=[(-15, 15), None, None, (-5, -5)],
+                          qflags=(True, True, True, True))
+
+    # private
+    def _assert_can_support_nonorthogonal_axes(self, expectation, frame, qflags):
+        frame, point, transpose, = frame, (None, None, 0.5), False
+        dimrange, spatial = (None, None, (-15, 15)), qflags
+
+        info = SliceInfo(frame=frame,
+                         point=point,
+                         transpose=transpose,
+                         range=dimrange,
+                         qflags=spatial)
+
+        self.assertEqual(expectation, info.can_support_nonorthogonal_axes())
 
 
 if __name__ == '__main__':

--- a/qt/python/mantidqt/widgets/sliceviewer/toolbar.py
+++ b/qt/python/mantidqt/widgets/sliceviewer/toolbar.py
@@ -92,4 +92,6 @@ class SliceViewerNavigationToolbar(NavigationToolbar2QT):
         actions = self.actions()
         for action in actions:
             if action.text() == text:
+                if action.isChecked() and not state:
+                    action.trigger()  # ensure view reacts appropriately
                 action.setEnabled(state)

--- a/qt/python/mantidqt/widgets/sliceviewer/view.py
+++ b/qt/python/mantidqt/widgets/sliceviewer/view.py
@@ -83,9 +83,9 @@ class SliceViewerDataView(QWidget):
         # MPL toolbar
         self.mpl_toolbar = SliceViewerNavigationToolbar(self.canvas, self)
         self.mpl_toolbar.gridClicked.connect(self.toggle_grid)
-        self.mpl_toolbar.linePlotsClicked.connect(self.line_plots_toggle)
+        self.mpl_toolbar.linePlotsClicked.connect(self.on_line_plots_toggle)
         self.mpl_toolbar.plotOptionsChanged.connect(self.colorbar.mappable_changed)
-        self.mpl_toolbar.nonOrthogonalClicked.connect(self.non_orthogonal_axes_toggle)
+        self.mpl_toolbar.nonOrthogonalClicked.connect(self.on_non_orthogonal_axes_toggle)
 
         # layout
         self.layout = QGridLayout(self)
@@ -253,11 +253,11 @@ class SliceViewerDataView(QWidget):
             self.image.set_data(data.T)
         self.colorbar.update_clim()
 
-    def line_plots_toggle(self, state):
+    def on_line_plots_toggle(self, state):
         self.presenter.line_plots(state)
         self.line_plots = state
 
-    def non_orthogonal_axes_toggle(self, state):
+    def on_non_orthogonal_axes_toggle(self, state):
         """
         Switch state of the non-orthognal axes on/off
         """
@@ -287,11 +287,17 @@ class SliceViewerDataView(QWidget):
         """
         self.mpl_toolbar.set_action_enabled(ToolItemText.OVERLAYPEAKS, False)
 
+    def enable_nonorthogonal_axes_button(self):
+        """
+        Enables access to non-orthogonal axes functionality
+        """
+        self.mpl_toolbar.set_action_enabled(ToolItemText.NONORTHOGONAL_AXES, True)
+
     def disable_nonorthogonal_axes_button(self):
         """
         Disables non-orthorognal axes functionality
         """
-        self.mpl_toolbar.set_action_enabled(ToolItemText.NONORTHOGONAL_AXES, False)
+        self.mpl_toolbar.set_action_enabled(ToolItemText.NONORTHOGONAL_AXES, state=False)
 
     def clear_line_plots(self):
         try:  # clear old plots


### PR DESCRIPTION
**Description of work.**

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

**To test:**

See script in the related issue for generating a workspace to test this functionality.
* Try enabling nonorthogonal axes mode
* Ensure that when one of the dimensions selected is not Q then the nonorthogonal button is disabled and then switching back enables the button again.
* When nonorthogonal mode becomes available then the peaks/line viewer should become disabled.

Fixes #28698 

*This does not require release notes* because **nonorthogonal axes are new in this version**

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
