### PR TITLE
Change default EngDiffUI fitting loadpath

### DIFF
--- a/docs/source/release/v6.0.0/diffraction.rst
+++ b/docs/source/release/v6.0.0/diffraction.rst
@@ -35,6 +35,7 @@ New features
 Improvements
 ############
 - :ref:`WANDPowderReduction <algm-WANDPowderReduction>` now accepts a sequence of input workspaces, combining them to reduce to a single spectrum.
+- The default loadpath in the fitting tab of the Engineering Diffraction UI is now set to the most recently focused files.
 
 Bugfixes
 ########

--- a/qt/python/mantidqt/_common.sip
+++ b/qt/python/mantidqt/_common.sip
@@ -984,7 +984,7 @@ public:
     void setFileExtensions(const QStringList &extensions);
     void findFiles(bool isModified);
     void isOptional(bool);
-	void setLastDirectory(const QString &lastDir);
+    void setLastDirectory(const QString &lastDir);
 
 signals:
     void fileTextChanged(const QString & /*_t1*/);

--- a/qt/python/mantidqt/_common.sip
+++ b/qt/python/mantidqt/_common.sip
@@ -984,6 +984,7 @@ public:
     void setFileExtensions(const QStringList &extensions);
     void findFiles(bool isModified);
     void isOptional(bool);
+	void setLastDirectory(const QString &lastDir);
 
 signals:
     void fileTextChanged(const QString & /*_t1*/);

--- a/scripts/Engineering/gui/engineering_diffraction/engineering_diffraction.py
+++ b/scripts/Engineering/gui/engineering_diffraction/engineering_diffraction.py
@@ -111,6 +111,7 @@ class EngineeringDiffractionGui(QtWidgets.QMainWindow, Ui_main_window):
     def setup_fitting(self):
         fitting_view = FittingView()
         self.fitting_presenter = FittingPresenter(fitting_view)
+        self.focus_presenter.add_focus_subscriber(self.fitting_presenter.data_widget.presenter.focus_run_observer)
         self.tabs.addTab(fitting_view, "Fitting")
 
     def setup_calibration_notifier(self):

--- a/scripts/Engineering/gui/engineering_diffraction/tabs/fitting/data_handling/data_presenter.py
+++ b/scripts/Engineering/gui/engineering_diffraction/tabs/fitting/data_handling/data_presenter.py
@@ -41,6 +41,8 @@ class FittingDataPresenter(object):
         self.fit_observer = GenericObserverWithArgPassing(self.fit_completed)
         self.fit_enabled_observer = GenericObserverWithArgPassing(self.set_fit_enabled)
         self.seq_fit_done_observer = GenericObserverWithArgPassing(self.fit_completed)
+        self.focus_run_observer = GenericObserverWithArgPassing(
+            self.view.set_file_last)
 
     def set_fit_enabled(self, fit_enabled):
         self.view.set_seq_fit_button_enabled(fit_enabled)

--- a/scripts/Engineering/gui/engineering_diffraction/tabs/fitting/data_handling/data_view.py
+++ b/scripts/Engineering/gui/engineering_diffraction/tabs/fitting/data_handling/data_view.py
@@ -5,6 +5,7 @@
 #   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
 # SPDX - License - Identifier: GPL - 3.0 +
 from qtpy import QtWidgets, QtCore
+from os import path
 
 from mantidqt.utils.qt import load_ui
 
@@ -63,6 +64,11 @@ class FittingDataView(QtWidgets.QWidget, Ui_data):
     # =================
     # Component Setters
     # =================
+
+    def set_file_last(self, filepath):
+        self.finder_data.setUserInput(filepath)
+        directory, discard = path.split(filepath)
+        self.finder_data.setLastDirectory(directory)
 
     def set_load_button_enabled(self, enabled):
         self.button_load.setEnabled(enabled)

--- a/scripts/Engineering/gui/engineering_diffraction/tabs/focus/model.py
+++ b/scripts/Engineering/gui/engineering_diffraction/tabs/focus/model.py
@@ -19,6 +19,14 @@ FOCUSED_OUTPUT_WORKSPACE_NAME = "engggui_focusing_output_ws_bank_"
 
 
 class FocusModel(object):
+
+    def __init__(self):
+        self._last_path = None
+        self._last_path_ws = None
+
+    def get_last_path(self):
+        return self._last_path
+
     def focus_run(self, sample_paths, banks, plot_output, instrument, rb_num, spectrum_numbers):
         """
         Focus some data using the current calibration.
@@ -53,6 +61,8 @@ class FocusModel(object):
                     workspaces_for_run.append(output_workspace_name)
                     # Save the output to the file system.
                     self._save_output(instrument, sample_path, name, output_workspace_name, rb_num)
+                    if name == banks[0] and sample_path == sample_paths[0]:
+                        self._last_path_ws = (instrument + '_' + run_no + '_bank_' + name + '.nxs')
                 output_workspaces.append(workspaces_for_run)
                 self._output_sample_logs(instrument, run_no, sample_workspace, rb_num)
         else:
@@ -65,6 +75,10 @@ class FocusModel(object):
                 output_workspaces.append([output_workspace_name])
                 self._save_output(instrument, sample_path, "cropped", output_workspace_name, rb_num)
                 self._output_sample_logs(instrument, run_no, sample_workspace, rb_num)
+        if rb_num:
+            self._last_path = path.join(path_handling.get_output_path(), rb_num, 'Focus', str(self._last_path_ws))
+        else:
+            self._last_path = path.join(path_handling.get_output_path(), 'Focus', str(self._last_path_ws))
         # Plot the output
         if plot_output:
             for ws_names in output_workspaces:


### PR DESCRIPTION
**Description of work.**
Add functionality to set the loadpath on the fitting tab to the most recently focused files on the Engineering Diffraction ui.

**To test:**
1. Interfaces -> Diffraction -> Engineering Diffraction
2. In the calibration tab, load a calibration file (see attached)
3. Go to the focus tab, focus a run (e.g. input 305761 with archive search on)
4. This may give a message box while it finds the file, click focus again shortly after when it's found to run the focus
5. Go over the the fitting tab, the file location should be in the path
6. Click browse and make sure the location is the folder in which the focused files are stored
7. Try loading the focused files from the local filesystem

Fixes #29102 . <!-- and fix #xxxx or close #xxxx xor resolves #xxxx -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
