### PR TITLE
Modernise emplace usage to ensure in place construction

### DIFF
--- a/Framework/API/src/MultipleFileProperty.cpp
+++ b/Framework/API/src/MultipleFileProperty.cpp
@@ -309,7 +309,7 @@ MultipleFileProperty::setValueAsMultipleFiles(const std::string &propValue) {
       // existing) file within a token, but which has unexpected zero padding,
       // or some other anomaly.
       if (VectorHelper::flattenVector(f).empty())
-        f.emplace_back(std::vector<std::string>(1, plusTokenString));
+        f.emplace_back(1, plusTokenString);
 
       if (plusTokenStrings.size() > 1) {
         // See [3] in header documentation.  Basically, for reasons of

--- a/Framework/Algorithms/src/CreateDetectorTable.cpp
+++ b/Framework/Algorithms/src/CreateDetectorTable.cpp
@@ -183,23 +183,23 @@ createDetectorTableWorkspace(const MatrixWorkspace_sptr &ws,
 std::vector<std::pair<std::string, std::string>>
 createColumns(const bool isScanning, const bool includeData, const bool calcQ) {
   std::vector<std::pair<std::string, std::string>> colNames;
-  colNames.emplace_back(std::make_pair("double", "Index"));
-  colNames.emplace_back(std::make_pair("int", "Spectrum No"));
-  colNames.emplace_back(std::make_pair("str", "Detector ID(s)"));
+  colNames.emplace_back("double", "Index");
+  colNames.emplace_back("int", "Spectrum No");
+  colNames.emplace_back("str", "Detector ID(s)");
   if (isScanning)
-    colNames.emplace_back(std::make_pair("str", "Time Indexes"));
+    colNames.emplace_back("str", "Time Indexes");
   if (includeData) {
-    colNames.emplace_back(std::make_pair("double", "Data Value"));
-    colNames.emplace_back(std::make_pair("double", "Data Error"));
+    colNames.emplace_back("double", "Data Value");
+    colNames.emplace_back("double", "Data Error");
   }
 
-  colNames.emplace_back(std::make_pair("double", "R"));
-  colNames.emplace_back(std::make_pair("double", "Theta"));
+  colNames.emplace_back("double", "R");
+  colNames.emplace_back("double", "Theta");
   if (calcQ) {
-    colNames.emplace_back(std::make_pair("double", "Q"));
+    colNames.emplace_back("double", "Q");
   }
-  colNames.emplace_back(std::make_pair("double", "Phi"));
-  colNames.emplace_back(std::make_pair("str", "Monitor"));
+  colNames.emplace_back("double", "Phi");
+  colNames.emplace_back("str", "Monitor");
   return colNames;
 }
 

--- a/Framework/Crystal/src/OptimizeLatticeForCellType.cpp
+++ b/Framework/Crystal/src/OptimizeLatticeForCellType.cpp
@@ -100,7 +100,7 @@ void OptimizeLatticeForCellType::exec() {
   if (perRun) {
     std::vector<std::pair<std::string, bool>> criteria;
     // Sort by run number
-    criteria.emplace_back(std::pair<std::string, bool>("runnumber", true));
+    criteria.emplace_back("runnumber", true);
     ws->sort(criteria);
     const std::vector<Peak> &peaks_all = ws->getPeaks();
     int run = 0;

--- a/Framework/Crystal/src/PeakAlgorithmHelpers.cpp
+++ b/Framework/Crystal/src/PeakAlgorithmHelpers.cpp
@@ -170,8 +170,8 @@ generateOffsetVectors(const std::vector<Kernel::V3D> &modVectors,
           for (auto p = -maxOrder; p <= maxOrder; ++p) {
             if (m == 0 && n == 0 && p == 0)
               continue;
-            offsets.emplace_back(std::make_tuple(
-                m, n, p, modVector0 * m + modVector1 * n + modVector2 * p));
+            offsets.emplace_back(
+                m, n, p, modVector0 * m + modVector1 * n + modVector2 * p);
           }
         }
       }
@@ -188,13 +188,13 @@ generateOffsetVectors(const std::vector<Kernel::V3D> &modVectors,
         V3D offset{modVector * order};
         switch (i) {
         case 0:
-          offsets.emplace_back(std::make_tuple(order, 0, 0, std::move(offset)));
+          offsets.emplace_back(order, 0, 0, std::move(offset));
           break;
         case 1:
-          offsets.emplace_back(std::make_tuple(0, order, 0, std::move(offset)));
+          offsets.emplace_back(0, order, 0, std::move(offset));
           break;
         case 2:
-          offsets.emplace_back(std::make_tuple(0, 0, order, std::move(offset)));
+          offsets.emplace_back(0, 0, order, std::move(offset));
           break;
         }
       }

--- a/Framework/Crystal/src/PredictPeaks.cpp
+++ b/Framework/Crystal/src/PredictPeaks.cpp
@@ -196,7 +196,7 @@ void PredictPeaks::exec() {
     // Sort peaks by run number so that peaks with equal goniometer matrices are
     // adjacent
     std::vector<std::pair<std::string, bool>> criteria;
-    criteria.emplace_back(std::pair<std::string, bool>("RunNumber", true));
+    criteria.emplace_back("RunNumber", true);
 
     peaksWS->sort(criteria);
 
@@ -360,8 +360,8 @@ void PredictPeaks::exec() {
   // Sort peaks by run number so that peaks with equal goniometer matrices are
   // adjacent
   std::vector<std::pair<std::string, bool>> criteria;
-  criteria.emplace_back(std::pair<std::string, bool>("RunNumber", true));
-  criteria.emplace_back(std::pair<std::string, bool>("BankName", true));
+  criteria.emplace_back("RunNumber", true);
+  criteria.emplace_back("BankName", true);
   m_pw->sort(criteria);
 
   auto &peaks = m_pw->getPeaks();

--- a/Framework/Crystal/src/PredictSatellitePeaks.cpp
+++ b/Framework/Crystal/src/PredictSatellitePeaks.cpp
@@ -231,11 +231,11 @@ void PredictSatellitePeaks::exec() {
   // Sort peaks by run number so that peaks with equal goniometer matrices are
   // adjacent
   std::vector<std::pair<std::string, bool>> criteria;
-  criteria.emplace_back(std::pair<std::string, bool>("RunNumber", true));
-  criteria.emplace_back(std::pair<std::string, bool>("BankName", true));
-  criteria.emplace_back(std::pair<std::string, bool>("h", true));
-  criteria.emplace_back(std::pair<std::string, bool>("k", true));
-  criteria.emplace_back(std::pair<std::string, bool>("l", true));
+  criteria.emplace_back("RunNumber", true);
+  criteria.emplace_back("BankName", true);
+  criteria.emplace_back("h", true);
+  criteria.emplace_back("k", true);
+  criteria.emplace_back("l", true);
   outPeaks->sort(criteria);
 
   for (int i = 0; i < static_cast<int>(outPeaks->getNumberPeaks()); ++i) {
@@ -317,11 +317,11 @@ void PredictSatellitePeaks::exec_peaks() {
   // Sort peaks by run number so that peaks with equal goniometer matrices are
   // adjacent
   std::vector<std::pair<std::string, bool>> criteria;
-  criteria.emplace_back(std::pair<std::string, bool>("RunNumber", true));
-  criteria.emplace_back(std::pair<std::string, bool>("BankName", true));
-  criteria.emplace_back(std::pair<std::string, bool>("h", true));
-  criteria.emplace_back(std::pair<std::string, bool>("k", true));
-  criteria.emplace_back(std::pair<std::string, bool>("l", true));
+  criteria.emplace_back("RunNumber", true);
+  criteria.emplace_back("BankName", true);
+  criteria.emplace_back("h", true);
+  criteria.emplace_back("k", true);
+  criteria.emplace_back("l", true);
   outPeaks->sort(criteria);
 
   for (int i = 0; i < static_cast<int>(outPeaks->getNumberPeaks()); ++i) {

--- a/Framework/Crystal/src/SaveLauenorm.cpp
+++ b/Framework/Crystal/src/SaveLauenorm.cpp
@@ -119,16 +119,16 @@ void SaveLauenorm::exec() {
   // We must sort the peaks
   std::vector<std::pair<std::string, bool>> criteria;
   if (type.compare(0, 2, "Ba") == 0)
-    criteria.emplace_back(std::pair<std::string, bool>("BankName", true));
+    criteria.emplace_back("BankName", true);
   else if (type.compare(0, 2, "Ru") == 0)
-    criteria.emplace_back(std::pair<std::string, bool>("RunNumber", true));
+    criteria.emplace_back("RunNumber", true);
   else {
-    criteria.emplace_back(std::pair<std::string, bool>("RunNumber", true));
-    criteria.emplace_back(std::pair<std::string, bool>("BankName", true));
+    criteria.emplace_back("RunNumber", true);
+    criteria.emplace_back("BankName", true);
   }
-  criteria.emplace_back(std::pair<std::string, bool>("h", true));
-  criteria.emplace_back(std::pair<std::string, bool>("k", true));
-  criteria.emplace_back(std::pair<std::string, bool>("l", true));
+  criteria.emplace_back("h", true);
+  criteria.emplace_back("k", true);
+  criteria.emplace_back("l", true);
   ws->sort(criteria);
 
   std::vector<Peak> peaks = ws->getPeaks();

--- a/Framework/Crystal/src/SortPeaksWorkspace.cpp
+++ b/Framework/Crystal/src/SortPeaksWorkspace.cpp
@@ -70,7 +70,7 @@ void SortPeaksWorkspace::exec() {
 
   // Perform the sorting.
   std::vector<PeaksWorkspace::ColumnAndDirection> sortCriteria;
-  sortCriteria.emplace_back(std::make_pair(columnToSortBy, sortAscending));
+  sortCriteria.emplace_back(columnToSortBy, sortAscending);
   outputWS->sort(sortCriteria);
   setProperty("OutputWorkspace", outputWS);
 }

--- a/Framework/Crystal/src/StatisticsOfPeaksWorkspace.cpp
+++ b/Framework/Crystal/src/StatisticsOfPeaksWorkspace.cpp
@@ -118,13 +118,13 @@ void StatisticsOfPeaksWorkspace::exec() {
   // We must sort the peaks
   std::vector<std::pair<std::string, bool>> criteria;
   if (sortType.compare(0, 2, "Re") == 0)
-    criteria.emplace_back(std::pair<std::string, bool>("DSpacing", false));
+    criteria.emplace_back("DSpacing", false);
   else if (sortType.compare(0, 2, "Ru") == 0)
-    criteria.emplace_back(std::pair<std::string, bool>("RunNumber", true));
-  criteria.emplace_back(std::pair<std::string, bool>("BankName", true));
-  criteria.emplace_back(std::pair<std::string, bool>("h", true));
-  criteria.emplace_back(std::pair<std::string, bool>("k", true));
-  criteria.emplace_back(std::pair<std::string, bool>("l", true));
+    criteria.emplace_back("RunNumber", true);
+  criteria.emplace_back("BankName", true);
+  criteria.emplace_back("h", true);
+  criteria.emplace_back("k", true);
+  criteria.emplace_back("l", true);
   ws->sort(criteria);
 
   // =========================================

--- a/Framework/CurveFitting/src/Algorithms/EstimateFitParameters.cpp
+++ b/Framework/CurveFitting/src/Algorithms/EstimateFitParameters.cpp
@@ -230,7 +230,7 @@ void runCrossEntropy(
   for (auto &range : ranges) {
     auto mean = (range.first + range.second) / 2;
     auto sigma = std::fabs(range.first - range.second) / 2;
-    distributionParams.emplace_back(std::make_pair(mean, sigma));
+    distributionParams.emplace_back(mean, sigma);
   }
 
   auto nParams = costFunction.nParams();
@@ -401,7 +401,7 @@ void EstimateFitParameters::execConcrete() {
     }
     // Use the lower and upper bounds of the constraint to set the range
     // of a generator with uniform distribution.
-    ranges.emplace_back(std::make_pair(boundary->lower(), boundary->upper()));
+    ranges.emplace_back(boundary->lower(), boundary->upper());
   }
   // Number of parameters could have changed
   costFunction->reset();

--- a/Framework/CurveFitting/src/Algorithms/LeBailFit.cpp
+++ b/Framework/CurveFitting/src/Algorithms/LeBailFit.cpp
@@ -1767,7 +1767,7 @@ void LeBailFit::setupRandomWalkStrategyFromTable(
       giter->second.emplace_back(parname);
     } else {
       // First instance in the new group.
-      m_MCGroups.emplace(group, vector<string>{parname});
+      m_MCGroups.emplace(group, std::initializer_list<std::string>{parname});
     }
 
     // 3. Set up MC parameters, A0, A1, non-negative

--- a/Framework/CurveFitting/src/Functions/CubicSpline.cpp
+++ b/Framework/CurveFitting/src/Functions/CubicSpline.cpp
@@ -106,7 +106,7 @@ void CubicSpline::setupInput(boost::scoped_array<double> &x,
     std::vector<point> pairs;
     pairs.reserve(n);
     for (int i = 0; i < n; ++i) {
-      pairs.emplace_back(std::make_pair(x[i], y[i]));
+      pairs.emplace_back(x[i], y[i]);
     }
 
     std::sort(pairs.begin(), pairs.end(),

--- a/Framework/DataHandling/src/GroupDetectors2.cpp
+++ b/Framework/DataHandling/src/GroupDetectors2.cpp
@@ -1035,7 +1035,7 @@ GroupDetectors2::formGroups(const API::MatrixWorkspace_const_sptr &inputWS,
       if (originalWI < 0)
         continue;
 
-      spectrumGroups.emplace_back(std::vector<size_t>(1, originalWI));
+      spectrumGroups.emplace_back(1, originalWI);
 
       auto spectrumNumber = inputWS->getSpectrum(originalWI).getSpectrumNo();
       spectrumNumbers.emplace_back(spectrumNumber);

--- a/Framework/DataHandling/src/LoadISISNexus2.cpp
+++ b/Framework/DataHandling/src/LoadISISNexus2.cpp
@@ -697,7 +697,7 @@ LoadISISNexus2::prepareSpectraBlocks(std::map<specnum_t, std::string> &monitors,
       includedMonitors.emplace_back(min);
     } else {
       auto max = dataBlock.getMaxSpectrumID();
-      m_spectraBlocks.emplace_back(SpectraBlock(min, max, false, ""));
+      m_spectraBlocks.emplace_back(min, max, false, "");
     }
   }
 

--- a/Framework/DataHandling/src/SaveParameterFile.cpp
+++ b/Framework/DataHandling/src/SaveParameterFile.cpp
@@ -112,24 +112,24 @@ void SaveParameterFile::exec() {
         V3D pos;
         std::istringstream pValueSS(pValue);
         pos.readPrinted(pValueSS);
-        toSave[cID].emplace_back(boost::make_tuple(
-            "x", "double", boost::lexical_cast<std::string>(pos.X())));
-        toSave[cID].emplace_back(boost::make_tuple(
-            "y", "double", boost::lexical_cast<std::string>(pos.Y())));
-        toSave[cID].emplace_back(boost::make_tuple(
-            "z", "double", boost::lexical_cast<std::string>(pos.Z())));
+        toSave[cID].emplace_back("x", "double",
+                                 boost::lexical_cast<std::string>(pos.X()));
+        toSave[cID].emplace_back("y", "double",
+                                 boost::lexical_cast<std::string>(pos.Y()));
+        toSave[cID].emplace_back("z", "double",
+                                 boost::lexical_cast<std::string>(pos.Z()));
       }
     } else if (pName == "rot") {
       if (saveLocationParams) {
         V3D rot;
         std::istringstream pValueSS(pValue);
         rot.readPrinted(pValueSS);
-        toSave[cID].emplace_back(boost::make_tuple(
-            "rotx", "double", boost::lexical_cast<std::string>(rot.X())));
-        toSave[cID].emplace_back(boost::make_tuple(
-            "roty", "double", boost::lexical_cast<std::string>(rot.Y())));
-        toSave[cID].emplace_back(boost::make_tuple(
-            "rotz", "double", boost::lexical_cast<std::string>(rot.Z())));
+        toSave[cID].emplace_back("rotx", "double",
+                                 boost::lexical_cast<std::string>(rot.X()));
+        toSave[cID].emplace_back("roty", "double",
+                                 boost::lexical_cast<std::string>(rot.Y()));
+        toSave[cID].emplace_back("rotz", "double",
+                                 boost::lexical_cast<std::string>(rot.Z()));
       }
     }
     // If it isn't a position or rotation parameter, we can just add it to the

--- a/Framework/DataHandling/test/LoadNexusProcessed2Test.h
+++ b/Framework/DataHandling/test/LoadNexusProcessed2Test.h
@@ -132,8 +132,8 @@ public:
     std::vector<SpectrumNumber> spectrumNumbers;
     size_t i = wsIn->getNumberHistograms() - 1;
     for (size_t j = 0; j < wsIn->getNumberHistograms(); --i, ++j) {
-      specDefinitions.emplace_back(SpectrumDefinition(i));
-      spectrumNumbers.emplace_back(SpectrumNumber(static_cast<int>(j)));
+      specDefinitions.emplace_back(i);
+      spectrumNumbers.emplace_back(static_cast<int>(j));
     }
     IndexInfo info(spectrumNumbers);
     info.setSpectrumDefinitions(specDefinitions);
@@ -189,8 +189,8 @@ public:
     std::vector<SpectrumNumber> spectrumNumbers;
     // We add a single detector index 0 to a single spectrum with number (1). No
     // other mappings provided!
-    specDefinitions.emplace_back(SpectrumDefinition(0));
-    spectrumNumbers.emplace_back(SpectrumNumber(1));
+    specDefinitions.emplace_back(0);
+    spectrumNumbers.emplace_back(1);
     IndexInfo info(spectrumNumbers);
     info.setSpectrumDefinitions(specDefinitions);
     wsIn->setIndexInfo(info);
@@ -252,7 +252,7 @@ public:
       def.add(i);
       def.add(i - 1);
       specDefinitions.emplace_back(def);
-      spectrumNumbers.emplace_back(SpectrumNumber(static_cast<int>(j)));
+      spectrumNumbers.emplace_back(static_cast<int>(j));
     }
     IndexInfo info(spectrumNumbers);
     info.setSpectrumDefinitions(specDefinitions);

--- a/Framework/DataObjects/inc/MantidDataObjects/MDBox.tcc
+++ b/Framework/DataObjects/inc/MantidDataObjects/MDBox.tcc
@@ -622,7 +622,7 @@ TMDE(void MDBox)::integrateSphere(
       if (out[0] < radiusSquared && out[0] > innerRadiusSquared) {
         const auto signal = static_cast<signal_t>(it.getSignal());
         const auto errSquared = static_cast<signal_t>(it.getErrorSquared());
-        vals.emplace_back(std::make_pair(signal, errSquared));
+        vals.emplace_back(signal, errSquared);
       }
     }
     // Sort based on signal values

--- a/Framework/Geometry/src/Instrument/InstrumentVisitor.cpp
+++ b/Framework/Geometry/src/Instrument/InstrumentVisitor.cpp
@@ -175,7 +175,7 @@ InstrumentVisitor::registerComponentAssembly(const ICompAssembly &assembly) {
   m_parentComponentIndices->emplace_back(componentIndex);
   const size_t componentStop = m_assemblySortedComponentIndices->size();
 
-  m_detectorRanges->emplace_back(std::make_pair(detectorStart, detectorStop));
+  m_detectorRanges->emplace_back(detectorStart, detectorStop);
   m_componentRanges->emplace_back(
       std::make_pair(componentStart, componentStop));
 
@@ -213,7 +213,7 @@ InstrumentVisitor::registerGenericComponent(const IComponent &component) {
   // updated later in the register call of the parent.
   m_parentComponentIndices->emplace_back(componentIndex);
   // Generic components are not assemblies and do not therefore have children.
-  m_children->emplace_back(std::vector<size_t>());
+  m_children->emplace_back();
   return componentIndex;
 }
 
@@ -228,21 +228,19 @@ size_t InstrumentVisitor::registerInfiniteComponent(
    * For a generic leaf component we extend the component ids list, but
    * the detector indexes entries will of course be empty
    */
-  m_detectorRanges->emplace_back(
-      std::make_pair(0, 0)); // Represents an empty range
-                             // Record the ID -> index mapping
+  m_detectorRanges->emplace_back(0, 0); // Represents an empty range
+                                        // Record the ID -> index mapping
   const size_t componentIndex = commonRegistration(component);
   m_componentType->emplace_back(Beamline::ComponentType::Infinite);
 
   const size_t componentStart = m_assemblySortedComponentIndices->size();
-  m_componentRanges->emplace_back(
-      std::make_pair(componentStart, componentStart + 1));
+  m_componentRanges->emplace_back(componentStart, componentStart + 1);
   m_assemblySortedComponentIndices->emplace_back(componentIndex);
   // Unless this is the root component this parent is not correct and will be
   // updated later in the register call of the parent.
   m_parentComponentIndices->emplace_back(componentIndex);
   // Generic components are not assemblies and do not therefore have children.
-  m_children->emplace_back(std::vector<size_t>());
+  m_children->emplace_back();
   return componentIndex;
 }
 

--- a/Framework/Kernel/src/Interpolation.cpp
+++ b/Framework/Kernel/src/Interpolation.cpp
@@ -137,7 +137,7 @@ void Interpolation::addPoint(const double &xx, const double &yy) {
   }
 
   if (xx > m_data[N - 1].first) {
-    m_data.emplace_back(DataXY(xx, yy));
+    m_data.emplace_back(xx, yy);
     return;
   }
 

--- a/Framework/Kernel/src/UserStringParser.cpp
+++ b/Framework/Kernel/src/UserStringParser.cpp
@@ -52,7 +52,7 @@ void UserStringParser::parse(const std::string &userString,
   std::string separators("-+:");
   // if input contains no separator string
   if (userString.find_first_of(separators) == std::string::npos) {
-    numbers.emplace_back(std::vector<unsigned int>(1, toUInt(userString)));
+    numbers.emplace_back(1, toUInt(userString));
   } else if (Contains(userString, '-')) {
     std::vector<unsigned int> value = separateDelimiters(userString, "-:");
     if (!value.empty()) {
@@ -107,7 +107,7 @@ UserStringParser::separateColon(const std::string &input) {
   std::vector<std::vector<unsigned int>> separatedValues;
   Tokenize(input, ":", startNum, endNum, step);
   for (unsigned int num = startNum; num <= endNum; num += step) {
-    separatedValues.emplace_back(std::vector<unsigned int>(1, num));
+    separatedValues.emplace_back(1, num);
   }
 
   return separatedValues;

--- a/Framework/MDAlgorithms/src/FindPeaksMD.cpp
+++ b/Framework/MDAlgorithms/src/FindPeaksMD.cpp
@@ -762,9 +762,9 @@ void FindPeaksMD::exec() {
 
   // Do a sort by bank name and then descending bin count (intensity)
   std::vector<std::pair<std::string, bool>> criteria;
-  criteria.emplace_back(std::pair<std::string, bool>("RunNumber", true));
-  criteria.emplace_back(std::pair<std::string, bool>("BankName", true));
-  criteria.emplace_back(std::pair<std::string, bool>("bincount", false));
+  criteria.emplace_back("RunNumber", true);
+  criteria.emplace_back("BankName", true);
+  criteria.emplace_back("bincount", false);
   peakWS->sort(criteria);
 
   for (auto i = 0; i != peakWS->getNumberPeaks(); ++i) {

--- a/Framework/Muon/src/ApplyMuonDetectorGroupPairing.cpp
+++ b/Framework/Muon/src/ApplyMuonDetectorGroupPairing.cpp
@@ -409,7 +409,7 @@ Muon::AnalysisOptions ApplyMuonDetectorGroupPairing::getUserInput() {
   const double alpha = static_cast<double>(getProperty("Alpha"));
   grouping.pairAlphas.emplace_back(alpha);
   grouping.pairNames.emplace_back(this->getPropertyValue("PairName"));
-  grouping.pairs.emplace_back(std::make_pair(0, 1));
+  grouping.pairs.emplace_back(0, 1);
 
   options.grouping = grouping;
   options.summedPeriods = this->getPropertyValue("SummedPeriods");

--- a/MantidPlot/src/Mantid/MantidTable.cpp
+++ b/MantidPlot/src/Mantid/MantidTable.cpp
@@ -403,8 +403,7 @@ void MantidTable::sortColumn(int col, int order) {
     // Customized sorting routine for this TableWorkspace
     std::vector<std::pair<std::string, bool>> criteria;
     // Only one criterion in sorting
-    criteria.emplace_back(std::pair<std::string, bool>(
-        m_ws->getColumn(col)->name(), (order == 0)));
+    criteria.emplace_back(m_ws->getColumn(col)->name(), (order == 0));
     m_ws->sort(criteria);
     // Refresh the table
     this->fillTable();
@@ -437,7 +436,7 @@ void MantidTable::sortColumns(const QStringList &s, int type, int order,
     if (n != std::string::npos && n < col.size() - 1)
       col = col.substr(n + 1, col.size() - n - 1);
     // Only one criterion in sorting
-    criteria.emplace_back(std::pair<std::string, bool>(col, (order == 0)));
+    criteria.emplace_back(col, (order == 0));
     m_ws->sort(criteria);
     // Refresh the table
     this->fillTable();

--- a/qt/scientific_interfaces/ISISSANS/SANSRunWindow.cpp
+++ b/qt/scientific_interfaces/ISISSANS/SANSRunWindow.cpp
@@ -2176,12 +2176,12 @@ bool SANSRunWindow::handleLoadButtonClick() {
           tuple<QLineEdit *, function<double(const Sample *)>, std::string>;
 
       std::vector<GeomSampleInfo> sampleInfoList;
-      sampleInfoList.emplace_back(make_tuple(
-          m_uiForm.sample_thick, &Sample::getThickness, "thickness"));
-      sampleInfoList.emplace_back(
-          make_tuple(m_uiForm.sample_width, &Sample::getWidth, "width"));
-      sampleInfoList.emplace_back(
-          make_tuple(m_uiForm.sample_height, &Sample::getHeight, "height"));
+      sampleInfoList.emplace_back(m_uiForm.sample_thick, &Sample::getThickness,
+                                  "thickness");
+      sampleInfoList.emplace_back(m_uiForm.sample_width, &Sample::getWidth,
+                                  "width");
+      sampleInfoList.emplace_back(m_uiForm.sample_height, &Sample::getHeight,
+                                  "height");
 
       // Populate the sample geometry fields, but replace any zero values with
       // 1.0, and warn the user where this has occured.

--- a/qt/scientific_interfaces/Indirect/IndirectFitDataModel.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectFitDataModel.cpp
@@ -111,7 +111,7 @@ IndirectFitDataModel::getResolutionsForFit() const {
     auto spectra = getSpectra(TableDatasetIndex{index});
     if (!resolutionWorkspace) {
       for (auto &spectraIndex : spectra) {
-        resolutionVector.emplace_back(std::make_pair("", spectraIndex.value));
+        resolutionVector.emplace_back("", spectraIndex.value);
       }
       continue;
     }
@@ -120,8 +120,8 @@ IndirectFitDataModel::getResolutionsForFit() const {
         m_resolutions->at(index).lock()->getNumberHistograms() == 1;
     for (auto &spectraIndex : spectra) {
       auto resolutionIndex = singleSpectraResolution ? 0 : spectraIndex.value;
-      resolutionVector.emplace_back(std::make_pair(
-          m_resolutions->at(index).lock()->getName(), resolutionIndex));
+      resolutionVector.emplace_back(m_resolutions->at(index).lock()->getName(),
+                                    resolutionIndex);
     }
   }
   return resolutionVector;
@@ -297,7 +297,7 @@ void IndirectFitDataModel::setExcludeRegion(const std::string &exclude,
 void IndirectFitDataModel::addNewWorkspace(
     const Mantid::API::MatrixWorkspace_sptr &workspace,
     const Spectra &spectra) {
-  m_fittingData->emplace_back(IndirectFitData(workspace, spectra));
+  m_fittingData->emplace_back(workspace, spectra);
 }
 
 void IndirectFitDataModel::removeWorkspace(TableDatasetIndex index) {

--- a/qt/scientific_interfaces/Muon/MuonAnalysisFitDataPresenter.cpp
+++ b/qt/scientific_interfaces/Muon/MuonAnalysisFitDataPresenter.cpp
@@ -381,7 +381,7 @@ std::vector<std::string> MuonAnalysisFitDataPresenter::generateWorkspaceNames(
   } else { // Analyse the runs one by one
     runNumberVectors.reserve(selectedRuns.size());
     for (const int run : selectedRuns) {
-      runNumberVectors.emplace_back(std::vector<int>(1, run));
+      runNumberVectors.emplace_back(1, run);
     }
   }
 

--- a/qt/widgets/instrumentview/src/InstrumentWidget.cpp
+++ b/qt/widgets/instrumentview/src/InstrumentWidget.cpp
@@ -1283,10 +1283,10 @@ void InstrumentWidget::createTabs(QSettings &settings) {
 
   connect(mControlsTab, SIGNAL(currentChanged(int)), this,
           SLOT(tabChanged(int)));
-  m_stateOfTabs.emplace_back(std::make_pair(std::string("Render"), true));
-  m_stateOfTabs.emplace_back(std::make_pair(std::string("Pick"), true));
-  m_stateOfTabs.emplace_back(std::make_pair(std::string("Draw"), true));
-  m_stateOfTabs.emplace_back(std::make_pair(std::string("Instrument"), true));
+  m_stateOfTabs.emplace_back(std::string("Render"), true);
+  m_stateOfTabs.emplace_back(std::string("Pick"), true);
+  m_stateOfTabs.emplace_back(std::string("Draw"), true);
+  m_stateOfTabs.emplace_back(std::string("Instrument"), true);
   addSelectedTabs();
   m_tabs << m_renderTab << m_pickTab << m_maskTab << m_treeTab;
 }

--- a/qt/widgets/instrumentview/src/InstrumentWidgetDecoder.cpp
+++ b/qt/widgets/instrumentview/src/InstrumentWidgetDecoder.cpp
@@ -371,7 +371,7 @@ void InstrumentWidgetDecoder::decodeAlignmentInfo(
                                qLabMap[QString("y")].toDouble(),
                                qLabMap[QString("z")].toDouble());
 
-    alignmentPlane.emplace_back(std::make_pair(qValue, marker));
+    alignmentPlane.emplace_back(qValue, marker);
   }
   obj->m_selectedAlignmentPlane = alignmentPlane;
 }

--- a/qt/widgets/instrumentview/src/ProjectionSurface.cpp
+++ b/qt/widgets/instrumentview/src/ProjectionSurface.cpp
@@ -978,8 +978,7 @@ void ProjectionSurface::alignPeaks(const QRect &rect) {
         });
 
     if (result == m_selectedAlignmentPlane.cend()) {
-      m_selectedAlignmentPlane.emplace_back(
-          std::make_pair(peak->getQSampleFrame(), origin));
+      m_selectedAlignmentPlane.emplace_back(peak->getQSampleFrame(), origin);
     }
   } else {
     m_selectedAlignmentPeak = std::make_pair(peak, origin);


### PR DESCRIPTION
**Description of work.**
This PR is a small code modernisation to make sure in place construction is used by `emplace` when possible. The typical example is with make_pair, where frequently the following call is made:

```
struct A; struct B;
vec.emplace_back(std::make_pair(A(1), B(3)))
```

when really the call should be
`vec.emplace_back(1,2)`
As emplace will delegate to the constructors. This avoids the tempory constructions destructions and moves which occur when you explicity create the objects/pair yourself.

**To test:**
- Code 
- Builds and tests pass



*There is no associated issue.*


This does not require release notes because its an internal change


<!-- Ensure the base of this PR is correct (e.g. release-next or master)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
