### PR TITLE
Speed up function template browsers in indirect analysis GUI

### DIFF
--- a/docs/source/release/v5.1.0/indirect_geometry.rst
+++ b/docs/source/release/v5.1.0/indirect_geometry.rst
@@ -28,6 +28,7 @@ Improvements
 - Added docking and undocking to the plot window and function browser window for the fit tabs in Indirect Data Analysis on workbench.
 - Update the Indirect, Corrections user interface to use the :ref:`PaalmanPingsMonteCarloAbsorption <algm-PaalmanPingsMonteCarloAbsorption>` algorithm
 - OutputCompositeMembers and ConvolveOutputs have been added as options in the ConvFit tab of Indirect Data Analysis.
+- Improved the responsiveness of the function browsers within the Indirect Data Analysis interface.
 
 Bug Fixes
 #########

--- a/qt/scientific_interfaces/Indirect/IIndirectFitPlotView.h
+++ b/qt/scientific_interfaces/Indirect/IIndirectFitPlotView.h
@@ -80,6 +80,9 @@ public:
   virtual void displayMessage(const std::string &message) const = 0;
   virtual void disableSpectrumPlotSelection() = 0;
 
+  virtual void allowRedraws(bool state) = 0;
+  virtual void redrawPlots() = 0;
+
 public slots:
   virtual void clearTopPreview() = 0;
   virtual void clearBottomPreview() = 0;

--- a/qt/scientific_interfaces/Indirect/IndirectFitAnalysisTab.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectFitAnalysisTab.cpp
@@ -813,8 +813,7 @@ void IndirectFitAnalysisTab::respondToBackgroundChanged(double value) {
 
 void IndirectFitAnalysisTab::respondToFunctionChanged() {
   setModelFitFunction();
-  m_plotPresenter->updatePlots();
-  m_plotPresenter->updateGuessAvailability();
+  m_plotPresenter->updateFit();
   emit functionChanged();
 }
 

--- a/qt/scientific_interfaces/Indirect/IndirectFitPlotPresenter.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectFitPlotPresenter.cpp
@@ -5,7 +5,6 @@
 //   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
 // SPDX - License - Identifier: GPL - 3.0 +
 #include "IndirectFitPlotPresenter.h"
-
 #include "MantidQtWidgets/Common/SignalBlocker.h"
 
 #include <QTimer>
@@ -14,6 +13,18 @@
 namespace MantidQt {
 namespace CustomInterfaces {
 namespace IDA {
+
+struct HoldRedrawing {
+  IIndirectFitPlotView *m_view;
+
+  HoldRedrawing(IIndirectFitPlotView *view) : m_view(view) {
+    m_view->allowRedraws(false);
+  }
+  ~HoldRedrawing() {
+    m_view->allowRedraws(true);
+    m_view->redrawPlots();
+  }
+};
 
 using namespace Mantid::API;
 
@@ -240,12 +251,19 @@ void IndirectFitPlotPresenter::setFitSingleSpectrumEnabled(bool enable) {
 }
 
 void IndirectFitPlotPresenter::updatePlots() {
+  HoldRedrawing holdRedrawing(m_view);
   m_view->clearPreviews();
-
   plotLines();
 
   updateRangeSelectors();
   updateFitRangeSelector();
+}
+
+void IndirectFitPlotPresenter::updateFit() {
+  HoldRedrawing holdRedrawing(m_view);
+  updateRangeSelectors();
+  updateFitRangeSelector();
+  updateGuess();
 }
 
 void IndirectFitPlotPresenter::plotLines() {
@@ -352,7 +370,10 @@ void IndirectFitPlotPresenter::plotGuessInSeparateWindow(
       [this, workspace]() { m_model->appendGuessToInput(workspace); });
 }
 
-void IndirectFitPlotPresenter::clearGuess() { updatePlots(); }
+void IndirectFitPlotPresenter::clearGuess() {
+  m_view->removeFromTopPreview("Guess");
+  m_view->redrawPlots();
+}
 
 void IndirectFitPlotPresenter::updateHWHMSelector() {
   const auto hwhm = m_model->getFirstHWHM();

--- a/qt/scientific_interfaces/Indirect/IndirectFitPlotPresenter.h
+++ b/qt/scientific_interfaces/Indirect/IndirectFitPlotPresenter.h
@@ -51,6 +51,7 @@ public slots:
   void updateDataSelection();
   void updateAvailableSpectra();
   void updatePlots();
+  void updateFit();
   void updateGuess();
   void updateGuessAvailability();
   void enablePlotGuessInSeparateWindow();

--- a/qt/scientific_interfaces/Indirect/IndirectFitPlotView.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectFitPlotView.cpp
@@ -381,6 +381,16 @@ void IndirectFitPlotView::setHWHMRangeVisible(bool visible) {
   m_topPlot->getRangeSelector("HWHM")->setVisible(visible);
 }
 
+void IndirectFitPlotView::allowRedraws(bool state) {
+  m_topPlot->allowRedraws(state);
+  m_bottomPlot->allowRedraws(state);
+}
+
+void IndirectFitPlotView::redrawPlots() {
+  m_topPlot->replot();
+  m_bottomPlot->replot();
+}
+
 void IndirectFitPlotView::displayMessage(const std::string &message) const {
   QMessageBox::information(parentWidget(), "MantidPlot - Warning",
                            QString::fromStdString(message));

--- a/qt/scientific_interfaces/Indirect/IndirectFitPlotView.h
+++ b/qt/scientific_interfaces/Indirect/IndirectFitPlotView.h
@@ -122,6 +122,9 @@ public:
   void displayMessage(const std::string &message) const override;
   void disableSpectrumPlotSelection() override;
 
+  void allowRedraws(bool state) override;
+  void redrawPlots() override;
+
 public slots:
   void clearTopPreview() override;
   void clearBottomPreview() override;

--- a/qt/scientific_interfaces/Indirect/IndirectFunctionBrowser/SingleFunctionTemplateBrowser.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectFunctionBrowser/SingleFunctionTemplateBrowser.cpp
@@ -83,6 +83,7 @@ void SingleFunctionTemplateBrowser::addParameter(
   m_parameterManager->setDescription(newParameter,
                                      parameterDescription.toStdString());
   m_parameterManager->setDecimals(newParameter, 6);
+
   m_fitType->addSubProperty(newParameter);
   m_parameterMap.insert(parameterName, newParameter);
   m_parameterNames.insert(newParameter, parameterName);

--- a/qt/scientific_interfaces/Indirect/IndirectFunctionBrowser/SingleFunctionTemplateBrowser.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectFunctionBrowser/SingleFunctionTemplateBrowser.cpp
@@ -173,6 +173,14 @@ void SingleFunctionTemplateBrowser::setParameterValue(
   m_parameterManager->setError(m_parameterMap[parameterName], parameterError);
 }
 
+void SingleFunctionTemplateBrowser::setParameterValueQuietly(
+    const QString &parameterName, double parameterValue,
+    double parameterError) {
+  ScopedFalse _(m_emitParameterValueChange);
+  m_parameterManager->setValue(m_parameterMap[parameterName], parameterValue);
+  m_parameterManager->setError(m_parameterMap[parameterName], parameterError);
+}
+
 void SingleFunctionTemplateBrowser::setCurrentDataset(int i) {
   m_presenter.setCurrentDataset(i);
 }

--- a/qt/scientific_interfaces/Indirect/IndirectFunctionBrowser/SingleFunctionTemplateBrowser.h
+++ b/qt/scientific_interfaces/Indirect/IndirectFunctionBrowser/SingleFunctionTemplateBrowser.h
@@ -67,6 +67,8 @@ public:
                     const QString &parameterDescription);
   void setParameterValue(const QString &parameterName, double parameterValue,
                          double parameterError);
+  void setParameterValueQuietly(const QString &parameterName, double parameterValue,
+                         double parameterError);
   void setDataType(const QStringList &allowedFunctionsList);
   void setEnumValue(int enumIndex);
 

--- a/qt/scientific_interfaces/Indirect/IndirectFunctionBrowser/SingleFunctionTemplateBrowser.h
+++ b/qt/scientific_interfaces/Indirect/IndirectFunctionBrowser/SingleFunctionTemplateBrowser.h
@@ -67,8 +67,8 @@ public:
                     const QString &parameterDescription);
   void setParameterValue(const QString &parameterName, double parameterValue,
                          double parameterError);
-  void setParameterValueQuietly(const QString &parameterName, double parameterValue,
-                         double parameterError);
+  void setParameterValueQuietly(const QString &parameterName,
+                                double parameterValue, double parameterError);
   void setDataType(const QStringList &allowedFunctionsList);
   void setEnumValue(int enumIndex);
 

--- a/qt/scientific_interfaces/Indirect/IndirectFunctionBrowser/SingleFunctionTemplatePresenter.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectFunctionBrowser/SingleFunctionTemplatePresenter.cpp
@@ -44,15 +44,14 @@ void SingleFunctionTemplatePresenter::updateAvailableFunctions(
 }
 
 void SingleFunctionTemplatePresenter::setFitType(const QString &name) {
-  m_view->clear();
-  m_model.setFitType(name);
   if (name == "None")
     return;
+  m_view->clear();
+  m_model.setFitType(name);
   auto functionParameters = m_model.getParameterNames();
   for (auto &parameter : functionParameters) {
     m_view->addParameter(parameter, m_model.getParameterDescription(parameter));
   }
-
   setErrorsEnabled(false);
   updateView();
   emit functionStructureChanged();
@@ -184,9 +183,9 @@ void SingleFunctionTemplatePresenter::updateView() {
   if (m_model.getFitType() == "None")
     return;
   for (auto parameterName : m_model.getParameterNames()) {
-    m_view->setParameterValue(parameterName,
-                              m_model.getParameter(parameterName),
-                              m_model.getParameterError(parameterName));
+    m_view->setParameterValueQuietly(parameterName,
+                                     m_model.getParameter(parameterName),
+                                     m_model.getParameterError(parameterName));
   }
 }
 

--- a/qt/scientific_interfaces/Indirect/IndirectFunctionBrowser/SingleFunctionTemplatePresenter.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectFunctionBrowser/SingleFunctionTemplatePresenter.cpp
@@ -182,7 +182,7 @@ void SingleFunctionTemplatePresenter::setLocalParameterTie(
 void SingleFunctionTemplatePresenter::updateView() {
   if (m_model.getFitType() == "None")
     return;
-  for (auto parameterName : m_model.getParameterNames()) {
+  for (auto &parameterName : m_model.getParameterNames()) {
     m_view->setParameterValueQuietly(parameterName,
                                      m_model.getParameter(parameterName),
                                      m_model.getParameterError(parameterName));

--- a/qt/scientific_interfaces/Indirect/test/IndirectFitPlotPresenterTest.h
+++ b/qt/scientific_interfaces/Indirect/test/IndirectFitPlotPresenterTest.h
@@ -136,6 +136,9 @@ public:
   MOCK_METHOD1(setBackgroundRangeVisible, void(bool visible));
   MOCK_METHOD1(setHWHMRangeVisible, void(bool visible));
 
+  MOCK_METHOD1(allowRedraws, void(bool state));
+  MOCK_METHOD0(redrawPlots, void());
+
   MOCK_CONST_METHOD1(displayMessage, void(std::string const &message));
 
   /// Public Slots
@@ -313,8 +316,7 @@ public:
     TableDatasetIndex const index(0);
     ON_CALL(*m_fittingModel, getWorkspace(index))
         .WillByDefault(Return(m_ads->retrieveWorkspace("WorkspaceName")));
-
-    EXPECT_CALL(*m_fittingModel, getWorkspace(index)).Times(5);
+    EXPECT_CALL(*m_fittingModel, getWorkspace(index)).Times(3);
 
     m_view->emitSelectedFitDataChanged(index);
   }
@@ -325,8 +327,8 @@ public:
     ON_CALL(*m_fittingModel, getWorkspace(index))
         .WillByDefault(Return(nullptr));
 
-    EXPECT_CALL(*m_fittingModel, getWorkspace(index)).Times(3);
-    EXPECT_CALL(*m_view, clearPreviews()).Times(2);
+    EXPECT_CALL(*m_fittingModel, getWorkspace(index)).Times(2);
+    EXPECT_CALL(*m_view, clearPreviews()).Times(1);
 
     m_view->emitSelectedFitDataChanged(index);
   }
@@ -339,10 +341,10 @@ public:
         .WillByDefault(Return(range));
 
     EXPECT_CALL(*m_fittingModel, getFittingRange(index, IDA::WorkspaceIndex(0)))
-        .Times(2)
+        .Times(1)
         .WillRepeatedly(Return(range));
-    EXPECT_CALL(*m_view, setFitRangeMinimum(1.0)).Times(2);
-    EXPECT_CALL(*m_view, setFitRangeMaximum(2.0)).Times(2);
+    EXPECT_CALL(*m_view, setFitRangeMinimum(1.0)).Times(1);
+    EXPECT_CALL(*m_view, setFitRangeMaximum(2.0)).Times(1);
 
     m_view->emitSelectedFitDataChanged(index);
   }
@@ -421,7 +423,8 @@ public:
     ON_CALL(*m_fittingModel, getWorkspace(index))
         .WillByDefault(Return(m_ads->retrieveWorkspace(workspaceName)));
 
-    EXPECT_CALL(*m_view, clearPreviews()).Times(0);
+    EXPECT_CALL(*m_view, removeFromTopPreview(QString::fromStdString("Guess")))
+        .Times(0);
 
     m_view->emitPlotGuessChanged(true);
   }
@@ -432,7 +435,8 @@ public:
     ON_CALL(*m_fittingModel, getWorkspace(index))
         .WillByDefault(Return(m_ads->retrieveWorkspace("WorkspaceName")));
 
-    EXPECT_CALL(*m_view, clearPreviews()).Times(1);
+    EXPECT_CALL(*m_view, removeFromTopPreview(QString::fromStdString("Guess")))
+        .Times(1);
 
     m_view->emitPlotGuessChanged(false);
   }

--- a/qt/widgets/plotting/inc/MantidQtWidgets/Plotting/Mpl/PreviewPlot.h
+++ b/qt/widgets/plotting/inc/MantidQtWidgets/Plotting/Mpl/PreviewPlot.h
@@ -90,6 +90,8 @@ public:
   std::tuple<double, double> getAxisRange(AxisID axisID = AxisID::XBottom);
   void disableContextMenu();
 
+  void allowRedraws(bool state);
+
 public slots:
   void clear();
   void resizeX();
@@ -141,6 +143,9 @@ private:
 
   boost::optional<char const *> overrideAxisLabel(AxisID const &axisID);
   void setAxisLabel(AxisID const &axisID, char const *const label);
+
+  // Block redrawing from taking place
+  bool m_allowRedraws = true;
 
   // Canvas objects
   Widgets::MplCpp::FigureCanvasQt *m_canvas;

--- a/qt/widgets/plotting/inc/MantidQtWidgets/Plotting/Qwt/PreviewPlot.h
+++ b/qt/widgets/plotting/inc/MantidQtWidgets/Plotting/Qwt/PreviewPlot.h
@@ -112,6 +112,9 @@ public:
   void disableYAxisMenu();
   void disableContextMenu();
 
+  // Needed to match the interface of the MPL graph widget
+  void allowRedraws(bool) { return; }
+
 signals:
   /// Signals that the plot should be refreshed
   void needToReplot();

--- a/qt/widgets/plotting/src/Mpl/PreviewPlot.cpp
+++ b/qt/widgets/plotting/src/Mpl/PreviewPlot.cpp
@@ -174,6 +174,7 @@ void PreviewPlot::removeSpectrum(const QString &lineName) {
   auto axes = m_canvas->gca();
   axes.removeArtists("lines", lineName);
   m_lines.remove(lineName);
+  regenerateLegend();
 }
 
 /**
@@ -328,14 +329,21 @@ std::tuple<double, double> PreviewPlot::getAxisRange(AxisID axisID) {
 }
 
 void PreviewPlot::replot() {
-  m_canvas->draw();
-  emit redraw();
+  if (m_allowRedraws) {
+    m_canvas->draw();
+    emit redraw();
+  }
 }
+
+void PreviewPlot::allowRedraws(bool state) { m_allowRedraws = state; }
 
 /**
  * Clear all lines from the plot
  */
-void PreviewPlot::clear() { m_canvas->gca().clear(); }
+void PreviewPlot::clear() {
+  m_canvas->gca().clear();
+  m_lines.clear();
+}
 
 /**
  * Resize the X axis to encompass all of the data
@@ -633,7 +641,9 @@ void PreviewPlot::onWorkspaceReplaced(
  */
 void PreviewPlot::regenerateLegend() {
   if (legendIsVisible()) {
-    m_canvas->gca().legend(DRAGGABLE_LEGEND);
+    if (!m_lines.isEmpty()) {
+      m_canvas->gca().legend(DRAGGABLE_LEGEND);
+    }
   }
 }
 


### PR DESCRIPTION
This PR speeds up/ improves the responsiveness of the function browser interaction in the indirect analysis GUI. The unresponsiveness was noted while trying to implement default parameter estimates within the MSD tab and therefore warranted an investigation. The primary issues found were:

-	When a function was changed in the browser the parameters were updated, with each parameter update sending a Qt signal.
-	There are a lot of replot/redraw calls. For instance, changing the function in the browser requested 5 replots/redraws of the graph, despite the data not changing. Redrawing the graph in Matplotlib is a fairly costly procedure.


Some timing results of changing the function in the MSD tab (on my Debug build), after the first and second set of changes.


  | Without data loaded –time (ms) | With data loaded - time (ms)
-- | -- | --
Master | 587 | 1068
Sending Qt signals silently | 108 | 190
Removing excess redrawing | 50 | 88



**To test:**
- Data to test the GUI can be found in #26631
- Run through each tab, testing that the functionality still works.

*There is no associated issue.*

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
