### PR TITLE
Add Colormaps to Workbench Instrument View

### DIFF
--- a/docs/source/release/v5.1.0/mantidworkbench.rst
+++ b/docs/source/release/v5.1.0/mantidworkbench.rst
@@ -38,6 +38,7 @@ Improvements
 
 - Surface plots no longer spill over the axes when their limits are reduced.
 - The instrument view now ignores non-finite (infinity and NaN) values and should now display workspaces containing those values.
+- The gray and plasma colormaps have been added to the instrument view. 
 
 Bugfixes
 ########

--- a/qt/widgets/mplcpp/src/MantidColorMap.cpp
+++ b/qt/widgets/mplcpp/src/MantidColorMap.cpp
@@ -28,8 +28,8 @@ namespace MplCpp {
  */
 QString MantidColorMap::chooseColorMap(const QString &previous,
                                        QWidget *parent) {
-  static QStringList allowedCMaps{"coolwarm", "jet", "summer", "winter",
-                                  "viridis"};
+  static QStringList allowedCMaps{"coolwarm", "gray",   "jet",    "plasma",
+                                  "summer",   "winter", "viridis"};
   const int currentIdx = allowedCMaps.indexOf(previous);
   bool ok;
   QString item =


### PR DESCRIPTION
**Description of work.**

Added the gray mpl colormap (to replicate the `Gamma_2.map`), and the plasma colormap (similar to the default `ColdFire.map`) to the instrument view. 

**Report to:** Pas


**To test:**
1. Launch workbench
2. Load a workspace
3. Right Click Workspace -> Show Instrument
4. Render -> Display Settings -> Colormap
5. Check `gray` and `plasma` appear in the list.
6. Check both look correct.

Fixes #28508 

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
-->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
