### PR TITLE
Fix SaveHKL direction cosines

### DIFF
--- a/docs/source/release/v6.0.0/diffraction.rst
+++ b/docs/source/release/v6.0.0/diffraction.rst
@@ -28,6 +28,10 @@ Engineering Diffraction
 
 Single Crystal Diffraction
 --------------------------
+Bugfixes
+########
+- Fix bug in :ref:`SaveHKL <algm-SaveHKL>` where the direction cosines were calculated incorrectly
+
 
 Imaging
 -------


### PR DESCRIPTION
**Description of work.**

The direction cosines in SaveHKL was being calculated incorrectly. For task https://code.ornl.gov/sns-hfir-scse/diffraction/single-crystal/single-crystal-diffraction/-/issues/130, part of story https://code.ornl.gov/sns-hfir-scse/diffraction/single-crystal/single-crystal-diffraction/-/issues/37

**To test:**

I used the following to compare to direction cosine calculation for a few peaks to the `NiTe2O5_nuc4K.int` file provided in [SCD37](https://code.ornl.gov/sns-hfir-scse/diffraction/single-crystal/single-crystal-diffraction/-/issues/37)

```python
from mantid.simpleapi import *
import numpy as np
from mantid import config
config['Q.convention'] = 'Crystallography'

spice_ub = np.array('-0.009884 -0.016780 0.115725 0.005899 -0.081084 -0.023625 0.112280 0.002840 0.011331'.split(), dtype=float).reshape((3,3))

# convert spice UB to mantid Crystallography Q convention UB                                                                         
mantid_ub = np.eye(3)
mantid_ub[0] = -spice_ub[0]
mantid_ub[1] = -spice_ub[2]
mantid_ub[2] = spice_ub[1]

ws = LoadEmptyInstrument(InstrumentName='HB3A')

# try one using values from /HFIR/HB3A/exp691/Datafiles/HB3A_exp0691_scan1085.dat                                                    
# scan_title = (1.000029 -1.999908 4.999999) 300.018 K                                                                               

omega = 29.0295
chi = 15.1168
phi = 4.7395
twotheta = 58.0595
det_trans = 399.9955

AddSampleLog(Workspace=ws, LogName='2theta', LogText=f'{twotheta}', LogType='Number Series')
AddSampleLog(Workspace=ws, LogName='det_trans', LogText=f'{det_trans}', LogType='Number Series')
LoadInstrument(ws, InstrumentName='HB3A', RewriteSpectraMap=False)

peaks = CreatePeaksWorkspace(ws, 0)
print(peaks.getInstrument().getDetector(1).getPos())
SetUB(peaks, UB=mantid_ub)

SetGoniometer(peaks, Axis0=f'{omega},0,1,0,-1', Axis1=f'{chi},0,0,1,-1', Axis2=f'{phi},0,1,0,-1')
peak = peaks.createPeakHKL([1, -2, 5])
peak.setIntensity(1)
print(peak.getQSampleFrame())
print(peak.getQLabFrame())
print(peak.getDetectorID())
peaks.addPeak(peak)

SaveHKL(peaks, Filename='/tmp/peaks_1-15.hkl', DirectionCosines=True)

# try one using values from /HFIR/HB3A/exp691/Datafiles/HB3A_exp0691_scan1000.dat                                                    
# scan_title = (0.999995 -1.999994 0.000004) 300.023 K                                                                               

omega = 8.9375
chi = 32.1317
phi = 81.9817
twotheta = 17.8753
det_trans = 399.9955

AddSampleLog(Workspace=ws, LogName='2theta', LogText=f'{twotheta}', LogType='Number Series')
AddSampleLog(Workspace=ws, LogName='det_trans', LogText=f'{det_trans}', LogType='Number Series')
LoadInstrument(ws, InstrumentName='HB3A', RewriteSpectraMap=False)

peaks = CreatePeaksWorkspace(ws, 0)
SetUB(peaks, UB=mantid_ub)

SetGoniometer(peaks, Axis0=f'{omega},0,1,0,-1', Axis1=f'{chi},0,0,1,-1', Axis2=f'{phi},0,1,0,-1')
peak = peaks.createPeakHKL([1, -2, 0])
peak.setIntensity(1)
peaks.addPeak(peak)

SaveHKL(peaks, Filename='/tmp/peaks_1-10.hkl', DirectionCosines=True)

# try one using values from /HFIR/HB3A/exp691/Datafiles/HB3A_exp0691_scan0900.dat                                                    
# scan_title = (-0.000046 8.999932 0.000021) 300.117 K                                                                               

omega = 35.3095
chi = 1.9640
phi = -101.6919
twotheta = 70.6185
det_trans = 399.9955

AddSampleLog(Workspace=ws, LogName='2theta', LogText=f'{twotheta}', LogType='Number Series')
AddSampleLog(Workspace=ws, LogName='det_trans', LogText=f'{det_trans}', LogType='Number Series')
LoadInstrument(ws, InstrumentName='HB3A', RewriteSpectraMap=False)

peaks = CreatePeaksWorkspace(ws, 0)
SetUB(peaks, UB=mantid_ub)

SetGoniometer(peaks, Axis0=f'{omega},0,1,0,-1', Axis1=f'{chi},0,0,1,-1', Axis2=f'{phi},0,1,0,-1')
peak = peaks.createPeakHKL([0, 9, 0])
peak.setIntensity(1)
peaks.addPeak(peak)

SaveHKL(peaks, Filename='/tmp/peaks_090.hkl', DirectionCosines=True)
```



---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
