### PR TITLE
Make engineering diffraction a child of workbench

### DIFF
--- a/docs/source/release/v5.1.0/diffraction.rst
+++ b/docs/source/release/v5.1.0/diffraction.rst
@@ -40,6 +40,10 @@ Improvements
 - The currently loaded calibration is now shown at the bottom of the GUI.
 - The location of the saved output files from the GUI is now shown in the messages log.
 
+Bugfixes
+^^^^^^^^
+- The Engineering diffraction gui no longer goes behind the workbench window when a plot is clicked on.
+
 Single Crystal Diffraction
 --------------------------
 Improvements

--- a/scripts/Engineering/gui/engineering_diffraction/engineering_diffraction.py
+++ b/scripts/Engineering/gui/engineering_diffraction/engineering_diffraction.py
@@ -32,10 +32,13 @@ class EngineeringDiffractionGui(QtWidgets.QMainWindow, Ui_main_window):
     """
     The engineering diffraction interface
     """
-    def __init__(self, parent=None):
-        super(EngineeringDiffractionGui, self).__init__(parent)
+    def __init__(self, parent=None, window_flags=None):
+        if window_flags is not None:
+            super(EngineeringDiffractionGui, self).__init__(parent, window_flags)
+        else:
+            super(EngineeringDiffractionGui, self).__init__(parent)
 
-        # Main Window
+    # Main Window
         self.setupUi(self)
         self.doc = "Engineering Diffraction"
         self.tabs = self.tab_main

--- a/scripts/Engineering_Diffraction.py
+++ b/scripts/Engineering_Diffraction.py
@@ -7,10 +7,16 @@
 # pylint: disable=invalid-name
 from Engineering.gui.engineering_diffraction.engineering_diffraction import EngineeringDiffractionGui
 from qtpy import QtCore
+import sys
 
 # If the GUI has not been created yet, make a new one.
 if 'engineering_gui' not in globals():
-    engineering_gui = EngineeringDiffractionGui()
+    if 'workbench' in sys.modules:
+        from workbench.config import get_window_config
+        parent, flags = get_window_config()
+    else:
+        parent, flags = None
+    engineering_gui = EngineeringDiffractionGui(parent=parent, window_flags=flags)
 
 # Restore minimised and hidden windows without recreating the GUI.
 if engineering_gui.isHidden():  # noqa


### PR DESCRIPTION
This PR makes the engineering diffraction gui always in focus on workbench. prevously if you clicked on workbench the gui would be pushed behind the main window. this would also happen if you clicked on any of the plots this would happen as well. this PR gives the engineering diffraction the same parent status as plots or some other interfaces so that it always stays above the main window.

**To test:**

1. Interfaces -> Diffraction -> Engineering Diffraction
1. click on the main window, the gui should stay in focus.
1. check the `Plot Calibrated Workspace` box
2. Load or create a Calibration V#: 307521 CeO2#: 305738
2. click on the new plot, it should be in front of the gui but the gui should still be in front of the main window.

This should be tested in as many different OS as possible.

Fixes #28941 

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
