### PR TITLE
Fix Bayes->Quasi Plotting bug

### DIFF
--- a/docs/source/release/v5.1.0/indirect_geometry.rst
+++ b/docs/source/release/v5.1.0/indirect_geometry.rst
@@ -51,5 +51,6 @@ Bug Fixes
   would yield a parsing error.
 - Fixed errors with the temperature correction in the ConvFit tab of the Indirect Data Analysis interface. These issues occurred when the function was evaluated at Q=0, where it is undefined.
 - Indirect Data Analysis F(Q) fit multiple workspaces can now load more than one spectra from each workspace.
+- Fixed a bug in the Indirect->Bayes->Quasi Interface, which caused the same parameter to be plotted twice.
 
 :ref:`Release 5.1.0 <v5.1.0>`

--- a/qt/scientific_interfaces/Indirect/Quasi.cpp
+++ b/qt/scientific_interfaces/Indirect/Quasi.cpp
@@ -567,7 +567,7 @@ void Quasi::plotClicked() {
               auto const workspaceIndices =
                   std::to_string(spectraIndices[0]) + "," +
                   std::to_string(spectraIndices[1]) + "," +
-                  std::to_string(spectraIndices[1]);
+                  std::to_string(spectraIndices[2]);
               m_plotter->plotSpectra(resultName, workspaceIndices);
             }
           } else


### PR DESCRIPTION
**Description of work.**
This PR fixes a bug with the Bayes->Quasi interface, which causes the same fit parameter to be plotted twice.


**Report to:** ISIS/Spencer

**To test:**
Go to Indirect->Bayes->Quasi
Load some data, e.g:
Sample: irs26176_graphite002_red.nxs
Resolution: irs26173_graphite002_res.nxs
Run the analysis
Bottom left of interface change plot result to amplitude and press plot
Each line should be unique (e.g f1.f1.Amp f2.f1.Amp and f2.f2.Amp)
<!-- Instructions for testing. -->

Fixes #29278 

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
-->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
