### PR TITLE
Add instructions to specify timeout for system test data download

### DIFF
--- a/dev-docs/source/SystemTests.rst
+++ b/dev-docs/source/SystemTests.rst
@@ -178,6 +178,14 @@ Usage differs depending on whether you are using a single-configuration
 generator with CMake, for example Makefiles/Ninja, or a
 multi-configuration generator such as Visual Studio or Xcode.
 
+Downloading the test data
+-------------------------
+
+The ``systemtest`` script will automatically attempt to download any missing
+data files but will time-out after 2 minutes. The time out limit can be set in two
+variables ``ExternalData_TIMEOUT_INACTIVITY`` and ``ExternalData_TIMEOUT_ABSOLUTE``.
+If using CMake these will need to be added as new string entries (value is in seconds).
+
 Visual Studio/Xcode
 -------------------
 


### PR DESCRIPTION
**Description of work.**
Added instructions on how to specify a time out for downloading system test data in dev docs

**To test:**
Nothing - it should be OK if the docs build passes

*There is no associated issue.*

*This does not require release notes* because is a change to dev docs


#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
