### PR TITLE
Prevent workbench settings appearing off screen

### DIFF
--- a/docs/source/release/v5.1.0/mantidworkbench.rst
+++ b/docs/source/release/v5.1.0/mantidworkbench.rst
@@ -84,6 +84,7 @@ Improvements
 - Added an option in the settings to specify the default legend size.
 - Added an option to the settings window to set the default colormap for image plots.
 - Improved loading of python plugins at startup on slow disks.
+- Workbench will now spot if it is about to create the settings window off the available screen, and will move it so it is all visible. This is important as it is a modal dialog and could freeze the application in an unrecoverable way before.
 - Sliceviewer no longer lists the reversed colourmaps along with the regular, instead they are accessed with a reverse checkbox.
 - Sliceviewer colourmap uses the default colourmap from the settings.
 

--- a/qt/applications/workbench/workbench/widgets/settings/presenter.py
+++ b/qt/applications/workbench/workbench/widgets/settings/presenter.py
@@ -10,6 +10,7 @@ from qtpy.QtWidgets import QFileDialog
 
 from mantid import ConfigService
 from mantidqt.interfacemanager import InterfaceManager
+from mantidqt.utils.qt import ensure_widget_is_on_screen
 from workbench.widgets.settings.categories.presenter import CategoriesSettings, CategoryProperties
 from workbench.widgets.settings.fitting.presenter import FittingSettings, FittingProperties
 from workbench.widgets.settings.general.presenter import GeneralSettings, GeneralProperties
@@ -56,6 +57,7 @@ class SettingsPresenter(object):
             self.view.setWindowModality(Qt.WindowModal)
 
         self.view.show()
+        ensure_widget_is_on_screen(self.view)
         self.current.show()
 
     def hide(self):

--- a/qt/python/mantidqt/utils/qt/__init__.py
+++ b/qt/python/mantidqt/utils/qt/__init__.py
@@ -179,7 +179,6 @@ def add_actions(target, actions):
             raise ValueError("Unexpected action type. "
                              "Expected one of (QAction,QMenu) but found '{}'".format(type(action)))
 
-
 def toQSettings(settings):
     '''Utility function to convert supplied settings object to a qtpy.QtCore.QSettings
     '''

--- a/qt/python/mantidqt/utils/qt/__init__.py
+++ b/qt/python/mantidqt/utils/qt/__init__.py
@@ -179,6 +179,7 @@ def add_actions(target, actions):
             raise ValueError("Unexpected action type. "
                              "Expected one of (QAction,QMenu) but found '{}'".format(type(action)))
 
+
 def toQSettings(settings):
     '''Utility function to convert supplied settings object to a qtpy.QtCore.QSettings
     '''
@@ -187,13 +188,12 @@ def toQSettings(settings):
     else:  # must be a QSettings already
         return settings
 
+
 def ensure_widget_is_on_screen(widget):
     """If the supplied widget is off the screen it will be moved so it is on the screen.
     The widget must already be 'shown' """
-
-    # make sure the window is smaller than the desktop
-    desktop = QDesktopWidget()
     # this gives the maximum screen number if the position is off screen
+    desktop = QDesktopWidget()
     screen = desktop.screenNumber(widget.pos())
 
     # get the window size


### PR DESCRIPTION
**Description of work.**
The settings dialog is modal so if it appears off screen then you are in an unrecoverable situation.

This change adds a helper method, and uses it in the settings presenter that will move any widget that appears off the screen back on.

**To test:**
1. Start workbench
1. File -> settings
1. The settings window should appear roughly in the centre of the workbench window
1. Move the window so most of it is hanging off the bottom of the screen, just the menus are visible.
1. File -> settings
1. The settings window should be fully visible on the screen (not off the bottom)
1. repeat the above after moving most of the window off the right of the screen
1. if you have more than one screen repeat the above with the workbench window straddling the two screens.

Fixes #28061 


---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
