### PR TITLE
Allow composite functions and TF Asymmetry in DoublePulseFit

### DIFF
--- a/Framework/CurveFitting/inc/MantidCurveFitting/Algorithms/DoublePulseFit.h
+++ b/Framework/CurveFitting/inc/MantidCurveFitting/Algorithms/DoublePulseFit.h
@@ -23,11 +23,13 @@ class IFuncMinimizer;
 
 namespace CurveFitting {
 namespace Algorithms {
-MANTID_CURVEFITTING_DLL Mantid::API::IFunction_sptr getDoublePulseFunction(
-    std::shared_ptr<const API::ParamFunction> const &function, double offset,
-    double firstPulseWeight, double secondPulseWeight);
+MANTID_CURVEFITTING_DLL Mantid::API::IFunction_sptr
+getDoublePulseFunction(std::shared_ptr<const API::IFunction> const &function,
+                       double offset, double firstPulseWeight,
+                       double secondPulseWeight);
 
-MANTID_CURVEFITTING_DLL Mantid::API::IFunction_sptr getDoublePulseFunction(
+MANTID_CURVEFITTING_DLL Mantid::API::IFunction_sptr
+getDoublePulseMultiDomainFunction(
     std::shared_ptr<const API::MultiDomainFunction> const &function,
     double offset, double firstPulseWeight, double secondPulseWeight);
 

--- a/Framework/CurveFitting/src/Algorithms/DoublePulseFit.cpp
+++ b/Framework/CurveFitting/src/Algorithms/DoublePulseFit.cpp
@@ -97,7 +97,8 @@ Mantid::API::IFunction_sptr getDoublePulseMultiDomainFunction(
   auto doublePulseFunc = std::make_shared<API::MultiDomainFunction>();
   for (size_t domain = 0; domain < initialFunction->getNumberDomains();
        domain++) {
-    auto twoPulseInnerFunction = getDoublePulseFunction(initialFunction->getFunction(domain), offset,
+    auto twoPulseInnerFunction =
+        getDoublePulseFunction(initialFunction->getFunction(domain), offset,
                                firstPulseWeight, secondPulseWeight);
     doublePulseFunc->addFunction(twoPulseInnerFunction);
     doublePulseFunc->setDomainIndex(domain, domain);
@@ -207,7 +208,7 @@ void DoublePulseFit::initConcrete() {
                   "Output is an empty string).");
   declareProperty("PulseOffset", 0.0, "The time offset between the two pulses");
   declareProperty("FirstPulseWeight", 0.5, "Weighting of first pulse.");
-  declareProperty("SecondPulseWeight", 0.5, "Weighting of first pulse.");
+  declareProperty("SecondPulseWeight", 0.5, "Weighting of second pulse.");
 }
 
 void DoublePulseFit::execConcrete() {

--- a/Framework/CurveFitting/test/Algorithms/DoublePulseFitTest.h
+++ b/Framework/CurveFitting/test/Algorithms/DoublePulseFitTest.h
@@ -36,7 +36,7 @@ public:
         FunctionFactory::Instance().createInitializedMultiDomainFunction(
             "name=ExpDecay, Height=5, Lifetime=2", 2);
     auto doublePulseFunction =
-        getDoublePulseFunction(initialFunction, 5.0, 1.0, 2.0);
+        getDoublePulseMultiDomainFunction(initialFunction, 5.0, 1.0, 2.0);
     TS_ASSERT_EQUALS(
         "composite=MultiDomainFunction,NumDeriv=true;(composite=Convolution,"
         "FixResolution=false,NumDeriv=true,$domains=i;name=ExpDecay,Height=5,"
@@ -48,17 +48,6 @@ public:
         "Height=1,Centre=-2.5,ties=(Height=1,Centre=-2.5);name=DeltaFunction,"
         "Height=2,Centre=2.5,ties=(Height=2,Centre=2.5)))",
         doublePulseFunction->asString());
-  }
-
-  void
-  test_double_pulse_function_throws_exception_if_inner_function_is_composite() {
-    auto initialFunction =
-        FunctionFactory::Instance().createInitializedMultiDomainFunction(
-            "(name=ExpDecay, Height=5, Lifetime=2; name=ExpDecay, Height=7, "
-            "Lifetime=3)",
-            5);
-    TS_ASSERT_THROWS(getDoublePulseFunction(initialFunction, 5.0, 1.0, 2.0),
-                     const std::runtime_error &);
   }
 
   void
@@ -95,7 +84,7 @@ public:
     auto initialFunction =
         FunctionFactory::Instance().createInitializedMultiDomainFunction(
             "(name=ExpDecay, Height=5, Lifetime=2; name=ExpDecay, Height=7, "
-            "Lifetime=3)",
+            "Lifetime = 3) ",
             5);
     TS_ASSERT_THROWS(extractInnerFunction(initialFunction),
                      const std::runtime_error &);

--- a/Framework/CurveFitting/test/Algorithms/DoublePulseFitTest.h
+++ b/Framework/CurveFitting/test/Algorithms/DoublePulseFitTest.h
@@ -71,7 +71,7 @@ public:
         FunctionFactory::Instance().createInitializedMultiDomainFunction(
             "name=ExpDecay, Height=5, Lifetime=2", 2);
     auto doublePulseFunction =
-        getDoublePulseFunction(initialFunction, 5.0, 1.0, 2.0);
+        getDoublePulseMultiDomainFunction(initialFunction, 5.0, 1.0, 2.0);
     auto restored_function = extractInnerFunction(
         std::dynamic_pointer_cast<MultiDomainFunction>(doublePulseFunction));
 

--- a/Framework/Muon/src/CalculateMuonAsymmetry.cpp
+++ b/Framework/Muon/src/CalculateMuonAsymmetry.cpp
@@ -97,8 +97,9 @@ void CalculateMuonAsymmetry::init() {
       "EnableDoublePulse", false,
       "Controls whether to perform a double pulse or single pulse fit.");
   declareProperty("PulseOffset", 0.0, "The time offset between the two pulses");
-  declareProperty("FirstPulseWeight", 0.5, "Weighting of first pulse.
-   The second pulse weighting is set as 1 - this.");
+  declareProperty("FirstPulseWeight", 0.5,
+                  "Weighting of first pulse."
+                  "The second pulse weighting is set as 1 - this.");
 }
 /*
  * Validate the input parameters

--- a/Framework/Muon/src/CalculateMuonAsymmetry.cpp
+++ b/Framework/Muon/src/CalculateMuonAsymmetry.cpp
@@ -98,8 +98,8 @@ void CalculateMuonAsymmetry::init() {
       "Controls whether to perform a double pulse or single pulse fit.");
   declareProperty("PulseOffset", 0.0, "The time offset between the two pulses");
   declareProperty("FirstPulseWeight", 0.5,
-                  "Weighting of first pulse."
-                  "The second pulse weighting is set as 1 - this.");
+                  "Weighting of first pulse (w_1)."
+                  "The second pulse weighting (w_1) is set as w_2 = 1 - w_1.");
 }
 /*
  * Validate the input parameters

--- a/Framework/Muon/src/CalculateMuonAsymmetry.cpp
+++ b/Framework/Muon/src/CalculateMuonAsymmetry.cpp
@@ -97,8 +97,8 @@ void CalculateMuonAsymmetry::init() {
       "EnableDoublePulse", false,
       "Controls whether to perform a double pulse or single pulse fit.");
   declareProperty("PulseOffset", 0.0, "The time offset between the two pulses");
-  declareProperty("FirstPulseWeight", 0.5, "Weighting of first pulse.");
-  declareProperty("SecondPulseWeight", 0.5, "Weighting of first pulse.");
+  declareProperty("FirstPulseWeight", 0.5, "Weighting of first pulse.
+   The second pulse weighting is set as 1 - this.");
 }
 /*
  * Validate the input parameters
@@ -179,6 +179,7 @@ std::map<std::string, std::string> CalculateMuonAsymmetry::validateInputs() {
                                                " name columns";
     }
   }
+
   return validationOutput;
 }
 /** Executes the algorithm
@@ -296,12 +297,11 @@ std::vector<double> CalculateMuonAsymmetry::getNormConstants(
   if (doublePulseEnabled) {
     double pulseOffset = getProperty("PulseOffset");
     double firstPulseWeight = getProperty("FirstPulseWeight");
-    double secondPulseWeight = getProperty("SecondPulseWeight");
     fit = createChildAlgorithm("DoublePulseFit");
     fit->initialize();
     fit->setProperty("PulseOffset", pulseOffset);
     fit->setProperty("FirstPulseWeight", firstPulseWeight);
-    fit->setProperty("SecondPulseWeight", secondPulseWeight);
+    fit->setProperty("SecondPulseWeight", 1.0 - firstPulseWeight);
   } else {
     fit = createChildAlgorithm("Fit");
     fit->initialize();

--- a/Framework/Muon/test/CalculateMuonAsymmetryTest.h
+++ b/Framework/Muon/test/CalculateMuonAsymmetryTest.h
@@ -356,7 +356,6 @@ public:
       TS_ASSERT_DELTA(outWS->e(0)[40], 0.0015, delta);
       TS_ASSERT_DELTA(outWS->e(0)[100], 0.0015, delta);
     }
-    TS_ASSERT(false);
     clearADS();
   }
 };

--- a/Framework/Muon/test/CalculateMuonAsymmetryTest.h
+++ b/Framework/Muon/test/CalculateMuonAsymmetryTest.h
@@ -327,7 +327,6 @@ public:
     alg->setProperty("EnableDoublePulse", true);
     alg->setProperty("PulseOffset", 0.33);
     alg->setProperty("FirstPulseWeight", 0.5);
-    alg->setProperty("SecondPulseWeight", 0.5);
 
     TS_ASSERT_THROWS_NOTHING(alg->execute());
     TS_ASSERT(alg->isExecuted());

--- a/Framework/Muon/test/CalculateMuonAsymmetryTest.h
+++ b/Framework/Muon/test/CalculateMuonAsymmetryTest.h
@@ -158,12 +158,6 @@ public:
 
   CalculateMuonAsymmetryTest() { FrameworkManager::Instance(); }
 
-  void testInit() {
-    // IAlgorithm_sptr alg = setUpAlg();
-
-    // TS_ASSERT(alg->isInitialized());
-  }
-
   void test_Execute() {
 
     genData();
@@ -176,8 +170,8 @@ public:
     TS_ASSERT_THROWS_NOTHING(alg->execute());
     TS_ASSERT(alg->isExecuted());
     clearADS();
-    // MatrixWorkspace_sptr outWS = alg->getProperty("OutputWorkspace");
   }
+
   void test_singleFit() {
 
     genData();
@@ -320,12 +314,59 @@ public:
 
     clearADS();
   }
+
+  void test_simultaneous_fit_with_double_pulse_mode_enabled() {
+    genData();
+    // need the 2 here to get multi func
+    std::vector<std::string> wsNames = {"ws1", "ws2"};
+    std::vector<std::string> wsOut = {"ws3", "ws4"};
+    auto func = genDoubleFunc(wsNames);
+    auto table = genTable();
+
+    IAlgorithm_sptr alg = setUpAlg(table, func, wsNames, wsOut);
+    alg->setProperty("EnableDoublePulse", true);
+    alg->setProperty("PulseOffset", 0.33);
+    alg->setProperty("FirstPulseWeight", 0.5);
+    alg->setProperty("SecondPulseWeight", 0.5);
+
+    TS_ASSERT_THROWS_NOTHING(alg->execute());
+    TS_ASSERT(alg->isExecuted());
+    std::vector<std::string> output =
+        alg->getProperty("ReNormalizedWorkspaceList");
+
+    for (int j = 0; j < 2; j++) {
+      MatrixWorkspace_sptr outWS =
+          AnalysisDataService::Instance().retrieveWS<MatrixWorkspace>(
+              output[j]);
+
+      double delta = 0.0001;
+
+      TS_ASSERT_DELTA(table->Double(j + 2, 0), 3.4, delta);
+      TS_ASSERT_EQUALS(table->String(j + 2, 1), output[j]);
+      TS_ASSERT_EQUALS(table->String(j + 2, 2), "Calculated");
+
+      TS_ASSERT_DELTA(outWS->x(0)[10], 0.5, delta);
+      TS_ASSERT_DELTA(outWS->x(0)[40], 2.0, delta);
+      TS_ASSERT_DELTA(outWS->x(0)[100], 5.0, delta);
+
+      TS_ASSERT_DELTA(outWS->y(0)[10], 0.1031, delta);
+      TS_ASSERT_DELTA(outWS->y(0)[40], -0.1250, delta);
+      TS_ASSERT_DELTA(outWS->y(0)[100], -0.0065, delta);
+
+      TS_ASSERT_DELTA(outWS->e(0)[10], 0.0015, delta);
+      TS_ASSERT_DELTA(outWS->e(0)[40], 0.0015, delta);
+      TS_ASSERT_DELTA(outWS->e(0)[100], 0.0015, delta);
+    }
+    TS_ASSERT(false);
+    clearADS();
+  }
 };
 
 class CalculateMuonAsymmetryTestPerformance : public CxxTest::TestSuite {
 public:
-  // This pair of boilerplate methods prevent the suite being created statically
-  // This means the constructor isn't called when running other tests
+  // This pair of boilerplate methods prevent the suite being created
+  // statically This means the constructor isn't called when running other
+  // tests
   static CalculateMuonAsymmetryTestPerformance *createSuite() {
     return new CalculateMuonAsymmetryTestPerformance();
   }

--- a/docs/source/algorithms/CalculateMuonAsymmetry-v1.rst
+++ b/docs/source/algorithms/CalculateMuonAsymmetry-v1.rst
@@ -127,7 +127,47 @@ Output:
 
    Normalization constant for b: 2.30
    Normalization constant for d: 4.10
-   
+
+**Example - Calculating Asymmetry for double pulse data:**
+
+.. testcode:: AsymmDoublePulse
+
+   import math
+   import numpy as np
+
+   delta = 0.33
+   x = np.linspace(0.,15.,100)
+   x_offset = np.linspace(delta/2, 15. + delta/2, 100)
+   x_offset_neg = np.linspace(-delta/2, 15. - delta/2, 100)
+
+   testFunction = GausOsc(Frequency = 1.5, A=0.22)
+   y1 = testFunction(x_offset_neg)
+   y2 = testFunction(x_offset)
+   N0 = 6.38
+   y = N0 * (1 + y1/2+y2/2)
+   y_norm = y1/2+y2/2
+   unnormalised_workspace = CreateWorkspace(x,y)
+   ws_to_normalise = CreateWorkspace(x,y)
+   ws_correctly_normalised = CreateWorkspace(x,y_norm)
+   AddSampleLog(Workspace='ws_to_normalise', LogName="analysis_asymmetry_norm", LogText="1")
+
+   innerFunction = FunctionFactory.createInitialized('name=GausOsc,A=0.20,Sigma=0.2,Frequency=1.0,Phi=0')
+   tf_function = ConvertFitFunctionForMuonTFAsymmetry(InputFunction=innerFunction, WorkspaceList=['ws_to_normalise'])
+
+   CalculateMuonAsymmetry(MaxIterations=100, EnableDoublePulse=True, PulseOffset=delta, UnNormalizedWorkspaceList='unnormalised_workspace', ReNormalizedWorkspaceList='ws_to_normalise',
+                           OutputFitWorkspace='DoublePulseFit', StartX=0, InputFunction=str(tf_function), Minimizer='Levenberg-Marquardt')
+
+   double_parameter_workspace = AnalysisDataService.retrieve('DoublePulseFit_Parameters')
+   values_column = double_parameter_workspace.column(1)
+
+   print("Normalization constant is: {0:.2f}".format(values_column[0]))
+
+Output:
+
+.. testoutput:: AsymmDoublePulse
+
+   Normalization constant is: 6.38
+
 .. categories::
 
 .. sourcelink::

--- a/docs/source/release/v5.1.0/muon.rst
+++ b/docs/source/release/v5.1.0/muon.rst
@@ -43,6 +43,7 @@ Improvements
 - The plot guess option within the fitting tab will now update when a parameter is changed.
 - Have updated the FDA GUI so that it functions correctly for frquency transforms and single fits.
 - Updated :ref:`DoublePulseFit <algm-DoublePulseFit>` to allow composite function input.
+- Updated :ref:`CalculateMuonAsymmetry <algm-CalculateMuonAsymmetry>` to allow double pulse fits.
 
 Bug fixes
 ---------

--- a/docs/source/release/v5.1.0/muon.rst
+++ b/docs/source/release/v5.1.0/muon.rst
@@ -42,6 +42,7 @@ Improvements
   These changes will make the addition of new functionality in the future easier.
 - The plot guess option within the fitting tab will now update when a parameter is changed.
 - Have updated the FDA GUI so that it functions correctly for frquency transforms and single fits.
+- Updated :ref:`DoublePulseFit <algm-DoublePulseFit>` to allow composite function input.
 
 Bug fixes
 ---------

--- a/docs/source/release/v5.1.0/muon.rst
+++ b/docs/source/release/v5.1.0/muon.rst
@@ -44,6 +44,7 @@ Improvements
 - Have updated the FDA GUI so that it functions correctly for frquency transforms and single fits.
 - Updated :ref:`DoublePulseFit <algm-DoublePulseFit>` to allow composite function input.
 - Updated :ref:`CalculateMuonAsymmetry <algm-CalculateMuonAsymmetry>` to allow double pulse fits.
+- Tf asymmetry mode can now be performed on double pulse fits from the muon analysis GUI.
 
 Bug fixes
 ---------

--- a/scripts/Muon/GUI/Common/fitting_tab_widget/fitting_tab_model.py
+++ b/scripts/Muon/GUI/Common/fitting_tab_widget/fitting_tab_model.py
@@ -179,7 +179,7 @@ class FittingTabModel(object):
 
     def do_single_fit_and_return_workspace_parameters_and_fit_function(
             self, parameters_dict):
-        if self.double_pulse_enanbled():
+        if self.double_pulse_enabled():
             alg = self._create_double_pulse_alg()
         else:
             alg = mantid.AlgorithmManager.create("Fit")
@@ -225,7 +225,7 @@ class FittingTabModel(object):
 
     def do_simultaneous_fit_and_return_workspace_parameters_and_fit_function(
             self, parameters_dict):
-        if self.double_pulse_enanbled():
+        if self.double_pulse_enabled():
             alg = self._create_double_pulse_alg()
         else:
             alg = mantid.AlgorithmManager.create("Fit")
@@ -580,7 +580,7 @@ class FittingTabModel(object):
             'Minimizer': self.fitting_options["minimiser"],
         }
 
-        if self.double_pulse_enanbled():
+        if self.double_pulse_enabled():
             offset = self.context.gui_context['DoublePulseTime']
             muon_halflife = 2.2
             decay = math.exp(-offset / muon_halflife)
@@ -604,7 +604,7 @@ class FittingTabModel(object):
             'EndX': self.fitting_options["endX"],
             'Minimizer': self.fitting_options["minimiser"],
         }
-        if self.double_pulse_enanbled():
+        if self.double_pulse_enabled():
             offset = self.context.gui_context['DoublePulseTime']
             muon_halflife = 2.2
             decay = math.exp(-offset / muon_halflife)
@@ -614,7 +614,7 @@ class FittingTabModel(object):
 
         return parameters
 
-    def double_pulse_enanbled(self):
+    def double_pulse_enabled(self):
         return 'DoublePulseEnabled' in self.context.gui_context and self.context.gui_context['DoublePulseEnabled']
 
     # get workspace information

--- a/scripts/Muon/GUI/Common/fitting_tab_widget/fitting_tab_model.py
+++ b/scripts/Muon/GUI/Common/fitting_tab_widget/fitting_tab_model.py
@@ -179,7 +179,7 @@ class FittingTabModel(object):
 
     def do_single_fit_and_return_workspace_parameters_and_fit_function(
             self, parameters_dict):
-        if 'DoublePulseEnabled' in self.context.gui_context and self.context.gui_context['DoublePulseEnabled']:
+        if self.double_pulse_enanbled():
             alg = self._create_double_pulse_alg()
         else:
             alg = mantid.AlgorithmManager.create("Fit")
@@ -225,7 +225,7 @@ class FittingTabModel(object):
 
     def do_simultaneous_fit_and_return_workspace_parameters_and_fit_function(
             self, parameters_dict):
-        if 'DoublePulseEnabled' in self.context.gui_context and self.context.gui_context['DoublePulseEnabled']:
+        if self.double_pulse_enanbled():
             alg = self._create_double_pulse_alg()
         else:
             alg = mantid.AlgorithmManager.create("Fit")
@@ -580,13 +580,13 @@ class FittingTabModel(object):
             'Minimizer': self.fitting_options["minimiser"],
         }
 
-        if ('DoublePulseEnabled' in self.context.gui_context and self.context.gui_context['DoublePulseEnabled']):
+        if self.double_pulse_enanbled():
             offset = self.context.gui_context['DoublePulseTime']
             muon_halflife = 2.2
             decay = math.exp(-offset / muon_halflife)
             first_pulse_weighting = decay / (1 + decay)
             parameters.update({'PulseOffset' : offset,
-                               'DoublePulseEnabled': True,'FirstPulseWeight': first_pulse_weighting})
+                               'EnableDoublePulse': True,'FirstPulseWeight': first_pulse_weighting})
 
         return parameters
 
@@ -604,15 +604,18 @@ class FittingTabModel(object):
             'EndX': self.fitting_options["endX"],
             'Minimizer': self.fitting_options["minimiser"],
         }
-        if ('DoublePulseEnabled' in self.context.gui_context and self.context.gui_context['DoublePulseEnabled']):
+        if self.double_pulse_enanbled():
             offset = self.context.gui_context['DoublePulseTime']
             muon_halflife = 2.2
             decay = math.exp(-offset / muon_halflife)
             first_pulse_weighting = decay / (1 + decay)
             parameters.update({'PulseOffset' : offset,
-                               'DoublePulseEnabled': True,'FirstPulseWeight': first_pulse_weighting})
+                               'EnableDoublePulse': True,'FirstPulseWeight': first_pulse_weighting})
 
         return parameters
+
+    def double_pulse_enanbled(self):
+        return 'DoublePulseEnabled' in self.context.gui_context and self.context.gui_context['DoublePulseEnabled']
 
     # get workspace information
     def get_selected_workspace_list(self):

--- a/scripts/Muon/GUI/Common/fitting_tab_widget/fitting_tab_model.py
+++ b/scripts/Muon/GUI/Common/fitting_tab_widget/fitting_tab_model.py
@@ -585,10 +585,8 @@ class FittingTabModel(object):
             muon_halflife = 2.2
             decay = math.exp(-offset / muon_halflife)
             first_pulse_weighting = decay / (1 + decay)
-            second_pulse_weighting = 1 / (1 + decay)
             parameters.update({'PulseOffset' : offset,
-                               'DoublePulseEnabled': True,'FirstPulseWeight': first_pulse_weighting,
-                               'SecondPulseWeight': second_pulse_weighting})
+                               'DoublePulseEnabled': True,'FirstPulseWeight': first_pulse_weighting})
 
         return parameters
 
@@ -611,10 +609,8 @@ class FittingTabModel(object):
             muon_halflife = 2.2
             decay = math.exp(-offset / muon_halflife)
             first_pulse_weighting = decay / (1 + decay)
-            second_pulse_weighting = 1 / (1 + decay)
             parameters.update({'PulseOffset' : offset,
-                               'DoublePulseEnabled': True,'FirstPulseWeight': first_pulse_weighting,
-                               'SecondPulseWeight': second_pulse_weighting})
+                               'DoublePulseEnabled': True,'FirstPulseWeight': first_pulse_weighting})
 
         return parameters
 

--- a/scripts/Muon/GUI/Common/fitting_tab_widget/fitting_tab_presenter.py
+++ b/scripts/Muon/GUI/Common/fitting_tab_widget/fitting_tab_presenter.py
@@ -286,12 +286,6 @@ class FittingTabPresenter(object):
         if self._tf_asymmetry_mode == self.view.tf_asymmetry_mode:
             return
 
-        if 'DoublePulseEnabled' in self.model.context.gui_context and self.model.context.gui_context['DoublePulseEnabled'] \
-                and self.view.tf_asymmetry_mode:
-            self.view.tf_asymmetry_mode = False
-            self.view.warning_popup('Tf asymmetry mode incompatible with double pulse analysis.')
-            return
-
         self._tf_asymmetry_mode = self.view.tf_asymmetry_mode
         global_parameters = self.view.get_global_parameters()
         if self._tf_asymmetry_mode:

--- a/scripts/test/CMakeLists.txt
+++ b/scripts/test/CMakeLists.txt
@@ -1,5 +1,6 @@
 set(TEST_PY_FILES
-    AbsorptionShapesTest.py 	
+    AbsorptionShapesTest.py
+    CalculateMuonAsymmetryTest.py
     ConvertToWavelengthTest.py
     CrystalFieldMultiSiteTest.py
     CrystalFieldTest.py

--- a/scripts/test/CalculateMuonAsymmetryTest.py
+++ b/scripts/test/CalculateMuonAsymmetryTest.py
@@ -1,0 +1,50 @@
+# Mantid Repository : https://github.com/mantidproject/mantid
+#
+# Copyright &copy; 2020 ISIS Rutherford Appleton Laboratory UKRI,
+#   NScD Oak Ridge National Laboratory, European Spallation Source,
+#   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+# SPDX - License - Identifier: GPL - 3.0 +
+import unittest
+from mantid.simpleapi import CreateWorkspace, GausOsc, AddSampleLog, ConvertFitFunctionForMuonTFAsymmetry, CalculateMuonAsymmetry, \
+ AnalysisDataService, CompareWorkspaces
+from mantid.api import FunctionFactory
+import numpy as np
+
+
+class SingleDomainDoublePulseFitTest(unittest.TestCase):
+    def test_that_correctly_identifies_normalisation_for_artificial_double_pulse_data(self):
+        delta = 0.33
+        x = np.linspace(0.,15.,100)
+        x_offset = np.linspace(delta/2, 15. + delta/2, 100)
+        x_offset_neg = np.linspace(-delta/2, 15. - delta/2, 100)
+
+        testFunction = GausOsc(Frequency = 1.5, A=0.22)
+        y1 = testFunction(x_offset_neg)
+        y2 = testFunction(x_offset)
+        N0 = 6.38
+        y = N0 * (1 + y1/2+y2/2)
+        y_norm = y1/2+y2/2
+        unnormalised_workspace = CreateWorkspace(x,y)
+        ws_to_normalise = CreateWorkspace(x,y)
+        ws_correctly_normalised = CreateWorkspace(x,y_norm)
+        AddSampleLog(Workspace='ws_to_normalise', LogName="analysis_asymmetry_norm", LogText="1")
+
+        innerFunction = FunctionFactory.createInitialized('name=GausOsc,A=0.20,Sigma=0.2,Frequency=1.0,Phi=0')
+        tf_function = ConvertFitFunctionForMuonTFAsymmetry(InputFunction=innerFunction, WorkspaceList=['ws_to_normalise'])
+
+        CalculateMuonAsymmetry(MaxIterations=100, EnableDoublePulse=True, PulseOffset=delta, UnNormalizedWorkspaceList='unnormalised_workspace', ReNormalizedWorkspaceList='ws_to_normalise',
+                               OutputFitWorkspace='DoublePulseFit', StartX=0, InputFunction=str(tf_function), Minimizer='Levenberg-Marquardt')
+
+        double_parameter_workspace = AnalysisDataService.retrieve('DoublePulseFit_Parameters')
+        values_column = double_parameter_workspace.column(1)
+        # Check that the correct normalisation is found.
+        self.assertAlmostEqual(values_column[0], N0, places=3)
+        # Check that normalised data is correct
+        result, message = CompareWorkspaces('ws_to_normalise', 'ws_correctly_normalised', Tolerance=1e-10)
+        self.assertTrue(result)
+        
+        AnalysisDataService.clear()
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/scripts/test/CalculateMuonAsymmetryTest.py
+++ b/scripts/test/CalculateMuonAsymmetryTest.py
@@ -40,7 +40,7 @@ class SingleDomainDoublePulseFitTest(unittest.TestCase):
         # Check that the correct normalisation is found.
         self.assertAlmostEqual(values_column[0], N0, places=3)
         # Check that normalised data is correct
-        result, message = CompareWorkspaces('ws_to_normalise', 'ws_correctly_normalised', Tolerance=1e-6)
+        result, message = CompareWorkspaces('ws_to_normalise', 'ws_correctly_normalised', Tolerance=1e-3)
         self.assertTrue(result)
         
         AnalysisDataService.clear()

--- a/scripts/test/CalculateMuonAsymmetryTest.py
+++ b/scripts/test/CalculateMuonAsymmetryTest.py
@@ -42,7 +42,7 @@ class SingleDomainDoublePulseFitTest(unittest.TestCase):
         # Check that normalised data is correct
         result, message = CompareWorkspaces('ws_to_normalise', 'ws_correctly_normalised', Tolerance=1e-3)
         self.assertTrue(result)
-        
+
         AnalysisDataService.clear()
 
 

--- a/scripts/test/CalculateMuonAsymmetryTest.py
+++ b/scripts/test/CalculateMuonAsymmetryTest.py
@@ -40,7 +40,7 @@ class SingleDomainDoublePulseFitTest(unittest.TestCase):
         # Check that the correct normalisation is found.
         self.assertAlmostEqual(values_column[0], N0, places=3)
         # Check that normalised data is correct
-        result, message = CompareWorkspaces('ws_to_normalise', 'ws_correctly_normalised', Tolerance=1e-10)
+        result, message = CompareWorkspaces('ws_to_normalise', 'ws_correctly_normalised', Tolerance=1e-6)
         self.assertTrue(result)
         
         AnalysisDataService.clear()

--- a/scripts/test/DoublePulseFitTest.py
+++ b/scripts/test/DoublePulseFitTest.py
@@ -154,5 +154,6 @@ class CompositeFunctionDoublePulseFitTest(unittest.TestCase):
         self.assertAlmostEqual(values_column[0], 0.22, places=3)
         self.assertAlmostEqual(values_column[2], 1.5, places=3)
 
+
 if __name__ == '__main__':
     unittest.main()

--- a/scripts/test/DoublePulseFitTest.py
+++ b/scripts/test/DoublePulseFitTest.py
@@ -105,5 +105,54 @@ class MultiDomainDoublePulseFitTest(unittest.TestCase):
         self.assertTrue(result)
 
 
+
+class CompositeFunctionDoublePulseFitTest(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        delta = 0.33
+        x = np.linspace(0.,15.,100)
+        x_offset = np.linspace(delta/2, 15. + delta/2, 100)
+        x_offset_neg = np.linspace(-delta/2, 15. - delta/2, 100)
+
+        testFunction = GausOsc(Frequency = 1.5, A=0.22)
+        y1 = testFunction(x_offset_neg)
+        y2 = testFunction(x_offset)
+        y = y1/2+y2/2 + 3.0
+        ws = CreateWorkspace(x,y)
+
+        convolution =  FunctionFactory.createCompositeFunction('Convolution')
+        innerFunction = FunctionFactory.createInitialized('name=GausOsc,A=0.2,Sigma=0.2,Frequency=1,Phi=0; name=FlatBackground, A0=5.0')
+        deltaFunctions = FunctionFactory.createInitialized('(name=DeltaFunction,Height=0.5,Centre={},ties=(Height=0.5,Centre={});name=DeltaFunction,Height=0.5,Centre={},ties=(Height=0.5,Centre={}))'.format(-delta/2, -delta/2, delta/2, delta/2))
+        convolution.setAttributeValue('FixResolution', False)
+        convolution.add(innerFunction)
+        convolution.add(deltaFunctions)
+
+        innerFunctionSingle = FunctionFactory.createInitialized('name=GausOsc,A=0.2,Sigma=0.2,Frequency=1,Phi=0; name=FlatBackground, A0=5.0')
+
+        DoublePulseFit(Function=innerFunctionSingle, InputWorkspace=ws, CreateOutput = True, PulseOffset = delta, StartX=0.0, EndX=15.0, Output='DoublePulseFit', MaxIterations=100)
+        Fit(Function=convolution, InputWorkspace=ws, CreateOutput = True, StartX=0.0, EndX=15.0, Output='Fit', MaxIterations=100)
+
+    @classmethod
+    def tearDownClass(cls):
+        AnalysisDataService.clear()
+
+    def test_that_simulated_output_data_is_the_same(self):
+        result, message = CompareWorkspaces('Fit_Workspace', 'DoublePulseFit_Workspace')
+        self.assertTrue(result)
+
+    def test_that_covariance_matricies_are_the_same(self):
+        result, message = CompareWorkspaces('Fit_NormalisedCovarianceMatrix', 'DoublePulseFit_NormalisedCovarianceMatrix')
+        self.assertTrue(result)
+
+    def test_that_output_parameters_are_the_same(self):
+        result, message = CompareWorkspaces('Fit_Parameters', 'DoublePulseFit_Parameters')
+        self.assertTrue(result)
+
+    def test_that_output_parameters_are_correct(self):
+        double_parameter_workspace = AnalysisDataService.retrieve('DoublePulseFit_Parameters')
+        values_column = double_parameter_workspace.column(1)
+        self.assertAlmostEqual(values_column[0], 0.22, places=3)
+        self.assertAlmostEqual(values_column[2], 1.5, places=3)
+
 if __name__ == '__main__':
     unittest.main()

--- a/scripts/test/Muon/fitting_tab_widget/fitting_tab_model_test.py
+++ b/scripts/test/Muon/fitting_tab_widget/fitting_tab_model_test.py
@@ -470,7 +470,7 @@ class FittingTabModelTest(unittest.TestCase):
         parameters = self.model.get_parameters_for_single_tf_fit(workspace_name)
 
         self.assertEquals(parameters['PulseOffset'], pulse_offset)
-        self.assertEquals(parameters['DoublePulseEnabled'], True)
+        self.assertEquals(parameters['EnableDoublePulse'], True)
         self.assertAlmostEquals(parameters['FirstPulseWeight'], 0.287, places=3)
 
     def test_that_single_fit_initialises_algorithm_with_correct_values_for_simultaneous_tf_asymmetry_double_pulse_mode(self):
@@ -482,7 +482,7 @@ class FittingTabModelTest(unittest.TestCase):
         parameters = self.model.get_parameters_for_simultaneous_tf_fit(workspace_name)
 
         self.assertEquals(parameters['PulseOffset'], pulse_offset)
-        self.assertEquals(parameters['DoublePulseEnabled'], True)
+        self.assertEquals(parameters['EnableDoublePulse'], True)
         self.assertAlmostEquals(parameters['FirstPulseWeight'], 0.287, places=3)
 
 

--- a/scripts/test/Muon/fitting_tab_widget/fitting_tab_model_test.py
+++ b/scripts/test/Muon/fitting_tab_widget/fitting_tab_model_test.py
@@ -472,7 +472,6 @@ class FittingTabModelTest(unittest.TestCase):
         self.assertEquals(parameters['PulseOffset'], pulse_offset)
         self.assertEquals(parameters['DoublePulseEnabled'], True)
         self.assertAlmostEquals(parameters['FirstPulseWeight'], 0.287, places=3)
-        self.assertAlmostEquals(parameters['SecondPulseWeight'], 0.713, places=3)
 
     def test_that_single_fit_initialises_algorithm_with_correct_values_for_simultaneous_tf_asymmetry_double_pulse_mode(self):
         workspace_name = 'MUSR62260; Group; fwd;'
@@ -485,7 +484,6 @@ class FittingTabModelTest(unittest.TestCase):
         self.assertEquals(parameters['PulseOffset'], pulse_offset)
         self.assertEquals(parameters['DoublePulseEnabled'], True)
         self.assertAlmostEquals(parameters['FirstPulseWeight'], 0.287, places=3)
-        self.assertAlmostEquals(parameters['SecondPulseWeight'], 0.713, places=3)
 
 
 if __name__ == '__main__':

--- a/scripts/test/Muon/fitting_tab_widget/fitting_tab_model_test.py
+++ b/scripts/test/Muon/fitting_tab_widget/fitting_tab_model_test.py
@@ -65,8 +65,8 @@ class FittingTabModelTest(unittest.TestCase):
         parameter_dict = {'Function': trial_function, 'InputWorkspace': workspace, 'Minimizer': 'Levenberg-Marquardt',
                           'StartX': 0.0, 'EndX': 100.0, 'EvaluationType': 'CentrePoint'}
 
-        output_workspace, parameter_table_name, fitting_function, fit_status, fit_chi_squared, covariance_matrix = self.model.do_single_fit_and_return_workspace_parameters_and_fit_function(
-            parameter_dict)
+        output_workspace, parameter_table_name, fitting_function, fit_status, fit_chi_squared, covariance_matrix = \
+            self.model.do_single_fit_and_return_workspace_parameters_and_fit_function(parameter_dict)
 
         parameter_table = AnalysisDataService.retrieve(parameter_table_name)
 
@@ -134,7 +134,7 @@ class FittingTabModelTest(unittest.TestCase):
         self.assertEqual(1, len(fit_context))
 
     def test_get_function_name_returns_correctly_for_composite_functions(self):
-        function_string = 'name=FlatBackground,A0=22.5129;name=Polynomial,n=0,A0=-22.5221;name=ExpDecayOsc,A=-0.172352,Lambda=0.111109,Frequency=-0.280031,Phi=-3.03983'
+        function_string = 'name=FlatBackground,A0=22.5129;name=Polynomial,n=0,A0=-22.5221;name=ExpDecayOsc,A=-0.172352,Lambda=0.111109, Frequency=-0.280031,Phi=-3.03983'
         function_object = FunctionFactory.createInitialized(function_string)
 
         name_as_string = self.model.get_function_name(function_object)
@@ -454,12 +454,38 @@ class FittingTabModelTest(unittest.TestCase):
 
     def test_create_double_pulse_alg_initialses_algorithm_with_correct_values(self):
         self.model.context.gui_context['DoublePulseTime'] = 2.0
-        
+
         double_pulse_alg = self.model._create_double_pulse_alg()
 
         self.assertEquals(double_pulse_alg.getProperty("PulseOffset").value, 2.0)
         self.assertAlmostEquals(double_pulse_alg.getProperty("FirstPulseWeight").value, 0.287, places=3)
         self.assertAlmostEquals(double_pulse_alg.getProperty("SecondPulseWeight").value, 0.713, places=3)
+
+    def test_that_single_fit_initialises_algorithm_with_correct_values_for_tf_asymmetry_double_pulse_mode(self):
+        workspace_name = 'MUSR62260; Group; fwd;'
+        pulse_offset = 2.0
+        self.model.context.gui_context['DoublePulseTime'] = pulse_offset
+        self.model.context.gui_context['DoublePulseEnabled'] = True
+
+        parameters = self.model.get_parameters_for_single_tf_fit(workspace_name)
+
+        self.assertEquals(parameters['PulseOffset'], pulse_offset)
+        self.assertEquals(parameters['DoublePulseEnabled'], True)
+        self.assertAlmostEquals(parameters['FirstPulseWeight'], 0.287, places=3)
+        self.assertAlmostEquals(parameters['SecondPulseWeight'], 0.713, places=3)
+
+    def test_that_single_fit_initialises_algorithm_with_correct_values_for_simultaneous_tf_asymmetry_double_pulse_mode(self):
+        workspace_name = 'MUSR62260; Group; fwd;'
+        pulse_offset = 2.0
+        self.model.context.gui_context['DoublePulseTime'] = pulse_offset
+        self.model.context.gui_context['DoublePulseEnabled'] = True
+
+        parameters = self.model.get_parameters_for_simultaneous_tf_fit(workspace_name)
+
+        self.assertEquals(parameters['PulseOffset'], pulse_offset)
+        self.assertEquals(parameters['DoublePulseEnabled'], True)
+        self.assertAlmostEquals(parameters['FirstPulseWeight'], 0.287, places=3)
+        self.assertAlmostEquals(parameters['SecondPulseWeight'], 0.713, places=3)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
**Description of work.**

This updates DoublePulseFit to allow composite functions to be used. It also updates CalculateMuonAsymmetry to allow double pulse fits to be performed in tf asymmetry mode.

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

**To test:**

The following script performs a DoublePulseFit and the equivalent normal fit against some artificial data. Check that the results match and that the script runs without issue
```
delta = 0.33
x = np.linspace(0.,15.,100)
x_offset = np.linspace(delta/2, 15. + delta/2, 100)
x_offset_neg = np.linspace(-delta/2, 15. - delta/2, 100)

testFunction = GausOsc(Frequency = 1.5, A=0.22)
y1 = testFunction(x_offset_neg)
y2 = testFunction(x_offset)
y = y1/2+y2/2 + 3.0
ws = CreateWorkspace(x,y)

convolution =  FunctionFactory.createCompositeFunction('Convolution')
innerFunction = FunctionFactory.createInitialized('name=GausOsc,A=0.2,Sigma=0.2,Frequency=1,Phi=0; name=FlatBackground, A0=5.0')
deltaFunctions = FunctionFactory.createInitialized('(name=DeltaFunction,Height=0.5,Centre={},ties=(Height=0.5,Centre={});name=DeltaFunction,Height=0.5,Centre={},ties=(Height=0.5,Centre={}))'.format(-delta/2, -delta/2, delta/2, delta/2))
convolution.setAttributeValue('FixResolution', False)
convolution.add(innerFunction)
convolution.add(deltaFunctions)

innerFunctionSingle = FunctionFactory.createInitialized('name=GausOsc,A=0.2,Sigma=0.2,Frequency=1,Phi=0; name=FlatBackground, A0=5.0')

DoublePulseFit(Function=innerFunctionSingle, InputWorkspace=ws, CreateOutput = True, PulseOffset = delta, StartX=0.0, EndX=15.0, Output='DoublePulseFit', MaxIterations=100)
Fit(Function=convolution, InputWorkspace=ws, CreateOutput = True, StartX=0.0, EndX=15.0, Output='Fit', MaxIterations=100)
```

This script performs a double pulse Fit in CalculateMuonAsymmetry
```
delta = 0.33
x = np.linspace(0.,15.,100)
x_offset = np.linspace(delta/2, 15. + delta/2, 100)
x_offset_neg = np.linspace(-delta/2, 15. - delta/2, 100)

testFunction = GausOsc(Frequency = 1.5, A=0.22)
y1 = testFunction(x_offset_neg)
y2 = testFunction(x_offset)
N0 = 6.38
y = N0 * (1 + y1/2+y2/2)
y_norm = y1/2+y2/2
unnormalised_workspace = CreateWorkspace(x,y)
ws_to_normalise = CreateWorkspace(x,y)
ws_correctly_normalised = CreateWorkspace(x,y_norm)
AddSampleLog(Workspace='ws_to_normalise', LogName="analysis_asymmetry_norm", LogText="1")

innerFunction = FunctionFactory.createInitialized('name=GausOsc,A=0.20,Sigma=0.2,Frequency=1.0,Phi=0')
tf_function = ConvertFitFunctionForMuonTFAsymmetry(InputFunction=innerFunction, WorkspaceList=['ws_to_normalise'])

CalculateMuonAsymmetry(MaxIterations=100, EnableDoublePulse=True, PulseOffset=delta, UnNormalizedWorkspaceList='unnormalised_workspace', ReNormalizedWorkspaceList='ws_to_normalise',
                               OutputFitWorkspace='DoublePulseFit', StartX=0, InputFunction=str(tf_function), Minimizer='Levenberg-Marquardt')
double_parameter_workspace = AnalysisDataService.retrieve('DoublePulseFit_Parameters')
values_column = double_parameter_workspace.column(1)
# Check that normalised data is correct
 result, message = CompareWorkspaces('ws_to_normalise', 'ws_correctly_normalised', Tolerance=1e-10)
        
```

Also check that the workflows work in the Muon Analysis GUI by:
  * Performing a fit of a GausOsc and a flat background in double pulse mode.
  * Performing a Double pulse fit in tf asymmetry mode.
<!-- Instructions for testing. -->


*There is no associated issue.*

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
-->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
