### PR TITLE
Fix SavePlot1D algorithm not working in Workbench

### DIFF
--- a/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/SavePlot1D.py
+++ b/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/SavePlot1D.py
@@ -7,7 +7,6 @@
 #pylint: disable=no-init,invalid-name,redefined-builtin
 import mantid
 from mantid.kernel import Direction, IntArrayProperty, StringArrayProperty, StringListValidator
-import sys
 import importlib
 
 
@@ -221,8 +220,6 @@ class SavePlot1D(mantid.api.PythonAlgorithm):
         if len(ok2run) > 0:
             raise RuntimeError(ok2run)
 
-        matplotlib = sys.modules['matplotlib']
-        matplotlib.use('agg')
         import matplotlib.pyplot as plt
 
         if isinstance(self._wksp, mantid.api.WorkspaceGroup):

--- a/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/SavePlot1D.py
+++ b/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/SavePlot1D.py
@@ -244,7 +244,8 @@ class SavePlot1D(mantid.api.PythonAlgorithm):
 
     def doPlotImage(self, ax, ws):
         spectra = ws.getNumberHistograms()
-        if spectra > 10:
+        number_of_lines = spectra if len(self.visibleSpectra) <= 0 else len(self.visibleSpectra)
+        if number_of_lines > 10:
             mantid.kernel.logger.warning("more than 10 spectra to plot")
         prog_reporter = mantid.api.Progress(self, start=0.0, end=1.0,
                                             nreports=spectra)
@@ -262,7 +263,7 @@ class SavePlot1D(mantid.api.PythonAlgorithm):
             ax.set_ylabel(ylabel)
             prog_reporter.report("Processing")
 
-        if 1 < spectra <= 10:
+        if 1 < number_of_lines <= 10:
             ax.legend()
 
 

--- a/docs/source/release/v5.1.0/mantidworkbench.rst
+++ b/docs/source/release/v5.1.0/mantidworkbench.rst
@@ -53,5 +53,6 @@ Bugfixes
 - The correct interpolation now appears in the plot figure options for colorfill plots.
 - Changing the axis scale on a colourfill plot now has the same result if it is done from either the context menu or figure options.
 - `plt.show()` now shows the most recently created figure.
+- The SavePlot1D algorithm can now be run in Workbench.
 
 :ref:`Release 5.1.0 <v5.1.0>`


### PR DESCRIPTION
**Description of work.**
See title. Previously the algorithm would cause an error.

**To test:**
```
ws = CreateSampleWorkspace()
SavePlot1D(ws, *put your own output file here*)
```
Check that the plot image has been saved correctly.

Fixes #28357 

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
