### PR TITLE
Fix peak selection mouse cursor bug

### DIFF
--- a/docs/source/release/v5.1.0/mantidworkbench.rst
+++ b/docs/source/release/v5.1.0/mantidworkbench.rst
@@ -65,5 +65,6 @@ Bugfixes
 - `plt.show()` now shows the most recently created figure.
 - Removed error when changing the normalisation of a ragged workspace with a log scaled colorbar.
 - The SavePlot1D algorithm can now be run in Workbench.
+- Fixed a bug with the peak cursor immediately resetting to the default cursor when trying to add a peak.
 
 :ref:`Release 5.1.0 <v5.1.0>`

--- a/qt/applications/workbench/workbench/plotting/figureinteraction.py
+++ b/qt/applications/workbench/workbench/plotting/figureinteraction.py
@@ -637,7 +637,8 @@ class FigureInteraction(object):
 
     def motion_event(self, event):
         """ Move the marker if the mouse is moving and in range """
-        if self.toolbar_manager.is_tool_active() or event is None:
+        if self.toolbar_manager.is_tool_active() or self.toolbar_manager.is_fit_active() \
+                or event is None:
             return
 
         x = event.xdata

--- a/qt/applications/workbench/workbench/plotting/test/test_figureinteraction.py
+++ b/qt/applications/workbench/workbench/plotting/test/test_figureinteraction.py
@@ -563,6 +563,13 @@ class FigureInteractionTest(unittest.TestCase):
 
         self.assertEqual(0, self.interactor._set_hover_cursor.call_count)
 
+    def test_motion_event_returns_if_fit_active(self):
+        self.interactor.toolbar_manager.is_fit_active = MagicMock(return_value=True)
+        self.interactor._set_hover_cursor = MagicMock()
+        self.interactor.motion_event(MagicMock())
+
+        self.assertEqual(0, self.interactor._set_hover_cursor.call_count)
+
     def test_motion_event_changes_cursor_and_draws_canvas_if_any_marker_is_moving(self):
         markers = [MagicMock(), MagicMock(), MagicMock()]
         for marker in markers:
@@ -572,6 +579,7 @@ class FigureInteractionTest(unittest.TestCase):
         event.ydata = 2
         self.interactor.markers = markers
         self.interactor.toolbar_manager.is_tool_active = MagicMock(return_value=False)
+        self.interactor.toolbar_manager.is_fit_active = MagicMock(return_value=False)
         self.interactor._set_hover_cursor = MagicMock()
 
         self.interactor.motion_event(event)
@@ -588,6 +596,7 @@ class FigureInteractionTest(unittest.TestCase):
         event.ydata = 2
         self.interactor.markers = markers
         self.interactor.toolbar_manager.is_tool_active = MagicMock(return_value=False)
+        self.interactor.toolbar_manager.is_fit_active = MagicMock(return_value=False)
         self.interactor._set_hover_cursor = MagicMock()
 
         self.interactor.motion_event(event)

--- a/qt/applications/workbench/workbench/plotting/toolbar.py
+++ b/qt/applications/workbench/workbench/plotting/toolbar.py
@@ -292,6 +292,12 @@ class ToolbarStateManager(object):
         """
         return self.is_pan_active() or self.is_zoom_active()
 
+    def is_fit_active(self):
+        """
+        Check if the fit button is checked
+        """
+        return self._toolbar._actions['toggle_fit'].isChecked()
+
     def toggle_fit_button_checked(self):
         fit_action = self._toolbar._actions['toggle_fit']
         if fit_action.isChecked():

--- a/qt/python/mantidqt/widgets/fitpropertybrowser/interactive_tool.py
+++ b/qt/python/mantidqt/widgets/fitpropertybrowser/interactive_tool.py
@@ -73,6 +73,7 @@ class FitInteractiveTool(QObject):
         self._cids.append(canvas.mpl_connect('motion_notify_event', self.motion_notify_callback))
         self._cids.append(canvas.mpl_connect('button_press_event', self.button_press_callback))
         self._cids.append(canvas.mpl_connect('button_release_event', self.button_release_callback))
+        self._cids.append(canvas.mpl_connect('figure_leave_event', self.stop_add_peak))
 
         # The mouse state machine that handles responses to the mouse events.
         self.mouse_state = StateMachine(self)
@@ -256,6 +257,9 @@ class FitInteractiveTool(QObject):
         self.select_peak(peak)
         self.canvas.draw()
         self.peak_added.emit(peak.peak_id, x, peak.height(), peak.fwhm())
+
+    def stop_add_peak(self, event):
+        self.mouse_state.state = self.mouse_state.state.transition()
 
     def update_peak(self, peak_id, centre, height, fwhm):
         """


### PR DESCRIPTION
**Description of work.**
This PR fixes a bug where the mouse cursor would reset to the default cursor when trying to select a peak. This was due to the figure interactive mouse tracking resetting the cursor. This has been fixed by adding a check in the figureinteraction to determine whether we are in the fit browser. Additionally, if the mouse cursor is moved outside the canvas the peak selection procedure will end.

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

**To test:**

1. Load data
2. Plot a spectra
3. Open the fit browser
4. Select add peak
5. If you move the cursor it should continue being a cross, waiting for the user to select a peak.
6. If you leave the figure canvas the peak selection should no longer be active (i.e clicking should not create a peak).

<!-- Instructions for testing. -->

Fixes #27925. <!-- and fix #xxxx or close #xxxx xor resolves #xxxx -->
<!-- alternative
*There is no associated issue.*
-->

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
-->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
