### PR TITLE
Remove profiling section to prevent confusion in Basic Course

### DIFF
--- a/docs/source/tutorials/mantid_basic_course/getting_started/getting_started.rst
+++ b/docs/source/tutorials/mantid_basic_course/getting_started/getting_started.rst
@@ -58,14 +58,3 @@ You may find a bug at some stage using Mantid, and here is how to tell us about 
 .. figure:: /images/ErrorReporterTutorial.PNG
    :alt: Error Reporter
    :align: center
-
-Profiling
-=========
-
-Mantid supports profiling of its underlying code using the `cProfile <https://docs.python.org/3/library/profile.html>`_ module from python.
-
-Launch Mantid Workbench from the command line using the script in the installation folder, adding the ``--profile`` modifier with a path to the output file.
-
-E.g: ``path/to/install/bin/workbench --profile path/to/outputFile.prof``
-
-This profile can then either be sent to the developers upon request or be analysed using the python module `snakeviz <https://pypi.org/project/snakeviz/>`_.


### PR DESCRIPTION
**Description of work.**

Removing this profiling section (meant for the dev-docs) would be nice to do before the release (in case the course is accessed within Workbench).

**To test:**

<!-- Instructions for testing. -->
Code review, just deleted lines

ref. #29337 
But it is not fixed as this should go into a new profiling section

<!-- alternative
*There is no associated issue.*
-->

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or master)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
