### PR TITLE
Bug in DrILL threadpool limit

### DIFF
--- a/scripts/Interface/ui/drill/model/DrillModel.py
+++ b/scripts/Interface/ui/drill/model/DrillModel.py
@@ -116,9 +116,9 @@ class DrillModel(QObject):
         self.visualSettings = None
 
         # set the instrument and default acquisition mode
+        self.tasksPool = DrillAlgorithmPool()
         self.setInstrument(config['default.instrument'], log=False)
 
-        self.tasksPool = DrillAlgorithmPool()
         # setup the thread pool
         self.tasksPool.signals.taskStarted.connect(self._onTaskStarted)
         self.tasksPool.signals.taskSuccess.connect(self._onTaskSuccess)
@@ -138,38 +138,25 @@ class DrillModel(QObject):
         self.rundexFile = None
         self.samples = list()
         self.settings = dict()
+        self.columns = list()
         self.visualSettings = None
+        self.instrument = None
+        self.acquisitionMode = None
+        self.algorithm = None
 
         # When the user changes the facility after DrILL has been started
         if config['default.facility'] != 'ILL':
             logger.error('Drill is enabled only if the facility is set to ILL.')
-            self.instrument = None
-            self.acquisitionMode = None
-            self.columns = list()
-            self.algorithm = None
-            self.settings = dict()
             return
 
         if (instrument in RundexSettings.ACQUISITION_MODES):
             config['default.instrument'] = instrument
             self.instrument = instrument
-            self.acquisitionMode = \
-                RundexSettings.ACQUISITION_MODES[instrument][0]
-            self.columns = RundexSettings.COLUMNS[self.acquisitionMode]
-            self.algorithm = RundexSettings.ALGORITHM[self.acquisitionMode]
-            self.settings = dict.fromkeys(
-                    RundexSettings.SETTINGS[self.acquisitionMode])
-            self._setDefaultSettings()
-            self._initController()
+            self.setAcquisitionMode(RundexSettings.ACQUISITION_MODES[instrument][0])
         else:
             if log:
                 logger.error('Instrument {0} is not supported yet.'
                              .format(instrument))
-            self.instrument = None
-            self.acquisitionMode = None
-            self.columns = list()
-            self.algorithm = None
-            self.settings = dict()
 
     def getInstrument(self):
         """


### PR DESCRIPTION
**Description of work.**

The thread pool size limit is not taken into account. Despite the fact that the underlying algorithm is not thread safe, processing of multiple rows calls multiple instances of this algorithm.

**To test:**

With data from `SystemTest/ILL/D11/`:
* open DrILL, select D11 instrument
* set 2888 in the first cell of the first row
* add a row and set 2889 in the first cell of the second row
* process all (Process -> Process all rows)

The first row should turn yellow and green. When this is done, the second row should then turn yellow and green.

Fixes #29851 

*This does not require release notes*: internal changes only

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
