### PR TITLE
Fix index peaks crash

### DIFF
--- a/Framework/Crystal/inc/MantidCrystal/PeakAlgorithmHelpers.h
+++ b/Framework/Crystal/inc/MantidCrystal/PeakAlgorithmHelpers.h
@@ -45,6 +45,12 @@ validModulationVectors(const std::vector<double> &modVector1,
                        const std::vector<double> &modVector2,
                        const std::vector<double> &modVector3);
 
+/// Create a list of valid modulation vectors from the input
+std::vector<Kernel::V3D>
+addModulationVectors(const std::vector<double> &modVector1,
+                     const std::vector<double> &modVector2,
+                     const std::vector<double> &modVector3);
+
 /// Calculate a list of HKL offsets from the given modulation vectors.
 std::vector<MNPOffset>
 generateOffsetVectors(const std::vector<Kernel::V3D> &modVectors,

--- a/Framework/Crystal/src/IndexPeaks.cpp
+++ b/Framework/Crystal/src/IndexPeaks.cpp
@@ -82,8 +82,14 @@ struct IndexPeaksArgs {
       maxOrderToUse = lattice.getMaxOrder(); // the lattice can return a 0 here
       // if lattice has maxOrder, we will use the modVec from it, otherwise
       // stick to the input got from previous assignment
+      // NOTE:
+      // The non-zero modVectors check are turned off in the initilization step
+      // as it will lead to unexpected errors for users not relying on this
+      // feature.  For projects/processing that relyies on non-zero modVectors,
+      // it is the application responsibility to ensure that non-zero vectors
+      // are passed to IndexPeaks.
       if (maxOrderToUse > 0) {
-        modVectorsToUse = validModulationVectors(
+        modVectorsToUse = addModulationVectors(
             lattice.getModVec(0), lattice.getModVec(1), lattice.getModVec(2));
       }
     }

--- a/Framework/Crystal/src/IndexPeaks.cpp
+++ b/Framework/Crystal/src/IndexPeaks.cpp
@@ -457,24 +457,24 @@ void IndexPeaks::exec() {
     auto &lattice = args.workspace->mutableSample().getOrientedLattice();
     lattice.setMaxOrder(args.satellites.maxOrder);
     lattice.setCrossTerm(args.satellites.crossTerms);
-    
-    if (args.satellites.modVectors[0].nullVector()){
+
+    if (args.satellites.modVectors[0].nullVector()) {
       g_log.warning("empty modVector 1, skipping saving");
     } else {
       lattice.setModVec1(args.satellites.modVectors[0]);
     }
 
-    if (args.satellites.modVectors[1].nullVector()){
+    if (args.satellites.modVectors[1].nullVector()) {
       g_log.warning("empty modVector 2, skipping saving");
     } else {
       lattice.setModVec2(args.satellites.modVectors[1]);
     }
 
-    if (args.satellites.modVectors[2].nullVector()){
+    if (args.satellites.modVectors[2].nullVector()) {
       g_log.warning("empty modVector 2, skipping saving");
     } else {
       lattice.setModVec3(args.satellites.modVectors[2]);
-    }    
+    }
   }
 
   CombinedIndexingStats indexingInfo;

--- a/Framework/Crystal/src/IndexPeaks.cpp
+++ b/Framework/Crystal/src/IndexPeaks.cpp
@@ -458,22 +458,22 @@ void IndexPeaks::exec() {
     lattice.setMaxOrder(args.satellites.maxOrder);
     lattice.setCrossTerm(args.satellites.crossTerms);
 
-    if (args.satellites.modVectors[0].nullVector()) {
-      g_log.warning("empty modVector 1, skipping saving");
-    } else {
+    if (args.satellites.modVectors.size() >= 1){
       lattice.setModVec1(args.satellites.modVectors[0]);
+    } else {
+      g_log.warning("empty modVector 1, skipping saving");
     }
 
-    if (args.satellites.modVectors[1].nullVector()) {
-      g_log.warning("empty modVector 2, skipping saving");
-    } else {
+    if (args.satellites.modVectors.size() >= 2){
       lattice.setModVec2(args.satellites.modVectors[1]);
+    } else {
+      g_log.warning("empty modVector 2, skipping saving");
     }
 
-    if (args.satellites.modVectors[2].nullVector()) {
-      g_log.warning("empty modVector 2, skipping saving");
-    } else {
+    if (args.satellites.modVectors.size() >= 3){
       lattice.setModVec3(args.satellites.modVectors[2]);
+    } else {
+      g_log.warning("empty modVector 3, skipping saving");
     }
   }
 

--- a/Framework/Crystal/src/IndexPeaks.cpp
+++ b/Framework/Crystal/src/IndexPeaks.cpp
@@ -82,14 +82,8 @@ struct IndexPeaksArgs {
       maxOrderToUse = lattice.getMaxOrder(); // the lattice can return a 0 here
       // if lattice has maxOrder, we will use the modVec from it, otherwise
       // stick to the input got from previous assignment
-      // NOTE:
-      // The non-zero modVectors check are turned off in the initilization step
-      // as it will lead to unexpected errors for users not relying on this
-      // feature.  For projects/processing that relyies on non-zero modVectors,
-      // it is the application responsibility to ensure that non-zero vectors
-      // are passed to IndexPeaks.
       if (maxOrderToUse > 0) {
-        modVectorsToUse = addModulationVectors(
+        modVectorsToUse = validModulationVectors(
             lattice.getModVec(0), lattice.getModVec(1), lattice.getModVec(2));
       }
     }
@@ -463,9 +457,24 @@ void IndexPeaks::exec() {
     auto &lattice = args.workspace->mutableSample().getOrientedLattice();
     lattice.setMaxOrder(args.satellites.maxOrder);
     lattice.setCrossTerm(args.satellites.crossTerms);
-    lattice.setModVec1(args.satellites.modVectors[0]);
-    lattice.setModVec2(args.satellites.modVectors[1]);
-    lattice.setModVec3(args.satellites.modVectors[2]);
+    
+    if (args.satellites.modVectors[0].nullVector()){
+      g_log.warning("empty modVector 1, skipping saving");
+    } else {
+      lattice.setModVec1(args.satellites.modVectors[0]);
+    }
+
+    if (args.satellites.modVectors[1].nullVector()){
+      g_log.warning("empty modVector 2, skipping saving");
+    } else {
+      lattice.setModVec2(args.satellites.modVectors[1]);
+    }
+
+    if (args.satellites.modVectors[2].nullVector()){
+      g_log.warning("empty modVector 2, skipping saving");
+    } else {
+      lattice.setModVec3(args.satellites.modVectors[2]);
+    }    
   }
 
   CombinedIndexingStats indexingInfo;

--- a/Framework/Crystal/src/PeakAlgorithmHelpers.cpp
+++ b/Framework/Crystal/src/PeakAlgorithmHelpers.cpp
@@ -109,6 +109,27 @@ validModulationVectors(const std::vector<double> &modVector1,
 }
 
 /**
+ * Direct add modulation a list to return.
+ * @param modVector1 List of 3 doubles specifying an offset
+ * @param modVector2 List of 3 doubles specifying an offset
+ * @param modVector3 List of 3 doubles specifying an offset
+ * @return A list of valid modulation vectors
+ */
+std::vector<Kernel::V3D>
+addModulationVectors(const std::vector<double> &modVector1,
+                     const std::vector<double> &modVector2,
+                     const std::vector<double> &modVector3) {
+  std::vector<V3D> modVectors;
+  auto addVec = [&modVectors](const auto &modVec) {
+    modVectors.emplace_back(V3D(modVec[0], modVec[1], modVec[2]));
+  };
+  addVec(modVector1);
+  addVec(modVector2);
+  addVec(modVector3);
+  return modVectors;
+}
+
+/**
  * @param maxOrder Integer specifying the multiples of the
  * modulation vector.
  * @param modVectors A list of modulation vectors form the user

--- a/Framework/PythonInterface/test/python/plugins/algorithms/IndexPeaksTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/IndexPeaksTest.py
@@ -1,0 +1,59 @@
+# Mantid Repository : https://github.com/mantidproject/mantid
+#
+# Copyright &copy; 2018 ISIS Rutherford Appleton Laboratory UKRI,
+#   NScD Oak Ridge National Laboratory, European Spallation Source,
+#   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+# SPDX - License - Identifier: GPL - 3.0 +
+from mantid.simpleapi import Load, FindUBUsingIndexedPeaks, IndexPeaks
+import unittest
+import numpy as np
+import numpy.testing as npt
+
+
+class IndexPeaksTest(unittest.TestCase):
+    """
+    The purpose of the testing is to ensure the Python bindning works
+    with various different input arguments.
+    """
+
+    def test_exec_with_different_args(self):
+        # load data
+        Load(
+            Filename="test_index_satellite_peaks.integrate", OutputWorkspace="test",
+        )
+        FindUBUsingIndexedPeaks(PeaksWorkspace="test")
+
+        # defualt args
+        IndexPeaks(PeaksWorkspace="test", Tolerance=0.12)
+
+        # testing zero (default) modVec with maxOrder=1
+        IndexPeaks(
+            PeaksWorkspace="test",
+            Tolerance=0.12,
+            RoundHKLs=False,
+            SaveModulationInfo=True,
+            MaxOrder=1,
+        )
+
+        # testing one non-zero modVec with maxOrder=1
+        IndexPeaks(
+            PeaksWorkspace="test",
+            Tolerance=0.12,
+            RoundHKLs=False,
+            SaveModulationInfo=True,
+            MaxOrder=1,
+            ModVector1="0,0,0.33333",
+        )
+
+        # testing one non-zero modVec with maxOrder=0
+        IndexPeaks(
+            PeaksWorkspace="test",
+            Tolerance=0.12,
+            RoundHKLs=False,
+            SaveModulationInfo=True,
+            ModVector1="0,0,0.33333",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/Testing/Data/UnitTest/test_index_peaks.integrate.md5
+++ b/Testing/Data/UnitTest/test_index_peaks.integrate.md5
@@ -1,0 +1,1 @@
+ca2dbe3033e5eb5c5bf984b16e0032cb

--- a/docs/source/release/v5.1.0/diffraction.rst
+++ b/docs/source/release/v5.1.0/diffraction.rst
@@ -32,6 +32,7 @@ Improvements
 Bugfixes
 ^^^^^^^^
 - The fourier filter on Polaris.create_total_scattering_pdf no longer produces a jagged mark at the cut off point.
+- Calling IndexPeaks with default modulation vectors `(0,0,0)` and `SaveModulationInfo=True` will no longer result in segmentation fault. 
 
 Engineering Diffraction
 -----------------------


### PR DESCRIPTION
**Description of work.**

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->
This is the same bug fix migrated from PR #29583.

> below is the original description

As described in #29429, the `IndexPeaks` function will leads to a segmentation fault when invoked with 

```python
IndexPeaks(
    PeaksWorkspace="data", 
    Tolerance=0.12, 
    RoundHKLs=False,
    SaveModulationInfo=True,
)
``` 

This is because the function `validModulationVectors` will return an empty `std::vector` with the default `modVector` values.
Trying to access these non-existing/empty `modVector` at any point in code will lead to the aforementioned segmentation fault.
This patch adjusted the order of the input property assignment to avoid empty `modVectors`, ensuring the internal representation matches the description in the documentation (default modVectors are `(0,0,0)`, not `()`).

**To test:**
Using the data provided in the linked issue, the following Python script can be used to perform the required test
```Python
#!/usr/bin/bash

from mantid.simpleapi import *
import matplotlib.pyplot as plt
import numpy as np

# load data
Load(
    Filename="test_index_satellite_peaks.integrate",
    OutputWorkspace="test",
    )

FindUBUsingIndexedPeaks(PeaksWorkspace="test")

print("testing default input")
IndexPeaks(
    PeaksWorkspace="test", Tolerance=0.12,
)

print("testing zero (default) modVec with maxOrder=1")
IndexPeaks(
    PeaksWorkspace="test", Tolerance=0.12, 
    RoundHKLs=False,
    SaveModulationInfo=True,
    MaxOrder=1,
    # ModVector1='0,0,0.33333',
    # ModVector2='0,0,0',
    # ModVector3='0,0,0',
    )

print("testing one non-zero modVec with maxOrder=1")
IndexPeaks(
    PeaksWorkspace="test", Tolerance=0.12, 
    RoundHKLs=False,
    SaveModulationInfo=True,
    MaxOrder=1,
    ModVector1='0,0,0.33333',
    # ModVector2='0,0,0',
    # ModVector3='0,0,0',
    )

print("testing one non-zero modVec with maxOrder=0")
IndexPeaks(
    PeaksWorkspace="test", Tolerance=0.12, 
    RoundHKLs=False,
    SaveModulationInfo=True,
    # MaxOrder=1,
    ModVector1='0,0,0.33333',
    # ModVector2='0,0,0',
    # ModVector3='0,0,0',
    )
```

<!-- Instructions for testing. -->

Fixes #29429. <!-- and fix #xxxx or close #xxxx xor resolves #xxxx -->
<!-- alternative
*There is no associated issue.*
-->

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or master)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
