### PR TITLE
Add fit output status to Indirect Data Analysis fitting tabs

### DIFF
--- a/Framework/PythonInterface/test/python/plugins/algorithms/WorkflowAlgorithms/IqtFitSequentialTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/WorkflowAlgorithms/IqtFitSequentialTest.py
@@ -5,12 +5,12 @@
 #   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
 # SPDX - License - Identifier: GPL - 3.0 +
 import unittest
+
 from mantid.simpleapi import *
 from mantid.api import MatrixWorkspace, WorkspaceGroup, ITableWorkspace
 
 
 class IqtFitSequentialTest(unittest.TestCase):
-
     _iqt_ws = None
     _function = r'name=LinearBackground,A0=0,A1=0,ties=(A1=0);name=ExpDecay,Height=1,Lifetime=0.0247558;ties=(f1.Height=1-f0.A0)'
 
@@ -18,8 +18,7 @@ class IqtFitSequentialTest(unittest.TestCase):
         self._iqt_ws = Load(Filename='iris26176_graphite002_iqt.nxs',
                             OutputWorkspace='iris26176_graphite002_iqt')
 
-
-#-----------------------------------Validation of result-------------------------------------
+    # -----------------------------------Validation of result-------------------------------------
 
     def _validate_output(self, params, result, fit_group):
         self.assertTrue(isinstance(params, ITableWorkspace))
@@ -36,8 +35,6 @@ class IqtFitSequentialTest(unittest.TestCase):
 
         self._validate_sample_log_values(result.getItem(0))
         self._validate_sample_log_values(fit_group.getItem(0))
-
-
 
     def _validate_table_shape(self, tableWS):
         # Check length of rows and columns
@@ -62,10 +59,10 @@ class IqtFitSequentialTest(unittest.TestCase):
         # Check histogram names
         text_axis = matrixWS.getAxis(1)
         self.assertTrue(text_axis.isText())
-        self.assertEqual('f0.A0',text_axis.label(0))
-        self.assertEqual('f1.Height',text_axis.label(1))
-        self.assertEqual('f1.Lifetime',text_axis.label(2))
-        self.assertEqual('Chi_squared',text_axis.label(3))
+        self.assertEqual('f0.A0', text_axis.label(0))
+        self.assertEqual('f1.Height', text_axis.label(1))
+        self.assertEqual('f1.Lifetime', text_axis.label(2))
+        self.assertEqual('Chi_squared', text_axis.label(3))
 
         # Check bin units
         self.assertEqual('MomentumTransfer', matrixWS.getAxis(0).getUnit().unitID())
@@ -83,13 +80,12 @@ class IqtFitSequentialTest(unittest.TestCase):
         # Check histogram names
         text_axis = sub_ws.getAxis(1)
         self.assertTrue(text_axis.isText())
-        self.assertEqual('Data',text_axis.label(0))
-        self.assertEqual('Calc',text_axis.label(1))
-        self.assertEqual('Diff',text_axis.label(2))
+        self.assertEqual('Data', text_axis.label(0))
+        self.assertEqual('Calc', text_axis.label(1))
+        self.assertEqual('Diff', text_axis.label(2))
 
         # Check bin units
         self.assertEqual('ns', str(sub_ws.getAxis(0).getUnit().symbol()))
-
 
     def _validate_table_values(self, tableWS):
         # Check column data
@@ -100,7 +96,7 @@ class IqtFitSequentialTest(unittest.TestCase):
 
         # Check row data
         row = tableWS.row(0)
-        self.assertEqual(round(row['axis-1'], 6),  0.483619)
+        self.assertEqual(round(row['axis-1'], 6), 0.483619)
         self.assertEqual(round(row['f1.Height'], 6), 0.966344)
         self.assertEqual(round(row['f1.Lifetime'], 7), 0.0287491)
 
@@ -108,32 +104,32 @@ class IqtFitSequentialTest(unittest.TestCase):
         # Check f1.A0
         a0 = matrixWS.readY(0)
         self.assertEqual(round(a0[0], 7), 0.0336564)
-        self.assertEqual(round(a0[-1],7), 0.0182411)
+        self.assertEqual(round(a0[-1], 7), 0.0182411)
 
         # Check f1.Height
         height = matrixWS.readY(1)
         self.assertEqual(round(height[0], 6), 0.966344)
-        self.assertEqual(round(height[-1],6), 0.981759)
+        self.assertEqual(round(height[-1], 6), 0.981759)
 
         # Check f1.Lifetime
         lifetime = matrixWS.readY(2)
         self.assertEqual(round(lifetime[0], 7), 0.0287491)
-        self.assertEqual(round(lifetime[-1],7), 0.0034427)
+        self.assertEqual(round(lifetime[-1], 7), 0.0034427)
 
     def _validate_group_values(self, groupWS):
         sub_ws = groupWS.getItem(0)
         # Check Data
         data = sub_ws.readY(0)
         self.assertEqual(round(data[0], 6), 0.797069)
-        self.assertEqual(round(data[-1],6), 0.039044)
+        self.assertEqual(round(data[-1], 6), 0.039044)
         # Check Calc
         calc = sub_ws.readY(1)
         self.assertEqual(round(calc[0], 6), 0.870524)
-        self.assertEqual(round(calc[-1],6), 0.033886)
+        self.assertEqual(round(calc[-1], 6), 0.033886)
         # Check Diff
         diff = sub_ws.readY(2)
-        self.assertEqual(round(diff[0], 6),-0.073455)
-        self.assertEqual(round(diff[-1],6), 0.005157)
+        self.assertEqual(round(diff[0], 6), -0.073455)
+        self.assertEqual(round(diff[-1], 6), 0.005157)
 
     def _validate_sample_log_values(self, matrixWS):
         run = matrixWS.getRun()
@@ -146,23 +142,21 @@ class IqtFitSequentialTest(unittest.TestCase):
         self.assertEqual(run.getProperty('iqt_resolution_workspace').value, 'iris26173_graphite002_res')
         self.assertEqual(run.getProperty('iqt_sample_workspace').value, 'iris26176_graphite002_red')
 
-
-
-#---------------------------------------Success cases--------------------------------------
+    # ---------------------------------------Success cases--------------------------------------
 
     def test_basic(self):
         """
         Tests a basic run of IqtfitSequential.
         """
         result, params, fit_group = IqtFitSequential(InputWorkspace=self._iqt_ws,
-                                                     Function=self._function,
-                                                     StartX=0,
-                                                     EndX=0.24,
-                                                     SpecMin=0,
-                                                     SpecMax=16)
+                                                                          Function=self._function,
+                                                                          StartX=0,
+                                                                          EndX=0.24,
+                                                                          SpecMin=0,
+                                                                          SpecMax=16)
         self._validate_output(params, result, fit_group)
 
-#----------------------------------------Failure cases-------------------------------------
+    # ----------------------------------------Failure cases-------------------------------------
 
     def test_minimum_spectra_number_less_than_0(self):
         self.assertRaises(ValueError, IqtFitSequential,
@@ -217,5 +211,6 @@ class IqtFitSequentialTest(unittest.TestCase):
                           OutputParameterWorkspace='table',
                           OutputWorkspaceGroup='fit_group')
 
-if __name__=="__main__":
+
+if __name__ == "__main__":
     unittest.main()

--- a/Framework/PythonInterface/test/python/plugins/algorithms/WorkflowAlgorithms/IqtFitSequentialTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/WorkflowAlgorithms/IqtFitSequentialTest.py
@@ -5,12 +5,12 @@
 #   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
 # SPDX - License - Identifier: GPL - 3.0 +
 import unittest
-
 from mantid.simpleapi import *
 from mantid.api import MatrixWorkspace, WorkspaceGroup, ITableWorkspace
 
 
 class IqtFitSequentialTest(unittest.TestCase):
+
     _iqt_ws = None
     _function = r'name=LinearBackground,A0=0,A1=0,ties=(A1=0);name=ExpDecay,Height=1,Lifetime=0.0247558;ties=(f1.Height=1-f0.A0)'
 
@@ -18,7 +18,8 @@ class IqtFitSequentialTest(unittest.TestCase):
         self._iqt_ws = Load(Filename='iris26176_graphite002_iqt.nxs',
                             OutputWorkspace='iris26176_graphite002_iqt')
 
-    # -----------------------------------Validation of result-------------------------------------
+
+#-----------------------------------Validation of result-------------------------------------
 
     def _validate_output(self, params, result, fit_group):
         self.assertTrue(isinstance(params, ITableWorkspace))
@@ -35,6 +36,8 @@ class IqtFitSequentialTest(unittest.TestCase):
 
         self._validate_sample_log_values(result.getItem(0))
         self._validate_sample_log_values(fit_group.getItem(0))
+
+
 
     def _validate_table_shape(self, tableWS):
         # Check length of rows and columns
@@ -59,10 +62,10 @@ class IqtFitSequentialTest(unittest.TestCase):
         # Check histogram names
         text_axis = matrixWS.getAxis(1)
         self.assertTrue(text_axis.isText())
-        self.assertEqual('f0.A0', text_axis.label(0))
-        self.assertEqual('f1.Height', text_axis.label(1))
-        self.assertEqual('f1.Lifetime', text_axis.label(2))
-        self.assertEqual('Chi_squared', text_axis.label(3))
+        self.assertEqual('f0.A0',text_axis.label(0))
+        self.assertEqual('f1.Height',text_axis.label(1))
+        self.assertEqual('f1.Lifetime',text_axis.label(2))
+        self.assertEqual('Chi_squared',text_axis.label(3))
 
         # Check bin units
         self.assertEqual('MomentumTransfer', matrixWS.getAxis(0).getUnit().unitID())
@@ -80,12 +83,13 @@ class IqtFitSequentialTest(unittest.TestCase):
         # Check histogram names
         text_axis = sub_ws.getAxis(1)
         self.assertTrue(text_axis.isText())
-        self.assertEqual('Data', text_axis.label(0))
-        self.assertEqual('Calc', text_axis.label(1))
-        self.assertEqual('Diff', text_axis.label(2))
+        self.assertEqual('Data',text_axis.label(0))
+        self.assertEqual('Calc',text_axis.label(1))
+        self.assertEqual('Diff',text_axis.label(2))
 
         # Check bin units
         self.assertEqual('ns', str(sub_ws.getAxis(0).getUnit().symbol()))
+
 
     def _validate_table_values(self, tableWS):
         # Check column data
@@ -96,7 +100,7 @@ class IqtFitSequentialTest(unittest.TestCase):
 
         # Check row data
         row = tableWS.row(0)
-        self.assertEqual(round(row['axis-1'], 6), 0.483619)
+        self.assertEqual(round(row['axis-1'], 6),  0.483619)
         self.assertEqual(round(row['f1.Height'], 6), 0.966344)
         self.assertEqual(round(row['f1.Lifetime'], 7), 0.0287491)
 
@@ -104,32 +108,32 @@ class IqtFitSequentialTest(unittest.TestCase):
         # Check f1.A0
         a0 = matrixWS.readY(0)
         self.assertEqual(round(a0[0], 7), 0.0336564)
-        self.assertEqual(round(a0[-1], 7), 0.0182411)
+        self.assertEqual(round(a0[-1],7), 0.0182411)
 
         # Check f1.Height
         height = matrixWS.readY(1)
         self.assertEqual(round(height[0], 6), 0.966344)
-        self.assertEqual(round(height[-1], 6), 0.981759)
+        self.assertEqual(round(height[-1],6), 0.981759)
 
         # Check f1.Lifetime
         lifetime = matrixWS.readY(2)
         self.assertEqual(round(lifetime[0], 7), 0.0287491)
-        self.assertEqual(round(lifetime[-1], 7), 0.0034427)
+        self.assertEqual(round(lifetime[-1],7), 0.0034427)
 
     def _validate_group_values(self, groupWS):
         sub_ws = groupWS.getItem(0)
         # Check Data
         data = sub_ws.readY(0)
         self.assertEqual(round(data[0], 6), 0.797069)
-        self.assertEqual(round(data[-1], 6), 0.039044)
+        self.assertEqual(round(data[-1],6), 0.039044)
         # Check Calc
         calc = sub_ws.readY(1)
         self.assertEqual(round(calc[0], 6), 0.870524)
-        self.assertEqual(round(calc[-1], 6), 0.033886)
+        self.assertEqual(round(calc[-1],6), 0.033886)
         # Check Diff
         diff = sub_ws.readY(2)
-        self.assertEqual(round(diff[0], 6), -0.073455)
-        self.assertEqual(round(diff[-1], 6), 0.005157)
+        self.assertEqual(round(diff[0], 6),-0.073455)
+        self.assertEqual(round(diff[-1],6), 0.005157)
 
     def _validate_sample_log_values(self, matrixWS):
         run = matrixWS.getRun()
@@ -142,21 +146,23 @@ class IqtFitSequentialTest(unittest.TestCase):
         self.assertEqual(run.getProperty('iqt_resolution_workspace').value, 'iris26173_graphite002_res')
         self.assertEqual(run.getProperty('iqt_sample_workspace').value, 'iris26176_graphite002_red')
 
-    # ---------------------------------------Success cases--------------------------------------
+
+
+#---------------------------------------Success cases--------------------------------------
 
     def test_basic(self):
         """
         Tests a basic run of IqtfitSequential.
         """
         result, params, fit_group = IqtFitSequential(InputWorkspace=self._iqt_ws,
-                                                                          Function=self._function,
-                                                                          StartX=0,
-                                                                          EndX=0.24,
-                                                                          SpecMin=0,
-                                                                          SpecMax=16)
+                                                     Function=self._function,
+                                                     StartX=0,
+                                                     EndX=0.24,
+                                                     SpecMin=0,
+                                                     SpecMax=16)
         self._validate_output(params, result, fit_group)
 
-    # ----------------------------------------Failure cases-------------------------------------
+#----------------------------------------Failure cases-------------------------------------
 
     def test_minimum_spectra_number_less_than_0(self):
         self.assertRaises(ValueError, IqtFitSequential,
@@ -211,6 +217,5 @@ class IqtFitSequentialTest(unittest.TestCase):
                           OutputParameterWorkspace='table',
                           OutputWorkspaceGroup='fit_group')
 
-
-if __name__ == "__main__":
+if __name__=="__main__":
     unittest.main()

--- a/docs/source/algorithms/PlotPeakByLogValue-v1.rst
+++ b/docs/source/algorithms/PlotPeakByLogValue-v1.rst
@@ -87,6 +87,10 @@ The possible flags are:
 :code:`$outputname`
   The output workspace name (i.e. the value of the OutputWorkspace property).
 
+:code:`$OutputFitStatus`
+  Optional flag determining whether to output fit status and chi square for each fit
+
+
 Usage
 -----
 
@@ -125,6 +129,32 @@ Output:
 .. testoutput:: ExPlotPeakByLogValueSeq
 
     True
+
+.. testcode:: ExPlotPeakByLogValueSeqWithOutputStatus
+
+    import numpy as np
+
+    ws = CreateSampleWorkspace()
+    function = "name=Gaussian,Height=10.0041,PeakCentre=10098.6,Sigma=48.8581;name=FlatBackground,A0=0.3"
+
+    #create string of workspaces to fit (ws,i0; ws,i1, ws,i2 ...)
+    workspaces = [ws.name() + ',i%d' % i for i in range(ws.getNumberHistograms())]
+    workspaces = ';'.join(workspaces)
+
+    peaks, status, chi2 = PlotPeakByLogValue(workspaces, function, Spectrum=1, OutputFitStatus=True)
+
+    # Print status of first 10 fits
+    print("Fit status = {}".format(status[0:10]))
+    print("Fit chi2 = {}".format(chi2[0:10]))
+
+Output:
+
+.. testoutput:: ExPlotPeakByLogValueSeqWithOutputStatus
+
+    Fit status = ['success', 'success', 'success', 'success', 'success', 'success', 'success', 'success', 'success', 'success']
+    Fit chi2 = [  5.09648779e-08   6.89426130e-09   9.33124574e-10   1.26539259e-10
+       1.73025195e-11   2.45555803e-12   4.06465408e-13   1.04496124e-13
+       4.79987355e-14   3.01813222e-14]
 
 .. categories::
 

--- a/docs/source/algorithms/QENSFitSequential-v1.rst
+++ b/docs/source/algorithms/QENSFitSequential-v1.rst
@@ -28,11 +28,9 @@ Usage
 
 .. testcode:: QENSFitSequentialExample
 
-  from __future__ import print_function
-
   # Load sample and resolution files
   sample = Load('irs26176_graphite002_red.nxs')
-  resolution = Load('irs26173_graphite002_red.nxs')
+  resolution = Load('irs26173_graphite002_res.nxs')
 
   # Set up algorithm parameters
   function = """name=LinearBackground,A0=0,A1=0,ties=(A0=0.000000,A1=0.0);
@@ -41,8 +39,6 @@ Usage
   name=Lorentzian,Amplitude=1,PeakCentre=0,FWHM=0.0175)"""
   startX = -0.547608
   endX = 0.543217
-  specMin = 0
-  specMax = sample.getNumberHistograms() - 1
   convolve = True  # Convolve the fitted model components with the resolution
   minimizer = "Levenberg-Marquardt"
   maxIt = 500
@@ -52,9 +48,19 @@ Usage
                                                 Function=function,
                                                 PassWSIndexToFunction=True,
                                                 StartX=startX, EndX=endX,
-                                                SpecMin=specMin, SpecMax=specMax,
                                                 ConvolveMembers=convolve,
                                                 Minimizer=minimizer, MaxIterations=maxIt)
+
+  # The QENSFitSequential algorithm can take an optional OutputFitStatus flag, to output the Chi squared and fit status
+  # of each fit
+  result, params, fit_group, fit_status, chi2 = QENSFitSequential(InputWorkspace=sample,
+                                                Function=function,
+                                                PassWSIndexToFunction=True,
+                                                StartX=startX, EndX=endX,
+                                                ConvolveMembers=convolve,
+                                                Minimizer=minimizer, MaxIterations=maxIt,
+                                                OutputFitStatus=True)
+
 
 .. categories::
 

--- a/docs/source/algorithms/QENSFitSimultaneous-v1.rst
+++ b/docs/source/algorithms/QENSFitSimultaneous-v1.rst
@@ -10,7 +10,7 @@
 Description
 -----------
 An algorithm used for fitting QENS-data simultaneously and formatting the output. Uses the
-:ref:`Fit <algm-Fit>` algorithm to perform the sequential fit.
+:ref:`Fit <algm-Fit>` algorithm to perform the simultaneous fit.
 
 The method of providing multiple data-sets to this algorithm is specified in the :ref:`Fit <algm-Fit>`
 documentation.
@@ -30,7 +30,7 @@ Usage
 
   # Load sample and resolution files
   sample = Load('irs26176_graphite002_red.nxs')
-  resolution = Load('irs26173_graphite002_red.nxs')
+  resolution = Load('irs26173_graphite002_res.nxs')
 
   background = LinearBackground(A0=0, A1=0)
   peak_function = Lorentzian(Amplitude=1, PeakCentre=0, FWHM=0.0175)
@@ -40,8 +40,6 @@ Usage
 
   startX = -0.547608
   endX = 0.543217
-  specMin = 0
-  specMax = sample.getNumberHistograms() - 1
   convolve = True  # Convolve the fitted model components with the resolution
   minimizer = "Levenberg-Marquardt"
   maxIt = 500

--- a/docs/source/release/v5.1.0/indirect_geometry.rst
+++ b/docs/source/release/v5.1.0/indirect_geometry.rst
@@ -31,7 +31,7 @@ Improvements
 - Improved the responsiveness of the function browsers within the Indirect Data Analysis interface.
 - Raw data will now be plotted from the input workspace, rather than the fit workspace, allowing the full range of data to be seen irrespective of the fitting bounds.
 - Added the fit output information (Algorithm status and Chi squared) to each fitting tab of the Indirect Data Analysis interface.
-  This change introduces two additional outputs from the QENSFit algorithms (fit status and Chi squared), which may be used to monitor the outcome of the fit.
+  This change introduces two optional outputs from the QENSFit algorithms (fit status and Chi squared), which may be used to monitor the outcome of the fit.
 
 Bug Fixes
 #########

--- a/docs/source/release/v5.1.0/indirect_geometry.rst
+++ b/docs/source/release/v5.1.0/indirect_geometry.rst
@@ -30,6 +30,8 @@ Improvements
 - OutputCompositeMembers and ConvolveOutputs have been added as options in the ConvFit tab of Indirect Data Analysis.
 - Improved the responsiveness of the function browsers within the Indirect Data Analysis interface.
 - Raw data will now be plotted from the input workspace, rather than the fit workspace, allowing the full range of data to be seen irrespective of the fitting bounds.
+- Added the fit output information (Algorithm status and Chi squared) to each fitting tab of the Indirect Data Analysis interface.
+  This change introduces two additional outputs from the QENSFit algorithms (fit status and Chi squared), which may be used to monitor the outcome of the fit.
 
 Bug Fixes
 #########

--- a/qt/scientific_interfaces/Indirect/CMakeLists.txt
+++ b/qt/scientific_interfaces/Indirect/CMakeLists.txt
@@ -75,6 +75,7 @@ set(
         IqtFit.cpp
         IqtFitModel.cpp
         IndirectFitPropertyBrowser.cpp
+        FitStatusWidget.cpp
         IndirectFunctionBrowser/ConvTypes.cpp
         IndirectFunctionBrowser/ConvFunctionModel.cpp
         IndirectFunctionBrowser/ConvTemplateBrowser.cpp
@@ -210,6 +211,7 @@ set(
         Quasi.h
         ResNorm.h
         Stretch.h
+        FitStatusWidget.h
 )
 
 set(
@@ -337,6 +339,7 @@ set(
         IndirectFitOutputOptionsPresenter.cpp
         IndirectFitOutputOptionsView.cpp
         IndirectFitPropertyBrowser.cpp
+        FitStatusWidget.cpp
         IndirectFitPlotModel.cpp
         IndirectFitPlotPresenter.cpp
         IndirectFitPlotView.cpp
@@ -477,6 +480,7 @@ set(
         Quasi.h
         ResNorm.h
         Stretch.h
+        FitStatusWidget.h
 )
 
 set(

--- a/qt/scientific_interfaces/Indirect/FitStatusWidget.cpp
+++ b/qt/scientific_interfaces/Indirect/FitStatusWidget.cpp
@@ -1,0 +1,80 @@
+// Mantid Repository : https://github.com/mantidproject/mantid
+//
+// Copyright &copy; 2020 ISIS Rutherford Appleton Laboratory UKRI,
+//   NScD Oak Ridge National Laboratory, European Spallation Source,
+//   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+// SPDX - License - Identifier: GPL - 3.0 +
+#include "FitStatusWidget.h"
+
+#include <QColor>
+#include <QHBoxLayout>
+#include <QLabel>
+#include <QString>
+#include <QVBoxLayout>
+
+namespace FitStatusStrings {
+const std::string FAILED{"Failed"};
+const std::string SUCCESS{"success"};
+const std::string CHANGESTOOSMALL{"Changes"};
+} // namespace FitStatusStrings
+namespace {
+QPalette getFitStatusColor(const std::string &status) {
+  QPalette statusPalette;
+  if (status.find(FitStatusStrings::SUCCESS) != std::string::npos) {
+    statusPalette.setColor(QPalette::WindowText, Qt::green);
+  } else if (status.find(FitStatusStrings::FAILED) != std::string::npos) {
+    statusPalette.setColor(QPalette::WindowText, Qt::red);
+  } else if (status.find(FitStatusStrings::CHANGESTOOSMALL) !=
+             std::string::npos) {
+    statusPalette.setColor(QPalette::WindowText, QColor(255, 165, 0));
+  } else {
+    statusPalette.setColor(QPalette::WindowText, Qt::black);
+  }
+  return statusPalette;
+}
+} // namespace
+
+namespace MantidQt {
+namespace CustomInterfaces {
+namespace IDA {
+
+FitStatusWidget::FitStatusWidget(QWidget *parent) : QWidget(parent) {
+  auto fitInformationLayout = new QVBoxLayout(this);
+
+  auto fitStatusLayout = new QHBoxLayout(this);
+  auto fitStatusLabel = new QLabel(this);
+  fitStatusLabel->setText(QString::fromStdString("Status:"));
+  m_fitStatus = new QLabel(this);
+  fitStatusLayout->addWidget(fitStatusLabel);
+  fitStatusLayout->addWidget(m_fitStatus);
+
+  auto fitChiSquaredLayout = new QHBoxLayout(this);
+  auto fitChiSquaredLabel = new QLabel(this);
+  fitChiSquaredLabel->setText(QString::fromStdString("Chi squared:"));
+  m_fitChiSquared = new QLabel(this);
+  fitChiSquaredLayout->addWidget(fitChiSquaredLabel);
+  fitChiSquaredLayout->addWidget(m_fitChiSquared);
+
+  fitInformationLayout->addLayout(fitStatusLayout);
+  fitInformationLayout->addLayout(fitChiSquaredLayout);
+
+  setLayout(fitInformationLayout);
+}
+
+void FitStatusWidget::update(const std::string &status,
+                             const double chiSquared) {
+  setFitStatus(status);
+  setFitChiSquared(chiSquared);
+  show();
+}
+void FitStatusWidget::setFitStatus(const std::string &status) {
+  auto color = getFitStatusColor(status);
+  m_fitStatus->setPalette(color);
+  m_fitStatus->setText(QString::fromStdString(status));
+}
+void FitStatusWidget::setFitChiSquared(const double chiSquared) {
+  m_fitChiSquared->setText(QString::fromStdString(std::to_string(chiSquared)));
+}
+} // namespace IDA
+} // namespace CustomInterfaces
+} // namespace MantidQt

--- a/qt/scientific_interfaces/Indirect/FitStatusWidget.h
+++ b/qt/scientific_interfaces/Indirect/FitStatusWidget.h
@@ -4,6 +4,8 @@
 //   NScD Oak Ridge National Laboratory, European Spallation Source,
 //   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
 // SPDX - License - Identifier: GPL - 3.0 +
+#pragma once
+
 #include <QWidget>
 
 class QLabel;

--- a/qt/scientific_interfaces/Indirect/FitStatusWidget.h
+++ b/qt/scientific_interfaces/Indirect/FitStatusWidget.h
@@ -1,0 +1,28 @@
+// Mantid Repository : https://github.com/mantidproject/mantid
+//
+// Copyright &copy; 2020 ISIS Rutherford Appleton Laboratory UKRI,
+//   NScD Oak Ridge National Laboratory, European Spallation Source,
+//   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+// SPDX - License - Identifier: GPL - 3.0 +
+#include <QWidget>
+
+class QLabel;
+
+namespace MantidQt {
+namespace CustomInterfaces {
+namespace IDA {
+class FitStatusWidget : public QWidget {
+  Q_OBJECT
+public:
+  FitStatusWidget(QWidget *parent = nullptr);
+  void update(const std::string &status, const double chiSquared);
+
+private:
+  void setFitChiSquared(const double chiSquared);
+  void setFitStatus(const std::string &status);
+  QLabel *m_fitStatus;
+  QLabel *m_fitChiSquared;
+};
+} // namespace IDA
+} // namespace CustomInterfaces
+} // namespace MantidQt

--- a/qt/scientific_interfaces/Indirect/IndirectFitAnalysisTab.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectFitAnalysisTab.cpp
@@ -470,14 +470,15 @@ void IndirectFitAnalysisTab::updateFitStatus() {
   if (m_fittingModel->getFittingMode() == FittingMode::SIMULTANEOUS) {
     std::string fit_status = m_fittingAlgorithm->getProperty("OutputStatus");
     double chi2 = m_fittingAlgorithm->getProperty("OutputChiSquared");
-    std::vector<std::string> status(m_fittingModel->getNumberOfDomains(),
-                                    fit_status);
-    std::vector<double> chiSquared(m_fittingModel->getNumberOfDomains(), chi2);
+    const std::vector<std::string> status(m_fittingModel->getNumberOfDomains(),
+                                          fit_status);
+    const std::vector<double> chiSquared(m_fittingModel->getNumberOfDomains(),
+                                         chi2);
     m_fitPropertyBrowser->updateFitStatusData(status, chiSquared);
   } else {
-    std::vector<std::string> status =
+    const std::vector<std::string> status =
         m_fittingAlgorithm->getProperty("OutputStatus");
-    std::vector<double> chiSquared =
+    const std::vector<double> chiSquared =
         m_fittingAlgorithm->getProperty("OutputChiSquared");
     m_fitPropertyBrowser->updateFitStatusData(status, chiSquared);
   }

--- a/qt/scientific_interfaces/Indirect/IndirectFitAnalysisTab.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectFitAnalysisTab.cpp
@@ -355,8 +355,9 @@ void IndirectFitAnalysisTab::updateFitOutput(bool error) {
   if (error) {
     m_fittingModel->cleanFailedRun(m_fittingAlgorithm);
     m_fittingAlgorithm.reset();
-  } else
+  } else {
     m_fittingModel->addOutput(m_fittingAlgorithm);
+  }
 }
 
 void IndirectFitAnalysisTab::updateSingleFitOutput(bool error) {
@@ -385,6 +386,7 @@ void IndirectFitAnalysisTab::fitAlgorithmComplete(bool error) {
   m_fitPropertyBrowser->setErrorsEnabled(!error);
   if (!error) {
     updateFitBrowserParameterValuesFromAlg();
+    updateFitStatus();
     setModelFitFunction();
   }
   m_spectrumPresenter->enableView();
@@ -460,7 +462,26 @@ void IndirectFitAnalysisTab::updateFitBrowserParameterValuesFromAlg() {
         "Warning issue updating parameter values in fit property browser");
   }
 }
+/**
+ * Updates the fit output status
+ */
+void IndirectFitAnalysisTab::updateFitStatus() {
 
+  if (m_fittingModel->getFittingMode() == FittingMode::SIMULTANEOUS) {
+    std::string fit_status = m_fittingAlgorithm->getProperty("OutputStatus");
+    double chi2 = m_fittingAlgorithm->getProperty("OutputChiSquared");
+    std::vector<std::string> status(m_fittingModel->getNumberOfDomains(),
+                                    fit_status);
+    std::vector<double> chiSquared(m_fittingModel->getNumberOfDomains(), chi2);
+    m_fitPropertyBrowser->updateFitStatusData(status, chiSquared);
+  } else {
+    std::vector<std::string> status =
+        m_fittingAlgorithm->getProperty("OutputStatus");
+    std::vector<double> chiSquared =
+        m_fittingAlgorithm->getProperty("OutputChiSquared");
+    m_fitPropertyBrowser->updateFitStatusData(status, chiSquared);
+  }
+}
 /**
  * Plots the spectra corresponding to the selected parameters
  */
@@ -667,6 +688,7 @@ void IndirectFitAnalysisTab::setAlgorithmProperties(
   if (m_fittingModel->getFittingMode() == FittingMode::SEQUENTIAL) {
     fitAlgorithm->setProperty("FitType", m_fitPropertyBrowser->fitType());
   }
+  fitAlgorithm->setProperty("OutputFitStatus", true);
 }
 
 /*

--- a/qt/scientific_interfaces/Indirect/IndirectFitAnalysisTab.h
+++ b/qt/scientific_interfaces/Indirect/IndirectFitAnalysisTab.h
@@ -118,6 +118,7 @@ protected slots:
       const std::unordered_map<std::string, ParameterValue> &parameters);
   void updateFitBrowserParameterValues();
   void updateFitBrowserParameterValuesFromAlg();
+  void updateFitStatus();
   void updateDataReferences();
   void updateResultOptions();
   void respondToFunctionChanged();

--- a/qt/scientific_interfaces/Indirect/IndirectFitPropertyBrowser.h
+++ b/qt/scientific_interfaces/Indirect/IndirectFitPropertyBrowser.h
@@ -33,6 +33,7 @@ using namespace Mantid::API;
 using namespace MantidWidgets;
 
 class FunctionTemplateBrowser;
+class FitStatusWidget;
 
 class MANTIDQT_INDIRECT_DLL IndirectFitPropertyBrowser : public QDockWidget {
   Q_OBJECT
@@ -58,6 +59,9 @@ public:
   void updateParameters(const IFunction &fun);
   void updateMultiDatasetParameters(const IFunction &fun);
   void updateMultiDatasetParameters(const ITableWorkspace &params);
+  void updateFitStatusData(const std::vector<std::string> &status,
+                           const std::vector<double> &chiSquared);
+  void updateFitStatus(const FitDomainIndex index);
   QString selectedFitType() const;
   void setConvolveMembers(bool convolveMembers);
   void setFitEnabled(bool enable);
@@ -111,8 +115,12 @@ private:
   FunctionBrowser *m_functionBrowser;
   FitOptionsBrowser *m_fitOptionsBrowser;
   FunctionTemplateBrowser *m_templateBrowser;
+  FitStatusWidget *m_fitStatusWidget;
   QStackedWidget *m_functionWidget;
   QCheckBox *m_browserSwitcher;
+
+  std::vector<std::string> m_fitStatus;
+  std::vector<double> m_fitChiSquared;
 };
 
 } // namespace IDA


### PR DESCRIPTION
**Description of work.**
This PR adds the fit output information (algorithm status and chi squared) to each fitting tab within the Indirect Data Analysis Interface. In order to break the existing API, these two outputs are optional, which is controlled through an additional flag to the PlotPeaksByLogValue Algorithm (and the QENSFit algorithms).

**Report to:** ISIS/Spencer

**To test:**
Data to test each tab of the Indirect Data Analysis GUI can be found in #26631.

1. Open the Indirect Data Analysis GUI.
2. Go to the ``Conv fit`` tab
3. Load in data
4. Add the ``One Lorentzian`` function
5. Do a fit - A fit success and chi squared value should be shown.
6. You can cycle through the chi squared values and fit status using the ``Plot Spectrum`` spinbox 
7. Change the ``Max Iterations`` to 1 and run the fit - A fit failed message should be shown

Lastly, check that the functionally works on the other fitting tabs.


Fixes #28964

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
