### PR TITLE
Fix ManageUserDirectories lifetime management when pressing escape 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -151,6 +151,7 @@ if(ENABLE_WORKBENCH)
                           Gui
                           Widgets
                           OpenGL
+                          Test
                REQUIRED)
   if(Qt5_FOUND)
     message(STATUS "Found Qt ${Qt5_VERSION}: ${Qt5_DIR}")

--- a/buildconfig/CMake/CppCheckSetup.cmake
+++ b/buildconfig/CMake/CppCheckSetup.cmake
@@ -15,6 +15,9 @@ if ( CPPCHECK_EXECUTABLE )
   # Force cppcheck to check when we use project-wide macros
   -DDLLExport=
   -DMANTID_ALGORITHMS_DLL=
+  # Undefine problematic macros:
+  #   Causes errors such as there was an internal error: bad macro syntax"
+  -UQT_TESTCASE_BUILDDIR
   )
 
   set (_cppcheck_args "${CPPCHECK_ARGS}")

--- a/docs/source/release/v6.0.0/mantidworkbench.rst
+++ b/docs/source/release/v6.0.0/mantidworkbench.rst
@@ -28,5 +28,6 @@ Bugfixes
 
 - Only display slice viewer widget for MDEventWorkspaces with 2 or more dimensions.
 - Fix Workbench crashes upon deleting rows or columns in a TableWorkspace.
+- Fix crash on second call to ManageUserDirectories after pressing Esc to close it.
 
 :ref:`Release 6.0.0 <v6.0.0>`

--- a/qt/widgets/common/CMakeLists.txt
+++ b/qt/widgets/common/CMakeLists.txt
@@ -1026,6 +1026,7 @@ set(
   test/ImageInfoModelMDTest.h
   test/ImageInfoPresenterTest.h
   test/InterfaceManagerTest.h
+  test/ManageUserDirectoriesTest.h
   test/QtJSONUtilsTest.h
   test/RepoModelTest.h
   test/Batch/BuildSubtreeItemsTest.h
@@ -1067,6 +1068,7 @@ mtd_add_qt_tests(
     PythonInterfaceCore
     DataObjects
     gmock
+    Qt5::Test
   MTD_QT_LINK_LIBS MantidQtWidgetsCommon
   PARENT_DEPENDENCIES GUITests
 )

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/ManageUserDirectories.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/ManageUserDirectories.h
@@ -35,10 +35,16 @@ class EXPORT_OPT_MANTIDQT_COMMON ManageUserDirectories
   Q_OBJECT
 
 public:
-  static void openManageUserDirectories();
+  static ManageUserDirectories *openManageUserDirectories();
 
 public:
   ManageUserDirectories(QWidget *parent = nullptr);
+
+  void enableSaveToFile(bool enabled);
+
+public:
+  /// Testing accessors
+  QPushButton *cancelButton() const { return m_uiForm.pbCancel; }
 
 private:
   virtual void initLayout();
@@ -59,6 +65,7 @@ private slots:
 
 private:
   Ui::ManageUserDirectories m_uiForm;
+  bool m_saveToFile;
 };
 
 } // namespace API

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/ManageUserDirectories.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/ManageUserDirectories.h
@@ -7,27 +7,43 @@
 #pragma once
 
 #include "DllOption.h"
+#include <QtGlobal>
+
+#if QT_VERSION < QT_VERSION_CHECK(5, 0, 0)
 #include "MantidQtWidgets/Common/MantidDialog.h"
-#include "ui_ManageUserDirectories.h"
+#else
 #include <QDialog>
+#endif
+#include "ui_ManageUserDirectories.h"
 
 namespace MantidQt {
 namespace API {
 
+/**
+ * Access and update the user directory settings within the
+ * Mantid config service
+ */
 class EXPORT_OPT_MANTIDQT_COMMON ManageUserDirectories
+#if QT_VERSION < QT_VERSION_CHECK(5, 0, 0)
     : public MantidQt::API::MantidDialog {
+  using BaseClass = MantidQt::API::MantidDialog;
+#else
+    : public QDialog {
+  using BaseClass = QDialog;
+#endif
+
   Q_OBJECT
 
 public:
-  ManageUserDirectories(QWidget *parent = nullptr);
-  ~ManageUserDirectories() override;
   static void openManageUserDirectories();
+
+public:
+  ManageUserDirectories(QWidget *parent = nullptr);
 
 private:
   virtual void initLayout();
   void loadProperties();
   void saveProperties();
-  void appendSlashIfNone(QString &path) const;
   QListWidget *listWidget(QObject *object);
 
 private slots:
@@ -43,7 +59,6 @@ private slots:
 
 private:
   Ui::ManageUserDirectories m_uiForm;
-  QString m_userPropFile;
 };
 
 } // namespace API

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/ManageUserDirectories.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/ManageUserDirectories.h
@@ -22,7 +22,6 @@ public:
   ManageUserDirectories(QWidget *parent = nullptr);
   ~ManageUserDirectories() override;
   static void openManageUserDirectories();
-  void closeEvent(QCloseEvent *event) override;
 
 private:
   virtual void initLayout();

--- a/qt/widgets/common/src/ManageUserDirectories.cpp
+++ b/qt/widgets/common/src/ManageUserDirectories.cpp
@@ -13,27 +13,63 @@
 #include <QSettings>
 #include <QUrl>
 
+using Mantid::Kernel::ConfigService;
 using namespace MantidQt::API;
 
 namespace {
+
+namespace ButtonPrefix {
+const QString DATA{"pbData"};
+const QString SCRIPT{"pbScript"};
+const QString EXTENSIONS{"pbExt"};
+} // namespace ButtonPrefix
+
+namespace ConfigKeys {
+const std::string DATASEARCH_DIRS{"datasearch.directories"};
+const std::string PYTHONSCRIPTS_DIRS{"pythonscripts.directories"};
+const std::string USERPYTHONPLUGINS_DIRS{"user.python.plugins.directories"};
+const std::string DATASEARCH_ARCHIVE{"datasearch.searcharchive"};
+const std::string DEFAULT_FACILITY{"default.facility"};
+const std::string DEFAULTSAVE_DIR{"defaultsave.directory"};
+} // namespace ConfigKeys
+
+namespace QSettingsKeys {
+const auto LastDirectory{"ManageUserSettings/last_directory"};
+} // namespace QSettingsKeys
+
+// ID for help page in docs
+const QString HELP_ID{"ManageUserDirectories"};
+// Current instance opened with openManageUserDirectories
 QPointer<ManageUserDirectories> CURRENTLY_OPEN_MUD;
 } // namespace
 
-namespace ButtonPrefix {
-const std::string DATA{"pbData"};
-const std::string SCRIPT{"pbScript"};
-const std::string EXTENSIONS{"pbExt"};
-} // namespace ButtonPrefix
+/**
+ * Show the dialog or raise the existing one if it exists
+ */
+void ManageUserDirectories::openManageUserDirectories() {
+  if (CURRENTLY_OPEN_MUD.isNull()) {
+    CURRENTLY_OPEN_MUD =
+        QPointer<ManageUserDirectories>(new ManageUserDirectories);
+    CURRENTLY_OPEN_MUD->show();
+  } else {
+    CURRENTLY_OPEN_MUD->raise();
+  }
+}
 
+/**
+ * Constructor
+ * @param parent A parent QWidget for the dialog
+ */
 ManageUserDirectories::ManageUserDirectories(QWidget *parent)
-    : MantidDialog(parent) {
+    : BaseClass(parent) {
   setAttribute(Qt::WA_DeleteOnClose);
   m_uiForm.setupUi(this);
   initLayout();
 }
 
-ManageUserDirectories::~ManageUserDirectories() {}
-
+/**
+ * Create the UI layout, fill the widgets and connect the relevant signals
+ */
 void ManageUserDirectories::initLayout() {
   loadProperties();
 
@@ -66,48 +102,33 @@ void ManageUserDirectories::initLayout() {
           SLOT(selectSaveDir()));
 }
 
+/**
+ * Load config properties into the form widgets
+ */
 void ManageUserDirectories::loadProperties() {
-  m_userPropFile =
-      QString::fromStdString(
-          Mantid::Kernel::ConfigService::Instance().getUserFilename())
-          .trimmed();
-
-  // get data search directories and populate the list widget (lwDataSearchDirs)
-  QString directories = QString::fromStdString(
-                            Mantid::Kernel::ConfigService::Instance().getString(
-                                "datasearch.directories"))
-                            .trimmed();
-  QStringList list = directories.split(";", QString::SkipEmptyParts);
-  m_uiForm.lwDataSearchDirs->clear();
-  m_uiForm.lwDataSearchDirs->addItems(list);
-
-  // Do the same thing for the "pythonscripts.directories" property.
-  directories = QString::fromStdString(
-                    Mantid::Kernel::ConfigService::Instance().getString(
-                        "pythonscripts.directories"))
-                    .trimmed();
-  list = directories.split(";", QString::SkipEmptyParts);
-  m_uiForm.lwScriptSearchDirs->clear();
-  m_uiForm.lwScriptSearchDirs->addItems(list);
-
-  directories = QString::fromStdString(
-                    Mantid::Kernel::ConfigService::Instance().getString(
-                        "user.python.plugins.directories"))
-                    .trimmed();
-  list = directories.split(";", QString::SkipEmptyParts);
-  m_uiForm.lwExtSearchDirs->clear();
-  m_uiForm.lwExtSearchDirs->addItems(list);
+  auto &config = ConfigService::Instance();
+  auto populateListWidget = [&config](QListWidget *widget,
+                                      const std::string &key) {
+    const auto directories =
+        QString::fromStdString(config.getString(key)).trimmed();
+    const auto items = directories.split(";", QString::SkipEmptyParts);
+    widget->clear();
+    widget->addItems(items);
+  };
+  // fill lists
+  populateListWidget(m_uiForm.lwDataSearchDirs, ConfigKeys::DATASEARCH_DIRS);
+  populateListWidget(m_uiForm.lwScriptSearchDirs,
+                     ConfigKeys::PYTHONSCRIPTS_DIRS);
+  populateListWidget(m_uiForm.lwExtSearchDirs,
+                     ConfigKeys::USERPYTHONPLUGINS_DIRS);
 
   // set flag of whether to search the data archive
-  QString archive = QString::fromStdString(
-                        Mantid::Kernel::ConfigService::Instance().getString(
-                            "datasearch.searcharchive"))
-                        .trimmed()
-                        .toLower();
-  QString defaultFacility =
-      QString::fromStdString(
-          Mantid::Kernel::ConfigService::Instance().getString(
-              "default.facility"))
+  const auto archive =
+      QString::fromStdString(config.getString(ConfigKeys::DATASEARCH_ARCHIVE))
+          .trimmed()
+          .toLower();
+  const auto defaultFacility =
+      QString::fromStdString(config.getString(ConfigKeys::DEFAULT_FACILITY))
           .trimmed()
           .toUpper();
   m_uiForm.cbSearchArchive->addItem(QString("default facility only - ") +
@@ -126,13 +147,18 @@ void ManageUserDirectories::loadProperties() {
   }
 
   // default save directory
-  QString saveDir = QString::fromStdString(
-                        Mantid::Kernel::ConfigService::Instance().getString(
-                            "defaultsave.directory"))
-                        .trimmed();
+  const auto saveDir =
+      QString::fromStdString(config.getString(ConfigKeys::DEFAULTSAVE_DIR))
+          .trimmed();
   m_uiForm.leDefaultSave->setText(saveDir);
 }
+
+/**
+ *  Save the current contents of the widgets back to the main config
+ */
 void ManageUserDirectories::saveProperties() {
+  auto &config = ConfigService::Instance();
+
   QString newSearchArchive = m_uiForm.cbSearchArchive->currentText().toLower();
   if (newSearchArchive == "all" || newSearchArchive == "off") {
     // do nothing
@@ -148,95 +174,78 @@ void ManageUserDirectories::saveProperties() {
                            .toLower();
   }
 
-  QStringList dataDirs;
-  QStringList userDirs;
-  QStringList extensionDirs;
+  // convert a path from the list to something the configservice will
+  // understand. replaces all \ with / and
+  auto toConfigPath = [](QString path) {
+    if (path.isEmpty())
+      return path;
+    auto unixStylePath = path.replace('\\', '/');
+    if (!unixStylePath.endsWith('/'))
+      unixStylePath.append('/');
+    return unixStylePath;
+  };
+  auto toConfigString = [&toConfigPath](QListWidget *itemsWidget) {
+    QStringList paths;
+    for (int i = 0; i < itemsWidget->count(); i++) {
+      const auto path = itemsWidget->item(i)->text().trimmed();
+      if (!path.isEmpty())
+        paths.append(toConfigPath(path));
+    }
+    return paths.join(";").toStdString();
+  };
 
-  for (int i = 0; i < m_uiForm.lwDataSearchDirs->count(); i++) {
-    QString dir = m_uiForm.lwDataSearchDirs->item(i)->text();
-    appendSlashIfNone(dir);
-    dataDirs.append(dir);
-  }
-
-  for (int i = 0; i < m_uiForm.lwScriptSearchDirs->count(); i++) {
-    QString dir = m_uiForm.lwScriptSearchDirs->item(i)->text();
-    appendSlashIfNone(dir);
-    userDirs.append(dir);
-  }
-
-  for (int i = 0; i < m_uiForm.lwExtSearchDirs->count(); i++) {
-    QString dir = m_uiForm.lwExtSearchDirs->item(i)->text();
-    appendSlashIfNone(dir);
-    extensionDirs.append(dir);
-  }
-  QString newDataDirs;
-  QString newUserDirs;
-  QString newSaveDir;
-  QString newExtensionDirs;
-
-  newDataDirs = dataDirs.join(";");
-  newUserDirs = userDirs.join(";");
-  newDataDirs.replace('\\', '/');
-  newUserDirs.replace('\\', '/');
-
-  // Extensions dirs
-  newExtensionDirs = extensionDirs.join(";");
-  newExtensionDirs.replace('\\', '/');
-
-  newSaveDir = m_uiForm.leDefaultSave->text();
-  newSaveDir.replace('\\', '/');
-  appendSlashIfNone(newSaveDir);
-
-  Mantid::Kernel::ConfigServiceImpl &config =
-      Mantid::Kernel::ConfigService::Instance();
-
-  config.setString("datasearch.searcharchive", newSearchArchive.toStdString());
-  config.setString("datasearch.directories", newDataDirs.toStdString());
-  config.setString("defaultsave.directory", newSaveDir.toStdString());
-  config.setString("pythonscripts.directories", newUserDirs.toStdString());
-  config.setString("user.python.plugins.directories",
-                   newExtensionDirs.toStdString());
-  config.saveConfig(m_userPropFile.toStdString());
+  // data directories
+  config.setString(ConfigKeys::DATASEARCH_ARCHIVE,
+                   newSearchArchive.toStdString());
+  config.setString(ConfigKeys::DATASEARCH_DIRS,
+                   toConfigString(m_uiForm.lwDataSearchDirs));
+  config.setString(
+      ConfigKeys::DEFAULTSAVE_DIR,
+      toConfigPath(m_uiForm.leDefaultSave->text().trimmed()).toStdString());
+  // python directories
+  config.setString(ConfigKeys::PYTHONSCRIPTS_DIRS,
+                   toConfigString(m_uiForm.lwScriptSearchDirs));
+  config.setString(ConfigKeys::USERPYTHONPLUGINS_DIRS,
+                   toConfigString(m_uiForm.lwExtSearchDirs));
+  config.saveConfig(config.getUserFilename());
 }
 
 /**
- * Appends a forward slash to the end of a path if there is no slash (forward or
- * back) there already, and strip whitespace from the path.
- *
- * @param path :: A reference to the path
+ * Return the QListWidget related to the given sender
+ * @param sender A pointer to the QObject that caused this slot to be called
+ * @return QListWidget if sender is a known button else nullptr
  */
-void ManageUserDirectories::appendSlashIfNone(QString &path) const {
-  path = path.trimmed();
-  if (!(path.endsWith("/") || path.endsWith("\\") || path.isEmpty())) {
-    // Don't need to add to a \\, as it would just get changed to a /
-    // immediately after
-    path.append("/");
-  }
-}
-
 QListWidget *ManageUserDirectories::listWidget(QObject *sender) {
-  std::string objectName = sender->objectName().toStdString();
-  if (objectName.find(ButtonPrefix::DATA) != std::string::npos) {
+  const auto objectName = sender->objectName();
+  if (objectName.contains(ButtonPrefix::DATA)) {
     return m_uiForm.lwDataSearchDirs;
-  } else if (objectName.find(ButtonPrefix::SCRIPT) != std::string::npos) {
+  } else if (objectName.contains(ButtonPrefix::SCRIPT)) {
     return m_uiForm.lwScriptSearchDirs;
-  } else if (objectName.find(ButtonPrefix::EXTENSIONS) != std::string::npos) {
+  } else if (objectName.contains(ButtonPrefix::EXTENSIONS)) {
     return m_uiForm.lwExtSearchDirs;
   } else {
     return nullptr;
   }
 }
 
-// SLOTS
+/// Show the help for ManageUserDirectories
 void ManageUserDirectories::helpClicked() {
-  HelpWindow::showCustomInterface(nullptr, QString("ManageUserDirectories"));
+  HelpWindow::showCustomInterface(nullptr, HELP_ID);
 }
+
+/// Close the dialog without saving the configuration
 void ManageUserDirectories::cancelClicked() { this->close(); }
+
+/// Persist the properties to the config store and close the dialog
 void ManageUserDirectories::confirmClicked() {
   saveProperties();
   this->close();
 }
 
+/**
+ * Handle the add directory button to take the text from a text
+ * box based on the signal sender to the correct list
+ */
 void ManageUserDirectories::addDirectory() {
   QLineEdit *input(nullptr);
 
@@ -253,26 +262,33 @@ void ManageUserDirectories::addDirectory() {
   }
 }
 
+/// Browse to find a new directory. The start directory
+/// is the last directory accessed by the application. The
+/// directory is added to the list based on the object sender
 void ManageUserDirectories::browseToDirectory() {
   QSettings settings;
-  QString lastDirectory =
-      settings.value("ManageUserSettings/last_directory", "").toString();
+  const auto lastDirectory =
+      settings.value(QSettingsKeys::LastDirectory, "").toString();
 
-  QString newDir = QFileDialog::getExistingDirectory(
+  const auto newDir = QFileDialog::getExistingDirectory(
       this, tr("Select New Data Directory"), lastDirectory,
       QFileDialog::ShowDirsOnly);
 
-  if (newDir != "") {
-    settings.setValue("ManageUserSettings/last_directory", newDir);
+  if (!newDir.isEmpty()) {
+    settings.setValue(QSettingsKeys::LastDirectory, newDir);
     listWidget(sender())->addItem(newDir);
   }
 }
+
+/// Remove a directory from the list based on the sender
 void ManageUserDirectories::remDir() {
   QList<QListWidgetItem *> selected = listWidget(sender())->selectedItems();
   for (auto &i : selected) {
     delete i;
   }
 }
+
+/// Raise an item up in the list based on the sender of the signal
 void ManageUserDirectories::moveUp() {
   QListWidget *list = listWidget(sender());
   QList<QListWidgetItem *> selected = list->selectedItems();
@@ -285,6 +301,8 @@ void ManageUserDirectories::moveUp() {
     list->setCurrentItem(i);
   }
 }
+
+/// Lower an item down in the list based on the sender of the signal
 void ManageUserDirectories::moveDown() {
   QListWidget *list = listWidget(sender());
   int count = list->count();
@@ -298,31 +316,21 @@ void ManageUserDirectories::moveDown() {
     list->setCurrentItem(i);
   }
 }
+
+/// Find an existing directory to be used for the save directory path
 void ManageUserDirectories::selectSaveDir() {
   QSettings settings;
-  QString lastDirectory = m_uiForm.leDefaultSave->text();
-  if (lastDirectory.trimmed() == "")
-    lastDirectory =
-        settings.value("ManageUserSettings/last_directory", "").toString();
+  auto lastDirectory = m_uiForm.leDefaultSave->text().trimmed();
+  if (lastDirectory.isEmpty())
+    lastDirectory = settings.value(QSettingsKeys::LastDirectory, "").toString();
 
-  const QString newDir = QFileDialog::getExistingDirectory(
+  const auto newDir = QFileDialog::getExistingDirectory(
       this, tr("Select New Default Save Directory"), lastDirectory,
       QFileDialog::ShowDirsOnly);
 
-  if (newDir != "") {
-    QString path = newDir + QDir::separator();
-    path.replace('\\', '/');
-    settings.setValue("ManageUserSettings/last_directory", path);
+  if (!newDir.isEmpty()) {
+    const auto path = newDir + QDir::separator();
+    settings.setValue(QSettingsKeys::LastDirectory, path);
     m_uiForm.leDefaultSave->setText(path);
-  }
-}
-
-void ManageUserDirectories::openManageUserDirectories() {
-  if (CURRENTLY_OPEN_MUD.isNull()) {
-    CURRENTLY_OPEN_MUD =
-        QPointer<ManageUserDirectories>(new ManageUserDirectories);
-    CURRENTLY_OPEN_MUD->show();
-  } else {
-    CURRENTLY_OPEN_MUD->raise();
   }
 }

--- a/qt/widgets/common/src/ManageUserDirectories.cpp
+++ b/qt/widgets/common/src/ManageUserDirectories.cpp
@@ -9,13 +9,14 @@
 #include "MantidQtWidgets/Common/HelpWindow.h"
 #include <QDir>
 #include <QFileDialog>
+#include <QPointer>
 #include <QSettings>
 #include <QUrl>
 
 using namespace MantidQt::API;
 
 namespace {
-std::unique_ptr<ManageUserDirectories> CURRENTLY_OPEN_MUD;
+QPointer<ManageUserDirectories> CURRENTLY_OPEN_MUD;
 } // namespace
 
 namespace ButtonPrefix {
@@ -317,15 +318,11 @@ void ManageUserDirectories::selectSaveDir() {
 }
 
 void ManageUserDirectories::openManageUserDirectories() {
-  if (CURRENTLY_OPEN_MUD) {
-    CURRENTLY_OPEN_MUD->raise();
-  } else {
-    CURRENTLY_OPEN_MUD = std::make_unique<ManageUserDirectories>();
+  if (CURRENTLY_OPEN_MUD.isNull()) {
+    CURRENTLY_OPEN_MUD =
+        QPointer<ManageUserDirectories>(new ManageUserDirectories);
     CURRENTLY_OPEN_MUD->show();
+  } else {
+    CURRENTLY_OPEN_MUD->raise();
   }
-}
-
-void ManageUserDirectories::closeEvent(QCloseEvent *event) {
-  CURRENTLY_OPEN_MUD.reset();
-  QWidget::closeEvent(event);
 }

--- a/qt/widgets/common/test/ManageUserDirectoriesTest.h
+++ b/qt/widgets/common/test/ManageUserDirectoriesTest.h
@@ -1,0 +1,88 @@
+// Mantid Repository : https://github.com/mantidproject/mantid
+//
+// Copyright &copy; 2020 ISIS Rutherford Appleton Laboratory UKRI,
+//   NScD Oak Ridge National Laboratory, European Spallation Source,
+//   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+// SPDX - License - Identifier: GPL - 3.0 +
+#pragma once
+
+#include <cxxtest/TestSuite.h>
+
+#include "MantidKernel/ConfigService.h"
+#include "MantidQtWidgets/Common/ManageUserDirectories.h"
+#include <QApplication>
+#include <QSignalSpy>
+#include <QtTest>
+
+using Mantid::Kernel::ConfigService;
+using MantidQt::API::ManageUserDirectories;
+
+class ManageUserDirectoriesTest : public CxxTest::TestSuite {
+public:
+  // This pair of boilerplate methods prevent the suite being created statically
+  // This means the constructor isn't called when running other tests
+  static ManageUserDirectoriesTest *createSuite() {
+    return new ManageUserDirectoriesTest();
+  }
+  static void destroySuite(ManageUserDirectoriesTest *suite) { delete suite; }
+
+  ManageUserDirectoriesTest() {
+    // Start ConfigService
+    ConfigService::Instance();
+  }
+
+  void test_openManageUserDirectories() {
+    auto dialog = openNonPersistingManageUserDirectories();
+
+    TS_ASSERT(dialog);
+    dialog->close();
+  }
+
+  void test_openManageUserDirectories_while_open_returns_same_dialog() {
+    auto firstTimeDialog = openNonPersistingManageUserDirectories();
+    auto secondTimeDialog = openNonPersistingManageUserDirectories();
+
+    TS_ASSERT_EQUALS(firstTimeDialog, secondTimeDialog);
+    firstTimeDialog->close();
+  }
+
+  void test_openManageUserDirectories_reopen_after_closing() {
+    // The internal instance pointer needs resetting if the dialog is closed
+    // by whatever way this is possible but esc doesn't run closeEvent if its
+    // overridden
+    auto firstTimeDialog = openNonPersistingManageUserDirectories();
+    QSignalSpy deletionSpy(firstTimeDialog, &QObject::destroyed);
+
+    QTest::mouseClick(firstTimeDialog->cancelButton(), Qt::LeftButton);
+
+    TS_ASSERT(deletionSpy.wait());
+    // firstTimeDialog is now unsafe
+    auto secondTimeDialog = openNonPersistingManageUserDirectories();
+    TS_ASSERT(secondTimeDialog);
+    secondTimeDialog->close();
+  }
+
+  void test_openManageUserDirectories_reopen_after_closing_with_esc() {
+    // The internal instance pointer needs resetting if the dialog is closed
+    // by whatever way this is possible but esc doesn't run closeEvent if its
+    // overridden
+    auto firstTimeDialog = openNonPersistingManageUserDirectories();
+    QSignalSpy deletionSpy(firstTimeDialog, &QObject::destroyed);
+
+    QTest::keyPress(firstTimeDialog, Qt::Key_Escape);
+    QTest::keyRelease(firstTimeDialog, Qt::Key_Escape);
+
+    TS_ASSERT(deletionSpy.wait());
+    // firstTimeDialog is now unsafe
+    auto secondTimeDialog = openNonPersistingManageUserDirectories();
+    TS_ASSERT(secondTimeDialog);
+    secondTimeDialog->close();
+  }
+
+private:
+  ManageUserDirectories *openNonPersistingManageUserDirectories() {
+    auto dialog = ManageUserDirectories::openManageUserDirectories();
+    dialog->enableSaveToFile(false);
+    return dialog;
+  }
+};


### PR DESCRIPTION
**Description of work.**

Replaces lifetime management mechanism for global version of ManageUserDirectories so that all routes out of the dialog end up deleting the static pointer. The fix is in the first commit and the remaining commits perform some code cleanup/modernization and add some basic unit tests using the QtTest framework.

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

**To test:**

Follow the instructions in the related issue and workbench should no longer crash.

Play with adding/removing directories and ensure that clicking cancel does not save the config but clicking okay does. The dialog on raising again should be populated with the previous values. Also check the user properties file contains the new values.

Fixes #29559 

<!-- Ensure the base of this PR is correct (e.g. release-next or master)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
