### PR TITLE
Added Clear All Memory Action To File Menu On Workbench

### DIFF
--- a/qt/applications/workbench/CMakeLists.txt
+++ b/qt/applications/workbench/CMakeLists.txt
@@ -139,6 +139,7 @@ endif()
 # Testing
 set(TEST_FILES
     workbench/config/test/test_user.py
+    workbench/test/mainwindowtest.py
     workbench/test/test_import.py
     workbench/plotting/plotscriptgenerator/test/test_plotscriptgeneratoraxes.py
     workbench/plotting/plotscriptgenerator/test/test_plotscriptgeneratorcolorfills.py

--- a/qt/applications/workbench/workbench/app/mainwindow.py
+++ b/qt/applications/workbench/workbench/app/mainwindow.py
@@ -254,7 +254,7 @@ class MainWindow(QMainWindow):
                                     shortcut="Ctrl+Q")
         action_clear_all_memory = create_action(self,
                                                 "Clear All Memory",
-                                                on_triggered=self.clear_all_memory,
+                                                on_triggered=self.clear_all_memory_action,
                                                 shortcut="Ctrl+Shift+L")
 
         menu_recently_closed_scripts = RecentlyClosedScriptsMenu(self)
@@ -624,14 +624,25 @@ class MainWindow(QMainWindow):
         settings.show()
         settings.general_settings.focus_layout_box()
 
-    def clear_all_memory(self):
-        msg = QMessageBox(QMessageBox.Question, "Clear All", "All workspaces and windows will be removed.\nAre you sure?")
+    def clear_all_memory_action(self):
+        """
+        Creates Question QMessageBox to check user wants to clear all memory
+        when action is pressed from file menu
+        """
+        msg = QMessageBox(QMessageBox.Question,
+                          "Clear All", "All workspaces and windows will be removed.\nAre you sure?")
         msg.addButton(QMessageBox.Ok)
         msg.addButton(QMessageBox.Cancel)
-        msg.setWindowIcon(QIcon(':/images/mantid_workbench.png'))
+        msg.setWindowIcon(QIcon(':/images/MantidIcon.ico'))
         reply = msg.exec()
         if reply == QMessageBox.Ok:
-            FrameworkManager.Instance().clear()
+            self.clear_all_memory()
+
+    def clear_all_memory(self):
+        """
+        Wrapper for call to FrameworkManager to clear all memory
+        """
+        FrameworkManager.Instance().clear()
 
     def config_updated(self):
         """

--- a/qt/applications/workbench/workbench/app/mainwindow.py
+++ b/qt/applications/workbench/workbench/app/mainwindow.py
@@ -12,6 +12,7 @@ Defines the QMainWindow of the application and the main() entry point.
 """
 import os
 
+from mantid.api import FrameworkManager
 from mantid.kernel import ConfigService, logger
 from workbench.app import MAIN_WINDOW_OBJECT_NAME, MAIN_WINDOW_TITLE
 from workbench.utils.windowfinder import find_window
@@ -22,7 +23,7 @@ from workbench.widgets.settings.presenter import SettingsPresenter
 # Qt
 # -----------------------------------------------------------------------------
 from qtpy.QtCore import (QEventLoop, Qt, QPoint, QSize)  # noqa
-from qtpy.QtGui import (QColor, QFontDatabase, QGuiApplication, QPixmap)  # noqa
+from qtpy.QtGui import (QColor, QFontDatabase, QGuiApplication, QIcon, QPixmap)  # noqa
 from qtpy.QtWidgets import (QApplication, QDesktopWidget, QFileDialog, QMainWindow,
                             QSplashScreen, QMessageBox)  # noqa
 from mantidqt.algorithminputhistory import AlgorithmInputHistory  # noqa
@@ -251,6 +252,10 @@ class MainWindow(QMainWindow):
                                     "&Quit",
                                     on_triggered=self.close,
                                     shortcut="Ctrl+Q")
+        action_clear_all_memory = create_action(self,
+                                                "Clear All Memory",
+                                                on_triggered=self.clear_all_memory,
+                                                shortcut="Ctrl+Shift+L")
 
         menu_recently_closed_scripts = RecentlyClosedScriptsMenu(self)
         self.editor.editors.sig_tab_closed.connect(menu_recently_closed_scripts.add_script_to_settings)
@@ -259,7 +264,7 @@ class MainWindow(QMainWindow):
             action_open, action_load_project, None, action_save_script, action_save_script_as,
             menu_recently_closed_scripts, action_generate_ws_script, None, action_save_project,
             action_save_project_as, None, action_settings, None, action_manage_directories, None,
-            action_script_repository, None, action_quit
+            action_script_repository, None, action_clear_all_memory, None, action_quit
         ]
 
         # view menu
@@ -618,6 +623,15 @@ class MainWindow(QMainWindow):
         settings = SettingsPresenter(self)
         settings.show()
         settings.general_settings.focus_layout_box()
+
+    def clear_all_memory(self):
+        msg = QMessageBox(QMessageBox.Question, "Clear All", "All workspaces and windows will be removed.\nAre you sure?")
+        msg.addButton(QMessageBox.Ok)
+        msg.addButton(QMessageBox.Cancel)
+        msg.setWindowIcon(QIcon(':/images/mantid_workbench.png'))
+        reply = msg.exec()
+        if reply == QMessageBox.Ok:
+            FrameworkManager.Instance().clear()
 
     def config_updated(self):
         """

--- a/qt/applications/workbench/workbench/test/mainwindowtest.py
+++ b/qt/applications/workbench/workbench/test/mainwindowtest.py
@@ -12,13 +12,20 @@ Defines the QMainWindow of the application and the main() entry point.
 """
 import unittest
 
-from unittest.mock import patch
-from workbench.app.mainwindow import MainWindow
+from unittest.mock import patch, MagicMock
+
+from mantidqt.utils.qt.testing import start_qapplication
+
+from mantid.api import FrameworkManager
+
+from qtpy.QtWidgets import QMessageBox
 
 
+@start_qapplication
 class MainWindowTest(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
+        from workbench.app.mainwindow import MainWindow
         cls.main_window = MainWindow()
 
     @patch("workbench.app.mainwindow.find_window")
@@ -39,6 +46,32 @@ class MainWindowTest(unittest.TestCase):
             mock_interface_manager.createSubWindow.assert_called_with(interface_name)
             self.main_window.launch_custom_cpp_gui(second_interface_name)
             mock_interface_manager.createSubWindow.assert_called_with(second_interface_name)
+
+    @patch("workbench.app.mainwindow.FrameworkManager")
+    @patch("workbench.app.mainwindow.QMessageBox")
+    def test_clear_all_memory_calls_frameworkmanager_when_user_presses_ok(self,mock_msg_box, mock_fm):
+        mock_msg_box_instance = MagicMock(spec=QMessageBox)
+        mock_msg_box.return_value = mock_msg_box_instance
+        mock_msg_box_instance.exec.return_value = mock_msg_box.Ok
+        mock_fm_instance = MagicMock(spec=FrameworkManager)
+        mock_fm.Instance.return_value = mock_fm_instance
+
+        self.main_window.clear_all_memory_action()
+
+        mock_fm_instance.clear.assert_called_once()
+
+    @patch("workbench.app.mainwindow.FrameworkManager")
+    @patch("workbench.app.mainwindow.QMessageBox")
+    def test_clear_all_memory_does_not_call_frameworkmanager_when_user_presses_cancel(self, mock_msg_box, mock_fm):
+        mock_msg_box_instance = MagicMock(spec=QMessageBox)
+        mock_msg_box.return_value = mock_msg_box_instance
+        mock_msg_box_instance.exec.return_value = mock_msg_box.Cancel
+        mock_fm_instance = MagicMock(spec=FrameworkManager)
+        mock_fm.Instance.return_value = mock_fm_instance
+
+        self.main_window.clear_all_memory_action()
+
+        mock_fm_instance.clear.assert_not_called()
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
**Description of work.**
Added a new action in the main File menu called Clear All Memory which makes a call to the frameworkmanager to clear all memory associated with the AlgorithmManager and the Analysis & Instrument data services.

**To test:**

1. Start Mantid Workbench and go to File > Clear All Memory
2. Check pressing Okay here doesn't break anything and you are returned to workbench
3. Create some different workspaces and create a range of plots 
4. Go to File > Clear All Memory and press Cancel and check you are returned to Workbench in the same state as before
5. Now do the same but press Okay and check all Workspaces and plots etc. have been removed

Fixes #29423  

*This does not require release notes* because **it is a small addition to the file menu**

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
