### PR TITLE
Missing string include

### DIFF
--- a/Framework/Geometry/src/Rendering/RenderingHelpersThrowing.cpp
+++ b/Framework/Geometry/src/Rendering/RenderingHelpersThrowing.cpp
@@ -6,6 +6,7 @@
 // SPDX - License - Identifier: GPL - 3.0 +
 #include "MantidGeometry/Rendering/RenderingHelpers.h"
 #include <stdexcept>
+#include <string>
 
 namespace {
 void throwNoOpenGLError(const std::string &function) {


### PR DESCRIPTION
Simple fix for compiler error as a result of concatenating `string` and `const char *`
This is only apparent when `ENABLE_OPENGL=OFF` - seen during conda build for mantid-framework on osx because of this implementation file is only compiled under those conditions.