### PR TITLE
Save Corelli calibration manifest file functionality

### DIFF
--- a/scripts/corelli/calibration/database.py
+++ b/scripts/corelli/calibration/database.py
@@ -59,6 +59,35 @@ def filename_bank_table( bankID:int, database_path:str, table_type:str = 'calibr
     return filename
 
 
+def save_manifest_file( bankIDs:list, database_path:str)->None:
+    """
+    Function that saves or updates an existing manifest_corelli_date.csv file.
+    There is one file stored for each calibration day. If file exist it will append two columns:
+    bankID, timestamp (ISO format)
+    :param bankIDs input of bankIDs that have been calibrated
+    :param database_path location of the corelli database (absolute or relative)
+           Example: database/corelli/ for manifest file:
+                    database/corelli/manifest_corelli_YYYYMMDD.csv
+    """
+
+    time:str = datetime.now().strftime('%Y%m%d') # format YYYYMMDD
+    filename = database_path + '/manifest_corelli_' + time + '.csv'
+
+    if pathlib.Path(filename).is_file():
+        file = open(filename, 'a+')
+    else:
+        file = open(filename, 'w')
+        file.write('bankID, timestamp\n') # header
+
+    iso_timestamp = datetime.now().replace(microsecond=0).isoformat()
+    lines:str = ''
+    for bankID in bankIDs:
+        lines += str(bankID) + ', ' + str(iso_timestamp) + '\n'
+
+    file.write(lines)
+    file.close()
+
+
 def save_bank_table( data:Workspace, bankID:int, database_path:str, table_type:str = 'calibration' ) -> None:
     """
     Function that saves a bank calibrated TableWorkspace into a single HDF5 file


### PR DESCRIPTION
**Description of work.**
Scripts to save a manifest csv file for a list of banks with timestamp
Appends if file exists
Stores one calibration file per day
Added Tests


**Report to:** @jmborr @peterfpeterson 


**To test:**
Added unit tests on CI
<!-- Instructions for testing. -->

Fixes #xxxx. <!-- and fix #xxxx or close #xxxx xor resolves #xxxx -->
*There is no associated issue.*


<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or master)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
