### PR TITLE
Stop displaying in-built methods of ReflectionFormat as allowed fmts

### DIFF
--- a/Framework/PythonInterface/plugins/algorithms/SaveReflections.py
+++ b/Framework/PythonInterface/plugins/algorithms/SaveReflections.py
@@ -97,7 +97,7 @@ class SaveReflections(PythonAlgorithm):
                              direction=Direction.Input,
                              defaultValue="Fullprof",
                              validator=StringListValidator(
-                                 [fmt for fmt in dir(ReflectionFormat) if not fmt.startswith('__')]),
+                                 [fmt.name for fmt in ReflectionFormat]),
                              doc="The output format to export reflections to")
 
         self.declareProperty(name="SplitFiles",

--- a/Framework/PythonInterface/plugins/algorithms/SaveReflections.py
+++ b/Framework/PythonInterface/plugins/algorithms/SaveReflections.py
@@ -96,15 +96,16 @@ class SaveReflections(PythonAlgorithm):
         self.declareProperty(name="Format",
                              direction=Direction.Input,
                              defaultValue="Fullprof",
-                             validator=StringListValidator(dir(ReflectionFormat)),
+                             validator=StringListValidator(
+                                 [fmt for fmt in dir(ReflectionFormat) if not fmt.startswith('__')]),
                              doc="The output format to export reflections to")
 
         self.declareProperty(name="SplitFiles",
                              defaultValue=False,
                              direction=Direction.Input,
                              doc="If True save separate files with only the peaks associated"
-                             "with a single modulation vector in a single file. Only "
-                             "applies to JANA format.")
+                                 "with a single modulation vector in a single file. Only "
+                                 "applies to JANA format.")
 
     def PyExec(self):
         """Execute the algorithm"""
@@ -126,6 +127,7 @@ class FullprofFormat(object):
     This is a 7 columns file format consisting of H, K, L, instensity,
     sigma, crystal domain, and wavelength.
     """
+
     def __call__(self, file_name, workspace, split_files):
         """Write a PeaksWorkspace to an ASCII file using this formatter.
 
@@ -182,8 +184,10 @@ class JanaFormat(object):
 
     Currently the last three columns are hard coded to 1.0, 0.0, and 0.0 respectively.
     """
+
     class FileBuilder(object):
         """Encapsulate information to build a single Jana file"""
+
         def __init__(self, filepath, workspace, num_mod_vec, modulation_col_num=None):
             self._filepath = filepath
             self._workspace = workspace
@@ -358,6 +362,7 @@ class SaveHKLFormat(object):
     The SaveHKL algorithm currently supports both the GSAS and SHELX formats. For
     more information see the SaveHKL algorithm documentation.
     """
+
     def __call__(self, file_name, workspace, _):
         """Write a PeaksWorkspace to an ASCII file using this formatter.
 


### PR DESCRIPTION
**Description of work.**
 One line bug fix to stop in-built methods of ReflectionFormat class as allowed output formats in validator

**To test:**

See instruction on original issue #29953

Fixes #29953 

*This does not require release notes* because small fix for unreported bug

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
