### PR TITLE
Slice Viewer ADS Observer

### DIFF
--- a/docs/source/release/v6.0.0/mantidworkbench.rst
+++ b/docs/source/release/v6.0.0/mantidworkbench.rst
@@ -37,6 +37,7 @@ Improvements
 - The matplotlib `zoom` selection box is now more visible on colorfill and sliceviewer plots.
 - Add an autoscale checkbox to plot config dialog.
 - Add a Python function to replace the workspace being shown by an instrument window.
+- Slice Viewer replots the workspace when it is modified outside the Slice Viewer.
 
 Bugfixes
 ########

--- a/qt/python/mantidqt/utils/qt/testing/qt_widget_finder.py
+++ b/qt/python/mantidqt/utils/qt/testing/qt_widget_finder.py
@@ -24,7 +24,7 @@ class QtWidgetFinder(object):
     def assert_widget_exists(self, name, expected_count=None):
         all = self.find_qt_widget_by_name(name)
         if not expected_count:
-            self.assertGreaterThan(0, len(all))
+            self.assertGreater(0, len(all))
         else:
             self.assertEqual(expected_count, len(all))
 

--- a/qt/python/mantidqt/widgets/sliceviewer/adsobsever.py
+++ b/qt/python/mantidqt/widgets/sliceviewer/adsobsever.py
@@ -55,19 +55,22 @@ class SliceViewerADSObserver(AnalysisDataServiceObserver):
         :param ws_name: The name of the workspace.
         :param _: A pointer to the workspace. Unused
         """
-        if ws_name == str(self.presenter.model._get_ws()):
+        if ws_name == str(self.presenter.model.get_ws()):
             self.view.emit_close()
 
     @_catch_exceptions
-    def replaceHandle(self, _, workspace):
+    def replaceHandle(self, ws_name, workspace):
         """
         Called when the ADS has replaced a workspace with one of the same name.
         If this workspace is the same as that of the sliceviewer model, the model
-        is updated.
-        :param _: The name of the workspace. Unused
+        is replaced.
+        :param ws_name: The name of the workspace.
         :param workspace: A reference to the new workspace
         """
-        self.logger.notice("replace" + str(workspace))
+        import pydevd_pycharm
+        pydevd_pycharm.settrace('localhost', port=44444, stdoutToServer=True, stderrToServer=True, suspend=False)
+
+        self.presenter.replace_workspace(ws_name, workspace)
 
     @_catch_exceptions
     def renameHandle(self, oldName, newName):

--- a/qt/python/mantidqt/widgets/sliceviewer/adsobsever.py
+++ b/qt/python/mantidqt/widgets/sliceviewer/adsobsever.py
@@ -44,18 +44,19 @@ class SliceViewerADSObserver(AnalysisDataServiceObserver):
     @_catch_exceptions
     def clearHandle(self):
         """Called when the ADS is deleted all of its workspaces"""
-        self.logger.notice("Cleared")
+        self.view.emit_close()
 
     @_catch_exceptions
-    def deleteHandle(self, _, workspace):
+    def deleteHandle(self, ws_name, _):
         """
         Called when the ADS has deleted a workspace. Checks if
         the deleted workspace is the same as the one used for the
         sliceviewer model. If so, sliceviewer is closed.
-        :param _: The name of the workspace. Unused
-        :param workspace: A pointer to the workspace
+        :param ws_name: The name of the workspace.
+        :param _: A pointer to the workspace. Unused
         """
-        self.logger.notice("delete" + str(workspace))
+        if ws_name == str(self.presenter.model._get_ws()):
+            self.view.emit_close()
 
     @_catch_exceptions
     def replaceHandle(self, _, workspace):

--- a/qt/python/mantidqt/widgets/sliceviewer/adsobsever.py
+++ b/qt/python/mantidqt/widgets/sliceviewer/adsobsever.py
@@ -1,0 +1,80 @@
+# Mantid Repository : https://github.com/mantidproject/mantid
+#
+# Copyright &copy; 2018 ISIS Rutherford Appleton Laboratory UKRI,
+#   NScD Oak Ridge National Laboratory, European Spallation Source,
+#   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+# SPDX - License - Identifier: GPL - 3.0 +
+#  This file is part of the mantid workbench.
+
+import sys
+from functools import wraps
+
+import mantid
+from mantid.api import AnalysisDataServiceObserver
+
+
+def _catch_exceptions(func):
+    """Catch all exceptions in method and print a traceback to stderr"""
+
+    @wraps(func)
+    def wrapper(*args, **kwargs):
+        try:
+            func(*args, **kwargs)
+        except Exception:
+            sys.stderr.write("Error occurred in handler:\n")
+            import traceback
+            traceback.print_exc()
+
+    return wrapper
+
+
+class SliceViewerADSObserver(AnalysisDataServiceObserver):
+
+    def __init__(self, presenter):
+        super(SliceViewerADSObserver, self).__init__()
+        self.presenter = presenter
+        self.view = self.presenter.view
+        self.logger = mantid.kernel.Logger("SliceViewerADSObserver")
+
+        self.observeClear(True)
+        self.observeDelete(True)
+        self.observeReplace(True)
+        self.observeRename(True)
+
+    @_catch_exceptions
+    def clearHandle(self):
+        """Called when the ADS is deleted all of its workspaces"""
+        self.logger.notice("Cleared")
+
+    @_catch_exceptions
+    def deleteHandle(self, _, workspace):
+        """
+        Called when the ADS has deleted a workspace. Checks if
+        the deleted workspace is the same as the one used for the
+        sliceviewer model. If so, sliceviewer is closed.
+        :param _: The name of the workspace. Unused
+        :param workspace: A pointer to the workspace
+        """
+        self.logger.notice("delete" + str(workspace))
+
+    @_catch_exceptions
+    def replaceHandle(self, _, workspace):
+        """
+        Called when the ADS has replaced a workspace with one of the same name.
+        If this workspace is the same as that of the sliceviewer model, the model
+        is updated.
+        :param _: The name of the workspace. Unused
+        :param workspace: A reference to the new workspace
+        """
+        self.logger.notice("replace" + str(workspace))
+
+    @_catch_exceptions
+    def renameHandle(self, oldName, newName):
+        """
+        Called when the ADS has renamed a workspace.
+        If this workspace is the same as that of the sliceviewer model, its name
+        is updated.
+        :param oldName: The old name of the workspace.
+        :param newName: The new name of the workspace
+        """
+        self.logger.notice("rename" + str(oldName) + str(newName))

--- a/qt/python/mantidqt/widgets/sliceviewer/adsobsever.py
+++ b/qt/python/mantidqt/widgets/sliceviewer/adsobsever.py
@@ -11,6 +11,7 @@ from functools import wraps
 
 import mantid
 from mantid.api import AnalysisDataServiceObserver
+from mantidqt.utils.qt.qappthreadcall import QAppThreadCall
 
 
 def _catch_exceptions(func):
@@ -67,10 +68,7 @@ class SliceViewerADSObserver(AnalysisDataServiceObserver):
         :param ws_name: The name of the workspace.
         :param workspace: A reference to the new workspace
         """
-        import pydevd_pycharm
-        pydevd_pycharm.settrace('localhost', port=44444, stdoutToServer=True, stderrToServer=True, suspend=False)
-
-        self.presenter.replace_workspace(ws_name, workspace)
+        QAppThreadCall(self.presenter.replace_workspace(ws_name, workspace))
 
     @_catch_exceptions
     def renameHandle(self, oldName, newName):

--- a/qt/python/mantidqt/widgets/sliceviewer/adsobsever.py
+++ b/qt/python/mantidqt/widgets/sliceviewer/adsobsever.py
@@ -31,14 +31,16 @@ def _catch_exceptions(func):
 
 class SliceViewerADSObserver(AnalysisDataServiceObserver):
 
-    def __init__(self, presenter):
+    def __init__(self, on_replace, on_rename, on_clear, on_delete):
         super(SliceViewerADSObserver, self).__init__()
-        self.presenter = presenter
-        self.view = self.presenter.view
-        self.logger = mantid.kernel.Logger("SliceViewerADSObserver")
 
-        self.on_replace_workspace = QAppThreadCall(self.presenter.replace_workspace)
-        self.on_rename_workspace = QAppThreadCall(self.presenter.rename_workspace)
+        # self.on_replace_workspace = QAppThreadCall(self.presenter.replace_workspace)
+        # self.on_rename_workspace = QAppThreadCall(self.presenter.rename_workspace)
+
+        self.on_replace_workspace = QAppThreadCall(on_replace)
+        self.on_rename_workspace = QAppThreadCall(on_rename)
+        self.on_clear = QAppThreadCall(on_clear)
+        self.on_delete_workspace = QAppThreadCall(on_delete)
 
         self.observeClear(True)
         self.observeDelete(True)
@@ -48,7 +50,7 @@ class SliceViewerADSObserver(AnalysisDataServiceObserver):
     @_catch_exceptions
     def clearHandle(self):
         """Called when the ADS is deleted all of its workspaces"""
-        self.view.emit_close()
+        self.on_clear()
 
     @_catch_exceptions
     def deleteHandle(self, ws_name, _):
@@ -59,8 +61,7 @@ class SliceViewerADSObserver(AnalysisDataServiceObserver):
         :param ws_name: The name of the workspace.
         :param _: A pointer to the workspace. Unused
         """
-        if ws_name == str(self.presenter.model.get_ws()):
-            self.view.emit_close()
+        self.on_delete_workspace(ws_name)
 
     @_catch_exceptions
     def replaceHandle(self, ws_name, workspace):

--- a/qt/python/mantidqt/widgets/sliceviewer/adsobsever.py
+++ b/qt/python/mantidqt/widgets/sliceviewer/adsobsever.py
@@ -37,6 +37,9 @@ class SliceViewerADSObserver(AnalysisDataServiceObserver):
         self.view = self.presenter.view
         self.logger = mantid.kernel.Logger("SliceViewerADSObserver")
 
+        self.on_replace_workspace = QAppThreadCall(self.presenter.replace_workspace)
+        self.on_rename_workspace = QAppThreadCall(self.presenter.rename_workspace)
+
         self.observeClear(True)
         self.observeDelete(True)
         self.observeReplace(True)
@@ -68,7 +71,7 @@ class SliceViewerADSObserver(AnalysisDataServiceObserver):
         :param ws_name: The name of the workspace.
         :param workspace: A reference to the new workspace
         """
-        QAppThreadCall(self.presenter.replace_workspace(ws_name, workspace))
+        self.on_replace_workspace(ws_name, workspace)
 
     @_catch_exceptions
     def renameHandle(self, oldName, newName):
@@ -79,4 +82,4 @@ class SliceViewerADSObserver(AnalysisDataServiceObserver):
         :param oldName: The old name of the workspace.
         :param newName: The new name of the workspace
         """
-        self.logger.notice("rename" + str(oldName) + str(newName))
+        self.on_rename_workspace(oldName, newName)

--- a/qt/python/mantidqt/widgets/sliceviewer/adsobsever.py
+++ b/qt/python/mantidqt/widgets/sliceviewer/adsobsever.py
@@ -33,9 +33,6 @@ class SliceViewerADSObserver(AnalysisDataServiceObserver):
     def __init__(self, on_replace, on_rename, on_clear, on_delete):
         super(SliceViewerADSObserver, self).__init__()
 
-        # self.on_replace_workspace = QAppThreadCall(self.presenter.replace_workspace)
-        # self.on_rename_workspace = QAppThreadCall(self.presenter.rename_workspace)
-
         self.on_replace_workspace = QAppThreadCall(on_replace)
         self.on_rename_workspace = QAppThreadCall(on_rename)
         self.on_clear = QAppThreadCall(on_clear)

--- a/qt/python/mantidqt/widgets/sliceviewer/adsobsever.py
+++ b/qt/python/mantidqt/widgets/sliceviewer/adsobsever.py
@@ -9,7 +9,6 @@
 import sys
 from functools import wraps
 
-import mantid
 from mantid.api import AnalysisDataServiceObserver
 from mantidqt.utils.qt.qappthreadcall import QAppThreadCall
 

--- a/qt/python/mantidqt/widgets/sliceviewer/model.py
+++ b/qt/python/mantidqt/widgets/sliceviewer/model.py
@@ -130,9 +130,12 @@ class SliceViewerModel:
         """Return the coordinate system of the workspace"""
         return self._ws.getSpecialCoordinateSystem()
 
-    def get_title(self) -> str:
-        """Return a title for model"""
-        ws_name = self.get_ws_name()
+    def get_title(self, ws_name=None) -> str:
+        """Return a title for the model, given a workspace name. Default to the name
+        of the model's workspace if none supplied.
+        """
+        if not ws_name:
+            ws_name = self.get_ws_name()
         return f'Sliceviewer - {ws_name}'
 
     def get_ws_MDE(self,
@@ -235,10 +238,6 @@ class SliceViewerModel:
             "supports_dynamic_rebinning": self.can_support_dynamic_rebinning(),
             "supports_peaks_overlays": self.can_support_peaks_overlays()
         }
-
-    def set_ws_name(self, name):
-        # TODO: Set the name of the workspace
-        pass
 
     def create_nonorthogonal_transform(self, slice_info: SliceInfo):
         """
@@ -488,7 +487,7 @@ class SliceViewerModel:
         return help_msg
 
     def workspace_equals(self, ws_name):
-        return str(self.get_ws()) == ws_name
+        return str(self._get_ws()) == ws_name
 
     # private api
     def _get_ws(self):

--- a/qt/python/mantidqt/widgets/sliceviewer/model.py
+++ b/qt/python/mantidqt/widgets/sliceviewer/model.py
@@ -223,6 +223,23 @@ class SliceViewerModel:
         else:
             raise ValueError("Unsupported workspace type")
 
+    def get_properties(self):
+        """
+        @return: a dictionary of properties about this model to compare new models against,
+        for example when the model workspace changes outside of the slice viewer.
+        """
+        return {
+            "workspace_type": self.get_ws_type(),
+            "supports_normalise": self.can_normalize_workspace(),
+            "supports_nonorthogonal_axes": self.can_support_nonorthogonal_axes(),
+            "supports_dynamic_rebinning": self.can_support_dynamic_rebinning(),
+            "supports_peaks_overlays": self.can_support_peaks_overlays()
+        }
+
+    def set_ws_name(self, name):
+        # TODO: Set the name of the workspace
+        pass
+
     def create_nonorthogonal_transform(self, slice_info: SliceInfo):
         """
         Calculate the transform object for nonorthogonal axes.
@@ -469,6 +486,9 @@ class SliceViewerModel:
             extract_roi_matrix(workspace, xpos, xpos, None, None, True, ycut_name)
 
         return help_msg
+
+    def workspace_equals(self, ws_name):
+        return str(self.get_ws()) == ws_name
 
     # private api
     def _get_ws(self):

--- a/qt/python/mantidqt/widgets/sliceviewer/presenter.py
+++ b/qt/python/mantidqt/widgets/sliceviewer/presenter.py
@@ -16,10 +16,12 @@ from .model import SliceViewerModel, WS_TYPE
 from .sliceinfo import SliceInfo
 from .toolbar import ToolItemText
 from .view import SliceViewerView
+from .adsobsever import SliceViewerADSObserver
 from .peaksviewer import PeaksViewerPresenter, PeaksViewerCollectionPresenter
+from ..observers.observing_presenter import ObservingPresenter
 
 
-class SliceViewer(object):
+class SliceViewer(ObservingPresenter):
     TEMPORARY_STATUS_TIMEOUT = 2000
 
     def __init__(self, ws, parent=None, model=None, view=None, conf=None):
@@ -66,6 +68,8 @@ class SliceViewer(object):
 
         # Start the GUI with zoom selected.
         self.view.data_view.activate_tool(ToolItemText.ZOOM)
+
+        self.ads_observer = SliceViewerADSObserver(self)
 
     def new_plot_MDH(self):
         """

--- a/qt/python/mantidqt/widgets/sliceviewer/presenter.py
+++ b/qt/python/mantidqt/widgets/sliceviewer/presenter.py
@@ -357,7 +357,6 @@ class SliceViewer(ObservingPresenter):
         """
         if not self.model.workspace_equals(workspace_name):
             return
-        print("replace")
         try:
             candidate_model = SliceViewerModel(workspace)
             candidate_model_properties = candidate_model.get_properties()

--- a/qt/python/mantidqt/widgets/sliceviewer/presenter.py
+++ b/qt/python/mantidqt/widgets/sliceviewer/presenter.py
@@ -372,6 +372,11 @@ class SliceViewer(ObservingPresenter):
             )
             return
 
+    def rename_workspace(self, old_name, new_name):
+        if str(self.model.get_ws()) == old_name:
+            self.model.set_workspace_name(new_name)
+            self.view.setWindowTitle(self.model.get_title())
+
     # private api
     def _create_peaks_presenter_if_necessary(self):
         if self._peaks_presenter is None:

--- a/qt/python/mantidqt/widgets/sliceviewer/presenter.py
+++ b/qt/python/mantidqt/widgets/sliceviewer/presenter.py
@@ -65,7 +65,9 @@ class SliceViewer(ObservingPresenter):
         # Start the GUI with zoom selected.
         self.view.data_view.activate_tool(ToolItemText.ZOOM)
 
-        self.ads_observer = SliceViewerADSObserver(self)
+        self.ads_observer = SliceViewerADSObserver(
+            self.replace_workspace, self.rename_workspace, self.ADS_cleared, self.delete_workspace
+        )
 
     def new_plot_MDH(self):
         """
@@ -377,6 +379,16 @@ class SliceViewer(ObservingPresenter):
             self.model.set_workspace_name(new_name)
             self.view.setWindowTitle(self.model.get_title())
 
+    def delete_workspace(self, ws_name):
+        if ws_name == str(self.model._ws):
+            self.view.emit_close()
+
+    def ADS_cleared(self):
+        self.view.emit_close()
+
+    def clear_observer(self):
+        self.ads_observer = None
+
     # private api
     def _create_peaks_presenter_if_necessary(self):
         if self._peaks_presenter is None:
@@ -430,10 +442,10 @@ class SliceViewer(ObservingPresenter):
         """
         # we don't want to use model.get_ws for the image info widget as this needs
         # extra arguments depending on workspace type.
-        self.view.data_view.image_info_widget.setWorkspace(self.model._ws)
+        self.view.data_view.image_info_widget.setWorkspace(self.model._get_ws())
         self.view.setWindowTitle(self.model.get_title())
         self.new_plot()
 
     def _close_view_with_message(self, message: str):
-        self.view.emit_close()
+        self.view.emit_close()  # inherited from ObservingView
         self._logger.warning(message)

--- a/qt/python/mantidqt/widgets/sliceviewer/presenter.py
+++ b/qt/python/mantidqt/widgets/sliceviewer/presenter.py
@@ -49,6 +49,7 @@ class SliceViewer(ObservingPresenter):
         self.view = view if view else SliceViewerView(self, self.model.get_dimensions_info(),
                                                       self.model.can_normalize_workspace(), parent,
                                                       conf)
+        self.view.setWindowTitle(self.model.get_title())
         self.view.data_view.create_axes_orthogonal(
             redraw_on_zoom=not self.model.can_support_dynamic_rebinning())
 
@@ -356,7 +357,7 @@ class SliceViewer(ObservingPresenter):
         """
         if not self.model.workspace_equals(workspace_name):
             return
-
+        print("replace")
         try:
             candidate_model = SliceViewerModel(workspace)
             candidate_model_properties = candidate_model.get_properties()
@@ -375,9 +376,8 @@ class SliceViewer(ObservingPresenter):
             return
 
     def rename_workspace(self, old_name, new_name):
-        if str(self.model.get_ws()) == old_name:
-            self.model.set_workspace_name(new_name)
-            self.view.setWindowTitle(self.model.get_title())
+        if str(self.model._get_ws()) == old_name:
+            self.view.emit_rename(self.model.get_title(new_name))
 
     def delete_workspace(self, ws_name):
         if ws_name == str(self.model._ws):
@@ -443,7 +443,6 @@ class SliceViewer(ObservingPresenter):
         # we don't want to use model.get_ws for the image info widget as this needs
         # extra arguments depending on workspace type.
         self.view.data_view.image_info_widget.setWorkspace(self.model._get_ws())
-        self.view.setWindowTitle(self.model.get_title())
         self.new_plot()
 
     def _close_view_with_message(self, message: str):

--- a/qt/python/mantidqt/widgets/sliceviewer/test/test_sliceviewer_presenter.py
+++ b/qt/python/mantidqt/widgets/sliceviewer/test/test_sliceviewer_presenter.py
@@ -99,7 +99,7 @@ class SliceViewerTest(unittest.TestCase):
 
         # setup calls
         self.assertEqual(self.model.get_dimensions_info.call_count, 0)
-        self.assertEqual(self.model.get_ws.call_count, 2)
+        self.assertEqual(self.model.get_ws.call_count, 1)
         self.assertEqual(self.model.get_properties.call_count, 1)
         self.assertEqual(self.view.data_view.dimensions.get_slicepoint.call_count, 1)
         self.assertEqual(self.view.data_view.plot_MDH.call_count, 1)
@@ -158,7 +158,7 @@ class SliceViewerTest(unittest.TestCase):
 
         # setup calls
         self.assertEqual(self.model.get_dimensions_info.call_count, 0)
-        self.assertEqual(self.model.get_ws.call_count, 2)
+        self.assertEqual(self.model.get_ws.call_count, 1)
         self.assertEqual(self.model.get_properties.call_count, 1)
         self.assertEqual(self.view.data_view.dimensions.get_slicepoint.call_count, 0)
         self.assertEqual(self.view.data_view.plot_matrix.call_count, 1)

--- a/qt/python/mantidqt/widgets/sliceviewer/test/test_sliceviewer_presenter.py
+++ b/qt/python/mantidqt/widgets/sliceviewer/test/test_sliceviewer_presenter.py
@@ -11,20 +11,19 @@ import sys
 import unittest
 from unittest import mock
 from unittest.mock import patch
+from mantid.api import MultipleExperimentInfos
 
 import matplotlib
 matplotlib.use('Agg')
 # Mock out simpleapi to import expensive import of something we don't use anyway
 sys.modules['mantid.simpleapi'] = mock.MagicMock()
 
-from mantid.api import MultipleExperimentInfos
 from mantidqt.widgets.sliceviewer.model import SliceViewerModel, WS_TYPE  # noqa: E402
 from mantidqt.widgets.sliceviewer.presenter import (  # noqa: E402
     PeaksViewerCollectionPresenter, SliceViewer)
 from mantidqt.widgets.sliceviewer.transform import NonOrthogonalTransform  # noqa: E402
 from mantidqt.widgets.sliceviewer.toolbar import ToolItemText  # noqa: E402
 from mantidqt.widgets.sliceviewer.view import SliceViewerView, SliceViewerDataView  # noqa: E402
-
 
 
 def _create_presenter(model, view, mock_sliceinfo_cls, enable_nonortho_axes, supports_nonortho):

--- a/qt/python/mantidqt/widgets/sliceviewer/test/test_sliceviewer_presenter.py
+++ b/qt/python/mantidqt/widgets/sliceviewer/test/test_sliceviewer_presenter.py
@@ -10,18 +10,21 @@
 import sys
 import unittest
 from unittest import mock
+from unittest.mock import patch
 
 import matplotlib
 matplotlib.use('Agg')
 # Mock out simpleapi to import expensive import of something we don't use anyway
 sys.modules['mantid.simpleapi'] = mock.MagicMock()
 
+from mantid.api import MultipleExperimentInfos
 from mantidqt.widgets.sliceviewer.model import SliceViewerModel, WS_TYPE  # noqa: E402
 from mantidqt.widgets.sliceviewer.presenter import (  # noqa: E402
     PeaksViewerCollectionPresenter, SliceViewer)
 from mantidqt.widgets.sliceviewer.transform import NonOrthogonalTransform  # noqa: E402
 from mantidqt.widgets.sliceviewer.toolbar import ToolItemText  # noqa: E402
 from mantidqt.widgets.sliceviewer.view import SliceViewerView, SliceViewerDataView  # noqa: E402
+
 
 
 def _create_presenter(model, view, mock_sliceinfo_cls, enable_nonortho_axes, supports_nonortho):
@@ -44,6 +47,16 @@ def _create_presenter(model, view, mock_sliceinfo_cls, enable_nonortho_axes, sup
     mock_sliceinfo_instance.can_support_nonorthogonal_axes.return_value = supports_nonortho
 
     return presenter, data_view_mock
+
+
+def create_workspace_mock():
+    # Mock out workspace methods needed for SliceViewerModel.__init__
+    workspace = mock.Mock(spec=MultipleExperimentInfos)
+    workspace.isMDHistoWorkspace = lambda: False
+    workspace.getNumDims = lambda: 2
+    workspace.name = lambda: "workspace"
+
+    return workspace
 
 
 class SliceViewerTest(unittest.TestCase):
@@ -70,6 +83,14 @@ class SliceViewerTest(unittest.TestCase):
         self.model.get_ws = mock.Mock()
         self.model.get_data = mock.Mock()
         self.model.rebin = mock.Mock()
+        self.model.workspace_equals = mock.Mock()
+        self.model.get_properties.return_value = {
+            "workspace_type": "WS_TYPE.MATRIX",
+            "supports_normalise": True,
+            "supports_nonorthogonal_axes": False,
+            "supports_dynamic_rebinning": False,
+            "supports_peaks_overlays": True
+        }
 
     def test_sliceviewer_MDH(self):
         self.model.get_ws_type = mock.Mock(return_value=WS_TYPE.MDH)
@@ -78,7 +99,8 @@ class SliceViewerTest(unittest.TestCase):
 
         # setup calls
         self.assertEqual(self.model.get_dimensions_info.call_count, 0)
-        self.assertEqual(self.model.get_ws.call_count, 1)
+        self.assertEqual(self.model.get_ws.call_count, 2)
+        self.assertEqual(self.model.get_properties.call_count, 1)
         self.assertEqual(self.view.data_view.dimensions.get_slicepoint.call_count, 1)
         self.assertEqual(self.view.data_view.plot_MDH.call_count, 1)
 
@@ -106,6 +128,7 @@ class SliceViewerTest(unittest.TestCase):
         # setup calls
         self.assertEqual(self.model.get_dimensions_info.call_count, 0)
         self.assertEqual(self.model.get_ws_MDE.call_count, 1)
+        self.assertEqual(self.model.get_properties.call_count, 1)
         self.assertEqual(self.view.data_view.dimensions.get_slicepoint.call_count, 1)
         self.assertEqual(self.view.data_view.dimensions.get_bin_params.call_count, 1)
         self.assertEqual(self.view.data_view.plot_MDH.call_count, 1)
@@ -135,7 +158,8 @@ class SliceViewerTest(unittest.TestCase):
 
         # setup calls
         self.assertEqual(self.model.get_dimensions_info.call_count, 0)
-        self.assertEqual(self.model.get_ws.call_count, 1)
+        self.assertEqual(self.model.get_ws.call_count, 2)
+        self.assertEqual(self.model.get_properties.call_count, 1)
         self.assertEqual(self.view.data_view.dimensions.get_slicepoint.call_count, 0)
         self.assertEqual(self.view.data_view.plot_matrix.call_count, 1)
 
@@ -320,6 +344,78 @@ class SliceViewerTest(unittest.TestCase):
         SliceViewer(None, model=self.model, view=self.view)
 
         self.view.data_view.activate_tool.assert_called_once_with(ToolItemText.ZOOM)
+
+    def test_replace_workspace_returns_when_the_workspace_is_not_the_model_workspace(self):
+        self.model.workspace_equals.return_value = False
+        presenter, _ = _create_presenter(self.model, self.view, mock.MagicMock(),
+                                         enable_nonortho_axes=False,
+                                         supports_nonortho=False)
+        presenter.update_view = mock.Mock()
+        presenter._decide_plot_update_methods = mock.Mock()
+        other_workspace = mock.Mock()
+
+        presenter.replace_workspace('other_workspace', other_workspace)
+
+        presenter._decide_plot_update_methods.assert_not_called()
+        presenter.update_view.assert_not_called()
+
+    def test_replace_workspace_closes_view_when_model_properties_change(self):
+
+        self.model.workspace_equals.return_value = True
+        presenter, _ = _create_presenter(self.model, self.view, mock.MagicMock(),
+                                         enable_nonortho_axes=False,
+                                         supports_nonortho=False)
+        presenter._update_view = mock.Mock()
+        presenter._decide_plot_update_methods = mock.Mock()
+
+        workspace = create_workspace_mock()
+
+        # Not equivalent to self.model.get_properties()
+        new_model_properties = {
+            "workspace_type": "WS_TYPE.MDE",
+            "supports_normalise": False,
+            "supports_nonorthogonal_axes": False,
+            "supports_dynamic_rebinning": False,
+            "supports_peaks_overlays": True
+        }
+
+        with patch.object(SliceViewerModel, "get_properties", return_value=new_model_properties):
+            presenter.replace_workspace('workspace', workspace)
+
+            self.view.emit_close.assert_called_once()
+            presenter._decide_plot_update_methods.assert_not_called()
+            presenter._update_view.assert_not_called()
+
+    def test_replace_workspace_updates_view(self):
+        presenter, _ = _create_presenter(self.model, self.view, mock.MagicMock(),
+                                         enable_nonortho_axes=False,
+                                         supports_nonortho=False)
+        presenter._update_view = mock.Mock()
+        presenter._decide_plot_update_methods = mock.Mock(
+            return_value=(presenter.new_plot_matrix(), presenter.update_plot_data_matrix())
+        )
+        workspace = create_workspace_mock()
+        new_model_properties = self.model.get_properties()
+
+        # Patch get_properties so that the properties of the new model match those of self.model
+        with patch.object(SliceViewerModel, "get_properties", return_value=new_model_properties):
+            presenter.replace_workspace('workspace', workspace)
+
+            self.view.emit_close.assert_not_called()
+            presenter._decide_plot_update_methods.assert_called_once()
+            presenter._update_view.assert_called_once()
+
+    def test_update_view(self):
+        presenter, _ = _create_presenter(self.model, self.view, mock.MagicMock(),
+                                         enable_nonortho_axes=False,
+                                         supports_nonortho=False)
+        presenter.new_plot = mock.Mock()
+
+        presenter._update_view()
+
+        self.view.data_view.image_info_widget.setWorkspace.assert_called()
+        self.view.setWindowTitle.assert_called_with(self.model.get_title())
+        presenter.new_plot.assert_called_once()
 
 
 if __name__ == '__main__':

--- a/qt/python/mantidqt/widgets/sliceviewer/test/test_sliceviewer_view.py
+++ b/qt/python/mantidqt/widgets/sliceviewer/test/test_sliceviewer_view.py
@@ -174,7 +174,7 @@ class SliceViewerViewTest(unittest.TestCase, QtWidgetFinder):
         pres = SliceViewer(ws)
         old_title = pres.model.get_title()
 
-        renamed = RenameWorkspace(ws)
+        renamed = RenameWorkspace(ws)  # noqa F841
 
         # View didn't close
         self.assertTrue(pres.view in self.find_widgets_of_type(str(type(pres.view))))
@@ -191,7 +191,7 @@ class SliceViewerViewTest(unittest.TestCase, QtWidgetFinder):
         pres = SliceViewer(ws)
         title = pres.model.get_title()
         other_workspace = CreateSampleWorkspace()
-        other_renamed = RenameWorkspace(other_workspace)
+        other_renamed = RenameWorkspace(other_workspace)  # noqa F841
 
         self.assertEqual(pres.model.get_title(), title)
         self.assertEqual(pres.view.windowTitle(), pres.model.get_title())

--- a/qt/python/mantidqt/widgets/sliceviewer/test/test_sliceviewer_view.py
+++ b/qt/python/mantidqt/widgets/sliceviewer/test/test_sliceviewer_view.py
@@ -13,7 +13,9 @@ from mantidqt.widgets.colorbar.colorbar import MIN_LOG_VALUE
 
 mpl.use('Agg')
 from mantid.simpleapi import (  # noqa: E402
-    CreateMDHistoWorkspace, CreateMDWorkspace, CreateSampleWorkspace, SetUB)
+    CreateMDHistoWorkspace, CreateMDWorkspace, CreateSampleWorkspace,
+    SetUB, DeleteWorkspace, ConvertToDistribution, Scale, RenameWorkspace)
+from mantid.api import AnalysisDataService  # noqa: E402
 from mantidqt.utils.qt.testing import start_qapplication  # noqa: E402
 from mantidqt.utils.qt.testing.qt_widget_finder import QtWidgetFinder  # noqa: E402
 from mantidqt.widgets.sliceviewer.presenter import SliceViewer  # noqa: E402
@@ -53,6 +55,7 @@ class SliceViewerViewTest(unittest.TestCase, QtWidgetFinder):
         QApplication.sendPostedEvents()
 
         self.assert_no_toplevel_widgets()
+        self.assertEqual(pres.ads_observer, None)
 
     def test_enable_nonorthogonal_view_disables_lineplots_if_enabled(self):
         pres = SliceViewer(self.hkl_ws)
@@ -118,6 +121,90 @@ class SliceViewerViewTest(unittest.TestCase, QtWidgetFinder):
 
         pres.view.close()
 
+    def test_view_closes_on_shown_workspace_deleted(self):
+        ws = CreateSampleWorkspace()
+        pres = SliceViewer(ws)
+        DeleteWorkspace(ws)
+
+        QApplication.sendPostedEvents()
+
+        self.assert_no_toplevel_widgets()
+        self.assertEqual(pres.ads_observer, None)
+
+    def test_view_does_not_close_on_other_workspace_deleted(self):
+        ws = CreateSampleWorkspace()
+        pres = SliceViewer(ws)
+        other_ws = CreateSampleWorkspace()
+        DeleteWorkspace(other_ws)
+
+        QApplication.sendPostedEvents()
+
+        # Strange behaviour between tests where views don't close properly means
+        # we cannot use self.assert_widget_exists, as many instances of SliceViewerView
+        # may be active at this time. As long as this view hasn't closed we are OK.
+        self.assertTrue(pres.view in self.find_widgets_of_type(str(type(pres.view))))
+        self.assertNotEqual(pres.ads_observer, None)
+
+        pres.view.close()
+
+    def test_view_closes_on_replace_when_model_properties_change(self):
+        ws = CreateSampleWorkspace()
+        pres = SliceViewer(ws)
+        ConvertToDistribution(ws)
+
+        QApplication.sendPostedEvents()
+
+        self.assert_no_toplevel_widgets()
+        self.assertEqual(pres.ads_observer, None)
+
+    def test_view_updates_on_replace_when_model_properties_dont_change(self):
+        ws = CreateSampleWorkspace()
+        pres = SliceViewer(ws)
+        ws = Scale(ws, 100, "Multiply")
+
+        QApplication.sendPostedEvents()
+
+        self.assertTrue(pres.view in self.find_widgets_of_type(str(type(pres.view))))
+        self.assertNotEqual(pres.ads_observer, None)
+
+        pres.view.close()
+
+    def test_view_title_correct_and_view_didnt_close_on_workspace_rename(self):
+        ws = CreateSampleWorkspace()
+        pres = SliceViewer(ws)
+        old_title = pres.model.get_title()
+
+        renamed = RenameWorkspace(ws)
+
+        # View didn't close
+        self.assertTrue(pres.view in self.find_widgets_of_type(str(type(pres.view))))
+        self.assertNotEqual(pres.ads_observer, None)
+
+        # Window title correct
+        self.assertNotEqual(pres.model.get_title(), old_title)
+        self.assertEqual(pres.view.windowTitle(), pres.model.get_title())
+
+        pres.view.close()
+
+    def test_view_title_did_not_change_other_workspace_rename(self):
+        ws = CreateSampleWorkspace()
+        pres = SliceViewer(ws)
+        title = pres.model.get_title()
+        other_workspace = CreateSampleWorkspace()
+        other_renamed = RenameWorkspace(other_workspace)
+
+        self.assertEqual(pres.model.get_title(), title)
+        self.assertEqual(pres.view.windowTitle(), pres.model.get_title())
+
+    def test_view_closes_on_ADS_cleared(self):
+        ws = CreateSampleWorkspace()
+        pres = SliceViewer(ws)
+        AnalysisDataService.clear()
+
+        QApplication.sendPostedEvents()
+
+        self.assert_no_toplevel_widgets()
+        self.assertEqual(pres.ads_observer, None)
 
 # private helper functions
 

--- a/qt/python/mantidqt/widgets/sliceviewer/view.py
+++ b/qt/python/mantidqt/widgets/sliceviewer/view.py
@@ -550,7 +550,6 @@ class SliceViewerView(QWidget, ObservingView):
 
         # connect up additional peaks signals
         self.data_view.mpl_toolbar.peaksOverlayClicked.connect(self.peaks_overlay_clicked)
-
         self.close_signal.connect(self._run_close)
 
     @property
@@ -594,11 +593,6 @@ class SliceViewerView(QWidget, ObservingView):
         """
         self.peaks_view.set_visible(on)
 
-    # event handlers
-    def closeEvent(self, event):
-        self.deleteLater()
-        super().closeEvent(event)
-
-    @Slot()
     def _run_close(self):
+        # handles the signal emitted from ObservingView.emit_close
         self.close()

--- a/qt/python/mantidqt/widgets/sliceviewer/view.py
+++ b/qt/python/mantidqt/widgets/sliceviewer/view.py
@@ -16,7 +16,7 @@ from mantid.plots.datafunctions import get_normalize_by_bin_width
 from matplotlib.figure import Figure
 from mpl_toolkits.axisartist import Subplot as CurveLinearSubPlot
 from mpl_toolkits.axisartist.grid_helper_curvelinear import GridHelperCurveLinear
-from qtpy.QtCore import Qt, Signal, Slot
+from qtpy.QtCore import Qt, Signal
 from qtpy.QtWidgets import (QCheckBox, QComboBox, QGridLayout, QLabel, QHBoxLayout, QSplitter,
                             QStatusBar, QVBoxLayout, QWidget)
 

--- a/qt/python/mantidqt/widgets/sliceviewer/view.py
+++ b/qt/python/mantidqt/widgets/sliceviewer/view.py
@@ -16,7 +16,7 @@ from mantid.plots.datafunctions import get_normalize_by_bin_width
 from matplotlib.figure import Figure
 from mpl_toolkits.axisartist import Subplot as CurveLinearSubPlot
 from mpl_toolkits.axisartist.grid_helper_curvelinear import GridHelperCurveLinear
-from qtpy.QtCore import Qt
+from qtpy.QtCore import Qt, Signal, Slot
 from qtpy.QtWidgets import (QCheckBox, QComboBox, QGridLayout, QLabel, QHBoxLayout, QSplitter,
                             QStatusBar, QVBoxLayout, QWidget)
 
@@ -35,6 +35,8 @@ from .peaksviewer.representation.painter import MplPainter
 from .zoom import ScrollZoomMixin
 
 # Constants
+from ..observers.observing_view import ObservingView
+
 DBLMAX = sys.float_info.max
 
 SCALENORM = "SliceViewer/scale_norm"
@@ -523,8 +525,10 @@ class SliceViewerDataView(QWidget):
             self.conf.set(POWERSCALE, exponent)
 
 
-class SliceViewerView(QWidget):
+class SliceViewerView(QWidget, ObservingView):
     """Combines the data view for the slice viewer with the optional peaks viewer."""
+    close_signal = Signal()
+
     def __init__(self, presenter, dims_info, can_normalise, parent=None, conf=None):
         super().__init__(parent)
 
@@ -546,6 +550,8 @@ class SliceViewerView(QWidget):
 
         # connect up additional peaks signals
         self.data_view.mpl_toolbar.peaksOverlayClicked.connect(self.peaks_overlay_clicked)
+
+        self.close_signal.connect(self._run_close)
 
     @property
     def data_view(self):
@@ -592,3 +598,7 @@ class SliceViewerView(QWidget):
     def closeEvent(self, event):
         self.deleteLater()
         super().closeEvent(event)
+
+    @Slot()
+    def _run_close(self):
+        self.close()

--- a/qt/python/mantidqt/widgets/sliceviewer/view.py
+++ b/qt/python/mantidqt/widgets/sliceviewer/view.py
@@ -528,6 +528,7 @@ class SliceViewerDataView(QWidget):
 class SliceViewerView(QWidget, ObservingView):
     """Combines the data view for the slice viewer with the optional peaks viewer."""
     close_signal = Signal()
+    rename_signal = Signal(str)
 
     def __init__(self, presenter, dims_info, can_normalise, parent=None, conf=None):
         super().__init__(parent)
@@ -551,6 +552,7 @@ class SliceViewerView(QWidget, ObservingView):
         # connect up additional peaks signals
         self.data_view.mpl_toolbar.peaksOverlayClicked.connect(self.peaks_overlay_clicked)
         self.close_signal.connect(self._run_close)
+        self.rename_signal.connect(self._on_rename)
 
     @property
     def data_view(self):
@@ -596,3 +598,6 @@ class SliceViewerView(QWidget, ObservingView):
     def _run_close(self):
         # handles the signal emitted from ObservingView.emit_close
         self.close()
+
+    def _on_rename(self, new_title):
+        self.setWindowTitle(new_title)


### PR DESCRIPTION
Introduces an ADS observer to the Slice Viewer so that when the workspace is modified outside the Viewer, it updates the plot with the new data.

**To test:**
1. Open a workspace in SliceViewer
2. Run an algorithm on the workspace, such as `scale`
3. Verify that the plot updates, along with the window title

Also verify conditions that should cause SliceViewer to close, either because you wouldn't be able to open a SliceViewer on that workspace in the first place, or because updating the view is too complex, such as: 
- Converting the workspace to a TableWorkspace
- Converting the workspace to any other type
- Converting a matrix workspace to a distribution
- Reducing the number of dimensions of a workspace to 1 or 0.

Fixes #29258 <!-- and fix #xxxx or close #xxxx xor resolves #xxxx -->

<!-- Ensure the base of this PR is correct (e.g. release-next or master)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
