### PR TITLE
Adding hollow cylinder integral tests

### DIFF
--- a/Framework/Geometry/inc/MantidGeometry/Objects/Track.h
+++ b/Framework/Geometry/inc/MantidGeometry/Objects/Track.h
@@ -171,6 +171,8 @@ public:
   const Kernel::V3D &startPoint() const { return m_line.getOrigin(); }
   /// Returns the direction as a unit vector
   const Kernel::V3D &direction() const { return m_line.getDirect(); }
+  /// Returns the sum of all the links distInsideObject in the track
+  double totalDistInsideObject() const;
   /// Returns an interator to the start of the set of links
   LType::iterator begin() { return m_links.begin(); }
   /// Returns an interator to one-past-the-end of the set of links

--- a/Framework/Geometry/src/Objects/Track.cpp
+++ b/Framework/Geometry/src/Objects/Track.cpp
@@ -235,6 +235,13 @@ void Track::buildLink() {
   m_surfPoints.clear();
 }
 
+double Track::totalDistInsideObject() const {
+  return std::accumulate(m_links.begin(), m_links.end(), 0.,
+                         [](double total, const auto &link) {
+                           return total + link.distInsideObject;
+                         });
+}
+
 std::ostream &operator<<(std::ostream &os, TrackDirection direction) {
   switch (direction) {
   case TrackDirection::ENTERING:

--- a/Framework/Geometry/src/Objects/Track.cpp
+++ b/Framework/Geometry/src/Objects/Track.cpp
@@ -235,6 +235,12 @@ void Track::buildLink() {
   m_surfPoints.clear();
 }
 
+/**
+ * Sums each link's distance inside an object to get a total
+ * interior distance for the track. This is needed when there
+ * are multiple intersection points through an object.
+ * @returns Sum of all links distInsideObject
+ */
 double Track::totalDistInsideObject() const {
   return std::accumulate(m_links.begin(), m_links.end(), 0.,
                          [](double total, const auto &link) {

--- a/Framework/Geometry/test/CSGObjectTest.h
+++ b/Framework/Geometry/test/CSGObjectTest.h
@@ -896,6 +896,58 @@ public:
     TS_ASSERT_EQUALS(back_midpoint.totalDistInsideObject(), 1.5 * RADIUS);
   }
 
+  void testTracksForHollowCylinder() {
+    // hollow cylinder at the origin with the symmetry axis along y
+    // using PAC06 dimensions: 2.95mm inner radius, 3.15mm outer radius
+    //   x 5.68mm height
+    constexpr double INNER_RADIUS{0.00295};
+    constexpr double OUTER_RADIUS{0.00315};
+    constexpr double WALL_THICKNESS{OUTER_RADIUS - INNER_RADIUS};
+    constexpr double HEIGHT{0.00568};
+    constexpr double TOLERANCE{1e-12};
+    V3D BOTTOM_CENTRE{0., -.5 * HEIGHT, 0.};
+    V3D AXIS_SYMM{0., 1., 0.};
+    auto cylinder = ComponentCreationHelper::createHollowCylinder(
+        INNER_RADIUS, OUTER_RADIUS, HEIGHT, BOTTOM_CENTRE, AXIS_SYMM, "cyl");
+
+    const V3D BEAM_DIRECTION{0., 0., 1.}; // along z-axis
+
+    // centre of sample
+    Track origin(V3D{0., 0., 0.}, BEAM_DIRECTION);
+    cylinder->interceptSurface(origin);
+    // this test should equal wall thickness since this track should
+    //  only be summing distances on the inside of an object
+    TS_ASSERT_DELTA(origin.totalDistInsideObject(), WALL_THICKNESS, TOLERANCE);
+
+    constexpr double WALL_CENTER{0.5 * (OUTER_RADIUS + INNER_RADIUS)};
+    // Right midpoint in wall between origin and radius (front wrt beam dir)
+    Track front_midpt(V3D{0., 0., WALL_CENTER}, BEAM_DIRECTION);
+    cylinder->interceptSurface(front_midpt);
+    TS_ASSERT_DELTA(front_midpt.totalDistInsideObject(), 0.5 * WALL_THICKNESS,
+                    TOLERANCE);
+
+    // Left midpoint in wall between origin and radius (back wrt beam dir)
+    Track back_midpt(V3D{0., 0., -WALL_CENTER}, BEAM_DIRECTION);
+    cylinder->interceptSurface(back_midpt);
+    TS_ASSERT_DELTA(back_midpt.totalDistInsideObject(), 1.5 * WALL_THICKNESS,
+                    TOLERANCE);
+
+    // Add a quarter offset to the midpoint
+    constexpr double WALL_CENTER_OFFSET{0.25 * INNER_RADIUS +
+                                        0.75 * OUTER_RADIUS};
+
+    front_midpt = Track(V3D{0., 0., WALL_CENTER_OFFSET}, BEAM_DIRECTION);
+    cylinder->interceptSurface(front_midpt);
+    TS_ASSERT_DELTA(front_midpt.totalDistInsideObject(), 0.25 * WALL_THICKNESS,
+                    TOLERANCE);
+
+    // Left midpoint in wall between origin and radius (back wrt beam dir)
+    back_midpt = Track(V3D{0., 0., -WALL_CENTER_OFFSET}, BEAM_DIRECTION);
+    cylinder->interceptSurface(back_midpt);
+    TS_ASSERT_DELTA(back_midpt.totalDistInsideObject(), 1.75 * WALL_THICKNESS,
+                    TOLERANCE);
+  }
+
   void testGeneratePointInsideSphere() {
     using namespace ::testing;
 

--- a/Framework/Geometry/test/CSGObjectTest.h
+++ b/Framework/Geometry/test/CSGObjectTest.h
@@ -861,39 +861,39 @@ public:
     sphere->interceptSurface(origin);
     TS_ASSERT_EQUALS(origin.totalDistInsideObject(), RADIUS);
 
-    Track front_midpoint(V3D{0.5*RADIUS, 0.0, 0.0}, BEAM_X);
+    Track front_midpoint(V3D{0.5 * RADIUS, 0.0, 0.0}, BEAM_X);
     sphere->interceptSurface(front_midpoint);
-    TS_ASSERT_EQUALS(front_midpoint.totalDistInsideObject(), 0.5*RADIUS);
+    TS_ASSERT_EQUALS(front_midpoint.totalDistInsideObject(), 0.5 * RADIUS);
 
-    Track back_midpoint(V3D{-0.5*RADIUS, 0.0, 0.0}, BEAM_X);
+    Track back_midpoint(V3D{-0.5 * RADIUS, 0.0, 0.0}, BEAM_X);
     sphere->interceptSurface(back_midpoint);
-    TS_ASSERT_EQUALS(back_midpoint.totalDistInsideObject(), 1.5*RADIUS);
+    TS_ASSERT_EQUALS(back_midpoint.totalDistInsideObject(), 1.5 * RADIUS);
 
     // Y axis tests
     origin = Track(V3D{0.0, 0.0, 0.0}, BEAM_Y);
     sphere->interceptSurface(origin);
     TS_ASSERT_EQUALS(origin.totalDistInsideObject(), RADIUS);
 
-    front_midpoint = Track(V3D{0.0, 0.5*RADIUS, 0.0}, BEAM_Y);
+    front_midpoint = Track(V3D{0.0, 0.5 * RADIUS, 0.0}, BEAM_Y);
     sphere->interceptSurface(front_midpoint);
-    TS_ASSERT_EQUALS(front_midpoint.totalDistInsideObject(), 0.5*RADIUS);
+    TS_ASSERT_EQUALS(front_midpoint.totalDistInsideObject(), 0.5 * RADIUS);
 
-    back_midpoint = Track(V3D{0.0, -0.5*RADIUS, 0.0}, BEAM_Y);
+    back_midpoint = Track(V3D{0.0, -0.5 * RADIUS, 0.0}, BEAM_Y);
     sphere->interceptSurface(back_midpoint);
-    TS_ASSERT_EQUALS(back_midpoint.totalDistInsideObject(), 1.5*RADIUS);
+    TS_ASSERT_EQUALS(back_midpoint.totalDistInsideObject(), 1.5 * RADIUS);
 
     // Z axis tests
     origin = Track(V3D{0.0, 0.0, 0.0}, BEAM_Z);
     sphere->interceptSurface(origin);
     TS_ASSERT_EQUALS(origin.totalDistInsideObject(), RADIUS);
 
-    front_midpoint = Track(V3D{0.0, 0.0, 0.5*RADIUS}, BEAM_Z);
+    front_midpoint = Track(V3D{0.0, 0.0, 0.5 * RADIUS}, BEAM_Z);
     sphere->interceptSurface(front_midpoint);
-    TS_ASSERT_EQUALS(front_midpoint.totalDistInsideObject(), 0.5*RADIUS);
+    TS_ASSERT_EQUALS(front_midpoint.totalDistInsideObject(), 0.5 * RADIUS);
 
-    back_midpoint = Track(V3D{0.0, 0.0, -0.5*RADIUS}, BEAM_Z);
+    back_midpoint = Track(V3D{0.0, 0.0, -0.5 * RADIUS}, BEAM_Z);
     sphere->interceptSurface(back_midpoint);
-    TS_ASSERT_EQUALS(back_midpoint.totalDistInsideObject(), 1.5*RADIUS);
+    TS_ASSERT_EQUALS(back_midpoint.totalDistInsideObject(), 1.5 * RADIUS);
   }
 
   void testGeneratePointInsideSphere() {

--- a/Framework/Geometry/test/CSGObjectTest.h
+++ b/Framework/Geometry/test/CSGObjectTest.h
@@ -905,12 +905,12 @@ public:
     constexpr double WALL_THICKNESS{OUTER_RADIUS - INNER_RADIUS};
     constexpr double HEIGHT{0.00568};
     constexpr double TOLERANCE{1e-12};
-    V3D BOTTOM_CENTRE{0., -.5 * HEIGHT, 0.};
-    V3D AXIS_SYMM{0., 1., 0.};
+    constexpr V3D BOTTOM_CENTRE{0., -.5 * HEIGHT, 0.};
+    constexpr V3D AXIS_SYMM{0., 1., 0.};
     auto cylinder = ComponentCreationHelper::createHollowCylinder(
         INNER_RADIUS, OUTER_RADIUS, HEIGHT, BOTTOM_CENTRE, AXIS_SYMM, "cyl");
 
-    const V3D BEAM_DIRECTION{0., 0., 1.}; // along z-axis
+    constexpr V3D BEAM_DIRECTION{0., 0., 1.}; // along z-axis
 
     // centre of sample
     Track origin(V3D{0., 0., 0.}, BEAM_DIRECTION);
@@ -945,6 +945,63 @@ public:
     back_midpt = Track(V3D{0., 0., -WALL_CENTER_OFFSET}, BEAM_DIRECTION);
     cylinder->interceptSurface(back_midpt);
     TS_ASSERT_DELTA(back_midpt.totalDistInsideObject(), 1.75 * WALL_THICKNESS,
+                    TOLERANCE);
+  }
+
+  void testTracksForHollowCylinderShifted() {
+    // hollow cylinder shifted right with the symmetry axis along z
+    // using PAC06 dimensions: 2.95mm inner radius, 3.15mm outer radius
+    //   x 5.68mm height
+    constexpr double INNER_RADIUS{0.00295};
+    constexpr double OUTER_RADIUS{0.00315};
+    constexpr double WALL_THICKNESS{OUTER_RADIUS - INNER_RADIUS};
+    constexpr double HEIGHT{0.00568};
+    constexpr double TOLERANCE{1e-12};
+    V3D BOTTOM_CENTRE{0.0, 0.0, -0.5 * HEIGHT};
+
+    // Put the cylinder with the symmetry axis along Z, this should go
+    //  straight through
+    constexpr V3D AXIS_SYMM{0., 0., 1.};
+    auto cylinder = ComponentCreationHelper::createHollowCylinder(
+        INNER_RADIUS, OUTER_RADIUS, HEIGHT, BOTTOM_CENTRE, AXIS_SYMM, "cyl");
+
+    constexpr V3D BEAM_DIRECTION{0., 0., 1.}; // along z-axis
+
+    Track origin = Track(V3D{0.0, 0.0, 0.0}, BEAM_DIRECTION);
+    cylinder->interceptSurface(origin);
+    TS_ASSERT_EQUALS(origin.totalDistInsideObject(), 0.0);
+
+    // Now shift the cylinder over a bit to the test a line through the wall
+    // midpoint
+    BOTTOM_CENTRE = V3D{1.0 - OUTER_RADIUS, 0.0, -0.5 * HEIGHT};
+    cylinder = ComponentCreationHelper::createHollowCylinder(
+        INNER_RADIUS, OUTER_RADIUS, HEIGHT, BOTTOM_CENTRE, AXIS_SYMM, "cyl");
+
+    // Front midpoint between right wall and top (height/2)
+    Track front_midpt =
+        Track(V3D{1.0 - WALL_THICKNESS, 0.0, 0.25 * HEIGHT}, BEAM_DIRECTION);
+    cylinder->interceptSurface(front_midpt);
+    TS_ASSERT_DELTA(front_midpt.totalDistInsideObject(), 0.25 * HEIGHT,
+                    TOLERANCE);
+
+    // Back midpoint between right wall and bottom (-height/2)
+    Track back_midpt =
+        Track(V3D{1.0 - WALL_THICKNESS, 0.0, -0.25 * HEIGHT}, BEAM_DIRECTION);
+    cylinder->interceptSurface(back_midpt);
+    TS_ASSERT_DELTA(back_midpt.totalDistInsideObject(), 0.75 * HEIGHT,
+                    TOLERANCE);
+
+    // Offset from the midpoint
+    front_midpt = Track(V3D{1.0 - 0.5 * WALL_THICKNESS, 0.0, 0.25 * HEIGHT},
+                        BEAM_DIRECTION);
+    cylinder->interceptSurface(front_midpt);
+    TS_ASSERT_DELTA(front_midpt.totalDistInsideObject(), 0.25 * HEIGHT,
+                    TOLERANCE);
+
+    back_midpt = Track(V3D{1.0 - 0.5 * WALL_THICKNESS, 0.0, -0.25 * HEIGHT},
+                       BEAM_DIRECTION);
+    cylinder->interceptSurface(back_midpt);
+    TS_ASSERT_DELTA(back_midpt.totalDistInsideObject(), 0.75 * HEIGHT,
                     TOLERANCE);
   }
 

--- a/Framework/Geometry/test/CSGObjectTest.h
+++ b/Framework/Geometry/test/CSGObjectTest.h
@@ -846,6 +846,56 @@ public:
     TS_ASSERT_DELTA(axisLength, point->Z(), tolerance);
   }
 
+  void testTracksForSphere() {
+    // Sphere centered at origin, 3 mm diameter
+    constexpr double RADIUS{0.0015};
+
+    const V3D BEAM_X{1.0, 0.0, 0.0};
+    const V3D BEAM_Y{0.0, 1.0, 0.0};
+    const V3D BEAM_Z{0.0, 0.0, 1.0};
+
+    auto sphere = ComponentCreationHelper::createSphere(RADIUS);
+
+    // Test center of sphere
+    Track origin(V3D{0.0, 0.0, 0.0}, BEAM_X);
+    sphere->interceptSurface(origin);
+    TS_ASSERT_EQUALS(origin.front().distInsideObject, RADIUS);
+
+    Track front_midpoint(V3D{0.5*RADIUS, 0.0, 0.0}, BEAM_X);
+    sphere->interceptSurface(front_midpoint);
+    TS_ASSERT_EQUALS(front_midpoint.front().distInsideObject, 0.5*RADIUS);
+
+    Track back_midpoint(V3D{-0.5*RADIUS, 0.0, 0.0}, BEAM_X);
+    sphere->interceptSurface(back_midpoint);
+    TS_ASSERT_EQUALS(back_midpoint.front().distInsideObject, 1.5*RADIUS);
+
+    // Y axis tests
+    origin = Track(V3D{0.0, 0.0, 0.0}, BEAM_Y);
+    sphere->interceptSurface(origin);
+    TS_ASSERT_EQUALS(origin.front().distInsideObject, RADIUS);
+
+    front_midpoint = Track(V3D{0.0, 0.5*RADIUS, 0.0}, BEAM_Y);
+    sphere->interceptSurface(front_midpoint);
+    TS_ASSERT_EQUALS(front_midpoint.front().distInsideObject, 0.5*RADIUS);
+
+    back_midpoint = Track(V3D{0.0, -0.5*RADIUS, 0.0}, BEAM_Y);
+    sphere->interceptSurface(back_midpoint);
+    TS_ASSERT_EQUALS(back_midpoint.front().distInsideObject, 1.5*RADIUS);
+
+    // Z axis tests
+    origin = Track(V3D{0.0, 0.0, 0.0}, BEAM_Z);
+    sphere->interceptSurface(origin);
+    TS_ASSERT_EQUALS(origin.front().distInsideObject, RADIUS);
+
+    front_midpoint = Track(V3D{0.0, 0.0, 0.5*RADIUS}, BEAM_Z);
+    sphere->interceptSurface(front_midpoint);
+    TS_ASSERT_EQUALS(front_midpoint.front().distInsideObject, 0.5*RADIUS);
+
+    back_midpoint = Track(V3D{0.0, 0.0, -0.5*RADIUS}, BEAM_Z);
+    sphere->interceptSurface(back_midpoint);
+    TS_ASSERT_EQUALS(back_midpoint.front().distInsideObject, 1.5*RADIUS);
+  }
+
   void testGeneratePointInsideSphere() {
     using namespace ::testing;
 

--- a/Framework/Geometry/test/CSGObjectTest.h
+++ b/Framework/Geometry/test/CSGObjectTest.h
@@ -859,41 +859,41 @@ public:
     // Test center of sphere
     Track origin(V3D{0.0, 0.0, 0.0}, BEAM_X);
     sphere->interceptSurface(origin);
-    TS_ASSERT_EQUALS(origin.front().distInsideObject, RADIUS);
+    TS_ASSERT_EQUALS(origin.totalDistInsideObject(), RADIUS);
 
     Track front_midpoint(V3D{0.5*RADIUS, 0.0, 0.0}, BEAM_X);
     sphere->interceptSurface(front_midpoint);
-    TS_ASSERT_EQUALS(front_midpoint.front().distInsideObject, 0.5*RADIUS);
+    TS_ASSERT_EQUALS(front_midpoint.totalDistInsideObject(), 0.5*RADIUS);
 
     Track back_midpoint(V3D{-0.5*RADIUS, 0.0, 0.0}, BEAM_X);
     sphere->interceptSurface(back_midpoint);
-    TS_ASSERT_EQUALS(back_midpoint.front().distInsideObject, 1.5*RADIUS);
+    TS_ASSERT_EQUALS(back_midpoint.totalDistInsideObject(), 1.5*RADIUS);
 
     // Y axis tests
     origin = Track(V3D{0.0, 0.0, 0.0}, BEAM_Y);
     sphere->interceptSurface(origin);
-    TS_ASSERT_EQUALS(origin.front().distInsideObject, RADIUS);
+    TS_ASSERT_EQUALS(origin.totalDistInsideObject(), RADIUS);
 
     front_midpoint = Track(V3D{0.0, 0.5*RADIUS, 0.0}, BEAM_Y);
     sphere->interceptSurface(front_midpoint);
-    TS_ASSERT_EQUALS(front_midpoint.front().distInsideObject, 0.5*RADIUS);
+    TS_ASSERT_EQUALS(front_midpoint.totalDistInsideObject(), 0.5*RADIUS);
 
     back_midpoint = Track(V3D{0.0, -0.5*RADIUS, 0.0}, BEAM_Y);
     sphere->interceptSurface(back_midpoint);
-    TS_ASSERT_EQUALS(back_midpoint.front().distInsideObject, 1.5*RADIUS);
+    TS_ASSERT_EQUALS(back_midpoint.totalDistInsideObject(), 1.5*RADIUS);
 
     // Z axis tests
     origin = Track(V3D{0.0, 0.0, 0.0}, BEAM_Z);
     sphere->interceptSurface(origin);
-    TS_ASSERT_EQUALS(origin.front().distInsideObject, RADIUS);
+    TS_ASSERT_EQUALS(origin.totalDistInsideObject(), RADIUS);
 
     front_midpoint = Track(V3D{0.0, 0.0, 0.5*RADIUS}, BEAM_Z);
     sphere->interceptSurface(front_midpoint);
-    TS_ASSERT_EQUALS(front_midpoint.front().distInsideObject, 0.5*RADIUS);
+    TS_ASSERT_EQUALS(front_midpoint.totalDistInsideObject(), 0.5*RADIUS);
 
     back_midpoint = Track(V3D{0.0, 0.0, -0.5*RADIUS}, BEAM_Z);
     sphere->interceptSurface(back_midpoint);
-    TS_ASSERT_EQUALS(back_midpoint.front().distInsideObject, 1.5*RADIUS);
+    TS_ASSERT_EQUALS(back_midpoint.totalDistInsideObject(), 1.5*RADIUS);
   }
 
   void testGeneratePointInsideSphere() {


### PR DESCRIPTION
**Do not merge before #29579**

**Description of work.**

Uses the function added in #29579 to make unit tests for evaluating line integrals at different points in a hollow cylinder centered at the origin with symmetry axis along y, as well as shifted slightly off the origin with symmetry axis along z.

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

**To test:**

<!-- Instructions for testing. -->

Code review and making sure the unit tests provide good coverage for a hollow cylinder. Verify that GeometryTest can be built and run to make sure all tests pass.

See #29579.

*This does not require release notes* because **it is an internal change.**

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
