### PR TITLE
Updated fermi distance in MERLIN.yaml

### DIFF
--- a/scripts/PyChop/merlin.yaml
+++ b/scripts/PyChop/merlin.yaml
@@ -3,7 +3,7 @@ name: MERLIN
 
 chopper_system:
   name: MERLIN chopper system
-  chop_sam: 1.82                # Distance (x1) from final chopper to sample (m)
+  chop_sam: 1.925                # Distance (x1) from final chopper to sample (m)
   sam_det: 2.5                  # Distance (x2) from sample to detector (m)
   aperture_width: 0.06667       # Width of aperture at moderator face (m)
   aperture_height: 0.06667      # Height of aperture at moderator face (m)
@@ -25,7 +25,7 @@ chopper_system:
       phaseName: 'Disk chopper phase delay time'
     -
       name: MERLIN Fermi
-      distance: 10.1            # Distance from moderator to this chopper in metres
+      distance: 9.995            # Distance from moderator to this chopper in metres
       aperture_distance: 7.19   # Distance from aperture (moderator face) to this chopper (only for Fermi)
       packages:                 # A hash of chopper packages
         G:


### PR DESCRIPTION
I have recently discovered that the MERLIN fermi is 10.5 cm closer to the moderator than believed (am in the process of writing a RAL report on this). This should be changed within pychop. There is no associated issue.

**Description of work.**

I discovered this issue. It is just a matter of updating all mentions to the MERLIN fermi distance.

**To test:**

No additional tests should be needed although if the merlin fermi distance is referenced elsewhere it will need to be changed.


*There is no associated issue.*


<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
-->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
