### PR TITLE
Add reverse reverse colourmap for sliceviewer

### DIFF
--- a/docs/source/release/v5.1.0/mantidworkbench.rst
+++ b/docs/source/release/v5.1.0/mantidworkbench.rst
@@ -83,6 +83,8 @@ Improvements
 - Added an option in the settings to specify the default legend size.
 - Added an option to the settings window to set the default colormap for image plots.
 - Improved loading of python plugins at startup on slow disks.
+- Sliceviewer no longer lists the reversed colourmaps along with the regular, instead they are accessed with a reverse checkbox.
+- Sliceviewer colourmap uses the default colourmap from the settings.
 
 Bugfixes
 ########


### PR DESCRIPTION
**Description of work.**

This PR adds a checkbox to sliceviewer that reverses the colourmap. because of this it also removes the _r reverse maps form the combo box.

**To test:**

1. In workbench load some data and show slice viewer
2. check the dropdown menu, there should be no options ending in `_r`
3. check that changing the option changes the colourmap
4. change that ticking the reverse box reverses the coloumap
5. in setting->plots change the default colourmap and check that sliceviewer uses that default.

re: #28915 


---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
