### PR TITLE
Fix labels in bin plots

### DIFF
--- a/Framework/PythonInterface/mantid/plots/axesfunctions.py
+++ b/Framework/PythonInterface/mantid/plots/axesfunctions.py
@@ -113,9 +113,12 @@ def _get_data_for_plot(axes, workspace, kwargs, with_dy=False, with_dx=False):
         workspace_index, distribution, kwargs = get_wksp_index_dist_and_label(
             workspace, axis, **kwargs)
         if axis == MantidAxType.BIN:
-            # Overwrite any user specified xlabel
             axes.set_xlabel("Spectrum")
             x, y, dy, dx = get_bins(workspace, workspace_index, with_dy)
+            vertical_axis = workspace.getAxis(1)
+            if isinstance(vertical_axis, mantid.api.NumericAxis):
+                x = vertical_axis.extractValues()
+                axes.set_xlabel(vertical_axis.getUnit().unitID())
         elif axis == MantidAxType.SPECTRUM:
             x, y, dy, dx = get_spectrum(workspace, workspace_index, normalize_by_bin_width, with_dy,
                                         with_dx)

--- a/Framework/PythonInterface/mantid/plots/axesfunctions.py
+++ b/Framework/PythonInterface/mantid/plots/axesfunctions.py
@@ -113,12 +113,16 @@ def _get_data_for_plot(axes, workspace, kwargs, with_dy=False, with_dx=False):
         workspace_index, distribution, kwargs = get_wksp_index_dist_and_label(
             workspace, axis, **kwargs)
         if axis == MantidAxType.BIN:
-            axes.set_xlabel("Spectrum")
             x, y, dy, dx = get_bins(workspace, workspace_index, with_dy)
             vertical_axis = workspace.getAxis(1)
             if isinstance(vertical_axis, mantid.api.NumericAxis):
-                x = vertical_axis.extractValues()
                 axes.set_xlabel(vertical_axis.getUnit().unitID())
+                values = vertical_axis.extractValues()
+                if isinstance(vertical_axis, mantid.api.BinEdgeAxis):
+                    # for bin edge axis we have one more edge than content
+                    values = (values[0:-1] + values[1:])/2.
+                x = values
+
         elif axis == MantidAxType.SPECTRUM:
             x, y, dy, dx = get_spectrum(workspace, workspace_index, normalize_by_bin_width, with_dy,
                                         with_dx)

--- a/Framework/PythonInterface/test/python/mantid/plots/axesfunctionsTest.py
+++ b/Framework/PythonInterface/test/python/mantid/plots/axesfunctionsTest.py
@@ -17,7 +17,7 @@ import mantid.plots.axesfunctions as funcs
 from mantid.plots.utility import MantidAxType
 from mantid.kernel import config
 from mantid.simpleapi import (CreateWorkspace, CreateEmptyTableWorkspace, DeleteWorkspace,
-                              CreateMDHistoWorkspace, ConjoinWorkspaces, AddTimeSeriesLog)
+                              CreateMDHistoWorkspace, ConjoinWorkspaces, AddTimeSeriesLog, CloneWorkspace)
 
 
 class PlotFunctionsTest(unittest.TestCase):
@@ -97,6 +97,29 @@ class PlotFunctionsTest(unittest.TestCase):
         funcs.plot(ax, self.ws2d_histo, 'rs', specNum=1)
         funcs.plot(ax, self.ws2d_histo, specNum=2, linewidth=6)
         funcs.plot(ax, self.ws_MD_1d, 'bo')
+
+    def test_1d_bin(self):
+        fig, ax = plt.subplots()
+        funcs.plot(ax, self.ws2d_histo, 'rs', specNum=1, axis=MantidAxType.BIN)
+
+    def test_1d_bin_numeric_axis(self):
+        fig, ax = plt.subplots()
+        x_axis = mantid.api.NumericAxis.create(2)
+        x_axis.setValue(0,3.)
+        x_axis.setValue(1,5.)
+        ws_local = CloneWorkspace(self.ws2d_histo, StoreInADS=False)
+        ws_local.replaceAxis(1, x_axis)
+        funcs.plot(ax, ws_local, 'rs', specNum=1, axis=MantidAxType.BIN)
+
+    def test_1d_bin_binedge_axis(self):
+        fig, ax = plt.subplots()
+        x_axis = mantid.api.BinEdgeAxis.create(3)
+        x_axis.setValue(0,3.)
+        x_axis.setValue(1,5.)
+        x_axis.setValue(2,7.)
+        ws_local = CloneWorkspace(self.ws2d_histo, StoreInADS=False)
+        ws_local.replaceAxis(1, x_axis)
+        funcs.plot(ax, ws_local, 'rs', specNum=1, axis=MantidAxType.BIN)
 
     def test_1d_log(self):
         fig, ax = plt.subplots()
@@ -196,6 +219,27 @@ class PlotFunctionsTest(unittest.TestCase):
         fig, ax = plt.subplots()
         funcs.plot(ax, self.ws2d_histo_non_dist, 'rs', specNum=1, axis=MantidAxType.BIN)
         self.assertEqual(ax.get_xlabel(), "Spectrum")
+
+    def test_1d_x_axes_label_numeric_axis_bin_plot(self):
+        fig, ax = plt.subplots()
+        x_axis = mantid.api.NumericAxis.create(2)
+        x_axis.setValue(0, 3.)
+        x_axis.setValue(1, 5.)
+        ws_local = CloneWorkspace(self.ws2d_histo_non_dist, StoreInADS=False)
+        ws_local.replaceAxis(1, x_axis)
+        funcs.plot(ax, ws_local, 'rs', specNum=1, axis=MantidAxType.BIN)
+        self.assertEqual(ax.get_xlabel(), "")
+
+    def test_1d_x_axes_label_numeric_axis_with_unit_bin_plot(self):
+        fig, ax = plt.subplots()
+        x_axis = mantid.api.NumericAxis.create(2)
+        x_axis.setValue(0, 3.)
+        x_axis.setValue(1, 5.)
+        x_axis.setUnit('MomentumTransfer')
+        ws_local = CloneWorkspace(self.ws2d_histo_non_dist, StoreInADS=False)
+        ws_local.replaceAxis(1, x_axis)
+        funcs.plot(ax, ws_local, 'rs', specNum=1, axis=MantidAxType.BIN)
+        self.assertEqual(ax.get_xlabel(), "q ($\\AA^{-1}$)")
 
     def test_1d_y_axes_label_auto_distribution_on(self):
         fig, ax = plt.subplots()

--- a/docs/source/release/v6.0.0/framework.rst
+++ b/docs/source/release/v6.0.0/framework.rst
@@ -55,6 +55,6 @@ Bugfixes
 ########
 - Error log messages from an EqualBinChecker are now no longer produced when editing python scripts if a workspace is present with unequal bin sizes
 - Warning log messages from the InstrumentValidator are no longer produced when editing some python scripts.
-
+- A bug has been fixed when plotting bin plots on a workspace with numerical axis.
 
 :ref:`Release 6.0.0 <v6.0.0>`


### PR DESCRIPTION
**Description of work.**
When plotting a bin on a workspace with numerical spectrum axis, it will now get the axes values instead of the spectrum numbers.

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

**To test:**
```
from mantid.simpleapi import CreateSampleWorkspace, ConvertSpectrumAxis
from mantid.api import NumericAxis, BinEdgeAxis

x_axis = NumericAxis.create(200)
be_axis = BinEdgeAxis.create(201)
for i in range(200):
    x_axis.setValue(i, 5*i+7)
    be_axis.setValue(i, 5*i+7)
be_axis.setValue(200, 1007)

ws1 = CreateSampleWorkspace()
ws2 = CreateSampleWorkspace()
ws3 = CreateSampleWorkspace()
ws4 = CreateSampleWorkspace()
ws2.replaceAxis(1, x_axis)
ws3.replaceAxis(1, be_axis)
ws4 = ConvertSpectrumAxis(ws4, Target='Theta')
```
Open the matrix view, select on one of the bin, then right click > plot bin.
Check the x-axis of the resulting plots, which should be as follows:

ws1: spectrum numbers (up to 200) with the label Spectrum.
ws2: the vertical axis values (going up to 1000) with empty label.
ws3: the vertical axis centres (going up to 1000) with empty label.
ws4: the vertical axis values with label Scattering Angle.

<!-- Instructions for testing. -->

Fixes #29882. <!-- and fix #xxxx or close #xxxx xor resolves #xxxx -->
<!-- alternative
*There is no associated issue.*
-->

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or master)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
