### PR TITLE
Catch errors opening the sliceviewer on MatrixWorkspaces types that don't contain expected information

### DIFF
--- a/Framework/PythonInterface/mantid/api/src/Exports/MDGeometry.cpp
+++ b/Framework/PythonInterface/mantid/api/src/Exports/MDGeometry.cpp
@@ -113,6 +113,9 @@ void export_MDGeometry() {
            "vector for the specified "
            "dimension")
 
+      .def("clearOriginalWorkspaces", &MDGeometry::clearOriginalWorkspaces,
+           (arg("self")), "Clear any attached original workspaces")
+
       .def("hasOriginalWorkspace", &MDGeometry::hasOriginalWorkspace,
            (arg("self"), arg("index")),
            "Returns True if there is a source workspace at the given index")

--- a/qt/python/mantidqt/_common.sip
+++ b/qt/python/mantidqt/_common.sip
@@ -934,13 +934,18 @@ class ImageInfoWidget : public QTableWidget {
 #include <boost/python/handle.hpp>
 %End
 public:
-    ImageInfoWidget(std::string workspace_type, QWidget *parent = nullptr);
-    void updateTable(const double x, const double y, const double z);
+    ImageInfoWidget(QWidget *parent = nullptr);
+    void cursorAt(const double x, const double y, const double signal);
     void setWorkspace(SIP_PYOBJECT);
     %MethodCode
     try {
       auto extractor = Mantid::PythonInterface::ExtractSharedPtr<Mantid::API::Workspace>(boost::python::object(boost::python::handle<>(a0)));
       sipCpp->setWorkspace(extractor());
+    } catch(const std::exception & exc) {
+      SIP_BLOCK_THREADS
+      PyErr_SetString(PyExc_RuntimeError, exc.what());
+      SIP_UNBLOCK_THREADS
+      return NULL;
     } catch(...) {
       sipRaiseUnknownException();
       return NULL;

--- a/qt/python/mantidqt/_common.sip
+++ b/qt/python/mantidqt/_common.sip
@@ -939,8 +939,9 @@ public:
     void setWorkspace(SIP_PYOBJECT);
     %MethodCode
     try {
-      auto extractor = Mantid::PythonInterface::ExtractSharedPtr<Mantid::API::Workspace>(boost::python::object(boost::python::handle<>(a0)));
-      sipCpp->setWorkspace(extractor());
+      using boost::python::extract;
+      using Mantid::PythonInterface::ExtractSharedPtr;
+      sipCpp->setWorkspace(ExtractSharedPtr<Mantid::API::Workspace>(a0)());
     } catch(const std::exception & exc) {
       SIP_BLOCK_THREADS
       PyErr_SetString(PyExc_RuntimeError, exc.what());

--- a/qt/python/mantidqt/_common.sip
+++ b/qt/python/mantidqt/_common.sip
@@ -936,6 +936,19 @@ class ImageInfoWidget : public QTableWidget {
 public:
     ImageInfoWidget(QWidget *parent = nullptr);
     void cursorAt(const double x, const double y, const double signal);
+    %MethodCode
+    try {
+      sipCpp->cursorAt(a0, a1, a2);
+    } catch(const std::exception & exc) {
+      SIP_BLOCK_THREADS
+      PyErr_SetString(PyExc_RuntimeError, exc.what());
+      SIP_UNBLOCK_THREADS
+      return NULL;
+    } catch(...) {
+      sipRaiseUnknownException();
+      return NULL;
+    }
+    %End
     void setWorkspace(SIP_PYOBJECT);
     %MethodCode
     try {

--- a/qt/python/mantidqt/utils/testing/compare.py
+++ b/qt/python/mantidqt/utils/testing/compare.py
@@ -1,0 +1,22 @@
+# Mantid Repository : https://github.com/mantidproject/mantid
+#
+# Copyright &copy; 2020 ISIS Rutherford Appleton Laboratory UKRI,
+#   NScD Oak Ridge National Laboratory, European Spallation Source,
+#   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+# SPDX - License - Identifier: GPL - 3.0 +
+#  This file is part of the mantidqt package
+import numpy as np
+
+
+class ArraysEqual:
+    """Compare arrays for equality in mock.assert_called_with calls.
+    """
+    def __init__(self, expected):
+        self._expected = expected
+
+    def __eq__(self, other):
+        return np.all(self._expected == other)
+
+    def __repr__(self):
+        """Return a string when the test comparison fails"""
+        return f"{self._expected}"

--- a/qt/python/mantidqt/widgets/sliceviewer/cursortracker.py
+++ b/qt/python/mantidqt/widgets/sliceviewer/cursortracker.py
@@ -1,0 +1,65 @@
+# Mantid Repository : https://github.com/mantidproject/mantid
+#
+# Copyright &copy; 2018 ISIS Rutherford Appleton Laboratory UKRI,
+#   NScD Oak Ridge National Laboratory, European Spallation Source,
+#   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+# SPDX - License - Identifier: GPL - 3.0 +
+#  This file is part of the mantidqt
+# std imports
+
+# 3rd party imports
+from matplotlib.axes import Axes
+
+
+class CursorTracker:
+    """
+    Attach to the motion_notify_event of the canvas a given
+    axes is draw on. Holds a list of subscribers that are notified
+    of the events. Subscribers are expected to have a cursor_at method.
+    """
+    def __init__(self, *, image_axes: Axes, autoconnect=True):
+        """
+        :param image_axes: A reference to the Axes object the image resides in
+        :param autoconnect: True if connections should be made on construction
+        """
+        self._im_axes = image_axes
+        self._mouse_move_cid, self._mouse_outside_cid = None, None
+        if autoconnect:
+            self.connect()
+
+    def __del__(self):
+        try:
+            self.disconnect()
+        except AttributeError:
+            pass
+
+    def connect(self):
+        canvas = self._im_axes.figure.canvas
+        self._mouse_move_cid = canvas.mpl_connect('motion_notify_event', self.on_mouse_move)
+        self._mouse_outside_cid = canvas.mpl_connect('axes_leave_event', self.on_mouse_leave)
+
+    def disconnect(self):
+        canvas = self._im_axes.figure.canvas
+
+        def impl(cid):
+            if cid is not None:
+                canvas.mpl_disconnect(cid)
+
+        self._mouse_move_cid = impl(self._mouse_move_cid)
+        self._mouse_outside_cid = impl(self._mouse_outside_cid)
+
+    def on_mouse_leave(self, event):
+        """
+        Subscribed to the axes_leave_event.
+        :param event: A MouseEvent describing the event
+        """
+        self.on_cursor_outside_axes()
+
+    def on_mouse_move(self, event):
+        """
+        Subscribed to the motion_notify_event event.
+        :param event: A MouseEvent describing the event
+        """
+        xdata, ydata = event.xdata, event.ydata
+        if event.inaxes == self._im_axes:
+            self.on_cursor_at(xdata, ydata)

--- a/qt/python/mantidqt/widgets/sliceviewer/cursortracker.py
+++ b/qt/python/mantidqt/widgets/sliceviewer/cursortracker.py
@@ -27,12 +27,6 @@ class CursorTracker:
         if autoconnect:
             self.connect()
 
-    def __del__(self):
-        try:
-            self.disconnect()
-        except AttributeError:
-            pass
-
     def connect(self):
         canvas = self._im_axes.figure.canvas
         self._mouse_move_cid = canvas.mpl_connect('motion_notify_event', self.on_mouse_move)

--- a/qt/python/mantidqt/widgets/sliceviewer/dimensionwidget.py
+++ b/qt/python/mantidqt/widgets/sliceviewer/dimensionwidget.py
@@ -22,7 +22,6 @@ class State(Enum):
 class DimensionWidget(QWidget):
     dimensionsChanged = Signal()
     valueChanged = Signal()
-
     """
     Hold all the individual dimensions
 
@@ -124,10 +123,13 @@ class DimensionWidget(QWidget):
         ]
 
     def get_bin_params(self):
-        return [
-            d.get_bins() if d.get_state() in (State.X, State.Y) else d.get_thickness()
-            for d in self.dims
-        ]
+        try:
+            return [
+                d.get_bins() if d.get_state() in (State.X, State.Y) else d.get_thickness()
+                for d in self.dims
+            ]
+        except AttributeError:
+            return None
 
     def set_slicepoint(self, point):
         """

--- a/qt/python/mantidqt/widgets/sliceviewer/imageinfowidget.py
+++ b/qt/python/mantidqt/widgets/sliceviewer/imageinfowidget.py
@@ -5,12 +5,16 @@
 #   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
 # SPDX - License - Identifier: GPL - 3.0 +
 #  This file is part of the mantidqt package
-#
-#
+# std imports
+import sys
+
 from mantidqt.utils.qt import import_qt
 from matplotlib.image import AxesImage
 
 from .lineplots import CursorTracker, cursor_info
+
+# Constants
+DBLMAX = sys.float_info.max
 
 ImageInfoWidget = import_qt('.._common', 'mantidqt.widgets', 'ImageInfoWidget')
 
@@ -47,4 +51,4 @@ class ImageInfoTracker(CursorTracker):
 
     def on_cursor_outside_axes(self):
         """Update the image table given the mouse has moved out of the image axes"""
-        self._widget.updateTable(0.0, 0.0, 0.0)
+        self._widget.updateTable(DBLMAX, DBLMAX, DBLMAX)

--- a/qt/python/mantidqt/widgets/sliceviewer/imageinfowidget.py
+++ b/qt/python/mantidqt/widgets/sliceviewer/imageinfowidget.py
@@ -22,7 +22,7 @@ ImageInfoWidget = import_qt('.._common', 'mantidqt.widgets', 'ImageInfoWidget')
 
 
 class ImageInfoTracker(CursorTracker):
-    def __init__(self, image: Union[AxesImage, QuadMesh], transpose_xy: False,
+    def __init__(self, image: Union[AxesImage, QuadMesh], transpose_xy: bool,
                  widget: ImageInfoWidget):
         """
         Update the image that the widget refers too.
@@ -42,7 +42,7 @@ class ImageInfoTracker(CursorTracker):
 
     def on_cursor_outside_axes(self):
         """Update the image table given the mouse has moved out of the image axes"""
-        self._widget.updateTable(DBLMAX, DBLMAX, DBLMAX)
+        self._widget.cursorAt(DBLMAX, DBLMAX, DBLMAX)
 
     # private api
 
@@ -62,7 +62,7 @@ class ImageInfoTracker(CursorTracker):
             if (0 <= i < arr.shape[0]) and (0 <= j < arr.shape[1]):
                 if self._transpose_xy:
                     ydata, xdata = xdata, ydata
-                self._widget.updateTable(xdata, ydata, arr[i, j])
+                self._widget.cursorAt(xdata, ydata, arr[i, j])
 
     def _on_cursor_at_mesh(self, xdata: float, ydata: float):
         """
@@ -75,4 +75,4 @@ class ImageInfoTracker(CursorTracker):
         """
         if self._image is None:
             return
-        self._widget.updateTable(xdata, ydata, DBLMAX)
+        self._widget.cursorAt(xdata, ydata, DBLMAX)

--- a/qt/python/mantidqt/widgets/sliceviewer/imageinfowidget.py
+++ b/qt/python/mantidqt/widgets/sliceviewer/imageinfowidget.py
@@ -8,5 +8,43 @@
 #
 #
 from mantidqt.utils.qt import import_qt
+from matplotlib.image import AxesImage
+
+from .lineplots import CursorTracker, cursor_info
 
 ImageInfoWidget = import_qt('.._common', 'mantidqt.widgets', 'ImageInfoWidget')
+
+
+class ImageInfoTracker(CursorTracker):
+    def __init__(self, image: AxesImage, transpose_xy: False, widget: ImageInfoWidget):
+        """
+        Update the image that the widget refers too.
+        :param: An AxesImage instance to track
+        :param: transpose_xy: If true the cursor position should be transposed
+                before sending to the table update
+        """
+        super().__init__(image_axes=image.axes, autoconnect=False)
+        self._image = image
+        self._transpose_xy = transpose_xy
+        self._widget = widget
+
+    def on_cursor_at(self, xdata: float, ydata: float):
+        """
+        Update the image table for the given coordinates
+        :param xdata: X coordinate of cursor in data space
+        :param ydata: Y coordinate of cursor in data space
+        """
+        if self._image is None:
+            return
+
+        cinfo = cursor_info(self._image, xdata, ydata)
+        if cinfo is not None:
+            arr, _, (i, j) = cinfo
+            if (0 <= i < arr.shape[0]) and (0 <= j < arr.shape[1]):
+                if self._transpose_xy:
+                    ydata, xdata = xdata, ydata
+                self._widget.updateTable(xdata, ydata, arr[i, j])
+
+    def on_cursor_outside_axes(self):
+        """Update the image table given the mouse has moved out of the image axes"""
+        self._widget.updateTable(0.0, 0.0, 0.0)

--- a/qt/python/mantidqt/widgets/sliceviewer/imageinfowidget.py
+++ b/qt/python/mantidqt/widgets/sliceviewer/imageinfowidget.py
@@ -6,9 +6,11 @@
 # SPDX - License - Identifier: GPL - 3.0 +
 #  This file is part of the mantidqt package
 # std imports
+from typing import Union
 import sys
 
 from mantidqt.utils.qt import import_qt
+from matplotlib.collections import QuadMesh
 from matplotlib.image import AxesImage
 
 from .lineplots import CursorTracker, cursor_info
@@ -20,10 +22,11 @@ ImageInfoWidget = import_qt('.._common', 'mantidqt.widgets', 'ImageInfoWidget')
 
 
 class ImageInfoTracker(CursorTracker):
-    def __init__(self, image: AxesImage, transpose_xy: False, widget: ImageInfoWidget):
+    def __init__(self, image: Union[AxesImage, QuadMesh], transpose_xy: False,
+                 widget: ImageInfoWidget):
         """
         Update the image that the widget refers too.
-        :param: An AxesImage instance to track
+        :param: An AxesImage or Mesh instance to track
         :param: transpose_xy: If true the cursor position should be transposed
                 before sending to the table update
         """
@@ -32,9 +35,21 @@ class ImageInfoTracker(CursorTracker):
         self._transpose_xy = transpose_xy
         self._widget = widget
 
-    def on_cursor_at(self, xdata: float, ydata: float):
+        if hasattr(image, 'get_extent'):
+            self.on_cursor_at = self._on_cursor_at_axesimage
+        else:
+            self.on_cursor_at = self._on_cursor_at_mesh
+
+    def on_cursor_outside_axes(self):
+        """Update the image table given the mouse has moved out of the image axes"""
+        self._widget.updateTable(DBLMAX, DBLMAX, DBLMAX)
+
+    # private api
+
+    def _on_cursor_at_axesimage(self, xdata: float, ydata: float):
         """
-        Update the image table for the given coordinates
+        Update the image table for the given coordinates given an AxesImage
+        object.
         :param xdata: X coordinate of cursor in data space
         :param ydata: Y coordinate of cursor in data space
         """
@@ -49,6 +64,15 @@ class ImageInfoTracker(CursorTracker):
                     ydata, xdata = xdata, ydata
                 self._widget.updateTable(xdata, ydata, arr[i, j])
 
-    def on_cursor_outside_axes(self):
-        """Update the image table given the mouse has moved out of the image axes"""
-        self._widget.updateTable(DBLMAX, DBLMAX, DBLMAX)
+    def _on_cursor_at_mesh(self, xdata: float, ydata: float):
+        """
+        Update the image table for the given coordinates for a mesh object.
+        This simply updates the position coordinates in the same fashion as
+        the standard matplotlib system as looking up the signal is not yet
+        supported.
+        :param xdata: X coordinate of cursor in data space
+        :param ydata: Y coordinate of cursor in data space
+        """
+        if self._image is None:
+            return
+        self._widget.updateTable(xdata, ydata, DBLMAX)

--- a/qt/python/mantidqt/widgets/sliceviewer/lineplots.py
+++ b/qt/python/mantidqt/widgets/sliceviewer/lineplots.py
@@ -7,6 +7,7 @@
 #  This file is part of the mantidqt
 # std imports
 from collections import namedtuple
+from functools import lru_cache
 from typing import Any, Optional
 
 # 3rd party imports
@@ -222,6 +223,7 @@ class PixelLinePlot(CursorTracker):
 CursorInfo = namedtuple("CursorInfo", ("array", "extent", "point"))
 
 
+@lru_cache(maxsize=32)
 def cursor_info(image: AxesImage, xdata: float, ydata: float) -> Optional[CursorInfo]:
     """Return information on the image for the given position in
     data coordinates.

--- a/qt/python/mantidqt/widgets/sliceviewer/lineplots.py
+++ b/qt/python/mantidqt/widgets/sliceviewer/lineplots.py
@@ -1,0 +1,243 @@
+# Mantid Repository : https://github.com/mantidproject/mantid
+#
+# Copyright &copy; 2018 ISIS Rutherford Appleton Laboratory UKRI,
+#   NScD Oak Ridge National Laboratory, European Spallation Source,
+#   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+# SPDX - License - Identifier: GPL - 3.0 +
+#  This file is part of the mantidqt
+# std imports
+from collections import namedtuple
+from typing import Any, Optional
+
+# 3rd party imports
+from matplotlib.artist import setp as set_artist_property
+from matplotlib.axes import Axes
+from matplotlib.image import AxesImage
+from matplotlib.gridspec import GridSpec
+from matplotlib.transforms import Bbox, BboxTransform
+import numpy as np
+
+# local imports
+from mantidqt.widgets.colorbar.colorbar import ColorbarWidget
+from .cursortracker import CursorTracker
+
+
+class LinePlotter:
+    """
+    Provides facilities to add line cut plots to an exist
+    image axes
+    """
+    __slots__ = ("_axx", "_axy", "_canvas", "_colorbar", "_fig", "_im_ax", "_image", "_plot_impl",
+                 "_xfig", "_yfig")
+
+    def __init__(self, image_axes: Axes, colorbar: ColorbarWidget, plottype_cls: Any):
+        """
+        :param image_axes: A reference to the image axes containing the
+                           source Image data for the cuts. It is assumed
+                           the Axes contains a single AxesImage object in the
+                           .images attribute
+        :param colorbar: An instance of a mantidqt.widgets.colorbar.colorbar.ColorbarWidget
+        :param plottype_cls: A class type defining how the plot should be created. It's __init__
+        method must accept a LinePlotter instance as a parameter.
+        """
+        self._im_ax = image_axes
+        self._image = image_axes.images[0]
+        self._fig = image_axes.figure
+        self._canvas = self._fig.canvas
+        self._colorbar = colorbar
+        self._plot_impl = plottype_cls(self)
+
+        self._add_line_plots()
+
+    @property
+    def image(self):
+        return self._image
+
+    @property
+    def image_axes(self):
+        return self._im_ax
+
+    def close(self):
+        """
+        Call to remove the line plots from the axes
+        """
+        self._remove_line_plots()
+
+    def delete_line_plot_lines(self):
+        """
+        Remove plotted cut curves
+        """
+        try:
+            try:
+                self._xfig.remove()
+                self._yfig.remove()
+            except ValueError:
+                pass
+            del self._xfig
+            del self._yfig
+            self._canvas.draw_idle()
+        except AttributeError:
+            pass
+
+    def plot_x_line(self, x: np.ndarray, y: np.ndarray):
+        """
+        Plots cut parallel to the X axis of the image
+        :param x: Array of values for X axis
+        :param y: Array of values for Y axis
+        """
+        try:
+            self._xfig.set_data(x, y)
+        except (AttributeError, IndexError):
+            self._axx.clear()
+            self._xfig = self._axx.plot(x, y, scalex=False)[0]
+            self.update_line_plot_labels()
+            self.update_line_plot_limits()
+        self._canvas.draw_idle()
+
+    def plot_y_line(self, x: np.array, y: np.array):
+        """
+        Plots cut parallel to the Y axis of the image.
+        :param x: Array of values for X axis
+        :param y: Array of values for Y axis
+        """
+        try:
+            self._yfig.set_data(y, x)
+        except (AttributeError, IndexError):
+            self._axy.clear()
+            self._yfig = self._axy.plot(y, x, scaley=False)[0]
+            self.update_line_plot_labels()
+            self.update_line_plot_limits()
+        self._canvas.draw_idle()
+
+    def update_line_plot_limits(self):
+        """
+        Update limits of line plots to match colorbar scale
+        """
+        # set line plot intensity axes to match colorbar limits
+        self._axx.set_ylim(self._colorbar.cmin_value, self._colorbar.cmax_value)
+        self._axy.set_xlim(self._colorbar.cmin_value, self._colorbar.cmax_value)
+
+    def update_line_plot_labels(self):
+        """
+        Update line plot labels to match main image labels
+        """
+        # ensure plot labels are in sync with main axes
+        self._axx.set_xlabel(self._im_ax.get_xlabel())
+        self._axy.set_ylabel(self._im_ax.get_ylabel())
+
+    def update_line_plot_scales(self):
+        """
+        Set line plot scale axes to match colorbar scale
+        """
+        scale, kwargs = self._colorbar.get_colorbar_scale()
+        try:
+            self._axx.set_yscale(scale, **kwargs)
+            self._axy.set_xscale(scale, **kwargs)
+        except AttributeError:
+            pass
+
+    # Private api
+    def _add_line_plots(self):
+        """
+        Create new axes for the X/Y cuts and attach them to the
+        existing image axes.
+        """
+        image_axes = self._im_ax
+
+        # Create a new GridSpec and reposition the existing image Axes
+        gs = GridSpec(2, 2, width_ratios=[1, 4], height_ratios=[4, 1], wspace=0.0, hspace=0.0)
+        image_axes.set_position(gs[1].get_position(self._fig))
+        set_artist_property(image_axes.get_xticklabels(), visible=False)
+        set_artist_property(image_axes.get_yticklabels(), visible=False)
+        self._axx = self._fig.add_subplot(gs[3], sharex=image_axes)
+        self._axx.yaxis.tick_right()
+        self._axy = self._fig.add_subplot(gs[0], sharey=image_axes)
+        self._axy.xaxis.tick_top()
+
+        self.update_line_plot_labels()
+        self.update_line_plot_scales()
+        # self.mpl_toolbar.update()  # sync list of axes in navstack
+        self._canvas.draw_idle()
+
+    def _remove_line_plots(self):
+        """
+        Remove the attached cut plots and restore the image axes to the central
+        axes position
+        """
+        image_axes = self._im_ax
+
+        self.delete_line_plot_lines()
+        all_axes = self._fig.axes
+        # The order is defined by the order of the add_subplot calls so we always want to remove
+        # the last two Axes. Do it backwards to cope with the container size change
+        all_axes[2].remove()
+        all_axes[1].remove()
+
+        gs = GridSpec(1, 1)
+        image_axes.set_position(gs[0].get_position(self._fig))
+        image_axes.xaxis.tick_bottom()
+        image_axes.yaxis.tick_left()
+        self._axx, self._axy = None, None
+
+        # self.mpl_toolbar.update()  # sync list of axes in navstack
+        self._canvas.draw_idle()
+
+
+class PixelLinePlot(CursorTracker):
+    """
+    Draws X/Y line plots from single rows/columns of an image.
+    """
+    def __init__(self, plotter: LinePlotter):
+        """
+        :param plotter: The object responsible for drawing the curves.
+                        Must have plot_x_line & plot_y_line methods.
+        """
+        super().__init__(image_axes=plotter.image_axes)
+        self._plotter = plotter
+
+    # CursorTracker interface
+    def on_cursor_at(self, xdata: float, ydata: float):
+        """
+        Notify the object that a new event has occurred at the given coordinates
+        :param xdata: X position in data coordinates
+        :param ydata: Y position in data coordinates
+        """
+        plotter = self._plotter
+        cinfo = cursor_info(plotter.image, xdata, ydata)
+        if cinfo is not None:
+            arr, (xmin, xmax, ymin, ymax), (i, j) = cinfo
+            if 0 <= i < arr.shape[0]:
+                plotter.plot_x_line(np.linspace(xmin, xmax, arr.shape[1]), arr[i, :])
+            if 0 <= j < arr.shape[1]:
+                plotter.plot_y_line(np.linspace(ymin, ymax, arr.shape[0]), arr[:, j])
+
+    def on_cursor_outside_axes(self):
+        """
+        Called when the mouse moves outside of the image axes
+        """
+        self._plotter.delete_line_plot_lines()
+
+
+# Data type to store information related to a cursor over an image
+CursorInfo = namedtuple("CursorInfo", ("array", "extent", "point"))
+
+
+def cursor_info(image: AxesImage, xdata: float, ydata: float) -> Optional[CursorInfo]:
+    """Return information on the image for the given position in
+    data coordinates.
+    :param image: An instance of an image type
+    :param xdata: X data coordinate of cursor
+    :param xdata: Y data coordinate of cursor
+    :return: None if point is not valid on the image else return CursorInfo type
+    """
+    extent = image.get_extent()
+    xmin, xmax, ymin, ymax = image.get_extent()
+    arr = image.get_array()
+    data_extent = Bbox([[extent[2], extent[0]], [extent[3], extent[1]]])
+    array_extent = Bbox([[0, 0], arr.shape[:2]])
+    trans = BboxTransform(boxin=data_extent, boxout=array_extent)
+    point = trans.transform_point([ydata, xdata])
+    if any(np.isnan(point)):
+        return None
+
+    return CursorInfo(array=arr, extent=extent, point=point.astype(int))

--- a/qt/python/mantidqt/widgets/sliceviewer/presenter.py
+++ b/qt/python/mantidqt/widgets/sliceviewer/presenter.py
@@ -159,8 +159,7 @@ class SliceViewer(object):
         """Notify data limits on image axes have changed"""
         data_view = self.view.data_view
         if self.model.can_support_dynamic_rebinning():
-            self.model.rebin(slicepoint=self.get_slicepoint(), limits=data_view.get_axes_limits())
-            self.new_plot()
+            self.new_plot()  # automatically uses current display limits
             self._call_peaks_presenter_if_created("notify", PeaksViewerPresenter.Event.OverlayPeaks)
         else:
             data_view.draw_plot()

--- a/qt/python/mantidqt/widgets/sliceviewer/presenter.py
+++ b/qt/python/mantidqt/widgets/sliceviewer/presenter.py
@@ -50,6 +50,7 @@ class SliceViewer(object):
                                                       self.model.can_normalize_workspace(), parent)
         self.view.data_view.create_axes_orthogonal(
             redraw_on_zoom=not self.model.can_support_dynamic_rebinning())
+        self.view.data_view.image_info_widget.setWorkspace(ws)
 
         if self.model.can_normalize_workspace():
             self.view.data_view.set_normalization(ws)
@@ -59,11 +60,7 @@ class SliceViewer(object):
         if not self.model.can_support_nonorthogonal_axes():
             self.view.data_view.disable_tool_button(ToolItemText.NONORTHOGONAL_AXES)
 
-        if self.model.get_ws_type() == WS_TYPE.MATRIX:
-            self.view.data_view.image_info_widget.setWorkspace(ws)
-
         self.view.setWindowTitle(self.model.get_title())
-
         self.new_plot()
 
         # Start the GUI with zoom selected.

--- a/qt/python/mantidqt/widgets/sliceviewer/roi.py
+++ b/qt/python/mantidqt/widgets/sliceviewer/roi.py
@@ -1,0 +1,230 @@
+# Mantid Repository : https://github.com/mantidproject/mantid
+#
+# Copyright &copy; 2020 ISIS Rutherford Appleton Laboratory UKRI,
+#   NScD Oak Ridge National Laboratory, European Spallation Source,
+#   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+# SPDX - License - Identifier: GPL - 3.0 +
+#  This file is part of the mantidqt.
+#
+import math
+
+from mantid.api import MatrixWorkspace
+from mantid.simpleapi import (DeleteWorkspace, ExtractSpectra, Rebin, ReplaceSpecialValues,
+                              SumSpectra, Transpose)
+import numpy as np
+
+
+def extract_matrix_cuts_spectra_axis(workspace: MatrixWorkspace,
+                                     xmin: float,
+                                     xmax: float,
+                                     ymin: float,
+                                     ymax: float,
+                                     xcut_name: str,
+                                     ycut_name: str,
+                                     log_algorithm_calls: bool = False):
+    """
+    Assuming a MatrixWorkspace with vertical spectra axis, extract 1D cuts from the region defined
+    by the given parameters
+    :param workspace: A MatrixWorkspace with a vertical SpectraAxis
+    :param xmin: X min for bounded region
+    :param xmax: X max for bounded region
+    :param ymin: Y min for bounded region
+    :param ymax: Y max for bounded region
+    :param xcut_name: Name of the X cut. Empty indicates it should be skipped
+    :param ycut_name: Name of the Y cut. Empty indicates it should be skipped
+    :param log_algorithm_calls: Log the algorithm call or be silent
+    """
+    # if the value is half way in a spectrum then include it
+    tmp_crop_region = '__tmp_sv_region_extract'
+    extract_roi_spectra_axis(workspace, xmin, xmax, ymin, ymax, tmp_crop_region,
+                             log_algorithm_calls)
+    if xcut_name:
+        SumSpectra(InputWorkspace=tmp_crop_region,
+                   OutputWorkspace=xcut_name,
+                   EnableLogging=log_algorithm_calls)
+    if ycut_name:
+        Rebin(InputWorkspace=tmp_crop_region,
+              OutputWorkspace=ycut_name,
+              Params=[xmin, xmax - xmin, xmax],
+              LOG_ALGORITHM_CALLS=log_algorithm_calls)
+        Transpose(InputWorkspace=ycut_name,
+                  OutputWorkspace=ycut_name,
+                  LOG_ALGORITHM_CALLS=log_algorithm_calls)
+    try:
+        DeleteWorkspace(tmp_crop_region)
+    except ValueError:
+        pass
+
+
+def extract_matrix_cuts_numeric_axis(workspace: MatrixWorkspace,
+                                     xmin: float,
+                                     xmax: float,
+                                     ymin: float,
+                                     ymax: float,
+                                     xcut_name: str,
+                                     ycut_name: str,
+                                     log_algorithm_calls: bool = False):
+    """
+    Assuming a MatrixWorkspace with vertical numeric axis, extract 1D cuts from the region defined
+    by the given parameters
+    :param workspace: A MatrixWorkspace with a vertical NumericAxis
+    :param xmin: X min for bounded region
+    :param xmax: X max for bounded region
+    :param ymin: Y min for bounded region
+    :param ymax: Y max for bounded region
+    :param xcut_name: Name of the X cut. Empty indicates it should be skipped
+    :param ycut_name: Name of the Y cut. Empty indicates it should be skipped
+    :param log_algorithm_calls: Log the algorithm call or be silent
+    """
+    if xcut_name:
+        ExtractSpectra(InputWorkspace=workspace,
+                       OutputWorkspace=xcut_name,
+                       XMin=xmin,
+                       XMax=xmax,
+                       EnableLogging=log_algorithm_calls)
+        # Rebin with nan/inf results in everything turning to NAN so
+        # set them all to zero as this will effectively ignore them for us
+        ReplaceSpecialValues(InputWorkspace=xcut_name,
+                             OutputWorkspace=xcut_name,
+                             NanValue=0.0,
+                             InfinityValue=0.0,
+                             EnableLogging=log_algorithm_calls)
+        Transpose(InputWorkspace=xcut_name,
+                  OutputWorkspace=xcut_name,
+                  EnableLogging=log_algorithm_calls)
+        Rebin(InputWorkspace=xcut_name,
+              OutputWorkspace=xcut_name,
+              Params=[ymin, ymax - ymin, ymax],
+              EnableLogging=log_algorithm_calls)
+        Transpose(InputWorkspace=xcut_name,
+                  OutputWorkspace=xcut_name,
+                  EnableLogging=log_algorithm_calls)
+    if ycut_name:
+        Rebin(InputWorkspace=workspace,
+              OutputWorkspace=ycut_name,
+              Params=[xmin, xmax - xmin, xmax],
+              EnableLogging=log_algorithm_calls)
+        Transpose(InputWorkspace=ycut_name,
+                  OutputWorkspace=ycut_name,
+                  EnableLogging=log_algorithm_calls)
+
+
+def extract_roi_matrix(workspace: MatrixWorkspace,
+                       xmin: float,
+                       xmax: float,
+                       ymin: float,
+                       ymax: float,
+                       transpose: bool,
+                       roi_name: str,
+                       log_algorithm_calls: bool = False):
+    """
+    Assuming a MatrixWorkspace extract a 2D region from it.
+    :param workspace: A MatrixWorkspace
+    :param xmin: X min for bounded region
+    :param xmax: X max for bounded region
+    :param ymin: Y min for bounded region
+    :param ymax: Y max for bounded region
+    :param transpose: If true then the region bounds are transposed from the orientation of the workspace
+    :param roi_name: Name of the result workspace
+    :param log_algorithm_calls: Log the algorithm call or be silent
+    """
+    if transpose:
+        xmin, xmax, ymin, ymax = ymin, ymax, xmin, xmax
+
+    yaxis = workspace.getAxis(1)
+    if yaxis.isSpectra():
+        extract_roi_spectra_axis(workspace, xmin, xmax, ymin, ymax, roi_name, log_algorithm_calls)
+    elif yaxis.isNumeric():
+        extract_roi_numeric_axis(workspace, xmin, xmax, ymin, ymax, roi_name, log_algorithm_calls)
+    else:
+        raise RuntimeError("Unknown vertical axis type")
+
+    if transpose:
+        Transpose(InputWorkspace=roi_name, OutputWorkspace=roi_name)
+
+
+def extract_roi_spectra_axis(workspace: MatrixWorkspace,
+                             xmin: float,
+                             xmax: float,
+                             ymin: float,
+                             ymax: float,
+                             roi_name: str,
+                             log_algorithm_calls: bool = False):
+    """
+    Assuming a MatrixWorkspace with vertical spectra axis, extract 1D cuts from the region defined
+    by the given parameters
+    :param workspace: A MatrixWorkspace with a vertical SpectraAxis
+    :param xmin: X min for bounded region
+    :param xmax: X max for bounded region
+    :param ymin: Y min for bounded region
+    :param ymax: Y max for bounded region
+    :param xcut_name: Name of the X cut. Empty indicates it should be skipped
+    :param ycut_name: Name of the Y cut. Empty indicates it should be skipped
+    :param log_algorithm_calls: Log the algorithm call or be silent
+    """
+    indexmin, indexmax = _index_range_spectraaxis(workspace, ymin, ymax)
+    _extract_region(workspace, xmin, xmax, indexmin, indexmax, roi_name, log_algorithm_calls)
+
+
+def extract_roi_numeric_axis(workspace: MatrixWorkspace,
+                             xmin: float,
+                             xmax: float,
+                             ymin: float,
+                             ymax: float,
+                             roi_name: str,
+                             log_algorithm_calls: bool = False):
+    """
+    Assuming a MatrixWorkspace with vertical spectra axis, extract 1D cuts from the region defined
+    by the given parameters
+    :param workspace: A MatrixWorkspace with a vertical SpectraAxis
+    :param xmin: X min for bounded region
+    :param xmax: X max for bounded region
+    :param ymin: Y min for bounded region
+    :param ymax: Y max for bounded region
+    :param xcut_name: Name of the X cut. Empty indicates it should be skipped
+    :param ycut_name: Name of the Y cut. Empty indicates it should be skipped
+    :param log_algorithm_calls: Log the algorithm call or be silent
+    """
+    yaxis_values = workspace.getAxis(1).extractValues()
+    # determine workspace indices for crop. We assume the region has been checked against the workspace
+    # data boundaries
+    indexmin, indexmax = int(np.searchsorted(yaxis_values, ymin)), \
+        int(np.searchsorted(yaxis_values, ymax) - 1)
+    _extract_region(workspace, xmin, xmax, indexmin, indexmax, roi_name, log_algorithm_calls)
+
+
+def _extract_region(workspace: MatrixWorkspace,
+                    xmin: float,
+                    xmax: float,
+                    indexmin: int,
+                    indexmax: int,
+                    name: str,
+                    log_algorithm_calls: bool = False):
+    """
+    Assuming a MatrixWorkspace crop a region with the given parameters
+    :param workspace: A MatrixWorkspace with a vertical SpectraAxis
+    :param xmin: X min for bounded region
+    :param xmax: X max for bounded region
+    :param ymin: Y min for bounded region
+    :param ymax: Y max for bounded region
+    :param name: A name for the workspace
+    """
+    ExtractSpectra(InputWorkspace=workspace,
+                   OutputWorkspace=name,
+                   XMin=xmin,
+                   XMax=xmax,
+                   StartWorkspaceIndex=indexmin,
+                   EndWorkspaceIndex=indexmax,
+                   EnableLogging=log_algorithm_calls)
+
+
+def _index_range_spectraaxis(workspace: MatrixWorkspace, ymin: float, ymax: float):
+    """
+    Return the workspace indicies for the given ymin/ymax values on the given workspace
+    :param workspace: A MatrixWorkspace object
+    :param ymin: Minimum Y value in range
+    :param ymax: Maximum Y value in range
+    """
+    indexmin = workspace.getIndexFromSpectrumNumber(math.floor(ymin + 0.5))
+    indexmax = workspace.getIndexFromSpectrumNumber(math.floor(ymax + 0.5))
+    return indexmin, indexmax

--- a/qt/python/mantidqt/widgets/sliceviewer/test/test_sliceviewer_cursortracker.py
+++ b/qt/python/mantidqt/widgets/sliceviewer/test/test_sliceviewer_cursortracker.py
@@ -1,0 +1,80 @@
+# Mantid Repository : https://github.com/mantidproject/mantid
+#
+# Copyright &copy; 2020 ISIS Rutherford Appleton Laboratory UKRI,
+#   NScD Oak Ridge National Laboratory, European Spallation Source,
+#   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+# SPDX - License - Identifier: GPL - 3.0 +
+#  This file is part of the mantidqt.
+# std imports
+import unittest
+from unittest.mock import MagicMock, call
+
+from mantidqt.widgets.sliceviewer.cursortracker import CursorTracker
+
+
+class CursorTrackerTest(unittest.TestCase):
+    def setUp(self):
+        self.mock_axes = MagicMock()
+
+    def test_construction_subscribes_to_expected_events_if_autoconnect_default(self):
+        tracker = CursorTracker(image_axes=self.mock_axes)
+
+        canvas = self.mock_axes.figure.canvas
+        canvas.mpl_connect.assert_has_calls(
+            (call('motion_notify_event',
+                  tracker.on_mouse_move), call('axes_leave_event', tracker.on_mouse_leave)),
+            any_order=True)
+
+    def test_construction_subscribes_to_expected_events_if_autoconnect_True(self):
+        tracker = CursorTracker(image_axes=self.mock_axes, autoconnect=True)
+
+        canvas = self.mock_axes.figure.canvas
+        canvas.mpl_connect.assert_has_calls(
+            (call('motion_notify_event',
+                  tracker.on_mouse_move), call('axes_leave_event', tracker.on_mouse_leave)),
+            any_order=True)
+
+    def test_on_mouse_move_notifies_if_inaxes(self):
+        tracker = _create_tracker(self.mock_axes)
+        mock_event = MagicMock(xdata=0.0, ydata=1.0, inaxes=self.mock_axes)
+
+        tracker.on_mouse_move(mock_event)
+
+        tracker.on_cursor_at.assert_called_once_with(0.0, 1.0)
+
+    def test_on_mouse_move_does_nothing_if_not_inaxes(self):
+        tracker = _create_tracker(self.mock_axes)
+        mock_event = MagicMock(xdata=0.0, ydata=1.0, inaxes=MagicMock())
+
+        tracker.on_mouse_move(mock_event)
+
+        tracker.on_cursor_at.assert_not_called()
+
+    def test_on_mouse_leave_calls_on_cursor_leave(self):
+        tracker = _create_tracker(self.mock_axes)
+        mock_event = MagicMock()
+
+        tracker.on_mouse_leave(mock_event)
+
+        tracker.on_cursor_outside_axes.assert_called_once()
+
+    def test_disconnect_removes_connections(self):
+        tracker = _create_tracker(self.mock_axes)
+        move_cid, leave_cid = tracker._mouse_move_cid, tracker._mouse_outside_cid
+
+        tracker.disconnect()
+
+        canvas = self.mock_axes.figure.canvas
+        canvas.mpl_disconnect.assert_has_calls((call(move_cid), call(leave_cid)), any_order=True)
+
+
+def _create_tracker(axes):
+    tracker = CursorTracker(image_axes=axes)
+    tracker.on_cursor_at = MagicMock()
+    tracker.on_cursor_outside_axes = MagicMock()
+
+    return tracker
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/qt/python/mantidqt/widgets/sliceviewer/test/test_sliceviewer_lineplots.py
+++ b/qt/python/mantidqt/widgets/sliceviewer/test/test_sliceviewer_lineplots.py
@@ -1,0 +1,140 @@
+# Mantid Repository : https://github.com/mantidproject/mantid
+#
+# Copyright &copy; 2020 ISIS Rutherford Appleton Laboratory UKRI,
+#   NScD Oak Ridge National Laboratory, European Spallation Source,
+#   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+# SPDX - License - Identifier: GPL - 3.0 +
+#  This file is part of the mantidqt.
+# std imports
+import unittest
+from unittest.mock import MagicMock, call, patch
+
+# 3rd party imports
+from mantidqt.widgets.sliceviewer.lineplots import LinePlotter, PixelLinePlot
+from mantidqt.utils.testing.compare import ArraysEqual
+
+from matplotlib.figure import SubplotParams
+import numpy as np
+
+
+class LinePlotterTest(unittest.TestCase):
+    def setUp(self):
+        self.image_axes = _create_mock_axes()
+        self.axx, self.axy = MagicMock(), MagicMock()
+        self.image_axes.figure.add_subplot.side_effect = [self.axx, self.axy]
+        self.mock_colorbar = MagicMock(cmin_value=1.0, cmax_value=50.)
+        self.plotimpl_cls = MagicMock()
+
+    @patch('mantidqt.widgets.sliceviewer.lineplots.GridSpec')
+    def test_construction_adds_line_plots_to_axes(self, mock_gridspec):
+        gs = mock_gridspec()
+        mock_gridspec.reset_mock()
+        LinePlotter(self.image_axes, self.mock_colorbar, self.plotimpl_cls)
+
+        fig = self.image_axes.figure
+        self.assertEqual(2, fig.add_subplot.call_count)
+        self.assertEqual(1, mock_gridspec.call_count)
+        # use spaces at 0, 1 & 3 in grid
+        gs.__getitem__.assert_has_calls((call(0), call(1), call(3)), any_order=True)
+        self.assertTrue('sharex' in fig.add_subplot.call_args_list[0].kwargs)
+        self.assertTrue('sharey' in fig.add_subplot.call_args_list[1].kwargs)
+
+    def test_construction_creates_plot_impl_instance(self):
+        plotter = LinePlotter(self.image_axes, self.mock_colorbar, self.plotimpl_cls)
+
+        self.plotimpl_cls.assert_called_once_with(plotter)
+
+    def test_delete_plot_lines_handles_empty_plots(self):
+        plotter = LinePlotter(self.image_axes, self.mock_colorbar, self.plotimpl_cls)
+
+        plotter.delete_line_plot_lines()
+
+    def test_delete_plot_lines_with_plots_present(self):
+        plotter = LinePlotter(self.image_axes, self.mock_colorbar, self.plotimpl_cls)
+        xfig, yfig = MagicMock(), MagicMock()
+        self.axx.plot.side_effect = [[xfig]]
+        self.axy.plot.side_effect = [[yfig]]
+        x, y = np.arange(10.), np.arange(10.)
+        plotter.plot_x_line(x, y)
+        plotter.plot_y_line(x, y)
+
+        plotter.delete_line_plot_lines()
+
+        xfig.remove.assert_called_once()
+        yfig.remove.assert_called_once()
+
+    def test_plot_with_no_line_present_creates_line_artist(self):
+        plotter = LinePlotter(self.image_axes, self.mock_colorbar, self.plotimpl_cls)
+        self.axx.set_xlabel.reset_mock()
+        x, y = np.arange(10.), np.arange(10.) * 2
+
+        plotter.plot_x_line(x, y)
+        self.axx.plot.assert_called_once_with(x, y, scalex=False)
+        self.axx.set_xlabel.assert_called_once_with(self.image_axes.get_xlabel())
+        self.axx.set_ylim.assert_called_once_with(self.mock_colorbar.cmin_value,
+                                                  self.mock_colorbar.cmax_value)
+
+        self.axy.set_ylabel.reset_mock()
+        self.axy.set_xlim.reset_mock()
+        plotter.plot_y_line(x, y)
+        self.axy.plot.assert_called_once_with(y, x, scaley=False)
+        self.axy.set_ylabel.assert_called_once_with(self.image_axes.get_ylabel())
+        self.axy.set_xlim.assert_called_once_with(self.mock_colorbar.cmin_value,
+                                                  self.mock_colorbar.cmax_value)
+
+    def test_plot_with_line_present_sets_data(self):
+        plotter = LinePlotter(self.image_axes, self.mock_colorbar, self.plotimpl_cls)
+        x, y = np.arange(10.), np.arange(10.) * 2
+        plotter.plot_x_line(x, y)
+        plotter.plot_y_line(x, y)
+        self.axx.reset_mock()
+        self.axy.reset_mock()
+
+        plotter.plot_x_line(x, y)
+        plotter.plot_y_line(x, y)
+
+        plotter._xfig.set_data.assert_called_once_with(x, y)
+        plotter._yfig.set_data.assert_called_once_with(y, x)
+        self.axx.plot.assert_not_called()
+        self.axy.plot.assert_not_called()
+
+
+class PixelLinePlotTest(unittest.TestCase):
+    def test_cursor_at_generates_xy_plots(self):
+        image_axes = _create_mock_axes()
+        mock_image = MagicMock()
+        mock_image.get_extent.return_value = (-1, 1, -3, 3)
+        signal = np.arange(25.).reshape(5, 5)
+        mock_image.get_array.return_value = signal
+        image_axes.images = [mock_image]
+        plotter = MagicMock(image_axes=image_axes, image=mock_image)
+        pixel_plots = PixelLinePlot(plotter)
+
+        pixel_plots.on_cursor_at(0.0, 1.0)
+
+        plotter.plot_x_line.assert_called_once_with(ArraysEqual(np.linspace(-1, 1, 5)),
+                                                    ArraysEqual(signal[3, :]))
+        plotter.plot_y_line.assert_called_once_with(ArraysEqual(np.linspace(-3, 3, 5)),
+                                                    ArraysEqual(signal[:, 2]))
+
+    def test_cursor_outside_axes_deletes_plot_lines(self):
+        plotter = MagicMock()
+        pixel_plots = PixelLinePlot(plotter)
+
+        pixel_plots.on_cursor_outside_axes()
+
+        plotter.delete_line_plot_lines.assert_called_once()
+
+
+def _create_mock_axes():
+    image_axes = MagicMock()
+    image_axes.figure.subplotpars = SubplotParams(0.125, 0.11, 0.9, 0.88, 0.2, 0.2)
+    image_axes.get_xlim.return_value = (-1, 1)
+    image_axes.get_ylim.return_value = (-3, 3)
+    image_axes.get_xlabel.return_value = 'x'
+    image_axes.get_ylabel.return_value = 'y'
+    return image_axes
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/qt/python/mantidqt/widgets/sliceviewer/test/test_sliceviewer_model.py
+++ b/qt/python/mantidqt/widgets/sliceviewer/test/test_sliceviewer_model.py
@@ -607,65 +607,6 @@ class SliceViewerModelTest(unittest.TestCase):
                           slicepoint=(None, None, 0, 0),
                           transpose=False)
 
-    @patch('mantidqt.widgets.sliceviewer.model.BinMD')
-    def test_rebin_mdhistworkspace_calls_binmd(self, mock_binmd):
-        orig_ws = self.ws_MD_3D
-        model = SliceViewerModel(orig_ws)
-
-        model.rebin(slicepoint=(None, 0, None), limits=((-1, 1), (-2, 2)))
-
-        mock_binmd.assert_called_once_with(InputWorkspace=self.ws_MD_3D,
-                                           OutputWorkspace='ws_MD_3D_svrebinned',
-                                           AxisAligned=False,
-                                           EnableLogging=False,
-                                           BasisVector0='Dim1,MomentumTransfer,1.0,0.0,0.0',
-                                           BasisVector1='Dim2,EnergyTransfer,0.0,1.0,0.0',
-                                           BasisVector2='Dim3,Angstrom,0.0,0.0,1.0',
-                                           OutputExtents='-1,1,-10,10,-2,2',
-                                           OutputBins='5,5,4')
-
-        self.assertEqual(
-            mock_binmd.return_value,
-            model._get_ws(),
-            msg='Expected internal workspace reference to have been overwritten by result of BinMD')
-
-    @patch('mantidqt.widgets.sliceviewer.model.BinMD')
-    def test_rebin_mdhistworkspace_twice_uses_same_output_wsname(self, mock_binmd):
-        orig_ws = self.ws_MD_3D
-        model = SliceViewerModel(orig_ws)
-        mock_rebinned_first = MagicMock(getNumDims=lambda: 3)
-        mock_binmd.return_value = mock_rebinned_first
-
-        model.rebin(slicepoint=(None, 0, None), limits=((-1, 1), (-2, 2)))
-        model.rebin(slicepoint=(None, 0, None), limits=((-0.5, 0.5), (-2, 2)))
-        self.assertEqual(2, mock_binmd.call_count)
-        self.assertEqual(self.ws_MD_3D.name() + '_svrebinned',
-                         mock_binmd.call_args[-1]['OutputWorkspace'])
-
-    @patch('mantidqt.widgets.sliceviewer.model.BinMD')
-    def test_rebin_mdeventworkspace_does_nothing(self, mock_binmd):
-        orig_ws = self.ws_MDE_3D
-        model = SliceViewerModel(orig_ws)
-
-        model.rebin(slicepoint=(None, None, 0.),
-                    bin_params=[100, 100, 1],
-                    limits=(-1, 1, -2, 2, -3, 3))
-
-        mock_binmd.assert_not_called()
-        self.assertEqual(orig_ws, model._get_ws())
-
-    @patch('mantidqt.widgets.sliceviewer.model.BinMD')
-    def test_rebin_matrixworkspace_does_nothing(self, mock_binmd):
-        orig_ws = self.ws2d_histo
-        model = SliceViewerModel(orig_ws)
-
-        model.rebin(slicepoint=(None, None, 0.),
-                    bin_params=[100, 100, 1],
-                    limits=(-1, 1, -2, 2, -3, 3))
-
-        mock_binmd.assert_not_called()
-        self.assertEqual(orig_ws, model._get_ws())
-
     # private
     def _assert_supports_non_orthogonal_axes(self, expectation, ws_type, coords,
                                              has_oriented_lattice):

--- a/qt/python/mantidqt/widgets/sliceviewer/test/test_sliceviewer_presenter.py
+++ b/qt/python/mantidqt/widgets/sliceviewer/test/test_sliceviewer_presenter.py
@@ -218,7 +218,6 @@ class SliceViewerTest(unittest.TestCase):
         presenter.data_limits_changed()
 
         new_plot_mock.assert_called_once()
-        self.model.rebin.assert_called_once()
 
     def test_data_limits_changed_does_not_create_new_plot_if_dynamic_rebinning_not_supported(self):
         presenter = SliceViewer(None, model=self.model, view=self.view)

--- a/qt/python/mantidqt/widgets/sliceviewer/test/test_sliceviewer_presenter.py
+++ b/qt/python/mantidqt/widgets/sliceviewer/test/test_sliceviewer_presenter.py
@@ -18,9 +18,9 @@ sys.modules['mantid.simpleapi'] = mock.MagicMock()  # noqa: E402
 
 import mantid.api
 from mantidqt.widgets.sliceviewer.model import SliceViewerModel, WS_TYPE
-from mantidqt.widgets.sliceviewer.presenter import SliceViewer
+from mantidqt.widgets.sliceviewer.presenter import (PeaksViewerCollectionPresenter, SliceViewer)
+from mantidqt.widgets.sliceviewer.toolbar import ToolItemText
 from mantidqt.widgets.sliceviewer.view import SliceViewerView, SliceViewerDataView
-from mantidqt.widgets.sliceviewer.presenter import PeaksViewerCollectionPresenter
 
 
 def _create_presenter(model, view, mock_sliceinfo_cls, enable_nonortho_axes, supports_nonortho):
@@ -32,6 +32,8 @@ def _create_presenter(model, view, mock_sliceinfo_cls, enable_nonortho_axes, sup
         presenter.nonorthogonal_axes(True)
     else:
         data_view_mock.nonorthogonal_mode = False
+
+    data_view_mock.disable_tool_button.reset_mock()
     data_view_mock.create_axes_orthogonal.reset_mock()
     data_view_mock.create_axes_nonorthogonal.reset_mock()
     mock_sliceinfo_instance = mock_sliceinfo_cls.return_value
@@ -152,7 +154,7 @@ class SliceViewerTest(unittest.TestCase):
 
         SliceViewer(None, model=self.model, view=self.view)
 
-        self.view.data_view.disable_peaks_button.assert_called_once()
+        self.view.data_view.disable_tool_button.assert_called_once_with(ToolItemText.OVERLAY_PEAKS)
 
     def peaks_button_not_disabled_if_model_can_support_it(self):
         self.model.get_ws_type = mock.Mock(return_value=WS_TYPE.MATRIX)
@@ -160,7 +162,7 @@ class SliceViewerTest(unittest.TestCase):
 
         SliceViewer(None, model=self.model, view=self.view)
 
-        self.view.data_view.disable_peaks_button.assert_not_called()
+        self.view.data_view.disable_tool_button.assert_not_called()
 
     def test_non_orthogonal_axes_toggled_on(self):
         self.model.get_ws_type = mock.Mock(return_value=WS_TYPE.MATRIX)
@@ -172,12 +174,12 @@ class SliceViewerTest(unittest.TestCase):
         data_view_mock.create_axes_orthogonal.reset_mock()
         presenter.nonorthogonal_axes(True)
 
-        data_view_mock.remove_line_plots.assert_called_once()
+        data_view_mock.deactivate_tool.assert_called_once_with(ToolItemText.LINEPLOTS)
         data_view_mock.create_axes_nonorthogonal.assert_called_once()
         data_view_mock.create_axes_orthogonal.assert_not_called()
         data_view_mock.plot_matrix.assert_called_once()
-        data_view_mock.disable_lineplots_button.assert_called_once()
-        data_view_mock.disable_peaks_button.assert_called_once()
+        data_view_mock.disable_tool_button.assert_has_calls(
+            (mock.call(ToolItemText.LINEPLOTS), mock.call(ToolItemText.OVERLAY_PEAKS)))
 
     def test_non_orthogonal_axes_toggled_off(self):
         self.model.get_ws_type = mock.Mock(return_value=WS_TYPE.MATRIX)
@@ -188,6 +190,8 @@ class SliceViewerTest(unittest.TestCase):
         data_view_mock.plot_matrix.reset_mock()  # clear initial plot call
         data_view_mock.create_axes_orthogonal.reset_mock()
         data_view_mock.create_axes_nonorthogonal.reset_mock()
+        data_view_mock.enable_tool_button.reset_mock()
+        data_view_mock.disable_tool_button.reset_mock()
         data_view_mock.remove_line_plots.reset_mock()
 
         presenter.nonorthogonal_axes(False)
@@ -195,8 +199,8 @@ class SliceViewerTest(unittest.TestCase):
         data_view_mock.create_axes_orthogonal.assert_called_once()
         data_view_mock.create_axes_nonorthogonal.assert_not_called()
         data_view_mock.plot_matrix.assert_called_once()
-        data_view_mock.enable_lineplots_button.assert_called_once()
-        data_view_mock.enable_peaks_button.assert_called_once()
+        data_view_mock.enable_tool_button.assert_has_calls(
+            (mock.call(ToolItemText.LINEPLOTS), mock.call(ToolItemText.OVERLAY_PEAKS)))
 
     def test_request_to_show_all_data_sets_correct_limits_on_view(self):
         presenter = SliceViewer(None, model=self.model, view=self.view)
@@ -240,7 +244,7 @@ class SliceViewerTest(unittest.TestCase):
 
         presenter.dimensions_changed()
 
-        data_view_mock.disable_nonorthogonal_axes_button.assert_called_once()
+        data_view_mock.disable_tool_button.assert_called_once_with(ToolItemText.NONORTHOGONAL_AXES)
         data_view_mock.create_axes_orthogonal.assert_called_once()
         data_view_mock.create_axes_nonorthogonal.assert_not_called()
 
@@ -256,7 +260,7 @@ class SliceViewerTest(unittest.TestCase):
         presenter.dimensions_changed()
 
         data_view_mock.create_axes_nonorthogonal.assert_called_once()
-        data_view_mock.disable_nonorthogonal_axes_button.assert_not_called()
+        data_view_mock.disable_tool_button.assert_not_called()
         data_view_mock.create_axes_orthogonal.assert_not_called()
 
     @mock.patch("mantidqt.widgets.sliceviewer.presenter.SliceInfo")
@@ -270,7 +274,7 @@ class SliceViewerTest(unittest.TestCase):
 
         presenter.dimensions_changed()
 
-        data_view_mock.disable_nonorthogonal_axes_button.assert_called_once()
+        data_view_mock.disable_tool_button.assert_called_once_with(ToolItemText.NONORTHOGONAL_AXES)
 
     @mock.patch("mantidqt.widgets.sliceviewer.presenter.SliceInfo")
     def test_changing_dimensions_in_ortho_mode_enables_nonortho_btn_if_supported(
@@ -283,7 +287,7 @@ class SliceViewerTest(unittest.TestCase):
 
         presenter.dimensions_changed()
 
-        data_view_mock.enable_nonorthogonal_axes_button.assert_called_once()
+        data_view_mock.enable_tool_button.assert_called_once_with(ToolItemText.NONORTHOGONAL_AXES)
 
     @mock.patch("mantidqt.widgets.sliceviewer.peaksviewer.presenter.TableWorkspaceDataPresenter")
     @mock.patch("mantidqt.widgets.sliceviewer.presenter.PeaksViewerCollectionPresenter",
@@ -299,7 +303,8 @@ class SliceViewerTest(unittest.TestCase):
 
     def test_gui_starts_with_zoom_selected(self):
         SliceViewer(None, model=self.model, view=self.view)
-        self.assertEqual(1, self.view.data_view.select_zoom.call_count)
+
+        self.view.data_view.activate_tool.assert_called_once_with(ToolItemText.ZOOM)
 
 
 if __name__ == '__main__':

--- a/qt/python/mantidqt/widgets/sliceviewer/test/test_sliceviewer_presenter.py
+++ b/qt/python/mantidqt/widgets/sliceviewer/test/test_sliceviewer_presenter.py
@@ -174,7 +174,8 @@ class SliceViewerTest(unittest.TestCase):
         data_view_mock.create_axes_orthogonal.reset_mock()
         presenter.nonorthogonal_axes(True)
 
-        data_view_mock.deactivate_tool.assert_called_once_with(ToolItemText.LINEPLOTS)
+        data_view_mock.deactivate_and_disable_tool.assert_called_once_with(
+            ToolItemText.REGIONSELECTION)
         data_view_mock.create_axes_nonorthogonal.assert_called_once()
         data_view_mock.create_axes_orthogonal.assert_not_called()
         data_view_mock.plot_matrix.assert_called_once()
@@ -200,7 +201,8 @@ class SliceViewerTest(unittest.TestCase):
         data_view_mock.create_axes_nonorthogonal.assert_not_called()
         data_view_mock.plot_matrix.assert_called_once()
         data_view_mock.enable_tool_button.assert_has_calls(
-            (mock.call(ToolItemText.LINEPLOTS), mock.call(ToolItemText.OVERLAY_PEAKS)))
+            (mock.call(ToolItemText.LINEPLOTS), mock.call(ToolItemText.REGIONSELECTION),
+             mock.call(ToolItemText.OVERLAY_PEAKS)))
 
     def test_request_to_show_all_data_sets_correct_limits_on_view(self):
         presenter = SliceViewer(None, model=self.model, view=self.view)

--- a/qt/python/mantidqt/widgets/sliceviewer/test/test_sliceviewer_view.py
+++ b/qt/python/mantidqt/widgets/sliceviewer/test/test_sliceviewer_view.py
@@ -52,8 +52,9 @@ class SliceViewerViewTest(unittest.TestCase, QtWidgetFinder):
 
     def test_enable_nonorthogonal_view_disables_lineplots_if_enabled(self):
         pres = SliceViewer(self.hkl_ws)
-        line_plots_action, non_ortho_action = toolbar_actions(
-            pres, (ToolItemText.LINEPLOTS, ToolItemText.NONORTHOGONAL_AXES))
+        line_plots_action, region_sel_action, non_ortho_action = toolbar_actions(
+            pres,
+            (ToolItemText.LINEPLOTS, ToolItemText.REGIONSELECTION, ToolItemText.NONORTHOGONAL_AXES))
         line_plots_action.trigger()
         QApplication.processEvents()
 
@@ -63,6 +64,24 @@ class SliceViewerViewTest(unittest.TestCase, QtWidgetFinder):
         self.assertTrue(non_ortho_action.isChecked())
         self.assertFalse(line_plots_action.isChecked())
         self.assertFalse(line_plots_action.isEnabled())
+        self.assertFalse(region_sel_action.isChecked())
+        self.assertFalse(region_sel_action.isEnabled())
+
+        pres.view.close()
+
+    def test_disable_lineplots_disables_region_selector(self):
+        pres = SliceViewer(self.hkl_ws)
+        line_plots_action, region_sel_action = toolbar_actions(
+            pres, (ToolItemText.LINEPLOTS, ToolItemText.REGIONSELECTION))
+        line_plots_action.trigger()
+        region_sel_action.trigger()
+        QApplication.processEvents()
+
+        line_plots_action.trigger()
+        QApplication.processEvents()
+
+        self.assertFalse(line_plots_action.isChecked())
+        self.assertFalse(region_sel_action.isChecked())
 
         pres.view.close()
 

--- a/qt/python/mantidqt/widgets/sliceviewer/toolbar.py
+++ b/qt/python/mantidqt/widgets/sliceviewer/toolbar.py
@@ -18,7 +18,8 @@ class ToolItemText:
     ZOOM = 'Zoom'
     GRID = 'Grid'
     LINEPLOTS = 'LinePlots'
-    OVERLAYPEAKS = 'OverlayPeaks'
+    REGIONSELECTION = 'RegionSelection'
+    OVERLAY_PEAKS = 'OverlayPeaks'
     NONORTHOGONAL_AXES = 'NonOrthogonalAxes'
     SAVE = 'Save'
     CUSTOMIZE = 'Customize'
@@ -29,6 +30,7 @@ class SliceViewerNavigationToolbar(NavigationToolbar2QT):
     gridClicked = Signal(bool)
     homeClicked = Signal()
     linePlotsClicked = Signal(bool)
+    regionSelectionClicked = Signal(bool)
     nonOrthogonalClicked = Signal(bool)
     peaksOverlayClicked = Signal(bool)
     plotOptionsChanged = Signal()
@@ -41,9 +43,13 @@ class SliceViewerNavigationToolbar(NavigationToolbar2QT):
         (ToolItemText.ZOOM, 'Zoom to rectangle', 'mdi.magnify', 'zoom', False),
         (None, None, None, None, None),
         (ToolItemText.GRID, 'Toggle grid on/off', 'mdi.grid', 'gridClicked', False),
+        (None, None, None, None, None),
         (ToolItemText.LINEPLOTS, 'Toggle lineplots on/off', 'mdi.chart-bell-curve',
          'linePlotsClicked', False),
-        (ToolItemText.OVERLAYPEAKS, 'Add peaks overlays on/off', 'mdi.chart-bubble',
+        (ToolItemText.REGIONSELECTION, 'Toggle region selection on/off', 'mdi.vector-rectangle',
+         'regionSelectionClicked', False),
+        (None, None, None, None, None),
+        (ToolItemText.OVERLAY_PEAKS, 'Add peaks overlays on/off', 'mdi.chart-bubble',
          'peaksOverlayClicked', None),
         (ToolItemText.NONORTHOGONAL_AXES, 'Toggle nonorthogonal axes on/off', 'mdi.axis',
          'nonOrthogonalClicked', False),
@@ -124,14 +130,19 @@ class SliceViewerNavigationToolbar(NavigationToolbar2QT):
                     action.trigger()  # ensure view reacts appropriately
                 action.setEnabled(state)
 
-    def set_action_checked(self, text: str, state: bool):
+    def set_action_checked(self, text: str, state: bool, trigger: bool = True):
         """
         Sets the checked/unchecked state of toggle button with the given text
         :param text: Text on the action
         :param state: checked if True else it is disabled
+        :param trigger: If true the action is triggered if the state changes,
+                        else the state changes only
         """
         actions = self.actions()
         for action in actions:
             if action.text() == text:
                 if action.isChecked() != state:
-                    action.trigger()  # ensure view reacts appropriately
+                    if trigger:
+                        action.trigger()  # ensure view reacts appropriately
+                    else:
+                        action.setChecked(state)

--- a/qt/python/mantidqt/widgets/sliceviewer/view.py
+++ b/qt/python/mantidqt/widgets/sliceviewer/view.py
@@ -331,7 +331,6 @@ class SliceViewerDataView(QWidget):
             self._line_plots.plotter.delete_line_plot_lines()
             self._line_plots.plotter.update_line_plot_labels()
 
-        self.canvas.setFocus()
         self.canvas.draw_idle()
 
     def export_region(self, limits, cut):
@@ -467,6 +466,7 @@ class SliceViewerDataView(QWidget):
     def mouse_release(self, event):
         if event.inaxes != self.ax:
             return
+        self.canvas.setFocus()
         if event.button == 1:
             self._image_info_tracker.on_cursor_at(event.xdata, event.ydata)
         if event.button == 3:

--- a/qt/python/mantidqt/widgets/sliceviewer/view.py
+++ b/qt/python/mantidqt/widgets/sliceviewer/view.py
@@ -306,7 +306,7 @@ class SliceViewerDataView(QWidget):
     def update_plot_data(self, data):
         """
         This just updates the plot data without creating a new plot. The extents
-        can change if the data has been rebinned
+        can change if the data has been rebinned.
         """
         if self.nonortho_tr:
             self.image.set_array(data.T.ravel())
@@ -318,11 +318,17 @@ class SliceViewerDataView(QWidget):
         """
         Called to notify the current state of the track cursor box
         """
+        if self._image_info_tracker is not None:
+            self._image_info_tracker.disconnect()
+
         self._image_info_tracker = ImageInfoTracker(image=self.image,
                                                     transpose_xy=self.dimensions.transpose,
                                                     widget=self.image_info_widget)
+
         if state:
             self._image_info_tracker.connect()
+        else:
+            self._image_info_tracker.disconnect()
 
     def on_home_clicked(self):
         """Reset the view to encompass all of the data"""

--- a/qt/python/mantidqt/widgets/sliceviewer/view.py
+++ b/qt/python/mantidqt/widgets/sliceviewer/view.py
@@ -70,7 +70,7 @@ class SliceViewerDataView(QWidget):
         self.colorbar_layout.setContentsMargins(0, 0, 0, 0)
         self.colorbar_layout.setSpacing(0)
 
-        self.image_info_widget = ImageInfoWidget(self.ws_type, self)
+        self.image_info_widget = ImageInfoWidget(self)
         self.track_cursor = QCheckBox("Track Cursor", self)
         self.track_cursor.setToolTip(
             "Update the image readout table when the cursor is over the plot. "
@@ -309,7 +309,7 @@ class SliceViewerDataView(QWidget):
         if self.image is not None:
             if self.line_plots_active:
                 self._line_plots.plotter.delete_line_plot_lines()
-            self.image_info_widget.updateTable(DBLMAX, DBLMAX, DBLMAX)
+            self.image_info_widget.cursorAt(DBLMAX, DBLMAX, DBLMAX)
             self.image.remove()
             self.image = None
 

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/IImageInfoWidget.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/IImageInfoWidget.h
@@ -8,8 +8,8 @@
 
 #include "DllOption.h"
 #include "MantidAPI/Workspace_fwd.h"
+#include "MantidQtWidgets/Common/ImageInfoModel.h"
 #include <QTableWidget>
-#include <cfloat>
 
 namespace MantidQt {
 namespace MantidWidgets {
@@ -19,8 +19,10 @@ class EXPORT_OPT_MANTIDQT_COMMON IImageInfoWidget : public QTableWidget {
 public:
   IImageInfoWidget(QWidget *parent = nullptr) : QTableWidget(0, 0, parent) {}
 
-  virtual void updateTable(const double x = DBL_MAX, const double y = DBL_MAX,
-                           const double z = DBL_MAX) = 0;
+  virtual void cursorAt(const double x, const double y,
+                        const double signal) = 0;
+  virtual void showInfo(const std::vector<QString> &info) = 0;
+  virtual void showInfo(const ImageInfoModel::ImageInfo &info) = 0;
   virtual void setWorkspace(const Mantid::API::Workspace_sptr &ws) = 0;
 };
 

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/IImageInfoWidget.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/IImageInfoWidget.h
@@ -21,7 +21,6 @@ public:
 
   virtual void cursorAt(const double x, const double y,
                         const double signal) = 0;
-  virtual void showInfo(const std::vector<QString> &info) = 0;
   virtual void showInfo(const ImageInfoModel::ImageInfo &info) = 0;
   virtual void setWorkspace(const Mantid::API::Workspace_sptr &ws) = 0;
 };

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/ImageInfoModel.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/ImageInfoModel.h
@@ -30,8 +30,7 @@ public:
   @return a vector containing pairs of strings
   */
   virtual std::vector<QString> getInfoList(const double x, const double y,
-                                           const double signal,
-                                           bool getValues = true) = 0;
+                                           const double signal) = 0;
 
   virtual void setWorkspace(const Mantid::API::Workspace_sptr &ws) = 0;
 
@@ -39,7 +38,7 @@ protected:
   void addNameAndValue(const std::string &label, std::vector<QString> &list,
                        const double value, const int precision,
                        bool includeValue = true,
-                       Mantid::Kernel::Unit_sptr units = nullptr);
+                       const Mantid::Kernel::Unit_sptr &units = nullptr);
 };
 
 } // namespace MantidWidgets

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/ImageInfoModel.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/ImageInfoModel.h
@@ -45,6 +45,8 @@ public:
   static constexpr auto FourDigitPrecision = 4;
   /// Default float format
   static constexpr auto DecimalFormat = 'f';
+  /// Value to indicate that a MissingValue should be shown
+  static constexpr auto UnsetValue = std::numeric_limits<double>::max();
   /// MissingValue identifier
   static inline const QString MissingValue = QString("-");
 
@@ -69,12 +71,6 @@ public:
   */
   virtual ImageInfoModel::ImageInfo info(const double x, const double y,
                                          const double signal) const = 0;
-
-protected:
-  void addNameAndValue(const std::string &label, std::vector<QString> &list,
-                       const double value, const int precision,
-                       bool includeValue = true,
-                       const Mantid::Kernel::Unit_sptr &units = nullptr);
 };
 
 } // namespace MantidWidgets

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/ImageInfoModel.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/ImageInfoModel.h
@@ -18,21 +18,57 @@ namespace MantidQt {
 namespace MantidWidgets {
 
 class EXPORT_OPT_MANTIDQT_COMMON ImageInfoModel {
+public:
+  class ImageInfo {
+  public:
+    using StringItems = std::vector<QString>;
+    ImageInfo(StringItems names);
+
+    inline bool empty() const noexcept { return m_names.empty(); }
+    inline int size() const noexcept {
+      return static_cast<int>(m_names.size());
+    }
+    inline const QString &name(int index) const noexcept {
+      return m_names[index];
+    }
+    inline const QString &value(int index) const noexcept {
+      return m_values[index];
+    }
+    inline void setValue(int index, const QString &value) noexcept {
+      m_values[index] = value;
+    }
+    StringItems m_names;
+    StringItems m_values;
+  };
+
+  /// Default float precision
+  static constexpr auto FourDigitPrecision = 4;
+  /// Default float format
+  static constexpr auto DecimalFormat = 'f';
+  /// MissingValue identifier
+  static inline const QString MissingValue = QString("-");
+
+  static inline const QString defaultFormat(const double x) {
+    return QString::number(x, ImageInfoModel::DecimalFormat,
+                           ImageInfoModel::FourDigitPrecision);
+  }
+
+  static inline const QString defaultFormat(const int x) {
+    return QString::number(x);
+  }
 
 public:
   virtual ~ImageInfoModel() = default;
 
-  /** Creates a list with information about the coordinates in the workspace.
+  /** Creates information about the point at the given coordinates in the
+  workspace.
   @param x: x data coordinate
-  @param y: y data coordinate, for a matrix workspace this will be the spectrum
-  number
-  @param signal: the signal value at x,y
-  @return a vector containing pairs of strings
+  @param y: y data coordinate
+  @param signal: the signal value at x, y
+  @return An ImageInfo object
   */
-  virtual std::vector<QString> getInfoList(const double x, const double y,
-                                           const double signal) = 0;
-
-  virtual void setWorkspace(const Mantid::API::Workspace_sptr &ws) = 0;
+  virtual ImageInfoModel::ImageInfo info(const double x, const double y,
+                                         const double signal) const = 0;
 
 protected:
   void addNameAndValue(const std::string &label, std::vector<QString> &list,

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/ImageInfoModel.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/ImageInfoModel.h
@@ -27,8 +27,6 @@ public:
   @param y: y data coordinate, for a matrix workspace this will be the spectrum
   number
   @param signal: the signal value at x,y
-  @param getValues: if false the returned list will have the information
-  headers and '-' for each of the values
   @return a vector containing pairs of strings
   */
   virtual std::vector<QString> getInfoList(const double x, const double y,

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/ImageInfoModelMD.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/ImageInfoModelMD.h
@@ -18,17 +18,13 @@ class EXPORT_OPT_MANTIDQT_COMMON ImageInfoModelMD : public ImageInfoModel {
 
 public:
   /** Creates a list with information about the coordinates in the workspace.
-  @param x: x data coordinate
-  @param y: y data coordinate
-  @param signal: the signal value at x, y
-  @return a vector containing pairs of strings
-  */
-  std::vector<QString> getInfoList(const double x, const double y,
-                                   const double signal) override;
-
-  void setWorkspace(const Mantid::API::Workspace_sptr &ws) override {
-    UNUSED_ARG(ws);
-  }
+   * @param x: x data coordinate
+   * @param y: y data coordinate
+   * @param signal: the signal value at x, y
+   * @return An ImageInfo object describing the point
+   */
+  ImageInfoModel::ImageInfo info(const double x, const double y,
+                                 const double signal) const override;
 };
 
 } // namespace MantidWidgets

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/ImageInfoModelMD.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/ImageInfoModelMD.h
@@ -21,13 +21,10 @@ public:
   @param x: x data coordinate
   @param y: y data coordinate
   @param signal: the signal value at x, y
-  @param getValues: if false the list will contain the header names and "-" for
-  each of the numeric values
   @return a vector containing pairs of strings
   */
   std::vector<QString> getInfoList(const double x, const double y,
-                                   const double signal,
-                                   bool getValues = true) override;
+                                   const double signal) override;
 
   void setWorkspace(const Mantid::API::Workspace_sptr &ws) override {
     UNUSED_ARG(ws);

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/ImageInfoModelMatrixWS.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/ImageInfoModelMatrixWS.h
@@ -35,8 +35,6 @@ public:
   @param x: x data coordinate
   @param specNum: the spectrum number of the coordinate
   @param signal: the signal value at x, y
-  @param getValues: if false the returned list will have the information
-  headers and '-' for each of the values
   @return a vector containing pairs of strings
   */
   std::vector<QString> getInfoList(const double x, const double specNum,

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/ImageInfoModelMatrixWS.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/ImageInfoModelMatrixWS.h
@@ -10,7 +10,9 @@
 
 #include "MantidAPI/MatrixWorkspace.h"
 #include "MantidAPI/SpectrumInfo.h"
+#include "MantidKernel/DeltaEMode.h"
 #include "MantidQtWidgets/Common/ImageInfoModel.h"
+#include <tuple>
 
 namespace Mantid {
 namespace Geometry {
@@ -25,33 +27,38 @@ class SpectrumInfo;
 namespace MantidQt {
 namespace MantidWidgets {
 
+/**
+ * Model to support looking up information about a given point with a
+ * MatrixWorkspace
+ */
 class EXPORT_OPT_MANTIDQT_COMMON ImageInfoModelMatrixWS
     : public ImageInfoModel {
 
 public:
-  ImageInfoModelMatrixWS();
+  /// Return the number of information items this model will produce
+  static constexpr int itemCount() noexcept { return 13; }
 
-  /** Creates a list with information about the coordinates in the workspace.
-  @param x: x data coordinate
-  @param specNum: the spectrum number of the coordinate
-  @param signal: the signal value at x, y
-  @return a vector containing pairs of strings
-  */
-  std::vector<QString> getInfoList(const double x, const double specNum,
-                                   const double signal) override;
+  ImageInfoModelMatrixWS(Mantid::API::MatrixWorkspace_sptr workspace);
 
-  void setWorkspace(const Mantid::API::Workspace_sptr &ws) override;
+  ImageInfoModel::ImageInfo info(const double x, const double y,
+                                 const double signal) const override;
 
 private:
-  void updateCachedWorkspaceInfo(const Mantid::API::MatrixWorkspace_sptr &ws);
+  void setUnitsInfo(ImageInfoModel::ImageInfo *info, int infoIndex,
+                    const size_t wsIndex, const double x) const;
+  std::tuple<Mantid::Kernel::DeltaEMode::Type, double>
+  efixedAt(const size_t wsIndex) const;
+  void cacheWorkspaceInfo();
+  ImageInfoModel::ImageInfo::StringItems createItemNames() const;
 
+private:
   Mantid::API::MatrixWorkspace_sptr m_workspace;
   const Mantid::API::SpectrumInfo *m_spectrumInfo;
   std::shared_ptr<const Mantid::Geometry::Instrument> m_instrument;
   std::shared_ptr<const Mantid::Geometry::IComponent> m_source;
   std::shared_ptr<const Mantid::Geometry::IComponent> m_sample;
-  double m_xMin;
-  double m_xMax;
+  double m_xMin, m_xMax;
+  QString m_xunit, m_yunit;
 };
 
 } // namespace MantidWidgets

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/ImageInfoModelMatrixWS.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/ImageInfoModelMatrixWS.h
@@ -35,9 +35,6 @@ class EXPORT_OPT_MANTIDQT_COMMON ImageInfoModelMatrixWS
     : public ImageInfoModel {
 
 public:
-  /// Return the number of information items this model will produce
-  static constexpr int itemCount() noexcept { return 13; }
-
   ImageInfoModelMatrixWS(Mantid::API::MatrixWorkspace_sptr workspace);
 
   ImageInfoModel::ImageInfo info(const double x, const double y,
@@ -49,7 +46,7 @@ private:
   std::tuple<Mantid::Kernel::DeltaEMode::Type, double>
   efixedAt(const size_t wsIndex) const;
   void cacheWorkspaceInfo();
-  ImageInfoModel::ImageInfo::StringItems createItemNames() const;
+  void createItemNames();
 
 private:
   Mantid::API::MatrixWorkspace_sptr m_workspace;
@@ -57,8 +54,9 @@ private:
   std::shared_ptr<const Mantid::Geometry::Instrument> m_instrument;
   std::shared_ptr<const Mantid::Geometry::IComponent> m_source;
   std::shared_ptr<const Mantid::Geometry::IComponent> m_sample;
-  double m_xMin, m_xMax;
-  QString m_xunit, m_yunit;
+  ImageInfoModel::ImageInfo::StringItems m_names;
+  Mantid::Kernel::Unit_sptr m_xunit;
+  bool m_xIsTOF;
 };
 
 } // namespace MantidWidgets

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/ImageInfoModelMatrixWS.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/ImageInfoModelMatrixWS.h
@@ -38,8 +38,7 @@ public:
   @return a vector containing pairs of strings
   */
   std::vector<QString> getInfoList(const double x, const double specNum,
-                                   const double signal,
-                                   bool getValues = true) override;
+                                   const double signal) override;
 
   void setWorkspace(const Mantid::API::Workspace_sptr &ws) override;
 

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/ImageInfoPresenter.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/ImageInfoPresenter.h
@@ -23,6 +23,8 @@ class EXPORT_OPT_MANTIDQT_COMMON ImageInfoPresenter {
 public:
   ImageInfoPresenter(IImageInfoWidget *view);
 
+  inline const ImageInfoModel &model() { return *m_model; }
+
   void cursorAt(const double x, const double y, const double signal);
   void setWorkspace(const Mantid::API::Workspace_sptr &ws);
 

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/ImageInfoPresenter.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/ImageInfoPresenter.h
@@ -11,8 +11,6 @@
 #include "MantidQtWidgets/Common/IImageInfoWidget.h"
 #include "MantidQtWidgets/Common/ImageInfoModel.h"
 
-#include <QTableWidget>
-
 namespace MantidQt {
 namespace MantidWidgets {
 
@@ -25,17 +23,11 @@ class EXPORT_OPT_MANTIDQT_COMMON ImageInfoPresenter {
 public:
   ImageInfoPresenter(IImageInfoWidget *view);
 
-  std::vector<QString> getInfoList(const double x = DBL_MAX,
-                                   const double y = DBL_MAX,
-                                   const double z = DBL_MAX);
-
-  void createImageInfoModel(const std::string &ws_type);
+  void cursorAt(const double x, const double y, const double signal);
   void setWorkspace(const Mantid::API::Workspace_sptr &ws);
 
-  std::shared_ptr<ImageInfoModel> getModel() { return m_model; }
-
 private:
-  std::shared_ptr<ImageInfoModel> m_model;
+  std::unique_ptr<ImageInfoModel> m_model;
   IImageInfoWidget *m_view;
 };
 

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/ImageInfoWidget.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/ImageInfoWidget.h
@@ -11,8 +11,6 @@
 #include "MantidQtWidgets/Common/IImageInfoWidget.h"
 #include "MantidQtWidgets/Common/ImageInfoPresenter.h"
 
-#include <QTableWidget>
-
 namespace MantidQt {
 namespace MantidWidgets {
 
@@ -24,12 +22,12 @@ class EXPORT_OPT_MANTIDQT_COMMON ImageInfoWidget : public IImageInfoWidget {
   Q_OBJECT
 
 public:
-  ImageInfoWidget(const std::string &workspace_type, QWidget *parent = nullptr);
+  ImageInfoWidget(QWidget *parent = nullptr);
 
-  void updateTable(const double x = DBL_MAX, const double y = DBL_MAX,
-                   const double z = DBL_MAX) override;
-
+  void cursorAt(const double x, const double y, const double signal) override;
   void setWorkspace(const Mantid::API::Workspace_sptr &ws) override;
+  void showInfo(const std::vector<QString> &info) override;
+  void showInfo(const ImageInfoModel::ImageInfo &info) override;
 
 private:
   std::unique_ptr<ImageInfoPresenter> m_presenter;

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/ImageInfoWidget.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/ImageInfoWidget.h
@@ -26,7 +26,6 @@ public:
 
   void cursorAt(const double x, const double y, const double signal) override;
   void setWorkspace(const Mantid::API::Workspace_sptr &ws) override;
-  void showInfo(const std::vector<QString> &info) override;
   void showInfo(const ImageInfoModel::ImageInfo &info) override;
 
 private:

--- a/qt/widgets/common/src/ImageInfoModel.cpp
+++ b/qt/widgets/common/src/ImageInfoModel.cpp
@@ -19,7 +19,7 @@ void ImageInfoModel::addNameAndValue(const std::string &label,
                                      std::vector<QString> &list,
                                      const double value, const int precision,
                                      bool includeValue,
-                                     Mantid::Kernel::Unit_sptr units) {
+                                     const Mantid::Kernel::Unit_sptr &units) {
   std::wstring unit;
   auto headerLabel = QString::fromStdString(label);
   if (units && !(unit = units->label().utf8()).empty()) {

--- a/qt/widgets/common/src/ImageInfoModel.cpp
+++ b/qt/widgets/common/src/ImageInfoModel.cpp
@@ -27,28 +27,5 @@ ImageInfoModel::ImageInfo::ImageInfo(
   m_values.resize(m_names.size(), MissingValue);
 }
 
-// ImageInfoModel
-
-/**
- * Appends a name/value to the given list
- */
-void ImageInfoModel::addNameAndValue(const std::string &label,
-                                     std::vector<QString> &list,
-                                     const double value, const int precision,
-                                     bool includeValue,
-                                     const Mantid::Kernel::Unit_sptr &units) {
-  std::wstring unit;
-  auto headerLabel = QString::fromStdString(label);
-  if (units && !(unit = units->label().utf8()).empty()) {
-    headerLabel += "(" + MantidQt::API::toQStringInternal(unit) + ")";
-  }
-  list.emplace_back(headerLabel);
-
-  if (includeValue) {
-    list.emplace_back(QString::number(value, 'f', precision));
-  } else
-    list.emplace_back(MissingValue);
-}
-
 } // namespace MantidWidgets
 } // namespace MantidQt

--- a/qt/widgets/common/src/ImageInfoModel.cpp
+++ b/qt/widgets/common/src/ImageInfoModel.cpp
@@ -8,13 +8,30 @@
 #include "MantidQtWidgets/Common/ImageInfoModel.h"
 #include "MantidQtWidgets/Common/QStringUtils.h"
 
-#include <QRegExp>
-#include <iomanip>
 #include <sstream>
+
+namespace {}
 
 namespace MantidQt {
 namespace MantidWidgets {
 
+// ImageInfo
+
+/**
+ * Construct an ImageInfo to store name/value pairs
+ * @param names The names of the name/value pairs in the table
+ */
+ImageInfoModel::ImageInfo::ImageInfo(
+    ImageInfoModel::ImageInfo::StringItems names)
+    : m_names(std::move(names)) {
+  m_values.resize(m_names.size(), MissingValue);
+}
+
+// ImageInfoModel
+
+/**
+ * Appends a name/value to the given list
+ */
 void ImageInfoModel::addNameAndValue(const std::string &label,
                                      std::vector<QString> &list,
                                      const double value, const int precision,
@@ -28,12 +45,9 @@ void ImageInfoModel::addNameAndValue(const std::string &label,
   list.emplace_back(headerLabel);
 
   if (includeValue) {
-    QString valueString = QString::number(value, 'f', precision);
-    // remove any trailing zeros after decimal place
-    valueString.replace(QRegExp("(\\.\\d*[1-9])(0+)$|\\.0+$"), "\\1");
-    list.emplace_back(valueString);
+    list.emplace_back(QString::number(value, 'f', precision));
   } else
-    list.emplace_back(QString("-"));
+    list.emplace_back(MissingValue);
 }
 
 } // namespace MantidWidgets

--- a/qt/widgets/common/src/ImageInfoModelMD.cpp
+++ b/qt/widgets/common/src/ImageInfoModelMD.cpp
@@ -8,19 +8,26 @@
 #include "MantidQtWidgets/Common/ImageInfoModelMD.h"
 #include <climits>
 
+namespace {
+constexpr double UNSET_VALUE = std::numeric_limits<double>::max();
+}
+
 namespace MantidQt {
 namespace MantidWidgets {
 
-std::vector<QString> ImageInfoModelMD::getInfoList(const double x,
-                                                   const double y,
-                                                   const double signal) {
-  std::vector<QString> list;
-  constexpr auto dblmax(std::numeric_limits<double>::max());
-  addNameAndValue("x", list, x, 4, (x != dblmax));
-  addNameAndValue("y", list, y, 4, (y != dblmax));
-  addNameAndValue("Signal", list, signal, 4, (signal != dblmax));
+/// @copydoc MantidQt::MantidWidgets::ImageInfoModel::info
+ImageInfoModel::ImageInfo ImageInfoModelMD::info(const double x, const double y,
+                                                 const double signal) const {
+  ImageInfo info({"x", "y", "Signal"});
 
-  return list;
+  auto valueOrMissing = [this](double value) {
+    return value == UNSET_VALUE ? MissingValue : defaultFormat(value);
+  };
+  info.setValue(0, valueOrMissing(x));
+  info.setValue(1, valueOrMissing(y));
+  info.setValue(2, valueOrMissing(signal));
+
+  return info;
 }
 
 } // namespace MantidWidgets

--- a/qt/widgets/common/src/ImageInfoModelMD.cpp
+++ b/qt/widgets/common/src/ImageInfoModelMD.cpp
@@ -6,18 +6,19 @@
 // SPDX - License - Identifier: GPL - 3.0 +
 
 #include "MantidQtWidgets/Common/ImageInfoModelMD.h"
+#include <climits>
 
 namespace MantidQt {
 namespace MantidWidgets {
 
 std::vector<QString> ImageInfoModelMD::getInfoList(const double x,
                                                    const double y,
-                                                   const double signal,
-                                                   bool getValues) {
+                                                   const double signal) {
   std::vector<QString> list;
-  addNameAndValue("x", list, x, 4, getValues);
-  addNameAndValue("y", list, y, 4, getValues);
-  addNameAndValue("Signal", list, signal, 4, getValues);
+  constexpr auto dblmax(std::numeric_limits<double>::max());
+  addNameAndValue("x", list, x, 4, (x != dblmax));
+  addNameAndValue("y", list, y, 4, (y != dblmax));
+  addNameAndValue("Signal", list, signal, 4, (signal != dblmax));
 
   return list;
 }

--- a/qt/widgets/common/src/ImageInfoModelMD.cpp
+++ b/qt/widgets/common/src/ImageInfoModelMD.cpp
@@ -8,10 +8,6 @@
 #include "MantidQtWidgets/Common/ImageInfoModelMD.h"
 #include <climits>
 
-namespace {
-constexpr double UNSET_VALUE = std::numeric_limits<double>::max();
-}
-
 namespace MantidQt {
 namespace MantidWidgets {
 
@@ -20,8 +16,8 @@ ImageInfoModel::ImageInfo ImageInfoModelMD::info(const double x, const double y,
                                                  const double signal) const {
   ImageInfo info({"x", "y", "Signal"});
 
-  auto valueOrMissing = [this](double value) {
-    return value == UNSET_VALUE ? MissingValue : defaultFormat(value);
+  auto valueOrMissing = [](double value) {
+    return value == UnsetValue ? MissingValue : defaultFormat(value);
   };
   info.setValue(0, valueOrMissing(x));
   info.setValue(1, valueOrMissing(y));

--- a/qt/widgets/common/src/ImageInfoModelMatrixWS.cpp
+++ b/qt/widgets/common/src/ImageInfoModelMatrixWS.cpp
@@ -37,13 +37,17 @@ ImageInfoModelMatrixWS::ImageInfoModelMatrixWS()
 // coordinates in the workspace.
 std::vector<QString> ImageInfoModelMatrixWS::getInfoList(const double x,
                                                          const double specNum,
-                                                         const double signal,
-                                                         bool getValues) {
+                                                         const double signal) {
+
   std::vector<QString> list;
 
   if (!m_workspace) {
     return list;
   }
+  constexpr auto dblmax(std::numeric_limits<double>::max());
+  bool getValues(true);
+  if (x == dblmax || specNum == dblmax || signal == dblmax)
+    getValues = false;
 
   const int spectrumNumber = static_cast<int>(specNum + 0.5);
   size_t wsIndex = 0;

--- a/qt/widgets/common/src/ImageInfoPresenter.cpp
+++ b/qt/widgets/common/src/ImageInfoPresenter.cpp
@@ -9,32 +9,42 @@
 #include "MantidQtWidgets/Common/ImageInfoModelMD.h"
 #include "MantidQtWidgets/Common/ImageInfoModelMatrixWS.h"
 
+using Mantid::API::MatrixWorkspace;
+
 namespace MantidQt {
 namespace MantidWidgets {
 
 /**
  * Constructor
+ * @param view A pointer to a view object that displays the information
  */
 ImageInfoPresenter::ImageInfoPresenter(IImageInfoWidget *view)
-    : m_view(std::move(view)) {}
-
-std::vector<QString> ImageInfoPresenter::getInfoList(const double x,
-                                                     const double y,
-                                                     const double z) {
-  return getModel()->getInfoList(x, y, z);
+    : m_model(), m_view(std::move(view)) {
+  m_view->setRowCount(2);
 }
 
-void ImageInfoPresenter::createImageInfoModel(
-    const std::string &workspace_type) {
-  if (workspace_type == "MATRIX")
-    m_model = std::make_unique<ImageInfoModelMatrixWS>();
+/**
+ * @param x X position on an image of the workspace
+ * @param y Y position on an image of the workspace
+ * @param signal The signal value at the given position
+ */
+void ImageInfoPresenter::cursorAt(const double x, const double y,
+                                  const double signal) {
+  assert(m_model);
+  m_view->showInfo(m_model->info(x, y, signal));
+}
+
+/**
+ * Set a new workspace for the view to display
+ * @param workspace A pointer to a new workspace
+ */
+void ImageInfoPresenter::setWorkspace(
+    const Mantid::API::Workspace_sptr &workspace) {
+  if (auto matrixWS = std::dynamic_pointer_cast<MatrixWorkspace>(workspace))
+    m_model = std::make_unique<ImageInfoModelMatrixWS>(matrixWS);
   else {
     m_model = std::make_unique<ImageInfoModelMD>();
   }
-}
-
-void ImageInfoPresenter::setWorkspace(const Mantid::API::Workspace_sptr &ws) {
-  m_model->setWorkspace(ws);
 }
 
 } // namespace MantidWidgets

--- a/qt/widgets/common/src/ImageInfoPresenter.cpp
+++ b/qt/widgets/common/src/ImageInfoPresenter.cpp
@@ -21,10 +21,7 @@ ImageInfoPresenter::ImageInfoPresenter(IImageInfoWidget *view)
 std::vector<QString> ImageInfoPresenter::getInfoList(const double x,
                                                      const double y,
                                                      const double z) {
-  bool getValues(true);
-  if (x == DBL_MAX || y == DBL_MAX || z == DBL_MAX)
-    getValues = false;
-  return getModel()->getInfoList(x, y, z, getValues);
+  return getModel()->getInfoList(x, y, z);
 }
 
 void ImageInfoPresenter::createImageInfoModel(

--- a/qt/widgets/common/src/ImageInfoPresenter.cpp
+++ b/qt/widgets/common/src/ImageInfoPresenter.cpp
@@ -45,6 +45,9 @@ void ImageInfoPresenter::setWorkspace(
   else {
     m_model = std::make_unique<ImageInfoModelMD>();
   }
+  // Blank view
+  cursorAt(ImageInfoModel::UnsetValue, ImageInfoModel::UnsetValue,
+           ImageInfoModel::UnsetValue);
 }
 
 } // namespace MantidWidgets

--- a/qt/widgets/common/src/ImageInfoWidget.cpp
+++ b/qt/widgets/common/src/ImageInfoWidget.cpp
@@ -42,32 +42,6 @@ void ImageInfoWidget::cursorAt(const double x, const double y,
 
 /**
  * Display the information provided within the table cells
- * @param info A reference to a vector of header/value paris
- */
-void ImageInfoWidget::showInfo(const std::vector<QString> &info) {
-  if (info.empty())
-    return;
-
-  setColumnCount(static_cast<int>(info.size() / 2));
-
-  auto row = 0;
-  auto column = 0;
-  for (const auto &item : info) {
-    auto cell = new QTableWidgetItem(item);
-    setItem(row, column, cell);
-    cell->setFlags(Qt::ItemIsSelectable);
-    row++;
-    if (row == 2) {
-      row = 0;
-      column++;
-    }
-  }
-  horizontalHeader()->setMinimumSectionSize(50);
-  resizeColumnsToContents();
-}
-
-/**
- * Display the information provided within the table cells
  * @param info A reference to a collection of header/value pairs
  */
 void ImageInfoWidget::showInfo(const ImageInfoModel::ImageInfo &info) {

--- a/qt/widgets/common/src/ImageInfoWidget.cpp
+++ b/qt/widgets/common/src/ImageInfoWidget.cpp
@@ -17,9 +17,9 @@ namespace MantidWidgets {
 
 /**
  * Constructor
+ * @param parent A QWidget to act as the parent widget
  */
-ImageInfoWidget::ImageInfoWidget(const std::string &workspace_type,
-                                 QWidget *parent)
+ImageInfoWidget::ImageInfoWidget(QWidget *parent)
     : IImageInfoWidget(parent),
       m_presenter(std::make_unique<ImageInfoPresenter>(this)) {
 #if (QT_VERSION >= QT_VERSION_CHECK(5, 0, 0))
@@ -28,20 +28,27 @@ ImageInfoWidget::ImageInfoWidget(const std::string &workspace_type,
   setSizePolicy(QSizePolicy::Maximum, QSizePolicy::Maximum);
   horizontalHeader()->hide();
   verticalHeader()->hide();
-
-  m_presenter->createImageInfoModel(workspace_type);
-  updateTable();
 }
 
-void ImageInfoWidget::updateTable(const double x, const double y,
-                                  const double z) {
-  auto info = m_presenter->getInfoList(x, y, z);
+/**
+ * @param x X position if the cursor
+ * @param y Y position if the cursor
+ * @param signal Signal value at cursor position
+ */
+void ImageInfoWidget::cursorAt(const double x, const double y,
+                               const double signal) {
+  m_presenter->cursorAt(x, y, signal);
+}
 
+/**
+ * Display the information provided within the table cells
+ * @param info A reference to a vector of header/value paris
+ */
+void ImageInfoWidget::showInfo(const std::vector<QString> &info) {
   if (info.empty())
     return;
 
   setColumnCount(static_cast<int>(info.size() / 2));
-  setRowCount(2);
 
   auto row = 0;
   auto column = 0;
@@ -58,9 +65,35 @@ void ImageInfoWidget::updateTable(const double x, const double y,
   horizontalHeader()->setMinimumSectionSize(50);
   resizeColumnsToContents();
 }
+
+/**
+ * Display the information provided within the table cells
+ * @param info A reference to a collection of header/value pairs
+ */
+void ImageInfoWidget::showInfo(const ImageInfoModel::ImageInfo &info) {
+  if (info.empty())
+    return;
+
+  const auto itemCount(info.size());
+  setColumnCount(itemCount);
+  for (int i = 0; i < itemCount; ++i) {
+    auto header = new QTableWidgetItem(info.name(i));
+    header->setFlags(Qt::ItemIsSelectable);
+    setItem(0, i, header);
+    auto value = new QTableWidgetItem(info.value(i));
+    value->setFlags(Qt::ItemIsSelectable);
+    setItem(1, i, value);
+  }
+  horizontalHeader()->setMinimumSectionSize(50);
+  resizeColumnsToContents();
+}
+
+/**
+ * Set the workspace to probe for information
+ * @param ws A pointer to a Workspace object
+ */
 void ImageInfoWidget::setWorkspace(const Mantid::API::Workspace_sptr &ws) {
   m_presenter->setWorkspace(ws);
-  updateTable();
 }
 } // namespace MantidWidgets
 } // namespace MantidQt

--- a/qt/widgets/common/test/ImageInfoModelMDTest.h
+++ b/qt/widgets/common/test/ImageInfoModelMDTest.h
@@ -20,27 +20,30 @@ public:
   }
   static void destroySuite(ImageInfoModelMDTest *suite) { delete suite; }
 
-  void test_getInfoList_with_md_ws() {
+  void test_info_with_md_ws() {
     ImageInfoModelMD model;
 
-    auto list = model.getInfoList(2, 4, 7);
+    auto info = model.info(2, 4, 7.5);
 
-    const std::array<QString, 6> expectList{"x", "2", "y", "4", "Signal", "7"};
-    TS_ASSERT_EQUALS(expectList.size(), list.size())
-    for (size_t i = 0; i < list.size(); ++i) {
-      TS_ASSERT_EQUALS(expectList[i], list[i]);
-    }
+    assertInfoMatches(info, {"2.0000", "4.0000", "7.5000"});
   }
 
-  void test_getInfoList_returns_dashes_when_given_double_max() {
+  void test_info_returns_dashes_when_given_double_max() {
     ImageInfoModelMD model;
 
-    auto list = model.getInfoList(2, std::numeric_limits<double>::max(), 7);
+    auto info = model.info(2, std::numeric_limits<double>::max(), 7);
 
-    const std::array<QString, 6> expectList{"x", "2", "y", "-", "Signal", "7"};
-    TS_ASSERT_EQUALS(expectList.size(), list.size())
-    for (size_t i = 0; i < list.size(); ++i) {
-      TS_ASSERT_EQUALS(expectList[i], list[i]);
+    assertInfoMatches(info, {"2.0000", "-", "7.0000"});
+  }
+
+private:
+  void assertInfoMatches(const ImageInfoModel::ImageInfo &info,
+                         const std::vector<std::string> &expectedValues) {
+    constexpr std::array<const char *, 3> expectedHeaders{"x", "y", "Signal"};
+    TS_ASSERT_EQUALS(expectedHeaders.size(), info.size())
+    for (int i = 0; i < info.size(); ++i) {
+      TS_ASSERT_EQUALS(expectedHeaders[i], info.name(i).toStdString());
+      TS_ASSERT_EQUALS(expectedValues[i], info.value(i).toLatin1().constData());
     }
   }
 };

--- a/qt/widgets/common/test/ImageInfoModelMDTest.h
+++ b/qt/widgets/common/test/ImageInfoModelMDTest.h
@@ -32,12 +32,12 @@ public:
     }
   }
 
-  void test_getInfoList_returns_dashes_when_getValues_is_false() {
+  void test_getInfoList_returns_dashes_when_given_double_max() {
     ImageInfoModelMD model;
 
-    auto list = model.getInfoList(2, 4, 7, false);
+    auto list = model.getInfoList(2, std::numeric_limits<double>::max(), 7);
 
-    const std::array<QString, 6> expectList{"x", "-", "y", "-", "Signal", "-"};
+    const std::array<QString, 6> expectList{"x", "2", "y", "-", "Signal", "7"};
     TS_ASSERT_EQUALS(expectList.size(), list.size())
     for (size_t i = 0; i < list.size(); ++i) {
       TS_ASSERT_EQUALS(expectList[i], list[i]);

--- a/qt/widgets/common/test/ImageInfoModelMatrixWSTest.h
+++ b/qt/widgets/common/test/ImageInfoModelMatrixWSTest.h
@@ -8,8 +8,10 @@
 
 #include "MantidAPI/MatrixWorkspace.h"
 #include "MantidAPI/NumericAxis.h"
+#include "MantidGeometry/Instrument.h"
 #include "MantidQtWidgets/Common/ImageInfoModelMatrixWS.h"
 #include "MantidQtWidgets/Common/QStringUtils.h"
+#include "MantidTestHelpers/InstrumentCreationHelper.h"
 #include "MantidTestHelpers/WorkspaceCreationHelper.h"
 #include <cxxtest/TestSuite.h>
 
@@ -19,6 +21,9 @@ using namespace Mantid::DataObjects;
 using MantidQt::API::toQStringInternal;
 
 class ImageInfoModelMatrixWSTest : public CxxTest::TestSuite {
+private:
+  using InfoItems = std::vector<std::pair<QString, QString>>;
+
 public:
   // This pair of boilerplate methods prevent the suite being created statically
   // This means the constructor isn't called when running other tests
@@ -27,141 +32,194 @@ public:
   }
   static void destroySuite(ImageInfoModelMatrixWSTest *suite) { delete suite; }
 
-  void test_getInfoList() {
-    MatrixWorkspace_sptr workspace =
-        WorkspaceCreationHelper::create2DWorkspaceWithFullInstrument(
-            10, 10, true, false, true, "workspace", false);
-    ImageInfoModelMatrixWS model;
-    model.setWorkspace(workspace);
+  void test_info_without_instrument() {
+    auto workspace =
+        WorkspaceCreationHelper::create2DWorkspaceBinned(10, 10, 15000.0, 100.);
+    ImageInfoModelMatrixWS model(workspace);
 
-    auto list = model.getInfoList(2, 4, 7);
-    const std::array<QString, 22> expectList{
-        "Signal",
-        "7",
-        "Spec Num",
-        "4",
-        "Time-of-flight" + toQStringInternal(L"(\u03bcs)"),
-        "2",
-        "Det ID",
-        "4",
-        "L2(m)",
-        "5.009",
-        "TwoTheta(Deg)",
-        "3.43",
-        "Azimuthal(Deg)",
-        "90",
-        "Wavelength" + toQStringInternal(L"(\u212b)"),
-        "0.0003",
-        "Energy(meV)",
-        "817312177.3087",
-        "d-Spacing" + toQStringInternal(L"(\u212b)"),
-        "0.0053",
-        "|Q|" + toQStringInternal(L"(\u212b\u207b\u00b9)"),
-        "1190.0137"};
+    const auto info = model.info(15200, 4, 7);
 
-    TS_ASSERT_EQUALS(expectList.size(), list.size())
-    for (size_t i = 0; i < list.size(); ++i) {
-      TS_ASSERT_EQUALS(expectList[i], list[i]);
+    const InfoItems expectedInfo = {
+        {"x", "15200.0000"},
+        {"Spectrum", "4"},
+        {"Signal", "7.0000"},
+        {"Det ID", "-"},
+        {"L2(m)", "-"},
+        {"TwoTheta(Deg)", "-"},
+        {"Azimuthal(Deg)", "-"},
+        {"TOF" + toQStringInternal(L"(\u03bcs)"), "-"},
+        {"Wavelength" + toQStringInternal(L"(\u212b)"), "-"},
+        {"Energy(meV)", "-"},
+        {"d-Spacing" + toQStringInternal(L"(\u212b)"), "-"},
+        {"|Q|" + toQStringInternal(L"(\u212b\u207b\u00b9)"), "-"},
+        {"Energy transfer(meV)", "-"}};
+    int index(0);
+    for (const auto &[expectedName, expectedValue] : expectedInfo) {
+      TS_ASSERT_EQUALS(expectedName, info.name(index));
+      TS_ASSERT_EQUALS(expectedValue, info.value(index));
+      index++;
     }
   }
 
-  void test_getInfoList_with_no_instrument() {
-    MatrixWorkspace_sptr workspace =
-        WorkspaceCreationHelper::create2DWorkspaceBinned(10, 10, false);
-    workspace->getAxis(0)->setUnit("TOF");
-    ImageInfoModelMatrixWS model;
-    model.setWorkspace(workspace);
+  void test_info_with_either_xysignal_dblmax() {
+    auto workspace =
+        WorkspaceCreationHelper::create2DWorkspaceBinned(1, 1, 15000.0, 100.);
+    ImageInfoModelMatrixWS model(workspace);
 
-    auto list = model.getInfoList(2, 4, 7);
-
-    const std::array<QString, 6> expectList{"Signal",
-                                            "7",
-                                            "Spec Num",
-                                            "4",
-                                            "Time-of-flight" +
-                                                toQStringInternal(L"(\u03bcs)"),
-                                            "2"};
-
-    TS_ASSERT_EQUALS(expectList.size(), list.size())
-    for (size_t i = 0; i < list.size(); ++i) {
-      TS_ASSERT_EQUALS(expectList[i], list[i]);
-    }
-  }
-
-  void test_getInfoList_ws_return_nothing_if_x_out_of_ws_range() {
-    MatrixWorkspace_sptr workspace =
-        WorkspaceCreationHelper::create2DWorkspaceWithFullInstrument(
-            10, 10, true, false, true, "workspace", false);
-    ImageInfoModelMatrixWS model;
-    model.setWorkspace(workspace);
-
-    auto list1 = model.getInfoList(-1, 4, 7);
-    auto list2 = model.getInfoList(10, 4, 7);
-
-    TS_ASSERT_EQUALS(0, list1.size())
-    TS_ASSERT_EQUALS(0, list2.size())
-  }
-
-  void test_getInfoList_return_nothing_if_y_out_of_range() {
-    MatrixWorkspace_sptr workspace =
-        WorkspaceCreationHelper::create2DWorkspaceWithFullInstrument(
-            10, 10, true, false, true, "workspace", false);
-    ImageInfoModelMatrixWS model;
-    model.setWorkspace(workspace);
-    auto list1 = model.getInfoList(2, -1, 7);
-    auto list2 = model.getInfoList(2, 11, 7);
-    TS_ASSERT_EQUALS(0, list1.size())
-    TS_ASSERT_EQUALS(0, list2.size())
-  }
-
-  void test_getInfoList_returns_dashes_if_given_DBLMAX() {
-    MatrixWorkspace_sptr workspace =
-        WorkspaceCreationHelper::create2DWorkspaceWithFullInstrument(
-            10, 10, true, false, true, "workspace", false);
-    ImageInfoModelMatrixWS model;
-    model.setWorkspace(workspace);
+    auto assertBlankInfo = [](const auto &info) {
+      const InfoItems expectedInfo = {
+          {"x", "-"},
+          {"Spectrum", "-"},
+          {"Signal", "-"},
+          {"Det ID", "-"},
+          {"L2(m)", "-"},
+          {"TwoTheta(Deg)", "-"},
+          {"Azimuthal(Deg)", "-"},
+          {"TOF" + toQStringInternal(L"(\u03bcs)"), "-"},
+          {"Wavelength" + toQStringInternal(L"(\u212b)"), "-"},
+          {"Energy(meV)", "-"},
+          {"d-Spacing" + toQStringInternal(L"(\u212b)"), "-"},
+          {"|Q|" + toQStringInternal(L"(\u212b\u207b\u00b9)"), "-"},
+          {"Energy transfer(meV)", "-"}};
+      int index(0);
+      for (const auto &[expectedName, expectedValue] : expectedInfo) {
+        TS_ASSERT_EQUALS(expectedName, info.name(index));
+        TS_ASSERT_EQUALS(expectedValue, info.value(index));
+        index++;
+      }
+    };
 
     constexpr auto dblmax = std::numeric_limits<double>::max();
-    auto list = model.getInfoList(dblmax, dblmax, dblmax);
+    assertBlankInfo(model.info(dblmax, 4, 7));
+    assertBlankInfo(model.info(15200, dblmax, 7));
+    assertBlankInfo(model.info(15200, 4, dblmax));
+  }
 
-    const std::array<QString, 22> expectList{
-        "Signal",
-        "-",
-        "Spec Num",
-        "-",
-        "Time-of-flight" + toQStringInternal(L"(\u03bcs)"),
-        "-",
-        "Det ID",
-        "-",
-        "L2(m)",
-        "-",
-        "TwoTheta(Deg)",
-        "-",
-        "Azimuthal(Deg)",
-        "-",
-        "Wavelength" + toQStringInternal(L"(\u212b)"),
-        "-",
-        "Energy(meV)",
-        "-",
-        "d-Spacing" + toQStringInternal(L"(\u212b)"),
-        "-",
-        "|Q|" + toQStringInternal(L"(\u212b\u207b\u00b9)"),
-        "-"};
+  void test_info_without_efixed_defined() {
+    auto noEfixed = [](MatrixWorkspace_sptr ws) { return ws; };
 
-    TS_ASSERT_EQUALS(expectList.size(), list.size())
-    for (size_t i = 0; i < list.size(); ++i) {
-      TS_ASSERT_EQUALS(expectList[i], list[i]);
+    const auto expectedUnits =
+        expectedUnitsInfo("2.4044", "14.1501", "40.1274", "0.1566", "-");
+    assertInfoAsExpected(noEfixed, expectedUnits);
+  }
+
+  void test_info_with_efixed_for_direct_mode() {
+    struct DirectEFixed {
+      DirectEFixed(std::string logName) : m_logName(std::move(logName)) {}
+      const std::string m_logName;
+
+      MatrixWorkspace_sptr operator()(MatrixWorkspace_sptr ws) const {
+        auto &instParams = ws->instrumentParameters();
+        instParams.addString(ws->getInstrument()->baseInstrument().get(),
+                             "deltaE-mode", "Direct");
+        ws->mutableRun().addProperty<double>(m_logName, 60., true);
+        return ws;
+      }
+    };
+
+    const auto expectedUnits =
+        expectedUnitsInfo("7.3425", "14.1501", "40.1274", "0.1566", "58.4827");
+    for (const auto &logName : {"Ei", "EnergyRequested", "EnergyEstimate"}) {
+      assertInfoAsExpected(DirectEFixed(logName), expectedUnits);
     }
   }
 
-  void test_getInfoList_returns_nothing_if_no_workspace_has_been_set() {
-    MatrixWorkspace_sptr workspace =
-        WorkspaceCreationHelper::create2DWorkspaceWithFullInstrument(
-            10, 10, true, false, true, "workspace", false);
-    ImageInfoModelMatrixWS model;
+  void test_info_with_efixed_for_indirect_mode() {
+    struct IndirectEFixed {
+      IndirectEFixed(std::string paramName)
+          : m_paramName(std::move(paramName)) {}
+      const std::string m_paramName;
 
-    auto list = model.getInfoList(2, 4, 7);
+      MatrixWorkspace_sptr operator()(MatrixWorkspace_sptr ws) const {
+        auto &instParams = ws->instrumentParameters();
+        auto baseInst = ws->getInstrument()->baseInstrument().get();
+        instParams.addString(baseInst, "deltaE-mode", "Indirect");
+        instParams.addDouble(baseInst, m_paramName, 50.);
+        return ws;
+      }
+    };
 
-    TS_ASSERT_EQUALS(0, list.size())
+    const auto expectedUnitsNoGroups =
+        expectedUnitsInfo("2.6862", "14.1501", "40.1274", "0.1566", "-38.6633");
+    const auto expectedUnitsWithGroup =
+        expectedUnitsInfo("2.6860", "14.1541", "34.4103", "0.1826", "-38.6614");
+    for (const auto &paramName : {"Efixed", "EFixed-val"}) {
+      bool includeGrouping(false);
+      assertInfoAsExpected(IndirectEFixed(paramName), expectedUnitsNoGroups,
+                           includeGrouping);
+      includeGrouping = true;
+      assertInfoAsExpected(IndirectEFixed(paramName), expectedUnitsWithGroup,
+                           includeGrouping);
+    }
+  }
+
+private:
+  template <typename EFixedProvider>
+  void assertInfoAsExpected(const EFixedProvider &addEfixed,
+                            const InfoItems &expectedUnitInfo,
+                            const bool includeGrouping = false) const {
+    auto workspace =
+        WorkspaceCreationHelper::create2DWorkspaceBinned(10, 10, 15000.0, 100.);
+    workspace->getAxis(0)->setUnit("TOF");
+    workspace->setYUnit("Counts");
+
+    InstrumentCreationHelper::addFullInstrumentToWorkspace(
+        *workspace, true, false, "test-instrument");
+    if (includeGrouping) {
+      workspace->getSpectrum(3).addDetectorID(5);
+    }
+    ImageInfoModelMatrixWS model(addEfixed(workspace));
+
+    const auto info = model.info(15200, 4, 7);
+
+    InfoItems expectedGeneralInfo;
+    if (includeGrouping)
+      expectedGeneralInfo = expectedCommonTOFInfo(
+          "15200.0000", "4", "7.0000", "4", "5.0125", "4.0038", "90.0000");
+    else
+      expectedGeneralInfo = expectedCommonTOFInfo(
+          "15200.0000", "4", "7.0000", "4", "5.0090", "3.4336", "90.0000");
+
+    TS_ASSERT_EQUALS(expectedGeneralInfo.size() + expectedUnitInfo.size(),
+                     info.size());
+    int index(0);
+    for (const auto &[expectedName, expectedValue] : expectedGeneralInfo) {
+      TS_ASSERT_EQUALS(expectedName, info.name(index));
+      TS_ASSERT_EQUALS(expectedValue, info.value(index));
+      index++;
+    }
+    for (const auto &[expectedName, expectedValue] : expectedUnitInfo) {
+      TS_ASSERT_EQUALS(expectedName, info.name(index));
+      TS_ASSERT_EQUALS(expectedValue, info.value(index));
+      index++;
+    }
+  }
+
+  InfoItems expectedCommonTOFInfo(const QString &tof, const QString &y,
+                                  const QString &signal, const QString &detID,
+                                  const QString &l2, const QString &twoTheta,
+                                  const QString &azimuth) const {
+    const InfoItems expectedCommonInfo = {
+        {"TOF" + toQStringInternal(L"(\u03bcs)"), tof},
+        {"Spectrum", y},
+        {"Signal", signal},
+        {"Det ID", detID},
+        {"L2(m)", l2},
+        {"TwoTheta(Deg)", twoTheta},
+        {"Azimuthal(Deg)", azimuth}};
+
+    return expectedCommonInfo;
+  }
+
+  InfoItems expectedUnitsInfo(const QString &wavelength, const QString &energy,
+                              const QString &dspacing, const QString &modQ,
+                              const QString &deltaE) const {
+    const InfoItems expectedUnitsInfo = {
+        {"Wavelength" + toQStringInternal(L"(\u212b)"), wavelength},
+        {"Energy(meV)", energy},
+        {"d-Spacing" + toQStringInternal(L"(\u212b)"), dspacing},
+        {"|Q|" + toQStringInternal(L"(\u212b\u207b\u00b9)"), modQ},
+        {"Energy transfer(meV)", deltaE}};
+    return expectedUnitsInfo;
   }
 };

--- a/qt/widgets/common/test/ImageInfoModelMatrixWSTest.h
+++ b/qt/widgets/common/test/ImageInfoModelMatrixWSTest.h
@@ -114,14 +114,15 @@ public:
     TS_ASSERT_EQUALS(0, list2.size())
   }
 
-  void test_getInfoList_returns_dashes_if_includeValues_is_false() {
+  void test_getInfoList_returns_dashes_if_given_DBLMAX() {
     MatrixWorkspace_sptr workspace =
         WorkspaceCreationHelper::create2DWorkspaceWithFullInstrument(
             10, 10, true, false, true, "workspace", false);
     ImageInfoModelMatrixWS model;
     model.setWorkspace(workspace);
 
-    auto list = model.getInfoList(2, 4, 7, false);
+    constexpr auto dblmax = std::numeric_limits<double>::max();
+    auto list = model.getInfoList(dblmax, dblmax, dblmax);
 
     const std::array<QString, 22> expectList{
         "Signal",


### PR DESCRIPTION
**Description of work.**

Refactors some code around the image info widget and fixes an issue with retrieving efixed from grouped detectors on indirect instruments.

**To test:**

* Use the file in the related issue and see that the sliceviewer now opens.
* Use other workspace types, e.g from #28832 and other MatrixWorkspace types from other reductions and check they load. Others to check would be results from `Testing/SystemTests/tests/analysis/reference`. 

Fixes #28966 

*This does not require release notes* because **it was a regression introduced this development cycle.**

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
