### PR TITLE
Startup scripts now default to pyqt5

### DIFF
--- a/buildconfig/CMake/DarwinSetup.cmake
+++ b/buildconfig/CMake/DarwinSetup.cmake
@@ -90,6 +90,7 @@ if(NOT TARGET mantidpython)
   if(MAKE_VATES)
     # Python packages go into bundle Python site-packages
     set(PARAVIEW_PYTHON_PATHS "")
+    set(PV_PLUGIN_INSTALL_PATH "PV_PLUGIN_PATH=\"${INSTALLDIR}/PlugIns/paraview/qt4\"")
   else()
     set(PARAVIEW_PYTHON_PATHS "")
   endif()

--- a/buildconfig/CMake/LinuxPackageScripts.cmake
+++ b/buildconfig/CMake/LinuxPackageScripts.cmake
@@ -42,21 +42,37 @@ set ( CPACK_RPM_EXCLUDE_FROM_AUTO_FILELIST_ADDITION /opt /usr/share/applications
 ###########################################################################
 # Environment scripts (profile.d)
 ###########################################################################
-# default shell (bash-like)
-file ( WRITE ${CMAKE_CURRENT_BINARY_DIR}/mantid.sh
-  "#!/bin/sh\n"
-  "PV_PLUGIN_PATH=${CMAKE_INSTALL_PREFIX}/${PVPLUGINS_DIR}\n"
-  "PATH=$PATH:${CMAKE_INSTALL_PREFIX}/${BIN_DIR}\n"
+if(MAKE_VATES)
+  # default shell (bash-like)
+  file ( WRITE ${CMAKE_CURRENT_BINARY_DIR}/mantid.sh
+    "#!/bin/sh\n"
+    "PV_PLUGIN_PATH=${CMAKE_INSTALL_PREFIX}/${PVPLUGINS_DIR}\n"
+    "PATH=$PATH:${CMAKE_INSTALL_PREFIX}/${BIN_DIR}\n"
 
-  "export PV_PLUGIN_PATH PATH\n"
-)
+    "export PV_PLUGIN_PATH PATH\n"
+  )
 
-# c-shell
-file ( WRITE ${CMAKE_CURRENT_BINARY_DIR}/mantid.csh
-  "#!/bin/csh\n"
-  "setenv PV_PLUGIN_PATH \"${CMAKE_INSTALL_PREFIX}/${PVPLUGINS_DIR}\"\n"
-  "setenv PATH \"\${PATH}:${CMAKE_INSTALL_PREFIX}/${BIN_DIR}\"\n"
-)
+  # c-shell
+  file ( WRITE ${CMAKE_CURRENT_BINARY_DIR}/mantid.csh
+    "#!/bin/csh\n"
+    "setenv PV_PLUGIN_PATH \"${CMAKE_INSTALL_PREFIX}/${PVPLUGINS_DIR}\"\n"
+    "setenv PATH \"\${PATH}:${CMAKE_INSTALL_PREFIX}/${BIN_DIR}\"\n"
+  )
+else()
+  # default shell (bash-like)
+  file ( WRITE ${CMAKE_CURRENT_BINARY_DIR}/mantid.sh
+    "#!/bin/sh\n"
+    "PATH=$PATH:${CMAKE_INSTALL_PREFIX}/${BIN_DIR}\n"
+
+    "export PATH\n"
+  )
+
+  # c-shell
+  file ( WRITE ${CMAKE_CURRENT_BINARY_DIR}/mantid.csh
+    "#!/bin/csh\n"
+    "setenv PATH \"\${PATH}:${CMAKE_INSTALL_PREFIX}/${BIN_DIR}\"\n"
+  )
+endif()
 
 install ( PROGRAMS ${CMAKE_CURRENT_BINARY_DIR}/mantid.sh
   ${CMAKE_CURRENT_BINARY_DIR}/mantid.csh
@@ -216,6 +232,9 @@ if (ENABLE_MANTIDPLOT)
   # Needs to be executable
   execute_process ( COMMAND "chmod" "+x" "${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/launch_mantidplot.sh"
                     OUTPUT_QUIET ERROR_QUIET )
+  if(MAKE_VATES)
+    set(PV_PLUGIN_INSTALL_PATH "PV_PLUGIN_PATH=\"${INSTALLDIR}/plugins/paraview/qt4\"")
+  endif()
 endif ()
 if (ENABLE_WORKBENCH)
   set ( MANTIDWORKBENCH_EXEC workbench ) # what the actual thing is called

--- a/buildconfig/CMake/Packaging/mantidpython.bat.in
+++ b/buildconfig/CMake/Packaging/mantidpython.bat.in
@@ -24,14 +24,14 @@ set PYTHONPATH=%_BIN_DIR%;%_sip_dir%;%PYTHONPATH%@PARAVIEW_PYTHON_PATHS@
 set _PYTHON_EXE=%PYTHONHOME%\python.exe
 set _IPYTHON_CMD=%PYTHONHOME%\Scripts\ipython.cmd
 
-:: QtPy should use Qt4 by unless specified
+:: QtPy should use Qt5 by unless specified
 if "%QT_API%"=="" (
-  set QT_API=pyqt
+  set QT_API=pyqt5
 )
 
 :: Matplotlib backend should default to Qt if not set (requires matplotlib >= 1.5)
 if "%MPLBACKEND%"=="" (
-  set MPLBACKEND=qt4agg
+  set MPLBACKEND=qt5agg
 )
 
 :::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::

--- a/buildconfig/CMake/Packaging/mantidpython.in
+++ b/buildconfig/CMake/Packaging/mantidpython.in
@@ -16,9 +16,6 @@ if [ -n "${LD_LIBRARY_PATH}" ]; then
   LOCAL_LDPATH=${LOCAL_LDPATH}:${LD_LIBRARY_PATH}
 fi
 
-# Define paraview information
-PV_PLUGIN_PATH="${INSTALLDIR}/plugins/paraview/qt4"
-
 # Define where python libraries are
 LOCAL_PYTHONPATH=@LOCAL_PYPATH@@PARAVIEW_PYTHON_PATHS@
 if [ -n "${PYTHONPATH}" ]; then
@@ -29,7 +26,7 @@ fi
 if [ -n "${QT_API}" ]; then
     LOCAL_QT_API=${QT_API}
 else
-    LOCAL_QT_API="pyqt" # force to use qt4
+    LOCAL_QT_API="pyqt5" # force to use qt5
 fi
 
 # Find private sip module if it exists. Required by qtpy
@@ -51,10 +48,9 @@ else
     set -- @WRAPPER_PREFIX@@Python_EXECUTABLE@ @PYTHON_ARGS@ -c "${IPYTHON_STARTUP}" "$@"@WRAPPER_POSTFIX@
 fi
 
+# Define paraview information
 LD_PRELOAD=${LOCAL_PRELOAD} \
-    @MTD_PATH_DEFINITION@ \
     PYTHONPATH=${LOCAL_PYTHONPATH} \
     QT_API=${LOCAL_QT_API} \
     LD_LIBRARY_PATH=${LOCAL_LDPATH} \
-    PV_PLUGIN_PATH=${PV_PLUGIN_PATH} \
-    exec "$@"
+    @PV_PLUGIN_INSTALL_PATH@ exec "$@"

--- a/buildconfig/CMake/Packaging/osx/mantidpython.in
+++ b/buildconfig/CMake/Packaging/osx/mantidpython.in
@@ -34,6 +34,13 @@ if [ -n "${PYTHONPATH}" ]; then
   LOCAL_PYTHONPATH=${LOCAL_PYTHONPATH}:${PYTHONPATH}
 fi
 
+# Define which qt backend to use
+if [ -n "${QT_API}" ]; then
+    LOCAL_QT_API=${QT_API}
+else
+    LOCAL_QT_API="pyqt5" # force to use qt5
+fi
+
 # Find private sip module for PyQt4 or qtpy fails to import
 if [ "$QT_API" = "pyqt" ] || [ "$QT_API" = "pyqt4" ]; then
   SIP_SO=`${PYTHONEXE} -c"import PyQt4.sip as sip;print(sip.__file__)"`
@@ -48,6 +55,5 @@ else
   set -- ${PYTHONEXE} -c "${IPYTHON_STARTUP}" $*
 fi
 
-PV_PLUGIN_PATH=${PV_PLUGIN_PATH} \
-  PYTHONPATH=${LOCAL_PYTHONPATH} \
-  exec "$@"
+PYTHONPATH=${LOCAL_PYTHONPATH} \
+  @PV_PLUGIN_INSTALL_PATH@ exec "$@"


### PR DESCRIPTION
**Description of work.**

Wrapper startup scripts for mantidpython and profiles now default to QT_API=pyqt5.

PV_PLUGIN_PATH has been removed from the Linux profile scripts if Vates is not built.

**To test:**

* Code review
* Build and run mantidpython. Try importing `qtpy` and `qtpt.PYQT5` should be true.

Refs #28650.

*This does not require release notes* because **it is an internal change.**

<!-- Ensure the base of this PR is correct (e.g. release-next or master)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
