### PR TITLE
Fix colorfill and sliceviewer unnecessary logging and system exception

### DIFF
--- a/Framework/PythonInterface/mantid/plots/datafunctions.py
+++ b/Framework/PythonInterface/mantid/plots/datafunctions.py
@@ -551,7 +551,7 @@ def _workspace_indices(y_bins, workspace):
 
 def _workspace_indices_maxpooling(y_bins, workspace):
     from mantid.simpleapi import Integration
-    summed_spectra_workspace = Integration(workspace, StoreInADS=False)
+    summed_spectra_workspace = Integration(workspace, StoreInADS=False, EnableLogging=False)
     summed_spectra = summed_spectra_workspace.extractY()
     workspace_indices = []
     for y_range in pairwise(y_bins):

--- a/Framework/PythonInterface/mantid/plots/datafunctions.py
+++ b/Framework/PythonInterface/mantid/plots/datafunctions.py
@@ -550,8 +550,7 @@ def _workspace_indices(y_bins, workspace):
 
 
 def _workspace_indices_maxpooling(y_bins, workspace):
-    from mantid.simpleapi import Integration
-    summed_spectra_workspace = Integration(workspace, StoreInADS=False, EnableLogging=False)
+    summed_spectra_workspace = _integrate_workspace(workspace)
     summed_spectra = summed_spectra_workspace.extractY()
     workspace_indices = []
     for y_range in pairwise(y_bins):
@@ -563,6 +562,19 @@ def _workspace_indices_maxpooling(y_bins, workspace):
         except IndexError:
             continue
     return workspace_indices
+
+
+def _integrate_workspace(workspace):
+    from mantid.api import AlgorithmManager
+    integration = AlgorithmManager.createUnmanaged("Integration")
+    integration.initialize()
+    integration.setAlwaysStoreInADS(False)
+    integration.setLogging(False)
+    integration.setChild(True)
+    integration.setProperty("InputWorkspace", workspace)
+    integration.setProperty("OutputWorkspace", "__dummy")
+    integration.execute()
+    return integration.getProperty("OutputWorkspace").value
 
 
 def interpolate_y_data(workspace, x, y, normalize_by_bin_width, spectrum_info=None, maxpooling=False):


### PR DESCRIPTION
**Description of work.**
This PR fixes the unnecessary logging produced by the maxpooling stage performed when sliceviewer and colorfill images are resampled. It also fixes another issue which causes a system exception due to `integration` running as a managed algorithm.

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

**To test:**
- Load some data
- Open sliceviwer and colorfill and make sure everything opens correctly
- Zoom in a resize the window to test that resampling still works.

<!-- Instructions for testing. -->

Fixes #29900 . <!-- and fix #xxxx or close #xxxx xor resolves #xxxx -->
<!-- alternative
*There is no associated issue.*
-->


This does not require release notes because they were issues introduced this sprint


<!-- Ensure the base of this PR is correct (e.g. release-next or master)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
