### PR TITLE
D20 convert spectrum axis

### DIFF
--- a/Framework/DataHandling/inc/MantidDataHandling/LoadILLDiffraction.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/LoadILLDiffraction.h
@@ -94,6 +94,7 @@ private:
   void resolveScanType();
   void setSampleLogs();
   void computeThetaOffset();
+  void convertAxisAndTranspose();
 
   ///< the 2theta offset for D20 to account for dead pixels
   double m_offsetTheta{0.};

--- a/Framework/DataHandling/src/LoadILLDiffraction.cpp
+++ b/Framework/DataHandling/src/LoadILLDiffraction.cpp
@@ -115,6 +115,9 @@ void LoadILLDiffraction::init() {
       std::make_unique<PropertyWithValue<bool>>("AlignTubes", true,
                                                 Direction::Input),
       "Apply vertical and horizontal alignment of tubes as defined in IPF");
+  declareProperty("ConvertAxisAndTranspose", false,
+                  "Whether to convert the spectrum axis to 2theta and "
+                  "transpose (for 1D detector and no-scan configuration)");
 }
 
 std::map<std::string, std::string> LoadILLDiffraction::validateInputs() {
@@ -148,6 +151,10 @@ void LoadILLDiffraction::exec() {
 
   progress.report("Setting additional sample logs");
   setSampleLogs();
+
+  if (m_instName != "D2B" && m_scanType == NoScan &&
+      getProperty("ConvertAxisAndTranspose"))
+    convertAxisAndTranspose();
 
   setProperty("OutputWorkspace", m_outWorkspace);
 }
@@ -899,6 +906,29 @@ bool LoadILLDiffraction::containsCalibratedData(
 void LoadILLDiffraction::computeThetaOffset() {
   m_offsetTheta = static_cast<double>(D20_NUMBER_DEAD_PIXELS) * D20_PIXEL_SIZE -
                   D20_PIXEL_SIZE / (static_cast<double>(m_resolutionMode) * 2);
+}
+
+/**
+ * Converts the spectrum axis to 2theta and transposes the workspace.
+ */
+void LoadILLDiffraction::convertAxisAndTranspose() {
+  auto extractor = createChildAlgorithm("ExtractMonitors");
+  extractor->setProperty("InputWorkspace", m_outWorkspace);
+  extractor->setProperty("DetectorWorkspace", "__unused");
+  extractor->execute();
+  API::MatrixWorkspace_sptr det = extractor->getProperty("DetectorWorkspace");
+  auto converter = createChildAlgorithm("ConvertSpectrumAxis");
+  converter->setProperty("InputWorkspace", det);
+  converter->setProperty("OutputWorkspace", "__unused");
+  converter->setProperty("Target", "SignedTheta");
+  converter->execute();
+  API::MatrixWorkspace_sptr converted = converter->getProperty("OutputWorkspace");
+  auto transposer = createChildAlgorithm("Transpose");
+  transposer->setProperty("InputWorkspace", converted);
+  transposer->setProperty("OutputWorkspace", "__unused");
+  transposer->execute();
+  API::MatrixWorkspace_sptr transposed = transposer->getProperty("OutputWorkspace");
+  m_outWorkspace = transposed;
 }
 
 } // namespace DataHandling

--- a/Framework/DataHandling/src/LoadILLDiffraction.cpp
+++ b/Framework/DataHandling/src/LoadILLDiffraction.cpp
@@ -152,7 +152,7 @@ void LoadILLDiffraction::exec() {
   progress.report("Setting additional sample logs");
   setSampleLogs();
 
-  if (m_instName != "D2B" && m_scanType == NoScan &&
+  if (m_instName != "D2B" && m_scanType != DetectorScan &&
       getProperty("ConvertAxisAndTranspose"))
     convertAxisAndTranspose();
 
@@ -912,22 +912,25 @@ void LoadILLDiffraction::computeThetaOffset() {
  * Converts the spectrum axis to 2theta and transposes the workspace.
  */
 void LoadILLDiffraction::convertAxisAndTranspose() {
-  auto extractor = createChildAlgorithm("ExtractMonitors");
+  auto extractor = createChildAlgorithm("ExtractSpectra");
   extractor->setProperty("InputWorkspace", m_outWorkspace);
-  extractor->setProperty("DetectorWorkspace", "__unused");
+  extractor->setProperty("StartWorkspaceIndex", 1);
+  extractor->setProperty("OutputWorkspace", "__unused");
   extractor->execute();
-  API::MatrixWorkspace_sptr det = extractor->getProperty("DetectorWorkspace");
+  API::MatrixWorkspace_sptr det = extractor->getProperty("OutputWorkspace");
   auto converter = createChildAlgorithm("ConvertSpectrumAxis");
   converter->setProperty("InputWorkspace", det);
   converter->setProperty("OutputWorkspace", "__unused");
   converter->setProperty("Target", "SignedTheta");
   converter->execute();
-  API::MatrixWorkspace_sptr converted = converter->getProperty("OutputWorkspace");
+  API::MatrixWorkspace_sptr converted =
+      converter->getProperty("OutputWorkspace");
   auto transposer = createChildAlgorithm("Transpose");
   transposer->setProperty("InputWorkspace", converted);
   transposer->setProperty("OutputWorkspace", "__unused");
   transposer->execute();
-  API::MatrixWorkspace_sptr transposed = transposer->getProperty("OutputWorkspace");
+  API::MatrixWorkspace_sptr transposed =
+      transposer->getProperty("OutputWorkspace");
   m_outWorkspace = transposed;
 }
 

--- a/Framework/DataHandling/test/LoadILLDiffractionTest.h
+++ b/Framework/DataHandling/test/LoadILLDiffractionTest.h
@@ -9,6 +9,8 @@
 #include <cxxtest/TestSuite.h>
 
 #include "MantidAPI/AnalysisDataService.h"
+#include "MantidAPI/Axis.h"
+#include "MantidAPI/FrameworkManager.h"
 #include "MantidAPI/MatrixWorkspace.h"
 #include "MantidAPI/Run.h"
 #include "MantidDataHandling/Load.h"
@@ -16,6 +18,7 @@
 #include "MantidGeometry/Instrument/DetectorInfo.h"
 #include "MantidKernel/ConfigService.h"
 #include "MantidKernel/FacilityInfo.h"
+#include "MantidKernel/Unit.h"
 #include "MantidKernel/V3D.h"
 
 using namespace Mantid::API;
@@ -58,6 +61,29 @@ public:
     LoadILLDiffraction alg;
     TS_ASSERT_THROWS_NOTHING(alg.initialize());
     TS_ASSERT(alg.isInitialized());
+  }
+
+  void test_D20_transposed_2theta() {
+    // Tests the axis conversion and transposition
+    // for non-detector scan D20 data from cycle 203
+    LoadILLDiffraction alg;
+    alg.setChild(true);
+    TS_ASSERT_THROWS_NOTHING(alg.initialize())
+    TS_ASSERT(alg.isInitialized())
+    TS_ASSERT_THROWS_NOTHING(alg.setPropertyValue("Filename", "170607.nxs"))
+    TS_ASSERT_THROWS_NOTHING(
+        alg.setPropertyValue("OutputWorkspace", "_unused_for_child"))
+    TS_ASSERT_THROWS_NOTHING(
+        alg.setProperty("ConvertAxisAndTranspose", true))
+    TS_ASSERT_THROWS_NOTHING(alg.execute())
+    TS_ASSERT(alg.isExecuted())
+    MatrixWorkspace_sptr outputWS = alg.getProperty("OutputWorkspace");
+    TS_ASSERT(outputWS)
+    TS_ASSERT_EQUALS(outputWS->getNumberHistograms(), 1)
+    TS_ASSERT_EQUALS(outputWS->blocksize(), 3072)
+    TS_ASSERT(!outputWS->isHistogramData())
+    TS_ASSERT(!outputWS->isDistribution())
+    TS_ASSERT_EQUALS(outputWS->getAxis(0)->unit()->unitID(), "Degrees")
   }
 
   void test_D20_no_scan() {

--- a/Framework/DataHandling/test/LoadILLDiffractionTest.h
+++ b/Framework/DataHandling/test/LoadILLDiffractionTest.h
@@ -10,7 +10,6 @@
 
 #include "MantidAPI/AnalysisDataService.h"
 #include "MantidAPI/Axis.h"
-#include "MantidAPI/FrameworkManager.h"
 #include "MantidAPI/MatrixWorkspace.h"
 #include "MantidAPI/Run.h"
 #include "MantidDataHandling/Load.h"
@@ -73,8 +72,7 @@ public:
     TS_ASSERT_THROWS_NOTHING(alg.setPropertyValue("Filename", "170607.nxs"))
     TS_ASSERT_THROWS_NOTHING(
         alg.setPropertyValue("OutputWorkspace", "_unused_for_child"))
-    TS_ASSERT_THROWS_NOTHING(
-        alg.setProperty("ConvertAxisAndTranspose", true))
+    TS_ASSERT_THROWS_NOTHING(alg.setProperty("ConvertAxisAndTranspose", true))
     TS_ASSERT_THROWS_NOTHING(alg.execute())
     TS_ASSERT(alg.isExecuted())
     MatrixWorkspace_sptr outputWS = alg.getProperty("OutputWorkspace");

--- a/Testing/Data/UnitTest/ILL/D20/170607.nxs.md5
+++ b/Testing/Data/UnitTest/ILL/D20/170607.nxs.md5
@@ -1,0 +1,1 @@
+b4f84fe2c4e91579bef17f1b4bf5c4a8


### PR DESCRIPTION
**Description of work.**
This PR adds an option to ILL diffraction loader to convert the spectrum axis to 2theta and transpose.
This will make loading/plotting of non detector scan D20 data far more easier for the users.

**To test:**
Pull the newly added unit test file, and load it with:
``` 
ws = LoadILLDiffraction(Filename='170607', ConvertAxisAndTranspose=True)
```
Double click on the workspace, you should see a diffractogram in scattering angle.
<!-- alternative
*There is no associated issue.*
-->

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
-->

---

#### Reviewer ####

**This is a new feature, but since it is small, low risk, yet high impact, it would be great to have in the release.**

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
