### PR TITLE
Minor Improvements To Plot In ALC Data Loading

### DIFF
--- a/docs/source/release/v6.0.0/muon.rst
+++ b/docs/source/release/v6.0.0/muon.rst
@@ -5,20 +5,49 @@ MuSR Changes
 .. contents:: Table of Contents
    :local:
 
+   
 .. warning:: **Developers:** Sort changes under appropriate heading
     putting new features at the top of the section, followed by
     improvements, followed by bug fixes.
 
-Bug Fixes
-#########
-- A bug on the Muon Analysis interface where ties and constraints were not being respected has been fixed.
+Muon Analysis 2 and Frequency Domain Analysis
+---------------------------------------------
 
-:ref:`Release 6.0.0 <v6.0.0>`
+New Features
+############
+
+Improvements
+############
+
+Bug fixes
+#########
+- Fixed a bug where ties and constraints were not being respected.
+
+ALC
+---
+
+New Features
+############
+
+Improvements
+############
+- Added an x label to the plot in data loading
+
+Bug fixes
+##########
+- Stopped scientific notation when plotting run numbers on x axis
+
+Elemental Analysis 
+------------------
+
+New Features
+############
+
+Bug fixes
+#########
 
 Algorithms
 ----------
-
-New Algorithms
-##############
-
 - :ref:`algm-LoadElementalAnalysisData` algorithm was introduced for loading runs for the new Elemental Analysis GUI, enabling it to be registered by WorkspaceHistory.
+
+:ref:`Release 6.0.0 <v6.0.0>`

--- a/qt/scientific_interfaces/Muon/ALCDataLoadingView.cpp
+++ b/qt/scientific_interfaces/Muon/ALCDataLoadingView.cpp
@@ -176,9 +176,9 @@ void ALCDataLoadingView::setDataCurve(MatrixWorkspace_sptr workspace,
   m_ui.dataPlot->setOverrideAxisLabel(MantidQt::MantidWidgets::AxisID::XBottom, _log.c_str());
   // If x scale is run number, ensure plain format
   if (log() == "run_number")
-    m_ui.dataPlot->setStyleTickLabels("x", "plain", false);
+    m_ui.dataPlot->tickLabelFormat("x", "plain", false);
   else
-    m_ui.dataPlot->setStyleTickLabels("x", "sci", true);
+    m_ui.dataPlot->tickLabelFormat("x", "sci", true);
 
   m_ui.dataPlot->addSpectrum("Data", workspace, workspaceIndex, Qt::black,
                              kwargs);

--- a/qt/scientific_interfaces/Muon/ALCDataLoadingView.cpp
+++ b/qt/scientific_interfaces/Muon/ALCDataLoadingView.cpp
@@ -173,7 +173,8 @@ void ALCDataLoadingView::setDataCurve(MatrixWorkspace_sptr workspace,
 
   m_ui.dataPlot->clear();
   auto _log = log();
-  m_ui.dataPlot->setOverrideAxisLabel(MantidQt::MantidWidgets::AxisID::XBottom, _log.c_str());
+  m_ui.dataPlot->setOverrideAxisLabel(MantidQt::MantidWidgets::AxisID::XBottom,
+                                      _log.c_str());
   // If x scale is run number, ensure plain format
   if (log() == "run_number")
     m_ui.dataPlot->tickLabelFormat("x", "plain", false);

--- a/qt/scientific_interfaces/Muon/ALCDataLoadingView.cpp
+++ b/qt/scientific_interfaces/Muon/ALCDataLoadingView.cpp
@@ -172,6 +172,12 @@ void ALCDataLoadingView::setDataCurve(MatrixWorkspace_sptr workspace,
 #endif
 
   m_ui.dataPlot->clear();
+  auto _log = log();
+  m_ui.dataPlot->setOverrideAxisLabel(MantidQt::MantidWidgets::AxisID::XBottom, _log.c_str());
+  // If x scale is run number, ensure plain format
+  if (log() == "run_number")
+    m_ui.dataPlot->styleTickLabels("x", "plain", false);
+
   m_ui.dataPlot->addSpectrum("Data", workspace, workspaceIndex, Qt::black,
                              kwargs);
 }

--- a/qt/scientific_interfaces/Muon/ALCDataLoadingView.cpp
+++ b/qt/scientific_interfaces/Muon/ALCDataLoadingView.cpp
@@ -176,7 +176,9 @@ void ALCDataLoadingView::setDataCurve(MatrixWorkspace_sptr workspace,
   m_ui.dataPlot->setOverrideAxisLabel(MantidQt::MantidWidgets::AxisID::XBottom, _log.c_str());
   // If x scale is run number, ensure plain format
   if (log() == "run_number")
-    m_ui.dataPlot->styleTickLabels("x", "plain", false);
+    m_ui.dataPlot->setStyleTickLabels("x", "plain", false);
+  else
+    m_ui.dataPlot->setStyleTickLabels("x", "sci", true);
 
   m_ui.dataPlot->addSpectrum("Data", workspace, workspaceIndex, Qt::black,
                              kwargs);

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/Python/Object.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/Python/Object.h
@@ -25,12 +25,9 @@ namespace Widgets {
 namespace Common {
 namespace Python {
 
-// Alias for boost python object wrapper
+// Alias for boost python object/dict/list wrapper
 using Object = boost::python::object;
-
-// Alias for boost python dict wrapper
 using Dict = boost::python::dict;
-
 using List = boost::python::list;
 
 // Alias for handle wrapping a raw PyObject*

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/Python/Object.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/Python/Object.h
@@ -11,6 +11,7 @@
 #include <boost/python/borrowed.hpp>
 #include <boost/python/dict.hpp>
 #include <boost/python/object.hpp>
+#include <boost/python/list.hpp>
 
 /**
  * The intetion of this module is to centralize the access
@@ -29,6 +30,8 @@ using Object = boost::python::object;
 
 // Alias for boost python dict wrapper
 using Dict = boost::python::dict;
+
+using List = boost::python::list;
 
 // Alias for handle wrapping a raw PyObject*
 template <typename T = PyObject> using Handle = boost::python::handle<T>;

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/Python/Object.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/Python/Object.h
@@ -10,8 +10,8 @@
 #include "MantidPythonInterface/core/GlobalInterpreterLock.h"
 #include <boost/python/borrowed.hpp>
 #include <boost/python/dict.hpp>
-#include <boost/python/object.hpp>
 #include <boost/python/list.hpp>
+#include <boost/python/object.hpp>
 
 /**
  * The intetion of this module is to centralize the access

--- a/qt/widgets/mplcpp/inc/MantidQtWidgets/MplCpp/Axes.h
+++ b/qt/widgets/mplcpp/inc/MantidQtWidgets/MplCpp/Axes.h
@@ -11,8 +11,6 @@
 #include "MantidQtWidgets/MplCpp/Line2D.h"
 
 #include <QString>
-#include <QVariant>
-#include <QHash>
 #include <functional>
 #include <tuple>
 
@@ -32,7 +30,6 @@ public:
   void forEachArtist(const char *containerAttr, const ArtistOperation &op);
   void removeArtists(const char *containerAttr, const QString &label);
   void setXLabel(const char *label);
-  void setXUseOffset(QHash<QString, QVariant> const &args);
   void setYLabel(const char *label);
   void setTitle(const char *label);
   void styleTickLabels(const char *axis, const char *style, const bool useOffset);

--- a/qt/widgets/mplcpp/inc/MantidQtWidgets/MplCpp/Axes.h
+++ b/qt/widgets/mplcpp/inc/MantidQtWidgets/MplCpp/Axes.h
@@ -32,7 +32,8 @@ public:
   void setXLabel(const char *label);
   void setYLabel(const char *label);
   void setTitle(const char *label);
-  void styleTickLabels(const char *axis, const char *style, const bool useOffset);
+  void tickLabelFormat(const char *axis, const char *style,
+                       const bool useOffset);
   /// @}
 
   /// @name Drawing

--- a/qt/widgets/mplcpp/inc/MantidQtWidgets/MplCpp/Axes.h
+++ b/qt/widgets/mplcpp/inc/MantidQtWidgets/MplCpp/Axes.h
@@ -6,10 +6,13 @@
 // SPDX - License - Identifier: GPL - 3.0 +
 #pragma once
 
+#include "MantidQtWidgets/Common/Python/Object.h"
 #include "MantidQtWidgets/MplCpp/DllConfig.h"
 #include "MantidQtWidgets/MplCpp/Line2D.h"
 
 #include <QString>
+#include <QVariant>
+#include <QHash>
 #include <functional>
 #include <tuple>
 
@@ -29,8 +32,10 @@ public:
   void forEachArtist(const char *containerAttr, const ArtistOperation &op);
   void removeArtists(const char *containerAttr, const QString &label);
   void setXLabel(const char *label);
+  void setXUseOffset(QHash<QString, QVariant> const &args);
   void setYLabel(const char *label);
   void setTitle(const char *label);
+  void styleTickLabels(const char *axis, const char *style, const bool useOffset);
   /// @}
 
   /// @name Drawing

--- a/qt/widgets/mplcpp/src/Axes.cpp
+++ b/qt/widgets/mplcpp/src/Axes.cpp
@@ -139,7 +139,7 @@ void Axes::setTitle(const char *label) {
  * @param bool useOffset :: True, the offset will be
  * calculated as needed, False no offset will be used
  */
-void Axes::styleTickLabels(const char *axis, const char *style,
+void Axes::tickLabelFormat(const char *axis, const char *style,
                            const bool useOffset) {
   try {
     GlobalInterpreterLock lock;

--- a/qt/widgets/mplcpp/src/Axes.cpp
+++ b/qt/widgets/mplcpp/src/Axes.cpp
@@ -5,15 +5,11 @@
 //   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
 // SPDX - License - Identifier: GPL - 3.0 +
 #include "MantidQtWidgets/MplCpp/Axes.h"
-#include "MantidQtWidgets/Common/Python/QHashToDict.h"
-
 #include "MantidPythonInterface/core/CallMethod.h"
 #include "MantidPythonInterface/core/Converters/VectorToNDArray.h"
 #include "MantidPythonInterface/core/Converters/WrapWithNDArray.h"
 #include "MantidPythonInterface/core/ErrorHandling.h"
 #include "MantidPythonInterface/core/VersionCompat.h"
-
-#include <iostream>
 
 namespace MantidQt {
 namespace Widgets {
@@ -58,11 +54,7 @@ std::tuple<double, double> limitsToTuple(const Python::Object &axes,
  * Construct an Axes wrapper around an existing Axes instance
  * @param obj A matplotlib.axes.Axes instance
  */
-Axes::Axes(Python::Object obj) : InstanceHolder(std::move(obj), "plot") {
-  QHash<QString, QVariant> otherkwargs;
-  otherkwargs.insert("useOffset", false);
-  Python::Dict lll = Python::qHashToDict(otherkwargs);
-}
+Axes::Axes(Python::Object obj) : InstanceHolder(std::move(obj), "plot") {}
 
 /**
  * Clear all artists from the axes
@@ -123,34 +115,6 @@ void Axes::setXLabel(const char *label) {
   callMethodNoCheck<void, const char *>(pyobj(), "set_xlabel", label);
 }
 
-Python::Dict createPythonDict() {
-  QHash<QString, QVariant> otherkwargs;
-  otherkwargs.insert("useOffset", false);
-  Python::Dict dict = Python::qHashToDict(otherkwargs);
-  return dict;
-}
-
-void Axes::setXUseOffset(QHash<QString, QVariant> const &args) {
-  // Python::Dict kwargs = Python::qHashToDict(args);
-  GlobalInterpreterLock lock;
-  try {
-    try {
-      // auto kwargs = createPythonDict();
-      // int scilimits[2] = { 0, 0};
-      // callMethodNoCheck<void, Python::Dict>(pyobj(),
-      // "ticklabel_format",kwargs);
-      Python::Dict kwargs;
-      Python::List args;
-      kwargs["useOffset"] = false;
-      pyobj().attr("ticklabel_format")(*args, **kwargs);
-    } catch (...) {
-      throw PythonException();
-    }
-  } catch (PythonException const &ex) {
-    throw std::runtime_error(ex.what());
-  }
-}
-
 /**
  * @brief Set the Y-axis label
  * @param label String for the axis label
@@ -177,13 +141,17 @@ void Axes::setTitle(const char *label) {
  */
 void Axes::styleTickLabels(const char *axis, const char *style,
                            const bool useOffset) {
-  GlobalInterpreterLock lock;
-  Python::List args;
-  Python::Dict kwargs;
-  kwargs["axis"] = axis;
-  kwargs["style"] = style;
-  kwargs["useOffset"] = useOffset;
-  pyobj().attr("ticklabel_format")(*args, **kwargs);
+  try {
+    GlobalInterpreterLock lock;
+    Python::List args;
+    Python::Dict kwargs;
+    kwargs["axis"] = axis;
+    kwargs["style"] = style;
+    kwargs["useOffset"] = useOffset;
+    pyobj().attr("ticklabel_format")(*args, **kwargs);
+  } catch (...) {
+    throw PythonException();
+  }
 }
 
 /**

--- a/qt/widgets/mplcpp/src/Figure.cpp
+++ b/qt/widgets/mplcpp/src/Figure.cpp
@@ -79,6 +79,7 @@ void Figure::setFaceColor(const char *color) {
  * @param args A hash of parameters to pass to set_tight_layout
  */
 void Figure::setTightLayout(QHash<QString, QVariant> const &args) {
+  GlobalInterpreterLock lock;
   pyobj().attr("set_tight_layout")(Python::qHashToDict(args));
 }
 

--- a/qt/widgets/plotting/inc/MantidQtWidgets/Plotting/Mpl/PreviewPlot.h
+++ b/qt/widgets/plotting/inc/MantidQtWidgets/Plotting/Mpl/PreviewPlot.h
@@ -84,9 +84,7 @@ public:
   bool hasCurve(const QString &lineName) const;
 
   void setOverrideAxisLabel(AxisID const &axisID, char const *const label);
-
   void tickLabelFormat(char *axis, char *style, bool useOffset);
-
   void setAxisRange(const QPair<double, double> &range,
                     AxisID axisID = AxisID::XBottom);
   std::tuple<double, double> getAxisRange(AxisID axisID = AxisID::XBottom);

--- a/qt/widgets/plotting/inc/MantidQtWidgets/Plotting/Mpl/PreviewPlot.h
+++ b/qt/widgets/plotting/inc/MantidQtWidgets/Plotting/Mpl/PreviewPlot.h
@@ -85,9 +85,7 @@ public:
 
   void setOverrideAxisLabel(AxisID const &axisID, char const *const label);
 
-  void setStyleTickLabels(char *axis, char *style, bool useOffset);
-
-  void styleTickLabels();
+  void tickLabelFormat(char *axis, char *style, bool useOffset);
 
   void setAxisRange(const QPair<double, double> &range,
                     AxisID axisID = AxisID::XBottom);

--- a/qt/widgets/plotting/inc/MantidQtWidgets/Plotting/Mpl/PreviewPlot.h
+++ b/qt/widgets/plotting/inc/MantidQtWidgets/Plotting/Mpl/PreviewPlot.h
@@ -183,11 +183,6 @@ private:
   // Whether or not a selector is currently being moved
   bool m_selectorActive;
 
-  // Tick label style
-  char *m_axis;
-  char *m_style;
-  bool m_useOffset;
-
   // Canvas tools
   Widgets::MplCpp::PanZoomTool m_panZoomTool;
 
@@ -196,6 +191,11 @@ private:
       m_wsRemovedObserver;
   Poco::NObserver<PreviewPlot, Mantid::API::WorkspaceBeforeReplaceNotification>
       m_wsReplacedObserver;
+
+  // Tick label style
+  char *m_axis;
+  char *m_style;
+  bool m_useOffset;
 
   // Context menu actions
   QActionGroup *m_contextPlotTools;

--- a/qt/widgets/plotting/inc/MantidQtWidgets/Plotting/Mpl/PreviewPlot.h
+++ b/qt/widgets/plotting/inc/MantidQtWidgets/Plotting/Mpl/PreviewPlot.h
@@ -85,7 +85,9 @@ public:
 
   void setOverrideAxisLabel(AxisID const &axisID, char const *const label);
 
-  void styleTickLabels(const char *axis, const char *style, const bool useOffset);
+  void setStyleTickLabels(char *axis, char *style, bool useOffset);
+
+  void styleTickLabels();
 
   void setAxisRange(const QPair<double, double> &range,
                     AxisID axisID = AxisID::XBottom);
@@ -182,6 +184,11 @@ private:
   QMap<QString, SingleSelector *> m_singleSelectors;
   // Whether or not a selector is currently being moved
   bool m_selectorActive;
+
+  // Tick label style
+  char *m_axis;
+  char *m_style;
+  bool m_useOffset;
 
   // Canvas tools
   Widgets::MplCpp::PanZoomTool m_panZoomTool;

--- a/qt/widgets/plotting/inc/MantidQtWidgets/Plotting/Mpl/PreviewPlot.h
+++ b/qt/widgets/plotting/inc/MantidQtWidgets/Plotting/Mpl/PreviewPlot.h
@@ -85,6 +85,8 @@ public:
 
   void setOverrideAxisLabel(AxisID const &axisID, char const *const label);
 
+  void styleTickLabels(const char *axis, const char *style, const bool useOffset);
+
   void setAxisRange(const QPair<double, double> &range,
                     AxisID axisID = AxisID::XBottom);
   std::tuple<double, double> getAxisRange(AxisID axisID = AxisID::XBottom);

--- a/qt/widgets/plotting/inc/MantidQtWidgets/Plotting/Qwt/PreviewPlot.h
+++ b/qt/widgets/plotting/inc/MantidQtWidgets/Plotting/Qwt/PreviewPlot.h
@@ -95,9 +95,7 @@ public:
 
   void setOverrideAxisLabel(AxisID const &axisID, char const *const label);
 
-  void setStyleTickLabels(char *axis, char *style, bool useOffset);
-
-  void styleTickLabels();
+  void tickLabelFormat(char *axis, char *style, bool useOffset);
 
   RangeSelector *
   addRangeSelector(const QString &rsName,

--- a/qt/widgets/plotting/inc/MantidQtWidgets/Plotting/Qwt/PreviewPlot.h
+++ b/qt/widgets/plotting/inc/MantidQtWidgets/Plotting/Qwt/PreviewPlot.h
@@ -71,6 +71,8 @@ public:
                     AxisID axisID = AxisID::XBottom);
   std::tuple<double, double>
   getAxisRange(AxisID axisID = AxisID::XBottom) const;
+  void setOverrideAxisLabel(AxisID const &axisID, char const *const label);
+  void tickLabelFormat(char *axis, char *style, bool useOffset);
 
   QPair<double, double>
   getCurveRange(const Mantid::API::MatrixWorkspace_sptr &ws);
@@ -89,20 +91,14 @@ public:
   void removeSpectrum(const QString &curveName);
 
   bool hasCurve(const QString &curveName);
-
   void setCurveStyle(const QString &curveName, const int style);
   void setCurveSymbol(const QString &curveName, const int symbol);
-
-  void setOverrideAxisLabel(AxisID const &axisID, char const *const label);
-
-  void tickLabelFormat(char *axis, char *style, bool useOffset);
 
   RangeSelector *
   addRangeSelector(const QString &rsName,
                    RangeSelector::SelectType type = RangeSelector::XMINMAX);
   RangeSelector *getRangeSelector(const QString &rsName);
   void removeRangeSelector(const QString &rsName, bool del);
-
   bool hasRangeSelector(const QString &rsName);
 
   SingleSelector *

--- a/qt/widgets/plotting/inc/MantidQtWidgets/Plotting/Qwt/PreviewPlot.h
+++ b/qt/widgets/plotting/inc/MantidQtWidgets/Plotting/Qwt/PreviewPlot.h
@@ -93,6 +93,11 @@ public:
   void setCurveStyle(const QString &curveName, const int style);
   void setCurveSymbol(const QString &curveName, const int symbol);
 
+  void setOverrideAxisLabel(AxisID const &axisID, char const *const label);
+
+  void styleTickLabels(const char *axis, const char *style,
+                       const bool useOffset);
+
   RangeSelector *
   addRangeSelector(const QString &rsName,
                    RangeSelector::SelectType type = RangeSelector::XMINMAX);

--- a/qt/widgets/plotting/inc/MantidQtWidgets/Plotting/Qwt/PreviewPlot.h
+++ b/qt/widgets/plotting/inc/MantidQtWidgets/Plotting/Qwt/PreviewPlot.h
@@ -95,8 +95,9 @@ public:
 
   void setOverrideAxisLabel(AxisID const &axisID, char const *const label);
 
-  void styleTickLabels(const char *axis, const char *style,
-                       const bool useOffset);
+  void setStyleTickLabels(char *axis, char *style, bool useOffset);
+
+  void styleTickLabels();
 
   RangeSelector *
   addRangeSelector(const QString &rsName,
@@ -190,6 +191,11 @@ private:
   QMap<QString, bool> m_rsVisibility;
   /// Cache of single selector visibility
   QMap<QString, bool> m_ssVisibility;
+
+  // Tick label style
+  char *m_axis;
+  char *m_style;
+  bool m_useOffset;
 
   /// Poco Observers for ADS Notifications
   Poco::NObserver<PreviewPlot, Mantid::API::WorkspacePreDeleteNotification>

--- a/qt/widgets/plotting/inc/MantidQtWidgets/Plotting/Qwt/PreviewPlot.h
+++ b/qt/widgets/plotting/inc/MantidQtWidgets/Plotting/Qwt/PreviewPlot.h
@@ -190,11 +190,6 @@ private:
   /// Cache of single selector visibility
   QMap<QString, bool> m_ssVisibility;
 
-  // Tick label style
-  char *m_axis;
-  char *m_style;
-  bool m_useOffset;
-
   /// Poco Observers for ADS Notifications
   Poco::NObserver<PreviewPlot, Mantid::API::WorkspacePreDeleteNotification>
       m_removeObserver;
@@ -234,6 +229,11 @@ private:
 
   QMap<QString, QwtPlotCurve::CurveStyle> m_curveStyle;
   QMap<QString, QwtSymbol::Style> m_curveSymbol;
+
+  // Tick label style
+  char *m_axis;
+  char *m_style;
+  bool m_useOffset;
 
   friend class DisplayCurveFit;
 

--- a/qt/widgets/plotting/src/Mpl/PreviewPlot.cpp
+++ b/qt/widgets/plotting/src/Mpl/PreviewPlot.cpp
@@ -790,7 +790,7 @@ void PreviewPlot::toggleLegend(const bool checked) {
  * @param bool useOffset :: True, the offset will be
  * calculated as needed, False no offset will be used
  */
-void PreviewPlot::tickLabelFormat(char* axis, char* style, bool useOffset) {
+void PreviewPlot::tickLabelFormat(char *axis, char *style, bool useOffset) {
   m_canvas->gca().tickLabelFormat(axis, style, useOffset);
 
   // Need to save parameters to re-format on scale change

--- a/qt/widgets/plotting/src/Mpl/PreviewPlot.cpp
+++ b/qt/widgets/plotting/src/Mpl/PreviewPlot.cpp
@@ -143,7 +143,6 @@ void PreviewPlot::addSpectrum(const QString &lineName,
       QSharedPointer<PlotCurveConfiguration>(new PlotCurveConfiguration(
           ws, lineName, wsIndex, lineColour, plotKwargs));
   m_plottedLines.insert(lineName, plotCurveConfig);
-
   if (auto const xLabel = overrideAxisLabel(AxisID::XBottom))
     setAxisLabel(AxisID::XBottom, xLabel.get());
   if (auto const yLabel = overrideAxisLabel(AxisID::YLeft))
@@ -775,6 +774,15 @@ void PreviewPlot::toggleLegend(const bool checked) {
     removeLegend();
   }
   this->replot();
+}
+
+void PreviewPlot::styleTickLabels(const char *axis, const char *style,
+                                  const bool useOffset) {
+  try {
+    m_canvas->gca().styleTickLabels(axis, style, useOffset);
+  } catch (Mantid::PythonInterface::PythonException &e) {
+    throw std::runtime_error(e.what());
+  }
 }
 
 } // namespace MantidWidgets

--- a/qt/widgets/plotting/src/Mpl/PreviewPlot.cpp
+++ b/qt/widgets/plotting/src/Mpl/PreviewPlot.cpp
@@ -59,7 +59,8 @@ PreviewPlot::PreviewPlot(QWidget *parent, bool observeADS)
                                                    parent)},
       m_panZoomTool(m_canvas),
       m_wsRemovedObserver(*this, &PreviewPlot::onWorkspaceRemoved),
-      m_wsReplacedObserver(*this, &PreviewPlot::onWorkspaceReplaced) {
+      m_wsReplacedObserver(*this, &PreviewPlot::onWorkspaceReplaced),
+      m_axis("both"), m_style("sci"), m_useOffset(true) {
   createLayout();
   createActions();
 
@@ -335,6 +336,7 @@ std::tuple<double, double> PreviewPlot::getAxisRange(AxisID axisID) {
 
 void PreviewPlot::replot() {
   if (m_allowRedraws) {
+    styleTickLabels();
     m_canvas->draw();
     emit redraw();
   }
@@ -776,13 +778,27 @@ void PreviewPlot::toggleLegend(const bool checked) {
   this->replot();
 }
 
-void PreviewPlot::styleTickLabels(const char *axis, const char *style,
-                                  const bool useOffset) {
+/**
+ * Makes a call to the python object for styling tick labels
+ */
+void PreviewPlot::styleTickLabels() {
   try {
-    m_canvas->gca().styleTickLabels(axis, style, useOffset);
-  } catch (Mantid::PythonInterface::PythonException &e) {
-    throw std::runtime_error(e.what());
-  }
+    m_canvas->gca().styleTickLabels(m_axis, m_style, m_useOffset);
+  } catch (Mantid::PythonInterface::PythonException &e) {}
+}
+
+/**
+ * Set variables used for styling tick labels
+ * @param char* axis :: [ 'x' | 'y' | 'both' ]
+ * @param char* style :: [ 'sci' (or 'scientific') | 'plain' ] plain turns off
+ * scientific notation
+ * @param bool useOffset :: True, the offset will be
+ * calculated as needed, False no offset will be used
+ */
+void PreviewPlot::setStyleTickLabels(char* axis, char* style, bool useOffset) {
+  m_axis = axis;
+  m_style = style;
+  m_useOffset = useOffset;
 }
 
 } // namespace MantidWidgets

--- a/qt/widgets/plotting/src/Mpl/PreviewPlot.cpp
+++ b/qt/widgets/plotting/src/Mpl/PreviewPlot.cpp
@@ -336,7 +336,6 @@ std::tuple<double, double> PreviewPlot::getAxisRange(AxisID axisID) {
 
 void PreviewPlot::replot() {
   if (m_allowRedraws) {
-    styleTickLabels();
     m_canvas->draw();
     emit redraw();
   }
@@ -759,6 +758,11 @@ void PreviewPlot::setScaleType(AxisID id, const QString &actionName) {
   default:
     break;
   }
+
+  // If linear scale need to reset tick labels
+  if (strcmp(scaleType.constData(), "linear") == 0)
+    tickLabelFormat(m_axis, m_style, m_useOffset);
+
   this->replot();
 }
 
@@ -779,23 +783,17 @@ void PreviewPlot::toggleLegend(const bool checked) {
 }
 
 /**
- * Makes a call to the python object for styling tick labels
- */
-void PreviewPlot::styleTickLabels() {
-  try {
-    m_canvas->gca().styleTickLabels(m_axis, m_style, m_useOffset);
-  } catch (Mantid::PythonInterface::PythonException &e) {}
-}
-
-/**
- * Set variables used for styling tick labels
+ * Format tick labels for linear scale
  * @param char* axis :: [ 'x' | 'y' | 'both' ]
  * @param char* style :: [ 'sci' (or 'scientific') | 'plain' ] plain turns off
  * scientific notation
  * @param bool useOffset :: True, the offset will be
  * calculated as needed, False no offset will be used
  */
-void PreviewPlot::setStyleTickLabels(char* axis, char* style, bool useOffset) {
+void PreviewPlot::tickLabelFormat(char* axis, char* style, bool useOffset) {
+  m_canvas->gca().tickLabelFormat(axis, style, useOffset);
+
+  // Need to save parameters to re-format on scale change
   m_axis = axis;
   m_style = style;
   m_useOffset = useOffset;

--- a/qt/widgets/plotting/src/Qwt/PreviewPlot.cpp
+++ b/qt/widgets/plotting/src/Qwt/PreviewPlot.cpp
@@ -1022,7 +1022,15 @@ void PreviewPlot::disableContextMenu() {
              SLOT(showContextMenu(QPoint)));
 }
 
-// Empty implementations for qt < 5
+// Needed for mpl, but can also be used for qwt
 void PreviewPlot::setOverrideAxisLabel(AxisID const &axisID,
-                                       char const *const label) {}
-void PreviewPlot::tickLabelFormat(char *axis, char *style, bool useOffset) {}
+                                       char const *const label) {
+  m_uiForm.plot->setAxisTitle(static_cast<int>(axisID), label);
+}
+
+// This is a mpl thing so not used here
+void PreviewPlot::tickLabelFormat(char *axis, char *style, bool useOffset) {
+  Q_UNUSED(axis);
+  Q_UNUSED(style);
+  Q_UNUSED(useOffset);
+}

--- a/qt/widgets/plotting/src/Qwt/PreviewPlot.cpp
+++ b/qt/widgets/plotting/src/Qwt/PreviewPlot.cpp
@@ -41,7 +41,7 @@ PreviewPlot::PreviewPlot(QWidget *parent, bool init)
       m_zoomTool(nullptr), m_contextMenu(new QMenu(this)),
       m_showLegendAction(nullptr), m_showErrorsMenuAction(nullptr),
       m_showErrorsMenu(nullptr), m_errorBarOptionCache(), m_curveStyle(),
-      m_curveSymbol() {
+      m_curveSymbol(), m_axis("both"), m_style("sci"), m_useOffset(true) {
   m_uiForm.setupUi(this);
   m_uiForm.loLegend->addStretch();
   watchADS(init);
@@ -1022,6 +1022,8 @@ void PreviewPlot::disableContextMenu() {
              SLOT(showContextMenu(QPoint)));
 }
 
-void PreviewPlot::styleTickLabels(const char *axis, const char *style, const bool useOffset) {}
-
-void PreviewPlot::setOverrideAxisLabel(AxisID const &axisID, char const *const label) {}
+// Empty implementations for qt < 5
+void PreviewPlot::styleTickLabels() {}
+void PreviewPlot::setOverrideAxisLabel(AxisID const &axisID,
+                                       char const *const label) {}
+void PreviewPlot::setStyleTickLabels(char *axis, char *style, bool useOffset) {}

--- a/qt/widgets/plotting/src/Qwt/PreviewPlot.cpp
+++ b/qt/widgets/plotting/src/Qwt/PreviewPlot.cpp
@@ -1021,3 +1021,7 @@ void PreviewPlot::disableContextMenu() {
   disconnect(m_uiForm.plot, SIGNAL(customContextMenuRequested(QPoint)), this,
              SLOT(showContextMenu(QPoint)));
 }
+
+void PreviewPlot::styleTickLabels(const char *axis, const char *style, const bool useOffset) {}
+
+void PreviewPlot::setOverrideAxisLabel(AxisID const &axisID, char const *const label) {}

--- a/qt/widgets/plotting/src/Qwt/PreviewPlot.cpp
+++ b/qt/widgets/plotting/src/Qwt/PreviewPlot.cpp
@@ -1023,7 +1023,6 @@ void PreviewPlot::disableContextMenu() {
 }
 
 // Empty implementations for qt < 5
-void PreviewPlot::styleTickLabels() {}
 void PreviewPlot::setOverrideAxisLabel(AxisID const &axisID,
                                        char const *const label) {}
-void PreviewPlot::setStyleTickLabels(char *axis, char *style, bool useOffset) {}
+void PreviewPlot::tickLabelFormat(char *axis, char *style, bool useOffset) {}


### PR DESCRIPTION
**Description of work.**
Added x label to plot and stopped scientific notation when plotting run numbers as it didn't make sense

**To test:**

1. Open ALC
2. Load some data
3. Check x label matches what is selected on log (need to reload when changed)
4. Check scientific notation is avoided when log is set to run number (try loading MUSR62260-MUSR62265, used to have an offset instead of just the numbers on the axis)
5. Check nothing breaks for example when changing scale etc.

<!-- Instructions for testing. -->

Fixes #29799 

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
