### PR TITLE
Add packing fraction to Material

### DIFF
--- a/Framework/Algorithms/src/AbsorptionCorrection.cpp
+++ b/Framework/Algorithms/src/AbsorptionCorrection.cpp
@@ -322,7 +322,7 @@ void AbsorptionCorrection::retrieveBaseProperties() {
   if (createMaterial) {
     // get values from the existing material
     if (isEmpty(rho))
-      rho = m_material.numberDensity();
+      rho = m_material.numberDensityEffective();
     if (isEmpty(sigma_s))
       sigma_s = m_material.totalScatterXSection();
     if (isEmpty(sigma_atten))
@@ -344,7 +344,7 @@ void AbsorptionCorrection::retrieveBaseProperties() {
   // NOTE: the angstrom^-2 to barns and the angstrom^-1 to cm^-1
   // will cancel for mu to give units: cm^-1
   m_linearCoefTotScatt =
-      -m_material.totalScatterXSection() * m_material.numberDensity() * 100;
+      -m_material.totalScatterXSection() * m_material.numberDensityEffective() * 100;
 
   m_num_lambda = getProperty("NumberOfWavelengthPoints");
 

--- a/Framework/Algorithms/src/AbsorptionCorrection.cpp
+++ b/Framework/Algorithms/src/AbsorptionCorrection.cpp
@@ -343,8 +343,8 @@ void AbsorptionCorrection::retrieveBaseProperties() {
 
   // NOTE: the angstrom^-2 to barns and the angstrom^-1 to cm^-1
   // will cancel for mu to give units: cm^-1
-  m_linearCoefTotScatt =
-      -m_material.totalScatterXSection() * m_material.numberDensityEffective() * 100;
+  m_linearCoefTotScatt = -m_material.totalScatterXSection() *
+                         m_material.numberDensityEffective() * 100;
 
   m_num_lambda = getProperty("NumberOfWavelengthPoints");
 

--- a/Framework/Algorithms/src/AbsorptionCorrectionPaalmanPings.cpp
+++ b/Framework/Algorithms/src/AbsorptionCorrectionPaalmanPings.cpp
@@ -380,9 +380,9 @@ void AbsorptionCorrectionPaalmanPings::retrieveBaseProperties() {
   // NOTE: the angstrom^-2 to barns and the angstrom^-1 to cm^-1
   // will cancel for mu to give units: cm^-1
   m_ampleLinearCoefTotScatt =
-      -m_material.totalScatterXSection() * m_material.numberDensity() * 100;
+      -m_material.totalScatterXSection() * m_material.numberDensityEffective() * 100;
   m_containerLinearCoefTotScatt = -m_containerMaterial.totalScatterXSection() *
-                                  m_containerMaterial.numberDensity() * 100;
+                                  m_containerMaterial.numberDensityEffective() * 100;
 
   m_num_lambda = getProperty("NumberOfWavelengthPoints");
 

--- a/Framework/Algorithms/src/AbsorptionCorrectionPaalmanPings.cpp
+++ b/Framework/Algorithms/src/AbsorptionCorrectionPaalmanPings.cpp
@@ -379,10 +379,11 @@ void AbsorptionCorrectionPaalmanPings::retrieveBaseProperties() {
 
   // NOTE: the angstrom^-2 to barns and the angstrom^-1 to cm^-1
   // will cancel for mu to give units: cm^-1
-  m_ampleLinearCoefTotScatt =
-      -m_material.totalScatterXSection() * m_material.numberDensityEffective() * 100;
+  m_ampleLinearCoefTotScatt = -m_material.totalScatterXSection() *
+                              m_material.numberDensityEffective() * 100;
   m_containerLinearCoefTotScatt = -m_containerMaterial.totalScatterXSection() *
-                                  m_containerMaterial.numberDensityEffective() * 100;
+                                  m_containerMaterial.numberDensityEffective() *
+                                  100;
 
   m_num_lambda = getProperty("NumberOfWavelengthPoints");
 

--- a/Framework/Kernel/inc/MantidKernel/Material.h
+++ b/Framework/Kernel/inc/MantidKernel/Material.h
@@ -71,11 +71,13 @@ public:
   /// temperature and pressure
   explicit Material(
       const std::string &name, const ChemicalFormula &formula,
-      const double numberDensity, const double temperature = 300,
+      const double numberDensity, const double packingFraction = 1,
+      const double temperature = 300,
       const double pressure = PhysicalConstants::StandardAtmosphere);
   explicit Material(
       const std::string &name, const PhysicalConstants::NeutronAtom &atom,
-      const double numberDensity, const double temperature = 300,
+      const double numberDensity, const double packingFraction = 1,
+      const double temperature = 300,
       const double pressure = PhysicalConstants::StandardAtmosphere);
   /// Virtual destructor.
   virtual ~Material() = default;
@@ -92,6 +94,10 @@ public:
   //@{
   /// Get the number density
   double numberDensity() const;
+  /// Get the effective number density
+  double numberDensityEffective() const;
+  /// Get the packing fraction
+  double packingFraction() const;
   /// Get the temperature
   double temperature() const;
   /// Get the pressure
@@ -206,6 +212,8 @@ private:
   double m_atomTotal;
   /// Number density in atoms per A^-3
   double m_numberDensity;
+  /// Packing fraction should be between 0 and 2
+  double m_packingFraction;
   /// Temperature
   double m_temperature;
   /// Pressure

--- a/Framework/Kernel/inc/MantidKernel/MaterialBuilder.h
+++ b/Framework/Kernel/inc/MantidKernel/MaterialBuilder.h
@@ -34,6 +34,7 @@ public:
 
   MaterialBuilder &setNumberDensity(double rho);
   MaterialBuilder &setNumberDensityUnit(NumberDensityUnit unit);
+  MaterialBuilder &setPackingFraction(double fraction);
   MaterialBuilder &setZParameter(double zparam);
   MaterialBuilder &setUnitCellVolume(double cellVolume);
   MaterialBuilder &setMassDensity(double massDensity);
@@ -57,13 +58,21 @@ private:
 
   // Material::ChemicalFormula createCompositionFromFormula() const;
   Material::ChemicalFormula createCompositionFromAtomicNumber() const;
-  double getOrCalculateRho(const Material::ChemicalFormula &formula) const;
+
+  struct density_packing {
+    double number_density;
+    double effective_number_density;
+    double packing_fraction;
+  };
+  density_packing
+  getOrCalculateRhoAndPacking(const Material::ChemicalFormula &formula) const;
 
   std::string m_name;
   Material::ChemicalFormula m_formula;
   boost::optional<int> m_atomicNo;
   int m_massNo;
-  boost::optional<double> m_numberDensity, m_zParam, m_cellVol, m_massDensity;
+  boost::optional<double> m_numberDensity, m_packingFraction;
+  boost::optional<double> m_zParam, m_cellVol, m_massDensity;
   boost::optional<double> m_totalXSection, m_cohXSection, m_incXSection,
       m_absSection;
   NumberDensityUnit m_numberDensityUnit;

--- a/Framework/Kernel/src/Material.cpp
+++ b/Framework/Kernel/src/Material.cpp
@@ -280,7 +280,7 @@ double Material::absorbXSection(const double lambda) const {
  */
 double Material::attenuationCoefficient(const double lambda) const {
   if (!m_attenuationOverride) {
-    return 100 * numberDensity() *
+    return 100 * numberDensityEffective() *
            (totalScatterXSection() + absorbXSection(lambda));
   } else {
     return m_attenuationOverride->getAttenuationCoefficient(lambda);

--- a/Framework/Kernel/src/Material.cpp
+++ b/Framework/Kernel/src/Material.cpp
@@ -615,7 +615,7 @@ void Material::loadNexus(::NeXus::File *file, const std::string &group) {
   file->readData("number_density", m_numberDensity);
   try {
     file->readData("packing_fraction", m_packingFraction);
-  } catch (NeXus::Exception &) {
+  } catch (::NeXus::Exception &) {
     m_packingFraction = 1.;
   }
   file->readData("temperature", m_temperature);

--- a/Framework/Kernel/src/Material.cpp
+++ b/Framework/Kernel/src/Material.cpp
@@ -8,7 +8,6 @@
 #include "MantidKernel/Atom.h"
 #include "MantidKernel/AttenuationProfile.h"
 #include "MantidKernel/StringTokenizer.h"
-#include <NeXusException.hpp>
 #include <NeXusFile.hpp>
 #include <boost/lexical_cast.hpp>
 #include <memory>
@@ -615,7 +614,7 @@ void Material::loadNexus(::NeXus::File *file, const std::string &group) {
   file->readData("number_density", m_numberDensity);
   try {
     file->readData("packing_fraction", m_packingFraction);
-  } catch (::NeXus::Exception &) {
+  } catch (std::runtime_error &) {
     m_packingFraction = 1.;
   }
   file->readData("temperature", m_temperature);

--- a/Framework/Kernel/src/Material.cpp
+++ b/Framework/Kernel/src/Material.cpp
@@ -300,7 +300,7 @@ double Material::attenuation(const double distance, const double lambda) const {
 // NOTE: the angstrom^-2 to barns and the angstrom^-1 to cm^-1
 // will cancel for mu to give units: cm^-1
 double Material::linearAbsorpCoef(const double lambda) const {
-  return absorbXSection(lambda) * 100. * numberDensity();
+  return absorbXSection(lambda) * 100. * numberDensityEffective();
 }
 
 // This must match the values that come from the scalar version
@@ -308,15 +308,13 @@ std::vector<double> Material::linearAbsorpCoef(
     std::vector<double>::const_iterator lambdaBegin,
     std::vector<double>::const_iterator lambdaEnd) const {
 
-  const double linearCoefByWL =
-      absorbXSection(PhysicalConstants::NeutronAtom::ReferenceLambda) * 100. *
-      numberDensity() / PhysicalConstants::NeutronAtom::ReferenceLambda;
+  const double densityTerm = 100. * numberDensityEffective();
 
   std::vector<double> linearCoef(std::distance(lambdaBegin, lambdaEnd));
 
   std::transform(lambdaBegin, lambdaEnd, linearCoef.begin(),
-                 [linearCoefByWL](const double lambda) {
-                   return linearCoefByWL * lambda;
+                 [densityTerm, this](const double lambda) {
+                   return densityTerm * this->absorbXSection(lambda);
                  });
 
   return linearCoef;

--- a/Framework/Kernel/src/Material.cpp
+++ b/Framework/Kernel/src/Material.cpp
@@ -77,6 +77,7 @@ Material::Material()
  * @param name :: The name of the material
  * @param formula :: The chemical formula
  * @param numberDensity :: Density in atoms / Angstrom^3
+ * @param packingFraction :: Packing fraction of material
  * @param temperature :: The temperature in Kelvin (Default = 300K)
  * @param pressure :: Pressure in kPa (Default: 101.325 kPa)
  */
@@ -97,6 +98,7 @@ Material::Material(const std::string &name, const ChemicalFormula &formula,
  * @param name :: The name of the material
  * @param atom :: The neutron atom to take scattering infrmation from
  * @param numberDensity :: Density in atoms / Angstrom^3
+ * @param packingFraction :: Packing fraction of material
  * @param temperature :: The temperature in Kelvin (Default = 300K)
  * @param pressure :: Pressure in kPa (Default: 101.325 kPa)
  */

--- a/Framework/Kernel/src/MaterialBuilder.cpp
+++ b/Framework/Kernel/src/MaterialBuilder.cpp
@@ -319,9 +319,8 @@ MaterialBuilder::density_packing MaterialBuilder::getOrCalculateRhoAndPacking(
 
   // calculate the number density by one of many ways
   if (m_numberDensity) {
-    if (m_numberDensityUnit == NumberDensityUnit::Atoms) {
-      result.number_density = m_numberDensity.get();
-    } else if (m_numberDensityUnit == NumberDensityUnit::FormulaUnits) {
+    result.number_density = m_numberDensity.get();
+    if (m_numberDensityUnit == NumberDensityUnit::FormulaUnits && totalNumAtoms > 0.)  {
       result.number_density = m_numberDensity.get() * totalNumAtoms;
     }
   } else if (m_zParam && m_cellVol) {

--- a/Framework/Kernel/src/MaterialBuilder.cpp
+++ b/Framework/Kernel/src/MaterialBuilder.cpp
@@ -344,7 +344,7 @@ MaterialBuilder::density_packing MaterialBuilder::getOrCalculateRhoAndPacking(
   }
 
   // count the number of values that were set and generate errors
-  uint count = 0;
+  int count = 0;
   if (result.packing_fraction > 0.)
     count++;
   if (result.effective_number_density > 0.)

--- a/Framework/Kernel/src/MaterialBuilder.cpp
+++ b/Framework/Kernel/src/MaterialBuilder.cpp
@@ -320,11 +320,12 @@ MaterialBuilder::density_packing MaterialBuilder::getOrCalculateRhoAndPacking(
   // calculate the number density by one of many ways
   if (m_numberDensity) {
     result.number_density = m_numberDensity.get();
-    if (m_numberDensityUnit == NumberDensityUnit::FormulaUnits && totalNumAtoms > 0.)  {
+    if (m_numberDensityUnit == NumberDensityUnit::FormulaUnits &&
+        totalNumAtoms > 0.) {
       result.number_density = m_numberDensity.get() * totalNumAtoms;
     }
   } else if (m_zParam && m_cellVol) {
-      result.number_density = totalNumAtoms * m_zParam.get() / m_cellVol.get();
+    result.number_density = totalNumAtoms * m_zParam.get() / m_cellVol.get();
   } else if (!m_formula.empty() && m_formula.size() == 1) {
     result.number_density = m_formula.front().atom->number_density;
   }

--- a/Framework/Kernel/src/MaterialBuilder.cpp
+++ b/Framework/Kernel/src/MaterialBuilder.cpp
@@ -318,17 +318,16 @@ MaterialBuilder::density_packing MaterialBuilder::getOrCalculateRhoAndPacking(
                       });
 
   // calculate the number density by one of many ways
-  if (m_numberDensity && m_numberDensityUnit == NumberDensityUnit::Atoms) {
-    result.number_density = m_numberDensity.get();
-  } else {
-    if (m_numberDensity &&
-        m_numberDensityUnit == NumberDensityUnit::FormulaUnits) {
+  if (m_numberDensity) {
+    if (m_numberDensityUnit == NumberDensityUnit::Atoms) {
+      result.number_density = m_numberDensity.get();
+    } else if (m_numberDensityUnit == NumberDensityUnit::FormulaUnits) {
       result.number_density = m_numberDensity.get() * totalNumAtoms;
-    } else if (m_zParam && m_cellVol) {
-      result.number_density = totalNumAtoms * m_zParam.get() / m_cellVol.get();
-    } else if (!m_formula.empty() && m_formula.size() == 1) {
-      result.number_density = m_formula.front().atom->number_density;
     }
+  } else if (m_zParam && m_cellVol) {
+      result.number_density = totalNumAtoms * m_zParam.get() / m_cellVol.get();
+  } else if (!m_formula.empty() && m_formula.size() == 1) {
+    result.number_density = m_formula.front().atom->number_density;
   }
 
   // calculate the effective number density

--- a/Framework/Kernel/test/MaterialTest.h
+++ b/Framework/Kernel/test/MaterialTest.h
@@ -63,11 +63,14 @@ public:
 
   void test_Vanadium() {
     const std::string name("Vanadium");
+    const double numberDensity = 0.072;
     NeutronAtom atom = getNeutronAtom(23);
-    Material material(name, atom, 0.072);
+    Material material(name, atom, numberDensity);
 
     TS_ASSERT_EQUALS(material.name(), name);
-    TS_ASSERT_EQUALS(material.numberDensity(), 0.072);
+    TS_ASSERT_EQUALS(material.numberDensity(), numberDensity);
+    TS_ASSERT_EQUALS(material.numberDensityEffective(), numberDensity);
+    TS_ASSERT_EQUALS(material.packingFraction(), 1.);
     TS_ASSERT_EQUALS(material.temperature(), 300);
     TS_ASSERT_EQUALS(material.pressure(),
                      Mantid::PhysicalConstants::StandardAtmosphere);
@@ -85,9 +88,13 @@ public:
   // highly absorbing material
   void test_Gadolinium() {
     const std::string name("Gadolinium");
+    const double numberDensity = 0.0768; // mass density is 7.90 g/cm3
     NeutronAtom atom = getNeutronAtom(64);
-    Material material(name, atom, 0.0768); // mass density is 7.90 g/cm3
+    Material material(name, atom, numberDensity);
     TS_ASSERT_EQUALS(material.name(), name);
+    TS_ASSERT_EQUALS(material.numberDensity(), numberDensity);
+    TS_ASSERT_EQUALS(material.numberDensityEffective(), numberDensity);
+    TS_ASSERT_EQUALS(material.packingFraction(), 1.);
 
     // check everything with (default) reference wavelength
     checkMatching(material, atom);
@@ -98,8 +105,17 @@ public:
 
   // "null scatterer" has only incoherent scattering
   void test_TiZr() {
-    Material TiZr("TiZr", Material::parseChemicalFormula("Ti2.082605 Zr"),
-                  0.542);
+    const std::string name("TiZr");
+    const double numberDensity = 0.542;
+    const double packingFraction = .6;
+    Material TiZr(name, Material::parseChemicalFormula("Ti2.082605 Zr"),
+                  numberDensity, packingFraction);
+
+    TS_ASSERT_EQUALS(TiZr.name(), name);
+    TS_ASSERT_EQUALS(TiZr.numberDensity(), numberDensity);
+    TS_ASSERT_EQUALS(TiZr.numberDensityEffective(),
+                     numberDensity * packingFraction);
+    TS_ASSERT_EQUALS(TiZr.packingFraction(), packingFraction);
 
     TS_ASSERT_EQUALS(TiZr.cohScatterLengthImg(), 0.);
     TS_ASSERT_DELTA(TiZr.cohScatterLengthReal(), 0., 1.e-5);
@@ -126,8 +142,8 @@ public:
   /** Save then re-load from a NXS file */
   void test_nexus() {
     Material testA("testMaterial",
-                   Mantid::PhysicalConstants::getNeutronAtom(23, 0), 0.072, 273,
-                   1.234);
+                   Mantid::PhysicalConstants::getNeutronAtom(23, 0), 0.072, 2.,
+                   273, 1.234);
     NexusTestHelper th(true);
     th.createFile("MaterialTest.nxs");
 

--- a/Framework/PythonInterface/mantid/kernel/src/Exports/Material.cpp
+++ b/Framework/PythonInterface/mantid/kernel/src/Exports/Material.cpp
@@ -76,9 +76,11 @@ void export_Material() {
            return_value_policy<copy_const_reference>(), "Name of the material")
       .add_property("numberDensity", make_function(&Material::numberDensity),
                     "Number density in atoms per A^-3")
-      .add_property("numberDensityEffective", make_function(&Material::numberDensityEffective),
+      .add_property("numberDensityEffective",
+                    make_function(&Material::numberDensityEffective),
                     "Effective number density in atoms per A^-3")
-      .add_property("packingFraction", make_function(&Material::packingFraction),
+      .add_property("packingFraction",
+                    make_function(&Material::packingFraction),
                     "Packing fraction as a number, ideally, 0 to 1")
       .add_property("temperature", make_function(&Material::temperature),
                     "Temperature")

--- a/Framework/PythonInterface/mantid/kernel/src/Exports/Material.cpp
+++ b/Framework/PythonInterface/mantid/kernel/src/Exports/Material.cpp
@@ -76,6 +76,10 @@ void export_Material() {
            return_value_policy<copy_const_reference>(), "Name of the material")
       .add_property("numberDensity", make_function(&Material::numberDensity),
                     "Number density in atoms per A^-3")
+      .add_property("numberDensityEffective", make_function(&Material::numberDensityEffective),
+                    "Effective number density in atoms per A^-3")
+      .add_property("packingFraction", make_function(&Material::packingFraction),
+                    "Packing fraction as a number, ideally, 0 to 1")
       .add_property("temperature", make_function(&Material::temperature),
                     "Temperature")
       .add_property("pressure", make_function(&Material::pressure), "Pressure")

--- a/Framework/PythonInterface/mantid/kernel/src/Exports/MaterialBuilder.cpp
+++ b/Framework/PythonInterface/mantid/kernel/src/Exports/MaterialBuilder.cpp
@@ -45,6 +45,10 @@ void export_MaterialBuilder() {
            return_self<>(), (arg("self"), arg("rho")),
            "Set the number density of the material in atoms (default) or "
            "formula units per Angstrom^3")
+      .def("setPackingFraction", &MaterialBuilder::setPackingFraction,
+           return_self<>(), (arg("self"), arg("fraction")),
+           "Set the packing fraction of the material (default is 1). This is "
+           "used to infer the effective number density.")
       .def("setNumberDensityUnit", &MaterialBuilder::setNumberDensityUnit,
            return_self<>(), (arg("self"), arg("unit")),
            "Change the number density units from atoms per Angstrom^3 to the "

--- a/Framework/PythonInterface/plugins/algorithms/AlignAndFocusPowderFromFiles.py
+++ b/Framework/PythonInterface/plugins/algorithms/AlignAndFocusPowderFromFiles.py
@@ -66,7 +66,7 @@ def uniqueDescription(name, wksp):
         sample = mtd[wksp].sample()
         materialname = sample.getMaterial().name()
         shapeXML = sample.getShape().getShapeXML()
-        density = str(sample.getMaterial().numberDensity)
+        density = str(sample.getMaterial().numberDensityEffective)
         wavelength = mtd[wksp].readX(0)
         wavelength = '{} to {} with {} bins'.format(wavelength[0], wavelength[-1], mtd[wksp].readY(0).size)
         value = ';'.join((materialname, density, shapeXML, wavelength))

--- a/Framework/PythonInterface/plugins/algorithms/IndirectTransmission.py
+++ b/Framework/PythonInterface/plugins/algorithms/IndirectTransmission.py
@@ -125,7 +125,7 @@ class IndirectTransmission(PythonAlgorithm):
         wave = 1.8 * math.sqrt(25.2429 / efixed)
 
         material = mtd[str(workspace)].sample().getMaterial()
-        number_density = material.numberDensity
+        number_density = material.numberDensityEffective
         absorption_x_section = material.absorbXSection(wave)
         coherent_x_section = material.cohScatterXSection()
         incoherent_x_section = material.incohScatterXSection()

--- a/Framework/PythonInterface/test/python/mantid/kernel/MaterialBuilderTest.py
+++ b/Framework/PythonInterface/test/python/mantid/kernel/MaterialBuilderTest.py
@@ -14,6 +14,10 @@ class MaterialBuilderTest(unittest.TestCase):
         builder = MaterialBuilder()
         material = builder.setName('Bizarre oxide').setFormula('Al2 O3').setNumberDensity(0.23).build()
         self.assertEqual(material.name(), 'Bizarre oxide')
+        self.assertEqual(material.numberDensity, 0.23)
+        self.assertEqual(material.numberDensityEffective, 0.23)
+        self.assertEqual(material.packingFraction, 1.)
+
         formula = material.chemicalFormula()
         self.assertEqual(len(formula), 2)
         atoms = formula[0]
@@ -32,7 +36,8 @@ class MaterialBuilderTest(unittest.TestCase):
         builder.setNumberDensityUnit(NumberDensityUnit.FormulaUnits)
         material = builder.build()
         self.assertEqual(material.numberDensity, 0.23 * (2. + 3.))
-
+        self.assertEqual(material.numberDensityEffective, 0.23 * (2. + 3.))
+        self.assertEqual(material.packingFraction, 1.)
 
 if __name__ == '__main__':
     unittest.main()

--- a/Framework/PythonInterface/test/python/mantid/kernel/MaterialBuilderTest.py
+++ b/Framework/PythonInterface/test/python/mantid/kernel/MaterialBuilderTest.py
@@ -7,15 +7,19 @@
 import unittest
 from mantid.kernel import MaterialBuilder, NumberDensityUnit
 
+NAME = 'Bizarre oxide'
+FORMULA = 'Al2 O3'
+NUMBER_DENSITY = 0.23 # atoms / Angstrom^3
+MASS_DENSITY = 3.987  # g/cm^3
+PACKING_OBS = 0.51192  # packing fraction from the above two values
 
 class MaterialBuilderTest(unittest.TestCase):
-
     def test_build_material(self):
         builder = MaterialBuilder()
-        material = builder.setName('Bizarre oxide').setFormula('Al2 O3').setNumberDensity(0.23).build()
-        self.assertEqual(material.name(), 'Bizarre oxide')
-        self.assertEqual(material.numberDensity, 0.23)
-        self.assertEqual(material.numberDensityEffective, 0.23)
+        material = builder.setName(NAME).setFormula(FORMULA).setNumberDensity(NUMBER_DENSITY).build()
+        self.assertEqual(material.name(), NAME)
+        self.assertEqual(material.numberDensity, NUMBER_DENSITY)
+        self.assertEqual(material.numberDensityEffective, NUMBER_DENSITY)
         self.assertEqual(material.packingFraction, 1.)
 
         formula = material.chemicalFormula()
@@ -28,15 +32,65 @@ class MaterialBuilderTest(unittest.TestCase):
         self.assertEqual(len(multiplicities), 2)
         self.assertEqual(multiplicities[0], 2)
         self.assertEqual(multiplicities[1], 3)
-        self.assertEqual(material.numberDensity, 0.23)
+        self.assertEqual(material.numberDensity, NUMBER_DENSITY)
+
+    def test_packing_fraction(self):
+        builder = MaterialBuilder().setName(NAME).setFormula(FORMULA)
+
+        # setting nothing should be an error
+        try:
+            material = builder.build()
+            raise AssertionError('Should throw an exception')
+        except RuntimeError as e:
+            assert 'number density' in str(e)
+
+        builder = MaterialBuilder().setName(NAME).setFormula(FORMULA).setNumberDensity(NUMBER_DENSITY)
+
+        # only with number density
+        material = builder.build()
+        self.assertEqual(material.name(), NAME)
+        self.assertEqual(material.numberDensity, material.numberDensityEffective)
+        self.assertEqual(material.packingFraction, 1.0)
+        self.assertEqual(material.numberDensity, NUMBER_DENSITY)
+
+        # with number density and packing fraction
+        material = builder.setPackingFraction(0.5).build()
+        self.assertEqual(material.name(), NAME)
+        self.assertEqual(material.numberDensity, NUMBER_DENSITY)
+        self.assertEqual(material.numberDensityEffective, NUMBER_DENSITY * 0.5)
+        self.assertEqual(material.packingFraction, 0.5)
+
+        # start a brand new material builder
+        builder = MaterialBuilder().setName(NAME).setFormula(FORMULA).setMassDensity(MASS_DENSITY)
+
+        # only with mass density
+        material = builder.build()
+        self.assertEqual(material.name(), NAME)
+        self.assertEqual(material.numberDensity, material.numberDensityEffective)
+        self.assertEqual(material.packingFraction, 1.0)
+        self.assertAlmostEqual(material.numberDensityEffective, NUMBER_DENSITY * PACKING_OBS, delta=1e-4)
+
+        # with mass density and number density
+        material = builder.setNumberDensity(NUMBER_DENSITY).build()
+        self.assertEqual(material.name(), NAME)
+        self.assertEqual(material.numberDensity, NUMBER_DENSITY)
+        self.assertAlmostEqual(material.numberDensityEffective, NUMBER_DENSITY * PACKING_OBS, delta=1e-4)
+        self.assertAlmostEqual(material.packingFraction, PACKING_OBS, delta=1e-4)
+
+        # setting all 3 should be an error
+        try:
+            material = builder.setPackingFraction(0.5).setNumberDensity(NUMBER_DENSITY).setMassDensity(MASS_DENSITY).build()
+            raise AssertionError('Should throw an exception')
+        except RuntimeError as e:
+            assert 'number density' in str(e)
 
     def test_number_density_units(self):
         builder = MaterialBuilder()
-        builder.setName('Bizarre oxide').setFormula('Al2 O3').setNumberDensity(0.23)
+        builder.setName(NAME).setFormula(FORMULA).setNumberDensity(NUMBER_DENSITY)
         builder.setNumberDensityUnit(NumberDensityUnit.FormulaUnits)
         material = builder.build()
-        self.assertEqual(material.numberDensity, 0.23 * (2. + 3.))
-        self.assertEqual(material.numberDensityEffective, 0.23 * (2. + 3.))
+        self.assertEqual(material.numberDensity, NUMBER_DENSITY * (2. + 3.))
+        self.assertEqual(material.numberDensityEffective, NUMBER_DENSITY * (2. + 3.))
         self.assertEqual(material.packingFraction, 1.)
 
 if __name__ == '__main__':

--- a/docs/source/release/v6.0.0/framework.rst
+++ b/docs/source/release/v6.0.0/framework.rst
@@ -12,6 +12,8 @@ Framework Changes
 Concepts
 --------
 
+- Added packing fraction to :ref:`Material <Materials>` to separate number density and effective number density.
+
 Algorithms
 ----------
 
@@ -48,5 +50,6 @@ Improvements
 
 Bugfixes
 ########
+
 
 :ref:`Release 6.0.0 <v6.0.0>`


### PR DESCRIPTION
For absorption corrections, there is a separate effective number density from the actual (e.g. crystallographic) number density. 

**To test:**

Use `MaterialBuilder` from python to see that it does the right thing. Alternatively, the tests should cover all of the standard ways of using it.

*There is no associated issue.*


<!-- Ensure the base of this PR is correct (e.g. release-next or master)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

The version of this into `ornl-next` is #29748.

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
