### PR TITLE
Convert some values from metres to millimetres for display in SANS user interface

### DIFF
--- a/scripts/Interface/ui/sans_isis/beam_centre.ui
+++ b/scripts/Interface/ui/sans_isis/beam_centre.ui
@@ -38,7 +38,7 @@
          <item row="0" column="0">
           <widget class="QLabel" name="lab_centre_label">
            <property name="text">
-            <string>Centre Position LAB</string>
+            <string>Centre Position LAB (mm)</string>
            </property>
           </widget>
          </item>
@@ -55,7 +55,7 @@
          <item row="2" column="0">
           <widget class="QLabel" name="hab_centre_label">
            <property name="text">
-            <string>Centre Position HAB</string>
+            <string>Centre Position HAB (mm)</string>
            </property>
           </widget>
          </item>
@@ -176,7 +176,7 @@
             <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;The radius limits which will be considered when finding the beam centre.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
            </property>
            <property name="text">
-            <string>Radius Limits(mm)</string>
+            <string>Radius Limits (mm)</string>
            </property>
           </widget>
          </item>

--- a/scripts/Interface/ui/sans_isis/sans_data_processor_window.ui
+++ b/scripts/Interface/ui/sans_isis/sans_data_processor_window.ui
@@ -941,7 +941,7 @@ QGroupBox::title {
                           <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;The z offset of the sample position.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
                          </property>
                          <property name="text">
-                          <string>Z Offset</string>
+                          <string>Z Offset [mm]</string>
                          </property>
                         </widget>
                        </item>

--- a/scripts/SANS/sans/gui_logic/models/beam_centre_model.py
+++ b/scripts/SANS/sans/gui_logic/models/beam_centre_model.py
@@ -7,6 +7,7 @@
 from mantid.kernel import Logger
 from sans.common.enums import (FindDirectionEnum, DetectorType, SANSInstrument)
 from sans.state.AllStates import AllStates
+from SANSUtility import (meter_2_millimeter, millimeter_2_meter)
 
 
 class BeamCentreModel(object):
@@ -19,7 +20,7 @@ class BeamCentreModel(object):
         self._r_max = 0
         self._left_right = True
         self._up_down = True
-        self._tolerance = 0.0001251
+        self._tolerance = 1.251E-07 # metres
         self._lab_pos_1 = ''
         self._lab_pos_2 = ''
         self._hab_pos_2 = ''
@@ -41,14 +42,14 @@ class BeamCentreModel(object):
 
     def reset_inst_defaults(self, instrument):
         if instrument is SANSInstrument.LOQ:
-            self._r_min = 96
-            self._r_max = 216
+            self._r_min = 0.096 # metres
+            self._r_max = 0.216 # metres
 
             # TODO HAB on LOQ prefers 96-750
         else:
             # All other instruments hard-code this as follows
-            self._r_min = 60
-            self._r_max = 280
+            self._r_min = 0.06 # metres
+            self._r_max = 0.280 # metres
 
     def find_beam_centre(self, state: AllStates):
         """
@@ -91,11 +92,11 @@ class BeamCentreModel(object):
 
     def _update_centre_positions(self, results):
         if self.component is DetectorType.LAB:
-            self.lab_pos_1 = results["pos1"]
-            self.lab_pos_2 = results["pos2"]
+            self._lab_pos_1 = results["pos1"]
+            self._lab_pos_2 = results["pos2"]
         elif self.component is DetectorType.HAB:
-            self.hab_pos_1 = results['pos1']
-            self.hab_pos_2 = results['pos2']
+            self._hab_pos_1 = results['pos1']
+            self._hab_pos_2 = results['pos2']
         else:
             raise RuntimeError("Unexpected detector type, got %r" % results)
 
@@ -120,19 +121,19 @@ class BeamCentreModel(object):
 
     @property
     def r_min(self):
-        return self._r_min
+        return meter_2_millimeter(self._r_min)
 
     @r_min.setter
     def r_min(self, value):
-        self._r_min = value
+        self._r_min = millimeter_2_meter(value)
 
     @property
     def r_max(self):
-        return self._r_max
+        return meter_2_millimeter(self._r_max)
 
     @r_max.setter
     def r_max(self, value):
-        self._r_max = value
+        self._r_max = millimeter_2_meter(value)
 
     @property
     def q_min(self):
@@ -184,43 +185,43 @@ class BeamCentreModel(object):
 
     @property
     def tolerance(self):
-        return self._tolerance
+        return meter_2_millimeter(self._tolerance)
 
     @tolerance.setter
     def tolerance(self, value):
-        self._tolerance = value
+        self._tolerance = millimeter_2_meter(value)
 
     @property
     def lab_pos_1(self):
-        return self._lab_pos_1
+        return meter_2_millimeter(self._lab_pos_1) if self._lab_pos_1 else ''
 
     @lab_pos_1.setter
     def lab_pos_1(self, value):
-        self._lab_pos_1 = value
+        self._lab_pos_1 = millimeter_2_meter(value)
 
     @property
     def lab_pos_2(self):
-        return self._lab_pos_2
+        return meter_2_millimeter(self._lab_pos_2) if self._lab_pos_2 else ''
 
     @lab_pos_2.setter
     def lab_pos_2(self, value):
-        self._lab_pos_2 = value
+        self._lab_pos_2 = millimeter_2_meter(value)
 
     @property
     def hab_pos_1(self):
-        return self._hab_pos_1
+        return meter_2_millimeter(self._hab_pos_1) if self._hab_pos_1 else ''
 
     @hab_pos_1.setter
     def hab_pos_1(self, value):
-        self._hab_pos_1 = value
+        self._hab_pos_1 = millimeter_2_meter(value)
 
     @property
     def hab_pos_2(self):
-        return self._hab_pos_2
+        return meter_2_millimeter(self._hab_pos_2) if self._hab_pos_2 else ''
 
     @hab_pos_2.setter
     def hab_pos_2(self, value):
-        self._hab_pos_2 = value
+        self._hab_pos_2 = millimeter_2_meter(value)
 
     @property
     def component(self):

--- a/scripts/SANS/sans/gui_logic/models/settings_adjustment_model.py
+++ b/scripts/SANS/sans/gui_logic/models/settings_adjustment_model.py
@@ -13,6 +13,7 @@ are not available in the model associated with the data table.
 from sans.common.enums import SANSInstrument, DataType, DetectorType, RebinType
 from sans.gui_logic.models.model_common import ModelCommon
 from sans.state.StateObjects.StateCalculateTransmission import StateTransmissionFit
+from SANSUtility import (meter_2_millimeter, millimeter_2_meter)
 
 
 class SettingsAdjustmentModel(ModelCommon):
@@ -256,22 +257,22 @@ class SettingsAdjustmentModel(ModelCommon):
     def transmission_mn_4_shift(self):
         # Note that this is actually part of the move operation, but is conceptually part of transmission
         val = getattr(self._user_file_items.move, "monitor_4_offset", None)
-        return val if val else ""
+        return meter_2_millimeter(val) if val else ""
 
     @transmission_mn_4_shift.setter
     def transmission_mn_4_shift(self, value):
         # Note that this is actually part of the move operation, but is conceptually part of transmission
         if hasattr(self._user_file_items.move, "monitor_4_offset"):
-            self._user_file_items.move.monitor_4_offset = value
+            self._user_file_items.move.monitor_4_offset = millimeter_2_meter(value)
 
     @property
     def transmission_mn_5_shift(self):
         # Note that this is actually part of the move operation, but is conceptually part of transmission
         val = getattr(self._user_file_items.move, "monitor_5_offset", None)
-        return val if val else ""
+        return meter_2_millimeter(val) if val else ""
 
     @transmission_mn_5_shift.setter
     def transmission_mn_5_shift(self, value):
         # Note that this is actually part of the move operation, but is conceptually part of transmission
         if hasattr(self._user_file_items.move, "monitor_5_offset"):
-            self._user_file_items.move.monitor_5_offset = value
+            self._user_file_items.move.monitor_5_offset = millimeter_2_meter(value)

--- a/scripts/SANS/sans/gui_logic/models/state_gui_model.py
+++ b/scripts/SANS/sans/gui_logic/models/state_gui_model.py
@@ -15,6 +15,7 @@ from sans.common.enums import (ReductionDimensionality, ReductionMode, RangeStep
 from sans.common.general_functions import get_ranges_from_event_slice_setting
 from sans.gui_logic.models.model_common import ModelCommon
 from sans.state.AllStates import AllStates
+from SANSUtility import (meter_2_millimeter, millimeter_2_meter)
 
 
 class StateGuiModel(ModelCommon):
@@ -105,44 +106,44 @@ class StateGuiModel(ModelCommon):
     @property
     def lab_pos_1(self):
         val = self._user_file_items.move.detectors[DetectorType.LAB.value].sample_centre_pos1
-        return val if val else ""
+        return meter_2_millimeter(val) if val else ""
 
     @lab_pos_1.setter
     def lab_pos_1(self, value):
-        self._user_file_items.move.detectors[DetectorType.LAB.value].sample_centre_pos1 = value
+        self._user_file_items.move.detectors[DetectorType.LAB.value].sample_centre_pos1 = millimeter_2_meter(value)
 
     @property
     def lab_pos_2(self):
         val = self._user_file_items.move.detectors[DetectorType.LAB.value].sample_centre_pos2
-        return val if val else ""
+        return meter_2_millimeter(val) if val else ""
 
     @lab_pos_2.setter
     def lab_pos_2(self, value):
-        self._user_file_items.move.detectors[DetectorType.LAB.value].sample_centre_pos2 = value
+        self._user_file_items.move.detectors[DetectorType.LAB.value].sample_centre_pos2 = millimeter_2_meter(value)
 
     @property
     def hab_pos_1(self):
         val = None
         if DetectorType.HAB.value in self._user_file_items.move.detectors:
             val = self._user_file_items.move.detectors[DetectorType.HAB.value].sample_centre_pos1
-        return val if val else ""
+        return meter_2_millimeter(val) if val else ""
 
     @hab_pos_1.setter
     def hab_pos_1(self, value):
         if DetectorType.HAB.value in self._user_file_items.move.detectors:
-            self._user_file_items.move.detectors[DetectorType.HAB.value].sample_centre_pos1 = value
+            self._user_file_items.move.detectors[DetectorType.HAB.value].sample_centre_pos1 = millimeter_2_meter(value)
 
     @property
     def hab_pos_2(self):
         val = None
         if DetectorType.HAB.value in self._user_file_items.move.detectors:
             val = self._user_file_items.move.detectors[DetectorType.HAB.value].sample_centre_pos2
-        return val if val else ""
+        return meter_2_millimeter(val) if val else ""
 
     @hab_pos_2.setter
     def hab_pos_2(self, value):
         if DetectorType.HAB.value in self._user_file_items.move.detectors:
-            self._user_file_items.move.detectors[DetectorType.HAB.value].sample_centre_pos1 = value
+            self._user_file_items.move.detectors[DetectorType.HAB.value].sample_centre_pos1 = millimeter_2_meter(value)
 
     # ==================================================================================================================
     # ==================================================================================================================
@@ -449,11 +450,11 @@ class StateGuiModel(ModelCommon):
     @property
     def z_offset(self):
         val = self._user_file_items.move.sample_offset
-        return val if val else ""
+        return meter_2_millimeter(val) if val else ""
 
     @z_offset.setter
     def z_offset(self, value):
-        self._user_file_items.move.sample_offset = value
+        self._user_file_items.move.sample_offset = millimeter_2_meter(value)
 
     # ==================================================================================================================
     # ==================================================================================================================
@@ -503,11 +504,11 @@ class StateGuiModel(ModelCommon):
     @property
     def r_cut(self):
         val = self._user_file_items.convert_to_q.radius_cutoff
-        return val if val else ""
+        return meter_2_millimeter(val) if val else ""
 
     @r_cut.setter
     def r_cut(self, value):
-        self._user_file_items.convert_to_q.radius_cutoff = value
+        self._user_file_items.convert_to_q.radius_cutoff = millimeter_2_meter(value)
 
     @property
     def w_cut(self):
@@ -554,65 +555,65 @@ class StateGuiModel(ModelCommon):
     @property
     def q_resolution_source_a(self):
         val = self._user_file_items.convert_to_q.q_resolution_a1
-        return val if val else ""
+        return meter_2_millimeter(val) if val else ""
 
     @q_resolution_source_a.setter
     def q_resolution_source_a(self, value):
-        self._user_file_items.convert_to_q.q_resolution_a1 = value
+        self._user_file_items.convert_to_q.q_resolution_a1 = millimeter_2_meter(value)
 
     @property
     def q_resolution_sample_a(self):
         val = self._user_file_items.convert_to_q.q_resolution_a2
-        return val if val else ""
+        return meter_2_millimeter(val) if val else ""
 
     @q_resolution_sample_a.setter
     def q_resolution_sample_a(self, value):
-        self._user_file_items.convert_to_q.q_resolution_a2 = value
+        self._user_file_items.convert_to_q.q_resolution_a2 = millimeter_2_meter(value)
 
     @property
     def q_resolution_source_h(self):
         val = self._user_file_items.convert_to_q.q_resolution_h1
-        return val if val else ""
+        return meter_2_millimeter(val) if val else ""
 
     @q_resolution_source_h.setter
     def q_resolution_source_h(self, value):
-        self._user_file_items.convert_to_q.q_resolution_h1 = value
+        self._user_file_items.convert_to_q.q_resolution_h1 = millimeter_2_meter(value)
 
     @property
     def q_resolution_sample_h(self):
         val = self._user_file_items.convert_to_q.q_resolution_h2
-        return val if val else ""
+        return meter_2_millimeter(val) if val else ""
 
     @q_resolution_sample_h.setter
     def q_resolution_sample_h(self, value):
-        self._user_file_items.convert_to_q.q_resolution_h2 = value
+        self._user_file_items.convert_to_q.q_resolution_h2 = millimeter_2_meter(value)
 
     @property
     def q_resolution_source_w(self):
         val = self._user_file_items.convert_to_q.q_resolution_w1
-        return val if val else ""
+        return meter_2_millimeter(val) if val else ""
 
     @q_resolution_source_w.setter
     def q_resolution_source_w(self, value):
-        self._user_file_items.convert_to_q.q_resolution_w1 = value
+        self._user_file_items.convert_to_q.q_resolution_w1 = millimeter_2_meter(value)
 
     @property
     def q_resolution_sample_w(self):
         val = self._user_file_items.convert_to_q.q_resolution_w2
-        return val if val else ""
+        return meter_2_millimeter(val) if val else ""
 
     @q_resolution_sample_w.setter
     def q_resolution_sample_w(self, value):
-        self._user_file_items.convert_to_q.q_resolution_w2 = value
+        self._user_file_items.convert_to_q.q_resolution_w2 = millimeter_2_meter(value)
 
     @property
     def q_resolution_delta_r(self):
         val = self._user_file_items.convert_to_q.q_resolution_delta_r
-        return val if val else ""
+        return meter_2_millimeter(val) if val else ""
 
     @q_resolution_delta_r.setter
     def q_resolution_delta_r(self, value):
-        self._user_file_items.convert_to_q.q_resolution_delta_r = value
+        self._user_file_items.convert_to_q.q_resolution_delta_r = millimeter_2_meter(value)
 
     @property
     def q_resolution_moderator_file(self):
@@ -674,20 +675,20 @@ class StateGuiModel(ModelCommon):
     @property
     def radius_limit_min(self):
         val = self._user_file_items.mask.radius_min
-        return val if val else ""
+        return meter_2_millimeter(val) if val else ""
 
     @radius_limit_min.setter
     def radius_limit_min(self, value):
-        self._user_file_items.mask.radius_min = value
+        self._user_file_items.mask.radius_min = millimeter_2_meter(value)
 
     @property
     def radius_limit_max(self):
         val = self._user_file_items.mask.radius_max
-        return val if val else ""
+        return meter_2_millimeter(val) if val else ""
 
     @radius_limit_max.setter
     def radius_limit_max(self, value):
-        self._user_file_items.mask.radius_max = value
+        self._user_file_items.mask.radius_max = millimeter_2_meter(value)
 
     # ------------------------------------------------------------------------------------------------------------------
     # Mask files

--- a/scripts/SANS/sans/gui_logic/presenter/beam_centre_presenter.py
+++ b/scripts/SANS/sans/gui_logic/presenter/beam_centre_presenter.py
@@ -13,6 +13,8 @@ from ui.sans_isis.work_handler import WorkHandler
 
 
 class BeamCentrePresenter(object):
+    DECIMAL_PLACES_CENTRE_POS = 3
+
     class ConcreteBeamCentreListener(BeamCentre.BeamCentreListener):
         def __init__(self, presenter):
             self._presenter = presenter
@@ -66,10 +68,10 @@ class BeamCentrePresenter(object):
         # Enable button
         self._view.set_run_button_to_normal()
         # Update Centre Positions in model and GUI
-        self._view.lab_pos_1 = self._beam_centre_model.lab_pos_1
-        self._view.lab_pos_2 = self._beam_centre_model.lab_pos_2
-        self._view.hab_pos_1 = self._beam_centre_model.hab_pos_1
-        self._view.hab_pos_2 = self._beam_centre_model.hab_pos_2
+        self._view.lab_pos_1 = round(self._beam_centre_model.lab_pos_1, self.DECIMAL_PLACES_CENTRE_POS)
+        self._view.lab_pos_2 = round(self._beam_centre_model.lab_pos_2, self.DECIMAL_PLACES_CENTRE_POS)
+        self._view.hab_pos_1 = round(self._beam_centre_model.hab_pos_1, self.DECIMAL_PLACES_CENTRE_POS)
+        self._view.hab_pos_2 = round(self._beam_centre_model.hab_pos_2, self.DECIMAL_PLACES_CENTRE_POS)
 
     def on_processing_error_centre_finder(self, error):
         self._logger.warning("There has been an error. See more: {}".format(error))
@@ -127,11 +129,11 @@ class BeamCentrePresenter(object):
         hab_pos_1 = getattr(state_model, 'hab_pos_1') if getattr(state_model, 'hab_pos_1') else lab_pos_1
         hab_pos_2 = getattr(state_model, 'hab_pos_2') if getattr(state_model, 'hab_pos_2') else lab_pos_2
 
-        self._view.lab_pos_1 = lab_pos_1
-        self._view.lab_pos_2 = lab_pos_2
+        self._view.lab_pos_1 = round(lab_pos_1, self.DECIMAL_PLACES_CENTRE_POS)
+        self._view.lab_pos_2 = round(lab_pos_2, self.DECIMAL_PLACES_CENTRE_POS)
 
-        self._view.hab_pos_1 = hab_pos_1
-        self._view.hab_pos_2 = hab_pos_2
+        self._view.hab_pos_1 = round(hab_pos_1, self.DECIMAL_PLACES_CENTRE_POS)
+        self._view.hab_pos_2 = round(hab_pos_2, self.DECIMAL_PLACES_CENTRE_POS)
 
     def update_hab_selected(self):
         self._beam_centre_model.update_hab = True

--- a/scripts/SANS/sans/gui_logic/presenter/presenter_common.py
+++ b/scripts/SANS/sans/gui_logic/presenter/presenter_common.py
@@ -41,16 +41,18 @@ class PresenterCommon(metaclass=ABCMeta):
     def _set_on_state_model(self, attribute_name):
         self._set_on_custom_model(attribute_name, self._model)
 
-    def _set_on_view(self, attribute_name):
-        self._set_on_view_to_custom_view(attribute_name, self._view)
+    def _set_on_view(self, attribute_name, decimal_places = None):
+        self._set_on_view_to_custom_view(attribute_name, self._view, decimal_places)
 
     def _set_on_custom_model(self, attribute_name, model):
         attribute = getattr(self._view, attribute_name)
         if attribute is not None and attribute != '':
             setattr(model, attribute_name, attribute)
 
-    def _set_on_view_to_custom_view(self, attribute_name, view):
+    def _set_on_view_to_custom_view(self, attribute_name, view, decimal_places):
         attribute = getattr(self._model, attribute_name)
         if attribute or isinstance(attribute,
                                    bool):  # We need to be careful here. We don't want to set empty strings, or None, but we want to set boolean values. # noqa
+            if decimal_places:
+                attribute = round(attribute,decimal_places)
             setattr(view, attribute_name, attribute)

--- a/scripts/SANS/sans/gui_logic/presenter/run_tab_presenter.py
+++ b/scripts/SANS/sans/gui_logic/presenter/run_tab_presenter.py
@@ -90,6 +90,8 @@ class SaveDirectoryObserver(ConfigPropertyObserver):
 
 
 class RunTabPresenter(PresenterCommon):
+    DEFAULT_DECIMAL_PLACES_MM = 1
+
     class ConcreteRunTabListener(SANSDataProcessorGui.RunTabListener):
         def __init__(self, presenter):
             super(RunTabPresenter.ConcreteRunTabListener, self).__init__()
@@ -1003,7 +1005,7 @@ class RunTabPresenter(PresenterCommon):
         self._set_on_view("wavelength_step")
 
         self._set_on_view("absolute_scale")
-        self._set_on_view("z_offset")
+        self._set_on_view("z_offset", self.DEFAULT_DECIMAL_PLACES_MM)
 
         # Q tab
         self._set_on_view_q_rebin_string()
@@ -1016,27 +1018,27 @@ class RunTabPresenter(PresenterCommon):
 
         self._set_on_view("use_q_resolution")
         self._set_on_view_q_resolution_aperture()
-        self._set_on_view("q_resolution_delta_r")
+        self._set_on_view("q_resolution_delta_r", self.DEFAULT_DECIMAL_PLACES_MM)
         self._set_on_view("q_resolution_collimation_length")
         self._set_on_view("q_resolution_moderator_file")
 
-        self._set_on_view("r_cut")
+        self._set_on_view("r_cut", self.DEFAULT_DECIMAL_PLACES_MM)
         self._set_on_view("w_cut")
 
         # Mask
         self._set_on_view("phi_limit_min")
         self._set_on_view("phi_limit_max")
         self._set_on_view("phi_limit_use_mirror")
-        self._set_on_view("radius_limit_min")
-        self._set_on_view("radius_limit_max")
+        self._set_on_view("radius_limit_min", self.DEFAULT_DECIMAL_PLACES_MM)
+        self._set_on_view("radius_limit_max", self.DEFAULT_DECIMAL_PLACES_MM)
 
     def _set_on_view_q_resolution_aperture(self):
-        self._set_on_view("q_resolution_source_a")
-        self._set_on_view("q_resolution_sample_a")
-        self._set_on_view("q_resolution_source_h")
-        self._set_on_view("q_resolution_sample_h")
-        self._set_on_view("q_resolution_source_w")
-        self._set_on_view("q_resolution_sample_w")
+        self._set_on_view("q_resolution_source_a", self.DEFAULT_DECIMAL_PLACES_MM)
+        self._set_on_view("q_resolution_sample_a", self.DEFAULT_DECIMAL_PLACES_MM)
+        self._set_on_view("q_resolution_source_h", self.DEFAULT_DECIMAL_PLACES_MM)
+        self._set_on_view("q_resolution_sample_h", self.DEFAULT_DECIMAL_PLACES_MM)
+        self._set_on_view("q_resolution_source_w", self.DEFAULT_DECIMAL_PLACES_MM)
+        self._set_on_view("q_resolution_sample_w", self.DEFAULT_DECIMAL_PLACES_MM)
 
         # If we have h1, h2, w1, and w2 selected then we want to select the rectangular aperture.
         is_rectangular = self._model.q_resolution_source_h and self._model.q_resolution_sample_h and \

--- a/scripts/SANS/sans/gui_logic/presenter/settings_adjustment_presenter.py
+++ b/scripts/SANS/sans/gui_logic/presenter/settings_adjustment_presenter.py
@@ -48,8 +48,8 @@ class SettingsAdjustmentPresenter(PresenterCommon):
         self._set_on_view("transmission_mask_files")
         self._set_on_view("transmission_radius")
         self._set_on_view("transmission_monitor")
-        self._set_on_view("transmission_mn_4_shift")
-        self._set_on_view("transmission_mn_5_shift")
+        self._set_on_view("transmission_mn_4_shift",1)
+        self._set_on_view("transmission_mn_5_shift",1)
 
         self._set_on_view_transmission_fit()
 

--- a/scripts/test/SANS/gui_logic/model_tests/settings_adjustment_model_test.py
+++ b/scripts/test/SANS/gui_logic/model_tests/settings_adjustment_model_test.py
@@ -115,8 +115,8 @@ class SettingsTransmissionModelTest(unittest.TestCase):
 
     def test_that_transmission_mn_shift_can_be_set(self):
         state_gui_model = self.create_model({})
-        state_gui_model.transmission_mn_shift = 234
-        self.assertEqual(state_gui_model.transmission_mn_shift, 234)
+        state_gui_model.transmission_mn_4_shift = 234
+        self.assertEqual(state_gui_model.transmission_mn_4_shift, 234)
 
     def test_that_default_for_adjustment_files_are_empty(self):
         state_gui_model = self.create_model({})

--- a/scripts/test/SANS/gui_logic/state_gui_model_test.py
+++ b/scripts/test/SANS/gui_logic/state_gui_model_test.py
@@ -7,8 +7,9 @@
 import unittest
 
 from sans.common.enums import (ReductionDimensionality, ReductionMode, RangeStepType, SampleShape, SaveType,
-                               SANSInstrument, FitModeForMerge, CanonicalCoordinates)
+                               SANSInstrument, FitModeForMerge, CanonicalCoordinates, DetectorType)
 from sans.gui_logic.models.state_gui_model import StateGuiModel
+from sans.state.StateObjects.StateMoveDetectors import StateMoveDetectors
 from sans.state.AllStates import AllStates
 from sans.user_file.settings_tags import (OtherId, event_binning_string_values, DetectorId)
 from sans.user_file.settings_tags import (det_fit_range)
@@ -447,6 +448,49 @@ class StateGuiModelTest(unittest.TestCase):
         state_gui_model = StateGuiModel(AllStates())
         state_gui_model.mask_files = ["file.txt", "file2.txt"]
         self.assertEqual(state_gui_model.mask_files, ["file.txt", "file2.txt"])
+
+    # ------------------------------------------------------------------------------------------------------------------
+    # User files - focus on fields that are displayed in mm and stored in m
+    # ------------------------------------------------------------------------------------------------------------------
+    def test_that_user_file_items_interpreted_correctly(self):
+        state = AllStates()
+        state.move.sample_offset = 1.78/1000.
+        state.scale.width = 1.2
+        state.scale.height = 1.6
+        state.scale.thickness = 1.8
+        state.scale.shape = SampleShape.FLAT_PLATE
+        state.convert_to_q.radius_cutoff = 45./1000.
+        state.convert_to_q.q_resolution_a1 = 1.5/1000.
+        state.convert_to_q.q_resolution_a2 = 2.5/1000.
+        state.convert_to_q.q_resolution_h1 = 1.5/1000.
+        state.convert_to_q.q_resolution_h2 = 2.5/1000.
+        state.convert_to_q.q_resolution_delta_r = 0.1/1000.
+        state.mask.radius_min = 12./1000.
+        state.mask.radius_max = 13./1000.
+        state.move.detectors = {DetectorType.LAB.value: StateMoveDetectors(),
+                                DetectorType.HAB.value: StateMoveDetectors()}
+        state.move.detectors[DetectorType.LAB.value].sample_centre_pos1 = 21.5/1000.
+        state.move.detectors[DetectorType.LAB.value].sample_centre_pos2 = 17.8 / 1000.
+        state.move.detectors[DetectorType.HAB.value].sample_centre_pos1 = 25.1/1000.
+        state.move.detectors[DetectorType.HAB.value].sample_centre_pos2 = 16.9 / 1000.
+        state_gui_model = StateGuiModel(state)
+        self.assertEqual(state_gui_model.sample_width, 1.2)
+        self.assertEqual(state_gui_model.sample_height, 1.6)
+        self.assertEqual(state_gui_model.sample_thickness, 1.8)
+        self.assertEqual(state_gui_model.z_offset, 1.78)
+        self.assertEqual(state_gui_model.sample_shape, SampleShape.FLAT_PLATE)
+        self.assertEqual(state_gui_model.r_cut, 45.)
+        self.assertEqual(state_gui_model.q_resolution_source_a, 1.5)
+        self.assertEqual(state_gui_model.q_resolution_sample_a, 2.5)
+        self.assertEqual(state_gui_model.q_resolution_source_h, 1.5)
+        self.assertEqual(state_gui_model.q_resolution_sample_h, 2.5)
+        self.assertEqual(state_gui_model.q_resolution_delta_r, 0.1)
+        self.assertEqual(state_gui_model.radius_limit_min, 12.)
+        self.assertEqual(state_gui_model.radius_limit_max, 13.)
+        self.assertEqual(state_gui_model.lab_pos_1, 21.5)
+        self.assertEqual(state_gui_model.lab_pos_2, 17.8)
+        self.assertEqual(state_gui_model.hab_pos_1, 25.1)
+        self.assertEqual(state_gui_model.hab_pos_2, 16.9)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
**Description of work.**

Various values in the ISIS SANS reduction UI are stored in metres but need to be displayed in millimetres. Apply the unit conversions in the model and also apply some rounding to specific numbers of decimal places as requested (most mm fields to 1dp except beam_centre_model positions to 3dp plus tolerance not currently rounded since hardcoded value is 0.0001251mm)

I applied the unit conversion in the model rather than in the presenter because unit conversion maths (even relatively trivial ones) seemed better in the model. Rounding is done in the presenter though.

There are one or two places where the stored metre value needs to be retrieved rather than the mm value. I've just referred to the _property name here rather than using the getter method.

A couple of comments on the rounding: 
- The 5.0 code didn't explicitly round the values for display - it just showed whatever precision was in the user file and it read the values in using string variables. The 5.1 code converts the value in the user file to a float when doing the unit conversion so this generates some standard floating point representation issues which is the cause of the problem
- The centre values output from the beam centre finding algorithm get written to the UI and also have to be rounded. I wonder whether the rounding may result in a second run of the beam centre finding still doing some work after a successful first run? Maybe not the end of the world...

Also added "mm" to a couple of the field labels for clarity

**To test:**

Open up ISIS SANS UI in workbench from Interfaces, SANS, ISIS SANS menu
Load User File MaskFile.txt from ISIS Sample data
Load Batch File batch_mode_reduction.csv also from ISIS sample data
Go to Settings and check the values highlighted on the issue are now displayed correctly eg "absolute scale" value matches the input value of -8.0 in the MaskFile.txt file (which is in mm)
Go to Beam Centre
Check that the four values in the Centre Position area are 324.46 (twice) and 330.99 (twice). These values are in mm
Also note the values are accurate to 3 dps (only 2 dp shown because that's the full value)
Click Run
Note that the Centre positions have been udpated and are now shown (more obviously) to 3 dps


Fixes #29415. 

*This does not require release notes* because **fixes a bug**

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
