### PR TITLE
Fix problem with blank pages in Workbench docs in nightly build

### DIFF
--- a/docs/source/conf-html.py
+++ b/docs/source/conf-html.py
@@ -39,3 +39,10 @@ html_theme_options = {
     # Ensure the nav bar always stays on top of page.
     'navbar_fixed_top': "false",
 }
+
+# -- Fix up angstrom symbol for mathjax
+rst_prolog = r"""
+
+:math:`\renewcommand\AA{\unicode{x212B}}`
+
+"""

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -145,13 +145,6 @@ pngmath_latex_preamble = r'\usepackage[active]{preview}'
 # See http://sphinx-doc.org/ext/math.html#confval-pngmath_use_preview
 pngmath_use_preview = True
 
-# -- Fix up angstrom symbol for mathjax which shouldn't have an effect on pngmath
-rst_prolog = r"""
-
-:math:`\renewcommand\AA{\unicode{x212B}}`
-
-"""
-
 # -- HTML output ----------------------------------------------------
 
 # The theme to use for HTML and HTML Help pages.  See the documentation for


### PR DESCRIPTION
**Description of work.**

The rst_prolog setting wasn't working properly when building the workbench docs with either sphinx.ext.imgmath or sphinx.ext.mathjax. With imgmath (the setting that is used in the nightly build) the docs pages are blank. With mathjax the
qthelp doc pages just display the renewcommand text instead of running the command
Have fixed this by moving the rst_prolog setting down into conf-html.py so only affect building html doc pages

**To test:**

Change the cmake DOCS_MATH_EXT setting to sphinx.ext.imgmath either in cmake UI or run "cmake -DDOCS_MATH_EXT=sphinx.ext.imgmath ." in your build directory. This will overwrite the cmake cache setting with may have a different value. The setting used in the nightly build is sphinx.ext.imgmath

Build the docs.

Note: to see the effect you need to build both the docs-qtassistant target and the docs-qthelp target. The docs-qthelp target is no longer in the documentation folder if you are building in Visual Studio

Check that the doc pages in Workbench on the help menu are now displayed properly and aren't blank (see screen shot on attached issue)

Check that the angstrom symbols in the html version of the Absorption and Multiple Scattering concepts page (AbsorptionAndMultipleScattering.html) are still displayed correctly eg in the formula under the "Absorption cross section" heading. This is what the rst_prolog statement does.

Fixes #29922.

*This does not require release notes* because **fixes a problem with the docs introduced in this release**

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
