### PR TITLE
Add new version of INTER IDF

### DIFF
--- a/instrument/INTER_Definition_2020.xml
+++ b/instrument/INTER_Definition_2020.xml
@@ -5,8 +5,8 @@
             xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
             xsi:schemaLocation="http://www.mantidproject.org/IDF/1.0 http://schema.mantidproject.org/IDF/1.0/IDFSchema.xsd"
             name="INTER"
-            valid-from="2017-02-14 00:00:00"
-            valid-to=  "2020-02-13 23:59:59"
+            valid-from="2020-02-14 00:00:00"
+            valid-to=  "2100-01-31 23:59:59"
             last-modified="2020-10-15 00:00:00">
 
   <defaults>
@@ -139,23 +139,23 @@
   <component type="panel" idstart="2001" idfillbyfirst="y" idstep="1" idstepbyrow="1">
     <location z="3.163" name="linear-detector"/>
     <parameter name="y">
-      <logfile id="Theta" eq="3.163*tan(2*value*0.0174533)-46*0.0012" extract-single-value-as="last_value"/>
+      <logfile id="Theta" eq="3.163*tan(1*value*0.0174533)" extract-single-value-as="last_value"/>
     </parameter>
 
   </component>
 
   <type name="panel" is="rectangular_detector" type="linear-detector-pixel"
     xpixels="1" xstart="0.0" xstep="0.05"
-    ypixels="243" ystart="0.0" ystep="+0.0012" >
+    ypixels="256" ystart="-0.0468" ystep="+0.000606" >
     <properties/>
   </type>
   <!--"-0.0576"-->
   <type name="linear-detector-pixel" is="detector">
     <cuboid id="shape">
-      <left-front-bottom-point z="0.01" x="-0.025" y="-0.0006"  />
-      <left-front-top-point  z="0.01" x="-0.025" y="0.0006"  />
-      <left-back-bottom-point  z="-0.01" x="-0.025" y="-0.0006"  />
-      <right-front-bottom-point  z="0.01" x="0.025" y="-0.0006"  />
+      <left-front-bottom-point z="0.01" x="0.15" y="-0.0003"  />
+      <left-front-top-point  z="0.01" x="0.15" y="0.0003"  />
+      <left-back-bottom-point  z="-0.01" x="0.15" y="-0.0003"  />
+      <right-front-bottom-point  z="0.01" x="-0.15" y="-0.0003"  />
     </cuboid>
     <algebra val="shape" />
   </type>


### PR DESCRIPTION
**Report to:** Max at ISIS

- This PR fixes a few issues with the linear detector.
- Note that this PR also places detectors at theta rather than 2*theta, which is not correct, but is required for the ConvertToReflectometryQ algorithm to work. This should be changed back when the fix for #20327 goes into a release.

**To test:**

This IDF has been provided by scientists and they are already actively using it, so it should suffice to just sanity check the changes and check that a recent INTER run can be loaded.

*There is no associated issue.*

*This does not require release notes* because **IDF changes are immediate and not related to the release**

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
