### PR TITLE
Replace deprecated alg in sans

### DIFF
--- a/scripts/SANS/sans/algorithm_detail/calibration.py
+++ b/scripts/SANS/sans/algorithm_detail/calibration.py
@@ -34,6 +34,9 @@ def apply_calibration(calibration_file_name, workspaces, monitor_workspaces, use
     """
     full_file_path = find_full_file_path(calibration_file_name)
 
+    if not full_file_path:
+        raise IOError(f"{calibration_file_name} was not found")
+
     # Check for the sample scatter and the can scatter workspaces
     workspaces_to_calibrate = {}
     if SANSDataType.SAMPLE_SCATTER in workspaces:
@@ -119,7 +122,7 @@ def get_calibration_workspace(full_file_path, use_loaded, parent_alg):
 
     if calibration_workspace is None:
         if not isfile(full_file_path):
-            raise RuntimeError("SANSCalibration: The file for  {0} does not seem to exist".format(full_file_path))
+            raise RuntimeError("SANSCalibration: The file for {0} does not seem to exist".format(full_file_path))
         loader_name = "LoadNexusProcessed"
         loader_options = {"Filename": full_file_path,
                           "OutputWorkspace": "dummy"}

--- a/scripts/SANS/sans/algorithm_detail/mask_workspace.py
+++ b/scripts/SANS/sans/algorithm_detail/mask_workspace.py
@@ -125,8 +125,7 @@ def mask_with_mask_files(mask_info, workspace):
         load_options = {"Instrument": idf_path,
                         "OutputWorkspace": EMPTY_NAME}
         load_alg = create_unmanaged_algorithm(load_name, **load_options)
-        dummy_params = {"OutputWorkspace": EMPTY_NAME}
-        mask_alg = create_unmanaged_algorithm("MaskInstrument", **dummy_params)
+        mask_alg = create_unmanaged_algorithm("MaskDetectors")
 
         # Masker
         for mask_file in mask_files:
@@ -141,11 +140,10 @@ def mask_with_mask_files(mask_info, workspace):
             # a) Extract detectors to mask from MaskWorkspace
             det_ids = masking_workspace.getMaskedDetectors()
             # b) Mask the detector ids on the instrument
-            mask_alg.setProperty("InputWorkspace", workspace)
-            mask_alg.setProperty("OutputWorkspace", workspace)
-            mask_alg.setProperty("DetectorIDs", det_ids)
+            mask_alg.setProperty("Workspace", workspace)
+            mask_alg.setProperty("DetectorList", det_ids)
             mask_alg.execute()
-            workspace = mask_alg.getProperty("OutputWorkspace").value
+            workspace = mask_alg.getProperty("Workspace").value
     return workspace
 
 

--- a/scripts/SANS/sans/gui_logic/presenter/masking_table_presenter.py
+++ b/scripts/SANS/sans/gui_logic/presenter/masking_table_presenter.py
@@ -157,7 +157,7 @@ class MaskingTablePresenter(object):
             raise e  # propagate errors for run_tab_presenter to deal with
 
         if not state:
-            self._logger.error("You can only show a masked workspace if a user file has been loaded and there"
+            self._logger.error("You can only show a masked workspace if a user file has been loaded and a"
                                "valid sample scatter entry has been provided in the selected row.")
             self._view.set_display_mask_button_to_normal()
             return

--- a/scripts/SANS/sans/gui_logic/presenter/run_tab_presenter.py
+++ b/scripts/SANS/sans/gui_logic/presenter/run_tab_presenter.py
@@ -963,7 +963,7 @@ class RunTabPresenter(PresenterCommon):
         row_entry = self._table_model.get_row(row_index)
         states, errors = self.get_states(row_entries=[row_entry], file_lookup=file_lookup,
                                          suppress_warnings=suppress_warnings)
-        if states is None:
+        if not states:
             if not suppress_warnings:
                 self.sans_logger.warning(
                     "There does not seem to be data for a row {}.".format(row_index))

--- a/scripts/test/SANS/gui_logic/run_tab_presenter_test.py
+++ b/scripts/test/SANS/gui_logic/run_tab_presenter_test.py
@@ -202,6 +202,14 @@ class RunTabPresenterTest(unittest.TestCase):
 
         self.assertEqual(expected_states[state_key].all_states, state)
 
+    def test_get_state_for_row_returns_empty_for_empty(self):
+        self.presenter.get_states = mock.Mock(return_value=({}, None))
+        self.presenter.sans_logger = mock.Mock()
+        state = self.presenter.get_state_for_row(0)
+
+        self.assertIsNone(state)
+        self.presenter.sans_logger.warning.assert_called_once()
+
     def test_on_data_changed_calls_update_rows(self):
         batch_file_path, user_file_path, _ = self._get_files_and_mock_presenter(BATCH_FILE_TEST_CONTENT_1)
         self.presenter._masking_table_presenter = mock.MagicMock()


### PR DESCRIPTION
**Description of work.**

- Fixes warnings for deprecated algs seen in #29443 
- Fixes an unhandled exception which was thrown before we could error that a sample number is required
- Fixes a bad error message which was thrown for a missing file, but did not contain the filename it was looking for

**Report to:** @smk78 

**To test:**
- Download the following SANS2D empty beam data: 
[SANS2D.zip](https://github.com/mantidproject/mantid/files/5219612/SANS2D.zip)
- Extract and add to data directories
- Open the SANS GUI
- Use the user file in the extracted folder
- Set the sample scatter to `42123`
- Hit load
- Go to Settings -> Mask -> Display Mask
- If the instrument view appears with no warnings / errors about deprecated algs this is fixed

Fixes #29443 . 

*This does not require release notes* because it was deprecated in the current release.

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
