### PR TITLE
Add warnings of non existent periods

### DIFF
--- a/docs/source/release/v5.1.0/muon.rst
+++ b/docs/source/release/v5.1.0/muon.rst
@@ -56,7 +56,7 @@ Improvements
 - The ALC interface in workbench will now show errors by default. The error bars can also be turned on/off using the right-click plot menu.
 - Have updated the FDA GUI so that it functions correctly for frequency transforms and single fits.
 - Added in default group and pair selection when loading grouping files from xml.
-- Added warnings when not all selected runs have the relevant periods to calculate certain groups.
+- Added warnings when the selected runs do not have the relevant periods to calculate the groups or pairs.
 
 Bug fixes
 ---------

--- a/docs/source/release/v5.1.0/muon.rst
+++ b/docs/source/release/v5.1.0/muon.rst
@@ -56,6 +56,7 @@ Improvements
 - The ALC interface in workbench will now show errors by default. The error bars can also be turned on/off using the right-click plot menu.
 - Have updated the FDA GUI so that it functions correctly for frequency transforms and single fits.
 - Added in default group and pair selection when loading grouping files from xml.
+- Added warnings when not all selected runs have the relevant periods to calculate certain groups.
 
 Bug fixes
 ---------

--- a/scripts/Muon/GUI/Common/ADSHandler/workspace_naming.py
+++ b/scripts/Muon/GUI/Common/ADSHandler/workspace_naming.py
@@ -31,11 +31,7 @@ def _base_run_name(instrument, run=None):
 
 
 def get_group_data_workspace_name(context, group_name, run, period_string, rebin):
-    if context.data_context.is_multi_period():
-        name = context.data_context._base_run_name(run) + group_str + group_name + \
-               "; Counts; Periods; " + period_string + ";"
-    else:
-        name = context.data_context._base_run_name(run) + group_str + group_name + "; Counts;"
+    name = context.data_context._base_run_name(run) + group_str + group_name + "; Counts;"
 
     if rebin:
         name += "".join([' ', REBIN_STR, ';'])
@@ -46,11 +42,7 @@ def get_group_data_workspace_name(context, group_name, run, period_string, rebin
 
 
 def get_group_asymmetry_name(context, group_name, run, period_string, rebin):
-    if context.data_context.is_multi_period():
-        name = context.data_context._base_run_name(run) + group_str + group_name + \
-               "; Asymmetry; Periods; " + period_string + ";"
-    else:
-        name = context.data_context._base_run_name(run) + group_str + group_name + "; Asymmetry;"
+    name = context.data_context._base_run_name(run) + group_str + group_name + "; Asymmetry;"
 
     if rebin:
         name += "".join([' ', REBIN_STR, ';'])
@@ -96,22 +88,6 @@ def get_raw_data_directory(context, run):
         return context.data_context._base_run_name(run) + "; Raw Data" + context.workspace_suffix + "/"
     else:
         return context.data_context._base_run_name(run) + " Raw Data" + context.workspace_suffix + "/"
-
-
-def get_group_data_directory(context, run):
-    if context.data_context.is_multi_period():
-        return context.data_context._base_run_name(run) + " Period " + context.gui_context.period_string(
-            run) + "; Groups" + context.workspace_suffix + "/"
-    else:
-        return context.data_context._base_run_name(run) + " Groups" + context.workspace_suffix + "/"
-
-
-def get_pair_data_directory(context, run):
-    if context.data_context.is_multi_period():
-        return context.data_context._base_run_name(run) + " Period " + context.gui_context.period_string(
-            run) + "; Pairs" + context.workspace_suffix + "/"
-    else:
-        return context.data_context._base_run_name(run) + " Pairs" + context.workspace_suffix + "/"
 
 
 def get_phase_table_workspace_name(raw_workspace, forward_group, backward_group):

--- a/scripts/Muon/GUI/Common/fitting_tab_widget/fitting_tab_model.py
+++ b/scripts/Muon/GUI/Common/fitting_tab_widget/fitting_tab_model.py
@@ -14,7 +14,7 @@ from mantid.simpleapi import (RenameWorkspace, ConvertFitFunctionForMuonTFAsymme
                               CopyLogs, EvaluateFunction)
 from mantid.api import AnalysisDataService
 from Muon.GUI.Common.contexts.frequency_domain_analysis_context import FrequencyDomainAnalysisContext
-
+from Muon.GUI.Common.utilities.run_string_utils import run_list_to_string
 import mantid
 import math
 
@@ -677,11 +677,12 @@ class FittingTabModel(object):
         workspace_names = []
         for run in runs:
             for group_or_pair in groups_and_pairs:
+                period_string = run_list_to_string(self.context.group_pair_context[group_or_pair].periods)
                 if group_or_pair in self.context.group_pair_context.selected_pairs:
-                    workspace_names += [get_pair_asymmetry_name(self.context, group_or_pair, run,
+                    workspace_names += [get_pair_asymmetry_name(self.context, group_or_pair, run, period_string,
                                                                 not self.fitting_options["fit_to_raw"])]
                 else:
-                    workspace_names += [get_group_asymmetry_name(self.context, group_or_pair, run,
+                    workspace_names += [get_group_asymmetry_name(self.context, group_or_pair, run, period_string,
                                                                  not self.fitting_options["fit_to_raw"])]
 
         return workspace_names

--- a/scripts/Muon/GUI/Common/grouping_table_widget/grouping_table_widget_presenter.py
+++ b/scripts/Muon/GUI/Common/grouping_table_widget/grouping_table_widget_presenter.py
@@ -20,6 +20,7 @@ class RowValid(Enum):
     valid_for_some_runs = 1
 
 
+# Row colours specified in RGB. i.e. (255, 0, 0) is red and (255, 255, 0) is yellow.
 row_colors = {RowValid.invalid_for_all_runs: (255, 0, 0), RowValid.valid_for_some_runs: (255, 255, 0),
               RowValid.valid_for_all_runs: (255, 255, 255)}
 

--- a/scripts/Muon/GUI/Common/grouping_table_widget/grouping_table_widget_presenter.py
+++ b/scripts/Muon/GUI/Common/grouping_table_widget/grouping_table_widget_presenter.py
@@ -96,8 +96,6 @@ class GroupingTablePresenter(object):
         try:
             period_list = run_utils.run_string_to_list(period_text)
         except IndexError:
-            self._view.warning_popup("Entered period range in invalid format."
-                                     " Valid format is a comma seperated list of numbers or dash seperated ranges e.g. 1,3-5")
             # An IndexError thrown here implies that the input string is not a valid
             # number list.
             return RowValid.invalid_for_all_runs

--- a/scripts/Muon/GUI/Common/grouping_table_widget/grouping_table_widget_presenter.py
+++ b/scripts/Muon/GUI/Common/grouping_table_widget/grouping_table_widget_presenter.py
@@ -5,19 +5,14 @@
 #   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
 # SPDX - License - Identifier: GPL - 3.0 +
 import re
-from enum import Enum
 from Muon.GUI.Common.utilities import run_string_utils as run_utils
 from Muon.GUI.Common.muon_group import MuonGroup
 from mantidqt.utils.observer_pattern import GenericObservable
 from Muon.GUI.Common.grouping_table_widget.grouping_table_widget_view import inverse_group_table_columns
+from Muon.GUI.Common.grouping_tab_widget.grouping_tab_widget_model import RowValid
+
 
 maximum_number_of_groups = 20
-
-
-class RowValid(Enum):
-    invalid_for_all_runs = 0
-    valid_for_all_runs = 2
-    valid_for_some_runs = 1
 
 
 # Row colours specified in RGB. i.e. (255, 0, 0) is red and (255, 255, 0) is yellow.
@@ -100,22 +95,7 @@ class GroupingTablePresenter(object):
             # An IndexError thrown here implies that the input string is not a valid
             # number list.
             return RowValid.invalid_for_all_runs
-        return self.validate_periods_list(period_list)
-
-    def validate_periods_list(self, periods):
-        invalid_runs = []
-        current_runs = self._model._context.current_runs
-
-        for run in current_runs:
-            if any([period < 1 or self._model._context.num_periods(run) < period for period in periods]):
-                invalid_runs.append(run)
-
-        if not invalid_runs:
-            return RowValid.valid_for_all_runs
-        elif len(invalid_runs) == len(current_runs):
-            return RowValid.invalid_for_all_runs
-        else:
-            return RowValid.valid_for_some_runs
+        return self._model.validate_periods_list(period_list)
 
     def disable_editing(self):
         self._view.disable_editing()
@@ -224,7 +204,7 @@ class GroupingTablePresenter(object):
 
         for group in self._model.groups:
             to_analyse = True if group.name in self._model.selected_groups else False
-            display_period_warning = self.validate_periods_list(group.periods)
+            display_period_warning = self._model.validate_periods_list(group.periods)
             color = row_colors[display_period_warning]
             tool_tip = row_tooltips[display_period_warning]
             self.add_group_to_view(group, to_analyse, color, tool_tip)

--- a/scripts/Muon/GUI/Common/grouping_table_widget/grouping_table_widget_presenter.py
+++ b/scripts/Muon/GUI/Common/grouping_table_widget/grouping_table_widget_presenter.py
@@ -24,7 +24,7 @@ row_colors = {RowValid.invalid_for_all_runs: (255, 0, 0), RowValid.valid_for_som
               RowValid.valid_for_all_runs: (255, 255, 255)}
 
 
-row_tooltips = {RowValid.invalid_for_all_runs: 'Warning: Group periods invalid for all runs',
+row_tooltips = {RowValid.invalid_for_all_runs: 'Warning: group periods invalid for all runs',
                 RowValid.valid_for_some_runs: 'Warning: group periods invalid for some runs',
                 RowValid.valid_for_all_runs: ''}
 

--- a/scripts/Muon/GUI/Common/grouping_table_widget/grouping_table_widget_view.py
+++ b/scripts/Muon/GUI/Common/grouping_table_widget/grouping_table_widget_view.py
@@ -386,12 +386,3 @@ class GroupingTableView(QtWidgets.QWidget):
     def set_group_range(self, range):
         self.group_range_min.setText(range[0])
         self.group_range_max.setText(range[1])
-
-    # def change_row_color(self, color, row_index):
-    #     for col in range(self.grouping_table.columnCount() - 1):
-    #         table_item = self.grouping_table.item(row_index, col)
-    #         q_color = QtGui.QColor(0, 0, 255, 127)
-    #         q_brush = QtGui.QBrush(q_color)
-    #         table_item.setBackground(q_brush)
-    #         print('Updating color')
-    #         self.grouping_table.setItem(row_index, col, table_item)

--- a/scripts/Muon/GUI/Common/grouping_table_widget/grouping_table_widget_view.py
+++ b/scripts/Muon/GUI/Common/grouping_table_widget/grouping_table_widget_view.py
@@ -11,6 +11,11 @@ from Muon.GUI.Common import message_box
 
 group_table_columns = {0: 'group_name', 2: 'to_analyse', 3: 'detector_ids', 4: 'number_of_detectors', 1: 'periods'}
 inverse_group_table_columns = {'group_name': 0, 'to_analyse': 2,  'detector_ids': 3,  'number_of_detectors': 4, 'periods': 1}
+table_column_flags = {'group_name': QtCore.Qt.ItemIsSelectable | QtCore.Qt.ItemIsEnabled,
+                      'to_analyse': QtCore.Qt.ItemIsUserCheckable | QtCore.Qt.ItemIsEnabled,
+                      'detector_ids': QtCore.Qt.ItemIsEnabled | QtCore.Qt.ItemIsEditable,
+                      'number_of_detectors': QtCore.Qt.ItemIsSelectable | QtCore.Qt.ItemIsEnabled,
+                      'periods': QtCore.Qt.ItemIsEnabled | QtCore.Qt.ItemIsEditable}
 
 
 class GroupingTableView(QtWidgets.QWidget):
@@ -158,44 +163,17 @@ class GroupingTableView(QtWidgets.QWidget):
         q_color = QtGui.QColor(*color, alpha=127)
         q_brush = QtGui.QBrush(q_color)
         for i, entry in enumerate(row_entries):
-            if group_table_columns[i] == 'group_name':
-                group_name_widget = QtWidgets.QTableWidgetItem(entry)
-                group_name_widget.setBackground(q_brush)
-                group_name_widget.setToolTip(tooltip)
-                self.grouping_table.setItem(row_position, i, group_name_widget)
-                group_name_widget.setFlags(QtCore.Qt.ItemIsSelectable | QtCore.Qt.ItemIsEnabled)
-
-            if group_table_columns[i] == 'periods':
-                period_widget = QtWidgets.QTableWidgetItem(entry)
-                period_widget.setBackground(q_brush)
-                period_widget.setToolTip(tooltip)
-                self.grouping_table.setItem(row_position, i, period_widget)
-                period_widget.setFlags(QtCore.Qt.ItemIsEnabled | QtCore.Qt.ItemIsEditable)
+            table_item = QtWidgets.QTableWidgetItem(entry)
+            table_item.setBackground(q_brush)
+            table_item.setToolTip(tooltip)
+            self.grouping_table.setItem(row_position, i, table_item)
+            table_item.setFlags(table_column_flags[group_table_columns[i]])
 
             if group_table_columns[i] == 'to_analyse':
-                to_analyse_widget = QtWidgets.QTableWidgetItem(entry)
-                to_analyse_widget.setBackground(q_brush)
-                to_analyse_widget.setToolTip(tooltip)
-                to_analyse_widget.setFlags(QtCore.Qt.ItemIsUserCheckable | QtCore.Qt.ItemIsEnabled)
                 if entry:
-                    to_analyse_widget.setCheckState(QtCore.Qt.Checked)
+                    table_item.setCheckState(QtCore.Qt.Checked)
                 else:
-                    to_analyse_widget.setCheckState(QtCore.Qt.Unchecked)
-                self.grouping_table.setItem(row_position, i, to_analyse_widget)
-
-            if group_table_columns[i] == 'detector_ids':
-                detector_widget = QtWidgets.QTableWidgetItem(entry)
-                detector_widget.setBackground(q_brush)
-                detector_widget.setToolTip(tooltip)
-                detector_widget.setFlags(QtCore.Qt.ItemIsEnabled | QtCore.Qt.ItemIsEditable)
-                self.grouping_table.setItem(row_position, i, detector_widget)
-
-            if group_table_columns[i] == 'number_of_detectors':
-                num_detectors_widget = QtWidgets.QTableWidgetItem(entry)
-                num_detectors_widget.setBackground(q_brush)
-                num_detectors_widget.setToolTip(tooltip)
-                num_detectors_widget.setFlags(QtCore.Qt.ItemIsSelectable | QtCore.Qt.ItemIsEnabled)
-                self.grouping_table.setItem(row_position, i, num_detectors_widget)
+                    table_item.setCheckState(QtCore.Qt.Unchecked)
 
     def _get_selected_row_indices(self):
         return list(set(index.row() for index in self.grouping_table.selectedIndexes()))

--- a/scripts/Muon/GUI/Common/grouping_table_widget/grouping_table_widget_view.py
+++ b/scripts/Muon/GUI/Common/grouping_table_widget/grouping_table_widget_view.py
@@ -7,7 +7,6 @@
 from qtpy import QtWidgets, QtGui, QtCore
 from qtpy.QtCore import Signal
 import sys
-from Muon.GUI.Common.utilities import table_utils
 from Muon.GUI.Common import message_box
 
 group_table_columns = {0: 'group_name', 2: 'to_analyse', 3: 'detector_ids', 4: 'number_of_detectors', 1: 'periods'}
@@ -152,26 +151,31 @@ class GroupingTableView(QtWidgets.QWidget):
     # ------------------------------------------------------------------------------------------------------------------
     # Adding / removing table entries
     # ------------------------------------------------------------------------------------------------------------------
-    def add_entry_to_table(self, row_entries):
+    def add_entry_to_table(self, row_entries, color = (255, 255, 255), tooltip=''):
         assert len(row_entries) == self.grouping_table.columnCount()
         row_position = self.grouping_table.rowCount()
         self.grouping_table.insertRow(row_position)
+        q_color = QtGui.QColor(*color, alpha=127)
+        q_brush = QtGui.QBrush(q_color)
         for i, entry in enumerate(row_entries):
             if group_table_columns[i] == 'group_name':
-                group_name_widget = table_utils.ValidatedTableItem(self._validate_group_name_entry)
-                group_name_widget.setText(entry)
+                group_name_widget = QtWidgets.QTableWidgetItem(entry)
+                group_name_widget.setBackground(q_brush)
+                group_name_widget.setToolTip(tooltip)
                 self.grouping_table.setItem(row_position, i, group_name_widget)
-                self.grouping_table.item(row_position, i).setToolTip(entry)
                 group_name_widget.setFlags(QtCore.Qt.ItemIsSelectable | QtCore.Qt.ItemIsEnabled)
 
             if group_table_columns[i] == 'periods':
                 period_widget = QtWidgets.QTableWidgetItem(entry)
+                period_widget.setBackground(q_brush)
+                period_widget.setToolTip(tooltip)
                 self.grouping_table.setItem(row_position, i, period_widget)
-                self.grouping_table.item(row_position, i).setToolTip(entry)
                 period_widget.setFlags(QtCore.Qt.ItemIsEnabled | QtCore.Qt.ItemIsEditable)
 
             if group_table_columns[i] == 'to_analyse':
                 to_analyse_widget = QtWidgets.QTableWidgetItem(entry)
+                to_analyse_widget.setBackground(q_brush)
+                to_analyse_widget.setToolTip(tooltip)
                 to_analyse_widget.setFlags(QtCore.Qt.ItemIsUserCheckable | QtCore.Qt.ItemIsEnabled)
                 if entry:
                     to_analyse_widget.setCheckState(QtCore.Qt.Checked)
@@ -180,16 +184,16 @@ class GroupingTableView(QtWidgets.QWidget):
                 self.grouping_table.setItem(row_position, i, to_analyse_widget)
 
             if group_table_columns[i] == 'detector_ids':
-                detector_widget = table_utils.ValidatedTableItem()
-                detector_widget.setText(entry)
-                self.grouping_table.setItem(row_position, i, detector_widget)
-                self.grouping_table.item(row_position, i).setToolTip(entry)
-                detector_widget.set_validator(self._validate_detector_ID_entry)
+                detector_widget = QtWidgets.QTableWidgetItem(entry)
+                detector_widget.setBackground(q_brush)
+                detector_widget.setToolTip(tooltip)
                 detector_widget.setFlags(QtCore.Qt.ItemIsEnabled | QtCore.Qt.ItemIsEditable)
                 self.grouping_table.setItem(row_position, i, detector_widget)
 
             if group_table_columns[i] == 'number_of_detectors':
                 num_detectors_widget = QtWidgets.QTableWidgetItem(entry)
+                num_detectors_widget.setBackground(q_brush)
+                num_detectors_widget.setToolTip(tooltip)
                 num_detectors_widget.setFlags(QtCore.Qt.ItemIsSelectable | QtCore.Qt.ItemIsEnabled)
                 self.grouping_table.setItem(row_position, i, num_detectors_widget)
 
@@ -404,3 +408,12 @@ class GroupingTableView(QtWidgets.QWidget):
     def set_group_range(self, range):
         self.group_range_min.setText(range[0])
         self.group_range_max.setText(range[1])
+
+    # def change_row_color(self, color, row_index):
+    #     for col in range(self.grouping_table.columnCount() - 1):
+    #         table_item = self.grouping_table.item(row_index, col)
+    #         q_color = QtGui.QColor(0, 0, 255, 127)
+    #         q_brush = QtGui.QBrush(q_color)
+    #         table_item.setBackground(q_brush)
+    #         print('Updating color')
+    #         self.grouping_table.setItem(row_index, col, table_item)

--- a/scripts/Muon/GUI/Common/pairing_table_widget/pairing_table_widget_view.py
+++ b/scripts/Muon/GUI/Common/pairing_table_widget/pairing_table_widget_view.py
@@ -139,13 +139,17 @@ class PairingTableView(QtWidgets.QWidget):
         if not self._updating:
             self.dataChanged.emit()
 
-    def add_entry_to_table(self, row_entries):
+    def add_entry_to_table(self, row_entries, color=(255, 255, 255), tooltip=''):
         assert len(row_entries) == self.pairing_table.columnCount() - 1
+        q_color = QtGui.QColor(*color, alpha=127)
+        q_brush = QtGui.QBrush(q_color)
 
         row_position = self.pairing_table.rowCount()
         self.pairing_table.insertRow(row_position)
         for i, entry in enumerate(row_entries):
             item = QtWidgets.QTableWidgetItem(entry)
+            item.setBackground(q_brush)
+            item.setToolTip(tooltip)
             if pair_columns[i] == 'pair_name':
                 pair_name_widget = table_utils.ValidatedTableItem(self._validate_pair_name_entry)
                 pair_name_widget.setText(entry)
@@ -277,6 +281,7 @@ class PairingTableView(QtWidgets.QWidget):
 
     def _context_menu_add_pair_action(self, slot):
         add_pair_action = QtWidgets.QAction('Add Pair', self)
+        add_pair_action.setCheckable(False)
         if len(self._get_selected_row_indices()) > 0:
             add_pair_action.setEnabled(False)
         add_pair_action.triggered.connect(slot)

--- a/scripts/test/Muon/grouping_tab/grouping_table_presenter_test.py
+++ b/scripts/test/Muon/grouping_tab/grouping_table_presenter_test.py
@@ -402,6 +402,36 @@ class GroupingTablePresenterTest(unittest.TestCase):
 
         self.assertEquals(self.model.selected_groups, ['group_1'])
 
+    def test_update_view_from_model_correctly_adds_warnings_for_invalid_periods(self):
+        self.presenter.validate_periods_list = mock.MagicMock(return_value=RowValid.invalid_for_all_runs)
+        self.presenter._view.add_entry_to_table = mock.MagicMock()
+        self.presenter.add_group_to_model(MuonGroup('group_1', [1,2,3,4], [3]))
+
+        self.presenter.update_view_from_model()
+
+        self.presenter._view.add_entry_to_table.assert_called_once_with(['group_1', '3', False, '1-4', '4'],
+                                                                        (255, 0, 0), 'Warning: group periods invalid for all runs')
+
+    def test_update_view_from_model_correctly_adds_warnings_for_semi_invalid_periods(self):
+        self.presenter.validate_periods_list = mock.MagicMock(return_value=RowValid.valid_for_some_runs)
+        self.presenter._view.add_entry_to_table = mock.MagicMock()
+        self.presenter.add_group_to_model(MuonGroup('group_1', [1,2,3,4], [3]))
+
+        self.presenter.update_view_from_model()
+
+        self.presenter._view.add_entry_to_table.assert_called_once_with(['group_1', '3', False, '1-4', '4'],
+                                                                        (255, 255, 0), 'Warning: group periods invalid for some runs')
+
+    def test_update_view_from_model_correctly_adds_warnings_for_valid(self):
+        self.presenter.validate_periods_list = mock.MagicMock(return_value=RowValid.valid_for_all_runs)
+        self.presenter._view.add_entry_to_table = mock.MagicMock()
+        self.presenter.add_group_to_model(MuonGroup('group_1', [1,2,3,4], [3]))
+
+        self.presenter.update_view_from_model()
+
+        self.presenter._view.add_entry_to_table.assert_called_once_with(['group_1', '3', False, '1-4', '4'],
+                                                                        (255, 255, 255), '')
+
 
 if __name__ == '__main__':
     unittest.main(buffer=False, verbosity=2)

--- a/scripts/test/Muon/grouping_tab/grouping_table_presenter_test.py
+++ b/scripts/test/Muon/grouping_tab/grouping_table_presenter_test.py
@@ -10,7 +10,7 @@ from mantidqt.utils.qt.testing import start_qapplication
 from qtpy.QtWidgets import QWidget
 
 from Muon.GUI.Common.grouping_tab_widget.grouping_tab_widget_model import GroupingTabModel
-from Muon.GUI.Common.grouping_table_widget.grouping_table_widget_presenter import GroupingTablePresenter
+from Muon.GUI.Common.grouping_table_widget.grouping_table_widget_presenter import GroupingTablePresenter, RowValid
 from Muon.GUI.Common.grouping_table_widget.grouping_table_widget_view import GroupingTableView, inverse_group_table_columns
 from Muon.GUI.Common.muon_group import MuonGroup
 from mantidqt.utils.observer_pattern import Observer
@@ -376,7 +376,7 @@ class GroupingTablePresenterTest(unittest.TestCase):
 
         valid = self.presenter.validate_periods('1-5')
 
-        self.assertFalse(valid)
+        self.assertEquals(RowValid.invalid_for_all_runs, valid)
 
     def test_that_period_valid_for_at_least_one_run_returns_valid(self):
         self.presenter._model._context = mock.MagicMock()
@@ -385,12 +385,12 @@ class GroupingTablePresenterTest(unittest.TestCase):
 
         valid = self.presenter.validate_periods('1-4')
 
-        self.assertTrue(valid)
+        self.assertEquals(RowValid.valid_for_some_runs, valid)
 
     def test_that_period_string_containing_not_matching_run_entry_regex_returns_invalid(self):
         valid = self.presenter.validate_periods('Invalid string')
 
-        self.assertFalse(valid)
+        self.assertEquals(RowValid.invalid_for_all_runs, valid)
 
     def _fake_num_periods(self, run):
         num_periods_dict = {'[84447]': 4, '[84448]': 4, '[84449]': 4, '[84450]':2, '[84451]' :1}

--- a/scripts/test/Muon/grouping_tab/grouping_table_presenter_test.py
+++ b/scripts/test/Muon/grouping_tab/grouping_table_presenter_test.py
@@ -397,15 +397,15 @@ class GroupingTablePresenterTest(unittest.TestCase):
         return num_periods_dict[str(run)]
 
     def test_when_adding_group_to_empty_table_it_is_selected(self):
-        self.presenter.add_group(MuonGroup('group_1', [1,2,3,4]))
-        self.presenter.add_group(MuonGroup('group_2', [1,2,3,4]))
+        self.presenter.add_group(MuonGroup(group_name='group_1', detector_ids=[1,2,3,4]))
+        self.presenter.add_group(MuonGroup(group_name='group_2', detector_ids=[1,2,3,4]))
 
         self.assertEquals(self.model.selected_groups, ['group_1'])
 
     def test_update_view_from_model_correctly_adds_warnings_for_invalid_periods(self):
         self.presenter.validate_periods_list = mock.MagicMock(return_value=RowValid.invalid_for_all_runs)
         self.presenter._view.add_entry_to_table = mock.MagicMock()
-        self.presenter.add_group_to_model(MuonGroup('group_1', [1,2,3,4], [3]))
+        self.presenter.add_group_to_model(MuonGroup(group_name='group_1', detector_ids=[1,2,3,4], periods=[3]))
 
         self.presenter.update_view_from_model()
 
@@ -415,7 +415,7 @@ class GroupingTablePresenterTest(unittest.TestCase):
     def test_update_view_from_model_correctly_adds_warnings_for_semi_invalid_periods(self):
         self.presenter.validate_periods_list = mock.MagicMock(return_value=RowValid.valid_for_some_runs)
         self.presenter._view.add_entry_to_table = mock.MagicMock()
-        self.presenter.add_group_to_model(MuonGroup('group_1', [1,2,3,4], [3]))
+        self.presenter.add_group_to_model(MuonGroup(group_name='group_1', detector_ids=[1,2,3,4], periods=[3]))
 
         self.presenter.update_view_from_model()
 
@@ -425,7 +425,7 @@ class GroupingTablePresenterTest(unittest.TestCase):
     def test_update_view_from_model_correctly_adds_warnings_for_valid(self):
         self.presenter.validate_periods_list = mock.MagicMock(return_value=RowValid.valid_for_all_runs)
         self.presenter._view.add_entry_to_table = mock.MagicMock()
-        self.presenter.add_group_to_model(MuonGroup('group_1', [1,2,3,4], [3]))
+        self.presenter.add_group_to_model(MuonGroup(group_name='group_1', detector_ids=[1,2,3,4], periods=[3]))
 
         self.presenter.update_view_from_model()
 

--- a/scripts/test/Muon/grouping_tab/grouping_table_presenter_test.py
+++ b/scripts/test/Muon/grouping_tab/grouping_table_presenter_test.py
@@ -403,7 +403,7 @@ class GroupingTablePresenterTest(unittest.TestCase):
         self.assertEquals(self.model.selected_groups, ['group_1'])
 
     def test_update_view_from_model_correctly_adds_warnings_for_invalid_periods(self):
-        self.presenter.validate_periods_list = mock.MagicMock(return_value=RowValid.invalid_for_all_runs)
+        self.presenter._model.validate_periods_list = mock.MagicMock(return_value=RowValid.invalid_for_all_runs)
         self.presenter._view.add_entry_to_table = mock.MagicMock()
         self.presenter.add_group_to_model(MuonGroup(group_name='group_1', detector_ids=[1,2,3,4], periods=[3]))
 
@@ -413,7 +413,7 @@ class GroupingTablePresenterTest(unittest.TestCase):
                                                                         (255, 0, 0), 'Warning: group periods invalid for all runs')
 
     def test_update_view_from_model_correctly_adds_warnings_for_semi_invalid_periods(self):
-        self.presenter.validate_periods_list = mock.MagicMock(return_value=RowValid.valid_for_some_runs)
+        self.presenter._model.validate_periods_list = mock.MagicMock(return_value=RowValid.valid_for_some_runs)
         self.presenter._view.add_entry_to_table = mock.MagicMock()
         self.presenter.add_group_to_model(MuonGroup(group_name='group_1', detector_ids=[1,2,3,4], periods=[3]))
 
@@ -423,7 +423,7 @@ class GroupingTablePresenterTest(unittest.TestCase):
                                                                         (255, 255, 0), 'Warning: group periods invalid for some runs')
 
     def test_update_view_from_model_correctly_adds_warnings_for_valid(self):
-        self.presenter.validate_periods_list = mock.MagicMock(return_value=RowValid.valid_for_all_runs)
+        self.presenter._model.validate_periods_list = mock.MagicMock(return_value=RowValid.valid_for_all_runs)
         self.presenter._view.add_entry_to_table = mock.MagicMock()
         self.presenter.add_group_to_model(MuonGroup(group_name='group_1', detector_ids=[1,2,3,4], periods=[3]))
 

--- a/scripts/test/Muon/grouping_tab/pairing_table_group_selector_test.py
+++ b/scripts/test/Muon/grouping_tab/pairing_table_group_selector_test.py
@@ -126,15 +126,16 @@ class GroupSelectorTest(unittest.TestCase):
         self.assertEqual(self.view.on_cell_changed.call_args_list[0][0], (0, 2))
 
     def test_that_removing_groups_and_then_calling_update_removes_groups_from_selections(self):
-        self.presenter.handle_add_pair_button_clicked()
-        self.group_context.remove_group("my_group_1")
-        self.group_context.remove_group('my_group_2')
+        pair = MuonPair(pair_name="my_pair_1", forward_group_name="my_group_1", backward_group_name="my_group_2",
+                        alpha=1.0)
+        self.presenter.add_pair(pair)
+        self.group_context.remove_group("my_group_0")
         self.presenter.update_view_from_model()
 
-        self.assertEqual(self.get_group_1_selector_from_pair(0).count(), 1)
-        self.assertEqual(self.get_group_2_selector_from_pair(0).count(), 1)
-        self.assertNotEqual(self.get_group_1_selector_from_pair(0).findText("my_group_0"), -1)
-        self.assertNotEqual(self.get_group_2_selector_from_pair(0).findText("my_group_0"), -1)
+        self.assertEqual(self.get_group_1_selector_from_pair(0).count(), 2)
+        self.assertEqual(self.get_group_2_selector_from_pair(0).count(), 2)
+        self.assertEqual(self.get_group_1_selector_from_pair(0).findText("my_group_0"), -1)
+        self.assertEqual(self.get_group_2_selector_from_pair(0).findText("my_group_0"), -1)
 
     def test_adding_new_group_does_not_change_pair_selection(self):
         self.presenter.handle_add_pair_button_clicked()
@@ -154,15 +155,16 @@ class GroupSelectorTest(unittest.TestCase):
         self.assertEqual(self.get_group_2_selector_from_pair(0).currentText(), 'my_group_1')
 
     def test_removing_group_used_in_pair_handled_gracefully(self):
-        self.presenter.handle_add_pair_button_clicked()
+        self.add_two_pairs_to_table()
 
         self.group_context.remove_group("my_group_0")
+        self.group_context.remove_pair("my_pair_0")
         self.presenter.update_view_from_model()
 
         self.assertEqual(self.get_group_1_selector_from_pair(0).count(), 2)
         self.assertEqual(self.get_group_2_selector_from_pair(0).count(), 2)
         self.assertEqual(self.get_group_1_selector_from_pair(0).currentText(), 'my_group_1')
-        self.assertEqual(self.get_group_2_selector_from_pair(0).currentText(), 'my_group_1')
+        self.assertEqual(self.get_group_2_selector_from_pair(0).currentText(), 'my_group_2')
 
     def test_group_changed_to_other_group_switches_groups(self):
         self.presenter.handle_add_pair_button_clicked()

--- a/scripts/test/Muon/grouping_tab/pairing_table_presenter_test.py
+++ b/scripts/test/Muon/grouping_tab/pairing_table_presenter_test.py
@@ -97,7 +97,7 @@ class PairingTablePresenterTest(unittest.TestCase):
     def test_that_add_pair_button_adds_pair_to_end_of_table(self):
         self.add_two_pairs_to_table()
 
-        self.presenter.add_pair(MuonPair(pair_name="new"))
+        self.presenter.add_pair(MuonPair(pair_name="new", forward_group_name='my_group_0', backward_group_name='my_group_1'))
 
         self.assertEqual(self.view.get_table_item_text(self.view.num_rows() - 1, 0), "new")
 


### PR DESCRIPTION
**Description of work.**

This adds warnings to the Muon Analysis GUI when one or more runs do not contain all the relevant periods to calculate a group fully. If some runs are missing periods the rows are colored in yellow and if all runs are missing periods they are colored in red. The tooltips are also updated to reflect this.

The names of groups calculated have also been updated to remove the periods information as this is now contained in the group.

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

**To test:**
You will need access to the ISIS data archive:
  * Load in a run with single period data and one with several periods. HIFI84447 and HIFI44447 should suffice for this.
  * Check that warnings are shown for all groups containing a period that is not 1.
  * Check that is you switch to just 44447 the yellow rows become red as they are now invalid for all groups.
  * Check that if you switch to just 84447 all the rows clear.

<!-- Instructions for testing. -->

Fixes #29121 <!-- and fix #xxxx or close #xxxx xor resolves #xxxx -->
<!-- alternative
*There is no associated issue.*
-->

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
-->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
