### PR TITLE
Fix Colorfill Plots Throwing When Toggling Normalisation with a Log Colorbar

### DIFF
--- a/docs/source/release/v5.1.0/mantidworkbench.rst
+++ b/docs/source/release/v5.1.0/mantidworkbench.rst
@@ -53,5 +53,6 @@ Bugfixes
 - The correct interpolation now appears in the plot figure options for colorfill plots.
 - Changing the axis scale on a colourfill plot now has the same result if it is done from either the context menu or figure options.
 - `plt.show()` now shows the most recently created figure.
+- Removed error when changing the normalisation of a ragged workspace with a log scaled colorbar.
 
 :ref:`Release 5.1.0 <v5.1.0>`

--- a/qt/applications/workbench/workbench/plotting/figureinteraction.py
+++ b/qt/applications/workbench/workbench/plotting/figureinteraction.py
@@ -689,6 +689,16 @@ class FigureInteraction(object):
 
             ax.update_waterfall(0, 0)
 
+        # The colorbar can get screwed up with ragged workspaces and log scales as they go
+        # through the normalisation toggle.
+        # Set it to Linear and change it back after if necessary, since there's no reason
+        # to duplicate the handling.
+        colorbar_log = False
+        if ax.images:
+            colorbar_log = isinstance(ax.images[-1].norm, LogNorm)
+            if colorbar_log:
+                self._change_colorbar_axes(Normalize)
+
         is_normalized = self._is_normalized(ax)
         for arg_set in ax.creation_args:
             if arg_set['function'] == 'contour':
@@ -737,6 +747,8 @@ class FigureInteraction(object):
             colorbar_max = np.nanmax(ax.images[-1].get_array())
             for image in ax.images:
                 image.set_clim(colorbar_min, colorbar_max)
+            if colorbar_log:  # If it had a log scaled colorbar before, put it back.
+                self._change_colorbar_axes(LogNorm)
 
         ax.autoscale()
 

--- a/qt/applications/workbench/workbench/plotting/figureinteraction.py
+++ b/qt/applications/workbench/workbench/plotting/figureinteraction.py
@@ -699,6 +699,31 @@ class FigureInteraction(object):
             if colorbar_log:
                 self._change_colorbar_axes(Normalize)
 
+        self._change_plot_normalization(ax)
+
+        if ax.lines:  # Relim causes issues with colour plots, which have no lines.
+            ax.relim()
+
+        if ax.images:  # Colour bar limits are wrong if workspace is ragged. Set them manually.
+            colorbar_min = np.nanmin(ax.images[-1].get_array())
+            colorbar_max = np.nanmax(ax.images[-1].get_array())
+            for image in ax.images:
+                image.set_clim(colorbar_min, colorbar_max)
+            if colorbar_log:  # If it had a log scaled colorbar before, put it back.
+                self._change_colorbar_axes(LogNorm)
+
+        ax.autoscale()
+
+        datafunctions.set_initial_dimensions(ax)
+        if waterfall:
+            ax.update_waterfall(x, y)
+
+            if has_fill:
+                ax.set_waterfall_fill(True, fill_colour)
+
+        self.canvas.draw()
+
+    def _change_plot_normalization(self, ax):
         is_normalized = self._is_normalized(ax)
         for arg_set in ax.creation_args:
             if arg_set['function'] == 'contour':
@@ -738,28 +763,6 @@ class FigureInteraction(object):
                                 col.set_color(contour_line_colour)
                         else:
                             ws_artist.replace_data(workspace, arg_set_copy)
-
-        if ax.lines:  # Relim causes issues with colour plots, which have no lines.
-            ax.relim()
-
-        if ax.images:  # Colour bar limits are wrong if workspace is ragged. Set them manually.
-            colorbar_min = np.nanmin(ax.images[-1].get_array())
-            colorbar_max = np.nanmax(ax.images[-1].get_array())
-            for image in ax.images:
-                image.set_clim(colorbar_min, colorbar_max)
-            if colorbar_log:  # If it had a log scaled colorbar before, put it back.
-                self._change_colorbar_axes(LogNorm)
-
-        ax.autoscale()
-
-        datafunctions.set_initial_dimensions(ax)
-        if waterfall:
-            ax.update_waterfall(x, y)
-
-            if has_fill:
-                ax.set_waterfall_fill(True, fill_colour)
-
-        self.canvas.draw()
 
     def _can_toggle_normalization(self, ax):
         """

--- a/qt/applications/workbench/workbench/plotting/test/test_figureinteraction.py
+++ b/qt/applications/workbench/workbench/plotting/test/test_figureinteraction.py
@@ -28,7 +28,7 @@ from mantid.simpleapi import CreateWorkspace
 from mantidqt.plotting.figuretype import FigureType
 from mantidqt.plotting.functions import plot, pcolormesh_from_names
 from mantidqt.utils.qt.testing import start_qapplication
-from workbench.plotting.figureinteraction import FigureInteraction
+from workbench.plotting.figureinteraction import FigureInteraction, LogNorm
 
 
 @start_qapplication
@@ -389,6 +389,18 @@ class FigureInteractionTest(unittest.TestCase):
         fig_interactor._toggle_normalization(fig.axes[0])
         self.assertEqual(clim, fig.axes[0].images[0].get_clim())
         self.assertNotEqual((-0.1, 0.1), fig.axes[0].images[0].get_clim())
+
+    def test_log_maintained_when_normalisation_toggled(self):
+        ws = CreateWorkspace(DataX=[1, 2, 3, 4, 2, 4, 6, 8], DataY=[2] * 8, NSpec=2, OutputWorkspace="ragged_ws")
+        fig = pcolormesh_from_names([ws])
+        mock_canvas = MagicMock(figure=fig)
+        fig_manager_mock = MagicMock(canvas=mock_canvas)
+        fig_interactor = FigureInteraction(fig_manager_mock)
+        fig_interactor._change_colorbar_axes(LogNorm)
+
+        fig_interactor._toggle_normalization(fig.axes[0])
+
+        self.assertTrue(isinstance(fig.axes[0].images[-1].norm, LogNorm))
 
     # Private methods
     def _create_mock_fig_manager_to_accept_right_click(self):


### PR DESCRIPTION
**Description of work.**
FIxes a bug with ragged colorfill plots where if they had a log scale and the normalisation was changed, an unhandled exception occured due to having negative values for the `vmin` value of the colorbar. This PR simply changes the colorbar to Linear while the normalisation changes occur, and then changes it back if neccessary, since all the handling for negative values has already been written in the colorbar changing methods. 

**To test:**
1. Load GEM38370_Focussed and make colorfill plot
2.Right-click and select Colorbar -> Log
3. Right-click and select Normalisation -> whichever one isn't currently selected


Fixes #28381


---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
