### PR TITLE
Reset peak HKL if outside tolerance in IndexPeaks

### DIFF
--- a/Framework/Crystal/src/IndexPeaks.cpp
+++ b/Framework/Crystal/src/IndexPeaks.cpp
@@ -299,6 +299,10 @@ indexPeaks(const std::vector<Peak *> &peaks, DblMatrix ub,
         stats.satellites.numIndexed++;
         stats.satellites.error += std::get<2>(satelliteInfo) / 3.;
       }
+    } else {
+      peak->setHKL(V3D(0, 0, 0));
+      peak->setIntHKL(V3D(0, 0, 0));
+      peak->setIntMNP(V3D(0, 0, 0));
     }
   }
   return stats;

--- a/Framework/Crystal/test/IndexPeaksTest.h
+++ b/Framework/Crystal/test/IndexPeaksTest.h
@@ -182,6 +182,38 @@ public:
     TS_ASSERT_DELTA(error.norm(), 0.0, 2e-4)
   }
 
+    void test_tolerance_main_refl() {
+    const auto ws = createTestPeaksWorkspaceMainReflOnly();
+    auto alg = indexPeaks(ws, {{"Tolerance", "0.02"}, {"RoundHKLs", "0"}});
+
+    // Check the output properties
+    assertNumberPeaksIndexed(*alg, 3, 3, 0);
+
+    // spot check a few peaks for
+    // fractional Miller indices
+    const V3D peak_0_hkl_d(0.0, 0.0, 0.0); // first peak
+    const V3D peak_1_hkl_d(3, -1, 4);
+    const V3D peak_2_hkl_d(4, -1, 5);
+    const V3D peak_3_hkl_d(3, -0, 7);
+    const V3D peak_4_hkl_d(0.0, 0.0, 0.0); // last peak
+
+    const auto &peaks = ws->getPeaks();
+    V3D error = peak_0_hkl_d - peaks[0].getHKL();
+    TS_ASSERT_DELTA(error.norm(), 0.0, 2e-4)
+
+    error = peak_1_hkl_d - peaks[1].getHKL();
+    TS_ASSERT_DELTA(error.norm(), 0.0, 1e-4)
+
+    error = peak_2_hkl_d - peaks[2].getHKL();
+    TS_ASSERT_DELTA(error.norm(), 0.0, 1e-4)
+
+    error = peak_3_hkl_d - peaks[3].getHKL();
+    TS_ASSERT_DELTA(error.norm(), 0.0, 1e-4)
+
+    error = peak_4_hkl_d - peaks[4].getHKL();
+    TS_ASSERT_DELTA(error.norm(), 0.0, 2e-4)
+  }
+
   void test_no_roundHKLS_leaves_peaks_as_found() {
     const auto ws = createTestPeaksWorkspaceMainReflOnly();
     auto alg = indexPeaks(ws, {{"Tolerance", "0.1"}, {"RoundHKLs", "0"}});

--- a/Framework/Crystal/test/IndexPeaksTest.h
+++ b/Framework/Crystal/test/IndexPeaksTest.h
@@ -182,7 +182,7 @@ public:
     TS_ASSERT_DELTA(error.norm(), 0.0, 2e-4)
   }
 
-    void test_tolerance_main_refl() {
+  void test_tolerance_main_refl() {
     const auto ws = createTestPeaksWorkspaceMainReflOnly();
     auto alg = indexPeaks(ws, {{"Tolerance", "0.02"}, {"RoundHKLs", "0"}});
 


### PR DESCRIPTION
**Description of work.**
 Small fix to set HKL to 0,0,0 if index not within tolerance in IndexPeaks (see description of original issue)


**To test:**
Follow script in original issue - having run IndexPeaks with a large tolerance, re-running with a smaller tolerance should set the indicated peaks to have index 0,0,0

Fixes #29008
<!-- alternative
*There is no associated issue.*
-->


*This does not require release notes* because **it is a small bug fix**


---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
