### PR TITLE
Extend MaskBTP for ILL's SANS instruments

### DIFF
--- a/Framework/PythonInterface/plugins/algorithms/MaskBTP.py
+++ b/Framework/PythonInterface/plugins/algorithms/MaskBTP.py
@@ -17,13 +17,13 @@ class MaskBTP(mantid.api.PythonAlgorithm):
     """
 
     # list of supported instruments
-    INSTRUMENT_LIST = ['ARCS', 'BIOSANS', 'CG2', 'CG3', 'CHESS', 'CNCS', 'CORELLI', 'EQ-SANS', 'GPSANS', 'HYSPEC', 'MANDI', 'NOMAD',
+    INSTRUMENT_LIST = ['ARCS', 'BIOSANS', 'CG2', 'CG3', 'CHESS', 'CNCS', 'CORELLI', 'EQ-SANS', 'GPSANS', 'HYSPEC', 'D33', 'MANDI', 'NOMAD',
                        'POWGEN', 'REF_M', 'SEQUOIA', 'SNAP', 'SXD', 'TOPAZ', 'WAND', 'WISH']
 
     instname = None
     instrument = None
-    bankmin = defaultdict(lambda: 1, {'SEQUOIA': 23, 'TOPAZ': 10})  # default is one
-    bankmax = {'ARCS': 115, 'BIOSANS': 88, 'CG2': 48, 'CG3': 88, 'CHESS': 163, 'CNCS': 50, 'CORELLI': 91, 'EQ-SANS': 48,
+    bankmin = defaultdict(lambda: 1, {'D33': 0, 'SEQUOIA': 23, 'TOPAZ': 10})  # default is one
+    bankmax = {'ARCS': 115, 'BIOSANS': 88, 'CG2': 48, 'CG3': 88, 'CHESS': 163, 'CNCS': 50, 'CORELLI': 91, 'D33': 4, 'EQ-SANS': 48,
                'GPSANS': 48, 'HYSPEC': 20, 'MANDI': 59, 'NOMAD': 99, 'POWGEN': 300, 'REF_M': 1, 'SEQUOIA': 150, 'SNAP': 64,
                'SXD': 11, 'TOPAZ': 59, 'WAND': 8, 'WISH': 10}
 
@@ -33,7 +33,7 @@ class MaskBTP(mantid.api.PythonAlgorithm):
         return "Transforms\\Masking;Inelastic\\Utility"
 
     def seeAlso(self):
-        return [ "MaskDetectors","MaskInstrument" ]
+        return ["MaskDetectors", "MaskInstrument"]
 
     def name(self):
         """ Mantid required
@@ -46,17 +46,17 @@ class MaskBTP(mantid.api.PythonAlgorithm):
         return "Algorithm to mask detectors in particular banks, tube, or pixels."
 
     def PyInit(self):
-        self.declareProperty(mantid.api.WorkspaceProperty("Workspace", "",direction=Direction.InOut,
-                                                          optional = mantid.api.PropertyMode.Optional), "Input workspace (optional)")
-        allowedInstrumentList=StringListValidator(['']+self.INSTRUMENT_LIST)
-        self.declareProperty("Instrument","",validator=allowedInstrumentList,doc="One of the following instruments: "
+        self.declareProperty(mantid.api.WorkspaceProperty("Workspace", "", direction=Direction.InOut,
+                                                          optional=mantid.api.PropertyMode.Optional), "Input workspace (optional)")
+        allowedInstrumentList = StringListValidator(['']+self.INSTRUMENT_LIST)
+        self.declareProperty("Instrument", "", validator=allowedInstrumentList, doc="One of the following instruments: "
                              + ', '.join(self.INSTRUMENT_LIST))
         self.declareProperty(StringArrayProperty(name='Components', values=[]),
                              doc='Component names to mask')
         self.declareProperty(IntArrayProperty(name="Bank", values=[]),
                              doc="Bank(s) to be masked. If empty, will apply to all banks")
-        self.declareProperty("Tube","",doc="Tube(s) to be masked. If empty, will apply to all tubes")
-        self.declareProperty("Pixel","",doc="Pixel(s) to be masked. If empty, will apply to all pixels")
+        self.declareProperty("Tube", "", doc="Tube(s) to be masked. If empty, will apply to all tubes")
+        self.declareProperty("Pixel", "", doc="Pixel(s) to be masked. If empty, will apply to all pixels")
         self.declareProperty(IntArrayProperty(name="MaskedDetectors", direction=Direction.Output),
                              doc="List of  masked detectors")
 
@@ -121,7 +121,7 @@ class MaskBTP(mantid.api.PythonAlgorithm):
         bankIndices = self._getBankIndices(compInfo, components)
 
         # generate the list of detector identifiers to mask
-        detlist=[]
+        detlist = []
         fullDetectorIdList = ws.detectorInfo().detectorIDs()
 
         if len(tubes) > 0 or len(pixels) > 0:
@@ -147,7 +147,7 @@ class MaskBTP(mantid.api.PythonAlgorithm):
             self.log().information("no detectors within this range")
 
         # set the outputs
-        self.setProperty("Workspace",ws.name())
+        self.setProperty("Workspace", ws.name())
         self.setProperty("MaskedDetectors", detlist)
 
     def _startsFrom(self):
@@ -191,22 +191,22 @@ class MaskBTP(mantid.api.PythonAlgorithm):
             return result - min_value
 
     def _getBankName(self, banknum, validFrom):  # noqa: C901
-        banknum=int(banknum)
+        banknum = int(banknum)
         if not (self.bankmin[self.instname] <= banknum <= self.bankmax[self.instname]):
             raise ValueError("Out of range index={} for {} instrument bank numbers".format(banknum, self.instname))
 
         if self.instname == 'ARCS':
-            ARCS_bank_names=['B{}'.format(b) for b in range(1,39)] + \
-                            ['M{}'.format(b) for b in range(1,32)] + \
-                            ['M32A','M32B'] + \
-                            ['M{}'.format(b) for b in range(33,39)] + \
-                            ['T{}'.format(b) for b in range(1,39)]
+            ARCS_bank_names = ['B{}'.format(b) for b in range(1, 39)] + \
+                              ['M{}'.format(b) for b in range(1, 32)] + \
+                              ['M32A', 'M32B'] + \
+                              ['M{}'.format(b) for b in range(33, 39)] + \
+                              ['T{}'.format(b) for b in range(1, 39)]
             if self.bankmin[self.instname] <= banknum <= self.bankmax[self.instname]:
                 return ARCS_bank_names[banknum-1]
             else:
                 raise ValueError("Out of range index for ARCS instrument bank numbers: {}".format(banknum))
         elif self.instname == 'SEQUOIA':
-            ToB = '' # top/bottom for short packs
+            ToB = ''  # top/bottom for short packs
             # there are only banks 23-26 in A row
             if self.bankmin[self.instname] <= banknum <= 37:
                 label = 'A'
@@ -229,7 +229,7 @@ class MaskBTP(mantid.api.PythonAlgorithm):
             elif 102 < banknum <= 113:
                 label = 'C'
                 banknum = banknum-76
-            elif 113 <banknum <= self.bankmax[self.instname]:
+            elif 113 < banknum <= self.bankmax[self.instname]:
                 label = 'D'
                 banknum = banknum-113
             else:
@@ -258,11 +258,15 @@ class MaskBTP(mantid.api.PythonAlgorithm):
                     return 'detector1'
                 elif banknum == 2:
                     return 'wing_detector'
+        elif self.instname == "D33":
+            banks = ["back_detector", "front_detector_left", "front_detector_right", "front_detector_bottom",
+                     "front_detector_top"]
+            return banks[banknum]
         else:
             return "bank" + str(banknum)
 
     def _getBankIndices(self, compInfo, bankNames):
-        '''This removes banks that don't exist'''
+        """This removes banks that don't exist"""
         if len(bankNames) == 0:
             return list()
 

--- a/Framework/PythonInterface/plugins/algorithms/MaskBTP.py
+++ b/Framework/PythonInterface/plugins/algorithms/MaskBTP.py
@@ -260,8 +260,8 @@ class MaskBTP(mantid.api.PythonAlgorithm):
                 elif banknum == 2:
                     return 'wing_detector'
         elif self.instname == "D33":
-            banks = ["back_detector", "front_detector_left", "front_detector_right", "front_detector_bottom",
-                     "front_detector_top"]
+            banks = ["back_detector", "front_detector_top", "front_detector_right", "front_detector_bottom",
+                     "front_detector_left"]
             return banks[banknum]
         elif self.instname in ["D11", "D11lr", "D22", "D22lr", "D16"]:
             return "detector"

--- a/Framework/PythonInterface/plugins/algorithms/MaskBTP.py
+++ b/Framework/PythonInterface/plugins/algorithms/MaskBTP.py
@@ -17,14 +17,15 @@ class MaskBTP(mantid.api.PythonAlgorithm):
     """
 
     # list of supported instruments
-    INSTRUMENT_LIST = ['ARCS', 'BIOSANS', 'CG2', 'CG3', 'CHESS', 'CNCS', 'CORELLI', 'D11', 'D16', 'D22', 'D33', 'EQ-SANS', 'GPSANS', 'HYSPEC', 'MANDI', 'NOMAD',
+    INSTRUMENT_LIST = ['ARCS', 'BIOSANS', 'CG2', 'CG3', 'CHESS', 'CNCS', 'CORELLI', 'D11', 'D11lr', 'D16', 'D22',
+                       'D22lr', 'D33', 'EQ-SANS', 'GPSANS', 'HYSPEC', 'MANDI', 'NOMAD',
                        'POWGEN', 'REF_M', 'SEQUOIA', 'SNAP', 'SXD', 'TOPAZ', 'WAND', 'WISH']
 
     instname = None
     instrument = None
     bankmin = defaultdict(lambda: 1, {'D33': 0, 'SEQUOIA': 23, 'TOPAZ': 10})  # default is one
-    bankmax = {'ARCS': 115, 'BIOSANS': 88, 'CG2': 48, 'CG3': 88, 'CHESS': 163, 'CNCS': 50, 'CORELLI': 91, 'D11': 1,
-               'D16': 1, 'D22': 1, 'D33': 4, 'EQ-SANS': 48, 'GPSANS': 48, 'HYSPEC': 20, 'MANDI': 59, 'NOMAD': 99,
+    bankmax = {'ARCS': 115, 'BIOSANS': 88, 'CG2': 48, 'CG3': 88, 'CHESS': 163, 'CNCS': 50, 'CORELLI': 91, 'D11': 1, 'D11lr': 1,
+               'D16': 1, 'D22': 1, 'D22lr': 1, 'D33': 4, 'EQ-SANS': 48, 'GPSANS': 48, 'HYSPEC': 20, 'MANDI': 59, 'NOMAD': 99,
                'POWGEN': 300, 'REF_M': 1, 'SEQUOIA': 150, 'SNAP': 64, 'SXD': 11, 'TOPAZ': 59, 'WAND': 8, 'WISH': 10}
 
     def category(self):
@@ -262,7 +263,7 @@ class MaskBTP(mantid.api.PythonAlgorithm):
             banks = ["back_detector", "front_detector_left", "front_detector_right", "front_detector_bottom",
                      "front_detector_top"]
             return banks[banknum]
-        elif self.instname in ["D11", "D22", "D16"]:
+        elif self.instname in ["D11", "D11lr", "D22", "D22lr", "D16"]:
             return "detector"
         else:
             return "bank" + str(banknum)
@@ -274,7 +275,6 @@ class MaskBTP(mantid.api.PythonAlgorithm):
 
         bankIndices = []
         known_banks = {}  # name: index
-        print(bankNames)
         for bank in bankNames:
             if bank in known_banks:  # use the known index
                 bankIndices.append(known_banks[bank])

--- a/Framework/PythonInterface/plugins/algorithms/MaskBTP.py
+++ b/Framework/PythonInterface/plugins/algorithms/MaskBTP.py
@@ -17,13 +17,13 @@ class MaskBTP(mantid.api.PythonAlgorithm):
     """
 
     # list of supported instruments
-    INSTRUMENT_LIST = ['ARCS', 'BIOSANS', 'CG2', 'CG3', 'CHESS', 'CNCS', 'CORELLI', 'D22', 'D33', 'EQ-SANS', 'GPSANS', 'HYSPEC', 'MANDI', 'NOMAD',
+    INSTRUMENT_LIST = ['ARCS', 'BIOSANS', 'CG2', 'CG3', 'CHESS', 'CNCS', 'CORELLI', 'D16', 'D22', 'D33', 'EQ-SANS', 'GPSANS', 'HYSPEC', 'MANDI', 'NOMAD',
                        'POWGEN', 'REF_M', 'SEQUOIA', 'SNAP', 'SXD', 'TOPAZ', 'WAND', 'WISH']
 
     instname = None
     instrument = None
     bankmin = defaultdict(lambda: 1, {'D33': 0, 'SEQUOIA': 23, 'TOPAZ': 10})  # default is one
-    bankmax = {'ARCS': 115, 'BIOSANS': 88, 'CG2': 48, 'CG3': 88, 'CHESS': 163, 'CNCS': 50, 'CORELLI': 91, 'D22': 1,
+    bankmax = {'ARCS': 115, 'BIOSANS': 88, 'CG2': 48, 'CG3': 88, 'CHESS': 163, 'CNCS': 50, 'CORELLI': 91, 'D16': 1, 'D22': 1,
                'D33': 4, 'EQ-SANS': 48, 'GPSANS': 48, 'HYSPEC': 20, 'MANDI': 59, 'NOMAD': 99, 'POWGEN': 300, 'REF_M': 1,
                'SEQUOIA': 150, 'SNAP': 64, 'SXD': 11, 'TOPAZ': 59, 'WAND': 8, 'WISH': 10}
 
@@ -262,7 +262,7 @@ class MaskBTP(mantid.api.PythonAlgorithm):
             banks = ["back_detector", "front_detector_left", "front_detector_right", "front_detector_bottom",
                      "front_detector_top"]
             return banks[banknum]
-        elif self.instname == "D22":
+        elif self.instname in ["D22", "D16"]:
             return "detector"
         else:
             return "bank" + str(banknum)

--- a/Framework/PythonInterface/plugins/algorithms/MaskBTP.py
+++ b/Framework/PythonInterface/plugins/algorithms/MaskBTP.py
@@ -17,15 +17,15 @@ class MaskBTP(mantid.api.PythonAlgorithm):
     """
 
     # list of supported instruments
-    INSTRUMENT_LIST = ['ARCS', 'BIOSANS', 'CG2', 'CG3', 'CHESS', 'CNCS', 'CORELLI', 'EQ-SANS', 'GPSANS', 'HYSPEC', 'D33', 'MANDI', 'NOMAD',
+    INSTRUMENT_LIST = ['ARCS', 'BIOSANS', 'CG2', 'CG3', 'CHESS', 'CNCS', 'CORELLI', 'D22', 'D33', 'EQ-SANS', 'GPSANS', 'HYSPEC', 'MANDI', 'NOMAD',
                        'POWGEN', 'REF_M', 'SEQUOIA', 'SNAP', 'SXD', 'TOPAZ', 'WAND', 'WISH']
 
     instname = None
     instrument = None
     bankmin = defaultdict(lambda: 1, {'D33': 0, 'SEQUOIA': 23, 'TOPAZ': 10})  # default is one
-    bankmax = {'ARCS': 115, 'BIOSANS': 88, 'CG2': 48, 'CG3': 88, 'CHESS': 163, 'CNCS': 50, 'CORELLI': 91, 'D33': 4, 'EQ-SANS': 48,
-               'GPSANS': 48, 'HYSPEC': 20, 'MANDI': 59, 'NOMAD': 99, 'POWGEN': 300, 'REF_M': 1, 'SEQUOIA': 150, 'SNAP': 64,
-               'SXD': 11, 'TOPAZ': 59, 'WAND': 8, 'WISH': 10}
+    bankmax = {'ARCS': 115, 'BIOSANS': 88, 'CG2': 48, 'CG3': 88, 'CHESS': 163, 'CNCS': 50, 'CORELLI': 91, 'D22': 1,
+               'D33': 4, 'EQ-SANS': 48, 'GPSANS': 48, 'HYSPEC': 20, 'MANDI': 59, 'NOMAD': 99, 'POWGEN': 300, 'REF_M': 1,
+               'SEQUOIA': 150, 'SNAP': 64, 'SXD': 11, 'TOPAZ': 59, 'WAND': 8, 'WISH': 10}
 
     def category(self):
         """ Mantid required
@@ -262,6 +262,8 @@ class MaskBTP(mantid.api.PythonAlgorithm):
             banks = ["back_detector", "front_detector_left", "front_detector_right", "front_detector_bottom",
                      "front_detector_top"]
             return banks[banknum]
+        elif self.instname == "D22":
+            return "detector"
         else:
             return "bank" + str(banknum)
 
@@ -272,6 +274,7 @@ class MaskBTP(mantid.api.PythonAlgorithm):
 
         bankIndices = []
         known_banks = {}  # name: index
+        print(bankNames)
         for bank in bankNames:
             if bank in known_banks:  # use the known index
                 bankIndices.append(known_banks[bank])

--- a/Framework/PythonInterface/plugins/algorithms/MaskBTP.py
+++ b/Framework/PythonInterface/plugins/algorithms/MaskBTP.py
@@ -17,15 +17,15 @@ class MaskBTP(mantid.api.PythonAlgorithm):
     """
 
     # list of supported instruments
-    INSTRUMENT_LIST = ['ARCS', 'BIOSANS', 'CG2', 'CG3', 'CHESS', 'CNCS', 'CORELLI', 'D16', 'D22', 'D33', 'EQ-SANS', 'GPSANS', 'HYSPEC', 'MANDI', 'NOMAD',
+    INSTRUMENT_LIST = ['ARCS', 'BIOSANS', 'CG2', 'CG3', 'CHESS', 'CNCS', 'CORELLI', 'D11', 'D16', 'D22', 'D33', 'EQ-SANS', 'GPSANS', 'HYSPEC', 'MANDI', 'NOMAD',
                        'POWGEN', 'REF_M', 'SEQUOIA', 'SNAP', 'SXD', 'TOPAZ', 'WAND', 'WISH']
 
     instname = None
     instrument = None
     bankmin = defaultdict(lambda: 1, {'D33': 0, 'SEQUOIA': 23, 'TOPAZ': 10})  # default is one
-    bankmax = {'ARCS': 115, 'BIOSANS': 88, 'CG2': 48, 'CG3': 88, 'CHESS': 163, 'CNCS': 50, 'CORELLI': 91, 'D16': 1, 'D22': 1,
-               'D33': 4, 'EQ-SANS': 48, 'GPSANS': 48, 'HYSPEC': 20, 'MANDI': 59, 'NOMAD': 99, 'POWGEN': 300, 'REF_M': 1,
-               'SEQUOIA': 150, 'SNAP': 64, 'SXD': 11, 'TOPAZ': 59, 'WAND': 8, 'WISH': 10}
+    bankmax = {'ARCS': 115, 'BIOSANS': 88, 'CG2': 48, 'CG3': 88, 'CHESS': 163, 'CNCS': 50, 'CORELLI': 91, 'D11': 1,
+               'D16': 1, 'D22': 1, 'D33': 4, 'EQ-SANS': 48, 'GPSANS': 48, 'HYSPEC': 20, 'MANDI': 59, 'NOMAD': 99,
+               'POWGEN': 300, 'REF_M': 1, 'SEQUOIA': 150, 'SNAP': 64, 'SXD': 11, 'TOPAZ': 59, 'WAND': 8, 'WISH': 10}
 
     def category(self):
         """ Mantid required
@@ -262,7 +262,7 @@ class MaskBTP(mantid.api.PythonAlgorithm):
             banks = ["back_detector", "front_detector_left", "front_detector_right", "front_detector_bottom",
                      "front_detector_top"]
             return banks[banknum]
-        elif self.instname in ["D22", "D16"]:
+        elif self.instname in ["D11", "D22", "D16"]:
             return "detector"
         else:
             return "bank" + str(banknum)

--- a/Framework/PythonInterface/test/python/plugins/algorithms/MaskBTPTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/MaskBTPTest.py
@@ -217,7 +217,7 @@ class MaskBTPTest(unittest.TestCase):
         self.assertEqual(10 * 90, len(masked))
 
     def test_d33(self):
-        ws = LoadEmptyInstrument(InstrumentName='D33', OutputWorkspace="D33")
+        ws = LoadEmptyInstrument(InstrumentName='D33')
         mask_rear = MaskBTP(Workspace=ws, Components='back_detector')
         mask_front = MaskBTP(Workspace=ws, Bank="1-4", Tube="15", Pixel='0-10')
 
@@ -229,7 +229,7 @@ class MaskBTPTest(unittest.TestCase):
         CHECK_CONSISTENCY = False
 
     def test_d11(self):
-        ws = LoadEmptyInstrument(InstrumentName="d11", OutputWorkspace="D11")
+        ws = LoadEmptyInstrument(InstrumentName="d11")
         mask = MaskBTP(Workspace=ws, Pixel="0-10")
 
         self.assertEquals(len(mask), 256*11)
@@ -240,7 +240,7 @@ class MaskBTPTest(unittest.TestCase):
         CHECK_CONSISTENCY = False
 
     def test_d22(self):
-        ws = LoadEmptyInstrument(InstrumentName="d22", OutputWorkspace="D22")
+        ws = LoadEmptyInstrument(InstrumentName="d22")
         mask = MaskBTP(Workspace=ws, Tube="2-5")
 
         self.assertEquals(len(mask), 256*4)
@@ -250,10 +250,34 @@ class MaskBTPTest(unittest.TestCase):
         CHECK_CONSISTENCY = False
 
     def test_d16(self):
-        ws = LoadEmptyInstrument(InstrumentName="d16", OutputWorkspace="D16")
+        ws = LoadEmptyInstrument(InstrumentName="d16")
         mask = MaskBTP(Workspace=ws, Tube="319", Pixel="319")
 
         self.assertEquals(len(mask), 1)
+        global CHECK_CONSISTENCY
+        CHECK_CONSISTENCY = True
+        self.checkConsistentMask(ws, mask)
+        CHECK_CONSISTENCY = False
+
+    def test_d11_lr(self):
+        path = config["instrumentDefinition.directory"] + "D11lr_Definition.xml"
+
+        ws = LoadEmptyInstrument(Filename=path)
+        mask = MaskBTP(Workspace=ws, Tube="127")
+
+        self.assertEquals(len(mask), 128)
+        global CHECK_CONSISTENCY
+        CHECK_CONSISTENCY = True
+        self.checkConsistentMask(ws, mask)
+        CHECK_CONSISTENCY = False
+
+    def test_d22lr(self):
+        path = config["instrumentDefinition.directory"] + "D22lr_Definition.xml"
+
+        ws = LoadEmptyInstrument(Filename=path)
+        mask = MaskBTP(Workspace=ws, Pixel="20-28")
+
+        self.assertEquals(len(mask), 9*128)
         global CHECK_CONSISTENCY
         CHECK_CONSISTENCY = True
         self.checkConsistentMask(ws, mask)

--- a/Framework/PythonInterface/test/python/plugins/algorithms/MaskBTPTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/MaskBTPTest.py
@@ -216,6 +216,33 @@ class MaskBTPTest(unittest.TestCase):
         masked = MaskBTP(Workspace=wksp, Components='bank3')
         self.assertEqual(10 * 90, len(masked))
 
+    def test_d33(self):
+        ws = LoadEmptyInstrument(InstrumentName='D33', OutputWorkspace="D33")
+        mask_rear = MaskBTP(Workspace=ws, Components='back_detector')
+        mask_front = MaskBTP(Workspace=ws, Bank="1-4", Tube="15", Pixel='0-10')
+
+        self.assertEqual(len(mask_rear), 256 * 128)
+        self.assertEqual(len(mask_front), 4 * 11)
+
+    def test_d11(self):
+        ws = LoadEmptyInstrument(InstrumentName="d11", OutputWorkspace="D11")
+        mask = MaskBTP(Workspace=ws, Pixel="0-10")
+
+        self.assertEquals(len(mask), 256*11)
+
+    def test_d22(self):
+        ws = LoadEmptyInstrument(InstrumentName="d22", OutputWorkspace="D22")
+        mask = MaskBTP(Workspace=ws, Tube="2-5")
+
+        self.assertEquals(len(mask), 256*4)
+
+    def test_d16(self):
+        ws = LoadEmptyInstrument(InstrumentName="d16", OutputWorkspace="D16")
+        mask = MaskBTP(Workspace=ws, Tube="319", Pixel="319")
+
+        self.assertEquals(len(mask), 1)
+
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/Framework/PythonInterface/test/python/plugins/algorithms/MaskBTPTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/MaskBTPTest.py
@@ -223,41 +223,28 @@ class MaskBTPTest(unittest.TestCase):
 
         self.assertEqual(len(mask_rear), 256 * 128)
         self.assertEqual(len(mask_front), 4 * 11)
-        global CHECK_CONSISTENCY
-        CHECK_CONSISTENCY = True
         self.checkConsistentMask(ws, concatenate((mask_rear, mask_front)))
-        CHECK_CONSISTENCY = False
 
     def test_d11(self):
         ws = LoadEmptyInstrument(InstrumentName="d11")
         mask = MaskBTP(Workspace=ws, Pixel="0-10")
 
         self.assertEquals(len(mask), 256*11)
-
-        global CHECK_CONSISTENCY
-        CHECK_CONSISTENCY = True
         self.checkConsistentMask(ws, mask)
-        CHECK_CONSISTENCY = False
 
     def test_d22(self):
         ws = LoadEmptyInstrument(InstrumentName="d22")
         mask = MaskBTP(Workspace=ws, Tube="2-5")
 
         self.assertEquals(len(mask), 256*4)
-        global CHECK_CONSISTENCY
-        CHECK_CONSISTENCY = True
         self.checkConsistentMask(ws, mask)
-        CHECK_CONSISTENCY = False
 
     def test_d16(self):
         ws = LoadEmptyInstrument(InstrumentName="d16")
         mask = MaskBTP(Workspace=ws, Tube="319", Pixel="319")
 
         self.assertEquals(len(mask), 1)
-        global CHECK_CONSISTENCY
-        CHECK_CONSISTENCY = True
         self.checkConsistentMask(ws, mask)
-        CHECK_CONSISTENCY = False
 
     def test_d11_lr(self):
         path = config["instrumentDefinition.directory"] + "D11lr_Definition.xml"
@@ -266,10 +253,7 @@ class MaskBTPTest(unittest.TestCase):
         mask = MaskBTP(Workspace=ws, Tube="127")
 
         self.assertEquals(len(mask), 128)
-        global CHECK_CONSISTENCY
-        CHECK_CONSISTENCY = True
         self.checkConsistentMask(ws, mask)
-        CHECK_CONSISTENCY = False
 
     def test_d22lr(self):
         path = config["instrumentDefinition.directory"] + "D22lr_Definition.xml"
@@ -278,10 +262,7 @@ class MaskBTPTest(unittest.TestCase):
         mask = MaskBTP(Workspace=ws, Pixel="20-28")
 
         self.assertEquals(len(mask), 9*128)
-        global CHECK_CONSISTENCY
-        CHECK_CONSISTENCY = True
         self.checkConsistentMask(ws, mask)
-        CHECK_CONSISTENCY = False
 
 
 if __name__ == '__main__':

--- a/docs/source/algorithms/MaskBTP-v1.rst
+++ b/docs/source/algorithms/MaskBTP-v1.rst
@@ -11,7 +11,7 @@ Description
 -----------
 
 Algorithm to mask detectors in particular banks, tube, or pixels.
-To use the ``Bank`` argument, the instrument must be one of: ARCS, BIOSANS, CG2 CNCS, CORELLI, EQ-SANS HYSPEC, MANDI, NOMAD, POWGEN, SEQUOIA, SNAP, SXD, TOPAZ, WAND, WISH.
+To use the ``Bank`` argument, the instrument must be one of: ARCS, BIOSANS, CG2, CNCS, CORELLI, D33, EQ-SANS, HYSPEC, MANDI, NOMAD, POWGEN, SEQUOIA, SNAP, SXD, TOPAZ, WAND, WISH.
 For instruments with rectangular position sensitive detectors (POWGEN, SNAP, TOPAZ), the tube is corresponding to the x coordinate, and pixel to the y coordinate.
 For example, on SNAP ``Bank="1"``, ``Tube="3"`` corresponds to ``SNAP/East/Column1/bank1/bank1(x=3)``, and ``Bank="1"``, ``Tube="3"``, ``Pixel="5"`` is ``SNAP/East/Column1/bank1/bank1(x=3)/bank1(3,5)``.
 

--- a/docs/source/release/v6.0.0/sans.rst
+++ b/docs/source/release/v6.0.0/sans.rst
@@ -5,6 +5,11 @@ SANS Changes
 .. contents:: Table of Contents
    :local:
 
+Improvements
+############
+
+- Add support for D11, D16, D22 and D33 in the :ref:`MaskBTP <algm-MaskBTP>` algorithm.
+
 .. warning:: **Developers:** Sort changes under appropriate heading
     putting new features at the top of the section, followed by
     improvements, followed by bug fixes.


### PR DESCRIPTION
**Description of work.**

This allows the user to use `MaskBTP` on ILL's D11, D16, D22 and D33 instruments. This algorithm masks the specified banks, tubes and pixels of the instrument selected.

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

**To test:**
- Load these instruments (using `LoadEmptyInstrument` or some real test data) and try masking the workspaces.
- For D33, there are 5 banks, rear, top, right, bottom and left, numbered in this order, starting at 0. The right and left banks have (currently) horizontal tubes, the other banks have vertical tubes.
- The other instruments have single bank, vertically oriented tubes.

<!-- Instructions for testing. -->

WIP for  #26906 .

<!-- Ensure the base of this PR is correct (e.g. release-next or master)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
