### PR TITLE
Ignore new PG3 files in LoadLotsOfFiles

### DIFF
--- a/Testing/SystemTests/tests/framework/LoadLotsOfFiles.py
+++ b/Testing/SystemTests/tests/framework/LoadLotsOfFiles.py
@@ -60,6 +60,9 @@ BANNED_FILES = ['80_tubes_Top_and_Bottom_April_2015.xml',
                 'MAP17589.raw',
                 'MER06399.raw',  # Don't need to check multiple MERLIN files
                 'PG3_11485-1.dat',  # Generic load doesn't do very well with ASCII files
+                'PG3_char_2020_05_06-HighRes-PAC_1.4_MW.txt',
+                'PG3_char_2020_01_04_PAC_limit_1.4MW',
+                'PG3_PAC_HR_d46168_2020_05_06.h5', # loaded by a different algorithm
                 'PG3_2538_event.nxs',  # Don't need to check all of the PG3 files
                 'PG3_9829_event.nxs',
                 'REF_M_9684_event.nxs',


### PR DESCRIPTION
**Description of work.**

Ignores new files not meant to be loaded by `Load` in general system test. The LoadLotsOfFiles test is not run on PRs as it takes a long time. 

The nightly systemtests are currently failing as they can't load these files.

**To test:**

* Code review.
* Run the LoadLotsOfFiles test and it should pass. 

*There is no associated issue.*

*This does not require release notes* because **it's an internal change.**

<!-- Ensure the base of this PR is correct (e.g. release-next or master)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
