### PR TITLE
Flip spectrum numbers on Colorfill if origin=upper

### DIFF
--- a/Framework/PythonInterface/test/python/mantid/plots/plots__init__Test.py
+++ b/Framework/PythonInterface/test/python/mantid/plots/plots__init__Test.py
@@ -5,6 +5,7 @@
 #   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
 # SPDX - License - Identifier: GPL - 3.0 +
 import matplotlib
+from matplotlib.backend_bases import MouseEvent
 
 matplotlib.use('AGG')  # noqa
 import matplotlib.pyplot as plt
@@ -354,7 +355,7 @@ class Plots__init__Test(unittest.TestCase):
 
     def test_artists_normalization_labeled_correctly_for_2d_plots_of_non_dist_workspace_and_dist_argument_false(self):
         plot_funcs = ['imshow', 'pcolor', 'pcolormesh', 'pcolorfast', 'tripcolor',
-                        'contour', 'contourf', 'tricontour', 'tricontourf']
+                      'contour', 'contourf', 'tricontour', 'tricontourf']
         non_dist_2d_ws = CreateWorkspace(DataX=[10, 20, 10, 20],
                                          DataY=[2, 3, 2, 3],
                                          DataE=[1, 2, 1, 2],
@@ -663,6 +664,26 @@ class Plots__init__Test(unittest.TestCase):
 
         # There should still be only two filled areas (one for each line)
         self.assertEqual(len(datafunctions.get_waterfall_fills(ax)), 2)
+
+    def test_imshow_with_origin_upper(self):
+        image = self.ax.imshow(self.ws2d_histo, origin="upper")
+
+        # 0,0 in ax coordinates is the bottom left of figure, add 0.5 to move into canvas
+        xy_pixels = self.ax.transAxes.transform((0, 0)) + (0.5, 0.5)
+        bottom_left_corner = MouseEvent("motion_notify_event", self.fig.canvas, x=xy_pixels[0], y=xy_pixels[1])
+
+        self.assertEqual(image.get_extent(), (10.0, 30.0, 9.0, 3.0))
+        self.assertEqual(image.get_cursor_data(bottom_left_corner), 3.0)
+
+    def test_imshow_with_origin_lower(self):
+        image = self.ax.imshow(self.ws2d_histo, origin="lower")
+
+        # 0,0 in ax coordinates is the bottom left of figure, add 0.5 to move into canvas
+        xy_pixels = self.ax.transAxes.transform((0, 0)) + (0.5, 0.5)
+        bottom_left_corner = MouseEvent("motion_notify_event", self.fig.canvas, x=xy_pixels[0], y=xy_pixels[1])
+
+        self.assertEqual(image.get_extent(), (10.0, 30.0, 3.0, 9.0))
+        self.assertEqual(image.get_cursor_data(bottom_left_corner), 2.0)
 
     def _run_check_axes_distribution_consistency(self, normalization_states):
         mock_tracked_workspaces = {

--- a/docs/source/release/v5.1.0/mantidworkbench.rst
+++ b/docs/source/release/v5.1.0/mantidworkbench.rst
@@ -140,5 +140,6 @@ Bugfixes
   flagging the old ``launch_workbench.exe`` as a threat and quarantining it.
 - Fixed a bug in the 3D Surface Plot where the colorbar limits were incorrect when plotting data with monitors.
 - Warn users when they attempt to use Generate Recovery Script with no workspaces present.
+- The y axis labels will now appear in the correct order if imshow is called from a script with origin=upper.
 
 :ref:`Release 5.1.0 <v5.1.0>`


### PR DESCRIPTION
**Description of work.**
This PR flips the spectrum numbers on colorfill plots (made through imshow) if origin=upper. It does this by setting the extent and making sure the subsequent world -> pixel transformation respects the flipped axis limits. This PR also makes imshow default to origin lower if no value is set.

**To test:**
The following script should correctly flip the spectrum numbers, you can compare with right clicking and selecting colorfill through the workspace widget.

```
# import mantid algorithms, numpy and matplotlib
from mantid.simpleapi import *
import matplotlib.pyplot as plt
import numpy as np
nrows, ncols = 5, 5
signal = np.arange(0,nrows*ncols)
x = np.arange(0,2*ncols+1,step=2)

data = CreateWorkspace(DataX=x, DataY=signal, NSpec=nrows,UnitX='TOF')
figC,axC = plt.subplots(subplot_kw={'projection':'mantid'})
c=axC.imshow(data, origin="upper")
axC.set_title('Imshow')
cbar=figC.colorbar(c)
plt.show()
```
It should produce the same colorfil plot - just flipped with respect to the y axis.

<!-- Instructions for testing. -->

Fixes #28870 . <!-- and fix #xxxx or close #xxxx xor resolves #xxxx -->
<!-- alternative
*There is no associated issue.*
-->

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
-->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
