### PR TITLE
Enable rebinning for MDHistoWorkspace with original in sliceviewer

### DIFF
--- a/docs/source/release/v6.0.0/mantidworkbench.rst
+++ b/docs/source/release/v6.0.0/mantidworkbench.rst
@@ -22,6 +22,7 @@ Improvements
 - Add the possibility to copy and paste shapes in the instrument viewer using Ctrl + C and Ctrl + V.
 - Improved spectra selection within the sliceviewer, which should ensure that high counting spectra are shown immediately when the sliceviewer is opened.
 - Powder diffraction support (instruments D2B and D20) has been added to DrILL interface. See
+- Dynamic binning has been enabled for MDHistoWorkspaces with an attached original in the SliceViewer. Manual rebinning options are now also shown.
 
 Bugfixes
 ########

--- a/qt/python/mantidqt/widgets/sliceviewer/dimensionwidget.py
+++ b/qt/python/mantidqt/widgets/sliceviewer/dimensionwidget.py
@@ -37,7 +37,6 @@ class DimensionWidget(QWidget):
     window.show()
     app.exec_()
     """
-
     def __init__(self, dims_info, parent=None):
         super().__init__(parent)
 
@@ -47,8 +46,9 @@ class DimensionWidget(QWidget):
         self.dims, self.qflags = [], []
         for n, dim in enumerate(dims_info):
             self.qflags.append(dim['qdim'])
-            if dim['type'] == 'MDE':
-                self.dims.append(DimensionMDE(dim, number=n, parent=self))
+            dim_type = dim['type']
+            if dim_type == 'MDE' or (dim_type == 'MDH' and dim['has_original']):
+                self.dims.append(DimensionNonIntegrated(dim, number=n, parent=self))
             else:
                 self.dims.append(Dimension(dim, number=n, parent=self))
 
@@ -120,9 +120,8 @@ class DimensionWidget(QWidget):
         dimension and are in the same positions as the list returned from get_slicepoint
         """
         return [
-            None if d.get_state() in (State.X, State.Y) else (d.spinbox.minimum(),
-                                                              d.spinbox.maximum())
-            for d in self.dims
+            None if d.get_state() in (State.X, State.Y) else
+            (d.spinbox.minimum(), d.spinbox.maximum()) for d in self.dims
         ]
 
     def get_bin_params(self):
@@ -161,7 +160,6 @@ class Dimension(QWidget):
     window.show()
     app.exec_()
     """
-
     def __init__(self, dim_info, number=0, state=State.NONE, parent=None):
         super().__init__(parent)
 
@@ -209,8 +207,7 @@ class Dimension(QWidget):
         self.layout.addWidget(self.spinbox)
         self.layout.addWidget(self.units)
 
-        self.set_value(0)
-
+        self.set_value(self.spinbox.value())
         if self.nbins < 2:
             state = State.DISABLE
 
@@ -289,28 +286,29 @@ class Dimension(QWidget):
         return self.value
 
 
-class DimensionMDE(Dimension):
+class DimensionNonIntegrated(Dimension):
     binningChanged = Signal()
     """
-    MDEventWorkspace has additional properties for either number_of_bins or thickness
+    A dimension that can either be sliced through or rebinned. It
+    has additional properties for either number_of_bins or thickness
 
     from mantidqt.widgets.sliceviewer.dimensionwidget import DimensionMDE
     from qtpy.QtWidgets import QApplication
     app = QApplication([])
-    window = DimensionMDE({'minimum':-1.1, 'number_of_bins':11, 'width':0.2, 'name':'Dim0', 'units':'A'})
+    window = DimensionNonIntegrated({'minimum':-1.1, 'number_of_bins':11,
+                                     'width':0.2, 'name':'Dim0', 'units':'A'})
     window.show()
     app.exec_()
     """
-
     def __init__(self, dim_info, number=0, state=State.NONE, parent=None):
-
         # hack in a number_of_bins for MDEventWorkspace
-        dim_info['number_of_bins'] = 1000
-        dim_info['width'] = (dim_info['maximum'] - dim_info['minimum']) / 1000
+        if dim_info['type'] == 'MDE':
+            dim_info['number_of_bins'] = 100
+            dim_info['width'] = (dim_info['maximum'] - dim_info['minimum']) / 100
 
         self.spinBins = QSpinBox()
         self.spinBins.setRange(2, 9999)
-        self.spinBins.setValue(100)
+        self.spinBins.setValue(dim_info['number_of_bins'])
         self.spinBins.hide()
         self.spinBins.setMinimumWidth(110)
         self.spinThick = QDoubleSpinBox()

--- a/qt/python/mantidqt/widgets/sliceviewer/dimensionwidget.py
+++ b/qt/python/mantidqt/widgets/sliceviewer/dimensionwidget.py
@@ -207,7 +207,7 @@ class Dimension(QWidget):
         self.layout.addWidget(self.spinbox)
         self.layout.addWidget(self.units)
 
-        self.set_value(self.spinbox.value())
+        self.set_value(self.spinbox.minimum())
         if self.nbins < 2:
             state = State.DISABLE
 

--- a/qt/python/mantidqt/widgets/sliceviewer/model.py
+++ b/qt/python/mantidqt/widgets/sliceviewer/model.py
@@ -7,7 +7,7 @@
 #  This file is part of the mantid workbench.
 #
 from enum import Enum
-from typing import Dict, List, Sequence, Optional
+from typing import Dict, List, Sequence, Tuple, Optional
 
 from mantid.api import MatrixWorkspace, MultipleExperimentInfos, SpecialCoordinateSystem
 from mantid.plots.datafunctions import get_indices
@@ -118,7 +118,9 @@ class SliceViewerModel:
         """
         Check if the given workspace can multiple BinMD calls.
         """
-        return self.get_ws_type() == WS_TYPE.MDE
+        ws_type = self.get_ws_type()
+        return ws_type == WS_TYPE.MDE or (ws_type == WS_TYPE.MDH
+                                          and self._get_ws().hasOriginalWorkspace(0))
 
     def get_ws_name(self) -> str:
         """Return the name of the workspace being viewed"""
@@ -135,30 +137,20 @@ class SliceViewerModel:
 
     def get_ws_MDE(self,
                    slicepoint: Sequence[Optional[float]],
-                   bin_params: Sequence[float],
+                   bin_params: Optional[Sequence[float]],
                    limits: Optional[tuple] = None):
         """
         :param slicepoint: ND sequence of either None or float. A float defines the point
                         in that dimension for the slice.
-        :param bin_params: ND sequence containing the number of bins for each dimension
+        :param bin_params: ND sequence containing the number of bins for each dimension or None to use
+                           the existing data
         :param limits: An optional 2-tuple sequence containing limits for plotting dimensions. If
                        not provided the full extent of each dimension is used
         """
         workspace = self._get_ws()
-        dim_limits = _dimension_limits(workspace, slicepoint, limits)
-        params = {'EnableLogging': LOG_GET_WS_MDE_ALGORITHM_CALLS}
-        for n in range(workspace.getNumDims()):
-            dimension = workspace.getDimension(n)
-            slice_pt = slicepoint[n]
-            nbins = bin_params[n]
-            if slice_pt is None:
-                dim_min, dim_max = dim_limits[n]
-            else:
-                dim_min, dim_max = slice_pt - nbins / 2, slice_pt + nbins / 2
-                nbins = 1
-            params[f'AlignedDim{n}'] = f'{dimension.name},{dim_min},{dim_max},{nbins}'
-
-        return BinMD(InputWorkspace=self._get_ws(), OutputWorkspace=self._rebinned_name, **params)
+        params, _, __ = _roi_binmd_parameters(workspace, slicepoint, bin_params, limits)
+        params['EnableLogging'] = LOG_GET_WS_MDE_ALGORITHM_CALLS
+        return BinMD(InputWorkspace=workspace, OutputWorkspace=self._rebinned_name, **params)
 
     def get_data_MDH(self, slicepoint, transpose=False):
         indices, _ = get_indices(self.get_ws(), slicepoint=slicepoint)
@@ -197,7 +189,8 @@ class SliceViewerModel:
 
     def get_dim_info(self, n: int) -> dict:
         """
-        returns dict of (minimum, maximun, number_of_bins, width, name, units) for dimension n
+        returns dict of (minimum :float, maximum :float, number_of_bins :int,
+                         width :float, name :str, units :str, type :str, has_original: bool, qdim: bool) for dimension n
         """
         workspace = self._get_ws()
         dim = workspace.getDimension(n)
@@ -209,6 +202,7 @@ class SliceViewerModel:
             'name': dim.name,
             'units': dim.getUnits(),
             'type': self.get_ws_type().name,
+            'has_original': workspace.hasOriginalWorkspace(0),
             'qdim': dim.getMDFrame().isQ()
         }
 
@@ -503,7 +497,8 @@ class SliceViewerModel:
 
 # private functions
 def _roi_binmd_parameters(workspace, slicepoint: Sequence[Optional[float]],
-                          bin_params: Optional[Sequence[float]], limits: tuple):
+                          bin_params: Optional[Sequence[float]],
+                          limits: tuple) -> Tuple[dict, int, int]:
     """
     Return a sequence of 2-tuples defining the limits for MDEventWorkspace binning
     :param workspace: MDEventWorkspace that is to be binned
@@ -512,6 +507,7 @@ def _roi_binmd_parameters(workspace, slicepoint: Sequence[Optional[float]],
     :param bin_params: A list of binning paramaters for each dimension or thickness for slicing dimensions
     :param limits: An optional Sequence of length 2 containing limits for plotting dimensions. If
                     not provided the full extent of each dimension is used.
+    :return: 3-tuple (binmd parameters, index of X dimension, index of Y dimension)
     """
     xindex, yindex = _display_indices(slicepoint)
     dim_limits = _dimension_limits(workspace, slicepoint, limits)
@@ -541,7 +537,7 @@ def _roi_binmd_parameters(workspace, slicepoint: Sequence[Optional[float]],
 
 def _dimension_limits(workspace,
                       slicepoint: Sequence[Optional[float]],
-                      limits: Optional[Sequence[tuple]] = None):
+                      limits: Optional[Sequence[tuple]] = None) -> Sequence[tuple]:
     """
     Return a sequence of 2-tuples defining the limits for MDEventWorkspace binning
     :param workspace: MDEventWorkspace that is to be binned
@@ -558,6 +554,16 @@ def _dimension_limits(workspace,
         dim_limits[yindex] = limits[1]
 
     return dim_limits
+
+
+def _dimension_bins(workspace) -> Sequence[float]:
+    """
+    Given a workspace return a sequence of float containing the number of bins
+    in each dimension
+    :param workspace: A reference to an MDHistoWorkspace
+    :return: A sequence of floats
+    """
+    return [workspace.getDimension(i).getNBins() for i in range(workspace.getNumDims())]
 
 
 def _display_indices(slicepoint: Sequence[Optional[float]], transpose: bool = False):

--- a/qt/python/mantidqt/widgets/sliceviewer/peaksviewer/representation/alpha.py
+++ b/qt/python/mantidqt/widgets/sliceviewer/peaksviewer/representation/alpha.py
@@ -13,6 +13,8 @@ VIEW_FRACTION = 0.015
 
 def compute_alpha(z, slicepoint, slicedim_width):
     """Calculate the alpha value based on the peak position and slicepoint
+    If a value cannot be computed, for zero dimension width for example, then
+    ALPHA_MAX is returned
     :param z: Z position of center out of slice plane
     :param slicepoint: float giving current slice point
     :param slicedim_width:
@@ -20,6 +22,9 @@ def compute_alpha(z, slicepoint, slicedim_width):
     """
     # Apply a linear transform to convert from a distance to an opacity between
     # alpha min & max
-    gradient = (ALPHA_MIN - ALPHA_MAX) / (slicedim_width * VIEW_FRACTION)
-    distance = abs(slicepoint - z)
-    return (gradient * distance) + ALPHA_MAX
+    try:
+        gradient = (ALPHA_MIN - ALPHA_MAX) / (slicedim_width * VIEW_FRACTION)
+        distance = abs(slicepoint - z)
+        return (gradient * distance) + ALPHA_MAX
+    except ArithmeticError:
+        return ALPHA_MAX

--- a/qt/python/mantidqt/widgets/sliceviewer/peaksviewer/representation/painter.py
+++ b/qt/python/mantidqt/widgets/sliceviewer/peaksviewer/representation/painter.py
@@ -12,8 +12,10 @@ from matplotlib.patches import Circle, Ellipse, Patch, PathPatch, Wedge
 from matplotlib.transforms import Affine2D, IdentityTransform
 import numpy as np
 
-# constants
+# Pad the zoom view by this extra fraction of the view width
 ZOOM_PAD_FRAC = 0.2
+# Minimum padding in case the view width is very small. This is quite arbitrary.
+MIN_PAD = 0.05
 
 
 class EllipticalShell(Patch):
@@ -210,5 +212,5 @@ class Painted(object):
         # pad by fraction of maximum width so the artist is still in the center
         xl, xr = ll[0], ur[0]
         yb, yt = ll[1], ur[1]
-        padding = max(xr - xl, yt - yb) * ZOOM_PAD_FRAC
+        padding = max(max(xr - xl, yt - yb) * ZOOM_PAD_FRAC, MIN_PAD)
         return ((xl - padding, xr + padding), (yb - padding, yt + padding))

--- a/qt/python/mantidqt/widgets/sliceviewer/peaksviewer/representation/test/test_peaksviewer_representation_alpha.py
+++ b/qt/python/mantidqt/widgets/sliceviewer/peaksviewer/representation/test/test_peaksviewer_representation_alpha.py
@@ -35,6 +35,13 @@ class AlphaTest(unittest.TestCase):
 
         self.assertTrue(alpha < 0)
 
+    def test_compute_alpha_with_zero_width_returns_max_value(self):
+        peak_center_z, slice_pt, slicedim_width = 1.8, 1, 0
+
+        alpha = compute_alpha(peak_center_z, slice_pt, slicedim_width)
+
+        self.assertAlmostEqual(ALPHA_MAX, alpha)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/qt/python/mantidqt/widgets/sliceviewer/presenter.py
+++ b/qt/python/mantidqt/widgets/sliceviewer/presenter.py
@@ -261,7 +261,7 @@ class SliceViewer(object):
                                                    transpose=data_view.dimensions.transpose))
         except Exception as exc:
             self._logger.error(str(exc))
-            self._show_status_message(f"Error exporting ROI")
+            self._show_status_message("Error exporting ROI")
 
     def export_cut(self, limits, cut_type):
         """Notify that an roi has been selected for export to a workspace
@@ -281,7 +281,7 @@ class SliceViewer(object):
                     cut=cut_type))
         except Exception as exc:
             self._logger.error(str(exc))
-            self._show_status_message(f"Error exporting roi cut")
+            self._show_status_message("Error exporting roi cut")
 
     def export_pixel_cut(self, pos, axis):
         """Notify a single pixel line plot has been requested from the
@@ -301,7 +301,7 @@ class SliceViewer(object):
                     axis=axis))
         except Exception as exc:
             self._logger.error(str(exc))
-            self._show_status_message(f"Error exporting single-pixel cut")
+            self._show_status_message("Error exporting single-pixel cut")
 
     def nonorthogonal_axes(self, state: bool):
         """

--- a/qt/python/mantidqt/widgets/sliceviewer/presenter.py
+++ b/qt/python/mantidqt/widgets/sliceviewer/presenter.py
@@ -47,7 +47,8 @@ class SliceViewer(object):
         self.normalization = False
 
         self.view = view if view else SliceViewerView(self, self.model.get_dimensions_info(),
-                                                      self.model.can_normalize_workspace(), parent, conf)
+                                                      self.model.can_normalize_workspace(), parent,
+                                                      conf)
         self.view.data_view.create_axes_orthogonal(
             redraw_on_zoom=not self.model.can_support_dynamic_rebinning())
         self.view.data_view.image_info_widget.setWorkspace(ws)
@@ -70,8 +71,14 @@ class SliceViewer(object):
         """
         Tell the view to display a new plot of an MDHistoWorkspace
         """
-        self.view.data_view.plot_MDH(self.model.get_ws(), slicepoint=self.get_slicepoint())
-        self._call_peaks_presenter_if_created("notify", PeaksViewerPresenter.Event.OverlayPeaks)
+        data_view = self.view.data_view
+        limits = data_view.get_axes_limits()
+
+        if limits is None or not self.model.can_support_dynamic_rebinning():
+            data_view.plot_MDH(self.model.get_ws(), slicepoint=self.get_slicepoint())
+            self._call_peaks_presenter_if_created("notify", PeaksViewerPresenter.Event.OverlayPeaks)
+        else:
+            self.new_plot_MDE()
 
     def new_plot_MDE(self):
         """
@@ -95,10 +102,9 @@ class SliceViewer(object):
                 limits = xlim, ylim
 
         data_view.plot_MDH(
-            self.model.get_ws(
-                slicepoint=self.get_slicepoint(),
-                bin_params=data_view.dimensions.get_bin_params(),
-                limits=limits))
+            self.model.get_ws_MDE(slicepoint=self.get_slicepoint(),
+                                  bin_params=data_view.dimensions.get_bin_params(),
+                                  limits=limits))
         self._call_peaks_presenter_if_created("notify", PeaksViewerPresenter.Event.OverlayPeaks)
 
     def new_plot_matrix(self):
@@ -110,8 +116,8 @@ class SliceViewer(object):
         Update the view to display an updated MDHistoWorkspace slice/cut
         """
         self.view.data_view.update_plot_data(
-            self.model.get_data(
-                self.get_slicepoint(), transpose=self.view.data_view.dimensions.transpose))
+            self.model.get_data(self.get_slicepoint(),
+                                transpose=self.view.data_view.dimensions.transpose))
 
     def update_plot_data_MDE(self):
         """
@@ -119,11 +125,10 @@ class SliceViewer(object):
         """
         data_view = self.view.data_view
         data_view.update_plot_data(
-            self.model.get_data(
-                self.get_slicepoint(),
-                bin_params=data_view.dimensions.get_bin_params(),
-                limits=data_view.get_axes_limits(),
-                transpose=self.view.data_view.dimensions.transpose))
+            self.model.get_data(self.get_slicepoint(),
+                                bin_params=data_view.dimensions.get_bin_params(),
+                                limits=data_view.get_axes_limits(),
+                                transpose=self.view.data_view.dimensions.transpose))
 
     def update_plot_data_matrix(self):
         # should never be called, since this workspace type is only 2D the plot dimensions never change
@@ -250,11 +255,10 @@ class SliceViewer(object):
 
         try:
             self._show_status_message(
-                self.model.export_roi_to_workspace(
-                    self.get_slicepoint(),
-                    bin_params=data_view.dimensions.get_bin_params(),
-                    limits=limits,
-                    transpose=data_view.dimensions.transpose))
+                self.model.export_roi_to_workspace(self.get_slicepoint(),
+                                                   bin_params=data_view.dimensions.get_bin_params(),
+                                                   limits=limits,
+                                                   transpose=data_view.dimensions.transpose))
         except Exception as exc:
             self._logger.error(str(exc))
             self._show_status_message(f"Error exporting ROI")

--- a/qt/python/mantidqt/widgets/sliceviewer/test/test_sliceviewer_model.py
+++ b/qt/python/mantidqt/widgets/sliceviewer/test/test_sliceviewer_model.py
@@ -41,7 +41,7 @@ def _create_mock_histoworkspace(ndims: int, coords: SpecialCoordinateSystem, ext
     ws = _create_mock_workspace(IMDHistoWorkspace, coords, has_oriented_lattice=False, ndims=ndims)
     ws.getSignalArray.return_value = signal
     ws.getErrorSquaredArray.return_value = error
-    ws.hasOriginalWorkspace.return_value = False
+    ws.hasOriginalWorkspace.side_effect = lambda index: False
     return _add_dimensions(ws, names, isq, extents, nbins, units)
 
 
@@ -53,11 +53,9 @@ def _attach_as_original(histo_ws, mde_ws):
     :param histo_ws: A mock MDHistoWorkspace
     :param mde_ws: A mock MDEventWorkspace
     """
-    histo_ws.hasOriginalWorkspace.return_value = True
-    histo_ws.getOriginalWorkspace.return_value = mde_ws
+    histo_ws.hasOriginalWorkspace.side_effect = lambda index: True
     yield
-    histo_ws.hasOriginalWorkspace.return_value = False
-    histo_ws.getOriginalWorkspace.return_value = MagicMock()
+    histo_ws.hasOriginalWorkspace.side_effect = lambda index: False
 
 
 def _create_mock_mdeventworkspace(ndims: int, coords: SpecialCoordinateSystem, extents: tuple,
@@ -281,12 +279,16 @@ class SliceViewerModelTest(unittest.TestCase):
         mock_binmd.return_value = self.ws_MD_3D
 
         self.assertNotEqual(model.get_ws((None, None, 0), (1, 2, 4)), self.ws_MDE_3D)
-        mock_binmd.assert_called_once_with(InputWorkspace=self.ws_MDE_3D,
-                                           OutputWorkspace='ws_MDE_3D_svrebinned',
-                                           AlignedDim0='h,-3,3,1',
-                                           AlignedDim1='k,-4,4,2',
-                                           AlignedDim2='l,-2.0,2.0,1',
-                                           EnableLogging=False)
+
+        mock_binmd.assert_called_once_with(AxisAligned=False,
+                                           BasisVector0='h,rlu,1.0,0.0,0.0',
+                                           BasisVector1='k,rlu,0.0,1.0,0.0',
+                                           BasisVector2='l,rlu,0.0,0.0,1.0',
+                                           EnableLogging=False,
+                                           InputWorkspace=self.ws_MDE_3D,
+                                           OutputBins=[1, 2, 1],
+                                           OutputExtents=[-3, 3, -4, 4, -2.0, 2.0],
+                                           OutputWorkspace='ws_MDE_3D_svrebinned')
         mock_binmd.reset_mock()
         self.assertEqual(model._get_ws(), self.ws_MDE_3D)
         self.assertEqual(model.get_ws_type(), WS_TYPE.MDE)
@@ -321,12 +323,16 @@ class SliceViewerModelTest(unittest.TestCase):
 
         self.assertNotEqual(model.get_ws((None, None, 0), (1, 2, 4), ((-2, 2), (-1, 1))),
                             self.ws_MDE_3D)
-        call_params = dict(InputWorkspace=self.ws_MDE_3D,
-                           OutputWorkspace='ws_MDE_3D_svrebinned',
-                           AlignedDim0='h,-2,2,1',
-                           AlignedDim1='k,-1,1,2',
-                           AlignedDim2='l,-2.0,2.0,1',
-                           EnableLogging=False)
+
+        call_params = dict(AxisAligned=False,
+                           BasisVector0='h,rlu,1.0,0.0,0.0',
+                           BasisVector1='k,rlu,0.0,1.0,0.0',
+                           BasisVector2='l,rlu,0.0,0.0,1.0',
+                           EnableLogging=False,
+                           InputWorkspace=self.ws_MDE_3D,
+                           OutputBins=[1, 2, 1],
+                           OutputExtents=[-2, 2, -1, 1, -2.0, 2.0],
+                           OutputWorkspace='ws_MDE_3D_svrebinned')
         mock_binmd.assert_called_once_with(**call_params)
         mock_binmd.reset_mock()
 
@@ -490,8 +496,8 @@ class SliceViewerModelTest(unittest.TestCase):
                                                 IMDEventWorkspace,
                                                 has_original_workspace=False)
 
-    def test_mdhistoworkspace_does_not_support_dynamic_rebinning(self):
-        self._assert_supports_dynamic_rebinning(False,
+    def test_mdhistoworkspace_supports_dynamic_rebinning_if_original_exists(self):
+        self._assert_supports_dynamic_rebinning(True,
                                                 IMDHistoWorkspace,
                                                 has_original_workspace=True)
         self._assert_supports_dynamic_rebinning(False,
@@ -861,11 +867,9 @@ class SliceViewerModelTest(unittest.TestCase):
                                     has_oriented_lattice=False,
                                     ndims=3)
         if ws_type == MatrixWorkspace:
-            ws.hasOriginalWorkspace.return_value = False
+            ws.hasOriginalWorkspace.side_effect = lambda index: False
         elif has_original_workspace is not None:
-            ws.hasOriginalWorkspace.return_value = has_original_workspace
-            if has_original_workspace:
-                ws.getOriginalWorkspace.return_value = self.ws_MDE_3D
+            ws.hasOriginalWorkspace.side_effect = lambda index: has_original_workspace
         model = SliceViewerModel(ws)
         self.assertEqual(expectation, model.can_support_dynamic_rebinning())
 

--- a/qt/python/mantidqt/widgets/sliceviewer/test/test_sliceviewer_presenter.py
+++ b/qt/python/mantidqt/widgets/sliceviewer/test/test_sliceviewer_presenter.py
@@ -104,7 +104,7 @@ class SliceViewerTest(unittest.TestCase):
 
         # setup calls
         self.assertEqual(self.model.get_dimensions_info.call_count, 0)
-        self.assertEqual(self.model.get_ws.call_count, 1)
+        self.assertEqual(self.model.get_ws_MDE.call_count, 1)
         self.assertEqual(self.view.data_view.dimensions.get_slicepoint.call_count, 1)
         self.assertEqual(self.view.data_view.dimensions.get_bin_params.call_count, 1)
         self.assertEqual(self.view.data_view.plot_MDH.call_count, 1)
@@ -113,7 +113,7 @@ class SliceViewerTest(unittest.TestCase):
         self.model.reset_mock()
         self.view.reset_mock()
         presenter.new_plot()
-        self.assertEqual(self.model.get_ws.call_count, 1)
+        self.assertEqual(self.model.get_ws_MDE.call_count, 1)
         self.assertEqual(self.view.data_view.dimensions.get_slicepoint.call_count, 1)
         self.assertEqual(self.view.data_view.dimensions.get_bin_params.call_count, 1)
         self.assertEqual(self.view.data_view.plot_MDH.call_count, 1)
@@ -152,8 +152,7 @@ class SliceViewerTest(unittest.TestCase):
 
         presenter = SliceViewer(None, model=self.model, view=self.view)
         presenter.normalization_changed("By bin width")
-        self.view.data_view.plot_matrix.assert_called_with(
-            self.model.get_ws(), distribution=False)
+        self.view.data_view.plot_matrix.assert_called_with(self.model.get_ws(), distribution=False)
 
     def peaks_button_disabled_if_model_cannot_support_it(self):
         self.model.get_ws_type = mock.Mock(return_value=WS_TYPE.MATRIX)
@@ -192,12 +191,11 @@ class SliceViewerTest(unittest.TestCase):
     @mock.patch("mantidqt.widgets.sliceviewer.presenter.SliceInfo")
     def test_non_orthogonal_axes_toggled_off(self, mock_sliceinfo_cls):
         self.model.get_ws_type = mock.Mock(return_value=WS_TYPE.MDE)
-        presenter, data_view_mock = _create_presenter(
-            self.model,
-            self.view,
-            mock_sliceinfo_cls,
-            enable_nonortho_axes=True,
-            supports_nonortho=True)
+        presenter, data_view_mock = _create_presenter(self.model,
+                                                      self.view,
+                                                      mock_sliceinfo_cls,
+                                                      enable_nonortho_axes=True,
+                                                      supports_nonortho=True)
 
         data_view_mock.plot_MDH.reset_mock()  # clear initial plot call
         data_view_mock.create_axes_orthogonal.reset_mock()
@@ -248,12 +246,11 @@ class SliceViewerTest(unittest.TestCase):
     @mock.patch("mantidqt.widgets.sliceviewer.presenter.SliceInfo")
     def test_changing_dimensions_in_nonortho_mode_switches_to_ortho_when_dim_not_Q(
             self, mock_sliceinfo_cls):
-        presenter, data_view_mock = _create_presenter(
-            self.model,
-            self.view,
-            mock_sliceinfo_cls,
-            enable_nonortho_axes=True,
-            supports_nonortho=False)
+        presenter, data_view_mock = _create_presenter(self.model,
+                                                      self.view,
+                                                      mock_sliceinfo_cls,
+                                                      enable_nonortho_axes=True,
+                                                      supports_nonortho=False)
 
         presenter.dimensions_changed()
 
@@ -264,12 +261,11 @@ class SliceViewerTest(unittest.TestCase):
     @mock.patch("mantidqt.widgets.sliceviewer.presenter.SliceInfo")
     def test_changing_dimensions_in_nonortho_mode_keeps_nonortho_when_dim_is_Q(
             self, mock_sliceinfo_cls):
-        presenter, data_view_mock = _create_presenter(
-            self.model,
-            self.view,
-            mock_sliceinfo_cls,
-            enable_nonortho_axes=True,
-            supports_nonortho=True)
+        presenter, data_view_mock = _create_presenter(self.model,
+                                                      self.view,
+                                                      mock_sliceinfo_cls,
+                                                      enable_nonortho_axes=True,
+                                                      supports_nonortho=True)
 
         presenter.dimensions_changed()
 
@@ -280,12 +276,11 @@ class SliceViewerTest(unittest.TestCase):
     @mock.patch("mantidqt.widgets.sliceviewer.presenter.SliceInfo")
     def test_changing_dimensions_in_ortho_mode_disables_nonortho_btn_if_not_supported(
             self, mock_sliceinfo_cls):
-        presenter, data_view_mock = _create_presenter(
-            self.model,
-            self.view,
-            mock_sliceinfo_cls,
-            enable_nonortho_axes=False,
-            supports_nonortho=False)
+        presenter, data_view_mock = _create_presenter(self.model,
+                                                      self.view,
+                                                      mock_sliceinfo_cls,
+                                                      enable_nonortho_axes=False,
+                                                      supports_nonortho=False)
 
         presenter.dimensions_changed()
 
@@ -294,21 +289,19 @@ class SliceViewerTest(unittest.TestCase):
     @mock.patch("mantidqt.widgets.sliceviewer.presenter.SliceInfo")
     def test_changing_dimensions_in_ortho_mode_enables_nonortho_btn_if_supported(
             self, mock_sliceinfo_cls):
-        presenter, data_view_mock = _create_presenter(
-            self.model,
-            self.view,
-            mock_sliceinfo_cls,
-            enable_nonortho_axes=False,
-            supports_nonortho=True)
+        presenter, data_view_mock = _create_presenter(self.model,
+                                                      self.view,
+                                                      mock_sliceinfo_cls,
+                                                      enable_nonortho_axes=False,
+                                                      supports_nonortho=True)
 
         presenter.dimensions_changed()
 
         data_view_mock.enable_tool_button.assert_called_once_with(ToolItemText.NONORTHOGONAL_AXES)
 
     @mock.patch("mantidqt.widgets.sliceviewer.peaksviewer.presenter.TableWorkspaceDataPresenter")
-    @mock.patch(
-        "mantidqt.widgets.sliceviewer.presenter.PeaksViewerCollectionPresenter",
-        spec=PeaksViewerCollectionPresenter)
+    @mock.patch("mantidqt.widgets.sliceviewer.presenter.PeaksViewerCollectionPresenter",
+                spec=PeaksViewerCollectionPresenter)
     def test_overlay_peaks_workspaces_attaches_view_and_draws_peaks(self, mock_peaks_presenter, _):
         for nonortho_axes in (False, True):
             presenter, _ = _create_presenter(self.model, self.view, mock.MagicMock(), nonortho_axes,


### PR DESCRIPTION
**Description of work.**

When an MDHistoWorkspace has an attached original workspace then
the rebinning boxes will now be displayed and the binning will take place
from the original workspace. The image will also be dynamically binned as
users zoom.

**To test:**

Use the non-axis-aligned example in the [BinMD](https://docs.mantidproject.org/nightly/algorithms/BinMD-v1.html#usage) docs to produce an MDHistoWorkspace from an MDEventWorkspace. View it in the sliceviewer. It should look like the image on the page with the exception of using a different colormap. As long as the original workspace is present then zooming should dynamically rebin the workspace to the current limits.

Fixes #29086

<!-- Ensure the base of this PR is correct (e.g. release-next or master)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
