### PR TITLE
Fixed elemental analysis reload bug

### DIFF
--- a/docs/source/release/v5.1.0/muon.rst
+++ b/docs/source/release/v5.1.0/muon.rst
@@ -91,5 +91,8 @@ New Features
 - Added a deselect all elements button.
 - Fixed an issue where groups were all being plotted on the same tiled plot.
 
+Bug fixes
+---------
+- Fixed an issue with reloading data after closing gui.
 
 :ref:`Release 5.1.0 <v5.1.0>`

--- a/scripts/Muon/GUI/ElementalAnalysis/LoadWidget/load_utils.py
+++ b/scripts/Muon/GUI/ElementalAnalysis/LoadWidget/load_utils.py
@@ -31,6 +31,7 @@ class LModel(object):
             workspace.getAxis(0).setUnit("Label").setLabel("Energy", "keV")
 
     def load_run(self):
+
         to_load = search_user_dirs(self.run)
         if not to_load:
             return None
@@ -48,6 +49,11 @@ class LModel(object):
         for ws_name in workspaces.values():
             loaded_detectors[ws_name[0]] = 1
         num_loaded_detectors = len(loaded_detectors)
+
+        if mantid.AnalysisDataService.Instance().doesExist(str(self.run)):
+            run_workspace = mantid.AnalysisDataService.Instance().retrieve(str(self.run))
+            mantid.DeleteWorkspace(run_workspace)
+
         self._load(workspaces)
         self.loaded_runs.update({self.run: merge_workspaces(self.run, workspaces.values())})
         self.num_loaded_detectors[self.run] = num_loaded_detectors


### PR DESCRIPTION
**Description of work.**
Fixed an issue where reloading a run after closing the elemental analysis gui causes an error.

**To test:**
1.Open elemental analysis
2.Load a run
3.Close the gui
4.Reopen it
5.Try to load the same run again - error

Fixes #29081 . 

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
