### PR TITLE
Stop PSIBackground crash with groups

### DIFF
--- a/Framework/Muon/src/PSIBackgroundSubtraction.cpp
+++ b/Framework/Muon/src/PSIBackgroundSubtraction.cpp
@@ -74,7 +74,10 @@ std::map<std::string, std::string> PSIBackgroundSubtraction::validateInputs() {
   std::map<std::string, std::string> errors;
 
   MatrixWorkspace_sptr inputWS = getProperty("InputWorkspace");
-
+  if (!inputWS) {
+    errors["InputWorkspace"] = "Input Workspace must be Matrix workspace.";
+    return errors;
+  }
   if (inputWS->YUnit() != "Counts") {
     errors["InputWorkspace"] = "Input Workspace should be a counts workspace.";
   }

--- a/Framework/Muon/test/PSIBackgroundSubtractionTest.h
+++ b/Framework/Muon/test/PSIBackgroundSubtractionTest.h
@@ -97,25 +97,6 @@ public:
     TS_ASSERT(alg.isInitialized());
   }
 
-  void test_that_algorithm_does_not_execute_if_invalid_workspace_type() {
-    PSIBackgroundSubtraction alg;
-    auto ws = createCountsTestWorkspace(2, 100);
-    IAlgorithm_sptr groupingAlg =
-        AlgorithmManager::Instance().createUnmanaged("GroupWorkspaces");
-    groupingAlg->initialize();
-    groupingAlg->setProperty("InputWorkspaces", ws);
-    groupingAlg->setPropertyValue("OutputWorkspace", "group");
-    groupingAlg->execute();
-
-    std::string group = groupingAlg->getProperty("OutputWorkspace");
-
-    alg.initialize();
-    alg.setProperty("InputWorkspace", group);
-
-    TS_ASSERT_THROWS(alg.execute(), const std::runtime_error &);
-    clearADS();
-  }
-
   void test_that_algorithm_does_not_execute_if_invalid_y_label() {
     PSIBackgroundSubtraction alg;
     auto ws = createInvalidTestWorkspace(2, 100);

--- a/Framework/Muon/test/PSIBackgroundSubtractionTest.h
+++ b/Framework/Muon/test/PSIBackgroundSubtractionTest.h
@@ -99,6 +99,25 @@ public:
 
   void test_that_algorithm_does_not_execute_if_invalid_workspace_type() {
     PSIBackgroundSubtraction alg;
+    auto ws = createCountsTestWorkspace(2, 100);
+    IAlgorithm_sptr groupingAlg =
+        AlgorithmManager::Instance().createUnmanaged("GroupWorkspaces");
+    groupingAlg->initialize();
+    groupingAlg->setProperty("InputWorkspaces", ws);
+    groupingAlg->setPropertyValue("OutputWorkspace", "group");
+    groupingAlg->execute();
+
+    WorkspaceGroup_sptr group = groupingAlg->getProperty("OutputWorkspace");
+
+    alg.initialize();
+    alg.setProperty("InputWorkspace", group);
+
+    TS_ASSERT_THROWS(alg.execute(), const std::runtime_error &);
+    clearADS();
+  }
+
+  void test_that_algorithm_does_not_execute_if_invalid_y_label() {
+    PSIBackgroundSubtraction alg;
     auto ws = createInvalidTestWorkspace(2, 100);
 
     alg.initialize();

--- a/Framework/Muon/test/PSIBackgroundSubtractionTest.h
+++ b/Framework/Muon/test/PSIBackgroundSubtractionTest.h
@@ -107,7 +107,7 @@ public:
     groupingAlg->setPropertyValue("OutputWorkspace", "group");
     groupingAlg->execute();
 
-    WorkspaceGroup_sptr group = groupingAlg->getProperty("OutputWorkspace");
+    std::string group = groupingAlg->getProperty("OutputWorkspace");
 
     alg.initialize();
     alg.setProperty("InputWorkspace", group);


### PR DESCRIPTION
When using a group workspace in PSIBackgroundSubtraction, Mantid would crash. This fixes it.

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

**To test:**
1. Open Muon Analysis
2. Load PSI data
3. Use the PSIBackgroundSubtraction alg with the grouped workspace as the input
4. It wont crash

If you want it to work with counts data, you will need to set the first good data and time zero to 0. 
<!-- Instructions for testing. -->

Fixes #28713. <!-- and fix #xxxx or close #xxxx xor resolves #xxxx -->
<!-- alternative
*There is no associated issue.*
-->

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
-->

---
This is not in the release notes as this is a new algorithm for this release
#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
