### PR TITLE
Add F(q) default parameter estimations

### DIFF
--- a/docs/source/release/v5.1.0/indirect_geometry.rst
+++ b/docs/source/release/v5.1.0/indirect_geometry.rst
@@ -33,6 +33,7 @@ Improvements
 - Added fit parameter estimations to the MSD fitting tab within the Indirect Data Analysis interface.
 - Added the fit output information (Algorithm status and Chi squared) to each fitting tab of the Indirect Data Analysis interface.
   This change introduces two optional outputs from the QENSFit algorithms (fit status and Chi squared), which may be used to monitor the outcome of the fit.
+- Added default parameter estimations to the F(q) tab.
 
 Bug Fixes
 #########

--- a/qt/scientific_interfaces/Indirect/FQFitConstants.h
+++ b/qt/scientific_interfaces/Indirect/FQFitConstants.h
@@ -21,7 +21,8 @@ enum class DataType {
 };
 
 static const std::map<std::string, std::string> widthFits{
-    {{std::string("ChudleyElliot"),
+    {{"None", ""},
+     {std::string("ChudleyElliot"),
       std::string(
           "name=ChudleyElliot, Tau=1, L=1.5, constraints=(Tau>0, L>0)")},
      {std::string("HallRoss"),

--- a/qt/scientific_interfaces/Indirect/IDAFunctionParameterEstimation.cpp
+++ b/qt/scientific_interfaces/Indirect/IDAFunctionParameterEstimation.cpp
@@ -23,9 +23,11 @@ void IDAFunctionParameterEstimation::addParameterEstimationFunction(
 void IDAFunctionParameterEstimation::estimateFunctionParameters(
     ::Mantid::API::IFunction_sptr &function,
     const DataForParameterEstimation &estimationData) {
-  std::string functionName = function->name();
-  if (m_funcMap.find(functionName) != m_funcMap.end()) {
-    m_funcMap[functionName](function, estimationData);
+  if (function) {
+    std::string functionName = function->name();
+    if (m_funcMap.find(functionName) != m_funcMap.end()) {
+      m_funcMap[functionName](function, estimationData);
+    }
   }
 }
 

--- a/qt/scientific_interfaces/Indirect/IndirectFunctionBrowser/SingleFunctionTemplateModel.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectFunctionBrowser/SingleFunctionTemplateModel.cpp
@@ -17,6 +17,22 @@ namespace MantidQt {
 namespace CustomInterfaces {
 namespace IDA {
 
+namespace {
+// Sort the function list, keep existing order just rotate the None entry into
+// the front
+void sortFunctionList(QStringList &list) {
+  auto ix = std::find(list.begin(), list.end(), QString("None"));
+  if (ix == list.end() || ix == list.begin()) {
+    return;
+  } else {
+    int index = std::distance(list.begin(), ix);
+    for (auto itr = ix; itr > list.begin(); --itr) {
+      std::rotate(itr - 1, itr, itr + 1);
+    }
+  }
+}
+} // namespace
+
 using namespace MantidWidgets;
 using namespace Mantid::API;
 
@@ -28,25 +44,33 @@ SingleFunctionTemplateModel::SingleFunctionTemplateModel(
 
 void SingleFunctionTemplateModel::updateAvailableFunctions(
     const std::map<std::string, std::string> &functionInitialisationStrings) {
-  m_functionStore.clear();
+  m_fitTypeToFunctionStore.clear();
   m_globalParameterStore.clear();
+  m_fitTypeList.clear();
   for (auto functionInfo : functionInitialisationStrings) {
-    auto function =
-        FunctionFactory::Instance().createInitialized(functionInfo.second);
-    m_functionStore.insert(QString::fromStdString(functionInfo.first),
-                           function);
+    IFunction_sptr function;
+    try {
+      function =
+          FunctionFactory::Instance().createInitialized(functionInfo.second);
+    } catch (std::invalid_argument &) {
+      // Error in function string, adding an empty function to map
+    }
+    m_fitTypeToFunctionStore.insert(QString::fromStdString(functionInfo.first),
+                                    function);
     m_globalParameterStore.insert(QString::fromStdString(functionInfo.first),
                                   QStringList());
   }
-  m_fitType = m_functionStore.keys().first();
+  // Sort the FunctionList as None should always appear first
+  m_fitTypeList = m_fitTypeToFunctionStore.keys();
+  sortFunctionList(m_fitTypeList);
+  m_fitType = m_fitTypeList.front();
 }
 
 QStringList SingleFunctionTemplateModel::getFunctionList() {
-  return m_functionStore.keys();
+  return m_fitTypeList;
 }
-
 int SingleFunctionTemplateModel::getEnumIndex() {
-  return m_functionStore.keys().indexOf(m_fitType);
+  return m_fitTypeList.indexOf(m_fitType);
 }
 
 void SingleFunctionTemplateModel::setFunction(IFunction_sptr fun) {
@@ -54,16 +78,9 @@ void SingleFunctionTemplateModel::setFunction(IFunction_sptr fun) {
     return;
   if (fun->nFunctions() == 0) {
     const auto name = fun->name();
-    std::vector<std::string> functionNameList;
-    std::unordered_map<std::string, QString> functionNameToDisplayNameMap;
-    for (auto functionKey : m_functionStore.keys()) {
-      auto functionName = m_functionStore[functionKey]->name();
-      functionNameList.emplace_back(functionName);
-      functionNameToDisplayNameMap.emplace(functionName, functionKey);
-    }
-    if (std::find(functionNameList.cbegin(), functionNameList.cend(), name) !=
-        functionNameList.cend()) {
-      setFitType(functionNameToDisplayNameMap.at(name));
+    auto fitType = findFitTypeForFunctionName(QString::fromStdString(name));
+    if (fitType) {
+      setFitType(fitType.value());
     } else {
       throw std::runtime_error("Cannot set function " + name);
     }
@@ -72,17 +89,17 @@ void SingleFunctionTemplateModel::setFunction(IFunction_sptr fun) {
   }
 }
 
-void SingleFunctionTemplateModel::setFitType(const QString &name) {
+void SingleFunctionTemplateModel::setFitType(const QString &type) {
   if (m_function) {
     m_globalParameterStore[m_fitType] = getGlobalParameters();
   }
-  m_fitType = name;
-  if (name == "None") {
-    clear();
+  m_fitType = type;
+  if (type == "None") {
+    FunctionModel::setFunction(IFunction_sptr());
     return;
   }
-  setGlobalParameters(m_globalParameterStore[name]);
-  FunctionModel::setFunction(m_functionStore[name]->clone());
+  setGlobalParameters(m_globalParameterStore[type]);
+  FunctionModel::setFunction(m_fitTypeToFunctionStore[type]->clone());
   estimateFunctionParameters();
 }
 
@@ -115,6 +132,24 @@ void SingleFunctionTemplateModel::setGlobal(const QString &name,
   }
   globalParameters.removeDuplicates();
   setGlobalParameters(globalParameters);
+}
+
+boost::optional<QString>
+SingleFunctionTemplateModel::findFitTypeForFunctionName(
+    const QString &name) const {
+  auto nameAsString = name.toStdString();
+  auto result = std::find_if(m_fitTypeToFunctionStore.constBegin(),
+                             m_fitTypeToFunctionStore.constEnd(),
+                             [&nameAsString](const auto &function) -> bool {
+                               if (function)
+                                 return function->name() == nameAsString;
+                               else
+                                 return false;
+                             });
+  if (result != std::end(m_fitTypeToFunctionStore)) {
+    return boost::optional<QString>{result.key()};
+  }
+  return boost::none;
 }
 
 } // namespace IDA

--- a/qt/scientific_interfaces/Indirect/IndirectFunctionBrowser/SingleFunctionTemplateModel.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectFunctionBrowser/SingleFunctionTemplateModel.cpp
@@ -25,7 +25,6 @@ void sortFunctionList(QStringList &list) {
   if (ix == list.end() || ix == list.begin()) {
     return;
   } else {
-    int index = std::distance(list.begin(), ix);
     for (auto itr = ix; itr > list.begin(); --itr) {
       std::rotate(itr - 1, itr, itr + 1);
     }

--- a/qt/scientific_interfaces/Indirect/IndirectFunctionBrowser/SingleFunctionTemplateModel.h
+++ b/qt/scientific_interfaces/Indirect/IndirectFunctionBrowser/SingleFunctionTemplateModel.h
@@ -51,10 +51,13 @@ public:
 private:
   QString m_fitType;
   DataForParameterEstimationCollection m_estimationData;
-  QMap<QString, IFunction_sptr> m_functionStore;
+  QMap<QString, IFunction_sptr> m_fitTypeToFunctionStore;
   QMap<QString, QStringList> m_globalParameterStore;
+  QStringList m_fitTypeList;
   std::string m_resolutionName;
   TableDatasetIndex m_resolutionIndex;
+  boost::optional<QString>
+  findFitTypeForFunctionName(const QString &name) const;
   // Parameter estimation
   std::unique_ptr<IDAFunctionParameterEstimation> m_parameterEstimation;
 };

--- a/qt/scientific_interfaces/Indirect/IndirectFunctionBrowser/SingleFunctionTemplatePresenter.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectFunctionBrowser/SingleFunctionTemplatePresenter.cpp
@@ -45,8 +45,6 @@ void SingleFunctionTemplatePresenter::updateAvailableFunctions(
 }
 
 void SingleFunctionTemplatePresenter::setFitType(const QString &name) {
-  if (name == "None")
-    return;
   m_view->clear();
   m_model.setFitType(name);
   auto functionParameters = m_model.getParameterNames();

--- a/qt/scientific_interfaces/Indirect/JumpFit.cpp
+++ b/qt/scientific_interfaces/Indirect/JumpFit.cpp
@@ -17,6 +17,7 @@
 #include "MantidAPI/MultiDomainFunction.h"
 #include "MantidAPI/Run.h"
 #include "MantidAPI/WorkspaceGroup.h"
+#include "MantidKernel/PhysicalConstants.h"
 #include "MantidQtWidgets/Common/UserInputValidator.h"
 
 #include "MantidQtWidgets/Common/SignalBlocker.h"
@@ -30,6 +31,11 @@ using namespace Mantid::API;
 namespace MantidQt {
 namespace CustomInterfaces {
 namespace IDA {
+
+namespace {
+constexpr double HBAR = Mantid::PhysicalConstants::h /
+                        Mantid::PhysicalConstants::meV * 1e12 / (2 * M_PI);
+}
 
 std::vector<std::string> FQFIT_HIDDEN_PROPS = std::vector<std::string>(
     {"CreateOutput", "LogValue", "PassWSIndexToFunction", "ConvolveMembers",
@@ -106,15 +112,106 @@ void JumpFit::setRunEnabled(bool enable) {
 }
 
 EstimationDataSelector JumpFit::getEstimationDataSelector() const {
-  return [](const std::vector<double> &, const std::vector<double> &,
-            const std::pair<double, double>) -> DataForParameterEstimation {
-    return DataForParameterEstimation{};
-  };
+  return
+      [](const std::vector<double> &x, const std::vector<double> &y,
+         const std::pair<double, double> range) -> DataForParameterEstimation {
+        // Find data thats within range
+        double xmin = range.first;
+        double xmax = range.second;
+
+        // If the two points are equal return empty data
+        if (fabs(xmin - xmax) < 1e-7) {
+          return DataForParameterEstimation{};
+        }
+
+        const auto startItr = std::find_if(
+            x.cbegin(), x.cend(),
+            [xmin](const double &val) -> bool { return val >= (xmin - 1e-7); });
+        auto endItr = std::find_if(
+            x.cbegin(), x.cend(),
+            [xmax](const double &val) -> bool { return val > xmax; });
+
+        if (std::distance(startItr, endItr - 1) < 2)
+          return DataForParameterEstimation{};
+
+        size_t first = std::distance(x.cbegin(), startItr);
+        size_t end = std::distance(x.cbegin(), endItr);
+        size_t m = first + (end - first) / 2;
+
+        return DataForParameterEstimation{{x[first], x[m]}, {y[first], y[m]}};
+      };
 }
-// TODO: Implement parameter estimation for JumpFit functions
+
+namespace {
+void estimateChudleyElliot(::Mantid::API::IFunction_sptr &function,
+                           const DataForParameterEstimation &estimationData) {
+
+  auto y = estimationData.y;
+  auto x = estimationData.x;
+  if (x.size() != 2 || y.size() != 2) {
+    return;
+  }
+
+  double L = 1.5;
+  double tau = (HBAR / y[1]) * (1 - sin(x[1] * L) / (L * x[1]));
+
+  function->setParameter("L", L);
+  function->setParameter("Tau", tau);
+}
+void estimateHallRoss(::Mantid::API::IFunction_sptr &function,
+                      const DataForParameterEstimation &estimationData) {
+
+  auto y = estimationData.y;
+  auto x = estimationData.x;
+  if (x.size() != 2 || y.size() != 2) {
+    return;
+  }
+
+  double L = 0.2;
+  double tau = (HBAR / y[1]) * (1 - exp((-x[1] * x[1] * L * L) / 2));
+
+  function->setParameter("L", L);
+  function->setParameter("Tau", tau);
+}
+void estimateTeixeiraWater(::Mantid::API::IFunction_sptr &function,
+                           const DataForParameterEstimation &estimationData) {
+
+  auto y = estimationData.y;
+  auto x = estimationData.x;
+  if (x.size() != 2 || y.size() != 2) {
+    return;
+  }
+
+  double L = 1.5;
+  double QL = x[1] * L;
+  double tau = (HBAR / y[1]) * ((QL * QL) / (6 + QL * QL));
+
+  function->setParameter("L", L);
+  function->setParameter("Tau", tau);
+}
+void estimateFickDiffusion(::Mantid::API::IFunction_sptr &function,
+                           const DataForParameterEstimation &estimationData) {
+  auto y = estimationData.y;
+  auto x = estimationData.x;
+  if (x.size() != 2 || y.size() != 2) {
+    return;
+  }
+
+  function->setParameter("D", y[1] / (x[1] * x[1]));
+}
+} // namespace
+
 IDAFunctionParameterEstimation JumpFit::createParameterEstimation() const {
 
   IDAFunctionParameterEstimation parameterEstimation;
+  parameterEstimation.addParameterEstimationFunction("ChudleyElliot",
+                                                     estimateChudleyElliot);
+  parameterEstimation.addParameterEstimationFunction("HallRoss",
+                                                     estimateHallRoss);
+  parameterEstimation.addParameterEstimationFunction("TeixeiraWater",
+                                                     estimateTeixeiraWater);
+  parameterEstimation.addParameterEstimationFunction("FickDiffusion",
+                                                     estimateFickDiffusion);
 
   return parameterEstimation;
 }

--- a/qt/scientific_interfaces/Indirect/MSDFit.cpp
+++ b/qt/scientific_interfaces/Indirect/MSDFit.cpp
@@ -40,7 +40,8 @@ namespace CustomInterfaces {
 namespace IDA {
 
 auto msdFunctionStrings = std::map<std::string, std::string>(
-    {{"Gauss", "name=MsdGauss,Height=1,Msd=0.05,constraints=(Height>0, Msd>0)"},
+    {{"None", ""},
+     {"Gauss", "name=MsdGauss,Height=1,Msd=0.05,constraints=(Height>0, Msd>0)"},
      {"Peters",
       "name=MsdPeters,Height=1,Msd=0.05,Beta=1,constraints=(Height>0, "
       "Msd>0, Beta>0)"},


### PR DESCRIPTION
**Description of work.**
This PR adds default parameter estimations to the F(q) tab. It also adds a none entry to the single template function browser to be consistent with the other tabs in the interface which start with 'none' in the function browser.

**To test:**

- Data to test each tab of the Indirect Data Analysis GUI can be found in #26631.
- Open the Indirect Data Analysis GUI
- Go to the F(Q) fitting tab
- Load Data
- Test the plot guess checkbox with each function in the interface, you should get a "good" guess with each function now.
- Lastly, check that the function browser behaves as expected. E.g switch between the template and full function view using the checkbox.

<!-- Instructions for testing. -->


This PR is part of the IDA minor fixes epic #28484.

----------------------------
#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
