### PR TITLE
Remove python 2/3 compatibility code from bindings

### DIFF
--- a/Framework/PythonInterface/mantid/api/src/Exports/IPeaksWorkspace.cpp
+++ b/Framework/PythonInterface/mantid/api/src/Exports/IPeaksWorkspace.cpp
@@ -239,15 +239,8 @@ IPeaksWorkspaceIterator makePyIterator(IPeaksWorkspace &self) {
 
 void export_IPeaksWorkspaceIterator() {
   class_<IPeaksWorkspaceIterator>("IPeaksWorkspaceIterator", no_init)
-      .def(
-#if PY_VERSION_HEX >= 0x03000000
-          "__next__"
-#else
-          "next"
-#endif
-          ,
-          &IPeaksWorkspaceIterator::next,
-          return_value_policy<reference_existing_object>())
+      .def("__next__", &IPeaksWorkspaceIterator::next,
+           return_value_policy<reference_existing_object>())
       .def("__iter__", objects::identity_function());
 }
 

--- a/Framework/PythonInterface/mantid/api/src/Exports/SpectrumInfoPythonIterator.cpp
+++ b/Framework/PythonInterface/mantid/api/src/Exports/SpectrumInfoPythonIterator.cpp
@@ -20,15 +20,8 @@ void export_SpectrumInfoPythonIterator() {
   // Export to Python
   class_<SpectrumInfoPythonIterator>("SpectrumInfoPythonIterator", no_init)
       .def("__iter__", objects::identity_function())
-      .def(
-#if PY_VERSION_HEX >= 0x03000000
-          "__next__"
-#else
-          "next"
-#endif
-          ,
-          &SpectrumInfoPythonIterator::next,
-          return_value_policy<copy_const_reference>());
+      .def("__next__", &SpectrumInfoPythonIterator::next,
+           return_value_policy<copy_const_reference>());
   /*
    Return value policy for next is to copy the const reference. Copy by value is
    essential for python 2.0 compatibility because items (SpectrumInfoItem) will

--- a/Framework/PythonInterface/mantid/kernel/src/kernel.cpp.in
+++ b/Framework/PythonInterface/mantid/kernel/src/kernel.cpp.in
@@ -40,37 +40,6 @@ namespace converter = boost::python::converter;
 // Forward declare
 @EXPORT_DECLARE@
 
-#if PY_VERSION_HEX < 0x03000000
-    /**
-     * Adds a from_python converter to converter unicode strings to std::string
-     * by encoding them in utf-8 if possible. Adapted from
-     * https://www.boost.org/doc/libs/1_68_0/libs/python/doc/html/faq/how_can_i_automatically_convert_.html
-     */
-struct from_unicode_py2 {
-  from_unicode_py2() {
-    converter::registry::push_back(&convertible, &construct,
-                                   type_id<std::string>());
-  }
-  static void *convertible(PyObject *obj_ptr) {
-    return (PyUnicode_Check(obj_ptr)) ? obj_ptr : 0;
-  }
-  static void construct(PyObject *obj_ptr,
-                        converter::rvalue_from_python_stage1_data *data) {
-    PyObject *pyutf8 = PyUnicode_AsUTF8String(obj_ptr);
-    if (pyutf8 == 0)
-      boost::python::throw_error_already_set();
-    const char *value = PyString_AsString(pyutf8);
-    if (value == 0)
-      boost::python::throw_error_already_set();
-    using rvalue_from_python_std_string = converter::rvalue_from_python_storage<std::string>;
-    void *storage = reinterpret_cast<rvalue_from_python_std_string*>(data)->storage.bytes;
-    new (storage) std::string(value);
-    data->convertible = storage;
-    Py_DECREF(pyutf8); // Must be deleted after the std::string has taken a copy
-  }
-};
-#endif
-
 BOOST_PYTHON_MODULE(_kernel) {
   // Doc string options - User defined, python arguments, C++ call signatures
   boost::python::docstring_options docstrings(true, true, false);
@@ -98,11 +67,6 @@ BOOST_PYTHON_MODULE(_kernel) {
   def("paper_citation", &Mantid::Kernel::MantidVersion::paperCitation,
       "Returns The citation for the Mantid paper");
 
-#if PY_VERSION_HEX < 0x03000000
-  // accept unicode strings wherever we see std::string (as long as they can be
-  // encoded in utf8)
-  from_unicode_py2();
-#endif
   Mantid::PythonInterface::Registry::TypeRegistry::registerBuiltins();
 
   @EXPORT_FUNCTIONS@

--- a/buildconfig/CMake/CppCheck_Suppressions.txt.in
+++ b/buildconfig/CMake/CppCheck_Suppressions.txt.in
@@ -88,9 +88,6 @@ noCopyConstructor:${CMAKE_SOURCE_DIR}/Framework/Geometry/inc/MantidGeometry/Rend
 
 // ----------------- Upstream libs ---------------
 
-// Always ignore bin dir
-*:*${CMAKE_BINARY_DIR}/*
-
 // All ANN files as they are upstream anyway
 *:*${CMAKE_SOURCE_DIR}/Framework/Kernel/src/ANN/*
 


### PR DESCRIPTION
While working on changes to logging, I discovered some compatibility code. This removes most of it from the bindings.

**To test:**

If the builds pass, it is good.

*There is no associated issue.*


*This does not require release notes* because it removes compatibility with python2 which has been gone for two releases.

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
