### PR TITLE
Remove Qt.EnableHighDPIScaling attribute

### DIFF
--- a/qt/applications/workbench/workbench/app/start.py
+++ b/qt/applications/workbench/workbench/app/start.py
@@ -46,8 +46,6 @@ def qapplication():
     if app is None:
         # attributes that must be set before creating QApplication
         QCoreApplication.setAttribute(Qt.AA_ShareOpenGLContexts)
-        if hasattr(Qt, 'AA_EnableHighDpiScaling'):
-            QCoreApplication.setAttribute(Qt.AA_EnableHighDpiScaling)
 
         argv = sys.argv[:]
         argv[0] = APPNAME  # replace application name


### PR DESCRIPTION
**Description of work.**

It causes the interfaces not to open on Windows with a dual 4K/2K monitor setup. The
tested scenario was a 4K laptop with a 2K second monitor. Attempting to open any
custom interface produced something that looked open in the task bar but the window
was nowhere to be seen.

The attribute was moved in #29240 to remove a warning that it was a noop as it was set too late.
As everything seemed to function without the setting the decision was that we are better not setting
it. It seems to make no difference to the instrument view.

**To test:**

* Code review

*There is no associated issue.*

*This does not require release notes* because **it fixes a regression we introduced in the PR referenced above.**

<!-- Ensure the base of this PR is correct (e.g. release-next or master)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
