### PR TITLE
Fix isis direct reduction wait mode

### DIFF
--- a/Testing/SystemTests/tests/framework/ISISDirectInelastic.py
+++ b/Testing/SystemTests/tests/framework/ISISDirectInelastic.py
@@ -168,7 +168,7 @@ class MARIReductionFromFileCache(ISISDirectInelasticReduction):
         if self._counter == 2:
             # second step. File is there but log have not been updated
             # nothing happens, the script reports "waiting for file"
-            print('******  Fake pause. step: 2')
+            print('******  Fake pause. step: 2. Fake nxs file created to ignore')
             source =  FileFinder.findRuns('MAR11001')[0]
             targ_path = config['defaultsave.directory']
             targ_file = os.path.join(targ_path,'MAR11002.nxs')
@@ -180,20 +180,20 @@ class MARIReductionFromFileCache(ISISDirectInelasticReduction):
             # when both files are added to archive,
             # but let's run it to test additional branch
             # of the code: invalid extension found
-            print('******  Fake pause. step: 3')
+            print('******  Fake pause. step: 3. Run log updated but file is not there')
             test_log = self._test_log_file
             with open(test_log ,'w') as fh:
                 fh.write('MAR 11002 0 \n')
             m_time = os.path.getmtime(test_log)
             # Update modification time manually as Unix may
-            # run the test too fast and mtime will be the same 
+            # run the test too fast and mtime will be the same
             # as the log has been generated initially
             m_time  = m_time +1
             os.utime(test_log,(m_time,m_time))
             return
 
         if self._counter>= 4:
-            print('******  Fake pause. step: {0}'.format(self._counter))
+            print('******  Fake pause. step: {0}. Created fake source. Reduction should run'.format(self._counter))
 
             source =  FileFinder.findRuns('MAR11001')[0]
             targ_path = config['defaultsave.directory']

--- a/Testing/SystemTests/tests/framework/ISISDirectInelastic.py
+++ b/Testing/SystemTests/tests/framework/ISISDirectInelastic.py
@@ -16,7 +16,7 @@ from Direct.PropertyManager  import PropertyManager
 #----------------------------------------------------------------------
 
 
-class ISISDirectInelasticReduction(metaclass=ABCMeta):
+class ISISDirectInelasticReduction(systemtesting.MantidSystemTest, metaclass=ABCMeta):
     """A base class for the ISIS direct inelastic tests
 
     The workflow is defined in the runTest() method, simply

--- a/scripts/Inelastic/Direct/ReductionWrapper.py
+++ b/scripts/Inelastic/Direct/ReductionWrapper.py
@@ -550,7 +550,7 @@ class ReductionWrapper(object):
         timeToWait = self._wait_for_file
         if timeToWait > 0:
             _, fext_requested = PropertyManager.sample_run.file_hint()
-            run_number_requsted = PropertyManager.sample_run.run_number
+            run_number_requsted = PropertyManager.sample_run.run_number()
             available,_,info = self._check_progress_log_run_completed(run_number_requsted)
             if len(info) > 0: # report if archive upload log is not available
                 self.reducer.prop_man.log("*** "+info, 'warning')
@@ -636,7 +636,7 @@ class ReductionWrapper(object):
                     # here we have run numbers. Let's get real file names
                     prop_man = self.reducer.prop_man
                     instr_name = prop_man.short_instr_name
-                    run_number_requsted = PropertyManager.sample_run.run_number
+                    run_number_requsted = PropertyManager.sample_run.run_number()
                     available,_,_ = self._check_progress_log_run_completed(run_number_requsted)
                     if available:
                         is_found, fname = PropertyManager.sample_run.find_file(prop_man, instr_name, run)

--- a/scripts/Inelastic/Direct/RunDescriptor.py
+++ b/scripts/Inelastic/Direct/RunDescriptor.py
@@ -1059,12 +1059,12 @@ class RunDescriptor(PropDescriptor):
         #
         file_hint,old_ext = self.file_hint(run_num_str,filePath,fileExt,**kwargs)
 
-        def _check_ext(file_name):
+        def _check_ext(file_name,file_hint='missing'):
             fname,fex = os.path.splitext(file_name)
             if old_ext != fex:
                 if 'force_extension' in kwargs:
                     if 'be_quet' not in kwargs:
-                        message= '*** Cannot find file matching hint {0} with the requested extension {1} on Mantid search paths '.\
+                        message= '*** Cannot find file matching hint: {0} with the requested extension {1} on Mantid search paths '.\
                                 format(file_hint,old_ext)
                         RunDescriptor._logger(message,'warning')
                     raise RuntimeError(message)
@@ -1078,7 +1078,7 @@ class RunDescriptor(PropDescriptor):
         #------------------------------------------------
         try:
             file_name = FileFinder.findRuns(file_hint)[0]
-            _check_ext(file_name)
+            _check_ext(file_name,file_hint)
             return (True,file_name)
         except RuntimeError as Err:
             if 'force_extension' in kwargs:
@@ -1088,7 +1088,7 @@ class RunDescriptor(PropDescriptor):
 #pylint: disable=unused-variable
                     file_hint,oext = os.path.splitext(file_hint)
                     file_name = FileFinder.findRuns(file_hint)[0]
-                    _check_ext(file_name)
+                    _check_ext(file_name,file_hint)
                     return (True,file_name)
                 except RuntimeError:
                     message = '*** Cannot find file matching hint {0} on Mantid search paths '.\

--- a/scripts/Inelastic/Direct/RunDescriptor.py
+++ b/scripts/Inelastic/Direct/RunDescriptor.py
@@ -1059,13 +1059,13 @@ class RunDescriptor(PropDescriptor):
         #
         file_hint,old_ext = self.file_hint(run_num_str,filePath,fileExt,**kwargs)
 
-        def _check_ext(file_name,file_hint='missing'):
+        def _check_ext(file_name):
             fname,fex = os.path.splitext(file_name)
             if old_ext != fex:
                 if 'force_extension' in kwargs:
+                    message= '*** Rejecting file matching hint: {0} with wrong extension {1} found on Mantid search paths '.\
+                            format(file_hint,fex)
                     if 'be_quet' not in kwargs:
-                        message= '*** Cannot find file matching hint: {0} with the requested extension {1} on Mantid search paths '.\
-                                format(file_hint,old_ext)
                         RunDescriptor._logger(message,'warning')
                     raise RuntimeError(message)
                 else:
@@ -1078,7 +1078,7 @@ class RunDescriptor(PropDescriptor):
         #------------------------------------------------
         try:
             file_name = FileFinder.findRuns(file_hint)[0]
-            _check_ext(file_name,file_hint)
+            _check_ext(file_name)
             return (True,file_name)
         except RuntimeError as Err:
             if 'force_extension' in kwargs:
@@ -1088,7 +1088,7 @@ class RunDescriptor(PropDescriptor):
 #pylint: disable=unused-variable
                     file_hint,oext = os.path.splitext(file_hint)
                     file_name = FileFinder.findRuns(file_hint)[0]
-                    _check_ext(file_name,file_hint)
+                    _check_ext(file_name)
                     return (True,file_name)
                 except RuntimeError:
                     message = '*** Cannot find file matching hint {0} on Mantid search paths '.\

--- a/scripts/Inelastic/Direct/RunDescriptor.py
+++ b/scripts/Inelastic/Direct/RunDescriptor.py
@@ -1063,7 +1063,7 @@ class RunDescriptor(PropDescriptor):
             fname,fex = os.path.splitext(file_name)
             if old_ext != fex:
                 if 'force_extension' in kwargs:
-                    message= '*** Rejecting file matching hint: {0} with wrong extension {1} found on Mantid search paths '.\
+                    message= '*** Rejecting file matching hint: {0} as found file has wrong extension: {1}'.\
                             format(file_hint,fex)
                     if 'be_quet' not in kwargs:
                         RunDescriptor._logger(message,'warning')

--- a/scripts/Inelastic/Direct/RunDescriptor.py
+++ b/scripts/Inelastic/Direct/RunDescriptor.py
@@ -1061,7 +1061,7 @@ class RunDescriptor(PropDescriptor):
 
         def _check_ext(file_name):
             fname,fex = os.path.splitext(file_name)
-            if old_ext != fex:
+            if old_ext.lower() != fex.lower():
                 if 'force_extension' in kwargs:
                     message= '*** Rejecting file matching hint: {0} as found file has wrong extension: {1}'.\
                             format(file_hint,fex)

--- a/scripts/test/RunDescriptorTest.py
+++ b/scripts/test/RunDescriptorTest.py
@@ -142,7 +142,7 @@ class RunDescriptorTest(unittest.TestCase):
         ok, file = PropertyManager.sample_run.find_file(propman,force_extension='.nxs')
         self.assertFalse(ok)
         self.assertEqual(file.strip(),
-                         '*** Cannot find file matching hint MAR11001.nxs with the requested extension .nxs on Mantid search paths')
+                         '*** Rejecting file matching hint: MAR11001.nxs as found file has wrong extension: .raw')
 
     #
     def test_load_workspace(self):


### PR DESCRIPTION
**Description of work.**

Fixes a mixup between a method/value comparision in direct reduction scripts.

**To test:**

* Run the `MARIReductionWaitAndSum` system test and it should pass
* All system tests should pass

*There is no associated issue.*

*This does not require release notes* because **it was broken this dev cycle.**

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
