### PR TITLE
Sliceviewer default scale set when opened

### DIFF
--- a/docs/source/release/v5.1.0/mantidworkbench.rst
+++ b/docs/source/release/v5.1.0/mantidworkbench.rst
@@ -94,6 +94,7 @@ Improvements
 - Workbench will now spot if it is about to create the settings window off the available screen, and will move it so it is all visible. This is important as it is a modal dialog and could freeze the application in an unrecoverable way before.
 - Sliceviewer no longer lists the reversed colourmaps along with the regular, instead they are accessed with a reverse checkbox.
 - Sliceviewer colourmap uses the default colourmap from the settings.
+- Sliceviewer scale remains set when reopened
 - Code completions are now loaded when the code editor is first changed.
 
 Bugfixes

--- a/qt/applications/workbench/workbench/plugins/workspacewidget.py
+++ b/qt/applications/workbench/workbench/plugins/workspacewidget.py
@@ -23,6 +23,7 @@ from mantidqt.widgets.workspacedisplay.matrix.presenter import MatrixWorkspaceDi
 from mantidqt.widgets.workspacedisplay.table.presenter import TableWorkspaceDisplay
 from mantidqt.widgets.workspacewidget.algorithmhistorywindow import AlgorithmHistoryWindow
 from mantidqt.widgets.workspacewidget.workspacetreewidget import WorkspaceTreeWidget
+from workbench.config import CONF
 from workbench.plugins.base import PluginWidget
 
 
@@ -174,7 +175,7 @@ class WorkspaceWidget(PluginWidget):
         """
         for ws in self._ads.retrieveWorkspaces(names, unrollGroups=True):
             try:
-                presenter = SliceViewer(ws=ws, parent=self)
+                presenter = SliceViewer(ws=ws, parent=self, conf=CONF)
                 presenter.view.show()
             except Exception as exception:
                 logger.warning("Could not open slice viewer for workspace '{}'."

--- a/qt/python/mantidqt/widgets/colorbar/colorbar.py
+++ b/qt/python/mantidqt/widgets/colorbar/colorbar.py
@@ -177,12 +177,9 @@ class ColorbarWidget(QWidget):
         Called when a different normalization is selected
         """
         idx = self.norm.currentIndex()
-        scale = NORM_OPTS[idx]
         if NORM_OPTS[idx] == 'Power':
             self.powerscale.show()
             self.powerscale_label.show()
-            if self.powerscale.hasAcceptableInput():
-                scale += "," + self.powerscale.text()
         else:
             self.powerscale.hide()
             self.powerscale_label.hide()

--- a/qt/python/mantidqt/widgets/sliceviewer/presenter.py
+++ b/qt/python/mantidqt/widgets/sliceviewer/presenter.py
@@ -22,7 +22,7 @@ from .peaksviewer import PeaksViewerPresenter, PeaksViewerCollectionPresenter
 class SliceViewer(object):
     TEMPORARY_STATUS_TIMEOUT = 2000
 
-    def __init__(self, ws, parent=None, model=None, view=None):
+    def __init__(self, ws, parent=None, model=None, view=None, conf=None):
         """
         Create a presenter for controlling the slice display for a workspace
         :param ws: Workspace containing data to display and slice
@@ -47,7 +47,7 @@ class SliceViewer(object):
         self.normalization = mantid.api.MDNormalization.NoNormalization
 
         self.view = view if view else SliceViewerView(self, self.model.get_dimensions_info(),
-                                                      self.model.can_normalize_workspace(), parent)
+                                                      self.model.can_normalize_workspace(), parent, conf)
         self.view.data_view.create_axes_orthogonal(
             redraw_on_zoom=not self.model.can_support_dynamic_rebinning())
         self.view.data_view.image_info_widget.setWorkspace(ws)

--- a/qt/python/mantidqt/widgets/sliceviewer/view.py
+++ b/qt/python/mantidqt/widgets/sliceviewer/view.py
@@ -39,7 +39,7 @@ from .zoom import ScrollZoomMixin
 DBLMAX = sys.float_info.max
 
 SCALENORM = "SliceViewer/scale_norm"
-POWERSCALE = "Sliceviewer/scale_norm_power"
+POWERSCALE = "SliceViewer/scale_norm_power"
 
 
 class SliceViewerCanvas(ScrollZoomMixin, FigureCanvas):

--- a/qt/python/mantidqt/widgets/sliceviewer/view.py
+++ b/qt/python/mantidqt/widgets/sliceviewer/view.py
@@ -46,7 +46,7 @@ class SliceViewerCanvas(ScrollZoomMixin, FigureCanvas):
 class SliceViewerDataView(QWidget):
     """The view for the data portion of the sliceviewer"""
 
-    def __init__(self, presenter, dims_info, can_normalise, parent=None):
+    def __init__(self, presenter, dims_info, can_normalise, parent=None, conf=None):
         super().__init__(parent)
 
         self.presenter = presenter
@@ -106,7 +106,7 @@ class SliceViewerDataView(QWidget):
 
         self.colorbar_label = QLabel("Colormap")
         self.colorbar_layout.addWidget(self.colorbar_label)
-        self.colorbar = ColorbarWidget(self)
+        self.colorbar = ColorbarWidget(self, conf)
         self.colorbar_layout.addWidget(self.colorbar)
         self.colorbar.colorbarChanged.connect(self.update_data_clim)
         # make width larger to fit image readout table
@@ -494,7 +494,7 @@ class SliceViewerDataView(QWidget):
 class SliceViewerView(QWidget):
     """Combines the data view for the slice viewer with the optional peaks viewer."""
 
-    def __init__(self, presenter, dims_info, can_normalise, parent=None):
+    def __init__(self, presenter, dims_info, can_normalise, parent=None, conf=None):
         super().__init__(parent)
 
         self.presenter = presenter
@@ -503,7 +503,7 @@ class SliceViewerView(QWidget):
         self.setAttribute(Qt.WA_DeleteOnClose, True)
 
         self._splitter = QSplitter(self)
-        self._data_view = SliceViewerDataView(presenter, dims_info, can_normalise, self)
+        self._data_view = SliceViewerDataView(presenter, dims_info, can_normalise, self, conf)
         self._splitter.addWidget(self._data_view)
         #  peaks viewer off by default
         self._peaks_view = None

--- a/qt/python/mantidqt/widgets/sliceviewer/view.py
+++ b/qt/python/mantidqt/widgets/sliceviewer/view.py
@@ -38,6 +38,9 @@ from .zoom import ScrollZoomMixin
 # Constants
 DBLMAX = sys.float_info.max
 
+SCALENORM = "SliceViewer/scale_norm"
+POWERSCALE = "Sliceviewer/scale_norm_power"
+
 
 class SliceViewerCanvas(ScrollZoomMixin, FigureCanvas):
     pass
@@ -495,23 +498,28 @@ class SliceViewerDataView(QWidget):
 
     def get_default_scale_norm(self):
         scale = 'Linear'
-        if self.conf and self.conf.has("sliceviewer/scale_norm"):
-            scale = self.conf.get("sliceviewer/scale_norm")
+        if self.conf is None:
+            return scale
 
-        if scale == 'Power' and self.conf and self.conf.has("sliceviewer/scale_norm_power"):
-            exponent = self.conf.get("sliceviewer/scale_norm_power")
+        if self.conf.has(SCALENORM):
+            scale = self.conf.get(SCALENORM)
+
+        if scale == 'Power' and self.conf.has(POWERSCALE):
+            exponent = self.conf.get(POWERSCALE)
             scale = (scale, exponent)
 
         return scale
 
     def scale_norm_changed(self):
-        if self.conf:
-            scale = self.colorbar.norm.currentText()
-            self.conf.set("sliceviewer/scale_norm", scale)
+        if self.conf is None:
+            return
 
-            if scale == 'Power':
-                exponent = self.colorbar.powerscale_value
-                self.conf.set("sliceviewer/scale_norm_power", exponent)
+        scale = self.colorbar.norm.currentText()
+        self.conf.set(SCALENORM, scale)
+
+        if scale == 'Power':
+            exponent = self.colorbar.powerscale_value
+            self.conf.set(POWERSCALE, exponent)
 
 
 class SliceViewerView(QWidget):
@@ -589,6 +597,5 @@ class SliceViewerView(QWidget):
 
     # event handlers
     def closeEvent(self, event):
-        self._data_view.colorbar.closeEvent(event)
         self.deleteLater()
         super().closeEvent(event)

--- a/qt/python/mantidqt/widgets/sliceviewer/view.py
+++ b/qt/python/mantidqt/widgets/sliceviewer/view.py
@@ -566,5 +566,6 @@ class SliceViewerView(QWidget):
 
     # event handlers
     def closeEvent(self, event):
+        self._data_view.colorbar.closeEvent(event)
         self.deleteLater()
         super().closeEvent(event)


### PR DESCRIPTION
**Description of work.**

This PR makes a change to Sliceviewer so that after changing the colorbar scale and closing and reopening Sliceviewer, it is still the same scale. This is done by adding a property to the user property file.

**To test:**
Load a workspace and open sliceviewer.
Change the colorbar scale to Logarithmic.
Close and reopen sliceviewer - the scale should still be logarithmic

Fixes #28516 

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
