### PR TITLE
SliceViewer: Cut plot line width reduction

### DIFF
--- a/docs/source/release/v5.1.0/mantidworkbench.rst
+++ b/docs/source/release/v5.1.0/mantidworkbench.rst
@@ -97,6 +97,7 @@ Improvements
 - Sliceviewer colourmap uses the default colourmap from the settings.
 - Code completions are now loaded when the code editor is first changed.
 - Legends in 1D plots are now editable in-situ.
+- Sliceviewer cut line plots' line widths reduced
 
 Bugfixes
 ########

--- a/qt/python/mantidqt/widgets/sliceviewer/lineplots.py
+++ b/qt/python/mantidqt/widgets/sliceviewer/lineplots.py
@@ -92,6 +92,7 @@ class LinePlots:
         except (AttributeError, IndexError):
             self._axx.clear()
             self._xfig = self._axx.plot(x, y, scalex=False)[0]
+            self._xfig.set_linewidth(0.5)
             self.update_line_plot_labels()
 
     def plot_y_line(self, x: np.array, y: np.array):
@@ -105,6 +106,7 @@ class LinePlots:
         except (AttributeError, IndexError):
             self._axy.clear()
             self._yfig = self._axy.plot(y, x, scaley=False)[0]
+            self._yfig.set_linewidth(0.5)
             self.update_line_plot_labels()
 
     def redraw(self):

--- a/qt/python/mantidqt/widgets/sliceviewer/test/test_sliceviewer_lineplots.py
+++ b/qt/python/mantidqt/widgets/sliceviewer/test/test_sliceviewer_lineplots.py
@@ -37,10 +37,8 @@ class LinePlotsTest(unittest.TestCase):
         self.assertEqual(1, mock_gridspec.call_count)
         # use spaces at 0, 1 & 3 in grid
         gs.__getitem__.assert_has_calls((call(0), call(1), call(3)), any_order=True)
-        self.assertTrue('sharey' in fig.add_subplot.call_args_list[0][1] or
-                        'sharey' in fig.add_subplot.call_args_list[1][1])
-        self.assertTrue('sharex' in fig.add_subplot.call_args_list[0][1] or
-                        'sharex' in fig.add_subplot.call_args_list[1][1])
+        self.assertTrue('sharey' in fig.add_subplot.call_args_list[0][1] or 'sharey' in fig.add_subplot.call_args_list[1][1])
+        self.assertTrue('sharex' in fig.add_subplot.call_args_list[0][1] or 'sharex' in fig.add_subplot.call_args_list[1][1])
 
     def test_delete_plot_lines_handles_empty_plots(self):
         plotter = LinePlots(self.image_axes, self.mock_colorbar)

--- a/qt/python/mantidqt/widgets/sliceviewer/test/test_sliceviewer_lineplots.py
+++ b/qt/python/mantidqt/widgets/sliceviewer/test/test_sliceviewer_lineplots.py
@@ -74,17 +74,18 @@ class LinePlotsTest(unittest.TestCase):
         self.axy.plot.assert_called_once_with(y, x, scaley=False)
         self.axy.set_ylabel.assert_called_once_with(self.image_axes.get_ylabel())
 
-    def test_plot_lines_are_set_to_width_of_below_default(self):
+    def test_plot_axx_lines_are_set_to_width_of_below_default(self):
         plotter = LinePlots(self.image_axes, self.mock_colorbar)
-        self.axx.set_xlabel.reset_mock()
         x, y = np.arange(10.), np.arange(10.) * 2
 
         plotter.plot_x_line(x, y)
         self.axx.plot.assert_called_once_with(x, y, scalex=False)
         self.assert_that_a_call_has_been_made_to_this_object_containing_linewidth_and_half(self.axx.plot)
 
-        self.axy.set_ylabel.reset_mock()
-        self.axy.set_xlim.reset_mock()
+    def test_plot_axy_lines_are_set_to_width_of_below_default(self):
+        plotter = LinePlots(self.image_axes, self.mock_colorbar)
+        x, y = np.arange(10.), np.arange(10.) * 2
+
         plotter.plot_y_line(x, y)
         self.axy.plot.assert_called_once_with(y, x, scaley=False)
         self.assert_that_a_call_has_been_made_to_this_object_containing_linewidth_and_half(self.axy.plot)


### PR DESCRIPTION
**Description of work.**
Reduced width of the lines on the slice cut line plots on the SliceViewer

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

**To test:**
- Open Sliceviewer with MAR11060 from sample data
- Click the plot button to pop up the slice cut plots
- Hover over the colorfill plot 
- Notice the lines are more visible as it is a quarter of the thickness of before

Should look like this: 
![image](https://user-images.githubusercontent.com/24723609/91540949-784a3100-e913-11ea-8eb4-d4dc19f46e7a.png)


<!-- Instructions for testing. -->

Fixes #29236 <!-- and fix #xxxx or close #xxxx xor resolves #xxxx -->
<!-- alternative
*There is no associated issue.*
-->

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
-->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
