### PR TITLE
Add check for valid energy transfers in PyChop

### DIFF
--- a/scripts/PyChop/Instruments.py
+++ b/scripts/PyChop/Instruments.py
@@ -775,6 +775,11 @@ class Instrument(object):
         # If not set, sets energy transfers to values to compare exactly to RAE's original implementation.
         if Etrans is None:
             Etrans = np.linspace(0.05*Ei, 0.95*Ei+0.05*0.05*Ei, 19, endpoint=True)
+        Etrans = np.array(Etrans if np.shape(Etrans) else [Etrans])
+        Etrans[np.where(Etrans == Ei)] = Ei - 1e-6
+        if len(np.where(Etrans > Ei)[0]) > 0:
+            raise ValueError('Cannot calculate for energy transfer greater than Ei '
+                             '(physically negative neutron energies!)')
         v_van, _, _ = self.getVanVar(Ei, frequency, Etrans)
         x2 = self.chopper_system.sam_det
         Ef = Ei - np.array(Etrans)

--- a/scripts/PyChop/Instruments.py
+++ b/scripts/PyChop/Instruments.py
@@ -776,10 +776,9 @@ class Instrument(object):
         if Etrans is None:
             Etrans = np.linspace(0.05*Ei, 0.95*Ei+0.05*0.05*Ei, 19, endpoint=True)
         Etrans = np.array(Etrans if np.shape(Etrans) else [Etrans])
-        Etrans[np.where(Etrans == Ei)] = Ei - 1e-6
         if len(np.where(Etrans > Ei)[0]) > 0:
-            raise ValueError('Cannot calculate for energy transfer greater than Ei '
-                             '(physically negative neutron energies!)')
+            warnings.warn('Cannot calculate for energy transfer greater than Ei (physically negative neutron energies!)')
+        Etrans[np.where(Etrans >= Ei)] = np.nan
         v_van, _, _ = self.getVanVar(Ei, frequency, Etrans)
         x2 = self.chopper_system.sam_det
         Ef = Ei - np.array(Etrans)

--- a/scripts/test/PyChopTest.py
+++ b/scripts/test/PyChopTest.py
@@ -7,6 +7,7 @@
 """Test suite for the PyChop package
 """
 import unittest
+import warnings
 import numpy as np
 
 from PyChop import PyChop2
@@ -72,6 +73,16 @@ class PyChop2Tests(unittest.TestCase):
             rr, ff = PyChop2.calculate('LET', variant, 200, 18, 0)
             self.assertAlmostEqual(rr[0], res[inc][0], places=7)
             self.assertAlmostEqual(ff, flux[inc], places=7)
+
+    def test_pychop_invalid_ei(self):
+        chopobj = PyChop2('MARI', 'G', 400.)
+        chopobj.setEi(120)
+        with warnings.catch_warnings(record=True) as w:
+            res = chopobj.getResolution(130.)
+            assert len(w) == 1
+            assert issubclass(w[0].category, UserWarning)
+            assert "Cannot calculate for energy transfer greater than Ei" in str(w[0].message)
+            assert np.isnan(res[0])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
**Description of work.**

Adds a check in the `getResolution` method of PyChop for when the user inputted energy transfer (EN) is either equal to or greater than the incident energy (Ei). If `EN>Ei` we have negative neutron energies which is unphysical. If `EN==Ei` we have zero neutron energy which is not unphysical but is undetectable (e.g. neutrons should never arrive at the detector). 

In both cases, the calculation of the resolution is invalid but there are situations where users want to give such input (an example is in the CrystalField documentation: https://docs.mantidproject.org/nightly/interfaces/Crystal%20Field%20Python%20Interface.html#defining-multiple-spectra where the resolution model is defined for multiple spectra with different Ei's and the resolution model can only be given a single energy transfer range.

Thus, in order to not break existing scripts, these values should be changed to `nan` and a warning emitted rather than an error.

**Report to:** Tatiana

**To test:**

<!-- Instructions for testing. -->

Fixes #30086. <!-- and fix #xxxx or close #xxxx xor resolves #xxxx -->
<!-- alternative
*There is no associated issue.*
-->

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
-->

Run the following script:

```python
import mantid
from PyChop import PyChop2
from CrystalField import ResolutionModel

marires = PyChop2('MARI', 'G', 400.)
marires.setEi(120)
rm = ResolutionModel(marires.getResolution, xstart=-120, xend=120, accuracy=0.01)
print(rm.model)
```

and check there is no error and no warnings. If `xend` is changed to be strictly greater than `120` (e.g. Ei) then a warning would be emitted and there will be `nan` in the output `rm.model` but there should be no errors.

<!-- Ensure the base of this PR is correct (e.g. release-next or master)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
