### PR TITLE
Fix crash when switching backgrounds in ConvFit tab of indirect GUI

### DIFF
--- a/docs/source/release/v5.1.0/indirect_geometry.rst
+++ b/docs/source/release/v5.1.0/indirect_geometry.rst
@@ -34,5 +34,6 @@ Bug Fixes
 
 - :ref:`CalculateMonteCarloAbsorption <algm-CalculateMonteCarloAbsorption>` will now work correctly for annular sample in a container.
 - FQ and Msd tabs now label output workspaces with the fitting function.
+- Fixed a crash when switching between linear and flat backgrounds in the ConvFit tab.
 
 :ref:`Release 5.1.0 <v5.1.0>`

--- a/qt/widgets/common/src/FunctionModel.cpp
+++ b/qt/widgets/common/src/FunctionModel.cpp
@@ -140,7 +140,9 @@ void FunctionModel::setParameter(const QString &paramName, double value) {
   if (!fun) {
     throw std::logic_error("Function is undefined.");
   }
-  fun->setParameter(paramName.toStdString(), value);
+  if (fun->hasParameter(paramName.toStdString())) {
+    fun->setParameter(paramName.toStdString(), value);
+  }
 }
 
 void FunctionModel::setParameterError(const QString &paramName, double value) {


### PR DESCRIPTION
**Description of work.**
This PR fixes a crash which occurred when switching background tabs in the ConvFit tab of the indirect interface. It occurred due to a parameter being set which no longer existed, to prevent this and similar issues, a check has been put in the model to ensure the parameter being set exists.

**To test:**
- Open the IDA GUI
- Go to the ConvFit tab
- Change the background from Linear to Flat - it should no longer crash
<!-- Instructions for testing. -->

Fixes #28955 . 

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
