### PR TITLE
Fix OpenGL viewport size for 4K resolutions

### DIFF
--- a/qt/widgets/instrumentview/inc/MantidQtWidgets/InstrumentView/InstrumentWidget.h
+++ b/qt/widgets/instrumentview/inc/MantidQtWidgets/InstrumentView/InstrumentWidget.h
@@ -250,10 +250,8 @@ protected:
   void setBackgroundColor(const QColor &color);
   /// Get the surface info string
   QString getSurfaceInfoText() const;
-  /// Return the width of the instrunemt display
-  int getInstrumentDisplayWidth() const;
-  /// Return the height of the instrunemt display
-  int getInstrumentDisplayHeight() const;
+  /// Return the size of the OpenGL display widget in logical pixels
+  QSize glWidgetPixelSize();
   /// Select the OpenGL or simple widget for instrument display
   void selectOpenGLDisplay(bool yes);
   /// Set the surface type.

--- a/qt/widgets/instrumentview/inc/MantidQtWidgets/InstrumentView/InstrumentWidget.h
+++ b/qt/widgets/instrumentview/inc/MantidQtWidgets/InstrumentView/InstrumentWidget.h
@@ -250,8 +250,8 @@ protected:
   void setBackgroundColor(const QColor &color);
   /// Get the surface info string
   QString getSurfaceInfoText() const;
-  /// Return the size of the OpenGL display widget in logical pixels
-  QSize glWidgetPixelSize();
+  /// Return the size of the OpenGL display widget in device pixels
+  QSize glWidgetDimensions();
   /// Select the OpenGL or simple widget for instrument display
   void selectOpenGLDisplay(bool yes);
   /// Set the surface type.

--- a/qt/widgets/instrumentview/inc/MantidQtWidgets/InstrumentView/Projection3D.h
+++ b/qt/widgets/instrumentview/inc/MantidQtWidgets/InstrumentView/Projection3D.h
@@ -35,8 +35,7 @@ class Projection3D : public ProjectionSurface {
   };
 
 public:
-  Projection3D(const InstrumentActor *rootActor, int winWidth, int winHeight);
-  ~Projection3D() override;
+  Projection3D(const InstrumentActor *rootActor, QSize viewportSize);
   RectF getSurfaceBounds() const override;
 
   void setViewDirection(const QString &vd);

--- a/qt/widgets/instrumentview/inc/MantidQtWidgets/InstrumentView/Viewport.h
+++ b/qt/widgets/instrumentview/inc/MantidQtWidgets/InstrumentView/Viewport.h
@@ -49,10 +49,10 @@ public:
   enum ProjectionType { ORTHO, PERSPECTIVE };
   /// Constructor with Width (w) and Height(h) as inputs
   /// Called by the display device when viewport is resized
-  explicit Viewport(QSize logicalPixelSize);
-  void resize(QSize logicalPixelSize);
+  explicit Viewport(QSize glWidgetDimensions);
+  void resize(QSize glWidgetDimensions);
   /// Get the viewport width and height.
-  QSize logicalPixelSize() const;
+  QSize dimensions() const;
   /// Return the projection type.
   ProjectionType getProjectionType() const;
   /// Set a projection.
@@ -139,7 +139,7 @@ protected:
   /* Projection */
 
   ProjectionType m_projectionType; ///< Type of display projection
-  QSize m_logicalPixelSize;
+  QSize m_dimensions;
   double m_left; ///< Ortho/Prespective Projection xmin value (Left side of the
   /// x axis)
   double m_right; ///< Ortho/Prespective Projection xmax value (Right side of

--- a/qt/widgets/instrumentview/inc/MantidQtWidgets/InstrumentView/Viewport.h
+++ b/qt/widgets/instrumentview/inc/MantidQtWidgets/InstrumentView/Viewport.h
@@ -8,6 +8,7 @@
 
 #include "MantidKernel/Quat.h"
 #include "MantidKernel/V3D.h"
+#include <QSize>
 
 namespace MantidQt {
 namespace MantidWidgets {
@@ -46,12 +47,12 @@ transformation to the model.
 class Viewport {
 public:
   enum ProjectionType { ORTHO, PERSPECTIVE };
-  Viewport(int w,
-           int h); ///< Constructor with Width (w) and Height(h) as inputs
-                   /// Called by the display device when viewport is resized
-  void resize(int /*w*/, int /*h*/);
+  /// Constructor with Width (w) and Height(h) as inputs
+  /// Called by the display device when viewport is resized
+  explicit Viewport(QSize logicalPixelSize);
+  void resize(QSize logicalPixelSize);
   /// Get the viewport width and height.
-  void getViewport(int &w, int &h) const;
+  QSize logicalPixelSize() const;
   /// Return the projection type.
   ProjectionType getProjectionType() const;
   /// Set a projection.
@@ -138,8 +139,7 @@ protected:
   /* Projection */
 
   ProjectionType m_projectionType; ///< Type of display projection
-  int m_width;                     ///< Width of the viewport in pixels
-  int m_height;                    ///< Height of the viewport in pixels
+  QSize m_logicalPixelSize;
   double m_left; ///< Ortho/Prespective Projection xmin value (Left side of the
   /// x axis)
   double m_right; ///< Ortho/Prespective Projection xmax value (Right side of

--- a/qt/widgets/instrumentview/src/InstrumentWidget.cpp
+++ b/qt/widgets/instrumentview/src/InstrumentWidget.cpp
@@ -91,6 +91,7 @@ private:
   WorkspaceReplacementFlagHolder();
   bool &m_worskpaceReplacementFlag;
 };
+
 } // namespace
 
 // Name of the QSettings group to store the InstrumentWindw settings
@@ -487,9 +488,8 @@ void InstrumentWidget::setSurfaceType(int type) {
         if (m_instrumentActor->hasGridBank())
           m_maskTab->setDisabled(true);
 
-        surface = new Projection3D(m_instrumentActor.get(),
-                                   getInstrumentDisplayWidth(),
-                                   getInstrumentDisplayHeight());
+        surface =
+            new Projection3D(m_instrumentActor.get(), glWidgetPixelSize());
       } else if (surfaceType <= CYLINDRICAL_Z) {
         m_renderTab->forceLayers(true);
         surface =
@@ -1169,24 +1169,17 @@ void InstrumentWidget::setSurface(ProjectionSurface *surface) {
   }
 }
 
-/// Return the width of the instrunemt display
-int InstrumentWidget::getInstrumentDisplayWidth() const {
-  if (m_InstrumentDisplay) {
-    return m_InstrumentDisplay->width();
-  } else if (m_simpleDisplay) {
-    return m_simpleDisplay->width();
-  }
-  return 0;
-}
-
-/// Return the height of the instrunemt display
-int InstrumentWidget::getInstrumentDisplayHeight() const {
-  if (m_InstrumentDisplay) {
-    return m_InstrumentDisplay->height();
-  } else if (m_simpleDisplay) {
-    return m_simpleDisplay->height();
-  }
-  return 0;
+/// Return the size of the OpenGL display widget in logical pixels
+QSize InstrumentWidget::glWidgetPixelSize() {
+  auto sizeinLogicalPixels = [](const QWidget *w) -> QSize {
+    return QSize(w->width(), w->height());
+  };
+  if (m_InstrumentDisplay)
+    return sizeinLogicalPixels(m_InstrumentDisplay);
+  else if (m_simpleDisplay)
+    return sizeinLogicalPixels(m_simpleDisplay);
+  else
+    return QSize(0, 0);
 }
 
 /// Redraw the instrument view

--- a/qt/widgets/instrumentview/src/InstrumentWidget.cpp
+++ b/qt/widgets/instrumentview/src/InstrumentWidget.cpp
@@ -489,7 +489,7 @@ void InstrumentWidget::setSurfaceType(int type) {
           m_maskTab->setDisabled(true);
 
         surface =
-            new Projection3D(m_instrumentActor.get(), glWidgetPixelSize());
+            new Projection3D(m_instrumentActor.get(), glWidgetDimensions());
       } else if (surfaceType <= CYLINDRICAL_Z) {
         m_renderTab->forceLayers(true);
         surface =
@@ -1170,10 +1170,17 @@ void InstrumentWidget::setSurface(ProjectionSurface *surface) {
 }
 
 /// Return the size of the OpenGL display widget in logical pixels
-QSize InstrumentWidget::glWidgetPixelSize() {
+QSize InstrumentWidget::glWidgetDimensions() {
+#if QT_VERSION < QT_VERSION_CHECK(5, 0, 0)
   auto sizeinLogicalPixels = [](const QWidget *w) -> QSize {
     return QSize(w->width(), w->height());
   };
+#else
+  auto sizeinLogicalPixels = [](const QWidget *w) -> QSize {
+    const auto devicePixelRatio = w->window()->devicePixelRatio();
+    return QSize(w->width() * devicePixelRatio, w->height() * devicePixelRatio);
+  };
+#endif
   if (m_InstrumentDisplay)
     return sizeinLogicalPixels(m_InstrumentDisplay);
   else if (m_simpleDisplay)

--- a/qt/widgets/instrumentview/src/Projection3D.cpp
+++ b/qt/widgets/instrumentview/src/Projection3D.cpp
@@ -45,11 +45,9 @@ using namespace Mantid::Geometry;
 
 namespace MantidQt {
 namespace MantidWidgets {
-Projection3D::Projection3D(const InstrumentActor *rootActor, int winWidth,
-                           int winHeight)
+Projection3D::Projection3D(const InstrumentActor *rootActor, QSize viewportSize)
     : ProjectionSurface(rootActor), m_drawAxes(true), m_wireframe(false),
-      m_viewport(0, 0) {
-  m_viewport.resize(winWidth, winHeight);
+      m_viewport(std::move(viewportSize)) {
   V3D minBounds, maxBounds;
   m_instrActor->getBoundingBox(minBounds, maxBounds);
 
@@ -76,15 +74,13 @@ Projection3D::Projection3D(const InstrumentActor *rootActor, int winWidth,
   connect(moveController, SIGNAL(finish()), this, SLOT(finishMove()));
 }
 
-Projection3D::~Projection3D() {}
-
 /**
  * Resize the surface on the screen.
  * @param w :: New width of the surface in pixels.
  * @param h :: New height of the surface in pixels.
  */
 void Projection3D::resize(int w, int h) {
-  m_viewport.resize(w, h);
+  m_viewport.resize(QSize(w, h));
   updateView();
 }
 
@@ -213,8 +209,8 @@ void Projection3D::getSelectedDetectors(std::vector<size_t> &detIndices) {
   double xmin, xmax, ymin, ymax, zmin, zmax;
   m_viewport.getInstantProjection(xmin, xmax, ymin, ymax, zmin, zmax);
   QRect rect = selectionRect();
-  int w, h;
-  m_viewport.getViewport(w, h);
+  auto size = m_viewport.logicalPixelSize();
+  const auto w(size.width()), h(size.height());
 
   double xLeft = xmin + (xmax - xmin) * rect.left() / w;
   double xRight = xmin + (xmax - xmin) * rect.right() / w;

--- a/qt/widgets/instrumentview/src/Projection3D.cpp
+++ b/qt/widgets/instrumentview/src/Projection3D.cpp
@@ -209,7 +209,7 @@ void Projection3D::getSelectedDetectors(std::vector<size_t> &detIndices) {
   double xmin, xmax, ymin, ymax, zmin, zmax;
   m_viewport.getInstantProjection(xmin, xmax, ymin, ymax, zmin, zmax);
   QRect rect = selectionRect();
-  auto size = m_viewport.logicalPixelSize();
+  auto size = m_viewport.dimensions();
   const auto w(size.width()), h(size.height());
 
   double xLeft = xmin + (xmax - xmin) * rect.left() / w;

--- a/qt/widgets/instrumentview/src/Viewport.cpp
+++ b/qt/widgets/instrumentview/src/Viewport.cpp
@@ -22,12 +22,11 @@ namespace MantidWidgets {
 
 /**
  * Initialize with defaults.
- * @param logicalPixelSize Viewport width/height in logical pixels
+ * @param glWidgetDimensions Viewport width/height in device pixels
  */
-Viewport::Viewport(QSize logicalPixelSize)
-    : m_projectionType(Viewport::ORTHO),
-      m_logicalPixelSize(std::move(logicalPixelSize)), m_left(-1), m_right(1),
-      m_bottom(-1), m_top(1), m_near(-1), m_far(1),
+Viewport::Viewport(QSize dimensions)
+    : m_projectionType(Viewport::ORTHO), m_dimensions(std::move(dimensions)),
+      m_left(-1), m_right(1), m_bottom(-1), m_top(1), m_near(-1), m_far(1),
       m_rotationspeed(180.0 / M_PI), m_zoomFactor(1.0), m_xTrans(0.0),
       m_yTrans(0.0), m_zTrans(0.0) {
   m_quaternion.GLMatrix(&m_rotationmatrix[0]);
@@ -35,17 +34,17 @@ Viewport::Viewport(QSize logicalPixelSize)
 
 /**
  * Resize the viewport = size of the displaying widget.
- * @param logicalPixelSize Viewport width/height in logical pixels
+ * @param dimensions Viewport width/height in device pixels
  */
-void Viewport::resize(QSize logicalPixelSize) {
-  m_logicalPixelSize = std::move(logicalPixelSize);
+void Viewport::resize(QSize dimensions) {
+  m_dimensions = std::move(dimensions);
 }
 
 /**
  * Get the size of the viewport in logical pixels (size of the displaying
  * widget).
  */
-QSize Viewport::logicalPixelSize() const { return m_logicalPixelSize; }
+QSize Viewport::dimensions() const { return m_dimensions; }
 
 /**
  * This will set the projection. The parameters describe the dimensions of a
@@ -114,8 +113,7 @@ void Viewport::correctForAspectRatioAndZoom(double &xmin, double &xmax,
   // and correct the extent to make it loook normal
   double xSize = m_right - m_left;
   double ySize = m_top - m_bottom;
-  double r = ySize * m_logicalPixelSize.width() /
-             (xSize * m_logicalPixelSize.height());
+  double r = ySize * m_dimensions.width() / (xSize * m_dimensions.height());
   if (r < 1.0) {
     // ySize is too small
     ySize /= r;
@@ -159,7 +157,7 @@ void Viewport::setTranslation(double xval, double yval) {
  * Issue the OpenGL commands that define the viewport and projection.
  */
 void Viewport::applyProjection() const {
-  glViewport(0, 0, m_logicalPixelSize.width(), m_logicalPixelSize.height());
+  glViewport(0, 0, m_dimensions.width(), m_dimensions.height());
   glMatrixMode(GL_PROJECTION);
   glLoadIdentity();
   OpenGLError::check("GLViewport::issueGL()");
@@ -205,10 +203,10 @@ void Viewport::applyProjection() const {
 void Viewport::projectOnSphere(int a, int b, Mantid::Kernel::V3D &point) const {
   // z initiaised to zero if out of the sphere
   double z = 0;
-  auto x = static_cast<double>((2.0 * a - m_logicalPixelSize.width()) /
-                               m_logicalPixelSize.width());
-  auto y = static_cast<double>((m_logicalPixelSize.height() - 2.0 * b) /
-                               m_logicalPixelSize.height());
+  auto x = static_cast<double>((2.0 * a - m_dimensions.width()) /
+                               m_dimensions.width());
+  auto y = static_cast<double>((m_dimensions.height() - 2.0 * b) /
+                               m_dimensions.height());
   double norm = x * x + y * y;
   if (norm > 1.0) // The point is inside the sphere
   {
@@ -335,11 +333,11 @@ void Viewport::setRotation(const Mantid::Kernel::Quat &rot) {
 void Viewport::initZoomFrom(int a, int b) {
   if (a <= 0 || b <= 0)
     return;
-  if (a >= m_logicalPixelSize.width() || b >= m_logicalPixelSize.height())
+  if (a >= m_dimensions.width() || b >= m_dimensions.height())
     return;
   double z = 0;
-  auto x = static_cast<double>(m_logicalPixelSize.width() - a);
-  auto y = static_cast<double>(b - m_logicalPixelSize.height());
+  auto x = static_cast<double>(m_dimensions.width() - a);
+  auto y = static_cast<double>(b - m_dimensions.height());
   m_lastpoint(x, y, z);
 }
 
@@ -350,10 +348,10 @@ void Viewport::initZoomFrom(int a, int b) {
  * @param b :: The y mouse coordinate
  */
 void Viewport::generateZoomTo(int a, int b) {
-  if (a >= m_logicalPixelSize.width() || b >= m_logicalPixelSize.height() ||
-      a <= 0 || b <= 0)
+  if (a >= m_dimensions.width() || b >= m_dimensions.height() || a <= 0 ||
+      b <= 0)
     return;
-  auto y = static_cast<double>(b - m_logicalPixelSize.height());
+  auto y = static_cast<double>(b - m_dimensions.height());
   if (y == 0)
     y = m_lastpoint[1];
   double diff = m_lastpoint[1] / y;
@@ -461,11 +459,9 @@ void Viewport::generateTranslationPoint(int a, int b,
   double xmin, xmax, ymin, ymax, zmin, zmax;
   correctForAspectRatioAndZoom(xmin, xmax, ymin, ymax, zmin, zmax);
   x = static_cast<double>(
-      (xmin +
-       ((xmax - xmin) * ((double)a / (double)m_logicalPixelSize.width()))));
-  y = static_cast<double>(
-      (ymin + ((ymax - ymin) * (m_logicalPixelSize.height() - b) /
-               m_logicalPixelSize.height())));
+      (xmin + ((xmax - xmin) * ((double)a / (double)m_dimensions.width()))));
+  y = static_cast<double>((ymin + ((ymax - ymin) * (m_dimensions.height() - b) /
+                                   m_dimensions.height())));
   point(x, y, z);
 }
 

--- a/qt/widgets/instrumentview/src/Viewport.cpp
+++ b/qt/widgets/instrumentview/src/Viewport.cpp
@@ -22,12 +22,12 @@ namespace MantidWidgets {
 
 /**
  * Initialize with defaults.
- * @param w :: Vieport width in pixels
- * @param h :: Vieport height in pixels
+ * @param logicalPixelSize Viewport width/height in logical pixels
  */
-Viewport::Viewport(int w, int h)
-    : m_projectionType(Viewport::ORTHO), m_width(w), m_height(h), m_left(-1),
-      m_right(1), m_bottom(-1), m_top(1), m_near(-1), m_far(1),
+Viewport::Viewport(QSize logicalPixelSize)
+    : m_projectionType(Viewport::ORTHO),
+      m_logicalPixelSize(std::move(logicalPixelSize)), m_left(-1), m_right(1),
+      m_bottom(-1), m_top(1), m_near(-1), m_far(1),
       m_rotationspeed(180.0 / M_PI), m_zoomFactor(1.0), m_xTrans(0.0),
       m_yTrans(0.0), m_zTrans(0.0) {
   m_quaternion.GLMatrix(&m_rotationmatrix[0]);
@@ -35,25 +35,17 @@ Viewport::Viewport(int w, int h)
 
 /**
  * Resize the viewport = size of the displaying widget.
- * @param w :: New viewport width in pixels.
- * @param h :: New viewport height in pixels.
+ * @param logicalPixelSize Viewport width/height in logical pixels
  */
-void Viewport::resize(int w, int h) {
-  m_width = w;
-  m_height = h;
+void Viewport::resize(QSize logicalPixelSize) {
+  m_logicalPixelSize = std::move(logicalPixelSize);
 }
 
 /**
- * Get the size of the viewport in screen pixels (size of the displaying
+ * Get the size of the viewport in logical pixels (size of the displaying
  * widget).
- *
- * @param w :: Buffer to accept the viewport width value.
- * @param h :: Buffer to accept the viewport height value.
  */
-void Viewport::getViewport(int &w, int &h) const {
-  w = m_width;
-  h = m_height;
-}
+QSize Viewport::logicalPixelSize() const { return m_logicalPixelSize; }
 
 /**
  * This will set the projection. The parameters describe the dimensions of a
@@ -122,7 +114,8 @@ void Viewport::correctForAspectRatioAndZoom(double &xmin, double &xmax,
   // and correct the extent to make it loook normal
   double xSize = m_right - m_left;
   double ySize = m_top - m_bottom;
-  double r = ySize * m_width / (xSize * m_height);
+  double r = ySize * m_logicalPixelSize.width() /
+             (xSize * m_logicalPixelSize.height());
   if (r < 1.0) {
     // ySize is too small
     ySize /= r;
@@ -166,7 +159,7 @@ void Viewport::setTranslation(double xval, double yval) {
  * Issue the OpenGL commands that define the viewport and projection.
  */
 void Viewport::applyProjection() const {
-  glViewport(0, 0, m_width, m_height);
+  glViewport(0, 0, m_logicalPixelSize.width(), m_logicalPixelSize.height());
   glMatrixMode(GL_PROJECTION);
   glLoadIdentity();
   OpenGLError::check("GLViewport::issueGL()");
@@ -212,8 +205,10 @@ void Viewport::applyProjection() const {
 void Viewport::projectOnSphere(int a, int b, Mantid::Kernel::V3D &point) const {
   // z initiaised to zero if out of the sphere
   double z = 0;
-  auto x = static_cast<double>((2.0 * a - m_width) / m_width);
-  auto y = static_cast<double>((m_height - 2.0 * b) / m_height);
+  auto x = static_cast<double>((2.0 * a - m_logicalPixelSize.width()) /
+                               m_logicalPixelSize.width());
+  auto y = static_cast<double>((m_logicalPixelSize.height() - 2.0 * b) /
+                               m_logicalPixelSize.height());
   double norm = x * x + y * y;
   if (norm > 1.0) // The point is inside the sphere
   {
@@ -340,11 +335,11 @@ void Viewport::setRotation(const Mantid::Kernel::Quat &rot) {
 void Viewport::initZoomFrom(int a, int b) {
   if (a <= 0 || b <= 0)
     return;
-  if (a >= m_width || b >= m_height)
+  if (a >= m_logicalPixelSize.width() || b >= m_logicalPixelSize.height())
     return;
   double z = 0;
-  auto x = static_cast<double>(m_width - a);
-  auto y = static_cast<double>(b - m_height);
+  auto x = static_cast<double>(m_logicalPixelSize.width() - a);
+  auto y = static_cast<double>(b - m_logicalPixelSize.height());
   m_lastpoint(x, y, z);
 }
 
@@ -355,9 +350,10 @@ void Viewport::initZoomFrom(int a, int b) {
  * @param b :: The y mouse coordinate
  */
 void Viewport::generateZoomTo(int a, int b) {
-  if (a >= m_width || b >= m_height || a <= 0 || b <= 0)
+  if (a >= m_logicalPixelSize.width() || b >= m_logicalPixelSize.height() ||
+      a <= 0 || b <= 0)
     return;
-  auto y = static_cast<double>(b - m_height);
+  auto y = static_cast<double>(b - m_logicalPixelSize.height());
   if (y == 0)
     y = m_lastpoint[1];
   double diff = m_lastpoint[1] / y;
@@ -465,8 +461,11 @@ void Viewport::generateTranslationPoint(int a, int b,
   double xmin, xmax, ymin, ymax, zmin, zmax;
   correctForAspectRatioAndZoom(xmin, xmax, ymin, ymax, zmin, zmax);
   x = static_cast<double>(
-      (xmin + ((xmax - xmin) * ((double)a / (double)m_width))));
-  y = static_cast<double>((ymin + ((ymax - ymin) * (m_height - b) / m_height)));
+      (xmin +
+       ((xmax - xmin) * ((double)a / (double)m_logicalPixelSize.width()))));
+  y = static_cast<double>(
+      (ymin + ((ymax - ymin) * (m_logicalPixelSize.height() - b) /
+               m_logicalPixelSize.height())));
   point(x, y, z);
 }
 


### PR DESCRIPTION
**Description of work.**

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

**To test:**

* You will need a monitor connect with a 4K resolution
* Build and start workbench
* Open the instrument view on any instrument and flick between the projections -> each should fill the full widget area

Fixes #27244

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
-->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
