### PR TITLE
Workbench sliceviewer: Dynamically rebin MDEventWorkspaces on zoom

### DIFF
--- a/qt/applications/workbench/workbench/plugins/workspacewidget.py
+++ b/qt/applications/workbench/workbench/plugins/workspacewidget.py
@@ -179,8 +179,8 @@ class WorkspaceWidget(PluginWidget):
             except Exception as exception:
                 logger.warning("Could not open slice viewer for workspace '{}'."
                                "".format(ws.name()))
-                logger.debug("{}: {}".format(type(exception).__name__,
-                                             exception))
+                logger.warning("{}: {}".format(type(exception).__name__,
+                                               exception))
 
     def _do_show_instrument(self, names):
         """

--- a/qt/python/CMakeLists.txt
+++ b/qt/python/CMakeLists.txt
@@ -123,6 +123,7 @@ if(ENABLE_MANTIDPLOT OR ENABLE_WORKBENCH)
         mantidqt/widgets/sliceviewer/test/test_sliceviewer_sliceinfo.py
         mantidqt/widgets/sliceviewer/test/test_sliceviewer_transform.py
         mantidqt/widgets/sliceviewer/test/test_sliceviewer_view.py
+        mantidqt/widgets/sliceviewer/test/test_sliceviewer_zoom.py
         mantidqt/widgets/sliceviewer/peaksviewer/test/test_peaksviewer_model.py
         mantidqt/widgets/sliceviewer/peaksviewer/test/test_peaksviewer_presenter.py
         mantidqt/widgets/sliceviewer/peaksviewer/test/test_peaksviewer_peaksviewercollectionpresenter.py

--- a/qt/python/mantidqt/widgets/sliceviewer/model.py
+++ b/qt/python/mantidqt/widgets/sliceviewer/model.py
@@ -111,7 +111,7 @@ class SliceViewerModel:
         """
         workspace = self._get_ws()
         bin_limits = _binning_limits(workspace, slicepoint, limits)
-        params = {}
+        params = {'EnableLogging': False}
         for n in range(workspace.getNumDims()):
             dimension = workspace.getDimension(n)
             slice_pt = slicepoint[n]

--- a/qt/python/mantidqt/widgets/sliceviewer/model.py
+++ b/qt/python/mantidqt/widgets/sliceviewer/model.py
@@ -220,7 +220,7 @@ class SliceViewerModel:
         try:
             proj_matrix = np.array(expt_info.run().get(PROJ_MATRIX_LOG_NAME).value)
             proj_matrix = proj_matrix.reshape(3, 3)
-        except KeyError:
+        except (AttributeError, KeyError):  # run can be None so no .get()
             # assume orthogonal projection
             proj_matrix = np.diag([1., 1., 1.])
 

--- a/qt/python/mantidqt/widgets/sliceviewer/peaksviewer/model.py
+++ b/qt/python/mantidqt/widgets/sliceviewer/peaksviewer/model.py
@@ -103,13 +103,13 @@ class PeaksViewerModel(TableWorkspaceDisplayModel):
 
         return slicepoint
 
-    def zoom_to(self, index):
+    def viewlimits(self, index):
         """
-        Set the view to display the peak center at the given index. It is assumed
+        Retrieve the view to limits to display the peak center at the given index. It is assumed
         that slice point has been updated so it contains this peak
         :param index: Index of peak in list
         """
-        self._representations[index].zoom_to()
+        return self._representations[index].viewlimits()
 
     def _frame_to_slice_fn(self, frame):
         """

--- a/qt/python/mantidqt/widgets/sliceviewer/peaksviewer/presenter.py
+++ b/qt/python/mantidqt/widgets/sliceviewer/peaksviewer/presenter.py
@@ -93,8 +93,11 @@ class PeaksViewerPresenter(object):
         if selected_index is None:
             return
 
+        # Two step:
+        #   - first update slice point so we are in the correct plane
+        #   - find and set limits required to "zoom" to the selected peak
         self._view.set_slicepoint(self.model.slicepoint(selected_index, self._view.sliceinfo))
-        self.model.zoom_to(selected_index)
+        self._view.set_axes_limits(*self.model.viewlimits(selected_index))
 
     # private api
     @staticmethod

--- a/qt/python/mantidqt/widgets/sliceviewer/peaksviewer/representation/noshape.py
+++ b/qt/python/mantidqt/widgets/sliceviewer/peaksviewer/representation/noshape.py
@@ -32,8 +32,22 @@ class NonIntegratedPeakRepresentation(object):
         alpha = compute_alpha(z, slice_info.z_value, slice_info.z_width)
         painted = None
         if alpha > 0.0:
+            # Non-integrated peaks have no size in Q space so we create an
+            # effective size. It is scaled according to the current view limits
+            # so not to dominate the view
             effective_radius = slice_info.z_width * cls.VIEW_FRACTION
-            painted = Painted(
-                painter, (painter.cross(x, y, effective_radius, alpha=alpha, color=fg_color), ))
+            # yapf: disable
+            effective_bbox = ((x - effective_radius, y - effective_radius),
+                              (x + effective_radius, y + effective_radius))
+            # yapf: enable
+            view_xlim = painter.axes.get_xlim()
+            deltax = view_xlim[1] - view_xlim[0]
+            view_radius = effective_radius
+            if effective_radius > cls.VIEW_FRACTION * deltax:
+                view_radius = cls.VIEW_FRACTION * deltax
+
+            painted = Painted(painter,
+                              (painter.cross(x, y, view_radius, alpha=alpha, color=fg_color), ),
+                              effective_bbox)
 
         return painted

--- a/qt/python/mantidqt/widgets/sliceviewer/peaksviewer/representation/painter.py
+++ b/qt/python/mantidqt/widgets/sliceviewer/peaksviewer/representation/painter.py
@@ -17,7 +17,6 @@ class EllipticalShell(Patch):
     """
     Elliptical shell patch.
     """
-
     def __str__(self):
         return f"EllipticalShell(center={self.center}, width={self.width}, height={self.height}, thick={self.thick}, angle={self.angle})"
 
@@ -158,8 +157,10 @@ class MplPainter(object):
         return self._axes.add_patch(
             Wedge((x, y), outer_radius, theta1=0.0, theta2=360., width=thick, **kwargs))
 
-    def zoom_to(self, artist):
-        """Set the view such that the given artist is in the center
+    def viewlimits(self, artist):
+        """Determine the view limits such that the given artist is in the center
+        with some padding
+        :param artist: An artist to inspect
         """
         # Use the bounding box of the artist with small amount of padding
         # to set the axis limits
@@ -171,13 +172,11 @@ class MplPainter(object):
         xl, xr = ll[0], ur[0]
         yb, yt = ll[1], ur[1]
         padding = max(xr - xl, yt - yb) * self.ZOOM_PAD_FRAC
-        self._axes.set_xlim(xl - padding, xr + padding)
-        self._axes.set_ylim(yb - padding, yt + padding)
+        return ((xl - padding, xr + padding), (yb - padding, yt + padding))
 
 
 class Painted(object):
     """Combine a collection of artists with the painter that created them"""
-
     def __init__(self, painter, artists):
         self._painter = painter
         self._artists = artists
@@ -194,10 +193,9 @@ class Painted(object):
         for artist in self._artists:
             self._painter.remove(artist)
 
-    def zoom_to(self):
+    def viewlimits(self):
         """
-        Place the painted objects at the center of the view.
-        There is an assumption that the final artist represents the "largest"
-        object painted on the screen
+        Determine the view limits such that the artists are in the center
+        with some padding.
         """
-        self._painter.zoom_to(self._artists[-1])
+        return self._painter.viewlimits(self._artists[-1])

--- a/qt/python/mantidqt/widgets/sliceviewer/peaksviewer/representation/painter.py
+++ b/qt/python/mantidqt/widgets/sliceviewer/peaksviewer/representation/painter.py
@@ -12,6 +12,9 @@ from matplotlib.patches import Circle, Ellipse, Patch, PathPatch, Wedge
 from matplotlib.transforms import Affine2D, IdentityTransform
 import numpy as np
 
+# constants
+ZOOM_PAD_FRAC = 0.2
+
 
 class EllipticalShell(Patch):
     """
@@ -76,8 +79,6 @@ class MplPainter(object):
     """
     Implementation of a PeakPainter that uses matplotlib to draw
     """
-    ZOOM_PAD_FRAC = 0.2
-
     def __init__(self, axes):
         """
         :param axes: A matplotlib.axes.Axes instance to draw on
@@ -157,29 +158,32 @@ class MplPainter(object):
         return self._axes.add_patch(
             Wedge((x, y), outer_radius, theta1=0.0, theta2=360., width=thick, **kwargs))
 
-    def viewlimits(self, artist):
-        """Determine the view limits such that the given artist is in the center
-        with some padding
+    def bbox(self, artist):
+        """Determine the lower-left and upper-right coordinates of
+        a box that encompasses the given artist
         :param artist: An artist to inspect
         """
         # Use the bounding box of the artist with small amount of padding
         # to set the axis limits
         to_data_coords = self._axes.transData.inverted()
         artist_bbox = artist.get_extents()
-        ll, ur = to_data_coords.transform(artist_bbox.min), \
+        return to_data_coords.transform(artist_bbox.min), \
             to_data_coords.transform(artist_bbox.max)
-        # pad by fraction of maximum width so the artist is still in the center
-        xl, xr = ll[0], ur[0]
-        yb, yt = ll[1], ur[1]
-        padding = max(xr - xl, yt - yb) * self.ZOOM_PAD_FRAC
-        return ((xl - padding, xr + padding), (yb - padding, yt + padding))
 
 
 class Painted(object):
     """Combine a collection of artists with the painter that created them"""
-    def __init__(self, painter, artists):
+    def __init__(self, painter, artists, effective_bbox=None):
+        """
+        :param painter: A reference to the painter responsible for
+                        drawing the artists.
+        :param artists: A list of drawn artists
+        :param effective_bbox: An optional bounding box for artists that
+                               represent something with no real extent
+        """
         self._painter = painter
         self._artists = artists
+        self._effective_bbox = effective_bbox
 
     @property
     def artists(self):
@@ -198,4 +202,12 @@ class Painted(object):
         Determine the view limits such that the artists are in the center
         with some padding.
         """
-        return self._painter.viewlimits(self._artists[-1])
+        if self._effective_bbox is None:
+            ll, ur = self._painter.bbox(self._artists[-1])
+        else:
+            ll, ur = self._effective_bbox
+        # pad by fraction of maximum width so the artist is still in the center
+        xl, xr = ll[0], ur[0]
+        yb, yt = ll[1], ur[1]
+        padding = max(xr - xl, yt - yb) * ZOOM_PAD_FRAC
+        return ((xl - padding, xr + padding), (yb - padding, yt + padding))

--- a/qt/python/mantidqt/widgets/sliceviewer/peaksviewer/representation/test/test_peaksviewer_representation_draw.py
+++ b/qt/python/mantidqt/widgets/sliceviewer/peaksviewer/representation/test/test_peaksviewer_representation_draw.py
@@ -25,6 +25,8 @@ def draw_shape(shape_name, shape_info=None):
     """
     peak_origin, fg_color, bg_color = (1, 3, 5), "r", "g"
     peak_shape, slice_info, painter = (MagicMock(), ) * 3
+    painter.axes = MagicMock()
+    painter.axes.get_xlim.return_value = (-1, 1)
     peak_shape.shapeName.return_value = shape_name
     if shape_info is not None:
         peak_shape.toJSON.return_value = shape_info

--- a/qt/python/mantidqt/widgets/sliceviewer/peaksviewer/representation/test/test_peaksviewer_representation_nonintegrated.py
+++ b/qt/python/mantidqt/widgets/sliceviewer/peaksviewer/representation/test/test_peaksviewer_representation_nonintegrated.py
@@ -25,6 +25,7 @@ class NonIntegratedPeakRepresentationTest(unittest.TestCase):
             self, compute_alpha_mock):
         peak_origin, fg_color = (1, 3, 5), "r"
         peak_shape, painter = MagicMock(), MagicMock()
+        painter.axes.get_xlim.return_value = (-10, 10)
         alpha = 0.5
         compute_alpha_mock.return_value = alpha
         slice_info = create_slice_info(lambda x: x, slice_value=3., slice_width=10.)
@@ -33,12 +34,11 @@ class NonIntegratedPeakRepresentationTest(unittest.TestCase):
                                                        fg_color, "unused")
 
         width = 0.15
-        painter.cross.assert_called_with(
-            peak_origin[0],
-            peak_origin[1],
-            FuzzyMatch(width, atol=1e-2),
-            alpha=alpha,
-            color=fg_color)
+        painter.cross.assert_called_with(peak_origin[0],
+                                         peak_origin[1],
+                                         FuzzyMatch(width, atol=1e-2),
+                                         alpha=alpha,
+                                         color=fg_color)
         self.assertTrue(painted is not None)
 
     @patch("mantidqt.widgets.sliceviewer.peaksviewer.representation.noshape.compute_alpha")

--- a/qt/python/mantidqt/widgets/sliceviewer/peaksviewer/representation/test/test_peaksviewer_representation_painter.py
+++ b/qt/python/mantidqt/widgets/sliceviewer/peaksviewer/representation/test/test_peaksviewer_representation_painter.py
@@ -82,7 +82,7 @@ class MplPainterTest(unittest.TestCase):
         axes.add_patch.assert_called_once()
         self._verify_patch(patch=axes.add_patch.call_args[0][0], nvertices=100, alpha=None)
 
-    def test_viewlimits_returns_xy_limits_so_xy_at_center(self):
+    def test_bbox_returns_ll_and_ur_of_containing_box(self):
         artist, axes, bbox, inv_trans = (MagicMock(), ) * 4
         # 1:1 transformation for simplicity
         inv_trans.transform.side_effect = lambda x: x
@@ -91,10 +91,10 @@ class MplPainterTest(unittest.TestCase):
         bbox.min, bbox.max = (1., 1.5), (3., 3.5)
         painter = MplPainter(axes)
 
-        xlim, ylim = painter.viewlimits(artist)
+        ll, ur = painter.bbox(artist)
 
-        self.assertEqual((0.6, 3.4), xlim)
-        self.assertEqual((1.1, 3.9), ylim)
+        self.assertEqual(bbox.min, ll)
+        self.assertEqual(bbox.max, ur)
 
     def test_painted_viewlimits_returns_limits_for_last_artist(self):
         def create_mock_artist(extents):

--- a/qt/python/mantidqt/widgets/sliceviewer/peaksviewer/representation/test/test_peaksviewer_representation_painter.py
+++ b/qt/python/mantidqt/widgets/sliceviewer/peaksviewer/representation/test/test_peaksviewer_representation_painter.py
@@ -10,9 +10,12 @@
 import unittest
 from unittest.mock import MagicMock
 
+# 3rd party
+from numpy.testing import assert_allclose
+
 # local imports
 from mantidqt.widgets.sliceviewer.peaksviewer.representation.painter \
-    import MplPainter
+    import MplPainter, Painted
 
 
 class MplPainterTest(unittest.TestCase):
@@ -25,20 +28,6 @@ class MplPainterTest(unittest.TestCase):
         painter.remove(mock_artist)
 
         mock_artist.remove.assert_called_once()
-
-    def test_zoom_to_sets_xy_limits_so_xy_at_center(self):
-        artist, axes, bbox, inv_trans = (MagicMock(), ) * 4
-        # 1:1 transformation for simplicity
-        inv_trans.transform.side_effect = lambda x: x
-        axes.transData.inverted.return_value = inv_trans
-        artist.get_extents.return_value = bbox
-        bbox.min, bbox.max = (1., 1.5), (3., 3.5)
-        painter = MplPainter(axes)
-
-        painter.zoom_to(artist)
-
-        axes.set_xlim.assert_called_once_with(0.6, 3.4)
-        axes.set_ylim.assert_called_once_with(1.1, 3.9)
 
     def test_circle_draws_circle_patch(self):
         axes = MagicMock()
@@ -92,6 +81,42 @@ class MplPainterTest(unittest.TestCase):
 
         axes.add_patch.assert_called_once()
         self._verify_patch(patch=axes.add_patch.call_args[0][0], nvertices=100, alpha=None)
+
+    def test_viewlimits_returns_xy_limits_so_xy_at_center(self):
+        artist, axes, bbox, inv_trans = (MagicMock(), ) * 4
+        # 1:1 transformation for simplicity
+        inv_trans.transform.side_effect = lambda x: x
+        axes.transData.inverted.return_value = inv_trans
+        artist.get_extents.return_value = bbox
+        bbox.min, bbox.max = (1., 1.5), (3., 3.5)
+        painter = MplPainter(axes)
+
+        xlim, ylim = painter.viewlimits(artist)
+
+        self.assertEqual((0.6, 3.4), xlim)
+        self.assertEqual((1.1, 3.9), ylim)
+
+    def test_painted_viewlimits_returns_limits_for_last_artist(self):
+        def create_mock_artist(extents):
+            artist = MagicMock()
+            bbox = MagicMock()
+            bbox.min, bbox.max = extents
+            artist.get_extents.return_value = bbox
+            return artist
+
+        axes, inv_trans = MagicMock(), MagicMock()
+        # 1:1 transformation for simplicity
+        inv_trans.transform.side_effect = lambda x: x
+        axes.transData.inverted.return_value = inv_trans
+        artists = create_mock_artist(((1., 1.5), (3., 3.5))), create_mock_artist(
+            ((1.1, 1.3), (2.9, 3.6)))
+        painter = MplPainter(axes)
+        painted = Painted(painter, artists)
+
+        xlim, ylim = painted.viewlimits()
+
+        assert_allclose((0.64, 3.36), xlim)
+        assert_allclose((0.84, 4.06), ylim)
 
     # --------------- failure tests -----------------
     def test_construction_raises_error_if_given_non_axes_instance(self):

--- a/qt/python/mantidqt/widgets/sliceviewer/peaksviewer/test/modeltesthelpers.py
+++ b/qt/python/mantidqt/widgets/sliceviewer/peaksviewer/test/modeltesthelpers.py
@@ -22,7 +22,9 @@ def draw_peaks(centers, fg_color, slice_value, slice_width, frame=SpecialCoordin
     model = create_peaks_viewer_model(centers, fg_color)
     slice_info = create_slice_info(centers, slice_value, slice_width, frame)
     mock_painter = MagicMock(spec=MplPainter)
-    mock_painter._axes = MagicMock()
+    mock_axes = MagicMock()
+    mock_axes.get_xlim.return_value = (-1, 1)
+    mock_painter.axes = mock_axes
 
     model.draw_peaks(slice_info, mock_painter)
 

--- a/qt/python/mantidqt/widgets/sliceviewer/peaksviewer/test/test_peaksviewer_model.py
+++ b/qt/python/mantidqt/widgets/sliceviewer/peaksviewer/test/test_peaksviewer_model.py
@@ -11,6 +11,7 @@ from unittest.mock import MagicMock, create_autospec, patch
 # thirdparty imports
 from mantid.api import MatrixWorkspace, SpecialCoordinateSystem
 from mantid.dataobjects import PeaksWorkspace
+from numpy.testing import assert_allclose
 
 # local imports
 from mantidqt.widgets.sliceviewer.peaksviewer.model import PeaksViewerModel, create_peaksviewermodel
@@ -57,7 +58,7 @@ class PeaksViewerModelTest(unittest.TestCase):
         call_args, call_kwargs = mock_painter.cross.call_args
         self.assertEqual(visible_peak_center[0], call_args[0])
         self.assertEqual(visible_peak_center[1], call_args[1])
-        self.assertAlmostEqual(0.450, call_args[2], places=3)
+        self.assertAlmostEqual(0.03, call_args[2], places=3)
         self.assertAlmostEqual(0.356, call_kwargs["alpha"], places=3)
         self.assertEqual(fg_color, call_kwargs["color"])
 
@@ -89,16 +90,17 @@ class PeaksViewerModelTest(unittest.TestCase):
         peak0.getHKL.assert_not_called()
         self.assertEqual([1, None, None], slicepoint)
 
-    def test_zoom_to(self):
+    def test_viewlimits(self):
         visible_peak_center, invisible_center = (0.5, 0.2, 0.25), (0.4, 0.3, 25)
         model, mock_painter = draw_peaks((visible_peak_center, invisible_center),
                                          fg_color='r',
                                          slice_value=0.5,
                                          slice_width=30)
 
-        model.zoom_to(0)
+        xlim, ylim = model.viewlimits(0)
 
-        mock_painter.zoom_to.assert_called_once()
+        assert_allclose((-0.13, 1.13), xlim)
+        assert_allclose((-0.43, 0.83), ylim)
 
     # -------------------------- Failure Tests --------------------------------
     def test_model_accepts_only_peaks_workspaces(self):

--- a/qt/python/mantidqt/widgets/sliceviewer/peaksviewer/test/test_peaksviewer_presenter.py
+++ b/qt/python/mantidqt/widgets/sliceviewer/peaksviewer/test/test_peaksviewer_presenter.py
@@ -63,7 +63,9 @@ class PeaksViewerPresenterTest(unittest.TestCase):
         centers = ((1, 2, 3), (4, 5, 3.01))
         slice_info = create_slice_info(centers, slice_value=3, slice_width=5)
         test_model = create_peaks_viewer_model(centers, fg_color="r")
-        painter = MagicMock()
+        painter, axes = MagicMock(), MagicMock()
+        axes.get_xlim.return_value = (-1, 1)
+        painter.axes = axes
         test_model.draw_peaks(slice_info, painter)
         mock_view = MagicMock()
         mock_view.painter = painter
@@ -79,7 +81,10 @@ class PeaksViewerPresenterTest(unittest.TestCase):
         slice_info = create_slice_info(centers, slice_value=3, slice_width=5)
         test_model = create_peaks_viewer_model(centers, fg_color="r")
         # draw some peaks first so we can test clearing them
-        painter = MagicMock()
+        painter, axes = MagicMock(), MagicMock()
+        axes.get_xlim.return_value = (-1, 1)
+        painter.axes = axes
+
         test_model.draw_peaks(slice_info, painter)
         # clear draw calls
         painter.cross.reset_mock()

--- a/qt/python/mantidqt/widgets/sliceviewer/peaksviewer/test/test_peaksviewer_presenter.py
+++ b/qt/python/mantidqt/widgets/sliceviewer/peaksviewer/test/test_peaksviewer_presenter.py
@@ -34,9 +34,8 @@ def create_mock_model(name):
     return mock
 
 
-@patch(
-    "mantidqt.widgets.sliceviewer.peaksviewer.presenter.TableWorkspaceDataPresenter",
-    autospec=TableWorkspaceDataPresenter)
+@patch("mantidqt.widgets.sliceviewer.peaksviewer.presenter.TableWorkspaceDataPresenter",
+       autospec=TableWorkspaceDataPresenter)
 class PeaksViewerPresenterTest(unittest.TestCase):
 
     # -------------------- success tests -----------------------------
@@ -98,12 +97,15 @@ class PeaksViewerPresenterTest(unittest.TestCase):
         mock_view = MagicMock()
         name = 'ws1'
         mock_model = create_mock_model(name)
+        viewlimits = (-1, 1), (-2, 2)
+        mock_model.viewlimits.return_value = viewlimits
         mock_view.selected_index = 0
         presenter = PeaksViewerPresenter(mock_model, mock_view)
 
         presenter.notify(PeaksViewerPresenter.Event.PeakSelected)
 
-        mock_model.zoom_to.assert_called_once_with(0)
+        mock_model.viewlimits.assert_called_once_with(0)
+        mock_view.set_axes_limits.assert_called_once_with(*viewlimits)
 
 
 if __name__ == '__main__':

--- a/qt/python/mantidqt/widgets/sliceviewer/peaksviewer/view.py
+++ b/qt/python/mantidqt/widgets/sliceviewer/peaksviewer/view.py
@@ -60,6 +60,14 @@ class PeaksViewerView(QWidget):
         self._current_selection = self._selected_index()
         return self._current_selection
 
+    def set_axes_limits(self, xlim, ylim):
+        """
+        Set the view limits on the image axes to the given extents
+        :param xlim: 2-tuple of (xmin, xmax)
+        :param ylim: 2-tuple of (ymin, ymax)
+        """
+        self._sliceinfo_provider.set_axes_limits(xlim, ylim)
+
     def set_peak_color(self, peak_color):
         """
         Set the color of the peak represented in this view

--- a/qt/python/mantidqt/widgets/sliceviewer/peaksviewer/view.py
+++ b/qt/python/mantidqt/widgets/sliceviewer/peaksviewer/view.py
@@ -13,10 +13,17 @@ from qtpy.QtWidgets import QGroupBox, QVBoxLayout, QWidget
 from mantidqt.widgets.workspacedisplay.table.view import TableWorkspaceDisplayView, QTableWidget
 
 
-class PeaksWorkspaceTableView(TableWorkspaceDisplayView):
-    """Specialization of a table view to display peaks"""
+class _PeaksWorkspaceTableView(TableWorkspaceDisplayView):
+    """Specialization of a table view to display peaks
+    Designed specifically to be used by PeaksViewerView
+    """
+    def __init__(self, *args, **kwargs):
+        self._key_handler = kwargs.pop('key_handler')
+        TableWorkspaceDisplayView.__init__(self, *args, **kwargs)
+
     def keyPressEvent(self, event):
         QTableWidget.keyPressEvent(self, event)
+        self._key_handler._row_selected()
 
 
 class PeaksViewerView(QWidget):
@@ -34,7 +41,6 @@ class PeaksViewerView(QWidget):
         super().__init__(parent)
         self._painter = painter
         self._sliceinfo_provider = sliceinfo_provider
-        self._current_selection = None
         self._group_box = None
         self._presenter = None
         self._table_view = None
@@ -56,9 +62,7 @@ class PeaksViewerView(QWidget):
 
     @property
     def selected_index(self):
-        # cache current selection for checking in mouse click handler
-        self._current_selection = self._selected_index()
-        return self._current_selection
+        return self._selected_index()
 
     def set_axes_limits(self, xlim, ylim):
         """
@@ -102,13 +106,9 @@ class PeaksViewerView(QWidget):
         """
         self._group_box = QGroupBox(self)
         self._group_box.setContentsMargins(0, 0, 0, 0)
-        self._table_view = PeaksWorkspaceTableView(parent=self)
-        self._table_view.setSelectionBehavior(PeaksWorkspaceTableView.SelectRows)
-        self._table_view.setSelectionMode(PeaksWorkspaceTableView.SingleSelection)
-        # itemSelectionChanges handles selection changes from either keyboard/mouse
-        self._table_view.itemSelectionChanged.connect(self._on_row_selection_changed)
-        # the selection might not change when an item is clicked but we want to notify
-        # the outside world
+        self._table_view = _PeaksWorkspaceTableView(parent=self, key_handler=self)
+        self._table_view.setSelectionBehavior(_PeaksWorkspaceTableView.SelectRows)
+        self._table_view.setSelectionMode(_PeaksWorkspaceTableView.SingleSelection)
         self._table_view.itemClicked.connect(self._on_row_clicked)
 
         group_box_layout = QVBoxLayout()
@@ -118,12 +118,6 @@ class PeaksViewerView(QWidget):
         widget_layout.addWidget(self._group_box)
         self.setLayout(widget_layout)
 
-    def _on_row_selection_changed(self):
-        """
-        Notify that a different peak has been selected. It is assumed only single row selection is allowed
-        """
-        self._presenter.notify(self._presenter.Event.PeakSelected)
-
     def _on_row_clicked(self, _):
         """
         When a peak is clicked check if it is already selected and notify that this
@@ -132,8 +126,13 @@ class PeaksViewerView(QWidget):
         selection notification when peak selection changes as _on_row_selection_changed
         handles this.
         """
-        if self._current_selection == self._selected_index():
-            self._presenter.notify(self._presenter.Event.PeakSelected)
+        self._row_selected()
+
+    def _row_selected(self):
+        """
+        Notify that a different peak has been selected. It is assumed only single row selection is allowed
+        """
+        self._presenter.notify(self._presenter.Event.PeakSelected)
 
     def _selected_index(self):
         # construction ensures we can only have 0 or 1 items selected

--- a/qt/python/mantidqt/widgets/sliceviewer/presenter.py
+++ b/qt/python/mantidqt/widgets/sliceviewer/presenter.py
@@ -45,7 +45,7 @@ class SliceViewer(object):
         self.view = view if view else SliceViewerView(self, self.model.get_dimensions_info(),
                                                       self.model.can_normalize_workspace(), parent)
         self.view.data_view.create_axes_orthogonal(
-            redraw_on_zoom=(self.model.get_ws_type() == WS_TYPE.MATRIX))
+            redraw_on_zoom=not self.model.can_support_dynamic_rebinning())
 
         if self.model.can_normalize_workspace():
             self.view.data_view.set_normalization(ws)
@@ -58,7 +58,7 @@ class SliceViewer(object):
         if self.model.get_ws_type() == WS_TYPE.MATRIX:
             self.view.data_view.image_info_widget.setWorkspace(ws)
 
-        self.view.setWindowTitle(f"SliceViewer - {self.model.get_ws_name()}")
+        self.view.setWindowTitle(self.model.get_title())
 
         self.new_plot()
 

--- a/qt/python/mantidqt/widgets/sliceviewer/presenter.py
+++ b/qt/python/mantidqt/widgets/sliceviewer/presenter.py
@@ -154,7 +154,9 @@ class SliceViewer(object):
 
     def data_limits_changed(self):
         """Notify data limits on image axes have changed"""
-        if self.model.get_ws_type() == WS_TYPE.MDE:
+        if self.model.can_support_dynamic_rebinning():
+            data_view = self.view.data_view
+            self.model.rebin(slicepoint=self.get_slicepoint(), limits=data_view.get_axes_limits())
             self.new_plot()
             self._call_peaks_presenter_if_created("notify", PeaksViewerPresenter.Event.OverlayPeaks)
 

--- a/qt/python/mantidqt/widgets/sliceviewer/presenter.py
+++ b/qt/python/mantidqt/widgets/sliceviewer/presenter.py
@@ -44,6 +44,9 @@ class SliceViewer(object):
 
         self.view = view if view else SliceViewerView(self, self.model.get_dimensions_info(),
                                                       self.model.can_normalize_workspace(), parent)
+        self.view.data_view.create_axes_orthogonal(
+            redraw_on_zoom=(self.model.get_ws_type() == WS_TYPE.MATRIX))
+
         if self.model.can_normalize_workspace():
             self.view.data_view.set_normalization(ws)
             self.view.data_view.norm_opts.currentTextChanged.connect(self.normalization_changed)

--- a/qt/python/mantidqt/widgets/sliceviewer/presenter.py
+++ b/qt/python/mantidqt/widgets/sliceviewer/presenter.py
@@ -137,7 +137,8 @@ class SliceViewer(object):
         Update the view to display an updated MDHistoWorkspace slice/cut
         """
         self.view.data_view.update_plot_data(
-            self.model.get_data(self.get_slicepoint(), self.view.data_view.dimensions.transpose))
+            self.model.get_data(self.get_slicepoint(),
+                                transpose=self.view.data_view.dimensions.transpose))
 
     def update_plot_data_MDE(self):
         """

--- a/qt/python/mantidqt/widgets/sliceviewer/presenter.py
+++ b/qt/python/mantidqt/widgets/sliceviewer/presenter.py
@@ -157,11 +157,13 @@ class SliceViewer(object):
 
     def data_limits_changed(self):
         """Notify data limits on image axes have changed"""
+        data_view = self.view.data_view
         if self.model.can_support_dynamic_rebinning():
-            data_view = self.view.data_view
             self.model.rebin(slicepoint=self.get_slicepoint(), limits=data_view.get_axes_limits())
             self.new_plot()
             self._call_peaks_presenter_if_created("notify", PeaksViewerPresenter.Event.OverlayPeaks)
+        else:
+            data_view.draw_plot()
 
     def show_all_data_requested(self):
         """Instructs the view to show all data"""

--- a/qt/python/mantidqt/widgets/sliceviewer/presenter.py
+++ b/qt/python/mantidqt/widgets/sliceviewer/presenter.py
@@ -154,8 +154,9 @@ class SliceViewer(object):
 
     def data_limits_changed(self):
         """Notify data limits on image axes have changed"""
-        self.new_plot()
-        self._call_peaks_presenter_if_created("notify", PeaksViewerPresenter.Event.OverlayPeaks)
+        if self.model.get_ws_type() == WS_TYPE.MDE:
+            self.new_plot()
+            self._call_peaks_presenter_if_created("notify", PeaksViewerPresenter.Event.OverlayPeaks)
 
     def show_all_data_requested(self):
         """Instructs the view to show all data"""

--- a/qt/python/mantidqt/widgets/sliceviewer/presenter.py
+++ b/qt/python/mantidqt/widgets/sliceviewer/presenter.py
@@ -159,10 +159,10 @@ class SliceViewer(object):
 
     def show_all_data_requested(self):
         """Instructs the view to show all data"""
-        self.update_axes_limits(*self.model.get_dim_limits(
-            self.get_slicepoint(), self.view.data_view.dimensions.transpose))
+        self.set_axes_limits(*self.model.get_dim_limits(self.get_slicepoint(),
+                                                        self.view.data_view.dimensions.transpose))
 
-    def update_axes_limits(self, xlim, ylim):
+    def set_axes_limits(self, xlim, ylim):
         """Set the axes limits on the view"""
         self.view.data_view.set_axes_limits(xlim, ylim)
         self.data_limits_changed()

--- a/qt/python/mantidqt/widgets/sliceviewer/test/modeltesthelpers.py
+++ b/qt/python/mantidqt/widgets/sliceviewer/test/modeltesthelpers.py
@@ -1,0 +1,142 @@
+# Mantid Repository : https://github.com/mantidproject/mantid
+#
+# Copyright &copy; 2020 ISIS Rutherford Appleton Laboratory UKRI,
+#   NScD Oak Ridge National Laboratory, European Spallation Source,
+#   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+# SPDX - License - Identifier: GPL - 3.0 +
+#  This file is part of the mantidqt.
+# std
+from unittest.mock import MagicMock
+
+# 3rd party imports
+from mantid.api import (MatrixWorkspace, IMDEventWorkspace, IMDHistoWorkspace,
+                        SpecialCoordinateSystem)
+from mantid.geometry import IMDDimension
+import numpy as np
+
+
+def create_mock_histoworkspace(ndims: int, coords: SpecialCoordinateSystem, extents: tuple,
+                               signal: np.array, error: np.array, nbins: tuple, names: tuple,
+                               units: tuple, isq: tuple):
+    """
+    :param ndims: The number of dimensions
+    :param coords: MD coordinate system
+    :param extents: Extents of each dimension
+    :param signal: Array to be returned as signal
+    :param error: Array to be returned as errors
+    :param nbins: Number of bins in each dimension
+    :param names: The name of each dimension
+    :param units: Unit labels for each dimension
+    :param isq: Boolean for each dimension defining if Q or not
+    """
+    ws = create_mock_workspace(IMDHistoWorkspace, coords, has_oriented_lattice=False, ndims=ndims)
+    ws.getSignalArray.return_value = signal
+    ws.getErrorSquaredArray.return_value = error
+    return add_dimensions(ws, names, isq, extents, nbins, units)
+
+
+def create_mock_mdeventworkspace(ndims: int, coords: SpecialCoordinateSystem, extents: tuple,
+                                 names: tuple, units: tuple, isq: tuple):
+    """
+    :param ndims: The number of dimensions
+    :param coords: MD coordinate system
+    :param extents: Extents of each dimension
+    :param names: The name of each dimension
+    :param units: Unit labels for each dimension
+    :param isq: Boolean for each dimension defining if Q or not
+    """
+    ws = create_mock_workspace(IMDEventWorkspace, coords, has_oriented_lattice=False, ndims=ndims)
+    return add_dimensions(ws, names, isq, extents, nbins=(1, ) * ndims, units=units)
+
+
+def create_mock_matrixworkspace(x_axis: tuple,
+                                y_axis: tuple,
+                                distribution: bool,
+                                names: tuple,
+                                units: tuple = None):
+    """
+    :param x_axis: X axis values
+    :param y_axis: Y axis values
+    :param distribution: Value of distribution flag
+    :param names: The name of each dimension
+    :param units: Unit labels for each dimension
+    """
+    ws = MagicMock(MatrixWorkspace)
+    ws.getNumDims.return_value = 2
+    ws.getNumberHistograms.return_value = len(y_axis)
+    ws.isDistribution.return_value = distribution
+    extents = (x_axis[0], x_axis[-1], y_axis[0], y_axis[-1])
+    nbins = (len(x_axis) - 1, len(y_axis) - 1)
+    return add_dimensions(ws, names, (False, False), extents, nbins, units)
+
+
+def create_mock_workspace(ws_type,
+                          coords: SpecialCoordinateSystem = None,
+                          has_oriented_lattice: bool = None,
+                          ndims: int = 2):
+    """
+    :param ws_type: Used this as spec for Mock
+    :param coords: MD coordinate system for MD workspaces
+    :param has_oriented_lattice: If the mock should claim to have an attached a lattice
+    :param ndims: The number of dimensions
+    """
+    ws = MagicMock(spec=ws_type)
+    if hasattr(ws, 'getExperimentInfo'):
+        ws.getNumDims.return_value = ndims
+        if ws_type == IMDHistoWorkspace:
+            ws.isMDHistoWorkspace.return_value = True
+            ws.getNonIntegratedDimensions.return_value = [MagicMock(), MagicMock()]
+        else:
+            ws.isMDHistoWorkspace.return_value = False
+
+        ws.getSpecialCoordinateSystem.return_value = coords
+        expt_info = MagicMock()
+        sample = MagicMock()
+        sample.hasOrientedLattice.return_value = has_oriented_lattice
+        expt_info.sample.return_value = sample
+        ws.getExperimentInfo.return_value = expt_info
+    elif hasattr(ws, 'getNumberHistograms'):
+        ws.getNumDims.return_value = 2
+        ws.getNumberHistograms.return_value = 3
+        mock_dimension = MagicMock()
+        mock_dimension.getNBins.return_value = 3
+        ws.getDimension.return_value = mock_dimension
+    return ws
+
+
+def add_dimensions(mock_ws,
+                   names,
+                   isq,
+                   extents: tuple = None,
+                   nbins: tuple = None,
+                   units: tuple = None):
+    """
+    :param mock_ws: An existing mock workspace object
+    :param names: The name of each dimension
+    :param isq: Boolean for each dimension defining if Q or not
+    :param extents: Extents of each dimension
+    :param nbins: Number of bins in each dimension
+    :param units: Unit labels for each dimension
+    """
+    def create_dimension(index):
+        dimension = MagicMock(spec=IMDDimension)
+        dimension.name = names[index]
+        mdframe = MagicMock()
+        mdframe.isQ.return_value = isq[index]
+        dimension.getMDFrame.return_value = mdframe
+        if units is not None:
+            dimension.getUnits.return_value = units[index]
+        if extents is not None:
+            dim_min, dim_max = extents[2 * index], extents[2 * index + 1]
+            dimension.getMinimum.return_value = dim_min
+            dimension.getMaximum.return_value = dim_max
+            if nbins is not None:
+                bin_width = (dim_max - dim_min) / nbins[index]
+                dimension.getBinWidth.return_value = bin_width
+                dimension.getX.side_effect = lambda i: dim_min + bin_width * i
+                dimension.getNBins.return_value = nbins[index]
+        return dimension
+
+    dimensions = [create_dimension(index) for index in range(len(names))]
+    mock_ws.getDimension.side_effect = lambda index: dimensions[index]
+    return mock_ws

--- a/qt/python/mantidqt/widgets/sliceviewer/test/test_sliceviewer_model.py
+++ b/qt/python/mantidqt/widgets/sliceviewer/test/test_sliceviewer_model.py
@@ -7,6 +7,7 @@
 #  This file is part of the mantid workbench.
 #
 #
+from contextlib import contextmanager
 import unittest
 from unittest.mock import MagicMock, patch
 import sys
@@ -40,7 +41,23 @@ def _create_mock_histoworkspace(ndims: int, coords: SpecialCoordinateSystem, ext
     ws = _create_mock_workspace(IMDHistoWorkspace, coords, has_oriented_lattice=False, ndims=ndims)
     ws.getSignalArray.return_value = signal
     ws.getErrorSquaredArray.return_value = error
+    ws.hasOriginalWorkspace.return_value = False
     return _add_dimensions(ws, names, isq, extents, nbins, units)
+
+
+@contextmanager
+def _attach_as_original(histo_ws, mde_ws):
+    """
+    Temporarily attach an MDEventWorkspace to a MDHistoWorkspace
+    as an original workspace
+    :param histo_ws: A mock MDHistoWorkspace
+    :param mde_ws: A mock MDEventWorkspace
+    """
+    histo_ws.hasOriginalWorkspace.return_value = True
+    histo_ws.getOriginalWorkspace.return_value = mde_ws
+    yield
+    histo_ws.hasOriginalWorkspace.return_value = False
+    histo_ws.getOriginalWorkspace.return_value = MagicMock()
 
 
 def _create_mock_mdeventworkspace(ndims: int, coords: SpecialCoordinateSystem, extents: tuple,
@@ -94,6 +111,7 @@ def _create_mock_workspace(ws_type,
         if ws_type == IMDHistoWorkspace:
             ws.isMDHistoWorkspace.return_value = True
             ws.getNonIntegratedDimensions.return_value = [MagicMock(), MagicMock()]
+            ws.hasOriginalWorkspace.return_value = False
         else:
             ws.isMDHistoWorkspace.return_value = False
 
@@ -201,6 +219,7 @@ class SliceViewerModelTest(unittest.TestCase):
                                                        distribution=True,
                                                        names=('Wavelength', 'Energy transfer'),
                                                        units=('Angstrom', 'meV'))
+        self.ws2d_histo.name.return_value = 'ws2d_histo'
 
     def test_model_MDH(self):
         model = SliceViewerModel(self.ws_MD_3D)
@@ -243,7 +262,7 @@ class SliceViewerModelTest(unittest.TestCase):
 
         self.assertNotEqual(model.get_ws((None, None, 0), (1, 2, 4)), self.ws_MDE_3D)
         mock_binmd.assert_called_once_with(InputWorkspace=self.ws_MDE_3D,
-                                           OutputWorkspace='ws_MDE_3D_rebinned',
+                                           OutputWorkspace='ws_MDE_3D_svrebinned',
                                            AlignedDim0='h,-3,3,1',
                                            AlignedDim1='k,-4,4,2',
                                            AlignedDim2='l,-2.0,2.0,1',
@@ -275,6 +294,12 @@ class SliceViewerModelTest(unittest.TestCase):
         self.assertEqual(dim_info['type'], 'MDE')
         self.assertEqual(dim_info['qdim'], False)
 
+    def test_model_given_MDH_with_original_uses_original_as_data_ws(self):
+        with _attach_as_original(self.ws_MD_3D, self.ws_MDE_3D):
+            model = SliceViewerModel(self.ws_MD_3D)
+
+            self.assertEqual(self.ws_MDE_3D, model._get_ws())
+
     @patch('mantidqt.widgets.sliceviewer.model.BinMD')
     def test_get_ws_MDE_with_limits_uses_limits_over_dimension_extents(self, mock_binmd):
         model = SliceViewerModel(self.ws_MDE_3D)
@@ -283,7 +308,7 @@ class SliceViewerModelTest(unittest.TestCase):
         self.assertNotEqual(model.get_ws((None, None, 0), (1, 2, 4), ((-2, 2), (-1, 1))),
                             self.ws_MDE_3D)
         call_params = dict(InputWorkspace=self.ws_MDE_3D,
-                           OutputWorkspace='ws_MDE_3D_rebinned',
+                           OutputWorkspace='ws_MDE_3D_svrebinned',
                            AlignedDim0='h,-2,2,1',
                            AlignedDim1='k,-1,1,2',
                            AlignedDim2='l,-2.0,2.0,1',
@@ -462,6 +487,27 @@ class SliceViewerModelTest(unittest.TestCase):
     def test_matrixworkspace_does_not_dynamic_rebinning(self):
         self._assert_supports_dynamic_rebinning(False, MatrixWorkspace)
 
+    def test_title_for_matrixworkspace_just_contains_ws_name(self):
+        model = SliceViewerModel(self.ws2d_histo)
+
+        self.assertEqual('Sliceviewer - ws2d_histo', model.get_title())
+
+    def test_title_for_mdeventworkspace_just_contains_ws_name(self):
+        model = SliceViewerModel(self.ws_MDE_3D)
+
+        self.assertEqual('Sliceviewer - ws_MDE_3D', model.get_title())
+
+    def test_title_for_mdhistoworkspace_without_original_just_contains_ws_name(self):
+        model = SliceViewerModel(self.ws_MD_3D)
+
+        self.assertEqual('Sliceviewer - ws_MD_3D', model.get_title())
+
+    def test_title_for_mdhistoworkspace_with_original_contains_original_name(self):
+        with _attach_as_original(self.ws_MD_3D, self.ws_MDE_3D):
+            model = SliceViewerModel(self.ws_MD_3D)
+
+            self.assertEqual('Sliceviewer - ws_MDE_3D (original of ws_MD_3D)', model.get_title())
+
     def test_create_non_orthogonal_transform_raises_error_if_not_supported(self):
         model = SliceViewerModel(
             _create_mock_workspace(MatrixWorkspace,
@@ -569,7 +615,7 @@ class SliceViewerModelTest(unittest.TestCase):
         model.rebin(slicepoint=(None, 0, None), limits=((-1, 1), (-2, 2)))
 
         mock_binmd.assert_called_once_with(InputWorkspace=self.ws_MD_3D,
-                                           OutputWorkspace='ws_MD_3D_rebinned',
+                                           OutputWorkspace='ws_MD_3D_svrebinned',
                                            AxisAligned=False,
                                            EnableLogging=False,
                                            BasisVector0='Dim1,MomentumTransfer,1.0,0.0,0.0',
@@ -593,7 +639,7 @@ class SliceViewerModelTest(unittest.TestCase):
         model.rebin(slicepoint=(None, 0, None), limits=((-1, 1), (-2, 2)))
         model.rebin(slicepoint=(None, 0, None), limits=((-0.5, 0.5), (-2, 2)))
         self.assertEqual(2, mock_binmd.call_count)
-        self.assertEqual(self.ws_MD_3D.name() + '_rebinned',
+        self.assertEqual(self.ws_MD_3D.name() + '_svrebinned',
                          mock_binmd.call_args[-1]['OutputWorkspace'])
 
     @patch('mantidqt.widgets.sliceviewer.model.BinMD')
@@ -643,6 +689,8 @@ class SliceViewerModelTest(unittest.TestCase):
             ws.hasOriginalWorkspace.return_value = False
         elif has_original_workspace is not None:
             ws.hasOriginalWorkspace.return_value = has_original_workspace
+            if has_original_workspace:
+                ws.getOriginalWorkspace.return_value = self.ws_MDE_3D
         model = SliceViewerModel(ws)
         self.assertEqual(expectation, model.can_support_dynamic_rebinning())
 

--- a/qt/python/mantidqt/widgets/sliceviewer/test/test_sliceviewer_model.py
+++ b/qt/python/mantidqt/widgets/sliceviewer/test/test_sliceviewer_model.py
@@ -187,6 +187,7 @@ class SliceViewerModelTest(unittest.TestCase):
                                                     units=('MomentumTransfer', 'EnergyTransfer',
                                                            'Angstrom'),
                                                     isq=(False, False, False))
+        self.ws_MD_3D.name.return_value = 'ws_MD_3D'
         self.ws_MDE_3D = _create_mock_mdeventworkspace(ndims=3,
                                                        coords=SpecialCoordinateSystem.NONE,
                                                        extents=(-3, 3, -4, 4, -5, 5),
@@ -442,6 +443,25 @@ class SliceViewerModelTest(unittest.TestCase):
         self._assert_supports_peaks_overlay(True, IMDEventWorkspace, ndims=3)
         self._assert_supports_peaks_overlay(True, IMDHistoWorkspace, ndims=3)
 
+    def test_mdeventworkspace_supports_dynamic_rebinning(self):
+        self._assert_supports_dynamic_rebinning(True,
+                                                IMDEventWorkspace,
+                                                has_original_workspace=True)
+        self._assert_supports_dynamic_rebinning(True,
+                                                IMDEventWorkspace,
+                                                has_original_workspace=False)
+
+    def test_mdhistoworkspace_supports_dynamic_rebinning(self):
+        self._assert_supports_dynamic_rebinning(True,
+                                                IMDHistoWorkspace,
+                                                has_original_workspace=True)
+        self._assert_supports_dynamic_rebinning(False,
+                                                IMDHistoWorkspace,
+                                                has_original_workspace=False)
+
+    def test_matrixworkspace_does_not_dynamic_rebinning(self):
+        self._assert_supports_dynamic_rebinning(False, MatrixWorkspace)
+
     def test_create_non_orthogonal_transform_raises_error_if_not_supported(self):
         model = SliceViewerModel(
             _create_mock_workspace(MatrixWorkspace,
@@ -541,6 +561,65 @@ class SliceViewerModelTest(unittest.TestCase):
                           slicepoint=(None, None, 0, 0),
                           transpose=False)
 
+    @patch('mantidqt.widgets.sliceviewer.model.BinMD')
+    def test_rebin_mdhistworkspace_calls_binmd(self, mock_binmd):
+        orig_ws = self.ws_MD_3D
+        model = SliceViewerModel(orig_ws)
+
+        model.rebin(slicepoint=(None, 0, None), limits=((-1, 1), (-2, 2)))
+
+        mock_binmd.assert_called_once_with(InputWorkspace=self.ws_MD_3D,
+                                           OutputWorkspace='ws_MD_3D_rebinned',
+                                           AxisAligned=False,
+                                           EnableLogging=False,
+                                           BasisVector0='Dim1,MomentumTransfer,1.0,0.0,0.0',
+                                           BasisVector1='Dim2,EnergyTransfer,0.0,1.0,0.0',
+                                           BasisVector2='Dim3,Angstrom,0.0,0.0,1.0',
+                                           OutputExtents='-1,1,-10,10,-2,2',
+                                           OutputBins='5,5,4')
+
+        self.assertEqual(
+            mock_binmd.return_value,
+            model._get_ws(),
+            msg='Expected internal workspace reference to have been overwritten by result of BinMD')
+
+    @patch('mantidqt.widgets.sliceviewer.model.BinMD')
+    def test_rebin_mdhistworkspace_twice_uses_same_output_wsname(self, mock_binmd):
+        orig_ws = self.ws_MD_3D
+        model = SliceViewerModel(orig_ws)
+        mock_rebinned_first = MagicMock(getNumDims=lambda: 3)
+        mock_binmd.return_value = mock_rebinned_first
+
+        model.rebin(slicepoint=(None, 0, None), limits=((-1, 1), (-2, 2)))
+        model.rebin(slicepoint=(None, 0, None), limits=((-0.5, 0.5), (-2, 2)))
+        self.assertEqual(2, mock_binmd.call_count)
+        self.assertEqual(self.ws_MD_3D.name() + '_rebinned',
+                         mock_binmd.call_args[-1]['OutputWorkspace'])
+
+    @patch('mantidqt.widgets.sliceviewer.model.BinMD')
+    def test_rebin_mdeventworkspace_does_nothing(self, mock_binmd):
+        orig_ws = self.ws_MDE_3D
+        model = SliceViewerModel(orig_ws)
+
+        model.rebin(slicepoint=(None, None, 0.),
+                    bin_params=[100, 100, 1],
+                    limits=(-1, 1, -2, 2, -3, 3))
+
+        mock_binmd.assert_not_called()
+        self.assertEqual(orig_ws, model._get_ws())
+
+    @patch('mantidqt.widgets.sliceviewer.model.BinMD')
+    def test_rebin_matrixworkspace_does_nothing(self, mock_binmd):
+        orig_ws = self.ws2d_histo
+        model = SliceViewerModel(orig_ws)
+
+        model.rebin(slicepoint=(None, None, 0.),
+                    bin_params=[100, 100, 1],
+                    limits=(-1, 1, -2, 2, -3, 3))
+
+        mock_binmd.assert_not_called()
+        self.assertEqual(orig_ws, model._get_ws())
+
     # private
     def _assert_supports_non_orthogonal_axes(self, expectation, ws_type, coords,
                                              has_oriented_lattice):
@@ -554,6 +633,18 @@ class SliceViewerModelTest(unittest.TestCase):
                                     ndims=ndims)
         model = SliceViewerModel(ws)
         self.assertEqual(expectation, model.can_support_peaks_overlays())
+
+    def _assert_supports_dynamic_rebinning(self, expectation, ws_type, has_original_workspace=None):
+        ws = _create_mock_workspace(ws_type,
+                                    coords=SpecialCoordinateSystem.QLab,
+                                    has_oriented_lattice=False,
+                                    ndims=3)
+        if ws_type == MatrixWorkspace:
+            ws.hasOriginalWorkspace.return_value = False
+        elif has_original_workspace is not None:
+            ws.hasOriginalWorkspace.return_value = has_original_workspace
+        model = SliceViewerModel(ws)
+        self.assertEqual(expectation, model.can_support_dynamic_rebinning())
 
 
 if __name__ == '__main__':

--- a/qt/python/mantidqt/widgets/sliceviewer/test/test_sliceviewer_model.py
+++ b/qt/python/mantidqt/widgets/sliceviewer/test/test_sliceviewer_model.py
@@ -245,7 +245,8 @@ class SliceViewerModelTest(unittest.TestCase):
                                            OutputWorkspace='ws_MDE_3D_rebinned',
                                            AlignedDim0='h,-3,3,1',
                                            AlignedDim1='k,-4,4,2',
-                                           AlignedDim2='l,-2.0,2.0,1')
+                                           AlignedDim2='l,-2.0,2.0,1',
+                                           EnableLogging=False)
         mock_binmd.reset_mock()
         self.assertEqual(model._get_ws(), self.ws_MDE_3D)
         self.assertEqual(model.get_ws_type(), WS_TYPE.MDE)
@@ -284,7 +285,8 @@ class SliceViewerModelTest(unittest.TestCase):
                            OutputWorkspace='ws_MDE_3D_rebinned',
                            AlignedDim0='h,-2,2,1',
                            AlignedDim1='k,-1,1,2',
-                           AlignedDim2='l,-2.0,2.0,1')
+                           AlignedDim2='l,-2.0,2.0,1',
+                           EnableLogging=False)
         mock_binmd.assert_called_once_with(**call_params)
         mock_binmd.reset_mock()
 

--- a/qt/python/mantidqt/widgets/sliceviewer/test/test_sliceviewer_model.py
+++ b/qt/python/mantidqt/widgets/sliceviewer/test/test_sliceviewer_model.py
@@ -273,6 +273,24 @@ class SliceViewerModelTest(unittest.TestCase):
         self.assertEqual(dim_info['type'], 'MDE')
         self.assertEqual(dim_info['qdim'], False)
 
+    @patch('mantidqt.widgets.sliceviewer.model.BinMD')
+    def test_get_ws_MDE_with_limits_uses_limits_over_dimension_extents(self, mock_binmd):
+        model = SliceViewerModel(self.ws_MDE_3D)
+        mock_binmd.return_value = self.ws_MD_3D
+
+        self.assertNotEqual(model.get_ws((None, None, 0), (1, 2, 4), ((-2, 2), (-1, 1))),
+                            self.ws_MDE_3D)
+        call_params = dict(InputWorkspace=self.ws_MDE_3D,
+                           OutputWorkspace='ws_MDE_3D_rebinned',
+                           AlignedDim0='h,-2,2,1',
+                           AlignedDim1='k,-1,1,2',
+                           AlignedDim2='l,-2.0,2.0,1')
+        mock_binmd.assert_called_once_with(**call_params)
+        mock_binmd.reset_mock()
+
+        model.get_data((None, None, 0), (1, 2, 4), ((-2, 2), (-1, 1)))
+        mock_binmd.assert_called_once_with(**call_params)
+
     def test_model_matrix(self):
         model = SliceViewerModel(self.ws2d_histo)
 

--- a/qt/python/mantidqt/widgets/sliceviewer/test/test_sliceviewer_view.py
+++ b/qt/python/mantidqt/widgets/sliceviewer/test/test_sliceviewer_view.py
@@ -9,29 +9,77 @@ import unittest
 
 import matplotlib as mpl
 mpl.use('Agg')  # noqa
-from mantid.simpleapi import CreateMDHistoWorkspace
+from mantid.simpleapi import (CreateMDHistoWorkspace, CreateMDWorkspace, CreateSampleWorkspace,
+                              SetUB)
 from mantidqt.utils.qt.testing import start_qapplication
 from mantidqt.utils.qt.testing.qt_widget_finder import QtWidgetFinder
 from mantidqt.widgets.sliceviewer.presenter import SliceViewer
+from mantidqt.widgets.sliceviewer.toolbar import ToolItemText
 from qtpy.QtWidgets import QApplication
 
 
 @start_qapplication
 class SliceViewerViewTest(unittest.TestCase, QtWidgetFinder):
+    @classmethod
+    def setUpClass(cls):
+        cls.histo_ws = CreateMDHistoWorkspace(Dimensionality=3,
+                                              Extents='-3,3,-10,10,-1,1',
+                                              SignalInput=range(100),
+                                              ErrorInput=range(100),
+                                              NumberOfBins='5,5,4',
+                                              Names='Dim1,Dim2,Dim3',
+                                              Units='MomentumTransfer,EnergyTransfer,Angstrom',
+                                              OutputWorkspace='ws_MD_2d')
+
     def test_deleted_on_close(self):
-        ws = CreateMDHistoWorkspace(
-            Dimensionality=3,
-            Extents='-3,3,-10,10,-1,1',
-            SignalInput=range(100),
-            ErrorInput=range(100),
-            NumberOfBins='5,5,4',
-            Names='Dim1,Dim2,Dim3',
-            Units='MomentumTransfer,EnergyTransfer,Angstrom',
-            OutputWorkspace='ws_MD_2d')
-        pres = SliceViewer(ws)
+        pres = SliceViewer(self.histo_ws)
         self.assert_widget_created()
         pres.view.close()
+        del pres
 
+        QApplication.processEvents()
         QApplication.processEvents()
 
         self.assert_no_toplevel_widgets()
+
+    def test_enable_nonorthogonal_view_disables_lineplots_if_enabled(self):
+        hkl_ws = CreateMDWorkspace(Dimensions=3,
+                                   Extents='-10,10,-10,10,-10,10',
+                                   Names='A,B,C',
+                                   Units='r.l.u.,r.l.u.,r.l.u.',
+                                   Frames='HKL,HKL,HKL')
+        expt_info = CreateSampleWorkspace()
+        hkl_ws.addExperimentInfo(expt_info)
+        SetUB(hkl_ws, 1, 1, 1, 90, 90, 90)
+        pres = SliceViewer(hkl_ws)
+        line_plots_action, non_ortho_action = toolbar_actions(
+            pres, (ToolItemText.LINEPLOTS, ToolItemText.NONORTHOGONAL_AXES))
+        line_plots_action.trigger()
+        QApplication.processEvents()
+
+        non_ortho_action.trigger()
+        QApplication.processEvents()
+
+        self.assertTrue(non_ortho_action.isChecked())
+        self.assertFalse(line_plots_action.isChecked())
+        self.assertFalse(line_plots_action.isEnabled())
+
+        pres.view.close()
+
+
+# private helper functions
+
+
+def toolbar_actions(presenter, text_labels):
+    """
+    Return a list of actions with the given text labels
+    :param presenter: Presenter containing view
+    :param text_labels: A list of text labels on toolbar buttons
+    :return: A list of QAction objects matching the text labels given
+    """
+    toolbar_actions = presenter.view.data_view.mpl_toolbar.actions()
+    return [action for action in toolbar_actions if action.text() in text_labels]
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/qt/python/mantidqt/widgets/sliceviewer/test/test_sliceviewer_view.py
+++ b/qt/python/mantidqt/widgets/sliceviewer/test/test_sliceviewer_view.py
@@ -6,7 +6,6 @@
 # SPDX - License - Identifier: GPL - 3.0 +
 #  This file is part of the mantid workbench.
 import unittest
-from unittest.mock import MagicMock
 
 import matplotlib as mpl
 mpl.use('Agg')  # noqa
@@ -64,26 +63,6 @@ class SliceViewerViewTest(unittest.TestCase, QtWidgetFinder):
         self.assertTrue(non_ortho_action.isChecked())
         self.assertFalse(line_plots_action.isChecked())
         self.assertFalse(line_plots_action.isEnabled())
-
-        pres.view.close()
-
-    def test_data_limits_changed_call_for_MDHisto_does_not_create_new_plot(self):
-        pres = SliceViewer(self.histo_ws)
-        new_plot_mock = MagicMock()
-        pres.new_plot = new_plot_mock
-        pres.data_limits_changed()
-
-        new_plot_mock.assert_not_called()
-
-        pres.view.close()
-
-    def test_data_limits_changed_call_for_MDE_creates_new_plot(self):
-        pres = SliceViewer(self.hkl_ws)
-        new_plot_mock = MagicMock()
-        pres.new_plot = new_plot_mock
-        pres.data_limits_changed()
-
-        new_plot_mock.assert_called_once()
 
         pres.view.close()
 

--- a/qt/python/mantidqt/widgets/sliceviewer/test/test_sliceviewer_zoom.py
+++ b/qt/python/mantidqt/widgets/sliceviewer/test/test_sliceviewer_zoom.py
@@ -1,0 +1,49 @@
+# Mantid Repository : https://github.com/mantidproject/mantid
+#
+# Copyright &copy; 2020 ISIS Rutherford Appleton Laboratory UKRI,
+#   NScD Oak Ridge National Laboratory, European Spallation Source,
+#   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+# SPDX - License - Identifier: GPL - 3.0 +
+#  This file is part of the mantidqt.
+# std imports
+import unittest
+from unittest.mock import ANY, MagicMock
+
+# 3rd party imports
+#from matplotlib.backend_bases import FigureCanvas
+from mantidqt.widgets.sliceviewer.zoom import ScrollZoomMixin
+
+
+class ScrollZoomMixinTest(unittest.TestCase):
+    class Canvas(ScrollZoomMixin, object):
+        def __init__(self):
+            self.mpl_connect = MagicMock()
+            self.mpl_disconnect = MagicMock()
+
+    def test_enable_zoom_connects_to_scroll_event(self):
+        canvas = ScrollZoomMixinTest.Canvas()
+        axes = MagicMock()
+        canvas.enable_zoom_on_scroll(axes)
+
+        canvas.mpl_connect.assert_called_once_with('scroll_event', ANY)
+        axes.set_xlim.assert_not_called()
+        axes.set_ylim.assert_not_called()
+
+    def test_disable_zoom_without_enable_does_nothing(self):
+        canvas = ScrollZoomMixinTest.Canvas()
+
+        canvas.disable_zoom_on_scroll()
+
+    def test_disable_zoom_after_enable_calls_disconnect_with_correct_id(self):
+        canvas = ScrollZoomMixinTest.Canvas()
+        axes = MagicMock()
+
+        canvas.enable_zoom_on_scroll(axes)
+        cid = canvas.scroll_cid
+        canvas.disable_zoom_on_scroll()
+
+        canvas.mpl_disconnect(cid)
+
+
+if __name__ == '__name':
+    unittest.main()

--- a/qt/python/mantidqt/widgets/sliceviewer/toolbar.py
+++ b/qt/python/mantidqt/widgets/sliceviewer/toolbar.py
@@ -32,6 +32,7 @@ class SliceViewerNavigationToolbar(NavigationToolbar2QT):
     nonOrthogonalClicked = Signal(bool)
     peaksOverlayClicked = Signal(bool)
     plotOptionsChanged = Signal()
+    zoomPanFinished = Signal()
 
     toolitems = (
         (ToolItemText.HOME, 'Reset original view', 'mdi.home', 'homeClicked', None),
@@ -84,6 +85,12 @@ class SliceViewerNavigationToolbar(NavigationToolbar2QT):
         NavigationToolbar2QT.edit_parameters(self)
         self.plotOptionsChanged.emit()
 
+    def release(self, _):
+        """
+        Called when a zoom/pan event has completed
+        """
+        self.zoomPanFinished.emit()
+
     def set_action_enabled(self, text: str, state: bool):
         """
         Sets the enabled/disabled state of action with the given text
@@ -97,7 +104,7 @@ class SliceViewerNavigationToolbar(NavigationToolbar2QT):
                     action.trigger()  # ensure view reacts appropriately
                 action.setEnabled(state)
 
-    def set_action_checked(self, text: str,  state: bool):
+    def set_action_checked(self, text: str, state: bool):
         """
         Sets the checked/unchecked state of toggle button with the given text
         :param text: Text on the action

--- a/qt/python/mantidqt/widgets/sliceviewer/toolbar.py
+++ b/qt/python/mantidqt/widgets/sliceviewer/toolbar.py
@@ -81,14 +81,34 @@ class SliceViewerNavigationToolbar(NavigationToolbar2QT):
         # Adjust icon size or they are too small in PyQt5 by default
         self.setIconSize(QSize(24, 24))
 
+        # Location of a press event
+        self._pressed_xy = None
+
     def edit_parameters(self):
         NavigationToolbar2QT.edit_parameters(self)
         self.plotOptionsChanged.emit()
 
-    def release(self, _):
+    def press(self, event):
         """
-        Called when a zoom/pan event has completed
+        Called by matplotlib after a press event has been handled. Stores the location
+        of the event.
         """
+        self._pressed_xy = event.x, event.y
+
+    def release(self, event):
+        """
+        Called when a zoom/pan event has completed. Mouse must move more than 5 pixels
+        to be consider a pan/zoom ending
+        """
+        if self._pressed_xy is None:
+            # this "should" never happen as the mouse press callback should have been
+            # called first
+            return
+
+        x, y = event.x, event.y
+        lastx, lasty = self._pressed_xy
+        if ((abs(x - lastx) < 5) or (abs(y - lasty) < 5)):
+            return
         self.zoomPanFinished.emit()
 
     def set_action_enabled(self, text: str, state: bool):

--- a/qt/python/mantidqt/widgets/sliceviewer/view.py
+++ b/qt/python/mantidqt/widgets/sliceviewer/view.py
@@ -223,8 +223,8 @@ class SliceViewerDataView(QWidget):
 
         gs = gridspec.GridSpec(1, 1)
         image_axes.set_position(gs[0].get_position(self.fig))
-        set_artist_property(image_axes.get_xticklabels(), visible=True)
-        set_artist_property(image_axes.get_yticklabels(), visible=True)
+        image_axes.xaxis.tick_bottom()
+        image_axes.yaxis.tick_left()
         self.axx, self.axy = None, None
 
         self.mpl_toolbar.update()  # sync list of axes in navstack

--- a/qt/python/mantidqt/widgets/sliceviewer/view.py
+++ b/qt/python/mantidqt/widgets/sliceviewer/view.py
@@ -5,6 +5,8 @@
 #   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
 # SPDX - License - Identifier: GPL - 3.0 +
 #  This file is part of the mantid workbench.
+# std imports
+import sys
 
 # 3rd party imports
 
@@ -34,6 +36,10 @@ from .peaksviewer.workspaceselection import \
 from .peaksviewer.view import PeaksViewerCollectionView
 from .peaksviewer.representation.painter import MplPainter
 from .zoom import ScrollZoomMixin
+
+
+# Constants
+DBLMAX = sys.float_info.max
 
 
 class SliceViewerCanvas(ScrollZoomMixin, FigureCanvas):
@@ -307,6 +313,7 @@ class SliceViewerDataView(QWidget):
         if self.image is not None:
             if self.line_plots:
                 self.delete_line_plot_lines()
+            self.image_info_widget.updateTable(DBLMAX, DBLMAX, DBLMAX)
             self.image.remove()
             self.image = None
 

--- a/qt/python/mantidqt/widgets/sliceviewer/view.py
+++ b/qt/python/mantidqt/widgets/sliceviewer/view.py
@@ -96,6 +96,7 @@ class SliceViewerDataView(QWidget):
         self.fig.set_facecolor(self.palette().window().color().getRgbF())
         self.canvas = SliceViewerCanvas(self.fig)
         self.canvas.mpl_connect('motion_notify_event', self.mouse_move)
+        self.canvas.mpl_connect('button_release_event', self.mouse_release)
         self.canvas.mpl_connect('axes_leave_event', self.mouse_outside_image)
         self.canvas.mpl_connect('button_press_event', self.mouse_click)
         self.create_axes_orthogonal()
@@ -450,6 +451,10 @@ class SliceViewerDataView(QWidget):
             signal = self.update_image_data(event.xdata, event.ydata, self.line_plots)
             if self.track_cursor.checkState() == Qt.Checked:
                 self.update_image_table_widget(event.xdata, event.ydata, signal)
+
+    def mouse_release(self, event):
+        if event.button == 3 and event.inaxes == self.ax:
+            self.on_home_clicked()
 
     def mouse_outside_image(self, _):
         """

--- a/qt/python/mantidqt/widgets/sliceviewer/view.py
+++ b/qt/python/mantidqt/widgets/sliceviewer/view.py
@@ -183,6 +183,8 @@ class SliceViewerDataView(QWidget):
         """
         if self.line_plots:
             return
+
+        self.line_plots = True
         image_axes = self.ax
         if image_axes is None:
             return
@@ -210,6 +212,8 @@ class SliceViewerDataView(QWidget):
         """
         if not self.line_plots:
             return
+
+        self.line_plots = False
         image_axes = self.ax
         if image_axes is None:
             return
@@ -342,7 +346,6 @@ class SliceViewerDataView(QWidget):
 
     def on_line_plots_toggle(self, state):
         self.presenter.line_plots(state)
-        self.line_plots = state
 
     def on_non_orthogonal_axes_toggle(self, state):
         """

--- a/qt/python/mantidqt/widgets/sliceviewer/zoom.py
+++ b/qt/python/mantidqt/widgets/sliceviewer/zoom.py
@@ -38,6 +38,9 @@ class ScrollZoomMixin:
         callback = callback if callback is not None else _noop
 
         def zoom_fun(event):
+            if event.inaxes != axes:
+                return
+
             # get the current x and y limits
             cur_xlim = axes.get_xlim()
             cur_ylim = axes.get_ylim()

--- a/qt/python/mantidqt/widgets/sliceviewer/zoom.py
+++ b/qt/python/mantidqt/widgets/sliceviewer/zoom.py
@@ -1,0 +1,85 @@
+# Mantid Repository : https://github.com/mantidproject/mantid
+#
+# Copyright &copy; 2020 ISIS Rutherford Appleton Laboratory UKRI,
+#   NScD Oak Ridge National Laboratory, European Spallation Source,
+#   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+# SPDX - License - Identifier: GPL - 3.0 +
+#  This file is part of the mantidqt.
+"""Provides a mixin to add zoom on scroll capability to a figure canvas
+"""
+
+
+def _noop():
+    """Do nothing on calling"""
+    pass
+
+
+class ScrollZoomMixin:
+    """
+    Mixin class to add zoom on scolling mouse wheel capability to a
+    matplotlib axes on a figure canvas
+    """
+    def enable_zoom_on_scroll(self,
+                              axes,
+                              base_scale: float = 1.2,
+                              redraw: bool = True,
+                              toolbar=None,
+                              callback=None):
+        """
+        Connect scroll events so that they zoom in/out of a canvas
+        :param axes: A matplotlib.Axes instance that will receive the scroll events
+        :param base_scale: Fraction of width between axes and event point limit to increase/decrease zoom level.
+                           Default=1.2 as experimentally it seems to give quite smooth scrolling without jumping too much
+        :param redraw: If True then force a canvas redraw after zooming, else it is assumed this will be dealt with
+                       by an external entity
+        :param toolbar: An optional toolbar instance. If present the navstack is updated before the the zoom takes place
+        :param callback: Optional callback called when zoom completes
+        """
+        callback = callback if callback is not None else _noop
+
+        def zoom_fun(event):
+            # get the current x and y limits
+            cur_xlim = axes.get_xlim()
+            cur_ylim = axes.get_ylim()
+
+            xdata = event.xdata  # get event x location
+            ydata = event.ydata  # get event y location
+
+            # Get distance from the cursor to the edge of the figure frame
+            x_left = xdata - cur_xlim[0]
+            x_right = cur_xlim[1] - xdata
+            y_top = ydata - cur_ylim[0]
+            y_bottom = cur_ylim[1] - ydata
+
+            if event.button == 'up':
+                # deal with zoom in
+                scale_factor = 1 / base_scale
+            elif event.button == 'down':
+                # deal with zoom out
+                scale_factor = base_scale
+            else:
+                # deal with something that should never happen
+                scale_factor = 1
+
+            if toolbar:
+                toolbar.push_current()
+            # set new limits
+            axes.set_xlim([xdata - x_left * scale_factor, xdata + x_right * scale_factor])
+            axes.set_ylim([ydata - y_top * scale_factor, ydata + y_bottom * scale_factor])
+            callback()
+            if redraw:
+                axes.figure.canvas.draw_idle()  # force re-draw the next time the GUI refreshes
+
+        # attach the call back
+        self.scroll_cid = self.mpl_connect('scroll_event', zoom_fun)
+
+    def disable_zoom_on_scroll(self):
+        """
+        Disconnect from the scoll event if it as been attached. If it has not
+        been attached then this is a noop.
+        """
+        try:
+            self.mpl_disconnect(self.cid)
+            del self.cid
+        except AttributeError:
+            pass


### PR DESCRIPTION
**Description of work.**

Adds dynamic rebinning to the sliceviewer. When the axes limits change on the view, if the workspace is an MDEventWorkspace, then the data is rebinned to the limits of the view rather than the full extent of the dimensions.

Zooming on scroll of the mouse wheel has also been enabled.

**To test:**

The following script can be used for a basic test of the functionality. It creates an `MDEventWorkspace`, fakes some data and creates some fake peaks.

Run the script and show the sliceviewer and play with the zooming:
* zoom with the magnifier tool and reset up to home - ensure the limits are as expected when drawing the zoom rectangle after the zooming completes
* zoom on scroll and check the data is as expected
* activate the peaks viewer and ensure the peak selection still zooms to the peak and when zooming in on the data the peaks stays where it should.
* check the non-orthogonal view works and vary the setub parameters to check

```python
mdws = CreateMDWorkspace(Dimensions=3,
                         Extents='-10,10,-10,10,-10,10',
                         Names='A,B,C',
                         Units='r.l.u.,r.l.u.,r.l.u.',
                         Frames='HKL,HKL,HKL')
expt_info = CreateSampleWorkspace()
mdws.addExperimentInfo(expt_info)
a, b, c = 1, 1, 1
alpha, beta, gamma = 90, 90, 90
SetUB(mdws, a, b, c, alpha, beta, gamma)
FakeMDEventData(InputWorkspace=mdws, PeakParams='500000,0,0,0,3')
run_number = 1
sxd_ws = LoadEmptyInstrument(InstrumentName='SXD')
AddSampleLog(sxd_ws, 'run_number', str(run_number), 'Number')
peak_ws = CreatePeaksWorkspace(InstrumentWorkspace=sxd_ws, NumberOfPeaks=0)
peak_ws.mutableRun().addProperty('run_number', run_number, True)
SetUB(peak_ws, a, b, c, alpha, beta, gamma)
# Add a new peak
AddPeakHKL(peak_ws, [2, 0, 0])
AddPeakHKL(peak_ws, [2, 1, 4])
# integrate to get a sphere with a background
peak_ws_sphere = IntegratePeaksMD(InputWorkspace=mdws,
                                  PeaksWorkspace=peak_ws, PeakRadius=0.2,
                                  BackgroundInnerRadius=0.7,
                                  BackgroundOuterRadius=0.9)

```

Also check that opening the viewer on the `mdws_svrebinned` actually shows the view for the original `mdws` but updates the window title to show this.

Pull request #28506 also has a script and data links to real examples. Test these too.

Fixes #28689
Fixes #28579 

*This does not require release notes* because **we'll update the sliceviewer release notes in one go before 5.1**

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
