### PR TITLE
ALC: Plot corrected data from latest fit only in base line modelling tab

### DIFF
--- a/docs/source/release/v5.1.0/muon.rst
+++ b/docs/source/release/v5.1.0/muon.rst
@@ -82,6 +82,7 @@ Bug fixes
 - Fixed an issue where Muon Analysis and Frequency Domain Analysis gui was not properly disabling during calculations.
 - Fixed an issue where Muon Analysis and Frequency Domain Analysis was not correctly resetting DeadTime property to default when a user changes the instrument
 - Fixed issue where select data was incorrectly enabling.
+- Fixed an issue in the ALC interface baseline fit where corrected data from all fits were plotted at the same time in the corrected data tab. Now only corrected data from the most recent fit is plotted.
 
 Elemental Analysis 
 ##################

--- a/docs/source/release/v5.1.0/muon.rst
+++ b/docs/source/release/v5.1.0/muon.rst
@@ -82,6 +82,12 @@ Bug fixes
 - Fixed an issue where Muon Analysis and Frequency Domain Analysis gui was not properly disabling during calculations.
 - Fixed an issue where Muon Analysis and Frequency Domain Analysis was not correctly resetting DeadTime property to default when a user changes the instrument
 - Fixed issue where select data was incorrectly enabling.
+
+ALC
+###
+
+Bug fixes
+----------
 - Fixed an issue in the ALC interface baseline fit where corrected data from all fits were plotted at the same time in the corrected data tab. Now only corrected data from the most recent fit is plotted.
 
 Elemental Analysis 

--- a/qt/scientific_interfaces/Muon/ALCBaselineModellingView.cpp
+++ b/qt/scientific_interfaces/Muon/ALCBaselineModellingView.cpp
@@ -91,6 +91,8 @@ void ALCBaselineModellingView::setDataCurve(MatrixWorkspace_sptr workspace,
 void ALCBaselineModellingView::setCorrectedCurve(
     MatrixWorkspace_sptr workspace, std::size_t const &workspaceIndex) {
   const auto kwargs = getPlotKwargs(m_ui.correctedPlot, "Corrected");
+
+  m_ui.correctedPlot->clear();
   m_ui.correctedPlot->addSpectrum("Corrected", workspace, workspaceIndex,
                                   Qt::blue, kwargs);
 }


### PR DESCRIPTION
This PR fixes a bug in the ALC interface base line modelling tab where, if you ran two fits, the corrected data tab would plot the corrected data from both fits. It now only plots corrected data from the most recent fit, by clearing the corrected data plot before plotting the new data.

**To test:**
1. Open the ALC interface and load some data
2. On the baseline fit, run a fit and check corrected data is plotted on the corrected data tab.
3. Run a different fit, and check that only the new corrected data is plotted.

Fixes #29408 

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
