### PR TITLE
Additional default package suffixes

### DIFF
--- a/buildconfig/Jenkins/buildscript
+++ b/buildconfig/Jenkins/buildscript
@@ -272,17 +272,24 @@ if [[ ${DO_BUILD_PKG} == true ]]; then
         # Use different suffix for linux builds if parameter is not defined
         if [[ -n "${PACKAGE_SUFFIX}" ]]; then
             echo "Using PACKAGE_SUFFIX=${PACKAGE_SUFFIX} from job parameter"
-            elif [[ ${JOB_NAME} == *release* ]]; then
+        elif [[ ${JOB_NAME} == release* ]]; then  # starts with "release"
             PACKAGE_SUFFIX=""
-            elif [[ ${JOB_NAME} == *master* ]]; then
+        elif [[ ${JOB_NAME} == ornl ]]; then
+            PACKAGE_SUFFIX=""
+        elif [[ ${JOB_NAME} == ornl-qa ]]; then
+            PACKAGE_SUFFIX="qa"
+        elif [[ ${JOB_NAME} == master ]]; then
             PACKAGE_SUFFIX="nightly"
-            elif [[ ${JOB_NAME} == *pvnext* ]]; then
+        elif [[ ${JOB_NAME} == *pvnext* ]]; then
             PACKAGE_SUFFIX="mantidunstable-pvnext"
         else
             PACKAGE_SUFFIX="unstable"
         fi
 
-        if [[ ${JOB_NAME} == *release* ]] && [[ -z "${PACKAGE_SUFFIX}" ]]; then
+        if [[ ${JOB_NAME} == release* ]] && [[ -z "${PACKAGE_SUFFIX}" ]]; then
+            # Traditional install path for release build
+            PACKAGINGVARS="${PACKAGINGVARS} -DCMAKE_INSTALL_PREFIX=/opt/Mantid -DCPACK_PACKAGE_SUFFIX="
+        elif [[ ${JOB_NAME} == ornl ]] && [[ -z "${PACKAGE_SUFFIX}" ]]; then
             # Traditional install path for release build
             PACKAGINGVARS="${PACKAGINGVARS} -DCMAKE_INSTALL_PREFIX=/opt/Mantid -DCPACK_PACKAGE_SUFFIX="
         else


### PR DESCRIPTION
In order to get appropriately named packages from the build servers, define a set of default package names for things built from the ornl branches.
* `ornl` creates a package without suffix
* `ornl-qa` creates a package with suffix `qa`
* `ornl-next` creates a package with suffix `unstable`

**To test:**

Reviewing the change should be enough

*There is no associated issue.*

*This does not require release notes* because it is a change to the buildscript.

This is the downstream version of #29664.

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
