### PR TITLE
Fix Y error labels in muon analysis results tables

### DIFF
--- a/Framework/PythonInterface/mantid/api/src/Exports/ITableWorkspace.cpp
+++ b/Framework/PythonInterface/mantid/api/src/Exports/ITableWorkspace.cpp
@@ -283,7 +283,7 @@ int getLinkedYCol(ITableWorkspace &self, const object &column) {
  * @return index of the associated Y column
  */
 void setLinkedYCol(ITableWorkspace &self, const object &errColumn,
-                  const int dataColomn) {
+                   const int dataColomn) {
   // Find the column
   Mantid::API::Column_sptr colptr;
   if (STR_CHECK(errColumn.ptr())) {

--- a/Framework/PythonInterface/mantid/api/src/Exports/ITableWorkspace.cpp
+++ b/Framework/PythonInterface/mantid/api/src/Exports/ITableWorkspace.cpp
@@ -277,6 +277,25 @@ int getLinkedYCol(ITableWorkspace &self, const object &column) {
 }
 
 /**
+ * Link a data column associated with a Y error column
+ * @param self Reference to TableWorkspace this is called on
+ * @param column Name or index of error column
+ * @return index of the associated Y column
+ */
+void setLinkedYCol(ITableWorkspace &self, const object &errColumn,
+                  const int dataColomn) {
+  // Find the column
+  Mantid::API::Column_sptr colptr;
+  if (STR_CHECK(errColumn.ptr())) {
+    colptr = self.getColumn(extract<std::string>(errColumn)());
+  } else {
+    colptr = self.getColumn(extract<int>(errColumn)());
+  }
+
+  colptr->setLinkedYCol(dataColomn);
+}
+
+/**
  * Access a cell and return a corresponding Python type
  * @param self A reference to the TableWorkspace python object that we were
  * called on
@@ -657,8 +676,11 @@ void export_ITableWorkspace() {
               "Label)."))
 
       .def("getLinkedYCol", &getLinkedYCol, (arg("self"), arg("column")),
-           "Get the plot type of given column as an integer. "
-           "Accepts column name or index. ")
+           "set the data column associated with a given error column. ")
+
+      .def("setLinkedYCol", &setLinkedYCol,
+           (arg("self"), arg("errColumn"), arg("dataColumn")),
+           "set the data column associated with a given error column. ")
 
       .def("removeColumn", &ITableWorkspace::removeColumn,
            (arg("self"), arg("name")), "Remove the named column.")

--- a/Framework/PythonInterface/mantid/api/src/Exports/ITableWorkspace.cpp
+++ b/Framework/PythonInterface/mantid/api/src/Exports/ITableWorkspace.cpp
@@ -676,11 +676,11 @@ void export_ITableWorkspace() {
               "Label)."))
 
       .def("getLinkedYCol", &getLinkedYCol, (arg("self"), arg("column")),
-           "set the data column associated with a given error column. ")
+           "Get the data column associated with a given error column. ")
 
       .def("setLinkedYCol", &setLinkedYCol,
            (arg("self"), arg("errColumn"), arg("dataColumn")),
-           "set the data column associated with a given error column. ")
+           "Set the data column associated with a given error column. ")
 
       .def("removeColumn", &ITableWorkspace::removeColumn,
            (arg("self"), arg("name")), "Remove the named column.")

--- a/docs/source/concepts/TableWorkspaces.rst
+++ b/docs/source/concepts/TableWorkspaces.rst
@@ -56,9 +56,12 @@ Most of the time Table workspaces are the output of certain algorithms, but you 
     tableWS = CreateEmptyTableWorkspace()
 
     # Add some columns, Recognized types are: int,float,double,bool,str,V3D,long64
-    tableWS.addColumn(type="int",name="Detector ID")  
-    tableWS.addColumn(type="str",name="Detector Name")  
-    tableWS.addColumn(type="V3D",name="Detector Position")
+    tableWS.addColumn(type="int",name="Detector ID",plottype=6)
+    tableWS.addColumn(type="str",name="Detector Name",plottype=6)
+    tableWS.addColumn(type="V3D",name="Detector Position",plottype=6)
+    tableWS.addColumn(type='float',name="Value",plottype=2)
+    tableWS.addColumn(type='float',name="Error",plottype=5)
+    tableWS.setLinkedYCol(4, 3)
 
     # Populate the columns for three detectors
     detIDList = range(1,4)
@@ -66,7 +69,9 @@ Most of the time Table workspaces are the output of certain algorithms, but you 
     for j in range(len(detIDList)):
         nextRow = { 'Detector ID': detIDList[j], 
                     'Detector Name': "Detector {0}".format(detIDList[j]),
-                    'Detector Position': detPosList[j] }
+                    'Detector Position': detPosList[j],
+                    'Value': 10,
+                    'Error': 1 }
         tableWS.addRow ( nextRow )
 
 Table Workspace Properties

--- a/docs/source/release/v5.1.0/mantidworkbench.rst
+++ b/docs/source/release/v5.1.0/mantidworkbench.rst
@@ -116,6 +116,7 @@ Improvements
 - When showing monochromatic workspaces, the instrument widget will not show the integration bar, nor the pick widget the detector spectra graph.
 - In the instrument widget's rendering tab, added a Reset view button to restore to default projection.
 - In the instrument widget's draw tab, added the option to mask, draw ROI and group single pixel and tube.
+- `TableWorkspaces` can now have columns containing errors linked to corresponding columns containing values, using the `setLinkedYCol(errColumn, dataColumn)`.
 
 
 Bugfixes

--- a/scripts/Muon/GUI/Common/results_tab_widget/results_tab_model.py
+++ b/scripts/Muon/GUI/Common/results_tab_widget/results_tab_model.py
@@ -275,6 +275,7 @@ class ResultsTabModel(object):
             if _param_error_should_be_displayed(name):
                 table.addColumn('float', _error_column_name(name),
                                 TableColumnType.YErr.value)
+                table.setLinkedYCol(table.columnCount()-1, table.columnCount()-2)
         return table
 
     def on_new_fit_performed(self):

--- a/scripts/Muon/GUI/Common/results_tab_widget/results_tab_model.py
+++ b/scripts/Muon/GUI/Common/results_tab_widget/results_tab_model.py
@@ -275,6 +275,8 @@ class ResultsTabModel(object):
             if _param_error_should_be_displayed(name):
                 table.addColumn('float', _error_column_name(name),
                                 TableColumnType.YErr.value)
+                # The error column will be the most recent one added (columnCount-1) and is corresponding value will be
+                # the second to last (columnCount-2).
                 table.setLinkedYCol(table.columnCount()-1, table.columnCount()-2)
         return table
 


### PR DESCRIPTION
**Description of work.**

The output results table from Muon analysis should label the colombs with `Y0, Y1, Y2...` and `Y0_err, Y1_err, Y2_err...` for the values and errors respectivly. This pr links the two colombs so this label is propperly added to the errors.

**To test:**

1. Open Muon Analysis.
2. Load EMU20918.
3. Perform a fit.
4. Go to the results tab and output the results.
5. check that the colomns in the results table have the right labels linking values with their errors.

Fixes #29409 


*This does not require release notes* because it fixes a bug that was not in the previous release.

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
