### PR TITLE
Axvline & Axhline replotting on project load

### DIFF
--- a/qt/python/mantidqt/project/plotsloader.py
+++ b/qt/python/mantidqt/project/plotsloader.py
@@ -148,18 +148,12 @@ class PlotsLoader(object):
         if dic["title"] is not None:
             ax.set_title(dic["title"])
 
-        # Flatten the creation args and get just the label from each dict.
-        # These labels are for lines associated with workspaces.
-        ws_line_labels = [
-            line_dict['label'] for sublist in self.creation_args for line_dict in sublist
-        ]
-
         # Update the lines
         line_list = dic["lines"]
         for line in line_list:
-            if line['label'] not in ws_line_labels:
+            if line['lineData']:
                 # Then assume this line was created with ax.axvline or hline.
-                points = line['lineData']['data']
+                points = line['lineData']
                 if points[0][0] == points[1][0]:
                     # The x-coords of each point matches, this is a vertical line
                     ax.axvline(points[0][0], ymin=points[0][1], ymax=points[1][1])

--- a/qt/python/mantidqt/project/plotssaver.py
+++ b/qt/python/mantidqt/project/plotssaver.py
@@ -212,10 +212,22 @@ class PlotsSaver(object):
                      "lineWidth": line.get_linewidth(),
                      "lineStyle": line.get_linestyle(),
                      "markerStyle": self.get_dict_from_marker_style(line),
-                     "errorbars": self.get_dict_for_errorbars(line)}
+                     "errorbars": self.get_dict_for_errorbars(line),
+                     "lineData": self.get_dict_from_line_data(line)
+                     }
         if line_dict["alpha"] is None:
             line_dict["alpha"] = 1
         return line_dict
+
+    def get_dict_from_line_data(self, line):
+        for arg_dict in self.figure_creation_args:
+            if arg_dict['label'] != line.get_label():
+                return {
+                    "exists": True,
+                    "data": line._xy.tolist()
+                }
+            else:
+                return {"exists": False}
 
     def get_dict_for_errorbars(self, line):
         if self.figure_creation_args[0]["function"] == "errorbar":

--- a/qt/python/mantidqt/project/plotssaver.py
+++ b/qt/python/mantidqt/project/plotssaver.py
@@ -220,14 +220,14 @@ class PlotsSaver(object):
         return line_dict
 
     def get_dict_from_line_data(self, line):
-        for arg_dict in self.figure_creation_args:
-            if arg_dict['label'] != line.get_label():
-                return {
-                    "exists": True,
-                    "data": line._xy.tolist()
-                }
-            else:
-                return {"exists": False}
+        # For axhlines and axvlines, save their data.
+        # (any lines with constant x or y will also be reproduced by one of these methods.)
+        if line._xy.shape == (2, 2):
+            points = line._xy.tolist()
+            if points[0][0] == points[1][0] or points[0][1] == points[1][1]:
+                # x1 == x2 or y1 == y2
+                return points
+        return None
 
     def get_dict_for_errorbars(self, line):
         if self.figure_creation_args[0]["function"] == "errorbar":

--- a/qt/python/mantidqt/project/test/test_plotsloader.py
+++ b/qt/python/mantidqt/project/test/test_plotsloader.py
@@ -31,7 +31,7 @@ class PlotsLoaderTest(unittest.TestCase):
         plt.plot = mock.MagicMock()
         mantid.plots.axesfunctions.plot = mock.MagicMock()
         self.dictionary = {u'legend': {u'exists': False},
-                           u'lines': [{u'label': 'wsLine'}],
+                           u'lines': [{u'label': 'wsLine', u'lineData': None}],
                            u'properties': {u'axisOn': True, u'bounds': (0.0, 0.0, 0.0, 0.0), u'dynamic': True,
                                            u'frameOn': True, u'visible': True,
                                            u'xAxisProperties': {u'fontSize': 10.0,
@@ -130,8 +130,8 @@ class PlotsLoaderTest(unittest.TestCase):
         ax.axhline = mock.MagicMock()
 
         dict = self.dictionary
-        dict['lines'].append({'label': 'vline', 'lineData': {'exists': True, 'data': [[1.0, 0.0], [1.0, 1.0]]}})
-        dict['lines'].append({'label': 'hline', 'lineData': {'exists': True, 'data': [[0.0, 1.0], [1.0, 1.0]]}})
+        dict['lines'].append({'label': 'vline', 'lineData': [[1.0, 0.0], [1.0, 1.0]]})
+        dict['lines'].append({'label': 'hline', 'lineData': [[0.0, 1.0], [1.0, 1.0]]})
         self.plots_loader.restore_fig_axes(ax, dict)
 
         self.assertEqual(ax.axvline.call_count, 1)

--- a/qt/python/mantidqt/project/test/test_plotssaver.py
+++ b/qt/python/mantidqt/project/test/test_plotssaver.py
@@ -62,7 +62,7 @@ class PlotsSaverTest(unittest.TestCase):
                                              u'markerType': u'None',
                                              u'zOrder': 2},
                             u'errorbars': {u'exists': False},
-                            u'lineData': {u'exists': False}}],
+                            u'lineData': None}],
                 u'properties': {u'axisOn': True, u'bounds': (0.0, 0.0, 0.0, 0.0),
                                 u'dynamic': True,
                                 u'frameOn': True,
@@ -154,28 +154,25 @@ class PlotsSaverTest(unittest.TestCase):
 
     def test_line_data_not_saved_for_workspace_line(self):
         # if a line is associated with a workspace, the line data should NOT be saved
-        self.plot_saver.figure_creation_args = [{"function": "plot", "label": "ws1: spec 2"}]
         return_value = self.plot_saver.get_dict_from_line_data(self.fig.axes[0].lines[0])
 
-        self.assertEqual(return_value, {"exists": False})
+        self.assertEqual(return_value, None)
 
     def test_line_data_is_saved_for_axvline(self):
         # if the figure contains an axvline, the line data should be saved
-        self.plot_saver.figure_creation_args = [{"function": "plot", "label": "ws1: spec 2"}]
         self.fig.axes[0].axvline(0, ymin=0, ymax=1)
 
         return_value = self.plot_saver.get_dict_from_line_data(self.fig.axes[0].lines[1])
 
-        self.assertEqual(return_value, {'exists': True, 'data': [[0.0, 0.0], [0.0, 1.0]]})
+        self.assertEqual(return_value, [[0.0, 0.0], [0.0, 1.0]])
 
     def test_line_data_is_saved_for_axhline(self):
         # if the figure contains an axvline, the line data should be saved
-        self.plot_saver.figure_creation_args = [{"function": "plot", "label": "ws1: spec 2"}]
         self.fig.axes[0].axhline(0, xmin=0, xmax=1)
 
         return_value = self.plot_saver.get_dict_from_line_data(self.fig.axes[0].lines[1])
 
-        self.assertEqual(return_value, {'exists': True, 'data': [[0.0, 0.0], [1.0, 0.0]]})
+        self.assertEqual(return_value, [[0.0, 0.0], [1.0, 0.0]])
 
     def test_get_dict_from_axes_properties(self):
         return_value = self.plot_saver.get_dict_from_axes_properties(self.fig.axes[0])


### PR DESCRIPTION
This pull request supports the saving and loading of projects that contain plots with `ax.axvline`s and `ax.axhline`s. 

This partially fixes issue #28985, as we are yet to investigate Mantid Line Markers.

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** Aidy / ISIS
-->

**To test:**

<!-- Instructions for testing. -->
1. Run the following script
```
from mantid.simpleapi import *
import matplotlib.pyplot as plt

ws1 = CreateSampleWorkspace(OutputWorkspace="ws1")
fig, axes = plt.subplots(edgecolor='#ffffff', num='SANSLOQCan2D-1', subplot_kw={'projection': 'mantid'})
axes.plot(ws1, label='ws1', specNum=1)
axes.axhline(1, xmin=0, xmax=1)
axes.axvline(0, ymin=0, ymax=1)
plt.show()
```
2. With the plot still open, save the project.
3. Close the plot and open the project you just saved.
4. When the project loads, verify the same plot appears, with the axvline and axhline plotted correctly.

fixes _**Partially**_ #28985 

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
