### PR TITLE
Added major and minor gridline option to muon guis

### DIFF
--- a/docs/source/release/v5.1.0/muon.rst
+++ b/docs/source/release/v5.1.0/muon.rst
@@ -33,8 +33,7 @@ New Features
 - Updated rounding for time zero and first good data to be 3 decimal places.
 - Added double pulse analysis, see :ref:`Muon home tab <muon_home_tab-ref>`.
 - Added multi-period support to the LoadMuonNexusV2 algorithm.
-- Added buttons on plotting toolbar to allow users to show major or minor gridlines on Muon analysis and Frequency 
-  domain analysis gui.
+- Added two buttons to the Muon analysis and Frequency domain analysis plot toolbar to allow users to show major and minor gridlines.
 
 
 Improvements

--- a/docs/source/release/v5.1.0/muon.rst
+++ b/docs/source/release/v5.1.0/muon.rst
@@ -33,6 +33,9 @@ New Features
 - Updated rounding for time zero and first good data to be 3 decimal places.
 - Added double pulse analysis, see :ref:`Muon home tab <muon_home_tab-ref>`.
 - Added multi-period support to the LoadMuonNexusV2 algorithm.
+- Added buttons on plotting toolbar to allow users to show major or minor gridlines on Muon analysis and Frequency 
+  domain analysis gui.
+
 
 Improvements
 -------------

--- a/scripts/Muon/GUI/Common/plot_widget/plotting_canvas/plot_toolbar.py
+++ b/scripts/Muon/GUI/Common/plot_widget/plotting_canvas/plot_toolbar.py
@@ -84,11 +84,15 @@ class PlotToolbar(NavigationToolbar):
     def show_minor_gridlines(self):
         if self.is_minor_grid_on:
             for ax in self.canvas.figure.get_axes():
-                ax.minorticks_off()
-            self.is_major_grid_on = False
+                ax.grid(which='minor')
+            self.is_minor_grid_on = False
         else:
             for ax in self.canvas.figure.get_axes():
                 ax.minorticks_on()
                 ax.grid(which='minor')
-            self.is_major_grid_on = True
+            self.is_minor_grid_on = True
         self.canvas.draw()
+
+    def reset_gridline_flags(self):
+        self.is_minor_grid_on = False
+        self.is_major_grid_on = False

--- a/scripts/Muon/GUI/Common/plot_widget/plotting_canvas/plot_toolbar.py
+++ b/scripts/Muon/GUI/Common/plot_widget/plotting_canvas/plot_toolbar.py
@@ -6,6 +6,7 @@
 # SPDX - License - Identifier: GPL - 3.0 +
 from matplotlib.backends.qt_compat import is_pyqt5
 from mantidqt.icons import get_icon
+from qtpy import QtCore, QtWidgets
 if is_pyqt5():
     from matplotlib.backends.backend_qt5agg import (
         NavigationToolbar2QT as NavigationToolbar)
@@ -13,9 +14,9 @@ else:
     from matplotlib.backends.backend_qt4agg import (
         NavigationToolbar2QT as NavigationToolbar)
 
-from qtpy import QtCore, QtWidgets
 
 class PlotToolbar(NavigationToolbar):
+
     def __init__(self, figure_canvas, parent=None):
         self.toolitems = (('Home', 'Reset original view', 'mdi.home', 'home'),
                           ('Back', 'Back to previous view', 'mdi.arrow-left', 'back'),

--- a/scripts/Muon/GUI/Common/plot_widget/plotting_canvas/plot_toolbar.py
+++ b/scripts/Muon/GUI/Common/plot_widget/plotting_canvas/plot_toolbar.py
@@ -5,7 +5,7 @@
 #   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
 # SPDX - License - Identifier: GPL - 3.0 +
 from matplotlib.backends.qt_compat import is_pyqt5
-
+from mantidqt.icons import get_icon
 if is_pyqt5():
     from matplotlib.backends.backend_qt5agg import (
         NavigationToolbar2QT as NavigationToolbar)
@@ -13,27 +13,76 @@ else:
     from matplotlib.backends.backend_qt4agg import (
         NavigationToolbar2QT as NavigationToolbar)
 
+from qtpy import QtCore, QtWidgets
 
 class PlotToolbar(NavigationToolbar):
     def __init__(self, figure_canvas, parent=None):
-        self.toolitems = (('Home', 'Reset original view', 'home', 'home'),
-                          ('Back', 'Back to previous view', 'back', 'back'),
-                          ('Forward', 'Forward to next view', 'forward', 'forward'),
+        self.toolitems = (('Home', 'Reset original view', 'mdi.home', 'home'),
+                          ('Back', 'Back to previous view', 'mdi.arrow-left', 'back'),
+                          ('Forward', 'Forward to next view', 'mdi.arrow-right', 'forward'),
                           (None, None, None, None),
-                          ('Pan', 'Pan axes with left mouse, zoom with right', 'move', 'pan'),
-                          ('Zoom', 'Zoom to rectangle', 'zoom_to_rect', 'zoom'),
+                          ('Pan', 'Pan axes with left mouse, zoom with right', 'mdi.arrow-all', 'pan'),
+                          ('Zoom', 'Zoom to rectangle', 'mdi.magnify', 'zoom'),
                           (None, None, None, None),
-                          ('Subplots', 'Edit subplots', 'subplots', 'configure_subplots'),
-                          ('Save', 'Save the figure', 'filesave', 'save_figure'),
+                          ('Show major','Show major gridlines','mdi.grid-large','show_major_gridlines'),
+                          ('Show minor','Show minor gridlines','mdi.grid','show_minor_gridlines' ),
                           (None, None, None, None),
-                          ('Show/hide legend', 'Toggles the legend on/off', "select", 'toggle_legend'),
+                          ('Subplots', 'Edit subplots', 'mdi.settings', 'configure_subplots'),
+                          ('Save', 'Save the figure', 'mdi.content-save', 'save_figure'),
+                          (None, None, None, None),
+                          ('Show/hide legend', 'Toggles the legend on/off', None, 'toggle_legend'),
                           )
-
+        self.is_major_grid_on = True
         NavigationToolbar.__init__(self, figure_canvas, parent=parent)
+
+    def _init_toolbar(self):
+        for text, tooltip_text, mdi_icon, callback in self.toolitems:
+            if text is None:
+                self.addSeparator()
+            else:
+
+                if mdi_icon:
+                    a = self.addAction(get_icon(mdi_icon), text, getattr(self, callback))
+                else:
+                    a = self.addAction(text, getattr(self, callback))
+                self._actions[callback] = a
+                if tooltip_text is not None:
+                    a.setToolTip(tooltip_text)
+
+        if self.coordinates:
+            self.locLabel = QtWidgets.QLabel("", self)
+            self.locLabel.setAlignment(QtCore.Qt.AlignRight | QtCore.Qt.AlignTop)
+            self.locLabel.setSizePolicy(QtWidgets.QSizePolicy(QtWidgets.QSizePolicy(QtWidgets.QSizePolicy.Expanding,
+                                                                                    QtWidgets.QSizePolicy.Ignored)))
+            labelAction = self.addWidget(self.locLabel)
+            labelAction.setVisible(True)
+
+        # Adjust icon size or they are too small in PyQt5 by default
+        dpi_ratio = QtWidgets.QApplication.instance().desktop().physicalDpiX() / 100
+        self.setIconSize(QtCore.QSize(24 * dpi_ratio, 24 * dpi_ratio))
 
     def toggle_legend(self):
         for ax in self.canvas.figure.get_axes():
             if ax.get_legend() is not None:
                 ax.get_legend().set_visible(not ax.get_legend().get_visible())
         self.canvas.figure.tight_layout()
+        self.canvas.draw()
+
+    def show_major_gridlines(self):
+        # if self.is_major_grid_on:
+        #     for ax in self.canvas.figure.get_axes():
+        #         ax.grid(self.is_major_grid_on,colour = 'black')
+        #     self.is_major_grid_on = False
+        # else:
+        #     for ax in self.canvas.figure.get_axes():
+        #         ax.grid(self.is_major_grid_on)
+        #     self.is_major_grid_on = True
+        for ax in self.canvas.figure.get_axes():
+            ax.grid(which='major')
+        self.canvas.draw()
+
+    def show_minor_gridlines(self):
+        for ax in self.canvas.figure.get_axes():
+            ax.minorticks_on()
+            ax.grid(which='minor')
         self.canvas.draw()

--- a/scripts/Muon/GUI/Common/plot_widget/plotting_canvas/plot_toolbar.py
+++ b/scripts/Muon/GUI/Common/plot_widget/plotting_canvas/plot_toolbar.py
@@ -32,7 +32,8 @@ class PlotToolbar(NavigationToolbar):
                           (None, None, None, None),
                           ('Show/hide legend', 'Toggles the legend on/off', None, 'toggle_legend'),
                           )
-        self.is_major_grid_on = True
+        self.is_major_grid_on = False
+        self.is_minor_grid_on = False
         NavigationToolbar.__init__(self, figure_canvas, parent=parent)
 
     def _init_toolbar(self):
@@ -69,20 +70,24 @@ class PlotToolbar(NavigationToolbar):
         self.canvas.draw()
 
     def show_major_gridlines(self):
-        # if self.is_major_grid_on:
-        #     for ax in self.canvas.figure.get_axes():
-        #         ax.grid(self.is_major_grid_on,colour = 'black')
-        #     self.is_major_grid_on = False
-        # else:
-        #     for ax in self.canvas.figure.get_axes():
-        #         ax.grid(self.is_major_grid_on)
-        #     self.is_major_grid_on = True
-        for ax in self.canvas.figure.get_axes():
-            ax.grid(which='major')
+        if self.is_major_grid_on:
+            for ax in self.canvas.figure.get_axes():
+                ax.grid(False)
+            self.is_major_grid_on = False
+        else:
+            for ax in self.canvas.figure.get_axes():
+                ax.grid(True , color='black')
+            self.is_major_grid_on = True
         self.canvas.draw()
 
     def show_minor_gridlines(self):
-        for ax in self.canvas.figure.get_axes():
-            ax.minorticks_on()
-            ax.grid(which='minor')
+        if self.is_minor_grid_on:
+            for ax in self.canvas.figure.get_axes():
+                ax.minorticks_off()
+            self.is_major_grid_on = False
+        else:
+            for ax in self.canvas.figure.get_axes():
+                ax.minorticks_on()
+                ax.grid(which='minor')
+            self.is_major_grid_on = True
         self.canvas.draw()

--- a/scripts/Muon/GUI/Common/plot_widget/plotting_canvas/plotting_canvas_view.py
+++ b/scripts/Muon/GUI/Common/plot_widget/plotting_canvas/plotting_canvas_view.py
@@ -85,6 +85,7 @@ class PlottingCanvasView(QtWidgets.QWidget, PlottingCanvasViewInterface):
 
     def create_new_plot_canvas(self, num_axes):
         """Creates a new blank plotting canvas"""
+        self.toolBar.reset_gridline_flags()
         self._plot_information_list = []
         self._number_of_axes = num_axes
         self._color_queue = [ColorQueue() for _ in range(num_axes) ]


### PR DESCRIPTION
**Description of work.**
Added 2 buttons on plotting toolbar used in Muon analysis gui and Frequency domain analysis gui which 
allow users to show major or minor gridlines.

**To test:**
1. Open Muon analysis gui.
2. Select 1 to show major gridlines and 2 to show minor gridlines.
3. The same should hold true for Frequency domain analysis gui.
![tempsnip](https://user-images.githubusercontent.com/59264035/90237363-128e7d00-de1c-11ea-906b-34a8d71d4672.png)


Fixes #29018 . 

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
