### PR TITLE
Fixes Crash Caused By Pressing Cancel In FDA During MaxEnt

### DIFF
--- a/scripts/Muon/GUI/FrequencyDomainAnalysis/MaxEnt/maxent_presenter_new.py
+++ b/scripts/Muon/GUI/FrequencyDomainAnalysis/MaxEnt/maxent_presenter_new.py
@@ -69,6 +69,10 @@ class MaxEntPresenter(object):
         if self.maxent_alg is not None:
             self.maxent_alg.cancel()
 
+            # Need to set this as sent as part of calculation finished signal
+            self._maxent_output_workspace_name = get_maxent_workspace_name(
+                self.get_parameters_for_maxent_calculation()['InputWorkspace'])
+
     # turn on button
     def activate(self):
         self.view.activateCalculateButton()


### PR DESCRIPTION
**Description of work.**
Fixed a crash which was caused by pressing cancel during execution of the MuonMaxEnt algorithm from the Frequency Domain Analysis GUI.

**To test:**
1. Open the FDA interface from **Interfaces** -> **Muon** -> **Frequency Domain Analysis**
2. Load in a dataset such as MUSR **62260**
3. Switch to the **Transform** tab
4. Change the drop down box from **FFT** to **MaxEnt**
5. Change the **Number of data points** in Advanced Options to a large number (this is so you have time to press cancel!)
6. Click **Calculate MaxEnt** and wait a second or two then press **Cancel**
7. Mantid shouldn't crash 

Fixes #29145 

*This does not require release notes* because **it is a regression bug fix**

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
