### PR TITLE
Fix [-wunused-result] MSVC build warnings

### DIFF
--- a/Framework/DataObjects/test/Histogram1DTest.h
+++ b/Framework/DataObjects/test/Histogram1DTest.h
@@ -170,28 +170,16 @@ public:
   }
   void testrangeexceptionX() {
     h.setPoints(x1);
-    // vector.at() is marked nodiscard in MSVC but we just want to test it
-    // throws so suppress the warning
-    MSVC_DIAG_OFF(4834)
     TS_ASSERT_THROWS(h.dataX().at(nel), const std::out_of_range &);
-    MSVC_DIAG_ON(4834)
   }
   void testrangeexceptionY() {
     h.setCounts(y1);
-    // vector.at() is marked nodiscard in MSVC but we just want to test it
-    // throws so suppress the warning
-    MSVC_DIAG_OFF(4834)
     TS_ASSERT_THROWS(h.dataY().at(nel), const std::out_of_range &);
-    MSVC_DIAG_ON(4834)
   }
   void testrangeexceptionE() {
     h.setCounts(y1);
     h.setCountStandardDeviations(e1);
-    // vector.at() is marked nodiscard in MSVC but we just want to test it
-    // throws so suppress the warning
-    MSVC_DIAG_OFF(4834)
     TS_ASSERT_THROWS(h.dataE().at(nel), const std::out_of_range &);
-    MSVC_DIAG_ON(4834)
   }
 
   void test_copy_constructor() {


### PR DESCRIPTION
**Description of work.**
This PR makes the `TS_ASSERT_...THROWS..` macros ignore the compiler warning [-wunused-result]. This is necessary when the first argument to these macro is a nodiscard function.

**To test:**
Code review
Check we have no MSBuild warnings/errors anymore.
<!-- Instructions for testing. -->

*There is no associated issue.*

This does not require release notes because its an internal issue.


<!-- Ensure the base of this PR is correct (e.g. release-next or master)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
