### PR TITLE
Unsupported instruments in DrILL

### DIFF
--- a/scripts/Interface/ui/drill/model/DrillModel.py
+++ b/scripts/Interface/ui/drill/model/DrillModel.py
@@ -336,12 +336,16 @@ class DrillModel(QObject):
                 of them uses the setting name as key. The type is a str:
                 "file", "workspace", "combobox", "bool" or "string".
         """
-        alg = sapi.AlgorithmManager.createUnmanaged(self.algorithm)
-        alg.initialize()
-
         types = dict()
         values = dict()
         docs = dict()
+
+        if not self.algorithm:
+            return types, values, docs
+
+        alg = sapi.AlgorithmManager.createUnmanaged(self.algorithm)
+        alg.initialize()
+
         for s in self.settings:
             p = alg.getProperty(s)
             if (isinstance(p, FileProperty)):

--- a/scripts/Interface/ui/drill/model/DrillModel.py
+++ b/scripts/Interface/ui/drill/model/DrillModel.py
@@ -166,16 +166,6 @@ class DrillModel(QObject):
         """
         return self.instrument
 
-    def getAvailableTechniques(self):
-        """
-        Get the list of techniques available.
-
-        Returns:
-            list(str): list of techniques
-        """
-        return [technique for (instrument, technique)
-                in RundexSettings.TECHNIQUE.items()]
-
     def setAcquisitionMode(self, mode):
         """
         Set the acquisition mode. The acquisition mode is modified only if it

--- a/scripts/Interface/ui/drill/model/DrillModel.py
+++ b/scripts/Interface/ui/drill/model/DrillModel.py
@@ -115,7 +115,7 @@ class DrillModel(QObject):
         self.visualSettings = None
 
         # set the instrument and default acquisition mode
-        self.setInstrument(config['default.instrument'])
+        self.setInstrument(config['default.instrument'], log=False)
 
         self.tasksPool = DrillAlgorithmPool()
         # setup the thread pool
@@ -125,7 +125,7 @@ class DrillModel(QObject):
         self.tasksPool.signals.progressUpdate.connect(self._onProcessingProgress)
         self.tasksPool.signals.processingDone.connect(self._onProcessingDone)
 
-    def setInstrument(self, instrument):
+    def setInstrument(self, instrument, log=True):
         """
         Set the instrument. This methods change the current instrument and all
         the associated parameters (acquisition mode, algorithm, parameters). It
@@ -138,6 +138,16 @@ class DrillModel(QObject):
         self.samples = list()
         self.settings = dict()
 
+        # When the user changes the facility after DrILL has been started
+        if config['default.facility'] != 'ILL':
+            logger.error('Drill is enabled only if the facility is set to ILL.')
+            self.instrument = None
+            self.acquisitionMode = None
+            self.columns = list()
+            self.algorithm = None
+            self.settings = dict()
+            return
+
         if (instrument in RundexSettings.ACQUISITION_MODES):
             config['default.instrument'] = instrument
             self.instrument = instrument
@@ -149,8 +159,9 @@ class DrillModel(QObject):
                     RundexSettings.SETTINGS[self.acquisitionMode])
             self._initController()
         else:
-            logger.error('Instrument {0} is not supported yet.'
-                         .format(instrument))
+            if log:
+                logger.error('Instrument {0} is not supported yet.'
+                             .format(instrument))
             self.instrument = None
             self.acquisitionMode = None
             self.columns = list()

--- a/scripts/Interface/ui/drill/presenter/DrillPresenter.py
+++ b/scripts/Interface/ui/drill/presenter/DrillPresenter.py
@@ -22,7 +22,6 @@ class DrillPresenter:
         """
         self.model = DrillModel()
         self.view = view
-        self.view.set_available_instruments(self.model.getAvailableTechniques())
 
         # view signals connection
         self.view.instrumentChanged.connect(self.instrumentChanged)

--- a/scripts/Interface/ui/drill/test/DrillModelTest.py
+++ b/scripts/Interface/ui/drill/test/DrillModelTest.py
@@ -70,9 +70,10 @@ class DrillModelTest(unittest.TestCase):
         self.addCleanup(patch.stop)
 
         # mock config
+        d = {'default.instrument': 'i1', 'default.facility': 'ILL'}
         patch = mock.patch('Interface.ui.drill.model.DrillModel.config')
         self.mConfig = patch.start()
-        self.mConfig.__getitem__.return_value = "i1"
+        self.mConfig.__getitem__.side_effect = d.__getitem__
         self.addCleanup(patch.stop)
 
         # mock logger

--- a/scripts/Interface/ui/drill/test/DrillModelTest.py
+++ b/scripts/Interface/ui/drill/test/DrillModelTest.py
@@ -154,9 +154,6 @@ class DrillModelTest(unittest.TestCase):
     def test_getInstrument(self):
         self.assertEqual(self.model.getInstrument(), self.model.instrument)
 
-    def test_getAvailableTechniques(self):
-        self.assertEqual(self.model.getAvailableTechniques(), ["t1"])
-
     def test_setAcquisitionMode(self):
         # invalid aquisition mode
         self.mController.reset_mock()

--- a/scripts/Interface/ui/drill/test/DrillTest.py
+++ b/scripts/Interface/ui/drill/test/DrillTest.py
@@ -146,6 +146,11 @@ class DrillTest(unittest.TestCase):
                 'Interface.ui.drill.model.DrillModel.DrillParameterController')
         self.mController = patch.start()
         self.addCleanup(patch.stop)
+        # mock logger
+        patch = mock.patch(
+                'Interface.ui.drill.model.DrillModel.logger')
+        self.mLogger = patch.start()
+        self.addCleanup(patch.stop)
 
         self.view = DrillView()
         self.presenter = self.view._presenter
@@ -162,16 +167,19 @@ class DrillTest(unittest.TestCase):
             mColumns = self.model.columns
             mAlgorithm = self.model.algorithm
             mSettings = self.model.settings
-            self.assertEqual(mInstrument,
-                             self.view.instrumentselector.currentText())
-            self.assertEqual(mAcquisitionMode,
-                             RundexSettings.ACQUISITION_MODES[mInstrument][0])
-            self.assertEqual(mColumns,
-                             RundexSettings.COLUMNS[mAcquisitionMode])
-            self.assertEqual(mAlgorithm,
-                             RundexSettings.ALGORITHM[mAcquisitionMode])
-            self.assertDictEqual(mSettings,
-                                 RundexSettings.SETTINGS[mAcquisitionMode])
+            if not self.mLogger.error.mock_calls:
+                self.assertEqual(mInstrument,
+                                 self.view.instrumentselector.currentText())
+                self.assertEqual(mAcquisitionMode,
+                                 RundexSettings.ACQUISITION_MODES[mInstrument][0])
+                self.assertEqual(mColumns,
+                                 RundexSettings.COLUMNS[mAcquisitionMode])
+                self.assertEqual(mAlgorithm,
+                                 RundexSettings.ALGORITHM[mAcquisitionMode])
+                self.assertDictEqual(mSettings,
+                                     RundexSettings.SETTINGS[mAcquisitionMode])
+            else:
+                self.mLogger.reset_mock()
 
     def test_changeAcquisitionMode(self):
         # D17 has two acquisition modes

--- a/scripts/Interface/ui/drill/test/DrillTest.py
+++ b/scripts/Interface/ui/drill/test/DrillTest.py
@@ -156,6 +156,13 @@ class DrillTest(unittest.TestCase):
         self.presenter = self.view._presenter
         self.model = self.presenter.model
 
+        # mock popup
+        self.view._saveDataQuestion = mock.Mock()
+
+        # shown window
+        self.view.isHidden = mock.Mock()
+        self.view.isHidden.return_value = False
+
     def tearDown(self):
         config['default.facility'] = self.facility
 

--- a/scripts/Interface/ui/drill/test/DrillViewTest.py
+++ b/scripts/Interface/ui/drill/test/DrillViewTest.py
@@ -340,12 +340,6 @@ class DrillViewTest(unittest.TestCase):
         self.view.show_directory_manager()
         self.mUserDir.ManageUserDirectories.assert_called_once()
 
-    def test_setAvailableInstruments(self):
-        self.view.instrumentselector = mock.Mock()
-        self.view.set_available_instruments("test")
-        self.view.instrumentselector.setTechniques.assert_called_once_with(
-                "test")
-
     def test_setAvailableModes(self):
         self.view.modeSelector = mock.Mock()
         self.view.set_available_modes(["test", "test"])

--- a/scripts/Interface/ui/drill/view/DrillView.py
+++ b/scripts/Interface/ui/drill/view/DrillView.py
@@ -587,16 +587,6 @@ class DrillView(QMainWindow):
     # for model calls                                                         #
     ###########################################################################
 
-    def set_available_instruments(self, techniques):
-        """
-        Change the available instruments in the comboxbox based on the
-        supported techniques.
-
-        Args:
-            techniques (list(str)): list of supported techniques
-        """
-        self.instrumentselector.setTechniques(techniques)
-
     def set_available_modes(self, modes):
         """
         Set the available acquisition modes in the comboxbox.

--- a/scripts/Interface/ui/drill/view/DrillView.py
+++ b/scripts/Interface/ui/drill/view/DrillView.py
@@ -124,6 +124,14 @@ class DrillView(QMainWindow):
 
         self._presenter = DrillPresenter(self)
 
+    def show(self):
+        """
+        Override QMainWindow::show. It calls the base class method and
+        updates the instrument.
+        """
+        super(DrillView, self).show()
+        self._changeInstrument(self.instrumentselector.currentText())
+
     def setup_header(self):
         """
         Setup the window header. Set the buttons icons and connect the signals.
@@ -244,6 +252,8 @@ class DrillView(QMainWindow):
         Args:
             instrument(str): instrument name
         """
+        if self.isHidden():
+            return
         if self.isWindowModified():
             self._saveDataQuestion()
         self.instrumentChanged.emit(instrument)


### PR DESCRIPTION
**Description of work.**

This PR changes the way the unsupported instruments are treated in DrILL. Previous behaviour was confusing, see #29604 
DrILL can be started only if the facility is ILL but with any instrument. If the instrument is not supported, an error is logged.

* all instruments are now in the DrILL interface. No matter which instrument is selected in Workbench, the interface will show the same in its combobox
* when the user selects an unsupported instrument (from DrILL or Workbench), an error message is logged (only if DrILL is visible)
* if the user changes the facility when DriLL is visible, an error is logged

**To test:**

Play with the interface. Try to change the instrument and the facility when DrILL is visible or not.

*This does not require release notes*: internal changes only

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
