### PR TITLE
Fix crash transferring run into empty group

### DIFF
--- a/docs/source/release/v5.1.0/reflectometry.rst
+++ b/docs/source/release/v5.1.0/reflectometry.rst
@@ -71,9 +71,12 @@ Bug fixes
 ---------
 
 - Save/Load settings: A bug has been fixed where Experiment/Instrument settings were not being restored if the instrument changes on load.
+
 - Lost settings on New Batch and Restore Defaults:
 
   - A bug has been fixed where creating a new Batch would result in the Experiment/Instrument settings of all batches being reset to their defaults.
   - A bug has been fixed where clicking Restore Defaults on an Experiment/Instrument tab would cause all Experiment and Instrument tabs in every batch to be reset to defaults. Now, only the tab where you click Restore Defaults is changed.
+
+- A bug has been fixed where Mantid could crash if you transfer search results into an empty group
 
 :ref:`Release 5.1.0 <v5.1.0>`

--- a/qt/scientific_interfaces/ISISReflectometry/Reduction/Group.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/Reduction/Group.cpp
@@ -136,13 +136,19 @@ void Group::insertRow(boost::optional<Row> const &row, int beforeRowAtIndex) {
   m_rows.insert(m_rows.begin() + beforeRowAtIndex, row);
 }
 
+/** Insert a row into a group and sort rows by the angle column. If the
+ * row/angle is not initialized, add it at the end of the group.
+ *
+ * @param row : the row to insert
+ * @returns : the index of the inserted row in the group's list of rows
+ */
 int Group::insertRowSortedByAngle(boost::optional<Row> const &row) {
   Item::resetState();
 
   // If the row is not sortable, or there is nothing in the list yet, append it
   if (!row.is_initialized() || m_rows.size() == 0) {
     appendRow(row);
-    return static_cast<int>(m_rows.size());
+    return static_cast<int>(m_rows.size() - 1);
   }
 
   // Find the first row with theta greater than the row we're inserting (or

--- a/qt/scientific_interfaces/ISISReflectometry/TestHelpers/ModelCreationHelper.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/TestHelpers/ModelCreationHelper.cpp
@@ -109,6 +109,12 @@ Group makeGroupWithTwoRows() {
           makeRowWithOutputNames({"IvsLam_2", "IvsQ_2", "IvsQ_binned_2"})});
 }
 
+Group makeGroupWithTwoRowsWithDifferentAngles() {
+  return Group("multi_angle_group",
+               std::vector<boost::optional<Row>>{makeRow("12345", 0.2),
+                                                 makeRow("12346", 0.9)});
+}
+
 Group makeGroupWithTwoRowsWithNonstandardNames() {
   return Group(
       "multi_row_group",

--- a/qt/scientific_interfaces/ISISReflectometry/TestHelpers/ModelCreationHelper.h
+++ b/qt/scientific_interfaces/ISISReflectometry/TestHelpers/ModelCreationHelper.h
@@ -44,6 +44,7 @@ makeRowWithOptionsCellFilled(double theta, ReductionOptionsMap options);
 MANTIDQT_ISISREFLECTOMETRY_DLL Group makeEmptyGroup();
 MANTIDQT_ISISREFLECTOMETRY_DLL Group makeGroupWithOneRow();
 MANTIDQT_ISISREFLECTOMETRY_DLL Group makeGroupWithTwoRows();
+MANTIDQT_ISISREFLECTOMETRY_DLL Group makeGroupWithTwoRowsWithDifferentAngles();
 MANTIDQT_ISISREFLECTOMETRY_DLL Group makeGroupWithTwoRowsWithNonstandardNames();
 MANTIDQT_ISISREFLECTOMETRY_DLL Group
 makeGroupWithTwoRowsWithMixedQResolutions();

--- a/qt/scientific_interfaces/test/ISISReflectometry/Reduction/GroupTest.h
+++ b/qt/scientific_interfaces/test/ISISReflectometry/Reduction/GroupTest.h
@@ -7,9 +7,12 @@
 #pragma once
 #include "../../../ISISReflectometry/Reduction/Group.h"
 #include "../../../ISISReflectometry/Reduction/ReductionWorkspaces.h"
+#include "../../../ISISReflectometry/TestHelpers/ModelCreationHelper.h"
 #include <cxxtest/TestSuite.h>
 
 using namespace MantidQt::CustomInterfaces::ISISReflectometry;
+using namespace MantidQt::CustomInterfaces::ISISReflectometry::
+    ModelCreationHelper;
 
 class GroupTest : public CxxTest::TestSuite {
 public:
@@ -22,16 +25,101 @@ public:
     return ReductionWorkspaces({}, TransmissionRunPair{});
   }
 
-  void testConstructorSetsGroupName() {
+  void test_constructor_sets_group_name() {
     auto group = Group("Group1", {});
     TS_ASSERT_EQUALS("Group1", group.name());
   }
 
-  void testCanAddEmptyRowToGroup() {
-    auto group = Group("Group1", {});
-    auto run = Row({"000000", "000002"}, 0.02, {"", ""},
-                   RangeInQ(0.0, 1.0, 10.0), 1.2, {}, workspaceNames());
-    group.appendRow(run);
-    TS_ASSERT_EQUALS(run.runNumbers(), group[0].get().runNumbers());
+  void test_append_row() {
+    auto group = makeEmptyGroup();
+    auto rowToAdd = makeRow("12345", 0.5);
+    group.appendRow(rowToAdd);
+    TS_ASSERT_EQUALS(group.rows().size(), 1);
+    TS_ASSERT(group[0].is_initialized());
+    TS_ASSERT_EQUALS(group[0].get(), rowToAdd);
+  }
+
+  void test_append_empty_row() {
+    auto group = makeEmptyGroup();
+    group.appendEmptyRow();
+    TS_ASSERT_EQUALS(group.rows().size(), 1);
+    TS_ASSERT_EQUALS(group[0].is_initialized(), false);
+  }
+
+  void test_append_uninitialized_row() {
+    // manually append an empty (uninitialized) row
+    auto group = makeEmptyGroup();
+    auto rowToAdd = boost::optional<Row>{boost::none};
+    group.appendRow(rowToAdd);
+    TS_ASSERT_EQUALS(group.rows().size(), 1);
+    TS_ASSERT_EQUALS(group[0].is_initialized(), false);
+  }
+
+  void test_insert_row_at_position() {
+    auto group = makeGroupWithTwoRows();
+    auto rowToAdd = makeRow("12345", 0.5);
+    auto const index = 1;
+    group.insertRow(rowToAdd, index);
+    TS_ASSERT_EQUALS(group.rows().size(), 3);
+    TS_ASSERT(group[index].is_initialized());
+    TS_ASSERT_EQUALS(group[index].get(), rowToAdd);
+  }
+
+  void test_insert_row_sorted_by_angle() {
+    auto group = makeGroupWithTwoRowsWithDifferentAngles();
+    auto rowToAdd = makeRow("22345", 0.5);
+    auto const index = 1; // angle 0.5 is between the two existing rows
+    group.insertRowSortedByAngle(rowToAdd);
+    TS_ASSERT_EQUALS(group.rows().size(), 3);
+    TS_ASSERT(group[index].is_initialized());
+    TS_ASSERT_EQUALS(group[index].get(), rowToAdd);
+  }
+
+  void test_insert_row_sorted_by_angle_at_start() {
+    auto group = makeGroupWithTwoRowsWithDifferentAngles();
+    auto rowToAdd = makeRow("22345", 0.1);
+    auto const index = 0; // angle 0.1 is before the current two rows
+    group.insertRowSortedByAngle(rowToAdd);
+    TS_ASSERT_EQUALS(group.rows().size(), 3);
+    TS_ASSERT(group[index].is_initialized());
+    TS_ASSERT_EQUALS(group[index].get(), rowToAdd);
+  }
+
+  void test_insert_row_sorted_by_angle_at_end() {
+    auto group = makeGroupWithTwoRowsWithDifferentAngles();
+    auto rowToAdd = makeRow("22345", 1.5);
+    auto const index = 2; // angle 1.5 is after the current two rows
+    group.insertRowSortedByAngle(rowToAdd);
+    TS_ASSERT_EQUALS(group.rows().size(), 3);
+    TS_ASSERT(group[index].is_initialized());
+    TS_ASSERT_EQUALS(group[index].get(), rowToAdd);
+  }
+
+  void test_insert_row_sorted_by_angle_into_empty_group() {
+    auto group = makeEmptyGroup();
+    auto rowToAdd = makeRow("22345", 0.5);
+    auto const index = 0;
+    group.insertRowSortedByAngle(rowToAdd);
+    TS_ASSERT_EQUALS(group.rows().size(), 1);
+    TS_ASSERT(group[index].is_initialized());
+    TS_ASSERT_EQUALS(group[index].get(), rowToAdd);
+  }
+
+  void test_insert_row_sorted_by_angle_adds_uninitialized_row_at_end() {
+    auto group = makeGroupWithTwoRowsWithDifferentAngles();
+    auto rowToAdd = boost::optional<Row>{boost::none};
+    auto const index = 2; // should be added at the end
+    group.insertRowSortedByAngle(rowToAdd);
+    TS_ASSERT_EQUALS(group.rows().size(), 3);
+    TS_ASSERT_EQUALS(group[index].is_initialized(), false);
+  }
+
+  void test_insert_uninitialized_row_sorted_by_angle_into_empty_group() {
+    auto group = makeEmptyGroup();
+    auto rowToAdd = boost::optional<Row>{boost::none};
+    auto const index = 0;
+    group.insertRowSortedByAngle(rowToAdd);
+    TS_ASSERT_EQUALS(group.rows().size(), 1);
+    TS_ASSERT_EQUALS(group[index].is_initialized(), false);
   }
 };


### PR DESCRIPTION
**Description of work.**

- This PR fixes a crash on the reflectometry GUI transferring a run into an empty group. The bug was due to an incorrect index being returned for the position of the inserted row, in the case where the group was empty.
- There were very few tests for this class so I have added several around the functionality for inserting rows. I've created issue #29460 to add the rest.

**To test:**

Must be tested at ISIS. A suggested instrument/investigation/cycle are given but you can use any.

- Open the ISIS Reflectometry interface
- Select instrument OFFSPEC and enter investigation ID 1920533 and cycle 19_3, and click Search
- Select the first non-highlighted row in the search results list and click Transfer
- Expand the group that appears in the runs table. Select the row inside it and press Del to remove it. This leaves an empty group.
- Click Transfer again. It should re-add the row to the group without crashing.


Fixes #29439

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
