### PR TITLE
Add write access to HKL in peak workspace tables in workbench

### DIFF
--- a/docs/source/release/v5.1.0/diffraction.rst
+++ b/docs/source/release/v5.1.0/diffraction.rst
@@ -43,5 +43,6 @@ Improvements
 - New algorithm :ref:`FindGoniometerFromUB <algm-FindGoniometerFromUB-v1>` for making UBs for runs at different goniometer angles share common indexing and determine the goniometer axis and rotation required to match UBs to a reference.
 - New instrument geometry for MaNDi instrument at SNS
 - New algorithm :ref:`AddAbsorptionWeightedPathLengths <algm-AddAbsorptionWeightedPathLengths-v1>` for calculating the absorption weighted path length for each peak in a peaks workspace. The absorption weighted path length is used downstream from Mantid in extinction correction calculations
+- Can now edit H,K,L in the table of a peaks workspace in workbench (now consistent with Mantid Plot)
 
 :ref:`Release 5.1.0 <v5.1.0>`

--- a/qt/python/mantidqt/widgets/workspacedisplay/table/model.py
+++ b/qt/python/mantidqt/widgets/workspacedisplay/table/model.py
@@ -107,7 +107,7 @@ class TableWorkspaceDisplayModel:
         if self.is_peaks_workspace():
             return self.ws.getColumnNames()[icol] in self.EDITABLE_COLUMN_NAMES
         else:
-            return False
+            return True
 
     def is_peaks_workspace(self):
         return isinstance(self.ws, IPeaksWorkspace)

--- a/qt/python/mantidqt/widgets/workspacedisplay/table/presenter.py
+++ b/qt/python/mantidqt/widgets/workspacedisplay/table/presenter.py
@@ -66,11 +66,9 @@ class TableWorkspaceDataPresenter(object):
         num_cols = self.model.get_number_of_columns()
         table.setColumnCount(num_cols)
 
-        # the table should be editable if the ws is not PeaksWS
-        editable = not self.model.is_peaks_workspace()
-
         for col in range(num_cols):
             column_data = self.model.get_column(col)
+            editable = self.model.is_editable_column(col)
             for row in range(num_rows):
                 item = WorkbenchTableWidgetItem(column_data[row], editable=editable)
                 table.setItem(row, col, item)

--- a/qt/python/mantidqt/widgets/workspacedisplay/table/test/test_tableworkspacedisplay_model.py
+++ b/qt/python/mantidqt/widgets/workspacedisplay/table/test/test_tableworkspacedisplay_model.py
@@ -12,7 +12,7 @@ import unittest
 
 from mantid.dataobjects import PeaksWorkspace
 from mantid.kernel import V3D
-from unittest.mock import Mock, patch
+from unittest.mock import Mock
 from mantidqt.utils.testing.mocks.mock_mantid import MockWorkspace
 from mantidqt.utils.testing.strict_mock import StrictMock
 from mantidqt.widgets.workspacedisplay.table.model import TableWorkspaceColumnTypeMapping, TableWorkspaceDisplayModel


### PR DESCRIPTION
Also added test

**Description of work.**

Changes allow columns with names 'h', 'k' and 'l' to be editable and update the HKL of the peak objects in the PeaksWorkspace. This is now consistent with the behaviour in mantidplot.

**To test:**

(1) Load in a peaks workspace [SXD23767_peaks.txt](https://github.com/mantidproject/mantid/files/4820143/SXD23767_peaks.txt)  using
`LoadIsawUB(Filename='C:/Users/xhg73778/Desktop/SXD23767_peaks.txt', OutputWorkspace='peaks')`
(2) You should be able to change the values in columns corresponding only to the h, k, l 
(3) Make an empty table workspace and check that you can edit all columns (including the V3D)
```
from mantid.simpleapi import *
from mantid.kernel import V3D

# Create PositionTable
tableWS = CreateEmptyTableWorkspace()

# Add some columns, Recognized types are: int,float,double,bool,str,V3D,long64
tableWS.addColumn(type="int",name="Detector ID")
tableWS.addColumn(type="str",name="Detector Name")
tableWS.addColumn(type="V3D",name="Detector Position")

# Populate the columns for three detectors
detIDList = range(1,4)
detPosList = [ V3D(9.0,0.0,0.0), V3D(10.0,3.0,0.0), V3D(12.0,3.0,6.0)]
for j in range(len(detIDList)):
    nextRow = { 'Detector ID': detIDList[j],
                'Detector Name': "Detector {0}".format(detIDList[j]),
                'Detector Position': detPosList[j] }
    tableWS.addRow ( nextRow )
```


Fixes #28382 

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
-->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
