### PR TITLE
Rework function browser in ConvFit tab of IDA GUI

### DIFF
--- a/qt/scientific_interfaces/Indirect/IndirectFitAnalysisTab.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectFitAnalysisTab.cpp
@@ -268,7 +268,14 @@ size_t IndirectFitAnalysisTab::numberOfCustomFunctions(
 }
 
 void IndirectFitAnalysisTab::setModelFitFunction() {
-  m_fittingModel->setFitFunction(m_fitPropertyBrowser->getFittingFunction());
+  auto future = QtConcurrent::run(
+      m_fitPropertyBrowser, &IndirectFitPropertyBrowser::getFittingFunction);
+
+  while (future.isRunning()) {
+    qApp->processEvents();
+  }
+
+  m_fittingModel->setFitFunction(future.result());
 }
 
 void IndirectFitAnalysisTab::setModelStartX(double startX) {

--- a/qt/scientific_interfaces/Indirect/IndirectFunctionBrowser/ConvFunctionModel.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectFunctionBrowser/ConvFunctionModel.cpp
@@ -30,8 +30,9 @@ void ConvFunctionModel::clearData() {
 
 void ConvFunctionModel::setModel() {
   m_model.setModel(buildBackgroundFunctionString(), m_fitResolutions,
-                   buildPeaksFunctionString(), m_hasDeltaFunction, m_qValues,
-                   m_isQDependentFunction, m_hasTempCorrection, m_tempValue);
+                   buildLorentzianPeaksString(), buildFitTypeString(),
+                   m_hasDeltaFunction, m_qValues, m_isQDependentFunction,
+                   m_hasTempCorrection, m_tempValue);
   if (m_hasTempCorrection && !m_globals.contains(ParamID::TEMPERATURE)) {
     m_globals.push_back(ParamID::TEMPERATURE);
   }
@@ -107,17 +108,18 @@ void ConvFunctionModel::checkSingleFunction(const IFunction_sptr &fun,
   assert(fun->nFunctions() == 0);
   auto const name = fun->name();
   if (name == "Lorentzian") {
-    if (isFitTypeSet && m_fitType != FitType::OneLorentzian) {
+    if (isFitTypeSet && m_lorentzianType != LorentzianType::OneLorentzian) {
       throw std::runtime_error("Function has wrong structure.");
     }
     if (isFitTypeSet)
-      m_fitType = FitType::TwoLorentzians;
+      m_lorentzianType = LorentzianType::TwoLorentzians;
     else
-      m_fitType = FitType::OneLorentzian;
+      m_lorentzianType = LorentzianType::OneLorentzian;
     m_isQDependentFunction = false;
     isFitTypeSet = true;
+  }
 
-  } else if (FitTypeStringToEnum.count(name) == 1) {
+  if (FitTypeStringToEnum.count(name) == 1) {
     if (isFitTypeSet) {
       throw std::runtime_error(
           "Function has wrong structure. More than one fit type set");
@@ -147,10 +149,15 @@ BackgroundType ConvFunctionModel::getBackgroundType() const {
   return m_backgroundType;
 }
 
+LorentzianType ConvFunctionModel::getLorentzianType() const {
+  return m_lorentzianType;
+}
+
 bool ConvFunctionModel::hasFunction() const { return m_model.hasFunction(); }
 
 void ConvFunctionModel::addFunction(const QString &prefix,
                                     const QString &funStr) {
+  std::cout << " CALLINGA DD FUNCTION ADD FUNCTION" << std::endl;
   if (!prefix.isEmpty())
     throw std::runtime_error(
         "Function doesn't have member function with prefix " +
@@ -160,13 +167,13 @@ void ConvFunctionModel::addFunction(const QString &prefix,
   auto const name = fun->name();
   QString newPrefix;
   if (name == "Lorentzian") {
-    if (m_fitType == FitType::TwoLorentzians) {
+    if (m_lorentzianType == LorentzianType::TwoLorentzians) {
       throw std::runtime_error("Cannot add more Lorentzians.");
-    } else if (m_fitType == FitType::OneLorentzian) {
-      m_fitType = FitType::TwoLorentzians;
+    } else if (m_lorentzianType == LorentzianType::OneLorentzian) {
+      m_lorentzianType = LorentzianType::TwoLorentzians;
       newPrefix = *getLor2Prefix();
-    } else if (m_fitType == FitType::None) {
-      m_fitType = FitType::OneLorentzian;
+    } else if (m_lorentzianType == LorentzianType::None) {
+      m_lorentzianType = LorentzianType::OneLorentzian;
       newPrefix = *getLor1Prefix();
     } else {
       throw std::runtime_error("Cannot add more Lorentzians.");
@@ -202,12 +209,12 @@ void ConvFunctionModel::removeFunction(const QString &prefix) {
   }
   auto prefix1 = getLor1Prefix();
   if (prefix1 && *prefix1 == prefix) {
-    setFitType(FitType::None);
+    setLorentzianType(LorentzianType::None);
     return;
   }
   prefix1 = getLor2Prefix();
   if (prefix1 && *prefix1 == prefix) {
-    setFitType(FitType::OneLorentzian);
+    setLorentzianType(LorentzianType::OneLorentzian);
     return;
   }
   prefix1 = getDeltaPrefix();
@@ -392,6 +399,7 @@ QStringList ConvFunctionModel::makeGlobalList() const {
 }
 
 void ConvFunctionModel::setFitType(FitType fitType) {
+  std::cout << "calling set fit type with";
   m_fitType = fitType;
   if (FitTypeQDepends[m_fitType])
     m_isQDependentFunction = true;
@@ -400,10 +408,15 @@ void ConvFunctionModel::setFitType(FitType fitType) {
   setModel();
 }
 
+void ConvFunctionModel::setLorentzianType(LorentzianType lorentzianType) {
+  m_lorentzianType = lorentzianType;
+  setModel();
+}
+
 int ConvFunctionModel::getNumberOfPeaks() const {
-  if (m_fitType == FitType::None)
+  if (m_lorentzianType == LorentzianType::None)
     return 0;
-  if (m_fitType == FitType::TwoLorentzians)
+  if (m_lorentzianType == LorentzianType::TwoLorentzians)
     return 2;
   return 1;
 }
@@ -565,6 +578,8 @@ boost::optional<QString> ConvFunctionModel::getPrefix(ParamID name) const {
     return m_model.deltaFunctionPrefix();
   } else if (name == ParamID::TEMPERATURE) {
     return m_model.tempFunctionPrefix();
+  } else if (name >= ParamID::TW_HEIGHT && name < ParamID::FLAT_BG_A0) {
+    return m_model.fitTypePrefix();
   } else {
     auto const prefixes = m_model.peakPrefixes();
     if (!prefixes)
@@ -610,6 +625,7 @@ void ConvFunctionModel::setCurrentValues(const QMap<ParamID, double> &values) {
 
 void ConvFunctionModel::applyParameterFunction(
     const std::function<void(ParamID)> &paramFun) const {
+  applyToLorentzianType(m_lorentzianType, paramFun);
   applyToFitType(m_fitType, paramFun);
   applyToBackground(m_backgroundType, paramFun);
   applyToDelta(m_hasDeltaFunction, paramFun);
@@ -668,14 +684,15 @@ ConvFunctionModel::buildElasticDiffRotDiscreteCircleFunctionString() const {
 
 std::string ConvFunctionModel::buildPeaksFunctionString() const {
   std::string functions;
-  if (m_fitType == FitType::OneLorentzian) {
+  if (m_lorentzianType == LorentzianType::OneLorentzian) {
     functions.append(buildLorentzianFunctionString());
-  } else if (m_fitType == FitType::TwoLorentzians) {
+  } else if (m_lorentzianType == LorentzianType::TwoLorentzians) {
     auto const lorentzian = buildLorentzianFunctionString();
     functions.append(lorentzian);
     functions.append(";");
     functions.append(lorentzian);
-  } else if (m_fitType == FitType::TeixeiraWater) {
+  }
+  if (m_fitType == FitType::TeixeiraWater) {
     functions.append(buildTeixeiraFunctionString());
   } else if (m_fitType == FitType::StretchedExpFT) {
     functions.append(buildStretchExpFTFunctionString());
@@ -689,7 +706,38 @@ std::string ConvFunctionModel::buildPeaksFunctionString() const {
     functions.append(buildElasticDiffRotDiscreteCircleFunctionString());
   }
   return functions;
-} // namespace IDA
+}
+
+std::string ConvFunctionModel::buildLorentzianPeaksString() const {
+  std::string functions;
+  if (m_lorentzianType == LorentzianType::OneLorentzian) {
+    functions.append(buildLorentzianFunctionString());
+  } else if (m_lorentzianType == LorentzianType::TwoLorentzians) {
+    auto const lorentzian = buildLorentzianFunctionString();
+    functions.append(lorentzian);
+    functions.append(";");
+    functions.append(lorentzian);
+  }
+  return functions;
+}
+
+std::string ConvFunctionModel::buildFitTypeString() const {
+  std::string functions;
+  if (m_fitType == FitType::TeixeiraWater) {
+    functions.append(buildTeixeiraFunctionString());
+  } else if (m_fitType == FitType::StretchedExpFT) {
+    functions.append(buildStretchExpFTFunctionString());
+  } else if (m_fitType == FitType::ElasticDiffSphere) {
+    functions.append(buildElasticDiffSphereFunctionString());
+  } else if (m_fitType == FitType::InelasticDiffSphere) {
+    functions.append(buildInelasticDiffSphereFunctionString());
+  } else if (m_fitType == FitType::InelasticDiffRotDiscreteCircle) {
+    functions.append(buildInelasticDiffRotDiscreteCircleFunctionString());
+  } else if (m_fitType == FitType::ElasticDiffRotDiscreteCircle) {
+    functions.append(buildElasticDiffRotDiscreteCircleFunctionString());
+  }
+  return functions;
+}
 
 std::string ConvFunctionModel::buildBackgroundFunctionString() const {
   if (m_backgroundType == BackgroundType::None)
@@ -704,6 +752,10 @@ boost::optional<QString> ConvFunctionModel::getLor1Prefix() const {
 
 boost::optional<QString> ConvFunctionModel::getLor2Prefix() const {
   return m_model.peakPrefixes()->at(1);
+}
+
+boost::optional<QString> ConvFunctionModel::getFitTypePrefix() const {
+  return m_model.fitTypePrefix();
 }
 
 boost::optional<QString> ConvFunctionModel::getDeltaPrefix() const {

--- a/qt/scientific_interfaces/Indirect/IndirectFunctionBrowser/ConvFunctionModel.h
+++ b/qt/scientific_interfaces/Indirect/IndirectFunctionBrowser/ConvFunctionModel.h
@@ -36,6 +36,7 @@ public:
   void setParameter(const QString &paramName, double value) override;
   void setParameterError(const QString &paramName, double value) override;
   FitType getFitType() const;
+  LorentzianType getLorentzianType() const;
   BackgroundType getBackgroundType() const;
   double getParameter(const QString &paramName) const override;
   double getParameterError(const QString &paramName) const override;
@@ -81,6 +82,7 @@ public:
   void updateMultiDatasetParameters(const ITableWorkspace &paramTable);
 
   void setFitType(FitType fitType);
+  void setLorentzianType(LorentzianType lorentzianType);
   void setDeltaFunction(bool);
   bool hasDeltaFunction() const;
   void setTempCorrection(bool, double value);
@@ -103,9 +105,9 @@ public:
 private:
   void clearData();
   void setModel();
-  // QString buildFunctionString() const;
   boost::optional<QString> getLor1Prefix() const;
   boost::optional<QString> getLor2Prefix() const;
+  boost::optional<QString> getFitTypePrefix() const;
   boost::optional<QString> getDeltaPrefix() const;
   boost::optional<QString> getBackgroundPrefix() const;
   void setParameter(ParamID name, double value);
@@ -121,6 +123,8 @@ private:
   std::string buildLorentzianFunctionString() const;
   std::string buildTeixeiraFunctionString() const;
   std::string buildPeaksFunctionString() const;
+  std::string buildLorentzianPeaksString() const;
+  std::string buildFitTypeString() const;
   std::string buildBackgroundFunctionString() const;
   std::string buildStretchExpFTFunctionString() const;
   std::string buildElasticDiffSphereFunctionString() const;
@@ -136,6 +140,7 @@ private:
 
   ConvolutionFunctionModel m_model;
   FitType m_fitType = FitType::None;
+  LorentzianType m_lorentzianType = LorentzianType::None;
   BackgroundType m_backgroundType = BackgroundType::None;
   bool m_hasDeltaFunction = false;
   bool m_hasTempCorrection = false;

--- a/qt/scientific_interfaces/Indirect/IndirectFunctionBrowser/ConvFunctionModel.h
+++ b/qt/scientific_interfaces/Indirect/IndirectFunctionBrowser/ConvFunctionModel.h
@@ -136,7 +136,8 @@ private:
   QStringList makeGlobalList() const;
   int getNumberOfPeaks() const;
   void checkConvolution(const IFunction_sptr &fun);
-  void checkSingleFunction(const IFunction_sptr &fun, bool &isFitTypeSet);
+  void checkSingleFunction(const IFunction_sptr &fun, bool &isLorentzianTypeSet,
+                           bool &isFiTypeSet);
 
   ConvolutionFunctionModel m_model;
   FitType m_fitType = FitType::None;

--- a/qt/scientific_interfaces/Indirect/IndirectFunctionBrowser/ConvTemplateBrowser.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectFunctionBrowser/ConvTemplateBrowser.cpp
@@ -56,6 +56,7 @@ void ConvTemplateBrowser::createProperties() {
   m_parameterManager->blockSignals(true);
   m_boolManager->blockSignals(true);
   m_enumManager->blockSignals(true);
+  m_intManager->blockSignals(true);
 
   createFunctionParameterProperties();
   createDeltaFunctionProperties();
@@ -70,7 +71,6 @@ void ConvTemplateBrowser::createProperties() {
   m_parameterManager->blockSignals(false);
   m_enumManager->blockSignals(false);
   m_boolManager->blockSignals(false);
-  // updateState();
 }
 
 void ConvTemplateBrowser::setFunction(const QString &funStr) {

--- a/qt/scientific_interfaces/Indirect/IndirectFunctionBrowser/ConvTemplateBrowser.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectFunctionBrowser/ConvTemplateBrowser.cpp
@@ -28,6 +28,7 @@ namespace CustomInterfaces {
 namespace IDA {
 
 namespace {
+
 class ScopedFalse {
   bool &m_ref;
   bool m_oldValue;
@@ -44,6 +45,7 @@ public:
 
 ConvTemplateBrowser::ConvTemplateBrowser(QWidget *parent)
     : FunctionTemplateBrowser(parent), m_presenter(this) {
+  m_templateSubTypes.emplace_back(std::make_unique<LorentzianSubType>());
   m_templateSubTypes.emplace_back(std::make_unique<FitSubType>());
   m_templateSubTypes.emplace_back(std::make_unique<BackgroundSubType>());
   connect(&m_presenter, SIGNAL(functionStructureChanged()), this,
@@ -59,10 +61,11 @@ void ConvTemplateBrowser::createProperties() {
   createDeltaFunctionProperties();
   createTempCorrectionProperties();
 
-  m_browser->addProperty(m_subTypeProperties[0]);
+  m_browser->addProperty(m_subTypeProperties[SubTypeIndex::Lorentzian]);
+  m_browser->addProperty(m_subTypeProperties[SubTypeIndex::Fit]);
   m_browser->addProperty(m_deltaFunctionOn);
   m_browser->addProperty(m_tempCorrectionOn);
-  m_browser->addProperty(m_subTypeProperties[1]);
+  m_browser->addProperty(m_subTypeProperties[SubTypeIndex::Background]);
 
   m_parameterManager->blockSignals(false);
   m_enumManager->blockSignals(false);

--- a/qt/scientific_interfaces/Indirect/IndirectFunctionBrowser/ConvTemplateBrowser.h
+++ b/qt/scientific_interfaces/Indirect/IndirectFunctionBrowser/ConvTemplateBrowser.h
@@ -63,6 +63,8 @@ public:
   void removeTempCorrection();
   void setQValues(const std::vector<double> &qValues) override;
   void setEnum(size_t subTypeIndex, int fitType);
+  void setInt(size_t subTypeIndex, int val);
+
   void updateTemperatureCorrectionAndDelta(bool tempCorrection,
                                            bool deltaFunction);
 
@@ -80,6 +82,7 @@ private:
   void setParameterPropertyValue(QtProperty *prop, double value, double error);
   void setGlobalParametersQuiet(const QStringList &globals);
   void createFunctionParameterProperties();
+  void createLorentzianFunctionProperties();
   void createDeltaFunctionProperties();
   void createTempCorrectionProperties();
   void setSubType(size_t subTypeIndex, int typeIndex);
@@ -109,6 +112,7 @@ private:
   bool m_emitParameterValueChange = true;
   bool m_emitBoolChange = true;
   bool m_emitEnumChange = true;
+  bool m_emitIntChange = true;
   friend class ConvTemplatePresenter;
 };
 

--- a/qt/scientific_interfaces/Indirect/IndirectFunctionBrowser/ConvTemplatePresenter.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectFunctionBrowser/ConvTemplatePresenter.cpp
@@ -32,6 +32,8 @@ ConvTemplatePresenter::ConvTemplatePresenter(ConvTemplateBrowser *view)
 void ConvTemplatePresenter::setSubType(size_t subTypeIndex, int typeIndex) {
   if (subTypeIndex == SubTypeIndex::Fit) {
     m_model.setFitType(static_cast<FitType>(typeIndex));
+  } else if (subTypeIndex == SubTypeIndex::Lorentzian) {
+    m_model.setLorentzianType(static_cast<LorentzianType>(typeIndex));
   } else {
     m_model.setBackground(static_cast<BackgroundType>(typeIndex));
   }
@@ -96,6 +98,8 @@ void ConvTemplatePresenter::setFunction(const QString &funStr) {
                                               m_model.hasDeltaFunction());
 
   m_view->setSubType(SubTypeIndex::Fit, static_cast<int>(m_model.getFitType()));
+  m_view->setSubType(SubTypeIndex::Lorentzian,
+                     static_cast<int>(m_model.getLorentzianType()));
   m_view->setSubType(SubTypeIndex::Background,
                      static_cast<int>(m_model.getBackgroundType()));
   m_view->setEnum(SubTypeIndex::Fit, static_cast<int>(m_model.getFitType()));

--- a/qt/scientific_interfaces/Indirect/IndirectFunctionBrowser/ConvTemplatePresenter.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectFunctionBrowser/ConvTemplatePresenter.cpp
@@ -97,11 +97,14 @@ void ConvTemplatePresenter::setFunction(const QString &funStr) {
   m_view->updateTemperatureCorrectionAndDelta(m_model.hasTempCorrection(),
                                               m_model.hasDeltaFunction());
 
-  m_view->setSubType(SubTypeIndex::Fit, static_cast<int>(m_model.getFitType()));
   m_view->setSubType(SubTypeIndex::Lorentzian,
                      static_cast<int>(m_model.getLorentzianType()));
+  m_view->setSubType(SubTypeIndex::Fit, static_cast<int>(m_model.getFitType()));
   m_view->setSubType(SubTypeIndex::Background,
                      static_cast<int>(m_model.getBackgroundType()));
+
+  m_view->setEnum(SubTypeIndex::Lorentzian,
+                  static_cast<int>(m_model.getLorentzianType()));
   m_view->setEnum(SubTypeIndex::Fit, static_cast<int>(m_model.getFitType()));
   m_view->setEnum(SubTypeIndex::Background,
                   static_cast<int>(m_model.getBackgroundType()));

--- a/qt/scientific_interfaces/Indirect/IndirectFunctionBrowser/ConvTemplatePresenter.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectFunctionBrowser/ConvTemplatePresenter.cpp
@@ -8,12 +8,26 @@
 #include "ConvTemplateBrowser.h"
 #include "MantidQtWidgets/Common/EditLocalParameterDialog.h"
 #include <QInputDialog>
+#include <QtConcurrentRun>
 #include <cmath>
 #include <float.h>
 
 namespace MantidQt {
 namespace CustomInterfaces {
 namespace IDA {
+
+namespace {
+class ScopedDisable {
+  FunctionTemplateBrowser *m_browser;
+
+public:
+  // Disables the function browser and re-enables when leaving scope
+  ScopedDisable(FunctionTemplateBrowser *browser) : m_browser(browser) {
+    m_browser->setDisabled(true);
+  }
+  ~ScopedDisable() { m_browser->setDisabled(false); }
+};
+} // namespace
 
 using namespace MantidWidgets;
 
@@ -29,13 +43,23 @@ ConvTemplatePresenter::ConvTemplatePresenter(ConvTemplateBrowser *view)
           SLOT(viewChangedParameterValue(const QString &, double)));
 }
 
+// This function creates a Qt thread to run the model updates
+// This was found to be necessary to allow the processing of the GUI thread to
+// continue which is necessary to stop the int manager from self-incrementing
+// itself due to an internal timer occurring within the class
 void ConvTemplatePresenter::setSubType(size_t subTypeIndex, int typeIndex) {
-  if (subTypeIndex == SubTypeIndex::Fit) {
-    m_model.setFitType(static_cast<FitType>(typeIndex));
-  } else if (subTypeIndex == SubTypeIndex::Lorentzian) {
-    m_model.setLorentzianType(static_cast<LorentzianType>(typeIndex));
-  } else {
-    m_model.setBackground(static_cast<BackgroundType>(typeIndex));
+  auto fun = [this, subTypeIndex, typeIndex]() {
+    if (subTypeIndex == SubTypeIndex::Fit) {
+      m_model.setFitType(static_cast<FitType>(typeIndex));
+    } else if (subTypeIndex == SubTypeIndex::Lorentzian) {
+      m_model.setLorentzianType(static_cast<LorentzianType>(typeIndex));
+    } else {
+      m_model.setBackground(static_cast<BackgroundType>(typeIndex));
+    }
+  };
+  auto future = QtConcurrent::run(fun);
+  while (future.isRunning()) {
+    qApp->processEvents();
   }
   m_view->setSubType(subTypeIndex, typeIndex);
   setErrorsEnabled(false);
@@ -103,8 +127,8 @@ void ConvTemplatePresenter::setFunction(const QString &funStr) {
   m_view->setSubType(SubTypeIndex::Background,
                      static_cast<int>(m_model.getBackgroundType()));
 
-  m_view->setEnum(SubTypeIndex::Lorentzian,
-                  static_cast<int>(m_model.getLorentzianType()));
+  m_view->setInt(SubTypeIndex::Lorentzian,
+                 static_cast<int>(m_model.getLorentzianType()));
   m_view->setEnum(SubTypeIndex::Fit, static_cast<int>(m_model.getFitType()));
   m_view->setEnum(SubTypeIndex::Background,
                   static_cast<int>(m_model.getBackgroundType()));

--- a/qt/scientific_interfaces/Indirect/IndirectFunctionBrowser/ConvTypes.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectFunctionBrowser/ConvTypes.cpp
@@ -17,8 +17,6 @@ using namespace Mantid::API;
 
 std::map<FitType, bool> FitTypeQDepends =
     std::map<FitType, bool>({{FitType::None, false},
-                             {FitType::OneLorentzian, false},
-                             {FitType::TwoLorentzians, false},
                              {FitType::TeixeiraWater, true},
                              {FitType::StretchedExpFT, false},
                              {FitType::ElasticDiffSphere, true},
@@ -27,9 +25,7 @@ std::map<FitType, bool> FitTypeQDepends =
                              {FitType::ElasticDiffRotDiscreteCircle, true}});
 
 std::unordered_map<FitType, std::string> FitTypeEnumToString(
-    {{FitType::OneLorentzian, "Lorentzian"},
-     {FitType::TwoLorentzians, "Lorentzian"},
-     {FitType::TeixeiraWater, "TeixeiraWaterSQE"},
+    {{FitType::TeixeiraWater, "TeixeiraWaterSQE"},
      {FitType::StretchedExpFT, "StretchedExpFT"},
      {FitType::ElasticDiffSphere, "ElasticDiffSphere"},
      {FitType::InelasticDiffSphere, "InelasticDiffSphere"},
@@ -38,8 +34,7 @@ std::unordered_map<FitType, std::string> FitTypeEnumToString(
      {FitType::ElasticDiffRotDiscreteCircle, "ElasticDiffRotDiscreteCircle"}});
 
 std::unordered_map<std::string, FitType> FitTypeStringToEnum(
-    {{"Lorentzian", FitType::OneLorentzian},
-     {"TeixeiraWaterSQE", FitType::TeixeiraWater},
+    {{"TeixeiraWaterSQE", FitType::TeixeiraWater},
      {"StretchedExpFT", FitType::StretchedExpFT},
      {"ElasticDiffSphere", FitType::ElasticDiffSphere},
      {"InelasticDiffSphere", FitType::InelasticDiffSphere},
@@ -91,15 +86,6 @@ template <>
 std::map<FitType, TemplateSubTypeDescriptor>
     TemplateSubTypeImpl<FitType>::g_typeMap{
         {FitType::None, {"None", "", {ParamID::NONE, ParamID::NONE}}},
-        {FitType::OneLorentzian,
-         {"One Lorentzian",
-          "Lorentzian",
-          {ParamID::LOR1_AMPLITUDE, ParamID::LOR1_FWHM}}},
-        {FitType::TwoLorentzians,
-         {"Two Lorentzians",
-          "Lorentzian",
-          {ParamID::LOR2_AMPLITUDE_1, ParamID::LOR2_FWHM_1,
-           ParamID::LOR2_FWHM_2}}},
         {FitType::TeixeiraWater,
          {"Teixeira Water",
           "TeixeiraWaterSQE",
@@ -124,6 +110,20 @@ std::map<FitType, TemplateSubTypeDescriptor>
          {"ElasticDiffRotDiscreteCircle",
           "ElasticDiffRotDiscreteCircle",
           {ParamID::EDRDC_HEIGHT, ParamID::EDRDC_RADIUS}}},
+    };
+template <>
+std::map<LorentzianType, TemplateSubTypeDescriptor>
+    TemplateSubTypeImpl<LorentzianType>::g_typeMap{
+        {LorentzianType::None, {"None", "", {ParamID::NONE, ParamID::NONE}}},
+        {LorentzianType::OneLorentzian,
+         {"One Lorentzian",
+          "Lorentzian",
+          {ParamID::LOR1_AMPLITUDE, ParamID::LOR1_FWHM}}},
+        {LorentzianType::TwoLorentzians,
+         {"Two Lorentzians",
+          "Lorentzian",
+          {ParamID::LOR2_AMPLITUDE_1, ParamID::LOR2_FWHM_1,
+           ParamID::LOR2_FWHM_2}}},
     };
 
 template <>
@@ -166,6 +166,13 @@ void applyToFitType(FitType fitType,
                     const std::function<void(ParamID)> &paramFun) {
   applyToParamIDRange(FitSubType::g_typeMap[fitType].blocks.front(),
                       FitSubType::g_typeMap[fitType].blocks.back(), paramFun);
+}
+
+void applyToLorentzianType(LorentzianType lorentzianType,
+                           const std::function<void(ParamID)> &paramFun) {
+  applyToParamIDRange(
+      LorentzianSubType::g_typeMap[lorentzianType].blocks.front(),
+      LorentzianSubType::g_typeMap[lorentzianType].blocks.back(), paramFun);
 }
 
 void applyToBackground(BackgroundType bgType,

--- a/qt/scientific_interfaces/Indirect/IndirectFunctionBrowser/ConvTypes.h
+++ b/qt/scientific_interfaces/Indirect/IndirectFunctionBrowser/ConvTypes.h
@@ -218,7 +218,7 @@ void applyToFitType(FitType fitType,
                     const std::function<void(ParamID)> &paramFun);
 
 void applyToLorentzianType(LorentzianType lorenzianType,
-                    const std::function<void(ParamID)> &paramFun);
+                           const std::function<void(ParamID)> &paramFun);
 
 void applyToBackground(BackgroundType bgType,
                        const std::function<void(ParamID)> &paramFun);

--- a/qt/scientific_interfaces/Indirect/IndirectFunctionBrowser/ConvTypes.h
+++ b/qt/scientific_interfaces/Indirect/IndirectFunctionBrowser/ConvTypes.h
@@ -25,8 +25,6 @@ using namespace Mantid::API;
 
 enum class FitType {
   None,
-  OneLorentzian,
-  TwoLorentzians,
   TeixeiraWater,
   StretchedExpFT,
   ElasticDiffSphere,
@@ -35,9 +33,20 @@ enum class FitType {
   InelasticDiffRotDiscreteCircle,
 };
 
+enum class LorentzianType {
+  None,
+  OneLorentzian,
+  TwoLorentzians,
+};
+
 extern std::map<FitType, bool> FitTypeQDepends;
 extern std::unordered_map<FitType, std::string> FitTypeEnumToString;
 extern std::unordered_map<std::string, FitType> FitTypeStringToEnum;
+
+extern std::unordered_map<LorentzianType, std::string>
+    LorentzianTypeEnumToString;
+extern std::unordered_map<std::string, LorentzianType>
+    LorentzianTypeStringToEnum;
 
 enum class BackgroundType { None, Flat, Linear };
 
@@ -100,7 +109,8 @@ inline void applyToParamIDRange(ParamID from, ParamID to,
 }
 
 enum SubTypeIndex {
-  Fit = 0,
+  Lorentzian = 0,
+  Fit = 1,
   Background = 1,
 };
 
@@ -188,6 +198,10 @@ struct FitSubType : public TemplateSubTypeImpl<FitType> {
   QString name() const override { return "Fit Type"; }
 };
 
+struct LorentzianSubType : public TemplateSubTypeImpl<LorentzianType> {
+  QString name() const override { return "Lorentzians"; }
+};
+
 struct BackgroundSubType : public TemplateSubTypeImpl<BackgroundType> {
   QString name() const override { return "Background"; }
 };
@@ -202,6 +216,10 @@ struct TempSubType : public TemplateSubTypeImpl<TempCorrectionType> {
 
 void applyToFitType(FitType fitType,
                     const std::function<void(ParamID)> &paramFun);
+
+void applyToLorentzianType(LorentzianType lorenzianType,
+                    const std::function<void(ParamID)> &paramFun);
+
 void applyToBackground(BackgroundType bgType,
                        const std::function<void(ParamID)> &paramFun);
 void applyToDelta(bool deltaType, const std::function<void(ParamID)> &paramFun);

--- a/qt/scientific_interfaces/Indirect/IndirectFunctionBrowser/ConvTypes.h
+++ b/qt/scientific_interfaces/Indirect/IndirectFunctionBrowser/ConvTypes.h
@@ -111,7 +111,7 @@ inline void applyToParamIDRange(ParamID from, ParamID to,
 enum SubTypeIndex {
   Lorentzian = 0,
   Fit = 1,
-  Background = 1,
+  Background = 2,
 };
 
 struct TemplateSubType {

--- a/qt/scientific_interfaces/Indirect/test/ConvFunctionModelTest.h
+++ b/qt/scientific_interfaces/Indirect/test/ConvFunctionModelTest.h
@@ -114,7 +114,7 @@ public:
   }
 
   void test_setFunction_does_not_throw_for_valid_temperature_function() {
-    m_model->setFitType(FitType::OneLorentzian);
+    m_model->setLorentzianType(LorentzianType::OneLorentzian);
     m_model->setTempCorrection(true, 100.0);
     auto func = m_model->getFitFunction();
 
@@ -123,12 +123,13 @@ public:
     TS_ASSERT_EQUALS(m_model->getCurrentFunction()->asString(),
                      func->asString())
     TS_ASSERT_EQUALS(m_model->getBackgroundType(), BackgroundType::None);
-    TS_ASSERT_EQUALS(m_model->getFitType(), FitType::OneLorentzian);
+    TS_ASSERT_EQUALS(m_model->getLorentzianType(),
+                     LorentzianType::OneLorentzian);
   }
 
   void
   test_setFunction_does_not_throw_for_valid_temperature_function_with_delta() {
-    m_model->setFitType(FitType::OneLorentzian);
+    m_model->setLorentzianType(LorentzianType::OneLorentzian);
     m_model->setTempCorrection(true, 100.0);
     m_model->setDeltaFunction(true);
     auto func = m_model->getFitFunction();
@@ -138,12 +139,13 @@ public:
     TS_ASSERT_EQUALS(m_model->getCurrentFunction()->asString(),
                      func->asString())
     TS_ASSERT_EQUALS(m_model->getBackgroundType(), BackgroundType::None);
-    TS_ASSERT_EQUALS(m_model->getFitType(), FitType::OneLorentzian);
+    TS_ASSERT_EQUALS(m_model->getLorentzianType(),
+                     LorentzianType::OneLorentzian);
   }
 
   void
   test_setFunction_does_not_throw_for_valid_two_lorenztian_temperature_function() {
-    m_model->setFitType(FitType::TwoLorentzians);
+    m_model->setLorentzianType(LorentzianType::TwoLorentzians);
     m_model->setTempCorrection(true, 100.0);
     auto func = m_model->getFitFunction();
 
@@ -152,12 +154,13 @@ public:
     TS_ASSERT_EQUALS(m_model->getCurrentFunction()->asString(),
                      func->asString())
     TS_ASSERT_EQUALS(m_model->getBackgroundType(), BackgroundType::None);
-    TS_ASSERT_EQUALS(m_model->getFitType(), FitType::TwoLorentzians);
+    TS_ASSERT_EQUALS(m_model->getLorentzianType(),
+                     LorentzianType::TwoLorentzians);
   }
 
   void
   test_setFunction_does_not_throw_for_valid_two_lorenztian_temperature_function_with_delta() {
-    m_model->setFitType(FitType::TwoLorentzians);
+    m_model->setLorentzianType(LorentzianType::TwoLorentzians);
     m_model->setTempCorrection(true, 100.0);
     m_model->setDeltaFunction(true);
     auto func = m_model->getFitFunction();
@@ -167,7 +170,8 @@ public:
     TS_ASSERT_EQUALS(m_model->getCurrentFunction()->asString(),
                      func->asString());
     TS_ASSERT_EQUALS(m_model->getBackgroundType(), BackgroundType::None);
-    TS_ASSERT_EQUALS(m_model->getFitType(), FitType::TwoLorentzians);
+    TS_ASSERT_EQUALS(m_model->getLorentzianType(),
+                     LorentzianType::TwoLorentzians);
   }
 
 private:

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/ConvolutionFunctionModel.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/ConvolutionFunctionModel.h
@@ -50,7 +50,6 @@ public:
 
 private:
   void findComponentPrefixes();
-  //  void findConvolutionPrefixes(const IFunction_sptr &fun);
   void iterateThroughFunction(IFunction *func, const QString &prefix);
   void setPrefix(IFunction *func, const QString &prefix);
 

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/ConvolutionFunctionModel.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/ConvolutionFunctionModel.h
@@ -27,9 +27,9 @@ public:
   void setModel(
       const std::string &background,
       const std::vector<std::pair<std::string, size_t>> &resolutionWorkspaces,
-      const std::string &peaks, bool hasDeltaFunction,
-      const std::vector<double> &qValues, const bool isQDependent,
-      bool hasTempCorrection, double tempValue);
+      const std::string &lorentzianPeaks, const std::string &fitType,
+      bool hasDeltaFunction, const std::vector<double> &qValues,
+      const bool isQDependent, bool hasTempCorrection, double tempValue);
   boost::optional<QString> backgroundPrefix() const {
     return m_backgroundPrefix;
   }
@@ -43,6 +43,8 @@ public:
     return m_tempFunctionPrefix;
   }
   boost::optional<QStringList> peakPrefixes() const { return m_peakPrefixes; }
+  boost::optional<QString> fitTypePrefix() const { return m_fitTypePrefix; }
+
   std::string resolutionWorkspace() const { return m_resolutionWorkspace; }
   int resolutionWorkspaceIndex() const { return m_resolutionWorkspaceIndex; }
 
@@ -51,7 +53,9 @@ private:
   //  void findConvolutionPrefixes(const IFunction_sptr &fun);
   void iterateThroughFunction(IFunction *func, const QString &prefix);
   void setPrefix(IFunction *func, const QString &prefix);
-  CompositeFunction_sptr createInnerFunction(const std::string &peaksFunction,
+
+  CompositeFunction_sptr createInnerFunction(const std::string &lorentzianPeaks,
+                                             const std::string &fitType,
                                              bool hasDeltaFunction,
                                              bool isQDependent, double q,
                                              bool hasTempCorrection,
@@ -71,6 +75,7 @@ private:
   boost::optional<QString> m_convolutionPrefix;
   boost::optional<QString> m_deltaFunctionPrefix;
   boost::optional<QString> m_tempFunctionPrefix;
+  boost::optional<QString> m_fitTypePrefix;
   boost::optional<QStringList> m_peakPrefixes;
   std::string m_resolutionWorkspace;
   int m_resolutionWorkspaceIndex;

--- a/qt/widgets/common/src/ConvolutionFunctionModel.cpp
+++ b/qt/widgets/common/src/ConvolutionFunctionModel.cpp
@@ -133,7 +133,6 @@ CompositeFunction_sptr ConvolutionFunctionModel::createInnerFunction(
     bool hasDeltaFunction, bool isQDependent, double qValue,
     bool hasTempCorrection, double tempValue) {
   CompositeFunction_sptr innerFunction = std::make_shared<CompositeFunction>();
-  std::cout << " Peak function is " << lorentzianPeaks << std::endl;
   if (!lorentzianPeaks.empty()) {
     auto lorentzianPeakFunction =
         FunctionFactory::Instance().createInitialized(lorentzianPeaks);
@@ -145,7 +144,6 @@ CompositeFunction_sptr ConvolutionFunctionModel::createInnerFunction(
       innerFunction->addFunction(lorentzianPeakFunction);
     }
   }
-  std::cout << " fit type function is " << fitType << std::endl;
 
   if (!fitType.empty()) {
     auto fitTypeFunction =
@@ -265,7 +263,6 @@ void ConvolutionFunctionModel::iterateThroughFunction(IFunction *func,
 
 void ConvolutionFunctionModel::setPrefix(IFunction *func,
                                          const QString &prefix) {
-  std::cout << " PREFIX: " << prefix.toStdString() << std::endl;
   if (isBackground(func)) {
     if (m_backgroundPrefix) {
       throw std::runtime_error("Model cannot have more than one background.");

--- a/qt/widgets/common/src/ConvolutionFunctionModel.cpp
+++ b/qt/widgets/common/src/ConvolutionFunctionModel.cpp
@@ -105,8 +105,8 @@ void ConvolutionFunctionModel::setModel(
   }
   // The two clones here are needed as the clone value of IFunction goes through
   // a string serialisation and deserialisation. This can lead to the function
-  // structure subtly changeing. For exmaple composite functions of only one
-  // member are removed and uneeded brackets are removed from user defined
+  // structure subtly changing. For example composite functions of only one
+  // member are removed and unneeded brackets are removed from user defined
   // functions. As function cloning is used later on in the workflow it seems
   // safer to clone twice here to get the function in it's final state early on
   // rather than have it change during the workflow.

--- a/qt/widgets/common/test/ConvolutionFunctionModelTest.h
+++ b/qt/widgets/common/test/ConvolutionFunctionModelTest.h
@@ -46,7 +46,7 @@ public:
   void test_no_convolution_2() {
     ConvolutionFunctionModel model;
     TS_ASSERT_THROWS_EQUALS(
-        model.setFunctionString("name=LinearBackground;name=Gaussian"),
+        model.setFunctionString("name=LinearBackground;name=Lorentzian"),
         const std::runtime_error &e, std::string(e.what()),
         "Model doesn't contain a convolution.");
   }
@@ -108,9 +108,10 @@ public:
 
   void test_background_after_convolution() {
     ConvolutionFunctionModel model;
+    int a = 3;
     TS_ASSERT_THROWS_NOTHING(
         model.setFunctionString("(composite=Convolution;name=Resolution;name="
-                                "Gaussian);name=LinearBackground"));
+                                "Lorentzian);name=LinearBackground"));
     TS_ASSERT_EQUALS(model.backgroundPrefix()->toStdString(), "f1.");
     TS_ASSERT_EQUALS(model.convolutionPrefix()->toStdString(), "f0.");
     TS_ASSERT_EQUALS(model.resolutionWorkspace(), "");
@@ -123,7 +124,7 @@ public:
   void test_two_peaks() {
     ConvolutionFunctionModel model;
     TS_ASSERT_THROWS_NOTHING(model.setFunctionString(
-        "(composite=Convolution;name=Resolution;name=Gaussian;name=Gaussian);"
+        "(composite=Convolution;name=Resolution;name=Lorentzian;name=Lorentzian);"
         "name=LinearBackground"));
     TS_ASSERT_EQUALS(model.backgroundPrefix()->toStdString(), "f1.");
     TS_ASSERT_EQUALS(model.convolutionPrefix()->toStdString(), "f0.");
@@ -138,7 +139,7 @@ public:
   void test_two_peaks_no_background() {
     ConvolutionFunctionModel model;
     TS_ASSERT_THROWS_NOTHING(model.setFunctionString(
-        "composite=Convolution;name=Resolution;name=Gaussian;name=Gaussian"));
+        "composite=Convolution;name=Resolution;name=Lorentzian;name=Lorentzian"));
     TS_ASSERT(!model.backgroundPrefix());
     TS_ASSERT_EQUALS(model.convolutionPrefix()->toStdString(), "");
     TS_ASSERT_EQUALS(model.resolutionWorkspace(), "");
@@ -178,7 +179,7 @@ public:
     ConvolutionFunctionModel model;
     TS_ASSERT_THROWS_NOTHING(
         model.setFunctionString("composite=Convolution;name=Resolution;name="
-                                "Gaussian;name=Gaussian;name=DeltaFunction"));
+                                "Lorentzian;name=Lorentzian;name=DeltaFunction"));
     TS_ASSERT(!model.backgroundPrefix());
     TS_ASSERT_EQUALS(model.convolutionPrefix()->toStdString(), "");
     TS_ASSERT_EQUALS(model.resolutionWorkspace(), "");
@@ -193,7 +194,7 @@ public:
     ConvolutionFunctionModel model;
     TS_ASSERT_THROWS_NOTHING(
         model.setFunctionString("(composite=Convolution;name=Resolution;name="
-                                "DeltaFunction;name=Gaussian;name=Gaussian);"
+                                "DeltaFunction;name=Lorentzian;name=Lorentzian);"
                                 "name=LinearBackground"));
     TS_ASSERT_EQUALS(model.backgroundPrefix()->toStdString(), "f1.");
     TS_ASSERT_EQUALS(model.convolutionPrefix()->toStdString(), "f0.");
@@ -215,7 +216,7 @@ public:
     ConvolutionFunctionModel model;
     TS_ASSERT_THROWS_NOTHING(
         model.setFunctionString("composite=Convolution;name=Resolution,"
-                                "Workspace=\"abc\";name=Gaussian"));
+                                "Workspace=\"abc\";name=Lorentzian"));
     TS_ASSERT(!model.backgroundPrefix());
     TS_ASSERT_EQUALS(model.convolutionPrefix()->toStdString(), "");
     TS_ASSERT_EQUALS(model.resolutionWorkspace(), "abc");
@@ -235,7 +236,7 @@ public:
     ConvolutionFunctionModel model;
     TS_ASSERT_THROWS_NOTHING(model.setFunctionString(
         "composite=Convolution;name=Resolution,Workspace=\"abc\","
-        "WorkspaceIndex=3;name=Gaussian"));
+        "WorkspaceIndex=3;name=Lorentzian"));
     TS_ASSERT(!model.backgroundPrefix());
     TS_ASSERT_EQUALS(model.convolutionPrefix()->toStdString(), "");
     TS_ASSERT_EQUALS(model.resolutionWorkspace(), "abc");
@@ -260,8 +261,8 @@ public:
     fitResolutions.emplace_back(pair1);
     fitResolutions.emplace_back(pair2);
 
-    model.setModel("", fitResolutions, "", false, std::vector<double>(), false,
-                   false, 100.0);
+    model.setModel("", fitResolutions, "", "", false, std::vector<double>(),
+                   false, false, 100.0);
 
     auto fitFunctionAsString = model.getFitFunction()->asString();
     TS_ASSERT_EQUALS(
@@ -288,11 +289,10 @@ public:
     fitResolutions.emplace_back(pair1);
     fitResolutions.emplace_back(pair2);
 
-    model.setModel("", fitResolutions, "", true, std::vector<double>(), false,
-                   false, 100.0);
+    model.setModel("", fitResolutions, "", "", true, std::vector<double>(),
+                   false, false, 100.0);
 
     auto fitFunctionAsString = model.getFitFunction()->asString();
-    std::cout << fitFunctionAsString << std::endl;
     TS_ASSERT_EQUALS(
         fitFunctionAsString,
         "composite=MultiDomainFunction,NumDeriv=true;(composite=Convolution,"
@@ -317,12 +317,11 @@ public:
     fitResolutions.emplace_back(pair1);
     fitResolutions.emplace_back(pair2);
 
-    model.setModel("name=FlatBackground", fitResolutions,
+    model.setModel("name=FlatBackground", fitResolutions, "",
                    "name=TeixeiraWaterSQE", true, std::vector<double>(), false,
                    false, 100.0);
 
     auto fitFunctionAsString = model.getFitFunction()->asString();
-    std::cout << fitFunctionAsString << std::endl;
     TS_ASSERT_EQUALS(
         fitFunctionAsString,
         "composite=MultiDomainFunction,NumDeriv=true;(composite="
@@ -355,7 +354,7 @@ public:
     fitResolutions.emplace_back(pair2);
 
     model.setModel("name=FlatBackground", fitResolutions,
-                   "(name=Lorentzian;name=Lorentzian)", true,
+                   "(name=Lorentzian;name=Lorentzian)", "", true,
                    std::vector<double>(), false, false, 100.0);
 
     auto fitFunctionAsString = model.getFitFunction()->asString();
@@ -391,7 +390,7 @@ public:
     fitResolutions.emplace_back(pair2);
 
     model.setModel("name=FlatBackground", fitResolutions,
-                   "(name=Lorentzian;name=Lorentzian)", true,
+                   "(name=Lorentzian;name=Lorentzian)", "", true,
                    std::vector<double>(), false, true, 100.0);
 
     auto fitFunctionAsString = model.getFitFunction()->asString();
@@ -433,7 +432,7 @@ public:
     fitResolutions.emplace_back(pair2);
 
     model.setModel("name=FlatBackground", fitResolutions,
-                   "(name=Lorentzian;name=Lorentzian)", true,
+                   "(name=Lorentzian;name=Lorentzian)","", true,
                    std::vector<double>(), false, false, 100.0);
 
     TS_ASSERT_EQUALS(model.backgroundPrefix().value().toStdString(), "f0.");
@@ -462,7 +461,7 @@ public:
     fitResolutions.emplace_back(pair2);
 
     model.setModel("name=FlatBackground", fitResolutions,
-                   "(name=Lorentzian;name=Lorentzian)", false,
+                   "(name=Lorentzian;name=Lorentzian)", "", false,
                    std::vector<double>(), false, true, 100.0);
 
     TS_ASSERT_EQUALS(model.backgroundPrefix().value().toStdString(), "f0.");
@@ -490,7 +489,7 @@ public:
     fitResolutions.emplace_back(pair1);
     fitResolutions.emplace_back(pair2);
 
-    model.setModel("", fitResolutions, "", false, std::vector<double>(), false,
+    model.setModel("", fitResolutions, "","", false, std::vector<double>(), false,
                    true, 100.0);
 
     TS_ASSERT_EQUALS(model.convolutionPrefix().value().toStdString(), "");
@@ -514,6 +513,7 @@ public:
     fitResolutions.emplace_back(pair2);
 
     model.setModel("name=FlatBackground", fitResolutions, "name=Lorentzian",
+                   "",
                    false, std::vector<double>(), false, true, 100.0);
     TS_ASSERT_EQUALS(model.backgroundPrefix().value().toStdString(), "f0.");
     TS_ASSERT_EQUALS(model.convolutionPrefix().value().toStdString(), "f1.");
@@ -539,6 +539,7 @@ public:
     fitResolutions.emplace_back(pair2);
 
     model.setModel("name=FlatBackground", fitResolutions, "name=Lorentzian",
+                   "",
                    true, std::vector<double>(), false, true, 100.0);
     TS_ASSERT_EQUALS(model.backgroundPrefix().value().toStdString(), "f0.");
     TS_ASSERT_EQUALS(model.convolutionPrefix().value().toStdString(), "f1.");

--- a/qt/widgets/common/test/ConvolutionFunctionModelTest.h
+++ b/qt/widgets/common/test/ConvolutionFunctionModelTest.h
@@ -108,7 +108,6 @@ public:
 
   void test_background_after_convolution() {
     ConvolutionFunctionModel model;
-    int a = 3;
     TS_ASSERT_THROWS_NOTHING(
         model.setFunctionString("(composite=Convolution;name=Resolution;name="
                                 "Lorentzian);name=LinearBackground"));

--- a/qt/widgets/common/test/ConvolutionFunctionModelTest.h
+++ b/qt/widgets/common/test/ConvolutionFunctionModelTest.h
@@ -123,9 +123,10 @@ public:
 
   void test_two_peaks() {
     ConvolutionFunctionModel model;
-    TS_ASSERT_THROWS_NOTHING(model.setFunctionString(
-        "(composite=Convolution;name=Resolution;name=Lorentzian;name=Lorentzian);"
-        "name=LinearBackground"));
+    TS_ASSERT_THROWS_NOTHING(
+        model.setFunctionString("(composite=Convolution;name=Resolution;name="
+                                "Lorentzian;name=Lorentzian);"
+                                "name=LinearBackground"));
     TS_ASSERT_EQUALS(model.backgroundPrefix()->toStdString(), "f1.");
     TS_ASSERT_EQUALS(model.convolutionPrefix()->toStdString(), "f0.");
     TS_ASSERT_EQUALS(model.resolutionWorkspace(), "");
@@ -138,8 +139,9 @@ public:
 
   void test_two_peaks_no_background() {
     ConvolutionFunctionModel model;
-    TS_ASSERT_THROWS_NOTHING(model.setFunctionString(
-        "composite=Convolution;name=Resolution;name=Lorentzian;name=Lorentzian"));
+    TS_ASSERT_THROWS_NOTHING(
+        model.setFunctionString("composite=Convolution;name=Resolution;name="
+                                "Lorentzian;name=Lorentzian"));
     TS_ASSERT(!model.backgroundPrefix());
     TS_ASSERT_EQUALS(model.convolutionPrefix()->toStdString(), "");
     TS_ASSERT_EQUALS(model.resolutionWorkspace(), "");
@@ -177,9 +179,9 @@ public:
 
   void test_two_peaks_no_background_delta() {
     ConvolutionFunctionModel model;
-    TS_ASSERT_THROWS_NOTHING(
-        model.setFunctionString("composite=Convolution;name=Resolution;name="
-                                "Lorentzian;name=Lorentzian;name=DeltaFunction"));
+    TS_ASSERT_THROWS_NOTHING(model.setFunctionString(
+        "composite=Convolution;name=Resolution;name="
+        "Lorentzian;name=Lorentzian;name=DeltaFunction"));
     TS_ASSERT(!model.backgroundPrefix());
     TS_ASSERT_EQUALS(model.convolutionPrefix()->toStdString(), "");
     TS_ASSERT_EQUALS(model.resolutionWorkspace(), "");
@@ -192,10 +194,10 @@ public:
 
   void test_two_peaks_delta() {
     ConvolutionFunctionModel model;
-    TS_ASSERT_THROWS_NOTHING(
-        model.setFunctionString("(composite=Convolution;name=Resolution;name="
-                                "DeltaFunction;name=Lorentzian;name=Lorentzian);"
-                                "name=LinearBackground"));
+    TS_ASSERT_THROWS_NOTHING(model.setFunctionString(
+        "(composite=Convolution;name=Resolution;name="
+        "DeltaFunction;name=Lorentzian;name=Lorentzian);"
+        "name=LinearBackground"));
     TS_ASSERT_EQUALS(model.backgroundPrefix()->toStdString(), "f1.");
     TS_ASSERT_EQUALS(model.convolutionPrefix()->toStdString(), "f0.");
     TS_ASSERT_EQUALS(model.resolutionWorkspace(), "");
@@ -432,7 +434,7 @@ public:
     fitResolutions.emplace_back(pair2);
 
     model.setModel("name=FlatBackground", fitResolutions,
-                   "(name=Lorentzian;name=Lorentzian)","", true,
+                   "(name=Lorentzian;name=Lorentzian)", "", true,
                    std::vector<double>(), false, false, 100.0);
 
     TS_ASSERT_EQUALS(model.backgroundPrefix().value().toStdString(), "f0.");
@@ -489,8 +491,8 @@ public:
     fitResolutions.emplace_back(pair1);
     fitResolutions.emplace_back(pair2);
 
-    model.setModel("", fitResolutions, "","", false, std::vector<double>(), false,
-                   true, 100.0);
+    model.setModel("", fitResolutions, "", "", false, std::vector<double>(),
+                   false, true, 100.0);
 
     TS_ASSERT_EQUALS(model.convolutionPrefix().value().toStdString(), "");
     TS_ASSERT_EQUALS(model.tempFunctionPrefix().value().toStdString(),
@@ -512,8 +514,7 @@ public:
     fitResolutions.emplace_back(pair1);
     fitResolutions.emplace_back(pair2);
 
-    model.setModel("name=FlatBackground", fitResolutions, "name=Lorentzian",
-                   "",
+    model.setModel("name=FlatBackground", fitResolutions, "name=Lorentzian", "",
                    false, std::vector<double>(), false, true, 100.0);
     TS_ASSERT_EQUALS(model.backgroundPrefix().value().toStdString(), "f0.");
     TS_ASSERT_EQUALS(model.convolutionPrefix().value().toStdString(), "f1.");
@@ -538,8 +539,7 @@ public:
     fitResolutions.emplace_back(pair1);
     fitResolutions.emplace_back(pair2);
 
-    model.setModel("name=FlatBackground", fitResolutions, "name=Lorentzian",
-                   "",
+    model.setModel("name=FlatBackground", fitResolutions, "name=Lorentzian", "",
                    true, std::vector<double>(), false, true, 100.0);
     TS_ASSERT_EQUALS(model.backgroundPrefix().value().toStdString(), "f0.");
     TS_ASSERT_EQUALS(model.convolutionPrefix().value().toStdString(), "f1.");


### PR DESCRIPTION
**Description of work.**
This PR reworks the function browser in the ConvFit tab of the IDA GUI. The main objective of this rework is to allow Lorentzians to be combined with other functions defined within the tab.

This PR encountered an issue with the spinbox defined as part of `QtIntPropertyManager`. When this value is changed, it kicks off a timer which is used to simulate `mouse hold` events. However, when the slot triggers a processing stage which takes a "long" time, the timer event falsely goes off, which leads to the spinbox being incremented (meaning it will increment to its maximum value on the first step). Ideally we should be able to detatch that timer for particular use cases (such as this one). A similar issue can be found in the QT bug report https://bugreports.qt.io/browse/QTBUG-33128. To get round this issue for the time being we have offloaded the main processing to Qt threads, which allows us to continue processing the `QtEvents` (which ceases the spin box timer event). An issue to deal with this can be found in #29046

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** ISIS/Spencer
-->

**To test:**

- Data to test each tab of the Indirect Data Analysis GUI can be found in #26631.
- Open the Indirect Data Analysis GUI
- Go to the ConvFit tab
- Load in data and a resolution file
- Add a single lorentzian using the new spinner
- Add a fit type
- Do a fit (this should all work)
- Play around with the GUI checking other functionality works e.g Switching between the full function view using the checkbox
<!-- Instructions for testing. -->

This is part of a minor set of changes to the IDA GUI #28484


<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
-->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
