### PR TITLE
Workbench fit slider bug

### DIFF
--- a/docs/source/release/v5.1.0/mantidworkbench.rst
+++ b/docs/source/release/v5.1.0/mantidworkbench.rst
@@ -131,10 +131,7 @@ Bugfixes
 - Fixed a bug which prevented the double click axis editor menus from working for tiled plots.
 - Select image in the plot figure option contains each image rather than each spectra for colorfil plots of workspaces with a numeric vertical axis
 - A bug has been fixed that caused an error if a workspace containing only monitor spectra was attempted to be plotted as a colorfill plot
-<<<<<<< HEAD
 - The figure options button on the sliceviewer has been removed as most options did not function correctly.
-=======
 - Fixed the bug that caused the fit browser on plots to reset size changes on mouse interactions with the figure.
->>>>>>> e848561139d... Amended release notes for bug fix RE #26999
 
 :ref:`Release 5.1.0 <v5.1.0>`

--- a/docs/source/release/v5.1.0/mantidworkbench.rst
+++ b/docs/source/release/v5.1.0/mantidworkbench.rst
@@ -122,7 +122,7 @@ Bugfixes
 - `plt.show()` now shows the most recently created figure.
 - Removed error when changing the normalisation of a ragged workspace with a log scaled colorbar.
 - The SavePlot1D algorithm can now be run in Workbench.
-- Changing the settings on tiled colorbars now applys to all the plots if there is only one colorbar.
+- Changing the settings on tiled colorbars now applies to all the plots if there is only one colorbar.
 - Colorfill plots now correctly use the workspace name as the plot title.
 - Overplotting no longer resets the axes scales.
 - Fixed a bug with the peak cursor immediately resetting to the default cursor when trying to add a peak.
@@ -131,6 +131,10 @@ Bugfixes
 - Fixed a bug which prevented the double click axis editor menus from working for tiled plots.
 - Select image in the plot figure option contains each image rather than each spectra for colorfil plots of workspaces with a numeric vertical axis
 - A bug has been fixed that caused an error if a workspace containing only monitor spectra was attempted to be plotted as a colorfill plot
+<<<<<<< HEAD
 - The figure options button on the sliceviewer has been removed as most options did not function correctly.
+=======
+- Fixed the bug that caused the fit browser on plots to reset size changes on mouse interactions with the figure.
+>>>>>>> e848561139d... Amended release notes for bug fix RE #26999
 
 :ref:`Release 5.1.0 <v5.1.0>`

--- a/qt/applications/workbench/workbench/plotting/figuremanager.py
+++ b/qt/applications/workbench/workbench/plotting/figuremanager.py
@@ -243,9 +243,10 @@ class FigureManagerWorkbench(FigureManagerBase, QObject):
         self.window.setCentralWidget(canvas)
         self.window.addDockWidget(Qt.LeftDockWidgetArea, self.fit_browser)
         # Need this line to stop the bug where the dock window snaps back to its original size after resizing.
+        # 0 argument is arbitrary and has no effect on fit widget size
         # This is a qt bug reported at (https://bugreports.qt.io/browse/QTBUG-65592)
         if QT_VERSION >= LooseVersion("5.6"):
-            self.window.resizeDocks([self.fit_browser], [40], Qt.Horizontal)
+            self.window.resizeDocks([self.fit_browser], [0], Qt.Horizontal)
         self.fit_browser.hide()
 
         if matplotlib.is_interactive():

--- a/qt/applications/workbench/workbench/plotting/figuremanager.py
+++ b/qt/applications/workbench/workbench/plotting/figuremanager.py
@@ -9,6 +9,7 @@
 #
 """Provides our custom figure manager to wrap the canvas, window and our custom toolbar"""
 import copy
+from distutils.version import LooseVersion
 import io
 import sys
 from functools import wraps
@@ -22,6 +23,7 @@ from mpl_toolkits.mplot3d.axes3d import Axes3D
 from qtpy.QtCore import QObject, Qt
 from qtpy.QtGui import QImage
 from qtpy.QtWidgets import QApplication, QLabel, QFileDialog
+from qtpy import QT_VERSION
 
 from mantid.api import AnalysisDataService, AnalysisDataServiceObserver, ITableWorkspace, MatrixWorkspace
 from mantid.kernel import logger
@@ -240,6 +242,10 @@ class FigureManagerWorkbench(FigureManagerBase, QObject):
         self.fit_browser.closing.connect(self.handle_fit_browser_close)
         self.window.setCentralWidget(canvas)
         self.window.addDockWidget(Qt.LeftDockWidgetArea, self.fit_browser)
+        # Need this line to stop the bug where the dock window snaps back to its original size after resizing.
+        # This is a qt bug reported at (https://bugreports.qt.io/browse/QTBUG-65592)
+        if QT_VERSION >= LooseVersion("5.6"):
+            self.window.resizeDocks([self.fit_browser], [40], Qt.Horizontal)
         self.fit_browser.hide()
 
         if matplotlib.is_interactive():

--- a/scripts/Muon/GUI/FrequencyDomainAnalysis/frequency_domain_analysis_2.py
+++ b/scripts/Muon/GUI/FrequencyDomainAnalysis/frequency_domain_analysis_2.py
@@ -99,9 +99,10 @@ class FrequencyAnalysisGui(QtWidgets.QMainWindow):
         # Add dock widget to main Muon analysis window
         self.addDockWidget(QtCore.Qt.RightDockWidgetArea, self.dockable_plot_widget_window)
         # Need this line to stop the bug where the dock window snaps back to its original size after resizing.
+        # 0 argument is arbitrary and has no effect on fit widget size
         # This is a qt bug reported at (https://bugreports.qt.io/browse/QTBUG-65592)
         if QT_VERSION >= LooseVersion("5.6"):
-            self.resizeDocks({self.dockable_plot_widget_window}, {40}, QtCore.Qt.Horizontal)
+            self.resizeDocks({self.dockable_plot_widget_window}, {0}, QtCore.Qt.Horizontal)
 
         # construct all the widgets.
         self.load_widget = LoadWidget(self.loaded_data, self.context, self)

--- a/scripts/Muon/GUI/MuonAnalysis/muon_analysis_2.py
+++ b/scripts/Muon/GUI/MuonAnalysis/muon_analysis_2.py
@@ -95,9 +95,10 @@ class MuonAnalysisGui(QtWidgets.QMainWindow):
         # Add dock widget to main Muon analysis window
         self.addDockWidget(QtCore.Qt.RightDockWidgetArea, self.dockable_plot_widget_window)
         # Need this line to stop the bug where the dock window snaps back to its original size after resizing.
+        # 0 argument is arbitrary and has no effect on fit widget size
         # This is a qt bug reported at (https://bugreports.qt.io/browse/QTBUG-65592)
         if QT_VERSION >= LooseVersion("5.6"):
-            self.resizeDocks({self.dockable_plot_widget_window}, {40}, QtCore.Qt.Horizontal)
+            self.resizeDocks({self.dockable_plot_widget_window}, {0}, QtCore.Qt.Horizontal)
 
         # set up other widgets
         self.load_widget = LoadWidget(self.loaded_data, self.context, self)


### PR DESCRIPTION
**Description of work.**
Addresses Qt issue described here: https://bugreports.qt.io/browse/QTBUG-65592
In which a QDockWidget resizes on interaction with QMainWindow. The same workaround has been used in the Muon Analysis, Frequency Domain Analysis and Indirect Data Analysis GUIs (see https://github.com/mantidproject/mantid/pull/28348/files and https://github.com/mantidproject/mantid/blame/master/qt/scientific_interfaces/Indirect/IndirectDockWidgetArea.cpp)

Unit test not added for this change as adding a unit test to check a signal based Qt bug is fixed is impractical, and an easy functional test exists.

**Report to:** Spencer Howells

**To test:**

Verify that the issue described in #26999 is resolved.

Fixes #26999 

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
