### PR TITLE
Fix bug in MonteCarloAbsorption where spectra have diff wavelength ranges

### DIFF
--- a/Framework/Algorithms/src/MonteCarloAbsorption.cpp
+++ b/Framework/Algorithms/src/MonteCarloAbsorption.cpp
@@ -307,11 +307,11 @@ MatrixWorkspace_uptr MonteCarloAbsorption::doSimulation(
 
     for (size_t j = 0; j < packedLambdas.size(); j++) {
       simulationWS.getSpectrum(i)
-          .dataY()[simulationWS.yIndexOfX(packedLambdas[j])] =
+          .dataY()[simulationWS.yIndexOfX(packedLambdas[j], i)] =
           packedAttFactors[j];
 
       simulationWS.getSpectrum(i)
-          .dataE()[simulationWS.yIndexOfX(packedLambdas[j])] =
+          .dataE()[simulationWS.yIndexOfX(packedLambdas[j], i)] =
           packedAttFactorErrors[j];
     }
 


### PR DESCRIPTION
**Description of work.**

If the input workspaces has spectra that have a wider wavelength range than the first
spectrum in the workspace the absorption correction calculation failed with an error:
MatrixWorkspace::yIndexOfX - X value is greater than the highest in the current range

I've fixed this and have also added a unit test that runs the calculation with an
input workspace featuring this kind of variation in the wavelength ranges.
In the existing tests the spectra all had the same x range because they were really
TOF spectra that had been relabelled wavelength

**To test:**

Run the following script. Following the fix the call to MonteCarloAbsorption will succeed. The PEARL data file is part of the Mantid testing data:

```
# import mantid algorithms, numpy and matplotlib
from mantid.simpleapi import *
import matplotlib.pyplot as plt
import numpy as np

from mantid.simpleapi import (ConvertUnits, Load, LoadSampleShape, MonteCarloAbsorption, SetSample, CreateGroupingWorkspace, GroupDetectors)

# Grab some data. This happens to be a run with a 10mm vanadium sphere

# select spectra for detector ids 1040, 2040, 3040, 4040, 5040, 6040, 7040, 8040, 9040
sample_env_mesh = Load(Filename='PEARL00073987.raw', SpectrumMin='14',SpectrumMax=’672’)

# MonteCarloAbsorption requires an input ws with x units of wavelength - this determines
# which wavelengths to calculate the absorption correction for
sample_env_mesh = ConvertUnits(InputWorkspace=sample_env_mesh, Target='Wavelength')

SetSample(InputWorkspace=sample_env_mesh, Environment={'Name':'Pearl','Container':'Gasket_inner'},Material={'ChemicalFormula': 'Ni'})

sample_env_mesh_abscorr = MonteCarloAbsorption(InputWorkspace=sample_env_mesh, EventsPerPoint=100)
```

Fixes #28777.

*This does not require release notes* because the bug was introduced since the 5.0 release (in PR #27828)

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
