### PR TITLE
Remove resetting of the fit range on changing workspace in elwin

### DIFF
--- a/docs/source/release/v6.0.0/indirect_geometry.rst
+++ b/docs/source/release/v6.0.0/indirect_geometry.rst
@@ -13,4 +13,8 @@ Improvements
 ############
 - Added an option to load diffraction data on IN16B.
 
+Bug Fixes
+#########
+- A bug has been fixed in Indirect data analysis on the Elwin tab that causes the integration range to be reset when changing between plotted workspaces.
+
 :ref:`Release 6.0.0 <v6.0.0>`

--- a/qt/scientific_interfaces/Indirect/Elwin.cpp
+++ b/qt/scientific_interfaces/Indirect/Elwin.cpp
@@ -505,10 +505,8 @@ void Elwin::newPreviewFileSelected(int index) {
  */
 void Elwin::plotInput() {
   IndirectDataAnalysisTab::plotInput(m_uiForm.ppPlot);
-  IndirectDataAnalysisTab::updatePlotRange("ElwinIntegrationRange",
-                                           m_uiForm.ppPlot, "IntegrationStart",
-                                           "IntegrationEnd");
-
+  Elwin::updatePlotRange("ElwinIntegrationRange", m_uiForm.ppPlot,
+                         "IntegrationStart", "IntegrationEnd");
   setDefaultSampleLog(inputWorkspace());
 }
 
@@ -554,7 +552,6 @@ void Elwin::minChanged(double val) {
 
   disconnect(m_dblManager, SIGNAL(valueChanged(QtProperty *, double)), this,
              SLOT(updateRS(QtProperty *, double)));
-
   if (from == integrationRangeSelector) {
     m_dblManager->setValue(m_properties["IntegrationStart"], val);
   } else if (from == backgroundRangeSelector) {
@@ -661,6 +658,33 @@ void Elwin::setRunEnabled(const bool &enabled) {
 
 void Elwin::setSaveResultEnabled(const bool &enabled) {
   m_uiForm.pbSave->setEnabled(enabled);
+}
+
+/*
+ * Updates the plot range with the specified name, to match the range of
+ * the sample curve.
+ *
+ * @param rangeName           The name of the range to update.
+ * @param previewPlot         The preview plot widget, in which the range
+ *                            is specified.
+ * @param startRangePropName  The name of the property specifying the start
+ *                            value for the range.
+ * @param endRangePropName    The name of the property specifying the end
+ *                            value for the range.
+ */
+void Elwin::updatePlotRange(const QString &rangeName,
+                            MantidQt::MantidWidgets::PreviewPlot *previewPlot,
+                            const QString &startRangePropName,
+                            const QString &endRangePropName) {
+
+  if (auto const workspace = inputWorkspace()) {
+    try {
+      auto const xRange = getXRangeFromWorkspace(workspace);
+      auto rangeSelector = previewPlot->getRangeSelector(rangeName);
+    } catch (std::exception &exc) {
+      showMessageBox(exc.what());
+    }
+  }
 }
 
 } // namespace IDA

--- a/qt/scientific_interfaces/Indirect/Elwin.cpp
+++ b/qt/scientific_interfaces/Indirect/Elwin.cpp
@@ -505,8 +505,6 @@ void Elwin::newPreviewFileSelected(int index) {
  */
 void Elwin::plotInput() {
   IndirectDataAnalysisTab::plotInput(m_uiForm.ppPlot);
-  Elwin::updatePlotRange("ElwinIntegrationRange", m_uiForm.ppPlot,
-                         "IntegrationStart", "IntegrationEnd");
   setDefaultSampleLog(inputWorkspace());
 }
 
@@ -658,33 +656,6 @@ void Elwin::setRunEnabled(const bool &enabled) {
 
 void Elwin::setSaveResultEnabled(const bool &enabled) {
   m_uiForm.pbSave->setEnabled(enabled);
-}
-
-/*
- * Updates the plot range with the specified name, to match the range of
- * the sample curve.
- *
- * @param rangeName           The name of the range to update.
- * @param previewPlot         The preview plot widget, in which the range
- *                            is specified.
- * @param startRangePropName  The name of the property specifying the start
- *                            value for the range.
- * @param endRangePropName    The name of the property specifying the end
- *                            value for the range.
- */
-void Elwin::updatePlotRange(const QString &rangeName,
-                            MantidQt::MantidWidgets::PreviewPlot *previewPlot,
-                            const QString &startRangePropName,
-                            const QString &endRangePropName) {
-
-  if (auto const workspace = inputWorkspace()) {
-    try {
-      auto const xRange = getXRangeFromWorkspace(workspace);
-      auto rangeSelector = previewPlot->getRangeSelector(rangeName);
-    } catch (std::exception &exc) {
-      showMessageBox(exc.what());
-    }
-  }
 }
 
 } // namespace IDA

--- a/qt/scientific_interfaces/Indirect/Elwin.h
+++ b/qt/scientific_interfaces/Indirect/Elwin.h
@@ -53,10 +53,6 @@ private:
   void setButtonsEnabled(const bool &enabled);
   void setRunEnabled(const bool &enabled);
   void setSaveResultEnabled(const bool &enabled);
-  void updatePlotRange(const QString &rangeName,
-                       MantidQt::MantidWidgets::PreviewPlot *previewPlot,
-                       const QString &startRangePropName = "",
-                       const QString &endRangePropName = "");
 
   Ui::Elwin m_uiForm;
   QtTreePropertyBrowser *m_elwTree;

--- a/qt/scientific_interfaces/Indirect/Elwin.h
+++ b/qt/scientific_interfaces/Indirect/Elwin.h
@@ -53,6 +53,10 @@ private:
   void setButtonsEnabled(const bool &enabled);
   void setRunEnabled(const bool &enabled);
   void setSaveResultEnabled(const bool &enabled);
+  void updatePlotRange(const QString &rangeName,
+                       MantidQt::MantidWidgets::PreviewPlot *previewPlot,
+                       const QString &startRangePropName = "",
+                       const QString &endRangePropName = "");
 
   Ui::Elwin m_uiForm;
   QtTreePropertyBrowser *m_elwTree;

--- a/qt/scientific_interfaces/Indirect/IndirectDataAnalysisTab.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectDataAnalysisTab.cpp
@@ -355,34 +355,6 @@ void IndirectDataAnalysisTab::updatePlot(
     clearAndPlotInput(fitPreviewPlot, diffPreviewPlot);
 }
 
-/*
- * Updates the plot range with the specified name, to match the range of
- * the sample curve.
- *
- * @param rangeName           The name of the range to update.
- * @param previewPlot         The preview plot widget, in which the range
- *                            is specified.
- * @param startRangePropName  The name of the property specifying the start
- *                            value for the range.
- * @parma endRangePropName    The name of the property specifying the end
- *                            value for the range.
- */
-void IndirectDataAnalysisTab::updatePlotRange(
-    const QString &rangeName, MantidQt::MantidWidgets::PreviewPlot *previewPlot,
-    const QString &startRangePropName, const QString &endRangePropName) {
-
-  if (auto const workspace = inputWorkspace()) {
-    try {
-      auto const xRange = getXRangeFromWorkspace(workspace);
-      auto rangeSelector = previewPlot->getRangeSelector(rangeName);
-      setPlotPropertyRange(rangeSelector, m_properties[startRangePropName],
-                           m_properties[endRangePropName], xRange);
-    } catch (std::exception &exc) {
-      showMessageBox(exc.what());
-    }
-  }
-}
-
 } // namespace IDA
 } // namespace CustomInterfaces
 } // namespace MantidQt

--- a/qt/scientific_interfaces/Indirect/IndirectDataAnalysisTab.h
+++ b/qt/scientific_interfaces/Indirect/IndirectDataAnalysisTab.h
@@ -127,11 +127,6 @@ protected:
                   MantidQt::MantidWidgets::PreviewPlot *fitPreviewPlot,
                   MantidQt::MantidWidgets::PreviewPlot *diffPreviewPlot);
 
-  void updatePlotRange(const QString &rangeName,
-                       MantidQt::MantidWidgets::PreviewPlot *previewPlot,
-                       const QString &startRangePropName = "",
-                       const QString &endRangePropName = "");
-
   /// DoubleEditorFactory
   DoubleEditorFactory *m_dblEdFac;
   /// QtCheckBoxFactory


### PR DESCRIPTION
This PR removes the resetting of the fit ranges when changing the plotted workspace in elwin tab on indirect data analysis.

**Report to:** Spencer 

**To test:**

<!-- Instructions for testing. -->

1. Open indiect data analysis on the Elwin Tab
2. Load data from multiple runs.
3. Change between ploted workspaces from the dropdown menu. The fitting integretion range should stay the same
4. Change the range yourself.
5. Change workspace, the range should remain as what you set it as.

Fixes #24662 

<!-- Ensure the base of this PR is correct (e.g. release-next or master)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
