### PR TITLE
Fix spinbox crash in IDA GUI

### DIFF
--- a/qt/scientific_interfaces/Indirect/FunctionTemplateBrowser.cpp
+++ b/qt/scientific_interfaces/Indirect/FunctionTemplateBrowser.cpp
@@ -47,7 +47,9 @@ void FunctionTemplateBrowser::createBrowser() {
   m_parameterManager = new ParameterPropertyManager(this, true);
 
   // create editor factories
-  auto *spinBoxFactoryReadOnly = new QtSpinBoxFactoryReadOnly(this);
+  // Here we create a spin box factory with a custom timer method
+  // This avoids the slot double incrementing the box
+  auto *spinBoxFactoryNoTimer = new QtSpinBoxFactoryNoTimer(this);
   auto *doubleEditorFactory = new DoubleEditorFactory(this);
   auto *lineEditFactory = new QtLineEditFactory(this);
   auto *checkBoxFactory = new QtCheckBoxFactory(this);
@@ -58,7 +60,7 @@ void FunctionTemplateBrowser::createBrowser() {
   // assign factories to property managers
   m_browser->setFactoryForManager(m_stringManager, lineEditFactory);
   m_browser->setFactoryForManager(m_doubleManager, doubleEditorFactory);
-  m_browser->setFactoryForManager(m_intManager, spinBoxFactoryReadOnly);
+  m_browser->setFactoryForManager(m_intManager, spinBoxFactoryNoTimer);
   m_browser->setFactoryForManager(m_boolManager, checkBoxFactory);
   m_browser->setFactoryForManager(m_enumManager, comboBoxFactory);
   m_browser->setFactoryForManager(m_parameterManager, doubleDialogFactory);

--- a/qt/scientific_interfaces/Indirect/FunctionTemplateBrowser.cpp
+++ b/qt/scientific_interfaces/Indirect/FunctionTemplateBrowser.cpp
@@ -47,7 +47,7 @@ void FunctionTemplateBrowser::createBrowser() {
   m_parameterManager = new ParameterPropertyManager(this, true);
 
   // create editor factories
-  auto *spinBoxFactory = new QtSpinBoxFactory(this);
+  auto *spinBoxFactoryReadOnly = new QtSpinBoxFactoryReadOnly(this);
   auto *doubleEditorFactory = new DoubleEditorFactory(this);
   auto *lineEditFactory = new QtLineEditFactory(this);
   auto *checkBoxFactory = new QtCheckBoxFactory(this);
@@ -58,7 +58,7 @@ void FunctionTemplateBrowser::createBrowser() {
   // assign factories to property managers
   m_browser->setFactoryForManager(m_stringManager, lineEditFactory);
   m_browser->setFactoryForManager(m_doubleManager, doubleEditorFactory);
-  m_browser->setFactoryForManager(m_intManager, spinBoxFactory);
+  m_browser->setFactoryForManager(m_intManager, spinBoxFactoryReadOnly);
   m_browser->setFactoryForManager(m_boolManager, checkBoxFactory);
   m_browser->setFactoryForManager(m_enumManager, comboBoxFactory);
   m_browser->setFactoryForManager(m_parameterManager, doubleDialogFactory);

--- a/qt/scientific_interfaces/Indirect/IndirectFitAnalysisTab.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectFitAnalysisTab.cpp
@@ -268,14 +268,8 @@ size_t IndirectFitAnalysisTab::numberOfCustomFunctions(
 }
 
 void IndirectFitAnalysisTab::setModelFitFunction() {
-  auto future = QtConcurrent::run(
-      m_fitPropertyBrowser, &IndirectFitPropertyBrowser::getFittingFunction);
-
-  while (future.isRunning()) {
-    qApp->processEvents();
-  }
-
-  m_fittingModel->setFitFunction(future.result());
+  auto func = m_fitPropertyBrowser->getFittingFunction();
+  m_fittingModel->setFitFunction(func);
 }
 
 void IndirectFitAnalysisTab::setModelStartX(double startX) {

--- a/qt/scientific_interfaces/Indirect/IndirectFunctionBrowser/ConvTemplatePresenter.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectFunctionBrowser/ConvTemplatePresenter.cpp
@@ -48,18 +48,12 @@ ConvTemplatePresenter::ConvTemplatePresenter(ConvTemplateBrowser *view)
 // continue which is necessary to stop the int manager from self-incrementing
 // itself due to an internal timer occurring within the class
 void ConvTemplatePresenter::setSubType(size_t subTypeIndex, int typeIndex) {
-  auto fun = [this, subTypeIndex, typeIndex]() {
-    if (subTypeIndex == SubTypeIndex::Fit) {
-      m_model.setFitType(static_cast<FitType>(typeIndex));
-    } else if (subTypeIndex == SubTypeIndex::Lorentzian) {
-      m_model.setLorentzianType(static_cast<LorentzianType>(typeIndex));
-    } else {
-      m_model.setBackground(static_cast<BackgroundType>(typeIndex));
-    }
-  };
-  auto future = QtConcurrent::run(fun);
-  while (future.isRunning()) {
-    qApp->processEvents();
+  if (subTypeIndex == SubTypeIndex::Fit) {
+    m_model.setFitType(static_cast<FitType>(typeIndex));
+  } else if (subTypeIndex == SubTypeIndex::Lorentzian) {
+    m_model.setLorentzianType(static_cast<LorentzianType>(typeIndex));
+  } else {
+    m_model.setBackground(static_cast<BackgroundType>(typeIndex));
   }
   m_view->setSubType(subTypeIndex, typeIndex);
   setErrorsEnabled(false);

--- a/qt/widgets/common/src/QtPropertyBrowser/qteditorfactory.cpp
+++ b/qt/widgets/common/src/QtPropertyBrowser/qteditorfactory.cpp
@@ -175,58 +175,6 @@ QtSpinBoxFactoryReadOnly::~QtSpinBoxFactoryReadOnly() {
   delete d_ptr;
 }
 
-/**
-    \internal
-
-    Reimplemented from the QtAbstractEditorFactory class.
-*/
-template <class SpinBox>
-void QtSpinBoxFactoryBase<SpinBox>::connectPropertyManager(
-    QtIntPropertyManager *manager) {
-  connect(manager, SIGNAL(valueChanged(QtProperty *, int)), this,
-          SLOT(slotPropertyChanged(QtProperty *, int)));
-  connect(manager, SIGNAL(rangeChanged(QtProperty *, int, int)), this,
-          SLOT(slotRangeChanged(QtProperty *, int, int)));
-  connect(manager, SIGNAL(singleStepChanged(QtProperty *, int)), this,
-          SLOT(slotSingleStepChanged(QtProperty *, int)));
-}
-
-/**
-    \internal
-
-    Reimplemented from the QtAbstractEditorFactory class.
-*/
-template <class SpinBox>
-QWidget *QtSpinBoxFactoryBase<SpinBox>::createEditorForManager(
-    QtIntPropertyManager *manager, QtProperty *property, QWidget *parent) {
-  auto *editor = d_ptr->createEditor(property, parent);
-  editor->setSingleStep(manager->singleStep(property));
-  editor->setRange(manager->minimum(property), manager->maximum(property));
-  editor->setValue(manager->value(property));
-  editor->setKeyboardTracking(false);
-
-  connect(editor, SIGNAL(valueChanged(int)), this, SLOT(slotSetValue(int)));
-  connect(editor, SIGNAL(destroyed(QObject *)), this,
-          SLOT(slotEditorDestroyed(QObject *)));
-  return editor;
-}
-
-/**
-    \internal
-
-    Reimplemented from the QtAbstractEditorFactory class.
-*/
-template <class SpinBox>
-void QtSpinBoxFactoryBase<SpinBox>::disconnectPropertyManager(
-    QtIntPropertyManager *manager) {
-  disconnect(manager, SIGNAL(valueChanged(QtProperty *, int)), this,
-             SLOT(slotPropertyChanged(QtProperty *, int)));
-  disconnect(manager, SIGNAL(rangeChanged(QtProperty *, int, int)), this,
-             SLOT(slotRangeChanged(QtProperty *, int, int)));
-  disconnect(manager, SIGNAL(singleStepChanged(QtProperty *, int)), this,
-             SLOT(slotSingleStepChanged(QtProperty *, int)));
-}
-
 // QtSliderFactory
 
 void QtSliderFactoryPrivate::slotPropertyChanged(QtProperty *property,

--- a/qt/widgets/common/src/QtPropertyBrowser/qteditorfactory.cpp
+++ b/qt/widgets/common/src/QtPropertyBrowser/qteditorfactory.cpp
@@ -138,7 +138,7 @@ static inline void setupTreeViewEditorMargin(QLayout *lt) {
 QtSpinBoxFactory::QtSpinBoxFactory(QObject *parent)
     : QtSpinBoxFactoryBase<QSpinBox>(parent) {
   d_ptr = new QtSpinBoxFactoryPrivate();
-  initailiseQPtr();
+  initializeQPtr();
 }
 
 /**
@@ -149,11 +149,11 @@ QtSpinBoxFactory::~QtSpinBoxFactory() {
   delete d_ptr;
 }
 /**
-    \class QtSpinBoxFactoryReadOnly
+    \class QtSpinBoxFactoryNoTimer
 
     \brief The QtSpinBoxFactory class provides QSpinBox widgets for
-    properties created by QtIntPropertyManager objects. The linedit of
-    the spinbox is read only.
+    properties created by QtIntPropertyManager objects. The spinbox has
+    a custom timer event to avoid double incrementing when the slot lags.
 
     \sa QtAbstractEditorFactory, QtIntPropertyManager
 */
@@ -161,16 +161,16 @@ QtSpinBoxFactory::~QtSpinBoxFactory() {
 /**
     Creates a factory with the given \a parent.
 */
-QtSpinBoxFactoryReadOnly::QtSpinBoxFactoryReadOnly(QObject *parent)
-    : QtSpinBoxFactoryBase<QSpinBoxReadOnly>(parent) {
-  d_ptr = new QtSpinBoxFactoryReadOnlyPrivate();
-  initailiseQPtr();
+QtSpinBoxFactoryNoTimer::QtSpinBoxFactoryNoTimer(QObject *parent)
+    : QtSpinBoxFactoryBase<QSpinBoxNoTimer>(parent) {
+  d_ptr = new QtSpinBoxFactoryNoTimerPrivate();
+  initializeQPtr();
 }
 
 /**
     Destroys this factory, and all the widgets it has created.
 */
-QtSpinBoxFactoryReadOnly::~QtSpinBoxFactoryReadOnly() {
+QtSpinBoxFactoryNoTimer::~QtSpinBoxFactoryNoTimer() {
   qDeleteAll(d_ptr->m_editorToProperty.keys());
   delete d_ptr;
 }


### PR DESCRIPTION
**Description of work.**
This PR fixes a crash in the IDA GUI which occurs when a value is entered into one of the spinbox using the keyboard and `enter` pressed. To circumvent the issue for the time being, this PR implements a SpinBox factory which creates spinboxes with a read only lineedit.  

_**The problem that lead here:**_
This issue came about while fixing another issue with the spinbox, where they could doubly increment while we were holding onto the GUI thread. This caused the spinbox to think the mouse was being held down. To avoid this we offloaded some of the processing onto a separate thread and while that was running we called qApp->processEvents().

**_The issue now:_**
When the spinbox is changed a propertyChanged signal is emitted. This is connected to the intChanged slot in ConvTemplateBrowser.cpp (L391). This calls the presenter to update the model and subsequently the view, using the function setSubType in the ConvTemplatePresenter.cpp (L50). Here, we use a QtConncurrent::run call so we can keep processing the GUI events using qApp->processEvents()).

```
auto future = QtConcurrent::run(fun);
 while (future.isRunning()) 
 qApp->processEvents();
 } 

```
While we are processing these events, QT dispatches a deleteLater event for our spinbox, which means by the time we've returned from the slot our spinbox has been deleted - hence causing a hard crash. The cause of this delete call is as yet unknown. So for now we've implemented a temporary fix.  In the future we should try:

- Updating the PropertyBrowser code, which is available here: https://code.qt.io/cgit/qt/qttools.git/tree/src/shared/qtpropertybrowser?h=5.8
- Try it again on Qt 5.14 as it may be related to this bug https://bugreports.qt.io/browse/QTBUG-40

**To test:**
- Data to test the GUI can be found in #26631.
- Open the IDA GUI
- Go to to the IqtFit tab
- Load data
- Change the exponentials spinbox, it shouldn't crash and should't accept keyboard inputs.
- Do the same for ConvFit (it should behave the same)
<!-- Instructions for testing. -->

Fixes #29111. <!-- and fix #xxxx or close #xxxx xor resolves #xxxx -->
<!-- alternative
*There is no associated issue.*
-->


*This does not require release notes* because **as it was introduced this release**


---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
