### PR TITLE
Muon Interface Pretty XML Output for Grouping File

### DIFF
--- a/scripts/Muon/GUI/Common/utilities/xml_utils.py
+++ b/scripts/Muon/GUI/Common/utilities/xml_utils.py
@@ -6,6 +6,7 @@
 # SPDX - License - Identifier: GPL - 3.0 +
 import os
 import xml.etree.ElementTree as ET
+import xml.dom.minidom as MD
 import Muon.GUI.Common.utilities.run_string_utils as run_string_utils
 
 from Muon.GUI.Common.muon_group import MuonGroup
@@ -71,10 +72,11 @@ def save_grouping_to_XML(groups, pairs, filename, save=True, description=''):
     # handle pairs
     _create_XML_subElement_for_pairs(root, pairs)
 
-    tree = ET.ElementTree(root)
     if save:
-        tree.write(filename)
-    return tree
+        prettyXML = MD.parseString(ET.tostring(root)).toprettyxml(indent="\t")
+        with open(filename, "w") as xmlfile:
+            xmlfile.write(prettyXML)
+    return ET.ElementTree(root)
 
 
 def load_grouping_from_XML(filename):


### PR DESCRIPTION
**Description of work.**

This fixes a cosmetic issue (which is a regression) with the output of grouping files in the muon interface. XML output files are formatted so they are easily readable.

**To test:**

Open Muon analysis
Go to the grouping tab
Click save grouping
Read the xml file using notepad ++
Should now be nicely formatted (Was previously all on a single line)

Fixes #29342

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
