### PR TITLE
Save log averages so don't need to recalculate when refreshing EngDiff UI fitting table

### DIFF
--- a/scripts/Engineering/gui/engineering_diffraction/tabs/fitting/data_handling/test/test_data_model.py
+++ b/scripts/Engineering/gui/engineering_diffraction/tabs/fitting/data_handling/test/test_data_model.py
@@ -228,12 +228,14 @@ class TestFittingDataModel(unittest.TestCase):
         self.model._loaded_workspaces = {"name1": self.mock_ws, "name2": self.mock_ws}
         self.model._background_workspaces = {"name1": self.mock_ws, "name2": self.mock_ws}
         self.model._bg_params = {"name1": [True, 80, 1000, False]}
+        self.model._log_values = {"name1": 1, "name2": 2}
 
         self.model.update_workspace_name("name1", "new_name")
 
         self.assertEqual({"new_name": self.mock_ws, "name2": self.mock_ws}, self.model._loaded_workspaces)
         self.assertEqual({"new_name": self.mock_ws, "name2": self.mock_ws}, self.model._background_workspaces)
         self.assertEqual({"new_name": [True, 80, 1000, False]}, self.model._bg_params)
+        self.assertEqual({"new_name": 1, "name2": 2}, self.model._log_values)
 
 
 if __name__ == '__main__':

--- a/scripts/Engineering/gui/engineering_diffraction/tabs/fitting/data_handling/test/test_data_model.py
+++ b/scripts/Engineering/gui/engineering_diffraction/tabs/fitting/data_handling/test/test_data_model.py
@@ -237,6 +237,20 @@ class TestFittingDataModel(unittest.TestCase):
         self.assertEqual({"new_name": [True, 80, 1000, False]}, self.model._bg_params)
         self.assertEqual({"new_name": 1, "name2": 2}, self.model._log_values)
 
+    @patch(file_path + ".FittingDataModel.update_log_group_name")
+    @patch(file_path + ".AverageLogData")
+    def test_reload_calculated_log_values(self, mock_avglogs, mock_update_logname):
+        # grouped ws acts like a container/list of ws here
+        self.model._log_workspaces = [mock.MagicMock(), mock.MagicMock()]  # first one is run_info not related to a log
+        self.model._log_workspaces[1].name.return_value = "LogName"
+        self.model._log_values = {"name1": {"LogName": [2, 1]}}
+
+        self.model.add_log_to_table("name1", self.mock_ws)
+
+        self.model._log_workspaces[1].addRow.assert_called_with([2, 1])
+        mock_avglogs.assert_not_called()
+        mock_update_logname.assert_called_once()
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
**Description of work.**

Have added a dict to store the average and stdev of log values for the runs when loaded. This means when re-loading a run into the UI  (after removing the run from the UI or deleting it in the ADS), the average of the logs doesn't need to be recalculated. This is quicker and also avoids the many lines of notifications printed out by AverageLogData. 

**To test:**

(1) Follow the instructions in PR #29191 - but check that the log average is only calculated once when the run is initially loaded (can easily be seen on the notifications, AverageLogdata prints out lots of stuff)
(2) Try renaming a workspace in the ADS (should also refresh log tables) - again check AvergaeLogData isn't called by looking in notifications panel.

Fixes #29552
<!-- alternative
*There is no associated issue.*
-->

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or master)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
