### PR TITLE
Fix typo in install rename command

### DIFF
--- a/Framework/PythonInterface/plugins/CMakeLists.txt
+++ b/Framework/PythonInterface/plugins/CMakeLists.txt
@@ -368,5 +368,5 @@ install(
 install(
     FILES ${PACKAGE_FILE}
     DESTINATION ${PLUGINS_DIR}/python
-    RENAME "python-plugin-mantifest.txt"
+    RENAME "python-plugin-manifest.txt"
 )


### PR DESCRIPTION
**Description of work.**

Fixes a typo in an install command leading to an incorrect file rename. This only affects macOS as all other platforms currently have the same workbench/mantidplot install directory so have the correctly named file alongside the incorrect one but the MantidPlot bundle on macOS only has a file with the incorrect name.


**To test:**

* Code review

*There is no associated issue.*

*This does not require release notes* because **because it fixes a development regression**

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
