### PR TITLE
Handle wb start pos when it is off the right or bottom of the screen

### DIFF
--- a/qt/applications/workbench/workbench/app/mainwindow.py
+++ b/qt/applications/workbench/workbench/app/mainwindow.py
@@ -666,7 +666,7 @@ class MainWindow(QMainWindow):
         screen = desktop.screenNumber(window_pos)
 
         # recalculate the window size
-        desktop_geom = desktop.screenGeometry(screen)
+        desktop_geom = desktop.availableGeometry(screen)
         w = min(desktop_geom.size().width(), window_size.width())
         h = min(desktop_geom.size().height(), window_size.height())
         window_size = QSize(w, h)
@@ -674,6 +674,10 @@ class MainWindow(QMainWindow):
         # and position it on the supplied desktop screen
         x = max(window_pos.x(), desktop_geom.left())
         y = max(window_pos.y(), desktop_geom.top())
+        if x + w > desktop_geom.right():
+            x = desktop_geom.right() - w
+        if y + h > desktop_geom.bottom():
+            y = desktop_geom.bottom() - h
         window_pos = QPoint(x, y)
 
         # set the geometry


### PR DESCRIPTION
**Description of work.**

We already had check for the top and right this just completes the set


**To test:**

1. Start workbench
1. Move the window so it is mostly off the right side of the screen
1. close workbench and restart it
1. the window should be moved to be mainly on the screen
1. the repeat with the window mostly off the bottom of the screen


*There is no associated issue.*


*This does not require release notes* because **it is a minor fix that pales in comparison to the other work in the release notes**


---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
