### PR TITLE
Muon Analysis - Fix Global Parameter Reset Bug

### DIFF
--- a/docs/source/release/v6.0.0/muon.rst
+++ b/docs/source/release/v6.0.0/muon.rst
@@ -24,7 +24,8 @@ Bug fixes
 #########
 - Fixed a bug where ties and constraints were not being respected.
 - Fixed a bug to swap start and end time fit properties on the interface if start > end
-- Fixed a bug where editing constraints would result in a crash
+- Fixed a bug where editing constraints would result in a crash.
+- Fixed a bug where global parameter values would reset when changing the displayed dataset.
 
 ALC
 ---

--- a/qt/scientific_interfaces/Indirect/IndirectFunctionBrowser/ConvFunctionModel.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectFunctionBrowser/ConvFunctionModel.cpp
@@ -544,6 +544,11 @@ void ConvFunctionModel::setLocalParameterFixed(const QString &parName, int i,
   m_model.setLocalParameterFixed(parName, i, fixed);
 }
 
+void ConvFunctionModel::setGlobalParameterValue(const QString &paramName,
+                                                double value) {
+  m_model.setGlobalParameterValue(paramName, value);
+}
+
 void ConvFunctionModel::setParameter(ParamID name, double value) {
   auto const prefix = getPrefix(name);
   if (prefix) {

--- a/qt/scientific_interfaces/Indirect/IndirectFunctionBrowser/ConvFunctionModel.h
+++ b/qt/scientific_interfaces/Indirect/IndirectFunctionBrowser/ConvFunctionModel.h
@@ -78,6 +78,7 @@ public:
                             const QString &tie) override;
   void setLocalParameterConstraint(const QString &parName, int i,
                                    const QString &constraint) override;
+  void setGlobalParameterValue(const QString &paramName, double value) override;
   QString setBackgroundA0(double value) override;
 
   void updateMultiDatasetParameters(const ITableWorkspace &paramTable);

--- a/qt/scientific_interfaces/Indirect/IndirectFunctionBrowser/IqtFunctionModel.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectFunctionBrowser/IqtFunctionModel.cpp
@@ -463,6 +463,11 @@ void IqtFunctionModel::setLocalParameterFixed(const QString &parName, int i,
   m_model.setLocalParameterFixed(parName, i, fixed);
 }
 
+void IqtFunctionModel::setGlobalParameterValue(const QString &paramName,
+                                               double value) {
+  m_model.setGlobalParameterValue(paramName, value);
+}
+
 void IqtFunctionModel::setParameter(ParamID name, double value) {
   auto const prefix = getPrefix(name);
   if (prefix) {

--- a/qt/scientific_interfaces/Indirect/IndirectFunctionBrowser/IqtFunctionModel.h
+++ b/qt/scientific_interfaces/Indirect/IndirectFunctionBrowser/IqtFunctionModel.h
@@ -72,6 +72,7 @@ public:
                             const QString &tie) override;
   void setLocalParameterConstraint(const QString &parName, int i,
                                    const QString &constraint) override;
+  void setGlobalParameterValue(const QString &paramName, double value) override;
   QString setBackgroundA0(double value) override;
 
   void updateMultiDatasetParameters(const ITableWorkspace &paramTable);

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/FunctionModel.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/FunctionModel.h
@@ -61,6 +61,7 @@ public:
                               double value) override;
   void setLocalParameterValue(const QString &parName, int i, double value,
                               double error) override;
+  void setGlobalParameterValue(const QString &paramName, double value);
   void setLocalParameterFixed(const QString &parName, int i,
                               bool fixed) override;
   void setLocalParameterTie(const QString &parName, int i,

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/FunctionModel.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/FunctionModel.h
@@ -61,13 +61,13 @@ public:
                               double value) override;
   void setLocalParameterValue(const QString &parName, int i, double value,
                               double error) override;
-  void setGlobalParameterValue(const QString &paramName, double value);
   void setLocalParameterFixed(const QString &parName, int i,
                               bool fixed) override;
   void setLocalParameterTie(const QString &parName, int i,
                             const QString &tie) override;
   void setLocalParameterConstraint(const QString &parName, int i,
                                    const QString &constraint) override;
+  void setGlobalParameterValue(const QString &paramName, double value) override;
   void changeTie(const QString &parName, const QString &tie) override;
   void addConstraint(const QString &functionIndex,
                      const QString &constraint) override;

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/FunctionModel.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/FunctionModel.h
@@ -86,6 +86,8 @@ protected:
   MultiDomainFunction_sptr m_function;
 
 private:
+  IFunction_sptr getFitFunctionWithGlobals(std::size_t const &index) const;
+
   void checkDatasets();
   void checkNumberOfDomains(const QList<FunctionModelDataset> &datasets) const;
   int numberOfDomains(const QList<FunctionModelDataset> &datasets) const;

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/IFunctionModel.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/IFunctionModel.h
@@ -75,6 +75,8 @@ public:
                                     const QString &tie) = 0;
   virtual void setLocalParameterConstraint(const QString &parName, int i,
                                            const QString &constraint) = 0;
+  virtual void setGlobalParameterValue(const QString &paramName,
+                                       double value) = 0;
   virtual QString setBackgroundA0(double value) = 0;
 
 protected:

--- a/qt/widgets/common/src/FunctionModel.cpp
+++ b/qt/widgets/common/src/FunctionModel.cpp
@@ -420,7 +420,7 @@ void FunctionModel::setLocalParameterValue(const QString &parName, int i,
 void FunctionModel::setGlobalParameterValue(const QString &paramName,
                                             double value) {
   if (isGlobal(paramName))
-    for (auto i = 0; i < static_cast<int>(m_function->nFunctions()); ++i)
+    for (auto i = 0; i < getNumberDomains(); ++i)
       setLocalParameterValue(paramName, i, value);
 }
 

--- a/qt/widgets/common/src/FunctionModel.cpp
+++ b/qt/widgets/common/src/FunctionModel.cpp
@@ -55,7 +55,7 @@ IFunction_sptr FunctionModel::getFitFunction() const {
     return getFitFunctionWithGlobals(0);
 
   } else if (numberOfFunctions == 1) {
-    auto const function = m_function->getFunction(0);
+    auto const function = m_function->getFunction(0)->clone();
     auto const composite =
         std::dynamic_pointer_cast<CompositeFunction>(function);
 
@@ -422,13 +422,6 @@ void FunctionModel::setLocalParameterValue(const QString &parName, int i,
   fun->setError(parIndex, error);
 }
 
-void FunctionModel::setGlobalParameterValue(const QString &paramName,
-                                            double value) {
-  if (isGlobal(paramName))
-    for (auto i = 0; i < getNumberDomains(); ++i)
-      setLocalParameterValue(paramName, i, value);
-}
-
 void FunctionModel::setLocalParameterFixed(const QString &parName, int i,
                                            bool fixed) {
   auto fun = getSingleFunction(i);
@@ -480,6 +473,13 @@ void FunctionModel::setLocalParameterConstraint(const QString &parName, int i,
     newConstraint.replace(parts.first, name);
     fun->addConstraints(newConstraint.toStdString());
   }
+}
+
+void FunctionModel::setGlobalParameterValue(const QString &paramName,
+                                            double value) {
+  if (isGlobal(paramName))
+    for (auto i = 0; i < getNumberDomains(); ++i)
+      setLocalParameterValue(paramName, i, value);
 }
 
 void FunctionModel::changeTie(const QString &parName, const QString &tie) {

--- a/qt/widgets/common/src/FunctionModel.cpp
+++ b/qt/widgets/common/src/FunctionModel.cpp
@@ -48,11 +48,8 @@ IFunction_sptr FunctionModel::getFitFunction() const {
     return m_function;
   }
   auto const nf = m_function->nFunctions();
-  if (nf <= m_currentDomainIndex)
-    throw std::logic_error(
-        "The number of functions is less than the current domain index");
 
-  if (nf > 1) {
+  if (nf > 1 && nf <= m_currentDomainIndex) {
     auto fun =
         std::dynamic_pointer_cast<MultiDomainFunction>(m_function->clone());
 

--- a/qt/widgets/common/src/FunctionModel.cpp
+++ b/qt/widgets/common/src/FunctionModel.cpp
@@ -409,7 +409,9 @@ QString FunctionModel::getLocalParameterConstraint(const QString &parName,
 
 void FunctionModel::setLocalParameterValue(const QString &parName, int i,
                                            double value) {
-  getSingleFunction(i)->setParameter(parName.toStdString(), value);
+  auto function = getSingleFunction(i);
+  if (function && function->hasParameter(parName.toStdString()))
+    function->setParameter(parName.toStdString(), value);
 }
 
 void FunctionModel::setLocalParameterValue(const QString &parName, int i,

--- a/qt/widgets/common/src/FunctionModel.cpp
+++ b/qt/widgets/common/src/FunctionModel.cpp
@@ -44,42 +44,50 @@ void FunctionModel::setFunction(IFunction_sptr fun) {
 }
 
 IFunction_sptr FunctionModel::getFitFunction() const {
-  if (!m_function) {
+  if (!m_function)
     return m_function;
-  }
-  auto const nf = m_function->nFunctions();
 
-  if (nf > 1 && nf <= m_currentDomainIndex) {
-    auto fun =
-        std::dynamic_pointer_cast<MultiDomainFunction>(m_function->clone());
+  auto const numberOfFunctions = m_function->nFunctions();
 
-    auto const singleFun = m_function->getFunction(m_currentDomainIndex);
-    for (auto par = m_globalParameterNames.begin();
-         par != m_globalParameterNames.end();) {
-      if (singleFun->hasParameter(par->toStdString())) {
-        QStringList ties;
-        for (size_t i = 0; i < nf; ++i) {
-          if (i != m_currentDomainIndex)
-            ties << "f" + QString::number(i) + "." + *par;
-        }
-        ties << "f" + QString::number(m_currentDomainIndex) + "." + *par;
-        fun->addTies(ties.join("=").toStdString());
-        ++par;
-      } else {
-        par = m_globalParameterNames.erase(par);
-      }
-    }
-    return fun;
-  }
-  if (nf == 1) {
-    auto fun = m_function->getFunction(0);
-    auto compFun = std::dynamic_pointer_cast<CompositeFunction>(fun);
-    if (compFun && compFun->nFunctions() == 1) {
-      return compFun->getFunction(0);
-    }
-    return fun;
+  if (numberOfFunctions > 1) {
+    if (m_currentDomainIndex < numberOfFunctions)
+      return getFitFunctionWithGlobals(m_currentDomainIndex);
+    return getFitFunctionWithGlobals(0);
+
+  } else if (numberOfFunctions == 1) {
+    auto const function = m_function->getFunction(0);
+    auto const composite =
+        std::dynamic_pointer_cast<CompositeFunction>(function);
+
+    if (composite && composite->nFunctions() == 1)
+      return composite->getFunction(0);
+    return function;
   }
   return IFunction_sptr();
+}
+
+IFunction_sptr
+FunctionModel::getFitFunctionWithGlobals(std::size_t const &index) const {
+  auto function =
+      std::dynamic_pointer_cast<MultiDomainFunction>(m_function->clone());
+
+  auto const singleFun = m_function->getFunction(index);
+  for (auto paramIter = m_globalParameterNames.begin();
+       paramIter != m_globalParameterNames.end();) {
+    if (singleFun->hasParameter(paramIter->toStdString())) {
+      QStringList ties;
+      for (auto i = 0u; i < m_function->nFunctions(); ++i)
+        if (i != index)
+          ties << "f" + QString::number(i) + "." + *paramIter;
+
+      ties << "f" + QString::number(index) + "." + *paramIter;
+      function->addTies(ties.join("=").toStdString());
+      ++paramIter;
+    } else {
+      paramIter = m_globalParameterNames.erase(paramIter);
+    }
+  }
+  return function;
 }
 
 bool FunctionModel::hasFunction() const {

--- a/qt/widgets/common/src/FunctionModel.cpp
+++ b/qt/widgets/common/src/FunctionModel.cpp
@@ -409,9 +409,7 @@ QString FunctionModel::getLocalParameterConstraint(const QString &parName,
 
 void FunctionModel::setLocalParameterValue(const QString &parName, int i,
                                            double value) {
-  auto function = getSingleFunction(i);
-  if (function && function->hasParameter(parName.toStdString()))
-    function->setParameter(parName.toStdString(), value);
+  getSingleFunction(i)->setParameter(parName.toStdString(), value);
 }
 
 void FunctionModel::setLocalParameterValue(const QString &parName, int i,

--- a/qt/widgets/common/test/FunctionModelTest.h
+++ b/qt/widgets/common/test/FunctionModelTest.h
@@ -151,6 +151,40 @@ public:
     TS_ASSERT_EQUALS(locals[0], "A1");
   }
 
+  void test_that_setParameter_will_set_a_local_parameter_as_expected() {
+    m_model->setFunctionString("composite=MultiDomainFunction,NumDeriv=true;"
+                               "name=LinearBackground,A0=1,A1=2,$domains=i;"
+                               "name=LinearBackground,A0=1,A1=2,$domains=i");
+
+    m_model->setNumberDomains(2);
+    m_model->setCurrentDomainIndex(0);
+    m_model->setParameter("A0", 5.0);
+
+    TS_ASSERT_EQUALS(m_model->getFitFunction()->asString(),
+                     "composite=MultiDomainFunction,NumDeriv=true;"
+                     "name=LinearBackground,A0=5,A1=2,$domains=i;"
+                     "name=LinearBackground,A0=1,A1=2,$domains=i;"
+                     "name=LinearBackground,A0=1,A1=2,$domains=All");
+  }
+
+  void test_that_setParameter_will_set_a_global_parameter_as_expected() {
+    m_model->setFunctionString("composite=MultiDomainFunction,NumDeriv=true;"
+                               "name=LinearBackground,A0=1,A1=2,$domains=i;"
+                               "name=LinearBackground,A0=1,A1=2,$domains=i");
+
+    m_model->setNumberDomains(2);
+    m_model->setCurrentDomainIndex(0);
+    m_model->setGlobalParameters(QStringList("A0"));
+    m_model->setParameter("A0", 5.0);
+
+    TS_ASSERT_EQUALS(m_model->getFitFunction()->asString(),
+                     "composite=MultiDomainFunction,NumDeriv=true;"
+                     "name=LinearBackground,A0=5,A1=2,$domains=i;"
+                     "name=LinearBackground,A0=5,A1=2,$domains=i;"
+                     "name=LinearBackground,A0=5,A1=2,$domains=All;"
+                     "ties=(f2.A0=f0.A0,f1.A0=f0.A0)");
+  }
+
   void test_set_number_domains_after_clear() {
     m_model->clear();
     m_model->setNumberDomains(1);


### PR DESCRIPTION
**Description of work.**
This PR fixes a bug in Muon analysis where global parameters get reset after switching to a different display dataset.

**To test:**
2. Muon Analysis interface
1. `MUSR` run `62260`
2. Fitting tab. Click Simultaneous fit
3. Add `GausOsc` function
4. Make `Sigma` Global
5. Click `Fit` and wait (optional)
6. Change the visible dataset using `>>`
7. Change the Sigma parameter to a different value.
8. Change visible dataset using `>>` again. The Sigma parameter should have the value you just gave it.

Fixes #30054

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
