### PR TITLE
Fix workbench tests for Qt 5.14

### DIFF
--- a/qt/applications/workbench/workbench/config/test/test_user.py
+++ b/qt/applications/workbench/workbench/config/test/test_user.py
@@ -40,7 +40,11 @@ class ConfigUserManager(object):
 
     def __exit__(self, exc_type, exc_val, exc_tb):
         try:
-            os.remove(self.cfg.filename)
+            filename = self.cfg.filename
+            # Force QSettings destructor to run before
+            # deleting the file as it will just recreate it
+            del self.cfg
+            os.remove(filename)
         except:
             # File does not exist so it has been deleted already
             # This seems to happen when the whole module is ran in PyCharm
@@ -65,8 +69,11 @@ class ConfigUserTest(TestCase):
     @classmethod
     def tearDownClass(cls):
         try:
-            os.remove(cls.cfg.filename)
+            filename = cls.cfg.filename
+            # Force QSettings destructor to run before
+            # deleting the file as it will just recreate it
             del cls.cfg
+            os.remove(filename)
         except OSError:
             pass
 

--- a/qt/applications/workbench/workbench/plotting/test/test_figurewindow.py
+++ b/qt/applications/workbench/workbench/plotting/test/test_figurewindow.py
@@ -9,14 +9,14 @@
 import unittest
 
 import matplotlib
-matplotlib.use('Qt5Agg')  # noqa  # we need Qt for events to work
-import matplotlib.pyplot as plt
-
-from mantid import plots  # noqa  # register mantid projection
+from mantid import plots  # noqa: F401  # need mantid projection
 from unittest.mock import Mock, patch
 from mantid.simpleapi import CreateWorkspace
 from mantidqt.utils.qt.testing import start_qapplication
 from workbench.plotting.figurewindow import FigureWindow
+
+matplotlib.use('Qt5Agg')
+import matplotlib.pyplot as plt  # noqa: E402
 
 
 @start_qapplication
@@ -45,9 +45,11 @@ class Test(unittest.TestCase):
 
     def test_drag_and_drop_adds_plot_to_correct_axes(self):
         ax = self.fig.get_axes()[1]
+        dpi_ratio = self.fig.canvas.devicePixelRatio() or 1
         # Find the center of the axes and simulate a drop event there
-        ax_x_centre = (ax.xaxis.clipbox.x1 + ax.xaxis.clipbox.x0)/2
-        ax_y_centre = (ax.yaxis.clipbox.y1 + ax.yaxis.clipbox.y0)/2
+        # Need to use Qt logical pixels to factor in dpi
+        ax_x_centre = (ax.xaxis.clipbox.min[0] + ax.xaxis.clipbox.width*0.5)/dpi_ratio
+        ax_y_centre = (ax.xaxis.clipbox.min[1] + ax.xaxis.clipbox.height*0.5)/dpi_ratio
         mock_event = Mock(pos=lambda: Mock(x=lambda: ax_x_centre, y=lambda: ax_y_centre))
         mock_event.mimeData().text.return_value = "ws"
         with patch('workbench.plotting.figurewindow.QMainWindow.dropEvent'):

--- a/qt/applications/workbench/workbench/plugins/test/test_workspacewidget.py
+++ b/qt/applications/workbench/workbench/plugins/test/test_workspacewidget.py
@@ -8,18 +8,18 @@
 #
 #
 import unittest
+from unittest import mock
 
 import matplotlib as mpl
-mpl.use('Agg')  # noqa
-
-from unittest import mock
 from mantid.simpleapi import (CreateEmptyTableWorkspace, CreateSampleWorkspace,
                               GroupWorkspaces)
 from mantidqt.utils.qt.testing import start_qapplication
 from mantidqt.utils.qt.testing.qt_widget_finder import QtWidgetFinder
-from qtpy.QtWidgets import QMainWindow, QApplication
+from qtpy.QtWidgets import QMainWindow
 from workbench.plugins.workspacewidget import WorkspaceWidget
 from mantid.plots.utility import MantidAxType
+
+mpl.use('Agg')  # noqa
 
 ALGORITHM_HISTORY_WINDOW_TYPE = "AlgorithmHistoryWindow"
 ALGORITHM_HISTORY_WINDOW = "mantidqt.widgets.workspacewidget." \
@@ -27,7 +27,6 @@ ALGORITHM_HISTORY_WINDOW = "mantidqt.widgets.workspacewidget." \
 MATRIXWORKSPACE_DISPLAY = "mantidqt.widgets.workspacedisplay.matrix." \
                           "presenter.MatrixWorkspaceDisplay"
 MATRIXWORKSPACE_DISPLAY_TYPE = "StatusBarView"
-app = QApplication([])
 
 
 @start_qapplication


### PR DESCRIPTION
**Description of work.**

Fixes several unreliable tests after upgrading to Qt 5.14.

* Qt 5.14 has become less tolerant of multiple QApplication objects being constructed
* QSettings was not reliably destroyed before the test settings file was removed
* Figure drop tests were not using Qt logical pixels to simulate drop events but
  just happened to work before.

**To test:**

* Build on macOS with up to date Homebrew depedencies
* Build all tests `ninja AllTests`
* Run `ctest --output-on-failure -j8` and all tests should pass.

*This does not require release notes* because **it is an internal change**

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
