### PR TITLE
Fixed issue with select data button enabling

### DIFF
--- a/docs/source/release/v5.1.0/muon.rst
+++ b/docs/source/release/v5.1.0/muon.rst
@@ -80,6 +80,7 @@ Bug fixes
 - Fixed an issue with setting the current workspace before adding a function.
 - Fixed an issue with the results tab not updating correctly after multiple fits with different functions.
 - Fixed an issue where Muon Analysis and Frequency Domain Analysis gui was not properly disabling during calculations.
+- Fixed issue where select data was incorrectly enabling.
 
 
 Elemental Analysis 

--- a/scripts/Muon/GUI/Common/fitting_tab_widget/fitting_tab_presenter.py
+++ b/scripts/Muon/GUI/Common/fitting_tab_widget/fitting_tab_presenter.py
@@ -315,7 +315,6 @@ class FittingTabPresenter(object):
                 self.view.function_name += ',TFAsymmetry'
                 self.model.function_name = self.view.function_name
         else:
-            self.view.select_workspaces_to_fit_button.setEnabled(True)
             new_global_parameters = [item[9:] for item in global_parameters]
             if self.automatically_update_fit_name:
                 self.view.function_name = self.view.function_name.replace(',TFAsymmetry', '')


### PR DESCRIPTION
**Description of work.**
Fixed issue with select data data enabling on muon analysis

**To test:**

1.Open moun analysis interface and load some data (2 or more runs)
2.Go to fit and add a function
3.Turn on simultaneous mode
4.Turn on TF asymmetry mode
5.Turn off TF asymmetry mode
6.The select data button has been activated - using this can get you into an odd state
<!-- Instructions for testing. -->

Fixes #29410 . 

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
