### PR TITLE
Clone axis when replacing

### DIFF
--- a/Framework/PythonInterface/mantid/api/src/Exports/MatrixWorkspace.cpp
+++ b/Framework/PythonInterface/mantid/api/src/Exports/MatrixWorkspace.cpp
@@ -250,11 +250,12 @@ std::vector<size_t> maskedBinsIndices(MatrixWorkspace &self, const int i) {
  * Raw Pointer wrapper of replaceAxis to allow it to work with python
  * @param self
  * @param axisIndex :: The index of the axis to replace
- * @param newAxis :: A pointer to the new axis. The class will take ownership.
+ * @param newAxis :: A pointer to the new axis. The class will take ownership of
+ * its clone.
  */
 void pythonReplaceAxis(MatrixWorkspace &self, const std::size_t &axisIndex,
                        Axis *newAxis) {
-  self.replaceAxis(axisIndex, std::unique_ptr<Axis>(newAxis));
+  self.replaceAxis(axisIndex, std::unique_ptr<Axis>(newAxis->clone(&self)));
 }
 
 /**

--- a/Framework/PythonInterface/mantid/api/src/Exports/MatrixWorkspace.cpp
+++ b/Framework/PythonInterface/mantid/api/src/Exports/MatrixWorkspace.cpp
@@ -451,7 +451,8 @@ void export_MatrixWorkspace() {
            "the bin-width.")
       .def("replaceAxis", &pythonReplaceAxis,
            (arg("self"), arg("axisIndex"), arg("newAxis")),
-           "Replaces one of the workspace's axes with the new one provided.")
+           "Replaces one of the workspace's axes with the new one provided. "
+           "The axis is cloned.")
       .def("applyBinEdgesFromAnotherWorkspace",
            &applyBinEdgesFromAnotherWorkspace,
            (arg("self"), arg("ws"), arg("getIndex"), arg("setIndex")),

--- a/Framework/PythonInterface/test/python/mantid/api/MatrixWorkspaceTest.py
+++ b/Framework/PythonInterface/test/python/mantid/api/MatrixWorkspaceTest.py
@@ -12,7 +12,7 @@ from mantid.api import (MatrixWorkspace, MatrixWorkspaceProperty, WorkspacePrope
                         ExperimentInfo, AnalysisDataService, WorkspaceFactory, NumericAxis)
 from mantid.geometry import Detector
 from mantid.kernel import Direction, V3D
-from mantid.simpleapi import CreateSampleWorkspace, Rebin, DeleteWorkspaces
+from mantid.simpleapi import CreateSampleWorkspace, Rebin
 import numpy as np
 
 

--- a/Framework/PythonInterface/test/python/mantid/api/MatrixWorkspaceTest.py
+++ b/Framework/PythonInterface/test/python/mantid/api/MatrixWorkspaceTest.py
@@ -9,10 +9,10 @@ import sys
 import math
 from testhelpers import create_algorithm, run_algorithm, can_be_instantiated, WorkspaceCreationHelper
 from mantid.api import (MatrixWorkspace, MatrixWorkspaceProperty, WorkspaceProperty, Workspace,
-                        ExperimentInfo, AnalysisDataService, WorkspaceFactory)
+                        ExperimentInfo, AnalysisDataService, WorkspaceFactory, NumericAxis)
 from mantid.geometry import Detector
 from mantid.kernel import Direction, V3D
-from mantid.simpleapi import CreateSampleWorkspace, Rebin
+from mantid.simpleapi import CreateSampleWorkspace, Rebin, DeleteWorkspaces
 import numpy as np
 
 
@@ -68,6 +68,18 @@ class MatrixWorkspaceTest(unittest.TestCase):
         self.assertEqual(yunit.caption(), "Spectrum")
         self.assertEqual(str(yunit.symbol()), "")
         self.assertEqual(yunit.unitID(), "Label")
+
+    def test_replace_axis(self):
+        x_axis = NumericAxis.create(1)
+        x_axis.setValue(0, 0)
+        ws1 = WorkspaceCreationHelper.create2DWorkspaceWithFullInstrument(2, 1, False)
+        ws1.replaceAxis(0, x_axis)
+        ws2 = WorkspaceCreationHelper.create2DWorkspaceWithFullInstrument(2, 1, False)
+        ws2.replaceAxis(0, x_axis)
+        try:
+            del ws1, ws2
+        except:
+            self.fail("Segmentation violation when deleting the same axis twice")
 
     def test_detector_retrieval(self):
         det = self._test_ws.getDetector(0)

--- a/docs/source/release/v6.0.0/framework.rst
+++ b/docs/source/release/v6.0.0/framework.rst
@@ -55,6 +55,7 @@ Bugfixes
 ########
 - Error log messages from an EqualBinChecker are now no longer produced when editing python scripts if a workspace is present with unequal bin sizes
 - Warning log messages from the InstrumentValidator are no longer produced when editing some python scripts.
+- A bug is fixed when setting the same axis to multiple workspaces, which would cause a crash when deleting the workspaces.
 
 
 :ref:`Release 6.0.0 <v6.0.0>`


### PR DESCRIPTION
**Description of work.**
It is commonplace in python to set the same axis to different workspaces.
Previously the ownership was transferred to the host, which would cause a hard crash when deleting.
Now the axis is cloned for each workspace.

**To test:**
1) Run this code.
```
from mantid.simpleapi import *
from mantid.api import NumericAxis

x_axis = NumericAxis.create(1)
x_axis.setValue(0, 0) ​

for meas_no in range(2):
    name = 'out_{}'.format(meas_no)
    CreateSampleWorkspace(WorkspaceType='Histogram', Function='One Peak', NumEvents=1, 
        XMin=0, XMax=1, BinWidth=1, OutputWorkspace=name)
    mtd[name].replaceAxis(0, x_axis)
```

2) Delete the created workspaces, this shouldn't cause a crash.

<!-- Instructions for testing. -->

Fixes #29844. <!-- and fix #xxxx or close #xxxx xor resolves #xxxx -->
<!-- alternative
*There is no associated issue.*
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or master)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
