### PR TITLE
Added unit test to test findContainer without specified ID

### DIFF
--- a/Framework/DataHandling/test/SampleEnvironmentSpecTest.h
+++ b/Framework/DataHandling/test/SampleEnvironmentSpecTest.h
@@ -47,6 +47,20 @@ public:
     TS_ASSERT_EQUALS(testContainer, retrieved);
   }
 
+  void test_Find_Single_Container_Without_ID() {
+    using Mantid::Geometry::Container;
+    SampleEnvironmentSpec spec("CRYO-001");
+    auto testContainer = std::make_shared<Container>("");
+    testContainer->setID("8mm");
+
+    TS_ASSERT_EQUALS(0, spec.ncans());
+    TS_ASSERT_THROWS_NOTHING(spec.addContainer(testContainer));
+    TS_ASSERT_EQUALS(1, spec.ncans());
+    auto retrieved = spec.findContainer("");
+    TS_ASSERT(retrieved);
+    TS_ASSERT_EQUALS(testContainer, retrieved);
+  }
+
   void test_AddObject_Stores_Reference_To_Object() {
     SampleEnvironmentSpec spec("CRYO-001");
 


### PR DESCRIPTION
Fixes [#28872](https://github.com/mantidproject/mantid/issues/28872)

SampleEnvironmentSpec::findContainer does not need to specify a container ID anymore when the sample environment only has a single container. The new unit test covers this special case.

To Test: Run the unit test test_Find_Single_Container_Without_ID  in SampleEnvironmentSpecTest.

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
