### PR TITLE
Add test for Larmor StateMove throwing if RB is None

### DIFF
--- a/scripts/SANS/sans/state/StateObjects/StateMoveDetectors.py
+++ b/scripts/SANS/sans/state/StateObjects/StateMoveDetectors.py
@@ -276,7 +276,13 @@ class StateMoveLARMORBuilder(object):
 
     def _set_conversion_value(self, data_info):
         run_number = data_info.sample_scatter_run_number
-        self.conversion_value = 1000. if run_number <= 2217 else 1.
+
+        # If we are going through init before file was selected, lets assume were using
+        # a newer file so in the probable-case the division is the same as Pos 2
+        # When a run number is entered this re-runs anyway overwriting our assumptions
+        # User files after 2217 use Si. units for x but not y
+        if run_number is None or run_number > 2217:
+            self.conversion_value = 1.
 
     def build(self):
         return copy.copy(self.state)

--- a/scripts/test/SANS/state/move_test.py
+++ b/scripts/test/SANS/state/move_test.py
@@ -5,6 +5,7 @@
 #   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
 # SPDX - License - Identifier: GPL - 3.0 +
 import unittest
+from unittest import mock
 
 from sans.common.enums import (CanonicalCoordinates, SANSFacility, DetectorType, SANSInstrument)
 from sans.state.StateObjects.StateData import get_data_builder
@@ -167,6 +168,17 @@ class StateMoveBuilderTest(unittest.TestCase):
         self.assertEqual(state.detectors[DetectorType.LAB.value].detector_name,  "rear-detector")
         self.assertEqual(state.monitor_names[str(4)],  "monitor4")
         self.assertEqual(len(state.monitor_names),  4)
+
+    def test_state_with_no_file_info_can_be_built(self):
+        data_info = mock.NonCallableMock()
+        data_info.instrument = SANSInstrument.LARMOR
+        data_info.idf_file_path = None
+        data_info.ipf_file_path = None
+        # This will happen if the user has not selected a run number
+        data_info.sample_scatter_run_number = None
+
+        builder = get_move_builder(data_info)
+        self.assertEqual(1., builder.conversion_value)
 
     def test_that_state_for_larmor_can_be_built(self):
         # Arrange


### PR DESCRIPTION
**Description of work.**

Adds a test to check for StateMove throwing when the run number is none.
This happens when we add a user file without a run number in the box.

I checked with the SANS team and Larmor uses their x dim in
m, and y in mm for runs after 2217. So we want to use the same divider
to keep the display consistent until they load in run data.


**Report to:** @smk78 

**To test:**

- Open the SANS GUI
- Load the following userfile: 
[USER_Larmor_202A_Changer_r51476.txt](https://github.com/mantidproject/mantid/files/5219147/USER_Larmor_202A_Changer_r51476.txt)
- Go to beam centre finder 
- Check centre positions look sane mm values in m form (e.g. 0.01 and 0.001). 
They should not be > 1 (in meters) or tiny (like 1e-5)

Note the display of meters is being done in #29415 


Fixes #29414 


*This does not require release notes* because regression was introduced recently

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
