### PR TITLE
Fix Indirect Data Reduction OSIRIS crash

### DIFF
--- a/qt/scientific_interfaces/Indirect/ISISEnergyTransfer.cpp
+++ b/qt/scientific_interfaces/Indirect/ISISEnergyTransfer.cpp
@@ -369,8 +369,6 @@ bool ISISEnergyTransfer::validate() {
     int detectorMax = m_uiForm.spPlotTimeSpecMax->value();
 
     const QString rawFile = m_uiForm.dsRunFiles->getFirstFilename();
-    const auto pos = rawFile.lastIndexOf(".");
-    const auto extension = rawFile.right(rawFile.length() - pos);
     const QFileInfo rawFileInfo(rawFile);
     const std::string name = rawFileInfo.baseName().toStdString();
 

--- a/qt/scientific_interfaces/Indirect/ISISEnergyTransfer.cpp
+++ b/qt/scientific_interfaces/Indirect/ISISEnergyTransfer.cpp
@@ -375,14 +375,8 @@ bool ISISEnergyTransfer::validate() {
     const std::string name = rawFileInfo.baseName().toStdString();
 
     auto loadAlg = loadAlgorithm(rawFile.toStdString(), name);
-    if (extension.compare(".nxs") == 0) {
-      loadAlg->setProperty("SpectrumMin", static_cast<int64_t>(detectorMin));
-      loadAlg->setProperty("SpectrumMax", static_cast<int64_t>(detectorMax));
-    } else {
-      loadAlg->setProperty("SpectrumMin", detectorMin);
-      loadAlg->setProperty("SpectrumMax", detectorMax);
-    }
-
+    loadAlg->setPropertyValue("SpectrumMin", std::to_string(detectorMin));
+    loadAlg->setPropertyValue("SpectrumMax", std::to_string(detectorMax));
     loadAlg->execute();
 
     if (m_uiForm.ckBackgroundRemoval->isChecked()) {


### PR DESCRIPTION
**Description of work.**
This PR fixes a crash when reducing OSIRIS runs on Indirect Data Reduction.

**To test:**
1. Turn on the Data Archive
1. `Interfaces`->`Indirect`->`Data Reduction`->`Energy Transfer` tab
2. Select `OSIRIS` as instrument
3. Enter run numbers `104371-104375`, wait for them to load
4. Detector grouping is `Individual`
5. Click `Run`

The interface should successfully finish running without a crash.

Fixes #29346 

*This does not require release notes* because **the crash is not present in the previous mantid version.**