### PR TITLE
Allow MonteCarloAbsorption to run without a sample specified

### DIFF
--- a/Framework/Algorithms/src/SampleCorrections/MCInteractionVolume.cpp
+++ b/Framework/Algorithms/src/SampleCorrections/MCInteractionVolume.cpp
@@ -37,10 +37,6 @@ MCInteractionVolume::MCInteractionVolume(
     : m_sample(sample.getShape().clone()), m_env(nullptr),
       m_activeRegion(activeRegion), m_maxScatterAttempts(maxScatterAttempts),
       m_pointsIn(pointsIn) {
-  if (!m_sample->hasValidShape()) {
-    throw std::invalid_argument(
-        "MCInteractionVolume() - Sample shape does not have a valid shape.");
-  }
   try {
     m_env = &sample.getEnvironment();
     assert(m_env);
@@ -50,6 +46,21 @@ MCInteractionVolume::MCInteractionVolume(
     }
   } catch (std::runtime_error &) {
     // swallow this as no defined environment from getEnvironment
+  }
+
+  bool atLeastOneValidShape = m_sample->hasValidShape();
+  if (!atLeastOneValidShape && m_env) {
+    for (size_t i = 0; i < m_env->nelements(); i++) {
+      if (m_env->getComponent(i).hasValidShape()) {
+        atLeastOneValidShape = true;
+        break;
+      }
+    }
+  }
+  if (!atLeastOneValidShape) {
+    throw std::invalid_argument(
+        "MCInteractionVolume() - Either the Sample or one of the "
+        "environment parts must have a valid shape.");
   }
 }
 

--- a/Framework/Algorithms/test/MCInteractionVolumeTest.h
+++ b/Framework/Algorithms/test/MCInteractionVolumeTest.h
@@ -237,6 +237,16 @@ public:
     TS_ASSERT_DELTA(0.73100698, factorSample, 1e-8);
   }
 
+  void test_Construction_With_Env_But_No_Sample_Shape_Does_Not_Throw_Error() {
+    Mantid::API::Sample sample;
+    auto kit = createTestKit();
+    sample.setEnvironment(
+        std::make_unique<Mantid::Geometry::SampleEnvironment>(*kit));
+
+    TS_ASSERT_THROWS_NOTHING(
+        MCInteractionVolume mcv(sample, kit->getComponent(0).getBoundingBox()));
+  }
+
   //----------------------------------------------------------------------------
   // Failure cases
   //----------------------------------------------------------------------------

--- a/Framework/DataHandling/test/SetSampleTest.h
+++ b/Framework/DataHandling/test/SetSampleTest.h
@@ -272,6 +272,7 @@ public:
     auto alg = createAlgorithm(inputWS);
     alg->setProperty("Environment", createEnvironmentProps("10mm_empty"));
     TS_ASSERT_THROWS_NOTHING(alg->execute());
+    config.setString("instrumentDefinition.directory", defaultDirs);
   }
 
   void test_Setting_Geometry_As_FlatPlate() {
@@ -890,6 +891,7 @@ public:
     alg->setProperty("Environment", props);
     alg->setProperty("Geometry", createOverrideGeometryProps());
     TS_ASSERT_THROWS(alg->execute(), const std::runtime_error &);
+    config.setString("instrumentDefinition.directory", defaultDirs);
   }
 
   void test_Geometry_Override_On_Environment_Without_Sample_Gives_Error() {
@@ -910,6 +912,7 @@ public:
     alg->setProperty("Environment", createEnvironmentProps("10mm_empty"));
     alg->setProperty("Geometry", createOverrideGeometryProps());
     TS_ASSERT_THROWS(alg->execute(), const std::runtime_error &);
+    config.setString("instrumentDefinition.directory", defaultDirs);
   }
 
   //----------------------------------------------------------------------------

--- a/docs/source/release/v5.1.0/framework.rst
+++ b/docs/source/release/v5.1.0/framework.rst
@@ -28,6 +28,7 @@ Algorithms
 - Adjusted :ref:`AddPeak <algm-AddPeak>` to only allow peaks from the same instrument as the peaks worksapce to be added to that workspace.
 - :ref:`MonteCarloAbsorption <algm-MonteCarloAbsorption>` Bug fixed where setting ResimulateTracksForDifferentWavelengths parameter to True was being ignored
 - :ref:`MonteCarloAbsorption <algm-MonteCarloAbsorption>` Corrections are not calculated anymore for masked spectra
+- :ref:`MonteCarloAbsorption <algm-MonteCarloAbsorption>` Corrections can be calculated for a workspace without a sample eg container only
 - :ref:`MaskDetectorsIf <algm-MaskDetectorsIf>` has received a number of updates:
 
   - The algorithm now checks all of the data bins for each spectrum of a workspace, previously it only checked the first bin.


### PR DESCRIPTION
**Description of work.**

The validations to prevent MonteCarloAbsorption running on a workspace without a sample shape have been removed. A validation has been added to check that either the sample or one of the environment components has a shape
I've also made a change to the validations in SetSample that in one special case were preventing the "no sample" calculation. If you load the environment definition from a sample environment .xml then Mantid was previously requiring a sample shape to be specified in the xml file.
The motivation for doing this is to support the PaalmanPingsMonteCarloAbsorption approach where one of the corrections has to be for a "empty can" scenario

**To test:**

1) Run the following script that doesn't specify a sample shape but does specify an environment consisting of a single part - a cylindrical container. It should run without an error (before this PR it would have failed)
```
# import mantid algorithms, numpy and matplotlib
from mantid.simpleapi import *
import matplotlib.pyplot as plt
import numpy as np

ws = CreateSampleWorkspace()

ws_wave = ConvertUnits(InputWorkspace=ws, Target='Wavelength')

SetSample(ws_wave,
        ContainerGeometry={'Shape': 'HollowCylinder', 'Height': 4.0,
                  'InnerRadius': 2.0, 'OuterRadius': 2.3,
                  'Center': [0.,0.,0.]},
        ContainerMaterial={'ChemicalFormula': 'Al',
                  'NumberDensity': 0.01})
                  
ws_wave_abscorr = MonteCarloAbsorption(InputWorkspace=ws_wave, EventsPerPoint=100)
```

2) Then comment out to the call to SetSample - without any shapes specified the script should raise an error

Fixes #28859.

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
