### PR TITLE
Use stable sys.platform over platform.platform

### DIFF
--- a/Testing/SystemTests/tests/analysis/GUIStartupTest.py
+++ b/Testing/SystemTests/tests/analysis/GUIStartupTest.py
@@ -5,8 +5,8 @@
 #   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
 # SPDX - License - Identifier: GPL - 3.0 +
 import os
-import platform
 import subprocess
+import sys
 import systemtesting
 import mantid
 
@@ -28,13 +28,13 @@ class GUIStartupTest(systemtesting.MantidSystemTest):
             f.write('import mantid\n'
                     'print("Hello Mantid")\n')
         # get the mantidplot executable
-        current_platform = platform.platform()
+        current_platform = sys.platform
         mantid_init_dirname = os.path.dirname(os.path.abspath(mantid.__file__))
-        if 'Linux' in current_platform:
+        if 'linux' in current_platform:
             mantid_exe = os.path.join(mantid_init_dirname, "../launch_mantidplot.sh")
-        elif 'Darwin' in current_platform:
+        elif 'darwin' in current_platform:
             mantid_exe = os.path.join(mantid_init_dirname, "../MantidPlot")
-        elif 'Windows' in current_platform:
+        elif 'win32' in current_platform:
             mantid_exe = 'wscript.exe {}'.format(os.path.join(mantid_init_dirname,
                                                               "../bin/launch_mantidplot.vbs"))
         else:


### PR DESCRIPTION
**Description of work.**

platform.platform() is subject to change. In Python 3.8 it changed
to return mac_vers(). sys.platform is guaranteed to return a stable
string for platform identification.

**To test:**

* Review & system tests should pass

*There is no associated issue.*


*This does not require release notes* because **it is an internal change**

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
