### PR TITLE
Enable workaround for readling segv in 3.6+

### DIFF
--- a/docs/source/release/v5.1.1/index.rst
+++ b/docs/source/release/v5.1.1/index.rst
@@ -16,6 +16,8 @@ The main changes are:
 
 - a bug in the Muon interface that lead to error bars being lost on fitted data has been fixed
 
+- fixed a bug where `import CaChannel` would cause a hard crash within MantidWorkbench on Linux.
+
 Citation
 --------
 
@@ -37,12 +39,13 @@ Changes in this version
 Summary of impact
 -----------------
 
-+-------+-------------------------+----------+--------------+
-| Issue | Impact                  | Solution | Side Effect  |
-|       |                         |          | Probability  |
-+=======+=========================+==========+==============+
-| 29672 | Fixed muon fitting bugs |          | **low**      |
-+-------+-------------------------+----------+--------------+
++-------+----------------------------------------------+----------+--------------+
+| Issue | Impact                                       | Solution | Side Effect  |
+|       |                                              |          | Probability  |
++=======+==============================================+==========+==============+
+| 29672 | Fixed muon fitting bugs                      |          | **low**      |
+| 29695 | Fixes cachannel import on Linux in workbench |          | **medium**   |
++-------+----------------------------------------------+----------+--------------+
 
 .. _download page: http://download.mantidproject.org
 

--- a/qt/applications/workbench/workbench/app/start.py
+++ b/qt/applications/workbench/workbench/app/start.py
@@ -49,13 +49,14 @@ def qapplication():
 
         argv = sys.argv[:]
         argv[0] = APPNAME  # replace application name
-        # Workaround a segfault with the IPython console when using Python 3.5 + PyQt 5
-        # Without this using this fix the above combination causes a segfault when the IPython
-        # console is started
+        # Workaround a segfault importing readline with PyQt5
+        # This is because PyQt5 messes up pystate (internal) modules_by_index
+        # so PyState_FindModule will return null instead of the module address.
+        # Readline (so far) is the only module that falls over during init as it blindly uses FindModules result
         # The workaround mentioned in https://groups.google.com/forum/#!topic/leo-editor/ghiIN7irzY0
-        # is to ensure readline is imported before the QApplication object is created
-        if sys.version_info[0] == 3 and sys.version_info[1] == 5:
+        if sys.platform == "linux" or sys.platform == "linux2" or sys.platform == "darwin":
             importlib.import_module("readline")
+
         app = QApplication(argv)
         app.setOrganizationName(ORGANIZATION)
         app.setOrganizationDomain(ORG_DOMAIN)


### PR DESCRIPTION
I'm not sure if we want to pull in the docs for 6.0 to make this a true cherry-pick, or instead move it to 5.1.

**Description of work.**

Enables the workaround for Python Segmentation fault in 3.6 and above.
This is the easiest fix, since finding and upstreaming a true bug fix
for PyQt5 would require significant time for (so far) a single module.

----

Technical info:

Readline creates a hook which calls FindModule and passes the result
directly into GetState for the PyState object. However PyQt5 messes up
this internal state by causing the module index tracked internally to be
one less than the modules imported.
This means any calls to FindModule will return a null pointer which
readline happily passes along to GetState.

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

**To test:**

See instructions from #29651 

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
