### PR TITLE
Fix a bug clearing the distribution flag incorrectly

### DIFF
--- a/Framework/Reflectometry/src/ReflectometryReductionOne2.cpp
+++ b/Framework/Reflectometry/src/ReflectometryReductionOne2.cpp
@@ -717,11 +717,13 @@ ReflectometryReductionOne2::convertToQ(const MatrixWorkspace_sptr &inputWS) {
     refRoi->setProperty("ScatteringAngle", theta);
     refRoi->execute();
     IvsQ = refRoi->getProperty("OutputWorkspace");
-    // RefRoi outputs as distribution data but ConvertUnits outputs as
-    // counts. For now make this consistent with the original behaviour using
-    // ConvertUnits but we may wish to change this in future.
-    IvsQ->setYUnitLabel("Counts");
-    IvsQ->setDistribution(false);
+    // RefRoi outputs as distribution data but ConvertUnits outputs as counts
+    // if the input is counts. For now make this consistent with the original
+    // behaviour using ConvertUnits but we may wish to change this in future.
+    if (!inputWS->isDistribution()) {
+      IvsQ->setYUnitLabel("Counts");
+      IvsQ->setDistribution(false);
+    }
   }
   return IvsQ;
 }

--- a/Framework/Reflectometry/test/ReflectometryReductionOne2Test.h
+++ b/Framework/Reflectometry/test/ReflectometryReductionOne2Test.h
@@ -1013,6 +1013,163 @@ public:
          {"DegreeOfPolynomial", "2"}});
   }
 
+  void test_history_for_sum_in_lambda() {
+    ReflectometryReductionOne2 alg;
+    setupAlgorithm(alg, 1.5, 15.0, "3+4");
+    alg.setChild(false); // required to get history
+    alg.execute();
+    auto outputWS = std::dynamic_pointer_cast<MatrixWorkspace>(
+        AnalysisDataService::Instance().retrieve("IvsQ"));
+    checkWorkspaceHistory(outputWS, {"GroupDetectors", "ConvertUnits",
+                                     "CropWorkspace", "ConvertUnits"});
+  }
+
+  void test_history_for_sum_in_lambda_with_angle_correction() {
+    ReflectometryReductionOne2 alg;
+    setupAlgorithm(alg, 1.5, 15.0, "3+4");
+    alg.setProperty("ThetaIn", 22.0);
+    alg.setChild(false); // required to get history
+    alg.execute();
+    auto outputWS = std::dynamic_pointer_cast<MatrixWorkspace>(
+        AnalysisDataService::Instance().retrieve("IvsQ"));
+    // Uses RefRoi instead of ConvertUnits
+    checkWorkspaceHistory(outputWS, {"GroupDetectors", "ConvertUnits",
+                                     "CropWorkspace", "RefRoi"});
+  }
+
+  void test_history_for_sum_in_lambda_with_monitor_normalisation() {
+    ReflectometryReductionOne2 alg;
+    setupAlgorithmMonitorCorrection(alg, 1.5, 15.0, "3+4", m_multiDetectorWS,
+                                    false);
+    alg.setChild(false); // required to get history
+    alg.execute();
+    auto outputWS = std::dynamic_pointer_cast<MatrixWorkspace>(
+        AnalysisDataService::Instance().retrieve("IvsQ"));
+    checkWorkspaceHistory(outputWS,
+                          {"GroupDetectors", "ConvertUnits", "CropWorkspace",
+                           "ConvertUnits", "CalculateFlatBackground",
+                           "RebinToWorkspace", "Divide", "CropWorkspace",
+                           "ConvertUnits"});
+  }
+
+  void test_history_for_sum_in_lambda_with_transmission_normalisation() {
+    ReflectometryReductionOne2 alg;
+    setupAlgorithmTransmissionCorrection(alg, 1.5, 15.0, "3+4",
+                                         m_multiDetectorWS, false);
+    alg.setChild(false); // required to get history
+    alg.execute();
+    auto outputWS = std::dynamic_pointer_cast<MatrixWorkspace>(
+        AnalysisDataService::Instance().retrieve("IvsQ"));
+    checkWorkspaceHistory(outputWS,
+                          {"GroupDetectors", "ConvertUnits", "CropWorkspace",
+                           "CreateTransmissionWorkspace", "RebinToWorkspace",
+                           "Divide", "ConvertUnits"});
+  }
+
+  void test_history_for_sum_in_q() {
+    ReflectometryReductionOne2 alg;
+    setupAlgorithm(alg, 1.5, 15.0, "3+4");
+    alg.setProperty("SummationType", "SumInQ");
+    alg.setProperty("ReductionType", "DivergentBeam");
+    alg.setProperty("ThetaIn", 22.0);
+    alg.setChild(false); // required to get history
+    alg.execute();
+    auto outputWS = std::dynamic_pointer_cast<MatrixWorkspace>(
+        AnalysisDataService::Instance().retrieve("IvsQ"));
+    checkWorkspaceHistory(outputWS,
+                          {"ConvertUnits", "CropWorkspace", "ConvertUnits"});
+  }
+
+  void test_history_for_sum_in_q_with_monitor_normalisation() {
+    ReflectometryReductionOne2 alg;
+    setupAlgorithmMonitorCorrection(alg, 1.5, 15.0, "3+4", m_multiDetectorWS,
+                                    false);
+    alg.setProperty("SummationType", "SumInQ");
+    alg.setProperty("ReductionType", "DivergentBeam");
+    alg.setProperty("ThetaIn", 22.0);
+    alg.setChild(false); // required to get history
+    alg.execute();
+    auto outputWS = std::dynamic_pointer_cast<MatrixWorkspace>(
+        AnalysisDataService::Instance().retrieve("IvsQ"));
+    checkWorkspaceHistory(outputWS,
+                          {"ConvertUnits", "CropWorkspace", "ConvertUnits",
+                           "CalculateFlatBackground", "RebinToWorkspace",
+                           "Divide", "CropWorkspace", "ConvertUnits"});
+  }
+
+  void test_history_for_sum_in_q_with_transmission_normalisation() {
+    ReflectometryReductionOne2 alg;
+    setupAlgorithmTransmissionCorrection(alg, 1.5, 15.0, "3+4",
+                                         m_multiDetectorWS, false);
+    alg.setProperty("SummationType", "SumInQ");
+    alg.setProperty("ReductionType", "DivergentBeam");
+    alg.setProperty("ThetaIn", 22.0);
+    alg.setChild(false); // required to get history
+    alg.execute();
+    auto outputWS = std::dynamic_pointer_cast<MatrixWorkspace>(
+        AnalysisDataService::Instance().retrieve("IvsQ"));
+    checkWorkspaceHistory(outputWS,
+                          {"ConvertUnits", "CreateTransmissionWorkspace",
+                           "RebinToWorkspace", "Divide", "CropWorkspace",
+                           "ConvertUnits"});
+  }
+
+  void test_IvsQ_is_not_distribution_data() {
+    // This may not be correct but this behaviour is historic - the output is
+    // not distribution data if the input is not distribution
+    ReflectometryReductionOne2 alg;
+    setupAlgorithm(alg, 1.5, 15.0, "3+4");
+    alg.execute();
+    MatrixWorkspace_sptr outQ = alg.getProperty("OutputWorkspace");
+    TS_ASSERT_EQUALS(outQ->isDistribution(), false);
+  }
+
+  void test_IvsQ_is_not_distribution_data_when_angle_correction_is_done() {
+    // This may not be correct but this behaviour is historic - the output is
+    // not distribution data if the input is not distribution. Similar to above
+    // but also check the special case where angle correction is done with
+    // RefRoi
+    ReflectometryReductionOne2 alg;
+    setupAlgorithm(alg, 1.5, 15.0, "3+4");
+    alg.setProperty("ThetaIn", 22.0);
+    alg.execute();
+    MatrixWorkspace_sptr outQ = alg.getProperty("OutputWorkspace");
+    TS_ASSERT_EQUALS(outQ->isDistribution(), false);
+  }
+
+  void test_IvsQ_is_distribution_data_if_input_is_distribution() {
+    ReflectometryReductionOne2 alg;
+    auto inputWS = MatrixWorkspace_sptr(m_multiDetectorWS->clone());
+    inputWS->setDistribution(true);
+    setupAlgorithm(alg, 1.5, 15.0, "3+4");
+    alg.setProperty("InputWorkspace", inputWS);
+    alg.execute();
+    MatrixWorkspace_sptr outQ = alg.getProperty("OutputWorkspace");
+    TS_ASSERT_EQUALS(outQ->isDistribution(), true);
+  }
+
+  void test_IvsQ_is_distribution_data_if_normalised_by_monitor() {
+    // Monitor correction causes the divided workspace to become
+    // distribution data therefore the output is also distribution
+    ReflectometryReductionOne2 alg;
+    setupAlgorithmMonitorCorrection(alg, 1.5, 15.0, "3+4", m_multiDetectorWS,
+                                    false);
+    alg.execute();
+    MatrixWorkspace_sptr outQ = alg.getProperty("OutputWorkspace");
+    TS_ASSERT_EQUALS(outQ->isDistribution(), true);
+  }
+
+  void test_IvsQ_is_distribution_data_if_normalised_by_transmission() {
+    // Transmission correction causes the divided workspace to become
+    // distribution data therefore the output is also distribution
+    ReflectometryReductionOne2 alg;
+    setupAlgorithmTransmissionCorrection(alg, 1.5, 15.0, "3+4",
+                                         m_multiDetectorWS, false);
+    alg.execute();
+    MatrixWorkspace_sptr outQ = alg.getProperty("OutputWorkspace");
+    TS_ASSERT_EQUALS(outQ->isDistribution(), true);
+  }
+
 private:
   // Do standard algorithm setup
   void setupAlgorithm(ReflectometryReductionOne2 &alg,


### PR DESCRIPTION
This PR fixes a bug where the distribution flag was being incorrectly cleared in some cases for the output of `ReflectometryReductionOne`.

This bug was due to an assumption that the input is always non-distribution, which it typically is, but we should not make that assumption, and in particular if we do a transmission or monitor normalisation then the interim workspace becomes distribution data, so we should not clear the flag in this case.

Fixes #29521

**Report to:** Jos and Max at ISIS

**To test:**

See linked issue

*This does not require release notes* because **it fixes a regression since v5.0**

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
