### PR TITLE
Output convolved members by default in ConvFit

### DIFF
--- a/docs/source/release/v5.1.0/indirect_geometry.rst
+++ b/docs/source/release/v5.1.0/indirect_geometry.rst
@@ -35,6 +35,7 @@ Improvements
 - Added the fit output information (Algorithm status and Chi squared) to each fitting tab of the Indirect Data Analysis interface.
   This change introduces two optional outputs from the QENSFit algorithms (fit status and Chi squared), which may be used to monitor the outcome of the fit.
 - Added default parameter estimations to the F(q) tab.
+- The ConvFit tab within the IDA GUI will now output convolved members by default.
 
 Bug Fixes
 #########

--- a/qt/scientific_interfaces/Indirect/IndirectFitAnalysisTab.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectFitAnalysisTab.cpp
@@ -355,6 +355,9 @@ void IndirectFitAnalysisTab::endXChanged(double endX) {
  */
 void IndirectFitAnalysisTab::setConvolveMembers(bool convolveMembers) {
   m_fitPropertyBrowser->setConvolveMembers(convolveMembers);
+  // if convolve members is on, output members should also be on
+  if (convolveMembers)
+    m_fitPropertyBrowser->setOutputCompositeMembers(true);
 }
 
 void IndirectFitAnalysisTab::updateFitOutput(bool error) {

--- a/qt/scientific_interfaces/Indirect/IndirectFitPropertyBrowser.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectFitPropertyBrowser.cpp
@@ -327,9 +327,22 @@ QString IndirectFitPropertyBrowser::selectedFitType() const {
 /**
  * Sets whether fit members should be convolved with the resolution after a fit.
  *
- * @param convolveMembers If true, members are to be convolved.
+ * @param convolveEnabled: If true, members are to be convolved.
  */
-void IndirectFitPropertyBrowser::setConvolveMembers(bool) {}
+void IndirectFitPropertyBrowser::setConvolveMembers(bool convolveEnabled) {
+  m_fitOptionsBrowser->setProperty("ConvolveMembers",
+                                   QString(convolveEnabled ? "1" : "0"));
+}
+
+/**
+ * Sets whether to output fit members
+ *
+ * @param outputEnabled: If true, fit members are outputted
+ */
+void IndirectFitPropertyBrowser::setOutputCompositeMembers(bool outputEnabled) {
+  m_fitOptionsBrowser->setProperty("OutputCompositeMembers",
+                                   QString(outputEnabled ? "1" : "0"));
+}
 
 /**
  * Clears the functions in this indirect fit property browser.

--- a/qt/scientific_interfaces/Indirect/IndirectFitPropertyBrowser.h
+++ b/qt/scientific_interfaces/Indirect/IndirectFitPropertyBrowser.h
@@ -63,7 +63,8 @@ public:
                            const std::vector<double> &chiSquared);
   void updateFitStatus(const FitDomainIndex index);
   QString selectedFitType() const;
-  void setConvolveMembers(bool convolveMembers);
+  void setConvolveMembers(bool convolveEnabled);
+  void setOutputCompositeMembers(bool outputEnabled);
   void setFitEnabled(bool enable);
   void setCurrentDataset(FitDomainIndex i);
   FitDomainIndex currentDataset() const;


### PR DESCRIPTION
**Description of work.**
This PR makes the ConvFit tab output the convolved fit members by default.

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** ISIS/Spencer
-->

**To test:**

- Data to test each tab of the Indirect Data Analysis GUI can be found in #26631.
- Open the Indirect Data Analysis GUI
- Go to the ConvFit tab
- Load in data and a resolution file
- At the bototm of the fit browser the Convolve members checkbox should be ticked
- Run a fit (e.g two Lorentzians)
- Go to the Conv_seq_2L workspace group in the ADS
- Each workspace in that group should have 5 spectra (3 for the fit and one for each convolved member (each Lorentzian))
<!-- Instructions for testing. -->

This PR is part of the IDA minor fixes issue #28484


<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
-->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
