### PR TITLE
Fix Colorfill Plotting for Ragged Workspaces

### DIFF
--- a/Framework/API/inc/MantidAPI/MatrixWorkspace.h
+++ b/Framework/API/inc/MantidAPI/MatrixWorkspace.h
@@ -121,6 +121,9 @@ public:
 
   bool hasGroupedDetectors() const;
 
+  /// Returns true if the workspace is ragged (has differently sized spectra).
+  virtual bool isRaggedWorkspace() const = 0;
+
   /// Get the footprint in memory in bytes.
   size_t getMemorySize() const override;
   virtual size_t getMemorySizeForXAxes() const;

--- a/Framework/API/test/CompositeFunctionTest.h
+++ b/Framework/API/test/CompositeFunctionTest.h
@@ -43,6 +43,8 @@ public:
 
   ~CompositeFunctionTest_MocMatrixWorkspace() override {}
 
+  bool isRaggedWorkspace() const override { return false; }
+
   // Section required for iteration
   /// Returns the number of single indexable items in the workspace
   std::size_t size() const override { return m_spectra.size() * m_blocksize; }

--- a/Framework/Algorithms/test/RebinByTimeBaseTest.h
+++ b/Framework/Algorithms/test/RebinByTimeBaseTest.h
@@ -100,6 +100,7 @@ public:
   MOCK_METHOD0(resetAllXToSingleBin, void());
   MOCK_METHOD0(clearMRU, void());
   MOCK_CONST_METHOD0(clearMRU, void());
+  MOCK_CONST_METHOD0(isRaggedWorkspace, bool());
   MOCK_CONST_METHOD0(blocksize, std::size_t());
   MOCK_CONST_METHOD0(size, std::size_t());
   MOCK_CONST_METHOD0(getNumberHistograms, std::size_t());

--- a/Framework/DataObjects/inc/MantidDataObjects/EventWorkspace.h
+++ b/Framework/DataObjects/inc/MantidDataObjects/EventWorkspace.h
@@ -60,6 +60,9 @@ public:
 
   //------------------------------------------------------------
 
+  /// Returns true if the workspace is ragged (has differently sized spectra).
+  bool isRaggedWorkspace() const override;
+
   // Returns the number of single indexable items in the workspace
   std::size_t size() const override;
 

--- a/Framework/DataObjects/inc/MantidDataObjects/Workspace2D.h
+++ b/Framework/DataObjects/inc/MantidDataObjects/Workspace2D.h
@@ -48,6 +48,9 @@ public:
     return std::unique_ptr<Workspace2D>(doCloneEmpty());
   }
 
+  /// Returns true if the workspace is ragged (has differently sized spectra).
+  bool isRaggedWorkspace() const override;
+
   /// Returns the histogram number
   std::size_t getNumberHistograms() const override;
 

--- a/Framework/DataObjects/inc/MantidDataObjects/WorkspaceSingleValue.h
+++ b/Framework/DataObjects/inc/MantidDataObjects/WorkspaceSingleValue.h
@@ -38,6 +38,10 @@ public:
     return std::unique_ptr<WorkspaceSingleValue>(doCloneEmpty());
   }
   WorkspaceSingleValue &operator=(const WorkspaceSingleValue &other) = delete;
+
+  /// Returns true if the workspace is ragged (has differently sized spectra).
+  bool isRaggedWorkspace() const override { return false; }
+
   /// Returns the number of single indexable items in the workspace
   std::size_t size() const override { return 1; }
 

--- a/Framework/DataObjects/src/EventWorkspace.cpp
+++ b/Framework/DataObjects/src/EventWorkspace.cpp
@@ -136,6 +136,21 @@ void EventWorkspace::init(const HistogramData::Histogram &histogram) {
   m_axes[1] = std::make_unique<API::SpectraAxis>(this);
 }
 
+///  Returns true if the workspace is ragged (has differently sized spectra).
+/// @returns true if the workspace is ragged.
+bool EventWorkspace::isRaggedWorkspace() const {
+  if (data.empty()) {
+    throw std::runtime_error("There are no pixels in the event workspace, "
+                             "therefore cannot determine if it is ragged.");
+  } else {
+    const auto numberOfBins = data[0]->histogram_size();
+    for (const auto &eventList : data)
+      if (numberOfBins != eventList->histogram_size())
+        return true;
+    return false;
+  }
+}
+
 /// The total size of the workspace
 /// @returns the number of single indexable items in the workspace
 size_t EventWorkspace::size() const {

--- a/Framework/DataObjects/src/EventWorkspace.cpp
+++ b/Framework/DataObjects/src/EventWorkspace.cpp
@@ -25,6 +25,7 @@
 #include "MantidKernel/TimeSeriesProperty.h"
 
 #include "tbb/parallel_for.h"
+#include <algorithm>
 #include <limits>
 #include <numeric>
 
@@ -144,10 +145,10 @@ bool EventWorkspace::isRaggedWorkspace() const {
                              "therefore cannot determine if it is ragged.");
   } else {
     const auto numberOfBins = data[0]->histogram_size();
-    for (const auto &eventList : data)
-      if (numberOfBins != eventList->histogram_size())
-        return true;
-    return false;
+    return std::any_of(data.cbegin(), data.cend(),
+                       [&numberOfBins](const auto &eventList) {
+                         return numberOfBins != eventList->histogram_size();
+                       });
   }
 }
 

--- a/Framework/DataObjects/src/Workspace2D.cpp
+++ b/Framework/DataObjects/src/Workspace2D.cpp
@@ -104,6 +104,21 @@ void Workspace2D::init(const HistogramData::Histogram &histogram) {
   m_axes[1] = std::make_unique<API::SpectraAxis>(this);
 }
 
+///  Returns true if the workspace is ragged (has differently sized spectra).
+/// @returns true if the workspace is ragged.
+bool Workspace2D::isRaggedWorkspace() const {
+  if (data.empty()) {
+    throw std::runtime_error("There is no data in the Workspace2D, "
+                             "therefore cannot determine if it is ragged.");
+  } else {
+    const auto numberOfBins = data[0]->size();
+    for (const auto &histogram : data)
+      if (numberOfBins != histogram->size())
+        return true;
+    return false;
+  }
+}
+
 /** Gets the number of histograms
 @return Integer
 */

--- a/Framework/DataObjects/src/Workspace2D.cpp
+++ b/Framework/DataObjects/src/Workspace2D.cpp
@@ -112,10 +112,10 @@ bool Workspace2D::isRaggedWorkspace() const {
                              "therefore cannot determine if it is ragged.");
   } else {
     const auto numberOfBins = data[0]->size();
-    for (const auto &histogram : data)
-      if (numberOfBins != histogram->size())
-        return true;
-    return false;
+    return std::any_of(data.cbegin(), data.cend(),
+                       [&numberOfBins](const auto &histogram) {
+                         return numberOfBins != histogram->size();
+                       });
   }
 }
 

--- a/Framework/DataObjects/test/EventWorkspaceTest.h
+++ b/Framework/DataObjects/test/EventWorkspaceTest.h
@@ -149,11 +149,14 @@ public:
 
   void
   test_that_isRaggedWorkspace_returns_false_for_a_non_ragged_EventWorkspace() {
+    ew = createEventWorkspace(true, false);
+
     TS_ASSERT(!ew->isRaggedWorkspace());
     TS_ASSERT_EQUALS(ew->blocksize(), 1);
   }
 
   void test_that_isRaggedWorkspace_returns_true_for_a_ragged_EventWorkspace() {
+    ew = createEventWorkspace(true, false);
     ew->getSpectrum(0).setHistogram(BinEdges({0., 10., 20.}));
 
     TS_ASSERT(ew->isRaggedWorkspace());

--- a/Framework/DataObjects/test/EventWorkspaceTest.h
+++ b/Framework/DataObjects/test/EventWorkspaceTest.h
@@ -147,6 +147,19 @@ public:
     TS_ASSERT_LESS_THAN_EQUALS(min_memory, ew->getMemorySize());
   }
 
+  void
+  test_that_isRaggedWorkspace_returns_false_for_a_non_ragged_EventWorkspace() {
+    TS_ASSERT(!ew->isRaggedWorkspace());
+    TS_ASSERT_EQUALS(ew->blocksize(), 1);
+  }
+
+  void test_that_isRaggedWorkspace_returns_true_for_a_ragged_EventWorkspace() {
+    ew->getSpectrum(0).setHistogram(BinEdges({0., 10., 20.}));
+
+    TS_ASSERT(ew->isRaggedWorkspace());
+    TS_ASSERT_THROWS(ew->blocksize(), const std::logic_error &);
+  }
+
   void testUnequalBins() {
     ew = createEventWorkspace(true, false);
     // normal behavior

--- a/Framework/DataObjects/test/Workspace2DTest.h
+++ b/Framework/DataObjects/test/Workspace2DTest.h
@@ -80,6 +80,20 @@ public:
     }
   }
 
+  void
+  test_that_isRaggedWorkspace_returns_false_for_a_non_ragged_Workspace2D() {
+    TS_ASSERT(!ws->isRaggedWorkspace());
+    TS_ASSERT_EQUALS(ws->blocksize(), 5);
+  }
+
+  void test_that_isRaggedWorkspace_returns_true_for_a_ragged_Workspace2D() {
+    Workspace2D_sptr cloned(ws->clone());
+    cloned->setHistogram(0, Points(0), Counts(0));
+
+    TS_ASSERT(cloned->isRaggedWorkspace());
+    TS_ASSERT_THROWS(cloned->blocksize(), const std::logic_error &);
+  }
+
   void testUnequalBins() {
     // try normal kind first
     TS_ASSERT_EQUALS(ws->blocksize(), 5);

--- a/Framework/DataObjects/test/WorkspaceSingleValueTest.h
+++ b/Framework/DataObjects/test/WorkspaceSingleValueTest.h
@@ -100,4 +100,9 @@ public:
     TS_ASSERT(wsCastNonConst != nullptr);
     TS_ASSERT_EQUALS(wsCastConst, wsCastNonConst);
   }
+
+  void test_that_isRaggedWorkspace_returns_false_for_a_WorkspaceSingleValue() {
+    WorkspaceSingleValue ws;
+    TS_ASSERT(!ws.isRaggedWorkspace());
+  }
 };

--- a/Framework/PythonInterface/mantid/api/src/Exports/MatrixWorkspace.cpp
+++ b/Framework/PythonInterface/mantid/api/src/Exports/MatrixWorkspace.cpp
@@ -344,6 +344,10 @@ void export_MatrixWorkspace() {
          boost::noncopyable>("MatrixWorkspace", no_init)
       //--------------------------------------- Meta information
       //-----------------------------------------------------------------------
+      .def("isRaggedWorkspace", &MatrixWorkspace::isRaggedWorkspace,
+           arg("self"),
+           "Returns true if the workspace is ragged (has differently sized "
+           "spectra).")
       .def("blocksize", &MatrixWorkspace::blocksize, arg("self"),
            "Returns size of the Y data array")
       .def("getNumberHistograms", &MatrixWorkspace::getNumberHistograms,

--- a/Framework/PythonInterface/mantid/plots/resampling_image/samplingimage.py
+++ b/Framework/PythonInterface/mantid/plots/resampling_image/samplingimage.py
@@ -148,22 +148,8 @@ class SamplingImage(mimage.AxesImage):
         If the workspace is large, or ragged, we skip this maxpooling step and set the option as False
         """
         axis = self.ws.getAxis(1)
-        is_ragged = self._is_workspace_ragged()
-        if self.ws.getNumberHistograms() <= MAX_HISTOGRAMS and axis.isSpectra() and not is_ragged:
-            self._maxpooling = True
-        else:
-            self._maxpooling = False
-
-    def _is_workspace_ragged(self):
-        """
-        Checks to see if the workspace is ragged or not. blocksize will fail if the workspace is ragged.
-        :return: True if the workspace is ragged (i.e. not all spectra have the same length)
-        """
-        try:
-            _ = self.ws.blocksize()
-            return False
-        except RuntimeError:
-            return True
+        self._maxpooling = (self.ws.getNumberHistograms() <= MAX_HISTOGRAMS and axis.isSpectra() and
+                            not self.ws.isRaggedWorkspace())
 
 
 def imshow_sampling(axes,

--- a/Framework/PythonInterface/mantid/plots/resampling_image/samplingimage.py
+++ b/Framework/PythonInterface/mantid/plots/resampling_image/samplingimage.py
@@ -145,13 +145,25 @@ class SamplingImage(mimage.AxesImage):
     def _update_maxpooling_option(self):
         """
         Updates the maxpooling option, used when the image is downsampled
-        If the workspace is large, we skip this maxpooling step and set the option as False
+        If the workspace is large, or ragged, we skip this maxpooling step and set the option as False
         """
         axis = self.ws.getAxis(1)
-        if self.ws.getNumberHistograms() <= MAX_HISTOGRAMS and axis.isSpectra():
+        is_ragged = self._is_workspace_ragged()
+        if self.ws.getNumberHistograms() <= MAX_HISTOGRAMS and axis.isSpectra() and not is_ragged:
             self._maxpooling = True
         else:
             self._maxpooling = False
+
+    def _is_workspace_ragged(self):
+        """
+        Checks to see if the workspace is ragged or not.
+        :return: True if the workspace is ragged (i.e. not all spectra have the same length)
+        """
+        row_length = len(self.ws.readY(0))
+        for i in range(1, self.ws.getNumberHistograms()):
+            if len(self.ws.readY(i)) != row_length:
+                return True
+        return False
 
 
 def imshow_sampling(axes,

--- a/Framework/PythonInterface/mantid/plots/resampling_image/samplingimage.py
+++ b/Framework/PythonInterface/mantid/plots/resampling_image/samplingimage.py
@@ -156,14 +156,14 @@ class SamplingImage(mimage.AxesImage):
 
     def _is_workspace_ragged(self):
         """
-        Checks to see if the workspace is ragged or not.
+        Checks to see if the workspace is ragged or not. blocksize will fail if the workspace is ragged.
         :return: True if the workspace is ragged (i.e. not all spectra have the same length)
         """
-        row_length = len(self.ws.readY(0))
-        for i in range(1, self.ws.getNumberHistograms()):
-            if len(self.ws.readY(i)) != row_length:
-                return True
-        return False
+        try:
+            _ = self.ws.blocksize()
+            return False
+        except RuntimeError:
+            return True
 
 
 def imshow_sampling(axes,

--- a/Framework/PythonInterface/test/python/mantid/plots/axesfunctionsTest.py
+++ b/Framework/PythonInterface/test/python/mantid/plots/axesfunctionsTest.py
@@ -155,6 +155,10 @@ class PlotFunctionsTest(unittest.TestCase):
         funcs.pcolorfast(ax, self.ws2d_point_uneven, vmin=-1)
         funcs.imshow(ax, self.ws2d_histo)
 
+    def test_imshow_works_with_a_ragged_workspace(self):
+        fig, ax = plt.subplots()
+        funcs.imshow(ax, self.ws2d_point_uneven)
+
     def _do_update_colorplot_datalimits(self, color_func):
         fig, ax = plt.subplots()
         mesh = color_func(ax, self.ws2d_histo)

--- a/Framework/TestHelpers/inc/MantidTestHelpers/FakeObjects.h
+++ b/Framework/TestHelpers/inc/MantidTestHelpers/FakeObjects.h
@@ -130,6 +130,19 @@ public:
                               Mantid::Parallel::StorageMode::Cloned)
       : MatrixWorkspace(storageMode), m_spec(0) {}
 
+  bool isRaggedWorkspace() const override {
+    if (m_vec.empty()) {
+      throw std::runtime_error(
+          "Vector data is empty, cannot check for ragged workspace.");
+    } else {
+      auto numberOfBins = m_vec[0].dataY().size();
+      for (const auto &spectrum : m_vec)
+        if (spectrum.dataY().size() != numberOfBins)
+          return true;
+      return false;
+    }
+  }
+
   // Empty overrides of virtual methods
   size_t getNumberHistograms() const override { return m_spec; }
   const std::string id() const override { return "AxeslessWorkspaceTester"; }

--- a/Framework/TestHelpers/inc/MantidTestHelpers/FakeObjects.h
+++ b/Framework/TestHelpers/inc/MantidTestHelpers/FakeObjects.h
@@ -135,11 +135,11 @@ public:
       throw std::runtime_error(
           "Vector data is empty, cannot check for ragged workspace.");
     } else {
-      auto numberOfBins = m_vec[0].dataY().size();
-      for (const auto &spectrum : m_vec)
-        if (spectrum.dataY().size() != numberOfBins)
-          return true;
-      return false;
+      const auto numberOfBins = m_vec[0].dataY().size();
+      return std::any_of(m_vec.cbegin(), m_vec.cend(),
+                         [&numberOfBins](const auto &spectrum) {
+                           return numberOfBins != spectrum.dataY().size();
+                         });
     }
   }
 


### PR DESCRIPTION
~~Merge after #29859~~ 
---------------------

**Description of work.**
This PR fixes a bug where attempting to Plot Colorfill on a ragged workspace causes an error.

**To test:**
1. Run this script to create a ragged workspace
```
ws = CreateWorkspace([0,1,2,3,4,2, 3,4,5,6],[0,1,2,3,4,3,4,5,6,7], NSpec=2)
min = 1
max = 6
for j in range(0,2):
    x =[]
    y =[]
    data = ws.readY(j)
    k=0
    for v in ws.readX(j):
        if v >= min and v<=max:
            x.append(v)
            y.append(data[k])
        k+=1
    tmp = CreateWorkspace(x,y)
    ConjoinWorkspaces(ws, tmp, CheckOverlapping=False)
```
2. Right click the workspace and select `Plot ColorFill`
3. A colorfill plot should appear without an error.

*Release notes are not needed as this is a regression since the last release.*

Fixes #29855 

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
