### PR TITLE
Remove comment from .desktop file to fix apps menu item in Ubuntu

### DIFF
--- a/installers/LinuxInstaller/launcher-template.desktop.in
+++ b/installers/LinuxInstaller/launcher-template.desktop.in
@@ -1,9 +1,3 @@
-// Mantid Repository : https://github.com/mantidproject/mantid
-//
-// Copyright &copy; 2020 ISIS Rutherford Appleton Laboratory UKRI,
-//   NScD Oak Ridge National Laboratory, European Spallation Source,
-//   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
-// SPDX - License - Identifier: GPL - 3.0 +
 [Desktop Entry]
 Name=@DESKTOP_NAME@
 Comment=Neutron Data Reduction Framework

--- a/tools/Copyright/copyrightupdate.py
+++ b/tools/Copyright/copyrightupdate.py
@@ -43,7 +43,7 @@ directories_to_ignore = ["external", "CMake", "GSoapGenerated", "buildconfig"]
 # Accepted file extensions
 accepted_file_extensions = [".py", ".cpp", ".h", ".tcc", ".in", ".hh"]
 # excluded_file_tokens
-excluded_files = [".cmake.in", ".rb.in", ".py.in", "systemtest.in", "systemtest.bat.in"]
+excluded_files = [".cmake.in", ".desktop.in", ".rb.in", ".py.in", "systemtest.in", "systemtest.bat.in"]
 # python file exxtensions
 python_file_extensions = [".py"]
 # extensions to ignore, don't even report these


### PR DESCRIPTION
**Description of work.**

This change solves a problem where the Mantid Workbench application (icon + name) had gone missing from the Ubuntu applications menu. It solves it by removing a C++ comment from the top of a .desktop file

**To test:**

1. Set ENABLE_CPACK=true in cmake
2. Run cmake configure\generate
3. build mantid source
4. run "cpack -G DEB" from the mantid build directory to build a new .deb package (assuming on Ubuntu)
5. install the .deb package
6. visit the applications menu and observe the "Mantid Workbench unstable" application is present (screenshot on linked issue). Or may be "...nightly" depending on the CPACK_PACKAGE_SUFFIX value you have set up in cmake

Fixes #29364 

*This does not require release notes* because **it fixes a bug introduced in v5.1**

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
