### PR TITLE
28927 ill d7 signed two theta

### DIFF
--- a/Framework/DataHandling/src/LoadILLPolarizedDiffraction.cpp
+++ b/Framework/DataHandling/src/LoadILLPolarizedDiffraction.cpp
@@ -446,11 +446,20 @@ API::MatrixWorkspace_sptr LoadILLPolarizedDiffraction::convertSpectrumAxis(
   convertSpectrumAxis->initialize();
   convertSpectrumAxis->setProperty("InputWorkspace", workspace);
   convertSpectrumAxis->setProperty("OutputWorkspace", "__unused_for_child");
-  convertSpectrumAxis->setProperty("Target", "Theta");
+  convertSpectrumAxis->setProperty("Target", "SignedTheta");
   convertSpectrumAxis->setProperty("EMode", "Direct");
   convertSpectrumAxis->setProperty("OrderAxis", false);
   convertSpectrumAxis->execute();
-  return convertSpectrumAxis->getProperty("OutputWorkspace");
+  workspace = convertSpectrumAxis->getProperty("OutputWorkspace");
+
+  IAlgorithm_sptr changeSign = createChildAlgorithm("ConvertAxisByFormula");
+  changeSign->initialize();
+  changeSign->setProperty("InputWorkspace", workspace);
+  changeSign->setProperty("OutputWorkspace", "__unused_for_child");
+  changeSign->setProperty("Axis", "Y");
+  changeSign->setProperty("Formula", "-y");
+  changeSign->execute();
+  return changeSign->getProperty("OutputWorkspace");
 }
 
 /**

--- a/Framework/DataHandling/test/LoadILLPolarizedDiffractionTest.h
+++ b/Framework/DataHandling/test/LoadILLPolarizedDiffractionTest.h
@@ -565,7 +565,7 @@ public:
     LoadILLPolarizedDiffraction alg;
     alg.setChild(true);
     alg.initialize();
-    TS_ASSERT_THROWS_NOTHING(alg.setPropertyValue("Filename", "394882"))
+    TS_ASSERT_THROWS_NOTHING(alg.setPropertyValue("Filename", "394458"))
     TS_ASSERT_THROWS_NOTHING(alg.setPropertyValue("OutputWorkspace", "_outWS"))
     TS_ASSERT_THROWS_NOTHING(
         alg.setPropertyValue("PositionCalibration", "None"))

--- a/Framework/DataHandling/test/LoadILLPolarizedDiffractionTest.h
+++ b/Framework/DataHandling/test/LoadILLPolarizedDiffractionTest.h
@@ -560,6 +560,48 @@ public:
     }
   }
 
+  void test_D7_sign_TwoTheta() {
+    // Tests pixel position alignment coming from the YIG calibration IPF file
+    LoadILLPolarizedDiffraction alg;
+    alg.setChild(true);
+    alg.initialize();
+    TS_ASSERT_THROWS_NOTHING(alg.setPropertyValue("Filename", "394882"))
+    TS_ASSERT_THROWS_NOTHING(alg.setPropertyValue("OutputWorkspace", "_outWS"))
+    TS_ASSERT_THROWS_NOTHING(
+        alg.setPropertyValue("PositionCalibration", "None"))
+    TS_ASSERT_THROWS_NOTHING(alg.setProperty("ConvertToScatteringAngle", true))
+    TS_ASSERT_THROWS_NOTHING(alg.setProperty("TransposeMonochromatic", false))
+    TS_ASSERT_THROWS_NOTHING(alg.execute())
+    TS_ASSERT(alg.isExecuted())
+
+    WorkspaceGroup_sptr outputWS = alg.getProperty("OutputWorkspace");
+    TS_ASSERT(outputWS)
+    TS_ASSERT(outputWS->isGroup())
+    TS_ASSERT_EQUALS(outputWS->getNumberOfEntries(), 1)
+    do_test_general_features(outputWS, "monochromatic");
+
+    for (auto entry_no = 0; entry_no < outputWS->getNumberOfEntries();
+         ++entry_no) {
+      MatrixWorkspace_sptr workspaceEntry =
+          std::dynamic_pointer_cast<Mantid::API::MatrixWorkspace>(
+              outputWS->getItem(entry_no));
+      TS_ASSERT(workspaceEntry)
+
+      TS_ASSERT_DELTA(workspaceEntry->detectorInfo().signedTwoTheta(0) * RAD_2_DEG,
+                      -88.87, 0.01)
+      TS_ASSERT_DELTA(workspaceEntry->detectorInfo().signedTwoTheta(43) * RAD_2_DEG,
+                      -46.08, 0.01)
+      TS_ASSERT_DELTA(workspaceEntry->detectorInfo().signedTwoTheta(44) * RAD_2_DEG,
+                      -42.65, 0.01)
+      TS_ASSERT_DELTA(workspaceEntry->detectorInfo().signedTwoTheta(87) * RAD_2_DEG,
+                      0.13, 0.01)
+      TS_ASSERT_DELTA(workspaceEntry->detectorInfo().signedTwoTheta(88) * RAD_2_DEG,
+                      -0.80, 0.01)
+      TS_ASSERT_DELTA(workspaceEntry->detectorInfo().signedTwoTheta(131) * RAD_2_DEG,
+                      41.99, 0.01)
+    }
+  }
+
   void do_test_general_features(WorkspaceGroup_sptr outputWS,
                                 std::string measurementMode) {
     for (auto entry_no = 0; entry_no < outputWS->getNumberOfEntries();

--- a/Framework/DataHandling/test/LoadILLPolarizedDiffractionTest.h
+++ b/Framework/DataHandling/test/LoadILLPolarizedDiffractionTest.h
@@ -382,23 +382,17 @@ public:
               outputWS->getItem(entry_no));
       TS_ASSERT(workspaceEntry)
 
-      TS_ASSERT_DELTA(workspaceEntry->detectorInfo().signedTwoTheta(0) *
-                          RAD_2_DEG,
+      TS_ASSERT_DELTA(workspaceEntry->detectorInfo().twoTheta(0) * RAD_2_DEG,
                       12.66, 0.01)
-      TS_ASSERT_DELTA(workspaceEntry->detectorInfo().signedTwoTheta(43) *
-                          RAD_2_DEG,
+      TS_ASSERT_DELTA(workspaceEntry->detectorInfo().twoTheta(43) * RAD_2_DEG,
                       55.45, 0.01)
-      TS_ASSERT_DELTA(workspaceEntry->detectorInfo().signedTwoTheta(44) *
-                          RAD_2_DEG,
+      TS_ASSERT_DELTA(workspaceEntry->detectorInfo().twoTheta(44) * RAD_2_DEG,
                       58.79, 0.01)
-      TS_ASSERT_DELTA(workspaceEntry->detectorInfo().signedTwoTheta(87) *
-                          RAD_2_DEG,
+      TS_ASSERT_DELTA(workspaceEntry->detectorInfo().twoTheta(87) * RAD_2_DEG,
                       101.58, 0.01)
-      TS_ASSERT_DELTA(workspaceEntry->detectorInfo().signedTwoTheta(88) *
-                          RAD_2_DEG,
+      TS_ASSERT_DELTA(workspaceEntry->detectorInfo().twoTheta(88) * RAD_2_DEG,
                       100.78, 0.01)
-      TS_ASSERT_DELTA(workspaceEntry->detectorInfo().signedTwoTheta(131) *
-                          RAD_2_DEG,
+      TS_ASSERT_DELTA(workspaceEntry->detectorInfo().twoTheta(131) * RAD_2_DEG,
                       143.57, 0.01)
     }
   }
@@ -430,23 +424,17 @@ public:
               outputWS->getItem(entry_no));
       TS_ASSERT(workspaceEntry)
 
-      TS_ASSERT_DELTA(workspaceEntry->detectorInfo().signedTwoTheta(0) *
-                          RAD_2_DEG,
+      TS_ASSERT_DELTA(workspaceEntry->detectorInfo().twoTheta(0) * RAD_2_DEG,
                       10.86, 0.01)
-      TS_ASSERT_DELTA(workspaceEntry->detectorInfo().signedTwoTheta(43) *
-                          RAD_2_DEG,
+      TS_ASSERT_DELTA(workspaceEntry->detectorInfo().twoTheta(43) * RAD_2_DEG,
                       53.81, 0.01)
-      TS_ASSERT_DELTA(workspaceEntry->detectorInfo().signedTwoTheta(44) *
-                          RAD_2_DEG,
+      TS_ASSERT_DELTA(workspaceEntry->detectorInfo().twoTheta(44) * RAD_2_DEG,
                       57.06, 0.01)
-      TS_ASSERT_DELTA(workspaceEntry->detectorInfo().signedTwoTheta(87) *
-                          RAD_2_DEG,
+      TS_ASSERT_DELTA(workspaceEntry->detectorInfo().twoTheta(87) * RAD_2_DEG,
                       99.45, 0.01)
-      TS_ASSERT_DELTA(workspaceEntry->detectorInfo().signedTwoTheta(88) *
-                          RAD_2_DEG,
+      TS_ASSERT_DELTA(workspaceEntry->detectorInfo().twoTheta(88) * RAD_2_DEG,
                       101.38, 0.01)
-      TS_ASSERT_DELTA(workspaceEntry->detectorInfo().signedTwoTheta(131) *
-                          RAD_2_DEG,
+      TS_ASSERT_DELTA(workspaceEntry->detectorInfo().twoTheta(131) * RAD_2_DEG,
                       144.17, 0.01)
     }
   }
@@ -479,23 +467,17 @@ public:
               outputWS->getItem(entry_no));
       TS_ASSERT(workspaceEntry)
 
-      TS_ASSERT_DELTA(workspaceEntry->detectorInfo().signedTwoTheta(0) *
-                          RAD_2_DEG,
+      TS_ASSERT_DELTA(workspaceEntry->detectorInfo().twoTheta(0) * RAD_2_DEG,
                       10.86, 0.01)
-      TS_ASSERT_DELTA(workspaceEntry->detectorInfo().signedTwoTheta(43) *
-                          RAD_2_DEG,
+      TS_ASSERT_DELTA(workspaceEntry->detectorInfo().twoTheta(43) * RAD_2_DEG,
                       53.81, 0.01)
-      TS_ASSERT_DELTA(workspaceEntry->detectorInfo().signedTwoTheta(44) *
-                          RAD_2_DEG,
+      TS_ASSERT_DELTA(workspaceEntry->detectorInfo().twoTheta(44) * RAD_2_DEG,
                       57.06, 0.01)
-      TS_ASSERT_DELTA(workspaceEntry->detectorInfo().signedTwoTheta(87) *
-                          RAD_2_DEG,
+      TS_ASSERT_DELTA(workspaceEntry->detectorInfo().twoTheta(87) * RAD_2_DEG,
                       99.45, 0.01)
-      TS_ASSERT_DELTA(workspaceEntry->detectorInfo().signedTwoTheta(88) *
-                          RAD_2_DEG,
+      TS_ASSERT_DELTA(workspaceEntry->detectorInfo().twoTheta(88) * RAD_2_DEG,
                       101.38, 0.01)
-      TS_ASSERT_DELTA(workspaceEntry->detectorInfo().signedTwoTheta(131) *
-                          RAD_2_DEG,
+      TS_ASSERT_DELTA(workspaceEntry->detectorInfo().twoTheta(131) * RAD_2_DEG,
                       144.17, 0.01)
     }
   }

--- a/Framework/DataHandling/test/LoadILLPolarizedDiffractionTest.h
+++ b/Framework/DataHandling/test/LoadILLPolarizedDiffractionTest.h
@@ -587,17 +587,23 @@ public:
               outputWS->getItem(entry_no));
       TS_ASSERT(workspaceEntry)
 
-      TS_ASSERT_DELTA(workspaceEntry->detectorInfo().signedTwoTheta(0) * RAD_2_DEG,
+      TS_ASSERT_DELTA(workspaceEntry->detectorInfo().signedTwoTheta(0) *
+                          RAD_2_DEG,
                       -88.87, 0.01)
-      TS_ASSERT_DELTA(workspaceEntry->detectorInfo().signedTwoTheta(43) * RAD_2_DEG,
+      TS_ASSERT_DELTA(workspaceEntry->detectorInfo().signedTwoTheta(43) *
+                          RAD_2_DEG,
                       -46.08, 0.01)
-      TS_ASSERT_DELTA(workspaceEntry->detectorInfo().signedTwoTheta(44) * RAD_2_DEG,
+      TS_ASSERT_DELTA(workspaceEntry->detectorInfo().signedTwoTheta(44) *
+                          RAD_2_DEG,
                       -42.65, 0.01)
-      TS_ASSERT_DELTA(workspaceEntry->detectorInfo().signedTwoTheta(87) * RAD_2_DEG,
+      TS_ASSERT_DELTA(workspaceEntry->detectorInfo().signedTwoTheta(87) *
+                          RAD_2_DEG,
                       0.13, 0.01)
-      TS_ASSERT_DELTA(workspaceEntry->detectorInfo().signedTwoTheta(88) * RAD_2_DEG,
+      TS_ASSERT_DELTA(workspaceEntry->detectorInfo().signedTwoTheta(88) *
+                          RAD_2_DEG,
                       -0.80, 0.01)
-      TS_ASSERT_DELTA(workspaceEntry->detectorInfo().signedTwoTheta(131) * RAD_2_DEG,
+      TS_ASSERT_DELTA(workspaceEntry->detectorInfo().signedTwoTheta(131) *
+                          RAD_2_DEG,
                       41.99, 0.01)
     }
   }

--- a/Framework/DataHandling/test/LoadILLPolarizedDiffractionTest.h
+++ b/Framework/DataHandling/test/LoadILLPolarizedDiffractionTest.h
@@ -586,25 +586,14 @@ public:
           std::dynamic_pointer_cast<Mantid::API::MatrixWorkspace>(
               outputWS->getItem(entry_no));
       TS_ASSERT(workspaceEntry)
-
-      TS_ASSERT_DELTA(workspaceEntry->detectorInfo().signedTwoTheta(0) *
-                          RAD_2_DEG,
-                      -88.87, 0.01)
-      TS_ASSERT_DELTA(workspaceEntry->detectorInfo().signedTwoTheta(43) *
-                          RAD_2_DEG,
-                      -46.08, 0.01)
-      TS_ASSERT_DELTA(workspaceEntry->detectorInfo().signedTwoTheta(44) *
-                          RAD_2_DEG,
-                      -42.65, 0.01)
-      TS_ASSERT_DELTA(workspaceEntry->detectorInfo().signedTwoTheta(87) *
-                          RAD_2_DEG,
-                      0.13, 0.01)
-      TS_ASSERT_DELTA(workspaceEntry->detectorInfo().signedTwoTheta(88) *
-                          RAD_2_DEG,
-                      -0.80, 0.01)
-      TS_ASSERT_DELTA(workspaceEntry->detectorInfo().signedTwoTheta(131) *
-                          RAD_2_DEG,
-                      41.99, 0.01)
+      auto axis = workspaceEntry->getAxis(1);
+      TS_ASSERT(!axis->isSpectra())
+      TS_ASSERT_DELTA(axis->getValue(0), -88.87, 0.01)
+      TS_ASSERT_DELTA(axis->getValue(43), -46.08, 0.01)
+      TS_ASSERT_DELTA(axis->getValue(44), -42.65, 0.01)
+      TS_ASSERT_DELTA(axis->getValue(87), 0.13, 0.01)
+      TS_ASSERT_DELTA(axis->getValue(88), -0.80, 0.01)
+      TS_ASSERT_DELTA(axis->getValue(131), 41.99, 0.01)
     }
   }
 

--- a/Testing/Data/UnitTest/ILL/D7/394458.nxs.md5
+++ b/Testing/Data/UnitTest/ILL/D7/394458.nxs.md5
@@ -1,0 +1,1 @@
+d627baac49d8228d967253ee0ee75bfc

--- a/instrument/D7_Definition.xml
+++ b/instrument/D7_Definition.xml
@@ -35,6 +35,7 @@
       <along-beam axis="z"/>
       <pointing-up axis="y"/>
       <handedness val="right"/>
+      <theta-sign axis="x" />
     </reference-frame>
     <default-view axis-view="z-" view="3D"/>
   </defaults>


### PR DESCRIPTION
**Description of work.**

Changed the target for ConvertSpectrumAxis algorithm invoked by ticking 'ConvertToSpectrumAxis' box from 'Theta' to 'signedTheta'. Now, the algorithm should return the signed twoTheta value, which is required to properly take into account that detectors can be located on either side of the beam axis, for example during YIG scans. 

**To test:**

<!-- Instructions for testing. -->

Load ILL D7 data from a YIG scan, for example 394458.nxs from run 193 taken on 28.08.2019 and tick the 'ConvertToScatteringAngle'.  Observe the labels of the spectrum axis, the value for index 0 spectrum should be -88.88 (degrees).

Fixes #28927. 

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
-->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
