### PR TITLE
Use cmake wrappers to invoke msbuild in systemtest.bat

### DIFF
--- a/Testing/SystemTests/scripts/systemtest.bat.in
+++ b/Testing/SystemTests/scripts/systemtest.bat.in
@@ -40,9 +40,9 @@ if [%1] EQU [-C] (
 
 :: Update testing data
 echo Updating testing data...
-msbuild /nologo /nr:false /p:Configuration=%2 StandardTestData.vcxproj
+cmake --build . --config %2 --target StandardTestData
 if ERRORLEVEL 1 exit /b %ERRORLEVEL%
-msbuild /nologo /nr:false /p:Configuration=%2 SystemTestData.vcxproj
+cmake --build . --config %2 --target SystemTestData
 if ERRORLEVEL 1 exit /b %ERRORLEVEL%
 
 :: Execute


### PR DESCRIPTION
**Description of work.**

See commit message for description.

**To test:**

* Open a standard command prompt on Windows and change to the build directory
* Run cmake
* Try a system test: `systemtest -C Debug -R CodeConventions` (replace Debug with Release depending on your configuration)
* The system test should pass.

*There is no associated issue.*

*This does not require release notes* because **this is a minor quality of life improvement.**

<!-- Ensure the base of this PR is correct (e.g. release-next or master)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
