### PR TITLE
Add control for axes tick format on plots

### DIFF
--- a/docs/source/release/v5.1.0/mantidworkbench.rst
+++ b/docs/source/release/v5.1.0/mantidworkbench.rst
@@ -12,6 +12,7 @@ New
 - There is now a dialog for project saving that allows you to choose between saving all workspaces or only saving workspaces which have been altered.
 - A default legend location can be set in the Workbench settings.
 - The Sample Transmission Calculator is now implemented in workbench.
+- The number of significant figures on plots can be set from the axis property dialogue.
 
 Improvements
 ############

--- a/docs/source/release/v5.1.0/mantidworkbench.rst
+++ b/docs/source/release/v5.1.0/mantidworkbench.rst
@@ -12,7 +12,7 @@ New
 - There is now a dialog for project saving that allows you to choose between saving all workspaces or only saving workspaces which have been altered.
 - A default legend location can be set in the Workbench settings.
 - The Sample Transmission Calculator is now implemented in workbench.
-- The number of significant figures on plots can be set from the axis property dialogue.
+- The axis tick markers in a plot can be switched between Log and decimal formats indepentantly of the axes scale.
 
 Improvements
 ############

--- a/qt/applications/workbench/workbench/plotting/axiseditor.ui
+++ b/qt/applications/workbench/workbench/plotting/axiseditor.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>245</width>
+    <width>321</width>
     <height>204</height>
    </rect>
   </property>
@@ -21,17 +21,29 @@
      </property>
     </widget>
    </item>
-   <item row="3" column="2">
-    <widget class="QLineEdit" name="editor_min"/>
-   </item>
-   <item row="4" column="1">
-    <widget class="QLabel" name="label_2">
+   <item row="2" column="1" colspan="2">
+    <widget class="QLabel" name="errors">
+     <property name="enabled">
+      <bool>true</bool>
+     </property>
+     <property name="styleSheet">
+      <string notr="true">.QLabel{background-color: #F18888; border: 1px solid gray; border-radius: 5px}</string>
+     </property>
+     <property name="frameShape">
+      <enum>QFrame::Box</enum>
+     </property>
+     <property name="frameShadow">
+      <enum>QFrame::Sunken</enum>
+     </property>
      <property name="text">
-      <string>Max</string>
+      <string>Error text</string>
      </property>
     </widget>
    </item>
-   <item row="6" column="2">
+   <item row="3" column="2">
+    <widget class="QLineEdit" name="editor_min"/>
+   </item>
+   <item row="7" column="2">
     <widget class="QDialogButtonBox" name="buttonBox">
      <property name="orientation">
       <enum>Qt::Horizontal</enum>
@@ -41,7 +53,10 @@
      </property>
     </widget>
    </item>
-   <item row="5" column="2">
+   <item row="4" column="2">
+    <widget class="QLineEdit" name="editor_max"/>
+   </item>
+   <item row="6" column="2">
     <layout class="QHBoxLayout" name="horizontalLayout">
      <item>
       <widget class="QCheckBox" name="logBox">
@@ -65,27 +80,22 @@
      </item>
     </layout>
    </item>
-   <item row="4" column="2">
-    <widget class="QLineEdit" name="editor_max"/>
-   </item>
-   <item row="2" column="1" colspan="2">
-    <widget class="QLabel" name="errors">
-     <property name="enabled">
-      <bool>true</bool>
-     </property>
-     <property name="styleSheet">
-      <string notr="true">.QLabel{background-color: #F18888; border: 1px solid gray; border-radius: 5px}</string>
-     </property>
-     <property name="frameShape">
-      <enum>QFrame::Box</enum>
-     </property>
-     <property name="frameShadow">
-      <enum>QFrame::Sunken</enum>
-     </property>
+   <item row="4" column="1">
+    <widget class="QLabel" name="label_2">
      <property name="text">
-      <string>Error text</string>
+      <string>Max</string>
      </property>
     </widget>
+   </item>
+   <item row="5" column="1">
+    <widget class="QLabel" name="label_3">
+     <property name="text">
+      <string>Significant Figures</string>
+     </property>
+    </widget>
+   </item>
+   <item row="5" column="2">
+    <widget class="QSpinBox" name="editor_dec_place"/>
    </item>
   </layout>
  </widget>

--- a/qt/applications/workbench/workbench/plotting/axiseditor.ui
+++ b/qt/applications/workbench/workbench/plotting/axiseditor.ui
@@ -90,12 +90,12 @@
    <item row="5" column="1">
     <widget class="QLabel" name="label_3">
      <property name="text">
-      <string>Significant Figures</string>
+      <string>Tick Format</string>
      </property>
     </widget>
    </item>
    <item row="5" column="2">
-    <widget class="QSpinBox" name="editor_dec_place"/>
+    <widget class="QComboBox" name="editor_format"/>
    </item>
   </layout>
  </widget>

--- a/qt/applications/workbench/workbench/plotting/propertiesdialog.py
+++ b/qt/applications/workbench/workbench/plotting/propertiesdialog.py
@@ -118,8 +118,8 @@ class AxisEditor(PropertiesEditorBase):
         if figure_type(canvas.figure) in [FigureType.Surface, FigureType.Wireframe]:
             self.ui.logBox.hide()
             self.ui.gridBox.hide()
-        self.ui.editor_format.addItem('Scalar Format')
-        self.ui.editor_format.addItem('Log Format')
+        self.ui.editor_format.addItem('Decimal Format')
+        self.ui.editor_format.addItem('Scientific Format')
         self.axes = axes
         self.axis_id = axis_id
         self.lim_getter = getattr(axes, 'get_{}lim'.format(axis_id))
@@ -141,9 +141,9 @@ class AxisEditor(PropertiesEditorBase):
         memento.log = getattr(self.axes, 'get_{}scale'.format(self.axis_id))() != 'linear'
         memento.grid = self.axis._gridOnMajor
         if type(self.axis.get_major_formatter()) is ScalarFormatter:
-            memento.formatter = 'Scalar Format'
+            memento.formatter = 'Decimal Format'
         elif type(self.axis.get_major_formatter()) is LogFormatterSciNotation:
-            memento.formatter = 'Log Format'
+            memento.formatter = 'Scientific Format'
         self._fill(memento)
 
     def changes_accepted(self):
@@ -159,6 +159,7 @@ class AxisEditor(PropertiesEditorBase):
             self.scale_setter('linear')
 
         self.lim_setter(self.limit_min, self.limit_max)
+        self._set_tick_format()
         which = 'both' if hasattr(axes, 'show_minor_gridlines') and axes.show_minor_gridlines else 'major'
         axes.grid(self.ui.gridBox.isChecked(), axis=self.axis_id, which=which)
 
@@ -188,9 +189,9 @@ class AxisEditor(PropertiesEditorBase):
 
     def _set_tick_format(self):
         formatter = self.ui.editor_format.currentText()
-        if formatter == 'Scalar Format':
+        if formatter == 'Decimal Format':
             fmt = ScalarFormatter(useOffset=True)
-        elif formatter == 'Log Format':
+        elif formatter == 'Scientific Format':
             fmt = LogFormatterSciNotation()
         getattr(self.axes, 'get_{}axis'.format(self.axis_id))().set_major_formatter(fmt)
         return
@@ -238,6 +239,7 @@ class ColorbarAxisEditor(AxisEditor):
                     self.images.append(img)
 
         self.create_model()
+        self.ui.editor_format.setEnabled(False)
 
     def changes_accepted(self):
         self.ui.errors.hide()

--- a/qt/applications/workbench/workbench/plotting/propertiesdialog.py
+++ b/qt/applications/workbench/workbench/plotting/propertiesdialog.py
@@ -14,7 +14,7 @@ from mantidqt.plotting.figuretype import FigureType, figure_type
 from mantidqt.utils.qt import load_ui
 
 from matplotlib.colors import LogNorm, Normalize
-from matplotlib.ticker import ScalarFormatter, FuncFormatter
+from matplotlib.ticker import ScalarFormatter, LogFormatterSciNotation
 from mpl_toolkits.mplot3d.axes3d import Axes3D
 from qtpy.QtGui import QDoubleValidator, QIcon
 from qtpy.QtWidgets import QDialog, QWidget
@@ -97,7 +97,7 @@ class AxisEditorModel(object):
     max = None
     log = None
     grid = None
-    dec_place = None
+    formatter = None
 
 
 class AxisEditor(PropertiesEditorBase):
@@ -118,7 +118,8 @@ class AxisEditor(PropertiesEditorBase):
         if figure_type(canvas.figure) in [FigureType.Surface, FigureType.Wireframe]:
             self.ui.logBox.hide()
             self.ui.gridBox.hide()
-
+        self.ui.editor_format.addItem('Scalar Format')
+        self.ui.editor_format.addItem('Log Format')
         self.axes = axes
         self.axis_id = axis_id
         self.lim_getter = getattr(axes, 'get_{}lim'.format(axis_id))
@@ -139,12 +140,10 @@ class AxisEditor(PropertiesEditorBase):
         memento.min, memento.max = getattr(self.axes, 'get_{}lim'.format(self.axis_id))()
         memento.log = getattr(self.axes, 'get_{}scale'.format(self.axis_id))() != 'linear'
         memento.grid = self.axis._gridOnMajor
-        tick_labels = getattr(self.axes, 'get_{}ticklabels'.format(self.axis_id))()
-        tick_text = [label.get_text() for label in tick_labels]
-        if len(tick_text[0].split('.')) == 1:
-            memento.dec_place = 0
-        else:
-            memento.dec_place = len(tick_text[0].split('.')[1])
+        if type(self.axis.get_major_formatter()) is ScalarFormatter:
+            memento.formatter = 'Scalar Format'
+        elif type(self.axis.get_major_formatter()) is LogFormatterSciNotation:
+            memento.formatter = 'Log Format'
         self._fill(memento)
 
     def changes_accepted(self):
@@ -160,8 +159,6 @@ class AxisEditor(PropertiesEditorBase):
             self.scale_setter('linear')
 
         self.lim_setter(self.limit_min, self.limit_max)
-        self._set_tick_order()
-
         which = 'both' if hasattr(axes, 'show_minor_gridlines') and axes.show_minor_gridlines else 'major'
         axes.grid(self.ui.gridBox.isChecked(), axis=self.axis_id, which=which)
 
@@ -177,7 +174,7 @@ class AxisEditor(PropertiesEditorBase):
         self.ui.editor_max.setText(str(model.max))
         self.ui.logBox.setChecked(model.log)
         self.ui.gridBox.setChecked(model.grid)
-        self.ui.editor_dec_place.setValue(model.dec_place)
+        self.ui.editor_format.setCurrentText(model.formatter)
 
     def _check_log_limits(self, editor_min, editor_max):
         # Check that the limits from the editor are sensible for a log graph
@@ -189,23 +186,14 @@ class AxisEditor(PropertiesEditorBase):
             editor_max = lim_max
         return editor_min, editor_max
 
-    def _set_tick_order(self):
-        dec_places = self.ui.editor_dec_place.value()
-
-        class DecPlacesScalarFormatter(ScalarFormatter):
-            def _set_format(self):
-                super()
-                self.format = '%1.' + str(dec_places) + 'f'
-                if self._usetex:
-                    self.format = '$%s$' % self.format
-                elif self._useMathText:
-                    self.format = '$%s$' % '\\mathdefault{%s}' % self.format
-
-        fmt = DecPlacesScalarFormatter(useOffset=False)
+    def _set_tick_format(self):
+        formatter = self.ui.editor_format.currentText()
+        if formatter == 'Scalar Format':
+            fmt = ScalarFormatter(useOffset=True)
+        elif formatter == 'Log Format':
+            fmt = LogFormatterSciNotation()
         getattr(self.axes, 'get_{}axis'.format(self.axis_id))().set_major_formatter(fmt)
-
         return
-
 
 
 class XAxisEditor(AxisEditor):

--- a/qt/applications/workbench/workbench/plotting/test/test_propertiesdialog.py
+++ b/qt/applications/workbench/workbench/plotting/test/test_propertiesdialog.py
@@ -47,6 +47,9 @@ class PropertiesDialogTest(unittest.TestCase):
         self.assertEqual(xEditor._memento.max, ax.get_xlim()[1])
         self.assertEqual(yEditor._memento.min, ax.get_ylim()[0])
         self.assertEqual(yEditor._memento.max, ax.get_ylim()[1])
+        # test format
+        self.assertEqual(xEditor._memento.formatter, 'Scalar Format')
+        self.assertEqual(yEditor._memento.formatter, 'Log Format')
         # test scale
         self.assertEqual(xEditor._memento.log, False)
         self.assertEqual(yEditor._memento.log, True)

--- a/qt/applications/workbench/workbench/plotting/test/test_propertiesdialog.py
+++ b/qt/applications/workbench/workbench/plotting/test/test_propertiesdialog.py
@@ -48,8 +48,8 @@ class PropertiesDialogTest(unittest.TestCase):
         self.assertEqual(yEditor._memento.min, ax.get_ylim()[0])
         self.assertEqual(yEditor._memento.max, ax.get_ylim()[1])
         # test format
-        self.assertEqual(xEditor._memento.formatter, 'Scalar Format')
-        self.assertEqual(yEditor._memento.formatter, 'Log Format')
+        self.assertEqual(xEditor._memento.formatter, 'Decimal Format')
+        self.assertEqual(yEditor._memento.formatter, 'Scientific Format')
         # test scale
         self.assertEqual(xEditor._memento.log, False)
         self.assertEqual(yEditor._memento.log, True)


### PR DESCRIPTION
This PR adds an option on the plot axes property dialog box to crontrol the tick format independently of the axes scale. currently the tick format will always be `ScalarFormatter` when in linear scale and `LogFormatterSciNotation` in log scale.

**Report to:** @smk78 Steve King

**To test:**

1. open workbench.
2. plot some data.
3. doubleclick on the axes to bring up the property dialog.
4. change the tick format.
5. open the property dialog again and make the axis log scale.
6. change the tick format again.
7. test with both the x and y axis.

Fixes #28853 

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
