### PR TITLE
Allowing group workspaces as output in WANDPowderReduction algorithm

### DIFF
--- a/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/WANDPowderReduction.py
+++ b/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/WANDPowderReduction.py
@@ -202,7 +202,7 @@ class WANDPowderReduction(DataProcessorAlgorithm):
             if summing:
                 # conjoin
                 if n < 1:
-                    CloneWorkspace(
+                    RenameWorkspace(
                         InputWorkspace=_wsn,
                         OutputWorkspace="__ws_conjoined",
                         EnableLogging=False,
@@ -308,6 +308,7 @@ class WANDPowderReduction(DataProcessorAlgorithm):
         mask = self.getProperty("MaskWorkspace").value
         mask_angle = self.getProperty("MaskAngle").value
         outname = self.getProperty("OutputWorkspace").valueAsStr
+        summing = self.getProperty("Sum").value
 
         # NOTE:
         # Due to range difference among incoming spectra, a common bin para is needed
@@ -317,6 +318,7 @@ class WANDPowderReduction(DataProcessorAlgorithm):
         output_workspaces = [f'{outname}{n+1}' for n in range(len(input_workspaces))]
         mask_workspaces = []
         for n, (_wksp_in, _wksp_out) in enumerate(zip(input_workspaces, output_workspaces)):
+            _wksp_in = str(_wksp_in)
             _mask_n = f'__mask_{n}'  # mask for n-th
             self.temp_workspace_list.append(_mask_n)  # cleanup later
 
@@ -392,6 +394,7 @@ class WANDPowderReduction(DataProcessorAlgorithm):
 
         # create unique name for this background
         outname = str(current_background) + str(current_workspace)
+        self.temp_workspace_list.append(outname)
 
         self._to_spectrum_axis_resample(current_background, outname, make_name,
                                         current_workspace, x_min, x_max)

--- a/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/WANDPowderReduction.py
+++ b/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/WANDPowderReduction.py
@@ -149,7 +149,6 @@ class WANDPowderReduction(DataProcessorAlgorithm):
         numberBins = self.getProperty("NumberBins").value
         outWS = self.getPropertyValue("OutputWorkspace")
         summing = self.getProperty("Sum").value  # [Yes or No]
-        outWksp = self.getPropertyValue("OutputWorkspace")
 
         # convert all of the input workspaces into spectrum of "target" units (generally angle)
         data, masks = self._convert_data(data)
@@ -221,7 +220,7 @@ class WANDPowderReduction(DataProcessorAlgorithm):
         # ref: https://docs.mantidproject.org/nightly/algorithms/SumSpectra-v1.html
         if summing:
             if cal is not None:
-                SumSpectra(
+                outWS = SumSpectra(
                     InputWorkspace="__ws_conjoined",
                     OutputWorkspace=outWS,
                     WeightedSum=True,
@@ -229,7 +228,7 @@ class WANDPowderReduction(DataProcessorAlgorithm):
                     EnableLogging=False,
                 )
             else:
-                SumSpectra(
+                outWS = SumSpectra(
                     InputWorkspace="__ws_conjoined",
                     OutputWorkspace=outWS,
                     WeightedSum=True,
@@ -238,8 +237,12 @@ class WANDPowderReduction(DataProcessorAlgorithm):
                 )
 
         else:
-            outWS = GroupWorkspaces(data)
-            print(outWS.getNames())
+            if len(data) == 1:
+                outWS = RenameWorkspace(InputWorkspace=data[0],
+                                OutputWorkspace=outWS)
+            else:
+                outWS = GroupWorkspaces(InputWorkspaces=data,
+                                        OutputWorkspace=outWS)
 
         self.setProperty("OutputWorkspace", outWS)
 
@@ -306,7 +309,7 @@ class WANDPowderReduction(DataProcessorAlgorithm):
         mask = self.getProperty("MaskWorkspace").value
         mask_angle = self.getProperty("MaskAngle").value
         outname = self.getProperty("OutputWorkspace").valueAsStr
-        
+
         # NOTE:
         # Due to range difference among incoming spectra, a common bin para is needed
         # such that all data can be binned exactly the same way.

--- a/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/WANDPowderReduction.py
+++ b/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/WANDPowderReduction.py
@@ -34,7 +34,7 @@ from mantid.simpleapi import (
     BinaryOperateMasks,
     Integration,
     GroupWorkspaces,
-    RenameWorkspaces,
+    RenameWorkspace,
 )
 from mantid.kernel import (
     StringListValidator,
@@ -235,7 +235,6 @@ class WANDPowderReduction(DataProcessorAlgorithm):
                     MultiplyBySpectra=True,
                     EnableLogging=False,
                 )
-
         else:
             if len(data) == 1:
                 outWS = RenameWorkspace(InputWorkspace=data[0],
@@ -315,14 +314,10 @@ class WANDPowderReduction(DataProcessorAlgorithm):
         # such that all data can be binned exactly the same way.
 
         # BEGIN_FOR: located_global_xMin&xMax
-        #output_workspaces = [f'{outname}{n+1}' for n in range(len(input_workspaces))]
-        #mask_workspaces = [f'{mask}{n+1}' for n in range(len(input_workspaces))]
-        #for _wksp_in, _mask_n, _wksp_out in zip(input_workspaces, mask_workspaces, output_workspaces):
         output_workspaces = [f'{outname}{n+1}' for n in range(len(input_workspaces))]
         mask_workspaces = []
         for n, (_wksp_in, _wksp_out) in enumerate(zip(input_workspaces, output_workspaces)):
             _mask_n = f'__mask_{n}'  # mask for n-th
-            #_wksp_out = output_workspaces[n]    # output workspace for n-th
             self.temp_workspace_list.append(_mask_n)  # cleanup later
 
             ExtractMask(InputWorkspace=_wksp_in, OutputWorkspace=_mask_n, EnableLogging=False)
@@ -344,9 +339,8 @@ class WANDPowderReduction(DataProcessorAlgorithm):
                 )
 
             self._to_spectrum_axis(_wksp_in, _wksp_out, _mask_n)
-
-            # append to the list of processed workspaces
-            output_workspaces.append(_wksp_out)
+            
+            #append to the list of processed workspaces
             mask_workspaces.append(_mask_n)
 
         return output_workspaces, mask_workspaces

--- a/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/WANDPowderReduction.py
+++ b/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/WANDPowderReduction.py
@@ -179,7 +179,6 @@ class WANDPowderReduction(DataProcessorAlgorithm):
             else:
                 _ws_cal_resampled = None
 
-
             Scale(
                 InputWorkspace=_wsn,
                 OutputWorkspace=_wsn,
@@ -193,7 +192,7 @@ class WANDPowderReduction(DataProcessorAlgorithm):
                     bkg, _wsn, _mskn, xMin, xMax, _ws_cal_resampled
                 )
 
-                _ws_resampled = Minus(
+                Minus(
                     LHSWorkspace=_wsn,
                     RHSWorkspace=_ws_bkg_resampled,
                     OutputWorkspace=_wsn,
@@ -217,9 +216,7 @@ class WANDPowderReduction(DataProcessorAlgorithm):
                         EnableLogging=False,
                     )
 
-
         # END_FOR: prcess_spectra
-
         # Step_3: sum all spectra
         # ref: https://docs.mantidproject.org/nightly/algorithms/SumSpectra-v1.html
         if summing:
@@ -242,7 +239,7 @@ class WANDPowderReduction(DataProcessorAlgorithm):
         else:
             if len(data) == 1:
                 outWS = RenameWorkspace(InputWorkspace=data[0],
-                                OutputWorkspace=outWS)
+                                        OutputWorkspace=outWS)
             else:
                 outWS = GroupWorkspaces(InputWorkspaces=data,
                                         OutputWorkspace=outWS)
@@ -271,7 +268,6 @@ class WANDPowderReduction(DataProcessorAlgorithm):
                 return mtd[str(x)].run().getLogData("duration").value
             else:
                 raise ValueError(f"Unknown normalize type: {normaliseBy}")
-
 
     def _to_spectrum_axis(self, workspace_in, workspace_out, mask, instrument_donor=None):
         target = self.getProperty("Target").value

--- a/Framework/PythonInterface/test/python/plugins/algorithms/WorkflowAlgorithms/WANDPowderReductionTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/WorkflowAlgorithms/WANDPowderReductionTest.py
@@ -11,10 +11,8 @@ from mantid.simpleapi import (
     MoveInstrumentComponent,
     CloneWorkspace,
     AddSampleLog,
-    GroupWorkspaces,
 )
 from mantid.api import (
-    IEventWorkspace,
     MatrixWorkspace,
     WorkspaceGroup,
 )
@@ -368,12 +366,12 @@ class WANDPowderReductionTest(unittest.TestCase):
             NormaliseBy="None",
             Sum=False,
         )
-        
+
         assert isinstance(pd_out, MatrixWorkspace)
 
         x = pd_out.extractX()
         y = pd_out.extractY()
-        
+
         print(x.min(), x.max())
 
         self.assertAlmostEqual(x.min(), 0.03517355)
@@ -391,7 +389,7 @@ class WANDPowderReductionTest(unittest.TestCase):
             NormaliseBy="None",
             Sum=True,
         )
-        
+
         x = pd_out.extractX()
         y = pd_out.extractY()
 
@@ -399,7 +397,7 @@ class WANDPowderReductionTest(unittest.TestCase):
         self.assertAlmostEqual(x.max(), 70.3119282)
         self.assertAlmostEqual(y[0, 0], 0.0)
         assert isinstance(pd_out, MatrixWorkspace)
-        
+
         #CASE 3
         #DOES NOT WORK YET -- currently outputs Workspace2D -- will modify when algorithm is updated
         #input group ws containing several ws, output group ws containing several ws
@@ -412,7 +410,7 @@ class WANDPowderReductionTest(unittest.TestCase):
             NormaliseBy="None",
             Sum=False,
         )
-        
+
         print(pd_out.getNumberOfEntries())
 
         for i in pd_out:
@@ -426,7 +424,6 @@ class WANDPowderReductionTest(unittest.TestCase):
 
         assert isinstance(pd_out, WorkspaceGroup)
         assert len(pd_out) == 2
-
 
 
 if __name__ == "__main__":

--- a/Framework/PythonInterface/test/python/plugins/algorithms/WorkflowAlgorithms/WANDPowderReductionTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/WorkflowAlgorithms/WANDPowderReductionTest.py
@@ -372,8 +372,6 @@ class WANDPowderReductionTest(unittest.TestCase):
         x = pd_out.extractX()
         y = pd_out.extractY()
 
-        print(x.min(), x.max())
-
         self.assertAlmostEqual(x.min(), 0.03517355)
         self.assertAlmostEqual(x.max(), 70.3119282)
         self.assertAlmostEqual(y[0, 0], 0.0)
@@ -398,11 +396,16 @@ class WANDPowderReductionTest(unittest.TestCase):
         self.assertAlmostEqual(y[0, 0], 0.0)
         assert isinstance(pd_out, MatrixWorkspace)
 
+        event_data2 = CloneWorkspace(event_data)
+
+        group = WorkspaceGroup()
+        group.addWorkspace(event_data)
+        group.addWorkspace(event_data2)
+
         #CASE 3
-        #DOES NOT WORK YET -- currently outputs Workspace2D -- will modify when algorithm is updated
         #input group ws containing several ws, output group ws containing several ws
         pd_out = WANDPowderReduction(
-            InputWorkspace=[event_data,event_data],
+            InputWorkspace=group,
             CalibrationWorkspace=event_cal,
             BackgroundWorkspace=event_bkg,
             Target="Theta",
@@ -411,10 +414,36 @@ class WANDPowderReductionTest(unittest.TestCase):
             Sum=False,
         )
 
-        print(pd_out.getNumberOfEntries())
-
         for i in pd_out:
 
+            x = i.extractX()
+            y = i.extractY()
+
+            self.assertAlmostEqual(x.min(), 0.03517355)
+            self.assertAlmostEqual(x.max(), 70.3119282)
+            self.assertAlmostEqual(y[0, 0], 0.0)
+
+        assert isinstance(pd_out, WorkspaceGroup)
+        assert len(pd_out) == 2
+
+        event_data2 = CloneWorkspace(event_data)
+
+        group = WorkspaceGroup()
+        group.addWorkspace(event_data)
+        group.addWorkspace(event_data2)
+
+        #CASE 4 - input group ws, output group ws
+        pd_out = WANDPowderReduction(
+            InputWorkspace=group,
+            CalibrationWorkspace=event_cal,
+            BackgroundWorkspace=event_bkg,
+            Target="Theta",
+            NumberBins=1000,
+            NormaliseBy="None",
+            Sum=False,
+        )
+
+        for i in pd_out:
             x = i.extractX()
             y = i.extractY()
 

--- a/Framework/PythonInterface/test/python/plugins/algorithms/WorkflowAlgorithms/WANDPowderReductionTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/WorkflowAlgorithms/WANDPowderReductionTest.py
@@ -340,13 +340,6 @@ class WANDPowderReductionTest(unittest.TestCase):
             BankPixelWidth=100,
             WorkspaceType="Event",
         )
-        event_data2 = CreateSampleWorkspace(
-            NumBanks=1,
-            BinWidth=20000,
-            PixelSpacing=0.1,
-            BankPixelWidth=100,
-            WorkspaceType="Event",
-        )
         event_cal = CreateSampleWorkspace(
             NumBanks=1,
             BinWidth=20000,
@@ -415,13 +408,8 @@ class WANDPowderReductionTest(unittest.TestCase):
         #CASE 3
         #DOES NOT WORK YET -- currently outputs Workspace2D -- will modify when algorithm is updated
         #input group ws containing several ws, output group ws containing several ws
-        groupWS = WorkspaceGroup()
-        groupWS.addWorkspace(event_data)
-        groupWS.addWorkspace(event_data2)
-
-        
         pd_out = WANDPowderReduction(
-            InputWorkspace=groupWS,
+            InputWorkspace=[event_data,event_data],
             CalibrationWorkspace=event_cal,
             BackgroundWorkspace=event_bkg,
             Target="Theta",

--- a/Framework/PythonInterface/test/python/plugins/algorithms/WorkflowAlgorithms/WANDPowderReductionTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/WorkflowAlgorithms/WANDPowderReductionTest.py
@@ -197,7 +197,7 @@ class WANDPowderReductionTest(unittest.TestCase):
         pd_out3_multi = WANDPowderReduction(
             InputWorkspace=[data, data],
             CalibrationWorkspace=cal,
-            BackgroundWorkspace="bkg,bkg",
+            BackgroundWorkspace=bkg,
             Target="Theta",
             NumberBins=1000,
             NormaliseBy="Time",
@@ -234,7 +234,7 @@ class WANDPowderReductionTest(unittest.TestCase):
         pd_out4_multi = WANDPowderReduction(
             InputWorkspace=[data, data],
             CalibrationWorkspace=cal,
-            BackgroundWorkspace="bkg,bkg",
+            BackgroundWorkspace=bkg,
             Target="ElasticDSpacing",
             EFixed=30,
             NumberBins=1000,
@@ -274,7 +274,7 @@ class WANDPowderReductionTest(unittest.TestCase):
         pd_out4_multi = WANDPowderReduction(
             InputWorkspace=[data, data],
             CalibrationWorkspace=cal,
-            BackgroundWorkspace="bkg,bkg",
+            BackgroundWorkspace=bkg,
             Target="ElasticQ",
             EFixed=30,
             NumberBins=2000,
@@ -313,7 +313,7 @@ class WANDPowderReductionTest(unittest.TestCase):
         pd_out4_multi = WANDPowderReduction(
             InputWorkspace=[data, data],
             CalibrationWorkspace=cal,
-            BackgroundWorkspace="bkg,bkg",
+            BackgroundWorkspace=bkg,
             BackgroundScale=0.5,
             Target="Theta",
             NumberBins=1000,
@@ -362,7 +362,7 @@ class WANDPowderReductionTest(unittest.TestCase):
             WorkspaceType="Event",
             Function="Flat background",
         )
-        
+
         #CASE 1
         #input single workspace, output single workspace
         pd_out = WANDPowderReduction(
@@ -382,13 +382,13 @@ class WANDPowderReductionTest(unittest.TestCase):
         self.assertAlmostEqual(x.max(), 70.3119282)
         self.assertAlmostEqual(y[0, 0], 0.0)
         assert isinstance(pd_out, MatrixWorkspace)
-        
+
         #CASE 2
         #input multiple single ws, output (single) summed ws
         pd_out = WANDPowderReduction(
             InputWorkspace=[event_data, event_data],
             CalibrationWorkspace=event_cal,
-            BackgroundWorkspace="event_bkg,event_bkg",
+            BackgroundWorkspace=event_bkg,
             Target="Theta",
             NumberBins=1000,
             NormaliseBy="None",
@@ -402,18 +402,18 @@ class WANDPowderReductionTest(unittest.TestCase):
         self.assertAlmostEqual(x.max(), 70.3119282)
         self.assertAlmostEqual(y[0, 0], 0.0)
         assert isinstance(pd_out, MatrixWorkspace)
-        
+
         #CASE 3
         #DOES NOT WORK YET -- currently outputs Workspace2D -- will modify when algorithm is updated
         #input group ws containing several ws, output group ws containing several ws
         groupWS = WorkspaceGroup()
         groupWS.addWorkspace(event_data)
         groupWS.addWorkspace(event_data2)
-        
+
         pd_out = WANDPowderReduction(
             InputWorkspace=groupWS,
             CalibrationWorkspace=event_cal,
-            BackgroundWorkspace="event_bkg,event_bkg",
+            BackgroundWorkspace=event_bkg,
             Target="Theta",
             NumberBins=1000,
             NormaliseBy="None",
@@ -428,14 +428,14 @@ class WANDPowderReductionTest(unittest.TestCase):
         self.assertAlmostEqual(y[0, 0], 0.0)
         assert isinstance(pd_out, WorkspaceGroup)
         assert len(pd_out) == 2
-        
+
         #CASE 4
         #DOES NOT WORK YET -- currently outputs Workspace2D -- will modify when algorithm is updated
         #input multiple single ws, output group ws containing several ws
         pd_out = WANDPowderReduction(
             InputWorkspace=[event_data, event_data],
             CalibrationWorkspace=event_cal,
-            BackgroundWorkspace="event_bkg,event_bkg",
+            BackgroundWorkspace=event_bkg,
             Target="Theta",
             NumberBins=1000,
             NormaliseBy="None",

--- a/Framework/PythonInterface/test/python/plugins/algorithms/WorkflowAlgorithms/WANDPowderReductionTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/WorkflowAlgorithms/WANDPowderReductionTest.py
@@ -400,7 +400,7 @@ class WANDPowderReductionTest(unittest.TestCase):
         # CASE 3
         # input group ws containing several ws, output group ws containing several ws
         pd_out = WANDPowderReduction(
-            InputWorkspace=[event_data,event_data],
+            InputWorkspace=[event_data, event_data],
             CalibrationWorkspace=event_cal,
             BackgroundWorkspace=event_bkg,
             Target="Theta",
@@ -450,7 +450,7 @@ class WANDPowderReductionTest(unittest.TestCase):
         assert len(pd_out) == 2
 
         event_data2 = CloneWorkspace(event_data)
-        event_data_group = GroupWorkspaces([event_data,event_data2])
+        event_data_group = GroupWorkspaces([event_data, event_data2])
 
         pd_out = WANDPowderReduction(
             InputWorkspace=event_data_group,
@@ -461,7 +461,7 @@ class WANDPowderReductionTest(unittest.TestCase):
             NormaliseBy="None",
             Sum=False,
         )
-        
+
         for i in pd_out:
             x = i.extractX()
             y = i.extractY()

--- a/Framework/PythonInterface/test/python/plugins/algorithms/WorkflowAlgorithms/WANDPowderReductionTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/WorkflowAlgorithms/WANDPowderReductionTest.py
@@ -396,16 +396,10 @@ class WANDPowderReductionTest(unittest.TestCase):
         self.assertAlmostEqual(y[0, 0], 0.0)
         assert isinstance(pd_out, MatrixWorkspace)
 
-        event_data2 = CloneWorkspace(event_data)
-
-        group = WorkspaceGroup()
-        group.addWorkspace(event_data)
-        group.addWorkspace(event_data2)
-
         # CASE 3
         # input group ws containing several ws, output group ws containing several ws
         pd_out = WANDPowderReduction(
-            InputWorkspace=group,
+            InputWorkspace=[event_data,event_data],
             CalibrationWorkspace=event_cal,
             BackgroundWorkspace=event_bkg,
             Target="Theta",

--- a/Framework/PythonInterface/test/python/plugins/algorithms/WorkflowAlgorithms/WANDPowderReductionTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/WorkflowAlgorithms/WANDPowderReductionTest.py
@@ -368,22 +368,17 @@ class WANDPowderReductionTest(unittest.TestCase):
             NormaliseBy="None",
             Sum=False,
         )
+        
+        assert isinstance(pd_out, MatrixWorkspace)
 
-        print(pd_out.getNumberOfEntries())
+        x = pd_out.extractX()
+        y = pd_out.extractY()
+        
+        print(x.min(), x.max())
 
-        for i in pd_out:
-
-            x = i.extractX()
-            y = i.extractY()
-            
-            print(x.min(), x.max())
-
-            self.assertAlmostEqual(x.min(), 0.03517355)
-            self.assertAlmostEqual(x.max(), 70.3119282)
-            self.assertAlmostEqual(y[0, 0], 0.0)
-
-        assert isinstance(pd_out, WorkspaceGroup)
-        assert len(pd_out) == 1
+        self.assertAlmostEqual(x.min(), 0.03517355)
+        self.assertAlmostEqual(x.max(), 70.3119282)
+        self.assertAlmostEqual(y[0, 0], 0.0)
 
         #CASE 2
         #input multiple single ws, output (single) summed ws

--- a/Framework/PythonInterface/test/python/plugins/algorithms/WorkflowAlgorithms/WANDPowderReductionTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/WorkflowAlgorithms/WANDPowderReductionTest.py
@@ -11,6 +11,7 @@ from mantid.simpleapi import (
     MoveInstrumentComponent,
     CloneWorkspace,
     AddSampleLog,
+    GroupWorkspaces,
 )
 from mantid.api import (
     IEventWorkspace,
@@ -375,13 +376,21 @@ class WANDPowderReductionTest(unittest.TestCase):
             Sum=False,
         )
 
-        x = pd_out.extractX()
-        y = pd_out.extractY()
+        print(pd_out.getNumberOfEntries())
 
-        self.assertAlmostEqual(x.min(), 0.03517355)
-        self.assertAlmostEqual(x.max(), 70.3119282)
-        self.assertAlmostEqual(y[0, 0], 0.0)
-        assert isinstance(pd_out, MatrixWorkspace)
+        for i in pd_out:
+
+            x = i.extractX()
+            y = i.extractY()
+            
+            print(x.min(), x.max())
+
+            self.assertAlmostEqual(x.min(), 0.03517355)
+            self.assertAlmostEqual(x.max(), 70.3119282)
+            self.assertAlmostEqual(y[0, 0], 0.0)
+
+        assert isinstance(pd_out, WorkspaceGroup)
+        assert len(pd_out) == 1
 
         #CASE 2
         #input multiple single ws, output (single) summed ws
@@ -394,7 +403,7 @@ class WANDPowderReductionTest(unittest.TestCase):
             NormaliseBy="None",
             Sum=True,
         )
-
+        
         x = pd_out.extractX()
         y = pd_out.extractY()
 
@@ -402,7 +411,7 @@ class WANDPowderReductionTest(unittest.TestCase):
         self.assertAlmostEqual(x.max(), 70.3119282)
         self.assertAlmostEqual(y[0, 0], 0.0)
         assert isinstance(pd_out, MatrixWorkspace)
-
+        
         #CASE 3
         #DOES NOT WORK YET -- currently outputs Workspace2D -- will modify when algorithm is updated
         #input group ws containing several ws, output group ws containing several ws
@@ -410,6 +419,7 @@ class WANDPowderReductionTest(unittest.TestCase):
         groupWS.addWorkspace(event_data)
         groupWS.addWorkspace(event_data2)
 
+        
         pd_out = WANDPowderReduction(
             InputWorkspace=groupWS,
             CalibrationWorkspace=event_cal,
@@ -419,37 +429,21 @@ class WANDPowderReductionTest(unittest.TestCase):
             NormaliseBy="None",
             Sum=False,
         )
+        
+        print(pd_out.getNumberOfEntries())
 
-        x = pd_out.extractX()
-        y = pd_out.extractY()
+        for i in pd_out:
 
-        self.assertAlmostEqual(x.min(), 0.03517355)
-        self.assertAlmostEqual(x.max(), 70.3119282)
-        self.assertAlmostEqual(y[0, 0], 0.0)
+            x = i.extractX()
+            y = i.extractY()
+
+            self.assertAlmostEqual(x.min(), 0.03517355)
+            self.assertAlmostEqual(x.max(), 70.3119282)
+            self.assertAlmostEqual(y[0, 0], 0.0)
+
         assert isinstance(pd_out, WorkspaceGroup)
         assert len(pd_out) == 2
 
-        #CASE 4
-        #DOES NOT WORK YET -- currently outputs Workspace2D -- will modify when algorithm is updated
-        #input multiple single ws, output group ws containing several ws
-        pd_out = WANDPowderReduction(
-            InputWorkspace=[event_data, event_data],
-            CalibrationWorkspace=event_cal,
-            BackgroundWorkspace=event_bkg,
-            Target="Theta",
-            NumberBins=1000,
-            NormaliseBy="None",
-            Sum=False,
-        )
-
-        x = pd_out.extractX()
-        y = pd_out.extractY()
-
-        self.assertAlmostEqual(x.min(), 0.03517355)
-        self.assertAlmostEqual(x.max(), 70.3119282)
-        self.assertAlmostEqual(y[0, 0], 0.0)
-        assert isinstance(pd_out, WorkspaceGroup)
-        assert len(pd_out) == 2
 
 
 if __name__ == "__main__":

--- a/Framework/PythonInterface/test/python/plugins/algorithms/WorkflowAlgorithms/WANDPowderReductionTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/WorkflowAlgorithms/WANDPowderReductionTest.py
@@ -355,8 +355,8 @@ class WANDPowderReductionTest(unittest.TestCase):
             Function="Flat background",
         )
 
-        #CASE 1
-        #input single workspace, output single workspace
+        # CASE 1
+        # input single workspace, output single workspace
         pd_out = WANDPowderReduction(
             InputWorkspace=event_data,
             CalibrationWorkspace=event_cal,
@@ -376,8 +376,8 @@ class WANDPowderReductionTest(unittest.TestCase):
         self.assertAlmostEqual(x.max(), 70.3119282)
         self.assertAlmostEqual(y[0, 0], 0.0)
 
-        #CASE 2
-        #input multiple single ws, output (single) summed ws
+        # CASE 2
+        # input multiple single ws, output (single) summed ws
         pd_out = WANDPowderReduction(
             InputWorkspace=[event_data, event_data],
             CalibrationWorkspace=event_cal,
@@ -402,8 +402,8 @@ class WANDPowderReductionTest(unittest.TestCase):
         group.addWorkspace(event_data)
         group.addWorkspace(event_data2)
 
-        #CASE 3
-        #input group ws containing several ws, output group ws containing several ws
+        # CASE 3
+        # input group ws containing several ws, output group ws containing several ws
         pd_out = WANDPowderReduction(
             InputWorkspace=group,
             CalibrationWorkspace=event_cal,
@@ -432,7 +432,7 @@ class WANDPowderReductionTest(unittest.TestCase):
         group.addWorkspace(event_data)
         group.addWorkspace(event_data2)
 
-        #CASE 4 - input group ws, output group ws
+        # CASE 4 - input group ws, output group ws
         pd_out = WANDPowderReduction(
             InputWorkspace=group,
             CalibrationWorkspace=event_cal,

--- a/docs/source/algorithms/WANDPowderReduction-v1.rst
+++ b/docs/source/algorithms/WANDPowderReduction-v1.rst
@@ -50,7 +50,8 @@ Usage
                        CalibrationWorkspace=vanadium,
                        Target='Theta',
                        NumberBins=1000,
-                       OutputWorkspace='silicon_powder')
+                       OutputWorkspace='silicon_powder',
+                       Sum=False)
 
 .. figure:: /images/WANDPowderReduction_silicon_powder.png
 
@@ -67,7 +68,8 @@ Usage
                        XMin=4.5,
                        Xmax=6.25,
                        NumberBins=500,
-                       OutputWorkspace='silicon_powder_q')
+                       OutputWorkspace='silicon_powder_q',
+                       Sum=False)
 
 .. figure:: /images/WANDPowderReduction_silicon_powder_q.png
 
@@ -82,7 +84,8 @@ Usage
                        CalibrationWorkspace=vanadium,
                        Target='ElasticDSpacing',
                        NumberBins=1000,
-                       OutputWorkspace='silicon_powder_d_spacing')
+                       OutputWorkspace='silicon_powder_d_spacing',
+                       Sum=False)
 
 .. figure:: /images/WANDPowderReduction_silicon_powder_d.png
 
@@ -104,7 +107,8 @@ Usage
                        BackgroundWorkspace=bkg,
                        Target='Theta',
                        NumberBins=1000,
-                       OutputWorkspace='silicon_powder_background')
+                       OutputWorkspace='silicon_powder_background',
+                       Sum=False)
 
    # Scale background by 50%
    WANDPowderReduction(InputWorkspace=silicon,
@@ -113,7 +117,8 @@ Usage
                        BackgroundScale=0.5,
                        Target='Theta',
                        NumberBins=1000,
-                       OutputWorkspace='silicon_powder_background_0.5')
+                       OutputWorkspace='silicon_powder_background_0.5',
+                       Sum=False)
 
 .. figure:: /images/WANDPowderReduction_silicon_powder_bkg.png
 
@@ -133,6 +138,7 @@ Usage
          NumberBins=1000,
          NormaliseBy='Time',
          OutputWorkspace=f'si1_reduced',
+         Sum=False,
          )
 
    # single ws
@@ -143,9 +149,10 @@ Usage
          NumberBins=1000,
          NormaliseBy='Time',
          OutputWorkspace=f'si2_reduced',
+         Sum=False,
          )
 
-   # merged ws
+   # merged ws - single (summed) output ws
    WANDPowderReduction(
          InputWorkspace=[si1, si2],
          CalibrationWorkspace=va0,
@@ -153,6 +160,18 @@ Usage
          NumberBins=1000,
          NormaliseBy='Time',
          OutputWorkspace=f'si_reduced',
+         Sum=True,
+         )
+         
+   # merged ws - group output ws
+   WANDPowderReduction(
+         InputWorkspace=[si1, si2],
+         CalibrationWorkspace=va0,
+         Target='Theta',
+         NumberBins=1000,
+         NormaliseBy='Time',
+         OutputWorkspace=f'si_reduced',
+         Sum=False,
          )
 
 .. figure:: /images/WANDPowderReduction_silicon_powder_multiple_input.png

--- a/docs/source/release/v6.0.0/diffraction.rst
+++ b/docs/source/release/v6.0.0/diffraction.rst
@@ -52,6 +52,10 @@ Bugfixes
 - Focus in PEARL powder diffraction scripts no longer fails if previous run has left Van splines workspace group in ADS
 
 
+Bugfixes
+########
+- :ref:`WANDPowderReduction <algm-WANDPowderReduction>` once again accepts multiple input workspaces and outputs a group workspace when specified by user.
+
 Engineering Diffraction
 -----------------------
 - PaalmanPingsMonteCarloAbsorption can now use tabulated density values, and allows for overridden X Sections
@@ -75,13 +79,6 @@ Single Crystal Diffraction
 Bugfixes
 ########
 - Fix bug in :ref:`SaveHKL <algm-SaveHKL>` where the direction cosines were calculated incorrectly
-
-
-New features
-############
-- Scripts for pixel calibration of CORELLI 16-packs. Produce a calibration table, a masking table, and a goodness of fit workspace.
-- Fix problem that was causing matrix diagonalization to return NaNs in certain cases. The diagonalization is used in :ref:`CalculateUMatrix <algm-CalculateUMatrix>` and :ref:`IntegratePeaksMD <algm-IntegratePeaksMD>`
-
 
 Imaging
 -------


### PR DESCRIPTION
**Description of work.**

Refactored code to fix bug when the user wants multiple input workspaces and a group workspace as output.

Fixes GitLab issue [PD#109](https://code.ornl.gov/sns-hfir-scse/diffraction/powder/powder-diffraction/-/issues/109)
Version into [master](https://github.com/mantidproject/mantid/pull/30038)

**To test:**

From CLI: ./mantidpython /path/to/WANDPowderReductionTest.py