### PR TITLE
`LRAutoReduction` can now use `LRReductionWithReference`

### DIFF
--- a/Framework/PythonInterface/plugins/algorithms/LRAutoReduction.py
+++ b/Framework/PythonInterface/plugins/algorithms/LRAutoReduction.py
@@ -653,68 +653,45 @@ class LRAutoReduction(PythonAlgorithm):
         # Write template before we start the computation
         self._write_template(data_set, run_number, first_run_of_set, sequence_number)
 
-        # Execute the reduction
+        # input args for both reduction
+        kwargs = {
+            "InputWorkspace": self.event_data,
+            "NormalizationRunNumber": str(data_set.norm_file),
+            "SignalPeakPixelRange": data_set.DataPeakPixels,
+            "SubtractSignalBackground": data_set.DataBackgroundFlag,
+            "SignalBackgroundPixelRange": data_set.DataBackgroundRoi[:2],
+            "NormFlag": data_set.NormFlag,
+            "NormPeakPixelRange": data_set.NormPeakPixels,
+            "NormBackgroundPixelRange": data_set.NormBackgroundRoi,
+            "SubtractNormBackground": data_set.NormBackgroundFlag,
+            "LowResDataAxisPixelRangeFlag": data_set.data_x_range_flag,
+            "LowResDataAxisPixelRange": data_set.data_x_range,
+            "LowResNormAxisPixelRangeFlag": data_set.norm_x_range_flag,
+            "LowResNormAxisPixelRange": data_set.norm_x_range,
+            "TOFRange": data_set.DataTofRange,
+            "IncidentMediumSelected": incident_medium,
+            "GeometryCorrectionFlag": False,
+            "QMin": data_set.q_min,
+            "QStep": data_set.q_step,
+            "AngleOffset": data_set.angle_offset,
+            "AngleOffsetError": data_set.angle_offset_error,
+            "ScalingFactorFile": str(data_set.scaling_factor_file),
+            "SlitsWidthFlag": data_set.slits_width_flag,
+            "ApplyPrimaryFraction": True,
+            "SlitTolerance": slit_tolerance,
+            "PrimaryFractionRange": [data_set.clocking_from, data_set.clocking_to],
+            "OutputWorkspace": 'reflectivity_%s_%s_%s' % (first_run_of_set, sequence_number, run_number)
+        }
+
+        # Execute the reduction for the selected normalization type
         norm_type = self.getProperty("NormalizationType").value
         if norm_type == "DirectBeam":
-            LiquidsReflectometryReduction(
-                #RunNumbers=[int(run_number)],
-                InputWorkspace=self.event_data,
-                NormalizationRunNumber=str(data_set.norm_file),
-                SignalPeakPixelRange=data_set.DataPeakPixels,
-                SubtractSignalBackground=data_set.DataBackgroundFlag,
-                SignalBackgroundPixelRange=data_set.DataBackgroundRoi[:2],
-                NormFlag=data_set.NormFlag,
-                NormPeakPixelRange=data_set.NormPeakPixels,
-                NormBackgroundPixelRange=data_set.NormBackgroundRoi,
-                SubtractNormBackground=data_set.NormBackgroundFlag,
-                LowResDataAxisPixelRangeFlag=data_set.data_x_range_flag,
-                LowResDataAxisPixelRange=data_set.data_x_range,
-                LowResNormAxisPixelRangeFlag=data_set.norm_x_range_flag,
-                LowResNormAxisPixelRange=data_set.norm_x_range,
-                TOFRange=data_set.DataTofRange,
-                IncidentMediumSelected=incident_medium,
-                GeometryCorrectionFlag=False,
-                QMin=data_set.q_min,
-                QStep=data_set.q_step,
-                AngleOffset=data_set.angle_offset,
-                AngleOffsetError=data_set.angle_offset_error,
-                ScalingFactorFile=str(data_set.scaling_factor_file),
-                SlitsWidthFlag=data_set.slits_width_flag,
-                ApplyPrimaryFraction=True,
-                SlitTolerance=slit_tolerance,
-                PrimaryFractionRange=[data_set.clocking_from, data_set.clocking_to],
-                OutputWorkspace='reflectivity_%s_%s_%s' % (first_run_of_set, sequence_number, run_number))
+            LiquidsReflectometryReduction(**kwargs)
 
         elif "WithReference":
             refl1d_parameters = self.getProperty("Refl1DModelParameters").value
-            LRReductionWithReference(
-                InputWorkspace=self.event_data,
-                NormalizationRunNumber=str(data_set.norm_file),
-                SignalPeakPixelRange=data_set.DataPeakPixels,
-                SubtractSignalBackground=data_set.DataBackgroundFlag,
-                SignalBackgroundPixelRange=data_set.DataBackgroundRoi[:2],
-                NormFlag=data_set.NormFlag,
-                NormPeakPixelRange=data_set.NormPeakPixels,
-                NormBackgroundPixelRange=data_set.NormBackgroundRoi,
-                SubtractNormBackground=data_set.NormBackgroundFlag,
-                LowResDataAxisPixelRangeFlag=data_set.data_x_range_flag,
-                LowResDataAxisPixelRange=data_set.data_x_range,
-                LowResNormAxisPixelRangeFlag=data_set.norm_x_range_flag,
-                LowResNormAxisPixelRange=data_set.norm_x_range,
-                TOFRange=data_set.DataTofRange,
-                IncidentMediumSelected=incident_medium,
-                GeometryCorrectionFlag=False,
-                QMin=data_set.q_min,
-                QStep=data_set.q_step,
-                AngleOffset=data_set.angle_offset,
-                AngleOffsetError=data_set.angle_offset_error,
-                ScalingFactorFile=str(data_set.scaling_factor_file),
-                SlitsWidthFlag=data_set.slits_width_flag,
-                ApplyPrimaryFraction=True,
-                SlitTolerance=slit_tolerance,
-                PrimaryFractionRange=[data_set.clocking_from, data_set.clocking_to],
-                OutputWorkspace='reflectivity_%s_%s_%s' % (first_run_of_set, sequence_number, run_number),
-                Refl1DModelParameters=refl1d_parameters)
+            kwargs['Refl1DModelParameters'] = refl1d_parameters
+            LRReductionWithReference(**kwargs)
 
         # Put the reflectivity curve together
         self._save_partial_output(data_set, first_run_of_set, sequence_number, run_number)

--- a/Framework/PythonInterface/plugins/algorithms/LRAutoReduction.py
+++ b/Framework/PythonInterface/plugins/algorithms/LRAutoReduction.py
@@ -86,7 +86,8 @@ class LRAutoReduction(PythonAlgorithm):
         self.declareProperty("SlitTolerance", 0.02, doc="Tolerance for matching slit positions")
         self.declareProperty("NormalizationType", "DirectBeam",
                              doc="Normalization type for reduction. Allowed values: ['DirectBeam', 'WithReference']")
-        self.copyProperties("LRReductionWithReference", "Refl1DModelParameters")
+        self.declareProperty("Refl1DModelParameters", "",
+                             doc="JSON string for Refl1D theoretical model parameters for 'NormalizationType'=='WithReference' ")
 
     def load_data(self):
         """

--- a/Framework/PythonInterface/plugins/algorithms/LRReductionWithReference.py
+++ b/Framework/PythonInterface/plugins/algorithms/LRReductionWithReference.py
@@ -71,7 +71,7 @@ class LRReductionWithReference(DataProcessorAlgorithm):
     def PyInit(self):
         self.copyProperties(LR_ALG_FOR_PROPS, PROPS_TO_COPY)
         self.declareProperty("Refl1DModelParameters", "",
-                             doc="JSON string for Refl1D theoretical model paramters")
+                             doc="JSON string for Refl1D theoretical model parameters")
 
     def PyExec(self):
         try:

--- a/docs/source/release/v5.1.0/reflectometry.rst
+++ b/docs/source/release/v5.1.0/reflectometry.rst
@@ -22,6 +22,7 @@ Improvements
 
 - Sample waviness term is removed from resolution calculation in incoherent mode in :ref:`ReflectometryMomentumTransfer <algm-ReflectometryMomentumTransfer>`.
 - Flag to enable / disable apply scaling factor from `ScalingFactorFile`, called `ApplyScalingFactor`, added to :ref:`algm-LiquidsReflectometryReduction`.
+- Modified :ref:`algm-LRAutoReduction` to allow the option to autoreduce data with a reference measurement for normalization (instead of only direct beam) using the new :ref:`algm-LRReductionWithReference` algorithm of this release
 
 Bug fixes
 ---------


### PR DESCRIPTION
**Description of work.**

This adds the new parameters to `LRAutoReduction` so that the `LRReductionWithReference` algorithm for reduction can be used.

Also, there is a small doc string fix for `LRReductionWithReference`

**To test:**

This will have to be tested on the SNS REF_L beamline for autoreduction *after* merge into `master`.
The current autoreduction using `DirectBeam` for normalization is not being used since they are running normalization using a reference and performing manual reduction so no issues with merge to affect that beamline.

Fixes #28791 

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
