### PR TITLE
Exclude TOML files from System Test

### DIFF
--- a/Testing/SystemTests/tests/analysis/LoadLotsOfFiles.py
+++ b/Testing/SystemTests/tests/analysis/LoadLotsOfFiles.py
@@ -143,7 +143,8 @@ BANNED_REGEXP = [r'SANS2D\d+.log$',
                  r'.*\.hkl',
                  r'EVS.*\.raw',
                  r'.*_pulseid\.dat',
-                 r'.*\.phonon']
+                 r'.*\.phonon',
+                 r'.*\.toml']
 
 BANNED_DIRS = ["DocTest", "UnitTest", "reference"]
 


### PR DESCRIPTION
**Description of work.**

Excludes all TOML files, as these are done by a SANS user parser which
is bespoke, not a Mantid load algorithm.


**To test:**
Note: Looking at CI tests is not enough, as this test is excluded from PRs for taking too long
- Run the system tests with `-R LoadLotsOfFiles`


*There is no associated issue.*

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
