### PR TITLE
Make workbench 1D plots legends editable in-situ

### DIFF
--- a/docs/source/release/v5.1.0/mantidworkbench.rst
+++ b/docs/source/release/v5.1.0/mantidworkbench.rst
@@ -95,6 +95,7 @@ Improvements
 - Sliceviewer no longer lists the reversed colourmaps along with the regular, instead they are accessed with a reverse checkbox.
 - Sliceviewer colourmap uses the default colourmap from the settings.
 - Code completions are now loaded when the code editor is first changed.
+- Legends in 1D plots are now editable in-situ.
 
 Bugfixes
 ########

--- a/qt/applications/workbench/workbench/plotting/propertiesdialog.py
+++ b/qt/applications/workbench/workbench/plotting/propertiesdialog.py
@@ -92,6 +92,43 @@ class LabelEditor(PropertiesEditorBase):
         self.ui.errors.show()
 
 
+class LegendEditorModel(object):
+
+    def __init__(self, label_text):
+        self.label_text = label_text
+
+
+class LegendEditor(PropertiesEditorBase):
+    """Provides a dialog box to edit a legend label"""
+
+    def __init__(self, canvas, target, target_curve):
+        """
+        :param target: A reference to the label being edited
+        :param target_curve: A reference to the curve whose legend is being edited
+       """
+        super().__init__('labeleditor.ui', canvas)
+        self.ui.errors.hide()
+
+        self.target = target
+        self.target_curve = target_curve
+        self._memento = LegendEditorModel(target.get_text())
+        self.ui.editor.setText(self._memento.label_text)
+
+    def changes_accepted(self):
+        self.ui.errors.hide()
+        self.target.set_text(self.ui.editor.text())
+        self.target_curve.set_label(self.ui.editor.text())
+
+    def error_occurred(self, exc):
+        """
+        Display errors to user and reset state
+        :param exc: The exception that occurred
+        """
+        self.target.set_text(self._memento.label_text)
+        self.ui.errors.setText(str(exc).strip())
+        self.ui.errors.show()
+
+
 class AxisEditorModel(object):
     min = None
     max = None
@@ -225,12 +262,12 @@ class ColorbarAxisEditor(AxisEditor):
 
         self.ui.gridBox.hide()
 
-        self.images=[]
+        self.images = []
 
         images = get_images_from_figure(canvas.figure)
         # If there are an equal number of plots and colorbars so apply changes to plot with the selected colorbar
         # Otherwise apply changes to all the plots in the figure
-        if len(images) != len(self.canvas.figure.axes)/2:
+        if len(images) != len(self.canvas.figure.axes) / 2:
             self.images = images
         else:
             # apply changes to selected axes

--- a/qt/applications/workbench/workbench/plotting/test/test_propertiesdialog.py
+++ b/qt/applications/workbench/workbench/plotting/test/test_propertiesdialog.py
@@ -22,7 +22,7 @@ from unittest.mock import MagicMock
 from mantid.api import WorkspaceFactory
 from mantidqt.utils.qt.testing import start_qapplication
 from mantidqt.plotting.functions import pcolormesh
-from workbench.plotting.propertiesdialog import XAxisEditor, YAxisEditor, ColorbarAxisEditor
+from workbench.plotting.propertiesdialog import XAxisEditor, YAxisEditor, ColorbarAxisEditor, LegendEditor
 
 
 @start_qapplication
@@ -74,6 +74,21 @@ class PropertiesDialogTest(unittest.TestCase):
             self.assertEqual(min_value, fig.axes[ax].collections[0].norm.vmin)
             self.assertEqual(max_value, fig.axes[ax].collections[0].norm.vmax)
             self.assertTrue(isinstance(fig.axes[ax].collections[0].norm, LogNorm))
+
+    def test_legend_editor_correctly_updates_axis_legend(self):
+        # make figure
+        fig, ax = plt.subplots(1, 1)
+        lines = ax.plot([1, 2, 3], [1, 10, 100], 'o', label="Old label")
+        ax.legend()
+        legend_text = ax.get_legend().get_texts()[0]
+        # Make the legend editor
+        legend_editor = LegendEditor(fig.canvas, legend_text, lines[0])
+        legend_editor.ui.editor.text = MagicMock(return_value="New label")
+
+        legend_editor.changes_accepted()
+
+        self.assertEqual(ax.get_legend().get_texts()[0].get_text(), "New label")
+        self.assertEqual(lines[0].get_label(), "New label")
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
**Description of work.**
This PR makes the legends of 1D plots editable in-situ. 
<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

**To test:**

1. Load any data
2. Plot some spectra
3. You should be able to edit the legend in-situ by double clicking on one of the labels.
4. Everything should work as normal including the legend settings within the figure options.

<!-- Instructions for testing. -->

Fixes #28549. <!-- and fix #xxxx or close #xxxx xor resolves #xxxx -->
<!-- alternative
*There is no associated issue.*
-->

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
-->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
