### PR TITLE
Add function help option to fit browser

### DIFF
--- a/docs/source/release/v5.1.0/indirect_geometry.rst
+++ b/docs/source/release/v5.1.0/indirect_geometry.rst
@@ -36,6 +36,7 @@ Improvements
   This change introduces two optional outputs from the QENSFit algorithms (fit status and Chi squared), which may be used to monitor the outcome of the fit.
 - Added default parameter estimations to the F(q) tab.
 - The ConvFit tab within the IDA GUI will now output convolved members by default.
+- Added a Help option to the right-click menu in the function browser (in full function view) which brings up a relevant documentation page describing the function.
 
 Bug Fixes
 #########

--- a/docs/source/release/v5.1.0/muon.rst
+++ b/docs/source/release/v5.1.0/muon.rst
@@ -35,6 +35,7 @@ New Features
 - Added multi-period support to the LoadMuonNexusV2 algorithm.
 - Added two buttons to the Muon analysis and Frequency domain analysis plot toolbar to allow users to show major and minor gridlines.
 - Added a Plot difference checkbox to the Muon Analysis GUI, which allows user to choose whether the fit difference curve is shown.
+- Added a Help option to the right-click menu in the function browser which brings up a relevant documentation page describing the function.
 
 Improvements
 -------------

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/FunctionMultiDomainPresenter.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/FunctionMultiDomainPresenter.h
@@ -90,6 +90,7 @@ private slots:
   void viewChangedGlobals(const QStringList &globalParameters);
   void editLocalParameter(const QString &parName);
   void editLocalParameterFinish(int result);
+  void viewRequestedFunctionHelp();
 
 private:
   void updateViewFromModel();

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/FunctionTreeView.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/FunctionTreeView.h
@@ -116,6 +116,9 @@ public:
   /// Get a list of global parameters
   QStringList getGlobalParameters() const;
 
+  IFunction_sptr getSelectedFunction() override;
+  void showFunctionHelp(const QString &functionName) const override;
+
   /// Return the function
   Mantid::API::IFunction_sptr getFunction(QtProperty *prop = nullptr,
                                           bool attributesOnly = false);
@@ -253,9 +256,7 @@ protected slots:
   void removeConstraint();
   /// Update index of currently selected function
   void updateCurrentFunctionIndex();
-
   //   Property change slots
-
   /// Called when a function attribute property is changed
   void attributeChanged(QtProperty *);
   /// Called when a member of a vector attribute is changed
@@ -343,6 +344,8 @@ protected:
   QAction *m_actionRemoveConstraints;
   /// Remove one constraints from current parameter
   QAction *m_actionRemoveConstraint;
+  /// Show function help menu
+  QAction *m_actionFunctionHelp;
   /// Index of currently selected function. Gets updated in
   /// updateCurrentFunctionIndex()
   boost::optional<QString> m_currentFunctionIndex;

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/IFunctionView.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/IFunctionView.h
@@ -30,6 +30,7 @@ public:
   virtual void clear() = 0;
   virtual void setFunction(IFunction_sptr fun) = 0;
   virtual bool hasFunction() const = 0;
+  virtual IFunction_sptr getSelectedFunction() = 0;
   virtual void setParameter(const QString &paramName, double value) = 0;
   virtual void setParameterError(const QString &paramName, double error) = 0;
   virtual double getParameter(const QString &paramName) const = 0;
@@ -41,6 +42,7 @@ public:
   virtual void setParameterConstraint(const QString &paramName,
                                       const QString &constraint) = 0;
   virtual void setGlobalParameters(const QStringList &) = 0;
+  virtual void showFunctionHelp(const QString &) const = 0;
 
 signals:
   /// User replaces the whole function (eg, by pasting it from clipboard)
@@ -64,6 +66,8 @@ signals:
   void parameterConstraintRemoved(const QString &paramName);
   /// User requested copy function to clipboard
   void copyToClipboardRequest();
+  /// User requested function help
+  void functionHelpRequest();
   /// User changed the list of global parameters.
   void globalsChanged(const QStringList &);
 };

--- a/qt/widgets/common/src/FunctionMultiDomainPresenter.cpp
+++ b/qt/widgets/common/src/FunctionMultiDomainPresenter.cpp
@@ -49,6 +49,8 @@ FunctionMultiDomainPresenter::FunctionMultiDomainPresenter(IFunctionView *view)
           SLOT(viewRequestedCopyToClipboard()));
   connect(m_view, SIGNAL(globalsChanged(const QStringList &)), this,
           SLOT(viewChangedGlobals(const QStringList &)));
+  connect(m_view, SIGNAL(functionHelpRequest()), this,
+          SLOT(viewRequestedFunctionHelp()));
 }
 
 void FunctionMultiDomainPresenter::setFunction(IFunction_sptr fun) {
@@ -305,6 +307,12 @@ void FunctionMultiDomainPresenter::viewChangedGlobals(
     const QStringList &globalParameters) {
   m_model->setGlobalParameters(globalParameters);
   emit functionStructureChanged();
+}
+
+void FunctionMultiDomainPresenter::viewRequestedFunctionHelp() {
+  auto func = m_view->getSelectedFunction();
+  if (func)
+    m_view->showFunctionHelp(QString::fromStdString(func->name()));
 }
 
 QString FunctionMultiDomainPresenter::getFunctionString() const {

--- a/qt/widgets/common/src/FunctionTreeView.cpp
+++ b/qt/widgets/common/src/FunctionTreeView.cpp
@@ -17,6 +17,7 @@
 #include "MantidKernel/Logger.h"
 
 #include "MantidQtWidgets/Common/EditLocalParameterDialog.h"
+#include "MantidQtWidgets/Common/InterfaceManager.h"
 #include "MantidQtWidgets/Common/QtPropertyBrowser/DoubleDialogEditor.h"
 #include "MantidQtWidgets/Common/QtPropertyBrowser/FilenameDialogEditor.h"
 #include "MantidQtWidgets/Common/QtPropertyBrowser/FormulaDialogEditor.h"
@@ -251,6 +252,10 @@ void FunctionTreeView::createActions() {
   m_actionRemoveConstraint = new QAction("Remove", this);
   connect(m_actionRemoveConstraint, SIGNAL(triggered()), this,
           SLOT(removeConstraint()));
+
+  m_actionFunctionHelp = new QAction("Help", this);
+  connect(m_actionFunctionHelp, SIGNAL(triggered()), this,
+          SIGNAL(functionHelpRequest()));
 
   setErrorsEnabled(false);
 }
@@ -1119,6 +1124,7 @@ void FunctionTreeView::popupMenu(const QPoint &) {
     if (!m_browser->properties().isEmpty()) {
       context.addAction(m_actionToClipboard);
     }
+    context.addAction(m_actionFunctionHelp);
     context.exec(QCursor::pos());
   } else if (isParameter(prop)) { // parameters
     QMenu context(this);
@@ -1661,6 +1667,24 @@ void FunctionTreeView::removeConstraint() {
   if (!constraint.isEmpty()) {
     emit parameterConstraintAdded(functionIndex, constraint);
   }
+}
+/**
+ * Get user selected function
+ */
+IFunction_sptr FunctionTreeView::getSelectedFunction() {
+  auto item = m_browser->currentItem();
+  if (!item)
+    return IFunction_sptr();
+  QtProperty *prop = item->property();
+  if (!isFunction(prop))
+    return IFunction_sptr();
+  return getFunction(prop);
+}
+/**
+ * Show function help page for input functionName
+ */
+void FunctionTreeView::showFunctionHelp(const QString &functionName) const {
+  API::InterfaceManager().showFitFunctionHelp(functionName);
 }
 
 std::pair<QString, QString>


### PR DESCRIPTION
**Description of work.**
This PR adds a help option to the context menu in the fit browser, directing users to the relevant docs page on that function.

**Report to:** ISIS/Spencer

**To test:**
(You'll need to have docs built to test this)
- Open Indirect data analysis
- Go to the ConvFit tab
- Add a Lorentzian (using the spinbox)
- Click show full function view
- You should be able to right click on each function in that browser and open a help page.
- The same holds true for the fit browser in Muon Analysis and Frequency Domain Analysis

*There is no associated issue.*

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
-->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
