### PR TITLE
Bug in date/time loading

### DIFF
--- a/Framework/DataHandling/src/LoadParameterFile.cpp
+++ b/Framework/DataHandling/src/LoadParameterFile.cpp
@@ -141,7 +141,7 @@ void LoadParameterFile::exec() {
   // pRootElem
   InstrumentDefinitionParser loadInstr;
   loadInstr.setComponentLinks(instrument, pRootElem, &prog,
-                              localWorkspace->getAvailableWorkspaceStartDate());
+                              localWorkspace->getWorkspaceStartDate());
 
   // populate parameter map of workspace
   localWorkspace->populateInstrumentParameters();


### PR DESCRIPTION
When the locale is different from English (I got the error with French locale), the date/time is incorrectly parsed from the nexus metadata. The problem is coming from a conversion from ISO to string using `strftime`, which depends on the locale.
 
**To reproduce:**

The problem does not occur on all tested systems. It happens on my computer: Ubuntu 18.04, Gnome, system language sets to French.  When loading `002888.nxs` from the ILL D11 system test data, I got the following error:
```
Error in execution of algorithm LoadParameterFile:
Error interpreting string '2019-juin-28 12:54:49' as a date/time.
```
The error disappears with `LC_TIME=en_US.UTF-8`.

**To test:**

First try to reproduce the original problem. If the system language is set to English, the error can, sometimes, be simulated with `LC_TIME=fr_FR.UTF-8`.

*There is no associated issue.*

*This does not require release notes*, internal changes only

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
