### PR TITLE
Fix Indirect Data Analysis not load multiple spectra from a single ws in F(Q) fit

### DIFF
--- a/docs/source/release/v5.1.0/indirect_geometry.rst
+++ b/docs/source/release/v5.1.0/indirect_geometry.rst
@@ -49,5 +49,6 @@ Bug Fixes
   (i.e. free molecules). Previously, data files from such calculations
   would yield a parsing error.
 - Fixed errors with the temperature correction in the ConvFit tab of the Indirect Data Analysis interface. These issues occurred when the function was evaluated at Q=0, where it is undefined.
+- Indirect Data Analysis F(Q) fit multiple workspaces can now load more than one spectra from each workspace.
 
 :ref:`Release 5.1.0 <v5.1.0>`

--- a/qt/scientific_interfaces/Indirect/IndirectFitDataModel.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectFitDataModel.cpp
@@ -205,11 +205,15 @@ void IndirectFitDataModel::addWorkspace(const std::string &workspaceName,
 
 void IndirectFitDataModel::addWorkspace(
     Mantid::API::MatrixWorkspace_sptr workspace, const Spectra &spectra) {
-  if (!m_fittingData->empty() &&
-      equivalentWorkspaces(workspace, m_fittingData->back().workspace()))
-    m_fittingData->back().combine(IndirectFitData(workspace, spectra));
-  else
-    addNewWorkspace(workspace, spectra);
+  if (!m_fittingData->empty()) {
+    for (auto i = m_fittingData->begin(); i != m_fittingData->end(); ++i) {
+      if (equivalentWorkspaces(workspace, i->workspace())) {
+        i->combine(IndirectFitData(workspace, spectra));
+        return;
+      }
+    }
+  }
+  addNewWorkspace(workspace, spectra);
 }
 
 FitDomainIndex

--- a/qt/scientific_interfaces/Indirect/IndirectFitDataModel.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectFitDataModel.cpp
@@ -206,9 +206,9 @@ void IndirectFitDataModel::addWorkspace(const std::string &workspaceName,
 void IndirectFitDataModel::addWorkspace(
     Mantid::API::MatrixWorkspace_sptr workspace, const Spectra &spectra) {
   if (!m_fittingData->empty()) {
-    for (auto i = m_fittingData->begin(); i != m_fittingData->end(); ++i) {
-      if (equivalentWorkspaces(workspace, i->workspace())) {
-        i->combine(IndirectFitData(workspace, spectra));
+    for (auto i : *m_fittingData) {
+      if (equivalentWorkspaces(workspace, i.workspace())) {
+        i.combine(IndirectFitData(workspace, spectra));
         return;
       }
     }

--- a/qt/scientific_interfaces/Indirect/IndirectFitPlotPresenter.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectFitPlotPresenter.cpp
@@ -194,10 +194,15 @@ void IndirectFitPlotPresenter::disablePlotGuessInSeparateWindow() {
 
 void IndirectFitPlotPresenter::appendLastDataToSelection() {
   const auto workspaceCount = m_model->numberOfWorkspaces();
-  if (m_view->dataSelectionSize() == workspaceCount)
-    m_view->setNameInDataSelection(m_model->getLastFitDataName(),
-                                   workspaceCount - TableDatasetIndex{1});
-  else
+  if (m_view->dataSelectionSize() == workspaceCount) {
+    // if adding a spectra to an existing workspace, update all the combo box entires.
+    for (int i = 0; i < workspaceCount.value; i++) {
+      m_model->getFitDataName(TableDatasetIndex(i));
+      m_view->setNameInDataSelection(
+          m_model->getFitDataName(TableDatasetIndex(i)),
+          TableDatasetIndex(i));
+    }
+  } else
     m_view->appendToDataSelection(m_model->getLastFitDataName());
 }
 

--- a/qt/scientific_interfaces/Indirect/IndirectFitPlotPresenter.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectFitPlotPresenter.cpp
@@ -198,7 +198,6 @@ void IndirectFitPlotPresenter::appendLastDataToSelection() {
     // if adding a spectra to an existing workspace, update all the combo box
     // entires.
     for (int i = 0; i < workspaceCount.value; i++) {
-      m_model->getFitDataName(TableDatasetIndex(i));
       m_view->setNameInDataSelection(
           m_model->getFitDataName(TableDatasetIndex(i)), TableDatasetIndex(i));
     }

--- a/qt/scientific_interfaces/Indirect/IndirectFitPlotPresenter.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectFitPlotPresenter.cpp
@@ -196,7 +196,7 @@ void IndirectFitPlotPresenter::appendLastDataToSelection() {
   const auto workspaceCount = m_model->numberOfWorkspaces();
   if (m_view->dataSelectionSize() == workspaceCount) {
     // if adding a spectra to an existing workspace, update all the combo box
-    // entires.
+    // entries.
     for (size_t i = 0; i < workspaceCount.value; i++) {
       m_view->setNameInDataSelection(
           m_model->getFitDataName(TableDatasetIndex(i)), TableDatasetIndex(i));

--- a/qt/scientific_interfaces/Indirect/IndirectFitPlotPresenter.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectFitPlotPresenter.cpp
@@ -197,7 +197,7 @@ void IndirectFitPlotPresenter::appendLastDataToSelection() {
   if (m_view->dataSelectionSize() == workspaceCount) {
     // if adding a spectra to an existing workspace, update all the combo box
     // entires.
-    for (int i = 0; i < workspaceCount.value; i++) {
+    for (size_t i = 0; i < workspaceCount.value; i++) {
       m_view->setNameInDataSelection(
           m_model->getFitDataName(TableDatasetIndex(i)), TableDatasetIndex(i));
     }

--- a/qt/scientific_interfaces/Indirect/IndirectFitPlotPresenter.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectFitPlotPresenter.cpp
@@ -195,12 +195,12 @@ void IndirectFitPlotPresenter::disablePlotGuessInSeparateWindow() {
 void IndirectFitPlotPresenter::appendLastDataToSelection() {
   const auto workspaceCount = m_model->numberOfWorkspaces();
   if (m_view->dataSelectionSize() == workspaceCount) {
-    // if adding a spectra to an existing workspace, update all the combo box entires.
+    // if adding a spectra to an existing workspace, update all the combo box
+    // entires.
     for (int i = 0; i < workspaceCount.value; i++) {
       m_model->getFitDataName(TableDatasetIndex(i));
       m_view->setNameInDataSelection(
-          m_model->getFitDataName(TableDatasetIndex(i)),
-          TableDatasetIndex(i));
+          m_model->getFitDataName(TableDatasetIndex(i)), TableDatasetIndex(i));
     }
   } else
     m_view->appendToDataSelection(m_model->getLastFitDataName());

--- a/qt/scientific_interfaces/Indirect/JumpFitDataPresenter.cpp
+++ b/qt/scientific_interfaces/Indirect/JumpFitDataPresenter.cpp
@@ -246,12 +246,12 @@ void JumpFitDataPresenter::setDataIndexToCurrentWorkspace(
   //  and the vector in m_fitDataModel which is in the base class
   //  indirectFittingModel get table workspace index
   const auto wsName = dialog->workspaceName().append("_HWHM");
-  auto wsVector = m_jumpModel->m_fitDataModel->getWorkspaceNames();
   // This a vector of workspace names currently loaded
-  auto wsIt = std::find(wsVector.begin(), wsVector.end(), wsName);
+  auto wsVector = m_jumpModel->m_fitDataModel->getWorkspaceNames();
   // this is an iterator pointing to the current wsName in wsVector
-  int index = std::distance(wsVector.begin(), wsIt);
+  auto wsIt = std::find(wsVector.begin(), wsVector.end(), wsName);
   // this is the index of the workspace.
+  int index = int(std::distance(wsVector.begin(), wsIt));
   updateActiveDataIndex(index);
 }
 

--- a/qt/scientific_interfaces/Indirect/JumpFitDataPresenter.cpp
+++ b/qt/scientific_interfaces/Indirect/JumpFitDataPresenter.cpp
@@ -95,6 +95,10 @@ void JumpFitDataPresenter::updateActiveDataIndex() {
   m_dataIndex = m_jumpModel->numberOfWorkspaces();
 }
 
+void JumpFitDataPresenter::updateActiveDataIndex(int index) {
+  m_dataIndex = index;
+}
+
 void JumpFitDataPresenter::updateAvailableParameters() {
   updateAvailableParameters(m_cbParameterType->currentText());
 }
@@ -202,6 +206,19 @@ void JumpFitDataPresenter::addWorkspace(IndirectFittingModel *model,
 void JumpFitDataPresenter::addDataToModel(IAddWorkspaceDialog const *dialog) {
   if (const auto jumpDialog =
           dynamic_cast<JumpFitAddWorkspaceDialog const *>(dialog)) {
+    //  update active data index with correct index based on the workspace name
+    //  and the vector in m_fitDataModel which is in the base class
+    //  indirectFittingModel get table workspace index
+    const auto wsName = jumpDialog->workspaceName().append("_HWHM");
+    auto wsVector = m_jumpModel->m_fitDataModel->getWorkspaceNames();
+    // This a vector of workspace names currently loaded
+    auto wsIt = std::find(wsVector.begin(), wsVector.end(), wsName);
+    // this is an iterator pointing to the current wsName in wsVector
+    int index = std::distance(wsVector.begin(), wsIt);
+    // this is the index of the workspace.
+    updateActiveDataIndex(index);
+    // here we can say that we are in multiple mode so we can append the spectra
+    // to the current one and then setspectra
     setModelSpectrum(jumpDialog->parameterNameIndex());
     updateActiveDataIndex();
   }
@@ -224,9 +241,11 @@ void JumpFitDataPresenter::setModelSpectrum(int index) {
   if (index < 0)
     throw std::runtime_error("No valid parameter was selected.");
   else if (m_activeParameterType == "Width")
-    m_jumpModel->setActiveWidth(static_cast<std::size_t>(index), m_dataIndex);
+    m_jumpModel->setActiveWidth(static_cast<std::size_t>(index), m_dataIndex,
+                                false);
   else
-    m_jumpModel->setActiveEISF(static_cast<std::size_t>(index), m_dataIndex);
+    m_jumpModel->setActiveEISF(static_cast<std::size_t>(index), m_dataIndex,
+                               false);
 }
 
 void JumpFitDataPresenter::closeDialog() {

--- a/qt/scientific_interfaces/Indirect/JumpFitDataPresenter.cpp
+++ b/qt/scientific_interfaces/Indirect/JumpFitDataPresenter.cpp
@@ -241,7 +241,7 @@ void JumpFitDataPresenter::setModelSpectrum(int index) {
 }
 
 void JumpFitDataPresenter::setDataIndexToCurrentWorkspace(
-    IAddWorkspaceDialog const* dialog) {
+    IAddWorkspaceDialog const *dialog) {
   //  update active data index with correct index based on the workspace name
   //  and the vector in m_fitDataModel which is in the base class
   //  indirectFittingModel get table workspace index

--- a/qt/scientific_interfaces/Indirect/JumpFitDataPresenter.cpp
+++ b/qt/scientific_interfaces/Indirect/JumpFitDataPresenter.cpp
@@ -173,6 +173,7 @@ void JumpFitDataPresenter::dialogParameterTypeUpdated(
 
 void JumpFitDataPresenter::updateParameterOptions(
     JumpFitAddWorkspaceDialog *dialog) {
+  setDataIndexToCurrentWorkspace(dialog);
   if (m_activeParameterType == "Width")
     dialog->setParameterNames(m_jumpModel->getWidths(m_dataIndex));
   else if (m_activeParameterType == "EISF")
@@ -183,6 +184,7 @@ void JumpFitDataPresenter::updateParameterOptions(
 
 void JumpFitDataPresenter::updateParameterTypes(
     JumpFitAddWorkspaceDialog *dialog) {
+  setDataIndexToCurrentWorkspace(dialog);
   dialog->setParameterTypes(getParameterTypes(m_dataIndex));
 }
 
@@ -206,17 +208,7 @@ void JumpFitDataPresenter::addWorkspace(IndirectFittingModel *model,
 void JumpFitDataPresenter::addDataToModel(IAddWorkspaceDialog const *dialog) {
   if (const auto jumpDialog =
           dynamic_cast<JumpFitAddWorkspaceDialog const *>(dialog)) {
-    //  update active data index with correct index based on the workspace name
-    //  and the vector in m_fitDataModel which is in the base class
-    //  indirectFittingModel get table workspace index
-    const auto wsName = jumpDialog->workspaceName().append("_HWHM");
-    auto wsVector = m_jumpModel->m_fitDataModel->getWorkspaceNames();
-    // This a vector of workspace names currently loaded
-    auto wsIt = std::find(wsVector.begin(), wsVector.end(), wsName);
-    // this is an iterator pointing to the current wsName in wsVector
-    int index = std::distance(wsVector.begin(), wsIt);
-    // this is the index of the workspace.
-    updateActiveDataIndex(index);
+    setDataIndexToCurrentWorkspace(jumpDialog);
     // here we can say that we are in multiple mode so we can append the spectra
     // to the current one and then setspectra
     setModelSpectrum(jumpDialog->parameterNameIndex());
@@ -246,6 +238,21 @@ void JumpFitDataPresenter::setModelSpectrum(int index) {
   else
     m_jumpModel->setActiveEISF(static_cast<std::size_t>(index), m_dataIndex,
                                false);
+}
+
+void JumpFitDataPresenter::setDataIndexToCurrentWorkspace(
+    IAddWorkspaceDialog const* dialog) {
+  //  update active data index with correct index based on the workspace name
+  //  and the vector in m_fitDataModel which is in the base class
+  //  indirectFittingModel get table workspace index
+  const auto wsName = dialog->workspaceName().append("_HWHM");
+  auto wsVector = m_jumpModel->m_fitDataModel->getWorkspaceNames();
+  // This a vector of workspace names currently loaded
+  auto wsIt = std::find(wsVector.begin(), wsVector.end(), wsName);
+  // this is an iterator pointing to the current wsName in wsVector
+  int index = std::distance(wsVector.begin(), wsIt);
+  // this is the index of the workspace.
+  updateActiveDataIndex(index);
 }
 
 void JumpFitDataPresenter::closeDialog() {

--- a/qt/scientific_interfaces/Indirect/JumpFitDataPresenter.h
+++ b/qt/scientific_interfaces/Indirect/JumpFitDataPresenter.h
@@ -68,8 +68,7 @@ private:
   std::vector<std::string> getParameterTypes(TableDatasetIndex dataIndex) const;
   void addWorkspace(IndirectFittingModel *model, const std::string &name);
   void setModelSpectrum(int index);
-  void JumpFitDataPresenter::setDataIndexToCurrentWorkspace(
-      IAddWorkspaceDialog const *dialog);
+  void setDataIndexToCurrentWorkspace(IAddWorkspaceDialog const *dialog);
 
   void setMultiInputResolutionFBSuffixes(IAddWorkspaceDialog *dialog) override;
   void setMultiInputResolutionWSSuffixes(IAddWorkspaceDialog *dialog) override;

--- a/qt/scientific_interfaces/Indirect/JumpFitDataPresenter.h
+++ b/qt/scientific_interfaces/Indirect/JumpFitDataPresenter.h
@@ -68,6 +68,8 @@ private:
   std::vector<std::string> getParameterTypes(TableDatasetIndex dataIndex) const;
   void addWorkspace(IndirectFittingModel *model, const std::string &name);
   void setModelSpectrum(int index);
+  void JumpFitDataPresenter::setDataIndexToCurrentWorkspace(
+      IAddWorkspaceDialog const *dialog);
 
   void setMultiInputResolutionFBSuffixes(IAddWorkspaceDialog *dialog) override;
   void setMultiInputResolutionWSSuffixes(IAddWorkspaceDialog *dialog) override;

--- a/qt/scientific_interfaces/Indirect/JumpFitDataPresenter.h
+++ b/qt/scientific_interfaces/Indirect/JumpFitDataPresenter.h
@@ -44,6 +44,7 @@ private slots:
                                const std::string &workspace);
   void setActiveParameterType(const std::string &type);
   void updateActiveDataIndex();
+  void updateActiveDataIndex(int index);
   void setSingleModelSpectrum(int index);
   void handleParameterTypeChanged(const QString &parameter);
   void handleSpectrumSelectionChanged(int parameterIndex);

--- a/qt/scientific_interfaces/Indirect/JumpFitModel.cpp
+++ b/qt/scientific_interfaces/Indirect/JumpFitModel.cpp
@@ -293,8 +293,8 @@ void JumpFitModel::setActiveWidth(std::size_t widthIndex,
              // existing spectra list.
       auto spectra_vec = std::vector<std::size_t>({widthSpectra[widthIndex]});
       auto spectra = getSpectra(dataIndex);
-      for (size_t i = 0; i < spectra.size().value; i++) {
-        spectra_vec.push_back(spectra[i].value);
+      for (auto i : spectra) {
+        spectra_vec.push_back(i.value);
       }
       setSpectra(createSpectra(spectra_vec), dataIndex);
     }

--- a/qt/scientific_interfaces/Indirect/JumpFitModel.cpp
+++ b/qt/scientific_interfaces/Indirect/JumpFitModel.cpp
@@ -243,8 +243,7 @@ void JumpFitModel::addWorkspace(const std::string &workspaceName) {
 
   const auto hwhmWorkspace =
       createHWHMWorkspace(workspace, name, parameters.widthSpectra);
-  IndirectFittingModel::addWorkspace(hwhmWorkspace->getName(),
-                                     Spectra(createSpectra(spectrum.get())));
+  IndirectFittingModel::addWorkspace(hwhmWorkspace->getName(), Spectra(""));
 }
 
 void JumpFitModel::removeWorkspace(TableDatasetIndex index) {
@@ -281,28 +280,47 @@ std::string JumpFitModel::getFitParameterName(TableDatasetIndex dataIndex,
 }
 
 void JumpFitModel::setActiveWidth(std::size_t widthIndex,
-                                  TableDatasetIndex dataIndex) {
+                                  TableDatasetIndex dataIndex, bool single) {
   const auto parametersIt = findJumpFitParameters(dataIndex);
   if (parametersIt != m_jumpParameters.end() &&
       parametersIt->second.widthSpectra.size() > widthIndex) {
     const auto &widthSpectra = parametersIt->second.widthSpectra;
-
-    setSpectra(
-        createSpectra(std::vector<std::size_t>({widthSpectra[widthIndex]})),
-        dataIndex);
+    if (single == true) {
+      setSpectra(
+          createSpectra(std::vector<std::size_t>({widthSpectra[widthIndex]})),
+          dataIndex);
+    } else { // In multiple mode the spectra needs to be appending on the
+             // existing spectra list.
+      auto spectra_vec = std::vector<std::size_t>({widthSpectra[widthIndex]});
+      auto spectra = getSpectra(dataIndex);
+      for (size_t i = 0; i < spectra.size().value; i++) {
+        spectra_vec.push_back(spectra[i].value);
+      }
+      setSpectra(createSpectra(spectra_vec), dataIndex);
+    }
   } else
     logger.warning("Invalid width index specified.");
 }
 
 void JumpFitModel::setActiveEISF(std::size_t eisfIndex,
-                                 TableDatasetIndex dataIndex) {
+                                 TableDatasetIndex dataIndex, bool single) {
   const auto parametersIt = findJumpFitParameters(dataIndex);
   if (parametersIt != m_jumpParameters.end() &&
       parametersIt->second.eisfSpectra.size() > eisfIndex) {
     const auto &eisfSpectra = parametersIt->second.eisfSpectra;
-    setSpectra(
-        createSpectra(std::vector<std::size_t>({eisfSpectra[eisfIndex]})),
-        dataIndex);
+    if (single == true) {
+      setSpectra(
+          createSpectra(std::vector<std::size_t>({eisfSpectra[eisfIndex]})),
+          dataIndex);
+    } else { // In multiple mode the spectra needs to be appending on the
+             // existing spectra list.
+      auto spectra_vec = std::vector<std::size_t>({eisfSpectra[eisfIndex]});
+      auto spectra = getSpectra(dataIndex);
+      for (size_t i = 0; i < spectra.size().value; i++) {
+        spectra_vec.push_back(spectra[i].value);
+      }
+      setSpectra(createSpectra(spectra_vec), dataIndex);
+    }
   } else
     logger.warning("Invalid EISF index specified.");
 }

--- a/qt/scientific_interfaces/Indirect/JumpFitModel.h
+++ b/qt/scientific_interfaces/Indirect/JumpFitModel.h
@@ -41,8 +41,10 @@ public:
   getWidthSpectrum(std::size_t widthIndex, TableDatasetIndex dataIndex) const;
   boost::optional<std::size_t>
   getEISFSpectrum(std::size_t eisfIndex, TableDatasetIndex dataIndex) const;
-  void setActiveWidth(std::size_t widthIndex, TableDatasetIndex dataIndex);
-  void setActiveEISF(std::size_t eisfIndex, TableDatasetIndex dataIndex);
+  void setActiveWidth(std::size_t widthIndex, TableDatasetIndex dataIndex,
+                      bool single = true);
+  void setActiveEISF(std::size_t eisfIndex, TableDatasetIndex dataIndex,
+                     bool single = true);
 
 private:
   bool

--- a/qt/scientific_interfaces/Indirect/test/IndirectFitPlotPresenterTest.h
+++ b/qt/scientific_interfaces/Indirect/test/IndirectFitPlotPresenterTest.h
@@ -562,22 +562,32 @@ public:
 
   void
   test_that_appendLastDataToSelection_will_set_the_name_of_the_data_selection_if_the_dataSelectionSize_and_numberOfWorkspaces_are_equal() {
-    TableDatasetIndex const index(1);
+    TableDatasetIndex const index1(1);
+    TableDatasetIndex const index2(1);
 
     ON_CALL(*m_view, dataSelectionSize())
         .WillByDefault(Return(TableDatasetIndex(2)));
     ON_CALL(*m_fittingModel, numberOfWorkspaces())
         .WillByDefault(Return(TableDatasetIndex(2)));
+    ON_CALL(*m_fittingModel, createDisplayName(TableDatasetIndex(0)))
+        .WillByDefault(Return("DisplayName-0"));
     ON_CALL(*m_fittingModel, createDisplayName(TableDatasetIndex(1)))
         .WillByDefault(Return("DisplayName-1"));
-    ON_CALL(*m_fittingModel, getWorkspace(index))
+    ON_CALL(*m_fittingModel, getWorkspace(index1))
+        .WillByDefault(Return(m_ads->retrieveWorkspace("WorkspaceName")));
+    ON_CALL(*m_fittingModel, getWorkspace(index2))
         .WillByDefault(Return(m_ads->retrieveWorkspace("WorkspaceName")));
 
-    Expectation createName =
-        EXPECT_CALL(*m_fittingModel, createDisplayName(index)).Times(1);
+    Expectation createName1 =
+        EXPECT_CALL(*m_fittingModel, createDisplayName(index1)).Times(1);
+    EXPECT_CALL(*m_view, setNameInDataSelection("DisplayName-0", index))
+        .Times(1)
+        .After(createName1);
+    Expectation createName2 =
+        EXPECT_CALL(*m_fittingModel, createDisplayName(index2)).Times(1);
     EXPECT_CALL(*m_view, setNameInDataSelection("DisplayName-1", index))
         .Times(1)
-        .After(createName);
+        .After(createName2);
 
     m_presenter->appendLastDataToSelection();
   }

--- a/qt/scientific_interfaces/Indirect/test/IndirectFitPlotPresenterTest.h
+++ b/qt/scientific_interfaces/Indirect/test/IndirectFitPlotPresenterTest.h
@@ -562,7 +562,7 @@ public:
 
   void
   test_that_appendLastDataToSelection_will_set_the_name_of_the_data_selection_if_the_dataSelectionSize_and_numberOfWorkspaces_are_equal() {
-    TableDatasetIndex const index1(1);
+    TableDatasetIndex const index1(0);
     TableDatasetIndex const index2(1);
 
     ON_CALL(*m_view, dataSelectionSize())
@@ -580,12 +580,12 @@ public:
 
     Expectation createName1 =
         EXPECT_CALL(*m_fittingModel, createDisplayName(index1)).Times(1);
-    EXPECT_CALL(*m_view, setNameInDataSelection("DisplayName-0", index))
+    EXPECT_CALL(*m_view, setNameInDataSelection("DisplayName-0", index1))
         .Times(1)
         .After(createName1);
     Expectation createName2 =
         EXPECT_CALL(*m_fittingModel, createDisplayName(index2)).Times(1);
-    EXPECT_CALL(*m_view, setNameInDataSelection("DisplayName-1", index))
+    EXPECT_CALL(*m_view, setNameInDataSelection("DisplayName-1", index2))
         .Times(1)
         .After(createName2);
 

--- a/qt/scientific_interfaces/Indirect/test/JumpFitDataPresenterTest.h
+++ b/qt/scientific_interfaces/Indirect/test/JumpFitDataPresenterTest.h
@@ -202,6 +202,9 @@ public:
     TS_ASSERT_EQUALS(m_model->numberOfWorkspaces(), TableDatasetIndex{1});
   }
 
+  /// TODO: Add unittests for setDataIndexToCurrentWorkspace when mainanence
+  /// makes tests simpler.
+
   ///----------------------------------------------------------------------
   /// Unit Tests that test the signals, methods and slots of the presenter
   ///----------------------------------------------------------------------

--- a/qt/scientific_interfaces/Indirect/test/JumpFitModelTest.h
+++ b/qt/scientific_interfaces/Indirect/test/JumpFitModelTest.h
@@ -234,6 +234,9 @@ public:
                      3);
   }
 
+  /// TODO: Add unittests for setActiveWidth and setActiveELSF when mainanence
+  /// makes tests simpler.
+
 private:
   template <typename Workspace, typename... Workspaces>
   void addWorkspacesToModel(Spectra const &spectra, Workspace const &workspace,


### PR DESCRIPTION
**Description of work**

This PR makes it so that the multiple workspaces tab on the indirect data analysis f(q) fit tab can accept multiple spectra from a single workspace. Previously if a second spectra was added from the same workspace it would not be accepted.

re: #28527

**To test:**

1. Load test data.
1. open Indirect Data Analysis
2. go to the F(Q) fit tab and switch to multiple input mode.
4. click add workspace, change from file to workspace.
5. add width data from workspace, add a different spectra from the same workspace.
6. change to a different workspace and add a spectra.
7. these spectra should all be availalbe to fit.
8. Try messing with it in other ways to get it to break.

Fixes #28527


---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
