### PR TITLE
Skip cppcheck for .rst or .py changes

### DIFF
--- a/buildconfig/Jenkins/clangformat
+++ b/buildconfig/Jenkins/clangformat
@@ -5,6 +5,19 @@
 # running environment
 
 # clang-format executable
+
+SCRIPT_DIR=$(dirname "$0")
+if [[ ${JOB_NAME} == *pull_requests* ]]; then
+    # This relies on the fact pull requests use pull/$PR-NAME
+    # which squashes the branch into a single merge commit
+    cd $WORKSPACE
+
+    if ${SCRIPT_DIR}/check_for_changes cpp; then
+        echo "No C++ files have changed. Skipping check."
+        exit 0
+    fi
+fi
+
 CLANG_FORMAT_EXE=clang-format-6.0
 CLANG_FORMAT=$(which $CLANG_FORMAT_EXE)
 if [ -z "$CLANG_FORMAT" ]; then

--- a/buildconfig/Jenkins/cppcheck.sh
+++ b/buildconfig/Jenkins/cppcheck.sh
@@ -1,0 +1,16 @@
+#!/bin/bash -ex
+
+###############################################################################
+# Create the build directory if it doesn't exist
+###############################################################################
+[ -d $WORKSPACE/build ] || mkdir $WORKSPACE/build
+cd $WORKSPACE/build
+
+if [ "$(command -v ninja)" ]; then
+  CMAKE_GENERATOR="-G Ninja"
+elif [ "$(command -v ninja-build)" ]; then
+  CMAKE_GENERATOR="-G Ninja"
+fi
+
+cmake ${CMAKE_GENERATOR} -DCMAKE_BUILD_TYPE=Debug -DCPPCHECK_GENERATE_XML=TRUE -DCPPCHECK_NUM_THREADS=$BUILD_THREADS -DMAKE_VATES=ON -DParaView_DIR=${PARAVIEW_DIR} ..
+cmake --build . --target cppcheck

--- a/buildconfig/Jenkins/cppcheck.sh
+++ b/buildconfig/Jenkins/cppcheck.sh
@@ -1,5 +1,18 @@
 #!/bin/bash -ex
 
+SCRIPT_DIR=$(dirname "$0")
+
+if [[ ${JOB_NAME} == *pull_requests* ]]; then
+    # This relies on the fact pull requests use pull/$PR-NAME
+    # which squashes the branch into a single merge commit
+    cd $WORKSPACE
+
+    if ${SCRIPT_DIR}/check_for_changes cpp; then
+        echo "No C++ files have changed. Skipping check."
+        exit 0
+    fi
+fi
+
 ###############################################################################
 # Create the build directory if it doesn't exist
 ###############################################################################


### PR DESCRIPTION
**Description of work.**

- Moves our cppcheck steps into a shell script off of Jenkins
- Skips cppcheck for pull requests if the diff only has Python or RST files, this saves 4-5 minutes for Python only PRs which are becoming more popular


After merging we need to:
- Change cppcheck shallow clone depth to 2 so we can diff
- Replace script with `$WORKSPACE/buildconfig/Jenkins/cppcheck.sh`

**To test:**

- Code Review
- Check that cppcheck passes - this job was run custom with the new script

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
