### PR TITLE
Add apply to all button to plot axes properties

### DIFF
--- a/docs/source/release/v5.1.0/mantidworkbench.rst
+++ b/docs/source/release/v5.1.0/mantidworkbench.rst
@@ -12,7 +12,8 @@ New
 - There is now a dialog for project saving that allows you to choose between saving all workspaces or only saving workspaces which have been altered.
 - A default legend location can be set in the Workbench settings.
 - The Sample Transmission Calculator is now implemented in workbench.
-- The axis tick markers in a plot can be switched between Log and decimal formats indepentantly of the axes scale.
+- The axis tick markers in a plot can be switched between Log and decimal formats independently of the axes scale.
+- Axes limits and labels can be set simultaneously for all subplots with the `Apply to all` button.
 
 Improvements
 ############

--- a/docs/source/workbench/plotwindow.rst
+++ b/docs/source/workbench/plotwindow.rst
@@ -57,7 +57,7 @@ window. There are two tabs within this window: axes options and curve options.
 In the "Axes" tab you can change the figure's title, the axes limits and scale
 and change the axes labels. There is also the "(Re-)Generate automatic legend"
 tick box at the bottom, make sure this is ticked if you want to update your
-legend.
+legend. The apply all button applies the current settings to all axes in the figure.
 
 In the "Curves" tab you can change the properties of curves within your figure.
 The drop down menu at the top gives a list of the curves present in the figure,

--- a/qt/python/mantidqt/widgets/plotconfigdialog/axestabwidget/axes_tab_widget.ui
+++ b/qt/python/mantidqt/widgets/plotconfigdialog/axestabwidget/axes_tab_widget.ui
@@ -69,6 +69,45 @@
      </item>
     </layout>
    </item>
+   <item row="1" column="0">
+    <spacer name="verticalSpacer_6">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>20</width>
+       <height>40</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
+   <item row="7" column="0">
+    <spacer name="verticalSpacer">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>20</width>
+       <height>40</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
+   <item row="19" column="0">
+    <spacer name="verticalSpacer_2">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>20</width>
+       <height>40</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
    <item row="9" column="0">
     <layout class="QHBoxLayout" name="horizontalLayout_2">
      <item alignment="Qt::AlignHCenter">
@@ -108,75 +147,6 @@
       </widget>
      </item>
     </layout>
-   </item>
-   <item row="0" column="0">
-    <layout class="QVBoxLayout" name="axes_selector_layout">
-     <property name="topMargin">
-      <number>5</number>
-     </property>
-     <item>
-      <widget class="QLabel" name="label">
-       <property name="text">
-        <string>Select a set of axes</string>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QComboBox" name="select_axes_combo_box"/>
-     </item>
-    </layout>
-   </item>
-   <item row="1" column="0">
-    <spacer name="verticalSpacer_6">
-     <property name="orientation">
-      <enum>Qt::Vertical</enum>
-     </property>
-     <property name="sizeHint" stdset="0">
-      <size>
-       <width>20</width>
-       <height>40</height>
-      </size>
-     </property>
-    </spacer>
-   </item>
-   <item row="7" column="0">
-    <spacer name="verticalSpacer">
-     <property name="orientation">
-      <enum>Qt::Vertical</enum>
-     </property>
-     <property name="sizeHint" stdset="0">
-      <size>
-       <width>20</width>
-       <height>40</height>
-      </size>
-     </property>
-    </spacer>
-   </item>
-   <item row="3" column="0">
-    <spacer name="verticalSpacer_3">
-     <property name="orientation">
-      <enum>Qt::Vertical</enum>
-     </property>
-     <property name="sizeHint" stdset="0">
-      <size>
-       <width>20</width>
-       <height>40</height>
-      </size>
-     </property>
-    </spacer>
-   </item>
-   <item row="19" column="0">
-    <spacer name="verticalSpacer_2">
-     <property name="orientation">
-      <enum>Qt::Vertical</enum>
-     </property>
-     <property name="sizeHint" stdset="0">
-      <size>
-       <width>20</width>
-       <height>40</height>
-      </size>
-     </property>
-    </spacer>
    </item>
    <item row="18" column="0">
     <layout class="QGridLayout" name="gridLayout">
@@ -356,6 +326,30 @@
      </item>
     </layout>
    </item>
+   <item row="21" column="0">
+    <layout class="QHBoxLayout" name="horizontalLayout_3">
+     <item>
+      <spacer name="horizontalSpacer">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>40</width>
+         <height>20</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+     <item>
+      <widget class="QPushButton" name="apply_all_button">
+       <property name="text">
+        <string>Apply to all</string>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
    <item row="5" column="0">
     <layout class="QVBoxLayout" name="verticalLayout">
      <item>
@@ -373,6 +367,49 @@
       </widget>
      </item>
     </layout>
+   </item>
+   <item row="0" column="0">
+    <layout class="QVBoxLayout" name="axes_selector_layout">
+     <property name="topMargin">
+      <number>5</number>
+     </property>
+     <item>
+      <widget class="QLabel" name="label">
+       <property name="text">
+        <string>Select a set of axes</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QComboBox" name="select_axes_combo_box"/>
+     </item>
+    </layout>
+   </item>
+   <item row="1" column="0">
+    <spacer name="verticalSpacer_6">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>20</width>
+       <height>40</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
+   <item row="3" column="0">
+    <spacer name="verticalSpacer_3">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>20</width>
+       <height>40</height>
+      </size>
+     </property>
+    </spacer>
    </item>
   </layout>
  </widget>

--- a/qt/python/mantidqt/widgets/plotconfigdialog/axestabwidget/presenter.py
+++ b/qt/python/mantidqt/widgets/plotconfigdialog/axestabwidget/presenter.py
@@ -102,10 +102,27 @@ class AxesTabWidgetPresenter:
         """Update the axes with the user inputted properties"""
         # Make sure current_view_props is up to date if values have been changed
         self.axis_changed()
-        ax_names = self.axes_names_dict.keys()
         view_props = self.current_view_props
-        for key in ax_names:
-            ax = self.axes_names_dict[key]
+        for ax in self.axes_names_dict.values():
+
+            if self.current_view_props['minor_ticks']:
+                ax.minorticks_on()
+            else:
+                ax.minorticks_off()
+
+            ax.show_minor_gridlines = self.current_view_props['minor_gridlines']
+
+            # If the grid is enabled update it
+            if ax.show_minor_gridlines:
+                if ax.xaxis._gridOnMajor and ax.yaxis._gridOnMajor:
+                    ax.grid(True, which='minor')
+                elif ax.xaxis._gridOnMajor:
+                    ax.grid(True, axis='x', which='minor')
+                elif ax.yaxis._gridOnMajor:
+                    ax.grid(True, axis='y', which='minor')
+            else:
+                ax.grid(False, which='minor')
+
             if "xlabel" in view_props:
                 ax.set_xlabel(view_props['xlabel'])
                 ax.set_xscale(view_props['xscale'])

--- a/qt/python/mantidqt/widgets/plotconfigdialog/axestabwidget/presenter.py
+++ b/qt/python/mantidqt/widgets/plotconfigdialog/axestabwidget/presenter.py
@@ -41,6 +41,7 @@ class AxesTabWidgetPresenter:
             self.update_view)
         self.view.axis_button_group.buttonClicked.connect(
             self.axis_changed)
+        self.view.apply_all_button.clicked.connect(self.apply_all_properties)
         self.view.show_minor_ticks_check_box.toggled.connect(
             self.show_minor_ticks_checked)
 
@@ -95,6 +96,39 @@ class AxesTabWidgetPresenter:
             ax.set_zscale(self.current_view_props['zscale'])
             ax.set_zlim3d(self.current_view_props['zlim'])
 
+        self.update_view()
+
+    def apply_all_properties(self):
+        """Update the axes with the user inputted properties"""
+        # Make sure current_view_props is up to date if values have been changed
+        self.axis_changed()
+        ax_names = self.axes_names_dict.keys()
+        view_props = self.current_view_props
+        for key in ax_names:
+            ax = self.axes_names_dict[key]
+            if "xlabel" in view_props:
+                ax.set_xlabel(view_props['xlabel'])
+                ax.set_xscale(view_props['xscale'])
+
+                if isinstance(ax, Axes3D):
+                    ax.set_xlim3d(view_props['xlim'])
+                else:
+                    ax.set_xlim(view_props['xlim'])
+
+            if "ylabel" in view_props:
+                ax.set_ylabel(view_props['ylabel'])
+                ax.set_yscale(view_props['yscale'])
+
+                if isinstance(ax, Axes3D):
+                    ax.set_ylim3d(view_props['ylim'])
+                else:
+                    ax.set_ylim(view_props['ylim'])
+
+            if "zlabel" in view_props:
+                ax.set_zlabel(view_props['zlabel'])
+                ax.set_zscale(view_props['zscale'])
+                ax.set_zlim3d(view_props['zlim'])
+            ax.figure.canvas.draw()
         self.update_view()
 
     def get_selected_ax(self):

--- a/qt/python/mantidqt/widgets/plotconfigdialog/axestabwidget/test/test_axestabwidgetpresenter.py
+++ b/qt/python/mantidqt/widgets/plotconfigdialog/axestabwidget/test/test_axestabwidgetpresenter.py
@@ -74,6 +74,32 @@ class AxesTabWidgetPresenterTest(unittest.TestCase):
                     presenter.current_view_props.yscale)
                 ax_mock.minorticks_on.assert_called_once()
 
+    def test_apply_all_properties_calls_setters_with_correct_properties(self):
+        ax_mock_1 = mock.MagicMock()
+        ax_mock_2 = mock.MagicMock()
+        presenter = self._generate_presenter()
+        presenter.axes_names_dict = {'1': ax_mock_1, '2': ax_mock_2}
+        with mock.patch.object(presenter, 'get_selected_ax', lambda: ax_mock_1):
+            with mock.patch.object(presenter, 'update_view', lambda: None):
+                presenter.current_view_props = presenter.get_selected_ax_properties()
+                presenter.apply_all_properties()
+                # Mock properties object and view then test that the view's setters
+                # are called with the correct property values
+                for key in presenter.axes_names_dict.keys():
+                    ax_mock = presenter.axes_names_dict[key]
+                    ax_mock.set_xlim.assert_called_once_with(
+                        presenter.current_view_props.xlim)
+                    ax_mock.set_xlabel.assert_called_once_with(
+                        presenter.current_view_props.xlabel)
+                    ax_mock.set_xscale.assert_called_once_with(
+                        presenter.current_view_props.xscale)
+                    ax_mock.set_ylim.assert_called_once_with(
+                        presenter.current_view_props.ylim)
+                    ax_mock.set_ylabel.assert_called_once_with(
+                        presenter.current_view_props.ylabel)
+                    ax_mock.set_yscale.assert_called_once_with(
+                        presenter.current_view_props.yscale)
+
     def test_get_axes_names_dict(self):
         actual_dict = get_axes_names_dict(self.fig)
         expected = {"My Axes: (0, 0)": self.fig.get_axes()[0],


### PR DESCRIPTION
**Description of work.**

This PR adds a button to the axes tab of the plot properties dialogue that sets all the axes properties to be the same as the current visible one.

**Report to:** Steve King

**To test:**

1. Load some data and make a tile plot.
2. open the plot dialogue dialogue.
3. one one axes, change the axes label and limits.
4. click apply to all, this should change all the subplots in the figure to have these settings.
5. check that this works when starting from other subplots.

Fixes #28907 

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
