### PR TITLE
Minor improvements to Reflectometry GUI unscripted tests

### DIFF
--- a/dev-docs/source/Testing/ReflectometryGUI/ReflectometryGUITests.rst
+++ b/dev-docs/source/Testing/ReflectometryGUI/ReflectometryGUITests.rst
@@ -143,11 +143,10 @@ Closing the interface
 ---------------------
 
 - Open the interface and load some data.
-- Edit or process the data.
+- Go to the Tools menu and select Options. Ensure the warnings are all enabled.
+- Edit the data (note that processing does not count as an edit even though it changes the state displayed).
 - Close the interface using the `x` button at the top.
 - The interface should show a 'Save/Discard/Cancel' dialogue.
-
-Note that closing the Mantid main window should work and will not give you the option to save.
 
 Saving
 ------


### PR DESCRIPTION
Minor changes to wording in the ISIS Reflectometry GUI test instructions:
- Remove misleading comment about processing data causing a save-changes warning, and ensure warnings are enabled for the tests
- Remove misleading comment that a save-changes prompt is not given on closing (this is now fixed)

**To test:**

Just proof read the changes

*There is no associated issue.*

*This does not require release notes* because **it relates to developer documentation**

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
