### PR TITLE
Mark cells in Sliceviewer ImageInfoWidget read only and remove selectable flag

### DIFF
--- a/qt/widgets/common/src/ImageInfoWidget.cpp
+++ b/qt/widgets/common/src/ImageInfoWidget.cpp
@@ -52,10 +52,10 @@ void ImageInfoWidget::showInfo(const ImageInfoModel::ImageInfo &info) {
   setColumnCount(itemCount);
   for (int i = 0; i < itemCount; ++i) {
     auto header = new QTableWidgetItem(info.name(i));
-    header->setFlags(Qt::ItemIsSelectable);
+    header->setFlags(header->flags() & ~Qt::ItemIsEditable);
     setItem(0, i, header);
     auto value = new QTableWidgetItem(info.value(i));
-    value->setFlags(Qt::ItemIsSelectable);
+    value->setFlags(header->flags() & ~Qt::ItemIsEditable);
     setItem(1, i, value);
   }
   horizontalHeader()->setMinimumSectionSize(50);


### PR DESCRIPTION
**Description of work.**

The text colour in the cursor info widget was quite hard to read and had accidentally been set this way. Removing the selectable flag means the text is now black rather than very light gray. This change also removes the editable flag as it was not sensible to edit the table.

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

**To test:**

* Load any MatrixWorkspace or MDWorkspace from the test data
* Open the slice viewer
* The cursor info table should now have black text and no longer be editable 

Fixes #29522

*This does not require release notes* because **as the sliceviewer release notes are being created separately**

<!-- Ensure the base of this PR is correct (e.g. release-next or master)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
