### PR TITLE
Convert index to spectrum number in _get_data_for_plot() for plotBin()

### DIFF
--- a/Framework/PythonInterface/mantid/plots/axesfunctions.py
+++ b/Framework/PythonInterface/mantid/plots/axesfunctions.py
@@ -122,6 +122,9 @@ def _get_data_for_plot(axes, workspace, kwargs, with_dy=False, with_dx=False):
                     # for bin edge axis we have one more edge than content
                     values = (values[0:-1] + values[1:])/2.
                 x = values
+            if isinstance(vertical_axis, mantid.api.SpectraAxis):
+                spectrum_numbers = workspace.getSpectrumNumbers()
+                x = [spectrum_numbers[i] for i in x]
 
         elif axis == MantidAxType.SPECTRUM:
             x, y, dy, dx = get_spectrum(workspace, workspace_index, normalize_by_bin_width, with_dy,

--- a/Framework/PythonInterface/mantid/plots/datafunctions.py
+++ b/Framework/PythonInterface/mantid/plots/datafunctions.py
@@ -393,7 +393,7 @@ def get_bin_indices(workspace):
 
 def get_bins(workspace, bin_index, withDy=False):
     """
-    Extract all the bins for a spectrum
+    Extract a requested bin from each spectrum
 
     :param workspace: a Workspace2D or an EventWorkspace
     :param bin_index: the index of a bin

--- a/Framework/PythonInterface/test/python/mantid/plots/axesfunctionsTest.py
+++ b/Framework/PythonInterface/test/python/mantid/plots/axesfunctionsTest.py
@@ -72,6 +72,11 @@ class PlotFunctionsTest(unittest.TestCase):
                                                 DataY=[1, 2, 3],
                                                 NSpec=1,
                                                 OutputWorkspace='ws2d_point_uneven')
+        cls.ws_spec = CreateWorkspace(DataX=[10, 20, 30, 10, 20, 30, 10, 20, 30],
+                                      DataY=[2, 3, 4, 5, 2, 3],
+                                      DataE=[1, 2, 3, 4, 1, 2],
+                                      NSpec=3,
+                                      OutputWorkspace='ws_spec')
         wp = CreateWorkspace(DataX=[15, 25, 35, 45], DataY=[1, 2, 3, 4], NSpec=1)
         ConjoinWorkspaces(cls.ws2d_point_uneven, wp, CheckOverlapping=False)
         cls.ws2d_point_uneven = mantid.mtd['ws2d_point_uneven']
@@ -269,6 +274,19 @@ class PlotFunctionsTest(unittest.TestCase):
         finally:
             config['graph1d.autodistribution'] = 'On'
 
+    def test_get_data_for_plot_binplot_binedgeaxis(self):
+        fig, ax = plt.subplots()
+        kwargs = {'wkspIndex': 0, 'axis': MantidAxType.BIN}
+        x, y, dy, dx, indices, axis, kwargs = funcs._get_data_for_plot(ax, self.ws2d_histo, kwargs)
+        self.assertTrue(np.array_equal([5., 7.], x))
+        self.assertTrue(np.array_equal([2., 4.], y))
+
+    def test_get_data_for_plot_binplot_spectrumaxis(self):
+        fig, ax = plt.subplots()
+        kwargs = {'wkspIndex': 0, 'axis': MantidAxType.BIN}
+        x, y, dy, dx, indices, axis, kwargs = funcs._get_data_for_plot(ax, self.ws_spec, kwargs)
+        self.assertTrue(np.array_equal([1, 2, 3], x))
+        self.assertTrue(np.array_equal([2., 4., 2.], y))
 
 if __name__ == '__main__':
     unittest.main()

--- a/docs/source/release/v6.0.0/mantidworkbench.rst
+++ b/docs/source/release/v6.0.0/mantidworkbench.rst
@@ -35,5 +35,6 @@ Bugfixes
 - Fix crash on second call to ManageUserDirectories after pressing Esc to close it.
 - A bug in plot config where changing an axes title in the axis tab did not change the title in the curves tab.
 - Fixed a Workbench crash when attempting to show the data in a ragged workspace.
+- Show spectrum numbers instead of workspace index in plotBin
 
 :ref:`Release 6.0.0 <v6.0.0>`


### PR DESCRIPTION
Fixes #29918

When gathering data for a binPlot with a SpectraAxis workspace in _get_data_for_plot() convert the workspace indices to spectrum numbers.

Add test for _get_data_for_plot in the SpectraAxis and BinEdgeAxis cases.

Improve docstring for get_bins()

**Description of work.**

plotBin currently uses workspace indexes for the x axis. The data to plot is gathered in _get_data_for_plot(). There are already some transforms for the x values for NumericAxis and BinEdgeAxis. Add a conversion to Spectrum number for the SpectraAxis case.


**To test:**
```python
ws = CreateSampleWorkspace()
ws = ExtractSpectra(ws,StartWorkspaceIndex = 9, EndWorkspaceIndex = 12)
plotBin(ws,0)
```
x axis should be in spectrum number, e.g. 10 -> 13

Fixes #29918

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or master)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
