### PR TITLE
Updated line colouring in muon Analysis GUI

### DIFF
--- a/docs/source/release/v5.1.0/muon.rst
+++ b/docs/source/release/v5.1.0/muon.rst
@@ -45,6 +45,7 @@ Improvements
 - Updated :ref:`DoublePulseFit <algm-DoublePulseFit>` to allow composite function input.
 - Updated :ref:`CalculateMuonAsymmetry <algm-CalculateMuonAsymmetry>` to allow double pulse fits.
 - Tf asymmetry mode can now be performed on double pulse fits from the muon analysis GUI.
+- Updated line colouring in Muon Analysis plots to be more consistent.
 
 Bug fixes
 ---------

--- a/scripts/Muon/GUI/Common/plot_widget/plotting_canvas/plotting_canvas_presenter.py
+++ b/scripts/Muon/GUI/Common/plot_widget/plotting_canvas/plotting_canvas_presenter.py
@@ -44,31 +44,24 @@ class PlottingCanvasPresenter(PlottingCanvasPresenterInterface):
         workspace_plot_info = self._model.create_workspace_plot_information(workspace_names, workspace_indices,
                                                                             self._options_presenter.get_errors())
         if not hold_on:
-            # Remove data which is currently plotted and not in the new workspace_plot_info
-            workspaces_info_to_remove = [plot_info for plot_info in self._view.plotted_workspace_information
-                                         if plot_info not in workspace_plot_info]
-            self._view.remove_workspace_info_from_plot(workspaces_info_to_remove)
+            self._view.clear_all_workspaces_from_plot()
 
         # Add workspace info which is currently not plotted
-        workspace_info_to_add = [plot_info for plot_info in workspace_plot_info if plot_info
-                                 not in self._view.plotted_workspace_information]
+        workspace_info_to_add = [plot_info for plot_info in workspace_plot_info if plot_info]
         self._view.add_workspaces_to_plot(workspace_info_to_add)
         self._set_axes_limits_and_titles(autoscale)
 
     def remove_workspace_names_from_plot(self, workspace_names: List[str]):
         """Removes the input workspace names from the plot"""
-        for workspace_name in workspace_names:
-            try:
-                workspace = AnalysisDataService.Instance().retrieve(workspace_name)
-            except RuntimeError:
-                continue
-            self._view.remove_workspace_from_plot(workspace)
-        self._view.redraw_figure()
+        workspace_plot_info = self._view.plotted_workspace_information
+        workspace_plot_info = [plot_info for plot_info in workspace_plot_info if plot_info.workspace_name not in workspace_names]
+        self._view.clear_all_workspaces_from_plot()
+        self._view.add_workspaces_to_plot(workspace_plot_info)
+        self._set_axes_limits_and_titles(False)
 
     def remove_workspace_from_plot(self, workspace):
         """Removes all references to the input workspace from the plot"""
-        self._view.remove_workspace_from_plot(workspace)
-        self._view.redraw_figure()
+        self.remove_workspace_names_from_plot([workspace])
 
     def replace_workspace_in_plot(self, workspace):
         """Replace specified workspace in the plot with a new and presumably updated instance"""

--- a/scripts/Muon/GUI/Common/plot_widget/plotting_canvas/plotting_canvas_presenter.py
+++ b/scripts/Muon/GUI/Common/plot_widget/plotting_canvas/plotting_canvas_presenter.py
@@ -10,7 +10,6 @@ from Muon.GUI.Common.plot_widget.plotting_canvas.plotting_canvas_model import Pl
 from Muon.GUI.Common.plot_widget.plotting_canvas.plotting_canvas_presenter_interface import \
     PlottingCanvasPresenterInterface
 from Muon.GUI.Common.plot_widget.plotting_canvas.plotting_canvas_view_interface import PlottingCanvasViewInterface
-from mantid import AnalysisDataService
 
 DEFAULT_X_LIMITS = [0, 15]
 DEFAULT_Y_LIMITS = [-1, 1]

--- a/scripts/test/Muon/plotting_canvas/plotting_canvas_presenter_test.py
+++ b/scripts/test/Muon/plotting_canvas/plotting_canvas_presenter_test.py
@@ -47,7 +47,7 @@ class PlottingCanvasPresenterTest(unittest.TestCase):
     def tearDown(self):
         AnalysisDataService.Instance().clear()
 
-    def test_plot_workspaces_removes_workspaces_from_plot_if_hold_on_false(self):
+    def test_plot_workspaces_cleares_plot_if_hold_on_false(self):
         workspace_names = ["MUSR6220"]
         workspace_indices = [0]
         self.presenter._set_axes_limits_and_titles = mock.Mock()
@@ -60,9 +60,9 @@ class PlottingCanvasPresenterTest(unittest.TestCase):
         self.presenter.plot_workspaces(workspace_names=workspace_names, workspace_indices=workspace_indices,
                                        hold_on=False, autoscale=False)
 
-        self.view.remove_workspace_info_from_plot.assert_called_once_with([plotted_information])
+        self.view.clear_all_workspaces_from_plot.assert_called_once_with()
 
-    def test_plot_workspaces_does_not_replot_existing_workspaces(self):
+    def test_plot_workspaces_replots_existing_workspaces_if_hold_on_is_false(self):
         workspace_names = ["MUSR6220"]
         workspace_indices = [0]
         self.presenter._set_axes_limits_and_titles = mock.Mock()
@@ -75,7 +75,7 @@ class PlottingCanvasPresenterTest(unittest.TestCase):
         self.presenter.plot_workspaces(workspace_names=workspace_names, workspace_indices=workspace_indices,
                                        hold_on=False, autoscale=False)
 
-        self.view.add_workspaces_to_plot.assert_called_once_with([])
+        self.view.add_workspaces_to_plot.assert_called_once_with([plotted_information])
 
     def test_plot_workspaces_gets_workspace_info_from_model(self):
         workspace_names = ["MUSR6220"]
@@ -103,15 +103,15 @@ class PlottingCanvasPresenterTest(unittest.TestCase):
 
         self.view.add_workspaces_to_plot.assert_called_once_with([plot_info])
 
-    def test_remove_workspace_names_from_plot_calls_passes_on_workspaces_to_view_correctly(self):
+    def test_remove_workspace_names_from_plot_calls_clears_plot_and_then_adds_workspaces_correctly(self):
         ws_names = ["MUSR62260;fwd", "MUSR62260;bkwd"]
-        workspaces = create_test_workspaces(ws_names)
+        create_test_workspaces(ws_names)
+        self.presenter._set_axes_limits_and_titles = mock.Mock()
 
         self.presenter.remove_workspace_names_from_plot(ws_names)
 
-        self.assertEqual(self.view.remove_workspace_from_plot.call_count, len(ws_names))
-        self.assertTrue(self.view.remove_workspace_from_plot.call_args_list[0][0][0].equals(workspaces[0], 1e-9))
-        self.assertTrue(self.view.remove_workspace_from_plot.call_args_list[1][0][0].equals(workspaces[1], 1e-9))
+        self.view.clear_all_workspaces_from_plot.assert_called_once_with()
+        self.view.add_workspaces_to_plot.assert_called_once_with([])
 
     def test_convert_to_single_plot_correctly_sets_up_new_plot(self):
         workspaces = ["MUSR62260;fwd", "MUSR62260;bkwd"]


### PR DESCRIPTION
This resets the colours on the plot every time the plot is updated to ensure we always end up with the same set of consistent colours.

After some debate it was decided to go with the simple approach of ensuring that we always used the same colour progression for every plot and that this was reset when the plots were updated.

**Description of work.**

This PR resets the colouring each time the plotis changed

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

**To test:**

 * Try using the GUI and producing plots and check that the line colouring remains clear and consistent.
 * Note that #29076 already exists on master and is not resolved here.

<!-- Instructions for testing. -->

Fixes #29064  <!-- and fix #xxxx or close #xxxx xor resolves #xxxx -->
<!-- alternative
*There is no associated issue.*
-->

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
-->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
