### PR TITLE
Add Option to Copy Bins and Spectra into a Data Table

### DIFF
--- a/docs/source/release/v5.1.0/mantidworkbench.rst
+++ b/docs/source/release/v5.1.0/mantidworkbench.rst
@@ -54,6 +54,7 @@ Improvements
 - The colorbar on colorfill plots is now labelled.
 - User data directories are no longer checked at startup, reducing launch times with slow network drives.
 - Added an option to set the default ```drawstyle``` within the workbench settings window. Additionally, the ```linestyle``` can now be set to 'None'.
+- Added an option to matrix workspaces to export bins and spectra to a table workspace.
 
 Bugfixes
 ########

--- a/qt/python/mantidqt/widgets/workspacedisplay/matrix/presenter.py
+++ b/qt/python/mantidqt/widgets/workspacedisplay/matrix/presenter.py
@@ -84,6 +84,12 @@ class MatrixWorkspaceDisplay(ObservingPresenter, DataCopier):
         num_rows = self.model._ws.getNumberHistograms()
         self.copy_bin_values(table, ws_read, num_rows)
 
+    def action_copy_spectrum_to_table(self, table):
+        pass
+
+    def action_copy_bin_to_table(self, table):
+        pass
+
     def action_copy_cells(self, table):
         self.copy_cells(table)
 

--- a/qt/python/mantidqt/widgets/workspacedisplay/matrix/presenter.py
+++ b/qt/python/mantidqt/widgets/workspacedisplay/matrix/presenter.py
@@ -91,7 +91,7 @@ class MatrixWorkspaceDisplay(ObservingPresenter, DataCopier):
             self.notify_no_selection_to_copy()
             return
         ws = table.model().ws
-        table_ws = CreateEmptyTableWorkspace(OutputWorkspace=ws.getName() + "_spectra")
+        table_ws = CreateEmptyTableWorkspace(OutputWorkspace=ws.name() + "_spectra")
         num_rows = ws.blocksize()
         table_ws.setRowCount(num_rows)
         for i, row in enumerate(selected_rows):
@@ -118,7 +118,7 @@ class MatrixWorkspaceDisplay(ObservingPresenter, DataCopier):
             self.notify_no_selection_to_copy()
             return
         ws = table.model().ws
-        table_ws = CreateEmptyTableWorkspace(OutputWorkspace=ws.getName() + "_bins")
+        table_ws = CreateEmptyTableWorkspace(OutputWorkspace=ws.name() + "_bins")
         num_rows = ws.getNumberHistograms()
         table_ws.setRowCount(num_rows)
         table_ws.addColumn("double", "X")

--- a/qt/python/mantidqt/widgets/workspacedisplay/matrix/presenter.py
+++ b/qt/python/mantidqt/widgets/workspacedisplay/matrix/presenter.py
@@ -86,11 +86,11 @@ class MatrixWorkspaceDisplay(ObservingPresenter, DataCopier):
         self.copy_bin_values(table, ws_read, num_rows)
 
     def action_copy_spectrum_to_table(self, table):
-        ws = table.model().ws
         selected_rows = [i.row() for i in table.selectionModel().selectedRows()]
         if not selected_rows:
             self.notify_no_selection_to_copy()
             return
+        ws = table.model().ws
         table_ws = CreateEmptyTableWorkspace(OutputWorkspace=ws.getName() + "_spectra")
         num_rows = ws.blocksize()
         table_ws.setRowCount(num_rows)
@@ -113,11 +113,11 @@ class MatrixWorkspaceDisplay(ObservingPresenter, DataCopier):
                 table_ws.setCell(j, col_e, data_e[j])
 
     def action_copy_bin_to_table(self, table):
-        ws = table.model().ws
         selected_cols = [i.column() for i in table.selectionModel().selectedColumns()]
         if not selected_cols:
             self.notify_no_selection_to_copy()
             return
+        ws = table.model().ws
         table_ws = CreateEmptyTableWorkspace(OutputWorkspace=ws.getName() + "_bins")
         num_rows = ws.getNumberHistograms()
         table_ws.setRowCount(num_rows)

--- a/qt/python/mantidqt/widgets/workspacedisplay/matrix/presenter.py
+++ b/qt/python/mantidqt/widgets/workspacedisplay/matrix/presenter.py
@@ -103,9 +103,9 @@ class MatrixWorkspaceDisplay(ObservingPresenter, DataCopier):
             col_y = 3 * i + 1
             col_e = 3 * i + 2
 
-            data_y = ws.dataY(row)
-            data_x = ws.dataX(row)
-            data_e = ws.dataE(row)
+            data_y = ws.readY(row)
+            data_x = ws.readX(row)
+            data_e = ws.readE(row)
 
             for j in range(num_rows):
                 table_ws.setCell(j, col_x, data_x[j])
@@ -130,8 +130,8 @@ class MatrixWorkspaceDisplay(ObservingPresenter, DataCopier):
             col_e = 2 * i + 2
 
             for j in range(num_rows):
-                data_y = ws.dataY(j)
-                data_e = ws.dataE(j)
+                data_y = ws.readY(j)
+                data_e = ws.readE(j)
 
                 if i == 0:
                     if ws.axes() > 1:

--- a/qt/python/mantidqt/widgets/workspacedisplay/matrix/presenter.py
+++ b/qt/python/mantidqt/widgets/workspacedisplay/matrix/presenter.py
@@ -110,8 +110,32 @@ class MatrixWorkspaceDisplay(ObservingPresenter, DataCopier):
                 table_ws.setCell(j, col_y, data_y[j])
                 table_ws.setCell(j, col_e, data_e[j])
 
-    def action_copy_bin_to_table(self, table):
-        pass
+    @staticmethod
+    def action_copy_bin_to_table(table):
+        ws = table.model().ws
+        selected_cols = [i.column() for i in table.selectionModel().selectedColumns()]
+        table_ws = CreateEmptyTableWorkspace(OutputWorkspace=ws.getName() + "_bins")
+        num_rows = ws.getNumberHistograms()
+        table_ws.setRowCount(num_rows)
+        table_ws.addColumn("double", "X")
+        for i, col in enumerate(selected_cols):
+            table_ws.addColumn("double", "YB" + str(col))
+            table_ws.addColumn("double", "YE" + str(col))
+
+            col_y = 2 * i + 1
+            col_e = 2 * i + 2
+
+            for j in range(num_rows):
+                data_y = ws.dataY(j)
+                data_e = ws.dataE(j)
+
+                if i == 0:
+                    if ws.axes() > 1:
+                        table_ws.setCell(j, 0, ws.getAxis(1).getValue(j))
+                    else:
+                        table_ws.setCell(j, 0, j)
+                table_ws.setCell(j, col_y, data_y[col])
+                table_ws.setCell(j, col_e, data_e[col])
 
     def action_copy_cells(self, table):
         self.copy_cells(table)

--- a/qt/python/mantidqt/widgets/workspacedisplay/matrix/presenter.py
+++ b/qt/python/mantidqt/widgets/workspacedisplay/matrix/presenter.py
@@ -85,10 +85,12 @@ class MatrixWorkspaceDisplay(ObservingPresenter, DataCopier):
         num_rows = self.model._ws.getNumberHistograms()
         self.copy_bin_values(table, ws_read, num_rows)
 
-    @staticmethod
-    def action_copy_spectrum_to_table(table):
+    def action_copy_spectrum_to_table(self, table):
         ws = table.model().ws
         selected_rows = [i.row() for i in table.selectionModel().selectedRows()]
+        if not selected_rows:
+            self.notify_no_selection_to_copy()
+            return
         table_ws = CreateEmptyTableWorkspace(OutputWorkspace=ws.getName() + "_spectra")
         num_rows = ws.blocksize()
         table_ws.setRowCount(num_rows)
@@ -110,10 +112,12 @@ class MatrixWorkspaceDisplay(ObservingPresenter, DataCopier):
                 table_ws.setCell(j, col_y, data_y[j])
                 table_ws.setCell(j, col_e, data_e[j])
 
-    @staticmethod
-    def action_copy_bin_to_table(table):
+    def action_copy_bin_to_table(self, table):
         ws = table.model().ws
         selected_cols = [i.column() for i in table.selectionModel().selectedColumns()]
+        if not selected_cols:
+            self.notify_no_selection_to_copy()
+            return
         table_ws = CreateEmptyTableWorkspace(OutputWorkspace=ws.getName() + "_bins")
         num_rows = ws.getNumberHistograms()
         table_ws.setRowCount(num_rows)

--- a/qt/python/mantidqt/widgets/workspacedisplay/matrix/test/test_matrixworkspacedisplay_presenter.py
+++ b/qt/python/mantidqt/widgets/workspacedisplay/matrix/test/test_matrixworkspacedisplay_presenter.py
@@ -353,7 +353,7 @@ class MatrixWorkspaceDisplayPresenterTest(unittest.TestCase):
         mock_table_ws = Mock()
         mock_create_table.return_value = mock_table_ws
         mock_input_ws = Mock()
-        mock_input_ws.getName.return_value = "mock_ws"
+        mock_input_ws.name.return_value = "mock_ws"
         mock_input_ws.getNumberHistograms.return_value = 2
         mock_input_ws.axes.return_value = 1
         mock_input_ws.readY.return_value = [2, 2]
@@ -395,7 +395,7 @@ class MatrixWorkspaceDisplayPresenterTest(unittest.TestCase):
         mock_table_ws = Mock()
         mock_create_table.return_value = mock_table_ws
         mock_input_ws = Mock()
-        mock_input_ws.getName.return_value = "mock_ws"
+        mock_input_ws.name.return_value = "mock_ws"
         mock_input_ws.blocksize.return_value = 2
         mock_input_ws.readX.return_value = [3, 3]
         mock_input_ws.readY.return_value = [2, 2]

--- a/qt/python/mantidqt/widgets/workspacedisplay/matrix/test/test_matrixworkspacedisplay_presenter.py
+++ b/qt/python/mantidqt/widgets/workspacedisplay/matrix/test/test_matrixworkspacedisplay_presenter.py
@@ -366,7 +366,6 @@ class MatrixWorkspaceDisplayPresenterTest(unittest.TestCase):
         # (2 Selected Bins * 2 Spectra * 2 Cols per bin) + 2 spectra names
         self.assertEqual(mock_table_ws.setCell.call_count, 10)
 
-
     @patch("mantidqt.widgets.workspacedisplay.matrix.presenter.MatrixWorkspaceDisplay.notify_no_selection_to_copy")
     def test_action_copy_spectrum_to_table_no_selection(self, mock_notify):
         _, mock_table, _, presenter = self.common_setup_action_plot(table_has_selection=False)

--- a/qt/python/mantidqt/widgets/workspacedisplay/matrix/test/test_matrixworkspacedisplay_presenter.py
+++ b/qt/python/mantidqt/widgets/workspacedisplay/matrix/test/test_matrixworkspacedisplay_presenter.py
@@ -356,8 +356,8 @@ class MatrixWorkspaceDisplayPresenterTest(unittest.TestCase):
         mock_input_ws.getName.return_value = "mock_ws"
         mock_input_ws.getNumberHistograms.return_value = 2
         mock_input_ws.axes.return_value = 1
-        mock_input_ws.dataY.return_value = [2, 2]
-        mock_input_ws.dataE.return_value = [1, 1]
+        mock_input_ws.readY.return_value = [2, 2]
+        mock_input_ws.readE.return_value = [1, 1]
 
         mock_table.model().ws = mock_input_ws
 
@@ -398,9 +398,9 @@ class MatrixWorkspaceDisplayPresenterTest(unittest.TestCase):
         mock_input_ws = Mock()
         mock_input_ws.getName.return_value = "mock_ws"
         mock_input_ws.blocksize.return_value = 2
-        mock_input_ws.dataX.return_value = [3, 3]
-        mock_input_ws.dataY.return_value = [2, 2]
-        mock_input_ws.dataE.return_value = [1, 1]
+        mock_input_ws.readX.return_value = [3, 3]
+        mock_input_ws.readY.return_value = [2, 2]
+        mock_input_ws.readE.return_value = [1, 1]
 
         mock_table.model().ws = mock_input_ws
 

--- a/qt/python/mantidqt/widgets/workspacedisplay/matrix/test/test_matrixworkspacedisplay_presenter.py
+++ b/qt/python/mantidqt/widgets/workspacedisplay/matrix/test/test_matrixworkspacedisplay_presenter.py
@@ -324,6 +324,91 @@ class MatrixWorkspaceDisplayPresenterTest(unittest.TestCase):
         self.assertNotCalled(mock_table.mock_selection_model.selectedColumns)
         self.assertNotCalled(mock_plot)
 
+    @patch("mantidqt.widgets.workspacedisplay.matrix.presenter.MatrixWorkspaceDisplay.notify_no_selection_to_copy")
+    def test_action_copy_bin_to_table_no_selection(self, mock_notify):
+        _, mock_table, _, presenter = self.common_setup_action_plot(table_has_selection=False)
+        self.setup_mock_selection(mock_table, num_selected_cols=None, num_selected_rows=None)
+        mock_table.selectionModel().selectedColumns.return_value = []
+
+        presenter.action_copy_bin_to_table(mock_table)
+
+        self.assertEqual(mock_notify.call_count, 1)
+        self.assertEqual(mock_table.model.call_count, 0)
+
+    @patch("mantidqt.widgets.workspacedisplay.matrix.presenter.MatrixWorkspaceDisplay.notify_no_selection_to_copy")
+    def test_action_copy_bin_to_table_only_spectra_selected(self, mock_notify):
+        _, mock_table, _, presenter = self.common_setup_action_plot(table_has_selection=True)
+        self.setup_mock_selection(mock_table, num_selected_cols=None, num_selected_rows=2)
+        mock_table.selectionModel().selectedColumns.return_value = []
+
+        presenter.action_copy_bin_to_table(mock_table)
+
+        self.assertEqual(mock_notify.call_count, 1)
+        self.assertEqual(mock_table.model.call_count, 0)
+
+    @patch("mantidqt.widgets.workspacedisplay.matrix.presenter.CreateEmptyTableWorkspace")
+    def test_action_copy_bin_to_table(self, mock_create_table):
+        _, mock_table, _, presenter = self.common_setup_action_plot(table_has_selection=False)
+        self.setup_mock_selection(mock_table, num_selected_cols=2, num_selected_rows=None)
+        mock_table_ws = Mock()
+        mock_create_table.return_value = mock_table_ws
+        mock_input_ws = Mock()
+        mock_input_ws.getName.return_value = "mock_ws"
+        mock_input_ws.getNumberHistograms.return_value = 2
+        mock_input_ws.axes.return_value = 1
+        mock_input_ws.dataY.return_value = [2, 2]
+        mock_input_ws.dataE.return_value = [1, 1]
+
+        mock_table.model().ws = mock_input_ws
+
+        presenter.action_copy_bin_to_table(mock_table)
+
+        # (2 Selected Bins * 2 Spectra * 2 Cols per bin) + 2 spectra names
+        self.assertEqual(mock_table_ws.setCell.call_count, 10)
+
+
+    @patch("mantidqt.widgets.workspacedisplay.matrix.presenter.MatrixWorkspaceDisplay.notify_no_selection_to_copy")
+    def test_action_copy_spectrum_to_table_no_selection(self, mock_notify):
+        _, mock_table, _, presenter = self.common_setup_action_plot(table_has_selection=False)
+        self.setup_mock_selection(mock_table, num_selected_cols=None, num_selected_rows=None)
+        mock_table.selectionModel().selectedRows.return_value = []
+
+        presenter.action_copy_spectrum_to_table(mock_table)
+
+        self.assertEqual(mock_notify.call_count, 1)
+        self.assertEqual(mock_table.model.call_count, 0)
+
+    @patch("mantidqt.widgets.workspacedisplay.matrix.presenter.MatrixWorkspaceDisplay.notify_no_selection_to_copy")
+    def test_action_copy_spectra_to_table_only_bins_selected(self, mock_notify):
+        _, mock_table, _, presenter = self.common_setup_action_plot(table_has_selection=True)
+        self.setup_mock_selection(mock_table, num_selected_cols=2, num_selected_rows=None)
+        mock_table.selectionModel().selectedRows.return_value = []
+
+        presenter.action_copy_spectrum_to_table(mock_table)
+
+        self.assertEqual(mock_notify.call_count, 1)
+        self.assertEqual(mock_table.model.call_count, 0)
+
+    @patch("mantidqt.widgets.workspacedisplay.matrix.presenter.CreateEmptyTableWorkspace")
+    def test_action_copy_spectrum_to_table(self, mock_create_table):
+        _, mock_table, _, presenter = self.common_setup_action_plot(table_has_selection=False)
+        self.setup_mock_selection(mock_table, num_selected_cols=None, num_selected_rows=2)
+        mock_table_ws = Mock()
+        mock_create_table.return_value = mock_table_ws
+        mock_input_ws = Mock()
+        mock_input_ws.getName.return_value = "mock_ws"
+        mock_input_ws.blocksize.return_value = 2
+        mock_input_ws.dataX.return_value = [3, 3]
+        mock_input_ws.dataY.return_value = [2, 2]
+        mock_input_ws.dataE.return_value = [1, 1]
+
+        mock_table.model().ws = mock_input_ws
+
+        presenter.action_copy_spectrum_to_table(mock_table)
+
+        # 2 Selected Bins * 2 Spectra * 3 Cols per bin
+        self.assertEqual(mock_table_ws.setCell.call_count, 12)
+
     @with_mock_presenter
     def test_close_incorrect_workspace(self, ws, view, presenter):
         presenter.close(ws.TEST_NAME + "123")

--- a/qt/python/mantidqt/widgets/workspacedisplay/matrix/view.py
+++ b/qt/python/mantidqt/widgets/workspacedisplay/matrix/view.py
@@ -45,6 +45,7 @@ class MatrixWorkspaceDisplayView(QTabWidget):
         self.presenter = presenter
         self.COPY_ICON = mantidqt.icons.get_icon("mdi.content-copy")
         self.GRAPH_ICON = mantidqt.icons.get_icon("mdi.chart-line")
+        self.TABLE_ICON = mantidqt.icons.get_icon("mdi.table")
 
         # change the default color of the rows - makes them light blue
         # monitors and masked rows are colored in the table's custom model
@@ -114,6 +115,8 @@ class MatrixWorkspaceDisplayView(QTabWidget):
 
         copy_bin_values = QAction(self.COPY_ICON, "Copy", horizontalHeader)
         copy_bin_values.triggered.connect(partial(self.presenter.action_copy_bin_values, table))
+        copy_bin_to_table = QAction(self.TABLE_ICON, "Copy bin to table", horizontalHeader)
+        copy_bin_to_table.triggered.connect(partial(self.presenter.action_copy_bin_to_table, table))
 
         plot_bin_action = QAction(self.GRAPH_ICON, "Plot bin (values only)", horizontalHeader)
         plot_bin_action.triggered.connect(partial(self.presenter.action_plot_bin, table))
@@ -123,6 +126,7 @@ class MatrixWorkspaceDisplayView(QTabWidget):
         separator1.setSeparator(True)
 
         horizontalHeader.addAction(copy_bin_values)
+        horizontalHeader.addAction(copy_bin_to_table)
         horizontalHeader.addAction(separator1)
         horizontalHeader.addAction(plot_bin_action)
         horizontalHeader.addAction(plot_bin_with_errors_action)
@@ -134,6 +138,8 @@ class MatrixWorkspaceDisplayView(QTabWidget):
         copy_spectrum_values = QAction(self.COPY_ICON, "Copy", verticalHeader)
         copy_spectrum_values.triggered.connect(
             partial(self.presenter.action_copy_spectrum_values, table))
+        copy_spectrum_to_table = QAction(self.TABLE_ICON, "Copy spectrum to table", horizontalHeader)
+        copy_spectrum_to_table.triggered.connect(partial(self.presenter.action_copy_spectrum_to_table, table))
 
         plot_spectrum_action = QAction(self.GRAPH_ICON, "Plot spectrum (values only)", verticalHeader)
         plot_spectrum_action.triggered.connect(partial(self.presenter.action_plot_spectrum, table))
@@ -145,6 +151,7 @@ class MatrixWorkspaceDisplayView(QTabWidget):
         separator1.setSeparator(True)
 
         verticalHeader.addAction(copy_spectrum_values)
+        verticalHeader.addAction(copy_spectrum_to_table)
         verticalHeader.addAction(separator1)
         verticalHeader.addAction(plot_spectrum_action)
         verticalHeader.addAction(plot_spectrum_with_errors_action)


### PR DESCRIPTION
**Description of work.**

Adds an option to the right click context menu of the matrix workspace data view to export the selected bins or spectra into a table workspace. This was requested by a user so that the values could be quickly exported to an excel compatible format. 

**To test:**
1. Load some data
2. Open the data view.
3. Select some bins
4. Right Click -> Copy to table workspace
5. Check the right values are in the table workspace that has been generated.
6. Repeat 3-5 with some spectra. 

Fixes #28609 

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
