### PR TITLE
Bug during copy/cut/paste in DrILL

### DIFF
--- a/scripts/Interface/ui/drill/test/DrillTableWidgetTest.py
+++ b/scripts/Interface/ui/drill/test/DrillTableWidgetTest.py
@@ -121,9 +121,20 @@ class DrillTableWidgetTest(unittest.TestCase):
         self.selectCell(1, 1, Qt.ControlModifier)
         self.selectCell(2, 2, Qt.ControlModifier)
         self.assertEqual(self.table.getSelectedCells(), [(0, 0),
-                                                         (4, 0),
                                                          (1, 1),
-                                                         (2, 2)])
+                                                         (2, 2),
+                                                         (4, 0)])
+
+    def test_getSelectionShape(self):
+        self.table.getSelectedCells = mock.Mock()
+        self.table.setRowCount(3)
+        self.table.setColumnCount(1)
+        self.table.getSelectedCells.return_value = [(0, 0)]
+        self.assertEqual(self.table.getSelectionShape(), (1, 1))
+        self.table.getSelectedCells.return_value = [(0, 0), (1, 0), (2, 0)]
+        self.assertEqual(self.table.getSelectionShape(), (3, 1))
+        self.table.getSelectedCells.return_value = [(0, 0), (10, 10)]
+        self.assertEqual(self.table.getSelectionShape(), (0, 0))
 
     def test_getRowsFromSelectedCells(self):
         self.assertEqual(self.table.getSelectedCells(), [])

--- a/scripts/Interface/ui/drill/test/DrillTableWidgetTest.py
+++ b/scripts/Interface/ui/drill/test/DrillTableWidgetTest.py
@@ -121,9 +121,9 @@ class DrillTableWidgetTest(unittest.TestCase):
         self.selectCell(1, 1, Qt.ControlModifier)
         self.selectCell(2, 2, Qt.ControlModifier)
         self.assertEqual(self.table.getSelectedCells(), [(0, 0),
+                                                         (4, 0),
                                                          (1, 1),
-                                                         (2, 2),
-                                                         (4, 0)])
+                                                         (2, 2)])
 
     def test_getSelectionShape(self):
         self.table.getSelectedCells = mock.Mock()

--- a/scripts/Interface/ui/drill/test/DrillViewTest.py
+++ b/scripts/Interface/ui/drill/test/DrillViewTest.py
@@ -55,32 +55,6 @@ class DrillViewTest(unittest.TestCase):
         c2.close.assert_called_once()
         c3.close.assert_not_called()
 
-    def test_getSelectionShape(self):
-        # no selection
-        selection = []
-        shape = self.view._getSelectionShape(selection)
-        self.assertEqual(shape, (0, 0))
-
-        # valid selection
-        selection = [(0, 0), (0, 1), (0, 2),
-                     (1, 0), (1, 1), (1, 2)]
-        shape = self.view._getSelectionShape(selection)
-        self.assertEqual(shape, (2, 3))
-        selection = [(0, 0), (0, 1),
-                     (1, 0), (1, 1),
-                     (2, 0), (2, 1)]
-        shape = self.view._getSelectionShape(selection)
-        self.assertEqual(shape, (3, 2))
-
-        # invalid selection
-        selection = [(0, 0), (0, 1), (0, 2),
-                     (1, 0), (1, 1)]
-        shape = self.view._getSelectionShape(selection)
-        self.assertEqual(shape, (0, 0))
-        selection = [(0, 0), (0, 1), (10, 10)]
-        shape = self.view._getSelectionShape(selection)
-        self.assertEqual(shape, (0, 0))
-
     def test_copySelectedCells(self):
         # no selection
         self.view.table.getSelectedCells.return_value = []
@@ -91,12 +65,14 @@ class DrillViewTest(unittest.TestCase):
 
         # valid selection
         self.view.table.getSelectedCells.return_value = [(0, 0)]
+        self.view.table.getSelectionShape.return_value = (1, 1)
         self.view.table.getCellContents.return_value = "test"
         self.view.copySelectedCells()
         self.assertEqual(self.view.buffer, ["test"])
         self.assertEqual(self.view.bufferShape, (1, 1))
         self.view.table.getSelectedCells.return_value = [(0, 0), (0, 1),
                                                          (1, 0), (1, 1)]
+        self.view.table.getSelectionShape.return_value = (2, 2)
         self.view.table.getCellContents.return_value = "test"
         self.view.copySelectedCells()
         self.view.table.getCellContents.assert_called()
@@ -106,6 +82,7 @@ class DrillViewTest(unittest.TestCase):
         # invalid selection
         self.view.table.reset_mock()
         self.view.table.getSelectedCells.return_value = [(0, 0), (10, 10)]
+        self.view.table.getSelectionShape.return_value = (0, 0)
         self.view.copySelectedCells()
         self.view.table.getCellContents.assert_not_called()
 
@@ -115,6 +92,7 @@ class DrillViewTest(unittest.TestCase):
         self.view.bufferShape = (1, 1)
         self.view.table.getSelectedCells.return_value = [(0, 0), (0, 1),
                                                          (1, 0), (1, 1)]
+        self.view.table.getSelectionShape.return_value = (1, 1)
         self.view.table.getCellContents.return_value = ""
         self.view.copySelectedCells()
         self.view.table.getCellContents.assert_called()
@@ -124,6 +102,7 @@ class DrillViewTest(unittest.TestCase):
     def test_cutSelectedCells(self):
         # no selection
         self.view.table.getSelectedCells.return_value = []
+        self.view.table.getSelectionShape.return_value = (0, 0)
         self.view.cutSelectedCells()
         self.assertEqual(self.view.buffer, [])
         self.assertEqual(self.view.bufferShape, ())
@@ -131,6 +110,7 @@ class DrillViewTest(unittest.TestCase):
 
         # valid selection
         self.view.table.getSelectedCells.return_value = [(0, 0)]
+        self.view.table.getSelectionShape.return_value = (1, 1)
         self.view.table.getCellContents.return_value = "test"
         self.view.cutSelectedCells()
         self.assertEqual(self.view.buffer, ["test"])
@@ -140,6 +120,7 @@ class DrillViewTest(unittest.TestCase):
         self.view.table.reset_mock()
         self.view.table.getSelectedCells.return_value = [(0, 0), (0, 1),
                                                          (1, 0), (1, 1)]
+        self.view.table.getSelectionShape.return_value = (2, 2)
         self.view.table.getCellContents.return_value = "test"
         self.view.cutSelectedCells()
         self.assertEqual(self.view.buffer, ["test", "test", "test", "test"])
@@ -151,6 +132,7 @@ class DrillViewTest(unittest.TestCase):
         # invalid selection
         self.view.table.reset_mock()
         self.view.table.getSelectedCells.return_value = [(0, 0), (10, 10)]
+        self.view.table.getSelectionShape.return_value = (0, 0)
         self.view.table.getCellContents.assert_not_called()
         self.view.table.eraseCell.assert_not_called()
 
@@ -159,6 +141,7 @@ class DrillViewTest(unittest.TestCase):
         self.view.buffer = ["test"]
         self.view.bufferShape = (1, 1)
         self.view.table.getSelectedCells.return_value = []
+        self.view.table.getSelectionShape.return_value = (0, 0)
         self.view.pasteCells()
         self.view.table.setCellContents.assert_not_called()
 
@@ -174,12 +157,14 @@ class DrillViewTest(unittest.TestCase):
         self.view.bufferShape = (1, 1)
         self.view.table.reset_mock()
         self.view.table.getSelectedCells.return_value = [(1, 1)]
+        self.view.table.getSelectionShape.return_value = (1, 1)
         self.view.pasteCells()
         self.view.table.setCellContents.assert_called_once()
 
         self.view.table.reset_mock()
         self.view.table.getSelectedCells.return_value = [(0, 0), (0, 1),
                                                          (1, 0), (1, 1)]
+        self.view.table.getSelectionShape.return_value = (2, 2)
         self.view.pasteCells()
         calls = [mock.call(0, 0, "test"), mock.call(0, 1, "test"),
                  mock.call(1, 0, "test"), mock.call(1, 1, "test")]
@@ -191,6 +176,7 @@ class DrillViewTest(unittest.TestCase):
         self.view.table.reset_mock()
         self.view.table.getSelectedCells.return_value = [(0, 0), (0, 1),
                                                          (1, 0), (1, 1)]
+        self.view.table.getSelectionShape.return_value = (2, 2)
         self.view.pasteCells()
         calls = [mock.call(0, 0, "test00"), mock.call(0, 1, "test01"),
                  mock.call(1, 0, "test10"), mock.call(1, 1, "test11")]

--- a/scripts/Interface/ui/drill/test/DrillViewTest.py
+++ b/scripts/Interface/ui/drill/test/DrillViewTest.py
@@ -287,6 +287,7 @@ class DrillViewTest(unittest.TestCase):
         self.view.table.getSelectedCells.return_value = [(0, 0),
                                                          (0, 1)]
         self.view.table.getCellContents.return_value = "1000,2000,3000"
+        self.view.table.getRowsFromSelectedCells.return_value = [0]
         self.view.increment.value.return_value = 1
         self.view.automatic_filling()
         calls = [mock.call(0, 1, "1001,2001,3001")]

--- a/scripts/Interface/ui/drill/view/DrillTableWidget.py
+++ b/scripts/Interface/ui/drill/view/DrillTableWidget.py
@@ -172,7 +172,7 @@ class DrillTableWidget(QTableWidget):
             cellsLi.append((i.row(), i.column()))
             cellsVi.append((self.visualRow(i.row()),
                           self.visualColumn(i.column())))
-        return sorted(cellsLi, key=lambda i : cellsVi[cellsLi.index(i)])
+        return sorted(cellsLi, key=lambda i : cellsVi[cellsLi.index(i)][1])
 
     def getSelectionShape(self):
         """

--- a/scripts/Interface/ui/drill/view/DrillTableWidget.py
+++ b/scripts/Interface/ui/drill/view/DrillTableWidget.py
@@ -158,14 +158,51 @@ class DrillTableWidget(QTableWidget):
 
     def getSelectedCells(self):
         """
-        Get the coordinates of the selected cells.
+        Get the coordinates of the selected cells. These coordinates are sorted
+        by visual index to be able to copy(cut) paste in the same order.
 
         Returns:
             list(tuple(int, int)): the coordinates (row, column) of the
                 selected cells
         """
         selected_indexes = self.selectionModel().selectedIndexes()
-        return [(i.row(), i.column()) for i in selected_indexes]
+        cellsLi = []
+        cellsVi = []
+        for i in selected_indexes:
+            cellsLi.append((i.row(), i.column()))
+            cellsVi.append((self.visualRow(i.row()),
+                          self.visualColumn(i.column())))
+        return sorted(cellsLi, key=lambda i : cellsVi[cellsLi.index(i)])
+
+    def getSelectionShape(self):
+        """
+        Get the shape of the selection, the number of rows and the number of
+        columns.
+
+        Returns:
+        tuple(int, int): selection shape (n_rows, n_col), (0, 0) if the
+                         selection is empty or discontinuous
+        """
+        selection = self.getSelectedCells()
+        if not selection:
+            return (0, 0)
+        for i in range(len(selection)):
+            selection[i] = (self.visualRow(selection[i][0]),
+                            self.visualColumn(selection[i][1]))
+        rmin = selection[0][0]
+        rmax = rmin
+        cmin = selection[0][1]
+        cmax = cmin
+        for item in selection:
+            if item[0] > rmax:
+                rmax = item[0]
+            if item[1] > cmax:
+                cmax = item[1]
+        shape = (rmax - rmin + 1, cmax - cmin + 1)
+        if shape[0] * shape[1] != len(selection):
+            return (0, 0)
+        else:
+            return shape
 
     def getRowsFromSelectedCells(self):
         """

--- a/scripts/Interface/ui/drill/view/DrillView.py
+++ b/scripts/Interface/ui/drill/view/DrillView.py
@@ -280,35 +280,6 @@ class DrillView(QMainWindow):
             self.cycleAndExperimentChanged.emit(cycle, exp)
         self.setWindowModified(True)
 
-    def _getSelectionShape(self, selection):
-        """
-        Get the shape of the selection, the number of rows and the number of
-        columns.
-
-        Args:
-            selection (list(tuple(int, int))): list of selected cells indexes
-
-        Returns:
-            tuple(int, int): selection shape (n_rows, n_col), (0, 0) if the
-                             selection is empty or discontinuous
-        """
-        if not selection:
-            return (0, 0)
-        rmin = selection[0][0]
-        rmax = rmin
-        cmin = selection[0][1]
-        cmax = cmin
-        for item in selection:
-            if item[0] > rmax:
-                rmax = item[0]
-            if item[1] > cmax:
-                cmax = item[1]
-        shape = (rmax - rmin + 1, cmax - cmin + 1)
-        if shape[0] * shape[1] != len(selection):
-            return (0, 0)
-        else:
-            return shape
-
     def copySelectedCells(self):
         """
         Copy in the local buffer the content of the selected cells. The
@@ -318,8 +289,7 @@ class DrillView(QMainWindow):
         cells = self.table.getSelectedCells()
         if not cells:
             return
-        cells.sort()
-        shape = self._getSelectionShape(cells)
+        shape = self.table.getSelectionShape()
         if shape == (0, 0):
             QMessageBox.warning(self, "Selection error",
                                 "Please select adjacent cells")
@@ -361,8 +331,7 @@ class DrillView(QMainWindow):
         if not cells:
             QMessageBox.warning(self, "Paste error", "No cell selected")
             return
-        cells.sort()
-        shape = self._getSelectionShape(cells)
+        shape = self.table.getSelectionShape()
         if self.bufferShape == (1, 1) and shape != (0, 0):
             for cell in cells:
                 self.table.setCellContents(cell[0], cell[1], self.buffer[0])

--- a/scripts/Interface/ui/drill/view/DrillView.py
+++ b/scripts/Interface/ui/drill/view/DrillView.py
@@ -467,7 +467,9 @@ class DrillView(QMainWindow):
         Copy (and increment) the contents of the first selected cell in the
         other ones. If a numors string is detected in the first cell, the
         numors values are incremented by the number found in the ui spinbox
-        associated with this action.
+        associated with this action. If a single row is selected, the increment
+        will be propagated along that row. Otherwise, the increment is
+        propagated along columns.
         """
         def inc(numors, i):
             """
@@ -522,10 +524,15 @@ class DrillView(QMainWindow):
 
         increment = self.increment.value()
         cells = self.table.getSelectedCells()
+        # check if increment should append along columns
+        columnIncrement = (len(self.table.getRowsFromSelectedCells()) > 1)
         if not cells:
             return
         # increment or copy the content of the previous cell
         for i in range(1, len(cells)):
+            # if we increment along columns and this is a new column
+            if columnIncrement and cells[i][1] != cells[i-1][1]:
+                continue
             contents = self.table.getCellContents(cells[i-1][0], cells[i-1][1])
             self.table.setCellContents(cells[i][0], cells[i][1],
                                        inc(contents, increment))


### PR DESCRIPTION
When the columns are reordered, the cut/copy/paste was not properly working.

**Description of work.**

This PR modifies the way the table is returning the selected cells and the selection shape.
Selected cells are now ordered by there visual index (i.e. their position in the table taking into account any potential reordering). and the selection shape is calculated on the visual position of cells.

**To test:**

* open DrILL interface (Interfaces -> DrILL)
* add some rows (use the toolbox or the menu)
* reorder the columns
* enter some random values
* try to select cells and use the cut/copy/paste function
* try also the increment filling (spinbox in the toolbox)

Fixes #30076 

*This does not require release notes*, internal changes only.

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
