### PR TITLE
Update axesfunctions.py

### DIFF
--- a/Framework/PythonInterface/mantid/plots/axesfunctions.py
+++ b/Framework/PythonInterface/mantid/plots/axesfunctions.py
@@ -72,7 +72,7 @@ def _setLabels1D(axes,
     '''
     labels = get_axes_labels(workspace, indices, normalize_by_bin_width)
     # We assume that previous checking has ensured axis can only be 1 of 2 types
-    axes.set_xlabel(labels[1 if axis == MantidAxType.SPECTRUM else 2])
+    axes.set_xlabel(labels[2 if axis == MantidAxType.BIN else 1])
     axes.set_ylabel(labels[0])
 
 


### PR DESCRIPTION
**Description of work.**

1D x_label does not show up for plotting MDHisto workspaces (the axis parameter is None, not MantidAxType)

**To test:**
```python
from mantid.simpleapi import *
import matplotlib.pyplot as plt
from mantid import plots

ws = CreateMDHistoWorkspace(SignalInput='1,2,3,4,5',
                            ErrorInput='1,1,1,1,1',
                            Dimensionality=1,
                            Extents='0.5,5.5',
                            NumberOfBins='5',
                            Names='DeltaE',
                            Units='meV')
fig, ax = plt.subplots(subplot_kw={'projection': 'mantid'})
ax.plot(ws)
fig.show()
```
Look at the x axis label. It should show $\Delta E$ (before it was empty)

*There is no associated issue.*

*This does not require release notes* because **minor bug**

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
