### PR TITLE
Fix a crash loading an old batch file in the reflectometry GUI

### DIFF
--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Common/Decoder.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Common/Decoder.cpp
@@ -155,8 +155,13 @@ void Decoder::decodePerAngleDefaultsRow(QTableWidget *tab, int rowIndex,
                                         int columnsNum,
                                         const QList<QVariant> &list) {
   MantidQt::API::SignalBlocker blocker(tab);
-  for (auto columnIndex = 0; columnIndex < columnsNum; ++columnIndex) {
-    auto tableWidgetItem = new QTableWidgetItem(list[columnIndex].toString());
+  // Loop all columns in the table
+  for (auto columnIndex = 0; columnIndex < tab->columnCount(); ++columnIndex) {
+    // Old files may not include all of the columns so add an empty cell if it
+    // doesn't exist in the file
+    auto const columnValue =
+        columnIndex < columnsNum ? list[columnIndex].toString() : QString();
+    auto tableWidgetItem = new QTableWidgetItem(columnValue);
     tab->setItem(rowIndex, columnIndex, tableWidgetItem);
   }
 }

--- a/qt/scientific_interfaces/test/ISISReflectometry/Common/DecoderTest.h
+++ b/qt/scientific_interfaces/test/ISISReflectometry/Common/DecoderTest.h
@@ -310,7 +310,7 @@ const static QString BATCH_JSON_STRING{
     "    }"
     "}"};
 
-const static QString EMPTY_BATCH_JSON_STRING{
+const static QString EMPTY_EVENT_JSON_STRING{
     "{"
     "    \"eventView\": {"
     "        \"customButton\": false,"
@@ -323,7 +323,9 @@ const static QString EMPTY_BATCH_JSON_STRING{
     "        \"uniformEdit\": 1,"
     "        \"uniformEvenButton\": false,"
     "        \"uniformEvenEdit\": 1"
-    "    },"
+    "    },"};
+
+const static QString EMPTY_EXPERIMENT_JSON_STRING{
     "    \"experimentView\": {"
     "        \"analysisModeComboBox\": 0,"
     "        \"backgroundMethodComboBox\": 0,"
@@ -360,7 +362,9 @@ const static QString EMPTY_BATCH_JSON_STRING{
     "        \"summationTypeComboBox\": 0,"
     "        \"transScaleRHSCheckBox\": true,"
     "        \"transStitchParamsEdit\": \"\""
-    "    },"
+    "    },"};
+
+const static QString EMPTY_INSTRUMENT_JSON_STRING{
     "    \"instrumentView\": {"
     "        \"I0MonitorIndex\": 2,"
     "        \"correctDetectorsCheckBox\": true,"
@@ -372,7 +376,9 @@ const static QString EMPTY_BATCH_JSON_STRING{
     "        \"monBgMinEdit\": 17,"
     "        \"monIntMaxEdit\": 10,"
     "        \"monIntMinEdit\": 4"
-    "    },"
+    "    },"};
+
+const static QString EMPTY_RUNS_JSON_STRING{
     "    \"runsView\": {"
     "        \"comboSearchInstrument\": 0,"
     "        \"runsTable\": {"
@@ -392,7 +398,9 @@ const static QString EMPTY_BATCH_JSON_STRING{
     "        },"
     "        \"textCycle\": \"\","
     "        \"textSearch\": \"\""
-    "    },"
+    "    },"};
+
+const static QString EMPTY_SAVE_JSON_STRING{
     "    \"saveView\": {"
     "        \"commaRadioButton\": true,"
     "        \"fileFormatComboBox\": 0,"
@@ -407,6 +415,57 @@ const static QString EMPTY_BATCH_JSON_STRING{
     "        \"headerCheckBox\": false"
     "    }"
     "}"};
+
+const static QString EMPTY_BATCH_JSON_STRING{
+    EMPTY_EVENT_JSON_STRING + EMPTY_EXPERIMENT_JSON_STRING +
+    EMPTY_INSTRUMENT_JSON_STRING + EMPTY_RUNS_JSON_STRING +
+    EMPTY_SAVE_JSON_STRING};
+
+// This batch file has an incorrect number of columns (9 instead of 10) for the
+// experiment tab's table - this needs to be supported for backwards
+// compatibility
+const static QString EXPERIMENT_JSON_STRING_9_COLUMNS{
+    "    \"experimentView\": {"
+    "        \"analysisModeComboBox\": 0,"
+    "        \"backgroundMethodComboBox\": 0,"
+    "        \"costFunctionComboBox\": 0,"
+    "        \"debugCheckbox\": false,"
+    "        \"endOverlapEdit\": 12,"
+    "        \"floodCorComboBox\": 0,"
+    "        \"floodWorkspaceWsSelector\": 0,"
+    "        \"includePartialBinsCheckBox\": false,"
+    "        \"perAngleDefaults\": {"
+    "            \"columnsNum\": 9,"
+    "            \"rows\": ["
+    "                ["
+    "                    \"\","
+    "                    \"\","
+    "                    \"\","
+    "                    \"\","
+    "                    \"\","
+    "                    \"\","
+    "                    \"\","
+    "                    \"\","
+    "                    \"\""
+    "                ]"
+    "            ],"
+    "            \"rowsNum\": 1"
+    "        },"
+    "        \"polCorrCheckBox\": false,"
+    "        \"polynomialDegreeSpinBox\": 3,"
+    "        \"reductionTypeComboBox\": 0,"
+    "        \"startOverlapEdit\": 10,"
+    "        \"stitchEdit\": \"\","
+    "        \"subtractBackgroundCheckBox\": false,"
+    "        \"summationTypeComboBox\": 0,"
+    "        \"transScaleRHSCheckBox\": true,"
+    "        \"transStitchParamsEdit\": \"\""
+    "    },"};
+
+const static QString BATCH_JSON_STRING_9_COLUMNS{
+    EMPTY_EVENT_JSON_STRING + EXPERIMENT_JSON_STRING_9_COLUMNS +
+    EMPTY_INSTRUMENT_JSON_STRING + EMPTY_RUNS_JSON_STRING +
+    EMPTY_SAVE_JSON_STRING};
 
 const static QString MAINWINDOW_JSON_STRING{
     QString("{\"batches\": [") + BATCH_JSON_STRING + QString(", ") +
@@ -474,6 +533,21 @@ public:
     decoder.decodeBatch(&mwv, 0, map);
 
     tester.testBatch(gui, &mwv, map);
+  }
+
+  void test_decodeOldBatchFile() {
+    CoderCommonTester tester;
+    QtMainWindowView mwv;
+    mwv.initLayout();
+    auto gui = dynamic_cast<QtBatchView *>(mwv.batches()[0]);
+    Decoder decoder;
+    // Decode from the old 9-column format
+    auto oldMap =
+        MantidQt::API::loadJSONFromString(BATCH_JSON_STRING_9_COLUMNS);
+    decoder.decodeBatch(&mwv, 0, oldMap);
+    // Check that the result matches the new 10-column format
+    auto newMap = MantidQt::API::loadJSONFromString(EMPTY_BATCH_JSON_STRING);
+    tester.testBatch(gui, &mwv, newMap);
   }
 };
 } // namespace ISISReflectometry


### PR DESCRIPTION
Batch files from v5.0.0 did not have the background column in the Experiment tab table. Loading one of these files creates a table with the new column count of 10, but only 9 of the columns have a cell created for them. This causes potential crashing e.g. when re-saving the batch, because the Encoder expects 10 valid cells. This commit fixes the problem by adding empty cells if they are not in the file.

Fixes #29367

**To test:**

- Go to Interfaces, Reflectometry, ISIS Reflectometry
- Go to Batch, Load and load the INTER_NR_test.json file
- Go to Batch, Save and choose a new file name to save the GUI contents to
- Previously it crashed on saving (either manually as described here or when project recovery ran). This should be fixed.

Fixes #29367

*This does not require release notes* because **it fixes a regression since the last release**

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
