### PR TITLE
Remove TCMalloc on Windows

### DIFF
--- a/buildconfig/CMake/MSVCSetup.cmake
+++ b/buildconfig/CMake/MSVCSetup.cmake
@@ -62,33 +62,6 @@ endif()
 # ##############################################################################
 set(Qt5_DIR ${THIRD_PARTY_DIR}/lib/qt5/lib/cmake/Qt5)
 
-# ##############################################################################
-# If required, find tcmalloc
-# ##############################################################################
-# Not ready for production use with MSVC 2015
-option(USE_TCMALLOC "If true, link with tcmalloc" OFF)
-# If not wanted, just carry on without it
-if(USE_TCMALLOC)
-  # Only link in release configurations. There seems to be problem linking in
-  # debug mode
-  set(TCMALLOC_LIBRARIES optimized
-                         "${CMAKE_LIBRARY_PATH}/libtcmalloc_minimal.lib"
-  )
-  # Use an alternate variable name so that it is only set on Windows
-  set(TCMALLOC_LIBRARIES_LINKTIME ${TCMALLOC_LIBRARIES})
-  set(_configs RELEASE RELWITHDEBINFO MINSIZEREL)
-  set(_targets EXE SHARED)
-  foreach(_tgt ${_targets})
-    foreach(_cfg ${_configs})
-      set(CMAKE_${_tgt}_LINKER_FLAGS_${_cfg}
-          "${CMAKE_${_tgt}_LINKER_FLAGS_${_cfg}} /INCLUDE:__tcmalloc"
-      )
-    endforeach()
-  endforeach()
-else(USE_TCMALLOC)
-  message(STATUS "TCMalloc will not be included.")
-endif()
-
 option(CONSOLE "Switch for enabling/disabling the console" ON)
 
 # ##############################################################################


### PR DESCRIPTION
**Description of work.**
Since the provided default allocator on windows is ok, there is no need for a custom allocator like TCMalloc on Windows (where it is not used anyhow), thus the block of code adding managing its inclusion is removed.
removed.

**To test:**
Check it still compiles on Windows.
<!-- Instructions for testing. -->

WIP for #29054 

<!-- delete this if you added release notes
*This does not require release notes* because **it removes an unused feature. **
-->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
