### PR TITLE
Sliceviewer sub-plots follow image scaling

### DIFF
--- a/docs/source/release/v5.1.0/mantidworkbench.rst
+++ b/docs/source/release/v5.1.0/mantidworkbench.rst
@@ -115,6 +115,7 @@ Bugfixes
 - Overplotting no longer resets the axes scales.
 - Fixed a bug with the peak cursor immediately resetting to the default cursor when trying to add a peak.
 - Changing a curve's properties on a plot no longer changes the order of the plot legend.
+- Sub-plots in the sliceviewer now follow the scaling on the colorbar
 - Fixed a bug which prevented the double click axis editor menus from working for tiled plots.
 
 :ref:`Release 5.1.0 <v5.1.0>`

--- a/qt/python/mantidqt/widgets/colorbar/colorbar.py
+++ b/qt/python/mantidqt/widgets/colorbar/colorbar.py
@@ -175,6 +175,17 @@ class ColorbarWidget(QWidget):
         else:
             return Normalize(vmin=cmin, vmax=cmax)
 
+    def get_colorbar_scale(self):
+        norm = self.colorbar.norm
+        scale = 'linear'
+        kwargs = {}
+        if isinstance(norm, SymLogNorm):
+            scale = 'symlog'
+        elif isinstance(norm, PowerNorm):
+            scale = 'function'
+            kwargs = {'functions': (lambda x: np.power(x, norm.gamma), lambda x: np.power(x, 1 / norm.gamma))}
+        return scale, kwargs
+
     def clim_changed(self):
         """
         Called when either the min or max is changed. Will unset the autoscale.

--- a/qt/python/mantidqt/widgets/sliceviewer/view.py
+++ b/qt/python/mantidqt/widgets/sliceviewer/view.py
@@ -213,6 +213,7 @@ class SliceViewerDataView(QWidget):
         self.axx.yaxis.tick_right()
         self.axy = self.fig.add_subplot(gs[0], sharey=image_axes)
         self.axy.xaxis.tick_top()
+        self.update_line_plot_limits()
         self.update_line_plot_labels()
         self.mpl_toolbar.update()  # sync list of axes in navstack
         self.canvas.draw_idle()
@@ -520,6 +521,16 @@ class SliceViewerDataView(QWidget):
         try:  # set line plot intensity axes to match colorbar limits
             self.axx.set_ylim(self.colorbar.cmin_value, self.colorbar.cmax_value)
             self.axy.set_xlim(self.colorbar.cmin_value, self.colorbar.cmax_value)
+            self.update_line_plot_scale()
+        except AttributeError:
+            pass
+
+    def update_line_plot_scale(self):
+        # set line plot scale axes to match colorbar scale
+        scale, kwargs = self.colorbar.get_colorbar_scale()
+        try:
+            self.axx.set_yscale(scale, **kwargs)
+            self.axy.set_xscale(scale, **kwargs)
         except AttributeError:
             pass
 


### PR DESCRIPTION
**Description of work.**
This PR sets the scale on the line plots in sliceviewer to match the scale on the colorbar.

**Report to:** Jos Cooper

**To test:**
Load a workspace and open sliceviewer
Toggle line plots on
Change the colorbar scaling - the scale on the line plots should change to match the new scale 

Fixes #28518 

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
