### PR TITLE
Fix performance tests

### DIFF
--- a/Framework/DataHandling/test/InstrumentRayTracerTest.h
+++ b/Framework/DataHandling/test/InstrumentRayTracerTest.h
@@ -71,7 +71,7 @@ public:
       InstrumentRayTracer tracker(m_inst);
       tracker.traceFromSample(testDir);
       Links results = tracker.getResults();
-      TS_ASSERT_EQUALS(results.size(), 3);
+      TS_ASSERT_EQUALS(results.size(), 2);
       // showResults(results, m_inst);
     }
   }

--- a/Framework/TestHelpers/src/ComponentCreationHelper.cpp
+++ b/Framework/TestHelpers/src/ComponentCreationHelper.cpp
@@ -987,19 +987,8 @@ Instrument_sptr sansInstrument(const Mantid::Kernel::V3D &sourcePos,
       Mantid::Geometry::Y /*up*/, Mantid::Geometry::Z /*along*/, Left,
       "0,0,0"));
 
-  // A source
-  ObjComponent *source = new ObjComponent("source");
-  source->setPos(sourcePos);
-  source->setShape(createSphere(0.01 /*1cm*/, V3D(0, 0, 0), "1"));
-  instrument->add(source);
-  instrument->markAsSource(source);
-
-  // A sample
-  ObjComponent *sample = new ObjComponent("some-surface-holder");
-  sample->setPos(samplePos);
-  sample->setShape(createSphere(0.01 /*1cm*/, V3D(0, 0, 0), "1"));
-  instrument->add(sample);
-  instrument->markAsSamplePos(sample);
+  addSourceToInstrument(instrument, sourcePos);
+  addSampleToInstrument(instrument, samplePos);
 
   size_t width = 100;
   size_t height = 100;


### PR DESCRIPTION
**Description of work.**

Recent changes to disallow storing a sample shape on the sample position component caused some [performance tests](https://builds.mantidproject.org/job/master_performancetests2/lastCompletedBuild/consoleText) to no longer run. The tests are only run on `master` so the changes slipped through.


**To test:**

* Run cmake with `CXXTEST_ADD_PERFORMANCE` set to on.
* Compile APITest & DataHandlingTest
* Run the 4 tests listed at the bottom of the link above and they should pass.

*There is no associated issue.*

*This does not require release notes* because **it was broken this dev cycle.**

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
