### PR TITLE
Deprecating RecordPythonScript

### DIFF
--- a/Framework/Algorithms/inc/MantidAlgorithms/RecordPythonScript.h
+++ b/Framework/Algorithms/inc/MantidAlgorithms/RecordPythonScript.h
@@ -7,6 +7,7 @@
 #pragma once
 
 #include "MantidAPI/AlgorithmObserver.h"
+#include "MantidAPI/DeprecatedAlgorithm.h"
 #include "MantidAlgorithms/DllConfig.h"
 #include "MantidAlgorithms/GeneratePythonScript.h"
 
@@ -26,7 +27,8 @@ namespace Algorithms {
 */
 class MANTID_ALGORITHMS_DLL RecordPythonScript
     : public Algorithms::GeneratePythonScript,
-      public API::AlgorithmObserver {
+      public API::AlgorithmObserver,
+      public API::DeprecatedAlgorithm {
 public:
   RecordPythonScript();
   /// Algorithm's name for identification

--- a/Framework/Algorithms/src/RecordPythonScript.cpp
+++ b/Framework/Algorithms/src/RecordPythonScript.cpp
@@ -23,7 +23,7 @@ DECLARE_ALGORITHM(RecordPythonScript)
 //----------------------------------------------------------------------------------------------
 /// Constructor
 RecordPythonScript::RecordPythonScript()
-    : Algorithms::GeneratePythonScript(), API::AlgorithmObserver() {}
+    : Algorithms::GeneratePythonScript(), API::AlgorithmObserver() { useAlgorithm("GeneratePythonScript", 1); }
 
 //----------------------------------------------------------------------------------------------
 

--- a/Framework/Algorithms/src/RecordPythonScript.cpp
+++ b/Framework/Algorithms/src/RecordPythonScript.cpp
@@ -23,7 +23,9 @@ DECLARE_ALGORITHM(RecordPythonScript)
 //----------------------------------------------------------------------------------------------
 /// Constructor
 RecordPythonScript::RecordPythonScript()
-    : Algorithms::GeneratePythonScript(), API::AlgorithmObserver() { useAlgorithm("GeneratePythonScript", 1); }
+    : Algorithms::GeneratePythonScript(), API::AlgorithmObserver() {
+  useAlgorithm("GeneratePythonScript", 1);
+}
 
 //----------------------------------------------------------------------------------------------
 

--- a/docs/source/release/v5.1.0/framework.rst
+++ b/docs/source/release/v5.1.0/framework.rst
@@ -47,7 +47,7 @@ Algorithms
   and :ref:`MaskInstrument <algm-MaskInstrument>` is now deprecated and you should use :ref:`MaskDetectors <algm-MaskDetectors>` instead.
 - Add parameters to :ref:`LoadSampleShape <algm-LoadSampleShape>` to allow the mesh in the input file to be rotated and\or translated
 - Algorithms now lazily load their documentation and function signatures, improving import times from the `simpleapi`.
-
+- Deprecated the RecordPythonScript algorithm
 
 Data Handling
 -------------


### PR DESCRIPTION
**Description of work.**
Deprecate the rarely used RecordPythonScript algorithm

**Report to:** Martyn Gigg

**To test:**
Attempt to use the RecordPythonScript algorithm, ensure that it gives a message warning that it is deprecated

Fixes #29139 . <!-- and fix #xxxx or close #xxxx xor resolves #xxxx -->
<!-- alternative
*There is no associated issue.*
-->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
