### PR TITLE
Ensure unit tests pass when only workbench and qt5 is built

### DIFF
--- a/Framework/PythonInterface/test/python/mantid/plots/CMakeLists.txt
+++ b/Framework/PythonInterface/test/python/mantid/plots/CMakeLists.txt
@@ -11,4 +11,6 @@ set(TEST_PY_FILES
 check_tests_valid(${CMAKE_CURRENT_SOURCE_DIR} ${TEST_PY_FILES})
 
 # Prefix for test=PythonInterfacePlots
+set(PYUNITTEST_QT_API pyqt5) # force to use qt5
 pyunittest_add_test(${CMAKE_CURRENT_SOURCE_DIR} python.plots ${TEST_PY_FILES})
+unset(PYUNITTEST_QT_API)

--- a/qt/applications/workbench/workbench/widgets/settings/test/test_settings_view.py
+++ b/qt/applications/workbench/workbench/widgets/settings/test/test_settings_view.py
@@ -54,6 +54,6 @@ class SettingsViewTest(unittest.TestCase, QtWidgetFinder):
 
             widget.view.close()
 
-        QApplication.processEvents()
+        QApplication.sendPostedEvents()
 
         self.assert_no_toplevel_widgets()

--- a/qt/python/mantidqt/utils/qt/test/test_qappthreadcall.py
+++ b/qt/python/mantidqt/utils/qt/test/test_qappthreadcall.py
@@ -37,7 +37,7 @@ class QAppThreadCallTest(unittest.TestCase):
         thread = AsyncTask(self.task, error_cb=collect_error)
         thread.start()
         while thread.is_alive():
-            QApplication.processEvents()
+            QApplication.sendPostedEvents()
         thread.join(0.5)
         self.assertTrue(isinstance(self.exc.exc_value, CustomException))
         self.assertEqual(TaskExitCode.ERROR, thread.exit_code)

--- a/qt/python/mantidqt/utils/test/test_writetosignal.py
+++ b/qt/python/mantidqt/utils/test/test_writetosignal.py
@@ -47,7 +47,7 @@ class WriteToSignalTest(unittest.TestCase):
             writer.sig_write_received.connect(recv.capture_text)
             txt = "I expect to see this"
             writer.write(txt)
-            QCoreApplication.processEvents()
+            QCoreApplication.sendPostedEvents()
             self.assertEqual(txt, recv.captured_txt)
             mock_stdout.fileno.assert_called_once_with()
 

--- a/qt/python/mantidqt/widgets/codeeditor/tab_widget/test/test_codeeditor_tab_view.py
+++ b/qt/python/mantidqt/widgets/codeeditor/tab_widget/test/test_codeeditor_tab_view.py
@@ -47,12 +47,12 @@ class CodeEditorTabWidgetTest(unittest.TestCase, QtWidgetFinder, QtAssertionsHel
 
         view.close()
 
-        QApplication.processEvents()
+        QApplication.sendPostedEvents()
         self.assert_widget_not_present(CodeEditorTabWidget.__name__)
 
         # closing our local mock should leave the QApplication without any widgets
         mock_mfp.close()
-        QApplication.processEvents()
+        QApplication.sendPostedEvents()
         self.assert_no_toplevel_widgets()
 
     def test_widget_connections_exist(self):
@@ -71,12 +71,12 @@ class CodeEditorTabWidgetTest(unittest.TestCase, QtWidgetFinder, QtAssertionsHel
 
         view.close()
 
-        QApplication.processEvents()
+        QApplication.sendPostedEvents()
         self.assert_widget_not_present(CodeEditorTabWidget.__name__)
 
         # closing our local mock should leave the QApplication without any widgets
         mock_mfp.close()
-        QApplication.processEvents()
+        QApplication.sendPostedEvents()
         self.assert_no_toplevel_widgets()
 
 

--- a/qt/python/mantidqt/widgets/codeeditor/test/test_execution.py
+++ b/qt/python/mantidqt/widgets/codeeditor/test/test_execution.py
@@ -220,8 +220,7 @@ foo()
         executor.sig_exec_error.connect(recv.on_error)
         task = executor.execute_async(code, line_no, filename)
         task.join()
-        QCoreApplication.processEvents()
-        QCoreApplication.processEvents()
+        QCoreApplication.sendPostedEvents()
 
         return executor, recv
 

--- a/qt/python/mantidqt/widgets/codeeditor/test/test_execution.py
+++ b/qt/python/mantidqt/widgets/codeeditor/test/test_execution.py
@@ -221,6 +221,7 @@ foo()
         task = executor.execute_async(code, line_no, filename)
         task.join()
         QCoreApplication.processEvents()
+        QCoreApplication.processEvents()
 
         return executor, recv
 

--- a/qt/python/mantidqt/widgets/codeeditor/test/test_multifileinterpreter_view.py
+++ b/qt/python/mantidqt/widgets/codeeditor/test/test_multifileinterpreter_view.py
@@ -28,22 +28,22 @@ class MultiPythonFileInterpreterDeletionTest(unittest.TestCase, QtWidgetFinder):
 
         widget.close_tab(0)
 
-        QApplication.processEvents()
+        QApplication.sendPostedEvents()
         self.assert_number_of_widgets_matching(".interpreter.PythonFileInterpreter", 2)
         widget.close_tab(0)
 
-        QApplication.processEvents()
+        QApplication.sendPostedEvents()
         self.assert_number_of_widgets_matching(".interpreter.PythonFileInterpreter", 1)
 
         widget.close_all()
 
-        QApplication.processEvents()
+        QApplication.sendPostedEvents()
         # there should be zero interpreters
         self.assert_number_of_widgets_matching(".interpreter.PythonFileInterpreter", 0)
 
         # close the whole widget, this should delete everything from the QApplication
         widget.close()
-        QApplication.processEvents()
+        QApplication.sendPostedEvents()
         self.assert_number_of_widgets_matching(".interpreter.PythonFileInterpreter", 0)
         self.assert_no_toplevel_widgets()
 
@@ -57,14 +57,14 @@ class MultiPythonFileInterpreterDeletionTest(unittest.TestCase, QtWidgetFinder):
 
         widget.close_tab(1)
 
-        QApplication.processEvents()
+        QApplication.sendPostedEvents()
         # there will always be 1, because we never allow an empty editor widget
         self.assert_number_of_widgets_matching(".interpreter.PythonFileInterpreter", 1)
         self.assert_number_of_widgets_matching("Embedded", 0)
 
         # close the whole widget, this should delete everything from the QApplication
         widget.close()
-        QApplication.processEvents()
+        QApplication.sendPostedEvents()
         self.assert_number_of_widgets_matching(".interpreter.PythonFileInterpreter", 0)
         self.assert_no_toplevel_widgets()
 
@@ -77,14 +77,14 @@ class MultiPythonFileInterpreterDeletionTest(unittest.TestCase, QtWidgetFinder):
 
         widget.close_tab(1)
 
-        QApplication.processEvents()
+        QApplication.sendPostedEvents()
         # there will always be 1, because we never allow an empty editor widget
         self.assert_number_of_widgets_matching(".interpreter.PythonFileInterpreter", 1)
         self.assert_number_of_widgets_matching("Embedded", 0)
 
         # close the whole widget, this should delete everything from the QApplication
         widget.close()
-        QApplication.processEvents()
+        QApplication.sendPostedEvents()
         self.assert_number_of_widgets_matching(".interpreter.PythonFileInterpreter", 0)
         self.assert_no_toplevel_widgets()
 

--- a/qt/python/mantidqt/widgets/instrumentview/test/test_instrumentview_view.py
+++ b/qt/python/mantidqt/widgets/instrumentview/test/test_instrumentview_view.py
@@ -26,7 +26,7 @@ class InstrumentViewTest(unittest.TestCase, QtWidgetFinder):
 
         p.close(ws.name())
 
-        QApplication.processEvents()
+        QApplication.sendPostedEvents()
         self.assertEqual(None, p.ads_observer)
         self.assert_widget_not_present("instr")
         self.assert_no_toplevel_widgets()
@@ -40,7 +40,7 @@ class InstrumentViewTest(unittest.TestCase, QtWidgetFinder):
 
         p.force_close()
 
-        QApplication.processEvents()
+        QApplication.sendPostedEvents()
         self.assertEqual(None, p.ads_observer)
         self.assert_widget_not_present("instr")
         self.assert_no_toplevel_widgets()

--- a/qt/python/mantidqt/widgets/samplelogs/test/test_samplelogs_view.py
+++ b/qt/python/mantidqt/widgets/samplelogs/test/test_samplelogs_view.py
@@ -24,6 +24,6 @@ class SampleLogsViewTest(unittest.TestCase, QtWidgetFinder):
         self.assert_widget_created()
         pres.view.close()
 
-        QApplication.processEvents()
+        QApplication.sendPostedEvents()
 
         self.assert_no_toplevel_widgets()

--- a/qt/python/mantidqt/widgets/sliceviewer/test/test_sliceviewer_view.py
+++ b/qt/python/mantidqt/widgets/sliceviewer/test/test_sliceviewer_view.py
@@ -45,8 +45,8 @@ class SliceViewerViewTest(unittest.TestCase, QtWidgetFinder):
         self.assert_widget_created()
         pres.view.close()
 
-        QApplication.processEvents()
-        QApplication.processEvents()
+        QApplication.sendPostedEvents()
+        QApplication.sendPostedEvents()
 
         self.assert_no_toplevel_widgets()
 
@@ -56,10 +56,10 @@ class SliceViewerViewTest(unittest.TestCase, QtWidgetFinder):
             pres,
             (ToolItemText.LINEPLOTS, ToolItemText.REGIONSELECTION, ToolItemText.NONORTHOGONAL_AXES))
         line_plots_action.trigger()
-        QApplication.processEvents()
+        QApplication.sendPostedEvents()
 
         non_ortho_action.trigger()
-        QApplication.processEvents()
+        QApplication.sendPostedEvents()
 
         self.assertTrue(non_ortho_action.isChecked())
         self.assertFalse(line_plots_action.isChecked())
@@ -75,10 +75,10 @@ class SliceViewerViewTest(unittest.TestCase, QtWidgetFinder):
             pres, (ToolItemText.LINEPLOTS, ToolItemText.REGIONSELECTION))
         line_plots_action.trigger()
         region_sel_action.trigger()
-        QApplication.processEvents()
+        QApplication.sendPostedEvents()
 
         line_plots_action.trigger()
-        QApplication.processEvents()
+        QApplication.sendPostedEvents()
 
         self.assertFalse(line_plots_action.isChecked())
         self.assertFalse(region_sel_action.isChecked())

--- a/qt/python/mantidqt/widgets/workspacedisplay/matrix/test/test_matrixworkspacedisplay_view.py
+++ b/qt/python/mantidqt/widgets/workspacedisplay/matrix/test/test_matrixworkspacedisplay_view.py
@@ -25,7 +25,7 @@ class MatrixWorkspaceDisplayViewTest(unittest.TestCase, QtWidgetFinder):
 
         self.assert_widget_created()
 
-        QApplication.processEvents()
+        QApplication.sendPostedEvents()
 
         self.assertEqual(None, p.ads_observer)
         self.assert_widget_not_present("work")
@@ -41,7 +41,7 @@ class MatrixWorkspaceDisplayViewTest(unittest.TestCase, QtWidgetFinder):
 
         self.assert_widget_created()
 
-        QApplication.processEvents()
+        QApplication.sendPostedEvents()
 
         self.assertEqual(None, p.ads_observer)
         self.assert_widget_not_present("work")

--- a/qt/python/mantidqt/widgets/workspacedisplay/table/test/test_tableworkspacedisplay_view.py
+++ b/qt/python/mantidqt/widgets/workspacedisplay/table/test/test_tableworkspacedisplay_view.py
@@ -25,7 +25,7 @@ class TableWorkspaceDisplayViewQtTest(unittest.TestCase, QtWidgetFinder):
         self.assert_widget_created()
         p.close(ws.name())
 
-        QApplication.processEvents()
+        QApplication.sendPostedEvents()
 
         self.assertEqual(None, p.ads_observer)
         self.assert_widget_not_present("work")
@@ -38,7 +38,7 @@ class TableWorkspaceDisplayViewQtTest(unittest.TestCase, QtWidgetFinder):
         self.assert_widget_created()
         p.force_close()
 
-        QApplication.processEvents()
+        QApplication.sendPostedEvents()
 
         self.assertEqual(None, p.ads_observer)
         self.assert_widget_not_present("work")

--- a/qt/widgets/common/CMakeLists.txt
+++ b/qt/widgets/common/CMakeLists.txt
@@ -932,51 +932,6 @@ mtd_add_qt_library(
   LINUX_INSTALL_RPATH "\$ORIGIN/../${WORKBENCH_LIB_DIR}"
 )
 
-# Testing
-set(TEST_FILES
-    test/AlgorithmHintStrategyTest.h
-    test/BatchAlgorithmRunnerTest.h
-    test/FileDialogHandlerTest.h
-    test/FindFilesThreadPoolManagerTest.h
-    test/FindFilesWorkerTest.h
-    test/FitPropertyBrowserTest.h
-    test/FunctionModelTest.h
-    test/FunctionMultiDomainPresenterTest.h
-    test/FunctionBrowserUtilsTest.h
-    test/LogValueFinderTest.h
-    test/InterfaceManagerTest.h
-    test/NonOrthogonalTest.h
-    test/ParseKeyValueStringTest.h
-    test/PlotAxisTest.h
-    test/ProgressableViewTest.h
-    test/ProjectSaveModelTest.h
-    test/ProjectSavePresenterTest.h
-    test/RepoModelTest.h
-    test/SelectionNotificationServiceTest.h
-    test/SignalBlockerTest.h
-    test/TrackedActionTest.h
-    test/QtJSONUtilsTest.h
-    test/Batch/BuildSubtreeItemsTest.h
-    test/Batch/ExtractSubtreesTest.h
-    test/Batch/FindSubtreeRootsTest.h
-    test/Batch/QtAdaptedModelTest.h
-    test/Batch/RowLocationTest.h
-    test/DataProcessorUI/CommandsTest.h
-    test/DataProcessorUI/GenerateNotebookTest.h
-    test/DataProcessorUI/GenericDataProcessorPresenterTest.h
-    test/DataProcessorUI/OneLevelTreeManagerTest.h
-    test/DataProcessorUI/PostprocessingAlgorithmTest.h
-    test/DataProcessorUI/PreprocessingAlgorithmTest.h
-    test/DataProcessorUI/PreprocessMapTest.h
-    test/DataProcessorUI/ProcessingAlgorithmBaseTest.h
-    test/DataProcessorUI/ProcessingAlgorithmTest.h
-    test/DataProcessorUI/QOneLevelTreeModelTest.h
-    test/DataProcessorUI/QTwoLevelTreeModelTest.h
-    test/DataProcessorUI/TwoLevelTreeManagerTest.h
-    test/DataProcessorUI/WhiteListTest.h
-    test/WorkspacePresenter/ADSAdapterTest.h
-    test/WorkspacePresenter/WorkspacePresenterTest.h)
-
 set(
   TEST_FILES
   test/AlgorithmHintStrategyTest.h

--- a/qt/widgets/common/CMakeLists.txt
+++ b/qt/widgets/common/CMakeLists.txt
@@ -16,8 +16,6 @@ set(
   src/FileDialogHandler.cpp
   src/FileFinderWidget.cpp
   src/FilePropertyWidget.cpp
-  src/FindFilesThreadPoolManager.cpp
-  src/FindFilesWorker.cpp
   src/FindReplaceDialog.cpp
   src/FitOptionsBrowser.cpp
   src/FitPropertyBrowser.cpp
@@ -153,9 +151,6 @@ set(
   inc/MantidQtWidgets/Common/DataSelector.h
   inc/MantidQtWidgets/Common/EditLocalParameterDialog.h
   inc/MantidQtWidgets/Common/FilePropertyWidget.h
-  inc/MantidQtWidgets/Common/FindFilesThreadPoolManager.h
-  inc/MantidQtWidgets/Common/FindFilesThreadPoolManagerMockObjects.h
-  inc/MantidQtWidgets/Common/FindFilesWorker.h
   inc/MantidQtWidgets/Common/FindReplaceDialog.h
   inc/MantidQtWidgets/Common/FitOptionsBrowser.h
   inc/MantidQtWidgets/Common/FitPropertyBrowser.h
@@ -1064,8 +1059,6 @@ set(
   QT5_TEST_FILES
   test/BatchAlgorithmRunnerTest.h
   test/FileDialogHandlerTest.h
-  test/FindFilesThreadPoolManagerTest.h
-  test/FindFilesWorkerTest.h
   test/FitPropertyBrowserTest.h
   test/ImageInfoModelMatrixWSTest.h
   test/ImageInfoModelMDTest.h

--- a/qt/widgets/common/CMakeLists.txt
+++ b/qt/widgets/common/CMakeLists.txt
@@ -16,6 +16,8 @@ set(
   src/FileDialogHandler.cpp
   src/FileFinderWidget.cpp
   src/FilePropertyWidget.cpp
+  src/FindFilesThreadPoolManager.cpp
+  src/FindFilesWorker.cpp
   src/FindReplaceDialog.cpp
   src/FitOptionsBrowser.cpp
   src/FitPropertyBrowser.cpp
@@ -151,6 +153,9 @@ set(
   inc/MantidQtWidgets/Common/DataSelector.h
   inc/MantidQtWidgets/Common/EditLocalParameterDialog.h
   inc/MantidQtWidgets/Common/FilePropertyWidget.h
+  inc/MantidQtWidgets/Common/FindFilesThreadPoolManager.h
+  inc/MantidQtWidgets/Common/FindFilesThreadPoolManagerMockObjects.h
+  inc/MantidQtWidgets/Common/FindFilesWorker.h
   inc/MantidQtWidgets/Common/FindReplaceDialog.h
   inc/MantidQtWidgets/Common/FitOptionsBrowser.h
   inc/MantidQtWidgets/Common/FitPropertyBrowser.h
@@ -1014,6 +1019,8 @@ set(
   QT5_TEST_FILES
   test/BatchAlgorithmRunnerTest.h
   test/FileDialogHandlerTest.h
+  test/FindFilesThreadPoolManagerTest.h
+  test/FindFilesWorkerTest.h
   test/FitPropertyBrowserTest.h
   test/ImageInfoModelMatrixWSTest.h
   test/ImageInfoModelMDTest.h

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/Testing/QApplicationGlobalFixture.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/Testing/QApplicationGlobalFixture.h
@@ -24,10 +24,14 @@ public:
     return true;
   }
 
-  bool tearDownWorld() override {
-    m_app->quit();
-    return true;
-  }
+  // Removed as it causes a segfault on Ubuntu 20.04 due to PyQt claiming 
+  // the Qapplication object and deleting it before tearDownWorld occurs.
+  // the memory leak caused by m_app not being deleted in some circumstances
+  // Doesn't matter as it executes this on exit
+  // bool tearDownWorld() override {
+  //   delete m_app;
+  //   return true;
+  // }
 
   int m_argc = 1;
   GNU_DIAG_OFF("pedantic")

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/Testing/QApplicationGlobalFixture.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/Testing/QApplicationGlobalFixture.h
@@ -25,7 +25,7 @@ public:
   }
 
   bool tearDownWorld() override {
-    delete m_app;
+    m_app->quit();
     return true;
   }
 

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/Testing/QApplicationGlobalFixture.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/Testing/QApplicationGlobalFixture.h
@@ -24,7 +24,7 @@ public:
     return true;
   }
 
-  // Removed as it causes a segfault on Ubuntu 20.04 due to PyQt claiming 
+  // Removed as it causes a segfault on Ubuntu 20.04 due to PyQt claiming
   // the Qapplication object and deleting it before tearDownWorld occurs.
   // the memory leak caused by m_app not being deleted in some circumstances
   // Doesn't matter as it executes this on exit

--- a/qt/widgets/common/test/FindFilesThreadPoolManagerTest.h
+++ b/qt/widgets/common/test/FindFilesThreadPoolManagerTest.h
@@ -57,7 +57,7 @@ public:
     poolManager.createWorker(widget, parameters);
     // Block and wait for all the threads to process
     poolManager.waitForDone();
-    QCoreApplication::processEvents();
+    QCoreApplication::sendPostedEvents();
 
     // Assert
     const auto results = widget->getResults();
@@ -115,7 +115,7 @@ public:
 
     // Block and wait for all the threads to process
     poolManager.waitForDone();
-    QCoreApplication::processEvents();
+    QCoreApplication::sendPostedEvents();
 
     // Assert
     const auto results = widget.getResults();

--- a/qt/widgets/common/test/FindFilesWorkerTest.h
+++ b/qt/widgets/common/test/FindFilesWorkerTest.h
@@ -145,6 +145,6 @@ private:
     auto threadPool = QThreadPool::globalInstance();
     threadPool->start(worker);
     threadPool->waitForDone();
-    QCoreApplication::processEvents();
+    QCoreApplication::sendPostedEvents();
   }
 };

--- a/scripts/Engineering/gui/CMakeLists.txt
+++ b/scripts/Engineering/gui/CMakeLists.txt
@@ -25,7 +25,7 @@ check_tests_valid(${CMAKE_CURRENT_SOURCE_DIR} ${TEST_PY_FILES})
 
 if(ENABLE_MANTIDPLOT)
     set(PYUNITTEST_QT_API pyqt) # force to use qt4
-    pyunittest_add_test(${CMAKE_CURRENT_SOURCE_DIR} python.EngineeringDiffraction
+    pyunittest_add_test(${CMAKE_CURRENT_SOURCE_DIR} python.EngineeringDiffractionQt4
                         ${TEST_PY_FILES})
     unset(PYUNITTEST_QT_API)
 endif()

--- a/scripts/Engineering/gui/CMakeLists.txt
+++ b/scripts/Engineering/gui/CMakeLists.txt
@@ -23,5 +23,16 @@ set(TEST_PY_FILES
 
 check_tests_valid(${CMAKE_CURRENT_SOURCE_DIR} ${TEST_PY_FILES})
 
-pyunittest_add_test(${CMAKE_CURRENT_SOURCE_DIR} python.EngineeringDiffraction
-                    ${TEST_PY_FILES})
+if(ENABLE_MANTIDPLOT)
+    set(PYUNITTEST_QT_API pyqt) # force to use qt4
+    pyunittest_add_test(${CMAKE_CURRENT_SOURCE_DIR} python.EngineeringDiffraction
+                        ${TEST_PY_FILES})
+    unset(PYUNITTEST_QT_API)
+endif()
+
+if (ENABLE_WORKBENCH)
+    set(PYUNITTEST_QT_API pyqt5)
+    pyunittest_add_test(${CMAKE_CURRENT_SOURCE_DIR} python.EngineeringDiffraction
+                        ${TEST_PY_FILES})
+    unset(PYUNITTEST_QT_API)
+endif()

--- a/scripts/test/CMakeLists.txt
+++ b/scripts/test/CMakeLists.txt
@@ -12,7 +12,6 @@ set(TEST_PY_FILES
     InelasticDirectDetpackmapTest.py
     ISISDirecInelasticConfigTest.py
     PyChopTest.py
-    pythonTSVTest.py
     ReductionSettingsTest.py
     ReductionWrapperTest.py
     ReflectometryQuickAuxiliaryTest.py
@@ -34,15 +33,22 @@ set(TEST_PYQT4_FILES
     SANSCommandInterfaceTest.py
     SansIsisGuiSettings.py
     SANSReducerTest.py
-    SANSReductionStepsUserFileTest.py)
+    SANSReductionStepsUserFileTest.py
+    pythonTSVTest.py)
 
-pyunittest_add_test(${CMAKE_CURRENT_SOURCE_DIR} python.scripts
-  ${TEST_PY_FILES})
+if (ENABLE_WORKBENCH)
+  set(PYUNITTEST_QT_API pyqt5) # force to use qt5
+  pyunittest_add_test(${CMAKE_CURRENT_SOURCE_DIR} python.scripts
+    ${TEST_PY_FILES})
+  unset(PYUNITTEST_QT_API)
+endif()
 
-set(PYUNITTEST_QT_API pyqt) # force to use qt4
-pyunittest_add_test(${CMAKE_CURRENT_SOURCE_DIR} python.scriptsQt4
-                      ${TEST_PYQT4_FILES})
-unset(PYUNITTEST_QT_API)
+if(ENABLE_MANTIDPLOT)
+  set(PYUNITTEST_QT_API pyqt) # force to use qt4
+  pyunittest_add_test(${CMAKE_CURRENT_SOURCE_DIR} python.scriptsQt4
+                        ${TEST_PYQT4_FILES})
+  unset(PYUNITTEST_QT_API)
+endif()
 
 
 # Additional tests

--- a/scripts/test/Muon/fitting_tab_widget/fitting_tab_presenter_test.py
+++ b/scripts/test/Muon/fitting_tab_widget/fitting_tab_presenter_test.py
@@ -9,7 +9,7 @@ import unittest
 from mantid.api import FunctionFactory, MultiDomainFunction
 from unittest import mock
 from mantidqt.utils.qt.testing import start_qapplication
-from qtpy import QtWidgets
+from qtpy.QtWidgets import QApplication
 from Muon.GUI.Common.fitting_tab_widget.fitting_tab_widget import FittingTabWidget
 from Muon.GUI.Common.test_helpers.context_setup import setup_context
 
@@ -38,7 +38,7 @@ def retrieve_combobox_info(combo_box):
 def wait_for_thread(thread_model):
     if thread_model:
         thread_model._thread.wait()
-        QtWidgets.QApplication.instance().processEvents()
+        QApplication.sendPostedEvents()
 
 
 def create_multi_domain_function(function_list):

--- a/scripts/test/Muon/load_file_widget/loadfile_presenter_multiple_file_test.py
+++ b/scripts/test/Muon/load_file_widget/loadfile_presenter_multiple_file_test.py
@@ -57,7 +57,7 @@ class LoadFileWidgetPresenterMultipleFileModeTest(unittest.TestCase):
     def wait_for_thread(self, thread_model):
         if thread_model:
             thread_model._thread.wait()
-            QApplication.instance().processEvents()
+            QApplication.sendPostedEvents()
 
     def setUp(self):
         setup_context_for_tests(self)

--- a/scripts/test/Muon/load_file_widget/loadfile_presenter_single_file_test.py
+++ b/scripts/test/Muon/load_file_widget/loadfile_presenter_single_file_test.py
@@ -31,7 +31,7 @@ class LoadFileWidgetPresenterTest(unittest.TestCase):
     def wait_for_thread(self, thread_model):
         if thread_model:
             thread_model._thread.wait()
-            QApplication.instance().processEvents()
+            QApplication.sendPostedEvents()
 
     def setUp(self):
         self.view = BrowseFileWidgetView()

--- a/scripts/test/Muon/load_run_widget/loadrun_presenter_current_run_test.py
+++ b/scripts/test/Muon/load_run_widget/loadrun_presenter_current_run_test.py
@@ -48,7 +48,7 @@ class LoadRunWidgetLoadCurrentRunTest(unittest.TestCase):
     def wait_for_thread(self, thread_model):
         if thread_model:
             thread_model._thread.wait()
-            QApplication.instance().processEvents()
+            QApplication.sendPostedEvents()
 
     def create_fake_workspace(self):
         return {'MainFieldDirection': 'transverse'}

--- a/scripts/test/Muon/load_run_widget/loadrun_presenter_increment_decrement_test.py
+++ b/scripts/test/Muon/load_run_widget/loadrun_presenter_increment_decrement_test.py
@@ -31,7 +31,7 @@ class LoadRunWidgetIncrementDecrementSingleFileModeTest(unittest.TestCase):
     def wait_for_thread(self, thread_model):
         if thread_model:
             thread_model._thread.wait()
-            QApplication.instance().processEvents()
+            QApplication.sendPostedEvents()
 
     def setUp(self):
         # Store an empty widget to parent all the views, and ensure they are deleted correctly

--- a/scripts/test/Muon/load_run_widget/loadrun_presenter_multiple_file_test.py
+++ b/scripts/test/Muon/load_run_widget/loadrun_presenter_multiple_file_test.py
@@ -29,7 +29,7 @@ class LoadRunWidgetIncrementDecrementMultipleFileModeTest(unittest.TestCase):
     def wait_for_thread(self, thread_model):
         if thread_model:
             thread_model._thread.wait()
-            QApplication.instance().processEvents()
+            QApplication.sendPostedEvents()
 
     def setUp(self):
         # Store an empty widget to parent all the views, and ensure they are deleted correctly

--- a/scripts/test/Muon/load_run_widget/loadrun_presenter_single_file_test.py
+++ b/scripts/test/Muon/load_run_widget/loadrun_presenter_single_file_test.py
@@ -30,7 +30,7 @@ class LoadRunWidgetPresenterTest(unittest.TestCase):
     def wait_for_thread(self, thread_model):
         if thread_model:
             thread_model._thread.wait()
-            QApplication.instance().processEvents()
+            QApplication.sendPostedEvents()
 
     def setUp(self):
         # Store an empty widget to parent all the views, and ensure they are deleted correctly

--- a/scripts/test/Muon/loading_tab/loadwidget_presenter_failure_test.py
+++ b/scripts/test/Muon/loading_tab/loadwidget_presenter_failure_test.py
@@ -29,7 +29,7 @@ class LoadRunWidgetPresenterLoadFailTest(unittest.TestCase):
     def wait_for_thread(self, thread_model):
         if thread_model:
             thread_model._thread.wait()
-            QApplication.instance().processEvents()
+            QApplication.sendPostedEvents()
 
     def create_fake_workspace(self, name):
         workspace_mock = CreateSampleWorkspace(StoreInADS=False)

--- a/scripts/test/Muon/loading_tab/loadwidget_presenter_multiple_file_test.py
+++ b/scripts/test/Muon/loading_tab/loadwidget_presenter_multiple_file_test.py
@@ -30,9 +30,9 @@ from Muon.GUI.MuonAnalysis.load_widget.load_widget_view import LoadWidgetView
 class LoadRunWidgetPresenterMultipleFileTest(unittest.TestCase):
     def wait_for_thread(self, thread_model):
         while(thread_model._thread.isRunning()):
-            QApplication.instance().processEvents()
+            QApplication.sendPostedEvents()
             time.sleep(0.1)
-        QApplication.instance().processEvents()
+        QApplication.sendPostedEvents()
 
     def setUp(self):
         # Store an empty widget to parent all the views, and ensure they are deleted correctly

--- a/scripts/test/Muon/loading_tab/loadwidget_presenter_test.py
+++ b/scripts/test/Muon/loading_tab/loadwidget_presenter_test.py
@@ -30,7 +30,7 @@ class LoadRunWidgetPresenterTest(unittest.TestCase):
     def wait_for_thread(self, thread_model):
         if thread_model:
             thread_model._thread.wait()
-            QApplication.instance().processEvents()
+            QApplication.sendPostedEvents()
 
     def setUp(self):
         # Store an empty widget to parent all the views, and ensure they are deleted correctly

--- a/scripts/test/Muon/phase_table_widget/phase_table_presenter_test.py
+++ b/scripts/test/Muon/phase_table_widget/phase_table_presenter_test.py
@@ -22,7 +22,7 @@ class PhaseTablePresenterTest(unittest.TestCase):
     def wait_for_thread(self, thread_model):
         if thread_model:
             thread_model._thread.wait()
-            QApplication.instance().processEvents()
+            QApplication.sendPostedEvents()
 
     def setUp(self):
         self.view = PhaseTableView()

--- a/scripts/test/Muon/seq_fitting_tab_widget/seq_fitting_tab_presenter_test.py
+++ b/scripts/test/Muon/seq_fitting_tab_widget/seq_fitting_tab_presenter_test.py
@@ -14,13 +14,13 @@ from mantidqt.utils.qt.testing import start_qapplication
 from mantidqt.utils.observer_pattern import GenericObservable
 from Muon.GUI.Common.seq_fitting_tab_widget.seq_fitting_tab_presenter import SeqFittingTabPresenter
 from Muon.GUI.Common.test_helpers.context_setup import setup_context
-from qtpy import QtWidgets
+from qtpy.QtWidgets import QApplication
 
 
 def wait_for_thread(thread_model):
     if thread_model:
         thread_model._thread.wait()
-        QtWidgets.QApplication.instance().processEvents()
+        QApplication.sendPostedEvents()
 
 
 @start_qapplication

--- a/scripts/test/TOFTOF/CMakeLists.txt
+++ b/scripts/test/TOFTOF/CMakeLists.txt
@@ -8,14 +8,14 @@ check_tests_valid(${CMAKE_CURRENT_SOURCE_DIR} ${TEST_PY_FILES})
 
 if(ENABLE_MANTIDPLOT)
     set(PYUNITTEST_QT_API pyqt) # force to use qt4
-    pyunittest_add_test(${CMAKE_CURRENT_SOURCE_DIR} PythonTOFTOFReduction
+    pyunittest_add_test(${CMAKE_CURRENT_SOURCE_DIR} PythonTOFTOFReductionQt4
                         ${TEST_PY_FILES})
     unset(PYUNITTEST_QT_API)
 endif()
 
 if (ENABLE_WORKBENCH)
     set(PYUNITTEST_QT_API pyqt5) # force to use qt5
-    pyunittest_add_test(${CMAKE_CURRENT_SOURCE_DIR} PythonTOFTOFReduction
+    pyunittest_add_test(${CMAKE_CURRENT_SOURCE_DIR} PythonTOFTOFReductionQt5
                         ${TEST_PY_FILES})
     unset(PYUNITTEST_QT_API)
 endif()

--- a/scripts/test/TOFTOF/CMakeLists.txt
+++ b/scripts/test/TOFTOF/CMakeLists.txt
@@ -6,5 +6,16 @@ set(TEST_PY_FILES
 
 check_tests_valid(${CMAKE_CURRENT_SOURCE_DIR} ${TEST_PY_FILES})
 
-pyunittest_add_test(${CMAKE_CURRENT_SOURCE_DIR} PythonTOFTOFReduction
-                    ${TEST_PY_FILES})
+if(ENABLE_MANTIDPLOT)
+    set(PYUNITTEST_QT_API pyqt) # force to use qt4
+    pyunittest_add_test(${CMAKE_CURRENT_SOURCE_DIR} PythonTOFTOFReduction
+                        ${TEST_PY_FILES})
+    unset(PYUNITTEST_QT_API)
+endif()
+
+if (ENABLE_WORKBENCH)
+    set(PYUNITTEST_QT_API pyqt5) # force to use qt5
+    pyunittest_add_test(${CMAKE_CURRENT_SOURCE_DIR} PythonTOFTOFReduction
+                        ${TEST_PY_FILES})
+    unset(PYUNITTEST_QT_API)
+endif()


### PR DESCRIPTION
**Description of work.**
Built mantid without Qt4 and MantidPlot using `-DENABLE_MANTIDPLOT=OFF` in CMake. Run tests and made sure they all passed.

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

**To test:**
Just code review
<!-- Instructions for testing. -->

Fixes #29390  <!-- and fix #xxxx or close #xxxx xor resolves #xxxx -->
<!-- alternative
*There is no associated issue.*
-->

Behind the scenes maintenance, not user facing.

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
