### PR TITLE
fix index peaks crashes

### DIFF
--- a/Framework/Crystal/inc/MantidCrystal/PeakAlgorithmHelpers.h
+++ b/Framework/Crystal/inc/MantidCrystal/PeakAlgorithmHelpers.h
@@ -45,6 +45,12 @@ validModulationVectors(const std::vector<double> &modVector1,
                        const std::vector<double> &modVector2,
                        const std::vector<double> &modVector3);
 
+/// Create a list of valid modulation vectors from the input
+std::vector<Kernel::V3D>
+addModulationVectors(const std::vector<double> &modVector1,
+                     const std::vector<double> &modVector2,
+                     const std::vector<double> &modVector3);
+
 /// Calculate a list of HKL offsets from the given modulation vectors.
 std::vector<MNPOffset>
 generateOffsetVectors(const std::vector<Kernel::V3D> &modVectors,

--- a/Framework/Crystal/src/IndexPeaks.cpp
+++ b/Framework/Crystal/src/IndexPeaks.cpp
@@ -69,19 +69,19 @@ struct IndexPeaksArgs {
     // default behavior: map everything automatically
     maxOrderToUse = maxOrderFromAlg;
     crossTermToUse = alg.getProperty(ModulationProperties::CrossTerms);
-    modVectorsToUse = addModulationVectors(
-        alg.getProperty(ModulationProperties::ModVector1),
-        alg.getProperty(ModulationProperties::ModVector2),
-        alg.getProperty(ModulationProperties::ModVector3));
-    
+    modVectorsToUse =
+        addModulationVectors(alg.getProperty(ModulationProperties::ModVector1),
+                             alg.getProperty(ModulationProperties::ModVector2),
+                             alg.getProperty(ModulationProperties::ModVector3));
+
     // deal with special cases
-    if (maxOrderFromAlg <= 0){
+    if (maxOrderFromAlg <= 0) {
       // Use lattice definitions if they exist
       const auto &lattice = peaksWS->sample().getOrientedLattice();
       crossTermToUse = lattice.getCrossTerm();
-      maxOrderToUse = lattice.getMaxOrder();  // the lattice can return a 0 here
-      // if lattice has maxOrder, we will use the modVec from it, otherwise stick
-      // to the input got from previous assignment
+      maxOrderToUse = lattice.getMaxOrder(); // the lattice can return a 0 here
+      // if lattice has maxOrder, we will use the modVec from it, otherwise
+      // stick to the input got from previous assignment
       if (maxOrderToUse > 0) {
         modVectorsToUse = validModulationVectors(
             lattice.getModVec(0), lattice.getModVec(1), lattice.getModVec(2));

--- a/Framework/Crystal/src/IndexPeaks.cpp
+++ b/Framework/Crystal/src/IndexPeaks.cpp
@@ -69,7 +69,7 @@ struct IndexPeaksArgs {
       // Use inputs from algorithm
       maxOrderToUse = maxOrderFromAlg;
       crossTermToUse = alg.getProperty(ModulationProperties::CrossTerms);
-      modVectorsToUse = validModulationVectors(
+      modVectorsToUse = addModulationVectors(
           alg.getProperty(ModulationProperties::ModVector1),
           alg.getProperty(ModulationProperties::ModVector2),
           alg.getProperty(ModulationProperties::ModVector3));

--- a/Framework/Crystal/src/IndexPeaks.cpp
+++ b/Framework/Crystal/src/IndexPeaks.cpp
@@ -65,23 +65,27 @@ struct IndexPeaksArgs {
     std::vector<V3D> modVectorsToUse;
     modVectorsToUse.reserve(3);
     bool crossTermToUse{false};
-    if (maxOrderFromAlg > 0) {
-      // Use inputs from algorithm
-      maxOrderToUse = maxOrderFromAlg;
-      crossTermToUse = alg.getProperty(ModulationProperties::CrossTerms);
-      modVectorsToUse = addModulationVectors(
-          alg.getProperty(ModulationProperties::ModVector1),
-          alg.getProperty(ModulationProperties::ModVector2),
-          alg.getProperty(ModulationProperties::ModVector3));
-    } else {
+
+    // default behavior: map everything automatically
+    maxOrderToUse = maxOrderFromAlg;
+    crossTermToUse = alg.getProperty(ModulationProperties::CrossTerms);
+    modVectorsToUse = addModulationVectors(
+        alg.getProperty(ModulationProperties::ModVector1),
+        alg.getProperty(ModulationProperties::ModVector2),
+        alg.getProperty(ModulationProperties::ModVector3));
+    
+    // deal with special cases
+    if (maxOrderFromAlg <= 0){
       // Use lattice definitions if they exist
       const auto &lattice = peaksWS->sample().getOrientedLattice();
-      maxOrderToUse = lattice.getMaxOrder();
+      crossTermToUse = lattice.getCrossTerm();
+      maxOrderToUse = lattice.getMaxOrder();  // the lattice can return a 0 here
+      // if lattice has maxOrder, we will use the modVec from it, otherwise stick
+      // to the input got from previous assignment
       if (maxOrderToUse > 0) {
         modVectorsToUse = validModulationVectors(
             lattice.getModVec(0), lattice.getModVec(1), lattice.getModVec(2));
       }
-      crossTermToUse = lattice.getCrossTerm();
     }
 
     return {peaksWS,

--- a/Framework/Crystal/src/PeakAlgorithmHelpers.cpp
+++ b/Framework/Crystal/src/PeakAlgorithmHelpers.cpp
@@ -109,6 +109,27 @@ validModulationVectors(const std::vector<double> &modVector1,
 }
 
 /**
+ * Direct add modulation a list to return.
+ * @param modVector1 List of 3 doubles specifying an offset
+ * @param modVector2 List of 3 doubles specifying an offset
+ * @param modVector3 List of 3 doubles specifying an offset
+ * @return A list of valid modulation vectors
+ */
+std::vector<Kernel::V3D>
+addModulationVectors(const std::vector<double> &modVector1,
+                     const std::vector<double> &modVector2,
+                     const std::vector<double> &modVector3) {
+  std::vector<V3D> modVectors;
+  auto addVec = [&modVectors](const auto &modVec) {
+    modVectors.emplace_back(V3D(modVec[0], modVec[1], modVec[2]));
+  };
+  addVec(modVector1);
+  addVec(modVector2);
+  addVec(modVector3);
+  return modVectors;
+}
+
+/**
  * @param maxOrder Integer specifying the multiples of the
  * modulation vector.
  * @param modVectors A list of modulation vectors form the user


### PR DESCRIPTION
**Description of work.**

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

As described in #29429, the `IndexPeaks` function will leads to a segmentation fault when invoked with 

```python
IndexPeaks(
    PeaksWorkspace="data", 
    Tolerance=0.12, 
    RoundHKLs=False,
    SaveModulationInfo=True,
)
``` 

This is because the function `validModulationVectors` will return an empty `std::vector` with the default `modVector` values.
Trying to access these non-existing/empty `modVector` at any point in code will lead to the aforementioned segmentation fault.
This patch adjusted the order of the input property assignment to avoid empty `modVectors`, ensuring the internal representation matches the description in the documentation (default modVectors are `(0,0,0)`, not `()`).

**To test:**
Using the data provided in the linked issue, the following Python script can be used to perform the required test
```Python
#!/usr/bin/bash

from mantid.simpleapi import *
import matplotlib.pyplot as plt
import numpy as np

# load data
Load(
    Filename="test_index_satellite_peaks.integrate",
    OutputWorkspace="test",
    )

FindUBUsingIndexedPeaks(PeaksWorkspace="test")

print("testing default input")
IndexPeaks(
    PeaksWorkspace="test", Tolerance=0.12,
)

print("testing zero (default) modVec with maxOrder=1")
IndexPeaks(
    PeaksWorkspace="test", Tolerance=0.12, 
    RoundHKLs=False,
    SaveModulationInfo=True,
    MaxOrder=1,
    # ModVector1='0,0,0.33333',
    # ModVector2='0,0,0',
    # ModVector3='0,0,0',
    )

print("testing one non-zero modVec with maxOrder=1")
IndexPeaks(
    PeaksWorkspace="test", Tolerance=0.12, 
    RoundHKLs=False,
    SaveModulationInfo=True,
    MaxOrder=1,
    ModVector1='0,0,0.33333',
    # ModVector2='0,0,0',
    # ModVector3='0,0,0',
    )

print("testing one non-zero modVec with maxOrder=0")
IndexPeaks(
    PeaksWorkspace="test", Tolerance=0.12, 
    RoundHKLs=False,
    SaveModulationInfo=True,
    # MaxOrder=1,
    ModVector1='0,0,0.33333',
    # ModVector2='0,0,0',
    # ModVector3='0,0,0',
    )
```

<!-- Instructions for testing. -->

Fixes #29429. <!-- and fix #xxxx or close #xxxx xor resolves #xxxx -->
<!-- alternative
*There is no associated issue.*
-->

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or master)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
