### PR TITLE
Add missing includes for stdexcept needed for Visual Studio 16.6.0

### DIFF
--- a/Framework/API/inc/MantidAPI/Expression.h
+++ b/Framework/API/inc/MantidAPI/Expression.h
@@ -13,6 +13,7 @@
 #endif
 
 #include <map>
+#include <stdexcept>
 #include <string>
 #include <unordered_set>
 #include <vector>

--- a/qt/icons/src/CharIconPainter.cpp
+++ b/qt/icons/src/CharIconPainter.cpp
@@ -8,6 +8,7 @@
 #include "MantidQtIcons/Icon.h"
 #include <QVariant>
 #include <cmath>
+#include <stdexcept>
 
 namespace MantidQt {
 namespace Icons {

--- a/qt/icons/src/Icon.cpp
+++ b/qt/icons/src/Icon.cpp
@@ -16,6 +16,7 @@
 #include <QJsonDocument>
 #include <QJsonObject>
 #endif
+#include <stdexcept>
 
 namespace {
 MantidQt::Icons::IconicFont &iconFontInstance() {

--- a/qt/widgets/common/src/QtJSONUtils.cpp
+++ b/qt/widgets/common/src/QtJSONUtils.cpp
@@ -16,6 +16,7 @@
 #include <QJsonObject>
 #include <QTextStream>
 #endif
+#include <stdexcept>
 
 namespace {
 #if QT_VERSION < QT_VERSION_CHECK(5, 0, 0)


### PR DESCRIPTION
**Description of work.**
After updating to Visual Studio 16.6.0 there are a few files that need the include for stdexcept adding.

**To test:**
1. Simple code review


*There is no associated issue.*



*This does not require release notes* because it has no impact on users whatsoever


---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
