### PR TITLE
Fix Muon Editing Constraints Causing A Crash

### DIFF
--- a/docs/source/release/v6.0.0/muon.rst
+++ b/docs/source/release/v6.0.0/muon.rst
@@ -22,6 +22,7 @@ Improvements
 Bug fixes
 #########
 - Fixed a bug where ties and constraints were not being respected.
+- Fixed a bug where editing constraints would result in a crash
 
 ALC
 ---

--- a/qt/widgets/common/src/FunctionTreeView.cpp
+++ b/qt/widgets/common/src/FunctionTreeView.cpp
@@ -1990,7 +1990,7 @@ void FunctionTreeView::constraintChanged(QtProperty *prop) {
         emit parameterConstraintAdded(functionIndex, constraint);
       }
     }
-    // Increment constarint map only if we know it is safe to do so
+    // Increment iterator only if we know it is safe to do so
     if (i + 1 != m_constraints.size())
       ++it;
   }

--- a/qt/widgets/common/src/FunctionTreeView.cpp
+++ b/qt/widgets/common/src/FunctionTreeView.cpp
@@ -1978,7 +1978,7 @@ void FunctionTreeView::tieChanged(QtProperty *prop) {
 /// Called when a constraint property changes
 void FunctionTreeView::constraintChanged(QtProperty *prop) {
   // Needed more control over loop here to prevent exceptions being thrown
-  QMultiMap<QtProperty *, AConstraint>::iterator it = m_constraints.begin();
+  auto it = m_constraints.begin();
   for (int i = 0; i < m_constraints.size(); ++i) {
     const bool isLower = it.value().lower == prop;
     const bool isUpper = it.value().upper == prop;

--- a/qt/widgets/common/src/FunctionTreeView.cpp
+++ b/qt/widgets/common/src/FunctionTreeView.cpp
@@ -1977,9 +1977,12 @@ void FunctionTreeView::tieChanged(QtProperty *prop) {
 
 /// Called when a constraint property changes
 void FunctionTreeView::constraintChanged(QtProperty *prop) {
-  for (const auto &constraint : m_constraints) {
-    const bool isLower = constraint.lower == prop;
-    const bool isUpper = constraint.upper == prop;
+  // Needed more control over loop here to prevent exceptions being thrown
+  QMultiMap<QtProperty *, AConstraint>::iterator it =
+      m_constraints.begin();
+  for (int i = 0; i < m_constraints.size(); ++i) {
+    const bool isLower = it.value().lower == prop;
+    const bool isUpper = it.value().upper == prop;
     if (isLower || isUpper) {
       auto paramProp = getParentParameterProperty(prop);
       QString functionIndex, constraint;
@@ -1988,6 +1991,9 @@ void FunctionTreeView::constraintChanged(QtProperty *prop) {
         emit parameterConstraintAdded(functionIndex, constraint);
       }
     }
+    // Increment constarint map only if we know it is safe to do so
+    if (i + 1 != m_constraints.size())
+      ++it;
   }
 }
 

--- a/qt/widgets/common/src/FunctionTreeView.cpp
+++ b/qt/widgets/common/src/FunctionTreeView.cpp
@@ -1977,22 +1977,18 @@ void FunctionTreeView::tieChanged(QtProperty *prop) {
 
 /// Called when a constraint property changes
 void FunctionTreeView::constraintChanged(QtProperty *prop) {
-  // Needed more control over loop here to prevent exceptions being thrown
-  auto it = m_constraints.begin();
-  for (int i = 0; i < m_constraints.size(); ++i) {
-    const bool isLower = it.value().lower == prop;
-    const bool isUpper = it.value().upper == prop;
+  for (const auto &constraint : m_constraints) {
+    const bool isLower = constraint.lower == prop;
+    const bool isUpper = constraint.upper == prop;
     if (isLower || isUpper) {
       auto paramProp = getParentParameterProperty(prop);
       QString functionIndex, constraint;
       std::tie(functionIndex, constraint) = getFunctionAndConstraint(paramProp);
       if (!constraint.isEmpty()) {
         emit parameterConstraintAdded(functionIndex, constraint);
+        return; // No need to keep looping as found constraint changed
       }
     }
-    // Increment iterator only if we know it is safe to do so
-    if (i + 1 != m_constraints.size())
-      ++it;
   }
 }
 

--- a/qt/widgets/common/src/FunctionTreeView.cpp
+++ b/qt/widgets/common/src/FunctionTreeView.cpp
@@ -1978,8 +1978,7 @@ void FunctionTreeView::tieChanged(QtProperty *prop) {
 /// Called when a constraint property changes
 void FunctionTreeView::constraintChanged(QtProperty *prop) {
   // Needed more control over loop here to prevent exceptions being thrown
-  QMultiMap<QtProperty *, AConstraint>::iterator it =
-      m_constraints.begin();
+  QMultiMap<QtProperty *, AConstraint>::iterator it = m_constraints.begin();
   for (int i = 0; i < m_constraints.size(); ++i) {
     const bool isLower = it.value().lower == prop;
     const bool isUpper = it.value().upper == prop;


### PR DESCRIPTION
**Description of work.**
A read access violation exception was being thrown in a for range loop when attempting to editing constraints on a parameter when fitting. I have altered the loop a bit to have a little more control over what is accessed

**Report to:** Peter Baker / ISIS

**To test:**
Follow original instructions #29994, should no longer crash

Fixes #29994 

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
