### PR TITLE
Split out monitor/det names into file info

### DIFF
--- a/Framework/PythonInterface/mantid/py36compat/__init__.py
+++ b/Framework/PythonInterface/mantid/py36compat/__init__.py
@@ -1,0 +1,26 @@
+# Mantid Repository : https://github.com/mantidproject/mantid
+#
+# Copyright &copy; 2020 ISIS Rutherford Appleton Laboratory UKRI,
+#     NScD Oak Ridge National Laboratory, European Spallation Source
+#   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+# SPDX - License - Identifier: GPL - 3.0 +
+
+
+"""
+mantid.py36compat
+
+Provides a compatibility layer to backport features found in later
+Python versions (3.7 onwards) to Ubuntu 18.04 / RHEL 7
+which are both on Python 3.6.
+
+"""
+import sys
+
+__requires_compat = False if sys.version_info[0:2] > (3, 6) else True
+
+if __requires_compat:
+    from ._dataclasses.dataclasses import dataclass
+else:
+    from dataclasses import dataclass
+
+__all__ = "dataclass"

--- a/Framework/PythonInterface/mantid/py36compat/_dataclasses/LICENSE.txt
+++ b/Framework/PythonInterface/mantid/py36compat/_dataclasses/LICENSE.txt
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/Framework/PythonInterface/mantid/py36compat/_dataclasses/__init__.py
+++ b/Framework/PythonInterface/mantid/py36compat/_dataclasses/__init__.py
@@ -1,0 +1,1 @@
+from .dataclasses import *

--- a/Framework/PythonInterface/mantid/py36compat/_dataclasses/dataclasses.py
+++ b/Framework/PythonInterface/mantid/py36compat/_dataclasses/dataclasses.py
@@ -1,0 +1,1186 @@
+# Included from https://github.com/ericvsmith/dataclasses
+
+import re
+import sys
+import copy
+import types
+import inspect
+import keyword
+
+__all__ = ['dataclass',
+           'field',
+           'Field',
+           'FrozenInstanceError',
+           'InitVar',
+           'MISSING',
+
+           # Helper functions.
+           'fields',
+           'asdict',
+           'astuple',
+           'make_dataclass',
+           'replace',
+           'is_dataclass',
+           ]
+
+# Conditions for adding methods.  The boxes indicate what action the
+# dataclass decorator takes.  For all of these tables, when I talk
+# about init=, repr=, eq=, order=, unsafe_hash=, or frozen=, I'm
+# referring to the arguments to the @dataclass decorator.  When
+# checking if a dunder method already exists, I mean check for an
+# entry in the class's __dict__.  I never check to see if an attribute
+# is defined in a base class.
+
+# Key:
+# +=========+=========================================+
+# + Value   | Meaning                                 |
+# +=========+=========================================+
+# | <blank> | No action: no method is added.          |
+# +---------+-----------------------------------------+
+# | add     | Generated method is added.              |
+# +---------+-----------------------------------------+
+# | raise   | TypeError is raised.                    |
+# +---------+-----------------------------------------+
+# | None    | Attribute is set to None.               |
+# +=========+=========================================+
+
+# __init__
+#
+#   +--- init= parameter
+#   |
+#   v     |       |       |
+#         |  no   |  yes  |  <--- class has __init__ in __dict__?
+# +=======+=======+=======+
+# | False |       |       |
+# +-------+-------+-------+
+# | True  | add   |       |  <- the default
+# +=======+=======+=======+
+
+# __repr__
+#
+#    +--- repr= parameter
+#    |
+#    v    |       |       |
+#         |  no   |  yes  |  <--- class has __repr__ in __dict__?
+# +=======+=======+=======+
+# | False |       |       |
+# +-------+-------+-------+
+# | True  | add   |       |  <- the default
+# +=======+=======+=======+
+
+
+# __setattr__
+# __delattr__
+#
+#    +--- frozen= parameter
+#    |
+#    v    |       |       |
+#         |  no   |  yes  |  <--- class has __setattr__ or __delattr__ in __dict__?
+# +=======+=======+=======+
+# | False |       |       |  <- the default
+# +-------+-------+-------+
+# | True  | add   | raise |
+# +=======+=======+=======+
+# Raise because not adding these methods would break the "frozen-ness"
+# of the class.
+
+# __eq__
+#
+#    +--- eq= parameter
+#    |
+#    v    |       |       |
+#         |  no   |  yes  |  <--- class has __eq__ in __dict__?
+# +=======+=======+=======+
+# | False |       |       |
+# +-------+-------+-------+
+# | True  | add   |       |  <- the default
+# +=======+=======+=======+
+
+# __lt__
+# __le__
+# __gt__
+# __ge__
+#
+#    +--- order= parameter
+#    |
+#    v    |       |       |
+#         |  no   |  yes  |  <--- class has any comparison method in __dict__?
+# +=======+=======+=======+
+# | False |       |       |  <- the default
+# +-------+-------+-------+
+# | True  | add   | raise |
+# +=======+=======+=======+
+# Raise because to allow this case would interfere with using
+# functools.total_ordering.
+
+# __hash__
+
+#    +------------------- unsafe_hash= parameter
+#    |       +----------- eq= parameter
+#    |       |       +--- frozen= parameter
+#    |       |       |
+#    v       v       v    |        |        |
+#                         |   no   |  yes   |  <--- class has explicitly defined __hash__
+# +=======+=======+=======+========+========+
+# | False | False | False |        |        | No __eq__, use the base class __hash__
+# +-------+-------+-------+--------+--------+
+# | False | False | True  |        |        | No __eq__, use the base class __hash__
+# +-------+-------+-------+--------+--------+
+# | False | True  | False | None   |        | <-- the default, not hashable
+# +-------+-------+-------+--------+--------+
+# | False | True  | True  | add    |        | Frozen, so hashable, allows override
+# +-------+-------+-------+--------+--------+
+# | True  | False | False | add    | raise  | Has no __eq__, but hashable
+# +-------+-------+-------+--------+--------+
+# | True  | False | True  | add    | raise  | Has no __eq__, but hashable
+# +-------+-------+-------+--------+--------+
+# | True  | True  | False | add    | raise  | Not frozen, but hashable
+# +-------+-------+-------+--------+--------+
+# | True  | True  | True  | add    | raise  | Frozen, so hashable
+# +=======+=======+=======+========+========+
+# For boxes that are blank, __hash__ is untouched and therefore
+# inherited from the base class.  If the base is object, then
+# id-based hashing is used.
+#
+# Note that a class may already have __hash__=None if it specified an
+# __eq__ method in the class body (not one that was created by
+# @dataclass).
+#
+# See _hash_action (below) for a coded version of this table.
+
+
+# Raised when an attempt is made to modify a frozen class.
+class FrozenInstanceError(AttributeError): pass
+
+# A sentinel object for default values to signal that a default
+# factory will be used.  This is given a nice repr() which will appear
+# in the function signature of dataclasses' constructors.
+class _HAS_DEFAULT_FACTORY_CLASS:
+    def __repr__(self):
+        return '<factory>'
+_HAS_DEFAULT_FACTORY = _HAS_DEFAULT_FACTORY_CLASS()
+
+# A sentinel object to detect if a parameter is supplied or not.  Use
+# a class to give it a better repr.
+class _MISSING_TYPE:
+    pass
+MISSING = _MISSING_TYPE()
+
+# Since most per-field metadata will be unused, create an empty
+# read-only proxy that can be shared among all fields.
+_EMPTY_METADATA = types.MappingProxyType({})
+
+# Markers for the various kinds of fields and pseudo-fields.
+class _FIELD_BASE:
+    def __init__(self, name):
+        self.name = name
+    def __repr__(self):
+        return self.name
+_FIELD = _FIELD_BASE('_FIELD')
+_FIELD_CLASSVAR = _FIELD_BASE('_FIELD_CLASSVAR')
+_FIELD_INITVAR = _FIELD_BASE('_FIELD_INITVAR')
+
+# The name of an attribute on the class where we store the Field
+# objects.  Also used to check if a class is a Data Class.
+_FIELDS = '__dataclass_fields__'
+
+# The name of an attribute on the class that stores the parameters to
+# @dataclass.
+_PARAMS = '__dataclass_params__'
+
+# The name of the function, that if it exists, is called at the end of
+# __init__.
+_POST_INIT_NAME = '__post_init__'
+
+# String regex that string annotations for ClassVar or InitVar must match.
+# Allows "identifier.identifier[" or "identifier[".
+# https://bugs.python.org/issue33453 for details.
+_MODULE_IDENTIFIER_RE = re.compile(r'^(?:\s*(\w+)\s*\.)?\s*(\w+)')
+
+class _InitVarMeta(type):
+    def __getitem__(self, params):
+        return self
+
+class InitVar(metaclass=_InitVarMeta):
+    pass
+
+
+# Instances of Field are only ever created from within this module,
+# and only from the field() function, although Field instances are
+# exposed externally as (conceptually) read-only objects.
+#
+# name and type are filled in after the fact, not in __init__.
+# They're not known at the time this class is instantiated, but it's
+# convenient if they're available later.
+#
+# When cls._FIELDS is filled in with a list of Field objects, the name
+# and type fields will have been populated.
+class Field:
+    __slots__ = ('name',
+                 'type',
+                 'default',
+                 'default_factory',
+                 'repr',
+                 'hash',
+                 'init',
+                 'compare',
+                 'metadata',
+                 '_field_type',  # Private: not to be used by user code.
+                 )
+
+    def __init__(self, default, default_factory, init, repr, hash, compare,
+                 metadata):
+        self.name = None
+        self.type = None
+        self.default = default
+        self.default_factory = default_factory
+        self.init = init
+        self.repr = repr
+        self.hash = hash
+        self.compare = compare
+        self.metadata = (_EMPTY_METADATA
+                         if metadata is None or len(metadata) == 0 else
+                         types.MappingProxyType(metadata))
+        self._field_type = None
+
+    def __repr__(self):
+        return ('Field('
+                f'name={self.name!r},'
+                f'type={self.type!r},'
+                f'default={self.default!r},'
+                f'default_factory={self.default_factory!r},'
+                f'init={self.init!r},'
+                f'repr={self.repr!r},'
+                f'hash={self.hash!r},'
+                f'compare={self.compare!r},'
+                f'metadata={self.metadata!r},'
+                f'_field_type={self._field_type}'
+                ')')
+
+    # This is used to support the PEP 487 __set_name__ protocol in the
+    # case where we're using a field that contains a descriptor as a
+    # defaul value.  For details on __set_name__, see
+    # https://www.python.org/dev/peps/pep-0487/#implementation-details.
+    #
+    # Note that in _process_class, this Field object is overwritten
+    # with the default value, so the end result is a descriptor that
+    # had __set_name__ called on it at the right time.
+    def __set_name__(self, owner, name):
+        func = getattr(type(self.default), '__set_name__', None)
+        if func:
+            # There is a __set_name__ method on the descriptor, call
+            # it.
+            func(self.default, owner, name)
+
+
+class _DataclassParams:
+    __slots__ = ('init',
+                 'repr',
+                 'eq',
+                 'order',
+                 'unsafe_hash',
+                 'frozen',
+                 )
+
+    def __init__(self, init, repr, eq, order, unsafe_hash, frozen):
+        self.init = init
+        self.repr = repr
+        self.eq = eq
+        self.order = order
+        self.unsafe_hash = unsafe_hash
+        self.frozen = frozen
+
+    def __repr__(self):
+        return ('_DataclassParams('
+                f'init={self.init!r},'
+                f'repr={self.repr!r},'
+                f'eq={self.eq!r},'
+                f'order={self.order!r},'
+                f'unsafe_hash={self.unsafe_hash!r},'
+                f'frozen={self.frozen!r}'
+                ')')
+
+
+# This function is used instead of exposing Field creation directly,
+# so that a type checker can be told (via overloads) that this is a
+# function whose type depends on its parameters.
+def field(*, default=MISSING, default_factory=MISSING, init=True, repr=True,
+          hash=None, compare=True, metadata=None):
+    """Return an object to identify dataclass fields.
+
+    default is the default value of the field.  default_factory is a
+    0-argument function called to initialize a field's value.  If init
+    is True, the field will be a parameter to the class's __init__()
+    function.  If repr is True, the field will be included in the
+    object's repr().  If hash is True, the field will be included in
+    the object's hash().  If compare is True, the field will be used
+    in comparison functions.  metadata, if specified, must be a
+    mapping which is stored but not otherwise examined by dataclass.
+
+    It is an error to specify both default and default_factory.
+    """
+
+    if default is not MISSING and default_factory is not MISSING:
+        raise ValueError('cannot specify both default and default_factory')
+    return Field(default, default_factory, init, repr, hash, compare,
+                 metadata)
+
+
+def _tuple_str(obj_name, fields):
+    # Return a string representing each field of obj_name as a tuple
+    # member.  So, if fields is ['x', 'y'] and obj_name is "self",
+    # return "(self.x,self.y)".
+
+    # Special case for the 0-tuple.
+    if not fields:
+        return '()'
+    # Note the trailing comma, needed if this turns out to be a 1-tuple.
+    return f'({",".join([f"{obj_name}.{f.name}" for f in fields])},)'
+
+
+def _create_fn(name, args, body, *, globals=None, locals=None,
+               return_type=MISSING):
+    # Note that we mutate locals when exec() is called.  Caller
+    # beware!  The only callers are internal to this module, so no
+    # worries about external callers.
+    if locals is None:
+        locals = {}
+    return_annotation = ''
+    if return_type is not MISSING:
+        locals['_return_type'] = return_type
+        return_annotation = '->_return_type'
+    args = ','.join(args)
+    body = '\n'.join(f' {b}' for b in body)
+
+    # Compute the text of the entire function.
+    txt = f'def {name}({args}){return_annotation}:\n{body}'
+
+    exec(txt, globals, locals)
+    return locals[name]
+
+
+def _field_assign(frozen, name, value, self_name):
+    # If we're a frozen class, then assign to our fields in __init__
+    # via object.__setattr__.  Otherwise, just use a simple
+    # assignment.
+    #
+    # self_name is what "self" is called in this function: don't
+    # hard-code "self", since that might be a field name.
+    if frozen:
+        return f'object.__setattr__({self_name},{name!r},{value})'
+    return f'{self_name}.{name}={value}'
+
+
+def _field_init(f, frozen, globals, self_name):
+    # Return the text of the line in the body of __init__ that will
+    # initialize this field.
+
+    default_name = f'_dflt_{f.name}'
+    if f.default_factory is not MISSING:
+        if f.init:
+            # This field has a default factory.  If a parameter is
+            # given, use it.  If not, call the factory.
+            globals[default_name] = f.default_factory
+            value = (f'{default_name}() '
+                     f'if {f.name} is _HAS_DEFAULT_FACTORY '
+                     f'else {f.name}')
+        else:
+            # This is a field that's not in the __init__ params, but
+            # has a default factory function.  It needs to be
+            # initialized here by calling the factory function,
+            # because there's no other way to initialize it.
+
+            # For a field initialized with a default=defaultvalue, the
+            # class dict just has the default value
+            # (cls.fieldname=defaultvalue).  But that won't work for a
+            # default factory, the factory must be called in __init__
+            # and we must assign that to self.fieldname.  We can't
+            # fall back to the class dict's value, both because it's
+            # not set, and because it might be different per-class
+            # (which, after all, is why we have a factory function!).
+
+            globals[default_name] = f.default_factory
+            value = f'{default_name}()'
+    else:
+        # No default factory.
+        if f.init:
+            if f.default is MISSING:
+                # There's no default, just do an assignment.
+                value = f.name
+            elif f.default is not MISSING:
+                globals[default_name] = f.default
+                value = f.name
+        else:
+            # This field does not need initialization.  Signify that
+            # to the caller by returning None.
+            return None
+
+    # Only test this now, so that we can create variables for the
+    # default.  However, return None to signify that we're not going
+    # to actually do the assignment statement for InitVars.
+    if f._field_type is _FIELD_INITVAR:
+        return None
+
+    # Now, actually generate the field assignment.
+    return _field_assign(frozen, f.name, value, self_name)
+
+
+def _init_param(f):
+    # Return the __init__ parameter string for this field.  For
+    # example, the equivalent of 'x:int=3' (except instead of 'int',
+    # reference a variable set to int, and instead of '3', reference a
+    # variable set to 3).
+    if f.default is MISSING and f.default_factory is MISSING:
+        # There's no default, and no default_factory, just output the
+        # variable name and type.
+        default = ''
+    elif f.default is not MISSING:
+        # There's a default, this will be the name that's used to look
+        # it up.
+        default = f'=_dflt_{f.name}'
+    elif f.default_factory is not MISSING:
+        # There's a factory function.  Set a marker.
+        default = '=_HAS_DEFAULT_FACTORY'
+    return f'{f.name}:_type_{f.name}{default}'
+
+
+def _init_fn(fields, frozen, has_post_init, self_name):
+    # fields contains both real fields and InitVar pseudo-fields.
+
+    # Make sure we don't have fields without defaults following fields
+    # with defaults.  This actually would be caught when exec-ing the
+    # function source code, but catching it here gives a better error
+    # message, and future-proofs us in case we build up the function
+    # using ast.
+    seen_default = False
+    for f in fields:
+        # Only consider fields in the __init__ call.
+        if f.init:
+            if not (f.default is MISSING and f.default_factory is MISSING):
+                seen_default = True
+            elif seen_default:
+                raise TypeError(f'non-default argument {f.name!r} '
+                                'follows default argument')
+
+    globals = {'MISSING': MISSING,
+               '_HAS_DEFAULT_FACTORY': _HAS_DEFAULT_FACTORY}
+
+    body_lines = []
+    for f in fields:
+        line = _field_init(f, frozen, globals, self_name)
+        # line is None means that this field doesn't require
+        # initialization (it's a pseudo-field).  Just skip it.
+        if line:
+            body_lines.append(line)
+
+    # Does this class have a post-init function?
+    if has_post_init:
+        params_str = ','.join(f.name for f in fields
+                              if f._field_type is _FIELD_INITVAR)
+        body_lines.append(f'{self_name}.{_POST_INIT_NAME}({params_str})')
+
+    # If no body lines, use 'pass'.
+    if not body_lines:
+        body_lines = ['pass']
+
+    locals = {f'_type_{f.name}': f.type for f in fields}
+    return _create_fn('__init__',
+                      [self_name] + [_init_param(f) for f in fields if f.init],
+                      body_lines,
+                      locals=locals,
+                      globals=globals,
+                      return_type=None)
+
+
+def _repr_fn(fields):
+    return _create_fn('__repr__',
+                      ('self',),
+                      ['return self.__class__.__qualname__ + f"(' +
+                       ', '.join([f"{f.name}={{self.{f.name}!r}}"
+                                  for f in fields]) +
+                       ')"'])
+
+
+def _frozen_get_del_attr(cls, fields):
+    # XXX: globals is modified on the first call to _create_fn, then
+    # the modified version is used in the second call.  Is this okay?
+    globals = {'cls': cls,
+              'FrozenInstanceError': FrozenInstanceError}
+    if fields:
+        fields_str = '(' + ','.join(repr(f.name) for f in fields) + ',)'
+    else:
+        # Special case for the zero-length tuple.
+        fields_str = '()'
+    return (_create_fn('__setattr__',
+                      ('self', 'name', 'value'),
+                      (f'if type(self) is cls or name in {fields_str}:',
+                        ' raise FrozenInstanceError(f"cannot assign to field {name!r}")',
+                       f'super(cls, self).__setattr__(name, value)'),
+                       globals=globals),
+            _create_fn('__delattr__',
+                      ('self', 'name'),
+                      (f'if type(self) is cls or name in {fields_str}:',
+                        ' raise FrozenInstanceError(f"cannot delete field {name!r}")',
+                       f'super(cls, self).__delattr__(name)'),
+                       globals=globals),
+            )
+
+
+def _cmp_fn(name, op, self_tuple, other_tuple):
+    # Create a comparison function.  If the fields in the object are
+    # named 'x' and 'y', then self_tuple is the string
+    # '(self.x,self.y)' and other_tuple is the string
+    # '(other.x,other.y)'.
+
+    return _create_fn(name,
+                      ('self', 'other'),
+                      [ 'if other.__class__ is self.__class__:',
+                       f' return {self_tuple}{op}{other_tuple}',
+                        'return NotImplemented'])
+
+
+def _hash_fn(fields):
+    self_tuple = _tuple_str('self', fields)
+    return _create_fn('__hash__',
+                      ('self',),
+                      [f'return hash({self_tuple})'])
+
+
+def _is_classvar(a_type, typing):
+    # This test uses a typing internal class, but it's the best way to
+    # test if this is a ClassVar.
+    return type(a_type) is typing._ClassVar
+
+
+def _is_initvar(a_type, dataclasses):
+    # The module we're checking against is the module we're
+    # currently in (dataclasses.py).
+    return a_type is dataclasses.InitVar
+
+
+def _is_type(annotation, cls, a_module, a_type, is_type_predicate):
+    # Given a type annotation string, does it refer to a_type in
+    # a_module?  For example, when checking that annotation denotes a
+    # ClassVar, then a_module is typing, and a_type is
+    # typing.ClassVar.
+
+    # It's possible to look up a_module given a_type, but it involves
+    # looking in sys.modules (again!), and seems like a waste since
+    # the caller already knows a_module.
+
+    # - annotation is a string type annotation
+    # - cls is the class that this annotation was found in
+    # - a_module is the module we want to match
+    # - a_type is the type in that module we want to match
+    # - is_type_predicate is a function called with (obj, a_module)
+    #   that determines if obj is of the desired type.
+
+    # Since this test does not do a local namespace lookup (and
+    # instead only a module (global) lookup), there are some things it
+    # gets wrong.
+
+    # With string annotations, cv0 will be detected as a ClassVar:
+    #   CV = ClassVar
+    #   @dataclass
+    #   class C0:
+    #     cv0: CV
+
+    # But in this example cv1 will not be detected as a ClassVar:
+    #   @dataclass
+    #   class C1:
+    #     CV = ClassVar
+    #     cv1: CV
+
+    # In C1, the code in this function (_is_type) will look up "CV" in
+    # the module and not find it, so it will not consider cv1 as a
+    # ClassVar.  This is a fairly obscure corner case, and the best
+    # way to fix it would be to eval() the string "CV" with the
+    # correct global and local namespaces.  However that would involve
+    # a eval() penalty for every single field of every dataclass
+    # that's defined.  It was judged not worth it.
+
+    match = _MODULE_IDENTIFIER_RE.match(annotation)
+    if match:
+        ns = None
+        module_name = match.group(1)
+        if not module_name:
+            # No module name, assume the class's module did
+            # "from dataclasses import InitVar".
+            ns = sys.modules.get(cls.__module__).__dict__
+        else:
+            # Look up module_name in the class's module.
+            module = sys.modules.get(cls.__module__)
+            if module and module.__dict__.get(module_name) is a_module:
+                ns = sys.modules.get(a_type.__module__).__dict__
+        if ns and is_type_predicate(ns.get(match.group(2)), a_module):
+            return True
+    return False
+
+
+def _get_field(cls, a_name, a_type):
+    # Return a Field object for this field name and type.  ClassVars
+    # and InitVars are also returned, but marked as such (see
+    # f._field_type).
+
+    # If the default value isn't derived from Field, then it's only a
+    # normal default value.  Convert it to a Field().
+    default = getattr(cls, a_name, MISSING)
+    if isinstance(default, Field):
+        f = default
+    else:
+        if isinstance(default, types.MemberDescriptorType):
+            # This is a field in __slots__, so it has no default value.
+            default = MISSING
+        f = field(default=default)
+
+    # Only at this point do we know the name and the type.  Set them.
+    f.name = a_name
+    f.type = a_type
+
+    # Assume it's a normal field until proven otherwise.  We're next
+    # going to decide if it's a ClassVar or InitVar, everything else
+    # is just a normal field.
+    f._field_type = _FIELD
+
+    # In addition to checking for actual types here, also check for
+    # string annotations.  get_type_hints() won't always work for us
+    # (see https://github.com/python/typing/issues/508 for example),
+    # plus it's expensive and would require an eval for every stirng
+    # annotation.  So, make a best effort to see if this is a ClassVar
+    # or InitVar using regex's and checking that the thing referenced
+    # is actually of the correct type.
+
+    # For the complete discussion, see https://bugs.python.org/issue33453
+
+    # If typing has not been imported, then it's impossible for any
+    # annotation to be a ClassVar.  So, only look for ClassVar if
+    # typing has been imported by any module (not necessarily cls's
+    # module).
+    typing = sys.modules.get('typing')
+    if typing:
+        if (_is_classvar(a_type, typing)
+            or (isinstance(f.type, str)
+                and _is_type(f.type, cls, typing, typing.ClassVar,
+                             _is_classvar))):
+            f._field_type = _FIELD_CLASSVAR
+
+    # If the type is InitVar, or if it's a matching string annotation,
+    # then it's an InitVar.
+    if f._field_type is _FIELD:
+        # The module we're checking against is the module we're
+        # currently in (dataclasses.py).
+        dataclasses = sys.modules[__name__]
+        if (_is_initvar(a_type, dataclasses)
+            or (isinstance(f.type, str)
+                and _is_type(f.type, cls, dataclasses, dataclasses.InitVar,
+                             _is_initvar))):
+            f._field_type = _FIELD_INITVAR
+
+    # Validations for individual fields.  This is delayed until now,
+    # instead of in the Field() constructor, since only here do we
+    # know the field name, which allows for better error reporting.
+
+    # Special restrictions for ClassVar and InitVar.
+    if f._field_type in (_FIELD_CLASSVAR, _FIELD_INITVAR):
+        if f.default_factory is not MISSING:
+            raise TypeError(f'field {f.name} cannot have a '
+                            'default factory')
+        # Should I check for other field settings? default_factory
+        # seems the most serious to check for.  Maybe add others.  For
+        # example, how about init=False (or really,
+        # init=<not-the-default-init-value>)?  It makes no sense for
+        # ClassVar and InitVar to specify init=<anything>.
+
+    # For real fields, disallow mutable defaults for known types.
+    if f._field_type is _FIELD and isinstance(f.default, (list, dict, set)):
+        raise ValueError(f'mutable default {type(f.default)} for field '
+                         f'{f.name} is not allowed: use default_factory')
+
+    return f
+
+
+def _set_new_attribute(cls, name, value):
+    # Never overwrites an existing attribute.  Returns True if the
+    # attribute already exists.
+    if name in cls.__dict__:
+        return True
+    setattr(cls, name, value)
+    return False
+
+
+# Decide if/how we're going to create a hash function.  Key is
+# (unsafe_hash, eq, frozen, does-hash-exist).  Value is the action to
+# take.  The common case is to do nothing, so instead of providing a
+# function that is a no-op, use None to signify that.
+
+def _hash_set_none(cls, fields):
+    return None
+
+def _hash_add(cls, fields):
+    flds = [f for f in fields if (f.compare if f.hash is None else f.hash)]
+    return _hash_fn(flds)
+
+def _hash_exception(cls, fields):
+    # Raise an exception.
+    raise TypeError(f'Cannot overwrite attribute __hash__ '
+                    f'in class {cls.__name__}')
+
+#
+#                +-------------------------------------- unsafe_hash?
+#                |      +------------------------------- eq?
+#                |      |      +------------------------ frozen?
+#                |      |      |      +----------------  has-explicit-hash?
+#                |      |      |      |
+#                |      |      |      |        +-------  action
+#                |      |      |      |        |
+#                v      v      v      v        v
+_hash_action = {(False, False, False, False): None,
+                (False, False, False, True ): None,
+                (False, False, True,  False): None,
+                (False, False, True,  True ): None,
+                (False, True,  False, False): _hash_set_none,
+                (False, True,  False, True ): None,
+                (False, True,  True,  False): _hash_add,
+                (False, True,  True,  True ): None,
+                (True,  False, False, False): _hash_add,
+                (True,  False, False, True ): _hash_exception,
+                (True,  False, True,  False): _hash_add,
+                (True,  False, True,  True ): _hash_exception,
+                (True,  True,  False, False): _hash_add,
+                (True,  True,  False, True ): _hash_exception,
+                (True,  True,  True,  False): _hash_add,
+                (True,  True,  True,  True ): _hash_exception,
+                }
+# See https://bugs.python.org/issue32929#msg312829 for an if-statement
+# version of this table.
+
+
+def _process_class(cls, init, repr, eq, order, unsafe_hash, frozen):
+    # Now that dicts retain insertion order, there's no reason to use
+    # an ordered dict.  I am leveraging that ordering here, because
+    # derived class fields overwrite base class fields, but the order
+    # is defined by the base class, which is found first.
+    fields = {}
+
+    setattr(cls, _PARAMS, _DataclassParams(init, repr, eq, order,
+                                           unsafe_hash, frozen))
+
+    # Find our base classes in reverse MRO order, and exclude
+    # ourselves.  In reversed order so that more derived classes
+    # override earlier field definitions in base classes.  As long as
+    # we're iterating over them, see if any are frozen.
+    any_frozen_base = False
+    has_dataclass_bases = False
+    for b in cls.__mro__[-1:0:-1]:
+        # Only process classes that have been processed by our
+        # decorator.  That is, they have a _FIELDS attribute.
+        base_fields = getattr(b, _FIELDS, None)
+        if base_fields:
+            has_dataclass_bases = True
+            for f in base_fields.values():
+                fields[f.name] = f
+            if getattr(b, _PARAMS).frozen:
+                any_frozen_base = True
+
+    # Annotations that are defined in this class (not in base
+    # classes).  If __annotations__ isn't present, then this class
+    # adds no new annotations.  We use this to compute fields that are
+    # added by this class.
+    #
+    # Fields are found from cls_annotations, which is guaranteed to be
+    # ordered.  Default values are from class attributes, if a field
+    # has a default.  If the default value is a Field(), then it
+    # contains additional info beyond (and possibly including) the
+    # actual default value.  Pseudo-fields ClassVars and InitVars are
+    # included, despite the fact that they're not real fields.  That's
+    # dealt with later.
+    cls_annotations = cls.__dict__.get('__annotations__', {})
+
+    # Now find fields in our class.  While doing so, validate some
+    # things, and set the default values (as class attributes) where
+    # we can.
+    cls_fields = [_get_field(cls, name, type)
+                  for name, type in cls_annotations.items()]
+    for f in cls_fields:
+        fields[f.name] = f
+
+        # If the class attribute (which is the default value for this
+        # field) exists and is of type 'Field', replace it with the
+        # real default.  This is so that normal class introspection
+        # sees a real default value, not a Field.
+        if isinstance(getattr(cls, f.name, None), Field):
+            if f.default is MISSING:
+                # If there's no default, delete the class attribute.
+                # This happens if we specify field(repr=False), for
+                # example (that is, we specified a field object, but
+                # no default value).  Also if we're using a default
+                # factory.  The class attribute should not be set at
+                # all in the post-processed class.
+                delattr(cls, f.name)
+            else:
+                setattr(cls, f.name, f.default)
+
+    # Do we have any Field members that don't also have annotations?
+    for name, value in cls.__dict__.items():
+        if isinstance(value, Field) and not name in cls_annotations:
+            raise TypeError(f'{name!r} is a field but has no type annotation')
+
+    # Check rules that apply if we are derived from any dataclasses.
+    if has_dataclass_bases:
+        # Raise an exception if any of our bases are frozen, but we're not.
+        if any_frozen_base and not frozen:
+            raise TypeError('cannot inherit non-frozen dataclass from a '
+                            'frozen one')
+
+        # Raise an exception if we're frozen, but none of our bases are.
+        if not any_frozen_base and frozen:
+            raise TypeError('cannot inherit frozen dataclass from a '
+                            'non-frozen one')
+
+    # Remember all of the fields on our class (including bases).  This
+    # also marks this class as being a dataclass.
+    setattr(cls, _FIELDS, fields)
+
+    # Was this class defined with an explicit __hash__?  Note that if
+    # __eq__ is defined in this class, then python will automatically
+    # set __hash__ to None.  This is a heuristic, as it's possible
+    # that such a __hash__ == None was not auto-generated, but it
+    # close enough.
+    class_hash = cls.__dict__.get('__hash__', MISSING)
+    has_explicit_hash = not (class_hash is MISSING or
+                             (class_hash is None and '__eq__' in cls.__dict__))
+
+    # If we're generating ordering methods, we must be generating the
+    # eq methods.
+    if order and not eq:
+        raise ValueError('eq must be true if order is true')
+
+    if init:
+        # Does this class have a post-init function?
+        has_post_init = hasattr(cls, _POST_INIT_NAME)
+
+        # Include InitVars and regular fields (so, not ClassVars).
+        flds = [f for f in fields.values()
+                if f._field_type in (_FIELD, _FIELD_INITVAR)]
+        _set_new_attribute(cls, '__init__',
+                           _init_fn(flds,
+                                    frozen,
+                                    has_post_init,
+                                    # The name to use for the "self"
+                                    # param in __init__.  Use "self"
+                                    # if possible.
+                                    '__dataclass_self__' if 'self' in fields
+                                            else 'self',
+                          ))
+
+    # Get the fields as a list, and include only real fields.  This is
+    # used in all of the following methods.
+    field_list = [f for f in fields.values() if f._field_type is _FIELD]
+
+    if repr:
+        flds = [f for f in field_list if f.repr]
+        _set_new_attribute(cls, '__repr__', _repr_fn(flds))
+
+    if eq:
+        # Create _eq__ method.  There's no need for a __ne__ method,
+        # since python will call __eq__ and negate it.
+        flds = [f for f in field_list if f.compare]
+        self_tuple = _tuple_str('self', flds)
+        other_tuple = _tuple_str('other', flds)
+        _set_new_attribute(cls, '__eq__',
+                           _cmp_fn('__eq__', '==',
+                                   self_tuple, other_tuple))
+
+    if order:
+        # Create and set the ordering methods.
+        flds = [f for f in field_list if f.compare]
+        self_tuple = _tuple_str('self', flds)
+        other_tuple = _tuple_str('other', flds)
+        for name, op in [('__lt__', '<'),
+                         ('__le__', '<='),
+                         ('__gt__', '>'),
+                         ('__ge__', '>='),
+                         ]:
+            if _set_new_attribute(cls, name,
+                                  _cmp_fn(name, op, self_tuple, other_tuple)):
+                raise TypeError(f'Cannot overwrite attribute {name} '
+                                f'in class {cls.__name__}. Consider using '
+                                'functools.total_ordering')
+
+    if frozen:
+        for fn in _frozen_get_del_attr(cls, field_list):
+            if _set_new_attribute(cls, fn.__name__, fn):
+                raise TypeError(f'Cannot overwrite attribute {fn.__name__} '
+                                f'in class {cls.__name__}')
+
+    # Decide if/how we're going to create a hash function.
+    hash_action = _hash_action[bool(unsafe_hash),
+                               bool(eq),
+                               bool(frozen),
+                               has_explicit_hash]
+    if hash_action:
+        # No need to call _set_new_attribute here, since by the time
+        # we're here the overwriting is unconditional.
+        cls.__hash__ = hash_action(cls, field_list)
+
+    if not getattr(cls, '__doc__'):
+        # Create a class doc-string.
+        cls.__doc__ = (cls.__name__ +
+                       str(inspect.signature(cls)).replace(' -> None', ''))
+
+    return cls
+
+
+# _cls should never be specified by keyword, so start it with an
+# underscore.  The presence of _cls is used to detect if this
+# decorator is being called with parameters or not.
+def dataclass(_cls=None, *, init=True, repr=True, eq=True, order=False,
+              unsafe_hash=False, frozen=False):
+    """Returns the same class as was passed in, with dunder methods
+    added based on the fields defined in the class.
+
+    Examines PEP 526 __annotations__ to determine fields.
+
+    If init is true, an __init__() method is added to the class. If
+    repr is true, a __repr__() method is added. If order is true, rich
+    comparison dunder methods are added. If unsafe_hash is true, a
+    __hash__() method function is added. If frozen is true, fields may
+    not be assigned to after instance creation.
+    """
+
+    def wrap(cls):
+        return _process_class(cls, init, repr, eq, order, unsafe_hash, frozen)
+
+    # See if we're being called as @dataclass or @dataclass().
+    if _cls is None:
+        # We're called with parens.
+        return wrap
+
+    # We're called as @dataclass without parens.
+    return wrap(_cls)
+
+
+def fields(class_or_instance):
+    """Return a tuple describing the fields of this dataclass.
+
+    Accepts a dataclass or an instance of one. Tuple elements are of
+    type Field.
+    """
+
+    # Might it be worth caching this, per class?
+    try:
+        fields = getattr(class_or_instance, _FIELDS)
+    except AttributeError:
+        raise TypeError('must be called with a dataclass type or instance')
+
+    # Exclude pseudo-fields.  Note that fields is sorted by insertion
+    # order, so the order of the tuple is as the fields were defined.
+    return tuple(f for f in fields.values() if f._field_type is _FIELD)
+
+
+def _is_dataclass_instance(obj):
+    """Returns True if obj is an instance of a dataclass."""
+    return not isinstance(obj, type) and hasattr(obj, _FIELDS)
+
+
+def is_dataclass(obj):
+    """Returns True if obj is a dataclass or an instance of a
+    dataclass."""
+    return hasattr(obj, _FIELDS)
+
+
+def asdict(obj, *, dict_factory=dict):
+    """Return the fields of a dataclass instance as a new dictionary mapping
+    field names to field values.
+
+    Example usage:
+
+      @dataclass
+      class C:
+          x: int
+          y: int
+
+      c = C(1, 2)
+      assert asdict(c) == {'x': 1, 'y': 2}
+
+    If given, 'dict_factory' will be used instead of built-in dict.
+    The function applies recursively to field values that are
+    dataclass instances. This will also look into built-in containers:
+    tuples, lists, and dicts.
+    """
+    if not _is_dataclass_instance(obj):
+        raise TypeError("asdict() should be called on dataclass instances")
+    return _asdict_inner(obj, dict_factory)
+
+
+def _asdict_inner(obj, dict_factory):
+    if _is_dataclass_instance(obj):
+        result = []
+        for f in fields(obj):
+            value = _asdict_inner(getattr(obj, f.name), dict_factory)
+            result.append((f.name, value))
+        return dict_factory(result)
+    elif isinstance(obj, (list, tuple)):
+        return type(obj)(_asdict_inner(v, dict_factory) for v in obj)
+    elif isinstance(obj, dict):
+        return type(obj)((_asdict_inner(k, dict_factory), _asdict_inner(v, dict_factory))
+                          for k, v in obj.items())
+    else:
+        return copy.deepcopy(obj)
+
+
+def astuple(obj, *, tuple_factory=tuple):
+    """Return the fields of a dataclass instance as a new tuple of field values.
+
+    Example usage::
+
+      @dataclass
+      class C:
+          x: int
+          y: int
+
+    c = C(1, 2)
+    assert astuple(c) == (1, 2)
+
+    If given, 'tuple_factory' will be used instead of built-in tuple.
+    The function applies recursively to field values that are
+    dataclass instances. This will also look into built-in containers:
+    tuples, lists, and dicts.
+    """
+
+    if not _is_dataclass_instance(obj):
+        raise TypeError("astuple() should be called on dataclass instances")
+    return _astuple_inner(obj, tuple_factory)
+
+
+def _astuple_inner(obj, tuple_factory):
+    if _is_dataclass_instance(obj):
+        result = []
+        for f in fields(obj):
+            value = _astuple_inner(getattr(obj, f.name), tuple_factory)
+            result.append(value)
+        return tuple_factory(result)
+    elif isinstance(obj, (list, tuple)):
+        return type(obj)(_astuple_inner(v, tuple_factory) for v in obj)
+    elif isinstance(obj, dict):
+        return type(obj)((_astuple_inner(k, tuple_factory), _astuple_inner(v, tuple_factory))
+                          for k, v in obj.items())
+    else:
+        return copy.deepcopy(obj)
+
+
+def make_dataclass(cls_name, fields, *, bases=(), namespace=None, init=True,
+                   repr=True, eq=True, order=False, unsafe_hash=False,
+                   frozen=False):
+    """Return a new dynamically created dataclass.
+
+    The dataclass name will be 'cls_name'.  'fields' is an iterable
+    of either (name), (name, type) or (name, type, Field) objects. If type is
+    omitted, use the string 'typing.Any'.  Field objects are created by
+    the equivalent of calling 'field(name, type [, Field-info])'.
+
+      C = make_dataclass('C', ['x', ('y', int), ('z', int, field(init=False))], bases=(Base,))
+
+    is equivalent to:
+
+      @dataclass
+      class C(Base):
+          x: 'typing.Any'
+          y: int
+          z: int = field(init=False)
+
+    For the bases and namespace parameters, see the builtin type() function.
+
+    The parameters init, repr, eq, order, unsafe_hash, and frozen are passed to
+    dataclass().
+    """
+
+    if namespace is None:
+        namespace = {}
+    else:
+        # Copy namespace since we're going to mutate it.
+        namespace = namespace.copy()
+
+    # While we're looking through the field names, validate that they
+    # are identifiers, are not keywords, and not duplicates.
+    seen = set()
+    anns = {}
+    for item in fields:
+        if isinstance(item, str):
+            name = item
+            tp = 'typing.Any'
+        elif len(item) == 2:
+            name, tp, = item
+        elif len(item) == 3:
+            name, tp, spec = item
+            namespace[name] = spec
+        else:
+            raise TypeError(f'Invalid field: {item!r}')
+
+        if not isinstance(name, str) or not name.isidentifier():
+            raise TypeError(f'Field names must be valid identifers: {name!r}')
+        if keyword.iskeyword(name):
+            raise TypeError(f'Field names must not be keywords: {name!r}')
+        if name in seen:
+            raise TypeError(f'Field name duplicated: {name!r}')
+
+        seen.add(name)
+        anns[name] = tp
+
+    namespace['__annotations__'] = anns
+    # We use `types.new_class()` instead of simply `type()` to allow dynamic creation
+    # of generic dataclassses.
+    cls = types.new_class(cls_name, bases, {}, lambda ns: ns.update(namespace))
+    return dataclass(cls, init=init, repr=repr, eq=eq, order=order,
+                     unsafe_hash=unsafe_hash, frozen=frozen)
+
+
+def replace(obj, **changes):
+    """Return a new object replacing specified fields with new values.
+
+    This is especially useful for frozen classes.  Example usage:
+
+      @dataclass(frozen=True)
+      class C:
+          x: int
+          y: int
+
+      c = C(1, 2)
+      c1 = replace(c, x=3)
+      assert c1.x == 3 and c1.y == 2
+      """
+
+    # We're going to mutate 'changes', but that's okay because it's a
+    # new dict, even if called with 'replace(obj, **my_changes)'.
+
+    if not _is_dataclass_instance(obj):
+        raise TypeError("replace() should be called on dataclass instances")
+
+    # It's an error to have init=False fields in 'changes'.
+    # If a field is not in 'changes', read its value from the provided obj.
+
+    for f in getattr(obj, _FIELDS).values():
+        # Only consider normal fields or InitVars.
+        if f._field_type is _FIELD_CLASSVAR:
+            continue
+
+        if not f.init:
+            # Error if this field is specified in changes.
+            if f.name in changes:
+                raise ValueError(f'field {f.name} is declared with '
+                                 'init=False, it cannot be specified with '
+                                 'replace()')
+            continue
+
+        if f.name not in changes:
+            if f._field_type is _FIELD_INITVAR:
+                raise ValueError(f"InitVar {f.name!r} "
+                                 'must be specified with replace()')
+            changes[f.name] = getattr(obj, f.name)
+
+    # Create the new object, which calls __init__() and
+    # __post_init__() (if defined), using all of the init fields we've
+    # added and/or left in 'changes'.  If there are values supplied in
+    # changes that aren't fields, this will correctly raise a
+    # TypeError.
+    return obj.__class__(**changes)

--- a/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/SANS/SANSBeamCentreFinderCore.py
+++ b/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/SANS/SANSBeamCentreFinderCore.py
@@ -22,6 +22,7 @@ from sans.algorithm_detail.xml_shapes import quadrant_xml
 from sans.common.constants import EMPTY_NAME
 from sans.common.enums import (DetectorType, DataType, MaskingQuadrant)
 from sans.common.general_functions import create_child_algorithm, append_to_sans_file_tag
+from sans.state.AllStates import AllStates
 from sans.state.Serializer import Serializer
 
 
@@ -297,12 +298,12 @@ class SANSBeamCentreFinderCore(DataProcessorAlgorithm):
         slice_event_factor = returned["SliceEventFactor"]
         return workspace, monitor_workspace, slice_event_factor
 
-    def _move(self, state, workspace, component, is_transmission=False):
+    def _move(self, state: AllStates, workspace, component, is_transmission=False):
         # First we set the workspace to zero, since it might have been moved around by the user in the ADS
         # Second we use the initial move to bring the workspace into the correct position
-        move_component(move_info=state.move, component_name='', move_type=MoveTypes.RESET_POSITION,
+        move_component(state=state, component_name='', move_type=MoveTypes.RESET_POSITION,
                        workspace=workspace)
-        move_component(component_name=component, move_info=state.move, move_type=MoveTypes.INITIAL_MOVE,
+        move_component(component_name=component, state=state, move_type=MoveTypes.INITIAL_MOVE,
                        workspace=workspace, is_transmission_workspace=is_transmission)
         return workspace
 

--- a/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/SANS/SANSBeamCentreFinderMassMethod.py
+++ b/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/SANS/SANSBeamCentreFinderMassMethod.py
@@ -217,10 +217,10 @@ class SANSBeamCentreFinderMassMethod(DataProcessorAlgorithm):
     def _move(self, state, workspace, component, is_transmission=False):
         # First we set the workspace to zero, since it might have been moved around by the user in the ADS
         # Second we use the initial move to bring the workspace into the correct position
-        move_component(move_info=state.move, component_name='',
+        move_component(state=state, component_name='',
                        workspace=workspace, move_type=MoveTypes.RESET_POSITION)
 
-        move_component(component_name=component, move_info=state.move, workspace=workspace,
+        move_component(component_name=component, state=state, workspace=workspace,
                        is_transmission_workspace=is_transmission, move_type=MoveTypes.INITIAL_MOVE)
         return workspace
 

--- a/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/SANS/SANSLoad.py
+++ b/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/SANS/SANSLoad.py
@@ -330,10 +330,10 @@ class SANSLoad(ParallelDataProcessorAlgorithm):
                                SANSDataType.SAMPLE_TRANSMISSION, SANSDataType.SAMPLE_DIRECT]
 
             for workspace in workspace_list:
-                move_component(component_name="", move_info=state.move,
+                move_component(component_name="", state=state,
                                workspace=workspace, move_type=MoveTypes.RESET_POSITION)
 
-                move_component(component_name="LAB", move_info=state.move,
+                move_component(component_name="LAB", state=state,
                                beam_coordinates=beam_coordinates, move_type=MoveTypes.INITIAL_MOVE,
                                workspace=workspace, is_transmission_workspace=is_trans)
 

--- a/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/SANS/SANSReductionCoreBase.py
+++ b/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/SANS/SANSReductionCoreBase.py
@@ -124,10 +124,10 @@ class SANSReductionCoreBase(DistributedDataProcessorAlgorithm):
     def _move(self, state, workspace, component, is_transmission=False):
         # First we set the workspace to zero, since it might have been moved around by the user in the ADS
         # Second we use the initial move to bring the workspace into the correct position
-        move_component(component_name="", move_info=state.move, move_type=MoveTypes.RESET_POSITION,
+        move_component(component_name="", state=state, move_type=MoveTypes.RESET_POSITION,
                        workspace=workspace)
 
-        move_component(component_name=component, move_info=state.move, move_type=MoveTypes.INITIAL_MOVE,
+        move_component(component_name=component, state=state, move_type=MoveTypes.INITIAL_MOVE,
                        workspace=workspace, is_transmission_workspace=is_transmission)
 
         return workspace

--- a/scripts/SANS/sans/algorithm_detail/mask_sans_workspace.py
+++ b/scripts/SANS/sans/algorithm_detail/mask_sans_workspace.py
@@ -7,9 +7,10 @@
 from sans.algorithm_detail.mask_workspace import create_masker
 from sans.common.enums import DetectorType
 from sans.common.general_functions import append_to_sans_file_tag
+from sans.state.AllStates import AllStates
 
 
-def mask_workspace(state, component_as_string, workspace):
+def mask_workspace(state: AllStates, component_as_string, workspace):
     assert (state is not dict)
     component = DetectorType(component_as_string)
 
@@ -18,7 +19,8 @@ def mask_workspace(state, component_as_string, workspace):
 
     # Perform the masking
     mask_info = state.mask
-    workspace = masker.mask_workspace(mask_info, workspace, component)
+    inst_info = state.instrument_info
+    workspace = masker.mask_workspace(mask_info, inst_info, workspace, component)
 
     append_to_sans_file_tag(workspace, "_masked")
     return workspace

--- a/scripts/SANS/sans/algorithm_detail/mask_workspace.py
+++ b/scripts/SANS/sans/algorithm_detail/mask_workspace.py
@@ -100,7 +100,7 @@ def mask_cylinder(mask_info, workspace):
     return workspace
 
 
-def mask_with_mask_files(mask_info, workspace):
+def mask_with_mask_files(mask_info, inst_info, workspace):
     """
     Apply mask files to the workspace
 
@@ -118,7 +118,7 @@ def mask_with_mask_files(mask_info, workspace):
     """
     mask_files = mask_info.mask_files
     if mask_files:
-        idf_path = mask_info.idf_path
+        idf_path = inst_info.idf_path
 
         # Mask loader
         load_name = "LoadMask"
@@ -361,7 +361,7 @@ class Masker(metaclass=ABCMeta):
         super(Masker, self).__init__()
 
     @abstractmethod
-    def mask_workspace(self, mask_info, workspace_to_mask, detector_type):
+    def mask_workspace(self, mask_info, inst_info, workspace_to_mask, detector_type):
         pass
 
 
@@ -369,7 +369,7 @@ class NullMasker(Masker):
     def __init__(self):
         super(NullMasker, self).__init__()
 
-    def mask_workspace(self, mask_info, workspace_to_mask, detector_type):
+    def mask_workspace(self, mask_info, inst_info, workspace_to_mask, detector_type):
         return workspace_to_mask
 
 
@@ -378,7 +378,7 @@ class MaskerISIS(Masker):
         super(MaskerISIS, self).__init__()
         self._spectra_block = spectra_block
 
-    def mask_workspace(self, mask_info, workspace_to_mask, detector_type):
+    def mask_workspace(self, mask_info, inst_info, workspace_to_mask, detector_type):
         """
         Performs the different types of masks that are currently available for ISIS reductions.
 
@@ -395,7 +395,7 @@ class MaskerISIS(Masker):
         workspace_to_mask = mask_cylinder(mask_info, workspace_to_mask)
 
         # Apply the xml mask files
-        workspace_to_mask = mask_with_mask_files(mask_info, workspace_to_mask)
+        workspace_to_mask = mask_with_mask_files(mask_info, inst_info, workspace_to_mask)
 
         # Mask spectrum list
         workspace_to_mask = mask_spectra(mask_info, workspace_to_mask, self._spectra_block, detector_type)

--- a/scripts/SANS/sans/algorithm_detail/move_workspaces.py
+++ b/scripts/SANS/sans/algorithm_detail/move_workspaces.py
@@ -9,10 +9,13 @@
 import math
 from mantid.api import MatrixWorkspace
 from abc import (ABCMeta, abstractmethod)
-from sans.state.StateObjects.StateMoveDetectors import StateMove
+
+from sans.state.AllStates import AllStates
+from sans.state.StateObjects.StateMoveDetectors import StateMoveLARMOR, StateMoveLOQ, StateMove, StateMoveSANS2D, \
+    StateMoveZOOM
 from sans.common.enums import CanonicalCoordinates, DetectorType, SANSInstrument
 from sans.common.general_functions import (create_unmanaged_algorithm, get_single_valued_logs_from_workspace,
-                                           quaternion_to_angle_and_axis, sanitise_instrument_name)
+                                           sanitise_instrument_name, quaternion_to_angle_and_axis)
 
 
 # -------------------------------------------------
@@ -76,15 +79,15 @@ def rotate_component(workspace, angle, direction, component_to_rotate):
     alg.execute()
 
 
-def move_monitor(ws, move_info, monitor_offset, monitor_spectrum_number):
+def move_monitor(ws, inst_info, monitor_offset, monitor_spectrum_number):
     """
     Moves a monitor relative to it's original position
     :param ws: The workspace to move the monitor in
-    :param move_info: A dictionary containing various move details
+    :param inst_info: StateInstInfo object
     :param monitor_offset: Offset to shift by (m)
     :param monitor_spectrum_number: The spectrum number of the monitor to shift
     """
-    monitor_n_name = move_info.monitor_names[str(monitor_spectrum_number)]
+    monitor_n_name = inst_info.monitor_names[str(monitor_spectrum_number)]
 
     z_move = monitor_offset
     offset = {CanonicalCoordinates.Z: z_move}
@@ -92,18 +95,18 @@ def move_monitor(ws, move_info, monitor_offset, monitor_spectrum_number):
     move_component(ws, offset, monitor_n_name)
 
 
-def move_backstop_monitor(ws, move_info, monitor_offset, monitor_spectrum_number):
+def move_backstop_monitor(ws, inst_info, monitor_offset, monitor_spectrum_number):
     """
     Moves the monitor attached to the backstop (rear-detector) relative to
     the rear detector
     :param ws: The workspace to move the monitor in
-    :param move_info: A dictionary containing various move details
+    :param inst_info: StateInstrument information
     :param monitor_offset: Offset to shift by (m)
     :param monitor_spectrum_number: The spectrum number of the monitor to shift
     """
     monitor_spectrum_number_as_string = str(monitor_spectrum_number)
     # TODO we should pass the detector ID through, not the spec num
-    monitor_n_name = move_info.monitor_names[monitor_spectrum_number_as_string]
+    monitor_n_name = inst_info.monitor_names[monitor_spectrum_number_as_string]
 
     comp_info = ws.componentInfo()
     monitor_n = comp_info.indexOfAny(monitor_n_name)
@@ -112,8 +115,7 @@ def move_backstop_monitor(ws, move_info, monitor_offset, monitor_spectrum_number
     monitor_position = comp_info.position(monitor_n)
 
     # The location is relative to the rear-detector, get this position
-    lab_detector = move_info.detectors[DetectorType.LAB.value]
-    detector_name = lab_detector.detector_name
+    detector_name = inst_info.detector_names[DetectorType.LAB.value].detector_name
     lab_detector_index = comp_info.indexOfAny(detector_name)
     detector_position = comp_info.position(lab_detector_index)
 
@@ -139,7 +141,7 @@ def move_sample_holder(workspace, sample_offset, sample_offset_direction):
     move_component(workspace, offset, 'some-sample-holder')
 
 
-def apply_standard_displacement(move_info, workspace, coordinates, component):
+def apply_standard_displacement(inst_info, workspace, coordinates, component):
     """
     Applies a standard displacement to a workspace.
 
@@ -152,7 +154,7 @@ def apply_standard_displacement(move_info, workspace, coordinates, component):
     :param component: the component which is to be moved.
     """
     # Get the detector name
-    component_name = move_info.detectors[component].detector_name
+    component_name = inst_info.detector_names[component].detector_name
     # Offset
     offset = {CanonicalCoordinates.X: coordinates[0],
               CanonicalCoordinates.Y: coordinates[1]}
@@ -246,31 +248,31 @@ def set_selected_components_to_original_position(workspace, component_names):
                 rot_alg.execute()
 
 
-def set_components_to_original_for_isis(move_info, workspace, component):
+def set_components_to_original_for_isis(inst_info, workspace, component):
     """
     This function resets the components for ISIS instruments. These are normally HAB, LAB, the monitors and
     the sample holder
 
-    :param move_info: a StateMove object.
+    :param inst_info: a StateInstrumentInfo object.
     :param workspace: the workspace which is being reset.
     :param component: the component which is being reset on the workspace. If this is not specified, then
                       everything is being reset.
     """
-    def _reset_detector(_key, _move_info, _component_names):
-        if _key in _move_info.detectors:
-            _detector_name = _move_info.detectors[_key].detector_name
+    def _reset_detector(_key, _inst_info, _component_names):
+        if _key in _inst_info.detector_names:
+            _detector_name = _inst_info.detector_names[_key].detector_name
             if _detector_name:
                 _component_names.append(_detector_name)
 
     # We reset the HAB, the LAB, the sample holder and monitor 4
     if not component:
-        component_names = list(move_info.monitor_names.values())
+        component_names = list(inst_info.monitor_names.values())
 
         hab_key = DetectorType.HAB.value
-        _reset_detector(hab_key, move_info, component_names)
+        _reset_detector(hab_key, inst_info, component_names)
 
         lab_key = DetectorType.LAB.value
-        _reset_detector(lab_key, move_info, component_names)
+        _reset_detector(lab_key, inst_info, component_names)
 
         component_names.append("some-sample-holder")
     else:
@@ -280,7 +282,7 @@ def set_components_to_original_for_isis(move_info, workspace, component):
     set_selected_components_to_original_position(workspace, component_names)
 
 
-def get_detector_component(move_info, component):
+def get_detector_component(inst_info, component):
     """
     Gets the detector component on the workspace
 
@@ -290,15 +292,15 @@ def get_detector_component(move_info, component):
     """
     component_selection = component
     if component:
-        for detector_key in list(move_info.detectors.keys()):
-            is_name = component == move_info.detectors[detector_key].detector_name
-            is_name_short = component == move_info.detectors[detector_key].detector_name_short
+        for detector_key, value in list(inst_info.detector_names.items()):
+            is_name = component == value.detector_name
+            is_name_short = component == value.detector_name_short
             if is_name or is_name_short:
                 component_selection = detector_key
     return component_selection
 
 
-def move_low_angle_bank_for_SANS2D_and_ZOOM(move_info, workspace, coordinates, use_rear_det_z=True):
+def move_low_angle_bank_for_SANS2D_and_ZOOM(move_info, inst_info, workspace, coordinates, use_rear_det_z=True):
     # REAR_DET_Z
     if use_rear_det_z:
         lab_detector_z_tag = "Rear_Det_Z"
@@ -315,14 +317,14 @@ def move_low_angle_bank_for_SANS2D_and_ZOOM(move_info, workspace, coordinates, u
 
     # Perform x and y tilt
     lab_detector = move_info.detectors[DetectorType.LAB.value]
-    SANSMoveSANS2D.perform_x_and_y_tilts(workspace, lab_detector)
+    detector_name = inst_info.detector_names[DetectorType.LAB.value].detector_name
+    SANSMoveSANS2D.perform_x_and_y_tilts(workspace, lab_detector, detector_name)
 
     lab_detector_default_sd_m = move_info.lab_detector_default_sd_m
     x_shift = -coordinates[0]
     y_shift = -coordinates[1]
 
     z_shift = (lab_detector_z + lab_detector.z_translation_correction) - lab_detector_default_sd_m
-    detector_name = lab_detector.detector_name
     offset = {CanonicalCoordinates.X: x_shift,
               CanonicalCoordinates.Y: y_shift,
               CanonicalCoordinates.Z: z_shift}
@@ -333,19 +335,21 @@ def move_low_angle_bank_for_SANS2D_and_ZOOM(move_info, workspace, coordinates, u
 # Move classes
 # -------------------------------------------------
 class SANSMove(metaclass=ABCMeta):
-    def __init__(self):
+    def __init__(self, state: AllStates):
         super(SANSMove, self).__init__()
+        self.inst_state = state.instrument_info
+        self.move_state = state.move
 
     @abstractmethod
-    def do_move_initial(self, move_info, workspace, coordinates, component, is_transmission_workspace):
+    def do_move_initial(self, workspace, coordinates, component, is_transmission_workspace):
         pass
 
     @abstractmethod
-    def do_move_with_elementary_displacement(self, move_info, workspace, coordinates, component):
+    def do_move_with_elementary_displacement(self, workspace, coordinates, component):
         pass
 
     @abstractmethod
-    def do_set_to_zero(self, move_info, workspace, component):
+    def do_set_to_zero(self, workspace, component):
         pass
 
     @staticmethod
@@ -353,33 +357,35 @@ class SANSMove(metaclass=ABCMeta):
     def is_correct(instrument_type, run_number, **kwargs):
         pass
 
-    def move_initial(self, move_info, workspace, coordinates, component, is_transmission_workspace):
-        SANSMove._validate(move_info, workspace, coordinates, component)
-        component_selection = get_detector_component(move_info, component)
-        return self.do_move_initial(move_info, workspace, coordinates, component_selection, is_transmission_workspace)
+    def move_initial(self, workspace, coordinates, component, is_transmission_workspace):
+        self._validate(workspace, coordinates, component)
+        component_selection = get_detector_component(self.inst_state, component)
+        return self.do_move_initial(workspace, coordinates, component_selection, is_transmission_workspace)
 
-    def move_with_elementary_displacement(self, move_info, workspace, coordinates, component):
-        SANSMove._validate(move_info, workspace, coordinates, component)
-        component_selection = get_detector_component(move_info, component)
-        return self.do_move_with_elementary_displacement(move_info, workspace, coordinates, component_selection)
+    def move_with_elementary_displacement(self, workspace, coordinates, component):
+        self._validate(workspace, coordinates, component)
+        component_selection = get_detector_component(self.inst_state, component)
+        return self.do_move_with_elementary_displacement(workspace, coordinates, component_selection)
 
-    def set_to_zero(self, move_info, workspace, component):
-        SANSMove._validate_set_to_zero(move_info, workspace, component)
-        return self.do_set_to_zero(move_info, workspace, component)
+    def set_to_zero(self, workspace, component):
+        self._validate_set_to_zero(workspace, component)
+        return self.do_set_to_zero(workspace, component)
 
-    @staticmethod
-    def _validate_component(move_info, component):
+    def _validate_component(self, component):
         if component is not None and len(component) != 0:
             found_name = False
-            for detector_keys in list(move_info.detectors.keys()):
-                is_name = component == move_info.detectors[detector_keys].detector_name
-                is_name_short = component == move_info.detectors[detector_keys].detector_name_short
+
+            detector_names = self.inst_state.detector_names
+
+            for detector_keys in list(self.move_state.detectors.keys()):
+                is_name = component == detector_names[detector_keys].detector_name
+                is_name_short = component == detector_names[detector_keys].detector_name_short
                 if is_name or is_name_short:
                     found_name = True
                     break
             if not found_name:
-                raise ValueError("MoveInstrumentComponent: The component to be moved {0} cannot be found in the"
-                                 " state information of type {1}".format(str(component), str(type(move_info))))
+                raise ValueError(f"MoveInstrumentComponent: The component to be moved {str(component)}"
+                                 f" cannot be found in the state information of type {type(self.move_state)}")
 
     @staticmethod
     def _validate_workspace(workspace):
@@ -392,30 +398,27 @@ class SANSMove(metaclass=ABCMeta):
             raise ValueError("MoveInstrumentComponent: The provided state information is of the wrong type. It must be"
                              " of type StateMove, but was {0}".format(str(type(move_info))))
 
-    @staticmethod
-    def _validate(move_info, workspace, coordinates, component):
-        SANSMove._validate_state(move_info)
+    def _validate(self, workspace, coordinates, component):
+        self._validate_state(self.move_state)
         if coordinates is None or len(coordinates) == 0:
             raise ValueError("MoveInstrumentComponent: The provided coordinates cannot be empty.")
-        SANSMove._validate_workspace(workspace)
-        SANSMove._validate_component(move_info, component)
-        move_info.validate()
+        self._validate_workspace(workspace)
+        self._validate_component(component)
+        self.move_state.validate()
 
-    @staticmethod
-    def _validate_set_to_zero(move_info, workspace, component):
-        SANSMove._validate_state(move_info)
-        SANSMove._validate_workspace(workspace)
-        SANSMove._validate_component(move_info, component)
-        move_info.validate()
+    def _validate_set_to_zero(self, workspace, component):
+        self._validate_state(self.move_state)
+        self._validate_workspace(workspace)
+        self._validate_component(component)
+        self.move_state.validate()
 
 
 class SANSMoveSANS2D(SANSMove):
-    def __init__(self):
-        super(SANSMoveSANS2D, self).__init__()
+    def __init__(self, state):
+        super(SANSMoveSANS2D, self).__init__(state)
 
     @staticmethod
-    def perform_x_and_y_tilts(workspace, detector):
-        detector_name = detector.detector_name
+    def perform_x_and_y_tilts(workspace, detector, detector_name):
         # Perform rotation a y tilt correction. This tilt rotates around the instrument axis / around the X-AXIS!
         y_tilt_correction = detector.y_tilt_correction
         if y_tilt_correction != 0.0:
@@ -433,8 +436,7 @@ class SANSMoveSANS2D(SANSMove):
             rotate_component(workspace, x_tilt_correction, x_tilt_correction_direction, detector_name)
 
 # pylint: disable=too-many-locals
-    @staticmethod
-    def _move_high_angle_bank(move_info, workspace, coordinates):
+    def _move_high_angle_bank(self, workspace, coordinates):
         # Get FRONT_DET_X, FRONT_DET_Z, FRONT_DET_ROT, REAR_DET_X
 
         hab_detector_x_tag = "Front_Det_X"
@@ -447,6 +449,8 @@ class SANSMoveSANS2D(SANSMove):
         log_values = get_single_valued_logs_from_workspace(workspace, log_names, log_types,
                                                            convert_from_millimeter_to_meter=True)
 
+        move_info = self.move_state
+        assert isinstance(move_info, StateMoveSANS2D)
         hab_detector_x = move_info.hab_detector_x \
             if log_values[hab_detector_x_tag] is None else log_values[hab_detector_x_tag]
 
@@ -469,10 +473,10 @@ class SANSMoveSANS2D(SANSMove):
 
         # Detector and name
         hab_detector = move_info.detectors[DetectorType.HAB.value]
-        detector_name = hab_detector.detector_name
+        detector_name = self.inst_state.detector_names[DetectorType.HAB.value].detector_name
 
         # Perform x and y tilt
-        SANSMoveSANS2D.perform_x_and_y_tilts(workspace, hab_detector)
+        SANSMoveSANS2D.perform_x_and_y_tilts(workspace, hab_detector, detector_name)
 
         # Perform rotation of around the Y-AXIS. This is more complicated as the high angle bank detector is
         # offset.
@@ -505,46 +509,47 @@ class SANSMoveSANS2D(SANSMove):
 
         move_component(workspace, offset, detector_name)
 
-    @staticmethod
-    def _move_low_angle_bank(move_info, workspace, coordinates):
-        move_low_angle_bank_for_SANS2D_and_ZOOM(move_info, workspace, coordinates)
+    def _move_low_angle_bank(self, workspace, coordinates):
+        assert isinstance(self.move_state, StateMoveSANS2D)
+        move_low_angle_bank_for_SANS2D_and_ZOOM(self.move_state, self.inst_state, workspace, coordinates)
 
-    @staticmethod
-    def _move_monitor_n(workspace, move_info, monitor_spectrum_number):
+    def _move_monitor_n(self, workspace, monitor_spectrum_number):
         # Only monitor 4 can be moved for SANS2D
         assert(monitor_spectrum_number == 4)
 
-        move_backstop_monitor(ws=workspace, move_info=move_info,
+        move_info = self.move_state
+        assert isinstance(move_info, StateMoveSANS2D)
+        move_backstop_monitor(ws=workspace, inst_info=self.inst_state,
                               monitor_spectrum_number=monitor_spectrum_number,
                               monitor_offset=move_info.monitor_4_offset)
 
-    def do_move_initial(self, move_info, workspace, coordinates, component, is_transmission_workspace):
+    def do_move_initial(self, workspace, coordinates, component, is_transmission_workspace):
         # For LOQ we only have to coordinates
         assert len(coordinates) == 2
         _component = component  # noqa
         _is_transmission_workspace = is_transmission_workspace  # noqa
 
         # Move the high angle bank
-        self._move_high_angle_bank(move_info, workspace, coordinates)
+        self._move_high_angle_bank(workspace, coordinates)
 
         # Move the low angle bank
-        self._move_low_angle_bank(move_info, workspace, coordinates)
+        self._move_low_angle_bank(workspace, coordinates)
 
         # Move the sample holder
-        move_sample_holder(workspace, move_info.sample_offset, move_info.sample_offset_direction)
+        move_sample_holder(workspace, self.move_state.sample_offset, self.move_state.sample_offset_direction)
 
         # Move monitor
         monitor_spectrum_number = 4
-        self._move_monitor_n(workspace, move_info, monitor_spectrum_number=monitor_spectrum_number)
+        self._move_monitor_n(workspace, monitor_spectrum_number=monitor_spectrum_number)
 
-    def do_move_with_elementary_displacement(self, move_info, workspace, coordinates, component):
+    def do_move_with_elementary_displacement(self, workspace, coordinates, component):
         # For LOQ we only have to coordinates
         assert len(coordinates) == 2
         coordinates_to_move = [-coordinates[0], -coordinates[1]]
-        apply_standard_displacement(move_info, workspace, coordinates_to_move, component)
+        apply_standard_displacement(self.inst_state, workspace, coordinates_to_move, component)
 
-    def do_set_to_zero(self, move_info, workspace, component):
-        set_components_to_original_for_isis(move_info, workspace, component)
+    def do_set_to_zero(self, workspace, component):
+        set_components_to_original_for_isis(self.inst_state, workspace, component)
 
     @staticmethod
     def is_correct(instrument_type, run_number, **kwargs):
@@ -552,14 +557,16 @@ class SANSMoveSANS2D(SANSMove):
 
 
 class SANSMoveLOQ(SANSMove):
-    def __init__(self):
-        super(SANSMoveLOQ, self).__init__()
+    def __init__(self, state):
+        super(SANSMoveLOQ, self).__init__(state)
 
-    def do_move_initial(self, move_info, workspace, coordinates, component, is_transmission_workspace):
+    def do_move_initial(self, workspace, coordinates, component, is_transmission_workspace):
         # For LOQ we only have two coordinates
         assert len(coordinates) == 2
         if not is_transmission_workspace:
             # First move the sample holder
+            move_info = self.move_state
+            assert isinstance(move_info, StateMoveLOQ)
             move_sample_holder(workspace, move_info.sample_offset, move_info.sample_offset_direction)
 
             x = coordinates[0]
@@ -572,7 +579,7 @@ class SANSMoveLOQ(SANSMove):
             detectors = [DetectorType.LAB.value, DetectorType.HAB.value]
             for detector in detectors:
                 # Get the detector name
-                component_name = move_info.detectors[detector].detector_name
+                component_name = self.inst_state.detector_names[detector].detector_name
 
                 # Shift the detector by the the input amount
                 offset = {CanonicalCoordinates.X: x_shift,
@@ -585,14 +592,14 @@ class SANSMoveLOQ(SANSMove):
                                            CanonicalCoordinates.Z: move_info.detectors[detector].z_translation_correction}
                 move_component(workspace, offset_from_corrections, component_name)
 
-    def do_move_with_elementary_displacement(self, move_info, workspace, coordinates, component):
+    def do_move_with_elementary_displacement(self, workspace, coordinates, component):
         # For LOQ we only have to coordinates
         assert len(coordinates) == 2
         coordinates_to_move = [-coordinates[0], -coordinates[1]]
-        apply_standard_displacement(move_info, workspace, coordinates_to_move, component)
+        apply_standard_displacement(self.inst_state, workspace, coordinates_to_move, component)
 
-    def do_set_to_zero(self, move_info, workspace, component):
-        set_components_to_original_for_isis(move_info, workspace, component)
+    def do_set_to_zero(self, workspace, component):
+        set_components_to_original_for_isis(self.inst_state, workspace, component)
 
     @staticmethod
     def is_correct(instrument_type, run_number, **kwargs):
@@ -600,14 +607,16 @@ class SANSMoveLOQ(SANSMove):
 
 
 class SANSMoveLARMOROldStyle(SANSMove):
-    def __init__(self):
-        super(SANSMoveLARMOROldStyle, self).__init__()
+    def __init__(self, state):
+        super(SANSMoveLARMOROldStyle, self).__init__(state)
 
-    def do_move_initial(self, move_info, workspace, coordinates, component, is_transmission_workspace):
+    def do_move_initial(self, workspace, coordinates, component, is_transmission_workspace):
         _is_transmission_workspace = is_transmission_workspace  # noqa
 
         # For LARMOR we only have to coordinates
         assert len(coordinates) == 2
+
+        move_info = self.move_state
 
         # Move the sample holder
         move_sample_holder(workspace, move_info.sample_offset, move_info.sample_offset_direction)
@@ -615,16 +624,16 @@ class SANSMoveLARMOROldStyle(SANSMove):
         # Shift the low-angle bank detector in the y direction
         y_shift = -coordinates[1]
         coordinates_for_only_y = [0.0, y_shift]
-        apply_standard_displacement(move_info, workspace, coordinates_for_only_y,
+        apply_standard_displacement(self.inst_state, workspace, coordinates_for_only_y,
                                     DetectorType.LAB.value)
 
         # Shift the low-angle bank detector in the x direction
         x_shift = -coordinates[0]
         coordinates_for_only_x = [x_shift, 0.0]
-        apply_standard_displacement(move_info, workspace, coordinates_for_only_x,
+        apply_standard_displacement(self.inst_state, workspace, coordinates_for_only_x,
                                     DetectorType.LAB.value)
 
-    def do_move_with_elementary_displacement(self, move_info, workspace, coordinates, component):
+    def do_move_with_elementary_displacement(self, workspace, coordinates, component):
         # For LOQ we only have to coordinates
         assert len(coordinates) == 2
 
@@ -632,15 +641,15 @@ class SANSMoveLARMOROldStyle(SANSMove):
         # Shift the low-angle bank detector in the y direction
         y_shift = -coordinates[1]
         coordinates_for_only_y = [0.0, y_shift]
-        apply_standard_displacement(move_info, workspace, coordinates_for_only_y, component)
+        apply_standard_displacement(self.inst_state, workspace, coordinates_for_only_y, component)
 
         # Shift component along the x direction
         x_shift = -coordinates[0]
         coordinates_for_only_x = [x_shift, 0.0]
-        apply_standard_displacement(move_info, workspace, coordinates_for_only_x, component)
+        apply_standard_displacement(self.inst_state, workspace, coordinates_for_only_x, component)
 
-    def do_set_to_zero(self, move_info, workspace, component):
-        set_components_to_original_for_isis(move_info, workspace, component)
+    def do_set_to_zero(self, workspace, component):
+        set_components_to_original_for_isis(self.inst_state, workspace, component)
 
     @staticmethod
     def is_correct(instrument_type, run_number, **kwargs):
@@ -651,13 +660,12 @@ class SANSMoveLARMOROldStyle(SANSMove):
 
 
 class SANSMoveLARMORNewStyle(SANSMove):
-    def __init__(self):
-        super(SANSMoveLARMORNewStyle, self).__init__()
+    def __init__(self, state):
+        super(SANSMoveLARMORNewStyle, self).__init__(state)
 
     @staticmethod
-    def _rotate_around_y_axis(move_info, workspace, angle, component, bench_rotation):
-        detector = move_info.detectors[component]
-        detector_name = detector.detector_name
+    def _rotate_around_y_axis(inst_info, workspace, angle, component, bench_rotation):
+        detector_name = inst_info.detector_names[component].detector_name
         # Note that the angle definition for the bench in LARMOR and in Mantid seem to have a different handedness
         total_angle = bench_rotation - angle
         direction = {CanonicalCoordinates.X: 0.0,
@@ -665,11 +673,14 @@ class SANSMoveLARMORNewStyle(SANSMove):
                      CanonicalCoordinates.Z: 0.0}
         rotate_component(workspace, total_angle, direction, detector_name)
 
-    def do_move_initial(self, move_info, workspace, coordinates, component, is_transmission_workspace):
+    def do_move_initial(self, workspace, coordinates, component, is_transmission_workspace):
         _is_transmission_workspace = is_transmission_workspace  # noqa
 
         # For LARMOR we only have to coordinates
         assert len(coordinates) == 2
+
+        move_info = self.move_state
+        assert isinstance(move_info, StateMoveLARMOR)
 
         # Move the sample holder
         move_sample_holder(workspace, move_info.sample_offset, move_info.sample_offset_direction)
@@ -677,7 +688,7 @@ class SANSMoveLARMORNewStyle(SANSMove):
         # Shift the low-angle bank detector in the y direction
         y_shift = -coordinates[1]
         coordinates_for_only_y = [0.0, y_shift]
-        apply_standard_displacement(move_info, workspace, coordinates_for_only_y,
+        apply_standard_displacement(self.inst_state, workspace, coordinates_for_only_y,
                                     DetectorType.LAB.value)
 
         # Shift the low-angle bank detector in the x direction
@@ -690,10 +701,10 @@ class SANSMoveLARMORNewStyle(SANSMove):
         bench_rotation = move_info.bench_rotation \
             if log_values[bench_rot_tag] is None else log_values[bench_rot_tag]
 
-        self._rotate_around_y_axis(move_info, workspace, angle,
+        self._rotate_around_y_axis(self.inst_state, workspace, angle,
                                    DetectorType.LAB.value, bench_rotation)
 
-    def do_move_with_elementary_displacement(self, move_info, workspace, coordinates, component):
+    def do_move_with_elementary_displacement(self, workspace, coordinates, component):
         # For LOQ we only have to coordinates
         assert len(coordinates) == 2
 
@@ -701,14 +712,14 @@ class SANSMoveLARMORNewStyle(SANSMove):
         # Shift the low-angle bank detector in the y direction
         y_shift = -coordinates[1]
         coordinates_for_only_y = [0.0, y_shift]
-        apply_standard_displacement(move_info, workspace, coordinates_for_only_y, component)
+        apply_standard_displacement(self.inst_state, workspace, coordinates_for_only_y, component)
 
         # Shift component along the x direction; not that we don't want to perform a bench rotation again
         angle = coordinates[0]
-        self._rotate_around_y_axis(move_info, workspace, angle, component, 0.0)
+        self._rotate_around_y_axis(self.inst_state, workspace, angle, component, 0.0)
 
-    def do_set_to_zero(self, move_info, workspace, component):
-        set_components_to_original_for_isis(move_info, workspace, component)
+    def do_set_to_zero(self, workspace, component):
+        set_components_to_original_for_isis(self.inst_state, workspace, component)
 
     @staticmethod
     def is_correct(instrument_type, run_number, **kwargs):
@@ -718,29 +729,30 @@ class SANSMoveLARMORNewStyle(SANSMove):
 
 
 class SANSMoveZOOM(SANSMove):
-    @staticmethod
-    def _move_low_angle_bank(move_info, workspace, coordinates):
-        move_low_angle_bank_for_SANS2D_and_ZOOM(move_info, workspace, coordinates, use_rear_det_z=False)
+    def _move_low_angle_bank(self, workspace, coordinates):
+        assert isinstance(self.move_state, StateMoveZOOM)
+        move_low_angle_bank_for_SANS2D_and_ZOOM(self.move_state, self.inst_state, workspace,
+                                                coordinates, use_rear_det_z=False)
 
-    @staticmethod
-    def _move_monitor_n(workspace, move_info):
+    def _move_monitor_n(self, workspace):
         """
         Moves n monitors in the workspace
         :param workspace: The associated workspace
-        :param move_info: A move info object containing this instruments details
         """
 
         # Apply monitor 4 offset
-        move_monitor(ws=workspace, move_info=move_info,
+        move_info = self.move_state
+        assert isinstance(move_info, StateMoveZOOM)
+        move_monitor(ws=workspace, inst_info=self.inst_state,
                      monitor_offset=move_info.monitor_4_offset,
                      monitor_spectrum_number=4)
 
         # Apply monitor 5 offset
-        move_backstop_monitor(ws=workspace, move_info=move_info,
+        move_backstop_monitor(ws=workspace, inst_info=self.inst_state,
                               monitor_offset=move_info.monitor_5_offset,
                               monitor_spectrum_number=5)
 
-    def do_move_initial(self, move_info, workspace, coordinates, component, is_transmission_workspace):
+    def do_move_initial(self, workspace, coordinates, component, is_transmission_workspace):
         # For ZOOM we only have to coordinates
         assert len(coordinates) == 2
 
@@ -748,29 +760,30 @@ class SANSMoveZOOM(SANSMove):
         _is_transmission_workspace = is_transmission_workspace  # noqa
 
         # Move the low angle bank
-        self._move_low_angle_bank(move_info, workspace, coordinates)
+        self._move_low_angle_bank(workspace, coordinates)
 
+        move_info = self.move_state
         # Move the sample holder
         move_sample_holder(workspace, move_info.sample_offset, move_info.sample_offset_direction)
 
         # Move the monitors
-        self._move_monitor_n(workspace, move_info)
+        self._move_monitor_n(workspace)
 
-    def do_move_with_elementary_displacement(self, move_info, workspace, coordinates, component):
+    def do_move_with_elementary_displacement(self, workspace, coordinates, component):
         # For ZOOM we only have to coordinates
         assert len(coordinates) == 2
         coordinates_to_move = [-coordinates[0], -coordinates[1]]
-        apply_standard_displacement(move_info, workspace, coordinates_to_move, component)
+        apply_standard_displacement(self.inst_state, workspace, coordinates_to_move, component)
 
-    def do_set_to_zero(self, move_info, workspace, component):
-        set_components_to_original_for_isis(move_info, workspace, component)
+    def do_set_to_zero(self, workspace, component):
+        set_components_to_original_for_isis(self.inst_state, workspace, component)
 
     @staticmethod
     def is_correct(instrument_type, run_number, **kwargs):
         return instrument_type is SANSInstrument.ZOOM
 
 
-def create_mover(workspace):
+def create_mover(workspace, state):
     # Get selection
     run_number = workspace.getRunNumber()
     instrument = workspace.getInstrument()
@@ -778,16 +791,15 @@ def create_mover(workspace):
     instrument_name = sanitise_instrument_name(instrument_name)
     instrument_type = SANSInstrument[instrument_name]
     if SANSMoveLOQ.is_correct(instrument_type, run_number):
-        mover = SANSMoveLOQ()
+        mover = SANSMoveLOQ(state)
     elif SANSMoveSANS2D.is_correct(instrument_type, run_number):
-        mover = SANSMoveSANS2D()
+        mover = SANSMoveSANS2D(state)
     elif SANSMoveLARMOROldStyle.is_correct(instrument_type, run_number):
-        mover = SANSMoveLARMOROldStyle()
+        mover = SANSMoveLARMOROldStyle(state)
     elif SANSMoveLARMORNewStyle.is_correct(instrument_type, run_number):
-        mover = SANSMoveLARMORNewStyle()
+        mover = SANSMoveLARMORNewStyle(state)
     elif SANSMoveZOOM.is_correct(instrument_type, run_number):
-        mover = SANSMoveZOOM()
+        mover = SANSMoveZOOM(state)
     else:
-        mover = None
-        NotImplementedError("SANSLoaderFactory: Other instruments are not implemented yet.")
+        raise NotImplementedError("SANSLoaderFactory: Other instruments are not implemented yet.")
     return mover

--- a/scripts/SANS/sans/common/general_functions.py
+++ b/scripts/SANS/sans/common/general_functions.py
@@ -679,8 +679,7 @@ def get_standard_output_workspace_name(state, reduction_data_type,
         period_as_string = ""
 
     # 3. Detector name
-    move = state.move
-    detectors = move.detectors
+    detectors = state.instrument_info.detector_names
     if reduction_data_type is ReductionMode.MERGED:
         detector_name_short = "merged"
     elif reduction_data_type is ReductionMode.HAB:

--- a/scripts/SANS/sans/gui_logic/presenter/masking_table_presenter.py
+++ b/scripts/SANS/sans/gui_logic/presenter/masking_table_presenter.py
@@ -86,9 +86,8 @@ def perform_load(serialized_state):
 
 
 def perform_move(state, workspace):
-    move_info = state.move
-    move_component(move_info=move_info, component_name='', workspace=workspace, move_type=MoveTypes.RESET_POSITION)
-    move_component(component_name=None, move_info=move_info, workspace=workspace, move_type=MoveTypes.INITIAL_MOVE)
+    move_component(state=state, component_name='', workspace=workspace, move_type=MoveTypes.RESET_POSITION)
+    move_component(component_name=None, state=state, workspace=workspace, move_type=MoveTypes.INITIAL_MOVE)
 
 
 def store_in_ads_as_hidden(workspace_name, workspace):

--- a/scripts/SANS/sans/state/AllStates.py
+++ b/scripts/SANS/sans/state/AllStates.py
@@ -23,6 +23,7 @@ from sans.state.StateObjects.StateSave import StateSave
 from sans.state.StateObjects.StateScale import StateScale
 from sans.state.StateObjects.StateSliceEvent import StateSliceEvent
 from sans.state.StateObjects.StateWavelength import StateWavelength
+from sans.state.StateObjects.state_instrument_info import StateInstrumentInfo
 from sans.state.automatic_setters import automatic_setters
 
 
@@ -37,6 +38,7 @@ class AllStates(metaclass=JsonSerializable):
         super(AllStates, self).__init__()
         self.data : StateData = StateData()
         self.move: StateMove = StateMove()
+        self.instrument_info: StateInstrumentInfo = StateInstrumentInfo()
         self.reduction: StateReductionMode = StateReductionMode()
         self.slice: StateSliceEvent = StateSliceEvent()
         self.mask: StateMask = StateMask()

--- a/scripts/SANS/sans/state/IStateParser.py
+++ b/scripts/SANS/sans/state/IStateParser.py
@@ -22,6 +22,7 @@ from sans.state.StateObjects.StateScale import StateScale
 from sans.state.StateObjects.StateSliceEvent import StateSliceEvent
 from sans.state.StateObjects.StateWavelength import StateWavelength
 from sans.state.StateObjects.StateWavelengthAndPixelAdjustment import StateWavelengthAndPixelAdjustment
+from sans.state.StateObjects.state_instrument_info import StateInstrumentInfo
 
 
 class IStateParser(metaclass=ABCMeta):
@@ -38,6 +39,7 @@ class IStateParser(metaclass=ABCMeta):
         all_states.convert_to_q = self.get_state_convert_to_q()
         all_states.compatibility = self.get_state_compatibility()
         all_states.data = self.get_state_data(file_information)
+        all_states.instrument_info = StateInstrumentInfo.build_from_data_info(all_states.data)
 
         return all_states
 

--- a/scripts/SANS/sans/state/StateObjects/StateMaskDetectors.py
+++ b/scripts/SANS/sans/state/StateObjects/StateMaskDetectors.py
@@ -14,7 +14,7 @@ from typing import List
 
 from sans.state.JsonSerializable import JsonSerializable
 from sans.state.automatic_setters import automatic_setters
-from sans.state.state_functions import (is_pure_none_or_not_none, validation_message, set_detector_names)
+from sans.state.state_functions import (is_pure_none_or_not_none, validation_message)
 
 from sans.common.file_information import find_full_file_path
 from sans.common.enums import (DetectorType, SANSInstrument)
@@ -201,9 +201,6 @@ class StateMask(metaclass=JsonSerializable):
         # The detector dependent masks
         self.detectors = None  # : Dict
 
-        # The idf path of the instrument
-        self.idf_path = ""
-
     def validate(self):
         is_invalid = dict()
 
@@ -306,25 +303,12 @@ class StateMaskNoInst(StateMask):
 # ----------------------------------------------------------------------------------------------------------------------
 
 
-def setup_idf_and_ipf_content(move_info, data_info):
-    # Get the IDF and IPF path since they contain most of the import information
-    idf_file_path = data_info.idf_file_path
-    ipf_file_path = data_info.ipf_file_path
-    # Set the detector names
-    if ipf_file_path:
-        set_detector_names(move_info, ipf_file_path)
-    # Set the idf path
-    move_info.idf_path = idf_file_path
-
-
 class StateMaskBuilder(object):
     @automatic_setters(StateMask)
     def __init__(self, data_info, state):
         super(StateMaskBuilder, self).__init__()
         self._data = data_info
         self.state = state
-        if data_info.instrument is not SANSInstrument.NO_INSTRUMENT:
-            setup_idf_and_ipf_content(self.state, data_info)
 
     def set_single_spectra_on_detector(self, single_spectra):
         """

--- a/scripts/SANS/sans/state/StateObjects/StateMoveDetectors.py
+++ b/scripts/SANS/sans/state/StateObjects/StateMoveDetectors.py
@@ -9,13 +9,11 @@
 """State for moving workspaces."""
 
 import copy
-import json
 from typing import Dict
 
 from sans.common.enums import (CanonicalCoordinates, SANSInstrument, DetectorType)
 from sans.state.JsonSerializable import JsonSerializable
 from sans.state.automatic_setters import automatic_setters
-from sans.state.state_functions import (validation_message, set_detector_names, set_monitor_names)
 
 
 # ----------------------------------------------------------------------------------------------------------------------
@@ -42,26 +40,6 @@ class StateMoveDetectors(metaclass=JsonSerializable):
         self.sample_centre_pos1 = 0.0  # : Float
         self.sample_centre_pos2 = 0.0  # : Float
 
-        # Name of the detector
-        self.detector_name = None  # : Str
-        self.detector_name_short = None  # : Str
-
-    def validate(self):
-        is_invalid = {}
-        if self.detector_name == "" or self.detector_name is None:
-            entry = validation_message("Missing detector name",
-                                       "Make sure that a detector name was specified.",
-                                       {"detector_name": self.detector_name})
-            is_invalid.update(entry)
-        if self.detector_name_short == "" or self.detector_name_short is None:
-            entry = validation_message("Missing short detector name",
-                                       "Make sure that a short detector name was specified.",
-                                       {"detector_name_short": self.detector_name_short})
-            is_invalid.update(entry)
-        if is_invalid:
-            raise ValueError("StateMoveDetectorISIS: The provided inputs are illegal. "
-                             "Please see: {0}".format(json.dumps(is_invalid)))
-
 
 class StateMove(metaclass=JsonSerializable):
     def __init__(self):
@@ -69,7 +47,6 @@ class StateMove(metaclass=JsonSerializable):
 
         self.sample_offset = 0.0  # : Float
         self.detectors: Dict[StateMoveDetectors] = {}
-        self.monitor_names = None  # : Dict
 
         # The sample offset direction is Z for the ISIS instruments
         self.sample_offset_direction = CanonicalCoordinates.Z
@@ -79,19 +56,12 @@ class StateMove(metaclass=JsonSerializable):
         if not self.detectors:
             raise ValueError("No detectors have been set.")
 
-        # No validation of the descriptors on this level, let potential exceptions from detectors "bubble" up
-        for key in self.detectors:
-            self.detectors[key].validate()
-
 
 class StateMoveLOQ(StateMove):
     def __init__(self):
         super(StateMoveLOQ, self).__init__()
         # Set the center_position in meter
         self.center_position = 317.5 / 1000.  # : Float
-
-        # Set the monitor names
-        self.monitor_names = {}
 
         # Setup the detectors
         self.detectors = {DetectorType.LAB.value: StateMoveDetectors(),
@@ -118,8 +88,6 @@ class StateMoveSANS2D(StateMove):
         self.lab_detector_x = 0.0  # : Float
         self.lab_detector_z = 0.0  # : Float
 
-        # Set the monitor names
-        self.monitor_names = {}
         self.monitor_4_offset = 0.0  # : Float
 
         # Setup the detectors
@@ -137,9 +105,6 @@ class StateMoveLARMOR(StateMove):
         # Set a default for the bench rotation
         self.bench_rotation = 0.0  # : Float
 
-        # Set the monitor names
-        self.monitor_names = {}
-
         # Setup the detectors
         self.detectors = {DetectorType.LAB.value: StateMoveDetectors()}
 
@@ -151,9 +116,6 @@ class StateMoveZOOM(StateMove):
     def __init__(self):
         super(StateMoveZOOM, self).__init__()
         self.lab_detector_default_sd_m = 0.0  # : Float
-
-        # Set the monitor names
-        self.monitor_names = {}
 
         self.monitor_4_offset = 0.0  # : Float
         self.monitor_5_offset = 0.0  # : Float
@@ -169,8 +131,6 @@ class StateMoveNoInst(StateMove):
     def __init__(self):
         super(StateMoveNoInst, self).__init__()
         self.lab_detector_default_sd_m = 0.0  # : Float
-        # Set the monitor names
-        self.monitor_names = {}
         self.monitor_4_offset = 0.0  # : Float
 
         # Setup the detectors
@@ -184,25 +144,13 @@ class StateMoveNoInst(StateMove):
 # ----------------------------------------------------------------------------------------------------------------------
 # Builder
 # ----------------------------------------------------------------------------------------------------------------------
-def setup_idf_and_ipf_content(move_info, data_info, invalid_detector_types=None, invalid_monitor_names=None):
-    # Get the IDF and IPF path since they contain most of the import information
-    idf_file_path = data_info.idf_file_path
-    ipf_file_path = data_info.ipf_file_path
-
-    # Set the detector names
-    if ipf_file_path:
-        set_detector_names(move_info, ipf_file_path, invalid_detector_types)
-    # Set the monitor names
-    if idf_file_path:
-        set_monitor_names(move_info, idf_file_path, invalid_monitor_names)
 
 
 class StateMoveLOQBuilder(object):
     @automatic_setters(StateMoveLOQ, exclusions=["detector_name", "detector_name_short", "monitor_names"])
-    def __init__(self, data_info):
+    def __init__(self):
         super(StateMoveLOQBuilder, self).__init__()
         self.state = StateMoveLOQ()
-        setup_idf_and_ipf_content(self.state, data_info)
 
     def build(self):
         return copy.copy(self.state)
@@ -216,13 +164,9 @@ class StateMoveLOQBuilder(object):
 
 class StateMoveSANS2DBuilder(object):
     @automatic_setters(StateMoveSANS2D, exclusions=["detector_name", "detector_name_short", "monitor_names"])
-    def __init__(self, data_info):
+    def __init__(self):
         super(StateMoveSANS2DBuilder, self).__init__()
         self.state = StateMoveSANS2D()
-        # TODO: At the moment we set the monitor names up manually here. In principle we have all necessary information
-        #       in the IDF we should be able to parse it and get.
-        invalid_monitor_names = ["monitor5", "monitor6", "monitor7", "monitor8"]
-        setup_idf_and_ipf_content(self.state, data_info, invalid_monitor_names=invalid_monitor_names)
 
     def build(self):
         return copy.copy(self.state)
@@ -236,16 +180,9 @@ class StateMoveSANS2DBuilder(object):
 
 class StateMoveZOOMBuilder(object):
     @automatic_setters(StateMoveZOOM, exclusions=["detector_name", "detector_name_short", "monitor_names"])
-    def __init__(self, data_info):
+    def __init__(self):
         super(StateMoveZOOMBuilder, self).__init__()
         self.state = StateMoveZOOM()
-        # TODO: At the moment we set the monitor names up manually here. In principle we have all necessary information
-        #       in the IDF we should be able to parse it and get.
-        invalid_monitor_names = ["monitor6", "monitor7", "monitor8", "monitor9", "monitor10"]
-        invalid_detector_types = [DetectorType.HAB]
-        setup_idf_and_ipf_content(self.state, data_info,
-                                  invalid_detector_types=invalid_detector_types,
-                                  invalid_monitor_names=invalid_monitor_names)
 
     def build(self):
         return copy.copy(self.state)
@@ -262,15 +199,7 @@ class StateMoveLARMORBuilder(object):
     def __init__(self, data_info):
         super(StateMoveLARMORBuilder, self).__init__()
         self.state = StateMoveLARMOR()
-        # There are several invalid monitor names which are not setup for LARMOR, also the IPF has a high-angle-bank
-        # but this is not setup for LARMOR
-        # TODO: At the moment we set the monitor names up manually here. In principle we have all necessary information
-        #       in the IDF we should be able to parse it and get.
-        invalid_monitor_names = ["monitor6", "monitor7", "monitor8", "monitor9", "monitor10"]
-        invalid_detector_types = [DetectorType.HAB]
-        setup_idf_and_ipf_content(self.state, data_info,
-                                  invalid_detector_types=invalid_detector_types,
-                                  invalid_monitor_names=invalid_monitor_names)
+
         self.conversion_value = 1000.
         self._set_conversion_value(data_info)
 
@@ -315,13 +244,13 @@ def get_move_builder(data_info):
     instrument = data_info.instrument
 
     if instrument is SANSInstrument.LOQ:
-        return StateMoveLOQBuilder(data_info)
+        return StateMoveLOQBuilder()
     elif instrument is SANSInstrument.SANS2D:
-        return StateMoveSANS2DBuilder(data_info)
+        return StateMoveSANS2DBuilder()
     elif instrument is SANSInstrument.LARMOR:
         return StateMoveLARMORBuilder(data_info)
     elif instrument is SANSInstrument.ZOOM:
-        return StateMoveZOOMBuilder(data_info)
+        return StateMoveZOOMBuilder()
     elif instrument is SANSInstrument.NO_INSTRUMENT:
         return StateMoveNoInstBuilder()
     else:

--- a/scripts/SANS/sans/state/StateObjects/state_instrument_info.py
+++ b/scripts/SANS/sans/state/StateObjects/state_instrument_info.py
@@ -1,0 +1,119 @@
+# Mantid Repository : https://github.com/mantidproject/mantid
+#
+# Copyright &copy; 2020 ISIS Rutherford Appleton Laboratory UKRI,
+#     NScD Oak Ridge National Laboratory, European Spallation Source
+#   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+# SPDX - License - Identifier: GPL - 3.0 +
+from typing import Dict
+
+from sans.common.enums import SANSInstrument, DetectorType
+from sans.common.xml_parsing import get_monitor_names_from_idf_file, get_named_elements_from_ipf_file
+from sans.state.JsonSerializable import JsonSerializable
+from mantid.py36compat import dataclass
+from sans.state.StateObjects.StateData import StateData
+
+
+@dataclass()
+class DetectorNames(metaclass=JsonSerializable):
+    detector_name: str = None
+    detector_name_short: str = None
+
+
+class StateInstrumentInfo(metaclass=JsonSerializable):
+    """
+    Holds instrument state that is found in the IDF / IPF files. This was separated
+    out from the other state objects as we need to know our run number to look up
+    the correct IPF/IDF. However to load in a run number we need the other instrument
+    fields of state info filled. This helps break that circular dependency.
+    """
+    @staticmethod
+    def build_from_data_info(data_info):
+        inst_info = StateInstrumentInfo()
+        _init_detector_names(inst_info=inst_info, data_info=data_info)
+        _init_monitor_names(inst_info=inst_info, data_info=data_info)
+
+        inst_info.idf_path = data_info.idf_file_path
+        return inst_info
+
+    def __init__(self):
+        self.detector_names = {DetectorType.LAB.value: DetectorNames(),
+                               DetectorType.HAB.value: DetectorNames()}
+        self.monitor_names: Dict[str, str] = dict()
+        self.idf_path: str = ""
+
+
+def _get_invalid_monitor_names(instrument: SANSInstrument):
+    if instrument is SANSInstrument.LARMOR:
+        return ["monitor6", "monitor7", "monitor8", "monitor9", "monitor10"]
+    elif instrument is SANSInstrument.SANS2D:
+        return ["monitor5", "monitor6", "monitor7", "monitor8"]
+    elif instrument is SANSInstrument.ZOOM:
+        return ["monitor6", "monitor7", "monitor8", "monitor9", "monitor10"]
+    return None
+
+
+def _get_invalid_monitor_types(instrument: SANSInstrument):
+    if instrument in (SANSInstrument.LARMOR, SANSInstrument.ZOOM):
+        return [DetectorType.HAB]
+
+
+def _set_detector_names(state: StateInstrumentInfo, ipf_path, invalid_detector_types=None):
+    """
+    Sets the detectors names on a State object which has a `detector` map entry, e.g. StateMask
+
+    :param state: the state object
+    :param ipf_path: the path to the Instrument Parameter File
+    :param invalid_detector_types: a list of invalid detector types which don't exist for the instrument
+    """
+    if invalid_detector_types is None:
+        invalid_detector_types = []
+
+    lab_keyword = DetectorType.LAB.value
+    hab_keyword = DetectorType.HAB.value
+    detector_names = {lab_keyword: "low-angle-detector-name",
+                      hab_keyword: "high-angle-detector-name"}
+    detector_names_short = {lab_keyword: "low-angle-detector-short-name",
+                            hab_keyword: "high-angle-detector-short-name"}
+
+    names_to_search = []
+    names_to_search.extend(list(detector_names.values()))
+    names_to_search.extend(list(detector_names_short.values()))
+
+    found_detector_names = get_named_elements_from_ipf_file(ipf_path, names_to_search, str)
+
+    for detector_type in state.detector_names:
+        try:
+            if DetectorType(detector_type) in invalid_detector_types:
+                continue
+            detector_name_tag = detector_names[detector_type]
+            detector_name_short_tag = detector_names_short[detector_type]
+            detector_name = found_detector_names[detector_name_tag]
+            detector_name_short = found_detector_names[detector_name_short_tag]
+        except KeyError:
+            continue
+        state.detector_names[detector_type].detector_name = detector_name
+        state.detector_names[detector_type].detector_name_short = detector_name_short
+
+
+def _set_monitor_names(inst_info_state, idf_path, invalid_monitor_names=None):
+    if invalid_monitor_names is None:
+        invalid_monitor_names = []
+    monitor_names = get_monitor_names_from_idf_file(idf_path, invalid_monitor_names)
+    inst_info_state.monitor_names = monitor_names
+
+
+def _init_detector_names(inst_info: StateInstrumentInfo, data_info: StateData):
+    ipf_file_path = data_info.ipf_file_path
+    if ipf_file_path:
+        invalid_detector_types = _get_invalid_monitor_types(data_info.instrument)
+        _set_detector_names(inst_info, ipf_file_path, invalid_detector_types=invalid_detector_types)
+
+
+def _init_monitor_names(inst_info: StateInstrumentInfo, data_info: StateData):
+    # Get the IDF and IPF path since they contain most of the import information
+    idf_file_path = data_info.idf_file_path
+
+    # Set the monitor names
+    if idf_file_path:
+        invalid_monitors = _get_invalid_monitor_names(data_info.instrument)
+        _set_monitor_names(inst_info, idf_file_path, invalid_monitor_names=invalid_monitors)

--- a/scripts/SANS/sans/state/state_functions.py
+++ b/scripts/SANS/sans/state/state_functions.py
@@ -6,13 +6,12 @@
 # SPDX - License - Identifier: GPL - 3.0 +
 """Set of general purpose functions which are related to the SANSState approach."""
 
-from sans.common.enums import (DetectorType)
-from sans.common.xml_parsing import (get_monitor_names_from_idf_file, get_named_elements_from_ipf_file)
-
 
 # ----------------------------------------------------------------------------------------------------------------------
 # General functions
 # ----------------------------------------------------------------------------------------------------------------------
+
+
 def is_pure_none_or_not_none(elements_to_check):
     """
     Checks a list of elements contains None entries and non-None entries
@@ -66,48 +65,3 @@ def validation_message(error_message, instruction, variables):
         message += "{0}: {1}\n".format(key, value)
     message += instruction
     return {error_message: message}
-
-
-def set_detector_names(state, ipf_path, invalid_detector_types=None):
-    """
-    Sets the detectors names on a State object which has a `detector` map entry, e.g. StateMask
-
-    :param state: the state object
-    :param ipf_path: the path to the Instrument Parameter File
-    :param invalid_detector_types: a list of invalid detector types which don't exist for the instrument
-    """
-    if invalid_detector_types is None:
-        invalid_detector_types = []
-
-    lab_keyword = DetectorType.LAB.value
-    hab_keyword = DetectorType.HAB.value
-    detector_names = {lab_keyword: "low-angle-detector-name",
-                      hab_keyword: "high-angle-detector-name"}
-    detector_names_short = {lab_keyword: "low-angle-detector-short-name",
-                            hab_keyword: "high-angle-detector-short-name"}
-
-    names_to_search = []
-    names_to_search.extend(list(detector_names.values()))
-    names_to_search.extend(list(detector_names_short.values()))
-
-    found_detector_names = get_named_elements_from_ipf_file(ipf_path, names_to_search, str)
-
-    for detector_type in state.detectors:
-        try:
-            if DetectorType(detector_type) in invalid_detector_types:
-                continue
-            detector_name_tag = detector_names[detector_type]
-            detector_name_short_tag = detector_names_short[detector_type]
-            detector_name = found_detector_names[detector_name_tag]
-            detector_name_short = found_detector_names[detector_name_short_tag]
-        except KeyError:
-            continue
-        state.detectors[detector_type].detector_name = detector_name
-        state.detectors[detector_type].detector_name_short = detector_name_short
-
-
-def set_monitor_names(state, idf_path, invalid_monitor_names=None):
-    if invalid_monitor_names is None:
-        invalid_monitor_names = []
-    monitor_names = get_monitor_names_from_idf_file(idf_path, invalid_monitor_names)
-    state.monitor_names = monitor_names

--- a/scripts/SANS/sans/test_helper/test_director.py
+++ b/scripts/SANS/sans/test_helper/test_director.py
@@ -23,6 +23,7 @@ from sans.state.StateObjects.StateConvertToQ import get_convert_to_q_builder
 from sans.common.enums import (SANSFacility, ReductionMode, ReductionDimensionality,
                                FitModeForMerge, RebinType, RangeStepType, SaveType, FitType, SampleShape,
                                SANSInstrument)
+from sans.state.StateObjects.state_instrument_info import StateInstrumentInfo
 from sans.test_helper.file_information_mock import SANSFileInformationMock
 
 
@@ -41,6 +42,7 @@ class TestDirector(object):
         self.scale_state = None
         self.adjustment_state = None
         self.convert_to_q_state = None
+        self.inst_info_state = None
 
     def set_states(self, data_state=None, move_state=None, reduction_state=None, slice_state=None,
                    mask_state=None, wavelength_state=None, save_state=None, scale_state=None, adjustment_state=None,
@@ -75,6 +77,9 @@ class TestDirector(object):
                 move_builder.set_HAB_x_translation_correction(21.2)
             move_builder.set_LAB_x_translation_correction(12.1)
             self.move_state = move_builder.build()
+
+        if self.inst_info_state is None:
+            self.inst_info_state = StateInstrumentInfo.build_from_data_info(self.data_state)
 
         # Build the SANSStateReduction
         if self.reduction_state is None:
@@ -204,4 +209,5 @@ class TestDirector(object):
         state_builder.set_scale(self.scale_state)
         state_builder.set_adjustment(self.adjustment_state)
         state_builder.set_convert_to_q(self.convert_to_q_state)
+        state_builder.state.instrument_info = self.inst_info_state
         return state_builder.build()

--- a/scripts/test/SANS/algorithm_detail/mask_sans_workspace_test.py
+++ b/scripts/test/SANS/algorithm_detail/mask_sans_workspace_test.py
@@ -17,6 +17,7 @@ from sans.state.Serializer import Serializer
 from sans.state.StateObjects.StateData import get_data_builder
 from sans.state.StateObjects.StateMaskDetectors import get_mask_builder
 from sans.state.StateObjects.StateMoveDetectors import get_move_builder
+from sans.state.StateObjects.state_instrument_info import StateInstrumentInfo
 from sans.test_helper.test_director import TestDirector
 
 
@@ -275,6 +276,8 @@ class MaskSansWorkspaceTest(unittest.TestCase):
         test_director.set_states(data_state=data_info, mask_state=mask_info)
         state = test_director.construct()
 
+        state.instrument_info = StateInstrumentInfo.build_from_data_info(data_info)
+
         workspace = self._sans_data
 
         # Act
@@ -406,6 +409,8 @@ class MaskSansWorkspaceTest(unittest.TestCase):
         test_director = TestDirector()
         test_director.set_states(data_state=data_info, mask_state=mask_info)
         state = test_director.construct()
+
+        state.instrument_info = StateInstrumentInfo.build_from_data_info(data_info)
 
         returned_data = SANSLoad(SANSState=Serializer.to_json(state), SampleScatterWorkspace="mask_sans_ws",
                                  SampleScatterMonitorWorkspace="dummy")

--- a/scripts/test/SANS/algorithm_detail/move_sans_instrument_component_test.py
+++ b/scripts/test/SANS/algorithm_detail/move_sans_instrument_component_test.py
@@ -7,6 +7,7 @@
 # pylint: disable=too-many-public-methods, invalid-name, too-many-arguments
 
 import unittest
+from unittest import mock
 
 from mantid.kernel import (Quat, V3D)
 from mantid.simpleapi import AddSampleLog, LoadEmptyInstrument
@@ -14,8 +15,10 @@ from sans.algorithm_detail.move_sans_instrument_component import move_component,
 from sans.algorithm_detail.move_workspaces import (create_mover, SANSMoveLOQ, SANSMoveSANS2D, SANSMoveLARMORNewStyle,
                                                    SANSMoveZOOM)
 from sans.common.enums import (SANSFacility, DetectorType, SANSInstrument)
+from sans.state.AllStates import AllStates
 from sans.state.StateObjects.StateData import get_data_builder
 from sans.state.StateObjects.StateMoveDetectors import get_move_builder
+from sans.state.StateObjects.state_instrument_info import StateInstrumentInfo
 from sans.test_helper.file_information_mock import SANSFileInformationMock
 
 
@@ -29,7 +32,7 @@ class SANSMoveFactoryTest(unittest.TestCase):
         # Arrange
         workspace = load_empty_instrument(instrument_name)
         # Act
-        mover = create_mover(workspace)
+        mover = create_mover(workspace, state=mock.NonCallableMock())
         # Assert
         self.assertTrue(isinstance(mover, mover_type))
 
@@ -58,48 +61,51 @@ class SANSMoveFactoryTest(unittest.TestCase):
 # Component movement tests
 
 
-def compare_expected_position(instance, expected_position, expected_rotation, component, move_info, workspace):
-    position, rotation = _get_position_and_rotation(workspace, move_info, component)
+def compare_expected_position(instance, expected_position, expected_rotation, component,
+                              inst_info: StateInstrumentInfo, workspace):
+    position, rotation = _get_position_and_rotation(workspace, inst_info, component)
     for index in range(0, 3):
         instance.assertAlmostEqual(position[index], expected_position[index], delta=1e-4)
     for index in range(0, 4):
         instance.assertAlmostEqual(rotation[index], expected_rotation[index], delta=1e-4)
 
 
-def check_elementry_displacement_with_translation(instance, workspace, move_info,
+def check_elementry_displacement_with_translation(instance, workspace, state: AllStates,
                                                   coordinates, component, component_key):
     # Get position and rotation before the move
-    position_before_move, rotation_before_move = _get_position_and_rotation(workspace, move_info,
+    position_before_move, rotation_before_move = _get_position_and_rotation(workspace, state.instrument_info,
                                                                             component_key)
     expected_position_elementary_move = V3D(position_before_move[0] - coordinates[0],
                                             position_before_move[1] - coordinates[1],
                                             position_before_move[2])
     expected_rotation = rotation_before_move
 
-    move_component(component_name=component, move_info=move_info, workspace=workspace,
+    move_component(component_name=component, state=state, workspace=workspace,
                    beam_coordinates=coordinates, move_type=MoveTypes.ELEMENTARY_DISPLACEMENT)
 
     compare_expected_position(instance, expected_position_elementary_move, expected_rotation,
-                              component_key, move_info, workspace)
+                              component_key, state.instrument_info, workspace)
 
 
-def check_that_sets_to_zero(instance, workspace, move_info, comp_name=None):
-    def _get_components_to_compare(_key, _move_info, _component_names):
-        if _key in _move_info.detectors:
-            _name = _move_info.detectors[_key].detector_name
-            _component_names.append(_name)
+def check_that_sets_to_zero(instance, workspace, state: AllStates, comp_name=None):
+    def _get_components_to_compare(_key, inst_info, _component_names):
+        if _key in inst_info.detector_names:
+            _name = inst_info.detector_names[_key].detector_name
+            if _name:
+                _component_names.append(_name)
 
     # Reset the position to zero
-    move_component(component_name=comp_name, move_info=move_info, workspace=workspace,
+    move_component(component_name=comp_name, state=state, workspace=workspace,
                    move_type=MoveTypes.RESET_POSITION)
 
     # Get the components to compare
+    inst_info = state.instrument_info
     if comp_name is None:
-        component_names = list(move_info.monitor_names.values())
+        component_names = list(inst_info.monitor_names.values())
         hab_name = DetectorType.HAB.value
         lab_name = DetectorType.LAB.value,
-        _get_components_to_compare(hab_name, move_info, component_names)
-        _get_components_to_compare(lab_name, move_info, component_names)
+        _get_components_to_compare(hab_name, inst_info, component_names)
+        _get_components_to_compare(lab_name, inst_info, component_names)
         component_names.append("some-sample-holder")
     else:
         component_names = [comp_name]
@@ -126,7 +132,7 @@ def check_that_sets_to_zero(instance, workspace, move_info, comp_name=None):
             instance.assertAlmostEquals(rotation[index], rotation_base[index], delta=1e-4)
 
 
-def _get_state_move_obj(instrument, x_translation=None, z_translation=None):
+def _get_state_obj(instrument, x_translation=None, z_translation=None):
     facility = SANSFacility.ISIS
     file_information = SANSFileInformationMock(instrument=instrument, run_number=123)
     data_builder = get_data_builder(facility, file_information)
@@ -140,13 +146,16 @@ def _get_state_move_obj(instrument, x_translation=None, z_translation=None):
     if z_translation:
         state_builder.set_LAB_z_translation_correction(z_translation)
 
-    state = state_builder.build()
+    state = AllStates()
+    state.move = state_builder.build()
+    state.instrument_info = StateInstrumentInfo.build_from_data_info(data_info)
+
     return state
 
 
-def _get_position_and_rotation(workspace, move_info, component):
+def _get_position_and_rotation(workspace, inst_info, component):
     instrument = workspace.getInstrument()
-    component_name = move_info.detectors[component].detector_name
+    component_name = inst_info.detector_names[component].detector_name
     detector = instrument.getComponentByName(component_name)
     position = detector.getPos()
     rotation = detector.getRotation()
@@ -161,32 +170,33 @@ class LOQMoveTest(unittest.TestCase):
         component_key = DetectorType.LAB.value
 
         workspace = load_empty_instrument("LOQ")
-        move_info = _get_state_move_obj(SANSInstrument.LOQ, lab_x_translation_correction)
+        state = _get_state_obj(SANSInstrument.LOQ, lab_x_translation_correction)
 
         # Initial move
-        move_component(component_name=component, workspace=workspace, move_info=move_info,
+        move_component(component_name=component, workspace=workspace, state=state,
                        move_type=MoveTypes.INITIAL_MOVE, beam_coordinates=beam_coordinates)
 
-        center_position = move_info.center_position
+        center_position = state.move.center_position
         initial_z_position = 15.15
         expected_position = V3D(center_position - beam_coordinates[0] + lab_x_translation_correction,
                                 center_position - beam_coordinates[1],
                                 initial_z_position)
         expected_rotation = Quat(1., 0., 0., 0.)
-        compare_expected_position(self, expected_position, expected_rotation, component_key, move_info, workspace)
+        compare_expected_position(self, expected_position, expected_rotation, component_key, state.instrument_info,
+                                  workspace)
 
         # Elementary Move
         component_elementary_move = "HAB"
         component_elementary_move_key = DetectorType.HAB.value
 
         beam_coordinates_elementary_move = [120, 135]
-        check_elementry_displacement_with_translation(self, workspace, move_info,
+        check_elementry_displacement_with_translation(self, workspace, state,
                                                       beam_coordinates_elementary_move,
                                                       component_elementary_move,
                                                       component_elementary_move_key)
 
         # Reset to zero
-        check_that_sets_to_zero(self, workspace, move_info=move_info)
+        check_that_sets_to_zero(self, workspace, state=state)
 
 
 class SANS2DMoveTest(unittest.TestCase):
@@ -211,9 +221,9 @@ class SANS2DMoveTest(unittest.TestCase):
         # All detectors are moved on SANS2D
         component = None
 
-        move_info = _get_state_move_obj(SANSInstrument.SANS2D, z_translation=lab_z_translation_correction)
+        state = _get_state_obj(SANSInstrument.SANS2D, z_translation=lab_z_translation_correction)
 
-        move_component(component_name=component, workspace=workspace, move_info=move_info,
+        move_component(component_name=component, workspace=workspace, state=state,
                        move_type=MoveTypes.INITIAL_MOVE, beam_coordinates=beam_coordinates)
 
         # Assert for initial move for low angle bank
@@ -228,7 +238,7 @@ class SANS2DMoveTest(unittest.TestCase):
         expected_position = V3D(total_x - beam_coordinates[0], total_y - beam_coordinates[1], total_z)
         expected_rotation = Quat(1., 0., 0., 0.)
         compare_expected_position(self, expected_position, expected_rotation,
-                                  component_to_investigate, move_info, workspace)
+                                  component_to_investigate, state.instrument_info, workspace)
 
         # Assert for initial move for high angle bank
         # These values are on the workspace and in the sample logs
@@ -243,34 +253,34 @@ class SANS2DMoveTest(unittest.TestCase):
         expected_position = V3D(total_x - beam_coordinates[0], total_y - beam_coordinates[1], total_z)
         expected_rotation = Quat(0.9968998362876025, 0., 0.07868110579898738, 0.)
         compare_expected_position(self, expected_position, expected_rotation,
-                                  component_to_investigate, move_info, workspace)
+                                  component_to_investigate, state.instrument_info, workspace)
 
         # Act + Assert for elementary move
         component_elementary_move = "rear-detector"
         component_elementary_move_key = DetectorType.LAB.value
         beam_coordinates_elementary_move = [120, 135]
-        check_elementry_displacement_with_translation(self, workspace, move_info,
+        check_elementry_displacement_with_translation(self, workspace, state,
                                                       beam_coordinates_elementary_move,
                                                       component_elementary_move,
                                                       component_elementary_move_key)
 
         # # Act + Assert for setting to zero position for all
-        check_that_sets_to_zero(self, workspace, move_info, comp_name=None)
+        check_that_sets_to_zero(self, workspace, state, comp_name=None)
 
     def test_that_missing_beam_centre_is_taken_from_move_state(self):
         lab_z_translation_correction = 123.
 
         workspace = self._prepare_sans2d_empty_ws()
-        move_info = _get_state_move_obj(instrument=SANSInstrument.SANS2D,
-                                        z_translation=lab_z_translation_correction)
+        state = _get_state_obj(instrument=SANSInstrument.SANS2D,
+                               z_translation=lab_z_translation_correction)
 
         # These values should be used instead of an explicitly specified beam centre
-        move_info.detectors[DetectorType.HAB.value].sample_centre_pos1 = 26.
-        move_info.detectors[DetectorType.HAB.value].sample_centre_pos2 = 98.
+        state.move.detectors[DetectorType.HAB.value].sample_centre_pos1 = 26.
+        state.move.detectors[DetectorType.HAB.value].sample_centre_pos2 = 98.
 
         # The component input is not relevant for SANS2D's initial move. All detectors are moved
         component = "front-detector"
-        move_component(component_name=component, move_info=move_info, workspace=workspace,
+        move_component(component_name=component, state=state, workspace=workspace,
                        move_type=MoveTypes.INITIAL_MOVE)
 
         # These values are on the workspace and in the sample logs
@@ -285,24 +295,24 @@ class SANS2DMoveTest(unittest.TestCase):
         expected_position = V3D(total_x - 26., total_y - 98., total_z)
         expected_rotation = Quat(0.9968998362876025, 0., 0.07868110579898738, 0.)
         compare_expected_position(self, expected_position, expected_rotation,
-                                  component_to_investigate, move_info, workspace)
+                                  component_to_investigate, state.instrument_info, workspace)
 
     def test_that_missing_beam_centre_is_taken_from_lab_move_state_when_no_component_is_specified(self):
         lab_z_translation_correction = 123.
 
         workspace = self._prepare_sans2d_empty_ws()
-        move_info = _get_state_move_obj(instrument=SANSInstrument.SANS2D,
-                                        z_translation=lab_z_translation_correction)
+        state = _get_state_obj(instrument=SANSInstrument.SANS2D,
+                               z_translation=lab_z_translation_correction)
 
         # These values should be used instead of an explicitly specified beam centre
         x_offset = 26.
         y_offset = 98.
-        move_info.detectors[DetectorType.LAB.value].sample_centre_pos1 = x_offset
-        move_info.detectors[DetectorType.LAB.value].sample_centre_pos2 = y_offset
+        state.move.detectors[DetectorType.LAB.value].sample_centre_pos1 = x_offset
+        state.move.detectors[DetectorType.LAB.value].sample_centre_pos2 = y_offset
 
         # The component input is not relevant for SANS2D's initial move. All detectors are moved
         component = None
-        move_component(component_name=component, move_info=move_info, workspace=workspace,
+        move_component(component_name=component, state=state, workspace=workspace,
                        move_type=MoveTypes.INITIAL_MOVE)
 
         # Assert for initial move for low angle bank
@@ -317,7 +327,7 @@ class SANS2DMoveTest(unittest.TestCase):
         expected_position = V3D(total_x - x_offset, total_y - y_offset, total_z)
         expected_rotation = Quat(1., 0., 0., 0.)
         compare_expected_position(self, expected_position, expected_rotation,
-                                  component_to_investigate, move_info, workspace)
+                                  component_to_investigate, state.instrument_info, workspace)
 
 
 class LARMORMoveTest(unittest.TestCase):
@@ -334,9 +344,10 @@ class LARMORMoveTest(unittest.TestCase):
 
         # Act for initial move
         component = None
-        move_info = _get_state_move_obj(instrument=SANSInstrument.LARMOR,
-                                        x_translation=lab_x_translation_correction)
-        move_component(component_name=component, workspace=workspace, move_info=move_info,
+        state = _get_state_obj(instrument=SANSInstrument.LARMOR,
+                               x_translation=lab_x_translation_correction)
+
+        move_component(component_name=component, workspace=workspace, state=state,
                        move_type=MoveTypes.INITIAL_MOVE, beam_coordinates=beam_coordinates)
 
         # Assert low angle bank for initial move
@@ -347,9 +358,9 @@ class LARMORMoveTest(unittest.TestCase):
         expected_position = V3D(0, -38, 25.3)
         expected_rotation = Quat(0.978146, 0, -0.20792, 0)
         compare_expected_position(self, expected_position, expected_rotation,
-                                  component_to_investigate, move_info, workspace)
+                                  component_to_investigate, state.instrument_info, workspace)
 
-        check_that_sets_to_zero(self, workspace, move_info, comp_name=None)
+        check_that_sets_to_zero(self, workspace, state, comp_name=None)
 
 
 class ZOOMMoveTest(unittest.TestCase):
@@ -359,10 +370,10 @@ class ZOOMMoveTest(unittest.TestCase):
         component_key = DetectorType.LAB.value
 
         workspace = load_empty_instrument("ZOOM")
-        move_info = _get_state_move_obj(SANSInstrument.ZOOM)
+        state = _get_state_obj(SANSInstrument.ZOOM)
 
         # Initial move
-        move_component(component_name=component, workspace=workspace, move_info=move_info,
+        move_component(component_name=component, workspace=workspace, state=state,
                        move_type=MoveTypes.INITIAL_MOVE, beam_coordinates=beam_coordinates)
 
         initial_z_position = 20.77408
@@ -370,20 +381,21 @@ class ZOOMMoveTest(unittest.TestCase):
                                 -beam_coordinates[1],
                                 initial_z_position)
         expected_rotation = Quat(1., 0., 0., 0.)
-        compare_expected_position(self, expected_position, expected_rotation, component_key, move_info, workspace)
+        compare_expected_position(self, expected_position, expected_rotation, component_key,
+                                  state.instrument_info, workspace)
 
         # Elementary Move
         component_elementary_move = "LAB"
         component_elementary_move_key = DetectorType.LAB.value
 
         beam_coordinates_elementary_move = [120, 135]
-        check_elementry_displacement_with_translation(self, workspace, move_info,
+        check_elementry_displacement_with_translation(self, workspace, state,
                                                       beam_coordinates_elementary_move,
                                                       component_elementary_move,
                                                       component_elementary_move_key)
 
         # Reset to zero
-        check_that_sets_to_zero(self, workspace, move_info=move_info)
+        check_that_sets_to_zero(self, workspace, state)
 
 
 if __name__ == '__main__':

--- a/scripts/test/SANS/algorithm_detail/move_workspaces_test.py
+++ b/scripts/test/SANS/algorithm_detail/move_workspaces_test.py
@@ -9,8 +9,10 @@ import unittest
 import mantid.simpleapi
 from sans.algorithm_detail.move_workspaces import SANSMoveZOOM, SANSMoveSANS2D
 from sans.common.enums import SANSFacility, SANSInstrument, DetectorType
+from sans.state.AllStates import AllStates
 from sans.state.StateObjects.StateData import get_data_builder
 from sans.state.StateObjects.StateMoveDetectors import get_move_builder
+from sans.state.StateObjects.state_instrument_info import StateInstrumentInfo
 from sans.test_helper.file_information_mock import SANSFileInformationMock
 
 
@@ -19,8 +21,8 @@ def get_coordinates():
     return [0, 0]
 
 
-def get_monitor_pos(ws, monitor_spectrum_no, move_info):
-    monitor_name = move_info.monitor_names[str(monitor_spectrum_no)]
+def get_monitor_pos(ws, monitor_spectrum_no, inst_info):
+    monitor_name = inst_info.monitor_names[str(monitor_spectrum_no)]
 
     comp_info = ws.componentInfo()
     monitor_index = comp_info.indexOfAny(monitor_name)
@@ -28,15 +30,15 @@ def get_monitor_pos(ws, monitor_spectrum_no, move_info):
     return monitor_z_pos
 
 
-def calculate_new_pos_rel_to_rear(ws, move_info, offset):
+def calculate_new_pos_rel_to_rear(ws, inst_info, offset):
     # Calculates the new position relative to the rear detector offset
-    rear_detector_z = get_rear_detector_pos(move_info=move_info, ws=ws)
+    rear_detector_z = get_rear_detector_pos(inst_info=inst_info, ws=ws)
     expected_pos = rear_detector_z + offset
     return expected_pos
 
 
-def get_rear_detector_pos(move_info, ws):
-    lab_detector = move_info.detectors[DetectorType.LAB.value]
+def get_rear_detector_pos(inst_info, ws):
+    lab_detector = inst_info.detector_names[DetectorType.LAB.value]
     detector_name = lab_detector.detector_name
     comp_info = ws.componentInfo()
     lab_detector_index = comp_info.indexOfAny(detector_name)
@@ -65,7 +67,7 @@ class MoveSans2DMonitor(unittest.TestCase):
         return cls.sans_ws
 
     @staticmethod
-    def get_state_move_obj(monitor_4_dist):
+    def get_state_obj(monitor_4_dist):
         facility = SANSFacility.ISIS
         file_information = SANSFileInformationMock(instrument=SANSInstrument.SANS2D, run_number=22048)
         data_builder = get_data_builder(facility, file_information)
@@ -75,37 +77,40 @@ class MoveSans2DMonitor(unittest.TestCase):
 
         state_builder = get_move_builder(data_info)
 
-        state = state_builder.build()
-        state.monitor_4_offset = monitor_4_dist
+        state = AllStates()
+        state.move = state_builder.build()
+        state.instrument_info = StateInstrumentInfo.build_from_data_info(data_info)
+
+        state.move.monitor_4_offset = monitor_4_dist
         return state
 
     def test_move_sans_monitors(self):
-        zoom_class = SANSMoveSANS2D()
-
         # Unused for unit test
         component = None
         is_transmission_workspace = None
 
         mon_4_dist = 15.0
 
-        move_info = self.get_state_move_obj(monitor_4_dist=mon_4_dist)
+        state = self.get_state_obj(monitor_4_dist=mon_4_dist)
+
+        zoom_class = SANSMoveSANS2D(state=state)
         workspace = self.get_sans_workspace()
         coordinates = get_coordinates()
 
-        z_pos_mon_4_before = get_monitor_pos(ws=workspace, monitor_spectrum_no=4, move_info=move_info)
+        inst_info = state.instrument_info
+        z_pos_mon_4_before = get_monitor_pos(ws=workspace, monitor_spectrum_no=4, inst_info=inst_info)
 
         self.assertTrue(isinstance(z_pos_mon_4_before, float))
 
-        zoom_class.move_initial(move_info=move_info, workspace=workspace, coordinates=coordinates,
+        zoom_class.move_initial(workspace=workspace, coordinates=coordinates,
                                 component=component, is_transmission_workspace=is_transmission_workspace)
 
-        z_pos_mon_4_after = get_monitor_pos(ws=workspace, monitor_spectrum_no=4, move_info=move_info)
+        z_pos_mon_4_after = get_monitor_pos(ws=workspace, monitor_spectrum_no=4, inst_info=inst_info)
 
-        self.assertAlmostEqual(calculate_new_pos_rel_to_rear(ws=workspace, move_info=move_info, offset=mon_4_dist),
+        self.assertAlmostEqual(calculate_new_pos_rel_to_rear(ws=workspace, inst_info=inst_info, offset=mon_4_dist),
                                z_pos_mon_4_after)
 
     def test_not_moving_monitors(self):
-        zoom_class = SANSMoveSANS2D()
 
         # Unused for unit test
         component = None
@@ -113,20 +118,22 @@ class MoveSans2DMonitor(unittest.TestCase):
 
         mon_4_dist = 0.0
 
-        move_info = self.get_state_move_obj(monitor_4_dist=mon_4_dist)
+        state = self.get_state_obj(monitor_4_dist=mon_4_dist)
+        zoom_class = SANSMoveSANS2D(state=state)
         workspace = self.get_sans_workspace()
         coordinates = get_coordinates()
+        inst_info = state.instrument_info
 
-        z_pos_mon_4_before = get_monitor_pos(ws=workspace, monitor_spectrum_no=4, move_info=move_info)
+        z_pos_mon_4_before = get_monitor_pos(ws=workspace, monitor_spectrum_no=4, inst_info=inst_info)
 
         self.assertTrue(isinstance(z_pos_mon_4_before, float))
 
-        zoom_class.move_initial(move_info=move_info, workspace=workspace, coordinates=coordinates,
+        zoom_class.move_initial(workspace=workspace, coordinates=coordinates,
                                 component=component, is_transmission_workspace=is_transmission_workspace)
 
-        z_pos_mon_4_after = get_monitor_pos(ws=workspace, monitor_spectrum_no=4, move_info=move_info)
+        z_pos_mon_4_after = get_monitor_pos(ws=workspace, monitor_spectrum_no=4, inst_info=inst_info)
 
-        self.assertAlmostEqual(calculate_new_pos_rel_to_rear(ws=workspace, move_info=move_info, offset=mon_4_dist),
+        self.assertAlmostEqual(calculate_new_pos_rel_to_rear(ws=workspace, offset=mon_4_dist, inst_info=inst_info),
                                z_pos_mon_4_after)
 
 
@@ -146,8 +153,7 @@ class MoveZoomMonitors(unittest.TestCase):
         return cls.zoom_empty
 
     @staticmethod
-    def get_state_move_obj(monitor_4_dist, monitor_5_dist):
-        # Arrange
+    def get_state_obj(monitor_4_dist, monitor_5_dist):
         facility = SANSFacility.ISIS
         file_information = SANSFileInformationMock(instrument=SANSInstrument.ZOOM, run_number=6113)
         data_builder = get_data_builder(facility, file_information)
@@ -155,17 +161,14 @@ class MoveZoomMonitors(unittest.TestCase):
         data_builder.set_sample_scatter_period(3)
         data_info = data_builder.build()
 
-        # Act
-        state_builder = get_move_builder(data_info)
-
-        # Assert
-        state = state_builder.build()
-        state.monitor_4_offset = monitor_4_dist
-        state.monitor_5_offset = monitor_5_dist
+        state = AllStates()
+        state.move = get_move_builder(data_info).build()
+        state.instrument_info = StateInstrumentInfo.build_from_data_info(data_info)
+        state.move.monitor_4_offset = monitor_4_dist
+        state.move.monitor_5_offset = monitor_5_dist
         return state
 
     def test_move_both_zoom_monitors(self):
-        zoom_class = SANSMoveZOOM()
 
         # Unused for unit test
         component = None
@@ -174,84 +177,86 @@ class MoveZoomMonitors(unittest.TestCase):
         mon_4_dist = 40.0
         mon_5_dist = 20.0
 
-        move_info = self.get_state_move_obj(monitor_4_dist=mon_4_dist, monitor_5_dist=mon_5_dist)
+        state = self.get_state_obj(monitor_4_dist=mon_4_dist, monitor_5_dist=mon_5_dist)
+        zoom_class = SANSMoveZOOM(state=state)
         workspace = self.get_zoom_workspace()
         coordinates = get_coordinates()
 
-        z_pos_mon_4_before = get_monitor_pos(ws=workspace, monitor_spectrum_no=4, move_info=move_info)
-        z_pos_mon_5_before = get_monitor_pos(ws=workspace, monitor_spectrum_no=5, move_info=move_info)
+        inst_info = state.instrument_info
+        z_pos_mon_4_before = get_monitor_pos(ws=workspace, monitor_spectrum_no=4, inst_info=inst_info)
+        z_pos_mon_5_before = get_monitor_pos(ws=workspace, monitor_spectrum_no=5, inst_info=inst_info)
 
         self.assertTrue(isinstance(z_pos_mon_4_before, float))
         self.assertTrue(isinstance(z_pos_mon_5_before, float))
 
-        zoom_class.move_initial(move_info=move_info, workspace=workspace, coordinates=coordinates,
+        zoom_class.move_initial(workspace=workspace, coordinates=coordinates,
                                 component=component, is_transmission_workspace=is_transmission_workspace)
 
         # Monitor 4 shifts relative to itself rather than the rear detector on ZOOM
-        z_pos_mon_4_after = get_monitor_pos(ws=workspace, monitor_spectrum_no=4, move_info=move_info)
-        z_pos_mon_5_after = get_monitor_pos(ws=workspace, monitor_spectrum_no=5, move_info=move_info)
+        z_pos_mon_4_after = get_monitor_pos(ws=workspace, monitor_spectrum_no=4, inst_info=inst_info)
+        z_pos_mon_5_after = get_monitor_pos(ws=workspace, monitor_spectrum_no=5, inst_info=inst_info)
 
         self.assertAlmostEqual(z_pos_mon_4_before + mon_4_dist, z_pos_mon_4_after)
-        self.assertAlmostEqual(calculate_new_pos_rel_to_rear(ws=workspace, move_info=move_info, offset=mon_5_dist),
+        self.assertAlmostEqual(calculate_new_pos_rel_to_rear(ws=workspace, offset=mon_5_dist, inst_info=inst_info),
                                z_pos_mon_5_after)
 
     def test_moving_only_monitor_4(self):
-        zoom_class = SANSMoveZOOM()
-
         component = None
         is_transmission_workspace = None
 
         mon_4_dist = 40.0
         mon_5_dist = 0.0
 
-        move_info = self.get_state_move_obj(monitor_4_dist=mon_4_dist, monitor_5_dist=mon_5_dist)
+        state = self.get_state_obj(monitor_4_dist=mon_4_dist, monitor_5_dist=mon_5_dist)
+        zoom_class = SANSMoveZOOM(state)
         workspace = self.get_zoom_workspace()
         coordinates = get_coordinates()
 
-        z_pos_mon_4_before = get_monitor_pos(ws=workspace, monitor_spectrum_no=4, move_info=move_info)
-        z_pos_mon_5_before = get_monitor_pos(ws=workspace, monitor_spectrum_no=5, move_info=move_info)
+        inst_info = state.instrument_info
+        z_pos_mon_4_before = get_monitor_pos(ws=workspace, monitor_spectrum_no=4, inst_info=inst_info)
+        z_pos_mon_5_before = get_monitor_pos(ws=workspace, monitor_spectrum_no=5, inst_info=inst_info)
 
         self.assertTrue(isinstance(z_pos_mon_4_before, float))
         self.assertTrue(isinstance(z_pos_mon_5_before, float))
 
-        zoom_class.move_initial(move_info=move_info, workspace=workspace, coordinates=coordinates,
+        zoom_class.move_initial(workspace=workspace, coordinates=coordinates,
                                 component=component, is_transmission_workspace=is_transmission_workspace)
 
         # Monitor 4 shifts relative to itself rather than the rear detector on ZOOM
-        z_pos_mon_4_after = get_monitor_pos(ws=workspace, monitor_spectrum_no=4, move_info=move_info)
-        z_pos_mon_5_after = get_monitor_pos(ws=workspace, monitor_spectrum_no=5, move_info=move_info)
+        z_pos_mon_4_after = get_monitor_pos(ws=workspace, monitor_spectrum_no=4, inst_info=inst_info)
+        z_pos_mon_5_after = get_monitor_pos(ws=workspace, monitor_spectrum_no=5, inst_info=inst_info)
 
         self.assertAlmostEqual(z_pos_mon_4_before + mon_4_dist, z_pos_mon_4_after)
-        self.assertAlmostEqual(calculate_new_pos_rel_to_rear(ws=workspace, move_info=move_info, offset=mon_5_dist),
+        self.assertAlmostEqual(calculate_new_pos_rel_to_rear(ws=workspace, offset=mon_5_dist, inst_info=inst_info),
                                z_pos_mon_5_after)
 
     def test_moving_only_monitor_5(self):
-        zoom_class = SANSMoveZOOM()
-
         component = None
         is_transmission_workspace = None
 
         mon_4_dist = 0.0
         mon_5_dist = 80.0
 
-        move_info = self.get_state_move_obj(monitor_4_dist=mon_4_dist, monitor_5_dist=mon_5_dist)
+        state = self.get_state_obj(monitor_4_dist=mon_4_dist, monitor_5_dist=mon_5_dist)
+        zoom_class = SANSMoveZOOM(state=state)
         workspace = self.get_zoom_workspace()
         coordinates = get_coordinates()
 
-        z_pos_mon_4_before = get_monitor_pos(ws=workspace, monitor_spectrum_no=4, move_info=move_info)
-        z_pos_mon_5_before = get_monitor_pos(ws=workspace, monitor_spectrum_no=5, move_info=move_info)
+        inst_info = state.instrument_info
+        z_pos_mon_4_before = get_monitor_pos(ws=workspace, monitor_spectrum_no=4, inst_info=inst_info)
+        z_pos_mon_5_before = get_monitor_pos(ws=workspace, monitor_spectrum_no=5, inst_info=inst_info)
 
         self.assertTrue(isinstance(z_pos_mon_4_before, float))
         self.assertTrue(isinstance(z_pos_mon_5_before, float))
 
-        zoom_class.move_initial(move_info=move_info, workspace=workspace, coordinates=coordinates,
+        zoom_class.move_initial(workspace=workspace, coordinates=coordinates,
                                 component=component, is_transmission_workspace=is_transmission_workspace)
 
-        z_pos_mon_4_after = get_monitor_pos(ws=workspace, monitor_spectrum_no=4, move_info=move_info)
-        z_pos_mon_5_after = get_monitor_pos(ws=workspace, monitor_spectrum_no=5, move_info=move_info)
+        z_pos_mon_4_after = get_monitor_pos(ws=workspace, monitor_spectrum_no=4, inst_info=inst_info)
+        z_pos_mon_5_after = get_monitor_pos(ws=workspace, monitor_spectrum_no=5, inst_info=inst_info)
 
         self.assertAlmostEqual(z_pos_mon_4_before, z_pos_mon_4_after)
-        self.assertAlmostEqual(calculate_new_pos_rel_to_rear(ws=workspace, move_info=move_info, offset=mon_5_dist),
+        self.assertAlmostEqual(calculate_new_pos_rel_to_rear(ws=workspace, offset=mon_5_dist, inst_info=inst_info),
                                z_pos_mon_5_after)
 
 

--- a/scripts/test/SANS/state/CMakeLists.txt
+++ b/scripts/test/SANS/state/CMakeLists.txt
@@ -7,6 +7,7 @@ set(TEST_PY_FILES
     convert_to_q_test.py
     data_test.py
     state_functions_test.py
+    state_instrument_info_test.py
     scale_test.py
     mask_test.py
     move_test.py

--- a/scripts/test/SANS/state/move_test.py
+++ b/scripts/test/SANS/state/move_test.py
@@ -18,32 +18,6 @@ from sans.test_helper.file_information_mock import SANSFileInformationMock
 # State
 # ----------------------------------------------------------------------------------------------------------------------
 class StateMoveWorkspaceTest(unittest.TestCase):
-    def test_that_raises_if_the_detector_name_is_not_set_up(self):
-        state = StateMove()
-        state.detectors = {DetectorType.LAB.value: StateMoveDetectors(),
-                           DetectorType.HAB.value: StateMoveDetectors()}
-        state.detectors[DetectorType.LAB.value].detector_name = "test"
-        state.detectors[DetectorType.HAB.value].detector_name_short = "test"
-        state.detectors[DetectorType.LAB.value].detector_name_short = "test"
-        with self.assertRaises(ValueError):
-            state.validate()
-
-        state.detectors[DetectorType.HAB.value].detector_name = "test"
-        self.assertIsNone(state.validate())
-
-    def test_that_raises_if_the_short_detector_name_is_not_set_up(self):
-        state = StateMove()
-        state.detectors = {DetectorType.LAB.value: StateMoveDetectors(),
-                           DetectorType.HAB.value: StateMoveDetectors()}
-        state.detectors[DetectorType.HAB.value].detector_name = "test"
-        state.detectors[DetectorType.LAB.value].detector_name = "test"
-        state.detectors[DetectorType.HAB.value].detector_name_short = "test"
-        with self.assertRaises(ValueError):
-            state.validate()
-
-        state.detectors[DetectorType.LAB.value].detector_name_short = "test"
-        self.assertIsNone(state.validate())
-
     def test_that_general_isis_default_values_are_set_up(self):
         state = StateMove()
         state.detectors = {DetectorType.LAB.value: StateMoveDetectors(),
@@ -71,7 +45,6 @@ class StateMoveWorkspaceLOQTest(unittest.TestCase):
     def test_that_LOQ_has_centre_position_set_up(self):
         state = StateMoveLOQ()
         self.assertEqual(state.center_position,  317.5 / 1000.)
-        self.assertEqual(state.monitor_names,  {})
 
 
 class StateMoveWorkspaceSANS2DTest(unittest.TestCase):
@@ -91,7 +64,6 @@ class StateMoveWorkspaceSANS2DTest(unittest.TestCase):
         self.assertEqual(state.hab_detector_rotation,  0.0)
         self.assertEqual(state.lab_detector_x,  0.0)
         self.assertEqual(state.lab_detector_z,  0.0)
-        self.assertEqual(state.monitor_names,  {})
         self.assertEqual(state.monitor_4_offset,  0.0)
 
 
@@ -103,7 +75,6 @@ class StateMoveWorkspaceLARMORTest(unittest.TestCase):
     def test_that_can_set_and_get_values(self):
         state = StateMoveLARMOR()
         self.assertEqual(state.bench_rotation,  0.0)
-        self.assertEqual(state.monitor_names,  {})
 
 
 class StateMoveWorkspaceZOOMTest(unittest.TestCase):
@@ -114,7 +85,6 @@ class StateMoveWorkspaceZOOMTest(unittest.TestCase):
     def test_that_can_set_and_get_values(self):
         state = StateMoveZOOM()
         self.assertEqual(len(state.detectors),  1)
-        self.assertEqual(state.monitor_names,  {})
 
 
 # ----------------------------------------------------------------------------------------------------------------------
@@ -141,10 +111,6 @@ class StateMoveBuilderTest(unittest.TestCase):
         state = builder.build()
         self.assertEqual(state.center_position,  value)
         self.assertEqual(state.detectors[DetectorType.HAB.value].x_translation_correction,  value)
-        self.assertEqual(state.detectors[DetectorType.HAB.value].detector_name_short,  "HAB")
-        self.assertEqual(state.detectors[DetectorType.LAB.value].detector_name,  "main-detector-bank")
-        self.assertEqual(state.monitor_names[str(2)],  "monitor2")
-        self.assertEqual(len(state.monitor_names),  2)
         self.assertEqual(state.detectors[DetectorType.LAB.value].sample_centre_pos1,  value)
 
     def test_that_state_for_sans2d_can_be_built(self):
@@ -164,10 +130,6 @@ class StateMoveBuilderTest(unittest.TestCase):
         # Assert
         state = builder.build()
         self.assertEqual(state.detectors[DetectorType.HAB.value].x_translation_correction,  value)
-        self.assertEqual(state.detectors[DetectorType.HAB.value].detector_name_short,  "front")
-        self.assertEqual(state.detectors[DetectorType.LAB.value].detector_name,  "rear-detector")
-        self.assertEqual(state.monitor_names[str(4)],  "monitor4")
-        self.assertEqual(len(state.monitor_names),  4)
 
     def test_state_with_no_file_info_can_be_built(self):
         data_info = mock.NonCallableMock()
@@ -197,10 +159,6 @@ class StateMoveBuilderTest(unittest.TestCase):
         # Assert
         state = builder.build()
         self.assertEqual(state.detectors[DetectorType.LAB.value].x_translation_correction,  value)
-        self.assertEqual(state.detectors[DetectorType.LAB.value].detector_name,  "DetectorBench")
-        self.assertTrue(DetectorType.HAB.value not in state.detectors)
-        self.assertEqual(state.monitor_names[str(5)],  "monitor5")
-        self.assertEqual(len(state.monitor_names),  5)
 
     def test_that_state_for_zoom_can_be_built(self):
         # TODO when data becomes available

--- a/scripts/test/SANS/state/state_instrument_info_test.py
+++ b/scripts/test/SANS/state/state_instrument_info_test.py
@@ -1,0 +1,136 @@
+# Mantid Repository : https://github.com/mantidproject/mantid
+#
+# Copyright &copy; 2020 ISIS Rutherford Appleton Laboratory UKRI,
+#     NScD Oak Ridge National Laboratory, European Spallation Source
+#   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+# SPDX - License - Identifier: GPL - 3.0 +
+import unittest
+from unittest import mock
+
+from sans.common.enums import SANSInstrument, DetectorType
+from sans.state.StateObjects import state_instrument_info
+from sans.state.StateObjects.state_instrument_info import StateInstrumentInfo
+
+
+class StateInstrumentInfoTest(unittest.TestCase):
+    def test_invalid_monitor_types(self):
+        has_no_hab = (SANSInstrument.LARMOR, SANSInstrument.ZOOM)
+        for i in has_no_hab:
+            invalid_types = state_instrument_info._get_invalid_monitor_types(i)
+            self.assertEqual([DetectorType.HAB], invalid_types)
+
+        for i in SANSInstrument:
+            if i in has_no_hab:
+                continue
+            self.assertIsNone(state_instrument_info._get_invalid_monitor_types(i))
+
+    def test_invalid_monitors(self):
+        has_invalid_monitors = (SANSInstrument.LARMOR, SANSInstrument.SANS2D, SANSInstrument.ZOOM)
+        for i in SANSInstrument:
+            returned = state_instrument_info._get_invalid_monitor_names(i)
+
+            if i in has_invalid_monitors:
+                self.assertTrue(len(returned) >= 1)
+            else:
+                self.assertIsNone(returned)
+
+    @staticmethod
+    def _get_ipf_names():
+        return {"lab_short": "low-angle-detector-short-name",
+                "lab_full": "low-angle-detector-name",
+                "hab_short": "high-angle-detector-short-name",
+                "hab_full": "high-angle-detector-name"}
+
+    def _prep_mock_det_ipf(self):
+        lab_short, lab_full = mock.NonCallableMock(), mock.NonCallableMock()
+        hab_short, hab_full = mock.NonCallableMock(), mock.NonCallableMock()
+        ipf_names = self._get_ipf_names()
+        mocked_ipf = {ipf_names["lab_short"]: lab_short,
+                      ipf_names["lab_full"]: lab_full,
+                      ipf_names["hab_short"]: hab_short,
+                      ipf_names["hab_full"]: hab_full}
+        return mocked_ipf
+
+    @mock.patch("state_instrument_info_test.state_instrument_info.get_named_elements_from_ipf_file")
+    def test_setting_det_names(self, mocked_ipf_loader):
+        mocked_ipf_data = self._prep_mock_det_ipf()
+        mocked_ipf_loader.return_value = mocked_ipf_data
+        mocked_data_info = mock.NonCallableMock()
+
+        inst_info = StateInstrumentInfo()
+        state_instrument_info._set_detector_names(inst_info, mocked_data_info)
+        ipf_names = self._get_ipf_names()
+
+        lab_values = inst_info.detector_names[DetectorType.LAB.value]
+        hab_values = inst_info.detector_names[DetectorType.HAB.value]
+        self.assertEqual(mocked_ipf_data[ipf_names["lab_short"]], lab_values.detector_name_short)
+        self.assertEqual(mocked_ipf_data[ipf_names["lab_full"]], lab_values.detector_name)
+        self.assertEqual(mocked_ipf_data[ipf_names["hab_short"]], hab_values.detector_name_short)
+        self.assertEqual(mocked_ipf_data[ipf_names["hab_full"]], hab_values.detector_name)
+
+    @mock.patch("state_instrument_info_test.state_instrument_info.get_named_elements_from_ipf_file")
+    def test_setting_det_names_no_hab(self, mocked_ipf_loader):
+        mocked_ipf_data = self._prep_mock_det_ipf()
+        mocked_ipf_loader.return_value = mocked_ipf_data
+        mocked_data_info = mock.NonCallableMock()
+
+        inst_info = StateInstrumentInfo()
+        state_instrument_info._set_detector_names(inst_info, mocked_data_info,
+                                                  invalid_detector_types=[DetectorType.HAB])
+
+        ipf_names = self._get_ipf_names()
+        lab_values = inst_info.detector_names[DetectorType.LAB.value]
+        self.assertEqual(mocked_ipf_data[ipf_names["lab_short"]], lab_values.detector_name_short)
+        self.assertEqual(mocked_ipf_data[ipf_names["lab_full"]], lab_values.detector_name)
+
+        hab_values = inst_info.detector_names[DetectorType.HAB.value]
+        self.assertIsNone(hab_values.detector_name_short)
+        self.assertIsNone(hab_values.detector_name)
+
+    @mock.patch("state_instrument_info_test.state_instrument_info._get_invalid_monitor_types")
+    @mock.patch("state_instrument_info_test.state_instrument_info._set_detector_names")
+    def test_init_detector_names_forwards_invalid(self, set_det_names, get_invalid_monitors):
+        expected = mock.NonCallableMock()
+        get_invalid_monitors.return_value = expected
+
+        state_instrument_info._init_detector_names(data_info=mock.NonCallableMock(),
+                                                   inst_info=mock.NonCallableMock())
+
+        set_det_names.assert_called_once_with(mock.ANY, mock.ANY, invalid_detector_types=expected)
+
+    @mock.patch("state_instrument_info_test.state_instrument_info._get_invalid_monitor_names")
+    @mock.patch("state_instrument_info_test.state_instrument_info._set_monitor_names")
+    def test_init_monitor_names_forwards_invalid(self, set_monitor_names, get_invalid_names):
+        expected = mock.NonCallableMock()
+        get_invalid_names.return_value = expected
+
+        state_instrument_info._init_monitor_names(data_info=mock.NonCallableMock(),
+                                                  inst_info=mock.NonCallableMock())
+
+        set_monitor_names.assert_called_once_with(mock.ANY, mock.ANY, invalid_monitor_names=expected)
+
+    @mock.patch("state_instrument_info_test.state_instrument_info.get_monitor_names_from_idf_file")
+    def test_set_monitor_names(self, mocked_idf_names):
+        expected = mock.NonCallableMock()
+        mocked_idf_names.return_value = expected
+
+        inst_info = StateInstrumentInfo()
+        state_instrument_info._set_monitor_names(inst_info_state=inst_info, idf_path=None, invalid_monitor_names=None)
+
+        self.assertEqual(expected, inst_info.monitor_names)
+
+    @mock.patch("state_instrument_info_test.state_instrument_info._init_detector_names")
+    @mock.patch("state_instrument_info_test.state_instrument_info._init_monitor_names")
+    def test_builder(self, init_monitor_names, init_detector_names):
+        data_info = mock.NonCallableMock()
+        data_info.idf_file_path = "idf_path"
+        returned = StateInstrumentInfo.build_from_data_info(data_info=data_info)
+
+        init_detector_names.assert_called_once()
+        init_monitor_names.assert_called_once()
+        self.assertIsInstance(returned, StateInstrumentInfo)
+        self.assertEqual("idf_path", returned.idf_path)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
**Description of work.**

- Backports dataclasses, to remove boilerplate from adding new POD types
- Splits out monitor / detector names. These require reading from the IDF/IPF so conflating them into the state information (which is read from user files) causes chicken-egg problems on the GUI

**To test:**

- Check unit tests / system tests pass - this exercises all paths that uses State Objects
- Code review

Partially Fixes #29534 

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
