### PR TITLE
Workaround segv in doctests & readline import

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -3,6 +3,15 @@
 # All configuration values have a default; values that are commented out
 # serve to show the default.
 
+# Workaround a segfault importing readline with doctests and PyQt5.
+# doctest.py initializes a custom pdb to be able to redirect stdout:
+#   https://github.com/python/cpython/blob/750c5abf43b7b1627ab59ead237bef4c2314d29e/Lib/doctest.py#L367
+# and in turn this attempts to import readline:
+#   https://github.com/python/cpython/blob/750c5abf43b7b1627ab59ead237bef4c2314d29e/Lib/pdb.py#L157
+# The workaround is discussed in https://groups.google.com/forum/#!topic/leo-editor/ghiIN7irzY0
+# and simply amounts to importing readline before a QApplication is created in the screenshots
+# directive
+import readline
 import sys
 import os
 from sphinx import __version__ as sphinx_version


### PR DESCRIPTION
**Description of work.**

A clean build + doctests now results in a [segfault](https://builds.mantidproject.org/view/Master%20Pipeline/job/master_clean-ubuntu-18.04/651/consoleText) in the doctests now that PyQt5 is the default in the mantidpython wrapper script after merging #29921.

The core dump produced shows:
```
#0  0x000000000055f321 in PyModule_GetState ()
#1  0x00007f65664bc0ce in  () at /usr/lib/python3.6/lib-dynload/readline.cpython-36m-x86_64-linux-gnu.so
#2  0x00007f656f327441 in rl_initialize () at /usr/lib/x86_64-linux-gnu/libedit.so.2
#3  0x00007f65664bbf79 in PyInit_readline ()
    at /usr/lib/python3.6/lib-dynload/readline.cpython-36m-x86_64-linux-gnu.so
#4  0x00000000005fb2bf in _PyImport_LoadDynamicModuleWithSpec ()
#5  0x00000000005fb53d in  ()
#6  0x00000000005671ce in PyCFunction_Call ()
#7  0x0000000000511341 in _PyEval_EvalFrameDefault ()
#8  0x0000000000507f24 in  ()
#9  0x0000000000509c50 in  ()
#10 0x000000000050a64d in  ()
```

showing the issue is with readline and is the same problem that was fixed for workbench in #29651.

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

**To test:**

I was able to reproduce this using the [ubuntubionic](https://github.com/mantidproject/dockerfiles/tree/master/development) docker environment:

```
cd /mantid_build
cmake -DDOCS_SCREENSHOTS=ON -DMANTID_DATA_STORE=/mantid_data /mantid_src
xvfb-run '--server-args=-screen 0 640x480x24' --server-num=101 cmake --build . --target docs-doctest
```

produced a crash without this fix.

You could also just ensure a clean build of this PR on Ubuntu passes.

*There is no associated issue.*

*This does not require release notes* because **it fixes an internal issue.**

<!-- Ensure the base of this PR is correct (e.g. release-next or master)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
