### PR TITLE
Plot raw data after a fit in Indirect Data Analysis Interface

### DIFF
--- a/docs/source/release/v5.1.0/indirect_geometry.rst
+++ b/docs/source/release/v5.1.0/indirect_geometry.rst
@@ -29,6 +29,7 @@ Improvements
 - Update the Indirect, Corrections user interface to use the :ref:`PaalmanPingsMonteCarloAbsorption <algm-PaalmanPingsMonteCarloAbsorption>` algorithm
 - OutputCompositeMembers and ConvolveOutputs have been added as options in the ConvFit tab of Indirect Data Analysis.
 - Improved the responsiveness of the function browsers within the Indirect Data Analysis interface.
+- Raw data will now be plotted from the input workspace, rather than the fit workspace, allowing the full range of data to be seen irrespective of the fitting bounds.
 
 Bug Fixes
 #########

--- a/qt/scientific_interfaces/Indirect/IndirectFitDataView.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectFitDataView.cpp
@@ -35,6 +35,8 @@ IndirectFitDataView::IndirectFitDataView(QWidget *parent)
   m_dataForm->lbResolution->hide();
   m_dataForm->dsbStartX->setRange(-1e100, 1e100);
   m_dataForm->dsbEndX->setRange(-1e100, 1e100);
+  m_dataForm->dsbStartX->setKeyboardTracking(false);
+  m_dataForm->dsbEndX->setKeyboardTracking(false);
 
   connect(m_dataForm->dsSample, SIGNAL(dataReady(const QString &)), this,
           SIGNAL(sampleLoaded(const QString &)));

--- a/qt/scientific_interfaces/Indirect/IndirectFitPlotPresenter.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectFitPlotPresenter.cpp
@@ -268,6 +268,7 @@ void IndirectFitPlotPresenter::updateFit() {
 
 void IndirectFitPlotPresenter::plotLines() {
   if (auto const resultWorkspace = m_model->getResultWorkspace()) {
+    plotInput(m_model->getWorkspace(), m_model->getActiveSpectrum());
     plotFit(resultWorkspace);
     updatePlotRange(m_model->getResultRange());
   } else if (auto const inputWorkspace = m_model->getWorkspace()) {
@@ -288,7 +289,6 @@ void IndirectFitPlotPresenter::plotInput(MatrixWorkspace_sptr workspace,
 }
 
 void IndirectFitPlotPresenter::plotFit(const MatrixWorkspace_sptr &workspace) {
-  plotInput(workspace, WorkspaceIndex{0});
   if (auto doGuess = m_view->isPlotGuessChecked())
     plotGuess(doGuess);
   plotFit(workspace, WorkspaceIndex{1});

--- a/qt/widgets/plotting/src/Mpl/PreviewPlot.cpp
+++ b/qt/widgets/plotting/src/Mpl/PreviewPlot.cpp
@@ -311,7 +311,6 @@ void PreviewPlot::setAxisRange(const QPair<double, double> &range,
     break;
   }
 }
-
 /**
  * Gets the range of the specified axis
  * @param axisID An enumeration defining the axis


### PR DESCRIPTION
**Description of work.**
After performing a fit in the IDA GUI the raw_data would be taken from the 0th spectrum of the fit output workspace. This resulted in issues when using a reduced fitting range, as the raw data was also plotted with this reduced range. 


**To test:**
 Data to test each tab of the Indirect Data Analysis GUI can be found in #26631.
- Open the IDA GUI
- Go to the Conv fit tab
- Load the data
- Add a single Lorentzian
- Change the fitting range (either using the black dotted lines on the plot or the double spin boxes)
- Do a fit
- The full range of raw data should still be shown



Fixes #28898 . <!-- and fix #xxxx or close #xxxx xor resolves #xxxx -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
