### PR TITLE
Update input workspaces in fitproperty browser of EngDiff UI to stop exception

### DIFF
--- a/qt/python/mantidqt/_common.sip
+++ b/qt/python/mantidqt/_common.sip
@@ -480,6 +480,7 @@ public:
     void addFitResultWorkspacesToTableWidget();
     void setWorkspaceName(const QString &wsName);
     void postDeleteHandle(const std::string &wsName);
+    void removeWorkspaceAndSpectra(const std::string &wsName);
     std::string getFitAlgorithmParameters() const;
 
     SIP_PYOBJECT defaultPeakType();

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/FitPropertyBrowser.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/FitPropertyBrowser.h
@@ -275,6 +275,10 @@ public:
   void addHandle(const std::string &wsName,
                  const std::shared_ptr<Mantid::API::Workspace> &ws) override;
 
+  // Remove Workspace
+  void removeWorkspace(const std::string &wsName);
+  void removeWorkspaceAndSpectra(const std::string &wsName);
+
   /// Called when the Fit is finished
   void finishHandle(const Mantid::API::IAlgorithm *alg) override;
 

--- a/qt/widgets/common/src/FitPropertyBrowser.cpp
+++ b/qt/widgets/common/src/FitPropertyBrowser.cpp
@@ -1871,6 +1871,10 @@ void FitPropertyBrowser::addHandle(
 
 /// workspace was removed
 void FitPropertyBrowser::postDeleteHandle(const std::string &wsName) {
+  removeWorkspace(wsName);
+}
+
+void FitPropertyBrowser::removeWorkspace(const std::string &wsName) {
   QString oldName = QString::fromStdString(workspaceName());
   int i = m_workspaceNames.indexOf(QString(wsName.c_str()));
   if (i >= 0) {
@@ -3502,6 +3506,13 @@ void FitPropertyBrowser::addAllowedSpectra(const QString &wsName,
   } else {
     throw std::runtime_error("Workspace " + name + " is not a MatrixWorkspace");
   }
+}
+
+void FitPropertyBrowser::removeWorkspaceAndSpectra(const std::string &wsName) {
+  removeWorkspace(wsName);
+  // remove spectra
+  QString qWsName = QString::fromStdString(wsName.c_str());
+  m_allowedSpectra.erase(m_allowedSpectra.find(qWsName));
 }
 
 void FitPropertyBrowser::addAllowedTableWorkspace(const QString &wsName) {

--- a/qt/widgets/common/src/FitPropertyBrowser.cpp
+++ b/qt/widgets/common/src/FitPropertyBrowser.cpp
@@ -3511,7 +3511,7 @@ void FitPropertyBrowser::addAllowedSpectra(const QString &wsName,
 void FitPropertyBrowser::removeWorkspaceAndSpectra(const std::string &wsName) {
   removeWorkspace(wsName);
   // remove spectra
-  QString qWsName = QString::fromStdString(wsName.c_str());
+  QString qWsName = QString::fromStdString(wsName);
   m_allowedSpectra.erase(m_allowedSpectra.find(qWsName));
 }
 

--- a/scripts/Engineering/gui/engineering_diffraction/tabs/fitting/plotting/EngDiff_fitpropertybrowser.py
+++ b/scripts/Engineering/gui/engineering_diffraction/tabs/fitting/plotting/EngDiff_fitpropertybrowser.py
@@ -29,3 +29,21 @@ class EngDiffFitPropertyBrowser(FitPropertyBrowser):
         :return: None
         """
         return None
+
+    def _get_allowed_spectra(self):
+        """
+        Get the workspaces and spectra that can be fitted from the
+        tracked workspaces.
+        """
+        allowed_spectra = {}
+        output_wsnames = [self.getWorkspaceList().item(ii).text() for ii in range(self.getWorkspaceList().count())]
+        for ax in self.canvas.figure.get_axes():
+            try:
+                for ws_name, artists in ax.tracked_workspaces.items():
+                    # don't allow existing output workspaces (fitted curves) to be added
+                    if ws_name not in output_wsnames:
+                        spectrum_list = [artist.spec_num for artist in artists]
+                        allowed_spectra[ws_name] = spectrum_list
+            except AttributeError:  # scripted plots have no tracked_workspaces
+                pass
+        return allowed_spectra

--- a/scripts/Engineering/gui/engineering_diffraction/tabs/fitting/plotting/plot_presenter.py
+++ b/scripts/Engineering/gui/engineering_diffraction/tabs/fitting/plotting/plot_presenter.py
@@ -35,9 +35,11 @@ class FittingPlotPresenter(object):
     def remove_workspace_from_plot(self, ws):
         for ax in self.view.get_axes():
             self.model.remove_workspace_from_plot(ws, ax)
+            self.view.remove_ws_from_fitbrowser(ws)
         self.view.update_figure()
 
     def clear_plot(self):
         for ax in self.view.get_axes():
             self.model.remove_all_workspaces_from_plot(ax)
         self.view.clear_figure()
+        self.view.update_fitbrowser()

--- a/scripts/Engineering/gui/engineering_diffraction/tabs/fitting/plotting/plot_toolbar.py
+++ b/scripts/Engineering/gui/engineering_diffraction/tabs/fitting/plotting/plot_toolbar.py
@@ -64,3 +64,6 @@ class FittingPlotToolbar(NavigationToolbar2QT):
 
     def trigger_fit_toggle_action(self):
         self._actions['toggle_fit'].trigger()
+
+    def set_fit_checkstate(self, checkstate):
+        self._actions['toggle_fit'].setChecked(checkstate)

--- a/scripts/Engineering/gui/engineering_diffraction/tabs/fitting/plotting/plot_view.py
+++ b/scripts/Engineering/gui/engineering_diffraction/tabs/fitting/plotting/plot_view.py
@@ -91,6 +91,19 @@ class FittingPlotView(QtWidgets.QWidget, Ui_plot):
         self.figure.tight_layout()
         self.update_legend(self.get_axes()[0])
         self.figure.canvas.draw()
+        self.update_fitbrowser()
+
+    def update_fitbrowser(self):
+        is_visible = self.fit_browser.isVisible()
+        self.toolbar.set_fit_checkstate(False)
+        self.fit_browser.hide()
+        if self.fit_browser.getWorkspaceNames() and is_visible:
+            self.toolbar.set_fit_checkstate(True)
+            self.fit_browser.show()
+
+    def remove_ws_from_fitbrowser(self, ws):
+        # only one spectra per workspace
+        self.fit_browser.removeWorkspaceAndSpectra(ws.name())
 
     def update_legend(self, ax):
         if ax.get_lines():

--- a/scripts/Engineering/gui/engineering_diffraction/tabs/fitting/plotting/test/test_plot_presenter.py
+++ b/scripts/Engineering/gui/engineering_diffraction/tabs/fitting/plotting/test/test_plot_presenter.py
@@ -35,6 +35,7 @@ class FittingPlotPresenterTest(unittest.TestCase):
         self.presenter.remove_workspace_from_plot("workspace")
 
         self.assertEqual(1, self.view.update_figure.call_count)
+        self.assertEqual(2, self.view.remove_ws_from_fitbrowser.call_count)
         self.assertEqual(2, self.model.remove_workspace_from_plot.call_count)
         self.model.remove_workspace_from_plot.assert_any_call("workspace", "axis1")
         self.model.remove_workspace_from_plot.assert_any_call("workspace", "axis2")
@@ -45,6 +46,7 @@ class FittingPlotPresenterTest(unittest.TestCase):
         self.presenter.clear_plot()
 
         self.assertEqual(1, self.view.clear_figure.call_count)
+        self.assertEqual(1, self.view.update_fitbrowser.call_count)
         self.assertEqual(2, self.model.remove_all_workspaces_from_plot.call_count)
         self.model.remove_all_workspaces_from_plot.assert_any_call("axis1")
         self.model.remove_all_workspaces_from_plot.assert_any_call("axis2")


### PR DESCRIPTION
**Description of work.**
There was an unhandled exception when attempting to fit a workspace that is not plotted - to fix this it is now only possible to select plotted workspaces.

Every time a spectra is added or removed from the axes the fit property browser is updated (by hide/show). If a workspace is removed from the plot then all the spectra associated with that workspace (only one in this case) are removed from the list which populates the drop-down box of input Workspaces. In addition the evaluated fit functions are not allowed to be fitted. 

**To test:**

(1) Load data and fit as per instructions in #28393
(2) Add and remove data from the axes (using the plot checkbox or the remove buttons)
(3) The drop-down box for workspaces should only display the plotted workspaces.
(4) Try removing the only plotted workspace - the fit browser should close and won't re-open till you plot another (valid) workspace
(5) Plot and fit  the spectra outside the Eng Diff UI in a normal mantid plot- try deleting one of the workspaces. The behaviour should be the same (i.e. if you have selected to fit the workspace you delete it will be removed from the dropdown, but otherwise it seem the fit browser needs to be toggled off/on)I


<!-- Instructions for testing. -->

Fixes #29339


---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
