### PR TITLE
Improve Muon Analysis handling of deleted workspaces.

### DIFF
--- a/scripts/Muon/GUI/Common/seq_fitting_tab_widget/QSequentialTableModel.py
+++ b/scripts/Muon/GUI/Common/seq_fitting_tab_widget/QSequentialTableModel.py
@@ -135,6 +135,8 @@ class QSequentialTableModel(QAbstractTableModel):
 
     def set_fit_workspaces(self, runs, group_and_pairs):
         self.clear_fit_workspaces()
+        if not runs or not group_and_pairs:
+            return
         self.beginInsertRows(QModelIndex(), 0, len(runs) - 1)
         for i in range(len(runs)):
             self._defaultData.insert(i, [runs[i], group_and_pairs[i], default_fit_status, default_chi_squared])

--- a/scripts/Muon/GUI/Common/seq_fitting_tab_widget/seq_fitting_tab_widget.py
+++ b/scripts/Muon/GUI/Common/seq_fitting_tab_widget/seq_fitting_tab_widget.py
@@ -9,8 +9,8 @@ from Muon.GUI.Common.seq_fitting_tab_widget.seq_fitting_tab_presenter import Seq
 
 
 class SeqFittingTabWidget(object):
-    def __init__(self, context, model, parent):
-        self.seq_fitting_tab_view = SeqFittingTabView(parent)
+    def __init__(self, context, model, parent, view=None):
+        self.seq_fitting_tab_view = view if view else SeqFittingTabView(parent)
         self.seq_fitting_tab_model = model
 
         self.seq_fitting_tab_presenter = SeqFittingTabPresenter(self.seq_fitting_tab_view, self.seq_fitting_tab_model,
@@ -29,3 +29,5 @@ class SeqFittingTabWidget(object):
 
         self.seq_fitting_tab_view.fit_table.set_slot_for_key_up_down_pressed(
             self.seq_fitting_tab_presenter.handle_fit_selected_in_table)
+
+        context.deleted_plots_notifier.add_subscriber(self.seq_fitting_tab_presenter.selected_workspaces_observer)


### PR DESCRIPTION
This PR addresses the sequential fitting tab not behaving correctly when a workspace is deleted.
This was fixed by connecting the tab to the plot deletion signal in the context. This brought up another issue with the creation of empty tables in the sequential widget, which has also been fixed.

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

**To test:**
Both the issue in #28637 should now be fixed.

First, 
1. Load data in the Muon GUI (MUSR62260)
2. Delete the workspace
3. The sequential fitting tab should now update (and be empty).

Second,
1. Load data in the Muon GUI (MUSR62260)
2. Deselect all groups in the grouping tabs
3. An error should no longer pop-up
<!-- Instructions for testing. -->

Fixes #28637 <!-- and fix #xxxx or close #xxxx xor resolves #xxxx -->
<!-- alternative
*There is no associated issue.*
-->


*This does not require release notes* because this behavior was introduced in this sprint.


---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
