### PR TITLE
Fix remove workspaces in QENS interfaces

### DIFF
--- a/qt/scientific_interfaces/Indirect/IndirectDataTablePresenter.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectDataTablePresenter.cpp
@@ -136,18 +136,17 @@ QString IndirectDataTablePresenter::getText(FitDomainIndex row,
 
 void IndirectDataTablePresenter::removeSelectedData() {
   auto selectedIndices = m_dataTable->selectionModel()->selectedIndexes();
-
-  for (auto item : selectedIndices) {
-    m_model->removeDataByIndex(FitDomainIndex(item.row()));
+  std::sort(selectedIndices.begin(), selectedIndices.end());
+  for (auto item = selectedIndices.end(); item != selectedIndices.begin();) {
+    --item;
+    m_model->removeDataByIndex(FitDomainIndex(item->row()));
   }
-
   updateTableFromModel();
 }
 
 void IndirectDataTablePresenter::updateTableFromModel() {
   ScopedFalse _signalBlock(m_emitCellChanged);
   m_dataTable->setRowCount(0);
-
   for (auto domainIndex = FitDomainIndex{0};
        domainIndex < m_model->getNumberOfDomains(); domainIndex++) {
     addTableEntry(domainIndex);

--- a/qt/scientific_interfaces/Indirect/IndirectFitData.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectFitData.cpp
@@ -234,9 +234,11 @@ Spectra &Spectra::operator=(Spectra &&vec) {
   return *this;
 }
 
-bool Spectra::empty() const { return m_vec.empty(); }
+[[nodiscard]] bool Spectra::empty() const { return m_vec.empty(); }
 
-FitDomainIndex Spectra::size() const { return FitDomainIndex{m_vec.size()}; }
+FitDomainIndex Spectra::size() const {
+  return FitDomainIndex{m_vec.size()};
+}
 
 std::string Spectra::getString() const {
   if (empty())
@@ -348,7 +350,7 @@ Mantid::API::MatrixWorkspace_sptr IndirectFitData::workspace() const {
 
 const Spectra &IndirectFitData::spectra() const { return m_spectra; }
 
-Spectra IndirectFitData::getMutableSpectra() { return m_spectra; }
+Spectra &IndirectFitData::getMutableSpectra() { return m_spectra; }
 
 WorkspaceIndex IndirectFitData::getSpectrum(FitDomainIndex index) const {
   return m_spectra[index];

--- a/qt/scientific_interfaces/Indirect/IndirectFitData.h
+++ b/qt/scientific_interfaces/Indirect/IndirectFitData.h
@@ -120,7 +120,7 @@ public:
 
   Mantid::API::MatrixWorkspace_sptr workspace() const;
   const Spectra &spectra() const;
-  Spectra getMutableSpectra();
+  Spectra &getMutableSpectra();
   WorkspaceIndex getSpectrum(FitDomainIndex index) const;
   FitDomainIndex numberOfSpectra() const;
   bool zeroSpectra() const;

--- a/qt/scientific_interfaces/Indirect/IndirectFitDataModel.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectFitDataModel.cpp
@@ -310,9 +310,13 @@ void IndirectFitDataModel::removeWorkspace(TableDatasetIndex index) {
 
 void IndirectFitDataModel::removeDataByIndex(FitDomainIndex fitDomainIndex) {
   auto subIndices = getSubIndices(fitDomainIndex);
-  m_fittingData->at(subIndices.first.value)
-      .getMutableSpectra()
-      .erase(subIndices.second);
+  auto &spectra = m_fittingData->at(subIndices.first.value).getMutableSpectra();
+  spectra.erase(subIndices.second);
+  // If the spectra list corresponding to a workspace is empty, remove workspace
+  // at this index, else we'll have a workspace persist with no spectra loaded.
+  if (spectra.empty()) {
+    removeWorkspace(subIndices.first.value);
+  }
 }
 
 void IndirectFitDataModel::switchToSingleInputMode() {


### PR DESCRIPTION
**Description of work.**

This PR fixes the remove button in QENS interfaces. Firstly, the mutable spectra was returned by value and then modified, therefore not updating the stored data. Secondly, for the case of multiple selections, the data was removed using a forward iterator, which meant the next index to be removed was invalidated, meaning multiple selection removal would segfault.

**To test:**

1. Open the Indirect data analysis GUI
2. Go to convfit
3. Go to multiple inputs
4. Add workspace and resolution and some spectra e.g (1-10)
5. Test that remove workspace functions as expected
6. Test some other tabs in the interface.

<!-- Instructions for testing. -->

Fixes #29635. <!-- and fix #xxxx or close #xxxx xor resolves #xxxx -->
<!-- alternative
*There is no associated issue.*
-->


<!-- Ensure the base of this PR is correct (e.g. release-next or master)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
