### PR TITLE
Cherry-pick TableWorkspace alteration fix

### DIFF
--- a/qt/python/mantidqt/widgets/workspacedisplay/table/presenter.py
+++ b/qt/python/mantidqt/widgets/workspacedisplay/table/presenter.py
@@ -19,7 +19,11 @@ from mantidqt.widgets.workspacedisplay.table.error_column import ErrorColumn
 from mantidqt.widgets.workspacedisplay.table.model import TableWorkspaceDisplayModel
 from mantidqt.widgets.workspacedisplay.table.plot_type import PlotType
 from mantidqt.widgets.workspacedisplay.table.view import TableWorkspaceDisplayView
-from mantidqt.widgets.workspacedisplay.table.tableworkspace_item import QStandardItem, create_table_item
+from mantidqt.widgets.workspacedisplay.table.tableworkspace_item import (
+    QStandardItem,
+    create_table_item,
+    RevertibleItem,
+)
 
 
 class TableWorkspaceDataPresenter(object):
@@ -176,6 +180,9 @@ class TableWorkspaceDisplay(TableWorkspaceDataPresenter, ObservingPresenter, Dat
         """
         :type item: A reference to the item that has been edited
         """
+        if not isinstance(item, RevertibleItem):
+            # Do not perform any additional task for standard QStandardItem
+            return
         try:
             self.model.set_cell_data(item.row(), item.column(), item.data(Qt.DisplayRole),
                                      item.is_v3d)

--- a/qt/python/mantidqt/widgets/workspacedisplay/table/test/test_tableworkspacedisplay_presenter.py
+++ b/qt/python/mantidqt/widgets/workspacedisplay/table/test/test_tableworkspacedisplay_presenter.py
@@ -22,7 +22,7 @@ from mantidqt.widgets.workspacedisplay.table.model import TableWorkspaceDisplayM
 from mantidqt.widgets.workspacedisplay.table.plot_type import PlotType
 from mantidqt.widgets.workspacedisplay.table.presenter import TableWorkspaceDisplay
 from mantidqt.widgets.workspacedisplay.table.view import TableWorkspaceDisplayView
-from mantidqt.widgets.workspacedisplay.table.tableworkspace_item import QStandardItem
+from mantidqt.widgets.workspacedisplay.table.tableworkspace_item import QStandardItem, RevertibleItem
 
 
 class MockQTable:
@@ -114,63 +114,63 @@ class TableWorkspaceDisplayPresenterTest(unittest.TestCase):
 
     @with_mock_presenter
     def test_handleItemChanged(self, ws, view, twd):
-        item = Mock(spec=QStandardItem)
-        item.row.return_value = 5
-        item.column.return_value = 5
-        item.data.return_value = "magic parameter"
-        item.is_v3d = False
+        items = [Mock(spec=RevertibleItem) ,Mock(spec=QStandardItem)]
+        for item in items:
+            item.row.return_value = 5
+            item.column.return_value = 5
+            item.data.return_value = "magic parameter"
 
-        twd.handleItemChanged(item)
+            twd.handleItemChanged(item)
 
-        item.row.assert_called_once_with()
-        item.column.assert_called_once_with()
-        ws.setCell.assert_called_once_with(5, 5, "magic parameter", notify_replace=False)
-        item.update.assert_called_once_with()
-        item.reset.assert_called_once_with()
+            item.row.assert_called_once_with()
+            item.column.assert_called_once_with()
+            ws.setCell.assert_called_once_with(5, 5, "magic parameter", notify_replace=False)
+            item.update.assert_called_once_with()
+            item.reset.assert_called_once_with()
 
     @with_mock_presenter
     def test_handleItemChanged_raises_ValueError(self, ws, view, twd):
-        item = Mock(spec=QStandardItem)
-        item.row.return_value = 5
-        item.column.return_value = 5
-        item.data.return_value = "magic parameter"
-        item.is_v3d = False
+        items = [Mock(spec=RevertibleItem) ,Mock(spec=QStandardItem)]
+        for item in items:
+            item.row.return_value = 5
+            item.column.return_value = 5
+            item.data.return_value = "magic parameter"
 
-        # setCell will throw an exception as a side effect
-        ws.setCell.side_effect = ValueError
+            # setCell will throw an exception as a side effect
+            ws.setCell.side_effect = ValueError
 
-        twd.handleItemChanged(item)
+            twd.handleItemChanged(item)
 
-        item.row.assert_called_once_with()
-        item.column.assert_called_once_with()
-        ws.setCell.assert_called_once_with(5, 5, "magic parameter")
-        view.show_warning.assert_called_once_with(
-            TableWorkspaceDisplay.ITEM_CHANGED_INVALID_DATA_MESSAGE)
-        self.assertNotCalled(item.update)
-        item.reset.assert_called_once_with()
+            item.row.assert_called_once_with()
+            item.column.assert_called_once_with()
+            ws.setCell.assert_called_once_with(5, 5, "magic parameter")
+            view.show_warning.assert_called_once_with(
+                TableWorkspaceDisplay.ITEM_CHANGED_INVALID_DATA_MESSAGE)
+            self.assertNotCalled(item.update)
+            item.reset.assert_called_once_with()
 
     @with_mock_presenter
     def test_handleItemChanged_raises_Exception(self, ws, view, twd):
-        item = Mock(spec=QStandardItem)
+        items = [Mock(spec=RevertibleItem) ,Mock(spec=QStandardItem)]
+        for item in items:
+            item.row.return_value = ws.ROWS
+            item.column.return_value = ws.COLS
+            item.data.return_value = "magic parameter"
+            item.is_v3d = False
 
-        item.row.return_value = ws.ROWS
-        item.column.return_value = ws.COLS
-        item.data.return_value = "magic parameter"
-        item.is_v3d = False
+            # setCell will throw an exception as a side effect
+            error_message = "TEST_EXCEPTION_MESSAGE"
+            ws.setCell.side_effect = Exception(error_message)
 
-        # setCell will throw an exception as a side effect
-        error_message = "TEST_EXCEPTION_MESSAGE"
-        ws.setCell.side_effect = Exception(error_message)
+            twd.handleItemChanged(item)
 
-        twd.handleItemChanged(item)
-
-        item.row.assert_called_once_with()
-        item.column.assert_called_once_with()
-        ws.setCell.assert_called_once_with(ws.ROWS, ws.COLS, "magic parameter")
-        view.show_warning.assert_called_once_with(
-            TableWorkspaceDisplay.ITEM_CHANGED_UNKNOWN_ERROR_MESSAGE.format(error_message))
-        self.assertNotCalled(item.update)
-        item.reset.assert_called_once_with()
+            item.row.assert_called_once_with()
+            item.column.assert_called_once_with()
+            ws.setCell.assert_called_once_with(ws.ROWS, ws.COLS, "magic parameter")
+            view.show_warning.assert_called_once_with(
+                TableWorkspaceDisplay.ITEM_CHANGED_UNKNOWN_ERROR_MESSAGE.format(error_message))
+            self.assertNotCalled(item.update)
+            item.reset.assert_called_once_with()
 
     @with_mock_presenter
     def test_update_column_headers(self, ws, view, twd):


### PR DESCRIPTION
**Description of work.**

Pulls non-formatting changes from #29777 to fix a bug in 5.1 related to altering table & peaks workspaces in workbench.

**To test:**

Try the same steps as #29777 

*There is no associated issue.*

*This does not require release notes* because **the notes will be updated separately if the PR is accepted**

<!-- Ensure the base of this PR is correct (e.g. release-next or master)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
