### PR TITLE
Always use selected workspace in sliceviewer and don't dynamically bin MDHistoWorkspace

### DIFF
--- a/qt/python/mantidqt/widgets/sliceviewer/model.py
+++ b/qt/python/mantidqt/widgets/sliceviewer/model.py
@@ -31,11 +31,9 @@ class WS_TYPE(Enum):
 
 class SliceViewerModel:
     """Store the workspace to be plotted. Can be MatrixWorkspace, MDEventWorkspace or MDHistoWorkspace"""
-
     def __init__(self, ws):
         # reference to the workspace requested to be viewed
-        # For MDH the view will show the original NDE if possible
-        self._selected_ws = ws
+        self._ws = ws
         if isinstance(ws, MatrixWorkspace):
             if ws.getNumberHistograms() < 2:
                 raise ValueError("workspace must contain at least 2 spectrum")
@@ -45,15 +43,12 @@ class SliceViewerModel:
             if ws.isMDHistoWorkspace():
                 if len(ws.getNonIntegratedDimensions()) < 2:
                     raise ValueError("workspace must have at least 2 non-integrated dimensions")
-                if ws.hasOriginalWorkspace(0):
-                    ws = ws.getOriginalWorkspace(0)
             else:
                 if ws.getNumDims() < 2:
                     raise ValueError("workspace must have at least 2 dimensions")
         else:
             raise ValueError("only works for MatrixWorkspace and MDWorkspace")
 
-        self._ws = ws
         wsname = self.get_ws_name()
         self._rebinned_name = wsname + '_svrebinned'
         self._xcut_name, self._ycut_name = wsname + '_cut_x', wsname + '_cut_y'
@@ -123,12 +118,7 @@ class SliceViewerModel:
         """
         Check if the given workspace can multiple BinMD calls.
         """
-        try:
-            return self.get_ws_type() == WS_TYPE.MDE or self._get_ws().hasOriginalWorkspace(0)
-        except AttributeError:
-            pass
-
-        return False
+        return self.get_ws_type() == WS_TYPE.MDE
 
     def get_ws_name(self) -> str:
         """Return the name of the workspace being viewed"""
@@ -141,11 +131,7 @@ class SliceViewerModel:
     def get_title(self) -> str:
         """Return a title for model"""
         ws_name = self.get_ws_name()
-        title = f'Sliceviewer - {ws_name}'
-        selected_name = self._selected_ws.name()
-        if selected_name != ws_name:
-            title += f' (original of {selected_name})'
-        return title
+        return f'Sliceviewer - {ws_name}'
 
     def get_ws_MDE(self,
                    slicepoint: Sequence[Optional[float]],
@@ -262,10 +248,9 @@ class SliceViewerModel:
             proj_matrix = np.diag([1., 1., 1.])
 
         display_indices = slice_info.transform([0, 1, 2]).astype(int)
-        return NonOrthogonalTransform.from_lattice(
-            lattice,
-            x_proj=proj_matrix[:, display_indices[0]],
-            y_proj=proj_matrix[:, display_indices[1]])
+        return NonOrthogonalTransform.from_lattice(lattice,
+                                                   x_proj=proj_matrix[:, display_indices[0]],
+                                                   y_proj=proj_matrix[:, display_indices[1]])
 
     def export_roi_to_workspace_mdevent(self, slicepoint: Sequence[Optional[float]],
                                         bin_params: Sequence[float], limits: tuple,

--- a/qt/python/mantidqt/widgets/sliceviewer/test/test_sliceviewer_model.py
+++ b/qt/python/mantidqt/widgets/sliceviewer/test/test_sliceviewer_model.py
@@ -159,7 +159,6 @@ def _add_dimensions(mock_ws,
     :param nbins: Number of bins in each dimension
     :param units: Unit labels for each dimension
     """
-
     def create_dimension(index):
         dimension = MagicMock(spec=IMDDimension)
         dimension.name = names[index]
@@ -187,7 +186,6 @@ def _add_dimensions(mock_ws,
 class ArraysEqual:
     """Compare arrays for equality in mock.assert_called_with calls.
     """
-
     def __init__(self, expected):
         self._expected = expected
 
@@ -205,39 +203,38 @@ def create_mock_sliceinfo(indices: tuple):
     :param indices: 3D indices defining permuation order of dimensions
     """
     slice_info = MagicMock()
-    slice_info.transform.side_effect = lambda x: np.array([x[indices[0]], x[indices[1]], x[indices[2]]])
+    slice_info.transform.side_effect = lambda x: np.array(
+        [x[indices[0]], x[indices[1]], x[indices[2]]])
     return slice_info
 
 
 class SliceViewerModelTest(unittest.TestCase):
     @classmethod
     def setUpClass(self):
-        self.ws_MD_3D = _create_mock_histoworkspace(
-            ndims=3,
-            coords=SpecialCoordinateSystem.NONE,
-            extents=(-3, 3, -10, 10, -1, 1),
-            signal=np.arange(100.).reshape(5, 5, 4),
-            error=np.arange(100.).reshape(5, 5, 4),
-            nbins=(5, 5, 4),
-            names=('Dim1', 'Dim2', 'Dim3'),
-            units=('MomentumTransfer', 'EnergyTransfer', 'Angstrom'),
-            isq=(False, False, False))
+        self.ws_MD_3D = _create_mock_histoworkspace(ndims=3,
+                                                    coords=SpecialCoordinateSystem.NONE,
+                                                    extents=(-3, 3, -10, 10, -1, 1),
+                                                    signal=np.arange(100.).reshape(5, 5, 4),
+                                                    error=np.arange(100.).reshape(5, 5, 4),
+                                                    nbins=(5, 5, 4),
+                                                    names=('Dim1', 'Dim2', 'Dim3'),
+                                                    units=('MomentumTransfer', 'EnergyTransfer',
+                                                           'Angstrom'),
+                                                    isq=(False, False, False))
         self.ws_MD_3D.name.return_value = 'ws_MD_3D'
-        self.ws_MDE_3D = _create_mock_mdeventworkspace(
-            ndims=3,
-            coords=SpecialCoordinateSystem.NONE,
-            extents=(-3, 3, -4, 4, -5, 5),
-            names=('h', 'k', 'l'),
-            units=('rlu', 'rlu', 'rlu'),
-            isq=(False, False, False))
+        self.ws_MDE_3D = _create_mock_mdeventworkspace(ndims=3,
+                                                       coords=SpecialCoordinateSystem.NONE,
+                                                       extents=(-3, 3, -4, 4, -5, 5),
+                                                       names=('h', 'k', 'l'),
+                                                       units=('rlu', 'rlu', 'rlu'),
+                                                       isq=(False, False, False))
         self.ws_MDE_3D.name.return_value = 'ws_MDE_3D'
 
-        self.ws2d_histo = _create_mock_matrixworkspace(
-            x_axis=(10, 20, 30),
-            y_axis=(4, 6, 8),
-            distribution=True,
-            names=('Wavelength', 'Energy transfer'),
-            units=('Angstrom', 'meV'))
+        self.ws2d_histo = _create_mock_matrixworkspace(x_axis=(10, 20, 30),
+                                                       y_axis=(4, 6, 8),
+                                                       distribution=True,
+                                                       names=('Wavelength', 'Energy transfer'),
+                                                       units=('Angstrom', 'meV'))
         self.ws2d_histo.name.return_value = 'ws2d_histo'
 
     def setUp(self):
@@ -283,13 +280,12 @@ class SliceViewerModelTest(unittest.TestCase):
         mock_binmd.return_value = self.ws_MD_3D
 
         self.assertNotEqual(model.get_ws((None, None, 0), (1, 2, 4)), self.ws_MDE_3D)
-        mock_binmd.assert_called_once_with(
-            InputWorkspace=self.ws_MDE_3D,
-            OutputWorkspace='ws_MDE_3D_svrebinned',
-            AlignedDim0='h,-3,3,1',
-            AlignedDim1='k,-4,4,2',
-            AlignedDim2='l,-2.0,2.0,1',
-            EnableLogging=False)
+        mock_binmd.assert_called_once_with(InputWorkspace=self.ws_MDE_3D,
+                                           OutputWorkspace='ws_MDE_3D_svrebinned',
+                                           AlignedDim0='h,-3,3,1',
+                                           AlignedDim1='k,-4,4,2',
+                                           AlignedDim2='l,-2.0,2.0,1',
+                                           EnableLogging=False)
         mock_binmd.reset_mock()
         self.assertEqual(model._get_ws(), self.ws_MDE_3D)
         self.assertEqual(model.get_ws_type(), WS_TYPE.MDE)
@@ -317,26 +313,19 @@ class SliceViewerModelTest(unittest.TestCase):
         self.assertEqual(dim_info['type'], 'MDE')
         self.assertEqual(dim_info['qdim'], False)
 
-    def test_model_given_MDH_with_original_uses_original_as_data_ws(self):
-        with _attach_as_original(self.ws_MD_3D, self.ws_MDE_3D):
-            model = SliceViewerModel(self.ws_MD_3D)
-
-            self.assertEqual(self.ws_MDE_3D, model._get_ws())
-
     @patch('mantidqt.widgets.sliceviewer.model.BinMD')
     def test_get_ws_MDE_with_limits_uses_limits_over_dimension_extents(self, mock_binmd):
         model = SliceViewerModel(self.ws_MDE_3D)
         mock_binmd.return_value = self.ws_MD_3D
 
-        self.assertNotEqual(
-            model.get_ws((None, None, 0), (1, 2, 4), ((-2, 2), (-1, 1))), self.ws_MDE_3D)
-        call_params = dict(
-            InputWorkspace=self.ws_MDE_3D,
-            OutputWorkspace='ws_MDE_3D_svrebinned',
-            AlignedDim0='h,-2,2,1',
-            AlignedDim1='k,-1,1,2',
-            AlignedDim2='l,-2.0,2.0,1',
-            EnableLogging=False)
+        self.assertNotEqual(model.get_ws((None, None, 0), (1, 2, 4), ((-2, 2), (-1, 1))),
+                            self.ws_MDE_3D)
+        call_params = dict(InputWorkspace=self.ws_MDE_3D,
+                           OutputWorkspace='ws_MDE_3D_svrebinned',
+                           AlignedDim0='h,-2,2,1',
+                           AlignedDim1='k,-1,1,2',
+                           AlignedDim2='l,-2.0,2.0,1',
+                           EnableLogging=False)
         mock_binmd.assert_called_once_with(**call_params)
         mock_binmd.reset_mock()
 
@@ -373,10 +362,11 @@ class SliceViewerModelTest(unittest.TestCase):
         self.assertEqual(dim_info['qdim'], False)
 
     def test_qflags_for_qlab_coordinates_detected(self):
-        mock_q3d = _create_mock_workspace(
-            IMDEventWorkspace, coords=SpecialCoordinateSystem.QLab, has_oriented_lattice=False)
-        mock_q3d = _add_dimensions(
-            mock_q3d, ('Q_lab_x', 'Q_lab_y', 'Q_lab_z', 'DeltaE'), isq=(True, True, True, False))
+        mock_q3d = _create_mock_workspace(IMDEventWorkspace,
+                                          coords=SpecialCoordinateSystem.QLab,
+                                          has_oriented_lattice=False)
+        mock_q3d = _add_dimensions(mock_q3d, ('Q_lab_x', 'Q_lab_y', 'Q_lab_z', 'DeltaE'),
+                                   isq=(True, True, True, False))
         model = SliceViewerModel(mock_q3d)
 
         for i in range(3):
@@ -385,11 +375,11 @@ class SliceViewerModelTest(unittest.TestCase):
         self.assertFalse(model.get_dim_info(3)['qdim'])
 
     def test_qflags_for_qsample_coordinates_detected(self):
-        mock_q3d = _create_mock_workspace(
-            IMDEventWorkspace, coords=SpecialCoordinateSystem.QSample, has_oriented_lattice=False)
-        mock_q3d = _add_dimensions(
-            mock_q3d, ('Q_sample_x', 'Q_sample_y', 'Q_sample_z', 'DeltaE'),
-            isq=(True, True, True, False))
+        mock_q3d = _create_mock_workspace(IMDEventWorkspace,
+                                          coords=SpecialCoordinateSystem.QSample,
+                                          has_oriented_lattice=False)
+        mock_q3d = _add_dimensions(mock_q3d, ('Q_sample_x', 'Q_sample_y', 'Q_sample_z', 'DeltaE'),
+                                   isq=(True, True, True, False))
 
         model = SliceViewerModel(mock_q3d)
 
@@ -399,10 +389,11 @@ class SliceViewerModelTest(unittest.TestCase):
         self.assertFalse(model.get_dim_info(3)['qdim'])
 
     def test_qflags_for_hkl_coordinates_detected(self):
-        mock_q3d = _create_mock_workspace(
-            IMDEventWorkspace, coords=SpecialCoordinateSystem.HKL, has_oriented_lattice=False)
-        mock_q3d = _add_dimensions(
-            mock_q3d, ('[H,0,0]', '[0,K,0]', '[0,0,L]', 'DeltaE'), isq=(True, True, True, False))
+        mock_q3d = _create_mock_workspace(IMDEventWorkspace,
+                                          coords=SpecialCoordinateSystem.HKL,
+                                          has_oriented_lattice=False)
+        mock_q3d = _add_dimensions(mock_q3d, ('[H,0,0]', '[0,K,0]', '[0,0,L]', 'DeltaE'),
+                                   isq=(True, True, True, False))
         model = SliceViewerModel(mock_q3d)
 
         for i in range(3):
@@ -411,8 +402,9 @@ class SliceViewerModelTest(unittest.TestCase):
         self.assertFalse(model.get_dim_info(3)['qdim'])
 
     def test_matrix_workspace_can_be_normalized_if_not_a_distribution(self):
-        non_distrib_ws2d = _create_mock_matrixworkspace(
-            (1, 2, 3), (4, 5, 6), distribution=False, names=('a', 'b'))
+        non_distrib_ws2d = _create_mock_matrixworkspace((1, 2, 3), (4, 5, 6),
+                                                        distribution=False,
+                                                        names=('a', 'b'))
         model = SliceViewerModel(non_distrib_ws2d)
         self.assertTrue(model.can_normalize_workspace())
 
@@ -429,63 +421,54 @@ class SliceViewerModelTest(unittest.TestCase):
         self.assertFalse(model.can_normalize_workspace())
 
     def test_MDH_workspace_in_hkl_supports_non_orthogonal_axes(self):
-        self._assert_supports_non_orthogonal_axes(
-            True,
-            ws_type=IMDHistoWorkspace,
-            coords=SpecialCoordinateSystem.HKL,
-            has_oriented_lattice=True)
+        self._assert_supports_non_orthogonal_axes(True,
+                                                  ws_type=IMDHistoWorkspace,
+                                                  coords=SpecialCoordinateSystem.HKL,
+                                                  has_oriented_lattice=True)
 
     def test_MDE_workspace_in_hkl_supports_non_orthogonal_axes(self):
-        self._assert_supports_non_orthogonal_axes(
-            True,
-            ws_type=IMDEventWorkspace,
-            coords=SpecialCoordinateSystem.HKL,
-            has_oriented_lattice=True)
+        self._assert_supports_non_orthogonal_axes(True,
+                                                  ws_type=IMDEventWorkspace,
+                                                  coords=SpecialCoordinateSystem.HKL,
+                                                  has_oriented_lattice=True)
 
     def test_matrix_workspace_cannot_support_non_orthogonal_axes(self):
-        self._assert_supports_non_orthogonal_axes(
-            False,
-            ws_type=MatrixWorkspace,
-            coords=SpecialCoordinateSystem.HKL,
-            has_oriented_lattice=None)
+        self._assert_supports_non_orthogonal_axes(False,
+                                                  ws_type=MatrixWorkspace,
+                                                  coords=SpecialCoordinateSystem.HKL,
+                                                  has_oriented_lattice=None)
 
     def test_MDH_workspace_in_hkl_without_lattice_cannot_support_non_orthogonal_axes(self):
-        self._assert_supports_non_orthogonal_axes(
-            False,
-            ws_type=IMDHistoWorkspace,
-            coords=SpecialCoordinateSystem.HKL,
-            has_oriented_lattice=False)
+        self._assert_supports_non_orthogonal_axes(False,
+                                                  ws_type=IMDHistoWorkspace,
+                                                  coords=SpecialCoordinateSystem.HKL,
+                                                  has_oriented_lattice=False)
 
     def test_MDE_workspace_in_hkl_without_lattice_cannot_support_non_orthogonal_axes(self):
-        self._assert_supports_non_orthogonal_axes(
-            False,
-            ws_type=IMDEventWorkspace,
-            coords=SpecialCoordinateSystem.HKL,
-            has_oriented_lattice=False)
+        self._assert_supports_non_orthogonal_axes(False,
+                                                  ws_type=IMDEventWorkspace,
+                                                  coords=SpecialCoordinateSystem.HKL,
+                                                  has_oriented_lattice=False)
 
     def test_MDH_workspace_in_non_hkl_cannot_support_non_orthogonal_axes(self):
-        self._assert_supports_non_orthogonal_axes(
-            False,
-            ws_type=IMDHistoWorkspace,
-            coords=SpecialCoordinateSystem.QLab,
-            has_oriented_lattice=False)
-        self._assert_supports_non_orthogonal_axes(
-            False,
-            ws_type=IMDHistoWorkspace,
-            coords=SpecialCoordinateSystem.QLab,
-            has_oriented_lattice=True)
+        self._assert_supports_non_orthogonal_axes(False,
+                                                  ws_type=IMDHistoWorkspace,
+                                                  coords=SpecialCoordinateSystem.QLab,
+                                                  has_oriented_lattice=False)
+        self._assert_supports_non_orthogonal_axes(False,
+                                                  ws_type=IMDHistoWorkspace,
+                                                  coords=SpecialCoordinateSystem.QLab,
+                                                  has_oriented_lattice=True)
 
     def test_MDE_workspace_in_non_hkl_cannot_support_non_orthogonal_axes(self):
-        self._assert_supports_non_orthogonal_axes(
-            False,
-            ws_type=IMDEventWorkspace,
-            coords=SpecialCoordinateSystem.QLab,
-            has_oriented_lattice=False)
-        self._assert_supports_non_orthogonal_axes(
-            False,
-            ws_type=IMDEventWorkspace,
-            coords=SpecialCoordinateSystem.QLab,
-            has_oriented_lattice=True)
+        self._assert_supports_non_orthogonal_axes(False,
+                                                  ws_type=IMDEventWorkspace,
+                                                  coords=SpecialCoordinateSystem.QLab,
+                                                  has_oriented_lattice=False)
+        self._assert_supports_non_orthogonal_axes(False,
+                                                  ws_type=IMDEventWorkspace,
+                                                  coords=SpecialCoordinateSystem.QLab,
+                                                  has_oriented_lattice=True)
 
     def test_matrix_workspace_cannot_support_peaks_overlay(self):
         self._assert_supports_peaks_overlay(False, MatrixWorkspace)
@@ -499,16 +482,20 @@ class SliceViewerModelTest(unittest.TestCase):
         self._assert_supports_peaks_overlay(True, IMDHistoWorkspace, ndims=3)
 
     def test_mdeventworkspace_supports_dynamic_rebinning(self):
-        self._assert_supports_dynamic_rebinning(
-            True, IMDEventWorkspace, has_original_workspace=True)
-        self._assert_supports_dynamic_rebinning(
-            True, IMDEventWorkspace, has_original_workspace=False)
+        self._assert_supports_dynamic_rebinning(True,
+                                                IMDEventWorkspace,
+                                                has_original_workspace=True)
+        self._assert_supports_dynamic_rebinning(True,
+                                                IMDEventWorkspace,
+                                                has_original_workspace=False)
 
-    def test_mdhistoworkspace_supports_dynamic_rebinning(self):
-        self._assert_supports_dynamic_rebinning(
-            True, IMDHistoWorkspace, has_original_workspace=True)
-        self._assert_supports_dynamic_rebinning(
-            False, IMDHistoWorkspace, has_original_workspace=False)
+    def test_mdhistoworkspace_does_not_support_dynamic_rebinning(self):
+        self._assert_supports_dynamic_rebinning(False,
+                                                IMDHistoWorkspace,
+                                                has_original_workspace=True)
+        self._assert_supports_dynamic_rebinning(False,
+                                                IMDHistoWorkspace,
+                                                has_original_workspace=False)
 
     def test_matrixworkspace_does_not_dynamic_rebinning(self):
         self._assert_supports_dynamic_rebinning(False, MatrixWorkspace)
@@ -528,23 +515,25 @@ class SliceViewerModelTest(unittest.TestCase):
 
         self.assertEqual('Sliceviewer - ws_MD_3D', model.get_title())
 
-    def test_title_for_mdhistoworkspace_with_original_contains_original_name(self):
+    def test_title_for_mdhistoworkspace_with_original(self):
         with _attach_as_original(self.ws_MD_3D, self.ws_MDE_3D):
             model = SliceViewerModel(self.ws_MD_3D)
 
-            self.assertEqual('Sliceviewer - ws_MDE_3D (original of ws_MD_3D)', model.get_title())
+            self.assertEqual('Sliceviewer - ws_MD_3D', model.get_title())
 
     def test_create_non_orthogonal_transform_raises_error_if_not_supported(self):
         model = SliceViewerModel(
-            _create_mock_workspace(
-                MatrixWorkspace, SpecialCoordinateSystem.QLab, has_oriented_lattice=False))
+            _create_mock_workspace(MatrixWorkspace,
+                                   SpecialCoordinateSystem.QLab,
+                                   has_oriented_lattice=False))
 
         self.assertRaises(RuntimeError, model.create_nonorthogonal_transform, (0, 1, 2))
 
     @patch("mantidqt.widgets.sliceviewer.model.NonOrthogonalTransform")
     def test_create_non_orthogonal_transform_uses_W_if_avilable(self, mock_nonortho_trans):
-        ws = _create_mock_workspace(
-            IMDEventWorkspace, SpecialCoordinateSystem.HKL, has_oriented_lattice=True)
+        ws = _create_mock_workspace(IMDEventWorkspace,
+                                    SpecialCoordinateSystem.HKL,
+                                    has_oriented_lattice=True)
         w_prop = MagicMock()
         w_prop.value = [0, 1, 1, 0, 0, 1, 1, 0, 0]
         run = MagicMock()
@@ -564,8 +553,9 @@ class SliceViewerModelTest(unittest.TestCase):
     @patch("mantidqt.widgets.sliceviewer.model.NonOrthogonalTransform")
     def test_create_non_orthogonal_transform_uses_identity_if_W_unavilable(
             self, mock_nonortho_trans):
-        ws = _create_mock_workspace(
-            IMDEventWorkspace, SpecialCoordinateSystem.HKL, has_oriented_lattice=True)
+        ws = _create_mock_workspace(IMDEventWorkspace,
+                                    SpecialCoordinateSystem.HKL,
+                                    has_oriented_lattice=True)
         lattice = MagicMock()
         ws.getExperimentInfo().sample().getOrientedLattice.return_value = lattice
         run = MagicMock()
@@ -606,8 +596,10 @@ class SliceViewerModelTest(unittest.TestCase):
         model = SliceViewerModel(self.ws_MDE_3D)
 
         self.assertRaises(ValueError, model.get_dim_limits, slicepoint=(0, 0, 0), transpose=False)
-        self.assertRaises(
-            ValueError, model.get_dim_limits, slicepoint=(None, 0, 0), transpose=False)
+        self.assertRaises(ValueError,
+                          model.get_dim_limits,
+                          slicepoint=(None, 0, 0),
+                          transpose=False)
 
     @patch('mantidqt.widgets.sliceviewer.roi.ExtractSpectra')
     def test_export_roi_for_matrixworkspace(self, mock_extract_spectra):
@@ -615,11 +607,10 @@ class SliceViewerModelTest(unittest.TestCase):
 
         def assert_call_as_expected(exp_xmin, exp_xmax, exp_start_index, exp_end_index, transpose,
                                     is_spectra):
-            mock_ws = _create_mock_matrixworkspace(
-                x_axis=[10, 20, 30],
-                y_axis=[1, 2, 3, 4, 5],
-                distribution=False,
-                y_is_spectra=is_spectra)
+            mock_ws = _create_mock_matrixworkspace(x_axis=[10, 20, 30],
+                                                   y_axis=[1, 2, 3, 4, 5],
+                                                   distribution=False,
+                                                   y_is_spectra=is_spectra)
             mock_ws.name.return_value = 'mock_ws'
             model = SliceViewerModel(mock_ws)
             slicepoint, bin_params = MagicMock(), MagicMock()
@@ -633,14 +624,13 @@ class SliceViewerModelTest(unittest.TestCase):
             else:
                 mock_ws.getAxis(1).extractValues.assert_called_once()
 
-            mock_extract_spectra.assert_called_once_with(
-                InputWorkspace=mock_ws,
-                OutputWorkspace='mock_ws_roi',
-                XMin=exp_xmin,
-                XMax=exp_xmax,
-                StartWorkspaceIndex=exp_start_index,
-                EndWorkspaceIndex=exp_end_index,
-                EnableLogging=True)
+            mock_extract_spectra.assert_called_once_with(InputWorkspace=mock_ws,
+                                                         OutputWorkspace='mock_ws_roi',
+                                                         XMin=exp_xmin,
+                                                         XMax=exp_xmax,
+                                                         StartWorkspaceIndex=exp_start_index,
+                                                         EndWorkspaceIndex=exp_end_index,
+                                                         EnableLogging=True)
             mock_extract_spectra.reset_mock()
 
         assert_call_as_expected(xmin, xmax, 3, 5, transpose=False, is_spectra=True)
@@ -660,8 +650,9 @@ class SliceViewerModelTest(unittest.TestCase):
             model = SliceViewerModel(mock_ws)
             slicepoint, bin_params = MagicMock(), MagicMock()
 
-            help_msg = model.export_cuts_to_workspace(
-                slicepoint, bin_params, ((xmin, xmax), (ymin, ymax)), transpose, export_type)
+            help_msg = model.export_cuts_to_workspace(slicepoint, bin_params,
+                                                      ((xmin, xmax), (ymin, ymax)), transpose,
+                                                      export_type)
 
             if export_type == 'c':
                 if is_spectra:
@@ -705,33 +696,29 @@ class SliceViewerModelTest(unittest.TestCase):
         for export_type in ('c', 'x', 'y'):
             is_ragged = False
             for is_spectra in (True, False):
-                mock_ws = _create_mock_matrixworkspace(
-                    x_axis=[10, 20, 30],
-                    y_axis=[1, 2, 3, 4, 5],
-                    distribution=False,
-                    y_is_spectra=is_spectra)
+                mock_ws = _create_mock_matrixworkspace(x_axis=[10, 20, 30],
+                                                       y_axis=[1, 2, 3, 4, 5],
+                                                       distribution=False,
+                                                       y_is_spectra=is_spectra)
                 mock_ws.name.return_value = 'mock_ws'
-                assert_call_as_expected(
-                    mock_ws,
-                    transpose=False,
-                    export_type=export_type,
-                    is_spectra=is_spectra,
-                    is_ragged=is_ragged)
+                assert_call_as_expected(mock_ws,
+                                        transpose=False,
+                                        export_type=export_type,
+                                        is_spectra=is_spectra,
+                                        is_ragged=is_ragged)
 
             is_ragged = True
-            mock_ws = _create_mock_matrixworkspace(
-                x_axis=[10, 20, 30, 11, 21, 31],
-                y_axis=[1, 2, 3, 4, 5],
-                distribution=False,
-                y_is_spectra=is_spectra)
+            mock_ws = _create_mock_matrixworkspace(x_axis=[10, 20, 30, 11, 21, 31],
+                                                   y_axis=[1, 2, 3, 4, 5],
+                                                   distribution=False,
+                                                   y_is_spectra=is_spectra)
             mock_ws.isCommonBins.return_value = False
             mock_ws.name.return_value = 'mock_ws'
-            assert_call_as_expected(
-                mock_ws,
-                transpose=False,
-                export_type=export_type,
-                is_spectra=is_spectra,
-                is_ragged=is_ragged)
+            assert_call_as_expected(mock_ws,
+                                    transpose=False,
+                                    export_type=export_type,
+                                    is_spectra=is_spectra,
+                                    is_ragged=is_ragged)
 
     @patch('mantidqt.widgets.sliceviewer.model.TransposeMD')
     @patch('mantidqt.widgets.sliceviewer.model.BinMD')
@@ -747,28 +734,27 @@ class SliceViewerModelTest(unittest.TestCase):
                 help_msg = model.export_roi_to_workspace(slicepoint, bin_params,
                                                          ((xmin, xmax), (ymin, ymax)), transpose)
             else:
-                help_msg = model.export_cuts_to_workspace(
-                    slicepoint, bin_params, ((xmin, xmax), (ymin, ymax)), transpose, export_type)
+                help_msg = model.export_cuts_to_workspace(slicepoint, bin_params,
+                                                          ((xmin, xmax), (ymin, ymax)), transpose,
+                                                          export_type)
 
             if transpose:
                 extents = [ymin, ymax, xmin, xmax, zmin, zmax]
             else:
                 extents = [xmin, xmax, ymin, ymax, zmin, zmax]
-            common_call_params = dict(
-                InputWorkspace=self.ws_MDE_3D,
-                AxisAligned=False,
-                BasisVector0='h,rlu,1.0,0.0,0.0',
-                BasisVector1='k,rlu,0.0,1.0,0.0',
-                BasisVector2='l,rlu,0.0,0.0,1.0',
-                OutputExtents=extents)
+            common_call_params = dict(InputWorkspace=self.ws_MDE_3D,
+                                      AxisAligned=False,
+                                      BasisVector0='h,rlu,1.0,0.0,0.0',
+                                      BasisVector1='k,rlu,0.0,1.0,0.0',
+                                      BasisVector2='l,rlu,0.0,0.0,1.0',
+                                      OutputExtents=extents)
             xcut_name, ycut_name = 'ws_MDE_3D_cut_x', 'ws_MDE_3D_cut_y'
             if export_type == 'r':
                 expected_help_msg = 'ROI created: ws_MDE_3D_roi'
                 expected_calls = [
-                    call(
-                        **common_call_params,
-                        OutputBins=[100, 100, 1],
-                        OutputWorkspace='ws_MDE_3D_roi')
+                    call(**common_call_params,
+                         OutputBins=[100, 100, 1],
+                         OutputWorkspace='ws_MDE_3D_roi')
                 ]
             elif export_type == 'x':
                 expected_help_msg = f'Cut along X created: {xcut_name}'
@@ -839,8 +825,9 @@ class SliceViewerModelTest(unittest.TestCase):
                     help_msg = model.export_roi_to_workspace(slicepoint, bin_params,
                                                              ((1.0, 2.0), (-1, 2.0)), True)
                 else:
-                    help_msg = model.export_cuts_to_workspace(
-                        slicepoint, bin_params, ((1.0, 2.0), (-1, 2.0)), True, export_type)
+                    help_msg = model.export_cuts_to_workspace(slicepoint, bin_params,
+                                                              ((1.0, 2.0), (-1, 2.0)), True,
+                                                              export_type)
             except Exception as exc:
                 help_msg = str(exc)
             mock_alg.reset_mock()
@@ -860,14 +847,18 @@ class SliceViewerModelTest(unittest.TestCase):
         self.assertEqual(expectation, model.can_support_nonorthogonal_axes())
 
     def _assert_supports_peaks_overlay(self, expectation, ws_type, ndims=2):
-        ws = _create_mock_workspace(
-            ws_type, coords=SpecialCoordinateSystem.QLab, has_oriented_lattice=False, ndims=ndims)
+        ws = _create_mock_workspace(ws_type,
+                                    coords=SpecialCoordinateSystem.QLab,
+                                    has_oriented_lattice=False,
+                                    ndims=ndims)
         model = SliceViewerModel(ws)
         self.assertEqual(expectation, model.can_support_peaks_overlays())
 
     def _assert_supports_dynamic_rebinning(self, expectation, ws_type, has_original_workspace=None):
-        ws = _create_mock_workspace(
-            ws_type, coords=SpecialCoordinateSystem.QLab, has_oriented_lattice=False, ndims=3)
+        ws = _create_mock_workspace(ws_type,
+                                    coords=SpecialCoordinateSystem.QLab,
+                                    has_oriented_lattice=False,
+                                    ndims=3)
         if ws_type == MatrixWorkspace:
             ws.hasOriginalWorkspace.return_value = False
         elif has_original_workspace is not None:


### PR DESCRIPTION
**Description of work.**

See commit description.

**Note that this disables dynamic binning of MDHistoWorkspaces but this be fixed in a future issue.

**To test:**

Use the non-axis-aligned example in the [BinMD docs](https://docs.mantidproject.org/nightly/algorithms/BinMD-v1.html#usage) to produce an MDHistoWorkspace from an MDEventWorkspace. View it in the sliceviewer. It should look like the image on the page with the exception of using a different colormap. The current version on master goes back to the original workspace and the peaks would appear separated along a 45deg slope. To be sure compare the sliceviewer with the MDEventWorkspace and MDHistoWorkspace.


Refs #29086 

*This does not require release notes* because **as it will only be in nightly.**

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
