### PR TITLE
Fix waterfall plots not replotting correctly after changing curve settings

### DIFF
--- a/qt/python/mantidqt/widgets/plotconfigdialog/curvestabwidget/presenter.py
+++ b/qt/python/mantidqt/widgets/plotconfigdialog/curvestabwidget/presenter.py
@@ -125,6 +125,14 @@ class CurvesTabWidgetPresenter:
             curve_index = ax.get_lines().index(curve[0])
             errorbar = True
 
+        # When you remove the curve on a waterfall plot, the remaining curves are repositioned so that they are
+        # equally spaced apart. However since the curve is being replotted we don't want that to happen, so here
+        # the waterfall offsets are set to 0 so the plot appears to be non-waterfall. The offsets are then re-set
+        # after the curve is replotted.
+        if waterfall:
+            x_offset, y_offset = ax.waterfall_x_offset, ax.waterfall_y_offset
+            ax.waterfall_x_offset = ax.waterfall_y_offset = 0
+
         new_curve = FigureErrorsManager.replot_curve(ax, curve, plot_kwargs)
         self.curve_names_dict[self.view.get_selected_curve_name()] = new_curve
 
@@ -139,6 +147,8 @@ class CurvesTabWidgetPresenter:
         ax.lines.insert(curve_index, ax.lines.pop())
 
         if waterfall:
+            # Set the waterfall offsets to what they were previously.
+            ax.waterfall_x_offset, ax.waterfall_y_offset = x_offset, y_offset
             if check_line_colour:
                 # curve can be either a Line2D or an ErrorContainer and the colour is accessed differently for each.
                 if not errorbar:


### PR DESCRIPTION
**Description of work.**
This PR fixes an issue where changing the curve settings for a line on a waterfall plot would cause two lines to be in the same position rather than offset. This is because the changed curve was being removed and replotted, and when it was removed the rest of the curves wrongly repositioned themselves.

**To test:**
Run
```
from mantid.simpleapi import *
import matplotlib.pyplot as plt

ws = CreateSampleWorkspace()

fig, axes = plt.subplots(subplot_kw={'projection': 'mantid'})

for i in range(1, 4):
    axes.plot(ws, specNum=i)

axes.set_waterfall(True)
plt.show()
```
Open figure options, go to Curves tab, and change the settings for one of the curves. Check that all of the lines stay in the same position after applying the settings.

Fixes #28820 

No release notes because this wasn't an issue in 5.0.

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
