### PR TITLE
Fixed Bug with unselecting peak checkbox on elemental analysis

### DIFF
--- a/docs/source/release/v5.1.0/muon.rst
+++ b/docs/source/release/v5.1.0/muon.rst
@@ -91,5 +91,9 @@ New Features
 - Added a deselect all elements button.
 - Fixed an issue where groups were all being plotted on the same tiled plot.
 
+Bug fixes
+---------
+- Fixed an issue where Elemental Analysis gui was crashing when any peak checkbox was unselected.
+
 
 :ref:`Release 5.1.0 <v5.1.0>`

--- a/scripts/Muon/GUI/ElementalAnalysis/PeriodicTable/PeakSelector/peak_selector_view.py
+++ b/scripts/Muon/GUI/ElementalAnalysis/PeriodicTable/PeakSelector/peak_selector_view.py
@@ -142,12 +142,13 @@ class PeakSelectorView(QtWidgets.QListWidget):
         return checkboxes
 
     def _parse_checkbox_name(self, name):
-        peak_type, value = name.replace(" ", "").split(":")
+        peak_type, value = name.split(":")
         return peak_type, value
 
     def _remove_value_from_new_data(self, checkbox):
         peak_type, _ = self._parse_checkbox_name(checkbox.name)
-        del self.new_data[peak_type]
+        if peak_type in self.new_data:
+            del self.new_data[peak_type]
 
     def _add_value_to_new_data(self, checkbox):
         peak_type, value = self._parse_checkbox_name(checkbox.name)

--- a/scripts/test/Muon/elemental_analysis/peak_selector_view_test.py
+++ b/scripts/test/Muon/elemental_analysis/peak_selector_view_test.py
@@ -69,12 +69,12 @@ class PeakSelectorViewTest(unittest.TestCase):
         name = 'type: value'
         peak_type, value = self.view._parse_checkbox_name(name)
         self.assertEqual(peak_type, 'type')
-        self.assertEqual(value, 'value')
+        self.assertEqual(value, ' value')
 
     def test_parse_checkbox_name_does_not_convert_value_to_float(self):
         name = 'type: 1.0'
         peak_type, value = self.view._parse_checkbox_name(name)
-        self.assertEqual(value, '1.0')
+        self.assertEqual(value, ' 1.0')
 
     def test_remove_value_from_new_data_removes_existing_key_from_new_data(self):
         self.view.new_data['type'] = 'value'
@@ -82,9 +82,12 @@ class PeakSelectorViewTest(unittest.TestCase):
         self.view._remove_value_from_new_data(checkbox)
         self.assertIs('type' in self.view.new_data.keys(), False)
 
-    def test_remove_value_from_new_data_raises_KeyError_is_type_not_in_new_data(self):
+    def test_remove_value_from_new_data_does_not_raise_KeyError_if_type_not_in_new_data(self):
         checkbox = Checkbox('type: value')
-        self.assertRaises(KeyError, self.view._remove_value_from_new_data, checkbox)
+        try:
+            self.view._remove_value_from_new_data(checkbox)
+        except KeyError:
+            raise AssertionError
 
     def test_add_value_to_new_data(self):
         self.new_data = {}


### PR DESCRIPTION
**Description of work.**
Fixed a Bug that caused the elemental analysis gui to crash with any of the peak checkbox was unselected.

**Report to:** Adrian Hillier

**To test:**
1.Open Elemental Analysis Interface
2.Put Sundials into your Data search directories in MUD (Contact myself or @AnthonyLim23)
3.Enter 2695 and click Load.
4.Plot detector GE1
5.Select minor peaks
6.Deselect minor ticks (or infact the major ticks!)



Fixes #29162 . 


---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
