### PR TITLE
Fix Double Click of Ragged workspaces

### DIFF
--- a/Framework/API/inc/MantidAPI/MatrixWorkspace.h
+++ b/Framework/API/inc/MantidAPI/MatrixWorkspace.h
@@ -135,6 +135,10 @@ public:
   /// This throws an exception if the lengths are not identical across the
   /// spectra.
   virtual std::size_t blocksize() const = 0;
+  /// Returns the number of bins for a given histogram index.
+  virtual std::size_t getNumberBins(const std::size_t &index) const = 0;
+  /// Returns the maximum number of bins in a workspace (works on ragged data).
+  virtual std::size_t getMaxNumberBins() const = 0;
   /// Returns the number of histograms in the workspace
   virtual std::size_t getNumberHistograms() const = 0;
 
@@ -165,7 +169,7 @@ public:
     return getSpectrum(index).histogram();
   }
   template <typename... T>
-  void setHistogram(const size_t index, T &&... data) & {
+  void setHistogram(const size_t index, T &&...data) & {
     getSpectrum(index).setHistogram(std::forward<T>(data)...);
   }
   void convertToCounts(const size_t index) {
@@ -184,20 +188,19 @@ public:
   pointStandardDeviations(const size_t index) const {
     return getSpectrum(index).pointStandardDeviations();
   }
-  template <typename... T>
-  void setBinEdges(const size_t index, T &&... data) & {
+  template <typename... T> void setBinEdges(const size_t index, T &&...data) & {
     getSpectrum(index).setBinEdges(std::forward<T>(data)...);
   }
-  template <typename... T> void setPoints(const size_t index, T &&... data) & {
+  template <typename... T> void setPoints(const size_t index, T &&...data) & {
     getSpectrum(index).setPoints(std::forward<T>(data)...);
   }
   template <typename... T>
-  void setPointVariances(const size_t index, T &&... data) & {
+  void setPointVariances(const size_t index, T &&...data) & {
     getSpectrumWithoutInvalidation(index).setPointVariances(
         std::forward<T>(data)...);
   }
   template <typename... T>
-  void setPointStandardDeviations(const size_t index, T &&... data) & {
+  void setPointStandardDeviations(const size_t index, T &&...data) & {
     getSpectrumWithoutInvalidation(index).setPointStandardDeviations(
         std::forward<T>(data)...);
   }
@@ -222,31 +225,31 @@ public:
   frequencyStandardDeviations(const size_t index) const {
     return getSpectrum(index).frequencyStandardDeviations();
   }
-  template <typename... T> void setCounts(const size_t index, T &&... data) & {
+  template <typename... T> void setCounts(const size_t index, T &&...data) & {
     getSpectrumWithoutInvalidation(index).setCounts(std::forward<T>(data)...);
   }
   template <typename... T>
-  void setCountVariances(const size_t index, T &&... data) & {
+  void setCountVariances(const size_t index, T &&...data) & {
     getSpectrumWithoutInvalidation(index).setCountVariances(
         std::forward<T>(data)...);
   }
   template <typename... T>
-  void setCountStandardDeviations(const size_t index, T &&... data) & {
+  void setCountStandardDeviations(const size_t index, T &&...data) & {
     getSpectrumWithoutInvalidation(index).setCountStandardDeviations(
         std::forward<T>(data)...);
   }
   template <typename... T>
-  void setFrequencies(const size_t index, T &&... data) & {
+  void setFrequencies(const size_t index, T &&...data) & {
     getSpectrumWithoutInvalidation(index).setFrequencies(
         std::forward<T>(data)...);
   }
   template <typename... T>
-  void setFrequencyVariances(const size_t index, T &&... data) & {
+  void setFrequencyVariances(const size_t index, T &&...data) & {
     getSpectrumWithoutInvalidation(index).setFrequencyVariances(
         std::forward<T>(data)...);
   }
   template <typename... T>
-  void setFrequencyStandardDeviations(const size_t index, T &&... data) & {
+  void setFrequencyStandardDeviations(const size_t index, T &&...data) & {
     getSpectrumWithoutInvalidation(index).setFrequencyStandardDeviations(
         std::forward<T>(data)...);
   }

--- a/Framework/API/inc/MantidAPI/MatrixWorkspace.h
+++ b/Framework/API/inc/MantidAPI/MatrixWorkspace.h
@@ -169,7 +169,7 @@ public:
     return getSpectrum(index).histogram();
   }
   template <typename... T>
-  void setHistogram(const size_t index, T &&...data) & {
+  void setHistogram(const size_t index, T &&... data) & {
     getSpectrum(index).setHistogram(std::forward<T>(data)...);
   }
   void convertToCounts(const size_t index) {
@@ -188,19 +188,20 @@ public:
   pointStandardDeviations(const size_t index) const {
     return getSpectrum(index).pointStandardDeviations();
   }
-  template <typename... T> void setBinEdges(const size_t index, T &&...data) & {
+  template <typename... T>
+  void setBinEdges(const size_t index, T &&... data) & {
     getSpectrum(index).setBinEdges(std::forward<T>(data)...);
   }
-  template <typename... T> void setPoints(const size_t index, T &&...data) & {
+  template <typename... T> void setPoints(const size_t index, T &&... data) & {
     getSpectrum(index).setPoints(std::forward<T>(data)...);
   }
   template <typename... T>
-  void setPointVariances(const size_t index, T &&...data) & {
+  void setPointVariances(const size_t index, T &&... data) & {
     getSpectrumWithoutInvalidation(index).setPointVariances(
         std::forward<T>(data)...);
   }
   template <typename... T>
-  void setPointStandardDeviations(const size_t index, T &&...data) & {
+  void setPointStandardDeviations(const size_t index, T &&... data) & {
     getSpectrumWithoutInvalidation(index).setPointStandardDeviations(
         std::forward<T>(data)...);
   }
@@ -225,31 +226,31 @@ public:
   frequencyStandardDeviations(const size_t index) const {
     return getSpectrum(index).frequencyStandardDeviations();
   }
-  template <typename... T> void setCounts(const size_t index, T &&...data) & {
+  template <typename... T> void setCounts(const size_t index, T &&... data) & {
     getSpectrumWithoutInvalidation(index).setCounts(std::forward<T>(data)...);
   }
   template <typename... T>
-  void setCountVariances(const size_t index, T &&...data) & {
+  void setCountVariances(const size_t index, T &&... data) & {
     getSpectrumWithoutInvalidation(index).setCountVariances(
         std::forward<T>(data)...);
   }
   template <typename... T>
-  void setCountStandardDeviations(const size_t index, T &&...data) & {
+  void setCountStandardDeviations(const size_t index, T &&... data) & {
     getSpectrumWithoutInvalidation(index).setCountStandardDeviations(
         std::forward<T>(data)...);
   }
   template <typename... T>
-  void setFrequencies(const size_t index, T &&...data) & {
+  void setFrequencies(const size_t index, T &&... data) & {
     getSpectrumWithoutInvalidation(index).setFrequencies(
         std::forward<T>(data)...);
   }
   template <typename... T>
-  void setFrequencyVariances(const size_t index, T &&...data) & {
+  void setFrequencyVariances(const size_t index, T &&... data) & {
     getSpectrumWithoutInvalidation(index).setFrequencyVariances(
         std::forward<T>(data)...);
   }
   template <typename... T>
-  void setFrequencyStandardDeviations(const size_t index, T &&...data) & {
+  void setFrequencyStandardDeviations(const size_t index, T &&... data) & {
     getSpectrumWithoutInvalidation(index).setFrequencyStandardDeviations(
         std::forward<T>(data)...);
   }

--- a/Framework/API/test/CompositeFunctionTest.h
+++ b/Framework/API/test/CompositeFunctionTest.h
@@ -50,6 +50,13 @@ public:
   std::size_t size() const override { return m_spectra.size() * m_blocksize; }
   /// Returns the size of each block of data returned by the dataY accessors
   std::size_t blocksize() const override { return m_blocksize; }
+  /// Returns the number of bins for a given histogram index.
+  std::size_t getNumberBins(const std::size_t &index) const override {
+    UNUSED_ARG(index);
+    return m_blocksize;
+  }
+  /// Returns the maximum number of bins in a workspace (works on ragged data).
+  std::size_t getMaxNumberBins() const override { return m_blocksize; }
   /// Returns the number of histograms in the workspace
   std::size_t getNumberHistograms() const override { return m_spectra.size(); }
 

--- a/Framework/Algorithms/test/RebinByTimeBaseTest.h
+++ b/Framework/Algorithms/test/RebinByTimeBaseTest.h
@@ -102,6 +102,8 @@ public:
   MOCK_CONST_METHOD0(clearMRU, void());
   MOCK_CONST_METHOD0(isRaggedWorkspace, bool());
   MOCK_CONST_METHOD0(blocksize, std::size_t());
+  MOCK_CONST_METHOD1(getNumberBins, std::size_t(const std::size_t &));
+  MOCK_CONST_METHOD0(getMaxNumberBins, std::size_t());
   MOCK_CONST_METHOD0(size, std::size_t());
   MOCK_CONST_METHOD0(getNumberHistograms, std::size_t());
   MOCK_METHOD1(getSpectrum, Mantid::API::IEventList &(const std::size_t));

--- a/Framework/DataObjects/inc/MantidDataObjects/EventWorkspace.h
+++ b/Framework/DataObjects/inc/MantidDataObjects/EventWorkspace.h
@@ -68,11 +68,15 @@ public:
 
   // Get the blocksize, aka the number of bins in the histogram
   std::size_t blocksize() const override;
-
-  size_t getMemorySize() const override;
+  /// Returns the number of bins for a given histogram index.
+  std::size_t getNumberBins(const std::size_t &index) const override;
+  /// Returns the maximum number of bins in a workspace (works on ragged data).
+  std::size_t getMaxNumberBins() const override;
 
   // Get the number of histograms. aka the number of pixels or detectors.
   std::size_t getNumberHistograms() const override;
+
+  size_t getMemorySize() const override;
 
   EventList &getSpectrum(const size_t index) override {
     invalidateCommonBinsFlag();

--- a/Framework/DataObjects/inc/MantidDataObjects/Workspace2D.h
+++ b/Framework/DataObjects/inc/MantidDataObjects/Workspace2D.h
@@ -51,12 +51,17 @@ public:
   /// Returns true if the workspace is ragged (has differently sized spectra).
   bool isRaggedWorkspace() const override;
 
-  /// Returns the histogram number
-  std::size_t getNumberHistograms() const override;
-
   // section required for iteration
   std::size_t size() const override;
+
   std::size_t blocksize() const override;
+  /// Returns the number of bins for a given histogram index.
+  std::size_t getNumberBins(const std::size_t &index) const override;
+  /// Returns the maximum number of bins in a workspace (works on ragged data).
+  std::size_t getMaxNumberBins() const override;
+
+  /// Returns the histogram number
+  std::size_t getNumberHistograms() const override;
 
   Histogram1D &getSpectrum(const size_t index) override {
     invalidateCommonBinsFlag();

--- a/Framework/DataObjects/inc/MantidDataObjects/WorkspaceSingleValue.h
+++ b/Framework/DataObjects/inc/MantidDataObjects/WorkspaceSingleValue.h
@@ -47,6 +47,13 @@ public:
 
   /// Returns the size of each block of data returned by the dataX accessors
   std::size_t blocksize() const override { return 1; }
+  /// Returns the number of bins for a given histogram index.
+  std::size_t getNumberBins(const std::size_t &index) const override {
+    UNUSED_ARG(index);
+    return 1;
+  }
+  /// Returns the maximum number of bins in a workspace.
+  std::size_t getMaxNumberBins() const override { return 1; }
 
   /// @return the number of histograms (spectra)
   std::size_t getNumberHistograms() const override { return 1; }

--- a/Framework/DataObjects/src/EventWorkspace.cpp
+++ b/Framework/DataObjects/src/EventWorkspace.cpp
@@ -178,6 +178,36 @@ size_t EventWorkspace::blocksize() const {
   }
 }
 
+/** Returns the number of bins for a given histogram index.
+ * @param index :: The histogram index to check for the number of bins.
+ * @return the number of bins for a given histogram index.
+ */
+std::size_t EventWorkspace::getNumberBins(const std::size_t &index) const {
+  if (index <= data.size())
+    return data[index]->histogram_size();
+
+  throw std::invalid_argument(
+      "Could not find number of bins in a histogram at index " +
+      std::to_string(index) + ": index is too large.");
+}
+
+/** Returns the maximum number of bins in a workspace (works on ragged data).
+ * @return the maximum number of bins in a workspace.
+ */
+std::size_t EventWorkspace::getMaxNumberBins() const {
+  if (data.empty()) {
+    return 0;
+  } else {
+    auto maxNumberOfBins = data[0]->histogram_size();
+    for (const auto &iter : data) {
+      const auto numberOfBins = iter->histogram_size();
+      if (numberOfBins > maxNumberOfBins)
+        maxNumberOfBins = numberOfBins;
+    }
+    return maxNumberOfBins;
+  }
+}
+
 /** Get the number of histograms, usually the same as the number of pixels or
  detectors.
  @returns the number of histograms / event lists

--- a/Framework/DataObjects/src/EventWorkspace.cpp
+++ b/Framework/DataObjects/src/EventWorkspace.cpp
@@ -183,7 +183,7 @@ size_t EventWorkspace::blocksize() const {
  * @return the number of bins for a given histogram index.
  */
 std::size_t EventWorkspace::getNumberBins(const std::size_t &index) const {
-  if (index <= data.size())
+  if (index < data.size())
     return data[index]->histogram_size();
 
   throw std::invalid_argument(

--- a/Framework/DataObjects/src/Workspace2D.cpp
+++ b/Framework/DataObjects/src/Workspace2D.cpp
@@ -149,6 +149,36 @@ size_t Workspace2D::blocksize() const {
   }
 }
 
+/** Returns the number of bins for a given histogram index.
+ * @param index :: The histogram index to check for the number of bins.
+ * @return the number of bins for a given histogram index.
+ */
+std::size_t Workspace2D::getNumberBins(const std::size_t &index) const {
+  if (index <= data.size())
+    return data[index]->size();
+
+  throw std::invalid_argument(
+      "Could not find number of bins in a histogram at index " +
+      std::to_string(index) + ": index is too large.");
+}
+
+/** Returns the maximum number of bins in a workspace (works on ragged data).
+ * @return the maximum number of bins in a workspace.
+ */
+std::size_t Workspace2D::getMaxNumberBins() const {
+  if (data.empty()) {
+    return 0;
+  } else {
+    auto maxNumberOfBins = data[0]->size();
+    for (const auto &iter : data) {
+      const auto numberOfBins = iter->size();
+      if (numberOfBins > maxNumberOfBins)
+        maxNumberOfBins = numberOfBins;
+    }
+    return maxNumberOfBins;
+  }
+}
+
 /**
  * Copy the data (Y's) from an image to this workspace.
  * @param image :: An image to copy the data from.

--- a/Framework/DataObjects/src/Workspace2D.cpp
+++ b/Framework/DataObjects/src/Workspace2D.cpp
@@ -154,7 +154,7 @@ size_t Workspace2D::blocksize() const {
  * @return the number of bins for a given histogram index.
  */
 std::size_t Workspace2D::getNumberBins(const std::size_t &index) const {
-  if (index <= data.size())
+  if (index < data.size())
     return data[index]->size();
 
   throw std::invalid_argument(

--- a/Framework/DataObjects/test/EventWorkspaceTest.h
+++ b/Framework/DataObjects/test/EventWorkspaceTest.h
@@ -163,6 +163,32 @@ public:
     TS_ASSERT_THROWS(ew->blocksize(), const std::logic_error &);
   }
 
+  void
+  test_that_getNumberBins_returns_the_correct_number_of_bins_for_different_histograms_in_a_ragged_EventWorkspace() {
+    ew = createEventWorkspace(true, false);
+    ew->getSpectrum(0).setHistogram(BinEdges({0., 10., 20.}));
+
+    TS_ASSERT(ew->isRaggedWorkspace());
+    TS_ASSERT_EQUALS(ew->getNumberBins(0), 2);
+    TS_ASSERT_EQUALS(ew->getNumberBins(1), 1025);
+  }
+
+  void
+  test_that_getNumberBins_throws_when_provided_an_index_which_is_too_large() {
+    ew = createEventWorkspace(true, false);
+    TS_ASSERT_THROWS_NOTHING(ew->getNumberBins(1024));
+    TS_ASSERT_THROWS(ew->getNumberBins(1025), const std::invalid_argument &);
+  }
+
+  void
+  test_that_getMaxNumberBins_returns_the_correct_number_for_a_ragged_EventWorkspace() {
+    ew = createEventWorkspace(true, false);
+    ew->getSpectrum(0).setHistogram(BinEdges({0., 10., 20.}));
+
+    TS_ASSERT(ew->isRaggedWorkspace());
+    TS_ASSERT_EQUALS(ew->getMaxNumberBins(), 1025);
+  }
+
   void testUnequalBins() {
     ew = createEventWorkspace(true, false);
     // normal behavior

--- a/Framework/DataObjects/test/EventWorkspaceTest.h
+++ b/Framework/DataObjects/test/EventWorkspaceTest.h
@@ -170,14 +170,17 @@ public:
 
     TS_ASSERT(ew->isRaggedWorkspace());
     TS_ASSERT_EQUALS(ew->getNumberBins(0), 2);
-    TS_ASSERT_EQUALS(ew->getNumberBins(1), 1025);
+    TS_ASSERT_EQUALS(ew->getNumberBins(1), 1);
   }
 
   void
   test_that_getNumberBins_throws_when_provided_an_index_which_is_too_large() {
     ew = createEventWorkspace(true, false);
-    TS_ASSERT_THROWS_NOTHING(ew->getNumberBins(1024));
-    TS_ASSERT_THROWS(ew->getNumberBins(1025), const std::invalid_argument &);
+
+    const auto numberOfHistograms = ew->getNumberHistograms();
+    TS_ASSERT_THROWS_NOTHING(ew->getNumberBins(numberOfHistograms - 1u));
+    TS_ASSERT_THROWS(ew->getNumberBins(numberOfHistograms),
+                     const std::invalid_argument &);
   }
 
   void
@@ -186,7 +189,7 @@ public:
     ew->getSpectrum(0).setHistogram(BinEdges({0., 10., 20.}));
 
     TS_ASSERT(ew->isRaggedWorkspace());
-    TS_ASSERT_EQUALS(ew->getMaxNumberBins(), 1025);
+    TS_ASSERT_EQUALS(ew->getMaxNumberBins(), 2);
   }
 
   void testUnequalBins() {

--- a/Framework/DataObjects/test/Workspace2DTest.h
+++ b/Framework/DataObjects/test/Workspace2DTest.h
@@ -100,14 +100,17 @@ public:
     cloned->setHistogram(0, Points(0), Counts(0));
 
     TS_ASSERT(cloned->isRaggedWorkspace());
-    TS_ASSERT_EQUALS(cloned->getNumberBins(0), 1);
+    TS_ASSERT_EQUALS(cloned->getNumberBins(0), 0);
     TS_ASSERT_EQUALS(cloned->getNumberBins(1), 5);
   }
 
   void
   test_that_getNumberBins_throws_when_provided_an_index_which_is_too_large() {
-    TS_ASSERT_THROWS_NOTHING(ws->getNumberBins(4));
-    TS_ASSERT_THROWS(ws->getNumberBins(5), const std::invalid_argument &);
+    const auto numberOfHistograms = ws->getNumberHistograms();
+
+    TS_ASSERT_THROWS_NOTHING(ws->getNumberBins(numberOfHistograms - 1));
+    TS_ASSERT_THROWS(ws->getNumberBins(numberOfHistograms),
+                     const std::invalid_argument &);
   }
 
   void

--- a/Framework/DataObjects/test/Workspace2DTest.h
+++ b/Framework/DataObjects/test/Workspace2DTest.h
@@ -94,6 +94,31 @@ public:
     TS_ASSERT_THROWS(cloned->blocksize(), const std::logic_error &);
   }
 
+  void
+  test_that_getNumberBins_returns_the_correct_number_of_bins_for_different_histograms_in_a_ragged_Workspace2D() {
+    Workspace2D_sptr cloned(ws->clone());
+    cloned->setHistogram(0, Points(0), Counts(0));
+
+    TS_ASSERT(cloned->isRaggedWorkspace());
+    TS_ASSERT_EQUALS(cloned->getNumberBins(0), 1);
+    TS_ASSERT_EQUALS(cloned->getNumberBins(1), 5);
+  }
+
+  void
+  test_that_getNumberBins_throws_when_provided_an_index_which_is_too_large() {
+    TS_ASSERT_THROWS_NOTHING(ws->getNumberBins(4));
+    TS_ASSERT_THROWS(ws->getNumberBins(5), const std::invalid_argument &);
+  }
+
+  void
+  test_that_getMaxNumberBins_returns_the_correct_number_for_a_ragged_Workspace2D() {
+    Workspace2D_sptr cloned(ws->clone());
+    cloned->setHistogram(0, Points(0), Counts(0));
+
+    TS_ASSERT(cloned->isRaggedWorkspace());
+    TS_ASSERT_EQUALS(cloned->getMaxNumberBins(), 5);
+  }
+
   void testUnequalBins() {
     // try normal kind first
     TS_ASSERT_EQUALS(ws->blocksize(), 5);

--- a/Framework/DataObjects/test/WorkspaceSingleValueTest.h
+++ b/Framework/DataObjects/test/WorkspaceSingleValueTest.h
@@ -105,4 +105,11 @@ public:
     WorkspaceSingleValue ws;
     TS_ASSERT(!ws.isRaggedWorkspace());
   }
+
+  void
+  test_that_getNumberBins_and_getMaxNumberBins_returns_one_for_a_WorkspaceSingleValue() {
+    WorkspaceSingleValue ws;
+    TS_ASSERT_EQUALS(ws.getNumberBins(0), 1);
+    TS_ASSERT_EQUALS(ws.getMaxNumberBins(), 1);
+  }
 };

--- a/Framework/PythonInterface/mantid/api/src/Exports/MatrixWorkspace.cpp
+++ b/Framework/PythonInterface/mantid/api/src/Exports/MatrixWorkspace.cpp
@@ -185,18 +185,6 @@ void setDxFromPyObject(MatrixWorkspace &self, const size_t wsIndex,
 }
 
 /**
- * Adds a deprecation warning to the getNumberBins call to warn about using
- * blocksize instead
- * @param self A reference to the calling object
- * @returns The blocksize()
- */
-size_t getNumberBinsDeprecated(MatrixWorkspace &self) {
-  PyErr_Warn(PyExc_DeprecationWarning,
-             "``getNumberBins`` is deprecated, use ``blocksize`` instead.");
-  return self.blocksize();
-}
-
-/**
  * Adds a deprecation warning to the getSampleDetails call to warn about using
  * getRun instead
  * @param self A reference to the calling object
@@ -350,6 +338,12 @@ void export_MatrixWorkspace() {
            "spectra).")
       .def("blocksize", &MatrixWorkspace::blocksize, arg("self"),
            "Returns size of the Y data array")
+      .def("getNumberBins", &MatrixWorkspace::getNumberBins,
+           (arg("self"), arg("index")),
+           "Returns the number of bins for a given histogram index.")
+      .def("getMaxNumberBins", &MatrixWorkspace::getMaxNumberBins, arg("self"),
+           "Returns the maximum number of bins in a workspace (works on ragged "
+           "data).")
       .def("getNumberHistograms", &MatrixWorkspace::getNumberHistograms,
            arg("self"), "Returns the number of spectra in the workspace")
       .def("getSpectrumNumbers", &getSpectrumNumbers, arg("self"),
@@ -424,11 +418,6 @@ void export_MatrixWorkspace() {
            "Find first index in Y equal to value. Start may be specified to "
            "begin at a specifc index. Returns tuple with the "
            "histogram and bin indices.")
-      // Deprecated
-      .def("getNumberBins", &getNumberBinsDeprecated, arg("self"),
-           "Returns size of the Y data array (deprecated, use "
-           ":class:`~mantid.api.MatrixWorkspace.blocksize` "
-           "instead)")
       .def("getSampleDetails", &getSampleDetailsDeprecated, arg("self"),
            return_internal_reference<>(),
            "Return the Run object for this workspace (deprecated, use "

--- a/Framework/PythonInterface/plugins/algorithms/PearlMCAbsorption.py
+++ b/Framework/PythonInterface/plugins/algorithms/PearlMCAbsorption.py
@@ -79,7 +79,7 @@ class PearlMCAbsorption(PythonAlgorithm):
         """
         #c = math.exp(-1.0*mu*thickness)
         num_hist = input_ws.getNumberHistograms()
-        num_vals = input_ws.getNumberBins()
+        num_vals = input_ws.blocksize()
         for i in range(num_hist):
             mu_values = input_ws.readY(i)
             for j in range(num_vals):

--- a/Framework/PythonInterface/test/python/plugins/algorithms/LoadDNSLegacyTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/LoadDNSLegacyTest.py
@@ -172,7 +172,7 @@ class LoadDNSLegacyTest(unittest.TestCase):
         ws = AnalysisDataService.retrieve(outputWorkspaceName)
         # dimensions
         self.assertEqual(24, ws.getNumberHistograms())
-        self.assertEqual(100,  ws.getNumberBins())
+        self.assertEqual(100,  ws.blocksize())
         # data array
         self.assertEqual(8, ws.readY(19)[23])
         self.assertAlmostEqual(tof1, ws.readX(0)[0], 3)

--- a/Framework/PythonInterface/test/python/plugins/algorithms/LoadGudrunOutputTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/LoadGudrunOutputTest.py
@@ -31,31 +31,31 @@ class LoadGudrunOutputTest(unittest.TestCase):
     def test_load_dcs(self):
         actual = LoadGudrunOutput(self.file_name.format('.dcs'))
         self.assertIsInstance(actual, Workspace)
-        self.assertEqual(actual.getNumberBins(), 100)
+        self.assertEqual(actual.blocksize(), 100)
         self.assertEqual(actual.getNumberHistograms(), 5)
 
     def test_load_mdsc(self):
         actual = LoadGudrunOutput(self.file_name.format('.mdcs'))
         self.assertIsInstance(actual, Workspace)
-        self.assertEqual(actual.getNumberBins(), 100)
+        self.assertEqual(actual.blocksize(), 100)
         self.assertEqual(actual.getNumberHistograms(), 1)
 
     def test_load_mint(self):
         actual = LoadGudrunOutput(self.file_name.format('.mint'))
         self.assertIsInstance(actual, Workspace)
-        self.assertEqual(actual.getNumberBins(), 100)
+        self.assertEqual(actual.blocksize(), 100)
         self.assertEqual(actual.getNumberHistograms(), 1)
 
     def test_load_mdor(self):
         actual = LoadGudrunOutput(self.file_name.format('.mdor'))
         self.assertIsInstance(actual, Workspace)
-        self.assertEqual(actual.getNumberBins(), 100)
+        self.assertEqual(actual.blocksize(), 100)
         self.assertEqual(actual.getNumberHistograms(), 1)
 
     def test_load_mgor(self):
         actual = LoadGudrunOutput(self.file_name.format('.mgor'))
         self.assertIsInstance(actual, Workspace)
-        self.assertEqual(actual.getNumberBins(), 100)
+        self.assertEqual(actual.blocksize(), 100)
         self.assertEqual(actual.getNumberHistograms(), 1)
 
     def test_one_column_data_file(self):

--- a/Framework/TestHelpers/inc/MantidTestHelpers/FakeObjects.h
+++ b/Framework/TestHelpers/inc/MantidTestHelpers/FakeObjects.h
@@ -23,6 +23,7 @@
  *      Author: Janik Zikovsky
  */
 
+#include <algorithm>
 #include <fstream>
 #include <map>
 #include <string>
@@ -166,6 +167,26 @@ public:
     }
     return m_vec.empty() ? 0 : m_vec[0].dataY().size();
   }
+
+  std::size_t getNumberBins(const std::size_t &index) const override {
+    if (index > m_vec.size())
+      return 0;
+    return m_vec[index].dataY().size();
+  }
+
+  std::size_t getMaxNumberBins() const override {
+    if (m_vec.empty()) {
+      return 0;
+    } else {
+      const auto iter = std::max_element(
+          m_vec.cbegin(), m_vec.cend(),
+          [](const SpectrumTester &s1, const SpectrumTester &s2) {
+            return s1.dataY().size() < s2.dataY().size();
+          });
+      return iter->dataY().size();
+    }
+  }
+
   ISpectrum &getSpectrum(const size_t index) override {
     invalidateCommonBinsFlag();
     m_vec[index].setMatrixWorkspace(this, index);

--- a/Testing/SystemTests/tests/framework/AlignAndFocusPowderFromFilesTest.py
+++ b/Testing/SystemTests/tests/framework/AlignAndFocusPowderFromFilesTest.py
@@ -259,7 +259,7 @@ class AbsorptionCompare(systemtesting.MantidSystemTest):
         SetSample(InputWorkspace='V_abs',
                   Material={'ChemicalFormula': 'V', 'SampleNumberDensity': 0.0721},
                   Geometry={'Shape': 'Cylinder', 'Height': 6.97, 'Radius': (0.63 / 2), 'Center': [0., 0., 0.]})
-        self.assertEqual(absorptionWS.getNumberBins(), num_wl_bins)
+        self.assertEqual(absorptionWS.blocksize(), num_wl_bins)
         # calculate the absorption
         CylinderAbsorption(InputWorkspace='V_abs', OutputWorkspace='V_abs',
                            NumberOfSlices=20, NumberOfAnnuli=3)

--- a/docs/source/release/v6.0.0/mantidworkbench.rst
+++ b/docs/source/release/v6.0.0/mantidworkbench.rst
@@ -50,5 +50,6 @@ Bugfixes
 - Fix sort order of peaks in the peaks overlay on SliceViewer.
 - The colorfill plot on ragged workspaces will have the correct horizontal extent.
 - Fix replot of colorfill image after a workspace is replaced.
+- Fixed a bug causing an error when double clicking a ragged workspace.
 
 :ref:`Release 6.0.0 <v6.0.0>`

--- a/qt/applications/workbench/workbench/plugins/test/test_workspacewidget.py
+++ b/qt/applications/workbench/workbench/plugins/test/test_workspacewidget.py
@@ -39,6 +39,13 @@ class WorkspaceWidgetTest(unittest.TestCase, QtWidgetFinder):
         table_ws = CreateEmptyTableWorkspace()
         group_ws = GroupWorkspaces([mat_ws, table_ws])
         single_val_ws = CreateSingleValuedWorkspace(5, 6)
+
+        # Create ragged workspace
+        ws2d_ragged = CreateWorkspace(DataX=[10, 20, 30], DataY=[1, 2, 3], NSpec=1, OutputWorkspace='Ragged')
+        temp = CreateWorkspace(DataX=[15, 25, 35, 45], DataY=[1, 2, 3, 4], NSpec=1)
+        ConjoinWorkspaces(ws2d_ragged, temp, CheckOverlapping=False)
+        ws2d_ragged = mantid.mtd['Ragged']
+
         self.w_spaces = [mat_ws, table_ws, group_ws, single_val_ws]
         self.ws_names = ['MatWS', 'TableWS', 'GroupWS', 'SingleValWS']
         # create md workspace
@@ -56,6 +63,8 @@ class WorkspaceWidgetTest(unittest.TestCase, QtWidgetFinder):
             self.ws_widget._ads.add(ws_name, ws)
         self.ws_names.append(md_ws.name())
         self.w_spaces.append(md_ws)
+        self.ws_names.append(ws2d_ragged.name())
+        self.w_spaces.append(ws2d_ragged)
 
     def tearDown(self):
         self.ws_widget._ads.clear()
@@ -131,6 +140,10 @@ class WorkspaceWidgetTest(unittest.TestCase, QtWidgetFinder):
         with mock.patch(MATRIXWORKSPACE_DISPLAY + '.show_view', lambda x: None):
             self.ws_widget._action_double_click_workspace(self.ws_names[3])
         self.assert_widget_type_exists(MATRIXWORKSPACE_DISPLAY_TYPE)
+
+    def test_double_click_with_ragged_ws_does_not_show_data_and_therefore_plots_it_instead(self):
+        self.ws_widget._action_double_click_workspace(self.ws_names[5])
+        self.assert_widget_type_doesnt_exist(MATRIXWORKSPACE_DISPLAY_TYPE)
 
     def test_empty_workspaces(self):
         self.ws_widget._ads.clear()

--- a/qt/applications/workbench/workbench/plugins/test/test_workspacewidget.py
+++ b/qt/applications/workbench/workbench/plugins/test/test_workspacewidget.py
@@ -142,10 +142,12 @@ class WorkspaceWidgetTest(unittest.TestCase, QtWidgetFinder):
             self.ws_widget._action_double_click_workspace(self.ws_names[3])
         self.assert_widget_type_exists(MATRIXWORKSPACE_DISPLAY_TYPE)
 
-    def test_double_click_with_ragged_ws_does_not_raise(self):
+    @mock.patch('mantidqt.plotting.functions.plot_from_names', autospec=True)
+    def test_double_click_with_ragged_ws_calls_plot_from_names(self, mock_plot_from_names):
         self.assertTrue(self.w_spaces[5].isRaggedWorkspace())
-        with mock.patch(MATRIXWORKSPACE_DISPLAY + '.show_view', lambda x: None):
-            self.ws_widget._action_double_click_workspace(self.ws_names[5])
+        self.ws_widget._action_double_click_workspace(self.ws_names[5])
+        mock_plot_from_names.assert_called_once_with([self.ws_names[5]], errors=False, overplot=False,
+                                                     show_colorfill_btn=True)
 
     def test_empty_workspaces(self):
         self.ws_widget._ads.clear()

--- a/qt/applications/workbench/workbench/plugins/test/test_workspacewidget.py
+++ b/qt/applications/workbench/workbench/plugins/test/test_workspacewidget.py
@@ -142,9 +142,10 @@ class WorkspaceWidgetTest(unittest.TestCase, QtWidgetFinder):
             self.ws_widget._action_double_click_workspace(self.ws_names[3])
         self.assert_widget_type_exists(MATRIXWORKSPACE_DISPLAY_TYPE)
 
-    def test_double_click_with_ragged_ws_does_not_show_data_and_therefore_plots_it_instead(self):
-        self.ws_widget._action_double_click_workspace(self.ws_names[5])
-        self.assert_widget_type_doesnt_exist(MATRIXWORKSPACE_DISPLAY_TYPE)
+    def test_double_click_with_ragged_ws_does_not_raise(self):
+        self.assertTrue(self.w_spaces[5].isRaggedWorkspace())
+        with mock.patch(MATRIXWORKSPACE_DISPLAY + '.show_view', lambda x: None):
+            self.ws_widget._action_double_click_workspace(self.ws_names[5])
 
     def test_empty_workspaces(self):
         self.ws_widget._ads.clear()

--- a/qt/applications/workbench/workbench/plugins/test/test_workspacewidget.py
+++ b/qt/applications/workbench/workbench/plugins/test/test_workspacewidget.py
@@ -11,8 +11,9 @@ import unittest
 from unittest import mock
 
 import matplotlib as mpl
-from mantid.simpleapi import (CreateEmptyTableWorkspace, CreateSampleWorkspace,
-                              GroupWorkspaces, CreateSingleValuedWorkspace, CreateMDHistoWorkspace)
+from mantid.api import AnalysisDataService
+from mantid.simpleapi import (CreateEmptyTableWorkspace, CreateSampleWorkspace, CreateSingleValuedWorkspace,
+                              CreateMDHistoWorkspace, CreateWorkspace, ConjoinWorkspaces, GroupWorkspaces)
 from mantidqt.utils.qt.testing import start_qapplication
 from mantidqt.utils.qt.testing.qt_widget_finder import QtWidgetFinder
 from qtpy.QtWidgets import QMainWindow
@@ -44,7 +45,7 @@ class WorkspaceWidgetTest(unittest.TestCase, QtWidgetFinder):
         ws2d_ragged = CreateWorkspace(DataX=[10, 20, 30], DataY=[1, 2, 3], NSpec=1, OutputWorkspace='Ragged')
         temp = CreateWorkspace(DataX=[15, 25, 35, 45], DataY=[1, 2, 3, 4], NSpec=1)
         ConjoinWorkspaces(ws2d_ragged, temp, CheckOverlapping=False)
-        ws2d_ragged = mantid.mtd['Ragged']
+        ws2d_ragged = AnalysisDataService.retrieve('Ragged')
 
         self.w_spaces = [mat_ws, table_ws, group_ws, single_val_ws]
         self.ws_names = ['MatWS', 'TableWS', 'GroupWS', 'SingleValWS']

--- a/qt/applications/workbench/workbench/plugins/workspacewidget.py
+++ b/qt/applications/workbench/workbench/plugins/workspacewidget.py
@@ -289,7 +289,7 @@ class WorkspaceWidget(PluginWidget):
             TableWorkspaceDisplay.supports(ws)
             self._do_show_data([name])
         except ValueError:
-            if hasattr(ws, 'blocksize') and ws.blocksize() == 1:
+            if hasattr(ws, 'getMaxNumberBins') and ws.getMaxNumberBins() == 1:
                 #If this is ws is just a single value show the data, else plot the bin
                 if hasattr(ws, 'getNumberHistograms') and ws.getNumberHistograms() == 1:
                     self._do_show_data([name])

--- a/qt/python/mantidqt/utils/testing/mocks/mock_mantid.py
+++ b/qt/python/mantidqt/utils/testing/mocks/mock_mantid.py
@@ -75,6 +75,7 @@ class MockWorkspace:
         self.getNumberHistograms = StrictMock(return_value=1)
         self.isHistogramData = StrictMock(return_value=isHistogramData)
         self.blocksize = StrictMock(return_value=len(read_return))
+        self.getMaxNumberBins = StrictMock(return_value=len(read_return))
         self.readX = StrictMock(return_value=read_return)
         self.readY = StrictMock(return_value=read_return)
         self.readE = StrictMock(return_value=read_return)

--- a/qt/python/mantidqt/widgets/workspacedisplay/matrix/table_view_model.py
+++ b/qt/python/mantidqt/widgets/workspacedisplay/matrix/table_view_model.py
@@ -61,7 +61,7 @@ class MatrixWorkspaceTableViewModel(QAbstractTableModel):
         self.ws = ws
         self.ws_spectrum_info = self.ws.spectrumInfo()
         self.row_count = self.ws.getNumberHistograms()
-        self.column_count = self._get_column_count()
+        self.column_count = self.ws.getMaxNumberBins()
 
         self.masked_rows_cache = []
         self.monitor_rows_cache = []
@@ -89,29 +89,6 @@ class MatrixWorkspaceTableViewModel(QAbstractTableModel):
             self.relevant_data = self.ws.readDx
         else:
             raise ValueError("Unknown model type {0}".format(self.type))
-
-    def _get_column_count(self):
-        """
-        Gets the size of the spectrum data in the workspace (i.e. number of bins). If blocksize fails, then the
-        workspace is ragged.
-        :return: The number of columns required to display the workspace in a table.
-        """
-        try:
-            return self.ws.blocksize()
-        except RuntimeError:
-            return self._get_max_column_count()
-
-    def _get_max_column_count(self):
-        """
-        Gets the number of columns required to display the workspace. This method is used for ragged workspaces.
-        :return: The number of columns required to display the workspace in a table.
-        """
-        max_column_count = 0
-        for i in range(self.ws.getNumberHistograms()):
-            column_count = len(self.ws.readY(i))
-            if column_count > max_column_count:
-                max_column_count = column_count
-        return max_column_count
 
     def _makeVerticalHeader(self, section, role):
         def _numeric_axis_value_unit(axis):

--- a/scripts/Diffraction/isis_powder/test/ISISPowderCommonTest.py
+++ b/scripts/Diffraction/isis_powder/test/ISISPowderCommonTest.py
@@ -392,14 +392,14 @@ class ISISPowderCommonTest(unittest.TestCase):
                                           Function='Flat background', NumBanks=1, BankPixelWidth=1, XMax=10, BinWidth=1)
         new_bin_width = 0.5
         # Originally had bins at 1 unit each. So binning of 0.5 should give us 2n bins back
-        original_number_bins = ws.getNumberBins()
+        original_number_bins = ws.blocksize()
         original_first_x_val = ws.readX(0)[0]
         original_last_x_val = ws.readX(0)[-1]
 
         expected_bins = original_number_bins * 2
 
         ws = common.rebin_workspace(workspace=ws, new_bin_width=new_bin_width)
-        self.assertEqual(ws.getNumberBins(), expected_bins)
+        self.assertEqual(ws.blocksize(), expected_bins)
 
         # Check bin boundaries were preserved
         self.assertEqual(ws.readX(0)[0], original_first_x_val)
@@ -413,7 +413,7 @@ class ISISPowderCommonTest(unittest.TestCase):
         # Originally we had 10 bins from 0, 10. Resize from 0, 0.5, 5 so we should have the same number of output
         # bins with different boundaries
         new_bin_width = 0.5
-        original_number_bins = ws.getNumberBins()
+        original_number_bins = ws.blocksize()
 
         expected_start_x = 1
         expected_end_x = 6
@@ -422,7 +422,7 @@ class ISISPowderCommonTest(unittest.TestCase):
                                     start_x=expected_start_x, end_x=expected_end_x)
 
         # Check number of bins is the same as we halved the bin width and interval so we should have n bins
-        self.assertEqual(ws.getNumberBins(), original_number_bins)
+        self.assertEqual(ws.blocksize(), original_number_bins)
 
         # Check bin boundaries were changed
         self.assertEqual(ws.readX(0)[0], expected_start_x)


### PR DESCRIPTION
**Description of work.**
This PR fixes a bug where an error message appears after double clicking a ragged workspace in the ADS.

The problem was caused by the `blocksize` method (which is not compatible with ragged workspaces). The ongoing issues with ragged workspaces has shown there are several missing methods in the MatrixWorkspace API. @martyngigg has suggested adding:

- `getNumberBins(std::size_t index)` can now be used to find the number of bins for a given histogram index.
- `getMaxNumberBins()` will get the maximum number of bins in a workspace (useful for ragged workspaces)!

These have been added in this PR.

**To test:**
1. Run this code to create a ragged workspace:
```
ws = CreateWorkspace([0,1,2,3,4,2, 3,4,5,6],[0,1,2,3,4,3,4,5,6,7], NSpec=2)
min = 1
max = 6
for j in range(0,2):
    x =[]
    y =[]
    data = ws.readY(j)
    k=0
    for v in ws.readX(j):
        if v >= min and v<=max:
            x.append(v)
            y.append(data[k])
        k+=1
    tmp = CreateWorkspace(x,y)
    ConjoinWorkspaces(ws, tmp, CheckOverlapping=False)
```
2. Double click the ragged workspace in the ADS. The plot dialog should appear, and no error in the logger.

Fixes #30071

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
