### PR TITLE
Removing use of namespace std in ExtractMaskToTable.cpp

### DIFF
--- a/Framework/Algorithms/src/ExtractMaskToTable.cpp
+++ b/Framework/Algorithms/src/ExtractMaskToTable.cpp
@@ -54,7 +54,8 @@ void ExtractMaskToTable::exec() {
   // Get input properties
   m_dataWS = getProperty("InputWorkspace");
   if (!m_dataWS)
-    throw std::runtime_error("InputWorkspace cannot be cast to a MatrixWorkspace.");
+    throw std::runtime_error(
+        "InputWorkspace cannot be cast to a MatrixWorkspace.");
   MaskWorkspace_const_sptr maskws =
       std::dynamic_pointer_cast<const MaskWorkspace>(m_dataWS);
 
@@ -308,9 +309,9 @@ void ExtractMaskToTable::copyTableWorkspaceContent(
  * @param xmax :: maximum x
  * @param prevmaskedids :: vector of previous masked detector IDs
  */
-void ExtractMaskToTable::addToTableWorkspace(const TableWorkspace_sptr &outws,
-                                             std::vector<detid_t> maskeddetids,
-                                             double xmin, double xmax, std::vector<detid_t> prevmaskedids) {
+void ExtractMaskToTable::addToTableWorkspace(
+    const TableWorkspace_sptr &outws, std::vector<detid_t> maskeddetids,
+    double xmin, double xmax, std::vector<detid_t> prevmaskedids) {
   // Sort vector of detectors ID
   size_t numdetids = maskeddetids.size();
   if (numdetids == 0) {


### PR DESCRIPTION
**Description of work.**
Removed `using namespace std` followed by adding in `std::` where required.

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

**To test:**
Does not require any practical testing, check Mantid builds okay and unit test passes

<!-- Instructions for testing. -->

Fixes #26948 
<!-- alternative
*There is no associated issue.*
-->

*This does not require release notes* because this is a small change to a single file in order to be consistent with mantid coding standards

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
