### PR TITLE
Crystal Field - Fix Ties for Cubic Crystal Structures

### DIFF
--- a/Framework/CurveFitting/inc/MantidCurveFitting/Functions/CrystalFieldMultiSpectrum.h
+++ b/Framework/CurveFitting/inc/MantidCurveFitting/Functions/CrystalFieldMultiSpectrum.h
@@ -21,6 +21,8 @@ class MANTID_CURVEFITTING_DLL CrystalFieldMultiSpectrum
     : public API::FunctionGenerator {
 public:
   CrystalFieldMultiSpectrum();
+
+  void init() override;
   std::string name() const override { return "CrystalFieldMultiSpectrum"; }
   const std::string category() const override { return "General"; }
   size_t getNumberDomains() const override;

--- a/Framework/CurveFitting/inc/MantidCurveFitting/Functions/CrystalFieldSpectrum.h
+++ b/Framework/CurveFitting/inc/MantidCurveFitting/Functions/CrystalFieldSpectrum.h
@@ -19,6 +19,8 @@ class MANTID_CURVEFITTING_DLL CrystalFieldSpectrum
     : public API::FunctionGenerator {
 public:
   CrystalFieldSpectrum();
+
+  void init() override;
   std::string name() const override { return "CrystalFieldSpectrum"; }
   const std::string category() const override { return "General"; }
   void buildTargetFunction() const override;

--- a/Framework/CurveFitting/src/Functions/CrystalFieldMultiSpectrum.cpp
+++ b/Framework/CurveFitting/src/Functions/CrystalFieldMultiSpectrum.cpp
@@ -21,6 +21,7 @@
 #include "MantidAPI/ParameterTie.h"
 
 #include "MantidKernel/Exception.h"
+#include "MantidKernel/Logger.h"
 #include <boost/regex.hpp>
 
 namespace Mantid {
@@ -34,6 +35,8 @@ using namespace API;
 DECLARE_FUNCTION(CrystalFieldMultiSpectrum)
 
 namespace {
+
+Kernel::Logger g_log("CrystalFieldMultiSpectrum");
 
 // Regex for the FWHMX# type strings (single-site mode)
 const boost::regex FWHMX_ATTR_REGEX("FWHMX([0-9]+)");
@@ -120,6 +123,14 @@ CrystalFieldMultiSpectrum::CrystalFieldMultiSpectrum()
   declareAttribute("FixAllPeaks", Attribute(false));
   declareAttribute("PhysicalProperties",
                    Attribute(std::vector<double>(1, 0.0)));
+}
+
+void CrystalFieldMultiSpectrum::init() {
+  try {
+    buildTargetFunction();
+  } catch (std::runtime_error const &ex) {
+    g_log.warning(ex.what());
+  }
 }
 
 size_t CrystalFieldMultiSpectrum::getNumberDomains() const {

--- a/Framework/CurveFitting/src/Functions/CrystalFieldMultiSpectrum.cpp
+++ b/Framework/CurveFitting/src/Functions/CrystalFieldMultiSpectrum.cpp
@@ -129,7 +129,7 @@ void CrystalFieldMultiSpectrum::init() {
   try {
     buildTargetFunction();
   } catch (std::runtime_error const &ex) {
-    g_log.warning(ex.what());
+    g_log.error(ex.what());
   }
 }
 

--- a/Framework/CurveFitting/src/Functions/CrystalFieldSpectrum.cpp
+++ b/Framework/CurveFitting/src/Functions/CrystalFieldSpectrum.cpp
@@ -14,9 +14,14 @@
 #include "MantidAPI/IPeakFunction.h"
 #include "MantidAPI/ParameterTie.h"
 #include "MantidCurveFitting/Constraints/BoundaryConstraint.h"
+#include "MantidKernel/Logger.h"
 #include "MantidKernel/Strings.h"
 
 #include <algorithm>
+
+namespace {
+Mantid::Kernel::Logger g_log("CrystalFieldSpectrum");
+}
 
 namespace Mantid {
 namespace CurveFitting {
@@ -41,6 +46,14 @@ CrystalFieldSpectrum::CrystalFieldSpectrum()
   declareAttribute("FixAllPeaks", Attribute(false));
 }
 
+void CrystalFieldSpectrum::init() {
+  try {
+    buildTargetFunction();
+  } catch (std::runtime_error const &ex) {
+    g_log.error(ex.what());
+  }
+}
+
 /// Uses m_crystalField to calculate peak centres and intensities
 /// then populates m_spectrum with peaks of type given in PeakShape attribute.
 void CrystalFieldSpectrum::buildTargetFunction() const {
@@ -52,6 +65,7 @@ void CrystalFieldSpectrum::buildTargetFunction() const {
   FunctionDomainGeneral domain;
   FunctionValues values;
   m_source->function(domain, values);
+  m_source->applyTies();
 
   if (values.size() == 0) {
     return;

--- a/docs/source/release/v6.0.0/direct_geometry.rst
+++ b/docs/source/release/v6.0.0/direct_geometry.rst
@@ -5,6 +5,10 @@ Direct Geometry Changes
 .. contents:: Table of Contents
    :local:
 
+.. warning:: **Developers:** Sort changes under appropriate heading
+    putting new features at the top of the section, followed by
+    improvements, followed by bug fixes.
+
 DGSPlanner
 ----------
 
@@ -12,8 +16,13 @@ Improvements
 ############
 - Widgets were rearranged into groups of items based on their logical function
 
-.. warning:: **Developers:** Sort changes under appropriate heading
-    putting new features at the top of the section, followed by
-    improvements, followed by bug fixes.
+
+CrystalField
+------------
+
+BugFixes
+########
+
+- Fixed a bug in the :ref:`Crystal Field Python Interface` where ties were not being applied properly for cubic crystal structures.
 
 :ref:`Release 6.0.0 <v6.0.0>`

--- a/scripts/Inelastic/CrystalField/fitting.py
+++ b/scripts/Inelastic/CrystalField/fitting.py
@@ -394,6 +394,8 @@ class CrystalField(object):
         self._dirty_eigensystem = True
         self._dirty_peaks = True
 
+        self.crystalFieldFunction.initialize()
+
     @property
     def ToleranceEnergy(self):
         """Get energy tolerance"""

--- a/scripts/Inelastic/CrystalField/fitting.py
+++ b/scripts/Inelastic/CrystalField/fitting.py
@@ -226,6 +226,9 @@ class CrystalField(object):
 
         self._setPeaks()
 
+        # Required to build the target function for the first time (which includes applying all ties)
+        self.crystalFieldFunction.initialize()
+
         # Eigensystem
         self._dirty_eigensystem = True
         self._eigenvalues = None

--- a/scripts/test/CrystalFieldTest.py
+++ b/scripts/test/CrystalFieldTest.py
@@ -296,6 +296,14 @@ class CrystalFieldTests(unittest.TestCase):
         self.assertAlmostEqual(y1[139], 0.17385222868511149, 8)
         self.assertAlmostEqual(y1[142], 0.17671738547959939, 8)
 
+    def test_api_CrystalField_when_using_cubic_crystal_structures(self):
+        from CrystalField import CrystalField
+
+        cf = CrystalField('Ce', 'Oh', B40=1, B60=0.1, Temperature=0.01, FWHM=1)
+
+        np.testing.assert_allclose(np.array(cf.getEigenvalues()), np.array([0.0, 0.0, 360.0, 360.0, 360.0, 360.0]))
+        np.testing.assert_allclose(np.array(cf.getPeakList()[0]), np.array([360.0, 0.0]))
+
     def test_api_CrystalField_spectrum_background(self):
         from CrystalField import CrystalField, Background, Function
         cf = CrystalField('Ce', 'C2v', B20=0.035, B40=-0.012, B43=-0.027, B60=-0.00012, B63=0.0025, B66=0.0068,

--- a/scripts/test/CrystalFieldTest.py
+++ b/scripts/test/CrystalFieldTest.py
@@ -304,6 +304,15 @@ class CrystalFieldTests(unittest.TestCase):
         np.testing.assert_allclose(np.array(cf.getEigenvalues()), np.array([0.0, 0.0, 360.0, 360.0, 360.0, 360.0]))
         np.testing.assert_allclose(np.array(cf.getPeakList()[0]), np.array([360.0, 0.0]))
 
+    def test_api_CrystalField_when_setting_a_structures_symmetry_as_being_cubic(self):
+        from CrystalField import CrystalField
+
+        cf = CrystalField('Ce', 'C1', B40=1, B60=0.1, Temperature=0.01, FWHM=1)
+        cf.Symmetry = 'Oh'
+
+        np.testing.assert_allclose(np.array(cf.getEigenvalues()), np.array([0.0, 0.0, 360.0, 360.0, 360.0, 360.0]))
+        np.testing.assert_allclose(np.array(cf.getPeakList()[0]), np.array([360.0, 0.0]))
+
     def test_api_CrystalField_spectrum_background(self):
         from CrystalField import CrystalField, Background, Function
         cf = CrystalField('Ce', 'C2v', B20=0.035, B40=-0.012, B43=-0.027, B60=-0.00012, B63=0.0025, B66=0.0068,


### PR DESCRIPTION
**Description of work.**
This PR ensures the crystal field function `CrystalFieldSpectrum` is initialized properly and has all ties applied to the function when building the target function. This fixes a bug where the relevant ties (`B44=5*B40` and `B64=-21*B60`) were not being applied for cubic crystal structures.

**To test:**
Run this script:
```py
import CrystalField

cf = CrystalField.CrystalField('Ce', 'Oh', B40=1, B60=0.1, Temperature=0.01, FWHM=1)
print('Eigenvalues')
print(cf.getEigenvalues())
print('Calculated peak energies')
print(cf.getPeakList()[0])
ws = CreateWorkspace(*cf.getSpectrum())
```
This should produce the following output:

```py
Eigenvalues
This function is under development and can be changed/removed in the future
CrystalFieldEnergies started
CrystalFieldEnergies successful, Duration 0.00 seconds
[  0.   0. 360. 360. 360. 360.]

Calculated peak energies
[360.   0.]
CreateWorkspace started
CreateWorkspace successful, Duration 0.00 seconds
```
Plotting the spectrum in the created workspace should show a peak at zero and 360 meV only.

![image](https://user-images.githubusercontent.com/40830825/94669412-16f9f100-0309-11eb-8916-228bcb532568.png)

Fixes #28401

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
