### PR TITLE
Add paper citation for equations

### DIFF
--- a/docs/source/algorithms/CylinderPaalmanPingsCorrection-v2.rst
+++ b/docs/source/algorithms/CylinderPaalmanPingsCorrection-v2.rst
@@ -15,6 +15,7 @@ factor for scattering and absorption in sample), :math:`A_{s,sc}` (scattering in
 sample and absorption in sample and container), :math:`A_{c,sc}` (scattering in
 container and absorption in sample and container) and  :math:`A_{c,c}`
 (scattering and absorption in container).
+This uses the equations from Kendig Pings 1965 which account for partially illuminated samples.
 
 Restrictions on the input workspace
 ###################################
@@ -81,6 +82,14 @@ Output:
 .. testoutput:: ExCylinderPaalmanPingsCorrection
 
     Correction workspaces: corr_ass, corr_assc, corr_acsc, corr_acc
+
+References
+----------
+
+#. Kendig, A. P., and C. J. Pings. *X‐Ray Absorption Factors for Cylindrical Samples
+   in Annular Sample Cells Exposed to Incident Beams of Limited Width.* Journal of
+   Applied Physics **36.5** (1965): 1692-1698
+   `doi: 10.1063/1.1703111 <https://doi.org/10.1063/1.1703111>`__
 
 Related Algorithms
 ------------------

--- a/docs/source/concepts/AbsorptionAndMultipleScattering.rst
+++ b/docs/source/concepts/AbsorptionAndMultipleScattering.rst
@@ -16,29 +16,29 @@ First, we define the total cross section per atom, which for the majority of ele
 
 .. math::
    :label: total_xs
-    
-   \sigma_t (\lambda) = \sigma_s (\lambda) + \sigma_a (\lambda) 
+
+   \sigma_t (\lambda) = \sigma_s (\lambda) + \sigma_a (\lambda)
 
 where :math:`\lambda` is the neutron wavelength, :math:`\sigma_s = \int_{\Omega} \frac{d\sigma}{d\Omega} \left( \lambda, 2\theta \right) d\Omega`, and
 :math:`\frac{d\sigma}{d\Omega} \left( \lambda, 2\theta \right)` is the differential cross-section which is the cross-section (:math:`\sigma`) per solid angle (:math:`d\Omega`).
 
 Scattering cross section (:math:`\sigma_s` )
 #############################################
-Typically, the scattering cross section is directly found from tabulated single atom values [1]_ and with good approximation, assumed independent of wavelength. 
-If we observe the equation above for :math:`\sigma_s`, we have that it is equal to the integration of the differential cross section. Yet, for the typical diffraction experiment, 
+Typically, the scattering cross section is directly found from tabulated single atom values [1]_ and with good approximation, assumed independent of wavelength.
+If we observe the equation above for :math:`\sigma_s`, we have that it is equal to the integration of the differential cross section. Yet, for the typical diffraction experiment,
 the differential cross-section is exactly the quantity we wish to measure. Thus, to proceed one could chose from the following:
 
 1) Measure the sample and integrate over all :math:`d\Omega` (very difficult to do exactly since instruments typically cannot cover all :math:`4 \pi` of :math:`\Omega`).
 2) Perform a transmission measurement to directly measure :math:`\sigma_t` and subtract a known value for :math:`\sigma_a` (also not typical).
-3) Use tabulated single atom values for :math:`\sigma_s` [1]_ (bingo!). 
+3) Use tabulated single atom values for :math:`\sigma_s` [1]_ (bingo!).
 
 For the energies used to measure structure of materials, :math:`\sigma_s` is to
 reasonable approximation independent of :math:`\lambda`. However, exceptions include nuclear resonances, strong Bragg scattering as in beryllium, and significant inelastic effects. [2]_
- 
+
 Absorption cross section (:math:`\sigma_a`)
 ###########################################
 For the absorption cross section, again typically the cross section is used from the same tabulated single atom values [1]_ but is only valid for the reference wavelength, 1.7982 :math:`\AA`,
-at which it was measured at. Thus, we can look up the value of :math:`\sigma_a (1.7982 \AA)`. Yet, the absorption cross section is a linear function of wavelength (away from nuclear resonances). 
+at which it was measured at. Thus, we can look up the value of :math:`\sigma_a (1.7982 \AA)`. Yet, the absorption cross section is a linear function of wavelength (away from nuclear resonances).
 Thus, we can calculate the absorption cross section at other wavelengths from:
 
 .. math::
@@ -46,20 +46,20 @@ Thus, we can calculate the absorption cross section at other wavelengths from:
 
     \sigma_a (\lambda) = \sigma_a (1.7982 \AA) \left( \frac{\lambda}{1.7982} \right)
 
-**NOTE:** In Mantid, the reference wavelength is defined as a variable :code:`ReferenceLambda` in :code:`NeutronAtom.cpp` [3]_. This variable should be used for consistency in all sample correction algorithms that 
+**NOTE:** In Mantid, the reference wavelength is defined as a variable :code:`ReferenceLambda` in :code:`NeutronAtom.cpp` [3]_. This variable should be used for consistency in all sample correction algorithms that
 calculate :math:`\sigma_a (\lambda)` from this reference wavelength.
 
 Attenuation Length (:math:`\mu`)
 #################################
-The attenuation length is defined as: 
+The attenuation length is defined as:
 
 .. math::
    :label: attenuation_length
 
     \mu = \rho \sigma_t = \rho \left( \sigma_s + \sigma_a \right)
 
-where :math:`\rho` is the atomic number density of the sample. 
-Note that :math:`\rho` is not the crystallographic or microscopic density of a unit cell but the macroscopic density of the bulk sample. If one were to measure a powder sample, the powder would not pack 
+where :math:`\rho` is the atomic number density of the sample.
+Note that :math:`\rho` is not the crystallographic or microscopic density of a unit cell but the macroscopic density of the bulk sample. If one were to measure a powder sample, the powder would not pack
 perfectly and thus there would be a given packing fraction, :math:`f`. Then, if the microscopic density is given as :math:`\rho_{micro}`, it is related to :math:`\rho` via:
 
 .. math::
@@ -74,7 +74,7 @@ Techniques for Calculating Corrections
 
 Methods for calculating the absorption corrections (and also the multiple scattering)  generally fall into these categories:
 
-1) Analytical solutions. For some simple situations it is possible to do an exact, analytical integration to produce a formula for the absorption correction based on parameters of the sample 
+1) Analytical solutions. For some simple situations it is possible to do an exact, analytical integration to produce a formula for the absorption correction based on parameters of the sample
 
 * Very fast.
 * Results are often stored in look up tables.
@@ -89,21 +89,21 @@ Methods for calculating the absorption corrections (and also the multiple scatte
 * Implemented in Mantid
 
 3) Monte Carlo integration
- 
+
 * Generally a more computationally demanding calculation and slower to solution. Monte Carlo is used for the numerical integration technique.
 * Relaxation of most assumptions needed by analytical solutions.
 * More flexible than the analytical techniques for shapes, beam profiles, and mixed number of scattering processes.
 * Implemented in Mantid
 
-4) Monte Carlo ray tracing 
+4) Monte Carlo ray tracing
 
 * Most general solution in that it is a virtual neutron experiment with all neutron histories kept. Slowest to solution.
 * Relatively no assumptions needed. Can simulate mixed numbers of scattering, complex scattering processes (ie scattering sample to sample environment back to sample then to detector), moderator and guides included.
 * Most flexible but mainly a tool for designing new instruments than for calculating sample corrections.
-* Typically calculated in another program specific to ray tracing and then imported into Mantid. 
+* Typically calculated in another program specific to ray tracing and then imported into Mantid.
 
 The analytical and numerical integration methods generally provide a quicker solution, but at the expense of having to make assumptions about sample geometries and scattering processes that make them less flexible than the Monte Carlo techniques (integration and ray-tracing).
-However, in many cases analytical and numerical integration solutions are satisfactory and allow much more efficient analysis of results. 
+However, in many cases analytical and numerical integration solutions are satisfactory and allow much more efficient analysis of results.
 
 .. _Absorption Corrections:
 
@@ -112,15 +112,15 @@ Absorption
 
 Introduction
 ###############
-Determination of the structure and/or dynamics of samples depends on the analysis of single scattering data. 
+Determination of the structure and/or dynamics of samples depends on the analysis of single scattering data.
 Overall, the absorption correction is a factor, :math:`A`, such that 0 < :math:`A` < 1 . It is a factor that accounts for the loss of intensity from single scattering in the sample (or other component in the instrument).
 due to both scattering and capture events in the sample. The factor :math:`A` is divided by the measured intensity. Thus, the absorption correction has an overall multiplicative enhancement of the measured intensity.
 
 Basic Sample Absorption Theory
 ###############################
-The figure shows how a general single scattering process might occur. The neutron travels 
+The figure shows how a general single scattering process might occur. The neutron travels
 a certain distance :math:`l_1` through the sample before a single scattering event occurs in
-the volume element :math:`dV` of the sample. Then, the neutron travels a final length :math:`l_2` before leaving the sample and being picked up by 
+the volume element :math:`dV` of the sample. Then, the neutron travels a final length :math:`l_2` before leaving the sample and being picked up by
 a detector.
 
 .. figure:: ../images/AbsorptionVolume.png
@@ -129,16 +129,16 @@ a detector.
 To formulate the absorption sample correction, first, we assume we have a homogeneous sample of a given shape that is fully illuminated by the incident beam.
 Then, the number of neutrons per unit solid angle scattered once by a volume element :math:`dV` of the sample and seen by a detector is given by:
 
-.. math::    
+.. math::
    :label: dI1
 
    dI_1(\theta) = J_0 \rho \frac{d\sigma}{d\Omega} \left( \theta \right) exp \left[ -\mu (\lambda_1) l_1 + - \mu (\lambda_2) l_2 \right] dV
 
-where :math:`J_0` is the incident flux, :math:`\rho` is the atomic number density, :math:`\frac{d\sigma}{d\Omega} \left( \theta \right)` is the differential cross-section, 
-:math:`l_1` and :math:`l_2` are the path lengths for incident neutrons to :math:`dV` and from :math:`dV` to the detector, respectively, 
+where :math:`J_0` is the incident flux, :math:`\rho` is the atomic number density, :math:`\frac{d\sigma}{d\Omega} \left( \theta \right)` is the differential cross-section,
+:math:`l_1` and :math:`l_2` are the path lengths for incident neutrons to :math:`dV` and from :math:`dV` to the detector, respectively,
 and :math:`\lambda_1` and :math:`\lambda_2` are the incident and scattered wavelength, respectively.
 
-Yet, this is only the contribution from a single volume element, or voxel, of the sample volume that contributes to a detector. Thus, if we integrate over the entire sample volume (all the voxels), 
+Yet, this is only the contribution from a single volume element, or voxel, of the sample volume that contributes to a detector. Thus, if we integrate over the entire sample volume (all the voxels),
 we arrive at the total intensity of neutrons scattered once through an angle :math:`\theta` and then leaving the sample without further scattering, given as:
 
 .. math::
@@ -155,7 +155,7 @@ In the last part of the equation for :math:`I_1(\theta)`, we have introduced the
 
     A = \frac{1}{V} \int_{V} exp \left[ -\mu (\lambda_1) l_1 + -\mu (\lambda_2) l_2 \right] dV
 
-This is the basic absorption correction for a single sample volume (i.e. no container included, no partial correction factors, no partial illumination, etc.). 
+This is the basic absorption correction for a single sample volume (i.e. no container included, no partial correction factors, no partial illumination, etc.).
 NOTE: In some references, this term :math:`A` is instead defined as the inverse :math:`A^{-1}`. Some references use the notation here: [2]_ [4]_ [5]_ [7]_ [8]_ and [10]_, while others use the inverse notation: [6]_.
 
 For elastic scattering, :math:`\lambda_1` = :math:`\lambda_2` = :math:`\lambda` and we can simplify to:
@@ -168,12 +168,12 @@ For elastic scattering, :math:`\lambda_1` = :math:`\lambda_2` = :math:`\lambda` 
 Partial Absorption Correction Factors: Paalman and Pings Formalism
 ###################################################################
 
-When the scattering of a sample (liquid, powder, gas, etc.) is measured, the sample is often held in a thick sample container. This container contributes significantly to the measured neutron beam. Often the empty container is measured and the signal from the container (:math:`C`) subtracted from the signal of sample plus container (:math:`S+C`). 
+When the scattering of a sample (liquid, powder, gas, etc.) is measured, the sample is often held in a thick sample container. This container contributes significantly to the measured neutron beam. Often the empty container is measured and the signal from the container (:math:`C`) subtracted from the signal of sample plus container (:math:`S+C`).
 
 The Paalman-Pings formalism (PPF) [4]_ provides a framework for correcting for individual component absorption contributions, or the partial absorption correction factors, when a sample is measured in a container and, possibly, one or more sample environments. PPF builds on the earlier work of Ritter [5]_, who described a graphical approach of accounting for partial absorption correction factors. The PPF goes beyond the work of Ritter in two important ways
 
 * The graphical approach is formulated instead using numerical integration.
-* The contribution from the sample/container correlation region, or the interface, where the density of each is affected due to their inter-material interactions. 
+* The contribution from the sample/container correlation region, or the interface, where the density of each is affected due to their inter-material interactions.
 
 In their analysis, Paalman and Pings show that the latter point is not generally of consequence since this region only exists for a few angstroms in most materials, but the ability to account for it is re-assuring. The sample/container interaction could be of significant importance in cases where the container and sample are single crystal or poly-crystalline.
 
@@ -230,27 +230,27 @@ Legends for Absorption Correction Algorithms in Mantid Table
 
 Indicates the energy modes that the algorithm can accommodate:
 
-+-------------+-----------+ 
-| Legend for Energy Mode  | 
-+=============+===========+ 
-| E           | Elastic   | 
-+-------------+-----------+ 
-| D           | Direct    | 
-+-------------+-----------+ 
-| I           | Indirect  | 
-+-------------+-----------+ 
++-------------+-----------+
+| Legend for Energy Mode  |
++=============+===========+
+| E           | Elastic   |
++-------------+-----------+
+| D           | Direct    |
++-------------+-----------+
+| I           | Indirect  |
++-------------+-----------+
 
 Indicates the technique used for calculating the absorption correction:
 
-+------------+-------------------------+ 
-|  Legend for Technique                | 
-+============+=========================+ 
-|  A         | Analytical              | 
-+------------+-------------------------+ 
-|  NI        | Numerical Integration   | 
-+------------+-------------------------+ 
-|  MC        | Monte Carlo Integration | 
-+------------+-------------------------+ 
++------------+-------------------------+
+|  Legend for Technique                |
++============+=========================+
+|  A         | Analytical              |
++------------+-------------------------+
+|  NI        | Numerical Integration   |
++------------+-------------------------+
+|  MC        | Monte Carlo Integration |
++------------+-------------------------+
 
 Options that describe what functions the algorithm is capable of and the output types:
 
@@ -309,7 +309,7 @@ Absorption Correction Algorithms in Mantid Table
 +-------------------------------------------------------------------------------------+-------------+------------+---------------------------------+--------------------+---------------------+---------------------------------------------------------------------------------------+
 | :ref:`CylinderAbsorption <algm-CylinderAbsorption>`                                 | E,D,I       | NI         | Cylinder                        | Wavelength         | A,FI                | Base class: AbsorptionCorrection                                                      |
 +-------------------------------------------------------------------------------------+-------------+------------+---------------------------------+--------------------+---------------------+---------------------------------------------------------------------------------------+
-| :ref:`CylinderPaalmanPingsCorrection <algm-CylinderPaalmanPingsCorrection>`         | E,D,I       | NI         | Cylinder                        | Wavelength         | A\++,FI             |                                                                                       |
+| :ref:`CylinderPaalmanPingsCorrection <algm-CylinderPaalmanPingsCorrection>`         | E,D,I       | NI         | Cylinder                        | Wavelength         | A\++,PI             | in-plane only                                                                         |
 +-------------------------------------------------------------------------------------+-------------+------------+---------------------------------+--------------------+---------------------+---------------------------------------------------------------------------------------+
 | :ref:`FlatPlateAbsorption <algm-FlatPlateAbsorption>`                               | E,D,I       | NI         | Flat Plate / Slab               | Wavelength         | A,FI                | Base class: AbsorptionCorrection                                                      |
 +-------------------------------------------------------------------------------------+-------------+------------+---------------------------------+--------------------+---------------------+---------------------------------------------------------------------------------------+
@@ -362,11 +362,11 @@ Multiple Scattering
 Introduction
 ############
 
-Determination of the structure and/or dynamics of samples depends on the analysis of single scattering data. 
-Small but unwanted higher-order scattering is always present although in many typical 
-experiments multiple scattering effects are negligible. However, in some cases the data may 
-contain a significant contribution from multiple scattering. In neutron scattering, the absorption cross-section is often much smaller than the scattering cross-section. 
-For this reason it is necessary to account for multiple scattering events. Using the PPF notation from previously, the measured beam from :math:`S+C` 
+Determination of the structure and/or dynamics of samples depends on the analysis of single scattering data.
+Small but unwanted higher-order scattering is always present although in many typical
+experiments multiple scattering effects are negligible. However, in some cases the data may
+contain a significant contribution from multiple scattering. In neutron scattering, the absorption cross-section is often much smaller than the scattering cross-section.
+For this reason it is necessary to account for multiple scattering events. Using the PPF notation from previously, the measured beam from :math:`S+C`
 (neglecting multiple scattering and inelastic effects) is given as:
 
 .. math::
@@ -375,7 +375,7 @@ For this reason it is necessary to account for multiple scattering events. Using
     I^E_{S+C} = [I_SA_{S,SC} + I_CA_{C,SC} + I_{m,S+C}]
 
 Thus, the multiple scattering is a parasitic signal that needs to be subtracted from the experimentally measured :math:`I^E` intensity.
-To get an idea of when and why multiple scattering 
+To get an idea of when and why multiple scattering
 corrections are needed, let us define :math:`\sigma_n` as the likelihood of a neutron being scattered :math:`n` times.
 Then it is possible to show [6]_ that:
 
@@ -383,22 +383,22 @@ Then it is possible to show [6]_ that:
    :label: sigma_m
 
 	\sigma_m \sim (\frac{\sigma_s}{\sigma_t})^m
-   
-Where practical, the shape and thickness of a sample are carefully chosen to minimize as much 
+
+Where practical, the shape and thickness of a sample are carefully chosen to minimize as much
 unwanted multiple. This may be achieved by using a sample that is either [7]_
 
 * Small in comparison with its mean free path.
 * Strongly absorbing (the absorption cross section is much greater than the scattering cross section. Usually this means the dimensions of a sample are chosen to ensure that between 10% and 20% of incident neutrons end up being scattered [8]_ ).
 
-Increasing the absorption cross section is not always attainable - due to the type of material in question - or desirable, due to 
-the accompanying intensity losses becoming overly prohibitive. 
+Increasing the absorption cross section is not always attainable - due to the type of material in question - or desirable, due to
+the accompanying intensity losses becoming overly prohibitive.
 
 Theory
 ############
-The figure shows how a general double scattering process might occur. The neutron travels 
+The figure shows how a general double scattering process might occur. The neutron travels
 a certain distance :math:`l_1` through the sample before the first scattering event in the volume
-element :math:`dV_1`. The second scattering occurs in another volume element :math:`dV_2` after a distance 
-:math:`l_{12}` has been traversed following which the neutron travels a final length :math:`l_2` before 
+element :math:`dV_1`. The second scattering occurs in another volume element :math:`dV_2` after a distance
+:math:`l_{12}` has been traversed following which the neutron travels a final length :math:`l_2` before
 leaving the sample and being picked up by a detector.
 
 .. figure:: ../images/MultipleScatteringVolume.png
@@ -413,20 +413,20 @@ We define the multiple scattering intensity, :math:`I_m`, in terms of the total 
               &= I_1 + \sum_{i=2}^{n} I_i \\
               &= I_1 + I_m
 
-Then, we see that to compute the multiple scattering, we must compute :math:`n-1` scattering intensity terms to subtract from the total, :math:`I_{total}`. 
+Then, we see that to compute the multiple scattering, we must compute :math:`n-1` scattering intensity terms to subtract from the total, :math:`I_{total}`.
 
 Let us first just consider the secondary scattering term, :math:`I_2`. We again assume we have a homogeneous sample of a given shape that is fully illuminated by the incident beam.
-Then, extending from Eq. :eq:`dI1`, we have that the number of neutrons per unit solid angle scattered once by a volume element :math:`dV_1` and then a second time by 
+Then, extending from Eq. :eq:`dI1`, we have that the number of neutrons per unit solid angle scattered once by a volume element :math:`dV_1` and then a second time by
 a volume element :math:`dV_2` of the sample and seen by a detector is given by:
 
-.. math::    
+.. math::
    :label: dI2
 
    dI_2(\theta_s) = J_0 \rho^2 \frac{d\sigma}{d\Omega} \left( \theta_1 \right) \frac{d\sigma}{d\Omega} \left( \theta_2 \right) \frac{exp \left[ -\mu (\lambda_1) l_1 + - \mu (\lambda_{12}) l_{12} + - \mu (\lambda_2) l_2 \right]}{l_{12}^2} dV dV
 
-where :math:`\theta_1` is the angle between the incident path and scatter path from :math:`dV_1`, 
-:math:`\theta_2` is the angle between scatter path from :math:`dV_1` and  scatter path from `dV_2`, 
-:math:`\theta_s` is the angle between the incident path and scatter path from :math:`dV_2` to the detector, 
+where :math:`\theta_1` is the angle between the incident path and scatter path from :math:`dV_1`,
+:math:`\theta_2` is the angle between scatter path from :math:`dV_1` and  scatter path from `dV_2`,
+:math:`\theta_s` is the angle between the incident path and scatter path from :math:`dV_2` to the detector,
 :math:`\mu_{12}` is the scattered wavelength from volume element :math:`dV_1`,
 and the :math:`l_12` term is due to the inverse square law (that as the distance increases between :math:`dV_1` and
 :math:`dV_2`, the solid angle subtended by :math:`dV_2` at :math:`dV_1` decreases as the inverse square of :math:`l_{12}`).
@@ -441,7 +441,7 @@ And the total secondary scattering intensity seen by a detector is:
 
 We can generalize this for :math:`i^{th}` order of scatter terms as:
 
-.. math::    
+.. math::
    :label: dIi
 
    dI_i(\theta_s) = J_0 \rho^n \prod_{j=1}^{i} \frac{d\sigma}{d\Omega} \left( \theta_j \right) \frac{exp \left[ -\mu (\lambda_1) l_1 + - \sum_{j=1}^{i-1} \mu (\lambda_{j,j+1}) l_{j,j+1} + - \mu (\lambda_i) l_i \right]}{ \prod_{j=1}^{i-1} l_{j,j+1}^2}  dV^{i}
@@ -517,23 +517,23 @@ Then, with the assumption that :math:`\Delta < 1`, Eq. :eq:`Im` can be manipulat
    :label: Im_proof
 
    I_m &= \sum_{i=2}^n I_i = \sum_{i=2}^n I_i \prod_{j=1}^{i-1} \frac{I_{j}}{I_{j}} = \sum_{i=2}^n I_i \frac{I_1}{I_{i-1}} \prod_{j=2}^{i-1} \frac{I_{j}}{I_{j-1}} \\
-       &=  \sum_{i=2}^n I_1 \prod_{j=2}^{i} \frac{I_{j}}{I_{j-1}} = \sum_{i=2}^n I_1 \prod_{j=2}^{i} \Delta \\ 
+       &=  \sum_{i=2}^n I_1 \prod_{j=2}^{i} \frac{I_{j}}{I_{j-1}} = \sum_{i=2}^n I_1 \prod_{j=2}^{i} \Delta \\
        &= I_1 \sum_{i=2}^n \Delta^{i-1}
 
 Similarly:
 
-.. math:: 
+.. math::
     :label: Im_delta_proof
 
-    I_m \Delta &= I_1 \Delta \sum_{i=2}^n \Delta^{i-1} = I_1 \sum_{i=2}^n \Delta^{i} 
+    I_m \Delta &= I_1 \Delta \sum_{i=2}^n \Delta^{i-1} = I_1 \sum_{i=2}^n \Delta^{i}
 
 Subtracting Eq. :eq:`Im_delta_proof` from Eq. :eq:`Im_proof`, we have:
 
-.. math:: 
+.. math::
     :label: Im_delta_difference
 
     I_m - I_m \Delta &= I_1 \sum_{i=2}^n \Delta^{i-1}  - I_1 \sum_{i=2}^n \Delta^{i} \\
-                     &= I_1 (\Delta - \Delta^{n}) 
+                     &= I_1 (\Delta - \Delta^{n})
 
 Which, solving for :math:`I_m` and based on the assumption :math:`\Delta < 1`, implying :math:`\Delta^n << \Delta`, we arrive at:
 
@@ -541,9 +541,9 @@ Which, solving for :math:`I_m` and based on the assumption :math:`\Delta < 1`, i
     :label: Im_geometric
 
     I_m &= I_1 \frac{\Delta - \Delta^{n}}{1 - \Delta} \\
-        &\approx I_1 \frac{\Delta }{1 - \Delta} 
+        &\approx I_1 \frac{\Delta }{1 - \Delta}
 
-NOTE: Sears arrived at a separate equation for :math:`I_m` based on flat plate samples but supposedly general enough for any shape sample: :math:`I_{m,Sears} = I_1 \left( \frac{exp(2\delta)-1}{2\delta} - 1 \right)`. 
+NOTE: Sears arrived at a separate equation for :math:`I_m` based on flat plate samples but supposedly general enough for any shape sample: :math:`I_{m,Sears} = I_1 \left( \frac{exp(2\delta)-1}{2\delta} - 1 \right)`.
 However, comparisons of both equations for cylinders show that Eq. :eq:`Im_geometric` is more accurate solution. [10]_
 
 From Eq. :eq:`Im_geometric`, we are left with calculating :math:`\Delta`:
@@ -556,7 +556,7 @@ From Eq. :eq:`Im_geometric`, we are left with calculating :math:`\Delta`:
                    { J_0 \rho \frac{d\sigma}{d\Omega} \left( \theta_s \right) \int_{V} exp \left[ -\mu (\lambda_1) l_1 + -\mu (\lambda_2) l_2 \right] dV  } \\
            &= \frac{ \rho \frac{d\sigma}{d\Omega} \left( \theta_1 \right) \frac{d\sigma}{d\Omega} \left( \theta_2 \right) \int_{V} \int_{V} \frac{exp \left[ -\mu (\lambda_1) l_1 + - \mu (\lambda_{12}) l_{12} + - \mu (\lambda_2) l_2 \right]}{l_{12}^2} dV dV }
                    { \frac{d\sigma}{d\Omega} \left( \theta_s \right) \int_{V} exp \left[ -\mu (\lambda_1) l_1 + -\mu (\lambda_2) l_2 \right] dV  }
-              
+
 Using the isotropic approximation, we arrive at:
 
 .. math::
@@ -564,9 +564,9 @@ Using the isotropic approximation, we arrive at:
 
     \Delta_{elastic} &= \frac{ \rho \left( \frac{\sigma_s}{4 \pi} \right)^2 \int_{V} \int_{V} \frac{exp \left[ -\mu (\lambda_1) l_1 + - \mu (\lambda_{12}) l_{12} + - \mu (\lambda_2) l_2 \right]}{l_{12}^2} dV dV }
                              { \frac{\sigma_s}{4 \pi}  \int_{V} exp \left[ -\mu (\lambda_1) l_1 + -\mu (\lambda_2) l_2 \right] dV  } \\
-                     &= \frac{ \rho \sigma_s A_2 V^2 }{ 4 \pi A_1 V  } = \frac{ \rho V \sigma_s A_2 }{ 4 \pi A_1  } 
+                     &= \frac{ \rho \sigma_s A_2 V^2 }{ 4 \pi A_1 V  } = \frac{ \rho V \sigma_s A_2 }{ 4 \pi A_1  }
 
-where :math:`A_2` is the secondary scattering absorption factor and :math:`A_1` is the single scattering absorption factor, equivalent to :math:`A` in Eq. :eq:`absorption_factor`. 
+where :math:`A_2` is the secondary scattering absorption factor and :math:`A_1` is the single scattering absorption factor, equivalent to :math:`A` in Eq. :eq:`absorption_factor`.
 The absorption factors can be further simplified by using the elastic scattering assumption from Eq. :eq:`absorption_factor_elastic`.
 
 We can now begin to solve for :math:`I_m` by taking Eq. :eq:`Im_geometric` and substituting this into Eq. :eq:`Itotal`:
@@ -593,7 +593,7 @@ Thus, comparing Eq. :eq:`ms_derivation_part2` and Eq. :eq:`delta_equation_elasti
     :label: Im_equation
 
     I_m &= I_{total} \Delta \\
-        &= I_{total} \frac{ \rho V \sigma_s A_2 }{ 4 \pi A_1  } 
+        &= I_{total} \frac{ \rho V \sigma_s A_2 }{ 4 \pi A_1  }
 
 General Notes
 ##############
@@ -603,28 +603,28 @@ Analytical Methods
 
 The analytical approach has been further extended in a number of ways:
 
-1. The beam profile (and similarly the detector visibility of the sample) can also be included to accommodate partial illumination of the sample by the beam by means of a convolution function for the shape of the profile. [10]_ 
+1. The beam profile (and similarly the detector visibility of the sample) can also be included to accommodate partial illumination of the sample by the beam by means of a convolution function for the shape of the profile. [10]_
 2. The isotropic approximation can be relaxed, giving anisotropic scattering for the single scattering term :math:`I_1` in Eq. :eq:`Im_isotropic`. This can be realized by either producing a solvable equation for :math:`\frac{d\sigma}{d\Omega}` [6]_ or by using a model equation for :math:`\frac{d\sigma}{d\Omega}`. [11]_
 3. The constant ratio assumption can be tested by computing the higher orders of scattering terms with comparison to Monte Carlo (for flat plate and cylinder comparisons to Monte Carlo, see [12]_).
 
 Monte Carlo Methods
 ^^^^^^^^^^^^^^^^^^^^
 
-Monte Carlo approaches are a "brute force" technique that does require more computational time than the analytical approaches yet does not suffer many of the drawbacks 
+Monte Carlo approaches are a "brute force" technique that does require more computational time than the analytical approaches yet does not suffer many of the drawbacks
 to the analytical approach. Such drawbacks included assumptions of isotropic scattering required to formulate the solvable equations, not being able to include
 the intermediate energy transfers for scattering, and easier flexibility to handle complicated shapes for sample, container, and/or sample environments.
 
-In the Monte Carlo ray tracing technique, a virtual experiment is performed such that individual neutrons are put on a trajectory through a model of the 
-instrument with scattering kernels defined for samples, containers, and other components of the instrument. 
+In the Monte Carlo ray tracing technique, a virtual experiment is performed such that individual neutrons are put on a trajectory through a model of the
+instrument with scattering kernels defined for samples, containers, and other components of the instrument.
 Neutron histories are recorded so there is a clear distinction between single and multiple scattered neutrons and the multiple scattering correction
 is easily obtained from the result.
 
 
 Small Angle Scattering
 ^^^^^^^^^^^^^^^^^^^^^^
-In some areas, such as small angle scattering, there may be useful approximations that can be 
-applied that are not present for the more general wide angle scattering case. 
-Again matters may become complicated, as for example small angle scatter followed by incoherent 
+In some areas, such as small angle scattering, there may be useful approximations that can be
+applied that are not present for the more general wide angle scattering case.
+Again matters may become complicated, as for example small angle scatter followed by incoherent
 scatter from hydrogen can be more significant in blurring sharp features than double small angle scatter.
 For early considerations of multiple small angle scattering see for example [13]_ [14]_.
 
@@ -633,25 +633,25 @@ Legends for Multiple Scattering Correction Algorithms in Mantid Table
 ######################################################################
 Indicates the energy modes that the algorithm can accommodate:
 
-+-------------+-----------+ 
-| Legend for Energy Mode  | 
-+=============+===========+ 
-| E           | Elastic   | 
-+-------------+-----------+ 
-| D           | Direct    | 
-+-------------+-----------+ 
-| I           | Indirect  | 
-+-------------+-----------+ 
++-------------+-----------+
+| Legend for Energy Mode  |
++=============+===========+
+| E           | Elastic   |
++-------------+-----------+
+| D           | Direct    |
++-------------+-----------+
+| I           | Indirect  |
++-------------+-----------+
 
 Indicates the technique used for calculating the absorption correction:
 
-+------------+-------------------------+ 
-|  Legend for Technique                | 
-+============+=========================+ 
-|  NI        | Numerical Integration   | 
-+------------+-------------------------+ 
-|  MC        | Monte Carlo Integration | 
-+------------+-------------------------+ 
++------------+-------------------------+
+|  Legend for Technique                |
++============+=========================+
+|  NI        | Numerical Integration   |
++------------+-------------------------+
+|  MC        | Monte Carlo Integration |
++------------+-------------------------+
 
 Options that describe what functions the algorithm is capable of, assumptions, and the output types:
 
@@ -716,13 +716,13 @@ References
 .. [3] Mantid source code for `NeutronAtom.cpp to define ReferenceLambda variable. <https://github.com/mantidproject/mantid/blob/master/Framework/Kernel/src/NeutronAtom.cpp#L23>`__
 .. [4] H. H. Paalman, and C. J. Pings. (1962) *Numerical Evaluation of X‐Ray Absorption Factors for Cylindrical Samples and Annular Sample Cells*, Journal of Applied Physics 33:8 2635–2639 `doi: 10.1063/1.1729034 <http://dx.doi.org/10.1063/1.1729034>`__
 .. [5] H. L. Ritter, R. L. Harris, & R. E. Wood (1951) *On the X-Ray Absorption Correction for Encased Diffracters in the Debye-Sherrer Technique*, Journal of Applied Physics 22:2 169-176 `doi: 10.1063/1.699919 <https://doi.org/10.1063/1.1699919>`__
-.. [6] E. J. Lindley & J. Mayers (Ed.). (1988). *Chapter 10: Experimental method and corrections to data*. United Kingdom: Adam Hilger. - https://inis.iaea.org/search/search.aspx?orig_q=RN:20000574 
+.. [6] E. J. Lindley & J. Mayers (Ed.). (1988). *Chapter 10: Experimental method and corrections to data*. United Kingdom: Adam Hilger. - https://inis.iaea.org/search/search.aspx?orig_q=RN:20000574
 .. [7] V.F. Sears (1975): *Slow-neutron multiple scattering*, `Advances in Physics <http://dx.doi.org/10.1080/00018737500101361>`__, 24:1, 1-45
 .. [8] A.K.Soper, W.S.Howells and A.C.Hannon *ATLAS - Analysis of Time-of-Flight Diffraction Data from Liquid and Amorphous Samples* Rutherford Appleton Laboratory Report (1989): `RAL-89-046 <http://wwwisis2.isis.rl.ac.uk/disordered/Manuals/ATLAS/ATLAS%20manual%20v1.0.pdf>`__
-.. [9] I. A. Blech,& B. L. Averbach (Ed.). (1965). *Multiple Scattering of Neutrons in Vanadium and Copper*. Physical Review 137:4A A1113–A1116 `doi: 10.1103/PhysRev.137.A1113 <https://doi.org/10.1103/PhysRev.137.A1113>`__ 
-.. [10] A. K. Soper & P. A. Egelstaff (1980). *Multiple Scattering and Attenuation of Neutrons in Concentric Cylinders: I. Isotropic First Scattering*. Nuclear Instruments and Methods 178 415–425 `doi: 10.1016/0029-554X(80)90820-4 <https://doi.org/10.1016/0029-554X(80)90820-4>`__ 
+.. [9] I. A. Blech,& B. L. Averbach (Ed.). (1965). *Multiple Scattering of Neutrons in Vanadium and Copper*. Physical Review 137:4A A1113–A1116 `doi: 10.1103/PhysRev.137.A1113 <https://doi.org/10.1103/PhysRev.137.A1113>`__
+.. [10] A. K. Soper & P. A. Egelstaff (1980). *Multiple Scattering and Attenuation of Neutrons in Concentric Cylinders: I. Isotropic First Scattering*. Nuclear Instruments and Methods 178 415–425 `doi: 10.1016/0029-554X(80)90820-4 <https://doi.org/10.1016/0029-554X(80)90820-4>`__
 .. [11] S. J. Cocking & C. R. T. Heard (1965). *Multiple Scattering in Plane Samples: Application to Scattering of Thermal Neutrons*. Report AERE - R5016, Harwell, Berkshire.
-.. [12] J. Mayers & R. Cywinski (1985). *A Monte Carlo Evaluation of Analytical Multiple Scattering Corrections for Unpolarised Neutron Scatting and Polarization Analysis Data*. Nuclear Instruments and Methods in Physics Research Section A: Accelerators, Spectrometers, Detectors, and Associated Equipment 241, 519-531 `doi: 10.1016/0168-9002(85)90607-2 <https://doi.org/10.1016/0168-9002(85)90607-2>`__ 
+.. [12] J. Mayers & R. Cywinski (1985). *A Monte Carlo Evaluation of Analytical Multiple Scattering Corrections for Unpolarised Neutron Scatting and Polarization Analysis Data*. Nuclear Instruments and Methods in Physics Research Section A: Accelerators, Spectrometers, Detectors, and Associated Equipment 241, 519-531 `doi: 10.1016/0168-9002(85)90607-2 <https://doi.org/10.1016/0168-9002(85)90607-2>`__
 .. [13] J.Schelten & W.Schmatz, J.Appl.Cryst. 13(1980)385-390
 .. [14] J.R.D.Copley J.Appl.Cryst 21(1988)639-644
 .. [15] McStas: A neutron ray-trace simulation package `website <http://mcstas.org/>`__


### PR DESCRIPTION
There is the original 1962 Paalman Pings and the update by Kendig Pings in 1965. The algorithm implements the latter. This PR also updates the table in the absorption/multiple scattering concept page to denote that partial illumination is implemented and the calculation is only in-plane.

**To test:**

Reviewing the text that was changed is enough.

*There is no associated issue.*

*This does not require release notes* because it is minor documentation change

<!-- Ensure the base of this PR is correct (e.g. release-next or master)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
