### PR TITLE
Fix LoadCIF bug causing an error message

### DIFF
--- a/Testing/Data/SystemTest/DyAgGe20K.cif.md5
+++ b/Testing/Data/SystemTest/DyAgGe20K.cif.md5
@@ -1,0 +1,1 @@
+48ead9890bea64fa0c3ef336cc90bb36

--- a/Testing/SystemTests/tests/framework/LoadCIFTest.py
+++ b/Testing/SystemTests/tests/framework/LoadCIFTest.py
@@ -1,0 +1,35 @@
+# Mantid Repository : https://github.com/mantidproject/mantid
+#
+# Copyright &copy; 2020 ISIS Rutherford Appleton Laboratory UKRI,
+#   NScD Oak Ridge National Laboratory, European Spallation Source,
+#   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+# SPDX - License - Identifier: GPL - 3.0 +
+import systemtesting
+import numpy as np
+from CrystalField import PointCharge
+
+
+class LoadCIFDataWithTwoSectionsTest(systemtesting.MantidSystemTest):
+    """
+    Tests that the LoadCIF algorithm embedded in the PointCharge class will load cif data which contains two sections,
+    and calculates the correct parameters from this data.
+    """
+    expected_parameter_values = [-1.004456, -0.488169, 0.579923, 0.000888, -0.001776, 0.000195, 0.001026, 0.000512,
+                                 -5.418847e-7, -4.066401e-7, -1.459750e-7, 2.347822e-7, -3.138693e-7, -1.384160e-6]
+
+    def __init__(self):
+        super(LoadCIFDataWithTwoSectionsTest, self).__init__()
+
+    def requiredFiles(self):
+        return ['DyAgGe20K.cif']
+
+    def runTest(self):
+
+        cif_pc_model = PointCharge('DyAgGe20K.cif')
+
+        cif_pc_model.Charges = {'Ge2': -3, 'Ge1': -3, 'Dy': 2.3, 'Ag': 0.7}
+        cif_pc_model.IonLabel = 'Dy'
+        cif_pc_model.Neighbour = 4
+        cif_blm = cif_pc_model.calculate()
+
+        np.testing.assert_allclose(list(cif_blm.values()), self.expected_parameter_values, atol=0.00001)

--- a/docs/source/release/v6.0.0/direct_geometry.rst
+++ b/docs/source/release/v6.0.0/direct_geometry.rst
@@ -46,6 +46,8 @@ New
 BugFixes
 ########
 - Fixed a bug in the :ref:`Crystal Field Python Interface` where ties were not being applied properly for cubic crystal structures.
+- Fixed a bug in the :ref:`LoadCIF <algm-LoadCIF>` algorithm caused when a **.cif** file has 2 sections, with the first not having
+  the required data keys.
 
 
 DGSPlanner


### PR DESCRIPTION
**Description of work.**
This PR fixes a bug in the LoadCIF algorithm which was caused by a .cif file with more than 1 sections. If the 1st section didn't have the required data keys, the algorithm would not check any of the subsequent sections.

**To test:**
1. Run the script provided below. Make sure the data is saved in a findable location.
2. The Script should run without a red error message appearing in the log.

**Test Script**
[bug-29930.zip](https://github.com/mantidproject/mantid/files/5525040/bug-29930.zip)

[test-data.zip](https://github.com/mantidproject/mantid/files/5525047/test-data.zip)

Fixes #29930

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
