### PR TITLE
#26773 Disabled other tabs on muon guis while other process run

### DIFF
--- a/docs/source/release/v5.1.0/muon.rst
+++ b/docs/source/release/v5.1.0/muon.rst
@@ -64,6 +64,8 @@ Bug fixes
 - Fixed an issue with setting the current workspace before adding a function.
 - Fixed an issue with the results tab not updating correctly after multiple fits with different functions.
 - Fixed an issue where gui was not properly disabling during calculations.
+- Fixed an issue where Muon Analysis and Frequency Domain Analysis gui was not properly disabling during calculations.
+
 
 Elemental Analysis 
 ##################

--- a/docs/source/release/v5.1.0/muon.rst
+++ b/docs/source/release/v5.1.0/muon.rst
@@ -63,7 +63,6 @@ Bug fixes
 - Fixed an issue where mantid crashed when the muon analysis plotting window crashed was resized to be too small.
 - Fixed an issue with setting the current workspace before adding a function.
 - Fixed an issue with the results tab not updating correctly after multiple fits with different functions.
-- Fixed an issue where gui was not properly disabling during calculations.
 - Fixed an issue where Muon Analysis and Frequency Domain Analysis gui was not properly disabling during calculations.
 
 

--- a/docs/source/release/v5.1.0/muon.rst
+++ b/docs/source/release/v5.1.0/muon.rst
@@ -63,6 +63,7 @@ Bug fixes
 - Fixed an issue where mantid crashed when the muon analysis plotting window crashed was resized to be too small.
 - Fixed an issue with setting the current workspace before adding a function.
 - Fixed an issue with the results tab not updating correctly after multiple fits with different functions.
+- Fixed an issue where gui was not properly disabling during calculations.
 
 Elemental Analysis 
 ##################
@@ -71,5 +72,6 @@ New Features
 ------------
 - Added a deselect all elements button.
 - Fixed an issue where groups were all being plotted on the same tiled plot.
+
 
 :ref:`Release 5.1.0 <v5.1.0>`

--- a/scripts/Muon/GUI/Common/fitting_tab_widget/fitting_tab_presenter.py
+++ b/scripts/Muon/GUI/Common/fitting_tab_widget/fitting_tab_presenter.py
@@ -75,9 +75,6 @@ class FittingTabPresenter(object):
         if self.selected_data:
             self.view.setEnabled(True)
 
-
-
-
     @property
     def selected_data(self):
         return self._selected_data

--- a/scripts/Muon/GUI/Common/fitting_tab_widget/fitting_tab_presenter.py
+++ b/scripts/Muon/GUI/Common/fitting_tab_widget/fitting_tab_presenter.py
@@ -65,12 +65,18 @@ class FittingTabPresenter(object):
 
         self.view.setEnabled(False)
 
+        self.enable_editing_notifier = GenericObservable()
+        self.disable_editing_notifier = GenericObservable()
+
     def disable_view(self):
         self.view.setEnabled(False)
 
     def enable_view(self):
         if self.selected_data:
             self.view.setEnabled(True)
+
+
+
 
     @property
     def selected_data(self):
@@ -180,14 +186,14 @@ class FittingTabPresenter(object):
         self.perform_fit()
 
     def handle_started(self):
-        self.view.setEnabled(False)
+        self.disable_editing_notifier.notify_subscribers()
         self.thread_success = True
 
     def handle_finished(self):
+        self.enable_editing_notifier.notify_subscribers()
         if not self.thread_success:
             return
 
-        self.view.setEnabled(True)
         fit_function, fit_status, fit_chi_squared = self.fitting_calculation_model.result
         if any([not fit_function, not fit_status, not fit_chi_squared]):
             return
@@ -212,9 +218,9 @@ class FittingTabPresenter(object):
         self.fit_parameter_changed_notifier.notify_subscribers()
 
     def handle_error(self, error):
+        self.enable_editing_notifier.notify_subscribers()
         self.thread_success = False
         self.view.warning_popup(error)
-        self.view.setEnabled(True)
 
     def handle_start_x_updated(self):
         value = self.view.start_time

--- a/scripts/Muon/GUI/Common/grouping_tab_widget/grouping_tab_widget_presenter.py
+++ b/scripts/Muon/GUI/Common/grouping_tab_widget/grouping_tab_widget_presenter.py
@@ -4,7 +4,7 @@
 #   NScD Oak Ridge National Laboratory, European Spallation Source,
 #   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
 # SPDX - License - Identifier: GPL - 3.0 +
-from mantidqt.utils.observer_pattern import Observer, Observable, GenericObservable, GenericObserver
+from mantidqt.utils.observer_pattern import Observer, Observable, GenericObservable,GenericObserver
 import Muon.GUI.Common.utilities.muon_file_utils as file_utils
 import Muon.GUI.Common.utilities.xml_utils as xml_utils
 import Muon.GUI.Common.utilities.algorithm_utils as algorithm_utils
@@ -66,6 +66,9 @@ class GroupingTabPresenter(object):
         self.gui_variables_observer = GroupingTabPresenter.GuiVariablesChangedObserver(self)
         self.enable_observer = GroupingTabPresenter.EnableObserver(self)
         self.disable_observer = GroupingTabPresenter.DisableObserver(self)
+
+        self.disable_tab_observer = GenericObserver(self.disable_editing_without_notifying_subscribers)
+        self.enable_tab_observer = GenericObserver(self.enable_editing_without_notifying_subscribers)
 
         self.update_view_from_model_observer = GenericObserver(self.update_view_from_model)
 
@@ -173,6 +176,16 @@ class GroupingTabPresenter(object):
         self.grouping_table_widget.enable_editing()
         self.pairing_table_widget.enable_editing()
         self.enable_editing_notifier.notify_subscribers()
+
+    def disable_editing_without_notifying_subscribers(self):
+        self._view.set_buttons_enabled(False)
+        self.grouping_table_widget.disable_editing()
+        self.pairing_table_widget.disable_editing()
+
+    def enable_editing_without_notifying_subscribers(self):
+        self._view.set_buttons_enabled(True)
+        self.grouping_table_widget.enable_editing()
+        self.pairing_table_widget.enable_editing()
 
     def calculate_all_data(self):
         self._model.show_all_groups_and_pairs()

--- a/scripts/Muon/GUI/Common/grouping_tab_widget/grouping_tab_widget_presenter.py
+++ b/scripts/Muon/GUI/Common/grouping_tab_widget/grouping_tab_widget_presenter.py
@@ -185,7 +185,7 @@ class GroupingTabPresenter(object):
         self.update_thread.start()
 
     def error_callback(self, error_message):
-        self.enable_editing_notifier.notify_subscribers()
+        self.enable_editing()
         self._view.display_warning_box(error_message)
 
     def handle_update_finished(self):

--- a/scripts/Muon/GUI/Common/phase_table_widget/phase_table_presenter.py
+++ b/scripts/Muon/GUI/Common/phase_table_widget/phase_table_presenter.py
@@ -7,22 +7,13 @@
 from Muon.GUI.Common.thread_model_wrapper import ThreadModelWrapper
 from Muon.GUI.Common import thread_model
 from Muon.GUI.Common.utilities.algorithm_utils import run_CalMuonDetectorPhases, run_PhaseQuad
-from mantidqt.utils.observer_pattern import Observer, Observable
+from mantidqt.utils.observer_pattern import Observable,GenericObserver
 import re
 from Muon.GUI.Common.ADSHandler.workspace_naming import get_phase_table_workspace_name, \
     get_phase_table_workspace_group_name, \
     get_phase_quad_workspace_name, get_fitting_workspace_name, get_base_data_directory
 from Muon.GUI.Common.ADSHandler.muon_workspace_wrapper import MuonWorkspaceWrapper
 import mantid
-
-
-class GenericObserver(Observer):
-    def __init__(self, callback):
-        Observer.__init__(self)
-        self.callback = callback
-
-    def update(self, observable, arg):
-        self.callback()
 
 
 class PhaseTablePresenter(object):
@@ -37,6 +28,9 @@ class PhaseTablePresenter(object):
 
         self.phase_table_calculation_complete_notifier = Observable()
         self.phase_quad_calculation_complete_nofifier = Observable()
+
+        self.disable_tab_observer = GenericObserver(lambda: self.view.setEnabled(False))
+        self.enable_tab_observer = GenericObserver(lambda: self.view.setEnabled(True))
 
         self.update_view_from_model_observer = GenericObserver(self.update_view_from_model)
 

--- a/scripts/Muon/GUI/Common/results_tab_widget/results_tab_presenter.py
+++ b/scripts/Muon/GUI/Common/results_tab_widget/results_tab_presenter.py
@@ -25,6 +25,11 @@ class ResultsTabPresenter(QObject):
 
         self._init_view()
 
+        self.disable_tab_observer = GenericObserver(lambda: self.view.
+                                                    setEnabled(False))
+        self.enable_tab_observer = GenericObserver(lambda: self.view.
+                                                   setEnabled(True))
+
     # callbacks
     def on_results_table_name_edited(self):
         """React to the results table name being edited"""

--- a/scripts/Muon/GUI/Common/seq_fitting_tab_widget/seq_fitting_tab_presenter.py
+++ b/scripts/Muon/GUI/Common/seq_fitting_tab_widget/seq_fitting_tab_presenter.py
@@ -31,6 +31,10 @@ class SeqFittingTabPresenter(object):
         self.fit_parameter_updated_observer = GenericObserver(self.handle_fit_function_parameter_changed)
         self.fit_parameter_changed_in_view = GenericObserverWithArgPassing(self.handle_updated_fit_parameter_in_table)
         self.selected_sequential_fit_notifier = GenericObservable()
+        self.disable_tab_observer = GenericObserver(lambda: self.view.
+                                                    setEnabled(False))
+        self.enable_tab_observer = GenericObserver(lambda: self.view.
+                                                   setEnabled(True))
 
     def create_thread(self, callback):
         self.fitting_calculation_model = ThreadModelWrapperWithOutput(callback)

--- a/scripts/Muon/GUI/FrequencyDomainAnalysis/frequency_domain_analysis_2.py
+++ b/scripts/Muon/GUI/FrequencyDomainAnalysis/frequency_domain_analysis_2.py
@@ -131,13 +131,11 @@ class FrequencyAnalysisGui(QtWidgets.QMainWindow):
         self.disable_observer = GenericObserver(self.disable_notifier.notify_subscribers)
         self.enable_notifier = GenericObservable()
         self.enable_observer = GenericObserver(self.enable_notifier.notify_subscribers)
+        self.setup_disable_notifier()
+        self.setup_enable_notifier()
 
         self.setCentralWidget(central_widget)
         self.setWindowTitle(self.context.window_title)
-
-        self.setup_disable_notifier()
-
-        self.setup_enable_notifier()
 
         self.setup_load_observers()
 

--- a/scripts/Muon/GUI/FrequencyDomainAnalysis/frequency_domain_analysis_2.py
+++ b/scripts/Muon/GUI/FrequencyDomainAnalysis/frequency_domain_analysis_2.py
@@ -276,6 +276,15 @@ class FrequencyAnalysisGui(QtWidgets.QMainWindow):
         self.grouping_tab_widget.group_tab_presenter.enable_editing_notifier.add_subscriber(
             self.fitting_tab.fitting_tab_presenter.enable_tab_observer)
 
+        self.grouping_tab_widget.group_tab_presenter.enable_editing_notifier.add_subscriber(
+            self.phase_tab.phase_table_presenter.enable_tab_observer)
+
+        self.grouping_tab_widget.group_tab_presenter.enable_editing_notifier.add_subscriber(
+            self.results_tab.results_tab_presenter.enable_tab_observer)
+
+        self.grouping_tab_widget.group_tab_presenter.enable_editing_notifier.add_subscriber(
+            self.transform.enable_observer)
+
     def setup_group_calculation_disabler_notifier(self):
         self.grouping_tab_widget.group_tab_presenter.disable_editing_notifier.add_subscriber(
             self.home_tab.home_tab_widget.disable_observer)
@@ -285,6 +294,15 @@ class FrequencyAnalysisGui(QtWidgets.QMainWindow):
 
         self.grouping_tab_widget.group_tab_presenter.disable_editing_notifier.add_subscriber(
             self.fitting_tab.fitting_tab_presenter.disable_tab_observer)
+
+        self.grouping_tab_widget.group_tab_presenter.disable_editing_notifier.add_subscriber(
+            self.phase_tab.phase_table_presenter.disable_tab_observer)
+
+        self.grouping_tab_widget.group_tab_presenter.disable_editing_notifier.add_subscriber(
+            self.results_tab.results_tab_presenter.disable_tab_observer)
+
+        self.grouping_tab_widget.group_tab_presenter.disable_editing_notifier.add_subscriber(
+            self.transform.disable_observer)
 
     def setup_on_load_enabler(self):
         self.load_widget.load_widget.load_run_widget.enable_notifier.add_subscriber(

--- a/scripts/Muon/GUI/FrequencyDomainAnalysis/frequency_domain_analysis_2.py
+++ b/scripts/Muon/GUI/FrequencyDomainAnalysis/frequency_domain_analysis_2.py
@@ -217,7 +217,9 @@ class FrequencyAnalysisGui(QtWidgets.QMainWindow):
 
         self.disable_notifier.add_subscriber(self.results_tab.results_tab_presenter.disable_tab_observer)
 
-        self.disable_notifier.add_subscriber(self.transform.enable_observer)
+        self.disable_notifier.add_subscriber(self.transform.disable_observer)
+
+        self.disable_notifier.add_subscriber(self.grouping_tab_widget.group_tab_presenter.disable_tab_observer)
 
     def setup_enable_notifier(self):
 
@@ -232,6 +234,8 @@ class FrequencyAnalysisGui(QtWidgets.QMainWindow):
         self.enable_notifier.add_subscriber(self.results_tab.results_tab_presenter.enable_tab_observer)
 
         self.enable_notifier.add_subscriber(self.transform.enable_observer)
+
+        self.enable_notifier.add_subscriber(self.grouping_tab_widget.group_tab_presenter.enable_tab_observer)
 
     def setup_load_observers(self):
         self.load_widget.load_widget.loadNotifier.add_subscriber(
@@ -308,11 +312,17 @@ class FrequencyAnalysisGui(QtWidgets.QMainWindow):
         self.fitting_tab.fitting_tab_presenter.enable_editing_notifier.add_subscriber(
             self.enable_observer)
 
+        self.phase_tab.phase_table_presenter.enable_editing_notifier.add_subscriber(
+            self.enable_observer)
+
     def setup_group_calculation_disabler_notifier(self):
         self.grouping_tab_widget.group_tab_presenter.disable_editing_notifier.add_subscriber(
             self.disable_observer)
 
         self.fitting_tab.fitting_tab_presenter.disable_editing_notifier.add_subscriber(
+            self.disable_observer)
+
+        self.phase_tab.phase_table_presenter.disable_editing_notifier.add_subscriber(
             self.disable_observer)
 
     def setup_on_load_enabler(self):

--- a/scripts/Muon/GUI/FrequencyDomainAnalysis/frequency_domain_analysis_2.py
+++ b/scripts/Muon/GUI/FrequencyDomainAnalysis/frequency_domain_analysis_2.py
@@ -33,7 +33,7 @@ from Muon.GUI.Common.results_tab_widget.results_tab_widget import ResultsTabWidg
 from Muon.GUI.Common.fitting_tab_widget.fitting_tab_widget import FittingTabWidget
 from Muon.GUI.Common.plot_widget.plot_widget import PlotWidget
 from Muon.GUI.Common.plotting_dock_widget.plotting_dock_widget import PlottingDockWidget
-from mantidqt.utils.observer_pattern import GenericObserver, GenericObserverWithArgPassing
+from mantidqt.utils.observer_pattern import GenericObserver, GenericObserverWithArgPassing,GenericObservable
 
 SUPPORTED_FACILITIES = ["ISIS", "SmuS"]
 TAB_ORDER = ["Home", "Grouping", "Phase Table", "Transform", "Fitting", "Sequential Fitting", "Results"]
@@ -127,8 +127,17 @@ class FrequencyAnalysisGui(QtWidgets.QMainWindow):
         vertical_layout.addWidget(self.help_widget.view)
         central_widget.setLayout(vertical_layout)
 
+        self.disable_notifier = GenericObservable()
+        self.disable_observer = GenericObserver(self.disable_notifier.notify_subscribers)
+        self.enable_notifier = GenericObservable()
+        self.enable_observer = GenericObserver(self.enable_notifier.notify_subscribers)
+
         self.setCentralWidget(central_widget)
         self.setWindowTitle(self.context.window_title)
+
+        self.setup_disable_notifier()
+
+        self.setup_enable_notifier()
 
         self.setup_load_observers()
 
@@ -197,6 +206,34 @@ class FrequencyAnalysisGui(QtWidgets.QMainWindow):
         self.fitting_tab.fitting_tab_presenter.handle_new_data_loaded()
         self.fitting_tab.fitting_tab_presenter.set_display_workspace(new_data_workspace_name)
         self.plot_widget.presenter.update_plot(autoscale=True)
+
+    def setup_disable_notifier(self):
+
+        self.disable_notifier.add_subscriber(self.home_tab.home_tab_widget.disable_observer)
+
+        self.disable_notifier.add_subscriber(self.load_widget.load_widget.disable_observer)
+
+        self.disable_notifier.add_subscriber(self.fitting_tab.fitting_tab_presenter.disable_tab_observer)
+
+        self.disable_notifier.add_subscriber(self.phase_tab.phase_table_presenter.disable_tab_observer)
+
+        self.disable_notifier.add_subscriber(self.results_tab.results_tab_presenter.disable_tab_observer)
+
+        self.disable_notifier.add_subscriber(self.transform.enable_observer)
+
+    def setup_enable_notifier(self):
+
+        self.enable_notifier.add_subscriber(self.home_tab.home_tab_widget.enable_observer)
+
+        self.enable_notifier.add_subscriber(self.load_widget.load_widget.enable_observer)
+
+        self.enable_notifier.add_subscriber(self.fitting_tab.fitting_tab_presenter.enable_tab_observer)
+
+        self.enable_notifier.add_subscriber(self.phase_tab.phase_table_presenter.enable_tab_observer)
+
+        self.enable_notifier.add_subscriber(self.results_tab.results_tab_presenter.enable_tab_observer)
+
+        self.enable_notifier.add_subscriber(self.transform.enable_observer)
 
     def setup_load_observers(self):
         self.load_widget.load_widget.loadNotifier.add_subscriber(
@@ -268,41 +305,17 @@ class FrequencyAnalysisGui(QtWidgets.QMainWindow):
 
     def setup_group_calculation_enable_notifier(self):
         self.grouping_tab_widget.group_tab_presenter.enable_editing_notifier.add_subscriber(
-            self.home_tab.home_tab_widget.enable_observer)
+            self.enable_observer)
 
-        self.grouping_tab_widget.group_tab_presenter.enable_editing_notifier.add_subscriber(
-            self.load_widget.load_widget.enable_observer)
-
-        self.grouping_tab_widget.group_tab_presenter.enable_editing_notifier.add_subscriber(
-            self.fitting_tab.fitting_tab_presenter.enable_tab_observer)
-
-        self.grouping_tab_widget.group_tab_presenter.enable_editing_notifier.add_subscriber(
-            self.phase_tab.phase_table_presenter.enable_tab_observer)
-
-        self.grouping_tab_widget.group_tab_presenter.enable_editing_notifier.add_subscriber(
-            self.results_tab.results_tab_presenter.enable_tab_observer)
-
-        self.grouping_tab_widget.group_tab_presenter.enable_editing_notifier.add_subscriber(
-            self.transform.enable_observer)
+        self.fitting_tab.fitting_tab_presenter.enable_editing_notifier.add_subscriber(
+            self.enable_observer)
 
     def setup_group_calculation_disabler_notifier(self):
         self.grouping_tab_widget.group_tab_presenter.disable_editing_notifier.add_subscriber(
-            self.home_tab.home_tab_widget.disable_observer)
+            self.disable_observer)
 
-        self.grouping_tab_widget.group_tab_presenter.disable_editing_notifier.add_subscriber(
-            self.load_widget.load_widget.disable_observer)
-
-        self.grouping_tab_widget.group_tab_presenter.disable_editing_notifier.add_subscriber(
-            self.fitting_tab.fitting_tab_presenter.disable_tab_observer)
-
-        self.grouping_tab_widget.group_tab_presenter.disable_editing_notifier.add_subscriber(
-            self.phase_tab.phase_table_presenter.disable_tab_observer)
-
-        self.grouping_tab_widget.group_tab_presenter.disable_editing_notifier.add_subscriber(
-            self.results_tab.results_tab_presenter.disable_tab_observer)
-
-        self.grouping_tab_widget.group_tab_presenter.disable_editing_notifier.add_subscriber(
-            self.transform.disable_observer)
+        self.fitting_tab.fitting_tab_presenter.disable_editing_notifier.add_subscriber(
+            self.disable_observer)
 
     def setup_on_load_enabler(self):
         self.load_widget.load_widget.load_run_widget.enable_notifier.add_subscriber(

--- a/scripts/Muon/GUI/MuonAnalysis/muon_analysis_2.py
+++ b/scripts/Muon/GUI/MuonAnalysis/muon_analysis_2.py
@@ -262,6 +262,15 @@ class MuonAnalysisGui(QtWidgets.QMainWindow):
         self.grouping_tab_widget.group_tab_presenter.enable_editing_notifier.add_subscriber(
             self.fitting_tab.fitting_tab_presenter.enable_tab_observer)
 
+        self.grouping_tab_widget.group_tab_presenter.enable_editing_notifier.add_subscriber(
+            self.phase_tab.phase_table_presenter.enable_tab_observer)
+
+        self.grouping_tab_widget.group_tab_presenter.enable_editing_notifier.add_subscriber(
+            self.results_tab.results_tab_presenter.enable_tab_observer)
+
+        self.grouping_tab_widget.group_tab_presenter.enable_editing_notifier.add_subscriber(
+            self.seq_fitting_tab.seq_fitting_tab_presenter.enable_tab_observer)
+
     def setup_group_calculation_disabler_notifier(self):
         self.grouping_tab_widget.group_tab_presenter.disable_editing_notifier.add_subscriber(
             self.home_tab.home_tab_widget.disable_observer)
@@ -271,6 +280,15 @@ class MuonAnalysisGui(QtWidgets.QMainWindow):
 
         self.grouping_tab_widget.group_tab_presenter.disable_editing_notifier.add_subscriber(
             self.fitting_tab.fitting_tab_presenter.disable_tab_observer)
+
+        self.grouping_tab_widget.group_tab_presenter.disable_editing_notifier.add_subscriber(
+            self.phase_tab.phase_table_presenter.disable_tab_observer)
+
+        self.grouping_tab_widget.group_tab_presenter.disable_editing_notifier.add_subscriber(
+            self.results_tab.results_tab_presenter.disable_tab_observer)
+
+        self.grouping_tab_widget.group_tab_presenter.disable_editing_notifier.add_subscriber(
+            self.seq_fitting_tab.seq_fitting_tab_presenter.disable_tab_observer)
 
     def setup_on_load_enabler(self):
         self.load_widget.load_widget.load_run_widget.enable_notifier.add_subscriber(
@@ -300,8 +318,7 @@ class MuonAnalysisGui(QtWidgets.QMainWindow):
             self.seq_fitting_tab.seq_fitting_tab_presenter.selected_workspaces_observer)
 
         self.grouping_tab_widget.group_tab_presenter.calculation_finished_notifier.add_subscriber(
-            self.update_plot_observer
-        )
+            self.update_plot_observer )
 
     def setup_phase_quad_changed_notifier(self):
         pass

--- a/scripts/Muon/GUI/MuonAnalysis/muon_analysis_2.py
+++ b/scripts/Muon/GUI/MuonAnalysis/muon_analysis_2.py
@@ -29,7 +29,7 @@ from Muon.GUI.Common.phase_table_widget.phase_table_widget import PhaseTabWidget
 from Muon.GUI.Common.results_tab_widget.results_tab_widget import ResultsTabWidget
 from Muon.GUI.Common.plot_widget.plot_widget import PlotWidget
 from Muon.GUI.Common.plotting_dock_widget.plotting_dock_widget import PlottingDockWidget
-from mantidqt.utils.observer_pattern import GenericObserver
+from mantidqt.utils.observer_pattern import GenericObserver,GenericObservable
 
 
 SUPPORTED_FACILITIES = ["ISIS", "SmuS"]
@@ -100,6 +100,11 @@ class MuonAnalysisGui(QtWidgets.QMainWindow):
         if QT_VERSION >= LooseVersion("5.6"):
             self.resizeDocks({self.dockable_plot_widget_window}, {0}, QtCore.Qt.Horizontal)
 
+        self.disable_notifier = GenericObservable()
+        self.disable_observer = GenericObserver(self.disable_notifier.notify_subscribers)
+        self.enable_notifier = GenericObservable()
+        self.enable_observer = GenericObserver(self.enable_notifier.notify_subscribers)
+
         # set up other widgets
         self.load_widget = LoadWidget(self.loaded_data, self.context, self)
         self.home_tab = HomeTabWidget(self.context, self)
@@ -148,6 +153,10 @@ class MuonAnalysisGui(QtWidgets.QMainWindow):
         self.context.data_context.message_notifier.add_subscriber(
             self.grouping_tab_widget.group_tab_presenter.message_observer)
 
+        self.setup_disable_notifier()
+
+        self.setup_enable_notifier()
+
     def setup_tabs(self):
         """
         Set up the tabbing structure; the tabs work similarly to conventional
@@ -175,6 +184,34 @@ class MuonAnalysisGui(QtWidgets.QMainWindow):
             return
 
         self.plot_widget.presenter.handle_plot_mode_changed(plot_mode)
+
+    def setup_disable_notifier(self):
+
+        self.disable_notifier.add_subscriber(self.home_tab.home_tab_widget.disable_observer)
+
+        self.disable_notifier.add_subscriber(self.load_widget.load_widget.disable_observer)
+
+        self.disable_notifier.add_subscriber(self.fitting_tab.fitting_tab_presenter.disable_tab_observer)
+
+        self.disable_notifier.add_subscriber(self.phase_tab.phase_table_presenter.disable_tab_observer)
+
+        self.disable_notifier.add_subscriber(self.results_tab.results_tab_presenter.disable_tab_observer)
+
+        self.disable_notifier.add_subscriber(self.seq_fitting_tab.seq_fitting_tab_presenter.disable_tab_observer)
+
+    def setup_enable_notifier(self):
+
+        self.enable_notifier.add_subscriber(self.home_tab.home_tab_widget.enable_observer)
+
+        self.enable_notifier.add_subscriber(self.load_widget.load_widget.enable_observer)
+
+        self.enable_notifier.add_subscriber(self.fitting_tab.fitting_tab_presenter.enable_tab_observer)
+
+        self.enable_notifier.add_subscriber(self.phase_tab.phase_table_presenter.enable_tab_observer)
+
+        self.enable_notifier.add_subscriber(self.results_tab.results_tab_presenter.enable_tab_observer)
+
+        self.enable_notifier.add_subscriber(self.seq_fitting_tab.seq_fitting_tab_presenter.enable_tab_observer)
 
     def setup_load_observers(self):
         self.load_widget.load_widget.loadNotifier.add_subscriber(
@@ -253,42 +290,20 @@ class MuonAnalysisGui(QtWidgets.QMainWindow):
             self.plot_widget.presenter.instrument_observer)
 
     def setup_group_calculation_enable_notifier(self):
-        self.grouping_tab_widget.group_tab_presenter.enable_editing_notifier.add_subscriber(
-            self.home_tab.home_tab_widget.enable_observer)
 
         self.grouping_tab_widget.group_tab_presenter.enable_editing_notifier.add_subscriber(
-            self.load_widget.load_widget.enable_observer)
+              self.enable_observer)
 
-        self.grouping_tab_widget.group_tab_presenter.enable_editing_notifier.add_subscriber(
-            self.fitting_tab.fitting_tab_presenter.enable_tab_observer)
-
-        self.grouping_tab_widget.group_tab_presenter.enable_editing_notifier.add_subscriber(
-            self.phase_tab.phase_table_presenter.enable_tab_observer)
-
-        self.grouping_tab_widget.group_tab_presenter.enable_editing_notifier.add_subscriber(
-            self.results_tab.results_tab_presenter.enable_tab_observer)
-
-        self.grouping_tab_widget.group_tab_presenter.enable_editing_notifier.add_subscriber(
-            self.seq_fitting_tab.seq_fitting_tab_presenter.enable_tab_observer)
+        self.fitting_tab.fitting_tab_presenter.enable_editing_notifier.add_subscriber(
+              self.enable_observer)
 
     def setup_group_calculation_disabler_notifier(self):
-        self.grouping_tab_widget.group_tab_presenter.disable_editing_notifier.add_subscriber(
-            self.home_tab.home_tab_widget.disable_observer)
 
         self.grouping_tab_widget.group_tab_presenter.disable_editing_notifier.add_subscriber(
-            self.load_widget.load_widget.disable_observer)
+               self.disable_observer)
 
-        self.grouping_tab_widget.group_tab_presenter.disable_editing_notifier.add_subscriber(
-            self.fitting_tab.fitting_tab_presenter.disable_tab_observer)
-
-        self.grouping_tab_widget.group_tab_presenter.disable_editing_notifier.add_subscriber(
-            self.phase_tab.phase_table_presenter.disable_tab_observer)
-
-        self.grouping_tab_widget.group_tab_presenter.disable_editing_notifier.add_subscriber(
-            self.results_tab.results_tab_presenter.disable_tab_observer)
-
-        self.grouping_tab_widget.group_tab_presenter.disable_editing_notifier.add_subscriber(
-            self.seq_fitting_tab.seq_fitting_tab_presenter.disable_tab_observer)
+        self.fitting_tab.fitting_tab_presenter.disable_editing_notifier.add_subscriber(
+               self.disable_observer)
 
     def setup_on_load_enabler(self):
         self.load_widget.load_widget.load_run_widget.enable_notifier.add_subscriber(

--- a/scripts/Muon/GUI/MuonAnalysis/muon_analysis_2.py
+++ b/scripts/Muon/GUI/MuonAnalysis/muon_analysis_2.py
@@ -199,6 +199,8 @@ class MuonAnalysisGui(QtWidgets.QMainWindow):
 
         self.disable_notifier.add_subscriber(self.seq_fitting_tab.seq_fitting_tab_presenter.disable_tab_observer)
 
+        self.disable_notifier.add_subscriber(self.grouping_tab_widget.group_tab_presenter.disable_tab_observer)
+
     def setup_enable_notifier(self):
 
         self.enable_notifier.add_subscriber(self.home_tab.home_tab_widget.enable_observer)
@@ -212,6 +214,8 @@ class MuonAnalysisGui(QtWidgets.QMainWindow):
         self.enable_notifier.add_subscriber(self.results_tab.results_tab_presenter.enable_tab_observer)
 
         self.enable_notifier.add_subscriber(self.seq_fitting_tab.seq_fitting_tab_presenter.enable_tab_observer)
+
+        self.enable_notifier.add_subscriber(self.grouping_tab_widget.group_tab_presenter.enable_tab_observer)
 
     def setup_load_observers(self):
         self.load_widget.load_widget.loadNotifier.add_subscriber(
@@ -297,6 +301,9 @@ class MuonAnalysisGui(QtWidgets.QMainWindow):
         self.fitting_tab.fitting_tab_presenter.enable_editing_notifier.add_subscriber(
               self.enable_observer)
 
+        self.phase_tab.phase_table_presenter.enable_editing_notifier.add_subscriber(
+            self.enable_observer)
+
     def setup_group_calculation_disabler_notifier(self):
 
         self.grouping_tab_widget.group_tab_presenter.disable_editing_notifier.add_subscriber(
@@ -304,6 +311,9 @@ class MuonAnalysisGui(QtWidgets.QMainWindow):
 
         self.fitting_tab.fitting_tab_presenter.disable_editing_notifier.add_subscriber(
                self.disable_observer)
+
+        self.phase_tab.phase_table_presenter.disable_editing_notifier.add_subscriber(
+            self.disable_observer)
 
     def setup_on_load_enabler(self):
         self.load_widget.load_widget.load_run_widget.enable_notifier.add_subscriber(

--- a/scripts/test/Muon/fitting_tab_widget/fitting_tab_presenter_test.py
+++ b/scripts/test/Muon/fitting_tab_widget/fitting_tab_presenter_test.py
@@ -326,7 +326,7 @@ class FittingTabPresenterTest(unittest.TestCase):
         self.presenter.fitting_calculation_model.result = (fit_function, 'Success', 1.07)
 
         self.presenter.handle_finished()
-
+        self.view.setEnabled(True)
         self.assertEqual(self.view.undo_fit_button.isEnabled(), True)
 
     def test_after_fit_fit_cache_is_populated_for_after_fit(self):

--- a/scripts/test/Muon/phase_table_widget/phase_table_presenter_test.py
+++ b/scripts/test/Muon/phase_table_widget/phase_table_presenter_test.py
@@ -8,6 +8,7 @@ import unittest
 
 from unittest import mock
 from mantidqt.utils.qt.testing import start_qapplication
+from mantidqt.utils.observer_pattern import GenericObservable
 from qtpy.QtWidgets import QApplication
 from qtpy import QtCore
 from Muon.GUI.Common.phase_table_widget.phase_table_presenter import PhaseTablePresenter
@@ -214,6 +215,22 @@ class PhaseTablePresenterTest(unittest.TestCase):
 
         workspace_wrapper_mock.assert_called_once_with('MUSR22222 MA/MUSR22222 Phase Tab MA/MUSR22222_PhaseTable; fit_information')
         workspace_wrapper_mock.return_value.show.assert_called_once_with()
+
+    def test_that_disable_observer_calls_on_view_when_triggered(self):
+        disable_notifier = GenericObservable()
+        disable_notifier.add_subscriber(self.presenter.disable_tab_observer)
+        self.view.setEnabled = mock.MagicMock()
+
+        disable_notifier.notify_subscribers()
+        self.view.setEnabled.assert_called_once_with(False)
+
+    def test_that_enable_observer_calls_on_view_when_triggered(self):
+        enable_notifier = GenericObservable()
+        enable_notifier.add_subscriber(self.presenter.enable_tab_observer)
+        self.view.setEnabled = mock.MagicMock()
+
+        enable_notifier.notify_subscribers()
+        self.view.setEnabled.assert_called_once_with(True)
 
 
 if __name__ == '__main__':

--- a/scripts/test/Muon/phase_table_widget/phase_table_presenter_test.py
+++ b/scripts/test/Muon/phase_table_widget/phase_table_presenter_test.py
@@ -218,23 +218,40 @@ class PhaseTablePresenterTest(unittest.TestCase):
 
     def test_that_disable_observer_calls_on_view_when_triggered(self):
         self.view.setEnabled(True)
-        self.assertTrue(self.view.isEnabled())
+        self.view.enable_widget()
+
+        for widget in self.view.children():
+            if str(widget.objectName()) in ['cancel_button', 'phasequad_cancel_button']:
+                continue
+            self.assertTrue(widget.isEnabled())
 
         disable_notifier = GenericObservable()
         disable_notifier.add_subscriber(self.presenter.disable_tab_observer)
 
         disable_notifier.notify_subscribers()
-        self.assertFalse(self.view.isEnabled())
+        for widget in self.view.children():
+            if str(widget.objectName()) in ['cancel_button', 'phasequad_cancel_button']:
+                continue
+            self.assertFalse(widget.isEnabled())
+
 
     def test_that_enable_observer_calls_on_view_when_triggered(self):
-        self.view.setEnabled(False)
-        self.assertFalse(self.view.isEnabled())
+        self.view.setEnabled(True)
+        self.view.disable_widget()
+
+        for widget in self.view.children():
+            if str(widget.objectName()) in ['cancel_button', 'phasequad_cancel_button']:
+                continue
+            self.assertFalse(widget.isEnabled())
 
         enable_notifier = GenericObservable()
         enable_notifier.add_subscriber(self.presenter.enable_tab_observer)
 
         enable_notifier.notify_subscribers()
-        self.assertTrue(self.view.isEnabled())
+        for widget in self.view.children():
+            if str(widget.objectName()) in ['cancel_button', 'phasequad_cancel_button']:
+                continue
+            self.assertTrue(widget.isEnabled())
 
 
 if __name__ == '__main__':

--- a/scripts/test/Muon/phase_table_widget/phase_table_presenter_test.py
+++ b/scripts/test/Muon/phase_table_widget/phase_table_presenter_test.py
@@ -217,20 +217,24 @@ class PhaseTablePresenterTest(unittest.TestCase):
         workspace_wrapper_mock.return_value.show.assert_called_once_with()
 
     def test_that_disable_observer_calls_on_view_when_triggered(self):
+        self.view.setEnabled(True)
+        self.assertTrue(self.view.isEnabled())
+
         disable_notifier = GenericObservable()
         disable_notifier.add_subscriber(self.presenter.disable_tab_observer)
-        self.view.setEnabled = mock.MagicMock()
 
         disable_notifier.notify_subscribers()
-        self.view.setEnabled.assert_called_once_with(False)
+        self.assertFalse(self.view.isEnabled())
 
     def test_that_enable_observer_calls_on_view_when_triggered(self):
+        self.view.setEnabled(False)
+        self.assertFalse(self.view.isEnabled())
+
         enable_notifier = GenericObservable()
         enable_notifier.add_subscriber(self.presenter.enable_tab_observer)
-        self.view.setEnabled = mock.MagicMock()
 
         enable_notifier.notify_subscribers()
-        self.view.setEnabled.assert_called_once_with(True)
+        self.assertTrue(self.view.isEnabled())
 
 
 if __name__ == '__main__':

--- a/scripts/test/Muon/results_tab_widget/results_tab_presenter_test.py
+++ b/scripts/test/Muon/results_tab_widget/results_tab_presenter_test.py
@@ -7,6 +7,7 @@
 import unittest
 from unittest import mock
 from Muon.GUI.Common.results_tab_widget.results_tab_presenter import ResultsTabPresenter
+from mantidqt.utils.observer_pattern import GenericObservable
 
 RESULTS_TAB_MODEL_CLS = 'Muon.GUI.Common.results_tab_widget.results_tab_model.ResultsTabModel'
 RESULTS_TAB_VIEW_CLS = 'Muon.GUI.Common.results_tab_widget.results_tab_widget.ResultsTabView'
@@ -149,6 +150,21 @@ class ResultsTabPresenterTest(unittest.TestCase):
 
         self.mock_model.on_new_fit_performed.assert_called_once_with()
 
+    def test_that_disable_observer_calls_on_view_when_triggered(self):
+        presenter = ResultsTabPresenter(self.mock_view, self.mock_model)
+        disable_notifier = GenericObservable()
+        disable_notifier.add_subscriber(presenter.disable_tab_observer)
+
+        disable_notifier._notify_subscribers_impl(arg=None)
+        self.mock_view.setEnabled.assert_called_once_with(False)
+
+    def test_that_enable_observer_calls_on_view_when_triggered(self):
+        presenter = ResultsTabPresenter(self.mock_view, self.mock_model)
+        enable_notifier = GenericObservable()
+        enable_notifier.add_subscriber(presenter.enable_tab_observer)
+
+        enable_notifier._notify_subscribers_impl(arg=None)
+        self.mock_view.setEnabled.assert_called_once_with(True)
 
 if __name__ == '__main__':
     unittest.main(buffer=False, verbosity=2)

--- a/scripts/test/Muon/seq_fitting_tab_widget/seq_fitting_tab_presenter_test.py
+++ b/scripts/test/Muon/seq_fitting_tab_widget/seq_fitting_tab_presenter_test.py
@@ -11,6 +11,7 @@ from mantid.api import FunctionFactory, MultiDomainFunction
 from mantid.simpleapi import CreateSampleWorkspace, DeleteWorkspace
 from unittest import mock
 from mantidqt.utils.qt.testing import start_qapplication
+from mantidqt.utils.observer_pattern import GenericObservable
 from Muon.GUI.Common.seq_fitting_tab_widget.seq_fitting_tab_presenter import SeqFittingTabPresenter
 from Muon.GUI.Common.test_helpers.context_setup import setup_context
 from qtpy import QtWidgets
@@ -203,6 +204,22 @@ class SeqFittingTabPresenterTest(unittest.TestCase):
 
         self.model.get_runs_groups_and_pairs_for_fits.assert_called_once()
         self.view.fit_table.set_fit_workspaces.assert_called_once()
+
+    def test_that_disable_observer_calls_on_view_when_triggered(self):
+        disable_notifier = GenericObservable()
+        disable_notifier.add_subscriber(self.presenter.disable_tab_observer)
+        self.view.setEnabled = mock.MagicMock()
+
+        disable_notifier.notify_subscribers()
+        self.view.setEnabled.assert_called_once_with(False)
+
+    def test_that_enable_observer_calls_on_view_when_triggered(self):
+        enable_notifier = GenericObservable()
+        enable_notifier.add_subscriber(self.presenter.enable_tab_observer)
+        self.view.setEnabled = mock.MagicMock()
+
+        enable_notifier.notify_subscribers()
+        self.view.setEnabled.assert_called_once_with(True)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
**Description of work.**
 Disabled other tabs on muon analysis and frequency domain analysis gui while other process run

**To test:**
1. open muon analysis gui.
2. Drag phase table tab, sequential fitting tab and results tab out.
3. Load MUSR00015189 and notice that the tabs are disabled while data loads and enabled after load is done.
4. Rebin the data and notice the tabs are disabled while rebin algorithm runs and 
enabled after.

<!-- Instructions for testing. -->

Fixes #26773. 

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
