### PR TITLE
Warn people about settings that need a restart in workbench

### DIFF
--- a/docs/source/release/v5.1.0/mantidworkbench.rst
+++ b/docs/source/release/v5.1.0/mantidworkbench.rst
@@ -24,6 +24,8 @@ Improvements
 
 - The plot selection dialog now correctly shows the full range of valid spectra to plot, not just the min to max range.
 - We have added a Copy to Clipboard button to the plot window.
+- Any changes in the settings menu (currently only changing the default font) that require a restart will be detailed in
+  a pop up notification when leaving the settings window.
 - Tile plots are now reloaded correctly by project recovery.
 - When you stop a script running in workbench it will now automatically attempt to cancel the algorithm the script is running, rather than wait for the current algorthm to end.
   This is similar to what Mantidplot does, and should result in the script stopping much sooner.

--- a/qt/applications/workbench/workbench/widgets/settings/general/presenter.py
+++ b/qt/applications/workbench/workbench/widgets/settings/general/presenter.py
@@ -104,9 +104,10 @@ class GeneralSettings(object):
         font_string = ""
         if CONF.has(GeneralProperties.FONT.value):
             font_string = CONF.get(GeneralProperties.FONT.value)
-        if self.settings_presenter is not None and font_string != font.toString():
+        if font_string != font.toString():
             CONF.set(GeneralProperties.FONT.value, font.toString())
-            self.settings_presenter.register_change_needs_restart("Main Font Selection")
+            if self.settings_presenter is not None:
+                self.settings_presenter.register_change_needs_restart("Main Font Selection")
 
     def setup_checkbox_signals(self):
         self.view.show_invisible_workspaces.stateChanged.connect(self.action_show_invisible_workspaces)

--- a/qt/applications/workbench/workbench/widgets/settings/general/presenter.py
+++ b/qt/applications/workbench/workbench/widgets/settings/general/presenter.py
@@ -42,9 +42,10 @@ class GeneralSettings(object):
     be handled here.
     """
 
-    def __init__(self, parent, view=None):
+    def __init__(self, parent, view=None, settings_presenter=None):
         self.view = view if view else GeneralSettingsView(parent, self)
         self.parent = parent
+        self.settings_presenter = settings_presenter
         self.load_current_setting_values()
 
         self.setup_facilities_group()
@@ -100,7 +101,12 @@ class GeneralSettings(object):
         font_dialog.fontSelected.connect(self.action_font_selected)
 
     def action_font_selected(self, font):
-        CONF.set(GeneralProperties.FONT.value, font.toString())
+        font_string = ""
+        if CONF.has(GeneralProperties.FONT.value):
+            font_string = CONF.get(GeneralProperties.FONT.value)
+        if self.settings_presenter is not None and font_string != font.toString():
+            CONF.set(GeneralProperties.FONT.value, font.toString())
+            self.settings_presenter.register_change_needs_restart("Main Font Selection")
 
     def setup_checkbox_signals(self):
         self.view.show_invisible_workspaces.stateChanged.connect(self.action_show_invisible_workspaces)

--- a/qt/applications/workbench/workbench/widgets/settings/presenter.py
+++ b/qt/applications/workbench/workbench/widgets/settings/presenter.py
@@ -22,6 +22,9 @@ from workbench.widgets.settings.model import SettingsModel
 class SettingsPresenter(object):
     ASK_BEFORE_CLOSE_TITLE = "Confirm exit"
     ASK_BEFORE_CLOSE_MESSAGE = "Are you sure you want to exit without applying the settings?"
+    CHANGES_NEED_RESTART_TITLE = "Some changes require restart"
+    CHANGES_NEED_RESTART_MESSAGE = "The following changes will be applied when the workbench is restarted:\n\n"
+
     SETTINGS_TABS = {'general_settings' : "General",
                      'categories_settings' : "Categories",
                      'plot_settings': "Plots",
@@ -31,7 +34,7 @@ class SettingsPresenter(object):
                  categories_settings=None, plot_settings=None, fitting_settings=None):
         self.view = view if view else SettingsView(parent, self)
         self.model = model if model else SettingsModel()
-        self.general_settings = general_settings if general_settings else GeneralSettings(parent)
+        self.general_settings = general_settings if general_settings else GeneralSettings(parent, None, self)
         self.categories_settings = categories_settings if categories_settings else CategoriesSettings(parent)
         self.plot_settings = plot_settings if plot_settings else PlotSettings(parent)
         self.fitting_settings = fitting_settings if fitting_settings else FittingSettings(parent)
@@ -51,6 +54,8 @@ class SettingsPresenter(object):
         self.view.load_file_button.clicked.connect(self.action_load_settings_from_file)
         self.view.help_button.clicked.connect(self.action_open_help_window)
         self.ask_before_close = False
+
+        self.changes_that_need_restart = []
 
     def show(self, modal=True):
         if modal:
@@ -94,6 +99,8 @@ class SettingsPresenter(object):
             ConfigService.saveConfig(ConfigService.getUserFilename())
             self.parent.config_updated()
             self.view.close()
+            if self.changes_that_need_restart:
+                self.view.notify_changes_need_restart(self.changes_that_need_restart)
             return True
         else:
             # try to stop the close action
@@ -110,6 +117,9 @@ class SettingsPresenter(object):
         if filepath:
             self.model.load_settings_from_file(filepath, self.all_properties)
             self._update_all_properties()
+
+    def register_change_needs_restart(self, change_description):
+        self.changes_that_need_restart.append(change_description)
 
     def _update_all_properties(self):
         for settings in self.SETTINGS_TABS.keys():

--- a/qt/applications/workbench/workbench/widgets/settings/test/test_settings_presenter.py
+++ b/qt/applications/workbench/workbench/widgets/settings/test/test_settings_presenter.py
@@ -103,3 +103,19 @@ class SettingsPresenterTest(TestCase):
         presenter.categories_settings.update_properties.assert_called_once_with()
         presenter.plot_settings.update_properties.assert_called_once_with()
         presenter.fitting_settings.update_properties.assert_called_once_with()
+
+    def test_register_change_needs_restart(self):
+        mock_view = MagicMock()
+        mock_model = MagicMock()
+        mock_parent = MagicMock()
+        presenter = SettingsPresenter(mock_parent, view=mock_view, model = mock_model,
+                                      general_settings=mock_view.general_settings,
+                                      categories_settings=mock_view.categories_settings,
+                                      plot_settings=mock_view.plot_settings,
+                                      fitting_settings=mock_view.fitting_settings)
+
+        settings_needing_restart = ["Setting one","Setting two"]
+        for setting in settings_needing_restart:
+            presenter.register_change_needs_restart(setting)
+        presenter.view_closing()
+        presenter.view.notify_changes_need_restart.assert_called_once_with(settings_needing_restart)

--- a/qt/applications/workbench/workbench/widgets/settings/view.py
+++ b/qt/applications/workbench/workbench/widgets/settings/view.py
@@ -42,6 +42,6 @@ class SettingsView(base, form):
 
     def notify_changes_need_restart(self, list_of_changes_that_need_restart):
         QMessageBox.information(self, self.presenter.CHANGES_NEED_RESTART_TITLE,
-                             self.presenter.CHANGES_NEED_RESTART_MESSAGE + "  • " +
-                                "\n  • ".join(list_of_changes_that_need_restart),
-                             QMessageBox.Ok)
+                                self.presenter.CHANGES_NEED_RESTART_MESSAGE + "  • "
+                                + "\n  • ".join(list_of_changes_that_need_restart),
+                                QMessageBox.Ok)

--- a/qt/applications/workbench/workbench/widgets/settings/view.py
+++ b/qt/applications/workbench/workbench/widgets/settings/view.py
@@ -39,3 +39,9 @@ class SettingsView(base, form):
     def get_properties_filename(self, accept_mode, file_mode):
         return open_a_file_dialog(parent=self, default_suffix=".properties", file_filter="PROPERTIES file (*.properties)",
                                   accept_mode=accept_mode, file_mode=file_mode)
+
+    def notify_changes_need_restart(self, list_of_changes_that_need_restart):
+        QMessageBox.information(self, self.presenter.CHANGES_NEED_RESTART_TITLE,
+                             self.presenter.CHANGES_NEED_RESTART_MESSAGE + "  • " +
+                                "\n  • ".join(list_of_changes_that_need_restart),
+                             QMessageBox.Ok)


### PR DESCRIPTION
**Description of work.**

Added a reusable method for any setting to register text to warn users is changes require a restart, only used for the main font settings at the moment as that seems to be the only setting so far that needs a restart.
The user is informed via a pop up box when leaving the settings dialog.


**To test:**

1. start workbench
1. File->Settings
1. In the general tab change something (not the main font)
1. close the settings box -> no pop up
1. repeat, but this time open the main font selection, click cancel, close, no pop up
1. repeat, but this time open the main font selection, make no change, click ok, close, no pop up
1. repeat, but this time open the main font selection, make a change (not too freaky), click ok, close, get a pop up


<!-- Instructions for testing. -->

Fixes #28612

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
