### PR TITLE
Use temp dir for settings

### DIFF
--- a/scripts/Engineering/gui/engineering_diffraction/settings/test/test_settings_helper.py
+++ b/scripts/Engineering/gui/engineering_diffraction/settings/test/test_settings_helper.py
@@ -11,6 +11,7 @@ from qtpy.QtCore import QSettings, QCoreApplication
 from shutil import rmtree
 from os.path import dirname
 
+import tempfile
 import unittest
 
 GROUP = "CustomInterfaces"
@@ -32,6 +33,8 @@ class SettingsHelperTest(unittest.TestCase):
         QCoreApplication.setApplicationName("test1")
         QCoreApplication.setOrganizationName("org1")
         QSettings.setDefaultFormat(QSettings.IniFormat)
+        cls.settings_dir = tempfile.TemporaryDirectory()
+        QSettings.setPath(QSettings.IniFormat, QSettings.UserScope, cls.settings_dir.name)
 
     def test_set_setting_with_string(self):
         set_setting(GROUP, PREFIX, "something", "value")


### PR DESCRIPTION
Removes race condition on settings file for parallel runs

Fixes #29933

**Description of work.**

Test failed if it was unable to delete `~/.config/org1/` in the `tearDown()`. This can happen if a file is created in that directory while `rmtree()` is running. The tests within the class run in serial, so this can only happen if another test uses the same directory (none appear to) or multiple instances of the testsuite are run simultaneously with a shared home director.

Fix is to make a temporary directory and passing that to QSettings. It is at class level, so it is not cleaned up until the class is destructed.

**To test:**

Hard to trigger naturally. But can trigger by running the following commands simultaneously:
```
while true; do touch /home/sam/.config/org1/foo.ini ; sleep 0.1 ; done
while ctest3 --output-on-failure --tests-regex python.EngineeringDiffraction.test_settings_helper.test_settings_helper ; do true ; done
```
With change test1.ini is created in a different temp directory on each run.

Fixes #29933 

Not sure if an where this should be in the release notes?

<!-- Ensure the base of this PR is correct (e.g. release-next or master)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
