### PR TITLE
Handle incorrect batch file loading

### DIFF
--- a/docs/source/release/v5.1.0/sans.rst
+++ b/docs/source/release/v5.1.0/sans.rst
@@ -34,5 +34,6 @@ Fixed
 #####
 
 - A bug has been fixed where processing old data could fail if it involves -add files produced from 2013 or earlier.
+- Batch file selector now only shows CSV files and will handle loading in non-CSV data (such as mask files) gracefully.
 
 :ref:`Release 5.1.0 <v5.1.0>`

--- a/scripts/Interface/ui/sans_isis/sans_data_processor_gui.py
+++ b/scripts/Interface/ui/sans_isis/sans_data_processor_gui.py
@@ -609,7 +609,7 @@ class SANSDataProcessorGui(QMainWindow,
         Load the batch file
         """
         UsageService.registerFeatureUsage(FeatureType.Feature, ["ISIS SANS", "Loaded Batch File"], False)
-        load_file(self.batch_line_edit, "*.*", self.__generic_settings, self.__batch_file_key,
+        load_file(self.batch_line_edit, "CSV Files(*.csv)", self.__generic_settings, self.__batch_file_key,
                   self.get_batch_file_path)
         self._call_settings_listeners(lambda listener: listener.on_batch_file_load())
 

--- a/scripts/SANS/sans/command_interface/batch_csv_parser.py
+++ b/scripts/SANS/sans/command_interface/batch_csv_parser.py
@@ -46,9 +46,13 @@ class BatchCsvParser(object):
 
         parsed_rows = []
 
-        with open(batch_file_name, 'r') as csvfile:
-            batch_reader = reader(csvfile, delimiter=",")
-            read_rows = list(batch_reader)
+        try:
+            with open(batch_file_name, 'r') as csvfile:
+                batch_reader = reader(csvfile, delimiter=",")
+                read_rows = list(batch_reader)
+        except (csv.Error, UnicodeDecodeError) as e:
+            # Wrap so caller does not need to know about csv.Error
+            raise SyntaxError(f"Bad CSV detected:\n{str(e)}")
 
         for row_number, row in enumerate(read_rows):
             # Check if the row is empty or is a comment

--- a/scripts/SANS/sans/gui_logic/presenter/run_tab_presenter.py
+++ b/scripts/SANS/sans/gui_logic/presenter/run_tab_presenter.py
@@ -447,7 +447,7 @@ class RunTabPresenter(PresenterCommon):
             self._table_model.clear_table_entries()
 
             self._add_multiple_rows_to_table_model(rows=parsed_rows)
-        except RuntimeError as e:
+        except (RuntimeError, ValueError, SyntaxError) as e:
             self.sans_logger.error("Loading of the batch file failed. {}".format(str(e)))
             self.display_warning_box('Warning', 'Loading of the batch file failed', str(e))
 

--- a/scripts/test/SANS/command_interface/batch_csv_file_parser_test.py
+++ b/scripts/test/SANS/command_interface/batch_csv_file_parser_test.py
@@ -38,6 +38,11 @@ class BatchCsvParserTest(unittest.TestCase):
             parser.parse_batch_file(batch_file_path)
         BatchCsvParserTest._remove_csv(batch_file_path)
 
+    def test_handles_unknown_data(self):
+        parser = BatchCsvParser()
+        with self.assertRaises(SyntaxError):
+            parser.parse_batch_file('LOQ74044.nxs')
+
     def test_raises_if_the_batch_file_uses_key_as_val(self):
         content = "# MANTID_BATCH_FILE add more text here\n" \
                    "sample_sans,sample_trans,74024,sample_direct_beam,74014,can_sans,74019,can_trans,74020," \


### PR DESCRIPTION
**Description of work.**
- Adds a filter so we only can pick CSV files from batch selector
- Convert `csv.Error` into Python Syntax error so we can catch it, preventing the unknown error dialog appearing

**To test:**
- Open the SANS GUI
- Check that hitting Batch File only shows CSV
- Attempt to load some files that are not CSVs (this might be difficult if the filtering does not allow you to pick others, such as on KDE. In this case you will have to type the name of a file in that folder to work around the filter)
- Check that a warning box appears, not the Mantid unknown exception one

Fixes #28368 .

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
