### PR TITLE
Fix deprecation warning

### DIFF
--- a/scripts/SANS/sans/algorithm_detail/mask_functions.py
+++ b/scripts/SANS/sans/algorithm_detail/mask_functions.py
@@ -4,7 +4,8 @@
 #   NScD Oak Ridge National Laboratory, European Spallation Source,
 #   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
 # SPDX - License - Identifier: GPL - 3.0 +
-from collections import (namedtuple, Sequence)
+from collections import namedtuple
+from collections.abc import Sequence
 
 from enum import Enum
 from sans.common.enums import (DetectorType, SANSInstrument)


### PR DESCRIPTION
```
/home/andrei/Mantid/mantid/scripts/SANS/sans/algorithm_detail/mask_functions.py:7: DeprecationWarning: Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated since Python 3.3, and in 3.9 it will stop working
  from collections import (namedtuple, Sequence)
```
*There is no associated issue.*

*This does not require release notes* because **minor import path change**

