### PR TITLE
Set min length and adjust policy for algorthm combo box

### DIFF
--- a/qt/widgets/common/src/AlgorithmPropertiesWidget.cpp
+++ b/qt/widgets/common/src/AlgorithmPropertiesWidget.cpp
@@ -69,6 +69,11 @@ AlgorithmPropertiesWidget::AlgorithmPropertiesWidget(QWidget *parent)
   setLayout(dialog_layout);
 
   this->initLayout();
+
+  // Wide widgets inside the QScrollArea do not cause the dialog to grow
+  // and so can be cut off. Force a minimum width
+  setObjectName("AlgorithmPropertiesWidget");
+  setStyleSheet("#AlgorithmPropertiesWidget {min-width: 25em;}");
 }
 
 //----------------------------------------------------------------------------------------------

--- a/qt/widgets/common/src/OptionsPropertyWidget.cpp
+++ b/qt/widgets/common/src/OptionsPropertyWidget.cpp
@@ -48,6 +48,9 @@ OptionsPropertyWidget::OptionsPropertyWidget(Mantid::Kernel::Property *prop,
     connect(m_combo->lineEdit(), SIGNAL(editingFinished()),
             SLOT(editingFinished()));
   }
+  m_combo->setSizeAdjustPolicy(
+      QComboBox::AdjustToMinimumContentsLengthWithIcon);
+  m_combo->setMinimumContentsLength(20);
   m_widgets.push_back(m_combo);
 
   std::vector<std::string> items = prop->allowedValues();


### PR DESCRIPTION
OptionsPropertyWidget, use setSizeAdjustPolicy() and setMinimumContentsLength()

Fixes 28827

**Description of work.**

OptionsPropertyWidget, use setSizeAdjustPolicy() and setMinimumContentsLength()

**To test:**

See  

Fixes #28827

*This does not require release notes* because **small change?**

Before and after:
![Screenshot at 2020-11-23 12-21-31](https://user-images.githubusercontent.com/74248560/99961506-795df380-2d86-11eb-8a58-b02899fc2977.png)

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
