### PR TITLE
Save Instrument 2.0 shape data to Nexus file

### DIFF
--- a/Framework/NexusGeometry/inc/MantidNexusGeometry/NexusGeometryDefinitions.h
+++ b/Framework/NexusGeometry/inc/MantidNexusGeometry/NexusGeometryDefinitions.h
@@ -13,6 +13,7 @@
 namespace Mantid {
 namespace NexusGeometry {
 
+const int COMPRESSION_LEVEL = 1;
 const H5G_obj_t GROUP_TYPE = static_cast<H5G_obj_t>(0);
 const H5G_obj_t DATASET_TYPE = static_cast<H5G_obj_t>(1);
 const std::vector<std::string> nexus_geometry_extensions = {".nxs", ".hdf5"};
@@ -35,6 +36,11 @@ const H5std_string TRANSLATION = "translation";
 const H5std_string ROTATION = "rotation";
 const H5std_string NO_DEPENDENCY = ".";
 const H5std_string LOCATION = "location";
+const H5std_string CYLINDERS = "cylinders";
+const H5std_string VERTICES = "vertices";
+const H5std_string FACES = "faces";
+const H5std_string DETECTOR_FACES = "detector_faces";
+const H5std_string WINDING_ORDER = "winding_order";
 const H5std_string ORIENTATION = "orientation";
 const H5std_string DEPENDS_ON = "depends_on";
 const H5std_string X_PIXEL_OFFSET = "x_pixel_offset";

--- a/Framework/NexusGeometry/src/NexusGeometrySave.cpp
+++ b/Framework/NexusGeometry/src/NexusGeometrySave.cpp
@@ -1382,7 +1382,7 @@ public:
       H5::Group pixelShapeGroup =
           simpleNXSubGroup(grp, PIXEL_SHAPE, NX_CYLINDER);
       // write cylinder only once, using the first index
-      auto &geometry = firstShapeInfo.cylinderGeometry();
+      auto const &geometry = firstShapeInfo.cylinderGeometry();
       const Eigen::Vector3d &base =
           Kernel::toVector3d(geometry.centreOfBottomBase);
       const Eigen::Vector3d &axis = Kernel::toVector3d(geometry.axis);

--- a/Framework/NexusGeometry/src/NexusGeometrySave.cpp
+++ b/Framework/NexusGeometry/src/NexusGeometrySave.cpp
@@ -1,5 +1,3 @@
-// Mantid Repository : https://github.com/mantidproject/mantid
-//
 // Copyright &copy; 2019 ISIS Rutherford Appleton Laboratory UKRI,
 //   NScD Oak Ridge National Laboratory, European Spallation Source,
 //   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
@@ -19,12 +17,19 @@
 #include "MantidGeometry/Instrument/ComponentInfo.h"
 #include "MantidGeometry/Instrument/ComponentInfoBankHelpers.h"
 #include "MantidGeometry/Instrument/DetectorInfo.h"
+#include "MantidGeometry/Objects/IObject.h"
+#include "MantidGeometry/Objects/MeshObject.h"
+#include "MantidGeometry/Objects/MeshObject2D.h"
+#include "MantidGeometry/Objects/MeshObjectCommon.h"
+#include "MantidGeometry/Rendering/ShapeInfo.h"
 #include "MantidIndexing/IndexInfo.h"
 #include "MantidKernel/EigenConversionHelpers.h"
 #include "MantidKernel/ProgressBase.h"
 #include "MantidNexusGeometry/H5ForwardCompatibility.h"
 #include "MantidNexusGeometry/NexusGeometryDefinitions.h"
+#include "MantidNexusGeometry/NexusGeometrySave.h"
 #include "MantidNexusGeometry/NexusGeometryUtilities.h"
+
 #include <H5Cpp.h>
 #include <algorithm>
 #include <boost/filesystem/operations.hpp>
@@ -32,6 +37,7 @@
 #include <list>
 #include <memory>
 #include <string>
+#include <tuple>
 
 namespace Mantid {
 namespace NexusGeometry {
@@ -59,14 +65,13 @@ struct SpectraMappings {
  * @param childGroupName : intended name of the child goup.
  * @return : new H5 Group object with name <childGroupName> if did not throw.
  */
-inline H5::Group tryCreateGroup(const H5::Group &parentGroup,
-                                const std::string &childGroupName) {
+H5::Group tryCreateGroup(const H5::Group &parentGroup,
+                         const std::string &childGroupName) {
   H5std_string parentGroupName = H5_OBJ_NAME(parentGroup);
   for (hsize_t i = 0; i < parentGroup.getNumObjs(); ++i) {
     if (parentGroup.getObjTypeByIdx(i) == GROUP_TYPE) {
       H5std_string child = parentGroup.getObjnameByIdx(i);
       if (childGroupName == child) {
-        // TODO: runtime error instead?
         throw std::invalid_argument(
             "Cannot create group with name " + childGroupName +
             " inside parent group " + parentGroupName +
@@ -75,6 +80,100 @@ inline H5::Group tryCreateGroup(const H5::Group &parentGroup,
     }
   }
   return parentGroup.createGroup(childGroupName);
+}
+
+/*
+produces a vector containing the index of MeshObject 'faces', which is the first
+index of the vertex in a winding order that makes a triangle, and the ID (not
+index!) of the detector whose position is within that triangle. Returns a vector
+of data organied in ascending order of the 'faces' index with their detector ID
+as consecutive:
+
+EXAMPLE
+key: f - face index, d - detector ID.
+
+return format: {f0, d0, f1, d1, f2, d2, f3, d3... }
+
+*/
+
+std::vector<size_t> findDetectorFaces(const Geometry::ComponentInfo &compInfo,
+                                      size_t idx,
+                                      const std::vector<int> &detIds) {
+
+  if (!compInfo.hasValidShape(idx)) {
+    throw std::invalid_argument("no shape in nxDetector.");
+  }
+
+  std::vector<size_t> pairs;
+  auto &shapeObj = compInfo.shape(idx);
+  const auto childrenDetectors = compInfo.detectorsInSubtree(idx);
+  if (auto meshObj = dynamic_cast<const Geometry::MeshObject *>(&shapeObj)) {
+    auto triangles = meshObj->getV3Ds(); // V3D vertices of NxDetector shape
+    auto nFaces = meshObj->numberOfTriangles();
+    auto windingOrder = meshObj->getTriangles();
+
+    for (size_t i = 0; i < nFaces; i += 3) {
+      for (const size_t j : childrenDetectors) {
+
+        // position of pixel
+        const auto position =
+            Kernel::toV3D(offsetFromAncestor(compInfo, idx, j));
+
+        if (Geometry::MeshObjectCommon::isOnTriangle(
+                position, triangles[windingOrder[i]],
+                triangles[windingOrder[i + 1]],
+                triangles[windingOrder[i + 2]])) {
+          pairs.push_back(i);
+          pairs.push_back(detIds[j]);
+        }
+      }
+    }
+  } else if (auto meshObj =
+                 dynamic_cast<const Geometry::MeshObject2D *>(&shapeObj)) {
+    auto points = meshObj->getVertices();
+    auto nFaces = meshObj->numberOfTriangles();
+    auto windingOrder = meshObj->getTriangles();
+
+    for (size_t i = 0; i < nFaces; i += 3) {
+      for (const size_t j : childrenDetectors) {
+
+        // position of pixel
+        const auto position =
+            Kernel::toV3D(offsetFromAncestor(compInfo, idx, j));
+        std::vector<Kernel::V3D> v3ds = {
+            Kernel::V3D{points[i], points[i + 1], points[i + 2]},
+            Kernel::V3D{points[i + 3], points[i + 4], points[i + 5]},
+            Kernel::V3D{points[i + 6], points[i + 7], points[i + 9]}
+
+        };
+
+        if (Geometry::MeshObjectCommon::isOnTriangle(
+                position, v3ds[windingOrder[i]], v3ds[windingOrder[i + 1]],
+                v3ds[windingOrder[i + 2]])) {
+          pairs.push_back(i);
+          pairs.push_back(detIds[j]);
+        }
+      }
+    }
+  } else {
+    throw std::invalid_argument("no mesh shape in nxdetector.");
+  }
+  return pairs;
+}
+
+Eigen::Vector3d generateOrthogonal(const Eigen::Vector3d &vector) {
+  Eigen::Vector3d i, j, k;
+  i = {1.0, 0.0, 0.0};
+  j = {0.0, 1.0, 0.0};
+  k = {0.0, 0.0, 1.0};
+  if (vector.normalized().isApprox(i, PRECISION))
+    return j;
+  if (vector.normalized().isApprox(j, PRECISION))
+    return k;
+  if (vector.normalized().isApprox(k, PRECISION))
+    return i;
+  else
+    return {1, -(vector[0] / vector[1]), 0};
 }
 /*
  * Function toStdVector (Overloaded). Store data in Mantid::Kernel::V3D vector
@@ -113,16 +212,20 @@ std::vector<double> toStdVector(const Eigen::Vector3d &data) {
  * by SaveInstrument methods to determine whether or not to write a dataset to
  * file.
  *
- * @param data : std::vector<T> data
+ * @param data : std::vector<double> data
  * @param precision : double precision specifier
  * @return true if all elements are approx zero, else false.
  */
-bool isApproxZero(const std::vector<double> &data, const double &precision) {
 
+bool isApproxZero(const std::vector<double> &data, const double &precision) {
   return std::all_of(data.begin(), data.end(),
                      [&precision](const double &element) {
                        return std::abs(element) < precision;
                      });
+}
+
+inline bool isApproxZero(const double data, const double precision) {
+  return std::abs(data) < precision;
 }
 
 // overload. return true if vector is approx to zero
@@ -160,6 +263,9 @@ void writeStrDataset(H5::Group &grp, const std::string &dSetName,
                      const std::string &dSetVal,
                      const H5::DataSpace &dataSpace = SCALAR) {
   // TODO. may need to review if we shoud in fact replace.
+  // added safety check for older HDF libraries
+  if (dSetVal.empty())
+    return;
   if (!utilities::findDataset(grp, dSetName)) {
     H5::StrType dataType = strTypeOfSize(dSetVal);
     H5::DataSet dSet = grp.createDataSet(dSetName, dataType, dataSpace);
@@ -168,7 +274,10 @@ void writeStrDataset(H5::Group &grp, const std::string &dSetName,
 }
 
 /*
- * Function: writeStrAttribute
+TODO: TESTS to check empty datasets and attributes are not written.
+*/
+
+/** Function: writeStrAttribute
  * writes a StrType HDF attribute and attribute value to a HDF group.
  *
  * @param grp : HDF group object.
@@ -178,6 +287,10 @@ void writeStrDataset(H5::Group &grp, const std::string &dSetName,
 void writeStrAttribute(H5::Group &grp, const std::string &attrName,
                        const std::string &attrVal,
                        const H5::DataSpace &dataSpace = SCALAR) {
+  // added safety check for older HDF libraries
+  if (attrVal.empty())
+    throw std::invalid_argument("attribute value in " + attrName +
+                                " cannot be empty.");
   if (!grp.attrExists(attrName)) {
     H5::StrType dataType = strTypeOfSize(attrVal);
     H5::Attribute attribute =
@@ -530,8 +643,8 @@ SpectraMappings makeMappings(const Geometry::ComponentInfo &compInfo,
                                 // spectra-detector map for this NXdetector
   // local to this nxdetector
   std::map<size_t, int> detector_count_map;
-  // We start knowing only the detector index, we have to establish spectra from
-  // that.
+  // We start knowing only the detector index, we have to establish spectra
+  // from that.
   for (const auto det_index : childrenDetectors) {
     auto detector_id = detIds[det_index];
 
@@ -546,6 +659,7 @@ SpectraMappings makeMappings(const Geometry::ComponentInfo &compInfo,
                          // recording
     }
   }
+
   // Sized to spectra in bank
   SpectraMappings mappings;
   mappings.detector_list.resize(nChildDetectors);
@@ -565,8 +679,8 @@ SpectraMappings makeMappings(const Geometry::ComponentInfo &compInfo,
     mappings.spectra_ids[specCounter] =
         int32_t(indexInfo.spectrumNumber(pair.first));
 
-    // We will list everything by spectrum index, so we need to add the detector
-    // ids in the same order.
+    // We will list everything by spectrum index, so we need to add the
+    // detector ids in the same order.
     const auto &specDefintion = specInfo.spectrumDefinition(pair.first);
     for (const auto &def : specDefintion) {
       mappings.detector_list[detCounter] = detIds[def.first];
@@ -610,8 +724,8 @@ void validateInputs(AbstractLogger &logger, const std::string &fullPath,
   }
 
   if (!compInfo.hasDetectorInfo()) {
-    logger.error(
-        "No detector info was found in the Instrument. Instrument not saved.");
+    logger.error("No detector info was found in the Instrument. Instrument "
+                 "not saved.");
     throw std::invalid_argument("No detector info was found in the Instrument");
   }
   if (!compInfo.hasSample()) {
@@ -636,8 +750,8 @@ void validateInputs(AbstractLogger &logger, const std::string &fullPath,
 
 /*
  * Function determines if a given index has an ancestor index in the
- * saved_indices list. This allows us to prevent duplicate saving of things that
- * could be considered NXDetectors
+ * saved_indices list. This allows us to prevent duplicate saving of things
+ * that could be considered NXDetectors
  */
 template <typename T>
 bool isDesiredNXDetector(size_t index, const T &saved_indices,
@@ -650,14 +764,16 @@ bool isDesiredNXDetector(size_t index, const T &saved_indices,
 }
 
 /**
- * Internal save implementation. We can either write a new file containing only
- * the geometry, or we might also need to append/merge with an existing file.
- * Knowing the logic for this is important so we build an object around the Mode
- * state.
+ * Internal save implementation. We can either write a new file containing
+ * only the geometry, or we might also need to append/merge with an existing
+ * file. Knowing the logic for this is important so we build an object around
+ * the Mode state.
  */
 class NexusGeometrySaveImpl {
 public:
   enum class Mode { Trunc, Append };
+  std::vector<detid_t> m_detectorIds;
+  hid_t m_fileID;
 
   explicit NexusGeometrySaveImpl(Mode mode) : m_mode(mode) {}
   NexusGeometrySaveImpl(const NexusGeometrySaveImpl &) =
@@ -793,8 +909,9 @@ public:
    */
   H5::Group monitor(const H5::Group &parentGroup,
                     const Geometry::ComponentInfo &compInfo,
-                    const int monitorId, const size_t index) {
+                    const size_t index) {
 
+    const detid_t monitorId = m_detectorIds[index];
     // if the component is unnamed sets the name as unspecified with the
     // location of the component in the cache
     std::string nameInCache = compInfo.name(index);
@@ -846,6 +963,8 @@ public:
 
     H5::StrType dependencyStrType = strTypeOfSize(dependency);
     writeNXMonitorNumber(childGroup, monitorId);
+    // write either INDIVIDUAL mesh or cylinder
+    writeMonitorShape(compInfo, childGroup, index);
 
     writeStrDataset(childGroup, BANK_NAME, monitorName);
     writeStrDataset(childGroup, DEPENDS_ON, dependency);
@@ -867,15 +986,15 @@ public:
    * @param mappings : Spectra to detector mappings
    */
   void monitor(const H5::Group &parentGroup,
-               const Geometry::ComponentInfo &compInfo, const int monitorId,
-               const size_t index, SpectraMappings &mappings) {
+               const Geometry::ComponentInfo &compInfo, const size_t index,
+               SpectraMappings &mappings) {
 
-    auto childGroup = monitor(parentGroup, compInfo, monitorId, index);
+    auto childGroup = monitor(parentGroup, compInfo, index);
     // Additional mapping information written.
     writeDetectorCount(childGroup, mappings);
     // Note that the detector list is the same as detector_number, but it is
-    // ordered by spectrum index 0 - N, whereas detector_number is just written
-    // out in the order the detectors are encountered in the bank.
+    // ordered by spectrum index 0 - N, whereas detector_number is just
+    // written out in the order the detectors are encountered in the bank.
     writeDetectorList(childGroup, mappings);
     writeDetectorIndex(childGroup, mappings);
     writeSpectra(childGroup, mappings);
@@ -897,7 +1016,7 @@ public:
    */
   H5::Group detector(const H5::Group &parentGroup,
                      const Geometry::ComponentInfo &compInfo,
-                     const std::vector<int> &detIds, const size_t index) {
+                     const size_t index) {
 
     // if the component is unnamed sets the name as unspecified with the
     // location of the component in the cache
@@ -949,8 +1068,10 @@ public:
     }
 
     H5::StrType dependencyStrType = strTypeOfSize(dependency);
-    writeXYZPixeloffset(childGroup, compInfo, index);
-    writeNXDetectorNumber(childGroup, compInfo, detIds, index);
+    writePixelOffsets(childGroup, compInfo, index);
+    writeNXDetectorNumber(childGroup, compInfo, m_detectorIds, index);
+    // write either meshes or cyinders
+    writePixelShapes(compInfo, m_detectorIds, childGroup, index);
 
     writeStrDataset(childGroup, BANK_NAME, detectorName);
     writeStrDataset(childGroup, DEPENDS_ON, dependency);
@@ -973,20 +1094,444 @@ public:
    * NXdetector will be extracted.
    */
   void detector(const H5::Group &parentGroup,
-                const Geometry::ComponentInfo &compInfo,
-                const std::vector<int> &detIds, const size_t index,
+                const Geometry::ComponentInfo &compInfo, const size_t index,
                 SpectraMappings &mappings) {
 
-    auto childGroup = detector(parentGroup, compInfo, detIds, index);
+    auto childGroup = detector(parentGroup, compInfo, index);
 
     // Additional mapping information written.
     writeDetectorCount(childGroup, mappings);
     // Note that the detector list is the same as detector_number, but it is
-    // ordered by spectrum index 0 - N, whereas detector_number is just written
-    // out in the order the detectors are encountered in the bank.
+    // ordered by spectrum index 0 - N, whereas detector_number is just
+    // written out in the order the detectors are encountered in the bank.
     writeDetectorList(childGroup, mappings);
     writeDetectorIndex(childGroup, mappings);
     writeSpectra(childGroup, mappings);
+  }
+
+  /*
+    TODO:
+    */
+  void writeMesh(H5::Group &grp, const std::vector<double> &vertices,
+                 const std::vector<uint32_t> &windingOrder, const size_t nFaces,
+                 const size_t nVertices, std::vector<size_t> detFaces = {}) {
+
+    H5::DataSet dFaces, dVertices, dWindingOrder;
+
+    // vertices
+
+    int vrank = 2;
+    hsize_t vdims[static_cast<hsize_t>(2)];
+    vdims[0] = static_cast<hsize_t>(nVertices);
+    vdims[1] = static_cast<hsize_t>(3);
+    H5::DataSpace vspace = H5Screate_simple(vrank, vdims, nullptr);
+
+    // Modify dataset creation property to enable chunking
+    hsize_t vchunks[2] = {static_cast<hsize_t>(nVertices), 3};
+    H5::DSetCreatPropList vplist;
+    vplist.setChunk(2, vchunks);
+    vplist.setDeflate(6);
+
+    dVertices =
+        grp.createDataSet(VERTICES, H5::PredType::NATIVE_FLOAT, vspace, vplist);
+    writeToDataset(dVertices, vertices, H5::PredType::NATIVE_FLOAT, vspace);
+    writeStrAttribute(dVertices, UNITS, METRES);
+
+    // winding order
+
+    int wrank = 1;
+    auto wsize = static_cast<hsize_t>(windingOrder.size());
+    hsize_t wdims[static_cast<hsize_t>(1)];
+    wdims[0] = wsize;
+    H5::DataSpace wspace = H5Screate_simple(wrank, wdims, nullptr);
+
+    // Modify dataset creation property to enable chunking
+    hsize_t wchunks[1] = {wsize};
+    H5::DSetCreatPropList wplist;
+    wplist.setChunk(1, wchunks);
+    wplist.setDeflate(6);
+
+    dWindingOrder = grp.createDataSet(WINDING_ORDER, H5::PredType::NATIVE_INT,
+                                      wspace, wplist);
+    writeToDataset(dWindingOrder, windingOrder, H5::PredType::NATIVE_INT,
+                   wspace);
+
+    // faces
+
+    // fixed to 3 for triangles.
+    int jumps = 3;
+
+    std::vector<int> facesData;
+    for (int i = 0; static_cast<hsize_t>(i) <= nFaces; ++i)
+      facesData.push_back(i * jumps);
+
+    int frank = 1;
+    hsize_t fdims[static_cast<hsize_t>(1)];
+    fdims[0] = static_cast<hsize_t>(nFaces);
+    H5::DataSpace fspace = H5Screate_simple(frank, fdims, nullptr);
+
+    // Modify dataset creation property to enable chunking
+    hsize_t fchunks[1] = {static_cast<hsize_t>(nFaces)};
+    H5::DSetCreatPropList fplist;
+    fplist.setChunk(1, fchunks);
+    fplist.setDeflate(6);
+
+    dFaces = grp.createDataSet(FACES, H5::PredType::NATIVE_INT, fspace, fplist);
+    writeToDataset(dFaces, facesData, H5::PredType::NATIVE_INT, fspace);
+
+    // only if the mesh describes the shape of the NXdetector should
+    // 'detector_faces' be written, such as when the pixels are
+    // non-homogeneous
+    if (!detFaces.empty()) {
+
+      // detector faces
+      int dfrank = 2;
+      hsize_t dfdims[static_cast<hsize_t>(2)];
+      dfdims[0] = static_cast<hsize_t>(detFaces.size() / 2);
+      dfdims[1] = static_cast<hsize_t>(2);
+      H5::DataSpace dfspace = H5Screate_simple(dfrank, dfdims, nullptr);
+      H5::DataSet dDetectorFaces =
+          grp.createDataSet(DETECTOR_FACES, H5::PredType::NATIVE_INT, dfspace);
+      writeToDataset(dDetectorFaces, detFaces, H5::PredType::NATIVE_INT,
+                     dfspace);
+    }
+  }
+
+  /*
+  TODO:
+  */
+  void writeCylinder(H5::Group &grp, size_t nCylinders,
+                     const std::vector<double> &vertexCoordinates) {
+
+    H5::DataSet cylinders, vertices;
+    // prepare the data
+    std::vector<int> cylinderData(nCylinders * 3);
+    for (size_t i = 0; i < nCylinders * 3; i += 3) {
+      for (int j = 0; j < 3; ++j) {
+        cylinderData[i + j] = static_cast<int>(i + j); // testing output
+      }
+    }
+
+    int crank = 2;
+    hsize_t cdims[static_cast<hsize_t>(2)];
+    cdims[0] = static_cast<hsize_t>(nCylinders); // nCylinders;
+    cdims[1] = static_cast<hsize_t>(3);
+    H5::DataSpace cspace = H5Screate_simple(crank, cdims, nullptr);
+
+    // Modify dataset creation property to enable chunking
+    if (nCylinders > 1) {
+      // cylinder dataset can be chunked if describing more than cylinder only
+      hsize_t cchunks[2] = {nCylinders, 3};
+      H5::DSetCreatPropList cplist;
+      cplist.setChunk(2, cchunks);
+      cplist.setDeflate(COMPRESSION_LEVEL);
+
+      cylinders = grp.createDataSet(CYLINDERS, H5::PredType::NATIVE_INT, cspace,
+                                    cplist);
+    } else {
+      // cylinder dataset is contiguous if describing only one pixel shape.
+      cylinders =
+          grp.createDataSet(CYLINDERS, H5::PredType::NATIVE_INT, cspace);
+    }
+    writeToDataset(cylinders, cylinderData, H5::PredType::NATIVE_INT, cspace);
+
+    int vrank = 2;
+    hsize_t vdims[static_cast<hsize_t>(2)];
+    vdims[0] = static_cast<hsize_t>(3 * nCylinders);
+    vdims[1] = static_cast<hsize_t>(3);
+    H5::DataSpace vspace = H5Screate_simple(vrank, vdims, nullptr);
+
+    // Modify dataset creation property to enable chunking
+    hsize_t vchunks[2] = {static_cast<hsize_t>(3 * nCylinders), 3};
+    H5::DSetCreatPropList vplist;
+    vplist.setChunk(2, vchunks);
+    vplist.setDeflate(COMPRESSION_LEVEL);
+
+    vertices = grp.createDataSet(VERTICES, H5::PredType::NATIVE_DOUBLE, vspace,
+                                 vplist);
+    writeToDataset(vertices, vertexCoordinates, H5::PredType::NATIVE_DOUBLE,
+                   vspace);
+    writeStrAttribute(vertices, UNITS, METRES);
+  }
+
+  template <typename T>
+  void writeMeshObjShapeToPixels(const Geometry::ComponentInfo &compInfo,
+                                 const std::vector<int> &detIds, H5::Group &grp,
+                                 std::vector<size_t> &meshes, size_t bankIdx) {
+
+    // shape type of the first detector in children detectors
+    auto &firstShapeObj = compInfo.shape(meshes.front());
+    auto fMeshObj = dynamic_cast<const T *>(&firstShapeObj);
+    auto fVertices = fMeshObj->getVertices();
+    auto fWindingOrder = fMeshObj->getTriangles();
+
+    // prevents undefined behaviour when passing empty container into
+    // std::all_of. If empty, there is no data to write. No associated group
+    // will be created in file.
+
+    // check if cylinders are homogeneous
+    bool meshesAreHomogeneous =
+        std::all_of(meshes.begin(), meshes.end(), [&](const size_t &idx) {
+          auto &shapeObj = compInfo.shape(idx);
+          auto meshObj = dynamic_cast<const T *>(&shapeObj);
+          auto vertices = meshObj->getVertices();
+          auto windingOrder = meshObj->getTriangles();
+
+          // by extension, if the vertices in both first and current mesh are
+          // equal, then the number of triangles are also equal
+          return (fVertices == vertices && fWindingOrder == windingOrder);
+        });
+    if (meshesAreHomogeneous) {
+      // homogeneous pixels can be optimised so as to only write the shape of
+      // one pixel, the group of which is called the 'pixel_shape'
+      H5::Group pixelShapeGroup = simpleNXSubGroup(grp, PIXEL_SHAPE, NX_OFF);
+      // write first mesh
+
+      auto &shapeObj = compInfo.shape(meshes.front());
+      auto meshObj = dynamic_cast<const T *>(&shapeObj);
+
+      size_t nFaces = meshObj->numberOfTriangles();
+      size_t nVertices = meshObj->numberOfVertices();
+
+      auto windingOrder = meshObj->getTriangles();
+      std::vector<double> vertices = meshObj->getVertices();
+
+      writeMesh(pixelShapeGroup, vertices, windingOrder, nFaces, nVertices);
+
+    } else {
+      // non-homogeneous pixels will describe the entire shape of the
+      // detector, the group for which is called 'detector_shape'
+      H5::Group pixelShapeGroup = simpleNXSubGroup(grp, DETECTOR_SHAPE, NX_OFF);
+      std::vector<double> vertices;
+      std::vector<int> detFaces;
+      std::vector<uint32_t> windingOrder;
+      size_t totalNumOfVertices = 0;
+      size_t totalNumOfFaces = 0;
+      for (std::vector<size_t>::iterator it = meshes.begin();
+           it != meshes.end(); ++it) {
+
+        auto &shapeObj = compInfo.shape(*it);
+        auto meshObj = dynamic_cast<const T *>(&shapeObj);
+
+        size_t nFaces = meshObj->numberOfTriangles();
+        size_t nVertices = meshObj->numberOfVertices();
+
+        std::vector<uint32_t> currentWindingOrder = meshObj->getTriangles();
+        std::vector<double> currentVertices = meshObj->getVertices();
+
+        // append the data
+        vertices.insert(vertices.end(), currentVertices.begin(),
+                        currentVertices.end());
+        windingOrder.insert(windingOrder.end(), currentWindingOrder.begin(),
+                            currentWindingOrder.end());
+        totalNumOfFaces += nFaces;
+        totalNumOfVertices += nVertices;
+      }
+      const std::vector<size_t> detFacesData =
+          findDetectorFaces(compInfo, bankIdx, detIds);
+      writeMesh(pixelShapeGroup, vertices, windingOrder, totalNumOfFaces,
+                totalNumOfVertices, detFacesData);
+    }
+  }
+
+  /*
+  TODO: DOC
+  */
+  void writeCylinderShapeToPixels(const Geometry::ComponentInfo &compInfo,
+                                  H5::Group &grp,
+                                  std::vector<size_t> &cylinders) {
+
+    // shape type of the first detector in children detectors
+    auto &firstShape = compInfo.shape(cylinders.front());
+    auto firstShapeInfo = firstShape.shapeInfo();
+    auto fType = firstShapeInfo.shape();
+    auto fHeight = firstShapeInfo.height();
+    auto fRadius = firstShapeInfo.radius();
+
+    // check if cylinders are homogeneous
+    bool cylindersAreHomogeneous =
+        std::all_of(cylinders.begin(), cylinders.end(), [&](const size_t &idx) {
+          auto &shapeObj = compInfo.shape(idx);
+          auto shapeInfo = shapeObj.shapeInfo();
+          auto type = shapeInfo.shape();
+          auto height = shapeInfo.height();
+          auto radius = shapeInfo.radius();
+          return (type == fType && height == fHeight && fRadius == radius);
+        });
+    if (cylindersAreHomogeneous) {
+      // homogeneous pixels can be optimised so as to only write the shape of
+      // one pixel, the group of which is called the 'pixel_shape'
+      H5::Group pixelShapeGroup =
+          simpleNXSubGroup(grp, PIXEL_SHAPE, NX_CYLINDER);
+      // write cylinder only once, using the first index
+      auto geometry = firstShapeInfo.cylinderGeometry();
+      const Eigen::Vector3d &base =
+          Kernel::toVector3d(geometry.centreOfBottomBase);
+      const Eigen::Vector3d &axis = Kernel::toVector3d(geometry.axis);
+      double &height = geometry.height;
+      double &radius = geometry.radius;
+
+      double a, b, c;
+      a = axis[0];
+      b = axis[1];
+      c = axis[2];
+      // A vector orthogonal to the axis and lying on plane z.
+      Eigen::Vector3d orthogonalToAxis = generateOrthogonal(axis);
+      if (!isApproxZero(axis.dot(orthogonalToAxis), PRECISION))
+        throw;
+      orthogonalToAxis.normalize();
+      Eigen::Vector3d edge = base + (radius * orthogonalToAxis);
+      Eigen::Vector3d top = base + (height * axis.normalized());
+
+      std::vector<double> vertices{base[0], base[1], base[2], edge[0], edge[1],
+                                   edge[2], top[0],  top[1],  top[2]};
+      writeCylinder(pixelShapeGroup, 1, vertices);
+    } else {
+      // non-homogeneous pixels will describe the entire shape of the
+      // detector, the group for which is called 'detector_shape'
+      H5::Group pixelShapeGroup =
+          simpleNXSubGroup(grp, DETECTOR_SHAPE, NX_CYLINDER);
+      std::vector<double> vertices;
+      for (std::vector<size_t>::iterator it = cylinders.begin();
+           it != cylinders.end(); ++it) {
+
+        auto shapeInfo = compInfo.shape(*it).shapeInfo();
+        auto geometry = shapeInfo.cylinderGeometry();
+        const Eigen::Vector3d &base =
+            Kernel::toVector3d(geometry.centreOfBottomBase);
+        const Eigen::Vector3d &axis = Kernel::toVector3d(geometry.axis);
+        double &height = geometry.height;
+        double &radius = geometry.radius;
+
+        Eigen::Vector3d orthogonalToBase{base[1], base[0], base[2]};
+        if (!isApproxZero(orthogonalToBase.dot(orthogonalToBase), PRECISION))
+          throw;
+        orthogonalToBase.normalize();
+        Eigen::Vector3d edge = base + (radius * orthogonalToBase);
+        Eigen::Vector3d top = base + (height * axis.normalized());
+
+        std::vector<double> additionalVertices{base[0], base[1], base[2],
+                                               edge[0], edge[1], edge[2],
+                                               top[0],  top[1],  top[2]};
+        vertices.insert(vertices.end(), additionalVertices.begin(),
+                        additionalVertices.end());
+      }
+      writeCylinder(pixelShapeGroup, cylinders.size(), vertices);
+    }
+  }
+
+  /*
+  optimisation for
+  */
+  void writeMonitorShape(const Geometry::ComponentInfo &compInfo,
+                         H5::Group &grp, size_t idx) {
+
+    if (compInfo.hasValidShape(idx)) {
+      auto &shapeObj = compInfo.shape(idx);
+      if (const auto mesh =
+              dynamic_cast<const Geometry::MeshObject *>(&shapeObj)) {
+
+        size_t nFaces = mesh->numberOfTriangles();
+        size_t nVertices = mesh->numberOfVertices();
+        auto windingOrder = mesh->getTriangles();
+        std::vector<double> vertices = mesh->getVertices();
+        H5::Group shapeGroup = simpleNXSubGroup(grp, SHAPE, NX_OFF);
+        writeMesh(shapeGroup, vertices, windingOrder, nFaces, nVertices);
+      } else if (const auto mesh =
+                     dynamic_cast<const Geometry::MeshObject2D *>(&shapeObj)) {
+        size_t nFaces = mesh->numberOfTriangles();
+        size_t nVertices = mesh->numberOfVertices();
+        auto windingOrder = mesh->getTriangles();
+        std::vector<double> vertices = mesh->getVertices();
+        H5::Group shapeGroup = simpleNXSubGroup(grp, SHAPE, NX_OFF);
+        writeMesh(shapeGroup, vertices, windingOrder, nFaces, nVertices);
+
+      } else {
+
+        auto shapeInfo = shapeObj.shapeInfo();
+        auto type = shapeObj.shapeInfo().shape();
+        // this makes the assumption that if either dynamic casts above fail
+        // then the shape must be of type CSGObject, and has implementation
+        // for shabeObj.ShapeInfo().
+        if (static_cast<int>(type) == 4 /*CYLINDER*/) {
+
+          H5::Group shapeGroup = simpleNXSubGroup(grp, SHAPE, NX_CYLINDER);
+
+          auto geometry = shapeInfo.cylinderGeometry();
+          const Eigen::Vector3d &base =
+              Kernel::toVector3d(geometry.centreOfBottomBase);
+          const Eigen::Vector3d &axis = Kernel::toVector3d(geometry.axis);
+          double &height = geometry.height;
+          double &radius = geometry.radius;
+
+          Eigen::Vector3d orthogonalToBase{base[1], base[0], base[2]};
+          if (!isApproxZero(orthogonalToBase.dot(orthogonalToBase), PRECISION))
+            throw;
+          orthogonalToBase.normalize();
+          Eigen::Vector3d edge = base + (radius * orthogonalToBase);
+          Eigen::Vector3d top = base + (height * axis.normalized());
+
+          std::vector<double> vertices{base[0], base[1], base[2],
+                                       edge[0], edge[1], edge[2],
+                                       top[0],  top[1],  top[2]};
+          writeCylinder(shapeGroup, 1, vertices);
+        }
+      }
+    }
+  }
+
+  void writePixelShapes(const Geometry::ComponentInfo &compInfo,
+                        const std::vector<int> &detIds, H5::Group &grp,
+                        size_t idx) {
+
+    auto pixels =
+        compInfo.detectorsInSubtree(idx); // indices of all pixels in bank
+    // If children detectors empty, there is no data to write to bank. exits
+    // here.
+    if (pixels.empty())
+      return;
+
+    std::vector<size_t> meshes;
+    std::vector<size_t> meshes2D;
+    std::vector<size_t> cylinders;
+
+    // shape type of the first detector in children detectors
+
+    // return true if all shape types, heights and radii are equal to the
+    // first shape in children detectors.
+
+    std::for_each(pixels.begin(), pixels.end(), [&](const size_t &idx) {
+      if (compInfo.hasValidShape(idx)) {
+        const Geometry::MeshObject *mesh;
+        const Geometry::MeshObject2D *mesh2D;
+        auto &shapeObj = compInfo.shape(idx);
+        if (mesh = dynamic_cast<const Geometry::MeshObject *>(&shapeObj))
+          meshes.push_back(idx);
+        else if (mesh2D =
+                     dynamic_cast<const Geometry::MeshObject2D *>(&shapeObj))
+          meshes2D.push_back(idx);
+        else {
+          // this makes the assumption that if either dynamic casts above fail
+          // then the shape must be of type CSGObject, and has implementation
+          // for shabeObj.ShapeInfo().
+          auto type = shapeObj.shapeInfo().shape();
+          if (static_cast<int>(type) == 4 /*CYLINDER*/)
+            cylinders.push_back(idx);
+        }
+      }
+    });
+
+    // prevents undefined behaviour when passing empty container into
+    // std::all_of. If empty, there is no data to write. No associated group
+    // will be created in file.
+    if (meshes.size() == pixels.size())
+      writeMeshObjShapeToPixels<Geometry::MeshObject>(compInfo, detIds, grp,
+                                                      meshes, idx);
+    else if (meshes2D.size() == pixels.size())
+      writeMeshObjShapeToPixels<Geometry::MeshObject2D>(compInfo, detIds, grp,
+                                                        meshes2D, idx);
+    else if (cylinders.size() == pixels.size())
+      writeCylinderShapeToPixels(compInfo, grp, cylinders);
   }
 
 private:
@@ -1015,10 +1560,378 @@ private:
     writeStrAttribute(subGroup, NX_CLASS, nexusAttribute);
     return subGroup;
   }
+
+  template <typename T>
+  void writeToDataset(H5::DataSet &dSet, const std::vector<T> &data,
+                      const H5::PredType &predType, const H5::DataSpace space) {
+
+    if (!data.empty()) {
+
+      dSet.write(data.data(), predType, space);
+    }
+  }
+
+  template <typename T>
+  void writeToAttribute(H5::Attribute &attr, const std::vector<T> &data,
+                        const H5::PredType &predType) {
+    if (!data.empty())
+      attr.write(predType, data.data());
+  }
+
+  /*
+   * Function: writePixelOffsets
+   * write the x, y, and z offset of the pixels from the parent detector bank as
+   * HDF5 datasets to HDF5 group. If all of the pixel offsets in either x, y, or
+   * z are approximately zero, skips writing that dataset to file.
+   *
+   * @param grp : HDF5 parent group
+   * @param compInfo : Component Info Instrument cache
+   * @param idx : index of bank in cache.
+   */
+  void writePixelOffsets(H5::Group &grp,
+                         const Geometry::ComponentInfo &compInfo,
+                         const size_t idx) {
+
+    H5::DataSet xPixelOffset, yPixelOffset,
+        zPixelOffset; // pixel offset datasets
+    auto pixels =
+        compInfo.detectorsInSubtree(idx); // indices of all pixels in bank
+    const auto nPixels = pixels.size();   // number of pixels
+
+    // If children detectors empty, there is no data to write to bank. exits
+    // here.
+    if (pixels.empty())
+      return;
+
+    std::vector<double> posx;
+    std::vector<double> posy;
+    std::vector<double> posz;
+
+    posx.reserve(nPixels);
+    posy.reserve(nPixels);
+    posz.reserve(nPixels);
+
+    bool xIsZero{true}; // becomes false when atleast 1 non-zero x found
+    bool yIsZero{true}; // becomes false when atleast 1 non-zero y found
+    bool zIsZero{true}; // becomes false when atleast 1 non-zero z found
+    // get pixel offset data
+    for (std::vector<size_t>::iterator it = pixels.begin(); it != pixels.end();
+         ++it) {
+      Eigen::Vector3d offset =
+          Geometry::ComponentInfoBankHelpers::offsetFromAncestor(compInfo, idx,
+                                                                 *it);
+      if (!isApproxZero(offset[0], PRECISION))
+        xIsZero = false;
+      if (!isApproxZero(offset[1], PRECISION))
+        yIsZero = false;
+      if (!isApproxZero(offset[2], PRECISION))
+        zIsZero = false;
+
+      posx.push_back(offset[0]); // x pixel offset
+      posy.push_back(offset[1]); // y pixel offset
+      posz.push_back(offset[2]); // z pixel offset
+    }
+
+    auto bankName = compInfo.name(idx);
+    const auto nDetectorsInBank = static_cast<hsize_t>(posx.size());
+
+    int rank = 1;
+    hsize_t dims[static_cast<hsize_t>(1)];
+    dims[0] = nDetectorsInBank;
+    H5::DataSpace space = H5Screate_simple(rank, dims, nullptr);
+
+    // Modify dataset creation property to enable chunking
+    hsize_t chunks[1] = {nDetectorsInBank};
+    H5::DSetCreatPropList plist;
+    plist.setChunk(1, chunks);
+    plist.setDeflate(COMPRESSION_LEVEL);
+
+    if (!xIsZero) {
+      xPixelOffset = grp.createDataSet(
+          X_PIXEL_OFFSET, H5::PredType::NATIVE_DOUBLE, space, plist);
+      writeToDataset(xPixelOffset, posx, H5::PredType::NATIVE_DOUBLE, space);
+      writeStrAttribute(xPixelOffset, UNITS, METRES);
+    }
+
+    if (!yIsZero) {
+      yPixelOffset = grp.createDataSet(
+          Y_PIXEL_OFFSET, H5::PredType::NATIVE_DOUBLE, space, plist);
+      writeToDataset(yPixelOffset, posy, H5::PredType::NATIVE_DOUBLE, space);
+      writeStrAttribute(yPixelOffset, UNITS, METRES);
+    }
+
+    if (!zIsZero) {
+      zPixelOffset = grp.createDataSet(
+          Z_PIXEL_OFFSET, H5::PredType::NATIVE_DOUBLE, space, plist);
+      writeToDataset(zPixelOffset, posz, H5::PredType::NATIVE_DOUBLE, space);
+      writeStrAttribute(zPixelOffset, UNITS, METRES);
+    }
+  }
+
+  /*
+   * Function: writeNXMonitorNumber
+   * For use with NXmonitor group. write 'detector_id's of an NXmonitor, which
+   * is a specific type of pixel, to its group.
+   *
+   * @param grp : NXmonitor group (HDF group)
+   * @param monitorID : monitor ID to be
+   * stored into dataset 'detector_id' (or 'detector_number'. naming convention
+   * inconsistency?).
+   */
+  void writeNXMonitorNumber(H5::Group &grp, const int monitorID) {
+
+    // these DataSets are duplicates of each other. written to the NXmonitor
+    // group to handle the naming inconsistency. probably temporary.
+    H5::DataSet detectorNumber, detector_id;
+
+    int rank = 1;
+    hsize_t dims[static_cast<hsize_t>(1)];
+    dims[0] = static_cast<hsize_t>(1);
+
+    H5::DataSpace space = H5Screate_simple(rank, dims, nullptr);
+
+    // these DataSets are duplicates of each other. written to the group to
+    // handle the naming inconsistency. probably temporary.
+
+    // monitorIds are always singular, and can be contiguous.
+    if (!utilities::findDataset(grp, DETECTOR_IDS)) {
+
+      detectorNumber =
+          grp.createDataSet(DETECTOR_IDS, H5::PredType::NATIVE_INT, space);
+      detectorNumber.write(&monitorID, H5::PredType::NATIVE_INT, space);
+    }
+    if (!utilities::findDataset(grp, DETECTOR_ID)) {
+
+      detector_id =
+          grp.createDataSet(DETECTOR_ID, H5::PredType::NATIVE_INT, space);
+      detector_id.write(&monitorID, H5::PredType::NATIVE_INT, space);
+    }
+  }
+
+  /*
+   * Function: writeLocation
+   * For use with NXdetector group. Writes absolute position of detector bank to
+   * dataset and metadata as attributes.
+   *
+   * @param grp : NXdetector group : (HDF group)
+   * @param position : Eigen::Vector3d position of component in instrument
+   * cache.
+   */
+  void writeLocation(H5::Group &grp, const Eigen::Vector3d &position) {
+
+    std::string dependency = NO_DEPENDENCY; // self dependent
+
+    double norm;
+
+    H5::DataSet location;
+    H5::DataSpace dspace;
+    H5::DataSpace aspace;
+
+    H5::Attribute vector;
+    H5::Attribute units;
+    H5::Attribute transformationType;
+    H5::Attribute dependsOn;
+
+    H5::StrType strSize;
+
+    int drank = 1;                          // rank of dataset
+    hsize_t ddims[static_cast<hsize_t>(1)]; // dimensions of dataset
+    ddims[0] = static_cast<hsize_t>(1);     // datapoints in dataset dimension 0
+
+    norm = position.norm();               // norm of the position vector
+    auto unitVec = position.normalized(); // unit vector of the position vector
+    std::vector<double> stdNormPos =
+        toStdVector(unitVec); // convert to std::vector
+
+    dspace = H5Screate_simple(drank, ddims, nullptr); // dataspace for dataset
+    location = grp.createDataSet(LOCATION, H5::PredType::NATIVE_DOUBLE,
+                                 dspace); // dataset location
+    location.write(&norm, H5::PredType::NATIVE_DOUBLE,
+                   dspace); // write norm to location
+
+    int arank = 1;                          // rank of attribute
+    hsize_t adims[static_cast<hsize_t>(3)]; // dimensions of attribute
+    adims[0] = 3; // datapoints in attribute dimension 0
+
+    aspace = H5Screate_simple(arank, adims, nullptr); // dataspace for attribute
+    vector = location.createAttribute(VECTOR, H5::PredType::NATIVE_DOUBLE,
+                                      aspace); // attribute vector
+    writeToAttribute(
+        vector, stdNormPos,
+        H5::PredType::NATIVE_DOUBLE); // write unit vector to vector
+
+    // units attribute
+    strSize = strTypeOfSize(METRES);
+    units = location.createAttribute(UNITS, strSize, SCALAR);
+    units.write(strSize, METRES);
+
+    // transformation-type attribute
+    strSize = strTypeOfSize(TRANSLATION);
+    transformationType =
+        location.createAttribute(TRANSFORMATION_TYPE, strSize, SCALAR);
+    transformationType.write(strSize, TRANSLATION);
+
+    // dependency attribute
+    strSize = strTypeOfSize(dependency);
+    dependsOn = location.createAttribute(DEPENDS_ON, strSize, SCALAR);
+    dependsOn.write(strSize, dependency);
+  }
+
+  /*
+   * Function: writeOrientation
+   * For use with NXdetector group. Writes the absolute rotation of detector
+   * bank to dataset and metadata as attributes.
+   *
+   * @param grp : NXdetector group : (HDF group)
+   * @param rotation : Eigen::Quaterniond rotation of component in instrument
+   * cache.
+   * @param dependency : dependency of the orientation dataset:
+   * Compliant to the Mantid Instrument Definition file, if a translation
+   * exists, it precedes a rotation.
+   * https://docs.mantidproject.org/nightly/concepts/InstrumentDefinitionFile.html
+   */
+  void writeOrientation(H5::Group &grp, const Eigen::Quaterniond &rotation,
+                        const std::string &dependency) {
+
+    // dependency for orientation defaults to self-dependent. If Location
+    // dataset exists, the orientation will depend on it instead.
+
+    double angle;
+
+    H5::DataSet orientation;
+    H5::DataSpace dspace;
+    H5::DataSpace aspace;
+
+    H5::Attribute vector;
+    H5::Attribute units;
+    H5::Attribute transformationType;
+    H5::Attribute dependsOn;
+
+    H5::StrType strSize;
+
+    int drank = 1;                          // rank of dataset
+    hsize_t ddims[static_cast<hsize_t>(1)]; // dimensions of dataset
+    ddims[0] = static_cast<hsize_t>(1);     // datapoints in dataset dimension 0
+
+    angle = std::acos(rotation.w()) * (360.0 / M_PI); // angle magnitude
+    Eigen::Vector3d axisOfRotation = rotation.vec().normalized(); // angle axis
+    std::vector<double> stdNormAxis =
+        toStdVector(axisOfRotation); // convert to std::vector
+
+    dspace = H5Screate_simple(drank, ddims, nullptr); // dataspace for dataset
+    orientation = grp.createDataSet(ORIENTATION, H5::PredType::NATIVE_DOUBLE,
+                                    dspace); // dataset orientation
+    orientation.write(&angle, H5::PredType::NATIVE_DOUBLE,
+                      dspace); // write angle magnitude to orientation
+
+    int arank = 1;                          // rank of attribute
+    hsize_t adims[static_cast<hsize_t>(3)]; // dimensions of attribute
+    adims[0] = static_cast<hsize_t>(3); // datapoints in attibute dimension 0
+
+    aspace = H5Screate_simple(arank, adims, nullptr); // dataspace for attribute
+    vector = orientation.createAttribute(VECTOR, H5::PredType::NATIVE_DOUBLE,
+                                         aspace); // attribute vector
+    writeToAttribute(vector, stdNormAxis,
+                     H5::PredType::NATIVE_DOUBLE); // write angle axis to vector
+
+    // units attribute
+    strSize = strTypeOfSize(DEGREES);
+    units = orientation.createAttribute(UNITS, strSize, SCALAR);
+    units.write(strSize, DEGREES);
+
+    // transformation-type attribute
+    strSize = strTypeOfSize(ROTATION);
+    transformationType =
+        orientation.createAttribute(TRANSFORMATION_TYPE, strSize, SCALAR);
+    transformationType.write(strSize, ROTATION);
+
+    // dependency attribute
+    strSize = strTypeOfSize(dependency);
+    dependsOn = orientation.createAttribute(DEPENDS_ON, strSize, SCALAR);
+    dependsOn.write(strSize, dependency);
+  }
+
+  template <typename T>
+  void write1DIntDataset(H5::Group &grp, const H5std_string &name,
+                         const std::vector<T> &container) {
+
+    auto csize = static_cast<hsize_t>(container.size());
+    H5::DataSet dataset;
+    const int rank = 1;
+    hsize_t dims[1] = {csize};
+
+    H5::DataSpace space = H5Screate_simple(rank, dims, nullptr);
+
+    // dataset can be chunked if datasize is > 1. else is contiguous.
+    if (csize > 1) {
+      hsize_t chunks[1] = {csize};
+      H5::DSetCreatPropList plist;
+      plist.setChunk(1, chunks);
+      plist.setDeflate(COMPRESSION_LEVEL);
+
+      dataset = grp.createDataSet(name, H5::PredType::NATIVE_INT, space, plist);
+    } else {
+      dataset = grp.createDataSet(name, H5::PredType::NATIVE_INT, space);
+    }
+    writeToDataset(dataset, container, H5::PredType::NATIVE_INT, space);
+  }
+
+  /*
+   * Function: writeNXDetectorNumber
+   * For use with NXdetector group. Writes the detector numbers for all detector
+   * pixels in compInfo to a new dataset in the group.
+   *
+   * @param detectorIDs : std::vector<int> container of all detectorIDs to be
+   * stored into dataset 'detector_number'.
+   * @param compInfo : instrument cache with component info.
+   * @idx : size_t index of bank in compInfo.
+   */
+  void writeNXDetectorNumber(H5::Group &grp,
+                             const Geometry::ComponentInfo &compInfo,
+                             const std::vector<int> &detectorIDs,
+                             const size_t idx) {
+
+    H5::DataSet detectorNumber;
+
+    std::vector<int> bankDetIDs; // IDs of detectors beloning to bank
+    std::vector<size_t> bankDetectors = compInfo.detectorsInSubtree(
+        idx); // Indexes of children detectors in bank
+    bankDetIDs.reserve(bankDetectors.size());
+
+    // write the ID for each child detector to std::vector to be written to
+    // dataset
+    std::for_each(bankDetectors.begin(), bankDetectors.end(),
+                  [&bankDetIDs, &detectorIDs](const size_t index) {
+                    bankDetIDs.push_back(detectorIDs[index]);
+                  });
+
+    write1DIntDataset(grp, DETECTOR_IDS, bankDetIDs);
+  }
+
+  // Write the count of how many detectors contribute to each spectra
+  void writeDetectorCount(H5::Group &grp, const SpectraMappings &mappings) {
+    write1DIntDataset(grp, SPECTRA_COUNTS, mappings.detector_count);
+  }
+
+  // Write the detectors ids ordered by spectra index 0 - N for each NXDetector
+  void writeDetectorList(H5::Group &grp, const SpectraMappings &mappings) {
+    write1DIntDataset(grp, DETECTOR_LIST, mappings.detector_list);
+  }
+
+  // Write the detector indexes. This provides offsets into the detector_list
+  // and is sized to the number of spectra
+  void writeDetectorIndex(H5::Group &grp, const SpectraMappings &mappings) {
+    write1DIntDataset(grp, DETECTOR_INDEX, mappings.detector_index);
+  }
+
+  // Write the spectra numbers for each spectra
+  void writeSpectra(H5::Group &grp, const SpectraMappings &mappings) {
+    write1DIntDataset(grp, SPECTRA_NUMBERS, mappings.spectra_ids);
+  }
+
 }; // class NexusGeometrySaveImpl
 
-/*
- * Function: saveInstrument
+/**
  * calls the save methods to write components to file after exception
  * checking. Produces a Nexus format file containing the Instrument geometry
  * and metadata.
@@ -1040,8 +1953,12 @@ void saveInstrument(const Geometry::ComponentInfo &compInfo,
 
   validateInputs(logger, fullPath, compInfo);
   // IDs of all detectors in Instrument
+  const auto &detIds = detInfo.detectorIDs();
+
   H5::Group rootGroup;
   H5::H5File file;
+  hid_t fileID;
+
   if (append) {
     file = H5::H5File(fullPath, H5F_ACC_RDWR); // open file
     rootGroup = file.openGroup(rootName);
@@ -1050,10 +1967,13 @@ void saveInstrument(const Geometry::ComponentInfo &compInfo,
     rootGroup = file.createGroup(rootName);
   }
 
+  fileID = H5Fcreate(fullPath.c_str(), H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT);
+
   writeStrAttribute(rootGroup, NX_CLASS, NX_ENTRY);
 
   using Mode = NexusGeometrySaveImpl::Mode;
   NexusGeometrySaveImpl writer(append ? Mode::Append : Mode::Trunc);
+
   // save and capture NXinstrument (component root)
   H5::Group instrument = writer.instrument(rootGroup, compInfo);
 
@@ -1063,7 +1983,9 @@ void saveInstrument(const Geometry::ComponentInfo &compInfo,
   // save NXsample
   writer.sample(rootGroup, compInfo);
 
-  const auto &detIds = detInfo.detectorIDs();
+  writer.m_fileID = fileID;
+  writer.m_detectorIds = detIds;
+
   // save NXdetectors
   std::list<size_t> saved_indices;
   // Looping from highest to lowest component index is critical
@@ -1073,10 +1995,9 @@ void saveInstrument(const Geometry::ComponentInfo &compInfo,
       if (isDesiredNXDetector(index, saved_indices, compInfo)) {
         if (reporter != nullptr)
           reporter->report();
-        writer.detector(instrument, compInfo, detIds, index);
+        writer.detector(instrument, compInfo, index);
         saved_indices.emplace_back(
             index); // Now record the fact that children of
-                    // this are not needed as NXdetectors
       }
     }
   }
@@ -1086,7 +2007,7 @@ void saveInstrument(const Geometry::ComponentInfo &compInfo,
     if (detInfo.isMonitor(index)) {
       if (reporter != nullptr)
         reporter->report();
-      writer.monitor(instrument, compInfo, detIds[index], index);
+      writer.monitor(instrument, compInfo, index);
     }
   }
 
@@ -1136,6 +2057,8 @@ void saveInstrument(const Mantid::API::MatrixWorkspace &ws,
 
   H5::Group rootGroup;
   H5::H5File file;
+  hid_t fileID;
+
   if (append) {
     file = H5::H5File(fullPath, H5F_ACC_RDWR); // open file
     rootGroup = file.openGroup(rootName);
@@ -1143,6 +2066,8 @@ void saveInstrument(const Mantid::API::MatrixWorkspace &ws,
     file = H5::H5File(fullPath, H5F_ACC_TRUNC); // open file
     rootGroup = file.createGroup(rootName);
   }
+
+  fileID = H5Fcreate(fullPath.c_str(), H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT);
 
   writeStrAttribute(rootGroup, NX_CLASS, NX_ENTRY);
 
@@ -1156,6 +2081,9 @@ void saveInstrument(const Mantid::API::MatrixWorkspace &ws,
 
   // save NXsample
   writer.sample(rootGroup, compInfo);
+
+  writer.m_fileID = fileID;
+  writer.m_detectorIds = detIds;
 
   // save NXdetectors
   auto detToIndexMap =
@@ -1174,7 +2102,7 @@ void saveInstrument(const Mantid::API::MatrixWorkspace &ws,
 
         if (reporter != nullptr)
           reporter->report();
-        writer.detector(instrument, compInfo, detIds, index, mappings);
+        writer.detector(instrument, compInfo, index, mappings);
         saved_indices.emplace_back(
             index); // Now record the fact that children of
                     // this are not needed as NXdetectors
@@ -1192,7 +2120,7 @@ void saveInstrument(const Mantid::API::MatrixWorkspace &ws,
 
       if (reporter != nullptr)
         reporter->report();
-      writer.monitor(instrument, compInfo, detIds[index], index, mappings);
+      writer.monitor(instrument, compInfo, index, mappings);
     }
   }
 

--- a/Framework/NexusGeometry/src/NexusGeometrySave.cpp
+++ b/Framework/NexusGeometry/src/NexusGeometrySave.cpp
@@ -352,7 +352,6 @@ void writeXYZPixeloffset(H5::Group &grp,
   bool yIsZero = isApproxZero(posy, PRECISION);
   bool zIsZero = isApproxZero(posz, PRECISION);
 
-  auto const &bankName = compInfo.name(idx);
   const auto nDetectorsInBank = static_cast<hsize_t>(posx.size());
 
   int rank = 1;

--- a/Framework/NexusGeometry/src/NexusGeometrySave.cpp
+++ b/Framework/NexusGeometry/src/NexusGeometrySave.cpp
@@ -1273,7 +1273,7 @@ public:
                                  std::vector<size_t> &meshes, size_t bankIdx) {
 
     // shape type of the first detector in children detectors
-    auto &firstShapeObj = compInfo.shape(meshes.front());
+    auto const &firstShapeObj = compInfo.shape(meshes.front());
     auto fMeshObj = dynamic_cast<const T *>(&firstShapeObj);
     auto fVertices = fMeshObj->getVertices();
     auto fWindingOrder = fMeshObj->getTriangles();

--- a/Framework/NexusGeometry/src/NexusGeometrySave.cpp
+++ b/Framework/NexusGeometry/src/NexusGeometrySave.cpp
@@ -1449,7 +1449,7 @@ public:
                          H5::Group &grp, size_t idx) {
 
     if (compInfo.hasValidShape(idx)) {
-      auto &shapeObj = compInfo.shape(idx);
+      auto const &shapeObj = compInfo.shape(idx);
       if (const auto mesh =
               dynamic_cast<const Geometry::MeshObject *>(&shapeObj)) {
 
@@ -1479,12 +1479,12 @@ public:
 
           H5::Group shapeGroup = simpleNXSubGroup(grp, SHAPE, NX_CYLINDER);
 
-          auto &geometry = shapeInfo.cylinderGeometry();
+          auto const &geometry = shapeInfo.cylinderGeometry();
           const Eigen::Vector3d &base =
               Kernel::toVector3d(geometry.centreOfBottomBase);
           const Eigen::Vector3d &axis = Kernel::toVector3d(geometry.axis);
-          double &height = geometry.height;
-          double &radius = geometry.radius;
+          double const &height = geometry.height;
+          double const &radius = geometry.radius;
 
           Eigen::Vector3d orthogonalToBase{base[1], base[0], base[2]};
           if (!isApproxZero(orthogonalToBase.dot(orthogonalToBase), PRECISION))

--- a/Framework/NexusGeometry/src/NexusGeometrySave.cpp
+++ b/Framework/NexusGeometry/src/NexusGeometrySave.cpp
@@ -1654,9 +1654,7 @@ private:
       posz.push_back(offset[2]); // z pixel offset
     }
 
-    auto bankName = compInfo.name(idx);
     const auto nDetectorsInBank = static_cast<hsize_t>(posx.size());
-
     int rank = 1;
     hsize_t dims[static_cast<hsize_t>(1)];
     dims[0] = nDetectorsInBank;

--- a/Framework/NexusGeometry/test/NexusGeometrySaveTest.h
+++ b/Framework/NexusGeometry/test/NexusGeometrySaveTest.h
@@ -291,7 +291,7 @@ used.
     const auto &compInfo = *instr.first;
 
     // full H5 path to the NXinstrument group
-    FullNXPath path = {DEFAULT_ROOT_ENTRY_NAME, compInfo.name(compInfo.root())};
+    FullH5Path path = {DEFAULT_ROOT_ENTRY_NAME, compInfo.name(compInfo.root())};
 
     // assert no exception thrown on open of instrument group in file with
     // manually set name.
@@ -390,7 +390,7 @@ used.
     NexusGeometrySave::saveInstrument(instr, destinationFile,
                                       DEFAULT_ROOT_ENTRY_NAME, m_mockLogger);
     NexusFileReader tester(destinationFile);
-    FullNXPath path = {DEFAULT_ROOT_ENTRY_NAME,
+    FullH5Path path = {DEFAULT_ROOT_ENTRY_NAME,
                        "basic_rect" /*instrument name*/};
 
     int numOfNXDetectors = tester.countNXgroup(path, NX_DETECTOR);
@@ -451,7 +451,7 @@ Instrument cache.
     NexusFileReader tester(destinationFile);
 
     // full path to group to be opened in test utility
-    FullNXPath path = {
+    FullH5Path path = {
         DEFAULT_ROOT_ENTRY_NAME,
         "test-instrument-with-detector-rotations" /*instrument name*/,
         "detector-stage" /*bank name*/, TRANSFORMATIONS};
@@ -512,7 +512,7 @@ Instrument cache.
     NexusFileReader tester(destinationFile);
 
     // full path to group to be opened in test utility
-    FullNXPath path = {DEFAULT_ROOT_ENTRY_NAME, "test-instrument-with-monitor",
+    FullH5Path path = {DEFAULT_ROOT_ENTRY_NAME, "test-instrument-with-monitor",
                        "test-monitor", TRANSFORMATIONS};
 
     // get angle magnitude in dataset
@@ -569,7 +569,7 @@ Instrument cache.
     NexusFileReader tester(destinationFile);
 
     // full path to group to be opened in test utility
-    FullNXPath path = {DEFAULT_ROOT_ENTRY_NAME,
+    FullH5Path path = {DEFAULT_ROOT_ENTRY_NAME,
                        "test-instrument" /*instrument name*/,
                        "source" /*source name*/, TRANSFORMATIONS};
 
@@ -626,7 +626,7 @@ Instrument cache.
     NexusFileReader tester(destinationFile);
 
     // full path to group to be opened in test utility
-    FullNXPath path = {DEFAULT_ROOT_ENTRY_NAME,
+    FullH5Path path = {DEFAULT_ROOT_ENTRY_NAME,
                        "test-instrument" /*instrument name*/,
                        "source" /*source name*/, TRANSFORMATIONS};
 
@@ -685,7 +685,7 @@ Instrument cache.
     NexusFileReader tester(destinationFile);
 
     // full path to group to be opened in test utility
-    FullNXPath path = {DEFAULT_ROOT_ENTRY_NAME,
+    FullH5Path path = {DEFAULT_ROOT_ENTRY_NAME,
                        "test-instrument" /*instrument name*/,
                        "source" /*source name*/, TRANSFORMATIONS};
 
@@ -722,7 +722,7 @@ Instrument cache.
     auto instr = Mantid::Geometry::InstrumentVisitor::makeWrappers(*instrument);
 
     // full path to access NXtransformations group with test utility
-    FullNXPath path = {
+    FullH5Path path = {
         DEFAULT_ROOT_ENTRY_NAME,
         "test-instrument-with-detector-rotations" /*instrument name*/,
         "detector-stage" /*bank name*/, TRANSFORMATIONS};
@@ -762,7 +762,7 @@ Instrument cache.
     auto instr = Mantid::Geometry::InstrumentVisitor::makeWrappers(*instrument);
 
     // full path to group to be opened in test utility
-    FullNXPath path = {DEFAULT_ROOT_ENTRY_NAME, "test-instrument-with-monitor",
+    FullH5Path path = {DEFAULT_ROOT_ENTRY_NAME, "test-instrument-with-monitor",
                        "test-monitor", TRANSFORMATIONS};
 
     // call saveInstrument passing test instrument as parameter
@@ -804,7 +804,7 @@ Instrument cache.
     auto instr = Mantid::Geometry::InstrumentVisitor::makeWrappers(*instrument);
 
     // full path to group to be opened in test utility
-    FullNXPath path = {DEFAULT_ROOT_ENTRY_NAME, "test-instrument", "source",
+    FullH5Path path = {DEFAULT_ROOT_ENTRY_NAME, "test-instrument", "source",
                        TRANSFORMATIONS};
 
     // call saveinstrument passing test instrument as parameter
@@ -858,7 +858,7 @@ Instrument cache.
 
     // instance of test utility to check saved file
     NexusFileReader tester(destinationFile);
-    FullNXPath path = {
+    FullH5Path path = {
         DEFAULT_ROOT_ENTRY_NAME,
         "test-instrument-with-detector-rotations" /*instrument name*/,
         "detector-stage" /*bank name*/};
@@ -931,11 +931,11 @@ Instrument cache.
             detectorLocation, sourceRotation);
     auto instr = Mantid::Geometry::InstrumentVisitor::makeWrappers(*instrument);
 
-    FullNXPath transformationsPath = {
+    FullH5Path transformationsPath = {
         DEFAULT_ROOT_ENTRY_NAME, "test-instrument" /*instrument name*/,
         "source" /*source name*/, TRANSFORMATIONS};
 
-    FullNXPath sourcePath = transformationsPath;
+    FullH5Path sourcePath = transformationsPath;
     sourcePath.pop_back(); // source path is one level abve transformationsPath
 
     // call saveInstrument with test instrument as parameter
@@ -956,7 +956,7 @@ Instrument cache.
     // assert that the NXsource depends on dataset 'orientation' in the
     // transformationsPath, since the dataset exists.
     bool sourceDependencyIsOrientation = tester.dataSetHasStrValue(
-        DEPENDS_ON, toNXPathString(transformationsPath) + "/" + ORIENTATION,
+        DEPENDS_ON, toH5PathString(transformationsPath) + "/" + ORIENTATION,
         sourcePath);
     TS_ASSERT(sourceDependencyIsOrientation);
 
@@ -997,11 +997,11 @@ Instrument cache.
             detectorLocation, sourceRotation);
     auto instr = Mantid::Geometry::InstrumentVisitor::makeWrappers(*instrument);
 
-    FullNXPath transformationsPath = {
+    FullH5Path transformationsPath = {
         DEFAULT_ROOT_ENTRY_NAME, "test-instrument" /*instrument name*/,
         "source" /*source name*/, TRANSFORMATIONS};
 
-    FullNXPath sourcePath = transformationsPath;
+    FullH5Path sourcePath = transformationsPath;
     sourcePath.pop_back(); // source path is one level abve transformationsPath
 
     // call saveInstrument with test instrument as parameter
@@ -1023,7 +1023,7 @@ Instrument cache.
     // transformationsPath, since the dataset exists.
     bool sourceDependencyIsLocation = tester.dataSetHasStrValue(
         DEPENDS_ON /*dataset name*/,
-        toNXPathString(transformationsPath) + "/" + LOCATION /*dataset value*/,
+        toH5PathString(transformationsPath) + "/" + LOCATION /*dataset value*/,
         sourcePath /*where the dataset lives*/);
     TS_ASSERT(sourceDependencyIsLocation);
 
@@ -1066,12 +1066,12 @@ Instrument cache.
     auto instr = Mantid::Geometry::InstrumentVisitor::makeWrappers(*instrument);
 
     // path to NXtransformations subgoup in NXsource
-    FullNXPath transformationsPath = {
+    FullH5Path transformationsPath = {
         DEFAULT_ROOT_ENTRY_NAME, "test-instrument" /*instrument name*/,
         "source" /*source name*/, TRANSFORMATIONS};
 
     // path to NXsource group
-    FullNXPath sourcePath = transformationsPath;
+    FullH5Path sourcePath = transformationsPath;
     sourcePath.pop_back(); // source path is one level abve transformationsPath
 
     // call saveInstrument passing test instrument as parameter
@@ -1089,15 +1089,15 @@ Instrument cache.
 
     bool sourceDependencyIsOrientation =
         tester.dataSetHasStrValue(DEPENDS_ON /*dataset name*/,
-                                  toNXPathString(transformationsPath) + "/" +
+                                  toH5PathString(transformationsPath) + "/" +
                                       ORIENTATION /*value in dataset*/,
                                   sourcePath /*where the dataset lives*/);
     TS_ASSERT(sourceDependencyIsOrientation);
-    auto x = toNXPathString(transformationsPath) + "/" +
+    auto x = toH5PathString(transformationsPath) + "/" +
              LOCATION /*dAttribute value*/;
     bool orientationDependencyIsLocation = tester.hasAttributeInDataSet(
         ORIENTATION /*dataset name*/, DEPENDS_ON /*dAttribute name*/,
-        toNXPathString(transformationsPath) + "/" +
+        toH5PathString(transformationsPath) + "/" +
             LOCATION /*dAttribute value*/,
         transformationsPath
         /*where the dataset lives*/);
@@ -1137,12 +1137,12 @@ Instrument cache.
     auto instr = Mantid::Geometry::InstrumentVisitor::makeWrappers(*instrument);
 
     // path to NXtransformations subgoup in NXsource
-    FullNXPath transformationsPath = {
+    FullH5Path transformationsPath = {
         DEFAULT_ROOT_ENTRY_NAME, "test-instrument" /*instrument name*/,
         "source" /*source name*/, TRANSFORMATIONS};
 
     // path to NXsource group
-    FullNXPath sourcePath = transformationsPath;
+    FullH5Path sourcePath = transformationsPath;
     sourcePath.pop_back(); // source path is one level abve transformationsPath
 
     // call saveInstrument passing test instrument as parameter

--- a/Framework/NexusGeometry/test/NexusGeometrySaveTest.h
+++ b/Framework/NexusGeometry/test/NexusGeometrySaveTest.h
@@ -216,7 +216,7 @@ used.
     // this test checks that the root group of the output file in saveInstrument
     // has NXclass attribute of NXentry. as required by the Nexus file format.
 
-    // RAII file resource for test file destination
+    //  file resource for test file destination
     FileResource fileResource("check_nxentry_group_test_file.nxs");
     std::string destinationFile = fileResource.fullPath();
 
@@ -240,7 +240,7 @@ used.
     // this test checks that inside of the NXentry root group, the instrument
     // data is saved to a group of NXclass NXinstrument
 
-    // RAII file resource for test file destination
+    //  file resource for test file destination
     FileResource fileResource("check_nxinstrument_group_test_file.hdf5");
     std::string destinationFile = fileResource.fullPath();
 
@@ -267,7 +267,7 @@ used.
     // NXInstrument group name is always written as "instrument" for legacy
     // compatibility reasons
 
-    // RAII file resource for test file destination
+    //  file resource for test file destination
     FileResource fileResource("check_instrument_name_test_file.nxs");
     auto destinationFile = fileResource.fullPath();
 
@@ -315,7 +315,7 @@ used.
     // same name, HDF5 will throw a group exception. In this test, we expect no
     // such exception to throw.
 
-    // RAII file resource for test file destination.
+    //  file resource for test file destination.
     FileResource fileResource("default_group_names_test.hdf5");
     std::string destinationFile = fileResource.fullPath();
 
@@ -332,7 +332,7 @@ used.
     // this test checks that inside of the NXinstrument group, the the source
     // data is saved to a group of NXclass NXsource
 
-    // RAII file resource for test file destination.
+    //  file resource for test file destination.
     FileResource fileResource("check_nxsource_group_test_file.hdf5");
     std::string destinationFile = fileResource.fullPath();
 
@@ -427,7 +427,7 @@ Instrument cache.
    indicating that saveinstrument has correctly written the orientation data.
    */
 
-    // RAII file resource for test file destination
+    //  file resource for test file destination
     FileResource fileResource(
         "check_rotation_written_to_nxdetector_test_file.hdf5");
     std::string destinationFile = fileResource.fullPath();
@@ -489,7 +489,7 @@ Instrument cache.
     data.
     */
 
-    // RAII file resource for test file destination
+    //  file resource for test file destination
     FileResource fileResource(
         "check_rotation_written_to_nx_monitor_test_file.hdf5");
     std::string destinationFile = fileResource.fullPath();
@@ -546,7 +546,7 @@ Instrument cache.
     saveinstrument has correctly written the location data.
     */
 
-    // RAII file resource for test file destination
+    //  file resource for test file destination
     FileResource fileResource(
         "check_location_written_to_nxsource_test_file.hdf5");
     std::string destinationFile = fileResource.fullPath();
@@ -603,7 +603,7 @@ Instrument cache.
     indicating that saveinstrument has correctly written the orientation data.
     */
 
-    // RAII file resource for test file destination
+    //  file resource for test file destination
     FileResource fileResource(
         "check_rotation_written_to_nxsource_test_file.hdf5");
     std::string destinationFile = fileResource.fullPath();
@@ -661,7 +661,7 @@ Instrument cache.
     transformation to file
     */
 
-    // RAII file resource for test file destination
+    // file resource for test file destination
     FileResource fileResource("origin_nx_source_location_file_test.hdf5");
     std::string destinationFile = fileResource.fullPath();
 
@@ -710,7 +710,7 @@ Instrument cache.
     const Quat someRotation(30, V3D(1, 0, 0)); // arbitrary
     const Quat bankRotation(0, V3D(0, 0, 1));  // set (angle) to zero
 
-    // RAII file resource for test file destination
+    // file resource for test file destination
     FileResource fileResource("zero_nx_detector_rotation_file_test.hdf5");
     std::string destinationFile = fileResource.fullPath();
 
@@ -749,7 +749,7 @@ Instrument cache.
     file
     */
 
-    // RAII file resource for test file destination
+    // file resource for test file destination
     FileResource fileResource("zero_nx_monitor_rotation_file_test.hdf5");
     std::string destinationFile = fileResource.fullPath();
 
@@ -792,7 +792,7 @@ Instrument cache.
     const V3D sourceLocation(-10, 0, 0);
     const Quat sourceRotation(0, V3D(0, 0, 1)); // set (angle) to zero
 
-    // RAII file resource for test file destination
+    // file resource for test file destination
     FileResource inFileResource("zero_nx_source_rotation_file_test.hdf5");
     std::string destinationFile = inFileResource.fullPath();
 
@@ -831,7 +831,7 @@ Instrument cache.
     manually set offset.
     */
 
-    // create RAII file resource for testing
+    // create file resource for testing
     FileResource fileResource("check_pixel_offset_format_test_file.hdf5");
     std::string destinationFile = fileResource.fullPath();
 
@@ -919,7 +919,7 @@ Instrument cache.
     const Quat sourceRotation(90, V3D(0, 1, 0)); // arbitrary
     const V3D sourceLocation(0, 0, 0);           // set to zero
 
-    // create RAII file resource for testing
+    // create  file resource for testing
     FileResource fileResource("no_location_dependency_test.hdf5");
     std::string destinationFile = fileResource.fullPath();
 
@@ -985,7 +985,7 @@ Instrument cache.
     const V3D sourceLocation(0.0, 0.0, -10.0);          // arbitrary
     const Quat sourceRotation(0.0, V3D(0.0, 1.0, 0.0)); // set to zero
 
-    // create RAII file resource for testing
+    // create  file resource for testing
     FileResource fileResource("no_orientation_dependency_test.hdf5");
     std::string destinationFile = fileResource.fullPath();
 
@@ -1054,7 +1054,7 @@ Instrument cache.
     const V3D sourceLocation(0, 0, -10);         // arbitrary non-origin
     const Quat sourceRotation(45, V3D(0, 1, 0)); // arbitrary non-zero
 
-    // create RAII file resource for testing
+    // create  file resource for testing
     FileResource fileResource("both_transformations_dependency_test.hdf5");
     std::string destinationFile = fileResource.fullPath();
 
@@ -1125,7 +1125,7 @@ Instrument cache.
     const V3D sourceLocation(0, 0, 0);          // set to zero
     const Quat sourceRotation(0, V3D(0, 1, 0)); // set to zero
 
-    // create RAII file resource for testing
+    // create file resource for testing
     FileResource fileResource("neither_transformations_dependency_test.hdf5");
     std::string destinationFile = fileResource.fullPath();
 

--- a/Framework/TestHelpers/inc/MantidTestHelpers/ComponentCreationHelper.h
+++ b/Framework/TestHelpers/inc/MantidTestHelpers/ComponentCreationHelper.h
@@ -18,6 +18,8 @@
 #include "MantidGeometry/Instrument.h"
 #include "MantidGeometry/Instrument/Detector.h"
 #include "MantidGeometry/Objects/CSGObject.h"
+#include "MantidGeometry/Objects/MeshObject.h"
+#include "MantidGeometry/Objects/MeshObject2D.h"
 #include "MantidKernel/V3D.h"
 #include <memory>
 
@@ -45,7 +47,19 @@ tests.
 
 //----------------------------------------------------------------------------------------------
 
-/// Add a sample at samplePos to given instrument.
+std::shared_ptr<Mantid::Geometry::MeshObject>
+createSimpleMeshObject(const std::vector<uint32_t> &faces,
+                       const std::vector<Mantid::Kernel::V3D> &vertices,
+                       const Mantid::Kernel::Material &material);
+
+std::shared_ptr<Mantid::Geometry::MeshObject>
+createCubeFromTriangles(const double size, const Mantid::Kernel::V3D &centre);
+
+std::shared_ptr<Mantid::Geometry::MeshObject>
+createCubeFromTriangles(const double size);
+
+/// Add a spherical sample at samplePos to given instrument.
+
 void addSampleToInstrument(Mantid::Geometry::Instrument_sptr &instrument,
                            const Mantid::Kernel::V3D &samplePos);
 
@@ -170,12 +184,14 @@ createVectorOfCylindricalDetectors(const double R_min = 4.5,
  * @param xMax :: x-max for bank
  * @param yMin :: y-min for bank (use offsets to shift individual tubes)
  * @param yMax :: y-max for bank (use offsets to shift individual tubes)
+ * @param inhomogeneous :: cylinder heights are dissimilar if true
  * @return Instrument with single bank as described by parameters.
  */
 Mantid::Geometry::Instrument_sptr
 createCylInstrumentWithVerticalOffsetsSpecified(
     size_t nTubes, std::vector<double> verticalOffsets, size_t nDetsPerTube,
-    double xMin, double xMax, double yMin, double yMax);
+    double xMin, double xMax, double yMin, double yMax,
+    bool inhomogeneous = false);
 
 /** create instrument with cylindrical detectors located in specific angular
  * positions */
@@ -234,7 +250,12 @@ Mantid::Geometry::Instrument_sptr
 createMinimalInstrumentWithMonitor(const Mantid::Kernel::V3D &monitorPos,
                                    const Mantid::Kernel::Quat &monitorRot);
 
-// creates a minimal instrument with optional source, sample, and detector.
+Mantid::Geometry::Instrument_sptr createMinimalInstrumentWithShapes(
+    const std::shared_ptr<Mantid::Geometry::IObject> &monitorShape,
+    const std::shared_ptr<Mantid::Geometry::IObject> &detectorShape,
+    const std::shared_ptr<Mantid::Geometry::IObject> &bankShape);
+
+/// creates a minimal instrument with optional source, sample, and detector.
 Mantid::Geometry::Instrument_sptr
 createInstrumentWithOptionalComponents(bool haveSource, bool haveSample,
                                        bool haveDetector);

--- a/Framework/TestHelpers/inc/MantidTestHelpers/ComponentCreationHelper.h
+++ b/Framework/TestHelpers/inc/MantidTestHelpers/ComponentCreationHelper.h
@@ -190,8 +190,7 @@ createVectorOfCylindricalDetectors(const double R_min = 4.5,
 Mantid::Geometry::Instrument_sptr
 createCylInstrumentWithVerticalOffsetsSpecified(
     size_t nTubes, std::vector<double> verticalOffsets, size_t nDetsPerTube,
-    double xMin, double xMax, double yMin, double yMax,
-    bool inhomogeneous = false);
+    double xMin, double xMax, double yMin, double yMax);
 
 /** create instrument with cylindrical detectors located in specific angular
  * positions */

--- a/Framework/TestHelpers/inc/MantidTestHelpers/FileResource.h
+++ b/Framework/TestHelpers/inc/MantidTestHelpers/FileResource.h
@@ -4,8 +4,9 @@
 //   NScD Oak Ridge National Laboratory, European Spallation Source,
 //   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
 // SPDX - License - Identifier: GPL - 3.0 +
-/** RAII: Gives a clean file destination and removes the file when
- * handle is out of scope. Must be stack allocated.
+//
+/** RAII File handle which gives a clean file destination and removes the file
+ * when handle is out of scope. Must be stack allocated.
  *
  * @author Takudzwa Makoni, RAL (UKRI), ISIS
  * @date 06/08/2019
@@ -28,7 +29,7 @@ public:
 private:
   bool m_debugMode;
   boost::filesystem::path m_full_path; // full path to file
-  // prevent heap allocation for ScopedFileHandle
+  // prevent heap allocation for FileResource
 protected:
   static void *operator new(std::size_t); // prevent heap allocation of scalar.
   static void *operator new[](std::size_t); // prevent heap allocation of array.

--- a/Framework/TestHelpers/inc/MantidTestHelpers/NexusFileReader.h
+++ b/Framework/TestHelpers/inc/MantidTestHelpers/NexusFileReader.h
@@ -25,9 +25,9 @@
 
 namespace Mantid {
 namespace NexusGeometry {
-using FullNXPath = std::vector<std::string>;
+using FullH5Path = std::vector<std::string>;
 // get Nexus file path as string. Used in Nexus Geometry unit tests.
-std::string toNXPathString(FullNXPath &path) {
+std::string toH5PathString(FullH5Path &path) {
   std::string pathString = "";
   for (const std::string &grp : path) {
     pathString += "/" + grp;
@@ -87,7 +87,7 @@ public:
     }
   }
 
-  int countNXgroup(const FullNXPath &pathToGroup, const std::string &nxClass) {
+  int countNXgroup(const FullH5Path &pathToGroup, const std::string &nxClass) {
     int counter = 0;
     H5::Group parentGroup = openfullH5Path(pathToGroup);
     for (hsize_t i = 0; i < parentGroup.getNumObjs(); ++i) {
@@ -120,7 +120,7 @@ public:
 
   // read a multidimensional dataset and returns vector containing the data
   template <typename T>
-  std::vector<T> readDataSetMultidimensional(FullNXPath &pathToGroup,
+  std::vector<T> readDataSetMultidimensional(FullH5Path &pathToGroup,
                                              const std::string &dataSetName) {
 
     std::vector<T> dataInFile;
@@ -139,7 +139,7 @@ public:
 
   /* safely open a HDF5 group path with additional helpful
    debug information to output where open fails) */
-  H5::Group openfullH5Path(const FullNXPath &pathList) const {
+  H5::Group openfullH5Path(const FullH5Path &pathList) const {
 
     H5::Group child;
     H5::Group parent = m_file.openGroup(pathList[0]);
@@ -216,7 +216,7 @@ public:
   } // namespace
 
   double readDoubleFromDataset(const std::string &datasetName,
-                               const FullNXPath &pathToGroup) {
+                               const FullH5Path &pathToGroup) {
     double value;
     int rank = 1;
     hsize_t dims[static_cast<hsize_t>(1)];
@@ -235,7 +235,7 @@ public:
   std::vector<double>
   readDoubleVectorFrom_d_Attribute(const std::string &attrName,
                                    const std::string &datasetName,
-                                   const FullNXPath &pathToGroup) {
+                                   const FullH5Path &pathToGroup) {
 
     // open dataset and read.
     H5::Group parentGroup = openfullH5Path(pathToGroup);
@@ -299,7 +299,7 @@ public:
     return false;
   }
 
-  bool hasDataset(const std::string &dsetName, const FullNXPath &pathToGroup) {
+  bool hasDataset(const std::string &dsetName, const FullH5Path &pathToGroup) {
 
     H5::Group parentGroup = openfullH5Path(pathToGroup);
 
@@ -329,7 +329,7 @@ public:
 
   bool dataSetHasStrValue(
       const std::string &dataSetName, const std::string &dataSetValue,
-      const FullNXPath &pathToGroup /*where the dataset lives*/) const {
+      const FullH5Path &pathToGroup /*where the dataset lives*/) const {
 
     H5::Group parentGroup = openfullH5Path(pathToGroup);
 
@@ -348,7 +348,7 @@ public:
   // check if dataset or group has name-specific attribute
   bool hasAttributeInGroup(const std::string &attrName,
                            const std::string &attrVal,
-                           const FullNXPath &pathToGroup) {
+                           const FullH5Path &pathToGroup) {
 
     H5::Group parentGroup = openfullH5Path(pathToGroup);
 
@@ -361,7 +361,7 @@ public:
   }
 
   bool hasNXAttributeInGroup(const std::string &attrVal,
-                             const FullNXPath &pathToGroup) {
+                             const FullH5Path &pathToGroup) {
 
     H5::Group parentGroup = openfullH5Path(pathToGroup);
 
@@ -375,7 +375,7 @@ public:
   bool hasAttributeInDataSet(
       const std::string &dataSetName, const std::string &attrName,
       const std::string &attrVal,
-      const FullNXPath &pathToGroup /*where the dataset lives*/) {
+      const FullH5Path &pathToGroup /*where the dataset lives*/) {
 
     H5::Attribute attribute;
     H5::Group parentGroup = openfullH5Path(pathToGroup);
@@ -389,7 +389,7 @@ public:
 
   bool hasNXAttributeInDataSet(const std::string &dataSetName,
                                const std::string &attrVal,
-                               const FullNXPath &pathToGroup) {
+                               const FullH5Path &pathToGroup) {
     H5::Attribute attribute;
     H5::Group parentGroup = openfullH5Path(pathToGroup);
     H5::DataSet dataSet = parentGroup.openDataSet(dataSetName);


### PR DESCRIPTION
Additional features to saveInstrument for writing instrument from memory to file, Including
parsing and writing Nexus Geometry shapes in the instrument cache to a HDF5 file using the Nexus format.

<!-- Instructions for testing. -->

Fixes #26458. <!-- and fix #xxxx or close #xxxx xor resolves #xxxx -->
<!-- alternative
*There is no associated issue.*
-->

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or master)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
