### PR TITLE
Fix handling image replotting when the underlying workspace updates

### DIFF
--- a/Framework/PythonInterface/test/python/mantid/plots/CMakeLists.txt
+++ b/Framework/PythonInterface/test/python/mantid/plots/CMakeLists.txt
@@ -4,7 +4,7 @@ add_subdirectory(modest_image)
 
 set(TEST_PY_FILES
     datafunctionsTest.py axesfunctionsTest.py axesfunctions3DTest.py
-    plotfunctionsTest.py plots__init__Test.py ScalesTest.py UtilityTest.py
+    plotfunctionsTest.py mantidaxesTest.py ScalesTest.py UtilityTest.py
     compatabilityTest.py surfacecontourplotsTest.py legendTest.py
 )
 

--- a/docs/source/release/v6.0.0/mantidworkbench.rst
+++ b/docs/source/release/v6.0.0/mantidworkbench.rst
@@ -49,5 +49,6 @@ Bugfixes
 - Fixed a bug which would cause unrealistic errorbars on the fit calc curve.
 - Fix sort order of peaks in the peaks overlay on SliceViewer.
 - The colorfill plot on ragged workspaces will have the correct horizontal extent.
+- Fix replot of colorfill image after a workspace is replaced.
 
 :ref:`Release 6.0.0 <v6.0.0>`


### PR DESCRIPTION
**Description of work.**

Fixes a bug where an exception would be shown the log when a workspace backing a colorfill plot was replaced.

Further tests have been added to flex this area of plotting.

**To test:**

* Load any workspace, e.g. `<builddir>/ExternalData/Testing/Data/SystemTest/irs26173_diffspec_red.nxs`
* Run any algorithm to replace the workspace, e.g. Scale with a factor of 1000
* The image should update and not write an error to the log.

Fixes #27228 


<!-- Ensure the base of this PR is correct (e.g. release-next or master)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
