### PR TITLE
Add PythonNotebook.rst to Concepts category

### DIFF
--- a/docs/source/concepts/PythonNotebook.rst
+++ b/docs/source/concepts/PythonNotebook.rst
@@ -1,4 +1,4 @@
-.. _JupyterNotebook:
+.. _PythonNotebook:
 
 ==========================
 MantidPython and Notebook
@@ -116,3 +116,5 @@ Script and Notebook Generation
 ==============================
 
 After processing a workspace in Mantid, the history of how this data was manipulated can be converted to a script or a notebook, with the use of :ref:`algm-GeneratePythonScript` or :ref:`algm-GenerateIPythonNotebook` respectively.
+
+.. categories:: Concepts


### PR DESCRIPTION
**Description of work.**

Small change so that https://docs.mantidproject.org/nightly/concepts/PythonNotebook.html can be found here: https://docs.mantidproject.org/nightly/concepts/index.html

I also renamed the inline link in the from JupyterNotebook to PythonNotebook for consistency.

**To test:**
- Build `docs-html`
- Check there is a link in the `concepts/index.html` page to `PythonNotebook.html` or "MantidPython and Notebook"

*There is no associated issue.*

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
-->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
