### PR TITLE
Neaten up the user interface in sliceviewer

### DIFF
--- a/docs/source/release/v5.1.0/mantidworkbench.rst
+++ b/docs/source/release/v5.1.0/mantidworkbench.rst
@@ -37,7 +37,7 @@ Improvements
 - On 3D plots you can now double-click on the z-axis to change its limits or label.
 - Plots extracted from "Show Sample Logs" by double clicking the plot can now be converted to a python script, just like other workbench plots.
 - The workspace sample logs interface now responds to keyboard input from the cursor keys to move between logs.
-- We have neatened up the dimension selection section at the top of the slice viewer, to reduce the amount of wasted space and devote more to the data view itself.
+- We have neatened up the the slice viewer user interface, to reduce the amount of wasted space and devote more to the data view itself.
 - Surface plots no longer spill over the axes when their limits are reduced.
 - The instrument view now ignores non-finite (infinity and NaN) values and should now display workspaces containing those values.
 - The gray and plasma colormaps have been added to the instrument view.

--- a/docs/source/release/v5.1.0/mantidworkbench.rst
+++ b/docs/source/release/v5.1.0/mantidworkbench.rst
@@ -36,7 +36,7 @@ Improvements
 - On 3D plots you can now double-click on the z-axis to change its limits or label.
 - Plots extracted from "Show Sample Logs" by double clicking the plot can now be converted to a python script, just like other workbench plots.
 - The workspace sample logs interface now responds to keyboard input from the cursor keys to move between logs.
-
+- We have neatened up the dimension selection section at the top of the slice viewer, to reduce the amount of wasted space and devote more to the data view itself.
 - Surface plots no longer spill over the axes when their limits are reduced.
 - The instrument view now ignores non-finite (infinity and NaN) values and should now display workspaces containing those values.
 - The gray and plasma colormaps have been added to the instrument view. 

--- a/qt/python/mantidqt/widgets/colorbar/colorbar.py
+++ b/qt/python/mantidqt/widgets/colorbar/colorbar.py
@@ -84,7 +84,7 @@ class ColorbarWidget(QWidget):
         if parent:
             # Set facecolor to match parent
             self.canvas.figure.set_facecolor(parent.palette().window().color().getRgbF())
-        self.ax = self.canvas.figure.add_axes([0.4,0.05,0.2,0.9])
+        self.ax = self.canvas.figure.add_axes([0.0,0.02,0.2,0.97])
 
         # layout
         self.layout = QVBoxLayout(self)

--- a/qt/python/mantidqt/widgets/colorbar/colorbar.py
+++ b/qt/python/mantidqt/widgets/colorbar/colorbar.py
@@ -29,7 +29,7 @@ class ColorbarWidget(QWidget):
         super(ColorbarWidget, self).__init__(parent)
 
         self.setWindowTitle("Colorbar")
-        self.setMaximumWidth(200)
+        self.setMaximumWidth(100)
 
         self.cmap = QComboBox()
         self.cmap.addItems(sorted(cm.cmap_d.keys()))
@@ -88,6 +88,8 @@ class ColorbarWidget(QWidget):
 
         # layout
         self.layout = QVBoxLayout(self)
+        self.layout.setContentsMargins(0,0,0,0)
+        self.layout.setSpacing(2)
         self.layout.addWidget(self.cmap)
         self.layout.addLayout(self.cmax_layout)
         self.layout.addWidget(self.canvas, stretch=1)

--- a/qt/python/mantidqt/widgets/sliceviewer/dimensionwidget.py
+++ b/qt/python/mantidqt/widgets/sliceviewer/dimensionwidget.py
@@ -167,7 +167,6 @@ class Dimension(QWidget):
         self.layout = QHBoxLayout(self)
         self.layout.setContentsMargins(0,0,0,0)
 
-
         self.name = QLabel(dim_info['name'])
         self.units = QLabel(dim_info['units'])
 

--- a/qt/python/mantidqt/widgets/sliceviewer/dimensionwidget.py
+++ b/qt/python/mantidqt/widgets/sliceviewer/dimensionwidget.py
@@ -40,6 +40,8 @@ class DimensionWidget(QWidget):
         super().__init__(parent)
 
         self.layout = QVBoxLayout(self)
+        self.layout.setContentsMargins(0,0,0,0)
+        self.layout.setSpacing(0)
         self.dims, self.qflags = [], []
         for n, dim in enumerate(dims_info):
             self.qflags.append(dim['qdim'])
@@ -163,17 +165,19 @@ class Dimension(QWidget):
         self.number = number
 
         self.layout = QHBoxLayout(self)
+        self.layout.setContentsMargins(0,0,0,0)
+
 
         self.name = QLabel(dim_info['name'])
         self.units = QLabel(dim_info['units'])
 
         self.x = QPushButton('X')
-        self.x.setFixedSize(32, 32)
+        self.x.setFixedSize(26, 26)
         self.x.setCheckable(True)
         self.x.clicked.connect(self.x_clicked)
 
         self.y = QPushButton('Y')
-        self.y.setFixedSize(32, 32)
+        self.y.setFixedSize(26, 26)
         self.y.setCheckable(True)
         self.y.clicked.connect(self.y_clicked)
 
@@ -188,8 +192,12 @@ class Dimension(QWidget):
         self.spinbox.editingFinished.connect(self.spinbox_changed)
 
         self.layout.addWidget(self.name)
-        self.layout.addWidget(self.x)
-        self.layout.addWidget(self.y)
+        self.button_layout = QHBoxLayout(self)
+        self.button_layout.setContentsMargins(0,0,0,0)
+        self.button_layout.setSpacing(0)
+        self.button_layout.addWidget(self.x)
+        self.button_layout.addWidget(self.y)
+        self.layout.addLayout(self.button_layout)
         self.layout.addWidget(self.slider, stretch=1)
         self.layout.addStretch(0)
         self.layout.addWidget(self.spinbox)

--- a/qt/python/mantidqt/widgets/sliceviewer/view.py
+++ b/qt/python/mantidqt/widgets/sliceviewer/view.py
@@ -57,10 +57,10 @@ class SliceViewerDataView(QWidget):
 
         # normalization options
         if can_normalise:
-            self.norm_layout = QHBoxLayout()
+            self.norm_layout = QVBoxLayout()
             self.norm_layout.setContentsMargins(0, 0, 0, 0)
             self.norm_layout.setSpacing(0)
-            self.norm_label = QLabel("Normalization =")
+            self.norm_label = QLabel("Normalization")
             self.norm_layout.addWidget(self.norm_label)
             self.norm_opts = QComboBox()
             self.norm_opts.addItems(["None", "By bin width"])
@@ -73,6 +73,7 @@ class SliceViewerDataView(QWidget):
         self.mpl_layout.setContentsMargins(0,0,0,0)
         self.mpl_layout.setSpacing(0)
         self.fig = Figure()
+        self.fig.set_tight_layout(True)
         self.ax = None
         self._grid_on = False
         self.fig.set_facecolor(self.palette().window().color().getRgbF())
@@ -80,6 +81,8 @@ class SliceViewerDataView(QWidget):
         self.canvas.mpl_connect('motion_notify_event', self.mouse_move)
         self.create_axes_orthogonal()
         self.mpl_layout.addWidget(self.canvas)
+        self.colorbar_label = QLabel("Colormap")
+        self.colorbar_layout.addWidget(self.colorbar_label)
         self.colorbar = ColorbarWidget(self)
         self.colorbar_layout.addWidget(self.colorbar)
         self.colorbar.colorbarChanged.connect(self.update_data_clim)

--- a/qt/python/mantidqt/widgets/sliceviewer/view.py
+++ b/qt/python/mantidqt/widgets/sliceviewer/view.py
@@ -52,10 +52,14 @@ class SliceViewerDataView(QWidget):
         self.dimensions_layout.addWidget(self.dimensions)
 
         self.colorbar_layout = QVBoxLayout()
+        self.colorbar_layout.setContentsMargins(0,0,0,0)
+        self.colorbar_layout.setSpacing(0)
 
         # normalization options
         if can_normalise:
             self.norm_layout = QHBoxLayout()
+            self.norm_layout.setContentsMargins(0, 0, 0, 0)
+            self.norm_layout.setSpacing(0)
             self.norm_label = QLabel("Normalization =")
             self.norm_layout.addWidget(self.norm_label)
             self.norm_opts = QComboBox()
@@ -66,6 +70,8 @@ class SliceViewerDataView(QWidget):
 
         # MPL figure + colorbar
         self.mpl_layout = QHBoxLayout()
+        self.mpl_layout.setContentsMargins(0,0,0,0)
+        self.mpl_layout.setSpacing(0)
         self.fig = Figure()
         self.ax = None
         self._grid_on = False
@@ -89,6 +95,7 @@ class SliceViewerDataView(QWidget):
 
         # layout
         self.layout = QGridLayout(self)
+        self.layout.setSpacing(1)
         self.layout.addLayout(self.dimensions_layout, 0, 0)
         self.layout.addWidget(self.mpl_toolbar, 1, 0)
         self.layout.addLayout(self.mpl_layout, 2, 0)


### PR DESCRIPTION
**Description of work.**
Improved layout at the top of the workbench sliceviewer.

Before:
![image](https://user-images.githubusercontent.com/1017173/83420149-1c5c3300-a41e-11ea-807e-5a14138d048a.png)


After: 
![image](https://user-images.githubusercontent.com/1017173/83420135-17977f00-a41e-11ea-9dd6-4e23dbc41da0.png)


**To test:**
1. Start workbench
1. Load TOPAZ_3680_5_sec_MDEW (UNIT TEST)
1. Show the slice viewer, compare it to the images above.  (Ignore the window title)

*There is no associated issue.*


---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
