### PR TITLE
Add ability to enable the MSVC address sanitizer via cmake

### DIFF
--- a/buildconfig/CMake/GoogleTest.cmake
+++ b/buildconfig/CMake/GoogleTest.cmake
@@ -35,3 +35,10 @@ foreach( target_var gmock gtest gmock_main gtest_main )
                           PROPERTIES EXCLUDE_FROM_ALL TRUE
                           FOLDER "UnitTests/gmock" )
 endforeach()
+
+# W4 logging doesn't work with MSVC address sanitizer, turn off sanitizer since not our code
+if(MSVC)
+    get_target_property(opts gmock COMPILE_OPTIONS)
+    string(REPLACE "/fsanitize=address" "" opts ${opts})
+    set_property(TARGET gmock PROPERTY COMPILE_OPTIONS ${opts})
+endif()

--- a/buildconfig/CMake/GoogleTest.cmake
+++ b/buildconfig/CMake/GoogleTest.cmake
@@ -37,7 +37,7 @@ foreach( target_var gmock gtest gmock_main gtest_main )
 endforeach()
 
 # W4 logging doesn't work with MSVC address sanitizer, turn off sanitizer since not our code
-if(MSVC)
+if(MSVC AND (USE_SANITIZERS_LOWER STREQUAL "address"))
     get_target_property(opts gmock COMPILE_OPTIONS)
     string(REPLACE "/fsanitize=address" "" opts ${opts})
     set_property(TARGET gmock PROPERTY COMPILE_OPTIONS ${opts})

--- a/buildconfig/CMake/Sanitizers.cmake
+++ b/buildconfig/CMake/Sanitizers.cmake
@@ -31,14 +31,11 @@ if(NOT ${USE_SANITIZERS_LOWER} MATCHES "off")
         if(${USE_SANITIZERS_LOWER} MATCHES "address")
             add_compile_options($<$<OR:$<CONFIG:Debug>,$<CONFIG:RelWithDebInfo>>:/fsanitize=address>)
             add_link_options("$<IF:$<CONFIG:Debug>,/wholearchive:clang_rt.asan_dbg_dynamic-x86_64.lib;/wholearchive:clang_rt.asan_dbg_dynamic_runtime_thunk-x86_64.lib;/wholearchive:vcasand.lib,/wholearchive:clang_rt.asan_dynamic-x86_64.lib;/wholearchive:clang_rt.asan_dynamic_runtime_thunk-x86_64.lib;/wholearchive:vcasan.lib>")
-            # Re additional switches enabled below on gcc:
-            # Equivalent of -fno-omit-frame-pointer in MSVC is /Oy- but documentation says it's not available for x64
-            # Don't think there is a VS equivalent of -fno-optimize-sibling-calls
         else()
             message(FATAL_ERROR "MSVC only supports address sanitizer")
         endif()
     else()
-        # Check and warn if we are not in a mode without debug symbols)
+        # Check and warn if we are not in a mode without debug symbols
         string(TOLOWER "${CMAKE_BUILD_TYPE}" build_type_lower)
         if("${build_type_lower}" MATCHES "release" OR "${build_type_lower}" MATCHES "minsizerel" )
             message(WARNING "You are running address sanitizers without debug information, try RelWithDebInfo")

--- a/buildconfig/CMake/Sanitizers.cmake
+++ b/buildconfig/CMake/Sanitizers.cmake
@@ -9,54 +9,72 @@ set_property(CACHE USE_SANITIZER PROPERTY STRINGS
 string(TOLOWER "${USE_SANITIZER}" USE_SANITIZERS_LOWER)
 
 if(NOT ${USE_SANITIZERS_LOWER} MATCHES "off")
-    # Check we have a supported compiler
-    if(WIN32)
-        message(FATAL_ERROR "Windows does not support sanitizers")
-    endif()
 
     if(CMAKE_COMPILER_IS_GNUCXX AND (NOT CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 8))
         message(FATAL_ERROR "GCC 7 and below do not support sanitizers")
     endif()
 
-    # Check and warn if we are not in a mode without debug symbols
-    string(TOLOWER "${CMAKE_BUILD_TYPE}" build_type_lower)
-    if("${build_type_lower}" MATCHES "release" OR "${build_type_lower}" MATCHES "minsizerel" )
-        message(WARNING "You are running address sanitizers without debug information, try RelWithDebInfo")
+    if(MSVC)
+        if(MSVC_VERSION LESS 1927)
+            message(FATAL_ERROR "MSVC version below 16.7 doesn't support address sanitizer")
+        endif()
+    endif()
 
-    elseif(${build_type_lower} MATCHES "relwithdebinfo")
+    if(MSVC)
+        # some units don't compile using the /O2 flag
+        message("Replacing -O2 flag with -O1 so that code compiles with sanitizer")
+        string(REPLACE "/O2" "/O1" CMAKE_CXX_FLAGS_RELWITHDEBINFO ${CMAKE_CXX_FLAGS_RELWITHDEBINFO})
+        string(REPLACE "/O2" "/O1" CMAKE_C_FLAGS_RELWITHDEBINFO ${CMAKE_C_FLAGS_RELWITHDEBINFO})
+        set(CMAKE_CXX_FLAGS_RELWITHDEBINFO ${CMAKE_CXX_FLAGS_RELWITHDEBINFO} CACHE STRING "" FORCE)
+        set(CMAKE_C_FLAGS_RELWITHDEBINFO ${CMAKE_C_FLAGS_RELWITHDEBINFO} CACHE STRING "" FORCE)
+
+        if(${USE_SANITIZERS_LOWER} MATCHES "address")
+            add_compile_options($<$<OR:$<CONFIG:Debug>,$<CONFIG:RelWithDebInfo>>:/fsanitize=address>)
+            add_link_options("$<IF:$<CONFIG:Debug>,/wholearchive:clang_rt.asan_dbg_dynamic-x86_64.lib;/wholearchive:clang_rt.asan_dbg_dynamic_runtime_thunk-x86_64.lib;/wholearchive:vcasand.lib,/wholearchive:clang_rt.asan_dynamic-x86_64.lib;/wholearchive:clang_rt.asan_dynamic_runtime_thunk-x86_64.lib;/wholearchive:vcasan.lib>")
+            # Re additional switches enabled below on gcc:
+            # Equivalent of -fno-omit-frame-pointer in MSVC is /Oy- but documentation says it's not available for x64
+            # Don't think there is a VS equivalent of -fno-optimize-sibling-calls
+        else()
+            message(FATAL_ERROR "MSVC only supports address sanitizer")
+        endif()
+    else()
+        # Check and warn if we are not in a mode without debug symbols)
+        string(TOLOWER "${CMAKE_BUILD_TYPE}" build_type_lower)
+        if("${build_type_lower}" MATCHES "release" OR "${build_type_lower}" MATCHES "minsizerel" )
+            message(WARNING "You are running address sanitizers without debug information, try RelWithDebInfo")
+        endif()
         # RelWithDebug runs with -o2 which performs inlining reducing the usefulness
         message("Replacing -O2 flag with -O1 to preserve stack trace on sanitizers")
         string(REPLACE "-O2" "-O1" CMAKE_CXX_FLAGS_RELWITHDEBINFO ${CMAKE_CXX_FLAGS_RELWITHDEBINFO})
         string(REPLACE "-O2" "-O1" CMAKE_C_FLAGS_RELWITHDEBINFO ${CMAKE_C_FLAGS_RELWITHDEBINFO})
-
         set(CMAKE_CXX_FLAGS_RELWITHDEBINFO ${CMAKE_CXX_FLAGS_RELWITHDEBINFO} CACHE STRING "" FORCE)
         set(CMAKE_C_FLAGS_RELWITHDEBINFO ${CMAKE_C_FLAGS_RELWITHDEBINFO} CACHE STRING "" FORCE)
+        if(${build_type_lower} MATCHES "relwithdebinfo")
+            add_compile_options(-fno-omit-frame-pointer -fno-optimize-sibling-calls)
+        endif()
 
-        add_compile_options(-fno-omit-frame-pointer -fno-optimize-sibling-calls)
+        # Allow all instrumented code to continue beyond the first error
+        add_compile_options($<$<NOT:$<STREQUAL:$<LOWER_CASE:"${USE_SANITIZER}">,"off">>:-fsanitize-recover=all>)
+        # Address
+        add_compile_options(
+            $<$<STREQUAL:$<LOWER_CASE:"${USE_SANITIZER}">,"address">:-fsanitize=address>)
+        add_link_options(
+            $<$<STREQUAL:$<LOWER_CASE:"${USE_SANITIZER}">,"address">:-fsanitize=address>)
+
+        # Thread
+        add_compile_options(
+            $<$<STREQUAL:$<LOWER_CASE:"${USE_SANITIZER}">,"thread">:-fsanitize=thread>)
+        add_link_options(
+            $<$<STREQUAL:$<LOWER_CASE:"${USE_SANITIZER}">,"thread">:-fsanitize=thread>)
+
+        # Undefined
+        # RTTI information is not exported for some classes causing the
+        # linker to fail whilst adding vptr instrumentation
+        add_compile_options(
+            $<$<STREQUAL:$<LOWER_CASE:"${USE_SANITIZER}">,"undefined">:-fsanitize=undefined>
+            $<$<STREQUAL:$<LOWER_CASE:"${USE_SANITIZER}">,"undefined">:-fno-sanitize=vptr>)
+
+        add_link_options(
+            $<$<STREQUAL:$<LOWER_CASE:"${USE_SANITIZER}">,"undefined">:-fsanitize=undefined>)
     endif()
 endif()
-
-# Allow all instrumented code to continue beyond the first error
-add_compile_options($<$<NOT:$<STREQUAL:$<LOWER_CASE:"${USE_SANITIZER}">,"off">>:-fsanitize-recover=all>)
-
-# Address
-add_compile_options(
-    $<$<STREQUAL:$<LOWER_CASE:"${USE_SANITIZER}">,"address">:-fsanitize=address>)
-add_link_options(
-    $<$<STREQUAL:$<LOWER_CASE:"${USE_SANITIZER}">,"address">:-fsanitize=address>)
-
-# Thread
-add_compile_options(
-    $<$<STREQUAL:$<LOWER_CASE:"${USE_SANITIZER}">,"thread">:-fsanitize=thread>)
-add_link_options(
-    $<$<STREQUAL:$<LOWER_CASE:"${USE_SANITIZER}">,"thread">:-fsanitize=thread>)
-
-# Undefined
-# RTTI information is not exported for some classes causing the
-# linker to fail whilst adding vptr instrumentation
-add_compile_options(
-    $<$<STREQUAL:$<LOWER_CASE:"${USE_SANITIZER}">,"undefined">:-fsanitize=undefined>
-    $<$<STREQUAL:$<LOWER_CASE:"${USE_SANITIZER}">,"undefined">:-fno-sanitize=vptr>)
-
-add_link_options(
-    $<$<STREQUAL:$<LOWER_CASE:"${USE_SANITIZER}">,"undefined">:-fsanitize=undefined>)

--- a/dev-docs/source/RunningSanitizers.rst
+++ b/dev-docs/source/RunningSanitizers.rst
@@ -16,10 +16,12 @@ related to memory, threading or undefined behaviour.
 Pre-requisites
 ==============
 
-The following tooling is required:
+The following tooling is required for the GCC compiler:
 
 - GCC-8 onwards
 - Clang 3.2 onwards
+
+Microsoft Visual Studio 2019 provides an (experimental) address sanitizer that applies to x64 targets in version 16.7 and later
 
 
 Switching to Sanitizer Build
@@ -28,8 +30,8 @@ Switching to Sanitizer Build
 The following sanitizers modes are available:
 
 - Address
-- Thread
-- Undefined
+- Thread (GCC only)
+- Undefined (GCC only)
 
 It's recommended to build in *RelWithDebInfo* mode, CMake will automatically
 switch to -O1 and append extra flags for stack traces to work correctly whilst
@@ -41,17 +43,23 @@ performance penalty will be pretty severe.
 Command Line
 ------------
 
-First, delete *CMakeCache.txt* if your system compiler is GCC 7 or below
+First, delete *CMakeCache.txt* if using GCC and your system compiler is GCC 7 or below
 (you can check with *gcc -v*).
 
 To change to a sanitized build navigate to your build folder and execute the
-following:
+following if you're using a single-config generator (eg Ninja):
 
     .. code-block:: sh
 
         cmake *path_to_src* -DUSE_SANITIZER=*Mode* -DCMAKE_BUILD_TYPE=RelWithDebInfo
 
-If you need to specify a different compiler too (for example if your system
+...or the following with a multi-config generator (eg Visual Studio):
+
+    .. code-block:: sh
+
+        cmake *path_to_src* -DUSE_SANITIZER=*Mode*
+
+If you are using GCC and need to specify a different compiler too (for example if your system
 default is GCC-7)
 
     .. code-block:: sh
@@ -68,12 +76,13 @@ For example, to switch to an address sanitizer build the following can be used:
 CMake GUI
 ---------
 
-- Delete the cache if your system compiler is GCC 7 or below (you can check
-  with *gcc -v*). Hit configure and click specify native compilers to *gcc-8*
-  and *g++-8*
-- Change *CMAKE_BUILD_TYPE* to *RelWithDebInfo* (or *Debug*)
+- If using GCC, delete the cache if your system compiler is GCC 7 or below (you can check
+  with *gcc -v*)
+- Hit configure
+- If using GCC, click specify native compilers to *gcc-8* and *g++-8*
+- If using a single-config generator, change *CMAKE_BUILD_TYPE* to *RelWithDebInfo* (or *Debug*)
 - Change *USE_SANITIZERS* to any of the options in the drop down
-- Hit generate and rebuild the project
+- Hit configure again, then generate and rebuild the project
 
 Running Tests
 =============
@@ -83,6 +92,25 @@ resolve (or have been resolved but not appeared downstream).
 
 We can suppress warnings in the address sanitizer by setting environment
 variables in the console before running in each mode.
+
+Visual Studio Address Sanitizer
+===============================
+
+The Visual Studio address sanitizer raises exceptions with code 0xC0000005 as part of its normal operation. 
+The exceptions are handled but they cause the debugger to stop. These exceptions need to be ignored in the Debug, Windows, Exception Settings dialog
+
+Genuine sanitizer issues cause an unhandled exception and the debugger will stop at the relevant unit\line.
+
+Some parts of the Mantid code (eg H5Util.cpp) don't compile when the address sanitizer is enabled and the /O2 optimisation flag is used (in RelWithDebInfo).
+This flag is switched to /O1 in order to improve stack trace information (see above) and this fortunately removes the compilation errors.
+
+The following path (or equivalent for your Visual Studio version) needs to be added to your path environment variable in order for Visual Studio to find some .lib files that are used by the sanitizer and also to locate a symbolizer exe that is required for useful error messages:
+
+C:\\Program Files (x86)\\Microsoft Visual Studio\\2019\\Community\\VC\\Tools\\MSVC\\14.27.29110\\bin\\Hostx64\\x64
+
+Additional information is available on this web page:
+
+https://devblogs.microsoft.com/cppblog/asan-for-windows-x64-and-debug-build-support/
 
 Advanced Details
 ================


### PR DESCRIPTION
**Description of work.**

Microsoft have recently added an address sanitizer that checks for run time memory errors to VS 2019. 

https://devblogs.microsoft.com/cppblog/addresssanitizer-asan-for-windows-with-msvc/
https://devblogs.microsoft.com/cppblog/asan-for-windows-x64-and-debug-build-support/

These changes allow this to be configured in all of the Mantid targets using the existing USE_SANITIZER switch that was previously only relevant to the gcc compiler.

Excluded the gmock target from having the sanitizer set up applied because the gmock cmake set up specifies a W4 logging level that doesn't play nicely with the sanitizer. Since this isn't our code have assumed we don't need to sanitize it

**To test:**

1. Check you are running Visual Studio 2019 v16.7 or later
2. Run CMake with USE_SANITIZER set to Address. If using the CMake gui you need to press Configure, wait to complete, then press Generate
3. This should update most of the targets (ie Visual Studio projects) with some new settings
4. In Visual Studio go to Debug, Windows, Exception Settings and uncheck the exception with description "0xc0000005 0xC0000005" under the "Win32 Exceptions" heading
5. Add this (or similar) to your path environment variable:
C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\VC\Tools\MSVC\14.27.29110\bin\Hostx64\x64
6. Paste the following lines of code into one of the C++ units within the Framework (eg in the exec method of one of the Algorithms). These lines create an address issue that the sanitizer should find:
```
int* array = new int[100];
array[100] = 1;
```
7. Build the Framework and the corresponding unit test (eg in AlgorithmsTest) in RelWithDebInfo mode
8. Run the unit test from Visual Studio and check the debugger stops\finds this problem
9. Check the dev docs changes to the "Running Sanitizers" page adequately describe the set up. They cover the gcc set up and now the Visual Studio use of sanitizers

Fixes #29568. 

*This does not require release notes* because **the sanitizer is not active in release builds of Mantid**

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
