### PR TITLE
Fix Crash In Muon Analysis GUI

### DIFF
--- a/docs/source/release/v5.1.0/muon.rst
+++ b/docs/source/release/v5.1.0/muon.rst
@@ -78,7 +78,7 @@ Bug fixes
 - Fixed an issue where Muon Analysis and Frequency Domain Analysis was not correctly resetting DeadTime property to default when a user changes the instrument
 - Fixed issue where select data was incorrectly enabling.
 - Fixed a bug in simultaneous TF asymmetry mode fitting, which would cause a crash when the run was incremented. Note that currently the single fitting tab will not update with the new normalization constants after a new run is loaded.
-- Fixed a bug were fitting in TF asymmetry mode for group data, then switching instrument and loading pair data would cause mantid to crash
+- Fixed a bug were fitting in TF asymmetry mode for group data, then switching instrument and loading pair data would cause mantid to crash.
 
 ALC
 ###

--- a/docs/source/release/v5.1.0/muon.rst
+++ b/docs/source/release/v5.1.0/muon.rst
@@ -78,6 +78,7 @@ Bug fixes
 - Fixed an issue where Muon Analysis and Frequency Domain Analysis was not correctly resetting DeadTime property to default when a user changes the instrument
 - Fixed issue where select data was incorrectly enabling.
 - Fixed a bug in simultaneous TF asymmetry mode fitting, which would cause a crash when the run was incremented. Note that currently the single fitting tab will not update with the new normalization constants after a new run is loaded.
+- Fixed a bug were fitting in TF asymmetry mode for group data, then switching instrument and loading pair data would cause mantid to crash
 
 ALC
 ###

--- a/scripts/Muon/GUI/Common/fitting_tab_widget/fitting_tab_model.py
+++ b/scripts/Muon/GUI/Common/fitting_tab_widget/fitting_tab_model.py
@@ -680,7 +680,7 @@ class FittingTabModel(object):
                 if group_or_pair in self.context.group_pair_context.selected_pairs:
                     workspace_names += [get_pair_asymmetry_name(self.context, group_or_pair, run,
                                                                 not self.fitting_options["fit_to_raw"])]
-                else:
+                elif group_or_pair in self.context.group_pair_context.selected_groups:
                     period_string = run_list_to_string(self.context.group_pair_context[group_or_pair].periods)
                     workspace_names += [get_group_asymmetry_name(self.context, group_or_pair, run, period_string,
                                                                  not self.fitting_options["fit_to_raw"])]
@@ -711,6 +711,8 @@ class FittingTabModel(object):
 
     @staticmethod
     def get_fit_function_parameter_values(fit_function):
+        if fit_function is None:
+            return []
         number_of_parameters = fit_function.nParams()
         parameters = [fit_function.parameterName(i) for i in range(number_of_parameters)]
         parameter_values = [fit_function.getParameterValue(parameters[i]) for i in

--- a/scripts/Muon/GUI/Common/fitting_tab_widget/fitting_tab_presenter.py
+++ b/scripts/Muon/GUI/Common/fitting_tab_widget/fitting_tab_presenter.py
@@ -54,6 +54,7 @@ class FittingTabPresenter(object):
 
         self.disable_tab_observer = GenericObserver(self.disable_view)
         self.enable_tab_observer = GenericObserver(self.enable_view)
+        self.instrument_changed_observer = GenericObserver(self.instrument_changed)
 
         self.update_view_from_model_observer = GenericObserverWithArgPassing(
             self.update_view_from_model)
@@ -606,6 +607,12 @@ class FittingTabPresenter(object):
                 return [FitPlotInformation(input_workspaces=self.selected_data, fit=fit)]
         else:
             return []
+
+    def instrument_changed(self):
+        self.deactivate_tf_asymmetry()
+
+    def deactivate_tf_asymmetry(self):
+        self.view.tf_asymmetry_mode = False
 
     def _get_selected_groups_and_pairs(self):
         return self.context.group_pair_context.selected_groups + self.context.group_pair_context.selected_pairs

--- a/scripts/Muon/GUI/Common/fitting_tab_widget/fitting_tab_presenter.py
+++ b/scripts/Muon/GUI/Common/fitting_tab_widget/fitting_tab_presenter.py
@@ -609,9 +609,6 @@ class FittingTabPresenter(object):
             return []
 
     def instrument_changed(self):
-        self.deactivate_tf_asymmetry()
-
-    def deactivate_tf_asymmetry(self):
         self.view.tf_asymmetry_mode = False
 
     def _get_selected_groups_and_pairs(self):

--- a/scripts/Muon/GUI/MuonAnalysis/muon_analysis_2.py
+++ b/scripts/Muon/GUI/MuonAnalysis/muon_analysis_2.py
@@ -293,6 +293,9 @@ class MuonAnalysisGui(QtWidgets.QMainWindow):
         self.context.data_context.instrumentNotifier.add_subscriber(
             self.plot_widget.presenter.instrument_observer)
 
+        self.context.data_context.instrumentNotifier.add_subscriber(
+            self.fitting_tab.fitting_tab_presenter.instrument_changed_observer)
+
     def setup_group_calculation_enable_notifier(self):
 
         self.grouping_tab_widget.group_tab_presenter.enable_editing_notifier.add_subscriber(


### PR DESCRIPTION
**Description of work.**
Added observer to fitting tab so that when instrument is changed tf_asymmetry is turned off

**To test:**
Follow instructions in #29571 and check Mantid doesn't crash anymore

Fixes #29571 


---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
