### PR TITLE
Unit tests ununtu 20 04

### DIFF
--- a/scripts/test/MultiPlotting/CMakeLists.txt
+++ b/scripts/test/MultiPlotting/CMakeLists.txt
@@ -16,6 +16,12 @@ set(TEST_PY_FILES
 check_tests_valid(${CMAKE_CURRENT_SOURCE_DIR} ${TEST_PY_FILES})
 
 # Prefix for test name=PythonAlgorithms
-set(PYUNITTEST_QT_API pyqt) # force to use qt4
-pyunittest_add_test(${CMAKE_CURRENT_SOURCE_DIR} python.MuonQt4 ${TEST_PY_FILES})
+if(ENABLE_MANTIDPLOT)
+    set(PYUNITTEST_QT_API pyqt) # force to use qt4
+    pyunittest_add_test(${CMAKE_CURRENT_SOURCE_DIR} python.MuonQt4 ${TEST_PY_FILES})
+    unset(PYUNITTEST_QT_API)
+endif()
+
+set(PYUNITTEST_QT_API pyqt5) # force to use qt5
+pyunittest_add_test(${CMAKE_CURRENT_SOURCE_DIR} python.MuonQt5 ${TEST_PY_FILES})
 unset(PYUNITTEST_QT_API)

--- a/scripts/test/Muon/CMakeLists.txt
+++ b/scripts/test/Muon/CMakeLists.txt
@@ -136,9 +136,11 @@ set ( TEST_PY_FILES_QT4
 check_tests_valid(${CMAKE_CURRENT_SOURCE_DIR} ${TEST_PY_FILES})
 
 # Prefix for test name=PythonAlgorithms
-set(PYUNITTEST_QT_API pyqt) # force to use qt4
-pyunittest_add_test(${CMAKE_CURRENT_SOURCE_DIR} python.MuonQt4
-${TEST_PY_FILES_QT4} ${})
+if(ENABLE_MANTIDPLOT)
+    set(PYUNITTEST_QT_API pyqt) # force to use qt4
+    pyunittest_add_test(${CMAKE_CURRENT_SOURCE_DIR} python.MuonQt4
+    ${TEST_PY_FILES_QT4} ${})
+endif()
 
 set(PYUNITTEST_QT_API pyqt5) # force to use qt5
 pyunittest_add_test(${CMAKE_CURRENT_SOURCE_DIR} python.MuonQt5

--- a/scripts/test/Muon/CMakeLists.txt
+++ b/scripts/test/Muon/CMakeLists.txt
@@ -135,9 +135,11 @@ set ( TEST_PY_FILES_QT4
 check_tests_valid(${CMAKE_CURRENT_SOURCE_DIR} ${TEST_PY_FILES})
 
 # Prefix for test name=PythonAlgorithms
-set(PYUNITTEST_QT_API pyqt) # force to use qt4
-pyunittest_add_test(${CMAKE_CURRENT_SOURCE_DIR} python.MuonQt4
-${TEST_PY_FILES_QT4} ${})
+if(ENABLE_MANTIDPLOT)
+    set(PYUNITTEST_QT_API pyqt) # force to use qt4
+    pyunittest_add_test(${CMAKE_CURRENT_SOURCE_DIR} python.MuonQt4
+    ${TEST_PY_FILES_QT4} ${})
+endif()
 
 set(PYUNITTEST_QT_API pyqt5) # force to use qt5
 pyunittest_add_test(${CMAKE_CURRENT_SOURCE_DIR} python.MuonQt5

--- a/scripts/test/SANS/gui_logic/CMakeLists.txt
+++ b/scripts/test/SANS/gui_logic/CMakeLists.txt
@@ -24,10 +24,11 @@ set(TEST_PY_FILES
     save_other_presenter_test.py)
 
 check_tests_valid(${CMAKE_CURRENT_SOURCE_DIR} ${TEST_PY_FILES})
-
-set(PYUNITTEST_QT_API pyqt) # force to use qt4
-pyunittest_add_test(${CMAKE_CURRENT_SOURCE_DIR} PythonSANSQt4 ${TEST_PY_FILES})
-unset(PYUNITTEST_QT_API)
+if(ENABLE_MANTIDPLOT)
+    set(PYUNITTEST_QT_API pyqt) # force to use qt4
+    pyunittest_add_test(${CMAKE_CURRENT_SOURCE_DIR} PythonSANSQt4 ${TEST_PY_FILES})
+    unset(PYUNITTEST_QT_API)
+endif()
 
 set(PYUNITTEST_QT_API pyqt5)
 pyunittest_add_test(${CMAKE_CURRENT_SOURCE_DIR} PythonSANSQt5 ${TEST_PY_FILES})

--- a/scripts/test/SANS/gui_logic/model_tests/CMakeLists.txt
+++ b/scripts/test/SANS/gui_logic/model_tests/CMakeLists.txt
@@ -4,9 +4,11 @@ set(TEST_PY_FILES
 
 check_tests_valid(${CMAKE_CURRENT_SOURCE_DIR} ${TEST_PY_FILES})
 
-set(PYUNITTEST_QT_API pyqt) # force to use qt4
-pyunittest_add_test(${CMAKE_CURRENT_SOURCE_DIR} PythonSANSQt4 ${TEST_PY_FILES})
-unset(PYUNITTEST_QT_API)
+if(ENABLE_MANTIDPLOT)
+    set(PYUNITTEST_QT_API pyqt) # force to use qt4
+    pyunittest_add_test(${CMAKE_CURRENT_SOURCE_DIR} PythonSANSQt4 ${TEST_PY_FILES})
+    unset(PYUNITTEST_QT_API)
+endif()
 
 set(PYUNITTEST_QT_API pyqt5)
 pyunittest_add_test(${CMAKE_CURRENT_SOURCE_DIR} PythonSANSQt5 ${TEST_PY_FILES})


### PR DESCRIPTION
**Description of work.**

Disabled testing Qt4 when ManatidPlot is not enabled. When running on Ubuntu 20.04, I've got the following results

Tests failing on master
```
96% tests passed, 95 tests failed out of 2340

Total Test time (real) = 1970.10 sec

The following tests FAILED:
	593 - python.plots.plots__init__Test.plots__init__Test (Failed)
	597 - python.plots.surfacecontourplotsTest.surfacecontourplotsTest (Failed)
	1850 - MantidQtWidgetsCommonTestQt5_FindFilesThreadPoolManagerTest (Failed)
	1851 - MantidQtWidgetsCommonTestQt5_FindFilesWorkerTest (Failed)
	1868 - MantidQtWidgetsCommonTestQt5_SipTest (Failed)
	1921 - mantidqt_qt5.test_execution.test_execution (Failed)
	1926 - mantidqt_qt5.test_multifileinterpreter_view.test_multifileinterpreter_view (Failed)
	1928 - mantidqt_qt5.test_codeeditor_tab_view.test_codeeditor_tab_view (Failed)
	1931 - mantidqt_qt5.test_instrumentview_view.test_instrumentview_view (Failed)
	1939 - mantidqt_qt5.test_samplelogs_view.test_samplelogs_view (Failed)
	1963 - mantidqt_qt5.test_matrixworkspacedisplay_view.test_matrixworkspacedisplay_view (Failed)
	1970 - mantidqt_qt5.test_tableworkspacedisplay_view.test_tableworkspacedisplay_view (Failed)
	2029 - workbench.test_settings_view.test_settings_view (Failed)
	2057 - python.scripts.pythonTSVTest.pythonTSVTest (Failed)
	2067 - python.scripts.StitchingTest.StitchingTest (Failed)
	2094 - python.MuonQt4.AxisChangerTwoPresenter_test.AxisChangerTwoPresenter_test (Failed)
	2095 - python.MuonQt4.AxisChangerTwoView_test.AxisChangerTwoView_test (Failed)
	2096 - python.MuonQt4.QuickEditPresenter_test.QuickEditPresenter_test (Failed)
	2097 - python.MuonQt4.QuickEditWidget_test.QuickEditWidget_test (Failed)
	2099 - python.MuonQt4.MultiPlotWidget_test.MultiPlotWidget_test (Failed)
	2101 - python.MuonQt4.Subplot_test.Subplot_test (Failed)
	2105 - python.MuonQt4.LoadWidgetPresenter_test.LoadWidgetPresenter_test (Failed)
	2106 - python.MuonQt4.LoadWidgetView_test.LoadWidgetView_test (Failed)
	2107 - python.MuonQt4.FFTPresenter_test.FFTPresenter_test (Failed)
	2108 - python.MuonQt4.fft_presenter_context_interaction_test.fft_presenter_context_interaction_test (Failed)
	2110 - python.MuonQt4.workspace_selector_dialog_presenter_test.workspace_selector_dialog_presenter_test (Failed)
	2111 - python.MuonQt4.fitting_tab_presenter_test.fitting_tab_presenter_test (Failed)
	2112 - python.MuonQt4.fitting_tab_model_test.fitting_tab_model_test (Failed)
	2113 - python.MuonQt4.seq_fitting_tab_presenter_test.seq_fitting_tab_presenter_test (Failed)
	2114 - python.MuonQt4.sequential_table_test.sequential_table_test (Failed)
	2115 - python.MuonQt4.fit_information_test.fit_information_test (Failed)
	2116 - python.MuonQt4.fit_parameters_test.fit_parameters_test (Failed)
	2117 - python.MuonQt4.fitting_context_test.fitting_context_test (Failed)
	2118 - python.MuonQt4.home_instrument_widget_test.home_instrument_widget_test (Failed)
	2119 - python.MuonQt4.plot_widget_presenter_test.plot_widget_presenter_test (Failed)
	2120 - python.MuonQt4.plot_widget_model_test.plot_widget_model_test (Failed)
	2121 - python.MuonQt4.plotting_canvas_presenter_test.plotting_canvas_presenter_test (Failed)
	2122 - python.MuonQt4.plotting_canvas_model_test.plotting_canvas_model_test (Failed)
	2124 - python.MuonQt4.home_runinfo_presenter_test.home_runinfo_presenter_test (Failed)
	2125 - python.MuonQt4.list_selector_view_test.list_selector_view_test (Failed)
	2126 - python.MuonQt4.list_selector_presenter_test.list_selector_presenter_test (Failed)
	2127 - python.MuonQt4.loadrun_presenter_current_run_test.loadrun_presenter_current_run_test (Failed)
	2128 - python.MuonQt4.loadrun_presenter_single_file_test.loadrun_presenter_single_file_test (Failed)
	2129 - python.MuonQt4.loadrun_presenter_multiple_file_test.loadrun_presenter_multiple_file_test (Failed)
	2130 - python.MuonQt4.loadfile_presenter_single_file_test.loadfile_presenter_single_file_test (Failed)
	2131 - python.MuonQt4.loadfile_presenter_multiple_file_test.loadfile_presenter_multiple_file_test (Failed)
	2132 - python.MuonQt4.loadfile_view_test.loadfile_view_test (Failed)
	2133 - python.MuonQt4.loadrun_presenter_increment_decrement_test.loadrun_presenter_increment_decrement_test (Failed)
	2134 - python.MuonQt4.loadrun_view_test.loadrun_view_test (Failed)
	2135 - python.MuonQt4.loadwidget_presenter_test.loadwidget_presenter_test (Failed)
	2136 - python.MuonQt4.loadwidget_presenter_multiple_file_test.loadwidget_presenter_multiple_file_test (Failed)
	2137 - python.MuonQt4.loadwidget_presenter_failure_test.loadwidget_presenter_failure_test (Failed)
	2138 - python.MuonQt4.phase_table_presenter_test.phase_table_presenter_test (Failed)
	2139 - python.MuonQt4.grouping_table_presenter_test.grouping_table_presenter_test (Failed)
	2140 - python.MuonQt4.pairing_table_presenter_test.pairing_table_presenter_test (Failed)
	2141 - python.MuonQt4.grouping_tab_presenter_test.grouping_tab_presenter_test (Failed)
	2142 - python.MuonQt4.pairing_table_group_selector_test.pairing_table_group_selector_test (Failed)
	2143 - python.MuonQt4.pairing_table_alpha_test.pairing_table_alpha_test (Failed)
	2144 - python.MuonQt4.MaxEntPresenter_test.MaxEntPresenter_test (Failed)
	2145 - python.MuonQt4.max_ent_presenter_load_interaction_test.max_ent_presenter_load_interaction_test (Failed)
	2146 - python.MuonQt4.results_tab_presenter_test.results_tab_presenter_test (Failed)
	2147 - python.MuonQt4.transformWidget_test.transformWidget_test (Failed)
	2148 - python.MuonQt4.transform_widget_new_test.transform_widget_new_test (Failed)
	2149 - python.MuonQt4.help_widget_presenter_test.help_widget_presenter_test (Failed)
	2151 - python.MuonQt4.PeriodicTablePresenter_test.PeriodicTablePresenter_test (Failed)
	2177 - python.MuonQt5.loadrun_presenter_single_file_test.loadrun_presenter_single_file_test (Failed)
	2178 - python.MuonQt5.loadrun_presenter_multiple_file_test.loadrun_presenter_multiple_file_test (Failed)
	2181 - python.MuonQt5.loadfile_presenter_multiple_file_test.loadfile_presenter_multiple_file_test (Failed)
	2183 - python.MuonQt5.loadrun_presenter_increment_decrement_test.loadrun_presenter_increment_decrement_test (Failed)
	2185 - python.MuonQt5.loadwidget_presenter_test.loadwidget_presenter_test (Failed)
	2256 - PythonSANSQt4.gui_state_director_test.gui_state_director_test (Failed)
	2257 - PythonSANSQt4.gui_common_test.gui_common_test (Failed)
	2258 - PythonSANSQt4.masking_table_presenter_test.masking_table_presenter_test (Failed)
	2259 - PythonSANSQt4.run_tab_presenter_test.run_tab_presenter_test (Failed)
	2261 - PythonSANSQt4.settings_diagnostic_presenter_test.settings_diagnostic_presenter_test (Failed)
	2262 - PythonSANSQt4.table_model_test.table_model_test (Failed)
	2263 - PythonSANSQt4.run_selector_presenter_test.run_selector_presenter_test (Failed)
	2264 - PythonSANSQt4.summation_settings_presenter_test.summation_settings_presenter_test (Failed)
	2266 - PythonSANSQt4.add_runs_presenter_test.add_runs_presenter_test (Failed)
	2267 - PythonSANSQt4.beam_centre_presenter_test.beam_centre_presenter_test (Failed)
	2269 - PythonSANSQt4.diagnostics_page_presenter_test.diagnostics_page_presenter_test (Failed)
	2271 - PythonSANSQt4.create_state_test.create_state_test (Failed)
	2272 - PythonSANSQt4.batch_process_runner_test.batch_process_runner_test (Failed)
	2319 - PythonTOFTOFReduction.TOFTOFGUITest.TOFTOFGUITest (Failed)
	2329 - python.EngineeringDiffraction.test_vanadium_corrections.test_vanadium_corrections (Failed)
	2330 - python.EngineeringDiffraction.test_cropping_model.test_cropping_model (Failed)
	2331 - python.EngineeringDiffraction.test_cropping_presenter.test_cropping_presenter (Failed)
	2332 - python.EngineeringDiffraction.test_settings_helper.test_settings_helper (Failed)
	2333 - python.EngineeringDiffraction.test_settings_model.test_settings_model (Failed)
	2334 - python.EngineeringDiffraction.test_settings_presenter.test_settings_presenter (Failed)
	2335 - python.EngineeringDiffraction.test_calib_model.test_calib_model (Failed)
	2336 - python.EngineeringDiffraction.test_calib_presenter.test_calib_presenter (Failed)
	2338 - python.EngineeringDiffraction.test_data_presenter.test_data_presenter (Failed)
	2339 - python.EngineeringDiffraction.test_focus_model.test_focus_model (Failed)
	2340 - python.EngineeringDiffraction.test_focus_presenter.test_focus_presenter (Failed)
```
Tests failing on this branch
```
99% tests passed, 32 tests failed out of 2273

Total Test time (real) = 1940.69 sec

The following tests FAILED:
	593 - python.plots.plots__init__Test.plots__init__Test (Failed)
	597 - python.plots.surfacecontourplotsTest.surfacecontourplotsTest (Failed)
	1850 - MantidQtWidgetsCommonTestQt5_FindFilesThreadPoolManagerTest (Failed)
	1851 - MantidQtWidgetsCommonTestQt5_FindFilesWorkerTest (Failed)
	1868 - MantidQtWidgetsCommonTestQt5_SipTest (Failed)
	1921 - mantidqt_qt5.test_execution.test_execution (Failed)
	1926 - mantidqt_qt5.test_multifileinterpreter_view.test_multifileinterpreter_view (Failed)
	1928 - mantidqt_qt5.test_codeeditor_tab_view.test_codeeditor_tab_view (Failed)
	1931 - mantidqt_qt5.test_instrumentview_view.test_instrumentview_view (Failed)
	1939 - mantidqt_qt5.test_samplelogs_view.test_samplelogs_view (Failed)
	1963 - mantidqt_qt5.test_matrixworkspacedisplay_view.test_matrixworkspacedisplay_view (Failed)
	1970 - mantidqt_qt5.test_tableworkspacedisplay_view.test_tableworkspacedisplay_view (Failed)
	2029 - workbench.test_settings_view.test_settings_view (Failed)
	2057 - python.scripts.pythonTSVTest.pythonTSVTest (Failed)
	2067 - python.scripts.StitchingTest.StitchingTest (Failed)
	2129 - python.MuonQt5.loadrun_presenter_single_file_test.loadrun_presenter_single_file_test (Failed)
	2130 - python.MuonQt5.loadrun_presenter_multiple_file_test.loadrun_presenter_multiple_file_test (Failed)
	2133 - python.MuonQt5.loadfile_presenter_multiple_file_test.loadfile_presenter_multiple_file_test (Failed)
	2135 - python.MuonQt5.loadrun_presenter_increment_decrement_test.loadrun_presenter_increment_decrement_test (Failed)
	2137 - python.MuonQt5.loadwidget_presenter_test.loadwidget_presenter_test (Failed)
	2252 - PythonTOFTOFReduction.TOFTOFGUITest.TOFTOFGUITest (Failed)
	2262 - python.EngineeringDiffraction.test_vanadium_corrections.test_vanadium_corrections (Failed)
	2263 - python.EngineeringDiffraction.test_cropping_model.test_cropping_model (Failed)
	2264 - python.EngineeringDiffraction.test_cropping_presenter.test_cropping_presenter (Failed)
	2265 - python.EngineeringDiffraction.test_settings_helper.test_settings_helper (Failed)
	2266 - python.EngineeringDiffraction.test_settings_model.test_settings_model (Failed)
	2267 - python.EngineeringDiffraction.test_settings_presenter.test_settings_presenter (Failed)
	2268 - python.EngineeringDiffraction.test_calib_model.test_calib_model (Failed)
	2269 - python.EngineeringDiffraction.test_calib_presenter.test_calib_presenter (Failed)
	2271 - python.EngineeringDiffraction.test_data_presenter.test_data_presenter (Failed)
	2272 - python.EngineeringDiffraction.test_focus_model.test_focus_model (Failed)
	2273 - python.EngineeringDiffraction.test_focus_presenter.test_focus_presenter (Failed)
```
Some of the failing tests assumed that I have PySide2. When I've used `export QT_API=pyqt5` I get
```
99% tests passed, 17 tests failed out of 2273

Total Test time (real) = 1896.14 sec

The following tests FAILED:
	1850 - MantidQtWidgetsCommonTestQt5_FindFilesThreadPoolManagerTest (Failed)
	1851 - MantidQtWidgetsCommonTestQt5_FindFilesWorkerTest (Failed)
	1868 - MantidQtWidgetsCommonTestQt5_SipTest (Failed)
	1921 - mantidqt_qt5.test_execution.test_execution (Failed)
	1926 - mantidqt_qt5.test_multifileinterpreter_view.test_multifileinterpreter_view (Failed)
	1928 - mantidqt_qt5.test_codeeditor_tab_view.test_codeeditor_tab_view (Failed)
	1931 - mantidqt_qt5.test_instrumentview_view.test_instrumentview_view (Failed)
	1939 - mantidqt_qt5.test_samplelogs_view.test_samplelogs_view (Failed)
	1963 - mantidqt_qt5.test_matrixworkspacedisplay_view.test_matrixworkspacedisplay_view (Failed)
	1970 - mantidqt_qt5.test_tableworkspacedisplay_view.test_tableworkspacedisplay_view (Failed)
	2029 - workbench.test_settings_view.test_settings_view (Failed)
	2057 - python.scripts.pythonTSVTest.pythonTSVTest (Failed)
	2129 - python.MuonQt5.loadrun_presenter_single_file_test.loadrun_presenter_single_file_test (Failed)
	2130 - python.MuonQt5.loadrun_presenter_multiple_file_test.loadrun_presenter_multiple_file_test (Failed)
	2133 - python.MuonQt5.loadfile_presenter_multiple_file_test.loadfile_presenter_multiple_file_test (Failed)
	2135 - python.MuonQt5.loadrun_presenter_increment_decrement_test.loadrun_presenter_increment_decrement_test (Failed)
	2137 - python.MuonQt5.loadwidget_presenter_test.loadwidget_presenter_test (Failed)
```


**To test:**

Run unit tests on Ubuntu 20.04

Fixes #29007

*This does not require release notes* because **this is a partial fix for the unit tests**

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
