### PR TITLE
Fix workbench launchscripts for windows package

### DIFF
--- a/buildconfig/CMake/MSVCSetup.cmake
+++ b/buildconfig/CMake/MSVCSetup.cmake
@@ -179,8 +179,10 @@ set(MANTIDPYTHON_PREAMBLE
 # Launch script
 # Developer verison
 set(MANTIDLAUNCH_PREAMBLE
-    "$QT_PLUGIN_PATH=\"${THIRD_PARTY_DIR}\\lib\\qt5\\plugins\"\n$PYTHONHOME=\"${THIRD_PARTY_DIR}\\lib\\python3.8\"\n$ERROR_REPORTER_DIR=\"${PROJECT_SOURCE_DIR}\\scripts\\ErrorReporter\"\n
-    $LAUNCH_SCRIPT=\"workbench-script.pyw\""
+    "$QT_PLUGIN_PATH=\"${THIRD_PARTY_DIR}\\lib\\qt5\\plugins\"
+$PYTHONHOME=\"${THIRD_PARTY_DIR}\\lib\\python3.8\"
+$ERROR_REPORTER_DIR=\"${PROJECT_SOURCE_DIR}\\scripts\\ErrorReporter\"
+$LAUNCH_SCRIPT=\"$scriptRootDirectory\\workbench-script.pyw\""
 )
 configure_file ( ${PACKAGING_DIR}/launch_workbench.ps1.in
     ${PROJECT_BINARY_DIR}/launch_workbench.ps1.in @ONLY )
@@ -193,8 +195,10 @@ file(GENERATE
   )
 # Install version
 set(MANTIDLAUNCH_PREAMBLE
-    "$QT_PLUGIN_PATH=\"..\\plugins\\qt5\"\n$PYTHONHOME=\".\"\n$ERROR_REPORTER_DIR=\"..\\scripts\\ErrorReporter\"
-     $LAUNCH_SCRIPT=\"launch_workbench.pyw\""
+    "$QT_PLUGIN_PATH=\"$scriptRootDirectory\\..\\plugins\\qt5\"
+$PYTHONHOME=\"$scriptRootDirectory\"
+$ERROR_REPORTER_DIR=\"$scriptRootDirectory\\..\\scripts\\ErrorReporter\"
+$LAUNCH_SCRIPT=\"$scriptRootDirectory\\launch_workbench.pyw\""
 )
 configure_file(
   ${PACKAGING_DIR}/launch_workbench.ps1.in

--- a/buildconfig/CMake/Packaging/launch_workbench.ps1.in
+++ b/buildconfig/CMake/Packaging/launch_workbench.ps1.in
@@ -16,8 +16,6 @@ if ($help) {
   exit
 }
 
-## Setup some initial paths
-@MANTIDLAUNCH_PREAMBLE@
 
 # Getting script directory in PowerShell 2.0, sourced from PS2EXE `Get-ScriptPath.ps1` example
 if ($MyInvocation.MyCommand.CommandType -eq "ExternalScript") {
@@ -35,6 +33,8 @@ if ($console) {
 else {
   $python_executable = "pythonw.exe"
 }
+## Setup some initial paths
+@MANTIDLAUNCH_PREAMBLE@
 
 # Set the Qt plugins path to point QT to the correct directory
 $env:QT_PLUGIN_PATH = Resolve-Path("$QT_PLUGIN_PATH")
@@ -49,7 +49,7 @@ $env:PYTHONWARNINGS = "default::DeprecationWarning:__main__,ignore::DeprecationW
 # Additionally that will correctly capture the output when run with just python.exe (console visible)
 # The -PassThru parameter tells PowerShell to return the process object
 
-$p = Start-Process -NoNewWindow -PassThru -FilePath "$env:PYTHONHOME/$python_executable" "./$LAUNCH_SCRIPT" 2>&1
+$p = Start-Process -NoNewWindow -PassThru -FilePath "$env:PYTHONHOME/$python_executable" "$LAUNCH_SCRIPT" 2>&1
 
 # Getting the process ExitCode, source from https://stackoverflow.com/a/23797762/2823526
 # It is important that we cache the handle here, otherwise when reading


### PR DESCRIPTION
**Description of work.**
In a previous PR, a general launch script for both developer and package builds was generated. For the package builds this used relative paths (assuming the exe directory was the /bin folder), which could lead to the wrong directory being set for the QT_PATH. This PR updates the launch script to use the scriptRootDirectory as the base path.

**Report to:** [Spencer Howells]

**To test:**
1. Code review
2. Test the windows unstable package built here

_There is no associated issue.
This does not require release notes because because it fixes a development regression_

-------------------------------
#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
