### PR TITLE
Use UNIX epoch instead of throwing error if offset attribute is not found in nexus file

### DIFF
--- a/Framework/DataHandling/src/LoadEventNexus.cpp
+++ b/Framework/DataHandling/src/LoadEventNexus.cpp
@@ -450,6 +450,8 @@ firstLastPulseTimes(::NeXus::File &file, Kernel::Logger &logger) {
   // Unix epoch (https://manual.nexusformat.org/classes/base_classes/NXlog.html)
   if (!file.hasAttr("offset")) {
     offset = DateAndTime("1970-01-01T00:00:00Z");
+    logger.warning("event_time_zero: no ISO8601 offset attribute provided, "
+                   "Using UNIX epoch instead");
   } else {
     file.getAttr("offset", isooffset);
     offset = DateAndTime(isooffset);


### PR DESCRIPTION
**Description of work.**

According to the Nexus standard, when dealing with `NXlog`, if the `start` attribute is not present, it is assumed that the reference is the Unix epoch.
> Time of logged entry. The times are relative to the “start” attribute and in the units specified in the “units” attribute. Please note that absolute timestamps under unix are relative to 1970-01-01T:00:00.
(https://manual.nexusformat.org/classes/base_classes/NXlog.html)

The equivalent for `NXevent_data` is `offset`, and we propose that if the `offset` attribute for `event_time_zero` is not present, it should also imply the offset is and absolute timestamp, which is relative to the start of Unix epoch.

Hence, if `offset` is not found in the `event_time_zero` attributes, we use UNIX epoch instead, and log a warning.
This is required to be able to load files written by the ESS file writer.

**To test:**

- Generate a file using https://github.com/ess-dmsc/generate-nexus-files (e.g. the [WISH_example.py](https://github.com/ess-dmsc/generate-nexus-files/blob/master/examples/wish/WISH_example.py))
- Try to load the file with:
```Py
import mantid.simpleapi as mantid
ws = mantid.LoadEventNexus(Filename='WISH_example.nxs')
```

Without the changes, it fails with
```
LoadInstrument-[Debug] LoadInstrument finished with isChild = 1
LoadEventNexus-[Error] Error in execution of algorithm LoadEventNexus:
LoadEventNexus-[Error] No ISO8601 offset attribute provided
Traceback (most recent call last):
  File "load_nexus_file.py", line 7, in <module>
    ws = mantid.LoadEventNexus(Filename='WISH_example.nxs')
  File "/home/nvaytet/work/code/mantid/install/lib/mantid/simpleapi.py", line 1136, in algorithm_wrapper
    algm.execute()
RuntimeError: No ISO8601 offset attribute provided
```

*There is no associated issue.*

*This does not require release notes* because it is a very low-level minor change.

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
