### PR TITLE
CORELLI tube-calibration algorithm with input from home-made Cd-wire-panels scans

### DIFF
--- a/scripts/Calibration/__init__.py
+++ b/scripts/Calibration/__init__.py
@@ -1,0 +1,6 @@
+# Mantid Repository : https://github.com/mantidproject/mantid
+#
+# Copyright &copy; 2019 ISIS Rutherford Appleton Laboratory UKRI,
+#   NScD Oak Ridge National Laboratory, European Spallation Source,
+#   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+# SPDX - License - Identifier: GPL - 3.0 +

--- a/scripts/Calibration/ideal_tube.py
+++ b/scripts/Calibration/ideal_tube.py
@@ -4,7 +4,7 @@
 #   NScD Oak Ridge National Laboratory, European Spallation Source,
 #   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
 # SPDX - License - Identifier: GPL - 3.0 +
-import numpy
+import numpy as np
 
 # This class is the ideal tube, which specifies where the peaks formed by slits or edges should occur
 
@@ -33,27 +33,28 @@ class IdealTube(object):
     * :meth:`~ideal_tube.IdealTube.getFunctionalForms`
 
    """
-    def __init__( self ):
+
+    def __init__(self):
         """
         Create empty instance
         """
-        self.positions = numpy.ndarray((0)) # position of the points in metres
-        self.functionalForms = [] # function form of points 1=peak 2=edge. peaks assumed if [].
+        self.positions = np.empty(0, dtype=float)  # position of the points in metres
+        self.functionalForms = []  # function form of points 1=peak 2=edge. peaks assumed if [].
 
-    def setArray ( self, array ):
+    def setArray (self, array):
         """
        Construct an ideal tube directly from an array of positions
 
-       :param points: Array of points where the peaks should be in Metres
+       :param array: Array of points where the peaks should be in Metres
 
        """
-        self.positions =numpy.array( array)
+        self.positions = np.array(array)
 
     def setForm(self, form):
         """Define the functional form for the peaks"""
         self.functionalForms = form
 
-    def setPositionsAndForm ( self, pos, form ):
+    def setPositionsAndForm (self, pos, form):
         """
        Construct and ideal tube directly from an array of positions and functional forms
 
@@ -61,34 +62,34 @@ class IdealTube(object):
        :param form: Array of functional forms of the points 1=peak, 2=edge
 
        """
-        self.positions = numpy.array(pos )
+        self.positions = np.array(pos)
         self.functionalForms = form
 
-    def constructTubeFor3PointsMethod( self, idealAP, idealBP, idealCP, activeTubeLen ):
+    def constructTubeFor3PointsMethod(self, idealAP, idealBP, idealCP, activeTubeLen):
         """
-       Construct and ideal tube for Merlin 3-point calibration
+        Construct and ideal tube for Merlin 3-point calibration
 
-       :param idealAP: Ideal left (AP) in pixels
-       :param idealBP: ideal right (BP) in pixels
-       :param idealCP: ideal centre (CP) in pixels
-       :param activeTubeLen: Active tube length in metres
+        :param idealAP: Ideal left (AP) in pixels
+        :param idealBP: ideal right (BP) in pixels
+        :param idealCP: ideal centre (CP) in pixels
+        :param activeTubeLen: Active tube length in metres
 
-       """
-       #Construct Ideal tube for 3 point calibration of MERLIN standard tube (code could be put into a function)
+        """
+        #Construct Ideal tube for 3 point calibration of MERLIN standard tube (code could be put into a function)
         pixelLen = activeTubeLen/1024  # Pixel length
 
-       # we then convert idealAP, idealCP and idealBP to Y coordinates and put into ideal tube array
-        self.positions = numpy.array([ idealAP*pixelLen - activeTubeLen/2,
-                                       idealCP*pixelLen - activeTubeLen/2, idealBP*pixelLen - activeTubeLen/2])
-        self.functionalForms = [ 2, 1, 2 ]
+        # we then convert idealAP, idealCP and idealBP to Y coordinates and put into ideal tube array
+        self.positions = np.array([idealAP*pixelLen - activeTubeLen/2,
+                                   idealCP*pixelLen - activeTubeLen/2, idealBP*pixelLen - activeTubeLen/2])
+        self.functionalForms = [2, 1, 2]
 
-    def getArray( self ):
+    def getArray(self):
         """
        Return the array of of points where the peaks should be in Metres
        """
         return self.positions
 
-    def getFunctionalForms( self ):
+    def getFunctionalForms(self):
         """
        Return the array of of points where the peaks should be in Metres
        """

--- a/scripts/Calibration/tube.py
+++ b/scripts/Calibration/tube.py
@@ -941,8 +941,9 @@ class _CalibrationParameterHelper(object):
     def _get_fit_par(self, args, tube_set, ideal_tube):
         if self.FITPAR in args:
             fit_par = args[self.FITPAR]
-            # fitPar must be a TubeCalibFitParams
-            if not isinstance(fit_par, TubeCalibFitParams):
+            try:
+                assert getattr(fit_par, 'setAutomatic')  # duck typing check for correct type
+            except AssertionError:
                 raise RuntimeError(
                     "Wrong argument {0}. This argument, when given, must be a valid TubeCalibFitParams object".
                     format(self.FITPAR))

--- a/scripts/Calibration/tube_spec.py
+++ b/scripts/Calibration/tube_spec.py
@@ -16,9 +16,8 @@
 class TubeSpec:
     """
     The python class :class:`~tube_spec.TubeSpec` provides a way of specifying a set of tubes for
-    calibration, so that the necessary information about detectors etc. is forethcoming. This class
-    is provide by the python file tube_spec.py. The function :func:`~tube_calib.getCalibration` of
-    :mod:`tube_calib` needs such an object.
+    calibration, so that the necessary information about detectors etc. is forthcoming.
+    The function :func:`~tube_calib.getCalibration` of :mod:`tube_calib` needs such an object.
 
     Configuration methods:
 
@@ -39,13 +38,12 @@ class TubeSpec:
 
         Tubes are currently ordered in the specification in the same order as they appear in the IDF.
         This may differ from the order they appear in the workspace indices.
-
     """
 
-    def __init__(self,ws):
+    def __init__(self, ws):
         """
         The constructor creates empty tube specification for specified instrument.
-        :param ws: workspace containing the specified instrument with one pixel detector per spectrum.
+        :param ws: workspace containing the specified instrument with oneN pixel detector per spectrum.
         """
         self.ws = ws
         self.inst = ws.getInstrument()
@@ -54,9 +52,9 @@ class TubeSpec:
         self.componentArray = []
         self.minNumDetsInTube = 200
         self.tubes = []
-        self.delimiter = '/' # delimiter between parts of string in tree
+        self.delimiter = '/'  # delimiter between parts of string in tree
 
-    def setTubeSpecByString(self, tubeSpecString ):
+    def setTubeSpecByString(self, tubeSpecString):
         """
         Define the sets of tube from the workspace.
 

--- a/scripts/corelli/__init__.py
+++ b/scripts/corelli/__init__.py
@@ -1,0 +1,6 @@
+# Mantid Repository : https://github.com/mantidproject/mantid
+#
+# Copyright &copy; 2019 ISIS Rutherford Appleton Laboratory UKRI,
+#   NScD Oak Ridge National Laboratory, European Spallation Source,
+#   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+# SPDX - License - Identifier: GPL - 3.0 +

--- a/scripts/corelli/calibration/__init__.py
+++ b/scripts/corelli/calibration/__init__.py
@@ -1,0 +1,6 @@
+# Mantid Repository : https://github.com/mantidproject/mantid
+#
+# Copyright &copy; 2019 ISIS Rutherford Appleton Laboratory UKRI,
+#   NScD Oak Ridge National Laboratory, European Spallation Source,
+#   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+# SPDX - License - Identifier: GPL - 3.0 +

--- a/scripts/corelli/calibration/utils.py
+++ b/scripts/corelli/calibration/utils.py
@@ -21,7 +21,7 @@ def calculate_tube_calibration(workspace: InputWorkspace, tube_name: str, shadow
     r"""
     Calibration table for one tube of CORELLI
 
-    :workspace:
+    :param workspace: string or handle to ~mantid.dataobjects.Workspace2D
     :param tube_name: string uniquely representing one tube e.g. 'bank88/sixteenpack/tube3'
     :param shadow_height: estimated dip in the background intensity.
     :param shadow_width: estimated width of the shadow cast by the wire, in pixel units

--- a/scripts/corelli/calibration/utils.py
+++ b/scripts/corelli/calibration/utils.py
@@ -29,7 +29,8 @@ def calculate_tube_calibration(workspace: InputWorkspace, tube_name: str, shadow
 
     :return: table containing detector ID and position vector
     """
-    assert isinstance(workspace, (str, Workspace2D)), 'Cannot process this workspace'
+    message = f'Cannot process workspace {workspace}. Pass the name of an existing workspace or a workspace handle'
+    assert isinstance(workspace, (str, Workspace2D)), message
     assert shadow_height > 0, 'shadow height must be positive'
     for marker in ('bank', 'sixteenpack', 'tube'):
         assert marker in tube_name, f'{tube_name} does not uniquely specify one tube'

--- a/scripts/corelli/calibration/utils.py
+++ b/scripts/corelli/calibration/utils.py
@@ -1,0 +1,55 @@
+# Mantid Repository : https://github.com/mantidproject/mantid
+#
+# Copyright &copy; 2018 ISIS Rutherford Appleton Laboratory UKRI,
+#   NScD Oak Ridge National Laboratory, European Spallation Source,
+#   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+# SPDX - License - Identifier: GPL - 3.0 +
+
+import numpy as np
+from typing import Union
+
+# imports from Mantid
+from mantid.dataobjects import TableWorkspace, Workspace2D
+from Calibration import tube
+from Calibration.tube_calib_fit_params import TubeCalibFitParams
+
+InputWorkspace = Union[str, Workspace2D]  # type alias
+
+
+def calculate_tube_calibration(workspace: InputWorkspace, tube_name: str, shadow_height: float = 1000,
+                               shadow_width: float = 4, fit_domain: float = 7) -> TableWorkspace:
+    r"""
+    Calibration table for one tube of CORELLI
+
+    :workspace:
+    :param tube_name: string uniquely representing one tube e.g. 'bank88/sixteenpack/tube3'
+    :param shadow_height: estimated dip in the background intensity.
+    :param shadow_width: estimated width of the shadow cast by the wire, in pixel units
+    :param fit_domain: estimated range, in pixel units, over which to carry out the fit.
+
+    :return: table containing detector ID and position vector
+    """
+    assert isinstance(workspace, (str, Workspace2D)), 'Cannot process this workspace'
+    assert shadow_height > 0, 'shadow height must be positive'
+    for marker in ('bank', 'sixteenpack', 'tube'):
+        assert marker in tube_name, f'{tube_name} does not uniquely specify one tube'
+    peak_height, peak_width = -shadow_height, shadow_width
+    wire_gap = (2 * 25.4 + 2) / 1000  # gap along the Y-coordinate between consecutive wire centers
+    # the center of the 16 wires is aligned with the center of the tube, set to Y == 0
+    wire_positions = np.arange(-7.5 * wire_gap, 8.5 * wire_gap, wire_gap)
+    # Fit only the inner 14 dips because the extrema wires are too close to the tube tips.
+    # The dead zone in the tube tips interferes with the shadow cast by the extrema  wires
+    # preventing a good fitting
+    wire_positions = wire_positions[1: -1]  # drop the extrema wires
+    wire_count = len(wire_positions)
+    peaks_form = [1] * wire_count  # signals we'll be fitting dips (peaks with negative heights)
+    # Initial guess for the peak positions, assuming:
+    # - the center of the the wire mesh coincides with the center ot the tube_calib_fit_params
+    # - wires cast a shadow on a perfectly calibrated tube
+    tube_length, pixels_per_tube = 0.9001, 256
+    fit_extent = (fit_domain / pixels_per_tube) * tube_length  # fit domain in meters
+    assert fit_extent < wire_gap, 'The fit domain cannot be larger than the distance between consecutive wires'
+    wire_pixel_positions = (pixels_per_tube / tube_length) * wire_positions + pixels_per_tube / 2
+    fit_par = TubeCalibFitParams(wire_pixel_positions, height=peak_height, width=peak_width, margin=fit_domain)
+    fit_par.setAutomatic(True)
+    return tube.calibrate(workspace, tube_name, wire_positions, peaks_form, fitPar=fit_par)

--- a/scripts/test/CMakeLists.txt
+++ b/scripts/test/CMakeLists.txt
@@ -48,6 +48,8 @@ unset(PYUNITTEST_QT_API)
 # Additional tests
 add_subdirectory(Abins)
 add_subdirectory(directtools)
+add_subdirectory(Calibration)
+add_subdirectory(corelli)
 add_subdirectory(MultiPlotting)
 add_subdirectory(Muon)
 add_subdirectory(sample_transmission_calculator)

--- a/scripts/test/Calibration/CMakeLists.txt
+++ b/scripts/test/Calibration/CMakeLists.txt
@@ -1,0 +1,10 @@
+# Unit tests for Calibration
+
+set(TEST_PY_FILES
+    test_ideal_tube.py
+    )
+
+check_tests_valid(${CMAKE_CURRENT_SOURCE_DIR} ${TEST_PY_FILES})
+
+pyunittest_add_test(${CMAKE_CURRENT_SOURCE_DIR} python.Calibration
+                    ${TEST_PY_FILES})

--- a/scripts/test/Calibration/__init__.py
+++ b/scripts/test/Calibration/__init__.py
@@ -1,0 +1,6 @@
+# Mantid Repository : https://github.com/mantidproject/mantid
+#
+# Copyright &copy; 2019 ISIS Rutherford Appleton Laboratory UKRI,
+#   NScD Oak Ridge National Laboratory, European Spallation Source,
+#   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+# SPDX - License - Identifier: GPL - 3.0 +

--- a/scripts/test/Calibration/test_ideal_tube.py
+++ b/scripts/test/Calibration/test_ideal_tube.py
@@ -1,0 +1,38 @@
+# Mantid Repository : https://github.com/mantidproject/mantid
+#
+# Copyright &copy; 2018 ISIS Rutherford Appleton Laboratory UKRI,
+#   NScD Oak Ridge National Laboratory, European Spallation Source,
+#   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+# SPDX - License - Identifier: GPL - 3.0 +
+
+import numpy as np
+from numpy.testing import assert_allclose
+import unittest
+from Calibration.ideal_tube import IdealTube
+
+
+class TestIdealTube(unittest.TestCase):
+    def setUp(self):
+        tube_length = 0.003278125 * 256  # assume a tube of 256 pixels, each about 3 mm tall
+        self.peaks_count = 16  # assume we calibrate the tube with 16 peaks
+        # partition the tube into 16 chunks and output the middle-position of each chunk
+        self.peak_centers = np.linspace(0, tube_length, 2 * self.peaks_count, endpoint=False)[1::2]
+
+    def test_init(self):
+        self.assertTrue(IdealTube())
+
+    def test_setArray(self):
+        tube = IdealTube()
+        tube.setArray(self.peak_centers)
+        assert_allclose(tube.positions, self.peak_centers, atol=1e-6)
+
+    def test_getArray(self):
+        tube = IdealTube()
+        tube.setArray(self.peak_centers)
+        self.assertTrue(isinstance(tube.getArray(), np.ndarray))
+
+
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/scripts/test/corelli/CMakeLists.txt
+++ b/scripts/test/corelli/CMakeLists.txt
@@ -1,0 +1,1 @@
+add_subdirectory(calibration)

--- a/scripts/test/corelli/__init__.py
+++ b/scripts/test/corelli/__init__.py
@@ -1,0 +1,6 @@
+# Mantid Repository : https://github.com/mantidproject/mantid
+#
+# Copyright &copy; 2019 ISIS Rutherford Appleton Laboratory UKRI,
+#   NScD Oak Ridge National Laboratory, European Spallation Source,
+#   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+# SPDX - License - Identifier: GPL - 3.0 +

--- a/scripts/test/corelli/calibration/CMakeLists.txt
+++ b/scripts/test/corelli/calibration/CMakeLists.txt
@@ -1,0 +1,10 @@
+# Unit tests for corelli/calibration
+
+set(TEST_PY_FILES
+    test_utils.py
+    )
+
+check_tests_valid(${CMAKE_CURRENT_SOURCE_DIR} ${TEST_PY_FILES})
+
+pyunittest_add_test(${CMAKE_CURRENT_SOURCE_DIR} python.corelli.calibration
+                    ${TEST_PY_FILES})

--- a/scripts/test/corelli/calibration/__init__.py
+++ b/scripts/test/corelli/calibration/__init__.py
@@ -1,0 +1,6 @@
+# Mantid Repository : https://github.com/mantidproject/mantid
+#
+# Copyright &copy; 2019 ISIS Rutherford Appleton Laboratory UKRI,
+#   NScD Oak Ridge National Laboratory, European Spallation Source,
+#   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+# SPDX - License - Identifier: GPL - 3.0 +

--- a/scripts/test/corelli/calibration/test_utils.py
+++ b/scripts/test/corelli/calibration/test_utils.py
@@ -1,0 +1,86 @@
+# Mantid Repository : https://github.com/mantidproject/mantid
+#
+# Copyright &copy; 2018 ISIS Rutherford Appleton Laboratory UKRI,
+#   NScD Oak Ridge National Laboratory, European Spallation Source,
+#   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+# SPDX - License - Identifier: GPL - 3.0 +
+
+import numpy as np
+from numpy.testing import assert_allclose
+import unittest
+
+from corelli.calibration.utils import calculate_tube_calibration
+from mantid.simpleapi import DeleteWorkspaces, LoadEmptyInstrument
+
+
+class TestUtils(unittest.TestCase):
+
+    def setUp(self) -> None:
+        # Neutron counts along a tube
+        counts = [50, 122, 118, 197, 414, 545, 1026, 1767, 3242, 7132, 16232, 34663, 52842, 59767, 58638, 55250, 47723,
+                  47400, 54642, 56830, 57664, 57563, 57398, 57438, 57370, 57386, 57447, 56951, 57258, 56195, 52775,
+                  46106, 48802, 54698, 57072, 57876, 57754, 57712, 57800, 57837, 57606, 57398, 57038, 56504, 54408,
+                  49406, 44668, 50911, 55364, 55906, 56175, 56612, 56375, 56179, 56265, 56329, 56497, 56131, 55034,
+                  52618, 46515, 44466, 51293, 54234, 54961, 55219, 54601, 54359, 54866, 54839, 54474, 54031, 54064,
+                  53431, 50619, 44013, 45435, 52264, 54087, 55002, 54589, 54568, 53516, 53285, 52656, 52676, 52420,
+                  52375, 51837, 47664, 41643, 45292, 51215, 52851, 53284, 53421, 52999, 52985, 52596, 52799, 52658,
+                  51894, 51504, 50154, 44435, 39820, 45640, 49871, 50920, 51190, 51091, 51448, 50937, 50927, 50773,
+                  51173, 50819, 50110, 48138, 42389, 39823, 46671, 50037, 50013, 50840, 50400, 50138, 49500, 50616,
+                  49890, 49853, 49548, 48731, 45211, 39185, 39270, 45409, 47628, 48348, 48652, 48025, 48518, 48915,
+                  48351, 48486, 48391, 47793, 47079, 43590, 37528, 40016, 45604, 47259, 47710, 47252, 47687, 47145,
+                  47453, 47409, 47294, 46735, 46170, 45028, 40783, 35924, 40234, 44613, 45660, 45921, 45125, 45544,
+                  45482, 45261, 45326, 45547, 44914, 44966, 43711, 39302, 35101, 39600, 44185, 45054, 44538, 44443,
+                  44617, 44509, 44589, 44806, 45078, 44265, 44053, 42055, 36702, 35192, 40304, 42712, 42910, 42992,
+                  43593, 44157, 43675, 43442, 43348, 43668, 42447, 42193, 39349, 33887, 34026, 38630, 40354, 40798,
+                  40866, 40592, 40593, 40645, 40507, 40316, 40256, 40068, 39481, 37928, 33034, 31521, 36298, 38938,
+                  39451, 39544, 39479, 39624, 39471, 39300, 39197, 38777, 39288, 39163, 37350, 33507, 31309, 36124,
+                  38921, 30633, 14932, 5370, 2069, 955, 545, 329, 216, 157, 82, 49, 54, 25, 10]
+        # Calibrated Y-coordinates
+        y = [-0.342, -0.338, -0.335, -0.331, -0.328, -0.324, -0.320, -0.317, -0.313, -0.310, -0.306, -0.303, -0.299,
+             -0.296, -0.292, -0.289, -0.285, -0.282, -0.278, -0.275, -0.271, -0.268, -0.264, -0.261, -0.257, -0.254,
+             -0.250, -0.247, -0.243, -0.240, -0.236, -0.232, -0.229, -0.225, -0.222, -0.218, -0.215, -0.211, -0.208,
+             -0.204, -0.201, -0.197, -0.194, -0.190, -0.187, -0.183, -0.180, -0.176, -0.173, -0.169, -0.166, -0.162,
+             -0.159, -0.155, -0.152, -0.148, -0.144, -0.141, -0.137, -0.134, -0.130, -0.127, -0.123, -0.120, -0.116,
+             -0.113, -0.109, -0.106, -0.102, -0.099, -0.095, -0.092, -0.088, -0.085, -0.081, -0.078, -0.074, -0.071,
+             -0.067, -0.064, -0.060, -0.056, -0.053, -0.049, -0.046, -0.042, -0.039, -0.035, -0.032, -0.028, -0.025,
+             -0.021, -0.018, -0.014, -0.011, -0.007, -0.004, -0.000,  0.003,  0.007,  0.010,  0.014,  0.017,  0.021,
+             0.024,  0.028,  0.032,  0.035,  0.039,  0.042,  0.046,  0.049,  0.053,  0.056,  0.060,  0.063,  0.067,
+             0.070,  0.074,  0.077,  0.081,  0.084,  0.088,  0.091,  0.095,  0.098,  0.102,  0.105,  0.109,  0.112,
+             0.116,  0.120,  0.123,  0.127,  0.130,  0.134,  0.137,  0.141,  0.144,  0.148,  0.151,  0.155,  0.158,
+             0.162,  0.165,  0.169,  0.172,  0.176,  0.179,  0.183,  0.186,  0.190,  0.193,  0.197,  0.200,  0.204,
+             0.208,  0.211,  0.215,  0.218,  0.222,  0.225,  0.229,  0.232,  0.236,  0.239,  0.243,  0.246,  0.250,
+             0.253,  0.257,  0.260,  0.264,  0.267,  0.271,  0.274,  0.278,  0.281,  0.285,  0.288,  0.292,  0.296,
+             0.299,  0.303,  0.306,  0.310,  0.313,  0.317,  0.320,  0.324,  0.327,  0.331,  0.334,  0.338,  0.341,
+             0.345,  0.348,  0.352,  0.355,  0.359,  0.362,  0.366,  0.369,  0.373,  0.376,  0.380,  0.384,  0.387,
+             0.391,  0.394,  0.398,  0.401,  0.405,  0.408,  0.412,  0.415,  0.419,  0.422,  0.426,  0.429,  0.433,
+             0.436,  0.440,  0.443,  0.447,  0.450,  0.454,  0.457,  0.461,  0.464,  0.468,  0.472,  0.475,  0.479,
+             0.482,  0.486,  0.489,  0.493,  0.496,  0.500,  0.503,  0.507,  0.510,  0.514,  0.517,  0.521,  0.524,
+             0.528,  0.531,  0.535,  0.538,  0.542,  0.545,  0.549,  0.552,  0.556]
+        # Create a workspace with an uncalibrated tube bank42/sixteenpack/tube8
+        workspace = LoadEmptyInstrument(InstrumentName='CORELLI', MakeEventWorkspace=False,
+                                        OutputWorkspace='uncalibrated')
+        # the workspace index for the first pixel in bank87/sixteenpack/tube12 is 355075
+        for pixel_index in range(256):
+            workspace.dataY(355075 + pixel_index)[:] = counts[pixel_index]
+        self.workspace = 'uncalibrated'
+        self.table = 'calibTable'
+        self.calibrated_y = y
+
+    def test_calculate_tube_calibration(self) -> None:
+        # Check the validators are doing what they're supposed to do
+        with self.assertRaises(AssertionError) as exception_info:
+            calculate_tube_calibration(None, 'bank42/sixteenpack/tube8')
+        assert 'Cannot process this workspace' in str(exception_info.exception)
+        with self.assertRaises(AssertionError) as exception_info:
+            calculate_tube_calibration(self.workspace, 'tube42')
+        assert 'tube42 does not uniquely specify one tube' in str(exception_info.exception)
+        with self.assertRaises(AssertionError) as exception_info:
+            calculate_tube_calibration(self.workspace, 'bank42/sixteenpack/tube8', fit_domain=20)
+        assert 'The fit domain cannot be larger than the distance between consecutive' in str(exception_info.exception)
+
+        table = calculate_tube_calibration(self.workspace, 'bank42/sixteenpack/tube8')
+        calibrated_y = np.array([v.Y() for v in table.column(1)])
+        assert_allclose(calibrated_y, self.calibrated_y, atol=1e-3)
+
+    def tearDown(self) -> None:
+        DeleteWorkspaces([self.workspace, self.table])

--- a/scripts/test/corelli/calibration/test_utils.py
+++ b/scripts/test/corelli/calibration/test_utils.py
@@ -84,3 +84,7 @@ class TestUtils(unittest.TestCase):
 
     def tearDown(self) -> None:
         DeleteWorkspaces([self.workspace, self.table])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/test/corelli/calibration/test_utils.py
+++ b/scripts/test/corelli/calibration/test_utils.py
@@ -70,7 +70,7 @@ class TestUtils(unittest.TestCase):
         # Check the validators are doing what they're supposed to do
         with self.assertRaises(AssertionError) as exception_info:
             calculate_tube_calibration(None, 'bank42/sixteenpack/tube8')
-        assert 'Cannot process this workspace' in str(exception_info.exception)
+        assert 'Cannot process workspace' in str(exception_info.exception)
         with self.assertRaises(AssertionError) as exception_info:
             calculate_tube_calibration(self.workspace, 'tube42')
         assert 'tube42 does not uniquely specify one tube' in str(exception_info.exception)


### PR DESCRIPTION
**Description of work.**
- [x] utility function to calculate a calibration table for a single tube of CORELLI

**To test:**
In the *python editor* of the workbench, execute this script

```
from mantid import plots
import numpy as np
from corelli.calibration.utils import calculate_tube_calibration

counts_file = '/SNS/CORELLI/shared/tmp/CORELLI_123453_counts.h5'
LoadNexus(Filename=counts_file, OutputWorkspace='counts')
table = calculate_tube_calibration('counts', 'bank87/sixteenpack/tube12')
CreateWorkspace(range(256), [v.Y() for v in table.column(1)], NSpec=1, OutputWorkspace='pixel_positions')
fig, ax = plt.subplots(subplot_kw={'projection':'mantid'})
ax.plot(mtd['pixel_positions'], 'go-', specNum=1, label='pixel positions')
ax.legend()
fig.show()
```

Compare the resulting figure withe the expected figure below
<img src="https://user-images.githubusercontent.com/1136006/93632050-aa066300-f9ba-11ea-9e41-b0b7f4218ae3.png" width=300>


Fixes #29470

This does not require release notes because this functionality is not intended to be part of the public interface.

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
