### PR TITLE
Only display slice viewer widget for MDEventWorkspaces with 2 or more dimensions

### DIFF
--- a/docs/source/release/v6.0.0/mantidworkbench.rst
+++ b/docs/source/release/v6.0.0/mantidworkbench.rst
@@ -13,4 +13,6 @@ Improvements
 Bugfixes
 ########
 
+- Only display slice viewer widget for MDEventWorkspaces with 2 or more dimensions.
+
 :ref:`Release 6.0.0 <v6.0.0>`

--- a/qt/widgets/common/src/WorkspacePresenter/WorkspaceTreeWidgetSimple.cpp
+++ b/qt/widgets/common/src/WorkspacePresenter/WorkspaceTreeWidgetSimple.cpp
@@ -27,11 +27,7 @@ using namespace Mantid::Kernel;
 
 namespace {
 bool singleValued(const MatrixWorkspace &ws) {
-  if (ws.getNumberHistograms() == 1 && ws.blocksize() == 1) {
-    return true;
-  } else {
-    return false;
-  }
+  return (ws.getNumberHistograms() == 1 && ws.blocksize() == 1);
 }
 } // namespace
 
@@ -197,11 +193,10 @@ void WorkspaceTreeWidgetSimple::popupContextMenu() {
       bool add_slice_viewer = false;
       bool add_1d_plot = false;
 
-      auto mdhist_ws = std::dynamic_pointer_cast<IMDHistoWorkspace>(workspace);
-      if (mdhist_ws) {
+      if (matrixWS->isMDHistoWorkspace()) {
         // if the number of non-integral  if the number of non-integrated
         // dimensions is 1.
-        auto num_dims = mdhist_ws->getNonIntegratedDimensions().size();
+        auto num_dims = matrixWS->getNumNonIntegratedDims();
         if (num_dims == 1) {
           // number of non-integral dimension is 1: show menu item to plot
           // spectrum
@@ -211,7 +206,7 @@ void WorkspaceTreeWidgetSimple::popupContextMenu() {
           // to launch slice view
           add_slice_viewer = true;
         }
-      } else {
+      } else if (matrixWS->getNumDims() > 1) {
         add_slice_viewer = true;
       }
 


### PR DESCRIPTION
**Description of work.**



**Report to:** @AndreiSavici 

**To test:**

Create a 1D and 3D MDEventWorkspace
```python
mde_3D = CreateMDWorkspace(Dimensions='3', Extents='-3,3,-3,3,-3,3', Names='h,k,l',
                           Units='rlu,rlu,rlu', SplitInto='4') 
mde_1D = CreateMDWorkspace(Dimensions='1', Extents='-3,3', Names='l',Units='a')
```
`Slice Viewer` should be an a menu option for the 3D, but not the 1D, MDEventWorkspace.

Fixes https://code.ornl.gov/sns-hfir-scse/spectroscopy/spectroscopy/-/issues/28

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
