### PR TITLE
Add workspace name to sliceviewer title bar

### DIFF
--- a/qt/python/mantidqt/widgets/sliceviewer/model.py
+++ b/qt/python/mantidqt/widgets/sliceviewer/model.py
@@ -59,6 +59,9 @@ class SliceViewerModel:
             return True
         return False
 
+    def get_ws_name(self) -> str:
+        return self._ws.name()
+
     def can_support_nonorthogonal_axes(self) -> bool:
         """
         Query if the workspace can support non-orthogonal axes.

--- a/qt/python/mantidqt/widgets/sliceviewer/presenter.py
+++ b/qt/python/mantidqt/widgets/sliceviewer/presenter.py
@@ -52,6 +52,7 @@ class SliceViewer(object):
         if not self.model.can_support_nonorthogonal_axes():
             self.view.data_view.disable_nonorthogonal_axes_button()
 
+        self.view.setWindowTitle(f"SliceViewer - {self.model.get_ws_name()}")
         self.new_plot()
 
     def new_plot_MDH(self):

--- a/qt/python/mantidqt/widgets/sliceviewer/view.py
+++ b/qt/python/mantidqt/widgets/sliceviewer/view.py
@@ -465,7 +465,6 @@ class SliceViewerView(QWidget):
 
         self.presenter = presenter
 
-        self.setWindowTitle("SliceViewer")
         self.setWindowFlags(Qt.Window)
         self.setAttribute(Qt.WA_DeleteOnClose, True)
 


### PR DESCRIPTION

**Description of work.**
Adds the workspace name to the sliceviewer window title


**To test:**
Files are in unit test data
``` python
Load(Filename='HET15869.raw', OutputWorkspace='HET15869_WS2D') # 2020-06-01T10:29:03.655998000 execCount: 1
Load(Filename='TOPAZ_3680_5_sec_MDEW.nxs', OutputWorkspace='TOPAZ_3680_5_sec_MDEW')
BinMD(InputWorkspace='TOPAZ_3680_5_sec_MDEW', AlignedDim0='Q_lab_x,-15.0,15.0,100', AlignedDim1='Q_lab_y,-15.0,15.0,100', AlignedDim2='Q_lab_z,-0.03500000000000121,0.0649999999999988,1', OutputWorkspace='An MDHisto Workspace')
```
1. Show the sliceviewer for each of the three workspace types.
1. For each, the window title should include the workspace name being plotted.

Fixes #28514

<!-- delete this if you added release notes
*This does not require release notes* because it is too minor compared to the raft of other slice viewer improvements
-->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
