### PR TITLE
Add simplified sequential fitting to EngDiff UI fitting tab.

### DIFF
--- a/docs/source/interfaces/Engineering Diffraction.rst
+++ b/docs/source/interfaces/Engineering Diffraction.rst
@@ -35,7 +35,8 @@ Settings
     Provides a range of options that apply across the entire interface, currently
     providing the option to change the default output directory and force the
     recalculation of the vanadium correction files. The user can also select the
-    log values from a list which are loaded with data in the fitting tab.
+    log values from a list which are loaded with data in the fitting tab and select 
+	a log by which to sort the runs in a sequential fit.
 
 Close
     Close the interface.
@@ -177,7 +178,9 @@ This allows for the user to select peaks of any supported type (e.g. :ref:`Pseud
 After a successful fit the best-fit model is stored as a setup in the fit browser (Setup > Custom Setup) with the name of the workspace fitted. 
 Selecting this loads the function and the parameters and the curve can be inspected by doing Display > Plot Guess.
 
-The output from the fit is stored in a group of workspaces that contains a matrix workspace of the fit value and error for each parameter in the model. If there is more than one of the same function, the parameters are stored in the same workspace with different x-values. For example, if there were two Gaussian peaks then there would be a workspace for each parameter of the Gaussian (i.e. Height, PeakCentre, Sigma) each of which will have two columns corresponding to each peak. Each workspace has a spectra per run loaded (each row in the table of the UI fitting tab). In general different models/functions could be fitted to each run, so when there is a parameter that does not exist for a run (or that run has not yet been fitted), the Y and E fields in the relevant row are filled with NaNs. The group of fit workspaces also contains a table workspace that stores the model string that can be copied into the fitpropertybrowser (Setup > Manage Setup > Load From String).
+The output from the fit is stored in a group of workspaces that contains a matrix workspace of the fit value and error for each parameter in the model. If there is more than one of the same function, the parameters are stored in the same workspace with different x-values. For example, if there were two Gaussian peaks then there would be a workspace for each parameter of the Gaussian (i.e. Height, PeakCentre, Sigma) each of which will have two columns corresponding to each peak. Each workspace has a spectra per run loaded (each row in the table of the UI fitting tab). In general different models/functions could be fitted to each run, so when there is a parameter that does not exist for a run (or that run has not yet been fitted), the Y and E fields in the relevant row are filled with NaNs. The group of fit workspaces also contains a table workspace that stores the model string that can be copied into the fit browser (Setup > Manage Setup > Load From String).
+
+The workspaces can be fit sequentially (sorted by the average of a chosen log in the settings). If a valid model is present in the fit browser then the Sequential Fit button will be enabled - it is not necessary to run an initial fit. The user may want to fix or constrain certain model parameters, which can be done in the usual way in the fit browser. The sequential fit will popoulate the fit tables as above and store the model in the Custom Setups.
 
 Parameters
 ^^^^^^^^^^

--- a/docs/source/interfaces/Engineering Diffraction.rst
+++ b/docs/source/interfaces/Engineering Diffraction.rst
@@ -36,7 +36,7 @@ Settings
     providing the option to change the default output directory and force the
     recalculation of the vanadium correction files. The user can also select the
     log values from a list which are loaded with data in the fitting tab and select 
-	a log by which to sort the runs in a sequential fit.
+    a log by which to sort the runs in a sequential fit.
 
 Close
     Close the interface.
@@ -50,7 +50,7 @@ Red Stars
 
 Status Bar
     The status bar shows the calibration run numbers the GUI is currently using.
-	It also displays the save directory (which can be changed in the settings).
+    It also displays the save directory (which can be changed in the settings).
 
 Saved File Outputs
     The location of files saved by the GUI during processing will be shown in the mantid

--- a/docs/source/release/v6.0.0/diffraction.rst
+++ b/docs/source/release/v6.0.0/diffraction.rst
@@ -33,10 +33,20 @@ Bugfixes
 
 Engineering Diffraction
 -----------------------
+
+Bugfixes
+############
+- Settings are now saved only when the Apply or OK button are clicked (i.e. clicking cancel will not update the settings).
+
+Improvements
+############
+- The user is no longer asked to overwrite an automatically generated model that is saved in as a Custom Setup in the fit browser (it is overwritten).
+
 New features
 ############
 - When a fit is successful the model will be stored as a Custom Setup in the fit property browser under the name of the workspace fitted. 
-- The fitting tab now creates a group of workspaces that store the model string and  the fit value and error of parameters of the model for each loaded workspace.
+- The fitting tab now creates a group of workspaces that store the model string and the fit value and error of parameters of the model for each loaded workspace.
+- Sequential fitting of workspaces now provided in fitting tab by average value of a log set in settings.
 
 Single Crystal Diffraction
 --------------------------

--- a/qt/python/mantidqt/_common.sip
+++ b/qt/python/mantidqt/_common.sip
@@ -459,6 +459,7 @@ public:
     int sizeOfFunctionsGroup() const;
     void loadFunction(QString funStr);
     void saveFunction(const QString &fnName);
+    void executeCustomSetupRemove(const QString &name);
     double startX() const;
     void setStartX(double start);
     double endX() const;

--- a/qt/python/mantidqt/_common.sip
+++ b/qt/python/mantidqt/_common.sip
@@ -457,6 +457,8 @@ public:
     }
 %End
     int sizeOfFunctionsGroup() const;
+    bool isFitEnabled() const;
+    std::string getFunctionString() const;
     void loadFunction(QString funStr);
     void saveFunction(const QString &fnName);
     void executeCustomSetupRemove(const QString &name);
@@ -466,6 +468,7 @@ public:
     void setEndX(double end);
     void setXRange(double start, double end);
     QVector<double> getXRange() throw(std::invalid_argument);
+    std::string getExcludeRange() const;
     QString getXColumnName() const;
     QString getYColumnName() const;
     QString getErrColumnName() const;

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/FitPropertyBrowser.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/FitPropertyBrowser.h
@@ -182,6 +182,8 @@ public:
   /// Get the X limits of the workspace
   QVector<double> getXRange();
 
+  /// Get the function as a string
+  std::string getFunctionString() const;
   /// Get the start X
   double startX() const;
   /// Set the start X

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/FitPropertyBrowser.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/FitPropertyBrowser.h
@@ -342,6 +342,7 @@ public slots:
   void executeSetupMenu(const QString & /*item*/);
   void executeSetupManageMenu(const QString & /*item*/);
   void workspaceDoubleClicked(QListWidgetItem *item);
+  void executeCustomSetupRemove(const QString &name);
 
 signals:
   void currentChanged() const;
@@ -450,7 +451,7 @@ private slots:
   void processMultiBGResults();
 
   void executeCustomSetupLoad(const QString &name);
-  void executeCustomSetupRemove(const QString &name);
+  // void executeCustomSetupRemove(const QString &name);
 
   /// Update structure tooltips for all functions
   void updateStructureTooltips();

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/FitPropertyBrowser.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/FitPropertyBrowser.h
@@ -453,7 +453,6 @@ private slots:
   void processMultiBGResults();
 
   void executeCustomSetupLoad(const QString &name);
-  // void executeCustomSetupRemove(const QString &name);
 
   /// Update structure tooltips for all functions
   void updateStructureTooltips();

--- a/qt/widgets/common/src/FitPropertyBrowser.cpp
+++ b/qt/widgets/common/src/FitPropertyBrowser.cpp
@@ -1759,7 +1759,7 @@ void FitPropertyBrowser::finishHandle(const Mantid::API::IAlgorithm *alg) {
   }
 }
 
-std::string FitPropertyBrowser::getFunctionString() const{
+std::string FitPropertyBrowser::getFunctionString() const {
   auto function = getFittingFunction();
   std::string funStr = function->asString();
   return funStr;

--- a/qt/widgets/common/src/FitPropertyBrowser.cpp
+++ b/qt/widgets/common/src/FitPropertyBrowser.cpp
@@ -1761,8 +1761,7 @@ void FitPropertyBrowser::finishHandle(const Mantid::API::IAlgorithm *alg) {
 
 std::string FitPropertyBrowser::getFunctionString() const {
   auto function = getFittingFunction();
-  std::string funStr = function->asString();
-  return funStr;
+  return function->asString();
 }
 
 /// Display the status string returned from Fit

--- a/qt/widgets/common/src/FitPropertyBrowser.cpp
+++ b/qt/widgets/common/src/FitPropertyBrowser.cpp
@@ -1646,8 +1646,7 @@ void FitPropertyBrowser::doFit(int maxIterations) {
     }
     m_fitActionUndoFit->setEnabled(true);
 
-    auto function = getFittingFunction();
-    const std::string funStr = function->asString();
+    const std::string funStr = getFunctionString();
 
     Mantid::API::IAlgorithm_sptr alg =
         Mantid::API::AlgorithmManager::Instance().create("Fit");
@@ -1758,6 +1757,12 @@ void FitPropertyBrowser::finishHandle(const Mantid::API::IAlgorithm *alg) {
   if (m_compositeFunction->name() == "MultiBG") {
     emit multifitFinished();
   }
+}
+
+std::string FitPropertyBrowser::getFunctionString() const{
+  auto function = getFittingFunction();
+  std::string funStr = function->asString();
+  return funStr;
 }
 
 /// Display the status string returned from Fit

--- a/scripts/Engineering/gui/engineering_diffraction/engineering_diffraction.py
+++ b/scripts/Engineering/gui/engineering_diffraction/engineering_diffraction.py
@@ -143,7 +143,6 @@ class EngineeringDiffractionGui(QtWidgets.QMainWindow, Ui_main_window):
         InterfaceManager().showCustomInterfaceHelp(self.doc)
 
     def open_settings(self):
-        self.settings_presenter.load_existing_settings()
         self.settings_presenter.show()
 
     def get_rb_no(self):

--- a/scripts/Engineering/gui/engineering_diffraction/settings/settings_presenter.py
+++ b/scripts/Engineering/gui/engineering_diffraction/settings/settings_presenter.py
@@ -18,7 +18,7 @@ DEFAULT_SETTINGS = {
     "logs": ','.join(
         ['Temp_1', 'W_position', 'X_position', 'Y_position', 'Z_position', 'stress', 'strain', 'stressrig_go']),
     "primary_log": 'strain',
-    "sort_ascending": True
+    "sort_ascending": "true"
 }
 
 ALL_LOGS = ','.join(
@@ -108,6 +108,7 @@ class SettingsPresenter(object):
         if not self._validate_settings(self.settings):
             self.settings = DEFAULT_SETTINGS.copy()
             self._save_settings_to_file()
+        self._find_files()
 
     @staticmethod
     def _validate_settings(settings):

--- a/scripts/Engineering/gui/engineering_diffraction/settings/settings_presenter.py
+++ b/scripts/Engineering/gui/engineering_diffraction/settings/settings_presenter.py
@@ -18,7 +18,7 @@ DEFAULT_SETTINGS = {
     "logs": ','.join(
         ['Temp_1', 'W_position', 'X_position', 'Y_position', 'Z_position', 'stress', 'strain', 'stressrig_go']),
     "primary_log": 'strain',
-    "sort_ascending": "true"
+    "sort_ascending": True
 }
 
 ALL_LOGS = ','.join(
@@ -118,7 +118,8 @@ class SettingsPresenter(object):
             save_location = str(settings["save_location"])
             save_valid = save_location != ""
             log_valid = settings["logs"] != ""
-            return all_keys and not_none and save_valid and log_valid
+            ascending_valid = settings["sort_ascending"] != ""
+            return all_keys and not_none and save_valid and log_valid and ascending_valid
         except KeyError:  # Settings contained invalid key.
             return False
 

--- a/scripts/Engineering/gui/engineering_diffraction/settings/settings_view.py
+++ b/scripts/Engineering/gui/engineering_diffraction/settings/settings_view.py
@@ -25,6 +25,12 @@ class SettingsView(QtWidgets.QDialog, Ui_settings):
         self.finder_fullCalib.setLabelText("Full Calibration")
         self.finder_fullCalib.isForRunFiles(False)
 
+        # set text of labels
+        self.log_list_label.setText("Check logs to average when loading focused data")
+        self.primary_log_label.setText(
+            "Sort workspaces by selected log average in sequential fitting (default is ascending order)\n"
+            "If the box below is empty the workspaces will be fitted in the order they appear in the table.")
+
     # ===============
     # Slot Connectors
     # ===============
@@ -41,8 +47,11 @@ class SettingsView(QtWidgets.QDialog, Ui_settings):
     def set_on_log_changed(self, slot):
         self.log_list.itemChanged.connect(slot)
 
-    def set_on_primary_log_changed(self, slot):
-        self.primary_log.currentTextChanged.connect(slot)
+    def set_on_check_ascending_changed(self, slot):
+        self.check_ascending.stateChanged.connect(slot)
+
+    def set_on_check_descending_changed(self, slot):
+        self.check_descending.stateChanged.connect(slot)
 
     # =================
     # Component Getters
@@ -63,6 +72,9 @@ class SettingsView(QtWidgets.QDialog, Ui_settings):
 
     def get_primary_log(self):
         return self.primary_log.currentText()
+
+    def get_ascending_checked(self):
+        return self.check_ascending.isChecked()
 
     # =================
     # Component Setters
@@ -100,6 +112,12 @@ class SettingsView(QtWidgets.QDialog, Ui_settings):
             self.primary_log.setCurrentText(primary_log)
         else:
             self.primary_log.setCurrentText('')
+
+    def set_ascending_checked(self, checked):
+        self.check_ascending.setChecked(checked)
+
+    def set_descending_checked(self, checked):
+        self.check_descending.setChecked(checked)
 
     # =================
     # Force Actions

--- a/scripts/Engineering/gui/engineering_diffraction/settings/settings_view.py
+++ b/scripts/Engineering/gui/engineering_diffraction/settings/settings_view.py
@@ -41,6 +41,9 @@ class SettingsView(QtWidgets.QDialog, Ui_settings):
     def set_on_log_changed(self, slot):
         self.log_list.itemChanged.connect(slot)
 
+    def set_on_primary_log_changed(self, slot):
+        self.primary_log.currentTextChanged.connect(slot)
+
     # =================
     # Component Getters
     # =================
@@ -57,6 +60,9 @@ class SettingsView(QtWidgets.QDialog, Ui_settings):
     def get_checked_logs(self):
         return ','.join([self.log_list.item(ilog).text() for ilog in range(self.log_list.count()) if
                          self.log_list.item(ilog).checkState() == QtCore.Qt.Checked])
+
+    def get_primary_log(self):
+        return self.primary_log.currentText()
 
     # =================
     # Component Setters
@@ -79,9 +85,21 @@ class SettingsView(QtWidgets.QDialog, Ui_settings):
             self.log_list.addItem(item)
 
     def set_checked_logs(self, logs):
+        # block signal so as not to reset primary log
+        self.log_list.blockSignals(True)
         for log in logs.split(','):
             items = self.log_list.findItems(log, QtCore.Qt.MatchExactly)
             items[0].setCheckState(QtCore.Qt.Checked)
+        self.log_list.blockSignals(False)
+
+    def set_primary_log_combobox(self, primary_log):
+        checked_logs = self.get_checked_logs().split(',') + ['']
+        self.primary_log.clear()
+        self.primary_log.addItems(checked_logs)
+        if primary_log in checked_logs:
+            self.primary_log.setCurrentText(primary_log)
+        else:
+            self.primary_log.setCurrentText('')
 
     # =================
     # Force Actions

--- a/scripts/Engineering/gui/engineering_diffraction/settings/settings_widget.ui
+++ b/scripts/Engineering/gui/engineering_diffraction/settings/settings_widget.ui
@@ -65,17 +65,47 @@ QGroupBox:title {
       <string>Fitting</string>
      </property>
      <layout class="QGridLayout" name="gridLayout_3">
-      <item row="0" column="0">
+	  <item row="0" column="0">
+	   <widget class="QLabel" name="log_list_label"></widget>
+	  </item>
+      <item row="1" column="0">
        <widget class="QListWidget" name="log_list">
 		<property name="verticalScrollBarPolicy">
 		  <enum>Qt::ScrollBarAlwaysOn</enum>
         </property>
        </widget>
       </item>
-	  <item row="1" column="0">
+	  <item row="2" column="0">
+	   <widget class="QLabel" name="primary_log_label"></widget>
+	  </item>
+	  <item row="3" column="0">
        <widget class="QComboBox" name="primary_log">
        </widget>
       </item>
+	  <item row="3" column="1">
+	   <layout class="QVBoxLayout" name="SeqFitOrder_layout">
+	    <item>
+         <widget class="QCheckBox" name="check_ascending">
+          <property name="text">
+           <string>Ascending</string>
+          </property>
+		  <property name="checked">
+           <bool>true</bool>
+          </property>
+	    </widget>
+	    </item>
+		<item>
+         <widget class="QCheckBox" name="check_descending">
+          <property name="text">
+           <string>Descending</string>
+          </property>
+		  <property name="checked">
+           <bool>false</bool>
+          </property>
+	    </widget>
+	    </item>
+	   </layout>
+	  </item>
      </layout>
     </widget>
    </item>

--- a/scripts/Engineering/gui/engineering_diffraction/settings/settings_widget.ui
+++ b/scripts/Engineering/gui/engineering_diffraction/settings/settings_widget.ui
@@ -72,6 +72,10 @@ QGroupBox:title {
         </property>
        </widget>
       </item>
+	  <item row="1" column="0">
+       <widget class="QComboBox" name="primary_log">
+       </widget>
+      </item>
      </layout>
     </widget>
    </item>

--- a/scripts/Engineering/gui/engineering_diffraction/settings/test/test_settings_presenter.py
+++ b/scripts/Engineering/gui/engineering_diffraction/settings/test/test_settings_presenter.py
@@ -11,8 +11,6 @@ from unittest import mock
 
 from Engineering.gui.engineering_diffraction.settings import settings_model, settings_view, settings_presenter
 
-dir_path = "Engineering.gui.engineering_diffraction.settings."
-
 
 class SettingsPresenterTest(unittest.TestCase):
     def setUp(self):
@@ -20,38 +18,26 @@ class SettingsPresenterTest(unittest.TestCase):
         self.view = mock.create_autospec(settings_view.SettingsView)
         self.presenter = settings_presenter.SettingsPresenter(self.model, self.view)
         self.presenter.settings = {}
+        self.settings = {"save_location": "save",
+                         "full_calibration": "cal",
+                         "recalc_vanadium": False,
+                         "logs": "some,logs",
+                         "primary_log": "some",
+                         "sort_ascending": True
+                         }
 
     def test_load_existing_settings(self):
-        self.model.get_settings_dict.return_value = {
-            "save_location": "result",
-            "full_calibration": "value",
-            "recalc_vanadium": False,
-            "logs": "some,logs"
-        }
+        self.model.get_settings_dict.return_value = self.settings.copy()
 
-        self.presenter.load_existing_settings()
+        self.presenter.load_settings_from_file_or_default()
 
-        self.assertEqual(self.presenter.settings, {
-            "full_calibration": "value",
-            "save_location": "result",
-            "recalc_vanadium": False,
-            "logs": "some,logs"
-        })
-        self.assertEqual(self.view.set_save_location.call_count, 1)
-        self.assertEqual(self.view.set_full_calibration.call_count, 1)
-        self.assertEqual(self.view.set_van_recalc.call_count, 1)
-        self.assertEqual(self.view.add_log_checkboxs.call_count, 1)
-        self.assertEqual(self.view.set_checked_logs.call_count, 1)
+        self.assertEqual(self.presenter.settings, self.settings)
+        self.model.set_settings_dict.assert_not_called()
 
     def test_file_searched_on_opening(self):
-        self.model.get_settings_dict.return_value = {
-            "save_location": "result",
-            "full_calibration": "value",
-            "recalc_vanadium": False,
-            "logs": "some,logs"
-        }
+        self.model.get_settings_dict.return_value = self.settings.copy()
 
-        self.presenter.load_existing_settings()
+        self.presenter.load_settings_from_file_or_default()
 
         self.assertEqual(1, self.view.find_full_calibration.call_count)
         self.assertEqual(1, self.view.find_save.call_count)
@@ -62,60 +48,60 @@ class SettingsPresenterTest(unittest.TestCase):
             "bar": "result"
         }
         self.presenter.savedir_notifier = mock.MagicMock()
-        self.presenter.load_existing_settings()
 
-        self.view.set_save_location.assert_called_with(settings_presenter.DEFAULT_SETTINGS["save_location"])
-        self.view.set_full_calibration.assert_called_with(settings_presenter.DEFAULT_SETTINGS["full_calibration"])
-        self.view.set_van_recalc.assert_called_with(settings_presenter.DEFAULT_SETTINGS["recalc_vanadium"])
-        self.view.set_checked_logs.assert_called_with(settings_presenter.DEFAULT_SETTINGS["logs"])
+        self.presenter.load_settings_from_file_or_default()
+
+        self.assertEqual(self.presenter.settings, settings_presenter.DEFAULT_SETTINGS)
+        self.model.set_settings_dict.assert_called_once()  # called to replace invalid settings
 
     def test_save_new_settings(self):
-        self.view.get_save_location.return_value = "save"
-        self.view.get_full_calibration.return_value = "cal"
-        self.view.get_van_recalc.return_value = False
-        self.view.get_checked_logs.return_value = "some,logs"
+        self.view.get_save_location.return_value = self.settings['save_location'][:]
+        self.view.get_full_calibration.return_value = self.settings['full_calibration'][:]
+        self.view.get_van_recalc.return_value = self.settings['recalc_vanadium']
+        self.view.get_checked_logs.return_value = self.settings['logs'][:]
+        self.view.get_primary_log.return_value = self.settings['primary_log'][:]
+        self.view.get_ascending_checked.return_value = self.settings['sort_ascending']
         self.presenter.savedir_notifier = mock.MagicMock()
 
         self.presenter.save_new_settings()
 
-        self.assertEqual(self.presenter.settings, {
-            "full_calibration": "cal",
-            "save_location": "save",
-            "recalc_vanadium": False,
-            "logs": "some,logs"
-        })
-        self.model.set_settings_dict.assert_called_with({
-            "full_calibration": "cal",
-            "save_location": "save",
-            "recalc_vanadium": False,
-            "logs": "some,logs"
-        })
         self.assertEqual(self.view.close.call_count, 0)
+        self.assertEqual(self.presenter.settings, self.settings)
+        self.model.set_settings_dict.assert_called_with(self.settings)
         self.assertEqual(self.presenter.savedir_notifier.notify_subscribers.call_count, 1)
 
+    def test_show(self):
+        self.presenter.settings = self.settings.copy()
+
+        self.presenter.show()
+
+        # check that view is updated before being shown
+        self.view.set_save_location.assert_called_with(self.settings["save_location"])
+        self.view.set_full_calibration.assert_called_with(self.settings["full_calibration"])
+        self.view.set_van_recalc.assert_called_with(self.settings["recalc_vanadium"])
+        self.view.set_checked_logs.assert_called_with(self.settings["logs"])
+        self.view.set_primary_log_combobox.assert_called_with(self.settings["primary_log"])
+        self.view.set_ascending_checked.assert_called_with(self.settings["sort_ascending"])
+
     def test_save_settings_and_close(self):
-        self.view.get_save_location.return_value = "save"
-        self.view.get_full_calibration.return_value = "cal"
-        self.view.get_van_recalc.return_value = False
-        self.view.get_checked_logs.return_value = "some,logs"
+        self.view.get_save_location.return_value = self.settings['save_location'][:]
+        self.view.get_full_calibration.return_value = self.settings['full_calibration'][:]
+        self.view.get_van_recalc.return_value = self.settings['recalc_vanadium']
+        self.view.get_checked_logs.return_value = self.settings['logs'][:]
+        self.view.get_primary_log.return_value = self.settings['primary_log'][:]
+        self.view.get_ascending_checked.return_value = self.settings['sort_ascending']
         self.presenter.savedir_notifier = mock.MagicMock()
 
         self.presenter.save_and_close_dialog()
 
-        self.assertEqual(self.presenter.settings, {
-            "full_calibration": "cal",
-            "save_location": "save",
-            "recalc_vanadium": False,
-            "logs": "some,logs"
-        })
-        self.model.set_settings_dict.assert_called_with({
-            "full_calibration": "cal",
-            "save_location": "save",
-            "recalc_vanadium": False,
-            "logs": "some,logs"
-        })
+        self.assertEqual(self.presenter.settings, self.settings)
+        self.model.set_settings_dict.assert_called_with(self.settings)
         self.assertEqual(self.view.close.call_count, 1)
         self.assertEqual(self.presenter.savedir_notifier.notify_subscribers.call_count, 1)
+
+    def test_settings_not_changed_when_cancelled(self):
+        self.presenter.close_dialog()
+        self.model.set_settings_dict.assert_not_called()
 
 
 if __name__ == '__main__':

--- a/scripts/Engineering/gui/engineering_diffraction/tabs/fitting/data_handling/data_model.py
+++ b/scripts/Engineering/gui/engineering_diffraction/tabs/fitting/data_handling/data_model.py
@@ -171,7 +171,7 @@ class FittingDataModel(object):
             # get num params for each function (first elem empty as str begins with 'name=')
             # need to remove ties and constrtaints which are enclosed in ()
             nparams = [s.count('=') for s in
-                       sub('=\([^)]*\)', '', fitprop['properties']['Function']).split('name=')[1:]]
+                       sub(r'=\([^)]*\)', '', fitprop['properties']['Function']).split('name=')[1:]]
             params_dict = ADS.retrieve(fitprop['properties']['Output'] + '_Parameters').toDict()
             # loop over rows in output workspace to get value and error for each parameter
             istart = 0

--- a/scripts/Engineering/gui/engineering_diffraction/tabs/fitting/data_handling/data_model.py
+++ b/scripts/Engineering/gui/engineering_diffraction/tabs/fitting/data_handling/data_model.py
@@ -151,12 +151,16 @@ class FittingDataModel(object):
         ws_list = list(self._loaded_workspaces.keys())
         primary_log = get_setting(path_handling.INTERFACES_SETTINGS_GROUP, path_handling.ENGINEERING_PREFIX,
                                   "primary_log")
+        sort_ascending = get_setting(path_handling.INTERFACES_SETTINGS_GROUP, path_handling.ENGINEERING_PREFIX,
+                                     "sort_ascending")
         if primary_log:
             log_table = ADS.retrieve(primary_log)
             isort = argsort(array(log_table.column('avg')))
-            return [ws_list[iws] for iws in isort]
-        else:
-            return ws_list
+            ws_list = [ws_list[iws] for iws in isort]
+        if not sort_ascending == 'true':
+            # settings can only be saved as text
+            ws_list = ws_list[::-1]
+        return ws_list
 
     def update_fit(self, fitprops):
         for fitprop in fitprops:

--- a/scripts/Engineering/gui/engineering_diffraction/tabs/fitting/data_handling/data_model.py
+++ b/scripts/Engineering/gui/engineering_diffraction/tabs/fitting/data_handling/data_model.py
@@ -182,6 +182,9 @@ class FittingDataModel(object):
                     self._fit_results[wsname]['results'][key].append([
                         params_dict['Value'][irow], params_dict['Error'][irow]])
                 istart += nparams[ifunc]
+            # append the cost function value (in this case always chisq/DOF) as don't let user change cost func
+            # always last row in parameters table
+            self._fit_results[wsname]['costFunction'] = params_dict['Value'][-1]
         self.create_fit_tables()
 
     def create_fit_tables(self):
@@ -214,13 +217,14 @@ class FittingDataModel(object):
         # table for model summary/info
         model = CreateEmptyTableWorkspace(OutputWorkspace='model')
         model.addColumn(type="str", name="Workspace")
+        model.addColumn(type="float", name="chisq/DOF")  # always is for LM minimiser (users can't change)
         model.addColumn(type="str", name="Model")
         for iws, wsname in enumerate(self._loaded_workspaces.keys()):
             if wsname in self._fit_results:
-                row = [wsname, self._fit_results[wsname]['model']]
+                row = [wsname, self._fit_results[wsname]['costFunction'], self._fit_results[wsname]['model']]
                 self.write_table_row(model, row, iws)
             else:
-                self.write_table_row(model, ['', ''], iws)
+                self.write_table_row(model, ['', nan, ''], iws)
         wslist += [model]
         group_name = self._log_workspaces.name().split('_log')[0] + '_fits'
         self._fit_workspaces = GroupWorkspaces(wslist, OutputWorkspace=group_name)

--- a/scripts/Engineering/gui/engineering_diffraction/tabs/fitting/data_handling/data_model.py
+++ b/scripts/Engineering/gui/engineering_diffraction/tabs/fitting/data_handling/data_model.py
@@ -13,7 +13,7 @@ from Engineering.gui.engineering_diffraction.tabs.common import path_handling
 from mantid.api import AnalysisDataService as ADS
 from mantid.api import TextAxis
 from matplotlib.pyplot import subplots
-from numpy import full, nan, max, array, vstack
+from numpy import full, nan, max, array, vstack, argsort
 from itertools import chain
 from re import findall
 from collections import defaultdict
@@ -146,6 +146,14 @@ class FittingDataModel(object):
                 RenameWorkspace(InputWorkspace=self._log_workspaces.name(), OutputWorkspace=name)
         else:
             self.clear_logs()
+
+    def get_ws_sorted_by_primary_log(self):
+        primary_log = get_setting(path_handling.INTERFACES_SETTINGS_GROUP, path_handling.ENGINEERING_PREFIX,
+                                  "primary_log")
+        log_table = ADS.retrieve(primary_log)
+        isort = argsort(array(log_table.column('avg')))
+        ws_list = list(self._loaded_workspaces.keys())
+        return [ws_list[iws] for iws in isort]
 
     def update_fit(self, results_dict):
         wsname = results_dict['properties']['InputWorkspace']

--- a/scripts/Engineering/gui/engineering_diffraction/tabs/fitting/data_handling/data_model.py
+++ b/scripts/Engineering/gui/engineering_diffraction/tabs/fitting/data_handling/data_model.py
@@ -166,7 +166,7 @@ class FittingDataModel(object):
         for fitprop in fitprops:
             wsname = fitprop['properties']['InputWorkspace']
             self._fit_results[wsname] = {'model': fitprop['properties']['Function']}
-            self._fit_results[wsname]['results'] = dict()  # {function_param: [[Y1, E1], [Y2,E2],...] }
+            self._fit_results[wsname]['results'] = defaultdict(list)  # {function_param: [[Y1, E1], [Y2,E2],...] }
             fnames = [x.split('=')[-1] for x in findall('name=[^,]*', fitprop['properties']['Function'])]
             # get num params for each function (first elem empty as str begins with 'name=')
             # need to remove ties and constrtaints which are enclosed in ()
@@ -179,8 +179,6 @@ class FittingDataModel(object):
                 for iparam in range(0, nparams[ifunc]):
                     irow = istart + iparam
                     key = '_'.join([fname, params_dict['Name'][irow].split('.')[-1]])  # funcname_param
-                    if key not in self._fit_results[wsname]['results']:
-                        self._fit_results[wsname]['results'][key] = []
                     self._fit_results[wsname]['results'][key].append([
                         params_dict['Value'][irow], params_dict['Error'][irow]])
                 istart += nparams[ifunc]

--- a/scripts/Engineering/gui/engineering_diffraction/tabs/fitting/data_handling/data_model.py
+++ b/scripts/Engineering/gui/engineering_diffraction/tabs/fitting/data_handling/data_model.py
@@ -15,8 +15,8 @@ from mantid.api import TextAxis
 from matplotlib.pyplot import subplots
 from numpy import full, nan, max, array, vstack, argsort
 from itertools import chain
-from re import findall
 from collections import defaultdict
+from re import findall, sub
 
 
 class FittingDataModel(object):
@@ -148,30 +148,38 @@ class FittingDataModel(object):
             self.clear_logs()
 
     def get_ws_sorted_by_primary_log(self):
+        ws_list = list(self._loaded_workspaces.keys())
         primary_log = get_setting(path_handling.INTERFACES_SETTINGS_GROUP, path_handling.ENGINEERING_PREFIX,
                                   "primary_log")
-        log_table = ADS.retrieve(primary_log)
-        isort = argsort(array(log_table.column('avg')))
-        ws_list = list(self._loaded_workspaces.keys())
-        return [ws_list[iws] for iws in isort]
+        if primary_log:
+            log_table = ADS.retrieve(primary_log)
+            isort = argsort(array(log_table.column('avg')))
+            return [ws_list[iws] for iws in isort]
+        else:
+            return ws_list
 
-    def update_fit(self, results_dict):
-        wsname = results_dict['properties']['InputWorkspace']
-        self._fit_results[wsname] = {'model': results_dict['properties']['Function']}
-        self._fit_results[wsname]['results'] = defaultdict(list)  # {function_param: [[Y1, E1], [Y2,E2],...] }
-        fnames = [x.split('=')[-1] for x in findall('name=[^,]*', results_dict['properties']['Function'])]
-        # get num params for each function (first elem empty as str begins with 'name='
-        nparams = [s.count('=') for s in results_dict['properties']['Function'].split('name=')[1:]]
-        params_dict = ADS.retrieve(results_dict['properties']['Output'] + '_Parameters').toDict()
-        # loop over rows in output workspace to get value and error for each parameter
-        istart = 0
-        for ifunc, fname in enumerate(fnames):
-            for iparam in range(0, nparams[ifunc]):
-                irow = istart + iparam
-                key = '_'.join([fname, params_dict['Name'][irow].split('.')[-1]])  # funcname_param
-                self._fit_results[wsname]['results'][key].append([
-                    params_dict['Value'][irow], params_dict['Error'][irow]])
-            istart += nparams[ifunc]
+    def update_fit(self, fitprops):
+        for fitprop in fitprops:
+            wsname = fitprop['properties']['InputWorkspace']
+            self._fit_results[wsname] = {'model': fitprop['properties']['Function']}
+            self._fit_results[wsname]['results'] = dict()  # {function_param: [[Y1, E1], [Y2,E2],...] }
+            fnames = [x.split('=')[-1] for x in findall('name=[^,]*', fitprop['properties']['Function'])]
+            # get num params for each function (first elem empty as str begins with 'name=')
+            # need to remove ties and constrtaints which are enclosed in ()
+            nparams = [s.count('=') for s in
+                       sub('=\([^)]*\)', '', fitprop['properties']['Function']).split('name=')[1:]]
+            params_dict = ADS.retrieve(fitprop['properties']['Output'] + '_Parameters').toDict()
+            # loop over rows in output workspace to get value and error for each parameter
+            istart = 0
+            for ifunc, fname in enumerate(fnames):
+                for iparam in range(0, nparams[ifunc]):
+                    irow = istart + iparam
+                    key = '_'.join([fname, params_dict['Name'][irow].split('.')[-1]])  # funcname_param
+                    if key not in self._fit_results[wsname]['results']:
+                        self._fit_results[wsname]['results'][key] = []
+                    self._fit_results[wsname]['results'][key].append([
+                        params_dict['Value'][irow], params_dict['Error'][irow]])
+                istart += nparams[ifunc]
         self.create_fit_tables()
 
     def create_fit_tables(self):

--- a/scripts/Engineering/gui/engineering_diffraction/tabs/fitting/data_handling/data_presenter.py
+++ b/scripts/Engineering/gui/engineering_diffraction/tabs/fitting/data_handling/data_presenter.py
@@ -39,10 +39,10 @@ class FittingDataPresenter(object):
         self.seq_fit_notifier = GenericObservable()
         # Obeservers
         self.fit_observer = GenericObserverWithArgPassing(self.fit_completed)
-        self.func_changed_observer = GenericObserverWithArgPassing(self.func_changed)
+        self.fit_enabled_observer = GenericObserverWithArgPassing(self.set_fit_enabled)
         self.seq_fit_observer = GenericObserverWithArgPassing(self.fit_completed)
 
-    def func_changed(self, fit_enabled):
+    def set_fit_enabled(self, fit_enabled):
         self.view.set_seq_fit_button_enabled(fit_enabled)
 
     def fit_completed(self, fitprops):

--- a/scripts/Engineering/gui/engineering_diffraction/tabs/fitting/data_handling/data_presenter.py
+++ b/scripts/Engineering/gui/engineering_diffraction/tabs/fitting/data_handling/data_presenter.py
@@ -39,15 +39,13 @@ class FittingDataPresenter(object):
         self.apply_fit_notifier = GenericObservable()
         # Obeservers
         self.fit_observer = GenericObserverWithArgPassing(self.fit_completed)
-        self.seq_fit_observer = GenericObserverWithArgPassing(self.seq_fit_completed)
+        self.func_changed_observer = GenericObserverWithArgPassing(self.func_changed)
+        self.seq_fit_observer = GenericObserverWithArgPassing(self.fit_completed)
 
+    def func_changed(self, fit_enabled):
+        self.view.set_apply_fit_button_enabled(fit_enabled)
 
-    def fit_completed(self, fitprop):
-        if self.get_loaded_workspaces():
-            self.view.set_apply_fit_button_enabled(True)
-        self.model.update_fit([fitprop])
-
-    def seq_fit_completed(self, fitprops):
+    def fit_completed(self, fitprops):
         self.model.update_fit(fitprops)
 
     def _start_seq_fit(self):

--- a/scripts/Engineering/gui/engineering_diffraction/tabs/fitting/data_handling/data_presenter.py
+++ b/scripts/Engineering/gui/engineering_diffraction/tabs/fitting/data_handling/data_presenter.py
@@ -27,7 +27,7 @@ class FittingDataPresenter(object):
         self.view.set_on_remove_selected_clicked(self._remove_selected_tracked_workspaces)
         self.view.set_on_remove_all_clicked(self._remove_all_tracked_workspaces)
         self.view.set_on_plotBG_clicked(self._plotBG)
-        self.view.set_on_apply_fit_clicked(self._start_seq_fit)
+        self.view.set_on_seq_fit_clicked(self._start_seq_fit)
         self.view.set_on_table_cell_changed(self._handle_table_cell_changed)
         self.view.set_on_xunit_changed(self._log_xunit_change)
         self.view.set_table_selection_changed(self._handle_selection_changed)
@@ -36,14 +36,14 @@ class FittingDataPresenter(object):
         self.plot_added_notifier = GenericObservable()
         self.plot_removed_notifier = GenericObservable()
         self.all_plots_removed_notifier = GenericObservable()
-        self.apply_fit_notifier = GenericObservable()
+        self.seq_fit_notifier = GenericObservable()
         # Obeservers
         self.fit_observer = GenericObserverWithArgPassing(self.fit_completed)
         self.func_changed_observer = GenericObserverWithArgPassing(self.func_changed)
         self.seq_fit_observer = GenericObserverWithArgPassing(self.fit_completed)
 
     def func_changed(self, fit_enabled):
-        self.view.set_apply_fit_button_enabled(fit_enabled)
+        self.view.set_seq_fit_button_enabled(fit_enabled)
 
     def fit_completed(self, fitprops):
         self.model.update_fit(fitprops)
@@ -51,7 +51,7 @@ class FittingDataPresenter(object):
     def _start_seq_fit(self):
         ws_list = self.model.get_ws_sorted_by_primary_log()
         # set off sequential fit
-        self.apply_fit_notifier.notify_subscribers(ws_list)
+        self.seq_fit_notifier.notify_subscribers(ws_list)
 
     def _log_xunit_change(self, xunit):
         logger.notice("Subsequent files will be loaded with the x-axis unit:\t{}".format(xunit))

--- a/scripts/Engineering/gui/engineering_diffraction/tabs/fitting/data_handling/data_presenter.py
+++ b/scripts/Engineering/gui/engineering_diffraction/tabs/fitting/data_handling/data_presenter.py
@@ -36,11 +36,11 @@ class FittingDataPresenter(object):
         self.plot_added_notifier = GenericObservable()
         self.plot_removed_notifier = GenericObservable()
         self.all_plots_removed_notifier = GenericObservable()
-        self.seq_fit_notifier = GenericObservable()
+        self.seq_fit_started_notifier = GenericObservable()
         # Obeservers
         self.fit_observer = GenericObserverWithArgPassing(self.fit_completed)
         self.fit_enabled_observer = GenericObserverWithArgPassing(self.set_fit_enabled)
-        self.seq_fit_observer = GenericObserverWithArgPassing(self.fit_completed)
+        self.seq_fit_done_observer = GenericObserverWithArgPassing(self.fit_completed)
 
     def set_fit_enabled(self, fit_enabled):
         self.view.set_seq_fit_button_enabled(fit_enabled)
@@ -51,7 +51,7 @@ class FittingDataPresenter(object):
     def _start_seq_fit(self):
         ws_list = self.model.get_ws_sorted_by_primary_log()
         # set off sequential fit
-        self.seq_fit_notifier.notify_subscribers(ws_list)
+        self.seq_fit_started_notifier.notify_subscribers(ws_list)
 
     def _log_xunit_change(self, xunit):
         logger.notice("Subsequent files will be loaded with the x-axis unit:\t{}".format(xunit))

--- a/scripts/Engineering/gui/engineering_diffraction/tabs/fitting/data_handling/data_view.py
+++ b/scripts/Engineering/gui/engineering_diffraction/tabs/fitting/data_handling/data_view.py
@@ -51,8 +51,8 @@ class FittingDataView(QtWidgets.QWidget, Ui_data):
     def set_on_plotBG_clicked(self, slot):
         self.button_plotBG.clicked.connect(slot)
 
-    def set_on_apply_fit_clicked(self, slot):
-        self.button_ApplyFit.clicked.connect(slot)
+    def set_on_seq_fit_clicked(self, slot):
+        self.button_SeqFit.clicked.connect(slot)
 
     def set_on_table_cell_changed(self, slot):
         self.table_selection.cellChanged.connect(slot)  # Row, Col
@@ -70,8 +70,8 @@ class FittingDataView(QtWidgets.QWidget, Ui_data):
     def set_inspect_bg_button_enabled(self, enabled):
         self.button_plotBG.setEnabled(enabled)
 
-    def set_apply_fit_button_enabled(self, enabled):
-        self.button_ApplyFit.setEnabled(enabled)
+    def set_seq_fit_button_enabled(self, enabled):
+        self.button_SeqFit.setEnabled(enabled)
 
     def add_table_row(self, run_no, bank, checked, bgsub, niter, xwindow, SG):
         row_no = self.table_selection.rowCount()

--- a/scripts/Engineering/gui/engineering_diffraction/tabs/fitting/data_handling/data_view.py
+++ b/scripts/Engineering/gui/engineering_diffraction/tabs/fitting/data_handling/data_view.py
@@ -51,6 +51,9 @@ class FittingDataView(QtWidgets.QWidget, Ui_data):
     def set_on_plotBG_clicked(self, slot):
         self.button_plotBG.clicked.connect(slot)
 
+    def set_on_apply_fit_clicked(self, slot):
+        self.button_ApplyFit.clicked.connect(slot)
+
     def set_on_table_cell_changed(self, slot):
         self.table_selection.cellChanged.connect(slot)  # Row, Col
 
@@ -66,6 +69,9 @@ class FittingDataView(QtWidgets.QWidget, Ui_data):
 
     def set_inspect_bg_button_enabled(self, enabled):
         self.button_plotBG.setEnabled(enabled)
+
+    def set_apply_fit_button_enabled(self, enabled):
+        self.button_ApplyFit.setEnabled(enabled)
 
     def add_table_row(self, run_no, bank, checked, bgsub, niter, xwindow, SG):
         row_no = self.table_selection.rowCount()
@@ -129,6 +135,12 @@ class FittingDataView(QtWidgets.QWidget, Ui_data):
         for row in reversed(sorted(selected)):
             self.remove_table_row(row)
         return selected
+
+    def set_item_checkstate(self, row, col, checked):
+        if checked:
+            self.get_table_item(row, col).setCheckState(QtCore.Qt.Checked)
+        else:
+            self.get_table_item(row, col).setCheckState(QtCore.Qt.Unchecked)
 
     # =================
     # Component Getters

--- a/scripts/Engineering/gui/engineering_diffraction/tabs/fitting/data_handling/data_widget.ui
+++ b/scripts/Engineering/gui/engineering_diffraction/tabs/fitting/data_handling/data_widget.ui
@@ -223,12 +223,12 @@ QGroupBox:title {
          </widget>
         </item>
 		<item row="0" column="3">
-         <widget class="QPushButton" name="button_ApplyFit">
+         <widget class="QPushButton" name="button_SeqFit">
           <property name="enabled">
            <bool>false</bool>
           </property>
           <property name="text">
-           <string>Apply Fit To All</string>
+		   <string>Sequential Fit</string>
           </property>
          </widget>
         </item>

--- a/scripts/Engineering/gui/engineering_diffraction/tabs/fitting/data_handling/data_widget.ui
+++ b/scripts/Engineering/gui/engineering_diffraction/tabs/fitting/data_handling/data_widget.ui
@@ -222,6 +222,16 @@ QGroupBox:title {
           </property>
          </widget>
         </item>
+		<item row="0" column="3">
+         <widget class="QPushButton" name="button_ApplyFit">
+          <property name="enabled">
+           <bool>false</bool>
+          </property>
+          <property name="text">
+           <string>Apply Fit To All</string>
+          </property>
+         </widget>
+        </item>
        </layout>
       </item>
      </layout>

--- a/scripts/Engineering/gui/engineering_diffraction/tabs/fitting/data_handling/test/test_data_model.py
+++ b/scripts/Engineering/gui/engineering_diffraction/tabs/fitting/data_handling/test/test_data_model.py
@@ -8,7 +8,7 @@ import unittest
 
 from unittest import mock
 from unittest.mock import patch
-from numpy import isnan
+from numpy import isnan, nan
 from Engineering.gui.engineering_diffraction.tabs.fitting.data_handling.data_model import FittingDataModel
 
 file_path = "Engineering.gui.engineering_diffraction.tabs.fitting.data_handling.data_model"
@@ -345,11 +345,7 @@ class TestFittingDataModel(unittest.TestCase):
                                                                                           [51.0, 2.0]]})
         mock_create_fit_tables.assert_called_once()
 
-    @patch(file_path + '.FittingDataModel.write_table_row')
-    @patch(file_path + ".GroupWorkspaces")
-    @patch(file_path + ".CreateEmptyTableWorkspace")
-    @patch(file_path + ".CreateWorkspace")
-    def test_create_fit_tables(self, mock_create_ws, mock_create_table, mock_groupws, mock_writerow):
+    def setup_test_create_fit_tables(self, mock_create_ws, mock_create_table, mock_groupws):
         mock_ws_list = [mock.MagicMock(), mock.MagicMock(), mock.MagicMock()]
         mock_create_ws.side_effect = mock_ws_list
         mock_create_table.return_value = mock.MagicMock()
@@ -365,16 +361,29 @@ class TestFittingDataModel(unittest.TestCase):
                                                         'Gaussian_PeakCentre': [[38837.0, 10.0],
                                                                                 [33638.0, 10.0]],
                                                         'Gaussian_Sigma': [[54.0, 2.0],
-                                                                           [51.0, 2.0]]}}
+                                                                           [51.0, 2.0]]},
+                                            'costFunction': 1.0}
+        return mock_ws_list, mock_create_table, mock_create_ws
+
+    @patch(file_path + '.FittingDataModel.write_table_row')
+    @patch(file_path + ".GroupWorkspaces")
+    @patch(file_path + ".CreateEmptyTableWorkspace")
+    @patch(file_path + ".CreateWorkspace")
+    def test_create_fit_tables(self, mock_create_ws, mock_create_table, mock_groupws, mock_writerow):
+        mock_ws_list, mock_create_table, mock_create_ws = self.setup_test_create_fit_tables(mock_create_ws,
+                                                                                            mock_create_table,
+                                                                                            mock_groupws)
 
         self.model.create_fit_tables()
 
         # test the workspaces were created and added to fit_workspaces
         self.assertEqual(self.model._fit_workspaces, mock_ws_list + [mock_create_table.return_value])
         # test the table stores the correct function strings (empty string if no function present)
-        mock_writerow.assert_any_call(mock_create_table.return_value, ['name1', func_str], 0)
-        mock_writerow.assert_any_call(mock_create_table.return_value, ['', ''], 1)  # name2 has no entry in fit_results
-        # check the matrix workspaces corresponding to the fit parametes
+        mock_writerow.assert_any_call(mock_create_table.return_value,
+                                      ['name1', self.model._fit_results['name1']['costFunction'],
+                                       self.model._fit_results['name1']['model']], 0)
+        mock_writerow.assert_any_call(mock_create_table.return_value, ['', nan, ''], 1)  # name2 has no entry
+        # check the matrix workspaces corresponding to the fit parameters
         ws_names = [mock_create_ws.mock_calls[iws][2]['OutputWorkspace'] for iws in range(0, 3)]  # 3 params in gauss
         self.assertEqual(sorted(ws_names), sorted(self.model._fit_results['name1']['results'].keys()))
         # check the first call to setY and setE for one of the parameters
@@ -397,35 +406,28 @@ class TestFittingDataModel(unittest.TestCase):
     @patch(file_path + ".CreateEmptyTableWorkspace")
     @patch(file_path + ".CreateWorkspace")
     def test_create_fit_tables_different_funcs(self, mock_create_ws, mock_create_table, mock_groupws, mock_writerow):
-        mock_ws_list = [mock.MagicMock(), mock.MagicMock(), mock.MagicMock(), mock.MagicMock()]
-        mock_create_ws.side_effect = mock_ws_list
-        mock_create_table.return_value = mock.MagicMock()
-        mock_groupws.side_effect = lambda wslist, OutputWorkspace: wslist
-        # setup fit results
-        self.model._loaded_workspaces = {"name1": self.mock_ws, "name2": self.mock_ws}
-        self.model._log_workspaces = mock.MagicMock()
-        self.model._log_workspaces.name.return_value = 'some_log'
-        func_str1 = 'name=Gaussian,Height=11,PeakCentre=38837,Sigma=54;name=Gaussian,Height=10,PeakCentre=33638,Sigma=51'
-        self.model._fit_results = dict()
-        self.model._fit_results['name1'] = {'model': func_str1,
-                                            'results': {'Gaussian_Height': [[11.0, 1.0], [10.0, 1.0]],
-                                                        'Gaussian_PeakCentre': [[38837.0, 10.0],
-                                                                                [33638.0, 10.0]],
-                                                        'Gaussian_Sigma': [[54.0, 2.0],
-                                                                           [51.0, 2.0]]}}
-        func_str2 = func_str1 + ';name=FlatBackground,A0=1'
+        mock_ws_list, mock_create_table, mock_create_ws = self.setup_test_create_fit_tables(mock_create_ws,
+                                                                                            mock_create_table,
+                                                                                            mock_groupws)
+        mock_ws_list.append(mock.MagicMock())  # adding an additional parameter into model for name2
+        func_str2 = self.model._fit_results['name1']['model'] + ';name=FlatBackground,A0=1'
         self.model._fit_results['name2'] = {'model': func_str2,
                                             'results': dict(self.model._fit_results['name1']['results'],
-                                                            FlatBackground_A0=[[1.0, 0.1]])}
+                                                            FlatBackground_A0=[[1.0, 0.1]]),
+                                            'costFunction': 2.0}
 
         self.model.create_fit_tables()
 
         # test the workspaces were created and added to fit_workspaces
         self.assertEqual(self.model._fit_workspaces, mock_ws_list + [mock_create_table.return_value])
         # test the table stores the correct function strings (empty string if no function present)
-        mock_writerow.assert_any_call(mock_create_table.return_value, ['name1', func_str1], 0)
-        mock_writerow.assert_any_call(mock_create_table.return_value, ['name2', func_str2], 1)
-        # check the matrix workspaces corresponding to the fit parametes
+        mock_writerow.assert_any_call(mock_create_table.return_value,
+                                      ['name1', self.model._fit_results['name1']['costFunction'],
+                                       self.model._fit_results['name1']['model']], 0)
+        mock_writerow.assert_any_call(mock_create_table.return_value,
+                                      ['name2', self.model._fit_results['name2']['costFunction'],
+                                       self.model._fit_results['name2']['model']], 1)
+        # check the matrix workspaces corresponding to the fit parameters
         ws_names = [mock_create_ws.mock_calls[iws][2]['OutputWorkspace'] for iws in range(0, 4)]  # 4 unique params
         # get list of all unique params across both models
         param_names = list(set(list(self.model._fit_results['name1']['results'].keys()) + list(

--- a/scripts/Engineering/gui/engineering_diffraction/tabs/fitting/plotting/EngDiff_fitpropertybrowser.py
+++ b/scripts/Engineering/gui/engineering_diffraction/tabs/fitting/plotting/EngDiff_fitpropertybrowser.py
@@ -26,7 +26,7 @@ class EngDiffFitPropertyBrowser(FitPropertyBrowser):
     def __init__(self, canvas, toolbar_manager, parent=None):
         super(EngDiffFitPropertyBrowser, self).__init__(canvas, toolbar_manager, parent)
         self.fit_notifier = GenericObservable()
-        self.func_changed_notifier = GenericObservable()
+        self.fit_enabled_notifier = GenericObservable()
 
     def set_output_window_names(self):
         """
@@ -69,6 +69,20 @@ class EngDiffFitPropertyBrowser(FitPropertyBrowser):
         self.executeCustomSetupRemove(name)
         self.saveFunction(name)
 
+    def show(self):
+        """
+        Override the base class method. Hide the peak editing tool.
+        """
+        super(EngDiffFitPropertyBrowser, self).show()
+        self.fit_enabled_notifier.notify_subscribers(self.isFitEnabled() and self.isVisible())
+
+    def hide(self):
+        """
+        Override the base class method. Hide the peak editing tool.
+        """
+        super(EngDiffFitPropertyBrowser, self).hide()
+        self.fit_enabled_notifier.notify_subscribers(self.isFitEnabled() and self.isVisible())
+
     def _get_allowed_spectra(self):
         """
         Get the workspaces and spectra that can be fitted from the
@@ -106,4 +120,4 @@ class EngDiffFitPropertyBrowser(FitPropertyBrowser):
         the browser: functions added and/or removed.
         """
         super(EngDiffFitPropertyBrowser, self).function_changed_slot()
-        self.func_changed_notifier.notify_subscribers(self.isFitEnabled())
+        self.fit_enabled_notifier.notify_subscribers(self.isFitEnabled() and self.isVisible())

--- a/scripts/Engineering/gui/engineering_diffraction/tabs/fitting/plotting/EngDiff_fitpropertybrowser.py
+++ b/scripts/Engineering/gui/engineering_diffraction/tabs/fitting/plotting/EngDiff_fitpropertybrowser.py
@@ -36,13 +36,34 @@ class EngDiffFitPropertyBrowser(FitPropertyBrowser):
         return None
 
     def get_fitprop(self):
-        # evalaute string to make a dict (replace case of bool values)
+        """
+        Get the algorithm parameters updated post-fit
+        :return: dictionary of parameters
+        """
         dict_str = self.getFitAlgorithmParameters()
         if dict_str:
+            # evalaute string to make a dict (replace case of bool values)
             return eval(dict_str.replace('true', 'True').replace('false', 'False'))
         else:
+            # if no fit has been performed
             return None
 
+    def read_current_fitprop(self):
+        """
+        Get algorithm parameters currently displayed in the UI browser (incl. defaults that user cannot change)
+        :return: dict in style of self.getFitAlgorithmParameters()
+        """
+        fitprop = {'properties': {'InputWorkspace': self.workspaceName(),
+                                  'Output': self.outputName(),
+                                  'StartX': self.startX(),
+                                  'EndX': self.endX(),
+                                  'Function': self.getFunctionString(),
+                                  'ConvolveMembers': True,
+                                  'OutputCompositeMembers': True}}
+        exclude = self.getExcludeRange()
+        if exclude:
+            fitprop['properties']['Exclude'] = [int(s) for s in exclude.split(',')]
+        return fitprop
 
     def save_current_setup(self, name):
         self.executeCustomSetupRemove(name)

--- a/scripts/Engineering/gui/engineering_diffraction/tabs/fitting/plotting/EngDiff_fitpropertybrowser.py
+++ b/scripts/Engineering/gui/engineering_diffraction/tabs/fitting/plotting/EngDiff_fitpropertybrowser.py
@@ -34,6 +34,13 @@ class EngDiffFitPropertyBrowser(FitPropertyBrowser):
         """
         return None
 
+    def get_fitprop(self):
+        return eval(self.getFitAlgorithmParameters().replace('true', 'True').replace('false', 'False'))
+
+    def save_current_setup(self, name):
+        self.executeCustomSetupRemove(name)
+        self.saveFunction(name)
+
     def _get_allowed_spectra(self):
         """
         Get the workspaces and spectra that can be fitted from the
@@ -58,10 +65,8 @@ class EngDiffFitPropertyBrowser(FitPropertyBrowser):
         This is called after Fit finishes to update the fit curves.
         :param name: The name of Fit's output workspace.
         """
-
         ws = AnalysisDataService.retrieve(name)
         self.do_plot(ws, plot_diff=self.plotDiff())
         self.fit_result_ws_name = name
-        self.saveFunction(self.workspaceName())
-        results_dict = eval(self.getFitAlgorithmParameters().replace('true', 'True').replace('false', 'False'))
-        self.fit_notifier.notify_subscribers(results_dict)
+        self.save_current_setup(self.workspaceName())
+        self.fit_notifier.notify_subscribers(self.get_fitprop())

--- a/scripts/Engineering/gui/engineering_diffraction/tabs/fitting/plotting/plot_presenter.py
+++ b/scripts/Engineering/gui/engineering_diffraction/tabs/fitting/plotting/plot_presenter.py
@@ -26,7 +26,7 @@ class FittingPlotPresenter(object):
         self.workspace_added_observer = GenericObserverWithArgPassing(self.add_workspace_to_plot)
         self.workspace_removed_observer = GenericObserverWithArgPassing(self.remove_workspace_from_plot)
         self.all_workspaces_removed_observer = GenericObserver(self.clear_plot)
-        self.apply_fit_observer = GenericObserverWithArgPassing(self.apply_fit)
+        self.seq_fit_observer = GenericObserverWithArgPassing(self.do_sequential_fit)
         self.seq_fit_done_notifier = GenericObservable()
 
     def add_workspace_to_plot(self, ws):
@@ -47,7 +47,7 @@ class FittingPlotPresenter(object):
         self.view.clear_figure()
         self.view.update_fitbrowser()
 
-    def apply_fit(self, ws_list):
+    def do_sequential_fit(self, ws_list):
         fitprop_list = []
         for ws in ws_list:
             fitprop = self.view.read_fitprop_from_browser()

--- a/scripts/Engineering/gui/engineering_diffraction/tabs/fitting/plotting/plot_presenter.py
+++ b/scripts/Engineering/gui/engineering_diffraction/tabs/fitting/plotting/plot_presenter.py
@@ -47,6 +47,7 @@ class FittingPlotPresenter(object):
         self.view.update_fitbrowser()
 
     def apply_fit(self, ws_list):
+        fitprop_list = []
         for ws in ws_list:
-            self.view.fit_ws(ws)
-        self.seq_fit_done_notifier.notify_subscribers()
+            fitprop_list += [self.view.fit_ws(ws)]
+        self.seq_fit_done_notifier.notify_subscribers(fitprop_list)

--- a/scripts/Engineering/gui/engineering_diffraction/tabs/fitting/plotting/plot_presenter.py
+++ b/scripts/Engineering/gui/engineering_diffraction/tabs/fitting/plotting/plot_presenter.py
@@ -7,7 +7,7 @@
 from mantidqt.utils.observer_pattern import GenericObserverWithArgPassing, GenericObserver, GenericObservable
 from Engineering.gui.engineering_diffraction.tabs.fitting.plotting.plot_model import FittingPlotModel
 from Engineering.gui.engineering_diffraction.tabs.fitting.plotting.plot_view import FittingPlotView
-from mantid.simpleapi import Fit
+from mantid.simpleapi import Fit, logger
 
 PLOT_KWARGS = {"linestyle": "", "marker": "x", "markersize": "3"}
 
@@ -26,7 +26,7 @@ class FittingPlotPresenter(object):
         self.workspace_added_observer = GenericObserverWithArgPassing(self.add_workspace_to_plot)
         self.workspace_removed_observer = GenericObserverWithArgPassing(self.remove_workspace_from_plot)
         self.all_workspaces_removed_observer = GenericObserver(self.clear_plot)
-        self.seq_fit_observer = GenericObserverWithArgPassing(self.do_sequential_fit)
+        self.seq_fit_started_observer = GenericObserverWithArgPassing(self.do_sequential_fit)
         self.seq_fit_done_notifier = GenericObservable()
 
     def add_workspace_to_plot(self, ws):
@@ -50,10 +50,11 @@ class FittingPlotPresenter(object):
     def do_sequential_fit(self, ws_list):
         fitprop_list = []
         for ws in ws_list:
+            logger.notice(f'Starting to fit workspace {ws}')
             fitprop = self.view.read_fitprop_from_browser()
             # update I/O workspace name
-            fitprop['properties']['InputWorkspace'] = ws
             fitprop['properties']['Output'] = ws
+            fitprop['properties']['InputWorkspace'] = ws
             # do fit
             fit_output = Fit(**fitprop['properties'])
             fitprop['properties']['Function'] = str(fit_output.Function.fun)

--- a/scripts/Engineering/gui/engineering_diffraction/tabs/fitting/plotting/plot_presenter.py
+++ b/scripts/Engineering/gui/engineering_diffraction/tabs/fitting/plotting/plot_presenter.py
@@ -4,7 +4,7 @@
 #   NScD Oak Ridge National Laboratory, European Spallation Source,
 #   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
 # SPDX - License - Identifier: GPL - 3.0 +
-from mantidqt.utils.observer_pattern import GenericObserverWithArgPassing, GenericObserver
+from mantidqt.utils.observer_pattern import GenericObserverWithArgPassing, GenericObserver, GenericObservable
 from Engineering.gui.engineering_diffraction.tabs.fitting.plotting.plot_model import FittingPlotModel
 from Engineering.gui.engineering_diffraction.tabs.fitting.plotting.plot_view import FittingPlotView
 
@@ -25,6 +25,8 @@ class FittingPlotPresenter(object):
         self.workspace_added_observer = GenericObserverWithArgPassing(self.add_workspace_to_plot)
         self.workspace_removed_observer = GenericObserverWithArgPassing(self.remove_workspace_from_plot)
         self.all_workspaces_removed_observer = GenericObserver(self.clear_plot)
+        self.apply_fit_observer = GenericObserverWithArgPassing(self.apply_fit)
+        self.seq_fit_done_notifier = GenericObservable()
 
     def add_workspace_to_plot(self, ws):
         axes = self.view.get_axes()
@@ -43,3 +45,8 @@ class FittingPlotPresenter(object):
             self.model.remove_all_workspaces_from_plot(ax)
         self.view.clear_figure()
         self.view.update_fitbrowser()
+
+    def apply_fit(self, ws_list):
+        for ws in ws_list:
+            self.view.fit_ws(ws)
+        self.seq_fit_done_notifier.notify_subscribers()

--- a/scripts/Engineering/gui/engineering_diffraction/tabs/fitting/plotting/plot_presenter.py
+++ b/scripts/Engineering/gui/engineering_diffraction/tabs/fitting/plotting/plot_presenter.py
@@ -57,7 +57,7 @@ class FittingPlotPresenter(object):
             # do fit
             fit_output = Fit(**fitprop['properties'])
             fitprop['properties']['Function'] = str(fit_output.Function.fun)
-            # save setup in fitprop browser
+            # save setup in fitprop browser (updates browser for next iteration of loop)
             self.view.update_browser_setup(fitprop['properties']['Function'], ws)
-            fitprop_list += [fitprop]
+            fitprop_list.append(fitprop)
         self.seq_fit_done_notifier.notify_subscribers(fitprop_list)

--- a/scripts/Engineering/gui/engineering_diffraction/tabs/fitting/plotting/plot_view.py
+++ b/scripts/Engineering/gui/engineering_diffraction/tabs/fitting/plotting/plot_view.py
@@ -14,6 +14,8 @@ from matplotlib.backends.qt_compat import is_pyqt5
 from .EngDiff_fitpropertybrowser import EngDiffFitPropertyBrowser
 from workbench.plotting.toolbar import ToolbarStateManager
 from Engineering.gui.engineering_diffraction.tabs.fitting.plotting.plot_toolbar import FittingPlotToolbar
+from mantid.simpleapi import Fit
+
 
 if is_pyqt5():
     from matplotlib.backends.backend_qt5agg import FigureCanvas
@@ -121,9 +123,16 @@ class FittingPlotView(QtWidgets.QWidget, Ui_plot):
         self.update_figure()
 
     def fit_ws(self, ws_name):
-        # set workspace to fit
-        self.fit_browser.setWorkspaceName(ws_name)
-        self.fit_browser.fit()
+        # get input properties from fitproperty browser
+        fitprop = self.fit_browser.get_fitprop()
+        fitprop['properties']['InputWorkspace'] = ws_name
+        fitprop['properties']['Output'] = ws_name
+        fit_output = Fit(**fitprop['properties'])
+        fitprop['properties']['Function'] = str(fit_output.Function.fun)
+        # update fitproperty browser function and save setup
+        self.fit_browser.loadFunction(fitprop['properties']['Function'])
+        self.fit_browser.save_current_setup(ws_name)
+        return fitprop
 
     # =================
     # Component Getters

--- a/scripts/Engineering/gui/engineering_diffraction/tabs/fitting/plotting/plot_view.py
+++ b/scripts/Engineering/gui/engineering_diffraction/tabs/fitting/plotting/plot_view.py
@@ -14,7 +14,6 @@ from matplotlib.backends.qt_compat import is_pyqt5
 from .EngDiff_fitpropertybrowser import EngDiffFitPropertyBrowser
 from workbench.plotting.toolbar import ToolbarStateManager
 from Engineering.gui.engineering_diffraction.tabs.fitting.plotting.plot_toolbar import FittingPlotToolbar
-from mantid.simpleapi import Fit
 
 if is_pyqt5():
     from matplotlib.backends.backend_qt5agg import FigureCanvas
@@ -121,24 +120,13 @@ class FittingPlotView(QtWidgets.QWidget, Ui_plot):
             ax.autoscale()
         self.update_figure()
 
-    def fit_ws(self, ws_name):
-        # populate dict with input params for fit in same dict format as fit_browser.getFitAlgorithmParameters()
-        fitprop = {'properties': {'InputWorkspace': ws_name,
-                                  'Output': ws_name,
-                                  'StartX': self.fit_browser.startX(),
-                                  'EndX': self.fit_browser.endX(),
-                                  'Function': self.fit_browser.getFunctionString(),
-                                  'ConvolveMembers': True,
-                                  'OutputCompositeMembers': True}}
-        exclude = self.fit_browser.getExcludeRange()
-        if exclude:
-            fitprop['properties']['Exclude'] = [int(s) for s in exclude.split(',')]
-        fit_output = Fit(**fitprop['properties'])
-        fitprop['properties']['Function'] = str(fit_output.Function.fun)
+    def read_fitprop_from_browser(self):
+        return self.fit_browser.read_current_fitprop()
+
+    def update_browser_setup(self, func_str, setup_name):
         # update browser with output function and save setup
-        self.fit_browser.loadFunction(fitprop['properties']['Function'])
-        self.fit_browser.save_current_setup(ws_name)
-        return fitprop
+        self.fit_browser.loadFunction(func_str)
+        self.fit_browser.save_current_setup(setup_name)
 
     # =================
     # Component Getters

--- a/scripts/Engineering/gui/engineering_diffraction/tabs/fitting/plotting/plot_view.py
+++ b/scripts/Engineering/gui/engineering_diffraction/tabs/fitting/plotting/plot_view.py
@@ -16,7 +16,6 @@ from workbench.plotting.toolbar import ToolbarStateManager
 from Engineering.gui.engineering_diffraction.tabs.fitting.plotting.plot_toolbar import FittingPlotToolbar
 from mantid.simpleapi import Fit
 
-
 if is_pyqt5():
     from matplotlib.backends.backend_qt5agg import FigureCanvas
 else:
@@ -123,13 +122,20 @@ class FittingPlotView(QtWidgets.QWidget, Ui_plot):
         self.update_figure()
 
     def fit_ws(self, ws_name):
-        # get input properties from fitproperty browser
-        fitprop = self.fit_browser.get_fitprop()
-        fitprop['properties']['InputWorkspace'] = ws_name
-        fitprop['properties']['Output'] = ws_name
+        # populate dict with input params for fit in same dict format as fit_browser.getFitAlgorithmParameters()
+        fitprop = {'properties': {'InputWorkspace': ws_name,
+                                  'Output': ws_name,
+                                  'StartX': self.fit_browser.startX(),
+                                  'EndX': self.fit_browser.endX(),
+                                  'Function': self.fit_browser.getFunctionString(),
+                                  'ConvolveMembers': True,
+                                  'OutputCompositeMembers': True}}
+        exclude = self.fit_browser.getExcludeRange()
+        if exclude:
+            fitprop['properties']['Exclude'] = [int(s) for s in exclude.split(',')]
         fit_output = Fit(**fitprop['properties'])
         fitprop['properties']['Function'] = str(fit_output.Function.fun)
-        # update fitproperty browser function and save setup
+        # update browser with output function and save setup
         self.fit_browser.loadFunction(fitprop['properties']['Function'])
         self.fit_browser.save_current_setup(ws_name)
         return fitprop

--- a/scripts/Engineering/gui/engineering_diffraction/tabs/fitting/plotting/plot_view.py
+++ b/scripts/Engineering/gui/engineering_diffraction/tabs/fitting/plotting/plot_view.py
@@ -120,6 +120,11 @@ class FittingPlotView(QtWidgets.QWidget, Ui_plot):
             ax.autoscale()
         self.update_figure()
 
+    def fit_ws(self, ws_name):
+        # set workspace to fit
+        self.fit_browser.setWorkspaceName(ws_name)
+        self.fit_browser.fit()
+
     # =================
     # Component Getters
     # =================

--- a/scripts/Engineering/gui/engineering_diffraction/tabs/fitting/presenter.py
+++ b/scripts/Engineering/gui/engineering_diffraction/tabs/fitting/presenter.py
@@ -21,6 +21,6 @@ class FittingPresenter(object):
             self.plot_widget.workspace_added_observer)
         self.data_widget.presenter.all_plots_removed_notifier.add_subscriber(
             self.plot_widget.all_workspaces_removed_observer)
-        # this is where we can add observers to tlak between fitting and data prresener
-        # so can let data widget know  when fit suceeded?
+        self.data_widget.presenter.apply_fit_notifier.add_subscriber(self.plot_widget.apply_fit_observer)
         self.plot_widget.view.fit_browser.fit_notifier.add_subscriber(self.data_widget.presenter.fit_observer)
+        self.plot_widget.seq_fit_done_notifier.add_subscriber(self.data_widget.presenter.seq_fit_observer)

--- a/scripts/Engineering/gui/engineering_diffraction/tabs/fitting/presenter.py
+++ b/scripts/Engineering/gui/engineering_diffraction/tabs/fitting/presenter.py
@@ -21,7 +21,7 @@ class FittingPresenter(object):
             self.plot_widget.workspace_added_observer)
         self.data_widget.presenter.all_plots_removed_notifier.add_subscriber(
             self.plot_widget.all_workspaces_removed_observer)
-        self.data_widget.presenter.apply_fit_notifier.add_subscriber(self.plot_widget.apply_fit_observer)
+        self.data_widget.presenter.seq_fit_notifier.add_subscriber(self.plot_widget.seq_fit_observer)
         self.plot_widget.view.fit_browser.fit_notifier.add_subscriber(self.data_widget.presenter.fit_observer)
         self.plot_widget.view.fit_browser.func_changed_notifier.add_subscriber(
             self.data_widget.presenter.func_changed_observer)

--- a/scripts/Engineering/gui/engineering_diffraction/tabs/fitting/presenter.py
+++ b/scripts/Engineering/gui/engineering_diffraction/tabs/fitting/presenter.py
@@ -6,6 +6,7 @@
 # SPDX - License - Identifier: GPL - 3.0 +
 from Engineering.gui.engineering_diffraction.tabs.fitting.data_handling.data_widget import FittingDataWidget
 from Engineering.gui.engineering_diffraction.tabs.fitting.plotting.plot_presenter import FittingPlotPresenter
+from mantidqt.utils.observer_pattern import GenericObserverWithArgPassing
 
 
 class FittingPresenter(object):
@@ -14,6 +15,8 @@ class FittingPresenter(object):
 
         self.data_widget = FittingDataWidget(self.view, view=self.view.get_data_widget())
         self.plot_widget = FittingPlotPresenter(self.view, view=self.view.get_plot_widget())
+        self.seq_fit_started_observer = GenericObserverWithArgPassing(self.disable_view)
+        self.seq_fit_done_observer = GenericObserverWithArgPassing(self.enable_view)
 
         self.data_widget.presenter.plot_removed_notifier.add_subscriber(
             self.plot_widget.workspace_removed_observer)
@@ -21,8 +24,16 @@ class FittingPresenter(object):
             self.plot_widget.workspace_added_observer)
         self.data_widget.presenter.all_plots_removed_notifier.add_subscriber(
             self.plot_widget.all_workspaces_removed_observer)
-        self.data_widget.presenter.seq_fit_notifier.add_subscriber(self.plot_widget.seq_fit_observer)
+        self.data_widget.presenter.seq_fit_started_notifier.add_subscriber(self.seq_fit_started_observer)
+        self.data_widget.presenter.seq_fit_started_notifier.add_subscriber(self.plot_widget.seq_fit_started_observer)
         self.plot_widget.view.fit_browser.fit_notifier.add_subscriber(self.data_widget.presenter.fit_observer)
         self.plot_widget.view.fit_browser.fit_enabled_notifier.add_subscriber(
             self.data_widget.presenter.fit_enabled_observer)
-        self.plot_widget.seq_fit_done_notifier.add_subscriber(self.data_widget.presenter.seq_fit_observer)
+        self.plot_widget.seq_fit_done_notifier.add_subscriber(self.data_widget.presenter.seq_fit_done_observer)
+        self.plot_widget.seq_fit_done_notifier.add_subscriber(self.seq_fit_done_observer)
+
+    def disable_view(self, _):
+        self.view.setEnabled(False)
+
+    def enable_view(self, _):
+        self.view.setEnabled(True)

--- a/scripts/Engineering/gui/engineering_diffraction/tabs/fitting/presenter.py
+++ b/scripts/Engineering/gui/engineering_diffraction/tabs/fitting/presenter.py
@@ -23,4 +23,6 @@ class FittingPresenter(object):
             self.plot_widget.all_workspaces_removed_observer)
         self.data_widget.presenter.apply_fit_notifier.add_subscriber(self.plot_widget.apply_fit_observer)
         self.plot_widget.view.fit_browser.fit_notifier.add_subscriber(self.data_widget.presenter.fit_observer)
+        self.plot_widget.view.fit_browser.func_changed_notifier.add_subscriber(
+            self.data_widget.presenter.func_changed_observer)
         self.plot_widget.seq_fit_done_notifier.add_subscriber(self.data_widget.presenter.seq_fit_observer)

--- a/scripts/Engineering/gui/engineering_diffraction/tabs/fitting/presenter.py
+++ b/scripts/Engineering/gui/engineering_diffraction/tabs/fitting/presenter.py
@@ -23,6 +23,6 @@ class FittingPresenter(object):
             self.plot_widget.all_workspaces_removed_observer)
         self.data_widget.presenter.seq_fit_notifier.add_subscriber(self.plot_widget.seq_fit_observer)
         self.plot_widget.view.fit_browser.fit_notifier.add_subscriber(self.data_widget.presenter.fit_observer)
-        self.plot_widget.view.fit_browser.func_changed_notifier.add_subscriber(
-            self.data_widget.presenter.func_changed_observer)
+        self.plot_widget.view.fit_browser.fit_enabled_notifier.add_subscriber(
+            self.data_widget.presenter.fit_enabled_observer)
         self.plot_widget.seq_fit_done_notifier.add_subscriber(self.data_widget.presenter.seq_fit_observer)


### PR DESCRIPTION
**Description of work.**

Add simplified sequential fitting to EngDiff UI fitting tab. 
The primary log (specified in the settings) dictates the order in which to fit the workspaces (choosing a blank primary log will fit in the order in which they appear in the UI table). In the settings it is also possible to choose to to fit in ascending or descending order of the primary log value.

Additionally the settings has been refactored - clicking Cancel should not update the settings. When OK or Apply is clicked then the settings are saved to file and should still persist across sessions. 

**To test:**
In the Engineering diffraction UI
(1) Open the settings (cog symbol in bottom left) and choose a primary log (the combo box at bottom - should be brief description above it)
(2) Choose a log (or leave blank in which case the runs will be fitted in the order they appear in the table of the fitting tab) - the runs provided are d=taken at different stress and strain. Choose an order by checking one of the ascending/descending boxes (selecting one should automatically update the check state of the other, they should never both have the same state). Click OK. 
(3) Open the settings again - change any of them but this time press Cancel. When you re-open the settings the changes should not have been saved.
(4) Load the following focussed data [ENGINX_data.zip](https://github.com/mantidproject/mantid/files/5392081/ENGINX_data.zip) but do not check the add to plot
(5) Check the Sequential Fit button is disabled (is greyed out)
(6) Add one of the runs to the plot by checking the appropriate box in the table
(7) Open the fit browser by clicking Fit on the plot toolbar - the Sequential Fit button should still be disabled.
(8) Add a function (e.g. couple of peaks and background) - the Sequential Fit button should now be enabled (it is enabled when the Fit button in the Fit menu of the browser is enabled).
(9) Add constraints (fix/tie parameters), you can also try with/without excluded regions (note the regions are not displayed in the plot - and will not be visible if you plot guess either)
(10) Make a note of the starting parameters and click the Sequential Fit button - check the following
- For each matrix workspace in the group with suffix "_fit" (one per fit parameter) there are no rows with NaNs (this indicates the same function was fitted to all). Check this also in the model table workspace in the same grouping.
- The parameters displayed in the fit browser should match those of the last fitted run (which can be inferred from the primary log values in the table workspace (grouped together with suffix _logs).
- Inspect the saved setups in the fit browser (Setup > Custom Setup) - there should be a model with the name of each workspace. Select each model and check the parameters match those in the tables in the ADS.

(11) Run the sequential fit again (you can change the model but you don't have to) - you should not get prompted to ask whether you want to overwrite the saved setup (this is a change of behaviour introduced in this PR)
(12) Repeat steps (2-11) with different logs (incl. blank) the order can be inferred from the last fitted run (the actual sorting is covered by a unit test)


Fixes #29828 

Don't merge until PR #29667 is merged

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or master)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
