### PR TITLE
Make colorfill plots use workspace name as the plot title

### DIFF
--- a/Framework/PythonInterface/mantid/plots/axesfunctions.py
+++ b/Framework/PythonInterface/mantid/plots/axesfunctions.py
@@ -92,7 +92,6 @@ def _setLabels2D(axes,
     else:
         axes.set_xlabel(labels[1])
         axes.set_ylabel(labels[2])
-    axes.set_title(labels[0])
     if xscale is None and hasattr(workspace, 'isCommonLogBins') and workspace.isCommonLogBins():
         axes.set_xscale('log')
     elif xscale is not None:

--- a/docs/source/release/v5.1.0/mantidworkbench.rst
+++ b/docs/source/release/v5.1.0/mantidworkbench.rst
@@ -63,5 +63,6 @@ Bugfixes
 - `plt.show()` now shows the most recently created figure.
 - Removed error when changing the normalisation of a ragged workspace with a log scaled colorbar.
 - The SavePlot1D algorithm can now be run in Workbench.
+- Colorfill plots now correctly use the workspace name as the plot title.
 
 :ref:`Release 5.1.0 <v5.1.0>`

--- a/qt/python/mantidqt/plotting/functions.py
+++ b/qt/python/mantidqt/plotting/functions.py
@@ -297,7 +297,6 @@ def plot_contour(workspaces, fig=None):
                    colors=DEFAULT_CONTOUR_COLOUR,
                    linewidths=DEFAULT_CONTOUR_WIDTH)
 
-        ax.set_title(ws.name())
         fig.show()
 
     return fig


### PR DESCRIPTION
**Description of work.**
Currently colorfill plots use what should be the colorbar axis label as the plot title, this PR makes it so that they correctly use the workspace name as the title instead.

**To test:**
Make a colorfill plot and check that the title is the workspace name.

Fixes #28598 

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
