### PR TITLE
Suppress C++17 deprecation warnings on inheriting std::iterator

### DIFF
--- a/buildconfig/CMake/MSVCSetup.cmake
+++ b/buildconfig/CMake/MSVCSetup.cmake
@@ -18,6 +18,9 @@ add_definitions(-D_SCL_SECURE_NO_WARNINGS -D_CRT_SECURE_NO_WARNINGS)
 # Prevent deprecation errors from std::tr1 in googletest until it is fixed
 # upstream. In MSVC 2017 and later
 add_definitions(-D_SILENCE_TR1_NAMESPACE_DEPRECATION_WARNING)
+# Suppress warnings about std::iterator as a base. TBB emits this warning
+# and it is not yet fixed.
+add_definitions(-D_SILENCE_CXX17_ITERATOR_BASE_CLASS_DEPRECATION_WARNING)
 
 # ##############################################################################
 # Additional compiler flags

--- a/qt/applications/workbench/CMakeLists.txt
+++ b/qt/applications/workbench/CMakeLists.txt
@@ -5,8 +5,12 @@ if(WIN32)
 else()
   set(_exclude_on_install "")
 endif()
+# egg link name has to match setup.py name or Visual Studio generates
+# a warning that the output filename of the target does not match
+# the output that is produced by setuptools
 add_python_package(workbench
   EXECUTABLE
+  EGGLINKNAME MantidWorkbench
   EXCLUDE_FROM_INSTALL ${_exclude_on_install}
   INSTALL_LIB_DIRS "${WORKBENCH_LIB_DIR}"
   INSTALL_BIN_DIR "${WORKBENCH_BIN_DIR}"


### PR DESCRIPTION
**Description of work.**

A recent change started to run into an internal compiler error on Visual Studio. Upgrading the compiler solves the problem but the latest version produces many warnings like:

```
C:\Jenkins\workspace\pull_requests-windows\external\src\ThirdParty\include\tbb\internal/_concurrent_unordered_impl.h(67,36): warning C4996: 'std::iterator<std::forward_iterator_tag,Value,ptrdiff_t,Value *,Value &>': warning STL4015: The std::iterator class template (used as a base class to provide typedefs) is deprecated in C++17. (The <iterator> header is NOT deprecated.) The C++ Standard has never required user-defined iterators to derive from std::iterator. To fix this warning, stop deriving from std::iterator and start providing publicly accessible typedefs named iterator_category, value_type, difference_type, pointer, and reference. Note that value_type is required to be non-const, even for constant iterators. You can define _SILENCE_CXX17_ITERATOR_BASE_CLASS_DEPRECATION_WARNING or _SILENCE_ALL_CXX17_DEPRECATION_WARNINGS to acknowledge that you have received this warning. [C:\Jenkins\workspace\pull_requests-windows\build\Framework\API\API.vcxproj]
          with
          [
              Value=std::pair<const Mantid::Geometry::ComponentID ,std::shared_ptr<Mantid::Geometry::Parameter>>
          ]
```

This issue suppresses the warnings.

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

**To test:**

* Code review.
* Windows build should have no warnings
* If you want to test locally then upgrade Visual Studio to the latest version then
* Build the clean build the API project.


*This does not require release notes* because **it is an internal change.**

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
