### PR TITLE
Remove stale ui_ include causing builds to fail

### DIFF
--- a/buildconfig/Jenkins/buildscript
+++ b/buildconfig/Jenkins/buildscript
@@ -185,6 +185,8 @@ fi
 #                            the links helps keep it fresh
 #   - build/Testing/**: old ctest xml files will change over time and removing
 #                       the links helps keep it fresh
+#   - build/qt/**/ui_*.h: Header files produced from .ui files can remain stale
+#                         if a .ui file is removed from a CMakeLists.txt file
 ###############################################################################
 if [ -z "$BUILD_DIR" ]; then
     echo "Build directory not set. Cannot continue"
@@ -199,6 +201,7 @@ mkdir -p $BUILD_DIR
 
 # Tidy build dir
 rm -rf ${BUILD_DIR:?}/bin ${BUILD_DIR:?}/ExternalData ${BUILD_DIR:?}/Testing
+find ${BUILD_DIR:?}/qt -name 'ui_*.h' -delete
 find ${BUILD_DIR:?} -name 'TEST-*.xml' -delete
 
 if [[ -n ${CLEAN_EXTERNAL_PROJECTS} && "${CLEAN_EXTERNAL_PROJECTS}" == true ]]; then
@@ -303,13 +306,13 @@ fi
 
 if [[ ${JOB_NAME} == *address* ]]; then
     SANITIZER_FLAGS="-DUSE_SANITIZER=Address"
-    
+
 elif [[ ${JOB_NAME} == *memory* ]]; then
     SANITIZER_FLAGS="-DUSE_SANITIZER=memory"
-    
+
 elif [[ ${JOB_NAME} == *thread* ]]; then
     SANITIZER_FLAGS="-DUSE_SANITIZER=thread"
-    
+
 elif [[ ${JOB_NAME} == *undefined* ]]; then
     SANITIZER_FLAGS="-DUSE_SANITIZER=undefined"
 fi

--- a/buildconfig/Jenkins/buildscript.bat
+++ b/buildconfig/Jenkins/buildscript.bat
@@ -124,7 +124,12 @@ if "!CLEANBUILD!" == "yes" (
 
 if EXIST %BUILD_DIR% (
   rmdir /S /Q %BUILD_DIR%\bin %BUILD_DIR%\ExternalData %BUILD_DIR%\Testing
+  pushd %BUILD_DIR%
   for /f %%F in ('dir /b /a-d /S "TEST-*.xml"') do del /Q %%F >/nul
+  pushd qt
+  for /f %%F in ('dir /b /a-d /S "ui_*.h"') do del /Q %%F >/nul
+  popd
+  popd
   if "!CLEAN_EXTERNAL_PROJECTS!" == "true" (
     rmdir /S /Q %BUILD_DIR%\eigen-prefix
     rmdir /S /Q %BUILD_DIR%\googletest-download %BUILD_DIR%\googletest-src

--- a/qt/scientific_interfaces/Indirect/IndirectFitAnalysisTab.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectFitAnalysisTab.cpp
@@ -5,7 +5,6 @@
 //   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
 // SPDX - License - Identifier: GPL - 3.0 +
 #include "IndirectFitAnalysisTab.h"
-#include "ui_IqtFit.h"
 
 #include "MantidAPI/FunctionFactory.h"
 #include "MantidAPI/MultiDomainFunction.h"


### PR DESCRIPTION
**Description of work.**

The [clean builds](https://builds.mantidproject.org/view/Master%20Pipeline/job/master_clean-rhel7/1275/console) are failing with
```
01:30:18 ../qt/scientific_interfaces/Indirect/IndirectFitAnalysisTab.cpp:8:10: fatal error: ui_IqtFit.h: No such file or directory
01:30:18  #include "ui_IqtFit.h"
```
The IqtFit.ui file was removed in [6a16b4fddb6bd39dcc23bea1e7e7ce6e64cf9ae8](
https://github.com/mantidproject/mantid/commit/6a16b4fddb6bd39dcc23bea1e7e7ce6e64cf9ae8) but the builders didn't remove the generate header so the PR builds that tested that branch still saw the header and they passed.

This also includes some changes to the build scripts to remove ui_.h files on each build.

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

**To test:**

Code review and builds pass.

*There is no associated issue.*

*This does not require release notes* because **it is an internal issue.**

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
