### PR TITLE
Sliceviewer fix lingering statusbar text

### DIFF
--- a/qt/python/mantidqt/widgets/sliceviewer/view.py
+++ b/qt/python/mantidqt/widgets/sliceviewer/view.py
@@ -225,7 +225,7 @@ class SliceViewerDataView(QWidget):
         plotter.delete_line_plot_lines()
         self._line_plots.disconnect()
         self._line_plots = toolcls(plotter, exporter)
-        self.status_bar.showMessage(self._line_plots.status_message())
+        self.status_bar_label.setText(self._line_plots.status_message())
         self.canvas.setFocus()
         self.canvas.draw_idle()
 
@@ -236,7 +236,7 @@ class SliceViewerDataView(QWidget):
             return
 
         self._line_plots.plotter.close()
-        self.status_bar.clearMessage()
+        self.status_bar_label.clear()
         self._line_plots = None
         self.line_plots_active = False
 


### PR DESCRIPTION
**Description of work.**

Fixes a lingering statusbar message on the sliceviewer when lineplots are disabled. 

**To test:**
1. Open sliceviewer
2. Activate lineplots, verify the message _Keys: arrow keys control..._ appears.
3. Deactivate lineplots, verify statusbar is empty.
4. Activate region selection, verify the message _Press key to send..._ appears
5. Deactivate region selection, verify the message _Keys: arrow keys control..._ appears.
6. Deactivate lineplots, verify statusbar is empty.

Fixes #29347 

*This does not require release notes* because **It is a regression from the previous version**

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
