### PR TITLE
Check for null box pointer due to rounding errors

### DIFF
--- a/Framework/DataObjects/inc/MantidDataObjects/MDEventWorkspace.tcc
+++ b/Framework/DataObjects/inc/MantidDataObjects/MDEventWorkspace.tcc
@@ -822,7 +822,7 @@ TMDE(API::IMDWorkspace::LinePlot MDEventWorkspace)
         auto box = this->data->getBoxAtCoord(ws_pos.getBareArray());
 
         // If the box is not masked then record the signal and error here
-        if (!box->getIsMasked()) {
+        if (box && !box->getIsMasked()) {
           line.x.emplace_back(line_pos);
           signal_t signal = this->getNormalizedSignal(box, normalize);
           if (std::isinf(signal)) {


### PR DESCRIPTION
**Description of work.**

Fix a segfault in MantidPlot SliceViewer. See commit details for the problem and why there is no test added.

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

**To test:**

Follow the instructions in the linked issue. Note that this is the **MantidPlot** SliceViewer and not MantidWorkbench.

Fixes #23562 

*This does not require release notes* because **it is too small and not user reported.**

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
