### PR TITLE
Allow MuonPreProcess Algorithm To Accept Multiple Time Zeros

### DIFF
--- a/Framework/Algorithms/test/MuonWorkspaceCreationHelperTest.h
+++ b/Framework/Algorithms/test/MuonWorkspaceCreationHelperTest.h
@@ -263,8 +263,6 @@ public:
     std::vector<double> timeZeros = {0.5, 1.0, 1.5};
     ITableWorkspace_sptr timeZeroTable = createTimeZeroTable(3, timeZeros);
 
-    const auto test = timeZeroTable->getRow(0);
-
     TS_ASSERT_EQUALS(timeZeroTable->columnCount(), 1);
     TS_ASSERT_EQUALS(timeZeroTable->rowCount(), 3);
     TS_ASSERT_DELTA(timeZeroTable->getColumn(0)->toDouble(0), 0.5, 0.01);

--- a/Framework/Algorithms/test/MuonWorkspaceCreationHelperTest.h
+++ b/Framework/Algorithms/test/MuonWorkspaceCreationHelperTest.h
@@ -251,6 +251,27 @@ public:
     TS_ASSERT_DELTA(deadTimeTable->getColumn(1)->toDouble(4), 0.005, 0.0001);
   }
 
+  void test_createTimeZeroTable_empty_for_incorrect_length() {
+    std::vector<double> timeZeros = {0.5, 1.0};
+    ITableWorkspace_sptr timeZeroTable = createTimeZeroTable(3, timeZeros);
+
+    TS_ASSERT_EQUALS(timeZeroTable->columnCount(), 1);
+    TS_ASSERT_EQUALS(timeZeroTable->rowCount(), 0);
+  }
+
+  void test_createTimeZeroTable_correct_value() {
+    std::vector<double> timeZeros = {0.5, 1.0, 1.5};
+    ITableWorkspace_sptr timeZeroTable = createTimeZeroTable(3, timeZeros);
+
+    const auto test = timeZeroTable->getRow(0);
+
+    TS_ASSERT_EQUALS(timeZeroTable->columnCount(), 1);
+    TS_ASSERT_EQUALS(timeZeroTable->rowCount(), 3);
+    TS_ASSERT_DELTA(timeZeroTable->getColumn(0)->toDouble(0), 0.5, 0.01);
+    TS_ASSERT_DELTA(timeZeroTable->getColumn(0)->toDouble(1), 1.0, 0.01);
+    TS_ASSERT_DELTA(timeZeroTable->getColumn(0)->toDouble(2), 1.5, 0.01);
+  }
+
   void
   test_createWorkspaceWithInstrumentandRun_run_number_and_instrument_set_correctly() {
     MatrixWorkspace_sptr ws =

--- a/Framework/DataHandling/inc/MantidDataHandling/LoadMuonStrategy.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/LoadMuonStrategy.h
@@ -31,8 +31,8 @@ public:
   virtual API::Workspace_sptr loadDetectorGrouping() const = 0;
   // Load dead time table
   virtual API::Workspace_sptr loadDeadTimeTable() const = 0;
-  // Set time zero table
-  virtual API::Workspace_sptr setTimeZeroTable() const = 0;
+  // Get time zero table
+  virtual API::Workspace_sptr getTimeZeroTable() = 0;
 
 protected:
   // Create grouping table

--- a/Framework/DataHandling/inc/MantidDataHandling/LoadMuonStrategy.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/LoadMuonStrategy.h
@@ -42,6 +42,9 @@ protected:
   createDeadTimeTable(const std::vector<detid_t> &detectorsLoaded,
                       const std::vector<double> &deadTimes) const;
 
+  DataObjects::TableWorkspace_sptr LoadMuonStrategy::createTimeZeroTable(
+      const std::vector<double> &timeZeros) const;
+
   API::Workspace_sptr loadDefaultDetectorGrouping(
       const DataObjects::Workspace2D &localWorkspace) const;
 

--- a/Framework/DataHandling/inc/MantidDataHandling/LoadMuonStrategy.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/LoadMuonStrategy.h
@@ -31,6 +31,8 @@ public:
   virtual API::Workspace_sptr loadDetectorGrouping() const = 0;
   // Load dead time table
   virtual API::Workspace_sptr loadDeadTimeTable() const = 0;
+  // Set time zero table
+  virtual API::Workspace_sptr setTimeZeroTable() const = 0;
 
 protected:
   // Create grouping table
@@ -42,8 +44,9 @@ protected:
   createDeadTimeTable(const std::vector<detid_t> &detectorsLoaded,
                       const std::vector<double> &deadTimes) const;
 
-  DataObjects::TableWorkspace_sptr LoadMuonStrategy::createTimeZeroTable(
-      const std::vector<double> &timeZeros) const;
+  DataObjects::TableWorkspace_sptr
+  createTimeZeroTable(const size_t numSpec,
+                      const std::vector<double> &timeZeros) const;
 
   API::Workspace_sptr loadDefaultDetectorGrouping(
       const DataObjects::Workspace2D &localWorkspace) const;

--- a/Framework/DataHandling/inc/MantidDataHandling/LoadMuonStrategy.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/LoadMuonStrategy.h
@@ -44,6 +44,7 @@ protected:
   createDeadTimeTable(const std::vector<detid_t> &detectorsLoaded,
                       const std::vector<double> &deadTimes) const;
 
+  // Create time zero table
   DataObjects::TableWorkspace_sptr
   createTimeZeroTable(const size_t numSpec,
                       const std::vector<double> &timeZeros) const;

--- a/Framework/DataHandling/inc/MantidDataHandling/LoadMuonStrategy.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/LoadMuonStrategy.h
@@ -14,6 +14,11 @@
 namespace Mantid {
 namespace DataHandling {
 class LoadMuonNexusV2NexusHelper;
+
+// Create time zero table
+DataObjects::TableWorkspace_sptr
+createTimeZeroTable(const size_t numSpec, const std::vector<double> &timeZeros);
+
 class DLLExport LoadMuonStrategy {
 public:
   // Constructor
@@ -43,11 +48,6 @@ protected:
   DataObjects::TableWorkspace_sptr
   createDeadTimeTable(const std::vector<detid_t> &detectorsLoaded,
                       const std::vector<double> &deadTimes) const;
-
-  // Create time zero table
-  DataObjects::TableWorkspace_sptr
-  createTimeZeroTable(const size_t numSpec,
-                      const std::vector<double> &timeZeros) const;
 
   API::Workspace_sptr loadDefaultDetectorGrouping(
       const DataObjects::Workspace2D &localWorkspace) const;

--- a/Framework/DataHandling/inc/MantidDataHandling/LoadPSIMuonBin.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/LoadPSIMuonBin.h
@@ -88,6 +88,7 @@ private:
   void readInHistograms(Mantid::Kernel::BinaryStreamReader &streamReader);
   void generateUnknownAxis();
   void makeDeadTimeTable(const size_t &numSpec);
+  void makeTimeZeroTable(const std::vector<double> &timeZeroList);
 
   // Temperature file processing
   void readInTemperatureFile(DataObjects::Workspace2D_sptr &ws);

--- a/Framework/DataHandling/inc/MantidDataHandling/LoadPSIMuonBin.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/LoadPSIMuonBin.h
@@ -88,7 +88,6 @@ private:
   void readInHistograms(Mantid::Kernel::BinaryStreamReader &streamReader);
   void generateUnknownAxis();
   void makeDeadTimeTable(const size_t &numSpec);
-  void makeTimeZeroTable(const std::vector<double> &timeZeroList);
 
   // Temperature file processing
   void readInTemperatureFile(DataObjects::Workspace2D_sptr &ws);

--- a/Framework/DataHandling/inc/MantidDataHandling/MultiPeriodLoadMuonStrategy.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/MultiPeriodLoadMuonStrategy.h
@@ -27,6 +27,8 @@ public:
   API::Workspace_sptr loadDetectorGrouping() const override;
   // Load dead time table
   API::Workspace_sptr loadDeadTimeTable() const override;
+  // Set time zero table
+  API::Workspace_sptr setTimeZeroTable() const override;
 
 private:
   API::WorkspaceGroup &m_workspaceGroup;

--- a/Framework/DataHandling/inc/MantidDataHandling/MultiPeriodLoadMuonStrategy.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/MultiPeriodLoadMuonStrategy.h
@@ -27,8 +27,8 @@ public:
   API::Workspace_sptr loadDetectorGrouping() const override;
   // Load dead time table
   API::Workspace_sptr loadDeadTimeTable() const override;
-  // Set time zero table
-  API::Workspace_sptr setTimeZeroTable() const override;
+  // Get time zero table
+  API::Workspace_sptr getTimeZeroTable() override;
 
 private:
   API::WorkspaceGroup &m_workspaceGroup;

--- a/Framework/DataHandling/inc/MantidDataHandling/SinglePeriodLoadMuonStrategy.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/SinglePeriodLoadMuonStrategy.h
@@ -29,8 +29,8 @@ public:
   API::Workspace_sptr loadDetectorGrouping() const override;
   // Load dead time table
   API::Workspace_sptr loadDeadTimeTable() const override;
-  // Set time zero table
-  API::Workspace_sptr setTimeZeroTable() const override;
+  // Get time zero table
+  API::Workspace_sptr getTimeZeroTable() override;
 
 private:
   DataObjects::Workspace2D &m_workspace;

--- a/Framework/DataHandling/inc/MantidDataHandling/SinglePeriodLoadMuonStrategy.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/SinglePeriodLoadMuonStrategy.h
@@ -29,6 +29,8 @@ public:
   API::Workspace_sptr loadDetectorGrouping() const override;
   // Load dead time table
   API::Workspace_sptr loadDeadTimeTable() const override;
+  // Set time zero table
+  API::Workspace_sptr setTimeZeroTable() const override;
 
 private:
   DataObjects::Workspace2D &m_workspace;

--- a/Framework/DataHandling/src/LoadMuonNexusV2.cpp
+++ b/Framework/DataHandling/src/LoadMuonNexusV2.cpp
@@ -126,6 +126,11 @@ void LoadMuonNexusV2::init() {
                   "A vector of time zero values");
 
   declareProperty(
+      std::make_unique<WorkspaceProperty<Workspace>>(
+          "TimeZeroTable", "", Direction::Output, PropertyMode::Optional),
+      "TableWorkspace containing time zero values per spectra.");
+
+  declareProperty(
       "CorrectTime", true,
       "Boolean flag controlling whether time should be corrected by timezero.",
       Direction::Input);
@@ -170,6 +175,14 @@ void LoadMuonNexusV2::execLoader() {
   auto deadtimeTable = m_loadMuonStrategy->loadDeadTimeTable();
   if (!getPropertyValue("DeadTimeTable").empty()) {
     setProperty("DeadTimeTable", deadtimeTable);
+  }
+
+  // Time Zero table should be returned if found
+  const std::vector<double> timeZeros = getProperty("TimeZeroList");
+  if (!timeZeros.empty()) {
+    // Create table and set property
+    //setProperty("TimeZeroTable",
+      //          m_loadMuonStrategy->createTimeZeroTable(timeZeros));
   }
 }
 

--- a/Framework/DataHandling/src/LoadMuonNexusV2.cpp
+++ b/Framework/DataHandling/src/LoadMuonNexusV2.cpp
@@ -182,7 +182,7 @@ void LoadMuonNexusV2::execLoader() {
   // Time Zero table should be returned if found
   if (!getPropertyValue("TimeZerotable").empty()) {
     // Create table and set property]
-    auto timeZeroTable = m_loadMuonStrategy->setTimeZeroTable();
+    auto timeZeroTable = m_loadMuonStrategy->getTimeZeroTable();
     setProperty("TimeZeroTable", timeZeroTable);
   }
 }

--- a/Framework/DataHandling/src/LoadMuonNexusV2.cpp
+++ b/Framework/DataHandling/src/LoadMuonNexusV2.cpp
@@ -181,7 +181,7 @@ void LoadMuonNexusV2::execLoader() {
 
   // Time Zero table should be returned if found
   if (!getPropertyValue("TimeZerotable").empty()) {
-    // Create table and set property]
+    // Create table and set property
     auto timeZeroTable = m_loadMuonStrategy->getTimeZeroTable();
     setProperty("TimeZeroTable", timeZeroTable);
   }

--- a/Framework/DataHandling/src/LoadMuonNexusV2.cpp
+++ b/Framework/DataHandling/src/LoadMuonNexusV2.cpp
@@ -8,11 +8,13 @@
 #include "MantidAPI/Axis.h"
 #include "MantidAPI/FileProperty.h"
 #include "MantidAPI/RegisterFileLoader.h"
+#include "MantidAPI/TableRow.h"
 #include "MantidAPI/WorkspaceFactory.h"
 #include "MantidAPI/WorkspaceGroup.h"
 #include "MantidDataHandling/LoadISISNexus2.h"
 #include "MantidDataHandling/MultiPeriodLoadMuonStrategy.h"
 #include "MantidDataHandling/SinglePeriodLoadMuonStrategy.h"
+#include "MantidDataObjects/TableWorkspace.h"
 #include "MantidDataObjects/Workspace2D.h"
 #include "MantidKernel/ArrayProperty.h"
 #include "MantidKernel/BoundedValidator.h"
@@ -178,11 +180,10 @@ void LoadMuonNexusV2::execLoader() {
   }
 
   // Time Zero table should be returned if found
-  const std::vector<double> timeZeros = getProperty("TimeZeroList");
-  if (!timeZeros.empty()) {
-    // Create table and set property
-    //setProperty("TimeZeroTable",
-      //          m_loadMuonStrategy->createTimeZeroTable(timeZeros));
+  if (!getPropertyValue("TimeZerotable").empty()) {
+    // Create table and set property]
+    auto timeZeroTable = m_loadMuonStrategy->setTimeZeroTable();
+    setProperty("TimeZeroTable", timeZeroTable);
   }
 }
 

--- a/Framework/DataHandling/src/LoadMuonStrategy.cpp
+++ b/Framework/DataHandling/src/LoadMuonStrategy.cpp
@@ -124,5 +124,25 @@ DataObjects::TableWorkspace_sptr LoadMuonStrategy::createDeadTimeTable(
   return deadTimesTable;
 }
 
+/**
+ * Creates a timezero table for the loaded detectors
+ * @param timeZeros :: Vector containing time zero values for each spectra
+ * @return TableWorkspace of time zeros
+ */
+DataObjects::TableWorkspace_sptr LoadMuonStrategy::createTimeZeroTable(
+    const std::vector<double> &timeZeros) const {
+  auto timeZeroTable = std::dynamic_pointer_cast<DataObjects::TableWorkspace>(
+      API::WorkspaceFactory::Instance().createTable("TableWorkspace"));
+
+  timeZeroTable->addColumn("double", "time zero");
+
+  for (size_t i = 0; i < timeZeros.size(); ++i) {
+    API::TableRow row = timeZeroTable->appendRow();
+    row << timeZeros[i];
+  }
+
+  return timeZeroTable;
+}
+
 } // namespace DataHandling
 } // namespace Mantid

--- a/Framework/DataHandling/src/LoadMuonStrategy.cpp
+++ b/Framework/DataHandling/src/LoadMuonStrategy.cpp
@@ -126,6 +126,7 @@ DataObjects::TableWorkspace_sptr LoadMuonStrategy::createDeadTimeTable(
 
 /**
  * Creates a timezero table for the loaded detectors
+ * @param numSpec :: Numer of spectra (number of rows in table)
  * @param timeZeros :: Vector containing time zero values for each spectra
  * @return TableWorkspace of time zeros
  */

--- a/Framework/DataHandling/src/LoadMuonStrategy.cpp
+++ b/Framework/DataHandling/src/LoadMuonStrategy.cpp
@@ -18,6 +18,29 @@
 namespace Mantid {
 namespace DataHandling {
 
+/**
+ * Creates a timezero table for the loaded detectors
+ * @param numSpec :: Numer of spectra (number of rows in table)
+ * @param timeZeros :: Vector containing time zero values for each spectra
+ * @return TableWorkspace of time zeros
+ */
+DataObjects::TableWorkspace_sptr
+createTimeZeroTable(const size_t numSpec,
+                    const std::vector<double> &timeZeros) {
+  Mantid::DataObjects::TableWorkspace_sptr timeZeroTable =
+      std::dynamic_pointer_cast<Mantid::DataObjects::TableWorkspace>(
+          Mantid::API::WorkspaceFactory::Instance().createTable(
+              "TableWorkspace"));
+  timeZeroTable->addColumn("double", "time zero");
+
+  for (size_t specNum = 0; specNum < numSpec; ++specNum) {
+    Mantid::API::TableRow row = timeZeroTable->appendRow();
+    row << timeZeros[specNum];
+  }
+
+  return timeZeroTable;
+}
+
 // Constructor
 LoadMuonStrategy::LoadMuonStrategy(Kernel::Logger &g_log, std::string filename,
                                    LoadMuonNexusV2NexusHelper &nexusLoader)
@@ -122,29 +145,6 @@ DataObjects::TableWorkspace_sptr LoadMuonStrategy::createDeadTimeTable(
   }
 
   return deadTimesTable;
-}
-
-/**
- * Creates a timezero table for the loaded detectors
- * @param numSpec :: Numer of spectra (number of rows in table)
- * @param timeZeros :: Vector containing time zero values for each spectra
- * @return TableWorkspace of time zeros
- */
-DataObjects::TableWorkspace_sptr LoadMuonStrategy::createTimeZeroTable(
-    const size_t numSpec, const std::vector<double> &timeZeros) const {
-  Mantid::DataObjects::TableWorkspace_sptr timeZeroTable =
-      std::dynamic_pointer_cast<Mantid::DataObjects::TableWorkspace>(
-          Mantid::API::WorkspaceFactory::Instance().createTable(
-              "TableWorkspace"));
-  assert(timeZeroTable);
-  timeZeroTable->addColumn("double", "time zero");
-
-  for (size_t specNum = 0; specNum < numSpec; ++specNum) {
-    Mantid::API::TableRow row = timeZeroTable->appendRow();
-    row << timeZeros[specNum];
-  }
-
-  return timeZeroTable;
 }
 
 } // namespace DataHandling

--- a/Framework/DataHandling/src/LoadMuonStrategy.cpp
+++ b/Framework/DataHandling/src/LoadMuonStrategy.cpp
@@ -130,15 +130,17 @@ DataObjects::TableWorkspace_sptr LoadMuonStrategy::createDeadTimeTable(
  * @return TableWorkspace of time zeros
  */
 DataObjects::TableWorkspace_sptr LoadMuonStrategy::createTimeZeroTable(
-    const std::vector<double> &timeZeros) const {
-  auto timeZeroTable = std::dynamic_pointer_cast<DataObjects::TableWorkspace>(
-      API::WorkspaceFactory::Instance().createTable("TableWorkspace"));
-
+    const size_t numSpec, const std::vector<double> &timeZeros) const {
+  Mantid::DataObjects::TableWorkspace_sptr timeZeroTable =
+      std::dynamic_pointer_cast<Mantid::DataObjects::TableWorkspace>(
+          Mantid::API::WorkspaceFactory::Instance().createTable(
+              "TableWorkspace"));
+  assert(timeZeroTable);
   timeZeroTable->addColumn("double", "time zero");
 
-  for (size_t i = 0; i < timeZeros.size(); ++i) {
-    API::TableRow row = timeZeroTable->appendRow();
-    row << timeZeros[i];
+  for (size_t specNum = 0; specNum < numSpec; ++specNum) {
+    Mantid::API::TableRow row = timeZeroTable->appendRow();
+    row << timeZeros[specNum];
   }
 
   return timeZeroTable;

--- a/Framework/DataHandling/src/LoadMuonStrategy.cpp
+++ b/Framework/DataHandling/src/LoadMuonStrategy.cpp
@@ -20,7 +20,7 @@ namespace DataHandling {
 
 /**
  * Creates a timezero table for the loaded detectors
- * @param numSpec :: Numer of spectra (number of rows in table)
+ * @param numSpec :: Number of spectra (number of rows in table)
  * @param timeZeros :: Vector containing time zero values for each spectra
  * @return TableWorkspace of time zeros
  */

--- a/Framework/DataHandling/src/LoadPSIMuonBin.cpp
+++ b/Framework/DataHandling/src/LoadPSIMuonBin.cpp
@@ -128,7 +128,8 @@ void LoadPSIMuonBin::init() {
                   "A vector of time zero values");
 
   declareProperty(
-      std::make_unique<Mantid::API::WorkspaceProperty<Mantid::API::ITableWorkspace>>(
+      std::make_unique<
+          Mantid::API::WorkspaceProperty<Mantid::API::ITableWorkspace>>(
           "TimeZeroTable", "", Mantid::Kernel::Direction::Output,
           Mantid::API::PropertyMode::Optional),
       "TableWorkspace of time zeros for each spectra");

--- a/Framework/DataHandling/src/LoadPSIMuonBin.cpp
+++ b/Framework/DataHandling/src/LoadPSIMuonBin.cpp
@@ -126,11 +126,13 @@ void LoadPSIMuonBin::init() {
   declareProperty(std::make_unique<Kernel::ArrayProperty<double>>(
                       "TimeZeroList", Kernel::Direction::Output),
                   "A vector of time zero values");
+
   declareProperty(
-      std::make_unique<Mantid::API::WorkspaceProperty<Mantid::API::Workspace>>(
+      std::make_unique<Mantid::API::WorkspaceProperty<Mantid::API::ITableWorkspace>>(
           "TimeZeroTable", "", Mantid::Kernel::Direction::Output,
           Mantid::API::PropertyMode::Optional),
-      "A table containing the time zero values");
+      "TableWorkspace of time zeros for each spectra");
+
   declareProperty(
       "CorrectTime", true,
       "Boolean flag controlling whether time should be corrected by timezero.",

--- a/Framework/DataHandling/src/MultiPeriodLoadMuonStrategy.cpp
+++ b/Framework/DataHandling/src/MultiPeriodLoadMuonStrategy.cpp
@@ -120,6 +120,20 @@ API::Workspace_sptr MultiPeriodLoadMuonStrategy::loadDeadTimeTable() const {
 }
 
 /**
+ * Sets time zero table from loaded time zeros
+ * Assumes all peridos have same time zero
+ * @returns :: Time zero table
+ */
+Workspace_sptr MultiPeriodLoadMuonStrategy::setTimeZeroTable() const {
+  const double timeZero = m_nexusLoader.loadTimeZeroFromNexusFile();
+  auto workspace =
+      std::dynamic_pointer_cast<Workspace2D>(m_workspaceGroup.getItem(0));
+  const auto numSpec = workspace->getNumberHistograms();
+  std::vector<double> timeZeros(numSpec, timeZero);
+  return createTimeZeroTable(numSpec, timeZeros);
+}
+
+/**
  * Finds the detectors which are loaded in the stored workspace group
  */
 std::vector<detid_t> MultiPeriodLoadMuonStrategy::getLoadedDetectors() {

--- a/Framework/DataHandling/src/MultiPeriodLoadMuonStrategy.cpp
+++ b/Framework/DataHandling/src/MultiPeriodLoadMuonStrategy.cpp
@@ -120,16 +120,15 @@ API::Workspace_sptr MultiPeriodLoadMuonStrategy::loadDeadTimeTable() const {
 }
 
 /**
- * Sets time zero table from loaded time zeros
+ * Gets time zero table from loaded time zeros
  * Assumes all peridos have same time zero
  * @returns :: Time zero table
  */
-Workspace_sptr MultiPeriodLoadMuonStrategy::setTimeZeroTable() const {
-  const double timeZero = m_nexusLoader.loadTimeZeroFromNexusFile();
+Workspace_sptr MultiPeriodLoadMuonStrategy::getTimeZeroTable() {
   auto workspace =
       std::dynamic_pointer_cast<Workspace2D>(m_workspaceGroup.getItem(0));
   const auto numSpec = workspace->getNumberHistograms();
-  std::vector<double> timeZeros(numSpec, timeZero);
+  auto timeZeros = m_nexusLoader.loadTimeZeroListFromNexusFile(numSpec);
   return createTimeZeroTable(numSpec, timeZeros);
 }
 

--- a/Framework/DataHandling/src/SinglePeriodLoadMuonStrategy.cpp
+++ b/Framework/DataHandling/src/SinglePeriodLoadMuonStrategy.cpp
@@ -94,13 +94,12 @@ Workspace_sptr SinglePeriodLoadMuonStrategy::loadDeadTimeTable() const {
   return createDeadTimeTable(m_detectors, deadTimes);
 }
 /**
- * Sets time zero table from loaded time zeros
+ * Gets time zero table from loaded time zeros
  * @returns :: Time zero table
  */
-Workspace_sptr SinglePeriodLoadMuonStrategy::setTimeZeroTable() const {
-  const double timeZero = m_nexusLoader.loadTimeZeroFromNexusFile();
+Workspace_sptr SinglePeriodLoadMuonStrategy::getTimeZeroTable() {
   const auto numSpec = m_workspace.getNumberHistograms();
-  std::vector<double> timeZeros(numSpec, timeZero);
+  auto timeZeros = m_nexusLoader.loadTimeZeroListFromNexusFile(numSpec);
   return createTimeZeroTable(numSpec, timeZeros);
 }
 /**

--- a/Framework/DataHandling/src/SinglePeriodLoadMuonStrategy.cpp
+++ b/Framework/DataHandling/src/SinglePeriodLoadMuonStrategy.cpp
@@ -94,6 +94,16 @@ Workspace_sptr SinglePeriodLoadMuonStrategy::loadDeadTimeTable() const {
   return createDeadTimeTable(m_detectors, deadTimes);
 }
 /**
+ * Sets time zero table from loaded time zeros
+ * @returns :: Time zero table
+ */
+Workspace_sptr SinglePeriodLoadMuonStrategy::setTimeZeroTable() const {
+  const double timeZero = m_nexusLoader.loadTimeZeroFromNexusFile();
+  const auto numSpec = m_workspace.getNumberHistograms();
+  std::vector<double> timeZeros(numSpec, timeZero);
+  return createTimeZeroTable(numSpec, timeZeros);
+}
+/**
  * Performs time-zero correction on the loaded workspace.
  */
 void SinglePeriodLoadMuonStrategy::applyTimeZeroCorrection() {

--- a/Framework/DataHandling/test/LoadMuonNexusV2Test.h
+++ b/Framework/DataHandling/test/LoadMuonNexusV2Test.h
@@ -124,6 +124,37 @@ public:
     TS_ASSERT_DELTA(deadTimeTable->Double(62, 1), 0.0073113599, 1e-6);
   }
 
+  void testExecWithTimeZeroTable() {
+    LoadMuonNexusV2 ld;
+    ld.initialize();
+    ld.setPropertyValue("Filename", "EMU00102347.nxs_v2");
+    ld.setPropertyValue("OutputWorkspace", "outWS");
+    ld.setPropertyValue("TimeZeroTable", "tzt");
+
+    TS_ASSERT_THROWS_NOTHING(ld.execute());
+    TS_ASSERT(ld.isExecuted());
+    // Verify that the output workspace exists
+    MatrixWorkspace_sptr output_ws;
+    TS_ASSERT_THROWS_NOTHING(
+        output_ws = AnalysisDataService::Instance().retrieveWS<MatrixWorkspace>(
+            "outWS"));
+
+    Workspace2D_sptr output2D =
+        std::dynamic_pointer_cast<Workspace2D>(output_ws);
+
+    TableWorkspace_sptr tbl;
+    TS_ASSERT_THROWS_NOTHING(
+        tbl =
+            AnalysisDataService::Instance().retrieveWS<TableWorkspace>("tzt"));
+    TS_ASSERT(tbl);
+    // Check number of rows and columns
+    TS_ASSERT_EQUALS(tbl->columnCount(), 1);
+    TS_ASSERT_EQUALS(tbl->rowCount(), output2D->getNumberHistograms());
+    TS_ASSERT_DELTA(tbl->Double(0, 0), 0.16, 0.001);
+    TS_ASSERT_DELTA(tbl->Double(47, 0), 0.16, 0.001);
+    TS_ASSERT_DELTA(tbl->Double(95, 0), 0.16, 0.001);
+  }
+
   void testExecWithGroupingTable() {
 
     LoadMuonNexusV2 ld;

--- a/Framework/DataHandling/test/LoadMuonNexusV2Test.h
+++ b/Framework/DataHandling/test/LoadMuonNexusV2Test.h
@@ -128,25 +128,20 @@ public:
     LoadMuonNexusV2 ld;
     ld.initialize();
     ld.setPropertyValue("Filename", "EMU00102347.nxs_v2");
-    ld.setPropertyValue("OutputWorkspace", "outWS");
+    ld.setPropertyValue("OutputWorkspace", "outWs");
     ld.setPropertyValue("TimeZeroTable", "tzt");
+    ld.setRethrows(true);
+    auto &ads = AnalysisDataService::Instance();
 
-    TS_ASSERT_THROWS_NOTHING(ld.execute());
-    TS_ASSERT(ld.isExecuted());
-    // Verify that the output workspace exists
-    MatrixWorkspace_sptr output_ws;
-    TS_ASSERT_THROWS_NOTHING(
-        output_ws = AnalysisDataService::Instance().retrieveWS<MatrixWorkspace>(
-            "outWS"));
+    ld.execute();
+    // Verify that the output workspaces exist
+    TS_ASSERT(ads.doesExist("outWs"));
+    TS_ASSERT(ads.doesExist("tzt"));
 
-    Workspace2D_sptr output2D =
-        std::dynamic_pointer_cast<Workspace2D>(output_ws);
+    Workspace2D_sptr output2D = std::dynamic_pointer_cast<Workspace2D>(
+        ads.retrieveWS<MatrixWorkspace>("outWs"));
+    TableWorkspace_sptr tbl = ads.retrieveWS<TableWorkspace>("tzt");
 
-    TableWorkspace_sptr tbl;
-    TS_ASSERT_THROWS_NOTHING(
-        tbl =
-            AnalysisDataService::Instance().retrieveWS<TableWorkspace>("tzt"));
-    TS_ASSERT(tbl);
     // Check number of rows and columns
     TS_ASSERT_EQUALS(tbl->columnCount(), 1);
     TS_ASSERT_EQUALS(tbl->rowCount(), output2D->getNumberHistograms());

--- a/Framework/DataHandling/test/LoadPSIMuonBinTest.h
+++ b/Framework/DataHandling/test/LoadPSIMuonBinTest.h
@@ -194,7 +194,6 @@ public:
   void test_time_zero_list_loaded_correctly() {
     LoadPSIMuonBin alg;
     alg.initialize();
-    alg.isInitialized();
     alg.setProperty("SearchForTempFile", false);
 
     alg.setProperty("Filename", getTestFilePath("deltat_tdc_dolly_1529.bin"));
@@ -214,20 +213,15 @@ public:
   void test_time_zero_table_loaded_correctly() {
     LoadPSIMuonBin alg;
     alg.initialize();
-    alg.isInitialized();
     alg.setProperty("SearchForTempFile", false);
-
     alg.setProperty("Filename", getTestFilePath("deltat_tdc_dolly_1529.bin"));
     alg.setProperty("OutputWorkspace", "ws");
     alg.setPropertyValue("TimeZeroTable", "tzt");
     alg.execute();
 
-    ITableWorkspace_sptr tbl;
-    TS_ASSERT_THROWS_NOTHING(
-        tbl =
-            AnalysisDataService::Instance().retrieveWS<TableWorkspace>("tzt"));
+    auto &ads = AnalysisDataService::Instance();
+    ITableWorkspace_sptr tbl = ads.retrieveWS<TableWorkspace>("tzt");
 
-    TS_ASSERT(tbl);
     TS_ASSERT_EQUALS(tbl->columnCount(), 1);
     TS_ASSERT_EQUALS(tbl->getColumnNames(),
                      std::vector<std::string>{"time zero"});
@@ -241,7 +235,6 @@ public:
   void test_dead_time_table_loaded_correctly() {
     LoadPSIMuonBin alg;
     alg.initialize();
-    alg.isInitialized();
     alg.setProperty("SearchForTempFile", false);
 
     alg.setProperty("Filename", getTestFilePath("deltat_tdc_dolly_1529.bin"));
@@ -249,12 +242,9 @@ public:
     alg.setPropertyValue("DeadTimeTable", "dtt");
     alg.execute();
 
-    ITableWorkspace_sptr tbl;
-    TS_ASSERT_THROWS_NOTHING(
-        tbl =
-            AnalysisDataService::Instance().retrieveWS<TableWorkspace>("dtt"));
+    auto &ads = AnalysisDataService::Instance();
+    ITableWorkspace_sptr tbl = ads.retrieveWS<TableWorkspace>("dtt");
 
-    TS_ASSERT(tbl);
     TS_ASSERT_EQUALS(tbl->columnCount(), 2);
     std::vector<std::string> colNames{"spectrum", "dead-time"};
     TS_ASSERT_EQUALS(tbl->getColumnNames(), colNames);

--- a/Framework/DataHandling/test/LoadPSIMuonBinTest.h
+++ b/Framework/DataHandling/test/LoadPSIMuonBinTest.h
@@ -219,22 +219,25 @@ public:
 
     alg.setProperty("Filename", getTestFilePath("deltat_tdc_dolly_1529.bin"));
     alg.setProperty("OutputWorkspace", "ws");
-    alg.setProperty("TimeZeroTable", "tzt");
+    alg.setPropertyValue("TimeZeroTable", "tzt");
     alg.execute();
 
     ITableWorkspace_sptr tbl;
     TS_ASSERT_THROWS_NOTHING(
-        tbl = AnalysisDataService::Instance().retrieveWS<TableWorkspace>("tzt"));
+        tbl =
+            AnalysisDataService::Instance().retrieveWS<TableWorkspace>("tzt"));
 
+    TS_ASSERT(tbl);
     TS_ASSERT_EQUALS(tbl->columnCount(), 1);
-    TS_ASSERT_EQUALS(tbl->getColumnNames(), std::vector<std::string>{"time zero"});
+    TS_ASSERT_EQUALS(tbl->getColumnNames(),
+                     std::vector<std::string>{"time zero"});
     TS_ASSERT_EQUALS(tbl->rowCount(), 4);
     TS_ASSERT_DELTA(tbl->getColumn(0)->toDouble(0), 0.1582, 0.0001);
     TS_ASSERT_DELTA(tbl->getColumn(0)->toDouble(1), 0.1553, 0.0001);
     TS_ASSERT_DELTA(tbl->getColumn(0)->toDouble(2), 0.1592, 0.0001);
     TS_ASSERT_DELTA(tbl->getColumn(0)->toDouble(3), 0.1602, 0.0001);
   }
-  
+
   void test_dead_time_table_loaded_correctly() {
     LoadPSIMuonBin alg;
     alg.initialize();
@@ -243,7 +246,7 @@ public:
 
     alg.setProperty("Filename", getTestFilePath("deltat_tdc_dolly_1529.bin"));
     alg.setProperty("OutputWorkspace", "ws");
-    alg.setProperty("DeadTimeTable", "dtt");
+    alg.setPropertyValue("DeadTimeTable", "dtt");
     alg.execute();
 
     ITableWorkspace_sptr tbl;
@@ -251,8 +254,9 @@ public:
         tbl =
             AnalysisDataService::Instance().retrieveWS<TableWorkspace>("dtt"));
 
+    TS_ASSERT(tbl);
     TS_ASSERT_EQUALS(tbl->columnCount(), 2);
-    std::vector<std::string> colNames{"spectrum","dead-time"};
+    std::vector<std::string> colNames{"spectrum", "dead-time"};
     TS_ASSERT_EQUALS(tbl->getColumnNames(), colNames);
     TS_ASSERT_EQUALS(tbl->rowCount(), 4);
     TS_ASSERT_EQUALS(tbl->getColumn(0)->toDouble(0), 1.0);
@@ -264,7 +268,7 @@ public:
     TS_ASSERT_EQUALS(tbl->getColumn(0)->toDouble(3), 4.0);
     TS_ASSERT_EQUALS(tbl->getColumn(1)->toDouble(3), 0.0);
   }
-  
+
   void test_uncorected_time_loaded_if_corrected_time_flag_is_false() {
     LoadPSIMuonBin alg;
     alg.initialize();

--- a/Framework/DataHandling/test/LoadPSIMuonBinTest.h
+++ b/Framework/DataHandling/test/LoadPSIMuonBinTest.h
@@ -13,11 +13,13 @@
 #include "MantidAPI/MatrixWorkspace.h"
 #include "MantidAPI/Sample.h"
 #include "MantidDataHandling/LoadPSIMuonBin.h"
+#include "MantidDataObjects/TableWorkspace.h"
 #include "MantidDataObjects/Workspace2D.h"
 #include "MantidKernel/FileDescriptor.h"
 
 using namespace Mantid;
 using namespace Mantid::DataHandling;
+using namespace Mantid::DataObjects;
 using namespace Mantid::API;
 using namespace Mantid::Kernel;
 
@@ -209,6 +211,60 @@ public:
     AnalysisDataService::Instance().remove("ws");
   }
 
+  void test_time_zero_table_loaded_correctly() {
+    LoadPSIMuonBin alg;
+    alg.initialize();
+    alg.isInitialized();
+    alg.setProperty("SearchForTempFile", false);
+
+    alg.setProperty("Filename", getTestFilePath("deltat_tdc_dolly_1529.bin"));
+    alg.setProperty("OutputWorkspace", "ws");
+    alg.setProperty("TimeZeroTable", "tzt");
+    alg.execute();
+
+    ITableWorkspace_sptr tbl;
+    TS_ASSERT_THROWS_NOTHING(
+        tbl = AnalysisDataService::Instance().retrieveWS<TableWorkspace>("tzt"));
+
+    TS_ASSERT_EQUALS(tbl->columnCount(), 1);
+    TS_ASSERT_EQUALS(tbl->getColumnNames(), std::vector<std::string>{"time zero"});
+    TS_ASSERT_EQUALS(tbl->rowCount(), 4);
+    TS_ASSERT_DELTA(tbl->getColumn(0)->toDouble(0), 0.1582, 0.0001);
+    TS_ASSERT_DELTA(tbl->getColumn(0)->toDouble(1), 0.1553, 0.0001);
+    TS_ASSERT_DELTA(tbl->getColumn(0)->toDouble(2), 0.1592, 0.0001);
+    TS_ASSERT_DELTA(tbl->getColumn(0)->toDouble(3), 0.1602, 0.0001);
+  }
+  
+  void test_dead_time_table_loaded_correctly() {
+    LoadPSIMuonBin alg;
+    alg.initialize();
+    alg.isInitialized();
+    alg.setProperty("SearchForTempFile", false);
+
+    alg.setProperty("Filename", getTestFilePath("deltat_tdc_dolly_1529.bin"));
+    alg.setProperty("OutputWorkspace", "ws");
+    alg.setProperty("DeadTimeTable", "dtt");
+    alg.execute();
+
+    ITableWorkspace_sptr tbl;
+    TS_ASSERT_THROWS_NOTHING(
+        tbl =
+            AnalysisDataService::Instance().retrieveWS<TableWorkspace>("dtt"));
+
+    TS_ASSERT_EQUALS(tbl->columnCount(), 2);
+    std::vector<std::string> colNames{"spectrum","dead-time"};
+    TS_ASSERT_EQUALS(tbl->getColumnNames(), colNames);
+    TS_ASSERT_EQUALS(tbl->rowCount(), 4);
+    TS_ASSERT_EQUALS(tbl->getColumn(0)->toDouble(0), 1.0);
+    TS_ASSERT_EQUALS(tbl->getColumn(1)->toDouble(0), 0.0);
+    TS_ASSERT_EQUALS(tbl->getColumn(0)->toDouble(1), 2.0);
+    TS_ASSERT_EQUALS(tbl->getColumn(1)->toDouble(1), 0.0);
+    TS_ASSERT_EQUALS(tbl->getColumn(0)->toDouble(2), 3.0);
+    TS_ASSERT_EQUALS(tbl->getColumn(1)->toDouble(2), 0.0);
+    TS_ASSERT_EQUALS(tbl->getColumn(0)->toDouble(3), 4.0);
+    TS_ASSERT_EQUALS(tbl->getColumn(1)->toDouble(3), 0.0);
+  }
+  
   void test_uncorected_time_loaded_if_corrected_time_flag_is_false() {
     LoadPSIMuonBin alg;
     alg.initialize();

--- a/Framework/Muon/inc/MantidMuon/MuonPreProcess.h
+++ b/Framework/Muon/inc/MantidMuon/MuonPreProcess.h
@@ -79,12 +79,12 @@ private:
 
   /// Crop workspace with single xMin and xMax values
   MatrixWorkspace_sptr cropWithSingleValues(MatrixWorkspace_sptr ws,
-                                            const double &xMin,
-                                            const double &xMax);
+                                            const double xMin,
+                                            const double xMax);
 
   /// Crop workspace with vector of doubles
   MatrixWorkspace_sptr cropWithVectors(MatrixWorkspace_sptr ws,
-                                       const double &xMin, const double &xMax);
+                                       const double xMin, const double xMax);
 };
 
 } // namespace Muon

--- a/Framework/Muon/inc/MantidMuon/MuonPreProcess.h
+++ b/Framework/Muon/inc/MantidMuon/MuonPreProcess.h
@@ -54,9 +54,8 @@ private:
   MatrixWorkspace_sptr applyTimeOffset(MatrixWorkspace_sptr ws,
                                        const double &offset);
 
-  MatrixWorkspace_sptr
-  applyTimeZeroVector(MatrixWorkspace_sptr ws,
-                      const std::vector<double> &timeZeros);
+  MatrixWorkspace_sptr applyTimeZeroTable(MatrixWorkspace_sptr ws,
+                                          const TableWorkspace_sptr &tz);
 
   MatrixWorkspace_sptr applyCropping(MatrixWorkspace_sptr ws,
                                      const double &xMin, const double &xMax);

--- a/Framework/Muon/inc/MantidMuon/MuonPreProcess.h
+++ b/Framework/Muon/inc/MantidMuon/MuonPreProcess.h
@@ -54,6 +54,10 @@ private:
   MatrixWorkspace_sptr applyTimeOffset(MatrixWorkspace_sptr ws,
                                        const double &offset);
 
+  MatrixWorkspace_sptr
+  applyTimeZeroVector(MatrixWorkspace_sptr ws,
+                      const std::vector<double> &timeZeros);
+
   MatrixWorkspace_sptr applyCropping(MatrixWorkspace_sptr ws,
                                      const double &xMin, const double &xMax);
 

--- a/Framework/Muon/inc/MantidMuon/MuonPreProcess.h
+++ b/Framework/Muon/inc/MantidMuon/MuonPreProcess.h
@@ -71,8 +71,20 @@ private:
   /// Perform validation of inputs to the algorithm
   std::map<std::string, std::string> validateInputs() override;
 
+  /// Validates the tables used in the alg (called in validateInputs)
+  void validateTableInputs(std::map<std::string, std::string> &errors);
+
   /// Allow WorkspaceGroup property to function correctly.
   bool checkGroups() override;
+
+  /// Crop workspace with single xMin and xMax values
+  MatrixWorkspace_sptr cropWithSingleValues(MatrixWorkspace_sptr ws,
+                                            const double &xMin,
+                                            const double &xMax);
+
+  /// Crop workspace with vector of doubles
+  MatrixWorkspace_sptr cropWithVectors(MatrixWorkspace_sptr ws,
+                                       const double &xMin, const double &xMax);
 };
 
 } // namespace Muon

--- a/Framework/Muon/src/MuonPreProcess.cpp
+++ b/Framework/Muon/src/MuonPreProcess.cpp
@@ -68,17 +68,6 @@ void MuonPreProcess::init() {
                   Direction::Input);
 
   declareProperty(
-      std::make_unique<ArrayProperty<double>>("TimeOffsetVector",
-                                              Direction::Input),
-      "An array of time offsets which correspond to each spectra, if "
-      "length one the same offset is assumed for all spectra");
-
-  declareProperty(std::make_unique<ArrayProperty<double>>("TimeZeroVector",
-                                                          Direction::Input),
-                  "An array of time zeros which correspond to each spectra, if "
-                  "length one the same time zero is assumed for all spectra");
-
-  declareProperty(
       std::make_unique<WorkspaceProperty<TableWorkspace>>(
           "TimeZeroTable", "", Direction::Input, PropertyMode::Optional),
       "TableWorkspace with time zero information, used to apply time zero "
@@ -203,8 +192,6 @@ MatrixWorkspace_sptr MuonPreProcess::correctWorkspace(MatrixWorkspace_sptr ws) {
   double xMin = getProperty("TimeMin");
   double xMax = getProperty("TimeMax");
   std::vector<double> rebinParams = getProperty("RebinArgs");
-  std::vector<double> offsets = getProperty("TimeOffsetVector");
-  std::vector<double> timeZeros = getProperty("TimeZeroVector");
   TableWorkspace_sptr deadTimes = getProperty("DeadTimeTable");
   TableWorkspace_sptr timeZeroTable = getProperty("TimeZeroTable");
 

--- a/Framework/Muon/src/MuonPreProcess.cpp
+++ b/Framework/Muon/src/MuonPreProcess.cpp
@@ -131,7 +131,6 @@ std::map<std::string, std::string> MuonPreProcess::validateInputs() {
   // Check length of time zero vector is one or matches number of spectra
   if (auto ws = std::dynamic_pointer_cast<MatrixWorkspace>(inputWS)) {
     const std::vector<double> timeZeros = this->getProperty("TimeZeroVector");
-    // Need to make this optional
     if (!timeZeros.empty()) {
       if (timeZeros.size() != 1) {
         if (timeZeros.size() != ws->getNumberHistograms()) {
@@ -161,7 +160,7 @@ void MuonPreProcess::exec() {
 
   allPeriodsWS = correctWorkspaces(allPeriodsWS);
 
-  addPreProcessSampleLogs(allPeriodsWS);
+  //addPreProcessSampleLogs(allPeriodsWS);
 
   setProperty("OutputWorkspace", allPeriodsWS);
 }
@@ -248,18 +247,18 @@ MuonPreProcess::applyTimeZeroVector(MatrixWorkspace_sptr ws,
   } else {
     // Loop ws spectra and update x with offset values
     const auto numSpec = ws->getNumberHistograms();
-    PARALLEL_FOR_IF(Kernel::threadSafe(*ws))
+    //PARALLEL_FOR_IF(Kernel::threadSafe(*ws))
     for (int i = 0; i < numSpec; ++i) {
-      PARALLEL_START_INTERUPT_REGION
+      //PARALLEL_START_INTERUPT_REGION
 
       auto &xData = ws->mutableX(i);
       const double offset = timeZeros[i];
       std::transform(xData.begin(), xData.end(), xData.begin(),
                      [offset](double x) { return x + offset; });
 
-      PARALLEL_END_INTERUPT_REGION
+      //PARALLEL_END_INTERUPT_REGION
     }
-    PARALLEL_CHECK_INTERUPT_REGION
+    //PARALLEL_CHECK_INTERUPT_REGION
 
     return ws;
   }
@@ -269,6 +268,7 @@ MatrixWorkspace_sptr MuonPreProcess::applyCropping(MatrixWorkspace_sptr ws,
                                                    const double &xMin,
                                                    const double &xMax) {
   if (xMin != EMPTY_DBL() || xMax != EMPTY_DBL()) {
+    std::cout << "xMin : " << xMin << " , xMax : " << xMax << std::endl;
     IAlgorithm_sptr crop = createChildAlgorithm("CropWorkspace");
     crop->setProperty("InputWorkspace", ws);
     if (xMin != EMPTY_DBL())

--- a/Framework/Muon/src/MuonPreProcess.cpp
+++ b/Framework/Muon/src/MuonPreProcess.cpp
@@ -237,27 +237,25 @@ MatrixWorkspace_sptr MuonPreProcess::applyTimeOffset(MatrixWorkspace_sptr ws,
 
 MatrixWorkspace_sptr
 MuonPreProcess::applyTimeZeroTable(MatrixWorkspace_sptr ws,
-                                   const TableWorkspace_sptr &tz) {
-  if (tz != nullptr) {
-    const auto numSpec = ws->getNumberHistograms();
+                                   const TableWorkspace_sptr &timeZeroTable) {
+  auto cloneWs = cloneWorkspace(ws);
+  if (timeZeroTable != nullptr) {
+    const auto numSpec = cloneWs->getNumberHistograms();
     for (auto specNum = 0u; specNum < numSpec; ++specNum) {
-      auto &xData = ws->mutableX(specNum);
+      auto &xData = cloneWs->mutableX(specNum);
       for (auto &xValue : xData) {
-        API::TableRow row = tz->getRow(specNum);
+        API::TableRow row = timeZeroTable->getRow(specNum);
         xValue -= row.Double(0);
       }
     }
-    return ws;
-  } else {
-    return ws;
   }
+  return cloneWs;
 }
 
 MatrixWorkspace_sptr MuonPreProcess::applyCropping(MatrixWorkspace_sptr ws,
                                                    const double &xMin,
                                                    const double &xMax) {
   if (xMin != EMPTY_DBL() || xMax != EMPTY_DBL()) {
-    std::cout << "xMin : " << xMin << " , xMax : " << xMax << std::endl;
     IAlgorithm_sptr crop = createChildAlgorithm("CropWorkspace");
     crop->setProperty("InputWorkspace", ws);
     if (xMin != EMPTY_DBL())

--- a/Framework/Muon/src/MuonPreProcess.cpp
+++ b/Framework/Muon/src/MuonPreProcess.cpp
@@ -272,8 +272,8 @@ MatrixWorkspace_sptr MuonPreProcess::applyCropping(MatrixWorkspace_sptr ws,
 }
 
 MatrixWorkspace_sptr
-MuonPreProcess::cropWithSingleValues(MatrixWorkspace_sptr ws,
-                                     const double &xMin, const double &xMax) {
+MuonPreProcess::cropWithSingleValues(MatrixWorkspace_sptr ws, const double xMin,
+                                     const double xMax) {
   IAlgorithm_sptr crop = createChildAlgorithm("CropWorkspace");
   crop->setProperty("InputWorkspace", ws);
   if (xMin != EMPTY_DBL())
@@ -285,8 +285,8 @@ MuonPreProcess::cropWithSingleValues(MatrixWorkspace_sptr ws,
 }
 
 MatrixWorkspace_sptr MuonPreProcess::cropWithVectors(MatrixWorkspace_sptr ws,
-                                                     const double &xMin,
-                                                     const double &xMax) {
+                                                     const double xMin,
+                                                     const double xMax) {
   std::vector<double> xMinVec;
   std::vector<double> xMaxVec;
 

--- a/Framework/Muon/src/MuonPreProcess.cpp
+++ b/Framework/Muon/src/MuonPreProcess.cpp
@@ -196,8 +196,8 @@ MatrixWorkspace_sptr MuonPreProcess::correctWorkspace(MatrixWorkspace_sptr ws) {
   TableWorkspace_sptr timeZeroTable = getProperty("TimeZeroTable");
 
   ws = applyDTC(ws, deadTimes);
-  ws = applyTimeOffset(ws, offset);
   ws = applyTimeZeroTable(ws, timeZeroTable);
+  ws = applyTimeOffset(ws, offset);
   ws = applyCropping(ws, xMin, xMax);
   ws = applyRebinning(ws, rebinParams);
 

--- a/Framework/Muon/test/MuonPreProcessTest.h
+++ b/Framework/Muon/test/MuonPreProcessTest.h
@@ -68,14 +68,14 @@ IAlgorithm_sptr setUpAlgorithmWithTimeOffset(const MatrixWorkspace_sptr &ws,
   return alg;
 }
 
-// Set up algorithm with TimeZeroVectors applied
+// Set up algorithm with TimeZeroTable applied
 IAlgorithm_sptr
-setUpAlgorithmWithTimeZeroVector(const MatrixWorkspace_sptr &ws,
-                                 const std::vector<double> &timeZeros) {
+setUpAlgorithmWithTimeZeroTable(const MatrixWorkspace_sptr &ws,
+                                const ITableWorkspace_sptr &timeZeroTable) {
   setUpADSWithWorkspace setup(ws);
   IAlgorithm_sptr alg =
       algorithmWithoutOptionalPropertiesSet(setup.inputWSName);
-  alg->setProperty("TimeZeroVector", timeZeros);
+  alg->setProperty("TimeZeroTable", timeZeroTable);
   return alg;
 }
 
@@ -229,28 +229,34 @@ public:
   }
 
   // --------------------------------------------------------------------------
-  // Input property validation : Time Zero vector
+  // Input property validation : Time Zero Table
   // --------------------------------------------------------------------------
 
-  void
-  test_validation_fails_if_timezerovector_length_is_greater_than_number_of_spectra() {
-    // Workspace has 2 spectra, time zero vector has 3 values
-    auto ws = createCountsWorkspace(2, 10, 0.0);
-    std::vector<double> timeZeros = {0.5, 0.75, 0.5};
+  void test_successful_execution_with_valid_time_zero_table() {
+    // workspace has 2 spectra, dead time table has 5 rows
+    auto ws = createCountsWorkspace(5, 10, 0.0);
+    std::vector<double> timeZeros = {0.5, 1.0, 1.5, 2.0, 2.5};
+    ITableWorkspace_sptr timeZeroTable = createTimeZeroTable(5, timeZeros);
 
-    auto alg = setUpAlgorithmWithTimeZeroVector(ws, timeZeros);
-
-    TS_ASSERT_THROWS(alg->execute(), const std::runtime_error &);
-  }
-
-  void test_validation_okay_if_timezerovector_length_one() {
-    // Workspace has 2 spectra, time zero vector has 1 value
-    auto ws = createCountsWorkspace(2, 10, 0.0);
-    std::vector<double> timeZeros = {0.5};
-
-    auto alg = setUpAlgorithmWithTimeZeroVector(ws, timeZeros);
+    auto alg = setUpAlgorithmWithTimeZeroTable(ws, timeZeroTable);
 
     TS_ASSERT_THROWS_NOTHING(alg->execute());
+  }
+
+  void test_cannot_execute_on_invalid_time_zero_table() {
+    // workspace has 2 spectra, dead time table has 5 rows
+    auto ws = createCountsWorkspace(2, 10, 0.0);
+    std::vector<double> timeZeros = {0.5, 1.0, 1.5, 2.0, 2.5};
+    ITableWorkspace_sptr timeZeroTable = createTimeZeroTable(5, timeZeros);
+
+    auto alg = setUpAlgorithmWithTimeZeroTable(ws, timeZeroTable);
+    auto errors = alg->validateInputs();
+    const auto expected = "TimeZeroTable must have as many rows as there are "
+                          "spectra in InputWorkspace. Use TimeOffset to apply "
+                          "same time correcton to all data";
+
+    TS_ASSERT_THROWS(alg->execute(), const std::runtime_error &);
+    TS_ASSERT_EQUALS(errors["TimeZeroTable"], expected);
   }
 
   // --------------------------------------------------------------------------
@@ -361,65 +367,41 @@ public:
   }
 
   // --------------------------------------------------------------------------
-  // Correct output : Time Zero Vector
+  // Correct output : Time Zero Table
   // --------------------------------------------------------------------------
 
-  void test_vector_size_one_applied_correctly() {
-    auto ws = createCountsWorkspace(3, 10, 0.0);
+  void test_that_empty_time_zero_table_applied_correctly() {
+    auto ws = createCountsWorkspace(2, 2, 0.0);
+    std::vector<double> timeZeros = {0, 0};
+    auto timeZeroTable = createTimeZeroTable(2, timeZeros);
 
-    const std::vector<double> timeZeros = {0.5};
-    auto alg = setUpAlgorithmWithTimeZeroVector(ws, timeZeros);
-
+    auto alg = setUpAlgorithmWithTimeZeroTable(ws, timeZeroTable);
     alg->execute();
 
     auto wsOut = getOutputWorkspace(alg, 0);
-
-    // x-values
-    TS_ASSERT_DELTA(wsOut->readX(0)[0], 0.000 + 0.500, 0.001);
-    TS_ASSERT_DELTA(wsOut->readX(0)[1], 0.100 + 0.500, 0.001);
-    TS_ASSERT_DELTA(wsOut->readX(0)[10], 1.000 + 0.500, 0.001);
-    TS_ASSERT_DELTA(wsOut->readX(1)[0], 0.000 + 0.500, 0.001);
-    TS_ASSERT_DELTA(wsOut->readX(1)[1], 0.100 + 0.500, 0.001);
-    TS_ASSERT_DELTA(wsOut->readX(1)[10], 1.000 + 0.500, 0.001);
-    TS_ASSERT_DELTA(wsOut->readX(2)[0], 0.000 + 0.500, 0.001);
-    TS_ASSERT_DELTA(wsOut->readX(2)[1], 0.100 + 0.500, 0.001);
-    TS_ASSERT_DELTA(wsOut->readX(2)[10], 1.000 + 0.500, 0.001);
-    // y-values
-    TS_ASSERT_DELTA(wsOut->readY(0)[0], 0.0, 0.001);
-    TS_ASSERT_DELTA(wsOut->readY(0)[9], 9.0, 0.001);
-    TS_ASSERT_DELTA(wsOut->readY(1)[0], 10.0, 0.001);
-    TS_ASSERT_DELTA(wsOut->readY(1)[9], 19.0, 0.001);
-    TS_ASSERT_DELTA(wsOut->readY(2)[0], 20.0, 0.001);
-    TS_ASSERT_DELTA(wsOut->readY(2)[9], 29.0, 0.001);
+    TS_ASSERT_DELTA(wsOut->readX(0)[0], 0.0, 0.01);
+    TS_ASSERT_DELTA(wsOut->readX(0)[1], 0.5, 0.01);
+    TS_ASSERT_DELTA(wsOut->readX(0)[2], 1.0, 0.01);
+    TS_ASSERT_DELTA(wsOut->readX(1)[0], 0.0, 0.01);
+    TS_ASSERT_DELTA(wsOut->readX(1)[1], 0.5, 0.01);
+    TS_ASSERT_DELTA(wsOut->readX(1)[2], 1.0, 0.01);
   }
 
-  void test_vector_size_same_as_number_spectra_applied_correctly() {
-    auto ws = createCountsWorkspace(3, 10, 0.0);
+  void test_not_empty_time_zero_table_applied_correctly() {
+    auto ws = createCountsWorkspace(2, 2, 0.0);
+    std::vector<double> timeZeros = {0.25, -0.25}; // Applied as minus in alg
+    auto timeZeroTable = createTimeZeroTable(2, timeZeros);
 
-    const std::vector<double> timeZeros = {0.25, 0.5, 0.75};
-    auto alg = setUpAlgorithmWithTimeZeroVector(ws, timeZeros);
-
+    auto alg = setUpAlgorithmWithTimeZeroTable(ws, timeZeroTable);
     alg->execute();
 
     auto wsOut = getOutputWorkspace(alg, 0);
-
-    // x-values
-    TS_ASSERT_DELTA(wsOut->readX(0)[0], 0.000 + 0.250, 0.001);
-    TS_ASSERT_DELTA(wsOut->readX(0)[1], 0.100 + 0.250, 0.001);
-    TS_ASSERT_DELTA(wsOut->readX(0)[10], 1.000 + 0.250, 0.001);
-    TS_ASSERT_DELTA(wsOut->readX(1)[0], 0.000 + 0.500, 0.001);
-    TS_ASSERT_DELTA(wsOut->readX(1)[1], 0.100 + 0.500, 0.001);
-    TS_ASSERT_DELTA(wsOut->readX(1)[10], 1.000 + 0.500, 0.001);
-    TS_ASSERT_DELTA(wsOut->readX(2)[0], 0.000 + 0.750, 0.001);
-    TS_ASSERT_DELTA(wsOut->readX(2)[1], 0.100 + 0.750, 0.001);
-    TS_ASSERT_DELTA(wsOut->readX(2)[10], 1.000 + 0.750, 0.001);
-    // y-values
-    TS_ASSERT_DELTA(wsOut->readY(0)[0], 0.0, 0.001);
-    TS_ASSERT_DELTA(wsOut->readY(0)[9], 9.0, 0.001);
-    TS_ASSERT_DELTA(wsOut->readY(1)[0], 10.0, 0.001);
-    TS_ASSERT_DELTA(wsOut->readY(1)[9], 19.0, 0.001);
-    TS_ASSERT_DELTA(wsOut->readY(2)[0], 20.0, 0.001);
-    TS_ASSERT_DELTA(wsOut->readY(2)[9], 29.0, 0.001);
+    TS_ASSERT_DELTA(wsOut->readX(0)[0], 0.0 - 0.25, 0.01);
+    TS_ASSERT_DELTA(wsOut->readX(0)[1], 0.5 - 0.25, 0.01);
+    TS_ASSERT_DELTA(wsOut->readX(0)[2], 1.0 - 0.25, 0.01);
+    TS_ASSERT_DELTA(wsOut->readX(1)[0], 0.0 + 0.25, 0.01);
+    TS_ASSERT_DELTA(wsOut->readX(1)[1], 0.5 + 0.25, 0.01);
+    TS_ASSERT_DELTA(wsOut->readX(1)[2], 1.0 + 0.25, 0.01);
   }
 
   // --------------------------------------------------------------------------

--- a/Framework/Muon/test/MuonPreProcessTest.h
+++ b/Framework/Muon/test/MuonPreProcessTest.h
@@ -233,7 +233,7 @@ public:
   // --------------------------------------------------------------------------
 
   void test_successful_execution_with_valid_time_zero_table() {
-    // workspace has 2 spectra, dead time table has 5 rows
+    // workspace has 5 spectra, time zero table has 5 rows
     auto ws = createCountsWorkspace(5, 10, 0.0);
     std::vector<double> timeZeros = {0.5, 1.0, 1.5, 2.0, 2.5};
     ITableWorkspace_sptr timeZeroTable = createTimeZeroTable(5, timeZeros);
@@ -244,7 +244,7 @@ public:
   }
 
   void test_cannot_execute_on_invalid_time_zero_table() {
-    // workspace has 2 spectra, dead time table has 5 rows
+    // workspace has 2 spectra, time zero table has 5 rows
     auto ws = createCountsWorkspace(2, 10, 0.0);
     std::vector<double> timeZeros = {0.5, 1.0, 1.5, 2.0, 2.5};
     ITableWorkspace_sptr timeZeroTable = createTimeZeroTable(5, timeZeros);

--- a/Framework/TestHelpers/inc/MantidTestHelpers/MuonWorkspaceCreationHelper.h
+++ b/Framework/TestHelpers/inc/MantidTestHelpers/MuonWorkspaceCreationHelper.h
@@ -116,6 +116,12 @@ createMultiPeriodAsymmetryData(const int &nPeriods, size_t nspec, size_t maxt,
 Mantid::API::ITableWorkspace_sptr
 createDeadTimeTable(const size_t &nspec, std::vector<double> &deadTimes);
 
+/**
+ * Create a simple time zero TableWorkspace with one column (time zero)
+ */
+Mantid::API::ITableWorkspace_sptr
+createTimeZeroTable(const size_t &numSpec, std::vector<double> &timeZeros);
+
 // Creates a single - point workspace with instrument and runNumber set.
 Mantid::API::MatrixWorkspace_sptr
 createWorkspaceWithInstrumentandRun(const std::string &instrName, int runNumber,

--- a/Framework/TestHelpers/src/MuonWorkspaceCreationHelper.cpp
+++ b/Framework/TestHelpers/src/MuonWorkspaceCreationHelper.cpp
@@ -204,6 +204,32 @@ ITableWorkspace_sptr createDeadTimeTable(const size_t &nspec,
 }
 
 /**
+ * Create a simple time zero TableWorkspace with one column (time zero)
+ * @param numSpec :: The number of spectra (rows of the table)
+ * @param timeZeros :: Vector of time zeros for each spectra
+ * @return TableWorkspace with time zeros in each row for all spectra
+ */
+ITableWorkspace_sptr createTimeZeroTable(const size_t &numSpec,
+                                         std::vector<double> &timeZeros) {
+
+  auto timeZeroTable = std::dynamic_pointer_cast<ITableWorkspace>(
+      WorkspaceFactory::Instance().createTable("TableWorkspace"));
+
+  timeZeroTable->addColumn("double", "time zero");
+
+  if (timeZeros.size() != numSpec) {
+    return timeZeroTable;
+  }
+
+  for (size_t specNum = 0; specNum < numSpec; ++specNum) {
+    TableRow row = timeZeroTable->appendRow();
+    row << timeZeros[specNum];
+  }
+
+  return timeZeroTable;
+}
+
+/**
  * Creates a single-point workspace with instrument and runNumber set.
  * @param instrName :: Instrument name e.g. MUSR
  * @param runNumber ::  e.g. 1000

--- a/docs/source/algorithms/LoadMuonNexusV2-v1.rst
+++ b/docs/source/algorithms/LoadMuonNexusV2-v1.rst
@@ -146,7 +146,7 @@ Output:
 .. testcode:: ExTimeZeroLoading
 
    # Load some spectra
-   ws, main_field_direction, time_zero, first_good_data, time_zero_list, dead_time_table, detector_grouping_table, time_zero_table = \
+   ws, main_field_direction, time_zero, first_good_data, time_zero_list, time_zero_table, dead_time_table, detector_grouping_table = \
       LoadMuonNexusV2(Filename="EMU00102347.nxs_v2",SpectrumMin=5,SpectrumMax=10,DeadTimeTable="deadTimeTable",TimeZeroTable="timeZeroTable")
   
    print('Single time zero value is {:.2g}'.format(time_zero))

--- a/docs/source/algorithms/LoadMuonNexusV2-v1.rst
+++ b/docs/source/algorithms/LoadMuonNexusV2-v1.rst
@@ -146,8 +146,8 @@ Output:
 .. testcode:: ExTimeZeroLoading
 
    # Load some spectra
-   ws, main_field_direction, time_zero, first_good_data, time_zero_list, dead_time_table, detector_grouping_table = \
-      LoadMuonNexusV2(Filename="EMU00102347.nxs_v2",SpectrumMin=5,SpectrumMax=10,DeadTimeTable="deadTimeTable")
+   ws, main_field_direction, time_zero, first_good_data, time_zero_list, dead_time_table, detector_grouping_table, time_zero_table = \
+      LoadMuonNexusV2(Filename="EMU00102347.nxs_v2",SpectrumMin=5,SpectrumMax=10,DeadTimeTable="deadTimeTable",TimeZeroTable="timeZeroTable")
   
    print('Single time zero value is {:.2g}'.format(time_zero))
    print("TimeZeroList values are:")

--- a/docs/source/algorithms/MuonPreProcess-v1.rst
+++ b/docs/source/algorithms/MuonPreProcess-v1.rst
@@ -9,16 +9,17 @@
 Description
 -----------
 
-When interacting with the :ref:`Muon_Analysis-ref` interface, operations such as detector grouping, group and pair asymmetry are performed on data. As part of the workflow, several "pre-processing" steps are also necessary; such as rebinning and cropping the data, applying dead time corrections, and shifting the time axis by a fixed amount (sometimes referred to as "first good data").
+When interacting with the :ref:`Muon_Analysis-ref` interface, operations such as detector grouping, group and pair asymmetry are performed on data. As part of the workflow, several "pre-processing" steps are also necessary; such as rebinning and cropping the data, applying dead time corrections, applying time zero corrections, and shifting the time axis by a fixed amount (sometimes referred to as "first good data").
 
 This algorithm intends to capture the common pre-processing steps, which are not muon physics specific concepts, and apply them all at once to produce data which is ready for the muon-specific operations. This way, scripting the workflows of the :ref:`Muon_Analysis-ref` interface is much more intuitive and simple.
 
 Analysis
 ########
 
-As indicated in the input variable names to this algorithm; there are four distinct operations applied to the input data. In order of application these are;
+As indicated in the input variable names to this algorithm; there are five distinct operations applied to the input data. In order of application these are;
 
 #. Apply dead time correction through the **DeadTimeTable** input.
+#. Apply time zero correction through the **TimeZeroTable** input.
 #. Apply a time offset to the time axis through the **TimeOffset** input, which may be positive or negative. This time offset is directly added to all times within the workspace.
 #. Apply a cropping to the upper (lower) ends of the time axis via the **TimeMax** (**TimeMin**) input.
 #. Finally, apply a rebinning via **RebinArgs**, using the same syntax as in :ref:`algm-Rebin`.
@@ -27,7 +28,7 @@ The **InputWorkspace** can be a single workspace object, and multi period data i
 
 The **OutputWorkspace** is always a *Workspace Group*; for single period data the group only contains a single workspace. The reason for this is so that the muon algorithms MuonGroupingCounts, MuonGroupingAsymmetry and MuonPairingAsymmetry can expect a consistent input between single and multi period data, and where single period data is just a limiting case of multi period data.
 
-The four operations listed above correspond to a run of :ref:`algm-ApplyDeadTimeCorr`, :ref:`algm-ChangeBinOffset`, :ref:`algm-CropWorkspace` and :ref:`algm-Rebin` respectively; and so the documentation of these algorithms can be consulted for more detailed discussion of precisely how the operations are applied.
+Four of the operations listed above correspond to a run of :ref:`algm-ApplyDeadTimeCorr`, :ref:`algm-ChangeBinOffset`, :ref:`algm-CropWorkspace` and :ref:`algm-Rebin` respectively; and so the documentation of these algorithms can be consulted for more detailed discussion of precisely how the operations are applied. Time zero correction does not correspond to it's own algorithm.
 
 As already mentioned; the output of this algorithm can (and is intended to be) fed into one of the following algorithms;
 
@@ -168,7 +169,32 @@ Output:
 
     X values are : [ 0.  1.  2.  3.  4.  5.]
     Y values are : [ 100.3  201.2  302.8  201.2  100.3]
+	
+**Example - Applying only a time zero correction**
 
+.. testcode:: ExampleTimeZero
+
+    dataX = [0, 1, 2, 3, 4, 5] * 4
+	dataY = [100, 200, 300, 200, 100] * 4
+	input_workspace = CreateWorkspace(dataX, dataY, NSpec=4)
+	
+	# Create a time zero table
+	time_zero_table = CreateEmptyTableWorkspace()
+	time_zero_table.addColumn("double", "time zero")
+	[time_zero_table.addRow([i+2]) for i in range(4)]
+	
+	output_workspace = MuonPreProcess(InputWorkspace=input_workspace, 
+	                                  TimeZeroTable=time_zero_table)
+	print("X values are : {}".format(output_workspace[0].readX(0)))
+    print("Y values are : {}".format(output_workspace[0].readY(0)))						  
+	
+Output:
+
+.. testoutput:: ExampleTimeZero
+
+    X values are : [ -2.  -1.  0.  1.  2.  3.]
+    Y values are : [ 100.  200.  300.0  200.0  100.]
+	
 .. categories::
 
 .. sourcelink::

--- a/docs/source/algorithms/MuonPreProcess-v1.rst
+++ b/docs/source/algorithms/MuonPreProcess-v1.rst
@@ -185,15 +185,22 @@ Output:
     
     output_workspace = MuonPreProcess(InputWorkspace=input_workspace, 
                                       TimeZeroTable=time_zero_table)
-    print("X values are : {}".format(output_workspace[0].readX(0)))
-    print("Y values are : {}".format(output_workspace[0].readY(0)))						  
+    
+    print("X values are : [{:.0f}, {:.0f}, {:.0f}, {:.0f}, {:.0f}, {:.0f}]".format(
+        output_workspace[0].readX(0)[0],output_workspace[0].readX(0)[1],
+        output_workspace[0].readX(0)[2],output_workspace[0].readX(0)[3],
+        output_workspace[0].readX(0)[4],output_workspace[0].readX(0)[5]))
+    print("Y values are : [{:.0f}, {:.0f}, {:.0f}, {:.0f}, {:.0f}]".format(
+        output_workspace[0].readY(0)[0],output_workspace[0].readY(0)[1],
+        output_workspace[0].readY(0)[2],output_workspace[0].readY(0)[3],
+        output_workspace[0].readY(0)[4]))
 	
 Output:
 
 .. testoutput:: ExampleTimeZero
 
-    X values are : [ -2.  -1.  0.  1.  2.  3.]
-    Y values are : [ 100.  200.  300.0  200.0  100.]
+    X values are : [-2, -1, 0, 1, 2, 3]
+    Y values are : [100, 200, 300, 200, 100]
 	
 .. categories::
 

--- a/docs/source/algorithms/MuonPreProcess-v1.rst
+++ b/docs/source/algorithms/MuonPreProcess-v1.rst
@@ -175,17 +175,17 @@ Output:
 .. testcode:: ExampleTimeZero
 
     dataX = [0, 1, 2, 3, 4, 5] * 4
-	dataY = [100, 200, 300, 200, 100] * 4
-	input_workspace = CreateWorkspace(dataX, dataY, NSpec=4)
-	
-	# Create a time zero table
-	time_zero_table = CreateEmptyTableWorkspace()
-	time_zero_table.addColumn("double", "time zero")
-	[time_zero_table.addRow([i+2]) for i in range(4)]
-	
-	output_workspace = MuonPreProcess(InputWorkspace=input_workspace, 
-	                                  TimeZeroTable=time_zero_table)
-	print("X values are : {}".format(output_workspace[0].readX(0)))
+    dataY = [100, 200, 300, 200, 100] * 4
+    input_workspace = CreateWorkspace(dataX, dataY, NSpec=4)
+    
+    # Create a time zero table
+    time_zero_table = CreateEmptyTableWorkspace()
+    time_zero_table.addColumn("double", "time zero")
+    [time_zero_table.addRow([i+2]) for i in range(4)]
+    
+    output_workspace = MuonPreProcess(InputWorkspace=input_workspace, 
+                                      TimeZeroTable=time_zero_table)
+    print("X values are : {}".format(output_workspace[0].readX(0)))
     print("Y values are : {}".format(output_workspace[0].readY(0)))						  
 	
 Output:

--- a/docs/source/algorithms/MuonPreProcess-v1.rst
+++ b/docs/source/algorithms/MuonPreProcess-v1.rst
@@ -9,7 +9,7 @@
 Description
 -----------
 
-When interacting with the :ref:`Muon_Analysis-ref` interface, operations such as detector grouping, group and pair asymmetry are performed on data. As part of the workflow, several "pre-processing" steps are also necessary; such as rebinning and cropping the data, applying dead time corrections, applying time zero corrections, and shifting the time axis by a fixed amount (sometimes referred to as "first good data").
+When interacting with the :ref:`Muon_Analysis-ref` interface, operations such as detector grouping, group and pair asymmetry are performed on data. As part of the workflow, several "pre-processing" steps are also necessary; such as rebinning and cropping the data, applying dead time corrections and applying time zero corrections/shifting the time axis by a fixed amount (sometimes referred to as "first good data").
 
 This algorithm intends to capture the common pre-processing steps, which are not muon physics specific concepts, and apply them all at once to produce data which is ready for the muon-specific operations. This way, scripting the workflows of the :ref:`Muon_Analysis-ref` interface is much more intuitive and simple.
 

--- a/docs/source/release/v6.0.0/muon.rst
+++ b/docs/source/release/v6.0.0/muon.rst
@@ -5,8 +5,6 @@ MuSR Changes
 .. contents:: Table of Contents
    :local:
 
-=======
-
 .. warning:: **Developers:** Sort changes under appropriate heading
     putting new features at the top of the section, followed by
     improvements, followed by bug fixes.
@@ -54,5 +52,7 @@ Algorithms
 ----------
 - :ref:`algm-LoadElementalAnalysisData` algorithm was introduced for loading runs for the new Elemental Analysis GUI, enabling it to be registered by WorkspaceHistory.
 - The functions RemoveExpDecay and EstimateMuonAsymmetryFromCounts were modified to use point data instead of bin edges for removing the exponential.
+- LoadPSIMuonBin and LoadMuonNexusV2 can now return a table of time zeros
+- MuonPreProcess has a new input 'TimeZeroTable' which requires a TableWorkspace of time zero values
 
 :ref:`Release 6.0.0 <v6.0.0>`


### PR DESCRIPTION
**Blocked by #30037** 

**Description of work.**
Updated LoadPSIMuonBin to return a TableWorkspace of time zero values. The same for LoadMuonNexusV2. Updated MuonPreProcess to take a new input TimeZeroTable which is a TableWorkspace. This table is then used to apply time zero correction to all spectra individually rather than using a single value for all spectra which is currently in place.

**To test:**
To test make sure you have access to the data archive or the files from the scripts

**LoadPSIMuonBin loader**

1. Run below script

```
ws, first, last, timezero, dead, field, timezerolist, timezerotable = LoadPSIMuonBin(Filename='deltat_tdc_dolly_1529.bin', OutputWorkspace='1529_corrected', CorrectTime=True)
print(timezerolist)
```
2. Check the values output from timezerolist match those stored in the table workspace produced called timezerotable
3. Also check if you remove all the return arguments (i.e. ws, first, last etc.) no timezerotable is produced

**LoadMuonNexusV2 loader**

1. Run below script

```
ws, field, timezero, first, timezerolist, timezerotable, dead, group = LoadMuonNexusV2(FileName='EMU00102347.nxs_v2',OutputWorkspace="102347_corrected", CorrectTime=True)
print(timezerolist)
```
2. Check the values output from timezerolist match those stored in the table workspace produced called timezerotable
3. Also check if you remove all the return arguments (i.e. ws, first, last etc.) no timezerotable is produced

**Muon PreProcess**

1. Use the script below to load in some data, once corrected and again uncorrected
```
LoadPSIMuonBin(Filename='deltat_tdc_dolly_1529.bin', OutputWorkspace='1529_corrected', CorrectTime=True)
ws, first, last, timezero, dead, field, timezerolist, timezerotable = LoadPSIMuonBin(Filename='deltat_tdc_dolly_1529.bin', OutputWorkspace='1529_uncorrected', CorrectTime=False)
```

2. Check that these data are in fact different and that the corrected X data looks to be "shifted" by some value compared to uncorrected

3. Now run the below script to correct the uncorrected data to be exactly the same as when loaded with CorrectTime=True
```
tbl = CreateEmptyTableWorkspace()
tbl.addColumn("double", "time zero")
[tbl.addRow([0.16015625]) for i in range(4)]
MuonPreProcess(InputWorkspace=ws,TimeZeroTable=tbl,OutputWorkspace="1529_uncorrected_corrected")
```

4. Check **1529_uncorrected_corrected** and **1529_corrected** are equal now
5. Now clear the workspaces and run this script to load corrected and uncorrected data, then correct the data by the time zero table produced from the load algorithm
```
LoadPSIMuonBin(Filename='deltat_tdc_dolly_1529.bin', OutputWorkspace='1529_corrected', CorrectTime=True)
ws, first, last, timezero, dead, field, timezerolist, timezerotable = LoadPSIMuonBin(Filename='deltat_tdc_dolly_1529.bin', OutputWorkspace='1529_uncorrected', CorrectTime=False)
MuonPreProcess(InputWorkspace=ws,TimeZeroTable=timezerotable,OutputWorkspace="1529_uncorrected_corrected")
```

6. The corrected data should both now be different as the default from load used a single value for all spectra, where as MuonPreProcess applied the correction from the table for each spectra (the load algorithm uses the last value for correction so the last spectrum in each workspace should be equal still)
7. Now try create a ragged workspace using the table in muonpreprocess by running the below script (again clear all workspaces to make it easier to follow).
```
ws, first, last, timezero, dead, field, timezerolist, timezerotable = LoadPSIMuonBin(Filename='deltat_tdc_dolly_1529.bin', OutputWorkspace='1529_uncorrected', CorrectTime=False)
MuonPreProcess(InputWorkspace=ws,TimeMin=8,TimeZeroTable=timezerotable,OutputWorkspace="1529_uncorrected_corrected_with_crop")
```
and 
```
ws, first, last, timezero, dead, field, timezerolist, timezerotable = LoadPSIMuonBin(Filename='deltat_tdc_dolly_1529.bin', OutputWorkspace='1529_uncorrected', CorrectTime=False)
MuonPreProcess(InputWorkspace=ws,TimeMax=9,TimeZeroTable=timezerotable,OutputWorkspace="1529_uncorrected_corrected_with_crop")
```

**Check docs**
1. LoadMuonNexusV2
2. MuonPreProcess
3. Muon Release Notes

Fixes #29025 

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

LoadPSIMuonBin(Filename='deltat_tdc_dolly_1529.bin', OutputWorkspace='1529_corrected', CorrectTime=True)
ws, first, last, timezero, dead, field, timezerolist, timezerotable = LoadPSIMuonBin(Filename='deltat_tdc_dolly_1529.bin', OutputWorkspace='1529_uncorrected', CorrectTime=False)
##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
