### PR TITLE
Fix plot settings tests

### DIFF
--- a/qt/applications/workbench/CMakeLists.txt
+++ b/qt/applications/workbench/CMakeLists.txt
@@ -96,6 +96,9 @@ set(TEST_FILES
     workbench/widgets/settings/test/test_settings_presenter.py
     workbench/widgets/settings/test/test_settings_view.py
     workbench/widgets/settings/general/test/test_general_settings.py
+    workbench/widgets/settings/plots/test/test_plot_settings.py
+    workbench/widgets/settings/categories/test/test_categories_settings.py
+    workbench/widgets/settings/fitting/test/test_fitting_settings.py
     workbench/projectrecovery/test/test_projectrecovery.py
     workbench/projectrecovery/test/test_projectrecoveryloader.py
     workbench/projectrecovery/test/test_projectrecoverysaver.py

--- a/qt/applications/workbench/workbench/widgets/settings/plots/test/test_plot_settings.py
+++ b/qt/applications/workbench/workbench/widgets/settings/plots/test/test_plot_settings.py
@@ -22,7 +22,7 @@ class MockConfigService(object):
 
 
 @start_qapplication
-class FittingSettingsTest(unittest.TestCase):
+class PlotsSettingsTest(unittest.TestCase):
     CONFIG_SERVICE_CLASSPATH = "workbench.widgets.settings.plots.presenter.ConfigService"
 
     def assert_connected_once(self, owner, signal):
@@ -35,14 +35,16 @@ class FittingSettingsTest(unittest.TestCase):
 
         mock_ConfigService.getString.assert_has_calls([call(PlotSettings.NORMALIZATION),
                                                        call(PlotSettings.SHOW_TITLE),
-                                                       call(PlotSettings.DEFAULT_AXIS_SCALE),
+                                                       call(PlotSettings.X_AXES_SCALE),
+                                                       call(PlotSettings.Y_AXES_SCALE),
                                                        call(PlotSettings.LINE_STYLE),
                                                        call(PlotSettings.LINE_WIDTH),
+                                                       call(PlotSettings.MARKER_STYLE),
+                                                       call(PlotSettings.MARKER_SIZE),
                                                        call(PlotSettings.ERROR_WIDTH),
                                                        call(PlotSettings.CAPSIZE),
                                                        call(PlotSettings.CAP_THICKNESS),
-                                                       call(PlotSettings.ERROR_EVERY),
-                                                       call(PlotSettings.IMAGE_SCALE)])
+                                                       call(PlotSettings.ERROR_EVERY)])
 
     @patch(CONFIG_SERVICE_CLASSPATH, new_callable=MockConfigService)
     def test_action_normalization_changed(self, mock_ConfigService):
@@ -73,18 +75,32 @@ class FittingSettingsTest(unittest.TestCase):
         mock_ConfigService.setString.assert_called_once_with(PlotSettings.SHOW_TITLE, "Off")
 
     @patch(CONFIG_SERVICE_CLASSPATH, new_callable=MockConfigService)
-    def test_action_default_axes_changed(self, mock_ConfigService):
+    def test_action_default_x_axes_changed(self, mock_ConfigService):
         presenter = PlotSettings(None)
         # reset any effects from the constructor
         mock_ConfigService.setString.reset_mock()
 
-        presenter.action_default_axes_changed("Log x/Log y")
-        mock_ConfigService.setString.assert_called_once_with(PlotSettings.DEFAULT_AXIS_SCALE, "Log x/Log y")
+        presenter.action_default_x_axes_changed("Linear")
+        mock_ConfigService.setString.assert_called_once_with(PlotSettings.X_AXES_SCALE, "Linear")
 
         mock_ConfigService.setString.reset_mock()
 
-        presenter.action_default_axes_changed("Lin x/Log y")
-        mock_ConfigService.setString.assert_called_once_with(PlotSettings.DEFAULT_AXIS_SCALE, "Lin x/Log y")
+        presenter.action_default_x_axes_changed("Log")
+        mock_ConfigService.setString.assert_called_once_with(PlotSettings.X_AXES_SCALE, "Log")
+
+    @patch(CONFIG_SERVICE_CLASSPATH, new_callable=MockConfigService)
+    def test_action_default_y_axes_changed(self, mock_ConfigService):
+        presenter = PlotSettings(None)
+        # reset any effects from the constructor
+        mock_ConfigService.setString.reset_mock()
+
+        presenter.action_default_y_axes_changed("Linear")
+        mock_ConfigService.setString.assert_called_once_with(PlotSettings.Y_AXES_SCALE, "Linear")
+
+        mock_ConfigService.setString.reset_mock()
+
+        presenter.action_default_y_axes_changed("Log")
+        mock_ConfigService.setString.assert_called_once_with(PlotSettings.Y_AXES_SCALE, "Log")
 
     @patch(CONFIG_SERVICE_CLASSPATH, new_callable=MockConfigService)
     def test_action_line_style_changed(self, mock_ConfigService):
@@ -113,6 +129,34 @@ class FittingSettingsTest(unittest.TestCase):
 
         presenter.action_line_width_changed(3.5)
         mock_ConfigService.setString.assert_called_once_with(PlotSettings.LINE_WIDTH, "3.5")
+
+    @patch(CONFIG_SERVICE_CLASSPATH, new_callable=MockConfigService)
+    def test_action_marker_style_changed(self, mock_ConfigService):
+        presenter = PlotSettings(None)
+        # reset any effects from the constructor
+        mock_ConfigService.setString.reset_mock()
+
+        presenter.action_marker_style_changed('circle')
+        mock_ConfigService.setString.assert_called_once_with(PlotSettings.MARKER_STYLE, "circle")
+
+        mock_ConfigService.setString.reset_mock()
+
+        presenter.action_marker_style_changed('octagon')
+        mock_ConfigService.setString.assert_called_once_with(PlotSettings.MARKER_STYLE, "octagon")
+
+    @patch(CONFIG_SERVICE_CLASSPATH, new_callable=MockConfigService)
+    def test_action_marker_size_changed(self, mock_ConfigService):
+        presenter = PlotSettings(None)
+        # reset any effects from the constructor
+        mock_ConfigService.setString.reset_mock()
+
+        presenter.action_marker_size_changed('8.0')
+        mock_ConfigService.setString.assert_called_once_with(PlotSettings.MARKER_SIZE, "8.0")
+
+        mock_ConfigService.setString.reset_mock()
+
+        presenter.action_marker_size_changed('5.0')
+        mock_ConfigService.setString.assert_called_once_with(PlotSettings.MARKER_SIZE, "5.0")
 
     @patch(CONFIG_SERVICE_CLASSPATH, new_callable=MockConfigService)
     def test_action_error_width_changed(self, mock_ConfigService):
@@ -169,17 +213,3 @@ class FittingSettingsTest(unittest.TestCase):
 
         presenter.action_error_every_changed(5)
         mock_ConfigService.setString.assert_called_once_with(PlotSettings.ERROR_EVERY, "5")
-
-    @patch(CONFIG_SERVICE_CLASSPATH, new_callable=MockConfigService)
-    def test_action_image_scale_changed(self, mock_ConfigService):
-        presenter = PlotSettings(None)
-        # reset any effects from the constructor
-        mock_ConfigService.setString.reset_mock()
-
-        presenter.action_image_scale_changed("Log")
-        mock_ConfigService.setString.assert_called_once_with(PlotSettings.IMAGE_SCALE, "Log")
-
-        mock_ConfigService.setString.reset_mock()
-
-        presenter.action_image_scale_changed("Linear")
-        mock_ConfigService.setString.assert_called_once_with(PlotSettings.IMAGE_SCALE, "Linear")


### PR DESCRIPTION
**Description of work.**
This PR adds the file `plot_settings_test.py` to the `CMakeLists.txt` and makes it so the tests pass.

**To test:**
Check the tests pass and they look sensible.

Fixes #28818 

No release notes because this is an internal change.

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
