### PR TITLE
more useful error messages for encounter emtpy eventworkspace

### DIFF
--- a/Framework/WorkflowAlgorithms/src/AlignAndFocusPowder.cpp
+++ b/Framework/WorkflowAlgorithms/src/AlignAndFocusPowder.cpp
@@ -260,8 +260,10 @@ std::map<std::string, std::string> AlignAndFocusPowder::validateInputs() {
   m_inputW = getProperty(PropertyNames::INPUT_WKSP);
   m_inputEW = std::dynamic_pointer_cast<EventWorkspace>(m_inputW);
   if (m_inputEW && m_inputEW->getNumberEvents() <= 0)
-    result[PropertyNames::INPUT_WKSP] = "Empty workspace encounter, possibly due to beam down."
-                                        "Please plot the pCharge-time to identify suitable range for re-time-slicing";
+    result[PropertyNames::INPUT_WKSP] =
+        "Empty workspace encounter, possibly due to beam down."
+        "Please plot the pCharge-time to identify suitable range for "
+        "re-time-slicing";
 
   return result;
 }

--- a/Framework/WorkflowAlgorithms/src/AlignAndFocusPowder.cpp
+++ b/Framework/WorkflowAlgorithms/src/AlignAndFocusPowder.cpp
@@ -260,7 +260,8 @@ std::map<std::string, std::string> AlignAndFocusPowder::validateInputs() {
   m_inputW = getProperty(PropertyNames::INPUT_WKSP);
   m_inputEW = std::dynamic_pointer_cast<EventWorkspace>(m_inputW);
   if (m_inputEW && m_inputEW->getNumberEvents() <= 0)
-    result[PropertyNames::INPUT_WKSP] = "Cannot process empty event workspace";
+    result[PropertyNames::INPUT_WKSP] = "Empty workspace encounter, possibly due to beam down."
+                                        "Please plot the pCharge-time to identify suitable range for re-time-slicing";
 
   return result;
 }


### PR DESCRIPTION
**Description of work.**

This pull request adjusted the error messages output when empty event workspace is encountered during powder reduction.

> related issue: https://code.ornl.gov/sns-hfir-scse/diffraction/powder/powder-diffraction/-/issues/93

Previous error messages (orange):
![Origin_Error_MSG](https://user-images.githubusercontent.com/5064852/95779997-1d895080-0c99-11eb-9ad4-c5617245b76a.png)

New error messages (orange):
![UPDATED_Error_MSG](https://user-images.githubusercontent.com/5064852/95780036-2d089980-0c99-11eb-8f19-1811cad7de9f.png)


<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

**To test:**
On the analysis cluster, using the following code in the Mantid IPython console
```python
config['default.facility']="SNS"
# Load data's log only
Load(Filename = 'PG3_44875.nxs.h5',
         OutputWorkspace = 'PG3_44875_meta',
         MetaDataOnly = True)
# Construct the event filters
GenerateEventsFilter(
                       InputWorkspace  = 'PG3_44875_meta',
                       OutputWorkspace = 'PG3_44875_splitters',
                       InformationWorkspace = 'PG3_44875_splitinfo',
                       TimeInterval   = '900.0',
                       UnitOfTime = 'Seconds',
                       LogName    = '',
)
SNSPowderReduction(
                       SaveAs = 'topas',
                       FinalDataUnits = 'dSpacing',
                       VanadiumNumber = '-1',
                       VanadiumBackgroundNumber = '-1',
                       Filename = 'PG3_44875',
                       Sum = '0',
                       BackgroundNumber = '-1',
                       Binning = '-0.0008000',
                       OutputDirectory = '/tmp',  
                       BinInDspace = '1',
                       CalibrationFile = '/SNS/snfs1/instruments/PG3/shared/CALIBRATION/2019_2_11A_CAL/PG3_AGES_d44275_2019_08_22.h5',
                       CharacterizationRunsFile = '/SNS/snfs1/instruments/PG3/shared/CALIBRATION/2019_2_11A_CAL/PG3_char_2019_08_22-HR-AGES.txt,/SNS/snfs1/instruments/PG3/shared/CALIBRATION/2019_2_11A_CAL/PG3_char_2019_08_22_AGES_limit.txt',
                       StripVanadiumPeaks = '1',
                       RemovePromptPulseWidth = '50.0',
                       FilterBadPulses = '10.0',
                       PushDataPositive = 'None',
                       BackgroundSmoothParams = '40,10',
                       PreserveEvents = '1',
                       ScaleData = '100.0',
                       SplittersWorkspace = 'PG3_44875_splitters',
                       SplitInformationWorkspace='PG3_44875_splitinfo',
                       )
```

<!-- Instructions for testing. -->

<!-- and fix #xxxx or close #xxxx xor resolves #xxxx -->
<!-- alternative
*There is no associated issue.*
-->

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or master)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
