### PR TITLE
Use RefRoi for conversion to Q in RRO

### DIFF
--- a/Framework/Reflectometry/inc/MantidReflectometry/ReflectometryReductionOne2.h
+++ b/Framework/Reflectometry/inc/MantidReflectometry/ReflectometryReductionOne2.h
@@ -82,6 +82,7 @@ private:
   Mantid::API::MatrixWorkspace_sptr
   monitorCorrection(Mantid::API::MatrixWorkspace_sptr detectorWS);
   // convert to momentum transfer
+  bool useDetectorAngleForQConversion(const MatrixWorkspace_sptr &ws) const;
   Mantid::API::MatrixWorkspace_sptr
   convertToQ(const Mantid::API::MatrixWorkspace_sptr &inputWS);
   // Get the twoTheta width of a given detector
@@ -124,7 +125,7 @@ private:
   Mantid::API::MatrixWorkspace_sptr
   constructIvsLamWS(const API::MatrixWorkspace_sptr &detectorWS);
   // Whether summation should be done in Q or the default lambda
-  bool summingInQ();
+  bool summingInQ() const;
   // Get projected coordinates onto twoThetaR
   void getProjectedLambdaRange(const double lambda, const double twoTheta,
                                const double bLambda, const double bTwoTheta,

--- a/Framework/Reflectometry/src/ReflectometryReductionOne2.cpp
+++ b/Framework/Reflectometry/src/ReflectometryReductionOne2.cpp
@@ -885,7 +885,7 @@ void ReflectometryReductionOne2::findWavelengthMinMax(
       m_wavelengthMax = projectedMax;
       first = false;
     } else {
-      m_wavelengthMin = std::min(m_wavelengthMax, projectedMin);
+      m_wavelengthMin = std::min(m_wavelengthMin, projectedMin);
       m_wavelengthMax = std::max(m_wavelengthMax, projectedMax);
     }
   }

--- a/Framework/Reflectometry/src/ReflectometryReductionOne2.cpp
+++ b/Framework/Reflectometry/src/ReflectometryReductionOne2.cpp
@@ -42,6 +42,9 @@ namespace {
 std::string const OUTPUT_WORKSPACE_DEFAULT_PREFIX("IvsQ");
 std::string const OUTPUT_WORKSPACE_WAVELENGTH_DEFAULT_PREFIX("IvsLam");
 
+static constexpr double degToRad = M_PI / 180.;
+static constexpr double radToDeg = 180. / M_PI;
+
 /** Get the twoTheta angle for the centre of the detector associated with the
  * given spectrum
  *
@@ -773,7 +776,7 @@ void ReflectometryReductionOne2::findTheta0() {
   g_log.debug("theta0: " + std::to_string(theta0()) + " degrees\n");
 
   // Convert to radians
-  m_theta0 *= M_PI / 180.0;
+  m_theta0 *= degToRad;
 }
 
 /**
@@ -1200,9 +1203,9 @@ void ReflectometryReductionOne2::getProjectedLambdaRange(
   // We cannot project pixels below the horizon angle
   if (twoTheta <= theta0()) {
     throw std::runtime_error(
-        "Cannot process twoTheta=" + std::to_string(twoTheta * 180.0 / M_PI) +
+        "Cannot process twoTheta=" + std::to_string(twoTheta * radToDeg) +
         " as it is below the horizon angle=" +
-        std::to_string(theta0() * 180.0 / M_PI));
+        std::to_string(theta0() * radToDeg));
   }
 
   // Get the angle from twoThetaR to this detector
@@ -1229,7 +1232,7 @@ void ReflectometryReductionOne2::getProjectedLambdaRange(
   } catch (std::exception &ex) {
     throw std::runtime_error(
         "Failed to project (lambda, twoTheta) = (" + std::to_string(lambda) +
-        "," + std::to_string(twoTheta * 180.0 / M_PI) + ") onto twoThetaR = " +
+        "," + std::to_string(twoTheta * radToDeg) + ") onto twoThetaR = " +
         std::to_string(twoThetaRVal) + ": " + ex.what());
   }
 }

--- a/Framework/Reflectometry/src/ReflectometryReductionOne2.cpp
+++ b/Framework/Reflectometry/src/ReflectometryReductionOne2.cpp
@@ -1014,7 +1014,9 @@ MatrixWorkspace_sptr ReflectometryReductionOne2::constructIvsLamWS(
   MatrixWorkspace_sptr outputWS = WorkspaceFactory::Instance().create(
       detectorWS, numGroups, numBins, numBins - 1);
 
-  // Loop through each detector group in the input
+  // Loop through each detector group in the input and collate the related list
+  // of spectrum numbers for the output
+  std::vector<SpectrumNumber> spectrumNumbers;
   for (size_t groupIdx = 0; groupIdx < numGroups; ++groupIdx) {
     // Get the detectors in this group
     auto &detectors = detectorGroups()[groupIdx];
@@ -1028,12 +1030,12 @@ MatrixWorkspace_sptr ReflectometryReductionOne2::constructIvsLamWS(
     outSpec.clearDetectorIDs();
     outSpec.addDetectorID(twoThetaRDetID);
     // Set the spectrum number from the twoThetaR detector
-    SpectrumNumber specNum =
-        detectorWS->indexInfo().spectrumNumber(twoThetaRIdx);
-    auto indexInf = outputWS->indexInfo();
-    indexInf.setSpectrumNumbers(specNum, specNum);
-    outputWS->setIndexInfo(indexInf);
+    spectrumNumbers.emplace_back(
+        detectorWS->indexInfo().spectrumNumber(twoThetaRIdx));
   }
+  auto indexInf = outputWS->indexInfo();
+  indexInf.setSpectrumNumbers(std::move(spectrumNumbers));
+  outputWS->setIndexInfo(indexInf);
 
   return outputWS;
 }

--- a/Framework/Reflectometry/test/ReflectometryReductionOne2Test.h
+++ b/Framework/Reflectometry/test/ReflectometryReductionOne2Test.h
@@ -883,7 +883,7 @@ public:
         AnalysisDataService::Instance().retrieve("IvsQ"));
     checkWorkspaceHistory(outputWS,
                           {"ExtractSpectra", "GroupDetectors", "ConvertUnits",
-                           "CropWorkspace", "RefRoi"});
+                           "CropWorkspace", "ConvertUnits"});
   }
 
   void test_background_subtraction_with_default_properties() {
@@ -897,7 +897,7 @@ public:
     // used for the background subtraction
     checkWorkspaceHistory(outputWS, {"ReflectometryBackgroundSubtraction",
                                      "GroupDetectors", "ConvertUnits",
-                                     "CropWorkspace", "RefRoi"});
+                                     "CropWorkspace", "ConvertUnits"});
     checkHistoryAlgorithmProperties(
         outputWS, 1, 0,
         {{"ProcessingInstructions", ""},
@@ -916,7 +916,7 @@ public:
     checkWorkspaceHistory(outputWS, {"ExtractSpectra",
                                      "ReflectometryBackgroundSubtraction",
                                      "GroupDetectors", "ConvertUnits",
-                                     "CropWorkspace", "RefRoi"});
+                                     "CropWorkspace", "ConvertUnits"});
     checkHistoryAlgorithmProperties(
         outputWS, 1, 1,
         {{"ProcessingInstructions", "1-2,4-5"},
@@ -936,7 +936,7 @@ public:
     checkWorkspaceHistory(outputWS, {"ExtractSpectra",
                                      "ReflectometryBackgroundSubtraction",
                                      "GroupDetectors", "ConvertUnits",
-                                     "CropWorkspace", "RefRoi"});
+                                     "CropWorkspace", "ConvertUnits"});
     checkHistoryAlgorithmProperties(
         outputWS, 1, 1,
         {{"ProcessingInstructions", "1-4,6-8"},

--- a/Framework/Reflectometry/test/ReflectometryReductionOne2Test.h
+++ b/Framework/Reflectometry/test/ReflectometryReductionOne2Test.h
@@ -883,7 +883,7 @@ public:
         AnalysisDataService::Instance().retrieve("IvsQ"));
     checkWorkspaceHistory(outputWS,
                           {"ExtractSpectra", "GroupDetectors", "ConvertUnits",
-                           "CropWorkspace", "ConvertUnits"});
+                           "CropWorkspace", "RefRoi"});
   }
 
   void test_background_subtraction_with_default_properties() {
@@ -897,7 +897,7 @@ public:
     // used for the background subtraction
     checkWorkspaceHistory(outputWS, {"ReflectometryBackgroundSubtraction",
                                      "GroupDetectors", "ConvertUnits",
-                                     "CropWorkspace", "ConvertUnits"});
+                                     "CropWorkspace", "RefRoi"});
     checkHistoryAlgorithmProperties(
         outputWS, 1, 0,
         {{"ProcessingInstructions", ""},
@@ -916,7 +916,7 @@ public:
     checkWorkspaceHistory(outputWS, {"ExtractSpectra",
                                      "ReflectometryBackgroundSubtraction",
                                      "GroupDetectors", "ConvertUnits",
-                                     "CropWorkspace", "ConvertUnits"});
+                                     "CropWorkspace", "RefRoi"});
     checkHistoryAlgorithmProperties(
         outputWS, 1, 1,
         {{"ProcessingInstructions", "1-2,4-5"},
@@ -936,7 +936,7 @@ public:
     checkWorkspaceHistory(outputWS, {"ExtractSpectra",
                                      "ReflectometryBackgroundSubtraction",
                                      "GroupDetectors", "ConvertUnits",
-                                     "CropWorkspace", "ConvertUnits"});
+                                     "CropWorkspace", "RefRoi"});
     checkHistoryAlgorithmProperties(
         outputWS, 1, 1,
         {{"ProcessingInstructions", "1-4,6-8"},

--- a/Framework/Reflectometry/test/ReflectometryReductionOne2Test.py
+++ b/Framework/Reflectometry/test/ReflectometryReductionOne2Test.py
@@ -31,7 +31,7 @@ class ReflectometryReductionOne2Test(unittest.TestCase):
                 'OutputWorkspace': 'output'}
         output = self._assert_run_algorithm_succeeds(args)
         history = ['ExtractSpectra', 'ReflectometryBackgroundSubtraction', 'GroupDetectors',
-                   'ConvertUnits', 'CropWorkspace', 'ConvertUnits']
+                   'ConvertUnits', 'CropWorkspace', 'RefRoi']
         self._check_history(output, history)
         self._check_history_algorithm_properties(output, 1, 1,
                                                  {'ProcessingInstructions': '1-3',

--- a/Framework/Reflectometry/test/ReflectometryReductionOne2Test.py
+++ b/Framework/Reflectometry/test/ReflectometryReductionOne2Test.py
@@ -31,7 +31,7 @@ class ReflectometryReductionOne2Test(unittest.TestCase):
                 'OutputWorkspace': 'output'}
         output = self._assert_run_algorithm_succeeds(args)
         history = ['ExtractSpectra', 'ReflectometryBackgroundSubtraction', 'GroupDetectors',
-                   'ConvertUnits', 'CropWorkspace', 'RefRoi']
+                   'ConvertUnits', 'CropWorkspace', 'ConvertUnits']
         self._check_history(output, history)
         self._check_history_algorithm_properties(output, 1, 1,
                                                  {'ProcessingInstructions': '1-3',

--- a/docs/source/algorithms/ReflectometryReductionOne-v2.rst
+++ b/docs/source/algorithms/ReflectometryReductionOne-v2.rst
@@ -188,22 +188,34 @@ range for the instrument then the red regions may contain valid counts.
 Conversion to Momentum Transfer (Q)
 ###################################
 
-Finally, the output workspace in wavelength is converted to momentum transfer
-(:math:`Q`) using :ref:`algm-ConvertUnits`. The equation used is
-:math:`Q=4\pi sin(\theta_R)/\lambda_v` in the non-flat sample case or
-:math:`Q=4\pi sin(2\theta_R-\theta_0)/\lambda_v` in the divergent beam
-case. This is because the latter needs to take into account the divergence of
-the beam from the assumed direct beam direction.
+Finally, the output workspace in wavelength is converted to momentum transfer,
+:math:`Q=\frac{4\pi}{\lambda}sin(\theta)`. The angle :math:`\theta` used depends on
+the method used.
+
+When summing in wavelength, if ``ThetaIn`` is specified, this is used in the
+conversion to :math:`Q` and the conversion is done using
+:ref:`algm-RefRoi`. Otherwise, :ref:`algm-ConvertUnits` is used. This takes
+:math:`\theta` from the average of the grouped detectors' :math:`2\theta`
+values (note that this is not the same as the :math:`2\theta` of the average
+detector position).
+
+When summing in :math:`Q`, :math:`\theta` is :math:`\theta_R` in the non-flat
+sample case or :math:`2\theta_R-\theta_0` in the divergent beam case. This is
+because the latter needs to take into account the divergence of the beam from
+the assumed direct beam direction. The output workspace is set up with a single
+detector at the relevant :math:`2\theta` so that the conversion can be done
+with :ref:`algm-ConvertUnits`.
 
 .. diagram:: ReflectometryReductionOne_ConvertToMomentum-v2_wkflw.dot
 
-Note that the output workspace in Q is a workspace with native binning, and no
-rebin step is applied to it. If you wish to obtain a rebinned workspace in Q
-you should consider using algorithm :ref:`algm-ReflectometryReductionOneAuto`
-instead, which is a facade over this algorithm and has two extra steps
-(:ref:`algm-Rebin` and :ref:`algm-Scale`) to produce an additional workspace in
-Q with specified binning and scale factor. Please refer to
-:ref:`algm-ReflectometryReductionOneAuto` for more information.
+Note that the output workspace in :math:`Q` is a workspace with native binning,
+and no rebin step is applied to it. If you wish to obtain a rebinned workspace
+in :math:`Q` you should consider using algorithm
+:ref:`algm-ReflectometryReductionOneAuto` instead, which is a facade over this
+algorithm and has two extra steps (:ref:`algm-Rebin` and :ref:`algm-Scale`) to
+produce an additional workspace in :math:`Q` with specified binning and scale
+factor. Please refer to :ref:`algm-ReflectometryReductionOneAuto` for more
+information.
 
 Previous Versions
 -----------------

--- a/docs/source/diagrams/ReflectometryReductionOne_ConvertToMomentum-v2_wkflw.dot
+++ b/docs/source/diagrams/ReflectometryReductionOne_ConvertToMomentum-v2_wkflw.dot
@@ -5,16 +5,19 @@ label = "\n"
 subgraph params {
  $param_style
   inputWorkspace     [label="OutputWorkspaceWavelength", group=g1]
+  thetaIn            [label="ThetaIn"]
   outputWorkspace    [label="OutputWorkspace"]
 }
 
 subgraph decisions {
  $decision_style
+ checkCorrectAngle  [label="Sum in wavelength and ThetaIn provided?"]
 }
 
 subgraph algorithms {
  $algorithm_style
   convertUnits  [label="ConvertUnits\n(AlignBins=False)", group=g1]
+  refRoi        [label="RefRoi"]
 }
 
 subgraph processes {
@@ -25,8 +28,15 @@ subgraph values {
  $value_style
 }
 
-inputWorkspace     -> convertUnits
-convertUnits       ->  outputWorkspace
+inputWorkspace     -> checkCorrectAngle
+
+checkCorrectAngle  -> convertUnits [label="No"]
+checkCorrectAngle  -> refRoi [label="Yes"]
+
+convertUnits       -> outputWorkspace
+
+thetaIn            -> refRoi
+refRoi             -> outputWorkspace
 
 }
 

--- a/docs/source/release/v5.1.0/reflectometry.rst
+++ b/docs/source/release/v5.1.0/reflectometry.rst
@@ -23,11 +23,12 @@ Improvements
 - Sample waviness term is removed from resolution calculation in incoherent mode in :ref:`ReflectometryMomentumTransfer <algm-ReflectometryMomentumTransfer>`.
 - Flag to enable / disable apply scaling factor from `ScalingFactorFile`, called `ApplyScalingFactor`, added to :ref:`algm-LiquidsReflectometryReduction`.
 - Modified :ref:`algm-LRAutoReduction` to allow the option to autoreduce data with a reference measurement for normalization (instead of only direct beam) using the new :ref:`algm-LRReductionWithReference` algorithm of this release
-
+  
 Bug fixes
 ---------
 
 - :ref:`LoadILLReflectometry <algm-LoadILLReflectometry>` has been fixed to update the sample logs of chopper gap and chopper position with correct units regardless the wrong setting in nexus files.
+- The history for :ref:`algm-ReflectometryReductionOne` has been fixed so that the conversion to Q is now always included in the history.
 
 ISIS Reflectometry Interface
 ############################


### PR DESCRIPTION
**Description of work.**

This PR adds a call to `RefRoi` to do the conversion to Q in `ReflectometryReductionOne`. This fixes the workflow algorithm history when summing in lambda because previously this calculation was done within `ReflectometryReductionOne` rather than via a child algorithm.

This PR also includes:
- Up-front validation that `ThetaIn` is provided for the divergent beam case, rather than checking during execution.
- Several unit tests have been added to expand the coverage for cases where the angle is corrected (i.e. by providing `ThetaIn`).
- A typo fix where the minimum wavelength for cropping was not being set correctly for multiple groups.
- A bug fix where spectrum numbers were not being set up correctly for multiple groups.

**Note**
- The output of RefRoi is distribution data and output of ConvertUnits is not distribution. To make things consistent with previous behaviour, for now I've reset the distribution flag to false and the axis label to 'Counts' for the RefRoi case. Unfortunately this defeats the object of this PR slightly because this part of the history is not included. However, this PR is still an improvement so I would like to address the distribution problem in a future PR after discussion with scientists about the best way to do this.

Refs #23012

**To test:**

Should be tested at ISIS with the archive enabled.

- Run the script below.
- Check the history for the `IvsQ` workspaces. They should all use `ConvertUnits` for the conversion to Q except for the two workspaces with `RefRoi` in the name (i.e. when summing in lambda with `ThetaIn` specified).
- Remove `ThetaIn` from the call where the `ReductionType='DivergentBeam'` and it should throw.


```
theta=1.29977  # the angle of specular pixel spectrum 52. Use an ROI centred on this to get the same results whether providing ThetaIn or not.
Load(Filename='INTER00043583.nxs', OutputWorkspace='TOF')

# Sum in wavelength without overriding ThetaIn uses ConvertUnits
ReflectometryReductionOne('TOF', ProcessingInstructions='42-62',
  WavelengthMin=1.5, WavelengthMax=17.0,
  OutputWorkspace='IvsQ_43583_ConvertUnits', SummationType='SumInLambda'
  )
  
# Sum in wavelength and override ThetaIn uses RefRoi
ReflectometryReductionOne('TOF', ProcessingInstructions='42-62',
  WavelengthMin=1.5, WavelengthMax=17.0,
  ThetaIn=theta, OutputWorkspace='IvsQ_RefRoi', SummationType='SumInLambda'
  )

# Using a different value of theta shifts the plot
ReflectometryReductionOne('TOF', ProcessingInstructions='42-62',
  WavelengthMin=1.5, WavelengthMax=17.0,
  ThetaIn=1.1, OutputWorkspace='IvsQ_RefRoi_theta_1.1', SummationType='SumInLambda'
  )
  
# Summing in Q always uses ConvertUnits regardless of whether we provide ThetaIn
ReflectometryReductionOne('TOF', ProcessingInstructions='42-62',
  WavelengthMin=1.5, WavelengthMax=17.0,
  ThetaIn=theta,
  OutputWorkspace='IvsQ_SumInQ_ConvertUnits', SummationType='SumInQ', ReductionType='DivergentBeam'
  )

ReflectometryReductionOne('TOF', ProcessingInstructions='42-62',
  WavelengthMin=1.5, WavelengthMax=17.0,
  OutputWorkspace='IvsQ_SumInQ_bent_ConvertUnits', SummationType='SumInQ', ReductionType='NonFlatSample'
  )
```

![image](https://user-images.githubusercontent.com/12895056/87927305-eb41cb80-ca7a-11ea-9aca-9acd47e9ae50.png)

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
