### PR TITLE
Corrected variable names in DUP_TOP workflow in funcinspect

### DIFF
--- a/Framework/PythonInterface/mantid/kernel/funcinspect.py
+++ b/Framework/PythonInterface/mantid/kernel/funcinspect.py
@@ -274,14 +274,14 @@ def process_frame(frame):
         # put this in a loop and stack the results in an array.
         count = 0
         max_returns = 0 # Must count the max_returns ourselves in this case
-        while count < len(ins_stack[call_function_locs[i][0]:call_function_locs[i][1]]):
-            (offset_, op_, name_, argument_, argvalue_) = ins[call_function_locs[i][0]+count]
+        while count < len(ins_stack[call_function_locs[last_i][0]:call_function_locs[last_i][1]]):
+            (offset_, op_, name_, argument_, argvalue_) = ins_stack[call_function_locs[last_i][0]+count]
             if name_ == 'UNPACK_SEQUENCE': # Many Return Values, One equal sign
                 hold = []
                 if argvalue_ > max_returns:
                     max_returns = argvalue_
                 for index in range(argvalue_):
-                    (_offset_, _op_, _name_, _argument_, _argvalue_) = ins[call_function_locs[i][0] + count+1+index]
+                    (_offset_, _op_, _name_, _argument_, _argvalue_) = ins_stack[call_function_locs[last_i][0] + count+1+index]
                     hold.append(_argvalue_)
                 count = count + argvalue_
                 output_var_names.append(hold)


### PR DESCRIPTION
**Description of work.**

Changed the variable names to actually declared values and following the usage in the code blocks before the `DUP_TOP`.

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

**To test:**

In the workbench or the Mantid python try assigning:

from mantid.simpleapi import *
othername = sample = CreateSampleWorkspace()

There should be no NameError anymore.

<!-- Instructions for testing. -->

Fixes #29972 . 


*This does not require release notes* because **ti fixes an internal issue**.


<!-- Ensure the base of this PR is correct (e.g. release-next or master)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
