### PR TITLE
Fit only TOF in EngDiffUI

### DIFF
--- a/qt/python/mantidqt/_common.sip
+++ b/qt/python/mantidqt/_common.sip
@@ -470,6 +470,7 @@ public:
     auto function = boost::python::extract<const Mantid::API::IFunction_sptr &>(a0)();
     sipRes = sipCpp->findHandler(function);
     %End
+    QString functionName() const;
 };
 
 // ---------------------------------
@@ -545,6 +546,7 @@ SIP_PYOBJECT defaultBackgroundType();
     QStringList registeredOthers() const;
     QStringList getPeakPrefixes() const;
     QString addFunction(QString);
+    PropertyHandler *getPeakHandler(const QString &prefix);
     double getPeakCentreOf(QString);
     void setPeakCentreOf(QString, double);
     double getPeakHeightOf(QString);

--- a/scripts/Engineering/gui/engineering_diffraction/tabs/fitting/data_handling/data_model.py
+++ b/scripts/Engineering/gui/engineering_diffraction/tabs/fitting/data_handling/data_model.py
@@ -164,7 +164,9 @@ class FittingDataModel(object):
             log_table = ADS.retrieve(primary_log)
             isort = argsort(array(log_table.column('avg')))
             ws_list_tof = [ws_list[iws] for iws in isort if iws in tof_ws_inds]
-        if not sort_ascending == 'true':
+        else:
+            ws_list_tof = ws_list
+        if sort_ascending == 'false':
             # settings can only be saved as text
             ws_list_tof = ws_list_tof[::-1]
         return ws_list_tof

--- a/scripts/Engineering/gui/engineering_diffraction/tabs/fitting/data_handling/data_model.py
+++ b/scripts/Engineering/gui/engineering_diffraction/tabs/fitting/data_handling/data_model.py
@@ -155,7 +155,7 @@ class FittingDataModel(object):
     def get_ws_sorted_by_primary_log(self):
         ws_list = list(self._loaded_workspaces.keys())
         tof_ws_inds = [ind for ind, ws in enumerate(ws_list) if
-                       ADS.retrieve(ws).getAxis(0).getUnit().caption() == 'Time-of-flight']
+                       self._loaded_workspaces[ws].getAxis(0).getUnit().caption() == 'Time-of-flight']
         primary_log = get_setting(path_handling.INTERFACES_SETTINGS_GROUP, path_handling.ENGINEERING_PREFIX,
                                   "primary_log")
         sort_ascending = get_setting(path_handling.INTERFACES_SETTINGS_GROUP, path_handling.ENGINEERING_PREFIX,

--- a/scripts/Engineering/gui/engineering_diffraction/tabs/fitting/data_handling/data_model.py
+++ b/scripts/Engineering/gui/engineering_diffraction/tabs/fitting/data_handling/data_model.py
@@ -154,6 +154,8 @@ class FittingDataModel(object):
 
     def get_ws_sorted_by_primary_log(self):
         ws_list = list(self._loaded_workspaces.keys())
+        tof_ws_inds = [ind for ind, ws in enumerate(ws_list) if
+                       ADS.retrieve(ws).getAxis(0).getUnit().caption() == 'Time-of-flight']
         primary_log = get_setting(path_handling.INTERFACES_SETTINGS_GROUP, path_handling.ENGINEERING_PREFIX,
                                   "primary_log")
         sort_ascending = get_setting(path_handling.INTERFACES_SETTINGS_GROUP, path_handling.ENGINEERING_PREFIX,
@@ -161,11 +163,11 @@ class FittingDataModel(object):
         if primary_log:
             log_table = ADS.retrieve(primary_log)
             isort = argsort(array(log_table.column('avg')))
-            ws_list = [ws_list[iws] for iws in isort]
+            ws_list_tof = [ws_list[iws] for iws in isort if iws in tof_ws_inds]
         if not sort_ascending == 'true':
             # settings can only be saved as text
-            ws_list = ws_list[::-1]
-        return ws_list
+            ws_list_tof = ws_list_tof[::-1]
+        return ws_list_tof
 
     def update_fit(self, args):
         fit_props, peak_centre_params = ([], ) * 2

--- a/scripts/Engineering/gui/engineering_diffraction/tabs/fitting/data_handling/data_presenter.py
+++ b/scripts/Engineering/gui/engineering_diffraction/tabs/fitting/data_handling/data_presenter.py
@@ -38,7 +38,6 @@ class FittingDataPresenter(object):
         self.all_plots_removed_notifier = GenericObservable()
         self.seq_fit_started_notifier = GenericObservable()
         # Observers
-        # TODO observer for fpb fit complete
         self.fit_observer = GenericObserverWithArgPassing(self.fit_completed)
         #
         self.fit_enabled_observer = GenericObserverWithArgPassing(self.set_fit_enabled)

--- a/scripts/Engineering/gui/engineering_diffraction/tabs/fitting/data_handling/data_presenter.py
+++ b/scripts/Engineering/gui/engineering_diffraction/tabs/fitting/data_handling/data_presenter.py
@@ -37,8 +37,10 @@ class FittingDataPresenter(object):
         self.plot_removed_notifier = GenericObservable()
         self.all_plots_removed_notifier = GenericObservable()
         self.seq_fit_started_notifier = GenericObservable()
-        # Obeservers
+        # Observers
+        # TODO observer for fpb fit complete
         self.fit_observer = GenericObserverWithArgPassing(self.fit_completed)
+        #
         self.fit_enabled_observer = GenericObserverWithArgPassing(self.set_fit_enabled)
         self.seq_fit_done_observer = GenericObserverWithArgPassing(self.fit_completed)
         self.focus_run_observer = GenericObserverWithArgPassing(
@@ -47,8 +49,8 @@ class FittingDataPresenter(object):
     def set_fit_enabled(self, fit_enabled):
         self.view.set_seq_fit_button_enabled(fit_enabled)
 
-    def fit_completed(self, fitprops):
-        self.model.update_fit(fitprops)
+    def fit_completed(self, fit_props):
+        self.model.update_fit(fit_props)
 
     def _start_seq_fit(self):
         ws_list = self.model.get_ws_sorted_by_primary_log()

--- a/scripts/Engineering/gui/engineering_diffraction/tabs/fitting/data_handling/test/test_data_model.py
+++ b/scripts/Engineering/gui/engineering_diffraction/tabs/fitting/data_handling/test/test_data_model.py
@@ -10,16 +10,17 @@ from unittest import mock
 from unittest.mock import patch
 from numpy import isnan, nan
 from Engineering.gui.engineering_diffraction.tabs.fitting.data_handling.data_model import FittingDataModel
+from mantid.kernel import V3D
 
-file_path = "Engineering.gui.engineering_diffraction.tabs.fitting.data_handling.data_model"
+data_model_path = "Engineering.gui.engineering_diffraction.tabs.fitting.data_handling.data_model"
 
 
 class TestFittingDataModel(unittest.TestCase):
     def setUp(self):
         self.model = FittingDataModel()
         # setup a mock workspace
-        mock_inst = mock.MagicMock()
-        mock_inst.getFullName.return_value = 'instrument'
+        self.mock_inst = mock.MagicMock()
+        self.mock_inst.getFullName.return_value = 'instrument'
         mock_prop = mock.MagicMock()
         mock_prop.value = 1  # bank-id
         mock_run = mock.MagicMock()
@@ -28,12 +29,12 @@ class TestFittingDataModel(unittest.TestCase):
         self.mock_ws = mock.MagicMock()
         self.mock_ws.getNumberHistograms.return_value = 1
         self.mock_ws.getRun.return_value = mock_run
-        self.mock_ws.getInstrument.return_value = mock_inst
+        self.mock_ws.getInstrument.return_value = self.mock_inst
         self.mock_ws.getRunNumber.return_value = 1
         self.mock_ws.getTitle.return_value = 'title'
 
-    @patch(file_path + '.ConvertUnits')
-    @patch(file_path + ".Load")
+    @patch(data_model_path + '.ConvertUnits')
+    @patch(data_model_path + ".Load")
     def test_loading_single_file_stores_workspace(self, mock_load, mock_convunits):
         mock_load.return_value = self.mock_ws
 
@@ -44,10 +45,10 @@ class TestFittingDataModel(unittest.TestCase):
         self.assertEqual(self.mock_ws, self.model._loaded_workspaces["a_filename_dSpacing"])
         mock_load.assert_called_with("/ar/a_filename.whatever", OutputWorkspace="a_filename_dSpacing")
 
-    @patch(file_path + '.FittingDataModel.write_table_row')
-    @patch(file_path + '.FittingDataModel.update_log_group_name')
-    @patch(file_path + '.ADS')
-    @patch(file_path + ".Load")
+    @patch(data_model_path + '.FittingDataModel.write_table_row')
+    @patch(data_model_path + '.FittingDataModel.update_log_group_name')
+    @patch(data_model_path + '.ADS')
+    @patch(data_model_path + ".Load")
     def test_loading_single_file_already_loaded_untracked(self, mock_load, mock_ads, mock_update_logname,
                                                           mock_writerow):
         mock_ads.doesExist.return_value = True
@@ -60,8 +61,8 @@ class TestFittingDataModel(unittest.TestCase):
         mock_update_logname.assert_called_once()  # needed to patch this as calls ADS.retrieve
         self.assertEqual(1, mock_writerow.call_count)  # no logs included
 
-    @patch(file_path + '.FittingDataModel.update_log_group_name')
-    @patch(file_path + ".Load")
+    @patch(data_model_path + '.FittingDataModel.update_log_group_name')
+    @patch(data_model_path + ".Load")
     def test_loading_single_file_already_loaded_tracked(self, mock_load, mock_update_logname):
         fpath = "/ar/a_filename.whatever"
         xunit = "TOF"
@@ -73,9 +74,9 @@ class TestFittingDataModel(unittest.TestCase):
         mock_load.assert_not_called()
         mock_update_logname.assert_called()
 
-    @patch(file_path + '.get_setting')
-    @patch(file_path + '.AverageLogData')
-    @patch(file_path + ".Load")
+    @patch(data_model_path + '.get_setting')
+    @patch(data_model_path + '.AverageLogData')
+    @patch(data_model_path + ".Load")
     def test_loading_single_file_with_logs(self, mock_load, mock_avglogs, mock_getsetting):
         mock_load.return_value = self.mock_ws
         log_names = ['to', 'test']
@@ -92,9 +93,9 @@ class TestFittingDataModel(unittest.TestCase):
             self.assertEqual(log_names[ilog], self.model._log_workspaces[ilog + 1].name())
             self.assertEqual(1, self.model._log_workspaces[ilog + 1].rowCount())
 
-    @patch(file_path + '.ConvertUnits')
-    @patch(file_path + ".logger")
-    @patch(file_path + ".Load")
+    @patch(data_model_path + '.ConvertUnits')
+    @patch(data_model_path + ".logger")
+    @patch(data_model_path + ".Load")
     def test_loading_single_file_invalid(self, mock_load, mock_logger, mock_convunits):
         mock_load.side_effect = RuntimeError("Invalid Path")
 
@@ -104,7 +105,7 @@ class TestFittingDataModel(unittest.TestCase):
         mock_load.assert_called_with("/ar/a_filename.whatever", OutputWorkspace="a_filename_TOF")
         self.assertEqual(1, mock_logger.error.call_count)
 
-    @patch(file_path + ".Load")
+    @patch(data_model_path + ".Load")
     def test_loading_multiple_files(self, mock_load):
         mock_load.return_value = self.mock_ws
 
@@ -116,8 +117,8 @@ class TestFittingDataModel(unittest.TestCase):
         mock_load.assert_any_call("/dir/file1.txt", OutputWorkspace="file1_TOF")
         mock_load.assert_any_call("/dir/file2.nxs", OutputWorkspace="file2_TOF")
 
-    @patch(file_path + ".logger")
-    @patch(file_path + ".Load")
+    @patch(data_model_path + ".logger")
+    @patch(data_model_path + ".Load")
     def test_loading_multiple_files_too_many_spectra(self, mock_load, mock_logger):
         self.mock_ws.getNumberHistograms.return_value = 2
         mock_load.return_value = self.mock_ws
@@ -129,8 +130,8 @@ class TestFittingDataModel(unittest.TestCase):
         mock_load.assert_any_call("/dir/file2.nxs", OutputWorkspace="file2_TOF")
         self.assertEqual(2, mock_logger.warning.call_count)
 
-    @patch(file_path + ".logger")
-    @patch(file_path + ".Load")
+    @patch(data_model_path + ".logger")
+    @patch(data_model_path + ".Load")
     def test_loading_multiple_files_invalid(self, mock_load, mock_logger):
         mock_load.side_effect = RuntimeError("Invalid Path")
 
@@ -141,9 +142,9 @@ class TestFittingDataModel(unittest.TestCase):
         mock_load.assert_any_call("/dir/file2.nxs", OutputWorkspace="file2_TOF")
         self.assertEqual(2, mock_logger.error.call_count)
 
-    @patch(file_path + ".EnggEstimateFocussedBackground")
-    @patch(file_path + ".Minus")
-    @patch(file_path + ".Plus")
+    @patch(data_model_path + ".EnggEstimateFocussedBackground")
+    @patch(data_model_path + ".Minus")
+    @patch(data_model_path + ".Plus")
     def test_do_background_subtraction_first_time(self, mock_plus, mock_minus, mock_estimate_bg):
         self.model._loaded_workspaces = {"name1": self.mock_ws}
         self.model._background_workspaces = {"name1": None}
@@ -158,9 +159,9 @@ class TestFittingDataModel(unittest.TestCase):
         mock_estimate_bg.assert_called_once()
         mock_plus.assert_not_called()
 
-    @patch(file_path + ".EnggEstimateFocussedBackground")
-    @patch(file_path + ".Minus")
-    @patch(file_path + ".Plus")
+    @patch(data_model_path + ".EnggEstimateFocussedBackground")
+    @patch(data_model_path + ".Minus")
+    @patch(data_model_path + ".Plus")
     def test_do_background_subtraction_bgparams_changed(self, mock_plus, mock_minus, mock_estimate_bg):
         self.model._loaded_workspaces = {"name1": self.mock_ws}
         self.model._background_workspaces = {"name1": self.mock_ws}
@@ -175,9 +176,9 @@ class TestFittingDataModel(unittest.TestCase):
         mock_estimate_bg.assert_called_once()
         mock_plus.assert_called_once()
 
-    @patch(file_path + ".EnggEstimateFocussedBackground")
-    @patch(file_path + ".Minus")
-    @patch(file_path + ".Plus")
+    @patch(data_model_path + ".EnggEstimateFocussedBackground")
+    @patch(data_model_path + ".Minus")
+    @patch(data_model_path + ".Plus")
     def test_do_background_subtraction_no_change(self, mock_plus, mock_minus, mock_estimate_bg):
         self.model._loaded_workspaces = {"name1": self.mock_ws}
         self.model._background_workspaces = {"name1": self.mock_ws}
@@ -192,9 +193,9 @@ class TestFittingDataModel(unittest.TestCase):
         mock_estimate_bg.assert_not_called()
         mock_plus.assert_not_called()
 
-    @patch(file_path + '.RenameWorkspace')
-    @patch(file_path + ".ADS")
-    @patch(file_path + ".DeleteTableRows")
+    @patch(data_model_path + '.RenameWorkspace')
+    @patch(data_model_path + ".ADS")
+    @patch(data_model_path + ".DeleteTableRows")
     def test_remove_run_from_log_table(self, mock_delrows, mock_ads, mock_rename):
         mock_table = mock.MagicMock()
         mock_table.column.return_value = [1, 2]
@@ -210,9 +211,9 @@ class TestFittingDataModel(unittest.TestCase):
         new_name = f"{mock_table.row()['Instrument']}_{min(mock_table.column())}-{max(mock_table.column())}_logs"
         mock_rename.assert_called_with(InputWorkspace=self.model._log_workspaces.name(), OutputWorkspace=new_name)
 
-    @patch(file_path + '.DeleteWorkspace')
-    @patch(file_path + ".ADS")
-    @patch(file_path + ".DeleteTableRows")
+    @patch(data_model_path + '.DeleteWorkspace')
+    @patch(data_model_path + ".ADS")
+    @patch(data_model_path + ".DeleteTableRows")
     def test_remove_last_run_from_log_table(self, mock_delrows, mock_ads, mock_delws):
         mock_table = mock.MagicMock()
         mock_table.rowCount.return_value = 0  # none left post-removal
@@ -240,8 +241,8 @@ class TestFittingDataModel(unittest.TestCase):
         self.assertEqual({"new_name": [True, 80, 1000, False]}, self.model._bg_params)
         self.assertEqual({"new_name": 1, "name2": 2}, self.model._log_values)
 
-    @patch(file_path + ".FittingDataModel.create_log_workspace_group")
-    @patch(file_path + ".FittingDataModel.add_log_to_table")
+    @patch(data_model_path + ".FittingDataModel.create_log_workspace_group")
+    @patch(data_model_path + ".FittingDataModel.add_log_to_table")
     def test_update_logs_initial(self, mock_add_log, mock_create_log_group):
         self.model._loaded_workspaces = {"name1": self.mock_ws}
         self.model._log_workspaces = None
@@ -250,11 +251,11 @@ class TestFittingDataModel(unittest.TestCase):
         mock_create_log_group.assert_called_once()
         mock_add_log.assert_called_with("name1", self.mock_ws, 0)
 
-    @patch(file_path + ".FittingDataModel.make_log_table")
-    @patch(file_path + ".FittingDataModel.make_runinfo_table")
-    @patch(file_path + ".FittingDataModel.create_log_workspace_group")
-    @patch(file_path + ".FittingDataModel.add_log_to_table")
-    @patch(file_path + ".ADS")
+    @patch(data_model_path + ".FittingDataModel.make_log_table")
+    @patch(data_model_path + ".FittingDataModel.make_runinfo_table")
+    @patch(data_model_path + ".FittingDataModel.create_log_workspace_group")
+    @patch(data_model_path + ".FittingDataModel.add_log_to_table")
+    @patch(data_model_path + ".ADS")
     def test_update_logs_deleted(self, mock_ads, mock_add_log, mock_create_log_group, mock_make_runinfo,
                                  mock_make_log_table):
         self.model._loaded_workspaces = {"name1": self.mock_ws}
@@ -271,10 +272,10 @@ class TestFittingDataModel(unittest.TestCase):
         self.model._log_workspaces.add.assert_any_call("LogName2")
         mock_add_log.assert_called_with("name1", self.mock_ws, 0)
 
-    @patch(file_path + ".FittingDataModel.make_log_table")
-    @patch(file_path + ".FittingDataModel.make_runinfo_table")
-    @patch(file_path + ".get_setting")
-    @patch(file_path + ".GroupWorkspaces")
+    @patch(data_model_path + ".FittingDataModel.make_log_table")
+    @patch(data_model_path + ".FittingDataModel.make_runinfo_table")
+    @patch(data_model_path + ".get_setting")
+    @patch(data_model_path + ".GroupWorkspaces")
     def test_create_log_workspace_group(self, mock_group, mock_get_setting, mock_make_runinfo, mock_make_log_table):
         log_names = ['LogName1', 'LogName2']
         mock_get_setting.return_value = ','.join(log_names)
@@ -290,10 +291,10 @@ class TestFittingDataModel(unittest.TestCase):
         mock_make_runinfo.assert_called_once()
         self.assertEqual(mock_make_log_table.call_count, len(log_names))
 
-    @patch(file_path + ".FittingDataModel.write_table_row")
-    @patch(file_path + ".ADS")
-    @patch(file_path + ".FittingDataModel.update_log_group_name")
-    @patch(file_path + ".AverageLogData")
+    @patch(data_model_path + ".FittingDataModel.write_table_row")
+    @patch(data_model_path + ".ADS")
+    @patch(data_model_path + ".FittingDataModel.update_log_group_name")
+    @patch(data_model_path + ".AverageLogData")
     def test_add_log_to_table(self, mock_avglogs, mock_update_logname, mock_ads, mock_writerow):
         # grouped ws acts like a container/list of ws here
         self.model._log_workspaces = [mock.MagicMock(), mock.MagicMock()]
@@ -319,9 +320,10 @@ class TestFittingDataModel(unittest.TestCase):
         table_ws.setCell.assert_any_call(3, 0, 1)
         table_ws.setCell.assert_any_call(3, 1, 2)
 
-    @patch(file_path + ".FittingDataModel.create_fit_tables")
-    @patch(file_path + ".ADS")
-    def test_update_fit(self, mock_ads, mock_create_fit_tables):
+    @patch(data_model_path + ".FittingDataModel.estimate_difc")
+    @patch(data_model_path + ".FittingDataModel.create_fit_tables")
+    @patch(data_model_path + ".ADS")
+    def test_update_fit(self, mock_ads, mock_create_fit_tables, mock_estimate_difc):
         mock_table = mock.MagicMock()
         mock_table.toDict.return_value = {
             'Name': ['f0.Height', 'f0.PeakCentre', 'f0.Sigma', 'f1.Height', 'f1.PeakCentre', 'f1.Sigma',
@@ -329,13 +331,14 @@ class TestFittingDataModel(unittest.TestCase):
             'Value': [11.0, 38837.0, 54.0, 10.0, 33638.0, 51.0, 1.0],
             'Error': [1.0, 10.0, 2.0, 1.0, 10.0, 2.0, 0.0]}
         mock_ads.retrieve.return_value = mock_table
+        mock_estimate_difc.return_value = 16
         func_str = 'name=Gaussian,Height=11,PeakCentre=38837,Sigma=54;name=Gaussian,Height=10,PeakCentre=33638,Sigma=51'
         fitprop = {'name': 'Fit', 'properties': {'ConvolveMembers': True, 'EndX': 52000,
                                                  'Function': func_str,
                                                  'InputWorkspace': "name1", 'Output': "name1",
                                                  'OutputCompositeMembers': True, 'StartX': 50000}, 'version': 1}
-
-        self.model.update_fit([fitprop])
+        args = [fitprop, ['Gaussian_PeakCentre']]
+        self.model.update_fit(args)
 
         self.assertEqual(self.model._fit_results['name1']['model'], func_str)
         self.assertEqual(self.model._fit_results['name1']['results'], {'Gaussian_Height': [[11.0, 1.0], [10.0, 1.0]],
@@ -343,7 +346,10 @@ class TestFittingDataModel(unittest.TestCase):
                                                                                                [33638.0, 10.0]],
                                                                        'Gaussian_Sigma': [[54.0, 2.0],
                                                                                           [51.0, 2.0]]})
+        self.assertEqual(self.model._fit_results['name1']['dpeaks'], {'Gaussian_PeakCentre':
+                                                                      [[2427.3125, 0.625], [2102.375, 0.625]]})
         mock_create_fit_tables.assert_called_once()
+        mock_estimate_difc.assert_called_once()
 
     def setup_test_create_fit_tables(self, mock_create_ws, mock_create_table, mock_groupws):
         mock_ws_list = [mock.MagicMock(), mock.MagicMock(), mock.MagicMock()]
@@ -362,22 +368,25 @@ class TestFittingDataModel(unittest.TestCase):
                                                                                 [33638.0, 10.0]],
                                                         'Gaussian_Sigma': [[54.0, 2.0],
                                                                            [51.0, 2.0]]},
+                                            'dpeaks': {'Gaussian_PeakCentre': [[2427.3125, 0.625], [2102.375, 0.625]]},
                                             'costFunction': 1.0}
         return mock_ws_list, mock_create_table, mock_create_ws
 
-    @patch(file_path + '.FittingDataModel.write_table_row')
-    @patch(file_path + ".GroupWorkspaces")
-    @patch(file_path + ".CreateEmptyTableWorkspace")
-    @patch(file_path + ".CreateWorkspace")
+    @patch(data_model_path + '.FittingDataModel.write_table_row')
+    @patch(data_model_path + ".GroupWorkspaces")
+    @patch(data_model_path + ".CreateEmptyTableWorkspace")
+    @patch(data_model_path + ".CreateWorkspace")
     def test_create_fit_tables(self, mock_create_ws, mock_create_table, mock_groupws, mock_writerow):
         mock_ws_list, mock_create_table, mock_create_ws = self.setup_test_create_fit_tables(mock_create_ws,
                                                                                             mock_create_table,
                                                                                             mock_groupws)
 
-        self.model.create_fit_tables()
+        mock_peak_centre_params = ['Gaussian_PeakCentre']
+        self.model.create_fit_tables(mock_peak_centre_params)
 
         # test the workspaces were created and added to fit_workspaces
-        self.assertEqual(self.model._fit_workspaces, mock_ws_list + [mock_create_table.return_value])
+        self.assertEqual(self.model._fit_workspaces, (mock_ws_list + [mock_create_table.return_value,
+                                                                           mock_create_table.return_value]))
         # test the table stores the correct function strings (empty string if no function present)
         mock_writerow.assert_any_call(mock_create_table.return_value,
                                       ['name1', self.model._fit_results['name1']['costFunction'],
@@ -386,12 +395,14 @@ class TestFittingDataModel(unittest.TestCase):
         # check the matrix workspaces corresponding to the fit parameters
         ws_names = [mock_create_ws.mock_calls[iws][2]['OutputWorkspace'] for iws in range(0, 3)]  # 3 params in gauss
         self.assertEqual(sorted(ws_names), sorted(self.model._fit_results['name1']['results'].keys()))
+        # check that the dspacing peaks table has been made
+        mock_create_table.assert_any_call(OutputWorkspace='Gaussian_PeakCentre_dSpacing')
         # check the first call to setY and setE for one of the parameters
-        for im, m in enumerate(self.model._fit_workspaces[:-1]):
+        for im, m in enumerate(self.model._fit_workspaces[:-2]):
             for iws, ws in enumerate(self.model._loaded_workspaces.keys()):
                 _, argsY, _ = m.setY.mock_calls[iws]
                 _, argsE, _ = m.setE.mock_calls[iws]
-                self.assertEquals([argsY[0], argsE[0]], [iws, iws])
+                self.assertEqual([argsY[0], argsE[0]], [iws, iws])
                 if ws in self.model._fit_results:
                     self.assertTrue(
                         all(argsY[1] == [x[0] for x in self.model._fit_results['name1']['results'][ws_names[im]]]))
@@ -401,10 +412,10 @@ class TestFittingDataModel(unittest.TestCase):
                     self.assertTrue(all(isnan(argsY[1])))
                     self.assertTrue(all(isnan(argsE[1])))
 
-    @patch(file_path + '.FittingDataModel.write_table_row')
-    @patch(file_path + ".GroupWorkspaces")
-    @patch(file_path + ".CreateEmptyTableWorkspace")
-    @patch(file_path + ".CreateWorkspace")
+    @patch(data_model_path + '.FittingDataModel.write_table_row')
+    @patch(data_model_path + ".GroupWorkspaces")
+    @patch(data_model_path + ".CreateEmptyTableWorkspace")
+    @patch(data_model_path + ".CreateWorkspace")
     def test_create_fit_tables_different_funcs(self, mock_create_ws, mock_create_table, mock_groupws, mock_writerow):
         mock_ws_list, mock_create_table, mock_create_ws = self.setup_test_create_fit_tables(mock_create_ws,
                                                                                             mock_create_table,
@@ -414,12 +425,18 @@ class TestFittingDataModel(unittest.TestCase):
         self.model._fit_results['name2'] = {'model': func_str2,
                                             'results': dict(self.model._fit_results['name1']['results'],
                                                             FlatBackground_A0=[[1.0, 0.1]]),
+                                            'dpeaks': {'Gaussian_PeakCentre': [[38837.0, 10.0],
+                                                                               [33638.0, 10.0]]},
                                             'costFunction': 2.0}
 
-        self.model.create_fit_tables()
+        mock_peak_centre_params = ['Gaussian_PeakCentre', 'Lorentzian_PeakCentre']
+        self.model.create_fit_tables(mock_peak_centre_params)
 
         # test the workspaces were created and added to fit_workspaces
-        self.assertEqual(self.model._fit_workspaces, mock_ws_list + [mock_create_table.return_value])
+        self.assertEqual(self.model._fit_workspaces, mock_ws_list +
+                         [mock_create_table.return_value, mock_create_table.return_value])
+        # check that the dspacing peaks tables have been made
+        mock_create_table.assert_any_call(OutputWorkspace='Gaussian_PeakCentre_dSpacing')
         # test the table stores the correct function strings (empty string if no function present)
         mock_writerow.assert_any_call(mock_create_table.return_value,
                                       ['name1', self.model._fit_results['name1']['costFunction'],
@@ -435,8 +452,53 @@ class TestFittingDataModel(unittest.TestCase):
         # test only table for unique parameter
         self.assertEqual(sorted(ws_names), sorted(param_names))
 
-    @patch(file_path + '.get_setting')
-    @patch(file_path + '.ADS')
+    @patch(data_model_path + '.FittingDataModel.write_table_row')
+    @patch(data_model_path + ".GroupWorkspaces")
+    @patch(data_model_path + ".CreateEmptyTableWorkspace")
+    @patch(data_model_path + ".CreateWorkspace")
+    def test_create_fit_tables_different_peaks(self, mock_create_ws, mock_create_table, mock_groupws, mock_write_row):
+        mock_ws_list, mock_create_table, mock_create_ws = self.setup_test_create_fit_tables(mock_create_ws,
+                                                                                            mock_create_table,
+                                                                                            mock_groupws)
+        mock_create_table.return_value = mock.MagicMock()
+        mock_ws_list.append(mock.MagicMock())
+        self.model._fit_results['name1']['results']['Lorentzian_PeakCentre'] = [[999, 100]]
+        self.model._fit_results['name1']['dpeaks']['Lorentzian_PeakCentre'] = [[99, 10]]
+        self.model._fit_results['name1']['model'] = 'name=Gaussian,Height=11,PeakCentre=38837,Sigma=54;name=Gaussian,' \
+                                                    'Height=10,PeakCentre=33638,Sigma=51;name=Lorentzian,Height=7,' \
+                                                    'PeakCentre=999,Sigma=52'
+        mock_peak_centre_params = ['Gaussian_PeakCentre', 'Lorentzian_PeakCentre']
+        self.model.create_fit_tables(mock_peak_centre_params)
+        mock_create_table.assert_any_call(OutputWorkspace='Gaussian_PeakCentre_dSpacing')
+        mock_create_table.assert_any_call(OutputWorkspace='Lorentzian_PeakCentre_dSpacing')
+
+    @patch(data_model_path + '.ADS')
+    def test_estimate_difc(self, mock_ads):
+        mock_ads.retrieve.return_value = self.mock_ws
+        mock_detector = mock.MagicMock()
+        mock_sample = mock.MagicMock()
+        mock_source = mock.MagicMock()
+        self.mock_ws.getDetector.return_value = mock_detector
+        self.mock_inst.getSample.return_value = mock_sample
+        self.mock_inst.getSource.return_value = mock_source
+        mock_sample.getPos.return_value = V3D(3, 4, 5)
+        mock_source.getPos.return_value = V3D(6, 8, 10)
+        mock_source.getDistance.return_value = 7.071068
+        mock_sample.getDistance.return_value = 15
+        mock_detector.getTwoTheta.return_value = 1
+        calc_difc = self.model.estimate_difc('name1')
+        expected_difc = 5350.3115
+        self.assertAlmostEqual(expected_difc, calc_difc, 3)
+
+    def test_convert_tof_peaks_to_dspacing(self):
+        self.model._fit_results['name1'] = {'dpeaks': {'Gaussian_PeakCentre': [[38837.0, 10.0], [33638.0, 10.0]]}}
+        mock_difc = 15
+        expected_lists = [[38837.0 / 15, 10.0 / 15], [33638.0 / 15, 10.0 / 15]]
+        self.model.convert_tof_peaks_to_dspacing('name1', mock_difc)
+        self.assertEqual(self.model._fit_results['name1']['dpeaks']['Gaussian_PeakCentre'], expected_lists)
+
+    @patch(data_model_path + '.get_setting')
+    @patch(data_model_path + '.ADS')
     def test_get_ws_sorted_by_primary_log_ascending(self, mock_ads, mock_getsetting):
         self.model._loaded_workspaces = {"name1": self.mock_ws, "name2": self.mock_ws, "name3": self.mock_ws}
         mock_getsetting.side_effect = ['log', 'true']  # primary log, sort_ascending
@@ -448,8 +510,8 @@ class TestFittingDataModel(unittest.TestCase):
 
         self.assertEqual(ws_list, ["name2", "name3", "name1"])
 
-    @patch(file_path + '.get_setting')
-    @patch(file_path + '.ADS')
+    @patch(data_model_path + '.get_setting')
+    @patch(data_model_path + '.ADS')
     def test_get_ws_sorted_by_primary_log_descending(self, mock_ads, mock_getsetting):
         self.model._loaded_workspaces = {"name1": self.mock_ws, "name2": self.mock_ws, "name3": self.mock_ws}
         mock_getsetting.side_effect = ['log', 'false']  # primary log, sort_ascending
@@ -461,8 +523,8 @@ class TestFittingDataModel(unittest.TestCase):
 
         self.assertEqual(ws_list, ["name1", "name3", "name2"])
 
-    @patch(file_path + '.get_setting')
-    @patch(file_path + '.ADS')
+    @patch(data_model_path + '.get_setting')
+    @patch(data_model_path + '.ADS')
     def test_get_ws_sorted_by_primary_log_not_specified(self, mock_ads, mock_getsetting):
         self.model._loaded_workspaces = {"name1": self.mock_ws, "name2": self.mock_ws, "name3": self.mock_ws}
         mock_getsetting.side_effect = ['', 'false']  # primary log, sort_ascending

--- a/scripts/Engineering/gui/engineering_diffraction/tabs/fitting/data_handling/test/test_data_model.py
+++ b/scripts/Engineering/gui/engineering_diffraction/tabs/fitting/data_handling/test/test_data_model.py
@@ -386,7 +386,7 @@ class TestFittingDataModel(unittest.TestCase):
 
         # test the workspaces were created and added to fit_workspaces
         self.assertEqual(self.model._fit_workspaces, (mock_ws_list + [mock_create_table.return_value,
-                                                                           mock_create_table.return_value]))
+                                                                      mock_create_table.return_value]))
         # test the table stores the correct function strings (empty string if no function present)
         mock_writerow.assert_any_call(mock_create_table.return_value,
                                       ['name1', self.model._fit_results['name1']['costFunction'],
@@ -433,8 +433,8 @@ class TestFittingDataModel(unittest.TestCase):
         self.model.create_fit_tables(mock_peak_centre_params)
 
         # test the workspaces were created and added to fit_workspaces
-        self.assertEqual(self.model._fit_workspaces, mock_ws_list +
-                         [mock_create_table.return_value, mock_create_table.return_value])
+        self.assertEqual(self.model._fit_workspaces, mock_ws_list
+                         + [mock_create_table.return_value, mock_create_table.return_value])
         # check that the dspacing peaks tables have been made
         mock_create_table.assert_any_call(OutputWorkspace='Gaussian_PeakCentre_dSpacing')
         # test the table stores the correct function strings (empty string if no function present)

--- a/scripts/Engineering/gui/engineering_diffraction/tabs/fitting/data_handling/test/test_data_model.py
+++ b/scripts/Engineering/gui/engineering_diffraction/tabs/fitting/data_handling/test/test_data_model.py
@@ -32,6 +32,11 @@ class TestFittingDataModel(unittest.TestCase):
         self.mock_ws.getInstrument.return_value = self.mock_inst
         self.mock_ws.getRunNumber.return_value = 1
         self.mock_ws.getTitle.return_value = 'title'
+        mock_axis = mock.MagicMock()
+        mock_unit = mock.MagicMock()
+        self.mock_ws.getAxis.return_value = mock_axis
+        mock_axis.getUnit.return_value = mock_unit
+        mock_unit.caption.return_value = 'Time-of-flight'
 
     @patch(data_model_path + '.ConvertUnits')
     @patch(data_model_path + ".Load")

--- a/scripts/Engineering/gui/engineering_diffraction/tabs/fitting/plotting/EngDiff_fitpropertybrowser.py
+++ b/scripts/Engineering/gui/engineering_diffraction/tabs/fitting/plotting/EngDiff_fitpropertybrowser.py
@@ -94,7 +94,7 @@ class EngDiffFitPropertyBrowser(FitPropertyBrowser):
             try:
                 for ws_name, artists in ax.tracked_workspaces.items():
                     # don't allow existing output workspaces (fitted curves) to be added
-                    if ws_name not in output_wsnames:
+                    if ws_name not in output_wsnames and ws_name[-3:] == 'TOF':
                         spectrum_list = [artist.spec_num for artist in artists]
                         allowed_spectra[ws_name] = spectrum_list
             except AttributeError:  # scripted plots have no tracked_workspaces

--- a/scripts/Engineering/gui/engineering_diffraction/tabs/fitting/plotting/EngDiff_fitpropertybrowser.py
+++ b/scripts/Engineering/gui/engineering_diffraction/tabs/fitting/plotting/EngDiff_fitpropertybrowser.py
@@ -12,7 +12,7 @@ from qtpy.QtCore import Slot
 from mantidqt.utils.qt import import_qt
 from mantidqt.utils.observer_pattern import GenericObservable
 from mantidqt.widgets.fitpropertybrowser import FitPropertyBrowser
-from mantid.api import AnalysisDataService
+from mantid.api import AnalysisDataService as ADS
 
 BaseBrowser = import_qt('.._common', 'mantidqt.widgets', 'FitPropertyBrowser')
 
@@ -94,7 +94,8 @@ class EngDiffFitPropertyBrowser(FitPropertyBrowser):
             try:
                 for ws_name, artists in ax.tracked_workspaces.items():
                     # don't allow existing output workspaces (fitted curves) to be added
-                    if ws_name not in output_wsnames and ws_name[-3:] == 'TOF':
+                    if ws_name not in output_wsnames and \
+                            ADS.retrieve(ws_name).getAxis(0).getUnit().caption() == 'Time-of-flight':
                         spectrum_list = [artist.spec_num for artist in artists]
                         allowed_spectra[ws_name] = spectrum_list
             except AttributeError:  # scripted plots have no tracked_workspaces
@@ -107,7 +108,7 @@ class EngDiffFitPropertyBrowser(FitPropertyBrowser):
         This is called after Fit finishes to update the fit curves.
         :param name: The name of Fit's output workspace.
         """
-        ws = AnalysisDataService.retrieve(name)
+        ws = ADS.retrieve(name)
         self.do_plot(ws, plot_diff=self.plotDiff())
         self.fit_result_ws_name = name
         self.save_current_setup(self.workspaceName())

--- a/scripts/Engineering/gui/engineering_diffraction/tabs/fitting/plotting/EngDiff_fitpropertybrowser.py
+++ b/scripts/Engineering/gui/engineering_diffraction/tabs/fitting/plotting/EngDiff_fitpropertybrowser.py
@@ -42,7 +42,7 @@ class EngDiffFitPropertyBrowser(FitPropertyBrowser):
         """
         dict_str = self.getFitAlgorithmParameters()
         if dict_str:
-            # evalaute string to make a dict (replace case of bool values)
+            # evaluate string to make a dict (replace case of bool values)
             return eval(dict_str.replace('true', 'True').replace('false', 'False'))
         else:
             # if no fit has been performed
@@ -111,7 +111,14 @@ class EngDiffFitPropertyBrowser(FitPropertyBrowser):
         self.do_plot(ws, plot_diff=self.plotDiff())
         self.fit_result_ws_name = name
         self.save_current_setup(self.workspaceName())
-        self.fit_notifier.notify_subscribers([self.get_fitprop()])  # needs to be passed a list
+        peak_prefixes = self.getPeakPrefixes()
+        peak_center_params = []
+        for peak_pre in peak_prefixes:
+            handler = self.getPeakHandler(peak_pre)
+            func_name_prefixed = handler.functionName()
+            func_name = func_name_prefixed.split('-')[1]  # separate the prefix from the function name
+            peak_center_params.append(func_name + '_' + self.getCentreParameterNameOf(peak_pre))
+        self.fit_notifier.notify_subscribers([self.get_fitprop(), peak_center_params])  # needs to be passed a list
 
     @Slot()
     def function_changed_slot(self):

--- a/scripts/Engineering/gui/engineering_diffraction/tabs/fitting/presenter.py
+++ b/scripts/Engineering/gui/engineering_diffraction/tabs/fitting/presenter.py
@@ -27,6 +27,7 @@ class FittingPresenter(object):
         self.data_widget.presenter.seq_fit_started_notifier.add_subscriber(self.seq_fit_started_observer)
         self.data_widget.presenter.seq_fit_started_notifier.add_subscriber(self.plot_widget.seq_fit_started_observer)
         self.plot_widget.view.fit_browser.fit_notifier.add_subscriber(self.data_widget.presenter.fit_observer)
+        #
         self.plot_widget.view.fit_browser.fit_enabled_notifier.add_subscriber(
             self.data_widget.presenter.fit_enabled_observer)
         self.plot_widget.seq_fit_done_notifier.add_subscriber(self.data_widget.presenter.seq_fit_done_observer)


### PR DESCRIPTION
Merge after https://github.com/mantidproject/mantid/pull/29929, will remove Richard's commits once in master
**Description of work.**

This PR removes the ability to fit in dSpacing in the engineering diffraction GUI, and creates table(s) for TOF peak centres converted to dSpacing as part of the output of a fit.

**To test:**
1. Interfaces -> Diffraction -> Engineering Diffraction
2. Load a focused run file in BOTH TOF and dSpacing e.g.
[ENGINX_305500_bank_1.zip](https://github.com/mantidproject/mantid/files/5554626/ENGINX_305500_bank_1.zip)
3. Select the checkboxes to plot both
4. Ensure in the fit property browser that only the TOF ws can be selected
5. Unplot the dSpacing plot
6. Add some peaks of one type to the plot and fit
7. Ensure that these peaks are shown in dSpasing in a ws2d, e.g. `Gaussian_PeakCentre_dSpacing`
8. Try another fit with peaks of different type and a background function or two thrown in
9. Ensure that the tables are made with the correct names

Fixes #28929. 

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
