### PR TITLE
Abins: remove unnecessary check on parameters dict when testing data loaders

### DIFF
--- a/docs/source/concepts/AbinsImplementation.rst
+++ b/docs/source/concepts/AbinsImplementation.rst
@@ -120,9 +120,10 @@ code-specific tests e.g. *AbinsLoadGAUSSIANTest*.  To create a new
 reference data file with a specific build of Abins, instantiate a
 Loader and pass it to *save_ab_initio_test_data*. This takes two lines of Python, e.g.:
 
-:: python
+.. code-block:: python
+
    reader = abins.input.CRYSTALLoader(input_ab_initio_filename='my_calc.out')
-   reader.save_ab_initio_test_data(reader, 'my_new_test')
+   abins.input.Tester.save_ab_initio_test_data(reader, 'my_new_test')
 
 which will write the necessary *my_new_test_data.txt* file and
 *my_new_test_atomic_displacements_data_{k}.txt* files for each phonon wavevector.

--- a/scripts/abins/input/tester.py
+++ b/scripts/abins/input/tester.py
@@ -179,7 +179,7 @@ class Tester(object):
         """
         abins_type_data = ab_initio_reader.read_vibrational_or_phonon_data()
         data = {"datasets": abins_type_data.extract(),
-                "attributes": ab_initio_reader._clerk._attributes
+                "attributes": ab_initio_reader._clerk._attributes.copy()
                 }
         data["datasets"].update({"unit_cell": ab_initio_reader._clerk._data["unit_cell"]})
         return data
@@ -199,6 +199,9 @@ class Tester(object):
         """
 
         data = cls._get_reader_data(ab_initio_reader)
+
+        # Discard advanced_parameters cache as this is not relevant to loader tests
+        del data["attributes"]["advanced_parameters"]
 
         displacements = data["datasets"]["k_points_data"].pop("atomic_displacements")
         for i, eigenvector in displacements.items():

--- a/scripts/abins/input/tester.py
+++ b/scripts/abins/input/tester.py
@@ -1,11 +1,10 @@
 # Mantid Repository : https://github.com/mantidproject/mantid
 #
-# Copyright &copy; 2018 ISIS Rutherford Appleton Laboratory UKRI,
+# Copyright &copy; 2020 ISIS Rutherford Appleton Laboratory UKRI,
 #   NScD Oak Ridge National Laboratory, European Spallation Source,
 #   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
 # SPDX - License - Identifier: GPL - 3.0 +
 import json
-from typing import Any, Dict, Optional
 import numpy as np
 
 import abins
@@ -78,12 +77,6 @@ class Tester(object):
         # check attributes
         self.assertEqual(correct_data["attributes"]["hash"], data["attributes"]["hash"])
         self.assertEqual(correct_data["attributes"]["ab_initio_program"], data["attributes"]["ab_initio_program"])
-        # advanced_parameters is stored as a str but we unpack/compare to dict
-        # so comparison will tolerate unimportant formatting changes
-
-        self._compare_advanced_parameters(correct_data["attributes"]["advanced_parameters"],
-                                          json.loads(data["attributes"]["advanced_parameters"]))
-
         try:
             self.assertEqual(abins.test_helpers.find_file(filename + "." + extension),
                              data["attributes"]["filename"])
@@ -93,39 +86,6 @@ class Tester(object):
 
         # check datasets
         self.assertEqual(True, np.allclose(correct_data["datasets"]["unit_cell"], data["datasets"]["unit_cell"]))
-
-    def _compare_advanced_parameters(self,
-                                     ref_params: Dict[str, Any],
-                                     test_params: Dict[str, Any],
-                                     instrument: Optional[str] = None) -> None:
-        """Assert that relevant parts of advanced_parameters dict agree
-
-        Args:
-            instrument: identity of instrument for test
-            ref_params: advanced_parameters dictionary from reference data
-            test_params: advanded_parameters dictionary from test file
-
-        Raises:
-            AssertionError if data does not agree
-            ValueError if instrument does not match ref_params
-        """
-
-        if 'fwhm' in ref_params['instruments']:
-            self.assertEqual(test_params['instruments'], ref_params['instruments'])
-        else:
-            assert 'fwhm' not in test_params
-
-        #raise Exception("IS THIS EVEN WORTH CHECKING FOR THIS KIND OF TEST?")
-        if instrument:
-            if instrument not in ref_params['instruments']:
-                raise ValueError(f'Instrument "{instrument}" parameters are not in the reference data')
-            self.assertIn(instrument, ref_params['instruments'])
-            self.assertEqual(test_params['instruments'][instrument],
-                             ref_params['instruments'][instrument])
-
-        self.assertEqual(test_params['hdf_groups'], ref_params['hdf_groups'])
-        self.assertEqual(test_params['sampling'], ref_params['sampling'])
-        
 
     def _check_loader_data(self, correct_data=None, input_ab_initio_filename=None, extension=None, loader=None):
 
@@ -239,11 +199,6 @@ class Tester(object):
         """
 
         data = cls._get_reader_data(ab_initio_reader)
-
-        # Unpack advanced parameters into a dictionary for ease of comparison later.
-        # It might be wise to remove this and store escaped strings for consistency,
-        # but for now we don't want to disturb the old test data so follow its format.
-        data["attributes"]["advanced_parameters"] = json.loads(data["attributes"]["advanced_parameters"])
 
         displacements = data["datasets"]["k_points_data"].pop("atomic_displacements")
         for i, eigenvector in displacements.items():

--- a/scripts/abins/parameters.py
+++ b/scripts/abins/parameters.py
@@ -49,7 +49,7 @@ sampling = {
     'min_wavenumber': 0.0,  # minimal wavenumber in cm^-1 taken into account while creating workspaces (exclusive)
     'frequencies_threshold': 0.0,  # minimum included frequency
     's_relative_threshold': 0.01,  # low cutoff for S intensity (fraction of maximum S)
-    's_absolute_threshold': 10e-8,  # low cutoff for S intensity (absolute value)
+    's_absolute_threshold': 1e-7,  # low cutoff for S intensity (absolute value)
     'broadening_scheme': 'auto',
     }
 


### PR DESCRIPTION
**Description of work.**
The unit tests for Abins include a standardised check that data from many ab initio data files is imported correctly. The resulting object is compared to data from reference .dat files.

These files also contain a cache of the "advanced_parameters" at the point they were generated. This results in a need to regenerate test data whenever the advanced parameter defaults are changed/renamed/restructured.

Presumably the original purpose of this check was to ensure that parameters used in the file loading process are unchanged. However, at present abins.parameters is not used at all by the file loaders! There is no clear value in validating these parameters when the purpose of the test is to ensure that the file parsing and data object instantiation are working.

This commit therefore removes that check, and the code for writing such data to reference files. Old reference files will continue to pass tests as the presence of extra dict keys is tolerated.

**To test:**

Unit tests should pass as normal. They should also pass if changes are made to advanced parameters, e.g. by editing values in scripts/abins/parameters.py (within reasonable limits!)

*This does not require release notes* because it does not impact features, the API or performance outside of testing.

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
