### PR TITLE
Remove plotted fit when paramiters are changed in Indirect data analysis

### DIFF
--- a/docs/source/release/v6.0.0/indirect_geometry.rst
+++ b/docs/source/release/v6.0.0/indirect_geometry.rst
@@ -14,6 +14,7 @@ Improvements
 - Added an option to load diffraction data on IN16B.
 - Indirect Data Analysis multiple input tabs can now accept different fit ranges for each spectra.
 - :ref:`QENSFitSequential <algm-QENSFitSequential>` now accepts multiple inputs for `StartX` and `EndX` for each spectra.
+- Plotted fits in indirect data analysis are cleared when the fit parameters are changed.
 - The context menu for plots in the  indirect data analysis GUI is now enabled.
 
 Bug Fixes

--- a/qt/scientific_interfaces/Indirect/IndirectFitAnalysisTab.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectFitAnalysisTab.cpp
@@ -848,6 +848,8 @@ void IndirectFitAnalysisTab::respondToBackgroundChanged(double value) {
 
 void IndirectFitAnalysisTab::respondToFunctionChanged() {
   setModelFitFunction();
+  m_fittingModel->removeFittingData();
+  m_plotPresenter->updatePlots();
   m_plotPresenter->updateFit();
   emit functionChanged();
 }

--- a/qt/scientific_interfaces/Indirect/IndirectFitPlotPresenter.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectFitPlotPresenter.cpp
@@ -265,8 +265,6 @@ void IndirectFitPlotPresenter::updatePlots() {
 
 void IndirectFitPlotPresenter::updateFit() {
   HoldRedrawing holdRedrawing(m_view);
-  updateRangeSelectors();
-  updateFitRangeSelector();
   updateGuess();
 }
 


### PR DESCRIPTION
**Description of work.**

This PR makes indirect data analysis remove the previous fit from the miniplot when the fit parameters are changed in indirect data analysis.

**To test:**

1. open indirect dat analysis.
2. load data in one of the fitting tabs
3. run a fit.
4. the fit should be plotted on the miniplot
5. change the fit paramiters
6. the fit should be rmeoved from the plot.

Fixes #28991 


<!-- Ensure the base of this PR is correct (e.g. release-next or master)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
