### PR TITLE
Add LogNorm option to Sliceviewer

### DIFF
--- a/Framework/PythonInterface/mantid/plots/datafunctions.py
+++ b/Framework/PythonInterface/mantid/plots/datafunctions.py
@@ -549,7 +549,7 @@ def _workspace_indices(y_bins, workspace):
 
 def _workspace_indices_maxpooling(y_bins, workspace):
     from mantid.simpleapi import Integration
-    summed_spectra_workspace = Integration(workspace)
+    summed_spectra_workspace = Integration(workspace, StoreInADS=False)
     summed_spectra = summed_spectra_workspace.extractY()
     workspace_indices = []
     for y_range in pairwise(y_bins):

--- a/docs/source/release/v6.0.0/mantidworkbench.rst
+++ b/docs/source/release/v6.0.0/mantidworkbench.rst
@@ -10,6 +10,7 @@ New Features
 
 - Added a colorbar scale option to the workbench plot settings. This allows the user to choose between a linear (default) or logarithmic scale.
 - Added a show legend checkbox to the workbench plot settings. This allows users to choose whether to display the legend on graphs by default.
+- Added a ``Log`` colorbar scale option to the Sliceviewer. This differs from the existing ``Symlog`` option as it prohibits negative values.
 
 Improvements
 ############

--- a/qt/python/mantidqt/widgets/sliceviewer/test/test_sliceviewer_view.py
+++ b/qt/python/mantidqt/widgets/sliceviewer/test/test_sliceviewer_view.py
@@ -8,6 +8,9 @@
 import unittest
 
 import matplotlib as mpl
+
+from mantidqt.widgets.colorbar.colorbar import MIN_LOG_VALUE
+
 mpl.use('Agg')  # noqa
 from mantid.simpleapi import (CreateMDHistoWorkspace, CreateMDWorkspace, CreateSampleWorkspace,
                               SetUB)
@@ -16,6 +19,7 @@ from mantidqt.utils.qt.testing.qt_widget_finder import QtWidgetFinder
 from mantidqt.widgets.sliceviewer.presenter import SliceViewer
 from mantidqt.widgets.sliceviewer.toolbar import ToolItemText
 from qtpy.QtWidgets import QApplication
+from math import inf
 
 
 @start_qapplication
@@ -82,6 +86,35 @@ class SliceViewerViewTest(unittest.TestCase, QtWidgetFinder):
 
         self.assertFalse(line_plots_action.isChecked())
         self.assertFalse(region_sel_action.isChecked())
+
+        pres.view.close()
+
+    def test_clim_edits_prevent_negative_values_if_lognorm(self):
+        pres = SliceViewer(self.histo_ws)
+        colorbar = pres.view.data_view.colorbar
+        colorbar.autoscale.setChecked(False)
+        colorbar.norm.setCurrentText("Log")
+        prev_bottom_limit = colorbar.cmin.text()
+        prev_top_limit = colorbar.cmax.text()
+
+        colorbar.cmin.textChanged.emit(str(-10))
+        colorbar.cmax.textChanged.emit(str(-5))
+
+        self.assertEqual(colorbar.cmin.text(), prev_bottom_limit)
+        self.assertEqual(colorbar.cmax.text(), prev_top_limit)
+
+        pres.view.close()
+
+    def test_changing_norm_updates_clim_validators(self):
+        pres = SliceViewer(self.histo_ws)
+        colorbar = pres.view.data_view.colorbar
+        colorbar.autoscale.setChecked(False)
+
+        colorbar.norm.setCurrentText("Log")
+        self.assertEqual(colorbar.cmin.validator().bottom(), MIN_LOG_VALUE)
+
+        colorbar.norm.setCurrentText("Linear")
+        self.assertEqual(colorbar.cmin.validator().bottom(), -inf)
 
         pres.view.close()
 


### PR DESCRIPTION
**Description of work.**
This PR adds a Lognorm scale to sliceviewer. This differs from the existing SymLogNorm as it prohibits negative values.

**To test:**
1. Code review
2. Load some data, e.g that from the linked issue or something with zero/negative values e.g MUSR62260.nxs
3. Change to log scale
4. The colorbar min box should not show anything (<=0) it should also reject any negative or zero inputs.
5. Change to linear scale, you should be able to put any number you want in the colorbar scale boxes


Fixes #27959. <!-- and fix #xxxx or close #xxxx xor resolves #xxxx -->
<!-- alternative
*There is no associated issue.*
-->

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or master)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
