### PR TITLE
Fix InterpolateTestPerformance Segfault

### DIFF
--- a/Framework/HistogramData/test/InterpolateTest.h
+++ b/Framework/HistogramData/test/InterpolateTest.h
@@ -437,6 +437,9 @@ public:
       : hist(BinEdges(binSize, LinearGenerator(0, 1))) {
     Counts counts(binSize - 1, LinearGenerator(10, 0.1));
     hist.setCounts(counts);
+
+    CountStandardDeviations errors(binSize - 1, LinearGenerator(10, 0.1));
+    hist.setCountStandardDeviations(errors);
   }
 
   void testInterpolateLinearSmallStep() {


### PR DESCRIPTION
**Description of work.**
This PR fixes the InterpolateTestPerformance [segfault](https://builds.mantidproject.org/job/master_performancetests2/lastCompletedBuild/console) by setting the errors in the histogram.

This is a simple fix and so the merge target has been set to `release-next`.

**To test:**
Make sure `InterpolateTestPerformance` in `HistogramDataTest` passes.

Fixes #29541

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
