### PR TITLE
Fix Muon Analysis fit browser crash

### DIFF
--- a/scripts/Muon/GUI/Common/fitting_tab_widget/fitting_tab_presenter.py
+++ b/scripts/Muon/GUI/Common/fitting_tab_widget/fitting_tab_presenter.py
@@ -109,6 +109,7 @@ class FittingTabPresenter(object):
 
     def handle_new_data_loaded(self):
         self.manual_selection_made = False
+        self.view.plot_guess_checkbox.setChecked(False)
         self.update_selected_workspace_list_for_fit()
         self.model.create_ws_fit_function_map()
         if self.selected_data:

--- a/scripts/Muon/GUI/Common/fitting_tab_widget/fitting_tab_widget.py
+++ b/scripts/Muon/GUI/Common/fitting_tab_widget/fitting_tab_widget.py
@@ -39,8 +39,6 @@ class FittingTabWidget(object):
 
         self.fitting_tab_view.function_browser.functionStructureChanged.connect(
             self.fitting_tab_presenter.handle_function_structure_changed)
-        self.fitting_tab_view.function_browser.functionStructureChanged.connect(
-            self.fitting_tab_presenter.handle_plot_guess_changed)
         self.fitting_tab_view.function_name_line_edit.textChanged.connect(
             self.fitting_tab_presenter.handle_fit_name_changed_by_user)
         self.fitting_tab_view.undo_fit_button.clicked.connect(self.fitting_tab_presenter.handle_undo_fit_clicked)


### PR DESCRIPTION
**Description of work.**
This PR fixes a crash with the Muon Analysis GUI. It seemed to originate from trying to plot the fit guess before the fit function had been set up after loading new data, this was due to an additional connection to the fit browser.


**To test:**
Instructions are in the issue #29621 
<!-- Instructions for testing. -->

Fixes #29621. <!-- and fix #xxxx or close #xxxx xor resolves #xxxx -->
<!-- alternative
*There is no associated issue.*
-->

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or master)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
