### PR TITLE
Muon analysis update group saving and loading

### DIFF
--- a/docs/source/release/v5.1.0/muon.rst
+++ b/docs/source/release/v5.1.0/muon.rst
@@ -36,6 +36,8 @@ New Features
 - Added support for specifying which groups should be used to calculate a group.
 - Added two buttons to the Muon analysis and Frequency domain analysis plot toolbar to allow users to show major and minor gridlines.
 - Added a Plot difference checkbox to the Muon Analysis GUI, which allows user to choose whether the fit difference curve is shown.
+- Added support for specifying which periods should be used to calculate a group.
+- Added suport for loading and saving group period data from xml files.
 
 Improvements
 -------------

--- a/docs/source/release/v5.1.0/muon.rst
+++ b/docs/source/release/v5.1.0/muon.rst
@@ -37,7 +37,7 @@ New Features
 - Added two buttons to the Muon analysis and Frequency domain analysis plot toolbar to allow users to show major and minor gridlines.
 - Added a Plot difference checkbox to the Muon Analysis GUI, which allows user to choose whether the fit difference curve is shown.
 - Added support for specifying which periods should be used to calculate a group.
-- Added suport for loading and saving group period data from xml files.
+- Added support for loading and saving group period data from xml files.
 - Added a Help option to the right-click menu in the function browser which brings up a relevant documentation page describing the function.
 
 Improvements

--- a/scripts/test/Muon/xml_utils_test.py
+++ b/scripts/test/Muon/xml_utils_test.py
@@ -5,7 +5,10 @@
 #   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
 # SPDX - License - Identifier: GPL - 3.0 +
 import unittest
-from Muon.GUI.Common.utilities.xml_utils import load_grouping_from_XML
+from unittest import mock
+from Muon.GUI.Common.utilities.xml_utils import load_grouping_from_XML, save_grouping_to_XML
+from Muon.GUI.Common.muon_group import MuonGroup
+from Muon.GUI.Common.muon_pair import MuonPair
 from mantid import ConfigService
 import os
 
@@ -28,6 +31,20 @@ class FittingTabPresenterTest(unittest.TestCase):
 
         self.assertEquals(description, filename)
         self.assertEquals(default, '')
+
+    @mock.patch('Muon.GUI.Common.utilities.xml_utils.ET.parse')
+    def test_that_save_and_load_grouping_xml_correctly_stores_and_reads_period_data(self, mock_file_parse):
+        groups = [MuonGroup('fwd', [1,2,3], [1,3]), MuonGroup('bwd', [4,5,6], [2,4])]
+        pairs = [MuonPair('long', 'fwd', 'bwd')]
+
+        xml_tree = save_grouping_to_XML(groups, pairs, 'filename.xml', save=False, description='Bespoke grouping')
+        mock_file_parse.return_value = xml_tree
+
+        loaded_groups, loaded_pairs, loaded_description, loaded_default = load_grouping_from_XML('filename.xml')
+
+        self.assertEqual(loaded_groups[0].periods, groups[0].periods)
+        self.assertEqual(loaded_groups[1].periods, groups[1].periods)
+
 
 if __name__ == '__main__':
     unittest.main(buffer=False, verbosity=2)


### PR DESCRIPTION
**Description of work.**

This updates the loading and saving routines for muon grouping xml files so that the period information contained in groups can be saved and loaded. 

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

**To test:**

 * Load some multiperiod data into the MuonAnalysis GUI. If you have access to the ISIS data archive the HIFI84447.
 * On the grouping tab save out an xml file and re-load it. Check that the periods information has been preserved in the groups.
 * Check that old grouping files still load correctly. Default grouping files can be found in the `instrument/Grouping` directory of the mantid source directory.

<!-- Instructions for testing. -->

Fixes #29115  <!-- and fix #xxxx or close #xxxx xor resolves #xxxx -->
<!-- alternative
*There is no associated issue.*
-->

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
-->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
