### PR TITLE
Fix up navigation bar in qthelp documentation pages

### DIFF
--- a/docs/CMakeLists.txt
+++ b/docs/CMakeLists.txt
@@ -48,7 +48,7 @@ endif()
 function (add_sphinx_build_target builder math_renderer)
   set(runner ${CMAKE_LIBRARY_OUTPUT_DIRECTORY}/${CMAKE_CFG_INTDIR}/mantidpython$<$<BOOL:${WIN32}>:.bat>)
   set(runner_args "--classic")
-  if(ARGC GREATER 2)  # the target name is last
+  if(ARGC GREATER 2)
     set(target_name ${ARGV2})
   else()
     set(target_name docs-${builder})
@@ -59,6 +59,12 @@ function (add_sphinx_build_target builder math_renderer)
     set(conf_builder ${SPHINX_CONF_DIR}/conf-${builder}.py)
   endif()
 
+  set(sphinx_options ${SPHINX_NOCOLOR} -b ${builder} -d ${DOCTREES_DIR})
+  # add a tag to differentiate between html/qthelp in conf
+  if(ARGC GREATER 3)
+    set(sphinx_options ${sphinx_options} -t ${ARGV3})
+  endif()
+
   add_custom_target(${target_name}
       COMMAND
         ${CMAKE_COMMAND} -E env
@@ -67,7 +73,7 @@ function (add_sphinx_build_target builder math_renderer)
              DOT_EXECUTABLE=${DOT_EXECUTABLE}
              MATH_EXT=${math_renderer}
              ENABLE_PLOTDIRECTIVE=${ENABLE_PLOTDIRECTIVE}
-             ${runner} ${runner_args} -m ${SPHINX_MAIN} ${SPHINX_NOCOLOR} -b ${builder} -d ${DOCTREES_DIR} ${SPHINX_CONF_DIR} ${output_dir}
+             ${runner} ${runner_args} -m ${SPHINX_MAIN} ${sphinx_options} ${SPHINX_CONF_DIR} ${output_dir}
       DEPENDS Framework
               mantidqt
               ${SPHINX_CONF_DIR}/conf.py
@@ -89,7 +95,7 @@ add_sphinx_build_target(doctest "sphinx.ext.mathjax")
 # qthelp if building workbench
 if(DOCS_QTHELP AND ENABLE_WORKBENCH)
   find_package(Qt5 COMPONENTS Help REQUIRED)
-  add_sphinx_build_target(qthelp ${DOCS_MATH_EXT} docs-qtassistant)
+  add_sphinx_build_target(qthelp ${DOCS_MATH_EXT} docs-qtassistant qthelp)
   add_custom_target(docs-qthelp
                       COMMAND Qt5::qcollectiongenerator qthelp/MantidProject.qhcp
                       COMMENT "Compiling Qt help documentation")


### PR DESCRIPTION
**Description of work.**

The navigation bar had ended up with the wrong configuration\settings following recent changes to move the documentation build over to workbench instead of MantidPlot (see screenshot on linked issue). This affected the qthelp (aka qtassistant?) doc pages only.

I've fixed this by reinstating the tag for the qthelp build. The tag is supplied using a -t switch to the sphinx build command.

This tag is read in conf.py and causes and is used to decide whether to use conf-qthelp.py or conf-html.py

I did a build of master on both Windows and Ubuntu and the problem exists on both

**To test:**

Build docs and check the navigation bar in the workbench help pages looks correct

Fixes #29875 .

*This does not require release notes* because **fixes a bug introduced in this release cycle**

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
