### PR TITLE
Replace deprecated save algorithms in Reflectometry GUI

### DIFF
--- a/docs/source/interfaces/ISIS Reflectometry.rst
+++ b/docs/source/interfaces/ISIS Reflectometry.rst
@@ -782,6 +782,7 @@ Save ASCII Tab
 
 The **Save ASCII** tab allows for processed workspaces to be saved in specific
 ASCII formats. The filenames are saved in the form [Prefix][Workspace Name].[ext].
+See :ref:`algm-SaveReflectometryAscii` for a description of the formats.
 
 .. figure:: /images/ISISReflectometryInterface/save_tab.png
   :class: screenshot
@@ -834,7 +835,7 @@ ASCII formats. The filenames are saved in the form [Prefix][Workspace Name].[ext
 |                               | available as save algorithms from mantid itself.     |
 +-------------------------------+------------------------------------------------------+
 | Custom Format Options         | When saving in 'Custom' this section allows you      |
-|                               | to specify if you want a Title and/or Q Resolution   |
+|                               | to specify if you want a Header and/or Q Resolution  |
 |                               | column as well as specifying the delimiter.          |
 +-------------------------------+------------------------------------------------------+
 | Automatic Save                | Automatically save the main output workspace for     |

--- a/docs/source/release/v5.1.0/reflectometry.rst
+++ b/docs/source/release/v5.1.0/reflectometry.rst
@@ -55,6 +55,8 @@ New
 
   *Provide cycle name for more reliable search results*
 
+- The output formats from the **Save ASCII** tab now follow standards more rigidly - see :ref:`algm-SaveReflectometryAscii`, which replaces the old deprecated algorithms.
+
 - The **Options** dialog can now be accessed from the Tools menu, controlling the display of warnings and rounding precision.
 
 Bug fixes

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Common/Decoder.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Common/Decoder.cpp
@@ -436,7 +436,7 @@ void Decoder::decodeSave(const QtSaveView *gui,
                          const QMap<QString, QVariant> &map) {
   gui->m_ui.savePathEdit->setText(map[QString("savePathEdit")].toString());
   gui->m_ui.prefixEdit->setText(map[QString("prefixEdit")].toString());
-  gui->m_ui.titleCheckBox->setChecked(map[QString("titleCheckBox")].toBool());
+  gui->m_ui.headerCheckBox->setChecked(map[QString("headerCheckBox")].toBool());
   gui->m_ui.qResolutionCheckBox->setChecked(
       map[QString("qResolutionCheckBox")].toBool());
   gui->m_ui.commaRadioButton->setChecked(

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Common/Encoder.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Common/Encoder.cpp
@@ -363,8 +363,8 @@ QMap<QString, QVariant> Encoder::encodeSave(const QtSaveView *gui) {
   QMap<QString, QVariant> map;
   map.insert(QString("savePathEdit"), QVariant(gui->m_ui.savePathEdit->text()));
   map.insert(QString("prefixEdit"), QVariant(gui->m_ui.prefixEdit->text()));
-  map.insert(QString("titleCheckBox"),
-             QVariant(gui->m_ui.titleCheckBox->isChecked()));
+  map.insert(QString("headerCheckBox"),
+             QVariant(gui->m_ui.headerCheckBox->isChecked()));
   map.insert(QString("qResolutionCheckBox"),
              QVariant(gui->m_ui.qResolutionCheckBox->isChecked()));
   map.insert(QString("commaRadioButton"),

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Save/AsciiSaver.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Save/AsciiSaver.h
@@ -16,7 +16,7 @@ namespace CustomInterfaces {
 namespace ISISReflectometry {
 class AsciiSaver : public IAsciiSaver {
 public:
-  static Mantid::API::IAlgorithm_sptr algorithmForFormat(NamedFormat format);
+  static Mantid::API::IAlgorithm_sptr getSaveAlgorithm();
   static std::string extensionForFormat(NamedFormat format);
 
   bool isValidSaveDirectory(std::string const &filePath) const override;

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Save/IAsciiSaver.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Save/IAsciiSaver.cpp
@@ -23,12 +23,12 @@ std::string const &InvalidWorkspaceName::name() const { return m_name; }
 
 FileFormatOptions::FileFormatOptions(NamedFormat format,
                                      std::string const &prefix,
-                                     bool includeTitle,
+                                     bool includeHeader,
                                      std::string const &separator,
                                      bool includeQResolution)
-    : m_format(format), m_prefix(prefix), m_includeTitle(includeTitle),
+    : m_format(format), m_prefix(prefix), m_includeHeader(includeHeader),
       m_separator(separator), m_includeQResolution(includeQResolution) {}
-bool FileFormatOptions::shouldIncludeTitle() const { return m_includeTitle; }
+bool FileFormatOptions::shouldIncludeHeader() const { return m_includeHeader; }
 bool FileFormatOptions::shouldIncludeQResolution() const {
   return m_includeQResolution;
 }

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Save/IAsciiSaver.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Save/IAsciiSaver.h
@@ -20,9 +20,9 @@ enum class NamedFormat { Custom, ThreeColumn, ANSTO, ILLCosmos };
 class MANTIDQT_ISISREFLECTOMETRY_DLL FileFormatOptions {
 public:
   FileFormatOptions(NamedFormat format, std::string const &prefix,
-                    bool includeTitle, std::string const &separator,
+                    bool includeHeader, std::string const &separator,
                     bool includeQResolution);
-  bool shouldIncludeTitle() const;
+  bool shouldIncludeHeader() const;
   bool shouldIncludeQResolution() const;
   std::string const &separator() const;
   std::string const &prefix() const;
@@ -31,7 +31,7 @@ public:
 private:
   NamedFormat m_format;
   std::string m_prefix;
-  bool m_includeTitle;
+  bool m_includeHeader;
   std::string m_separator;
   bool m_includeQResolution;
 };
@@ -48,7 +48,7 @@ private:
 inline bool operator==(const FileFormatOptions &lhs,
                        const FileFormatOptions &rhs) {
   return lhs.format() == rhs.format() &&
-         lhs.shouldIncludeTitle() == rhs.shouldIncludeTitle() &&
+         lhs.shouldIncludeHeader() == rhs.shouldIncludeHeader() &&
          lhs.shouldIncludeQResolution() == rhs.shouldIncludeQResolution() &&
          lhs.separator() == rhs.separator() && lhs.prefix() == rhs.prefix();
 }

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Save/ISaveView.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Save/ISaveView.h
@@ -66,6 +66,15 @@ public:
   virtual void enableLocationControls() = 0;
   virtual void disableLocationControls() = 0;
 
+  virtual void enableLogList() = 0;
+  virtual void disableLogList() = 0;
+  virtual void enableHeaderCheckBox() = 0;
+  virtual void disableHeaderCheckBox() = 0;
+  virtual void enableQResolutionCheckBox() = 0;
+  virtual void disableQResolutionCheckBox() = 0;
+  virtual void enableSeparatorButtonGroup() = 0;
+  virtual void disableSeparatorButtonGroup() = 0;
+
   virtual void showFilterEditValid() = 0;
   virtual void showFilterEditInvalid() = 0;
   virtual void errorInvalidSaveDirectory() = 0;

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Save/ISaveView.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Save/ISaveView.h
@@ -48,7 +48,7 @@ public:
   virtual std::vector<std::string> getSelectedWorkspaces() const = 0;
   virtual std::vector<std::string> getSelectedParameters() const = 0;
   virtual int getFileFormatIndex() const = 0;
-  virtual bool getTitleCheck() const = 0;
+  virtual bool getHeaderCheck() const = 0;
   virtual bool getQResolutionCheck() const = 0;
   virtual std::string getSeparator() const = 0;
 

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Save/ISaveView.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Save/ISaveView.h
@@ -61,8 +61,10 @@ public:
   virtual void disableAutosaveControls() = 0;
   virtual void enableAutosaveControls() = 0;
 
-  virtual void enableFileFormatAndLocationControls() = 0;
-  virtual void disableFileFormatAndLocationControls() = 0;
+  virtual void enableFileFormatControls() = 0;
+  virtual void disableFileFormatControls() = 0;
+  virtual void enableLocationControls() = 0;
+  virtual void disableLocationControls() = 0;
 
   virtual void showFilterEditValid() = 0;
   virtual void showFilterEditInvalid() = 0;

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Save/QtSaveView.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Save/QtSaveView.cpp
@@ -76,7 +76,7 @@ void QtSaveView::connectSaveSettingsWidgets() {
   connectSettingsChange(*m_ui.filterEdit);
   connectSettingsChange(*m_ui.regexCheckBox);
   connectSettingsChange(*m_ui.saveReductionResultsCheckBox);
-  connectSettingsChange(*m_ui.titleCheckBox);
+  connectSettingsChange(*m_ui.headerCheckBox);
   connectSettingsChange(*m_ui.qResolutionCheckBox);
   connectSettingsChange(*m_ui.commaRadioButton);
   connectSettingsChange(*m_ui.spaceRadioButton);
@@ -205,11 +205,11 @@ int QtSaveView::getFileFormatIndex() const {
   return m_ui.fileFormatComboBox->currentIndex();
 }
 
-/** Returns the title check value
- * @return :: The title check
+/** Returns the header check value
+ * @return :: The header check
  */
-bool QtSaveView::getTitleCheck() const {
-  return m_ui.titleCheckBox->isChecked();
+bool QtSaveView::getHeaderCheck() const {
+  return m_ui.headerCheckBox->isChecked();
 }
 
 /** Returns the Q resolution check value

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Save/QtSaveView.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Save/QtSaveView.cpp
@@ -122,13 +122,19 @@ void QtSaveView::enableAutosaveControls() {
   m_ui.autosaveGroup->setEnabled(true);
 }
 
-void QtSaveView::enableFileFormatAndLocationControls() {
+void QtSaveView::enableFileFormatControls() {
   m_ui.fileFormatGroup->setEnabled(true);
+}
+
+void QtSaveView::disableFileFormatControls() {
+  m_ui.fileFormatGroup->setEnabled(false);
+}
+
+void QtSaveView::enableLocationControls() {
   m_ui.fileLocationGroup->setEnabled(true);
 }
 
-void QtSaveView::disableFileFormatAndLocationControls() {
-  m_ui.fileFormatGroup->setEnabled(false);
+void QtSaveView::disableLocationControls() {
   m_ui.fileLocationGroup->setEnabled(false);
 }
 

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Save/QtSaveView.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Save/QtSaveView.cpp
@@ -138,6 +138,42 @@ void QtSaveView::disableLocationControls() {
   m_ui.fileLocationGroup->setEnabled(false);
 }
 
+void QtSaveView::enableLogList() {
+  m_ui.listOfLoggedParameters->setEnabled(true);
+}
+
+void QtSaveView::disableLogList() {
+  m_ui.listOfLoggedParameters->setEnabled(false);
+}
+
+void QtSaveView::enableHeaderCheckBox() {
+  m_ui.headerCheckBox->setEnabled(true);
+}
+
+void QtSaveView::disableHeaderCheckBox() {
+  m_ui.headerCheckBox->setEnabled(false);
+}
+
+void QtSaveView::enableQResolutionCheckBox() {
+  m_ui.qResolutionCheckBox->setEnabled(true);
+}
+
+void QtSaveView::disableQResolutionCheckBox() {
+  m_ui.qResolutionCheckBox->setEnabled(false);
+}
+
+void QtSaveView::enableSeparatorButtonGroup() {
+  m_ui.commaRadioButton->setEnabled(true);
+  m_ui.spaceRadioButton->setEnabled(true);
+  m_ui.tabRadioButton->setEnabled(true);
+}
+
+void QtSaveView::disableSeparatorButtonGroup() {
+  m_ui.commaRadioButton->setEnabled(false);
+  m_ui.spaceRadioButton->setEnabled(false);
+  m_ui.tabRadioButton->setEnabled(false);
+}
+
 /** Returns the save path
  * @return :: The save path
  */

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Save/QtSaveView.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Save/QtSaveView.h
@@ -73,8 +73,10 @@ public:
   void disableAutosaveControls() override;
   void enableAutosaveControls() override;
 
-  void enableFileFormatAndLocationControls() override;
-  void disableFileFormatAndLocationControls() override;
+  void enableFileFormatControls() override;
+  void disableFileFormatControls() override;
+  void enableLocationControls() override;
+  void disableLocationControls() override;
 
   void error(const std::string &title, const std::string &prompt);
   void warning(const std::string &title, const std::string &prompt);

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Save/QtSaveView.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Save/QtSaveView.h
@@ -51,7 +51,7 @@ public:
   /// Returns the index of selected file format
   int getFileFormatIndex() const override;
   /// Returns the title check
-  bool getTitleCheck() const override;
+  bool getHeaderCheck() const override;
   /// Returns the Q resolution check
   bool getQResolutionCheck() const override;
   /// Returns the separator type

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Save/QtSaveView.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Save/QtSaveView.h
@@ -78,6 +78,15 @@ public:
   void enableLocationControls() override;
   void disableLocationControls() override;
 
+  void enableLogList() override;
+  void disableLogList() override;
+  void enableHeaderCheckBox() override;
+  void disableHeaderCheckBox() override;
+  void enableQResolutionCheckBox() override;
+  void disableQResolutionCheckBox() override;
+  void enableSeparatorButtonGroup() override;
+  void disableSeparatorButtonGroup() override;
+
   void error(const std::string &title, const std::string &prompt);
   void warning(const std::string &title, const std::string &prompt);
 

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Save/SavePresenter.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Save/SavePresenter.cpp
@@ -209,7 +209,7 @@ FileFormatOptions SavePresenter::getSaveParametersFromView() const {
   return FileFormatOptions(
       /*format=*/formatFromIndex(m_view->getFileFormatIndex()),
       /*prefix=*/m_view->getPrefix(),
-      /*includeTitle=*/m_view->getTitleCheck(),
+      /*includeHeader=*/m_view->getHeaderCheck(),
       /*separator=*/m_view->getSeparator(),
       /*includeQResolution=*/m_view->getQResolutionCheck());
 }

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Save/SavePresenter.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Save/SavePresenter.cpp
@@ -78,13 +78,17 @@ bool SavePresenter::isAutoreducing() const {
 void SavePresenter::updateWidgetEnabledState() const {
   if (isProcessing() || isAutoreducing()) {
     m_view->disableAutosaveControls();
-    if (shouldAutosave())
-      m_view->disableFileFormatAndLocationControls();
-    else
-      m_view->enableFileFormatAndLocationControls();
+    if (shouldAutosave()) {
+      m_view->disableFileFormatControls();
+      m_view->disableLocationControls();
+    } else {
+      m_view->enableFileFormatControls();
+      m_view->enableLocationControls();
+    }
   } else {
     m_view->enableAutosaveControls();
-    m_view->enableFileFormatAndLocationControls();
+    m_view->enableFileFormatControls();
+    m_view->enableLocationControls();
   }
 }
 

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Save/SavePresenter.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Save/SavePresenter.cpp
@@ -48,6 +48,7 @@ void SavePresenter::acceptMainPresenter(IBatchPresenter *mainPresenter) {
 
 void SavePresenter::notifySettingsChanged() {
   m_mainPresenter->setBatchUnsaved();
+  updateWidgetEnabledState();
 }
 
 void SavePresenter::notifyPopulateWorkspaceList() { populateWorkspaceList(); }
@@ -72,6 +73,30 @@ bool SavePresenter::isAutoreducing() const {
   return m_mainPresenter->isAutoreducing();
 }
 
+/** Tells the view to enable/disable certain widgets based on the
+ * selected file format
+ */
+void SavePresenter::updateWidgetStateBasedOnFileFormat() const {
+  auto const fileFormat = formatFromIndex(m_view->getFileFormatIndex());
+  // Enable/disable the log list. Note that at the moment the log list is used
+  // in SaveReflectometryAscii for ILLCosmos (MFT) but I'm not sure if it should
+  // be.
+  if (fileFormat == NamedFormat::Custom || fileFormat == NamedFormat::ILLCosmos)
+    m_view->enableLogList();
+  else
+    m_view->disableLogList();
+  // Everything else is enabled for Custom and disabled otherwise
+  if (fileFormat == NamedFormat::Custom) {
+    m_view->enableHeaderCheckBox();
+    m_view->enableQResolutionCheckBox();
+    m_view->enableSeparatorButtonGroup();
+  } else {
+    m_view->disableHeaderCheckBox();
+    m_view->disableQResolutionCheckBox();
+    m_view->disableSeparatorButtonGroup();
+  }
+}
+
 /** Tells the view to update the enabled/disabled state of all relevant
  * widgets based on whether processing is in progress or not.
  */
@@ -81,14 +106,17 @@ void SavePresenter::updateWidgetEnabledState() const {
     if (shouldAutosave()) {
       m_view->disableFileFormatControls();
       m_view->disableLocationControls();
+      updateWidgetStateBasedOnFileFormat();
     } else {
       m_view->enableFileFormatControls();
       m_view->enableLocationControls();
+      updateWidgetStateBasedOnFileFormat();
     }
   } else {
     m_view->enableAutosaveControls();
     m_view->enableFileFormatControls();
     m_view->enableLocationControls();
+    updateWidgetStateBasedOnFileFormat();
   }
 }
 

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Save/SavePresenter.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Save/SavePresenter.cpp
@@ -78,10 +78,11 @@ bool SavePresenter::isAutoreducing() const {
  */
 void SavePresenter::updateWidgetStateBasedOnFileFormat() const {
   auto const fileFormat = formatFromIndex(m_view->getFileFormatIndex());
-  // Enable/disable the log list. Note that at the moment the log list is used
-  // in SaveReflectometryAscii for ILLCosmos (MFT) but I'm not sure if it should
-  // be.
-  if (fileFormat == NamedFormat::Custom || fileFormat == NamedFormat::ILLCosmos)
+  // Enable/disable the log list for formats that include the header.
+  // Note that at the moment the log list is used in SaveReflectometryAscii for
+  // ILLCosmos (MFT) but I'm not sure if it should be.
+  if ((fileFormat == NamedFormat::Custom && m_view->getHeaderCheck()) ||
+      fileFormat == NamedFormat::ILLCosmos)
     m_view->enableLogList();
   else
     m_view->disableLogList();

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Save/SavePresenter.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Save/SavePresenter.h
@@ -77,6 +77,7 @@ private:
   void enableAutosave();
   void disableAutosave();
   void updateWidgetEnabledState() const;
+  void updateWidgetStateBasedOnFileFormat() const;
   bool isProcessing() const;
   bool isAutoreducing() const;
 

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Save/SaveWidget.ui
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Save/SaveWidget.ui
@@ -189,9 +189,9 @@
          <number>6</number>
         </property>
         <item>
-         <widget class="QCheckBox" name="titleCheckBox">
+         <widget class="QCheckBox" name="headerCheckBox">
           <property name="text">
-           <string>Title</string>
+           <string>Header</string>
           </property>
          </widget>
         </item>

--- a/qt/scientific_interfaces/test/ISISReflectometry/Common/CoderCommonTester.h
+++ b/qt/scientific_interfaces/test/ISISReflectometry/Common/CoderCommonTester.h
@@ -292,8 +292,8 @@ private:
                      map[QString("savePathEdit")].toString())
     TS_ASSERT_EQUALS(gui->m_ui.prefixEdit->text(),
                      map[QString("prefixEdit")].toString())
-    TS_ASSERT_EQUALS(gui->m_ui.titleCheckBox->isChecked(),
-                     map[QString("titleCheckBox")].toBool())
+    TS_ASSERT_EQUALS(gui->m_ui.headerCheckBox->isChecked(),
+                     map[QString("headerCheckBox")].toBool())
     TS_ASSERT_EQUALS(gui->m_ui.qResolutionCheckBox->isChecked(),
                      map[QString("qResolutionCheckBox")].toBool())
     TS_ASSERT_EQUALS(gui->m_ui.commaRadioButton->isChecked(),

--- a/qt/scientific_interfaces/test/ISISReflectometry/Common/DecoderTest.h
+++ b/qt/scientific_interfaces/test/ISISReflectometry/Common/DecoderTest.h
@@ -306,7 +306,7 @@ const static QString BATCH_JSON_STRING{
     "        \"saveReductionResultsCheckBox\": false,"
     "        \"spaceRadioButton\": true,"
     "        \"tabRadioButton\": false,"
-    "        \"titleCheckBox\": true"
+    "        \"headerCheckBox\": true"
     "    }"
     "}"};
 
@@ -404,7 +404,7 @@ const static QString EMPTY_BATCH_JSON_STRING{
     "        \"saveReductionResultsCheckBox\": false,"
     "        \"spaceRadioButton\": false,"
     "        \"tabRadioButton\": false,"
-    "        \"titleCheckBox\": false"
+    "        \"headerCheckBox\": false"
     "    }"
     "}"};
 

--- a/qt/scientific_interfaces/test/ISISReflectometry/Save/MockSaveView.h
+++ b/qt/scientific_interfaces/test/ISISReflectometry/Save/MockSaveView.h
@@ -40,8 +40,10 @@ public:
   MOCK_METHOD0(disableAutosaveControls, void());
   MOCK_METHOD0(enableAutosaveControls, void());
 
-  MOCK_METHOD0(enableFileFormatAndLocationControls, void());
-  MOCK_METHOD0(disableFileFormatAndLocationControls, void());
+  MOCK_METHOD0(enableFileFormatControls, void());
+  MOCK_METHOD0(disableFileFormatControls, void());
+  MOCK_METHOD0(enableLocationControls, void());
+  MOCK_METHOD0(disableLocationControls, void());
 
   MOCK_METHOD0(showFilterEditValid, void());
   MOCK_METHOD0(showFilterEditInvalid, void());

--- a/qt/scientific_interfaces/test/ISISReflectometry/Save/MockSaveView.h
+++ b/qt/scientific_interfaces/test/ISISReflectometry/Save/MockSaveView.h
@@ -45,6 +45,15 @@ public:
   MOCK_METHOD0(enableLocationControls, void());
   MOCK_METHOD0(disableLocationControls, void());
 
+  MOCK_METHOD0(enableLogList, void());
+  MOCK_METHOD0(disableLogList, void());
+  MOCK_METHOD0(enableHeaderCheckBox, void());
+  MOCK_METHOD0(disableHeaderCheckBox, void());
+  MOCK_METHOD0(enableQResolutionCheckBox, void());
+  MOCK_METHOD0(disableQResolutionCheckBox, void());
+  MOCK_METHOD0(enableSeparatorButtonGroup, void());
+  MOCK_METHOD0(disableSeparatorButtonGroup, void());
+
   MOCK_METHOD0(showFilterEditValid, void());
   MOCK_METHOD0(showFilterEditInvalid, void());
   MOCK_METHOD0(errorInvalidSaveDirectory, void());

--- a/qt/scientific_interfaces/test/ISISReflectometry/Save/MockSaveView.h
+++ b/qt/scientific_interfaces/test/ISISReflectometry/Save/MockSaveView.h
@@ -27,7 +27,7 @@ public:
   MOCK_CONST_METHOD0(getSelectedWorkspaces, std::vector<std::string>());
   MOCK_CONST_METHOD0(getSelectedParameters, std::vector<std::string>());
   MOCK_CONST_METHOD0(getFileFormatIndex, int());
-  MOCK_CONST_METHOD0(getTitleCheck, bool());
+  MOCK_CONST_METHOD0(getHeaderCheck, bool());
   MOCK_CONST_METHOD0(getQResolutionCheck, bool());
   MOCK_CONST_METHOD0(getSeparator, std::string());
 

--- a/qt/scientific_interfaces/test/ISISReflectometry/Save/SavePresenterTest.h
+++ b/qt/scientific_interfaces/test/ISISReflectometry/Save/SavePresenterTest.h
@@ -242,7 +242,7 @@ public:
     expectSetWorkspaceListFromADS(workspaceNames);
     expectNotProcessingOrAutoreducing();
     EXPECT_CALL(m_view, enableAutosaveControls()).Times(1);
-    EXPECT_CALL(m_view, enableFileFormatAndLocationControls()).Times(1);
+    expectFileFormatAndLocationControlsEnabled();
     presenter.notifyReductionPaused();
     verifyAndClear();
   }
@@ -260,7 +260,7 @@ public:
     auto presenter = makePresenter();
     enableAutosave(presenter);
     expectProcessing();
-    EXPECT_CALL(m_view, disableFileFormatAndLocationControls()).Times(1);
+    expectFileFormatAndLocationControlsDisabled();
     presenter.notifyReductionResumed();
     verifyAndClear();
   }
@@ -269,7 +269,7 @@ public:
     auto presenter = makePresenter();
     disableAutosave(presenter);
     expectProcessing();
-    EXPECT_CALL(m_view, enableFileFormatAndLocationControls()).Times(1);
+    expectFileFormatAndLocationControlsEnabled();
     presenter.notifyReductionResumed();
     verifyAndClear();
   }
@@ -296,7 +296,7 @@ public:
     auto presenter = makePresenter();
     enableAutosave(presenter);
     expectAutoreducing();
-    EXPECT_CALL(m_view, disableFileFormatAndLocationControls()).Times(1);
+    expectFileFormatAndLocationControlsDisabled();
     presenter.notifyAutoreductionResumed();
     verifyAndClear();
   }
@@ -305,7 +305,7 @@ public:
     auto presenter = makePresenter();
     disableAutosave(presenter);
     expectAutoreducing();
-    EXPECT_CALL(m_view, enableFileFormatAndLocationControls()).Times(1);
+    expectFileFormatAndLocationControlsEnabled();
     presenter.notifyAutoreductionResumed();
     verifyAndClear();
   }
@@ -477,6 +477,16 @@ private:
     EXPECT_CALL(m_mainPresenter, isAutoreducing())
         .Times(1)
         .WillOnce(Return(false));
+  }
+
+  void expectFileFormatAndLocationControlsEnabled() {
+    EXPECT_CALL(m_view, enableFileFormatControls()).Times(1);
+    EXPECT_CALL(m_view, enableLocationControls()).Times(1);
+  }
+
+  void expectFileFormatAndLocationControlsDisabled() {
+    EXPECT_CALL(m_view, disableFileFormatControls()).Times(1);
+    EXPECT_CALL(m_view, disableLocationControls()).Times(1);
   }
 
   NiceMock<MockSaveView> m_view;

--- a/qt/scientific_interfaces/test/ISISReflectometry/Save/SavePresenterTest.h
+++ b/qt/scientific_interfaces/test/ISISReflectometry/Save/SavePresenterTest.h
@@ -338,6 +338,70 @@ public:
     verifyAndClear();
   }
 
+  void testLogListEnabledForCustomFormat() {
+    auto presenter = makePresenter();
+    expectFileFormat(NamedFormat::Custom);
+    expectLogListEnabled();
+    presenter.notifySettingsChanged();
+    verifyAndClear();
+  }
+
+  void testCustomOptionsEnabledForCustomFormat() {
+    auto presenter = makePresenter();
+    expectFileFormat(NamedFormat::Custom);
+    expectCustomOptionsEnabled();
+    presenter.notifySettingsChanged();
+    verifyAndClear();
+  }
+
+  void testLogListEnabledForILLCosmosFormat() {
+    auto presenter = makePresenter();
+    expectFileFormat(NamedFormat::ILLCosmos);
+    expectLogListEnabled();
+    presenter.notifySettingsChanged();
+    verifyAndClear();
+  }
+
+  void testCustomOptionsDisabledForILLCosmosFormat() {
+    auto presenter = makePresenter();
+    expectFileFormat(NamedFormat::ILLCosmos);
+    expectCustomOptionsDisabled();
+    presenter.notifySettingsChanged();
+    verifyAndClear();
+  }
+
+  void testLogListDisabledForANSTOFormat() {
+    auto presenter = makePresenter();
+    expectFileFormat(NamedFormat::ANSTO);
+    expectLogListDisabled();
+    presenter.notifySettingsChanged();
+    verifyAndClear();
+  }
+
+  void testCustomOptionsDisabledForANSTOFormat() {
+    auto presenter = makePresenter();
+    expectFileFormat(NamedFormat::ANSTO);
+    expectCustomOptionsDisabled();
+    presenter.notifySettingsChanged();
+    verifyAndClear();
+  }
+
+  void testLogListDisabledForThreeColumnFormat() {
+    auto presenter = makePresenter();
+    expectFileFormat(NamedFormat::ThreeColumn);
+    expectLogListDisabled();
+    presenter.notifySettingsChanged();
+    verifyAndClear();
+  }
+
+  void testCustomOptionsDisabledForThreeColumnFormat() {
+    auto presenter = makePresenter();
+    expectFileFormat(NamedFormat::ThreeColumn);
+    expectCustomOptionsDisabled();
+    presenter.notifySettingsChanged();
+    verifyAndClear();
+  }
+
 private:
   SavePresenter makePresenter() {
     auto asciiSaver = std::make_unique<NiceMock<MockAsciiSaver>>();
@@ -487,6 +551,30 @@ private:
   void expectFileFormatAndLocationControlsDisabled() {
     EXPECT_CALL(m_view, disableFileFormatControls()).Times(1);
     EXPECT_CALL(m_view, disableLocationControls()).Times(1);
+  }
+
+  void expectFileFormat(NamedFormat fileFormat) {
+    EXPECT_CALL(m_view, getFileFormatIndex())
+        .Times(AtLeast(1))
+        .WillOnce(Return(static_cast<int>(fileFormat)));
+  }
+
+  void expectLogListEnabled() { EXPECT_CALL(m_view, enableLogList()).Times(1); }
+
+  void expectLogListDisabled() {
+    EXPECT_CALL(m_view, disableLogList()).Times(1);
+  }
+
+  void expectCustomOptionsEnabled() {
+    EXPECT_CALL(m_view, enableHeaderCheckBox()).Times(1);
+    EXPECT_CALL(m_view, enableQResolutionCheckBox()).Times(1);
+    EXPECT_CALL(m_view, enableSeparatorButtonGroup()).Times(1);
+  }
+
+  void expectCustomOptionsDisabled() {
+    EXPECT_CALL(m_view, disableHeaderCheckBox()).Times(1);
+    EXPECT_CALL(m_view, disableQResolutionCheckBox()).Times(1);
+    EXPECT_CALL(m_view, disableSeparatorButtonGroup()).Times(1);
   }
 
   NiceMock<MockSaveView> m_view;

--- a/qt/scientific_interfaces/test/ISISReflectometry/Save/SavePresenterTest.h
+++ b/qt/scientific_interfaces/test/ISISReflectometry/Save/SavePresenterTest.h
@@ -38,7 +38,7 @@ public:
 
   SavePresenterTest()
       : m_view(), m_savePath("/foo/bar/"), m_fileFormat(NamedFormat::Custom),
-        m_prefix("testoutput_"), m_includeTitle(true), m_separator(","),
+        m_prefix("testoutput_"), m_includeHeader(true), m_separator(","),
         m_includeQResolution(true) {}
 
   void testPresenterSubscribesToView() {
@@ -433,9 +433,9 @@ private:
         .Times(1)
         .WillOnce(Return(static_cast<int>(m_fileFormat)));
     EXPECT_CALL(m_view, getPrefix()).Times(1).WillOnce(Return(m_prefix));
-    EXPECT_CALL(m_view, getTitleCheck())
+    EXPECT_CALL(m_view, getHeaderCheck())
         .Times(1)
-        .WillOnce(Return(m_includeTitle));
+        .WillOnce(Return(m_includeHeader));
     EXPECT_CALL(m_view, getSeparator()).Times(1).WillOnce(Return(m_separator));
     EXPECT_CALL(m_view, getQResolutionCheck())
         .Times(1)
@@ -451,7 +451,7 @@ private:
     expectGetValidSaveDirectory();
     expectGetSaveParametersFromView();
     auto fileFormatOptions =
-        FileFormatOptions(m_fileFormat, m_prefix, m_includeTitle, m_separator,
+        FileFormatOptions(m_fileFormat, m_prefix, m_includeHeader, m_separator,
                           m_includeQResolution);
     EXPECT_CALL(*m_asciiSaver,
                 save(m_savePath, workspaceNames, logs, fileFormatOptions))
@@ -486,7 +486,7 @@ private:
   // file format options for ascii saver
   NamedFormat m_fileFormat;
   std::string m_prefix;
-  bool m_includeTitle;
+  bool m_includeHeader;
   std::string m_separator;
   bool m_includeQResolution;
 };

--- a/qt/scientific_interfaces/test/ISISReflectometry/Save/SavePresenterTest.h
+++ b/qt/scientific_interfaces/test/ISISReflectometry/Save/SavePresenterTest.h
@@ -338,10 +338,20 @@ public:
     verifyAndClear();
   }
 
-  void testLogListEnabledForCustomFormat() {
+  void testLogListEnabledForCustomFormatIfHeaderEnabled() {
     auto presenter = makePresenter();
     expectFileFormat(NamedFormat::Custom);
+    expectHeaderOptionEnabled();
     expectLogListEnabled();
+    presenter.notifySettingsChanged();
+    verifyAndClear();
+  }
+
+  void testLogListDisabledForCustomFormatIfHeaderDisabled() {
+    auto presenter = makePresenter();
+    expectFileFormat(NamedFormat::Custom);
+    expectHeaderOptionDisabled();
+    expectLogListDisabled();
     presenter.notifySettingsChanged();
     verifyAndClear();
   }
@@ -557,6 +567,18 @@ private:
     EXPECT_CALL(m_view, getFileFormatIndex())
         .Times(AtLeast(1))
         .WillOnce(Return(static_cast<int>(fileFormat)));
+  }
+
+  void expectHeaderOptionEnabled() {
+    EXPECT_CALL(m_view, getHeaderCheck())
+        .Times(AtLeast(1))
+        .WillOnce(Return(true));
+  }
+
+  void expectHeaderOptionDisabled() {
+    EXPECT_CALL(m_view, getHeaderCheck())
+        .Times(AtLeast(1))
+        .WillOnce(Return(false));
   }
 
   void expectLogListEnabled() { EXPECT_CALL(m_view, enableLogList()).Times(1); }


### PR DESCRIPTION
**Report to:** Max at ISIS

**Description of work.**

This PR replaces 4 deprecated algorithms used in the ISIS Reflectometry GUI with `SaveReflectometryAscii`. This algorithm supports the same 4 output options. Relevant inputs are enabled/disabled on the GUI based on the selected file format.

The deprecated algorithms will be removed in a subsequent PR.

**To test:**

- Open the ISIS Reflectometry interface
- In the table, enter run `13460` and angle `0.7` and click `Process`. This just generates a workspace we can experiment with.
- Go to the Save tab and enter a valid save path.
- Double-click 'IvsQ_binned_13460` in the table. This should populate the list of logged parameters. Select `run_number` in the list.
- In the File Format drop-down box, try selecting all of the options. The parameters list should be enabled for Custom and ILLCosmos but disabled for ThreeColumn and ANSTO.
- The other options under File Format (Header, Q resolution and Separator) should be disabled for all options except Custom.
- Try clicking save with each of the file formats and check that they make sense with the descriptions in the linked issue. Check that when the optional inputs are enabled:
  - If Header is ticked a header will be added before the columns of numbers (this is the same as the default MFT header)
  - If values are selected in LogList they will appear in the header.
  - If Q resolution is ticked there will be 4 columns of numbers, otherwise 3
  - Check that the correct separator is used

Refs #24429 

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
