### PR TITLE
Expose C++ method of matrix workspace getIndicesFromDetectorID to python

### DIFF
--- a/Framework/PythonInterface/mantid/api/src/Exports/MatrixWorkspace.cpp
+++ b/Framework/PythonInterface/mantid/api/src/Exports/MatrixWorkspace.cpp
@@ -326,6 +326,13 @@ void applyPointsFromAnotherWorkspace(MatrixWorkspace &self,
   self.setPoints(setIndex, ws.points(getIndex));
 }
 
+std::vector<size_t>
+getIndicesFromDetectorIDs(MatrixWorkspace &self,
+                          const boost::python::list &detIDs) {
+  return self.getIndicesFromDetectorIDs(
+      Converters::PySequenceToVector<int>(detIDs)());
+}
+
 } // namespace
 
 /** Python exports of the Mantid::API::MatrixWorkspace class. */
@@ -366,6 +373,10 @@ void export_MatrixWorkspace() {
            (arg("self"), arg("spec_no")),
            "Returns workspace index correspondent to the given spectrum "
            "number. Throws if no such spectrum is present in the workspace")
+      .def("getIndicesFromDetectorIDs", &getIndicesFromDetectorIDs,
+           (arg("self"), arg("detID_list")),
+           "Returns a list of workspace indices from the corrresponding "
+           "detector IDs.")
       .def("getDetector", &MatrixWorkspace::getDetector,
            return_value_policy<RemoveConstSharedPtr>(),
            (arg("self"), arg("workspaceIndex")),

--- a/Framework/PythonInterface/test/python/mantid/api/MatrixWorkspaceTest.py
+++ b/Framework/PythonInterface/test/python/mantid/api/MatrixWorkspaceTest.py
@@ -17,7 +17,6 @@ import numpy as np
 
 
 class MatrixWorkspaceTest(unittest.TestCase):
-
     _test_ws_prop = None
     _test_ws = None
 
@@ -188,9 +187,9 @@ class MatrixWorkspaceTest(unittest.TestCase):
     def test_setxy_data_coerced_correctly_to_float64(self):
         nbins = 10
         nspec = 2
-        xdata = np.arange(nbins+1)
+        xdata = np.arange(nbins + 1)
         ydata = np.arange(nbins)
-        ws = WorkspaceFactory.create("Workspace2D", NVectors=nspec, XLength=nbins+1, YLength=nbins)
+        ws = WorkspaceFactory.create("Workspace2D", NVectors=nspec, XLength=nbins + 1, YLength=nbins)
         for i in range(nspec):
             ws.setX(i, xdata)
             ws.setY(i, ydata)
@@ -204,9 +203,9 @@ class MatrixWorkspaceTest(unittest.TestCase):
     def test_setxy_accepts_python_list(self):
         nbins = 10
         nspec = 2
-        xdata = list(range(nbins+1))
+        xdata = list(range(nbins + 1))
         ydata = list(range(nbins))
-        ws = WorkspaceFactory.create("Workspace2D", NVectors=nspec, XLength=nbins+1, YLength=nbins)
+        ws = WorkspaceFactory.create("Workspace2D", NVectors=nspec, XLength=nbins + 1, YLength=nbins)
         for i in range(nspec):
             ws.setX(i, xdata)
             ws.setY(i, ydata)
@@ -235,7 +234,7 @@ class MatrixWorkspaceTest(unittest.TestCase):
         else:
             nhist = 1
             start = index
-            end = index+nhist
+            end = index + nhist
 
         blocksize = workspace.blocksize()
         for arr in (x_np, y_np, e_np):
@@ -290,11 +289,11 @@ class MatrixWorkspaceTest(unittest.TestCase):
 
     def test_operators_with_workspaces_in_ADS(self):
         run_algorithm('CreateWorkspace', OutputWorkspace='a', DataX=[
-                      1., 2., 3.], DataY=[2., 3.], DataE=[2., 3.], UnitX='TOF')
+            1., 2., 3.], DataY=[2., 3.], DataE=[2., 3.], UnitX='TOF')
         ads = AnalysisDataService
         A = ads['a']
         run_algorithm('CreateWorkspace', OutputWorkspace='b', DataX=[
-                      1., 2., 3.], DataY=[2., 3.], DataE=[2., 3.], UnitX='TOF')
+            1., 2., 3.], DataY=[2., 3.], DataE=[2., 3.], UnitX='TOF')
         B = ads['b']
 
         # Equality
@@ -324,7 +323,7 @@ class MatrixWorkspaceTest(unittest.TestCase):
         ads.remove('C')
         self.assertTrue('C' not in ads)
         run_algorithm('CreateWorkspace', OutputWorkspace='ca', DataX=[
-                      1., 2., 3.], DataY=[2., 3.], DataE=[2., 3.], UnitX='TOF')
+            1., 2., 3.], DataY=[2., 3.], DataE=[2., 3.], UnitX='TOF')
         C = ads['ca']
 
         C *= B
@@ -349,9 +348,9 @@ class MatrixWorkspaceTest(unittest.TestCase):
 
     def test_complex_binary_ops_do_not_leave_temporary_workspaces_behind(self):
         run_algorithm('CreateWorkspace', OutputWorkspace='ca', DataX=[
-                      1., 2., 3.], DataY=[2., 3.], DataE=[2., 3.], UnitX='TOF')
+            1., 2., 3.], DataY=[2., 3.], DataE=[2., 3.], UnitX='TOF')
         ads = AnalysisDataService
-        w1 = (ads['ca']*0.0)+1.0
+        w1 = (ads['ca'] * 0.0) + 1.0
 
         self.assertTrue('w1' in ads)
         self.assertTrue('ca' in ads)
@@ -359,7 +358,7 @@ class MatrixWorkspaceTest(unittest.TestCase):
 
     def test_history_access(self):
         run_algorithm('CreateWorkspace', OutputWorkspace='raw', DataX=[
-                      1., 2., 3.], DataY=[2., 3.], DataE=[2., 3.], UnitX='TOF')
+            1., 2., 3.], DataY=[2., 3.], DataE=[2., 3.], UnitX='TOF')
         run_algorithm('Rebin', InputWorkspace='raw', Params=[1., 0.5, 3.], OutputWorkspace='raw')
         raw = AnalysisDataService['raw']
         history = raw.getHistory()
@@ -373,7 +372,7 @@ class MatrixWorkspaceTest(unittest.TestCase):
 
     def test_setTitleAndComment(self):
         run_algorithm('CreateWorkspace', OutputWorkspace='ws1', DataX=[
-                      1., 2., 3.], DataY=[2., 3.], DataE=[2., 3.], UnitX='TOF')
+            1., 2., 3.], DataY=[2., 3.], DataE=[2., 3.], UnitX='TOF')
         ws1 = AnalysisDataService['ws1']
         title = 'test_title'
         ws1.setTitle(title)
@@ -385,9 +384,9 @@ class MatrixWorkspaceTest(unittest.TestCase):
 
     def test_setGetMonitorWS(self):
         run_algorithm('CreateWorkspace', OutputWorkspace='ws1', DataX=[
-                      1., 2., 3.], DataY=[2., 3.], DataE=[2., 3.], UnitX='TOF')
+            1., 2., 3.], DataY=[2., 3.], DataE=[2., 3.], UnitX='TOF')
         run_algorithm('CreateWorkspace', OutputWorkspace='ws_mon', DataX=[
-                      1., 2., 3.], DataY=[2., 3.], DataE=[2., 3.], UnitX='TOF')
+            1., 2., 3.], DataY=[2., 3.], DataE=[2., 3.], UnitX='TOF')
 
         ws1 = AnalysisDataService.retrieve('ws1')
         try:
@@ -434,33 +433,42 @@ class MatrixWorkspaceTest(unittest.TestCase):
 
     def test_isCommonLogBins(self):
         self.assertFalse(self._test_ws.isCommonLogBins())
-        ws=CreateSampleWorkspace('Event')
-        ws=Rebin(ws, '1,-1,10000')
+        ws = CreateSampleWorkspace('Event')
+        ws = Rebin(ws, '1,-1,10000')
         self.assertTrue(ws.isCommonLogBins())
-        ws=Rebin(ws, '1,-0.1,10000')
+        ws = Rebin(ws, '1,-0.1,10000')
         self.assertTrue(ws.isCommonLogBins())
 
     def test_hasMaskedBins(self):
         numBins = 10
-        numHist=11
+        numHist = 11
         ws = WorkspaceCreationHelper.create2DWorkspace123WithMaskedBin(numHist, numBins, 0, 1)
         self.assertTrue(ws.hasMaskedBins(0))
         self.assertFalse(ws.hasMaskedBins(1))
 
     def test_hasAnyMaskedBins(self):
         numBins = 10
-        numHist=11
+        numHist = 11
         ws = WorkspaceCreationHelper.create2DWorkspace123WithMaskedBin(numHist, numBins, 0, 1)
         self.assertTrue(ws.hasAnyMaskedBins())
 
     def test_maskedBinsIndices(self):
         numBins = 10
-        numHist=11
+        numHist = 11
         ws = WorkspaceCreationHelper.create2DWorkspace123WithMaskedBin(numHist, numBins, 0, 1)
         maskedBinsIndices = ws.maskedBinsIndices(0)
         self.assertEqual(1, len(maskedBinsIndices))
         for index in maskedBinsIndices:
             self.assertEqual(1, index)
+
+    def test_getIndicesFromDetectorIDs(self):
+        detinfo = self._test_ws.detectorInfo()
+        detIDs = detinfo.detectorIDs()  # [1, 2]
+        # from test_spectrum_retrieval we know
+        # self._test_ws.getSpectrum(1).hasDetectorID(2) == True
+        index = self._test_ws.getIndicesFromDetectorIDs([int(detIDs[1])])
+        self.assertEqual(1, index[0])
+        # index == None!
 
     def test_rebinnedOutput(self):
         rebin = WorkspaceFactory.create("RebinnedOutput", 2, 3, 2)
@@ -510,24 +518,24 @@ class MatrixWorkspaceTest(unittest.TestCase):
     def test_findY(self):
         # Check that zero is not present
         idx = self._test_ws.findY(0.)
-        self.assertEquals(idx[0],-1)
-        self.assertEquals(idx[1],-1)
+        self.assertEquals(idx[0], -1)
+        self.assertEquals(idx[1], -1)
         # Check that 5. is the first element
         idx = self._test_ws.findY(5.)
-        self.assertEquals(idx[0],0)
-        self.assertEquals(idx[1],0)
+        self.assertEquals(idx[0], 0)
+        self.assertEquals(idx[1], 0)
         # Check that no other elements are 5
         idx = self._test_ws.findY(5., (0, 1))
-        self.assertEquals(idx[0],-1)
-        self.assertEquals(idx[1],-1)
+        self.assertEquals(idx[0], -1)
+        self.assertEquals(idx[1], -1)
         # Check that 2. is the next element
         idx = self._test_ws.findY(2.)
-        self.assertEquals(idx[0],0)
-        self.assertEquals(idx[1],1)
+        self.assertEquals(idx[0], 0)
+        self.assertEquals(idx[1], 1)
         # Check that 2. is the next element
         idx = self._test_ws.findY(2., (0, 2))
-        self.assertEquals(idx[0],0)
-        self.assertEquals(idx[1],2)
+        self.assertEquals(idx[0], 0)
+        self.assertEquals(idx[1], 2)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
**Description of work.**
Exposed C++ method of matrix workspace getIndicesFromDetectorID to python so can access the xye etc. for a given detector in python

**To test:**

<!-- Instructions for testing. -->
Small change - is covered by a unit test

*There is no associated issue.*

*This does not require release notes* because **it is a small change with no associated issue**


---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
