### PR TITLE
Re #29021. Fix temporary workspace validation.

### DIFF
--- a/Framework/MDAlgorithms/src/MDNorm.cpp
+++ b/Framework/MDAlgorithms/src/MDNorm.cpp
@@ -890,14 +890,18 @@ void MDNorm::validateBinningForTemporaryDataWorkspace(
 
     } else if ((key != "OutputBins") && (key != "OutputExtents")) {
       // make sure the names of non-directional dimensions are the same
-      const std::string nameData = tempDataWS->getDimension(parametersIndex)->getName();
-      if(value.find(nameData) != 0){
-        g_log.error()<<"Dimension "<<nameData<<" from the temporary workspace"
-                    " is not one of the binning dimensions, "
-                    " or dimensions are in the wrong order."<<std::endl;
-        throw(std::invalid_argument("Beside the Q dimensions, "
-                                    "TemporaryDataWorkspace does not have the "
-                                    "same dimension names as OutputWorkspace."));
+      const std::string nameData =
+          tempDataWS->getDimension(parametersIndex)->getName();
+      if (value.find(nameData) != 0) {
+        g_log.error() << "Dimension " << nameData
+                      << " from the temporary workspace"
+                         " is not one of the binning dimensions, "
+                         " or dimensions are in the wrong order."
+                      << std::endl;
+        throw(
+            std::invalid_argument("Beside the Q dimensions, "
+                                  "TemporaryDataWorkspace does not have the "
+                                  "same dimension names as OutputWorkspace."));
       }
     }
     parametersIndex++;

--- a/Framework/MDAlgorithms/src/MDNorm.cpp
+++ b/Framework/MDAlgorithms/src/MDNorm.cpp
@@ -795,8 +795,6 @@ void MDNorm::validateBinningForTemporaryDataWorkspace(
   size_t parametersIndex = 0;
   std::vector<size_t> dimensionIndex(
       numDimsTemp + 1, 3); // stores h, k, l or Qx, Qy, Qz dimensions
-  std::vector<size_t>
-      nonDimensionIndex; // stores non-h,k,l or non-Qx,Qy,Qz dimensions
   for (auto const &p : parameters) {
     auto key = p.first;
     auto value = p.second;
@@ -891,7 +889,16 @@ void MDNorm::validateBinningForTemporaryDataWorkspace(
       }
 
     } else if ((key != "OutputBins") && (key != "OutputExtents")) {
-      nonDimensionIndex.emplace_back(parametersIndex);
+      // make sure the names of non-directional dimensions are the same
+      const std::string nameData = tempDataWS->getDimension(parametersIndex)->getName();
+      if(value.find(nameData) != 0){
+        g_log.error()<<"Dimension "<<nameData<<" from the temporary workspace"
+                    " is not one of the binning dimensions, "
+                    " or dimensions are in the wrong order."<<std::endl;
+        throw(std::invalid_argument("Beside the Q dimensions, "
+                                    "TemporaryDataWorkspace does not have the "
+                                    "same dimension names as OutputWorkspace."));
+      }
     }
     parametersIndex++;
   }
@@ -899,20 +906,6 @@ void MDNorm::validateBinningForTemporaryDataWorkspace(
     if (idx > numDimsTemp)
       throw(std::invalid_argument("Cannot find at least one of QDimension0, "
                                   "QDimension1, or QDimension2"));
-  }
-
-  // make sure the names of non-directional dimensions are the same
-  if (!(nonDimensionIndex.empty())) {
-    for (auto &indexID : nonDimensionIndex) {
-      const std::string nameInput = m_inputWS->getDimension(indexID)->getName();
-      const std::string nameData = tempDataWS->getDimension(indexID)->getName();
-      if (nameInput != nameData) {
-        g_log.warning() << "Input: " << nameInput << " Temporary: " << nameData
-                        << std::endl;
-        throw(std::invalid_argument("TemporaryDataWorkspace does not have the "
-                                    "same dimension names as InputWorkspace."));
-      }
-    }
   }
 }
 

--- a/docs/source/release/v5.1.0/direct_geometry.rst
+++ b/docs/source/release/v5.1.0/direct_geometry.rst
@@ -30,5 +30,6 @@ Bugfixes
 --------
 
 - A bug introduced in v5.0 causing error values to tend to zero on multiple instances of :ref:`Rebin2D <algm-Rebin2D>` on the same workspace has been fixed.
+- A bug in the validation of temporary workpaces for :ref:`MDNorm <algm-MDNorm>` has been fixed. One can now use temporary workspaces when slicing in any order.
 
 :ref:`Release 5.1.0 <v5.1.0>`

--- a/docs/source/release/v5.1.0/direct_geometry.rst
+++ b/docs/source/release/v5.1.0/direct_geometry.rst
@@ -30,6 +30,6 @@ Bugfixes
 --------
 
 - A bug introduced in v5.0 causing error values to tend to zero on multiple instances of :ref:`Rebin2D <algm-Rebin2D>` on the same workspace has been fixed.
-- A bug in the validation of temporary workpaces for :ref:`MDNorm <algm-MDNorm>` has been fixed. One can now use temporary workspaces when slicing in any order.
+- A bug in the validation of temporary workpaces for :ref:`MDNorm <algm-MDNorm>` has been fixed. One can now use temporary workspaces in any order when slicing.
 
 :ref:`Release 5.1.0 <v5.1.0>`


### PR DESCRIPTION
**Description of work.**
Fix the validation of temporary workspaces, so the dimensions match the expected output workspace.

**To test:**
Run the script in #29021. Play with the order of binning dimensions, their number, or add `Phase2` instead of `Phase1` in the second `ConvertToMD` and the corresponding `MDNorm` 

Fixes #29021 


---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
