### PR TITLE
Add .mrd extension when saving in DrILL interface

### DIFF
--- a/scripts/Interface/ui/drill/presenter/DrillPresenter.py
+++ b/scripts/Interface/ui/drill/presenter/DrillPresenter.py
@@ -110,7 +110,9 @@ class DrillPresenter:
             self.updateViewFromModel()
         except Exception as ex:
             self.view.errorPopup("Import error",
-                                 "Unable to open {0}".format(filename),
+                                 "Unable to load file {0}, please select a "
+                                 "rundex file (.mrd) saved from this interface."
+                                 .format(filename),
                                  str(ex))
 
     def rundexSaved(self, filename):

--- a/scripts/Interface/ui/drill/view/DrillView.py
+++ b/scripts/Interface/ui/drill/view/DrillView.py
@@ -465,7 +465,8 @@ class DrillView(QMainWindow):
         Ask for the saving of the table in a rundex file.
         """
         filename = QFileDialog.getSaveFileName(
-                self, 'Save rundex', '.', "Rundex (*.mrd)"
+                self, 'Save rundex', './*.mrd',
+                "Rundex (*.mrd);;All files (*.*)"
                 )
         if not filename[0]:
             return


### PR DESCRIPTION
**Description of work.**

This tiny PR adds the extension when saving the DrILL interface content. The extension is not automatically added but proposed in the field the user will use to set the name of the file.

Before that, the user had to add the `.mrd` extension himself. This extension is then used to filter the files that can be loaded by DrILL.

**To test:**

* Open the DrILL interface.
* Save the table (File -> Save as)
* Check that the filename field in the saving window contains `*.mrd`

Part of #29570 

*This does not require release notes*: internal changes only.

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
