### PR TITLE
Add missing TS_ASSERT calls to wrap Mock::VerifyAndClearExpectations

### DIFF
--- a/Framework/Algorithms/test/MCInteractionVolumeTest.h
+++ b/Framework/Algorithms/test/MCInteractionVolumeTest.h
@@ -111,7 +111,7 @@ public:
                                          afterScatter, trackStatistics);
     TestGeneratedTracks(startPos, endPos, beforeScatter, afterScatter,
                         sample.getShape());
-    Mock::VerifyAndClearExpectations(&rng);
+    TS_ASSERT(Mock::VerifyAndClearExpectations(&rng));
 
     // force scatter near back (longer distance traversed with before lambda)
     EXPECT_CALL(rng, nextValue())
@@ -174,7 +174,7 @@ public:
                                          afterScatter, trackStatistics);
     TestGeneratedTracks(startPos, endPos, beforeScatter, afterScatter,
                         sample.getEnvironment().getContainer());
-    Mock::VerifyAndClearExpectations(&rng);
+    TS_ASSERT(Mock::VerifyAndClearExpectations(&rng));
 
     // force scatter in sample (0)
     EXPECT_CALL(rng, nextInt(0, 1))
@@ -190,7 +190,7 @@ public:
     const double factorSample = interactor.calculateAbsorption(
         beforeScatter, afterScatter, lambdaBefore, lambdaAfter);
     TS_ASSERT_DELTA(0.73100698, factorSample, 1e-8);
-    Mock::VerifyAndClearExpectations(&rng);
+    TS_ASSERT(Mock::VerifyAndClearExpectations(&rng));
   }
 
   void test_Sample_And_Environment_Gives_Expected_Absorption() {
@@ -304,7 +304,7 @@ public:
     TS_ASSERT_THROWS_NOTHING(comp1Point = interactor.generatePoint(rng));
     TS_ASSERT(kit->isValid(comp1Point.scatterPoint));
     TS_ASSERT_EQUALS(comp1Point.componentIndex, 0);
-    Mock::VerifyAndClearExpectations(&rng);
+    TS_ASSERT(Mock::VerifyAndClearExpectations(&rng));
 
     // Selects second component
     MCInteractionVolume interactor2(sample, maxAttempts);
@@ -321,7 +321,7 @@ public:
     TS_ASSERT(comp2Point.scatterPoint != comp1Point.scatterPoint);
     TS_ASSERT(kit->isValid(comp2Point.scatterPoint));
     TS_ASSERT_EQUALS(comp2Point.componentIndex, 1);
-    Mock::VerifyAndClearExpectations(&rng);
+    TS_ASSERT(Mock::VerifyAndClearExpectations(&rng));
 
     // Selects third component
     MCInteractionVolume interactor3(sample, maxAttempts);
@@ -338,7 +338,7 @@ public:
     TS_ASSERT(comp3Point.scatterPoint != comp1Point.scatterPoint);
     TS_ASSERT(kit->isValid(comp3Point.scatterPoint));
     TS_ASSERT_EQUALS(comp3Point.componentIndex, 2);
-    Mock::VerifyAndClearExpectations(&rng);
+    TS_ASSERT(Mock::VerifyAndClearExpectations(&rng));
   }
 
   void testGeneratePointRespectsActiveRegion() {
@@ -361,7 +361,7 @@ public:
     MCInteractionVolume interactor(sample, maxAttempts);
     // Restrict region to can
     TS_ASSERT_THROWS(interactor.generatePoint(rng), const std::runtime_error &);
-    Mock::VerifyAndClearExpectations(&rng);
+    TS_ASSERT(Mock::VerifyAndClearExpectations(&rng));
   }
 
 private:

--- a/Framework/Algorithms/test/MaxEnt/MaxentCalculatorTest.h
+++ b/Framework/Algorithms/test/MaxEnt/MaxentCalculatorTest.h
@@ -115,8 +115,8 @@ public:
         calculator.iterate(vec1, vec1, vec2, bkg, emptyVec, emptyVec),
         const std::runtime_error &);
 
-    Mock::VerifyAndClearExpectations(entropy);
-    Mock::VerifyAndClearExpectations(transform);
+    TS_ASSERT(Mock::VerifyAndClearExpectations(entropy));
+    TS_ASSERT(Mock::VerifyAndClearExpectations(transform));
   }
 
   void test_size_complex_data_real_image() {
@@ -156,8 +156,8 @@ public:
     TS_ASSERT_THROWS_NOTHING(
         calculator.iterate(vec1, vec1, vec2, bkg, emptyVec, emptyVec));
 
-    Mock::VerifyAndClearExpectations(entropy);
-    Mock::VerifyAndClearExpectations(transform);
+    TS_ASSERT(Mock::VerifyAndClearExpectations(entropy));
+    TS_ASSERT(Mock::VerifyAndClearExpectations(transform));
   }
 
   void test_size_resolution_factor() {
@@ -214,8 +214,8 @@ public:
         calculator.iterate(vec2, vec2, vec1, bkg, emptyVec, emptyVec),
         const std::runtime_error &);
 
-    Mock::VerifyAndClearExpectations(entropy);
-    Mock::VerifyAndClearExpectations(transform);
+    TS_ASSERT(Mock::VerifyAndClearExpectations(entropy));
+    TS_ASSERT(Mock::VerifyAndClearExpectations(transform));
   }
 
   void test_data_not_loaded() {
@@ -273,8 +273,8 @@ public:
     TS_ASSERT_DELTA(calculator.getChisq(), 1, 1e-8);
     TS_ASSERT_DELTA(calculator.getAngle(), 0.7071, 1e-4);
 
-    Mock::VerifyAndClearExpectations(entropy);
-    Mock::VerifyAndClearExpectations(transform);
+    TS_ASSERT(Mock::VerifyAndClearExpectations(entropy));
+    TS_ASSERT(Mock::VerifyAndClearExpectations(transform));
   }
 
   void test_dirs_coefficients() {
@@ -335,7 +335,7 @@ public:
     TS_ASSERT_DELTA(coeff.c2[0][1], 0, 1E-6);
     TS_ASSERT_DELTA(coeff.c2[1][1], 0, 1E-6);
 
-    Mock::VerifyAndClearExpectations(entropy);
-    Mock::VerifyAndClearExpectations(transform);
+    TS_ASSERT(Mock::VerifyAndClearExpectations(entropy));
+    TS_ASSERT(Mock::VerifyAndClearExpectations(transform));
   }
 };


### PR DESCRIPTION
**Description of work.**

Mock::VerifyAndClearExpectations returns a `bool` indicating if the expectations have been met or not. If this is not checked then the unit test will print that the expectations are unmatched but CxxTest will not show the test as failed.

These changes add the missing `TS_ASSERT` to stop the unit test if the expectations are not matched.

**To test:**

Code review. CI will check the tests pass.

*There is no associated issue.*

*This does not require release notes* because **this is an internal issue.**

<!-- Ensure the base of this PR is correct (e.g. release-next or master)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
