### PR TITLE
Use sourceforge link for older sip versions

### DIFF
--- a/buildconfig/CMake/ExternalSipPyQt4.cmake
+++ b/buildconfig/CMake/ExternalSipPyQt4.cmake
@@ -12,7 +12,7 @@ set(PYQT4_SIP_VERSION_STR "4.19.7" CACHE STRING "sip version string" FORCE)
 ExternalProject_Add(extern-pyqt4-sip
   PREFIX ${_SIP_PYQT_DIR}/sip
   INSTALL_DIR ${_SIP_PYQT_INSTALL_DIR}
-  URL https://www.riverbankcomputing.com/static/Downloads/sip/4.19.7/sip-4.19.7.tar.gz
+  URL https://sourceforge.net/projects/pyqt/files/sip/sip-4.19.7/sip-4.19.7.tar.gz/download
   URL_HASH MD5=ae4f2db79713046d61b2a44e5ee1e3ab
   CONFIGURE_COMMAND "${Python_EXECUTABLE}" "<SOURCE_DIR>/configure.py"
     --sip-module=PyQt4.sip


### PR DESCRIPTION
**Description of work.**

Riverbank computing seem to only keep the latest version of sip on their servers and archive everything else on sourceforge or pypi.

**To test:**

* Check a clean RHEL7 build passes

*There is no associated issue.*

*This does not require release notes* because **it is an internal change.**

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
