### PR TITLE
Switch to explicit LRAutoReduction arguements for reduction calls

### DIFF
--- a/Framework/PythonInterface/plugins/algorithms/LRAutoReduction.py
+++ b/Framework/PythonInterface/plugins/algorithms/LRAutoReduction.py
@@ -654,45 +654,71 @@ class LRAutoReduction(PythonAlgorithm):
         # Write template before we start the computation
         self._write_template(data_set, run_number, first_run_of_set, sequence_number)
 
-        # input args for both reduction
-        kwargs = {
-            "InputWorkspace": self.event_data,
-            "NormalizationRunNumber": str(data_set.norm_file),
-            "SignalPeakPixelRange": data_set.DataPeakPixels,
-            "SubtractSignalBackground": data_set.DataBackgroundFlag,
-            "SignalBackgroundPixelRange": data_set.DataBackgroundRoi[:2],
-            "NormFlag": data_set.NormFlag,
-            "NormPeakPixelRange": data_set.NormPeakPixels,
-            "NormBackgroundPixelRange": data_set.NormBackgroundRoi,
-            "SubtractNormBackground": data_set.NormBackgroundFlag,
-            "LowResDataAxisPixelRangeFlag": data_set.data_x_range_flag,
-            "LowResDataAxisPixelRange": data_set.data_x_range,
-            "LowResNormAxisPixelRangeFlag": data_set.norm_x_range_flag,
-            "LowResNormAxisPixelRange": data_set.norm_x_range,
-            "TOFRange": data_set.DataTofRange,
-            "IncidentMediumSelected": incident_medium,
-            "GeometryCorrectionFlag": False,
-            "QMin": data_set.q_min,
-            "QStep": data_set.q_step,
-            "AngleOffset": data_set.angle_offset,
-            "AngleOffsetError": data_set.angle_offset_error,
-            "ScalingFactorFile": str(data_set.scaling_factor_file),
-            "SlitsWidthFlag": data_set.slits_width_flag,
-            "ApplyPrimaryFraction": True,
-            "SlitTolerance": slit_tolerance,
-            "PrimaryFractionRange": [data_set.clocking_from, data_set.clocking_to],
-            "OutputWorkspace": 'reflectivity_%s_%s_%s' % (first_run_of_set, sequence_number, run_number)
-        }
-
         # Execute the reduction for the selected normalization type
+        # NOTE: Did have all key-word args as **kwargs so didn't have to repeat args twice
+        #       but raised error for pickling EventWorkspace in LRReductionWithReference.
+        out_wksp_name = 'reflectivity_%s_%s_%s' % (first_run_of_set, sequence_number, run_number)
         norm_type = self.getProperty("NormalizationType").value
         if norm_type == "DirectBeam":
-            LiquidsReflectometryReduction(**kwargs)
+            LiquidsReflectometryReduction(
+                InputWorkspace=self.event_data,
+                NormalizationRunNumber=str(data_set.norm_file),
+                SignalPeakPixelRange=data_set.DataPeakPixels,
+                SubtractSignalBackground=data_set.DataBackgroundFlag,
+                SignalBackgroundPixelRange=data_set.DataBackgroundRoi[:2],
+                NormFlag=data_set.NormFlag,
+                NormPeakPixelRange=data_set.NormPeakPixels,
+                NormBackgroundPixelRange=data_set.NormBackgroundRoi,
+                SubtractNormBackground=data_set.NormBackgroundFlag,
+                LowResDataAxisPixelRangeFlag=data_set.data_x_range_flag,
+                LowResDataAxisPixelRange=data_set.data_x_range,
+                LowResNormAxisPixelRangeFlag=data_set.norm_x_range_flag,
+                LowResNormAxisPixelRange=data_set.norm_x_range,
+                TOFRange=data_set.DataTofRange,
+                IncidentMediumSelected=incident_medium,
+                GeometryCorrectionFlag=False,
+                QMin=data_set.q_min,
+                QStep=data_set.q_step,
+                AngleOffset=data_set.angle_offset,
+                AngleOffsetError=data_set.angle_offset_error,
+                ScalingFactorFile=str(data_set.scaling_factor_file),
+                SlitsWidthFlag=data_set.slits_width_flag,
+                ApplyPrimaryFraction=True,
+                SlitTolerance=slit_tolerance,
+                PrimaryFractionRange=[data_set.clocking_from, data_set.clocking_to],
+                OutputWorkspace=out_wksp_name)
 
         elif "WithReference":
             refl1d_parameters = self.getProperty("Refl1DModelParameters").value
-            kwargs['Refl1DModelParameters'] = refl1d_parameters
-            LRReductionWithReference(**kwargs)
+
+            LRReductionWithReference(
+                InputWorkspace=self.event_data,
+                NormalizationRunNumber=str(data_set.norm_file),
+                SignalPeakPixelRange=data_set.DataPeakPixels,
+                SubtractSignalBackground=data_set.DataBackgroundFlag,
+                SignalBackgroundPixelRange=data_set.DataBackgroundRoi[:2],
+                NormFlag=data_set.NormFlag,
+                NormPeakPixelRange=data_set.NormPeakPixels,
+                NormBackgroundPixelRange=data_set.NormBackgroundRoi,
+                SubtractNormBackground=data_set.NormBackgroundFlag,
+                LowResDataAxisPixelRangeFlag=data_set.data_x_range_flag,
+                LowResDataAxisPixelRange=data_set.data_x_range,
+                LowResNormAxisPixelRangeFlag=data_set.norm_x_range_flag,
+                LowResNormAxisPixelRange=data_set.norm_x_range,
+                TOFRange=data_set.DataTofRange,
+                IncidentMediumSelected=incident_medium,
+                GeometryCorrectionFlag=False,
+                QMin=data_set.q_min,
+                QStep=data_set.q_step,
+                AngleOffset=data_set.angle_offset,
+                AngleOffsetError=data_set.angle_offset_error,
+                ScalingFactorFile=str(data_set.scaling_factor_file),
+                SlitsWidthFlag=data_set.slits_width_flag,
+                ApplyPrimaryFraction=True,
+                SlitTolerance=slit_tolerance,
+                PrimaryFractionRange=[data_set.clocking_from, data_set.clocking_to],
+                Refl1DModelParameters=refl1d_parameters,
+                OutputWorkspace=out_wksp_name)
 
         # Put the reflectivity curve together
         self._save_partial_output(data_set, first_run_of_set, sequence_number, run_number)


### PR DESCRIPTION
**Description of work.**

Switch from `**kwargs` dictionary for arguments to either `LiquidsReflectometryReduction` or `LRWithReference` inside `LRAutoReduction` (which are all the same except for one additional arg in `LRWithReference`) to explicitly stating the arguments to each algorithm.

Fixes #28920 . 

*This does not require release notes* because this is a bug fix to a new feature that is already in the release notes.

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
