### PR TITLE
Reduce invalid logs messages on loading a nexus file to one per file.

### DIFF
--- a/Framework/DataHandling/inc/MantidDataHandling/LoadNexusLogs.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/LoadNexusLogs.h
@@ -8,6 +8,7 @@
 
 #include "MantidAPI/NexusFileLoader.h"
 #include <nexus/NeXusFile.hpp>
+#include <vector>
 
 namespace Mantid {
 namespace Kernel {
@@ -107,6 +108,8 @@ private:
   /// Use frequency start for Monitor19 and Special1_19 logs with "No Time" for
   /// SNAP
   std::string freqStart;
+
+  mutable std::vector<std::string> m_logsWithInvalidValues;
 };
 
 } // namespace DataHandling

--- a/Framework/DataHandling/src/LoadNexusLogs.cpp
+++ b/Framework/DataHandling/src/LoadNexusLogs.cpp
@@ -649,19 +649,17 @@ void LoadNexusLogs::execLoader() {
   if (m_logsWithInvalidValues.size() > 0) {
     if (m_logsWithInvalidValues.size() == 1) {
       g_log.warning()
-        << "Sample Log \"" << m_logsWithInvalidValues[0]
-        << "\" contains invalid values, click \"Show Sample Logs\" "
-           "for details.\n";
-
+          << "Sample Log \"" << m_logsWithInvalidValues[0]
+          << "\" contains invalid values, click \"Show Sample Logs\" "
+             "for details.\n";
     }
-    auto other_string = (m_logsWithInvalidValues.size() < 2) ? " other " : " others";
+    auto other_string =
+        (m_logsWithInvalidValues.size() < 2) ? " other " : " others";
     g_log.warning()
-      << "Sample Log \"" << m_logsWithInvalidValues[0]
-      << "\" and " << m_logsWithInvalidValues.size() - 1
-      << other_string
-      << " contain invalid values, click \"Show Sample Logs\" for "
-          "details.\n";
-
+        << "Sample Log \"" << m_logsWithInvalidValues[0] << "\" and "
+        << m_logsWithInvalidValues.size() - 1 << other_string
+        << " contain invalid values, click \"Show Sample Logs\" for "
+           "details.\n";
   }
 }
 

--- a/Framework/DataHandling/src/LoadNexusLogs.cpp
+++ b/Framework/DataHandling/src/LoadNexusLogs.cpp
@@ -648,16 +648,19 @@ void LoadNexusLogs::execLoader() {
 
   if (m_logsWithInvalidValues.size() > 0) {
     if (m_logsWithInvalidValues.size() == 1) {
-      g_log.warning() << "Sample Log \"" << m_logsWithInvalidValues[0]
-                      << "\" contains invalid values, click \"Show Sample Logs\" "
-                         "for details.\n";
+      g_log.warning()
+        << "Sample Log \"" << m_logsWithInvalidValues[0]
+        << "\" contains invalid values, click \"Show Sample Logs\" "
+           "for details.\n";
+
     }
-    auto other_string = (m_logsWithInvalidValues.size() < 2) ? " other" : " others";
-    g_log.warning() << "Sample Log \"" << m_logsWithInvalidValues[0]
-                    << "\" and " << m_logsWithInvalidValues.size() - 1
-                    << other_string
-                    << " contains invalid values, click \"Show Sample Logs\" for "
-                       "details.\n";
+    auto other_string = (m_logsWithInvalidValues.size() < 2) ? " other " : " others";
+    g_log.warning()
+      << "Sample Log \"" << m_logsWithInvalidValues[0]
+      << "\" and " << m_logsWithInvalidValues.size() - 1
+      << other_string
+      << " contain invalid values, click \"Show Sample Logs\" for "
+          "details.\n";
 
   }
 }

--- a/Framework/DataHandling/src/LoadNexusLogs.cpp
+++ b/Framework/DataHandling/src/LoadNexusLogs.cpp
@@ -344,7 +344,6 @@ std::unique_ptr<Kernel::Property> createTimeSeriesValidityFilter(
     }
   }
   if (invalidDataFound) {
-    log.warning() << "Some \"" << prop.name() << "\" log data is invalid!\n";
     const auto tspName =
         API::LogManager::getInvalidValuesFilterLogName(prop.name());
     auto tsp = std::make_unique<TimeSeriesProperty<bool>>(tspName);
@@ -646,6 +645,21 @@ void LoadNexusLogs::execLoader() {
 
   // Close the file
   file.close();
+
+  if (m_logsWithInvalidValues.size() > 0) {
+    if (m_logsWithInvalidValues.size() == 1) {
+      g_log.warning() << "Sample Log \"" << m_logsWithInvalidValues[0]
+                      << "\" contains invalid values, click \"Show Sample Logs\" "
+                         "for details.\n";
+    }
+    auto other_string = (m_logsWithInvalidValues.size() < 2) ? " other" : " others";
+    g_log.warning() << "Sample Log \"" << m_logsWithInvalidValues[0]
+                    << "\" and " << m_logsWithInvalidValues.size() - 1
+                    << other_string
+                    << " contains invalid values, click \"Show Sample Logs\" for "
+                       "details.\n";
+
+  }
 }
 
 /** Try to load the "Veto_pulse" field in DASLogs
@@ -853,6 +867,7 @@ void LoadNexusLogs::loadNXLog(
         appendEndTimeLog(validityLogValue.get(), workspace->run());
         workspace->mutableRun().addProperty(std::move(validityLogValue),
                                             overwritelogs);
+        m_logsWithInvalidValues.emplace_back(entry_name);
       }
       appendEndTimeLog(logValue.get(), workspace->run());
       workspace->mutableRun().addProperty(std::move(logValue), overwritelogs);
@@ -917,6 +932,7 @@ void LoadNexusLogs::loadSELog(
       if (validityLogValue) {
         appendEndTimeLog(validityLogValue.get(), workspace->run());
         workspace->mutableRun().addProperty(std::move(validityLogValue));
+        m_logsWithInvalidValues.emplace_back(propName);
       }
       appendEndTimeLog(logValue.get(), workspace->run());
 


### PR DESCRIPTION
**Description of work.**
The previous implementation could spam the log if a nexus file had many logs with invalid values (and many do).
```
Load started
Some "CCR_head" log data is invalid!
Some "CCR_heater" log data is invalid!
Some "Cycle" log data is invalid!
Some "Jaw_East" log data is invalid!
Some "Jaw_Horiz_Gap" log data is invalid!
Some "Jaw_North" log data is invalid!
Some "Jaw_South" log data is invalid!
Some "Jaw_Vert_Centre" log data is invalid!
Some "Jaw_Vert_Gap" log data is invalid!
Some "Jaw_West" log data is invalid!
Some "RB" log data is invalid!
Some "Stick_heater" log data is invalid!
Some "T_fixed" log data is invalid!
Some "T_float" log data is invalid!
Some "CCR_head" log data is invalid!
Some "CCR_heater" log data is invalid!
Some "Cycle" log data is invalid!
Some "Jaw_East" log data is invalid!
Some "Jaw_Horiz_Gap" log data is invalid!
Some "Jaw_North" log data is invalid!
Some "Jaw_South" log data is invalid!
Some "Jaw_Vert_Centre" log data is invalid!
Some "Jaw_Vert_Gap" log data is invalid!
Some "Jaw_West" log data is invalid!
Some "RB" log data is invalid!
Some "Stick_heater" log data is invalid!
Some "T_fixed" log data is invalid!
Some "T_float" log data is invalid!
Load successful, Duration 4.33 seconds
```

This reduces the invalid logs messages on loading a nexus file to one per file.
No matter how many logs are affected.

**To test:**

1. Load a recent file, e.g. MAR27283 (most recent cycle)
1. Only get one log message warning about invalid logs
```
Sample Log "CCR_head" and 13 others contain invalid values, use "Show Sample Logs" for details.
```

*There is no associated issue.*



*This does not require release notes* because it is a minor change to something that was added in this release and the existing notes still apply.


---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
