### PR TITLE
Fix crash when displaying of Ragged Workspaces

### DIFF
--- a/Framework/PythonInterface/mantid/plots/datafunctions.py
+++ b/Framework/PythonInterface/mantid/plots/datafunctions.py
@@ -391,25 +391,25 @@ def get_bin_indices(workspace):
         return indices
 
 
-def get_bins(workspace, wkspIndex, withDy=False):
+def get_bins(workspace, bin_index, withDy=False):
     """
     Extract all the bins for a spectrum
 
     :param workspace: a Workspace2D or an EventWorkspace
-    :param wkspIndex: workspace index
+    :param bin_index: the index of a bin
     :param withDy: if True, it will return the error in the "counts", otherwise None
 
     """
-    bins = get_bin_indices(workspace)
+    indices = get_bin_indices(workspace)
     x_values, y_values = [], []
     dy = [] if withDy else None
-    for bin_index in bins:
-        y_data = workspace.readY(int(bin_index))
-        if wkspIndex < len(y_data):
-            x_values.append(bin_index)
-            y_values.append(y_data[wkspIndex])
+    for row_index in indices:
+        y_data = workspace.readY(int(row_index))
+        if bin_index < len(y_data):
+            x_values.append(row_index)
+            y_values.append(y_data[bin_index])
             if withDy:
-                dy.append(workspace.readE(int(bin_index))[wkspIndex])
+                dy.append(workspace.readE(int(row_index))[bin_index])
     dx = None
     return x_values, y_values, dy, dx
 

--- a/Framework/PythonInterface/mantid/plots/datafunctions.py
+++ b/Framework/PythonInterface/mantid/plots/datafunctions.py
@@ -401,15 +401,17 @@ def get_bins(workspace, wkspIndex, withDy=False):
 
     """
     bins = get_bin_indices(workspace)
-    y_values = []
+    x_values, y_values = [], []
     dy = [] if withDy else None
     for bin_index in bins:
-        y_values.append(workspace.readY(int(bin_index))[wkspIndex])
-        if withDy:
-            dy.append(workspace.readE(int(bin_index))[wkspIndex])
-
+        y_data = workspace.readY(int(bin_index))
+        if wkspIndex < len(y_data):
+            x_values.append(bin_index)
+            y_values.append(y_data[wkspIndex])
+            if withDy:
+                dy.append(workspace.readE(int(bin_index))[wkspIndex])
     dx = None
-    return bins, y_values, dy, dx
+    return x_values, y_values, dy, dx
 
 
 def get_md_data2d_bin_bounds(workspace, normalization, indices=None, transpose=False):

--- a/Framework/PythonInterface/test/python/mantid/plots/datafunctionsTest.py
+++ b/Framework/PythonInterface/test/python/mantid/plots/datafunctionsTest.py
@@ -17,21 +17,11 @@ import numpy as np
 import mantid.api
 import mantid.plots.datafunctions as funcs
 from unittest.mock import Mock
-from mantid.api import AnalysisDataService
 from mantid.kernel import config
 from mantid.plots.utility import MantidAxType
 from mantid.simpleapi import (AddSampleLog, AddTimeSeriesLog, ConjoinWorkspaces,
                               CreateMDHistoWorkspace, CreateSampleWorkspace,
                               CreateSingleValuedWorkspace, CreateWorkspace, DeleteWorkspace, LoadRaw)
-
-
-def create_ragged_workspace():
-    CreateWorkspace([0, 1, 2, 3, 4, 2, 3, 4, 5, 6], [0, 1, 2, 3, 4, 3, 4, 5, 6, 7], NSpec=2, OutputWorkspace='Ragged')
-    CreateWorkspace([1, 2, 3, 4], [1, 2, 3, 4], NSpec=1, OutputWorkspace='__temp1')
-    CreateWorkspace([2, 3, 4, 5, 6], [3, 4, 5, 6, 7], NSpec=1, OutputWorkspace='__temp2')
-    ConjoinWorkspaces('Ragged', '__temp1', CheckOverlapping=False)
-    ConjoinWorkspaces('Ragged', '__temp2', CheckOverlapping=False)
-    return AnalysisDataService.retrieve('Ragged')
 
 
 def add_workspace_with_data(func):
@@ -799,11 +789,11 @@ class DataFunctionsTest(unittest.TestCase):
         self.assertTrue(np.array_equal([2.0, 5.0, 8.0, 11.0], dy))
 
     def test_get_bins_with_a_ragged_workspace(self):
-        x, y, dy, dx = funcs.get_bins(create_ragged_workspace(), 4, withDy=True)
+        x, y, dy, dx = funcs.get_bins(self.ws2d_point_uneven, 3, withDy=True)
 
-        self.assertTrue(np.array_equal([0, 1, 3], x))
-        self.assertTrue(np.array_equal([4.0, 7.0, 7.0], y))
-        self.assertTrue(np.array_equal([0.0, 0.0, 0.0], dy))
+        self.assertTrue(np.array_equal([1], x))
+        self.assertTrue(np.array_equal([4.0], y))
+        self.assertTrue(np.array_equal([0.0], dy))
 
     @add_md_workspace_with_data(dimensions=3)
     def test_get_md_data2d_bin_bounds_raises_AssertionException_too_many_dims(self, mdws):

--- a/docs/source/release/v6.0.0/mantidworkbench.rst
+++ b/docs/source/release/v6.0.0/mantidworkbench.rst
@@ -33,5 +33,6 @@ Bugfixes
 - Fix Workbench crashes upon deleting rows or columns in a TableWorkspace.
 - Fix crash on second call to ManageUserDirectories after pressing Esc to close it.
 - A bug in plot config where changing an axes title in the axis tab did not change the title in the curves tab.
+- Fixed a Workbench crash when attempting to show the data in a ragged workspace.
 
 :ref:`Release 6.0.0 <v6.0.0>`

--- a/qt/python/CMakeLists.txt
+++ b/qt/python/CMakeLists.txt
@@ -149,6 +149,7 @@ if(ENABLE_MANTIDPLOT OR ENABLE_WORKBENCH)
         mantidqt/widgets/sliceviewer/peaksviewer/representation/test/test_peaksviewer_representation_spherical.py
         mantidqt/widgets/test/test_jupyterconsole.py
         mantidqt/widgets/workspacedisplay/test/test_data_copier.py
+        mantidqt/widgets/workspacedisplay/test/test_workspacedisplay_view.py
         mantidqt/widgets/workspacedisplay/test/test_user_notifier.py
         mantidqt/widgets/workspacedisplay/matrix/test/test_matrixworkspacedisplay_model.py
         mantidqt/widgets/workspacedisplay/matrix/test/test_matrixworkspacedisplay_presenter.py

--- a/qt/python/mantidqt/widgets/workspacedisplay/matrix/table_view_model.py
+++ b/qt/python/mantidqt/widgets/workspacedisplay/matrix/table_view_model.py
@@ -59,7 +59,7 @@ class MatrixWorkspaceTableViewModel(QAbstractTableModel):
         self.ws = ws
         self.ws_spectrum_info = self.ws.spectrumInfo()
         self.row_count = self.ws.getNumberHistograms()
-        self.column_count = self._get_max_column_count()
+        self.column_count = self.get_max_column_count()
 
         self.masked_rows_cache = []
         self.monitor_rows_cache = []
@@ -86,7 +86,7 @@ class MatrixWorkspaceTableViewModel(QAbstractTableModel):
         else:
             raise ValueError("Unknown model type {0}".format(self.type))
 
-    def _get_max_column_count(self):
+    def get_max_column_count(self):
         max_column_count = 0
         for i in range(self.ws.getNumberHistograms()):
             column_count = len(self.ws.readY(i))

--- a/qt/python/mantidqt/widgets/workspacedisplay/matrix/table_view_model.py
+++ b/qt/python/mantidqt/widgets/workspacedisplay/matrix/table_view_model.py
@@ -60,10 +60,11 @@ class MatrixWorkspaceTableViewModel(QAbstractTableModel):
         self.masked_rows_cache = []
         self.monitor_rows_cache = []
         self.masked_bins_cache = {}
+        self.blank_cell_cache = {}
 
         self.masked_color = QtGui.QColor(240, 240, 240)
-
         self.monitor_color = QtGui.QColor(255, 253, 209)
+        self.blank_cell_color = QtGui.QColor(255, 102, 153)
 
         self.type = model_type
         if self.type == MatrixWorkspaceTableViewModelType.x:
@@ -189,6 +190,10 @@ class MatrixWorkspaceTableViewModel(QAbstractTableModel):
             elif self.checkMaskedBinCache(row, index):
                 return self.masked_color
 
+            # Checks if the cell is BLANK, if so it returns the specified color for blank cells
+            elif self.checkBlankCache(row, index.column()):
+                return self.blank_cell_color
+
         elif role == Qt.ToolTipRole:
             tooltip = QVariant()
             if self.checkMaskedCache(row):
@@ -231,3 +236,14 @@ class MatrixWorkspaceTableViewModel(QAbstractTableModel):
             if index.column() in masked_bins:
                 self.masked_bins_cache[row] = masked_bins
                 return True
+
+    def checkBlankCache(self, row, column):
+        if row in self.blank_cell_cache and column in self.blank_cell_cache[row]:
+            return True
+        elif str(self.relevant_data(row)[column]) == "":
+            if row in self.blank_cell_cache:
+                self.blank_cell_cache[row].append(column)
+            else:
+                self.blank_cell_cache[row] = [column]
+            return True
+        return False

--- a/qt/python/mantidqt/widgets/workspacedisplay/matrix/test/test_matrixworkspacedisplay_table_view_model.py
+++ b/qt/python/mantidqt/widgets/workspacedisplay/matrix/test/test_matrixworkspacedisplay_table_view_model.py
@@ -103,10 +103,9 @@ class MatrixWorkspaceDisplayTableViewModelTest(unittest.TestCase):
     def test_row_and_column_count(self):
         ws = MockWorkspace()
         model_type = MatrixWorkspaceTableViewModelType.x
-        model = MatrixWorkspaceTableViewModel(ws, model_type)
+        MatrixWorkspaceTableViewModel(ws, model_type)
         # these are called when the TableViewModel is initialised
         ws.getNumberHistograms.assert_called()
-        model.get_max_column_count.assert_called_once()
 
     def test_data_background_role_masked_row(self):
         ws, model, row, index = setup_common_for_test_data()
@@ -134,7 +133,7 @@ class MatrixWorkspaceDisplayTableViewModelTest(unittest.TestCase):
 
         # assert that the row was called twice with no parameters
         self.assertEqual(2, index.row.call_count)
-        self.assertFalse(index.column.called)
+        self.assertEqual(2, index.column.call_count)
 
     def test_data_background_role_monitor_row(self):
         ws, model, row, index = setup_common_for_test_data()
@@ -167,7 +166,7 @@ class MatrixWorkspaceDisplayTableViewModelTest(unittest.TestCase):
 
         # assert that the row was called twice with no parameters
         self.assertEqual(2, index.row.call_count)
-        self.assertFalse(index.column.called)
+        self.assertEqual(2, index.column.call_count)
 
     def test_data_background_role_masked_bin(self):
         ws, model, row, index = setup_common_for_test_data()

--- a/qt/python/mantidqt/widgets/workspacedisplay/matrix/test/test_matrixworkspacedisplay_table_view_model.py
+++ b/qt/python/mantidqt/widgets/workspacedisplay/matrix/test/test_matrixworkspacedisplay_table_view_model.py
@@ -97,16 +97,16 @@ class MatrixWorkspaceDisplayTableViewModelTest(unittest.TestCase):
         model = MatrixWorkspaceTableViewModel(ws, model_type)
         index = MockQModelIndex(row, column)
         output = model.data(index, Qt.DisplayRole)
-        model.relevant_data.assert_called_once_with(row)
+        model.relevant_data.assert_called_with(row)
         self.assertEqual(str(mock_data[column]), output)
 
     def test_row_and_column_count(self):
         ws = MockWorkspace()
         model_type = MatrixWorkspaceTableViewModelType.x
-        MatrixWorkspaceTableViewModel(ws, model_type)
+        model = MatrixWorkspaceTableViewModel(ws, model_type)
         # these are called when the TableViewModel is initialised
-        ws.getNumberHistograms.assert_called_once_with()
-        ws.blocksize.assert_called_once_with()
+        ws.getNumberHistograms.assert_called()
+        model.get_max_column_count.assert_called_once()
 
     def test_data_background_role_masked_row(self):
         ws, model, row, index = setup_common_for_test_data()
@@ -119,7 +119,7 @@ class MatrixWorkspaceDisplayTableViewModelTest(unittest.TestCase):
         model.ws_spectrum_info.isMasked.assert_called_once_with(row)
 
         index.row.assert_called_once_with()
-        self.assertFalse(index.column.called)
+        index.column.assert_called_once_with()
 
         self.assertEqual(model.masked_color, output)
 
@@ -148,8 +148,8 @@ class MatrixWorkspaceDisplayTableViewModelTest(unittest.TestCase):
         model.ws_spectrum_info.isMasked.assert_called_once_with(row)
         model.ws_spectrum_info.isMonitor.assert_called_once_with(row)
 
-        index.row.assert_called_once_with()
-        self.assertFalse(index.column.called)
+        index.row.assert_called_once()
+        index.column.assert_called_once()
 
         self.assertEqual(model.monitor_color, output)
 
@@ -183,8 +183,8 @@ class MatrixWorkspaceDisplayTableViewModelTest(unittest.TestCase):
         ws.hasMaskedBins.assert_called_once_with(row)
         ws.maskedBinsIndices.assert_called_once_with(row)
 
-        index.row.assert_called_once_with()
-        index.column.assert_called_once_with()
+        index.row.assert_called_once()
+        index.column.assert_called_once()
 
         self.assertEqual(model.masked_color, output)
         # Just do it a second time -> This time it's cached and should be read off the cache.
@@ -221,7 +221,7 @@ class MatrixWorkspaceDisplayTableViewModelTest(unittest.TestCase):
         model.ws_spectrum_info.isMasked.assert_called_once_with(row)
         model.ws_spectrum_info.isMonitor.assert_called_once_with(row)
 
-        self.assertEqual(MatrixWorkspaceTableViewModel.MASKED_ROW_STRING, output)
+        self.assertEqual(MatrixWorkspaceTableViewModel.MASKED_ROW_TOOLTIP, output)
 
         output = model.data(index, Qt.ToolTipRole)
 
@@ -232,7 +232,7 @@ class MatrixWorkspaceDisplayTableViewModelTest(unittest.TestCase):
         self.assertEqual(3, model.ws_spectrum_info.hasDetectors.call_count)
         self.assertEqual(2, model.ws_spectrum_info.isMonitor.call_count)
 
-        self.assertEqual(MatrixWorkspaceTableViewModel.MASKED_ROW_STRING, output)
+        self.assertEqual(MatrixWorkspaceTableViewModel.MASKED_ROW_TOOLTIP, output)
 
     def test_data_tooltip_role_masked_monitor_row(self):
         if not qtpy.PYQT5:
@@ -248,7 +248,7 @@ class MatrixWorkspaceDisplayTableViewModelTest(unittest.TestCase):
         model.ws_spectrum_info.isMasked.assert_called_once_with(row)
         model.ws_spectrum_info.isMonitor.assert_called_once_with(row)
 
-        self.assertEqual(MatrixWorkspaceTableViewModel.MASKED_MONITOR_ROW_STRING, output)
+        self.assertEqual(MatrixWorkspaceTableViewModel.MASKED_MONITOR_ROW_TOOLTIP, output)
 
         # Doing the same thing a second time should hit the cache, so no additional calls will have been made
         output = model.data(index, Qt.ToolTipRole)
@@ -256,7 +256,7 @@ class MatrixWorkspaceDisplayTableViewModelTest(unittest.TestCase):
         model.ws_spectrum_info.isMasked.assert_called_once_with(row)
         model.ws_spectrum_info.isMonitor.assert_called_once_with(row)
 
-        self.assertEqual(MatrixWorkspaceTableViewModel.MASKED_MONITOR_ROW_STRING, output)
+        self.assertEqual(MatrixWorkspaceTableViewModel.MASKED_MONITOR_ROW_TOOLTIP, output)
 
     def test_data_tooltip_role_monitor_row(self):
         if not qtpy.PYQT5:
@@ -275,7 +275,7 @@ class MatrixWorkspaceDisplayTableViewModelTest(unittest.TestCase):
         model.ws_spectrum_info.isMasked.assert_called_once_with(row)
         model.ws_spectrum_info.isMonitor.assert_called_once_with(row)
 
-        self.assertEqual(MatrixWorkspaceTableViewModel.MONITOR_ROW_STRING, output)
+        self.assertEqual(MatrixWorkspaceTableViewModel.MONITOR_ROW_TOOLTIP, output)
 
         # Doing the same thing a second time should hit the cache, so no additional calls will have been made
         output = model.data(index, Qt.ToolTipRole)
@@ -284,7 +284,7 @@ class MatrixWorkspaceDisplayTableViewModelTest(unittest.TestCase):
         # This was called only once because the monitor was cached
         model.ws_spectrum_info.isMonitor.assert_called_once_with(row)
 
-        self.assertEqual(MatrixWorkspaceTableViewModel.MONITOR_ROW_STRING, output)
+        self.assertEqual(MatrixWorkspaceTableViewModel.MONITOR_ROW_TOOLTIP, output)
 
     def test_data_tooltip_role_masked_bin_in_monitor_row(self):
         if not qtpy.PYQT5:
@@ -304,7 +304,7 @@ class MatrixWorkspaceDisplayTableViewModelTest(unittest.TestCase):
         model.ws_spectrum_info.isMonitor.assert_called_once_with(row)
 
         self.assertEqual(
-            MatrixWorkspaceTableViewModel.MONITOR_ROW_STRING + MatrixWorkspaceTableViewModel.MASKED_BIN_STRING, output)
+            MatrixWorkspaceTableViewModel.MONITOR_ROW_TOOLTIP + MatrixWorkspaceTableViewModel.MASKED_BIN_TOOLTIP, output)
 
         # Doing the same thing a second time should hit the cache, so no additional calls will have been made
         output = model.data(index, Qt.ToolTipRole)
@@ -314,7 +314,7 @@ class MatrixWorkspaceDisplayTableViewModelTest(unittest.TestCase):
         model.ws_spectrum_info.isMonitor.assert_called_once_with(row)
 
         self.assertEqual(
-            MatrixWorkspaceTableViewModel.MONITOR_ROW_STRING + MatrixWorkspaceTableViewModel.MASKED_BIN_STRING, output)
+            MatrixWorkspaceTableViewModel.MONITOR_ROW_TOOLTIP + MatrixWorkspaceTableViewModel.MASKED_BIN_TOOLTIP, output)
 
     def test_data_tooltip_role_masked_bin(self):
         if not qtpy.PYQT5:
@@ -333,7 +333,7 @@ class MatrixWorkspaceDisplayTableViewModelTest(unittest.TestCase):
         model.ws_spectrum_info.isMasked.assert_called_once_with(row)
         model.ws_spectrum_info.isMonitor.assert_called_once_with(row)
 
-        self.assertEqual(MatrixWorkspaceTableViewModel.MASKED_BIN_STRING, output)
+        self.assertEqual(MatrixWorkspaceTableViewModel.MASKED_BIN_TOOLTIP, output)
 
         # Doing the same thing a second time should hit the cache, so no additional calls will have been made
         output = model.data(index, Qt.ToolTipRole)
@@ -344,7 +344,7 @@ class MatrixWorkspaceDisplayTableViewModelTest(unittest.TestCase):
         ws.hasMaskedBins.assert_called_once_with(row)
         ws.maskedBinsIndices.assert_called_once_with(row)
 
-        self.assertEqual(MatrixWorkspaceTableViewModel.MASKED_BIN_STRING, output)
+        self.assertEqual(MatrixWorkspaceTableViewModel.MASKED_BIN_TOOLTIP, output)
 
     def test_headerData_not_display_or_tooltip(self):
         if not qtpy.PYQT5:

--- a/qt/python/mantidqt/widgets/workspacedisplay/test/test_workspacedisplay_view.py
+++ b/qt/python/mantidqt/widgets/workspacedisplay/test/test_workspacedisplay_view.py
@@ -1,0 +1,71 @@
+# Mantid Repository : https://github.com/mantidproject/mantid
+#
+# Copyright &copy; 2020 ISIS Rutherford Appleton Laboratory UKRI,
+#   NScD Oak Ridge National Laboratory, European Spallation Source,
+#   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+# SPDX - License - Identifier: GPL - 3.0 +
+#  This file is part of the mantid workbench.
+import unittest
+
+from mantid.api import AnalysisDataService
+from mantid.simpleapi import ConjoinWorkspaces, CreateWorkspace
+from mantidqt.utils.qt.testing import start_qapplication
+from mantidqt.utils.qt.testing.qt_widget_finder import QtWidgetFinder
+from mantidqt.widgets.workspacedisplay.matrix.presenter import MatrixWorkspaceDisplay
+
+from qtpy.QtWidgets import QApplication
+
+
+def create_test_workspace(workspace_name, number_of_spectra=2, ragged=False):
+    workspace = CreateWorkspace([0, 1, 2, 3, 4, 2, 3, 4, 5, 6], [0, 1, 2, 3, 4, 3, 4, 5, 6, 7], NSpec=number_of_spectra)
+    AnalysisDataService.addOrReplace(workspace_name, workspace)
+    if ragged:
+        for j in range(number_of_spectra):
+            x, y = [], []
+            k = 0
+            for v in workspace.readX(j):
+                if 1 <= v <= 6:
+                    x.append(v)
+                    y.append(workspace.readY(j)[k])
+                k += 1
+            tmp = CreateWorkspace(x, y)
+            ConjoinWorkspaces(workspace_name, tmp, CheckOverlapping=False)
+    return workspace
+
+
+@start_qapplication
+class WorkspaceDisplayViewTest(unittest.TestCase, QtWidgetFinder):
+    @classmethod
+    def setUpClass(cls):
+        cls.normal_workspace = create_test_workspace("normal")
+        cls.ragged_workspace = create_test_workspace("ragged", ragged=True)
+
+    @classmethod
+    def tearDownClass(cls):
+        AnalysisDataService.clear()
+
+    def test_that_the_workspace_display_opens_and_closes_ok_with_a_normal_workspace(self):
+        presenter = MatrixWorkspaceDisplay(self.normal_workspace)
+        presenter.show_view()
+        self.assert_widget_created()
+
+        presenter.container.close()
+
+        QApplication.sendPostedEvents()
+
+        self.assert_no_toplevel_widgets()
+
+    def test_that_the_workspace_display_opens_and_closes_ok_with_a_ragged_workspace(self):
+        presenter = MatrixWorkspaceDisplay(self.ragged_workspace)
+        presenter.show_view()
+        self.assert_widget_created()
+
+        presenter.container.close()
+
+        QApplication.sendPostedEvents()
+
+        self.assert_no_toplevel_widgets()
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/qt/python/mantidqt/widgets/workspacedisplay/test/test_workspacedisplay_view.py
+++ b/qt/python/mantidqt/widgets/workspacedisplay/test/test_workspacedisplay_view.py
@@ -16,21 +16,15 @@ from mantidqt.widgets.workspacedisplay.matrix.presenter import MatrixWorkspaceDi
 from qtpy.QtWidgets import QApplication
 
 
-def create_test_workspace(workspace_name, number_of_spectra=2, ragged=False):
-    workspace = CreateWorkspace([0, 1, 2, 3, 4, 2, 3, 4, 5, 6], [0, 1, 2, 3, 4, 3, 4, 5, 6, 7], NSpec=number_of_spectra)
-    AnalysisDataService.addOrReplace(workspace_name, workspace)
+def create_test_workspace(workspace_name, ragged=False):
+    CreateWorkspace([0, 1, 2, 3, 4, 2, 3, 4, 5, 6], [0, 1, 2, 3, 4, 3, 4, 5, 6, 7], NSpec=2,
+                    OutputWorkspace=workspace_name)
     if ragged:
-        for j in range(number_of_spectra):
-            x, y = [], []
-            k = 0
-            for v in workspace.readX(j):
-                if 1 <= v <= 6:
-                    x.append(v)
-                    y.append(workspace.readY(j)[k])
-                k += 1
-            tmp = CreateWorkspace(x, y)
-            ConjoinWorkspaces(workspace_name, tmp, CheckOverlapping=False)
-    return workspace
+        CreateWorkspace([1, 2, 3, 4], [1, 2, 3, 4], NSpec=1, OutputWorkspace='__temp1')
+        CreateWorkspace([2, 3, 4, 5, 6], [3, 4, 5, 6, 7], NSpec=1, OutputWorkspace='__temp2')
+        ConjoinWorkspaces(workspace_name, '__temp1', CheckOverlapping=False)
+        ConjoinWorkspaces(workspace_name, '__temp2', CheckOverlapping=False)
+    return AnalysisDataService.retrieve(workspace_name)
 
 
 @start_qapplication

--- a/qt/python/mantidqt/widgets/workspacedisplay/test/test_workspacedisplay_view.py
+++ b/qt/python/mantidqt/widgets/workspacedisplay/test/test_workspacedisplay_view.py
@@ -31,15 +31,15 @@ def create_test_workspace(workspace_name, ragged=False):
 class WorkspaceDisplayViewTest(unittest.TestCase, QtWidgetFinder):
     @classmethod
     def setUpClass(cls):
-        cls.normal_workspace = create_test_workspace("normal")
+        cls.non_ragged_workspace = create_test_workspace("non-ragged")
         cls.ragged_workspace = create_test_workspace("ragged", ragged=True)
 
     @classmethod
     def tearDownClass(cls):
         AnalysisDataService.clear()
 
-    def test_that_the_workspace_display_opens_and_closes_ok_with_a_normal_workspace(self):
-        presenter = MatrixWorkspaceDisplay(self.normal_workspace)
+    def test_that_the_workspace_display_opens_and_closes_ok_with_a_non_ragged_workspace(self):
+        presenter = MatrixWorkspaceDisplay(self.non_ragged_workspace)
         presenter.show_view()
         self.assert_widget_created()
 


### PR DESCRIPTION
**Description of work.**
This PR allows ragged workspaces to be displayed through `right click`->`Show Data`. It uses blank cells with a grey colour to represent the places where data is ragged.

**To test:**
1. Run this code to create a ragged workspace:
```
ws = CreateWorkspace([0,1,2,3,4,2, 3,4,5,6],[0,1,2,3,4,3,4,5,6,7], NSpec=2)
min = 1
max = 6
for j in range(0,2):
    x =[]
    y =[]
    data = ws.readY(j)
    k=0
    for v in ws.readX(j):
        if v >= min and v<=max:
            x.append(v)
            y.append(data[k])
        k+=1
    tmp = CreateWorkspace(x,y)
    ConjoinWorkspaces(ws, tmp, CheckOverlapping=False)
```
2. Right click the workspace and select `Show Data`. It should look something like this:
![image](https://user-images.githubusercontent.com/40830825/97599629-1e8fe100-1a00-11eb-951d-1bd89a6f44ce.png)

3. Right click the last column and select `Plot Bin`. This should plot a graph containing only the three data points in the bin.

Fixes #29760 

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
