### PR TITLE
Ensure DeadTime resets on Muon GUIs when instrument changes

### DIFF
--- a/docs/source/release/v5.1.0/muon.rst
+++ b/docs/source/release/v5.1.0/muon.rst
@@ -80,7 +80,7 @@ Bug fixes
 - Fixed an issue with setting the current workspace before adding a function.
 - Fixed an issue with the results tab not updating correctly after multiple fits with different functions.
 - Fixed an issue where Muon Analysis and Frequency Domain Analysis gui was not properly disabling during calculations.
-
+- Fixed an issue where Muon Analysis and Frequency Domain Analysis was not correctly resetting DeadTime property to default when a user changes the instrument
 
 Elemental Analysis 
 ##################

--- a/scripts/Muon/GUI/Common/home_instrument_widget/home_instrument_widget_presenter.py
+++ b/scripts/Muon/GUI/Common/home_instrument_widget/home_instrument_widget_presenter.py
@@ -171,6 +171,7 @@ class InstrumentWidgetPresenter(HomeTabSubWidget):
         if instrument != self._model._data.instrument:
             self._model._data.instrument = instrument
             self._view.set_instrument(instrument, block=True)
+            self._model.set_dead_time_from_data()
 
     def handle_double_pulse_time_changed(self):
         double_pulse_time = self._view.get_double_pulse_time()

--- a/scripts/test/Muon/home_instrument_widget_test.py
+++ b/scripts/test/Muon/home_instrument_widget_test.py
@@ -220,6 +220,16 @@ class HomeTabInstrumentPresenterTest(unittest.TestCase):
         self.assertEqual(self.view.dead_time_file_selector.itemText(3), 'table_3')
         self.assertEqual(self.gui_variable_observer.update.call_count, 0)
 
+    def test_that_when_deadtime_option_is_not_fromFile_is_set_to_fromFile_on_instrument_change_and_update_occurs(self):
+        self.view.set_instrument('EMU')
+        self.view.dead_time_selector.setCurrentIndex(DEADTIME_WORKSPACE)
+        self.context.gui_context['DeadTimeSource'] = 'FromADS'
+        self.view.set_instrument('MUSR')
+        self.presenter.update_view_from_model()
+
+        self.assertEqual(self.context.gui_context['DeadTimeSource'], "FromFile")
+        self.assertEqual(self.view.dead_time_selector.currentIndex(), DEADTIME_DATA_FILE)
+
     def test_that_returning_to_None_options_hides_table_workspace_selector(self):
         self.view.dead_time_selector.setCurrentIndex(DEADTIME_WORKSPACE)
         self.context.gui_context['DeadTimeSource'] = 'FromADS'


### PR DESCRIPTION
**Description of work.**
Force the Muon GUIs to reset the DeadTime property in the Instrument Widget when the instrument is changed.


**To test:**
- Open Workbench
- Open Interfaces->Muon Analysis
- Load in an EMU nexus file
- Set dead time to `from table workspace`
- Then change instrument 
- It should be reset to `from file`
<!-- Instructions for testing. -->

Fixes #29412 . <!-- and fix #xxxx or close #xxxx xor resolves #xxxx -->
<!-- alternative
*There is no associated issue.*
-->

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
-->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
