### PR TITLE
Fixed muon fitting bugs

### DIFF
--- a/scripts/Muon/GUI/Common/fitting_tab_widget/fitting_tab_presenter.py
+++ b/scripts/Muon/GUI/Common/fitting_tab_widget/fitting_tab_presenter.py
@@ -562,7 +562,7 @@ class FittingTabPresenter(object):
         self.view.update_with_fit_outputs(self._fit_function[current_index],
                                           self._fit_status[current_index],
                                           self._fit_chi_squared[current_index])
-        self.view.update_global_fit_state(self._fit_status)
+        self.view.update_global_fit_state(self._fit_status, current_index)
 
     def update_view_from_model(self, workspace_removed=None):
         if workspace_removed:

--- a/scripts/Muon/GUI/Common/fitting_tab_widget/fitting_tab_view.py
+++ b/scripts/Muon/GUI/Common/fitting_tab_widget/fitting_tab_view.py
@@ -116,12 +116,12 @@ class FittingTabView(QtWidgets.QWidget, ui_fitting_tab):
         else:
             self.fit_status_success_failure.setText('Failure: {}'.format(output_status))
             self.fit_status_success_failure.setStyleSheet('color: red')
-
+        self.function_browser.setErrorsEnabled(True)
         self.fit_status_chi_squared.setText('Chi squared: {:.4g}'.format(output_chi_squared))
 
-    def update_global_fit_state(self, output_list):
+    def update_global_fit_state(self, output_list, index):
         if self.fit_type == self.simultaneous_fit:
-            indexed_fit = output_list[self.get_index_for_start_end_times()]
+            indexed_fit = output_list[index]
             boolean_list = [indexed_fit == 'success'] if indexed_fit else []
         else:
             boolean_list = [output == 'success' for output in output_list if output]

--- a/scripts/test/Muon/fitting_tab_widget/fitting_tab_presenter_test.py
+++ b/scripts/test/Muon/fitting_tab_widget/fitting_tab_presenter_test.py
@@ -709,6 +709,19 @@ class FittingTabPresenterTest(unittest.TestCase):
         self.view.warning_popup.assert_called_once_with('No data selected to fit')
         self.presenter.perform_fit.assert_not_called()
 
+    def test_update_fit_status_information_in_view(self):
+        self.view.get_index_for_start_end_times = mock.MagicMock(return_value = 1)
+        self.view.update_global_fit_state = mock.MagicMock()
+        self.view.update_global_fit_outputs = mock.MagicMock()
+
+        self._fit_function = ["FlatBackground", "LinearBackground"]
+        self._fit_status = ["failure", "success"]
+        self._fit_chi_squared = [23.0, 3.2]
+
+        self.presenter.update_fit_status_information_in_view()
+        self.view.update_global_fit_outputs.assert_called_with("LinearBackground", "success", 3.2)
+        self.view.update_global_fit_state.assert_called_with(self._fit_status, 1)
+
 
 if __name__ == '__main__':
     unittest.main(buffer=False, verbosity=2)

--- a/scripts/test/Muon/fitting_tab_widget/fitting_tab_presenter_test.py
+++ b/scripts/test/Muon/fitting_tab_widget/fitting_tab_presenter_test.py
@@ -712,15 +712,15 @@ class FittingTabPresenterTest(unittest.TestCase):
     def test_update_fit_status_information_in_view(self):
         self.view.get_index_for_start_end_times = mock.MagicMock(return_value = 1)
         self.view.update_global_fit_state = mock.MagicMock()
-        self.view.update_global_fit_outputs = mock.MagicMock()
+        self.view.update_with_fit_outputs = mock.MagicMock()
 
-        self._fit_function = ["FlatBackground", "LinearBackground"]
-        self._fit_status = ["failure", "success"]
-        self._fit_chi_squared = [23.0, 3.2]
+        self.presenter._fit_function = ["FlatBackground", "LinearBackground"]
+        self.presenter._fit_status = ["failure", "success"]
+        self.presenter._fit_chi_squared = [23.0, 3.2]
 
         self.presenter.update_fit_status_information_in_view()
-        self.view.update_global_fit_outputs.assert_called_with("LinearBackground", "success", 3.2)
-        self.view.update_global_fit_state.assert_called_with(self._fit_status, 1)
+        self.view.update_with_fit_outputs.assert_called_with("LinearBackground", "success", 3.2)
+        self.view.update_global_fit_state.assert_called_with(self.presenter._fit_status, 1)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
A user has reported a couple of bugs in muon analysis. Check that you can cause the bugs on your dev build before testing the fix.

Bug 1:
Open muon analysis
Select the EMU instrument
Load 84447-9 (and repeat with 84447-9)
Go to fitting
Add dynamicKobyeTobye
Fix the field
Tick simultaneous fitting
Change from run to group/pair
Change the field values (all of them should be fixed) to have unique values (e.g. 1,2,3 ...)
Click the increment run button or load current run
CRASH!

Bug 2:
Open muon analysis
Load some data
Go to fitting
Add a function
Manually change a value
Errors have gone

After fix 2, the errors will still disappear, but will come back after doing a fit.

**To test:**

<!-- Instructions for testing. -->

Fixes #29669. <!-- and fix #xxxx or close #xxxx xor resolves #xxxx -->
<!-- alternative
*There is no associated issue.*
-->

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or master)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
