### PR TITLE
Update autoscale on masking

### DIFF
--- a/docs/source/release/v5.1.0/mantidworkbench.rst
+++ b/docs/source/release/v5.1.0/mantidworkbench.rst
@@ -170,5 +170,6 @@ Bugfixes
 - Use Jemalloc for memory allocation on Linux so memory can be released to the system.
 - Fixed a bug where instrument view would not update on wheel zoom.
 - Fixed a bug which caused workbench to crash midway through closing normally when logging level was set to debug.
+- Fixed a bug where the color map would not update when masking in the instrument viewer.
 
 :ref:`Release 5.1.0 <v5.1.0>`

--- a/qt/widgets/instrumentview/src/InstrumentActor.cpp
+++ b/qt/widgets/instrumentview/src/InstrumentActor.cpp
@@ -1051,13 +1051,16 @@ void InstrumentActor::setDataIntegrationRange(const double &xmin,
     m_DataMaxValue = -DBL_MAX;
 
     const auto &spectrumInfo = workspace->spectrumInfo();
+    auto maskWksp = getMaskWorkspace();
 
     // Ignore monitors if multiple detectors aren't grouped.
     for (size_t i = 0; i < m_specIntegrs.size(); i++) {
       const auto &spectrumDefinition = spectrumInfo.spectrumDefinition(i);
+      // Ignore monitors if they are masked on the view
       if (spectrumDefinition.size() == 1 &&
-          std::find(monitorIndices.begin(), monitorIndices.end(), i) !=
-              monitorIndices.end())
+          (std::find(monitorIndices.begin(), monitorIndices.end(), i) !=
+               monitorIndices.end() ||
+           maskWksp->isMasked(i)))
         continue;
 
       auto sum = m_specIntegrs[i];

--- a/qt/widgets/instrumentview/src/InstrumentActor.cpp
+++ b/qt/widgets/instrumentview/src/InstrumentActor.cpp
@@ -1060,7 +1060,7 @@ void InstrumentActor::setDataIntegrationRange(const double &xmin,
       if (spectrumDefinition.size() == 1 &&
           (std::find(monitorIndices.begin(), monitorIndices.end(), i) !=
                monitorIndices.end() ||
-           maskWksp->isMasked(i)))
+           maskWksp->isMasked(static_cast<int>(i))))
         continue;
 
       auto sum = m_specIntegrs[i];

--- a/qt/widgets/instrumentview/src/InstrumentWidgetMaskTab.cpp
+++ b/qt/widgets/instrumentview/src/InstrumentWidgetMaskTab.cpp
@@ -765,6 +765,7 @@ void InstrumentWidgetMaskTab::applyMask() {
   storeMask();
   QApplication::setOverrideCursor(QCursor(Qt::WaitCursor));
   m_instrWidget->getInstrumentActor().applyMaskWorkspace();
+  m_instrWidget->setupColorMap();
   enableApplyButtons();
   QApplication::restoreOverrideCursor();
 }
@@ -774,6 +775,7 @@ void InstrumentWidgetMaskTab::applyMask() {
  */
 void InstrumentWidgetMaskTab::applyMaskToView() {
   storeMask();
+  m_instrWidget->setupColorMap();
   enableApplyButtons();
 }
 
@@ -785,6 +787,7 @@ void InstrumentWidgetMaskTab::clearMask() {
   m_detectorsToGroup.clear();
   m_instrWidget->getInstrumentActor().clearMasks();
   m_instrWidget->getInstrumentActor().updateColors();
+  m_instrWidget->setupColorMap();
   m_instrWidget->updateInstrumentView();
   enableApplyButtons();
 }

--- a/qt/widgets/instrumentview/src/InstrumentWidgetMaskTab.cpp
+++ b/qt/widgets/instrumentview/src/InstrumentWidgetMaskTab.cpp
@@ -784,6 +784,7 @@ void InstrumentWidgetMaskTab::clearMask() {
   clearShapes();
   m_detectorsToGroup.clear();
   m_instrWidget->getInstrumentActor().clearMasks();
+  m_instrWidget->getInstrumentActor().updateColors();
   m_instrWidget->updateInstrumentView();
   enableApplyButtons();
 }


### PR DESCRIPTION
**Description of work.**

Fixed a bug where the range of the color map of the instrument view was not properly updated when modified by masking operations.

**To test:**
- Load ExternalData/Testing/Data/UnitTest/ILL/D22/192068.nxs
- Open the instrument view
- Mask the top of the detector and the silhouette of the beam stop, so that only the background remains
- Mask using  `Apply to view` and check the color map is correctly updated.
- Clear all and check it goes back to normal
- Re-mask using `Apply to data` and see that the color map is again correctly updated

Fixes #29510 

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
