### PR TITLE
Fix figure options image tab settings for ws with numeric axis

### DIFF
--- a/Framework/PythonInterface/mantid/plots/datafunctions.py
+++ b/Framework/PythonInterface/mantid/plots/datafunctions.py
@@ -1101,7 +1101,7 @@ def add_colorbar_label(colorbar, axes):
     :param axes: the axes that the colorbar belongs to.
     """
     colorbar_labels = [ax.colorbar_label for ax in axes if hasattr(ax, 'colorbar_label')]
-    if colorbar_labels.count(colorbar_labels[0]) == len(colorbar_labels):
+    if colorbar_labels and colorbar_labels.count(colorbar_labels[0]) == len(colorbar_labels):
         colorbar.set_label(colorbar_labels[0])
 
 

--- a/docs/source/release/v5.1.0/mantidworkbench.rst
+++ b/docs/source/release/v5.1.0/mantidworkbench.rst
@@ -116,5 +116,6 @@ Bugfixes
 - Fixed a bug with the peak cursor immediately resetting to the default cursor when trying to add a peak.
 - Changing a curve's properties on a plot no longer changes the order of the plot legend.
 - Fixed a bug which prevented the double click axis editor menus from working for tiled plots.
+- Select image in the plot figure option contains each image rather than each spectra for colorfil plots of workspaces with a numeric vertical axis
 
 :ref:`Release 5.1.0 <v5.1.0>`

--- a/qt/python/mantidqt/widgets/plotconfigdialog/__init__.py
+++ b/qt/python/mantidqt/widgets/plotconfigdialog/__init__.py
@@ -99,12 +99,17 @@ def errorbars_in_ax(ax):
 
 
 def get_images_from_fig(fig):
-    """Return a list of images in the given Figure"""
+    """
+    Return the images in the given Figure.
+    This is a list of list so ensure images that are a group of collections remain together
+    """
     colorbar_images = get_colorbars_from_fig(fig)
     images = []
     for ax in fig.get_axes():
         ax_imgs = get_images_from_ax(ax)
-        images += [img for img in ax_imgs if img not in colorbar_images]
+        imgs = [img for img in ax_imgs if img not in colorbar_images]
+        if imgs:
+            images.append(imgs)
     return images
 
 

--- a/qt/python/mantidqt/widgets/plotconfigdialog/imagestabwidget/__init__.py
+++ b/qt/python/mantidqt/widgets/plotconfigdialog/imagestabwidget/__init__.py
@@ -22,6 +22,8 @@ class ImageProperties(dict):
 
     @classmethod
     def from_image(cls, image):
+        if isinstance(image, list):
+            image = image[0]
         props = dict()
 
         props['label'] = ""

--- a/qt/python/mantidqt/widgets/plotconfigdialog/imagestabwidget/presenter.py
+++ b/qt/python/mantidqt/widgets/plotconfigdialog/imagestabwidget/presenter.py
@@ -93,7 +93,7 @@ class ImagesTabWidgetPresenter:
     @staticmethod
     def generate_image_name(image):
         """Generate a name for an image"""
-        label = image.get_label()
+        label = image.get_label().lstrip('_')
         ax_name = generate_ax_name(image.axes)
         if label:
             return "{} - {}".format(ax_name, label)

--- a/qt/python/mantidqt/widgets/plotconfigdialog/imagestabwidget/presenter.py
+++ b/qt/python/mantidqt/widgets/plotconfigdialog/imagestabwidget/presenter.py
@@ -5,6 +5,8 @@
 #   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
 # SPDX - License - Identifier: GPL - 3.0 +
 #  This file is part of the mantid workbench.
+from matplotlib.collections import QuadMesh
+from mpl_toolkits.mplot3d.art3d import Poly3DCollection
 
 from mantid.plots.datafunctions import update_colorbar_scale
 from mantidqt.utils.qt import block_signals
@@ -36,16 +38,17 @@ class ImagesTabWidgetPresenter:
         props = self.view.get_properties()
         # if only one colorbar apply settings to all images
         if len(get_colorbars_from_fig(self.fig)) == 1:
-            images = self.image_names_dict.values()
+            # flatten the values into one list
+            images = sum(self.image_names_dict.values(), [])
         else:
-            images = [self.get_selected_image()]
+            images = self.get_selected_image()
 
         for image in images:
             if image.colorbar:
                 image.colorbar.set_label(props.label)
 
             image.set_cmap(props.colormap)
-            if props.interpolation:
+            if props.interpolation and (not isinstance(image, QuadMesh) or not isinstance(image, Poly3DCollection)):
                 image.set_interpolation(props.interpolation)
 
             update_colorbar_scale(self.fig, image, SCALES[props.scale], props.vmin, props.vmax)
@@ -112,7 +115,7 @@ class ImagesTabWidgetPresenter:
         self.view.select_image_combo_box.clear()
         for img in get_images_from_fig(self.fig):
             self.image_names_dict = self.set_name_in_names_dict(
-                self.generate_image_name(img), img, self.image_names_dict)
+                self.generate_image_name(img[0]), img, self.image_names_dict)
         self.view.populate_select_image_combo_box(
             sorted(self.image_names_dict.keys()))
 

--- a/qt/python/mantidqt/widgets/plotconfigdialog/imagestabwidget/test/test_imagestabwidgetpresenter.py
+++ b/qt/python/mantidqt/widgets/plotconfigdialog/imagestabwidget/test/test_imagestabwidgetpresenter.py
@@ -63,8 +63,21 @@ class ImagesTabWidgetPresenterTest(unittest.TestCase):
 
     def test_image_dict_names_populated_on_init(self):
         presenter = self._generate_presenter()
-        expected = {'(0, 1) - {}'.format(self.img0_label): self.img0,
-                    'Second Axes: (1, 1) - {}'.format(self.img1_label): self.img1}
+        expected = {'(0, 1) - {}'.format(self.img0_label): [self.img0],
+                    'Second Axes: (1, 1) - {}'.format(self.img1_label): [self.img1]}
+        self.assertEqual(presenter.image_names_dict, expected)
+
+    def test_image_dict_names_populated_correctly_for_plot_done_per_spectra(self):
+        ws = CreateWorkspace(DataX=list([0, 1, 1.5, 1.75, 1.83])*4, DataY=range(20), NSpec=4, OutputWorkspace='test_ws',
+                             VerticalAxisUnit='TOF', VerticalAxisValues=[1, 2, 4, 10])
+        fig = figure()
+        axes = fig.add_subplot(111, projection='mantid')
+        label = 'Test_Label'
+        img = axes.pcolormesh(ws, label=label)
+        fig.colorbar(img)
+        mock_view = Mock(get_selected_image_name=lambda: '(0, 0) - {}'.format(label))
+        presenter = self._generate_presenter(fig=fig, view=mock_view)
+        expected = {'(0, 0) - {}'.format(label): axes.collections}
         self.assertEqual(presenter.image_names_dict, expected)
 
     def test_generate_image_name(self):

--- a/qt/python/mantidqt/widgets/plotconfigdialog/imagestabwidget/test/test_imagestabwidgetpresenter.py
+++ b/qt/python/mantidqt/widgets/plotconfigdialog/imagestabwidget/test/test_imagestabwidgetpresenter.py
@@ -162,7 +162,7 @@ class ImagesTabWidgetPresenterTest(unittest.TestCase):
         fig = figure()
         ax = fig.add_subplot(111)
         ax.pcolormesh([[0, 2], [2, 0]])
-        view = Mock(get_selected_image_name=lambda: '(0, 0) - _collection0')
+        view = Mock(get_selected_image_name=lambda: '(0, 0) - collection0')
         presenter = self._generate_presenter(view, fig)
         presenter.view.enable_interpolation.assert_called_once_with(False)
 

--- a/qt/python/mantidqt/widgets/plotconfigdialog/test/test_apply_all_properties.py
+++ b/qt/python/mantidqt/widgets/plotconfigdialog/test/test_apply_all_properties.py
@@ -169,7 +169,7 @@ class ApplyAllPropertiesTest(unittest.TestCase):
 
         # Mock images tab view
         cls.img_view_mock = Mock(
-            get_selected_image_name=lambda: '(0, 0) - _image0',
+            get_selected_image_name=lambda: '(0, 0) - image0',
             get_properties=lambda: ImageProperties(new_image_props))
         cls.img_view_patch = patch(IMAGE_VIEW, lambda x: cls.img_view_mock)
         cls.img_view_patch.start()


### PR DESCRIPTION
**Description of work.**
This PR fixes an issue where colorfill plots done using pcolormesh of workspaces with an uneven numeric vertical axis are done per spectra so in the image tab in figure options each spectra was appearing as an image. This has been changed so that there is only one entry for each plot.

**To test:**
Load workspace `d16_colorfill` from the linked issue.
Do a colorfill plot
Open `Figure options` and go to the `Images` tab
In the select image drop down there should only be one image
Change some of the image settings and click apply or okay and this should update the plot correctly

Fixes #28801 

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
