### PR TITLE
Use tweak version in long version string

### DIFF
--- a/Framework/Kernel/src/MantidVersion.cpp.in
+++ b/Framework/Kernel/src/MantidVersion.cpp.in
@@ -20,7 +20,7 @@ const char* MantidVersion::version()
 {
   // The major and minor version numbers are specified in Build/CMake/VersionNumber.cmake
   // The patch number is the number of commits since the most recent tag of the repository
-  return "@VERSION_MAJOR@.@VERSION_MINOR@.@VERSION_PATCH@";
+  return "@VERSION_MAJOR@.@VERSION_MINOR@.@VERSION_PATCH@@VERSION_TWEAK@";
 }
 
 const char* MantidVersion::versionShort()


### PR DESCRIPTION
This is the `ornl-next` version of #29838 and takes care of [planning 48](https://code.ornl.gov/sns-hfir-scse/planning/-/issues/48).