### PR TITLE
Check Data Directories on Request, Not Startup

### DIFF
--- a/Framework/DataHandling/test/LoadILLDiffractionTest.h
+++ b/Framework/DataHandling/test/LoadILLDiffractionTest.h
@@ -31,10 +31,12 @@ public:
   }
   static void destroySuite(LoadILLDiffractionTest *suite) { delete suite; }
 
-  void setUp() override {
+  LoadILLDiffractionTest() {
     ConfigService::Instance().appendDataSearchSubDir("ILL/D20/");
     ConfigService::Instance().appendDataSearchSubDir("ILL/D2B/");
+  }
 
+  void setUp() override {
     m_oldFacility = ConfigService::Instance().getFacility().name();
     ConfigService::Instance().setFacility("ILL");
 

--- a/Framework/DataHandling/test/LoadILLSANSTest.h
+++ b/Framework/DataHandling/test/LoadILLSANSTest.h
@@ -37,7 +37,13 @@ public:
   static LoadILLSANSTest *createSuite() { return new LoadILLSANSTest(); }
   static void destroySuite(LoadILLSANSTest *suite) { delete suite; }
 
-  void setUp() override { ConfigService::Instance().setFacility("ILL"); }
+  LoadILLSANSTest() {
+    ConfigService::Instance().appendDataSearchSubDir("ILL/D11/");
+    ConfigService::Instance().appendDataSearchSubDir("ILL/D22/");
+    ConfigService::Instance().appendDataSearchSubDir("ILL/D33/");
+    ConfigService::Instance().appendDataSearchSubDir("ILL/D16/");
+    ConfigService::Instance().setFacility("ILL");
+  }
 
   void tearDown() override { AnalysisDataService::Instance().clear(); }
 

--- a/Framework/DataHandling/test/LoadILLSANSTest.h
+++ b/Framework/DataHandling/test/LoadILLSANSTest.h
@@ -37,13 +37,7 @@ public:
   static LoadILLSANSTest *createSuite() { return new LoadILLSANSTest(); }
   static void destroySuite(LoadILLSANSTest *suite) { delete suite; }
 
-  void setUp() override {
-    ConfigService::Instance().appendDataSearchSubDir("ILL/D11/");
-    ConfigService::Instance().appendDataSearchSubDir("ILL/D22/");
-    ConfigService::Instance().appendDataSearchSubDir("ILL/D33/");
-    ConfigService::Instance().appendDataSearchSubDir("ILL/D16/");
-    ConfigService::Instance().setFacility("ILL");
-  }
+  void setUp() override { ConfigService::Instance().setFacility("ILL"); }
 
   void tearDown() override { AnalysisDataService::Instance().clear(); }
 

--- a/Framework/Kernel/inc/MantidKernel/ConfigService.h
+++ b/Framework/Kernel/inc/MantidKernel/ConfigService.h
@@ -288,15 +288,15 @@ private:
   /// The directory that is considered to be the base directory
   std::string m_strBaseDir;
   /// The configuration properties in string format
-  std::string m_PropertyString;
+  std::string m_propertyString;
   /// The filename of the Mantid properties file
   const std::string m_properties_file_name;
   /// The filename of the Mantid user properties file
   const std::string m_user_properties_file_name;
   /// Store a list of data search paths
-  std::vector<std::string> m_DataSearchDirs;
+  std::vector<std::string> m_dataSearchDirs;
   /// Store a list of instrument directory paths
-  std::vector<std::string> m_InstrumentDirs;
+  std::vector<std::string> m_instrumentDirs;
 
   /// The list of available facilities
   std::vector<FacilityInfo *> m_facilities;

--- a/Framework/Kernel/inc/MantidKernel/ConfigService.h
+++ b/Framework/Kernel/inc/MantidKernel/ConfigService.h
@@ -119,7 +119,7 @@ public:
   void saveConfig(const std::string &filename) const;
   /// Searches for a configuration property
   std::string getString(const std::string &keyName,
-                        bool use_cache = true) const;
+                        bool pathAbsolute = true) const;
   /// Searches for a key in the configuration property
   std::vector<std::string> getKeys(const std::string &keyName) const;
   /// Returns a list of all full keys in the config
@@ -255,9 +255,6 @@ private:
 
   /// Writes out a fresh user properties file
   void createUserPropertiesFile() const;
-  /// Convert any relative paths to absolute ones and store them locally so that
-  /// if the working directory is altered the paths will not be affected
-  void convertRelativeToAbsolute();
   /// Make a relative path or a list of relative paths into an absolute one.
   std::string makeAbsolute(const std::string &dir,
                            const std::string &key) const;
@@ -288,12 +285,6 @@ private:
   /// A set of property keys that have been changed
   mutable std::set<std::string> m_changed_keys;
 
-  /// A map storing string/key pairs where the string denotes a path
-  /// that could be relative in the user properties file
-  /// The boolean indicates whether the path needs to exist or not
-  std::map<std::string, bool> m_ConfigPaths;
-  /// Local storage for the relative path key/values that have been changed
-  std::map<std::string, std::string> m_AbsolutePaths;
   /// The directory that is considered to be the base directory
   std::string m_strBaseDir;
   /// The configuration properties in string format

--- a/Framework/Kernel/inc/MantidKernel/ConfigService.h
+++ b/Framework/Kernel/inc/MantidKernel/ConfigService.h
@@ -192,8 +192,6 @@ public:
   void appendDataSearchDir(const std::string &path);
   /// Appends subdirectory to each of the specified data search directories
   void appendDataSearchSubDir(const std::string &subdir);
-  /// Get the list of user search paths
-  const std::vector<std::string> &getUserSearchDirs() const;
   /// Sets instrument directories
   void setInstrumentDirectories(const std::vector<std::string> &directories);
   /// Get instrument search directories
@@ -265,8 +263,6 @@ private:
                            const std::string &key) const;
   /// Create the storage of the data search directories
   void cacheDataSearchPaths();
-  /// Create the storage of the user search directories
-  void cacheUserSearchPaths();
   /// Create the storage of the instrument directories
   void cacheInstrumentPaths();
   /// Returns true if the path is in the data search list
@@ -308,8 +304,6 @@ private:
   const std::string m_user_properties_file_name;
   /// Store a list of data search paths
   std::vector<std::string> m_DataSearchDirs;
-  /// Store a list of user search paths
-  std::vector<std::string> m_UserSearchDirs;
   /// Store a list of instrument directory paths
   std::vector<std::string> m_InstrumentDirs;
 

--- a/Framework/Kernel/src/ConfigService.cpp
+++ b/Framework/Kernel/src/ConfigService.cpp
@@ -84,6 +84,15 @@ namespace { // anonymous namespace for some utility functions
 /// static Logger object
 Logger g_log("ConfigService");
 
+/// Identifier for a key that will contain a path. This is defined
+/// so as to catch both the word directory and directories in a key name.
+/// Any keys found containing this string are assumed to contain paths
+/// and if their values are relative paths then when fetched they
+/// are transformed to absolute paths using the application directory
+/// as a base. This is necessary to avoid problems with the interpretation of
+/// a relative path if current directory s changed at runtime.
+std::string DIRECTORY_KEY_MAGIC{"director"};
+
 /**
  * Split the supplied string on semicolons.
  *
@@ -118,8 +127,8 @@ std::vector<std::string> splitPath(const std::string &path) {
 /// Private constructor for singleton class
 ConfigServiceImpl::ConfigServiceImpl()
     : m_pConf(nullptr), m_pSysConfig(nullptr), m_changed_keys(),
-      m_ConfigPaths(), m_AbsolutePaths(), m_strBaseDir(""),
-      m_PropertyString(""), m_properties_file_name("Mantid.properties"),
+      m_strBaseDir(""), m_PropertyString(""),
+      m_properties_file_name("Mantid.properties"),
 #ifdef MPI_BUILD
       // Use a different user properties file for an mpi-enabled build to avoid
       // confusion if both are used on the same file system
@@ -139,25 +148,6 @@ ConfigServiceImpl::ConfigServiceImpl()
       new Poco::Instantiator<Poco::StdoutChannel, Poco::Channel>);
 
   setBaseDirectory();
-
-  // Fill the list of possible relative path keys that may require conversion to
-  // absolute paths
-  m_ConfigPaths.emplace("mantidqt.python_interfaces_directory", true);
-  m_ConfigPaths.emplace("framework.plugins.directory", true);
-  m_ConfigPaths.emplace("pvplugins.directory", false);
-  m_ConfigPaths.emplace("mantidqt.plugins.directory", false);
-  m_ConfigPaths.emplace("instrumentDefinition.directory", true);
-  m_ConfigPaths.emplace("instrumentDefinition.vtpDirectory", true);
-  m_ConfigPaths.emplace("groupingFiles.directory", true);
-  m_ConfigPaths.emplace("maskFiles.directory", true);
-  m_ConfigPaths.emplace("colormaps.directory", true);
-  m_ConfigPaths.emplace("requiredpythonscript.directories", true);
-  m_ConfigPaths.emplace("pythonscripts.directory", true);
-  m_ConfigPaths.emplace("pythonscripts.directories", true);
-  m_ConfigPaths.emplace("python.plugins.directories", true);
-  m_ConfigPaths.emplace("user.python.plugins.directories", true);
-  m_ConfigPaths.emplace("datasearch.directories", true);
-  m_ConfigPaths.emplace("icatDownload.directory", true);
 
   // attempt to load the default properties file that resides in the directory
   // of the executable
@@ -433,30 +423,6 @@ void ConfigServiceImpl::configureLogging() {
 }
 
 /**
- * Searches the stored list for keys that have been loaded from the config file
- * and may contain
- * relative paths. Any it find are converted to absolute paths and stored
- * separately
- */
-void ConfigServiceImpl::convertRelativeToAbsolute() {
-  if (m_ConfigPaths.empty())
-    return;
-
-  m_AbsolutePaths.clear();
-  std::map<std::string, bool>::const_iterator send = m_ConfigPaths.end();
-  for (std::map<std::string, bool>::const_iterator sitr = m_ConfigPaths.begin();
-       sitr != send; ++sitr) {
-    std::string key = sitr->first;
-    if (!m_pConf->hasProperty(key))
-      continue;
-
-    std::string value(m_pConf->getString(key));
-    value = makeAbsolute(value, key);
-    m_AbsolutePaths.emplace(key, value);
-  }
-}
-
-/**
  * Make a relative path or a list of relative paths into an absolute one.
  * @param dir :: The directory to convert
  * @param key :: The key variable this relates to
@@ -513,25 +479,6 @@ std::string ConfigServiceImpl::makeAbsolute(const std::string &dir,
   }
   converted = Poco::Path(converted).makeDirectory().toString();
 
-  // C++ doesn't have a const version of operator[] for maps so I can't call
-  // that here
-  auto it = m_ConfigPaths.find(key);
-  bool required = false;
-  if (it != m_ConfigPaths.end()) {
-    required = it->second;
-  }
-  try {
-    if (required && !Poco::File(converted).exists()) {
-      g_log.debug() << "Required properties path \"" << converted
-                    << "\" in the \"" << key << "\" variable does not exist.\n";
-      converted = "";
-    }
-  } catch (Poco::FileException &) {
-    g_log.debug() << "Required properties path \"" << converted
-                  << "\" in the \"" << key << "\" variable does not exist.\n";
-    converted = "";
-  }
-
   // Backward slashes cannot be allowed to go into our properties file
   // Note this is a temporary fix for ticket #2445.
   // Ticket #2460 prompts a review of our path handling in the config service.
@@ -545,7 +492,7 @@ std::string ConfigServiceImpl::makeAbsolute(const std::string &dir,
  * The value of the key should be a semi-colon separated list of directories
  */
 void ConfigServiceImpl::cacheDataSearchPaths() {
-  std::string paths = getString("datasearch.directories");
+  std::string paths = getString("datasearch.directories", true);
   if (paths.empty()) {
     m_DataSearchDirs.clear();
   } else {
@@ -707,9 +654,6 @@ void ConfigServiceImpl::updateConfig(const std::string &filename,
   if (update_caches) {
     // Only configure logging once
     configureLogging();
-    // Ensure that any relative paths given in the configuration file are
-    // relative to the correct directory
-    convertRelativeToAbsolute();
     // Configure search paths into a specially saved store as they will be used
     // frequently
     cacheDataSearchPaths();
@@ -831,21 +775,20 @@ void ConfigServiceImpl::saveConfig(const std::string &filename) const {
  *
  *  @param keyName :: The case sensitive name of the property that you need the
  *value of.
- *  @param use_cache :: If true, the local cache of directory names is queried
- *first.
+ *  @param pathAbsolute :: If true then any key that looks like it contains
+ * a path has this path converted to an absolute path.
  *  @returns The string value of the property, or an empty string if the key
  *cannot be found
  */
 std::string ConfigServiceImpl::getString(const std::string &keyName,
-                                         bool use_cache) const {
-  if (use_cache) {
-    auto mitr = m_AbsolutePaths.find(keyName);
-    if (mitr != m_AbsolutePaths.end()) {
-      return (*mitr).second;
-    }
-  }
+                                         bool pathAbsolute) const {
   if (m_pConf->hasProperty(keyName)) {
-    return m_pConf->getString(keyName);
+    std::string value = m_pConf->getString(keyName);
+    if (pathAbsolute &&
+        keyName.rfind(DIRECTORY_KEY_MAGIC) != std::string::npos) {
+      value = makeAbsolute(value, keyName);
+    }
+    return value;
   }
 
   g_log.debug() << "Unable to find " << keyName << " in the properties file"
@@ -988,12 +931,10 @@ void ConfigServiceImpl::setString(const std::string &key,
   if (value == old)
     return;
 
-  // Ensure we keep a correct full path
-  std::map<std::string, bool>::const_iterator itr = m_ConfigPaths.find(key);
-  if (itr != m_ConfigPaths.end()) {
-    m_AbsolutePaths[key] = makeAbsolute(value, key);
-  }
+  // Update the internal value
+  m_pConf->setString(key, value);
 
+  // Cache things that are accessed frequently
   if (key == "datasearch.directories") {
     cacheDataSearchPaths();
   } else if (key == "instrumentDefinition.directory") {
@@ -1001,8 +942,6 @@ void ConfigServiceImpl::setString(const std::string &key,
   } else if (key == "defaultsave.directory") {
     appendDataSearchDir(value);
   }
-
-  m_pConf->setString(key, value);
 
   m_notificationCenter.postNotification(new ValueChanged(key, value, old));
   m_changed_keys.insert(key);
@@ -1565,6 +1504,7 @@ void ConfigServiceImpl::appendDataSearchDir(const std::string &path) {
   if (!isInDataSearchList(dirPath.toString())) {
     auto newSearchString = Strings::join(std::begin(m_DataSearchDirs),
                                          std::end(m_DataSearchDirs), ";");
+    newSearchString.append(path);
     setString("datasearch.directories", newSearchString);
   }
 }
@@ -1600,7 +1540,7 @@ const std::string ConfigServiceImpl::getInstrumentDirectory() const {
  */
 const std::string ConfigServiceImpl::getVTPFileDirectory() {
   // Determine the search directory for XML instrument definition files (IDFs)
-  std::string directoryName = getString("instrumentDefinition.vtpDirectory");
+  std::string directoryName = getString("instrumentDefinition.vtp.directory");
 
   if (directoryName.empty()) {
     Poco::Path path(getAppDataDir());
@@ -1635,7 +1575,7 @@ void ConfigServiceImpl::cacheInstrumentPaths() {
 #endif
 
   // Determine the search directory for XML instrument definition files (IDFs)
-  std::string directoryName = getString("instrumentDefinition.directory");
+  std::string directoryName = getString("instrumentDefinition.directory", true);
   if (directoryName.empty()) {
     // This is the assumed deployment directory for IDFs, where we need to be
     // relative to the

--- a/Framework/Kernel/src/ConfigService.cpp
+++ b/Framework/Kernel/src/ConfigService.cpp
@@ -1504,7 +1504,7 @@ void ConfigServiceImpl::appendDataSearchDir(const std::string &path) {
   if (!isInDataSearchList(dirPath.toString())) {
     auto newSearchString = Strings::join(std::begin(m_dataSearchDirs),
                                          std::end(m_dataSearchDirs), ";");
-    newSearchString.append(path);
+    newSearchString.append(";" + path);
     setString("datasearch.directories", newSearchString);
   }
 }

--- a/Framework/Kernel/src/ConfigService.cpp
+++ b/Framework/Kernel/src/ConfigService.cpp
@@ -136,7 +136,7 @@ ConfigServiceImpl::ConfigServiceImpl()
 #else
       m_user_properties_file_name("Mantid.user.properties"),
 #endif
-      m_dataSearchDirs(), m_InstrumentDirs(), m_proxyInfo(),
+      m_dataSearchDirs(), m_instrumentDirs(), m_proxyInfo(),
       m_isProxySet(false) {
   // getting at system details
   m_pSysConfig = new Poco::Util::SystemConfiguration();

--- a/Framework/Kernel/src/ConfigService.cpp
+++ b/Framework/Kernel/src/ConfigService.cpp
@@ -127,7 +127,7 @@ std::vector<std::string> splitPath(const std::string &path) {
 /// Private constructor for singleton class
 ConfigServiceImpl::ConfigServiceImpl()
     : m_pConf(nullptr), m_pSysConfig(nullptr), m_changed_keys(),
-      m_strBaseDir(""), m_PropertyString(""),
+      m_strBaseDir(""), m_propertyString(""),
       m_properties_file_name("Mantid.properties"),
 #ifdef MPI_BUILD
       // Use a different user properties file for an mpi-enabled build to avoid
@@ -136,7 +136,7 @@ ConfigServiceImpl::ConfigServiceImpl()
 #else
       m_user_properties_file_name("Mantid.user.properties"),
 #endif
-      m_DataSearchDirs(), m_InstrumentDirs(), m_proxyInfo(),
+      m_dataSearchDirs(), m_InstrumentDirs(), m_proxyInfo(),
       m_isProxySet(false) {
   // getting at system details
   m_pSysConfig = new Poco::Util::SystemConfiguration();
@@ -339,7 +339,7 @@ void ConfigServiceImpl::loadConfig(const std::string &filename,
 
   if (!append) {
     // remove the previous property string
-    m_PropertyString = "";
+    m_propertyString = "";
     m_changed_keys.clear();
   }
 
@@ -362,10 +362,10 @@ void ConfigServiceImpl::loadConfig(const std::string &filename,
     temp = checkForBadConfigOptions(filename, temp);
 
     // store the property string
-    if ((append) && (!m_PropertyString.empty())) {
-      m_PropertyString = m_PropertyString + "\n" + temp;
+    if ((append) && (!m_propertyString.empty())) {
+      m_propertyString = m_propertyString + "\n" + temp;
     } else {
-      m_PropertyString = temp;
+      m_propertyString = temp;
     }
   } catch (std::exception &e) {
     // there was a problem loading the file - it probably is not there
@@ -376,7 +376,7 @@ void ConfigServiceImpl::loadConfig(const std::string &filename,
   }
 
   // use the cached property string to initialise the POCO property file
-  std::istringstream istr(m_PropertyString);
+  std::istringstream istr(m_propertyString);
   m_pConf = new Poco::Util::PropertyFileConfiguration(istr);
 }
 
@@ -494,9 +494,9 @@ std::string ConfigServiceImpl::makeAbsolute(const std::string &dir,
 void ConfigServiceImpl::cacheDataSearchPaths() {
   std::string paths = getString("datasearch.directories", true);
   if (paths.empty()) {
-    m_DataSearchDirs.clear();
+    m_dataSearchDirs.clear();
   } else {
-    m_DataSearchDirs = splitPath(paths);
+    m_dataSearchDirs = splitPath(paths);
   }
 }
 
@@ -514,9 +514,9 @@ bool ConfigServiceImpl::isInDataSearchList(const std::string &path) const {
 
   using std::placeholders::_1;
   auto it =
-      std::find_if(m_DataSearchDirs.cbegin(), m_DataSearchDirs.cend(),
+      std::find_if(m_dataSearchDirs.cbegin(), m_dataSearchDirs.cend(),
                    std::bind(std::equal_to<std::string>(), _1, correctedPath));
-  return (it != m_DataSearchDirs.end());
+  return (it != m_dataSearchDirs.end());
 }
 
 /**
@@ -1425,7 +1425,7 @@ std::string ConfigServiceImpl::getUserPropertiesDir() const {
  * @returns A vector of strings containing the defined search directories
  */
 const std::vector<std::string> &ConfigServiceImpl::getDataSearchDirs() const {
-  return m_DataSearchDirs;
+  return m_dataSearchDirs;
 }
 
 /**
@@ -1467,8 +1467,8 @@ void ConfigServiceImpl::appendDataSearchSubDir(const std::string &subdir) {
     return;
   }
 
-  auto newDataDirs = m_DataSearchDirs;
-  for (const auto &path : m_DataSearchDirs) {
+  auto newDataDirs = m_dataSearchDirs;
+  for (const auto &path : m_dataSearchDirs) {
     Poco::Path newDirPath;
     try {
       newDirPath = Poco::Path(path);
@@ -1502,8 +1502,8 @@ void ConfigServiceImpl::appendDataSearchDir(const std::string &path) {
     return;
   }
   if (!isInDataSearchList(dirPath.toString())) {
-    auto newSearchString = Strings::join(std::begin(m_DataSearchDirs),
-                                         std::end(m_DataSearchDirs), ";");
+    auto newSearchString = Strings::join(std::begin(m_dataSearchDirs),
+                                         std::end(m_dataSearchDirs), ";");
     newSearchString.append(path);
     setString("datasearch.directories", newSearchString);
   }
@@ -1515,7 +1515,7 @@ void ConfigServiceImpl::appendDataSearchDir(const std::string &path) {
  */
 void ConfigServiceImpl::setInstrumentDirectories(
     const std::vector<std::string> &directories) {
-  m_InstrumentDirs = directories;
+  m_instrumentDirs = directories;
 }
 
 /**
@@ -1524,7 +1524,7 @@ void ConfigServiceImpl::setInstrumentDirectories(
  */
 const std::vector<std::string> &
 ConfigServiceImpl::getInstrumentDirectories() const {
-  return m_InstrumentDirs;
+  return m_instrumentDirs;
 }
 
 /**
@@ -1532,7 +1532,7 @@ ConfigServiceImpl::getInstrumentDirectories() const {
  * @returns a last entry of getInstrumentDirectories
  */
 const std::string ConfigServiceImpl::getInstrumentDirectory() const {
-  return m_InstrumentDirs.back();
+  return m_instrumentDirs.back();
 }
 /**
  * Return the search directory for vtp files
@@ -1562,16 +1562,16 @@ const std::string ConfigServiceImpl::getVTPFileDirectory() {
  * - The install directory/instrument
  */
 void ConfigServiceImpl::cacheInstrumentPaths() {
-  m_InstrumentDirs.clear();
+  m_instrumentDirs.clear();
 
   Poco::Path path(getAppDataDir());
   path.makeDirectory();
   path.pushDirectory("instrument");
   const std::string appdatadir = path.toString();
-  addDirectoryifExists(appdatadir, m_InstrumentDirs);
+  addDirectoryifExists(appdatadir, m_instrumentDirs);
 
 #ifndef _WIN32
-  addDirectoryifExists("/etc/mantid/instrument", m_InstrumentDirs);
+  addDirectoryifExists("/etc/mantid/instrument", m_instrumentDirs);
 #endif
 
   // Determine the search directory for XML instrument definition files (IDFs)
@@ -1583,7 +1583,7 @@ void ConfigServiceImpl::cacheInstrumentPaths() {
     directoryName =
         Poco::Path(getPropertiesDir()).resolve("../instrument").toString();
   }
-  addDirectoryifExists(directoryName, m_InstrumentDirs);
+  addDirectoryifExists(directoryName, m_instrumentDirs);
 }
 
 /**

--- a/Framework/Kernel/src/ConfigService.cpp
+++ b/Framework/Kernel/src/ConfigService.cpp
@@ -127,7 +127,7 @@ ConfigServiceImpl::ConfigServiceImpl()
 #else
       m_user_properties_file_name("Mantid.user.properties"),
 #endif
-      m_DataSearchDirs(), m_UserSearchDirs(), m_InstrumentDirs(), m_proxyInfo(),
+      m_DataSearchDirs(), m_InstrumentDirs(), m_proxyInfo(),
       m_isProxySet(false) {
   // getting at system details
   m_pSysConfig = new Poco::Util::SystemConfiguration();
@@ -554,21 +554,6 @@ void ConfigServiceImpl::cacheDataSearchPaths() {
 }
 
 /**
- * Create the store of user search paths from the 'usersearch.directories' key
- * within the Mantid.properties file.
- * The value of the key should be a semi-colon separated list of directories
- */
-void ConfigServiceImpl::cacheUserSearchPaths() {
-  m_UserSearchDirs.clear();
-  std::string paths = getString("usersearch.directories");
-  if (paths.empty()) {
-    m_UserSearchDirs.clear();
-  } else {
-    m_UserSearchDirs = splitPath(paths);
-  }
-}
-
-/**
  *  The path that is passed should be as returned by makeAbsolute() and
  *  this function will return true if that path is in the list
  *  @param path :: the absolute path name to search for
@@ -729,7 +714,6 @@ void ConfigServiceImpl::updateConfig(const std::string &filename,
     // frequently
     cacheDataSearchPaths();
     appendDataSearchDir(getString("defaultsave.directory"));
-    cacheUserSearchPaths();
     cacheInstrumentPaths();
   }
 }
@@ -1012,8 +996,6 @@ void ConfigServiceImpl::setString(const std::string &key,
 
   if (key == "datasearch.directories") {
     cacheDataSearchPaths();
-  } else if (key == "usersearch.directories") {
-    cacheUserSearchPaths();
   } else if (key == "instrumentDefinition.directory") {
     cacheInstrumentPaths();
   } else if (key == "defaultsave.directory") {
@@ -1581,22 +1563,10 @@ void ConfigServiceImpl::appendDataSearchDir(const std::string &path) {
     return;
   }
   if (!isInDataSearchList(dirPath.toString())) {
-    std::string newSearchString;
-    for (const std::string &it : m_DataSearchDirs) {
-      newSearchString.append(it);
-      newSearchString.append(";");
-    }
-    newSearchString.append(path);
+    auto newSearchString = Strings::join(std::begin(m_DataSearchDirs),
+                                         std::end(m_DataSearchDirs), ";");
     setString("datasearch.directories", newSearchString);
   }
-}
-
-/**
- * Return the list of user search paths
- * @returns A vector of strings containing the defined search directories
- */
-const std::vector<std::string> &ConfigServiceImpl::getUserSearchDirs() const {
-  return m_UserSearchDirs;
 }
 
 /**

--- a/Framework/Kernel/test/ConfigServiceTest.h
+++ b/Framework/Kernel/test/ConfigServiceTest.h
@@ -10,7 +10,6 @@
 
 #include "MantidKernel/ConfigService.h"
 #include "MantidKernel/FacilityInfo.h"
-#include "MantidKernel/InstrumentInfo.h"
 #include "MantidKernel/Logger.h"
 #include "MantidKernel/TestChannel.h"
 
@@ -20,11 +19,7 @@
 #include <memory>
 #include <string>
 
-#include <Poco/Environment.h>
-#include <Poco/File.h>
-#include <Poco/Logger.h>
 #include <Poco/NObserver.h>
-#include <Poco/SplitterChannel.h>
 
 using namespace Mantid::Kernel;
 using Mantid::TestChannel;
@@ -230,7 +225,7 @@ public:
                      "OSIRIS");
   }
 
-  void TestSystemValues() {
+  void testSystemValues() {
     // we cannot test the return values here as they will differ based on the
     // environment.
     // therfore we will just check they return a non empty string.
@@ -274,7 +269,7 @@ public:
 #endif
   }
 
-  void TestInstrumentDirectory() {
+  void testInstrumentDirectory() {
 
     auto directories = ConfigService::Instance().getInstrumentDirectories();
     TS_ASSERT_LESS_THAN(1, directories.size());
@@ -307,7 +302,7 @@ public:
     }
   }
 
-  void TestSetInstrumentDirectory() {
+  void testSetInstrumentDirectory() {
 
     auto originalDirectories =
         ConfigService::Instance().getInstrumentDirectories();
@@ -327,13 +322,14 @@ public:
     TS_ASSERT_EQUALS(readDirectories[0], originalDirectories[0]);
   }
 
-  void TestCustomProperty() {
+  void testCustomProperty() {
     std::string countString =
         ConfigService::Instance().getString("projectRecovery.secondsBetween");
     TS_ASSERT_EQUALS(countString, "60");
   }
 
-  void TestCustomPropertyAsValue() {
+  void testCustomPropertyAsValue() {
+    // Mantid.legs is defined in the properties script as 6
     int value = ConfigService::Instance()
                     .getValue<int>("projectRecovery.secondsBetween")
                     .get_value_or(0);
@@ -345,7 +341,7 @@ public:
     TS_ASSERT_EQUALS(dblValue, 60.0);
   }
 
-  void TestMissingProperty() {
+  void testMissingProperty() {
     // Mantid.noses is not defined in the properties script
     std::string noseCountString =
         ConfigService::Instance().getString("mantid.noses");
@@ -360,7 +356,7 @@ public:
     // TS_ASSERT( Poco::Path(path).isAbsolute() );
   }
 
-  void TestAppendProperties() {
+  void testAppendProperties() {
 
     // This should clear out all old properties
     const std::string propfilePath =

--- a/Framework/Kernel/test/ConfigServiceTest.h
+++ b/Framework/Kernel/test/ConfigServiceTest.h
@@ -350,10 +350,32 @@ public:
     TS_ASSERT_EQUALS(noseCountString, "");
   }
 
-  void TestRelativeToAbsolute() {
-    // std::string path =
-    // ConfigService::Instance().getString("defaultsave.directory");
-    // TS_ASSERT( Poco::Path(path).isAbsolute() );
+  void testRelativeToAbsoluteForKeysWithCorrectIdentifier() {
+    auto &cfg = ConfigService::Instance();
+    cfg.setString("mantid.test.directory", "..");
+    cfg.setString("mantid.test.directories", "..");
+
+    TS_ASSERT(Poco::Path(cfg.getString("mantid.test.directory")).isAbsolute());
+    TS_ASSERT(
+        Poco::Path(cfg.getString("mantid.test.directories")).isAbsolute());
+  }
+
+  void testNoRelativeToAbsoluteForKeysWithoutCorrectIdentifier() {
+    auto &cfg = ConfigService::Instance();
+    cfg.setString("mantid.test.direc", "..");
+
+    TS_ASSERT(Poco::Path(cfg.getString("mantid.test.direc")).isRelative());
+  }
+
+  void testNoRelativeToAbsoluteForKeysOnRequest() {
+    auto &cfg = ConfigService::Instance();
+    cfg.setString("mantid.test.directory", "..");
+    cfg.setString("mantid.test.directories", "..");
+
+    TS_ASSERT(
+        Poco::Path(cfg.getString("mantid.test.directory", false)).isRelative());
+    TS_ASSERT(Poco::Path(cfg.getString("mantid.test.directories", false))
+                  .isRelative());
   }
 
   void testAppendProperties() {
@@ -646,8 +668,6 @@ public:
 
     // Returns all *root* keys, i.e. unique keys left of the first period
     std::vector<std::string> keyVector = ConfigService::Instance().getKeys("");
-    // The 4 unique in the file and the ConfigService always sets a
-    // datasearch.directories key on creation
     TS_ASSERT_EQUALS(keyVector.size(), 5);
   }
 

--- a/Framework/Properties/Mantid.properties.template
+++ b/Framework/Properties/Mantid.properties.template
@@ -95,10 +95,6 @@ paraview.ignore = @IGNORE_PARAVIEW@
 # Root of html documentation (kept as unix-style path)
 docs.html.root = @HTML_ROOT@
 
-# A semi-colon(;) separated list of directories to use to search for files other than data
-# Use forward slash / for all paths
-usersearch.directories =
-
 # Setting this to On enables searching the facilitie's archive automatically
 datasearch.searcharchive = Off
 

--- a/Framework/PythonInterface/mantid/kernel/src/Exports/ConfigService.cpp
+++ b/Framework/PythonInterface/mantid/kernel/src/Exports/ConfigService.cpp
@@ -122,11 +122,12 @@ void export_ConfigService() {
                "default.instrument is returned",
                (arg("self"), arg("instrumentName") = boost::python::object()))
                [return_value_policy<copy_const_reference>()])
-      .def(
-          "getString", &ConfigServiceImpl::getString,
-          getStringOverload("Returns the named key's value. If use_cache = "
-                            "true [default] then relative paths->absolute",
-                            (arg("self"), arg("key"), arg("use_cache") = true)))
+      .def("getString", &ConfigServiceImpl::getString,
+           getString_Overload(
+               "Returns the named key's value. If use_cache = "
+               "true [default] then relative paths->absolute",
+               (arg("self"), arg("key"), arg("pathAbsolute") = true)))
+
       .def("setString", &ConfigServiceImpl::setString,
            (arg("self"), arg("key"), arg("value")),
            "Set the given property name. "

--- a/Framework/PythonInterface/mantid/kernel/src/Exports/ConfigService.cpp
+++ b/Framework/PythonInterface/mantid/kernel/src/Exports/ConfigService.cpp
@@ -61,7 +61,7 @@ GNU_DIAG_OFF("conversion")
 // Overload generator for getInstrument
 BOOST_PYTHON_FUNCTION_OVERLOADS(getInstrument_Overload, getInstrument, 1, 2)
 // Overload generator for getString
-BOOST_PYTHON_MEMBER_FUNCTION_OVERLOADS(getStringOverload,
+BOOST_PYTHON_MEMBER_FUNCTION_OVERLOADS(getString_Overload,
                                        ConfigServiceImpl::getString, 1, 2)
 
 GNU_DIAG_ON("conversion")

--- a/Framework/PythonInterface/test/python/mantid/kernel/ConfigServiceTest.py
+++ b/Framework/PythonInterface/test/python/mantid/kernel/ConfigServiceTest.py
@@ -1,4 +1,5 @@
 # Mantid Repository : https://github.com/mantidproject/mantid
+# Mantid Repository : https://github.com/mantidproject/mantid
 #
 # Copyright &copy; 2018 ISIS Rutherford Appleton Laboratory UKRI,
 #   NScD Oak Ridge National Laboratory, European Spallation Source,
@@ -109,12 +110,13 @@ class ConfigServiceTest(unittest.TestCase):
     def test_appending_paths(self):
         new_path_list = self._setup_test_areas()
         try:
+            num_of_dirs = len(config.getDataSearchDirs())
             config.appendDataSearchDir(str(new_path_list[0]))
             updated_paths = config.getDataSearchDirs()
         finally:
             self._clean_up_test_areas()
 
-        self.assertEqual(4, len(updated_paths))
+        self.assertEqual(num_of_dirs+1, len(updated_paths))
 
     def test_setting_log_channel_levels(self):
         testhelpers.assertRaisesNothing(self, config.setLogLevel, 4, True)
@@ -153,7 +155,7 @@ class ConfigServiceTest(unittest.TestCase):
                            'loading.multifile', 'loading.multifilelimit',
                            'maskFiles.directory',
                            'pythonalgorithms.refresh.allowed',
-                           'sliceviewer.nonorthogonal'
+                           'sliceviewer.nonorthogonal',
 
                            ########## TODO should these be documented?
                            'curvefitting.defaultPeak', 'curvefitting.findPeaksFWHM', 'curvefitting.findPeaksTolerance', 'curvefitting.guiExclude',

--- a/Framework/PythonInterface/test/python/mantid/kernel/ConfigServiceTest.py
+++ b/Framework/PythonInterface/test/python/mantid/kernel/ConfigServiceTest.py
@@ -153,8 +153,7 @@ class ConfigServiceTest(unittest.TestCase):
                            'loading.multifile', 'loading.multifilelimit',
                            'maskFiles.directory',
                            'pythonalgorithms.refresh.allowed',
-                           'sliceviewer.nonorthogonal',
-                           'usersearch.directories',
+                           'sliceviewer.nonorthogonal'
 
                            ########## TODO should these be documented?
                            'curvefitting.defaultPeak', 'curvefitting.findPeaksFWHM', 'curvefitting.findPeaksTolerance', 'curvefitting.guiExclude',

--- a/Framework/PythonInterface/test/python/plugins/algorithms/LoadAndMergeTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/LoadAndMergeTest.py
@@ -11,11 +11,14 @@ from mantid.simpleapi import LoadAndMerge, config, mtd
 
 class LoadAndMergeTest(unittest.TestCase):
 
+    @classmethod
+    def setUpClass(cls):
+        config.appendDataSearchSubDir('ILL/IN16B/')
+        config.appendDataSearchSubDir('ILL/D20/')
+
     def setUp(self):
         config['default.facility'] = 'ILL'
         config['default.instrument'] = 'IN16B'
-        config.appendDataSearchSubDir('ILL/IN16B/')
-        config.appendDataSearchSubDir('ILL/D20/')
 
     def test_single_run_load(self):
         out1 = LoadAndMerge(Filename='170257')

--- a/Framework/PythonInterface/test/python/plugins/algorithms/LoadLampTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/LoadLampTest.py
@@ -10,7 +10,8 @@ import unittest
 
 class LoadLampTest(unittest.TestCase):
 
-    def setUp(self):
+    @classmethod
+    def setUpClass(cls):
         config.appendDataSearchSubDir('ILL/LAMP/')
 
     def tearDown(self):

--- a/Framework/PythonInterface/test/python/plugins/algorithms/WorkflowAlgorithms/PowderILLDetectorScanTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/WorkflowAlgorithms/PowderILLDetectorScanTest.py
@@ -13,10 +13,13 @@ from mantid.simpleapi import PowderILLDetectorScan, config, mtd
 # More options are covered by system tests, since it takes too long for a unit test.
 class PowderILLDetectorScanTest(unittest.TestCase):
 
+    @classmethod
+    def setUpClass(cls):
+        config.appendDataSearchSubDir('ILL/D2B/')
+
     def setUp(self):
         config['default.facility'] = 'ILL'
         config['default.instrument'] = 'D2B'
-        config.appendDataSearchSubDir('ILL/D2B/')
 
     def tearDown(self):
         mtd.clear()

--- a/Framework/PythonInterface/test/python/plugins/algorithms/WorkflowAlgorithms/PowderILLParameterScanTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/WorkflowAlgorithms/PowderILLParameterScanTest.py
@@ -13,10 +13,13 @@ class PowderILLParameterScanTest(unittest.TestCase):
 
     _runs = '967087:967088'
 
+    @classmethod
+    def setUpClass(cls):
+        config.appendDataSearchSubDir('ILL/D20/')
+
     def setUp(self):
         config['default.facility'] = 'ILL'
         config['default.instrument'] = 'D20'
-        config.appendDataSearchSubDir('ILL/D20/')
 
     def tearDown(self):
         mtd.remove('red')

--- a/Framework/PythonInterface/test/python/plugins/algorithms/WorkflowAlgorithms/SANSILLReductionTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/WorkflowAlgorithms/SANSILLReductionTest.py
@@ -15,10 +15,12 @@ class SANSILLReductionTest(unittest.TestCase):
     _facility = None
     _instrument = None
 
-    def setUp(self):
+    @classmethod
+    def setUpClass(cls):
         config.appendDataSearchSubDir('ILL/D11/')
         config.appendDataSearchSubDir('ILL/D33/')
 
+    def setUp(self):
         self._facility = config['default.facility']
         self._instrument = config['default.instrument']
 

--- a/Framework/WorkflowAlgorithms/src/EQSANSLoad.cpp
+++ b/Framework/WorkflowAlgorithms/src/EQSANSLoad.cpp
@@ -147,16 +147,18 @@ std::string EQSANSLoad::findConfigFile(const int &run) {
   static boost::regex re1("eqsans_configuration\\.([0-9]+)$");
   boost::smatch matches;
   for (const auto &searchPath : searchPaths) {
-    Poco::DirectoryIterator file_it(searchPath);
-    Poco::DirectoryIterator end;
-    for (; file_it != end; ++file_it) {
-      if (boost::regex_search(file_it.name(), matches, re1)) {
-        std::string s = matches[1];
-        int run_number = 0;
-        Poco::NumberParser::tryParse(s, run_number);
-        if (run_number > max_run_number && run_number <= run) {
-          max_run_number = run_number;
-          config_file = file_it.path().toString();
+    if (Poco::File(searchPath).exists()) {
+      Poco::DirectoryIterator file_it(searchPath);
+      Poco::DirectoryIterator end;
+      for (; file_it != end; ++file_it) {
+        if (boost::regex_search(file_it.name(), matches, re1)) {
+          std::string s = matches[1];
+          int run_number = 0;
+          Poco::NumberParser::tryParse(s, run_number);
+          if (run_number > max_run_number && run_number <= run) {
+            max_run_number = run_number;
+            config_file = file_it.path().toString();
+          }
         }
       }
     }

--- a/docs/source/release/v5.1.0/mantidworkbench.rst
+++ b/docs/source/release/v5.1.0/mantidworkbench.rst
@@ -51,7 +51,7 @@ Improvements
 - Improved the usability of the fit function and peak selection pop-up menus by allowing the user to immediately search for the desired function and activate autocompletion by pressing "enter" if there is just a single possible function.
 - The figure options menu now has a help button which opens the documentation for the menu.
 - Variables assigned in python scripts are now cleared when a script is run in its entirety.
-
+- User data directories are no longer checked at startup, reducing launch times with slow network drives.
 
 Bugfixes
 ########

--- a/scripts/test/IndirectCommonTests.py
+++ b/scripts/test/IndirectCommonTests.py
@@ -79,9 +79,9 @@ class IndirectCommonTests(unittest.TestCase):
         self.assertRaises(ValueError, indirect_common.getEfixed, ws.name())
 
     def test_getDefaultWorkingDirectory(self):
-        config['defaultsave.directory'] = os.path.expanduser('~')
+        config['defaultsave.directory'] = os.path.expanduser('~/')
         workdir = indirect_common.getDefaultWorkingDirectory()
-        self.assertEqual(os.path.expanduser('~'), workdir,
+        self.assertEqual(os.path.expanduser('~/'), workdir,
                           "The working directory does not match the expected one")
 
     def test_getDefaultWorkingDirectory_failure(self):

--- a/scripts/test/IndirectCommonTests.py
+++ b/scripts/test/IndirectCommonTests.py
@@ -9,7 +9,6 @@
 These scripts are used by the ISIS Indirect geometry interfaces such as Indirect Convert to Energy,
 Data Analysis, and Bayes.
 """
-import os
 import unittest
 import numpy as np
 
@@ -79,9 +78,10 @@ class IndirectCommonTests(unittest.TestCase):
         self.assertRaises(ValueError, indirect_common.getEfixed, ws.name())
 
     def test_getDefaultWorkingDirectory(self):
-        config['defaultsave.directory'] = os.path.join(os.path.expanduser('~'), "")
+        path = os.path.join(os.path.expanduser('~'), "")
+        config['defaultsave.directory'] = path
         workdir = indirect_common.getDefaultWorkingDirectory()
-        self.assertEqual(os.path.join(os.path.expanduser('~'), ""), workdir,
+        self.assertEqual(path.replace("\\", "/"), workdir,
                          "The working directory does not match the expected one")
 
     def test_getDefaultWorkingDirectory_failure(self):

--- a/scripts/test/IndirectCommonTests.py
+++ b/scripts/test/IndirectCommonTests.py
@@ -79,10 +79,10 @@ class IndirectCommonTests(unittest.TestCase):
         self.assertRaises(ValueError, indirect_common.getEfixed, ws.name())
 
     def test_getDefaultWorkingDirectory(self):
-        config['defaultsave.directory'] = os.path.expanduser('~/')
+        config['defaultsave.directory'] = os.path.join(os.path.expanduser('~'), "")
         workdir = indirect_common.getDefaultWorkingDirectory()
-        self.assertEqual(os.path.expanduser('~/'), workdir,
-                          "The working directory does not match the expected one")
+        self.assertEqual(os.path.join(os.path.expanduser('~'), ""), workdir,
+                         "The working directory does not match the expected one")
 
     def test_getDefaultWorkingDirectory_failure(self):
         config['defaultsave.directory'] = ''

--- a/scripts/test/SANS/gui_logic/add_runs_presenter_test.py
+++ b/scripts/test/SANS/gui_logic/add_runs_presenter_test.py
@@ -370,6 +370,8 @@ class AddRunsDefaultSettingsTest(unittest.TestCase):
     def test_that_if_output_directory_is_empty_default_save_directory_is_used_instead(self):
         default_dir = os.path.join("default", "save", "directory")
         ConfigService["defaultsave.directory"] = default_dir
+        # ConfigService returns an absolute path when called.
+        default_dir = os.path.join(os.getcwd(), default_dir, "")
 
         output_dir = self.presenter.set_output_directory("")
         ConfigService["defaultsave.directory"] = ""

--- a/scripts/test/SANS/gui_logic/add_runs_presenter_test.py
+++ b/scripts/test/SANS/gui_logic/add_runs_presenter_test.py
@@ -370,8 +370,8 @@ class AddRunsDefaultSettingsTest(unittest.TestCase):
     def test_that_if_output_directory_is_empty_default_save_directory_is_used_instead(self):
         default_dir = os.path.join("default", "save", "directory")
         ConfigService["defaultsave.directory"] = default_dir
-        # ConfigService returns an absolute path when called.
-        default_dir = os.path.join(os.getcwd(), default_dir, "")
+        # ConfigService may do some conversion in the background.
+        default_dir = ConfigService["defaultsave.directory"]
 
         output_dir = self.presenter.set_output_directory("")
         ConfigService["defaultsave.directory"] = ""


### PR DESCRIPTION
**Description of work.**

Changes the behaviour of the ConfigService so that data directories are checked when access is reqested, rather than on startup. The intention is to reduce the startup time of workbench when checking for network drives that may be very slow to access. 

**To test:**
1. Launch workbench
2. Add some directories on network drives to the list of user data directories.
3. Slow down the network connection somehow (utilities such as `trickle` might be useful)
4. Relaunch workbench, it should start more quickly as it isn't waiting for connections on startup any more. 

Refs #28499 

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
