### PR TITLE
Fix LoadMuonNexusV2 wrongly being called to load PSI Muon files

### DIFF
--- a/Framework/DataHandling/src/LoadMuonNexusV2.cpp
+++ b/Framework/DataHandling/src/LoadMuonNexusV2.cpp
@@ -35,6 +35,7 @@ namespace NeXusEntry {
 const std::string RAWDATA{"/raw_data_1"};
 const std::string DEFINITION{"/raw_data_1/definition"};
 const std::string PERIOD{"/periods"};
+const std::string BEAMLINE{"/raw_data_1/beamline"};
 } // namespace NeXusEntry
 
 /// Empty default constructor
@@ -53,9 +54,16 @@ int LoadMuonNexusV2::confidence(NexusHDF5Descriptor &descriptor) const {
   if (!descriptor.isEntry(NeXusEntry::RAWDATA, "NXentry")) {
     return 0;
   }
+
+  // Check if beamline entry exists beneath raw_data_1 - /raw_data_1/beamline
+  // Necessary to differentiate between ISIS and PSI nexus files.
+  if (!descriptor.isEntry(NeXusEntry::BEAMLINE))
+    return 0;
+
   // Check if Muon source in definition entry
   if (!descriptor.isEntry(NeXusEntry::DEFINITION))
     return 0;
+
   ::NeXus::File file(descriptor.getFilename());
   file.openPath(NeXusEntry::DEFINITION);
   std::string def = file.getStrData();


### PR DESCRIPTION
**Description of work.**
This PR fixes the LoadMuonNexusV2 loader wrongly being used to load PSI Muon files. This occurs as the file types are very similar, with both having a /raw_data_1 entry and a /raw_data_1/definition muon entry. To solve this issue, an additional metric is added to the confidence check in LoadMuonNexusV2 which looks for a top level beam line entry, i.e /raw_data_1/beamline.

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

**To test:**
Running `Load` on the following two files should now work:

1. GPS5397.NXS
2. GPD900.nxs

Furthermore, loading a Muon Nexus V2 file should still work, e.g EMU00102349.nxs_v2


<!-- Instructions for testing. -->

Fixes #28729 . <!-- and fix #xxxx or close #xxxx xor resolves #xxxx -->
<!-- alternative
*There is no associated issue.*
-->


*This does not require release notes* because **as it was a bug introduced in this release**


---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
