### PR TITLE
Remove `deepcopy` calls from `LRReductionWithReference` and fixes to `LRAutoReduction`

### DIFF
--- a/Framework/PythonInterface/plugins/algorithms/LRReductionWithReference.py
+++ b/Framework/PythonInterface/plugins/algorithms/LRReductionWithReference.py
@@ -5,14 +5,14 @@
 #   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
 # SPDX - License - Identifier: GPL - 3.0 +
 #pylint: disable=no-init,invalid-name
-import copy
 import json
 import numpy as np
 
-from mantid.api import DataProcessorAlgorithm
+from mantid.api import DataProcessorAlgorithm, AnalysisDataService
 from mantid.simpleapi import \
     AlgorithmFactory, \
     CreateWorkspace, \
+    DeleteWorkspace, \
     Divide, \
     LiquidsReflectometryReduction
 
@@ -86,15 +86,40 @@ class LRReductionWithReference(DataProcessorAlgorithm):
             kwargs[prop] = self.getProperty(prop).value
 
         # Process the reference normalization run
-        norm_kwargs = copy.deepcopy(kwargs)
-        norm_kwargs['SignalPeakPixelRange'] = kwargs['NormPeakPixelRange']
-        norm_kwargs['SubtractSignalBackground'] = kwargs['SubtractNormBackground']
-        norm_kwargs['SignalBackgroundPixelRange'] = kwargs['NormBackgroundPixelRange']
-        norm_kwargs['NormFlag'] = False
-        norm_kwargs['LowResDataAxisPixelRangeFlag'] = kwargs['LowResNormAxisPixelRangeFlag']
-        norm_kwargs['LowResDataAxisPixelRange'] = kwargs['LowResNormAxisPixelRange']
-        norm_kwargs['ApplyScalingFactor'] = False
-        norm_wksp = LiquidsReflectometryReduction(**norm_kwargs)
+        norm_wksp = LiquidsReflectometryReduction(
+            RunNumbers=kwargs['RunNumbers'],
+            InputWorkspace=kwargs['InputWorkspace'],
+            NormalizationRunNumber=kwargs['NormalizationRunNumber'],
+            SignalPeakPixelRange=kwargs['NormPeakPixelRange'],
+            SubtractSignalBackground=kwargs['SubtractNormBackground'],
+            SignalBackgroundPixelRange=kwargs['NormBackgroundPixelRange'],
+            NormFlag=False,
+            NormPeakPixelRange=kwargs['NormPeakPixelRange'],
+            SubtractNormBackground=kwargs['SubtractNormBackground'],
+            NormBackgroundPixelRange=kwargs['NormBackgroundPixelRange'],
+            LowResDataAxisPixelRangeFlag=kwargs['LowResNormAxisPixelRangeFlag'],
+            LowResDataAxisPixelRange=kwargs['LowResNormAxisPixelRange'],
+            LowResNormAxisPixelRangeFlag=kwargs['LowResNormAxisPixelRangeFlag'],
+            LowResNormAxisPixelRange=kwargs['LowResNormAxisPixelRange'],
+            TOFRange=kwargs['TOFRange'],
+            TOFRangeFlag=kwargs['TOFRangeFlag'],
+            QMin=kwargs['QMin'],
+            QStep=kwargs['QStep'],
+            AngleOffset=kwargs['AngleOffset'],
+            AngleOffsetError=kwargs['AngleOffsetError'],
+            OutputWorkspace=kwargs['OutputWorkspace'],
+            ApplyScalingFactor=False,
+            ScalingFactorFile=kwargs['ScalingFactorFile'],
+            SlitTolerance=kwargs['SlitTolerance'],
+            SlitsWidthFlag=kwargs['SlitsWidthFlag'],
+            IncidentMediumSelected=kwargs['IncidentMediumSelected'],
+            GeometryCorrectionFlag=kwargs['GeometryCorrectionFlag'],
+            FrontSlitName=kwargs['FrontSlitName'],
+            BackSlitName=kwargs['BackSlitName'],
+            TOFSteps=kwargs['TOFSteps'],
+            CropFirstAndLastPoints=kwargs['CropFirstAndLastPoints'],
+            ApplyPrimaryFraction=kwargs['ApplyPrimaryFraction'],
+            PrimaryFractionRange=kwargs['PrimaryFractionRange'])
 
         # Calculate the theoretical reflectivity for normalization using Refl1D
         q = norm_wksp.readX(0)
@@ -112,14 +137,20 @@ class LRReductionWithReference(DataProcessorAlgorithm):
         incident_flux = Divide(norm_wksp, model_wksp)
 
         # Process the sample run(s)
-        sample_kwargs = copy.deepcopy(kwargs)
-        sample_kwargs['NormFlag'] = False
-        sample_kwargs['ApplyScalingFactor'] = False
-        sample_wksp = LiquidsReflectometryReduction(**sample_kwargs)
+        kwargs['NormFlag'] = False
+        kwargs['ApplyScalingFactor'] = False
+        sample_wksp = LiquidsReflectometryReduction(**kwargs)
 
         # Normalize using the incident flux
         out_wksp = Divide(sample_wksp, incident_flux)
+
+        # Output
         self.setProperty('OutputWorkspace', out_wksp)
+
+        # Clean up
+        DeleteWorkspace(model_wksp)
+        DeleteWorkspace(norm_wksp)
+        DeleteWorkspace(incident_flux)
 
     def calculate_reflectivity(self, model_description, q, q_resolution=0.025):
         """

--- a/Framework/PythonInterface/plugins/algorithms/LRReductionWithReference.py
+++ b/Framework/PythonInterface/plugins/algorithms/LRReductionWithReference.py
@@ -8,7 +8,7 @@
 import json
 import numpy as np
 
-from mantid.api import DataProcessorAlgorithm, AnalysisDataService
+from mantid.api import DataProcessorAlgorithm
 from mantid.simpleapi import \
     AlgorithmFactory, \
     CreateWorkspace, \


### PR DESCRIPTION
**Description of work.**

Removed `copy.deepcopy` calls in `LRReductionWithReference` that were raising pickling errors.
Fix output workspace in `LRAutoReduction`.

**To test:**
I used datasets from `REF_L` instrument at SNS to reproduce the autoreduction script workflow.
Was able to reproduce the original issues and, with fixes, successfully reduce data.

Fixes #28920 

*This does not require release notes* because fixing bugs in new features that have already been added to release notes.

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
