### PR TITLE
Fix an exception exporting a batch in the SANS GUI

### DIFF
--- a/scripts/SANS/sans/gui_logic/presenter/run_tab_presenter.py
+++ b/scripts/SANS/sans/gui_logic/presenter/run_tab_presenter.py
@@ -703,7 +703,7 @@ class RunTabPresenter(PresenterCommon):
             return
 
         with self.disable_buttons():
-            default_filename = self._table_model.batch_file
+            default_filename = self._model.batch_file
             filename = self.display_save_file_box("Save table as", default_filename, "*.csv")
             filename = self._get_filename_to_save(filename)
 


### PR DESCRIPTION
This PR fixes a regression in a recent change where the `batch_file` member had been moved to the `_model`, but it was still being accessed from the `_table_model` when exporting the batch.

Fixes #29353

**Description of work.**

**To test:**

- Open Interfaces->ISIS SANS
- Choose Load User File, Maskfile.txt
- Choose Load Batch File, choose batch_mode_reduction.csv
- Click the Export Table button.

*This does not require release notes* because **it fixes a regression since the last release**

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
