### PR TITLE
Warn users if they attempt to use Generate Recovery Script with no workspaces

### DIFF
--- a/docs/source/release/v5.1.0/mantidworkbench.rst
+++ b/docs/source/release/v5.1.0/mantidworkbench.rst
@@ -137,5 +137,6 @@ Bugfixes
 - The workbench launch scripts have been replaced by an executable on macOS & Windows. On Windows this will stop virus scanners
   flagging the old ``launch_workbench.exe`` as a threat and quarantining it.
 - Fixed a bug in the 3D Surface Plot where the colorbar limits were incorrect when plotting data with monitors.
+- Warn users when they attempt to use Generate Recovery Script with no workspaces present.
 
 :ref:`Release 5.1.0 <v5.1.0>`

--- a/qt/applications/workbench/workbench/app/mainwindow.py
+++ b/qt/applications/workbench/workbench/app/mainwindow.py
@@ -24,7 +24,7 @@ from workbench.widgets.settings.presenter import SettingsPresenter
 from qtpy.QtCore import (QEventLoop, Qt, QPoint, QSize)  # noqa
 from qtpy.QtGui import (QColor, QFontDatabase, QGuiApplication, QIcon, QPixmap)  # noqa
 from qtpy.QtWidgets import (QApplication, QDesktopWidget, QFileDialog, QMainWindow,
-                            QSplashScreen)  # noqa
+                            QSplashScreen, QMessageBox)  # noqa
 from mantidqt.algorithminputhistory import AlgorithmInputHistory  # noqa
 from mantidqt.interfacemanager import InterfaceManager  # noqa
 from mantidqt.widgets import manageuserdirectories  # noqa
@@ -577,9 +577,15 @@ class MainWindow(QMainWindow):
         self.editor.save_current_file_as()
 
     def generate_script_from_workspaces(self):
-        task = BlockingAsyncTaskWithCallback(target=self._generate_script_from_workspaces,
-                                             blocking_cb=QApplication.processEvents)
-        task.start()
+        if not self.workspacewidget.empty_of_workspaces():
+            task = BlockingAsyncTaskWithCallback(target=self._generate_script_from_workspaces,
+                                                 blocking_cb=QApplication.processEvents)
+            task.start()
+        else:
+            # Tell users they need a workspace to do that
+            QMessageBox().warning(None, "No Workspaces!",
+                                  "In order to generate a recovery script there needs to be some workspaces.",
+                                  QMessageBox.Ok)
 
     def _generate_script_from_workspaces(self):
         script = "from mantid.simpleapi import *\n\n" + get_all_workspace_history_from_ads()

--- a/qt/applications/workbench/workbench/plugins/test/test_workspacewidget.py
+++ b/qt/applications/workbench/workbench/plugins/test/test_workspacewidget.py
@@ -33,17 +33,19 @@ MATRIXWORKSPACE_DISPLAY_TYPE = "StatusBarView"
 @start_qapplication
 class WorkspaceWidgetTest(unittest.TestCase, QtWidgetFinder):
 
-    @classmethod
-    def setUpClass(cls):
-        cls.ws_widget = WorkspaceWidget(QMainWindow())
+    def setUp(self):
+        self.ws_widget = WorkspaceWidget(QMainWindow())
         mat_ws = CreateSampleWorkspace()
         table_ws = CreateEmptyTableWorkspace()
         group_ws = GroupWorkspaces([mat_ws, table_ws])
         single_val_ws = CreateSingleValuedWorkspace(5, 6)
-        cls.w_spaces = [mat_ws, table_ws, group_ws, single_val_ws]
-        cls.ws_names = ['MatWS', 'TableWS', 'GroupWS', 'SingleValWS']
-        for ws_name, ws in zip(cls.ws_names, cls.w_spaces):
-            cls.ws_widget._ads.add(ws_name, ws)
+        self.w_spaces = [mat_ws, table_ws, group_ws, single_val_ws]
+        self.ws_names = ['MatWS', 'TableWS', 'GroupWS', 'SingleValWS']
+        for ws_name, ws in zip(self.ws_names, self.w_spaces):
+            self.ws_widget._ads.add(ws_name, ws)
+
+    def tearDown(self):
+        self.ws_widget._ads.clear()
 
     def test_algorithm_history_window_opens_with_workspace(self):
         with mock.patch(ALGORITHM_HISTORY_WINDOW + '.show', lambda x: None):
@@ -105,6 +107,12 @@ class WorkspaceWidgetTest(unittest.TestCase, QtWidgetFinder):
         with mock.patch(MATRIXWORKSPACE_DISPLAY + '.show_view', lambda x: None):
             self.ws_widget._action_double_click_workspace(self.ws_names[3])
         self.assert_widget_type_exists(MATRIXWORKSPACE_DISPLAY_TYPE)
+
+    def test_empty_workspaces(self):
+        self.ws_widget._ads.clear()
+        self.assertEqual(self.ws_widget.empty_of_workspaces(), True)
+        CreateSampleWorkspace(OutputWorkspace="ws")
+        self.assertEqual(self.ws_widget.empty_of_workspaces(), False)
 
 
 if __name__ == '__main__':

--- a/qt/applications/workbench/workbench/plugins/workspacewidget.py
+++ b/qt/applications/workbench/workbench/plugins/workspacewidget.py
@@ -274,3 +274,6 @@ class WorkspaceWidget(PluginWidget):
 
     def refresh_workspaces(self):
         self.workspacewidget.refreshWorkspaces()
+
+    def empty_of_workspaces(self):
+        return len(self._ads.getObjectNames()) == 0


### PR DESCRIPTION
**Description of work.**
A message box will pop up warnings users if they have clicked Generate Recovery Script when there are no workspaces in the ADS/Workspace Widget

**To test:**
- Open Workbench
- Click File->Generate Recovery Script
- A window should pop up and say it won't work without workspaces.

<!-- Instructions for testing. -->

Fixes #29194 <!-- and fix #xxxx or close #xxxx xor resolves #xxxx -->
<!-- alternative
*There is no associated issue.*
-->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
