### PR TITLE
Pull in fix for mslice cli in workbench

### DIFF
--- a/scripts/ExternalInterfaces/CMakeLists.txt
+++ b/scripts/ExternalInterfaces/CMakeLists.txt
@@ -8,7 +8,7 @@ externalproject_add(mslice
                     GIT_REPOSITORY
                     "https://github.com/mantidproject/mslice.git"
                     GIT_TAG
-                    966f05885864d06f09636e732d00ed2c6ad4275c
+                    37d279b354c9131542607f4c48c3327d26228ed8
                     EXCLUDE_FROM_ALL 1
                     CONFIGURE_COMMAND ""
                     BUILD_COMMAND ""


### PR DESCRIPTION
**Description of work.**

Pulls in fix in mslice so that scripts in workbench don't randomly crash.

**To test:**

The following script should no longer crash:

```python
import mslice.cli as mc
import mslice.plotting.pyplot as plt

ws = mc.Load(Filename='MARIReductionAutoEi.nxs', OutputWorkspace='MARIReductionAutoEi')

fig = plt.gcf()
ax = fig.add_subplot(111, projection="mslice")
slice_ws = mc.Slice(ws, Axis1="|Q|,0.27356,11.0351,0.04671", Axis2="DeltaE,-30.0,58.2,0.3", NormToOne=False)

mesh = ax.pcolormesh(slice_ws, cmap="viridis")
mesh.set_clim(0.0, 376.8665783219241)
cb = plt.colorbar(mesh, ax=ax)
cb.set_label('Intensity (arb. units)', labelpad=20, rotation=270, picker=5)
ax.set_title('MARIReductionAutoEi.00meV')
mc.Show()
```
The file is in the system test data reference folder.

Note that a Windows debug build is the best thing for knowing if this works correctly as if not then you will get a debug assertion exception

Fixes #29061 

*This does not require release notes* because **it is a regression in this dev cycle.**

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
