### PR TITLE
Add missing imports from gcc 10

### DIFF
--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Common/Decoder.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Common/Decoder.h
@@ -16,6 +16,7 @@
 #include <QTableWidget>
 #include <QVariant>
 #include <boost/optional.hpp>
+#include <string>
 
 namespace MantidQt {
 namespace CustomInterfaces {

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Common/Encoder.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Common/Encoder.h
@@ -15,6 +15,7 @@
 #include <QString>
 #include <QTableWidget>
 #include <QVariant>
+#include <string>
 
 namespace MantidQt {
 namespace CustomInterfaces {

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Options/IOptionsDialogView.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Options/IOptionsDialogView.h
@@ -8,6 +8,7 @@
 
 #include "Common/DllConfig.h"
 #include <map>
+#include <string>
 
 namespace MantidQt {
 namespace CustomInterfaces {

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Save/IAsciiSaver.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Save/IAsciiSaver.h
@@ -8,6 +8,7 @@
 #include "Common/DllConfig.h"
 #include "MantidAPI/IAlgorithm_fwd.h"
 #include "MantidAPI/MatrixWorkspace_fwd.h"
+#include <stdexcept>
 #include <string>
 #include <vector>
 namespace MantidQt {

--- a/qt/scientific_interfaces/ISISReflectometry/Reduction/ReductionOptionsMap.h
+++ b/qt/scientific_interfaces/ISISReflectometry/Reduction/ReductionOptionsMap.h
@@ -6,6 +6,8 @@
 // SPDX - License - Identifier: GPL - 3.0 +
 #pragma once
 #include <map>
+#include <string>
+
 namespace MantidQt {
 namespace CustomInterfaces {
 namespace ISISReflectometry {

--- a/qt/scientific_interfaces/Indirect/IFQFitObserver.h
+++ b/qt/scientific_interfaces/Indirect/IFQFitObserver.h
@@ -7,6 +7,7 @@
 #pragma once
 
 #include <map>
+#include <string>
 
 class IFQFitObserver {
 public:

--- a/qt/scientific_interfaces/Indirect/IndirectFunctionBrowser/SingleFunctionTemplateModel.h
+++ b/qt/scientific_interfaces/Indirect/IndirectFunctionBrowser/SingleFunctionTemplateModel.h
@@ -16,6 +16,7 @@
 
 #include <QMap>
 #include <boost/optional.hpp>
+#include <string>
 
 namespace MantidQt {
 namespace CustomInterfaces {


### PR DESCRIPTION
`std::string` is not not implicitly included in gcc 10. This may also be an issue with newer qt5.

**To test:**

The builds should pass.

*There is no associated issue.*

*This does not require release notes* because it is a change to the imports for fedora 32.


---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
