### PR TITLE
Add fit to auto-generation scripts in Workbench

### DIFF
--- a/docs/source/release/v5.1.0/mantidworkbench.rst
+++ b/docs/source/release/v5.1.0/mantidworkbench.rst
@@ -23,6 +23,7 @@ Improvements
 - When you stop a script running in workbench it will now automatically attempt to cancel the algorithm the script is running, rather than wait for the current algorthm to end.
   This is similar to what Mantidplot does, and should result in the script stopping much sooner.
 - The ``Python extensions directory`` setting from MantidPlot is now available in Workbench within the Manage User Directories window.
+- The script generation functionality attached to workbench plots will now include fitting code if the user has performed a fit.
 
 .. figure:: ../../images/wb_invalid_log_shading.png
    :align: right

--- a/qt/applications/workbench/CMakeLists.txt
+++ b/qt/applications/workbench/CMakeLists.txt
@@ -78,6 +78,7 @@ set(TEST_FILES
     workbench/plotting/plotscriptgenerator/test/test_plotscriptgeneratorfigure.py
     workbench/plotting/plotscriptgenerator/test/test_plotscriptgeneratorlines.py
     workbench/plotting/plotscriptgenerator/test/test_plotscriptgeneratorutils.py
+    workbench/plotting/plotscriptgenerator/test/test_plotscriptgeneratorfitting.py
     workbench/plotting/plotscriptgenerator/test/test_plotscriptgenerator.py
     workbench/plotting/test/test_figureerrorsmanager.py
     workbench/plotting/test/test_figureinteraction.py

--- a/qt/applications/workbench/workbench/plotting/plotscriptgenerator/__init__.py
+++ b/qt/applications/workbench/workbench/plotting/plotscriptgenerator/__init__.py
@@ -7,9 +7,9 @@
 #  This file is part of the mantid workbench.
 
 from mantid.plots.mantidaxes import MantidAxes
-
 from mantidqt.widgets.plotconfigdialog import curve_in_ax
 from matplotlib.legend import Legend
+
 from workbench.config import DEFAULT_SCRIPT_CONTENT
 from workbench.plotting.plotscriptgenerator.axes import (generate_axis_limit_commands,
                                                          generate_axis_label_commands,
@@ -19,6 +19,7 @@ from workbench.plotting.plotscriptgenerator.figure import generate_subplots_comm
 from workbench.plotting.plotscriptgenerator.lines import generate_plot_command
 from workbench.plotting.plotscriptgenerator.colorfills import generate_plot_2d_command
 from workbench.plotting.plotscriptgenerator.utils import generate_workspace_retrieval_commands, sorted_lines_in
+from workbench.plotting.plotscriptgenerator.fitting import get_fit_cmds
 from mantidqt.plotting.figuretype import FigureType, axes_type
 
 FIG_VARIABLE = "fig"
@@ -75,9 +76,15 @@ def generate_script(fig, exclude_headers=False):
     if not plot_commands:
         return
 
+    fit_commands, fit_headers = get_fit_cmds(fig)
+
     cmds = [] if exclude_headers else [DEFAULT_SCRIPT_CONTENT]
+    if exclude_headers and fit_headers:
+        cmds.extend(fit_headers)
     if plot_headers:
         cmds.extend(plot_headers)
+    if fit_commands:
+        cmds.extend(fit_commands + [''])
     cmds.extend(generate_workspace_retrieval_commands(fig) + [''])
     cmds.append("{}, {} = {}".format(FIG_VARIABLE, AXES_VARIABLE, generate_subplots_command(fig)))
     cmds.extend(plot_commands)

--- a/qt/applications/workbench/workbench/plotting/plotscriptgenerator/__init__.py
+++ b/qt/applications/workbench/workbench/plotting/plotscriptgenerator/__init__.py
@@ -28,6 +28,8 @@ if hasattr(Legend, "set_draggable"):
     SET_DRAGGABLE_METHOD = "set_draggable(True)"
 else:
     SET_DRAGGABLE_METHOD = "draggable()"
+FIT_DOCUMENTATION_STRING = "# Fit definition, see https://docs.mantidproject.org/algorithms/Fit-v1.html for more " \
+                           "details"
 
 
 def generate_script(fig, exclude_headers=False):
@@ -84,6 +86,7 @@ def generate_script(fig, exclude_headers=False):
     if plot_headers:
         cmds.extend(plot_headers)
     if fit_commands:
+        cmds.append(FIT_DOCUMENTATION_STRING)
         cmds.extend(fit_commands + [''])
     cmds.extend(generate_workspace_retrieval_commands(fig) + [''])
     cmds.append("{}, {} = {}".format(FIG_VARIABLE, AXES_VARIABLE, generate_subplots_command(fig)))

--- a/qt/applications/workbench/workbench/plotting/plotscriptgenerator/fitting.py
+++ b/qt/applications/workbench/workbench/plotting/plotscriptgenerator/fitting.py
@@ -1,0 +1,55 @@
+# Mantid Repository : https://github.com/mantidproject/mantid
+#
+# Copyright &copy; 2020 ISIS Rutherford Appleton Laboratory UKRI,
+#   NScD Oak Ridge National Laboratory, European Spallation Source,
+#   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+# SPDX - License - Identifier: GPL - 3.0 +
+#  This file is part of the mantid workbench.
+import json
+
+BASE_FIT_COMMAND = "Fit"
+BASE_FIT_INCLUDE = 'from mantid.simpleapi import Fit'
+
+FIT_COMMANDS_ORDER = {"Function": 1, "InputWorkspace": 2, "WorkspaceIndex": 3, "Output": 4, "StartX": 5, "EndX": 6}
+
+
+def get_fit_cmds(fig):
+    if not hasattr(fig.canvas.manager, 'fit_browser'):
+        return
+    cmds = []
+    fit_headers = [BASE_FIT_INCLUDE]
+    fit_browser = fig.canvas.manager.fit_browser
+    if fit_browser.fit_result_ws_name:
+        fit_parameters = json.loads(fit_browser.getFitAlgorithmParameters())
+        # Fit parameters is a Json object with the following entries
+        # {name: 'algorithm', properties: {json object containing all the properties of the alg'}
+        cmds.extend(_get_fit_variable_assigment_commands(fit_parameters['properties']))
+        cmds.append(_get_fit_call_command(fit_parameters['properties']))
+        return cmds, fit_headers
+    else:
+        return [], []
+
+
+def _get_fit_variable_assignment_command(fit_property, property_value):
+    if type(property_value) == str:
+        return "{}=\"{}\"".format(fit_property, property_value)
+    elif type(property_value) == float:
+        return "{0}={1:.5f}".format(fit_property, property_value)
+    else:
+        return "{}={}".format(fit_property, property_value)
+
+
+def _get_fit_variable_assigment_commands(fit_properties):
+    cmds = []
+    for fit_property in fit_properties:
+        cmds.append(_get_fit_variable_assignment_command(fit_property, fit_properties[fit_property]))
+    cmds.sort(key=lambda x: FIT_COMMANDS_ORDER[x.split('=')[0]] if x.split('=')[0] in FIT_COMMANDS_ORDER else 999)
+    return cmds
+
+
+def _get_fit_call_command(fit_properties):
+    fit_argument_list = []
+    for fit_property in fit_properties:
+        fit_argument_list.append("{}={}".format(fit_property, fit_property))
+    fit_command = "{}({})".format(BASE_FIT_COMMAND, ",".join(fit_argument_list))
+    return fit_command

--- a/qt/applications/workbench/workbench/plotting/plotscriptgenerator/fitting.py
+++ b/qt/applications/workbench/workbench/plotting/plotscriptgenerator/fitting.py
@@ -15,7 +15,7 @@ FIT_COMMANDS_ORDER = {"Function": 1, "InputWorkspace": 2, "WorkspaceIndex": 3, "
 
 def get_fit_cmds(fig):
     if not hasattr(fig.canvas.manager, 'fit_browser'):
-        return
+        return [], []
     cmds = []
     fit_headers = [BASE_FIT_INCLUDE]
     fit_browser = fig.canvas.manager.fit_browser

--- a/qt/applications/workbench/workbench/plotting/plotscriptgenerator/test/test_plotscriptgenerator.py
+++ b/qt/applications/workbench/workbench/plotting/plotscriptgenerator/test/test_plotscriptgenerator.py
@@ -47,6 +47,7 @@ SAMPLE_SCRIPT = ("import matplotlib.pyplot as plt\n"
 
 SAMPLE_SCRIPT_WITH_FIT = ("from mantid.simpleapi import Fit\n"
                           "import matplotlib.pyplot as plt\n"
+                          "# Fit definition, see https://docs.mantidproject.org/algorithms/Fit-v1.html for more details\n"
                           "Function=\"GaussOsc\"\n"
                           "InputWorkspace=\"TestWorkspace\"\n"
                           "Output=\"TestOutput\"\n"

--- a/qt/applications/workbench/workbench/plotting/plotscriptgenerator/test/test_plotscriptgenerator.py
+++ b/qt/applications/workbench/workbench/plotting/plotscriptgenerator/test/test_plotscriptgenerator.py
@@ -9,6 +9,7 @@
 import unittest
 
 import matplotlib
+
 matplotlib.use("Agg")  # noqa
 from matplotlib.axes import Axes
 from matplotlib.legend import Legend
@@ -23,6 +24,7 @@ GEN_PLOT_CMDS = 'workbench.plotting.plotscriptgenerator.generate_plot_command'
 GEN_SUBPLOTS_CMD = 'workbench.plotting.plotscriptgenerator.generate_subplots_command'
 GEN_AXIS_LIMIT_CMDS = 'workbench.plotting.plotscriptgenerator.generate_axis_limit_commands'
 GET_AUTOSCALE_LIMITS = 'workbench.plotting.plotscriptgenerator.axes.get_autoscale_limits'
+GET_FIT_COMMANDS = 'workbench.plotting.plotscriptgenerator.get_fit_cmds'
 
 SAMPLE_SCRIPT = ("import matplotlib.pyplot as plt\n"
                  "from mantid.api import AnalysisDataService\n"
@@ -43,6 +45,31 @@ SAMPLE_SCRIPT = ("import matplotlib.pyplot as plt\n"
                  "\n"
                  "# Scripting Plots in Mantid: https://docs.mantidproject.org/nightly/plotting/scripting_plots.html")
 
+SAMPLE_SCRIPT_WITH_FIT = ("from mantid.simpleapi import Fit\n"
+                          "import matplotlib.pyplot as plt\n"
+                          "Function=\"GaussOsc\"\n"
+                          "InputWorkspace=\"TestWorkspace\"\n"
+                          "Output=\"TestOutput\"\n"
+                          "Fit(Function=Function, InputWorkspace=InputWorkspace, Output=Output)\n"
+                          "\n"
+                          "from mantid.api import AnalysisDataService\n"
+                          "\n"
+                          "ADS.retrieve(...)\n"
+                          "\n"
+                          "fig, axes = plt.subplots(...)\n"
+                          "axes[0].plot(...)\n"
+                          "axes[0].plot(...)\n"
+                          "axes[0].set_xlim(...)\n"
+                          "axes[0].set_ylim(...)\n"
+                          "\n"
+                          "axes[1].plot(...)\n"
+                          "axes[1].set_xlim(...)\n"
+                          "axes[1].set_ylim(...)\n"
+                          "\n"
+                          "plt.show()"
+                          "\n"
+                          "# Scripting Plots in Mantid: https://docs.mantidproject.org/nightly/plotting/scripting_plots.html")
+
 
 class PlotScriptGeneratorTest(unittest.TestCase):
 
@@ -59,6 +86,10 @@ class PlotScriptGeneratorTest(unittest.TestCase):
         cls.subplots_cmd = "plt.subplots(...)"
         cls.plot_cmd = "plot(...)"
         cls.ax_limit_cmds = ['set_xlim(...)', 'set_ylim(...)']
+        cls.fit_cmds = ["Function=\"GaussOsc\"", "InputWorkspace=\"TestWorkspace\"",
+                        "Output=\"TestOutput\"",
+                        "Fit(Function=Function, InputWorkspace=InputWorkspace, Output=Output)"]
+        cls.fit_header = ["from mantid.simpleapi import Fit"]
 
     def _gen_mock_axes(self, **kwargs):
         mock_kwargs = {
@@ -109,7 +140,8 @@ class PlotScriptGeneratorTest(unittest.TestCase):
                                          get_lines=lambda: [None],
                                          numRows=1, numCols=2, colNum=1)
         mock_fig = Mock(get_axes=lambda: [mock_axes1, mock_axes2],
-                        axes= [mock_axes1, mock_axes2])
+                        axes=[mock_axes1, mock_axes2])
+        mock_fig.canvas.manager.fit_browser.fit_result_ws_name = ""
 
         output_script = generate_script(mock_fig, exclude_headers=True)
         self.assertEqual(SAMPLE_SCRIPT, output_script)
@@ -128,6 +160,7 @@ class PlotScriptGeneratorTest(unittest.TestCase):
 
         mock_ax = self._gen_mock_axes(legend_=True)
         mock_fig = Mock(get_axes=lambda: [mock_ax])
+        mock_fig.canvas.manager.fit_browser.fit_result_ws_name = ""
         if hasattr(Legend, "set_draggable"):
             self.assertIn('.legend().set_draggable(True)', generate_script(mock_fig))
         else:
@@ -146,7 +179,40 @@ class PlotScriptGeneratorTest(unittest.TestCase):
         mock_autoscale_lims.return_value = (-0.02, 1.02)
 
         mock_fig = Mock(get_axes=lambda: [self._gen_mock_axes()])
+        mock_fig.canvas.manager.fit_browser.fit_result_ws_name = ""
         self.assertNotIn('.legend()', generate_script(mock_fig))
+
+    @patch(GET_FIT_COMMANDS)
+    @patch(GET_AUTOSCALE_LIMITS)
+    @patch(GEN_AXIS_LIMIT_CMDS)
+    @patch(GEN_WS_RETRIEVAL_CMDS)
+    @patch(GEN_PLOT_CMDS)
+    @patch(GEN_SUBPLOTS_CMD)
+    def test_generate_script_compiles_script_correctly_with_fit(self, mock_subplots_cmd,
+                                                                mock_plot_cmd, mock_retrieval_cmd,
+                                                                mock_axis_lim_cmd,
+                                                                mock_autoscale_lims,
+                                                                mock_fit_cmds):
+
+        mock_retrieval_cmd.return_value = self.retrieval_cmds
+        mock_subplots_cmd.return_value = self.subplots_cmd
+        mock_plot_cmd.return_value = self.plot_cmd
+        mock_axis_lim_cmd.return_value = self.ax_limit_cmds
+        mock_autoscale_lims.return_value = (-0.02, 1.02)
+        mock_fit_cmds.return_value = self.fit_cmds, self.fit_header
+
+        mock_axes1 = self._gen_mock_axes(get_tracked_artists=lambda: [None, None],
+                                         get_lines=lambda: [None, None],
+                                         numRows=1, numCols=2, colNum=0)
+        mock_axes2 = self._gen_mock_axes(get_tracked_artists=lambda: [None],
+                                         get_lines=lambda: [None],
+                                         numRows=1, numCols=2, colNum=1)
+        mock_fig = Mock(get_axes=lambda: [mock_axes1, mock_axes2],
+                        axes=[mock_axes1, mock_axes2])
+        mock_fig.canvas.manager.fit_browser.fit_result_ws_name = "OutputWorkspace"
+
+        output_script = generate_script(mock_fig, exclude_headers=True)
+        self.assertEqual(SAMPLE_SCRIPT_WITH_FIT, output_script)
 
 
 if __name__ == '__main__':

--- a/qt/applications/workbench/workbench/plotting/plotscriptgenerator/test/test_plotscriptgeneratorfitting.py
+++ b/qt/applications/workbench/workbench/plotting/plotscriptgenerator/test/test_plotscriptgeneratorfitting.py
@@ -45,11 +45,15 @@ class PlotScriptGeneratorFittingTest(unittest.TestCase):
         self.assertEqual(commands, [])
         self.assertEqual(headers, [])
 
-    def test_returns_if_no_fit_browser(self):
+    def test_returns_empty_commands_if_no_fit_browser(self):
         mock_fig = Mock()
         # Figure manager base has no fit browser
         mock_fig.canvas.manager = Mock(spec=FigureManagerBase)
-        self.assertEqual(None, get_fit_cmds(mock_fig))
+
+        commands, headers = get_fit_cmds(mock_fig)
+
+        self.assertEqual(commands, [])
+        self.assertEqual(headers, [])
 
     def test_get_fit_cmds_returns_expected_commands(self):
         self.mock_browser.fit_result_ws_name = "TestWorkspace"

--- a/qt/applications/workbench/workbench/plotting/plotscriptgenerator/test/test_plotscriptgeneratorfitting.py
+++ b/qt/applications/workbench/workbench/plotting/plotscriptgenerator/test/test_plotscriptgeneratorfitting.py
@@ -1,0 +1,98 @@
+# Mantid Repository : https://github.com/mantidproject/mantid
+#
+# Copyright &copy; 2020 ISIS Rutherford Appleton Laboratory UKRI,
+#   NScD Oak Ridge National Laboratory, European Spallation Source,
+#   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+# SPDX - License - Identifier: GPL - 3.0 +
+#  This file is part of the mantid workbench.
+import ast
+import re
+import json
+import unittest
+from unittest.mock import Mock
+
+from matplotlib.backend_bases import FigureManagerBase
+
+from mantidqt.widgets.fitpropertybrowser import FitPropertyBrowser
+from workbench.plotting.plotscriptgenerator.fitting import get_fit_cmds, BASE_FIT_COMMAND, BASE_FIT_INCLUDE
+
+EXAMPLE_FIT_PROPERTIES = {'EndX': 1018,
+                          "Function": "name=Lorentzian,Amplitude=22078.3,"
+                                      "PeakCentre=492.226,FWHM=56.265",
+                          "InputWorkspace": "TestWorkspace",
+                          "MaxIterations": 5000,
+                          "Normalise": True,
+                          "Output": "TestWorkspaceOutput",
+                          "OutputCompositeMembers": True, "StartX": 5.6,
+                          "WorkspaceIndex": 4}
+
+# This is an example of whats returned by the method getFitAlgorithmParameters in the FitPropertyBrowser
+EXAMPLE_FIT_ALG_PROPERTIES = json.dumps({'name': 'Fit', 'properties': EXAMPLE_FIT_PROPERTIES, 'version': 1})
+
+
+class PlotScriptGeneratorFittingTest(unittest.TestCase):
+
+    def setUp(self):
+        self.mock_fig = Mock()
+        self.mock_browser = Mock(spec=FitPropertyBrowser)
+        self.mock_fig.canvas.manager.fit_browser = self.mock_browser
+
+    def test_fit_commands_empty_if_no_fit(self):
+        self.mock_browser.fit_result_ws_name = ""
+
+        commands, headers = get_fit_cmds(self.mock_fig)
+
+        self.assertEqual(commands, [])
+        self.assertEqual(headers, [])
+
+    def test_returns_if_no_fit_browser(self):
+        mock_fig = Mock()
+        # Figure manager base has no fit browser
+        mock_fig.canvas.manager = Mock(spec=FigureManagerBase)
+        self.assertEqual(None, get_fit_cmds(mock_fig))
+
+    def test_get_fit_cmds_returns_expected_commands(self):
+        self.mock_browser.fit_result_ws_name = "TestWorkspace"
+        self.mock_browser.getFitAlgorithmParameters.return_value = EXAMPLE_FIT_ALG_PROPERTIES
+
+        commands, headers = get_fit_cmds(self.mock_fig)
+
+        self.assertEqual(headers[0], BASE_FIT_INCLUDE)
+        # Should be the 9 algorithm properties + the final call to Fit
+        # Check each is its expected value
+        self.assertEqual(len(commands), len(EXAMPLE_FIT_PROPERTIES) + 1)
+        for i in range(len(commands) - 1):
+            fit_property, fit_value = tuple(commands[i].split('=', 1))
+            self.assertEqual(EXAMPLE_FIT_PROPERTIES[fit_property], ast.literal_eval(fit_value))
+
+    def test_get_fit_commands_returns_expected_fit_algorithm_call(self):
+        self.mock_browser.fit_result_ws_name = "TestWorkspace"
+        self.mock_browser.getFitAlgorithmParameters.return_value = EXAMPLE_FIT_ALG_PROPERTIES
+
+        commands, headers = get_fit_cmds(self.mock_fig)
+        fit_command = commands[-1]
+        alg_call = re.sub(r'\([^)]*\)', '', fit_command)
+        fit_args = re.findall(r'\((.*?)\)', fit_command)[0].split(',')
+
+        # check that the alg call is the same
+        # Check correct args are passed into the Fit call
+        self.assertEqual(alg_call, BASE_FIT_COMMAND)
+        self.assertEqual(len(fit_args), len(EXAMPLE_FIT_PROPERTIES))
+        fit_arg_list = [fit_arg.split('=')[0] for fit_arg in fit_args]
+        self.assertEqual(fit_arg_list, list(EXAMPLE_FIT_PROPERTIES.keys()))
+
+    def test_get_fit_commands_returns_expected_order(self):
+        self.mock_browser.fit_result_ws_name = "TestWorkspace"
+        self.mock_browser.getFitAlgorithmParameters.return_value = EXAMPLE_FIT_ALG_PROPERTIES
+
+        commands, headers = get_fit_cmds(self.mock_fig)
+        fit_properties = [fit_command.split('=')[0] for fit_command in commands]
+
+        # Test some of the properties are in the correct place
+        self.assertEqual(fit_properties[0], 'Function')
+        self.assertEqual(fit_properties[2], 'WorkspaceIndex')
+        self.assertEqual(fit_properties[5], 'EndX')
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/qt/python/mantidqt/_common.sip
+++ b/qt/python/mantidqt/_common.sip
@@ -461,6 +461,7 @@ public:
     void addFitResultWorkspacesToTableWidget();
     void setWorkspaceName(const QString &wsName);
     void postDeleteHandle(const std::string &wsName);
+    std::string getFitAlgorithmParameters() const;
 
     SIP_PYOBJECT defaultPeakType();
 %MethodCode

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/FitPropertyBrowser.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/FitPropertyBrowser.h
@@ -108,6 +108,8 @@ public:
   QList<double> getParameterValues() const;
   /// Get function parameter names
   QStringList getParameterNames() const;
+  // Get parameters used to run the Fit algorithm
+  std::string getFitAlgorithmParameters() const;
 
   /// Load function
   void loadFunction(const QString &funcString);
@@ -687,6 +689,9 @@ private:
 
   /// Should the data be normalised before fitting?
   bool m_shouldBeNormalised;
+
+  // Keep a history of the parameters used to run the Fit algorithm
+  std::string m_fitAlgParameters;
 
   /// If non-empty it contains references to the spectra
   /// allowed to be fitted in this browser:

--- a/qt/widgets/common/src/FitPropertyBrowser.cpp
+++ b/qt/widgets/common/src/FitPropertyBrowser.cpp
@@ -106,7 +106,8 @@ FitPropertyBrowser::FitPropertyBrowser(QWidget *parent, QObject *mantidui)
           Mantid::Kernel::ConfigService::Instance().getString(
               "curvefitting.autoBackground"))),
       m_autoBackground(nullptr), m_decimals(-1), m_mantidui(mantidui),
-      m_shouldBeNormalised(false), m_oldWorkspaceIndex(-1) {
+      m_shouldBeNormalised(false), m_fitAlgParameters(""),
+      m_oldWorkspaceIndex(-1) {
   Mantid::API::FrameworkManager::Instance().loadPlugins();
 
   // If Gaussian does not exist then the plugins did not load.
@@ -1693,6 +1694,7 @@ void FitPropertyBrowser::doFit(int maxIterations) {
     }
     observeFinish(alg);
     alg->executeAsync();
+    m_fitAlgParameters = alg->toString();
 
   } catch (const std::exception &e) {
     QString msg = "Fit algorithm failed.\n\n" + QString(e.what()) + "\n";
@@ -3399,6 +3401,12 @@ QStringList FitPropertyBrowser::getParameterNames() const {
     out.append(QString::fromStdString(parName));
   }
   return out;
+}
+/**=================================================================================================
+ * Get Fit Algorithm parameters
+ */
+std::string FitPropertyBrowser::getFitAlgorithmParameters() const {
+  return m_fitAlgParameters;
 }
 
 /**=================================================================================================


### PR DESCRIPTION
**Description of work.**
This PR adds completed fits to the auto-generation script button attached to workbench plots. It does this by grabbing the properties from the most recently run fit and using this to create python commands.
<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

**To test:**

1. Code review
2. Plot some data
3. Add a fit function
4. Perform the fit
5. Copy script to clipboard, paste and check the fit is included in the script (and the script is functional)
6. Copy script to file and check and check the fit is included in the file (and the file is functional)

Lastly, check this hasn't broken any existing features.

<!-- Instructions for testing. -->

Fixes #28736 . <!-- and fix #xxxx or close #xxxx xor resolves #xxxx -->
<!-- alternative
*There is no associated issue.*
-->

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
-->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
