### PR TITLE
Fix key/completer handling in AddFunctionDialog

### DIFF
--- a/qt/python/CMakeLists.txt
+++ b/qt/python/CMakeLists.txt
@@ -110,6 +110,7 @@ if(ENABLE_MANTIDPLOT OR ENABLE_WORKBENCH)
         mantidqt/widgets/codeeditor/tab_widget/test/test_codeeditor_tab_presenter.py
         mantidqt/widgets/codeeditor/tab_widget/test/test_codeeditor_tab_view.py
         mantidqt/widgets/fitpropertybrowser/addfunctiondialog/test/test_addfunctiondialogpresenter.py
+        mantidqt/widgets/fitpropertybrowser/addfunctiondialog/test/test_addfunctiondialogview.py
         mantidqt/widgets/instrumentview/test/test_instrumentview_io.py
         mantidqt/widgets/instrumentview/test/test_instrumentview_view.py
         mantidqt/widgets/plotconfigdialog/axestabwidget/test/test_axestabwidgetpresenter.py

--- a/qt/python/mantidqt/widgets/fitpropertybrowser/addfunctiondialog/presenter.py
+++ b/qt/python/mantidqt/widgets/fitpropertybrowser/addfunctiondialog/presenter.py
@@ -12,14 +12,17 @@ class AddFunctionDialog(object):
     """
     Dialog to add function to fit property browser
     """
-
-    def __init__(self, parent = None, function_names = None, view=None):
-        self.view = view if view else AddFunctionDialogView(parent, function_names)
+    def __init__(self, parent=None, function_names=None, view=None, default_function_name=None):
+        self.view = view if view else AddFunctionDialogView(parent, function_names,
+                                                            default_function_name)
         self.view.ui.buttonBox.accepted.connect(lambda: self.action_add_function())
         self.view.ui.helpButton.clicked.connect(self.function_help_dialog)
 
     def action_add_function(self):
-        current_function = self.view.ui.functionBox.currentText()
+        lineedit = self.view.ui.functionBox.lineEdit()
+        current_function = lineedit.text()
+        if current_function == "":
+            current_function = lineedit.placeholderText()
         if self.view.is_text_in_function_list(current_function):
             self.view.function_added.emit(current_function)
             self.view.accept()

--- a/qt/python/mantidqt/widgets/fitpropertybrowser/addfunctiondialog/test/test_addfunctiondialogpresenter.py
+++ b/qt/python/mantidqt/widgets/fitpropertybrowser/addfunctiondialog/test/test_addfunctiondialogpresenter.py
@@ -15,17 +15,26 @@ from testhelpers import assertRaisesNothing
 
 @patch('mantidqt.widgets.fitpropertybrowser.addfunctiondialog.view.AddFunctionDialogView')
 class AddFunctionDialogPresenterTest(unittest.TestCase):
-
     def test_initialization_does_not_raise(self, mock_view):
         assertRaisesNothing(self, AddFunctionDialog, view=mock_view)
 
-    def test_add_function(self, mock_view):
+    def test_add_function_with_typed_text_uses_this_text(self, mock_view):
         dialog = AddFunctionDialog(view=mock_view)
-        with patch.object(mock_view.ui.functionBox, 'currentText', lambda: "Gaussian"):
+        with patch.object(mock_view.ui.functionBox.lineEdit(), 'text', lambda: "Gaussian"):
             with patch.object(mock_view, 'is_text_in_function_list', lambda x: True):
                 dialog.action_add_function()
                 mock_view.function_added.emit.assert_called_once_with("Gaussian")
                 self.assertEqual(1, dialog.view.accept.call_count)
+
+    def test_add_function_with_placeholder_text_uses_placeholder_if_present(self, mock_view):
+        dialog = AddFunctionDialog(view=mock_view)
+        with patch.object(mock_view.ui.functionBox.lineEdit(), 'text', lambda: ""):
+            with patch.object(mock_view.ui.functionBox.lineEdit(), 'placeholderText',
+                              lambda: "Gaussian"):
+                with patch.object(mock_view, 'is_text_in_function_list', lambda x: True):
+                    dialog.action_add_function()
+                    mock_view.function_added.emit.assert_called_once_with("Gaussian")
+                    self.assertEqual(1, dialog.view.accept.call_count)
 
     def test_add_function_give_error_if_function_not_valid(self, mock_view):
         dialog = AddFunctionDialog(view=mock_view)

--- a/qt/python/mantidqt/widgets/fitpropertybrowser/addfunctiondialog/test/test_addfunctiondialogview.py
+++ b/qt/python/mantidqt/widgets/fitpropertybrowser/addfunctiondialog/test/test_addfunctiondialogview.py
@@ -30,6 +30,15 @@ class AddFunctionDialogPresenterTest(unittest.TestCase):
         self.assertTrue(view is not None)
         self.assertEqual(len(self.TEST_FUNCTION_NAMES), view.ui.functionBox.count())
 
+    def test_construction_with_functions_and_default_sets_placeholder_to_default(self):
+        view = AddFunctionDialogView(function_names=self.TEST_FUNCTION_NAMES,
+                                     default_function_name=self.TEST_FUNCTION_NAMES[1])
+
+        self.assertTrue(view is not None)
+        self.assertEqual(len(self.TEST_FUNCTION_NAMES), view.ui.functionBox.count())
+        self.assertEqual(self.TEST_FUNCTION_NAMES[1],
+                         view.ui.functionBox.lineEdit().placeholderText())
+
     def test_pressing_return_in_box_activates_completer(self):
         view = AddFunctionDialogView(function_names=self.TEST_FUNCTION_NAMES)
 

--- a/qt/python/mantidqt/widgets/fitpropertybrowser/addfunctiondialog/test/test_addfunctiondialogview.py
+++ b/qt/python/mantidqt/widgets/fitpropertybrowser/addfunctiondialog/test/test_addfunctiondialogview.py
@@ -1,0 +1,47 @@
+# Mantid Repository : https://github.com/mantidproject/mantid
+#
+# Copyright &copy; 2020 ISIS Rutherford Appleton Laboratory UKRI,
+#   NScD Oak Ridge National Laboratory, European Spallation Source,
+#   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+# SPDX - License - Identifier: GPL - 3.0 +
+#  This file is part of the mantid workbench.
+import unittest
+
+from qtpy.QtCore import Qt
+from qtpy.QtTest import QTest
+
+from mantidqt.widgets.fitpropertybrowser.addfunctiondialog.view import AddFunctionDialogView
+from mantidqt.utils.qt.testing import start_qapplication
+
+
+@start_qapplication
+class AddFunctionDialogPresenterTest(unittest.TestCase):
+    TEST_FUNCTION_NAMES = ['func1', 'secondfunc']
+
+    def test_construction_with_no_functions_gives_empty_list(self):
+        view = AddFunctionDialogView()
+
+        self.assertTrue(view is not None)
+        self.assertEqual(0, view.ui.functionBox.count())
+
+    def test_construction_with_functions_gives_list_of_same_length(self):
+        view = AddFunctionDialogView(function_names=self.TEST_FUNCTION_NAMES)
+
+        self.assertTrue(view is not None)
+        self.assertEqual(len(self.TEST_FUNCTION_NAMES), view.ui.functionBox.count())
+
+    def test_pressing_return_in_box_activates_completer(self):
+        view = AddFunctionDialogView(function_names=self.TEST_FUNCTION_NAMES)
+
+        QTest.keyPress(view.ui.functionBox, Qt.Key_F)
+        QTest.keyPress(view.ui.functionBox, Qt.Key_U)
+        QTest.keyPress(view.ui.functionBox, Qt.Key_N)
+        QTest.keyPress(view.ui.functionBox, Qt.Key_C)
+        QTest.keyPress(view.ui.functionBox, Qt.Key_1)
+        QTest.keyPress(view.ui.functionBox, Qt.Key_Return)
+
+        self.assertEqual(self.TEST_FUNCTION_NAMES[0], view.ui.functionBox.currentText())
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/qt/python/mantidqt/widgets/fitpropertybrowser/addfunctiondialog/view.py
+++ b/qt/python/mantidqt/widgets/fitpropertybrowser/addfunctiondialog/view.py
@@ -53,27 +53,37 @@ class AddFunctionDialogView(QDialog):
     # private
     _key_filter = None
 
-    def __init__(self, parent=None, function_names=None):
+    def __init__(self, parent=None, function_names=None, default_function_name=None):
+        """
+        :param parent: An optional parent widget
+        :param function_names: A list of function names to add to the box
+        :param default_function_name: An optional default name to display as a placeholder
+        """
         super(AddFunctionDialogView, self).__init__(parent)
         self.setWindowIcon(QIcon(':/images/MantidIcon.ico'))
         self.setAttribute(Qt.WA_DeleteOnClose, True)
-        self._setup_ui(function_names)
+        self._setup_ui(function_names, default_function_name)
 
-    def _setup_ui(self, function_names):
+    def is_text_in_function_list(self, function: str) -> bool:
+        """Return True if the given str is in the function list"""
+        return self.ui.functionBox.findText(function, Qt.MatchExactly) != -1
+
+    def set_error_message(self, text: str):
+        """Show the message as an error on the dialog"""
+        self.ui.errorMessage.setText("<span style='color:red'> %s </span>" % text)
+        self.ui.errorMessage.show()
+
+    # private api
+    def _setup_ui(self, function_names, default_function_name):
         self.ui = load_ui(__file__, 'add_function_dialog.ui', self)
         functionBox = self.ui.functionBox
         if function_names:
             functionBox.addItems(function_names)
+        if default_function_name is not None and default_function_name in function_names:
+            functionBox.lineEdit().setPlaceholderText(default_function_name)
         functionBox.clearEditText()
         functionBox.completer().setCompletionMode(QCompleter.PopupCompletion)
         functionBox.completer().setFilterMode(Qt.MatchContains)
         self._key_filter = ActivateCompleterOnReturn(functionBox)
         functionBox.installEventFilter(self._key_filter)
         self.ui.errorMessage.hide()
-
-    def is_text_in_function_list(self, function):
-        return self.ui.functionBox.findText(function, Qt.MatchExactly) != -1
-
-    def set_error_message(self, text):
-        self.ui.errorMessage.setText("<span style='color:red'> %s </span>" % text)
-        self.ui.errorMessage.show()

--- a/qt/python/mantidqt/widgets/fitpropertybrowser/interactive_tool.py
+++ b/qt/python/mantidqt/widgets/fitpropertybrowser/interactive_tool.py
@@ -26,7 +26,7 @@ class FitInteractiveTool(QObject):
 
     default_background = 'LinearBackground'
 
-    def __init__(self, canvas, toolbar_manager, current_peak_type, default_background = None):
+    def __init__(self, canvas, toolbar_manager, current_peak_type, default_background=None):
         """
         Create an instance of FitInteractiveTool.
         :param canvas: A MPL canvas to draw on.
@@ -201,8 +201,9 @@ class FitInteractiveTool(QObject):
         A QAction callback. Start a dialog to choose a peak function name. After that the tool will expect the user
         to click on the canvas to where the peak should be placed.
         """
-        dialog = AddFunctionDialog(self.canvas, self.peak_names)
-        dialog.view.ui.functionBox.lineEdit().setPlaceholderText(self.current_peak_type)
+        dialog = AddFunctionDialog(parent=self.canvas,
+                                   function_names=self.peak_names,
+                                   default_function_name=self.current_peak_type)
         dialog.view.function_added.connect(self.action_peak_added)
         dialog.view.open()
 
@@ -356,8 +357,7 @@ class FitInteractiveTool(QObject):
         """
         return self.fit_range.patch.get_transform()
 
-    def add_to_menu(self, menu, peak_names, current_peak_type, background_names,
-                    other_names):
+    def add_to_menu(self, menu, peak_names, current_peak_type, background_names, other_names):
         """
         Adds the fit tool menu actions to the given menu and returns the menu
 


### PR DESCRIPTION
**Description of work.**

Key handling in add function dialog is now handled by an event filter rather than monkey patching a function in QLineEdit. This avoids having to call protected methods that are only accessible on inheriting classes. 

**To test:**

Re-run the instructions from the referenced issue on Mac or Linux and the exception should no longer occur.

Fixes #29620 

*This does not require release notes* because **this is a regression from v5.0**

<!-- Ensure the base of this PR is correct (e.g. release-next or master)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
