### PR TITLE
fixed the passing of x-sections as doubles

### DIFF
--- a/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/PaalmanPingsMonteCarloAbsorption.py
+++ b/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/PaalmanPingsMonteCarloAbsorption.py
@@ -519,18 +519,18 @@ class PaalmanPingsMonteCarloAbsorption(DataProcessorAlgorithm):
             self._efixed = self._get_efixed()
 
         self._sample_chemical_formula = self.getPropertyValue('SampleChemicalFormula')
-        self._sample_coherent_cross_section = self.getPropertyValue('SampleCoherentXSection')
-        self._sample_incoherent_cross_section = self.getPropertyValue('SampleIncoherentXSection')
-        self._sample_attenuation_cross_section = self.getPropertyValue('SampleAttenuationXSection')
+        self._sample_coherent_cross_section = self.getProperty('SampleCoherentXSection').value
+        self._sample_incoherent_cross_section = self.getProperty('SampleIncoherentXSection').value
+        self._sample_attenuation_cross_section = self.getProperty('SampleAttenuationXSection').value
         self._sample_density_type = self.getPropertyValue('SampleDensityType')
         self._sample_number_density_unit = self.getPropertyValue('SampleNumberDensityUnit')
         self._sample_density = self.getProperty('SampleDensity').value
 
         if self._container_ws:
             self._container_chemical_formula = self.getPropertyValue('ContainerChemicalFormula')
-            self._container_coherent_cross_section = self.getPropertyValue('ContainerCoherentXSection')
-            self._container_incoherent_cross_section = self.getPropertyValue('ContainerIncoherentXSection')
-            self._container_attenuation_cross_section = self.getPropertyValue('ContainerAttenuationXSection')
+            self._container_coherent_cross_section = self.getProperty('ContainerCoherentXSection').value
+            self._container_incoherent_cross_section = self.getProperty('ContainerIncoherentXSection').value
+            self._container_attenuation_cross_section = self.getProperty('ContainerAttenuationXSection').value
             self._container_density_type = self.getPropertyValue('ContainerDensityType')
             self._container_number_density_unit = self.getPropertyValue('ContainerNumberDensityUnit')
             self._container_density = self.getProperty('ContainerDensity').value

--- a/Framework/PythonInterface/test/python/plugins/algorithms/WorkflowAlgorithms/PaalmanPingsMonteCarloAbsorptionTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/WorkflowAlgorithms/PaalmanPingsMonteCarloAbsorptionTest.py
@@ -65,6 +65,14 @@ class PaalmanPingsMonteCarloAbsorptionTest(unittest.TestCase):
         self._test_arguments['SampleOuterRadius'] = 1.8
         test_func('Annulus')
 
+    def _material_with_cross_section_test(self, test_func):
+        self._test_arguments['SampleWidth'] = 2.0
+        self._test_arguments['SampleThickness'] = 2.0
+        self._test_arguments['SampleChemicalFormula'] = ''
+        self._test_arguments['SampleIncoherentXSection'] = 5.7
+        self._test_arguments['SampleDensityType'] = 'Number Density'
+        test_func('FlatPlate')
+
     def _setup_flat_plate_container(self):
         self._test_arguments['ContainerFrontThickness'] = 1.5
         self._test_arguments['ContainerBackThickness'] = 1.5
@@ -147,6 +155,9 @@ class PaalmanPingsMonteCarloAbsorptionTest(unittest.TestCase):
         self._expected_hist = 18
         self._expected_blocksize = 1
         self._run_correction_and_test(shape, self._indirect_fws_ws.getItem(0), 'Degrees')
+
+    def test_material_with_cross_section(self):
+        self._material_with_cross_section_test(self._run_correction_and_test)
 
     def test_flat_plate_no_container(self):
         self._flat_plate_test(self._run_correction_and_test)


### PR DESCRIPTION
**Description of work.**
This fixes an oversight in the new `PaalmanPingsMonteCarloAbsorption` algorithm, where the cross-section values should be passed as doubles and not strings.

**To test:**
Code review should suffice.

<!-- Instructions for testing. -->

*There is no associated issue.*

*This does not require release notes since the algorithm was added in this release.*

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
