### PR TITLE
Changing axes title in axes tab does not update curves tab

### DIFF
--- a/docs/source/release/v6.0.0/mantidworkbench.rst
+++ b/docs/source/release/v6.0.0/mantidworkbench.rst
@@ -30,5 +30,6 @@ Bugfixes
 - Only display slice viewer widget for MDEventWorkspaces with 2 or more dimensions.
 - Fix Workbench crashes upon deleting rows or columns in a TableWorkspace.
 - Fix crash on second call to ManageUserDirectories after pressing Esc to close it.
+- A bug in plot config where changing an axes title in the axis tab did not change the title in the curves tab.
 
 :ref:`Release 6.0.0 <v6.0.0>`

--- a/qt/python/mantidqt/widgets/plotconfigdialog/axestabwidget/presenter.py
+++ b/qt/python/mantidqt/widgets/plotconfigdialog/axestabwidget/presenter.py
@@ -211,7 +211,7 @@ class AxesTabWidgetPresenter:
         self.view.show_minor_gridlines_check_box.setVisible(not plot_is_3d)
         self.view.show_minor_ticks_check_box.setVisible(not plot_is_3d)
 
-        ax = self.view.get_axis()
+        ax = self.current_axis
         self.view.set_title(ax_props.title)
 
         color_hex = convert_color_to_hex(ax_props["canvas_color"])
@@ -232,7 +232,6 @@ class AxesTabWidgetPresenter:
 
     def axis_changed(self):
         ax = self.current_axis
-
         self.current_view_props['title'] = self.view.get_title()
         self.current_view_props['minor_ticks'] = self.view.get_show_minor_ticks()
         self.current_view_props['minor_gridlines'] = self.view.get_show_minor_gridlines()
@@ -241,7 +240,8 @@ class AxesTabWidgetPresenter:
         self.current_view_props[f"{ax}scale"] = self.view.get_scale()
         self.current_view_props["canvas_color"] = self.view.get_canvas_color()
 
-        new_ax = self.view.get_axis()
+        # On Kubuntu, QT prepends the & on characters used as shortcut keys, which causes KeyErrors
+        new_ax = self.view.get_axis().replace('&', '')
         self.current_axis = new_ax
 
         if f"{new_ax}lim" in self.current_view_props:
@@ -252,7 +252,7 @@ class AxesTabWidgetPresenter:
             self.view.set_scale(self.current_view_props[f"{new_ax}scale"])
         else:
             ax_props = self.get_selected_ax_properties()
-            ax = self.view.get_axis()
+            ax = self.view.get_axis().replace('&', '')
             lim = ax_props[f"{ax}lim"]
             self.view.set_lower_limit(lim[0])
             self.view.set_upper_limit(lim[1])

--- a/qt/python/mantidqt/widgets/plotconfigdialog/axestabwidget/test/test_axestabwidgetpresenter.py
+++ b/qt/python/mantidqt/widgets/plotconfigdialog/axestabwidget/test/test_axestabwidgetpresenter.py
@@ -78,6 +78,27 @@ class AxesTabWidgetPresenterTest(unittest.TestCase):
                 ax_mock.set_facecolor.assert_called_once_with(
                     presenter.current_view_props.canvas_color)
 
+    def test_ampersand_removed_from_current_axis_title(self):
+        ax_title = "test"
+
+        # KDE prepends & to axes title
+        mock_kde_view = mock.Mock(get_selected_ax_name=lambda: "My Axes: (0, 0)",
+                                  get_axis=lambda: f"&{ax_title}",
+                                  get_properties=lambda: {})
+        ax_props_dict = {
+            # Mock out some properties that presenter.axis_changed depends on.
+            'canvas_color': (1.0, 1.0, 1.0, 1.0),
+            f"{ax_title}lim": (0, 1),
+            f"{ax_title}label": ax_title,
+            f"{ax_title}scale": "Linear",
+        }
+        presenter = Presenter(self.fig, view=mock_kde_view)
+        presenter.current_view_props = ax_props_dict
+
+        presenter.axis_changed()
+
+        self.assertEqual(presenter.current_axis, ax_title.replace('&', ''))
+
     def test_apply_all_properties_calls_setters_with_correct_properties(self):
         ax_mock_1 = mock.MagicMock()
         ax_mock_2 = mock.MagicMock()

--- a/qt/python/mantidqt/widgets/plotconfigdialog/curvestabwidget/curves_tab.ui
+++ b/qt/python/mantidqt/widgets/plotconfigdialog/curvestabwidget/curves_tab.ui
@@ -131,7 +131,7 @@
    <item row="0" column="0">
     <widget class="QLabel" name="select_axes_label">
      <property name="text">
-      <string>Select an axes</string>
+      <string>Select a set of axes</string>
      </property>
     </widget>
    </item>

--- a/qt/python/mantidqt/widgets/plotconfigdialog/curvestabwidget/presenter.py
+++ b/qt/python/mantidqt/widgets/plotconfigdialog/curvestabwidget/presenter.py
@@ -230,14 +230,28 @@ class CurvesTabWidgetPresenter:
         self.view.set_errorbars_tab_enabled(enable_errorbars)
 
     def on_axes_index_changed(self):
+        # No axes properties have changed, but we need to update the rest of
+        # the view to match the curve that are on the new axes.
         self.update_view(update_axes=False)
 
     def on_curves_index_changed(self):
+        # No properties about the axes or the curves have changed, but we need to
+        # update the rest of the view so the information matches the new selected curve.
         self.update_view(update_axes=False, update_curves=False)
 
     def update_view(self, update_axes=True, update_curves=True):
-        """Update the view with the selected curve's properties"""
+        """Update the view with the selected axes and curve properties.
+        By default we update everything since, if we changed something about
+        the axes (e.g. title), we need to ensure these propagate to the curves tab.
+
+        update_axes=True -> the axes combo will be updated
+        update_curves=True -> the curves combo will be updated
+
+        Regardless of the two parameters, the rest of the curves tab will update to show
+        the properties of the selected curve."""
+
         if update_axes:
+            # Update the 'select axes' combo box. Do this if axes properties have changed.
             self.axes_names_dict = get_axes_names_dict(self.fig, curves_only=True)
             self.populate_select_axes_combo_box()
         if update_curves:
@@ -247,6 +261,7 @@ class CurvesTabWidgetPresenter:
 
         self.set_apply_to_all_buttons_enabled()
 
+        # Then update the rest of the view to reflect the selected combo items.
         curve_props = CurveProperties.from_curve(self.get_selected_curve())
         self.view.update_fields(curve_props)
         self.set_errorbars_tab_enabled()

--- a/qt/python/mantidqt/widgets/plotconfigdialog/curvestabwidget/view.py
+++ b/qt/python/mantidqt/widgets/plotconfigdialog/curvestabwidget/view.py
@@ -13,7 +13,7 @@ from mantidqt.widgets.plotconfigdialog.curvestabwidget.errorbarstabwidget.view i
 from mantidqt.widgets.plotconfigdialog.curvestabwidget.linetabwidget.view import LineTabWidgetView
 from mantidqt.widgets.plotconfigdialog.curvestabwidget.markertabwidget.view import MarkerTabWidgetView
 from mantidqt.widgets.plotconfigdialog.curvestabwidget import CurveProperties
-from mantidqt.utils.qt import load_ui
+from mantidqt.utils.qt import load_ui, block_signals
 
 
 class CurvesTabWidgetView(QWidget):
@@ -33,10 +33,14 @@ class CurvesTabWidgetView(QWidget):
         self.setAttribute(Qt.WA_DeleteOnClose, True)
 
     def populate_select_axes_combo_box(self, axes_names):
-        self.select_axes_combo_box.addItems(axes_names)
+        with block_signals(self.select_axes_combo_box):
+            self.select_axes_combo_box.clear()
+            self.select_axes_combo_box.addItems(axes_names)
 
     def populate_select_curve_combo_box(self, curve_names):
-        self.select_curve_combo_box.addItems(curve_names)
+        with block_signals(self.select_curve_combo_box):
+            self.select_curve_combo_box.clear()
+            self.select_curve_combo_box.addItems(curve_names)
 
     def set_selected_curve_selector_text(self, new_text):
         current_index = self.select_curve_combo_box.currentIndex()

--- a/qt/python/mantidqt/widgets/plotconfigdialog/legendtabwidget/presenter.py
+++ b/qt/python/mantidqt/widgets/plotconfigdialog/legendtabwidget/presenter.py
@@ -25,7 +25,7 @@ class LegendTabWidgetPresenter:
 
         self.current_view_properties = None
         self.populate_font_combo_box()
-        self.init_view()
+        self.update_view()
 
         # Signals
         self.view.transparency_spin_box.valueChanged.connect(
@@ -39,7 +39,7 @@ class LegendTabWidgetPresenter:
         self.view.advanced_options_push_button.clicked.connect(self.show_advanced_options)
         self.view.advanced_options.rejected.connect(self.advanced_options_cancelled)
 
-    def init_view(self):
+    def update_view(self):
         """Sets all of the initial values of the input fields when the tab is first loaded"""
         if int(matplotlib.__version__[0]) < 2:
             self.view.hide_box_properties()

--- a/qt/python/mantidqt/widgets/plotconfigdialog/legendtabwidget/presenter.py
+++ b/qt/python/mantidqt/widgets/plotconfigdialog/legendtabwidget/presenter.py
@@ -25,7 +25,7 @@ class LegendTabWidgetPresenter:
 
         self.current_view_properties = None
         self.populate_font_combo_box()
-        self.update_view()
+        self.init_view()
 
         # Signals
         self.view.transparency_spin_box.valueChanged.connect(
@@ -39,7 +39,7 @@ class LegendTabWidgetPresenter:
         self.view.advanced_options_push_button.clicked.connect(self.show_advanced_options)
         self.view.advanced_options.rejected.connect(self.advanced_options_cancelled)
 
-    def update_view(self):
+    def init_view(self):
         """Sets all of the initial values of the input fields when the tab is first loaded"""
         if int(matplotlib.__version__[0]) < 2:
             self.view.hide_box_properties()

--- a/qt/python/mantidqt/widgets/plotconfigdialog/presenter.py
+++ b/qt/python/mantidqt/widgets/plotconfigdialog/presenter.py
@@ -70,6 +70,9 @@ class PlotConfigDialogPresenter:
             if tab and tab.view:
                 tab.apply_properties()
         self.fig.canvas.draw()
+        for tab in reversed(self.tab_widget_presenters):
+            if tab and tab.view:
+                tab.update_view()
 
     def apply_properties_and_exit(self):
         self.apply_properties()

--- a/qt/python/mantidqt/widgets/plotconfigdialog/presenter.py
+++ b/qt/python/mantidqt/widgets/plotconfigdialog/presenter.py
@@ -67,11 +67,11 @@ class PlotConfigDialogPresenter:
 
     def apply_properties(self):
         for tab in reversed(self.tab_widget_presenters):
-            if tab and tab.view:
+            if tab:
                 tab.apply_properties()
         self.fig.canvas.draw()
         for tab in reversed(self.tab_widget_presenters):
-            if tab and tab.view:
+            if tab:
                 tab.update_view()
 
     def apply_properties_and_exit(self):

--- a/qt/python/mantidqt/widgets/plotconfigdialog/presenter.py
+++ b/qt/python/mantidqt/widgets/plotconfigdialog/presenter.py
@@ -71,6 +71,11 @@ class PlotConfigDialogPresenter:
                 tab.apply_properties()
         self.fig.canvas.draw()
         for tab in reversed(self.tab_widget_presenters):
+            if tab == self.tab_widget_presenters[0]:
+                # Do not call update view on the legend tab because the legend config
+                # does not depend on the curves or axes - it only changes how the legend
+                # is displayed (e.g. legend fonts, border color, etc.)
+                continue
             if tab:
                 tab.update_view()
 

--- a/qt/python/mantidqt/widgets/plotconfigdialog/test/test_apply_all_properties.py
+++ b/qt/python/mantidqt/widgets/plotconfigdialog/test/test_apply_all_properties.py
@@ -126,7 +126,7 @@ def _run_apply_properties_on_figure_with_curve(curve_view_mock):
         with patch.object(presenter.tab_widget_presenters[1], 'axis_changed',
                           lambda: None):
             presenter.apply_properties()
-    return ax, curve_view_mock
+    return ax
 
 
 def _run_apply_properties_on_figure_with_image():
@@ -161,7 +161,7 @@ def _run_apply_properties_on_figure_with_legend(curve_view_mock):
         with patch.object(presenter.tab_widget_presenters[1], 'axis_changed',
                           lambda: None):
             presenter.apply_properties()
-    return ax, curve_view_mock
+    return ax
 
 
 class ApplyAllPropertiesTest(unittest.TestCase):
@@ -182,7 +182,7 @@ class ApplyAllPropertiesTest(unittest.TestCase):
         cls.curve_view_patch = patch(CURVE_VIEW, lambda x: cls.curve_view_mock)
         cls.curve_view_patch.start()
 
-        cls.ax, _ = _run_apply_properties_on_figure_with_curve(cls.curve_view_mock)
+        cls.ax = _run_apply_properties_on_figure_with_curve(cls.curve_view_mock)
         cls.new_curve = cls.ax.containers[0]
 
         # Mock images tab view
@@ -201,7 +201,7 @@ class ApplyAllPropertiesTest(unittest.TestCase):
         cls.legend_view_patch = patch(LEGEND_VIEW, lambda x: cls.legend_view_mock)
         cls.legend_view_patch.start()
 
-        cls.legend_ax, _ = _run_apply_properties_on_figure_with_legend(cls.curve_view_mock)
+        cls.legend_ax = _run_apply_properties_on_figure_with_legend(cls.curve_view_mock)
         cls.new_legend = cls.legend_ax.get_legend()
 
     @classmethod

--- a/qt/python/mantidqt/widgets/plotconfigdialog/test/test_apply_all_properties.py
+++ b/qt/python/mantidqt/widgets/plotconfigdialog/test/test_apply_all_properties.py
@@ -93,14 +93,30 @@ new_legend_props = {
     'marker_label_padding': 1.0}
 
 
+class CurveNameSideEffect:
+    def __init__(self, old_name, new_name, switch_count):
+        self.old_name = old_name
+        self.new_name = new_name
+        self.switch_count = switch_count
+
+        self.call_count = 0
+
+    def __call__(self):
+        self.call_count += 1
+        if self.call_count <= self.switch_count:
+            return self.old_name
+        return self.new_name
+
+
 def mock_axes_tab_presenter_update_view(presenter):
     presenter.current_view_props = new_ax_view_props
 
 
-def _run_apply_properties_on_figure_with_curve():
+def _run_apply_properties_on_figure_with_curve(curve_view_mock):
     fig = figure()
     ax = fig.add_subplot(111)
     ax.errorbar([0, 1], [0, 1], yerr=[0.1, 0.2], label='old label')
+    curve_view_mock.get_selected_curve_name = CurveNameSideEffect('old label', 'New label', switch_count=6)
 
     with patch.object(AxesTabWidgetPresenter, 'update_view', mock_axes_tab_presenter_update_view):
         presenter = PlotConfigDialogPresenter(fig, view=Mock())
@@ -110,7 +126,7 @@ def _run_apply_properties_on_figure_with_curve():
         with patch.object(presenter.tab_widget_presenters[1], 'axis_changed',
                           lambda: None):
             presenter.apply_properties()
-    return ax
+    return ax, curve_view_mock
 
 
 def _run_apply_properties_on_figure_with_image():
@@ -130,12 +146,14 @@ def _run_apply_properties_on_figure_with_image():
     return img_ax
 
 
-def _run_apply_properties_on_figure_with_legend():
+def _run_apply_properties_on_figure_with_legend(curve_view_mock):
     fig = figure()
     ax = fig.add_subplot(111)
     ax.plot([1, 2, 3], label='old label')
     legend = ax.legend()
     legend.get_frame().set_alpha(0.5)
+    curve_view_mock.get_selected_curve_name = CurveNameSideEffect('old label', 'New label', switch_count=3)
+
     with patch.object(AxesTabWidgetPresenter, 'update_view', mock_axes_tab_presenter_update_view):
         presenter = PlotConfigDialogPresenter(fig, view=Mock())
     with patch.object(presenter.tab_widget_presenters[1], 'update_view',
@@ -143,7 +161,7 @@ def _run_apply_properties_on_figure_with_legend():
         with patch.object(presenter.tab_widget_presenters[1], 'axis_changed',
                           lambda: None):
             presenter.apply_properties()
-    return ax
+    return ax, curve_view_mock
 
 
 class ApplyAllPropertiesTest(unittest.TestCase):
@@ -159,13 +177,12 @@ class ApplyAllPropertiesTest(unittest.TestCase):
 
         # Mock curves tab view
         cls.curve_view_mock = Mock(
-            get_selected_curve_name=lambda: 'old label',
             get_selected_ax_name=lambda: '(0, 0)',
             get_properties=lambda: CurveProperties(new_curve_view_props))
         cls.curve_view_patch = patch(CURVE_VIEW, lambda x: cls.curve_view_mock)
         cls.curve_view_patch.start()
 
-        cls.ax = _run_apply_properties_on_figure_with_curve()
+        cls.ax, _ = _run_apply_properties_on_figure_with_curve(cls.curve_view_mock)
         cls.new_curve = cls.ax.containers[0]
 
         # Mock images tab view
@@ -184,7 +201,7 @@ class ApplyAllPropertiesTest(unittest.TestCase):
         cls.legend_view_patch = patch(LEGEND_VIEW, lambda x: cls.legend_view_mock)
         cls.legend_view_patch.start()
 
-        cls.legend_ax = _run_apply_properties_on_figure_with_legend()
+        cls.legend_ax, _ = _run_apply_properties_on_figure_with_legend(cls.curve_view_mock)
         cls.new_legend = cls.legend_ax.get_legend()
 
     @classmethod

--- a/qt/python/mantidqt/widgets/plotconfigdialog/test/test_plotconfigdialogpresenter.py
+++ b/qt/python/mantidqt/widgets/plotconfigdialog/test/test_plotconfigdialogpresenter.py
@@ -167,16 +167,13 @@ class PlotConfigDialogPresenterTest(unittest.TestCase):
         ax.plot([0], [0])
         mock_view = Mock()
         presenter = PlotConfigDialogPresenter(fig, mock_view)
-        
         # use mock manager to ensure all user properties are applied before view update
         mock_axes_presenter = presenter.tab_widget_presenters[1]
         mock_curves_presenter = presenter.tab_widget_presenters[2]
         mock_manager = Mock()
         mock_manager.attach_mock(mock_axes_presenter, "mock_axes_presenter")
         mock_manager.attach_mock(mock_curves_presenter, "mock_curves_presenter")
-        
         presenter.apply_properties()
-
         mock_manager.assert_has_calls([
             call.mock_curves_presenter.apply_properties,
             call.mock_axes_presenter.apply_properties,

--- a/qt/python/mantidqt/widgets/plotconfigdialog/test/test_plotconfigdialogpresenter.py
+++ b/qt/python/mantidqt/widgets/plotconfigdialog/test/test_plotconfigdialogpresenter.py
@@ -167,12 +167,14 @@ class PlotConfigDialogPresenterTest(unittest.TestCase):
         ax.plot([0], [0])
         mock_view = Mock()
         presenter = PlotConfigDialogPresenter(fig, mock_view)
+
         # use mock manager to ensure all user properties are applied before view update
         mock_axes_presenter = presenter.tab_widget_presenters[1]
         mock_curves_presenter = presenter.tab_widget_presenters[2]
         mock_manager = Mock()
         mock_manager.attach_mock(mock_axes_presenter, "mock_axes_presenter")
         mock_manager.attach_mock(mock_curves_presenter, "mock_curves_presenter")
+
         presenter.apply_properties()
         mock_manager.assert_has_calls([
             call.mock_curves_presenter.apply_properties,

--- a/qt/python/mantidqt/widgets/plotconfigdialog/test/test_plotconfigdialogpresenter.py
+++ b/qt/python/mantidqt/widgets/plotconfigdialog/test/test_plotconfigdialogpresenter.py
@@ -7,12 +7,12 @@
 #  This file is part of the mantid workbench.
 
 import unittest
+from unittest.mock import Mock, call, patch
 
 from matplotlib import use as mpl_use
 mpl_use('Agg')  # noqa
 from matplotlib.pyplot import figure
 
-from unittest.mock import Mock, patch
 from mantidqt.widgets.plotconfigdialog.presenter import PlotConfigDialogPresenter
 
 
@@ -160,6 +160,29 @@ class PlotConfigDialogPresenterTest(unittest.TestCase):
                               (self.curves_mock.return_value.view, 'Curves')]
         self.assert_called_x_times_with(2, expected_call_args,
                                         mock_view.add_tab_widget)
+
+    def test_tabs_present_updated_properties_from_figure_when_apply_clicked(self):
+        fig = figure()
+        ax = fig.add_subplot(111)
+        ax.plot([0], [0])
+        mock_view = Mock()
+        presenter = PlotConfigDialogPresenter(fig, mock_view)
+        
+        # use mock manager to ensure all user properties are applied before view update
+        mock_axes_presenter = presenter.tab_widget_presenters[1]
+        mock_curves_presenter = presenter.tab_widget_presenters[2]
+        mock_manager = Mock()
+        mock_manager.attach_mock(mock_axes_presenter, "mock_axes_presenter")
+        mock_manager.attach_mock(mock_curves_presenter, "mock_curves_presenter")
+        
+        presenter.apply_properties()
+
+        mock_manager.assert_has_calls([
+            call.mock_curves_presenter.apply_properties,
+            call.mock_axes_presenter.apply_properties,
+            call.mock_curves_presenter.update_view,
+            call.mock_axes_presenter.update_view
+        ])
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
In the plot config dialog, changing the title of an axes in the axes tab did not update the title of the same axes in the curves tab. This has now been fixed, and the label above the axes combo in each tab has been changed to match, as suggested by the reporter.

**Report to:** Steve King

**To test:**
1. Open workbench and run the following script:
```
import matplotlib.pyplot as plt

fig, ax = plt.subplots(subplot_kw={'projection':'mantid'})
ax.plot([0,1],[0,1])
plt.show()
```
2. Open the plot config dialog
3. Set the title of the axes to something
4. In the curves tab, check that that axes has the same title in the axes combo box

Fixes #28900 

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
