### PR TITLE
Skip PVPython system test when ParaView not available

### DIFF
--- a/Testing/SystemTests/tests/framework/PVPythonTest.py
+++ b/Testing/SystemTests/tests/framework/PVPythonTest.py
@@ -10,9 +10,17 @@ import systemtesting
 
 
 class PVPythonTest(systemtesting.MantidSystemTest):
-
     def skipTests(self):
-        return sys.platform == 'win32'
+        if sys.platform == 'win32':
+            return True
+        else:
+            skip = False
+            try:
+                import paraview.simple  # noqa: F401
+            except ModuleNotFoundError:
+                skip = True
+
+            return skip
 
     def runTest(self):
         # Make Vates/ParaView a soft requirement rather than failing on module import


### PR DESCRIPTION
**Description of work.**

In order to disable Vates we need to check if it is available before trying to run the PVPython systemtest.

This work adds this check.

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

**To test:**

* Run a build with `MAKE_VATES=OFF`
* Run the PVPython system test and it should be skipped.

Refs #29362 

<!-- Ensure the base of this PR is correct (e.g. release-next or master)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
