### PR TITLE
Avoid changing behaviour of __round__ in numpy 1.19 in doc tests

### DIFF
--- a/docs/source/algorithms/ComputeCalibrationCoefVan-v1.rst
+++ b/docs/source/algorithms/ComputeCalibrationCoefVan-v1.rst
@@ -73,18 +73,18 @@ Usage
     epptable = FindEPP(wsVana)
     # calculate correction coefficients
     wsCoefs = ComputeCalibrationCoefVan(wsVana, epptable)
-    print('Spectrum 4 of the output workspace is filled with:  {}'.format(round(wsCoefs.readY(999)[0])))
+    print(f'Spectrum 4 of the output workspace is filled with:  {wsCoefs.readY(999)[0]:.1f}')
 
     # wsCoefs can be used as rhs with Divide algorithm to apply correction to the data
     wsCorr = wsVana/wsCoefs
-    print('Spectrum 4 of the input workspace is filled with:  {}'.format(round(wsVana.readY(999)[0], 1)))
-    print('Spectrum 4 of the corrected workspace is filled with:  {}'.format(round(wsCorr.readY(999)[0], 5)))
+    print(f'Spectrum 4 of the input workspace is filled with:  {wsVana.readY(999)[0]:.1f}')
+    print(f'Spectrum 4 of the corrected workspace is filled with:  {wsCorr.readY(999)[0]:.5f}')
 
 Output:
 
 .. testoutput:: ExComputeCalibrationCoefVan
 
-    Spectrum 4 of the output workspace is filled with:  6895.0
+    Spectrum 4 of the output workspace is filled with:  6894.8
     Spectrum 4 of the input workspace is filled with:  1.0
     Spectrum 4 of the corrected workspace is filled with:  0.00015
 

--- a/docs/source/algorithms/CropWorkspaceForMDNorm-v1.rst
+++ b/docs/source/algorithms/CropWorkspaceForMDNorm-v1.rst
@@ -11,7 +11,7 @@ Description
 -----------
 
 This algorithm is part of the new workflow for :ref:`normalizing <MDNorm>` multi-dimensional event workspaces.
-It is intended to :ref:`crop <algm-CropWorkspace>` the input event workspace, and store the end 
+It is intended to :ref:`crop <algm-CropWorkspace>` the input event workspace, and store the end
 of detector trajectories in either momentum (diffraction) or energy transfer (inelastic) units.
 
 **Example - CropWorkspaceForMDNorm**
@@ -26,9 +26,9 @@ of detector trajectories in either momentum (diffraction) or energy transfer (in
   ws_out = CropWorkspaceForMDNorm(InputWorkspace=ws_in,
                                   XMin=1,
                                   XMax=6)
-  print("Number of events in the original workspace {0}".format(ws_in.getNumberEvents()))
-  print("Number of events in the cropped workspace {0}".format(ws_out.getNumberEvents()))
-  print("Largest momentum in the output workspace {0}".format(round(ws_out.getSpectrum(1).getTofs().max())))
+  print(f"Number of events in the original workspace {ws_in.getNumberEvents()}")
+  print(f"Number of events in the cropped workspace {ws_out.getNumberEvents()}")
+  print(f"Largest momentum in the output workspace {ws_out.getSpectrum(1).getTofs().max():.1f}")
 
 .. testoutput:: CropWorkspaceForMDNormExample
 


### PR DESCRIPTION
**Description of work.**

In NumPy 1.19 [\_\_round\_\_](https://numpy.org/doc/stable/release/1.19.0-notes.html?highlight=__round__#change-output-of-round-on-scalars-to-be-consistent-with-python) changed its behaviour to be consistent with Python [`round()`](https://docs.python.org/3/library/functions.html#round). This affected the output matching for some documentation tests. See commit message for more details.

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

**To test:**

* Review and check the Ubuntu docs test pass.
* If you are able to you could upgrade numpy locally to 1.19 and check the docs tests that have changed pass.

*There is no associated issue.*

*This does not require release notes* because **it is an internal change.**

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
