### PR TITLE
Update GettingStarted.rst with Visual Studio settings for machines with less than 32GB memory

### DIFF
--- a/dev-docs/source/GettingStarted.rst
+++ b/dev-docs/source/GettingStarted.rst
@@ -25,6 +25,7 @@ Install the following:
 
     * ``Windows Universal CRT SDK``
     * The latest Windows 10 SDK
+  * If your machine has less than 32GB of memory Mantid may not build. If you have problems change the maximum number of parallel project builds to 1 in Visual Studio in Tools -> Options -> Projects and Solutions -> Build And Run.
 
 
 * `Git <https://git-scm.com/>`_.


### PR DESCRIPTION
**Description of work.**
An update to the setup instructions to include changing the maximum number of parallel builds in Visual Studio for machines with less than 32GB memory.

**To test:**

<!-- Instructions for testing. -->
Docs update only. Check docs build is ok

*There is no associated issue.*

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
