### PR TITLE
Add W matrix for MDNorm output

### DIFF
--- a/Framework/MDAlgorithms/src/MDNorm.cpp
+++ b/Framework/MDAlgorithms/src/MDNorm.cpp
@@ -1045,6 +1045,9 @@ DataObjects::MDHistoWorkspace_sptr MDNorm::binInputWS(
               outputMDHWS->getDimension(i)));
       mdHistoDimension->setMDFrame(*hklFrame);
     }
+    // add W_matrix
+    auto ei = outputMDHWS->getExperimentInfo(0);
+    ei->mutableRun().addProperty("W_MATRIX", m_W.getVector(), true);
   }
 
   outputMDHWS->setDisplayNormalization(Mantid::API::NoNormalization);

--- a/docs/source/release/v5.1.0/diffraction.rst
+++ b/docs/source/release/v5.1.0/diffraction.rst
@@ -67,5 +67,6 @@ Improvements
 - New algorithm :ref:`AddAbsorptionWeightedPathLengths <algm-AddAbsorptionWeightedPathLengths-v1>` for calculating the absorption weighted path length for each peak in a peaks workspace. The absorption weighted path length is used downstream from Mantid in extinction correction calculations
 - Can now edit H,K,L in the table of a peaks workspace in workbench (now consistent with Mantid Plot)
 - The peaks workspace table display now contains a column showing the value of the intensity/sigma for each peak.
+- SliceViewer can now correctly display non-orthogonal axes for output of :ref:`MDNorm <algm-MDNorm>`
 
 :ref:`Release 5.1.0 <v5.1.0>`

--- a/docs/source/release/v5.1.0/direct_geometry.rst
+++ b/docs/source/release/v5.1.0/direct_geometry.rst
@@ -32,5 +32,6 @@ Bugfixes
 - A bug introduced in v5.0 causing error values to tend to zero on multiple instances of :ref:`Rebin2D <algm-Rebin2D>` on the same workspace has been fixed.
 - A bug in the validation of temporary workpaces for :ref:`MDNorm <algm-MDNorm>` has been fixed. One can now use temporary workspaces in any order when slicing.
 - Fixed bugs in the DGSPlanner interface, that cause errors when using negative values
+- SliceViewer can now correctly display non-orthogonal axes for output of :ref:`MDNorm <algm-MDNorm>`
 
 :ref:`Release 5.1.0 <v5.1.0>`


### PR DESCRIPTION
**Description of work.**
Allows non-orthogonal axes for output of MDNorm

**To test:**
Follow the first script in the documentation of [MDNorm](https://docs.mantidproject.org/nightly/algorithms/MDNorm-v1.html)
Data is from Systemtests. Open sliceviewer. `110` and `1-10` should be perpendicular, even if you turn on non-orthogonal axes. Change `QDimension0` to `'1,0,0'` and `QDimension1` to `'1,-1,0'`. These axes should show up at 60 degrees when in non-orthogonal mode.

Fixes #28706 

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
