### PR TITLE
Make x-axis tick labels horizontal on colorfill plots

### DIFF
--- a/docs/source/release/v5.1.0/mantidworkbench.rst
+++ b/docs/source/release/v5.1.0/mantidworkbench.rst
@@ -39,7 +39,8 @@ Improvements
 
 - Surface plots no longer spill over the axes when their limits are reduced.
 - The instrument view now ignores non-finite (infinity and NaN) values and should now display workspaces containing those values.
-- The gray and plasma colormaps have been added to the instrument view. 
+- The gray and plasma colormaps have been added to the instrument view.
+- The x-axis tick labels on colorfill plots are now horizontal.
 
 Bugfixes
 ########

--- a/qt/python/mantidqt/plotting/functions.py
+++ b/qt/python/mantidqt/plotting/functions.py
@@ -240,8 +240,6 @@ def pcolormesh_on_axis(ax, ws):
         pcm = ax.imshow(ws, cmap=DEFAULT_CMAP, aspect='auto', origin='lower')
     else:
         pcm = ax.pcolormesh(ws, cmap=DEFAULT_CMAP)
-    for lbl in ax.get_xticklabels():
-        lbl.set_rotation(45)
 
     return pcm
 


### PR DESCRIPTION
**Description of work.**
This PR makes the x-axis tick labels on colorfill plots horizontal when they were previously rotated.

**To test:**
Make a colorfill plot.
Check that the tick labels on the x-axis are oriented correctly.

Fixes #28601 

Not sure if release notes are needed as this is a very small change?

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
