### PR TITLE
Bug in default settings export in DrILL

### DIFF
--- a/scripts/Interface/ui/drill/model/DrillModel.py
+++ b/scripts/Interface/ui/drill/model/DrillModel.py
@@ -8,6 +8,7 @@
 import json
 import os
 import sys
+import numpy
 
 from qtpy.QtCore import QObject, Signal, QThread
 
@@ -364,8 +365,10 @@ class DrillModel(QObject):
                     t = "string"
             elif (isinstance(p, BoolPropertyWithValue)):
                 t = "bool"
-            elif (isinstance(p, (FloatArrayProperty, IntArrayProperty))):
-                t = "array"
+            elif (isinstance(p, FloatArrayProperty)):
+                t = "floatArray"
+            elif (isinstance(p, IntArrayProperty)):
+                t = "intArray"
             else:
                 t = "string"
 
@@ -387,7 +390,11 @@ class DrillModel(QObject):
 
         for s in self.settings:
             p = alg.getProperty(s)
-            self.settings[s] = p.value
+            v = p.value
+            if (isinstance(v, numpy.ndarray)):
+                self.settings[s] = v.tolist()
+            else:
+                self.settings[s] = v
 
     def checkParameter(self, param, value, sample=-1):
         """

--- a/scripts/Interface/ui/drill/test/DrillModelTest.py
+++ b/scripts/Interface/ui/drill/test/DrillModelTest.py
@@ -347,10 +347,10 @@ class DrillModelTest(unittest.TestCase):
         prop.documentation = "test doc"
         alg.getProperty.return_value = prop
         types, values, docs = self.model.getSettingsTypes()
-        self.assertDictEqual(types, {"str": "array",
-                                     "int": "array",
-                                     "float": "array",
-                                     "bool": "array"})
+        self.assertDictEqual(types, {"str": "floatArray",
+                                     "int": "floatArray",
+                                     "float": "floatArray",
+                                     "bool": "floatArray"})
         self.assertDictEqual(values, {"str": ["test", "test"],
                                       "int": ["test", "test"],
                                       "float": ["test", "test"],

--- a/scripts/Interface/ui/drill/view/DrillSettingsDialog.py
+++ b/scripts/Interface/ui/drill/view/DrillSettingsDialog.py
@@ -79,14 +79,24 @@ class DrillSetting(QObject):
             self._setter = self._widget.setChecked
             self._getter = self._widget.isChecked
 
-        elif (settingType == "array"):
+        elif (settingType == "floatArray") or (settingType == "intArray"):
             self._widget = QLineEdit()
             self._widget.editingFinished.connect(
                     lambda : self.valueChanged.emit(name)
                     )
             self._setter = lambda v : self._widget.setText(','.join(str(e)
                                                            for e in v))
-            self._getter = self._widget.text
+
+            if (settingType == "floatArray"):
+                self._getter = (
+                        lambda : [float(v)
+                                  for v in self._widget.text().split(',')
+                                  if v])
+            else:
+                self._getter = (
+                        lambda : [int(v)
+                                  for v in self._widget.text().split(',')
+                                  if v])
 
         elif (settingType == "string"):
             self._widget = QLineEdit()


### PR DESCRIPTION
**Description of work.**

There was a problem with JSON serialization of `numpy.ndarray`. The property values of that type are now converted to python list.

**To test:**

* open DrILL (Interfaces -> ILL -> DrILL)
* save the rundex file (File -> Save rundex as)
* reload it (File -> Load rundex)

Fixes #29785 

*This does not require release notes*: internal changes only


---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
