### PR TITLE
28999 Fix extra newlines in SANS batch output

### DIFF
--- a/scripts/SANS/sans/command_interface/batch_csv_parser.py
+++ b/scripts/SANS/sans/command_interface/batch_csv_parser.py
@@ -69,7 +69,7 @@ class BatchCsvParser(object):
         for row in rows:
             to_write.append(self._convert_row_to_list(row))
 
-        with open(file_path, "w") as outfile:
+        with open(file_path, "w", newline="") as outfile:
             writer_handle = csv.writer(outfile)
             for line in to_write:
                 writer_handle.writerow(line)

--- a/scripts/test/SANS/command_interface/batch_csv_file_parser_test.py
+++ b/scripts/test/SANS/command_interface/batch_csv_file_parser_test.py
@@ -225,7 +225,7 @@ class BatchCsvParserTest(unittest.TestCase):
         with mock.patch(patchable, mocked_handle):
             parser.save_batch_file(rows=[], file_path=expected_file_path)
 
-        mocked_handle.assert_called_with(expected_file_path, "w")
+        mocked_handle.assert_called_with(expected_file_path, "w", newline="")
 
     def test_parses_row_to_csv_correctly(self):
         test_row = RowEntries()


### PR DESCRIPTION
**Description of work.**

So, `csv.writer` does intelligent, platform dependent handling of newlines.  On windows, this means correctly exporting "\r\n".  The basic python `open` then tramples all over this, assuming that the "\n" should be replaced with "\r\n", leading to "\r\r\n", which looks like two newlines in certain editors.  The official [docs](https://docs.python.org/3/library/csv.html#csv.writer) say that the file object should be opened with the option `newline=""` to prevent the file object from breaking csv's carefully crafted characters.

**Report to:** [smk77]

**To test:**

- On Windows, load the ISIS SANS Interface
- Populate the table with at least two rows
- Click the export button
- Confirm that the file lines end in "\r\n" and not "\r\r\n"

<!-- Instructions for testing. -->

Fixes #28999 .

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
-->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
