### PR TITLE
Added Unroll All Checkbox for Workspace History Window

### DIFF
--- a/docs/source/release/v5.1.0/framework.rst
+++ b/docs/source/release/v5.1.0/framework.rst
@@ -94,6 +94,7 @@ Python
 Improvements
 ------------
 - Updated the convolution function in the fitting framework to allow the convolution of two composite functions.
+- Added an unroll all checkbox in Algorithm History Window which allows all algorithms to be unrolled at once when copying the script
 
 Bugfixes
 --------

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/AlgorithmHistoryWindow.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/AlgorithmHistoryWindow.h
@@ -17,6 +17,7 @@
 #include "MantidKernel/EnvironmentHistory.h"
 
 #include <QAbstractListModel>
+#include <QCheckBox>
 #include <QComboBox>
 #include <QDialog>
 #include <QGroupBox>
@@ -163,6 +164,7 @@ public slots:
 
   void copytoClipboard();
   void writeToScriptFile();
+  void unrollAll(int state);
 
 private:
   AlgExecSummaryGrpBox *createExecSummaryGrpBox();
@@ -182,6 +184,7 @@ private:
   const Mantid::API::WorkspaceHistory &m_algHist;
   QLabel *m_scriptVersionLabel;
   QComboBox *m_scriptComboMode;
+  QCheckBox *m_unrollAllHistoryCheckbox;
   QPushButton *m_scriptButtonFile;
   QPushButton *m_scriptButtonClipboard;
   AlgHistoryTreeWidget *m_Historytree;

--- a/qt/widgets/common/src/AlgorithmHistoryWindow.cpp
+++ b/qt/widgets/common/src/AlgorithmHistoryWindow.cpp
@@ -235,10 +235,9 @@ AlgorithmHistoryWindow::AlgorithmHistoryWindow(
   if (m_Historytree) {
     QStringList headers;
     headers << "Algorithms"
-            << "Unroll"
-            << "Unroll All";
+            << "Unroll";
 
-    m_Historytree->setColumnCount(3);
+    m_Historytree->setColumnCount(2);
     m_Historytree->setColumnWidth(0, 180);
     m_Historytree->setColumnWidth(1, 55);
     m_Historytree->setHeaderLabels(headers);
@@ -305,16 +304,15 @@ AlgorithmHistoryWindow::AlgorithmHistoryWindow(
   buttonLayout->addWidget(m_scriptButtonFile);
   buttonLayout->addWidget(m_scriptButtonClipboard);
 
-  // Unroll all checkbox added in column 3 of top item
-  m_unrollAllHistoryCheckbox = new QCheckBox("", this);
+  // Unroll all checkbox below tree layout
+  m_unrollAllHistoryCheckbox = new QCheckBox("Unroll All Algorithms", this);
   connect(m_unrollAllHistoryCheckbox, SIGNAL(stateChanged(int)), this,
           SLOT(unrollAll(int)));
-  auto top = m_Historytree->topLevelItem(0);
-  m_Historytree->setItemWidget(top, 2, m_unrollAllHistoryCheckbox);
 
   // Main layout
   QVBoxLayout *mainLayout = new QVBoxLayout(this);
   mainLayout->addLayout(treeLayout);
+  mainLayout->addWidget(m_unrollAllHistoryCheckbox);
   mainLayout->addLayout(environmentLayout);
   mainLayout->addLayout(buttonLayout);
 }
@@ -518,12 +516,9 @@ void AlgorithmHistoryWindow::doUnroll(const std::vector<int> &unrollIndicies) {
 void AlgorithmHistoryWindow::doRoll(int index) { m_view->roll(index); }
 
 void AlgorithmHistoryWindow::unrollAll(int state) {
-  // Iterate all items in tree which have children algorithms to be unrolled
+  // Iterate all items in tree which have child algorithms to be unrolled
   QTreeWidgetItemIterator it(m_Historytree,
                              QTreeWidgetItemIterator::HasChildren);
-
-  auto head = m_Historytree->headerItem();
-  std::cout << head->text(0).toStdString() << std::endl;
   while (*it) {
     // set state of unroll based on checkbox sate
     if (state == Qt::Checked)

--- a/qt/widgets/common/src/AlgorithmHistoryWindow.cpp
+++ b/qt/widgets/common/src/AlgorithmHistoryWindow.cpp
@@ -235,9 +235,10 @@ AlgorithmHistoryWindow::AlgorithmHistoryWindow(
   if (m_Historytree) {
     QStringList headers;
     headers << "Algorithms"
-            << "Unroll";
+            << "Unroll"
+            << "Unroll All";
 
-    m_Historytree->setColumnCount(2);
+    m_Historytree->setColumnCount(3);
     m_Historytree->setColumnWidth(0, 180);
     m_Historytree->setColumnWidth(1, 55);
     m_Historytree->setHeaderLabels(headers);
@@ -303,6 +304,13 @@ AlgorithmHistoryWindow::AlgorithmHistoryWindow(
   buttonLayout->addWidget(m_scriptComboMode);
   buttonLayout->addWidget(m_scriptButtonFile);
   buttonLayout->addWidget(m_scriptButtonClipboard);
+
+  // Unroll all checkbox added in column 3 of top item
+  m_unrollAllHistoryCheckbox = new QCheckBox("", this);
+  connect(m_unrollAllHistoryCheckbox, SIGNAL(stateChanged(int)), this,
+          SLOT(unrollAll(int)));
+  auto top = m_Historytree->topLevelItem(0);
+  m_Historytree->setItemWidget(top, 2, m_unrollAllHistoryCheckbox);
 
   // Main layout
   QVBoxLayout *mainLayout = new QVBoxLayout(this);
@@ -508,6 +516,23 @@ void AlgorithmHistoryWindow::doUnroll(const std::vector<int> &unrollIndicies) {
 }
 
 void AlgorithmHistoryWindow::doRoll(int index) { m_view->roll(index); }
+
+void AlgorithmHistoryWindow::unrollAll(int state) {
+  // Iterate all items in tree which have children algorithms to be unrolled
+  QTreeWidgetItemIterator it(m_Historytree,
+                             QTreeWidgetItemIterator::HasChildren);
+
+  auto head = m_Historytree->headerItem();
+  std::cout << head->text(0).toStdString() << std::endl;
+  while (*it) {
+    // set state of unroll based on checkbox sate
+    if (state == Qt::Checked)
+      (*it)->setCheckState(1, Qt::Checked);
+    else
+      (*it)->setCheckState(1, Qt::Unchecked);
+    ++it;
+  }
+}
 
 //--------------------------------------------------------------------------------------------------
 // AlgHistoryProperties Definitions


### PR DESCRIPTION
**Description of work.**
There is a new checkbox "Unroll All" when viewing the Show History Window for a workspace. This checkbox checks and unchecks the unroll column for all parent algorithms in the tree. This saves time for users wanting to unroll all algorithms.

**To test:**

1. Load in the sample workspaces by following instructions from the original [issue](https://github.com/mantidproject/mantid/issues/27033)
2. Show Algorithm History for some of the workspaces and follow the rest of the instructions
3. Check Unroll All from the tree widget and try copy script to clipboard and copy script to file ensuring all child algorithms are copied correctly
4. Try checking unroll for a few algorithms and then unroll all to see if they are all checked/unchecked

Fixes #27033 

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
