### PR TITLE
Make Indirect, Corrections UI work with new algorithm

### DIFF
--- a/docs/source/release/v5.1.0/indirect_geometry.rst
+++ b/docs/source/release/v5.1.0/indirect_geometry.rst
@@ -26,6 +26,7 @@ Improvements
 - The centre parameter has been added to delta function in the ConvFit tab of Indirect Data Analysis.
 - :ref- :ref:`IndirectILLEnergyTransfer <algm-IndirectILLEnergyTransfer>` will produce energy transfer axis which takes into account that doppler channels are linear in velocity (not in time, neither energy as was assumed before). This will affect doppler mode QENS only.
 - Added docking and undocking to the plot window and function browser window for the fit tabs in Indirect Data Analysis on workbench.
+- Update the Indirect, Corrections user interface to use the :ref:`PaalmanPingsMonteCarloAbsorption <algm-PaalmanPingsMonteCarloAbsorption>` algorithm
 
 Bug Fixes
 #########

--- a/qt/scientific_interfaces/Indirect/AbsorptionCorrections.cpp
+++ b/qt/scientific_interfaces/Indirect/AbsorptionCorrections.cpp
@@ -187,7 +187,7 @@ void AbsorptionCorrections::run() {
   QString const sampleShape = m_uiForm.cbShape->currentText().replace(" ", "");
 
   IAlgorithm_sptr monteCarloAbsCor =
-      AlgorithmManager::Instance().create("CalculateMonteCarloAbsorption");
+      AlgorithmManager::Instance().create("PaalmanPingsMonteCarloAbsorption");
   monteCarloAbsCor->initialize();
 
   monteCarloAbsCor->setProperty("Shape", sampleShape.toStdString());
@@ -226,8 +226,6 @@ void AbsorptionCorrections::run() {
   // General details
   monteCarloAbsCor->setProperty("BeamHeight", m_uiForm.spBeamHeight->value());
   monteCarloAbsCor->setProperty("BeamWidth", m_uiForm.spBeamWidth->value());
-  long const wave = static_cast<long>(m_uiForm.spNumberWavelengths->value());
-  monteCarloAbsCor->setProperty("NumberOfWavelengthPoints", wave);
   long const events = static_cast<long>(m_uiForm.spNumberEvents->value());
   monteCarloAbsCor->setProperty("EventsPerPoint", events);
   auto const interpolation =
@@ -352,11 +350,8 @@ void AbsorptionCorrections::addShapeSpecificCanOptions(
     double const canBackThickness = m_uiForm.spFlatCanBackThickness->value();
     alg->setProperty("ContainerBackThickness", canBackThickness);
   } else if (shape == "Cylinder") {
-    double const canInnerRadius = m_uiForm.spCylSampleRadius->value();
-    alg->setProperty("ContainerInnerRadius", canInnerRadius);
-
     double const canOuterRadius = m_uiForm.spCylCanOuterRadius->value();
-    alg->setProperty("ContainerOuterRadius", canOuterRadius);
+    alg->setProperty("ContainerRadius", canOuterRadius);
 
   } else if (shape == "Annulus") {
     double const canInnerRadius = m_uiForm.spAnnCanInnerRadius->value();
@@ -529,7 +524,6 @@ void AbsorptionCorrections::getParameterDefaults(
     const Instrument_const_sptr &instrument) {
   setBeamWidthValue(instrument, "Workflow.beam-width");
   setBeamHeightValue(instrument, "Workflow.beam-height");
-  setWavelengthsValue(instrument, "Workflow.absorption-wavelengths");
   setEventsValue(instrument, "Workflow.absorption-events");
   setInterpolationValue(instrument, "Workflow.absorption-interpolation");
   setMaxAttemptsValue(instrument, "Workflow.absorption-attempts");
@@ -554,17 +548,6 @@ void AbsorptionCorrections::setBeamHeightValue(
         instrument->getStringParameter(beamHeightParamName)[0]);
     auto const beamHeightValue = beamHeight.toDouble();
     m_uiForm.spBeamHeight->setValue(beamHeightValue);
-  }
-}
-
-void AbsorptionCorrections::setWavelengthsValue(
-    const Instrument_const_sptr &instrument,
-    std::string const &wavelengthsParamName) const {
-  if (instrument->hasParameter(wavelengthsParamName)) {
-    auto const wavelengths = QString::fromStdString(
-        instrument->getStringParameter(wavelengthsParamName)[0]);
-    auto const wavelengthsValue = wavelengths.toInt();
-    m_uiForm.spNumberWavelengths->setValue(wavelengthsValue);
   }
 }
 

--- a/qt/scientific_interfaces/Indirect/AbsorptionCorrections.ui
+++ b/qt/scientific_interfaces/Indirect/AbsorptionCorrections.ui
@@ -114,7 +114,7 @@
       <bool>false</bool>
      </property>
      <layout class="QGridLayout" name="gridLayout_3">
-      <item row="1" column="2">
+      <item row="1" column="0">
        <widget class="QLabel" name="lbNumberEvents">
         <property name="text">
          <string>Events:</string>
@@ -122,29 +122,6 @@
        </widget>
       </item>
       <item row="1" column="1">
-       <widget class="QSpinBox" name="spNumberWavelengths">
-        <property name="minimum">
-         <number>1</number>
-        </property>
-        <property name="maximum">
-         <number>10000</number>
-        </property>
-        <property name="singleStep">
-         <number>1</number>
-        </property>
-        <property name="value">
-         <number>10</number>
-        </property>
-       </widget>
-      </item>
-      <item row="1" column="0">
-       <widget class="QLabel" name="lbNumberWavelengths">
-        <property name="text">
-         <string>Number Wavelengths:</string>
-        </property>
-       </widget>
-      </item>
-      <item row="1" column="4">
        <widget class="QSpinBox" name="spNumberEvents">
         <property name="maximum">
          <number>1000000</number>
@@ -1339,7 +1316,6 @@
  </customwidgets>
  <tabstops>
   <tabstop>ckUseCan</tabstop>
-  <tabstop>spNumberWavelengths</tabstop>
   <tabstop>spNumberEvents</tabstop>
   <tabstop>spBeamHeight</tabstop>
   <tabstop>spBeamWidth</tabstop>


### PR DESCRIPTION
**Description of work.**

A new algorithm was created recently to generate the Paalman Pings absorption corrections using a Monte Carlo absorption calculation (https://github.com/mantidproject/mantid/pull/28462). The new algorithm is called PaalmanPingsMonteCarloAbsorption. This is an improvement over the old algorithm (CalculationMonteCarloAbsorptionAlgorithm) because all 4 of the Paalman Pings absorption correction factors are output instead of only two.

This PR updates the Indirect, Corrections UI to use the new PaalmanPingsMonteCarloAbsorption instead of the old CalculationMonteCarloAbsorptionAlgorithm. The tab called "Calculate Monte Carlo" is the one that's affected.

The parameters of the two algorithms are slightly different. Not all of the changes need to be exposed but these two changes have been accommodated as part of this PR:
- so the ContainerOuterRadius parameter has been renamed to ContainerRadius
- the NumberOfWavelengths parameter was dropped

**Report to:** Spencer Howells

**To test:**

1) Run the following script to create 2 workspaces:
```
# import mantid algorithms, numpy and matplotlib
from mantid.simpleapi import *
import matplotlib.pyplot as plt
import numpy as np

sample_ws = CreateSampleWorkspace(Function="Quasielastic",
                                  XUnit="Wavelength",
                                  XMin=-0.5,
                                  XMax=0.5,
                                  BinWidth=0.01)
# Efixed is generally defined as part of the IDF for real data.
# Fake it here
inst_name = sample_ws.getInstrument().getName()
SetInstrumentParameter(sample_ws, ComponentName=inst_name,
    ParameterName='Efixed', ParameterType='Number', Value='4.1')
SetInstrumentParameter(sample_ws, ComponentName=inst_name,
    ParameterName='deltaE-mode', ParameterType='String', Value='Indirect')

container_ws = CreateSampleWorkspace(Function="Quasielastic",
                                     XUnit="Wavelength",
                                     XMin=-0.5,
                                     XMax=0.5,
                                     BinWidth=0.01)
SetInstrumentParameter(container_ws, ComponentName=inst_name,
    ParameterName='Efixed', ParameterType='Number', Value='4.1')
SetInstrumentParameter(container_ws, ComponentName=inst_name,
    ParameterName='deltaE-mode', ParameterType='String', Value='Indirect')
```
2) Open the Indirect, Corrections UI and on the settings screen uncheck "restrict allowed input files by name"
3) Go to the "Calculate Monte Carlo Absorption" tab
3) In the input section at the top check "Use Container" and specify the two workspaces created by the script in step 1) as the sample and container workspaces
3) In the Shape section populate "Sample Height", "Sample Thickness", "Container Front Thickness", "Sample Width" with the value 1.0000cm
4) Fill in the chemical formula as Ni in both the "Sample Details" and "Container Details" sections
5) click Run

The drop down in the Output Options section at the bottom should be populated with 4 workspaces. The workspaces will be called the same as the input but with an _ass, _assc, _acc, _acsc suffix


Fixes #28855 .

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
