### PR TITLE
Prevent a shape being stored against sample pos

### DIFF
--- a/Framework/API/src/Sample.cpp
+++ b/Framework/API/src/Sample.cpp
@@ -7,7 +7,6 @@
 #include "MantidAPI/Sample.h"
 #include "MantidGeometry/Crystal/CrystalStructure.h"
 #include "MantidGeometry/Crystal/OrientedLattice.h"
-#include "MantidGeometry/IComponent.h"
 #include "MantidGeometry/Instrument/SampleEnvironment.h"
 #include "MantidGeometry/Objects/CSGObject.h"
 #include "MantidGeometry/Objects/ShapeFactory.h"

--- a/Framework/API/test/InstrumentValidatorTest.h
+++ b/Framework/API/test/InstrumentValidatorTest.h
@@ -30,11 +30,8 @@ public:
     auto instr =
         std::make_shared<Mantid::Geometry::Instrument>("TestInstrument");
     ws->setInstrument(instr);
-    // Define a sample as a simple sphere
-    auto sample = new Mantid::Geometry::ObjComponent(
-        "samplePos",
-        ComponentCreationHelper::createSphere(0.1, V3D(0, 0, 0), "1"),
-        instr.get());
+    // Define a sample position
+    auto sample = new Mantid::Geometry::Component("samplePos", instr.get());
     instr->setPos(0.0, 0.0, 0.0);
     instr->add(sample);
     instr->markAsSamplePos(sample);

--- a/Framework/Algorithms/src/CreateSampleWorkspace.cpp
+++ b/Framework/Algorithms/src/CreateSampleWorkspace.cpp
@@ -10,6 +10,7 @@
 #include "MantidAPI/FunctionFactory.h"
 #include "MantidAPI/FunctionProperty.h"
 #include "MantidAPI/Run.h"
+#include "MantidAPI/Sample.h"
 #include "MantidDataObjects/EventWorkspace.h"
 #include "MantidDataObjects/ScanningWorkspaceBuilder.h"
 #include "MantidDataObjects/Workspace2D.h"
@@ -259,6 +260,9 @@ void CreateSampleWorkspace::exec() {
         std::dynamic_pointer_cast<Units::Label>(unit);
     label->setLabel(xUnit, xUnit);
   }
+
+  auto sampleSphere = createSphere(0.001, V3D(0.0, 0.0, 0.0), "sample-shape");
+  ws->mutableSample().setShape(sampleSphere);
 
   ws->setYUnit("Counts");
   ws->setTitle("Test Workspace");
@@ -581,10 +585,8 @@ Instrument_sptr CreateSampleWorkspace::createTestInstrumentRectangular(
   chopper->setPos(V3D(0.0, 0.0, -0.25 * sourceSampleDistance));
   testInst->add(chopper);
 
-  // Define a sample as a simple sphere
-  auto sampleSphere = createSphere(0.001, V3D(0.0, 0.0, 0.0), "sample-shape");
-  ObjComponent *sample =
-      new ObjComponent("sample", sampleSphere, testInst.get());
+  // Define a sample position
+  Component *sample = new Component("sample", testInst.get());
   testInst->setPos(0.0, 0.0, 0.0);
   testInst->add(sample);
   testInst->markAsSamplePos(sample);

--- a/Framework/Algorithms/src/EditInstrumentGeometry.cpp
+++ b/Framework/Algorithms/src/EditInstrumentGeometry.cpp
@@ -293,8 +293,8 @@ void EditInstrumentGeometry::exec() {
   }
 
   // Set up source and sample information
-  Geometry::ObjComponent *samplepos =
-      new Geometry::ObjComponent("Sample", instrument.get());
+  Geometry::Component *samplepos =
+      new Geometry::Component("Sample", instrument.get());
   instrument->add(samplepos);
   instrument->markAsSamplePos(samplepos);
   samplepos->setPos(0.0, 0.0, 0.0);

--- a/Framework/Algorithms/src/SampleCorrections/SparseInstrument.cpp
+++ b/Framework/Algorithms/src/SampleCorrections/SparseInstrument.cpp
@@ -204,8 +204,8 @@ createSparseWS(const API::MatrixWorkspace &modelWS,
       std::make_shared<Geometry::ReferenceFrame>(*refFrame));
   // The sparse instrument is build around origin.
   constexpr Kernel::V3D samplePos{0.0, 0.0, 0.0};
-  auto sample = std::make_unique<Geometry::ObjComponent>("sample", nullptr,
-                                                         instrument.get());
+  auto sample =
+      std::make_unique<Geometry::Component>("sample", instrument.get());
   sample->setPos(samplePos);
   instrument->add(sample.get());
   instrument->markAsSamplePos(sample.release());

--- a/Framework/Algorithms/test/AddAbsorptionWeightedPathLengthsTest.h
+++ b/Framework/Algorithms/test/AddAbsorptionWeightedPathLengthsTest.h
@@ -78,6 +78,9 @@ public:
     const int NPEAKS = 10;
     // this sets up a sample with a spherical shape of radius = 1mm
     auto peaksWS = WorkspaceCreationHelper::createPeaksWorkspace(NPEAKS);
+    auto shape =
+        ComponentCreationHelper::createSphere(0.001, {0, 0, 0}, "sample-shape");
+    peaksWS->mutableSample().setShape(shape);
     setMaterialToVanadium(peaksWS);
 
     Mantid::Algorithms::AddAbsorptionWeightedPathLengths alg;
@@ -161,13 +164,8 @@ private:
 
     peaksWS->setInstrument(testInst);
 
-    // setInstrument doesn't update the workspace's sample from the sample
-    // details in the instrument's component assembly for some reason. So
-    // explicitly set the shape here
-    auto sampleShapeComponent =
-        std::dynamic_pointer_cast<const IObjComponent>(testInst->getSample());
     auto shape =
-        std::shared_ptr<IObject>(sampleShapeComponent->shape()->clone());
+        ComponentCreationHelper::createSphere(0.001, {0, 0, 0}, "sample-shape");
     peaksWS->mutableSample().setShape(shape);
   }
   void setMaterialToVanadium(std::shared_ptr<PeaksWorkspace> peaksWS) {

--- a/Framework/Algorithms/test/ConvertUnitsTest.h
+++ b/Framework/Algorithms/test/ConvertUnitsTest.h
@@ -544,9 +544,8 @@ public:
     source->setPos(V3D(0, 0.0, -11.739));
     testInst->add(source);
     testInst->markAsSource(source);
-    // Define a sample as a simple sphere
-    ObjComponent *sample =
-        new ObjComponent("samplePos", IObject_sptr(), testInst.get());
+    // Define a sample position
+    Component *sample = new Component("samplePos", testInst.get());
     testInst->setPos(0.0, 0.0, 0.0);
     testInst->add(sample);
     testInst->markAsSamplePos(sample);

--- a/Framework/Algorithms/test/DetectorEfficiencyCorTest.h
+++ b/Framework/Algorithms/test/DetectorEfficiencyCorTest.h
@@ -138,7 +138,7 @@ private:
       instrument->markAsDetector(detector);
       detectors.emplace_back(detector);
     }
-    ObjComponent *sample = new ObjComponent("sample", shape, instrument.get());
+    Component *sample = new Component("sample", instrument.get());
     sample->setPos(0, 0, 0);
     instrument->add(sample);
     instrument->markAsSamplePos(sample);

--- a/Framework/Algorithms/test/HRPDSlabCanAbsorptionTest.h
+++ b/Framework/Algorithms/test/HRPDSlabCanAbsorptionTest.h
@@ -52,9 +52,8 @@ public:
     testInst->add(source);
     testInst->markAsSource(source);
 
-    // Define a sample as a simple sphere
-    ObjComponent *sample =
-        new ObjComponent("samplePos", IObject_sptr(), testInst.get());
+    // Define a sample position
+    Component *sample = new Component("samplePos", testInst.get());
     testInst->setPos(0.0, 0.0, 0.0);
     testInst->add(sample);
     testInst->markAsSamplePos(sample);

--- a/Framework/Algorithms/test/LorentzCorrectionTest.h
+++ b/Framework/Algorithms/test/LorentzCorrectionTest.h
@@ -60,7 +60,7 @@ private:
     instrument->add(source);
     instrument->markAsSource(source);
 
-    ObjComponent *sample = new ObjComponent("some-surface-holder");
+    Component *sample = new Component("some-surface-holder");
     source->setPos(V3D(15, 0, 0));
     instrument->add(sample);
     instrument->markAsSamplePos(sample);

--- a/Framework/Algorithms/test/SANSCollimationLengthEstimatorTest.h
+++ b/Framework/Algorithms/test/SANSCollimationLengthEstimatorTest.h
@@ -49,7 +49,7 @@ createTestInstrument(const Mantid::detid_t id,
   source->setPos(sourcePosition);
   inst->add(source);
   inst->markAsSource(source);
-  auto *sampleHolder = new ObjComponent("samplePos");
+  auto *sampleHolder = new Component("samplePos");
   sampleHolder->setPos(samplePosition);
   inst->add(sampleHolder);
   inst->markAsSamplePos(sampleHolder);

--- a/Framework/Algorithms/test/TOFSANSResolutionByPixelTest.h
+++ b/Framework/Algorithms/test/TOFSANSResolutionByPixelTest.h
@@ -59,7 +59,7 @@ createTestInstrument(const Mantid::detid_t id,
   source->setPos(sourcePosition);
   inst->add(source);
   inst->markAsSource(source);
-  auto *sampleHolder = new ObjComponent("samplePos");
+  auto *sampleHolder = new Component("samplePos");
   sampleHolder->setPos(samplePosition);
   inst->add(sampleHolder);
   inst->markAsSamplePos(sampleHolder);

--- a/Framework/Crystal/src/LoadHKL.cpp
+++ b/Framework/Crystal/src/LoadHKL.cpp
@@ -64,8 +64,8 @@ void LoadHKL::exec() {
   detector->setPos(0.0, 0.0, 0.0);
   inst->add(detector); // This takes care of deletion
   inst->markAsDetector(detector);
-  Mantid::Geometry::ObjComponent *sample =
-      new Mantid::Geometry::ObjComponent("Sample");
+  Mantid::Geometry::Component *sample =
+      new Mantid::Geometry::Component("Sample");
   inst->add(sample); // This takes care of deletion
   inst->markAsSamplePos(sample);
   Mantid::Geometry::ObjComponent *source =

--- a/Framework/CurveFitting/test/FitMWTest.h
+++ b/Framework/CurveFitting/test/FitMWTest.h
@@ -647,8 +647,8 @@ public:
     instrument->add(source);
     source->setPos(0.0, 0.0, -10.0);
     instrument->markAsSource(source);
-    Mantid::Geometry::ObjComponent *sample =
-        new Mantid::Geometry::ObjComponent("sample", instrument.get());
+    Mantid::Geometry::Component *sample =
+        new Mantid::Geometry::Component("sample", instrument.get());
     instrument->add(sample);
     instrument->markAsSamplePos(sample);
     auto *det = new Mantid::Geometry::Detector("det", 1, nullptr);

--- a/Framework/CurveFitting/test/Functions/ComptonProfileTestHelpers.h
+++ b/Framework/CurveFitting/test/Functions/ComptonProfileTestHelpers.h
@@ -157,7 +157,7 @@ createTestInstrumentWithNoFoilChanger(const Mantid::detid_t id,
   source->setPos(V3D(0.0, 0.0, -11.005));
   inst->add(source);
   inst->markAsSource(source);
-  auto *sampleHolder = new ObjComponent("samplePos");
+  auto *sampleHolder = new Component("samplePos");
   sampleHolder->setPos(V3D(0.0, 0.0, 0.0));
   inst->add(sampleHolder);
   inst->markAsSamplePos(sampleHolder);

--- a/Framework/CurveFitting/test/Functions/DiffRotDiscreteCircleTest.h
+++ b/Framework/CurveFitting/test/Functions/DiffRotDiscreteCircleTest.h
@@ -559,10 +559,7 @@ private:
     inst->markAsSource(source);
 
     // Add the sample position
-    ObjComponent *sample = new ObjComponent(
-        "samplePos",
-        ComponentCreationHelper::createSphere(0.1, V3D(0, 0, 0), "1"),
-        inst.get());
+    Component *sample = new Component("samplePos", inst.get());
     inst->setPos(0.0, 0.0, 0.0);
     inst->add(sample);
     inst->markAsSamplePos(sample);

--- a/Framework/CurveFitting/test/Functions/DiffSphereTest.h
+++ b/Framework/CurveFitting/test/Functions/DiffSphereTest.h
@@ -497,10 +497,7 @@ private:
     inst->markAsSource(source);
 
     // Add the sample position
-    ObjComponent *sample = new ObjComponent(
-        "samplePos",
-        ComponentCreationHelper::createSphere(0.1, V3D(0, 0, 0), "1"),
-        inst.get());
+    Component *sample = new Component("samplePos", inst.get());
     inst->setPos(0.0, 0.0, 0.0);
     inst->add(sample);
     inst->markAsSamplePos(sample);

--- a/Framework/DataHandling/src/LoadGSS.cpp
+++ b/Framework/DataHandling/src/LoadGSS.cpp
@@ -514,8 +514,8 @@ void LoadGSS::createInstrumentGeometry(
       new Geometry::Instrument(instrumentname));
 
   // Add dummy source and samplepos to instrument
-  Geometry::ObjComponent *samplepos =
-      new Geometry::ObjComponent("Sample", instrument.get());
+  Geometry::Component *samplepos =
+      new Geometry::Component("Sample", instrument.get());
   instrument->add(samplepos);
   instrument->markAsSamplePos(samplepos);
   samplepos->setPos(0.0, 0.0, 0.0);

--- a/Framework/DataHandling/src/LoadInstrumentFromNexus.cpp
+++ b/Framework/DataHandling/src/LoadInstrumentFromNexus.cpp
@@ -71,8 +71,8 @@ void LoadInstrumentFromNexus::exec() {
   // The L2 and 2-theta values from nexus file assumed to be relative to sample
   // position
 
-  Geometry::ObjComponent *samplepos =
-      new Geometry::ObjComponent("Unknown", instrument.get());
+  Geometry::Component *samplepos =
+      new Geometry::Component("Unknown", instrument.get());
   instrument->add(samplepos);
   instrument->markAsSamplePos(samplepos);
   samplepos->setPos(0.0, 0.0, 0.0);

--- a/Framework/DataHandling/src/LoadInstrumentFromRaw.cpp
+++ b/Framework/DataHandling/src/LoadInstrumentFromRaw.cpp
@@ -77,8 +77,8 @@ void LoadInstrumentFromRaw::exec() {
   // The L2 and 2-theta values from Raw file assumed to be relative to sample
   // position
 
-  Geometry::ObjComponent *samplepos =
-      new Geometry::ObjComponent("Sample", instrument.get());
+  Geometry::Component *samplepos =
+      new Geometry::Component("Sample", instrument.get());
   instrument->add(samplepos);
   instrument->markAsSamplePos(samplepos);
   samplepos->setPos(0.0, 0.0, 0.0);

--- a/Framework/DataHandling/src/LoadNXSPE.cpp
+++ b/Framework/DataHandling/src/LoadNXSPE.cpp
@@ -279,7 +279,7 @@ void LoadNXSPE::exec() {
   source->setPos(0.0, 0.0, -10.);
   instrument->add(source);
   instrument->markAsSource(source);
-  Geometry::ObjComponent *sample = new Geometry::ObjComponent("sample");
+  Geometry::Component *sample = new Geometry::Component("sample");
   instrument->add(sample);
   instrument->markAsSamplePos(sample);
 

--- a/Framework/DataHandling/src/LoadQKK.cpp
+++ b/Framework/DataHandling/src/LoadQKK.cpp
@@ -111,8 +111,8 @@ void LoadQKK::exec() {
   // Add dummy source and samplepos to instrument
 
   // Create an instrument component wich will represent the sample position.
-  Geometry::ObjComponent *samplepos =
-      new Geometry::ObjComponent("Sample", instrument.get());
+  Geometry::Component *samplepos =
+      new Geometry::Component("Sample", instrument.get());
   instrument->add(samplepos);
   instrument->markAsSamplePos(samplepos);
   // Put the sample in the centre of the coordinate system

--- a/Framework/DataHandling/test/FindDetectorsParTest.h
+++ b/Framework/DataHandling/test/FindDetectorsParTest.h
@@ -467,7 +467,7 @@ private:
     spInst->add(source);
     spInst->markAsSource(source);
 
-    Geometry::ObjComponent *sample = new Geometry::ObjComponent("sample");
+    Geometry::Component *sample = new Geometry::Component("sample");
     sample->setPos(0.0, 0.0, -2);
     spInst->add(sample);
     spInst->markAsSamplePos(sample);

--- a/Framework/DataHandling/test/LoadDetectorInfoTest.h
+++ b/Framework/DataHandling/test/LoadDetectorInfoTest.h
@@ -223,7 +223,7 @@ void makeTestWorkspace(const int ndets, const int nbins,
   }
 
   Instrument_sptr instr(new Instrument);
-  ObjComponent *samplePos = new ObjComponent("sample-pos", instr.get());
+  Component *samplePos = new Component("sample-pos", instr.get());
   instr->add(samplePos);
   instr->markAsSamplePos(samplePos);
 

--- a/Framework/DataHandling/test/LoadInstrumentTest.h
+++ b/Framework/DataHandling/test/LoadInstrumentTest.h
@@ -281,8 +281,8 @@ public:
     TS_ASSERT_EQUALS(source->getName(), "undulator");
     TS_ASSERT_DELTA(source->getPos().Z(), -11.016, 0.01);
 
-    std::shared_ptr<const IObjComponent> samplepos =
-        std::dynamic_pointer_cast<const IObjComponent>(i->getSample());
+    std::shared_ptr<const IComponent> samplepos =
+        std::dynamic_pointer_cast<const IComponent>(i->getSample());
     TS_ASSERT_EQUALS(samplepos->getName(), "nickel-holder");
     TS_ASSERT_DELTA(samplepos->getPos().Y(), 0.0, 0.01);
 
@@ -298,10 +298,6 @@ public:
         ptrDetShape.isValid(V3D(0.0, 0.0, 0.000001) + ptrDetShape.getPos()));
     TS_ASSERT(
         ptrDetShape.isValid(V3D(0.005, 0.1, 0.000002) + ptrDetShape.getPos()));
-
-    // test of sample shape
-    TS_ASSERT(samplepos->isValid(V3D(0.0, 0.0, 0.005) + samplepos->getPos()));
-    TS_ASSERT(!samplepos->isValid(V3D(0.0, 0.0, 0.05) + samplepos->getPos()));
   }
 
   void testExecNIMROD() {

--- a/Framework/DataHandling/test/RotateSourceTest.h
+++ b/Framework/DataHandling/test/RotateSourceTest.h
@@ -47,7 +47,7 @@ public:
     instr->markAsSource(source);
 
     // The sample
-    ObjComponent *sample = new ObjComponent("sample");
+    Component *sample = new Component("sample");
     sample->setPos(V3D(0, 0, 0));
     instr->add(sample);
     instr->markAsSamplePos(sample);
@@ -85,7 +85,7 @@ public:
     instr->markAsSource(source);
 
     // The sample
-    ObjComponent *sample = new ObjComponent("sample");
+    Component *sample = new Component("sample");
     sample->setPos(V3D(0, 0, 0));
     instr->add(sample);
     instr->markAsSamplePos(sample);
@@ -123,7 +123,7 @@ public:
     instr->markAsSource(source);
 
     // The sample
-    ObjComponent *sample = new ObjComponent("sample");
+    Component *sample = new Component("sample");
     sample->setPos(V3D(0, 0, 1));
     instr->add(sample);
     instr->markAsSamplePos(sample);
@@ -161,7 +161,7 @@ public:
     instr->markAsSource(source);
 
     // The sample
-    ObjComponent *sample = new ObjComponent("sample");
+    Component *sample = new Component("sample");
     sample->setPos(V3D(1, 1, 1));
     instr->add(sample);
     instr->markAsSamplePos(sample);

--- a/Framework/DataObjects/test/WorkspaceValidatorsTest.h
+++ b/Framework/DataObjects/test/WorkspaceValidatorsTest.h
@@ -176,7 +176,7 @@ public:
     { // default validator
       auto ws = std::make_shared<Mantid::DataObjects::Workspace2D>();
       auto inst = std::make_shared<Mantid::Geometry::Instrument>();
-      auto *sample = new Mantid::Geometry::ObjComponent("Sample");
+      auto *sample = new Mantid::Geometry::Component("Sample");
       inst->add(sample);
       inst->markAsSamplePos(sample);
 
@@ -214,7 +214,7 @@ public:
       TS_ASSERT_EQUALS(instVal->isValid(ws), "The instrument is missing the "
                                              "following components: "
                                              "source,sample holder");
-      auto *sample = new Mantid::Geometry::ObjComponent("Sample");
+      auto *sample = new Mantid::Geometry::Component("Sample");
       inst->add(sample);
       inst->markAsSamplePos(sample);
       auto *src = new Mantid::Geometry::ObjComponent("Source");

--- a/Framework/Geometry/src/Instrument.cpp
+++ b/Framework/Geometry/src/Instrument.cpp
@@ -108,7 +108,7 @@ Instrument::Instrument(const Instrument &instr)
     // Now check whether the current component is the source or sample.
     // As the majority of components will be detectors, we will rarely get to
     // here
-    if (const auto *obj = dynamic_cast<const ObjComponent *>(it->get())) {
+    if (const auto *obj = dynamic_cast<const Component *>(it->get())) {
       const std::string objName = obj->getName();
       // This relies on the source and sample having a unique name.
       // I think the way our instrument definition files work ensures this is
@@ -588,6 +588,15 @@ void Instrument::markAsSamplePos(const IComponent *comp) {
   if (m_map)
     throw std::runtime_error("Instrument::markAsSamplePos() called on a "
                              "parametrized Instrument object.");
+
+  auto objComp = dynamic_cast<const IObjComponent *>(comp);
+  if (objComp) {
+    throw std::runtime_error(
+        "Instrument::markAsSamplePos() called on an IObjComponent "
+        "object that supports shape definition. Sample is prevented from "
+        "being this type because the shape must only be stored in "
+        "ExperimentInfo::m_sample.");
+  }
 
   if (!m_sampleCache) {
     if (comp->getName().empty()) {

--- a/Framework/Geometry/src/Instrument/ComponentHelper.cpp
+++ b/Framework/Geometry/src/Instrument/ComponentHelper.cpp
@@ -49,9 +49,8 @@ createMinimalInstrument(const Mantid::Kernel::V3D &sourcePos,
   instrument->markAsSource(source);
 
   // A sample
-  ObjComponent *sample = new ObjComponent("some-surface-holder");
+  Component *sample = new Component("some-surface-holder");
   sample->setPos(samplePos);
-  sample->setShape(createSphere(0.01 /*1cm*/, V3D(0, 0, 0), "1"));
   instrument->add(sample);
   instrument->markAsSamplePos(sample);
 
@@ -82,9 +81,8 @@ createVirtualInstrument(Kernel::V3D sourcePos, Kernel::V3D samplePos,
   instrument->markAsSource(source);
 
   // A sample
-  ObjComponent *sample = new ObjComponent("some-surface-holder");
+  Component *sample = new Component("some-surface-holder");
   sample->setPos(samplePos);
-  sample->setShape(createSphere(0.01 /*1cm*/, V3D(0, 0, 0), "1"));
   instrument->add(sample);
   instrument->markAsSamplePos(sample);
 

--- a/Framework/Geometry/src/Objects/BoundingBox.cpp
+++ b/Framework/Geometry/src/Objects/BoundingBox.cpp
@@ -252,28 +252,29 @@ void BoundingBox::realign(std::vector<Kernel::V3D> const *const pCS) {
  * @param other :: The bounding box that should be encompassed
  */
 void BoundingBox::grow(const BoundingBox &other) {
-  m_null &= other.isNull();
+
   // If the current box is empty then we definitely need to grow
-  if (minPoint() == V3D() && maxPoint() == V3D()) {
+  if (m_null) {
     m_minPoint = other.minPoint();
     m_maxPoint = other.maxPoint();
-    return;
-  }
+  } else {
 
-  // Simply checks if an of the points in the given box are outside this one and
-  // changes the coordinate appropriately
-  V3D otherPoint = other.minPoint();
-  for (size_t i = 0; i < 3; ++i) {
-    if (otherPoint[i] < m_minPoint[i]) {
-      m_minPoint[i] = otherPoint[i];
+    // Simply checks if an of the points in the given box are outside this one
+    // and changes the coordinate appropriately
+    V3D otherPoint = other.minPoint();
+    for (size_t i = 0; i < 3; ++i) {
+      if (otherPoint[i] < m_minPoint[i]) {
+        m_minPoint[i] = otherPoint[i];
+      }
+    }
+    otherPoint = other.maxPoint();
+    for (size_t i = 0; i < 3; ++i) {
+      if (otherPoint[i] > m_maxPoint[i]) {
+        m_maxPoint[i] = otherPoint[i];
+      }
     }
   }
-  otherPoint = other.maxPoint();
-  for (size_t i = 0; i < 3; ++i) {
-    if (otherPoint[i] > m_maxPoint[i]) {
-      m_maxPoint[i] = otherPoint[i];
-    }
-  }
+  m_null &= other.isNull();
 }
 
 //--------------------------------------------------------------------------

--- a/Framework/Geometry/test/ComponentInfoTest.h
+++ b/Framework/Geometry/test/ComponentInfoTest.h
@@ -326,7 +326,8 @@ public:
     // Nullify shape and retest BoundingBox
     shapes->at(0) = std::shared_ptr<const Geometry::IObject>(nullptr);
     boundingBox = componentInfo.boundingBox(0);
-    TS_ASSERT(boundingBox.isNull());
+    TS_ASSERT((boundingBox.minPoint() - Kernel::V3D{1., 1., 1.}).norm() < 1e-9);
+    TS_ASSERT((boundingBox.maxPoint() - Kernel::V3D{1., 1., 1.}).norm() < 1e-9);
   }
 
   // Test calculation of the bounding box for a milimiter-sized
@@ -373,7 +374,8 @@ public:
     // Nullify shape and retest BoundingBox
     shapes->at(0) = std::shared_ptr<const Geometry::IObject>(nullptr);
     boundingBox = componentInfo.boundingBox(0);
-    TS_ASSERT(boundingBox.isNull());
+    TS_ASSERT((boundingBox.minPoint() - Kernel::V3D{1., 1., 1.}).norm() < 1e-9);
+    TS_ASSERT((boundingBox.maxPoint() - Kernel::V3D{1., 1., 1.}).norm() < 1e-9);
   }
 
   void test_boundingBox_complex() {
@@ -408,8 +410,8 @@ public:
     // min in the sample (source is ignored by design in instrument 1.0 and
     // instrument 2.0).
     TS_ASSERT((boundingBox.minPoint() -
-               (Kernel::V3D{samplePos[0] - radius, samplePos[1] - radius,
-                            samplePos[2] - radius}))
+               (Kernel::V3D{samplePos[0], detectorPos[1] - radius,
+                            detectorPos[2] - radius}))
                   .norm() < 1e-9);
     // max is the detector
     TS_ASSERT((boundingBox.maxPoint() -
@@ -478,10 +480,8 @@ public:
     instrument.markAsSource(source);
 
     // A sample
-    ObjComponent *sample = new ObjComponent("some-surface-holder");
+    Component *sample = new Component("some-surface-holder");
     sample->setPos(V3D{0, 0, 0});
-    sample->setShape(
-        ComponentCreationHelper::createSphere(0.01 /*1cm*/, V3D(0, 0, 0), "1"));
     instrument.add(sample);
     instrument.markAsSamplePos(sample);
 

--- a/Framework/Geometry/test/InstrumentDefinitionParserTest.h
+++ b/Framework/Geometry/test/InstrumentDefinitionParserTest.h
@@ -204,8 +204,8 @@ public:
     TS_ASSERT_EQUALS(source->getName(), "undulator");
     TS_ASSERT_DELTA(source->getPos().Z(), -17.0, 0.01);
 
-    std::shared_ptr<const IObjComponent> samplepos =
-        std::dynamic_pointer_cast<const IObjComponent>(i->getSample());
+    std::shared_ptr<const IComponent> samplepos =
+        std::dynamic_pointer_cast<const IComponent>(i->getSample());
     TS_ASSERT_EQUALS(samplepos->getName(), "nickel-holder");
     TS_ASSERT_DELTA(samplepos->getPos().Y(), 0.0, 0.01);
 
@@ -436,12 +436,6 @@ public:
     TS_ASSERT(ptrDet17->isValid(V3D(0.0, -0.09, 0.01) + ptrDet17->getPos()));
     TS_ASSERT(!ptrDet17->isValid(V3D(0.09, 0.0, 0.01) + ptrDet17->getPos()));
     TS_ASSERT(!ptrDet17->isValid(V3D(-0.09, 0.0, 0.01) + ptrDet17->getPos()));
-
-    // test of sample shape
-    TS_ASSERT(samplepos->isValid(V3D(0.0, 0.0, 0.005) + samplepos->getPos()));
-    TS_ASSERT(!samplepos->isValid(V3D(0.0, 0.0, 0.05) + samplepos->getPos()));
-    TS_ASSERT(samplepos->isValid(V3D(10.0, 0.0, 0.005) + samplepos->getPos()));
-    TS_ASSERT(!samplepos->isValid(V3D(10.0, 0.0, 0.05) + samplepos->getPos()));
 
     // test of source shape
     TS_ASSERT(source->isValid(V3D(0.0, 0.0, 0.005) + source->getPos()));

--- a/Framework/Geometry/test/InstrumentRayTracerTest.h
+++ b/Framework/Geometry/test/InstrumentRayTracerTest.h
@@ -64,18 +64,13 @@ public:
     tracker.trace(V3D(0., 0., 1));
     Links results = tracker.getResults();
     TS_ASSERT_EQUALS(results.size(), 2);
-    // Check they are actually what we expect: 1 with the sample and 1 with the
-    // central detector
-    IComponent_const_sptr centralPixel =
-        testInst->getComponentByName("pixel-(0;0)");
-    IComponent_const_sptr sampleComp = testInst->getSample();
+    // Check they are actually what we expect: 1 with the central detector
+    IComponent_const_sptr centralPixelBank1 =
+        testInst->getComponentByName("bank1/pixel-(0;0)");
+    IComponent_const_sptr centralPixelBank2 =
+        testInst->getComponentByName("bank2/pixel-(0;0)");
 
-    if (!sampleComp) {
-      TS_FAIL("Test instrument has been changed, the sample has been removed. "
-              "Ray tracing tests need to be updated.");
-      return;
-    }
-    if (!centralPixel) {
+    if ((!centralPixelBank1) || (!centralPixelBank2)) {
       TS_FAIL("Test instrument has been changed, the instrument config has "
               "changed. Ray tracing tests need to be updated.");
       return;
@@ -83,28 +78,29 @@ public:
     Links::const_iterator resultItr = results.begin();
     Link firstIntersect = *resultItr;
 
-    TS_ASSERT_DELTA(firstIntersect.distFromStart, 10.001, 1e-6);
-    TS_ASSERT_DELTA(firstIntersect.distInsideObject, 0.002, 1e-6);
+    TS_ASSERT_DELTA(firstIntersect.distFromStart, 15.004, 1e-6);
+    TS_ASSERT_DELTA(firstIntersect.distInsideObject, 0.008, 1e-6);
     TS_ASSERT_DELTA(firstIntersect.entryPoint.X(), 0.0, 1e-6);
     TS_ASSERT_DELTA(firstIntersect.entryPoint.Y(), 0.0, 1e-6);
-    TS_ASSERT_DELTA(firstIntersect.entryPoint.Z(), -0.001, 1e-6);
+    TS_ASSERT_DELTA(firstIntersect.entryPoint.Z(), 4.996, 1e-6);
     TS_ASSERT_DELTA(firstIntersect.exitPoint.X(), 0.0, 1e-6);
     TS_ASSERT_DELTA(firstIntersect.exitPoint.Y(), 0.0, 1e-6);
-    TS_ASSERT_DELTA(firstIntersect.exitPoint.Z(), 0.001, 1e-6);
-    TS_ASSERT_EQUALS(firstIntersect.componentID, sampleComp->getComponentID());
+    TS_ASSERT_DELTA(firstIntersect.exitPoint.Z(), 5.004, 1e-6);
+    TS_ASSERT_EQUALS(firstIntersect.componentID,
+                     centralPixelBank1->getComponentID());
 
     ++resultItr;
     Link secondIntersect = *resultItr;
-    TS_ASSERT_DELTA(secondIntersect.distFromStart, 15.004, 1e-6);
+    TS_ASSERT_DELTA(secondIntersect.distFromStart, 20.004, 1e-6);
     TS_ASSERT_DELTA(secondIntersect.distInsideObject, 0.008, 1e-6);
     TS_ASSERT_DELTA(secondIntersect.entryPoint.X(), 0.0, 1e-6);
     TS_ASSERT_DELTA(secondIntersect.entryPoint.Y(), 0.0, 1e-6);
-    TS_ASSERT_DELTA(secondIntersect.entryPoint.Z(), 4.996, 1e-6);
+    TS_ASSERT_DELTA(secondIntersect.entryPoint.Z(), 9.996, 1e-6);
     TS_ASSERT_DELTA(secondIntersect.exitPoint.X(), 0.0, 1e-6);
     TS_ASSERT_DELTA(secondIntersect.exitPoint.Y(), 0.0, 1e-6);
-    TS_ASSERT_DELTA(secondIntersect.exitPoint.Z(), 5.004, 1e-6);
+    TS_ASSERT_DELTA(secondIntersect.exitPoint.Z(), 10.004, 1e-6);
     TS_ASSERT_EQUALS(secondIntersect.componentID,
-                     centralPixel->getComponentID());
+                     centralPixelBank2->getComponentID());
 
     // Results vector should be empty after first getResults call
     results = tracker.getResults();
@@ -172,12 +168,12 @@ public:
 
     Links results = tracker.getResults();
     if (expectX == -1) { // Expect no intersection
-      TSM_ASSERT_LESS_THAN(message, results.size(), 2);
+      TSM_ASSERT_LESS_THAN(message, results.size(), 1);
       return;
     }
 
-    TSM_ASSERT_EQUALS(message, results.size(), 2);
-    if (results.size() < 2)
+    TSM_ASSERT_EQUALS(message, results.size(), 1);
+    if (results.size() < 1)
       return;
 
     // Get the first result
@@ -229,8 +225,9 @@ private:
   /// Setup the shared test instrument
   Instrument_sptr setupInstrument() {
     if (!m_testInst) {
-      // 9 cylindrical detectors
-      m_testInst = ComponentCreationHelper::createTestInstrumentCylindrical(1);
+      // 2 banks containing 9 cylindrical detectors each. Set up at different z
+      // values
+      m_testInst = ComponentCreationHelper::createTestInstrumentCylindrical(2);
     }
     return m_testInst;
   }

--- a/Framework/Geometry/test/InstrumentTest.h
+++ b/Framework/Geometry/test/InstrumentTest.h
@@ -36,7 +36,7 @@ public:
     source->setPos(0.0, 0.0, -10.0);
     instrument.add(source);
     instrument.markAsSource(source);
-    ObjComponent *sample = new ObjComponent("sample");
+    Component *sample = new Component("sample");
     instrument.add(sample);
     instrument.markAsSamplePos(sample);
     det = new Detector("det1", 1, nullptr);
@@ -152,17 +152,20 @@ public:
   void testSamplePos() {
     Instrument i;
     TS_ASSERT(!i.getSample());
-    ObjComponent *s = new ObjComponent("");
+    Component *s = new Component("");
     // Cannot have an unnamed source
     TS_ASSERT_THROWS(i.markAsSamplePos(s),
                      const Exception::InstrumentDefinitionError &);
     s->setName("sample");
     TS_ASSERT_THROWS_NOTHING(i.markAsSamplePos(s));
     TS_ASSERT_EQUALS(i.getSample().get(), s);
-    ObjComponent *ss = new ObjComponent("sample2");
+    Component *ss = new Component("sample2");
     // Trying to add sample a second time does nothing
     TS_ASSERT_THROWS_NOTHING(i.markAsSamplePos(ss));
     TS_ASSERT_EQUALS(i.getSample().get(), s);
+    // Try adding a component that supports a shape
+    ObjComponent *sss = new ObjComponent("");
+    TS_ASSERT_THROWS(i.markAsSamplePos(sss), const std::runtime_error &);
     delete s;
     delete ss;
   }

--- a/Framework/Geometry/test/ParInstrumentTest.h
+++ b/Framework/Geometry/test/ParInstrumentTest.h
@@ -30,7 +30,7 @@ public:
     source->setPos(0.0, 0.0, -10.0);
     instrument->add(source);
     instrument->markAsSource(source);
-    ObjComponent *sample = new ObjComponent("sample");
+    Component *sample = new Component("sample");
     instrument->add(sample);
     instrument->markAsSamplePos(sample);
     det = new Detector("det1", 1, nullptr);

--- a/Framework/MDAlgorithms/test/ConvertToMDMinMaxGlobalTest.h
+++ b/Framework/MDAlgorithms/test/ConvertToMDMinMaxGlobalTest.h
@@ -46,8 +46,8 @@ Mantid::API::MatrixWorkspace_sptr MakeWorkspace(double xmin, double dx,
   testInst->add(source);
   testInst->markAsSource(source);
   // Define a sample as a simple sphere
-  Mantid::Geometry::ObjComponent *sample = new Mantid::Geometry::ObjComponent(
-      "samplePos", Mantid::Geometry::IObject_sptr(), testInst.get());
+  Mantid::Geometry::Component *sample =
+      new Mantid::Geometry::Component("samplePos", testInst.get());
   testInst->setPos(0.0, 0.0, 0.0);
   testInst->add(sample);
   testInst->markAsSamplePos(sample);

--- a/Framework/MDAlgorithms/test/ConvertToMDMinMaxLocalTest.h
+++ b/Framework/MDAlgorithms/test/ConvertToMDMinMaxLocalTest.h
@@ -224,8 +224,8 @@ private:
     testInst->add(source);
     testInst->markAsSource(source);
     // Define a sample as a simple sphere
-    Mantid::Geometry::ObjComponent *sample = new Mantid::Geometry::ObjComponent(
-        "samplePos", Mantid::Geometry::IObject_sptr(), testInst.get());
+    Mantid::Geometry::Component *sample =
+        new Mantid::Geometry::Component("samplePos", testInst.get());
     testInst->setPos(0.0, 0.0, 0.0);
     testInst->add(sample);
     testInst->markAsSamplePos(sample);

--- a/Framework/NexusGeometry/src/InstrumentBuilder.cpp
+++ b/Framework/NexusGeometry/src/InstrumentBuilder.cpp
@@ -44,7 +44,7 @@ InstrumentBuilder::InstrumentBuilder(const std::string &instrumentName)
 Geometry::IComponent *
 InstrumentBuilder::addComponent(const std::string &compName,
                                 const Eigen::Vector3d &position) {
-  Geometry::IComponent *component(new Geometry::ObjCompAssembly(compName));
+  Geometry::IComponent *component(new Geometry::CompAssembly(compName));
   component->setPos(position(0), position(1), position(2));
   m_instrument->add(component);
   return component;

--- a/Framework/PythonInterface/test/python/mantid/geometry/InstrumentTest.py
+++ b/Framework/PythonInterface/test/python/mantid/geometry/InstrumentTest.py
@@ -6,7 +6,7 @@
 # SPDX - License - Identifier: GPL - 3.0 +
 import unittest
 from mantid.kernel import DateAndTime
-from mantid.geometry import(Detector, Instrument, ObjComponent, ReferenceFrame)
+from mantid.geometry import(Component, Detector, Instrument, ObjComponent, ReferenceFrame)
 from testhelpers import can_be_instantiated, WorkspaceCreationHelper
 
 
@@ -24,7 +24,7 @@ class InstrumentTest(unittest.TestCase):
 
     def test_getSample(self):
         sample_pos = self.__testws.getInstrument().getSample()
-        self.assertTrue(isinstance(sample_pos, ObjComponent))
+        self.assertTrue(isinstance(sample_pos, Component))
 
     def test_getSource(self):
         source_pos = self.__testws.getInstrument().getSource()

--- a/Framework/TestHelpers/inc/MantidTestHelpers/ComponentCreationHelper.h
+++ b/Framework/TestHelpers/inc/MantidTestHelpers/ComponentCreationHelper.h
@@ -45,7 +45,7 @@ tests.
 
 //----------------------------------------------------------------------------------------------
 
-/// Add a spherical sample at samplePos to given instrument.
+/// Add a sample at samplePos to given instrument.
 void addSampleToInstrument(Mantid::Geometry::Instrument_sptr &instrument,
                            const Mantid::Kernel::V3D &samplePos);
 
@@ -180,7 +180,7 @@ createCylInstrumentWithDetInGivenPositions(const std::vector<double> &L2,
                                            const std::vector<double> &azim);
 /**
  * Create an test instrument with n panels of 9 cylindrical detectors, a source
- * and spherical sample shape.
+ * and a sample position.
  * Detectors have IDs assigned as follows:
  * 7 8 9
  * 4 5 6

--- a/Framework/TestHelpers/inc/MantidTestHelpers/InstrumentCreationHelper.h
+++ b/Framework/TestHelpers/inc/MantidTestHelpers/InstrumentCreationHelper.h
@@ -19,7 +19,7 @@ namespace InstrumentCreationHelper {
 void addFullInstrumentToWorkspace(Mantid::API::MatrixWorkspace &workspace,
                                   bool includeMonitors, bool startYNegative,
                                   const std::string &instrumentName);
-Mantid::Geometry::ObjComponent *
+Mantid::Geometry::Component *
 addComponent(Mantid::Geometry::Instrument_sptr &instrument,
              const Mantid::Kernel::V3D &position, const std::string &name);
 void addSample(Mantid::Geometry::Instrument_sptr &instrument,

--- a/Framework/TestHelpers/src/ComponentCreationHelper.cpp
+++ b/Framework/TestHelpers/src/ComponentCreationHelper.cpp
@@ -118,11 +118,7 @@ createHollowCylinder(double innerRadius, double outerRadius, double height,
 }
 
 void addSampleToInstrument(Instrument_sptr &instrument, const V3D &samplePos) {
-  // Define a sample as a simple sphere
-  IObject_sptr sampleSphere =
-      createSphere(0.001, V3D(0.0, 0.0, 0.0), "sample-shape");
-  ObjComponent *sample =
-      new ObjComponent("sample", sampleSphere, instrument.get());
+  Component *sample = new Component("sample", instrument.get());
   instrument->setPos(samplePos);
   instrument->add(sample);
   instrument->markAsSamplePos(sample);
@@ -734,9 +730,8 @@ createMinimalInstrument(const Mantid::Kernel::V3D &sourcePos,
   instrument->markAsSource(source);
 
   // A sample
-  ObjComponent *sample = new ObjComponent("some-surface-holder");
+  Component *sample = new Component("some-surface-holder");
   sample->setPos(samplePos);
-  sample->setShape(createSphere(0.01 /*1cm*/, V3D(0, 0, 0), "1"));
   instrument->add(sample);
   instrument->markAsSamplePos(sample);
 
@@ -779,9 +774,8 @@ createMinimalInstrumentWithMonitor(const Mantid::Kernel::V3D &monitorPos,
   instrument->markAsSource(source);
 
   // A sample
-  auto *sample = new ObjComponent("some-surface-holder");
+  auto *sample = new Component("some-surface-holder");
   sample->setPos(V3D(0, 0, 0));
-  sample->setShape(createSphere(0.01 /*1cm*/, V3D(0, 0, 0), "1"));
   instrument->add(sample);
   instrument->markAsSamplePos(sample);
 
@@ -827,7 +821,7 @@ Instrument_sptr createInstrumentWithOptionalComponents(bool haveSource,
 
   // A sample
   if (haveSample) {
-    ObjComponent *sample = new ObjComponent("some-sample");
+    Component *sample = new Component("some-sample");
 
     instrument->add(sample);
     instrument->markAsSamplePos(sample);
@@ -881,9 +875,8 @@ Instrument_sptr createSimpleInstrumentWithRotation(
   instrument->markAsSource(source);
 
   // A sample
-  ObjComponent *sample = new ObjComponent("some-surface-holder");
+  Component *sample = new Component("some-surface-holder");
   sample->setPos(samplePos);
-  sample->setShape(createSphere(0.01 /*1cm*/, V3D(0, 0, 0), "1"));
   instrument->add(sample);
   instrument->markAsSamplePos(sample);
 
@@ -937,9 +930,8 @@ Instrument_sptr createInstrumentWithSourceRotation(
   instrument->markAsSource(source);
 
   // A sample
-  ObjComponent *sample = new ObjComponent("some-surface-holder");
+  Component *sample = new Component("some-surface-holder");
   sample->setPos(samplePos);
-  sample->setShape(createSphere(0.01 /*1cm*/, V3D(0, 0, 0), "1"));
   instrument->add(sample);
   instrument->markAsSamplePos(sample);
 

--- a/Framework/TestHelpers/src/InstrumentCreationHelper.cpp
+++ b/Framework/TestHelpers/src/InstrumentCreationHelper.cpp
@@ -81,10 +81,7 @@ void addFullInstrumentToWorkspace(MatrixWorkspace &workspace,
   instrument->markAsSource(source);
 
   // Define a sample as a simple sphere
-  ObjComponent *sample = new ObjComponent(
-      "samplePos",
-      ComponentCreationHelper::createSphere(0.1, V3D(0, 0, 0), "1"),
-      instrument.get());
+  Component *sample = new Component("samplePos", instrument.get());
   instrument->setPos(0.0, 0.0, 0.0);
   instrument->add(sample);
   instrument->markAsSamplePos(sample);
@@ -102,10 +99,10 @@ void addFullInstrumentToWorkspace(MatrixWorkspace &workspace,
  * @param name :: name of the component
  * @return a component pointer
  */
-ObjComponent *addComponent(Mantid::Geometry::Instrument_sptr &instrument,
-                           const Mantid::Kernel::V3D &position,
-                           const std::string &name) {
-  auto *component = new ObjComponent(name);
+Component *addComponent(Mantid::Geometry::Instrument_sptr &instrument,
+                        const Mantid::Kernel::V3D &position,
+                        const std::string &name) {
+  auto *component = new Component(name);
   component->setPos(position);
   instrument->add(component);
   return component;

--- a/Framework/TestHelpers/src/InstrumentCreationHelper.cpp
+++ b/Framework/TestHelpers/src/InstrumentCreationHelper.cpp
@@ -80,7 +80,7 @@ void addFullInstrumentToWorkspace(MatrixWorkspace &workspace,
   instrument->add(source);
   instrument->markAsSource(source);
 
-  // Define a sample as a simple sphere
+  // Define a sample position
   Component *sample = new Component("samplePos", instrument.get());
   instrument->setPos(0.0, 0.0, 0.0);
   instrument->add(sample);

--- a/Framework/TestHelpers/src/WorkspaceCreationHelper.cpp
+++ b/Framework/TestHelpers/src/WorkspaceCreationHelper.cpp
@@ -1332,12 +1332,6 @@ createPeaksWorkspace(const int numPeaks, const bool createOrientedLattice) {
       ComponentCreationHelper::createTestInstrumentRectangular2(1, 10);
   peaksWS->setInstrument(inst);
 
-  // workspace->sample only gets set if workspace is filebacked so force it here
-  auto sampleShapeComponent =
-      std::dynamic_pointer_cast<const IObjComponent>(inst->getSample());
-  auto shape = std::shared_ptr<IObject>(sampleShapeComponent->shape()->clone());
-  peaksWS->mutableSample().setShape(shape);
-
   for (int i = 0; i < numPeaks; ++i) {
     Peak peak(inst, i, i + 0.5);
     peaksWS->addPeak(peak);

--- a/instrument/unit_testing/IDF_for_UNIT_TESTING.xml
+++ b/instrument/unit_testing/IDF_for_UNIT_TESTING.xml
@@ -144,16 +144,6 @@
 
   <type name="nickel-holder" is="SamplePos">
     <properties />
-    
-    <sphere id="some-shape1">
-      <centre x="0.0"  y="0.0" z="0.0" />
-      <radius val="0.03" />
-    </sphere>
-    <sphere id="some-shape2">
-      <centre x="10.0"  y="0.0" z="0.0" />
-      <radius val="0.03" />
-    </sphere>    
-    <algebra val="some-shape1 : some-shape2" />  <!-- union example -->
   </type>
 
   <!-- Detectors types -->

--- a/instrument/unit_testing/IDF_for_UNIT_TESTING6.xml
+++ b/instrument/unit_testing/IDF_for_UNIT_TESTING6.xml
@@ -145,16 +145,6 @@
 
   <type name="nickel-holder" is="SamplePos">
     <properties />
-    
-    <sphere id="some-shape1">
-      <centre x="0.0"  y="0.0" z="0.0" />
-      <radius val="0.03" />
-    </sphere>
-    <sphere id="some-shape2">
-      <centre x="10.0"  y="0.0" z="0.0" />
-      <radius val="0.03" />
-    </sphere>    
-    <algebra val="some-shape1 : some-shape2" />  <!-- union example -->
   </type>
 
   <!-- Detectors types -->


### PR DESCRIPTION
**Description of work.**

The shape of the sample should be stored against the m_sample field in the ExperimentInfo class. This PR prevents a second (potentially different) sample shape being stored in the instrument definition on the "SamplePos" component which should only have a position. It also removes a lots of instances of the "wrong" place being used - mostly in tests but also in ~8 algorithms.

I've achieved this by requiring the "SamplePos" component to be of type Component instead of ObjComponent (see change in Instrument.cpp). There were various places where the sample was set up to be an ObjComponent without it needing to be so I've changed these to Component.

At the last count there were 48 files changed in this PR - however 32 of them are tests or test helpers. And beyond that a lot of the changes are just to update a use of the ObjComponent class to the Component class. So the PR isn't as large as it appears. The key code changes are:
- Instrument.cpp, the main change to prevent an instrument component being marked as the sample being of a type that supports a shape
- InstrumentDefinitionParser.cpp, this unit now creates samples to be of type Component rather than ObjComponent
- change to bounding box logic in ComponentInfo.cpp and BoundingBox.cpp. As a result of this PR the sample is now a point-like object as far as the instrument definition is concerned. But it still needs to contribute to the bounding box calculations and I found some limitations in these two units that didn't handle point-like objects properly and resulted in them being ignored. Maybe this is partly why the sample had a shape set up in the instrument definition in lots of places

**To test:**

To a large extent there's no functional impact of this PR because it's main aim is to stop developers creating a sample shape in the wrong place (which results in that shape being ignored). So it's mainly a case of checking nothing's been broken which will be largely achieved by the unit\system tests. However two suggestions:

1) A quick test that will run through the changes to Instrument.cpp\InstrumentDefinitionParser.cpp is to load MAR11060.raw and check the "Instrument Viewer", "Show Detectors" options still work on the right click menu.

2) There is one small functional change to the CreateSampleWorkspace algorithm which now sets up a sample shape in the correct place. This means that running an absorption correction calculation (like the following) which analyses the sample shape will now work. It previously failed with an error saying "no sample shape" set up:

```
# import mantid algorithms, numpy and matplotlib
from mantid.simpleapi import *
import matplotlib.pyplot as plt
import numpy as np

ws=CreateSampleWorkspace()

ws_wave = ConvertUnits(ws,"Wavelength")

ws_corr = MonteCarloAbsorption(ws_wave)
```

Fixes #28732 . 

*This does not require release notes* because no external functional impact on user. It just stops Mantid developers setting up sample shapes in the wrong place that never do anything

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
