### PR TITLE
shared ownership of axis in workspace

### DIFF
--- a/Framework/API/inc/MantidAPI/MatrixWorkspace.h
+++ b/Framework/API/inc/MantidAPI/MatrixWorkspace.h
@@ -412,7 +412,7 @@ public:
 
   int axes() const;
   virtual Axis *getAxis(const std::size_t &axisIndex) const;
-  void replaceAxis(const std::size_t &axisIndex, std::unique_ptr<Axis> newAxis);
+  void replaceAxis(const std::size_t &axisIndex, std::shared_ptr<Axis> newAxis);
 
   /// Will return the number of Axis currently stored in the workspace it is not
   /// always safe to assume it is just 2
@@ -575,7 +575,7 @@ protected:
   void updateCachedDetectorGrouping(const size_t index) const override;
 
   /// A vector of pointers to the axes for this workspace
-  std::vector<std::unique_ptr<Axis>> m_axes;
+  std::vector<std::shared_ptr<Axis>> m_axes;
 
 private:
   std::size_t binIndexOfValue(Mantid::HistogramData::HistogramX const &xValues,

--- a/Framework/API/src/MatrixWorkspace.cpp
+++ b/Framework/API/src/MatrixWorkspace.cpp
@@ -916,7 +916,7 @@ Axis *MatrixWorkspace::getAxis(const std::size_t &axisIndex) const {
 
 /** Replaces one of the workspace's axes with the new one provided.
  *  @param axisIndex :: The index of the axis to replace
- *  @param newAxis :: A Unique_ptr to the new axis. The class will take
+ *  @param newAxis :: A shared_ptr to the new axis. The class will take shared
  * ownership.
  *  @throw IndexError If the axisIndex given is outside the range of axes held
  * by this workspace
@@ -924,7 +924,7 @@ Axis *MatrixWorkspace::getAxis(const std::size_t &axisIndex) const {
  * (within one of the old one)
  */
 void MatrixWorkspace::replaceAxis(const std::size_t &axisIndex,
-                                  std::unique_ptr<Axis> newAxis) {
+                                  std::shared_ptr<Axis> newAxis) {
   // First check that axisIndex is in range
   if (axisIndex >= m_axes.size()) {
     throw Kernel::Exception::IndexError(

--- a/Framework/PythonInterface/mantid/api/src/Exports/MatrixWorkspace.cpp
+++ b/Framework/PythonInterface/mantid/api/src/Exports/MatrixWorkspace.cpp
@@ -250,11 +250,12 @@ std::vector<size_t> maskedBinsIndices(MatrixWorkspace &self, const int i) {
  * Raw Pointer wrapper of replaceAxis to allow it to work with python
  * @param self
  * @param axisIndex :: The index of the axis to replace
- * @param newAxis :: A pointer to the new axis. The class will take ownership.
+ * @param newAxis :: A pointer to the new axis. The class will take shared
+ * ownership.
  */
 void pythonReplaceAxis(MatrixWorkspace &self, const std::size_t &axisIndex,
                        Axis *newAxis) {
-  self.replaceAxis(axisIndex, std::unique_ptr<Axis>(newAxis));
+  self.replaceAxis(axisIndex, std::shared_ptr<Axis>(newAxis));
 }
 
 /**


### PR DESCRIPTION
**Description of work.**

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

**To test:**


In the Workbench run the following code:

```
from mantid.simpleapi import *
from mantid.api import NumericAxis

x_axis = NumericAxis.create(1)
x_axis.setValue(0, 0) 

for meas_no in range(2):
    name = 'out_{}'.format(meas_no)
    CreateSampleWorkspace(WorkspaceType='Histogram', Function='One Peak', NumEvents=1,
        XMin=0, XMax=1, BinWidth=1, OutputWorkspace=name)
    mtd[name].replaceAxis(0, x_axis)
```

Then, using GUI, delete one of the created workspaces, then the remaining one. There should be no segmentation fault.


Fixes #29844 .
<!-- alternative
*There is no associated issue.*
-->

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or master)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
