### PR TITLE
Fixes Spurious Instrument Warnings when editing a script

### DIFF
--- a/Framework/API/src/InstrumentValidator.cpp
+++ b/Framework/API/src/InstrumentValidator.cpp
@@ -45,10 +45,10 @@ std::string InstrumentValidator::checkValidity(
     return "The workspace must have an instrument defined";
 
   std::list<std::string> missing;
-  if ((m_requires & SourcePosition) && !inst->getSource(false)) {
+  if ((m_requires & SourcePosition) && !inst->hasSource()) {
     missing.emplace_back("source");
   }
-  if ((m_requires & SamplePosition) && !inst->getSample(false)) {
+  if ((m_requires & SamplePosition) && !inst->hasSample()) {
     missing.emplace_back("sample holder");
   }
 

--- a/Framework/API/src/InstrumentValidator.cpp
+++ b/Framework/API/src/InstrumentValidator.cpp
@@ -45,10 +45,10 @@ std::string InstrumentValidator::checkValidity(
     return "The workspace must have an instrument defined";
 
   std::list<std::string> missing;
-  if ((m_requires & SourcePosition) && !inst->getSource()) {
+  if ((m_requires & SourcePosition) && !inst->getSource(false)) {
     missing.emplace_back("source");
   }
-  if ((m_requires & SamplePosition) && !inst->getSample()) {
+  if ((m_requires & SamplePosition) && !inst->getSample(false)) {
     missing.emplace_back("sample holder");
   }
 

--- a/Framework/API/test/InstrumentValidatorTest.h
+++ b/Framework/API/test/InstrumentValidatorTest.h
@@ -40,11 +40,25 @@ public:
     TS_ASSERT_EQUALS(validator.checkValidity(ws), "");
   }
 
-  void test_fail() {
-    auto ws = std::make_shared<WorkspaceTester>();
-    InstrumentValidator validator;
+  void
+  test_that_the_expected_error_message_is_returned_when_the_instrument_is_missing_a_sample_component() {
+    auto const workspace = std::make_shared<WorkspaceTester>();
+
+    InstrumentValidator validator(InstrumentValidator::SamplePosition);
+
     TS_ASSERT_EQUALS(
-        validator.checkValidity(ws),
+        validator.checkValidity(workspace),
         "The instrument is missing the following components: sample holder");
+  }
+
+  void
+  test_that_the_expected_error_message_is_returned_when_the_instrument_is_missing_a_source_component() {
+    auto const workspace = std::make_shared<WorkspaceTester>();
+
+    InstrumentValidator validator(InstrumentValidator::SourcePosition);
+
+    TS_ASSERT_EQUALS(
+        validator.checkValidity(workspace),
+        "The instrument is missing the following components: source");
   }
 };

--- a/Framework/Geometry/inc/MantidGeometry/Instrument.h
+++ b/Framework/Geometry/inc/MantidGeometry/Instrument.h
@@ -56,8 +56,8 @@ public:
 
   Instrument *clone() const override;
 
-  IComponent_const_sptr getSource() const;
-  IComponent_const_sptr getSample() const;
+  IComponent_const_sptr getSource(bool writeToLog = true) const;
+  IComponent_const_sptr getSample(bool writeToLog = true) const;
   Kernel::V3D getBeamDirection() const;
 
   IDetector_const_sptr getDetector(const detid_t &detector_id) const;

--- a/Framework/Geometry/inc/MantidGeometry/Instrument.h
+++ b/Framework/Geometry/inc/MantidGeometry/Instrument.h
@@ -56,8 +56,11 @@ public:
 
   Instrument *clone() const override;
 
-  IComponent_const_sptr getSource(bool writeToLog = true) const;
-  IComponent_const_sptr getSample(bool writeToLog = true) const;
+  bool hasSource() const;
+  bool hasSample() const;
+
+  IComponent_const_sptr getSource() const;
+  IComponent_const_sptr getSample() const;
   Kernel::V3D getBeamDirection() const;
 
   IDetector_const_sptr getDetector(const detid_t &detector_id) const;

--- a/Framework/Geometry/src/Instrument.cpp
+++ b/Framework/Geometry/src/Instrument.cpp
@@ -320,14 +320,22 @@ void Instrument::getDetectorsInBank(std::vector<IDetector_const_sptr> &dets,
   getDetectorsInBank(dets, *comp);
 }
 
-//------------------------------------------------------------------------------------------
+/** Checks to see if the Instrument has a source.
+ *   @returns True if the instrument has a source cache.
+ */
+bool Instrument::hasSource() const { return m_sourceCache; }
+
+/** Checks to see if the Instrument has a sample.
+ *   @returns True if the instrument has a sample cache.
+ */
+bool Instrument::hasSample() const { return m_sampleCache; }
+
 /** Gets a pointer to the source
  *   @returns a pointer to the source
  */
-IComponent_const_sptr Instrument::getSource(bool writeToLog) const {
+IComponent_const_sptr Instrument::getSource() const {
   if (!m_sourceCache) {
-    if (writeToLog)
-      g_log.warning("In Instrument::getSource(). No source has been set.");
+    g_log.warning("In Instrument::getSource(). No source has been set.");
     return IComponent_const_sptr(m_sourceCache, NoDeleting());
   } else if (m_map) {
     auto sourceCache = static_cast<const Instrument *>(m_base)->m_sourceCache;
@@ -338,11 +346,9 @@ IComponent_const_sptr Instrument::getSource(bool writeToLog) const {
     else if (dynamic_cast<const Component *>(sourceCache))
       return IComponent_const_sptr(new Component(sourceCache, m_map));
     else {
-      if (writeToLog) {
-        g_log.error("In Instrument::getSource(). Source is not a recognised "
-                    "component type.");
-        g_log.error("Try to assume it is a Component.");
-      }
+      g_log.error("In Instrument::getSource(). Source is not a recognised "
+                  "component type.");
+      g_log.error("Try to assume it is a Component.");
       return IComponent_const_sptr(new ObjComponent(sourceCache, m_map));
     }
   } else {
@@ -353,11 +359,9 @@ IComponent_const_sptr Instrument::getSource(bool writeToLog) const {
 /** Gets a pointer to the Sample Position
  *  @returns a pointer to the Sample Position
  */
-IComponent_const_sptr Instrument::getSample(bool writeToLog) const {
+IComponent_const_sptr Instrument::getSample() const {
   if (!m_sampleCache) {
-    if (writeToLog)
-      g_log.warning(
-          "In Instrument::getSamplePos(). No SamplePos has been set.");
+    g_log.warning("In Instrument::getSamplePos(). No SamplePos has been set.");
     return IComponent_const_sptr(m_sampleCache, NoDeleting());
   } else if (m_map) {
     auto sampleCache = static_cast<const Instrument *>(m_base)->m_sampleCache;
@@ -368,11 +372,9 @@ IComponent_const_sptr Instrument::getSample(bool writeToLog) const {
     else if (dynamic_cast<const Component *>(sampleCache))
       return IComponent_const_sptr(new Component(sampleCache, m_map));
     else {
-      if (writeToLog) {
-        g_log.error("In Instrument::getSamplePos(). SamplePos is not a "
-                    "recognised component type.");
-        g_log.error("Try to assume it is a Component.");
-      }
+      g_log.error("In Instrument::getSamplePos(). SamplePos is not a "
+                  "recognised component type.");
+      g_log.error("Try to assume it is a Component.");
       return IComponent_const_sptr(new ObjComponent(sampleCache, m_map));
     }
   } else {

--- a/Framework/Geometry/src/Instrument.cpp
+++ b/Framework/Geometry/src/Instrument.cpp
@@ -324,9 +324,10 @@ void Instrument::getDetectorsInBank(std::vector<IDetector_const_sptr> &dets,
 /** Gets a pointer to the source
  *   @returns a pointer to the source
  */
-IComponent_const_sptr Instrument::getSource() const {
+IComponent_const_sptr Instrument::getSource(bool writeToLog) const {
   if (!m_sourceCache) {
-    g_log.warning("In Instrument::getSource(). No source has been set.");
+    if (writeToLog)
+      g_log.warning("In Instrument::getSource(). No source has been set.");
     return IComponent_const_sptr(m_sourceCache, NoDeleting());
   } else if (m_map) {
     auto sourceCache = static_cast<const Instrument *>(m_base)->m_sourceCache;
@@ -337,9 +338,11 @@ IComponent_const_sptr Instrument::getSource() const {
     else if (dynamic_cast<const Component *>(sourceCache))
       return IComponent_const_sptr(new Component(sourceCache, m_map));
     else {
-      g_log.error("In Instrument::getSource(). Source is not a recognised "
-                  "component type.");
-      g_log.error("Try to assume it is a Component.");
+      if (writeToLog) {
+        g_log.error("In Instrument::getSource(). Source is not a recognised "
+                    "component type.");
+        g_log.error("Try to assume it is a Component.");
+      }
       return IComponent_const_sptr(new ObjComponent(sourceCache, m_map));
     }
   } else {
@@ -350,9 +353,11 @@ IComponent_const_sptr Instrument::getSource() const {
 /** Gets a pointer to the Sample Position
  *  @returns a pointer to the Sample Position
  */
-IComponent_const_sptr Instrument::getSample() const {
+IComponent_const_sptr Instrument::getSample(bool writeToLog) const {
   if (!m_sampleCache) {
-    g_log.warning("In Instrument::getSamplePos(). No SamplePos has been set.");
+    if (writeToLog)
+      g_log.warning(
+          "In Instrument::getSamplePos(). No SamplePos has been set.");
     return IComponent_const_sptr(m_sampleCache, NoDeleting());
   } else if (m_map) {
     auto sampleCache = static_cast<const Instrument *>(m_base)->m_sampleCache;
@@ -363,9 +368,11 @@ IComponent_const_sptr Instrument::getSample() const {
     else if (dynamic_cast<const Component *>(sampleCache))
       return IComponent_const_sptr(new Component(sampleCache, m_map));
     else {
-      g_log.error("In Instrument::getSamplePos(). SamplePos is not a "
-                  "recognised component type.");
-      g_log.error("Try to assume it is a Component.");
+      if (writeToLog) {
+        g_log.error("In Instrument::getSamplePos(). SamplePos is not a "
+                    "recognised component type.");
+        g_log.error("Try to assume it is a Component.");
+      }
       return IComponent_const_sptr(new ObjComponent(sampleCache, m_map));
     }
   } else {

--- a/Framework/PythonInterface/mantid/geometry/src/Exports/Instrument.cpp
+++ b/Framework/PythonInterface/mantid/geometry/src/Exports/Instrument.cpp
@@ -24,12 +24,18 @@ void export_Instrument() {
 
   class_<Instrument, bases<CompAssembly>, boost::noncopyable>("Instrument",
                                                               no_init)
-      .def("getSample", &Instrument::getSample, arg("self"),
+      .def("getSample",
+           (std::shared_ptr<const IComponent>(Instrument::*)(bool) const) &
+               Instrument::getSample,
+           (arg("self"), arg("writeToLog") = true),
            return_value_policy<RemoveConstSharedPtr>(),
            "Return the :class:`~mantid.geometry.Component` object that "
            "represents the sample")
 
-      .def("getSource", &Instrument::getSource, arg("self"),
+      .def("getSource",
+           (std::shared_ptr<const IComponent>(Instrument::*)(bool) const) &
+               Instrument::getSource,
+           (arg("self"), arg("writeToLog") = true),
            return_value_policy<RemoveConstSharedPtr>(),
            "Return the :class:`~mantid.geometry.Component` object that "
            "represents the source")

--- a/Framework/PythonInterface/mantid/geometry/src/Exports/Instrument.cpp
+++ b/Framework/PythonInterface/mantid/geometry/src/Exports/Instrument.cpp
@@ -24,18 +24,12 @@ void export_Instrument() {
 
   class_<Instrument, bases<CompAssembly>, boost::noncopyable>("Instrument",
                                                               no_init)
-      .def("getSample",
-           (std::shared_ptr<const IComponent>(Instrument::*)(bool) const) &
-               Instrument::getSample,
-           (arg("self"), arg("writeToLog") = true),
+      .def("getSample", &Instrument::getSample, arg("self"),
            return_value_policy<RemoveConstSharedPtr>(),
            "Return the :class:`~mantid.geometry.Component` object that "
            "represents the sample")
 
-      .def("getSource",
-           (std::shared_ptr<const IComponent>(Instrument::*)(bool) const) &
-               Instrument::getSource,
-           (arg("self"), arg("writeToLog") = true),
+      .def("getSource", &Instrument::getSource, arg("self"),
            return_value_policy<RemoveConstSharedPtr>(),
            "Return the :class:`~mantid.geometry.Component` object that "
            "represents the source")

--- a/docs/source/release/v6.0.0/framework.rst
+++ b/docs/source/release/v6.0.0/framework.rst
@@ -50,5 +50,7 @@ Improvements
 Bugfixes
 ########
 - Error log messages from an EqualBinChecker are now no longer produced when editing python scripts if a workspace is present with unequal bin sizes
+- Warning log messages from the InstrumentValidator are no longer produced when editing some python scripts.
+
 
 :ref:`Release 6.0.0 <v6.0.0>`


### PR DESCRIPTION
**Description of work.**
This PR fixes a problem where a large number of warning messages are logged when editing a script after running it. The solution was to disable logging these messages when the `InstrumentValidator` is doing a check from the Lazy algorithm initialisation process. A good description of this is found in #29752 , which fixes a similar problem in the same way.

**To test:**
1. Load the script found in the associated issue. (and save the data in a findable location)
2. Run the script and wait for it to finish
3. Edit the script by changing anything. No warning messages should appear in the log.

Fixes #29755

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
