### PR TITLE
Indirect Reduction - Fix Custom Grouping Bug

### DIFF
--- a/Framework/PythonInterface/test/python/plugins/algorithms/WorkflowAlgorithms/ISISIndirectEnergyTransferTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/WorkflowAlgorithms/ISISIndirectEnergyTransferTest.py
@@ -104,6 +104,15 @@ class ISISIndirectEnergyTransferTest(unittest.TestCase):
         red_ws = wks.getItem(0)
         self.assertEqual(red_ws.getNumberHistograms(), 51)
 
+    def test_ISISIndirectEnergyTransfer_with_different_custom_groupings_creates_a_workspace_with_the_correct_size(self):
+        custom_grouping_strings = {"3:53": 51, "3:25,27:53": 50, "3-53": 1, "3-25,26:53": 29, "3+5+7,8-40,41:53": 15}
+
+        for custom_string, expected_size in custom_grouping_strings.items():
+            reduced_workspace = ISISIndirectEnergyTransfer(InputFiles=['IRS26176.RAW'], Instrument='IRIS',
+                                                           Analyser='graphite', Reflection='002', SpectraRange=[3, 53],
+                                                           GroupingMethod='Custom', GroupingString=custom_string)
+
+            self.assertEqual(reduced_workspace.getItem(0).getNumberHistograms(), expected_size)
 
     def test_reduction_with_background_subtraction(self):
         """

--- a/docs/source/interfaces/Indirect Data Reduction.rst
+++ b/docs/source/interfaces/Indirect Data Reduction.rst
@@ -191,7 +191,7 @@ The following options are available for grouping output data:
 
 Custom
   Follows the same grouping patterns used in the :ref:`GroupDetectors <algm-GroupDetectors>` algorithm.
-  An example of the syntax is 1,2+3,4-6,7-10
+  An example of the syntax is 1,2+3,4-6,7:10
 
   This would produce spectra for: spectra 1, the sum of spectra 2 and 3, the sum of spectra 4-6 (4+5+6)
   and individual spectra from 7 to 10 (7,8,9,10)

--- a/docs/source/release/v6.0.0/indirect_geometry.rst
+++ b/docs/source/release/v6.0.0/indirect_geometry.rst
@@ -22,5 +22,7 @@ Bug Fixes
 #########
 - A bug has been fixed in Indirect data analysis on the Elwin tab that causes the integration range to be reset when changing between plotted workspaces.
 - A bug in Indirect Data Analysis causing logs not to load in the Edit Local Fit Parameters dialog has been fixed.
+- Fixed a bug in Indirect Data Reduction causing the colon separator in Custom Grouping to act like a dash separator. This colon separator should now act
+  as expected (i.e. `1:5` means the same as `1,2,3,4,5`).
 
 :ref:`Release 6.0.0 <v6.0.0>`

--- a/scripts/Inelastic/IndirectReductionCommon.py
+++ b/scripts/Inelastic/IndirectReductionCommon.py
@@ -647,10 +647,7 @@ def create_group_from_spectra_list(group_detectors, spectra_list):
 
 
 def create_individual_spectra_groups(group_detectors, grouping_string):
-    workspaces = []
-    for spectrum_number in create_range_from(grouping_string, ':'):
-        workspaces.append(create_group_from_spectra_list(group_detectors, [spectrum_number]))
-    return workspaces
+    return [create_group_from_spectra_list(group_detectors, [i]) for i in create_range_from(grouping_string, ':')]
 
 
 def add_group_from_string(groups, group_detectors, grouping_string):
@@ -662,7 +659,6 @@ def add_group_from_string(groups, group_detectors, grouping_string):
         groups.append(create_group_from_spectra_list(group_detectors, [int(i) for i in grouping_string.split('+')]))
     else:
         groups.append(create_group_from_spectra_list(group_detectors, [int(grouping_string)]))
-    return groups
 
 
 def conjoin_workspaces(*workspaces):
@@ -676,7 +672,7 @@ def group_on_string(group_detectors, grouping_string):
     grouping_string.replace(' ', '')
     groups = []
     for sub_string in grouping_string.split(','):
-        groups = add_group_from_string(groups, group_detectors, sub_string)
+        add_group_from_string(groups, group_detectors, sub_string)
     return conjoin_workspaces(*groups)
 
 

--- a/scripts/Inelastic/IndirectReductionCommon.py
+++ b/scripts/Inelastic/IndirectReductionCommon.py
@@ -4,7 +4,7 @@
 #   NScD Oak Ridge National Laboratory, European Spallation Source,
 #   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
 # SPDX - License - Identifier: GPL - 3.0 +
-from mantid.simpleapi import DeleteWorkspace, Load
+from mantid.simpleapi import AppendSpectra, DeleteWorkspace, Load
 from mantid.api import AnalysisDataService, WorkspaceGroup, AlgorithmManager
 from mantid import mtd, logger, config
 
@@ -639,27 +639,33 @@ def scale_detectors(workspace_name, e_mode='Indirect'):
 # -------------------------------------------------------------------------------
 
 
-def get_group_from_string(grouping_string):
-    if '-' in grouping_string:
-        return list(create_range_from(grouping_string, '-'))
-    elif ':' in grouping_string:
-        return list(create_range_from(grouping_string, ':'))
-    elif '+' in grouping_string:
-        return [int(i) for i in grouping_string.split('+')]
-    else:
-        return [int(grouping_string)]
-
-
-def create_group_from_string(group_detectors, grouping_string):
-    group_detectors.setProperty("SpectraList", get_group_from_string(grouping_string))
+def create_group_from_spectra_list(group_detectors, spectra_list):
+    group_detectors.setProperty("SpectraList", spectra_list)
     group_detectors.setProperty("OutputWorkspace", "__temp")
     group_detectors.execute()
     return group_detectors.getProperty("OutputWorkspace").value
 
 
-def conjoin_workspaces(*workspaces):
-    from mantid.simpleapi import AppendSpectra
+def create_individual_spectra_groups(group_detectors, grouping_string):
+    workspaces = []
+    for spectrum_number in create_range_from(grouping_string, ':'):
+        workspaces.append(create_group_from_spectra_list(group_detectors, [spectrum_number]))
+    return workspaces
 
+
+def add_group_from_string(groups, group_detectors, grouping_string):
+    if ':' in grouping_string:
+        groups.extend(create_individual_spectra_groups(group_detectors, grouping_string))
+    elif '-' in grouping_string:
+        groups.append(create_group_from_spectra_list(group_detectors, list(create_range_from(grouping_string, '-'))))
+    elif '+' in grouping_string:
+        groups.append(create_group_from_spectra_list(group_detectors, [int(i) for i in grouping_string.split('+')]))
+    else:
+        groups.append(create_group_from_spectra_list(group_detectors, [int(grouping_string)]))
+    return groups
+
+
+def conjoin_workspaces(*workspaces):
     conjoined = workspaces[0]
     for workspace in workspaces[1:]:
         conjoined = AppendSpectra(conjoined, workspace, StoreInADS=False)
@@ -668,7 +674,9 @@ def conjoin_workspaces(*workspaces):
 
 def group_on_string(group_detectors, grouping_string):
     grouping_string.replace(' ', '')
-    groups = [create_group_from_string(group_detectors, group) for group in grouping_string.split(',')]
+    groups = []
+    for sub_string in grouping_string.split(','):
+        groups = add_group_from_string(groups, group_detectors, sub_string)
     return conjoin_workspaces(*groups)
 
 


### PR DESCRIPTION
**Description of work.**
This PR fixes a bug in custom detector grouping on Indirect Data Analysis where the colon `:` separator was being treated the same as the dash `-` separator. 

The colon separator should have worked as follows: `1:5` -> `1,2,3,4,5`

It was however summing the spectra instead of treating each spectra individually. (i.e. `1:5` -> `1+2+3+4+5`)

This PR also adds a test which will catch any future regressions for custom grouping, and corrects the documentation.

**To test:**
1. `Interfaces`->`Indirect Data Reduction`
2. Selected `IRIS`
3. Load `26176`
4. Select `Custom` for the detector grouping.
5. Enter `3:53` and click `Run`
6. The output workspace should contain 51 spectra.

Fixes #29975

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
