### PR TITLE
Add output options to ConvFit

### DIFF
--- a/Framework/CurveFitting/src/Algorithms/QENSFitSequential.cpp
+++ b/Framework/CurveFitting/src/Algorithms/QENSFitSequential.cpp
@@ -423,15 +423,13 @@ void QENSFitSequential::init() {
                   "Name of the log value to plot the "
                   "parameters against. Default: use spectra "
                   "numbers.");
-  declareProperty("StartX", EMPTY_DBL(),
-                  "A value of x in, or on the low x "
-                  "boundary of, the first bin to "
-                  "include in\n"
-                  "the fit (default lowest value of x)");
-  declareProperty("EndX", EMPTY_DBL(),
-                  "A value in, or on the high x boundary "
-                  "of, the last bin the fitting range\n"
-                  "(default the highest value of x)");
+  declareProperty("StartX", EMPTY_DBL(), "A value of x in, or on the low x "
+                                         "boundary of, the first bin to "
+                                         "include in\n"
+                                         "the fit (default lowest value of x)");
+  declareProperty("EndX", EMPTY_DBL(), "A value in, or on the high x boundary "
+                                       "of, the last bin the fitting range\n"
+                                       "(default the highest value of x)");
 
   declareProperty("PassWSIndexToFunction", false,
                   "For each spectrum in Input pass its workspace index to all "
@@ -470,6 +468,10 @@ void QENSFitSequential::init() {
       ", into their own workspace. These workspaces will have a histogram"
       " for each spectrum (Q-value) and will be grouped.",
       Direction::Input);
+
+  declareProperty("OutputCompositeMembers", false,
+                  "If true and CreateOutput is true then the value of each "
+                  "member of a Composite Function is also output.");
 
   declareProperty(std::make_unique<Kernel::PropertyWithValue<bool>>(
                       "ConvolveMembers", false),
@@ -758,6 +760,7 @@ ITableWorkspace_sptr QENSFitSequential::performFit(const std::string &input,
                                                    const std::string &output) {
   const std::vector<double> exclude = getProperty("Exclude");
   const bool convolveMembers = getProperty("ConvolveMembers");
+  const bool outputCompositeMembers = getProperty("OutputCompositeMembers");
   const bool passWsIndex = getProperty("PassWSIndexToFunction");
   const bool ignoreInvalidData = getProperty("IgnoreInvalidData");
   IFunction_sptr inputFunction = getProperty("Function");
@@ -773,7 +776,7 @@ ITableWorkspace_sptr QENSFitSequential::performFit(const std::string &input,
   plotPeaks->setProperty("IgnoreInvalidData", ignoreInvalidData);
   plotPeaks->setProperty("FitType", "Sequential");
   plotPeaks->setProperty("CreateOutput", true);
-  plotPeaks->setProperty("OutputCompositeMembers", true);
+  plotPeaks->setProperty("OutputCompositeMembers", outputCompositeMembers);
   plotPeaks->setProperty("ConvolveMembers", convolveMembers);
   plotPeaks->setProperty("MaxIterations", getPropertyValue("MaxIterations"));
   plotPeaks->setProperty("Minimizer", getPropertyValue("Minimizer"));

--- a/Framework/CurveFitting/src/Algorithms/QENSFitSequential.cpp
+++ b/Framework/CurveFitting/src/Algorithms/QENSFitSequential.cpp
@@ -423,13 +423,15 @@ void QENSFitSequential::init() {
                   "Name of the log value to plot the "
                   "parameters against. Default: use spectra "
                   "numbers.");
-  declareProperty("StartX", EMPTY_DBL(), "A value of x in, or on the low x "
-                                         "boundary of, the first bin to "
-                                         "include in\n"
-                                         "the fit (default lowest value of x)");
-  declareProperty("EndX", EMPTY_DBL(), "A value in, or on the high x boundary "
-                                       "of, the last bin the fitting range\n"
-                                       "(default the highest value of x)");
+  declareProperty("StartX", EMPTY_DBL(),
+                  "A value of x in, or on the low x "
+                  "boundary of, the first bin to "
+                  "include in\n"
+                  "the fit (default lowest value of x)");
+  declareProperty("EndX", EMPTY_DBL(),
+                  "A value in, or on the high x boundary "
+                  "of, the last bin the fitting range\n"
+                  "(default the highest value of x)");
 
   declareProperty("PassWSIndexToFunction", false,
                   "For each spectrum in Input pass its workspace index to all "

--- a/Framework/CurveFitting/src/Algorithms/QENSFitSimultaneous.cpp
+++ b/Framework/CurveFitting/src/Algorithms/QENSFitSimultaneous.cpp
@@ -346,9 +346,9 @@ const std::vector<std::string> QENSFitSimultaneous::seeAlso() const {
 
 void QENSFitSimultaneous::initConcrete() {
   declareProperty("Ties", "", Kernel::Direction::Input);
-  getPointerToProperty("Ties")->setDocumentation(
-      "Math expressions defining ties between parameters of "
-      "the fitting function.");
+  getPointerToProperty("Ties")
+      ->setDocumentation("Math expressions defining ties between parameters of "
+                         "the fitting function.");
   declareProperty("Constraints", "", Kernel::Direction::Input);
   getPointerToProperty("Constraints")->setDocumentation("List of constraints");
   auto mustBePositive = std::make_shared<Kernel::BoundedValidator<int>>();
@@ -378,6 +378,9 @@ void QENSFitSimultaneous::initConcrete() {
                   "If true members of any "
                   "Convolution are output convolved\n"
                   "with corresponding resolution");
+  declareProperty("OutputCompositeMembers", false,
+                  "If true and CreateOutput is true then the value of each "
+                  "member of a Composite Function is also output.");
 
   std::vector<std::string> unitOptions = UnitFactory::Instance().getKeys();
   unitOptions.emplace_back("");
@@ -483,6 +486,7 @@ QENSFitSimultaneous::performFit(
     const std::string &output) {
   IFunction_sptr function = getProperty("Function");
   const bool convolveMembers = getProperty("ConvolveMembers");
+  const bool outputCompositeMembers = getProperty("OutputCompositeMembers");
   const bool ignoreInvalidData = getProperty("IgnoreInvalidData");
   const bool calcErrors = getProperty("CalcErrors");
 
@@ -499,7 +503,7 @@ QENSFitSimultaneous::performFit(
   fit->setProperty("Minimizer", getPropertyValue("Minimizer"));
   fit->setProperty("CostFunction", getPropertyValue("CostFunction"));
   fit->setProperty("CalcErrors", calcErrors);
-  fit->setProperty("OutputCompositeMembers", true);
+  fit->setProperty("OutputCompositeMembers", outputCompositeMembers);
   fit->setProperty("ConvolveMembers", convolveMembers);
   fit->setProperty("CreateOutput", true);
   fit->setProperty("Output", output);

--- a/Framework/CurveFitting/src/Algorithms/QENSFitSimultaneous.cpp
+++ b/Framework/CurveFitting/src/Algorithms/QENSFitSimultaneous.cpp
@@ -346,9 +346,9 @@ const std::vector<std::string> QENSFitSimultaneous::seeAlso() const {
 
 void QENSFitSimultaneous::initConcrete() {
   declareProperty("Ties", "", Kernel::Direction::Input);
-  getPointerToProperty("Ties")
-      ->setDocumentation("Math expressions defining ties between parameters of "
-                         "the fitting function.");
+  getPointerToProperty("Ties")->setDocumentation(
+      "Math expressions defining ties between parameters of "
+      "the fitting function.");
   declareProperty("Constraints", "", Kernel::Direction::Input);
   getPointerToProperty("Constraints")->setDocumentation("List of constraints");
   auto mustBePositive = std::make_shared<Kernel::BoundedValidator<int>>();

--- a/Framework/CurveFitting/test/Algorithms/ConvolutionFitSequentialTest.h
+++ b/Framework/CurveFitting/test/Algorithms/ConvolutionFitSequentialTest.h
@@ -289,6 +289,7 @@ public:
     alg.setProperty("EndX", 3.0);
     alg.setProperty("SpecMin", boost::numeric_cast<int>(specMin));
     alg.setProperty("SpecMax", boost::numeric_cast<int>(specMax));
+    alg.setProperty("OutputCompositeMembers", true);
     alg.setProperty("ConvolveMembers", true);
     alg.setProperty("ExtractMembers", true);
     alg.setProperty("Minimizer", "Levenberg-Marquardt");

--- a/Framework/PythonInterface/test/python/plugins/algorithms/WorkflowAlgorithms/IqtFitSequentialTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/WorkflowAlgorithms/IqtFitSequentialTest.py
@@ -78,7 +78,7 @@ class IqtFitSequentialTest(unittest.TestCase):
         nbins = sub_ws.blocksize()
         nhists = sub_ws.getNumberHistograms()
         self.assertEqual(nbins, 58)
-        self.assertEqual(nhists, 5)
+        self.assertEqual(nhists, 3)
 
         # Check histogram names
         text_axis = sub_ws.getAxis(1)

--- a/docs/source/algorithms/ExtractQENSMembers-v1.rst
+++ b/docs/source/algorithms/ExtractQENSMembers-v1.rst
@@ -41,7 +41,7 @@ Usage
   # Run ConvolutionFitSequential algorithm
   ConvolutionFitSequential(InputWorkspace=sample, Function=function,
                            PassWSIndexToFunction=True, StartX=startX, EndX=endX,
-                           SpecMin=specMin, SpecMax=specMax, ConvolveMembers=convolve,
+                           SpecMin=specMin, SpecMax=specMax, OutputCompositeMembers=convolve, ConvolveMembers=convolve,
                            Minimizer=minimizer, MaxIterations=maxIt,
                            OutputWorkspace=output_ws_name)
 
@@ -96,7 +96,7 @@ Output:
 
   # Run ConvolutionFitSequential algorithm with ExtractMembers property
   ConvolutionFitSequential(InputWorkspace=sample, Function=function, PassWSIndexToFunction=True,
-                           StartX=startX, EndX=endX, SpecMin=specMin, SpecMax=specMax,
+                           StartX=startX, EndX=endX, SpecMin=specMin, SpecMax=specMax, OutputCompositeMembers=convolve,
                            ConvolveMembers=convolve, Minimizer=minimizer, MaxIterations=maxIt,
                            ExtractMembers=True, OutputWorkspace=output_ws_name)
 

--- a/docs/source/release/v5.1.0/indirect_geometry.rst
+++ b/docs/source/release/v5.1.0/indirect_geometry.rst
@@ -27,6 +27,7 @@ Improvements
 - :ref- :ref:`IndirectILLEnergyTransfer <algm-IndirectILLEnergyTransfer>` will produce energy transfer axis which takes into account that doppler channels are linear in velocity (not in time, neither energy as was assumed before). This will affect doppler mode QENS only.
 - Added docking and undocking to the plot window and function browser window for the fit tabs in Indirect Data Analysis on workbench.
 - Update the Indirect, Corrections user interface to use the :ref:`PaalmanPingsMonteCarloAbsorption <algm-PaalmanPingsMonteCarloAbsorption>` algorithm
+- OutputCompositeMembers and ConvolveOutputs have been added as options in the ConvFit tab of Indirect Data Analysis.
 
 Bug Fixes
 #########

--- a/qt/scientific_interfaces/Indirect/ConvFit.cpp
+++ b/qt/scientific_interfaces/Indirect/ConvFit.cpp
@@ -55,8 +55,9 @@ ConvFit::ConvFit(QWidget *parent)
   auto dataPresenter = std::make_unique<ConvFitDataPresenter>(
       m_convFittingModel, m_uiForm->dockArea->m_fitDataView);
   connect(
-      dataPresenter.get(), SIGNAL(modelResolutionAdded(
-                               std::string const &, TableDatasetIndex const &)),
+      dataPresenter.get(),
+      SIGNAL(
+          modelResolutionAdded(std::string const &, TableDatasetIndex const &)),
       this,
       SLOT(setModelResolution(std::string const &, TableDatasetIndex const &)));
   setFitDataPresenter(std::move(dataPresenter));

--- a/qt/scientific_interfaces/Indirect/ConvFit.cpp
+++ b/qt/scientific_interfaces/Indirect/ConvFit.cpp
@@ -29,7 +29,11 @@ using namespace Mantid::API;
 
 namespace {
 Mantid::Kernel::Logger g_log("ConvFit");
-}
+
+std::vector<std::string> CONVFIT_HIDDEN_PROPS = std::vector<std::string>(
+    {"CreateOutput", "LogValue", "PassWSIndexToFunction", "OutputWorkspace",
+     "IgnoreInvalidData", "Output", "PeakRadius", "PlotParameter"});
+} // namespace
 
 namespace MantidQt {
 namespace CustomInterfaces {
@@ -46,12 +50,13 @@ ConvFit::ConvFit(QWidget *parent)
   m_uiForm->dockArea->m_fitPropertyBrowser->setFunctionTemplateBrowser(
       new ConvTemplateBrowser);
   setFitPropertyBrowser(m_uiForm->dockArea->m_fitPropertyBrowser);
+  m_uiForm->dockArea->m_fitPropertyBrowser->setHiddenProperties(
+      CONVFIT_HIDDEN_PROPS);
   auto dataPresenter = std::make_unique<ConvFitDataPresenter>(
       m_convFittingModel, m_uiForm->dockArea->m_fitDataView);
   connect(
-      dataPresenter.get(),
-      SIGNAL(
-          modelResolutionAdded(std::string const &, TableDatasetIndex const &)),
+      dataPresenter.get(), SIGNAL(modelResolutionAdded(
+                               std::string const &, TableDatasetIndex const &)),
       this,
       SLOT(setModelResolution(std::string const &, TableDatasetIndex const &)));
   setFitDataPresenter(std::move(dataPresenter));

--- a/qt/scientific_interfaces/Indirect/IndirectFitAnalysisTab.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectFitAnalysisTab.cpp
@@ -93,9 +93,8 @@ void IndirectFitAnalysisTab::connectDataPresenter() {
   connect(m_dataPresenter.get(),
           SIGNAL(excludeRegionChanged(const std::string &, TableDatasetIndex,
                                       WorkspaceIndex)),
-          this,
-          SLOT(tableExcludeChanged(const std::string &, TableDatasetIndex,
-                                   WorkspaceIndex)));
+          this, SLOT(tableExcludeChanged(const std::string &, TableDatasetIndex,
+                                         WorkspaceIndex)));
   connect(m_dataPresenter.get(), SIGNAL(startXChanged(double)), this,
           SLOT(startXChanged(double)));
   connect(m_dataPresenter.get(), SIGNAL(endXChanged(double)), this,
@@ -658,6 +657,8 @@ void IndirectFitAnalysisTab::setAlgorithmProperties(
                             m_fitPropertyBrowser->fitEvaluationType());
   fitAlgorithm->setProperty("PeakRadius",
                             m_fitPropertyBrowser->getPeakRadius());
+  fitAlgorithm->setProperty("OutputCompositeMembers",
+                            m_fitPropertyBrowser->outputCompositeMembers());
 
   if (m_fittingModel->getFittingMode() == FittingMode::SEQUENTIAL) {
     fitAlgorithm->setProperty("FitType", m_fitPropertyBrowser->fitType());

--- a/qt/scientific_interfaces/Indirect/IndirectFitAnalysisTab.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectFitAnalysisTab.cpp
@@ -645,8 +645,6 @@ void IndirectFitAnalysisTab::setAlgorithmProperties(
   fitAlgorithm->setProperty("Minimizer", m_fitPropertyBrowser->minimizer(true));
   fitAlgorithm->setProperty("MaxIterations",
                             m_fitPropertyBrowser->maxIterations());
-  fitAlgorithm->setProperty("ConvolveMembers",
-                            m_fitPropertyBrowser->convolveMembers());
   fitAlgorithm->setProperty("PeakRadius",
                             m_fitPropertyBrowser->getPeakRadius());
   fitAlgorithm->setProperty("CostFunction",
@@ -657,8 +655,13 @@ void IndirectFitAnalysisTab::setAlgorithmProperties(
                             m_fitPropertyBrowser->fitEvaluationType());
   fitAlgorithm->setProperty("PeakRadius",
                             m_fitPropertyBrowser->getPeakRadius());
-  fitAlgorithm->setProperty("OutputCompositeMembers",
-                            m_fitPropertyBrowser->outputCompositeMembers());
+  if (m_fitPropertyBrowser->convolveMembers()) {
+    fitAlgorithm->setProperty("ConvolveMembers", true);
+    fitAlgorithm->setProperty("OutputCompositeMembers", true);
+  } else {
+    fitAlgorithm->setProperty("OutputCompositeMembers",
+                              m_fitPropertyBrowser->outputCompositeMembers());
+  }
 
   if (m_fittingModel->getFittingMode() == FittingMode::SEQUENTIAL) {
     fitAlgorithm->setProperty("FitType", m_fitPropertyBrowser->fitType());

--- a/qt/scientific_interfaces/Indirect/IndirectFitAnalysisTab.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectFitAnalysisTab.cpp
@@ -93,8 +93,9 @@ void IndirectFitAnalysisTab::connectDataPresenter() {
   connect(m_dataPresenter.get(),
           SIGNAL(excludeRegionChanged(const std::string &, TableDatasetIndex,
                                       WorkspaceIndex)),
-          this, SLOT(tableExcludeChanged(const std::string &, TableDatasetIndex,
-                                         WorkspaceIndex)));
+          this,
+          SLOT(tableExcludeChanged(const std::string &, TableDatasetIndex,
+                                   WorkspaceIndex)));
   connect(m_dataPresenter.get(), SIGNAL(startXChanged(double)), this,
           SLOT(startXChanged(double)));
   connect(m_dataPresenter.get(), SIGNAL(endXChanged(double)), this,

--- a/qt/scientific_interfaces/Indirect/IndirectFitPropertyBrowser.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectFitPropertyBrowser.cpp
@@ -84,17 +84,14 @@ void IndirectFitPropertyBrowser::initFitOptionsBrowser() {
       nullptr, FitOptionsBrowser::SimultaneousAndSequential);
   m_fitOptionsBrowser->setObjectName("fitOptionsBrowser");
   m_fitOptionsBrowser->setCurrentFittingType(FitOptionsBrowser::Sequential);
-  m_fitOptionsBrowser->addPropertyToBlacklist(QString("CreateOutput"));
-  m_fitOptionsBrowser->addPropertyToBlacklist(QString("LogValue"));
-  m_fitOptionsBrowser->addPropertyToBlacklist(QString("PassWSIndexToFunction"));
-  m_fitOptionsBrowser->addPropertyToBlacklist(QString("ConvolveMembers"));
-  m_fitOptionsBrowser->addPropertyToBlacklist(
-      QString("OutputCompositeMembers"));
-  m_fitOptionsBrowser->addPropertyToBlacklist(QString("OutputWorkspace"));
-  m_fitOptionsBrowser->addPropertyToBlacklist(QString("IgnoreInvalidData"));
-  m_fitOptionsBrowser->addPropertyToBlacklist(QString("Output"));
-  m_fitOptionsBrowser->addPropertyToBlacklist(QString("PeakRadius"));
-  m_fitOptionsBrowser->addPropertyToBlacklist(QString("PlotParameter"));
+}
+
+void IndirectFitPropertyBrowser::setHiddenProperties(
+    std::vector<std::string> hiddenProperties) {
+  for (const auto &propertyName : hiddenProperties) {
+    m_fitOptionsBrowser->addPropertyToBlacklist(
+        QString::fromStdString(propertyName));
+  }
 }
 
 bool IndirectFitPropertyBrowser::isFullFunctionBrowserActive() const {

--- a/qt/scientific_interfaces/Indirect/IndirectFitPropertyBrowser.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectFitPropertyBrowser.cpp
@@ -246,6 +246,11 @@ bool IndirectFitPropertyBrowser::convolveMembers() const {
          "0";
 }
 
+bool IndirectFitPropertyBrowser::outputCompositeMembers() const {
+  return m_fitOptionsBrowser->getProperty("OutputCompositeMembers")
+             .toStdString() != "0";
+}
+
 std::string IndirectFitPropertyBrowser::fitEvaluationType() const {
   return m_fitOptionsBrowser->getProperty("EvaluationType").toStdString();
 }

--- a/qt/scientific_interfaces/Indirect/IndirectFitPropertyBrowser.h
+++ b/qt/scientific_interfaces/Indirect/IndirectFitPropertyBrowser.h
@@ -71,6 +71,7 @@ public:
   void
   updateParameterEstimationData(DataForParameterEstimationCollection &&data);
   void setBackgroundA0(double value);
+  void setHiddenProperties(std::vector<std::string>);
 
 public slots:
   void fit();

--- a/qt/scientific_interfaces/Indirect/IndirectFitPropertyBrowser.h
+++ b/qt/scientific_interfaces/Indirect/IndirectFitPropertyBrowser.h
@@ -51,6 +51,7 @@ public:
   int getPeakRadius() const;
   std::string costFunction() const;
   bool convolveMembers() const;
+  bool outputCompositeMembers() const;
   std::string fitEvaluationType() const;
   std::string fitType() const;
   bool ignoreInvalidData() const;

--- a/qt/scientific_interfaces/Indirect/IqtFit.cpp
+++ b/qt/scientific_interfaces/Indirect/IqtFit.cpp
@@ -27,7 +27,11 @@ using namespace Mantid::API;
 
 namespace {
 Mantid::Kernel::Logger g_log("IqtFit");
-}
+std::vector<std::string> IQTFIT_HIDDEN_PROPS = std::vector<std::string>(
+    {"CreateOutput", "LogValue", "PassWSIndexToFunction", "ConvolveMembers",
+     "OutputCompositeMembers", "OutputWorkspace", "IgnoreInvalidData", "Output",
+     "PeakRadius", "PlotParameter"});
+} // namespace
 
 namespace MantidQt {
 namespace CustomInterfaces {
@@ -47,6 +51,8 @@ IqtFit::IqtFit(QWidget *parent)
   m_uiForm->dockArea->m_fitPropertyBrowser->setFunctionTemplateBrowser(
       templateBrowser);
   setFitPropertyBrowser(m_uiForm->dockArea->m_fitPropertyBrowser);
+  m_uiForm->dockArea->m_fitPropertyBrowser->setHiddenProperties(
+      IQTFIT_HIDDEN_PROPS);
 
   setEditResultVisible(true);
 }

--- a/qt/scientific_interfaces/Indirect/JumpFit.cpp
+++ b/qt/scientific_interfaces/Indirect/JumpFit.cpp
@@ -30,6 +30,11 @@ namespace MantidQt {
 namespace CustomInterfaces {
 namespace IDA {
 
+std::vector<std::string> FQFIT_HIDDEN_PROPS = std::vector<std::string>(
+    {"CreateOutput", "LogValue", "PassWSIndexToFunction", "ConvolveMembers",
+     "OutputCompositeMembers", "OutputWorkspace", "IgnoreInvalidData", "Output",
+     "PeakRadius", "PlotParameter"});
+
 JumpFit::JumpFit(QWidget *parent)
     : IndirectFitAnalysisTab(new JumpFitModel, parent),
       m_uiForm(new Ui::IndirectFitTab) {
@@ -51,6 +56,8 @@ JumpFit::JumpFit(QWidget *parent)
   m_uiForm->dockArea->m_fitPropertyBrowser->setFunctionTemplateBrowser(
       templateBrowser);
   setFitPropertyBrowser(m_uiForm->dockArea->m_fitPropertyBrowser);
+  m_uiForm->dockArea->m_fitPropertyBrowser->setHiddenProperties(
+      FQFIT_HIDDEN_PROPS);
 
   setEditResultVisible(false);
 }

--- a/qt/scientific_interfaces/Indirect/MSDFit.cpp
+++ b/qt/scientific_interfaces/Indirect/MSDFit.cpp
@@ -22,7 +22,11 @@ using namespace Mantid::API;
 
 namespace {
 Mantid::Kernel::Logger g_log("MSDFit");
-}
+std::vector<std::string> MSDFIT_HIDDEN_PROPS = std::vector<std::string>(
+    {"CreateOutput", "LogValue", "PassWSIndexToFunction", "ConvolveMembers",
+     "OutputCompositeMembers", "OutputWorkspace", "IgnoreInvalidData", "Output",
+     "PeakRadius", "PlotParameter"});
+} // namespace
 
 namespace MantidQt {
 namespace CustomInterfaces {
@@ -52,6 +56,8 @@ MSDFit::MSDFit(QWidget *parent)
   m_uiForm->dockArea->m_fitPropertyBrowser->setFunctionTemplateBrowser(
       templateBrowser);
   setFitPropertyBrowser(m_uiForm->dockArea->m_fitPropertyBrowser);
+  m_uiForm->dockArea->m_fitPropertyBrowser->setHiddenProperties(
+      MSDFIT_HIDDEN_PROPS);
 
   setEditResultVisible(false);
   respondToFunctionChanged();


### PR DESCRIPTION
**Description of work.**

This adds the OutputCompositeMembers and the Convolve Members options to the ConvFit tab in IndirectDataAnalysis. 

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

**To test:**
  * Perform a fit with both options (Convolve members overwrites OutputCompositeMembers). In the output composite members case you output workspace should contain both the raw data, calculated fit, the differance between them and the individual components of the composite function which makes up the fit function. If Convolve members is selected the output should instead contain the individual components of the fit convoluted with the resolution.
  * Data to test can be found in #26631

<!-- Instructions for testing. -->

Fixes #28721  <!-- and fix #xxxx or close #xxxx xor resolves #xxxx -->
<!-- alternative
*There is no associated issue.*
-->

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
-->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
