### PR TITLE
28758 minimum height muon analysis gui

### DIFF
--- a/docs/source/release/v5.1.0/muon.rst
+++ b/docs/source/release/v5.1.0/muon.rst
@@ -53,5 +53,6 @@ Bug fixes
 - Fixed a bug that caused rebinned data to override non-binned data.
 - Fixed an issue where switching to simultaneous fit mode was occasionally throwing an exception.
 - Fixed an issue where loading additional data in simultaneous fit mode was throwing an exception.
+- Fixed an issue where mantid crashed when the muon analysis plotting window crashed was resized to be too small.
 
 :ref:`Release 5.1.0 <v5.1.0>`

--- a/scripts/Muon/GUI/Common/plot_widget/plot_widget_view.py
+++ b/scripts/Muon/GUI/Common/plot_widget/plot_widget_view.py
@@ -22,6 +22,7 @@ class PlotWidgetView(QtWidgets.QWidget, PlotWidgetViewInterface, ui_plotting_vie
     def __init__(self, parent=None):
         super().__init__(parent=parent)
         self.setupUi(self)
+        self.setMinimumSize(600,600)
 
     def setup_plot_type_options(self, options):
         """


### PR DESCRIPTION
**Description of work.**
Added minimum width and height to plotting window used in muon gui to prevent mantid from crashing.

Original reporter: Steve Cottrell

**To test:**

<!-- Instructions for testing. -->
1.Open the muon analysis gui
2.Unhook plotting window from muon analysis gui by clicking button just below close button on muon gui.
3.resize the plotting window as much as possible, plotting window should stop at a minimum size before crashing.

Fixes #28758 . 

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
