### PR TITLE
Make workbench progress bars display the time remaining for slow algs

### DIFF
--- a/Framework/API/inc/MantidAPI/AlgorithmObserver.h
+++ b/Framework/API/inc/MantidAPI/AlgorithmObserver.h
@@ -38,7 +38,8 @@ public:
   void stopObservingManager();
 
   virtual void progressHandle(const IAlgorithm *alg, double p,
-                              const std::string &msg);
+                              const std::string &msg, const double estimatedTime,
+                              const int progressPrecision);
   virtual void startingHandle(IAlgorithm_sptr alg);
   virtual void startHandle(const IAlgorithm *alg);
   virtual void finishHandle(const IAlgorithm *alg);

--- a/Framework/API/inc/MantidAPI/AlgorithmObserver.h
+++ b/Framework/API/inc/MantidAPI/AlgorithmObserver.h
@@ -38,7 +38,8 @@ public:
   void stopObservingManager();
 
   virtual void progressHandle(const IAlgorithm *alg, double p,
-                              const std::string &msg, const double estimatedTime,
+                              const std::string &msg,
+                              const double estimatedTime,
                               const int progressPrecision);
   virtual void startingHandle(IAlgorithm_sptr alg);
   virtual void startHandle(const IAlgorithm *alg);

--- a/Framework/API/src/AlgorithmObserver.cpp
+++ b/Framework/API/src/AlgorithmObserver.cpp
@@ -116,12 +116,18 @@ The default handler is provided (doing nothing).
 @param alg :: Pointer to the algorithm sending the notification.
 @param p :: Progress reported by the algorithm, 0 <= p <= 1
 @param msg :: Optional message string sent by the algorithm
+@param estimatedTime :: estimated time to completion in seconds
+@param progressPrecision :: number of digits after the decimal
 */
 void AlgorithmObserver::progressHandle(const IAlgorithm *alg, double p,
-                                       const std::string &msg) {
+                                       const std::string &msg,
+                                       const double estimatedTime,
+                                       const int progressPrecision) {
   UNUSED_ARG(alg)
   UNUSED_ARG(p)
   UNUSED_ARG(msg)
+  UNUSED_ARG(estimatedTime)
+  UNUSED_ARG(progressPrecision)
 }
 
 /** Handler of the start notifications. Must be overriden in inherited classes.
@@ -159,7 +165,8 @@ void AlgorithmObserver::errorHandle(const IAlgorithm *alg,
 */
 void AlgorithmObserver::_progressHandle(
     const Poco::AutoPtr<Algorithm::ProgressNotification> &pNf) {
-  this->progressHandle(pNf->algorithm(), pNf->progress, pNf->message);
+  this->progressHandle(pNf->algorithm(), pNf->progress, pNf->message,
+    pNf->estimatedTime, pNf->progressPrecision);
 }
 
 /** Poco notification handler for Algorithm::StartedNotification.

--- a/Framework/API/src/AlgorithmObserver.cpp
+++ b/Framework/API/src/AlgorithmObserver.cpp
@@ -166,7 +166,7 @@ void AlgorithmObserver::errorHandle(const IAlgorithm *alg,
 void AlgorithmObserver::_progressHandle(
     const Poco::AutoPtr<Algorithm::ProgressNotification> &pNf) {
   this->progressHandle(pNf->algorithm(), pNf->progress, pNf->message,
-    pNf->estimatedTime, pNf->progressPrecision);
+                       pNf->estimatedTime, pNf->progressPrecision);
 }
 
 /** Poco notification handler for Algorithm::StartedNotification.

--- a/Framework/Algorithms/src/Pause.cpp
+++ b/Framework/Algorithms/src/Pause.cpp
@@ -41,7 +41,7 @@ void Pause::init() {
  */
 void Pause::exec() {
   DateAndTime startTime = DateAndTime::getCurrentTime();
-  double Duration = getProperty("Duration");
+  const double duration = getProperty("Duration");
 
   // Keep going until you get cancelled
   while (true) {
@@ -63,12 +63,12 @@ void Pause::exec() {
     DateAndTime now = DateAndTime::getCurrentTime();
     double seconds = DateAndTime::secondsFromDuration(now - startTime);
 
-    if (Duration > 0) {
+    if (duration > 0) {
       // Break when you've waited long enough
-      if (seconds > Duration)
+      if (seconds > duration)
         break;
       // Report progress for non-infinite runs
-      this->progress(seconds / Duration);
+      this->progress(seconds / duration,"",duration - seconds);
     }
   }
 }

--- a/Framework/Algorithms/src/Pause.cpp
+++ b/Framework/Algorithms/src/Pause.cpp
@@ -68,7 +68,7 @@ void Pause::exec() {
       if (seconds > duration)
         break;
       // Report progress for non-infinite runs
-      this->progress(seconds / duration,"",duration - seconds);
+      this->progress(seconds / duration, "", duration - seconds);
     }
   }
 }

--- a/Framework/PythonInterface/mantid/api/inc/MantidPythonInterface/api/Algorithms/AlgorithmObserverAdapter.h
+++ b/Framework/PythonInterface/mantid/api/inc/MantidPythonInterface/api/Algorithms/AlgorithmObserverAdapter.h
@@ -26,7 +26,8 @@ public:
   AlgorithmObserverAdapter &
   operator=(const AlgorithmObserverAdapter &) = delete;
   void progressHandle(const API::IAlgorithm *alg, double p,
-                      const std::string &msg) override;
+                      const std::string &msg, const double estimatedTime,
+                      const int progressPrecision) override;
   void startingHandle(API::IAlgorithm_sptr alg) override;
   void finishHandle(const API::IAlgorithm *alg) override;
   void errorHandle(const API::IAlgorithm *alg,

--- a/Framework/PythonInterface/mantid/api/src/Algorithms/AlgorithmObserverAdapter.cpp
+++ b/Framework/PythonInterface/mantid/api/src/Algorithms/AlgorithmObserverAdapter.cpp
@@ -23,7 +23,7 @@ void AlgorithmObserverAdapter::progressHandle(const API::IAlgorithm *alg,
   UNUSED_ARG(estimatedTime)
   UNUSED_ARG(progressPrecision)
   // This method is explicitly not implemented.
-  // There are so many progress calls that apssing these across the C++/Python
+  // There are so many progress calls that passing these across the C++/Python
   // boundary is too expensive and can slow down Mantid by up to an order of
   // magnitude
   return;

--- a/Framework/PythonInterface/mantid/api/src/Algorithms/AlgorithmObserverAdapter.cpp
+++ b/Framework/PythonInterface/mantid/api/src/Algorithms/AlgorithmObserverAdapter.cpp
@@ -18,6 +18,7 @@ void AlgorithmObserverAdapter::progressHandle(const API::IAlgorithm *alg,
                                               const double estimatedTime,
                                               const int progressPrecision) {
   UNUSED_ARG(alg)
+  UNUSED_ARG(p)
   UNUSED_ARG(msg)
   UNUSED_ARG(estimatedTime)
   UNUSED_ARG(progressPrecision)

--- a/Framework/PythonInterface/mantid/api/src/Algorithms/AlgorithmObserverAdapter.cpp
+++ b/Framework/PythonInterface/mantid/api/src/Algorithms/AlgorithmObserverAdapter.cpp
@@ -15,10 +15,13 @@ AlgorithmObserverAdapter::AlgorithmObserverAdapter(PyObject *self)
 
 void AlgorithmObserverAdapter::progressHandle(const API::IAlgorithm *alg,
                                               double p,
-                                              const std::string &msg) {
+                                              const std::string &msg,
+                                              const double estimatedTime,
+                                              const int progressPrecision) {
   UNUSED_ARG(alg)
   try {
-    return callMethod<void>(getSelf(), "progressHandle", p, msg);
+    return callMethod<void>(getSelf(), "progressHandle", p, msg, estimatedTime,
+                            progressPrecision);
   } catch (UndefinedAttributeError &) {
     return;
   }

--- a/Framework/PythonInterface/mantid/api/src/Algorithms/AlgorithmObserverAdapter.cpp
+++ b/Framework/PythonInterface/mantid/api/src/Algorithms/AlgorithmObserverAdapter.cpp
@@ -18,12 +18,14 @@ void AlgorithmObserverAdapter::progressHandle(const API::IAlgorithm *alg,
                                               const double estimatedTime,
                                               const int progressPrecision) {
   UNUSED_ARG(alg)
-  try {
-    return callMethod<void>(getSelf(), "progressHandle", p, msg, estimatedTime,
-                            progressPrecision);
-  } catch (UndefinedAttributeError &) {
-    return;
-  }
+  UNUSED_ARG(msg)
+  UNUSED_ARG(estimatedTime)
+  UNUSED_ARG(progressPrecision)
+  // This method is explicitly not implemented.
+  // There are so many progress calls that apssing these across the C++/Python
+  // boundary is too expensive and can slow down Mantid by up to an order of
+  // magnitude
+  return;
 }
 
 void AlgorithmObserverAdapter::startingHandle(API::IAlgorithm_sptr alg) {

--- a/Framework/PythonInterface/mantid/api/src/Algorithms/AlgorithmObserverAdapter.cpp
+++ b/Framework/PythonInterface/mantid/api/src/Algorithms/AlgorithmObserverAdapter.cpp
@@ -14,8 +14,7 @@ AlgorithmObserverAdapter::AlgorithmObserverAdapter(PyObject *self)
     : API::AlgorithmObserver(), m_self(self) {}
 
 void AlgorithmObserverAdapter::progressHandle(const API::IAlgorithm *alg,
-                                              double p,
-                                              const std::string &msg,
+                                              double p, const std::string &msg,
                                               const double estimatedTime,
                                               const int progressPrecision) {
   UNUSED_ARG(alg)

--- a/Framework/PythonInterface/mantid/api/src/Exports/AlgorithmObserver.cpp
+++ b/Framework/PythonInterface/mantid/api/src/Exports/AlgorithmObserver.cpp
@@ -24,12 +24,6 @@ void observeError(AlgorithmObserver &self, const boost::python::object &alg) {
   self.observeError(calg);
 }
 
-void observeProgress(AlgorithmObserver &self,
-                     const boost::python::object &alg) {
-  IAlgorithm_sptr &calg = boost::python::extract<IAlgorithm_sptr &>(alg);
-  self.observeProgress(calg);
-}
-
 void stopObserving(AlgorithmObserver &self, const boost::python::object &alg) {
   IAlgorithm_sptr &calg = boost::python::extract<IAlgorithm_sptr &>(alg);
   self.stopObserving(calg);
@@ -51,8 +45,6 @@ void export_algorithm_observer() {
            "Observe algorithm for its finish notification.")
       .def("observeError", &observeError, (arg("self"), arg("alg")),
            "Observe algorithm for its error notification.")
-      .def("observeProgress", &observeProgress, (arg("self"), arg("alg")),
-           "Observe algorithm for its progress notification.")
       .def("stopObserving", &stopObserving, (arg("self"), arg("alg")),
            "Remove all observers from the algorithm.");
 }

--- a/docs/source/release/v5.1.0/mantidworkbench.rst
+++ b/docs/source/release/v5.1.0/mantidworkbench.rst
@@ -42,6 +42,7 @@ Improvements
 - Surface plots no longer spill over the axes when their limits are reduced.
 - The instrument view now ignores non-finite (infinity and NaN) values and should now display workspaces containing those values.
 - The gray and plasma colormaps have been added to the instrument view.
+- Slow running algorithms will now display an estimated time to completion in their progress bars.
 - The x-axis tick labels on colorfill plots are now horizontal.
 
 Bugfixes

--- a/qt/python/mantidqt/test/test_algorithm_observer.py
+++ b/qt/python/mantidqt/test/test_algorithm_observer.py
@@ -45,14 +45,6 @@ class MockObserver(AlgorithmObserver):
     def errorHandle(self, message):
         self.error_message = message
 
-    def progressHandle(self, p, message, estimated_time, progress_precision):
-        if len(message) > 0:
-            self.progress_message = message
-        if p == 0.5:
-            self.first_progress_reported = True
-        if p == 1.0:
-            self.second_progress_reported = True
-
 
 class MockObserverStarting(AlgorithmObserver):
 
@@ -90,12 +82,3 @@ class TestAlgorithmObserver(unittest.TestCase):
         algorithm.execute()
         self.assertTrue(observer.finish_handled)
         self.assertTrue(observer.error_message.startswith('Error in algorithm'))
-
-    def test_progress_handle(self):
-        algorithm = AlgorithmManager.create("MockAlgorithm", -1)
-        observer = MockObserver()
-        observer.observeProgress(algorithm)
-        algorithm.execute()
-        self.assertTrue(observer.first_progress_reported)
-        self.assertTrue(observer.second_progress_reported)
-        self.assertEqual(observer.progress_message, 'Half way')

--- a/qt/python/mantidqt/test/test_algorithm_observer.py
+++ b/qt/python/mantidqt/test/test_algorithm_observer.py
@@ -45,7 +45,7 @@ class MockObserver(AlgorithmObserver):
     def errorHandle(self, message):
         self.error_message = message
 
-    def progressHandle(self, p, message):
+    def progressHandle(self, p, message, estimated_time, progress_precision):
         if len(message) > 0:
             self.progress_message = message
         if p == 0.5:

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/AlgorithmProgress/AlgorithmProgressDialogPresenter.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/AlgorithmProgress/AlgorithmProgressDialogPresenter.h
@@ -36,8 +36,9 @@ public:
                                    AlgorithmProgressModel &model);
 
   void algorithmStartedSlot(Mantid::API::AlgorithmID) override;
-  void updateProgressBarSlot(Mantid::API::AlgorithmID, double progress,
-                             QString message) override;
+  void updateProgressBarSlot(Mantid::API::AlgorithmID, const double progress,
+                             const QString message, const double estimatedTime,
+                             const int progressPrecision) override;
   void algorithmEndedSlot(Mantid::API::AlgorithmID) override;
   size_t getNumberTrackedAlgorithms();
 

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/AlgorithmProgress/AlgorithmProgressModel.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/AlgorithmProgress/AlgorithmProgressModel.h
@@ -49,7 +49,8 @@ public:
   void finishHandle(const Mantid::API::IAlgorithm *alg) override;
   /// Triggered when the algorithm reports progress
   void progressHandle(const Mantid::API::IAlgorithm *alg, double progress,
-                      const std::string &message) override;
+                      const std::string &message, const double estimatedTime,
+                      const int progressPrecision) override;
   /// Triggered when the algorithm encounters an error
   void errorHandle(const Mantid::API::IAlgorithm *alg,
                    const std::string &what) override;

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/AlgorithmProgress/AlgorithmProgressPresenter.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/AlgorithmProgress/AlgorithmProgressPresenter.h
@@ -41,8 +41,8 @@ public:
   AlgorithmProgressPresenter(QWidget *parent, IAlgorithmProgressWidget *);
 
   void algorithmStartedSlot(Mantid::API::AlgorithmID) override;
-  void updateProgressBarSlot(Mantid::API::AlgorithmID, double progress,
-                             QString message) override;
+  void updateProgressBarSlot(Mantid::API::AlgorithmID, const double,
+                             const QString, const double, const int) override;
   void algorithmEndedSlot(Mantid::API::AlgorithmID) override;
 
   AlgorithmProgressModel &model() { return m_model; }

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/AlgorithmProgress/AlgorithmProgressPresenterBase.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/AlgorithmProgress/AlgorithmProgressPresenterBase.h
@@ -41,19 +41,24 @@ public:
   void algorithmEnded(Mantid::API::AlgorithmID);
   /// Signals to the presenters that there has been progress in one of the
   /// algorithms
-  void updateProgressBar(Mantid::API::AlgorithmID, double, const std::string &);
+  void updateProgressBar(Mantid::API::AlgorithmID, double,
+                         const std::string &, const double estimatedTime,
+                         const int progressPrecision);
   /// Sets the parameter progress bar to show the progress and message
-  void setProgressBar(QProgressBar *, double, const QString &);
+  void setProgressBar(QProgressBar *, const double, const QString &,
+                      const double, const int);
 
   virtual void algorithmStartedSlot(Mantid::API::AlgorithmID) = 0;
-  virtual void updateProgressBarSlot(Mantid::API::AlgorithmID, double,
-                                     QString) = 0;
+  virtual void updateProgressBarSlot(Mantid::API::AlgorithmID, const double, const QString,
+                                     const double,
+                                     const int) = 0;
   virtual void algorithmEndedSlot(Mantid::API::AlgorithmID) = 0;
 
 signals:
   void algorithmStartedSignal(Mantid::API::AlgorithmID);
   void updateProgressBarSignal(Mantid::API::AlgorithmID, double progress,
-                               QString message);
+                               QString message, double estimatedTime,
+                               int progressPrecision);
   void algorithmEndedSignal(Mantid::API::AlgorithmID);
 };
 } // namespace MantidWidgets

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/AlgorithmProgress/AlgorithmProgressPresenterBase.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/AlgorithmProgress/AlgorithmProgressPresenterBase.h
@@ -41,16 +41,16 @@ public:
   void algorithmEnded(Mantid::API::AlgorithmID);
   /// Signals to the presenters that there has been progress in one of the
   /// algorithms
-  void updateProgressBar(Mantid::API::AlgorithmID, double,
-                         const std::string &, const double estimatedTime,
+  void updateProgressBar(Mantid::API::AlgorithmID, double, const std::string &,
+                         const double estimatedTime,
                          const int progressPrecision);
   /// Sets the parameter progress bar to show the progress and message
   void setProgressBar(QProgressBar *, const double, const QString &,
                       const double, const int);
 
   virtual void algorithmStartedSlot(Mantid::API::AlgorithmID) = 0;
-  virtual void updateProgressBarSlot(Mantid::API::AlgorithmID, const double, const QString,
-                                     const double,
+  virtual void updateProgressBarSlot(Mantid::API::AlgorithmID, const double,
+                                     const QString, const double,
                                      const int) = 0;
   virtual void algorithmEndedSlot(Mantid::API::AlgorithmID) = 0;
 

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/AlgorithmProgress/AlgorithmProgressWidget.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/AlgorithmProgress/AlgorithmProgressWidget.h
@@ -48,8 +48,8 @@ public:
   /// Enable or disable the processing of updates to the algorithm progress
   void blockUpdates(bool block = true);
   /// Update the progress bar
-  void updateProgress(const double progress,
-                      const QString &message, const double estimatedTime,
+  void updateProgress(const double progress, const QString &message,
+                      const double estimatedTime,
                       const int progressPrecision) override;
 
 public slots:

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/AlgorithmProgress/AlgorithmProgressWidget.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/AlgorithmProgress/AlgorithmProgressWidget.h
@@ -48,7 +48,9 @@ public:
   /// Enable or disable the processing of updates to the algorithm progress
   void blockUpdates(bool block = true);
   /// Update the progress bar
-  void updateProgress(double progress, const QString &message) override;
+  void updateProgress(const double progress,
+                      const QString &message, const double estimatedTime,
+                      const int progressPrecision) override;
 
 public slots:
   void showDetailsDialog() override;

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/AlgorithmProgress/IAlgorithmProgressWidget.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/AlgorithmProgress/IAlgorithmProgressWidget.h
@@ -16,7 +16,9 @@ public:
 
   virtual void algorithmStarted() = 0;
   virtual void algorithmEnded() = 0;
-  virtual void updateProgress(double progress, const QString &message) = 0;
+  virtual void updateProgress(const double progress, const QString &message,
+                              const double estimatedTime,
+                              const int progressPrecision) = 0;
   virtual void showDetailsDialog() = 0;
 };
 

--- a/qt/widgets/common/src/AlgorithmProgress/AlgorithmProgressDialogPresenter.cpp
+++ b/qt/widgets/common/src/AlgorithmProgress/AlgorithmProgressDialogPresenter.cpp
@@ -61,8 +61,11 @@ void AlgorithmProgressDialogPresenter::algorithmStartedSlot(
 /// @param progress The progress that the algorithm has reported
 /// @param message The message that the algorithm has reported. It can be
 /// emitted from another thread, so a copy of the message is forced
+/// @param estimatedTime :: estimated time to completion in seconds
+/// @param progressPrecision :: number of digits after the decimal
 void AlgorithmProgressDialogPresenter::updateProgressBarSlot(
-    Mantid::API::AlgorithmID alg, double progress, QString message) {
+    Mantid::API::AlgorithmID alg, const double progress, const QString message,
+    const double estimatedTime, const int progressPrecision) {
   // if the algorithm isn't contained in the progress bar tree, then pretend it
   // just started
   if (m_progressBars.count(alg) == 0) {
@@ -74,7 +77,8 @@ void AlgorithmProgressDialogPresenter::updateProgressBarSlot(
       return;
     }
   }
-  setProgressBar(m_progressBars.at(alg).second, progress, message);
+  setProgressBar(m_progressBars.at(alg).second, progress, message, estimatedTime,
+                 progressPrecision);
 }
 
 /// This slot is triggered whenever an algorithms ends. If the algorithm is not

--- a/qt/widgets/common/src/AlgorithmProgress/AlgorithmProgressDialogPresenter.cpp
+++ b/qt/widgets/common/src/AlgorithmProgress/AlgorithmProgressDialogPresenter.cpp
@@ -77,8 +77,8 @@ void AlgorithmProgressDialogPresenter::updateProgressBarSlot(
       return;
     }
   }
-  setProgressBar(m_progressBars.at(alg).second, progress, message, estimatedTime,
-                 progressPrecision);
+  setProgressBar(m_progressBars.at(alg).second, progress, message,
+                 estimatedTime, progressPrecision);
 }
 
 /// This slot is triggered whenever an algorithms ends. If the algorithm is not

--- a/qt/widgets/common/src/AlgorithmProgress/AlgorithmProgressModel.cpp
+++ b/qt/widgets/common/src/AlgorithmProgress/AlgorithmProgressModel.cpp
@@ -56,14 +56,19 @@ void AlgorithmProgressModel::startHandle(const Mantid::API::IAlgorithm *alg) {
 /// @param alg The algorithm that has reported progress
 /// @param progress The progress that the algorithm is currently at
 /// @param message The message that the progress bar should display
+/// @param estimatedTime :: estimated time to completion in seconds
+/// @param progressPrecision :: number of digits after the decimal
 void AlgorithmProgressModel::progressHandle(const Mantid::API::IAlgorithm *alg,
                                             const double progress,
-                                            const std::string &message) {
+                                            const std::string &message,
+                                            const double estimatedTime,
+                                            const int progressPrecision) {
   m_mainWindowPresenter->updateProgressBar(alg->getAlgorithmID(), progress,
-                                           message);
+                                           message, estimatedTime, progressPrecision);
   if (m_dialogPresenter) {
     m_dialogPresenter->updateProgressBar(alg->getAlgorithmID(), progress,
-                                         message);
+                                         message, estimatedTime,
+                                         progressPrecision);
   }
 }
 /// This handle is triggered when the algorithm finishes. It will notify

--- a/qt/widgets/common/src/AlgorithmProgress/AlgorithmProgressModel.cpp
+++ b/qt/widgets/common/src/AlgorithmProgress/AlgorithmProgressModel.cpp
@@ -64,7 +64,8 @@ void AlgorithmProgressModel::progressHandle(const Mantid::API::IAlgorithm *alg,
                                             const double estimatedTime,
                                             const int progressPrecision) {
   m_mainWindowPresenter->updateProgressBar(alg->getAlgorithmID(), progress,
-                                           message, estimatedTime, progressPrecision);
+                                           message, estimatedTime,
+                                           progressPrecision);
   if (m_dialogPresenter) {
     m_dialogPresenter->updateProgressBar(alg->getAlgorithmID(), progress,
                                          message, estimatedTime,

--- a/qt/widgets/common/src/AlgorithmProgress/AlgorithmProgressPresenter.cpp
+++ b/qt/widgets/common/src/AlgorithmProgress/AlgorithmProgressPresenter.cpp
@@ -43,9 +43,12 @@ void AlgorithmProgressPresenter::algorithmEndedSlot(
 /// @param progress The progress that the algorithm has reported
 /// @param message The message that the algorithm has reported. It can be
 /// emitted from another thread, so a copy of the message is forced
+/// @param estimatedTime :: estimated time to completion in seconds
+/// @param progressPrecision :: number of digits after the decimal
 void AlgorithmProgressPresenter::updateProgressBarSlot(
     Mantid::API::AlgorithmID algorithm, const double progress,
-    QString message) {
+    const QString message, const double estimatedTime,
+    const int progressPrecision) {
   if (algorithm == this->m_algorithm) {
     // this needs to be a call to the view
     // so that it can be mocked out for testing
@@ -53,7 +56,8 @@ void AlgorithmProgressPresenter::updateProgressBarSlot(
     float timeInterval = m_timer.elapsed_no_reset();
     if (timeInterval > maxRefreshInterval) {
       m_timer.reset();
-      m_view->updateProgress(progress, message);
+      m_view->updateProgress(progress, message, estimatedTime,
+                             progressPrecision);
     }
   }
 }

--- a/qt/widgets/common/src/AlgorithmProgress/AlgorithmProgressPresenterBase.cpp
+++ b/qt/widgets/common/src/AlgorithmProgress/AlgorithmProgressPresenterBase.cpp
@@ -47,10 +47,9 @@ void AlgorithmProgressPresenterBase::algorithmEnded(
 /// already have been copied into the GUI thread, so it is safe to receive it by
 /// @param estimatedTime :: estimated time to completion in seconds
 /// @param progressPrecision :: number of digits after the decimal
-void AlgorithmProgressPresenterBase::setProgressBar(QProgressBar *progressBar,
-                                                    const double progress,
-                                                    const QString &message, const double estimatedTime,
-                                                    const int progressPrecision) {
+void AlgorithmProgressPresenterBase::setProgressBar(
+    QProgressBar *progressBar, const double progress, const QString &message,
+    const double estimatedTime, const int progressPrecision) {
   progressBar->setValue(static_cast<int>(progress * 100));
   // Make the progress string
   std::ostringstream mess;
@@ -77,7 +76,6 @@ void AlgorithmProgressPresenterBase::setProgressBar(QProgressBar *progressBar,
   }
   QString formatStr = QString::fromStdString(mess.str());
   progressBar->setFormat(formatStr);
-
 }
 /// This function is called whenever an algorithm reports progress. It emits a
 /// signal triggering the slot inside the GUI thread. It is safe to call this
@@ -86,11 +84,10 @@ void AlgorithmProgressPresenterBase::setProgressBar(QProgressBar *progressBar,
 /// @param progress The progress that the algorithm has reported
 /// @param msg The message that the algorithm has sent
 void AlgorithmProgressPresenterBase::updateProgressBar(
-    Mantid::API::AlgorithmID alg, double progress,
-    const std::string &msg, const double estimatedTime,
-    const int progressPrecision) {
-  emit updateProgressBarSignal(alg, progress, QString::fromStdString(msg), 
-    estimatedTime, progressPrecision);
+    Mantid::API::AlgorithmID alg, double progress, const std::string &msg,
+    const double estimatedTime, const int progressPrecision) {
+  emit updateProgressBarSignal(alg, progress, QString::fromStdString(msg),
+                               estimatedTime, progressPrecision);
 }
 } // namespace MantidWidgets
 } // namespace MantidQt

--- a/qt/widgets/common/src/AlgorithmProgress/AlgorithmProgressPresenterBase.cpp
+++ b/qt/widgets/common/src/AlgorithmProgress/AlgorithmProgressPresenterBase.cpp
@@ -83,6 +83,8 @@ void AlgorithmProgressPresenterBase::setProgressBar(
 /// @param alg The ID of the algorithm that has started executing
 /// @param progress The progress that the algorithm has reported
 /// @param msg The message that the algorithm has sent
+/// @param estimatedTime :: estimated time to completion in seconds
+/// @param progressPrecision :: number of digits after the decimal
 void AlgorithmProgressPresenterBase::updateProgressBar(
     Mantid::API::AlgorithmID alg, double progress, const std::string &msg,
     const double estimatedTime, const int progressPrecision) {

--- a/qt/widgets/common/src/AlgorithmProgress/AlgorithmProgressPresenterBase.cpp
+++ b/qt/widgets/common/src/AlgorithmProgress/AlgorithmProgressPresenterBase.cpp
@@ -45,19 +45,39 @@ void AlgorithmProgressPresenterBase::algorithmEnded(
 /// @param progress The progress that an algorithm has reported
 /// @param message The message that an algorithm has sent. The object will
 /// already have been copied into the GUI thread, so it is safe to receive it by
-/// const ref
+/// @param estimatedTime :: estimated time to completion in seconds
+/// @param progressPrecision :: number of digits after the decimal
 void AlgorithmProgressPresenterBase::setProgressBar(QProgressBar *progressBar,
-                                                    double progress,
-                                                    const QString &message) {
+                                                    const double progress,
+                                                    const QString &message, const double estimatedTime,
+                                                    const int progressPrecision) {
   progressBar->setValue(static_cast<int>(progress * 100));
-
-  // If the progress reporter has sent a message, format the bar to display that
-  // as well as the % done
+  // Make the progress string
+  std::ostringstream mess;
   if (!message.isEmpty()) {
-    progressBar->setFormat(QString("%1 - %2").arg(message, "%p%"));
-  } else {
-    progressBar->setFormat("%p%");
+    mess << message.toStdString() << " ";
   }
+  mess.precision(progressPrecision);
+  mess << std::fixed << progress * 100 << "%";
+  if (estimatedTime > 0.5) {
+    mess.precision(0);
+    mess << " (~";
+    if (estimatedTime < 60)
+      mess << static_cast<int>(estimatedTime) << "s";
+    else if (estimatedTime < 60 * 60) {
+      int min = static_cast<int>(estimatedTime / 60);
+      int sec = static_cast<int>(estimatedTime - min * 60);
+      mess << min << "m" << std::setfill('0') << std::setw(2) << sec << "s";
+    } else {
+      int hours = static_cast<int>(estimatedTime / 3600);
+      int min = static_cast<int>((estimatedTime - hours * 3600) / 60);
+      mess << hours << "h" << std::setfill('0') << std::setw(2) << min << "m";
+    }
+    mess << ")";
+  }
+  QString formatStr = QString::fromStdString(mess.str());
+  progressBar->setFormat(formatStr);
+
 }
 /// This function is called whenever an algorithm reports progress. It emits a
 /// signal triggering the slot inside the GUI thread. It is safe to call this
@@ -66,8 +86,11 @@ void AlgorithmProgressPresenterBase::setProgressBar(QProgressBar *progressBar,
 /// @param progress The progress that the algorithm has reported
 /// @param msg The message that the algorithm has sent
 void AlgorithmProgressPresenterBase::updateProgressBar(
-    Mantid::API::AlgorithmID alg, double progress, const std::string &msg) {
-  emit updateProgressBarSignal(alg, progress, QString::fromStdString(msg));
+    Mantid::API::AlgorithmID alg, double progress,
+    const std::string &msg, const double estimatedTime,
+    const int progressPrecision) {
+  emit updateProgressBarSignal(alg, progress, QString::fromStdString(msg), 
+    estimatedTime, progressPrecision);
 }
 } // namespace MantidWidgets
 } // namespace MantidQt

--- a/qt/widgets/common/src/AlgorithmProgress/AlgorithmProgressWidget.cpp
+++ b/qt/widgets/common/src/AlgorithmProgress/AlgorithmProgressWidget.cpp
@@ -55,9 +55,11 @@ void AlgorithmProgressWidget::showDetailsDialog() {
   }
 }
 
-void AlgorithmProgressWidget::updateProgress(double progress,
-                                             const QString &message) {
-  m_presenter->setProgressBar(m_progressBar, progress, message);
+void AlgorithmProgressWidget::updateProgress(const double progress, const QString &message, const double estimatedTime,
+    const int progressPrecision) {
+  m_presenter->setProgressBar(m_progressBar, progress,
+                              message, estimatedTime,
+                               progressPrecision);
 }
 
 void AlgorithmProgressWidget::blockUpdates(bool block) {

--- a/qt/widgets/common/src/AlgorithmProgress/AlgorithmProgressWidget.cpp
+++ b/qt/widgets/common/src/AlgorithmProgress/AlgorithmProgressWidget.cpp
@@ -55,11 +55,12 @@ void AlgorithmProgressWidget::showDetailsDialog() {
   }
 }
 
-void AlgorithmProgressWidget::updateProgress(const double progress, const QString &message, const double estimatedTime,
-    const int progressPrecision) {
-  m_presenter->setProgressBar(m_progressBar, progress,
-                              message, estimatedTime,
-                               progressPrecision);
+void AlgorithmProgressWidget::updateProgress(const double progress,
+                                             const QString &message,
+                                             const double estimatedTime,
+                                             const int progressPrecision) {
+  m_presenter->setProgressBar(m_progressBar, progress, message, estimatedTime,
+                              progressPrecision);
 }
 
 void AlgorithmProgressWidget::blockUpdates(bool block) {

--- a/qt/widgets/common/test/AlgorithmProgress/AlgorithmProgressDialogPresenterTest.h
+++ b/qt/widgets/common/test/AlgorithmProgress/AlgorithmProgressDialogPresenterTest.h
@@ -60,7 +60,7 @@ public:
     EXPECT_CALL(*mainProgressBar.get(), algorithmStarted()).Times(1);
     for (const auto prog : {0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1.0}) {
       EXPECT_CALL(*mainProgressBar.get(),
-          updateProgress(DoubleEq(prog), emptyQString, 0.0, 0));
+                  updateProgress(DoubleEq(prog), emptyQString, 0.0, 0));
     }
     EXPECT_CALL(*mainProgressBar.get(), algorithmEnded()).Times(1);
     // End of assertions for the main progress bar

--- a/qt/widgets/common/test/AlgorithmProgress/AlgorithmProgressDialogPresenterTest.h
+++ b/qt/widgets/common/test/AlgorithmProgress/AlgorithmProgressDialogPresenterTest.h
@@ -60,7 +60,7 @@ public:
     EXPECT_CALL(*mainProgressBar.get(), algorithmStarted()).Times(1);
     for (const auto prog : {0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1.0}) {
       EXPECT_CALL(*mainProgressBar.get(),
-                  updateProgress(DoubleEq(prog), emptyQString));
+          updateProgress(DoubleEq(prog), emptyQString, 0.0, 0));
     }
     EXPECT_CALL(*mainProgressBar.get(), algorithmEnded()).Times(1);
     // End of assertions for the main progress bar
@@ -105,7 +105,7 @@ public:
     EXPECT_CALL(*mainProgressBar.get(), algorithmStarted()).Times(1);
     for (const auto prog : {0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1.0}) {
       EXPECT_CALL(*mainProgressBar.get(),
-                  updateProgress(DoubleEq(prog), emptyQString));
+                  updateProgress(DoubleEq(prog), emptyQString, 0.0, 0));
     }
     EXPECT_CALL(*mainProgressBar.get(), algorithmEnded()).Times(1);
     // End of assertions for the main progress bar

--- a/qt/widgets/common/test/AlgorithmProgress/AlgorithmProgressPresenterTest.h
+++ b/qt/widgets/common/test/AlgorithmProgress/AlgorithmProgressPresenterTest.h
@@ -97,33 +97,34 @@ public:
     pres->algorithmEndedSlot(secondAlgorithmID);
     TS_ASSERT(Mock::VerifyAndClearExpectations(&mockView));
   }
-
-  void testUpdateProgressBar() {
+  /*
+  TODO MUST FIX THE MOCK
+  void xtestUpdateProgressBar() {
     int testInt = 123;
     void *algorithmIDpretender = &testInt;
     EXPECT_CALL(*mockView.get(), algorithmStarted()).Times(1);
-    EXPECT_CALL(*mockView.get(), updateProgress(3.0, QString(""))).Times(1);
+    EXPECT_CALL(*mockView.get(), updateProgress(3.0, QString(""),0.,0)).Times(1);
 
     auto pres = mockView->m_presenter.get();
     pres->algorithmStartedSlot(algorithmIDpretender);
     // Algorithm reports a progress update
-    pres->updateProgressBarSlot(algorithmIDpretender, 3.0, "");
+    pres->updateProgressBarSlot(algorithmIDpretender, 3.0, "",0.,0);
     TS_ASSERT(Mock::VerifyAndClearExpectations(&mockView));
   }
-  void testUpdateProgressBar_NotUpdatedIfAlgorithmNotBeingTracked() {
+  void xtestUpdateProgressBar_NotUpdatedIfAlgorithmNotBeingTracked() {
     int testInt = 123;
     void *algorithmIDpretender = &testInt;
     int testInt2 = 666;
     void *secondAlgorithmID = &testInt2;
     EXPECT_CALL(*mockView.get(), algorithmStarted()).Times(1);
-    EXPECT_CALL(*mockView.get(), updateProgress(3.0, QString(""))).Times(0);
+    EXPECT_CALL(*mockView.get(), updateProgress(3.0, QString(""),0.,0)).Times(0);
 
     auto pres = mockView->m_presenter.get();
     pres->algorithmStartedSlot(algorithmIDpretender);
-    pres->updateProgressBarSlot(secondAlgorithmID, 3.0, "");
+    pres->updateProgressBarSlot(secondAlgorithmID, 3.0, "",0.,0);
     TS_ASSERT(Mock::VerifyAndClearExpectations(&mockView));
   }
-  void testRealAlgorithmRunning() {
+  void xtestRealAlgorithmRunning() {
     EXPECT_CALL(*mockView.get(), algorithmStarted()).Times(1);
     int reports = 10;
     QString emptyQString;
@@ -148,7 +149,7 @@ public:
 
     TS_ASSERT(Mock::VerifyAndClearExpectations(&mockView));
   }
-
+  */
 private:
   std::unique_ptr<NiceMock<MockAlgorithmProgressWidget>> mockView;
 };

--- a/qt/widgets/common/test/AlgorithmProgress/AlgorithmProgressPresenterTest.h
+++ b/qt/widgets/common/test/AlgorithmProgress/AlgorithmProgressPresenterTest.h
@@ -103,7 +103,8 @@ public:
     int testInt = 123;
     void *algorithmIDpretender = &testInt;
     EXPECT_CALL(*mockView.get(), algorithmStarted()).Times(1);
-    EXPECT_CALL(*mockView.get(), updateProgress(3.0, QString(""),0.,0)).Times(1);
+    EXPECT_CALL(*mockView.get(), updateProgress(3.0,
+  QString(""),0.,0)).Times(1);
 
     auto pres = mockView->m_presenter.get();
     pres->algorithmStartedSlot(algorithmIDpretender);
@@ -117,7 +118,8 @@ public:
     int testInt2 = 666;
     void *secondAlgorithmID = &testInt2;
     EXPECT_CALL(*mockView.get(), algorithmStarted()).Times(1);
-    EXPECT_CALL(*mockView.get(), updateProgress(3.0, QString(""),0.,0)).Times(0);
+    EXPECT_CALL(*mockView.get(), updateProgress(3.0,
+  QString(""),0.,0)).Times(0);
 
     auto pres = mockView->m_presenter.get();
     pres->algorithmStartedSlot(algorithmIDpretender);

--- a/qt/widgets/common/test/AlgorithmProgress/AlgorithmProgressPresenterTest.h
+++ b/qt/widgets/common/test/AlgorithmProgress/AlgorithmProgressPresenterTest.h
@@ -97,18 +97,18 @@ public:
     pres->algorithmEndedSlot(secondAlgorithmID);
     TS_ASSERT(Mock::VerifyAndClearExpectations(&mockView));
   }
-  
+
   void testUpdateProgressBar() {
     int testInt = 123;
     void *algorithmIDpretender = &testInt;
     EXPECT_CALL(*mockView.get(), algorithmStarted()).Times(1);
-    EXPECT_CALL(*mockView.get(), updateProgress(3.0,
-  QString(""),0.,0)).Times(1);
+    EXPECT_CALL(*mockView.get(), updateProgress(3.0, QString(""), 0., 0))
+        .Times(1);
 
     auto pres = mockView->m_presenter.get();
     pres->algorithmStartedSlot(algorithmIDpretender);
     // Algorithm reports a progress update
-    pres->updateProgressBarSlot(algorithmIDpretender, 3.0, "",0.,0);
+    pres->updateProgressBarSlot(algorithmIDpretender, 3.0, "", 0., 0);
     TS_ASSERT(Mock::VerifyAndClearExpectations(&mockView));
   }
   void testUpdateProgressBar_NotUpdatedIfAlgorithmNotBeingTracked() {
@@ -117,12 +117,12 @@ public:
     int testInt2 = 666;
     void *secondAlgorithmID = &testInt2;
     EXPECT_CALL(*mockView.get(), algorithmStarted()).Times(1);
-    EXPECT_CALL(*mockView.get(), updateProgress(3.0,
-  QString(""),0.,0)).Times(0);
+    EXPECT_CALL(*mockView.get(), updateProgress(3.0, QString(""), 0., 0))
+        .Times(0);
 
     auto pres = mockView->m_presenter.get();
     pres->algorithmStartedSlot(algorithmIDpretender);
-    pres->updateProgressBarSlot(secondAlgorithmID, 3.0, "",0.,0);
+    pres->updateProgressBarSlot(secondAlgorithmID, 3.0, "", 0., 0);
     TS_ASSERT(Mock::VerifyAndClearExpectations(&mockView));
   }
   void testRealAlgorithmRunning() {
@@ -136,7 +136,7 @@ public:
     // Another thing to note: 0.0 progress is NOT reported
     for (const auto prog : {0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1.0}) {
       EXPECT_CALL(*mockView.get(),
-                  updateProgress(DoubleEq(prog), emptyQString,0.,0));
+                  updateProgress(DoubleEq(prog), emptyQString, 0., 0));
     }
     EXPECT_CALL(*mockView.get(), algorithmEnded()).Times(1);
 

--- a/qt/widgets/common/test/AlgorithmProgress/AlgorithmProgressPresenterTest.h
+++ b/qt/widgets/common/test/AlgorithmProgress/AlgorithmProgressPresenterTest.h
@@ -97,9 +97,8 @@ public:
     pres->algorithmEndedSlot(secondAlgorithmID);
     TS_ASSERT(Mock::VerifyAndClearExpectations(&mockView));
   }
-  /*
-  TODO MUST FIX THE MOCK
-  void xtestUpdateProgressBar() {
+  
+  void testUpdateProgressBar() {
     int testInt = 123;
     void *algorithmIDpretender = &testInt;
     EXPECT_CALL(*mockView.get(), algorithmStarted()).Times(1);
@@ -112,7 +111,7 @@ public:
     pres->updateProgressBarSlot(algorithmIDpretender, 3.0, "",0.,0);
     TS_ASSERT(Mock::VerifyAndClearExpectations(&mockView));
   }
-  void xtestUpdateProgressBar_NotUpdatedIfAlgorithmNotBeingTracked() {
+  void testUpdateProgressBar_NotUpdatedIfAlgorithmNotBeingTracked() {
     int testInt = 123;
     void *algorithmIDpretender = &testInt;
     int testInt2 = 666;
@@ -126,7 +125,7 @@ public:
     pres->updateProgressBarSlot(secondAlgorithmID, 3.0, "",0.,0);
     TS_ASSERT(Mock::VerifyAndClearExpectations(&mockView));
   }
-  void xtestRealAlgorithmRunning() {
+  void testRealAlgorithmRunning() {
     EXPECT_CALL(*mockView.get(), algorithmStarted()).Times(1);
     int reports = 10;
     QString emptyQString;
@@ -137,7 +136,7 @@ public:
     // Another thing to note: 0.0 progress is NOT reported
     for (const auto prog : {0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1.0}) {
       EXPECT_CALL(*mockView.get(),
-                  updateProgress(DoubleEq(prog), emptyQString));
+                  updateProgress(DoubleEq(prog), emptyQString,0.,0));
     }
     EXPECT_CALL(*mockView.get(), algorithmEnded()).Times(1);
 
@@ -151,7 +150,7 @@ public:
 
     TS_ASSERT(Mock::VerifyAndClearExpectations(&mockView));
   }
-  */
+
 private:
   std::unique_ptr<NiceMock<MockAlgorithmProgressWidget>> mockView;
 };

--- a/qt/widgets/common/test/AlgorithmProgress/MockAlgorithmProgressWidget.h
+++ b/qt/widgets/common/test/AlgorithmProgress/MockAlgorithmProgressWidget.h
@@ -31,7 +31,7 @@ public:
 
   MOCK_METHOD0(algorithmStarted, void());
   MOCK_METHOD0(algorithmEnded, void());
-  MOCK_METHOD2(updateProgress, void(double, const QString &));
+  MOCK_METHOD4(updateProgress, void(const double, const QString &, const double, const int));
   MOCK_METHOD0(showDetailsDialog, void());
 
   std::shared_ptr<AlgorithmProgressPresenter> m_presenter;

--- a/qt/widgets/common/test/AlgorithmProgress/MockAlgorithmProgressWidget.h
+++ b/qt/widgets/common/test/AlgorithmProgress/MockAlgorithmProgressWidget.h
@@ -31,7 +31,8 @@ public:
 
   MOCK_METHOD0(algorithmStarted, void());
   MOCK_METHOD0(algorithmEnded, void());
-  MOCK_METHOD4(updateProgress, void(const double, const QString &, const double, const int));
+  MOCK_METHOD4(updateProgress,
+               void(const double, const QString &, const double, const int));
   MOCK_METHOD0(showDetailsDialog, void());
 
   std::shared_ptr<AlgorithmProgressPresenter> m_presenter;


### PR DESCRIPTION
**Description of work.**

Includes:
1. Passing the message down the pretty long chain to the widget
2. Updating Pause to output  these messages
3. Removing the ability to access algorithm progress from the Algorithm Observer in Python.  Not used now and a known performance issue.


**To test:**
1. Start workbench
1. Run Pause with a duration off say 30
1. Look at the progress bar in the algorithmToolbox, and under the details button, see the time remaining in the progress bar text.
1. Try a duration of 90, and 9000.  Feel free to cancel them once you see the values are formatted well.

Fixes #25803


---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
