### PR TITLE
Fix 2d reduction button not working

### DIFF
--- a/scripts/SANS/sans/gui_logic/models/state_gui_model.py
+++ b/scripts/SANS/sans/gui_logic/models/state_gui_model.py
@@ -24,6 +24,10 @@ class StateGuiModel(ModelCommon):
         super(StateGuiModel, self).__init__(user_file_items)
         self._user_file_items = user_file_items
 
+        # This is transformed in State* objects so it's purely GUI facing
+        # so store in the GUI model
+        self._wavelength_range = ''
+
     def __eq__(self, other):
         return self.__dict__ == other.__dict__
 
@@ -383,7 +387,7 @@ class StateGuiModel(ModelCommon):
 
     @property
     def wavelength_range(self):
-        val = self.wavelength_range
+        val = self._wavelength_range
         return val if val else ""
 
     @wavelength_range.setter
@@ -393,7 +397,7 @@ class StateGuiModel(ModelCommon):
         wavelength_stop = [max(wavelength_stop)] + wavelength_stop
         self.wavelength_min = wavelength_start
         self.wavelength_max = wavelength_stop
-        self.wavelength_range = value
+        self._wavelength_range = value
 
     # ------------------------------------------------------------------------------------------------------------------
     # Scale properties

--- a/scripts/SANS/sans/gui_logic/models/state_gui_model.py
+++ b/scripts/SANS/sans/gui_logic/models/state_gui_model.py
@@ -176,6 +176,7 @@ class StateGuiModel(ModelCommon):
     @reduction_dimensionality.setter
     def reduction_dimensionality(self, value):
         if value is ReductionDimensionality.ONE_DIM or value is ReductionDimensionality.TWO_DIM:
+            self._user_file_items.convert_to_q.reduction_dimensionality = value
             self._user_file_items.reduction.reduction_dimensionality = value
         else:
             raise ValueError("A reduction dimensionality was expected, got instead {}".format(value))

--- a/scripts/SANS/sans/gui_logic/presenter/gui_state_director.py
+++ b/scripts/SANS/sans/gui_logic/presenter/gui_state_director.py
@@ -58,6 +58,7 @@ class GuiStateDirector(object):
         if output_name:
             gui_state.output_name = output_name
         gui_state.save_types = self._state_gui_model.save_types
+        gui_state.reduction_dimensionality = self._state_gui_model.reduction_dimensionality
 
         if row_entry.sample_thickness:
             gui_state.sample_thickness = float(row_entry.sample_thickness)

--- a/scripts/SANS/sans/gui_logic/presenter/run_tab_presenter.py
+++ b/scripts/SANS/sans/gui_logic/presenter/run_tab_presenter.py
@@ -443,7 +443,6 @@ class RunTabPresenter(PresenterCommon):
 
             # 3. Populate the table
             self._table_model.clear_table_entries()
-
             self._add_multiple_rows_to_table_model(rows=parsed_rows)
 
             # 4. Set the batch file path in the model
@@ -578,6 +577,8 @@ class RunTabPresenter(PresenterCommon):
         Enabled canSAS if switching to 1D.
         :param is_1d: bool. If true then switching TO 1D reduction.
         """
+        self._model.reduction_dimensionality = self._view.reduction_dimensionality
+
         if not self._view.output_mode_memory_radio_button.isChecked():
             # If we're in memory mode, all file types should always be disabled
             if is_1d:

--- a/scripts/test/SANS/gui_logic/gui_state_director_test.py
+++ b/scripts/test/SANS/gui_logic/gui_state_director_test.py
@@ -4,6 +4,7 @@
 #   NScD Oak Ridge National Laboratory, European Spallation Source,
 #   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
 # SPDX - License - Identifier: GPL - 3.0 +
+import copy
 import os
 import unittest
 from unittest import mock
@@ -73,6 +74,22 @@ class GuiStateDirectorTest(unittest.TestCase):
         self.assertTrue(isinstance(state, StateGuiModel))
         self.assertEqual(state.all_states.reduction.merge_scale, 1.2)
         self.assertEqual(state.all_states.reduction.merge_shift, 0.5)
+
+    def test_reduction_dim_copied_from_gui(self):
+        state_model = mock.Mock(spec=self._get_state_gui_model())
+        expected_dim = mock.NonCallableMock()
+        # This is set by the user on the main GUI, so should be copied in with a custom user file still
+        state_model.reduction_dimensionality = expected_dim
+
+        # Copy the top level model and reset dim rather than load a file
+        copied_state = copy.deepcopy(state_model)
+        copied_state.reduction_dimensionality = None
+
+        director = GuiStateDirector(state_model, SANSFacility.ISIS)
+        director._load_current_state = mock.Mock(return_value=copied_state)
+        state = director.create_state(self._get_row_entry(), row_user_file="NotThere.txt")
+
+        self.assertEqual(expected_dim, state.reduction_dimensionality)
 
 
 if __name__ == '__main__':

--- a/scripts/test/SANS/gui_logic/run_tab_presenter_test.py
+++ b/scripts/test/SANS/gui_logic/run_tab_presenter_test.py
@@ -210,6 +210,13 @@ class RunTabPresenterTest(unittest.TestCase):
         self.assertIsNone(state)
         self.presenter.sans_logger.warning.assert_called_once()
 
+    def test_switching_dimensionality_updates_model(self):
+        expected_dim = mock.NonCallableMock()
+        self._mock_view.reduction_dimensionality = expected_dim
+        self.presenter.on_reduction_dimensionality_changed(is_1d=False)
+
+        self.assertEqual(expected_dim, self._mock_model.reduction_dimensionality)
+
     def test_on_data_changed_calls_update_rows(self):
         batch_file_path, user_file_path, _ = self._get_files_and_mock_presenter(BATCH_FILE_TEST_CONTENT_1)
         self.presenter._masking_table_presenter = mock.MagicMock()

--- a/scripts/test/SANS/gui_logic/state_gui_model_test.py
+++ b/scripts/test/SANS/gui_logic/state_gui_model_test.py
@@ -104,8 +104,12 @@ class StateGuiModelTest(unittest.TestCase):
 
     def test_that_is_set_to_2D_reduction(self):
         state_gui_model = StateGuiModel(AllStates())
-        state_gui_model.reduction_dimensionality = ReductionDimensionality.TWO_DIM
-        self.assertEqual(state_gui_model.reduction_dimensionality, ReductionDimensionality.TWO_DIM)
+        expected = ReductionDimensionality.TWO_DIM
+        state_gui_model.reduction_dimensionality = expected
+
+        self.assertEqual(expected, state_gui_model.reduction_dimensionality)
+        self.assertEqual(expected, state_gui_model.all_states.convert_to_q.reduction_dimensionality)
+        self.assertEqual(expected, state_gui_model.all_states.reduction.reduction_dimensionality)
 
     def test_that_raises_when_not_setting_with_reduction_dim_enum(self):
         def red_dim_wrapper():


### PR DESCRIPTION
**Description of work.**

Fixes the 2D reduction button not working. This was a combination of
minor problems:

- The presenter was not updating the model with the option. This became
a problem when the model was told off for reaching into the view as part
of the TOML work.
- When using a custom user file we ignore the GUI settings. This was a
little too strict as we were ignoring the reduction mode
- For some reason we have the ReductionDimensionality duplicated within
our state objects. If the GUI model does not set both, half the
reduction would be in 2D/1D.

**Report to:** @smk78 

**To test:**

- Download the ISIS Training data
- Make a copy of Maskfile.txt, call it something easy like `a.txt`
- Open the SANS GUI, set the user file to `Maskfile.txt`
- Use the batch file button and open the CSV in the same folder
- For the second run, in the user column enter your copy (e.g. `a.txt`) leave the first run blank
- Change the button at the bottom to 2D
- Process all and check that there is >1 spectrum (a colour fill has two dimensions) this means it's 2D
- Change button back to 1D, re-run. Check there is a single spectrum meaning its 1D

Fixes #29482 

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
