### PR TITLE
Muon analysis crash when using default grouping with no runs

### DIFF
--- a/scripts/Muon/GUI/Common/grouping_tab_widget/grouping_tab_widget_model.py
+++ b/scripts/Muon/GUI/Common/grouping_tab_widget/grouping_tab_widget_model.py
@@ -147,10 +147,13 @@ class GroupingTabModel(object):
         return pair
 
     def reset_groups_and_pairs_to_default(self):
+        if not self._context.current_runs:
+            return "failed"
         maximum_number_of_periods = max([self._context.num_periods(run) for run in self._context.current_runs])
 
         self._groups_and_pairs.reset_group_and_pairs_to_default(self._data.current_workspace, self._data.instrument,
                                                                 self._data.main_field_direction, maximum_number_of_periods)
+        return "success"
 
     def reset_selected_groups_and_pairs(self):
         self._groups_and_pairs.reset_selected_groups_and_pairs()

--- a/scripts/Muon/GUI/Common/grouping_tab_widget/grouping_tab_widget_presenter.py
+++ b/scripts/Muon/GUI/Common/grouping_tab_widget/grouping_tab_widget_presenter.py
@@ -207,7 +207,10 @@ class GroupingTabPresenter(object):
         self.calculation_finished_notifier.notify_subscribers()
 
     def handle_default_grouping_button_clicked(self):
-        self._model.reset_groups_and_pairs_to_default()
+        status = self._model.reset_groups_and_pairs_to_default()
+        if status == "failed":
+            self._view.display_warning_box("The default may depend on the instrument. Please load a run.")
+            return
         self._model.reset_selected_groups_and_pairs()
         self.grouping_table_widget.update_view_from_model()
         self.pairing_table_widget.update_view_from_model()

--- a/scripts/test/Muon/grouping_tab/grouping_tab_model_test.py
+++ b/scripts/test/Muon/grouping_tab/grouping_tab_model_test.py
@@ -19,17 +19,26 @@ class GroupingTabModelTest(unittest.TestCase):
         self.context.current_runs = [62260]
         model = GroupingTabModel(self.context)
 
-        model.reset_groups_and_pairs_to_default()
+        status = model.reset_groups_and_pairs_to_default()
 
+        self.assertEquals(status, "success")
         self.context.group_pair_context.reset_group_and_pairs_to_default.assert_called_once_with(mock.ANY, mock.ANY, mock.ANY, 4)
 
     def test_reset_group_and_pairs_to_default_correctly_identifies_maximum_number_of_periods_for_multiple_runs(self):
         self.context.current_runs = [62260, 62261, 62263]
         model = GroupingTabModel(self.context)
 
-        model.reset_groups_and_pairs_to_default()
+        status = model.reset_groups_and_pairs_to_default()
+        self.assertEquals(status, "success")
 
         self.context.group_pair_context.reset_group_and_pairs_to_default.assert_called_once_with(mock.ANY, mock.ANY, mock.ANY, 4)
+
+    def test_reset_group_and_pairs_to_default_for_no_loaded_runs(self):
+        self.context.current_runs = []
+        model = GroupingTabModel(self.context)
+
+        status = model.reset_groups_and_pairs_to_default()
+        self.assertEquals(status, "failed")
 
 
 if __name__ == '__main__':

--- a/scripts/test/Muon/grouping_tab/grouping_tab_presenter_test.py
+++ b/scripts/test/Muon/grouping_tab/grouping_tab_presenter_test.py
@@ -238,6 +238,16 @@ class GroupingTabPresenterTest(unittest.TestCase):
             mock_load.return_value = (groups, pairs, 'description', default)
             self.presenter.handle_load_grouping_from_file()
 
+    def test_default_clickd(self):
+        self.presenter._model.reset_groups_and_pairs_to_default = mock.MagicMock(return_value="success")
+        self.presenter.handle_default_grouping_button_clicked()
+        self.assertEqual(self.view.display_warning_box.call_count, 0)
+
+    def test_default_clicked_no_data(self):
+        self.presenter._model.reset_groups_and_pairs_to_default = mock.MagicMock(return_value="failed")
+        self.presenter.handle_default_grouping_button_clicked()
+        self.assertEqual(self.view.display_warning_box.call_count, 1)
+
 
 if __name__ == '__main__':
     unittest.main(buffer=False, verbosity=2)

--- a/scripts/test/Muon/grouping_tab/grouping_tab_presenter_test.py
+++ b/scripts/test/Muon/grouping_tab/grouping_tab_presenter_test.py
@@ -238,7 +238,7 @@ class GroupingTabPresenterTest(unittest.TestCase):
             mock_load.return_value = (groups, pairs, 'description', default)
             self.presenter.handle_load_grouping_from_file()
 
-    def test_default_clickd(self):
+    def test_default_clicked(self):
         self.presenter._model.reset_groups_and_pairs_to_default = mock.MagicMock(return_value="success")
         self.presenter.handle_default_grouping_button_clicked()
         self.assertEqual(self.view.display_warning_box.call_count, 0)


### PR DESCRIPTION
**Description of work.**

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

**To test:**
1. Go to the grouping tab
2. Press default 
3. It used to crash,  you now get a pop up

Test 2:
Open muon analysis
Set instrument to EMU
Load some data
Change the instrument to MUSR
Go to grouping tab
Click default - crash
<!-- Instructions for testing. -->

Fixes #29705. <!-- and fix #xxxx or close #xxxx xor resolves #xxxx -->
<!-- alternative
*There is no associated issue.*
-->

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or master)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
