### PR TITLE
Hide fit button for non 1D plots

### DIFF
--- a/qt/applications/workbench/workbench/plotting/figuremanager.py
+++ b/qt/applications/workbench/workbench/plotting/figuremanager.py
@@ -455,6 +455,7 @@ class FigureManagerWorkbench(FigureManagerBase, QObject):
 
     def update_toolbar_waterfall_plot(self, is_waterfall):
         self.toolbar.set_waterfall_options_enabled(is_waterfall)
+        self.toolbar.set_fit_enabled(not is_waterfall)
         self.toolbar.set_generate_plot_script_enabled(not is_waterfall)
 
     def change_line_collection_colour(self, colour):

--- a/qt/applications/workbench/workbench/plotting/toolbar.py
+++ b/qt/applications/workbench/workbench/plotting/toolbar.py
@@ -160,9 +160,9 @@ class WorkbenchNavigationToolbar(NavigationToolbar2QT):
             toolbar_action.setEnabled(on)
             toolbar_action.setVisible(on)
 
-        # show/hide separator
-        fit_action = self._actions['toggle_fit']
-        self.toggle_separator_visibility(fit_action, on)
+        # Show/hide the separator between this button and help button
+        action = self._actions['waterfall_fill_area']
+        self.toggle_separator_visibility(action, on)
 
     def set_generate_plot_script_enabled(self, enabled):
         action = self._actions['generate_plot_script']
@@ -171,10 +171,12 @@ class WorkbenchNavigationToolbar(NavigationToolbar2QT):
         # Show/hide the separator between this button and the "Fit" button
         self.toggle_separator_visibility(action, enabled)
 
-    def _set_fit_enabled(self, on):
+    def set_fit_enabled(self, on):
         action = self._actions['toggle_fit']
         action.setEnabled(on)
         action.setVisible(on)
+        # Show/hide the separator between this button and help button / waterfall options
+        self.toggle_separator_visibility(action, on)
 
     def waterfall_offset_amount(self):
         self.sig_waterfall_offset_amount_triggered.emit()
@@ -204,18 +206,18 @@ class WorkbenchNavigationToolbar(NavigationToolbar2QT):
                 break
 
     def set_buttons_visiblity(self, fig):
-        if figure_type(fig) not in [FigureType.Line, FigureType.Errorbar] and len(fig.get_axes()) > 1:
-            self._set_fit_enabled(False)
+        if figure_type(fig) not in [FigureType.Line, FigureType.Errorbar] or len(fig.get_axes()) > 1:
+            self.set_fit_enabled(False)
 
         # if any of the lines are a sample log plot disable fitting
         for ax in fig.get_axes():
             for artist in ax.get_lines():
                 try:
                     if ax.get_artists_sample_log_plot_details(artist) is not None:
-                        self._set_fit_enabled(False)
+                        self.set_fit_enabled(False)
                         break
                 except Exception:
-                    #The artist is not tracked - ignore this one and check the rest
+                    # The artist is not tracked - ignore this one and check the rest
                     continue
 
         # For plot-to-script button to show, every axis must be a MantidAxes with lines in it
@@ -224,7 +226,7 @@ class WorkbenchNavigationToolbar(NavigationToolbar2QT):
                 fig.get_axes()[0].is_waterfall():
             self.set_generate_plot_script_enabled(False)
 
-        #reenable script generation for colormaps
+        # reenable script generation for colormaps
         if self.is_colormap(fig):
             self.set_generate_plot_script_enabled(True)
 


### PR DESCRIPTION
**Description of work.**
This PR hides the fit button for plots which are not a simple 1D or error bar plots.

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

**To test:**

1. Load data
2. Do a range of plots. The fit button should only be visible for simple 1D or error bar plots. For the other plots it should be hidden.

<!-- Instructions for testing. -->

Fixes #28816. <!-- and fix #xxxx or close #xxxx xor resolves #xxxx -->
<!-- alternative
*There is no associated issue.*
-->


This does not require release notes because it doesn't feel like this is either a bug fix or an improvement. 


---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
