### PR TITLE
wb plot error when no data is from a workspace

### DIFF
--- a/qt/applications/workbench/workbench/plotting/toolbar.py
+++ b/qt/applications/workbench/workbench/plotting/toolbar.py
@@ -215,7 +215,7 @@ class WorkbenchNavigationToolbar(NavigationToolbar2QT):
                     if ax.get_artists_sample_log_plot_details(artist) is not None:
                         self._set_fit_enabled(False)
                         break
-                except ValueError:
+                except Exception:
                     #The artist is not tracked - ignore this one and check the rest
                     continue
 


### PR DESCRIPTION
**Description of work.**
Catch a previously uncaught exception while working out wether to show icons on the plot toolbar.


**Report to:** Tatiana Guidi


**To test:**
1. there is a nice test script in #28857, no test data is needed
1. if the script runs and a plot is generated without errors in the log then all is good.


Fixes #28857


*This does not require release notes* because *is was introduced in this sprint*


---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
