### PR TITLE
Fix failing plot settings test

### DIFF
--- a/qt/applications/workbench/workbench/widgets/settings/plots/test/test_plot_settings.py
+++ b/qt/applications/workbench/workbench/widgets/settings/plots/test/test_plot_settings.py
@@ -38,6 +38,7 @@ class PlotsSettingsTest(unittest.TestCase):
                                                        call(PlotSettings.X_AXES_SCALE),
                                                        call(PlotSettings.Y_AXES_SCALE),
                                                        call(PlotSettings.LINE_STYLE),
+                                                       call(PlotSettings.DRAW_STYLE),
                                                        call(PlotSettings.LINE_WIDTH),
                                                        call(PlotSettings.MARKER_STYLE),
                                                        call(PlotSettings.MARKER_SIZE),


### PR DESCRIPTION
**Description of work.**
The settings tests were added at the same time as a new setting was added. This resulted in an expected call being missed from the tests once both PRs were merged. This PR adds in the missing call.

**To test:**
Code review and tests pass.
<!-- Instructions for testing. -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
