### PR TITLE
Sort peaks table by value type and not string comparison

### DIFF
--- a/docs/source/release/v6.0.0/mantidworkbench.rst
+++ b/docs/source/release/v6.0.0/mantidworkbench.rst
@@ -40,5 +40,6 @@ Bugfixes
 - Fixed a Workbench crash when attempting to show the data in a ragged workspace.
 - Show spectrum numbers instead of workspace index in plotBin
 - Fixed a bug which would cause unrealistic errorbars on the fit calc curve.
+- Fix sort order of peaks in the peaks overlay on SliceViewer.
 
 :ref:`Release 6.0.0 <v6.0.0>`

--- a/qt/python/CMakeLists.txt
+++ b/qt/python/CMakeLists.txt
@@ -138,6 +138,7 @@ if(ENABLE_MANTIDPLOT OR ENABLE_WORKBENCH)
         mantidqt/widgets/sliceviewer/test/test_sliceviewer_zoom.py
         mantidqt/widgets/sliceviewer/peaksviewer/test/test_peaksviewer_model.py
         mantidqt/widgets/sliceviewer/peaksviewer/test/test_peaksviewer_presenter.py
+        mantidqt/widgets/sliceviewer/peaksviewer/test/test_peaksviewer_view.py
         mantidqt/widgets/sliceviewer/peaksviewer/test/test_peaksviewer_peaksviewercollectionpresenter.py
         mantidqt/widgets/sliceviewer/peaksviewer/test/test_peaksviewer_peaksworkspaceselectormodel.py
         mantidqt/widgets/sliceviewer/peaksviewer/test/test_peaksviewer_peaksworkspaceselectorpresenter.py

--- a/qt/python/mantidqt/widgets/sliceviewer/peaksviewer/presenter.py
+++ b/qt/python/mantidqt/widgets/sliceviewer/peaksviewer/presenter.py
@@ -19,17 +19,24 @@ class PeaksWorkspaceDataPresenter(TableWorkspaceDataPresenter):
     """Override create_item method to format table columns more
     appropriately
     """
+    # Format specifier for floats in the table
     FLOAT_FORMAT_STR = '{:.5f}'
+    # Qt model classes can store data against different roles.
+    # Defines a custom role to be used for sorting with QSortFilterProxy.
+    # See https://doc.qt.io/qt-5/qsortfilterproxymodel.html#sortRole-prop
+    DATA_SORT_ROLE = 2001
 
     def create_item(self, data, _):
         """Create a table item to display the data. The data is always readonly
         here.
         """
         if type(data) == float:
-            data = self.FLOAT_FORMAT_STR.format(data)
+            display_data = self.FLOAT_FORMAT_STR.format(data)
         else:
-            data = str(data)
-        return create_table_item(data, editable=False)
+            display_data = str(data)
+        item = create_table_item(display_data, editable=False)
+        item.setData(data, self.DATA_SORT_ROLE)
+        return item
 
 
 class PeaksViewerPresenter(object):
@@ -121,7 +128,7 @@ class PeaksViewerPresenter(object):
         Respond to a change in the peaks list in the model
         """
         self._peaks_table_presenter.refresh()
-        self.view.table_view.enable_sorting()
+        self.view.table_view.enable_sorting(PeaksWorkspaceDataPresenter.DATA_SORT_ROLE)
 
     # private api
     @staticmethod

--- a/qt/python/mantidqt/widgets/sliceviewer/peaksviewer/test/test_peaksviewer_presenter.py
+++ b/qt/python/mantidqt/widgets/sliceviewer/peaksviewer/test/test_peaksviewer_presenter.py
@@ -15,6 +15,8 @@ from mantid.dataobjects import PeaksWorkspace
 from mantidqt.widgets.sliceviewer.peaksviewer import PeaksViewerModel
 from mantidqt.widgets.sliceviewer.peaksviewer.presenter \
     import PeaksViewerPresenter, PeaksWorkspaceDataPresenter
+from mantidqt.widgets.sliceviewer.peaksviewer.view \
+    import PeaksViewerView, _PeaksWorkspaceTableView
 from mantidqt.widgets.sliceviewer.peaksviewer.test.modeltesthelpers\
     import create_peaks_viewer_model, create_slice_info  # noqa
 
@@ -34,30 +36,36 @@ def create_mock_model(name):
     return mock
 
 
+def create_mock_view():
+    mock_view = create_autospec(PeaksViewerView)
+    mock_view.table_view = create_autospec(_PeaksWorkspaceTableView)
+    return mock_view
+
+
 @patch("mantidqt.widgets.sliceviewer.peaksviewer.presenter.PeaksWorkspaceDataPresenter",
        autospec=PeaksWorkspaceDataPresenter)
 class PeaksViewerPresenterTest(unittest.TestCase):
+    def setUp(self):
+        self.mock_view = create_mock_view()
 
     # -------------------- success tests -----------------------------
     def test_presenter_subscribes_to_view_updates(self, _):
-        mock_view = MagicMock()
+        presenter = PeaksViewerPresenter(create_peaks_viewer_model([], 'r'), self.mock_view)
 
-        presenter = PeaksViewerPresenter(create_peaks_viewer_model([], 'r'), mock_view)
-
-        mock_view.subscribe.assert_called_once_with(presenter)
+        self.mock_view.subscribe.assert_called_once_with(presenter)
 
     def test_view_populated_on_presenter_construction(self, mock_peaks_list_presenter):
-        mock_view = MagicMock()
         name = "ws1"
         fg_color = "r"
         test_model = create_peaks_viewer_model([(1, 2, 3)], fg_color=fg_color, name=name)
 
-        PeaksViewerPresenter(test_model, mock_view)
+        PeaksViewerPresenter(test_model, self.mock_view)
 
-        mock_view.set_title.assert_called_once_with(name)
-        mock_view.set_peak_color.assert_called_once_with(fg_color)
+        self.mock_view.set_title.assert_called_once_with(name)
+        self.mock_view.set_peak_color.assert_called_once_with(fg_color)
         # peaks list presenter construction
-        mock_peaks_list_presenter.assert_called_once_with(ANY, mock_view.table_view)
+        mock_peaks_list_presenter.assert_called_once_with(ANY, self.mock_view.table_view)
+        self.mock_view.table_view.enable_sorting.assert_called_once()
 
     def test_clear_removes_painted_peaks(self, mock_peaks_list_presenter):
         centers = ((1, 2, 3), (4, 5, 3.01))
@@ -67,13 +75,12 @@ class PeaksViewerPresenterTest(unittest.TestCase):
         axes.get_xlim.return_value = (-1, 1)
         painter.axes = axes
         test_model.draw_peaks(slice_info, painter)
-        mock_view = MagicMock()
-        mock_view.painter = painter
-        presenter = PeaksViewerPresenter(test_model, mock_view)
+        self.mock_view.painter = painter
+        presenter = PeaksViewerPresenter(test_model, self.mock_view)
 
         presenter.notify(PeaksViewerPresenter.Event.ClearPeaks)
 
-        self.assertEqual(2, mock_view.painter.remove.call_count)
+        self.assertEqual(2, self.mock_view.painter.remove.call_count)
 
     def test_slice_point_changed_clears_old_peaks_and_overlays_visible(
             self, mock_peaks_list_presenter):
@@ -88,29 +95,27 @@ class PeaksViewerPresenterTest(unittest.TestCase):
         test_model.draw_peaks(slice_info, painter)
         # clear draw calls
         painter.cross.reset_mock()
-        mock_view = MagicMock()
-        mock_view.painter = painter
-        mock_view.sliceinfo = create_slice_info(centers, slice_value=3, slice_width=5)
-        presenter = PeaksViewerPresenter(test_model, mock_view)
+        self.mock_view.painter = painter
+        self.mock_view.sliceinfo = create_slice_info(centers, slice_value=3, slice_width=5)
+        presenter = PeaksViewerPresenter(test_model, self.mock_view)
 
         presenter.notify(PeaksViewerPresenter.Event.SlicePointChanged)
 
-        self.assertEqual(2, mock_view.painter.remove.call_count)
-        self.assertEqual(2, mock_view.painter.cross.call_count)
+        self.assertEqual(2, self.mock_view.painter.remove.call_count)
+        self.assertEqual(2, self.mock_view.painter.cross.call_count)
 
     def test_single_peak_selection(self, mock_peaks_list_presenter):
-        mock_view = MagicMock()
         name = 'ws1'
         mock_model = create_mock_model(name)
         viewlimits = (-1, 1), (-2, 2)
         mock_model.viewlimits.return_value = viewlimits
-        mock_view.selected_index = 0
-        presenter = PeaksViewerPresenter(mock_model, mock_view)
+        self.mock_view.selected_index = 0
+        presenter = PeaksViewerPresenter(mock_model, self.mock_view)
 
         presenter.notify(PeaksViewerPresenter.Event.PeakSelected)
 
         mock_model.viewlimits.assert_called_once_with(0)
-        mock_view.set_axes_limits.assert_called_once_with(*viewlimits, auto_transform=False)
+        self.mock_view.set_axes_limits.assert_called_once_with(*viewlimits, auto_transform=False)
 
 
 if __name__ == '__main__':

--- a/qt/python/mantidqt/widgets/sliceviewer/peaksviewer/test/test_peaksviewer_view.py
+++ b/qt/python/mantidqt/widgets/sliceviewer/peaksviewer/test/test_peaksviewer_view.py
@@ -1,0 +1,52 @@
+# Mantid Repository : https://github.com/mantidproject/mantid
+#
+# Copyright &copy; 2020 ISIS Rutherford Appleton Laboratory UKRI,
+#     NScD Oak Ridge National Laboratory, European Spallation Source
+#     & Institut Laue - Langevin
+# SPDX - License - Identifier: GPL - 3.0 +
+#  This file is part of the mantid workbench.
+
+# std imports
+import unittest
+
+# 3rdparty imports
+from mantidqt.widgets.sliceviewer.peaksviewer.model import PeaksViewerModel
+from mantidqt.widgets.sliceviewer.peaksviewer.view import PeaksViewerView
+from mantidqt.widgets.sliceviewer.peaksviewer.presenter import PeaksViewerPresenter, PeaksWorkspaceDataPresenter
+from mantidqt.utils.qt.testing import start_qapplication
+from qtpy.QtCore import Qt
+from testhelpers import WorkspaceCreationHelper
+
+
+@start_qapplication
+class PeaksViewerViewTest(unittest.TestCase):
+    def test_sort_by_value_not_string(self):
+        npeaks = 5
+        peaks_ws = WorkspaceCreationHelper.createPeaksWorkspace(npeaks)
+        view = PeaksViewerView(None, None)
+        model = PeaksViewerModel(peaks_ws, fg_color='r', bg_color='w')
+        presenter = PeaksViewerPresenter(model, view)
+        table_view = view.table_view
+        table_model = table_view.model()
+
+        # Very difficult to simulate mouse click to sort - trust Qt to do that
+        # We are more interested that the sort is based on value no a string comparison
+        # check a few columns
+        for column_index in (7, 16):  # tof & qlab
+            table_model.sort(column_index, Qt.DescendingOrder)
+
+            self.assertEqual(npeaks, view.table_view.rowCount())
+            # assert sort has happened
+            col_values = [
+                table_model.index(i, column_index).data(PeaksWorkspaceDataPresenter.DATA_SORT_ROLE)
+                for i in range(npeaks)
+            ]
+            self.assertTrue(all(col_values[i + 1] < col_values[i] for i in range(npeaks - 1)),
+                            msg="TOF values have not been sorted into descending order")
+
+        view.close()
+        del presenter
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/qt/python/mantidqt/widgets/sliceviewer/test/test_sliceviewer_presenter.py
+++ b/qt/python/mantidqt/widgets/sliceviewer/test/test_sliceviewer_presenter.py
@@ -12,15 +12,16 @@ import unittest
 from unittest import mock
 
 import matplotlib
-matplotlib.use('Agg')  # noqa: E402
+matplotlib.use('Agg')
 # Mock out simpleapi to import expensive import of something we don't use anyway
-sys.modules['mantid.simpleapi'] = mock.MagicMock()  # noqa: E402
+sys.modules['mantid.simpleapi'] = mock.MagicMock()
 
-from mantidqt.widgets.sliceviewer.model import SliceViewerModel, WS_TYPE
-from mantidqt.widgets.sliceviewer.presenter import (PeaksViewerCollectionPresenter, SliceViewer)
-from mantidqt.widgets.sliceviewer.transform import NonOrthogonalTransform
-from mantidqt.widgets.sliceviewer.toolbar import ToolItemText
-from mantidqt.widgets.sliceviewer.view import SliceViewerView, SliceViewerDataView
+from mantidqt.widgets.sliceviewer.model import SliceViewerModel, WS_TYPE  # noqa: E402
+from mantidqt.widgets.sliceviewer.presenter import (  # noqa: E402
+    PeaksViewerCollectionPresenter, SliceViewer)
+from mantidqt.widgets.sliceviewer.transform import NonOrthogonalTransform  # noqa: E402
+from mantidqt.widgets.sliceviewer.toolbar import ToolItemText  # noqa: E402
+from mantidqt.widgets.sliceviewer.view import SliceViewerView, SliceViewerDataView  # noqa: E402
 
 
 def _create_presenter(model, view, mock_sliceinfo_cls, enable_nonortho_axes, supports_nonortho):

--- a/qt/python/mantidqt/widgets/sliceviewer/test/test_sliceviewer_view.py
+++ b/qt/python/mantidqt/widgets/sliceviewer/test/test_sliceviewer_view.py
@@ -11,15 +11,15 @@ import matplotlib as mpl
 
 from mantidqt.widgets.colorbar.colorbar import MIN_LOG_VALUE
 
-mpl.use('Agg')  # noqa
-from mantid.simpleapi import (CreateMDHistoWorkspace, CreateMDWorkspace, CreateSampleWorkspace,
-                              SetUB)
-from mantidqt.utils.qt.testing import start_qapplication
-from mantidqt.utils.qt.testing.qt_widget_finder import QtWidgetFinder
-from mantidqt.widgets.sliceviewer.presenter import SliceViewer
-from mantidqt.widgets.sliceviewer.toolbar import ToolItemText
-from qtpy.QtWidgets import QApplication
-from math import inf
+mpl.use('Agg')
+from mantid.simpleapi import (  # noqa: E402
+    CreateMDHistoWorkspace, CreateMDWorkspace, CreateSampleWorkspace, SetUB)
+from mantidqt.utils.qt.testing import start_qapplication  # noqa: E402
+from mantidqt.utils.qt.testing.qt_widget_finder import QtWidgetFinder  # noqa: E402
+from mantidqt.widgets.sliceviewer.presenter import SliceViewer  # noqa: E402
+from mantidqt.widgets.sliceviewer.toolbar import ToolItemText  # noqa: E402
+from qtpy.QtWidgets import QApplication  # noqa: E402
+from math import inf  # noqa: E402
 
 
 @start_qapplication


### PR DESCRIPTION
**Description of work.**

Fixes the sort order of columns in peaks table attached to the SliceViewer. The separate main table uses the `SortPeaksWorkspace` to physically sort the workspace whereas the sliceviewer just wants to sort the view so the main table was never broken and is unaffected by these changes. 

**To test:**

Use the instructions in the linked issue and the column sorting should now make sense and not be based on strings

Fixes #29840 

<!-- Ensure the base of this PR is correct (e.g. release-next or master)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
