### PR TITLE
Make consecutive runs of Focus work in PEARL ISIS Powder diffraction scripts

### DIFF
--- a/docs/source/release/v6.0.0/diffraction.rst
+++ b/docs/source/release/v6.0.0/diffraction.rst
@@ -30,6 +30,7 @@ Bugfixes
 ########
 
 - Dummy detectors in polaris workspaces no longer prevent unit conversion.
+- Focus in PEARL powder diffraction scripts no longer fails if previous run has left Van splines workspace group in ADS
 
 Engineering Diffraction
 -----------------------

--- a/scripts/Diffraction/isis_powder/routines/focus.py
+++ b/scripts/Diffraction/isis_powder/routines/focus.py
@@ -122,14 +122,15 @@ def _batched_run_focusing(instrument, perform_vanadium_norm, run_number_string, 
                                                 OutputWorkspace=van)
         else:
             vanadium_splines = mantid.mtd[van]
-
     output = None
     for ws in read_ws_list:
         output = _focus_one_ws(input_workspace=ws, run_number=run_number_string, instrument=instrument,
                                perform_vanadium_norm=perform_vanadium_norm, absorb=absorb,
                                sample_details=sample_details, vanadium_path=vanadium_splines)
     if instrument.get_instrument_prefix() == "PEARL" and vanadium_splines is not None :
-        mantid.DeleteWorkspace(vanadium_splines.OutputWorkspace)
+        if hasattr(vanadium_splines, "OutputWorkspace"):
+            vanadium_splines = vanadium_splines.OutputWorkspace
+        mantid.DeleteWorkspace(vanadium_splines)
     return output
 
 


### PR DESCRIPTION
**Description of work.**

Running a Focus in the PEARL ISIS Powder diffraction scripts was creating an error "'WorkspaceGroup' object has no attribute 'OutputWorkspace'" if a previous call to Focus had left behind a van_XXX workspace group. One situation where this happens is if the first run failed with an error.
The bug occurs because some PEARL specific code assumed the van_XXX workspace group was always created by a LoadNexus call that returned a tuple rather than sometimes being read from the ADS
I have added an extra check on the type of a vanadium_splines variable to fix this. This follows a similar approach in the same unit to managing this problem (see function _divide_by_vanadium_splines)

**To test:**

1. Unzip this into a folder somewhere and edit the paths in the user_experiment.yaml file to match the folder. Note - I've been doing a couple of other changes to the PEARL powder diffraction scripts so if master has moved on a bit and the config in here doesn't work then let me know and I'll double check
[PearlFocusTest.zip](https://github.com/mantidproject/mantid/files/5400764/PearlFocusTest.zip)
2. Load the attached workspace group. This mimics a previous run of Focus having failed, leaving behind the vanadium workspace group:
[van_95634-95647.zip](https://github.com/mantidproject/mantid/files/5400704/van_95634-95647.zip)
3. Run the following python script in Workbench which calls Focus (you'll need archive access enabled):
```
# import mantid algorithms, numpy and matplotlib
from mantid.simpleapi import *
import matplotlib.pyplot as plt
import numpy as np

from isis_powder.pearl import Pearl

pearl_focus = Pearl(user_name="Danny",
                          output_directory=r"C:\some_path",   #directory above cycle number 
                          config_file=r"C:\some_path\User_experiment.yaml",
                          calibration_directory=r"C:\some_path\calib_critical_files",
                          calibration_mapping_file=r"C:\some_path\calib_critical_files\pearl.yaml")

#pearl_focus.create_vanadium(run_in_cycle=97545)
pearl_focus.focus(run_number="101540",perform_attenuation=True,tt_mode="tt70",file_ext=".raw")
```
3. Observe that the script works and no longer fails with the "object has no attribute 'OutputWorkspace'" error
4. Repeat but without step 2) to make sure the Focus still works in the most common situation where there's not a van_95634-95647 workspace group in the ADS

Fixes #29753 .

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
