### PR TITLE
Allow PaalmanPingsMCA to use tabulated density values

### DIFF
--- a/Framework/DataHandling/src/SetSample.cpp
+++ b/Framework/DataHandling/src/SetSample.cpp
@@ -1115,7 +1115,7 @@ PropertyManager SetSample::materialSettingsEnsureLegacyCompatibility(
     if (!compatible.existsProperty("NumberDensity")) {
       compatible.declareProperty("NumberDensity", numberDensity);
     } else {
-      compatible.setProperty("NumberDesnity", numberDensity);
+      compatible.setProperty("NumberDensity", numberDensity);
     }
   }
   if (materialArgs.existsProperty("SampleMassDensity")) {

--- a/Framework/Kernel/src/NeutronAtom.cpp
+++ b/Framework/Kernel/src/NeutronAtom.cpp
@@ -93,7 +93,7 @@ NeutronAtom::NeutronAtom(const uint16_t z, const uint16_t a,
  * @param coh_xs :: The coherent neutron cross-section
  * @param inc_xs :: The incoherent neutron cross-section
  * @param tot_xs :: The total neutron cross-section
- * @param abs_xs :: The absolute neutron cross-section
+ * @param abs_xs :: The absorption neutron cross-section
  */
 NeutronAtom::NeutronAtom(const uint16_t z, const uint16_t a,
                          const double coh_b_real, const double coh_b_img,

--- a/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/PaalmanPingsMonteCarloAbsorption.py
+++ b/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/PaalmanPingsMonteCarloAbsorption.py
@@ -306,7 +306,6 @@ class PaalmanPingsMonteCarloAbsorption(DataProcessorAlgorithm):
                              doc='Name of the workspace group to save correction factors')
 
     def PyExec(self):
-
         progess_steps = 1. if not self._container_ws else 0.25
 
         sample_wave_ws = self._convert_to_wavelength(self._sample_ws)
@@ -412,18 +411,21 @@ class PaalmanPingsMonteCarloAbsorption(DataProcessorAlgorithm):
             set_sample_alg.setProperty("Geometry", sample_geometry)
 
             sample_material = dict()
-            if self._set_sample_method == 'Chemical Formula':
-                sample_material['ChemicalFormula'] = self._sample_chemical_formula
-            else:
+            sample_material['ChemicalFormula'] = self._sample_chemical_formula
+
+            if (self._sample_attenuation_cross_section != 0 or self._sample_coherent_cross_section != 0 or
+                    self._sample_incoherent_cross_section != 0):
                 sample_material['CoherentXSection'] = self._sample_coherent_cross_section
                 sample_material['IncoherentXSection'] = self._sample_incoherent_cross_section
                 sample_material['AttenuationXSection'] = self._sample_attenuation_cross_section
                 sample_material['ScatteringXSection'] = self._sample_coherent_cross_section + self._sample_incoherent_cross_section
 
             if self._sample_density_type == 'Mass Density':
-                sample_material['SampleMassDensity'] = self._sample_density
+                if self._sample_density != 0:
+                    sample_material['SampleMassDensity'] = self._sample_density
             if self._sample_density_type == 'Number Density':
-                sample_material['SampleNumberDensity'] = self._sample_density
+                if self._sample_density != 0:
+                    sample_material['SampleNumberDensity'] = self._sample_density
                 sample_material['NumberDensityUnit'] = self._sample_number_density_unit
             set_sample_alg.setProperty("Material", sample_material)
 
@@ -462,9 +464,10 @@ class PaalmanPingsMonteCarloAbsorption(DataProcessorAlgorithm):
                 set_sample_alg.setProperty("ContainerGeometry", container_geometry)
 
             container_material = dict()
-            if self._set_can_method == 'Chemical Formula':
-                container_material['ChemicalFormula'] = self._container_chemical_formula
-            else:
+            container_material['ChemicalFormula'] = self._container_chemical_formula
+
+            if (self._container_attenuation_cross_section != 0 or self._container_coherent_cross_section != 0 or
+                    self._container_incoherent_cross_section != 0):
                 container_material['CoherentXSection'] = self._container_coherent_cross_section
                 container_material['IncoherentXSection'] = self._container_incoherent_cross_section
                 container_material['AttenuationXSection'] = self._container_attenuation_cross_section
@@ -472,9 +475,11 @@ class PaalmanPingsMonteCarloAbsorption(DataProcessorAlgorithm):
                     'ScatteringXSection'] = self._container_coherent_cross_section + self._container_incoherent_cross_section
 
             if self._container_density_type == 'Mass Density':
-                container_material['SampleMassDensity'] = self._container_density
+                if self._container_density != 0:
+                    container_material['SampleMassDensity'] = self._container_density
             if self._container_density_type == 'Number Density':
-                container_material['SampleNumberDensity'] = self._container_density
+                if self._container_density != 0:
+                    container_material['SampleNumberDensity'] = self._container_density
                 container_material['NumberDensityUnit'] = self._container_number_density_unit
 
             if can_as_sample:

--- a/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/PaalmanPingsMonteCarloAbsorption.py
+++ b/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/PaalmanPingsMonteCarloAbsorption.py
@@ -410,23 +410,7 @@ class PaalmanPingsMonteCarloAbsorption(DataProcessorAlgorithm):
 
             set_sample_alg.setProperty("Geometry", sample_geometry)
 
-            sample_material = dict()
-            sample_material['ChemicalFormula'] = self._sample_chemical_formula
-
-            if (self._sample_attenuation_cross_section != 0 or self._sample_coherent_cross_section != 0
-                    or self._sample_incoherent_cross_section != 0):
-                sample_material['CoherentXSection'] = self._sample_coherent_cross_section
-                sample_material['IncoherentXSection'] = self._sample_incoherent_cross_section
-                sample_material['AttenuationXSection'] = self._sample_attenuation_cross_section
-                sample_material['ScatteringXSection'] = self._sample_coherent_cross_section + self._sample_incoherent_cross_section
-
-            if self._sample_density_type == 'Mass Density':
-                if self._sample_density != 0:
-                    sample_material['SampleMassDensity'] = self._sample_density
-            if self._sample_density_type == 'Number Density':
-                if self._sample_density != 0:
-                    sample_material['SampleNumberDensity'] = self._sample_density
-                sample_material['NumberDensityUnit'] = self._sample_number_density_unit
+            sample_material = self._set_material('sample')
             set_sample_alg.setProperty("Material", sample_material)
 
         if 'Container' in components:
@@ -463,37 +447,35 @@ class PaalmanPingsMonteCarloAbsorption(DataProcessorAlgorithm):
             else:
                 set_sample_alg.setProperty("ContainerGeometry", container_geometry)
 
-            container_material = self._set_container_material()
+            container_material = self._set_material('container')
 
             if can_as_sample:
                 set_sample_alg.setProperty("Material", container_material)
             else:
                 set_sample_alg.setProperty("ContainerMaterial", container_material)
-
         set_sample_alg.execute()
 
-    def _set_container_material(self):
-        container_material = dict()
+    def _set_material(self, name):
+        def get_attribute(attr_name):
+            return getattr(self, "_" + name + "_" + attr_name)
+        material_dict = dict()
+        material_dict['ChemicalFormula'] = get_attribute('chemical_formula')
+        if (get_attribute('attenuation_cross_section') != 0 or get_attribute('coherent_cross_section') != 0
+                or get_attribute('incoherent_cross_section') != 0):
+            material_dict['CoherentXSection'] = get_attribute('coherent_cross_section')
+            material_dict['IncoherentXSection'] = get_attribute('incoherent_cross_section')
+            material_dict['AttenuationXSection'] = get_attribute('attenuation_cross_section')
+            material_dict['ScatteringXSection'] = get_attribute('coherent_cross_section') \
+                + get_attribute('incoherent_cross_section')
 
-        container_material['ChemicalFormula'] = self._container_chemical_formula
+        if get_attribute('density_type') == 'Mass Density' and get_attribute('density') != 0:
+            material_dict['SampleMassDensity'] = get_attribute('density')
+        if get_attribute('density_type') == 'Number Density':
+            if get_attribute('density') != 0:
+                material_dict['SampleNumberDensity'] = get_attribute('density')
+            material_dict['NumberDensityUnit'] = get_attribute('number_density_unit')
 
-        if (self._container_attenuation_cross_section != 0 or self._container_coherent_cross_section != 0
-                or self._container_incoherent_cross_section != 0):
-            container_material['CoherentXSection'] = self._container_coherent_cross_section
-            container_material['IncoherentXSection'] = self._container_incoherent_cross_section
-            container_material['AttenuationXSection'] = self._container_attenuation_cross_section
-            container_material[
-                'ScatteringXSection'] = self._container_coherent_cross_section + self._container_incoherent_cross_section
-
-        if self._container_density_type == 'Mass Density':
-            if self._container_density != 0:
-                container_material['SampleMassDensity'] = self._container_density
-        if self._container_density_type == 'Number Density':
-            if self._container_density != 0:
-                container_material['SampleNumberDensity'] = self._container_density
-            container_material['NumberDensityUnit'] = self._container_number_density_unit
-
-        return container_material
+        return material_dict
 
     def _setup(self):
 

--- a/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/PaalmanPingsMonteCarloAbsorption.py
+++ b/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/PaalmanPingsMonteCarloAbsorption.py
@@ -413,8 +413,8 @@ class PaalmanPingsMonteCarloAbsorption(DataProcessorAlgorithm):
             sample_material = dict()
             sample_material['ChemicalFormula'] = self._sample_chemical_formula
 
-            if (self._sample_attenuation_cross_section != 0 or self._sample_coherent_cross_section != 0 or
-                    self._sample_incoherent_cross_section != 0):
+            if (self._sample_attenuation_cross_section != 0 or self._sample_coherent_cross_section != 0
+                    or self._sample_incoherent_cross_section != 0):
                 sample_material['CoherentXSection'] = self._sample_coherent_cross_section
                 sample_material['IncoherentXSection'] = self._sample_incoherent_cross_section
                 sample_material['AttenuationXSection'] = self._sample_attenuation_cross_section
@@ -463,24 +463,7 @@ class PaalmanPingsMonteCarloAbsorption(DataProcessorAlgorithm):
             else:
                 set_sample_alg.setProperty("ContainerGeometry", container_geometry)
 
-            container_material = dict()
-            container_material['ChemicalFormula'] = self._container_chemical_formula
-
-            if (self._container_attenuation_cross_section != 0 or self._container_coherent_cross_section != 0 or
-                    self._container_incoherent_cross_section != 0):
-                container_material['CoherentXSection'] = self._container_coherent_cross_section
-                container_material['IncoherentXSection'] = self._container_incoherent_cross_section
-                container_material['AttenuationXSection'] = self._container_attenuation_cross_section
-                container_material[
-                    'ScatteringXSection'] = self._container_coherent_cross_section + self._container_incoherent_cross_section
-
-            if self._container_density_type == 'Mass Density':
-                if self._container_density != 0:
-                    container_material['SampleMassDensity'] = self._container_density
-            if self._container_density_type == 'Number Density':
-                if self._container_density != 0:
-                    container_material['SampleNumberDensity'] = self._container_density
-                container_material['NumberDensityUnit'] = self._container_number_density_unit
+            container_material = self._set_container_material()
 
             if can_as_sample:
                 set_sample_alg.setProperty("Material", container_material)
@@ -488,6 +471,29 @@ class PaalmanPingsMonteCarloAbsorption(DataProcessorAlgorithm):
                 set_sample_alg.setProperty("ContainerMaterial", container_material)
 
         set_sample_alg.execute()
+
+    def _set_container_material(self):
+        container_material = dict()
+
+        container_material['ChemicalFormula'] = self._container_chemical_formula
+
+        if (self._container_attenuation_cross_section != 0 or self._container_coherent_cross_section != 0
+                or self._container_incoherent_cross_section != 0):
+            container_material['CoherentXSection'] = self._container_coherent_cross_section
+            container_material['IncoherentXSection'] = self._container_incoherent_cross_section
+            container_material['AttenuationXSection'] = self._container_attenuation_cross_section
+            container_material[
+                'ScatteringXSection'] = self._container_coherent_cross_section + self._container_incoherent_cross_section
+
+        if self._container_density_type == 'Mass Density':
+            if self._container_density != 0:
+                container_material['SampleMassDensity'] = self._container_density
+        if self._container_density_type == 'Number Density':
+            if self._container_density != 0:
+                container_material['SampleNumberDensity'] = self._container_density
+            container_material['NumberDensityUnit'] = self._container_number_density_unit
+
+        return container_material
 
     def _setup(self):
 

--- a/docs/source/release/v6.0.0/diffraction.rst
+++ b/docs/source/release/v6.0.0/diffraction.rst
@@ -19,6 +19,7 @@ Bugfixes
 
 Engineering Diffraction
 -----------------------
+- PaalmanPingsMonteCarloAbsorption can now use tabulated density values, and allows for overridden X Sections
 
 Single Crystal Diffraction
 --------------------------


### PR DESCRIPTION
**Description of work.**
Previously, leaving the default value for density in PaalmanPingsMonteCarloAbsorption would cause 0 to be used, but now for an elemental sample the density will be looked up from the values stored within Mantid if this field is left blank. Similarly, cross section parameters can now be overridden if an element is supplied, but if left blank will still be looked up/calculated within mantid before the Monte Carlo is run.

**To test:**
1. Load a workspace e.g. PEARL00112777
2. Extract a single spectrum for the algorithm and save separately (optional but this will save **hours**)
3. Run PPMCA on this workspace, using example (unrelated) parameters:
Shape: Cylinder
Height: 5
Radius: 3
Sample Chemical formula: C
All sample X Sections: Blank (0)
Sample Density: Blank (0)
4. Save this workspace so it will not be overridden and is distinguishable
5. Repeat with the following X Sections set:
Coherent: _5.550_
Incoherent: _0.001_
Attenuation: _0.0035_
6. Repeat with the X sections at 0 and density set to _0.10529359453653825_ (tabulated double value)
7. Repeat with both X sections and density set to tabulated values
8. Cross reference all 4 corrections workspaces to make sure they are identical (allowing for slight density accuracy error). This should confirm that the cross section and density data are being correctly referenced if not set, independently.
9. Repeat with XSections and Density set to incorrect values in similar scale to correct data
10. Repeat with params set to any nonsense in a different scale to correct data
11. Make sure these last two produce corrections workspaces very different to the correct ones


Fixes #28957 . <!-- and fix #xxxx or close #xxxx xor resolves #xxxx -->
<!-- alternative
*There is no associated issue.*
-->

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or master)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
