### PR TITLE
Avoid hard crash in Indirect Energy Transfer load without TCP files

### DIFF
--- a/qt/scientific_interfaces/Indirect/ISISEnergyTransfer.cpp
+++ b/qt/scientific_interfaces/Indirect/ISISEnergyTransfer.cpp
@@ -144,11 +144,10 @@ double loadSampleLog(std::string const &filename,
   loader->execute();
 
   if (doesExistInADS(temporaryWorkspace)) {
-
     return getSampleLog(getADSMatrixWorkspace(temporaryWorkspace), logNames,
                         defaultValue);
   } else {
-    return -1;
+    return defaultValue;
   }
 }
 

--- a/qt/scientific_interfaces/Indirect/ISISEnergyTransfer.cpp
+++ b/qt/scientific_interfaces/Indirect/ISISEnergyTransfer.cpp
@@ -6,7 +6,6 @@
 // SPDX - License - Identifier: GPL - 3.0 +
 #include "ISISEnergyTransfer.h"
 #include "IndirectDataValidationHelper.h"
-
 #include "MantidAPI/MatrixWorkspace.h"
 #include "MantidAPI/WorkspaceGroup.h"
 #include "MantidQtWidgets/Common/UserInputValidator.h"
@@ -144,8 +143,13 @@ double loadSampleLog(std::string const &filename,
   auto loader = loadAlgorithm(filename, temporaryWorkspace);
   loader->execute();
 
-  return getSampleLog(getADSMatrixWorkspace(temporaryWorkspace), logNames,
-                      defaultValue);
+  if (doesExistInADS(temporaryWorkspace)) {
+
+    return getSampleLog(getADSMatrixWorkspace(temporaryWorkspace), logNames,
+                        defaultValue);
+  } else {
+    return -1;
+  }
 }
 
 void convertSpectrumAxis(std::string const &inputWorkspace,


### PR DESCRIPTION
**Description of work.**
Add a check to avoid Energy Transfer from trying to access files from the ADS that haven't loaded correctly, letting it fail 'nicely' like the other tabs rather than hard crashing

**Report to:** Sanghamitra, Anthony

**To test:**
1. Turn off the data archive, download an IRIS .raw but NOT the three accompanying ICP files (e.g. IRIS00055127)
2. Interfaces -> Indirect -> Data reduction -> Energy transfer (default tab)
3. Input runs -> browse to the .raw and try to load it

Fixes #29554. <!-- and fix #xxxx or close #xxxx xor resolves #xxxx -->
<!-- alternative
*There is no associated issue.*
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or master)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
