### PR TITLE
Fix doctests/packaging for Python 3.8

### DIFF
--- a/docs/source/algorithms/Pause-v1.rst
+++ b/docs/source/algorithms/Pause-v1.rst
@@ -25,9 +25,9 @@ Usage
 
    import time
 	
-   start_time = time.clock()
+   start_time = time.time()
    Pause(0.05)
-   end_time = time.clock()
+   end_time = time.time()
    print("The algorithm paused for {:.2f} seconds.".format(end_time-start_time))
 	
 Output:

--- a/docs/source/algorithms/StripVanadiumPeaks-v2.rst
+++ b/docs/source/algorithms/StripVanadiumPeaks-v2.rst
@@ -36,8 +36,9 @@ Usage
 Output:
 
 .. testoutput:: ExStripPeak
+   :options: +ELLIPSIS
 
-    This peak at 0.8116 Angstroms has been reduced from 11569 to a background level of 10845
+   This peak at ... Angstroms has been reduced from ... to a background level of ...
 
 .. categories::
 

--- a/installers/MacInstaller/make_package.rb
+++ b/installers/MacInstaller/make_package.rb
@@ -19,10 +19,14 @@ AT_RPATH_TAG = '@rpath'
 # Collection modules to copy from system installation
 # Required to install other packages with pip
 BUNDLED_PY_MODULES_COMMON = [
+  'easy_install.py',
   'pip',
+  'pip*.egg-info',
   'pkg_resources',
   'setuptools',
-  'wheel'
+  'setuptools*.egg-info',
+  'wheel',
+  'wheel*.egg-info'
 ]
 # Brew Python packages to be copied to bundle
 BUNDLED_PY_MODULES_MANTIDPLOT = [
@@ -129,7 +133,7 @@ def deploy_python_framework(destination, host_python_exe,
   bundle_py_home = bundle_python_framework + "Versions/#{py_ver}"
   deployable_assets = [
     'Python', "bin/python#{py_ver}", "bin/2to3-#{py_ver}",
-    "lib/python#{py_ver}", 'Resources'
+    "include/python#{py_ver}", "lib/python#{py_ver}", 'Resources'
   ]
 
   deployable_assets.each do |asset|
@@ -596,7 +600,6 @@ end
 # into the bundle and the main layout exists.
 bundle_py_site_packages = deploy_python_framework(contents_frameworks, host_python_exe,
                                                   bundled_packages, requirements_files)
-exit(0)
 if $PARAVIEW_BUILD_DIR.start_with?('/')
   pv_lib_dir = Pathname.new($PARAVIEW_BUILD_DIR) + 'lib'
   # add bare VTK/ParaView so libraries


### PR DESCRIPTION
**Description of work.**

macOS now has Python 3.8 and a couple of doctests are now failing on this version. This fixes those problems. See commit messages for more detail.

Also fixes an issue with the packaging if a cached wheel is not available.

**To test:**

* Code review.
* Build the package and check it builds successfully.

*There is no associated issue.*

*This does not require release notes* because **it is an internal change.**

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
