### PR TITLE
EngDiff UI Grey out Inspect Background button until usable

### DIFF
--- a/docs/source/release/v5.1.0/diffraction.rst
+++ b/docs/source/release/v5.1.0/diffraction.rst
@@ -47,6 +47,7 @@ Improvements
 - The currently loaded calibration is now shown at the bottom of the GUI.
 - The location of the saved output files from the GUI is now shown in the messages log.
 - The save directory is now displayed in the status bar of the GUI.
+- The Inspect Background button of the Fitting tab is now only enabled when the selected run has had a background subtraction.
 
 Bugfixes
 ^^^^^^^^

--- a/scripts/Engineering/gui/engineering_diffraction/tabs/fitting/data_handling/data_presenter.py
+++ b/scripts/Engineering/gui/engineering_diffraction/tabs/fitting/data_handling/data_presenter.py
@@ -21,12 +21,14 @@ class FittingDataPresenter(object):
 
         # Connect view signals to local methods
         self.view.set_on_load_clicked(self.on_load_clicked)
-        self.view.set_enable_button_connection(self._enable_load_button)
+        self.view.set_enable_load_button_connection(self._enable_load_button)
+        self.view.set_enable_inspect_bg_button_connection(self._enable_inspect_bg_button)
         self.view.set_on_remove_selected_clicked(self._remove_selected_tracked_workspaces)
         self.view.set_on_remove_all_clicked(self._remove_all_tracked_workspaces)
         self.view.set_on_plotBG_clicked(self._plotBG)
         self.view.set_on_table_cell_changed(self._handle_table_cell_changed)
         self.view.set_on_xunit_changed(self._log_xunit_change)
+        self.view.set_table_selection_changed(self._handle_selection_changed)
 
         # Observable Setup
         self.plot_added_notifier = GenericObservable()
@@ -81,13 +83,13 @@ class FittingDataPresenter(object):
         """
         self.worker = AsyncTask(self.model.load_files, (filenames, xunit),
                                 error_cb=self._on_worker_error,
-                                finished_cb=self._emit_enable_button_signal,
+                                finished_cb=self._emit_enable_load_button_signal,
                                 success_cb=self._on_worker_success)
         self.worker.start()
 
     def _on_worker_error(self, _):
         logger.error("Error occurred when loading files.")
-        self._emit_enable_button_signal()
+        self._emit_enable_load_button_signal()
 
     def _on_worker_success(self, _):
         if self.view.get_add_to_plot():
@@ -167,11 +169,22 @@ class FittingDataPresenter(object):
                     bg_params = self.view.read_bg_params_from_table(row)
                     self.model.do_background_subtraction(ws_name, bg_params)
 
+    def _handle_selection_changed(self):
+        rows = self.view.get_selected_rows()
+        enabled = False
+        for row in rows:
+            if self.view.get_item_checked(row, 3):
+                enabled = True
+        self._enable_inspect_bg_button(enabled)
+
     def _enable_load_button(self, enabled):
         self.view.set_load_button_enabled(enabled)
 
-    def _emit_enable_button_signal(self):
+    def _emit_enable_load_button_signal(self):
         self.view.sig_enable_load_button.emit(True)
+
+    def _enable_inspect_bg_button(self, enabled):
+        self.view.set_inspect_bg_button_enabled(enabled)
 
     def _get_filenames(self):
         return self.view.get_filenames_to_load()

--- a/scripts/Engineering/gui/engineering_diffraction/tabs/fitting/data_handling/data_view.py
+++ b/scripts/Engineering/gui/engineering_diffraction/tabs/fitting/data_handling/data_view.py
@@ -13,6 +13,7 @@ Ui_data, _ = load_ui(__file__, "data_widget.ui")
 
 class FittingDataView(QtWidgets.QWidget, Ui_data):
     sig_enable_load_button = QtCore.Signal(bool)
+    sig_enable_inspect_bg_button = QtCore.Signal(bool)
 
     def __init__(self, parent=None):
         super(FittingDataView, self).__init__(parent)
@@ -35,8 +36,11 @@ class FittingDataView(QtWidgets.QWidget, Ui_data):
     def set_on_xunit_changed(self, slot):
         self.combo_xunit.currentIndexChanged.connect(lambda: slot(self.combo_xunit.currentText()))
 
-    def set_enable_button_connection(self, slot):
+    def set_enable_load_button_connection(self, slot):
         self.sig_enable_load_button.connect(slot)
+
+    def set_enable_inspect_bg_button_connection(self, slot):
+        self.sig_enable_inspect_bg_button.connect(slot)
 
     def set_on_remove_all_clicked(self, slot):
         self.button_removeAll.clicked.connect(slot)
@@ -50,12 +54,18 @@ class FittingDataView(QtWidgets.QWidget, Ui_data):
     def set_on_table_cell_changed(self, slot):
         self.table_selection.cellChanged.connect(slot)  # Row, Col
 
+    def set_table_selection_changed(self, slot):
+        self.table_selection.itemSelectionChanged.connect(slot)
+
     # =================
     # Component Setters
     # =================
 
     def set_load_button_enabled(self, enabled):
         self.button_load.setEnabled(enabled)
+
+    def set_inspect_bg_button_enabled(self, enabled):
+        self.button_plotBG.setEnabled(enabled)
 
     def add_table_row(self, run_no, bank, checked, bgsub, niter, xwindow, SG):
         row_no = self.table_selection.rowCount()

--- a/scripts/Engineering/gui/engineering_diffraction/tabs/fitting/data_handling/data_widget.ui
+++ b/scripts/Engineering/gui/engineering_diffraction/tabs/fitting/data_handling/data_widget.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>472</width>
-    <height>257</height>
+    <width>1053</width>
+    <height>372</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -70,7 +70,7 @@ QGroupBox:title {
           </property>
          </widget>
         </item>
-		<item row="2" column="1">
+        <item row="2" column="1">
          <widget class="QComboBox" name="combo_xunit">
           <item>
            <property name="text">
@@ -84,7 +84,7 @@ QGroupBox:title {
           </item>
          </widget>
         </item>
-        <item row="2" column="0" colspan="1">
+        <item row="2" column="0">
          <widget class="QCheckBox" name="check_addToPlot">
           <property name="text">
            <string>Add to Plot</string>
@@ -162,22 +162,22 @@ QGroupBox:title {
           <string>Plot</string>
          </property>
         </column>
-		<column>
+        <column>
          <property name="text">
           <string>Subtract BG</string>
          </property>
         </column>
-		<column>
+        <column>
          <property name="text">
           <string>Niter</string>
          </property>
         </column>
-		<column>
+        <column>
          <property name="text">
           <string>Xwindow</string>
          </property>
         </column>
-		<column>
+        <column>
          <property name="text">
           <string>SG</string>
          </property>
@@ -212,8 +212,11 @@ QGroupBox:title {
           </property>
          </widget>
         </item>
-		<item row="0" column="2">
+        <item row="0" column="2">
          <widget class="QPushButton" name="button_plotBG">
+          <property name="enabled">
+           <bool>false</bool>
+          </property>
           <property name="text">
            <string>Inspect Background</string>
           </property>

--- a/scripts/Engineering/gui/engineering_diffraction/tabs/fitting/data_handling/test/test_data_presenter.py
+++ b/scripts/Engineering/gui/engineering_diffraction/tabs/fitting/data_handling/test/test_data_presenter.py
@@ -319,6 +319,18 @@ class FittingDataPresenterTest(unittest.TestCase):
         self.model.do_background_subtraction.assert_not_called()
         self.model.undo_background_subtraction.assert_called_once_with("name2")
 
+    def test_inspect_bg_button_enables_and_disables(self):
+        self.view.get_item_checked.return_value = False
+        self.presenter.row_numbers = data_presenter.TwoWayRowDict()
+        self.presenter.row_numbers["name1"] = 0
+        self.presenter.row_numbers["name2"] = 1
+        self.view.get_selected_rows.return_value = self.presenter.row_numbers
+        self.presenter._handle_selection_changed()
+        self.view.set_inspect_bg_button_enabled.assert_called_with(False)
+        self.view.get_item_checked.return_value = True
+        self.presenter._handle_selection_changed()
+        self.view.set_inspect_bg_button_enabled.assert_called_with(True)
+
     def _setup_bgsub_test(self):
         mocked_table_item = mock.MagicMock()
         mocked_table_item.checkState.return_value = True

--- a/scripts/Engineering/gui/engineering_diffraction/tabs/fitting/data_handling/test/test_data_presenter.py
+++ b/scripts/Engineering/gui/engineering_diffraction/tabs/fitting/data_handling/test/test_data_presenter.py
@@ -47,7 +47,7 @@ class FittingDataPresenterTest(unittest.TestCase):
         mock_worker.assert_called_with("mocked model method",
                                        ("/a/file/to/load.txt, /another/one.nxs", "TOF"),
                                        error_cb=self.presenter._on_worker_error,
-                                       finished_cb=self.presenter._emit_enable_button_signal,
+                                       finished_cb=self.presenter._emit_enable_load_button_signal,
                                        success_cb=self.presenter._on_worker_success)
 
     @patch(dir_path + ".data_presenter.create_error_message")
@@ -318,6 +318,24 @@ class FittingDataPresenterTest(unittest.TestCase):
         self.presenter._handle_table_cell_changed(1, 3)
         self.model.do_background_subtraction.assert_not_called()
         self.model.undo_background_subtraction.assert_called_once_with("name2")
+
+    def test_inspect_bg_btn_disabled_default(self):
+        mocked_table_item = mock.MagicMock()
+        mocked_table_item.checkState.return_value = True
+        self.view.get_table_item.return_value = mocked_table_item
+        self.presenter.row_numbers = data_presenter.TwoWayRowDict()
+        self.presenter.row_numbers["name1"] = 0
+        self.presenter.row_numbers["name2"] = 1
+        self.model.get_loaded_workspaces.return_value = {"name1": self.ws1, "name2": self.ws2}
+        self.assertFalse(self.view.button_plotBG.isEnabled())
+
+    def test_inspect_bg_btn_changes_enabled(self):
+        self._setup_bgsub_test()
+        self.assertTrue(self.view.button_plotBG.isEnabled())
+        # undo background subtraction
+        self.view.get_item_checked.return_value = False
+        self.presenter._handle_table_cell_changed(1, 3)
+        self.assertFalse(self.view.button_plotBG.isEnabled())
 
     def _setup_bgsub_test(self):
         mocked_table_item = mock.MagicMock()

--- a/scripts/Engineering/gui/engineering_diffraction/tabs/fitting/data_handling/test/test_data_presenter.py
+++ b/scripts/Engineering/gui/engineering_diffraction/tabs/fitting/data_handling/test/test_data_presenter.py
@@ -319,24 +319,6 @@ class FittingDataPresenterTest(unittest.TestCase):
         self.model.do_background_subtraction.assert_not_called()
         self.model.undo_background_subtraction.assert_called_once_with("name2")
 
-    def test_inspect_bg_btn_disabled_default(self):
-        mocked_table_item = mock.MagicMock()
-        mocked_table_item.checkState.return_value = True
-        self.view.get_table_item.return_value = mocked_table_item
-        self.presenter.row_numbers = data_presenter.TwoWayRowDict()
-        self.presenter.row_numbers["name1"] = 0
-        self.presenter.row_numbers["name2"] = 1
-        self.model.get_loaded_workspaces.return_value = {"name1": self.ws1, "name2": self.ws2}
-        self.assertFalse(self.view.button_plotBG.isEnabled())
-
-    def test_inspect_bg_btn_changes_enabled(self):
-        self._setup_bgsub_test()
-        self.assertTrue(self.view.button_plotBG.isEnabled())
-        # undo background subtraction
-        self.view.get_item_checked.return_value = False
-        self.presenter._handle_table_cell_changed(1, 3)
-        self.assertFalse(self.view.button_plotBG.isEnabled())
-
     def _setup_bgsub_test(self):
         mocked_table_item = mock.MagicMock()
         mocked_table_item.checkState.return_value = True


### PR DESCRIPTION
**Description of work.**
Grey out (disable) the Inspect Background button until a run with a background subtraction has been selected.

**Report to:** Richard Waite

**To test:**
1. Open up the Engineering Diffraction GUI (Interfaces -> Diffraction -> Engineering Diffraction)
2. Go to the fitting tab
2. Load a couple of focused run files, e.g.
[29099test.zip](https://github.com/mantidproject/mantid/files/5161812/29099test.zip)
3. Ensure Inspect Background button is disabled initially
4. Tick `Subtract BG` checkbox for one run, select this row and check the button enables (and works)
5. Check that the button remains greyed out for the other run
6. Check the box for both runs, select both and ensure button is enabled and produces two plots
7. Deselect and check the button is disabled

Fixes #29099 . <!-- and fix #xxxx or close #xxxx xor resolves #xxxx -->
<!-- alternative
*There is no associated issue.*
-->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
