### PR TITLE
Change generatePoint logic in CBP to ensure even distribution across disk

### DIFF
--- a/Framework/Algorithms/src/SampleCorrections/CircularBeamProfile.cpp
+++ b/Framework/Algorithms/src/SampleCorrections/CircularBeamProfile.cpp
@@ -44,12 +44,15 @@ CircularBeamProfile::CircularBeamProfile(const Geometry::ReferenceFrame &frame,
 IBeamProfile::Ray CircularBeamProfile::generatePoint(
     Kernel::PseudoRandomNumberGenerator &rng) const {
   V3D pt;
-  const double R = rng.nextValue() * m_radius;
-  const double theta = rng.nextValue() * 360.0;
-  pt.spherical(R, theta, m_beamIdx);
-  pt[0] += m_center[m_upIdx];
-  pt[1] += m_center[m_horIdx];
-  pt[2] += m_min[m_beamIdx];
+  const double rsq = m_radius * m_radius;
+  const double R = std::sqrt(rng.nextValue() * rsq);
+  const double theta = rng.nextValue() * M_PI * 2;
+  pt[m_upIdx] = R * cos(theta);
+  pt[m_horIdx] = R * sin(theta);
+  // Correct for centre point
+  pt[m_upIdx] += m_center[m_upIdx];
+  pt[m_horIdx] += m_center[m_horIdx];
+  pt[m_beamIdx] = m_center[m_beamIdx];
   return {pt, m_beamDir};
 }
 

--- a/Framework/Algorithms/test/CircularBeamProfileTest.h
+++ b/Framework/Algorithms/test/CircularBeamProfileTest.h
@@ -45,7 +45,8 @@ public:
         .Times(Exactly(2))
         .WillRepeatedly(Return(rand));
     auto ray = profile.generatePoint(rng);
-    TS_ASSERT_EQUALS(V3D(0.0, 0.0, -0.25), ray.startPos);
+    const double testPt3 = -1 * std::sqrt(0.125);
+    TS_ASSERT_EQUALS(V3D(0.0, 0.0, testPt3), ray.startPos);
     TS_ASSERT_EQUALS(V3D(1.0, 0, 0), ray.unitDir);
   }
 
@@ -55,7 +56,11 @@ public:
     using namespace ::testing;
 
     const double radius(0.5);
-    const V3D center(-3, 2, 1);
+    const V3D center(2, -3, 1);
+    const double testX = 2;
+    const double testY = -3;
+    const double testZ = 1 - std::sqrt(0.125);
+    constexpr const double DBL_EPS = std::numeric_limits<double>::epsilon();
     CircularBeamProfile profile(createTestFrame(), center, radius);
 
     MockRNG rng;
@@ -64,7 +69,9 @@ public:
         .Times(Exactly(2))
         .WillRepeatedly(Return(rand));
     auto ray = profile.generatePoint(rng);
-    TS_ASSERT_EQUALS(V3D(1.0, 2.0, -3.25), ray.startPos);
+    TS_ASSERT_DELTA(testX, ray.startPos.X(), DBL_EPS);
+    TS_ASSERT_DELTA(testY, ray.startPos.Y(), DBL_EPS);
+    TS_ASSERT_DELTA(testZ, ray.startPos.Z(), DBL_EPS);
     TS_ASSERT_EQUALS(V3D(1.0, 0, 0), ray.unitDir);
   }
 
@@ -76,8 +83,8 @@ public:
     const double radius(0.5);
     const V3D center;
     // values calculated using polar calculations from V3D class
-    const double testX = 0.25;
-    const double testY = 0;
+    const double testX = 0;
+    const double testY = sqrt(0.125);
     const double testZ = 0;
     constexpr const double DBL_EPS = std::numeric_limits<double>::epsilon();
     CircularBeamProfile profile(createTestFrame(), center, radius);

--- a/docs/source/algorithms/SetBeam-v1.rst
+++ b/docs/source/algorithms/SetBeam-v1.rst
@@ -11,25 +11,29 @@ Description
 -----------
 
 Set properties of the beam on a given workspace. Current support is limited to
-specifying the beam geometry and only supports a slit geometry with given
-width and height.
+specifying the beam geometry, which sets a Slit (rectangular) or Circular
+profile, with properties of either width and height, or radius, respectively.
 
 Geometry Flags
 --------------
 
 The following `Geometry` flags are recognised by the algorithm:
 
-- `Shape`: A string indicating the geometry type. Only supports `Slit`.
-- `Height`: Height of the slit in centimeters
-- `Width`: Width of the slit in centimeters
+- `Shape`: A string indicating the geometry type. Supports `Slit` and `Circle`.
+- `Height`: Height of the slit in centimeters. Required for the Slit setting.
+- `Width`: Width of the slit in centimeters. Required for the Slit setting.
+- `Radius`: Radius of the circle in centimeters. Required for the Circle setting.
 
 Usage
 -----
 
 .. testcode:: SetBeamExample
 
-   ws = CreateSampleWorkspace()
-   SetBeam(ws, Geometry={'Shape': 'Slit', 'Width': 1.0, 'Height': 0.75})
+   wsSlit = CreateSampleWorkspace()
+   SetBeam(wsSlit, Geometry={'Shape': 'Slit', 'Width': 1.0, 'Height': 0.75})
+
+   wsCircle = CreateSampleWorkspace()
+   SetBeam(wsCircle, Geometry={'Shape': 'Circle', 'Radius': 1.0})
 
 .. categories::
 


### PR DESCRIPTION
**Description of work.**
Previously, the `generatePoint` function logic would lead to points clustering toward the center of the disk. The logic has been changed as per https://mathworld.wolfram.com/DiskPointPicking.html to ensure the distribution is even.

Please note this is low risk for the release as it pertains to a feature that was only introduced in this sprint, and isn't used by default.

**To test:**
This is hard to test precisely, but please run the script from https://github.com/mantidproject/mantid/pull/29189 and make sure that produces something sane

*There is no associated issue.*

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
