### PR TITLE
Added Algorithm Aliases to Alg Toolbox on Workbench

### DIFF
--- a/Framework/API/inc/MantidAPI/AlgorithmFactory.h
+++ b/Framework/API/inc/MantidAPI/AlgorithmFactory.h
@@ -12,6 +12,7 @@
 #include "MantidAPI/DllConfig.h"
 #include "MantidKernel/DynamicFactory.h"
 #include "MantidKernel/SingletonHolder.h"
+#include <boost/optional.hpp>
 #include <memory>
 #include <sstream>
 #include <unordered_map>
@@ -115,7 +116,8 @@ public:
   const std::vector<std::string> getKeys(bool includeHidden) const;
 
   /// Get an algorithms name from the alias map
-  std::string getNameFromAliasMap(const std::string &algorithmName) const;
+  //std::string getNameFromAliasMap(const std::string &algorithmName) const;
+  boost::optional<std::string>getRealNameFromAlias(const std::string &alias) const noexcept;
 
   /// Returns the highest version of the algorithm currently registered
   int highestVersion(const std::string &algorithmName) const;

--- a/Framework/API/inc/MantidAPI/AlgorithmFactory.h
+++ b/Framework/API/inc/MantidAPI/AlgorithmFactory.h
@@ -114,6 +114,9 @@ public:
   const std::vector<std::string> getKeys() const override;
   const std::vector<std::string> getKeys(bool includeHidden) const;
 
+  /// Get an algorithms name from the alias map
+  std::string getNameFromAliasMap(const std::string &algorithmName) const;
+
   /// Returns the highest version of the algorithm currently registered
   int highestVersion(const std::string &algorithmName) const;
 
@@ -126,7 +129,7 @@ public:
 
   /// Returns algorithm descriptors.
   std::vector<AlgorithmDescriptor>
-  getDescriptors(bool includeHidden = false, bool includeAliases = true) const;
+  getDescriptors(bool includeHidden = false, bool includeAliases = false) const;
 
   /// unmangles the names used as keys into the name and version
   std::pair<std::string, int> decodeName(const std::string &mangledName) const;
@@ -160,7 +163,7 @@ private:
   using VersionMap = std::map<std::string, int>;
   /// The map holding the registered class names and their highest versions
   VersionMap m_vmap;
-  /// A typedef for the map pf algorithm aliases
+  /// A typedef for the map of algorithm aliases
   using AliasMap = std::unordered_map<std::string, std::string>;
   /// The map holding the alias names of registered algorithms
   AliasMap m_amap;

--- a/Framework/API/inc/MantidAPI/AlgorithmFactory.h
+++ b/Framework/API/inc/MantidAPI/AlgorithmFactory.h
@@ -116,8 +116,8 @@ public:
   const std::vector<std::string> getKeys(bool includeHidden) const;
 
   /// Get an algorithms name from the alias map
-  //std::string getNameFromAliasMap(const std::string &algorithmName) const;
-  boost::optional<std::string>getRealNameFromAlias(const std::string &alias) const noexcept;
+  boost::optional<std::string>
+  getRealNameFromAlias(const std::string &alias) const noexcept;
 
   /// Returns the highest version of the algorithm currently registered
   int highestVersion(const std::string &algorithmName) const;

--- a/Framework/API/src/AlgorithmFactory.cpp
+++ b/Framework/API/src/AlgorithmFactory.cpp
@@ -382,8 +382,19 @@ AlgorithmFactoryImpl::getDescriptors(bool includeHidden) const {
         currentLayer.append("\\");
       }
 
-      if (!categoryIsHidden)
+      if (!categoryIsHidden) {
         res.emplace_back(desc);
+        // Check alias
+        if (desc.alias != "") {
+          // Create a new descriptor for the alias
+          AlgorithmDescriptor aliasDesc;
+          aliasDesc.name = desc.alias + " [" + desc.name + "]";
+          //aliasDesc.name = desc.alias;
+          aliasDesc.category = desc.category;
+          aliasDesc.version = desc.version;
+          res.emplace_back(aliasDesc);
+        }
+      }
     }
   }
   return res;

--- a/Framework/API/src/AlgorithmFactory.cpp
+++ b/Framework/API/src/AlgorithmFactory.cpp
@@ -58,7 +58,7 @@ AlgorithmFactoryImpl::create(const std::string &name,
   // Fallback, name might be an alias
   // Try get real name and create from that instead
   const auto realName = getRealNameFromAlias(name);
-  if (realName != boost::none) {
+  if (realName) {
     // Try create algorithm again with real name
     try {
       return this->createAlgorithm(realName.get(), local_version);

--- a/Framework/API/src/AlgorithmFactory.cpp
+++ b/Framework/API/src/AlgorithmFactory.cpp
@@ -64,7 +64,8 @@ AlgorithmFactoryImpl::create(const std::string &name,
       return this->createAlgorithm(realName.get(), local_version);
     } catch (Kernel::Exception::NotFoundError &) {
       // Get highest registered version
-      const auto hVersion = highestVersion(realName.get()); // Throws if not found
+      const auto hVersion =
+          highestVersion(realName.get()); // Throws if not found
 
       // The version registered does not match version supplied
       g_log.error() << "algorithm " << name << " version " << version
@@ -226,12 +227,12 @@ AlgorithmFactoryImpl::getKeys(bool includeHidden) const {
 }
 
 /**
- * @param algorithmName The name of the algorithm to look up in the alias map
+ * @param alias The name of the algorithm to look up in the alias map
  * @return Real name of algroithm if found
  */
-// std::string AlgorithmFactoryImpl::getNameFromAliasMap(
-//    const std::string &algorithmName) const {
-boost::optional<std::string> AlgorithmFactoryImpl::getRealNameFromAlias(const std::string &alias) const noexcept {
+boost::optional<std::string>
+AlgorithmFactoryImpl::getRealNameFromAlias(const std::string &alias) const
+    noexcept {
   auto a_it = m_amap.find(alias);
   if (a_it == m_amap.end())
     return boost::none;
@@ -420,7 +421,8 @@ AlgorithmFactoryImpl::getDescriptors(bool includeHidden,
           aliasDesc.category = desc.category;
           aliasDesc.version = desc.version;
           res.emplace_back(aliasDesc);*/
-          res.emplace_back(AlgorithmDescriptor{desc.alias, desc.version, desc.category, ""});
+          res.emplace_back(
+              AlgorithmDescriptor{desc.alias, desc.version, desc.category, ""});
         }
       }
     }

--- a/Framework/API/src/AlgorithmFactory.cpp
+++ b/Framework/API/src/AlgorithmFactory.cpp
@@ -63,14 +63,13 @@ AlgorithmFactoryImpl::create(const std::string &name,
     try {
       return this->createAlgorithm(realName, local_version);
     } catch (Kernel::Exception::NotFoundError &) {
-      // Get highest registered version 
+      // Get highest registered version
       const auto hVersion = highestVersion(realName); // Throws if not found
 
       // The version registered does not match version supplied
       g_log.error() << "algorithm " << name << " version " << version
                     << " is not registered \n";
-      g_log.error() << "the latest registered version is " << hVersion
-                    << '\n';
+      g_log.error() << "the latest registered version is " << hVersion << '\n';
       throw std::runtime_error("algorithm not registered " +
                                createName(name, local_version));
     }
@@ -231,7 +230,7 @@ AlgorithmFactoryImpl::getKeys(bool includeHidden) const {
  * @return Real name of algrotihm if found, otherwsie empty string
  */
 std::string AlgorithmFactoryImpl::getNameFromAliasMap(
-  const std::string& algorithmName) const {
+    const std::string &algorithmName) const {
   auto a_it = m_amap.find(algorithmName);
   if (a_it == m_amap.end())
     return "";

--- a/Framework/API/test/AlgorithmFactoryTest.h
+++ b/Framework/API/test/AlgorithmFactoryTest.h
@@ -140,9 +140,9 @@ public:
     auto &algFactory = AlgorithmFactory::Instance();
 
     TS_ASSERT_THROWS(algFactory.highestVersion("ToyAlgorithm"),
-                     const std::invalid_argument &);
+                     const std::runtime_error &);
     TS_ASSERT_THROWS(algFactory.highestVersion("Dog"),
-                     const std::invalid_argument &);
+                     const std::runtime_error &);
 
     algFactory.subscribe<ToyAlgorithm>();
     TS_ASSERT_EQUALS(1, algFactory.highestVersion("ToyAlgorithm"));

--- a/Framework/API/test/AlgorithmFactoryTest.h
+++ b/Framework/API/test/AlgorithmFactoryTest.h
@@ -125,20 +125,34 @@ public:
     TS_ASSERT_EQUALS(noOfAlgs - 1, keys.size());
   }
 
+  void test_getNameFromAliasMap() {
+    auto &algFactory = AlgorithmFactory::Instance();
+
+    const auto resultAlias = algFactory.getNameFromAliasMap("Dog");
+    const auto resultFakeAlias = algFactory.getNameFromAliasMap("Frog");
+
+    TS_ASSERT_EQUALS(resultAlias, "ToyAlgorithm");
+    TS_ASSERT_EQUALS(resultFakeAlias, "");
+  }
+
   void test_HighestVersion() {
     auto &algFactory = AlgorithmFactory::Instance();
 
     TS_ASSERT_THROWS(algFactory.highestVersion("ToyAlgorithm"),
                      const std::invalid_argument &);
+    TS_ASSERT_THROWS(algFactory.highestVersion("Dog"),
+                     const std::invalid_argument &);
 
     algFactory.subscribe<ToyAlgorithm>();
     TS_ASSERT_EQUALS(1, algFactory.highestVersion("ToyAlgorithm"));
+    TS_ASSERT_EQUALS(1, algFactory.highestVersion("Dog"));
 
     std::unique_ptr<Mantid::Kernel::AbstractInstantiator<Algorithm>> newTwo =
         std::make_unique<
             Mantid::Kernel::Instantiator<ToyAlgorithmTwo, Algorithm>>();
     algFactory.subscribe(std::move(newTwo));
     TS_ASSERT_EQUALS(2, algFactory.highestVersion("ToyAlgorithm"));
+    TS_ASSERT_EQUALS(2, algFactory.highestVersion("Dog"));
 
     algFactory.unsubscribe("ToyAlgorithm", 1);
     algFactory.unsubscribe("ToyAlgorithm", 2);

--- a/Framework/API/test/AlgorithmFactoryTest.h
+++ b/Framework/API/test/AlgorithmFactoryTest.h
@@ -10,6 +10,7 @@
 #include "MantidAPI/AlgorithmFactory.h"
 #include "MantidKernel/Instantiator.h"
 #include <algorithm>
+#include <boost/optional.hpp>
 #include <cxxtest/TestSuite.h>
 
 class AlgorithmFactoryTest : public CxxTest::TestSuite {
@@ -125,14 +126,14 @@ public:
     TS_ASSERT_EQUALS(noOfAlgs - 1, keys.size());
   }
 
-  void test_getNameFromAliasMap() {
+  void test_getRealNameFromAlias() {
     auto &algFactory = AlgorithmFactory::Instance();
 
-    const auto resultAlias = algFactory.getNameFromAliasMap("Dog");
-    const auto resultFakeAlias = algFactory.getNameFromAliasMap("Frog");
+    const auto resultAlias = algFactory.getRealNameFromAlias("Dog");
+    const auto resultFakeAlias = algFactory.getRealNameFromAlias("Frog");
 
-    TS_ASSERT_EQUALS(resultAlias, "ToyAlgorithm");
-    TS_ASSERT_EQUALS(resultFakeAlias, "");
+    TS_ASSERT_EQUALS(resultAlias.get(), "ToyAlgorithm");
+    TS_ASSERT_EQUALS(resultFakeAlias, boost::none);
   }
 
   void test_HighestVersion() {

--- a/Framework/API/test/AlgorithmFactoryTest.h
+++ b/Framework/API/test/AlgorithmFactoryTest.h
@@ -9,6 +9,7 @@
 #include "FakeAlgorithms.h"
 #include "MantidAPI/AlgorithmFactory.h"
 #include "MantidKernel/Instantiator.h"
+#include <algorithm>
 #include <cxxtest/TestSuite.h>
 
 class AlgorithmFactoryTest : public CxxTest::TestSuite {
@@ -154,6 +155,7 @@ public:
     algFactory.subscribe(std::move(newTwo));
 
     TS_ASSERT_THROWS_NOTHING(algFactory.create("ToyAlgorithm", -1));
+    TS_ASSERT_THROWS_NOTHING(algFactory.create("Dog", -1));
     TS_ASSERT_THROWS_ANYTHING(algFactory.create("AlgorithmDoesntExist", -1));
 
     TS_ASSERT_THROWS_NOTHING(algFactory.create("ToyAlgorithm", 1));
@@ -171,30 +173,116 @@ public:
     algFactory.unsubscribe("ToyAlgorithm", 2);
   }
 
-  void testGetDescriptors() {
+  void testGetDescriptorsWithoutAliases() {
     auto &algFactory = AlgorithmFactory::Instance();
-
-    algFactory.subscribe<ToyAlgorithm>();
     std::vector<AlgorithmDescriptor> descriptors;
-    TS_ASSERT_THROWS_NOTHING(descriptors = algFactory.getDescriptors(true));
+    descriptors = algFactory.getDescriptors(false, false);
+    const auto sizeDescExcludeBefore = descriptors.size();
+    algFactory.subscribe<ToyAlgorithm>();
+    descriptors = algFactory.getDescriptors(false, false);
+    const auto sizeDescExcludeAfter = descriptors.size();
 
-    size_t noOfAlgs = descriptors.size();
-    std::vector<AlgorithmDescriptor>::const_iterator descItr =
-        descriptors.begin();
-    bool foundAlg = false;
-    while (descItr != descriptors.end() && !foundAlg) {
-      foundAlg = ("Cat" == descItr->category) &&
-                 ("ToyAlgorithm" == descItr->name) &&
-                 ("Dog" == descItr->alias) && (1 == descItr->version);
-      ++descItr;
-    }
-    TS_ASSERT(foundAlg);
+    auto resAlg = std::find_if(
+        descriptors.cbegin(), descriptors.cend(),
+        [](const AlgorithmDescriptor &d) {
+          return (("Cat" == d.category) && ("ToyAlgorithm" == d.name) &&
+                  ("Dog" == d.alias) && (1 == d.version));
+        });
+
+    auto resAlias =
+        std::find_if(descriptors.cbegin(), descriptors.cend(),
+                     [](const AlgorithmDescriptor &d) {
+                       return (("Cat" == d.category) && ("Dog" == d.name) &&
+                               ("" == d.alias) && (1 == d.version));
+                     });
+
+    TS_ASSERT_EQUALS(sizeDescExcludeAfter - sizeDescExcludeBefore, 1);
+    TS_ASSERT(resAlg != descriptors.cend());
+    TS_ASSERT(resAlias == descriptors.cend());
 
     algFactory.unsubscribe("ToyAlgorithm", 1);
 
-    TS_ASSERT_THROWS_NOTHING(descriptors = algFactory.getDescriptors(true));
+    descriptors = algFactory.getDescriptors(true, false);
+    const auto sizeDescIncludeBefore = descriptors.size();
+    algFactory.subscribe<ToyAlgorithm>();
+    descriptors = algFactory.getDescriptors(true, false);
+    const auto sizeDescIncludeAfter = descriptors.size();
 
-    TS_ASSERT_EQUALS(noOfAlgs - 1, descriptors.size());
+    resAlg = std::find_if(descriptors.cbegin(), descriptors.cend(),
+                          [](const AlgorithmDescriptor &d) {
+                            return (("Cat" == d.category) &&
+                                    ("ToyAlgorithm" == d.name) &&
+                                    ("Dog" == d.alias) && (1 == d.version));
+                          });
+
+    resAlias =
+        std::find_if(descriptors.cbegin(), descriptors.cend(),
+                     [](const AlgorithmDescriptor &d) {
+                       return (("Cat" == d.category) && ("Dog" == d.name) &&
+                               ("" == d.alias) && (1 == d.version));
+                     });
+
+    TS_ASSERT_EQUALS(sizeDescIncludeAfter - sizeDescIncludeBefore, 1);
+    TS_ASSERT(resAlg != descriptors.cend());
+    TS_ASSERT(resAlias == descriptors.cend());
+
+    algFactory.unsubscribe("ToyAlgorithm", 1);
+  }
+
+  void testGetDescriptorsWithAliases() {
+    auto &algFactory = AlgorithmFactory::Instance();
+    std::vector<AlgorithmDescriptor> descriptors;
+    descriptors = algFactory.getDescriptors(false, true);
+    const auto sizeDescExcludeBefore = descriptors.size();
+    algFactory.subscribe<ToyAlgorithm>();
+    descriptors = algFactory.getDescriptors(false, true);
+    const auto sizeDescExcludeAfter = descriptors.size();
+
+    auto resAlg = std::find_if(
+        descriptors.cbegin(), descriptors.cend(),
+        [](const AlgorithmDescriptor &d) {
+          return (("Cat" == d.category) && ("ToyAlgorithm" == d.name) &&
+                  ("Dog" == d.alias) && (1 == d.version));
+        });
+
+    auto resAlias =
+        std::find_if(descriptors.cbegin(), descriptors.cend(),
+                     [](const AlgorithmDescriptor &d) {
+                       return (("Cat" == d.category) && ("Dog" == d.name) &&
+                               ("" == d.alias) && (1 == d.version));
+                     });
+
+    TS_ASSERT_EQUALS(sizeDescExcludeAfter - sizeDescExcludeBefore, 2);
+    TS_ASSERT(resAlg != descriptors.cend());
+    TS_ASSERT(resAlias != descriptors.cend());
+
+    algFactory.unsubscribe("ToyAlgorithm", 1);
+
+    descriptors = algFactory.getDescriptors(true, true);
+    const auto sizeDescIncludeBefore = descriptors.size();
+    algFactory.subscribe<ToyAlgorithm>();
+    descriptors = algFactory.getDescriptors(true, true);
+    const auto sizeDescIncludeAfter = descriptors.size();
+
+    resAlg = std::find_if(descriptors.cbegin(), descriptors.cend(),
+                          [](const AlgorithmDescriptor &d) {
+                            return (("Cat" == d.category) &&
+                                    ("ToyAlgorithm" == d.name) &&
+                                    ("Dog" == d.alias) && (1 == d.version));
+                          });
+
+    resAlias =
+        std::find_if(descriptors.cbegin(), descriptors.cend(),
+                     [](const AlgorithmDescriptor &d) {
+                       return (("Cat" == d.category) && ("Dog" == d.name) &&
+                               ("" == d.alias) && (1 == d.version));
+                     });
+
+    TS_ASSERT_EQUALS(sizeDescIncludeAfter - sizeDescIncludeBefore, 2);
+    TS_ASSERT(resAlg != descriptors.cend());
+    TS_ASSERT(resAlias != descriptors.cend());
+
+    algFactory.unsubscribe("ToyAlgorithm", 1);
   }
 
   void testGetCategories() {

--- a/Framework/API/test/AlgorithmPropertyTest.h
+++ b/Framework/API/test/AlgorithmPropertyTest.h
@@ -105,7 +105,7 @@ public:
   void test_An_Invalid_String_Returns_An_Appropriate_Error() {
     AlgorithmProperty testProp("CalculateStep");
     TS_ASSERT_EQUALS(testProp.setValue("{\"name\":\"ComplexSum\"}"),
-                     "Algorithm not registered ComplexSum");
+                     "AlgorithmFactory::highestVersion() - Unknown algorithm 'ComplexSum'");
   }
 
   void test_Alg_With_An_AlgorithmProperty_Accepts_Another_Algorithm() {

--- a/Framework/API/test/AlgorithmPropertyTest.h
+++ b/Framework/API/test/AlgorithmPropertyTest.h
@@ -104,8 +104,9 @@ public:
 
   void test_An_Invalid_String_Returns_An_Appropriate_Error() {
     AlgorithmProperty testProp("CalculateStep");
-    TS_ASSERT_EQUALS(testProp.setValue("{\"name\":\"ComplexSum\"}"),
-                     "AlgorithmFactory::highestVersion() - Unknown algorithm 'ComplexSum'");
+    TS_ASSERT_EQUALS(
+        testProp.setValue("{\"name\":\"ComplexSum\"}"),
+        "AlgorithmFactory::highestVersion() - Unknown algorithm 'ComplexSum'");
   }
 
   void test_Alg_With_An_AlgorithmProperty_Accepts_Another_Algorithm() {

--- a/Framework/PythonInterface/mantid/api/src/Exports/AlgorithmFactory.cpp
+++ b/Framework/PythonInterface/mantid/api/src/Exports/AlgorithmFactory.cpp
@@ -72,7 +72,8 @@ dict getRegisteredAlgorithms(AlgorithmFactoryImpl &self, bool includeHidden) {
  * @param self :: An instance of AlgorithmFactory.
  * @param includeHidden :: If true hidden algorithms are included.
  */
-list getDescriptors(AlgorithmFactoryImpl &self, bool includeHidden = false, bool includeAlias = false) {
+list getDescriptors(AlgorithmFactoryImpl &self, bool includeHidden = false,
+                    bool includeAlias = false) {
   auto descriptors = self.getDescriptors(includeHidden, includeAlias);
   list pyDescriptors;
   for (auto &descr : descriptors) {
@@ -189,10 +190,11 @@ void export_AlgorithmFactory() {
            "Register a Python class derived from "
            "PythonAlgorithm into the factory")
       .def("getDescriptors", &getDescriptors,
-           getDescriptors_overloads((arg("self"), arg("include_hidden") = false,
-                                     arg("include_alias") = false),
-           "Return a list of descriptors of registered algorithms. Each "
-           "descriptor is a list: [name, version, category, alias]."))
+           getDescriptors_overloads(
+               (arg("self"), arg("include_hidden") = false,
+                arg("include_alias") = false),
+               "Return a list of descriptors of registered algorithms. Each "
+               "descriptor is a list: [name, version, category, alias]."))
       .def(
           "getCategoriesandState", &getCategoriesandState,
           "Return the categories of the algorithms. This includes those within "

--- a/Framework/PythonInterface/mantid/api/src/Exports/AlgorithmFactory.cpp
+++ b/Framework/PythonInterface/mantid/api/src/Exports/AlgorithmFactory.cpp
@@ -72,8 +72,8 @@ dict getRegisteredAlgorithms(AlgorithmFactoryImpl &self, bool includeHidden) {
  * @param self :: An instance of AlgorithmFactory.
  * @param includeHidden :: If true hidden algorithms are included.
  */
-list getDescriptors(AlgorithmFactoryImpl &self, bool includeHidden) {
-  auto descriptors = self.getDescriptors(includeHidden);
+list getDescriptors(AlgorithmFactoryImpl &self, bool includeHidden = false, bool includeAlias = false) {
+  auto descriptors = self.getDescriptors(includeHidden, includeAlias);
   list pyDescriptors;
   for (auto &descr : descriptors) {
     boost::python::object d(descr);
@@ -154,6 +154,7 @@ GNU_DIAG_OFF("unused-local-typedef")
 GNU_DIAG_OFF("conversion")
 
 BOOST_PYTHON_MEMBER_FUNCTION_OVERLOADS(existsOverloader, exists, 1, 2)
+BOOST_PYTHON_FUNCTION_OVERLOADS(getDescriptors_overloads, getDescriptors, 1, 3)
 
 GNU_DIAG_ON("conversion")
 GNU_DIAG_ON("unused-local-typedef")
@@ -188,9 +189,10 @@ void export_AlgorithmFactory() {
            "Register a Python class derived from "
            "PythonAlgorithm into the factory")
       .def("getDescriptors", &getDescriptors,
-           (arg("self"), arg("include_hidden")),
+           getDescriptors_overloads((arg("self"), arg("include_hidden") = false,
+                                     arg("include_alias") = false),
            "Return a list of descriptors of registered algorithms. Each "
-           "descriptor is a list: [name, version, category, alias].")
+           "descriptor is a list: [name, version, category, alias]."))
       .def(
           "getCategoriesandState", &getCategoriesandState,
           "Return the categories of the algorithms. This includes those within "

--- a/Framework/PythonInterface/test/python/mantid/api/AlgorithmFactoryTest.py
+++ b/Framework/PythonInterface/test/python/mantid/api/AlgorithmFactoryTest.py
@@ -37,6 +37,12 @@ class AlgorithmFactoryTest(unittest.TestCase):
         self.assertTrue(hasattr(d, 'category'))
         self.assertTrue(hasattr(d, 'version'))
 
+    def test_getDescriptorsWithAlias(self):
+
+        descriptors = AlgorithmFactory.getDescriptors(True, True)
+        result = [d for d in descriptors if (d.name == 'Subtract')]
+        self.assertEqual(1, len(result))
+
     def test_exists_returns_correct_value_for_given_args(self):
         self.assertTrue(AlgorithmFactory.exists('ConvertUnits')) #any version
         self.assertTrue(AlgorithmFactory.exists('ConvertUnits', 1)) #any version

--- a/qt/python/mantidqt/widgets/algorithmselector/model.py
+++ b/qt/python/mantidqt/widgets/algorithmselector/model.py
@@ -56,8 +56,9 @@ class AlgorithmSelectorModel(object):
             Here self.algorithm_key == '_'
 
         """
+        include_alias = True
         algm_factory = AlgorithmFactory.Instance()
-        descriptors = algm_factory.getDescriptors(self.include_hidden)
+        descriptors = algm_factory.getDescriptors(self.include_hidden, include_alias)
         data = {}
         for descriptor in descriptors:
             categories = descriptor.category.split(CATEGORY_SEP)
@@ -77,8 +78,10 @@ class AlgorithmSelectorModel(object):
                 d[descriptor.name] = []
             d[descriptor.name].append(descriptor.version)
 
+        # Add hidden algs to search box (hidden on tree)
+        include_hidden = True
         unique_alg_names = set(descr.name
-                               for descr in algm_factory.getDescriptors(True))
+                               for descr in algm_factory.getDescriptors(include_hidden, include_alias))
         return sorted(unique_alg_names), data
 
     def find_input_workspace_property(self, algorithm):

--- a/qt/python/mantidqt/widgets/algorithmselector/test/test_algorithmselector.py
+++ b/qt/python/mantidqt/widgets/algorithmselector/test/test_algorithmselector.py
@@ -64,12 +64,12 @@ class ModelTest(unittest.TestCase):
         counter = Counter(names)
         self.assertEqual(counter['Rebin'], 1)
         self.assertEqual(counter['DoStuff'], 1)
-        self.assertEqual(mock_get_algorithm_descriptors.mock_calls, [call(False), call(True)])
+        self.assertEqual(mock_get_algorithm_descriptors.mock_calls, [call(False, True), call(True, True)])
 
     def test_include_hidden_algorithms(self):
         model = AlgorithmSelectorModel(None, include_hidden=True)
         model.get_algorithm_data()
-        self.assertEqual(mock_get_algorithm_descriptors.mock_calls[-1], call(True))
+        self.assertEqual(mock_get_algorithm_descriptors.mock_calls[-1], call(True, True))
 
 
 createDialogFromName_func_name = ('mantidqt.interfacemanager.InterfaceManager.'

--- a/qt/python/mantidqt/widgets/algorithmselector/widget.py
+++ b/qt/python/mantidqt/widgets/algorithmselector/widget.py
@@ -33,6 +33,9 @@ def get_name_and_version_from_item_label(item_label):
     match = re.match(r'(\w+) v\.(\d+)', item_label)
     if match:
         return SelectedAlgorithm(name=match.group(1), version=int(match.group(2)))
+    # match = re.match(r'(\w+) \[(\w+)\] v\.(\d+)', item_label)
+    # if match is not None:
+    #     return SelectedAlgorithm(name=match.group(2), version=int(match.group(3)))
     return None
 
 
@@ -168,7 +171,11 @@ class AlgorithmSelectorWidget(IAlgorithmSelectorView, QWidget):
         i = self.search_box.findText(text)
         if i < 0:
             return None
-        return SelectedAlgorithm(name=self.search_box.currentText(), version=-1)
+        alg_name = self.search_box.currentText()
+        # index = alg_name.find('[')
+        # if index != -1:
+        #     alg_name = alg_name[index+1:len(alg_name)-1]
+        return SelectedAlgorithm(name=alg_name, version=-1)
 
     def _on_search_box_selection_changed(self, text):
         """

--- a/qt/python/mantidqt/widgets/algorithmselector/widget.py
+++ b/qt/python/mantidqt/widgets/algorithmselector/widget.py
@@ -168,8 +168,7 @@ class AlgorithmSelectorWidget(IAlgorithmSelectorView, QWidget):
         i = self.search_box.findText(text)
         if i < 0:
             return None
-        alg_name = self.search_box.currentText()
-        return SelectedAlgorithm(name=alg_name, version=-1)
+        return SelectedAlgorithm(name=self.search_box.currentText(), version=-1)
 
     def _on_search_box_selection_changed(self, text):
         """

--- a/qt/python/mantidqt/widgets/algorithmselector/widget.py
+++ b/qt/python/mantidqt/widgets/algorithmselector/widget.py
@@ -33,9 +33,6 @@ def get_name_and_version_from_item_label(item_label):
     match = re.match(r'(\w+) v\.(\d+)', item_label)
     if match:
         return SelectedAlgorithm(name=match.group(1), version=int(match.group(2)))
-    # match = re.match(r'(\w+) \[(\w+)\] v\.(\d+)', item_label)
-    # if match is not None:
-    #     return SelectedAlgorithm(name=match.group(2), version=int(match.group(3)))
     return None
 
 
@@ -172,9 +169,6 @@ class AlgorithmSelectorWidget(IAlgorithmSelectorView, QWidget):
         if i < 0:
             return None
         alg_name = self.search_box.currentText()
-        # index = alg_name.find('[')
-        # if index != -1:
-        #     alg_name = alg_name[index+1:len(alg_name)-1]
         return SelectedAlgorithm(name=alg_name, version=-1)
 
     def _on_search_box_selection_changed(self, text):

--- a/qt/widgets/common/src/AlgorithmSelectorWidget.cpp
+++ b/qt/widgets/common/src/AlgorithmSelectorWidget.cpp
@@ -276,7 +276,8 @@ void AlgorithmTreeWidget::update() {
   this->clear();
 
   using AlgNamesType = std::vector<AlgorithmDescriptor>;
-  AlgNamesType names = AlgorithmFactory::Instance().getDescriptors();
+  AlgNamesType names =
+      AlgorithmFactory::Instance().getDescriptors(false, false);
 
   // sort by category/name/version to fill QTreeWidget
   sort(names.begin(), names.end(), AlgorithmDescriptorLess);
@@ -349,7 +350,7 @@ void FindAlgComboBox::keyPressEvent(QKeyEvent *e) {
 /** Update the list of algos in the combo box */
 void FindAlgComboBox::update() {
   // include hidden categories in the combo list box
-  AlgNamesType names = AlgorithmFactory::Instance().getDescriptors(true);
+  AlgNamesType names = AlgorithmFactory::Instance().getDescriptors(true, false);
   addAliases(names);
 
   // sort by algorithm names only to fill this combobox


### PR DESCRIPTION
**Description of work.**
Added a new flag for getDescriptors in AlgorithmFactory which adds the alias names to the list of subscribed algorithms. Added new unit tests to test this functionality. Alias names can now be executed from the toolbox ui on workbench.

**To test:**

1. Run the AlgorithmFactory unit test.
2. Follow steps from the original issue #29131 except subtract should now be available and executable from the toolbox.


Fixes #29131 

*This does not require release notes* because it was a minor bug fix

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
