### PR TITLE
Crystal Field - Extend Background class to take a list of Function objects

### DIFF
--- a/docs/source/release/v6.0.0/direct_geometry.rst
+++ b/docs/source/release/v6.0.0/direct_geometry.rst
@@ -14,6 +14,20 @@ Improvements
 
 - The instrument geometry of PANTHER has been corrected according to the findings during the hot commissioning.
 
+
+CrystalField
+------------
+
+New
+###
+- Extended the ``Background`` class to accept a list of functions through using the ``functions`` keyword. This
+  allows more than two functions to be used for the ``Background`` of a CrystalField fit.
+
+BugFixes
+########
+- Fixed a bug in the :ref:`Crystal Field Python Interface` where ties were not being applied properly for cubic crystal structures.
+
+
 DGSPlanner
 ----------
 
@@ -21,14 +35,5 @@ Improvements
 ############
 
 - Widgets were rearranged into groups of items based on their logical function
-
-
-CrystalField
-------------
-
-BugFixes
-########
-
-- Fixed a bug in the :ref:`Crystal Field Python Interface` where ties were not being applied properly for cubic crystal structures.
 
 :ref:`Release 6.0.0 <v6.0.0>`

--- a/scripts/Inelastic/CrystalField/fitting.py
+++ b/scripts/Inelastic/CrystalField/fitting.py
@@ -619,15 +619,16 @@ class CrystalField(object):
 
     def _makeBackgroundObject(self, value, prefix=''):
         from .function import Background, Function
-        background_object = Background()
-
-        if len(value.functions()) == 1:
-            background_object.add_function(Function(self.function, prefix=prefix + 'f0.'))
-            return background_object
-        else:
-            for i in range(len(value.functions())):
-                background_object.add_function(Function(self.function, prefix=prefix + 'f0.f' + str(i) + '.'))
-            return background_object
+        if value.peak is not None and value.background is not None:
+            peak = Function(self.function, prefix=prefix + 'f0.f0.')
+            background = Function(self.function, prefix=prefix + 'f0.f1.')
+        elif value.peak is not None:
+            peak = Function(self.function, prefix=prefix + 'f0.')
+            background = None
+        elif value.background is not None:
+            peak = None
+            background = Function(self.function, prefix=prefix + 'f0.')
+        return Background(peak=peak, background=background)
 
     @property
     def PhysicalProperty(self):
@@ -970,9 +971,9 @@ class CrystalField(object):
         if self._background is not None:
             if isinstance(self._background, list):
                 for background in self._background:
-                    background.update(func, index)
+                    background.update(func)
             else:
-                self._background.update(func, index)
+                self._background.update(func)
         self._setPeaks()
 
     def calc_xmin_xmax(self, i):

--- a/scripts/Inelastic/CrystalField/fitting.py
+++ b/scripts/Inelastic/CrystalField/fitting.py
@@ -619,16 +619,15 @@ class CrystalField(object):
 
     def _makeBackgroundObject(self, value, prefix=''):
         from .function import Background, Function
-        if value.peak is not None and value.background is not None:
-            peak = Function(self.function, prefix=prefix + 'f0.f0.')
-            background = Function(self.function, prefix=prefix + 'f0.f1.')
-        elif value.peak is not None:
-            peak = Function(self.function, prefix=prefix + 'f0.')
-            background = None
-        elif value.background is not None:
-            peak = None
-            background = Function(self.function, prefix=prefix + 'f0.')
-        return Background(peak=peak, background=background)
+        background_object = Background()
+
+        if len(value.functions()) == 1:
+            background_object.add_function(Function(self.function, prefix=prefix + 'f0.'))
+            return background_object
+        else:
+            for i in range(len(value.functions())):
+                background_object.add_function(Function(self.function, prefix=prefix + 'f0.f' + str(i) + '.'))
+            return background_object
 
     @property
     def PhysicalProperty(self):
@@ -961,18 +960,19 @@ class CrystalField(object):
             createWS.execute()
             plotSpectrum(ws_name, 0)
 
-    def update(self, func):
+    def update(self, func, index=0):
         """
         Update values of the fitting parameters.
         @param func: A IFunction object containing new parameter values.
+        @param index: The index of the function to update in the Background object.
         """
         self.function = func
         if self._background is not None:
             if isinstance(self._background, list):
                 for background in self._background:
-                    background.update(func)
+                    background.update(func, index)
             else:
-                self._background.update(func)
+                self._background.update(func, index)
         self._setPeaks()
 
     def calc_xmin_xmax(self, i):

--- a/scripts/Inelastic/CrystalField/fitting.py
+++ b/scripts/Inelastic/CrystalField/fitting.py
@@ -606,7 +606,10 @@ class CrystalField(object):
         if not hasattr(value, 'toString'):
             raise TypeError('Expected a Background object, found %s' % str(value))
         if not self._isMultiSpectrum:
+            print("HERREE")
             fun_str = value.toString() + ';' + str(self.function)
+            print(fun_str)
+            print("HERREE")
             self.function = FunctionFactory.createInitialized(fun_str)
             self._background = self._makeBackgroundObject(value)
             self._setPeaks()
@@ -619,16 +622,24 @@ class CrystalField(object):
 
     def _makeBackgroundObject(self, value, prefix=''):
         from .function import Background, Function
-        if value.peak is not None and value.background is not None:
-            peak = Function(self.function, prefix=prefix + 'f0.f0.')
-            background = Function(self.function, prefix=prefix + 'f0.f1.')
-        elif value.peak is not None:
-            peak = Function(self.function, prefix=prefix + 'f0.')
-            background = None
-        elif value.background is not None:
-            peak = None
-            background = Function(self.function, prefix=prefix + 'f0.')
-        return Background(peak=peak, background=background)
+
+        if len(value.functions) > 1:
+            prefix += 'f0.'
+
+        n_functions = 0
+        peak, background = None, None
+        if value.peak is not None:
+            peak = Function(self.function, prefix=prefix + f'f{n_functions}.')
+            n_functions += 1
+        if value.background is not None:
+            background = Function(self.function, prefix=prefix + f'f{n_functions}.')
+            n_functions += 1
+
+        other_functions = []
+        for function_index in range(n_functions, len(value.functions)):
+            other_functions.append(Function(self.function, prefix=prefix + f'f{function_index}.'))
+
+        return Background(peak=peak, background=background, functions=other_functions)
 
     @property
     def PhysicalProperty(self):

--- a/scripts/Inelastic/CrystalField/fitting.py
+++ b/scripts/Inelastic/CrystalField/fitting.py
@@ -606,10 +606,7 @@ class CrystalField(object):
         if not hasattr(value, 'toString'):
             raise TypeError('Expected a Background object, found %s' % str(value))
         if not self._isMultiSpectrum:
-            print("HERREE")
             fun_str = value.toString() + ';' + str(self.function)
-            print(fun_str)
-            print("HERREE")
             self.function = FunctionFactory.createInitialized(fun_str)
             self._background = self._makeBackgroundObject(value)
             self._setPeaks()
@@ -982,9 +979,9 @@ class CrystalField(object):
         if self._background is not None:
             if isinstance(self._background, list):
                 for background in self._background:
-                    background.update(func)
+                    background.update(func, index)
             else:
-                self._background.update(func)
+                self._background.update(func, index)
         self._setPeaks()
 
     def calc_xmin_xmax(self, i):

--- a/scripts/Inelastic/CrystalField/function.py
+++ b/scripts/Inelastic/CrystalField/function.py
@@ -285,32 +285,42 @@ class Background(object):
     background.
     """
 
-    def __init__(self, peak=None, background=None):
+    def __init__(self, functions=[]):
         """
         Initialise new instance.
-        @param peak: An instance of Function class meaning to be the elastic peak.
-        @param background: An instance of Function class serving as the background.
+        @param functions: A list of Function class instances which make up the background.
         """
-        self.peak = peak
-        self.background = background
+        self._functions = functions
 
     def clone(self):
         """Make a copy of self."""
         aCopy = Background()
-        if self.peak is not None:
-            aCopy.peak = self.peak.clone()
-        if self.background is not None:
-            aCopy.background = self.background.clone()
+        for function in self._functions:
+            aCopy.add_function(function.clone())
         return aCopy
 
+    def add_function(self, function):
+        """
+        Add a function to the background object.
+        @param function: The Function class instance to add to the Background object.
+        """
+        if isinstance(function, Function):
+            self._functions.append(function)
+        else:
+            raise TypeError("Expected to add a Function object to the Background object.")
+
     def toString(self):
-        if self.peak is None and self.background is None:
+        """Return the Background object in string format."""
+        if len(self._functions) == 0:
             return ''
-        if self.peak is None:
-            return self.background.toString()
-        if self.background is None:
-            return self.peak.toString()
-        return '(%s;%s)' % (self.peak.toString(), self.background.toString())
+        elif len(self._functions) == 1:
+            return self._functions[0].toString()
+        else:
+            function_string = '(' + self._functions[0].toString()
+            for function in self._functions[1:]:
+                function_string += ';'
+                function_string += function.toString()
+            return function_string + ')'
 
     def update(self, func1, func2=None):
         """

--- a/scripts/Inelastic/CrystalField/function.py
+++ b/scripts/Inelastic/CrystalField/function.py
@@ -299,6 +299,10 @@ class Background(object):
             aCopy.add_function(function.clone())
         return aCopy
 
+    def functions(self):
+        """Return the list of functions which make up the Background object."""
+        return self._functions
+
     def add_function(self, function):
         """
         Add a function to the background object.
@@ -322,23 +326,19 @@ class Background(object):
                 function_string += function.toString()
             return function_string + ')'
 
-    def update(self, func1, func2=None):
+    def update(self, func, index=0):
         """
         Update values of the fitting parameters. If both arguments are given
             the first one updates the peak and the other updates the background.
 
-        @param func1: First IFunction object containing new parameter values.
-        @param func2: Second IFunction object containing new parameter values.
+        @param func: The IFunction object containing new parameter values.
+        @param index: The index of the function to update in the Background object.
         """
-        if func2 is not None:
-            if self.peak is None or self.background is None:
-                raise RuntimeError('Background has peak or background undefined.')
-            self.peak.update(func1)
-            self.background.update(func2)
-        elif self.peak is None:
-            self.background.update(func1)
+        if index < len(self._functions):
+            self._functions[index].update(func)
         else:
-            self.peak.update(func1)
+            raise ValueError("Invalid index ({0}) provided: Background object is made up of only {0} functions.".
+                             format(str(index), str(len(self._functions))))
 
 
 class ResolutionModel:

--- a/scripts/Inelastic/CrystalField/function.py
+++ b/scripts/Inelastic/CrystalField/function.py
@@ -322,35 +322,8 @@ class Background(object):
         if index < len(self.functions):
             self.functions[index].update(func)
         else:
-            raise ValueError(f"Invalid index ({index}) provided: Background is made of {len(self.functions)} Function(s).")
-
-    def index_of(self, func):
-        """
-        Returns the index of the Function object provided.
-
-        @param func: The Function object to search for.
-        @returns The index of the Function object provided.
-        """
-        if not isinstance(func, Function):
-            raise TypeError(f"Expected a Function object but found {type(function)} object.")
-
-        for index, function in enumerate(self.functions):
-            if func == function:
-                return index
-
-        raise RuntimeError(f"{str(func.toString())} was not found in the Background object.")
-
-    def function(self, index):
-        """
-        Returns the Function object at the given index in the Background object.
-
-        @param index: The index of the Function object to be returned.
-        @returns The Function object at the given index in the Background object.
-        """
-        if index < len(self.functions):
-            return self.functions[index]
-
-        raise ValueError(f"Invalid index ({index}) provided: Background is made of {len(self.functions)} Function(s).")
+            raise ValueError(f"Invalid index ({index}) provided: Background is made of {len(self.functions)} "
+                             f"Function(s).")
 
 
 class ResolutionModel:

--- a/scripts/Inelastic/CrystalField/function.py
+++ b/scripts/Inelastic/CrystalField/function.py
@@ -302,22 +302,8 @@ class Background(object):
             self.functions.append(self.background)
         self.functions.extend(functions)
 
-    def functions(self):
-        """Return the list of functions which make up the Background object."""
-        return self.functions
-
-    def add_function(self, function):
-        """
-        Add a function to the background object.
-        @param function: The Function class instance to add to the Background object.
-        """
-        if isinstance(function, Function):
-            self.functions.append(function)
-        else:
-            raise TypeError("Expected to add a Function object to the Background object.")
-
     def toString(self):
-        """Return the Background object in string format."""
+        """Returns the Background object in string format."""
         if len(self.functions) == 0:
             return ''
         elif len(self.functions) == 1:

--- a/scripts/Inelastic/CrystalField/function.py
+++ b/scripts/Inelastic/CrystalField/function.py
@@ -337,8 +337,8 @@ class Background(object):
         if index < len(self._functions):
             self._functions[index].update(func)
         else:
-            raise ValueError("Invalid index ({0}) provided: Background object is made up of only {0} functions.".
-                             format(str(index), str(len(self._functions))))
+            raise ValueError(f"Invalid index ({index}) provided: Background object is made up of only "
+                             f"{len(self._functions)} functions.")
 
 
 class ResolutionModel:

--- a/scripts/Inelastic/CrystalField/function.py
+++ b/scripts/Inelastic/CrystalField/function.py
@@ -322,8 +322,35 @@ class Background(object):
         if index < len(self.functions):
             self.functions[index].update(func)
         else:
-            raise ValueError(f"Invalid index ({index}) provided: Background object is made up of only "
-                             f"{len(self.functions)} functions.")
+            raise ValueError(f"Invalid index ({index}) provided: Background is made of {len(self.functions)} Function(s).")
+
+    def index_of(self, func):
+        """
+        Returns the index of the Function object provided.
+
+        @param func: The Function object to search for.
+        @returns The index of the Function object provided.
+        """
+        if not isinstance(func, Function):
+            raise TypeError(f"Expected a Function object but found {type(function)} object.")
+
+        for index, function in enumerate(self.functions):
+            if func == function:
+                return index
+
+        raise RuntimeError(f"{str(func.toString())} was not found in the Background object.")
+
+    def function(self, index):
+        """
+        Returns the Function object at the given index in the Background object.
+
+        @param index: The index of the Function object to be returned.
+        @returns The Function object at the given index in the Background object.
+        """
+        if index < len(self.functions):
+            return self.functions[index]
+
+        raise ValueError(f"Invalid index ({index}) provided: Background is made of {len(self.functions)} Function(s).")
 
 
 class ResolutionModel:

--- a/scripts/Inelastic/CrystalField/function.py
+++ b/scripts/Inelastic/CrystalField/function.py
@@ -333,11 +333,11 @@ class Background(object):
         @param func: The IFunction object containing new parameter values.
         @param index: The index of the function to update in the Background object.
         """
-        if index < len(updatable_functions):
-            self._functions[index].update(func)
+        if index < len(self.functions):
+            self.functions[index].update(func)
         else:
             raise ValueError(f"Invalid index ({index}) provided: Background object is made up of only "
-                             f"{len(self._functions)} functions.")
+                             f"{len(self.functions)} functions.")
 
 
 class ResolutionModel:

--- a/scripts/Inelastic/CrystalField/function.py
+++ b/scripts/Inelastic/CrystalField/function.py
@@ -302,21 +302,6 @@ class Background(object):
             self.functions.append(self.background)
         self.functions.extend(functions)
 
-    def clone(self):
-        """Make a copy of self."""
-        n = 0
-        peak_copy, background_copy = None, None
-        if self.peak is not None:
-            peak_copy = self.peak.clone()
-            n += 1
-        if self.background is not None:
-            background_copy = self.background.clone()
-            n += 1
-
-        functions_copy = [function.clone() for function in self.functions[n:]]
-
-        return Background(peak=peak_copy, background=background_copy, functions=functions_copy)
-
     def functions(self):
         """Return the list of functions which make up the Background object."""
         return self.functions

--- a/scripts/test/CrystalFieldTest.py
+++ b/scripts/test/CrystalFieldTest.py
@@ -337,6 +337,65 @@ class CrystalFieldTests(unittest.TestCase):
         self.assertAlmostEqual(y[80], 2.1309638244891764, 8)
         self.assertAlmostEqual(y[90], 5.47632096610588, 8)
 
+    def test_that_the_peak_and_background_in_a_Background_object_are_stored_in_the_functions_variable(self):
+        from CrystalField import CrystalField, Background, Function
+        parameters = {'B20': 0.2, 'B40': -0.00164, 'B60': 0.0001146, 'B66': 0.001509}
+        cf = CrystalField('Pr', 'C6v', Temperature=5, **parameters)
+
+        cf.background = Background(peak=Function('PseudoVoigt', Intensity=101, FWHM=0.8, Mixing=0.84),
+                                   background=Function('Gaussian', Height=1.8, Sigma=0.27, PeakCentre=9.0))
+
+        self.assertEqual(cf.background.functions[0].param['Intensity'], 101)
+        self.assertEqual(cf.background.functions[0].param['FWHM'], 0.8)
+        self.assertEqual(cf.background.functions[0].param['Mixing'], 0.84)
+        self.assertEqual(cf.background.functions[1].param['Height'], 1.8)
+        self.assertEqual(cf.background.functions[1].param['Sigma'], 0.27)
+        self.assertEqual(cf.background.functions[1].param['PeakCentre'], 9.0)
+
+    def test_that_multiple_Background_functions_are_instantiated_correctly_in_the_background_object(self):
+        from CrystalField import CrystalField, Background, Function
+        parameters = {'B20': 0.2, 'B40': -0.00164, 'B60': 0.0001146, 'B66': 0.001509}
+        cf = CrystalField('Pr', 'C6v', Temperature=5, **parameters)
+
+        cf.background = Background(functions=[Function('PseudoVoigt', Intensity=101, FWHM=0.8, Mixing=0.84),
+                                              Function('Gaussian', Height=1.8, Sigma=0.27, PeakCentre=9.0),
+                                              Function('LinearBackground', A0=34, A1=0.01)])
+
+        self.assertEqual(cf.background.functions[0].param['Intensity'], 101)
+        self.assertEqual(cf.background.functions[0].param['FWHM'], 0.8)
+        self.assertEqual(cf.background.functions[0].param['Mixing'], 0.84)
+        self.assertEqual(cf.background.functions[1].param['Height'], 1.8)
+        self.assertEqual(cf.background.functions[1].param['Sigma'], 0.27)
+        self.assertEqual(cf.background.functions[1].param['PeakCentre'], 9.0)
+        self.assertEqual(cf.background.functions[2].param['A0'], 34)
+        self.assertEqual(cf.background.functions[2].param['A1'], 0.01)
+
+    def test_that_the_Background_composite_returns_the_expected_function_string(self):
+        from CrystalField import Background, Function
+
+        background = Background(functions=[Function('PseudoVoigt', Intensity=101, FWHM=0.8, Mixing=0.84),
+                                           Function('Gaussian', Height=1.8, Sigma=0.27, PeakCentre=9.0),
+                                           Function('LinearBackground', A0=34, A1=0.01)])
+
+        self.assertEqual(background.toString(), "(name=PseudoVoigt,Mixing=0.84,Intensity=101,PeakCentre=0,FWHM=0.8;"
+                                                "name=Gaussian,Height=1.8,PeakCentre=9,Sigma=0.27;"
+                                                "name=LinearBackground,A0=34,A1=0.01)")
+
+    def test_that_the_Background_composite_returns_the_expected_function_string_with_ties(self):
+        from CrystalField import Background, Function
+
+        background = Background(functions=[Function('PseudoVoigt', Intensity=101, FWHM=0.8, Mixing=0.84),
+                                           Function('Gaussian', Height=1.8, Sigma=0.27, PeakCentre=9.0),
+                                           Function('LinearBackground', A0=34, A1=0.01)])
+        background.functions[0].ties(FWHM=0.8, Mixing=0.84, PeakCentre=-0.1)
+        background.functions[1].ties(PeakCentre=9.0, Height=1.8)
+
+        self.assertEqual(background.toString(), "(name=PseudoVoigt,Mixing=0.84,Intensity=101,PeakCentre=-0.1,FWHM=0.8,"
+                                                "ties=(Mixing=0.84,PeakCentre=-0.1,FWHM=0.8);"
+                                                "name=Gaussian,Height=1.8,PeakCentre=9,Sigma=0.27,"
+                                                "ties=(Height=1.8,PeakCentre=9);"
+                                                "name=LinearBackground,A0=34,A1=0.01)")
+
     def test_api_CrystalField_spectrum_background_no_peak(self):
         from CrystalField import CrystalField, Background, Function
         cf = CrystalField('Ce', 'C2v', B20=0.035, B40=-0.012, B43=-0.027, B60=-0.00012, B63=0.0025, B66=0.0068,


### PR DESCRIPTION
**Description of work.**
This PR extends the CrystalField.Background class to allow input of a list of functions and to combine these into a composite function rather than to have hardcoded only two functions. The PR also keeps backward-compatibility by keeping the `peak=` and `background=` keywords in the CrystalField.Background class constructor.

This means we should still be able to create a `Background` object, and enforce ties, by doing the following:
```py
cf.background = Background(peak=Function('PseudoVoigt', Intensity=101, FWHM=0.8, Mixing=0.84), 
                           background=Function('Gaussian', Height=1.8, Sigma=0.27, PeakCentre=9.0))

cf.background.peak.ties(FWHM=0.8, Mixing=0.84) 
cf.background.background.ties(PeakCentre=9.0, Height=1.8)
```

The PR extends the `Background` object to allow its creation using a list of functions:
```py
cf.background = Background(functions=[Function('PseudoVoigt', Intensity=101, FWHM=0.8, Mixing=0.84), 
                                      Function('Gaussian', Height=1.8, Sigma=0.27, PeakCentre=9.0)])
```
Ties can then be enforced on the functions by doing this:
```py
cf.background.functions[0].ties(FWHM=0.8, Mixing=0.84) 
cf.background.functions[1].ties(PeakCentre=9.0, Height=1.8)
```
This method of setting ties can also be used when creating a background using the `peak=` and `background=` keywords because the `peak` and `background` is stored at index 0 and 1 in the `functions` member variable list respectively if they are provided.

If the `peak=` keyword is not provided, but `background=` is, then `background` is stored at index 0 of the `functions` member variable.

**To test:**
A use-case requiring more than two functions in the `Background` object is found in the attached script and data below. In the Script:
- Line 33/34 is currently uncommented - this is the old way of creating a background which only allows two background functions at most.
- Line 37/38/39 is currently commented - this is the new way of creating a background using many functions in a list.

[Test_script_and_data.zip](https://github.com/mantidproject/mantid/files/5401274/Test_script_and_data.zip)

1. Download the data and save it in a findable location. Load the script into mantid.
2. Run the script with Line 33/34 uncommented. Rename the `fit_workspace` workspace so it is not overridden.
3. Comment out Line 33/34 and uncomment Line 37/38/39. Run the script again.
4. Overplot the 2nd spectrum from the `fit_workspace`s' produced above.
5. Set x axis to be between -1.5 and 1.5
6. Set y axis to be between 0 and 800.
7. The new fit workspace spectrum should appear to have a `Linear Background` (i.e. it should be slightly higher than the old fit). It will look something like this:
![image](https://user-images.githubusercontent.com/40830825/96442868-b4a75880-1203-11eb-9d9f-0a454bcab7ba.png)

It is also important for a scientist to make sure this is working as they would expect.

Fixes #29138

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
