### PR TITLE
Update Mac OSX getting started instructions

### DIFF
--- a/dev-docs/source/BuildingOnOSX.rst
+++ b/dev-docs/source/BuildingOnOSX.rst
@@ -31,7 +31,7 @@ These instructions are from the assumptions of a blank newly installed version o
 
    ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"
 
-4. Add the necessary 'taps'. The last 4 are to use qt4.
+4. Add the necessary 'taps':
 
 In order to be able to 'tap' the ``mantidproject/mantid`` 'tap' we need to have a couple of packages installed
 
@@ -40,7 +40,6 @@ In order to be able to 'tap' the ``mantidproject/mantid`` 'tap' we need to have 
    brew install git
    brew tap mantidproject/mantid
    brew tap homebrew/cask
-   brew tap cartr/qt4
    brew cask install xquartz
    brew cask install mactex
 
@@ -52,23 +51,13 @@ In order to be able to 'tap' the ``mantidproject/mantid`` 'tap' we need to have 
 
 6. Homebrew can stop early for reasons that are unclear. Repeat the above command until Homebrew states: *Warning: mantidproject/mantid/mantid-developer ?.? is already installed and up-to-date*.
 
-7. Unlink ``qt@4`` from ``/usr/local`` to avoid cross talk with Qt5 and ensure the webkit can be found when not linked
-
-.. code-block:: sh
-
-   brew unlink qt@4
-   ln -s /usr/local/Homebrew/Library/Taps/mantidproject/homebrew-mantid/qt.conf /usr/local/opt/qt@4/bin/qt.conf
-   ln -s /usr/local/opt/qt-webkit@2.3/include/QtWebKit /usr/local/opt/qt@4/include/QtWebKit
-   ln -s /usr/local/opt/qt-webkit@2.3/lib/QtWebKit.framework /usr/local/opt/qt@4/lib/QtWebKit.framework
-
-8. Unlink ``qscintilla2`` and ``qscintilla2qt4``
+7. Unlink ``qscintilla2``
 
 .. code-block:: sh
 
    brew unlink qscintilla2
-   brew unlink qscintilla2qt4
 
-9. Python is now keg-only. Add the appropriate version to ``PATH`` in shell profile and restart the terminal:
+8. Python is now keg-only. Add the appropriate version to ``PATH`` in shell profile and restart the terminal:
 
 .. code-block:: sh
 
@@ -78,13 +67,13 @@ In order to be able to 'tap' the ``mantidproject/mantid`` 'tap' we need to have 
    # If you have enabled Zsh
    echo 'export PATH="/usr/local/opt/python@3.8/bin:$PATH"' >> ~/.zshenv
 
-10. Downgrade setuptools to 48.0.0 until https://github.com/mantidproject/mantid/issues/29010 is fixed.
+9. Downgrade setuptools to 48.0.0 until https://github.com/mantidproject/mantid/issues/29010 is fixed.
 
 .. code-block:: sh
 
    python3 -m pip install setuptools==48.0.0  
 
-11. Install python requirements
+10. Install python requirements
 
 .. code-block:: sh
 

--- a/dev-docs/source/BuildingOnOSX.rst
+++ b/dev-docs/source/BuildingOnOSX.rst
@@ -38,11 +38,9 @@ In order to be able to 'tap' the ``mantidproject/mantid`` 'tap' we need to have 
 .. code-block:: sh
 
    brew install git
-   brew tap homebrew/science
    brew tap mantidproject/mantid
-   brew tap caskroom/cask
+   brew tap homebrew/cask
    brew tap cartr/qt4
-   brew tap-pin cartr/qt4
    brew cask install xquartz
    brew cask install mactex
 
@@ -76,6 +74,9 @@ In order to be able to 'tap' the ``mantidproject/mantid`` 'tap' we need to have 
 
    # Assume we are using bash
    echo 'export PATH="/usr/local/opt/python@3.8/bin:$PATH"' >> ~/.bash_profile
+
+   # If you have enabled Zsh
+   echo 'export PATH="/usr/local/opt/python@3.8/bin:$PATH"' >> ~/.zshenv
 
 10. Downgrade setuptools to 48.0.0 until https://github.com/mantidproject/mantid/issues/29010 is fixed.
 


### PR DESCRIPTION
**Description of work.**
Updates Homebrew install steps as some were no longer working

This also removes Qt4 steps as the sip binding it no longer working. Whilst we support building Mantid Plot on Mac until it's fully removed I doubt we will have new developers trying to setup their machines in the mean time

**To test:**
Read instructions


There is no associated issue.

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or master)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
