### PR TITLE
Include batch filename in CanSAS and NXcanSAS metadata

### DIFF
--- a/Framework/DataHandling/inc/MantidDataHandling/NXcanSASDefinitions.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/NXcanSASDefinitions.h
@@ -112,6 +112,8 @@ const std::string sasProcessTermSvn = "svn";
 const std::string sasProcessTermCan = "can_trans_run";
 const std::string sasProcessTermUserFile = "user_file";
 const std::string sasProcessUserFileInLogs = "UserFile";
+const std::string sasProcessTermBatchFile = "batch_file";
+const std::string sasProcessBatchFileInLogs = "BatchFile";
 
 // SASnote
 const std::string sasNoteClassAttr = "SASnote";

--- a/Framework/DataHandling/src/LoadNXcanSAS.cpp
+++ b/Framework/DataHandling/src/LoadNXcanSAS.cpp
@@ -106,25 +106,27 @@ createWorkspaceForHistogram(H5::DataSet &dataSet) {
 
 // ----- LOGS
 
+void addLogFromGroupIfExists(H5::Group &sasGroup, std::string const &sasTerm,
+                             Run &run, std::string const &propertyName) {
+  auto value = Mantid::DataHandling::H5Util::readString(sasGroup, sasTerm);
+  if (!value.empty()) {
+    run.addLogData(new PropertyWithValue<std::string>(propertyName, value));
+  }
+}
+
 void loadLogs(H5::Group &entry,
               const Mantid::API::MatrixWorkspace_sptr &workspace) {
   auto &run = workspace->mutableRun();
 
-  // Load UserFile (optional)
+  // Load UserFile and BatchFile (optional)
   auto process = entry.openGroup(sasProcessGroupName);
-  auto userFile =
-      Mantid::DataHandling::H5Util::readString(process, sasProcessTermUserFile);
-  if (!userFile.empty()) {
-    run.addLogData(
-        new PropertyWithValue<std::string>(sasProcessUserFileInLogs, userFile));
-  }
+  addLogFromGroupIfExists(process, sasProcessTermUserFile, run,
+                          sasProcessUserFileInLogs);
+  addLogFromGroupIfExists(process, sasProcessTermBatchFile, run,
+                          sasProcessBatchFileInLogs);
 
   // Load Run (optional)
-  auto runNumber = Mantid::DataHandling::H5Util::readString(entry, sasEntryRun);
-  if (!runNumber.empty()) {
-    run.addLogData(
-        new PropertyWithValue<std::string>(sasEntryRunInLogs, runNumber));
-  }
+  addLogFromGroupIfExists(entry, sasEntryRun, run, sasEntryRunInLogs);
 
   // Load Title (optional)
   auto title = Mantid::DataHandling::H5Util::readString(entry, sasEntryTitle);

--- a/Framework/DataHandling/src/SaveCanSAS1D2.cpp
+++ b/Framework/DataHandling/src/SaveCanSAS1D2.cpp
@@ -214,6 +214,8 @@ void SaveCanSAS1D2::createSASProcessElement(std::string &sasProcess) {
   std::string user_file;
   if (run.hasProperty("UserFile")) {
     user_file = run.getLogData("UserFile")->value();
+  } else {
+    g_log.warning("No user file was found in the input workspace.");
   }
 
   std::string sasProcuserfile = "\n\t\t\t<term name=\"user_file\">";
@@ -221,6 +223,15 @@ void SaveCanSAS1D2::createSASProcessElement(std::string &sasProcess) {
   sasProcuserfile += "</term>";
   // outFile<<sasProcuserfile;
   sasProcess += sasProcuserfile;
+
+  std::string batch_file;
+  if (run.hasProperty("BatchFile")) {
+    batch_file = run.getLogData("BatchFile")->value();
+  }
+  std::string sasProcbatchfile = "\n\t\t\t<term name=\"batch_file\">";
+  sasProcbatchfile += batch_file;
+  sasProcbatchfile += "</term>";
+  sasProcess += sasProcbatchfile;
 
   if (m_trans_ws) {
     // Add other run numbers

--- a/Framework/DataHandling/src/SaveNXcanSAS.cpp
+++ b/Framework/DataHandling/src/SaveNXcanSAS.cpp
@@ -299,6 +299,22 @@ std::string getDate() {
   return sasDate;
 }
 
+/** Write a property value to the H5 file if the property exists in the run
+ *
+ * @param run : the run to look for the property in
+ * @param propertyName : the name of the property to find
+ * @param sasGroup : the group to add the term into in the output file
+ * @param sasTerm : the name of the term to add
+ */
+void addPropertyFromRunIfExists(Run const &run, std::string const &propertyName,
+                                H5::Group &sasGroup,
+                                std::string const &sasTerm) {
+  if (run.hasProperty(propertyName)) {
+    auto property = run.getProperty(propertyName);
+    Mantid::DataHandling::H5Util::write(sasGroup, sasTerm, property->value());
+  }
+}
+
 /**
  * Add the process information to the NXcanSAS file. This information
  * about the run number, the Mantid version and the user file (if available)
@@ -324,13 +340,12 @@ void addProcess(H5::Group &group,
   const auto version = std::string(MantidVersion::version());
   Mantid::DataHandling::H5Util::write(process, sasProcessTermSvn, version);
 
+  // Add log values
   const auto run = workspace->run();
-  if (run.hasProperty(sasProcessUserFileInLogs)) {
-    auto userFileProperty = run.getProperty(sasProcessUserFileInLogs);
-    auto userFileString = userFileProperty->value();
-    Mantid::DataHandling::H5Util::write(process, sasProcessTermUserFile,
-                                        userFileString);
-  }
+  addPropertyFromRunIfExists(run, sasProcessUserFileInLogs, process,
+                             sasProcessTermUserFile);
+  addPropertyFromRunIfExists(run, sasProcessBatchFileInLogs, process,
+                             sasProcessTermBatchFile);
 }
 
 /**
@@ -360,12 +375,10 @@ void addProcess(H5::Group &group,
   Mantid::DataHandling::H5Util::write(process, sasProcessTermSvn, version);
 
   const auto run = workspace->run();
-  if (run.hasProperty(sasProcessUserFileInLogs)) {
-    auto userFileProperty = run.getProperty(sasProcessUserFileInLogs);
-    auto userFileString = userFileProperty->value();
-    Mantid::DataHandling::H5Util::write(process, sasProcessTermUserFile,
-                                        userFileString);
-  }
+  addPropertyFromRunIfExists(run, sasProcessUserFileInLogs, process,
+                             sasProcessTermUserFile);
+  addPropertyFromRunIfExists(run, sasProcessBatchFileInLogs, process,
+                             sasProcessTermBatchFile);
 
   // Add can run number
   const auto canRun = canWorkspace->getRunNumber();

--- a/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/SANS/SANSReductionCore.py
+++ b/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/SANS/SANSReductionCore.py
@@ -14,6 +14,8 @@ from mantid.api import AlgorithmFactory, Progress
 from sans.algorithm_detail.mask_workspace import mask_bins
 from sans.common.enums import DetectorType
 
+import os
+
 
 class SANSReductionCore(SANSReductionCoreBase):
     def category(self):
@@ -141,6 +143,11 @@ class SANSReductionCore(SANSReductionCoreBase):
         # ------------------------------------------------------------
         # Populate the output
         # ------------------------------------------------------------
+        replace_prop = False
+        if state.save.user_file:
+            workspace.getRun().addProperty("UserFile", os.path.basename(state.save.user_file), replace_prop)
+        if state.save.batch_file:
+            workspace.getRun().addProperty("BatchFile", os.path.basename(state.save.batch_file), replace_prop)
         self.setProperty("OutputWorkspace", workspace)
 
         # ------------------------------------------------------------

--- a/docs/source/release/v5.1.0/sans.rst
+++ b/docs/source/release/v5.1.0/sans.rst
@@ -12,6 +12,11 @@ SANS Changes
 Algorithms and instruments
 --------------------------
 
+New
+###
+
+- SaveCanSAS1D and SaveNXCanSAS now include the batch file name in their metadata if one was used to produce the output.
+
 Bug Fixed
 #########
 

--- a/scripts/SANS/sans/gui_logic/models/create_state.py
+++ b/scripts/SANS/sans/gui_logic/models/create_state.py
@@ -12,12 +12,11 @@ from sans.gui_logic.presenter.gui_state_director import (GuiStateDirector)
 sans_logger = Logger("SANS")
 
 
-def create_states(state_model, facility, row_entries=None, file_lookup=True, user_file=""):
+def create_states(state_model, facility, row_entries=None, file_lookup=True):
     """
     Here we create the states based on the settings in the models
     :param state_model: the state model object
     :param row_entries: a list of row entry objects to create state for
-    :param user_file: the user file under which the data is reduced
     """
 
     states = {}

--- a/scripts/SANS/sans/gui_logic/models/state_gui_model.py
+++ b/scripts/SANS/sans/gui_logic/models/state_gui_model.py
@@ -80,6 +80,24 @@ class StateGuiModel(ModelCommon):
     def save_types(self, value):
         self._user_file_items.save.file_format = value
 
+    @property
+    def user_file(self):
+        val = self._user_file_items.save.user_file
+        return val if val else ""
+
+    @user_file.setter
+    def user_file(self, value):
+        self._user_file_items.save.user_file = value
+
+    @property
+    def batch_file(self):
+        val = self._user_file_items.save.batch_file
+        return val if val else ""
+
+    @batch_file.setter
+    def batch_file(self, value):
+        self._user_file_items.save.batch_file = value
+
     # ==================================================================================================================
     # ==================================================================================================================
     # BeamCentre TAB

--- a/scripts/SANS/sans/gui_logic/models/table_model.py
+++ b/scripts/SANS/sans/gui_logic/models/table_model.py
@@ -29,8 +29,6 @@ class TableModel(object):
 
     def __init__(self):
         super(TableModel, self).__init__()
-        self.batch_file = ""
-        self.user_file = ""
         self._subscriber_list = []
 
         self._table_entries = []

--- a/scripts/SANS/sans/gui_logic/presenter/run_tab_presenter.py
+++ b/scripts/SANS/sans/gui_logic/presenter/run_tab_presenter.py
@@ -373,7 +373,6 @@ class RunTabPresenter(PresenterCommon):
             self._on_user_file_load_failure(path_error, error_msg + " when finding file.")
             return
 
-        self._table_model.user_file = user_file_path
         # Clear out the current view
         self._view.reset_all_fields_to_default()
         try:
@@ -388,6 +387,7 @@ class RunTabPresenter(PresenterCommon):
         try:
             # 4. Populate the model and update sub-presenters
             self._model = StateGuiModel(user_file_items)
+            self._model.user_file = user_file_path
             self._settings_adjustment_presenter.set_model(
                 SettingsAdjustmentModel(user_file_items=user_file_items))
             # 5. Update the views.
@@ -438,8 +438,6 @@ class RunTabPresenter(PresenterCommon):
                     "The batch file path {} does not exist. Make sure a valid batch file path"
                     " has been specified.".format(batch_file_path))
 
-            self._table_model.batch_file = batch_file_path
-
             # 2. Read the batch file
             parsed_rows = self._csv_parser.parse_batch_file(batch_file_path)
 
@@ -447,6 +445,10 @@ class RunTabPresenter(PresenterCommon):
             self._table_model.clear_table_entries()
 
             self._add_multiple_rows_to_table_model(rows=parsed_rows)
+
+            # 4. Set the batch file path in the model
+            self._model.batch_file = batch_file_path
+
         except RuntimeError as e:
             self.sans_logger.error("Loading of the batch file failed. {}".format(str(e)))
             self.display_warning_box('Warning', 'Loading of the batch file failed', str(e))

--- a/scripts/SANS/sans/gui_logic/presenter/run_tab_presenter.py
+++ b/scripts/SANS/sans/gui_logic/presenter/run_tab_presenter.py
@@ -938,8 +938,7 @@ class RunTabPresenter(PresenterCommon):
             states, errors = create_states(state_model_with_view_update,
                                            facility=self._facility,
                                            row_entries=row_entries,
-                                           file_lookup=file_lookup,
-                                           user_file=self._view.get_user_file_path())
+                                           file_lookup=file_lookup)
 
         if errors and not suppress_warnings:
             self.sans_logger.warning("Errors in getting states...")

--- a/scripts/SANS/sans/state/StateObjects/StateSave.py
+++ b/scripts/SANS/sans/state/StateObjects/StateSave.py
@@ -26,6 +26,10 @@ class StateSave(metaclass=JsonSerializable):
         self.user_specified_output_name_suffix = None  # : Str()
         self.use_reduction_mode_as_suffix = None  # : Bool
 
+        # Settings for the main user file and batch file
+        self.user_file = None # : Str
+        self.batch_file = None # : Str
+
     def validate(self):
         pass
 


### PR DESCRIPTION
**PR #28513 must be merged first**

**Report to:** Steve King

**Description of work.**

This PR adds the batch file name to the metadata when saving in CanSAS or NXcanSAS formats. 

- In `SANSReductionCore`, add properties for the user and batch file names to the output workspace run.
  - To support this, move the user_file and batch_file paths from the table model to the GUI state model. The table model contains per-row settings but these values are general settings applicable to all rows. The table model itself does not get passed through to the processing functions because we only the subset of rows being processed. Moving these values to the GUI state model means they are available on the SANSState object when we come to do the reduction.
- Update save and load algorithms to support the new batch file tag:
  - Extract the batch file name from the run logs when saving to CanSAS or NXcanSAS
  - Add the batch file name to run logs when loading from CanSAS or NXcanSAS
  - Minor refactoring to avoid code duplication

**To test:**

<!-- Instructions for testing. -->
Note that you'll need HDFView to check the output files.

- Ensure your default save directory is set to something sensible
- Open the ISIS SANS interface
- From the ISIS sample data in the loqdemo directory, load the user file `MaskFile.txt` and batch file `batch_mode_reduction.csv`
- Under Save Options, select `Both`, and tick `CanSAS` and `NxCanSAS`
- Select the first row in the table and click `Process Selected`
- For one of the workspaces, check that the saved `.xml` and `.h5` files contain the correct name for the `UserFile` and `BatchFile` elements (this is just the basename of the files you used).
- Try loading the files and re-saving them by manually calling `SaveCanSAS1D` and `SaveNXcanSAS` on the workspaces. Check that the fields are still correct.
- Repeat the test but without using a batch file and check that the field is empty.
- Make a copy of the MaskFile.txt with a different name and enter its path in the UserFile column in the table. Re-run the test and check that this overrides the default user file for that row.

Fixes #28458 and fixes #28847 

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
-->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
