### PR TITLE
Fix double click interaction for tiled plots

### DIFF
--- a/docs/source/release/v5.1.0/mantidworkbench.rst
+++ b/docs/source/release/v5.1.0/mantidworkbench.rst
@@ -107,5 +107,6 @@ Bugfixes
 - Overplotting no longer resets the axes scales.
 - Fixed a bug with the peak cursor immediately resetting to the default cursor when trying to add a peak.
 - Changing a curve's properties on a plot no longer changes the order of the plot legend.
+- Fixed a bug which prevented the double click axis editor menus from working for tiled plots.
 
 :ref:`Release 5.1.0 <v5.1.0>`

--- a/qt/applications/workbench/workbench/plotting/figureinteraction.py
+++ b/qt/applications/workbench/workbench/plotting/figureinteraction.py
@@ -16,6 +16,7 @@ from copy import copy
 from functools import partial
 
 # third party imports
+from matplotlib.axes import Axes
 from matplotlib.container import ErrorbarContainer
 from matplotlib.contour import QuadContourSet
 from qtpy.QtCore import Qt
@@ -233,10 +234,10 @@ class FigureInteraction(object):
                 move_and_show(XAxisEditor(canvas, ax))
             elif (ax.yaxis.contains(event)[0]
                   or any(tick.contains(event)[0] for tick in ax.get_yticklabels())):
-                if ax == axes[0]:
-                    move_and_show(YAxisEditor(canvas, ax))
-                else:
+                if type(ax) == Axes:
                     move_and_show(ColorbarAxisEditor(canvas, ax))
+                else:
+                    move_and_show(YAxisEditor(canvas, ax))
             elif hasattr(ax, 'zaxis'):
                 if ax.zaxis.label.contains(event)[0]:
                     move_and_show(LabelEditor(canvas, ax.zaxis.label))


### PR DESCRIPTION
**Description of work.**
This PR fixes a bug with the double click interaction for tiled plots. This caused a warning to be thrown if any y-axis other than the one corresponding to the first plot was selected.

**To test:**

1. Load some data
2. Make a tiled plot
3. Double click on y axis for one of the plots (not the first one)
4. A warning should no longer occur


Fixes #28908  <!-- and fix #xxxx or close #xxxx xor resolves #xxxx -->


---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
