### PR TITLE
Fixes for tests with macOS brew HEAD

### DIFF
--- a/Framework/Beamline/test/CMakeLists.txt
+++ b/Framework/Beamline/test/CMakeLists.txt
@@ -6,12 +6,18 @@ if(CXXTEST_FOUND)
   cxxtest_add_test(BeamlineTest ${TEST_FILES} ${GMOCK_TEST_FILES})
   target_include_directories(BeamlineTest SYSTEM PRIVATE ${Boost_INCLUDE_DIRS})
   target_link_libraries(BeamlineTest
-                        LINK_PRIVATE
+                        PRIVATE
                         ${TCMALLOC_LIBRARIES_LINKTIME}
                         Beamline
+			Kernel
                         ${Boost_LIBRARIES}
                         gmock
-)
+  )
+
+  if(OpenMP_CXX_FOUND)
+    # Access to config service is required
+    target_link_libraries(BeamlineTest PRIVATE Kernel)
+  endif()
 
   add_dependencies(FrameworkTests BeamlineTest)
   # Add to the 'FrameworkTests' group in VS

--- a/Framework/CMakeLists.txt
+++ b/Framework/CMakeLists.txt
@@ -77,7 +77,6 @@ add_subdirectory(Beamline)
 set(MANTIDLIBS ${MANTIDLIBS} Parallel)
 # HistogramData has header-only dependency on Kernel, so Kernel comes after.
 set(MANTIDLIBS ${MANTIDLIBS} HistogramData)
-# Indexing has header-only dependency on Kernel, so Kernel comes after.
 set(MANTIDLIBS ${MANTIDLIBS} Indexing)
 set(MANTIDLIBS ${MANTIDLIBS} Kernel)
 set(MANTIDLIBS ${MANTIDLIBS} Beamline)

--- a/Framework/HistogramData/test/CMakeLists.txt
+++ b/Framework/HistogramData/test/CMakeLists.txt
@@ -7,12 +7,17 @@ if(CXXTEST_FOUND)
   target_include_directories(HistogramDataTest SYSTEM
                              PRIVATE ${Boost_INCLUDE_DIRS})
   target_link_libraries(HistogramDataTest
-                        LINK_PRIVATE
+                        PRIVATE
                         ${TCMALLOC_LIBRARIES_LINKTIME}
                         HistogramData
+                        Kernel
                         ${Boost_LIBRARIES}
                         gmock
-)
+  )
+  if(OpenMP_CXX_FOUND)
+    # Access to config service is required
+    target_link_libraries(HistogramDataTest PRIVATE Kernel)
+  endif()
 
   add_dependencies(FrameworkTests HistogramDataTest)
   # Add to the 'FrameworkTests' group in VS

--- a/Framework/Indexing/test/CMakeLists.txt
+++ b/Framework/Indexing/test/CMakeLists.txt
@@ -10,13 +10,17 @@ if(CXXTEST_FOUND)
 
   cxxtest_add_test(IndexingTest ${TEST_FILES} ${GMOCK_TEST_FILES})
   target_link_libraries(IndexingTest
-                        LINK_PRIVATE
+                        PRIVATE
                         ${TCMALLOC_LIBRARIES_LINKTIME}
                         ${MANTIDLIBS}
                         Indexing
                         Parallel
                         gmock
-)
+  )
+  if(OpenMP_CXX_FOUND)
+    # Access to config service is required
+    target_link_libraries(IndexingTest PRIVATE Kernel)
+  endif()
 
   add_dependencies(FrameworkTests IndexingTest)
   # Add to the 'FrameworkTests' group in VS

--- a/Testing/SystemTests/scripts/mantidinstaller.py
+++ b/Testing/SystemTests/scripts/mantidinstaller.py
@@ -13,7 +13,11 @@ import sys
 import subprocess
 import time
 
+# global script path
 scriptLog = None
+# distributions
+RPMBASED = ['redhat', 'centos', 'fedora']
+DEBBASED = ['ubuntu', 'debian']
 
 
 def createScriptLog(path):
@@ -83,10 +87,10 @@ def get_installer(package_dir, do_install=True):
     if system == 'Windows':
         return NSISInstaller(package_dir, do_install)
     elif system == 'Linux':
-        dist = linux_distro_distributor()
-        if dist == 'Ubuntu':
+        dist = linux_distro_distributor().lower()
+        if any(map(lambda name: name in dist, DEBBASED)):
             return DebInstaller(package_dir, do_install)
-        elif dist.lower() == 'redhat' or dist.lower() == 'fedora' or dist.lower() == 'centos':
+        elif any(map(lambda name: name in dist, RPMBASED)):
             return RPMInstaller(package_dir, do_install)
         else:
             scriptfailure('Unknown Linux flavour: %s' % str(dist))

--- a/Testing/SystemTests/scripts/mantidinstaller.py
+++ b/Testing/SystemTests/scripts/mantidinstaller.py
@@ -83,10 +83,10 @@ def get_installer(package_dir, do_install=True):
     if system == 'Windows':
         return NSISInstaller(package_dir, do_install)
     elif system == 'Linux':
-        dist = platform.dist()
-        if dist[0] == 'Ubuntu':
+        dist = linux_distro_distributor()
+        if dist == 'Ubuntu':
             return DebInstaller(package_dir, do_install)
-        elif dist[0].lower() == 'redhat' or dist[0].lower() == 'fedora' or dist[0].lower() == 'centos':
+        elif dist.lower() == 'redhat' or dist.lower() == 'fedora' or dist.lower() == 'centos':
             return RPMInstaller(package_dir, do_install)
         else:
             scriptfailure('Unknown Linux flavour: %s' % str(dist))
@@ -94,6 +94,17 @@ def get_installer(package_dir, do_install=True):
         return DMGInstaller(package_dir, do_install)
     else:
         raise scriptfailure("Unsupported platform")
+
+
+def linux_distro_distributor():
+    """Extract the distributor for the current Linux distribution
+    """
+    try:
+        lsb_descr = subprocess.check_output('lsb_release --id', shell=True,
+                                            stderr=subprocess.STDOUT).decode('utf-8')
+        return lsb_descr.strip()[len('Distributor ID:')+1:].strip()
+    except subprocess.CalledProcessError as exc:
+        return f'Unknown distribution: lsb_release --id failed {exc}'
 
 
 def run(cmd):

--- a/Testing/SystemTests/scripts/performance/testresult.py
+++ b/Testing/SystemTests/scripts/performance/testresult.py
@@ -21,20 +21,29 @@ import sqlresults
 import numpy as np
 
 
+# Copy of that in systemtesting.py as there is no place to share it easily and its tiny and unlikely to change
+def linux_distro_description():
+    """Human readable string for linux distro description
+    """
+    try:
+        lsb_descr = subprocess.check_output('lsb_release --description', shell=True,
+                                            stderr=subprocess.STDOUT).decode('utf-8')
+        return lsb_descr.strip()[len('Description:')+1:].strip()
+    except subprocess.CalledProcessError as exc:
+        return f'Unknown distribution: lsb_release -d failed {exc}'
 
 
-#########################################################################
-#########################################################################
 def envAsString():
-    """ Return the environment as a string """
-    if os.name == 'nt':
+    platform_name = sys.platform
+    if platform_name == 'win32':
         system = platform.system().lower()[:3]
         arch = platform.architecture()[0][:2]
         env = system + arch
-    elif os.name == 'mac':
+    elif platform_name == 'darwin':
         env = platform.mac_ver()[0]
     else:
-        env = " ".join(platform.dist())
+        # assume linux
+        env = linux_distro_description()
     return env
     
     

--- a/Testing/SystemTests/scripts/runSystemTests.py
+++ b/Testing/SystemTests/scripts/runSystemTests.py
@@ -11,21 +11,6 @@ import sys
 import time
 from multiprocessing import Process, Array, Manager, Value, Lock
 
-try:
-    # If any tests happen to hit a PyQt4 import make sure item uses version 2 of the api
-    # Remove this when everything is switched to qtpy
-    import sip
-    sip.setapi('QString', 2)
-    sip.setapi('QVariant', 2)
-    sip.setapi('QDate', 2)
-    sip.setapi('QDateTime', 2)
-    sip.setapi('QTextStream', 2)
-    sip.setapi('QTime', 2)
-    sip.setapi('QUrl', 2)
-except (AttributeError, ImportError):
-    # PyQt < v4.6
-    pass
-
 # Prevents erros in systemtests that use matplotlib directly
 os.environ['MPLBACKEND'] = 'Agg'
 

--- a/buildconfig/CMake/Packaging/osx/mantidpython.in
+++ b/buildconfig/CMake/Packaging/osx/mantidpython.in
@@ -31,15 +31,21 @@ fi
 LOCAL_PYTHONPATH=${SCRIPT_PATH}
 LOCAL_PYTHONPATH=${LOCAL_PYTHONPATH}@PARAVIEW_PYTHON_PATHS@
 if [ -n "${PYTHONPATH}" ]; then
-	LOCAL_PYTHONPATH=${LOCAL_PYTHONPATH}:${PYTHONPATH}
+  LOCAL_PYTHONPATH=${LOCAL_PYTHONPATH}:${PYTHONPATH}
+fi
+
+# Find private sip module for PyQt4 or qtpy fails to import
+if [ "$QT_API" = "pyqt" ] || [ "$QT_API" = "pyqt4" ]; then
+  SIP_SO=`${PYTHONEXE} -c"import PyQt4.sip as sip;print(sip.__file__)"`
+  LOCAL_PYTHONPATH=`dirname ${SIP_SO}`:${LOCAL_PYTHONPATH}  
 fi
 
 if [ -n "$1" ] && [ "$1" = "--classic" ]; then
-    shift
-    set -- ${PYTHONEXE} $*
+  shift
+  set -- ${PYTHONEXE} $*
 else
-    IPYTHON_STARTUP="import IPython;IPython.start_ipython()"
-    set -- ${PYTHONEXE} -c "${IPYTHON_STARTUP}" $*
+  IPYTHON_STARTUP="import IPython;IPython.start_ipython()"
+  set -- ${PYTHONEXE} -c "${IPYTHON_STARTUP}" $*
 fi
 
 PV_PLUGIN_PATH=${PV_PLUGIN_PATH} \

--- a/buildconfig/Jenkins/buildscript
+++ b/buildconfig/Jenkins/buildscript
@@ -134,17 +134,8 @@ else
     SCL_ENABLE="eval"
 fi
 
-# Check if this is a Python 2 build and set CMake arguments.
-PY2_BUILD=false
-PY3_BUILD=false
-if [[ ${JOB_NAME} == *python2* ]]; then
-    PY2_BUILD=true
-    DIST_FLAGS="${DIST_FLAGS} -DWITH_PYTHON3=OFF"
-else
-    PY3_BUILD=true
-    DIST_FLAGS="${DIST_FLAGS} -DWITH_PYTHON3=ON"
-    PARAVIEW_DIR="${PARAVIEW_DIR}-python3"
-fi
+# Use Python 3 build of ParaView
+PARAVIEW_DIR="${PARAVIEW_DIR}-python3"
 
 # For pull requests decide on what to build based on changeset and Jenkins
 # parameters.
@@ -168,10 +159,8 @@ if [[ ${PRBUILD} == true ]]; then
     if [[ ${ON_RHEL7} == true ]]; then
         # rhel does system testing if there are any non-doc or gui changes
         if ! ${SCRIPT_DIR}/check_for_changes docs-gui-only; then
-            if [[ ${PY3_BUILD} == true ]]; then
-               DO_BUILD_PKG=true
-               DO_SYSTEMTESTS=true
-            fi
+            DO_BUILD_PKG=true
+            DO_SYSTEMTESTS=true
         fi
         elif [[ ${ON_UBUNTU} == true ]]; then
         # ubuntu does the docs build

--- a/buildconfig/Jenkins/doctests
+++ b/buildconfig/Jenkins/doctests
@@ -35,7 +35,7 @@ fi
 #####################################################################################
 INSTALLER_SCRIPT=$WORKSPACE/Testing/SystemTests/scripts/mantidinstaller.py
 EXE_PATH_FILE=$PWD/mantidplotpath.txt
-python ${INSTALLER_SCRIPT} install $WORKSPACE --dump-exe-path=${EXE_PATH_FILE}
+python3 ${INSTALLER_SCRIPT} install $WORKSPACE --dump-exe-path=${EXE_PATH_FILE}
 MANTIDPLOT_EXE=$(cat ${EXE_PATH_FILE})
 
 ###############################################################################
@@ -79,7 +79,7 @@ if [[ ${NODE_LABELS} == *ubuntu* ]]; then
     ON_WT_PLATFORMS=true
 fi
 if [[ "${ON_WT_PLATFORMS}" == true ]] && [[ ${JOB_NAME} == *wikitests* ]]; then
-  python ${WORKSPACE}/tools/scripts/TestWikiPython.py -o ${WORKSPACE}/docs/source/mwTests
+  python3 ${WORKSPACE}/tools/scripts/TestWikiPython.py -o ${WORKSPACE}/docs/source/mwTests
 fi
 
 #####################################################################################
@@ -110,6 +110,6 @@ set -e #exit on failures from now on
 #####################################################################################
 # Remove package
 #####################################################################################
-python ${INSTALLER_SCRIPT} uninstall $WORKSPACE
+python3 ${INSTALLER_SCRIPT} uninstall $WORKSPACE
 
 exit $status

--- a/buildconfig/Jenkins/systemtests
+++ b/buildconfig/Jenkins/systemtests
@@ -104,4 +104,4 @@ SYSTEST_NPROCS=${SYSTEST_NPROCS:-$BUILD_THREADS}
 echo "Running system tests with ${SYSTEST_NPROCS} cores."
 
 PKGDIR=${WORKSPACE}/build
-${X11_RUNNER} "${X11_RUNNER_ARGS}" python $WORKSPACE/Testing/SystemTests/scripts/InstallerTests.py -o -d $PKGDIR -j ${SYSTEST_NPROCS} $EXTRA_ARGS
+${X11_RUNNER} "${X11_RUNNER_ARGS}" python3 $WORKSPACE/Testing/SystemTests/scripts/InstallerTests.py -o -d $PKGDIR -j ${SYSTEST_NPROCS} $EXTRA_ARGS

--- a/qt/python/mantidqtpython/CMakeLists.txt
+++ b/qt/python/mantidqtpython/CMakeLists.txt
@@ -105,6 +105,7 @@ mtd_add_sip_module(MODULE_NAME mantidqtpython
                      Qt4::QtCore
                      Qt4::QtGui
                      Qt4::QtOpenGL
+		     Qt4::Qscintilla
                      Qwt5
                      ${PYTHON_LIBRARIES}
                    FOLDER Qt4

--- a/qt/widgets/factory/CMakeLists.txt
+++ b/qt/widgets/factory/CMakeLists.txt
@@ -29,6 +29,7 @@ mtd_add_qt_library(TARGET_NAME MantidQtWidgetsFactory
                      ${POCO_LIBRARIES}
                      ${Boost_LIBRARIES}
                    QT4_LINK_LIBS
+		     Qt4::Qscintilla
                      Qwt5
                    MTD_QT_LINK_LIBS
                      MantidQtWidgetsCommon

--- a/qt/widgets/plugins/algorithm_dialogs/CMakeLists.txt
+++ b/qt/widgets/plugins/algorithm_dialogs/CMakeLists.txt
@@ -75,12 +75,19 @@ mtd_add_qt_library(
     ${Boost_LIBRARIES}
     ${QT_LIBRARIES}
     ${OPENGL_LIBRARIES}
-  QT4_LINK_LIBS Qt4::QtOpenGL
+  QT4_LINK_LIBS Qt4::QtOpenGL Qt4::Qscintilla
   MTD_QT_LINK_LIBS MantidQtWidgetsCommon
   OSX_INSTALL_RPATH @loader_path/../../Contents/MacOS
   LINUX_INSTALL_RPATH "\$ORIGIN/../../${LIB_DIR}"
   INSTALL_DIR_BASE ${PLUGINS_DIR}
 )
+
+if(ENABLE_WORKBENCH)
+  find_package(
+    QScintillaQt5
+    REQUIRED
+  )
+endif()
 
 mtd_add_qt_library(
   TARGET_NAME MantidQtWidgetsPluginsAlgorithmDialogs
@@ -99,7 +106,7 @@ mtd_add_qt_library(
     ${Boost_LIBRARIES}
     ${QT_LIBRARIES}
     ${OPENGL_LIBRARIES}
-  QT5_LINK_LIBS Qt5::OpenGL
+  QT5_LINK_LIBS Qt5::OpenGL Qt5::Qscintilla
   MTD_QT_LINK_LIBS MantidQtWidgetsCommon
   OSX_INSTALL_RPATH @loader_path/../../Contents/MacOS
   LINUX_INSTALL_RPATH "\$ORIGIN/../../${LIB_DIR}"


### PR DESCRIPTION
**Description of work.**

Adds final fixes after #28681 to build and run tests against HEAD versions of Homebrew.

See commit messages for more details.

**To test:**

On macOS:
* On an existing machine upgrade all of Homebrew following [these instructions](https://gist.github.com/martyngigg/517648235f9b7eeb13921ef241be7364)
* Build and run `HistogramData` test: `ctest -R HistogramData`
* Run `ctest -R qt4.test_spectraselectiondialog`
* Run a system test: `./systemtest -R CodeConvention`

Both should pass.


*There is no associated issue.*

*This does not require release notes* because **it is an internal change.**

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
