### PR TITLE
Editable combo boxes for workspace selection

### DIFF
--- a/docs/source/release/v5.1.0/mantidworkbench.rst
+++ b/docs/source/release/v5.1.0/mantidworkbench.rst
@@ -25,6 +25,8 @@ New
 Improvements
 ############
 
+- Combo boxes for workspace selection through `OptionsPropertyWidget` and `WorkspaceSelector` are now editable and support popup autocompletion based on the beginning of a string.
+
 .. figure:: ../../images/Plot1DSelectionDialog5-1.png
    :align: right
 

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/OptionsPropertyWidget.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/OptionsPropertyWidget.h
@@ -43,7 +43,7 @@ protected:
   QComboBox *m_combo;
 
 public slots:
-   void editingFinished();
+  void editingFinished();
 };
 
 } // namespace API

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/OptionsPropertyWidget.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/OptionsPropertyWidget.h
@@ -20,6 +20,7 @@ namespace API {
 
   @date 2012-02-17
 */
+
 class DLLExport OptionsPropertyWidget : public PropertyWidget {
   Q_OBJECT
 
@@ -40,6 +41,9 @@ protected:
 
   /// Combo box with the allowed options
   QComboBox *m_combo;
+
+public slots:
+   void editingFinished();
 };
 
 } // namespace API

--- a/qt/widgets/common/src/OptionsPropertyWidget.cpp
+++ b/qt/widgets/common/src/OptionsPropertyWidget.cpp
@@ -9,6 +9,7 @@
 #include "MantidKernel/ConfigService.h"
 #include "MantidKernel/System.h"
 #include <QComboBox>
+#include <QCompleter>
 #include <QLabel>
 
 using namespace Mantid::Kernel;
@@ -40,6 +41,10 @@ OptionsPropertyWidget::OptionsPropertyWidget(Mantid::Kernel::Property *prop,
   // output box and used the saved combo box
   m_combo = new QComboBox(this);
   m_combo->setToolTip(m_doc);
+  if (std::string(prop->type()).find("Workspace") != std::string::npos) {
+    m_combo->setEditable(true);
+    m_combo->completer()->setCompletionMode(QCompleter::PopupCompletion);
+  }
   m_widgets.push_back(m_combo);
 
   std::vector<std::string> items = prop->allowedValues();

--- a/qt/widgets/common/src/OptionsPropertyWidget.cpp
+++ b/qt/widgets/common/src/OptionsPropertyWidget.cpp
@@ -11,10 +11,10 @@
 #include <QComboBox>
 #include <QCompleter>
 #include <QLabel>
+#include <QLineEdit>
 
 using namespace Mantid::Kernel;
 using namespace Mantid::API;
-using namespace MantidQt::CustomInterfaces;
 
 namespace MantidQt {
 namespace API {

--- a/qt/widgets/common/src/OptionsPropertyWidget.cpp
+++ b/qt/widgets/common/src/OptionsPropertyWidget.cpp
@@ -14,10 +14,10 @@
 
 using namespace Mantid::Kernel;
 using namespace Mantid::API;
+using namespace MantidQt::CustomInterfaces;
 
 namespace MantidQt {
 namespace API {
-
 //----------------------------------------------------------------------------------------------
 /** Destructor
  */
@@ -43,7 +43,10 @@ OptionsPropertyWidget::OptionsPropertyWidget(Mantid::Kernel::Property *prop,
   m_combo->setToolTip(m_doc);
   if (std::string(prop->type()).find("Workspace") != std::string::npos) {
     m_combo->setEditable(true);
+    m_combo->setInsertPolicy(QComboBox::NoInsert);
     m_combo->completer()->setCompletionMode(QCompleter::PopupCompletion);
+    connect(m_combo->lineEdit(), SIGNAL(editingFinished()),
+            SLOT(editingFinished()));
   }
   m_widgets.push_back(m_combo);
 
@@ -80,5 +83,18 @@ void OptionsPropertyWidget::setValueImpl(const QString &value) {
   if (index >= 0)
     m_combo->setCurrentIndex(index);
 }
+
+void OptionsPropertyWidget::editingFinished() {
+  auto value = m_combo->currentText();
+  const QString temp =
+      value.isEmpty() ? QString::fromStdString(m_prop->getDefault()) : value;
+  int index = m_combo->findText(temp);
+  if (index >= 0)
+    m_combo->setCurrentIndex(index);
+  else {
+    updateIconVisibility();
+  }
+}
+
 } // namespace API
 } // namespace MantidQt

--- a/qt/widgets/common/src/OptionsPropertyWidget.cpp
+++ b/qt/widgets/common/src/OptionsPropertyWidget.cpp
@@ -84,6 +84,8 @@ void OptionsPropertyWidget::setValueImpl(const QString &value) {
     m_combo->setCurrentIndex(index);
 }
 
+//----------------------------------------------------------------------------------------------
+/** Performs validation of the inputs when editing is finished */
 void OptionsPropertyWidget::editingFinished() {
   auto value = m_combo->currentText();
   const QString temp =

--- a/qt/widgets/common/src/WorkspaceSelector.cpp
+++ b/qt/widgets/common/src/WorkspaceSelector.cpp
@@ -18,6 +18,7 @@
 #include "MantidAPI/MatrixWorkspace.h"
 #include "MantidAPI/WorkspaceGroup.h"
 
+#include <QCompleter>
 #include <QDebug>
 #include <QDropEvent>
 #include <QMimeData>
@@ -40,7 +41,8 @@ WorkspaceSelector::WorkspaceSelector(QWidget *parent, bool init)
       m_init(init), m_workspaceTypes(), m_showHidden(false), m_showGroups(true),
       m_optional(false), m_binLimits(std::make_pair(0, -1)), m_suffix(),
       m_algName(), m_algPropName(), m_algorithm() {
-  setEditable(false);
+  setEditable(true);
+  this->completer()->setCompletionMode(QCompleter::PopupCompletion);
   if (init) {
     Mantid::API::AnalysisDataServiceImpl &ads =
         Mantid::API::AnalysisDataService::Instance();

--- a/qt/widgets/common/src/WorkspaceSelector.cpp
+++ b/qt/widgets/common/src/WorkspaceSelector.cpp
@@ -21,6 +21,7 @@
 #include <QCompleter>
 #include <QDebug>
 #include <QDropEvent>
+#include <QLineEdit>
 #include <QMimeData>
 #include <QUrl>
 using namespace MantidQt::MantidWidgets;
@@ -42,7 +43,6 @@ WorkspaceSelector::WorkspaceSelector(QWidget *parent, bool init)
       m_optional(false), m_binLimits(std::make_pair(0, -1)), m_suffix(),
       m_algName(), m_algPropName(), m_algorithm() {
   setEditable(true);
-  this->completer()->setCompletionMode(QCompleter::PopupCompletion);
   if (init) {
     Mantid::API::AnalysisDataServiceImpl &ads =
         Mantid::API::AnalysisDataService::Instance();
@@ -55,6 +55,8 @@ WorkspaceSelector::WorkspaceSelector(QWidget *parent, bool init)
     refresh();
   }
   this->setAcceptDrops(true);
+  this->completer()->setCompletionMode(QCompleter::PopupCompletion);
+  this->setInsertPolicy(QComboBox::NoInsert);
 }
 
 /**


### PR DESCRIPTION
**Description of work.**

Changed flag of the `QComboBox` in `OptionsPropertyWidget` to editable and set the completion mode to `PopupCompletion` if the property name contains 'Workspace' in its name.

**To test:**

1. Open Mantid workbench
2. Run the following loop from the editor:
```
for index in range(1000):
    CreateSingleValuedWorkspace(index, 0,  OutputWorkspace="{}_{}".format(index%10, index)) 
```

3. Select an algorithm that uses combo box selection of workspaces, for example `Plus`
4. Run `Plus` with `9_999` selected as the `LHSWorkspace`, and `1_1` as the `RHSWorkspace`. Try out selecting from the popup as you type the name in.
5. Check if the `OutputWorkspace` has Y axis value equal to 1000.

Fixes #29273 

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
-->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
