### PR TITLE
Workbench Segfault on exit when logger is debug

### DIFF
--- a/docs/source/release/v5.1.0/mantidworkbench.rst
+++ b/docs/source/release/v5.1.0/mantidworkbench.rst
@@ -167,5 +167,6 @@ Bugfixes
 - Fixed a bug with colorfill plot script generation for distribution workspaces.
 - Use Jemalloc for memory allocation on Linux so memory can be released to the system.
 - Fixed a bug where instrument view would not update on wheel zoom.
+- Fixed a bug which caused workbench to crash midway through closing normally when logging level was set to debug.
 
 :ref:`Release 5.1.0 <v5.1.0>`

--- a/qt/widgets/common/src/MessageDisplay.cpp
+++ b/qt/widgets/common/src/MessageDisplay.cpp
@@ -25,6 +25,7 @@
 #include <QScrollBar>
 #include <QSettings>
 #include <QSignalMapper>
+#include <QCoreApplication>
 
 #include <Poco/Logger.h>
 #include <Poco/Message.h>
@@ -507,9 +508,10 @@ QTextCharFormat MessageDisplay::format(const Message::Priority priority) const {
  * @param msg A Message object
  */
 bool MessageDisplay::shouldBeDisplayed(const Message &msg) {
-  if ((msg.scriptPath().isEmpty() && showFrameworkOutput()) ||
+  if (((msg.scriptPath().isEmpty() && showFrameworkOutput()) ||
       (!msg.scriptPath().isEmpty() && showAllScriptOutput()) ||
-      (showActiveScriptOutput() && (msg.scriptPath() == activeScript())))
+      (showActiveScriptOutput() && (msg.scriptPath() == activeScript()))) 
+      && !QCoreApplication::closingDown())
     return true;
   return false;
 }

--- a/qt/widgets/common/src/MessageDisplay.cpp
+++ b/qt/widgets/common/src/MessageDisplay.cpp
@@ -17,6 +17,7 @@
 
 #include <QAction>
 #include <QActionGroup>
+#include <QCoreApplication>
 #include <QHBoxLayout>
 #include <QInputDialog>
 #include <QMenu>
@@ -25,7 +26,6 @@
 #include <QScrollBar>
 #include <QSettings>
 #include <QSignalMapper>
-#include <QCoreApplication>
 
 #include <Poco/Logger.h>
 #include <Poco/Message.h>
@@ -509,9 +509,9 @@ QTextCharFormat MessageDisplay::format(const Message::Priority priority) const {
  */
 bool MessageDisplay::shouldBeDisplayed(const Message &msg) {
   if (((msg.scriptPath().isEmpty() && showFrameworkOutput()) ||
-      (!msg.scriptPath().isEmpty() && showAllScriptOutput()) ||
-      (showActiveScriptOutput() && (msg.scriptPath() == activeScript()))) 
-      && !QCoreApplication::closingDown())
+       (!msg.scriptPath().isEmpty() && showAllScriptOutput()) ||
+       (showActiveScriptOutput() && (msg.scriptPath() == activeScript()))) &&
+      !QCoreApplication::closingDown())
     return true;
   return false;
 }


### PR DESCRIPTION
**Description of work.**
Fixed an issue where whilst the logger is set to default logging level it would cause a segfault when closing workbench. Basically, don't attempt to display messages if the application is closing.

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

**To test:**
- Open workbench from a terminal
- Set logger level to Debug
- Close Workbench normally
- No seg fault should occur on close.

<!-- Instructions for testing. -->

Fixes #29336  <!-- and fix #xxxx or close #xxxx xor resolves #xxxx -->
<!-- alternative
*There is no associated issue.*
-->

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
-->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
