### PR TITLE
Fix incorrect MsdYi paper reference

### DIFF
--- a/Framework/PythonInterface/plugins/functions/MsdYi.py
+++ b/Framework/PythonInterface/plugins/functions/MsdYi.py
@@ -8,7 +8,7 @@ import math
 import numpy as np
 from mantid.api import IFunction1D, FunctionFactory
 
-# The model of Yi et al(J Phys Chem B 1316 5029 2012) takes into account motional heterogeneity.
+# The model of Yi et al(J Phys Chem B 116 5028 2012) takes into account motional heterogeneity.
 # The elastic intensity is proportional to exp(-(1/6)*Q^2*msd)*(1+Q^4*sigma/72)
 # where the mean square displacement msd = <r^2> and sigma^2 is the variance of the msd.
 # In the limit sigma = 0 the model becomes Gaussian.


### PR DESCRIPTION
**Description of work.**
Adjusts a comment in the MsdYi fit function so that it references the correct paper. 

**Report to:** Ian Silverwood


**To test:**
1. Check that the comment references the correct paper.


*There is no associated issue.*


*This does not require release notes* because **it only concerns internal documentation.**


---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
