### PR TITLE
Adjust color cycle in Muon Analysis

### DIFF
--- a/docs/source/release/v5.1.0/muon.rst
+++ b/docs/source/release/v5.1.0/muon.rst
@@ -60,7 +60,7 @@ Improvements
 - Updated :ref:`LoadMuonNexusV2 <algm-LoadMuonNexusV2>` and  :ref:`LoadPSIMuonBin <algm-LoadPSIMuonBin>` to add an option to not auto-correct the time by loaded timezero.
 - Fitting tab in Muon analysis and Frequency domain analysis GUI's are now disabled when no valid fitting data is present.
 - Globals parameters within the function browser will no longer reset when a new function is added/removed.
-- Updated plotting to make line colours more consistent.
+- Updated plotting to make line colours more consistent. The maximum number of unique line colors in each plot is 10.
 - The ALC interface in workbench will now show errors by default. The error bars can also be turned on/off using the right-click plot menu.
 - Have updated the FDA GUI so that it functions correctly for frequency transforms and single fits.
 - Added in default group and pair selection when loading grouping files from xml.

--- a/scripts/Muon/GUI/Common/plot_widget/plotting_canvas/plot_color_queue.py
+++ b/scripts/Muon/GUI/Common/plot_widget/plotting_canvas/plot_color_queue.py
@@ -4,36 +4,49 @@
 #   NScD Oak Ridge National Laboratory, European Spallation Source,
 #   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
 # SPDX - License - Identifier: GPL - 3.0 +
-
 # See https://docs.python.org/3/library/heapq.html for details on heapq
 import heapq
 
 
 class ColorQueue(object):
-    def __init__(self):
-        self._queue = []
-        self._max_index = 0
-
-    def __call__(self):
-        if len(self._queue) != 0:
-            return 'C' + str(heapq.heappop(self._queue))
-        else:
-            return_value = 'C' + str(self._max_index)
-            self._max_index = self._max_index + 1
-            return return_value
-
-    def __add__(self, color):
-        # Could use rexp to do these checks but feels
-        # like overkill in this case.
-        if color[0] != 'C':
-            return self
-        try:
-            colour_index = int(color[1:])
-        except ValueError:
-            return self
-        heapq.heappush(self._queue, colour_index)
-        return self
+    def __init__(self, color_list):
+        """Create a ColorQueue based on an input color_list
+        The entry at index 0 has highest priority
+        color_list could be an input list of color codes
+        e.g ['C0', 'C1', 'C2']
+        or a list of hex colors
+        e.g [#000000,#FF0000....]
+        or rgb values
+        e.g [(0, 0, 0), (255, 0, 0)..]
+        All the above are supported by matplotlib
+        """
+        self._color_cache = {color_list[i]: i for i in range(len(color_list))}
+        self._initialise_queue()
 
     def reset(self):
-        self._max_index = 0
+        """Reset the queue based on the stored color_cache"""
+        self._initialise_queue()
+
+    def __call__(self):
+        """Pop the highest priority color off the queue"""
+        if len(self._queue) == 0:
+            self._initialise_queue()
+        return heapq.heappop(self._queue)[1]
+
+    def __add__(self, color):
+        """Add a color into the queue, with its priority found from the stored cache
+        If its a duplicate color, it will be ignored"""
+        if not any(self._queue[i][1] == color for i in range(len(self._queue))):
+            heapq.heappush(self._queue, (self._get_color_priority(color), color))
+        return self
+
+    def _initialise_queue(self):
+        """Initialize the heap queue with the color_cache"""
         self._queue = []
+        for color, priority in self._color_cache.items():
+            heapq.heappush(self._queue, (priority, color))
+
+    def _get_color_priority(self, color):
+        """Return the priority of a color, if it is not present in the cache
+        set the priority so that it is in the back of the queue"""
+        return self._color_cache.get(color, max(len(self._queue), len(self._color_cache)) + 1)

--- a/scripts/Muon/GUI/Common/plot_widget/plotting_canvas/plot_color_queue.py
+++ b/scripts/Muon/GUI/Common/plot_widget/plotting_canvas/plot_color_queue.py
@@ -20,6 +20,7 @@ class ColorQueue(object):
         e.g [(0, 0, 0), (255, 0, 0)..]
         All the above are supported by matplotlib
         """
+        # Create a cache of the color list, where each entry is a {color: priority} pair
         self._color_cache = {color_list[i]: i for i in range(len(color_list))}
         self._initialise_queue()
 

--- a/scripts/Muon/GUI/Common/plot_widget/plotting_canvas/plotting_canvas_view.py
+++ b/scripts/Muon/GUI/Common/plot_widget/plotting_canvas/plotting_canvas_view.py
@@ -27,6 +27,8 @@ else:
     from matplotlib.backends.backend_qt4agg import FigureCanvas
 
 DEFAULT_X_LIMITS = [0, 15]
+# Default color cycle using Matplotlib color codes C0, C1...ect
+DEFAULT_COLOR_CYCLE = ["C" + str(index) for index in range(10)]
 
 
 def _do_single_plot(ax, workspace, index, errors, plot_kwargs):
@@ -49,7 +51,7 @@ class PlottingCanvasView(QtWidgets.QWidget, PlottingCanvasViewInterface):
         self.fig, axes = get_plot_fig(overplot=False, ax_properties=None, axes_num=1,
                                       fig=self.fig)
         self._number_of_axes = 1
-        self._color_queue = [ColorQueue()]
+        self._color_queue = [ColorQueue(DEFAULT_COLOR_CYCLE)]
 
         layout = QtWidgets.QVBoxLayout()
         layout.addWidget(self.toolBar)
@@ -88,7 +90,7 @@ class PlottingCanvasView(QtWidgets.QWidget, PlottingCanvasViewInterface):
         self.toolBar.reset_gridline_flags()
         self._plot_information_list = []
         self._number_of_axes = num_axes
-        self._color_queue = [ColorQueue() for _ in range(num_axes) ]
+        self._color_queue = [ColorQueue(DEFAULT_COLOR_CYCLE) for _ in range(num_axes)]
         self.fig.clf()
         self.fig, axes = get_plot_fig(overplot=False, ax_properties=None, axes_num=num_axes,
                                       fig=self.fig)
@@ -275,10 +277,10 @@ class PlottingCanvasView(QtWidgets.QWidget, PlottingCanvasViewInterface):
         return bottom, top
 
     def _reset_color_cycle(self):
-        for ax in self.fig.axes:
+        for i, ax in enumerate(self.fig.axes):
             ax.cla()
             ax.tracked_workspaces.clear()
-            ax.set_prop_cycle(None)
+            self._color_queue[i].reset()
 
     def resizeEvent(self, event):
         self.fig.tight_layout()
@@ -286,8 +288,8 @@ class PlottingCanvasView(QtWidgets.QWidget, PlottingCanvasViewInterface):
     def add_uncheck_autoscale_subscriber(self, observer):
         self.toolBar.uncheck_autoscale_notifier.add_subscriber(observer)
 
-    def add_enable_autoscale_subscriber(self,observer):
+    def add_enable_autoscale_subscriber(self, observer):
         self.toolBar.enable_autoscale_notifier.add_subscriber(observer)
 
-    def add_disable_autoscale_subscriber(self,observer):
+    def add_disable_autoscale_subscriber(self, observer):
         self.toolBar.uncheck_autoscale_notifier.add_subscriber(observer)

--- a/scripts/Muon/GUI/Common/plot_widget/plotting_canvas/plotting_canvas_view.py
+++ b/scripts/Muon/GUI/Common/plot_widget/plotting_canvas/plotting_canvas_view.py
@@ -280,7 +280,6 @@ class PlottingCanvasView(QtWidgets.QWidget, PlottingCanvasViewInterface):
         for i, ax in enumerate(self.fig.axes):
             ax.cla()
             ax.tracked_workspaces.clear()
-            self._color_queue[i].reset()
 
     def resizeEvent(self, event):
         self.fig.tight_layout()

--- a/scripts/test/Muon/plotting_canvas/plot_color_queue_test.py
+++ b/scripts/test/Muon/plotting_canvas/plot_color_queue_test.py
@@ -7,29 +7,43 @@
 import unittest
 from Muon.GUI.Common.plot_widget.plotting_canvas.plot_color_queue import ColorQueue
 
+EXAMPLE_COLOR_QUEUE = ["C" + str(i) for i in range(10)]
 
-class PlottingCanvasPresenterTest(unittest.TestCase):
+
+class PlotColorQueueTest(unittest.TestCase):
 
     def setUp(self):
-        self.color_queue = ColorQueue()
+        self.color_queue = ColorQueue(EXAMPLE_COLOR_QUEUE)
 
     def test_color_queue_returns_expected_colors_when_none_added(self):
-        for i in range(27):
+        for i in range(10):
             self.assertEqual('C' + str(i), self.color_queue())
 
-    def test_color_queue_returns_top_queue_when_colors_added(self):
-        self.color_queue += 'C5'
-        self.color_queue += 'C7'
-
-        self.assertEqual('C5', self.color_queue())
-        self.assertEqual('C7', self.color_queue())
+    def test_color_queue_repeats_cycle_when_out_of_range(self):
+        for i in range(10):
+            self.assertEqual('C' + str(i), self.color_queue())
         self.assertEqual('C0', self.color_queue())
 
-    def test_that_color_queue_ignores_invalid_additions(self):
-        self.color_queue += 'fC5'
-        self.color_queue += 'hello'
+    def test_color_queue_returns_when_colors_popped_and_pushed(self):
+        # pop the first two colors
+        self.color_queue()
+        self.color_queue()
+        self.color_queue()
+        # Add first color back in, it should be top of queue
+        self.color_queue += EXAMPLE_COLOR_QUEUE[0]
 
         self.assertEqual('C0', self.color_queue())
+        # The next color in the cycle
+        self.assertEqual('C3', self.color_queue())
+
+    def test_add_unknown_color_to_queue_adds_at_back(self):
+        self.color_queue += "test"
+        self.assertEqual('test', self.color_queue._queue[-1][1])
+
+    def test_add_color_ignores_duplicates(self):
+        self.color_queue += EXAMPLE_COLOR_QUEUE[0]
+        self.assertEqual('C0', self.color_queue())
+        self.assertEqual('C1', self.color_queue())
 
     def test_that_reset_functions_correctly(self):
         self.color_queue()

--- a/scripts/test/Muon/plotting_canvas/plot_color_queue_test.py
+++ b/scripts/test/Muon/plotting_canvas/plot_color_queue_test.py
@@ -44,6 +44,7 @@ class PlotColorQueueTest(unittest.TestCase):
         self.color_queue += EXAMPLE_COLOR_QUEUE[0]
         self.assertEqual('C0', self.color_queue())
         self.assertEqual('C1', self.color_queue())
+        self.assertEqual('C9', self.color_queue._queue[-1][1])
 
     def test_that_reset_functions_correctly(self):
         self.color_queue()


### PR DESCRIPTION
**Description of work.**
This PR fixes an issue with the color cycle on Linux. To avoid issues like this in the future, this PR also moves some things around in the color cycle, so it takes a color list as an input, which could be a matplotlib cycle or a list of hex/rgb color values. 


**To test:**
- Open Muon analysis
- Load some data
- Mess around with the plots and tiled plots, the general idea is that if you remove a line from the plot the next line should be plotted in that color.
- If you plot more than 10 lines the color cycle will repeat itself
<!-- Instructions for testing. -->

Fixes #29461 . <!-- and fix #xxxx or close #xxxx xor resolves #xxxx -->
<!-- alternative
*There is no associated issue.*
-->


*This does not require release notes* because it was a feature introduced this release.


<!-- Ensure the base of this PR is correct (e.g. release-next or master)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
