### PR TITLE
update docs for building Mantid on Ubuntu 20.04 (Focal)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -244,7 +244,7 @@ add_subdirectory(scripts)
 # Docs requirements
 option(ENABLE_DOCS "Enable Building user and developer documentation" ON)
 if (ENABLE_DOCS)
-  find_package(Sphinx 1.2)
+  find_package(Sphinx)
   if(SPHINX_FOUND)
     # run python to see if the theme is installed
     execute_process(COMMAND ${Python_EXECUTABLE} -c

--- a/buildconfig/dev-packages/deb/mantid-developer/ns-control
+++ b/buildconfig/dev-packages/deb/mantid-developer/ns-control
@@ -63,7 +63,7 @@ Depends: git,
   python3-psutil,
   python3-requests,
   python3-toml,
-  python3-pycifrw,
+  python3-pycifrw(>=4.2.1),
   python3-yaml,
   texlive,
   texlive-latex-extra

--- a/buildconfig/dev-packages/deb/mantid-developer/ns-control
+++ b/buildconfig/dev-packages/deb/mantid-developer/ns-control
@@ -63,6 +63,7 @@ Depends: git,
   python3-psutil,
   python3-requests,
   python3-toml,
+  python3-pycifrw,
   python3-yaml,
   texlive,
   texlive-latex-extra

--- a/buildconfig/dev-packages/deb/mantid-developer/ns-control
+++ b/buildconfig/dev-packages/deb/mantid-developer/ns-control
@@ -3,7 +3,7 @@ Priority: optional
 Standards-Version: 3.9.2
 
 Package: mantid-developer
-Version: 2.1
+Version: 2.2
 Maintainer: Mantid Project <mantid-tech@mantidproject.org>
 Priority: optional
 Architecture: all

--- a/buildconfig/dev-packages/rpm/mantid-developer/mantid-developer.spec
+++ b/buildconfig/dev-packages/rpm/mantid-developer/mantid-developer.spec
@@ -56,7 +56,7 @@ Requires: python%{python3_pkgversion}-setuptools
 Requires: python%{python3_pkgversion}-sphinx
 Requires: python%{python3_pkgversion}-sphinx-bootstrap-theme
 Requires: python%{python3_pkgversion}-toml
-Requires: python%{python3_pkgversion}-PyYAML
+Requires: python%{python3_pkgversion}-PyCifRW
 Requires: poco-devel >= 1.4.6
 Requires: qscintilla-devel
 Requires: qscintilla-qt5-devel

--- a/buildconfig/dev-packages/rpm/mantid-developer/mantid-developer.spec
+++ b/buildconfig/dev-packages/rpm/mantid-developer/mantid-developer.spec
@@ -1,5 +1,5 @@
 Name:           mantid-developer
-Version:        2.1
+Version:        2.2
 Release:        1%{?dist}
 Summary:        Meta Package to install dependencies for Mantid Development
 

--- a/dev-docs/source/GettingStarted.rst
+++ b/dev-docs/source/GettingStarted.rst
@@ -92,15 +92,22 @@ if you wish to setup eclipse for use developing mantid, then instructions can be
 
 Ubuntu 20.04
 ~~~~~~~~~~~~
+- Mantid uses `qtpy` to talk to Python bindings of Qt.  It is recommended to have the _
+  environment var `QT_API=pyqt5` exported to the shell before building with CMake.
+- The header and lib shipped with Anaconda (if installed) could interfere with Mantid building _
+  process. It is highly recommended to remove Anaconda Python from your env prior to building _
+  using `conda deactivate`.
 - Mantid is not yet officially supported on Ubuntu 20.04 as Qt4 has been removed but Workbench can be built by installing:
 
 .. code-block:: sh
 
-   apt-get install -y git \
+   apt-get install -y \
+     git \
      g++ \
      clang-format-6.0 \
      cmake \
      dvipng \
+     doxygen \
      libtbb-dev \
      libgoogle-perftools-dev \
      libboost-all-dev \
@@ -108,6 +115,7 @@ Ubuntu 20.04
      libnexus-dev \
      libhdf5-dev \
      libhdf4-dev \
+     libjemalloc-dev \
      libgsl-dev \
      liboce-visualization-dev \
      libmuparser-dev \

--- a/dev-docs/source/GettingStarted.rst
+++ b/dev-docs/source/GettingStarted.rst
@@ -141,6 +141,7 @@ Ubuntu 20.04
      python3-scipy \
      python3-sphinx \
      python3-sphinx-bootstrap-theme \
+     python3-pycifrw \
      python3-dateutil \
      python3-matplotlib \
      python3-qtconsole \


### PR DESCRIPTION
**Description of work.**

Update documentation on how to compile Mantidworkbench on `Ubuntu_20.04 (focal)`.

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

**To test:**
Checkout the branch to a vanilla Ubuntu_20.04 env.  Follow the updated instruction to compile Mantid locally using

```bash
cd $MANTID_LOCATION
mkdir build && cd build
cmake .. -DENABLE_MANTIDPLOT=OFF -DCMAKE_INSTALL_PREFIX=$MANTID_INSTALL_DIR -DENABLE_DOCS=ON
make -j8
make dev-docs-html
```
Then use ctest to perform test in the build directory if desired

```bash
make AllTests -j8
ctest --output-on-failure
```

<!-- Instructions for testing. -->

<!-- and fix #xxxx or close #xxxx xor resolves #xxxx -->
<!-- alternative
*There is no associated issue.*
-->

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
-->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
