### PR TITLE
Fix workbench crashes when deleting peaks from IPeaksTable

### DIFF
--- a/docs/source/release/v6.0.0/mantidworkbench.rst
+++ b/docs/source/release/v6.0.0/mantidworkbench.rst
@@ -14,5 +14,6 @@ Bugfixes
 ########
 
 - Only display slice viewer widget for MDEventWorkspaces with 2 or more dimensions.
+- Fix Workbench crashes upon deleting rows or columns in a TableWorkspace.
 
 :ref:`Release 6.0.0 <v6.0.0>`

--- a/qt/python/mantidqt/widgets/workspacedisplay/table/presenter.py
+++ b/qt/python/mantidqt/widgets/workspacedisplay/table/presenter.py
@@ -180,8 +180,11 @@ class TableWorkspaceDisplay(TableWorkspaceDataPresenter, ObservingPresenter, Dat
         :type item: A reference to the item that has been edited
         """
         try:
-            self.model.set_cell_data(item.row(), item.column(), item.data(Qt.DisplayRole),
-                                     item.is_v3d)
+            if self.is_peaks_worksapce:
+                self.model.set_cell_data(item.row(), item.column(), item.data(Qt.DisplayRole), False)
+            else:
+                self.model.set_cell_data(item.row(), item.column(), item.data(Qt.DisplayRole),
+                                        item.is_v3d)
         except ValueError:
             item.reset()
             self.view.show_warning(self.ITEM_CHANGED_INVALID_DATA_MESSAGE)
@@ -189,7 +192,8 @@ class TableWorkspaceDisplay(TableWorkspaceDataPresenter, ObservingPresenter, Dat
             item.reset()
             self.view.show_warning(self.ITEM_CHANGED_UNKNOWN_ERROR_MESSAGE.format(x))
         else:
-            item.sync()
+            if not self.is_peaks_worksapce:
+                item.sync()
 
     def action_copy_cells(self):
         self.copy_cells(self.view)

--- a/qt/python/mantidqt/widgets/workspacedisplay/table/presenter.py
+++ b/qt/python/mantidqt/widgets/workspacedisplay/table/presenter.py
@@ -22,6 +22,7 @@ from mantidqt.widgets.workspacedisplay.table.view import TableWorkspaceDisplayVi
 from mantidqt.widgets.workspacedisplay.table.tableworkspace_item import (
     QStandardItem,
     create_table_item,
+    RevertibleItem,
 )
 
 
@@ -136,9 +137,9 @@ class TableWorkspaceDisplay(TableWorkspaceDataPresenter, ObservingPresenter, Dat
         view = view if view else TableWorkspaceDisplayView(self, parent)
         TableWorkspaceDataPresenter.__init__(self, model, view)
 
-        from mantid.api import IPeaksWorkspace
+        # from mantid.api import IPeaksWorkspace
 
-        self.is_peaks_worksapce = isinstance(ws, IPeaksWorkspace)
+        # self.is_peaks_worksapce = isinstance(ws, IPeaksWorkspace)
 
         self.name = name if name else self.model.get_name()
         self.container = (container if container else StatusBarView(
@@ -190,12 +191,11 @@ class TableWorkspaceDisplay(TableWorkspaceDataPresenter, ObservingPresenter, Dat
         """
         :type item: A reference to the item that has been edited
         """
+        if not isinstance(item, RevertibleItem):
+            # Do not perform any additional task for standard QStandardItem
+            return
         try:
-            if self.is_peaks_worksapce:
-                self.model.set_cell_data(item.row(), item.column(), item.data(Qt.DisplayRole),
-                                         False)
-            else:
-                self.model.set_cell_data(item.row(), item.column(), item.data(Qt.DisplayRole),
+            self.model.set_cell_data(item.row(), item.column(), item.data(Qt.DisplayRole),
                                          item.is_v3d)
         except ValueError:
             item.reset()
@@ -204,8 +204,7 @@ class TableWorkspaceDisplay(TableWorkspaceDataPresenter, ObservingPresenter, Dat
             item.reset()
             self.view.show_warning(self.ITEM_CHANGED_UNKNOWN_ERROR_MESSAGE.format(x))
         else:
-            if not self.is_peaks_worksapce:
-                item.sync()
+            item.sync()
 
     def action_copy_cells(self):
         self.copy_cells(self.view)

--- a/qt/python/mantidqt/widgets/workspacedisplay/table/presenter.py
+++ b/qt/python/mantidqt/widgets/workspacedisplay/table/presenter.py
@@ -19,12 +19,16 @@ from mantidqt.widgets.workspacedisplay.table.error_column import ErrorColumn
 from mantidqt.widgets.workspacedisplay.table.model import TableWorkspaceDisplayModel
 from mantidqt.widgets.workspacedisplay.table.plot_type import PlotType
 from mantidqt.widgets.workspacedisplay.table.view import TableWorkspaceDisplayView
-from mantidqt.widgets.workspacedisplay.table.tableworkspace_item import QStandardItem, create_table_item
+from mantidqt.widgets.workspacedisplay.table.tableworkspace_item import (
+    QStandardItem,
+    create_table_item,
+)
 
 
 class TableWorkspaceDataPresenter(object):
     """Presenter to handle just displaying data from a table-like object.
     Useful for other widgets wishing to embed just the table display"""
+
     __slots__ = ("model", "view")
 
     def __init__(self, model=None, view=None):
@@ -72,7 +76,9 @@ class TableWorkspaceDataPresenter(object):
             column_data = self.model.get_column(col)
             editable = self.model.is_editable_column(col)
             for row in range(num_rows):
-                data_model.setItem(row, col, self.create_item(column_data[row], editable))
+                data_model.setItem(
+                    row, col, self.create_item(column_data[row], editable)
+                )
 
     def create_item(self, data, editable):
         """Create a QStandardItemModel for the data
@@ -82,35 +88,51 @@ class TableWorkspaceDataPresenter(object):
         return create_table_item(data, editable)
 
 
-class TableWorkspaceDisplay(TableWorkspaceDataPresenter, ObservingPresenter, DataCopier):
-    A_LOT_OF_THINGS_TO_PLOT_MESSAGE = "You selected {} spectra to plot. Are you sure you want to plot that many?"
-    TOO_MANY_SELECTED_FOR_X = "Too many columns are selected to use as X. Please select only 1."
-    TOO_MANY_SELECTED_TO_SORT = "Too many columns are selected to sort by. Please select only 1."
-    TOO_MANY_SELECTED_FOR_PLOT = "Too many columns are selected to plot. Please select only 1."
+class TableWorkspaceDisplay(
+    TableWorkspaceDataPresenter, ObservingPresenter, DataCopier
+):
+    A_LOT_OF_THINGS_TO_PLOT_MESSAGE = (
+        "You selected {} spectra to plot. Are you sure you want to plot that many?"
+    )
+    TOO_MANY_SELECTED_FOR_X = (
+        "Too many columns are selected to use as X. Please select only 1."
+    )
+    TOO_MANY_SELECTED_TO_SORT = (
+        "Too many columns are selected to sort by. Please select only 1."
+    )
+    TOO_MANY_SELECTED_FOR_PLOT = (
+        "Too many columns are selected to plot. Please select only 1."
+    )
     NUM_SELECTED_FOR_CONFIRMATION = 10
     NO_COLUMN_MARKED_AS_X = "No columns marked as X."
-    ITEM_CHANGED_INVALID_DATA_MESSAGE = "Error: Trying to set invalid data for the column."
+    ITEM_CHANGED_INVALID_DATA_MESSAGE = (
+        "Error: Trying to set invalid data for the column."
+    )
     ITEM_CHANGED_UNKNOWN_ERROR_MESSAGE = "Unknown error occurred: {}"
     TOO_MANY_TO_SET_AS_Y_ERR_MESSAGE = "Too many selected to set as Y Error"
     CANNOT_PLOT_AGAINST_SELF_MESSAGE = "Cannot plot column against itself."
-    NO_ASSOCIATED_YERR_FOR_EACH_Y_MESSAGE = "Column '{}' does not have an associated Y error column." \
-                                            "\n\nPlease set it by doing: Right click on column ->" \
-                                            " Set error for Y -> The label shown on the Y column"
+    NO_ASSOCIATED_YERR_FOR_EACH_Y_MESSAGE = (
+        "Column '{}' does not have an associated Y error column."
+        "\n\nPlease set it by doing: Right click on column ->"
+        " Set error for Y -> The label shown on the Y column"
+    )
     PLOT_FUNCTION_ERROR_MESSAGE = "One or more of the columns being plotted contain invalid data for Matplotlib.\n\nError message:\n{}"
     INVALID_DATA_WINDOW_TITLE = "Invalid data - Mantid Workbench"
-    COLUMN_DISPLAY_LABEL = 'Column {}'
+    COLUMN_DISPLAY_LABEL = "Column {}"
 
-    def __init__(self,
-                 ws,
-                 plot=None,
-                 parent=None,
-                 model=None,
-                 view=None,
-                 name=None,
-                 ads_observer=None,
-                 container=None,
-                 window_width=600,
-                 window_height=400):
+    def __init__(
+        self,
+        ws,
+        plot=None,
+        parent=None,
+        model=None,
+        view=None,
+        name=None,
+        ads_observer=None,
+        container=None,
+        window_width=600,
+        window_height=400,
+    ):
         """
         Creates a display for the provided workspace.
 
@@ -129,15 +151,22 @@ class TableWorkspaceDisplay(TableWorkspaceDataPresenter, ObservingPresenter, Dat
         TableWorkspaceDataPresenter.__init__(self, model, view)
 
         from mantid.api import IPeaksWorkspace
+
         self.is_peaks_worksapce = isinstance(ws, IPeaksWorkspace)
 
         self.name = name if name else self.model.get_name()
-        self.container = container if container else StatusBarView(parent,
-                                                                   self.view,
-                                                                   self.name,
-                                                                   window_width=window_width,
-                                                                   window_height=window_height,
-                                                                   presenter=self)
+        self.container = (
+            container
+            if container
+            else StatusBarView(
+                parent,
+                self.view,
+                self.name,
+                window_width=window_width,
+                window_height=window_height,
+                presenter=self,
+            )
+        )
 
         DataCopier.__init__(self, self.container.status_bar)
 
@@ -145,7 +174,9 @@ class TableWorkspaceDisplay(TableWorkspaceDataPresenter, ObservingPresenter, Dat
         self.plot = plot
         self.view.set_context_menu_actions(self.view)
 
-        self.ads_observer = ads_observer if ads_observer else WorkspaceDisplayADSObserver(self)
+        self.ads_observer = (
+            ads_observer if ads_observer else WorkspaceDisplayADSObserver(self)
+        )
 
         self.refresh()
 
@@ -181,10 +212,13 @@ class TableWorkspaceDisplay(TableWorkspaceDataPresenter, ObservingPresenter, Dat
         """
         try:
             if self.is_peaks_worksapce:
-                self.model.set_cell_data(item.row(), item.column(), item.data(Qt.DisplayRole), False)
+                self.model.set_cell_data(
+                    item.row(), item.column(), item.data(Qt.DisplayRole), False
+                )
             else:
-                self.model.set_cell_data(item.row(), item.column(), item.data(Qt.DisplayRole),
-                                        item.is_v3d)
+                self.model.set_cell_data(
+                    item.row(), item.column(), item.data(Qt.DisplayRole), item.is_v3d
+                )
         except ValueError:
             item.reset()
             self.view.show_warning(self.ITEM_CHANGED_INVALID_DATA_MESSAGE)
@@ -249,9 +283,9 @@ class TableWorkspaceDisplay(TableWorkspaceDataPresenter, ObservingPresenter, Dat
             return
 
         stats = self.model.get_statistics(selected_columns)
-        TableWorkspaceDisplay(stats,
-                              parent=self.parent,
-                              name="Column Statistics of {}".format(self.name))
+        TableWorkspaceDisplay(
+            stats, parent=self.parent, name="Column Statistics of {}".format(self.name)
+        )
 
     def action_hide_selected(self):
         try:
@@ -291,7 +325,9 @@ class TableWorkspaceDisplay(TableWorkspaceDataPresenter, ObservingPresenter, Dat
                             This will be the number in <ColumnName>[Y10] -> the 10
         """
         try:
-            selected_column = self._get_selected_columns(1, self.TOO_MANY_TO_SET_AS_Y_ERR_MESSAGE)
+            selected_column = self._get_selected_columns(
+                1, self.TOO_MANY_TO_SET_AS_Y_ERR_MESSAGE
+            )
         except ValueError:
             return
 
@@ -319,7 +355,9 @@ class TableWorkspaceDisplay(TableWorkspaceDataPresenter, ObservingPresenter, Dat
         :param sort_ascending: Whether to sort ascending
         """
         try:
-            selected_column = self._get_selected_columns(1, self.TOO_MANY_SELECTED_TO_SORT)
+            selected_column = self._get_selected_columns(
+                1, self.TOO_MANY_SELECTED_TO_SORT
+            )
         except ValueError:
             return
 
@@ -331,7 +369,9 @@ class TableWorkspaceDisplay(TableWorkspaceDataPresenter, ObservingPresenter, Dat
         except ValueError:
             return
 
-        x_cols = list(set(selected_columns).intersection(self.model.marked_columns.as_x))
+        x_cols = list(
+            set(selected_columns).intersection(self.model.marked_columns.as_x)
+        )
         num_x_cols = len(x_cols)
         # if there is more than 1 column marked as X in the selection
         # -> show toast to the user and do nothing
@@ -365,7 +405,10 @@ class TableWorkspaceDisplay(TableWorkspaceDataPresenter, ObservingPresenter, Dat
         self._do_plot(selected_columns, selected_x, plot_type)
 
     def _is_error_plot(self, plot_type):
-        return plot_type == PlotType.LINEAR_WITH_ERR or plot_type == PlotType.SCATTER_WITH_ERR
+        return (
+            plot_type == PlotType.LINEAR_WITH_ERR
+            or plot_type == PlotType.SCATTER_WITH_ERR
+        )
 
     def _do_plot(self, selected_columns, selected_x, plot_type):
         if self._is_error_plot(plot_type):
@@ -381,12 +424,14 @@ class TableWorkspaceDisplay(TableWorkspaceDataPresenter, ObservingPresenter, Dat
             if len(yerr) != len(selected_columns):
                 column_headers = self.model.original_column_headers()
                 self.view.show_warning(
-                    self.NO_ASSOCIATED_YERR_FOR_EACH_Y_MESSAGE.format(",".join(
-                        [column_headers[col] for col in selected_columns])))
+                    self.NO_ASSOCIATED_YERR_FOR_EACH_Y_MESSAGE.format(
+                        ",".join([column_headers[col] for col in selected_columns])
+                    )
+                )
                 return
         x = self.model.get_column(selected_x)
 
-        fig, ax = self.plot.subplots(subplot_kw={'projection': 'mantid'})
+        fig, ax = self.plot.subplots(subplot_kw={"projection": "mantid"})
         fig.canvas.set_window_title(self.model.get_name())
         ax.set_xlabel(self.model.get_column_header(selected_x))
         ax.wsName = self.model.get_name()
@@ -403,7 +448,9 @@ class TableWorkspaceDisplay(TableWorkspaceDataPresenter, ObservingPresenter, Dat
             y = self.model.get_column(column)
             column_label = self.model.get_column_header(column)
             try:
-                plot_func(x, y, label=self.COLUMN_DISPLAY_LABEL.format(column_label), **kwargs)
+                plot_func(
+                    x, y, label=self.COLUMN_DISPLAY_LABEL.format(column_label), **kwargs
+                )
             except ValueError as e:
                 error_message = self.PLOT_FUNCTION_ERROR_MESSAGE.format(e)
                 logger.error(error_message)
@@ -420,11 +467,11 @@ class TableWorkspaceDisplay(TableWorkspaceDataPresenter, ObservingPresenter, Dat
         elif type == PlotType.SCATTER:
             plot_func = ax.scatter
         elif type == PlotType.LINE_AND_SYMBOL:
-            plot_func = partial(ax.plot, marker='o')
+            plot_func = partial(ax.plot, marker="o")
         elif type == PlotType.LINEAR_WITH_ERR:
             plot_func = ax.errorbar
         elif type == PlotType.SCATTER_WITH_ERR:
-            plot_func = partial(ax.errorbar, fmt='o')
+            plot_func = partial(ax.errorbar, fmt="o")
         else:
             raise ValueError("Plot Type: {} not currently supported!".format(type))
         return plot_func

--- a/qt/python/mantidqt/widgets/workspacedisplay/table/presenter.py
+++ b/qt/python/mantidqt/widgets/workspacedisplay/table/presenter.py
@@ -76,9 +76,7 @@ class TableWorkspaceDataPresenter(object):
             column_data = self.model.get_column(col)
             editable = self.model.is_editable_column(col)
             for row in range(num_rows):
-                data_model.setItem(
-                    row, col, self.create_item(column_data[row], editable)
-                )
+                data_model.setItem(row, col, self.create_item(column_data[row], editable))
 
     def create_item(self, data, editable):
         """Create a QStandardItemModel for the data
@@ -88,50 +86,38 @@ class TableWorkspaceDataPresenter(object):
         return create_table_item(data, editable)
 
 
-class TableWorkspaceDisplay(
-    TableWorkspaceDataPresenter, ObservingPresenter, DataCopier
-):
+class TableWorkspaceDisplay(TableWorkspaceDataPresenter, ObservingPresenter, DataCopier):
     A_LOT_OF_THINGS_TO_PLOT_MESSAGE = (
-        "You selected {} spectra to plot. Are you sure you want to plot that many?"
-    )
-    TOO_MANY_SELECTED_FOR_X = (
-        "Too many columns are selected to use as X. Please select only 1."
-    )
-    TOO_MANY_SELECTED_TO_SORT = (
-        "Too many columns are selected to sort by. Please select only 1."
-    )
-    TOO_MANY_SELECTED_FOR_PLOT = (
-        "Too many columns are selected to plot. Please select only 1."
-    )
+        "You selected {} spectra to plot. Are you sure you want to plot that many?")
+    TOO_MANY_SELECTED_FOR_X = ("Too many columns are selected to use as X. Please select only 1.")
+    TOO_MANY_SELECTED_TO_SORT = ("Too many columns are selected to sort by. Please select only 1.")
+    TOO_MANY_SELECTED_FOR_PLOT = ("Too many columns are selected to plot. Please select only 1.")
     NUM_SELECTED_FOR_CONFIRMATION = 10
     NO_COLUMN_MARKED_AS_X = "No columns marked as X."
-    ITEM_CHANGED_INVALID_DATA_MESSAGE = (
-        "Error: Trying to set invalid data for the column."
-    )
+    ITEM_CHANGED_INVALID_DATA_MESSAGE = ("Error: Trying to set invalid data for the column.")
     ITEM_CHANGED_UNKNOWN_ERROR_MESSAGE = "Unknown error occurred: {}"
     TOO_MANY_TO_SET_AS_Y_ERR_MESSAGE = "Too many selected to set as Y Error"
     CANNOT_PLOT_AGAINST_SELF_MESSAGE = "Cannot plot column against itself."
     NO_ASSOCIATED_YERR_FOR_EACH_Y_MESSAGE = (
         "Column '{}' does not have an associated Y error column."
         "\n\nPlease set it by doing: Right click on column ->"
-        " Set error for Y -> The label shown on the Y column"
-    )
+        " Set error for Y -> The label shown on the Y column")
     PLOT_FUNCTION_ERROR_MESSAGE = "One or more of the columns being plotted contain invalid data for Matplotlib.\n\nError message:\n{}"
     INVALID_DATA_WINDOW_TITLE = "Invalid data - Mantid Workbench"
     COLUMN_DISPLAY_LABEL = "Column {}"
 
     def __init__(
-        self,
-        ws,
-        plot=None,
-        parent=None,
-        model=None,
-        view=None,
-        name=None,
-        ads_observer=None,
-        container=None,
-        window_width=600,
-        window_height=400,
+            self,
+            ws,
+            plot=None,
+            parent=None,
+            model=None,
+            view=None,
+            name=None,
+            ads_observer=None,
+            container=None,
+            window_width=600,
+            window_height=400,
     ):
         """
         Creates a display for the provided workspace.
@@ -155,18 +141,14 @@ class TableWorkspaceDisplay(
         self.is_peaks_worksapce = isinstance(ws, IPeaksWorkspace)
 
         self.name = name if name else self.model.get_name()
-        self.container = (
-            container
-            if container
-            else StatusBarView(
-                parent,
-                self.view,
-                self.name,
-                window_width=window_width,
-                window_height=window_height,
-                presenter=self,
-            )
-        )
+        self.container = (container if container else StatusBarView(
+            parent,
+            self.view,
+            self.name,
+            window_width=window_width,
+            window_height=window_height,
+            presenter=self,
+        ))
 
         DataCopier.__init__(self, self.container.status_bar)
 
@@ -174,9 +156,7 @@ class TableWorkspaceDisplay(
         self.plot = plot
         self.view.set_context_menu_actions(self.view)
 
-        self.ads_observer = (
-            ads_observer if ads_observer else WorkspaceDisplayADSObserver(self)
-        )
+        self.ads_observer = (ads_observer if ads_observer else WorkspaceDisplayADSObserver(self))
 
         self.refresh()
 
@@ -212,13 +192,11 @@ class TableWorkspaceDisplay(
         """
         try:
             if self.is_peaks_worksapce:
-                self.model.set_cell_data(
-                    item.row(), item.column(), item.data(Qt.DisplayRole), False
-                )
+                self.model.set_cell_data(item.row(), item.column(), item.data(Qt.DisplayRole),
+                                         False)
             else:
-                self.model.set_cell_data(
-                    item.row(), item.column(), item.data(Qt.DisplayRole), item.is_v3d
-                )
+                self.model.set_cell_data(item.row(), item.column(), item.data(Qt.DisplayRole),
+                                         item.is_v3d)
         except ValueError:
             item.reset()
             self.view.show_warning(self.ITEM_CHANGED_INVALID_DATA_MESSAGE)
@@ -283,9 +261,9 @@ class TableWorkspaceDisplay(
             return
 
         stats = self.model.get_statistics(selected_columns)
-        TableWorkspaceDisplay(
-            stats, parent=self.parent, name="Column Statistics of {}".format(self.name)
-        )
+        TableWorkspaceDisplay(stats,
+                              parent=self.parent,
+                              name="Column Statistics of {}".format(self.name))
 
     def action_hide_selected(self):
         try:
@@ -325,9 +303,7 @@ class TableWorkspaceDisplay(
                             This will be the number in <ColumnName>[Y10] -> the 10
         """
         try:
-            selected_column = self._get_selected_columns(
-                1, self.TOO_MANY_TO_SET_AS_Y_ERR_MESSAGE
-            )
+            selected_column = self._get_selected_columns(1, self.TOO_MANY_TO_SET_AS_Y_ERR_MESSAGE)
         except ValueError:
             return
 
@@ -355,9 +331,7 @@ class TableWorkspaceDisplay(
         :param sort_ascending: Whether to sort ascending
         """
         try:
-            selected_column = self._get_selected_columns(
-                1, self.TOO_MANY_SELECTED_TO_SORT
-            )
+            selected_column = self._get_selected_columns(1, self.TOO_MANY_SELECTED_TO_SORT)
         except ValueError:
             return
 
@@ -369,9 +343,7 @@ class TableWorkspaceDisplay(
         except ValueError:
             return
 
-        x_cols = list(
-            set(selected_columns).intersection(self.model.marked_columns.as_x)
-        )
+        x_cols = list(set(selected_columns).intersection(self.model.marked_columns.as_x))
         num_x_cols = len(x_cols)
         # if there is more than 1 column marked as X in the selection
         # -> show toast to the user and do nothing
@@ -405,10 +377,7 @@ class TableWorkspaceDisplay(
         self._do_plot(selected_columns, selected_x, plot_type)
 
     def _is_error_plot(self, plot_type):
-        return (
-            plot_type == PlotType.LINEAR_WITH_ERR
-            or plot_type == PlotType.SCATTER_WITH_ERR
-        )
+        return (plot_type == PlotType.LINEAR_WITH_ERR or plot_type == PlotType.SCATTER_WITH_ERR)
 
     def _do_plot(self, selected_columns, selected_x, plot_type):
         if self._is_error_plot(plot_type):
@@ -424,10 +393,8 @@ class TableWorkspaceDisplay(
             if len(yerr) != len(selected_columns):
                 column_headers = self.model.original_column_headers()
                 self.view.show_warning(
-                    self.NO_ASSOCIATED_YERR_FOR_EACH_Y_MESSAGE.format(
-                        ",".join([column_headers[col] for col in selected_columns])
-                    )
-                )
+                    self.NO_ASSOCIATED_YERR_FOR_EACH_Y_MESSAGE.format(",".join(
+                        [column_headers[col] for col in selected_columns])))
                 return
         x = self.model.get_column(selected_x)
 
@@ -448,9 +415,7 @@ class TableWorkspaceDisplay(
             y = self.model.get_column(column)
             column_label = self.model.get_column_header(column)
             try:
-                plot_func(
-                    x, y, label=self.COLUMN_DISPLAY_LABEL.format(column_label), **kwargs
-                )
+                plot_func(x, y, label=self.COLUMN_DISPLAY_LABEL.format(column_label), **kwargs)
             except ValueError as e:
                 error_message = self.PLOT_FUNCTION_ERROR_MESSAGE.format(e)
                 logger.error(error_message)

--- a/qt/python/mantidqt/widgets/workspacedisplay/table/presenter.py
+++ b/qt/python/mantidqt/widgets/workspacedisplay/table/presenter.py
@@ -128,6 +128,9 @@ class TableWorkspaceDisplay(TableWorkspaceDataPresenter, ObservingPresenter, Dat
         view = view if view else TableWorkspaceDisplayView(self, parent)
         TableWorkspaceDataPresenter.__init__(self, model, view)
 
+        from mantid.api import IPeaksWorkspace
+        self.is_peaks_worksapce = isinstance(ws, IPeaksWorkspace)
+
         self.name = name if name else self.model.get_name()
         self.container = container if container else StatusBarView(parent,
                                                                    self.view,

--- a/qt/python/mantidqt/widgets/workspacedisplay/table/presenter.py
+++ b/qt/python/mantidqt/widgets/workspacedisplay/table/presenter.py
@@ -196,7 +196,7 @@ class TableWorkspaceDisplay(TableWorkspaceDataPresenter, ObservingPresenter, Dat
             return
         try:
             self.model.set_cell_data(item.row(), item.column(), item.data(Qt.DisplayRole),
-                                         item.is_v3d)
+                                     item.is_v3d)
         except ValueError:
             item.reset()
             self.view.show_warning(self.ITEM_CHANGED_INVALID_DATA_MESSAGE)

--- a/qt/python/mantidqt/widgets/workspacedisplay/table/test/test_tableworkspacedisplay_presenter.py
+++ b/qt/python/mantidqt/widgets/workspacedisplay/table/test/test_tableworkspacedisplay_presenter.py
@@ -114,7 +114,7 @@ class TableWorkspaceDisplayPresenterTest(unittest.TestCase):
 
     @with_mock_presenter
     def test_handleItemChanged(self, ws, view, twd):
-        items = [Mock(spec=RevertibleItem) ,Mock(spec=QStandardItem)]
+        items = [Mock(spec=RevertibleItem), Mock(spec=QStandardItem)]
         for item in items:
             item.row.return_value = 5
             item.column.return_value = 5
@@ -130,7 +130,7 @@ class TableWorkspaceDisplayPresenterTest(unittest.TestCase):
 
     @with_mock_presenter
     def test_handleItemChanged_raises_ValueError(self, ws, view, twd):
-        items = [Mock(spec=RevertibleItem) ,Mock(spec=QStandardItem)]
+        items = [Mock(spec=RevertibleItem), Mock(spec=QStandardItem)]
         for item in items:
             item.row.return_value = 5
             item.column.return_value = 5
@@ -151,7 +151,7 @@ class TableWorkspaceDisplayPresenterTest(unittest.TestCase):
 
     @with_mock_presenter
     def test_handleItemChanged_raises_Exception(self, ws, view, twd):
-        items = [Mock(spec=RevertibleItem) ,Mock(spec=QStandardItem)]
+        items = [Mock(spec=RevertibleItem), Mock(spec=QStandardItem)]
         for item in items:
             item.row.return_value = ws.ROWS
             item.column.return_value = ws.COLS

--- a/qt/python/mantidqt/widgets/workspacedisplay/table/test/test_tableworkspacedisplay_presenter.py
+++ b/qt/python/mantidqt/widgets/workspacedisplay/table/test/test_tableworkspacedisplay_presenter.py
@@ -22,7 +22,7 @@ from mantidqt.widgets.workspacedisplay.table.model import TableWorkspaceDisplayM
 from mantidqt.widgets.workspacedisplay.table.plot_type import PlotType
 from mantidqt.widgets.workspacedisplay.table.presenter import TableWorkspaceDisplay
 from mantidqt.widgets.workspacedisplay.table.view import TableWorkspaceDisplayView
-from mantidqt.widgets.workspacedisplay.table.tableworkspace_item import QStandardItem
+from mantidqt.widgets.workspacedisplay.table.tableworkspace_item import QStandardItem, RevertibleItem
 
 
 class MockQTable:
@@ -114,63 +114,63 @@ class TableWorkspaceDisplayPresenterTest(unittest.TestCase):
 
     @with_mock_presenter
     def test_handleItemChanged(self, ws, view, twd):
-        item = Mock(spec=QStandardItem)
-        item.row.return_value = 5
-        item.column.return_value = 5
-        item.data.return_value = "magic parameter"
-        item.is_v3d = False
+        items = [Mock(spec=RevertibleItem) ,Mock(spec=QStandardItem)]
+        for item in items:
+            item.row.return_value = 5
+            item.column.return_value = 5
+            item.data.return_value = "magic parameter"
 
-        twd.handleItemChanged(item)
+            twd.handleItemChanged(item)
 
-        item.row.assert_called_once_with()
-        item.column.assert_called_once_with()
-        ws.setCell.assert_called_once_with(5, 5, "magic parameter", notify_replace=False)
-        item.update.assert_called_once_with()
-        item.reset.assert_called_once_with()
+            item.row.assert_called_once_with()
+            item.column.assert_called_once_with()
+            ws.setCell.assert_called_once_with(5, 5, "magic parameter", notify_replace=False)
+            item.update.assert_called_once_with()
+            item.reset.assert_called_once_with()
 
     @with_mock_presenter
     def test_handleItemChanged_raises_ValueError(self, ws, view, twd):
-        item = Mock(spec=QStandardItem)
-        item.row.return_value = 5
-        item.column.return_value = 5
-        item.data.return_value = "magic parameter"
-        item.is_v3d = False
+        items = [Mock(spec=RevertibleItem) ,Mock(spec=QStandardItem)]
+        for item in items:
+            item.row.return_value = 5
+            item.column.return_value = 5
+            item.data.return_value = "magic parameter"
 
-        # setCell will throw an exception as a side effect
-        ws.setCell.side_effect = ValueError
+            # setCell will throw an exception as a side effect
+            ws.setCell.side_effect = ValueError
 
-        twd.handleItemChanged(item)
+            twd.handleItemChanged(item)
 
-        item.row.assert_called_once_with()
-        item.column.assert_called_once_with()
-        ws.setCell.assert_called_once_with(5, 5, "magic parameter")
-        view.show_warning.assert_called_once_with(
-            TableWorkspaceDisplay.ITEM_CHANGED_INVALID_DATA_MESSAGE)
-        self.assertNotCalled(item.update)
-        item.reset.assert_called_once_with()
+            item.row.assert_called_once_with()
+            item.column.assert_called_once_with()
+            ws.setCell.assert_called_once_with(5, 5, "magic parameter")
+            view.show_warning.assert_called_once_with(
+                TableWorkspaceDisplay.ITEM_CHANGED_INVALID_DATA_MESSAGE)
+            self.assertNotCalled(item.update)
+            item.reset.assert_called_once_with()
 
     @with_mock_presenter
     def test_handleItemChanged_raises_Exception(self, ws, view, twd):
-        item = Mock(spec=QStandardItem)
+        items = [Mock(spec=RevertibleItem) ,Mock(spec=QStandardItem)]
+        for item in items:
+            item.row.return_value = ws.ROWS
+            item.column.return_value = ws.COLS
+            item.data.return_value = "magic parameter"
+            item.is_v3d = False
 
-        item.row.return_value = ws.ROWS
-        item.column.return_value = ws.COLS
-        item.data.return_value = "magic parameter"
-        item.is_v3d = False
+            # setCell will throw an exception as a side effect
+            error_message = "TEST_EXCEPTION_MESSAGE"
+            ws.setCell.side_effect = Exception(error_message)
 
-        # setCell will throw an exception as a side effect
-        error_message = "TEST_EXCEPTION_MESSAGE"
-        ws.setCell.side_effect = Exception(error_message)
+            twd.handleItemChanged(item)
 
-        twd.handleItemChanged(item)
-
-        item.row.assert_called_once_with()
-        item.column.assert_called_once_with()
-        ws.setCell.assert_called_once_with(ws.ROWS, ws.COLS, "magic parameter")
-        view.show_warning.assert_called_once_with(
-            TableWorkspaceDisplay.ITEM_CHANGED_UNKNOWN_ERROR_MESSAGE.format(error_message))
-        self.assertNotCalled(item.update)
-        item.reset.assert_called_once_with()
+            item.row.assert_called_once_with()
+            item.column.assert_called_once_with()
+            ws.setCell.assert_called_once_with(ws.ROWS, ws.COLS, "magic parameter")
+            view.show_warning.assert_called_once_with(
+                TableWorkspaceDisplay.ITEM_CHANGED_UNKNOWN_ERROR_MESSAGE.format(error_message))
+            self.assertNotCalled(item.update)
+            item.reset.assert_called_once_with()
 
     @with_mock_presenter
     def test_update_column_headers(self, ws, view, twd):


### PR DESCRIPTION
**Description**

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->
Fix the issue where Mantid workbench crashes when trying to delete a peak from IPeakTable interactively.

**To test:**
* Start MantidWorkbench
* Use LoadIsawPeaks to load a testing data set (see related issue for testing data)
* Right click on the workspace to open the context menu, then select show data
* Right click on the left most border to select an entire row (peak), then right-click to open the context menu, select Delete Row
* The row should be deleted without leading to workbench crashes
<!-- Instructions for testing. -->

Fixes #29776 #29774 . <!-- and fix #xxxx or close #xxxx xor resolves #xxxx -->
<!-- alternative
*There is no associated issue.*
-->

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or master)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
