### PR TITLE
Add a label to the colorbar on colorfill plots

### DIFF
--- a/Framework/PythonInterface/mantid/plots/axesfunctions.py
+++ b/Framework/PythonInterface/mantid/plots/axesfunctions.py
@@ -92,6 +92,7 @@ def _setLabels2D(axes,
     else:
         axes.set_xlabel(labels[1])
         axes.set_ylabel(labels[2])
+    axes.colorbar_label = labels[0]
     if xscale is None and hasattr(workspace, 'isCommonLogBins') and workspace.isCommonLogBins():
         axes.set_xscale('log')
     elif xscale is not None:

--- a/Framework/PythonInterface/mantid/plots/datafunctions.py
+++ b/Framework/PythonInterface/mantid/plots/datafunctions.py
@@ -1030,6 +1030,7 @@ def update_colorbar_scale(figure, image, scale, vmin, vmax):
     image.set_norm(scale(vmin=vmin, vmax=vmax))
 
     if image.colorbar:
+        label = image.colorbar._label
         image.colorbar.remove()
         locator = None
         if scale == LogNorm:
@@ -1039,7 +1040,19 @@ def update_colorbar_scale(figure, image, scale, vmin, vmax):
                 mantid.kernel.logger.warning("Minor ticks on colorbar scale cannot be shown "
                                              "as the range between min value and max value is too large")
         figure.subplots_adjust(wspace=0.5, hspace=0.5)
-        figure.colorbar(image, ax=figure.axes, ticks=locator, pad=0.06)
+        colorbar = figure.colorbar(image, ax=figure.axes, ticks=locator, pad=0.06)
+        colorbar.set_label(label)
+
+
+def add_colorbar_label(colorbar, axes):
+    """
+    Adds a label to the colorbar if every axis on the figure has the same label.
+    :param colorbar: the colorbar to label.
+    :param axes: the axes that the colorbar belongs to.
+    """
+    colorbar_labels = [ax.colorbar_label for ax in axes if hasattr(ax, 'colorbar_label')]
+    if colorbar_labels.count(colorbar_labels[0]) == len(colorbar_labels):
+        colorbar.set_label(colorbar_labels[0])
 
 
 def get_images_from_figure(figure):

--- a/docs/source/release/v5.1.0/mantidworkbench.rst
+++ b/docs/source/release/v5.1.0/mantidworkbench.rst
@@ -51,6 +51,7 @@ Improvements
 - Improved the usability of the fit function and peak selection pop-up menus by allowing the user to immediately search for the desired function and activate autocompletion by pressing "enter" if there is just a single possible function.
 - The figure options menu now has a help button which opens the documentation for the menu.
 - Variables assigned in python scripts are now cleared when a script is run in its entirety.
+- The colorbar on colorfill plots is now labelled.
 
 
 Bugfixes

--- a/qt/applications/workbench/workbench/plotting/figureinteraction.py
+++ b/qt/applications/workbench/workbench/plotting/figureinteraction.py
@@ -716,6 +716,11 @@ class FigureInteraction(object):
                 colorbar_max = np.nanmax(ax.images[-1].get_array())
                 for image in ax.images:
                     image.set_clim(colorbar_min, colorbar_max)
+
+                    # Update the colorbar label
+                    cb = image.colorbar
+                    if cb:
+                        datafunctions.add_colorbar_label(cb, ax.get_figure().axes)
                 if colorbar_log:  # If it had a log scaled colorbar before, put it back.
                     self._change_colorbar_axes(LogNorm)
 

--- a/qt/python/mantidqt/plotting/functions.py
+++ b/qt/python/mantidqt/plotting/functions.py
@@ -25,6 +25,7 @@ from mantid.api import AnalysisDataService, MatrixWorkspace
 from mantid.plots.plotfunctions import manage_workspace_names, figure_title, plot,\
                                        create_subplots,raise_if_not_sequence
 from mantid.kernel import Logger
+from mantid.plots.datafunctions import add_colorbar_label
 from mantid.plots.utility import get_single_workspace_log_value
 from mantidqt.plotting.figuretype import figure_type, FigureType
 from mantidqt.dialogs.spectraselectorutils import get_spectra_selection
@@ -221,7 +222,11 @@ def pcolormesh(workspaces, fig=None):
 
     # Adjust locations to ensure the plots don't overlap
     fig.subplots_adjust(wspace=SUBPLOT_WSPACE, hspace=SUBPLOT_HSPACE)
-    fig.colorbar(pcm, ax=axes.ravel().tolist(), pad=0.06)
+
+    axes = axes.ravel()
+    colorbar = fig.colorbar(pcm, ax=axes.tolist(), pad=0.06)
+    add_colorbar_label(colorbar, axes)
+
     fig.canvas.set_window_title(figure_title(workspaces, fig.number))
     #assert a minimum size, otherwise we can lose axis labels
     size = fig.get_size_inches()


### PR DESCRIPTION
**Description of work.**
See title.

**To test:**
Create a colorfill plot of a workspace and the colorbar should be labelled.
If you create a tiled colorfill plot the colorbar should only be labelled if both workspaces use the same label.
Toggling normalisation should update the label.

Fixes #28599 

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
