### PR TITLE
Add exception handling for psutil access denied in Project Recovery

### DIFF
--- a/docs/source/release/v5.1.0/mantidworkbench.rst
+++ b/docs/source/release/v5.1.0/mantidworkbench.rst
@@ -136,6 +136,7 @@ Bugfixes
 - Fix crash when subscribing algorithms from a separate thread
 - The workbench launch scripts have been replaced by an executable on macOS & Windows. On Windows this will stop virus scanners
   flagging the old ``launch_workbench.exe`` as a threat and quarantining it.
+- Fixed an issue where workbench would not open if PID assigned by project recovery was owned by another programme.
 - Fixed a bug in the 3D Surface Plot where the colorbar limits were incorrect when plotting data with monitors.
 
 :ref:`Release 5.1.0 <v5.1.0>`

--- a/qt/applications/workbench/workbench/projectrecovery/projectrecovery.py
+++ b/qt/applications/workbench/workbench/projectrecovery/projectrecovery.py
@@ -134,7 +134,11 @@ class ProjectRecovery(object):
         if self.recovery_directory not in directory:
             raise RuntimeError("Project Recovery: Only allowed to delete trees in the recovery directory")
 
-        shutil.rmtree(directory)
+        try:
+            shutil.rmtree(directory)
+        except FileNotFoundError:
+            # Doesn't matter if the file is deleted by another process as we are trying to do that anyway
+            return
 
     @staticmethod
     def sort_by_last_modified(paths):
@@ -161,8 +165,15 @@ class ProjectRecovery(object):
             pids.append(int(os.path.basename(path)))
 
         for pid in pids:
-            if not psutil.pid_exists(pid) or \
-                    not self._is_mantid_workbench_process(self._make_process_from_pid(pid=pid).cmdline()):
+            return_current_pid = True
+            if psutil.pid_exists(pid):
+                try:
+                    return_current_pid = not self._is_mantid_workbench_process(self._make_process_from_pid(pid=pid).cmdline())
+                except psutil.AccessDenied:
+                    # if we can't access the process properties then we assume it is not a mantid process
+                    pass
+
+            if return_current_pid:
                 return os.path.join(self.recovery_directory_hostname, str(pid))
 
     @staticmethod

--- a/qt/applications/workbench/workbench/projectrecovery/recoverygui/projectrecoverymodel.py
+++ b/qt/applications/workbench/workbench/projectrecovery/recoverygui/projectrecoverymodel.py
@@ -157,6 +157,8 @@ class ProjectRecoveryModel(QObject):
         self.rows = []
 
         pid_folder = self.project_recovery.get_pid_folder_to_load_a_checkpoint_from()
+        if pid_folder is None:
+            return
         paths = self.project_recovery.listdir_fullpath(os.path.join(self.project_recovery.recovery_directory_hostname,
                                                        pid_folder))
 

--- a/qt/applications/workbench/workbench/projectrecovery/recoverygui/projectrecoverypresenter.py
+++ b/qt/applications/workbench/workbench/projectrecovery/recoverygui/projectrecoverypresenter.py
@@ -60,6 +60,8 @@ class ProjectRecoveryPresenter(object):
 
         # Reset whether model believes recovery has been started.
         rows = self.model.rows
+        if len(rows) == 0:
+            return True
         self.model = ProjectRecoveryModel(self.project_recovery, self)
         self._set_checkpoint_tried_values_from_rows(rows)
 

--- a/qt/applications/workbench/workbench/projectrecovery/recoverygui/test/test_projectrecoverypresenter.py
+++ b/qt/applications/workbench/workbench/projectrecovery/recoverygui/test/test_projectrecoverypresenter.py
@@ -27,6 +27,7 @@ class ProjectRecoveryPresenterTest(unittest.TestCase):
     def setUp(self):
         self.prp = ProjectRecoveryPresenter(mock.MagicMock(), model=mock.MagicMock())
         self.prp.current_view = mock.MagicMock()
+        self.prp.model.rows.__len__.return_value = 1
 
     @mock.patch(PATCH_PROJECT_RECOVERY_VIEW)
     def test_start_recovery_view_exception_raised(self, view):
@@ -94,6 +95,14 @@ class ProjectRecoveryPresenterTest(unittest.TestCase):
 
         self.assertTrue(self.prp.start_recovery_failure())
         self.assertEqual(1, self.prp.current_view.exec_.call_count)
+
+    @mock.patch(PATCH_PROJECT_RECOVERY_FAILURE_VIEW)
+    @mock.patch(PATCH_PROJECT_RECOVERY_MODEL)
+    def test_start_recovery_failure_successful_when_no_rows(self, _, __):
+        self.prp.current_view = None
+        self.prp.model.rows.__len__.return_value = 0
+
+        self.assertTrue(self.prp.start_recovery_failure())
 
     def test_get_row_empty_list(self):
         self.prp.model.get_row.return_value = []

--- a/qt/applications/workbench/workbench/projectrecovery/test/test_projectrecovery.py
+++ b/qt/applications/workbench/workbench/projectrecovery/test/test_projectrecovery.py
@@ -15,6 +15,7 @@ import tempfile
 import time
 import unittest
 import datetime
+import psutil
 
 from mantid.api import AnalysisDataService as ADS
 from mantid.kernel import ConfigService
@@ -143,6 +144,13 @@ class ProjectRecoveryTest(unittest.TestCase):
 
         result = self.pr.get_pid_folder_to_load_a_checkpoint_from()
         self.assertEqual(one, result)
+
+    def test_get_pid_folder_returns_pid_if_access_denied(self):
+        pid = os.path.join(self.pr.recovery_directory_hostname, "10000000")
+        os.makedirs(pid)
+        with mock.patch('psutil.Process.cmdline', side_effect=psutil.AccessDenied()):
+            result = self.pr.get_pid_folder_to_load_a_checkpoint_from()
+        self.assertEqual(pid, result)
 
     def test_list_dir_full_path(self):
         one = os.path.join(self.working_directory, "10000000")


### PR DESCRIPTION
**Description of work.**
This PR fixes an issue where we were getting an access denied error from project recovery if the PID had been reassigned to another programme causing workbench to fail to start up.

**To test:**
In a file directory go to `%appdata%\mantidproject\mantid\workbench-recovery`.
If this is currently empty:
	-Open workbench (make sure project recovery is on)
	-Load any file
	-Make sure project recovery has saved something (check the directory above and it should no longer be empty)
	-Crash mantid - the easiest way to do this is with the `Segfault` algorithm with `DryRun` turned off
Within the machine name folder will be a folder with number (it's PID). 
Rename this folder to a PID owned by another user. (A simple way to find this is to open task manager and go to the `Details` tab. Look for any process not owned by the user e.g. SYSTEM. Use the number in the PID column)
(To check you have done the above correctly try opening the nightly or mantid 5 and it should fail to open)
Open workbench and you should get the project recovery gui.
Click `yes` to recover and it should work as normal

Fixes #28184 

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
