### PR TITLE
Update hard-coded PV names in RROLD

### DIFF
--- a/docs/source/release/v5.1.1/index.rst
+++ b/docs/source/release/v5.1.1/index.rst
@@ -18,6 +18,8 @@ The main changes are:
 
 - fixed a bug where `import CaChannel` would cause a hard crash within MantidWorkbench on Linux.
 
+- updated the ISIS Reflectometry live data monitor to work with new instrument PV names
+
 Citation
 --------
 


### PR DESCRIPTION
**Report to:** Max at ISIS

ReflectometryReductionOneLiveData fetches live values from the instrument. The PV names for the values are currently hard-coded. This PR updates them following a recent change on the instrument. It also supports two versions of the name because instruments are currently switching between IBEX and SECI and the name is changing. Longer term it would be good to avoid hard-coded values altogether but just updating them for now is a safer, smaller fix for the patch.

Fixes #29694 

**To test:**

Must be tested at ISIS

- Open the ISIS Reflectometry interface
- For each instrument, click the `Start Monitor` button. This will attempt to fetch Theta and the slit gaps from the instrument.
- The result will depend on the current state of the instrument.
  - OFFSPEC, POLREF and SURF should successfully fetch the values - check the log and they should be printed. However, the reduction may still fail: if Theta is zero, this is a valid failure because we can't reduce; it looks like the SURF reduction fails due to a monitor not existing. This is beyond scope of this PR.
  - INTER and CRISP are currently failing to fetch values due to a process not running on the instrument. You will get a timeout error in the log. Check that both PV names have been tried and both timed out (i.e. `THETA` and `Theta`)

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
