### PR TITLE
Correct the Y unit label on eq2 in elwin

### DIFF
--- a/Framework/Algorithms/src/ElasticWindow.cpp
+++ b/Framework/Algorithms/src/ElasticWindow.cpp
@@ -202,6 +202,8 @@ void ElasticWindow::exec() {
     convUnitQ2->execute();
     outputQSquared = convUnitQ2->getProperty("OutputWorkspace");
   }
+  auto yLabel = outputQSquared->YUnitLabel();
+  outputQSquared->setYUnitLabel("ln(" + yLabel + ")");
 
   setProperty("OutputInQ", outputQ);
   setProperty("OutputInQSquared", outputQSquared);

--- a/Framework/Algorithms/test/ElasticWindowTest.h
+++ b/Framework/Algorithms/test/ElasticWindowTest.h
@@ -193,6 +193,7 @@ public:
         AnalysisDataService::Instance().retrieveWS<MatrixWorkspace>(
             "__ElasticWindowTest_outputQsq");
     verifyQ2workspace(q2Ws);
+    TS_ASSERT(q2Ws->YUnitLabel() == "ln(" + qWs->YUnitLabel() + ")");
   }
 
 private:

--- a/docs/source/release/v5.1.0/indirect_geometry.rst
+++ b/docs/source/release/v5.1.0/indirect_geometry.rst
@@ -37,6 +37,8 @@ Improvements
 - Added default parameter estimations to the F(q) tab.
 - The ConvFit tab within the IDA GUI will now output convolved members by default.
 - Added a Help option to the right-click menu in the function browser (in full function view) which brings up a relevant documentation page describing the function.
+- The eq2 workspace output from the Indirect Data analysis Elwin tab now accurately has
+  the Y axis label as being the natural log of eq1.
 
 Bug Fixes
 #########


### PR DESCRIPTION
**Description of work.**

This Commit corrects the Y axis label on the eq2 workspace so that it is the natural log of eq1

**To test:**

1. Open indirect data analysis
2. Load data on the Elwin tab
3. Run
4. look at the output workspaces there should be a eq1 and an eq2
5. the y axis label on eq2 should be the natural log of eq1 (e.g. if eq1 is 'intencity' then eq2 will be 'ln(intencity)'

Fixes #29539

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
