### PR TITLE
Remove _noatten workspace that was produced if perform_attenuation=true

### DIFF
--- a/docs/source/release/v6.0.0/diffraction.rst
+++ b/docs/source/release/v6.0.0/diffraction.rst
@@ -12,6 +12,11 @@ Diffraction Changes
 Powder Diffraction
 ------------------
 
+New features
+############
+
+- Remove _noatten workspace that was produced by the Pearl powder diffraction scripts when run with perform_attenuation=True
+
 Bugfixes
 ########
 
@@ -28,7 +33,5 @@ New features
 - Scripts for pixel calibration of CORELLI 16-packs. Produce a calibration table, a masking table, and a goodness of fit workspace.
 - Fix problem that was causing matrix diagonalization to return NaNs in certain cases. The diagonalization is used in :ref:`CalculateUMatrix <algm-CalculateUMatrix>` and :ref:`IntegratePeaksMD <algm-IntegratePeaksMD>`
 
-Imaging
--------
 
 :ref:`Release 6.0.0 <v6.0.0>`

--- a/scripts/Diffraction/isis_powder/pearl_routines/pearl_output.py
+++ b/scripts/Diffraction/isis_powder/pearl_routines/pearl_output.py
@@ -35,13 +35,6 @@ def generate_and_save_focus_output(instrument, processed_spectra, run_details, a
     return processed_nexus_files
 
 
-def _attenuate_workspace(output_file_paths, attenuated_ws, attenuation_filepath):
-    # Clone a workspace which is not attenuated
-    no_att = output_file_paths["output_name"] + "_noatten"
-    mantid.CloneWorkspace(InputWorkspace=attenuated_ws, OutputWorkspace=no_att)
-    return pearl_algs.attenuate_workspace(attenuation_file_path=attenuation_filepath, ws_to_correct=attenuated_ws)
-
-
 def _focus_mode_all(output_file_paths, processed_spectra, attenuation_filepath):
     summed_spectra_name = output_file_paths["output_name"] + "_mods1-9"
     summed_spectra = mantid.MergeRuns(InputWorkspaces=processed_spectra[:9], OutputWorkspace=summed_spectra_name)
@@ -51,8 +44,7 @@ def _focus_mode_all(output_file_paths, processed_spectra, attenuation_filepath):
     summed_spectra = mantid.Scale(InputWorkspace=summed_spectra, Factor=0.111111111111111,
                                   OutputWorkspace=summed_spectra_name)
     if attenuation_filepath:
-        summed_spectra = _attenuate_workspace(output_file_paths=output_file_paths, attenuated_ws=summed_spectra,
-                                              attenuation_filepath=attenuation_filepath)
+        summed_spectra = pearl_algs.attenuate_workspace(attenuation_file_path=attenuation_filepath, ws_to_correct=summed_spectra)
 
     summed_spectra = mantid.ConvertUnits(InputWorkspace=summed_spectra, Target="TOF",
                                          OutputWorkspace=summed_spectra_name)
@@ -158,8 +150,7 @@ def _focus_mode_trans(output_file_paths, attenuation_filepath, calibrated_spectr
     summed_ws = mantid.Scale(InputWorkspace=summed_ws, Factor=0.111111111111111)
 
     if attenuation_filepath:
-        summed_ws = _attenuate_workspace(output_file_paths=output_file_paths, attenuated_ws=summed_ws,
-                                         attenuation_filepath=attenuation_filepath)
+        summed_ws = pearl_algs.attenuate_workspace(attenuation_file_path=attenuation_filepath, ws_to_correct=summed_ws)
 
     summed_ws = mantid.ConvertUnits(InputWorkspace=summed_ws, Target="TOF")
     mantid.SaveGSS(InputWorkspace=summed_ws, Filename=output_file_paths["gss_filename"], Append=False, Bank=1)


### PR DESCRIPTION
**Description of work.**

The Pearl diffraction scripts currently create a "diagnostics" workspace with a _noatten suffix when a Focus is run with perform_attenuation=True. This change stops that workspace being produced

**Report to:** Nick Funnell

**To test:**

Unzip the attached zip file into a folder.
Adjust paths in the test.py file to point at the folder you've just created
Also adjust path in the user_experiment.yaml file
Run test.py from Workbench (will need archive access enabled)
Observe that a _noatten workspace isn't produced any more in the Workbench user interface


[PearlFocusTest.zip](https://github.com/mantidproject/mantid/files/5326006/PearlFocusTest.zip)


Fixes #29420 .

<!-- Ensure the base of this PR is correct (e.g. release-next or master)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
