### PR TITLE
Add extra input validation to IndexPeaks

### DIFF
--- a/Framework/Crystal/inc/MantidCrystal/IndexPeaks.h
+++ b/Framework/Crystal/inc/MantidCrystal/IndexPeaks.h
@@ -19,7 +19,9 @@ class MANTID_CRYSTAL_DLL IndexPeaks : public API::Algorithm {
 public:
   const std::string name() const override { return "IndexPeaks"; }
   const std::string summary() const override {
-    return "Index the peaks using the UB from the sample.";
+    return "Index the peaks using the UB from the sample. Leave MaxOrder at "
+           "default value 0 to get this value, and ModVectors (unless "
+           "overridden) from the sample.";
   }
   int version() const override { return 1; }
   const std::vector<std::string> seeAlso() const override {

--- a/Framework/Crystal/src/IndexPeaks.cpp
+++ b/Framework/Crystal/src/IndexPeaks.cpp
@@ -442,17 +442,18 @@ std::map<std::string, std::string> IndexPeaks::validateInputs() {
   const bool isSave = this->getProperty(Prop::SAVEMODINFO);
   const bool isMOZero = (args.satellites.maxOrder == 0);
   bool isAllVecZero = true;
-  for (int vecNo = 0; vecNo < args.satellites.modVectors.size(); vecNo++) {
+  for (size_t vecNo = 0; vecNo < args.satellites.modVectors.size(); vecNo++) {
     if (args.satellites.modVectors[vecNo] != V3D(0.0, 0.0, 0.0)) {
       isAllVecZero = false;
     }
   }
   if (!isMOZero && isAllVecZero) {
-    helpMsgs["ModVector1"] = "At least one Modulation Vector must be supplied if Max Order set.";
+    helpMsgs["ModVector1"] =
+        "At least one Modulation Vector must be supplied if Max Order set.";
   }
   if (isSave && isAllVecZero) {
-    helpMsgs[Prop::SAVEMODINFO] =
-        "Modulation info cannot be saved with no valid Modulation Vectors supplied.";
+    helpMsgs[Prop::SAVEMODINFO] = "Modulation info cannot be saved with no "
+                                  "valid Modulation Vectors supplied.";
   }
   if (isSave && isMOZero) {
     helpMsgs["MaxOrder"] =

--- a/Framework/Crystal/src/IndexPeaks.cpp
+++ b/Framework/Crystal/src/IndexPeaks.cpp
@@ -417,7 +417,7 @@ std::map<std::string, std::string> IndexPeaks::validateInputs() {
   try {
     ws->sample().getOrientedLattice();
   } catch (std::runtime_error &exc) {
-    helpMsgs[Prop::PEAKSWORKSPACE] = exc.what();
+    helpMsgs[Prop::PEAKSWORKSPACE] = "No UB Matrix defined in the lattice.";
     return helpMsgs;
   }
 
@@ -446,6 +446,10 @@ std::map<std::string, std::string> IndexPeaks::validateInputs() {
     if (args.satellites.modVectors[vecNo] != V3D(0.0, 0.0, 0.0)) {
       isAllVecZero = false;
     }
+  }
+  if (isMOZero && !isAllVecZero) {
+    helpMsgs["MaxOrder"] =
+        "Max Order cannot be zero if a Modulation Vector has been supplied.";
   }
   if (!isMOZero && isAllVecZero) {
     helpMsgs["ModVector1"] =

--- a/Framework/Crystal/src/IndexPeaks.cpp
+++ b/Framework/Crystal/src/IndexPeaks.cpp
@@ -416,7 +416,7 @@ std::map<std::string, std::string> IndexPeaks::validateInputs() {
   PeaksWorkspace_sptr ws = this->getProperty(Prop::PEAKSWORKSPACE);
   try {
     ws->sample().getOrientedLattice();
-  } catch (std::runtime_error &exc) {
+  } catch (std::runtime_error &) {
     helpMsgs[Prop::PEAKSWORKSPACE] = "No UB Matrix defined in the lattice.";
     return helpMsgs;
   }

--- a/Framework/Crystal/test/IndexPeaksTest.h
+++ b/Framework/Crystal/test/IndexPeaksTest.h
@@ -487,20 +487,63 @@ public:
 
   // --------------------------- Failure tests -----------------------------
 
-  void test_workspace_with_no_oriented_lattice_gives_validateInputs_error() {
-    const auto peaksWS = WorkspaceCreationHelper::createPeaksWorkspace(1);
-    IndexPeaks alg;
-    alg.initialize();
-    alg.setProperty("PeaksWorkspace", peaksWS);
+  std::shared_ptr<IndexPeaks> setup_validate_inputs_test_alg() {
+    const auto peaksWS = createTestPeaksWorkspaceWithSatellites();
+    auto alg = std::make_shared<IndexPeaks>();
+    alg->initialize();
+    alg->setProperty("PeaksWorkspace", peaksWS);
+    return alg;
+  }
 
-    auto helpMsgs = alg.validateInputs();
+  bool
+  assert_helpmsgs_error_from_validate_inputs(std::shared_ptr<IndexPeaks> alg,
+                                             std::string prop,
+                                             std::string err_substring) {
+    auto helpMsgs = alg->validateInputs();
 
-    const auto valueIter = helpMsgs.find("PeaksWorkspace");
+    const auto valueIter = helpMsgs.find(prop);
     TS_ASSERT(valueIter != helpMsgs.cend())
     if (valueIter != helpMsgs.cend()) {
       const auto msg = valueIter->second;
-      TS_ASSERT(msg.find("OrientedLattice") != std::string::npos)
+      TS_ASSERT(msg.find(err_substring) != std::string::npos)
     }
+  }
+
+  void
+  test_inputs_with_save_mod_and_zero_max_order_gives_validateInputs_error() {
+    auto alg = setup_validate_inputs_test_alg();
+    alg->setProperty("SaveModulationInfo", true);
+
+    assert_helpmsgs_error_from_validate_inputs(alg, "MaxOrder",
+                                               "Modulation info");
+  }
+
+  void
+  test_inputs_with_save_mod_and_empty_mod_vectors_gives_validateInputs_error() {
+    auto alg = setup_validate_inputs_test_alg();
+    alg->setProperty("SaveModulationInfo", true);
+
+    assert_helpmsgs_error_from_validate_inputs(alg, "SaveModulationInfo",
+                                               "no valid Modulation");
+  }
+
+  void
+  test_inputs_with_max_order_set_and_empty_mod_vectors_gives_validateInputs_error() {
+    auto alg = setup_validate_inputs_test_alg();
+    alg->setProperty("MaxOrder", 3); // arbitary non-zero
+
+    assert_helpmsgs_error_from_validate_inputs(alg, "ModVector1",
+                                               "At least one Modulation");
+  }
+
+  void test_workspace_with_no_oriented_lattice_gives_validateInputs_error() {
+    const auto peaksWS = WorkspaceCreationHelper::createPeaksWorkspace(1);
+    auto alg = std::make_shared<IndexPeaks>();
+    alg->initialize();
+    alg->setProperty("PeaksWorkspace", peaksWS);
+
+    assert_helpmsgs_error_from_validate_inputs(alg, "PeaksWorkspace",
+                                               "OrientedLattice");
   }
 
   void test_negative_max_order_throws_error() {

--- a/Framework/Crystal/test/IndexPeaksTest.h
+++ b/Framework/Crystal/test/IndexPeaksTest.h
@@ -530,10 +530,21 @@ public:
   void
   test_inputs_with_max_order_set_and_empty_mod_vectors_gives_validateInputs_error() {
     auto alg = setup_validate_inputs_test_alg();
-    alg->setProperty("MaxOrder", 3); // arbitary non-zero
+    alg->setProperty("MaxOrder", 3); // arbitary non-zero max order
 
     assert_helpmsgs_error_from_validate_inputs(alg, "ModVector1",
                                                "At least one Modulation");
+  }
+
+  void
+  test_inputs_with_zero_max_order_and_valid_mod_vector_gives_validateInputs_error() {
+    auto alg = setup_validate_inputs_test_alg();
+    alg->setProperty(
+        "ModVector1",
+        std::vector<double>{1.0, 2.0, 3.0}); // arbitary non-zero mod vector
+
+    assert_helpmsgs_error_from_validate_inputs(alg, "MaxOrder",
+                                               "cannot be zero");
   }
 
   void test_workspace_with_no_oriented_lattice_gives_validateInputs_error() {
@@ -543,7 +554,7 @@ public:
     alg->setProperty("PeaksWorkspace", peaksWS);
 
     assert_helpmsgs_error_from_validate_inputs(alg, "PeaksWorkspace",
-                                               "OrientedLattice");
+                                               "No UB Matrix");
   }
 
   void test_negative_max_order_throws_error() {

--- a/Framework/Crystal/test/IndexPeaksTest.h
+++ b/Framework/Crystal/test/IndexPeaksTest.h
@@ -495,7 +495,7 @@ public:
     return alg;
   }
 
-  bool
+  void
   assert_helpmsgs_error_from_validate_inputs(std::shared_ptr<IndexPeaks> alg,
                                              std::string prop,
                                              std::string err_substring) {


### PR DESCRIPTION
**Description of work.**
This extra input validation should stop the user from giving inputs that could potentially lead to out of range errors, see PR #29597 .

**To test:**
1. Load a peaks workspace e.g.
[WISH00045319_peaks.zip](https://github.com/mantidproject/mantid/files/5573442/WISH00045319_peaks.zip)
2. Ensure input validation will not allow max order = 0 and Save Modulation Info = True
3. Ensure will not allow Save Info without at least one non-zero modulation vector
4. Ensure will not allow run if max order > 0 but not modulation vectors set (should be 1+)

Fixes #29609 . <!-- and fix #xxxx or close #xxxx xor resolves #xxxx -->
<!-- alternative
*There is no associated issue.*
-->

*This does not require release notes* because **it adds extra validation to a previously addressed fix**


<!-- Ensure the base of this PR is correct (e.g. release-next or master)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
