### PR TITLE
Simplify FitPropertyBrowser view in Eng Diff UI

### DIFF
--- a/docs/source/release/v5.1.0/diffraction.rst
+++ b/docs/source/release/v5.1.0/diffraction.rst
@@ -37,7 +37,7 @@ Engineering Diffraction
 New features
 ^^^^^^^^^^^^
 - New algorithm for estimating background of powder spectra :ref:`EnggEstimateFocussedBackground <algm-EnggEstimateFocussedBackground>` using iterative smoothing.
-- Mantid fitting capability added to fitting tab of Engineering Diffraction UI.
+- Mantid fitting capability added to fitting tab of Engineering Diffraction UI (with simpler fitpropertybrowser providing only relevant options).
 
 Improvements
 ^^^^^^^^^^^^

--- a/qt/python/mantidqt/_common.sip
+++ b/qt/python/mantidqt/_common.sip
@@ -453,6 +453,9 @@ public:
     void setWorkspaceIndex(int i);
     QStringList getWorkspaceNames();
     void fit();
+    void toggleSettingsBrowserVisible();
+    void removePropertiesFromSettingsBrowser(const QStringList &propsToRemove);
+    void toggleWsListVisible();
     void addAllowedSpectra(const QString &wsName, const QList<int> &wsIndices);
     void addAllowedTableWorkspace(const QString &wsName);
     void setTextPlotGuess(const QString);

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/FitPropertyBrowser.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/FitPropertyBrowser.h
@@ -664,11 +664,11 @@ private:
   /// Default background name
   std::string m_defaultBackground;
 
-  /// bool to display ws list or not
-  bool m_hideWsListWidget;
-
   /// Shows if the PeakPickerTool is on
   bool m_peakToolOn;
+
+  /// bool to display ws list or not
+  bool m_hideWsListWidget;
 
   /// If true background function will be included automatically
   bool m_auto_back;

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/FitPropertyBrowser.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/FitPropertyBrowser.h
@@ -321,6 +321,10 @@ public:
 
 public slots:
   virtual void fit();
+  virtual void toggleSettingsBrowserVisible();
+  virtual void
+  removePropertiesFromSettingsBrowser(const QStringList &propsToRemove);
+  virtual void toggleWsListVisible();
   virtual void sequentialFit();
   void undoFit();
   virtual void clear();
@@ -659,6 +663,9 @@ private:
   std::string m_defaultPeak;
   /// Default background name
   std::string m_defaultBackground;
+
+  /// bool to display ws list or not
+  bool m_hideWsListWidget;
 
   /// Shows if the PeakPickerTool is on
   bool m_peakToolOn;

--- a/qt/widgets/common/src/FitPropertyBrowser.cpp
+++ b/qt/widgets/common/src/FitPropertyBrowser.cpp
@@ -3301,10 +3301,8 @@ void FitPropertyBrowser::removePropertiesFromSettingsBrowser(
   // get settings properties
   QList<QtProperty *> props = m_settingsGroup->property()->subProperties();
   for (auto &prop : props) {
-    for (const auto &prop_name : propsToRemove) {
-      if (prop->propertyName() == prop_name) {
-        m_settingsGroup->property()->removeSubProperty(prop);
-      }
+    if (propsToRemove.contains(prop->propertyName())) {
+      m_settingsGroup->property()->removeSubProperty(prop);
     }
   }
 }

--- a/qt/widgets/common/src/FitPropertyBrowser.cpp
+++ b/qt/widgets/common/src/FitPropertyBrowser.cpp
@@ -569,7 +569,7 @@ void FitPropertyBrowser::addFitResultWorkspacesToTableWidget() {
   }
 
   auto noOfItems = m_wsListWidget->count();
-  if (noOfItems != 0 & !m_hideWsListWidget) {
+  if (noOfItems != 0 && !m_hideWsListWidget) {
     auto height = m_wsListWidget->sizeHintForRow(0) * (noOfItems + 1) +
                   2 * m_wsListWidget->frameWidth();
     m_wsListWidget->setMaximumHeight(height);

--- a/qt/widgets/common/src/FitPropertyBrowser.cpp
+++ b/qt/widgets/common/src/FitPropertyBrowser.cpp
@@ -101,7 +101,7 @@ FitPropertyBrowser::FitPropertyBrowser(QWidget *parent, QObject *mantidui)
       m_fitTree(nullptr), m_currentHandler(nullptr),
       m_defaultFunction("Gaussian"), m_defaultPeak("Gaussian"),
       m_defaultBackground("LinearBackground"), m_peakToolOn(false),
-      m_auto_back(false),
+      m_hideWsListWidget(false), m_auto_back(false),
       m_autoBgName(QString::fromStdString(
           Mantid::Kernel::ConfigService::Instance().getString(
               "curvefitting.autoBackground"))),
@@ -569,7 +569,7 @@ void FitPropertyBrowser::addFitResultWorkspacesToTableWidget() {
   }
 
   auto noOfItems = m_wsListWidget->count();
-  if (noOfItems != 0) {
+  if (noOfItems != 0 & !m_hideWsListWidget) {
     auto height = m_wsListWidget->sizeHintForRow(0) * (noOfItems + 1) +
                   2 * m_wsListWidget->frameWidth();
     m_wsListWidget->setMaximumHeight(height);
@@ -3185,18 +3185,20 @@ void FitPropertyBrowser::setWorkspaceProperties() {
   auto *settings =
       m_customSettingsGroup ? m_customSettingsGroup : m_settingsGroup;
 
-  settings->property()->removeSubProperty(m_evaluationType);
-  m_evaluationType->setEnabled(false);
-  // if it is a MatrixWorkspace insert WorkspaceIndex
-  auto mws = std::dynamic_pointer_cast<Mantid::API::MatrixWorkspace>(ws);
-  if (mws) {
-    addWorkspaceIndexToBrowser();
-    auto isHistogram = mws->isHistogramData();
-    m_evaluationType->setEnabled(isHistogram);
-    if (isHistogram) {
-      settings->property()->addSubProperty(m_evaluationType);
+  if (settings->property()->subProperties().contains(m_evaluationType)) {
+    settings->property()->removeSubProperty(m_evaluationType);
+    m_evaluationType->setEnabled(false);
+    // if it is a MatrixWorkspace insert WorkspaceIndex
+    auto mws = std::dynamic_pointer_cast<Mantid::API::MatrixWorkspace>(ws);
+    if (mws) {
+      addWorkspaceIndexToBrowser();
+      auto isHistogram = mws->isHistogramData();
+      m_evaluationType->setEnabled(isHistogram);
+      if (isHistogram) {
+        settings->property()->addSubProperty(m_evaluationType);
+      }
+      return;
     }
-    return;
   }
 
   // if it is a TableWorkspace insert the column properties
@@ -3277,6 +3279,38 @@ void FitPropertyBrowser::addWorkspaceIndexToBrowser() {
 void FitPropertyBrowser::fit() {
   int maxIterations = m_intManager->value(m_maxIterations);
   doFit(maxIterations);
+}
+
+/**
+ * Function to toggle the visibility of the settings browser
+ */
+void FitPropertyBrowser::toggleSettingsBrowserVisible() {
+  if (m_browser->isItemVisible(m_settingsGroup)) {
+    m_browser->setItemVisible(m_settingsGroup, false);
+  } else {
+    m_browser->setItemVisible(m_settingsGroup, true);
+  }
+}
+
+/**
+ * Function to toggle the visibility of a settings group property
+ * exposed to python
+ */
+void FitPropertyBrowser::removePropertiesFromSettingsBrowser(
+    const QStringList &propsToRemove) {
+  // get settings properties
+  QList<QtProperty *> props = m_settingsGroup->property()->subProperties();
+  for (auto &prop : props) {
+    for (const auto &prop_name : propsToRemove) {
+      if (prop->propertyName() == prop_name) {
+        m_settingsGroup->property()->removeSubProperty(prop);
+      }
+    }
+  }
+}
+
+void FitPropertyBrowser::toggleWsListVisible() {
+  m_hideWsListWidget = !m_hideWsListWidget;
 }
 
 /**=================================================================================================

--- a/scripts/Engineering/gui/engineering_diffraction/tabs/fitting/plotting/plot_view.py
+++ b/scripts/Engineering/gui/engineering_diffraction/tabs/fitting/plotting/plot_view.py
@@ -45,7 +45,13 @@ class FittingPlotView(QtWidgets.QWidget, Ui_plot):
         self.toolbar = FittingPlotToolbar(self.figure.canvas, self, False)
         self.vLayout_plot.addWidget(self.toolbar)
         self.vLayout_plot.addWidget(self.figure.canvas)
-        self.fit_browser = EngDiffFitPropertyBrowser(self.figure.canvas, ToolbarStateManager(self.toolbar)) # self.fitprop_toolbar
+        self.fit_browser = EngDiffFitPropertyBrowser(self.figure.canvas,
+                                                     ToolbarStateManager(self.toolbar))
+        hide_props = ['StartX', 'EndX', 'Minimizer', 'Cost function', 'Max Iterations', 'Output',
+                      'Ignore invalid data', 'Peak Radius', 'Plot Composite Members',
+                      'Convolve Composite Members', 'Show Parameter Errors', 'Evaluate Function As']
+        self.fit_browser.removePropertiesFromSettingsBrowser(hide_props)
+        self.fit_browser.toggleWsListVisible()
         self.fit_browser.closing.connect(self.toolbar.handle_fit_browser_close)
         self.vLayout_fitprop.addWidget(self.fit_browser)
         self.fit_browser.hide()


### PR DESCRIPTION
**Description of work.**

Simplified FitPropertyBroswer options in Eng Diff UI fitting tab - removing options that are not relevant from the setting browser and hiding the list of workspaces. To do this new C++ methods were made and exposed to python (see commit message). 

**To test:**

(1) Follow instructions 1-3 in PR #28895 (data is here [ENGINX_305761_bank_1.zip](https://github.com/mantidproject/mantid/files/5028525/ENGINX_305761_bank_1.zip))

(2) Compare this to the FitPropertyBrowser for a normal mantid figure - there should be fewer options and no list of workspaces (as in image below)
![image](https://user-images.githubusercontent.com/55979119/89313184-15e17600-d670-11ea-9453-4272f2516d6a.png)


Fixes #29100


---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
