### PR TITLE
Added option to take UB from workspace integrate ellipsoids

### DIFF
--- a/Framework/MDAlgorithms/src/IntegrateEllipsoids.cpp
+++ b/Framework/MDAlgorithms/src/IntegrateEllipsoids.cpp
@@ -367,7 +367,7 @@ void IntegrateEllipsoids::exec() {
   bool getUB = getProperty("GetUBFromPeaksWorkspace");
 
   // getUB only valid if peak workspace has a UB matrix
-  if (!(in_peak_ws->sample().hasOrientedLattice()) & getUB) {
+  if (!(in_peak_ws->sample().hasOrientedLattice()) && getUB) {
     throw std::runtime_error("Peaks workspace needs a oriented lattice for "
                              "GetUBFromPeaksWorkspace is true");
   }
@@ -439,8 +439,7 @@ void IntegrateEllipsoids::exec() {
     auto goniometerMatrix = peak_ws->run().getGoniometerMatrix();
     // get UB etc. and rotate by goniometer matrix
     UB = goniometerMatrix * lattice.getUB();
-    modUB = goniometerMatrix *
-            lattice.getModUB(); // what happedn when this is empty
+    modUB = goniometerMatrix * lattice.getModUB();
     modHKL = lattice.getModHKL();
     maxOrder = lattice.getMaxOrder();
     CT = lattice.getCrossTerm();

--- a/Framework/MDAlgorithms/test/IntegrateEllipsoidsTest.h
+++ b/Framework/MDAlgorithms/test/IntegrateEllipsoidsTest.h
@@ -262,7 +262,8 @@ public:
 
   void test_GetUBFromPeaksWorkspace() {
 
-    // integrate peak table without getting UB from lattice
+    // integrate peak table having altered the UB
+    // should find a new UB and overwrite it with the found UB (same as initial)
     OrientedLattice lattice = m_peaksWS->mutableSample().getOrientedLattice();
     auto initialUB = lattice.getUB();
     // make tmp UB identity
@@ -317,6 +318,18 @@ public:
     const auto &peak = integratedPeaksWS->getPeak(0);
     const auto &peak_getUB = integratedPeaksWS_getUB->getPeak(0);
     TS_ASSERT_DELTA(peak.getIntensity(), peak_getUB.getIntensity(), 1e-15);
+
+    // clear the UB and re-run (should throw error)
+    tmp_peaksWS->mutableSample().clearOrientedLattice();
+    IntegrateEllipsoids alg_noUB;
+    alg_noUB.setChild(true);
+    alg_noUB.setRethrows(true);
+    alg_noUB.initialize();
+    alg_noUB.setProperty("InputWorkspace", m_eventWS);
+    alg_noUB.setProperty("PeaksWorkspace", tmp_peaksWS);
+    alg_noUB.setProperty("GetUBFromPeaksWorkspace", true);
+    alg_noUB.setPropertyValue("OutputWorkspace", "dummy");
+    TS_ASSERT_THROWS(alg_noUB.execute(), std::runtime_error);
   }
 
   void test_execution_events() {

--- a/Framework/MDAlgorithms/test/IntegrateEllipsoidsTest.h
+++ b/Framework/MDAlgorithms/test/IntegrateEllipsoidsTest.h
@@ -5,6 +5,7 @@
 //   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
 // SPDX - License - Identifier: GPL - 3.0 +
 #include "MantidAPI/AlgorithmManager.h"
+#include "MantidAPI/AnalysisDataService.h"
 #include "MantidAPI/FrameworkManager.h"
 #include "MantidAPI/NumericAxis.h"
 #include "MantidAPI/Sample.h"
@@ -20,6 +21,7 @@
 #include <memory>
 
 using namespace Mantid;
+using namespace Mantid::API;
 using namespace Mantid::MDAlgorithms;
 using namespace Mantid::Kernel;
 using namespace Mantid::Geometry;
@@ -256,6 +258,65 @@ public:
     TS_ASSERT_THROWS(
         alg.setProperty("InputWorkspace", inputWorkspaceNoInstrument),
         std::invalid_argument &);
+  }
+
+  void test_GetUBFromPeaksWorkspace() {
+
+    // integrate peak table without getting UB from lattice
+    OrientedLattice lattice = m_peaksWS->mutableSample().getOrientedLattice();
+    auto initialUB = lattice.getUB();
+    // make tmp UB identity
+    Matrix<double> tmpUB(initialUB.numRows(), initialUB.numRows(), true);
+    lattice.setUB(tmpUB);
+    // run algorithm without taking UB from ws
+    IntegrateEllipsoids alg;
+    alg.setChild(true);
+    alg.setRethrows(true);
+    alg.initialize();
+    alg.setProperty("InputWorkspace", m_eventWS);
+    alg.setProperty("PeaksWorkspace", m_peaksWS);
+    alg.setProperty("GetUBFromPeaksWorkspace", false);
+    alg.setPropertyValue("OutputWorkspace", "dummy");
+    alg.execute();
+    PeaksWorkspace_sptr integratedPeaksWS = alg.getProperty("OutputWorkspace");
+    // the UB of peak_ws should be overwritten with initial UB
+    lattice = m_peaksWS->mutableSample().getOrientedLattice();
+    auto UB = lattice.getUB();
+    TS_ASSERT(UB.equals(initialUB, 1e-15));
+
+    // clone peaks workspace to copy instrument and sample etc.
+    const auto &algManager = AlgorithmManager::Instance();
+    auto cloneWorkspace = algManager.createUnmanaged("CloneWorkspace");
+    cloneWorkspace->setChild(true);
+    cloneWorkspace->initialize();
+    cloneWorkspace->setProperty("InputWorkspace", m_peaksWS);
+    cloneWorkspace->setPropertyValue("OutputWorkspace", "tmp_peaksWS");
+    cloneWorkspace->execute();
+    Workspace_sptr tmp = cloneWorkspace->getProperty("OutputWorkspace");
+    auto tmp_peaksWS = std::dynamic_pointer_cast<PeaksWorkspace>(tmp);
+    // remove all but first peak
+    std::vector<int> irem(tmp_peaksWS->getNumberPeaks() - 1);
+    std::iota(irem.begin(), irem.end(), 1); // [1:n]
+    tmp_peaksWS->removePeaks(irem);
+    // run algortihm but with getUB true
+    IntegrateEllipsoids alg_getUB;
+    alg_getUB.setChild(true);
+    alg_getUB.setRethrows(true);
+    alg_getUB.initialize();
+    alg_getUB.setProperty("InputWorkspace", m_eventWS);
+    alg_getUB.setProperty("PeaksWorkspace", tmp_peaksWS);
+    alg_getUB.setProperty("GetUBFromPeaksWorkspace", true);
+    alg_getUB.setPropertyValue("OutputWorkspace", "dummy");
+    // check execution doesn't throw error
+    // no minimum num peaks as don't construct new UB
+    TS_ASSERT_THROWS_NOTHING(alg_getUB.execute());
+    // check that integrated intensity is same
+    // i.e. integrating same area in Q space
+    PeaksWorkspace_sptr integratedPeaksWS_getUB =
+        alg_getUB.getProperty("OutputWorkspace");
+    const auto &peak = integratedPeaksWS->getPeak(0);
+    const auto &peak_getUB = integratedPeaksWS_getUB->getPeak(0);
+    TS_ASSERT_DELTA(peak.getIntensity(), peak_getUB.getIntensity(), 1e-15);
   }
 
   void test_execution_events() {


### PR DESCRIPTION
**Description of work.**
IntegrateEllipsoids can now take a UB from the peak workspace. This allows users to integrate fewer peaks than are required to make a UB from scratch, and allows for use of a better/more realistic UB that has been generated by the user with constraints.

**To test:**
(1) Run this script - you should get two integrated workspaces. The peaks_noUB_int shold have an intensity that matches the  first peak in peaks__int

```
from mantid.simpleapi import *

SXD23767 = Load(Filename='SXD23767')
LoadIsawUB(InputWorkspace='SXD23767', Filename='SXD23767_UB.mat')
peaks = PredictPeaks(InputWorkspace='SXD23767')
# remove some peaks for speed
DeleteTableRows(TableWorkspace='peaks', Rows='7-35')
IntegrateEllipsoids(InputWorkspace='SXD23767', PeaksWorkspace='peaks', SpecifySize=True, PeakSize=0.35, RegionRadius=0.5,
    BackgroundInnerSize=0.35, BackgroundOuterSize=0.5, getUBFromPeaksWorkspace=False,
    OutputWorkspace='peaks_int', UseOnePercentBackgroundCorrection=False)
    
# make new peaks worksapce with no orietned lattice
peaks_noUB = CreatePeaksWorkspace(InstrumentWorkspace='SXD23767', NumberOfPeaks=0)
# add one peak (not enough to make UB from scratch)
peaks_noUB.addPeak(peaks.getPeak(0))
IntegrateEllipsoids(InputWorkspace='SXD23767', PeaksWorkspace='peaks', SpecifySize=True, PeakSize=0.35, RegionRadius=0.5,
    BackgroundInnerSize=0.35, BackgroundOuterSize=0.5, getUBFromPeaksWorkspace=True,
    OutputWorkspace='peaks_noUB_int', UseOnePercentBackgroundCorrection=False)

```

(2) Try integrating the peaks_noUB with the argument getUBFromPeaksWorkspace=False.
This should give an error saying more peaks are required to make a UB.

Fixes #27601 

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
-->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
