### PR TITLE
Settings: restart warning for 'prompt when deleting workspace'

### DIFF
--- a/qt/applications/workbench/workbench/widgets/settings/general/presenter.py
+++ b/qt/applications/workbench/workbench/widgets/settings/general/presenter.py
@@ -144,6 +144,8 @@ class GeneralSettings(object):
 
     def action_prompt_deleting_workspace(self, state):
         CONF.set(GeneralProperties.PROMPT_ON_DELETING_WORKSPACE.value, bool(state))
+        if self.settings_presenter is not None:
+            self.settings_presenter.register_change_needs_restart("Prompt when deleting workspaces")
 
     def action_use_notifications_modified(self, state):
         ConfigService.setString(GeneralProperties.USE_NOTIFICATIONS.value, "On" if bool(state) else "Off")

--- a/qt/applications/workbench/workbench/widgets/settings/general/test/test_general_settings.py
+++ b/qt/applications/workbench/workbench/widgets/settings/general/test/test_general_settings.py
@@ -169,6 +169,23 @@ class GeneralSettingsTest(unittest.TestCase):
         mock_CONF.set.assert_called_once_with(GeneralProperties.PROMPT_SAVE_EDITOR_MODIFIED.value, False)
 
     @patch(WORKBENCH_CONF_CLASSPATH)
+    def test_action_prompt_deleting_workspace(self, mock_CONF):
+        presenter = GeneralSettings(None)
+        presenter.settings_presenter = MagicMock()
+
+        presenter.action_prompt_deleting_workspace(True)
+
+        mock_CONF.set.assert_called_once_with(GeneralProperties.PROMPT_ON_DELETING_WORKSPACE.value, True)
+        presenter.settings_presenter.register_change_needs_restart.assert_called_once()
+        mock_CONF.set.reset_mock()
+        presenter.settings_presenter.reset_mock()
+
+        presenter.action_prompt_deleting_workspace(False)
+
+        mock_CONF.set.assert_called_once_with(GeneralProperties.PROMPT_ON_DELETING_WORKSPACE.value, False)
+        presenter.settings_presenter.register_change_needs_restart.assert_called_once()
+
+    @patch(WORKBENCH_CONF_CLASSPATH)
     @patch(CONFIG_SERVICE_CLASSPATH, new_callable=MockConfigService)
     def test_load_current_setting_values(self, mock_ConfigService, mock_CONF):
         # load current setting is called automatically in the constructor


### PR DESCRIPTION
Adds a 'needs restart' warning when the 'prompt when deleting workspace' checkbox is modified in the general settings.

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

**To test:**

<!-- Instructions for testing. -->
- Ensure the warning appears when enabling or disabling the checkbox. This is located in the general tab.

Fixes #29333

Does this need release notes? Seems like it would be polluting them a bit from real features.

<!-- Ensure the base of this PR is correct (e.g. release-next or master)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
