### PR TITLE
Fix spurious transmission error with workspace groups

### DIFF
--- a/Framework/PythonInterface/test/python/plugins/algorithms/WorkflowAlgorithms/ReflectometryISISLoadAndProcessTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/WorkflowAlgorithms/ReflectometryISISLoadAndProcessTest.py
@@ -313,7 +313,7 @@ class ReflectometryISISLoadAndProcessTest(unittest.TestCase):
         # Note that the child sliced workspaces don't include the full history - this
         # might be something we want to change in the underlying algorithms at some point
         history = ['ReflectometryReductionOneAuto', 'ReflectometryReductionOneAuto',
-                   'ReflectometryReductionOneAuto', 'GroupWorkspaces', 'GroupWorkspaces']
+                   'ReflectometryReductionOneAuto', 'GroupWorkspaces']
         self._check_history(AnalysisDataService.retrieve('IvsQ_binned_38415_sliced_0_1200'), history, False)
 
     def test_slicing_uses_run_in_ADS_with_no_prefix(self):
@@ -330,7 +330,7 @@ class ReflectometryISISLoadAndProcessTest(unittest.TestCase):
              '38415_sliced_2400_3600', 'TOF']
         self._assert_run_algorithm_succeeds(args, outputs)
         history = ['ReflectometryReductionOneAuto', 'ReflectometryReductionOneAuto',
-                   'ReflectometryReductionOneAuto', 'GroupWorkspaces', 'GroupWorkspaces']
+                   'ReflectometryReductionOneAuto', 'GroupWorkspaces']
         self._check_history(AnalysisDataService.retrieve('IvsQ_binned_38415_1'), history, False)
 
     def test_slicing_loads_input_run_if_not_in_ADS(self):
@@ -340,7 +340,7 @@ class ReflectometryISISLoadAndProcessTest(unittest.TestCase):
         outputs = self._expected_real_time_sliced_outputs
         self._assert_run_algorithm_succeeds(args, outputs)
         history = ['ReflectometryReductionOneAuto', 'ReflectometryReductionOneAuto',
-                   'ReflectometryReductionOneAuto', 'GroupWorkspaces', 'GroupWorkspaces']
+                   'ReflectometryReductionOneAuto', 'GroupWorkspaces']
         self._check_history(AnalysisDataService.retrieve('IvsQ_binned_38415_sliced_0_210'), history, False)
 
     def test_slicing_reloads_input_run_if_workspace_is_incorrect_type(self):
@@ -351,7 +351,7 @@ class ReflectometryISISLoadAndProcessTest(unittest.TestCase):
         outputs = self._expected_real_time_sliced_outputs
         self._assert_run_algorithm_succeeds(args, outputs)
         history = ['ReflectometryReductionOneAuto', 'ReflectometryReductionOneAuto',
-                   'ReflectometryReductionOneAuto', 'GroupWorkspaces', 'GroupWorkspaces']
+                   'ReflectometryReductionOneAuto', 'GroupWorkspaces']
         self._check_history(AnalysisDataService.retrieve('IvsQ_binned_38415_sliced_0_210'), history, False)
 
     def test_slicing_loads_input_run_if_monitor_ws_not_in_ADS(self):
@@ -362,7 +362,7 @@ class ReflectometryISISLoadAndProcessTest(unittest.TestCase):
         outputs = self._expected_real_time_sliced_outputs
         self._assert_run_algorithm_succeeds(args, outputs)
         history = ['ReflectometryReductionOneAuto', 'ReflectometryReductionOneAuto',
-                   'ReflectometryReductionOneAuto', 'GroupWorkspaces', 'GroupWorkspaces']
+                   'ReflectometryReductionOneAuto', 'GroupWorkspaces']
         self._check_history(AnalysisDataService.retrieve('IvsQ_binned_38415_sliced_0_210'), history, False)
 
     def test_slicing_with_no_interval_returns_single_slice(self):
@@ -375,7 +375,7 @@ class ReflectometryISISLoadAndProcessTest(unittest.TestCase):
                    'IvsLam_38415_sliced_0_4200', 'TOF_38415', 'TOF_38415_monitors',
                    'TOF_38415_sliced', 'TOF_38415_sliced_0_4200', 'TOF']
         self._assert_run_algorithm_succeeds(args, outputs)
-        history = ['ReflectometryReductionOneAuto', 'GroupWorkspaces', 'GroupWorkspaces']
+        history = ['ReflectometryReductionOneAuto', 'GroupWorkspaces']
         self._check_history(AnalysisDataService.retrieve('IvsQ_binned_38415_sliced_0_4200'), history, False)
 
     def test_slicing_by_number_of_slices(self):
@@ -387,7 +387,7 @@ class ReflectometryISISLoadAndProcessTest(unittest.TestCase):
         outputs = self._expected_dummy_time_sliced_outputs
         self._assert_run_algorithm_succeeds(args, outputs)
         history = ['ReflectometryReductionOneAuto', 'ReflectometryReductionOneAuto',
-                   'ReflectometryReductionOneAuto', 'GroupWorkspaces', 'GroupWorkspaces']
+                   'ReflectometryReductionOneAuto', 'GroupWorkspaces']
         self._check_history(AnalysisDataService.retrieve('IvsQ_binned_38415_sliced_0_1200'), history, False)
 
     def test_slicing_by_log_value(self):
@@ -408,7 +408,7 @@ class ReflectometryISISLoadAndProcessTest(unittest.TestCase):
                    'TOF_38415'+slice2, 'TOF_38415'+slice3]
         self._assert_run_algorithm_succeeds(args, outputs)
         history = ['ReflectometryReductionOneAuto', 'ReflectometryReductionOneAuto',
-                   'ReflectometryReductionOneAuto', 'GroupWorkspaces', 'GroupWorkspaces']
+                   'ReflectometryReductionOneAuto', 'GroupWorkspaces']
         self._check_history(AnalysisDataService.retrieve('IvsQ_binned_38415'+slice1), history, False)
 
     def test_slicing_by_log_value_with_no_interval_returns_single_slice(self):
@@ -423,7 +423,7 @@ class ReflectometryISISLoadAndProcessTest(unittest.TestCase):
                    'TOF', 'TOF_38415', 'TOF_38415_monitors', 'TOF_38415_sliced',
                    'TOF_38415'+sliceName]
         self._assert_run_algorithm_succeeds(args, outputs)
-        history = ['ReflectometryReductionOneAuto', 'GroupWorkspaces', 'GroupWorkspaces']
+        history = ['ReflectometryReductionOneAuto', 'GroupWorkspaces']
         self._check_history(AnalysisDataService.retrieve('IvsQ_binned_38415'+sliceName), history, False)
 
     def test_with_input_workspace_group(self):
@@ -436,7 +436,7 @@ class ReflectometryISISLoadAndProcessTest(unittest.TestCase):
         self._assert_run_algorithm_succeeds(args, outputs)
         history = ['CreateSampleWorkspace', 'AddSampleLog',  'CreateSampleWorkspace', 'AddSampleLog',
                    'GroupWorkspaces', 'ReflectometryReductionOneAuto', 'ReflectometryReductionOneAuto',
-                   'GroupWorkspaces', 'GroupWorkspaces']
+                   'GroupWorkspaces']
         self._check_history(AnalysisDataService.retrieve('IvsQ_binned_12345_1'), history, False)
 
     def test_TOF_input_workspace_groups_collapsed(self):

--- a/Framework/Reflectometry/inc/MantidReflectometry/ReflectometryReductionOneAuto3.h
+++ b/Framework/Reflectometry/inc/MantidReflectometry/ReflectometryReductionOneAuto3.h
@@ -109,23 +109,22 @@ private:
   void applyFloodCorrections();
   double getPropertyOrDefault(const std::string &propertyName,
                               const double defaultValue, bool &isDefault);
-  void setOutputWorkspaces(const WorkspaceNames &outputGroupNames,
-                           std::vector<std::string> &IvsLamGroup,
-                           std::vector<std::string> &IvsQBinnedGroup,
-                           std::vector<std::string> &IvsQGroup);
   void setTransmissionProperties(Algorithm_sptr alg,
                                  std::string const &propertyName);
-  WorkspaceNames getOutputNamesForGroups(const std::string &inputName,
-                                         const std::string &runNumber,
-                                         const size_t wsGroupNumber);
+  WorkspaceNames getOutputNamesForGroupMember(const std::string &inputName,
+                                              const std::string &runNumber,
+                                              const size_t wsGroupNumber);
   void getTransmissionRun(std::map<std::string, std::string> &results,
                           WorkspaceGroup_sptr &workspaceGroup,
                           const std::string &transmissionRun);
-  Algorithm_sptr createAlgorithmForWorkspaceInGroup();
-  void groupOutputWorkspaces(std::vector<std::string> IvsQGroup,
-                             std::vector<std::string> IvsQBinnedGroup,
-                             std::vector<std::string> IvsLamGroup,
-                             WorkspaceNames const &outputNames);
+  Algorithm_sptr
+  createAlgorithmForWorkspaceInGroup(std::string const &inputName,
+                                     WorkspaceNames const &outputNames,
+                                     bool skipCorrections = false);
+  void setOutputWorkspaces(std::vector<std::string> IvsQGroup,
+                           std::vector<std::string> IvsQBinnedGroup,
+                           std::vector<std::string> IvsLamGroup,
+                           WorkspaceNames const &outputNames);
   void setOutputProperties(OutputProperties const &outputProperties);
 };
 } // namespace Reflectometry

--- a/Framework/Reflectometry/inc/MantidReflectometry/ReflectometryReductionOneAuto3.h
+++ b/Framework/Reflectometry/inc/MantidReflectometry/ReflectometryReductionOneAuto3.h
@@ -67,8 +67,7 @@ private:
 
   void init() override;
   void exec() override;
-  std::string
-  getRunNumberForWorkspaceGroup(const WorkspaceGroup_const_sptr &workspace);
+  std::string getRunNumberForWorkspaceGroup(std::string const &wsName);
   WorkspaceNames getOutputWorkspaceNames();
   void setDefaultOutputWorkspaceNames();
   /// Get the name of the detectors of interest based on processing instructions
@@ -111,21 +110,28 @@ private:
                               const double defaultValue, bool &isDefault);
   void setTransmissionProperties(Algorithm_sptr alg,
                                  std::string const &propertyName);
-  WorkspaceNames getOutputNamesForGroupMember(const std::string &inputName,
-                                              const std::string &runNumber,
-                                              const size_t wsGroupNumber);
+  WorkspaceNames
+  getOutputNamesForGroupMember(const std::vector<std::string> &inputNames,
+                               const std::string &runNumber,
+                               const size_t wsGroupNumber);
   void getTransmissionRun(std::map<std::string, std::string> &results,
                           WorkspaceGroup_sptr &workspaceGroup,
                           const std::string &transmissionRun);
   Algorithm_sptr
-  createAlgorithmForWorkspaceInGroup(std::string const &inputName,
-                                     WorkspaceNames const &outputNames,
-                                     bool skipCorrections = false);
-  void setOutputWorkspaces(std::vector<std::string> IvsQGroup,
-                           std::vector<std::string> IvsQBinnedGroup,
-                           std::vector<std::string> IvsLamGroup,
-                           WorkspaceNames const &outputNames);
-  void setOutputProperties(OutputProperties const &outputProperties);
+  createAlgorithmForGroupMember(std::string const &inputName,
+                                WorkspaceNames const &outputNames,
+                                bool recalculateIvsQ = false);
+  void
+  setOutputGroupedWorkspaces(std::vector<WorkspaceNames> const &outputNames,
+                             WorkspaceNames const &outputGroupNames);
+  void setOutputPropertyFromChild(Algorithm_sptr alg, std::string const &name);
+  void setOutputPropertiesFromChild(Algorithm_sptr alg);
+  auto processGroupMembers(std::vector<std::string> const &inputNames,
+                           std::vector<std::string> const &originalNames,
+                           std::string const &runNumber,
+                           bool recalculateIvsQ = false);
+  void groupWorkspaces(std::vector<std::string> workspaceNames,
+                       std::string const &outputName);
 };
 } // namespace Reflectometry
 } // namespace Mantid

--- a/Framework/Reflectometry/inc/MantidReflectometry/ReflectometryReductionOneAuto3.h
+++ b/Framework/Reflectometry/inc/MantidReflectometry/ReflectometryReductionOneAuto3.h
@@ -44,6 +44,16 @@ private:
     std::string iVsLam;
   };
 
+  // Utility struct to collate output properties of child algorithm when
+  // processing groups
+  struct OutputProperties {
+    double thetaIn;
+    double qMin;
+    double qMax;
+    double qStep;
+    double scale;
+  };
+
   struct RebinParams {
     double qMin;
     bool qMinIsDefault;
@@ -111,7 +121,12 @@ private:
   void getTransmissionRun(std::map<std::string, std::string> &results,
                           WorkspaceGroup_sptr &workspaceGroup,
                           const std::string &transmissionRun);
+  Algorithm_sptr createAlgorithmForWorkspaceInGroup();
+  void groupOutputWorkspaces(std::vector<std::string> IvsQGroup,
+                             std::vector<std::string> IvsQBinnedGroup,
+                             std::vector<std::string> IvsLamGroup,
+                             WorkspaceNames const &outputNames);
+  void setOutputProperties(OutputProperties const &outputProperties);
 };
-
 } // namespace Reflectometry
 } // namespace Mantid

--- a/Framework/Reflectometry/inc/MantidReflectometry/ReflectometryReductionOneAuto3.h
+++ b/Framework/Reflectometry/inc/MantidReflectometry/ReflectometryReductionOneAuto3.h
@@ -103,6 +103,8 @@ private:
                            std::vector<std::string> &IvsLamGroup,
                            std::vector<std::string> &IvsQBinnedGroup,
                            std::vector<std::string> &IvsQGroup);
+  void setTransmissionProperties(Algorithm_sptr alg,
+                                 std::string const &propertyName);
   WorkspaceNames getOutputNamesForGroups(const std::string &inputName,
                                          const std::string &runNumber,
                                          const size_t wsGroupNumber);

--- a/docs/source/algorithms/ReflectometryReductionOneAuto-v3.rst
+++ b/docs/source/algorithms/ReflectometryReductionOneAuto-v3.rst
@@ -95,30 +95,29 @@ workspace in Q, :literal:`OutputWorkspaceBinned`, is not represented but it is h
 
 .. diagram:: ReflectometryReductionOneAuto-v2-Groups_wkflw.dot
 
+Note that if transmission runs are given in the form of a workspace group, then
+the first element in the group will be used on every input workspace. If
+transmission runs are provided as matrix workspaces the specified runs will be
+used for all members of the input workspace group.
+
 Polarization Analysis 
 ~~~~~~~~~~~~~~~~~~~~~
 
-If :literal:`PolarizationAnalysis` is set to false the reduction stops. Note that if
-transmission runs are given in the form of a workspace group, then the first 
-element in the group will be used on every input workspace. If transmission runs
-are provided as matrix workspaces the specified runs will be used for all members
-of the input workspace group.
-
-If polarization analysis is set to true, the reduction continues and polarization
-corrections will be applied to the output workspace in wavelength. This uses the method 
-and values specified in the parameters file to run :ref:`algm-PolarizationCorrectionFredrikze` 
-or :ref:`algm-PolarizationCorrectionWildes` as appropriate.
+If :literal:`PolarizationAnalysis` is set to false the reduction stops. If it
+is set to true, the reduction continues and polarization corrections will be
+applied to the workspace that was output in wavelength. This uses the method
+and values specified in the parameters file to run
+:ref:`algm-PolarizationCorrectionFredrikze` or
+:ref:`algm-PolarizationCorrectionWildes` as appropriate.
 
 The result will be a new workspace in wavelength, which will override the
-previous one, that will be used as input to
+previous one. This will then be used as in input to re-run
 :ref:`algm-ReflectometryReductionOne` to calculate the new output workspaces in
-Q, which in turn will override the existing workspaces in Q. Note that if
-transmission runs are provided in the form of workspace groups, then the 
-first workspace in the group workspaces will be summed to produce a matrix 
-workspace that will be used as the transmission run for all items in the input 
-workspace group, as illustrated in the diagram below (note that, for the sake of 
-clarity, the rebinned output workspace in Q, :literal:`OutputWorkspaceBinned`, is 
-not represented but it is handled analogously to :literal:`OutputWorkspace`).
+Q, which in turn will override the existing workspaces in Q. Note that when run
+with a workspace that is already summed and converted to wavelength,
+`algm-ReflectometryReductionOne` will not re-run these steps, so it is only the
+conversion to Q that is run again. Transmission and algorithm corrections are
+also skipped on the second run through because they have already been applied.
 
 Previous Versions
 -----------------

--- a/docs/source/algorithms/ReflectometryReductionOneAuto-v3.rst
+++ b/docs/source/algorithms/ReflectometryReductionOneAuto-v3.rst
@@ -111,7 +111,7 @@ and values specified in the parameters file to run
 :ref:`algm-PolarizationCorrectionWildes` as appropriate.
 
 The result will be a new workspace in wavelength, which will override the
-previous one. This will then be used as in input to re-run
+previous one. This will then be used as an input to re-run
 :ref:`algm-ReflectometryReductionOne` to calculate the new output workspaces in
 Q, which in turn will override the existing workspaces in Q. Note that when run
 with a workspace that is already summed and converted to wavelength,

--- a/docs/source/release/v6.0.0/reflectometry.rst
+++ b/docs/source/release/v6.0.0/reflectometry.rst
@@ -13,5 +13,6 @@ Bugfixes
 ########
 
 - Fixed an issue where `import CaChannel` on Linux would cause a hard crash.
+- Fixed spurious error messages about transmission workspaces when running :ref:`algm-ReflectometryReductionOneAuto` on workspace groups
 
 :ref:`Release 6.0.0 <v6.0.0>`


### PR DESCRIPTION
**Report to:** Max at ISIS

**Description of work.**
- This PR fixes some spurious error messages that are issued when you run ReflectometryReductionOneAuto on a workspace group, with transmission corrections enabled. The problem was related to running the same child algorithm multiple times. Now, a new child algorithm is created each time.
- To do this some refactoring was required. Other tidying has also been done to simplify the `processGroups` function and reduce duplicated code
- The documentation regarding processing groups has also been updated because it was out of date.

**To test:**

Run the script in the linked issue and ensure that no red warning messages are displayed in the log.

Fixes #23471 and fixes #29411 

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
