### PR TITLE
Use x11 on fedora

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -470,7 +470,7 @@ if(ENABLE_CPACK)
         set(CPACK_DEBIAN_PACKAGE_DEPENDS
             "${CPACK_DEBIAN_PACKAGE_DEPENDS},libqscintilla2-qt5-13")
       endif()
-    else()
+    elseif ( "${UNIX_DIST}" MATCHES "Ubuntu" )
       message(WARNING "Unsupported Debian-like OS: ${UNIX_CODENAME}. Packaging is unlikely to work correctly.")
     endif()
     # python requirements

--- a/buildconfig/CMake/LinuxPackageScripts.cmake
+++ b/buildconfig/CMake/LinuxPackageScripts.cmake
@@ -105,6 +105,11 @@ if ( "${UNIX_DIST}" MATCHES "RedHatEnterprise" OR "${UNIX_DIST}" MATCHES "^Fedor
   if ( "${UNIX_CODENAME}" MATCHES "Santiago" )
     set ( WRAPPER_PREFIX "scl enable mantidlibs34 \"" )
     set ( WRAPPER_POSTFIX "\"" )
+  elseif ("${UNIX_DIST}" MATCHES "^Fedora")
+    # The instrument view doesn't work with the wayland compositor
+    # Override it to use X11 https://doc.qt.io/qt-5/embedded-linux.html#xcb
+    set ( WRAPPER_PREFIX "QT_QPA_PLATFORM=xcb " )
+    set ( WRAPPER_POSTFIX "" )
   else()
     set ( WRAPPER_PREFIX "" )
     set ( WRAPPER_POSTFIX "" )


### PR DESCRIPTION
This is a (hopefully temporary) workaround for the wayland compositor not rendering the instrument view correctly.

**To test:**

Build mantid on fedora and see that the instrument view works.

*There is no associated issue.*

*This does not require release notes* because it adds a workaround for an unsupported OS.

#29945 is the version into `ornl-next`

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
