### PR TITLE
Fix Muon Analysis TF asymmetry fitting crash

### DIFF
--- a/Framework/Muon/src/ConvertFitFunctionForMuonTFAsymmetry.cpp
+++ b/Framework/Muon/src/ConvertFitFunctionForMuonTFAsymmetry.cpp
@@ -109,6 +109,10 @@ void ConvertFitFunctionForMuonTFAsymmetry::init() {
   declareProperty(
       std::make_unique<FunctionProperty>("OutputFunction", Direction::Output),
       "The converted fitting function.");
+
+  declareProperty("CopyTies", true,
+                  "Set to true to copy over ties from input function"
+                  "(default is true).");
 }
 
 /*
@@ -237,7 +241,8 @@ ConvertFitFunctionForMuonTFAsymmetry::extractFromTFAsymmFitFunction(
     multi->addFunction(userFunc);
   }
   // if multi data set we need to do the ties manually
-  if (numDomains > 1) {
+  bool copyTies = getProperty("CopyTies");
+  if (numDomains > 1 && copyTies) {
     auto originalNames = original->getParameterNames();
     for (auto name : originalNames) {
       auto index = original->parameterIndex(name);
@@ -376,7 +381,8 @@ ConvertFitFunctionForMuonTFAsymmetry::getTFAsymmFitFunction(
     multi->addFunction(composite);
   }
   // if multi data set we need to do the ties manually
-  if (numDomains > 1) {
+  bool copyTies = getProperty("CopyTies");
+  if (numDomains > 1 && copyTies) {
     auto originalNames = original->getParameterNames();
     for (auto name : originalNames) {
       auto index = original->parameterIndex(name);

--- a/docs/source/algorithms/ConvertFitFunctionForMuonTFAsymmetry-v1.rst
+++ b/docs/source/algorithms/ConvertFitFunctionForMuonTFAsymmetry-v1.rst
@@ -19,6 +19,8 @@ The second mode is extract, if the TF normalisation function is given it will re
 
 This algorithm works for both single and multi domain functions.
 
+The algorithm takes an optional boolean parameter `CopyTies`, which when true will copy the ties present in the input function. By default it is set to true.
+
 Usage
 -----
 

--- a/docs/source/interfaces/muon_fitting_tab.rst
+++ b/docs/source/interfaces/muon_fitting_tab.rst
@@ -44,7 +44,7 @@ If it is unchecked it will use the rebinned data as specified on the home tab.
 
 **Evaluate Function As** Select if to fit to histogram or point data.
 
-**TF Asymmetry Mode** Evaluate the fit in TF asymmetry mode, see :ref:`Calculate Muon Asymmetry <algm-CalculateMuonAsymmetry>`.
+**TF Asymmetry Mode** Evaluate the fit in TF asymmetry mode, see :ref:`Calculate Muon Asymmetry <algm-CalculateMuonAsymmetry>`. Note that currently the TF asymmetry parameters will not automatically update when a new run is loaded.
 
 Used By
 ^^^^^^^

--- a/docs/source/release/v5.1.0/muon.rst
+++ b/docs/source/release/v5.1.0/muon.rst
@@ -82,6 +82,7 @@ Bug fixes
 - Fixed an issue where Muon Analysis and Frequency Domain Analysis gui was not properly disabling during calculations.
 - Fixed an issue where Muon Analysis and Frequency Domain Analysis was not correctly resetting DeadTime property to default when a user changes the instrument
 - Fixed issue where select data was incorrectly enabling.
+- Fixed a bug in simultaneous TF asymmetry mode fitting, which would cause a crash when the run was incremented.
 
 Elemental Analysis 
 ##################

--- a/docs/source/release/v5.1.0/muon.rst
+++ b/docs/source/release/v5.1.0/muon.rst
@@ -82,7 +82,7 @@ Bug fixes
 - Fixed an issue where Muon Analysis and Frequency Domain Analysis gui was not properly disabling during calculations.
 - Fixed an issue where Muon Analysis and Frequency Domain Analysis was not correctly resetting DeadTime property to default when a user changes the instrument
 - Fixed issue where select data was incorrectly enabling.
-- Fixed a bug in simultaneous TF asymmetry mode fitting, which would cause a crash when the run was incremented.
+- Fixed a bug in simultaneous TF asymmetry mode fitting, which would cause a crash when the run was incremented. Note that currently the single fitting tab will not update with the new normalization constants after a new run is loaded.
 
 Elemental Analysis 
 ##################

--- a/scripts/Muon/GUI/Common/fitting_tab_widget/fitting_tab_presenter.py
+++ b/scripts/Muon/GUI/Common/fitting_tab_widget/fitting_tab_presenter.py
@@ -284,7 +284,6 @@ class FittingTabPresenter(object):
     def handle_tf_asymmetry_mode_changed(self):
         def calculate_tf_fit_function(original_fit_function):
             tf_asymmetry_parameters = self.get_parameters_for_tf_function_calculation(original_fit_function)
-
             try:
                 tf_function = self.model.convert_to_tf_function(tf_asymmetry_parameters)
             except RuntimeError:
@@ -319,6 +318,7 @@ class FittingTabPresenter(object):
             if self.automatically_update_fit_name:
                 self.view.function_name = self.view.function_name.replace(',TFAsymmetry', '')
                 self.model.function_name = self.view.function_name
+
         if not self.view.is_simul_fit():
             for index, fit_function in enumerate(self._fit_function):
                 fit_function = fit_function if fit_function else self.view.fit_object.clone()
@@ -350,7 +350,8 @@ class FittingTabPresenter(object):
             self.view.display_workspace]
         return {'InputFunction': fit_function,
                 'WorkspaceList': workspace_list,
-                'Mode': mode}
+                'Mode': mode,
+                'CopyTies': False}
 
     def handle_function_parameter_changed(self):
         if not self.view.is_simul_fit():

--- a/scripts/test/Muon/fitting_tab_widget/fitting_tab_presenter_test.py
+++ b/scripts/test/Muon/fitting_tab_widget/fitting_tab_presenter_test.py
@@ -512,7 +512,7 @@ class FittingTabPresenterTest(unittest.TestCase):
         result = self.presenter.get_parameters_for_tf_function_calculation(fit_function)
 
         self.assertEqual(result, {'InputFunction': fit_function, 'WorkspaceList': [new_workspace_list[0]],
-                                  'Mode': 'Construct'})
+                                  'Mode': 'Construct', 'CopyTies': False})
 
     def test_get_parameters_for_tf_function_calculation_for_turning_mode_off(self):
         new_workspace_list = ['MUSR22725; Group; top; Asymmetry', 'MUSR22725; Group; bottom; Asymmetry',
@@ -523,7 +523,7 @@ class FittingTabPresenterTest(unittest.TestCase):
         result = self.presenter.get_parameters_for_tf_function_calculation(fit_function)
 
         self.assertEqual(result, {'InputFunction': fit_function, 'WorkspaceList': [new_workspace_list[0]],
-                                  'Mode': 'Extract'})
+                                  'Mode': 'Extract', 'CopyTies': False})
 
     def test_handle_asymmetry_mode_changed_reverts_changed_and_shows_error_if_non_group_selected(self):
         new_workspace_list = ['MUSR22725; Group; top; Asymmetry', 'MUSR22725; Group; bottom; Asymmetry',


### PR DESCRIPTION
**Description of work.**
This PR fixes a crash which occurs when the run is incremented while a simultaneous TF asymmetry fit is defined. This seems to occur due to the ties being invalidated, which is likely due to be setting in both ConvertFitFunctionForMuonTFAssymetry and in the function browser. To avoid this I've added an optional boolean parameter to the algorithm, which states whether ties are to be copied.

**To test:**
- Open Muon Analysis
- Load data
- Go to the fitting tab
- Add a function
- Share a parameter
- Turn on TF Asymmetry mode
- Change the run - should no longer crash

<!-- Instructions for testing. -->

Fixes #29388 . <!-- and fix #xxxx or close #xxxx xor resolves #xxxx -->
<!-- alternative
*There is no associated issue.*
-->



---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
