### PR TITLE
Fix Muon Analysis Ties and Constraints which are not respected

### DIFF
--- a/docs/source/release/v6.0.0/muon.rst
+++ b/docs/source/release/v6.0.0/muon.rst
@@ -9,5 +9,8 @@ MuSR Changes
     putting new features at the top of the section, followed by
     improvements, followed by bug fixes.
 
+Bug Fixes
+#########
+- A bug on the Muon Analysis interface where ties and constraints were not being respected has been fixed.
 
 :ref:`Release 6.0.0 <v6.0.0>`

--- a/qt/scientific_interfaces/Indirect/IndirectFitPropertyBrowser.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectFitPropertyBrowser.cpp
@@ -66,10 +66,6 @@ void IndirectFitPropertyBrowser::initFunctionBrowser() {
   connect(m_functionBrowser,
           SIGNAL(parameterChanged(const QString &, const QString &)), this,
           SIGNAL(functionChanged()));
-  connect(m_functionBrowser, SIGNAL(tiesChanged()), this,
-          SIGNAL(functionChanged()));
-  connect(m_functionBrowser, SIGNAL(constraintsChanged()), this,
-          SIGNAL(functionChanged()));
   connect(m_functionBrowser, SIGNAL(globalsChanged()), this,
           SIGNAL(functionChanged()));
   connect(m_functionBrowser,

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/FunctionBrowser.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/FunctionBrowser.h
@@ -132,8 +132,6 @@ signals:
   /// In multi-dataset context a button value editor was clicked
   void localParameterButtonClicked(const QString &parName);
   void globalsChanged();
-  void constraintsChanged();
-  void tiesChanged();
 
 public slots:
 

--- a/qt/widgets/common/src/FunctionMultiDomainPresenter.cpp
+++ b/qt/widgets/common/src/FunctionMultiDomainPresenter.cpp
@@ -396,6 +396,7 @@ void FunctionMultiDomainPresenter::editLocalParameterFinish(int result) {
     }
   }
   m_editLocalParameterDialog = nullptr;
+  emit functionStructureChanged();
 }
 
 void FunctionMultiDomainPresenter::updateViewFromModel() {


### PR DESCRIPTION
**Description of work.**
This PR ensures the ties and constraints set via the `Edit Local Parameter Dialog` are respected on the `Muon Analysis` interface. 

The problem was that the Muon `fitting_tab_presenter` was not being told to update its stored function when a tie or constraint was applied. To do this, we needed to emit functionStructureChanged` signal.

This PR also removes several unused signals in the `FunctionBrowser` which seem to be redundant.

**To test:**
Muon:
1. `Interfaces`->`Muon`->`Muon Analysis`
2. Load run `62260` for `MUSR` instrument
3. Go to `Fitting` tab
4. Tick `Simulataneous fit`
5. Add a function `GausOsc`
6. Click `...` next to a parameter (e.g. sigma)
9. Click the `Set` button in the Value column and select `Fix all`
10. Click `Ok` and then `Fit`
11. The tie should be respected!

Indirect (to check it is still working):
1. `Interfaces`->`Indirect`->`Data Analysis`
2. Go to `IqtFit` tab
3. Load the data below
4. Select Simultaneous Fit
5. Select 1 exponential
6. Tick `See Full Function`
7. Click the `...` box next to one of the parameters (e.g. `Height`)
8. Click the `Set` button in the Value column and select `Fix all`
9. Click `Ok` and then `Run`
10. The tie should be respected.

**Data**
[irs26176_graphite002_iqt.zip](https://github.com/mantidproject/mantid/files/5428108/irs26176_graphite002_iqt.zip)

Fixes #29803

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
