### PR TITLE
Make right-click while using zoom tool reset axes limits

### DIFF
--- a/docs/source/release/v5.1.0/mantidworkbench.rst
+++ b/docs/source/release/v5.1.0/mantidworkbench.rst
@@ -70,6 +70,7 @@ Improvements
 - When choosing a marker in the figure options, if one of the marker colours would not be used that selection is disabled.
 - Added an option to set the default ```drawstyle``` within the workbench settings window. Additionally, the ```linestyle``` can now be set to 'None'.
 - Added an option to matrix workspaces to export bins and spectra to a table workspace.
+- Right-clicking a plot without dragging while using the zoom tool now resets the axes limits.
 
 Bugfixes
 ########

--- a/qt/applications/workbench/workbench/plotting/figureinteraction.py
+++ b/qt/applications/workbench/workbench/plotting/figureinteraction.py
@@ -170,6 +170,9 @@ class FigureInteraction(object):
                     self.canvas.toolbar.release_pan(event)
                 finally:
                     event.button = 3
+        elif event.button == self.canvas.buttond.get(Qt.RightButton) and self.toolbar_manager.is_zoom_active():
+            # Reset the axes limits if you right click while using the zoom tool.
+            self.toolbar_manager.emit_sig_home_clicked()
 
         if self.toolbar_manager.is_tool_active():
             for marker in self.markers:


### PR DESCRIPTION
Report to: SANS group / Rob Dalgliesh

**Description of work.**
Previously, having the zoom tool active on a plot had the following behaviours:
- left click and drag: zoom in
- right click and drag: zoom out

This PR adds:
- right click without drag: reset axes limits (same as pressing the home button)

**To test:**
Make a plot.
Click the zoom tool in the toolbar.
Zoom in or out.
Right-click and check that the axes limits reset.

Fixes #28610 

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
