### PR TITLE
Fix broken launch script for the packaged versions

### DIFF
--- a/buildconfig/CMake/Packaging/launch_workbench.pyw
+++ b/buildconfig/CMake/Packaging/launch_workbench.pyw
@@ -1,4 +1,4 @@
 # Small startup script that replaces the compiled executable from setuptools
 # This script should be called with Mantid's Python from the launch_workbench run script
-import workbench.app.start
-workbench.app.start.main()
+import workbench.app.main
+workbench.app.main.main()


### PR DESCRIPTION
**Description of work.**
Fixes a bug introduced in #28771 where packaged versions would not launch due to a broken launch script. 

**To test:**
1. Create a packaged build of mantid
2. Check it launches correctly

*There is no associated issue.*

*This does not require release notes* because **it is fixing a regression**


---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
