### PR TITLE
Implement error bars in MPL based PreviewPlot

### DIFF
--- a/docs/source/release/v5.1.0/muon.rst
+++ b/docs/source/release/v5.1.0/muon.rst
@@ -48,6 +48,7 @@ Improvements
 - Updated :ref:`LoadMuonNexusV2 <algm-LoadMuonNexusV2>` and  :ref:`LoadPSIMuonBin <algm-LoadPSIMuonBin>` to load a list of time zeros into a new property TimZeroList.
 - Updated :ref:`LoadMuonNexusV2 <algm-LoadMuonNexusV2>` and  :ref:`LoadPSIMuonBin <algm-LoadPSIMuonBin>` to add an option to not auto-correct the time by loaded timezero.
 - Fitting tab in Muon analysis and Frequency domain analysis GUI's are now disabled when no valid fitting data is present.
+- The ALC interface in workbench will now show errors by default. The error bars can also be turned on/off using the right-click plot menu.
 
 Bug fixes
 ---------

--- a/qt/scientific_interfaces/Muon/ALCDataLoadingView.cpp
+++ b/qt/scientific_interfaces/Muon/ALCDataLoadingView.cpp
@@ -41,7 +41,7 @@ void ALCDataLoadingView::initialize() {
   // Error bars on the plot
   QStringList plotsWithErrors{"Data"};
   m_ui.dataPlot->setLinesWithErrors(plotsWithErrors);
-
+  m_ui.dataPlot->showLegend(false);
   // The following lines disable the groups' titles when the
   // group is disabled
   QPalette palette;

--- a/qt/widgets/plotting/inc/MantidQtWidgets/Plotting/Mpl/PreviewPlot.h
+++ b/qt/widgets/plotting/inc/MantidQtWidgets/Plotting/Mpl/PreviewPlot.h
@@ -91,6 +91,7 @@ public:
   void disableContextMenu();
 
   void allowRedraws(bool state);
+  void replotData();
 
 public slots:
   void clear();
@@ -98,6 +99,7 @@ public slots:
   void resetView();
   void setCanvasColour(const QColor &colour);
   void setLinesWithErrors(const QStringList &labels);
+  void setLinesWithoutErrors(const QStringList &labels);
   void showLegend(bool visible);
   void replot();
 
@@ -138,6 +140,7 @@ private:
   void switchPlotTool(QAction *selected);
   void setXScaleType(QAction *selected);
   void setYScaleType(QAction *selected);
+  void setErrorBars(QAction *selected);
   void setScaleType(AxisID id, const QString &actionName);
   void toggleLegend(const bool checked);
 
@@ -147,10 +150,29 @@ private:
   // Block redrawing from taking place
   bool m_allowRedraws = true;
 
+  // Curve configuration
+  struct PlotCurveConfiguration {
+    Mantid::API::MatrixWorkspace_sptr ws;
+    QString lineName;
+    QColor lineColour;
+    QHash<QString, QVariant> plotKwargs;
+    size_t wsIndex;
+
+    PlotCurveConfiguration(Mantid::API::MatrixWorkspace_sptr ws,
+                           QString lineName, size_t wsIndex, QColor lineColour,
+                           QHash<QString, QVariant> plotKwargs)
+        : ws(ws), lineName(lineName), wsIndex(wsIndex), lineColour(lineColour),
+          plotKwargs(plotKwargs) {};
+  };
+
   // Canvas objects
   Widgets::MplCpp::FigureCanvasQt *m_canvas;
   // Map a line label to the boolean indicating whether error bars are shown
   QHash<QString, bool> m_lines;
+  // Map a line name to a plot configuration
+  QMap<QString, QSharedPointer<PlotCurveConfiguration>> m_plottedLines;
+  // Cache of line names which always have errors
+  QHash<QString, bool> m_linesErrorsCache;
   // Map an axis to an override axis label
   QMap<AxisID, char const *> m_axisLabels;
   // Range selector widgets
@@ -174,6 +196,7 @@ private:
   QAction *m_contextResetView;
   QActionGroup *m_contextXScale, *m_contextYScale;
   QAction *m_contextLegend;
+  QActionGroup *m_contextErrorBars;
   bool m_context_enabled;
 };
 

--- a/qt/widgets/plotting/inc/MantidQtWidgets/Plotting/Mpl/PreviewPlot.h
+++ b/qt/widgets/plotting/inc/MantidQtWidgets/Plotting/Mpl/PreviewPlot.h
@@ -154,15 +154,15 @@ private:
   struct PlotCurveConfiguration {
     Mantid::API::MatrixWorkspace_sptr ws;
     QString lineName;
+    size_t wsIndex;
     QColor lineColour;
     QHash<QString, QVariant> plotKwargs;
-    size_t wsIndex;
 
     PlotCurveConfiguration(Mantid::API::MatrixWorkspace_sptr ws,
                            QString lineName, size_t wsIndex, QColor lineColour,
                            QHash<QString, QVariant> plotKwargs)
         : ws(ws), lineName(lineName), wsIndex(wsIndex), lineColour(lineColour),
-          plotKwargs(plotKwargs) {};
+          plotKwargs(plotKwargs){};
   };
 
   // Canvas objects

--- a/qt/widgets/plotting/src/Mpl/PreviewPlot.cpp
+++ b/qt/widgets/plotting/src/Mpl/PreviewPlot.cpp
@@ -769,6 +769,9 @@ void PreviewPlot::setScaleType(AxisID id, const QString &actionName) {
  * @param checked True if the state should be visible, false otherwise
  */
 void PreviewPlot::toggleLegend(const bool checked) {
+  if (m_lines.isEmpty()) {
+    return;
+  }
   if (checked) {
     regenerateLegend();
   } else {

--- a/qt/widgets/plotting/src/Mpl/PreviewPlot.cpp
+++ b/qt/widgets/plotting/src/Mpl/PreviewPlot.cpp
@@ -41,7 +41,8 @@ constexpr auto PLOT_TOOL_ZOOM = "Zoom";
 constexpr auto LINEAR_SCALE = "Linear";
 constexpr auto LOG_SCALE = "Log";
 constexpr auto SQUARE_SCALE = "Square";
-
+constexpr auto SHOWALLERRORS = "Show all errors";
+constexpr auto HIDEALLERRORS = "Hide all errors";
 } // namespace
 
 namespace MantidQt {
@@ -128,7 +129,8 @@ void PreviewPlot::addSpectrum(const QString &lineName,
   removeSpectrum(lineName);
 
   auto axes = m_canvas->gca<MantidAxes>();
-  if (linesWithErrors().contains(lineName)) {
+  if (m_linesErrorsCache.value(lineName)) {
+    m_lines[lineName] = true;
     axes.errorbar(ws, wsIndex, lineColour.name(QColor::HexRgb), lineName,
                   plotKwargs);
   } else {
@@ -136,6 +138,12 @@ void PreviewPlot::addSpectrum(const QString &lineName,
     axes.plot(ws, wsIndex, lineColour.name(QColor::HexRgb), lineName,
               plotKwargs);
   }
+
+  // Add line to stored line data
+  auto plotCurveConfig =
+      QSharedPointer<PlotCurveConfiguration>(new PlotCurveConfiguration(
+          ws, lineName, wsIndex, lineColour, plotKwargs));
+  m_plottedLines.insert(lineName, plotCurveConfig);
 
   if (auto const xLabel = overrideAxisLabel(AxisID::XBottom))
     setAxisLabel(AxisID::XBottom, xLabel.get());
@@ -334,6 +342,18 @@ void PreviewPlot::replot() {
   }
 }
 
+// Called when the user turns errors on/off
+void PreviewPlot::replotData() {
+  m_allowRedraws = false;
+  clear();
+  for (const auto &curveConfig : m_plottedLines) {
+    addSpectrum(curveConfig->lineName, curveConfig->ws, curveConfig->wsIndex,
+                curveConfig->lineColour, curveConfig->plotKwargs);
+  }
+  m_allowRedraws = true;
+  replot();
+}
+
 void PreviewPlot::allowRedraws(bool state) { m_allowRedraws = state; }
 
 /**
@@ -368,11 +388,20 @@ void PreviewPlot::setCanvasColour(const QColor &colour) {
 
 /**
  * @brief PreviewPlot::setLinesWithErrors
- * @param labels A list of line labels where error bars should be shown
+ * @param labels A list of line labels for which error should be shown
  */
 void PreviewPlot::setLinesWithErrors(const QStringList &labels) {
   for (const QString &label : labels) {
-    m_lines[label] = true;
+    m_linesErrorsCache[label] = true;
+  }
+}
+/**
+ * @brief PreviewPlot::setLinesWithoutErrors
+ * @param labels A list of line labels for which error bars should not be shown
+ */
+void PreviewPlot::setLinesWithoutErrors(const QStringList &labels) {
+  for (const QString &label : labels) {
+    m_linesErrorsCache[label] = false;
   }
 }
 
@@ -502,6 +531,11 @@ void PreviewPlot::showContextMenu(QMouseEvent *evt) {
   auto yScale = contextMenu.addMenu("Y Scale");
   yScale->addActions(m_contextYScale->actions());
 
+  // Create the error bars option
+  contextMenu.addSeparator();
+  auto errors = contextMenu.addMenu("Error Bars:");
+  errors->addActions(m_contextErrorBars->actions());
+
   contextMenu.addSeparator();
   contextMenu.addAction(m_contextLegend);
 
@@ -554,6 +588,12 @@ void PreviewPlot::createActions() {
           &PreviewPlot::setYScaleType);
   m_contextXScale->actions()[0]->setChecked(true);
   m_contextYScale->actions()[0]->setChecked(true);
+
+  // Error bars
+  m_contextErrorBars =
+      createExclusiveActionGroup({SHOWALLERRORS, HIDEALLERRORS});
+  connect(m_contextErrorBars, &QActionGroup::triggered, this,
+          &PreviewPlot::setErrorBars);
 
   // legend
   m_contextLegend = new QAction("Legend", this);
@@ -688,6 +728,19 @@ void PreviewPlot::setXScaleType(QAction *selected) {
 }
 
 /**
+ * Set the error bars based on the given QAction
+ * @param selected The action that triggered the slot
+ */
+void PreviewPlot::setErrorBars(QAction *selected) {
+  if (selected->text().toStdString() == SHOWALLERRORS) {
+    setLinesWithErrors(m_lines.keys());
+  } else {
+    setLinesWithoutErrors(m_lines.keys());
+  }
+  replotData();
+}
+
+/**
  * Set the X scale based on the given QAction
  * @param selected The action that triggered the slot
  */
@@ -727,7 +780,7 @@ void PreviewPlot::toggleLegend(const bool checked) {
 void PreviewPlot::disableContextMenu() {
   // Disable the context menu signal
   // TODO Currently when changes are made to the plot through the context menu
-  // it is not communicated through to the perant gui which can cause issues,
+  // it is not communicated through to the parent GUI which can cause issues,
   // for now we are disabling the context menu but is should be made to
   // communicate so it can be reactivated.
   m_context_enabled = false;

--- a/qt/widgets/plotting/src/Qwt/PreviewPlot.cpp
+++ b/qt/widgets/plotting/src/Qwt/PreviewPlot.cpp
@@ -1015,7 +1015,7 @@ void PreviewPlot::disableYAxisMenu() {
 void PreviewPlot::disableContextMenu() {
   // Disable the context menu signal
   // TODO Currently when changes are made to the plot through the context menu
-  // it is not communicated through to the perant gui which can cause issues,
+  // it is not communicated through to the parent GUI which can cause issues,
   // for now we are disabling the context menu but is should be made to
   // communicate so it can be reactivated.
   disconnect(m_uiForm.plot, SIGNAL(customContextMenuRequested(QPoint)), this,


### PR DESCRIPTION
**Description of work.**
This PR implements error bars for the MPL preview plot. This includes adding the ability to specify line names which will always have errors and allowing the error bars to be switched on/off through the context menu.

**Note**: The error bars are currently only implemented for the ALC interface. Although the Indirect interface uses the preview plot, the context menu was disabled in a previous PR. Therefore, before adding errors to this interface we would need to address the issues surrounding the plot context menu in the IDA GUI.


<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

**To test:**

1. Open ALC
2. Set first run to be 62260
3. Set the last run to be 62265
4. Set the log to Field_Danfysik
5. Click load
6. Error bars will be shown be default (as in Mantid plot)
7. They can be switched on/off using the right click menu on the plot

<!-- Instructions for testing. -->

Fixes #28182 . <!-- and fix #xxxx or close #xxxx xor resolves #xxxx -->
<!-- alternative
*There is no associated issue.*
-->

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
-->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
