### PR TITLE
Make MonteCarloAbsorption ignore masked detectors

### DIFF
--- a/Framework/Algorithms/src/MonteCarloAbsorption.cpp
+++ b/Framework/Algorithms/src/MonteCarloAbsorption.cpp
@@ -273,8 +273,8 @@ MatrixWorkspace_uptr MonteCarloAbsorption::doSimulation(
     auto &outE = simulationWS.mutableE(i);
     // The input was cloned so clear the errors out
     outE = 0.0;
-    // Final detector position
-    if (!spectrumInfo.hasDetectors(i)) {
+
+    if (!spectrumInfo.hasDetectors(i) || spectrumInfo.isMasked(i)) {
       continue;
     }
     // Per spectrum values

--- a/Framework/Algorithms/test/MonteCarloAbsorptionTest.h
+++ b/Framework/Algorithms/test/MonteCarloAbsorptionTest.h
@@ -10,6 +10,7 @@
 #include "MantidAPI/FileFinder.h"
 #include "MantidAPI/FrameworkManager.h"
 #include "MantidAPI/Sample.h"
+#include "MantidAPI/SpectrumInfo.h"
 #include "MantidAlgorithms/ConvertUnits.h"
 #include "MantidAlgorithms/MonteCarloAbsorption.h"
 #include "MantidDataHandling/LoadBinaryStl.h"
@@ -280,6 +281,26 @@ public:
     addSample(testWS, Environment::SampleOnly);
     TS_ASSERT_THROWS_NOTHING(mcAbsorb->setProperty("InputWorkspace", testWS));
     TS_ASSERT_THROWS_NOTHING(mcAbsorb->execute());
+  }
+
+  void test_ignore_masked_spectra() {
+    using Mantid::Kernel::DeltaEMode;
+    TestWorkspaceDescriptor wsProps = {
+        5, 10, Environment::SampleOnly, DeltaEMode::Elastic, -1, -1};
+    auto testWS = setUpWS(wsProps);
+    testWS->mutableSpectrumInfo().setMasked(0, true);
+    auto mcAbsorb = createAlgorithm();
+    TS_ASSERT_THROWS_NOTHING(mcAbsorb->setProperty("InputWorkspace", testWS));
+    TS_ASSERT_THROWS_NOTHING(mcAbsorb->execute());
+    auto outputWS = getOutputWorkspace(mcAbsorb);
+    // should still output a spectra but it should also be masked and equal to
+    // zero
+    TS_ASSERT_EQUALS(outputWS->getNumberHistograms(), 5);
+    TS_ASSERT_EQUALS(outputWS->spectrumInfo().isMasked(0), true);
+    auto yData = outputWS->getSpectrum(0).dataY();
+    bool allZero = std::all_of(yData.begin(), yData.end(),
+                               [](double i) { return i == 0; });
+    TS_ASSERT_EQUALS(allZero, true);
   }
 
   //---------------------------------------------------------------------------

--- a/docs/source/release/v5.1.0/framework.rst
+++ b/docs/source/release/v5.1.0/framework.rst
@@ -20,6 +20,7 @@ Algorithms
    cost of cloning the inputWorkspace.
 - Adjusted :ref:`AddPeak <algm-AddPeak>` to only allow peaks from the same instrument as the peaks worksapce to be added to that workspace.
 - :ref:`MonteCarloAbsorption <algm-MonteCarloAbsorption>` Bug fixed where setting ResimulateTracksForDifferentWavelengths parameter to True was being ignored
+- :ref:`MonteCarloAbsorption <algm-MonteCarloAbsorption>` Corrections are not calculated anymore for masked spectra
 - :ref:`MaskDetectorsIf <algm-MaskDetectorsIf>` has received a number of updates:
 
   - The algorithm now checks all of the data bins for each spectrum of a workspace, previously it only checked the first bin.


### PR DESCRIPTION
**Description of work.**

This change makes the MonteCarloAbsorption algorithm ignore masked detectors in the input workspace - in line with the behaviour of other correction algorithms such as MayersSampleCorrection and CalculateCarpenterSampleCorrection
The algorithm outputs a masked spectra with all values equal to zero for each masked spectrum in the input workspace. The Divide algorithm ignores masked spectra so if the correction workspace is used as the rhs of a divide then it will be OK

**To test:**

Run this script and observe that the spectra in the output WS called sample_env_mesh_abscorr are zero (and masked) apart from the 9 spectra corresponding to detector IDs 1040, 2040, 3040, 4040, 5040, 6040, 7040, 8040, 9040:

```
from __future__ import print_function, division, unicode_literals

from mantid.simpleapi import (ConvertUnits, Load, LoadSampleShape, MonteCarloAbsorption, SetSample, CreateGroupingWorkspace, GroupDetectors)
import matplotlib.pyplot as plt

# Grab some data. This happens to be a run with a 10mm vanadium sphere

sample_env_mesh = Load(Filename='PEARL00073987.raw')

masked_dets =  []
for i in range(sample_env_mesh.getNumberHistograms()):
  try:
     det = sample_env_mesh.getDetector(i)
  except:
      print("No detector found for workspace index " + str(i))
  if not det.getID() in [1040, 2040, 3040, 4040, 5040, 6040, 7040, 8040, 9040]:
    masked_dets.append( det.getID() )
print (masked_dets)
sample_env_mesh = MaskInstrument(InputWorkspace=sample_env_mesh,DetectorIDs=masked_dets)


# MonteCarloAbsorption requires an input ws with x units of wavelength - this determines
# which wavelengths to calculate the absorption correction for
sample_env_mesh = ConvertUnits(InputWorkspace=sample_env_mesh, Target='Wavelength')

SetSample(InputWorkspace=sample_env_mesh, Environment={'Name':'Pearl','Container':'Gasket_inner'},Material={'ChemicalFormula': 'Ni'})

sample_env_mesh_abscorr = MonteCarloAbsorption(InputWorkspace=sample_env_mesh, EventsPerPoint=100)
```

Fixes #28628.

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
