### PR TITLE
Fixes x-axis extent in colorfill plots on ragged workspaces

### DIFF
--- a/Framework/PythonInterface/mantid/plots/resampling_image/samplingimage.py
+++ b/Framework/PythonInterface/mantid/plots/resampling_image/samplingimage.py
@@ -9,6 +9,7 @@ import matplotlib.colors
 import numpy as np
 
 from mantid.plots.datafunctions import get_matrix_2d_ragged, get_normalize_by_bin_width
+from mantid.api import MatrixWorkspace
 
 MAX_HISTOGRAMS = 5000
 
@@ -190,6 +191,21 @@ def imshow_sampling(axes,
                           workspace.getDimension(0).getMaximum(),
                           workspace.getDimension(1).getMinimum(),
                           workspace.getDimension(1).getMaximum())
+        if isinstance(workspace, MatrixWorkspace) and not workspace.isCommonBins():
+            # for MatrixWorkspace the x extent obtained from dimension 0 corresponds to the first spectrum
+            # this is not correct in case of ragged workspaces, where we need to obtain the global xmin and xmax
+            # moreover the axis might be in ascending or descending order, so x[0] is not necessarily the minimum
+            for i in range(workspace.getNumberHistograms()):
+                x_axis = workspace.readX(i)
+                x_i_first = x_axis[0]
+                x_i_last = x_axis[-1]
+                x_i_min = min(x_i_first, x_i_last)
+                x_i_max = max(x_i_first, x_i_last)
+                if x_i_min < x0:
+                    x0 = x_i_min
+                if x_i_max > x1:
+                    x1 = x_i_max 
+
         if workspace.getDimension(1).getNBins() == workspace.getAxis(1).length():
             width = workspace.getDimension(1).getBinWidth()
             y0 -= width / 2

--- a/docs/source/release/v6.0.0/mantidworkbench.rst
+++ b/docs/source/release/v6.0.0/mantidworkbench.rst
@@ -42,5 +42,6 @@ Bugfixes
 - Show spectrum numbers instead of workspace index in plotBin
 - Fixed a bug which would cause unrealistic errorbars on the fit calc curve.
 - Fix sort order of peaks in the peaks overlay on SliceViewer.
+- The colorfill plot on ragged workspaces will have the correct horizontal extent.
 
 :ref:`Release 6.0.0 <v6.0.0>`


### PR DESCRIPTION
**Description of work.**
See the title.

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

**To test:**
Load the `ILL/D7/402652_403041.nxs` from unit test data and plot colorfill.
You should see the full data unlike on master, where the x-axis extent is defined by the first spectrum.

<!-- Instructions for testing. -->

Fixes #29907 . <!-- and fix #xxxx or close #xxxx xor resolves #xxxx -->
<!-- alternative
*There is no associated issue.*
-->

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or master)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
