### PR TITLE
Remove Tolerance Check in yIndexOfX for Histogram Data

### DIFF
--- a/Framework/API/inc/MantidAPI/MatrixWorkspace.h
+++ b/Framework/API/inc/MantidAPI/MatrixWorkspace.h
@@ -165,7 +165,7 @@ public:
     return getSpectrum(index).histogram();
   }
   template <typename... T>
-  void setHistogram(const size_t index, T &&...data) & {
+  void setHistogram(const size_t index, T &&... data) & {
     getSpectrum(index).setHistogram(std::forward<T>(data)...);
   }
   void convertToCounts(const size_t index) {
@@ -184,19 +184,20 @@ public:
   pointStandardDeviations(const size_t index) const {
     return getSpectrum(index).pointStandardDeviations();
   }
-  template <typename... T> void setBinEdges(const size_t index, T &&...data) & {
+  template <typename... T>
+  void setBinEdges(const size_t index, T &&... data) & {
     getSpectrum(index).setBinEdges(std::forward<T>(data)...);
   }
-  template <typename... T> void setPoints(const size_t index, T &&...data) & {
+  template <typename... T> void setPoints(const size_t index, T &&... data) & {
     getSpectrum(index).setPoints(std::forward<T>(data)...);
   }
   template <typename... T>
-  void setPointVariances(const size_t index, T &&...data) & {
+  void setPointVariances(const size_t index, T &&... data) & {
     getSpectrumWithoutInvalidation(index).setPointVariances(
         std::forward<T>(data)...);
   }
   template <typename... T>
-  void setPointStandardDeviations(const size_t index, T &&...data) & {
+  void setPointStandardDeviations(const size_t index, T &&... data) & {
     getSpectrumWithoutInvalidation(index).setPointStandardDeviations(
         std::forward<T>(data)...);
   }
@@ -221,31 +222,31 @@ public:
   frequencyStandardDeviations(const size_t index) const {
     return getSpectrum(index).frequencyStandardDeviations();
   }
-  template <typename... T> void setCounts(const size_t index, T &&...data) & {
+  template <typename... T> void setCounts(const size_t index, T &&... data) & {
     getSpectrumWithoutInvalidation(index).setCounts(std::forward<T>(data)...);
   }
   template <typename... T>
-  void setCountVariances(const size_t index, T &&...data) & {
+  void setCountVariances(const size_t index, T &&... data) & {
     getSpectrumWithoutInvalidation(index).setCountVariances(
         std::forward<T>(data)...);
   }
   template <typename... T>
-  void setCountStandardDeviations(const size_t index, T &&...data) & {
+  void setCountStandardDeviations(const size_t index, T &&... data) & {
     getSpectrumWithoutInvalidation(index).setCountStandardDeviations(
         std::forward<T>(data)...);
   }
   template <typename... T>
-  void setFrequencies(const size_t index, T &&...data) & {
+  void setFrequencies(const size_t index, T &&... data) & {
     getSpectrumWithoutInvalidation(index).setFrequencies(
         std::forward<T>(data)...);
   }
   template <typename... T>
-  void setFrequencyVariances(const size_t index, T &&...data) & {
+  void setFrequencyVariances(const size_t index, T &&... data) & {
     getSpectrumWithoutInvalidation(index).setFrequencyVariances(
         std::forward<T>(data)...);
   }
   template <typename... T>
-  void setFrequencyStandardDeviations(const size_t index, T &&...data) & {
+  void setFrequencyStandardDeviations(const size_t index, T &&... data) & {
     getSpectrumWithoutInvalidation(index).setFrequencyStandardDeviations(
         std::forward<T>(data)...);
   }

--- a/Framework/API/inc/MantidAPI/MatrixWorkspace.h
+++ b/Framework/API/inc/MantidAPI/MatrixWorkspace.h
@@ -582,7 +582,8 @@ protected:
 
 private:
   std::size_t binIndexOfValue(Mantid::HistogramData::HistogramX const &xValues,
-                              const double xValue, const bool ascendingOrder) const;
+                              const double xValue,
+                              const bool ascendingOrder) const;
   std::size_t xIndexOfValue(const Mantid::HistogramData::HistogramX &xValues,
                             const double xValue, const double tolerance) const;
 

--- a/Framework/API/inc/MantidAPI/MatrixWorkspace.h
+++ b/Framework/API/inc/MantidAPI/MatrixWorkspace.h
@@ -147,8 +147,8 @@ public:
   Types::Core::DateAndTime getLastPulseTime() const;
 
   /// Returns the y index which corresponds to the X Value provided
-  std::size_t yIndexOfX(const double xValue, const std::size_t = 0,
-                        const double tolerance = 0.0) const;
+  std::size_t yIndexOfX(double xValue, std::size_t const &index = 0,
+                        double tolerance = 0.0) const;
 
   //----------------------------------------------------------------------
   // DATA ACCESSORS
@@ -165,7 +165,7 @@ public:
     return getSpectrum(index).histogram();
   }
   template <typename... T>
-  void setHistogram(const size_t index, T &&... data) & {
+  void setHistogram(const size_t index, T &&...data) & {
     getSpectrum(index).setHistogram(std::forward<T>(data)...);
   }
   void convertToCounts(const size_t index) {
@@ -184,20 +184,19 @@ public:
   pointStandardDeviations(const size_t index) const {
     return getSpectrum(index).pointStandardDeviations();
   }
-  template <typename... T>
-  void setBinEdges(const size_t index, T &&... data) & {
+  template <typename... T> void setBinEdges(const size_t index, T &&...data) & {
     getSpectrum(index).setBinEdges(std::forward<T>(data)...);
   }
-  template <typename... T> void setPoints(const size_t index, T &&... data) & {
+  template <typename... T> void setPoints(const size_t index, T &&...data) & {
     getSpectrum(index).setPoints(std::forward<T>(data)...);
   }
   template <typename... T>
-  void setPointVariances(const size_t index, T &&... data) & {
+  void setPointVariances(const size_t index, T &&...data) & {
     getSpectrumWithoutInvalidation(index).setPointVariances(
         std::forward<T>(data)...);
   }
   template <typename... T>
-  void setPointStandardDeviations(const size_t index, T &&... data) & {
+  void setPointStandardDeviations(const size_t index, T &&...data) & {
     getSpectrumWithoutInvalidation(index).setPointStandardDeviations(
         std::forward<T>(data)...);
   }
@@ -222,31 +221,31 @@ public:
   frequencyStandardDeviations(const size_t index) const {
     return getSpectrum(index).frequencyStandardDeviations();
   }
-  template <typename... T> void setCounts(const size_t index, T &&... data) & {
+  template <typename... T> void setCounts(const size_t index, T &&...data) & {
     getSpectrumWithoutInvalidation(index).setCounts(std::forward<T>(data)...);
   }
   template <typename... T>
-  void setCountVariances(const size_t index, T &&... data) & {
+  void setCountVariances(const size_t index, T &&...data) & {
     getSpectrumWithoutInvalidation(index).setCountVariances(
         std::forward<T>(data)...);
   }
   template <typename... T>
-  void setCountStandardDeviations(const size_t index, T &&... data) & {
+  void setCountStandardDeviations(const size_t index, T &&...data) & {
     getSpectrumWithoutInvalidation(index).setCountStandardDeviations(
         std::forward<T>(data)...);
   }
   template <typename... T>
-  void setFrequencies(const size_t index, T &&... data) & {
+  void setFrequencies(const size_t index, T &&...data) & {
     getSpectrumWithoutInvalidation(index).setFrequencies(
         std::forward<T>(data)...);
   }
   template <typename... T>
-  void setFrequencyVariances(const size_t index, T &&... data) & {
+  void setFrequencyVariances(const size_t index, T &&...data) & {
     getSpectrumWithoutInvalidation(index).setFrequencyVariances(
         std::forward<T>(data)...);
   }
   template <typename... T>
-  void setFrequencyStandardDeviations(const size_t index, T &&... data) & {
+  void setFrequencyStandardDeviations(const size_t index, T &&...data) & {
     getSpectrumWithoutInvalidation(index).setFrequencyStandardDeviations(
         std::forward<T>(data)...);
   }
@@ -582,11 +581,9 @@ protected:
 
 private:
   std::size_t binIndexOfValue(Mantid::HistogramData::HistogramX const &xValues,
-                              double const &xValue, bool const &ascendingOrder,
-                              double const &tolerance) const;
+                              double xValue, bool ascendingOrder) const;
   std::size_t xIndexOfValue(Mantid::HistogramData::HistogramX const &xValues,
-                            double const &xValue,
-                            double const &tolerance) const;
+                            double xValue, double tolerance) const;
 
   MatrixWorkspace *doClone() const override = 0;
   MatrixWorkspace *doCloneEmpty() const override = 0;

--- a/Framework/API/inc/MantidAPI/MatrixWorkspace.h
+++ b/Framework/API/inc/MantidAPI/MatrixWorkspace.h
@@ -147,8 +147,8 @@ public:
   Types::Core::DateAndTime getLastPulseTime() const;
 
   /// Returns the y index which corresponds to the X Value provided
-  std::size_t yIndexOfX(double xValue, std::size_t const &index = 0,
-                        double tolerance = 0.0) const;
+  std::size_t yIndexOfX(const double xValue, const std::size_t &index = 0,
+                        const double tolerance = 0.0) const;
 
   //----------------------------------------------------------------------
   // DATA ACCESSORS
@@ -582,9 +582,9 @@ protected:
 
 private:
   std::size_t binIndexOfValue(Mantid::HistogramData::HistogramX const &xValues,
-                              double xValue, bool ascendingOrder) const;
-  std::size_t xIndexOfValue(Mantid::HistogramData::HistogramX const &xValues,
-                            double xValue, double tolerance) const;
+                              const double xValue, const bool ascendingOrder) const;
+  std::size_t xIndexOfValue(const Mantid::HistogramData::HistogramX &xValues,
+                            const double xValue, const double tolerance) const;
 
   MatrixWorkspace *doClone() const override = 0;
   MatrixWorkspace *doCloneEmpty() const override = 0;

--- a/Framework/API/src/MatrixWorkspace.cpp
+++ b/Framework/API/src/MatrixWorkspace.cpp
@@ -1377,8 +1377,9 @@ Types::Core::DateAndTime MatrixWorkspace::getLastPulseTime() const {
  *                     stored value (default = 0.0). Used for point data only.
  * @returns The index corresponding to the X value provided
  */
-std::size_t MatrixWorkspace::yIndexOfX(double xValue, std::size_t const &index,
-                                       double tolerance) const {
+std::size_t MatrixWorkspace::yIndexOfX(const double xValue,
+                                       const std::size_t &index,
+                                       const double tolerance) const {
   if (index >= getNumberHistograms())
     throw std::out_of_range("MatrixWorkspace::yIndexOfX - Index out of range.");
 
@@ -1413,7 +1414,8 @@ std::size_t MatrixWorkspace::yIndexOfX(double xValue, std::size_t const &index,
  */
 std::size_t
 MatrixWorkspace::binIndexOfValue(HistogramData::HistogramX const &xValues,
-                                 double xValue, bool ascendingOrder) const {
+                                 const double xValue,
+                                 const bool ascendingOrder) const {
   std::size_t hops;
   if (ascendingOrder) {
     auto lowerIter = std::lower_bound(xValues.cbegin(), xValues.cend(), xValue);
@@ -1425,11 +1427,9 @@ MatrixWorkspace::binIndexOfValue(HistogramData::HistogramX const &xValues,
     hops = std::distance(xValues.cbegin(), lowerIter);
   } else {
     auto lowerIter =
-        std::upper_bound(xValues.crbegin(), xValues.crend(), xValue);
+        std::lower_bound(xValues.crbegin(), xValues.crend(), xValue);
 
-    if (lowerIter == xValues.crend())
-      --lowerIter;
-    else if (lowerIter == xValues.crbegin())
+    if (lowerIter == xValues.crbegin())
       ++lowerIter;
 
     hops = xValues.size() - std::distance(xValues.crbegin(), lowerIter);
@@ -1448,8 +1448,9 @@ MatrixWorkspace::binIndexOfValue(HistogramData::HistogramX const &xValues,
  * @returns The index of the X value
  */
 std::size_t
-MatrixWorkspace::xIndexOfValue(HistogramData::HistogramX const &xValues,
-                               double xValue, double tolerance) const {
+MatrixWorkspace::xIndexOfValue(const HistogramData::HistogramX &xValues,
+                               const double xValue,
+                               const double tolerance) const {
   auto const iter = std::find_if(xValues.cbegin(), xValues.cend(),
                                  [&xValue, &tolerance](double const &value) {
                                    return std::abs(xValue - value) <= tolerance;

--- a/Framework/API/src/MatrixWorkspace.cpp
+++ b/Framework/API/src/MatrixWorkspace.cpp
@@ -1374,12 +1374,11 @@ Types::Core::DateAndTime MatrixWorkspace::getLastPulseTime() const {
  * @param xValue :: The X value to search for
  * @param index :: The index within the workspace to search within (default = 0)
  * @param tolerance :: The tolerance to accept between the passed xValue and the
- *                     stored value (default = 0.0)
+ *                     stored value (default = 0.0). Used for point data only.
  * @returns The index corresponding to the X value provided
  */
-std::size_t MatrixWorkspace::yIndexOfX(const double xValue,
-                                       const std::size_t index,
-                                       const double tolerance) const {
+std::size_t MatrixWorkspace::yIndexOfX(double xValue, std::size_t const &index,
+                                       double tolerance) const {
   if (index >= getNumberHistograms())
     throw std::out_of_range("MatrixWorkspace::yIndexOfX - Index out of range.");
 
@@ -1388,17 +1387,21 @@ std::size_t MatrixWorkspace::yIndexOfX(const double xValue,
   const auto minX = ascendingOrder ? xValues.front() : xValues.back();
   const auto maxX = ascendingOrder ? xValues.back() : xValues.front();
 
-  if (xValue < minX)
-    throw std::out_of_range("MatrixWorkspace::yIndexOfX - X value is lower"
-                            " than the lowest in the current range.");
-  else if (xValue > maxX)
-    throw std::out_of_range("MatrixWorkspace::yIndexOfX - X value is greater"
-                            " than the highest in the current range.");
+  if (isHistogramDataByIndex(index)) {
+    UNUSED_ARG(tolerance);
 
-  if (isHistogramDataByIndex(index))
-    return binIndexOfValue(xValues, xValue, ascendingOrder, tolerance);
-  else
+    if (xValue < minX || xValue > maxX)
+      throw std::out_of_range("MatrixWorkspace::yIndexOfX - X value is out of "
+                              "the range of the min and max bin edges.");
+
+    return binIndexOfValue(xValues, xValue, ascendingOrder);
+  } else {
+    if (xValue < minX - tolerance || xValue > maxX + tolerance)
+      throw std::out_of_range("MatrixWorkspace::yIndexOfX - X value is out of "
+                              "range for this point data.");
+
     return xIndexOfValue(xValues, xValue, tolerance);
+  }
 }
 
 /**
@@ -1406,17 +1409,14 @@ std::size_t MatrixWorkspace::yIndexOfX(const double xValue,
  * @param xValues :: The histogram to search
  * @param xValue :: The X value to search for
  * @param ascendingOrder :: True if the order of the xValues is ascending
- * @param tolerance :: The tolerance to accept between the passed xValue and the
- *                     stored value (default = 0.0)
  * @returns An index to the bin containing X
  */
-std::size_t MatrixWorkspace::binIndexOfValue(
-    HistogramData::HistogramX const &xValues, double const &xValue,
-    bool const &ascendingOrder, double const &tolerance) const {
+std::size_t
+MatrixWorkspace::binIndexOfValue(HistogramData::HistogramX const &xValues,
+                                 double xValue, bool ascendingOrder) const {
   std::size_t hops;
   if (ascendingOrder) {
-    auto lowerIter =
-        std::lower_bound(xValues.cbegin(), xValues.cend(), xValue - tolerance);
+    auto lowerIter = std::lower_bound(xValues.cbegin(), xValues.cend(), xValue);
 
     // If we are pointing at the first value then we want to be in the first bin
     if (lowerIter == xValues.cbegin())
@@ -1424,8 +1424,8 @@ std::size_t MatrixWorkspace::binIndexOfValue(
 
     hops = std::distance(xValues.cbegin(), lowerIter);
   } else {
-    auto lowerIter = std::upper_bound(xValues.crbegin(), xValues.crend(),
-                                      xValue + tolerance);
+    auto lowerIter =
+        std::upper_bound(xValues.crbegin(), xValues.crend(), xValue);
 
     if (lowerIter == xValues.crend())
       --lowerIter;
@@ -1449,8 +1449,7 @@ std::size_t MatrixWorkspace::binIndexOfValue(
  */
 std::size_t
 MatrixWorkspace::xIndexOfValue(HistogramData::HistogramX const &xValues,
-                               double const &xValue,
-                               double const &tolerance) const {
+                               double xValue, double tolerance) const {
   auto const iter = std::find_if(xValues.cbegin(), xValues.cend(),
                                  [&xValue, &tolerance](double const &value) {
                                    return std::abs(xValue - value) <= tolerance;

--- a/Framework/API/test/MatrixWorkspaceTest.h
+++ b/Framework/API/test/MatrixWorkspaceTest.h
@@ -1784,7 +1784,7 @@ public:
     std::vector<double> const xValues{5.3, 4.3, 3.3, 2.3};
     auto const workspace = getWorkspaceWithPopulatedX(1, 4, 3, xValues);
 
-    TS_ASSERT_EQUALS(workspace.yIndexOfX(4.3), 0);
+    TS_ASSERT_EQUALS(workspace.yIndexOfX(4.3), 1);
   }
 
   void
@@ -1855,7 +1855,7 @@ public:
     std::vector<double> const xValues{4.0, 3.0, 2.0, 1.0};
     auto const workspace = getWorkspaceWithPopulatedX(1, 4, 3, xValues);
 
-    TS_ASSERT_EQUALS(workspace.yIndexOfX(3.0), 0);
+    TS_ASSERT_EQUALS(workspace.yIndexOfX(3.0), 1);
   }
 
   void

--- a/Framework/Algorithms/src/CopyDataRange.cpp
+++ b/Framework/Algorithms/src/CopyDataRange.cpp
@@ -42,10 +42,8 @@ void copyDataRange(const MatrixWorkspace_const_sptr &inputWorkspace,
                    int const &specMin, int const &specMax, double const &xMin,
                    double const &xMax, int yInsertionIndex,
                    int const &xInsertionIndex) {
-  auto const xMinIndex =
-      static_cast<int>(inputWorkspace->yIndexOfX(xMin, 0, 0.000001));
-  auto const xMaxIndex =
-      static_cast<int>(inputWorkspace->yIndexOfX(xMax, 0, 0.000001));
+  auto const xMinIndex = static_cast<int>(inputWorkspace->yIndexOfX(xMin, 0));
+  auto const xMaxIndex = static_cast<int>(inputWorkspace->yIndexOfX(xMax, 0));
 
   copyDataRange(inputWorkspace, std::move(destWorkspace), specMin, specMax,
                 xMinIndex, xMaxIndex, yInsertionIndex, xInsertionIndex);
@@ -96,11 +94,15 @@ void CopyDataRange::init() {
   declareProperty("EndWorkspaceIndex", EMPTY_INT(), positiveInt,
                   "The index denoting the end of the spectra range.");
 
-  declareProperty("XMin", EMPTY_DBL(), anyDouble,
-                  "An X value that is within the first (lowest X value) bin");
+  declareProperty(
+      "XMin", EMPTY_DBL(), anyDouble,
+      "An X value that is equal to the lowest point to copy (point data), or "
+      "an X value that is within the first bin to copy (histogram data).");
 
-  declareProperty("XMax", EMPTY_DBL(), anyDouble,
-                  "An X value that is in the highest X value bin");
+  declareProperty(
+      "XMax", EMPTY_DBL(), anyDouble,
+      "An X value that is equal to the highest point to copy (point data), or "
+      "an X value that is within the last bin to copy (histogram data).");
 
   declareProperty("InsertionYIndex", 0, positiveInt,
                   "The index denoting the histogram position for the start of "


### PR DESCRIPTION
**Description of work.**
This PR fixes a problem with the `yIndexOfX` method when used on histogram data. It does not make sense to have a tolerance for histogram data. Here's an example of a histogram with two bins (top row is bin centre values, bottom row is bin edges):
```
| 3.5 | 4.5 |
3     4      5
```
In this case of yIndexOfX(4.1) we should expect to get the index of the right hand bin back regardless of any tolerance. At the moment if you supply a tolerance value (eg 0.2) the function would return the left hand bin. This does not make sense.

**To test:**
Make sure the tests pass, and that the above example returns the expected bin index.

No related issue. *No release notes required as this is more of an internal change.*

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
