### PR TITLE
Log errors with skipping invalid instrument info

### DIFF
--- a/Framework/Kernel/src/FacilityInfo.cpp
+++ b/Framework/Kernel/src/FacilityInfo.cpp
@@ -168,7 +168,9 @@ void FacilityInfo::fillInstruments(const Poco::XML::Element *elem) {
       try {
         InstrumentInfo instr(this, elem);
         m_instruments.emplace_back(instr);
-      } catch (...) { /*skip this instrument*/
+      } catch (std::runtime_error &e) { /*skip this instrument*/
+        g_log.warning("Failed to load instument for: " + m_name + ": " +
+                      e.what());
       }
     }
   }
@@ -193,7 +195,9 @@ void FacilityInfo::fillComputeResources(const Poco::XML::Element *elem) {
         m_computeResInfos.emplace_back(cr);
 
         g_log.debug() << "Compute resource found: " << cr << '\n';
-      } catch (...) { // next resource...
+      } catch (std::runtime_error &e) { // next resource...
+        g_log.warning("Failed to load compute resource for: " + m_name + ": " +
+                      e.what());
       }
 
       std::string name = elem->getAttribute("name");

--- a/docs/source/release/v6.0.0/framework.rst
+++ b/docs/source/release/v6.0.0/framework.rst
@@ -63,5 +63,6 @@ Bugfixes
 - Warning log messages from the InstrumentValidator are no longer produced when editing some python scripts.
 - A bug has been fixed when plotting bin plots on a workspace with numerical axis.
 - A bug is fixed when setting the same axis to multiple workspaces, which would cause a crash when deleting the workspaces.
+- Give warning when instrument in Facilities.xml has errors
 
 :ref:`Release 6.0.0 <v6.0.0>`


### PR DESCRIPTION
When loading Facilities.xml log any exceptions that are thrown.

Fixes #27085

**Description of work.**

If an instrument in Facilities.xml is missing a <technique> tag, the whole instrument was being silently ignored. This was already raising an exception, which was silently dropped in FacilityInfo::fillInstruments . This change cause the message to be logged at warning level. (same is true for other errors in loading the instruments)

I have done the same in fillComputeResources as that has the same issue (although 2 out of 3 throw)

The warning is not shown in the messages window. I assume because this happens before the main window is drawn?

**To test:**
1) Remove a <technique> tag pair from Facilities.xml
2) start workbench and watch stdout

Fixes #27085 

<!-- Ensure the base of this PR is correct (e.g. release-next or master)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
