### PR TITLE
Fix a crash when masking a ws while the ws display widget is visible

### DIFF
--- a/docs/source/release/v5.1.0/mantidworkbench.rst
+++ b/docs/source/release/v5.1.0/mantidworkbench.rst
@@ -76,6 +76,7 @@ Bugfixes
 - Fixed a crash when opening the plot options for a sample logs plot.
 - Fixed a crash when you defined a new Fit Function after deleting a plot.
 - Fixed a crash when plotting the logs from a multi-dimensional workspace, that combines several different original workspaces.
+- Fixed a crash when masking a workspace while the worspace data table was on the screen.
 - The scale of the color bars on colorfill plots of ragged workspaces now uses the maximum and minimum values of the data.
 - Fixed a bug where setting columns to Y error in table workspaces wasn't working. The links between the Y error and Y columns weren't being set up properly
 - Opening figure options on a plot with an empty legend no longer causes an unhandled exception.

--- a/qt/python/mantidqt/utils/testing/mocks/mock_observing.py
+++ b/qt/python/mantidqt/utils/testing/mocks/mock_observing.py
@@ -16,6 +16,7 @@ class MockObservingView(ObservingView):
     def __init__(self, _):
         self.close_signal = MockQtSignal()
         self.rename_signal = MockQtSignal()
+        self.replace_signal = MockQtSignal()
         self.presenter = Mock()
         self.presenter.clear_observer = Mock()
         self.setWindowTitle = Mock()

--- a/qt/python/mantidqt/widgets/observers/observing_presenter.py
+++ b/qt/python/mantidqt/widgets/observers/observing_presenter.py
@@ -50,7 +50,8 @@ class ObservingPresenter(object):
         return self.model.workspace_equals(name)
 
     def replace_workspace(self, workspace_name, workspace):
-        raise NotImplementedError("This method must be overridden.")
+        if self.model.workspace_equals(workspace_name):
+            self.container.emit_replace(workspace_name, workspace)
 
     def rename_workspace(self, old_name, new_name):
         if self.model.workspace_equals(old_name):

--- a/qt/python/mantidqt/widgets/observers/observing_view.py
+++ b/qt/python/mantidqt/widgets/observers/observing_view.py
@@ -15,7 +15,7 @@ class ObservingView(object):
 
     It is designed to be used with a presenter that inherits `ObservingPresenter`.
 
-    If this class is inherited a `close_signal` and a `rename_signal` must be declared.
+    If this class is inherited a `close_signal`, a `replace_signal` and a `rename_signal` must be declared.
 
     It is not possible to do that here, as this is not a QObject, however it was
     attempted to do the declaration here, but the signals don't seem to work
@@ -50,6 +50,9 @@ class ObservingView(object):
 
     def emit_rename(self, new_name):
         self.rename_signal.emit(new_name)
+
+    def emit_replace(self, name, workspace):
+        self.replace_signal.emit(name, workspace)
 
     def _rename(self, new_name):
         self.setWindowTitle(self.TITLE_STRING.format(new_name))

--- a/qt/python/mantidqt/widgets/observers/test/test_observing_presenter.py
+++ b/qt/python/mantidqt/widgets/observers/test/test_observing_presenter.py
@@ -47,9 +47,19 @@ class ObservingPresenterTest(unittest.TestCase):
         presenter.container.close_signal.emit.assert_called_once_with()
         self.assertIsNone(presenter.ads_observer)
 
+    @with_presenter()
+    def test_rename_workspace(self, presenter):
+        new_name = "xax"
+        ws=""
+        presenter.rename_workspace("", new_name, ws)
+        presenter.container.replace_signal.emit.assert_called_once_with(new_name, ws)
+
     @with_presenter(workspaces_are_equal=False)
-    def test_replace_workspace_not_implemented(self, presenter):
-        self.assertRaises(NotImplementedError, presenter.replace_workspace, "", "")
+    def test_not_renaming_workspace_with_invalid_name(self, presenter):
+        new_name = "xax"
+        ws=""
+        presenter.rename_workspace("", new_name, ws)
+        self.assertNotCalled(presenter.container.replace_signal.emit)
 
     @with_presenter()
     def test_rename_workspace(self, presenter):

--- a/qt/python/mantidqt/widgets/observers/test/test_observing_presenter.py
+++ b/qt/python/mantidqt/widgets/observers/test/test_observing_presenter.py
@@ -48,17 +48,17 @@ class ObservingPresenterTest(unittest.TestCase):
         self.assertIsNone(presenter.ads_observer)
 
     @with_presenter()
-    def test_rename_workspace(self, presenter):
+    def test_replace_workspace(self, presenter):
         new_name = "xax"
         ws=""
-        presenter.rename_workspace("", new_name, ws)
+        presenter.replace_workspace(new_name, ws)
         presenter.container.replace_signal.emit.assert_called_once_with(new_name, ws)
 
     @with_presenter(workspaces_are_equal=False)
-    def test_not_renaming_workspace_with_invalid_name(self, presenter):
+    def test_not_replacing_workspace_with_invalid_name(self, presenter):
         new_name = "xax"
         ws=""
-        presenter.rename_workspace("", new_name, ws)
+        presenter.replace_workspace(new_name, ws)
         self.assertNotCalled(presenter.container.replace_signal.emit)
 
     @with_presenter()

--- a/qt/python/mantidqt/widgets/workspacedisplay/matrix/presenter.py
+++ b/qt/python/mantidqt/widgets/workspacedisplay/matrix/presenter.py
@@ -54,10 +54,13 @@ class MatrixWorkspaceDisplay(ObservingPresenter, DataCopier):
         self.view.set_context_menu_actions(self.view.table_x)
         self.view.set_context_menu_actions(self.view.table_e)
 
+        # connect to replace_signal signal to handle replacement of the workspace
+        self.container.replace_signal.connect(self.action_replace_workspace)
+
     def show_view(self):
         self.container.show()
 
-    def replace_workspace(self, workspace_name, workspace):
+    def action_replace_workspace(self, workspace_name, workspace):
         if self.model.workspace_equals(workspace_name):
             self.model = MatrixWorkspaceDisplayModel(workspace)
             self.setup_tables()

--- a/qt/python/mantidqt/widgets/workspacedisplay/matrix/test/test_matrixworkspacedisplay_presenter.py
+++ b/qt/python/mantidqt/widgets/workspacedisplay/matrix/test/test_matrixworkspacedisplay_presenter.py
@@ -360,7 +360,7 @@ class MatrixWorkspaceDisplayPresenterTest(unittest.TestCase):
     def test_replace(self, ws, view, presenter):
         view.set_model.reset_mock()
 
-        presenter.replace_workspace(ws.TEST_NAME, ws)
+        presenter.action_replace_workspace(ws.TEST_NAME, ws)
 
         self.assertEqual(3, view.set_context_menu_actions.call_count)
         self.assertEqual(1, view.set_model.call_count)

--- a/qt/python/mantidqt/widgets/workspacedisplay/status_bar_view.py
+++ b/qt/python/mantidqt/widgets/workspacedisplay/status_bar_view.py
@@ -8,12 +8,14 @@
 from qtpy.QtCore import Qt, Signal, Slot
 from qtpy.QtWidgets import QMainWindow, QStatusBar
 
+from mantid.api import Workspace
 from mantidqt.widgets.observers.observing_view import ObservingView
 
 
 class StatusBarView(QMainWindow, ObservingView):
     close_signal = Signal()
     rename_signal = Signal(str)
+    replace_signal = Signal(str, Workspace)
 
     def __init__(self, parent, central_widget, name, window_width=600, window_height=400, presenter=None):
         super(StatusBarView, self).__init__(parent)


### PR DESCRIPTION
**Description of work.**
This was a call to change an object on the wrong thread,
rerouted through a signal and slot

**Report to:** @gemmaguest 


**To test:**
This uses a file from the Usage data.

Run the following script once
Then right-click dataws and select Show Data
Then re-run just the loop that does the masking - Workbench crashes
``` python 
dataws = LoadNexusProcessed(Filename="PG3_2538_2k.nxs")
for i in range(100):
    dataws.maskDetectors(100+i)
```

Fixes #28856


---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
