### PR TITLE
Add copy to clipboard button to the workbench graphs

### DIFF
--- a/Framework/API/inc/MantidAPI/Expression.h
+++ b/Framework/API/inc/MantidAPI/Expression.h
@@ -13,6 +13,7 @@
 #endif
 
 #include <map>
+#include <stdexcept>
 #include <string>
 #include <unordered_set>
 #include <vector>

--- a/docs/source/release/v5.1.0/mantidworkbench.rst
+++ b/docs/source/release/v5.1.0/mantidworkbench.rst
@@ -17,6 +17,7 @@ Improvements
    :align: right
 
 - The plot selection dialog now correctly shows the full range of valid spectra to plot, not just the min to max range.
+- We have added a Copy to Clipboard button to the plot window.
 - Tile plots are now reloaded correctly by project recovery.
 - When you stop a script running in workbench it will now automatically attempt to cancel the algorithm the script is running, rather than wait for the current algorthm to end.
   This is similar to what Mantidplot does, and should result in the script stopping much sooner.

--- a/qt/applications/workbench/workbench/plotting/toolbar.py
+++ b/qt/applications/workbench/workbench/plotting/toolbar.py
@@ -25,6 +25,7 @@ class WorkbenchNavigationToolbar(NavigationToolbar2QT):
     sig_active_triggered = QtCore.Signal()
     sig_hold_triggered = QtCore.Signal()
     sig_toggle_fit_triggered = QtCore.Signal()
+    sig_copy_to_clipboard_triggered = QtCore.Signal()
     sig_plot_options_triggered = QtCore.Signal()
     sig_generate_plot_script_file_triggered = QtCore.Signal()
     sig_generate_plot_script_clipboard_triggered = QtCore.Signal()
@@ -43,6 +44,7 @@ class WorkbenchNavigationToolbar(NavigationToolbar2QT):
         ('Zoom', 'Zoom \n In: L-click+drag \n Out: R-click+drag', 'mdi.magnify', 'zoom', False),
         (None, None, None, None, None),
         ('Grid', 'Grids on/off', 'mdi.grid', 'toggle_grid', False),
+        ('Copy', 'Copy image to clipboard', 'mdi.content-copy', 'copy_to_clipboard', None),
         ('Save', 'Save image file', 'mdi.content-save', 'save_figure', None),
         ('Print', 'Print image', 'mdi.printer', 'print_figure', None),
         (None, None, None, None, None),
@@ -102,6 +104,9 @@ class WorkbenchNavigationToolbar(NavigationToolbar2QT):
         # Adjust icon size or they are too small in PyQt5 by default
         dpi_ratio = QtWidgets.QApplication.instance().desktop().physicalDpiX() / 100
         self.setIconSize(QtCore.QSize(24 * dpi_ratio, 24 * dpi_ratio))
+
+    def copy_to_clipboard(self):
+        self.sig_copy_to_clipboard_triggered.emit()
 
     def launch_plot_options(self):
         self.sig_plot_options_triggered.emit()

--- a/qt/icons/src/CharIconPainter.cpp
+++ b/qt/icons/src/CharIconPainter.cpp
@@ -8,6 +8,7 @@
 #include "MantidQtIcons/Icon.h"
 #include <QVariant>
 #include <cmath>
+#include <stdexcept>
 
 namespace MantidQt {
 namespace Icons {

--- a/qt/icons/src/Icon.cpp
+++ b/qt/icons/src/Icon.cpp
@@ -16,6 +16,7 @@
 #include <QJsonDocument>
 #include <QJsonObject>
 #endif
+#include <stdexcept>
 
 namespace {
 MantidQt::Icons::IconicFont &iconFontInstance() {

--- a/qt/widgets/common/src/QtJSONUtils.cpp
+++ b/qt/widgets/common/src/QtJSONUtils.cpp
@@ -16,6 +16,7 @@
 #include <QJsonObject>
 #include <QTextStream>
 #endif
+#include <stdexcept>
 
 namespace {
 #if QT_VERSION < QT_VERSION_CHECK(5, 0, 0)


### PR DESCRIPTION
**Description of work.**
See the title.

**Note**: This does not add (ctrl+c) keyboard shortcut support, none of our custom buttons currently have that.
Apparently there is a way, but you have to monkey patch plt.figure, if we were to do that it should be in its own PR as the risk is higher.
https://stackoverflow.com/questions/31607458/how-to-add-clipboard-support-to-matplotlib-figures

**To test:**

1. in workbench load some data and plot some graphs
2. In the graph window plot the copy to clipboard button (the tooltip should help you find it)
3. Paste into word or another app so you can check the result
4. do this with a number of different graph types including colour fill and 3D.

Fixes #28545


---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
