### PR TITLE
Add missing wildcard for matching master job names

### DIFF
--- a/buildconfig/Jenkins/buildscript
+++ b/buildconfig/Jenkins/buildscript
@@ -280,8 +280,6 @@ if [[ ${DO_BUILD_PKG} == true ]]; then
             PACKAGE_SUFFIX="qa"
         elif [[ ${JOB_NAME} == master* ]]; then
             PACKAGE_SUFFIX="nightly"
-        elif [[ ${JOB_NAME} == *pvnext* ]]; then
-            PACKAGE_SUFFIX="mantidunstable-pvnext"
         else
             PACKAGE_SUFFIX="unstable"
         fi

--- a/buildconfig/Jenkins/buildscript
+++ b/buildconfig/Jenkins/buildscript
@@ -278,7 +278,7 @@ if [[ ${DO_BUILD_PKG} == true ]]; then
             PACKAGE_SUFFIX=""
         elif [[ ${JOB_NAME} == ornl-qa ]]; then
             PACKAGE_SUFFIX="qa"
-        elif [[ ${JOB_NAME} == master ]]; then
+        elif [[ ${JOB_NAME} == master* ]]; then
             PACKAGE_SUFFIX="nightly"
         elif [[ ${JOB_NAME} == *pvnext* ]]; then
             PACKAGE_SUFFIX="mantidunstable-pvnext"


### PR DESCRIPTION
**Description of work.**

Additional job name checks were added in #29663 that means a job name would need to match `master` exactly to be called nightly. The current master Linux jobs are producing packages labeled [unstable](https://builds.mantidproject.org/view/Master%20Pipeline/job/master_clean-rhel7/1367/)


<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

**To test:**

Code review

*There is no associated issue.*

*This does not require release notes* because **it is internal**

<!-- Ensure the base of this PR is correct (e.g. release-next or master)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
