### PR TITLE
Improve error messages in NeXusGeometryParser

### DIFF
--- a/Framework/NexusGeometry/src/NexusGeometryParser.cpp
+++ b/Framework/NexusGeometry/src/NexusGeometryParser.cpp
@@ -674,7 +674,7 @@ private:
       throw std::runtime_error("Expect to have as many detector_face entries "
                                "as detector_number entries");
     if (detFaces.size() % 2 != 0)
-      throw std::runtime_error("Unequal pairs of face incides to detector "
+      throw std::runtime_error("Unequal pairs of face indices to detector "
                                "indices in detector_faces");
     if (detFaces.size() / 2 > faceIndices.size())
       throw std::runtime_error(

--- a/Framework/NexusGeometry/src/NexusGeometryParser.cpp
+++ b/Framework/NexusGeometry/src/NexusGeometryParser.cpp
@@ -70,26 +70,26 @@ template <typename ExpectedT> void validateStorageType(const DataSet &data) {
     if (H5T_FLOAT != typeClass) {
       throw std::runtime_error("Storage type mismatch. Expecting to extract a "
                                "floating point number from " +
-                               data.getObjName());
+                               H5_OBJ_NAME(data));
     }
     if (sizeOfType != sizeof(ExpectedT)) {
       throw std::runtime_error(
           "Storage type mismatch for floats. This operation "
           "is dangerous. Nexus stored has byte size:" +
-          std::to_string(sizeOfType) + " in " + data.getObjName());
+          std::to_string(sizeOfType) + " in " + H5_OBJ_NAME(data));
     }
   } else if (std::is_integral<ExpectedT>::value) {
     if (H5T_INTEGER != typeClass) {
       throw std::runtime_error(
           "Storage type mismatch. Expecting to extract a integer from " +
-          data.getObjName());
+          H5_OBJ_NAME(data));
     }
     if (sizeOfType > sizeof(ExpectedT)) {
       // endianness not checked
       throw std::runtime_error(
           "Storage type mismatch for integer. Result "
           "would result in truncation. Nexus stored has byte size:" +
-          std::to_string(sizeOfType) + " in " + data.getObjName());
+          std::to_string(sizeOfType) + " in " + H5_OBJ_NAME(data));
     }
   }
 }

--- a/Framework/NexusGeometry/src/NexusGeometryParser.cpp
+++ b/Framework/NexusGeometry/src/NexusGeometryParser.cpp
@@ -485,8 +485,9 @@ private:
         Eigen::AngleAxisd rotation(angle, transformVector);
         transforms = rotation * transforms;
       } else {
-        throw std::runtime_error(
-            "Unknown Transform type in Nexus Geometry Parsing");
+        throw std::runtime_error("Unknown Transform type \"" + transformType +
+                                 "\" found in " + H5_OBJ_NAME(transformation) +
+                                 " when parsing Nexus geometry");
       }
     }
     return transforms;

--- a/Framework/NexusGeometry/src/NexusGeometryParser.cpp
+++ b/Framework/NexusGeometry/src/NexusGeometryParser.cpp
@@ -69,25 +69,27 @@ template <typename ExpectedT> void validateStorageType(const DataSet &data) {
   if (std::is_floating_point<ExpectedT>::value) {
     if (H5T_FLOAT != typeClass) {
       throw std::runtime_error("Storage type mismatch. Expecting to extract a "
-                               "floating point number");
+                               "floating point number from " +
+                               data.getObjName());
     }
     if (sizeOfType != sizeof(ExpectedT)) {
       throw std::runtime_error(
           "Storage type mismatch for floats. This operation "
           "is dangerous. Nexus stored has byte size:" +
-          std::to_string(sizeOfType));
+          std::to_string(sizeOfType) + " in " + data.getObjName());
     }
   } else if (std::is_integral<ExpectedT>::value) {
     if (H5T_INTEGER != typeClass) {
       throw std::runtime_error(
-          "Storage type mismatch. Expecting to extract a integer");
+          "Storage type mismatch. Expecting to extract a integer from " +
+          data.getObjName());
     }
     if (sizeOfType > sizeof(ExpectedT)) {
       // endianness not checked
       throw std::runtime_error(
           "Storage type mismatch for integer. Result "
           "would result in truncation. Nexus stored has byte size:" +
-          std::to_string(sizeOfType));
+          std::to_string(sizeOfType) + " in " + data.getObjName());
     }
   }
 }


### PR DESCRIPTION
Minor change to log messages from `NeXusGeometryParser` to inform the user which dataset is not of the expected type. `getObjName()` gives the full path of the dataset in the NeXus file.

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
