### PR TITLE
Update view on wheel zoom

### DIFF
--- a/docs/source/release/v5.1.0/mantidworkbench.rst
+++ b/docs/source/release/v5.1.0/mantidworkbench.rst
@@ -149,5 +149,6 @@ Bugfixes
 - Warn users when they attempt to use Generate Recovery Script with no workspaces present.
 - The y axis labels will now appear in the correct order if imshow is called from a script with origin=upper.
 - Fixed a bug with colorfill plot script generation for distribution workspaces.
+- Fixed a bug where instrument view would not update on wheel zoom.
 
 :ref:`Release 5.1.0 <v5.1.0>`

--- a/qt/widgets/instrumentview/src/Projection3D.cpp
+++ b/qt/widgets/instrumentview/src/Projection3D.cpp
@@ -373,7 +373,7 @@ void Projection3D::zoom(int x, int y) {
  */
 void Projection3D::wheelZoom(int x, int y, int d) {
   m_viewport.wheelZoom(x, y, d);
-  updateView(false);
+  updateView(true);
   emit finishedMove();
 }
 


### PR DESCRIPTION
**Description of work.**
This PR just makes it so the instrument view is also updated on mouse wheel scaling, not just on clicking and dragging ( see #29251 ).

-->

**To test:**
- Open Workbench.
- Load an instrument file.
- Open the instrument viewer.
- Go to the `Pick` tab. Select the `navigation` tool.
- Using the mouse wheel, zoom in or out.
- Select the `Select single pixel` tool.
- Check the info on the left boxes correspond to the pixel the mouse is hovering over.
 - Try the same thing on the `Mask` tab.
<!-- Instructions for testing. -->

Fixes #29251 .

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
