### PR TITLE
Enable peaks overlay for the nonorthogonal slice viewer.

### DIFF
--- a/Framework/PythonInterface/mantid/plots/axesfunctions.py
+++ b/Framework/PythonInterface/mantid/plots/axesfunctions.py
@@ -33,7 +33,7 @@ _LARGEST, _SMALLEST = float(sys.maxsize), -sys.maxsize
 # ================================================
 
 
-def _pcolormesh_nonortho(axes, workspace, to_display, *args, **kwargs):
+def _pcolormesh_nonortho(axes, workspace, nonortho_tr, *args, **kwargs):
     '''
     Essentially the same as :meth:`matplotlib.axes.Axes.pcolormesh` and adds arguments related to
     plotting slices on nonorthogonal axes. It requires a non-standard Axes type. See
@@ -45,8 +45,8 @@ def _pcolormesh_nonortho(axes, workspace, to_display, *args, **kwargs):
     :param axes:      :class:`matplotlib.axes.Axes` object that will do the plotting
     :param workspace: :class:`mantid.api.MatrixWorkspace` or :class:`mantid.api.IMDHistoWorkspace`
                       to extract the data from
-    :param to_display: Callable accepting two numpy arrays to transfrom from nonorthogonal
-                       coordinates to orthogonal display
+    :param nonortho_tr: Callable accepting two numpy arrays to transfrom from nonorthogonal
+                        coordinates to rectilinear image coordinates
     :param transpose: ``bool`` to transpose the x and y axes of the plotted dimensions of an MDHistoWorkspace
     '''
     transpose = kwargs.pop('transpose', False)
@@ -57,7 +57,7 @@ def _pcolormesh_nonortho(axes, workspace, to_display, *args, **kwargs):
                                        normalization=normalization,
                                        transpose=transpose)
     X, Y = numpy.meshgrid(x, y)
-    xx, yy = to_display(X, Y)
+    xx, yy = nonortho_tr(X, Y)
     _setLabels2D(axes, workspace, indices, transpose)
     return axes.pcolormesh(xx, yy, z, *args, **kwargs)
 

--- a/qt/python/mantidqt/widgets/sliceviewer/model.py
+++ b/qt/python/mantidqt/widgets/sliceviewer/model.py
@@ -261,7 +261,7 @@ class SliceViewerModel:
             # assume orthogonal projection
             proj_matrix = np.diag([1., 1., 1.])
 
-        display_indices = slice_info.transform([0, 1, 2])
+        display_indices = slice_info.transform([0, 1, 2]).astype(int)
         return NonOrthogonalTransform.from_lattice(
             lattice,
             x_proj=proj_matrix[:, display_indices[0]],

--- a/qt/python/mantidqt/widgets/sliceviewer/peaksviewer/model.py
+++ b/qt/python/mantidqt/widgets/sliceviewer/peaksviewer/model.py
@@ -7,7 +7,6 @@
 #  This file is part of the mantid workbench.
 
 # 3rd party imports
-from cycler import cycler
 from mantid.api import AnalysisDataService, SpecialCoordinateSystem
 from mantid.kernel import logger
 
@@ -16,16 +15,6 @@ from mantidqt.widgets.workspacedisplay.table.model \
     import TableWorkspaceDisplayModel
 from .representation.draw import draw_peak_representation
 
-# constants
-# cycle colors for each peaks workspace - it is unlikely there will be more than 3
-FG_COLORS = cycler(fg_color=[
-    '#d62728',  # ~red,
-    '#03ad06',  # ~green
-    '#17becf',  # ~cyan
-    '#e9f02e',  # ~yellow
-    '#e377c2'  # ~pink
-])()
-DEFAULT_BG_COLOR = '0.75'
 # map coordinate system to correct Peak getter
 FRAME_TO_PEAK_CENTER_ATTR = {
     SpecialCoordinateSystem.QLab: 'getQLabFrame',
@@ -38,6 +27,7 @@ class PeaksViewerModel(TableWorkspaceDisplayModel):
     """View model for PeaksViewer
     Extends PeaksWorkspace functionality to include color selection
     """
+
     def __init__(self, peaks_ws, fg_color, bg_color):
         """
         :param peaks_ws: A pointer to the PeaksWorkspace
@@ -124,20 +114,20 @@ class PeaksViewerModel(TableWorkspaceDisplayModel):
         return peak_center_getter
 
 
-def create_peaksviewermodel(peaks_ws_name):
+def create_peaksviewermodel(peaks_ws_name: str, fg_color: str, bg_color: str):
     """
     A factory function to create a PeaksViewerModel from the given workspace name
     :param peaks_ws_name: A str giving a workspace name that is expected to be a PeaksWorkspace
+    :param fg_color: Color of the glyphs marking the signal region
+    :param bg_color: Color of the glyphs marking the background region
     :return: A new PeaksViewerModel object
     :raises ValueError: if the workspace referred to by the name is not a PeaksWorkspace
     """
-    return PeaksViewerModel(_get_peaksworkspace(peaks_ws_name),
-                            fg_color=next(FG_COLORS)['fg_color'],
-                            bg_color=DEFAULT_BG_COLOR)
+    return PeaksViewerModel(_get_peaksworkspace(peaks_ws_name), fg_color, bg_color)
 
 
 # Private
-def _get_peaksworkspace(name):
+def _get_peaksworkspace(name: str):
     """Return a handle to a PeaksWorkspace
     :param name: The string name of a workspace in the ADS that should be a PeaksWorkspace
     :raises ValueError: if the workspace exists but is not a PeaksWorkspace

--- a/qt/python/mantidqt/widgets/sliceviewer/peaksviewer/presenter.py
+++ b/qt/python/mantidqt/widgets/sliceviewer/peaksviewer/presenter.py
@@ -97,7 +97,7 @@ class PeaksViewerPresenter(object):
         #   - first update slice point so we are in the correct plane
         #   - find and set limits required to "zoom" to the selected peak
         self._view.set_slicepoint(self.model.slicepoint(selected_index, self._view.sliceinfo))
-        self._view.set_axes_limits(*self.model.viewlimits(selected_index))
+        self._view.set_axes_limits(*self.model.viewlimits(selected_index), auto_transform=False)
 
     # private api
     @staticmethod

--- a/qt/python/mantidqt/widgets/sliceviewer/peaksviewer/presenter.py
+++ b/qt/python/mantidqt/widgets/sliceviewer/peaksviewer/presenter.py
@@ -19,6 +19,7 @@ class PeaksViewerPresenter(object):
     """Controls a PeaksViewerView with a given model to display
     the peaks table and interaction controls for single workspace.
     """
+
     class Event(Enum):
         PeaksListChanged = 1
         OverlayPeaks = 2
@@ -112,6 +113,18 @@ class PeaksViewerPresenter(object):
 class PeaksViewerCollectionPresenter(object):
     """Controls a widget comprising of multiple PeasViewerViews to display and
     interact with multiple PeaksWorkspaces"""
+
+    # constants
+    # colors for each peaks workspace - it is unlikely there will be more than 3 at once
+    FG_COLORS = [
+        '#d62728',  # ~red,
+        '#03ad06',  # ~green
+        '#17becf',  # ~cyan
+        '#e9f02e',  # ~yellow
+        '#e377c2'  # ~pink
+    ]
+    DEFAULT_BG_COLOR = '0.75'
+
     def __init__(self, view):
         """
         :param view: View displaying the model information
@@ -123,13 +136,14 @@ class PeaksViewerCollectionPresenter(object):
     def view(self):
         return self._view
 
-    def append_peaksworkspace(self, model):
+    def append_peaksworkspace(self, name):
         """
-        Create and append a view for the given workspace
-        :param model: A PeakWorkspace model object.
+        Create and append a view for the given named workspace
+        :param name: The name of a PeaksWorkspace.
         :returns: The child presenter
         """
-        presenter = PeaksViewerPresenter(model, self._view.append_peaksviewer())
+        presenter = PeaksViewerPresenter(
+            self._create_peaksviewer_model(name), self._view.append_peaksviewer())
         self._child_presenters.append(presenter)
         return presenter
 
@@ -156,7 +170,7 @@ class PeaksViewerCollectionPresenter(object):
                 self.remove_peaksworkspace(name)
 
         for name in names_to_overlay_final:
-            self.append_peaksworkspace(create_peaksviewermodel(name))
+            self.append_peaksworkspace(name)
 
         self.notify(PeaksViewerPresenter.Event.OverlayPeaks)
 
@@ -189,3 +203,24 @@ class PeaksViewerCollectionPresenter(object):
         """Dispatch notification to all subpresenters"""
         for presenter in self._child_presenters:
             presenter.notify(event)
+
+    # private api
+    def _create_peaksviewer_model(self, name):
+        """
+        Create a model for the given PeaksWorkspace with an appropriate color
+        :param name: The name of a PeaksWorkspace.
+        :return A new PeaksViewerModel object
+        """
+        # select first unused color
+        used_colors = map(lambda p: p.model.fg_color, self._child_presenters)
+        fg_color = None
+        for color in self.FG_COLORS:
+            if color not in used_colors:
+                fg_color = color
+                break
+
+        if fg_color is None:
+            # use black in this rare case
+            fg_color = '#000000'
+
+        return create_peaksviewermodel(name, fg_color, self.DEFAULT_BG_COLOR)

--- a/qt/python/mantidqt/widgets/sliceviewer/peaksviewer/representation/painter.py
+++ b/qt/python/mantidqt/widgets/sliceviewer/peaksviewer/representation/painter.py
@@ -79,17 +79,18 @@ class MplPainter(object):
     """
     Implementation of a PeakPainter that uses matplotlib to draw
     """
-    def __init__(self, axes):
+    def __init__(self, view):
         """
-        :param axes: A matplotlib.axes.Axes instance to draw on
+        :param view: An object defining an axes property.
         """
-        if not hasattr(axes, "scatter"):
-            raise ValueError("Expected matplotlib.axes.Axes instance. Found {}.".format(type(axes)))
-        self._axes = axes
+        self._view = view
+        if not hasattr(self._view, "ax"):
+            raise ValueError("Expected to find an 'ax' attribute on the view. Found {}.".format(
+                type(view)))
 
     @property
     def axes(self):
-        return self._axes
+        return self._view.ax
 
     def remove(self, artist):
         """
@@ -109,7 +110,7 @@ class MplPainter(object):
         :param radius: Radius of the circle
         :param kwargs: Additional matplotlib properties to pass to the call
         """
-        return self._axes.add_patch(Circle((x, y), radius, **kwargs))
+        return self.axes.add_patch(Circle((x, y), radius, **kwargs))
 
     def cross(self, x, y, half_width, **kwargs):
         """Draw a cross at the given location
@@ -121,7 +122,7 @@ class MplPainter(object):
         verts = ((x - half_width, y + half_width), (x + half_width, y - half_width),
                  (x + half_width, y + half_width), (x - half_width, y - half_width))
         codes = (Path.MOVETO, Path.LINETO, Path.MOVETO, Path.LINETO)
-        return self._axes.add_patch(PathPatch(Path(verts, codes), **kwargs))
+        return self.axes.add_patch(PathPatch(Path(verts, codes), **kwargs))
 
     def ellipse(self, x, y, width, height, angle=0.0, **kwargs):
         """Draw an ellipse at the given location
@@ -132,7 +133,7 @@ class MplPainter(object):
         :param angle: Angle in degrees w.r.t X axis
         :param kwargs: Additional matplotlib properties to pass to the call
         """
-        return self._axes.add_patch(Ellipse((x, y), width, height, angle, **kwargs))
+        return self.axes.add_patch(Ellipse((x, y), width, height, angle, **kwargs))
 
     def elliptical_shell(self, x, y, outer_width, outer_height, thick, angle=0.0, **kwargs):
         """Draw an ellipse at the given location
@@ -144,7 +145,7 @@ class MplPainter(object):
         :param angle: Angle in degrees w.r.t X axis
         :param kwargs: Additional matplotlib properties to pass to the call
         """
-        return self._axes.add_patch(
+        return self.axes.add_patch(
             EllipticalShell((x, y), outer_width, outer_height, thick, angle, **kwargs))
 
     def shell(self, x, y, outer_radius, thick, **kwargs):
@@ -155,7 +156,7 @@ class MplPainter(object):
         :param thick: The thickness of the shell
         :param kwargs: Additional matplotlib properties to pass to the call
         """
-        return self._axes.add_patch(
+        return self.axes.add_patch(
             Wedge((x, y), outer_radius, theta1=0.0, theta2=360., width=thick, **kwargs))
 
     def bbox(self, artist):
@@ -165,7 +166,7 @@ class MplPainter(object):
         """
         # Use the bounding box of the artist with small amount of padding
         # to set the axis limits
-        to_data_coords = self._axes.transData.inverted()
+        to_data_coords = self.axes.transData.inverted()
         artist_bbox = artist.get_extents()
         return to_data_coords.transform(artist_bbox.min), \
             to_data_coords.transform(artist_bbox.max)

--- a/qt/python/mantidqt/widgets/sliceviewer/peaksviewer/representation/test/test_peaksviewer_representation_painter.py
+++ b/qt/python/mantidqt/widgets/sliceviewer/peaksviewer/representation/test/test_peaksviewer_representation_painter.py
@@ -30,66 +30,67 @@ class MplPainterTest(unittest.TestCase):
         mock_artist.remove.assert_called_once()
 
     def test_circle_draws_circle_patch(self):
-        axes = MagicMock()
-        painter = MplPainter(axes)
+        view = MagicMock()
+        painter = MplPainter(view)
         x, y, radius = 1, 2, 0.8
 
         artist = painter.circle(x, y, radius)
 
-        axes.add_patch.assert_called_once()
+        painter.axes.add_patch.assert_called_once()
         self.assertTrue(artist is not None)
 
     def test_cross_draws_with_only_xy(self):
-        axes = MagicMock()
-        painter = MplPainter(axes)
+        view = MagicMock()
+        painter = MplPainter(view)
         x, y, half_width = 1, 2, 0.1
 
         artist = painter.cross(x, y, half_width)
 
-        axes.add_patch.assert_called_once()
+        painter.axes.add_patch.assert_called_once()
         self.assertTrue(artist is not None)
-        self._verify_patch(patch=axes.add_patch.call_args[0][0], nvertices=4, alpha=None)
+        self._verify_patch(patch=painter.axes.add_patch.call_args[0][0], nvertices=4, alpha=None)
 
     def test_cross_passes_kwargs_to_mpl(self):
-        axes = MagicMock()
-        painter = MplPainter(axes)
+        view = MagicMock()
+        painter = MplPainter(view)
         x, y, half_width = 1, 2, 0.1
         alpha = 0.8
 
         painter.cross(x, y, half_width, alpha=alpha)
 
-        axes.add_patch.assert_called_once()
-        self._verify_patch(patch=axes.add_patch.call_args[0][0], nvertices=4, alpha=alpha)
+        painter.axes.add_patch.assert_called_once()
+        self._verify_patch(patch=painter.axes.add_patch.call_args[0][0], nvertices=4, alpha=alpha)
 
     def test_ellipticalshell(self):
-        axes = MagicMock()
-        painter = MplPainter(axes)
+        view = MagicMock()
+        painter = MplPainter(view)
         x, y, outer_width, outer_height, thick = 1, 2, 0.8, 1.0, 0.2
         alpha = 1.0
 
         painter.elliptical_shell(x, y, outer_width, outer_height, thick, alpha=alpha)
 
-        axes.add_patch.assert_called_once()
-        self._verify_patch(patch=axes.add_patch.call_args[0][0], nvertices=100, alpha=alpha)
+        painter.axes.add_patch.assert_called_once()
+        self._verify_patch(patch=painter.axes.add_patch.call_args[0][0], nvertices=100, alpha=alpha)
 
     def test_shell_adds_patch(self):
-        axes = MagicMock()
-        painter = MplPainter(axes)
+        view = MagicMock()
+        painter = MplPainter(view)
         x, y, outer_radius, thick = 1, 2, 0.8, 0.2
 
         painter.shell(x, y, outer_radius, thick)
 
-        axes.add_patch.assert_called_once()
-        self._verify_patch(patch=axes.add_patch.call_args[0][0], nvertices=100, alpha=None)
+        painter.axes.add_patch.assert_called_once()
+        self._verify_patch(patch=painter.axes.add_patch.call_args[0][0], nvertices=100, alpha=None)
 
     def test_bbox_returns_ll_and_ur_of_containing_box(self):
-        artist, axes, bbox, inv_trans = (MagicMock(), ) * 4
+        artist, view, axes, bbox, inv_trans = (MagicMock(), ) * 5
         # 1:1 transformation for simplicity
         inv_trans.transform.side_effect = lambda x: x
         axes.transData.inverted.return_value = inv_trans
         artist.get_extents.return_value = bbox
         bbox.min, bbox.max = (1., 1.5), (3., 3.5)
-        painter = MplPainter(axes)
+        view.ax = axes
+        painter = MplPainter(view)
 
         ll, ur = painter.bbox(artist)
 
@@ -104,13 +105,14 @@ class MplPainterTest(unittest.TestCase):
             artist.get_extents.return_value = bbox
             return artist
 
-        axes, inv_trans = MagicMock(), MagicMock()
+        axes, view, inv_trans = MagicMock(), MagicMock(), MagicMock()
         # 1:1 transformation for simplicity
         inv_trans.transform.side_effect = lambda x: x
         axes.transData.inverted.return_value = inv_trans
         artists = create_mock_artist(((1., 1.5), (3., 3.5))), create_mock_artist(
             ((1.1, 1.3), (2.9, 3.6)))
-        painter = MplPainter(axes)
+        view.ax = axes
+        painter = MplPainter(view)
         painted = Painted(painter, artists)
 
         xlim, ylim = painted.viewlimits()

--- a/qt/python/mantidqt/widgets/sliceviewer/peaksviewer/test/test_peaksviewer_model.py
+++ b/qt/python/mantidqt/widgets/sliceviewer/peaksviewer/test/test_peaksviewer_model.py
@@ -35,24 +35,24 @@ class PeaksViewerModelTest(unittest.TestCase):
         self.assertEqual(bg_color, model.bg_color)
 
     @patch('mantidqt.widgets.sliceviewer.peaksviewer.model._get_peaksworkspace')
-    def test_successive_create_peaksviewermodel_use_different_fg_colors(
-            self, mock_get_peaks_workspace):
+    def test_create_peaksviewermodel_uses_given_colors(self, mock_get_peaks_workspace):
         mock_get_peaks_workspace.return_value = MagicMock(spec=PeaksWorkspace)
 
-        first_model = create_peaksviewermodel('test')
-        second_model = create_peaksviewermodel('test')
+        first_model = create_peaksviewermodel('test', 'red', 'gray')
+        second_model = create_peaksviewermodel('test', 'blue', 'white')
 
-        self.assertNotEqual(first_model.fg_color, second_model.fg_color)
+        self.assertEqual('red', first_model.fg_color)
+        self.assertEqual('gray', first_model.bg_color)
+        self.assertEqual('blue', second_model.fg_color)
+        self.assertEqual('white', second_model.bg_color)
 
     def test_draw_peaks(self):
         fg_color = 'r'
         # create 2 peaks: 1 visible, 1 not (far outside Z range)
         visible_peak_center, invisible_center = (0.5, 0.2, 0.25), (0.4, 0.3, 25)
 
-        _, mock_painter = draw_peaks((visible_peak_center, invisible_center),
-                                     fg_color,
-                                     slice_value=0.5,
-                                     slice_width=30)
+        _, mock_painter = draw_peaks(
+            (visible_peak_center, invisible_center), fg_color, slice_value=0.5, slice_width=30)
 
         self.assertEqual(1, mock_painter.cross.call_count)
         call_args, call_kwargs = mock_painter.cross.call_args
@@ -65,10 +65,8 @@ class PeaksViewerModelTest(unittest.TestCase):
     def test_clear_peaks_removes_all_drawn(self):
         # create 2 peaks: 1 visible, 1 not (far outside Z range)
         visible_peak_center, invisible_center = (0.5, 0.2, 0.25), (0.4, 0.3, 25)
-        model, mock_painter = draw_peaks((visible_peak_center, invisible_center),
-                                         fg_color='r',
-                                         slice_value=0.5,
-                                         slice_width=30)
+        model, mock_painter = draw_peaks(
+            (visible_peak_center, invisible_center), fg_color='r', slice_value=0.5, slice_width=30)
 
         model.clear_peak_representations()
 
@@ -92,10 +90,8 @@ class PeaksViewerModelTest(unittest.TestCase):
 
     def test_viewlimits(self):
         visible_peak_center, invisible_center = (0.5, 0.2, 0.25), (0.4, 0.3, 25)
-        model, mock_painter = draw_peaks((visible_peak_center, invisible_center),
-                                         fg_color='r',
-                                         slice_value=0.5,
-                                         slice_width=30)
+        model, mock_painter = draw_peaks(
+            (visible_peak_center, invisible_center), fg_color='r', slice_value=0.5, slice_width=30)
 
         xlim, ylim = model.viewlimits(0)
 

--- a/qt/python/mantidqt/widgets/sliceviewer/peaksviewer/test/test_peaksviewer_peaksviewercollectionpresenter.py
+++ b/qt/python/mantidqt/widgets/sliceviewer/peaksviewer/test/test_peaksviewer_peaksviewercollectionpresenter.py
@@ -8,12 +8,18 @@
 
 # std imports
 import unittest
-from unittest.mock import call, create_autospec, patch, MagicMock
+from unittest.mock import MagicMock, create_autospec, patch
 
 # 3rdparty imports
 from mantid.dataobjects import PeaksWorkspace
 from mantidqt.widgets.sliceviewer.peaksviewer \
     import PeaksViewerPresenter, PeaksViewerCollectionPresenter, PeaksViewerModel
+
+
+class FakePeaksModelFactory(MagicMock):
+    def __call__(self, name, fg, bg):
+        super().__call__(name, fg, bg)
+        return PeaksViewerModel(create_mock_peaks_workspace(name), fg, bg)
 
 
 def create_mock_peaks_workspace(name="peaks"):
@@ -23,63 +29,58 @@ def create_mock_peaks_workspace(name="peaks"):
     return mock
 
 
+@patch(
+    "mantidqt.widgets.sliceviewer.peaksviewer.presenter.create_peaksviewermodel",
+    new_callable=FakePeaksModelFactory)
 class PeaksViewerCollectionPresenterTest(unittest.TestCase):
 
     # -------------------- success tests -----------------------------
-    @patch("mantidqt.widgets.sliceviewer.peaksviewer.presenter.PeaksViewerPresenter")
-    def test_append_constructs_PeaksViewerPresenter(self, mock_single_presenter):
-        peaks_workspace = PeaksViewerModel(create_mock_peaks_workspace(), 'r', 'b')
-        mock_collection_view = MagicMock()
-        mock_peaks_view = MagicMock()
-        mock_collection_view.append_peaksviewer.return_value = mock_peaks_view
 
-        presenter = PeaksViewerCollectionPresenter(mock_collection_view)
-        presenter.append_peaksworkspace(peaks_workspace)
+    def test_append_constructs_PeaksViewerPresenter_for_call(self, mock_create_model):
+        # mock 2 models with the correct names and assume  create_peaksviewermodel makes them
+        names = ["peaks1", 'peaks2']
+        presenter = PeaksViewerCollectionPresenter(MagicMock())
 
-        mock_single_presenter.assert_has_calls([call(peaks_workspace, mock_peaks_view)])
-        self.assertEqual(1, presenter.view.append_peaksviewer.call_count)
+        for name in names:
+            presenter.append_peaksworkspace(name)
 
-    def test_notify_called_for_each_subpresenter(self):
-        peak_workspaces = (PeaksViewerModel(create_mock_peaks_workspace(), 'r', 'b')
-                           for _ in range(2))
+        self.assertEqual(names, presenter.workspace_names())
+
+    def test_append_uses_unused_fg_color(self, mock_create_model):
+        names = ["peaks1", 'peaks2']
+        # setup with 1 workspace
+        presenter = PeaksViewerCollectionPresenter(MagicMock())
+        presenter.append_peaksworkspace(names[0])
+
+        mock_create_model.assert_called_once_with(names[0],
+                                                  PeaksViewerCollectionPresenter.FG_COLORS[0],
+                                                  PeaksViewerCollectionPresenter.DEFAULT_BG_COLOR)
+        mock_create_model.reset_mock()
+        presenter.append_peaksworkspace(names[1])
+        mock_create_model.assert_called_once_with(names[1],
+                                                  PeaksViewerCollectionPresenter.FG_COLORS[1],
+                                                  PeaksViewerCollectionPresenter.DEFAULT_BG_COLOR)
+
+    def test_remove_removes_named_workspace(self, mock_create_model):
+        names = ["peaks1", 'peaks2', 'peaks3']
+        presenter = PeaksViewerCollectionPresenter(MagicMock())
+        for name in names:
+            presenter.append_peaksworkspace(name)
+
+        presenter.remove_peaksworkspace(names[1])
+
+        self.assertEqual([names[0], names[2]], presenter.workspace_names())
+
+    def test_notify_called_for_each_subpresenter(self, mock_create_model):
+        presenter = PeaksViewerCollectionPresenter(MagicMock())
+
         with patch("mantidqt.widgets.sliceviewer.peaksviewer.presenter.PeaksViewerPresenter"
                    ) as presenter_mock:
-            presenter, child_presenters = self._create_collection_presenter(
-                peak_workspaces, presenter_mock)
+            presenter_mock.side_effect = [MagicMock(), MagicMock()]
+            child_presenters = [presenter.append_peaksworkspace(f'peaks_{i}') for i in range(2)]
             presenter.notify(PeaksViewerPresenter.Event.OverlayPeaks)
             for child in child_presenters:
                 child.notify.assert_called_once_with(PeaksViewerPresenter.Event.OverlayPeaks)
-
-    def test_workspace_names_returns_all_displayed_names(self):
-        names = ("peaks1", "peaks2")
-        peak_workspaces = (PeaksViewerModel(create_mock_peaks_workspace(name), 'r', 'b')
-                           for name in names)
-        with patch("mantidqt.widgets.sliceviewer.peaksviewer.presenter.PeaksViewerPresenter"
-                   ) as presenter_mock:
-            presenter, child_presenters = self._create_collection_presenter(
-                peak_workspaces, presenter_mock)
-            overlayed_names = presenter.workspace_names()
-
-            for overlayed_name in overlayed_names:
-                self.assertTrue(overlayed_name in names)
-
-    # private
-    def _create_collection_presenter(self, models, single_presenter_mock):
-        view = MagicMock()
-        # make each call to to mock_presenter return a new mock object with
-        # the appropriate return_value for the model
-        side_effects = []
-        for model in models:
-            mock = MagicMock()
-            mock.model.return_value = model
-            side_effects.append(mock)
-        single_presenter_mock.side_effect = side_effects
-        presenter = PeaksViewerCollectionPresenter(view)
-        child_presenters = []
-        for peaks_ws in models:
-            child_presenters.append(presenter.append_peaksworkspace(peaks_ws))
-
-        return presenter, child_presenters
 
 
 if __name__ == '__main__':

--- a/qt/python/mantidqt/widgets/sliceviewer/peaksviewer/test/test_peaksviewer_presenter.py
+++ b/qt/python/mantidqt/widgets/sliceviewer/peaksviewer/test/test_peaksviewer_presenter.py
@@ -34,8 +34,9 @@ def create_mock_model(name):
     return mock
 
 
-@patch("mantidqt.widgets.sliceviewer.peaksviewer.presenter.TableWorkspaceDataPresenter",
-       autospec=TableWorkspaceDataPresenter)
+@patch(
+    "mantidqt.widgets.sliceviewer.peaksviewer.presenter.TableWorkspaceDataPresenter",
+    autospec=TableWorkspaceDataPresenter)
 class PeaksViewerPresenterTest(unittest.TestCase):
 
     # -------------------- success tests -----------------------------
@@ -110,7 +111,7 @@ class PeaksViewerPresenterTest(unittest.TestCase):
         presenter.notify(PeaksViewerPresenter.Event.PeakSelected)
 
         mock_model.viewlimits.assert_called_once_with(0)
-        mock_view.set_axes_limits.assert_called_once_with(*viewlimits)
+        mock_view.set_axes_limits.assert_called_once_with(*viewlimits, auto_transform=False)
 
 
 if __name__ == '__main__':

--- a/qt/python/mantidqt/widgets/sliceviewer/peaksviewer/view.py
+++ b/qt/python/mantidqt/widgets/sliceviewer/peaksviewer/view.py
@@ -64,13 +64,16 @@ class PeaksViewerView(QWidget):
     def selected_index(self):
         return self._selected_index()
 
-    def set_axes_limits(self, xlim, ylim):
+    def set_axes_limits(self, xlim, ylim, auto_transform):
         """
         Set the view limits on the image axes to the given extents
         :param xlim: 2-tuple of (xmin, xmax)
         :param ylim: 2-tuple of (ymin, ymax)
+        :param auto_transform: If True, the limits are transformed into the
+                               rectilinear frame using the transform provided
+                               by the sliceinfo
         """
-        self._sliceinfo_provider.set_axes_limits(xlim, ylim)
+        self._sliceinfo_provider.set_axes_limits(xlim, ylim, auto_transform)
 
     def set_peak_color(self, peak_color):
         """

--- a/qt/python/mantidqt/widgets/sliceviewer/presenter.py
+++ b/qt/python/mantidqt/widgets/sliceviewer/presenter.py
@@ -71,6 +71,7 @@ class SliceViewer(object):
         Tell the view to display a new plot of an MDHistoWorkspace
         """
         self.view.data_view.plot_MDH(self.model.get_ws(), slicepoint=self.get_slicepoint())
+        self._call_peaks_presenter_if_created("notify", PeaksViewerPresenter.Event.OverlayPeaks)
 
     def new_plot_MDE(self):
         """
@@ -78,13 +79,27 @@ class SliceViewer(object):
         """
         data_view = self.view.data_view
         limits = data_view.get_axes_limits()
-        if data_view.dimensions.transpose:
-            limits = limits[1], limits[0]
+
+        if limits is not None:
+            xlim, ylim = limits
+            # view limits are in orthogonal frame. transform to nonorthogonal
+            # model frame
+            if data_view.nonorthogonal_mode:
+                inv_tr = data_view.nonortho_transform.inv_tr
+                xmin_p, ymin_p = inv_tr(xlim[0], ylim[0])
+                xmax_p, ymax_p = inv_tr(xlim[1], ylim[1])
+                xlim, ylim = (xmin_p, xmax_p), (ymin_p, ymax_p)
+            if data_view.dimensions.transpose:
+                limits = ylim, xlim
+            else:
+                limits = xlim, ylim
+
         data_view.plot_MDH(
             self.model.get_ws(
                 slicepoint=self.get_slicepoint(),
                 bin_params=data_view.dimensions.get_bin_params(),
                 limits=limits))
+        self._call_peaks_presenter_if_created("notify", PeaksViewerPresenter.Event.OverlayPeaks)
 
     def new_plot_matrix(self):
         """Tell the view to display a new plot of an MatrixWorkspace"""
@@ -117,12 +132,12 @@ class SliceViewer(object):
     def get_sliceinfo(self):
         """Returns a SliceInfo object describing the current slice"""
         dimensions = self.view.data_view.dimensions
-        return SliceInfo(
-            frame=self.model.get_frame(),
-            point=dimensions.get_slicepoint(),
-            transpose=dimensions.transpose,
-            range=dimensions.get_slicerange(),
-            qflags=dimensions.qflags)
+        return SliceInfo(frame=self.model.get_frame(),
+                         point=dimensions.get_slicepoint(),
+                         transpose=dimensions.transpose,
+                         range=dimensions.get_slicerange(),
+                         qflags=dimensions.qflags,
+                         nonortho_transform=self.view.data_view.nonortho_transform)
 
     def get_slicepoint(self):
         """Returns the current slicepoint as a list of 3 elements.
@@ -154,7 +169,6 @@ class SliceViewer(object):
                 data_view.disable_tool_button(ToolItemText.NONORTHOGONAL_AXES)
 
         self.new_plot()
-        self._call_peaks_presenter_if_created("notify", PeaksViewerPresenter.Event.OverlayPeaks)
 
     def slicepoint_changed(self):
         """Indicates the slicepoint has been updated"""
@@ -167,7 +181,6 @@ class SliceViewer(object):
         data_view = self.view.data_view
         if self.model.can_support_dynamic_rebinning():
             self.new_plot()  # automatically uses current display limits
-            self._call_peaks_presenter_if_created("notify", PeaksViewerPresenter.Event.OverlayPeaks)
         else:
             data_view.draw_plot()
 
@@ -176,9 +189,21 @@ class SliceViewer(object):
         self.set_axes_limits(*self.model.get_dim_limits(self.get_slicepoint(),
                                                         self.view.data_view.dimensions.transpose))
 
-    def set_axes_limits(self, xlim, ylim):
-        """Set the axes limits on the view"""
-        self.view.data_view.set_axes_limits(xlim, ylim)
+    def set_axes_limits(self, xlim, ylim, auto_transform=True):
+        """Set the axes limits on the view.
+        :param xlim: Limits on the X axis in image coordinates
+        :param ylim: Limits on the Y axis in image coordinates
+        :param auto_transform: If True transform the given limits to the rectilinear
+        coordinate before passing to the view
+        """
+        data_view = self.view.data_view
+        if auto_transform and data_view.nonorthogonal_mode:
+            to_display = data_view.nonortho_transform.tr
+            xmin_p, ymin_p = to_display(xlim[0], ylim[0])
+            xmax_p, ymax_p = to_display(xlim[1], ylim[1])
+            xlim, ylim = (xmin_p, xmax_p), (ymin_p, ymax_p)
+
+        data_view.set_axes_limits(xlim, ylim)
         self.data_limits_changed()
 
     def line_plots(self, state):
@@ -283,16 +308,14 @@ class SliceViewer(object):
         if state:
             data_view.deactivate_and_disable_tool(ToolItemText.REGIONSELECTION)
             data_view.disable_tool_button(ToolItemText.LINEPLOTS)
-            data_view.disable_tool_button(ToolItemText.OVERLAY_PEAKS)
             data_view.create_axes_nonorthogonal(
                 self.model.create_nonorthogonal_transform(self.get_sliceinfo()))
-            self.new_plot()
         else:
             data_view.create_axes_orthogonal()
             data_view.enable_tool_button(ToolItemText.LINEPLOTS)
             data_view.enable_tool_button(ToolItemText.REGIONSELECTION)
-            data_view.enable_tool_button(ToolItemText.OVERLAY_PEAKS)
-            self.new_plot()
+
+        self.new_plot()
 
     def normalization_changed(self, norm_type):
         """

--- a/qt/python/mantidqt/widgets/sliceviewer/test/test_sliceviewer_model.py
+++ b/qt/python/mantidqt/widgets/sliceviewer/test/test_sliceviewer_model.py
@@ -205,7 +205,7 @@ def create_mock_sliceinfo(indices: tuple):
     :param indices: 3D indices defining permuation order of dimensions
     """
     slice_info = MagicMock()
-    slice_info.transform.side_effect = lambda x: [x[indices[0]], x[indices[1]], x[indices[2]]]
+    slice_info.transform.side_effect = lambda x: np.array([x[indices[0]], x[indices[1]], x[indices[2]]])
     return slice_info
 
 

--- a/qt/python/mantidqt/widgets/sliceviewer/test/test_sliceviewer_presenter.py
+++ b/qt/python/mantidqt/widgets/sliceviewer/test/test_sliceviewer_presenter.py
@@ -19,6 +19,7 @@ sys.modules['mantid.simpleapi'] = mock.MagicMock()  # noqa: E402
 import mantid.api
 from mantidqt.widgets.sliceviewer.model import SliceViewerModel, WS_TYPE
 from mantidqt.widgets.sliceviewer.presenter import (PeaksViewerCollectionPresenter, SliceViewer)
+from mantidqt.widgets.sliceviewer.transform import NonOrthogonalTransform
 from mantidqt.widgets.sliceviewer.toolbar import ToolItemText
 from mantidqt.widgets.sliceviewer.view import SliceViewerView, SliceViewerDataView
 
@@ -29,9 +30,12 @@ def _create_presenter(model, view, mock_sliceinfo_cls, enable_nonortho_axes, sup
     data_view_mock.plot_MDH = mock.Mock()
     presenter = SliceViewer(None, model=model, view=view)
     if enable_nonortho_axes:
+        data_view_mock.nonorthogonal_mode = True
+        data_view_mock.nonortho_transform = mock.MagicMock(NonOrthogonalTransform)
         presenter.nonorthogonal_axes(True)
     else:
         data_view_mock.nonorthogonal_mode = False
+        data_view_mock.nonortho_transform = None
 
     data_view_mock.disable_tool_button.reset_mock()
     data_view_mock.create_axes_orthogonal.reset_mock()
@@ -50,6 +54,10 @@ class SliceViewerTest(unittest.TestCase):
         data_view.dimensions = mock.Mock()
         data_view.norm_opts = mock.Mock()
         data_view.image_info_widget = mock.Mock()
+        data_view.nonorthogonal_mode = False
+        data_view.nonortho_transform = None
+        data_view.get_axes_limits.return_value = None
+
         dimensions = mock.Mock()
         dimensions.get_slicepoint.return_value = [None, None, 0.5]
         dimensions.transpose = False
@@ -165,12 +173,13 @@ class SliceViewerTest(unittest.TestCase):
         self.view.data_view.disable_tool_button.assert_not_called()
 
     def test_non_orthogonal_axes_toggled_on(self):
-        self.model.get_ws_type = mock.Mock(return_value=WS_TYPE.MATRIX)
+        self.model.get_ws_type = mock.Mock(return_value=WS_TYPE.MDE)
         data_view_mock = self.view.data_view
-        data_view_mock.plot_matrix = mock.Mock()
+        data_view_mock.plot_MDH = mock.Mock()
 
         presenter = SliceViewer(None, model=self.model, view=self.view)
-        data_view_mock.plot_matrix.reset_mock()  # clear initial plot call
+
+        data_view_mock.plot_MDH.reset_mock()  # clear initial plot call
         data_view_mock.create_axes_orthogonal.reset_mock()
         presenter.nonorthogonal_axes(True)
 
@@ -178,17 +187,20 @@ class SliceViewerTest(unittest.TestCase):
             ToolItemText.REGIONSELECTION)
         data_view_mock.create_axes_nonorthogonal.assert_called_once()
         data_view_mock.create_axes_orthogonal.assert_not_called()
-        data_view_mock.plot_matrix.assert_called_once()
-        data_view_mock.disable_tool_button.assert_has_calls(
-            (mock.call(ToolItemText.LINEPLOTS), mock.call(ToolItemText.OVERLAY_PEAKS)))
+        data_view_mock.plot_MDH.assert_called_once()
+        data_view_mock.disable_tool_button.assert_has_calls([mock.call(ToolItemText.LINEPLOTS)])
 
-    def test_non_orthogonal_axes_toggled_off(self):
-        self.model.get_ws_type = mock.Mock(return_value=WS_TYPE.MATRIX)
-        data_view_mock = self.view.data_view
-        data_view_mock.plot_matrix = mock.Mock()
-        presenter = SliceViewer(None, model=self.model, view=self.view)
-        presenter.nonorthogonal_axes(True)
-        data_view_mock.plot_matrix.reset_mock()  # clear initial plot call
+    @mock.patch("mantidqt.widgets.sliceviewer.presenter.SliceInfo")
+    def test_non_orthogonal_axes_toggled_off(self, mock_sliceinfo_cls):
+        self.model.get_ws_type = mock.Mock(return_value=WS_TYPE.MDE)
+        presenter, data_view_mock = _create_presenter(
+            self.model,
+            self.view,
+            mock_sliceinfo_cls,
+            enable_nonortho_axes=True,
+            supports_nonortho=True)
+
+        data_view_mock.plot_MDH.reset_mock()  # clear initial plot call
         data_view_mock.create_axes_orthogonal.reset_mock()
         data_view_mock.create_axes_nonorthogonal.reset_mock()
         data_view_mock.enable_tool_button.reset_mock()
@@ -199,10 +211,9 @@ class SliceViewerTest(unittest.TestCase):
 
         data_view_mock.create_axes_orthogonal.assert_called_once()
         data_view_mock.create_axes_nonorthogonal.assert_not_called()
-        data_view_mock.plot_matrix.assert_called_once()
+        data_view_mock.plot_MDH.assert_called_once()
         data_view_mock.enable_tool_button.assert_has_calls(
-            (mock.call(ToolItemText.LINEPLOTS), mock.call(ToolItemText.REGIONSELECTION),
-             mock.call(ToolItemText.OVERLAY_PEAKS)))
+            (mock.call(ToolItemText.LINEPLOTS), mock.call(ToolItemText.REGIONSELECTION)))
 
     def test_request_to_show_all_data_sets_correct_limits_on_view(self):
         presenter = SliceViewer(None, model=self.model, view=self.view)
@@ -238,11 +249,12 @@ class SliceViewerTest(unittest.TestCase):
     @mock.patch("mantidqt.widgets.sliceviewer.presenter.SliceInfo")
     def test_changing_dimensions_in_nonortho_mode_switches_to_ortho_when_dim_not_Q(
             self, mock_sliceinfo_cls):
-        presenter, data_view_mock = _create_presenter(self.model,
-                                                      self.view,
-                                                      mock_sliceinfo_cls,
-                                                      enable_nonortho_axes=True,
-                                                      supports_nonortho=False)
+        presenter, data_view_mock = _create_presenter(
+            self.model,
+            self.view,
+            mock_sliceinfo_cls,
+            enable_nonortho_axes=True,
+            supports_nonortho=False)
 
         presenter.dimensions_changed()
 
@@ -253,11 +265,12 @@ class SliceViewerTest(unittest.TestCase):
     @mock.patch("mantidqt.widgets.sliceviewer.presenter.SliceInfo")
     def test_changing_dimensions_in_nonortho_mode_keeps_nonortho_when_dim_is_Q(
             self, mock_sliceinfo_cls):
-        presenter, data_view_mock = _create_presenter(self.model,
-                                                      self.view,
-                                                      mock_sliceinfo_cls,
-                                                      enable_nonortho_axes=True,
-                                                      supports_nonortho=True)
+        presenter, data_view_mock = _create_presenter(
+            self.model,
+            self.view,
+            mock_sliceinfo_cls,
+            enable_nonortho_axes=True,
+            supports_nonortho=True)
 
         presenter.dimensions_changed()
 
@@ -268,11 +281,12 @@ class SliceViewerTest(unittest.TestCase):
     @mock.patch("mantidqt.widgets.sliceviewer.presenter.SliceInfo")
     def test_changing_dimensions_in_ortho_mode_disables_nonortho_btn_if_not_supported(
             self, mock_sliceinfo_cls):
-        presenter, data_view_mock = _create_presenter(self.model,
-                                                      self.view,
-                                                      mock_sliceinfo_cls,
-                                                      enable_nonortho_axes=False,
-                                                      supports_nonortho=False)
+        presenter, data_view_mock = _create_presenter(
+            self.model,
+            self.view,
+            mock_sliceinfo_cls,
+            enable_nonortho_axes=False,
+            supports_nonortho=False)
 
         presenter.dimensions_changed()
 
@@ -281,27 +295,33 @@ class SliceViewerTest(unittest.TestCase):
     @mock.patch("mantidqt.widgets.sliceviewer.presenter.SliceInfo")
     def test_changing_dimensions_in_ortho_mode_enables_nonortho_btn_if_supported(
             self, mock_sliceinfo_cls):
-        presenter, data_view_mock = _create_presenter(self.model,
-                                                      self.view,
-                                                      mock_sliceinfo_cls,
-                                                      enable_nonortho_axes=False,
-                                                      supports_nonortho=True)
+        presenter, data_view_mock = _create_presenter(
+            self.model,
+            self.view,
+            mock_sliceinfo_cls,
+            enable_nonortho_axes=False,
+            supports_nonortho=True)
 
         presenter.dimensions_changed()
 
         data_view_mock.enable_tool_button.assert_called_once_with(ToolItemText.NONORTHOGONAL_AXES)
 
     @mock.patch("mantidqt.widgets.sliceviewer.peaksviewer.presenter.TableWorkspaceDataPresenter")
-    @mock.patch("mantidqt.widgets.sliceviewer.presenter.PeaksViewerCollectionPresenter",
-                spec=PeaksViewerCollectionPresenter)
+    @mock.patch(
+        "mantidqt.widgets.sliceviewer.presenter.PeaksViewerCollectionPresenter",
+        spec=PeaksViewerCollectionPresenter)
     def test_overlay_peaks_workspaces_attaches_view_and_draws_peaks(self, mock_peaks_presenter, _):
-        presenter = SliceViewer(None, model=self.model, view=self.view)
+        for nonortho_axes in (False, True):
+            presenter, _ = _create_presenter(self.model, self.view, mock.MagicMock(), nonortho_axes,
+                                             nonortho_axes)
 
-        presenter.view.query_peaks_to_overlay.side_effect = ["peaks_workspace"]
-        presenter.overlay_peaks_workspaces()
-        presenter.view.query_peaks_to_overlay.assert_called_once()
-        mock_peaks_presenter.assert_called_once()
-        mock_peaks_presenter.overlay_peaksworkspaces.asssert_called_once()
+            presenter.view.query_peaks_to_overlay.side_effect = ["peaks_workspace"]
+            presenter.overlay_peaks_workspaces()
+            presenter.view.query_peaks_to_overlay.assert_called_once()
+            mock_peaks_presenter.assert_called_once()
+            mock_peaks_presenter.overlay_peaksworkspaces.asssert_called_once()
+            mock_peaks_presenter.reset_mock()
+            presenter.view.query_peaks_to_overlay.reset_mock()
 
     def test_gui_starts_with_zoom_selected(self):
         SliceViewer(None, model=self.model, view=self.view)

--- a/qt/python/mantidqt/widgets/sliceviewer/test/test_sliceviewer_sliceinfo.py
+++ b/qt/python/mantidqt/widgets/sliceviewer/test/test_sliceviewer_sliceinfo.py
@@ -19,11 +19,8 @@ class SliceInfoTest(unittest.TestCase):
     def test_construction_with_named_fields(self):
         frame, point, transpose, = SpecialCoordinateSystem.HKL, (None, None, 0.5), False
         dimrange, spatial = (None, None, (-15, 15)), [True] * 3
-        info = SliceInfo(frame=frame,
-                         point=point,
-                         transpose=transpose,
-                         range=dimrange,
-                         qflags=spatial)
+        info = SliceInfo(
+            frame=frame, point=point, transpose=transpose, range=dimrange, qflags=spatial)
 
         self.assertEqual(frame, info.frame)
         self.assertEqual(point, info.slicepoint)
@@ -35,44 +32,38 @@ class SliceInfoTest(unittest.TestCase):
     def test_no_spatial_dimensions_sets_z_properties_None(self):
         frame, point, transpose, = SpecialCoordinateSystem.HKL, (None, None, 0.5), False
         dimrange, spatial = (None, None, (-15, 15)), [False] * 3
-        info = SliceInfo(frame=frame,
-                         point=point,
-                         transpose=transpose,
-                         range=dimrange,
-                         qflags=spatial)
+        info = SliceInfo(
+            frame=frame, point=point, transpose=transpose, range=dimrange, qflags=spatial)
 
         self.assertTrue(info.z_index is None)
         self.assertTrue(info.z_value is None)
         self.assertTrue(info.z_width is None)
 
     def test_non_HKL_workspace_cannot_support_nonorthogonal_axes(self):
-        self._assert_can_support_nonorthogonal_axes(False,
-                                                    SpecialCoordinateSystem.QLab,
-                                                    qflags=[True] * 3)
+        self._assert_can_support_nonorthogonal_axes(
+            False, SpecialCoordinateSystem.QLab, qflags=[True] * 3)
 
     def test_HKL_workspace_with_one_slice_spatial_dimension_cannot_support_nonorthogonal_axes(self):
-        self._assert_can_support_nonorthogonal_axes(False,
-                                                    SpecialCoordinateSystem.HKL,
-                                                    qflags=[True, False, False])
+        self._assert_can_support_nonorthogonal_axes(
+            False, SpecialCoordinateSystem.HKL, qflags=[True, False, False])
 
     def test_HKL_workspace_with_no_slice_spatial_dimension_cannot_support_nonorthogonal_axes(self):
-        self._assert_can_support_nonorthogonal_axes(False,
-                                                    SpecialCoordinateSystem.HKL,
-                                                    qflags=[False] * 3)
+        self._assert_can_support_nonorthogonal_axes(
+            False, SpecialCoordinateSystem.HKL, qflags=[False] * 3)
 
     def test_HKL_workspace_with_two_slice_spatial_dimensions_can_support_nonorthogonal_axes(self):
-        self._assert_can_support_nonorthogonal_axes(True,
-                                                    SpecialCoordinateSystem.HKL,
-                                                    qflags=[True, True, False])
+        self._assert_can_support_nonorthogonal_axes(
+            True, SpecialCoordinateSystem.HKL, qflags=[True, True, False])
 
     def test_transform_selects_dimensions_correctly_when_not_transposed(self):
         # Set slice info such that display(X,Y) = data(Y,Z)
         slice_pt = 0.5
-        info = SliceInfo(frame=SpecialCoordinateSystem.HKL,
-                         point=(slice_pt, None, None),
-                         transpose=False,
-                         range=[(-15, 15), None, None],
-                         qflags=[True, True, True])
+        info = SliceInfo(
+            frame=SpecialCoordinateSystem.HKL,
+            point=(slice_pt, None, None),
+            transpose=False,
+            range=[(-15, 15), None, None],
+            qflags=[True, True, True])
 
         frame_point = (0.5, 1.0, -1.5)
         slice_frame = info.transform(frame_point)
@@ -85,11 +76,12 @@ class SliceInfoTest(unittest.TestCase):
     def test_transform_selects_dimensions_correctly_when_transposed(self):
         # Set slice info such that display(X,Y) = data(Z,Y)
         slice_pt = 0.5
-        info = SliceInfo(frame=SpecialCoordinateSystem.HKL,
-                         point=(slice_pt, None, None),
-                         transpose=True,
-                         range=[(-15, 15), None, None],
-                         qflags=[True, True, True])
+        info = SliceInfo(
+            frame=SpecialCoordinateSystem.HKL,
+            point=(slice_pt, None, None),
+            transpose=True,
+            range=[(-15, 15), None, None],
+            qflags=[True, True, True])
 
         frame_point = (0.5, 1.0, -1.5)
         slice_frame = info.transform(frame_point)
@@ -99,25 +91,45 @@ class SliceInfoTest(unittest.TestCase):
         self.assertEqual(frame_point[0], slice_frame[2])
         self.assertEqual(slice_pt, info.z_value)
 
+    def test_transform_respects_nonortho_tr_if_given(self):
+        # Set slice info such that display(X,Y) = data(Z,Y)
+
+        class FakeTransform:
+            def tr(self, x, y):
+                return x + 1, y - 1
+
+        info = SliceInfo(
+            frame=SpecialCoordinateSystem.HKL,
+            point=(None, None, 0.5),
+            transpose=False,
+            range=[None, None, (-15, 15)],
+            qflags=[True, True, True],
+            nonortho_transform=FakeTransform())
+
+        frame_point = (0.5, 1.0, -1.5)
+        slice_frame = info.transform(frame_point)
+
+        self.assertEqual(frame_point[0] + 1, slice_frame[0])
+        self.assertEqual(frame_point[1] - 1, slice_frame[1])
+        self.assertEqual(frame_point[2], slice_frame[2])
+
     def test_slicepoint_with_greater_than_three_qflags_true_raises_errors(self):
-        self.assertRaises(AssertionError,
-                          SliceInfo,
-                          frame=SpecialCoordinateSystem.HKL,
-                          point=(1, None, None, 4),
-                          transpose=True,
-                          range=[(-15, 15), None, None, (-5, -5)],
-                          qflags=(True, True, True, True))
+        self.assertRaises(
+            AssertionError,
+            SliceInfo,
+            frame=SpecialCoordinateSystem.HKL,
+            point=(1, None, None, 4),
+            transpose=True,
+            range=[(-15, 15), None, None, (-5, -5)],
+            qflags=(True, True, True, True))
 
     # private
     def _assert_can_support_nonorthogonal_axes(self, expectation, frame, qflags):
         frame, point, transpose, = frame, (None, None, 0.5), False
         dimrange, spatial = (None, None, (-15, 15)), qflags
 
-        info = SliceInfo(frame=frame,
-                         point=point,
-                         transpose=transpose,
-                         range=dimrange,
-                         qflags=spatial)
+        info = SliceInfo(
+            frame=frame, point=point, transpose=transpose, range=dimrange, qflags=spatial)
 
         self.assertEqual(expectation, info.can_support_nonorthogonal_axes())
 

--- a/qt/python/mantidqt/widgets/sliceviewer/view.py
+++ b/qt/python/mantidqt/widgets/sliceviewer/view.py
@@ -54,7 +54,7 @@ class SliceViewerDataView(QWidget):
         self.image = None
         self.line_plots_active = False
         self.can_normalise = can_normalise
-        self.nonortho_tr = None
+        self.nonortho_transform = None
         self.ws_type = dims_info[0]['type']
 
         self._line_plots = None
@@ -149,14 +149,14 @@ class SliceViewerDataView(QWidget):
 
     @property
     def nonorthogonal_mode(self):
-        return self.nonortho_tr is not None
+        return self.nonortho_transform is not None
 
     def create_axes_orthogonal(self, redraw_on_zoom=False):
         """Create a standard set of orthogonal axes
         :param redraw_on_zoom: If True then when scroll zooming the canvas is redrawn immediately
         """
         self.clear_figure()
-        self.nonortho_tr = None
+        self.nonortho_transform = None
         self.ax = self.fig.add_subplot(111, projection='mantid')
         self.enable_zoom_on_mouse_scroll(redraw_on_zoom)
         if self.grid_on:
@@ -171,12 +171,12 @@ class SliceViewerDataView(QWidget):
     def create_axes_nonorthogonal(self, transform):
         self.clear_figure()
         self.set_nonorthogonal_transform(transform)
-        self.ax = CurveLinearSubPlot(
-            self.fig,
-            1,
-            1,
-            1,
-            grid_helper=GridHelperCurveLinear((self.nonortho_tr, transform.inv_tr)))
+        self.ax = CurveLinearSubPlot(self.fig,
+                                     1,
+                                     1,
+                                     1,
+                                     grid_helper=GridHelperCurveLinear(
+                                         (transform.tr, transform.inv_tr)))
         # don't redraw on zoom as the data is rebinned and has to be redrawn again anyway
         self.enable_zoom_on_mouse_scroll(redraw=False)
         self.set_grid_on()
@@ -261,13 +261,12 @@ class SliceViewerDataView(QWidget):
 
     def plot_MDH_nonorthogonal(self, ws, **kwargs):
         self.clear_image()
-        self.image = pcolormesh_nonorthogonal(
-            self.ax,
-            ws,
-            self.nonortho_tr,
-            transpose=self.dimensions.transpose,
-            norm=self.colorbar.get_norm(),
-            **kwargs)
+        self.image = pcolormesh_nonorthogonal(self.ax,
+                                              ws,
+                                              self.nonortho_transform.tr,
+                                              transpose=self.dimensions.transpose,
+                                              norm=self.colorbar.get_norm(),
+                                              **kwargs)
         self.on_track_cursor_state_change(self.track_cursor.isChecked())
 
         # swapping dimensions in nonorthogonal mode currently resets back to the
@@ -349,7 +348,7 @@ class SliceViewerDataView(QWidget):
         This just updates the plot data without creating a new plot. The extents
         can change if the data has been rebinned.
         """
-        if self.nonortho_tr:
+        if self.nonortho_transform:
             self.image.set_array(data.T.ravel())
         else:
             self.image.set_data(data.T)
@@ -417,7 +416,7 @@ class SliceViewerDataView(QWidget):
 
     def get_axes_limits(self):
         """
-        Return the limits of the image axes or None if no image yet exists
+        Return the limits on the image axes in the orthogonal frame
         """
         if self.image is None:
             return None
@@ -426,7 +425,9 @@ class SliceViewerDataView(QWidget):
 
     def set_axes_limits(self, xlim, ylim):
         """
-        Set the view limits on the image axes to the given extents
+        Set the view limits on the image axes to the given extents. Assume the
+        limits are in the orthogonal frame.
+
         :param xlim: 2-tuple of (xmin, xmax)
         :param ylim: 2-tuple of (ymin, ymax)
         """
@@ -447,7 +448,7 @@ class SliceViewerDataView(QWidget):
         :param transform: An object with a tr method to transform from nonorthognal
                           coordinates to display coordinates
         """
-        self.nonortho_tr = transform.tr
+        self.nonortho_transform = transform
 
     def show_temporary_status_message(self, msg, timeout_ms):
         """
@@ -528,8 +529,7 @@ class SliceViewerView(QWidget):
     def peaks_view(self):
         """Lazily instantiates PeaksViewer and returns it"""
         if self._peaks_view is None:
-            self._peaks_view = PeaksViewerCollectionView(
-                MplPainter(self.data_view.ax), self.presenter)
+            self._peaks_view = PeaksViewerCollectionView(MplPainter(self.data_view), self.presenter)
             self._splitter.addWidget(self._peaks_view)
 
         return self._peaks_view
@@ -538,12 +538,6 @@ class SliceViewerView(QWidget):
         """Peaks overlay button has been toggled
         """
         self.presenter.overlay_peaks_workspaces()
-
-    def draw_peak(self, peak_info):
-        """
-        :param peak_info: A PeakRepresentation object
-        """
-        return peak_info.draw(self.ax)
 
     def query_peaks_to_overlay(self, current_overlayed_names):
         """Display a dialog to the user to ask which peaks to overlay


### PR DESCRIPTION
**Description of work.**

Adds support for peaks workspace overlays for non-orthogonal axes in the new slice viewer.

**To test:**

The following script creates a fake peak at a known HKL.

```python
# import mantid algorithms, numpy and matplotlib
from mantid.simpleapi import *
import matplotlib.pyplot as plt
import numpy as np

ws = CreateMDWorkspace(Dimensions='3', Extents='-5,5,-5,5,-5,5',
                       Names='H,K,L', Units='r.l.u.,r.l.u.,r.l.u.',
                       Frames='HKL,HKL,HKL',
                       SplitInto='2', SplitThreshold='50')
expt_info = CreateSampleWorkspace()
ws.addExperimentInfo(expt_info)
SetUB(ws, 1,1,2,90,90,120)
FakeMDEventData(ws, PeakParams='1e+06,0,1,0,0.5', RandomSeed='3873875')
peaks_ws = CreatePeaksWorkspace(ws, 1)
peaks_ws.getPeak(0).setHKL(0,1,0)
```

* Run the script
* Open the sliceviewer
* Click the non-orthogonal axes button
* Click the peaks overlay button
* The peak should be displayed at [0,1,0] on the Axes.

Play around with the UB, add more peaks and check clicking on the peaks zooms to them correctly.

Fixes #27464

*This does not require release notes* because **the sliceviewer release notes will be created separately.**

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
