### PR TITLE
Filtered Value is displayed in Sample logs table

### DIFF
--- a/docs/source/release/v5.1.1/index.rst
+++ b/docs/source/release/v5.1.1/index.rst
@@ -16,9 +16,11 @@ The main changes are:
 
 - a bug in the Muon interface that lead to error bars being lost on fitted data has been fixed
 
-- fixed a bug where `import CaChannel` would cause a hard crash within MantidWorkbench on Linux.
+- fixed a bug where `import CaChannel` would cause a hard crash within MantidWorkbench on Linux
 
 - updated the ISIS Reflectometry live data monitor to work with new instrument PV names
+
+- corrected the table value for a partially invalid, filtered log, with only one remaining entry
 
 Citation
 --------

--- a/qt/python/mantidqt/widgets/samplelogs/model.py
+++ b/qt/python/mantidqt/widgets/samplelogs/model.py
@@ -44,7 +44,8 @@ def get_value(log):
 
     if isinstance(log, TimeSeriesProperties):
         if log.size() == 1:
-            return '{} (1 entry)'.format(log.firstValue())
+            # for logs which are filtered or not
+            return '{} (1 entry)'.format(log.filtered_value[0])
         else:
             entry_descr = '({} entries)'.format(log.size())
 

--- a/qt/python/mantidqt/widgets/samplelogs/test/test_samplelogs_model.py
+++ b/qt/python/mantidqt/widgets/samplelogs/test/test_samplelogs_model.py
@@ -8,7 +8,7 @@
 #
 #
 from mantid.simpleapi import Load, CreateMDWorkspace
-from mantidqt.widgets.samplelogs.model import SampleLogsModel
+from mantidqt.widgets.samplelogs.model import SampleLogsModel, get_value
 
 import unittest
 
@@ -151,6 +151,65 @@ class SampleLogsModelTest(unittest.TestCase):
         self.assertEqual(2, len(hidden_logs))
         self.assertIn('cryo_temp1_invalid_values',hidden_logs)
         self.assertIn('cryo_temp2_invalid_values',hidden_logs)
+
+    def test_get_value_for_filtered(self):
+        # Checks that table values and plot log stats agree, even when filtered.
+        ws = Load('ENGINX00228061_log_alarm_data.nxs')
+
+        run = ws.getRun()
+        all_logs = run.getLogData()
+        model = SampleLogsModel(ws)
+
+        # Partially invalid log with one filtered entry
+        self.assertEqual(get_value(all_logs[31]), '{} (1 entry)'.format(model.get_statistics('cryo_temp1').mean))
+        self.assertEqual(get_value(all_logs[31]), '{} (1 entry)'.format(model.get_statistics('cryo_temp1').maximum))
+
+        # Fully invalid log with multiple entries (not affected by filtering)
+        self.assertEqual(get_value(all_logs[33]), '({} entries)'.format(all_logs[32].size())) # cryo_temp2
+
+        # Valid log with one entry filtered by status, with a differently valued entry unfiltered
+        self.assertEqual(get_value(all_logs[16]), '{} (1 entry)'.format(model.get_statistics('C6_SLAVE_FREQUENCY').mean))
+        self.assertEqual(get_value(all_logs[16]), '{} (1 entry)'.format(model.get_statistics('C6_SLAVE_FREQUENCY').maximum))
+
+        # Valid log with one entry filtered by status, with another same valued entries unfiltered
+        self.assertEqual(get_value(all_logs[25]), '{} (1 entry)'.format(model.get_statistics('SECI_OUT_OF_RANGE_BLOCK').mean))
+        self.assertEqual(get_value(all_logs[25]), '{} (1 entry)'.format(model.get_statistics('SECI_OUT_OF_RANGE_BLOCK').maximum))
+
+        # Valid log with 2 identical value entries
+        self.assertEqual(get_value(all_logs[21]), '{} (2 entries)'.format(model.get_statistics('C9_SLAVE_PHASE').mean))
+        self.assertEqual(get_value(all_logs[21]), '{} (2 entries)'.format(model.get_statistics('C9_SLAVE_PHASE').maximum))
+
+        # Valid log with 4 identical value entries
+        self.assertEqual(get_value(all_logs[38]), '{} (4 entries)'.format(model.get_statistics('x').mean))
+        self.assertEqual(get_value(all_logs[38]), '{} (4 entries)'.format(model.get_statistics('x').maximum))
+
+        # Valid log with multiple different value entries
+        self.assertEqual(get_value(all_logs[29]), '({} entries)'.format(all_logs[29].size())) # cryo_Sample
+
+    def test_get_value_for_unfiltered(self):
+        # Checks that filtered_value works for unfiltered logs, e.g. at SNS
+
+        ws_T = Load('Training_Exercise3a_SNS.nxs')
+        ws_C = Load('CNCS_7860_event.nxs') # Has no single entries
+
+        run_T = ws_T.getRun()
+        all_logs_T = run_T.getLogData()
+        model_T = SampleLogsModel(ws_T)
+
+        run_C = ws_C.getRun()
+        all_logs_C = run_C.getLogData()
+        model_C = SampleLogsModel(ws_C)
+
+        # Valid log with one entry
+        self.assertEqual(get_value(all_logs_T[2]), '{} (1 entry)'.format(model_T.get_statistics('ChopperStatus1').mean))
+        self.assertEqual(get_value(all_logs_T[2]), '{} (1 entry)'.format(model_T.get_statistics('ChopperStatus1').maximum))
+
+        # Valid log with 2 identical value entries
+        self.assertEqual(get_value(all_logs_C[2]), '{} (2 entries)'.format(model_C.get_statistics('ChopperStatus1').mean))
+        self.assertEqual(get_value(all_logs_C[2]), '{} (2 entries)'.format(model_C.get_statistics('ChopperStatus1').maximum))
+
+        # Valid log with multiple different value entries
+        self.assertEqual(get_value(all_logs_C[13]), '({} entries)'.format(all_logs_C[13].size())) # Phase2
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
**Description of work.**

Previously for any log with only one log entry, the first value
was used. This can be wrong if the values have been filtered and the one good value is not the first one. 

Also, added 2 tests for get_value(), for filtered and unfiltered data

**To test:**
- Load `ENGINX00228061_log_alarm_data.nxs` from the unit test data.
- Right-click "Show Sample Logs" 
- The partially invalid log `cryo_temp1` has 3 entries unfiltered, but when filtering out invalid values and by run status, there is only one entry left. This value gets reported in the table under the value column. Check that this matches the value that the graph centres on, when the Filtered tickbox at the top is ticked [7.0].
- Check the new tests pass

Fixes #29714 


<!-- Ensure the base of this PR is correct (e.g. release-next or master)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
