### PR TITLE
Reenable the miniplot context menues in indirect data analysis

### DIFF
--- a/docs/source/release/v6.0.0/indirect_geometry.rst
+++ b/docs/source/release/v6.0.0/indirect_geometry.rst
@@ -14,6 +14,7 @@ Improvements
 - Added an option to load diffraction data on IN16B.
 - Indirect Data Analysis multiple input tabs can now accept different fit ranges for each spectra.
 - :ref:`QENSFitSequential <algm-QENSFitSequential>` now accepts multiple inputs for `StartX` and `EndX` for each spectra.
+- The context menu for plots in the  indirect data analysis GUI is now enabled.
 
 Bug Fixes
 #########

--- a/qt/scientific_interfaces/Indirect/IndirectFitPlotView.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectFitPlotView.cpp
@@ -84,13 +84,11 @@ void IndirectFitPlotView::createSplitter() {
 
 PreviewPlot *IndirectFitPlotView::createTopPlot() {
   m_topPlot = std::make_unique<PreviewPlot>(m_splitter.get());
-  m_topPlot->disableContextMenu();
   return createPlot(m_topPlot.get(), QSize(0, 125), 0, 10);
 }
 
 PreviewPlot *IndirectFitPlotView::createBottomPlot() {
   m_bottomPlot = std::make_unique<PreviewPlot>(m_splitter.get());
-  m_bottomPlot->disableContextMenu();
   return createPlot(m_bottomPlot.get(), QSize(0, 75), 0, 6);
 }
 

--- a/qt/widgets/plotting/inc/MantidQtWidgets/Plotting/Mpl/PreviewPlot.h
+++ b/qt/widgets/plotting/inc/MantidQtWidgets/Plotting/Mpl/PreviewPlot.h
@@ -88,7 +88,6 @@ public:
   void setAxisRange(const QPair<double, double> &range,
                     AxisID axisID = AxisID::XBottom);
   std::tuple<double, double> getAxisRange(AxisID axisID = AxisID::XBottom);
-  void disableContextMenu();
 
   void allowRedraws(bool state);
   void replotData();
@@ -197,7 +196,6 @@ private:
   QActionGroup *m_contextXScale, *m_contextYScale;
   QAction *m_contextLegend;
   QActionGroup *m_contextErrorBars;
-  bool m_context_enabled;
 };
 
 } // namespace MantidWidgets

--- a/qt/widgets/plotting/src/Mpl/PreviewPlot.cpp
+++ b/qt/widgets/plotting/src/Mpl/PreviewPlot.cpp
@@ -64,7 +64,6 @@ PreviewPlot::PreviewPlot(QWidget *parent, bool observeADS)
   createActions();
 
   m_selectorActive = false;
-  m_context_enabled = true;
 
   m_canvas->installEventFilterToMplCanvas(this);
   watchADS(observeADS);
@@ -480,9 +479,7 @@ bool PreviewPlot::handleMouseReleaseEvent(QMouseEvent *evt) {
   bool stopEvent(false);
   if (evt->button() == Qt::RightButton) {
     stopEvent = true;
-    if (m_context_enabled) {
-      showContextMenu(evt);
-    }
+    showContextMenu(evt);
   } else if (evt->button() == Qt::LeftButton) {
     const auto position = evt->pos();
     if (!position.isNull())
@@ -778,15 +775,6 @@ void PreviewPlot::toggleLegend(const bool checked) {
     removeLegend();
   }
   this->replot();
-}
-
-void PreviewPlot::disableContextMenu() {
-  // Disable the context menu signal
-  // TODO Currently when changes are made to the plot through the context menu
-  // it is not communicated through to the parent GUI which can cause issues,
-  // for now we are disabling the context menu but is should be made to
-  // communicate so it can be reactivated.
-  m_context_enabled = false;
 }
 
 } // namespace MantidWidgets


### PR DESCRIPTION
**Description of work.**

This PR reenables the context menu in indirect data analysis that were disabled in PR #28169
The context menu was dissabled as a temporary fix for issue #28104 but on reenabling the initial issue cannot be replicated.

**To test:**

1. Open the indirect data analysis interface.
2. Go to one of the fitting tabs
3. Load a workspace
4. Right click on the plot and change the x axis scale to log
5. Move the marker
6. the plot should stay in log scale
7. try interacting with the context menu in different ways to break the plots/

Fixes #28104 

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
