### PR TITLE
Fix typo that replaced DIFA value with DIFC value from fit

### DIFF
--- a/scripts/Engineering/gui/engineering_diffraction/tabs/calibration/model.py
+++ b/scripts/Engineering/gui/engineering_diffraction/tabs/calibration/model.py
@@ -80,7 +80,7 @@ class CalibrationModel(object):
                 self._plot_tof_fit_single_bank_or_custom(bank)
             else:
                 self._plot_tof_fit_single_bank_or_custom("cropped")
-        difa = [i.DIFC for i in output]
+        difa = [i.DIFA for i in output]
         difc = [i.DIFC for i in output]
         tzero = [i.TZERO for i in output]
 


### PR DESCRIPTION
**Description of work.**
Fix typo to overwrote DIFA with DIFC parameter in model of Eng Diff calibration tab

**To test:**
Small typo but a test could be run as so

1) Interfaces -> Diffraction -> Engineering Diffraction
2) Create a Calibration V#: 307521 S#: 305738
3) Check DIFA and DIFC in calibration table


<!-- Instructions for testing. -->

*There is no associated issue.*

*This does not require release notes* because small typo not reported by user/scientist

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
