### PR TITLE
exterminate warnings found by clang11 and 12

### DIFF
--- a/Framework/API/inc/MantidAPI/IndexProperty.h
+++ b/Framework/API/inc/MantidAPI/IndexProperty.h
@@ -36,7 +36,7 @@ public:
                     Kernel::IValidator_sptr(new Kernel::NullValidator));
 
   IndexProperty(const IndexProperty &) = default;
-  IndexProperty &operator=(const IndexProperty &) = default;
+  IndexProperty &operator=(const IndexProperty &) = delete;
 
   IndexProperty *clone() const override;
 

--- a/Framework/API/inc/MantidAPI/IndexProperty.h
+++ b/Framework/API/inc/MantidAPI/IndexProperty.h
@@ -36,6 +36,7 @@ public:
                     Kernel::IValidator_sptr(new Kernel::NullValidator));
 
   IndexProperty(const IndexProperty &) = default;
+  // Copy assignment is deleted since there are reference type members.
   IndexProperty &operator=(const IndexProperty &) = delete;
 
   IndexProperty *clone() const override;

--- a/Framework/API/inc/MantidAPI/WorkspaceHistory.h
+++ b/Framework/API/inc/MantidAPI/WorkspaceHistory.h
@@ -40,7 +40,8 @@ public:
   virtual ~WorkspaceHistory() = default;
   /// Copy constructor
   WorkspaceHistory(const WorkspaceHistory &) = default;
-  /// Deleted copy assignment operator
+  /// Deleted copy assignment operator since m_environment has no copy
+  /// assignment.
   WorkspaceHistory &operator=(const WorkspaceHistory &) = delete;
   /// Retrieve the algorithm history list
   const AlgorithmHistories &getAlgorithmHistories() const;

--- a/Framework/API/inc/MantidAPI/WorkspaceHistory.h
+++ b/Framework/API/inc/MantidAPI/WorkspaceHistory.h
@@ -41,7 +41,7 @@ public:
   /// Copy constructor
   WorkspaceHistory(const WorkspaceHistory &) = default;
   /// Deleted copy assignment operator
-  WorkspaceHistory &operator=(const WorkspaceHistory &) = default;
+  WorkspaceHistory &operator=(const WorkspaceHistory &) = delete;
   /// Retrieve the algorithm history list
   const AlgorithmHistories &getAlgorithmHistories() const;
   /// Retrieve the environment history

--- a/Framework/Algorithms/src/CalculatePlaczekSelfScattering.cpp
+++ b/Framework/Algorithms/src/CalculatePlaczekSelfScattering.cpp
@@ -31,7 +31,7 @@ getSampleSpeciesInfo(const API::MatrixWorkspace_const_sptr &ws) {
   const double xSection = ws->sample().getMaterial().totalScatterXSection();
   const double bSqrdBar = xSection / (4.0 * M_PI);
 
-  for (const auto& element : formula) {
+  for (const auto &element : formula) {
     const std::map<std::string, double> atomMap{
         {"mass", element.atom->mass},
         {"stoich", element.multiplicity},

--- a/Framework/Algorithms/src/CalculatePlaczekSelfScattering.cpp
+++ b/Framework/Algorithms/src/CalculatePlaczekSelfScattering.cpp
@@ -31,7 +31,7 @@ getSampleSpeciesInfo(const API::MatrixWorkspace_const_sptr &ws) {
   const double xSection = ws->sample().getMaterial().totalScatterXSection();
   const double bSqrdBar = xSection / (4.0 * M_PI);
 
-  for (const Kernel::Material::Material::FormulaUnit element : formula) {
+  for (const auto& element : formula) {
     const std::map<std::string, double> atomMap{
         {"mass", element.atom->mass},
         {"stoich", element.multiplicity},

--- a/Framework/Algorithms/src/DetectorEfficiencyCor.cpp
+++ b/Framework/Algorithms/src/DetectorEfficiencyCor.cpp
@@ -223,7 +223,7 @@ void DetectorEfficiencyCor::correctForEfficiency(
   const auto &detectorInfo = m_inputWS->detectorInfo();
   const auto &spectrumDefinition = spectrumInfo.spectrumDefinition(spectraIn);
 
-  for (const auto index : spectrumDefinition) {
+  for (const auto& index : spectrumDefinition) {
     const auto detIndex = index.first;
     const auto &det_member = detectorInfo.detector(detIndex);
     Parameter_sptr par =

--- a/Framework/Algorithms/src/DetectorEfficiencyCor.cpp
+++ b/Framework/Algorithms/src/DetectorEfficiencyCor.cpp
@@ -223,7 +223,7 @@ void DetectorEfficiencyCor::correctForEfficiency(
   const auto &detectorInfo = m_inputWS->detectorInfo();
   const auto &spectrumDefinition = spectrumInfo.spectrumDefinition(spectraIn);
 
-  for (const auto& index : spectrumDefinition) {
+  for (const auto &index : spectrumDefinition) {
     const auto detIndex = index.first;
     const auto &det_member = detectorInfo.detector(detIndex);
     Parameter_sptr par =

--- a/Framework/Algorithms/src/MaskBinsFromWorkspace.cpp
+++ b/Framework/Algorithms/src/MaskBinsFromWorkspace.cpp
@@ -53,7 +53,7 @@ void MaskBinsFromWorkspace::exec() {
   // in the input workspace
   if (maskedWS->hasMaskedBins(0)) {
     const auto maskedBins = maskedWS->maskedBins(0);
-    for (const auto &wi : m_indexSet) {
+    for (const auto wi : m_indexSet) {
       for (const auto &maskedBin : maskedBins) {
         outputWS->flagMasked(wi, maskedBin.first, maskedBin.second);
       }

--- a/Framework/CurveFitting/src/Algorithms/QENSFitSimultaneous.cpp
+++ b/Framework/CurveFitting/src/Algorithms/QENSFitSimultaneous.cpp
@@ -220,7 +220,7 @@ getUniqueWorkspaceNames(std::vector<std::string> &&workspaceNames) {
   std::set<std::string> uniqueNames(workspaceNames.begin(),
                                     workspaceNames.end());
   workspaceNames.assign(uniqueNames.begin(), uniqueNames.end());
-  return workspaceNames;
+  return std::move(workspaceNames);
 }
 
 auto getNumericAxisValueReader(std::size_t axisIndex) {

--- a/Framework/Indexing/inc/MantidIndexing/Conversion.h
+++ b/Framework/Indexing/inc/MantidIndexing/Conversion.h
@@ -51,7 +51,7 @@ template <
 std::vector<Out> castVector(const std::vector<In> &indices) {
   std::vector<Out> converted;
   converted.reserve(indices.size());
-  for (const auto& index : indices)
+  for (const auto &index : indices)
     converted.emplace_back(
         static_cast<Out>(static_cast<typename In::underlying_type>(index)));
   return converted;

--- a/Framework/Indexing/inc/MantidIndexing/Conversion.h
+++ b/Framework/Indexing/inc/MantidIndexing/Conversion.h
@@ -51,7 +51,7 @@ template <
 std::vector<Out> castVector(const std::vector<In> &indices) {
   std::vector<Out> converted;
   converted.reserve(indices.size());
-  for (const auto index : indices)
+  for (const auto& index : indices)
     converted.emplace_back(
         static_cast<Out>(static_cast<typename In::underlying_type>(index)));
   return converted;

--- a/Framework/Kernel/inc/MantidKernel/PropertyWithValueJSON.h
+++ b/Framework/Kernel/inc/MantidKernel/PropertyWithValueJSON.h
@@ -137,7 +137,7 @@ template <typename ValueType> Json::Value encodeAsJson(const ValueType &value) {
 template <typename ValueType>
 Json::Value encodeAsJson(const std::vector<ValueType> &vectorValue) {
   Json::Value jsonArray(Json::arrayValue);
-  for (const auto &element : vectorValue) {
+  for (const auto& element : vectorValue) {
     jsonArray.append(encodeAsJson(element));
   }
   return jsonArray;

--- a/Framework/Kernel/inc/MantidKernel/PropertyWithValueJSON.h
+++ b/Framework/Kernel/inc/MantidKernel/PropertyWithValueJSON.h
@@ -137,7 +137,7 @@ template <typename ValueType> Json::Value encodeAsJson(const ValueType &value) {
 template <typename ValueType>
 Json::Value encodeAsJson(const std::vector<ValueType> &vectorValue) {
   Json::Value jsonArray(Json::arrayValue);
-  for (const auto& element : vectorValue) {
+  for (const auto &element : vectorValue) {
     jsonArray.append(encodeAsJson(element));
   }
   return jsonArray;

--- a/Framework/PythonInterface/mantid/api/src/Exports/MatrixWorkspace.cpp
+++ b/Framework/PythonInterface/mantid/api/src/Exports/MatrixWorkspace.cpp
@@ -133,7 +133,7 @@ list getSpectrumNumbers(const MatrixWorkspace &self) {
   const auto &spectrumNums = self.indexInfo().spectrumNumbers();
   list spectra;
 
-  for (const auto& index : spectrumNums) {
+  for (const auto &index : spectrumNums) {
     spectra.append(static_cast<int32_t>(index));
   }
 

--- a/Framework/PythonInterface/mantid/api/src/Exports/MatrixWorkspace.cpp
+++ b/Framework/PythonInterface/mantid/api/src/Exports/MatrixWorkspace.cpp
@@ -133,7 +133,7 @@ list getSpectrumNumbers(const MatrixWorkspace &self) {
   const auto &spectrumNums = self.indexInfo().spectrumNumbers();
   list spectra;
 
-  for (const auto index : spectrumNums) {
+  for (const auto& index : spectrumNums) {
     spectra.append(static_cast<int32_t>(index));
   }
 

--- a/qt/scientific_interfaces/Direct/CMakeLists.txt
+++ b/qt/scientific_interfaces/Direct/CMakeLists.txt
@@ -7,12 +7,12 @@ set(SRC_FILES
 set(MOC_FILES
     ALFView.h
     ALFCustomInstrumentView.h
-    ALFCustomInstrumentPresenter.h
-    ALFCustomInstrumentModel.h
-    ALFCustomInstrumentMocks.h)
+    ALFCustomInstrumentPresenter.h)
     
 set(INC_FILES
-    DllConfig.h)
+    DllConfig.h
+    ALFCustomInstrumentModel.h
+    ALFCustomInstrumentMocks.h)
 
 # Target
 mtd_add_qt_library(TARGET_NAME MantidScientificInterfacesDirect

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Batch/BatchJobRunner.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Batch/BatchJobRunner.cpp
@@ -108,7 +108,7 @@ void BatchJobRunner::notifyReductionResumed() {
           ++selectedRowsPerGroup[groupIndex];
         }
       }
-      for (const auto& groupIndexCountPair : selectedRowsPerGroup) {
+      for (const auto &groupIndexCountPair : selectedRowsPerGroup) {
         auto const groupIndex = groupIndexCountPair.first;
         auto const numSelected = groupIndexCountPair.second;
         m_processPartial =

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Batch/BatchJobRunner.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Batch/BatchJobRunner.cpp
@@ -108,7 +108,7 @@ void BatchJobRunner::notifyReductionResumed() {
           ++selectedRowsPerGroup[groupIndex];
         }
       }
-      for (const auto groupIndexCountPair : selectedRowsPerGroup) {
+      for (const auto& groupIndexCountPair : selectedRowsPerGroup) {
         auto const groupIndex = groupIndexCountPair.first;
         auto const numSelected = groupIndexCountPair.second;
         m_processPartial =

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Common/Encoder.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Common/Encoder.cpp
@@ -162,13 +162,13 @@ QMap<QString, QVariant> Encoder::encodeRangeInQ(const RangeInQ &rangeInQ) {
 QMap<QString, QVariant>
 Encoder::encodeTransmissionRunPair(const TransmissionRunPair &transRunPair) {
   QList<QVariant> firstTransRunNums;
-  for (const auto& firstTransRunNum :
+  for (const auto &firstTransRunNum :
        transRunPair.firstTransmissionRunNumbers()) {
     firstTransRunNums.append(
         QVariant(QString::fromStdString(firstTransRunNum)));
   }
   QList<QVariant> secondTransRunNums;
-  for (const auto& secondTransRunNum :
+  for (const auto &secondTransRunNum :
        transRunPair.secondTransmissionRunNumbers()) {
     secondTransRunNums.append(
         QVariant(QString::fromStdString(secondTransRunNum)));

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Common/Encoder.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Common/Encoder.cpp
@@ -162,13 +162,13 @@ QMap<QString, QVariant> Encoder::encodeRangeInQ(const RangeInQ &rangeInQ) {
 QMap<QString, QVariant>
 Encoder::encodeTransmissionRunPair(const TransmissionRunPair &transRunPair) {
   QList<QVariant> firstTransRunNums;
-  for (const auto firstTransRunNum :
+  for (const auto& firstTransRunNum :
        transRunPair.firstTransmissionRunNumbers()) {
     firstTransRunNums.append(
         QVariant(QString::fromStdString(firstTransRunNum)));
   }
   QList<QVariant> secondTransRunNums;
-  for (const auto secondTransRunNum :
+  for (const auto& secondTransRunNum :
        transRunPair.secondTransmissionRunNumbers()) {
     secondTransRunNums.append(
         QVariant(QString::fromStdString(secondTransRunNum)));

--- a/qt/scientific_interfaces/Indirect/IndirectFitData.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectFitData.cpp
@@ -236,7 +236,9 @@ Spectra &Spectra::operator=(Spectra &&vec) {
 
 [[nodiscard]] bool Spectra::empty() const { return m_vec.empty(); }
 
-FitDomainIndex Spectra::size() const { return FitDomainIndex{m_vec.size()}; }
+FitDomainIndex Spectra::size() const {
+    return FitDomainIndex{m_vec.size()};
+}
 
 std::string Spectra::getString() const {
   if (empty())

--- a/qt/scientific_interfaces/Indirect/IndirectFitData.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectFitData.cpp
@@ -236,9 +236,7 @@ Spectra &Spectra::operator=(Spectra &&vec) {
 
 [[nodiscard]] bool Spectra::empty() const { return m_vec.empty(); }
 
-FitDomainIndex Spectra::size() const {
-  return FitDomainIndex{m_vec.size()};
-}
+FitDomainIndex Spectra::size() const { return FitDomainIndex{m_vec.size()}; }
 
 std::string Spectra::getString() const {
   if (empty())
@@ -311,7 +309,7 @@ IndirectFitData::IndirectFitData(const MatrixWorkspace_sptr &workspace,
   setSpectra(spectra);
   auto const range =
       !spectra.empty() ? getBinRange(workspace) : std::make_pair(0.0, 0.0);
-  for (auto const& spectrum : spectra) {
+  for (auto const &spectrum : spectra) {
     m_ranges[spectrum] = range;
   }
 }
@@ -418,7 +416,7 @@ void IndirectFitData::setSpectra(Spectra const &spectra) {
 void IndirectFitData::validateSpectra(Spectra const &spectra) {
   size_t maxValue = workspace()->getNumberHistograms() - 1;
   std::vector<size_t> notInRange;
-  for (auto const& i : spectra) {
+  for (auto const &i : spectra) {
     if (i.value > maxValue)
       notInRange.emplace_back(i.value);
   }
@@ -446,7 +444,7 @@ void IndirectFitData::setStartX(double const &startX,
 }
 
 void IndirectFitData::setStartX(double const &startX) {
-  for (auto const& spectrum : m_spectra) {
+  for (auto const &spectrum : m_spectra) {
     setStartX(startX, spectrum);
   }
 }
@@ -463,7 +461,7 @@ void IndirectFitData::setEndX(double const &endX,
 }
 
 void IndirectFitData::setEndX(double const &endX) {
-  for (auto const& spectrum : m_spectra) {
+  for (auto const &spectrum : m_spectra) {
     setEndX(endX, spectrum);
   }
 }

--- a/qt/scientific_interfaces/Indirect/IndirectFitData.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectFitData.cpp
@@ -237,7 +237,7 @@ Spectra &Spectra::operator=(Spectra &&vec) {
 [[nodiscard]] bool Spectra::empty() const { return m_vec.empty(); }
 
 FitDomainIndex Spectra::size() const {
-    return FitDomainIndex{m_vec.size()};
+  return FitDomainIndex{m_vec.size()};
 }
 
 std::string Spectra::getString() const {

--- a/qt/scientific_interfaces/Indirect/IndirectFitData.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectFitData.cpp
@@ -311,7 +311,7 @@ IndirectFitData::IndirectFitData(const MatrixWorkspace_sptr &workspace,
   setSpectra(spectra);
   auto const range =
       !spectra.empty() ? getBinRange(workspace) : std::make_pair(0.0, 0.0);
-  for (auto const spectrum : spectra) {
+  for (auto const& spectrum : spectra) {
     m_ranges[spectrum] = range;
   }
 }
@@ -418,7 +418,7 @@ void IndirectFitData::setSpectra(Spectra const &spectra) {
 void IndirectFitData::validateSpectra(Spectra const &spectra) {
   size_t maxValue = workspace()->getNumberHistograms() - 1;
   std::vector<size_t> notInRange;
-  for (auto const i : spectra) {
+  for (auto const& i : spectra) {
     if (i.value > maxValue)
       notInRange.emplace_back(i.value);
   }
@@ -446,7 +446,7 @@ void IndirectFitData::setStartX(double const &startX,
 }
 
 void IndirectFitData::setStartX(double const &startX) {
-  for (auto const spectrum : m_spectra) {
+  for (auto const& spectrum : m_spectra) {
     setStartX(startX, spectrum);
   }
 }
@@ -463,7 +463,7 @@ void IndirectFitData::setEndX(double const &endX,
 }
 
 void IndirectFitData::setEndX(double const &endX) {
-  for (auto const spectrum : m_spectra) {
+  for (auto const& spectrum : m_spectra) {
     setEndX(endX, spectrum);
   }
 }

--- a/qt/scientific_interfaces/Indirect/IndirectFitOutputOptionsModel.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectFitOutputOptionsModel.cpp
@@ -100,7 +100,7 @@ void saveWorkspace(const Workspace_sptr &workspace) {
 }
 
 void saveWorkspacesInGroup(const WorkspaceGroup_const_sptr &group) {
-  for (auto const workspace : *group)
+  for (auto const& workspace : *group)
     saveWorkspace(workspace);
 }
 

--- a/qt/scientific_interfaces/Indirect/IndirectFitOutputOptionsModel.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectFitOutputOptionsModel.cpp
@@ -100,7 +100,7 @@ void saveWorkspace(const Workspace_sptr &workspace) {
 }
 
 void saveWorkspacesInGroup(const WorkspaceGroup_const_sptr &group) {
-  for (auto const& workspace : *group)
+  for (auto const &workspace : *group)
     saveWorkspace(workspace);
 }
 

--- a/qt/scientific_interfaces/Indirect/IndirectFittingModel.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectFittingModel.cpp
@@ -166,7 +166,7 @@ shortToLongParameterNames(const IFunction_sptr &function) {
 template <typename Map, typename KeyMap>
 Map mapKeys(const Map &map, const KeyMap &mapping) {
   Map mapped;
-  for (const auto value : map) {
+  for (const auto& value : map) {
     auto it = mapping.find(value.first);
     if (it != mapping.end())
       mapped[it->second] = value.second;

--- a/qt/scientific_interfaces/Indirect/IndirectFittingModel.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectFittingModel.cpp
@@ -166,7 +166,7 @@ shortToLongParameterNames(const IFunction_sptr &function) {
 template <typename Map, typename KeyMap>
 Map mapKeys(const Map &map, const KeyMap &mapping) {
   Map mapped;
-  for (const auto& value : map) {
+  for (const auto &value : map) {
     auto it = mapping.find(value.first);
     if (it != mapping.end())
       mapped[it->second] = value.second;

--- a/qt/widgets/common/CMakeLists.txt
+++ b/qt/widgets/common/CMakeLists.txt
@@ -192,7 +192,6 @@ set(
   inc/MantidQtWidgets/Common/PropertyHandler.h
   inc/MantidQtWidgets/Common/PropertyWidget.h
   inc/MantidQtWidgets/Common/PythonRunner.h
-  inc/MantidQtWidgets/Common/QSettingsHelper.h
   inc/MantidQtWidgets/Common/QtSignalChannel.h
   inc/MantidQtWidgets/Common/RenameParDialog.h
   inc/MantidQtWidgets/Common/RepoModel.h
@@ -520,7 +519,6 @@ set(
   inc/MantidQtWidgets/Common/PropertyWidget.h
   inc/MantidQtWidgets/Common/PythonRunner.h
   inc/MantidQtWidgets/Common/QScienceSpinBox.h
-  inc/MantidQtWidgets/Common/QSettingsHelper.h
   inc/MantidQtWidgets/Common/QtSignalChannel.h
   inc/MantidQtWidgets/Common/RepoTreeView.h
   inc/MantidQtWidgets/Common/RepoModel.h

--- a/qt/widgets/common/src/FunctionModel.cpp
+++ b/qt/widgets/common/src/FunctionModel.cpp
@@ -189,7 +189,7 @@ QStringList FunctionModel::getParameterNames() const {
   QStringList names;
   if (hasFunction()) {
     const auto paramNames = getCurrentFunction()->getParameterNames();
-    for (auto const name : paramNames) {
+    for (auto const& name : paramNames) {
       names << QString::fromStdString(name);
     }
   }

--- a/qt/widgets/common/src/FunctionModel.cpp
+++ b/qt/widgets/common/src/FunctionModel.cpp
@@ -189,7 +189,7 @@ QStringList FunctionModel::getParameterNames() const {
   QStringList names;
   if (hasFunction()) {
     const auto paramNames = getCurrentFunction()->getParameterNames();
-    for (auto const& name : paramNames) {
+    for (auto const &name : paramNames) {
       names << QString::fromStdString(name);
     }
   }

--- a/qt/widgets/common/src/FunctionMultiDomainPresenter.cpp
+++ b/qt/widgets/common/src/FunctionMultiDomainPresenter.cpp
@@ -400,7 +400,7 @@ void FunctionMultiDomainPresenter::editLocalParameterFinish(int result) {
 
 void FunctionMultiDomainPresenter::updateViewFromModel() {
   const auto index = m_model->currentDomainIndex();
-  for (auto const name : m_model->getParameterNames()) {
+  for (auto const& name : m_model->getParameterNames()) {
     auto const value = m_model->getParameter(name);
     m_view->setParameter(name, value);
     m_view->setParameterError(name, m_model->getParameterError(name));

--- a/qt/widgets/common/src/FunctionMultiDomainPresenter.cpp
+++ b/qt/widgets/common/src/FunctionMultiDomainPresenter.cpp
@@ -400,7 +400,7 @@ void FunctionMultiDomainPresenter::editLocalParameterFinish(int result) {
 
 void FunctionMultiDomainPresenter::updateViewFromModel() {
   const auto index = m_model->currentDomainIndex();
-  for (auto const& name : m_model->getParameterNames()) {
+  for (auto const &name : m_model->getParameterNames()) {
     auto const value = m_model->getParameter(name);
     m_view->setParameter(name, value);
     m_view->setParameterError(name, m_model->getParameterError(name));

--- a/qt/widgets/instrumentview/src/InstrumentWidgetDecoder.cpp
+++ b/qt/widgets/instrumentview/src/InstrumentWidgetDecoder.cpp
@@ -348,7 +348,7 @@ InstrumentWidgetDecoder::decodeFree(const QMap<QString, QVariant> &map) {
   QPolygonF polygon;
 
   const auto parameters = map[QString("paramaters")].toList();
-  for (const auto param : parameters) {
+  for (const auto& param : parameters) {
     const auto paramList = param.toList();
     const double x = paramList[0].toDouble();
     const double y = paramList[1].toDouble();

--- a/qt/widgets/instrumentview/src/InstrumentWidgetDecoder.cpp
+++ b/qt/widgets/instrumentview/src/InstrumentWidgetDecoder.cpp
@@ -348,7 +348,7 @@ InstrumentWidgetDecoder::decodeFree(const QMap<QString, QVariant> &map) {
   QPolygonF polygon;
 
   const auto parameters = map[QString("paramaters")].toList();
-  for (const auto& param : parameters) {
+  for (const auto &param : parameters) {
     const auto paramList = param.toList();
     const double x = paramList[0].toDouble();
     const double y = paramList[1].toDouble();

--- a/qt/widgets/instrumentview/src/InstrumentWidgetEncoder.cpp
+++ b/qt/widgets/instrumentview/src/InstrumentWidgetEncoder.cpp
@@ -95,7 +95,7 @@ InstrumentWidgetEncoder::encodeTreeTab(const InstrumentWidgetTreeTab *tab) {
 
   QList<QString> list;
   const auto names = tab->m_instrumentTree->findExpandedComponents();
-  for (const auto& name : names) {
+  for (const auto &name : names) {
     list.append(name);
   }
   map.insert(QString("expandedItems"), QVariant(list));

--- a/qt/widgets/instrumentview/src/InstrumentWidgetEncoder.cpp
+++ b/qt/widgets/instrumentview/src/InstrumentWidgetEncoder.cpp
@@ -95,7 +95,7 @@ InstrumentWidgetEncoder::encodeTreeTab(const InstrumentWidgetTreeTab *tab) {
 
   QList<QString> list;
   const auto names = tab->m_instrumentTree->findExpandedComponents();
-  for (const auto name : names) {
+  for (const auto& name : names) {
     list.append(name);
   }
   map.insert(QString("expandedItems"), QVariant(list));

--- a/qt/widgets/mplcpp/src/Plot.cpp
+++ b/qt/widgets/mplcpp/src/Plot.cpp
@@ -94,7 +94,7 @@ constructKwargs(boost::optional<std::vector<int>> spectrumNums,
   if (windowTitle)
     kwargs["window_title"] = windowTitle.get();
 
-  return kwargs;
+  return std::move(kwargs);
 }
 
 Python::Object plot(const Python::Object &args,


### PR DESCRIPTION
**Description of work.**
Fixes compiler warnings with the newer versions of clang on macOS.

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

**To test:**
Careful code review. If you happen to have one of those compilers make sure the project builds without any compile time warnings. There should be no compiler warning on any of the supported platforms/compilers.

<!-- Instructions for testing. -->

*There is no associated issue.*

*This does not require release notes, since it's an internal fix.*

<!-- Ensure the base of this PR is correct (e.g. release-next or master)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
