### PR TITLE
Fixed muon analysis rounding

### DIFF
--- a/docs/source/release/v5.1.0/muon.rst
+++ b/docs/source/release/v5.1.0/muon.rst
@@ -30,6 +30,7 @@ New Features
 - Addition of background correction algorithm (PSIBackgroundCorrection) to remove the background present in
   PSI bin data loaded using LoadPSIMuonBin.
 - Addition of a LoadMuonNexusV2 algorithm to load the new Muon V2 files, see :ref:`LoadMuonNexusV2 <algm-LoadMuonNexusV2>`.
+- Updated rounding for time zero and first good data to be 3 decimal places.
 
 Improvements
 -------------

--- a/scripts/Muon/GUI/Common/utilities/load_utils.py
+++ b/scripts/Muon/GUI/Common/utilities/load_utils.py
@@ -218,7 +218,8 @@ def load_workspace_from_filename(filename,
         for table in deadtime_tables[1:]:
             DeleteWorkspace(Workspace=table)
 
-        load_result["FirstGoodData"] = round(load_result["FirstGoodData"] - load_result['TimeZero'], 2)
+        load_result["FirstGoodData"] = round(load_result["FirstGoodData"] - load_result['TimeZero'], 3)
+        print("hiii", )
         UnGroupWorkspace(load_result["DeadTimeTable"])
         load_result["DeadTimeTable"] = None
         UnGroupWorkspace(workspace.name())
@@ -231,7 +232,7 @@ def load_workspace_from_filename(filename,
 
         load_result["DataDeadTimeTable"] = load_result["DeadTimeTable"]
         load_result["DeadTimeTable"] = None
-        load_result["FirstGoodData"] = round(load_result["FirstGoodData"] - load_result['TimeZero'], 2)
+        load_result["FirstGoodData"] = round(load_result["FirstGoodData"] - load_result['TimeZero'], 3)
 
     return load_result, run, filename, psi_data
 

--- a/scripts/test/Muon/muon_context_test.py
+++ b/scripts/test/Muon/muon_context_test.py
@@ -162,7 +162,7 @@ class MuonContextTest(unittest.TestCase):
 
         first_good_data = self.context.first_good_data([19489])
 
-        self.assertEqual(first_good_data, 0.11)
+        self.assertEqual(first_good_data, 0.113)
 
     def test_first_good_data_returns_correctly_when_manually_specified_used(self):
         self.gui_context.update({'FirstGoodDataFromFile': False, 'FirstGoodData': 5})

--- a/scripts/test/Muon/utilities/load_utils_test.py
+++ b/scripts/test/Muon/utilities/load_utils_test.py
@@ -71,7 +71,7 @@ class MuonFileUtilsTest(unittest.TestCase):
         load_result, run, filename, _ = utils.load_workspace_from_filename(filename)
 
         self.assertEqual(load_result['DeadTimeTable'], None)
-        self.assertEqual(load_result['FirstGoodData'], 0.11)
+        self.assertEqual(load_result['FirstGoodData'], 0.106)
         self.assertEqual(load_result['MainFieldDirection'], 'Transverse')
         self.assertAlmostEqual(load_result['TimeZero'], 0.55000, 5)
         self.assertEqual(run, 22725)


### PR DESCRIPTION
The muon gUI was rounding the first good data and time zero to 2 dp, but it was displaying 3 dp. We have made the rounding 3 dp. 

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

**To test:**

<!-- Instructions for testing. -->
Open muon analysis
Load PSI Dolly 1530
The first good data should be 0.006 and not 0.010.

Fixes #28747 . <!-- and fix #xxxx or close #xxxx xor resolves #xxxx -->
<!-- alternative

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
