### PR TITLE
Minor change to give newly added script tabs focus

### DIFF
--- a/qt/python/mantidqt/widgets/codeeditor/multifileinterpreter.py
+++ b/qt/python/mantidqt/widgets/codeeditor/multifileinterpreter.py
@@ -9,6 +9,7 @@
 #
 # std imports
 import os.path as osp
+from os import linesep
 
 # 3rd party imports
 from qtpy.QtCore import Qt, Slot, Signal
@@ -146,6 +147,11 @@ class MultiPythonFileInterpreter(QWidget):
         tab_idx = self._tabs.addTab(interpreter, tab_title)
         self._tabs.setTabToolTip(tab_idx, tab_tooltip)
         self._tabs.setCurrentIndex(tab_idx)
+
+        # set the cursor to the last line and give the new editor focus
+        interpreter.editor.setFocus()
+        line_count = content.count(linesep)
+        interpreter.editor.setCursorPosition(line_count,0)
         return tab_idx
 
     def abort_current(self):

--- a/qt/python/mantidqt/widgets/codeeditor/multifileinterpreter.py
+++ b/qt/python/mantidqt/widgets/codeeditor/multifileinterpreter.py
@@ -150,8 +150,9 @@ class MultiPythonFileInterpreter(QWidget):
 
         # set the cursor to the last line and give the new editor focus
         interpreter.editor.setFocus()
-        line_count = content.count(linesep)
-        interpreter.editor.setCursorPosition(line_count,0)
+        if content is not None:
+            line_count = content.count(linesep)
+            interpreter.editor.setCursorPosition(line_count,0)
         return tab_idx
 
     def abort_current(self):


### PR DESCRIPTION
**Description of work.**
A small change to give focus to the editor and set cursor position for newly created tabs in the script editor



**To test:**
1. open workbench
1. Add a new tab with the + button
1. the cursor should be at the bottom of the new tab and typing should go straight there without having to click on it first.
1. Create a couple of tabs
1. Save them, reload them, exit and restart workbench with them open
1. None of those should set the cursor position or give the editor focus, only creating a new tab

*There is no associated issue.*


*This does not require release notes* because *it is a very minor quality of life improvement*


---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
