### PR TITLE
Colour fill plots fail on workspaces of monitors

### DIFF
--- a/Framework/PythonInterface/mantid/plots/datafunctions.py
+++ b/Framework/PythonInterface/mantid/plots/datafunctions.py
@@ -480,6 +480,13 @@ def get_matrix_2d_ragged(workspace, normalize_by_bin_width, histogram2D=False, t
             max_value = max(max_value, xtmp.max())
             diff = xtmp[1:] - xtmp[:-1]
             delta = min(delta, diff.min())
+    xtmp = workspace.readX(0)
+    if delta == np.finfo(np.float64).max:
+        delta = (xtmp[1:] - xtmp[:-1]).min()
+    if min_value == np.finfo(np.float64).max:
+        min_value = xtmp.min()
+    if max_value == np.finfo(np.float64).min:
+        max_value = xtmp.max()
     num_edges = int(np.ceil((max_value - min_value)/delta)) + 1
     x_centers = np.linspace(min_value, max_value, num=num_edges)
     y = mantid.plots.datafunctions.boundaries_from_points(workspace.getAxis(1).extractValues())

--- a/Framework/PythonInterface/mantid/plots/datafunctions.py
+++ b/Framework/PythonInterface/mantid/plots/datafunctions.py
@@ -478,11 +478,11 @@ def get_matrix_2d_ragged(workspace, normalize_by_bin_width, histogram2D=False, t
                 pass
             min_value = min(min_value, xtmp.min())
             max_value = max(max_value, xtmp.max())
-            diff = xtmp[1:] - xtmp[:-1]
+            diff = np.diff(xtmp)
             delta = min(delta, diff.min())
     xtmp = workspace.readX(0)
     if delta == np.finfo(np.float64).max:
-        delta = (xtmp[1:] - xtmp[:-1]).min()
+        delta = np.diff(xtmp).min()
     if min_value == np.finfo(np.float64).max:
         min_value = xtmp.min()
     if max_value == np.finfo(np.float64).min:

--- a/Framework/PythonInterface/mantid/plots/datafunctions.py
+++ b/Framework/PythonInterface/mantid/plots/datafunctions.py
@@ -584,6 +584,8 @@ def get_uneven_data(workspace, distribution):
     y = []
     nhist = workspace.getNumberHistograms()
     yvals = workspace.getAxis(1).extractValues()
+    if yvals == ['']:
+        yvals = np.array([0])
     if len(yvals) == nhist:
         yvals = boundaries_from_points(yvals)
     try:
@@ -599,7 +601,7 @@ def get_uneven_data(workspace, distribution):
         else:
             xvals = boundaries_from_points(xvals)
         if specInfo and specInfo.hasDetectors(index) and (specInfo.isMasked(index) or specInfo.isMonitor(index)):
-            zvals[:] = np.nan
+            zvals = np.full_like(zvals, np.nan, dtype=np.double)
         zvals = np.ma.masked_invalid(zvals)
         z.append(zvals)
         x.append(xvals)

--- a/Framework/PythonInterface/mantid/plots/datafunctions.py
+++ b/Framework/PythonInterface/mantid/plots/datafunctions.py
@@ -531,7 +531,11 @@ def get_matrix_2d_data(workspace, distribution, histogram2D=False, transpose=Fal
     except RuntimeError:
         raise ValueError('The spectra are not the same length. Try using pcolor, pcolorfast, or pcolormesh instead')
     x = workspace.extractX()
-    y = workspace.getAxis(1).extractValues()
+    if workspace.getAxis(1).isText():
+        nhist = workspace.getNumberHistograms()
+        y = np.arange(nhist)
+    else:
+        y = workspace.getAxis(1).extractValues()
     z = workspace.extractY()
 
     try:
@@ -591,8 +595,8 @@ def get_uneven_data(workspace, distribution):
     y = []
     nhist = workspace.getNumberHistograms()
     yvals = workspace.getAxis(1).extractValues()
-    if yvals == ['']:
-        yvals = np.array([0])
+    if workspace.getAxis(1).isText():
+        yvals = np.arange(nhist)
     if len(yvals) == nhist:
         yvals = boundaries_from_points(yvals)
     try:

--- a/docs/source/release/v5.1.0/mantidworkbench.rst
+++ b/docs/source/release/v5.1.0/mantidworkbench.rst
@@ -122,5 +122,6 @@ Bugfixes
 - Sub-plots in the sliceviewer now follow the scaling on the colorbar
 - Fixed a bug which prevented the double click axis editor menus from working for tiled plots.
 - Select image in the plot figure option contains each image rather than each spectra for colorfil plots of workspaces with a numeric vertical axis
+- A bug has been fixed that caused an error if a workspace containing only monitor spectra was attempted to be plotted as a colorfill plot
 
 :ref:`Release 5.1.0 <v5.1.0>`

--- a/qt/python/mantidqt/plotting/functions.py
+++ b/qt/python/mantidqt/plotting/functions.py
@@ -165,7 +165,7 @@ def pcolormesh_from_names(names, fig=None, ax=None):
 def use_imshow(ws):
     y = ws.getAxis(1).extractValues()
     if y == ['']:
-        y = [0]
+        y = np.array([0])
     difference = np.diff(y)
     try:
         commonLogBins = hasattr(ws, 'isCommonLogBins') and ws.isCommonLogBins()

--- a/qt/python/mantidqt/plotting/functions.py
+++ b/qt/python/mantidqt/plotting/functions.py
@@ -164,8 +164,9 @@ def pcolormesh_from_names(names, fig=None, ax=None):
 
 def use_imshow(ws):
     y = ws.getAxis(1).extractValues()
-    if y == ['']:
-        y = np.array([0])
+    if ws.getAxis(1).isText():
+        nhist = ws.getNumberHistograms()
+        y = np.arange(nhist)
     difference = np.diff(y)
     try:
         commonLogBins = hasattr(ws, 'isCommonLogBins') and ws.isCommonLogBins()

--- a/qt/python/mantidqt/plotting/functions.py
+++ b/qt/python/mantidqt/plotting/functions.py
@@ -164,6 +164,8 @@ def pcolormesh_from_names(names, fig=None, ax=None):
 
 def use_imshow(ws):
     y = ws.getAxis(1).extractValues()
+    if y == ['']:
+        y = [0]
     difference = np.diff(y)
     try:
         commonLogBins = hasattr(ws, 'isCommonLogBins') and ws.isCommonLogBins()


### PR DESCRIPTION
**Description of work.**

This PR fixes an issue that would cause an error is a colourfill plot was attempted on a workspace that contained only monitor spectra. This is an issue if someone attempts to do a colourfill plot on a group worspace containing one of these monitor only workspaces as it prevents the plot from being performed.

**To test:**

1. Download the ISIS Training data
2. Open the ISIS SANS interface
3. Set the user file to training_data/loqdemo/maskfile.txt
4. Set the batch file to training_data/loqdemo/batch_reduce.csv
5. Hit process all
6. Attempt to colour fill plot and of the group workspaces
7. all group workspaces should be able to be plotted.

Fixes #29035

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
