### PR TITLE
'Old' MARI definition set sp4 as a monitor

### DIFF
--- a/docs/source/release/v5.1.0/direct_geometry.rst
+++ b/docs/source/release/v5.1.0/direct_geometry.rst
@@ -16,6 +16,9 @@ For ILL time-of-flight instruments, :ref:`LoadILLTOF <algm-LoadILLTOF-v2>` now a
 number by default, but you can still convert to time-of-flight using the `ConvertToTOF` property.
 The incident energy calibration has been fixed for PANTHER and IN6 in :ref:`DirectILLCollectData <algm-DirectILLCollectData-v1>`.
 
+An update to the instrument definition for 'old' mari has added in a definition for the sectra 4 as a monitor.
+This will not affect data after July 2017, when MARI was updated as this uses a different instrument definition.
+
 Bugfixes
 --------
 

--- a/instrument/MARI_Definition_19900101_20160911.xml
+++ b/instrument/MARI_Definition_19900101_20160911.xml
@@ -157,6 +157,7 @@
     <location z="-4.739" />
     <location z="-1.442" />
     <location z="5.82" />
+    <location z="1" />
   </component>
   
   <type name="monitor" is="monitor">
@@ -1379,7 +1380,7 @@
   </idlist> 
   
   <idlist idname="monitor">
-    <id start="1" end="3" />   
+    <id start="1" end="4" />   
   </idlist>
   
   <!--DETECTOR PARAMETERS-->

--- a/instrument/unit_testing/MARI_Definition_OLD.xml
+++ b/instrument/unit_testing/MARI_Definition_OLD.xml
@@ -1,0 +1,1405 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- For help on the notation used to specify an Instrument Definition File 
+     see http://www.mantidproject.org/IDF -->
+<instrument xmlns="http://www.mantidproject.org/IDF/1.0" 
+            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+            xsi:schemaLocation="http://www.mantidproject.org/IDF/1.0 http://schema.mantidproject.org/IDF/1.0/IDFSchema.xsd"
+ name="MARI" valid-from   ="1900-01-31 23:59:59"
+                        valid-to     ="2017-06-30 23:59:58"
+                        last-modified="2019-02-06 10:00:01">
+
+  <defaults>
+    <length unit="meter"/>
+    <angle unit="degree"/>
+    <reference-frame>
+      <!-- The z-axis is set parallel to and in the direction of the beam. the 
+           y-axis points up and the coordinate system is right handed. -->
+      <along-beam axis="z"/>
+      <pointing-up axis="y"/>
+      <handedness val="right"/>
+    </reference-frame>
+  </defaults>
+
+  
+  <!-- DESCRIPTION OF INSTRUMENT IN WORDS: 
+  
+    The data for Mari was obtained from Jon Taylor.
+  
+  -->
+
+  
+  <!--  SOURCE AND SAMPLE POSITION -->
+  
+  <component type="Moderator">
+    <location z="-11.739" />
+  </component>
+  <type name="Moderator" is="Source"> </type>
+  
+  <component type="sample-position">
+    <location />
+  </component>
+  <type name="sample-position" is="SamplePos"></type>
+  
+
+  <!-- CHOPPERS -->
+ <!-- Chopper position -->
+ <component type="chopper-position">
+    <location z="-1.689"/>
+    <!--description is="The component provides sample-choper distance, used
+    to estimate chopper delay time and Tobyfit resolution calculations."/ -->
+    <!-- if chopper "a": t_offset = -3281.8/SPEED + 16.2; 
+        if chopper "g": t_offset = -2822.5/SPEED + 9.7
+        if chopper "s": t_offset = -3326.8/SPEED + 7.7
+    -->
+    <parameter name="initial_phase">    
+        <value val="-3000."/>
+        <description is="The initial rotation phase of the disk used to caluclate the time
+        for neutrons arriving at the chopper according to the formula time = delay + initial_phase/Speed"/>
+    </parameter>
+    <parameter name="ChopperDelayLog" type="string">
+        <value val="fermi_delay"/>
+    </parameter>
+    <parameter name="ChopperSpeedLog" type="string">
+        <value val="fermi_speed"/>
+    </parameter>
+    <parameter name="FilterBaseLog" type="string">
+        <value val="good_uah_log"/>
+    </parameter>
+    <!-- if the log above should be used as it is or 
+    one should calculate its derivative -->
+    <parameter name="filter_with_derivative" type="bool">
+        <value val="True"/>	
+    </parameter>
+
+  </component>
+  <type name="chopper-position" is="ChopperPos"></type>  
+  
+  
+  <component type="fermi-chopper">
+    <location y="-0.1" z="-1.689" />
+    <parameter name="Speed (Hz)">
+      <logfile id="fermi_speed" extract-single-value-as="last_value" />
+    </parameter>
+    <parameter name="Delay (us)">
+      <logfile id="fermi_delay" extract-single-value-as="last_value" />
+      <description is="Delay is the time between the moment when beam hits moderator and the moment, 
+      when neutron passes through chopper for the first time."/>
+    </parameter>
+     
+  </component>  
+  <type name="fermi-chopper" is="chopper">
+    <cylinder id="body">
+        <centre-of-bottom-base x="0.0" y="0.0" z="0.0" />
+        <axis x="0.0" y="1.0" z="0.0" /> 
+        <radius val="0.13" />
+        <height val="0.2" />
+    </cylinder>
+  </type>  
+  
+  <component type="disc-chopper">
+    <location y="-0.18" z="-3.0" />
+    <parameter name="Speed (Hz)">
+      <logfile id="diskchopper" extract-single-value-as="last_value" />
+    </parameter>
+  </component>
+  <type name="disc-chopper" is="chopper">
+    <cylinder id="body">
+        <centre-of-bottom-base x="0.0" y="0.0" z="0.0" />
+        <axis x="0.0" y="0.0" z="1.0" /> 
+        <radius val="0.26" />
+        <height val="0.1" />
+    </cylinder>
+    <cuboid id="hole">
+       <left-front-bottom-point x="0.03" y="0.15" z="-0.1"  />
+       <left-front-top-point  x="0.03" y="0.15" z="0.1"  />
+       <left-back-bottom-point  x="-0.03" y="0.15" z="-0.1"  />
+       <right-front-bottom-point  x="0.03" y="0.21" z="-0.1"  />
+    </cuboid>
+     <algebra val="body (# hole)" />
+  </type>  
+  
+  <component type="nimonic-chopper">
+    <location x="0.0" y="-0.2" z="-4.0" rot="90" axis-x="0" axis-y="1" axis-z="0"  >
+        <rot val="30.0" axis-x="1.0" axis-y="0.0" axis-z="0.0" />
+    </location>
+  </component>
+  <type name="nimonic-chopper" is="chopper">
+    <cylinder id="cylinder">
+        <centre-of-bottom-base x="0.0" y="0.0" z="0.0" />
+        <axis x="1.0" y="0.0" z="0.0" /> 
+        <radius val="0.13" />
+        <height val="0.2" />
+    </cylinder>
+    <cuboid id="cuboid">
+       <left-front-bottom-point x="0.2" y="-0.03" z="-0.2"  />
+       <left-front-top-point  x="0.2" y="-0.03" z="0.2"  />
+       <left-back-bottom-point  x="0.0" y="-0.03" z="-0.2"  />
+       <right-front-bottom-point  x="0.2" y="0.03" z="-0.2"  />
+    </cuboid>
+    <algebra val="cylinder : cuboid" />
+  </type>  
+  
+  <component type="moderator">
+    <location x="0.0" y="0.0" z="-11.739" rot="-70.0" axis-x="1.0" axis-y="0.0" axis-z="0.0" />
+  </component>
+  <type name="moderator" is="chopper">
+    <cuboid id="cuboid">
+       <left-front-bottom-point x="0.06" y="-0.06" z="-0.03"  />
+       <left-front-top-point  x="0.06" y="-0.06" z="0.03"  />
+       <left-back-bottom-point  x="-0.06" y="-0.06" z="-0.03"  />
+       <right-front-bottom-point  x="0.06" y="0.06" z="-0.03"  />
+    </cuboid>
+  </type>  
+  
+  <!-- MONITORS -->
+
+  <component type="monitor" idlist="monitor">
+    <location z="-4.739" />
+    <location z="-1.442" />
+    <location z="5.82" />
+  </component>
+  
+  <type name="monitor" is="monitor">
+     <cuboid id="shape">
+       <left-front-bottom-point x="0.025" y="-0.025" z="0.0"  />
+       <left-front-top-point  x="0.025" y="-0.025" z="0.02"  />
+       <left-back-bottom-point  x="-0.025" y="-0.025" z="0.0"  />
+       <right-front-bottom-point  x="0.025" y="0.025" z="0.0"  />
+     </cuboid>
+  </type>  
+  
+  
+  <!-- DETECTORS -->
+  
+  <component type="low angle bank" idlist="low angle bank">
+    <location />
+  </component>
+  
+  <component type="wide angle bank" idlist="wide angle bank">
+    <location />
+  </component>  
+  
+  <type name="low angle bank"> 
+    <component type="W11 north"> <location /> </component> 
+    <component type="W12 north east"> <location /> </component>     
+    <component type="W13 east"> <location /> </component>   
+    <component type="W14 south east"> <location /> </component>     
+    <component type="W15 south"> <location /> </component>   
+    <component type="W16 south west"> <location /> </component>      
+    <component type="W17 west"> <location /> </component>   
+    <component type="W18 north west"> <location /> </component>          
+  </type>   
+  
+  <type name="wide angle bank"> 
+    <component type="W1-1"> <location /> </component>
+    <component type="W2-1"> <location /> </component>
+    <component type="W3-1"> <location /> </component>
+    <component type="W4-1"> <location /> </component>
+    <component type="W5-1"> <location /> </component>
+    <component type="W6-1"> <location /> </component>
+    <component type="W7-1"> <location /> </component>
+    <component type="W8-1"> <location /> </component>  
+
+    <component type="W1-2"> <location /> </component>
+    <component type="W2-2"> <location /> </component>
+    <component type="W3-2"> <location /> </component>
+    <component type="W4-2"> <location /> </component>
+    <component type="W5-2"> <location /> </component>
+    <component type="W6-2"> <location /> </component>
+    <component type="W7-2"> <location /> </component>
+    <component type="W8-2"> <location /> </component>    
+    
+    <component type="W1-3"> <location /> </component>
+    <component type="W2-3"> <location /> </component>
+    <component type="W3-3"> <location /> </component>
+    <component type="W4-3"> <location /> </component>
+    <component type="W5-3"> <location /> </component>
+    <component type="W6-3"> <location /> </component>
+    <component type="W7-3"> <location /> </component>
+    <component type="W8-3"> <location /> </component>    
+  </type> 
+
+
+  <type name="W1-1">  
+    <component type="tall He3 element">  
+      <location r="4.022" t="13.71" p="-68.64" rot="-90" />
+      <location r="4.022" t="14.14" p="-69.3" rot="-90" />
+      <location r="4.022" t="14.57" p="-69.92" rot="-90" />
+      <location r="4.022" t="15" p="-70.51" rot="-90" />
+      <location r="4.022" t="15.43" p="-71.06" rot="-90" />
+      <location r="4.022" t="15.86" p="-71.57" rot="-90" />
+      <location r="4.022" t="16.29" p="-72.06" rot="-90" />
+      <location r="4.022" t="16.71" p="-72.52" rot="-90" />
+      <location r="4.022" t="17.14" p="-72.96" rot="-90" />
+      <location r="4.022" t="17.57" p="-73.38" rot="-90" />
+      <location r="4.022" t="18" p="-73.77" rot="-90" />
+      <location r="4.022" t="18.43" p="-74.14" rot="-90" />
+      <location r="4.022" t="18.86" p="-74.5" rot="-90" />
+      <location r="4.022" t="19.29" p="-74.84" rot="-90" />
+      <location r="4.022" t="19.71" p="-75.17" rot="-90" />
+      <location r="4.022" t="20.14" p="-75.47" rot="-90" />
+      <location r="4.022" t="20.57" p="-75.77" rot="-90" />
+      <location r="4.022" t="21" p="-76.05" rot="-90" />
+      <location r="4.022" t="21.43" p="-76.33" rot="-90" />
+      <location r="4.022" t="21.86" p="-76.59" rot="-90" />
+      <location r="4.022" t="22.29" p="-76.84" rot="-90" />
+      <location r="4.022" t="22.71" p="-77.08" rot="-90" />
+      <location r="4.022" t="23.14" p="-77.31" rot="-90" />
+      <location r="4.022" t="23.57" p="-77.53" rot="-90" />
+      <location r="4.022" t="24" p="-77.74" rot="-90" />
+      <location r="4.022" t="24.43" p="-77.95" rot="-90" />
+      <location r="4.022" t="24.86" p="-78.14" rot="-90" />
+      <location r="4.022" t="25.29" p="-78.33" rot="-90" />
+      <location r="4.022" t="25.71" p="-78.52" rot="-90" />
+      <location r="4.022" t="26.14" p="-78.7" rot="-90" />
+      <location r="4.022" t="26.57" p="-78.87" rot="-90" />
+      <location r="4.022" t="27" p="-79.03" rot="-90" />
+      <location r="4.022" t="27.43" p="-79.19" rot="-90" />
+      <location r="4.022" t="27.86" p="-79.35" rot="-90" />
+      <location r="4.022" t="28.29" p="-79.5" rot="-90" />
+      <location r="4.022" t="28.71" p="-79.64" rot="-90" />
+      <location r="4.022" t="29.14" p="-79.78" rot="-90" />
+    </component>
+  </type>
+
+  <type name="W2-1">  
+    <component type="tall He3 element">
+      <location r="4.022" t="31.71" p="-80.54" rot="-90" />
+      <location r="4.022" t="32.14" p="-80.66" rot="-90" />
+      <location r="4.022" t="32.57" p="-80.77" rot="-90" />
+      <location r="4.022" t="33" p="-80.88" rot="-90" />
+      <location r="4.022" t="33.43" p="-80.98" rot="-90" />
+      <location r="4.022" t="33.86" p="-81.08" rot="-90" />
+      <location r="4.022" t="34.29" p="-81.18" rot="-90" />
+      <location r="4.022" t="34.71" p="-81.28" rot="-90" />
+      <location r="4.022" t="35.14" p="-81.37" rot="-90" />
+      <location r="4.022" t="35.57" p="-81.46" rot="-90" />
+      <location r="4.022" t="36" p="-81.55" rot="-90" />
+      <location r="4.022" t="36.43" p="-81.64" rot="-90" />
+      <location r="4.022" t="36.86" p="-81.72" rot="-90" />
+      <location r="4.022" t="37.29" p="-81.8" rot="-90" />
+      <location r="4.022" t="37.71" p="-81.88" rot="-90" />
+      <location r="4.022" t="38.14" p="-81.96" rot="-90" />
+      <location r="4.022" t="38.57" p="-82.04" rot="-90" />
+      <location r="4.022" t="39" p="-82.11" rot="-90" />
+      <location r="4.022" t="39.43" p="-82.18" rot="-90" />
+      <location r="4.022" t="39.86" p="-82.26" rot="-90" />
+      <location r="4.022" t="40.29" p="-82.32" rot="-90" />
+      <location r="4.022" t="40.71" p="-82.39" rot="-90" />
+      <location r="4.022" t="41.14" p="-82.46" rot="-90" />
+      <location r="4.022" t="41.57" p="-82.52" rot="-90" />
+      <location r="4.022" t="42" p="-82.58" rot="-90" />
+      <location r="4.022" t="42.43" p="-82.65" rot="-90" />
+      <location r="4.022" t="42.86" p="-82.71" rot="-90" />
+      <location r="4.022" t="43.29" p="-82.76" rot="-90" />
+      <location r="4.022" t="43.71" p="-82.82" rot="-90" />
+      <location r="4.022" t="44.14" p="-82.88" rot="-90" />
+    </component>
+  </type>
+
+  <type name="W3-1">  
+    <component type="tall He3 element">
+      <location r="4.022" t="45.86" p="-83.09" rot="-90" />
+      <location r="4.022" t="46.29" p="-83.14" rot="-90" />
+      <location r="4.022" t="46.71" p="-83.19" rot="-90" />
+      <location r="4.022" t="47.14" p="-83.23" rot="-90" />
+      <location r="4.022" t="47.57" p="-83.28" rot="-90" />
+      <location r="4.022" t="48" p="-83.33" rot="-90" />
+      <location r="4.022" t="48.43" p="-83.37" rot="-90" />
+      <location r="4.022" t="48.86" p="-83.41" rot="-90" />
+      <location r="4.022" t="49.29" p="-83.46" rot="-90" />
+      <location r="4.022" t="49.71" p="-83.5" rot="-90" />
+      <location r="4.022" t="50.14" p="-83.54" rot="-90" />
+      <location r="4.022" t="50.57" p="-83.58" rot="-90" />
+      <location r="4.022" t="51" p="-83.62" rot="-90" />
+      <location r="4.022" t="51.43" p="-83.66" rot="-90" />
+      <location r="4.022" t="51.86" p="-83.7" rot="-90" />
+      <location r="4.022" t="52.29" p="-83.73" rot="-90" />
+      <location r="4.022" t="52.71" p="-83.77" rot="-90" />
+      <location r="4.022" t="53.14" p="-83.8" rot="-90" />
+      <location r="4.022" t="53.57" p="-83.84" rot="-90" />
+      <location r="4.022" t="54" p="-83.87" rot="-90" />
+      <location r="4.022" t="54.43" p="-83.9" rot="-90" />
+      <location r="4.022" t="54.86" p="-83.94" rot="-90" />
+      <location r="4.022" t="55.29" p="-83.97" rot="-90" />
+      <location r="4.022" t="55.71" p="-84" rot="-90" />
+      <location r="4.022" t="56.14" p="-84.03" rot="-90" />
+      <location r="4.022" t="56.57" p="-84.06" rot="-90" />
+      <location r="4.022" t="57" p="-84.09" rot="-90" />
+      <location r="4.022" t="57.43" p="-84.12" rot="-90" />
+      <location r="4.022" t="57.86" p="-84.15" rot="-90" />
+      <location r="4.022" t="58.29" p="-84.17" rot="-90" />
+      <location r="4.022" t="58.71" p="-84.2" rot="-90" />
+      <location r="4.022" t="59.14" p="-84.23" rot="-90" />
+    </component>
+  </type>
+
+  <type name="W4-1">  
+    <component type="tall He3 element">
+      <location r="4.022" t="60.86" p="-84.33" rot="-90" />
+      <location r="4.022" t="61.29" p="-84.35" rot="-90" />
+      <location r="4.022" t="61.71" p="-84.37" rot="-90" />
+      <location r="4.022" t="62.14" p="-84.39" rot="-90" />
+      <location r="4.022" t="62.57" p="-84.42" rot="-90" />
+      <location r="4.022" t="63" p="-84.44" rot="-90" />
+      <location r="4.022" t="63.43" p="-84.46" rot="-90" />
+      <location r="4.022" t="63.86" p="-84.48" rot="-90" />
+      <location r="4.022" t="64.29" p="-84.5" rot="-90" />
+      <location r="4.022" t="64.71" p="-84.52" rot="-90" />
+      <location r="4.022" t="65.14" p="-84.54" rot="-90" />
+      <location r="4.022" t="65.57" p="-84.56" rot="-90" />
+      <location r="4.022" t="66" p="-84.58" rot="-90" />
+      <location r="4.022" t="66.43" p="-84.59" rot="-90" />
+      <location r="4.022" t="66.86" p="-84.61" rot="-90" />
+      <location r="4.022" t="67.29" p="-84.63" rot="-90" />
+      <location r="4.022" t="67.71" p="-84.64" rot="-90" />
+      <location r="4.022" t="68.14" p="-84.66" rot="-90" />
+      <location r="4.022" t="68.57" p="-84.68" rot="-90" />
+      <location r="4.022" t="69" p="-84.69" rot="-90" />
+      <location r="4.022" t="69.43" p="-84.71" rot="-90" />
+      <location r="4.022" t="69.86" p="-84.72" rot="-90" />
+      <location r="4.022" t="70.29" p="-84.74" rot="-90" />
+      <location r="4.022" t="70.71" p="-84.75" rot="-90" />
+      <location r="4.022" t="71.14" p="-84.76" rot="-90" />
+      <location r="4.022" t="71.57" p="-84.78" rot="-90" />
+      <location r="4.022" t="72" p="-84.79" rot="-90" />
+      <location r="4.022" t="72.43" p="-84.8" rot="-90" />
+      <location r="4.022" t="72.86" p="-84.81" rot="-90" />
+      <location r="4.022" t="73.29" p="-84.83" rot="-90" />
+      <location r="4.022" t="73.71" p="-84.84" rot="-90" />
+      <location r="4.022" t="74.14" p="-84.85" rot="-90" />
+    </component>
+  </type>
+
+  <type name="W5-1">  
+    <component type="tall He3 element">
+      <location r="4.022" t="75.86" p="-84.89" rot="-90" />
+      <location r="4.022" t="76.29" p="-84.9" rot="-90" />
+      <location r="4.022" t="76.71" p="-84.91" rot="-90" />
+      <location r="4.022" t="77.14" p="-84.92" rot="-90" />
+      <location r="4.022" t="77.57" p="-84.93" rot="-90" />
+      <location r="4.022" t="78" p="-84.93" rot="-90" />
+      <location r="4.022" t="78.43" p="-84.94" rot="-90" />
+      <location r="4.022" t="78.86" p="-84.95" rot="-90" />
+      <location r="4.022" t="79.29" p="-84.96" rot="-90" />
+      <location r="4.022" t="79.71" p="-84.96" rot="-90" />
+      <location r="4.022" t="80.14" p="-84.97" rot="-90" />
+      <location r="4.022" t="80.57" p="-84.98" rot="-90" />
+      <location r="4.022" t="81" p="-84.98" rot="-90" />
+      <location r="4.022" t="81.43" p="-84.99" rot="-90" />
+      <location r="4.022" t="81.86" p="-84.99" rot="-90" />
+      <location r="4.022" t="82.29" p="-85" rot="-90" />
+      <location r="4.022" t="82.71" p="-85" rot="-90" />
+      <location r="4.022" t="83.14" p="-85.01" rot="-90" />
+      <location r="4.022" t="83.57" p="-85.01" rot="-90" />
+      <location r="4.022" t="84" p="-85.02" rot="-90" />
+      <location r="4.022" t="84.43" p="-85.02" rot="-90" />
+      <location r="4.022" t="84.86" p="-85.03" rot="-90" />
+      <location r="4.022" t="85.29" p="-85.03" rot="-90" />
+      <location r="4.022" t="85.71" p="-85.03" rot="-90" />
+      <location r="4.022" t="86.14" p="-85.03" rot="-90" />
+      <location r="4.022" t="86.57" p="-85.04" rot="-90" />
+      <location r="4.022" t="87" p="-85.04" rot="-90" />
+      <location r="4.022" t="87.43" p="-85.04" rot="-90" />
+      <location r="4.022" t="87.86" p="-85.04" rot="-90" />
+      <location r="4.022" t="88.29" p="-85.04" rot="-90" />
+      <location r="4.022" t="88.71" p="-85.04" rot="-90" />
+      <location r="4.022" t="89.14" p="-85.04" rot="-90" />
+    </component>
+  </type>
+
+  <type name="W6-1">  
+    <component type="tall He3 element">
+      <location r="4.022" t="90.86" p="-85.04" rot="-90" />
+      <location r="4.022" t="91.29" p="-85.04" rot="-90" />
+      <location r="4.022" t="91.71" p="-85.04" rot="-90" />
+      <location r="4.022" t="92.14" p="-85.04" rot="-90" />
+      <location r="4.022" t="92.57" p="-85.04" rot="-90" />
+      <location r="4.022" t="93" p="-85.04" rot="-90" />
+      <location r="4.022" t="93.43" p="-85.04" rot="-90" />
+      <location r="4.022" t="93.86" p="-85.03" rot="-90" />
+      <location r="4.022" t="94.29" p="-85.03" rot="-90" />
+      <location r="4.022" t="94.71" p="-85.03" rot="-90" />
+      <location r="4.022" t="95.14" p="-85.03" rot="-90" />
+      <location r="4.022" t="95.57" p="-85.02" rot="-90" />
+      <location r="4.022" t="96" p="-85.02" rot="-90" />
+      <location r="4.022" t="96.43" p="-85.01" rot="-90" />
+      <location r="4.022" t="96.86" p="-85.01" rot="-90" />
+      <location r="4.022" t="97.29" p="-85" rot="-90" />
+      <location r="4.022" t="97.71" p="-85" rot="-90" />
+      <location r="4.022" t="98.14" p="-84.99" rot="-90" />
+      <location r="4.022" t="98.57" p="-84.99" rot="-90" />
+      <location r="4.022" t="99" p="-84.98" rot="-90" />
+      <location r="4.022" t="99.43" p="-84.98" rot="-90" />
+      <location r="4.022" t="99.86" p="-84.97" rot="-90" />
+      <location r="4.022" t="100.29" p="-84.96" rot="-90" />
+      <location r="4.022" t="100.71" p="-84.96" rot="-90" />
+      <location r="4.022" t="101.14" p="-84.95" rot="-90" />
+      <location r="4.022" t="101.57" p="-84.94" rot="-90" />
+      <location r="4.022" t="102" p="-84.93" rot="-90" />
+      <location r="4.022" t="102.43" p="-84.93" rot="-90" />
+      <location r="4.022" t="102.86" p="-84.92" rot="-90" />
+      <location r="4.022" t="103.29" p="-84.91" rot="-90" />
+      <location r="4.022" t="103.71" p="-84.9" rot="-90" />
+      <location r="4.022" t="104.14" p="-84.89" rot="-90" />
+    </component>
+  </type>
+
+  <type name="W7-1">  
+    <component type="tall He3 element">  
+      <location r="4.022" t="105.86" p="-84.85" rot="-90" />
+      <location r="4.022" t="106.29" p="-84.84" rot="-90" />
+      <location r="4.022" t="106.71" p="-84.83" rot="-90" />
+      <location r="4.022" t="107.14" p="-84.81" rot="-90" />
+      <location r="4.022" t="107.57" p="-84.8" rot="-90" />
+      <location r="4.022" t="108" p="-84.79" rot="-90" />
+      <location r="4.022" t="108.43" p="-84.78" rot="-90" />
+      <location r="4.022" t="108.86" p="-84.76" rot="-90" />
+      <location r="4.022" t="109.29" p="-84.75" rot="-90" />
+      <location r="4.022" t="109.71" p="-84.74" rot="-90" />
+      <location r="4.022" t="110.14" p="-84.72" rot="-90" />
+      <location r="4.022" t="110.57" p="-84.71" rot="-90" />
+      <location r="4.022" t="111" p="-84.69" rot="-90" />
+      <location r="4.022" t="111.43" p="-84.68" rot="-90" />
+      <location r="4.022" t="111.86" p="-84.66" rot="-90" />
+      <location r="4.022" t="112.29" p="-84.64" rot="-90" />
+      <location r="4.022" t="112.71" p="-84.63" rot="-90" />
+      <location r="4.022" t="113.14" p="-84.61" rot="-90" />
+      <location r="4.022" t="113.57" p="-84.59" rot="-90" />
+      <location r="4.022" t="114" p="-84.58" rot="-90" />
+      <location r="4.022" t="114.43" p="-84.56" rot="-90" />
+      <location r="4.022" t="114.86" p="-84.54" rot="-90" />
+      <location r="4.022" t="115.29" p="-84.52" rot="-90" />
+      <location r="4.022" t="115.71" p="-84.5" rot="-90" />
+      <location r="4.022" t="116.14" p="-84.48" rot="-90" />
+      <location r="4.022" t="116.57" p="-84.46" rot="-90" />
+      <location r="4.022" t="117" p="-84.44" rot="-90" />
+      <location r="4.022" t="117.43" p="-84.42" rot="-90" />
+      <location r="4.022" t="117.86" p="-84.39" rot="-90" />
+      <location r="4.022" t="118.29" p="-84.37" rot="-90" />
+      <location r="4.022" t="118.71" p="-84.35" rot="-90" />
+      <location r="4.022" t="119.14" p="-84.33" rot="-90" />
+    </component>
+  </type>
+
+  <type name="W8-1">  
+    <component type="tall He3 element">  
+      <location r="4.022" t="120.86" p="-84.23" rot="-90" />
+      <location r="4.022" t="121.29" p="-84.2" rot="-90" />
+      <location r="4.022" t="121.71" p="-84.17" rot="-90" />
+      <location r="4.022" t="122.14" p="-84.15" rot="-90" />
+      <location r="4.022" t="122.57" p="-84.12" rot="-90" />
+      <location r="4.022" t="123" p="-84.09" rot="-90" />
+      <location r="4.022" t="123.43" p="-84.06" rot="-90" />
+      <location r="4.022" t="123.86" p="-84.03" rot="-90" />
+      <location r="4.022" t="124.29" p="-84" rot="-90" />
+      <location r="4.022" t="124.71" p="-83.97" rot="-90" />
+      <location r="4.022" t="125.14" p="-83.94" rot="-90" />
+      <location r="4.022" t="125.57" p="-83.9" rot="-90" />
+      <location r="4.022" t="126" p="-83.87" rot="-90" />
+      <location r="4.022" t="126.43" p="-83.84" rot="-90" />
+      <location r="4.022" t="126.86" p="-83.8" rot="-90" />
+      <location r="4.022" t="127.29" p="-83.77" rot="-90" />
+      <location r="4.022" t="127.71" p="-83.73" rot="-90" />
+      <location r="4.022" t="128.14" p="-83.7" rot="-90" />
+      <location r="4.022" t="128.57" p="-83.66" rot="-90" />
+      <location r="4.022" t="129" p="-83.62" rot="-90" />
+      <location r="4.022" t="129.43" p="-83.58" rot="-90" />
+      <location r="4.022" t="129.86" p="-83.54" rot="-90" />
+      <location r="4.022" t="130.29" p="-83.5" rot="-90" />
+      <location r="4.022" t="130.71" p="-83.46" rot="-90" />
+      <location r="4.022" t="131.14" p="-83.41" rot="-90" />
+      <location r="4.022" t="131.57" p="-83.37" rot="-90" />
+      <location r="4.022" t="132" p="-83.33" rot="-90" />
+      <location r="4.022" t="132.43" p="-83.28" rot="-90" />
+      <location r="4.022" t="132.86" p="-83.23" rot="-90" />
+      <location r="4.022" t="133.29" p="-83.19" rot="-90" />
+      <location r="4.022" t="133.71" p="-83.14" rot="-90" />
+      <location r="4.022" t="134.14" p="-83.09" rot="-90" />
+    </component>
+  </type>   
+  
+  <type name="W1-2">  
+    <component type="tall He3 element">  
+      <location r="4.022" t="12.43" p="-90" rot="-90" />
+      <location r="4.022" t="12.86" p="-90" rot="-90" />
+      <location r="4.022" t="13.29" p="-90" rot="-90" />
+      <location r="4.022" t="13.71" p="-90" rot="-90" />
+      <location r="4.022" t="14.14" p="-90" rot="-90" />
+      <location r="4.022" t="14.57" p="-90" rot="-90" />
+      <location r="4.022" t="15" p="-90" rot="-90" />
+      <location r="4.022" t="15.43" p="-90" rot="-90" />
+      <location r="4.022" t="15.86" p="-90" rot="-90" />
+      <location r="4.022" t="16.29" p="-90" rot="-90" />
+      <location r="4.022" t="16.71" p="-90" rot="-90" />
+      <location r="4.022" t="17.14" p="-90" rot="-90" />
+      <location r="4.022" t="17.57" p="-90" rot="-90" />
+      <location r="4.022" t="18" p="-90" rot="-90" />
+      <location r="4.022" t="18.43" p="-90" rot="-90" />
+      <location r="4.022" t="18.86" p="-90" rot="-90" />
+      <location r="4.022" t="19.29" p="-90" rot="-90" />
+      <location r="4.022" t="19.71" p="-90" rot="-90" />
+      <location r="4.022" t="20.14" p="-90" rot="-90" />
+      <location r="4.022" t="20.57" p="-90" rot="-90" />
+      <location r="4.022" t="21" p="-90" rot="-90" />
+      <location r="4.022" t="21.43" p="-90" rot="-90" />
+      <location r="4.022" t="21.86" p="-90" rot="-90" />
+      <location r="4.022" t="22.29" p="-90" rot="-90" />
+      <location r="4.022" t="22.71" p="-90" rot="-90" />
+      <location r="4.022" t="23.14" p="-90" rot="-90" />
+      <location r="4.022" t="23.57" p="-90" rot="-90" />
+      <location r="4.022" t="24" p="-90" rot="-90" />
+      <location r="4.022" t="24.43" p="-90" rot="-90" />
+      <location r="4.022" t="24.86" p="-90" rot="-90" />
+      <location r="4.022" t="25.29" p="-90" rot="-90" />
+      <location r="4.022" t="25.71" p="-90" rot="-90" />
+      <location r="4.022" t="26.14" p="-90" rot="-90" />
+      <location r="4.022" t="26.57" p="-90" rot="-90" />
+      <location r="4.022" t="27" p="-90" rot="-90" />
+      <location r="4.022" t="27.43" p="-90" rot="-90" />
+      <location r="4.022" t="27.86" p="-90" rot="-90" />
+      <location r="4.022" t="28.29" p="-90" rot="-90" />
+      <location r="4.022" t="28.71" p="-90" rot="-90" />
+      <location r="4.022" t="29.14" p="-90" rot="-90" />
+    </component>
+  </type>
+
+  <type name="W2-2">  
+    <component type="tall He3 element">
+      <location r="4.022" t="30.86" p="-90" rot="-90" />
+      <location r="4.022" t="31.29" p="-90" rot="-90" />
+      <location r="4.022" t="31.71" p="-90" rot="-90" />
+      <location r="4.022" t="32.14" p="-90" rot="-90" />
+      <location r="4.022" t="32.57" p="-90" rot="-90" />
+      <location r="4.022" t="33" p="-90" rot="-90" />
+      <location r="4.022" t="33.43" p="-90" rot="-90" />
+      <location r="4.022" t="33.86" p="-90" rot="-90" />
+      <location r="4.022" t="34.29" p="-90" rot="-90" />
+      <location r="4.022" t="34.71" p="-90" rot="-90" />
+      <location r="4.022" t="35.14" p="-90" rot="-90" />
+      <location r="4.022" t="35.57" p="-90" rot="-90" />
+      <location r="4.022" t="36" p="-90" rot="-90" />
+      <location r="4.022" t="36.43" p="-90" rot="-90" />
+      <location r="4.022" t="36.86" p="-90" rot="-90" />
+      <location r="4.022" t="37.29" p="-90" rot="-90" />
+      <location r="4.022" t="37.71" p="-90" rot="-90" />
+      <location r="4.022" t="38.14" p="-90" rot="-90" />
+      <location r="4.022" t="38.57" p="-90" rot="-90" />
+      <location r="4.022" t="39" p="-90" rot="-90" />
+      <location r="4.022" t="39.43" p="-90" rot="-90" />
+      <location r="4.022" t="39.86" p="-90" rot="-90" />
+      <location r="4.022" t="40.29" p="-90" rot="-90" />
+      <location r="4.022" t="40.71" p="-90" rot="-90" />
+      <location r="4.022" t="41.14" p="-90" rot="-90" />
+      <location r="4.022" t="41.57" p="-90" rot="-90" />
+      <location r="4.022" t="42" p="-90" rot="-90" />
+      <location r="4.022" t="42.43" p="-90" rot="-90" />
+      <location r="4.022" t="42.86" p="-90" rot="-90" />
+      <location r="4.022" t="43.29" p="-90" rot="-90" />
+      <location r="4.022" t="43.71" p="-90" rot="-90" />
+      <location r="4.022" t="44.14" p="-90" rot="-90" />
+    </component>
+  </type>
+
+  <type name="W3-2">  
+    <component type="tall He3 element">
+      <location r="4.022" t="45.86" p="-90" rot="-90" />
+      <location r="4.022" t="46.29" p="-90" rot="-90" />
+      <location r="4.022" t="46.71" p="-90" rot="-90" />
+      <location r="4.022" t="47.14" p="-90" rot="-90" />
+      <location r="4.022" t="47.57" p="-90" rot="-90" />
+      <location r="4.022" t="48" p="-90" rot="-90" />
+      <location r="4.022" t="48.43" p="-90" rot="-90" />
+      <location r="4.022" t="48.86" p="-90" rot="-90" />
+      <location r="4.022" t="49.29" p="-90" rot="-90" />
+      <location r="4.022" t="49.71" p="-90" rot="-90" />
+      <location r="4.022" t="50.14" p="-90" rot="-90" />
+      <location r="4.022" t="50.57" p="-90" rot="-90" />
+      <location r="4.022" t="51" p="-90" rot="-90" />
+      <location r="4.022" t="51.43" p="-90" rot="-90" />
+      <location r="4.022" t="51.86" p="-90" rot="-90" />
+      <location r="4.022" t="52.29" p="-90" rot="-90" />
+      <location r="4.022" t="52.71" p="-90" rot="-90" />
+      <location r="4.022" t="53.14" p="-90" rot="-90" />
+      <location r="4.022" t="53.57" p="-90" rot="-90" />
+      <location r="4.022" t="54" p="-90" rot="-90" />
+      <location r="4.022" t="54.43" p="-90" rot="-90" />
+      <location r="4.022" t="54.86" p="-90" rot="-90" />
+      <location r="4.022" t="55.29" p="-90" rot="-90" />
+      <location r="4.022" t="55.71" p="-90" rot="-90" />
+      <location r="4.022" t="56.14" p="-90" rot="-90" />
+      <location r="4.022" t="56.57" p="-90" rot="-90" />
+      <location r="4.022" t="57" p="-90" rot="-90" />
+      <location r="4.022" t="57.43" p="-90" rot="-90" />
+      <location r="4.022" t="57.86" p="-90" rot="-90" />
+      <location r="4.022" t="58.29" p="-90" rot="-90" />
+      <location r="4.022" t="58.71" p="-90" rot="-90" />
+      <location r="4.022" t="59.14" p="-90" rot="-90" />
+    </component>
+  </type>
+
+  <type name="W4-2">  
+    <component type="tall He3 element"> 
+      <location r="4.022" t="60.86" p="-90" rot="-90" />
+      <location r="4.022" t="61.29" p="-90" rot="-90" />
+      <location r="4.022" t="61.71" p="-90" rot="-90" />
+      <location r="4.022" t="62.14" p="-90" rot="-90" />
+      <location r="4.022" t="62.57" p="-90" rot="-90" />
+      <location r="4.022" t="63" p="-90" rot="-90" />
+      <location r="4.022" t="63.43" p="-90" rot="-90" />
+      <location r="4.022" t="63.86" p="-90" rot="-90" />
+      <location r="4.022" t="64.29" p="-90" rot="-90" />
+      <location r="4.022" t="64.71" p="-90" rot="-90" />
+      <location r="4.022" t="65.14" p="-90" rot="-90" />
+      <location r="4.022" t="65.57" p="-90" rot="-90" />
+      <location r="4.022" t="66" p="-90" rot="-90" />
+      <location r="4.022" t="66.43" p="-90" rot="-90" />
+      <location r="4.022" t="66.86" p="-90" rot="-90" />
+      <location r="4.022" t="67.29" p="-90" rot="-90" />
+      <location r="4.022" t="67.71" p="-90" rot="-90" />
+      <location r="4.022" t="68.14" p="-90" rot="-90" />
+      <location r="4.022" t="68.57" p="-90" rot="-90" />
+      <location r="4.022" t="69" p="-90" rot="-90" />
+      <location r="4.022" t="69.43" p="-90" rot="-90" />
+      <location r="4.022" t="69.86" p="-90" rot="-90" />
+      <location r="4.022" t="70.29" p="-90" rot="-90" />
+      <location r="4.022" t="70.71" p="-90" rot="-90" />
+      <location r="4.022" t="71.14" p="-90" rot="-90" />
+      <location r="4.022" t="71.57" p="-90" rot="-90" />
+      <location r="4.022" t="72" p="-90" rot="-90" />
+      <location r="4.022" t="72.43" p="-90" rot="-90" />
+      <location r="4.022" t="72.86" p="-90" rot="-90" />
+      <location r="4.022" t="73.29" p="-90" rot="-90" />
+      <location r="4.022" t="73.71" p="-90" rot="-90" />
+      <location r="4.022" t="74.14" p="-90" rot="-90" />
+    </component>
+  </type>
+
+  <type name="W5-2">  
+    <component type="tall He3 element"> 
+      <location r="4.022" t="75.86" p="-90" rot="-90" />
+      <location r="4.022" t="76.29" p="-90" rot="-90" />
+      <location r="4.022" t="76.71" p="-90" rot="-90" />
+      <location r="4.022" t="77.14" p="-90" rot="-90" />
+      <location r="4.022" t="77.57" p="-90" rot="-90" />
+      <location r="4.022" t="78" p="-90" rot="-90" />
+      <location r="4.022" t="78.43" p="-90" rot="-90" />
+      <location r="4.022" t="78.86" p="-90" rot="-90" />
+      <location r="4.022" t="79.29" p="-90" rot="-90" />
+      <location r="4.022" t="79.71" p="-90" rot="-90" />
+      <location r="4.022" t="80.14" p="-90" rot="-90" />
+      <location r="4.022" t="80.57" p="-90" rot="-90" />
+      <location r="4.022" t="81" p="-90" rot="-90" />
+      <location r="4.022" t="81.43" p="-90" rot="-90" />
+      <location r="4.022" t="81.86" p="-90" rot="-90" />
+      <location r="4.022" t="82.29" p="-90" rot="-90" />
+      <location r="4.022" t="82.71" p="-90" rot="-90" />
+      <location r="4.022" t="83.14" p="-90" rot="-90" />
+      <location r="4.022" t="83.57" p="-90" rot="-90" />
+      <location r="4.022" t="84" p="-90" rot="-90" />
+      <location r="4.022" t="84.43" p="-90" rot="-90" />
+      <location r="4.022" t="84.86" p="-90" rot="-90" />
+      <location r="4.022" t="85.29" p="-90" rot="-90" />
+      <location r="4.022" t="85.71" p="-90" rot="-90" />
+      <location r="4.022" t="86.14" p="-90" rot="-90" />
+      <location r="4.022" t="86.57" p="-90" rot="-90" />
+      <location r="4.022" t="87" p="-90" rot="-90" />
+      <location r="4.022" t="87.43" p="-90" rot="-90" />
+      <location r="4.022" t="87.86" p="-90" rot="-90" />
+      <location r="4.022" t="88.29" p="-90" rot="-90" />
+      <location r="4.022" t="88.71" p="-90" rot="-90" />
+      <location r="4.022" t="89.14" p="-90" rot="-90" />
+    </component>
+  </type>
+
+  <type name="W6-2">  
+    <component type="tall He3 element"> 
+      <location r="4.022" t="90.86" p="-90" rot="-90" />
+      <location r="4.022" t="91.29" p="-90" rot="-90" />
+      <location r="4.022" t="91.71" p="-90" rot="-90" />
+      <location r="4.022" t="92.14" p="-90" rot="-90" />
+      <location r="4.022" t="92.57" p="-90" rot="-90" />
+      <location r="4.022" t="93" p="-90" rot="-90" />
+      <location r="4.022" t="93.43" p="-90" rot="-90" />
+      <location r="4.022" t="93.86" p="-90" rot="-90" />
+      <location r="4.022" t="94.29" p="-90" rot="-90" />
+      <location r="4.022" t="94.71" p="-90" rot="-90" />
+      <location r="4.022" t="95.14" p="-90" rot="-90" />
+      <location r="4.022" t="95.57" p="-90" rot="-90" />
+      <location r="4.022" t="96" p="-90" rot="-90" />
+      <location r="4.022" t="96.43" p="-90" rot="-90" />
+      <location r="4.022" t="96.86" p="-90" rot="-90" />
+      <location r="4.022" t="97.29" p="-90" rot="-90" />
+      <location r="4.022" t="97.71" p="-90" rot="-90" />
+      <location r="4.022" t="98.14" p="-90" rot="-90" />
+      <location r="4.022" t="98.57" p="-90" rot="-90" />
+      <location r="4.022" t="99" p="-90" rot="-90" />
+      <location r="4.022" t="99.43" p="-90" rot="-90" />
+      <location r="4.022" t="99.86" p="-90" rot="-90" />
+      <location r="4.022" t="100.29" p="-90" rot="-90" />
+      <location r="4.022" t="100.72" p="-90" rot="-90" />
+      <location r="4.022" t="101.15" p="-90" rot="-90" />
+      <location r="4.022" t="101.58" p="-90" rot="-90" />
+      <location r="4.022" t="102.01" p="-90" rot="-90" />
+      <location r="4.022" t="102.44" p="-90" rot="-90" />
+      <location r="4.022" t="102.87" p="-90" rot="-90" />
+      <location r="4.022" t="103.3" p="-90" rot="-90" />
+      <location r="4.022" t="103.73" p="-90" rot="-90" />
+      <location r="4.022" t="104.16" p="-90" rot="-90" />
+    </component>
+  </type>
+  
+  <type name="W7-2">  
+    <component type="tall He3 element">   
+      <location r="4.022" t="105.86" p="-90" rot="-90" />
+      <location r="4.022" t="106.29" p="-90" rot="-90" />
+      <location r="4.022" t="106.71" p="-90" rot="-90" />
+      <location r="4.022" t="107.14" p="-90" rot="-90" />
+      <location r="4.022" t="107.57" p="-90" rot="-90" />
+      <location r="4.022" t="108" p="-90" rot="-90" />
+      <location r="4.022" t="108.43" p="-90" rot="-90" />
+      <location r="4.022" t="108.86" p="-90" rot="-90" />
+      <location r="4.022" t="109.29" p="-90" rot="-90" />
+      <location r="4.022" t="109.71" p="-90" rot="-90" />
+      <location r="4.022" t="110.14" p="-90" rot="-90" />
+      <location r="4.022" t="110.57" p="-90" rot="-90" />
+      <location r="4.022" t="111" p="-90" rot="-90" />
+      <location r="4.022" t="111.43" p="-90" rot="-90" />
+      <location r="4.022" t="111.86" p="-90" rot="-90" />
+      <location r="4.022" t="112.29" p="-90" rot="-90" />
+      <location r="4.022" t="112.71" p="-90" rot="-90" />
+      <location r="4.022" t="113.14" p="-90" rot="-90" />
+      <location r="4.022" t="113.57" p="-90" rot="-90" />
+      <location r="4.022" t="114" p="-90" rot="-90" />
+      <location r="4.022" t="114.43" p="-90" rot="-90" />
+      <location r="4.022" t="114.86" p="-90" rot="-90" />
+      <location r="4.022" t="115.29" p="-90" rot="-90" />
+      <location r="4.022" t="115.71" p="-90" rot="-90" />
+      <location r="4.022" t="116.14" p="-90" rot="-90" />
+      <location r="4.022" t="116.57" p="-90" rot="-90" />
+      <location r="4.022" t="117" p="-90" rot="-90" />
+      <location r="4.022" t="117.43" p="-90" rot="-90" />
+      <location r="4.022" t="117.86" p="-90" rot="-90" />
+      <location r="4.022" t="118.29" p="-90" rot="-90" />
+      <location r="4.022" t="118.71" p="-90" rot="-90" />
+      <location r="4.022" t="119.14" p="-90" rot="-90" />
+    </component>
+  </type>
+  
+  <type name="W8-2">  
+    <component type="tall He3 element">   
+      <location r="4.022" t="120.86" p="-90" rot="-90" />
+      <location r="4.022" t="121.29" p="-90" rot="-90" />
+      <location r="4.022" t="121.71" p="-90" rot="-90" />
+      <location r="4.022" t="122.14" p="-90" rot="-90" />
+      <location r="4.022" t="122.57" p="-90" rot="-90" />
+      <location r="4.022" t="123" p="-90" rot="-90" />
+      <location r="4.022" t="123.43" p="-90" rot="-90" />
+      <location r="4.022" t="123.86" p="-90" rot="-90" />
+      <location r="4.022" t="124.29" p="-90" rot="-90" />
+      <location r="4.022" t="124.71" p="-90" rot="-90" />
+      <location r="4.022" t="125.14" p="-90" rot="-90" />
+      <location r="4.022" t="125.57" p="-90" rot="-90" />
+      <location r="4.022" t="126" p="-90" rot="-90" />
+      <location r="4.022" t="126.43" p="-90" rot="-90" />
+      <location r="4.022" t="126.86" p="-90" rot="-90" />
+      <location r="4.022" t="127.29" p="-90" rot="-90" />
+      <location r="4.022" t="127.71" p="-90" rot="-90" />
+      <location r="4.022" t="128.14" p="-90" rot="-90" />
+      <location r="4.022" t="128.57" p="-90" rot="-90" />
+      <location r="4.022" t="129" p="-90" rot="-90" />
+      <location r="4.022" t="129.43" p="-90" rot="-90" />
+      <location r="4.022" t="129.86" p="-90" rot="-90" />
+      <location r="4.022" t="130.29" p="-90" rot="-90" />
+      <location r="4.022" t="130.71" p="-90" rot="-90" />
+      <location r="4.022" t="131.14" p="-90" rot="-90" />
+      <location r="4.022" t="131.57" p="-90" rot="-90" />
+      <location r="4.022" t="132" p="-90" rot="-90" />
+      <location r="4.022" t="132.43" p="-90" rot="-90" />
+      <location r="4.022" t="132.86" p="-90" rot="-90" />
+      <location r="4.022" t="133.29" p="-90" rot="-90" />
+      <location r="4.022" t="133.71" p="-90" rot="-90" />
+      <location r="4.022" t="134.14" p="-90" rot="-90" />
+    </component>
+  </type>
+  
+
+
+  <type name="W1-3">  
+    <component type="tall He3 element">   
+      <location r="4.022" t="13.71" p="-113.66" rot="-90" />
+      <location r="4.022" t="14.14" p="-112.84" rot="-90" />
+      <location r="4.022" t="14.57" p="-112.08" rot="-90" />
+      <location r="4.022" t="15" p="-111.36" rot="-90" />
+      <location r="4.022" t="15.43" p="-110.7" rot="-90" />
+      <location r="4.022" t="15.86" p="-110.08" rot="-90" />
+      <location r="4.022" t="16.29" p="-109.49" rot="-90" />
+      <location r="4.022" t="16.71" p="-108.94" rot="-90" />
+      <location r="4.022" t="17.14" p="-108.43" rot="-90" />
+      <location r="4.022" t="17.57" p="-107.94" rot="-90" />
+      <location r="4.022" t="18" p="-107.48" rot="-90" />
+      <location r="4.022" t="18.43" p="-107.04" rot="-90" />
+      <location r="4.022" t="18.86" p="-106.62" rot="-90" />
+      <location r="4.022" t="19.29" p="-106.23" rot="-90" />
+      <location r="4.022" t="19.71" p="-105.86" rot="-90" />
+      <location r="4.022" t="20.14" p="-105.5" rot="-90" />
+      <location r="4.022" t="20.57" p="-105.16" rot="-90" />
+      <location r="4.022" t="21" p="-104.83" rot="-90" />
+      <location r="4.022" t="21.43" p="-104.53" rot="-90" />
+      <location r="4.022" t="21.86" p="-104.23" rot="-90" />
+      <location r="4.022" t="22.29" p="-103.95" rot="-90" />
+      <location r="4.022" t="22.71" p="-103.67" rot="-90" />
+      <location r="4.022" t="23.14" p="-103.41" rot="-90" />
+      <location r="4.022" t="23.57" p="-103.16" rot="-90" />
+      <location r="4.022" t="24" p="-102.92" rot="-90" />
+      <location r="4.022" t="24.43" p="-102.69" rot="-90" />
+      <location r="4.022" t="24.86" p="-102.47" rot="-90" />
+      <location r="4.022" t="25.29" p="-102.26" rot="-90" />
+      <location r="4.022" t="25.71" p="-102.05" rot="-90" />
+      <location r="4.022" t="26.14" p="-101.86" rot="-90" />
+      <location r="4.022" t="26.57" p="-101.67" rot="-90" />
+      <location r="4.022" t="27" p="-101.48" rot="-90" />
+      <location r="4.022" t="27.43" p="-101.3" rot="-90" />
+      <location r="4.022" t="27.86" p="-101.13" rot="-90" />
+      <location r="4.022" t="28.29" p="-100.97" rot="-90" />
+      <location r="4.022" t="28.71" p="-100.81" rot="-90" />
+      <location r="4.022" t="29.14" p="-100.65" rot="-90" />
+    </component>
+  </type>
+
+  <type name="W2-3">  
+    <component type="tall He3 element"> 
+      <location r="4.022" t="31.71" p="-99.69" rot="-90" />
+      <location r="4.022" t="32.14" p="-99.57" rot="-90" />
+      <location r="4.022" t="32.57" p="-99.46" rot="-90" />
+      <location r="4.022" t="33" p="-99.34" rot="-90" />
+      <location r="4.022" t="33.43" p="-99.23" rot="-90" />
+      <location r="4.022" t="33.86" p="-99.12" rot="-90" />
+      <location r="4.022" t="34.29" p="-99.02" rot="-90" />
+      <location r="4.022" t="34.71" p="-98.92" rot="-90" />
+      <location r="4.022" t="35.14" p="-98.82" rot="-90" />
+      <location r="4.022" t="35.57" p="-98.72" rot="-90" />
+      <location r="4.022" t="36" p="-98.63" rot="-90" />
+      <location r="4.022" t="36.43" p="-98.54" rot="-90" />
+      <location r="4.022" t="36.86" p="-98.45" rot="-90" />
+      <location r="4.022" t="37.29" p="-98.36" rot="-90" />
+      <location r="4.022" t="37.71" p="-98.28" rot="-90" />
+      <location r="4.022" t="38.14" p="-98.2" rot="-90" />
+      <location r="4.022" t="38.57" p="-98.12" rot="-90" />
+      <location r="4.022" t="39" p="-98.04" rot="-90" />
+      <location r="4.022" t="39.43" p="-97.96" rot="-90" />
+      <location r="4.022" t="39.86" p="-97.89" rot="-90" />
+      <location r="4.022" t="40.29" p="-97.82" rot="-90" />
+      <location r="4.022" t="40.71" p="-97.74" rot="-90" />
+      <location r="4.022" t="41.14" p="-97.68" rot="-90" />
+      <location r="4.022" t="41.57" p="-97.61" rot="-90" />
+      <location r="4.022" t="42" p="-97.54" rot="-90" />
+      <location r="4.022" t="42.43" p="-97.48" rot="-90" />
+      <location r="4.022" t="42.86" p="-97.42" rot="-90" />
+      <location r="4.022" t="43.29" p="-97.35" rot="-90" />
+      <location r="4.022" t="43.71" p="-97.29" rot="-90" />
+      <location r="4.022" t="44.14" p="-97.24" rot="-90" />
+    </component>
+  </type>
+
+  <type name="W3-3">  
+    <component type="tall He3 element"> 
+      <location r="4.022" t="45.86" p="-96.91" rot="-90" />
+      <location r="4.022" t="46.29" p="-96.86" rot="-90" />
+      <location r="4.022" t="46.71" p="-96.81" rot="-90" />
+      <location r="4.022" t="47.14" p="-96.77" rot="-90" />
+      <location r="4.022" t="47.57" p="-96.72" rot="-90" />
+      <location r="4.022" t="48" p="-96.67" rot="-90" />
+      <location r="4.022" t="48.43" p="-96.63" rot="-90" />
+      <location r="4.022" t="48.86" p="-96.59" rot="-90" />
+      <location r="4.022" t="49.29" p="-96.54" rot="-90" />
+      <location r="4.022" t="49.71" p="-96.5" rot="-90" />
+      <location r="4.022" t="50.14" p="-96.46" rot="-90" />
+      <location r="4.022" t="50.57" p="-96.42" rot="-90" />
+      <location r="4.022" t="51" p="-96.38" rot="-90" />
+      <location r="4.022" t="51.43" p="-96.34" rot="-90" />
+      <location r="4.022" t="51.86" p="-96.3" rot="-90" />
+      <location r="4.022" t="52.29" p="-96.27" rot="-90" />
+      <location r="4.022" t="52.71" p="-96.23" rot="-90" />
+      <location r="4.022" t="53.14" p="-96.2" rot="-90" />
+      <location r="4.022" t="53.57" p="-96.16" rot="-90" />
+      <location r="4.022" t="54" p="-96.13" rot="-90" />
+      <location r="4.022" t="54.43" p="-96.1" rot="-90" />
+      <location r="4.022" t="54.86" p="-96.06" rot="-90" />
+      <location r="4.022" t="55.29" p="-96.03" rot="-90" />
+      <location r="4.022" t="55.71" p="-96" rot="-90" />
+      <location r="4.022" t="56.14" p="-95.97" rot="-90" />
+      <location r="4.022" t="56.57" p="-95.94" rot="-90" />
+      <location r="4.022" t="57" p="-95.91" rot="-90" />
+      <location r="4.022" t="57.43" p="-95.88" rot="-90" />
+      <location r="4.022" t="57.86" p="-95.85" rot="-90" />
+      <location r="4.022" t="58.29" p="-95.83" rot="-90" />
+      <location r="4.022" t="58.71" p="-95.8" rot="-90" />
+      <location r="4.022" t="59.14" p="-95.77" rot="-90" />
+    </component>
+  </type>
+
+  <type name="W4-3">  
+    <component type="tall He3 element"> 
+      <location r="4.022" t="60.86" p="-95.67" rot="-90" />
+      <location r="4.022" t="61.29" p="-95.65" rot="-90" />
+      <location r="4.022" t="61.71" p="-95.63" rot="-90" />
+      <location r="4.022" t="62.14" p="-95.61" rot="-90" />
+      <location r="4.022" t="62.57" p="-95.58" rot="-90" />
+      <location r="4.022" t="63" p="-95.56" rot="-90" />
+      <location r="4.022" t="63.43" p="-95.54" rot="-90" />
+      <location r="4.022" t="63.86" p="-95.52" rot="-90" />
+      <location r="4.022" t="64.29" p="-95.5" rot="-90" />
+      <location r="4.022" t="64.71" p="-95.48" rot="-90" />
+      <location r="4.022" t="65.14" p="-95.46" rot="-90" />
+      <location r="4.022" t="65.57" p="-95.44" rot="-90" />
+      <location r="4.022" t="66" p="-95.42" rot="-90" />
+      <location r="4.022" t="66.43" p="-95.41" rot="-90" />
+      <location r="4.022" t="66.86" p="-95.39" rot="-90" />
+      <location r="4.022" t="67.29" p="-95.37" rot="-90" />
+      <location r="4.022" t="67.71" p="-95.36" rot="-90" />
+      <location r="4.022" t="68.14" p="-95.34" rot="-90" />
+      <location r="4.022" t="68.57" p="-95.32" rot="-90" />
+      <location r="4.022" t="69" p="-95.31" rot="-90" />
+      <location r="4.022" t="69.43" p="-95.29" rot="-90" />
+      <location r="4.022" t="69.86" p="-95.28" rot="-90" />
+      <location r="4.022" t="70.29" p="-95.26" rot="-90" />
+      <location r="4.022" t="70.71" p="-95.25" rot="-90" />
+      <location r="4.022" t="71.14" p="-95.24" rot="-90" />
+      <location r="4.022" t="71.57" p="-95.22" rot="-90" />
+      <location r="4.022" t="72" p="-95.21" rot="-90" />
+      <location r="4.022" t="72.43" p="-95.2" rot="-90" />
+      <location r="4.022" t="72.86" p="-95.19" rot="-90" />
+      <location r="4.022" t="73.29" p="-95.17" rot="-90" />
+      <location r="4.022" t="73.71" p="-95.16" rot="-90" />
+      <location r="4.022" t="74.14" p="-95.15" rot="-90" />
+    </component>
+  </type>
+
+  <type name="W5-3">  
+    <component type="tall He3 element"> 
+      <location r="4.022" t="75.86" p="-95.11" rot="-90" />
+      <location r="4.022" t="76.29" p="-95.1" rot="-90" />
+      <location r="4.022" t="76.71" p="-95.09" rot="-90" />
+      <location r="4.022" t="77.14" p="-95.08" rot="-90" />
+      <location r="4.022" t="77.57" p="-95.07" rot="-90" />
+      <location r="4.022" t="78" p="-95.07" rot="-90" />
+      <location r="4.022" t="78.43" p="-95.06" rot="-90" />
+      <location r="4.022" t="78.86" p="-95.05" rot="-90" />
+      <location r="4.022" t="79.29" p="-95.04" rot="-90" />
+      <location r="4.022" t="79.71" p="-95.04" rot="-90" />
+      <location r="4.022" t="80.14" p="-95.03" rot="-90" />
+      <location r="4.022" t="80.57" p="-95.02" rot="-90" />
+      <location r="4.022" t="81" p="-95.02" rot="-90" />
+      <location r="4.022" t="81.43" p="-95.01" rot="-90" />
+      <location r="4.022" t="81.86" p="-95.01" rot="-90" />
+      <location r="4.022" t="82.29" p="-95" rot="-90" />
+      <location r="4.022" t="82.71" p="-95" rot="-90" />
+      <location r="4.022" t="83.14" p="-94.99" rot="-90" />
+      <location r="4.022" t="83.57" p="-94.99" rot="-90" />
+      <location r="4.022" t="84" p="-94.98" rot="-90" />
+      <location r="4.022" t="84.43" p="-94.98" rot="-90" />
+      <location r="4.022" t="84.86" p="-94.97" rot="-90" />
+      <location r="4.022" t="85.29" p="-94.97" rot="-90" />
+      <location r="4.022" t="85.71" p="-94.97" rot="-90" />
+      <location r="4.022" t="86.14" p="-94.97" rot="-90" />
+      <location r="4.022" t="86.57" p="-94.96" rot="-90" />
+      <location r="4.022" t="87" p="-94.96" rot="-90" />
+      <location r="4.022" t="87.43" p="-94.96" rot="-90" />
+      <location r="4.022" t="87.86" p="-94.96" rot="-90" />
+      <location r="4.022" t="88.29" p="-94.96" rot="-90" />
+      <location r="4.022" t="88.71" p="-94.96" rot="-90" />
+      <location r="4.022" t="89.14" p="-94.96" rot="-90" />
+    </component>
+  </type>   
+
+  <type name="W6-3">  
+    <component type="tall He3 element">  
+      <location r="4.022" t="90.86" p="-94.96" rot="-90" />
+      <location r="4.022" t="91.29" p="-94.96" rot="-90" />
+      <location r="4.022" t="91.71" p="-94.96" rot="-90" />
+      <location r="4.022" t="92.14" p="-94.96" rot="-90" />
+      <location r="4.022" t="92.57" p="-94.96" rot="-90" />
+      <location r="4.022" t="93" p="-94.96" rot="-90" />
+      <location r="4.022" t="93.43" p="-94.96" rot="-90" />
+      <location r="4.022" t="93.86" p="-94.97" rot="-90" />
+      <location r="4.022" t="94.29" p="-94.97" rot="-90" />
+      <location r="4.022" t="94.71" p="-94.97" rot="-90" />
+      <location r="4.022" t="95.14" p="-94.97" rot="-90" />
+      <location r="4.022" t="95.57" p="-94.98" rot="-90" />
+      <location r="4.022" t="96" p="-94.98" rot="-90" />
+      <location r="4.022" t="96.43" p="-94.99" rot="-90" />
+      <location r="4.022" t="96.86" p="-94.99" rot="-90" />
+      <location r="4.022" t="97.29" p="-95" rot="-90" />
+      <location r="4.022" t="97.71" p="-95" rot="-90" />
+      <location r="4.022" t="98.14" p="-95.01" rot="-90" />
+      <location r="4.022" t="98.57" p="-95.01" rot="-90" />
+      <location r="4.022" t="99" p="-95.02" rot="-90" />
+      <location r="4.022" t="99.43" p="-95.02" rot="-90" />
+      <location r="4.022" t="99.86" p="-95.03" rot="-90" />
+      <location r="4.022" t="100.29" p="-95.04" rot="-90" />
+      <location r="4.022" t="100.71" p="-95.04" rot="-90" />
+      <location r="4.022" t="101.14" p="-95.05" rot="-90" />
+      <location r="4.022" t="101.57" p="-95.06" rot="-90" />
+      <location r="4.022" t="102" p="-95.07" rot="-90" />
+      <location r="4.022" t="102.43" p="-95.07" rot="-90" />
+      <location r="4.022" t="102.86" p="-95.08" rot="-90" />
+      <location r="4.022" t="103.29" p="-95.09" rot="-90" />
+      <location r="4.022" t="103.71" p="-95.1" rot="-90" />
+      <location r="4.022" t="104.14" p="-95.11" rot="-90" />
+    </component>
+  </type>   
+
+  <type name="W7-3">  
+    <component type="tall He3 element">  
+      <location r="4.022" t="105.86" p="-95.15" rot="-90" />
+      <location r="4.022" t="106.29" p="-95.16" rot="-90" />
+      <location r="4.022" t="106.71" p="-95.17" rot="-90" />
+      <location r="4.022" t="107.14" p="-95.19" rot="-90" />
+      <location r="4.022" t="107.57" p="-95.2" rot="-90" />
+      <location r="4.022" t="108" p="-95.21" rot="-90" />
+      <location r="4.022" t="108.43" p="-95.22" rot="-90" />
+      <location r="4.022" t="108.86" p="-95.24" rot="-90" />
+      <location r="4.022" t="109.29" p="-95.25" rot="-90" />
+      <location r="4.022" t="109.71" p="-95.26" rot="-90" />
+      <location r="4.022" t="110.14" p="-95.28" rot="-90" />
+      <location r="4.022" t="110.57" p="-95.29" rot="-90" />
+      <location r="4.022" t="111" p="-95.31" rot="-90" />
+      <location r="4.022" t="111.43" p="-95.32" rot="-90" />
+      <location r="4.022" t="111.86" p="-95.34" rot="-90" />
+      <location r="4.022" t="112.29" p="-95.36" rot="-90" />
+      <location r="4.022" t="112.71" p="-95.37" rot="-90" />
+      <location r="4.022" t="113.14" p="-95.39" rot="-90" />
+      <location r="4.022" t="113.57" p="-95.41" rot="-90" />
+      <location r="4.022" t="114" p="-95.42" rot="-90" />
+      <location r="4.022" t="114.43" p="-95.44" rot="-90" />
+      <location r="4.022" t="114.86" p="-95.46" rot="-90" />
+      <location r="4.022" t="115.29" p="-95.48" rot="-90" />
+      <location r="4.022" t="115.71" p="-95.5" rot="-90" />
+      <location r="4.022" t="116.14" p="-95.52" rot="-90" />
+      <location r="4.022" t="116.57" p="-95.54" rot="-90" />
+      <location r="4.022" t="117" p="-95.56" rot="-90" />
+      <location r="4.022" t="117.43" p="-95.58" rot="-90" />
+      <location r="4.022" t="117.86" p="-95.61" rot="-90" />
+      <location r="4.022" t="118.29" p="-95.63" rot="-90" />
+      <location r="4.022" t="118.71" p="-95.65" rot="-90" />
+      <location r="4.022" t="119.14" p="-95.67" rot="-90" />
+    </component>
+  </type>   
+  
+  <type name="W8-3">  
+    <component type="tall He3 element">  
+      <location r="4.022" t="120.86" p="-95.77" rot="-90" />
+      <location r="4.022" t="121.29" p="-95.8" rot="-90" />
+      <location r="4.022" t="121.71" p="-95.83" rot="-90" />
+      <location r="4.022" t="122.14" p="-95.85" rot="-90" />
+      <location r="4.022" t="122.57" p="-95.88" rot="-90" />
+      <location r="4.022" t="123" p="-95.91" rot="-90" />
+      <location r="4.022" t="123.43" p="-95.94" rot="-90" />
+      <location r="4.022" t="123.86" p="-95.97" rot="-90" />
+      <location r="4.022" t="124.29" p="-96" rot="-90" />
+      <location r="4.022" t="124.71" p="-96.03" rot="-90" />
+      <location r="4.022" t="125.14" p="-96.06" rot="-90" />
+      <location r="4.022" t="125.57" p="-96.1" rot="-90" />
+      <location r="4.022" t="126" p="-96.13" rot="-90" />
+      <location r="4.022" t="126.43" p="-96.16" rot="-90" />
+      <location r="4.022" t="126.86" p="-96.2" rot="-90" />
+      <location r="4.022" t="127.29" p="-96.23" rot="-90" />
+      <location r="4.022" t="127.71" p="-96.27" rot="-90" />
+      <location r="4.022" t="128.14" p="-96.3" rot="-90" />
+      <location r="4.022" t="128.57" p="-96.34" rot="-90" />
+      <location r="4.022" t="129" p="-96.38" rot="-90" />
+      <location r="4.022" t="129.43" p="-96.42" rot="-90" />
+      <location r="4.022" t="129.86" p="-96.46" rot="-90" />
+      <location r="4.022" t="130.29" p="-96.5" rot="-90" />
+      <location r="4.022" t="130.71" p="-96.54" rot="-90" />
+      <location r="4.022" t="131.14" p="-96.59" rot="-90" />
+      <location r="4.022" t="131.57" p="-96.63" rot="-90" />
+      <location r="4.022" t="132" p="-96.67" rot="-90" />
+      <location r="4.022" t="132.43" p="-96.72" rot="-90" />
+      <location r="4.022" t="132.86" p="-96.77" rot="-90" />
+      <location r="4.022" t="133.29" p="-96.81" rot="-90" />
+      <location r="4.022" t="133.71" p="-96.86" rot="-90" />
+      <location r="4.022" t="134.14" p="-96.91" rot="-90" />
+    </component>
+  </type>   
+  
+  
+  <type name="W11 north"> 
+    <component type="small He3 element">  
+      <location r="4.022" t="3.43" p="90" rot="90" />
+    </component>   
+    <component type="tall He3 element">  
+      <location r="4.022" t="3.86" p="90" rot="90" />
+      <location r="4.022" t="4.29" p="90" rot="90" />
+      <location r="4.022" t="4.71" p="90" rot="90" />
+      <location r="4.022" t="5.14" p="90" rot="90" />
+      <location r="4.022" t="5.57" p="90" rot="90" />
+      <location r="4.022" t="6" p="90" rot="90" />
+      <location r="4.022" t="6.43" p="90" rot="90" />
+      <location r="4.022" t="6.86" p="90" rot="90" />
+      <location r="4.022" t="7.29" p="90" rot="90" />
+      <location r="4.022" t="7.71" p="90" rot="90" />
+      <location r="4.022" t="8.14" p="90" rot="90" />
+      <location r="4.022" t="8.57" p="90" rot="90" />
+      <location r="4.022" t="9" p="90" rot="90" />
+      <location r="4.022" t="9.43" p="90" rot="90" />
+      <location r="4.022" t="9.86" p="90" rot="90" />
+      <location r="4.022" t="10.29" p="90" rot="90" />
+      <location r="4.022" t="10.71" p="90" rot="90" />
+      <location r="4.022" t="11.14" p="90" rot="90" />
+      <location r="4.022" t="11.57" p="90" rot="90" />
+      <location r="4.022" t="12" p="90" rot="90" />
+      <location r="4.022" t="12.43" p="90" rot="90" />
+      <location r="4.022" t="12.86" p="90" rot="90" />
+      <location r="4.022" t="13.29" p="90" rot="90" />
+    </component>
+  </type>   
+  
+  <type name="W12 north east"> 
+    <component type="small He3 element">  
+      <location r="4.022" t="6.43" p="135" rot="135" />
+    </component>   
+    <component type="tall He3 element">  
+      <location r="4.022" t="6.86" p="135" rot="135" />
+      <location r="4.022" t="7.29" p="135" rot="135" />
+      <location r="4.022" t="7.71" p="135" rot="135" />
+      <location r="4.022" t="8.14" p="135" rot="135" />
+      <location r="4.022" t="8.57" p="135" rot="135" />
+      <location r="4.022" t="9" p="135" rot="135" />
+      <location r="4.022" t="9.43" p="135" rot="135" />
+      <location r="4.022" t="9.86" p="135" rot="135" />
+      <location r="4.022" t="10.29" p="135" rot="135" />
+      <location r="4.022" t="10.71" p="135" rot="135" />
+      <location r="4.022" t="11.14" p="135" rot="135" />
+      <location r="4.022" t="11.57" p="135" rot="135" />
+      <location r="4.022" t="12" p="135" rot="135" />
+      <location r="4.022" t="12.43" p="135" rot="135" />
+      <location r="4.022" t="12.86" p="135" rot="135" />
+    </component>
+  </type> 
+  
+  <type name="W13 east"> 
+    <component type="small He3 element">  
+      <location r="4.022" t="3.43" p="180" rot="180" />
+    </component>   
+    <component type="tall He3 element">  
+      <location r="4.022" t="3.86" p="180" rot="180" />
+      <location r="4.022" t="4.29" p="180" rot="180" />
+      <location r="4.022" t="4.71" p="180" rot="180" />
+      <location r="4.022" t="5.14" p="180" rot="180" />
+      <location r="4.022" t="5.57" p="180" rot="180" />
+      <location r="4.022" t="6" p="180" rot="180" />
+      <location r="4.022" t="6.43" p="180" rot="180" />
+      <location r="4.022" t="6.86" p="180" rot="180" />
+      <location r="4.022" t="7.29" p="180" rot="180" />
+      <location r="4.022" t="7.71" p="180" rot="180" />
+      <location r="4.022" t="8.14" p="180" rot="180" />
+      <location r="4.022" t="8.57" p="180" rot="180" />
+      <location r="4.022" t="9" p="180" rot="180" />
+      <location r="4.022" t="9.43" p="180" rot="180" />
+      <location r="4.022" t="9.86" p="180" rot="180" />
+    </component>
+  </type> 
+  
+  <type name="W14 south east"> 
+    <component type="small He3 element">  
+      <location r="4.022" t="6.43" p="-135" rot="-135" />
+    </component>   
+    <component type="tall He3 element">  
+      <location r="4.022" t="6.86" p="-135" rot="-135" />
+      <location r="4.022" t="7.29" p="-135" rot="-135" />
+      <location r="4.022" t="7.71" p="-135" rot="-135" />
+      <location r="4.022" t="8.14" p="-135" rot="-135" />
+      <location r="4.022" t="8.57" p="-135" rot="-135" />
+      <location r="4.022" t="9" p="-135" rot="-135" />
+      <location r="4.022" t="9.43" p="-135" rot="-135" />
+      <location r="4.022" t="9.86" p="-135" rot="-135" />
+      <location r="4.022" t="10.29" p="-135" rot="-135" />
+      <location r="4.022" t="10.71" p="-135" rot="-135" />
+      <location r="4.022" t="11.14" p="-135" rot="-135" />
+      <location r="4.022" t="11.57" p="-135" rot="-135" />
+      <location r="4.022" t="12" p="-135" rot="-135" />
+      <location r="4.022" t="12.43" p="-135" rot="-135" />
+      <location r="4.022" t="12.86" p="-135" rot="-135" />
+    </component>
+  </type>   
+  
+  <type name="W15 south"> 
+    <component type="small He3 element">  
+      <location r="4.022" t="3.43" p="-90" rot="-90" />
+    </component>   
+    <component type="tall He3 element">  
+      <location r="4.022" t="3.86" p="-90" rot="-90" />
+      <location r="4.022" t="4.29" p="-90" rot="-90" />
+      <location r="4.022" t="4.71" p="-90" rot="-90" />
+      <location r="4.022" t="5.14" p="-90" rot="-90" />
+      <location r="4.022" t="5.57" p="-90" rot="-90" />
+      <location r="4.022" t="6" p="-90" rot="-90" />
+      <location r="4.022" t="6.43" p="-90" rot="-90" />
+      <location r="4.022" t="6.86" p="-90" rot="-90" />
+      <location r="4.022" t="7.29" p="-90" rot="-90" />
+      <location r="4.022" t="7.71" p="-90" rot="-90" />
+      <location r="4.022" t="8.14" p="-90" rot="-90" />
+      <location r="4.022" t="8.57" p="-90" rot="-90" />
+      <location r="4.022" t="9" p="-90" rot="-90" />
+      <location r="4.022" t="9.43" p="-90" rot="-90" />
+      <location r="4.022" t="9.86" p="-90" rot="-90" />
+    </component>
+  </type>     
+  
+  <type name="W16 south west"> 
+    <component type="small He3 element">  
+      <location r="4.022" t="6.43" p="-45" rot="-45" />
+    </component>   
+    <component type="tall He3 element">  
+      <location r="4.022" t="6.86" p="-45" rot="-45" />
+      <location r="4.022" t="7.29" p="-45" rot="-45" />
+      <location r="4.022" t="7.71" p="-45" rot="-45" />
+      <location r="4.022" t="8.14" p="-45" rot="-45" />
+      <location r="4.022" t="8.57" p="-45" rot="-45" />
+      <location r="4.022" t="9" p="-45" rot="-45" />
+      <location r="4.022" t="9.43" p="-45" rot="-45" />
+      <location r="4.022" t="9.86" p="-45" rot="-45" />
+      <location r="4.022" t="10.29" p="-45" rot="-45" />
+      <location r="4.022" t="10.71" p="-45" rot="-45" />
+      <location r="4.022" t="11.14" p="-45" rot="-45" />
+      <location r="4.022" t="11.57" p="-45" rot="-45" />
+      <location r="4.022" t="12" p="-45" rot="-45" />
+      <location r="4.022" t="12.43" p="-45" rot="-45" />
+      <location r="4.022" t="12.86" p="-45" rot="-45" />
+    </component>
+  </type>    
+
+  <type name="W17 west"> 
+    <component type="small He3 element">  
+      <location r="4.022" t="3.43" p="0" rot="0" />
+    </component>   
+    <component type="tall He3 element">  
+      <location r="4.022" t="3.86" p="0" rot="0" />
+      <location r="4.022" t="4.29" p="0" rot="0" />
+      <location r="4.022" t="4.71" p="0" rot="0" />
+      <location r="4.022" t="5.14" p="0" rot="0" />
+      <location r="4.022" t="5.57" p="0" rot="0" />
+      <location r="4.022" t="6" p="0" rot="0" />
+      <location r="4.022" t="6.43" p="0" rot="0" />
+      <location r="4.022" t="6.86" p="0" rot="0" />
+      <location r="4.022" t="7.29" p="0" rot="0" />
+      <location r="4.022" t="7.71" p="0" rot="0" />
+      <location r="4.022" t="8.14" p="0" rot="0" />
+      <location r="4.022" t="8.57" p="0" rot="0" />
+      <location r="4.022" t="9" p="0" rot="0" />
+      <location r="4.022" t="9.43" p="0" rot="0" />
+      <location r="4.022" t="9.86" p="0" rot="0" />
+    </component>
+  </type>  
+  
+  <type name="W18 north west"> 
+    <component type="small He3 element">  
+      <location r="4.022" t="6.43" p="45" rot="45" />
+    </component>   
+    <component type="tall He3 element">  
+      <location r="4.022" t="6.86" p="45" rot="45" />
+      <location r="4.022" t="7.29" p="45" rot="45" />
+      <location r="4.022" t="7.71" p="45" rot="45" />
+      <location r="4.022" t="8.14" p="45" rot="45" />
+      <location r="4.022" t="8.57" p="45" rot="45" />
+      <location r="4.022" t="9" p="45" rot="45" />
+      <location r="4.022" t="9.43" p="45" rot="45" />
+      <location r="4.022" t="9.86" p="45" rot="45" />
+      <location r="4.022" t="10.29" p="45" rot="45" />
+      <location r="4.022" t="10.71" p="45" rot="45" />
+      <location r="4.022" t="11.14" p="45" rot="45" />
+      <location r="4.022" t="11.57" p="45" rot="45" />
+      <location r="4.022" t="12" p="45" rot="45" />
+      <location r="4.022" t="12.43" p="45" rot="45" />
+      <location r="4.022" t="12.86" p="45" rot="45" />
+    </component>
+  </type>
+  
+  <type name="small He3 element" is="detector">    
+    <cylinder id="shape">
+      <centre-of-bottom-base x="0.0" y="-0.1" z="0.0" />
+      <axis x="0.0" y="1.0" z="0" /> 
+      <radius val="0.0125" />
+      <height val="0.2" />
+    </cylinder> 
+  </type>
+  
+  <type name="tall He3 element" is="detector">     
+    <cylinder id="shape">
+      <centre-of-bottom-base x="0.0" y="-0.15" z="0.0" />
+      <axis x="0.0" y="1.0" z="0" /> 
+      <radius val="0.0125" />
+      <height val="0.3" />
+    </cylinder> 
+  </type>  
+
+
+  
+  <!-- DETECTOR ID LISTS -->
+  <idlist idname="low angle bank">
+    <id start="4101" end="4124" />
+    <id start="4201" end="4216" />    
+    <id start="4301" end="4316" />        
+    <id start="4401" end="4416" />   
+    <id start="4501" end="4516" />        
+    <id start="4601" end="4616" />  
+    <id start="4701" end="4716" />        
+    <id start="4801" end="4816" />     
+  </idlist>
+  
+  <idlist idname="wide angle bank">
+    <id start="1101" end="1137" />
+    <id start="1201" end="1230" />    
+    <id start="1301" end="1332" />        
+    <id start="1401" end="1432" />   
+    <id start="1501" end="1532" />        
+    <id start="1601" end="1632" />  
+    <id start="1701" end="1732" />        
+    <id start="1801" end="1832" /> 
+    
+    <id start="2101" end="2140" />
+    <id start="2201" end="2232" />    
+    <id start="2301" end="2332" />        
+    <id start="2401" end="2432" />   
+    <id start="2501" end="2532" />        
+    <id start="2601" end="2632" />  
+    <id start="2701" end="2732" />        
+    <id start="2801" end="2832" />  
+    
+    <id start="3101" end="3137" />
+    <id start="3201" end="3230" />    
+    <id start="3301" end="3332" />        
+    <id start="3401" end="3432" />   
+    <id start="3501" end="3532" />        
+    <id start="3601" end="3632" />  
+    <id start="3701" end="3732" />        
+    <id start="3801" end="3832" />     
+  </idlist> 
+  
+  <idlist idname="monitor">
+    <id start="1" end="3" />   
+  </idlist>
+  
+  <!--DETECTOR PARAMETERS-->
+  <component-link name="monitor">
+   <parameter name="DelayTime">
+      <value units="microseconds" val="0"/>
+   </parameter>
+  </component-link>
+    
+  <!-- General defaults for instrument -->
+  <component-link name="MARI">
+    <parameter name="TubePressure">
+      <value units="atm" val="10.0"/>
+    </parameter>
+    <parameter name="TubeThickness">
+      <value units="metre" val="0.0008"/>
+    </parameter>
+    <parameter name="DelayTime">
+      <value units="microseconds" val="-3.9"/>
+    </parameter>
+  </component-link>
+
+</instrument>

--- a/scripts/test/DirectEnergyConversionTest.py
+++ b/scripts/test/DirectEnergyConversionTest.py
@@ -188,7 +188,7 @@ class DirectEnergyConversionTest(unittest.TestCase):
 
     def test_dgreduce_works(self):
         """ Test for old interface """
-        run_ws = CreateSampleWorkspace( Function='Multiple Peaks', NumBanks=1, BankPixelWidth=4, NumEvents=10000)
+        run_ws = CreateSampleWorkspace( Function='Multiple Peaks', NumBanks=1, BankPixelWidth=5, NumEvents=10000)
         LoadInstrument(run_ws,InstrumentName='MARI', RewriteSpectraMap=True)
 
         #mono_ws = CloneWorkspace(run_ws)
@@ -198,7 +198,7 @@ class DirectEnergyConversionTest(unittest.TestCase):
 
         dgreduce.setup('MAR')
         par = {}
-        par['ei_mon_spectra']=[4,5]
+        par['ei_mon_spectra']=[5,6]
         par['abs_units_van_range']=[-4000,8000]
         # overwrite parameters, which are necessary from command line, but we want them to have test values
         dgreduce.getReducer().map_file=None
@@ -210,7 +210,7 @@ class DirectEnergyConversionTest(unittest.TestCase):
 
     def test_dgreduce_works_with_name(self):
         """ Test for old interface """
-        run_ws = CreateSampleWorkspace( Function='Multiple Peaks', NumBanks=1, BankPixelWidth=4, NumEvents=10000)
+        run_ws = CreateSampleWorkspace( Function='Multiple Peaks', NumBanks=1, BankPixelWidth=5, NumEvents=10000)
         LoadInstrument(run_ws,InstrumentName='MARI', RewriteSpectraMap=True)
         AddSampleLog(run_ws,LogName='run_number',LogText='200',LogType='Number')
         #mono_ws = CloneWorkspace(run_ws)
@@ -220,7 +220,7 @@ class DirectEnergyConversionTest(unittest.TestCase):
 
         dgreduce.setup('MAR')
         par = {}
-        par['ei_mon_spectra']=[4,5]
+        par['ei_mon_spectra']=[5,6]
         par['abs_units_van_range']=[-4000,8000]
         # overwrite parameters, which are necessary from command line, but we want them to have test values
         dgreduce.getReducer().map_file=None
@@ -307,7 +307,6 @@ class DirectEnergyConversionTest(unittest.TestCase):
         ei_guess = 67.
         mono_s = tReducer.mono_sample(run, ei_guess,wb_ws)
 
-
         #
         mono_ref = tReducer.mono_sample(ref_ws, ei_guess,wb_clone)
 
@@ -317,7 +316,7 @@ class DirectEnergyConversionTest(unittest.TestCase):
 
     def test_tof_range(self):
 
-        run=CreateSampleWorkspace(Function='Multiple Peaks', NumBanks=6, BankPixelWidth=1, NumEvents=10,\
+        run=CreateSampleWorkspace(Function='Multiple Peaks', NumBanks=7, BankPixelWidth=1, NumEvents=10,\
                                   XUnit='Energy', XMin=5, XMax=75, BinWidth=0.2)
         LoadInstrument(run,InstrumentName='MARI', RewriteSpectraMap=True)
 
@@ -325,7 +324,7 @@ class DirectEnergyConversionTest(unittest.TestCase):
 
         red.prop_man.incident_energy = 26.2
         red.prop_man.energy_bins =  [-20,0.1,20]
-        red.prop_man.multirep_tof_specta_list = [4,5,6]
+        red.prop_man.multirep_tof_specta_list = [5,6,7]
         MoveInstrumentComponent(Workspace='run', ComponentName='Detector', DetectorID=1102, Z=3)
         MoveInstrumentComponent(Workspace='run', ComponentName='Detector', DetectorID=1103,Z=6)
 
@@ -348,7 +347,7 @@ class DirectEnergyConversionTest(unittest.TestCase):
         self.assertLess(tof_range[2], xMax)
 
         # check another working mode
-        red.prop_man.multirep_tof_specta_list = 4
+        red.prop_man.multirep_tof_specta_list = 5
         red.prop_man.incident_energy = 47.505
         red.prop_man.energy_bins =  [-20,0.1,45]
   

--- a/scripts/test/DirectEnergyConversionTest.py
+++ b/scripts/test/DirectEnergyConversionTest.py
@@ -9,14 +9,15 @@ from mantid.simpleapi import *
 from mantid import api
 import unittest
 from Direct.DirectEnergyConversion import DirectEnergyConversion
-from Direct.PropertyManager  import PropertyManager
+from Direct.PropertyManager import PropertyManager
 import Direct.dgreduce as dgreduce
 
-# -----------------------------------------------------------------------------------------------------------------------------------------
+# ----------------------------------------------------------------------------------------------------------------------
 # File paths to instrument files
 PRE_2018_MARI_INSTRUMENT_FILEPATH = 'MARI_Definition_19900101_20160911.xml'
 # two tests need the original before changes were made
 OLD_MARI_INSTRUMENT_FILEPATH = 'unit_testing/MARI_Definition_OLD.xml'
+
 
 class DirectEnergyConversionTest(unittest.TestCase):
     def __init__(self, methodName):
@@ -26,6 +27,7 @@ class DirectEnergyConversionTest(unittest.TestCase):
     def setUp(self):
         if self.reducer == None or type(self.reducer) != type(DirectEnergyConversion):
             self.reducer = DirectEnergyConversion("MAR")
+
     def tearDown(self):
         api.AnalysisDataService.clear()
         pass
@@ -35,14 +37,13 @@ class DirectEnergyConversionTest(unittest.TestCase):
         self.assertNotEqual(tReducer.prop_man, None)
 
         prop_man = tReducer.prop_man
-        self.assertEqual(prop_man.instr_name,"MARI")
-
+        self.assertEqual(prop_man.instr_name, "MARI")
 
     def test_save_formats(self):
         tReducer = self.reducer
 
-        files = ['save_formats_test_file.spe','save_formats_test_file.nxspe'
-                 'save_formats_test_file','save_formats_test_file.nxs']
+        files = ['save_formats_test_file.spe', 'save_formats_test_file.nxspe'
+                                               'save_formats_test_file', 'save_formats_test_file.nxs']
 
         def clean_up(file_list):
             for file in file_list:
@@ -62,239 +63,237 @@ class DirectEnergyConversionTest(unittest.TestCase):
                 os.remove(file)
 
         clean_up(files)
-        tReducer.prop_man.save_format=''
+        tReducer.prop_man.save_format = ''
 
-        tws =CreateSampleWorkspace(Function='Flat background', NumBanks=1, BankPixelWidth=1,\
-                NumEvents=10, XUnit='DeltaE', XMin=-10, XMax=10, BinWidth=0.1)
-
+        tws = CreateSampleWorkspace(Function='Flat background', NumBanks=1, BankPixelWidth=1, \
+                                    NumEvents=10, XUnit='DeltaE', XMin=-10, XMax=10, BinWidth=0.1)
 
         self.assertEqual(len(tReducer.prop_man.save_format), 0)
         # do nothing
-        tReducer.save_results(tws,'save_formats_test_file')
+        tReducer.save_results(tws, 'save_formats_test_file')
         #
         verify_absent(files)
 
-
-
         # redefine test save methods to produce test output
-        tReducer.prop_man.save_format=['spe','nxspe','nxs']
-        tReducer.save_results(tws,'save_formats_test_file.tt')
+        tReducer.prop_man.save_format = ['spe', 'nxspe', 'nxs']
+        tReducer.save_results(tws, 'save_formats_test_file.tt')
 
-        files = ['save_formats_test_file.spe','save_formats_test_file.nxspe','save_formats_test_file.nxs']
+        files = ['save_formats_test_file.spe', 'save_formats_test_file.nxspe', 'save_formats_test_file.nxs']
         verify_present_and_delete(files)
 
-        tReducer.prop_man.save_format=None
+        tReducer.prop_man.save_format = None
         # do nothing
-        tReducer.save_results(tws,'save_formats_test_file.tt')
+        tReducer.save_results(tws, 'save_formats_test_file.tt')
         file = FileFinder.getFullPath('save_formats_test_file.tt')
         self.assertEqual(len(file), 0)
 
         # save file with given extension on direct request:
-        tReducer.save_results(tws,'save_formats_test_file.nxs')
+        tReducer.save_results(tws, 'save_formats_test_file.nxs')
         verify_present_and_delete(['save_formats_test_file.nxs'])
 
-        tReducer.prop_man.save_format=[]
+        tReducer.prop_man.save_format = []
         # do nothing
-        tReducer.save_results(tws,'save_formats_test_file')
+        tReducer.save_results(tws, 'save_formats_test_file')
         file = FileFinder.getFullPath('save_formats_test_file')
         self.assertEqual(len(file), 0)
 
-
         # save files with extensions on request
-        tReducer.save_results(tws,'save_formats_test_file',['nxs','.nxspe'])
-        verify_present_and_delete(['save_formats_test_file.nxspe','save_formats_test_file.nxs'])
+        tReducer.save_results(tws, 'save_formats_test_file', ['nxs', '.nxspe'])
+        verify_present_and_delete(['save_formats_test_file.nxspe', 'save_formats_test_file.nxs'])
 
         # this is strange feature.
         self.assertEqual(len(tReducer.prop_man.save_format), 2)
 
     def test_diagnostics_wb(self):
         wb_ws = CreateSampleWorkspace(NumBanks=1, BankPixelWidth=4, NumEvents=10000)
-        LoadInstrument(wb_ws,filename=PRE_2018_MARI_INSTRUMENT_FILEPATH, RewriteSpectraMap=True)
+        LoadInstrument(wb_ws, filename=PRE_2018_MARI_INSTRUMENT_FILEPATH, RewriteSpectraMap=True)
 
         tReducer = DirectEnergyConversion(wb_ws.getInstrument())
 
-
-        mask_workspace=tReducer.diagnose(wb_ws)
+        mask_workspace = tReducer.diagnose(wb_ws)
         self.assertTrue(mask_workspace)
 
         api.AnalysisDataService.clear()
 
-
-    def test_do_white_wb(self) :
+    def test_do_white_wb(self):
         wb_ws = CreateSampleWorkspace(NumBanks=1, BankPixelWidth=4, NumEvents=10000)
-        #LoadParameterFile(Workspace=wb_ws,ParameterXML = used_parameters)
-        LoadInstrument(wb_ws,filename=PRE_2018_MARI_INSTRUMENT_FILEPATH, RewriteSpectraMap=True)
+        # LoadParameterFile(Workspace=wb_ws,ParameterXML = used_parameters)
+        LoadInstrument(wb_ws, filename=PRE_2018_MARI_INSTRUMENT_FILEPATH, RewriteSpectraMap=True)
 
         tReducer = DirectEnergyConversion(wb_ws.getInstrument())
 
         white_ws = tReducer.do_white(wb_ws, None, None)
         self.assertTrue(white_ws)
 
-
     def test_get_set_attributes(self):
         tReducer = self.reducer
 
         # prohibit accessing non-existing property
-        self.assertRaises(KeyError,getattr,tReducer,'non_existing_property')
-        self.assertRaises(KeyError,setattr,tReducer,'non_existing_property',1000)
-        self.assertRaises(KeyError,getattr,tReducer,'non_existing_property')
+        self.assertRaises(KeyError, getattr, tReducer, 'non_existing_property')
+        self.assertRaises(KeyError, setattr, tReducer, 'non_existing_property', 1000)
+        self.assertRaises(KeyError, getattr, tReducer, 'non_existing_property')
 
         # allow simple creation of a system property
-        self.assertRaises(KeyError,getattr,tReducer,'_new_system_property')
-        setattr(tReducer,'_new_system_property',True)
+        self.assertRaises(KeyError, getattr, tReducer, '_new_system_property')
+        setattr(tReducer, '_new_system_property', True)
         self.assertTrue(tReducer._new_system_property)
 
         # direct and indirect access to prop_man properties
         tReducer.sample_run = None
-        #sample run has not been defined
-        self.assertEqual(getattr(tReducer,'sample_run'), None)
+        # sample run has not been defined
+        self.assertEqual(getattr(tReducer, 'sample_run'), None)
         prop_man = tReducer.prop_man
-        self.assertEqual(getattr(prop_man,'sample_run'), None)
+        self.assertEqual(getattr(prop_man, 'sample_run'), None)
         # define sample run
-        tReducer.sample_run =10234
-        self.assertEqual(tReducer.sample_run,10234)
-        self.assertEqual(tReducer.prop_man.sample_run,10234)
+        tReducer.sample_run = 10234
+        self.assertEqual(tReducer.sample_run, 10234)
+        self.assertEqual(tReducer.prop_man.sample_run, 10234)
 
-
-    def test_get_abs_normalization_factor(self) :
-        mono_ws = CreateSampleWorkspace(NumBanks=1, BankPixelWidth=4, NumEvents=10000,XUnit='DeltaE',XMin=-5,XMax=15,BinWidth=0.1,function='Flat background')
-        LoadInstrument(mono_ws,filename=PRE_2018_MARI_INSTRUMENT_FILEPATH, RewriteSpectraMap=True)
+    def test_get_abs_normalization_factor(self):
+        mono_ws = CreateSampleWorkspace(NumBanks=1, BankPixelWidth=4, NumEvents=10000, XUnit='DeltaE', XMin=-5, XMax=15,
+                                        BinWidth=0.1, function='Flat background')
+        LoadInstrument(mono_ws, filename=PRE_2018_MARI_INSTRUMENT_FILEPATH, RewriteSpectraMap=True)
 
         tReducer = DirectEnergyConversion(mono_ws.getInstrument())
         tReducer.prop_man.incident_energy = 5.
-        tReducer.prop_man.monovan_integr_range=[-10,10]
+        tReducer.prop_man.monovan_integr_range = [-10, 10]
         tReducer.wb_run = mono_ws
 
-        (nf1,nf2,nf3,nf4) = tReducer.get_abs_normalization_factor(PropertyManager.wb_run,5.)
-        self.assertAlmostEqual(nf1,0.58561121802167193,7)
-        self.assertAlmostEqual(nf1,nf2)
-        self.assertAlmostEqual(nf2,nf3)
-        self.assertAlmostEqual(nf3,nf4)
+        (nf1, nf2, nf3, nf4) = tReducer.get_abs_normalization_factor(PropertyManager.wb_run, 5.)
+        self.assertAlmostEqual(nf1, 0.58561121802167193, 7)
+        self.assertAlmostEqual(nf1, nf2)
+        self.assertAlmostEqual(nf2, nf3)
+        self.assertAlmostEqual(nf3, nf4)
 
         # check warning. WB spectra with 0 signal indicate troubles.
-        mono_ws = CreateSampleWorkspace(NumBanks=1, BankPixelWidth=4, NumEvents=10000,XUnit='DeltaE',XMin=-5,XMax=15,BinWidth=0.1,function='Flat background')
-        LoadInstrument(mono_ws,filename=PRE_2018_MARI_INSTRUMENT_FILEPATH, RewriteSpectraMap=True)
+        mono_ws = CreateSampleWorkspace(NumBanks=1, BankPixelWidth=4, NumEvents=10000, XUnit='DeltaE', XMin=-5, XMax=15,
+                                        BinWidth=0.1, function='Flat background')
+        LoadInstrument(mono_ws, filename=PRE_2018_MARI_INSTRUMENT_FILEPATH, RewriteSpectraMap=True)
         sig = mono_ws.dataY(0)
-        sig[:]=0
+        sig[:] = 0
 
         tReducer.wb_run = mono_ws
-        (nf1,nf2,nf3,nf4) = tReducer.get_abs_normalization_factor(PropertyManager.wb_run,5.)
-        self.assertAlmostEqual(nf1,0.585611218022,7)
-        self.assertAlmostEqual(nf1,nf2)
-        self.assertAlmostEqual(nf2,nf3)
-        self.assertAlmostEqual(nf3,nf4)
-
+        (nf1, nf2, nf3, nf4) = tReducer.get_abs_normalization_factor(PropertyManager.wb_run, 5.)
+        self.assertAlmostEqual(nf1, 0.585611218022, 7)
+        self.assertAlmostEqual(nf1, nf2)
+        self.assertAlmostEqual(nf2, nf3)
+        self.assertAlmostEqual(nf3, nf4)
 
     def test_dgreduce_works(self):
         """ Test for old interface """
-        run_ws = CreateSampleWorkspace( Function='Multiple Peaks', NumBanks=1, BankPixelWidth=5, NumEvents=10000)
-        LoadInstrument(run_ws,filename=PRE_2018_MARI_INSTRUMENT_FILEPATH, RewriteSpectraMap=True)
+        run_ws = CreateSampleWorkspace(Function='Multiple Peaks', NumBanks=1, BankPixelWidth=5, NumEvents=10000)
+        LoadInstrument(run_ws, filename=PRE_2018_MARI_INSTRUMENT_FILEPATH, RewriteSpectraMap=True)
 
-        #mono_ws = CloneWorkspace(run_ws)
-        wb_ws   = CloneWorkspace(run_ws)
-        AddSampleLog(wb_ws,LogName='run_number',LogText='300',LogType='Number')
-        #wb_ws=CreateSampleWorkspace( Function='Multiple Peaks', NumBanks=1, BankPixelWidth=4, NumEvents=10000)
+        # mono_ws = CloneWorkspace(run_ws)
+        wb_ws = CloneWorkspace(run_ws)
+        AddSampleLog(wb_ws, LogName='run_number', LogText='300', LogType='Number')
+        # wb_ws=CreateSampleWorkspace( Function='Multiple Peaks', NumBanks=1, BankPixelWidth=4, NumEvents=10000)
 
         dgreduce.setup('MAR')
         par = {}
-        par['ei_mon_spectra']=[5,6]
-        par['abs_units_van_range']=[-4000,8000]
+        par['ei_mon_spectra'] = [5, 6]
+        par['abs_units_van_range'] = [-4000, 8000]
         # overwrite parameters, which are necessary from command line, but we want them to have test values
-        dgreduce.getReducer().map_file=None
-        dgreduce.getReducer().monovan_mapfile=None
+        dgreduce.getReducer().map_file = None
+        dgreduce.getReducer().monovan_mapfile = None
         dgreduce.getReducer().mono_correction_factor = 1
-        #abs_units(wb_for_run,sample_run,monovan_run,wb_for_monovanadium,samp_rmm,samp_mass,ei_guess,rebin,map_file='default',monovan_mapfile='default',**kwargs):
-        ws = dgreduce.abs_units(wb_ws,run_ws,None,wb_ws,10,100,8.8,[-10,0.1,7],None,None,**par)
-        self.assertTrue(isinstance(ws,api.MatrixWorkspace))
+        # abs_units(wb_for_run,sample_run,monovan_run,wb_for_monovanadium,samp_rmm,samp_mass,ei_guess,rebin,map_file='default',monovan_mapfile='default',**kwargs):
+        ws = dgreduce.abs_units(wb_ws, run_ws, None, wb_ws, 10, 100, 8.8, [-10, 0.1, 7], None, None, **par)
+        self.assertTrue(isinstance(ws, api.MatrixWorkspace))
 
     def test_dgreduce_works_with_name(self):
         """ Test for old interface """
-        run_ws = CreateSampleWorkspace( Function='Multiple Peaks', NumBanks=1, BankPixelWidth=5, NumEvents=10000)
-        LoadInstrument(run_ws,filename=PRE_2018_MARI_INSTRUMENT_FILEPATH, RewriteSpectraMap=True)
-        AddSampleLog(run_ws,LogName='run_number',LogText='200',LogType='Number')
-        #mono_ws = CloneWorkspace(run_ws)
-        wb_ws   = CloneWorkspace(run_ws)
-        AddSampleLog(wb_ws,LogName='run_number',LogText='100',LogType='Number')
-        #wb_ws=CreateSampleWorkspace( Function='Multiple Peaks', NumBanks=1, BankPixelWidth=4, NumEvents=10000)
+        run_ws = CreateSampleWorkspace(Function='Multiple Peaks', NumBanks=1, BankPixelWidth=5, NumEvents=10000)
+        LoadInstrument(run_ws, filename=PRE_2018_MARI_INSTRUMENT_FILEPATH, RewriteSpectraMap=True)
+        AddSampleLog(run_ws, LogName='run_number', LogText='200', LogType='Number')
+        # mono_ws = CloneWorkspace(run_ws)
+        wb_ws = CloneWorkspace(run_ws)
+        AddSampleLog(wb_ws, LogName='run_number', LogText='100', LogType='Number')
+        # wb_ws=CreateSampleWorkspace( Function='Multiple Peaks', NumBanks=1, BankPixelWidth=4, NumEvents=10000)
 
         dgreduce.setup('MAR')
         par = {}
-        par['ei_mon_spectra']=[5,6]
-        par['abs_units_van_range']=[-4000,8000]
+        par['ei_mon_spectra'] = [5, 6]
+        par['abs_units_van_range'] = [-4000, 8000]
         # overwrite parameters, which are necessary from command line, but we want them to have test values
-        dgreduce.getReducer().map_file=None
-        dgreduce.getReducer().monovan_mapfile=None
+        dgreduce.getReducer().map_file = None
+        dgreduce.getReducer().monovan_mapfile = None
         dgreduce.getReducer().mono_correction_factor = 1
-        #abs_units(wb_for_run,sample_run,monovan_run,wb_for_monovanadium,samp_rmm,samp_mass,ei_guess,rebin,map_file='default',monovan_mapfile='default',**kwargs):
-        ws = dgreduce.abs_units('wb_ws','run_ws',None,wb_ws,10,100,8.8,[-10,0.1,7],None,None,**par)
-        self.assertTrue(isinstance(ws,api.MatrixWorkspace))
-
-
+        # abs_units(wb_for_run,sample_run,monovan_run,wb_for_monovanadium,samp_rmm,samp_mass,ei_guess,rebin,map_file='default',monovan_mapfile='default',**kwargs):
+        ws = dgreduce.abs_units('wb_ws', 'run_ws', None, wb_ws, 10, 100, 8.8, [-10, 0.1, 7], None, None, **par)
+        self.assertTrue(isinstance(ws, api.MatrixWorkspace))
 
     ##    tReducet.di
     def test_energy_to_TOF_range(self):
 
-        ws = Load(Filename='MAR11001.raw',LoadMonitors='Include')
+        ws = Load(Filename='MAR11001.raw', LoadMonitors='Include')
 
-        en_range = [0.8*13,13,1.2*13]
-        detIDs=[1,2,3,10]
+        en_range = [0.8 * 13, 13, 1.2 * 13]
+        detIDs = [1, 2, 3, 10]
         red = DirectEnergyConversion()
-        TRange = red.get_TOF_for_energies(ws,en_range,detIDs)
-        for ind,detID in enumerate(detIDs):
+        TRange = red.get_TOF_for_energies(ws, en_range, detIDs)
+        for ind, detID in enumerate(detIDs):
             tof = TRange[ind]
-            y = [1]*(len(tof)-1)
+            y = [1] * (len(tof) - 1)
             ind = ws.getIndexFromSpectrumNumber(detID)
             ExtractSingleSpectrum(InputWorkspace=ws, OutputWorkspace='_ws_template', WorkspaceIndex=ind)
-            CreateWorkspace(OutputWorkspace='TOF_WS',NSpec = 1,DataX=tof,DataY=y,UnitX='TOF',ParentWorkspace='_ws_template')
-            EnWs=ConvertUnits(InputWorkspace='TOF_WS',Target='Energy',EMode='Elastic')
+            CreateWorkspace(OutputWorkspace='TOF_WS', NSpec=1, DataX=tof, DataY=y, UnitX='TOF',
+                            ParentWorkspace='_ws_template')
+            EnWs = ConvertUnits(InputWorkspace='TOF_WS', Target='Energy', EMode='Elastic')
 
             eni = EnWs.dataX(0)
-            for samp,rez in zip(eni,en_range): self.assertAlmostEqual(samp,rez)
+            for samp, rez in zip(eni, en_range): self.assertAlmostEqual(samp, rez)
 
         # Now Test shifted:
-        ei,mon1_peak,mon1_index,tzero = GetEi(InputWorkspace=ws, Monitor1Spec=int(2), Monitor2Spec=int(3),EnergyEstimate=13)
-        ScaleX(InputWorkspace='ws',OutputWorkspace='ws',Operation="Add",Factor=-mon1_peak,InstrumentParameter="DelayTime",Combine=True)
+        ei, mon1_peak, mon1_index, tzero = GetEi(InputWorkspace=ws, Monitor1Spec=int(2), Monitor2Spec=int(3),
+                                                 EnergyEstimate=13)
+        ScaleX(InputWorkspace='ws', OutputWorkspace='ws', Operation="Add", Factor=-mon1_peak,
+               InstrumentParameter="DelayTime", Combine=True)
         ws = mtd['ws']
 
         mon1_det = ws.getDetector(1)
         mon1_pos = mon1_det.getPos()
         src_name = ws.getInstrument().getSource().getName()
-        MoveInstrumentComponent(Workspace='ws',ComponentName= src_name, X=mon1_pos.getX(), Y=mon1_pos.getY(), Z=mon1_pos.getZ(), RelativePosition=False)
+        MoveInstrumentComponent(Workspace='ws', ComponentName=src_name, X=mon1_pos.getX(), Y=mon1_pos.getY(),
+                                Z=mon1_pos.getZ(), RelativePosition=False)
 
         # Does not work for monitor 2 as it has been moved to mon2 position and there all tof =0
-        detIDs=[1,3,10]
-        TRange1 = red.get_TOF_for_energies(ws,en_range,detIDs)
+        detIDs = [1, 3, 10]
+        TRange1 = red.get_TOF_for_energies(ws, en_range, detIDs)
 
-        for ind,detID in enumerate(detIDs):
+        for ind, detID in enumerate(detIDs):
             tof = TRange1[ind]
-            y = [1]*(len(tof)-1)
+            y = [1] * (len(tof) - 1)
             ind = ws.getIndexFromSpectrumNumber(detID)
             ExtractSingleSpectrum(InputWorkspace=ws, OutputWorkspace='_ws_template', WorkspaceIndex=ind)
-            CreateWorkspace(OutputWorkspace='TOF_WS',NSpec = 1,DataX=tof,DataY=y,UnitX='TOF',ParentWorkspace='_ws_template')
-            EnWs=ConvertUnits(InputWorkspace='TOF_WS',Target='Energy',EMode='Elastic')
+            CreateWorkspace(OutputWorkspace='TOF_WS', NSpec=1, DataX=tof, DataY=y, UnitX='TOF',
+                            ParentWorkspace='_ws_template')
+            EnWs = ConvertUnits(InputWorkspace='TOF_WS', Target='Energy', EMode='Elastic')
 
             eni = EnWs.dataX(0)
-            for samp,rez in zip(eni,en_range): self.assertAlmostEqual(samp,rez)
+            for samp, rez in zip(eni, en_range): self.assertAlmostEqual(samp, rez)
 
     def test_late_rebinning(self):
-        run_monitors=CreateSampleWorkspace(Function='Multiple Peaks', NumBanks=4, BankPixelWidth=1, NumEvents=100000, XUnit='Energy',
-                                                     XMin=3, XMax=200, BinWidth=0.1)
-        LoadInstrument(run_monitors,Filename=OLD_MARI_INSTRUMENT_FILEPATH, RewriteSpectraMap=True)
+        run_monitors = CreateSampleWorkspace(Function='Multiple Peaks', NumBanks=4, BankPixelWidth=1, NumEvents=100000,
+                                             XUnit='Energy',
+                                             XMin=3, XMax=200, BinWidth=0.1)
+        LoadInstrument(run_monitors, Filename=OLD_MARI_INSTRUMENT_FILEPATH, RewriteSpectraMap=True)
         ConvertUnits(InputWorkspace='run_monitors', OutputWorkspace='run_monitors', Target='TOF')
         run_monitors = mtd['run_monitors']
         tof = run_monitors.dataX(3)
         tMin = tof[0]
         tMax = tof[-1]
-        run = CreateSampleWorkspace( Function='Multiple Peaks',WorkspaceType='Event',NumBanks=8, BankPixelWidth=1, NumEvents=100000,
-                                    XUnit='TOF',xMin=tMin,xMax=tMax)
-        LoadInstrument(run,Filename=OLD_MARI_INSTRUMENT_FILEPATH, RewriteSpectraMap=True)
+        run = CreateSampleWorkspace(Function='Multiple Peaks', WorkspaceType='Event', NumBanks=8, BankPixelWidth=1,
+                                    NumEvents=100000,
+                                    XUnit='TOF', xMin=tMin, xMax=tMax)
+        LoadInstrument(run, Filename=OLD_MARI_INSTRUMENT_FILEPATH, RewriteSpectraMap=True)
 
         run.setMonitorWorkspace(run_monitors)
 
-        wb_ws   = Rebin(run,Params=[tMin,10,tMax],PreserveEvents=False)
+        wb_ws = Rebin(run, Params=[tMin, 10, tMax], PreserveEvents=False)
 
         # References used to test against ordinary reduction
-        ref_ws = Rebin(run,Params=[tMin,10,tMax],PreserveEvents=False)
+        ref_ws = Rebin(run, Params=[tMin, 10, tMax], PreserveEvents=False)
         ref_ws_monitors = CloneWorkspace('run_monitors')
         ref_ws.setMonitorWorkspace(ref_ws_monitors)
         # just in case, wb should work without clone too.
@@ -302,53 +301,51 @@ class DirectEnergyConversionTest(unittest.TestCase):
 
         # Run Mono
         tReducer = DirectEnergyConversion(run.getInstrument())
-        tReducer.energy_bins =  [-20,0.2,60]
+        tReducer.energy_bins = [-20, 0.2, 60]
         ei_guess = 67.
-        mono_s = tReducer.mono_sample(run, ei_guess,wb_ws)
+        mono_s = tReducer.mono_sample(run, ei_guess, wb_ws)
 
         #
-        mono_ref = tReducer.mono_sample(ref_ws, ei_guess,wb_clone)
+        mono_ref = tReducer.mono_sample(ref_ws, ei_guess, wb_clone)
 
-        rez = CompareWorkspaces(mono_s,mono_ref)
+        rez = CompareWorkspaces(mono_s, mono_ref)
         self.assertTrue(rez[0])
-
 
     def test_tof_range(self):
 
-        run=CreateSampleWorkspace(Function='Multiple Peaks', NumBanks=6, BankPixelWidth=1, NumEvents=10,\
-                                  XUnit='Energy', XMin=5, XMax=75, BinWidth=0.2)
-        LoadInstrument(run,Filename=OLD_MARI_INSTRUMENT_FILEPATH, RewriteSpectraMap=True)
+        run = CreateSampleWorkspace(Function='Multiple Peaks', NumBanks=6, BankPixelWidth=1, NumEvents=10, \
+                                    XUnit='Energy', XMin=5, XMax=75, BinWidth=0.2)
+        LoadInstrument(run, Filename=OLD_MARI_INSTRUMENT_FILEPATH, RewriteSpectraMap=True)
 
         red = DirectEnergyConversion(run.getInstrument())
 
         red.prop_man.incident_energy = 26.2
-        red.prop_man.energy_bins =  [-20,0.1,20]
-        red.prop_man.multirep_tof_specta_list = [4,5,6]
+        red.prop_man.energy_bins = [-20, 0.1, 20]
+        red.prop_man.multirep_tof_specta_list = [4, 5, 6]
         MoveInstrumentComponent(Workspace='run', ComponentName='Detector', DetectorID=1102, Z=3)
-        MoveInstrumentComponent(Workspace='run', ComponentName='Detector', DetectorID=1103,Z=6)
+        MoveInstrumentComponent(Workspace='run', ComponentName='Detector', DetectorID=1103, Z=6)
 
-        run_tof = ConvertUnits(run,Target='TOF',EMode='Elastic')
+        run_tof = ConvertUnits(run, Target='TOF', EMode='Elastic')
 
         tof_range = red.find_tof_range_for_multirep(run_tof)
 
-        self.assertEqual(len(tof_range),3)
+        self.assertEqual(len(tof_range), 3)
 
         x = run_tof.readX(3)
-        dx=abs(x[1:]-x[:-1])
+        dx = abs(x[1:] - x[:-1])
         xMin = min(x)
-        dt   = min(dx)
+        dt = min(dx)
         x = run_tof.readX(5)
         xMax = max(x)
 
-
         self.assertGreater(tof_range[0], xMin)
-        #self.assertAlmostEqual(tof_range[1],dt)
+        # self.assertAlmostEqual(tof_range[1],dt)
         self.assertLess(tof_range[2], xMax)
 
         # check another working mode
         red.prop_man.multirep_tof_specta_list = 4
         red.prop_man.incident_energy = 47.505
-        red.prop_man.energy_bins =  [-20,0.1,45]
+        red.prop_man.energy_bins = [-20, 0.1, 45]
 
         tof_range1 = red.find_tof_range_for_multirep(run_tof)
 
@@ -361,84 +358,83 @@ class DirectEnergyConversionTest(unittest.TestCase):
 
     def test_multirep_mode(self):
         # create test workspace
-        run_monitors=CreateSampleWorkspace(Function='Multiple Peaks', NumBanks=4, BankPixelWidth=1,\
-                                           NumEvents=100000,XUnit='Energy', XMin=3, XMax=200, BinWidth=0.1)
-        LoadInstrument(run_monitors,filename=PRE_2018_MARI_INSTRUMENT_FILEPATH, RewriteSpectraMap=True)
+        run_monitors = CreateSampleWorkspace(Function='Multiple Peaks', NumBanks=4, BankPixelWidth=1, \
+                                             NumEvents=100000, XUnit='Energy', XMin=3, XMax=200, BinWidth=0.1)
+        LoadInstrument(run_monitors, filename=PRE_2018_MARI_INSTRUMENT_FILEPATH, RewriteSpectraMap=True)
         ConvertUnits(InputWorkspace='run_monitors', OutputWorkspace='run_monitors', Target='TOF')
         run_monitors = mtd['run_monitors']
         tof = run_monitors.dataX(3)
         tMin = tof[0]
         tMax = tof[-1]
-        run = CreateSampleWorkspace( Function='Multiple Peaks',WorkspaceType='Event',NumBanks=8, BankPixelWidth=1,\
-                                     NumEvents=100000, XUnit='TOF',xMin=tMin,xMax=tMax)
-        LoadInstrument(run,filename=PRE_2018_MARI_INSTRUMENT_FILEPATH, RewriteSpectraMap=True)
-        MoveInstrumentComponent(Workspace='run', ComponentName='Detector', DetectorID=1102,Z=1)
-       # MoveInstrumentComponent(Workspace='run', ComponentName='Detector', DetectorID=1103,Z=4)
-       # MoveInstrumentComponent(Workspace='run', ComponentName='Detector', DetectorID=1104,Z=5)
+        run = CreateSampleWorkspace(Function='Multiple Peaks', WorkspaceType='Event', NumBanks=8, BankPixelWidth=1, \
+                                    NumEvents=100000, XUnit='TOF', xMin=tMin, xMax=tMax)
+        LoadInstrument(run, filename=PRE_2018_MARI_INSTRUMENT_FILEPATH, RewriteSpectraMap=True)
+        MoveInstrumentComponent(Workspace='run', ComponentName='Detector', DetectorID=1102, Z=1)
+        # MoveInstrumentComponent(Workspace='run', ComponentName='Detector', DetectorID=1103,Z=4)
+        # MoveInstrumentComponent(Workspace='run', ComponentName='Detector', DetectorID=1104,Z=5)
 
         # do second
         run2 = CloneWorkspace(run)
         run2_monitors = CloneWorkspace(run_monitors)
 
-        wb_ws   = Rebin(run,Params=[tMin,1,tMax],PreserveEvents=False)
+        wb_ws = Rebin(run, Params=[tMin, 1, tMax], PreserveEvents=False)
 
         # Run multirep
         tReducer = DirectEnergyConversion(run.getInstrument())
-        tReducer.prop_man.run_diagnostics=True
-        tReducer.hard_mask_file=None
-        tReducer.map_file=None
-        tReducer.save_format=None
-        tReducer.multirep_tof_specta_list = [4,5]
+        tReducer.prop_man.run_diagnostics = True
+        tReducer.hard_mask_file = None
+        tReducer.map_file = None
+        tReducer.save_format = None
+        tReducer.multirep_tof_specta_list = [4, 5]
 
-        result = tReducer.convert_to_energy(wb_ws,run,[67.,122.],[-2,0.02,0.8])
+        result = tReducer.convert_to_energy(wb_ws, run, [67., 122.], [-2, 0.02, 0.8])
 
-        self.assertEqual(len(result),2)
+        self.assertEqual(len(result), 2)
 
-        ws1=result[0]
-        self.assertEqual(ws1.getAxis(0).getUnit().unitID(),'DeltaE')
+        ws1 = result[0]
+        self.assertEqual(ws1.getAxis(0).getUnit().unitID(), 'DeltaE')
         x = ws1.readX(0)
-        self.assertAlmostEqual(x[0],-2*67.)
-        self.assertAlmostEqual(x[-1],0.8*67.)
+        self.assertAlmostEqual(x[0], -2 * 67.)
+        self.assertAlmostEqual(x[-1], 0.8 * 67.)
 
-        ws2=result[1]
-        self.assertEqual(ws2.getAxis(0).getUnit().unitID(),'DeltaE')
+        ws2 = result[1]
+        self.assertEqual(ws2.getAxis(0).getUnit().unitID(), 'DeltaE')
         x = ws2.readX(0)
-        self.assertAlmostEqual(x[0],-2*122.)
-        self.assertAlmostEqual(x[-1],0.8*122.)
+        self.assertAlmostEqual(x[0], -2 * 122.)
+        self.assertAlmostEqual(x[-1], 0.8 * 122.)
 
         # test another ws
         # rename samples from previous workspace to avoid deleting them on current run
-        for ind,item in enumerate(result):
-            result[ind]=RenameWorkspace(item,OutputWorkspace='SampleRez#'+str(ind))
+        for ind, item in enumerate(result):
+            result[ind] = RenameWorkspace(item, OutputWorkspace='SampleRez#' + str(ind))
         #
-        result2 = tReducer.convert_to_energy(None,run2,[67.,122.],[-2,0.02,0.8])
+        result2 = tReducer.convert_to_energy(None, run2, [67., 122.], [-2, 0.02, 0.8])
 
-        rez = CompareWorkspaces(result[0],result2[0])
+        rez = CompareWorkspaces(result[0], result2[0])
         self.assertTrue(rez[0])
-        rez = CompareWorkspaces(result[1],result2[1])
+        rez = CompareWorkspaces(result[1], result2[1])
         self.assertTrue(rez[0])
-
 
     def test_multirep_abs_units_mode(self):
         # create test workspace
-        run_monitors=CreateSampleWorkspace(Function='Multiple Peaks', NumBanks=4, BankPixelWidth=1,\
-                                            NumEvents=100000, XUnit='Energy', XMin=3, XMax=200, BinWidth=0.1)
-        LoadInstrument(run_monitors,filename=PRE_2018_MARI_INSTRUMENT_FILEPATH, RewriteSpectraMap=True)
+        run_monitors = CreateSampleWorkspace(Function='Multiple Peaks', NumBanks=4, BankPixelWidth=1, \
+                                             NumEvents=100000, XUnit='Energy', XMin=3, XMax=200, BinWidth=0.1)
+        LoadInstrument(run_monitors, filename=PRE_2018_MARI_INSTRUMENT_FILEPATH, RewriteSpectraMap=True)
         ConvertUnits(InputWorkspace='run_monitors', OutputWorkspace='run_monitors', Target='TOF')
         run_monitors = mtd['run_monitors']
         tof = run_monitors.dataX(3)
         tMin = tof[0]
         tMax = tof[-1]
-        run = CreateSampleWorkspace( Function='Multiple Peaks',WorkspaceType='Event',NumBanks=8, BankPixelWidth=1,\
-                                     NumEvents=100000, XUnit='TOF',xMin=tMin,xMax=tMax)
-        LoadInstrument(run,filename=PRE_2018_MARI_INSTRUMENT_FILEPATH, RewriteSpectraMap=True)
+        run = CreateSampleWorkspace(Function='Multiple Peaks', WorkspaceType='Event', NumBanks=8, BankPixelWidth=1, \
+                                    NumEvents=100000, XUnit='TOF', xMin=tMin, xMax=tMax)
+        LoadInstrument(run, filename=PRE_2018_MARI_INSTRUMENT_FILEPATH, RewriteSpectraMap=True)
 
         # build "monovanadium"
         mono = CloneWorkspace(run)
         mono_monitors = CloneWorkspace(run_monitors)
 
         # build "White-beam"
-        wb_ws   = Rebin(run,Params=[tMin,1,tMax],PreserveEvents=False)
+        wb_ws = Rebin(run, Params=[tMin, 1, tMax], PreserveEvents=False)
 
         # build "second run" to ensure repeated execution
         run2 = CloneWorkspace(run)
@@ -446,58 +442,57 @@ class DirectEnergyConversionTest(unittest.TestCase):
 
         # Run multirep
         tReducer = DirectEnergyConversion(run.getInstrument())
-        tReducer.prop_man.run_diagnostics=True
-        tReducer.hard_mask_file=None
-        tReducer.map_file=None
-        tReducer.prop_man.background_range=[0.99*tMax,tMax]
-        tReducer.prop_man.monovan_mapfile=None
-        tReducer.save_format=None
-        tReducer.prop_man.normalise_method='monitor-1'
-        tReducer.norm_mon_integration_range=[tMin,tMax]
+        tReducer.prop_man.run_diagnostics = True
+        tReducer.hard_mask_file = None
+        tReducer.map_file = None
+        tReducer.prop_man.background_range = [0.99 * tMax, tMax]
+        tReducer.prop_man.monovan_mapfile = None
+        tReducer.save_format = None
+        tReducer.prop_man.normalise_method = 'monitor-1'
+        tReducer.norm_mon_integration_range = [tMin, tMax]
 
+        result = tReducer.convert_to_energy(wb_ws, run, [67., 122.], [-2, 0.02, 0.8], None, mono)
 
-        result = tReducer.convert_to_energy(wb_ws,run,[67.,122.],[-2,0.02,0.8],None,mono)
+        self.assertEqual(len(result), 2)
 
-        self.assertEqual(len(result),2)
-
-        ws1=result[0]
-        self.assertEqual(ws1.getAxis(0).getUnit().unitID(),'DeltaE')
+        ws1 = result[0]
+        self.assertEqual(ws1.getAxis(0).getUnit().unitID(), 'DeltaE')
         x = ws1.readX(0)
-        self.assertAlmostEqual(x[0],-2*67.)
-        self.assertAlmostEqual(x[-1],0.8*67.)
+        self.assertAlmostEqual(x[0], -2 * 67.)
+        self.assertAlmostEqual(x[-1], 0.8 * 67.)
 
-        ws2=result[1]
-        self.assertEqual(ws2.getAxis(0).getUnit().unitID(),'DeltaE')
+        ws2 = result[1]
+        self.assertEqual(ws2.getAxis(0).getUnit().unitID(), 'DeltaE')
         x = ws2.readX(0)
-        self.assertAlmostEqual(x[0],-2*122.)
-        self.assertAlmostEqual(x[-1],0.8*122.)
+        self.assertAlmostEqual(x[0], -2 * 122.)
+        self.assertAlmostEqual(x[-1], 0.8 * 122.)
 
         # test another ws
         # rename samples from previous workspace to avoid deleting them on current run
-        for ind,item in enumerate(result):
-            result[ind]=RenameWorkspace(item,OutputWorkspace='SampleRez#'+str(ind))
+        for ind, item in enumerate(result):
+            result[ind] = RenameWorkspace(item, OutputWorkspace='SampleRez#' + str(ind))
         #
-        result2 = tReducer.convert_to_energy(None,run2)
+        result2 = tReducer.convert_to_energy(None, run2)
 
-        rez = CompareWorkspaces(result[0],result2[0])
+        rez = CompareWorkspaces(result[0], result2[0])
         self.assertTrue(rez[0])
-        rez = CompareWorkspaces(result[1],result2[1])
+        rez = CompareWorkspaces(result[1], result2[1])
         self.assertTrue(rez[0])
 
     def test_abs_multirep_with_bkg_and_bleed(self):
         # create test workspace
-        run_monitors=CreateSampleWorkspace(Function='Multiple Peaks', NumBanks=4, BankPixelWidth=1,\
-                                            NumEvents=100000, XUnit='Energy', XMin=3, XMax=200, BinWidth=0.1)
-        LoadInstrument(run_monitors,filename=PRE_2018_MARI_INSTRUMENT_FILEPATH, RewriteSpectraMap=True)
+        run_monitors = CreateSampleWorkspace(Function='Multiple Peaks', NumBanks=4, BankPixelWidth=1, \
+                                             NumEvents=100000, XUnit='Energy', XMin=3, XMax=200, BinWidth=0.1)
+        LoadInstrument(run_monitors, filename=PRE_2018_MARI_INSTRUMENT_FILEPATH, RewriteSpectraMap=True)
         ConvertUnits(InputWorkspace='run_monitors', OutputWorkspace='run_monitors', Target='TOF')
         run_monitors = mtd['run_monitors']
         tof = run_monitors.dataX(3)
         tMin = tof[0]
         tMax = tof[-1]
-        run = CreateSampleWorkspace( Function='Multiple Peaks',WorkspaceType='Event',NumBanks=8, BankPixelWidth=1,\
-                                     NumEvents=100000, XUnit='TOF',xMin=tMin,xMax=tMax)
-        LoadInstrument(run,filename=PRE_2018_MARI_INSTRUMENT_FILEPATH, RewriteSpectraMap=True)
-        AddSampleLog(run,LogName='gd_prtn_chrg',LogText='1.',LogType='Number')
+        run = CreateSampleWorkspace(Function='Multiple Peaks', WorkspaceType='Event', NumBanks=8, BankPixelWidth=1, \
+                                    NumEvents=100000, XUnit='TOF', xMin=tMin, xMax=tMax)
+        LoadInstrument(run, filename=PRE_2018_MARI_INSTRUMENT_FILEPATH, RewriteSpectraMap=True)
+        AddSampleLog(run, LogName='gd_prtn_chrg', LogText='1.', LogType='Number')
         run.setMonitorWorkspace(run_monitors)
 
         # build "monovanadium"
@@ -506,7 +501,7 @@ class DirectEnergyConversionTest(unittest.TestCase):
         mono.setMonitorWorkspace(mono_monitors)
 
         # build "White-beam"
-        wb_ws   = Rebin(run,Params=[tMin,1,tMax],PreserveEvents=False)
+        wb_ws = Rebin(run, Params=[tMin, 1, tMax], PreserveEvents=False)
 
         # build "second run" to ensure repeated execution
         run2 = CloneWorkspace(run)
@@ -515,61 +510,61 @@ class DirectEnergyConversionTest(unittest.TestCase):
 
         # Run multirep
         tReducer = DirectEnergyConversion(run.getInstrument())
-        tReducer.prop_man.run_diagnostics=True
-        tReducer.hard_mask_file=None
-        tReducer.map_file=None
+        tReducer.prop_man.run_diagnostics = True
+        tReducer.hard_mask_file = None
+        tReducer.map_file = None
         tReducer.prop_man.check_background = True
-        tReducer.prop_man.background_range=[0.99*tMax,tMax]
-        tReducer.prop_man.monovan_mapfile=None
-        tReducer.save_format=None
-        tReducer.prop_man.normalise_method='monitor-2'
+        tReducer.prop_man.background_range = [0.99 * tMax, tMax]
+        tReducer.prop_man.monovan_mapfile = None
+        tReducer.save_format = None
+        tReducer.prop_man.normalise_method = 'monitor-2'
 
         tReducer.prop_man.bleed = True
-        tReducer.norm_mon_integration_range=[tMin,tMax]
+        tReducer.norm_mon_integration_range = [tMin, tMax]
 
-        AddSampleLog(run,LogName='good_frames',LogText='1.',LogType='Number Series')
-        result = tReducer.convert_to_energy(wb_ws,run,[67.,122.],[-2,0.02,0.8],None,mono)
+        AddSampleLog(run, LogName='good_frames', LogText='1.', LogType='Number Series')
+        result = tReducer.convert_to_energy(wb_ws, run, [67., 122.], [-2, 0.02, 0.8], None, mono)
 
-        self.assertEqual(len(result),2)
+        self.assertEqual(len(result), 2)
 
-        ws1=result[0]
-        self.assertEqual(ws1.getAxis(0).getUnit().unitID(),'DeltaE')
+        ws1 = result[0]
+        self.assertEqual(ws1.getAxis(0).getUnit().unitID(), 'DeltaE')
         x = ws1.readX(0)
-        self.assertAlmostEqual(x[0],-2*67.)
-        self.assertAlmostEqual(x[-1],0.8*67.)
+        self.assertAlmostEqual(x[0], -2 * 67.)
+        self.assertAlmostEqual(x[-1], 0.8 * 67.)
 
-        ws2=result[1]
-        self.assertEqual(ws2.getAxis(0).getUnit().unitID(),'DeltaE')
+        ws2 = result[1]
+        self.assertEqual(ws2.getAxis(0).getUnit().unitID(), 'DeltaE')
         x = ws2.readX(0)
-        self.assertAlmostEqual(x[0],-2*122.)
-        self.assertAlmostEqual(x[-1],0.8*122.)
+        self.assertAlmostEqual(x[0], -2 * 122.)
+        self.assertAlmostEqual(x[-1], 0.8 * 122.)
 
         # test another ws
         # rename samples from previous workspace to avoid deleting them on current run
-        for ind,item in enumerate(result):
-            result[ind]=RenameWorkspace(item,OutputWorkspace='SampleRez#'+str(ind))
+        for ind, item in enumerate(result):
+            result[ind] = RenameWorkspace(item, OutputWorkspace='SampleRez#' + str(ind))
         #
-        AddSampleLog(run2,LogName='goodfrm',LogText='1',LogType='Number')
-        result2 = tReducer.convert_to_energy(None,run2)
+        AddSampleLog(run2, LogName='goodfrm', LogText='1', LogType='Number')
+        result2 = tReducer.convert_to_energy(None, run2)
 
-        rez = CompareWorkspaces(result[0],result2[0])
+        rez = CompareWorkspaces(result[0], result2[0])
         self.assertTrue(rez[0])
-        rez = CompareWorkspaces(result[1],result2[1])
+        rez = CompareWorkspaces(result[1], result2[1])
         self.assertTrue(rez[0])
 
     def test_sum_monitors(self):
         # create test workspace
-        monitor_ws=CreateSampleWorkspace(Function='Multiple Peaks', NumBanks=6, BankPixelWidth=1,\
-                                            NumEvents=100000, XUnit='Energy', XMin=3, XMax=200, BinWidth=0.1)
+        monitor_ws = CreateSampleWorkspace(Function='Multiple Peaks', NumBanks=6, BankPixelWidth=1, \
+                                           NumEvents=100000, XUnit='Energy', XMin=3, XMax=200, BinWidth=0.1)
         ConvertUnits(InputWorkspace=monitor_ws, OutputWorkspace='monitor_ws', Target='TOF')
 
         # Rebin to "formally" make common bin boundaries as it is not considered as such
-        #any more after converting units (Is this a bug?)
+        # any more after converting units (Is this a bug?)
         xx = monitor_ws.readX(0)
-        x_min = min(xx[0],xx[-1])
-        x_max= max(xx[0],xx[-1])
-        x_step = (x_max-x_min)/(len(xx)-1)
-        monitor_ws = Rebin(monitor_ws,Params=[x_min,x_step,x_max])
+        x_min = min(xx[0], xx[-1])
+        x_max = max(xx[0], xx[-1])
+        x_step = (x_max - x_min) / (len(xx) - 1)
+        monitor_ws = Rebin(monitor_ws, Params=[x_min, x_step, x_max])
         monitor_ws = mtd['monitor_ws']
         #
         # keep this workspace for second test below -- clone and give
@@ -578,48 +573,46 @@ class DirectEnergyConversionTest(unittest.TestCase):
         _TMPmonitor_ws_monitors = CloneWorkspace(monitor_ws)
 
         # Estimate energy from two monitors
-        ei,mon1_peak,mon1_index,tzero = \
-            GetEi(InputWorkspace=monitor_ws, Monitor1Spec=1,Monitor2Spec=4,
-                  EnergyEstimate=62.2,FixEi=False)
-        self.assertAlmostEqual(ei,62.1449,3)
+        ei, mon1_peak, mon1_index, tzero = \
+            GetEi(InputWorkspace=monitor_ws, Monitor1Spec=1, Monitor2Spec=4,
+                  EnergyEstimate=62.2, FixEi=False)
+        self.assertAlmostEqual(ei, 62.1449, 3)
 
         # Provide instrument parameter, necessary to define
         # DirectEnergyConversion class properly
-        SetInstrumentParameter(monitor_ws,ParameterName='fix_ei',ParameterType='Number',Value='0')
-        SetInstrumentParameter(monitor_ws,DetectorList=[1,2,3,6],ParameterName='DelayTime',\
-                               ParameterType='Number',Value='0.5')
-        SetInstrumentParameter(monitor_ws,ParameterName='mon2_norm_spec',\
-                               ParameterType='Number',Value='1')
+        SetInstrumentParameter(monitor_ws, ParameterName='fix_ei', ParameterType='Number', Value='0')
+        SetInstrumentParameter(monitor_ws, DetectorList=[1, 2, 3, 6], ParameterName='DelayTime', \
+                               ParameterType='Number', Value='0.5')
+        SetInstrumentParameter(monitor_ws, ParameterName='mon2_norm_spec', \
+                               ParameterType='Number', Value='1')
 
         # initiate test reducer
         tReducer = DirectEnergyConversion(monitor_ws.getInstrument())
-        tReducer.prop_man.ei_mon_spectra= ([1,2,3],6)
+        tReducer.prop_man.ei_mon_spectra = ([1, 2, 3], 6)
         tReducer.prop_man.normalise_method = 'current'
         tReducer.prop_man.mon2_norm_spec = 2
-        ei_mon_spectra  = tReducer.prop_man.ei_mon_spectra
-        ei_mon_spectra,monitor_ws  = tReducer.sum_monitors_spectra(monitor_ws,ei_mon_spectra)
+        ei_mon_spectra = tReducer.prop_man.ei_mon_spectra
+        ei_mon_spectra, monitor_ws = tReducer.sum_monitors_spectra(monitor_ws, ei_mon_spectra)
         #
         # Check GetEi with summed monitors. Try to run separately.
-        ei1,mon1_peak,mon1_index,tzero = \
-            GetEi(InputWorkspace=monitor_ws, Monitor1Spec=1,Monitor2Spec=6,
-                  EnergyEstimate=62.2,FixEi=False)
-        self.assertAlmostEqual(ei1,ei,2)
+        ei1, mon1_peak, mon1_index, tzero = \
+            GetEi(InputWorkspace=monitor_ws, Monitor1Spec=1, Monitor2Spec=6,
+                  EnergyEstimate=62.2, FixEi=False)
+        self.assertAlmostEqual(ei1, ei, 2)
 
         # Second test Check get_ei as part of the reduction
-        tReducer.prop_man.ei_mon_spectra= ([1,2,3],[4,5,6])
+        tReducer.prop_man.ei_mon_spectra = ([1, 2, 3], [4, 5, 6])
         tReducer.prop_man.fix_ei = False
         # DataWorkspace == monitor_ws data workspace is not used anyway. The only thing we
         # use it for is to retrieve monitor workspace from Mantid using its name
-        ei2,mon1_peak2=tReducer.get_ei(monitor_ws,62.2)
-        self.assertAlmostEqual(ei2,64.95,2)
+        ei2, mon1_peak2 = tReducer.get_ei(monitor_ws, 62.2)
+        self.assertAlmostEqual(ei2, 64.95, 2)
 
-        ei2b,mon1_peak2=tReducer.get_ei(monitor_ws,62.2)
-        self.assertAlmostEqual(ei2b,64.95,2)
-
-
+        ei2b, mon1_peak2 = tReducer.get_ei(monitor_ws, 62.2)
+        self.assertAlmostEqual(ei2b, 64.95, 2)
 
 
-if __name__=="__main__":
-   #test = DirectEnergyConversionTest('test_sum_monitors')
-   #test.run()
-   unittest.main()
+if __name__ == "__main__":
+    # test = DirectEnergyConversionTest('test_sum_monitors')
+    # test.run()
+    unittest.main()


### PR DESCRIPTION
For the old Mari definition we are missing a definiton for one of the monitors.  
This adds it in, using the location extracted from the RAW file using LoadInstrumentFromRaw.

This will only affect files before July 2017 as newer ones use another definition, and it does not have this monitor after those changes.

**To test:**
1. Start Mantid workbench,
1. Load MAR11060 (in test data)
1. Right click show detectors, sp 4 shold be a monitor
   ![image](https://user-images.githubusercontent.com/1017173/85011380-55eca800-b159-11ea-8ac6-12067c5b9643.png)
1.  right click and plot a colour fill plot, this spectra should not mess up the colour range so the image should look like this.
![image](https://user-images.githubusercontent.com/1017173/85011507-83d1ec80-b159-11ea-88d8-67488b4238f1.png)


This fine to merge, there are no associated code changes

Fixes #28845


---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
