### PR TITLE
Adding flat plate integral tests

### DIFF
--- a/Framework/Geometry/test/CSGObjectTest.h
+++ b/Framework/Geometry/test/CSGObjectTest.h
@@ -899,11 +899,11 @@ public:
   void testTracksForHollowCylinder() {
     // hollow cylinder at the origin with the symmetry axis along y
     // using PAC06 dimensions: 2.95mm inner radius, 3.15mm outer radius
-    //   x 5.68mm height
+    //   x 5.68cm height
     constexpr double INNER_RADIUS{0.00295};
     constexpr double OUTER_RADIUS{0.00315};
     constexpr double WALL_THICKNESS{OUTER_RADIUS - INNER_RADIUS};
-    constexpr double HEIGHT{0.00568};
+    constexpr double HEIGHT{0.0568};
     constexpr double TOLERANCE{1e-12};
     constexpr V3D BOTTOM_CENTRE{0., -.5 * HEIGHT, 0.};
     constexpr V3D AXIS_SYMM{0., 1., 0.};
@@ -951,11 +951,11 @@ public:
   void testTracksForHollowCylinderShifted() {
     // hollow cylinder shifted right with the symmetry axis along z
     // using PAC06 dimensions: 2.95mm inner radius, 3.15mm outer radius
-    //   x 5.68mm height
+    //   x 5.68cm height
     constexpr double INNER_RADIUS{0.00295};
     constexpr double OUTER_RADIUS{0.00315};
     constexpr double WALL_THICKNESS{OUTER_RADIUS - INNER_RADIUS};
-    constexpr double HEIGHT{0.00568};
+    constexpr double HEIGHT{0.0568};
     constexpr double TOLERANCE{1e-12};
     V3D BOTTOM_CENTRE{0.0, 0.0, -0.5 * HEIGHT};
 
@@ -1003,6 +1003,59 @@ public:
     cylinder->interceptSurface(back_midpt);
     TS_ASSERT_DELTA(back_midpt.totalDistInsideObject(), 0.75 * HEIGHT,
                     TOLERANCE);
+  }
+
+  void testTracksForFlatPlate() {
+    // Flat plate centered at origin, 5 mm x 5 mm x 2 mm
+    // Thin side of plate (2mm) is facing the beam
+    constexpr double WIDTH{0.005}; // along x axis
+    constexpr double LENGTH{0.005}; // along y axis
+    constexpr double HEIGHT{0.002}; // along z axis
+
+    // Beam is along X assuming z is "up" y is "right" and x is out of page
+    // This puts the thin side facing the +x axis
+    constexpr V3D BEAM_DIRECTION{1.0, 0.0, 0.0};
+
+    auto plate = ComponentCreationHelper::createCuboid(0.5*WIDTH, 0.5*LENGTH, 0.5*HEIGHT, 0.0, BEAM_DIRECTION);
+
+    // Test center of plate
+    Track origin(V3D{0.0, 0.0, 0.0}, BEAM_DIRECTION);
+    plate->interceptSurface(origin);
+    TS_ASSERT_EQUALS(origin.totalDistInsideObject(), WIDTH*0.5);
+
+    Track front_midpoint(V3D{0.25 * WIDTH, 0.0, 0.0}, BEAM_DIRECTION);
+    plate->interceptSurface(front_midpoint);
+    TS_ASSERT_EQUALS(front_midpoint.totalDistInsideObject(), 0.25 * WIDTH);
+
+    Track back_midpoint(V3D{-0.25 * WIDTH, 0.0, 0.0}, BEAM_DIRECTION);
+    plate->interceptSurface(back_midpoint);
+    TS_ASSERT_EQUALS(back_midpoint.totalDistInsideObject(), 0.75 * WIDTH);
+
+    // Repeat above tests but shift plate to the midpoint along the +y axis
+    Track yshifted(V3D{0.0, 0.25 * LENGTH, 0.0}, BEAM_DIRECTION);
+    plate->interceptSurface(yshifted);
+    TS_ASSERT_EQUALS(yshifted.totalDistInsideObject(), WIDTH*0.5);
+
+    front_midpoint = Track(V3D{0.25 * WIDTH, 0.25 * LENGTH, 0.0}, BEAM_DIRECTION);
+    plate->interceptSurface(front_midpoint);
+    TS_ASSERT_EQUALS(front_midpoint.totalDistInsideObject(), 0.25 * WIDTH);
+
+    back_midpoint = Track(V3D{-0.25 * WIDTH, 0.25 * LENGTH, 0.0}, BEAM_DIRECTION);
+    plate->interceptSurface(back_midpoint);
+    TS_ASSERT_EQUALS(back_midpoint.totalDistInsideObject(), 0.75 * WIDTH);
+
+    // shift plate to the midpoint along the +z axis
+    Track zshifted(V3D{0.0, 0.0, 0.25 * HEIGHT}, BEAM_DIRECTION);
+    plate->interceptSurface(zshifted);
+    TS_ASSERT_EQUALS(zshifted.totalDistInsideObject(), WIDTH*0.5);
+
+    front_midpoint = Track(V3D{0.25 * WIDTH, 0.0, 0.25 * HEIGHT}, BEAM_DIRECTION);
+    plate->interceptSurface(front_midpoint);
+    TS_ASSERT_EQUALS(front_midpoint.totalDistInsideObject(), 0.25 * WIDTH);
+
+    back_midpoint = Track(V3D{-0.25 * WIDTH, 0.0, 0.25 * HEIGHT}, BEAM_DIRECTION);
+    plate->interceptSurface(back_midpoint);
+    TS_ASSERT_EQUALS(back_midpoint.totalDistInsideObject(), 0.75 * WIDTH);
   }
 
   void testGeneratePointInsideSphere() {

--- a/Framework/Geometry/test/CSGObjectTest.h
+++ b/Framework/Geometry/test/CSGObjectTest.h
@@ -1008,7 +1008,7 @@ public:
   void testTracksForFlatPlate() {
     // Flat plate centered at origin, 5 mm x 5 mm x 2 mm
     // Thin side of plate (2mm) is facing the beam
-    constexpr double WIDTH{0.005}; // along x axis
+    constexpr double WIDTH{0.005};  // along x axis
     constexpr double LENGTH{0.005}; // along y axis
     constexpr double HEIGHT{0.002}; // along z axis
 
@@ -1016,12 +1016,13 @@ public:
     // This puts the thin side facing the +x axis
     constexpr V3D BEAM_DIRECTION{1.0, 0.0, 0.0};
 
-    auto plate = ComponentCreationHelper::createCuboid(0.5*WIDTH, 0.5*LENGTH, 0.5*HEIGHT, 0.0, BEAM_DIRECTION);
+    auto plate = ComponentCreationHelper::createCuboid(
+        0.5 * WIDTH, 0.5 * LENGTH, 0.5 * HEIGHT, 0.0, BEAM_DIRECTION);
 
     // Test center of plate
     Track origin(V3D{0.0, 0.0, 0.0}, BEAM_DIRECTION);
     plate->interceptSurface(origin);
-    TS_ASSERT_EQUALS(origin.totalDistInsideObject(), WIDTH*0.5);
+    TS_ASSERT_EQUALS(origin.totalDistInsideObject(), WIDTH * 0.5);
 
     Track front_midpoint(V3D{0.25 * WIDTH, 0.0, 0.0}, BEAM_DIRECTION);
     plate->interceptSurface(front_midpoint);
@@ -1034,26 +1035,30 @@ public:
     // Repeat above tests but shift plate to the midpoint along the +y axis
     Track yshifted(V3D{0.0, 0.25 * LENGTH, 0.0}, BEAM_DIRECTION);
     plate->interceptSurface(yshifted);
-    TS_ASSERT_EQUALS(yshifted.totalDistInsideObject(), WIDTH*0.5);
+    TS_ASSERT_EQUALS(yshifted.totalDistInsideObject(), WIDTH * 0.5);
 
-    front_midpoint = Track(V3D{0.25 * WIDTH, 0.25 * LENGTH, 0.0}, BEAM_DIRECTION);
+    front_midpoint =
+        Track(V3D{0.25 * WIDTH, 0.25 * LENGTH, 0.0}, BEAM_DIRECTION);
     plate->interceptSurface(front_midpoint);
     TS_ASSERT_EQUALS(front_midpoint.totalDistInsideObject(), 0.25 * WIDTH);
 
-    back_midpoint = Track(V3D{-0.25 * WIDTH, 0.25 * LENGTH, 0.0}, BEAM_DIRECTION);
+    back_midpoint =
+        Track(V3D{-0.25 * WIDTH, 0.25 * LENGTH, 0.0}, BEAM_DIRECTION);
     plate->interceptSurface(back_midpoint);
     TS_ASSERT_EQUALS(back_midpoint.totalDistInsideObject(), 0.75 * WIDTH);
 
     // shift plate to the midpoint along the +z axis
     Track zshifted(V3D{0.0, 0.0, 0.25 * HEIGHT}, BEAM_DIRECTION);
     plate->interceptSurface(zshifted);
-    TS_ASSERT_EQUALS(zshifted.totalDistInsideObject(), WIDTH*0.5);
+    TS_ASSERT_EQUALS(zshifted.totalDistInsideObject(), WIDTH * 0.5);
 
-    front_midpoint = Track(V3D{0.25 * WIDTH, 0.0, 0.25 * HEIGHT}, BEAM_DIRECTION);
+    front_midpoint =
+        Track(V3D{0.25 * WIDTH, 0.0, 0.25 * HEIGHT}, BEAM_DIRECTION);
     plate->interceptSurface(front_midpoint);
     TS_ASSERT_EQUALS(front_midpoint.totalDistInsideObject(), 0.25 * WIDTH);
 
-    back_midpoint = Track(V3D{-0.25 * WIDTH, 0.0, 0.25 * HEIGHT}, BEAM_DIRECTION);
+    back_midpoint =
+        Track(V3D{-0.25 * WIDTH, 0.0, 0.25 * HEIGHT}, BEAM_DIRECTION);
     plate->interceptSurface(back_midpoint);
     TS_ASSERT_EQUALS(back_midpoint.totalDistInsideObject(), 0.75 * WIDTH);
   }


### PR DESCRIPTION
~~**Do not merge before #29579**~~

**Description of work.**

Uses the function added in #29579 to make unit tests for evaluating line integrals at different points through a flat plate centered at the origin and also shifted off the origin along the y and z axis. All tests are done with the thin side of the plate in the beam direction. 

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

**To test:**

<!-- Instructions for testing. -->

Code review and making sure the unit tests provide good coverage for a flat plate. Verify that GeometryTest can be built and run to make sure all tests pass.

See #29579.

*This does not require release notes* because **it is an internal change.**

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
