### PR TITLE
IDA Convfit get lorentzian width from ipf

### DIFF
--- a/Framework/API/inc/MantidAPI/CompositeFunction.h
+++ b/Framework/API/inc/MantidAPI/CompositeFunction.h
@@ -107,8 +107,12 @@ public:
   [[nodiscard]] bool isExplicitlySet(size_t i) const override;
   /// Get the fitting error for a parameter
   [[nodiscard]] double getError(size_t i) const override;
+  /// Get the fitting error for a parameter by name
+  [[nodiscard]] double getError(const std::string &name) const override;
   /// Set the fitting error for a parameter
   void setError(size_t i, double err) override;
+  /// Set the fitting error for a parameter by name
+  void setError(const std::string &name, double err) override;
   /// Value of i-th active parameter. Override this method to make fitted
   /// parameters different from the declared
   [[nodiscard]] double activeParameter(size_t i) const override;

--- a/Framework/API/inc/MantidAPI/FunctionGenerator.h
+++ b/Framework/API/inc/MantidAPI/FunctionGenerator.h
@@ -65,8 +65,12 @@ public:
   bool isExplicitlySet(size_t i) const override;
   /// Get the fitting error for a parameter
   double getError(size_t i) const override;
+  /// Get the fitting error for a parameter by name
+  double getError(const std::string &name) const override;
   /// Set the fitting error for a parameter
   void setError(size_t i, double err) override;
+  /// Set the fitting error for a parameter by name
+  void setError(const std::string &name, double err) override;
 
   /// Return parameter index from a parameter reference.
   size_t getParameterIndex(const ParameterReference &ref) const override;

--- a/Framework/API/inc/MantidAPI/FunctionParameterDecorator.h
+++ b/Framework/API/inc/MantidAPI/FunctionParameterDecorator.h
@@ -75,8 +75,12 @@ public:
   bool isExplicitlySet(size_t i) const override;
   /// Get the fitting error for a parameter of decorated function.
   double getError(size_t i) const override;
+  /// Get the fitting error for a parameter of decorated function by name.
+  double getError(const std::string &name) const override;
   /// Set the fitting error for a parameter of decorated function.
   void setError(size_t i, double err) override;
+  /// Set the fitting error for a parameter of decorated function by name.
+  void setError(const std::string &name, double err) override;
 
   /// Return parameter index of decorated function from a parameter reference.
   /// Usefull for constraints and ties in composite functions.

--- a/Framework/API/inc/MantidAPI/IFunction.h
+++ b/Framework/API/inc/MantidAPI/IFunction.h
@@ -418,8 +418,12 @@ public:
   virtual bool isExplicitlySet(size_t i) const = 0;
   /// Get the fitting error for a parameter
   virtual double getError(size_t i) const = 0;
+  /// Get the fitting error for a parameter by name
+  virtual double getError(const std::string &name) const = 0;
   /// Set the fitting error for a parameter
   virtual void setError(size_t i, double err) = 0;
+  /// Set the fitting error for a parameter by name
+  virtual void setError(const std::string &name, double err) = 0;
 
   /// Check if a parameter i is fixed
   [[nodiscard]] bool isFixed(size_t i) const;

--- a/Framework/API/inc/MantidAPI/ParamFunction.h
+++ b/Framework/API/inc/MantidAPI/ParamFunction.h
@@ -64,8 +64,12 @@ public:
   bool isExplicitlySet(size_t i) const override;
   /// Get the fitting error for a parameter
   double getError(size_t i) const override;
+  /// Get the fitting error for a parameter by name
+  double getError(const std::string &name) const override;
   /// Set the fitting error for a parameter
   void setError(size_t i, double err) override;
+  /// Set the fitting error for a parameter by name
+  void setError(const std::string &name, double err) override;
 
   /// Return parameter index from a parameter reference. Usefull for constraints
   /// and ties in composite functions

--- a/Framework/API/src/CompositeFunction.cpp
+++ b/Framework/API/src/CompositeFunction.cpp
@@ -423,6 +423,16 @@ double CompositeFunction::getError(size_t i) const {
 }
 
 /**
+ * Get the fitting error for a parameter by name.
+ * @param name :: The name of the parameter.
+ * @return value of the requested named parameter
+ */
+double CompositeFunction::getError(const std::string &name) const {
+  const auto [parameterName, index] = parseName(name);
+  return getFunction(index)->getError(parameterName);
+}
+
+/**
  * Set the fitting error for a parameter
  * @param i :: The index of a parameter
  * @param err :: The error value to set
@@ -430,6 +440,16 @@ double CompositeFunction::getError(size_t i) const {
 void CompositeFunction::setError(size_t i, double err) {
   size_t iFun = functionIndex(i);
   m_functions[iFun]->setError(i - m_paramOffsets[iFun], err);
+}
+
+/**
+ * Sets the fitting error to a parameter by name.
+ * @param name :: The name of the parameter.
+ * @param err :: The error value to set
+ */
+void CompositeFunction::setError(const std::string &name, double err) {
+  auto [parameterName, index] = parseName(name);
+  getFunction(index)->setError(parameterName, err);
 }
 
 /// Value of i-th active parameter. Override this method to make fitted

--- a/Framework/API/src/CompositeFunction.cpp
+++ b/Framework/API/src/CompositeFunction.cpp
@@ -278,7 +278,9 @@ bool CompositeFunction::hasAttribute(const std::string &name) const {
       return true;
     }
     const auto [attributeName, index] = parseName(name);
-    return m_functions[index]->hasAttribute(attributeName);
+    return index < m_functions.size()
+               ? m_functions[index]->hasAttribute(attributeName)
+               : false;
   } catch (std::invalid_argument &) {
     return false;
   }

--- a/Framework/API/src/FunctionGenerator.cpp
+++ b/Framework/API/src/FunctionGenerator.cpp
@@ -151,6 +151,12 @@ double FunctionGenerator::getError(size_t i) const {
   }
 }
 
+/// Get the fitting error for a parameter by name
+double FunctionGenerator::getError(const std::string &name) const {
+  auto index = parameterIndex(name);
+  return getError(index);
+}
+
 /// Set the fitting error for a parameter
 void FunctionGenerator::setError(size_t i, double err) {
   if (i < m_nOwnParams) {
@@ -159,6 +165,12 @@ void FunctionGenerator::setError(size_t i, double err) {
     checkTargetFunction();
     m_target->setError(i - m_nOwnParams, err);
   }
+}
+
+/// Set the fitting error for a parameter by name
+void FunctionGenerator::setError(const std::string &name, double err) {
+  auto index = parameterIndex(name);
+  setError(index, err);
 }
 
 /// Change status of parameter

--- a/Framework/API/src/FunctionParameterDecorator.cpp
+++ b/Framework/API/src/FunctionParameterDecorator.cpp
@@ -159,10 +159,20 @@ double FunctionParameterDecorator::getError(size_t i) const {
   return m_wrappedFunction->getError(i);
 }
 
+double FunctionParameterDecorator::getError(const std::string &name) const {
+  auto index = parameterIndex(name);
+  return getError(index);
+}
+
 void FunctionParameterDecorator::setError(size_t i, double err) {
   throwIfNoFunctionSet();
 
   return m_wrappedFunction->setError(i, err);
+}
+
+void FunctionParameterDecorator::setError(const std::string &name, double err) {
+  auto index = parameterIndex(name);
+  setError(index, err);
 }
 
 size_t FunctionParameterDecorator::getParameterIndex(

--- a/Framework/API/src/ParamFunction.cpp
+++ b/Framework/API/src/ParamFunction.cpp
@@ -230,7 +230,7 @@ void ParamFunction::setError(size_t i, double err) {
 /**
  * Get the fitting error for a parameter by name.
  * @param name :: The name of a parameter
- * @return :: the error
+ * @param err :: The error value to set
  */
 void ParamFunction::setError(const std::string &name, double err) {
   auto it = std::find(m_parameterNames.cbegin(), m_parameterNames.cend(), name);

--- a/Framework/API/src/ParamFunction.cpp
+++ b/Framework/API/src/ParamFunction.cpp
@@ -188,7 +188,7 @@ std::string ParamFunction::parameterDescription(size_t i) const {
 }
 
 /**
- * Get the fitting error for a parameter
+ * Get the fitting error for a parameter.
  * @param i :: The index of a parameter
  * @return :: the error
  */
@@ -198,13 +198,53 @@ double ParamFunction::getError(size_t i) const {
 }
 
 /**
- * Set the fitting error for a parameter
+ * Get the fitting error for a parameter by name.
+ * @param name :: The name of a parameter
+ * @return :: the error
+ */
+double ParamFunction::getError(const std::string &name) const {
+  auto it = std::find(m_parameterNames.cbegin(), m_parameterNames.cend(), name);
+  if (it == m_parameterNames.cend()) {
+    std::ostringstream msg;
+    msg << "ParamFunction tries to get error of non-existing parameter ("
+        << name << ") "
+        << "to function " << this->name();
+    msg << "\nAllowed parameters: ";
+    for (const auto &parameterName : m_parameterNames)
+      msg << parameterName << ", ";
+    throw std::invalid_argument(msg.str());
+  }
+  return m_errors[static_cast<int>(it - m_parameterNames.begin())];
+}
+
+/**
+ * Set the fitting error for a parameter.
  * @param i :: The index of a parameter
  * @param err :: The error value to set
  */
 void ParamFunction::setError(size_t i, double err) {
   checkParameterIndex(i);
   m_errors[i] = err;
+}
+
+/**
+ * Get the fitting error for a parameter by name.
+ * @param name :: The name of a parameter
+ * @return :: the error
+ */
+void ParamFunction::setError(const std::string &name, double err) {
+  auto it = std::find(m_parameterNames.cbegin(), m_parameterNames.cend(), name);
+  if (it == m_parameterNames.cend()) {
+    std::ostringstream msg;
+    msg << "ParamFunction tries to set error of non-existing parameter ("
+        << name << ") "
+        << "to function " << this->name();
+    msg << "\nAllowed parameters: ";
+    for (const auto &parameterName : m_parameterNames)
+      msg << parameterName << ", ";
+    throw std::invalid_argument(msg.str());
+  }
+  m_errors[static_cast<int>(it - m_parameterNames.begin())] = err;
 }
 
 /**

--- a/Framework/API/test/CompositeFunctionTest.h
+++ b/Framework/API/test/CompositeFunctionTest.h
@@ -1420,4 +1420,20 @@ public:
     TS_ASSERT_EQUALS(mfun->attributeName(2), "f1.GaussAttribute");
     TS_ASSERT_EQUALS(mfun->attributeName(3), "f2.CubicAttribute");
   }
+
+  void test_setError_with_name() {
+    auto mfun = std::make_unique<CompositeFunction>();
+    auto gauss = std::make_shared<Gauss<false>>();
+    auto background = std::make_shared<Linear<true>>();
+    auto cubic = std::make_shared<Cubic<true>>();
+
+    mfun->addFunction(background);
+    mfun->addFunction(gauss);
+    mfun->addFunction(cubic);
+
+    mfun->setError(0, 1.0);
+    TS_ASSERT_EQUALS(mfun->getError(0), 1.0);
+    mfun->setError("f1.s", 5.0);
+    TS_ASSERT_EQUALS(mfun->getError("f1.s"), 5.0);
+  }
 };

--- a/Framework/API/test/FunctionParameterDecoratorTest.h
+++ b/Framework/API/test/FunctionParameterDecoratorTest.h
@@ -222,9 +222,10 @@ public:
     FunctionParameterDecorator_sptr fn =
         getFunctionParameterDecoratorGaussian();
     IFunction_sptr decoratedFunction = fn->getDecoratedFunction();
-
     TS_ASSERT_THROWS_NOTHING(fn->setError(0, 3.0));
+    TS_ASSERT_THROWS_NOTHING(fn->setError("PeakCentre", 4.0));
     TS_ASSERT_EQUALS(fn->getError(0), 3.0);
+    TS_ASSERT_EQUALS(fn->getError("PeakCentre"), 4.0);
     for (size_t i = 0; i < fn->nParams(); ++i) {
       TS_ASSERT_EQUALS(fn->getError(i), decoratedFunction->getError(i));
     }

--- a/Framework/API/test/IFunctionTest.h
+++ b/Framework/API/test/IFunctionTest.h
@@ -54,7 +54,9 @@ public:
   std::string parameterDescription(std::size_t) const override { return ""; }
   bool isExplicitlySet(std::size_t) const override { return true; }
   double getError(std::size_t) const override { return 0.0; }
+  double getError(const std::string &) const override { return 0.0; }
   void setError(std::size_t, double) override {}
+  void setError(const std::string &, double) override {}
   size_t
   getParameterIndex(const Mantid::API::ParameterReference &ref) const override {
     if (ref.getLocalFunction() == this && ref.getLocalIndex() < nParams()) {

--- a/Framework/API/test/ParamFunctionAttributeHolderTest.h
+++ b/Framework/API/test/ParamFunctionAttributeHolderTest.h
@@ -87,4 +87,13 @@ public:
     TS_ASSERT_EQUALS(attrNames.at(1), "Att2");
     TS_ASSERT_EQUALS(attrNames.at(2), "Att3");
   }
+
+  void test_setError_with_name() {
+    FakeParamFunctionAttributeHolder funct;
+    funct.initialize();
+    funct.setError(0, 1.0);
+    TS_ASSERT_EQUALS(funct.getError(0), 1.0);
+    funct.setError("Par1", 5.0);
+    TS_ASSERT_EQUALS(funct.getError("Par1"), 5.0);
+  }
 };

--- a/Framework/CurveFitting/inc/MantidCurveFitting/Functions/CrystalFieldFunction.h
+++ b/Framework/CurveFitting/inc/MantidCurveFitting/Functions/CrystalFieldFunction.h
@@ -61,8 +61,12 @@ public:
   bool isExplicitlySet(size_t i) const override;
   /// Get the fitting error for a parameter
   double getError(size_t i) const override;
+  /// Get the fitting error for a parameter by name
+  double getError(const std::string &name) const override;
   /// Set the fitting error for a parameter
   void setError(size_t i, double err) override;
+  /// Set the fitting error for a parameter by name
+  void setError(const std::string &name, double err) override;
 
   /// Return parameter index from a parameter reference.
   size_t getParameterIndex(const API::ParameterReference &ref) const override;

--- a/Framework/CurveFitting/src/Functions/CrystalFieldFunction.cpp
+++ b/Framework/CurveFitting/src/Functions/CrystalFieldFunction.cpp
@@ -319,6 +319,20 @@ double CrystalFieldFunction::getError(size_t i) const {
   }
 }
 
+/// Get the fitting error for a parameter
+double CrystalFieldFunction::getError(const std::string &name) const {
+  auto index = parameterIndex(name);
+  checkSourceFunction();
+  checkTargetFunction();
+  if (index < m_nControlParams) {
+    return m_control.getError(index);
+  } else if (index < m_nControlSourceParams) {
+    return m_source->getError(index - m_nControlParams);
+  } else {
+    return m_target->getError(index - m_nControlSourceParams);
+  }
+}
+
 /// Set the fitting error for a parameter
 void CrystalFieldFunction::setError(size_t i, double err) {
   checkSourceFunction();
@@ -329,6 +343,20 @@ void CrystalFieldFunction::setError(size_t i, double err) {
     m_source->setError(i - m_nControlParams, err);
   } else {
     m_target->setError(i - m_nControlSourceParams, err);
+  }
+}
+
+/// Set the fitting error for a parameter
+void CrystalFieldFunction::setError(const std::string &name, double err) {
+  auto index = parameterIndex(name);
+  checkSourceFunction();
+  checkTargetFunction();
+  if (index < m_nControlParams) {
+    m_control.setError(index, err);
+  } else if (index < m_nControlSourceParams) {
+    m_source->setError(index - m_nControlParams, err);
+  } else {
+    m_target->setError(index - m_nControlSourceParams, err);
   }
 }
 

--- a/docs/source/release/v6.0.0/indirect_geometry.rst
+++ b/docs/source/release/v6.0.0/indirect_geometry.rst
@@ -17,6 +17,7 @@ Improvements
 - Plotted fits in indirect data analysis are cleared when the fit parameters are changed.
 - The context menu for plots in the  indirect data analysis GUI is now enabled.
 - The function browser in the ConvFit tab should now correctly show Q values for Q dependent functions.
+- The ConvFit tab in the Indirect Data Analysis GUI will now set default parameters for the FWHM when a resolution file is loaded.
 
 Bug Fixes
 #########

--- a/qt/scientific_interfaces/Indirect/ConvFit.cpp
+++ b/qt/scientific_interfaces/Indirect/ConvFit.cpp
@@ -127,38 +127,6 @@ void ConvFit::setModelResolution(const std::string &resolutionName,
   setModelFitFunction();
 }
 
-void ConvFit::setDefaultResolution(
-    const Mantid::API::MatrixWorkspace_const_sptr &ws,
-    const QPair<double, double> &range) {
-  auto inst = ws->getInstrument();
-  auto analyser = inst->getStringParameter("analyser");
-
-  if (analyser.size() > 0) {
-    auto comp = inst->getComponentByName(analyser[0]);
-
-    if (comp) {
-      auto params = comp->getNumberParameter("resolution", true);
-      
-      // set the default instrument resolution
-      if (!params.empty()) {
-        double res = params[0];
-        m_dblManager->setValue(m_properties["InstrumentResolution"], res);
-        m_dblManager->setValue(m_properties["IntegrationStart"], -res);
-        m_dblManager->setValue(m_properties["IntegrationEnd"], res);
-
-        m_dblManager->setValue(m_properties["BackgroundStart"], -10 * res);
-        m_dblManager->setValue(m_properties["BackgroundEnd"], -9 * res);
-      } else {
-        m_dblManager->setValue(m_properties["IntegrationStart"], range.first);
-        m_dblManager->setValue(m_properties["IntegrationEnd"], range.second);
-      }
-    } else {
-      showMessageBox("Warning: The instrument definition file for the input "
-                     "workspace contains an invalid value.");
-    }
-  }
-}
-
 void ConvFit::fitFunctionChanged() {
   m_convFittingModel->setFitTypeString(fitTypeString());
 }

--- a/qt/scientific_interfaces/Indirect/ConvFit.cpp
+++ b/qt/scientific_interfaces/Indirect/ConvFit.cpp
@@ -123,7 +123,40 @@ void ConvFit::setModelResolution(const std::string &resolutionName,
   m_convFittingModel->setResolution(resolutionName, index);
   auto fitResolutions = m_convFittingModel->getResolutionsForFit();
   m_fitPropertyBrowser->setModelResolution(fitResolutions);
+  updateParameterValues();
   setModelFitFunction();
+}
+
+void ConvFit::setDefaultResolution(
+    const Mantid::API::MatrixWorkspace_const_sptr &ws,
+    const QPair<double, double> &range) {
+  auto inst = ws->getInstrument();
+  auto analyser = inst->getStringParameter("analyser");
+
+  if (analyser.size() > 0) {
+    auto comp = inst->getComponentByName(analyser[0]);
+
+    if (comp) {
+      auto params = comp->getNumberParameter("resolution", true);
+      
+      // set the default instrument resolution
+      if (!params.empty()) {
+        double res = params[0];
+        m_dblManager->setValue(m_properties["InstrumentResolution"], res);
+        m_dblManager->setValue(m_properties["IntegrationStart"], -res);
+        m_dblManager->setValue(m_properties["IntegrationEnd"], res);
+
+        m_dblManager->setValue(m_properties["BackgroundStart"], -10 * res);
+        m_dblManager->setValue(m_properties["BackgroundEnd"], -9 * res);
+      } else {
+        m_dblManager->setValue(m_properties["IntegrationStart"], range.first);
+        m_dblManager->setValue(m_properties["IntegrationEnd"], range.second);
+      }
+    } else {
+      showMessageBox("Warning: The instrument definition file for the input "
+                     "workspace contains an invalid value.");
+    }
+  }
 }
 
 void ConvFit::fitFunctionChanged() {

--- a/qt/scientific_interfaces/Indirect/ConvFit.h
+++ b/qt/scientific_interfaces/Indirect/ConvFit.h
@@ -32,6 +32,8 @@ protected slots:
   void setModelResolution(const std::string &resolutionName);
   void setModelResolution(const std::string &resolutionName,
                           TableDatasetIndex index);
+  void setDefaultResolution(const Mantid::API::MatrixWorkspace_const_sptr &ws,
+                            const QPair<double, double> &range);
   void runClicked();
   void fitFunctionChanged();
 

--- a/qt/scientific_interfaces/Indirect/ConvFit.h
+++ b/qt/scientific_interfaces/Indirect/ConvFit.h
@@ -32,8 +32,6 @@ protected slots:
   void setModelResolution(const std::string &resolutionName);
   void setModelResolution(const std::string &resolutionName,
                           TableDatasetIndex index);
-  void setDefaultResolution(const Mantid::API::MatrixWorkspace_const_sptr &ws,
-                            const QPair<double, double> &range);
   void runClicked();
   void fitFunctionChanged();
 

--- a/qt/scientific_interfaces/Indirect/IndirectFitAnalysisTab.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectFitAnalysisTab.cpp
@@ -419,7 +419,7 @@ void IndirectFitAnalysisTab::updateParameterValues(
         params) {
   try {
     updateFitBrowserParameterValues(params);
-  } catch (const std::out_of_range &error) {
+  } catch (const std::out_of_range &) {
     g_log.warning(
         "Warning issue updating parameter values in fit property browser");
   } catch (const std::invalid_argument &) {

--- a/qt/scientific_interfaces/Indirect/IndirectFitAnalysisTab.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectFitAnalysisTab.cpp
@@ -415,7 +415,7 @@ void IndirectFitAnalysisTab::updateParameterValues() {
  * @param parameters  The parameter values to update the browser with.
  */
 void IndirectFitAnalysisTab::updateParameterValues(
-    const std::unordered_map<std::string, ParameterValue> params) {
+    const std::unordered_map<std::string, ParameterValue> &params) {
   try {
     updateFitBrowserParameterValues(params);
   } catch (const std::out_of_range &) {

--- a/qt/scientific_interfaces/Indirect/IndirectFitAnalysisTab.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectFitAnalysisTab.cpp
@@ -415,8 +415,7 @@ void IndirectFitAnalysisTab::updateParameterValues() {
  * @param parameters  The parameter values to update the browser with.
  */
 void IndirectFitAnalysisTab::updateParameterValues(
-    const std::unordered_map<std::string, ParameterValue>
-        params) {
+    const std::unordered_map<std::string, ParameterValue> params) {
   try {
     updateFitBrowserParameterValues(params);
   } catch (const std::out_of_range &) {

--- a/qt/scientific_interfaces/Indirect/IndirectFitAnalysisTab.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectFitAnalysisTab.cpp
@@ -415,10 +415,11 @@ void IndirectFitAnalysisTab::updateParameterValues() {
  * @param parameters  The parameter values to update the browser with.
  */
 void IndirectFitAnalysisTab::updateParameterValues(
-    const std::unordered_map<std::string, ParameterValue> &) {
+    const std::unordered_map<std::string, ParameterValue>
+        params) {
   try {
-    updateFitBrowserParameterValues();
-  } catch (const std::out_of_range &) {
+    updateFitBrowserParameterValues(params);
+  } catch (const std::out_of_range &error) {
     g_log.warning(
         "Warning issue updating parameter values in fit property browser");
   } catch (const std::invalid_argument &) {
@@ -427,9 +428,13 @@ void IndirectFitAnalysisTab::updateParameterValues(
   }
 }
 
-void IndirectFitAnalysisTab::updateFitBrowserParameterValues() {
+void IndirectFitAnalysisTab::updateFitBrowserParameterValues(
+    std::unordered_map<std::string, ParameterValue> params) {
   IFunction_sptr fun = m_fittingModel->getFittingFunction();
   if (fun) {
+    for (auto pair : params) {
+      fun->setParameter(pair.first, pair.second.value);
+    }
     if (fun->getNumberDomains() > 1) {
       m_fitPropertyBrowser->updateMultiDatasetParameters(*fun);
     } else {

--- a/qt/scientific_interfaces/Indirect/IndirectFitAnalysisTab.h
+++ b/qt/scientific_interfaces/Indirect/IndirectFitAnalysisTab.h
@@ -115,8 +115,10 @@ protected slots:
   void executeFit();
   void updateParameterValues();
   void updateParameterValues(
-      const std::unordered_map<std::string, ParameterValue> &parameters);
-  void updateFitBrowserParameterValues();
+      const std::unordered_map<std::string, ParameterValue> parameters);
+  void updateFitBrowserParameterValues(
+      std::unordered_map<std::string, ParameterValue> parameters =
+          std::unordered_map<std::string, ParameterValue>());
   void updateFitBrowserParameterValuesFromAlg();
   void updateFitStatus();
   void updateDataReferences();

--- a/qt/scientific_interfaces/Indirect/IndirectFitAnalysisTab.h
+++ b/qt/scientific_interfaces/Indirect/IndirectFitAnalysisTab.h
@@ -115,7 +115,7 @@ protected slots:
   void executeFit();
   void updateParameterValues();
   void updateParameterValues(
-      const std::unordered_map<std::string, ParameterValue> parameters);
+      const std::unordered_map<std::string, ParameterValue> &parameters);
   void updateFitBrowserParameterValues(
       std::unordered_map<std::string, ParameterValue> parameters =
           std::unordered_map<std::string, ParameterValue>());

--- a/qt/scientific_interfaces/Indirect/IndirectFitPlotModel.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectFitPlotModel.cpp
@@ -246,8 +246,9 @@ std::string IndirectFitPlotModel::getLastFitDataName() const {
 
 boost::optional<double> IndirectFitPlotModel::getFirstHWHM() const {
   auto fwhm = findFirstFWHM(m_fittingModel->getFittingFunction());
-  if (fwhm)
+  if (fwhm) {
     return *fwhm / 2.0;
+  }
   return boost::none;
 }
 

--- a/qt/scientific_interfaces/Indirect/IndirectFittingModel.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectFittingModel.cpp
@@ -158,8 +158,14 @@ template <typename Map> Map combine(const Map &mapA, const Map &mapB) {
 std::unordered_map<std::string, std::string>
 shortToLongParameterNames(const IFunction_sptr &function) {
   std::unordered_map<std::string, std::string> shortToLong;
-  for (const auto &name : function->getParameterNames())
-    shortToLong[name.substr(name.rfind(".") + 1)] = name;
+  for (const auto &name : function->getParameterNames()) {
+    auto shortName = name.substr(name.rfind(".") + 1);
+    if (shortToLong.find(shortName) != shortToLong.end()) {
+      shortToLong[shortName] += "," + name;
+    } else {
+      shortToLong[shortName] = name;
+    }
+  }
   return shortToLong;
 }
 
@@ -168,8 +174,13 @@ Map mapKeys(const Map &map, const KeyMap &mapping) {
   Map mapped;
   for (const auto value : map) {
     auto it = mapping.find(value.first);
-    if (it != mapping.end())
-      mapped[it->second] = value.second;
+    if (it != mapping.end()) {
+      std::stringstream paramNames(it->second);
+      std::string paramName;
+      while (std::getline(paramNames, paramName, ',')) {
+        mapped[paramName] = value.second;
+      }
+    }
   }
   return mapped;
 }

--- a/qt/scientific_interfaces/Indirect/test/IndirectFittingModelTest.h
+++ b/qt/scientific_interfaces/Indirect/test/IndirectFittingModelTest.h
@@ -695,4 +695,26 @@ public:
     model->cleanFailedSingleRun(alg, 0);
     TS_ASSERT(!ads.doesExist("__ConvolutionFitSequential_ws1"));
   }
+
+  void
+  test_that_getDefaultParameters_returns_full_list_of_names_for_multi_domain_functions() {
+
+    auto model = createModelWithSingleWorkspace("Name", 1);
+
+    auto const function = getFunction(
+        "composite=MultiDomainFunction,NumDeriv=true;(composite=Convolution,"
+        "NumDeriv=true,FixResolution=true,$domains=i;name=Resolution,"
+        "WorkspaceIndex=0,X=(),Y=();(name=Lorentzian,Amplitude=1,PeakCentre=0,"
+        "FWHM=1,constraints=(0<Amplitude,0<FWHM);name=Lorentzian,Amplitude=1,"
+        "PeakCentre=0,FWHM=1,constraints=(0<Amplitude,0<FWHM)));");
+    model->setFitFunction(function);
+    model->setDefaultParameterValue("Amplitude", 1.5, 0);
+
+    auto paramMap = model->getDefaultParameters(0);
+    TS_ASSERT(paramMap.find("f0.f0.f1.f0.Amplitude") != paramMap.end());
+    TS_ASSERT(paramMap.find("f0.f0.f1.f1.Amplitude") != paramMap.end());
+    TS_ASSERT(paramMap.at("f0.f0.f1.f0.Amplitude").value == 1.5);
+    TS_ASSERT(paramMap.at("f0.f0.f1.f1.Amplitude").value == 1.5);
+    
+  }
 };

--- a/qt/scientific_interfaces/Indirect/test/IndirectFittingModelTest.h
+++ b/qt/scientific_interfaces/Indirect/test/IndirectFittingModelTest.h
@@ -715,6 +715,5 @@ public:
     TS_ASSERT(paramMap.find("f0.f0.f1.f1.Amplitude") != paramMap.end());
     TS_ASSERT(paramMap.at("f0.f0.f1.f0.Amplitude").value == 1.5);
     TS_ASSERT(paramMap.at("f0.f0.f1.f1.Amplitude").value == 1.5);
-    
   }
 };

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/FunctionModel.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/FunctionModel.h
@@ -82,6 +82,7 @@ protected:
 private:
   void checkIndex(int) const;
   void updateGlobals();
+  void setResolutionFromWorkspace(IFunction_sptr fun);
   size_t m_currentDomainIndex = 0;
   mutable QStringList m_datasetNames;
   mutable QStringList m_globalParameterNames;

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/FunctionModel.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/FunctionModel.h
@@ -10,6 +10,7 @@
 
 #include "IFunctionModel.h"
 #include "MantidAPI/IFunction.h"
+#include "MantidAPI/MatrixWorkspace.h"
 
 #include <QString>
 #include <QStringList>
@@ -83,6 +84,8 @@ private:
   void checkIndex(int) const;
   void updateGlobals();
   void setResolutionFromWorkspace(IFunction_sptr fun);
+  void setResolutionFromWorkspace(IFunction_sptr fun,
+                                  const MatrixWorkspace_sptr workspace);
   size_t m_currentDomainIndex = 0;
   mutable QStringList m_datasetNames;
   mutable QStringList m_globalParameterNames;

--- a/qt/widgets/common/src/FunctionModel.cpp
+++ b/qt/widgets/common/src/FunctionModel.cpp
@@ -11,8 +11,8 @@
 #include "MantidAPI/IBackgroundFunction.h"
 #include "MantidAPI/MatrixWorkspace.h"
 #include "MantidAPI/MultiDomainFunction.h"
-#include "MantidKernel/Logger.h"
 #include "MantidGeometry/Instrument.h"
+#include "MantidKernel/Logger.h"
 #include "MantidQtWidgets/Common/FunctionBrowser/FunctionBrowserUtils.h"
 
 namespace {

--- a/qt/widgets/common/src/FunctionModel.cpp
+++ b/qt/widgets/common/src/FunctionModel.cpp
@@ -450,14 +450,10 @@ void FunctionModel::checkIndex(int index) const {
 void FunctionModel::updateMultiDatasetParameters(const IFunction &fun) {
   if (!hasFunction())
     return;
-  if (m_function->nParams() != fun.nParams())
-    return;
-  for (size_t i = 0; i < fun.nParams(); ++i) {
-    m_function->setParameter(i, fun.getParameter(i));
-    m_function->setError(i, fun.getError(i));
-  }
+  copyParametersAndErrors(fun, *m_function);
   updateMultiDatasetAttributes(fun);
 }
+
 void FunctionModel::updateMultiDatasetAttributes(const IFunction &fun) {
   if (!hasFunction())
     return;

--- a/qt/widgets/common/src/FunctionModel.cpp
+++ b/qt/widgets/common/src/FunctionModel.cpp
@@ -505,7 +505,7 @@ void FunctionModel::setResolutionFromWorkspace(IFunction_sptr fun) {
         auto analyser = inst->getStringParameter("analyser");
         if (analyser.size() > 0) {
           auto comp = inst->getComponentByName(analyser[0]);
-          if (comp) {
+          if (comp && comp->hasParameter("resolution")) {
             auto params = comp->getNumberParameter("resolution", true);
             auto funString = fun->asString();
             for (auto param : fun->getParameterNames()) {

--- a/qt/widgets/common/test/FunctionModelTest.h
+++ b/qt/widgets/common/test/FunctionModelTest.h
@@ -101,12 +101,13 @@ public:
         "composite=Convolution,NumDeriv=true,FixResolution=true;name="
         "Resolution,"
         "Workspace=iris26173_graphite002_res,WorkspaceIndex=0,X=(),Y=();name="
-        "Lorentzian,Amplitude=1,PeakCentre=0,FWHM=0.0175,constraints=(0<Amplitude,0<"
+        "Lorentzian,Amplitude=1,PeakCentre=0,FWHM=0.0175,constraints=(0<"
+        "Amplitude,0<"
         "FWHM)";
     model.setFunctionString(initialFunString);
     auto fun = model.getFitFunction();
     auto funString = fun->asString();
-    TS_ASSERT(funString==correctedFunString);
+    TS_ASSERT(funString == correctedFunString);
   }
 
   void test_globals() {

--- a/qt/widgets/common/test/FunctionModelTest.h
+++ b/qt/widgets/common/test/FunctionModelTest.h
@@ -6,6 +6,8 @@
 // SPDX - License - Identifier: GPL - 3.0 +
 #pragma once
 
+#include "MantidAPI/AlgorithmManager.h"
+#include "MantidAPI/AnalysisDataService.h"
 #include "MantidAPI/FrameworkManager.h"
 #include "MantidAPI/FunctionFactory.h"
 #include "MantidAPI/IFunction.h"
@@ -81,6 +83,30 @@ public:
       TS_ASSERT_EQUALS(fun->getParameter("f1.A0"), 1.0);
       TS_ASSERT_EQUALS(fun->getParameter("f1.A1"), 2.0);
     }
+  }
+
+  void test_function_resolution_from_workspace() {
+    FunctionModel model;
+    auto algo = AlgorithmManager::Instance().create("Load");
+    algo->setPropertyValue("Filename", "iris26173_graphite002_res");
+    algo->setPropertyValue("OutputWorkspace", "iris26173_graphite002_res");
+    algo->execute();
+    auto initialFunString =
+        "composite=Convolution,NumDeriv=true,FixResolution=true;name="
+        "Resolution,"
+        "Workspace=iris26173_graphite002_res,WorkspaceIndex=0,X=(),Y=();name="
+        "Lorentzian,Amplitude=1,PeakCentre=0,FWHM=1,constraints=(0<Amplitude,0<"
+        "FWHM)";
+    auto correctedFunString =
+        "composite=Convolution,NumDeriv=true,FixResolution=true;name="
+        "Resolution,"
+        "Workspace=iris26173_graphite002_res,WorkspaceIndex=0,X=(),Y=();name="
+        "Lorentzian,Amplitude=1,PeakCentre=0,FWHM=0.0175,constraints=(0<Amplitude,0<"
+        "FWHM)";
+    model.setFunctionString(initialFunString);
+    auto fun = model.getFitFunction();
+    auto funString = fun->asString();
+    TS_ASSERT(funString==correctedFunString);
   }
 
   void test_globals() {


### PR DESCRIPTION
**Description of work.**

This PR makes it so that the Convfit tab in the indirct data analysis gui can get it's initial guess paramiters for it's lorenzian from the resolution IPF when it is loaded. 
Also as part of finding a solution to this I have also added a propper overload for IFunction getError and SetError by paramiter name instead of just index.

**To test:**

1. get data from #24664 
1. Open workbench
2. Open Indirect->Data Analysis
3. Go to Convfit
4. In the function browser add a lorenzian
5. Load a sample resolution pair
6. The function browser shoud have it's FWHM changed to 0.0175, the rage markers on the plor should have been updated to reflect this.
7. change to multiple input and do the same with indevidual spectra and combinations of different workspaces.

Fixes #29254 

The changes to convfit has release notes, but the overload for getError and setError are internal only and do not require them.

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
