### PR TITLE
Docs: Do not add allowed values to property tables for workspaces

### DIFF
--- a/docs/sphinxext/mantiddoc/directives/properties.py
+++ b/docs/sphinxext/mantiddoc/directives/properties.py
@@ -227,11 +227,13 @@ class PropertiesDirective(AlgorithmBaseDirective):
         Returns:
           str: The string to add to the property table description section.
         """
+        from mantid.api import IWorkspaceProperty
+
         desc = str(prop.documentation.replace("\n", " "))
 
         allowedValueString = str(prop.allowedValues)
         # 4 allows for ['']
-        if len(allowedValueString) > 4:
+        if len(allowedValueString) > 4 and not isinstance(prop, IWorkspaceProperty):
             ##make sure the last sentence ended with a full stop (or equivalent)
             if (not desc.rstrip().endswith("."))      \
                 and (not desc.rstrip().endswith("!")) \


### PR DESCRIPTION
**Description of work.**

Fixes documentation for workspace properties to remove the large allowed value lists such as:
![Screenshot from 2020-10-20 14-47-05](https://user-images.githubusercontent.com/733773/96595096-38844200-12e3-11eb-9985-e23c5255dbdb.png). It was though that #29754 fixed this but that only fixed it without the plot directive enabled. This fix fixes the issue if  `-DDOCS_PLOTDIRECTIVE=ON` is specified.

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

**To test:**

* Run cmake with `DOCS_PLOTDIRECTIVE` enabled
* Build `docs-html` and look at algorithm pages like SANSILLReduction & SaveNexusProcessed

*There is no associated issue.*

*This does not require release notes* because **it fixes user documentation**

<!-- Ensure the base of this PR is correct (e.g. release-next or master)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
