### PR TITLE
28992 surface plot colorbar limits

### DIFF
--- a/Framework/PythonInterface/mantid/plots/mantidaxes.py
+++ b/Framework/PythonInterface/mantid/plots/mantidaxes.py
@@ -1374,6 +1374,10 @@ class MantidAxes3D(Axes3D):
         else:
             polyc = Axes3D.plot_surface(self, *args, **kwargs)
 
+        # This is a bit of a hack, should be able to remove
+        # when matplotlib supports plotting masked arrays
+        polyc._A = np.ma.masked_invalid(polyc._A)
+
         # Create a copy of the original data points because data are set to nan when the axis limits are changed.
         self.original_data = copy.deepcopy(polyc._vec)
 

--- a/Framework/PythonInterface/mantid/plots/mantidaxes.py
+++ b/Framework/PythonInterface/mantid/plots/mantidaxes.py
@@ -14,6 +14,7 @@ import copy
 import numpy as np
 
 from matplotlib.axes import Axes
+from matplotlib.cbook import safe_masked_invalid
 from matplotlib.collections import Collection, PolyCollection
 from matplotlib.colors import Colormap
 from matplotlib.container import Container, ErrorbarContainer
@@ -1374,9 +1375,9 @@ class MantidAxes3D(Axes3D):
         else:
             polyc = Axes3D.plot_surface(self, *args, **kwargs)
 
-        # This is a bit of a hack, should be able to remove
-        # when matplotlib supports plotting masked arrays
-        polyc._A = np.ma.masked_invalid(polyc._A)
+            # This is a bit of a hack, should be able to remove
+            # when matplotlib supports plotting masked arrays
+            polyc._A = safe_masked_invalid(polyc._A)
 
         # Create a copy of the original data points because data are set to nan when the axis limits are changed.
         self.original_data = copy.deepcopy(polyc._vec)

--- a/docs/source/release/v5.1.0/mantidworkbench.rst
+++ b/docs/source/release/v5.1.0/mantidworkbench.rst
@@ -136,5 +136,6 @@ Bugfixes
 - Fix crash when subscribing algorithms from a separate thread
 - The workbench launch scripts have been replaced by an executable on macOS & Windows. On Windows this will stop virus scanners
   flagging the old ``launch_workbench.exe`` as a threat and quarantining it.
+- Fixed a bug in the 3D Surface Plot where the colorbar limits were incorrect when plotting data with monitors.
 
 :ref:`Release 5.1.0 <v5.1.0>`

--- a/qt/python/mantidqt/plotting/test/test_functions.py
+++ b/qt/python/mantidqt/plotting/test/test_functions.py
@@ -21,14 +21,14 @@ import numpy as np
 # register mantid projection
 import mantid.plots  # noqa
 from mantid.api import AnalysisDataService, WorkspaceFactory
-from mantid.simpleapi import CreateWorkspace
+from mantid.simpleapi import CreateWorkspace, CreateSampleWorkspace
 from mantid.kernel import config
 from mantid.plots import MantidAxes
 from unittest import mock
 from mantidqt.dialogs.spectraselectordialog import SpectraSelection
 from mantidqt.plotting.functions import (can_overplot, current_figure_or_none, figure_title,
                                          manage_workspace_names, plot, plot_from_names,
-                                         pcolormesh_from_names)
+                                         pcolormesh_from_names, plot_surface)
 
 
 # Avoid importing the whole of mantid for a single mock of the workspace class
@@ -325,6 +325,17 @@ class FunctionsTest(TestCase):
             self.assertEqual(ax.get_xlabel(), err_ax.get_xlabel())
             # Compare title
             self.assertEqual(ax.get_title(), err_ax.get_title())
+
+    def test_colorbar_limits_not_default_values_on_surface_plot_with_monitor(self):
+        ws = CreateSampleWorkspace(NumMonitors=1)
+        fig = plt.figure()
+        plot_surface([ws], fig=fig)
+        ax = fig.get_axes()
+        cmin, cmax = ax[0].collections[0].get_clim()
+
+        # the colorbar limits default to +-0.1 when it can't find max and min of array
+        self.assertNotEqual(cmax, 0.1)
+        self.assertNotEqual(cmin, -0.1)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Matplotlib does not support plotting masked array on a surface plot, which caused the colorbar limits to be set incorrectly. Solution was to create the plot object with the plain data (let matplotlib handle nan itself), reassign the plot data to be a masked array with `safe_masked_invalid` from `matplotlib.cbook`.

**To test:**
1. Load `MAR11060.raw`
2. Right click > Show Plot > 3D > Surface Plot
3. Colorbar limits should be `0.8550...` to `122.2...` (as opposed to -+0.01) and the monitors spectra should not be plotted.

Additionally, `test_colorbar_limits_correct_on_surface_plot_with_monitor` unittest in `qt/python/mantidqt/plotting/test/test_functions.py` should pass.

fixes #28992 

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
