### PR TITLE
Adding basic elemental analysis 2 GUI

### DIFF
--- a/dev-docs/source/Testing/ElementalAnalysis/ElementalAnalysisTests.rst
+++ b/dev-docs/source/Testing/ElementalAnalysis/ElementalAnalysisTests.rst
@@ -1,0 +1,26 @@
+.. _elemental_analysis_gui_testing:
+
+Elemental Analysis GUI Testing
+==============================
+
+.. contents::
+   :local:
+
+Introduction
+------------
+
+This document outlines some basic tests for the new elemental analysis GUI.
+Please note that it is currently hidden from users.
+
+Set up
+------
+
+To do the testing you will need some data (please request this from the ISIS spectroscopy team).
+You will need to add the file location to the search paths for Mantid.
+
+Basic tests
+^^^^^^^^^^^
+When the GUI starts up it will have some dummy widgets, these do not do anything.
+The bottom of the GUI will have a `Manage user directories` and help buttons.
+The tabs should be dockable, closing them will result in the tab returning to the docked state.
+Closing the GUI should also close any undocked tabs.

--- a/dev-docs/source/Testing/index.rst
+++ b/dev-docs/source/Testing/index.rst
@@ -22,6 +22,7 @@ creation is outlined in :ref:`issue_tracking`.
 
    MuonAnalysis_test_guides/index
    MuonInterface/MuonTesting
+   ElementalAnalysis/ElementalAnalysisGUITests
    IndirectInelastic/IndirectInelasticAcceptanceTests
    EngineeringDiffraction/EngineeringDiffractionTestGuide
    ErrorReporter-ProjectRecovery/ErrorReporterTesting

--- a/scripts/Elemental_Analysis_2.py
+++ b/scripts/Elemental_Analysis_2.py
@@ -1,0 +1,36 @@
+# Mantid Repository : https://github.com/mantidproject/mantid
+#
+# Copyright &copy; 2018 ISIS Rutherford Appleton Laboratory UKRI,
+#   NScD Oak Ridge National Laboratory, European Spallation Source,
+#   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+# SPDX - License - Identifier: GPL - 3.0 +
+# pylint: disable=invalid-name
+from Muon.GUI.ElementalAnalysis2.elemental_analysis import ElementalAnalysisGui
+from qtpy import QtCore
+from Muon.GUI.Common.usage_report import report_interface_startup
+
+Name = "Elemental_Analysis_2"
+
+if 'elemental_analysis_2' in globals():
+    elemental_analysis = globals()['elemental_analysis_2']
+    # If the object is deleted in the C++ side it can still exist in the
+    # python globals list. The try catch block below checks for this.
+    try:
+        is_hidden = elemental_analysis.isHidden()
+    except RuntimeError:
+        is_hidden = True
+    if not is_hidden:
+        elemental_analysis.setWindowState(
+            elemental_analysis.windowState(
+            ) & ~QtCore.Qt.WindowMinimized | QtCore.Qt.WindowActive)
+        elemental_analysis.activateWindow()
+    else:
+        elemental_analysis = ElementalAnalysisGui()
+        report_interface_startup(Name)
+        elemental_analysis.resize(700, 700)
+        elemental_analysis.show()
+else:
+    elemental_analysis = ElementalAnalysisGui()
+    report_interface_startup(Name)
+    elemental_analysis.resize(700, 700)
+    elemental_analysis.show()

--- a/scripts/Muon/GUI/ElementalAnalysis2/__init__.py
+++ b/scripts/Muon/GUI/ElementalAnalysis2/__init__.py
@@ -1,0 +1,6 @@
+# Mantid Repository : https://github.com/mantidproject/mantid
+#
+# Copyright &copy; 2018 ISIS Rutherford Appleton Laboratory UKRI,
+#   NScD Oak Ridge National Laboratory, European Spallation Source,
+#   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+# SPDX - License - Identifier: GPL - 3.0 +

--- a/scripts/Muon/GUI/ElementalAnalysis2/context/__init__.py
+++ b/scripts/Muon/GUI/ElementalAnalysis2/context/__init__.py
@@ -1,0 +1,6 @@
+# Mantid Repository : https://github.com/mantidproject/mantid
+#
+# Copyright &copy; 2018 ISIS Rutherford Appleton Laboratory UKRI,
+#   NScD Oak Ridge National Laboratory, European Spallation Source,
+#   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+# SPDX - License - Identifier: GPL - 3.0 +

--- a/scripts/Muon/GUI/ElementalAnalysis2/context/context.py
+++ b/scripts/Muon/GUI/ElementalAnalysis2/context/context.py
@@ -9,10 +9,8 @@
 class ElementalAnalysisContext(object):
 
     def __init__(self):
-      self._window_title = "Elemental Analysis 2"
+        self._window_title = "Elemental Analysis 2"
 
     @property
     def name(self):
         return self._window_title
-
-

--- a/scripts/Muon/GUI/ElementalAnalysis2/context/context.py
+++ b/scripts/Muon/GUI/ElementalAnalysis2/context/context.py
@@ -1,0 +1,18 @@
+# Mantid Repository : https://github.com/mantidproject/mantid
+#
+# Copyright &copy; 2018 ISIS Rutherford Appleton Laboratory UKRI,
+#   NScD Oak Ridge National Laboratory, European Spallation Source,
+#   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+# SPDX - License - Identifier: GPL - 3.0 +
+
+
+class ElementalAnalysisContext(object):
+
+    def __init__(self):
+      self._window_title = "Elemental Analysis 2"
+
+    @property
+    def name(self):
+        return self._window_title
+
+

--- a/scripts/Muon/GUI/ElementalAnalysis2/elemental_analysis.py
+++ b/scripts/Muon/GUI/ElementalAnalysis2/elemental_analysis.py
@@ -4,15 +4,11 @@
 #   NScD Oak Ridge National Laboratory, European Spallation Source,
 #   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
 # SPDX - License - Identifier: GPL - 3.0 +
-from qtpy import QtWidgets, QtCore, QT_VERSION
-from distutils.version import LooseVersion
-
-from mantid.kernel import ConfigServiceImpl
+from qtpy import QtWidgets, QtCore
 
 import Muon.GUI.Common.message_box as message_box
 from Muon.GUI.Common.help_widget.help_widget_presenter import HelpWidget
 from Muon.GUI.Common.dock.dockable_tabs import DetachableTabWidget
-from mantidqt.utils.observer_pattern import GenericObserver,GenericObservable
 from Muon.GUI.ElementalAnalysis2.context.context import ElementalAnalysisContext
 
 
@@ -68,5 +64,3 @@ class ElementalAnalysisGui(QtWidgets.QMainWindow):
     def closeEvent(self, event):
         self.tabs.closeEvent(event)
         super(ElementalAnalysisGui, self).closeEvent(event)
-
-

--- a/scripts/Muon/GUI/ElementalAnalysis2/elemental_analysis.py
+++ b/scripts/Muon/GUI/ElementalAnalysis2/elemental_analysis.py
@@ -1,0 +1,72 @@
+# Mantid Repository : https://github.com/mantidproject/mantid
+#
+# Copyright &copy; 2018 ISIS Rutherford Appleton Laboratory UKRI,
+#   NScD Oak Ridge National Laboratory, European Spallation Source,
+#   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+# SPDX - License - Identifier: GPL - 3.0 +
+from qtpy import QtWidgets, QtCore, QT_VERSION
+from distutils.version import LooseVersion
+
+from mantid.kernel import ConfigServiceImpl
+
+import Muon.GUI.Common.message_box as message_box
+from Muon.GUI.Common.help_widget.help_widget_presenter import HelpWidget
+from Muon.GUI.Common.dock.dockable_tabs import DetachableTabWidget
+from mantidqt.utils.observer_pattern import GenericObserver,GenericObservable
+from Muon.GUI.ElementalAnalysis2.context.context import ElementalAnalysisContext
+
+
+class ElementalAnalysisGui(QtWidgets.QMainWindow):
+    """
+    The Elemental Analysis 2.0 interface.
+    """
+
+    @staticmethod
+    def warning_popup(message):
+        message_box.warning(str(message))
+
+    def __init__(self, parent=None):
+        super(ElementalAnalysisGui, self).__init__(parent)
+        self.setAttribute(QtCore.Qt.WA_DeleteOnClose)
+        self.setFocusPolicy(QtCore.Qt.StrongFocus)
+        self.setObjectName("ElementalAnalysis2")
+        self.context = ElementalAnalysisContext()
+        self.current_tab = ''
+
+        self.setup_dummy()
+
+        self.setup_tabs()
+        self.help_widget = HelpWidget("Elemental Analysis")
+
+        central_widget = QtWidgets.QWidget()
+        vertical_layout = QtWidgets.QVBoxLayout()
+        vertical_layout.addWidget(self.load_widget)
+        vertical_layout.addWidget(self.tabs)
+        vertical_layout.addWidget(self.help_widget.view)
+        central_widget.setLayout(vertical_layout)
+
+        self.setCentralWidget(central_widget)
+        self.setWindowTitle(self.context.name)
+
+    def setup_dummy(self):
+        self.load_widget = QtWidgets.QLineEdit("load")
+        self.home_tab = QtWidgets.QLineEdit("home")
+        self.grouping_tab_widget = QtWidgets.QLineEdit("grouping")
+        self.fitting_tab = QtWidgets.QLineEdit("fitting")
+
+    def setup_tabs(self):
+        """
+        Set up the tabbing structure; the tabs work similarly to conventional
+        web browsers.
+        """
+        self.tabs = DetachableTabWidget(self)
+        self.tabs.addTabWithOrder(self.home_tab, 'Home')
+        self.tabs.addTabWithOrder(self.grouping_tab_widget,
+                                  'Grouping')
+        self.tabs.addTabWithOrder(self.fitting_tab, 'Fitting')
+
+    def closeEvent(self, event):
+        self.tabs.closeEvent(event)
+        super(ElementalAnalysisGui, self).closeEvent(event)
+
+

--- a/scripts/test/Muon/CMakeLists.txt
+++ b/scripts/test/Muon/CMakeLists.txt
@@ -82,6 +82,7 @@ set ( TEST_PY_FILES
    elemental_analysis/periodic_table_item_test.py
    elemental_analysis/lmodel_test.py
    elemental_analysis/load_model_test.py
+   elemental_analysis_2/elemental_analysis_context_test.py
 )
 
 # LoadWidgetModel_test.py, LoadWidgetPresenter_test.py and LoadWidgetView_test.py are currently not Qt5 compatible
@@ -134,6 +135,7 @@ set ( TEST_PY_FILES_QT4
    elemental_analysis/PeriodicTableModel_test.py
    elemental_analysis/PeriodicTablePresenter_test.py
    elemental_analysis/load_utils_test.py
+   elemental_analysis_2/elemental_analysis_context_test.py
 )
 
 check_tests_valid(${CMAKE_CURRENT_SOURCE_DIR} ${TEST_PY_FILES})

--- a/scripts/test/Muon/CMakeLists.txt
+++ b/scripts/test/Muon/CMakeLists.txt
@@ -83,6 +83,7 @@ set ( TEST_PY_FILES
    elemental_analysis/lmodel_test.py
    elemental_analysis/load_model_test.py
    elemental_analysis_2/elemental_analysis_context_test.py
+   elemental_analysis_2/elemental_analysis_main_GUI_test.py
 )
 
 # LoadWidgetModel_test.py, LoadWidgetPresenter_test.py and LoadWidgetView_test.py are currently not Qt5 compatible
@@ -136,6 +137,7 @@ set ( TEST_PY_FILES_QT4
    elemental_analysis/PeriodicTablePresenter_test.py
    elemental_analysis/load_utils_test.py
    elemental_analysis_2/elemental_analysis_context_test.py
+   elemental_analysis_2/elemental_analysis_main_GUI_test.py
 )
 
 check_tests_valid(${CMAKE_CURRENT_SOURCE_DIR} ${TEST_PY_FILES})

--- a/scripts/test/Muon/elemental_analysis_2/__init__.py
+++ b/scripts/test/Muon/elemental_analysis_2/__init__.py
@@ -1,0 +1,6 @@
+# Mantid Repository : https://github.com/mantidproject/mantid
+#
+# Copyright &copy; 2019 ISIS Rutherford Appleton Laboratory UKRI,
+#   NScD Oak Ridge National Laboratory, European Spallation Source,
+#   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+# SPDX - License - Identifier: GPL - 3.0 +

--- a/scripts/test/Muon/elemental_analysis_2/elemental_analysis_context_test.py
+++ b/scripts/test/Muon/elemental_analysis_2/elemental_analysis_context_test.py
@@ -1,0 +1,22 @@
+# Mantid Repository : https://github.com/mantidproject/mantid
+#
+# Copyright &copy; 2018 ISIS Rutherford Appleton Laboratory UKRI,
+#   NScD Oak Ridge National Laboratory, European Spallation Source,
+#   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+# SPDX - License - Identifier: GPL - 3.0 +
+import unittest
+from Muon.GUI.ElementalAnalysis2.context.context import ElementalAnalysisContext
+
+
+
+class ElementalAnalysisContextTest(unittest.TestCase):
+    def setUp(self):
+        self.context = ElementalAnalysisContext()
+
+
+    def test_name(self):
+        self.assertEqual(self.context.name, "Elemental Analysis 2")
+
+
+if __name__ == '__main__':
+    unittest.main(buffer=False, verbosity=2)

--- a/scripts/test/Muon/elemental_analysis_2/elemental_analysis_context_test.py
+++ b/scripts/test/Muon/elemental_analysis_2/elemental_analysis_context_test.py
@@ -8,11 +8,9 @@ import unittest
 from Muon.GUI.ElementalAnalysis2.context.context import ElementalAnalysisContext
 
 
-
 class ElementalAnalysisContextTest(unittest.TestCase):
     def setUp(self):
         self.context = ElementalAnalysisContext()
-
 
     def test_name(self):
         self.assertEqual(self.context.name, "Elemental Analysis 2")

--- a/scripts/test/Muon/elemental_analysis_2/elemental_analysis_main_GUI_test.py
+++ b/scripts/test/Muon/elemental_analysis_2/elemental_analysis_main_GUI_test.py
@@ -6,7 +6,6 @@
 # SPDX - License - Identifier: GPL - 3.0 +
 import unittest
 from qtpy.QtGui import QCloseEvent as event
-from unittest import mock
 from mantidqt.utils.qt.testing import start_qapplication
 from Muon.GUI.ElementalAnalysis2.elemental_analysis import ElementalAnalysisGui
 

--- a/scripts/test/Muon/elemental_analysis_2/elemental_analysis_main_GUI_test.py
+++ b/scripts/test/Muon/elemental_analysis_2/elemental_analysis_main_GUI_test.py
@@ -5,9 +5,8 @@
 #   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
 # SPDX - License - Identifier: GPL - 3.0 +
 import unittest
-from qtpy.QtCore import Qt
-from qtpy.QtTest import QTest
-
+from qtpy.QtGui import QCloseEvent as event
+from unittest import mock
 from mantidqt.utils.qt.testing import start_qapplication
 from Muon.GUI.ElementalAnalysis2.elemental_analysis import ElementalAnalysisGui
 
@@ -18,7 +17,7 @@ class ElementalAnalysisGUITest(unittest.TestCase):
         GUI = ElementalAnalysisGui()
         self.assertTrue(GUI is not None)
         try:
-            GUI.closeEvent()
+            GUI.closeEvent(event())
         except:
             self.assertEquals("GUI did not close correctly", "")
 

--- a/scripts/test/Muon/elemental_analysis_2/elemental_analysis_main_GUI_test.py
+++ b/scripts/test/Muon/elemental_analysis_2/elemental_analysis_main_GUI_test.py
@@ -1,0 +1,27 @@
+# Mantid Repository : https://github.com/mantidproject/mantid
+#
+# Copyright &copy; 2018 ISIS Rutherford Appleton Laboratory UKRI,
+#   NScD Oak Ridge National Laboratory, European Spallation Source,
+#   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+# SPDX - License - Identifier: GPL - 3.0 +
+import unittest
+from qtpy.QtCore import Qt
+from qtpy.QtTest import QTest
+
+from mantidqt.utils.qt.testing import start_qapplication
+from Muon.GUI.ElementalAnalysis2.elemental_analysis import ElementalAnalysisGui
+
+
+@start_qapplication
+class ElementalAnalysisGUITest(unittest.TestCase):
+    def test_start_and_close(self):
+        GUI = ElementalAnalysisGui()
+        self.assertTrue(GUI is not None)
+        try:
+            GUI.closeEvent()
+        except:
+            self.assertEquals("GUI did not close correctly", "")
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
This PR adds the basic code for a new elemental analysis GUI. The GUI itself just has some dummy line edits for now.

**To test:**
1. Before starting Mantid go to https://github.com/mantidproject/mantid/blob/master/Framework/Properties/Mantid.properties.template#L24 and add `Muon/Elemental_Analysis_2.py` to the end of the line

2. Start Mantid

3. Open the elemental analysis 2 GUI - it should appear. 

4. Check the manage user directories button works. Everything else is "dead"

5. Close the GUI and check it doesn't crash



There is no associated issue.


<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or master)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
