### PR TITLE
Show correct attribute values in Indirect Data Analysis FunctionBrowser

### DIFF
--- a/Framework/API/inc/MantidAPI/IFunction.h
+++ b/Framework/API/inc/MantidAPI/IFunction.h
@@ -44,6 +44,19 @@ class Workspace;
 class MatrixWorkspace;
 class FunctionHandler;
 
+/**
+ * Attribute visitor structure supporting lambda expressions
+ * Example usage: AttributeLambdaVisitor{[](const int val) {...}, [] (const
+ * double val) {}} would create a visitor capable of "visiting" an integer and
+ * double attribute*
+ * It functions by inheriting the () operator defined in each lambda
+ */
+template <class... Ts> struct AttributeLambdaVisitor : Ts... {
+  using Ts::operator()...;
+};
+template <class... Ts>
+AttributeLambdaVisitor(Ts...)->AttributeLambdaVisitor<Ts...>;
+
 /** This is an interface to a fitting function - a semi-abstarct class.
     Functions derived from IFunction can be used with the Fit algorithm.
     IFunction defines the structure of a fitting funtion.
@@ -249,6 +262,10 @@ public:
     /// Apply a const attribute visitor
     template <typename T> T apply(ConstAttributeVisitor<T> &v) const {
       return boost::apply_visitor(v, m_data);
+    }
+    /// Apply a lambda visitor
+    template <typename... Ts> void apply(AttributeLambdaVisitor<Ts...> &v) {
+      boost::apply_visitor(v, m_data);
     }
 
     /// Returns type of the attribute

--- a/docs/source/release/v6.0.0/indirect_geometry.rst
+++ b/docs/source/release/v6.0.0/indirect_geometry.rst
@@ -16,6 +16,7 @@ Improvements
 - :ref:`QENSFitSequential <algm-QENSFitSequential>` now accepts multiple inputs for `StartX` and `EndX` for each spectra.
 - Plotted fits in indirect data analysis are cleared when the fit parameters are changed.
 - The context menu for plots in the  indirect data analysis GUI is now enabled.
+- The function browser in the ConvFit tab should now correctly show Q values for Q dependent functions.
 
 Bug Fixes
 #########

--- a/qt/scientific_interfaces/Indirect/IndirectFitDataModel.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectFitDataModel.cpp
@@ -94,7 +94,7 @@ size_t IndirectFitDataModel::getNumberOfDomains() const {
 }
 
 std::vector<double> IndirectFitDataModel::getQValuesForData() const {
-  std::vector<double> qValues{1};
+  std::vector<double> qValues;
   for (auto &fitData : *m_fittingData) {
     auto indexQValues = fitData.getQValues();
     qValues.insert(std::end(qValues), std::begin(indexQValues),

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/FunctionBrowser.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/FunctionBrowser.h
@@ -105,6 +105,8 @@ public:
   IFunction_sptr getGlobalFunction() override;
   /// Update parameter values in the browser to match those of a function.
   void updateMultiDatasetParameters(const IFunction &fun) override;
+  /// Update parameter values in the browser to match those of a function.
+  void updateMultiDatasetAttributes(const IFunction &fun);
   /// Update parameter values in the browser to match those in a table
   /// workspace.
   void updateMultiDatasetParameters(const ITableWorkspace &paramTable) override;

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/FunctionModel.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/FunctionModel.h
@@ -27,6 +27,7 @@ public:
   void addFunction(const QString &prefix, const QString &funStr) override;
   void removeFunction(const QString &functionIndex) override;
   void setParameter(const QString &paramName, double value) override;
+  void setAttribute(const QString &attrName, IFunction::Attribute &val);
   void setParameterError(const QString &paramName, double value) override;
   double getParameter(const QString &paramName) const override;
   double getParameterError(const QString &paramName) const override;

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/FunctionModel.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/FunctionModel.h
@@ -27,7 +27,7 @@ public:
   void addFunction(const QString &prefix, const QString &funStr) override;
   void removeFunction(const QString &functionIndex) override;
   void setParameter(const QString &paramName, double value) override;
-  void setAttribute(const QString &attrName, IFunction::Attribute &val);
+  void setAttribute(const QString &attrName, const IFunction::Attribute &val);
   void setParameterError(const QString &paramName, double value) override;
   double getParameter(const QString &paramName) const override;
   double getParameterError(const QString &paramName) const override;

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/FunctionModel.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/FunctionModel.h
@@ -9,6 +9,7 @@
 #include "DllOption.h"
 
 #include "IFunctionModel.h"
+#include "MantidAPI/IFunction.h"
 
 #include <QString>
 #include <QStringList>
@@ -29,12 +30,14 @@ public:
   void setParameterError(const QString &paramName, double value) override;
   double getParameter(const QString &paramName) const override;
   double getParameterError(const QString &paramName) const override;
+  IFunction::Attribute getAttribute(const QString &attrName) const;
   QString getParameterDescription(const QString &paramName) const override;
   bool isParameterFixed(const QString &parName) const;
   QString getParameterTie(const QString &parName) const;
   void setParameterFixed(const QString &parName, bool fixed);
   void setParameterTie(const QString &parName, const QString &tie);
   QStringList getParameterNames() const override;
+  QStringList getAttributeNames() const;
   IFunction_sptr getSingleFunction(int index) const override;
   IFunction_sptr getCurrentFunction() const override;
   void setNumberDomains(int) override;
@@ -67,6 +70,7 @@ public:
   bool isGlobal(const QString &parName) const override;
   QStringList getLocalParameters() const override;
   void updateMultiDatasetParameters(const IFunction &fun) override;
+  void updateMultiDatasetAttributes(const IFunction &fun);
   void updateParameters(const IFunction &fun) override;
   QString setBackgroundA0(double value) override;
 

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/FunctionMultiDomainPresenter.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/FunctionMultiDomainPresenter.h
@@ -45,6 +45,7 @@ public:
   QString getParameterTie(const QString &parName) const;
   void updateParameters(const IFunction &fun);
   void updateMultiDatasetParameters(const IFunction &fun);
+  void updateMultiDatasetAttributes(const IFunction &fun);
   void clearErrors();
   boost::optional<QString> currentFunctionIndex() const;
   void setNumberOfDatasets(int);
@@ -94,6 +95,7 @@ private slots:
 
 private:
   void updateViewFromModel();
+  void updateViewAttributesFromModel();
 
 private:
   IFunctionView *m_view;

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/FunctionMultiDomainPresenter.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/FunctionMultiDomainPresenter.h
@@ -80,6 +80,7 @@ signals:
   void parameterChanged(const QString &funcIndex, const QString &paramName);
 private slots:
   void viewChangedParameter(const QString &parName);
+  void viewChangedAttribute(const QString &attrName);
   void viewPastedFunction(const QString &funStr);
   void viewAddedFunction(const QString &funStr);
   void viewRemovedFunction(const QString &functionIndex);

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/FunctionTreeView.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/FunctionTreeView.h
@@ -101,7 +101,7 @@ public:
   /// Get a value of a parameter
   double getParameter(const QString &paramName) const override;
   /// Get a value of a attribute
-  IFunction::Attribute getAttribute(const QString &attrName) const;
+  IFunction::Attribute getAttribute(const QString &attrName) const override;
   /// Set error display on/off
   void setErrorsEnabled(bool enabled) override;
   /// Clear all errors

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/FunctionTreeView.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/FunctionTreeView.h
@@ -370,7 +370,7 @@ private:
   /// Update a double attribute
   void setDoubleAttribute(const QString &attrName, double value) override;
   void setIntAttribute(const QString &attrName, int value) override;
-  void setStringAttribute(const QString &attrName, QString &value) override;
+  void setStringAttribute(const QString &attrName, std::string &value) override;
   void setBooleanAttribute(const QString &attrName, bool value) override;
   void setVectorAttribute(const QString &attrName,
                           std::vector<double> &val) override;

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/FunctionTreeView.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/FunctionTreeView.h
@@ -189,9 +189,10 @@ protected:
   /// Get function property for the index
   QtProperty *getFunctionProperty(const QString &index) const;
   ///// Get a property for a parameter
-  // QtProperty *getParameterProperty(const QString &paramName) const;
   /// Get a property for a parameter
   QtProperty *getParameterProperty(const QString &paramName) const;
+  /// Get a property for a parameter
+  QtProperty *getAttributeProperty(const QString &paramName) const;
   /// Get a property for a parameter which is a parent of a given
   /// property (tie or constraint).
   QtProperty *getParentParameterProperty(QtProperty *prop) const;
@@ -356,11 +357,19 @@ protected:
   SelectFunctionDialog *m_selectFunctionDialog;
   QtProperty *m_selectedFunctionProperty;
   bool m_emitParameterValueChange = true;
+  bool m_emitAttributeValueChange = true;
 
   friend class CreateAttributePropertyForFunctionTreeView;
   friend class SetAttributeFromProperty;
 
 private:
+  /// Update a double attribute 
+  void setDoubleAttribute(const QString &attrName, double value) override;
+  void setIntAttribute(const QString &attrName, int value) override;
+  void setStringAttribute(const QString &attrName, QString &value) override;
+  void setBooleanAttribute(const QString &attrName, bool value) override;
+  void setVectorAttribute(const QString &attrName, std::vector<double> &val) override;
+
   // Intended for testing only
   QTreeWidgetItem *getPropertyWidgetItem(QtProperty *prop) const;
   QRect visualItemRect(QtProperty *prop) const;

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/FunctionTreeView.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/FunctionTreeView.h
@@ -100,6 +100,8 @@ public:
   void setParameterError(const QString &paramName, double error) override;
   /// Get a value of a parameter
   double getParameter(const QString &paramName) const override;
+  /// Get a value of a attribute
+  IFunction::Attribute getAttribute(const QString &attrName) const;
   /// Set error display on/off
   void setErrorsEnabled(bool enabled) override;
   /// Clear all errors
@@ -186,6 +188,8 @@ protected:
   QString getIndex(QtProperty *prop) const;
   /// Get name of the parameter for a property
   QString getParameterName(QtProperty *prop) const;
+  /// Get name of the attribute for a property
+  QString getAttributeName(QtProperty *prop) const;
   /// Get function property for the index
   QtProperty *getFunctionProperty(const QString &index) const;
   ///// Get a property for a parameter
@@ -363,12 +367,13 @@ protected:
   friend class SetAttributeFromProperty;
 
 private:
-  /// Update a double attribute 
+  /// Update a double attribute
   void setDoubleAttribute(const QString &attrName, double value) override;
   void setIntAttribute(const QString &attrName, int value) override;
   void setStringAttribute(const QString &attrName, QString &value) override;
   void setBooleanAttribute(const QString &attrName, bool value) override;
-  void setVectorAttribute(const QString &attrName, std::vector<double> &val) override;
+  void setVectorAttribute(const QString &attrName,
+                          std::vector<double> &val) override;
 
   // Intended for testing only
   QTreeWidgetItem *getPropertyWidgetItem(QtProperty *prop) const;

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/IFunctionView.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/IFunctionView.h
@@ -81,7 +81,7 @@ signals:
   /// Function parameter gets changed
   void parameterChanged(const QString &paramName);
   /// Function attribute gets changed
-  void attributePropertyChanged(const QString attrName);
+  void attributePropertyChanged(const QString &attrName);
   /// In multi-dataset context a button value editor was clicked
   void localParameterButtonClicked(const QString &parName);
   /// User sets a tie

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/IFunctionView.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/IFunctionView.h
@@ -64,7 +64,8 @@ public:
 protected:
   virtual void setDoubleAttribute(const QString &paramName, double value) = 0;
   virtual void setIntAttribute(const QString &paramName, int value) = 0;
-  virtual void setStringAttribute(const QString &paramName, QString &value) = 0;
+  virtual void setStringAttribute(const QString &paramName,
+                                  std::string &value) = 0;
   virtual void setBooleanAttribute(const QString &paramName, bool value) = 0;
   virtual void setVectorAttribute(const QString &paramName,
                                   std::vector<double> &val) = 0;

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/IFunctionView.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/IFunctionView.h
@@ -13,6 +13,7 @@
 #include <QString>
 #include <QWidget>
 #include <boost/optional.hpp>
+#include <type_traits>
 
 namespace MantidQt {
 namespace MantidWidgets {
@@ -43,6 +44,29 @@ public:
                                       const QString &constraint) = 0;
   virtual void setGlobalParameters(const QStringList &) = 0;
   virtual void showFunctionHelp(const QString &) const = 0;
+  // Set the value of an attribute based on the template type
+  template <typename T>
+  void setAttributeValue(const QString &attributeName, T &value) {
+    if constexpr (std::is_same_v<T, double>) {
+      setDoubleAttribute(attributeName, value);
+    } else if constexpr (std::is_same_v<T, int>) {
+      setIntAttribute(attributeName, value);
+    } else if constexpr (std::is_same_v<T, QString>) {
+      setStringAttribute(attributeName, value);
+    } else if constexpr (std::is_same_v<T, bool>) {
+      setBooleanAttribute(attributeName, value);
+    } else if constexpr (std::is_same_v<T, std::vector<double>>) {
+      setVectorAttribute(attributeName, value);
+    }
+  }
+
+protected:
+  virtual void setDoubleAttribute(const QString &paramName, double value) = 0;
+  virtual void setIntAttribute(const QString &paramName, int value) = 0;
+  virtual void setStringAttribute(const QString &paramName, QString &value) = 0;
+  virtual void setBooleanAttribute(const QString &paramName, bool value) = 0;
+  virtual void setVectorAttribute(const QString &paramName,
+                                  std::vector<double> &val) = 0;
 
 signals:
   /// User replaces the whole function (eg, by pasting it from clipboard)

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/IFunctionView.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/IFunctionView.h
@@ -8,7 +8,7 @@
 
 #include "DllOption.h"
 
-#include "MantidAPI/IFunction_fwd.h"
+#include "MantidAPI/IFunction.h"
 
 #include <QString>
 #include <QWidget>
@@ -35,6 +35,7 @@ public:
   virtual void setParameter(const QString &paramName, double value) = 0;
   virtual void setParameterError(const QString &paramName, double error) = 0;
   virtual double getParameter(const QString &paramName) const = 0;
+  virtual IFunction::Attribute getAttribute(const QString &attrName) const = 0;
   virtual void setErrorsEnabled(bool enabled) = 0;
   virtual void clearErrors() = 0;
   virtual boost::optional<QString> currentFunctionIndex() const = 0;
@@ -79,6 +80,8 @@ signals:
   void currentFunctionChanged();
   /// Function parameter gets changed
   void parameterChanged(const QString &paramName);
+  /// Function attribute gets changed
+  void attributePropertyChanged(const QString attrName);
   /// In multi-dataset context a button value editor was clicked
   void localParameterButtonClicked(const QString &parName);
   /// User sets a tie

--- a/qt/widgets/common/src/FunctionBrowser.cpp
+++ b/qt/widgets/common/src/FunctionBrowser.cpp
@@ -258,6 +258,12 @@ void FunctionBrowser::updateMultiDatasetParameters(const IFunction &fun) {
   m_presenter->updateMultiDatasetParameters(fun);
 }
 
+/// Update the interface to have the same attribute values as in a function.
+/// @param fun :: A function to get attribute values from.
+void FunctionBrowser::updateMultiDatasetAttributes(const IFunction &fun) {
+  m_presenter->updateMultiDatasetAttributes(fun);
+}
+
 void FunctionBrowser::updateMultiDatasetParameters(
     const ITableWorkspace &paramTable) {
   auto const nRows = paramTable.rowCount();

--- a/qt/widgets/common/src/FunctionModel.cpp
+++ b/qt/widgets/common/src/FunctionModel.cpp
@@ -146,7 +146,7 @@ void FunctionModel::setParameter(const QString &paramName, double value) {
 }
 
 void FunctionModel::setAttribute(const QString &attrName,
-                                 IFunction::Attribute &value) {
+                                 const IFunction::Attribute &value) {
   auto fun = getCurrentFunction();
   if (!fun) {
     throw std::logic_error("Function is undefined.");

--- a/qt/widgets/common/src/FunctionModel.cpp
+++ b/qt/widgets/common/src/FunctionModel.cpp
@@ -155,6 +155,11 @@ double FunctionModel::getParameter(const QString &paramName) const {
   return getCurrentFunction()->getParameter(paramName.toStdString());
 }
 
+IFunction::Attribute
+FunctionModel::getAttribute(const QString &attrName) const {
+  return getCurrentFunction()->getAttribute(attrName.toStdString());
+}
+
 double FunctionModel::getParameterError(const QString &paramName) const {
   auto fun = getCurrentFunction();
   auto const index = fun->parameterIndex(paramName.toStdString());
@@ -195,6 +200,17 @@ QStringList FunctionModel::getParameterNames() const {
   }
   return names;
 }
+QStringList FunctionModel::getAttributeNames() const {
+  QStringList names;
+  if (hasFunction()) {
+    const auto attributeNames = getCurrentFunction()->getAttributeNames();
+    for (auto const name : attributeNames) {
+      names << QString::fromStdString(name);
+    }
+  }
+  return names;
+}
+
 
 IFunction_sptr FunctionModel::getSingleFunction(int index) const {
   checkIndex(index);
@@ -429,6 +445,16 @@ void FunctionModel::updateMultiDatasetParameters(const IFunction &fun) {
   for (size_t i = 0; i < fun.nParams(); ++i) {
     m_function->setParameter(i, fun.getParameter(i));
     m_function->setError(i, fun.getError(i));
+  }
+  updateMultiDatasetAttributes(fun);
+}
+void FunctionModel::updateMultiDatasetAttributes(const IFunction &fun) {
+  if (!hasFunction())
+    return;
+  if (m_function->nAttributes() != fun.nAttributes())
+    return;
+  for (const auto& name : fun.getAttributeNames()) {
+    m_function->setAttribute(name, fun.getAttribute(name));
   }
 }
 

--- a/qt/widgets/common/src/FunctionModel.cpp
+++ b/qt/widgets/common/src/FunctionModel.cpp
@@ -145,6 +145,17 @@ void FunctionModel::setParameter(const QString &paramName, double value) {
   }
 }
 
+void FunctionModel::setAttribute(const QString &attrName,
+                                 IFunction::Attribute &value) {
+  auto fun = getCurrentFunction();
+  if (!fun) {
+    throw std::logic_error("Function is undefined.");
+  }
+  if (fun->hasAttribute(attrName.toStdString())) {
+    fun->setAttribute(attrName.toStdString(), value);
+  }
+}
+
 void FunctionModel::setParameterError(const QString &paramName, double value) {
   auto fun = getCurrentFunction();
   auto const index = fun->parameterIndex(paramName.toStdString());
@@ -210,7 +221,6 @@ QStringList FunctionModel::getAttributeNames() const {
   }
   return names;
 }
-
 
 IFunction_sptr FunctionModel::getSingleFunction(int index) const {
   checkIndex(index);
@@ -453,7 +463,7 @@ void FunctionModel::updateMultiDatasetAttributes(const IFunction &fun) {
     return;
   if (m_function->nAttributes() != fun.nAttributes())
     return;
-  for (const auto& name : fun.getAttributeNames()) {
+  for (const auto &name : fun.getAttributeNames()) {
     m_function->setAttribute(name, fun.getAttribute(name));
   }
 }

--- a/qt/widgets/common/src/FunctionMultiDomainPresenter.cpp
+++ b/qt/widgets/common/src/FunctionMultiDomainPresenter.cpp
@@ -50,38 +50,9 @@ protected:
   void apply(std::vector<double> &v) const override {
     m_view->setAttributeValue(m_attrName, v);
   };
-private:
-  IFunctionView *m_view;
-  QString m_attrName;
-};
-
-/**
- * Attribute visitor to set an attribute in an IFunctionModel.
- */
-class SetAttributeInModel : public IFunction::AttributeVisitor<> {
-public:
-  SetAttributeInModel(IFunctionView *view, QString attrName)
-      : m_view(view), m_attrName(attrName){};
-protected:
-  void apply(double &d) const override {
-    m_view->setAttributeValue(m_attrName, d);
-  }
-  void apply(std::string &str) const override {
-    m_view->setAttributeValue(m_attrName, QString::fromStdString(str));
-  };
-  void apply(int &i) const override {
-    m_view->setAttributeValue(m_attrName, i);
-  }
-  void apply(bool &b) const override {
-    m_view->setAttributeValue(m_attrName, b);
-  };
-  void apply(std::vector<double> &v) const override {
-    m_view->setAttributeValue(m_attrName, v);
-  };
 
 private:
   IFunctionView *m_view;
-  IFunctionModel *m_model;
   QString m_attrName;
 };
 
@@ -111,6 +82,8 @@ FunctionMultiDomainPresenter::FunctionMultiDomainPresenter(IFunctionView *view)
           SLOT(viewChangedGlobals(const QStringList &)));
   connect(m_view, SIGNAL(functionHelpRequest()), this,
           SLOT(viewRequestedFunctionHelp()));
+  connect(m_view, SIGNAL(attributePropertyChanged(const QString &)), this,
+          SLOT(viewChangedAttribute(const QString &)));
 }
 
 void FunctionMultiDomainPresenter::setFunction(IFunction_sptr fun) {
@@ -410,6 +383,12 @@ void FunctionMultiDomainPresenter::viewChangedParameter(
   m_model->setParameter(paramName, value);
   auto const parts = splitParameterName(paramName);
   emit parameterChanged(parts.first, parts.second);
+}
+
+void FunctionMultiDomainPresenter::viewChangedAttribute(
+    const QString &attrName) {
+  auto value = m_view->getAttribute(attrName);
+  m_model->setAttribute(attrName, value);
 }
 
 /**

--- a/qt/widgets/common/src/FunctionTreeView.cpp
+++ b/qt/widgets/common/src/FunctionTreeView.cpp
@@ -1445,10 +1445,11 @@ void FunctionTreeView::setIntAttribute(const QString &attrName, int value) {
 /**
  * Updates the value of a string attribute
  * @param attrName :: Attribute name
- * @param value :: New value
+ * @param valueAsStdStr :: New value
  */
 void FunctionTreeView::setStringAttribute(const QString &attrName,
-                                          QString &value) {
+                                          std::string &valueAsStdStr) {
+  QString value = QString::fromStdString(valueAsStdStr);
   auto prop = getAttributeProperty(attrName);
   ScopedFalse _false(m_emitAttributeValueChange);
   // attName is the un-prefixed attribute name

--- a/qt/widgets/common/src/FunctionTreeView.cpp
+++ b/qt/widgets/common/src/FunctionTreeView.cpp
@@ -54,12 +54,17 @@
 namespace {
 const char *globalOptionName = "Global";
 Mantid::Kernel::Logger g_log("Function Browser");
-QString removePrefix(QString &param) { return param.split(QString("."))[1]; }
 QString addPrefix(QString &param) { return QString("f0.") + param; }
-
 const std::regex PREFIX_REGEX("(^[f][0-9](.*))");
 inline bool variableIsPrefixed(const std::string &name) {
   return std::regex_match(name, PREFIX_REGEX);
+}
+QString removePrefix(QString &param) {
+  if (variableIsPrefixed(param.toStdString()))
+    return param.split(QString("."))[1];
+  else {
+    return param;
+  }
 }
 // These attributes require the function to be fully reconstructed, as a
 // different number of properties will be required
@@ -1436,7 +1441,7 @@ void FunctionTreeView::setIntAttribute(const QString &attrName, int value) {
   auto prop = getAttributeProperty(attrName);
   ScopedFalse _false(m_emitAttributeValueChange);
   m_attributeIntManager->setValue(prop, value);
-};
+}
 /**
  * Updates the value of a string attribute
  * @param attrName :: Attribute name
@@ -1472,8 +1477,9 @@ void FunctionTreeView::setBooleanAttribute(const QString &attrName,
 /**
  * Updates the value of a vector attribute
  * NOTE: This is currently not implemented as there is no need for it
- * as the use of vector attributes is limited to tabulated functions (e.g resolution)
- * which create their attributes 'on-the-fly' when the fit is performed
+ * as the use of vector attributes is limited to tabulated functions (e.g
+ * resolution) which create their attributes 'on-the-fly' when the fit is
+ * performed
  * @param attrName :: Attribute name
  * @param value :: New value
  */
@@ -1877,7 +1883,8 @@ void FunctionTreeView::attributeChanged(QtProperty *prop) {
   // attributes emit an attributeValueChanged signal.
   if (std::find(REQUIRESRECONSTRUCTIONATTRIBUTES.begin(),
                 REQUIRESRECONSTRUCTIONATTRIBUTES.end(),
-                attributeName) != REQUIRESRECONSTRUCTIONATTRIBUTES.end()) {
+                removePrefix(attributeName)) !=
+      REQUIRESRECONSTRUCTIONATTRIBUTES.end()) {
     auto funProp = m_properties[prop].parent;
     if (!funProp)
       return;

--- a/qt/widgets/common/src/FunctionTreeView.cpp
+++ b/qt/widgets/common/src/FunctionTreeView.cpp
@@ -1471,8 +1471,9 @@ void FunctionTreeView::setBooleanAttribute(const QString &attrName,
 }
 /**
  * Updates the value of a vector attribute
- * NOTE: This is currently not implemented as vector attributes
- * such as (X,Y) for a resolution are not retrieved correctly from the function
+ * NOTE: This is currently not implemented as there is no need for it
+ * as the use of vector attributes is limited to tabulated functions (e.g resolution)
+ * which create their attributes 'on-the-fly' when the fit is performed
  * @param attrName :: Attribute name
  * @param value :: New value
  */
@@ -1491,7 +1492,7 @@ double FunctionTreeView::getParameter(const QString &paramName) const {
 }
 /**
  * Get a value of a attribute
- * @param paramName :: Attribute name
+ * @param attrName :: Attribute name
  */
 IFunction::Attribute
 FunctionTreeView::getAttribute(const QString &attrName) const {
@@ -1539,15 +1540,15 @@ FunctionTreeView::getAttributeProperty(const QString &attributeName) const {
   std::tie(index, name) = splitParameterName(attributeName);
   if (!variableIsPrefixed(attributeName.toStdString())) {
     // If variable is unprefixed then we are on the top level composite
-    // function so grab first property
+    // function so grab first property from the tree
     prop = m_browser->properties()[0];
+  } else {
+    prop = getFunctionProperty(index);
   }
-  if (prop = getFunctionProperty(index)) {
-    auto children = prop->subProperties();
-    foreach (QtProperty *child, children) {
-      if (isAttribute(child) && child->propertyName() == name) {
-        return child;
-      }
+  auto children = prop->subProperties();
+  foreach (QtProperty *child, children) {
+    if (isAttribute(child) && child->propertyName() == name) {
+      return child;
     }
   }
   std::string message =

--- a/qt/widgets/common/test/FunctionMultiDomainPresenterTest.h
+++ b/qt/widgets/common/test/FunctionMultiDomainPresenterTest.h
@@ -127,7 +127,7 @@ private:
   QStringList m_globals;
   MOCK_METHOD2(setDoubleAttribute, void(const QString &, double));
   MOCK_METHOD2(setIntAttribute, void(const QString &, int));
-  MOCK_METHOD2(setStringAttribute, void(const QString &, QString &));
+  MOCK_METHOD2(setStringAttribute, void(const QString &, std::string &));
   MOCK_METHOD2(setBooleanAttribute, void(const QString &, bool));
   MOCK_METHOD2(setVectorAttribute,
                void(const QString &, std::vector<double> &));

--- a/qt/widgets/common/test/FunctionMultiDomainPresenterTest.h
+++ b/qt/widgets/common/test/FunctionMultiDomainPresenterTest.h
@@ -10,6 +10,8 @@
 #include "MantidAPI/FrameworkManager.h"
 #include "MantidAPI/FunctionFactory.h"
 #include "MantidAPI/IFunction.h"
+#include "MantidAPI/MultiDomainFunction.h"
+#include "MantidKernel/EmptyValues.h"
 #include "MantidKernel/WarningSuppressions.h"
 #include "MantidQtWidgets/Common/FunctionBrowser/FunctionBrowserUtils.h"
 #include "MantidQtWidgets/Common/FunctionModel.h"
@@ -112,11 +114,23 @@ public:
 
   IFunction_sptr getFunction() const { return m_function; }
 
+  MOCK_CONST_METHOD1(getAttribute, IFunction::Attribute(const QString &));
+
+  void attributeChanged() { emit attributePropertyChanged(QString("f0.Q")); }
+
+  friend class FunctionMultiDomainPresenterTest;
+
 private:
   IFunction_sptr m_function;
   boost::optional<QString> m_currentFunctionIndex;
   bool m_areErrorsEnabled{true};
   QStringList m_globals;
+  MOCK_METHOD2(setDoubleAttribute, void(const QString &, double));
+  MOCK_METHOD2(setIntAttribute, void(const QString &, int));
+  MOCK_METHOD2(setStringAttribute, void(const QString &, QString &));
+  MOCK_METHOD2(setBooleanAttribute, void(const QString &, bool));
+  MOCK_METHOD2(setVectorAttribute,
+               void(const QString &, std::vector<double> &));
 };
 
 class FunctionMultiDomainPresenterTest : public CxxTest::TestSuite {
@@ -152,13 +166,13 @@ public:
   }
 
   void test_empty() {
-    auto view = std::make_unique<MockFunctionView>();
+    auto view = std::make_unique<NiceMock<MockFunctionView>>();
     FunctionMultiDomainPresenter presenter(view.get());
     TS_ASSERT(!presenter.getFitFunction());
   }
 
   void test_setFunction() {
-    auto view = std::make_unique<MockFunctionView>();
+    auto view = std::make_unique<NiceMock<MockFunctionView>>();
     FunctionMultiDomainPresenter presenter(view.get());
     presenter.setFunctionString("name=LinearBackground,A0=1,A1=2");
     TS_ASSERT_EQUALS(presenter.getNumberOfDatasets(), 0);
@@ -172,7 +186,7 @@ public:
   }
 
   void test_view_addFunction() {
-    auto view = std::make_unique<MockFunctionView>();
+    auto view = std::make_unique<NiceMock<MockFunctionView>>();
     FunctionMultiDomainPresenter presenter(view.get());
     presenter.setFunctionString("name=FlatBackground;(name=FlatBackground,A0=1;"
                                 "name=FlatBackground,A0=2)");
@@ -184,7 +198,7 @@ public:
   }
 
   void test_view_addFunction_top_level() {
-    auto view = std::make_unique<MockFunctionView>();
+    auto view = std::make_unique<NiceMock<MockFunctionView>>();
     FunctionMultiDomainPresenter presenter(view.get());
     presenter.setFunctionString("name=FlatBackground");
     view->addFunction("", "name=LinearBackground");
@@ -195,7 +209,7 @@ public:
   }
 
   void test_view_addFunction_to_empty() {
-    auto view = std::make_unique<MockFunctionView>();
+    auto view = std::make_unique<NiceMock<MockFunctionView>>();
     FunctionMultiDomainPresenter presenter(view.get());
     view->addFunction("", "name=LinearBackground");
     auto newFun = presenter.getFunction();
@@ -205,7 +219,7 @@ public:
   }
 
   void test_view_multi_addFunction() {
-    auto view = std::make_unique<MockFunctionView>();
+    auto view = std::make_unique<NiceMock<MockFunctionView>>();
     FunctionMultiDomainPresenter presenter(view.get());
     presenter.setNumberOfDatasets(3);
     TS_ASSERT_EQUALS(presenter.getNumberOfDatasets(), 3);
@@ -229,7 +243,7 @@ public:
   }
 
   void test_view_multi_addFunction_top_level() {
-    auto view = std::make_unique<MockFunctionView>();
+    auto view = std::make_unique<NiceMock<MockFunctionView>>();
     FunctionMultiDomainPresenter presenter(view.get());
     presenter.setNumberOfDatasets(3);
     presenter.setFunctionString("name=FlatBackground");
@@ -245,7 +259,7 @@ public:
   }
 
   void test_view_multi_addFunction_to_empty() {
-    auto view = std::make_unique<MockFunctionView>();
+    auto view = std::make_unique<NiceMock<MockFunctionView>>();
     FunctionMultiDomainPresenter presenter(view.get());
     presenter.setNumberOfDatasets(3);
     view->addFunction("", "name=LinearBackground");
@@ -260,7 +274,7 @@ public:
   }
 
   void test_setCurrentDataset() {
-    auto view = std::make_unique<MockFunctionView>();
+    auto view = std::make_unique<NiceMock<MockFunctionView>>();
     FunctionMultiDomainPresenter presenter(view.get());
     presenter.setNumberOfDatasets(3);
     presenter.setFunctionString("name=FlatBackground");
@@ -283,7 +297,7 @@ public:
   }
 
   void test_setCurrentDataset_composite() {
-    auto view = std::make_unique<MockFunctionView>();
+    auto view = std::make_unique<NiceMock<MockFunctionView>>();
     FunctionMultiDomainPresenter presenter(view.get());
     presenter.setNumberOfDatasets(3);
     presenter.setFunctionString("name=FlatBackground;name=FlatBackground");
@@ -306,7 +320,7 @@ public:
   }
 
   void test_view_set_tie() {
-    auto view = std::make_unique<MockFunctionView>();
+    auto view = std::make_unique<NiceMock<MockFunctionView>>();
     FunctionMultiDomainPresenter presenter(view.get());
     presenter.setFunctionString("name=FlatBackground;name=LinearBackground");
     view->userSetsParameterTie("f1.A0", "1.0");
@@ -325,7 +339,7 @@ public:
   }
 
   void test_view_set_tie_multi() {
-    auto view = std::make_unique<MockFunctionView>();
+    auto view = std::make_unique<NiceMock<MockFunctionView>>();
     FunctionMultiDomainPresenter presenter(view.get());
     presenter.setNumberOfDatasets(3);
     presenter.setFunctionString("name=FlatBackground;name=LinearBackground");
@@ -349,7 +363,7 @@ public:
   }
 
   void test_presenter_set_tie() {
-    auto view = std::make_unique<MockFunctionView>();
+    auto view = std::make_unique<NiceMock<MockFunctionView>>();
     FunctionMultiDomainPresenter presenter(view.get());
     presenter.setFunctionString("name=FlatBackground;name=LinearBackground");
     auto viewFun = view->getFunction();
@@ -362,7 +376,7 @@ public:
   }
 
   void test_presenter_set_tie_multi() {
-    auto view = std::make_unique<MockFunctionView>();
+    auto view = std::make_unique<NiceMock<MockFunctionView>>();
     FunctionMultiDomainPresenter presenter(view.get());
     presenter.setNumberOfDatasets(3);
     presenter.setFunctionString("name=FlatBackground;name=LinearBackground");
@@ -382,7 +396,7 @@ public:
   }
 
   void test_set_datasets() {
-    auto view = std::make_unique<MockFunctionView>();
+    auto view = std::make_unique<NiceMock<MockFunctionView>>();
     FunctionMultiDomainPresenter presenter(view.get());
     presenter.setFunctionString("name=FlatBackground");
     presenter.setNumberOfDatasets(0);
@@ -408,7 +422,7 @@ public:
   }
 
   void test_set_datasets_zero() {
-    auto view = std::make_unique<MockFunctionView>();
+    auto view = std::make_unique<NiceMock<MockFunctionView>>();
     FunctionMultiDomainPresenter presenter(view.get());
     presenter.setNumberOfDatasets(0);
     presenter.setFunctionString("name=FlatBackground");
@@ -423,7 +437,7 @@ public:
   }
 
   void test_remove_datasets() {
-    auto view = std::make_unique<MockFunctionView>();
+    auto view = std::make_unique<NiceMock<MockFunctionView>>();
     FunctionMultiDomainPresenter presenter(view.get());
     presenter.setFunctionString("name=FlatBackground");
     presenter.setNumberOfDatasets(5);
@@ -440,7 +454,7 @@ public:
   }
 
   void test_replace_function() {
-    auto view = std::make_unique<MockFunctionView>();
+    auto view = std::make_unique<NiceMock<MockFunctionView>>();
     FunctionMultiDomainPresenter presenter(view.get());
     presenter.setFunctionString("name=FlatBackground");
     presenter.setNumberOfDatasets(2);
@@ -450,7 +464,7 @@ public:
   }
 
   void test_remove_function_single() {
-    auto view = std::make_unique<MockFunctionView>();
+    auto view = std::make_unique<NiceMock<MockFunctionView>>();
     FunctionMultiDomainPresenter presenter(view.get());
     presenter.setFunctionString("name=FlatBackground");
     auto fun = presenter.getFunction();
@@ -466,7 +480,7 @@ public:
   }
 
   void test_remove_function_multi() {
-    auto view = std::make_unique<MockFunctionView>();
+    auto view = std::make_unique<NiceMock<MockFunctionView>>();
     FunctionMultiDomainPresenter presenter(view.get());
     presenter.setFunctionString("name=FlatBackground");
     presenter.setNumberOfDatasets(2);
@@ -485,7 +499,7 @@ public:
   }
 
   void test_view_addFunction_after_remove() {
-    auto view = std::make_unique<MockFunctionView>();
+    auto view = std::make_unique<NiceMock<MockFunctionView>>();
     FunctionMultiDomainPresenter presenter(view.get());
     presenter.setFunctionString("name=FlatBackground");
     view->removeFunction("");
@@ -497,7 +511,7 @@ public:
   }
 
   void test_set_globals() {
-    auto view = std::make_unique<MockFunctionView>();
+    auto view = std::make_unique<NiceMock<MockFunctionView>>();
     FunctionMultiDomainPresenter presenter(view.get());
     presenter.setFunctionString("name=LinearBackground");
     presenter.setNumberOfDatasets(3);
@@ -526,7 +540,7 @@ public:
     auto func =
         FunctionFactory::Instance().createInitialized("name=LinearBackground");
     QString functionName = QString::fromStdString(func->name());
-    auto view = std::make_unique<MockFunctionView>();
+    auto view = std::make_unique<NiceMock<MockFunctionView>>();
     FunctionMultiDomainPresenter presenter(view.get());
 
     EXPECT_CALL(*view, getSelectedFunction())
@@ -537,7 +551,7 @@ public:
     view->functionHelpRequested();
   }
   void test_open_function_help_window_no_function() {
-    auto view = std::make_unique<MockFunctionView>();
+    auto view = std::make_unique<NiceMock<MockFunctionView>>();
     FunctionMultiDomainPresenter presenter(view.get());
 
     EXPECT_CALL(*view, getSelectedFunction())
@@ -546,6 +560,53 @@ public:
     EXPECT_CALL(*view, showFunctionHelp(_)).Times(Exactly(0));
 
     view->functionHelpRequested();
+  }
+  void test_updateMultiDatasetAttributes_updates_view_attributes() {
+    auto view = std::make_unique<NiceMock<MockFunctionView>>();
+    FunctionMultiDomainPresenter presenter(view.get());
+    presenter.setNumberOfDatasets(1);
+    presenter.setFunctionString(
+        "name=TeixeiraWaterSQE, Q=3.14, WorkspaceIndex=4, Height=1, "
+        "DiffCoeff=2.3, Tau=1.25, Centre=0, "
+        "constraints=(Height>0, DiffCoeff>0, "
+        "Tau>0);name=FlatBackground;name=LinearBackground");
+
+    auto function =
+        FunctionFactory::Instance().createInitializedMultiDomainFunction(
+            "name=TeixeiraWaterSQE, Q=41.3, "
+            "Height=1, DiffCoeff=2.3, Tau=1.25, Centre=0, "
+            "constraints=(Height>0, DiffCoeff>0, "
+            "Tau>0);name=FlatBackground;name=LinearBackground",
+            1);
+    auto &func = dynamic_cast<IFunction &>(*function);
+
+    // this function has three attributes: NumDeriv (boolean attribute), f0.Q (a
+    // double attribute) and f0.WorkspaceIndex (integer attribute) so we should
+    // expect those calls
+    EXPECT_CALL(*view, setBooleanAttribute(QString("NumDeriv"), false))
+        .Times(Exactly(1));
+    EXPECT_CALL(*view, setDoubleAttribute(QString("f0.Q"), 41.3))
+        .Times(Exactly(1));
+    EXPECT_CALL(*view, setIntAttribute(QString("f0.WorkspaceIndex"),
+                                       Mantid::EMPTY_INT()))
+        .Times(Exactly(1));
+
+    presenter.updateMultiDatasetAttributes(func);
+  }
+
+  void test_attribute_changed_gets_attribute_value_from_view() {
+    auto view = std::make_unique<NiceMock<MockFunctionView>>();
+    FunctionMultiDomainPresenter presenter(view.get());
+    presenter.setFunctionString(
+        "name=TeixeiraWaterSQE, Q=3, WorkspaceIndex=4, Height=1, "
+        "DiffCoeff=2.3, Tau=1.25, Centre=0, "
+        "constraints=(Height>0, DiffCoeff>0, "
+        "Tau>0);name=FlatBackground;name=LinearBackground");
+    EXPECT_CALL(*view, getAttribute(QString("f0.Q")))
+        .Times(Exactly(1))
+        .WillOnce(Return(IFunction::Attribute()));
+
+    view->attributeChanged();
   }
 };
 


### PR DESCRIPTION
**Description of work.**
This PR adds a missing functions to manipulate attributes in `IFunctionModel` and `IFunctionView`. Both classes were missing `getAttribute` and `setAttribute` methods. Due to changes made in a previous PR, these can now be dealt with in the exact same manner as `setParameter(..)`.

The primary motivation for this work was to show the correct `Q` value for `Q` dependent functions in the `ConvFit` tab of the indirect data analysis GUI, as such as the testing instructions will relate to this issue:

**Test instructions**

1. Open the Indirect data analysis GUI
2. Go to Conv fit and load data from #26631
3. Add the fit type as the TeixeiraWater function
4. Change to full function view, you should note that the correct `Q` value is shown
5. Switch between spectra and the Q value will change
6. Change the `Q` value and switch on/off the full function view, you should note that the `Q` value that you set remained – signifying that the model has been appropriately updated.

As an aside, `Q` values set in this browser are not used in the Convolution fit performed in this Tab, as the 'Q' values are fetched from the workspace on-the-fly when a fit is requested (which explains why the correct values were used before even when the browser showed the incorrect Q values). Fixing this issue (if desired) would require another PR.

Fixes #28529 . <!-- and fix #xxxx or close #xxxx xor resolves #xxxx -->
<!-- alternative
*There is no associated issue.*
-->

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or master)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
