### PR TITLE
Allow convolutions of composite functions

### DIFF
--- a/Framework/CurveFitting/inc/MantidCurveFitting/Functions/Convolution.h
+++ b/Framework/CurveFitting/inc/MantidCurveFitting/Functions/Convolution.h
@@ -138,6 +138,7 @@ private:
   /// step in xValues) when in FFT mode, and the inverted resolution if in
   /// Direct mode
   mutable std::vector<double> m_resolution;
+  void innerFunctionsAre1D() const;
 };
 
 } // namespace Functions

--- a/Framework/CurveFitting/src/Functions/Convolution.cpp
+++ b/Framework/CurveFitting/src/Functions/Convolution.cpp
@@ -202,16 +202,6 @@ void Convolution::functionFFTMode(const FunctionDomain &domain,
     if (odd)
       xr[nData - 1] = -xr[0];
     evaluateFunctionOnRange(getFunction(0), nData, &xr[0], m_resolution);
-    // IFunction1D_sptr fun =
-    //     std::dynamic_pointer_cast<IFunction1D>(getFunction(0));
-    // if (!fun) {
-    //   FunctionDomain1DView ds(&xr[0], nData);
-    //   FunctionValues outs(ds);
-    //   getFunction(0)->function(ds, outs);
-    //   m_resolution = outs.toVector();
-    // } else {
-    //   fun->function1D(m_resolution.data(), xr.data(), nData);
-    // }
 
     // rotate the data to produce the right transform
     if (odd) {
@@ -335,7 +325,6 @@ void Convolution::functionFFTMode(const FunctionDomain &domain,
     // resolution
     std::vector<double> tmp(nData);
     evaluateFunctionOnRange(getFunction(0), nData, xValues, tmp);
-    // resolution->function1D(tmp.data(), xValues, nData);
     std::transform(tmp.begin(), tmp.end(), tmp.begin(),
                    std::bind(std::multiplies<double>(), _1, dltF));
     std::transform(out, out + nData, tmp.data(), out, std::plus<double>());
@@ -348,7 +337,6 @@ void Convolution::functionFFTMode(const FunctionDomain &domain,
                      std::bind(std::plus<double>(), _1, shift));
       std::vector<double> tmp(nData);
       evaluateFunctionOnRange(getFunction(0), nData, &x[0], tmp);
-      // resolution->function1D(tmp.data(), x.data(), nData);
       std::transform(tmp.begin(), tmp.end(), tmp.begin(),
                      std::bind(std::multiplies<double>(), _1, dltF));
       std::transform(out, out + nData, tmp.data(), out, std::plus<double>());
@@ -397,16 +385,6 @@ void Convolution::functionDirectMode(const FunctionDomain &domain,
   // Lines 341-349 is duplicated in functionFFTmode. To be cleanup
   // in issue 16064
   evaluateFunctionOnRange(getFunction(0), nData, &xValues[0], m_resolution);
-  // IFunction1D_sptr resolution =
-  //     std::dynamic_pointer_cast<IFunction1D>(getFunction(0));
-  // if (!resolution) {
-  //   FunctionDomain1DView ds(&xValues[0], nData);
-  //   FunctionValues outs(ds);
-  //   getFunction(0)->function(ds, outs);
-  //   m_resolution = outs.toVector();
-  // } else {
-  //   resolution->function1D(m_resolution.data(), xValues, nData);
-  // }
 
   // Reverse the axis of the resolution data
   std::reverse(m_resolution.begin(), m_resolution.end());
@@ -472,7 +450,6 @@ void Convolution::functionDirectMode(const FunctionDomain &domain,
     // in issue 16064
     std::vector<double> tmp(nData);
     evaluateFunctionOnRange(getFunction(0), nData, xValues, tmp);
-    // resolution->function1D(tmp.data(), xValues, nData);
     std::transform(tmp.begin(), tmp.end(), tmp.begin(),
                    std::bind(std::multiplies<double>(), _1, dltF));
     std::transform(out, out + nData, tmp.data(), out, std::plus<double>());
@@ -485,7 +462,6 @@ void Convolution::functionDirectMode(const FunctionDomain &domain,
                      std::bind(std::plus<double>(), _1, shift));
       std::vector<double> tmp(nData);
       evaluateFunctionOnRange(getFunction(0), nData, &x[0], tmp);
-      // resolution->function1D(tmp.data(), x.data(), nData);
       std::transform(tmp.begin(), tmp.end(), tmp.begin(),
                      std::bind(std::multiplies<double>(), _1, dltF));
       std::transform(out, out + nData, tmp.data(), out, std::plus<double>());

--- a/Framework/CurveFitting/src/Functions/Convolution.cpp
+++ b/Framework/CurveFitting/src/Functions/Convolution.cpp
@@ -40,6 +40,7 @@ using namespace API;
 using std::placeholders::_1;
 
 bool is1DCompositeFunction(const IFunction_sptr &function) {
+  bool is1D = true;
   const auto compositeFunction =
       std::dynamic_pointer_cast<CompositeFunction>(function);
   if (compositeFunction) {
@@ -52,9 +53,9 @@ bool is1DCompositeFunction(const IFunction_sptr &function) {
   } else {
     const IFunction1D_sptr fun =
         std::dynamic_pointer_cast<IFunction1D>(function);
-    bool is1D = fun ? true : false;
-    return is1D;
+    is1D = fun ? true : false;
   }
+  return is1D;
 }
 
 void evaluateFunctionOnRange(const IFunction_sptr &function, size_t domainSize,

--- a/docs/source/release/v5.1.0/framework.rst
+++ b/docs/source/release/v5.1.0/framework.rst
@@ -73,6 +73,10 @@ Python
 - Property.units now attempts to encode with windows-1252 if utf-8 fails.
 - Property.unitsAsBytes has been added to retrieve the raw bytes from the units string.
 
+Improvements
+------------
+- Updated the convolution function in the fitting framework to allow the convolution of two composite functions.
+
 Bugfixes
 --------
 - Fix an uncaught exception when loading empty fields from NeXus files. Now returns an empty vector.


### PR DESCRIPTION
**Description of work.**

Currently Convolutions require the first argument of the convolution to be a Function1D. This excludes composite functions even though doing a convolution of 1D composite functions is a valid operation. This updates Convolution to remove this restriction.

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

**To test:**

<!-- Instructions for testing. -->
Test that convolution fits still work as expected and that a convolution of two composite functions produces valid results. The script below gives an example of such a workflow.
```
import numpy as np
from mantid.simpleapi import CreateWorkspace, GausOsc, Fit, Gaussian
from mantid.api import FunctionFactory, AnalysisDataService

# Create a workspace with two offset oscillations
delta = 1.0
x = np.linspace(0.,15.,100)
x_offset = np.linspace(delta/2, 15. + delta/2, 100)
x_offset_neg = np.linspace(-delta/2, 15. - delta/2, 100)

testFunction = GausOsc(Frequency = 1.5, A=0.22) + Gaussian(Height=0.1, PeakCentre = 2.0, Sigma=0.2)
y1 = testFunction(x_offset_neg)
y2 = testFunction(x_offset)
y = y1/2+y2/2
ws = CreateWorkspace(x,y)

# Create functions to fit
convolution =  FunctionFactory.createCompositeFunction('Convolution')
innerFunction = FunctionFactory.createInitialized('name=GausOsc,A=0.2,Sigma=0.2,Frequency=1,Phi=0; name=Gaussian, Height=0.5, PeakCentre = 2.0, Sigma=0.1')
deltaFunctions = FunctionFactory.createInitialized('(name=DeltaFunction,Height=0.5,Centre={},ties=(Height=0.5,Centre={});name=DeltaFunction,Height=0.5,Centre={},ties=(Height=0.5,Centre={}))'.format(-delta/2, -delta/2, delta/2, delta/2))
convolution.setAttributeValue('FixResolution', False)
convolution.add(innerFunction)
convolution.add(deltaFunctions)

Fit(Function=convolution, InputWorkspace=ws, CreateOutput = True, StartX=0.0, EndX=15.0, Output='Fit')

single_parameter_workspace = AnalysisDataService.retrieve('Fit_Parameters')
col_values = single_parameter_workspace.column(1)

print('Fitted value of A from Fit is {:.2g}'.format(col_values[0]))
print('Fitted value of Frequency from Fit is {:.2g}'.format(col_values[2]))
print('Fitted value of Height from Fit is {:.2g}'.format(col_values[4]))
print('Fitted value of PeakCentre from Fit is {:.2g}'.format(col_values[5]))
print('Fitted value of Sigma from Fit is {:.2g}'.format(col_values[6]))
```
*There is no associated issue.*


---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
