### PR TITLE
EnggDiff Plot set checkboxes checked by default

### DIFF
--- a/scripts/Engineering/gui/engineering_diffraction/tabs/calibration/calibration_tab.ui
+++ b/scripts/Engineering/gui/engineering_diffraction/tabs/calibration/calibration_tab.ui
@@ -175,6 +175,9 @@ QGroupBox:title {
             <property name="enabled">
              <bool>true</bool>
             </property>
+		    <property name="checked">
+             <bool>true</bool>
+            </property>
             <property name="text">
              <string>Plot Calibrated Workspace</string>
             </property>

--- a/scripts/Engineering/gui/engineering_diffraction/tabs/focus/focus_tab.ui
+++ b/scripts/Engineering/gui/engineering_diffraction/tabs/focus/focus_tab.ui
@@ -98,7 +98,7 @@ QGroupBox:title {
           </item>
           <item row="6" column="2">
            <widget class="QPushButton" name="button_focus">
-            <property name="enabled">
+		    <property name="enabled">
              <bool>true</bool>
             </property>
             <property name="text">
@@ -132,6 +132,9 @@ QGroupBox:title {
           <item row="6" column="0" colspan="2">
            <widget class="QCheckBox" name="check_plotOutput">
             <property name="enabled">
+             <bool>true</bool>
+            </property>
+		    <property name="checked">
              <bool>true</bool>
             </property>
             <property name="text">


### PR DESCRIPTION
**Description of work.**
In the focus and calibration tabs of the Engineering Diffraction UI, set the plotting checkboxes to be enabled by default.

**Report to:** Richard Waite

**To test:**

Open EngDiff Ui and confirm checkboxes are enabled by default

Fixes #29098 . <!-- and fix #xxxx or close #xxxx xor resolves #xxxx -->
<!-- alternative
*There is no associated issue.*
-->


*This does not require release notes* because **it is a very minor GUI ease of use change**


---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
