### PR TITLE
Fix loading NeXus file while second is loading

### DIFF
--- a/Testing/SystemTests/tests/analysis/MultiThreadedLoadNeXusTest.py
+++ b/Testing/SystemTests/tests/analysis/MultiThreadedLoadNeXusTest.py
@@ -1,0 +1,75 @@
+# Mantid Repository : https://github.com/mantidproject/mantid
+#
+# Copyright &copy; 2020 ISIS Rutherford Appleton Laboratory UKRI,
+#   NScD Oak Ridge National Laboratory, European Spallation Source,
+#   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+# SPDX - License - Identifier: GPL - 3.0 +
+import concurrent.futures
+import sys
+
+from mantid.simpleapi import Load
+from systemtesting import MantidSystemTest, linux_distro_description
+
+
+def load_nexus_in_multiple_threads(filename, nthreads):
+    """Attempt to load the the given filename from multiple threads at once
+    """
+    results = [None for i in range(nthreads)]
+    with concurrent.futures.ThreadPoolExecutor(max_workers=nthreads) as executor:
+        jobs = [executor.submit(load_nexus, filename, index) for index in range(nthreads)]
+        for index, future in enumerate(concurrent.futures.as_completed(jobs)):
+            try:
+                future.result()
+            except Exception as exc:
+                results[index] = str(exc)
+            else:
+                results[index] = None
+
+    raise_error_if_failed(results)
+
+
+def load_nexus(filename: str, index: int) -> None:
+    """Callable for Thread object. Performs the Load call
+    :param filename: NeXus filename to load
+    :param index: Index of thread assigned to perform load
+    """
+    Load(filename, OutputWorkspace=f'w{index}')
+
+
+def raise_error_if_failed(results) -> None:
+    """Raises a RuntimeError if any failure occurred"""
+    if not all(map(lambda x: x is None, results)):
+        messages = ["It was not possible to load a NeXus file with multiple threads. Errors:"]
+        for index, msg in enumerate(filter(lambda x: x is not None, results)):
+            messages.append(f'Thread {index} raised an error: {msg}')
+
+        raise RuntimeError('\n'.join(messages))
+
+
+class MultiThreadedLoadNeXusTest(MantidSystemTest):
+    """Verify that a NeXus file can be loaded
+       from multiple threads.
+       HDF5 can be built without the threadsafe option
+       which causes problems for the current how the
+       framework accesses NeXus files.
+    """
+    NTHREADS = 2
+
+    def skipTests(self):
+        """HDF5 is currently not built in threadsafe mode on RHEL"""
+        # Ideally this would be a capability check but that's very difficult as
+        # the RHEL library doesn't have the H5is_library_threadsafe function
+        if sys.platform == 'linux':
+            distro = linux_distro_description().lower()
+            is_redhat_like = [name in distro for name in ('red hat', 'centos', 'fedora')]
+            return any(is_redhat_like)
+        else:
+            return False
+
+    def runTest(self):
+        """Spin up multiple threads and simply
+        check that we don't crash"""
+        # "Raw" data NeXus
+        load_nexus_in_multiple_threads(filename='INTER00013463.nxs', nthreads=self.NTHREADS)
+        # Mantid processed file
+        load_nexus_in_multiple_threads(filename='MARIReductionAutoEi.nxs', nthreads=self.NTHREADS)

--- a/buildconfig/CMake/Bootstrap.cmake
+++ b/buildconfig/CMake/Bootstrap.cmake
@@ -15,7 +15,7 @@ if(MSVC)
   set(THIRD_PARTY_GIT_URL
       "https://github.com/mantidproject/thirdparty-msvc2015.git"
   )
-  set(THIRD_PARTY_GIT_SHA1 51ae2facb5bd9267dee7369478446f689c1be13b)
+  set(THIRD_PARTY_GIT_SHA1 f834a89d01957e28e28443f132e1d7d546972ebc)
   set(THIRD_PARTY_DIR ${EXTERNAL_ROOT}/src/ThirdParty)
   # Generates a script to do the clone/update in tmp
   set(_project_name ThirdParty)

--- a/buildconfig/CMake/MSVCSetup.cmake
+++ b/buildconfig/CMake/MSVCSetup.cmake
@@ -57,6 +57,9 @@ else()
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /Zm${VISUALSTUDIO_COMPILERHEAPLIMIT}")
 endif()
 
+# HDF5 uses threads::threads target
+find_package (Threads)
+
 # ##############################################################################
 # Qt5 is always in the same place
 # ##############################################################################


### PR DESCRIPTION
**Description of work.**

Pulls in a rebuild of the HDF5 libraries on Windows that have the threadsafe option enabled. Without this option it is not possible to access the HDF5 libraries safely from multiple threads.

**To test:**

* Build on Windows in release mode
* Attempt the steps in the related issue and on clicking Load for the second time mantid should not crash.

Fixes #29469  

*This does not require release notes* because **it is a regression from v5.0**

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
