### PR TITLE
Change columns order and visibility in DrILL

### DIFF
--- a/docs/source/interfaces/DrILL.rst
+++ b/docs/source/interfaces/DrILL.rst
@@ -92,7 +92,9 @@ Table filling
 
 When selecting the instrument and the acquisition mode, the table is updated
 with the needed column headers. To obtain information about a column, a tooltip
-is displayed when moving the mouse over the corresponding header.
+is displayed when moving the mouse over the corresponding header. To facilitate
+filling, columns can be collapsed (button in the header), hidden (right click or
+menu bar) and their order can be changed by drag-and-drop.
 
 Each cell can be edited manually or filled programmatically by using some of the
 tool buttons.

--- a/docs/source/interfaces/DrILL.rst
+++ b/docs/source/interfaces/DrILL.rst
@@ -38,6 +38,8 @@ spreadsheet like table (1)
     measured at one or more distances (SANS) or angles (Reflectometry). There is no limit
     on the number of the different configurations.
     It is used to provide filenames and options to the reduction algorithm.
+    The state of the table is reset when the instrument and/or the acquisition
+    mode is changed.
 
 tool buttons (2)
     In two different places. At the top of the table, these buttons facilitate
@@ -149,7 +151,9 @@ the interface in JSON format. By using the appropriate tool button or the menu
 bar (*File* -> *Save...* or *Load...*) one can export or import a Rundex file.
 
 When saving, the global settings, all the samples and some of the visual setup
-are exported in the rundex file. Symmetrically, the load action imports all
-these data in the current DrILL session.
+are exported in the rundex file (i.e. the collapsed columns, the hidden
+columns...). Symmetrically, the load action imports all these data in the
+current DrILL session and one will recover the interface in the same state as
+it was previously saved.
 
 .. categories:: Interfaces

--- a/scripts/Interface/ui/drill/model/DrillModel.py
+++ b/scripts/Interface/ui/drill/model/DrillModel.py
@@ -137,6 +137,7 @@ class DrillModel(QObject):
         self.rundexFile = None
         self.samples = list()
         self.settings = dict()
+        self.visualSettings = None
 
         if (instrument in RundexSettings.ACQUISITION_MODES):
             config['default.instrument'] = instrument
@@ -191,6 +192,7 @@ class DrillModel(QObject):
             return
         self.rundexFile = None
         self.samples = list()
+        self.visualSettings = None
         self.acquisitionMode = mode
         self.columns = RundexSettings.COLUMNS[self.acquisitionMode]
         self.algorithm = RundexSettings.ALGORITHM[self.acquisitionMode]

--- a/scripts/Interface/ui/drill/test/DrillTableWidgetTest.py
+++ b/scripts/Interface/ui/drill/test/DrillTableWidgetTest.py
@@ -6,6 +6,7 @@
 # SPDX - License - Identifier: GPL - 3.0 +
 
 import unittest
+from unittest import mock
 import sys
 
 from qtpy.QtWidgets import QApplication, QTableWidgetItem
@@ -172,6 +173,22 @@ class DrillTableWidgetTest(unittest.TestCase):
         self.assertEqual(self.table.item(0, 1).text(), "test2")
         self.table.setRowContents(0, ["test", "test2", "test3"])
 
+    def test_setFoldedColumns(self):
+        self.table.horizontalHeader = mock.Mock()
+        mHeader = self.table.horizontalHeader.return_value
+        self.table.columns = ["test1", "test2", "test3"]
+        self.table.setFoldedColumns(["test"])
+        mHeader.foldSection.assert_not_called()
+        self.table.setFoldedColumns(["test2"])
+        mHeader.foldSection.assert_called_with(1)
+
+    def test_getFoldedColumns(self):
+        self.table.horizontalHeader = mock.Mock()
+        mHeader = self.table.horizontalHeader.return_value
+        mHeader.isSectionFolded.return_value = True
+        self.table.columns = ["test1", "test2", "test3"]
+        folded = self.table.getFoldedColumns()
+        self.assertEqual(folded, ["test1", "test2", "test3"])
 
 if __name__ == "__main__":
     unittest.main()

--- a/scripts/Interface/ui/drill/test/DrillTableWidgetTest.py
+++ b/scripts/Interface/ui/drill/test/DrillTableWidgetTest.py
@@ -190,5 +190,23 @@ class DrillTableWidgetTest(unittest.TestCase):
         folded = self.table.getFoldedColumns()
         self.assertEqual(folded, ["test1", "test2", "test3"])
 
+    def test_setHiddenColumns(self):
+        self.table.horizontalHeader = mock.Mock()
+        mHeader = self.table.horizontalHeader.return_value
+        self.table.columns = ["test1", "test2", "test3"]
+        self.table.setHiddenColumns(["test"])
+        mHeader.hideSection.assert_not_called()
+        self.table.setHiddenColumns(["test1"])
+        mHeader.hideSection.assert_called_with(0)
+
+    def test_getHiddenColumns(self):
+        self.table.horizontalHeader = mock.Mock()
+        mHeader = self.table.horizontalHeader.return_value
+        mHeader.isSectionHidden.return_value = True
+        self.table.columns = ["test1", "test2"]
+        hidden = self.table.getHiddenColumns()
+        self.assertEqual(hidden, ["test1", "test2"])
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/scripts/Interface/ui/drill/test/DrillTableWidgetTest.py
+++ b/scripts/Interface/ui/drill/test/DrillTableWidgetTest.py
@@ -207,6 +207,23 @@ class DrillTableWidgetTest(unittest.TestCase):
         hidden = self.table.getHiddenColumns()
         self.assertEqual(hidden, ["test1", "test2"])
 
+    def test_setColumnsOrder(self):
+        self.table.columns = ["test1", "test2", "test3"]
+        self.table.horizontalHeader = mock.Mock()
+        mHeader = self.table.horizontalHeader.return_value
+        mHeader.visualIndex.side_effect = [3, 1, 0]
+        self.table.setColumnsOrder(["test3", "test2", "test1"])
+        calls = [mock.call(3, 0), mock.call(1, 1), mock.call(0, 2)]
+        mHeader.moveSection.assert_has_calls(calls)
+
+    def test_getColumnsOrder(self):
+        self.table.columns = ["test1", "test2", "test3"]
+        self.table.horizontalHeader = mock.Mock()
+        mHeader = self.table.horizontalHeader.return_value
+        mHeader.visualIndex.side_effect = [2, 1, 0]
+        self.assertEqual(self.table.getColumnsOrder(),
+                         ["test3", "test2", "test1"])
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/scripts/Interface/ui/drill/test/DrillTest.py
+++ b/scripts/Interface/ui/drill/test/DrillTest.py
@@ -270,7 +270,7 @@ class DrillTest(unittest.TestCase):
                 'Instrument': 'D11',
                 'AcquisitionMode': 'SANS',
                 'VisualSettings': {
-                    'FoldedColumns': {}
+                    'FoldedColumns': []
                     },
                 'GlobalSettings': RundexSettings.SETTINGS['SANS'],
                 'Samples': []

--- a/scripts/Interface/ui/drill/test/DrillTest.py
+++ b/scripts/Interface/ui/drill/test/DrillTest.py
@@ -270,7 +270,8 @@ class DrillTest(unittest.TestCase):
                 'Instrument': 'D11',
                 'AcquisitionMode': 'SANS',
                 'VisualSettings': {
-                    'FoldedColumns': []
+                    'FoldedColumns': [],
+                    'HiddenColumns': []
                     },
                 'GlobalSettings': RundexSettings.SETTINGS['SANS'],
                 'Samples': []

--- a/scripts/Interface/ui/drill/test/DrillTest.py
+++ b/scripts/Interface/ui/drill/test/DrillTest.py
@@ -271,7 +271,8 @@ class DrillTest(unittest.TestCase):
                 'AcquisitionMode': 'SANS',
                 'VisualSettings': {
                     'FoldedColumns': [],
-                    'HiddenColumns': []
+                    'HiddenColumns': [],
+                    'ColumnsOrder': RundexSettings.COLUMNS['SANS']
                     },
                 'GlobalSettings': RundexSettings.SETTINGS['SANS'],
                 'Samples': []

--- a/scripts/Interface/ui/drill/test/DrillViewTest.py
+++ b/scripts/Interface/ui/drill/test/DrillViewTest.py
@@ -442,7 +442,9 @@ class DrillViewTest(unittest.TestCase):
     def test_getVisualSettings(self):
         self.view.columns = ["test1", "test2", "test3"]
         self.view.table.getFoldedColumns.return_value = ["test1", "test3"]
-        d = {"FoldedColumns": ["test1", "test3"]}
+        self.view.table.getHiddenColumns.return_value = ["test1", "test2"]
+        d = {"FoldedColumns": ["test1", "test3"],
+             "HiddenColumns": ["test1", "test2"]}
         self.assertDictEqual(self.view.getVisualSettings(), d)
 
 

--- a/scripts/Interface/ui/drill/test/DrillViewTest.py
+++ b/scripts/Interface/ui/drill/test/DrillViewTest.py
@@ -366,7 +366,7 @@ class DrillViewTest(unittest.TestCase):
 
     def test_setTable(self):
         self.view.set_table(["test", "test"])
-        self.view.table.setColumnCount.assert_called_once_with(2)
+        self.view.table.setColumnCount.assert_called_with(2)
 
     def test_fillTable(self):
         # empty contents

--- a/scripts/Interface/ui/drill/test/DrillViewTest.py
+++ b/scripts/Interface/ui/drill/test/DrillViewTest.py
@@ -434,12 +434,15 @@ class DrillViewTest(unittest.TestCase):
         self.view.table.setFoldedColumns.assert_called_once_with(["test"])
         self.view.table.reset_mock()
         self.view.setVisualSettings({"FoldedColumns": {"test1": True}})
-        self.view.table.setFoldedColumns.assert_called_once_with([])
+        self.view.table.setFoldedColumns.assert_called_once_with(["test1"])
+        self.view.table.reset_mock()
+        self.view.setVisualSettings({"FoldedColumns": ["test"]})
+        self.view.table.setFoldedColumns.assert_called_once_with(["test"])
 
     def test_getVisualSettings(self):
         self.view.columns = ["test1", "test2", "test3"]
         self.view.table.getFoldedColumns.return_value = ["test1", "test3"]
-        d = {"FoldedColumns": {"test1": True, "test3": True}}
+        d = {"FoldedColumns": ["test1", "test3"]}
         self.assertDictEqual(self.view.getVisualSettings(), d)
 
 

--- a/scripts/Interface/ui/drill/test/DrillViewTest.py
+++ b/scripts/Interface/ui/drill/test/DrillViewTest.py
@@ -443,8 +443,12 @@ class DrillViewTest(unittest.TestCase):
         self.view.columns = ["test1", "test2", "test3"]
         self.view.table.getFoldedColumns.return_value = ["test1", "test3"]
         self.view.table.getHiddenColumns.return_value = ["test1", "test2"]
+        self.view.table.getColumnsOrder.return_value  = ["test1",
+                                                         "test2",
+                                                         "test3"]
         d = {"FoldedColumns": ["test1", "test3"],
-             "HiddenColumns": ["test1", "test2"]}
+             "HiddenColumns": ["test1", "test2"],
+             "ColumnsOrder": ["test1", "test2", "test3"]}
         self.assertDictEqual(self.view.getVisualSettings(), d)
 
 

--- a/scripts/Interface/ui/drill/test/DrillViewTest.py
+++ b/scripts/Interface/ui/drill/test/DrillViewTest.py
@@ -426,19 +426,19 @@ class DrillViewTest(unittest.TestCase):
     def test_setVisualSettings(self):
         self.view.columns = ["test"]
         self.view.setVisualSettings(dict())
-        self.view.table.setHeaderFoldingState.assert_not_called()
+        self.view.table.setFoldedColumns.assert_not_called()
         self.view.setVisualSettings({"FoldedColumns": {}})
-        self.view.table.setHeaderFoldingState.assert_called_once_with([False])
+        self.view.table.setFoldedColumns.assert_called_once_with([])
         self.view.table.reset_mock()
         self.view.setVisualSettings({"FoldedColumns": {"test": True}})
-        self.view.table.setHeaderFoldingState.assert_called_once_with([True])
+        self.view.table.setFoldedColumns.assert_called_once_with(["test"])
         self.view.table.reset_mock()
         self.view.setVisualSettings({"FoldedColumns": {"test1": True}})
-        self.view.table.setHeaderFoldingState.assert_called_once_with([False])
+        self.view.table.setFoldedColumns.assert_called_once_with([])
 
     def test_getVisualSettings(self):
         self.view.columns = ["test1", "test2", "test3"]
-        self.view.table.getHeaderFoldingState.return_value = [True, False, True]
+        self.view.table.getFoldedColumns.return_value = ["test1", "test3"]
         d = {"FoldedColumns": {"test1": True, "test3": True}}
         self.assertDictEqual(self.view.getVisualSettings(), d)
 

--- a/scripts/Interface/ui/drill/view/DrillHeaderView.py
+++ b/scripts/Interface/ui/drill/view/DrillHeaderView.py
@@ -5,7 +5,7 @@
 #     & Institut Laue - Langevin
 # SPDX - License - Identifier: GPL - 3.0 +
 
-from qtpy.QtWidgets import QHeaderView, QStyle, QStyleOptionToolButton
+from qtpy.QtWidgets import QHeaderView, QStyle, QStyleOptionToolButton, QAbstractItemView
 from qtpy.QtCore import *
 
 
@@ -36,6 +36,11 @@ class DrillHeaderView(QHeaderView):
                                                 None, self)
         minHeaderSize = self.BUTTON_SIZE + 2 * headerMargin + 1
         self.setMinimumSectionSize(max(minCellSize, minHeaderSize))
+
+        # drag and drop activation
+        self.setSectionsMovable(True)
+        self.setDragEnabled(True)
+        self.setDragDropMode(QAbstractItemView.InternalMove)
 
     def sizeHint(self):
         """

--- a/scripts/Interface/ui/drill/view/DrillTableWidget.py
+++ b/scripts/Interface/ui/drill/view/DrillTableWidget.py
@@ -379,6 +379,33 @@ class DrillTableWidget(QTableWidget):
                 folded.append(self.columns[i])
         return folded
 
+    def setHiddenColumns(self, columns):
+        """
+        Hide specific columns.
+
+        Args:
+            columns(list(str)): list of column labels
+        """
+        header = self.horizontalHeader()
+        for i in range(len(self.columns)):
+            name = self.columns[i]
+            if name in columns:
+                header.hideSection(i)
+
+    def getHiddenColumns(self):
+        """
+        Get the list of hidden columns.
+
+        Returns:
+            list(str): list of column labels
+        """
+        header = self.horizontalHeader()
+        hidden = list()
+        for i in range(len(self.columns)):
+            if header.isSectionHidden(i):
+                hidden.append(self.columns[i])
+        return hidden
+
     def setDisabled(self, state):
         """
         Override QTableWidget::setDisabled. This methods disables only the table

--- a/scripts/Interface/ui/drill/view/DrillTableWidget.py
+++ b/scripts/Interface/ui/drill/view/DrillTableWidget.py
@@ -406,6 +406,8 @@ class DrillTableWidget(QTableWidget):
         if header.isSectionHidden(i):
             header.showSection(i)
         else:
+            for j in range(self.rowCount()):
+                self.setCellContents(j, i, "")
             header.hideSection(i)
 
     def getHiddenColumns(self):

--- a/scripts/Interface/ui/drill/view/DrillTableWidget.py
+++ b/scripts/Interface/ui/drill/view/DrillTableWidget.py
@@ -352,31 +352,32 @@ class DrillTableWidget(QTableWidget):
             if item and c < len(tooltips):
                 item.setToolTip(tooltips[c])
 
-    def setHeaderFoldingState(self, columns):
+    def setFoldedColumns(self, columns):
         """
-        Give a folding state for each column.
+        Fold specific columns.
 
         Args:
-            columns(list(bool)): column indexes
-        """
-        if (len(columns) != self.columnCount()):
-            return
-        for i in range(len(columns)):
-            if columns[i]:
-                self.horizontalHeader().foldSection(i)
-
-    def getHeaderFoldingState(self):
-        """
-        Get the folding state of each column.
-
-        Returns:
-            list(bool): True if the column is folded
+            columns (list(str)): list of column labels
         """
         header = self.horizontalHeader()
-        fold = list()
-        for i in range(self.columnCount()):
-            fold.append(header.isSectionFolded(i))
-        return fold
+        for i in range(len(self.columns)):
+            name = self.columns[i]
+            if name in columns:
+                header.foldSection(i)
+
+    def getFoldedColumns(self):
+        """
+        Get the list of folded columns.
+
+        Returns:
+            list(str): list of columns labels
+        """
+        header = self.horizontalHeader()
+        folded = list()
+        for i in range(len(self.columns)):
+            if header.isSectionFolded(i):
+                folded.append(self.columns[i])
+        return folded
 
     def setDisabled(self, state):
         """

--- a/scripts/Interface/ui/drill/view/DrillTableWidget.py
+++ b/scripts/Interface/ui/drill/view/DrillTableWidget.py
@@ -6,7 +6,7 @@
 # SPDX - License - Identifier: GPL - 3.0 +
 
 from qtpy.QtWidgets import QTableWidget, QTableWidgetItem, QHeaderView, \
-                           QStyle, QAbstractItemView, QMenu
+                           QStyle, QAbstractItemView, QMenu, QMessageBox
 from qtpy.QtGui import QBrush, QColor
 from qtpy.QtCore import *
 
@@ -394,7 +394,9 @@ class DrillTableWidget(QTableWidget):
 
     def toggleColumnVisibility(self, column):
         """
-        Change the visibility state of a column by giving its name.
+        Change the visibility state of a column by giving its name. If the
+        column is not empty it is emptied before being hidden. In that case, the
+        user is asked for confirmation.
 
         Args:
             column (str): column name
@@ -406,9 +408,20 @@ class DrillTableWidget(QTableWidget):
         if header.isSectionHidden(i):
             header.showSection(i)
         else:
+            empty = True
             for j in range(self.rowCount()):
-                self.setCellContents(j, i, "")
-            header.hideSection(i)
+                if self.getCellContents(j, i):
+                    empty = False
+            if not empty:
+                q = QMessageBox.question(self, "Column is not empty", "Hiding "
+                                         "the column will erase its content. "
+                                         "Do you want to continue?")
+                if q == QMessageBox.Yes:
+                    for j in range(self.rowCount()):
+                        self.setCellContents(j, i, "")
+                    header.hideSection(i)
+            else:
+                header.hideSection(i)
 
     def getHiddenColumns(self):
         """

--- a/scripts/Interface/ui/drill/view/DrillTableWidget.py
+++ b/scripts/Interface/ui/drill/view/DrillTableWidget.py
@@ -392,6 +392,22 @@ class DrillTableWidget(QTableWidget):
             if name in columns:
                 header.hideSection(i)
 
+    def toggleColumnVisibility(self, column):
+        """
+        Change the visibility state of a column by giving its name.
+
+        Args:
+            column (str): column name
+        """
+        if column not in self.columns:
+            return
+        header = self.horizontalHeader()
+        i = self.columns.index(column)
+        if header.isSectionHidden(i):
+            header.showSection(i)
+        else:
+            header.hideSection(i)
+
     def getHiddenColumns(self):
         """
         Get the list of hidden columns.

--- a/scripts/Interface/ui/drill/view/DrillTableWidget.py
+++ b/scripts/Interface/ui/drill/view/DrillTableWidget.py
@@ -406,6 +406,36 @@ class DrillTableWidget(QTableWidget):
                 hidden.append(self.columns[i])
         return hidden
 
+    def setColumnsOrder(self, columns):
+        """
+        Set the columns order by giving a list of labels.
+
+        Args:
+            columns (list(str)): list of labels whose table should follow the
+                                 order
+        """
+        header = self.horizontalHeader()
+        for c in columns:
+            if c not in self.columns:
+                continue
+            indexFrom = header.visualIndex(self.columns.index(c))
+            indexTo = columns.index(c)
+            header.moveSection(indexFrom, indexTo)
+
+    def getColumnsOrder(self):
+        """
+        Get the columns order as a list of labels.
+
+        Returns:
+            list(str): list of columns labels
+        """
+        columns = [""] * len(self.columns)
+        header = self.horizontalHeader()
+        for i in range(len(self.columns)):
+            index = header.visualIndex(i)
+            columns[index] = self.columns[i]
+        return columns
+
     def setDisabled(self, state):
         """
         Override QTableWidget::setDisabled. This methods disables only the table

--- a/scripts/Interface/ui/drill/view/DrillTableWidget.py
+++ b/scripts/Interface/ui/drill/view/DrillTableWidget.py
@@ -499,8 +499,4 @@ class DrillTableWidget(QTableWidget):
 
         selectedItem = rightClickMenu.exec(position)
         if selectedItem:
-            li = self.columns.index(selectedItem.text())
-            if header.isSectionHidden(li):
-                header.setSectionHidden(li, False)
-            else:
-                header.setSectionHidden(li, True)
+            self.toggleColumnVisibility(selectedItem.text())

--- a/scripts/Interface/ui/drill/view/DrillTableWidget.py
+++ b/scripts/Interface/ui/drill/view/DrillTableWidget.py
@@ -6,7 +6,7 @@
 # SPDX - License - Identifier: GPL - 3.0 +
 
 from qtpy.QtWidgets import QTableWidget, QTableWidgetItem, QHeaderView, \
-                           QStyle, QAbstractItemView, QMenu, QAction
+                           QStyle, QAbstractItemView, QMenu
 from qtpy.QtGui import QBrush, QColor
 from qtpy.QtCore import *
 

--- a/scripts/Interface/ui/drill/view/DrillView.py
+++ b/scripts/Interface/ui/drill/view/DrillView.py
@@ -815,6 +815,10 @@ class DrillView(QMainWindow):
                             if visualSettings["FoldedColumns"][c]]
                         )
 
+        # hidden columns
+        if ("HiddenColumns" in visualSettings):
+            self.table.setHiddenColumns(visualSettings["HiddenColumns"])
+
     def getVisualSettings(self):
         """
         Used by the model to get some visualisation data that should be saved
@@ -828,6 +832,9 @@ class DrillView(QMainWindow):
 
         # folded columns
         vs["FoldedColumns"] = self.table.getFoldedColumns()
+
+        # hidden columns
+        vs["HiddenColumns"] = self.table.getHiddenColumns()
 
         return vs
 

--- a/scripts/Interface/ui/drill/view/DrillView.py
+++ b/scripts/Interface/ui/drill/view/DrillView.py
@@ -805,14 +805,15 @@ class DrillView(QMainWindow):
             visualSettings (dict): dictionnary containing some visual
                                    parameters that the view can deal with
         """
-        # folding state
+        # folded columns
         if ("FoldedColumns" in visualSettings):
-            f = list()
-            for c in self.columns:
-                if ((c in visualSettings["FoldedColumns"])
-                        and (visualSettings["FoldedColumns"][c])):
-                    f.append(c)
-            self.table.setFoldedColumns(f)
+            if isinstance(visualSettings["FoldedColumns"], list):
+                self.table.setFoldedColumns(visualSettings["FoldedColumns"])
+            else:
+                self.table.setFoldedColumns(
+                        [c for c in visualSettings["FoldedColumns"]
+                            if visualSettings["FoldedColumns"][c]]
+                        )
 
     def getVisualSettings(self):
         """
@@ -824,12 +825,9 @@ class DrillView(QMainWindow):
             dict: visual settings dictionnay
         """
         vs = dict()
-        # folding state
-        vs["FoldedColumns"] = dict()
-        folded = self.table.getFoldedColumns()
-        for c in self.columns:
-            if c in folded:
-             vs["FoldedColumns"][c] = True
+
+        # folded columns
+        vs["FoldedColumns"] = self.table.getFoldedColumns()
 
         return vs
 

--- a/scripts/Interface/ui/drill/view/DrillView.py
+++ b/scripts/Interface/ui/drill/view/DrillView.py
@@ -648,6 +648,8 @@ class DrillView(QMainWindow):
         self.table.setHorizontalHeaderLabels(columns)
         if tooltips:
             self.table.setColumnHeaderToolTips(tooltips)
+        for i in range(len(columns)):
+            self.table.setColumnHidden(i, False)
         self.table.resizeColumnsToContents()
         self.setWindowModified(False)
 

--- a/scripts/Interface/ui/drill/view/DrillView.py
+++ b/scripts/Interface/ui/drill/view/DrillView.py
@@ -7,7 +7,8 @@
 
 import os
 
-from qtpy.QtWidgets import QMainWindow, QFileDialog, QMessageBox, QDialog
+from qtpy.QtWidgets import QMainWindow, QFileDialog, QMessageBox, QDialog, \
+                           QMenu, QAction
 from qtpy.QtCore import *
 from qtpy import uic
 
@@ -650,8 +651,34 @@ class DrillView(QMainWindow):
             self.table.setColumnHeaderToolTips(tooltips)
         for i in range(len(columns)):
             self.table.setColumnHidden(i, False)
+        self.menuAddRemoveColumn.aboutToShow.connect(
+                lambda : self.setAddRemoveColumnMenu(columns))
         self.table.resizeColumnsToContents()
         self.setWindowModified(False)
+
+    def setAddRemoveColumnMenu(self, columns):
+        """
+        Fill the "add/remove column" menu. This function is triggered each time
+        the menu is displayed to display a correct icon depending on the status
+        of the column (hidden or not).
+
+        Args:
+            columns (list(str)): list of column titles
+        """
+        if self.menuAddRemoveColumn.receivers(QMenu.triggered):
+            self.menuAddRemoveColumn.triggered.disconnect()
+        self.menuAddRemoveColumn.clear()
+        hidden = self.table.getHiddenColumns()
+        for c in columns:
+            action = QAction(c, self.menuAddRemoveColumn)
+            if c in hidden:
+                action.setIcon(icons.get_icon("mdi.close"))
+            else:
+                action.setIcon(icons.get_icon("mdi.check"))
+            self.menuAddRemoveColumn.addAction(action)
+
+        self.menuAddRemoveColumn.triggered.connect(
+                lambda action: self.table.toggleColumnVisibility(action.text()))
 
     def fill_table(self, rows_contents):
         """

--- a/scripts/Interface/ui/drill/view/DrillView.py
+++ b/scripts/Interface/ui/drill/view/DrillView.py
@@ -645,6 +645,8 @@ class DrillView(QMainWindow):
         self.invalidCells = set()
         self.coloredRows = set()
         self.table.setRowCount(0)
+        self.table.setColumnCount(0)
+        self.table.horizontalHeader().reset()
         self.table.setColumnCount(len(columns))
         self.table.setHorizontalHeaderLabels(columns)
         if tooltips:

--- a/scripts/Interface/ui/drill/view/DrillView.py
+++ b/scripts/Interface/ui/drill/view/DrillView.py
@@ -819,6 +819,10 @@ class DrillView(QMainWindow):
         if ("HiddenColumns" in visualSettings):
             self.table.setHiddenColumns(visualSettings["HiddenColumns"])
 
+        # columns order
+        if ("ColumnsOrder" in visualSettings):
+            self.table.setColumnsOrder(visualSettings["ColumnsOrder"])
+
     def getVisualSettings(self):
         """
         Used by the model to get some visualisation data that should be saved
@@ -835,6 +839,9 @@ class DrillView(QMainWindow):
 
         # hidden columns
         vs["HiddenColumns"] = self.table.getHiddenColumns()
+
+        # columns order
+        vs["ColumnsOrder"] = self.table.getColumnsOrder()
 
         return vs
 

--- a/scripts/Interface/ui/drill/view/DrillView.py
+++ b/scripts/Interface/ui/drill/view/DrillView.py
@@ -809,11 +809,10 @@ class DrillView(QMainWindow):
         if ("FoldedColumns" in visualSettings):
             f = list()
             for c in self.columns:
-                if (c not in visualSettings["FoldedColumns"]):
-                    f.append(False)
-                    continue
-                f.append(visualSettings["FoldedColumns"][c])
-            self.table.setHeaderFoldingState(f)
+                if ((c in visualSettings["FoldedColumns"])
+                        and (visualSettings["FoldedColumns"][c])):
+                    f.append(c)
+            self.table.setFoldedColumns(f)
 
     def getVisualSettings(self):
         """
@@ -827,10 +826,10 @@ class DrillView(QMainWindow):
         vs = dict()
         # folding state
         vs["FoldedColumns"] = dict()
-        f = self.table.getHeaderFoldingState()
-        for i in range(len(self.columns)):
-            if f[i]:
-                vs["FoldedColumns"][self.columns[i]] = f[i]
+        folded = self.table.getFoldedColumns()
+        for c in self.columns:
+            if c in folded:
+             vs["FoldedColumns"][c] = True
 
         return vs
 

--- a/scripts/Interface/ui/drill/view/ui/main.ui
+++ b/scripts/Interface/ui/drill/view/ui/main.ui
@@ -469,9 +469,15 @@
      </widget>
      <addaction name="menuAddRemoveColumn"/>
     </widget>
+    <widget class="QMenu" name="menuCell_s">
+     <property name="title">
+      <string>Cell(s)</string>
+     </property>
+     <addaction name="actionErase"/>
+    </widget>
     <addaction name="menuColumns_s"/>
     <addaction name="menuRow_s"/>
-    <addaction name="actionErase"/>
+    <addaction name="menuCell_s"/>
    </widget>
    <widget class="QMenu" name="menuProcess_2">
     <property name="title">

--- a/scripts/Interface/ui/drill/view/ui/main.ui
+++ b/scripts/Interface/ui/drill/view/ui/main.ui
@@ -448,11 +448,29 @@
     <property name="title">
      <string>&amp;Edit</string>
     </property>
-    <addaction name="actionAddRow"/>
-    <addaction name="actionDelRow"/>
-    <addaction name="actionCopyRow"/>
-    <addaction name="actionCutRow"/>
-    <addaction name="actionPasteRow"/>
+    <widget class="QMenu" name="menuRow_s">
+     <property name="title">
+      <string>Row(s)</string>
+     </property>
+     <addaction name="actionAddRow"/>
+     <addaction name="actionDelRow"/>
+     <addaction name="actionCopyRow"/>
+     <addaction name="actionCutRow"/>
+     <addaction name="actionPasteRow"/>
+    </widget>
+    <widget class="QMenu" name="menuColumns_s">
+     <property name="title">
+      <string>Columns(s)</string>
+     </property>
+     <widget class="QMenu" name="menuAddRemoveColumn">
+      <property name="title">
+       <string>Add/remove column</string>
+      </property>
+     </widget>
+     <addaction name="menuAddRemoveColumn"/>
+    </widget>
+    <addaction name="menuColumns_s"/>
+    <addaction name="menuRow_s"/>
     <addaction name="actionErase"/>
    </widget>
    <widget class="QMenu" name="menuProcess_2">
@@ -571,6 +589,11 @@
   <action name="actionHelp">
    <property name="text">
     <string>DrILL help</string>
+   </property>
+  </action>
+  <action name="actiona">
+   <property name="text">
+    <string>a</string>
    </property>
   </action>
  </widget>

--- a/scripts/Interface/ui/drill/view/ui/main.ui
+++ b/scripts/Interface/ui/drill/view/ui/main.ui
@@ -557,7 +557,7 @@
   </action>
   <action name="actionErase">
    <property name="text">
-    <string>Erase seleced cell(s)</string>
+    <string>Erase selected cell(s)</string>
    </property>
   </action>
   <action name="actionAddRow">


### PR DESCRIPTION
**Description of work.**

This PR adds two features in the table of the DrILL interface:
* the visibility of the columns can be toggled via the context menu
* the order of the columns can be changed by drag-and-drop

These two visual settings are also exported/imported to/from a 'rundex' file.

**To test:**

Open the DrILL interface and play with it:
* move the columns to change their order
* hide/show them through the context menu (mouse right click most of the time)
* save the 'rundex' file (*File* -> *Save rundex as*) and reload it (*File* -> *Load rundex*) to see if the table state is preserved

Part of #29570 

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
