### PR TITLE
Fix issue with numpy.where tuple return

### DIFF
--- a/Framework/PythonInterface/mantid/plots/datafunctions.py
+++ b/Framework/PythonInterface/mantid/plots/datafunctions.py
@@ -382,7 +382,7 @@ def get_bin_indices(workspace):
     if is_range:
         return range(range_start + 1, range_end)
     else:
-        indices = np.where(np.isin(range(total_range), monitors_indices, invert=True))
+        indices = np.where(np.isin(range(total_range), monitors_indices, invert=True))[0]
         return indices
 
 

--- a/Framework/PythonInterface/mantid/plots/datafunctions.py
+++ b/Framework/PythonInterface/mantid/plots/datafunctions.py
@@ -382,7 +382,9 @@ def get_bin_indices(workspace):
     if is_range:
         return range(range_start + 1, range_end)
     else:
-        indices = np.where(np.isin(range(total_range), monitors_indices, invert=True))[0]
+        indices = np.where(np.isin(range(total_range), monitors_indices, invert=True))
+        # this check is necessary as numpy may return a tuple or a plain array based on platform.
+        indices = indices[0] if isinstance(indices, tuple) else indices
         return indices
 
 

--- a/Framework/PythonInterface/test/python/mantid/plots/datafunctionsTest.py
+++ b/Framework/PythonInterface/test/python/mantid/plots/datafunctionsTest.py
@@ -21,7 +21,7 @@ from mantid.kernel import config
 from mantid.plots.utility import MantidAxType
 from mantid.simpleapi import (AddSampleLog, AddTimeSeriesLog, ConjoinWorkspaces,
                               CreateMDHistoWorkspace, CreateSampleWorkspace,
-                              CreateSingleValuedWorkspace, CreateWorkspace, DeleteWorkspace, Load)
+                              CreateSingleValuedWorkspace, CreateWorkspace, DeleteWorkspace, LoadRaw)
 
 
 def add_workspace_with_data(func):
@@ -841,7 +841,7 @@ class DataFunctionsTest(unittest.TestCase):
         self.assertTrue(isinstance(bin_indices, range))
 
     def test_get_bin_indices_returns_a_numpy_ndarray_with_monitors(self):
-        ws = Load("GEM40979")
+        ws = LoadRaw("GEM40979", SpectrumMin=1, SpectrumMax=102)
         bin_indices = funcs.get_bin_indices(ws)
         self.assertTrue(isinstance(bin_indices, np.ndarray))
 

--- a/Framework/PythonInterface/test/python/mantid/plots/datafunctionsTest.py
+++ b/Framework/PythonInterface/test/python/mantid/plots/datafunctionsTest.py
@@ -9,6 +9,7 @@ import datetime
 import unittest
 
 import matplotlib
+
 matplotlib.use('AGG')  # noqa
 from matplotlib.pyplot import figure
 import numpy as np
@@ -20,7 +21,7 @@ from mantid.kernel import config
 from mantid.plots.utility import MantidAxType
 from mantid.simpleapi import (AddSampleLog, AddTimeSeriesLog, ConjoinWorkspaces,
                               CreateMDHistoWorkspace, CreateSampleWorkspace,
-                              CreateSingleValuedWorkspace, CreateWorkspace, DeleteWorkspace)
+                              CreateSingleValuedWorkspace, CreateWorkspace, DeleteWorkspace, Load)
 
 
 def add_workspace_with_data(func):
@@ -73,7 +74,7 @@ def add_md_workspace_with_data(dimensions=2):
 
 
 class DataFunctionsTest(unittest.TestCase):
-    
+
     @classmethod
     def setUpClass(cls):
         cls.g1da = config['graph1d.autodistribution']
@@ -454,12 +455,12 @@ class DataFunctionsTest(unittest.TestCase):
 
     def test_get_matrix_2d_data_ragged_with_extent(self):
         x, y, z = funcs.get_matrix_2d_ragged(self.ws2d_point_rag, False, histogram2D=True,
-                                             extent=[2, 4 , 1, 2], xbins=8, ybins=5)
+                                             extent=[2, 4, 1, 2], xbins=8, ybins=5)
         np.testing.assert_allclose(x, np.array([2, 2.25, 2.5, 2.75, 3, 3.25, 3.5, 3.75, 4]))
         np.testing.assert_allclose(y, np.array([1, 1.25, 1.5, 1.75, 2.0]))
 
         x, y, z = funcs.get_matrix_2d_ragged(self.ws2d_histo_rag, False, histogram2D=True,
-                                             extent=[2, 6 , 5, 9], xbins=8, ybins=5)
+                                             extent=[2, 6, 5, 9], xbins=8, ybins=5)
         np.testing.assert_allclose(x, np.array([2, 2.5, 3, 3.5, 4, 4.5, 5, 5.5, 6]))
         np.testing.assert_allclose(y, np.array([5, 6, 7, 8, 9]))
 
@@ -833,6 +834,16 @@ class DataFunctionsTest(unittest.TestCase):
         [caps.set_visible(False) for caps in container[1] if container[1]]
         [bars.set_visible(False) for bars in container[2]]
         self.assertTrue(mantid.plots.datafunctions.errorbars_hidden(container))
+
+    def test_get_bin_indices_returns_a_range_with_no_monitors(self):
+        ws = self.ws2d_histo
+        bin_indices = funcs.get_bin_indices(ws)
+        self.assertTrue(isinstance(bin_indices, range))
+
+    def test_get_bin_indices_returns_a_numpy_ndarray_with_monitors(self):
+        ws = Load("GEM40979")
+        bin_indices = funcs.get_bin_indices(ws)
+        self.assertTrue(isinstance(bin_indices, np.ndarray))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
**Description of work.**

The `get_bin_indices` function in in `datafunctions.py`  uses `numpy.where` to determine the correct bin indices. However, not accounting for the fact that numpy.where returns a tuple.

**To test:**

Steps to reproduce the behavior
Load GEM40979
Show Data
Select one or more columns
Right click, plot bin (you should successfully plot the bins instead of seeing a type error in workbench)

Fixes #29355. <!-- and fix #xxxx or close #xxxx xor resolves #xxxx -->


*This does not require release notes* 

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
