### PR TITLE
Check separately for HAB coordinates in legacy SANS parser

### DIFF
--- a/scripts/Interface/ui/sans_isis/sans_data_processor_gui.py
+++ b/scripts/Interface/ui/sans_isis/sans_data_processor_gui.py
@@ -1448,7 +1448,10 @@ class SANSDataProcessorGui(QMainWindow,
     @property
     def transmission_sample_fit_type(self):
         fit_type_as_string = self.fit_sample_fit_type_combo_box.currentText()
-        return FitType(fit_type_as_string)
+        try:
+            return FitType(fit_type_as_string)
+        except (RuntimeError, ValueError):
+            return
 
     @transmission_sample_fit_type.setter
     def transmission_sample_fit_type(self, value):
@@ -1461,7 +1464,10 @@ class SANSDataProcessorGui(QMainWindow,
     @property
     def transmission_can_fit_type(self):
         fit_type_as_string = self.fit_can_fit_type_combo_box.currentText()
-        return FitType(fit_type_as_string)
+        try:
+            return FitType(fit_type_as_string)
+        except (RuntimeError, ValueError):
+            return None
 
     @transmission_can_fit_type.setter
     def transmission_can_fit_type(self, value):
@@ -1682,7 +1688,7 @@ class SANSDataProcessorGui(QMainWindow,
         q_xy_step_type_as_string = self.q_xy_step_type_combo_box.currentText()
         try:
             return RangeStepType(q_xy_step_type_as_string)
-        except RuntimeError:
+        except ValueError:
             return None
 
     @q_xy_step_type.setter

--- a/scripts/SANS/sans/user_file/txt_parsers/ParsedDictConverter.py
+++ b/scripts/SANS/sans/user_file/txt_parsers/ParsedDictConverter.py
@@ -741,8 +741,6 @@ class ParsedDictConverter(IStateParser):
         # ---------------------------
         if SetId.CENTRE in self._input_dict:
             beam_centres = self._input_dict[SetId.CENTRE]
-            beam_centres_for_hab = [beam_centre for beam_centre in beam_centres if beam_centre.detector_type
-                                    is DetectorType.HAB]
             beam_centres_for_lab = [beam_centre for beam_centre in beam_centres if beam_centre.detector_type
                                     is DetectorType.LAB]
             for beam_centre in beam_centres_for_lab:
@@ -750,16 +748,19 @@ class ParsedDictConverter(IStateParser):
                 pos2 = beam_centre.pos2
                 state_builder.set_LAB_sample_centre_pos1(state_builder.convert_pos1(pos1))
                 state_builder.set_LAB_sample_centre_pos2(state_builder.convert_pos2(pos2))
+                # default both detectors to the same centre position
                 if hasattr(state_builder, "set_HAB_sample_centre_pos1"):
                     state_builder.set_HAB_sample_centre_pos1(state_builder.convert_pos1(pos1))
                 if hasattr(state_builder, "set_HAB_sample_centre_pos2"):
                     state_builder.set_HAB_sample_centre_pos2(state_builder.convert_pos2(pos2))
 
+        if SetId.CENTRE_HAB in self._input_dict:
+            beam_centres = self._input_dict[SetId.CENTRE_HAB]
+            beam_centres_for_hab = [beam_centre for beam_centre in beam_centres if beam_centre.detector_type
+                                    is DetectorType.HAB]
             for beam_centre in beam_centres_for_hab:
-                pos1 = beam_centre.pos1
-                pos2 = beam_centre.pos2
-                state_builder.set_HAB_sample_centre_pos1(state_builder.convert_pos1(pos1))
-                state_builder.set_HAB_sample_centre_pos2(state_builder.convert_pos2(pos2))
+                state_builder.set_HAB_sample_centre_pos1(state_builder.convert_pos1(beam_centre.pos1))
+                state_builder.set_HAB_sample_centre_pos2(state_builder.convert_pos2(beam_centre.pos2))
 
         return state_builder.build()
 

--- a/scripts/test/SANS/command_interface/command_interface_state_director_test.py
+++ b/scripts/test/SANS/command_interface/command_interface_state_director_test.py
@@ -136,9 +136,14 @@ class CommandInterfaceStateDirectorTest(unittest.TestCase):
         self.assertEqual(state.reduction.reduction_mode, ReductionMode.HAB)
         self.assertTrue(state.convert_to_q.use_gravity)
         self.assertEqual(state.convert_to_q.gravity_extra_length,  12.4)
-        self.assertEqual(state.move.detectors[DetectorType.HAB.value].sample_centre_pos1,  12.4/1000.)
-        self.assertTrue(state.move.detectors[DetectorType.HAB.value].sample_centre_pos2
-                        == 23.54/1000.)
+        self.assertEqual(state.move.detectors[DetectorType.LAB.value].sample_centre_pos1,
+                         108.1/1000.)
+        self.assertEqual(state.move.detectors[DetectorType.LAB.value].sample_centre_pos2,
+                         -83.0/1000.)
+        self.assertEqual(state.move.detectors[DetectorType.HAB.value].sample_centre_pos1,
+                         108.1/1000.)
+        self.assertEqual(state.move.detectors[DetectorType.HAB.value].sample_centre_pos2,
+                         -83.0/1000.)
         self.assertTrue(state.adjustment.calculate_transmission.fit[DataType.CAN.value].fit_type
                         is FitType.LOGARITHMIC)
         self.assertTrue(state.adjustment.calculate_transmission.fit[DataType.CAN.value].polynomial_order

--- a/scripts/test/SANS/user_file/txt_parsers/ParsedDictConverterTest.py
+++ b/scripts/test/SANS/user_file/txt_parsers/ParsedDictConverterTest.py
@@ -10,7 +10,7 @@ from unittest import mock
 
 from sans.common.configurations import Configurations
 from sans.common.enums import DetectorType, SANSInstrument, ReductionMode, RangeStepType, RebinType, DataType, FitType
-from sans.test_helper.user_file_test_helper import create_user_file, sample_user_file
+from sans.test_helper.user_file_test_helper import base_user_file, create_user_file, sample_user_file
 from sans.user_file.txt_parsers.UserFileReaderAdapter import UserFileReaderAdapter
 
 
@@ -53,8 +53,12 @@ class ParsedDictConverterTest(unittest.TestCase):
         # Detector specific
         lab = move.detectors[DetectorType.LAB.value]
         hab = move.detectors[DetectorType.HAB.value]
+        self.assertEqual(lab.sample_centre_pos1,  155.45/1000.)
+        self.assertEqual(lab.sample_centre_pos2, -169.6/1000.)
         self.assertEqual(lab.x_translation_correction,  -16.0/1000.)
         self.assertEqual(lab.z_translation_correction,  47.0/1000.)
+        self.assertEqual(hab.sample_centre_pos1,  155.45/1000. )
+        self.assertEqual(hab.sample_centre_pos2, -169.6/1000.)
         self.assertEqual(hab.x_translation_correction,  -44.0/1000.)
         self.assertEqual(hab.y_translation_correction,  -20.0/1000.)
         self.assertEqual(hab.z_translation_correction,  47.0/1000.)
@@ -188,6 +192,23 @@ class ParsedDictConverterTest(unittest.TestCase):
         # Assert wide angle correction
         self.assertTrue(state.adjustment.wide_angle_correction)
         self.assertEqual("TUBE_SANS2D_BOTH_31681_25Sept15.nxs", state.adjustment.calibration)
+
+    def test_move_with_hab_centre_uses_hab_centre_value(self):
+        user_file_centre = """
+        set centre 160.2 -170.5
+        set centre/hab 160.5 -170.1
+        """
+        user_file_path = create_user_file(user_file_centre)
+        mocked_sans = self.create_mock_inst_file_information(SANSInstrument.SANS2D)
+        parser = UserFileReaderAdapter(user_file_name=user_file_path, file_information=mocked_sans)
+        state = parser.get_all_states(file_information=mocked_sans)
+        move = state.move
+        lab = move.detectors[DetectorType.LAB.value]
+        hab = move.detectors[DetectorType.HAB.value]
+        self.assertEqual(lab.sample_centre_pos1,  160.2/1000.)
+        self.assertEqual(lab.sample_centre_pos2, -170.5/1000.)
+        self.assertEqual(hab.sample_centre_pos1,  160.5/1000. )
+        self.assertEqual(hab.sample_centre_pos2, -170.1/1000.)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
**Description of work.**

Adds a missing check if the user file parser pulled out a separate `SET CENTRE` line for the HAB module. 

Also adds a test to verify this works as expected along with some minor fixes to make sure the debugger is able to attach correctly.

**To test:**

* I used the `MaskFile.txt` in the Sample ISIS data and added a line `SET CENTRE/HAB 321.209 319.683`
* Before these changes this line was ignored. The HAB box should now show the separate coordinates
* Removing the `/HAB` line should show the same coordinates in both.

Fixes #29501

*This does not require release notes* because **it is a regression since 5.0**

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
