### PR TITLE
Correct return type in sip declaration

### DIFF
--- a/MantidPlot/src/qti.sip
+++ b/MantidPlot/src/qti.sip
@@ -1207,7 +1207,7 @@ public:
   MDIWindowList windowsList() /PyName=windows/;
 
   // Required for setting the IPython console
-  QDockWidget _getInterpreterDock();
+  QDockWidget* _getInterpreterDock();
 %MethodCode
   sipRes = sipCpp->m_interpreterDock;
 %End


### PR DESCRIPTION
**Description of work.**

On setting up a new macOS builder MantidPlot kept segfaulting. Fixes return type of sip declaration causing segfault on MantidPlot shutdown. See commit message for more detail.


**To test:**

* Check the MantidPlot tests all pass

*There is no associated issue.*

*This does not require release notes* because **it fixes an internal bug**

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
