### PR TITLE
Fix to allow 'Show Error Bars' checkbox in plot dialog to work before indices input 

### DIFF
--- a/qt/python/mantidqt/dialogs/spectraselectordialog.py
+++ b/qt/python/mantidqt/dialogs/spectraselectordialog.py
@@ -91,6 +91,10 @@ class SpectraSelectionDialog(SpectraSelectionDialogUIBase):
         self._plottable_spectra = None
         self._advanced = advanced
 
+        # This is used as a flag to workaround the case in which the error bars checkbox is set before a selection is
+        # instantiated, causing it to have no effect. The update is then done in the parse_wksp / parse_spec functions
+        self._errorsset = False
+
         self._init_ui()
         self._set_placeholder_text()
         self._setup_connections()
@@ -325,6 +329,8 @@ class SpectraSelectionDialog(SpectraSelectionDialogUIBase):
             selection.wksp_indices = wksp_indices
             selection.plot_type = self._ui.plotType.currentIndex()
 
+            selection.errors = self._errorsset
+
             if self._advanced:
                 selection.log_name = self._ui.advanced_options_widget.ui.log_value_combo_box.currentText()
                 selection.axis_name = self._ui.advanced_options_widget.ui.plot_axis_label_line_edit.text()
@@ -346,6 +352,8 @@ class SpectraSelectionDialog(SpectraSelectionDialogUIBase):
             selection = SpectraSelection(self._workspaces)
             selection.spectra = spec_nums
             selection.plot_type = self._ui.plotType.currentIndex()
+
+            selection.errors = self._errorsset
 
             if self._advanced:
                 selection.log_name = self._ui.advanced_options_widget.ui.log_value_combo_box.currentText()
@@ -408,6 +416,8 @@ class AdvancedPlottingOptionsWidget(AdvancedPlottingOptionsWidgetUIBase):
     def _toggle_errors(self, enable: bool) -> None:
         if self._parent.selection:
             self._parent.selection.errors = enable
+        else:
+            self._parent._errorsset = enable
 
     def _axis_name_changed(self, text: str) -> None:
         if self._parent.selection:


### PR DESCRIPTION
**Description of work.**
Added a workaround to address the case in which the 'Show Error Bars' checkbox was selected before spectrum numbers/workspace indices are entered in the Plot - Advanced dialog, causing no error bars to be shown

**To test:**
1. In workbench, load a workspace (or use CreateSampleWorkspace)
2. Right click on the workspace, select Plot -> Advanced
3. Enter a valid number in the Spectrum Number input, then select the Error Bars checkbox
4. Plot and make sure the error bars are present
5. Repeat for the same spectrum, but ensure the Error Bars checkbox is ticked before you enter the spectrum number
6. Check the error bars are still shown

Fixes #29072 . <!-- and fix #xxxx or close #xxxx xor resolves #xxxx -->
<!-- alternative
*There is no associated issue.*
-->

*This does not require release notes* because **it is a very minor bugfix**

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
