### PR TITLE
Update A^-1 to A for wavelength step in SANS Settings

### DIFF
--- a/scripts/Interface/ui/sans_isis/sans_data_processor_gui.py
+++ b/scripts/Interface/ui/sans_isis/sans_data_processor_gui.py
@@ -364,7 +364,7 @@ class SANSDataProcessorGui(QMainWindow,
     def _on_wavelength_step_type_changed(self):
         if self.wavelength_step_type == RangeStepType.RANGE_LIN:
             self.wavelength_stacked_widget.setCurrentIndex(1)
-            self.wavelength_step_label.setText(u'Step [\u00c5^-1]')
+            self.wavelength_step_label.setText(u'Step [\u00c5]')
         elif self.wavelength_step_type == RangeStepType.RANGE_LOG:
             self.wavelength_stacked_widget.setCurrentIndex(1)
             self.wavelength_step_label.setText(u'Step [d\u03BB/\u03BB]')
@@ -373,7 +373,7 @@ class SANSDataProcessorGui(QMainWindow,
             self.wavelength_step_label.setText(u'Step [d\u03BB/\u03BB]')
         elif self.wavelength_step_type == RangeStepType.LIN:
             self.wavelength_stacked_widget.setCurrentIndex(0)
-            self.wavelength_step_label.setText(u'Step [\u00c5^-1]')
+            self.wavelength_step_label.setText(u'Step [\u00c5]')
 
     def create_data_table(self):
         # Delete an already existing table


### PR DESCRIPTION
**Description of work.**

Updates the step label from Angstrom ^-1 to Anstrom. This was pointed out by
Richard during unscripted testing


**To test:**

- Open the SANS GUI
- Go to settings
- Go to Q, Wavelength...
- Under the wavelength box check that Step is simply Angstrom, not Angstrom ^-1 (see original issue for image)
- Change step type to range Lin, check it's still as above
- Change step type back to Lin, check it's still as above
- Change step type to Log/RangeLog and it should still be `dLambda / Lambda`

Fixes #29442 

*This does not require release notes* because it's a minor display issue and personally I believe it would add noise than benefit users

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
