### PR TITLE
Reduce log level for failed plots in project recovery

### DIFF
--- a/docs/source/release/v5.1.0/mantidworkbench.rst
+++ b/docs/source/release/v5.1.0/mantidworkbench.rst
@@ -117,6 +117,7 @@ Improvements
 - In the instrument widget's rendering tab, added a Reset view button to restore to default projection.
 - In the instrument widget's draw tab, added the option to mask, draw ROI and group single pixel and tube.
 - `TableWorkspaces` can now have columns containing errors linked to corresponding columns containing values, using the `setLinkedYCol(errColumn, dataColumn)`.
+- Reduce log level of project recovery when it fails to save a plot correctly, to debug from warning level, to avoid excess messages in the console.
 
 
 Bugfixes

--- a/qt/python/mantidqt/project/plotssaver.py
+++ b/qt/python/mantidqt/project/plotssaver.py
@@ -40,10 +40,12 @@ class PlotsSaver(object):
                 # have built your project.
                 if isinstance(e, KeyboardInterrupt):
                     raise KeyboardInterrupt
+
+                error_string = "Plot: " + str(index) + " was not saved. Error: " + str(e)
                 if not is_project_recovery:
-                    logger.warning("A plot was unable to be saved")
+                    logger.warning(error_string)
                 else:
-                    logger.debug("A plot was unable to be saved")
+                    logger.debug(error_string)
         return plot_list
 
     def get_dict_from_fig(self, fig):

--- a/qt/python/mantidqt/project/plotssaver.py
+++ b/qt/python/mantidqt/project/plotssaver.py
@@ -26,7 +26,7 @@ class PlotsSaver(object):
     def __init__(self):
         self.figure_creation_args = {}
 
-    def save_plots(self, plot_dict):
+    def save_plots(self, plot_dict, is_project_recovery=False):
         # if arguement is none return empty dictionary
         if plot_dict is None:
             return []
@@ -40,7 +40,10 @@ class PlotsSaver(object):
                 # have built your project.
                 if isinstance(e, KeyboardInterrupt):
                     raise KeyboardInterrupt
-                logger.warning("A plot was unable to be saved")
+                if not is_project_recovery:
+                    logger.warning("A plot was unable to be saved")
+                else:
+                    logger.debug("A plot was unable to be saved")
         return plot_list
 
     def get_dict_from_fig(self, fig):

--- a/qt/python/mantidqt/project/projectsaver.py
+++ b/qt/python/mantidqt/project/projectsaver.py
@@ -52,7 +52,7 @@ class ProjectSaver(object):
             saved_workspaces = ADS.getObjectNames()
 
         # Generate plots
-        plots_to_save_list = PlotsSaver().save_plots(plots_to_save)
+        plots_to_save_list = PlotsSaver().save_plots(plots_to_save, not project_recovery)
 
         # Save interfaces
         if interfaces_to_save is None:


### PR DESCRIPTION
**Description of work.**
Hidden the plot failure log message as debug instead of showing a warning in the log during project recovery.

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

**To test:**
- Open workbench
- Right click on the log and make sure it is showing Debug
- Download and Load into workbench:
[scatterabletable.zip](https://github.com/mantidproject/mantid/files/5238180/scatterabletable.zip)
- Open Table workspace data
- Set column 1 as X
- Set column 2 as Y
- Set column 3 as Y_Error
- Click Column 2 and right click, click plot, then click scatter + errors.
- Then wait for the debug message saying `A plot was unable to be saved`
- it should not show a warning


<!-- Instructions for testing. -->

Fixes #29503 <!-- and fix #xxxx or close #xxxx xor resolves #xxxx -->
<!-- alternative
*There is no associated issue.*
-->

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or master)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
