### PR TITLE
Minor dgsplanner fixes

### DIFF
--- a/Framework/MDAlgorithms/src/MDNorm.cpp
+++ b/Framework/MDAlgorithms/src/MDNorm.cpp
@@ -1029,6 +1029,8 @@ DataObjects::MDHistoWorkspace_sptr MDNorm::binInputWS(
     // set the temporary workspace to be the output workspace, so it keeps
     // adding different symmetries
     tempDataWS = std::dynamic_pointer_cast<MDHistoWorkspace>(outputWS);
+    tempDataWS->clearOriginalWorkspaces();
+    tempDataWS->clearTransforms();
     soIndex += 1;
   }
 

--- a/scripts/DGSPlanner/DimensionSelectorWidget.py
+++ b/scripts/DGSPlanner/DimensionSelectorWidget.py
@@ -255,11 +255,14 @@ class DimensionSelectorWidget(QtWidgets.QWidget):
                 self.dimMax[senderIndex]=numpy.inf
                 color = '#ffffff'
             else:
-                tempvalue=float(sender.text())
-                self.dimMax[senderIndex]=tempvalue
-                if tempvalue>self.dimMin[senderIndex]:
-                    color = '#ffffff'
-                else:
+                try:
+                    tempvalue=float(sender.text())
+                    self.dimMax[senderIndex]=tempvalue
+                    if tempvalue>self.dimMin[senderIndex]:
+                        color = '#ffffff'
+                    else:
+                        color = '#ff0000'
+                except ValueError:
                     color = '#ff0000'
         minSenders[senderIndex].setStyleSheet('QLineEdit { background-color: %s }' % color)
         maxSenders[senderIndex].setStyleSheet('QLineEdit { background-color: %s }' % color)


### PR DESCRIPTION
**Description of work.**
Fixed 2 minor issues found in testing

**To test:**
1. Start DGSPlanner interface (in Direct). At the bottom of the window, start by putting a minus sign in one of the boxes in the Max column. The box should turn red, but there should be no error message
2. Run the script in the issue. Open the slice viewer. The axis should be HKL not Q_lab

@martyngigg One should not go back to the original workspace by default when looking at MDHisto in sliceviewer. Try to do a non-axis aligned binning (the the example in the BinMD help)

Fixes #28988

*This does not require release notes* because 
- DGSplanner is minor issue
- Slice viewer issue was introduced in this release
---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
