### PR TITLE
Handle errors from error bar artists when looking for sample logs

### DIFF
--- a/qt/applications/workbench/workbench/plotting/toolbar.py
+++ b/qt/applications/workbench/workbench/plotting/toolbar.py
@@ -200,9 +200,13 @@ class WorkbenchNavigationToolbar(NavigationToolbar2QT):
         # if any of the lines are a sample log plot disable fitting
         for ax in fig.get_axes():
             for artist in ax.get_lines():
-                if ax.get_artists_sample_log_plot_details(artist) is not None:
-                    self._set_fit_enabled(False)
-                    break
+                try:
+                    if ax.get_artists_sample_log_plot_details(artist) is not None:
+                        self._set_fit_enabled(False)
+                        break
+                except ValueError:
+                    #The artist is not tracked - ignore this one and check the rest
+                    continue
 
         # For plot-to-script button to show, every axis must be a MantidAxes with lines in it
         # Plot-to-script currently doesn't work with waterfall plots so the button is hidden for that plot type.


### PR DESCRIPTION
**Description of work.**
A change that was merged to master last week threw an error when trying to plot anything with errors.

This catches the error which is safe to ignore in this case.  The code is looking for sample log based plot lines, but this is thrown from an error bar artist, which we do not track and threw an error.  You can't have sample log errors, so we can just catch and ignore this exception.

**To test:**

1. In workbench
1. Load any data
1. Do a plot with errors
1. If the plot appears without an unhandled exception we are all good.

Fixes #28751

*This does not require release notes* because it was introduced in this release


---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
