### PR TITLE
stop imshow calls with log plots and invalid data failing

### DIFF
--- a/Framework/PythonInterface/mantid/plots/modest_image/modest_image.py
+++ b/Framework/PythonInterface/mantid/plots/modest_image/modest_image.py
@@ -54,7 +54,7 @@ class ModestImage(mi.AxesImage):
         ACCEPTS: numpy/PIL Image A
         """
         self._full_res = A
-        self._A = A
+        self._A = cbook.safe_masked_invalid(A)
 
         if self._A.dtype != np.uint8 and not np.can_cast(self._A.dtype,
                                                          np.float):


### PR DESCRIPTION
**Description of work.** 

for the attention of: @DanielMurphy22 

Made mosest_image handle invalid data like matplotlib image


**To test:**
1. open workbench, run the scripts, see two valid graphs on with log scale, the other linear.
1. check that the existing colourfill functionality in the workspace menu still works
``` python
from mantid.simpleapi import *
import matplotlib.pyplot as plt
from matplotlib.colors import LogNorm

data = Load('MAR11060')

fig, axes = plt.subplots(subplot_kw={'projection':'mantid'})

# IMPORTANT to set origin to lower
c = axes.imshow(data, origin = 'lower', cmap='viridis', aspect='auto', norm=LogNorm())
axes.set_title('MAR11060')
cbar=fig.colorbar(c)
cbar.set_label('Counts ($\mu s$)$^{-1}$') #add text to colorbar
plt.show()

fig, axes = plt.subplots(subplot_kw={'projection':'mantid'})

# IMPORTANT to set origin to lower
c = axes.imshow(data, origin = 'lower', cmap='viridis', aspect='auto')
axes.set_title('MAR11060')
cbar=fig.colorbar(c)
cbar.set_label('Counts ($\mu s$)$^{-1}$') #add text to colorbar
plt.show()
```
Fixes #28874



*This does not require release notes* because we caused this problem in this sprint


---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
