### PR TITLE
Add help button to figure options

### DIFF
--- a/docs/source/release/v5.1.0/mantidworkbench.rst
+++ b/docs/source/release/v5.1.0/mantidworkbench.rst
@@ -43,6 +43,8 @@ Improvements
 - The gray and plasma colormaps have been added to the instrument view.
 - The x-axis tick labels on colorfill plots are now horizontal.
 
+- The figure options menu now has a help button which opens the documentation for the menu.
+
 Bugfixes
 ########
 

--- a/docs/source/tutorials/mantid_basic_course/loading_and_displaying_data/06_formatting_plots.rst
+++ b/docs/source/tutorials/mantid_basic_course/loading_and_displaying_data/06_formatting_plots.rst
@@ -46,6 +46,8 @@ Click Menus
 |FigureOptionsGear.png| ptions Menu
 ===================================
 
+1D plots
+--------
 
 .. figure:: /images/PlotOptions.png
    :alt: Plot Options Axes Legend
@@ -60,6 +62,9 @@ Click Menus
 .. figure:: /images/PlotOptionsCurves.png
    :alt: Plot Options Axes Legend
    :align: center
+
+Image Plots
+-----------
 
 .. figure:: /images/PlotOptionsColorfill.png
    :alt: Plot Options Colorfill

--- a/qt/python/mantidqt/widgets/plotconfigdialog/plot_config_dialog.ui
+++ b/qt/python/mantidqt/widgets/plotconfigdialog/plot_config_dialog.ui
@@ -27,6 +27,25 @@
      <item>
       <layout class="QHBoxLayout" name="horizontalLayout">
        <item>
+        <widget class="QPushButton" name="help_button">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="maximumSize">
+          <size>
+           <width>30</width>
+           <height>30</height>
+          </size>
+         </property>
+         <property name="text">
+          <string>?</string>
+         </property>
+        </widget>
+       </item>
+       <item>
         <spacer name="horizontalSpacer">
          <property name="orientation">
           <enum>Qt::Horizontal</enum>

--- a/qt/python/mantidqt/widgets/plotconfigdialog/presenter.py
+++ b/qt/python/mantidqt/widgets/plotconfigdialog/presenter.py
@@ -14,6 +14,9 @@ from mantidqt.widgets.plotconfigdialog.curvestabwidget.presenter import CurvesTa
 from mantidqt.widgets.plotconfigdialog.imagestabwidget.presenter import ImagesTabWidgetPresenter
 from mantidqt.widgets.plotconfigdialog.legendtabwidget.presenter import LegendTabWidgetPresenter
 
+HELP_URL = 'qthelp://org.mantidproject/doc/tutorials/mantid_basic_course/loading_and_displaying_data/' \
+           '06_formatting_plots.html'
+
 
 class PlotConfigDialogPresenter:
 
@@ -76,6 +79,9 @@ class PlotConfigDialogPresenter:
         self.view.close()
 
     def open_help_window(self):
-        InterfaceManager().showHelpPage('qthelp://org.mantidproject/doc/tutorials/mantid_basic_course/'
-                                        'loading_and_displaying_data/'
-                                        '06_formatting_plots.html#figureoptionsgear-png-ptions-menu')
+        # Show the help documentation relevant to the plot type.
+        if self.tab_widget_presenters[3] is not None:
+            # If the dialog has the images tab then go to the section on image plots.
+            InterfaceManager().showHelpPage(HELP_URL + '#image-plots')
+        else:
+            InterfaceManager().showHelpPage(HELP_URL + '#figureoptionsgear-png-ptions-menu')

--- a/qt/python/mantidqt/widgets/plotconfigdialog/presenter.py
+++ b/qt/python/mantidqt/widgets/plotconfigdialog/presenter.py
@@ -6,6 +6,7 @@
 # SPDX - License - Identifier: GPL - 3.0 +
 #  This file is part of the mantid workbench.
 
+from mantidqt.interfacemanager import InterfaceManager
 from mantidqt.widgets.plotconfigdialog import curve_in_figure, image_in_figure, legend_in_figure
 from mantidqt.widgets.plotconfigdialog.view import PlotConfigDialogView
 from mantidqt.widgets.plotconfigdialog.axestabwidget.presenter import AxesTabWidgetPresenter
@@ -54,6 +55,7 @@ class PlotConfigDialogPresenter:
         self.view.ok_button.clicked.connect(self.apply_properties_and_exit)
         self.view.apply_button.clicked.connect(self.apply_properties)
         self.view.cancel_button.clicked.connect(self.exit)
+        self.view.help_button.clicked.connect(self.open_help_window)
 
     def _add_tab_widget_views(self):
         for tab_view in self.tab_widget_views:
@@ -72,3 +74,8 @@ class PlotConfigDialogPresenter:
 
     def exit(self):
         self.view.close()
+
+    def open_help_window(self):
+        InterfaceManager().showHelpPage('qthelp://org.mantidproject/doc/tutorials/mantid_basic_course/'
+                                        'loading_and_displaying_data/'
+                                        '06_formatting_plots.html#figureoptionsgear-png-ptions-menu')

--- a/qt/python/mantidqt/widgets/plotconfigdialog/view.py
+++ b/qt/python/mantidqt/widgets/plotconfigdialog/view.py
@@ -20,7 +20,7 @@ class PlotConfigDialogView(QDialog):
 
         self.ui = load_ui(__file__, 'plot_config_dialog.ui', baseinstance=self)
         self.setWindowIcon(QIcon(':/images/MantidIcon.ico'))
-        self.setModal(True)
+        self.setWindowModality(Qt.WindowModal)
         self.setAttribute(Qt.WA_DeleteOnClose, True)
 
     def add_tab_widget(self, tab_widget):


### PR DESCRIPTION
**Description of work.**
This PR adds a `?` button to the plot figure options which opens the help window at this page: https://docs.mantidproject.org/nightly/tutorials/mantid_basic_course/loading_and_displaying_data/06_formatting_plots.html#figureoptionsgear-png-ptions-menu

**To test:**
Build docs-qthelp.
In Workbench make a plot.
Open figure options.
Check that the help button is visible and it opens the help window with the correct page.


Fixes #28603 

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
