### PR TITLE
Add missing Efixed parameter

### DIFF
--- a/Framework/PythonInterface/test/python/plugins/algorithms/WorkflowAlgorithms/DirectILLCollectDataTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/WorkflowAlgorithms/DirectILLCollectDataTest.py
@@ -192,6 +192,8 @@ class DirectILLCollectDataTest(unittest.TestCase):
         inWS = mtd[self._TEST_WS_NAME]
         E_i = inWS.run().getProperty('Ei').value
         self.assertEqual(eiWS.readY(0)[0], E_i)
+        E_fixed = mtd[outWSName].getInstrument().getNumberParameter('Efixed')[0]
+        self.assertEqual(eiWS.readY(0)[0], E_fixed)
 
     def testIncidentEnergyPanther(self):
         outWSName = 'outWS'
@@ -210,6 +212,8 @@ class DirectILLCollectDataTest(unittest.TestCase):
         E_i = outWS.run().getProperty('Ei').value
         assert_almost_equal(eiWS.readY(0)[0], E_i, 2)
         assert_almost_equal(E_i, 75.37, 2)
+        E_fixed = outWS.getInstrument().getNumberParameter('Efixed')[0]
+        assert_almost_equal(E_fixed, 75.37, 2)
 
 if __name__ == '__main__':
     unittest.main()

--- a/Testing/SystemTests/tests/analysis/ILLDirectGeometryReductionTest.py
+++ b/Testing/SystemTests/tests/analysis/ILLDirectGeometryReductionTest.py
@@ -148,6 +148,7 @@ class IN5(systemtesting.MantidSystemTest):
     def validate(self):
         self.tolerance = 1e-7
         self.tolerance_is_rel_err = True
+        self.disableChecking = ['Instrument', 'Sample']
         return ['cropped', 'ILL_IN5_SofQW.nxs']
 
 
@@ -226,6 +227,7 @@ class IN5_Mask_Non_Overlapping_Bins(systemtesting.MantidSystemTest):
     def validate(self):
         self.tolerance = 1e-7
         self.tolerance_is_rel_err = True
+        self.disableChecking = ['Instrument', 'Sample']
         return ['red', 'ILL_IN5_Tweak_sqw.nxs']
 
     @staticmethod


### PR DESCRIPTION
**Description of work.**
This adds the calibrated Ei also as Efixed instrument parameter in direct ILL reduction.
This will enable manipulating ILL reduced data directly with the QENS analysis suite.

**Report to:**  [S.Howells @ ISIS]

**To test:**
Code review. Parameter is checked in the unit tests.

<!-- Instructions for testing. -->

Fixes #29399 . <!-- and fix #xxxx or close #xxxx xor resolves #xxxx -->
<!-- alternative
*There is no associated issue.*
-->

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or master)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
