### PR TITLE
Fixed unit tests for HB3A algorithms not being included ornl-next

### DIFF
--- a/Framework/PythonInterface/test/python/plugins/algorithms/CMakeLists.txt
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/CMakeLists.txt
@@ -48,6 +48,9 @@ set(TEST_PY_FILES
     FractionalIndexingTest.py
     GetEiT0atSNSTest.py
     HB2AReduceTest.py
+    HB3AAdjustSampleNormTest.py
+    HB3AFindPeaksTest.py
+    HB3AIntegratePeaksTest.py
     HFIRSANS2WavelengthTest.py
     IndirectTransmissionTest.py
     IndexSatellitePeaksTest.py


### PR DESCRIPTION
Version of #30131 into `ornl-next`


