### PR TITLE
Fix a crash loading event files without pulse_time_zero

### DIFF
--- a/Framework/DataHandling/src/LoadEventNexus.cpp
+++ b/Framework/DataHandling/src/LoadEventNexus.cpp
@@ -460,6 +460,10 @@ firstLastPulseTimes(::NeXus::File &file, Kernel::Logger &logger) {
       NeXus::NeXusIOHelper::readNexusVector<double>(file, "event_time_zero");
   // Remember to close the entry
   file.closeData();
+  // Check we have valid data
+  if (pulse_times.empty())
+    throw std::runtime_error(
+        "No event time zeros. Cannot establish run start or end");
   // Convert to seconds
   auto conv = Kernel::Units::timeConversionValue(units, "s");
   return std::make_pair(

--- a/docs/source/release/v6.0.0/framework.rst
+++ b/docs/source/release/v6.0.0/framework.rst
@@ -25,6 +25,8 @@ Algorithms
 Data Objects
 ------------
 
+- Fixed a bug in :ref:`algm-LoadEventNexus` where Mantid would crash if the file does not contain the ``event_time_zero`` attribute.
+
 Python
 ------
 


### PR DESCRIPTION
This is a regression caused by PR #29105. The implementation was changed and no longer checks that values exist before attempting to use them. This PR simply adds a check and throws an error if they don't exist.

This is actually an improvement over the behaviour in v4.0 - the load used to throw an error from somewhere else in the code and gave a confusing error about getData failing.

**To test:**

Run `ws=Load('OFFSPEC61971')`. Mantid should throw an error rather than crashing.

*There is no associated issue.*

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
