### PR TITLE
Crash in muon analysis

### DIFF
--- a/docs/source/release/v6.0.0/muon.rst
+++ b/docs/source/release/v6.0.0/muon.rst
@@ -10,4 +10,41 @@ MuSR Changes
     improvements, followed by bug fixes.
 
 
+Muon Analysis 2 and Frequency Domain Analysis
+---------------------------------------------
+
+New Features
+############
+
+Improvements
+############
+
+Bug fixes
+#########
+- Prevent a crash caused by switching from multiple to single run when simultaneous fitting.
+
+ALC
+---
+
+New Features
+############
+
+Improvements
+############
+  
+Bug fixes
+##########
+
+Elemental Analysis 
+------------------
+
+New Features
+############
+
+Bug fixes
+#########
+
+Algorithms
+##########
+
 :ref:`Release 6.0.0 <v6.0.0>`

--- a/scripts/Muon/GUI/Common/fitting_tab_widget/fitting_tab_presenter.py
+++ b/scripts/Muon/GUI/Common/fitting_tab_widget/fitting_tab_presenter.py
@@ -562,7 +562,7 @@ class FittingTabPresenter(object):
         self.view.update_with_fit_outputs(self._fit_function[current_index],
                                           self._fit_status[current_index],
                                           self._fit_chi_squared[current_index])
-        self.view.update_global_fit_state(self._fit_status)
+        self.view.update_global_fit_state(self._fit_status, current_index)
 
     def update_view_from_model(self, workspace_removed=None):
         if workspace_removed:

--- a/scripts/Muon/GUI/Common/fitting_tab_widget/fitting_tab_view.py
+++ b/scripts/Muon/GUI/Common/fitting_tab_widget/fitting_tab_view.py
@@ -119,9 +119,9 @@ class FittingTabView(QtWidgets.QWidget, ui_fitting_tab):
 
         self.fit_status_chi_squared.setText('Chi squared: {:.4g}'.format(output_chi_squared))
 
-    def update_global_fit_state(self, output_list):
+    def update_global_fit_state(self, output_list, index):
         if self.fit_type == self.simultaneous_fit:
-            indexed_fit = output_list[self.get_index_for_start_end_times()]
+            indexed_fit = output_list[index]
             boolean_list = [indexed_fit == 'success'] if indexed_fit else []
         else:
             boolean_list = [output == 'success' for output in output_list if output]
@@ -269,7 +269,9 @@ class FittingTabView(QtWidgets.QWidget, ui_fitting_tab):
         warning(message, parent=self)
 
     def get_index_for_start_end_times(self):
-        current_index = self.parameter_display_combo.currentIndex()
+        box = self.parameter_display_combo
+        print([box.itemText(i) for i in range(box.count())])
+        current_index = box.currentIndex()
         return current_index if current_index != -1 else 0
 
     def get_global_parameters(self):

--- a/scripts/Muon/GUI/Common/fitting_tab_widget/fitting_tab_view.py
+++ b/scripts/Muon/GUI/Common/fitting_tab_widget/fitting_tab_view.py
@@ -270,7 +270,6 @@ class FittingTabView(QtWidgets.QWidget, ui_fitting_tab):
 
     def get_index_for_start_end_times(self):
         box = self.parameter_display_combo
-        print([box.itemText(i) for i in range(box.count())])
         current_index = box.currentIndex()
         return current_index if current_index != -1 else 0
 


### PR DESCRIPTION
**Description of work.**
A user has reported a crash in muon analysis. Check that you can cause this crash on your dev build before testing the fix. 

1. Open muon analysis
2. Select the EMU instrument
3. Load 84447-9 (and repeat with 84447-9)
4. Go to fitting
5. Add dynamicKobyeTobye
6. Fix the field
7. Tick simultaneous fitting
8. Change from run to group/pair
9. Change the field values (all of them should be fixed) to have unique values (e.g. 1,2,3 ...)
10. Click the increment run button or load current run
11. CRASH!

There is no associated issue.

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
