### PR TITLE
Basic functionality for Corelli calibration database

### DIFF
--- a/scripts/corelli/calibration/database.py
+++ b/scripts/corelli/calibration/database.py
@@ -49,6 +49,10 @@ def filename_bank_table( bankID:int, database_path:str, table_type:str = 'calibr
     """
     subdirectory:str = database_path + '/' + 'bank' + str(bankID).zfill(3)
     abs_subdir:str = str(pathlib.Path(subdirectory).resolve())
+    # Windows debug
+    print ("relative location: " + subdirectory)
+    print ("absolute location: " + abs_subdir)
+
     pathlib.Path(abs_subdir).mkdir(parents=True, exist_ok=True)
     message = f'{"Cannot process Corelli filename_bank_table, table_type must be calibration, mask or acceptance"}'
     assert table_type == 'calibration' or table_type == 'mask' or table_type == 'acceptance', message

--- a/scripts/corelli/calibration/database.py
+++ b/scripts/corelli/calibration/database.py
@@ -1,0 +1,123 @@
+# Mantid Repository : https://github.com/mantidproject/mantid
+#
+# Copyright &copy; 2018 ISIS Rutherford Appleton Laboratory UKRI,
+#   NScD Oak Ridge National Laboratory, European Spallation Source,
+#   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+# SPDX - License - Identifier: GPL - 3.0 +
+
+# File that defines functionality for Corelli calibration database
+
+import pathlib
+from datetime import datetime
+
+from mantid.dataobjects import TableWorkspace
+from mantid.api import WorkspaceGroup, Workspace
+from mantid.simpleapi import CreateEmptyTableWorkspace, SaveNexusProcessed, LoadNexusProcessed
+
+
+def init_corelli_table()->TableWorkspace :
+    """
+    Function that initializes a Corelli calibration TableWorkspace columns
+    """
+    table:TableWorkspace = CreateEmptyTableWorkspace()
+    table.addColumn(type="int", name="Detector ID")
+    table.addColumn(type="vector_double", name="Detector Position")
+    return table
+
+
+def has_valid_columns(table:TableWorkspace)->bool:
+    """
+    Check if table column names are valid Corelli calibration tables
+    """
+    names = table.getColumnNames()
+    if names != ['Detector ID', 'Detector Position']:
+        return False
+
+    return True
+
+
+def filename_bank_table( bankID:int, database_path:str, table_type:str = 'calibration' ) -> str:
+    """
+    Function that returns the absolute path for a bank file using corelli format:
+    database_path/bank0ID/type_corelli_bank0ID_YYYYMMDD.nxs
+    :param bankID bank number that is calibrated
+    :param database_path location of the corelli database (absolute or relative)
+           Example: database/corelli/ for
+                    database/corelli/bank001/
+                    database/corelli/bank002/
+    :param type 'calibration', 'mask' or 'acceptance'
+    """
+    subdirectory:str = database_path + '/' + 'bank' + str(bankID).zfill(3)
+    abs_subdir:str = str(pathlib.Path(subdirectory).resolve())
+    pathlib.Path(abs_subdir).mkdir(parents=True, exist_ok=True)
+    message = f'{"Cannot process Corelli filename_bank_table, table_type must be calibration, mask or acceptance"}'
+    assert table_type == 'calibration' or table_type == 'mask' or table_type == 'acceptance', message
+
+    time:str = datetime.now().strftime('%Y%m%d') # format YYYYMMDD
+    return abs_subdir + '/' + table_type + '_corelli_bank' + str(bankID).zfill(3) + '_' + time + '.nxs.h5'
+
+
+def save_bank_table( data:Workspace, bankID:int, database_path:str, table_type:str = 'calibration' ) -> None:
+    """
+    Function that saves a bank calibrated TableWorkspace into a single HDF5 file
+    using corelli format:
+    database_path/bank0ID/type_corelli_bank0ID_YYYYMMDD.nxs
+    :param data input TableWorkspace data for calibrated pixels
+    :param bankID bank number that is calibrated
+    :param database_path location of the corelli database (absolute or relative)
+           Example: database/corelli/ for
+                    database/corelli/bank001/
+                    database/corelli/bank002/
+    :param table_type 'calibration', 'mask' or 'acceptance'
+    """
+    filename:str = filename_bank_table(bankID, database_path, table_type)
+    SaveNexusProcessed(data,filename)
+
+
+def load_bank_table( bankID:int, database_path:str, table_type:str = 'calibration' ) -> TableWorkspace:
+    """
+    Function that loads a bank calibrated TableWorkspace from a single HDF5 file
+    using corelli format:
+    database_path/bank0ID/type_corelli_bank0ID_YYYYMMDD.nxs
+    :param bankID bank number that is calibrated
+    :param database_path location of the corelli database (absolute or relative)
+           Example: database/corelli/ for
+                    database/corelli/bank001/
+                    database/corelli/bank002/
+    :param table_type 'calibration', 'mask' or 'acceptance'
+    :return TableWorkspace with corresponding data
+    """
+    filename:str = filename_bank_table(bankID, database_path, table_type)
+    outputWS = LoadNexusProcessed(filename)
+    return outputWS
+
+
+def combine_spatial_banks(tables:WorkspaceGroup)->TableWorkspace:
+    """
+    Function that inputs a GroupWorkspace of TableWorkspace .
+    :param tables: input GroupWorkspace with independent bank TableWorkspace for Corelli
+    :return unified TableWorkspace for all banks
+    """
+    message = f'{"Cannot process Corelli combine_spatial_banks, input is not of type WorkspaceGroup"}'
+    assert isinstance(tables, WorkspaceGroup), message
+
+    combined_table:TableWorkspace = init_corelli_table()
+
+    for i in range(tables.getNumberOfEntries()):
+        table = tables.getItem(i)
+
+        # check type
+        message = f'Cannot process Corelli combine_spatial_banks, table ' + str(i) + ' is not of type TableWorkspace'
+        assert isinstance(table, TableWorkspace), message
+
+        # check column names
+        if not has_valid_columns(table):
+            raise RuntimeError('Table index ' + str(i) + ' is not a valid Corelli TableWorkspace ["Detector ID", "Detector Position"]')
+
+        table_dict = table.toDict()
+
+        # loop through rows
+        for r in range(0,table.rowCount()):
+            combined_table.addRow( [table_dict['Detector ID'][r], table_dict['Detector Position'][r] ])
+
+    return combined_table

--- a/scripts/corelli/calibration/database.py
+++ b/scripts/corelli/calibration/database.py
@@ -48,17 +48,15 @@ def filename_bank_table( bankID:int, database_path:str, table_type:str = 'calibr
     :param type 'calibration', 'mask' or 'acceptance'
     """
     subdirectory:str = database_path + '/' + 'bank' + str(bankID).zfill(3)
-    abs_subdir:str = str(pathlib.Path(subdirectory).resolve())
-    # Windows debug
-    print ("relative location: " + subdirectory)
-    print ("absolute location: " + abs_subdir)
-
-    pathlib.Path(abs_subdir).mkdir(parents=True, exist_ok=True)
+    pathlib.Path(subdirectory).mkdir(parents=True, exist_ok=True)
     message = f'{"Cannot process Corelli filename_bank_table, table_type must be calibration, mask or acceptance"}'
     assert table_type == 'calibration' or table_type == 'mask' or table_type == 'acceptance', message
 
     time:str = datetime.now().strftime('%Y%m%d') # format YYYYMMDD
-    return abs_subdir + '/' + table_type + '_corelli_bank' + str(bankID).zfill(3) + '_' + time + '.nxs.h5'
+    filename = subdirectory + '/' + table_type + '_corelli_bank' + str(bankID).zfill(3) + '_' + time + '.nxs.h5'
+    # make it portable
+    filename = str(pathlib.Path(filename).resolve())
+    return filename
 
 
 def save_bank_table( data:Workspace, bankID:int, database_path:str, table_type:str = 'calibration' ) -> None:

--- a/scripts/test/corelli/calibration/CMakeLists.txt
+++ b/scripts/test/corelli/calibration/CMakeLists.txt
@@ -2,6 +2,7 @@
 
 set(TEST_PY_FILES
     test_utils.py
+    test_database.py
     )
 
 check_tests_valid(${CMAKE_CURRENT_SOURCE_DIR} ${TEST_PY_FILES})

--- a/scripts/test/corelli/calibration/test_database.py
+++ b/scripts/test/corelli/calibration/test_database.py
@@ -11,6 +11,7 @@ import unittest
 import numpy as np
 import pathlib
 from datetime import datetime
+import tempfile
 
 from mantid.dataobjects import TableWorkspace
 from mantid.api import WorkspaceGroup
@@ -21,10 +22,12 @@ from corelli.calibration.database import combine_spatial_banks, init_corelli_tab
 
 class TestCorelliDatabase(unittest.TestCase):
 
+    test_dir = tempfile.TemporaryDirectory('_data_corelli')
+
     def setUp(self) -> None:
 
         # create a mock database and tests save_bank_table and load_bank_table
-        self.database_path:str = 'data/corelli'
+        self.database_path:str = TestCorelliDatabase.test_dir.name
 
         calibratedWS10 = init_corelli_table()
         calibratedWS10.addRow( [28672,[2.291367950578997, -1.2497636826045173, -0.7778867990739283]])
@@ -64,28 +67,22 @@ class TestCorelliDatabase(unittest.TestCase):
 
     def test_filename_bank_table(self):
 
-        # calibration
-        abs_subdir:str = str(pathlib.Path(self.database_path + '/bank001/').resolve())
+        abs_subdir:str = self.database_path + '/bank001/'
         time:str = datetime.now().strftime('%Y%m%d') # format YYYYMMDD
-        expected_filename = abs_subdir + '/calibration_corelli_bank001_' + time + '.nxs.h5'
 
+        # calibration
+        expected_filename = str(pathlib.Path(abs_subdir + '/calibration_corelli_bank001_' + time + '.nxs.h5').resolve())
         filename = filename_bank_table(1, self.database_path, 'calibration')
         self.assertEqual(filename, expected_filename)
 
         # mask
-        abs_subdir:str = str(pathlib.Path(self.database_path + '/bank001/').resolve())
-        time:str = datetime.now().strftime('%Y%m%d') # format YYYYMMDD
-        expected_filename = abs_subdir + '/mask_corelli_bank001_' + time + '.nxs.h5'
-
+        expected_filename = str(pathlib.Path(abs_subdir + '/mask_corelli_bank001_' + time + '.nxs.h5').resolve())
         filename = filename_bank_table(1, self.database_path, 'mask')
         self.assertEqual(filename, expected_filename)
 
         # acceptance
-        abs_subdir:str = str(pathlib.Path(self.database_path + '/bank001/').resolve())
-        time:str = datetime.now().strftime('%Y%m%d') # format YYYYMMDD
-        expected_filename = abs_subdir + '/mask_corelli_bank001_' + time + '.nxs.h5'
-
-        filename = filename_bank_table(1, self.database_path, 'mask')
+        expected_filename = str(pathlib.Path(abs_subdir + '/acceptance_corelli_bank001_' + time + '.nxs.h5').resolve())
+        filename = filename_bank_table(1, self.database_path, 'acceptance')
         self.assertEqual(filename, expected_filename)
 
         # verify assertion is raised for invalid name
@@ -120,7 +117,7 @@ class TestCorelliDatabase(unittest.TestCase):
 
         remove(filename_bank_table(10, self.database_path))
         remove(filename_bank_table(20, self.database_path))
-        return
+        TestCorelliDatabase.test_dir.cleanup()
 
 
 if __name__ == "__main__":

--- a/scripts/test/corelli/calibration/test_database.py
+++ b/scripts/test/corelli/calibration/test_database.py
@@ -1,0 +1,127 @@
+
+# Mantid Repository : https://github.com/mantidproject/mantid
+#
+# Copyright &copy; 2018 ISIS Rutherford Appleton Laboratory UKRI,
+#   NScD Oak Ridge National Laboratory, European Spallation Source,
+#   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+# SPDX - License - Identifier: GPL - 3.0 +
+
+from os import remove
+import unittest
+import numpy as np
+import pathlib
+from datetime import datetime
+
+from mantid.dataobjects import TableWorkspace
+from mantid.api import WorkspaceGroup
+from mantid.simpleapi import CreateEmptyTableWorkspace
+from corelli.calibration.database import combine_spatial_banks, init_corelli_table, save_bank_table, filename_bank_table,\
+    load_bank_table, has_valid_columns
+
+
+class TestCorelliDatabase(unittest.TestCase):
+
+    def setUp(self) -> None:
+
+        # create a mock database and tests save_bank_table and load_bank_table
+        self.database_path:str = 'data/corelli'
+
+        calibratedWS10 = init_corelli_table()
+        calibratedWS10.addRow( [28672,[2.291367950578997, -1.2497636826045173, -0.7778867990739283]])
+        calibratedWS10.addRow( [28673,[2.291367950578997, -1.2462425728938251, -0.7778867990739283]])
+        calibratedWS10.addRow( [28674,[2.291367950578997, -1.2427213977528369, -0.7778867990739283]])
+        calibratedWS10.addRow( [28675,[2.291367950578997, -1.2392001571797284, -0.7778867990739283]])
+        save_bank_table( calibratedWS10, 10, self.database_path)
+
+        calibratedWS20 = init_corelli_table()
+        calibratedWS20.addRow( [28700,[2.291367950578997, -1.1511478720770645, -0.7778867990739283]])
+        calibratedWS20.addRow( [28701,[2.291367950578997, -1.1476249296284657, -0.7778867990739283]])
+        calibratedWS20.addRow( [28702,[2.291367950578997, -1.2427213977528369, -0.7778867990739283]])
+        calibratedWS20.addRow( [28703,[2.291367950578997, -1.2392001571797284, -0.7778867990739283]])
+        save_bank_table( calibratedWS20, 20, self.database_path)
+
+        # placeholder to read from the database
+        self.ws_group = WorkspaceGroup()
+        calibratedWS10 = load_bank_table( 10, self.database_path)
+        self.ws_group.addWorkspace(calibratedWS10)
+
+        calibratedWS20 = load_bank_table( 20, self.database_path)
+        self.ws_group.addWorkspace(calibratedWS20)
+
+    def test_init_corelli_table(self):
+
+        corelli_table = init_corelli_table()
+        assert isinstance(corelli_table, TableWorkspace)
+
+    def test_has_valid_columns(self):
+
+        corelli_table = init_corelli_table()
+        self.assertEqual(has_valid_columns(corelli_table), True)
+
+        table_incomplete:TableWorkspace = CreateEmptyTableWorkspace()
+        table_incomplete.addColumn(type="int", name="Detector ID")
+        self.assertEqual(has_valid_columns(table_incomplete), False)
+
+    def test_filename_bank_table(self):
+
+        # calibration
+        abs_subdir:str = str(pathlib.Path(self.database_path + '/bank001/').resolve())
+        time:str = datetime.now().strftime('%Y%m%d') # format YYYYMMDD
+        expected_filename = abs_subdir + '/calibration_corelli_bank001_' + time + '.nxs.h5'
+
+        filename = filename_bank_table(1, self.database_path, 'calibration')
+        self.assertEqual(filename, expected_filename)
+
+        # mask
+        abs_subdir:str = str(pathlib.Path(self.database_path + '/bank001/').resolve())
+        time:str = datetime.now().strftime('%Y%m%d') # format YYYYMMDD
+        expected_filename = abs_subdir + '/mask_corelli_bank001_' + time + '.nxs.h5'
+
+        filename = filename_bank_table(1, self.database_path, 'mask')
+        self.assertEqual(filename, expected_filename)
+
+        # acceptance
+        abs_subdir:str = str(pathlib.Path(self.database_path + '/bank001/').resolve())
+        time:str = datetime.now().strftime('%Y%m%d') # format YYYYMMDD
+        expected_filename = abs_subdir + '/mask_corelli_bank001_' + time + '.nxs.h5'
+
+        filename = filename_bank_table(1, self.database_path, 'mask')
+        self.assertEqual(filename, expected_filename)
+
+        # verify assertion is raised for invalid name
+        with self.assertRaises( AssertionError ) as ar:
+            filename_bank_table(1, self.database_path, 'wrong')
+
+        self.assertEqual( 'table_type must be calibration, mask or acceptance' in str(ar.exception), True)
+
+    def test_combine_spatial_banks(self):
+
+        combined_table = combine_spatial_banks(self.ws_group)
+        combined_dict = combined_table.toDict()
+
+        expected_dict = {'Detector ID': [28672, 28673, 28674, 28675, 28700, 28701, 28702, 28703],
+                         'Detector Position': [  np.array([2.29136795, -1.24976368, -0.7778868]),
+                                                 np.array([2.29136795, -1.24624257, -0.7778868]),
+                                                 np.array([2.29136795, -1.2427214,  -0.7778868]),
+                                                 np.array([2.29136795, -1.23920016, -0.7778868]),
+                                                 np.array([2.29136795, -1.15114787, -0.7778868]),
+                                                 np.array([2.29136795, -1.14762493, -0.7778868]),
+                                                 np.array([2.29136795, -1.2427214,  -0.7778868]),
+                                                 np.array([2.29136795, -1.23920016, -0.7778868])
+                                                 ]
+                         }
+
+        self.assertEqual(expected_dict['Detector ID'], combined_dict['Detector ID'] )
+
+        for i,expected_array in enumerate(expected_dict['Detector Position']):
+            self.assertAlmostEqual( expected_array.all(), combined_dict['Detector Position'][i].all() )
+
+    def tearDown(self) -> None:
+
+        remove(filename_bank_table(10, self.database_path))
+        remove(filename_bank_table(20, self.database_path))
+        return
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
**Description of work.**

Added a function to allow combining calibrated `TableWorkspaces` in a `WorkspaceGroup` into a single `TableWorkspace`
Valid for ORNL Corelli instrument
Added unit test

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->  @jmborr 

**To test:**

<!-- Instructions for testing. -->
Unit tests added to CI `test_corelli_calibration.py`

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
-->
Part of efforts to support Corelli instrument calibration, this is work in progress

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
