### PR TITLE
SCD algorithm for peak integration and Lorentz correction

### DIFF
--- a/Framework/PythonInterface/plugins/CMakeLists.txt
+++ b/Framework/PythonInterface/plugins/CMakeLists.txt
@@ -78,6 +78,7 @@ set(PYTHON_PLUGINS
     algorithms/HB2AReduce.py
     algorithms/HB3AAdjustSampleNorm.py
     algorithms/HB3AFindPeaks.py
+    algorithms/HB3AIntegratePeaks.py
     algorithms/HFIRSANS2Wavelength.py
     algorithms/IndexSatellitePeaks.py
     algorithms/IndirectTransmission.py

--- a/Framework/PythonInterface/plugins/algorithms/HB3AIntegratePeaks.py
+++ b/Framework/PythonInterface/plugins/algorithms/HB3AIntegratePeaks.py
@@ -1,0 +1,90 @@
+# Mantid Repository : https://github.com/mantidproject/mantid
+#
+# Copyright &copy; 2020 ISIS Rutherford Appleton Laboratory UKRI,
+#   NScD Oak Ridge National Laboratory, European Spallation Source,
+#   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+# SPDX - License - Identifier: GPL - 3.0 +
+from mantid.api import AlgorithmFactory, IMDEventWorkspaceProperty, IPeaksWorkspaceProperty, PythonAlgorithm, \
+    PropertyMode
+from mantid.kernel import Direction, FloatBoundedValidator
+from mantid.simpleapi import DeleteWorkspace, IntegratePeaksMD
+import numpy as np
+
+
+class HB3AIntegratePeaks(PythonAlgorithm):
+
+    def category(self):
+        return "Crystal\\Integration"
+
+    def seeAlso(self):
+        return ["HB3AFindPeaks", "IntegratePeaksMD"]
+
+    def name(self):
+        return "HB3AIntegratePeaks"
+
+    def summary(self):
+        return 'Integrates peaks from the input MDEvent workspace and applies a Lorentz correction to the ' \
+               'output peaks workspace'
+
+    def PyInit(self):
+        self.declareProperty(IMDEventWorkspaceProperty("InputWorkspace", defaultValue="",
+                                                       optional=PropertyMode.Mandatory,
+                                                       direction=Direction.Input),
+                             doc="Input MDEvent workspace to use for integration")
+
+        self.declareProperty(IPeaksWorkspaceProperty("PeaksWorkspace", defaultValue="", optional=PropertyMode.Mandatory,
+                                                     direction=Direction.Input),
+                             doc="Peaks workspace containing peaks to integrate")
+
+        positive_val = FloatBoundedValidator(lower=0.0)
+        self.declareProperty("PeakRadius", defaultValue=1.0, validator=positive_val,
+                             doc="Fixed radius around each peak position in which to integrate"
+                                 " (same units as input workspace) ")
+
+        self.declareProperty("BackgroundInnerRadius", defaultValue=0.0, validator=positive_val,
+                             doc="Inner radius used to evaluate the peak background")
+        self.declareProperty("BackgroundOuterRadius", defaultValue=0.0, validator=positive_val,
+                             doc="Outer radius used to evaluate the peak background")
+
+        self.declareProperty(IPeaksWorkspaceProperty("OutputWorkspace", defaultValue="", direction=Direction.Output,
+                                                     optional=PropertyMode.Mandatory),
+                             doc="Output peaks workspace (copy of input with updated peak intensities)")
+
+    def validateInputs(self):
+        issues = dict()
+
+        # Make sure outer radius > inner radius
+        inner_radius = self.getProperty("BackgroundInnerRadius").value
+        outer_radius = self.getProperty("BackgroundOuterRadius").value
+
+        if outer_radius < inner_radius:
+            issues['BackgroundOuterRadius'] = "Outer radius should be >= to inner radius"
+
+        return issues
+
+    def PyExec(self):
+        input_ws = self.getProperty("InputWorkspace").value
+        peak_ws = self.getProperty("PeaksWorkspace").value
+
+        peak_radius = self.getProperty("PeakRadius").value
+        inner_radius = self.getProperty("BackgroundInnerRadius").value
+        outer_radius = self.getProperty("BackgroundOuterRadius").value
+
+        out_ws = IntegratePeaksMD(InputWorkspace=input_ws,
+                                  PeakRadius=peak_radius,
+                                  BackgroundInnerRadius=inner_radius,
+                                  BackgroundOuterRadius=outer_radius,
+                                  PeaksWorkspace=peak_ws)
+
+        # Apply Lorentz correction:
+        for p in range(out_ws.getNumberPeaks()):
+            peak = out_ws.getPeak(p)
+            lorentz = abs(np.sin(peak.getScattering() * np.cos(peak.getAzimuthal())))
+            peak.setIntensity(peak.getIntensity() * lorentz)
+
+        self.setProperty("OutputWorkspace", out_ws)
+
+        DeleteWorkspace(out_ws)
+
+
+AlgorithmFactory.subscribe(HB3AIntegratePeaks)

--- a/Framework/PythonInterface/test/python/plugins/algorithms/HB3AIntegratePeaksTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/HB3AIntegratePeaksTest.py
@@ -1,0 +1,50 @@
+# Mantid Repository : https://github.com/mantidproject/mantid
+#
+# Copyright &copy; 2020 ISIS Rutherford Appleton Laboratory UKRI,
+#   NScD Oak Ridge National Laboratory, European Spallation Source,
+#   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+# SPDX - License - Identifier: GPL - 3.0 +
+import unittest
+import tempfile
+import shutil
+import os
+from mantid.simpleapi import HB3AAdjustSampleNorm, HB3AFindPeaks, HB3AIntegratePeaks, IntegratePeaksMD, mtd
+
+
+class HB3AIntegratePeaksTest(unittest.TestCase):
+
+    _files = "HB3A_exp0724_scan0182.nxs,HB3A_exp0724_scan0183.nxs"
+
+    def test_integrate_peaks(self):
+        # Make sure that this algorithm gives similar results to IntegratePeaksMD
+
+        HB3AAdjustSampleNorm(Filename=self._files, MergeInputs=True, OutputWorkspace="merged")
+        HB3AFindPeaks(InputWorkspace=mtd["merged"],
+                      CellType="Orthorhombic",
+                      Centering="F",
+                      OutputWorkspace="peaks")
+
+        int_peaks = IntegratePeaksMD(InputWorkspace=mtd["merged"], PeaksWorkspace=mtd["peaks"], PeakRadius=0.25)
+
+        test_dir = tempfile.mkdtemp()
+        fileout = os.path.join(test_dir, "integrated_peaks.hkl")
+
+        corrected_peaks = HB3AIntegratePeaks(InputWorkspace=mtd["merged"], PeaksWorkspace=mtd["peaks"],
+                                             PeakRadius=0.25, OutputFile=fileout)
+
+        # Verify that both have the same number of peaks
+        self.assertEqual(int_peaks.getNumberPeaks(), corrected_peaks.getNumberPeaks())
+
+        # Check that peaks match
+        for p in range(corrected_peaks.getNumberPeaks()):
+            peak1 = int_peaks.getPeak(p)
+            peak2 = corrected_peaks.getPeak(p)
+
+            self.assertAlmostEqual(peak1.getSigmaIntensity(), peak2.getSigmaIntensity())
+
+        mtd.clear()
+        shutil.rmtree(test_dir)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/docs/source/algorithms/HB3AIntegratePeaks-v1.rst
+++ b/docs/source/algorithms/HB3AIntegratePeaks-v1.rst
@@ -1,0 +1,47 @@
+.. algorithm::
+
+.. summary::
+
+.. relatedalgorithms::
+
+.. properties::
+
+Description
+-----------
+
+Uses an :ref:`MDEventWorkspace <MDWorkspace>` and `PeaksWorkspace` to integrate the peaks provided in the peaks
+workspace and apply a :ref:`LorentzCorrection <algm-LorentzCorrection>`. The results are written to `OutputFile` in
+HKL format using :ref:`SaveHKL <algm-SaveHKL>` with an option for including direction cosines in the output.
+
+The input to this algorithm is intended as part of the DEMAND data reduction workflow, using
+:ref:`HB3AAdjustSampleNorm <algm-HB3AAdjustSampleNorm>` and :ref:`HB3AFindPeaks <algm-HB3AFindPeaks>` which can be seen
+below in the example usage.
+
+Usage
+-----
+
+**Example - DEMAND Data Reduction Workflow**
+
+.. testcode:: ReductionWorkflow
+
+    # Input detector scan data to use. Can be a list of files, or workspaces - see HB3AAdjustSampleNorm for details
+    data = "HB3A_exp0724_scan0182.nxs, HB3A_exp0724_scan0183.nxs"
+
+    # Converts to MDEventWorkspace and merges multiple files into one workspace.
+    #  If needed, the sample position can be adjusted by a height and distance - see the HB3AAdjustSampleNorm docs
+    merged = HB3AAdjustSampleNorm(Filename=data, MergeInputs=True)
+
+    # Finds peaks on the combined workspace, optimizing the UB matrix for the given cell type parameters
+    #  lattice parameters can be optionally specified to calculate the UB matrix (see docs for HB3AFindPeaks)
+    peaks = HB3AFindPeaks(InputWorkspace=merged,
+                          CellType="Orthorhombic",
+                          Centering="F")
+
+    # Integrate the peaks from the optimized peaks workspace above
+    integrated_peaks = HB3AIntegratePeaks(InputWorkspace=merged, PeaksWorkspace=peaks,
+                                          PeakRadius=0.25,
+                                          OutputFile="./integrated_peaks.hkl")
+
+.. categories::
+
+.. sourcelink::

--- a/docs/source/algorithms/HB3AIntegratePeaks-v1.rst
+++ b/docs/source/algorithms/HB3AIntegratePeaks-v1.rst
@@ -9,10 +9,12 @@
 Description
 -----------
 
-Uses an :ref:`MDEventWorkspace <MDWorkspace>` and `PeaksWorkspace` to integrate the peaks provided in the peaks
-workspace and apply a :ref:`LorentzCorrection <algm-LorentzCorrection>`. The results are written to `OutputFile` in
-SHELX format with direction cosines using :ref:`SaveHKL <algm-SaveHKL>` or in the Fullprof format using
-:ref:`SaveReflections <algm-SaveReflections>`.
+Uses a :ref:`MDEventWorkspace <MDWorkspace>` and `PeaksWorkspace` to integrate the peaks provided in the peaks
+workspace. A :ref:`LorentzCorrection <algm-LorentzCorrection>` can be optionally applied to the integrated peaks with
+the `ApplyLorentz` option.
+
+The output peaks workspace can be written to `OutputFile` in either SHELX format with direction cosines using
+:ref:`SaveHKL <algm-SaveHKL>` or in the Fullprof format using :ref:`SaveReflections <algm-SaveReflections>`.
 
 The input to this algorithm is intended as part of the DEMAND data reduction workflow, using
 :ref:`HB3AAdjustSampleNorm <algm-HB3AAdjustSampleNorm>` and :ref:`HB3AFindPeaks <algm-HB3AFindPeaks>` which can be seen

--- a/docs/source/algorithms/HB3AIntegratePeaks-v1.rst
+++ b/docs/source/algorithms/HB3AIntegratePeaks-v1.rst
@@ -23,7 +23,7 @@ Usage
 
 **Example - DEMAND Workflow**
 
-.. testcode:: ExampleWorkflow
+.. code-block:: python
 
     # Input detector scan data to use. Can be a list of files, or workspaces - see HB3AAdjustSampleNorm for details
     data = "HB3A_exp0724_scan0182.nxs, HB3A_exp0724_scan0183.nxs"

--- a/docs/source/algorithms/HB3AIntegratePeaks-v1.rst
+++ b/docs/source/algorithms/HB3AIntegratePeaks-v1.rst
@@ -11,7 +11,8 @@ Description
 
 Uses an :ref:`MDEventWorkspace <MDWorkspace>` and `PeaksWorkspace` to integrate the peaks provided in the peaks
 workspace and apply a :ref:`LorentzCorrection <algm-LorentzCorrection>`. The results are written to `OutputFile` in
-HKL format using :ref:`SaveHKL <algm-SaveHKL>` with an option for including direction cosines in the output.
+SHELX format with direction cosines using :ref:`SaveHKL <algm-SaveHKL>` or in the Fullprof format using
+:ref:`SaveReflections <algm-SaveReflections>`.
 
 The input to this algorithm is intended as part of the DEMAND data reduction workflow, using
 :ref:`HB3AAdjustSampleNorm <algm-HB3AAdjustSampleNorm>` and :ref:`HB3AFindPeaks <algm-HB3AFindPeaks>` which can be seen
@@ -20,9 +21,9 @@ below in the example usage.
 Usage
 -----
 
-**Example - DEMAND Data Reduction Workflow**
+**Example - DEMAND Workflow**
 
-.. testcode:: ReductionWorkflow
+.. testcode:: ExampleWorkflow
 
     # Input detector scan data to use. Can be a list of files, or workspaces - see HB3AAdjustSampleNorm for details
     data = "HB3A_exp0724_scan0182.nxs, HB3A_exp0724_scan0183.nxs"

--- a/docs/source/release/v6.0.0/diffraction.rst
+++ b/docs/source/release/v6.0.0/diffraction.rst
@@ -72,6 +72,7 @@ Single Crystal Diffraction
 New features
 ############
 - New algorithm :ref:`HB3AFindPeaks <algm-HB3AFindPeaks>` to find peaks and set the UB matrix for DEMAND data.
+- New algorithm :ref:`HB3AIntegratePeaks <algm-HB3AIntegratePeaks>` used to integrate peaks from an MDEventWorkspace and apply Lorentz correction on DEMAND data.
 
 Bugfixes
 ########


### PR DESCRIPTION
**Description of work.**
Adds a new algorithm used to integrate peaks found from DEMAND data (such as using the output peaks workspace from `HB3AFindPeaks`). Peaks are integrated using `IntegratePeaksMD`, then a Lorentz correction is applied to adjust peak intensities. The resulting peaks workspace is saved to a file using either a SHELX format with direction cosines, or in the Fullprof format.

**To test:**
Run the unit test `HB3AIntegratePeaksTest` 
The following script can also be used for additional testing data:
```
scans = [34, 182, 183, 184]
files = ','.join("/HFIR/HB3A/IPTS-24655/shared/autoreduce/HB3A_exp0724_scan{:04}.nxs".format(scan) for scan in scans)

merged = HB3AAdjustSampleNorm(Filename=data, MergeInputs=True)

peaks = HB3AFindPeaks(InputWorkspace=merged, CellType="Orthorhombic", Centering="F")

integrated_peaks = HB3AIntegratePeaks(InputWorkspace=merged, PeaksWorkspace=peaks, 
                                      PeakRadius=0.25, OutputFile="./integrated_peaks")
```

*There is no associated issue.*

The version of this into `ornl-next` is #30100 

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
