### PR TITLE
Start the Sliceviewer with Zoom Selected

### DIFF
--- a/docs/source/release/v5.1.0/mantidworkbench.rst
+++ b/docs/source/release/v5.1.0/mantidworkbench.rst
@@ -74,6 +74,7 @@ Improvements
 - Added an option to matrix workspaces to export bins and spectra to a table workspace.
 - Improved the handling of ``WorkspaceSingleValue`` workspaces in workbench. This fixes a crash which occurred when interacting with workspaces of this type.
 - Right-clicking a plot without dragging while using the zoom tool now resets the axes limits.
+- The Slice Viewer now starts with the zoom option selected by default. 
 
 Bugfixes
 ########

--- a/qt/python/mantidqt/widgets/sliceviewer/presenter.py
+++ b/qt/python/mantidqt/widgets/sliceviewer/presenter.py
@@ -59,6 +59,9 @@ class SliceViewer(object):
 
         self.new_plot()
 
+        # Start the GUI with zoom selected.
+        self.view.data_view.select_zoom()
+
     def new_plot_MDH(self):
         """
         Tell the view to display a new plot of an MDHistoWorkspace

--- a/qt/python/mantidqt/widgets/sliceviewer/test/test_sliceviewer_presenter.py
+++ b/qt/python/mantidqt/widgets/sliceviewer/test/test_sliceviewer_presenter.py
@@ -276,6 +276,10 @@ class SliceViewerTest(unittest.TestCase):
         mock_peaks_presenter.assert_called_once()
         mock_peaks_presenter.overlay_peaksworkspaces.asssert_called_once()
 
+    def test_gui_starts_with_zoom_selected(self):
+        SliceViewer(None, model=self.model, view=self.view)
+        self.assertEqual(1, self.view.data_view.select_zoom.call_count)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/qt/python/mantidqt/widgets/sliceviewer/toolbar.py
+++ b/qt/python/mantidqt/widgets/sliceviewer/toolbar.py
@@ -80,9 +80,6 @@ class SliceViewerNavigationToolbar(NavigationToolbar2QT):
         # Adjust icon size or they are too small in PyQt5 by default
         self.setIconSize(QSize(24, 24))
 
-        # Set the zoom button to be selected on startup.
-        self.zoom()
-
     def edit_parameters(self):
         NavigationToolbar2QT.edit_parameters(self)
         self.plotOptionsChanged.emit()

--- a/qt/python/mantidqt/widgets/sliceviewer/toolbar.py
+++ b/qt/python/mantidqt/widgets/sliceviewer/toolbar.py
@@ -80,6 +80,9 @@ class SliceViewerNavigationToolbar(NavigationToolbar2QT):
         # Adjust icon size or they are too small in PyQt5 by default
         self.setIconSize(QSize(24, 24))
 
+        # Set the zoom button to be selected on startup.
+        self.zoom()
+
     def edit_parameters(self):
         NavigationToolbar2QT.edit_parameters(self)
         self.plotOptionsChanged.emit()

--- a/qt/python/mantidqt/widgets/sliceviewer/view.py
+++ b/qt/python/mantidqt/widgets/sliceviewer/view.py
@@ -298,6 +298,10 @@ class SliceViewerDataView(QWidget):
         """Reset the view to encompass all of the data"""
         self.presenter.show_all_data_requested()
 
+    def select_zoom(self):
+        """Select the zoom control on the toolbar"""
+        self.mpl_toolbar.zoom()
+
     def update_plot_data(self, data):
         """
         This just updates the plot data without creating a new plot


### PR DESCRIPTION
**Description of work.**

Adjusts the slice viewer so that the zoom toolbar option is immidiately selected. 


**To test:**
1. Load a Multi-Dimentional workspace, such as WISH00045319MD
2. Right click the workspace and open the slice viewer. 
3. Check that the magnify option is selected and you can immidiately zoom in on the plotted workspace. 

Fixes #27732 

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
