### PR TITLE
Remove plot options button from sliceviewer

### DIFF
--- a/docs/source/release/v5.1.0/mantidworkbench.rst
+++ b/docs/source/release/v5.1.0/mantidworkbench.rst
@@ -131,5 +131,6 @@ Bugfixes
 - Fixed a bug which prevented the double click axis editor menus from working for tiled plots.
 - Select image in the plot figure option contains each image rather than each spectra for colorfil plots of workspaces with a numeric vertical axis
 - A bug has been fixed that caused an error if a workspace containing only monitor spectra was attempted to be plotted as a colorfill plot
+- The figure options button on the sliceviewer has been removed as most options did not function correctly.
 
 :ref:`Release 5.1.0 <v5.1.0>`

--- a/qt/python/mantidqt/widgets/sliceviewer/toolbar.py
+++ b/qt/python/mantidqt/widgets/sliceviewer/toolbar.py
@@ -22,7 +22,6 @@ class ToolItemText:
     OVERLAY_PEAKS = 'OverlayPeaks'
     NONORTHOGONAL_AXES = 'NonOrthogonalAxes'
     SAVE = 'Save'
-    CUSTOMIZE = 'Customize'
 
 
 class SliceViewerNavigationToolbar(NavigationToolbar2QT):
@@ -33,7 +32,6 @@ class SliceViewerNavigationToolbar(NavigationToolbar2QT):
     regionSelectionClicked = Signal(bool)
     nonOrthogonalClicked = Signal(bool)
     peaksOverlayClicked = Signal(bool)
-    plotOptionsChanged = Signal()
     zoomPanFinished = Signal()
 
     toolitems = (
@@ -54,8 +52,7 @@ class SliceViewerNavigationToolbar(NavigationToolbar2QT):
         (ToolItemText.NONORTHOGONAL_AXES, 'Toggle nonorthogonal axes on/off', 'mdi.axis',
          'nonOrthogonalClicked', False),
         (None, None, None, None, None),
-        (ToolItemText.SAVE, 'Save the figure', 'mdi.content-save', 'save_figure', None),
-        (ToolItemText.CUSTOMIZE, 'Configure plot options', 'mdi.settings', 'edit_parameters', None),
+        (ToolItemText.SAVE, 'Save the figure', 'mdi.content-save', 'save_figure', None)
     )
 
     def _init_toolbar(self):
@@ -89,10 +86,6 @@ class SliceViewerNavigationToolbar(NavigationToolbar2QT):
 
         # Location of a press event
         self._pressed_xy = None
-
-    def edit_parameters(self):
-        NavigationToolbar2QT.edit_parameters(self)
-        self.plotOptionsChanged.emit()
 
     def press(self, event):
         """

--- a/qt/python/mantidqt/widgets/sliceviewer/view.py
+++ b/qt/python/mantidqt/widgets/sliceviewer/view.py
@@ -120,7 +120,6 @@ class SliceViewerDataView(QWidget):
         self.mpl_toolbar.linePlotsClicked.connect(self.on_line_plots_toggle)
         self.mpl_toolbar.regionSelectionClicked.connect(self.on_region_selection_toggle)
         self.mpl_toolbar.homeClicked.connect(self.on_home_clicked)
-        self.mpl_toolbar.plotOptionsChanged.connect(self.colorbar.mappable_changed)
         self.mpl_toolbar.nonOrthogonalClicked.connect(self.on_non_orthogonal_axes_toggle)
         self.mpl_toolbar.zoomPanFinished.connect(self.on_data_limits_changed)
         self.toolbar_layout.addWidget(self.mpl_toolbar)


### PR DESCRIPTION
**Description of work.**

Removed the figure options button from the sliceviewer toolbar. See commit message for more details.

**To test:**

See instructions in issue.

Fixes #29074 

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
