### PR TITLE
Delay Initialization of Code Editor Algorithm Tooltips

### DIFF
--- a/Framework/PythonInterface/mantid/api/src/Exports/IAlgorithm.cpp
+++ b/Framework/PythonInterface/mantid/api/src/Exports/IAlgorithm.cpp
@@ -362,8 +362,6 @@ boost::python::dict validateInputs(IAlgorithm &self) {
 }
 
 void initializeProxy(IAlgorithm &self) {
-  // Release the GIL to stop workbench freezing while initializing the
-  // algorithms.
   Mantid::PythonInterface::ReleaseGlobalInterpreterLock
       releaseGlobalInterpreterLock;
   self.initialize();

--- a/Framework/PythonInterface/mantid/api/src/Exports/IAlgorithm.cpp
+++ b/Framework/PythonInterface/mantid/api/src/Exports/IAlgorithm.cpp
@@ -362,8 +362,10 @@ boost::python::dict validateInputs(IAlgorithm &self) {
 }
 
 void initializeProxy(IAlgorithm &self) {
-  // Release the GIL to stop workbench freezing while initializing the algorithms.
-  Mantid::PythonInterface::ReleaseGlobalInterpreterLock releaseGlobalInterpreterLock;
+  // Release the GIL to stop workbench freezing while initializing the
+  // algorithms.
+  Mantid::PythonInterface::ReleaseGlobalInterpreterLock
+      releaseGlobalInterpreterLock;
   self.initialize();
 }
 

--- a/docs/source/release/v5.1.0/mantidworkbench.rst
+++ b/docs/source/release/v5.1.0/mantidworkbench.rst
@@ -86,6 +86,7 @@ Improvements
 - Improved loading of python plugins at startup on slow disks.
 - Sliceviewer no longer lists the reversed colourmaps along with the regular, instead they are accessed with a reverse checkbox.
 - Sliceviewer colourmap uses the default colourmap from the settings.
+- Code completions are now loaded when the code editor is first changed.
 
 Bugfixes
 ########

--- a/qt/python/mantidqt/widgets/codeeditor/completion.py
+++ b/qt/python/mantidqt/widgets/codeeditor/completion.py
@@ -39,6 +39,7 @@ from io import BytesIO
 
 from inspect import getfullargspec
 
+from mantidqt.utils.asynchronous import AsyncTask
 from mantidqt.widgets.codeeditor.editor import CodeEditor
 
 ArgSpec = namedtuple("ArgSpec", "args varargs keywords defaults")
@@ -226,13 +227,13 @@ class CodeCompleter(object):
     are updated on every successful script execution.
     """
     def __init__(self, editor, env_globals=None):
+        self.simpleapi_in_completions = False
         self.editor = editor
         self.env_globals = env_globals
+        self.worker = None
 
         # A dict gives O(1) lookups and ensures we have no duplicates
         self._completions_dict = dict()
-        if "from mantid.simpleapi import *" in self.editor.text():
-            self._add_to_completions(self._get_module_call_tips('mantid.simpleapi'))
         if re.search("^#{0}import .*numpy( |,|$)", self.editor.text(), re.MULTILINE):
             self._add_to_completions(self._get_module_call_tips('numpy'))
         if re.search("^#{0}import .*pyplot( |,|$)", self.editor.text(), re.MULTILINE):
@@ -258,6 +259,19 @@ class CodeCompleter(object):
         with _ignore_matplotlib_deprecation_warnings():
             self._add_to_completions(self._get_completions_from_globals())
         self.editor.updateCompletionAPI(self.completions)
+
+    def add_simpleapi_to_completions_if_required(self):
+        """
+        If the simpleapi functions haven't been added to the completions, start a separate thread to load them in.
+        """
+        if not self.simpleapi_in_completions and "from mantid.simpleapi import *" in self.editor.text():
+            self.simpleapi_in_completions = True
+            self.worker = AsyncTask(self._add_simpleapi_to_completions_if_required)
+            self.worker.start()
+
+    def _add_simpleapi_to_completions_if_required(self):
+        self._add_to_completions(self._get_module_call_tips('mantid.simpleapi'))
+        self.update_completion_api()
 
     def _get_module_call_tips(self, module):
         """

--- a/qt/python/mantidqt/widgets/codeeditor/interpreter.py
+++ b/qt/python/mantidqt/widgets/codeeditor/interpreter.py
@@ -150,6 +150,9 @@ class PythonFileInterpreter(QWidget):
         # Re-populate the completion API after execution success
         self._presenter.model.sig_exec_success.connect(self.code_completer.update_completion_api)
 
+        # Only load the simpleapi completions if the code editor starts being modified.
+        self.sig_editor_modified.connect(self.code_completer.add_simpleapi_to_completions_if_required)
+
     def closeEvent(self, event):
         self.deleteLater()
         if self.find_replace_dialog:

--- a/qt/python/mantidqt/widgets/codeeditor/test/test_completion.py
+++ b/qt/python/mantidqt/widgets/codeeditor/test/test_completion.py
@@ -26,8 +26,9 @@ class CodeCompletionTest(unittest.TestCase):
     def _run_check_call_tip_generated(self, script_text, call_tip_regex):
         completer = self._get_completer(script_text)
         update_completion_api_mock = completer.editor.updateCompletionAPI
-        call_tips = update_completion_api_mock.call_args_list[0][0][0]
-        self.assertEqual(1, update_completion_api_mock.call_count)
+        completer._add_simpleapi_to_completions_if_required()
+        call_tips = update_completion_api_mock.call_args_list[1][0][0]
+        self.assertEqual(2, update_completion_api_mock.call_count)
         self.assertGreater(len(call_tips), 1)
         self.assertTrue(re.search(call_tip_regex, ' '.join(call_tips)))
 


### PR DESCRIPTION
**Description of work.**
Originally, all of the python algorithms would be initialized on startup so that the editor tooltips would show the correct signature. 
Now the signatures are only loaded when the user starts typing in the code editor. This should reduce the amount of time waiting at the splash screen for Workbench to start. 

**To test:**
1. Start Workbench
2. Start typing into the code editor (if the log is set to debug mode you should see some output)
3. Typing something like `rebin(` should bring up a tooltip showing the signature for the algorithm. 

Fixes #29002 

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
