### PR TITLE
Fixed bug that caused Muon pairs to crash when fitting

### DIFF
--- a/scripts/Muon/GUI/Common/fitting_tab_widget/fitting_tab_model.py
+++ b/scripts/Muon/GUI/Common/fitting_tab_widget/fitting_tab_model.py
@@ -677,11 +677,11 @@ class FittingTabModel(object):
         workspace_names = []
         for run in runs:
             for group_or_pair in groups_and_pairs:
-                period_string = run_list_to_string(self.context.group_pair_context[group_or_pair].periods)
                 if group_or_pair in self.context.group_pair_context.selected_pairs:
-                    workspace_names += [get_pair_asymmetry_name(self.context, group_or_pair, run, period_string,
+                    workspace_names += [get_pair_asymmetry_name(self.context, group_or_pair, run,
                                                                 not self.fitting_options["fit_to_raw"])]
                 else:
+                    period_string = run_list_to_string(self.context.group_pair_context[group_or_pair].periods)
                     workspace_names += [get_group_asymmetry_name(self.context, group_or_pair, run, period_string,
                                                                  not self.fitting_options["fit_to_raw"])]
 


### PR DESCRIPTION
**Description of work.**
The muon GUI was crashing because it could not find the periods for a pair. This is a quick fix, a proper fix will involve fixing the WS naming in Muon analysis see #https://github.com/mantidproject/mantid/issues/29116

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

**To test:**
Open muon analysis/Frequency domain analysis
Load HIFI 84447
Go to the fitting tab
Add a function
do a fit
no crash!
<!-- Instructions for testing. -->

Fixes #29319 . <!-- and fix #xxxx or close #xxxx xor resolves #xxxx -->
<!-- alternative
*There is no associated issue.*
-->

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
-->

---
This does not need to be in the release notes as it is a side effect of a recent addition.
#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
