### PR TITLE
Add python extensions setting to workbench

### DIFF
--- a/docs/source/release/v5.1.0/mantidworkbench.rst
+++ b/docs/source/release/v5.1.0/mantidworkbench.rst
@@ -22,6 +22,7 @@ Improvements
 - Tile plots are now reloaded correctly by project recovery.
 - When you stop a script running in workbench it will now automatically attempt to cancel the algorithm the script is running, rather than wait for the current algorthm to end.
   This is similar to what Mantidplot does, and should result in the script stopping much sooner.
+- The ``Python extensions directory`` setting from MantidPlot is now available in Workbench within the Manage User Directories window.
 
 .. figure:: ../../images/wb_invalid_log_shading.png
    :align: right

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/ManageUserDirectories.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/ManageUserDirectories.h
@@ -41,6 +41,7 @@ private slots:
   void moveUp();
   void moveDown();
   void selectSaveDir();
+  void selectExtensionsDir();
 
 private:
   Ui::ManageUserDirectories m_uiForm;

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/ManageUserDirectories.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/ManageUserDirectories.h
@@ -29,7 +29,7 @@ private:
   void loadProperties();
   void saveProperties();
   void appendSlashIfNone(QString &path) const;
-  QListWidget *listWidget();
+  QListWidget *listWidget(QObject *object);
 
 private slots:
   void helpClicked();
@@ -41,7 +41,6 @@ private slots:
   void moveUp();
   void moveDown();
   void selectSaveDir();
-  void selectExtensionsDir();
 
 private:
   Ui::ManageUserDirectories m_uiForm;

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/ManageUserDirectories.ui
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/ManageUserDirectories.ui
@@ -48,7 +48,7 @@
              <widget class="QLineEdit" name="leDirectoryPath"/>
             </item>
             <item>
-             <widget class="QPushButton" name="pbAddDirectory">
+             <widget class="QPushButton" name="pbDataAddDirectory">
               <property name="text">
                <string>Add Directory</string>
               </property>
@@ -64,28 +64,28 @@
             <item>
              <layout class="QVBoxLayout" name="verticalLayout_2">
               <item>
-               <widget class="QPushButton" name="pbBrowseToDir">
+               <widget class="QPushButton" name="pbDataBrowseToDir">
                 <property name="text">
                  <string>Browse To Directory</string>
                 </property>
                </widget>
               </item>
               <item>
-               <widget class="QPushButton" name="pbRemDir">
+               <widget class="QPushButton" name="pbDataRemDir">
                 <property name="text">
                  <string>Remove Directory</string>
                 </property>
                </widget>
               </item>
               <item>
-               <widget class="QPushButton" name="pbMoveUp">
+               <widget class="QPushButton" name="pbDataMoveUp">
                 <property name="text">
                  <string>Move Up</string>
                 </property>
                </widget>
               </item>
               <item>
-               <widget class="QPushButton" name="pbMoveDown">
+               <widget class="QPushButton" name="pbDataMoveDown">
                 <property name="text">
                  <string>Move Down</string>
                 </property>
@@ -175,7 +175,7 @@
           <widget class="QLineEdit" name="leDirectoryPathPython"/>
          </item>
          <item>
-          <widget class="QPushButton" name="pbAddDirectoryPython">
+          <widget class="QPushButton" name="pbScriptAddDirectory">
            <property name="text">
             <string>Add Directory</string>
            </property>
@@ -186,33 +186,33 @@
        <item>
         <layout class="QHBoxLayout" name="horizontalLayout_4">
          <item>
-          <widget class="QListWidget" name="lwUserSearchDirs"/>
+          <widget class="QListWidget" name="lwScriptSearchDirs"/>
          </item>
          <item>
           <layout class="QVBoxLayout" name="verticalLayout_6">
            <item>
-            <widget class="QPushButton" name="pbBrowseToDirPython">
+            <widget class="QPushButton" name="pbScriptBrowseToDir">
              <property name="text">
               <string>Browse To Directory</string>
              </property>
             </widget>
            </item>
            <item>
-            <widget class="QPushButton" name="pbRemDirPython">
+            <widget class="QPushButton" name="pbScriptRemDir">
              <property name="text">
               <string>Remove Directory</string>
              </property>
             </widget>
            </item>
            <item>
-            <widget class="QPushButton" name="pbMoveUpPython">
+            <widget class="QPushButton" name="pbScriptMoveUp">
              <property name="text">
               <string>Move Up</string>
              </property>
             </widget>
            </item>
            <item>
-            <widget class="QPushButton" name="pbMoveDownPython">
+            <widget class="QPushButton" name="pbScriptMoveDown">
              <property name="text">
               <string>Move Down</string>
              </property>
@@ -236,20 +236,58 @@
         </layout>
        </item>
        <item>
-        <widget class="QGroupBox" name="pbPythonExt">
+        <widget class="QGroupBox" name="gbPythonExt">
          <property name="title">
           <string>Python Extensions (fit functions, algorithms)</string>
          </property>
          <layout class="QHBoxLayout" name="horizontalLayout_8">
           <item>
-           <widget class="QLineEdit" name="leExtensions"/>
+           <widget class="QListWidget" name="lwExtSearchDirs"/>
           </item>
           <item>
-           <widget class="QPushButton" name="pbExtensionsBrowser">
-            <property name="text">
-             <string>Browse to Directory</string>
-            </property>
-           </widget>
+           <layout class="QVBoxLayout" name="verticalLayout_7">
+            <item>
+             <widget class="QPushButton" name="pbExtBrowseToDir">
+              <property name="text">
+               <string>Broswse to Directory</string>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QPushButton" name="pbExtRemoveDir">
+              <property name="text">
+               <string>Remove Directory</string>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QPushButton" name="pbExtMoveUp">
+              <property name="text">
+               <string>Move Up</string>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QPushButton" name="pbExtMoveDown">
+              <property name="text">
+               <string>Move Down</string>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <spacer name="verticalSpacer_4">
+              <property name="orientation">
+               <enum>Qt::Vertical</enum>
+              </property>
+              <property name="sizeHint" stdset="0">
+               <size>
+                <width>20</width>
+                <height>40</height>
+               </size>
+              </property>
+             </spacer>
+            </item>
+           </layout>
           </item>
          </layout>
         </widget>

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/ManageUserDirectories.ui
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/ManageUserDirectories.ui
@@ -236,6 +236,25 @@
         </layout>
        </item>
        <item>
+        <widget class="QGroupBox" name="pbPythonExt">
+         <property name="title">
+          <string>Python Extensions (fit functions, algorithms)</string>
+         </property>
+         <layout class="QHBoxLayout" name="horizontalLayout_8">
+          <item>
+           <widget class="QLineEdit" name="leExtensions"/>
+          </item>
+          <item>
+           <widget class="QPushButton" name="pbExtensionsBrowser">
+            <property name="text">
+             <string>Browse to Directory</string>
+            </property>
+           </widget>
+          </item>
+         </layout>
+        </widget>
+       </item>
+       <item>
         <spacer name="verticalSpacer">
          <property name="orientation">
           <enum>Qt::Vertical</enum>

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/ManageUserDirectories.ui
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/ManageUserDirectories.ui
@@ -249,7 +249,7 @@
             <item>
              <widget class="QPushButton" name="pbExtBrowseToDir">
               <property name="text">
-               <string>Broswse to Directory</string>
+               <string>Browse to Directory</string>
               </property>
              </widget>
             </item>

--- a/qt/widgets/common/src/ManageUserDirectories.cpp
+++ b/qt/widgets/common/src/ManageUserDirectories.cpp
@@ -52,6 +52,8 @@ void ManageUserDirectories::initLayout() {
 
   connect(m_uiForm.pbSaveBrowse, SIGNAL(clicked()), this,
           SLOT(selectSaveDir()));
+  connect(m_uiForm.pbExtensionsBrowser, SIGNAL(clicked()), this,
+          SLOT(selectExtensionsDir()));
 }
 
 void ManageUserDirectories::loadProperties() {
@@ -111,6 +113,13 @@ void ManageUserDirectories::loadProperties() {
                             "defaultsave.directory"))
                         .trimmed();
   m_uiForm.leDefaultSave->setText(saveDir);
+
+  // extensions directory
+  QString extDir = QString::fromStdString(
+                       Mantid::Kernel::ConfigService::Instance().getString(
+                           "user.python.plugins.directories"))
+                       .trimmed();
+  m_uiForm.leExtensions->setText(extDir);
 }
 void ManageUserDirectories::saveProperties() {
   QString newSearchArchive = m_uiForm.cbSearchArchive->currentText().toLower();
@@ -146,6 +155,7 @@ void ManageUserDirectories::saveProperties() {
   QString newDataDirs;
   QString newUserDirs;
   QString newSaveDir;
+  QString newExtensionsDir;
 
   newDataDirs = dataDirs.join(";");
   newUserDirs = userDirs.join(";");
@@ -156,6 +166,10 @@ void ManageUserDirectories::saveProperties() {
   newSaveDir.replace('\\', '/');
   appendSlashIfNone(newSaveDir);
 
+  newExtensionsDir = m_uiForm.leExtensions->text();
+  newExtensionsDir.replace('\\', '/');
+  appendSlashIfNone(newExtensionsDir);
+
   Mantid::Kernel::ConfigServiceImpl &config =
       Mantid::Kernel::ConfigService::Instance();
 
@@ -163,6 +177,8 @@ void ManageUserDirectories::saveProperties() {
   config.setString("datasearch.directories", newDataDirs.toStdString());
   config.setString("defaultsave.directory", newSaveDir.toStdString());
   config.setString("pythonscripts.directories", newUserDirs.toStdString());
+  config.setString("user.python.plugins.directories",
+                   newExtensionsDir.toStdString());
   config.saveConfig(m_userPropFile.toStdString());
 }
 
@@ -279,6 +295,24 @@ void ManageUserDirectories::selectSaveDir() {
     path.replace('\\', '/');
     settings.setValue("ManageUserSettings/last_directory", path);
     m_uiForm.leDefaultSave->setText(path);
+  }
+}
+
+void ManageUserDirectories::selectExtensionsDir() {
+  QSettings settings;
+  QString lastDirectory = m_uiForm.leExtensions->text();
+  if (lastDirectory.trimmed() == "")
+    lastDirectory =
+        settings.value("ManageUserSettings/last_directory", "").toString();
+
+  const QString newDir = QFileDialog::getExistingDirectory(
+      this, tr("Select New Extensions Directory"), lastDirectory,
+      QFileDialog::ShowDirsOnly);
+
+  if (newDir != "") {
+    QString path = newDir + QDir::separator();
+    path.replace('\\', '/');
+    m_uiForm.leExtensions->setText(path);
   }
 }
 

--- a/qt/widgets/common/src/ManageUserDirectories.cpp
+++ b/qt/widgets/common/src/ManageUserDirectories.cpp
@@ -130,13 +130,6 @@ void ManageUserDirectories::loadProperties() {
                             "defaultsave.directory"))
                         .trimmed();
   m_uiForm.leDefaultSave->setText(saveDir);
-
-  //// extensions directory
-  // QString extDir = QString::fromStdString(
-  //                     Mantid::Kernel::ConfigService::Instance().getString(
-  //                         "user.python.plugins.directories"))
-  //                     .trimmed();
-  // m_uiForm.leExtensions->setText(extDir);
 }
 void ManageUserDirectories::saveProperties() {
   QString newSearchArchive = m_uiForm.cbSearchArchive->currentText().toLower();


### PR DESCRIPTION
**Description of work.**
This PR adds the python extensions setting to workbench. The new setting is located within the manage user directories widget. 
<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

**To test:**
(1) Create a new directory (e.g mantid_scripts)
(2) Put a file (test.py) in there with the code:
`print("running \n running \n running \n running \n running \n running")`
(3) Set the python extensions directory to this new directory (manage user dirs -> python-> python extensions)
(4) Relaunch workbench
(5) The script should run on launch, evidenced by the printing of 'running' in the logger.
<!-- Instructions for testing. -->

PARTLY Fixes #28253 . <!-- and fix #xxxx or close #xxxx xor resolves #xxxx -->
<!-- alternative
*There is no associated issue.*
-->

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
-->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
