### PR TITLE
Implement background subtraction for sum in Q

### DIFF
--- a/Framework/Reflectometry/src/ReflectometryReductionOne2.cpp
+++ b/Framework/Reflectometry/src/ReflectometryReductionOne2.cpp
@@ -384,6 +384,9 @@ MatrixWorkspace_sptr ReflectometryReductionOne2::makeIvsLam() {
   int step = 1;
 
   if (summingInQ()) {
+    // Background subtraction
+    result = backgroundSubtraction(result);
+    outputDebugWorkspace(result, wsName, "_subtracted_bkg", debug, step);
     if (m_convertUnits) {
       g_log.debug("Converting input workspace to wavelength\n");
       result = convertToWavelength(result);

--- a/Framework/Reflectometry/src/ReflectometryWorkflowBase2.cpp
+++ b/Framework/Reflectometry/src/ReflectometryWorkflowBase2.cpp
@@ -378,14 +378,6 @@ std::map<std::string, std::string>
 ReflectometryWorkflowBase2::validateBackgroundProperties() const {
 
   std::map<std::string, std::string> results;
-
-  const bool subtractBackground = getProperty("SubtractBackground");
-  const std::string summationType = getProperty("SummationType");
-  if (subtractBackground && summationType == "SumInQ") {
-    results["SubtractBackground"] =
-        "Background subtraction is not implemented if summing in Q";
-  }
-
   return results;
 }
 

--- a/Framework/Reflectometry/test/ReflectometryReductionOne2Test.h
+++ b/Framework/Reflectometry/test/ReflectometryReductionOne2Test.h
@@ -1170,6 +1170,19 @@ public:
     TS_ASSERT_EQUALS(outQ->isDistribution(), true);
   }
 
+  void test_subtract_background_sum_in_q() {
+    ReflectometryReductionOne2 alg;
+    setupAlgorithmForBackgroundSubtraction(alg, m_multiDetectorWS);
+    alg.setProperty("SummationType", "SumInQ");
+    alg.setProperty("ReductionType", "DivergentBeam");
+    alg.execute();
+    auto outputWS = std::dynamic_pointer_cast<MatrixWorkspace>(
+        AnalysisDataService::Instance().retrieve("IvsQ"));
+    checkWorkspaceHistory(outputWS,
+                          {"ReflectometryBackgroundSubtraction", "ConvertUnits",
+                           "CropWorkspace", "ConvertUnits"});
+  }
+
 private:
   // Do standard algorithm setup
   void setupAlgorithm(ReflectometryReductionOne2 &alg,


### PR DESCRIPTION
This PR implements background subtraction for summing in Q, which was omitted in the original implementation of this feature resulting in a confusing error for users. It uses exactly the same function as when summing in lambda so is a minor change to add this into the workflow for summing in Q.

Fixes #29528

**Report to:** Max and Jos at ISIS

**To test:**

See linked issue. The processed rows should now be green to indicate success and the IvsQ workspace history should contain `ReflectometryBackgroundSubtraction`

![image](https://user-images.githubusercontent.com/12895056/93622332-daf39180-f9d4-11ea-8f8e-44600e9b372b.png)

*This does not require release notes* because **it fixes a problem in a new feature**

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
