### PR TITLE
Fix Instrument View Bug for Rendering Flat Panels

### DIFF
--- a/qt/widgets/instrumentview/inc/MantidQtWidgets/InstrumentView/PanelsSurface.h
+++ b/qt/widgets/instrumentview/inc/MantidQtWidgets/InstrumentView/PanelsSurface.h
@@ -82,7 +82,7 @@ protected:
                                         Mantid::Kernel::V3D normal) const;
   // Add a detector from an assembly
   void addDetector(size_t detIndex, const Mantid::Kernel::V3D &refPos,
-                   int index, const Mantid::Kernel::Quat &rotation);
+                   int bankIndex, const Mantid::Kernel::Quat &rotation);
   // Spread the banks over the projection plane
   void spreadBanks();
   // Find index of the largest bank

--- a/qt/widgets/instrumentview/src/PanelsSurface.cpp
+++ b/qt/widgets/instrumentview/src/PanelsSurface.cpp
@@ -727,7 +727,7 @@ bool PanelsSurface::isOverlapped(QPolygonF &polygon, int iexclude) const {
     if (i == iexclude)
       continue;
     const auto &testPoly = m_flatBanks[i]->polygon;
-#if (QT_VERSION < QT_VERSION_CHECK(5, 0, 0))
+#if (QT_VERSION <= QT_VERSION_CHECK(5, 10, 0))
     QPainterPath subject;
     subject.addPolygon(testPoly);
     QPainterPath clip;

--- a/qt/widgets/instrumentview/src/PanelsSurface.cpp
+++ b/qt/widgets/instrumentview/src/PanelsSurface.cpp
@@ -21,8 +21,8 @@
 #include <QApplication>
 #include <QCursor>
 #include <QMessageBox>
-#include <QtDebug>
 #include <QPainterPath>
+#include <QtDebug>
 
 using namespace Mantid::Geometry;
 using Mantid::Beamline::ComponentType;
@@ -641,7 +641,8 @@ PanelsSurface::calcBankRotation(const Mantid::Kernel::V3D &detPos,
 }
 
 void PanelsSurface::addDetector(size_t detIndex,
-                                const Mantid::Kernel::V3D &refPos, int bankIndex,
+                                const Mantid::Kernel::V3D &refPos,
+                                int bankIndex,
                                 const Mantid::Kernel::Quat &rotation) {
   const auto &detectorInfo = m_instrActor->detectorInfo();
 

--- a/qt/widgets/instrumentview/src/PanelsSurface.cpp
+++ b/qt/widgets/instrumentview/src/PanelsSurface.cpp
@@ -726,15 +726,18 @@ bool PanelsSurface::isOverlapped(QPolygonF &polygon, int iexclude) const {
   for (int i = 0; i < m_flatBanks.size(); ++i) {
     if (i == iexclude)
       continue;
-    /* Once Qt4 support is dropped we should replace with
-     * QPolygonF::instersects()*/
     const auto &testPoly = m_flatBanks[i]->polygon;
+#if (QT_VERSION < QT_VERSION_CHECK(5, 0, 0))
     QPainterPath subject;
     subject.addPolygon(testPoly);
     QPainterPath clip;
     clip.addPolygon(polygon);
     if (subject.intersects(clip))
       return true;
+#else
+    if (testPoly.intersects(polygon))
+      return true;
+#endif
   }
   return false;
 }

--- a/qt/widgets/instrumentview/src/PanelsSurface.cpp
+++ b/qt/widgets/instrumentview/src/PanelsSurface.cpp
@@ -22,6 +22,7 @@
 #include <QCursor>
 #include <QMessageBox>
 #include <QtDebug>
+#include <QPainterPath>
 
 using namespace Mantid::Geometry;
 using Mantid::Beamline::ComponentType;
@@ -189,6 +190,24 @@ size_t findNumDetectors(const ComponentInfo &componentInfo,
   }
   return numDets;
 }
+
+void initialisePolygonWithTransformedBoundingBoxPoints(
+    QPolygonF &panelPolygon, const ComponentInfo &componentInfo,
+    size_t detectorIndex, const V3D &refPos, const Quat &rotation,
+    const V3D &xaxis, const V3D &yaxis) {
+  auto bb = componentInfo.boundingBox(detectorIndex);
+  auto bbMinPoint = bb.minPoint() - refPos;
+  auto bbMaxPoint = bb.maxPoint() - refPos;
+  rotation.rotate(bbMinPoint);
+  rotation.rotate(bbMaxPoint);
+  bbMinPoint += refPos;
+  bbMaxPoint += refPos;
+  QPointF bb0(xaxis.scalar_prod(bbMinPoint), yaxis.scalar_prod(bbMinPoint));
+  QPointF bb1(xaxis.scalar_prod(bbMaxPoint), yaxis.scalar_prod(bbMaxPoint));
+  panelPolygon << bb0;
+  panelPolygon << bb1;
+}
+
 } // namespace
 
 namespace MantidQt {
@@ -316,6 +335,12 @@ void PanelsSurface::addFlatBankOfDetectors(
   QVector<QPointF> vert;
   vert << p1 << p0;
   info->polygon = QPolygonF(vert);
+
+  // initialise bank polygon with sensible bounding box points
+  initialisePolygonWithTransformedBoundingBoxPoints(
+      info->polygon, m_instrActor->componentInfo(), detectors[0], pos0,
+      info->rotation, m_xaxis, m_yaxis);
+
 #pragma omp parallel for ordered
   for (int i = 0; i < static_cast<int>(detectors.size()); ++i) { // NOLINT
     auto detector = detectors[i];
@@ -497,8 +522,9 @@ PanelsSurface::processUnstructured(size_t rootIndex,
   detectors.reserve(numDets);
 
   for (auto child : children) {
-    if (detectorInfo.isMonitor(child))
+    if (!componentInfo.isDetector(child) || detectorInfo.isMonitor(child))
       continue;
+    visited[child] = true;
     auto pos = detectorInfo.position(child);
     if (child == children[0])
       pos0 = pos;
@@ -523,7 +549,6 @@ PanelsSurface::processUnstructured(size_t rootIndex,
     }
     detectors.emplace_back(child);
   }
-  setBankVisited(componentInfo, rootIndex, visited);
   return std::make_pair(detectors, normal);
 }
 
@@ -616,12 +641,12 @@ PanelsSurface::calcBankRotation(const Mantid::Kernel::V3D &detPos,
 }
 
 void PanelsSurface::addDetector(size_t detIndex,
-                                const Mantid::Kernel::V3D &refPos, int index,
+                                const Mantid::Kernel::V3D &refPos, int bankIndex,
                                 const Mantid::Kernel::Quat &rotation) {
   const auto &detectorInfo = m_instrActor->detectorInfo();
 
   auto pos = detectorInfo.position(detIndex);
-  m_detector2bankMap[detIndex] = index;
+  m_detector2bankMap[detIndex] = bankIndex;
   // get the colour
   UnwrappedDetector udet(m_instrActor->getColor(detIndex), detIndex);
   // apply bank's rotation
@@ -700,8 +725,14 @@ bool PanelsSurface::isOverlapped(QPolygonF &polygon, int iexclude) const {
   for (int i = 0; i < m_flatBanks.size(); ++i) {
     if (i == iexclude)
       continue;
-    QPolygonF poly = polygon.intersected(m_flatBanks[i]->polygon);
-    if (poly.size() > 0)
+    /* Once Qt4 support is dropped we should replace with
+     * QPolygonF::instersects()*/
+    const auto &testPoly = m_flatBanks[i]->polygon;
+    QPainterPath subject;
+    subject.addPolygon(testPoly);
+    QPainterPath clip;
+    clip.addPolygon(polygon);
+    if (subject.intersects(clip))
       return true;
   }
   return false;


### PR DESCRIPTION
**Description of work.**

NR Scientists identified a bug in the rendering of the OFFSPEC instrument geometry which caused a crash in Mantid when trying to render the side-by-side view. 

**To test:**

- Launch Mantid and Load any OFFSPEC data file. We have a few files in our testing data.
- Launch the instrument view and select the side-by-side view in the render tab.

Mantid should not crash and a sensible side-by-side view should be rendered.

Fixes #27739. <!-- and fix #xxxx or close #xxxx xor resolves #xxxx -->

<!-- Ensure the base of this PR is correct (e.g. release-next or master)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
