### PR TITLE
Fix string quote for NSIS v>=3

### DIFF
--- a/buildconfig/CMake/NSIS.template.in
+++ b/buildconfig/CMake/NSIS.template.in
@@ -1002,7 +1002,7 @@ FunctionEnd
   !ifndef Un${StrFuncName}_INCLUDED
     ${Un${StrFuncName}}
   !endif
-  !define un.${StrFuncName} "${Un${StrFuncName}}"
+  !define un.${StrFuncName} '${Un${StrFuncName}}'
 !macroend
 
 !insertmacro _IncludeStrFunction StrTok


### PR DESCRIPTION
**Description of work.**

CMake >= 3.17 requires NSIS v3 to be able to generate the Windows package but our current NSIS template is not compatible with NSIS v3. This change ensures the package can build with NSIS v3.

**To test:**

On Windows:
* download and install [NSIS v3](https://sourceforge.net/projects/nsis/files/NSIS%203/) 
* run cmake, setting `ENABLE_CPACK` to `ON`
* in Visual Studio build the `ALL_BUILD` target followed by the `package` target
* a `.exe` file should be generated in the build directory.

*There is no associated issue.*

*This does not require release notes* because **it fixes an internal issue.**

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
