### PR TITLE
Fix check for ORNL's vgl-wrapper script

### DIFF
--- a/buildconfig/CMake/LinuxPackageScripts.cmake
+++ b/buildconfig/CMake/LinuxPackageScripts.cmake
@@ -153,7 +153,7 @@ if [ -n \"\${NXSESSIONID}\" ]; then  # running in nx
   VGLRUN=\"vglrun\"
 elif [ -n \"\${TLSESSIONDATA}\" ]; then  # running in thin-linc
   command -v vglrun >/dev/null 2>&1 || { echo >&2 \"MantidPlot requires VirtualGL but it's not installed.  Aborting.\"; exit 1; }
-  if [ command -v vgl-wrapper.sh ]; then
+  if [ \$(command -v vgl-wrapper.sh) ]; then
     VGLRUN=\"vgl-wrapper.sh\"
   else
     VGLRUN=\"vglrun\"


### PR DESCRIPTION
Starting `mantidworkbench` at ORNL was giving a warning about an error in the bash script, then start the workbench. This change fixes that issue.

**To test:**

Start mantidworkbench through thin-linc at ORNL.

*There is no associated issue.*


*This does not require release notes* because it fixes an issue that people have been ignoring/not noticed.

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
