### PR TITLE
Warn if using system tools >= 49

### DIFF
--- a/Testing/SystemTests/lib/systemtests/systemtesting.py
+++ b/Testing/SystemTests/lib/systemtests/systemtesting.py
@@ -16,6 +16,15 @@ if os.environ.get('MANTID_FRAMEWORK_CONDA_SYSTEMTEST'):
     import matplotlib
 
 # =========================================================
+try:
+    import mantid
+except ModuleNotFoundError:
+    import setuptools
+    from packaging import version
+    if version.parse(setuptools.__version__) >= version.parse("49.0.0"):
+        raise EnvironmentError("Setup tools is v49 or greater. This is likely causing the Mantid import to fail. See \n"
+                                "https://github.com/mantidproject/mantid/issues/29010")
+
 import datetime
 import difflib
 import imp

--- a/buildconfig/CMake/Packaging/launch_mantidworkbench.sh.in
+++ b/buildconfig/CMake/Packaging/launch_mantidworkbench.sh.in
@@ -19,6 +19,13 @@ if [ -n "${PYTHONPATH}" ]; then
     LOCAL_PYTHONPATH=${LOCAL_PYTHONPATH}:${PYTHONPATH}
 fi
 
+SETUP_TOOLS_VERS=`@PYTHON_EXECUTABLE@ -m pip show setuptools | grep Version | cut -d. -f1 | cut -d' ' -f2`
+if [ "$SETUP_TOOLS_VERS" -ge "49" ]; then
+   # Print red so people notice it when they get a stack trace
+   echo "\e[31mSetup tools is >= 49. You may run into issues with a clean build.\e[0m"
+   echo "If you are failing to launch with missing modules see https://github.com/mantidproject/mantid/issues/29010"
+fi
+
 @GDB_DEFINITIONS@
 
 LD_PRELOAD=${LOCAL_PRELOAD} \


### PR DESCRIPTION
**Description of work.**

Emits a warning if system tools 49 onwards is used. This should save
future developers a significant amount of time if a clean build suddenly
stops working. This typically happens because existing egg links will continue
to work until they are deleted and regenerated

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

**To test:**

- Install Setup Tools 49 : `pip3 install setuptools==49.0.0`
- Go to your build folder and `rm bin/*egg* && ninja` (or make)
- Attempt to launch workbench `bin/launchMantidWorkbench.sh`, the warning should be printed in red
- Attempt to run system tests, if mantid fails to import it should emit an OSError (or EnvironmentError) stating setup tools 49 is used
- Revert to setup tools 48 `pip3 install setuptools==48.0.0` and regenerate egg links as above to restore functionality

<!-- Instructions for testing. -->


*There is no associated issue.*

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or master)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
