### PR TITLE
Fix sliceviewer extents to set correctly after axes swap

### DIFF
--- a/Framework/PythonInterface/mantid/plots/axesfunctions.py
+++ b/Framework/PythonInterface/mantid/plots/axesfunctions.py
@@ -621,7 +621,7 @@ def imshow(axes, workspace, *args, **kwargs):
                         number of bins, the polygons will be aligned with the axes
     :param transpose: ``bool`` to transpose the x and y axes of the plotted dimensions of an MDHistoWorkspace
     '''
-    transpose = kwargs.pop('transpose', False)
+    transpose = kwargs.get('transpose', False)
     if isinstance(workspace, mantid.dataobjects.MDHistoWorkspace):
         (normalization, kwargs) = get_normalization(workspace, **kwargs)
         indices, kwargs = get_indices(workspace, **kwargs)

--- a/Framework/PythonInterface/mantid/plots/axesfunctions.py
+++ b/Framework/PythonInterface/mantid/plots/axesfunctions.py
@@ -632,7 +632,7 @@ def imshow(axes, workspace, *args, **kwargs):
                 kwargs['extent'] = [x[0, 0], x[0, -1], y[0, 0], y[-1, 0]]
             else:
                 kwargs['extent'] = [x[0], x[-1], y[0], y[-1]]
-        return mantid.plots.modest_image.imshow(axes, z, transpose=transpose, *args, **kwargs)
+        return mantid.plots.modest_image.imshow(axes, z, *args, **kwargs)
     else:
         (aligned, kwargs) = check_resample_to_regular_grid(workspace, **kwargs)
         (normalize_by_bin_width, kwargs) = get_normalize_by_bin_width(workspace, axes, **kwargs)


### PR DESCRIPTION
**Description of work.**
Stop transpose kwarg from being removed, allowing a `true` value to propagate to the code that handles the changing of the image extent.

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

**To test:**
1. Load a 2D workspace such as MAR1160
2. Open the sliceviewer for this workspace
3. Switch between the axes, trying both sets of x/y buttons, and observe that the image transposes correctly and doesn't throw any errors
4. Repeat after zooming in/out on the image

Fixes #29400 . 

*This does not require release notes* because **it is a regression bugfix**

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
