### PR TITLE
Minor updates to the project recovery unscripted tests

### DIFF
--- a/dev-docs/source/Testing/ErrorReporter-ProjectRecovery/ProjectRecoveryTesting.rst
+++ b/dev-docs/source/Testing/ErrorReporter-ProjectRecovery/ProjectRecoveryTesting.rst
@@ -26,7 +26,7 @@ Project Recovery test
 
 1. Simple tests
 
-- Open MantidPlot 
+- Open MantidWorkbench
 - Right-click in the Results Log and set `Log level` to `Debug`
 - The Results Log should be printing `Nothing to save`
 - Run the following command to create a simple workspace:
@@ -66,7 +66,7 @@ Project Recovery test
    RenameWorkspace(InputWorkspace='Rename1_fit_Workspace_1_Workspace', OutputWorkspace='Sequential6')
 
 - Wait a few seconds, then provoke a crash by running `Segfault` from the algorithm window
-- Re-start MantidPlot
+- Restart MantidWorkbench
 - You should be presented with the Project Recovery dialog
 - Choose `Yes`
 - This should re-populate your workspace dialog and pop up a recovery script in the script window
@@ -75,7 +75,7 @@ Project Recovery test
 
 2. Testing many workspaces
 
-- Open up MantidPlot
+- Open up MantidWorkbench
 - Run the following script:
 
 .. code-block:: python
@@ -89,7 +89,7 @@ Project Recovery test
    SaveCSV(InputWorkspace='299Clone', Filename=testing_directory + 'Clone.csv')
 
 - Wait a few seconds, then provoke a crash by running `Segfault` from the algorithm window
-- Re-start MantidPlot
+- Restart MantidWorkbench
 - You should be presented with the Project Recovery dialog
 - Choose `Yes`
 - This should re-populate your workspace dialog and pop up a recovery script in the script window
@@ -106,7 +106,7 @@ Project Recovery test
 
 3. Testing workspaces of different types
 
-- Open up MantidPlot
+- Open up MantidWorkbench
 - Run the following script:
 
 .. code-block:: python
@@ -163,7 +163,7 @@ Project Recovery test
 
 4. Recovering plots and windows
 
-- Open MantidPlot - make sure no other instances of MantidPlot are running
+- Open MantidWorkbench - make sure no other instances of MantidWorkbench are running
 - Run the second script from test 1
 - In the workspace window right-click the ``Sequential3`` workspace and choose `Plot spectrum`
 - Choose `Plot All`
@@ -175,7 +175,7 @@ Project Recovery test
 
 
 - Crash Mantid with `Segfault` from the algorithm window
-- Reopen Mantid
+- Restart MantidWorkbench
 - You should be presented with the Project Recovery dialog
 - Choose `Yes`
 - Mantid should reload the workspaces and open windows, so you should see the plots and the data in the main screen.
@@ -184,7 +184,7 @@ Project Recovery test
 
 5. Test multiple instances of Mantid running
 
-- Launch 2 instances of mantid
+- Launch 2 instances of MantidWorkbench
 - Run the script on the first instance:
 
 .. code-block:: python
@@ -199,20 +199,20 @@ Project Recovery test
 
 - Crash the first instance of Mantid with `Segfault`; choose `Do not share information` in the error dialog
 - Do not exit the second instance of Mantid
-- Restart Mantid
+- Restart MantidWorkbench
 - You should be presented with a dialog offering to attempt a recovery - choose `Yes`
-- `NewWorkspace1` should appear in the workspace dialog
+- `Instance 1` should appear in the workspace dialog
 
 ---------
 
 6. Opening script only
 
-- Open MantidPlot
+- Open MantidWorkbench
 - Run the second script from test 1
 - In the workspace window right-click the ``Sequential3`` workspace and choose `Plot spectrum`
 - Choose `Plot All`
 - Crash Mantid with `Segfault` from the algorithm window
-- Reopen Mantid
+- Restart MantidWorkbench
 - You should be presented with the Project Recovery dialog
 - Choose `Only open in script editor`
 - Mantid should open the script editor, with a script named `ordered_recovery.py`
@@ -222,12 +222,12 @@ Project Recovery test
 
 7. Not attempting recovery
 
-- Open MantidPlot
+- Open MantidWorkbench
 - Run the second script from test 1
 - In the workspace window right-click the ``Sequential3`` workspace and choose `Plot spectrum`
 - Choose `Plot All`
 - Crash Mantid with `Segfault` from the algorithm window
-- Reopen Mantid
+- Restart MantidWorkbench
 - You should be presented with the Project Recovery dialog
 - Choose `Start mantid normally`
 - Mantid should open as normal
@@ -237,7 +237,7 @@ Project Recovery test
 
 8. Check old history is purged
 
-- Open MantidPlot
+- Open MantidWorkbench
 
 .. code-block:: python
 
@@ -246,11 +246,11 @@ Project Recovery test
 
 - Save the workspace as a `.nxs` file
 - Close Mantid normally
-- Re-open Mantid
+- Restart MantidWorkbench
 - Re-open the workspace from the saved `.nxs` file
 - Wait for saving
 - Crash Mantid with `Segfault` from the algorithm window
-- Reopen Mantid
+- Restart MantidWorkbench
 - Choose `Only open in script editor`
 - Mantid should open the script editor, with a script named `ordered_recovery.py`
 - This file should contain only the ``Load`` command and no previous history


### PR DESCRIPTION
This PR makes some minor improvements to the project recovery unscripted testing instructions:

- Update the instructions to use workbench instead of MantidPlot.
- Fix a mis-named workspace in the instructions

**To test:**

Just proof read the changes

*There is no associated issue.*

*This does not require release notes* because **it relates to developer documentation**

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
