### PR TITLE
Fit Script Generator - Connect FunctionTreeView to data table

### DIFF
--- a/Framework/API/inc/MantidAPI/CompositeFunction.h
+++ b/Framework/API/inc/MantidAPI/CompositeFunction.h
@@ -157,7 +157,7 @@ public:
   [[nodiscard]] std::vector<std::shared_ptr<IFunction>>
   createEquivalentFunctions() const override;
   /// Returns true if the composite has at least one of this function.
-  bool hasFunction(const std::string &functionStr) const;
+  bool hasFunction(const std::string &functionName) const;
   /// Returns the pointer to i-th function
   [[nodiscard]] IFunction_sptr getFunction(std::size_t i) const override;
   /// Number of functions
@@ -176,8 +176,9 @@ public:
   /// Replace a function
   void replaceFunctionPtr(const IFunction_sptr &f_old,
                           const IFunction_sptr &f_new);
-  /// Get the first function index with a matching function string
-  [[nodiscard]] std::size_t functionIndex(const std::string &functionStr) const;
+  /// Get the first function index with a matching function name
+  [[nodiscard]] std::size_t
+  functionIndex(const std::string &functionName) const;
   /// Get the function index
   [[nodiscard]] std::size_t functionIndex(std::size_t i) const;
   [[nodiscard]] std::size_t attributeFunctionIndex(std::size_t i) const;

--- a/Framework/API/inc/MantidAPI/CompositeFunction.h
+++ b/Framework/API/inc/MantidAPI/CompositeFunction.h
@@ -157,7 +157,7 @@ public:
   [[nodiscard]] std::vector<std::shared_ptr<IFunction>>
   createEquivalentFunctions() const override;
   /// Returns true if the composite has at least one of this function.
-  bool hasFunction(const std::string &functionName) const;
+  [[nodiscard]] bool hasFunction(const std::string &functionName) const;
   /// Returns the pointer to i-th function
   [[nodiscard]] IFunction_sptr getFunction(std::size_t i) const override;
   /// Number of functions

--- a/Framework/API/inc/MantidAPI/CompositeFunction.h
+++ b/Framework/API/inc/MantidAPI/CompositeFunction.h
@@ -156,6 +156,8 @@ public:
   /// Split this function (if needed) into a list of independent functions.
   [[nodiscard]] std::vector<std::shared_ptr<IFunction>>
   createEquivalentFunctions() const override;
+  /// Returns true if the composite has at least one of this function.
+  bool hasFunction(const std::string &functionStr) const;
   /// Returns the pointer to i-th function
   [[nodiscard]] IFunction_sptr getFunction(std::size_t i) const override;
   /// Number of functions
@@ -174,6 +176,8 @@ public:
   /// Replace a function
   void replaceFunctionPtr(const IFunction_sptr &f_old,
                           const IFunction_sptr &f_new);
+  /// Get the first function index with a matching function string
+  [[nodiscard]] std::size_t functionIndex(const std::string &functionStr) const;
   /// Get the function index
   [[nodiscard]] std::size_t functionIndex(std::size_t i) const;
   [[nodiscard]] std::size_t attributeFunctionIndex(std::size_t i) const;

--- a/Framework/API/inc/MantidAPI/ParameterTie.h
+++ b/Framework/API/inc/MantidAPI/ParameterTie.h
@@ -42,7 +42,7 @@ public:
   /// Set the tie expression
   virtual void set(const std::string &expr);
   /// Evaluate the expression
-  virtual double eval();
+  virtual double eval(bool setParameterValue = true);
   /// Return the string that can be used to recreate this tie
   virtual std::string asString(const IFunction *fun = nullptr) const;
 

--- a/Framework/API/src/CompositeFunction.cpp
+++ b/Framework/API/src/CompositeFunction.cpp
@@ -665,7 +665,7 @@ void CompositeFunction::replaceFunction(size_t functionIndex,
  */
 bool CompositeFunction::hasFunction(const std::string &functionName) const {
   return std::any_of(m_functions.cbegin(), m_functions.cend(),
-                     [&functionName](IFunction_sptr function) {
+                     [&functionName](const IFunction_const_sptr &function) {
                        return function->name() == functionName;
                      });
 }
@@ -691,15 +691,16 @@ IFunction_sptr CompositeFunction::getFunction(std::size_t i) const {
  */
 std::size_t
 CompositeFunction::functionIndex(const std::string &functionName) const {
-  const auto iter = std::find_if(m_functions.cbegin(), m_functions.cend(),
-                                 [&functionName](IFunction_sptr function) {
-                                   return function->name() == functionName;
-                                 });
+  const auto iter =
+      std::find_if(m_functions.cbegin(), m_functions.cend(),
+                   [&functionName](const IFunction_const_sptr &function) {
+                     return function->name() == functionName;
+                   });
 
   if (iter != m_functions.cend())
     return std::distance(m_functions.cbegin(), iter);
 
-  throw std::invalid_argument("A function with string '" + functionName +
+  throw std::invalid_argument("A function with name '" + functionName +
                               "' does not exist in this composite function.");
 }
 

--- a/Framework/API/src/CompositeFunction.cpp
+++ b/Framework/API/src/CompositeFunction.cpp
@@ -659,6 +659,18 @@ void CompositeFunction::replaceFunction(size_t functionIndex,
 }
 
 /**
+ * @param functionStr :: The function string to search for.
+ * @returns true if the composite function has at least one of a function with a
+ * matching string.
+ */
+bool CompositeFunction::hasFunction(const std::string &functionStr) const {
+  return std::any_of(m_functions.cbegin(), m_functions.cend(),
+                     [&functionStr](IFunction_sptr function) {
+                       return function->asString() == functionStr;
+                     });
+}
+
+/**
  * @param i :: The index of the function
  * @return function at the requested index
  */
@@ -669,6 +681,26 @@ IFunction_sptr CompositeFunction::getFunction(std::size_t i) const {
                             ").");
   }
   return m_functions[i];
+}
+
+/**
+ * Gets the index of the first function with a matching function string.
+ * @param functionStr :: The function string to search for.
+ * @returns function index of the first function with a matching function
+ * string.
+ */
+std::size_t
+CompositeFunction::functionIndex(const std::string &functionStr) const {
+  const auto iter = std::find_if(m_functions.cbegin(), m_functions.cend(),
+                                 [&functionStr](IFunction_sptr function) {
+                                   return function->asString() == functionStr;
+                                 });
+
+  if (iter != m_functions.cend())
+    return std::distance(m_functions.cbegin(), iter);
+
+  throw std::invalid_argument("A function with string '" + functionStr +
+                              "' does not exist in this composite function.");
 }
 
 /**

--- a/Framework/API/src/CompositeFunction.cpp
+++ b/Framework/API/src/CompositeFunction.cpp
@@ -685,7 +685,7 @@ IFunction_sptr CompositeFunction::getFunction(std::size_t i) const {
 
 /**
  * Gets the index of the first function with a matching function string.
- * @param functionStr :: The function string to search for.
+ * @param functionName :: The name of the function to search for.
  * @returns function index of the first function with a matching function
  * string.
  */

--- a/Framework/API/src/CompositeFunction.cpp
+++ b/Framework/API/src/CompositeFunction.cpp
@@ -659,14 +659,14 @@ void CompositeFunction::replaceFunction(size_t functionIndex,
 }
 
 /**
- * @param functionStr :: The function string to search for.
+ * @param functionName :: The function name to search for.
  * @returns true if the composite function has at least one of a function with a
- * matching string.
+ * matching name.
  */
-bool CompositeFunction::hasFunction(const std::string &functionStr) const {
+bool CompositeFunction::hasFunction(const std::string &functionName) const {
   return std::any_of(m_functions.cbegin(), m_functions.cend(),
-                     [&functionStr](IFunction_sptr function) {
-                       return function->asString() == functionStr;
+                     [&functionName](IFunction_sptr function) {
+                       return function->name() == functionName;
                      });
 }
 
@@ -690,16 +690,16 @@ IFunction_sptr CompositeFunction::getFunction(std::size_t i) const {
  * string.
  */
 std::size_t
-CompositeFunction::functionIndex(const std::string &functionStr) const {
+CompositeFunction::functionIndex(const std::string &functionName) const {
   const auto iter = std::find_if(m_functions.cbegin(), m_functions.cend(),
-                                 [&functionStr](IFunction_sptr function) {
-                                   return function->asString() == functionStr;
+                                 [&functionName](IFunction_sptr function) {
+                                   return function->name() == functionName;
                                  });
 
   if (iter != m_functions.cend())
     return std::distance(m_functions.cbegin(), iter);
 
-  throw std::invalid_argument("A function with string '" + functionStr +
+  throw std::invalid_argument("A function with string '" + functionName +
                               "' does not exist in this composite function.");
 }
 

--- a/Framework/API/src/ParameterTie.cpp
+++ b/Framework/API/src/ParameterTie.cpp
@@ -112,7 +112,7 @@ void ParameterTie::set(const std::string &expr) {
   m_expression.append(start, end);
 }
 
-double ParameterTie::eval() {
+double ParameterTie::eval(bool setParameterValue) {
   double res = 0;
   try {
     for (std::map<double *, ParameterReference>::const_iterator it =
@@ -125,7 +125,8 @@ double ParameterTie::eval() {
     throw std::runtime_error("Error in expression: " + e.GetMsg());
   }
 
-  setParameter(res);
+  if (setParameterValue)
+    setParameter(res);
 
   return res;
 }

--- a/Framework/API/test/CompositeFunctionTest.h
+++ b/Framework/API/test/CompositeFunctionTest.h
@@ -1459,6 +1459,9 @@ public:
   void
   test_hasFunction_returns_false_if_the_composite_does_not_contain_a_function_with_the_given_name() {
     auto const composite = std::make_unique<CompositeFunction>();
+    auto const background = std::make_shared<Linear<true>>();
+    composite->addFunction(background);
+
     TS_ASSERT(!composite->hasFunction("Gauss"));
   }
 
@@ -1478,6 +1481,9 @@ public:
   void
   test_functionIndex_throws_if_the_function_name_provided_does_not_exist_in_the_composite() {
     auto const composite = std::make_unique<CompositeFunction>();
+    auto const background = std::make_shared<Linear<true>>();
+    composite->addFunction(background);
+
     TS_ASSERT_THROWS(composite->functionIndex("Gauss"),
                      const std::invalid_argument &);
   }

--- a/Framework/API/test/CompositeFunctionTest.h
+++ b/Framework/API/test/CompositeFunctionTest.h
@@ -1445,4 +1445,40 @@ public:
     mfun->setError("f1.s", 5.0);
     TS_ASSERT_EQUALS(mfun->getError("f1.s"), 5.0);
   }
+
+  void
+  test_hasFunction_returns_true_if_the_composite_contains_a_function_with_the_given_name() {
+    auto composite = std::make_unique<CompositeFunction>();
+    auto const gauss = std::make_shared<Gauss<true>>();
+
+    composite->addFunction(gauss);
+
+    TS_ASSERT(composite->hasFunction("Gauss"));
+  }
+
+  void
+  test_hasFunction_returns_false_if_the_composite_does_not_contain_a_function_with_the_given_name() {
+    auto const composite = std::make_unique<CompositeFunction>();
+    TS_ASSERT(!composite->hasFunction("Gauss"));
+  }
+
+  void
+  test_functionIndex_returns_the_correct_index_of_a_function_in_the_composite() {
+    auto composite = std::make_unique<CompositeFunction>();
+    auto const gauss = std::make_shared<Gauss<true>>();
+    auto const background = std::make_shared<Linear<true>>();
+
+    composite->addFunction(gauss);
+    composite->addFunction(background);
+
+    TS_ASSERT_EQUALS(composite->functionIndex("Gauss"), 0);
+    TS_ASSERT_EQUALS(composite->functionIndex("Linear"), 1);
+  }
+
+  void
+  test_functionIndex_throws_if_the_function_name_provided_does_not_exist_in_the_composite() {
+    auto const composite = std::make_unique<CompositeFunction>();
+    TS_ASSERT_THROWS(composite->functionIndex("Gauss"),
+                     const std::invalid_argument &);
+  }
 };

--- a/Testing/SystemTests/tests/qt/FitScriptGeneratorStartupTest.py
+++ b/Testing/SystemTests/tests/qt/FitScriptGeneratorStartupTest.py
@@ -1,0 +1,48 @@
+# Mantid Repository : https://github.com/mantidproject/mantid
+#
+# Copyright &copy; 2020 ISIS Rutherford Appleton Laboratory UKRI,
+#   NScD Oak Ridge National Laboratory, European Spallation Source,
+#   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+# SPDX - License - Identifier: GPL - 3.0 +
+import systemtesting
+
+from mantid.api import AnalysisDataService
+from mantid.simpleapi import CreateWorkspace
+from mantidqt.utils.qt.testing import get_application
+from mantidqt.utils.qt.testing.qt_widget_finder import QtWidgetFinder  # noqa: E402
+
+from mantidqt.widgets.fitscriptgenerator import (FittingMode, FitScriptGeneratorModel, FitScriptGeneratorPresenter,
+                                                 FitScriptGeneratorView)
+
+from qtpy.QtWidgets import QApplication
+
+
+class FitScriptGeneratorStartupTest(systemtesting.MantidSystemTest, QtWidgetFinder):
+    """
+    A system test for testing that the Fit Script Generator interface opens ok.
+    """
+    def __init__(self):
+        super(FitScriptGeneratorStartupTest, self).__init__()
+
+        self._app = get_application()
+
+        self.ws_name = "WorkspaceName"
+        test_workspace = CreateWorkspace(DataX=[1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16],
+                                         DataY=[1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12], NSpec=4, UnitX="Wavelength")
+        AnalysisDataService.addOrReplace(self.ws_name, test_workspace)
+
+        self.fsg_model = FitScriptGeneratorModel()
+        self.fsg_view = FitScriptGeneratorView(None, FittingMode.SIMULTANEOUS, {"Minimizer": "Levenberg-Marquardt"})
+        self.fsg_presenter = FitScriptGeneratorPresenter(self.fsg_view, self.fsg_model, [self.ws_name], 1.0, 3.0)
+
+    def runTest(self):
+        try:
+            self.fsg_presenter.openFitScriptGenerator()
+            QApplication.sendPostedEvents()
+
+            self.assert_widget_created()
+
+            self.assertTrue(self.fsg_view.close())
+            QApplication.sendPostedEvents()
+        except Exception as ex:
+            self.fail(f"Exception thrown when attempting to open the Fit Script Generator interface: {ex}.")

--- a/qt/python/mantidqt/_common.sip
+++ b/qt/python/mantidqt/_common.sip
@@ -1094,6 +1094,9 @@ class FitScriptGeneratorModel {
 %End
 public:
     FitScriptGeneratorModel();
+
+private:
+    FitScriptGeneratorModel(const FitScriptGeneratorModel &model);
 };
 
 // ----------------------------------------------------------------------------

--- a/qt/python/mantidqt/_common.sip
+++ b/qt/python/mantidqt/_common.sip
@@ -1071,6 +1071,21 @@ public:
 };
 
 // ----------------------------------------------------------------------------
+// FittingMode
+// ----------------------------------------------------------------------------
+
+namespace MantidQt
+{
+namespace MantidWidgets
+{
+%TypeHeaderCode
+#include "MantidQtWidgets/Common/FittingMode.h"
+%End
+enum FittingMode {SIMULTANEOUS, SEQUENTIAL, SIMULTANEOUS_SEQUENTIAL};
+};
+};
+
+// ----------------------------------------------------------------------------
 // FitScriptGeneratorView
 // ----------------------------------------------------------------------------
 
@@ -1081,6 +1096,7 @@ class FitScriptGeneratorView : QWidget {
 public:
     FitScriptGeneratorView(
         QWidget *parent = nullptr,
+        MantidQt::MantidWidgets::FittingMode fittingMode = MantidQt::MantidWidgets::SEQUENTIAL,
         const QMap<QString, QString> &fitOptions = QMap<QString, QString>()) /KeywordArgs="All"/;
 };
 

--- a/qt/python/mantidqt/widgets/fitscriptgenerator/__init__.py
+++ b/qt/python/mantidqt/widgets/fitscriptgenerator/__init__.py
@@ -6,6 +6,8 @@
 # SPDX - License - Identifier: GPL - 3.0 +
 from mantidqt.utils.qt import import_qt
 
+FittingMode = import_qt('..._common', 'mantidqt.widgets.fitscriptgenerator').MantidQt.MantidWidgets.FittingMode
+
 FitScriptGeneratorView = import_qt('..._common', 'mantidqt.widgets.fitscriptgenerator', 'FitScriptGeneratorView')
 FitScriptGeneratorModel = import_qt('..._common', 'mantidqt.widgets.fitscriptgenerator', 'FitScriptGeneratorModel')
 FitScriptGeneratorPresenter = import_qt('..._common', 'mantidqt.widgets.fitscriptgenerator',

--- a/qt/scientific_interfaces/Indirect/IndirectFitAnalysisTab.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectFitAnalysisTab.cpp
@@ -11,6 +11,7 @@
 #include "MantidAPI/TextAxis.h"
 #include "MantidAPI/WorkspaceFactory.h"
 
+#include "MantidQtWidgets/Common/FittingMode.h"
 #include "MantidQtWidgets/Common/PropertyHandler.h"
 #include "MantidQtWidgets/Common/SignalBlocker.h"
 
@@ -448,7 +449,7 @@ void IndirectFitAnalysisTab::updateFitBrowserParameterValuesFromAlg() {
     updateFitBrowserParameterValues();
     if (m_fittingAlgorithm) {
       MantidQt::API::SignalBlocker blocker(m_fitPropertyBrowser);
-      if (m_fittingModel->getFittingMode() == FittingMode::SEQUENTIAL) {
+      if (m_fittingModel->getFittingMode() == FittingMode::Sequential) {
         auto const paramWsName =
             m_fittingAlgorithm->getPropertyValue("OutputParameterWorkspace");
         auto paramWs =
@@ -478,7 +479,7 @@ void IndirectFitAnalysisTab::updateFitBrowserParameterValuesFromAlg() {
  */
 void IndirectFitAnalysisTab::updateFitStatus() {
 
-  if (m_fittingModel->getFittingMode() == FittingMode::SIMULTANEOUS) {
+  if (m_fittingModel->getFittingMode() == FittingMode::Simultaneous) {
     std::string fit_status = m_fittingAlgorithm->getProperty("OutputStatus");
     double chi2 = m_fittingAlgorithm->getProperty("OutputChiSquared");
     const std::vector<std::string> status(m_fittingModel->getNumberOfDomains(),
@@ -561,7 +562,7 @@ void IndirectFitAnalysisTab::singleFit(TableDatasetIndex dataIndex,
     m_plotPresenter->setFitSingleSpectrumIsFitting(true);
     enableFitButtons(false);
     enableOutputOptions(false);
-    m_fittingModel->setFittingMode(FittingMode::SIMULTANEOUS);
+    m_fittingModel->setFittingMode(FittingMode::Simultaneous);
     m_currentTableDatasetIndex = dataIndex;
     runSingleFit(m_fittingModel->getSingleFit(dataIndex, spectrum));
   }
@@ -606,9 +607,9 @@ void IndirectFitAnalysisTab::run() {
   enableOutputOptions(false);
   auto const fitType = m_fitPropertyBrowser->selectedFitType();
   if (fitType == "Simultaneous") {
-    m_fittingModel->setFittingMode(FittingMode::SIMULTANEOUS);
+    m_fittingModel->setFittingMode(FittingMode::Simultaneous);
   } else {
-    m_fittingModel->setFittingMode(FittingMode::SEQUENTIAL);
+    m_fittingModel->setFittingMode(FittingMode::Sequential);
   }
   runFitAlgorithm(m_fittingModel->getFittingAlgorithm());
 }
@@ -703,7 +704,7 @@ void IndirectFitAnalysisTab::setAlgorithmProperties(
                               m_fitPropertyBrowser->outputCompositeMembers());
   }
 
-  if (m_fittingModel->getFittingMode() == FittingMode::SEQUENTIAL) {
+  if (m_fittingModel->getFittingMode() == FittingMode::Sequential) {
     fitAlgorithm->setProperty("FitType", m_fitPropertyBrowser->fitType());
   }
   fitAlgorithm->setProperty("OutputFitStatus", true);

--- a/qt/scientific_interfaces/Indirect/IndirectFitAnalysisTab.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectFitAnalysisTab.cpp
@@ -449,7 +449,7 @@ void IndirectFitAnalysisTab::updateFitBrowserParameterValuesFromAlg() {
     updateFitBrowserParameterValues();
     if (m_fittingAlgorithm) {
       MantidQt::API::SignalBlocker blocker(m_fitPropertyBrowser);
-      if (m_fittingModel->getFittingMode() == FittingMode::Sequential) {
+      if (m_fittingModel->getFittingMode() == FittingMode::SEQUENTIAL) {
         auto const paramWsName =
             m_fittingAlgorithm->getPropertyValue("OutputParameterWorkspace");
         auto paramWs =
@@ -479,7 +479,7 @@ void IndirectFitAnalysisTab::updateFitBrowserParameterValuesFromAlg() {
  */
 void IndirectFitAnalysisTab::updateFitStatus() {
 
-  if (m_fittingModel->getFittingMode() == FittingMode::Simultaneous) {
+  if (m_fittingModel->getFittingMode() == FittingMode::SIMULTANEOUS) {
     std::string fit_status = m_fittingAlgorithm->getProperty("OutputStatus");
     double chi2 = m_fittingAlgorithm->getProperty("OutputChiSquared");
     const std::vector<std::string> status(m_fittingModel->getNumberOfDomains(),
@@ -562,7 +562,7 @@ void IndirectFitAnalysisTab::singleFit(TableDatasetIndex dataIndex,
     m_plotPresenter->setFitSingleSpectrumIsFitting(true);
     enableFitButtons(false);
     enableOutputOptions(false);
-    m_fittingModel->setFittingMode(FittingMode::Simultaneous);
+    m_fittingModel->setFittingMode(FittingMode::SIMULTANEOUS);
     m_currentTableDatasetIndex = dataIndex;
     runSingleFit(m_fittingModel->getSingleFit(dataIndex, spectrum));
   }
@@ -607,9 +607,9 @@ void IndirectFitAnalysisTab::run() {
   enableOutputOptions(false);
   auto const fitType = m_fitPropertyBrowser->selectedFitType();
   if (fitType == "Simultaneous") {
-    m_fittingModel->setFittingMode(FittingMode::Simultaneous);
+    m_fittingModel->setFittingMode(FittingMode::SIMULTANEOUS);
   } else {
-    m_fittingModel->setFittingMode(FittingMode::Sequential);
+    m_fittingModel->setFittingMode(FittingMode::SEQUENTIAL);
   }
   runFitAlgorithm(m_fittingModel->getFittingAlgorithm());
 }
@@ -704,7 +704,7 @@ void IndirectFitAnalysisTab::setAlgorithmProperties(
                               m_fitPropertyBrowser->outputCompositeMembers());
   }
 
-  if (m_fittingModel->getFittingMode() == FittingMode::Sequential) {
+  if (m_fittingModel->getFittingMode() == FittingMode::SEQUENTIAL) {
     fitAlgorithm->setProperty("FitType", m_fitPropertyBrowser->fitType());
   }
   fitAlgorithm->setProperty("OutputFitStatus", true);

--- a/qt/scientific_interfaces/Indirect/IndirectFitPropertyBrowser.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectFitPropertyBrowser.cpp
@@ -16,6 +16,7 @@
 #include "MantidAPI/WorkspaceGroup.h"
 
 #include "MantidQtWidgets/Common/FitOptionsBrowser.h"
+#include "MantidQtWidgets/Common/FittingMode.h"
 #include "MantidQtWidgets/Common/FunctionBrowser.h"
 #include "MantidQtWidgets/Common/SignalBlocker.h"
 
@@ -77,10 +78,10 @@ void IndirectFitPropertyBrowser::initFitOptionsBrowser() {
   // this object is added as a child to the stacked widget m_templateBrowser
   // which is a child of this class so the lifetime of this pointer is handled
   // by Qt
-  m_fitOptionsBrowser = new FitOptionsBrowser(
-      nullptr, FitOptionsBrowser::SimultaneousAndSequential);
+  m_fitOptionsBrowser =
+      new FitOptionsBrowser(nullptr, FittingMode::SimultaneousAndSequential);
   m_fitOptionsBrowser->setObjectName("fitOptionsBrowser");
-  m_fitOptionsBrowser->setCurrentFittingType(FitOptionsBrowser::Sequential);
+  m_fitOptionsBrowser->setCurrentFittingType(FittingMode::Sequential);
 }
 
 void IndirectFitPropertyBrowser::setHiddenProperties(
@@ -315,7 +316,7 @@ void IndirectFitPropertyBrowser::updateFitStatus(const FitDomainIndex index) {
  */
 QString IndirectFitPropertyBrowser::selectedFitType() const {
   return m_fitOptionsBrowser->getCurrentFittingType() ==
-                 FitOptionsBrowser::Simultaneous
+                 FittingMode::Simultaneous
              ? "Simultaneous"
              : "Sequential";
 }
@@ -448,9 +449,9 @@ void IndirectFitPropertyBrowser::browserVisibilityChanged(bool isVisible) {
 void IndirectFitPropertyBrowser::updateFitType() {
   auto const nGlobals = m_functionBrowser->getGlobalParameters().size();
   if (nGlobals == 0) {
-    m_fitOptionsBrowser->setCurrentFittingType(FitOptionsBrowser::Sequential);
+    m_fitOptionsBrowser->setCurrentFittingType(FittingMode::Sequential);
   } else {
-    m_fitOptionsBrowser->setCurrentFittingType(FitOptionsBrowser::Simultaneous);
+    m_fitOptionsBrowser->setCurrentFittingType(FittingMode::Simultaneous);
   }
 }
 

--- a/qt/scientific_interfaces/Indirect/IndirectFitPropertyBrowser.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectFitPropertyBrowser.cpp
@@ -79,9 +79,9 @@ void IndirectFitPropertyBrowser::initFitOptionsBrowser() {
   // which is a child of this class so the lifetime of this pointer is handled
   // by Qt
   m_fitOptionsBrowser =
-      new FitOptionsBrowser(nullptr, FittingMode::SimultaneousAndSequential);
+      new FitOptionsBrowser(nullptr, FittingMode::SIMULTANEOUS_SEQUENTIAL);
   m_fitOptionsBrowser->setObjectName("fitOptionsBrowser");
-  m_fitOptionsBrowser->setCurrentFittingType(FittingMode::Sequential);
+  m_fitOptionsBrowser->setCurrentFittingType(FittingMode::SEQUENTIAL);
 }
 
 void IndirectFitPropertyBrowser::setHiddenProperties(
@@ -316,7 +316,7 @@ void IndirectFitPropertyBrowser::updateFitStatus(const FitDomainIndex index) {
  */
 QString IndirectFitPropertyBrowser::selectedFitType() const {
   return m_fitOptionsBrowser->getCurrentFittingType() ==
-                 FittingMode::Simultaneous
+                 FittingMode::SIMULTANEOUS
              ? "Simultaneous"
              : "Sequential";
 }
@@ -449,9 +449,9 @@ void IndirectFitPropertyBrowser::browserVisibilityChanged(bool isVisible) {
 void IndirectFitPropertyBrowser::updateFitType() {
   auto const nGlobals = m_functionBrowser->getGlobalParameters().size();
   if (nGlobals == 0) {
-    m_fitOptionsBrowser->setCurrentFittingType(FittingMode::Sequential);
+    m_fitOptionsBrowser->setCurrentFittingType(FittingMode::SEQUENTIAL);
   } else {
-    m_fitOptionsBrowser->setCurrentFittingType(FittingMode::Simultaneous);
+    m_fitOptionsBrowser->setCurrentFittingType(FittingMode::SIMULTANEOUS);
   }
 }
 

--- a/qt/scientific_interfaces/Indirect/IndirectFittingModel.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectFittingModel.cpp
@@ -269,11 +269,11 @@ namespace IDA {
 
 std::unordered_map<FittingMode, std::string> fitModeToName =
     std::unordered_map<FittingMode, std::string>(
-        {{FittingMode::SEQUENTIAL, "Seq"}, {FittingMode::SIMULTANEOUS, "Sim"}});
+        {{FittingMode::Sequential, "Seq"}, {FittingMode::Simultaneous, "Sim"}});
 
 IndirectFittingModel::IndirectFittingModel()
     : m_fitDataModel(std::make_unique<IndirectFitDataModel>()),
-      m_previousModelSelected(false), m_fittingMode(FittingMode::SEQUENTIAL),
+      m_previousModelSelected(false), m_fittingMode(FittingMode::Sequential),
       m_fitOutput(std::make_unique<IndirectFitOutputModel>()) {}
 
 bool IndirectFittingModel::hasWorkspace(
@@ -613,7 +613,7 @@ IAlgorithm_sptr IndirectFittingModel::getFittingAlgorithm() const {
 
 IAlgorithm_sptr
 IndirectFittingModel::getFittingAlgorithm(FittingMode mode) const {
-  if (mode == FittingMode::SEQUENTIAL) {
+  if (mode == FittingMode::Sequential) {
     if (m_activeFunction->getNumberDomains() == 0) {
       throw std::runtime_error("Function is undefined");
     }

--- a/qt/scientific_interfaces/Indirect/IndirectFittingModel.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectFittingModel.cpp
@@ -269,11 +269,11 @@ namespace IDA {
 
 std::unordered_map<FittingMode, std::string> fitModeToName =
     std::unordered_map<FittingMode, std::string>(
-        {{FittingMode::Sequential, "Seq"}, {FittingMode::Simultaneous, "Sim"}});
+        {{FittingMode::SEQUENTIAL, "Seq"}, {FittingMode::SIMULTANEOUS, "Sim"}});
 
 IndirectFittingModel::IndirectFittingModel()
     : m_fitDataModel(std::make_unique<IndirectFitDataModel>()),
-      m_previousModelSelected(false), m_fittingMode(FittingMode::Sequential),
+      m_previousModelSelected(false), m_fittingMode(FittingMode::SEQUENTIAL),
       m_fitOutput(std::make_unique<IndirectFitOutputModel>()) {}
 
 bool IndirectFittingModel::hasWorkspace(
@@ -613,7 +613,7 @@ IAlgorithm_sptr IndirectFittingModel::getFittingAlgorithm() const {
 
 IAlgorithm_sptr
 IndirectFittingModel::getFittingAlgorithm(FittingMode mode) const {
-  if (mode == FittingMode::Sequential) {
+  if (mode == FittingMode::SEQUENTIAL) {
     if (m_activeFunction->getNumberDomains() == 0) {
       throw std::runtime_error("Function is undefined");
     }

--- a/qt/scientific_interfaces/Indirect/IndirectFittingModel.h
+++ b/qt/scientific_interfaces/Indirect/IndirectFittingModel.h
@@ -17,6 +17,7 @@
 #include "MantidAPI/IAlgorithm.h"
 #include "MantidAPI/IFunction_fwd.h"
 #include "MantidAPI/WorkspaceGroup.h"
+#include "MantidQtWidgets/Common/FittingMode.h"
 #include "MantidQtWidgets/Common/FunctionModelSpectra.h"
 #include "MantidQtWidgets/Common/IndexTypes.h"
 
@@ -28,7 +29,6 @@ namespace CustomInterfaces {
 namespace IDA {
 using namespace MantidWidgets;
 
-enum class FittingMode { SEQUENTIAL, SIMULTANEOUS };
 extern std::unordered_map<FittingMode, std::string> fitModeToName;
 
 class IndirectFittingModel;

--- a/qt/scientific_interfaces/MultiDatasetFit/MultiDatasetFit.cpp
+++ b/qt/scientific_interfaces/MultiDatasetFit/MultiDatasetFit.cpp
@@ -189,7 +189,7 @@ void MultiDatasetFit::initLayout() {
           m_functionBrowser, SLOT(addDatasets(const QStringList &)));
 
   m_fitOptionsBrowser = new MantidQt::MantidWidgets::FitOptionsBrowser(
-      nullptr, MantidQt::MantidWidgets::FittingMode::SimultaneousAndSequential);
+      nullptr, MantidQt::MantidWidgets::FittingMode::SIMULTANEOUS_SEQUENTIAL);
   connect(m_fitOptionsBrowser, SIGNAL(changedToSequentialFitting()), this,
           SLOT(setLogNames()));
   splitter->addWidget(m_fitOptionsBrowser);
@@ -390,7 +390,7 @@ void MultiDatasetFit::fit() {
   }
   int fitAll = QMessageBox::Yes;
 
-  if (fittingType == MantidWidgets::FittingMode::Simultaneous || n == 1) {
+  if (fittingType == MantidWidgets::FittingMode::SIMULTANEOUS || n == 1) {
     if (n > 20 && m_fitAllSettings == QMessageBox::No) {
       fitAll = QMessageBox::question(this, "Fit All?",
                                      "Are you sure you would like to fit " +
@@ -405,7 +405,7 @@ void MultiDatasetFit::fit() {
       fitSimultaneous();
     }
 
-  } else if (fittingType == MantidWidgets::FittingMode::Sequential) {
+  } else if (fittingType == MantidWidgets::FittingMode::SEQUENTIAL) {
     if (n > 100 && m_fitAllSettings == QMessageBox::No) {
       fitAll = QMessageBox::question(this, "Fit All?",
                                      "Are you sure you would like to fit " +
@@ -496,7 +496,7 @@ void MultiDatasetFit::finishFit(bool error) {
     Mantid::API::IFunction_sptr fun;
     auto algorithm = m_fitRunner->getAlgorithm();
     if (m_fitOptionsBrowser->getCurrentFittingType() ==
-            MantidWidgets::FittingMode::Simultaneous ||
+            MantidWidgets::FittingMode::SIMULTANEOUS ||
         getNumberOfSpectra() == 1) {
       // After a simultaneous fit
       fun = algorithm->getProperty("Function");
@@ -739,7 +739,7 @@ void MultiDatasetFit::checkFittingType() {
     m_fitOptionsBrowser->unlockCurrentFittingType();
   } else {
     m_fitOptionsBrowser->lockCurrentFittingType(
-        MantidWidgets::FittingMode::Simultaneous);
+        MantidWidgets::FittingMode::SIMULTANEOUS);
   }
 }
 

--- a/qt/scientific_interfaces/MultiDatasetFit/MultiDatasetFit.cpp
+++ b/qt/scientific_interfaces/MultiDatasetFit/MultiDatasetFit.cpp
@@ -22,6 +22,7 @@
 
 #include "MantidQtWidgets/Common/AlgorithmRunner.h"
 #include "MantidQtWidgets/Common/FitOptionsBrowser.h"
+#include "MantidQtWidgets/Common/FittingMode.h"
 #include "MantidQtWidgets/Common/FunctionBrowser.h"
 
 #include <QMessageBox>
@@ -188,8 +189,7 @@ void MultiDatasetFit::initLayout() {
           m_functionBrowser, SLOT(addDatasets(const QStringList &)));
 
   m_fitOptionsBrowser = new MantidQt::MantidWidgets::FitOptionsBrowser(
-      nullptr,
-      MantidQt::MantidWidgets::FitOptionsBrowser::SimultaneousAndSequential);
+      nullptr, MantidQt::MantidWidgets::FittingMode::SimultaneousAndSequential);
   connect(m_fitOptionsBrowser, SIGNAL(changedToSequentialFitting()), this,
           SLOT(setLogNames()));
   splitter->addWidget(m_fitOptionsBrowser);
@@ -390,7 +390,7 @@ void MultiDatasetFit::fit() {
   }
   int fitAll = QMessageBox::Yes;
 
-  if (fittingType == MantidWidgets::FitOptionsBrowser::Simultaneous || n == 1) {
+  if (fittingType == MantidWidgets::FittingMode::Simultaneous || n == 1) {
     if (n > 20 && m_fitAllSettings == QMessageBox::No) {
       fitAll = QMessageBox::question(this, "Fit All?",
                                      "Are you sure you would like to fit " +
@@ -405,7 +405,7 @@ void MultiDatasetFit::fit() {
       fitSimultaneous();
     }
 
-  } else if (fittingType == MantidWidgets::FitOptionsBrowser::Sequential) {
+  } else if (fittingType == MantidWidgets::FittingMode::Sequential) {
     if (n > 100 && m_fitAllSettings == QMessageBox::No) {
       fitAll = QMessageBox::question(this, "Fit All?",
                                      "Are you sure you would like to fit " +
@@ -496,7 +496,7 @@ void MultiDatasetFit::finishFit(bool error) {
     Mantid::API::IFunction_sptr fun;
     auto algorithm = m_fitRunner->getAlgorithm();
     if (m_fitOptionsBrowser->getCurrentFittingType() ==
-            MantidWidgets::FitOptionsBrowser::Simultaneous ||
+            MantidWidgets::FittingMode::Simultaneous ||
         getNumberOfSpectra() == 1) {
       // After a simultaneous fit
       fun = algorithm->getProperty("Function");
@@ -739,7 +739,7 @@ void MultiDatasetFit::checkFittingType() {
     m_fitOptionsBrowser->unlockCurrentFittingType();
   } else {
     m_fitOptionsBrowser->lockCurrentFittingType(
-        MantidWidgets::FitOptionsBrowser::Simultaneous);
+        MantidWidgets::FittingMode::Simultaneous);
   }
 }
 

--- a/qt/widgets/common/CMakeLists.txt
+++ b/qt/widgets/common/CMakeLists.txt
@@ -1029,6 +1029,7 @@ set(
   test/FileDialogHandlerTest.h
   test/FindFilesThreadPoolManagerTest.h
   test/FindFilesWorkerTest.h
+  test/FitDomainTest.h
   test/FitOptionsBrowserTest.h
   test/FitPropertyBrowserTest.h
   test/FitScriptGeneratorDataTableTest.h

--- a/qt/widgets/common/CMakeLists.txt
+++ b/qt/widgets/common/CMakeLists.txt
@@ -261,6 +261,7 @@ set(QT5_INC_FILES
     inc/MantidQtWidgets/Common/FitDomain.h
     inc/MantidQtWidgets/Common/FitScriptGeneratorModel.h
     inc/MantidQtWidgets/Common/FitScriptGeneratorPresenter.h
+    inc/MantidQtWidgets/Common/FittingMode.h
     inc/MantidQtWidgets/Common/FlowLayout.h
     inc/MantidQtWidgets/Common/FunctionMultiDomainPresenter.h
     inc/MantidQtWidgets/Common/HelpWindow.h
@@ -658,6 +659,7 @@ set(
   inc/MantidQtWidgets/Common/FitDomain.h
   inc/MantidQtWidgets/Common/FitScriptGeneratorModel.h
   inc/MantidQtWidgets/Common/FitScriptGeneratorPresenter.h
+  inc/MantidQtWidgets/Common/FittingMode.h
   inc/MantidQtWidgets/Common/HelpWindow.h
   inc/MantidQtWidgets/Common/Hint.h
   inc/MantidQtWidgets/Common/IFitScriptGeneratorModel.h

--- a/qt/widgets/common/CMakeLists.txt
+++ b/qt/widgets/common/CMakeLists.txt
@@ -20,6 +20,7 @@ set(
   src/FindFilesThreadPoolManager.cpp
   src/FindFilesWorker.cpp
   src/FindReplaceDialog.cpp
+  src/FitDomain.cpp
   src/FitOptionsBrowser.cpp
   src/FitPropertyBrowser.cpp
   src/FitScriptGeneratorDataTable.cpp
@@ -257,6 +258,7 @@ set(QT5_INC_FILES
     inc/MantidQtWidgets/Common/BatchAlgorithmRunner.h
     inc/MantidQtWidgets/Common/DropEventHelper.h
     inc/MantidQtWidgets/Common/FileDialogHandler.h
+    inc/MantidQtWidgets/Common/FitDomain.h
     inc/MantidQtWidgets/Common/FitScriptGeneratorModel.h
     inc/MantidQtWidgets/Common/FitScriptGeneratorPresenter.h
     inc/MantidQtWidgets/Common/FlowLayout.h
@@ -448,6 +450,7 @@ set(
   src/FindFilesThreadPoolManager.cpp
   src/FindFilesWorker.cpp
   src/FindReplaceDialog.cpp
+  src/FitDomain.cpp
   src/FitOptionsBrowser.cpp
   src/FitPropertyBrowser.cpp
   src/FitScriptGeneratorDataTable.cpp
@@ -652,6 +655,7 @@ set(
   inc/MantidQtWidgets/Common/FlowLayout.h
   inc/MantidQtWidgets/Common/GraphOptions.h
   inc/MantidQtWidgets/Common/DistributionOptions.h
+  inc/MantidQtWidgets/Common/FitDomain.h
   inc/MantidQtWidgets/Common/FitScriptGeneratorModel.h
   inc/MantidQtWidgets/Common/FitScriptGeneratorPresenter.h
   inc/MantidQtWidgets/Common/HelpWindow.h

--- a/qt/widgets/common/CMakeLists.txt
+++ b/qt/widgets/common/CMakeLists.txt
@@ -260,6 +260,7 @@ set(QT5_INC_FILES
     inc/MantidQtWidgets/Common/DropEventHelper.h
     inc/MantidQtWidgets/Common/FileDialogHandler.h
     inc/MantidQtWidgets/Common/FitDomain.h
+    inc/MantidQtWidgets/Common/FitScriptGeneratorMockObjects.h
     inc/MantidQtWidgets/Common/FitScriptGeneratorModel.h
     inc/MantidQtWidgets/Common/FitScriptGeneratorPresenter.h
     inc/MantidQtWidgets/Common/FittingGlobals.h
@@ -1033,6 +1034,7 @@ set(
   test/FitOptionsBrowserTest.h
   test/FitPropertyBrowserTest.h
   test/FitScriptGeneratorDataTableTest.h
+  test/FitScriptGeneratorModelTest.h
   test/FitScriptGeneratorPresenterTest.h
   test/FitScriptGeneratorViewTest.h
   test/FunctionTreeViewTest.h

--- a/qt/widgets/common/CMakeLists.txt
+++ b/qt/widgets/common/CMakeLists.txt
@@ -27,6 +27,7 @@ set(
   src/FitScriptGeneratorModel.cpp
   src/FitScriptGeneratorPresenter.cpp
   src/FitScriptGeneratorView.cpp
+  src/FittingGlobals.cpp
   src/FlowLayout.cpp
   src/FunctionBrowser/FunctionBrowserUtils.cpp
   src/FunctionBrowser.cpp
@@ -261,6 +262,7 @@ set(QT5_INC_FILES
     inc/MantidQtWidgets/Common/FitDomain.h
     inc/MantidQtWidgets/Common/FitScriptGeneratorModel.h
     inc/MantidQtWidgets/Common/FitScriptGeneratorPresenter.h
+    inc/MantidQtWidgets/Common/FittingGlobals.h
     inc/MantidQtWidgets/Common/FittingMode.h
     inc/MantidQtWidgets/Common/FlowLayout.h
     inc/MantidQtWidgets/Common/FunctionMultiDomainPresenter.h
@@ -458,6 +460,7 @@ set(
   src/FitScriptGeneratorModel.cpp
   src/FitScriptGeneratorPresenter.cpp
   src/FitScriptGeneratorView.cpp
+  src/FittingGlobals.cpp
   src/FunctionBrowser/FunctionBrowserUtils.cpp
   src/FunctionBrowser.cpp
   src/FunctionModel.cpp
@@ -659,6 +662,7 @@ set(
   inc/MantidQtWidgets/Common/FitDomain.h
   inc/MantidQtWidgets/Common/FitScriptGeneratorModel.h
   inc/MantidQtWidgets/Common/FitScriptGeneratorPresenter.h
+  inc/MantidQtWidgets/Common/FittingGlobals.h
   inc/MantidQtWidgets/Common/FittingMode.h
   inc/MantidQtWidgets/Common/HelpWindow.h
   inc/MantidQtWidgets/Common/Hint.h

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/FitDomain.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/FitDomain.h
@@ -29,13 +29,16 @@ public:
   FitDomain(std::string const &workspaceName, WorkspaceIndex workspaceIndex,
             double startX, double endX);
 
-  [[nodiscard]] bool setStartX(double startX);
-  [[nodiscard]] bool setEndX(double startX);
-
   inline std::string workspaceName() const noexcept { return m_workspaceName; }
   inline WorkspaceIndex workspaceIndex() const noexcept {
     return m_workspaceIndex;
   }
+
+  [[nodiscard]] bool setStartX(double startX);
+  [[nodiscard]] bool setEndX(double startX);
+
+  inline double startX() const noexcept { return m_startX; }
+  inline double endX() const noexcept { return m_endX; }
 
   void setFunction(Mantid::API::IFunction_sptr const &function);
   [[nodiscard]] Mantid::API::IFunction_sptr getFunction() const;
@@ -43,11 +46,14 @@ public:
   void addFunction(Mantid::API::IFunction_sptr const &function);
 
   void setParameterValue(std::string const &parameter, double newValue);
+  [[nodiscard]] double getParameterValue(std::string const &parameter) const;
+
   void setAttributeValue(std::string const &attribute,
                          Mantid::API::IFunction::Attribute newValue);
+  [[nodiscard]] Mantid::API::IFunction::Attribute
+  getAttributeValue(std::string const &attribute) const;
 
   [[nodiscard]] bool hasParameter(std::string const &parameter) const;
-  [[nodiscard]] double getParameterValue(std::string const &parameter) const;
   [[nodiscard]] bool isParameterActive(std::string const &parameter) const;
 
   void clearParameterTie(std::string const &parameter);

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/FitDomain.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/FitDomain.h
@@ -60,14 +60,15 @@ public:
                                  std::string const &constraint);
 
 private:
-  bool setParameterTie(std::string const &parameter, std::string const &tie);
+  [[nodiscard]] bool setParameterTie(std::string const &parameter,
+                                     std::string const &tie);
 
   [[nodiscard]] bool isValidParameterValue(std::string const &parameter,
                                            double value) const;
   [[nodiscard]] bool isValidStartX(double startX) const;
   [[nodiscard]] bool isValidEndX(double endX) const;
-  std::pair<double, double> xLimits() const;
-  std::pair<double, double>
+  [[nodiscard]] std::pair<double, double> xLimits() const;
+  [[nodiscard]] std::pair<double, double>
   xLimits(Mantid::API::MatrixWorkspace_const_sptr const &workspace,
           WorkspaceIndex workspaceIndex) const;
 

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/FitDomain.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/FitDomain.h
@@ -47,6 +47,7 @@ public:
                          Mantid::API::IFunction::Attribute newValue);
 
   [[nodiscard]] bool hasParameter(std::string const &parameter) const;
+  [[nodiscard]] double getParameterValue(std::string const &parameter) const;
 
   [[nodiscard]] bool updateParameterTie(std::string const &parameter,
                                         std::string const &tie);

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/FitDomain.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/FitDomain.h
@@ -49,9 +49,14 @@ public:
   [[nodiscard]] bool hasParameter(std::string const &parameter) const;
   [[nodiscard]] double getParameterValue(std::string const &parameter) const;
 
+  void clearParameterTie(std::string const &parameter);
   [[nodiscard]] bool updateParameterTie(std::string const &parameter,
                                         std::string const &tie);
-  void clearParameterTie(std::string const &parameter);
+
+  void removeParameterConstraint(std::string const &parameter);
+  void updateParameterConstraint(std::string const &functionIndex,
+                                 std::string const &parameter,
+                                 std::string const &constraint);
 
 private:
   bool setParameterTie(std::string const &parameter, std::string const &tie);
@@ -69,6 +74,11 @@ private:
   removeFunctionFromComposite(std::string const &function,
                               Mantid::API::CompositeFunction_sptr &composite);
   void addFunctionToExisting(Mantid::API::IFunction_sptr const &function);
+
+  void updateParameterConstraint(Mantid::API::CompositeFunction_sptr &composite,
+                                 std::string const &functionIndex,
+                                 std::string const &parameter,
+                                 std::string const &constraint);
 
   std::string m_workspaceName;
   WorkspaceIndex m_workspaceIndex;

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/FitDomain.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/FitDomain.h
@@ -61,6 +61,8 @@ public:
 private:
   bool setParameterTie(std::string const &parameter, std::string const &tie);
 
+  [[nodiscard]] bool isValidParameterValue(std::string const &parameter,
+                                           double value) const;
   [[nodiscard]] bool isValidStartX(double startX) const;
   [[nodiscard]] bool isValidEndX(double endX) const;
   std::pair<double, double> xLimits() const;

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/FitDomain.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/FitDomain.h
@@ -75,6 +75,10 @@ private:
 
   [[nodiscard]] bool isValidParameterTie(std::string const &parameter,
                                          std::string const &tie) const;
+  [[nodiscard]] bool
+  isValidParameterConstraint(std::string const &parameter,
+                             std::string const &constraint) const;
+
   [[nodiscard]] bool isValidStartX(double startX) const;
   [[nodiscard]] bool isValidEndX(double endX) const;
   [[nodiscard]] std::pair<double, double> xLimits() const;

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/FitDomain.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/FitDomain.h
@@ -65,13 +65,14 @@ public:
                                  std::string const &parameter,
                                  std::string const &constraint);
 
+  [[nodiscard]] bool
+  isParameterValueWithinConstraints(std::string const &parameter,
+                                    double value) const;
+
 private:
   [[nodiscard]] bool setParameterTie(std::string const &parameter,
                                      std::string const &tie);
 
-  [[nodiscard]] bool
-  isParameterValueWithinConstraints(std::string const &parameter,
-                                    double value) const;
   [[nodiscard]] bool isValidParameterTie(std::string const &parameter,
                                          std::string const &tie) const;
   [[nodiscard]] bool isValidStartX(double startX) const;

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/FitDomain.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/FitDomain.h
@@ -14,6 +14,7 @@
 
 #include <string>
 #include <utility>
+#include <vector>
 
 namespace MantidQt {
 namespace MantidWidgets {
@@ -65,6 +66,9 @@ public:
                                  std::string const &parameter,
                                  std::string const &constraint);
 
+  [[nodiscard]] std::vector<std::string>
+  getParametersTiedTo(std::string const &parameter) const;
+
   [[nodiscard]] bool
   isParameterValueWithinConstraints(std::string const &parameter,
                                     double value) const;
@@ -72,6 +76,8 @@ public:
 private:
   [[nodiscard]] bool setParameterTie(std::string const &parameter,
                                      std::string const &tie);
+
+  [[nodiscard]] double getTieValue(std::string const &tie) const;
 
   [[nodiscard]] bool isValidParameterTie(std::string const &parameter,
                                          std::string const &tie) const;
@@ -97,6 +103,10 @@ private:
                                  std::string const &functionIndex,
                                  std::string const &parameter,
                                  std::string const &constraint);
+
+  void appendParametersTiedTo(std::vector<std::string> &tiedParameters,
+                              std::string const &parameter,
+                              std::size_t const &parameterIndex) const;
 
   void removeInvalidatedTies();
 

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/FitDomain.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/FitDomain.h
@@ -69,8 +69,11 @@ private:
   [[nodiscard]] bool setParameterTie(std::string const &parameter,
                                      std::string const &tie);
 
-  [[nodiscard]] bool isValidParameterValue(std::string const &parameter,
-                                           double value) const;
+  [[nodiscard]] bool
+  isParameterValueWithinConstraints(std::string const &parameter,
+                                    double value) const;
+  [[nodiscard]] bool isValidParameterTie(std::string const &parameter,
+                                         std::string const &tie) const;
   [[nodiscard]] bool isValidStartX(double startX) const;
   [[nodiscard]] bool isValidEndX(double endX) const;
   [[nodiscard]] std::pair<double, double> xLimits() const;
@@ -89,6 +92,8 @@ private:
                                  std::string const &functionIndex,
                                  std::string const &parameter,
                                  std::string const &constraint);
+
+  void removeInvalidatedTies();
 
   std::string m_workspaceName;
   WorkspaceIndex m_workspaceIndex;

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/FitDomain.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/FitDomain.h
@@ -46,7 +46,11 @@ public:
   void setAttributeValue(std::string const &attribute,
                          Mantid::API::IFunction::Attribute newValue);
 
-  bool updateParameterTie(std::string const &parameter, std::string const &tie);
+  [[nodiscard]] bool hasParameter(std::string const &parameter) const;
+
+  [[nodiscard]] bool updateParameterTie(std::string const &parameter,
+                                        std::string const &tie);
+  void clearParameterTie(std::string const &parameter);
 
 private:
   bool setParameterTie(std::string const &parameter, std::string const &tie);

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/FitDomain.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/FitDomain.h
@@ -46,9 +46,11 @@ public:
   void setAttributeValue(std::string const &attribute,
                          Mantid::API::IFunction::Attribute newValue);
 
-  void updateParameterTie(std::string const &parameter, std::string const &tie);
+  bool updateParameterTie(std::string const &parameter, std::string const &tie);
 
 private:
+  bool setParameterTie(std::string const &parameter, std::string const &tie);
+
   [[nodiscard]] bool isValidStartX(double startX) const;
   [[nodiscard]] bool isValidEndX(double endX) const;
   std::pair<double, double> xLimits() const;

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/FitDomain.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/FitDomain.h
@@ -1,0 +1,74 @@
+// Mantid Repository : https://github.com/mantidproject/mantid
+//
+// Copyright &copy; 2020 ISIS Rutherford Appleton Laboratory UKRI,
+//   NScD Oak Ridge National Laboratory, European Spallation Source,
+//   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+// SPDX - License - Identifier: GPL - 3.0 +
+#pragma once
+
+#include "DllOption.h"
+#include "MantidAPI/CompositeFunction.h"
+#include "MantidAPI/IFunction.h"
+#include "MantidAPI/MatrixWorkspace_fwd.h"
+#include "MantidQtWidgets/Common/IndexTypes.h"
+
+#include <string>
+#include <utility>
+
+namespace MantidQt {
+namespace MantidWidgets {
+
+/**
+ * This class is used to store all data relating to a single domain to be
+ * fitted. This includes the location of the domain (workspace Name & index),
+ * the fit range (start and end X), and the function to be fitted over.
+ */
+class EXPORT_OPT_MANTIDQT_COMMON FitDomain {
+
+public:
+  FitDomain(std::string const &workspaceName, WorkspaceIndex workspaceIndex,
+            double startX, double endX);
+
+  [[nodiscard]] bool setStartX(double startX);
+  [[nodiscard]] bool setEndX(double startX);
+
+  inline std::string workspaceName() const noexcept { return m_workspaceName; }
+  inline WorkspaceIndex workspaceIndex() const noexcept {
+    return m_workspaceIndex;
+  }
+
+  void setFunction(Mantid::API::IFunction_sptr const &function);
+  [[nodiscard]] Mantid::API::IFunction_sptr getFunction() const;
+  void removeFunction(std::string const &function);
+  void addFunction(Mantid::API::IFunction_sptr const &function);
+
+  void setParameterValue(std::string const &parameter, double newValue);
+  void setAttributeValue(std::string const &attribute,
+                         Mantid::API::IFunction::Attribute newValue);
+
+  void updateParameterTie(std::string const &parameter, std::string const &tie);
+
+private:
+  [[nodiscard]] bool isValidStartX(double startX) const;
+  [[nodiscard]] bool isValidEndX(double endX) const;
+  std::pair<double, double> xLimits() const;
+  std::pair<double, double>
+  xLimits(Mantid::API::MatrixWorkspace_const_sptr const &workspace,
+          WorkspaceIndex workspaceIndex) const;
+
+  void removeFunctionFromIFunction(std::string const &function,
+                                   Mantid::API::IFunction_sptr &iFunction);
+  void
+  removeFunctionFromComposite(std::string const &function,
+                              Mantid::API::CompositeFunction_sptr &composite);
+  void addFunctionToExisting(Mantid::API::IFunction_sptr const &function);
+
+  std::string m_workspaceName;
+  WorkspaceIndex m_workspaceIndex;
+  double m_startX;
+  double m_endX;
+  Mantid::API::IFunction_sptr m_function;
+};
+
+} // namespace MantidWidgets
+} // namespace MantidQt

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/FitDomain.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/FitDomain.h
@@ -48,6 +48,7 @@ public:
 
   [[nodiscard]] bool hasParameter(std::string const &parameter) const;
   [[nodiscard]] double getParameterValue(std::string const &parameter) const;
+  [[nodiscard]] bool isParameterActive(std::string const &parameter) const;
 
   void clearParameterTie(std::string const &parameter);
   [[nodiscard]] bool updateParameterTie(std::string const &parameter,

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/FitDomain.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/FitDomain.h
@@ -30,16 +30,18 @@ public:
   FitDomain(std::string const &workspaceName, WorkspaceIndex workspaceIndex,
             double startX, double endX);
 
-  inline std::string workspaceName() const noexcept { return m_workspaceName; }
-  inline WorkspaceIndex workspaceIndex() const noexcept {
+  [[nodiscard]] std::string workspaceName() const noexcept {
+    return m_workspaceName;
+  }
+  [[nodiscard]] WorkspaceIndex workspaceIndex() const noexcept {
     return m_workspaceIndex;
   }
 
   [[nodiscard]] bool setStartX(double startX);
   [[nodiscard]] bool setEndX(double startX);
 
-  inline double startX() const noexcept { return m_startX; }
-  inline double endX() const noexcept { return m_endX; }
+  [[nodiscard]] double startX() const noexcept { return m_startX; }
+  [[nodiscard]] double endX() const noexcept { return m_endX; }
 
   void setFunction(Mantid::API::IFunction_sptr const &function);
   [[nodiscard]] Mantid::API::IFunction_sptr getFunctionCopy() const;

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/FitDomain.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/FitDomain.h
@@ -42,7 +42,7 @@ public:
   inline double endX() const noexcept { return m_endX; }
 
   void setFunction(Mantid::API::IFunction_sptr const &function);
-  [[nodiscard]] Mantid::API::IFunction_sptr getFunction() const;
+  [[nodiscard]] Mantid::API::IFunction_sptr getFunctionCopy() const;
   void removeFunction(std::string const &function);
   void addFunction(Mantid::API::IFunction_sptr const &function);
 

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/FitOptionsBrowser.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/FitOptionsBrowser.h
@@ -7,6 +7,7 @@
 #pragma once
 
 #include "DllOption.h"
+#include "MantidQtWidgets/Common/FittingMode.h"
 
 #include <QMap>
 #include <QWidget>
@@ -42,25 +43,17 @@ namespace MantidWidgets {
 class EXPORT_OPT_MANTIDQT_COMMON FitOptionsBrowser : public QWidget {
   Q_OBJECT
 public:
-  /// Support for fitting algorithms:
-  ///   Simultaneous: Fit
-  ///   Sequential:   PlotPeakByLogValue
-  ///   SimultaneousAndSequential: both Fit and PlotPeakByLogValue, toggled with
-  ///       "Fitting" property.
-  enum FittingType { Simultaneous = 0, Sequential, SimultaneousAndSequential };
-
-  /// Constructor
   FitOptionsBrowser(QWidget *parent = nullptr,
-                    FittingType fitType = Simultaneous);
+                    FittingMode fitType = FittingMode::Simultaneous);
   ~FitOptionsBrowser();
   QString getProperty(const QString &name) const;
   void setProperty(const QString &name, const QString &value);
   void copyPropertiesToAlgorithm(Mantid::API::IAlgorithm &fit) const;
   void saveSettings(QSettings &settings) const;
   void loadSettings(const QSettings &settings);
-  FittingType getCurrentFittingType() const;
-  void setCurrentFittingType(FittingType fitType);
-  void lockCurrentFittingType(FittingType fitType);
+  FittingMode getCurrentFittingType() const;
+  void setCurrentFittingType(FittingMode fitType);
+  void lockCurrentFittingType(FittingMode fitType);
   void unlockCurrentFittingType();
   void setLogNames(const QStringList &logNames);
   void setParameterNamesForPlotting(const QStringList &parNames);
@@ -69,6 +62,7 @@ public:
 
 signals:
   void changedToSequentialFitting();
+  void changedToSimultaneousFitting();
   // emitted when m_doubleManager reports a change
   void doublePropertyChanged(const QString &propertyName);
 
@@ -181,7 +175,7 @@ private:
   QMap<QtProperty *, GetterType> m_getters;
 
   /// The Fitting Type
-  FittingType m_fittingType;
+  FittingMode m_fittingType;
   /// Store special properties of the normal Fit
   QList<QtProperty *> m_simultaneousProperties;
   QList<QtProperty *> m_blacklist;

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/FitOptionsBrowser.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/FitOptionsBrowser.h
@@ -44,7 +44,7 @@ class EXPORT_OPT_MANTIDQT_COMMON FitOptionsBrowser : public QWidget {
   Q_OBJECT
 public:
   FitOptionsBrowser(QWidget *parent = nullptr,
-                    FittingMode fitType = FittingMode::Simultaneous);
+                    FittingMode fitType = FittingMode::SIMULTANEOUS);
   ~FitOptionsBrowser();
   QString getProperty(const QString &name) const;
   void setProperty(const QString &name, const QString &value);

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/FitOptionsBrowser.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/FitOptionsBrowser.h
@@ -149,8 +149,8 @@ private:
   // PlotPeakByLogValue properties
   /// Store special properties of the sequential Fit
   QList<QtProperty *> m_sequentialProperties;
-  /// FitType property
-  QtProperty *m_fitType;
+  /// PlotPeakByLogValue FitType property
+  QtProperty *m_plotPeakByLogValueFitType;
   /// OutputWorkspace property
   QtProperty *m_outputWorkspace;
   /// LogValue property

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/FitScriptGenerator.ui
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/FitScriptGenerator.ui
@@ -48,7 +48,7 @@
    <item row="0" column="3">
     <widget class="QCheckBox" name="ckAddFunctionForAllDomains">
      <property name="text">
-      <string>Add functions across all datasets</string>
+      <string>Add/Remove functions across all datasets</string>
      </property>
      <property name="checked">
       <bool>true</bool>
@@ -66,13 +66,6 @@
     <widget class="QPushButton" name="pbAddWorkspace">
      <property name="text">
       <string>Add Workspace</string>
-     </property>
-    </widget>
-   </item>
-   <item row="0" column="4" colspan="2">
-    <widget class="QCheckBox" name="ckShowFullFunction">
-     <property name="text">
-      <string>Show full multi-domain function</string>
      </property>
     </widget>
    </item>

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/FitScriptGenerator.ui
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/FitScriptGenerator.ui
@@ -46,9 +46,9 @@
     </widget>
    </item>
    <item row="0" column="3">
-    <widget class="QCheckBox" name="ckAddFunctionForAllDomains">
+    <widget class="QCheckBox" name="ckApplyFunctionChangesToAll">
      <property name="text">
-      <string>Add/Remove functions across all datasets</string>
+      <string>Apply function changes to all datasets</string>
      </property>
      <property name="checked">
       <bool>true</bool>

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/FitScriptGenerator.ui
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/FitScriptGenerator.ui
@@ -46,9 +46,9 @@
     </widget>
    </item>
    <item row="0" column="3">
-    <widget class="QCheckBox" name="ckApplyFunctionChangesToAll">
+    <widget class="QCheckBox" name="ckAddRemoveFunctionForAllDatasets">
      <property name="text">
-      <string>Apply function changes to all datasets</string>
+      <string>Add/Remove function for all datasets</string>
      </property>
      <property name="checked">
       <bool>true</bool>

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/FitScriptGeneratorDataTable.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/FitScriptGeneratorDataTable.h
@@ -71,7 +71,7 @@ signals:
   void itemExited(int newRowIndex);
 
 private slots:
-  void handleItemPressed(QTableWidgetItem *item);
+  void handleItemClicked(QTableWidgetItem *item);
   void handleItemSelectionChanged();
 
 private:

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/FitScriptGeneratorDataTable.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/FitScriptGeneratorDataTable.h
@@ -78,6 +78,8 @@ private:
   bool eventFilter(QObject *widget, QEvent *event) override;
   QPersistentModelIndex hoveredRowIndex(QEvent *event);
 
+  void updateVerticalHeaders();
+
   int indexOfDomain(std::string const &workspaceName,
                     MantidWidgets::WorkspaceIndex workspaceIndex) const;
 

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/FitScriptGeneratorDataTable.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/FitScriptGeneratorDataTable.h
@@ -55,6 +55,7 @@ public:
   [[nodiscard]] double startX(FitDomainIndex row) const;
   [[nodiscard]] double endX(FitDomainIndex row) const;
 
+  [[nodiscard]] std::vector<FitDomainIndex> allRows() const;
   [[nodiscard]] std::vector<FitDomainIndex> selectedRows() const;
 
   void removeDomain(std::string const &workspaceName,
@@ -70,7 +71,8 @@ signals:
   void itemExited(int newRowIndex);
 
 private slots:
-  void handleItemClicked(QTableWidgetItem *item);
+  void handleItemPressed(QTableWidgetItem *item);
+  void handleItemSelectionChanged();
 
 private:
   bool eventFilter(QObject *widget, QEvent *event) override;
@@ -83,10 +85,10 @@ private:
 
   void setSelectedXValue(double xValue);
 
-  int m_selectedRow;
+  std::vector<FitDomainIndex> m_selectedRows;
   int m_selectedColumn;
   double m_selectedValue;
-  QPersistentModelIndex m_lastIndex;
+  QPersistentModelIndex m_lastHoveredIndex;
 };
 
 using ColumnIndex = FitScriptGeneratorDataTable::ColumnIndex;

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/FitScriptGeneratorDataTable.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/FitScriptGeneratorDataTable.h
@@ -58,6 +58,8 @@ public:
   [[nodiscard]] std::vector<FitDomainIndex> allRows() const;
   [[nodiscard]] std::vector<FitDomainIndex> selectedRows() const;
 
+  [[nodiscard]] QString selectedDomainFunctionPrefix() const;
+
   void removeDomain(std::string const &workspaceName,
                     MantidWidgets::WorkspaceIndex workspaceIndex);
   void addDomain(QString const &workspaceName,

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/FitScriptGeneratorDataTable.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/FitScriptGeneratorDataTable.h
@@ -69,6 +69,8 @@ public:
   void formatSelection();
   void resetSelection();
 
+  void setFunctionPrefixVisible(bool visible);
+
 signals:
   void itemExited(int newRowIndex);
 

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/FitScriptGeneratorMockObjects.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/FitScriptGeneratorMockObjects.h
@@ -133,6 +133,10 @@ public:
                void(std::string const &workspaceName,
                     MantidQt::MantidWidgets::WorkspaceIndex workspaceIndex,
                     double startX, double endX));
+  MOCK_CONST_METHOD2(
+      hasWorkspaceDomain,
+      bool(std::string const &workspaceName,
+           MantidQt::MantidWidgets::WorkspaceIndex workspaceIndex));
 
   MOCK_METHOD3(updateStartX,
                bool(std::string const &workspaceName,

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/FitScriptGeneratorMockObjects.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/FitScriptGeneratorMockObjects.h
@@ -1,0 +1,210 @@
+// Mantid Repository : https://github.com/mantidproject/mantid
+//
+// Copyright &copy; 2020 ISIS Rutherford Appleton Laboratory UKRI,
+//   NScD Oak Ridge National Laboratory, European Spallation Source,
+//   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+// SPDX - License - Identifier: GPL - 3.0 +
+#pragma once
+
+#include "MantidKernel/WarningSuppressions.h"
+
+#include "MantidAPI/IFunction.h"
+#include "MantidAPI/MatrixWorkspace.h"
+#include "MantidQtWidgets/Common/FitScriptGeneratorModel.h"
+#include "MantidQtWidgets/Common/FitScriptGeneratorView.h"
+#include "MantidQtWidgets/Common/FittingGlobals.h"
+#include "MantidQtWidgets/Common/FittingMode.h"
+#include "MantidQtWidgets/Common/IFitScriptGeneratorModel.h"
+#include "MantidQtWidgets/Common/IFitScriptGeneratorPresenter.h"
+#include "MantidQtWidgets/Common/IFitScriptGeneratorView.h"
+#include "MantidQtWidgets/Common/IndexTypes.h"
+
+#include <string>
+#include <vector>
+
+#include <gmock/gmock.h>
+
+using namespace MantidQt::MantidWidgets;
+
+GNU_DIAG_OFF_SUGGEST_OVERRIDE
+
+class MockFitScriptGeneratorPresenter : public IFitScriptGeneratorPresenter {
+
+public:
+  MockFitScriptGeneratorPresenter(FitScriptGeneratorView *view) {
+    m_view = view;
+    m_view->subscribePresenter(this);
+  }
+
+  MockFitScriptGeneratorPresenter(FitScriptGeneratorModel *model) {
+    m_model = model;
+    m_model->subscribePresenter(this);
+  }
+
+  void notifyPresenter(ViewEvent const &ev, std::string const &arg1 = "",
+                       std::string const &arg2 = "") override {
+    notifyPresenterImpl(ev, arg1, arg2);
+  }
+
+  MOCK_METHOD3(notifyPresenterImpl,
+               void(ViewEvent const &ev, std::string const &arg1,
+                    std::string const &arg2));
+  MOCK_METHOD2(notifyPresenter,
+               void(ViewEvent const &ev, std::vector<std::string> const &vec));
+  MOCK_METHOD2(notifyPresenter,
+               void(ViewEvent const &ev, FittingMode fittingMode));
+
+  MOCK_METHOD0(openFitScriptGenerator, void());
+
+  MOCK_METHOD1(setGlobalTies, void(std::vector<GlobalTie> const &globalTies));
+  MOCK_METHOD1(setGlobalParameters,
+               void(std::vector<GlobalParameter> const &globalParameters));
+
+private:
+  FitScriptGeneratorView *m_view;
+  FitScriptGeneratorModel *m_model;
+};
+
+class MockFitScriptGeneratorView : public IFitScriptGeneratorView {
+
+public:
+  MOCK_METHOD1(subscribePresenter,
+               void(IFitScriptGeneratorPresenter *presenter));
+
+  MOCK_CONST_METHOD1(workspaceName, std::string(FitDomainIndex index));
+  MOCK_CONST_METHOD1(workspaceIndex, MantidQt::MantidWidgets::WorkspaceIndex(
+                                         FitDomainIndex index));
+  MOCK_CONST_METHOD1(startX, double(FitDomainIndex index));
+  MOCK_CONST_METHOD1(endX, double(FitDomainIndex index));
+
+  MOCK_CONST_METHOD0(allRows, std::vector<FitDomainIndex>());
+  MOCK_CONST_METHOD0(selectedRows, std::vector<FitDomainIndex>());
+
+  MOCK_CONST_METHOD1(parameterValue, double(std::string const &parameter));
+  MOCK_CONST_METHOD1(attributeValue, Mantid::API::IFunction::Attribute(
+                                         std::string const &attribute));
+
+  MOCK_METHOD2(removeWorkspaceDomain,
+               void(std::string const &workspaceName,
+                    MantidQt::MantidWidgets::WorkspaceIndex workspaceIndex));
+  MOCK_METHOD4(addWorkspaceDomain,
+               void(std::string const &workspaceName,
+                    MantidQt::MantidWidgets::WorkspaceIndex workspaceIndex,
+                    double startX, double endX));
+
+  MOCK_METHOD0(openAddWorkspaceDialog, bool());
+  MOCK_METHOD0(getDialogWorkspaces,
+               std::vector<Mantid::API::MatrixWorkspace_const_sptr>());
+  MOCK_CONST_METHOD0(getDialogWorkspaceIndices,
+                     std::vector<MantidQt::MantidWidgets::WorkspaceIndex>());
+
+  MOCK_METHOD0(resetSelection, void());
+
+  MOCK_CONST_METHOD0(isAddRemoveFunctionForAllChecked, bool());
+
+  MOCK_METHOD0(clearFunction, void());
+  MOCK_CONST_METHOD1(setFunction,
+                     void(Mantid::API::IFunction_sptr const &function));
+
+  MOCK_METHOD1(setSimultaneousMode, void(bool simultaneousMode));
+
+  MOCK_METHOD1(setGlobalTies, void(std::vector<GlobalTie> const &globalTies));
+  MOCK_METHOD1(setGlobalParameters,
+               void(std::vector<GlobalParameter> const &globalParameter));
+
+  MOCK_METHOD1(displayWarning, void(std::string const &message));
+
+  MOCK_CONST_METHOD0(tableWidget, FitScriptGeneratorDataTable *());
+  MOCK_CONST_METHOD0(removeButton, QPushButton *());
+  MOCK_CONST_METHOD0(addWorkspaceButton, QPushButton *());
+  MOCK_CONST_METHOD0(addWorkspaceDialog, AddWorkspaceDialog *());
+};
+
+class MockFitScriptGeneratorModel : public IFitScriptGeneratorModel {
+
+public:
+  MOCK_METHOD1(subscribePresenter,
+               void(IFitScriptGeneratorPresenter *presenter));
+
+  MOCK_METHOD2(removeWorkspaceDomain,
+               void(std::string const &workspaceName,
+                    MantidQt::MantidWidgets::WorkspaceIndex workspaceIndex));
+  MOCK_METHOD4(addWorkspaceDomain,
+               void(std::string const &workspaceName,
+                    MantidQt::MantidWidgets::WorkspaceIndex workspaceIndex,
+                    double startX, double endX));
+
+  MOCK_METHOD3(updateStartX,
+               bool(std::string const &workspaceName,
+                    MantidQt::MantidWidgets::WorkspaceIndex workspaceIndex,
+                    double startX));
+  MOCK_METHOD3(updateEndX,
+               bool(std::string const &workspaceName,
+                    MantidQt::MantidWidgets::WorkspaceIndex workspaceIndex,
+                    double endX));
+
+  MOCK_METHOD3(removeFunction,
+               void(std::string const &workspaceName,
+                    MantidQt::MantidWidgets::WorkspaceIndex workspaceIndex,
+                    std::string const &function));
+  MOCK_METHOD3(addFunction,
+               void(std::string const &workspaceName,
+                    MantidQt::MantidWidgets::WorkspaceIndex workspaceIndex,
+                    std::string const &function));
+  MOCK_METHOD3(setFunction,
+               void(std::string const &workspaceName,
+                    MantidQt::MantidWidgets::WorkspaceIndex workspaceIndex,
+                    std::string const &function));
+  MOCK_CONST_METHOD2(
+      getFunction, Mantid::API::IFunction_sptr(
+                       std::string const &workspaceName,
+                       MantidQt::MantidWidgets::WorkspaceIndex workspaceIndex));
+
+  MOCK_CONST_METHOD3(
+      getEquivalentFunctionIndexForDomain,
+      std::string(std::string const &workspaceName,
+                  MantidQt::MantidWidgets::WorkspaceIndex workspaceIndex,
+                  std::string const &functionIndex));
+  MOCK_CONST_METHOD4(
+      getEquivalentParameterTieForDomain,
+      std::string(std::string const &workspaceName,
+                  MantidQt::MantidWidgets::WorkspaceIndex workspaceIndex,
+                  std::string const &fullParameter,
+                  std::string const &fullTie));
+
+  MOCK_METHOD4(updateParameterValue,
+               void(std::string const &workspaceName,
+                    MantidQt::MantidWidgets::WorkspaceIndex workspaceIndex,
+                    std::string const &fullParameter, double newValue));
+  MOCK_METHOD4(updateAttributeValue,
+               void(std::string const &workspaceName,
+                    MantidQt::MantidWidgets::WorkspaceIndex workspaceIndex,
+                    std::string const &fullAttribute,
+                    Mantid::API::IFunction::Attribute const &newValue));
+
+  MOCK_METHOD4(updateParameterTie,
+               void(std::string const &workspaceName,
+                    MantidQt::MantidWidgets::WorkspaceIndex workspaceIndex,
+                    std::string const &fullParameter, std::string const &tie));
+
+  MOCK_METHOD3(removeParameterConstraint,
+               void(std::string const &workspaceName,
+                    MantidQt::MantidWidgets::WorkspaceIndex workspaceIndex,
+                    std::string const &fullParameter));
+  MOCK_METHOD4(updateParameterConstraint,
+               void(std::string const &workspaceName,
+                    MantidQt::MantidWidgets::WorkspaceIndex workspaceIndex,
+                    std::string const &functionIndex,
+                    std::string const &constraint));
+
+  MOCK_METHOD1(setGlobalParameters,
+               void(std::vector<std::string> const &parameters));
+
+  MOCK_METHOD1(setFittingMode, void(FittingMode fittingMode));
+  MOCK_CONST_METHOD0(getFittingMode, FittingMode());
+
+  MOCK_CONST_METHOD0(getGlobalTies, std::vector<GlobalTie>());
+  MOCK_CONST_METHOD0(getGlobalParameters, std::vector<GlobalParameter>());
+};
+
+GNU_DIAG_ON_SUGGEST_OVERRIDE

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/FitScriptGeneratorMockObjects.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/FitScriptGeneratorMockObjects.h
@@ -6,10 +6,9 @@
 // SPDX - License - Identifier: GPL - 3.0 +
 #pragma once
 
-#include "MantidKernel/WarningSuppressions.h"
-
 #include "MantidAPI/IFunction.h"
 #include "MantidAPI/MatrixWorkspace.h"
+#include "MantidKernel/WarningSuppressions.h"
 #include "MantidQtWidgets/Common/FitScriptGeneratorModel.h"
 #include "MantidQtWidgets/Common/FitScriptGeneratorView.h"
 #include "MantidQtWidgets/Common/FittingGlobals.h"

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/FitScriptGeneratorModel.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/FitScriptGeneratorModel.h
@@ -144,11 +144,9 @@ private:
   void updateParameterValuesWithLocalTieTo(FitDomainIndex domainIndex,
                                            std::string const &parameter,
                                            double newValue);
-  void updateParameterValuesWithGlobalTieTo(FitDomainIndex domainIndex,
-                                            std::string const &fullParameter,
+  void updateParameterValuesWithGlobalTieTo(std::string const &fullParameter,
                                             double newValue);
-  void updateParameterValueInGlobalTie(FitDomainIndex domainIndex,
-                                       GlobalTie const &globalTie,
+  void updateParameterValueInGlobalTie(GlobalTie const &globalTie,
                                        double newValue);
 
   [[nodiscard]] double

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/FitScriptGeneratorModel.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/FitScriptGeneratorModel.h
@@ -62,9 +62,9 @@ public:
   getFunction(std::string const &workspaceName,
               WorkspaceIndex workspaceIndex) override;
 
-  [[nodiscard]] std::string getEquivalentParameterForDomain(
+  [[nodiscard]] std::string getEquivalentFunctionIndexForDomain(
       std::string const &workspaceName, WorkspaceIndex workspaceIndex,
-      std::string const &fullParameter) const override;
+      std::string const &functionIndex) const override;
   [[nodiscard]] std::string
   getEquivalentParameterTieForDomain(std::string const &workspaceName,
                                      WorkspaceIndex workspaceIndex,
@@ -73,16 +73,24 @@ public:
 
   void updateParameterValue(std::string const &workspaceName,
                             WorkspaceIndex workspaceIndex,
-                            std::string const &parameter,
+                            std::string const &fullParameter,
                             double newValue) override;
   void updateAttributeValue(
       std::string const &workspaceName, WorkspaceIndex workspaceIndex,
-      std::string const &attribute,
+      std::string const &fullAttribute,
       Mantid::API::IFunction::Attribute const &newValue) override;
+
   void updateParameterTie(std::string const &workspaceName,
                           WorkspaceIndex workspaceIndex,
-                          std::string const &parameter,
+                          std::string const &fullParameter,
                           std::string const &tie) override;
+  void removeParameterConstraint(std::string const &workspaceName,
+                                 WorkspaceIndex workspaceIndex,
+                                 std::string const &fullParameter) override;
+  void updateParameterConstraint(std::string const &workspaceName,
+                                 WorkspaceIndex workspaceIndex,
+                                 std::string const &functionIndex,
+                                 std::string const &constraint) override;
 
   void setFittingMode(FittingMode const &fittingMode) override;
   [[nodiscard]] inline FittingMode getFittingMode() const noexcept override {
@@ -104,10 +112,12 @@ private:
   [[nodiscard]] bool hasWorkspaceDomain(std::string const &workspaceName,
                                         WorkspaceIndex workspaceIndex) const;
 
-  std::string
+  [[nodiscard]] std::string
   getEquivalentParameterTieForDomain(std::size_t const &domainIndex,
                                      std::string const &fullParameter,
                                      std::string const &fullTie) const;
+  [[nodiscard]] std::string
+  getAdjustedFunctionIndex(std::string const &parameter) const;
 
   void updateParameterTie(std::size_t const &domainIndex,
                           std::string const &fullParameter,
@@ -121,11 +131,13 @@ private:
 
   void updateParameterValuesWithGlobalTieTo(std::string const &parameter);
 
-  double getParameterValue(std::string const &fullParameter) const;
+  [[nodiscard]] double
+  getParameterValue(std::string const &fullParameter) const;
 
   [[nodiscard]] bool validParameter(std::string const &fullParameter) const;
-
+  [[nodiscard]] bool validTie(std::string const &fullTie) const;
   [[nodiscard]] bool validGlobalTie(std::string const &fullTie) const;
+
   void clearGlobalTie(std::string const &fullParameter);
   [[nodiscard]] bool hasGlobalTie(std::string const &fullParameter) const;
   [[nodiscard]] std::vector<GlobalTie>::const_iterator

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/FitScriptGeneratorModel.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/FitScriptGeneratorModel.h
@@ -7,10 +7,9 @@
 #pragma once
 
 #include "DllOption.h"
-#include "MantidAPI/CompositeFunction.h"
-#include "MantidAPI/IFunction_fwd.h"
+#include "MantidAPI/IFunction.h"
 #include "MantidAPI/MatrixWorkspace_fwd.h"
-#include "MantidAPI/MultiDomainFunction.h"
+#include "MantidQtWidgets/Common/FitDomain.h"
 #include "MantidQtWidgets/Common/IFitScriptGeneratorModel.h"
 #include "MantidQtWidgets/Common/IndexTypes.h"
 
@@ -22,25 +21,8 @@ namespace MantidQt {
 namespace MantidWidgets {
 
 /**
- * This struct is used to store all data relating to a single domain to be
- * fitted. This includes the location of the domain (workspace Name & index),
- * and the fit range (start and end X).
- */
-struct FitDomain {
-
-  FitDomain(std::string const &workspaceName, WorkspaceIndex workspaceIndex,
-            double startX, double endX);
-
-  std::string m_workspaceName;
-  WorkspaceIndex m_workspaceIndex;
-  double m_startX;
-  double m_endX;
-};
-
-/**
- * This class stores the domain data to be fitted to, and the multi domain
- * function relating to this domain data. This data is used to generate a python
- * script for complex Mantid fitting.
+ * This class stores the domain and fit data to be fitted to. This data is used
+ * to generate a python script for complex Mantid fitting.
  */
 class EXPORT_OPT_MANTIDQT_COMMON FitScriptGeneratorModel
     : public IFitScriptGeneratorModel {
@@ -54,17 +36,12 @@ public:
                           WorkspaceIndex workspaceIndex, double startX,
                           double endX) override;
 
-  [[nodiscard]] bool isStartXValid(std::string const &workspaceName,
-                                   WorkspaceIndex workspaceIndex,
-                                   double startX) const override;
-  [[nodiscard]] bool isEndXValid(std::string const &workspaceName,
-                                 WorkspaceIndex workspaceIndex,
-                                 double endX) const override;
-
-  void updateStartX(std::string const &workspaceName,
-                    WorkspaceIndex workspaceIndex, double startX) override;
-  void updateEndX(std::string const &workspaceName,
-                  WorkspaceIndex workspaceIndex, double endX) override;
+  [[nodiscard]] bool updateStartX(std::string const &workspaceName,
+                                  WorkspaceIndex workspaceIndex,
+                                  double startX) override;
+  [[nodiscard]] bool updateEndX(std::string const &workspaceName,
+                                WorkspaceIndex workspaceIndex,
+                                double endX) override;
 
   void removeFunction(std::string const &workspaceName,
                       WorkspaceIndex workspaceIndex,
@@ -75,7 +52,7 @@ public:
   void setFunction(std::string const &workspaceName,
                    WorkspaceIndex workspaceIndex,
                    std::string const &function) override;
-  Mantid::API::CompositeFunction_sptr
+  Mantid::API::IFunction_sptr
   getFunction(std::string const &workspaceName,
               WorkspaceIndex workspaceIndex) override;
 
@@ -93,17 +70,6 @@ public:
                           std::string const &tie) override;
 
 private:
-  [[nodiscard]] std::pair<double, double>
-  xLimits(std::string const &workspaceName,
-          WorkspaceIndex workspaceIndex) const;
-  [[nodiscard]] std::pair<double, double>
-  xLimits(Mantid::API::MatrixWorkspace_const_sptr const &workspace,
-          WorkspaceIndex workspaceIndex) const;
-
-  void addFunction(std::string const &workspaceName,
-                   WorkspaceIndex workspaceIndex,
-                   Mantid::API::IFunction_sptr const &function);
-
   [[nodiscard]] std::size_t
   findDomainIndex(std::string const &workspaceName,
                   WorkspaceIndex workspaceIndex) const;
@@ -116,19 +82,11 @@ private:
   void updateParameterTie(Mantid::API::IFunction_sptr const &function,
                           std::string const &parameter, std::string const &tie);
 
-  void removeCompositeAtDomainIndex(std::size_t const &domainIndex);
-  void clearCompositeAtDomainIndex(std::size_t const &domainIndex);
-
-  void addEmptyCompositeAtDomainIndex(std::size_t const &domainIndex);
-
-  [[nodiscard]] std::string nextAvailableDomainPrefix() const;
-
   [[nodiscard]] inline std::size_t numberOfDomains() const noexcept {
     return m_fitDomains.size();
   }
 
   std::vector<FitDomain> m_fitDomains;
-  Mantid::API::MultiDomainFunction_sptr m_function;
 };
 
 } // namespace MantidWidgets

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/FitScriptGeneratorModel.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/FitScriptGeneratorModel.h
@@ -119,7 +119,7 @@ private:
                                 std::string const &fullParameter,
                                 std::string const &fullTie);
 
-  void updateParameterValuesWithGlobalTieTo(std::string const &fullTie);
+  void updateParameterValuesWithGlobalTieTo(std::string const &parameter);
 
   double getParameterValue(std::string const &fullParameter) const;
 

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/FitScriptGeneratorModel.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/FitScriptGeneratorModel.h
@@ -64,7 +64,7 @@ public:
                    std::string const &function) override;
   [[nodiscard]] Mantid::API::IFunction_sptr
   getFunction(std::string const &workspaceName,
-              WorkspaceIndex workspaceIndex) override;
+              WorkspaceIndex workspaceIndex) const override;
 
   [[nodiscard]] std::string getEquivalentFunctionIndexForDomain(
       std::string const &workspaceName, WorkspaceIndex workspaceIndex,

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/FitScriptGeneratorModel.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/FitScriptGeneratorModel.h
@@ -89,6 +89,10 @@ public:
       std::string const &workspaceName, WorkspaceIndex workspaceIndex,
       std::string const &attribute,
       Mantid::API::IFunction::Attribute const &newValue) override;
+  void updateParameterTie(std::string const &workspaceName,
+                          WorkspaceIndex workspaceIndex,
+                          std::string const &parameter,
+                          std::string const &tie) override;
 
 private:
   void removeWorkspaceDomain(
@@ -118,6 +122,9 @@ private:
                       WorkspaceIndex workspaceIndex) const;
   [[nodiscard]] bool hasWorkspaceDomain(std::string const &workspaceName,
                                         WorkspaceIndex workspaceIndex) const;
+
+  void updateParameterTie(Mantid::API::CompositeFunction_sptr const &composite,
+                          std::string const &parameter, std::string const &tie);
 
   void removeCompositeAtPrefix(std::string const &functionPrefix);
 

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/FitScriptGeneratorModel.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/FitScriptGeneratorModel.h
@@ -99,15 +99,15 @@ public:
                                  std::string const &functionIndex,
                                  std::string const &constraint) override;
 
-  [[nodiscard]] inline std::vector<GlobalTie> getGlobalTies() const
-      noexcept override {
+  [[nodiscard]] inline std::vector<GlobalTie>
+  getGlobalTies() const noexcept override {
     return m_globalTies;
   }
 
   void setGlobalParameters(std::vector<std::string> const &parameters) override;
 
-  [[nodiscard]] inline std::vector<GlobalParameter> getGlobalParameters() const
-      noexcept override {
+  [[nodiscard]] inline std::vector<GlobalParameter>
+  getGlobalParameters() const noexcept override {
     return m_globalParameters;
   }
 
@@ -142,6 +142,8 @@ private:
                                 std::string const &fullTie);
 
   void updateParameterValuesWithGlobalTieTo(std::string const &parameter);
+  void updateParameterValueInGlobalTie(GlobalTie const &globalTie,
+                                       double newValue);
 
   [[nodiscard]] double
   getParameterValue(std::string const &fullParameter) const;
@@ -149,7 +151,13 @@ private:
   [[nodiscard]] bool validParameter(FitDomainIndex domainIndex,
                                     std::string const &fullParameter) const;
   [[nodiscard]] bool validTie(std::string const &fullTie) const;
-  [[nodiscard]] bool validGlobalTie(std::string const &fullTie) const;
+  [[nodiscard]] bool validGlobalTie(std::string const &fullParameter,
+                                    std::string const &fullTie) const;
+
+  [[nodiscard]] bool
+  isParameterValueWithinConstraints(FitDomainIndex domainIndex,
+                                    std::string const &fullParameter,
+                                    double value) const;
 
   void clearGlobalTie(std::string const &fullParameter);
   [[nodiscard]] bool hasGlobalTie(std::string const &fullParameter) const;

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/FitScriptGeneratorModel.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/FitScriptGeneratorModel.h
@@ -58,13 +58,18 @@ public:
   void setFunction(std::string const &workspaceName,
                    WorkspaceIndex workspaceIndex,
                    std::string const &function) override;
-  Mantid::API::IFunction_sptr
+  [[nodiscard]] Mantid::API::IFunction_sptr
   getFunction(std::string const &workspaceName,
               WorkspaceIndex workspaceIndex) override;
 
-  std::string getEquivalentParameterForDomain(
+  [[nodiscard]] std::string getEquivalentParameterForDomain(
       std::string const &workspaceName, WorkspaceIndex workspaceIndex,
       std::string const &fullParameter) const override;
+  [[nodiscard]] std::string
+  getEquivalentParameterTieForDomain(std::string const &workspaceName,
+                                     WorkspaceIndex workspaceIndex,
+                                     std::string const &fullParameter,
+                                     std::string const &fullTie) const override;
 
   void updateParameterValue(std::string const &workspaceName,
                             WorkspaceIndex workspaceIndex,
@@ -99,6 +104,11 @@ private:
   [[nodiscard]] bool hasWorkspaceDomain(std::string const &workspaceName,
                                         WorkspaceIndex workspaceIndex) const;
 
+  std::string
+  getEquivalentParameterTieForDomain(std::size_t const &domainIndex,
+                                     std::string const &fullParameter,
+                                     std::string const &fullTie) const;
+
   void updateParameterTie(std::size_t const &domainIndex,
                           std::string const &fullParameter,
                           std::string const &fullTie);
@@ -109,10 +119,15 @@ private:
                                 std::string const &fullParameter,
                                 std::string const &fullTie);
 
+  void updateParameterValuesWithGlobalTieTo(std::string const &fullTie);
+
+  double getParameterValue(std::string const &fullParameter) const;
+
   [[nodiscard]] bool validParameter(std::string const &fullParameter) const;
 
   [[nodiscard]] bool validGlobalTie(std::string const &fullTie) const;
   void clearGlobalTie(std::string const &fullParameter);
+  [[nodiscard]] bool hasGlobalTie(std::string const &fullParameter) const;
   [[nodiscard]] std::vector<GlobalTie>::const_iterator
   findGlobalTie(std::string const &fullParameter) const;
   void checkGlobalTies();

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/FitScriptGeneratorModel.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/FitScriptGeneratorModel.h
@@ -10,6 +10,7 @@
 #include "MantidAPI/IFunction.h"
 #include "MantidAPI/MatrixWorkspace_fwd.h"
 #include "MantidQtWidgets/Common/FitDomain.h"
+#include "MantidQtWidgets/Common/FittingMode.h"
 #include "MantidQtWidgets/Common/IFitScriptGeneratorModel.h"
 #include "MantidQtWidgets/Common/IndexTypes.h"
 
@@ -69,6 +70,11 @@ public:
                           std::string const &parameter,
                           std::string const &tie) override;
 
+  void setFittingMode(FittingMode const &fittingMode) override;
+  [[nodiscard]] inline FittingMode getFittingMode() const noexcept override {
+    return m_fittingMode;
+  }
+
 private:
   [[nodiscard]] std::size_t
   findDomainIndex(std::string const &workspaceName,
@@ -84,6 +90,7 @@ private:
   }
 
   std::vector<FitDomain> m_fitDomains;
+  FittingMode m_fittingMode;
 };
 
 } // namespace MantidWidgets

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/FitScriptGeneratorModel.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/FitScriptGeneratorModel.h
@@ -99,15 +99,15 @@ public:
                                  std::string const &functionIndex,
                                  std::string const &constraint) override;
 
-  [[nodiscard]] inline std::vector<GlobalTie> getGlobalTies() const
-      noexcept override {
+  [[nodiscard]] inline std::vector<GlobalTie>
+  getGlobalTies() const noexcept override {
     return m_globalTies;
   }
 
   void setGlobalParameters(std::vector<std::string> const &parameters) override;
 
-  [[nodiscard]] inline std::vector<GlobalParameter> getGlobalParameters() const
-      noexcept override {
+  [[nodiscard]] inline std::vector<GlobalParameter>
+  getGlobalParameters() const noexcept override {
     return m_globalParameters;
   }
 
@@ -141,8 +141,12 @@ private:
                                 std::string const &fullParameter,
                                 std::string const &fullTie);
 
+  void updateParameterValuesWithLocalTieTo(FitDomainIndex domainIndex,
+                                           std::string const &parameter,
+                                           double newValue);
   void updateParameterValuesWithGlobalTieTo(FitDomainIndex domainIndex,
-                                            std::string const &parameter);
+                                            std::string const &fullParameter,
+                                            double newValue);
   void updateParameterValueInGlobalTie(GlobalTie const &globalTie,
                                        double newValue);
 

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/FitScriptGeneratorModel.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/FitScriptGeneratorModel.h
@@ -10,6 +10,7 @@
 #include "MantidAPI/IFunction.h"
 #include "MantidAPI/MatrixWorkspace_fwd.h"
 #include "MantidQtWidgets/Common/FitDomain.h"
+#include "MantidQtWidgets/Common/FittingGlobals.h"
 #include "MantidQtWidgets/Common/FittingMode.h"
 #include "MantidQtWidgets/Common/IFitScriptGeneratorModel.h"
 #include "MantidQtWidgets/Common/IndexTypes.h"
@@ -21,16 +22,7 @@
 namespace MantidQt {
 namespace MantidWidgets {
 
-struct GlobalTie {
-
-  GlobalTie(std::string const &parameter, std::string const &tie) {
-    m_parameter = parameter;
-    m_tie = tie;
-  }
-
-  std::string m_parameter;
-  std::string m_tie;
-};
+class IFitScriptGeneratorPresenter;
 
 /**
  * This class stores the domain and fit data to be fitted to. This data is used
@@ -41,6 +33,8 @@ class EXPORT_OPT_MANTIDQT_COMMON FitScriptGeneratorModel
 public:
   FitScriptGeneratorModel();
   ~FitScriptGeneratorModel();
+
+  void subscribePresenter(IFitScriptGeneratorPresenter *presenter) override;
 
   void removeWorkspaceDomain(std::string const &workspaceName,
                              WorkspaceIndex workspaceIndex) override;
@@ -90,6 +84,11 @@ public:
     return m_fittingMode;
   }
 
+  [[nodiscard]] inline std::vector<GlobalTie>
+  getGlobalTies() const noexcept override {
+    return m_globalTies;
+  }
+
 private:
   [[nodiscard]] std::size_t
   findDomainIndex(std::string const &workspaceName,
@@ -116,11 +115,13 @@ private:
   void clearGlobalTie(std::string const &fullParameter);
   [[nodiscard]] std::vector<GlobalTie>::const_iterator
   findGlobalTie(std::string const &fullParameter) const;
+  void checkGlobalTies();
 
   [[nodiscard]] inline std::size_t numberOfDomains() const noexcept {
     return m_fitDomains.size();
   }
 
+  IFitScriptGeneratorPresenter *m_presenter;
   std::vector<FitDomain> m_fitDomains;
   // A vector of global ties. E.g. f0.f0.A0=f1.f0.A0
   std::vector<GlobalTie> m_globalTies;

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/FitScriptGeneratorModel.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/FitScriptGeneratorModel.h
@@ -99,15 +99,15 @@ public:
                                  std::string const &functionIndex,
                                  std::string const &constraint) override;
 
-  [[nodiscard]] inline std::vector<GlobalTie>
-  getGlobalTies() const noexcept override {
+  [[nodiscard]] inline std::vector<GlobalTie> getGlobalTies() const
+      noexcept override {
     return m_globalTies;
   }
 
   void setGlobalParameters(std::vector<std::string> const &parameters) override;
 
-  [[nodiscard]] inline std::vector<GlobalParameter>
-  getGlobalParameters() const noexcept override {
+  [[nodiscard]] inline std::vector<GlobalParameter> getGlobalParameters() const
+      noexcept override {
     return m_globalParameters;
   }
 

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/FitScriptGeneratorModel.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/FitScriptGeneratorModel.h
@@ -123,7 +123,7 @@ private:
   [[nodiscard]] bool hasWorkspaceDomain(std::string const &workspaceName,
                                         WorkspaceIndex workspaceIndex) const;
 
-  void updateParameterTie(Mantid::API::CompositeFunction_sptr const &composite,
+  void updateParameterTie(Mantid::API::IFunction_sptr const &function,
                           std::string const &parameter, std::string const &tie);
 
   void removeCompositeAtPrefix(std::string const &functionPrefix);

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/FitScriptGeneratorModel.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/FitScriptGeneratorModel.h
@@ -21,6 +21,17 @@
 namespace MantidQt {
 namespace MantidWidgets {
 
+struct GlobalTie {
+
+  GlobalTie(std::string const &parameter, std::string const &tie) {
+    m_parameter = parameter;
+    m_tie = tie;
+  }
+
+  std::string m_parameter;
+  std::string m_tie;
+};
+
 /**
  * This class stores the domain and fit data to be fitted to. This data is used
  * to generate a python script for complex Mantid fitting.
@@ -57,6 +68,10 @@ public:
   getFunction(std::string const &workspaceName,
               WorkspaceIndex workspaceIndex) override;
 
+  std::string getEquivalentParameterForDomain(
+      std::string const &workspaceName, WorkspaceIndex workspaceIndex,
+      std::string const &fullParameter) const override;
+
   void updateParameterValue(std::string const &workspaceName,
                             WorkspaceIndex workspaceIndex,
                             std::string const &parameter,
@@ -85,11 +100,30 @@ private:
   [[nodiscard]] bool hasWorkspaceDomain(std::string const &workspaceName,
                                         WorkspaceIndex workspaceIndex) const;
 
+  void updateParameterTie(std::size_t const &domainIndex,
+                          std::string const &fullParameter,
+                          std::string const &fullTie);
+  void updateLocalParameterTie(std::size_t const &domainIndex,
+                               std::string const &fullParameter,
+                               std::string const &fullTie);
+  void updateGlobalParameterTie(std::size_t const &domainIndex,
+                                std::string const &fullParameter,
+                                std::string const &fullTie);
+
+  [[nodiscard]] bool validParameter(std::string const &fullParameter) const;
+
+  [[nodiscard]] bool validGlobalTie(std::string const &fullTie) const;
+  void clearGlobalTie(std::string const &fullParameter);
+  [[nodiscard]] std::vector<GlobalTie>::const_iterator
+  findGlobalTie(std::string const &fullParameter) const;
+
   [[nodiscard]] inline std::size_t numberOfDomains() const noexcept {
     return m_fitDomains.size();
   }
 
   std::vector<FitDomain> m_fitDomains;
+  // A vector of global ties. E.g. f0.f0.A0=f1.f0.A0
+  std::vector<GlobalTie> m_globalTies;
   FittingMode m_fittingMode;
 };
 

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/FitScriptGeneratorModel.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/FitScriptGeneratorModel.h
@@ -82,6 +82,10 @@ public:
                             WorkspaceIndex workspaceIndex,
                             std::string const &parameter,
                             double newValue) override;
+  void updateAttributeValue(
+      std::string const &workspaceName, WorkspaceIndex workspaceIndex,
+      std::string const &attribute,
+      Mantid::API::IFunction::Attribute const &newValue) override;
 
 private:
   void removeWorkspaceDomain(

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/FitScriptGeneratorModel.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/FitScriptGeneratorModel.h
@@ -31,9 +31,6 @@ struct FitDomain {
   FitDomain(std::string const &prefix, std::string const &workspaceName,
             WorkspaceIndex workspaceIndex, double startX, double endX);
 
-  [[nodiscard]] bool isSameDomain(std::string const &workspaceName,
-                                  WorkspaceIndex workspaceIndex) const;
-
   std::string m_multiDomainFunctionPrefix;
   std::string m_workspaceName;
   WorkspaceIndex m_workspaceIndex;
@@ -74,7 +71,7 @@ private:
   void removeWorkspaceDomain(
       std::size_t const &removeIndex,
       std::vector<FitDomain>::const_iterator const &removeIter);
-  void addWorkspaceDomain(std::string const &prefix,
+  void addWorkspaceDomain(std::string const &functionPrefix,
                           std::string const &workspaceName,
                           WorkspaceIndex workspaceIndex, double startX,
                           double endX);
@@ -95,17 +92,18 @@ private:
   [[nodiscard]] bool hasWorkspaceDomain(std::string const &workspaceName,
                                         WorkspaceIndex workspaceIndex) const;
 
-  void removeCompositeAtPrefix(std::string const &prefix);
+  void removeCompositeAtPrefix(std::string const &functionPrefix);
 
-  void addEmptyCompositeAtPrefix(std::string const &prefix);
-  void addEmptyCompositeAtPrefix(std::string const &compositePrefix,
-                                 std::size_t const &compositeIndex);
+  void addEmptyCompositeAtPrefix(std::string const &functionPrefix);
+  void addEmptyCompositeAtPrefix(std::string const &functionPrefix,
+                                 std::size_t const &functionIndex);
 
-  void removeCompositeAtIndex(std::size_t const &compositeIndex);
+  void removeCompositeAtIndex(std::size_t const &functionIndex);
 
-  [[nodiscard]] bool hasCompositeAtPrefix(std::string const &prefix) const;
+  [[nodiscard]] bool
+  hasCompositeAtPrefix(std::string const &functionPrefix) const;
 
-  [[nodiscard]] std::string nextAvailablePrefix() const;
+  [[nodiscard]] std::string nextAvailableCompositePrefix() const;
 
   [[nodiscard]] inline std::size_t numberOfDomains() const noexcept {
     return m_fitDomains.size();

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/FitScriptGeneratorModel.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/FitScriptGeneratorModel.h
@@ -45,6 +45,9 @@ public:
   void addWorkspaceDomain(std::string const &workspaceName,
                           WorkspaceIndex workspaceIndex, double startX,
                           double endX) override;
+  [[nodiscard]] bool
+  hasWorkspaceDomain(std::string const &workspaceName,
+                     WorkspaceIndex workspaceIndex) const override;
 
   [[nodiscard]] bool updateStartX(std::string const &workspaceName,
                                   WorkspaceIndex workspaceIndex,
@@ -120,8 +123,6 @@ private:
   [[nodiscard]] std::vector<std::unique_ptr<FitDomain>>::const_iterator
   findWorkspaceDomain(std::string const &workspaceName,
                       WorkspaceIndex workspaceIndex) const;
-  [[nodiscard]] bool hasWorkspaceDomain(std::string const &workspaceName,
-                                        WorkspaceIndex workspaceIndex) const;
 
   [[nodiscard]] std::string
   getEquivalentParameterTieForDomain(FitDomainIndex domainIndex,
@@ -145,7 +146,8 @@ private:
   [[nodiscard]] double
   getParameterValue(std::string const &fullParameter) const;
 
-  [[nodiscard]] bool validParameter(std::string const &fullParameter) const;
+  [[nodiscard]] bool validParameter(FitDomainIndex domainIndex,
+                                    std::string const &fullParameter) const;
   [[nodiscard]] bool validTie(std::string const &fullTie) const;
   [[nodiscard]] bool validGlobalTie(std::string const &fullTie) const;
 

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/FitScriptGeneratorModel.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/FitScriptGeneratorModel.h
@@ -15,6 +15,7 @@
 #include "MantidQtWidgets/Common/IFitScriptGeneratorModel.h"
 #include "MantidQtWidgets/Common/IndexTypes.h"
 
+#include <memory>
 #include <string>
 #include <utility>
 #include <vector>
@@ -32,6 +33,9 @@ class EXPORT_OPT_MANTIDQT_COMMON FitScriptGeneratorModel
     : public IFitScriptGeneratorModel {
 public:
   FitScriptGeneratorModel();
+  FitScriptGeneratorModel(FitScriptGeneratorModel const &model) = delete;
+  FitScriptGeneratorModel &
+  operator=(FitScriptGeneratorModel const &model) = delete;
   ~FitScriptGeneratorModel();
 
   void subscribePresenter(IFitScriptGeneratorPresenter *presenter) override;
@@ -113,7 +117,7 @@ private:
   [[nodiscard]] std::size_t
   findDomainIndex(std::string const &workspaceName,
                   WorkspaceIndex workspaceIndex) const;
-  [[nodiscard]] std::vector<FitDomain>::const_iterator
+  [[nodiscard]] std::vector<std::unique_ptr<FitDomain>>::const_iterator
   findWorkspaceDomain(std::string const &workspaceName,
                       WorkspaceIndex workspaceIndex) const;
   [[nodiscard]] bool hasWorkspaceDomain(std::string const &workspaceName,
@@ -160,7 +164,7 @@ private:
   void checkParameterIsNotGlobal(std::string const &fullParameter) const;
 
   IFitScriptGeneratorPresenter *m_presenter;
-  std::vector<FitDomain> m_fitDomains;
+  std::vector<std::unique_ptr<FitDomain>> m_fitDomains;
   // A vector of global parameters. E.g. f0.A0
   std::vector<GlobalParameter> m_globalParameters;
   // A vector of global ties. E.g. f0.f0.A0=f1.f0.A0

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/FitScriptGeneratorModel.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/FitScriptGeneratorModel.h
@@ -79,9 +79,6 @@ private:
   [[nodiscard]] bool hasWorkspaceDomain(std::string const &workspaceName,
                                         WorkspaceIndex workspaceIndex) const;
 
-  void updateParameterTie(Mantid::API::IFunction_sptr const &function,
-                          std::string const &parameter, std::string const &tie);
-
   [[nodiscard]] inline std::size_t numberOfDomains() const noexcept {
     return m_fitDomains.size();
   }

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/FitScriptGeneratorModel.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/FitScriptGeneratorModel.h
@@ -7,6 +7,7 @@
 #pragma once
 
 #include "DllOption.h"
+#include "MantidAPI/CompositeFunction.h"
 #include "MantidAPI/IFunction_fwd.h"
 #include "MantidAPI/MatrixWorkspace_fwd.h"
 #include "MantidAPI/MultiDomainFunction.h"
@@ -73,6 +74,9 @@ public:
   void addFunction(std::string const &workspaceName,
                    WorkspaceIndex workspaceIndex,
                    std::string const &function) override;
+  Mantid::API::CompositeFunction_sptr
+  getFunction(std::string const &workspaceName,
+              WorkspaceIndex workspaceIndex) override;
 
 private:
   void removeWorkspaceDomain(

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/FitScriptGeneratorModel.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/FitScriptGeneratorModel.h
@@ -147,7 +147,8 @@ private:
   void updateParameterValuesWithGlobalTieTo(FitDomainIndex domainIndex,
                                             std::string const &fullParameter,
                                             double newValue);
-  void updateParameterValueInGlobalTie(GlobalTie const &globalTie,
+  void updateParameterValueInGlobalTie(FitDomainIndex domainIndex,
+                                       GlobalTie const &globalTie,
                                        double newValue);
 
   [[nodiscard]] double

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/FitScriptGeneratorModel.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/FitScriptGeneratorModel.h
@@ -78,6 +78,11 @@ public:
   getFunction(std::string const &workspaceName,
               WorkspaceIndex workspaceIndex) override;
 
+  void updateParameterValue(std::string const &workspaceName,
+                            WorkspaceIndex workspaceIndex,
+                            std::string const &parameter,
+                            double newValue) override;
+
 private:
   void removeWorkspaceDomain(
       std::size_t const &removeIndex,

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/FitScriptGeneratorModel.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/FitScriptGeneratorModel.h
@@ -108,13 +108,13 @@ public:
     return m_globalParameters;
   }
 
-  void setFittingMode(FittingMode const &fittingMode) override;
+  void setFittingMode(FittingMode fittingMode) override;
   [[nodiscard]] inline FittingMode getFittingMode() const noexcept override {
     return m_fittingMode;
   }
 
 private:
-  [[nodiscard]] std::size_t
+  [[nodiscard]] FitDomainIndex
   findDomainIndex(std::string const &workspaceName,
                   WorkspaceIndex workspaceIndex) const;
   [[nodiscard]] std::vector<std::unique_ptr<FitDomain>>::const_iterator
@@ -124,19 +124,19 @@ private:
                                         WorkspaceIndex workspaceIndex) const;
 
   [[nodiscard]] std::string
-  getEquivalentParameterTieForDomain(std::size_t const &domainIndex,
+  getEquivalentParameterTieForDomain(FitDomainIndex domainIndex,
                                      std::string const &fullParameter,
                                      std::string const &fullTie) const;
   [[nodiscard]] std::string
   getAdjustedFunctionIndex(std::string const &parameter) const;
 
-  void updateParameterTie(std::size_t const &domainIndex,
+  void updateParameterTie(FitDomainIndex domainIndex,
                           std::string const &fullParameter,
                           std::string const &fullTie);
-  void updateLocalParameterTie(std::size_t const &domainIndex,
+  void updateLocalParameterTie(FitDomainIndex domainIndex,
                                std::string const &fullParameter,
                                std::string const &fullTie);
-  void updateGlobalParameterTie(std::size_t const &domainIndex,
+  void updateGlobalParameterTie(FitDomainIndex domainIndex,
                                 std::string const &fullParameter,
                                 std::string const &fullTie);
 

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/FitScriptGeneratorModel.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/FitScriptGeneratorModel.h
@@ -67,6 +67,13 @@ public:
   void updateEndX(std::string const &workspaceName,
                   WorkspaceIndex workspaceIndex, double endX) override;
 
+  void removeFunction(std::string const &workspaceName,
+                      WorkspaceIndex workspaceIndex,
+                      std::string const &function) override;
+  void addFunction(std::string const &workspaceName,
+                   WorkspaceIndex workspaceIndex,
+                   std::string const &function) override;
+
 private:
   void removeWorkspaceDomain(
       std::size_t const &removeIndex,

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/FitScriptGeneratorModel.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/FitScriptGeneratorModel.h
@@ -92,14 +92,21 @@ public:
                                  std::string const &functionIndex,
                                  std::string const &constraint) override;
 
-  void setFittingMode(FittingMode const &fittingMode) override;
-  [[nodiscard]] inline FittingMode getFittingMode() const noexcept override {
-    return m_fittingMode;
-  }
-
   [[nodiscard]] inline std::vector<GlobalTie>
   getGlobalTies() const noexcept override {
     return m_globalTies;
+  }
+
+  void setGlobalParameters(std::vector<std::string> const &parameters) override;
+
+  [[nodiscard]] inline std::vector<GlobalParameter>
+  getGlobalParameters() const noexcept override {
+    return m_globalParameters;
+  }
+
+  void setFittingMode(FittingMode const &fittingMode) override;
+  [[nodiscard]] inline FittingMode getFittingMode() const noexcept override {
+    return m_fittingMode;
   }
 
 private:
@@ -148,8 +155,14 @@ private:
     return m_fitDomains.size();
   }
 
+  void checkParameterIsInAllDomains(std::string const &globalParameter) const;
+  void checkGlobalParameterhasNoTies(std::string const &globalParameter) const;
+  void checkParameterIsNotGlobal(std::string const &fullParameter) const;
+
   IFitScriptGeneratorPresenter *m_presenter;
   std::vector<FitDomain> m_fitDomains;
+  // A vector of global parameters. E.g. f0.A0
+  std::vector<GlobalParameter> m_globalParameters;
   // A vector of global ties. E.g. f0.f0.A0=f1.f0.A0
   std::vector<GlobalTie> m_globalTies;
   FittingMode m_fittingMode;

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/FitScriptGeneratorModel.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/FitScriptGeneratorModel.h
@@ -24,15 +24,13 @@ namespace MantidWidgets {
 /**
  * This struct is used to store all data relating to a single domain to be
  * fitted. This includes the location of the domain (workspace Name & index),
- * the location of its composite function in the multi-domain function (the
- * prefix), and the fit range (start and end X).
+ * and the fit range (start and end X).
  */
 struct FitDomain {
 
-  FitDomain(std::string const &prefix, std::string const &workspaceName,
-            WorkspaceIndex workspaceIndex, double startX, double endX);
+  FitDomain(std::string const &workspaceName, WorkspaceIndex workspaceIndex,
+            double startX, double endX);
 
-  std::string m_multiDomainFunctionPrefix;
   std::string m_workspaceName;
   WorkspaceIndex m_workspaceIndex;
   double m_startX;
@@ -95,14 +93,6 @@ public:
                           std::string const &tie) override;
 
 private:
-  void removeWorkspaceDomain(
-      std::size_t const &removeIndex,
-      std::vector<FitDomain>::const_iterator const &removeIter);
-  void addWorkspaceDomain(std::string const &functionPrefix,
-                          std::string const &workspaceName,
-                          WorkspaceIndex workspaceIndex, double startX,
-                          double endX);
-
   [[nodiscard]] std::pair<double, double>
   xLimits(std::string const &workspaceName,
           WorkspaceIndex workspaceIndex) const;
@@ -126,19 +116,12 @@ private:
   void updateParameterTie(Mantid::API::IFunction_sptr const &function,
                           std::string const &parameter, std::string const &tie);
 
-  void removeCompositeAtPrefix(std::string const &functionPrefix);
+  void removeCompositeAtDomainIndex(std::size_t const &domainIndex);
+  void clearCompositeAtDomainIndex(std::size_t const &domainIndex);
 
-  void addEmptyCompositeAtPrefix(std::string const &functionPrefix);
-  void addEmptyCompositeAtPrefix(std::string const &functionPrefix,
-                                 std::size_t const &functionIndex);
+  void addEmptyCompositeAtDomainIndex(std::size_t const &domainIndex);
 
-  void removeCompositeAtIndex(std::size_t const &functionIndex);
-  void clearCompositeAtIndex(std::size_t const &functionIndex);
-
-  [[nodiscard]] bool
-  hasCompositeAtPrefix(std::string const &functionPrefix) const;
-
-  [[nodiscard]] std::string nextAvailableCompositePrefix() const;
+  [[nodiscard]] std::string nextAvailableDomainPrefix() const;
 
   [[nodiscard]] inline std::size_t numberOfDomains() const noexcept {
     return m_fitDomains.size();

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/FitScriptGeneratorModel.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/FitScriptGeneratorModel.h
@@ -141,12 +141,14 @@ private:
                                 std::string const &fullParameter,
                                 std::string const &fullTie);
 
-  void updateParameterValuesWithGlobalTieTo(std::string const &parameter);
+  void updateParameterValuesWithGlobalTieTo(FitDomainIndex domainIndex,
+                                            std::string const &parameter);
   void updateParameterValueInGlobalTie(GlobalTie const &globalTie,
                                        double newValue);
 
   [[nodiscard]] double
-  getParameterValue(std::string const &fullParameter) const;
+  getParameterValue(FitDomainIndex domainIndex,
+                    std::string const &fullParameter) const;
 
   [[nodiscard]] bool validParameter(FitDomainIndex domainIndex,
                                     std::string const &fullParameter) const;

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/FitScriptGeneratorModel.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/FitScriptGeneratorModel.h
@@ -74,6 +74,9 @@ public:
   void addFunction(std::string const &workspaceName,
                    WorkspaceIndex workspaceIndex,
                    std::string const &function) override;
+  void setFunction(std::string const &workspaceName,
+                   WorkspaceIndex workspaceIndex,
+                   std::string const &function) override;
   Mantid::API::CompositeFunction_sptr
   getFunction(std::string const &workspaceName,
               WorkspaceIndex workspaceIndex) override;
@@ -103,6 +106,10 @@ private:
   xLimits(Mantid::API::MatrixWorkspace_const_sptr const &workspace,
           WorkspaceIndex workspaceIndex) const;
 
+  void addFunction(std::string const &workspaceName,
+                   WorkspaceIndex workspaceIndex,
+                   Mantid::API::IFunction_sptr const &function);
+
   [[nodiscard]] std::size_t
   findDomainIndex(std::string const &workspaceName,
                   WorkspaceIndex workspaceIndex) const;
@@ -119,6 +126,7 @@ private:
                                  std::size_t const &functionIndex);
 
   void removeCompositeAtIndex(std::size_t const &functionIndex);
+  void clearCompositeAtIndex(std::size_t const &functionIndex);
 
   [[nodiscard]] bool
   hasCompositeAtPrefix(std::string const &functionPrefix) const;

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/FitScriptGeneratorPresenter.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/FitScriptGeneratorPresenter.h
@@ -31,7 +31,8 @@ public:
                               double startX = 0.0, double endX = 0.0);
   ~FitScriptGeneratorPresenter() override;
 
-  void notifyPresenter(ViewEvent const &event) override;
+  void notifyPresenter(ViewEvent const &event,
+                       std::string const &arg = "") override;
 
   void openFitScriptGenerator() override;
 
@@ -40,6 +41,8 @@ private:
   void handleAddWorkspaceClicked();
   void handleStartXChanged();
   void handleEndXChanged();
+  void handleFunctionAdded(std::string const &function);
+  void handleFunctionRemoved(std::string const &function);
 
   void setWorkspaces(QStringList const &workspaceNames, double startX,
                      double endX);

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/FitScriptGeneratorPresenter.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/FitScriptGeneratorPresenter.h
@@ -44,6 +44,7 @@ private:
   void handleSelectionChanged();
   void handleFunctionAdded(std::string const &function);
   void handleFunctionRemoved(std::string const &function);
+  void handleParameterChanged(std::string const &parameter);
 
   void setWorkspaces(QStringList const &workspaceNames, double startX,
                      double endX);

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/FitScriptGeneratorPresenter.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/FitScriptGeneratorPresenter.h
@@ -39,7 +39,7 @@ public:
   void notifyPresenter(ViewEvent const &event,
                        std::vector<std::string> const &vec) override;
   void notifyPresenter(ViewEvent const &event,
-                       FittingMode const &fittingMode) override;
+                       FittingMode fittingMode) override;
 
   void openFitScriptGenerator() override;
 
@@ -65,7 +65,7 @@ private:
                                         std::string const &constraint);
   void handleGlobalParametersChanged(
       std::vector<std::string> const &globalParameters);
-  void handleFittingModeChanged(FittingMode const &fittingMode);
+  void handleFittingModeChanged(FittingMode fittingMode);
 
   void setWorkspaces(QStringList const &workspaceNames, double startX,
                      double endX);

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/FitScriptGeneratorPresenter.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/FitScriptGeneratorPresenter.h
@@ -8,6 +8,7 @@
 
 #include "DllOption.h"
 #include "MantidAPI/MatrixWorkspace_fwd.h"
+#include "MantidQtWidgets/Common/FittingMode.h"
 #include "MantidQtWidgets/Common/IFitScriptGeneratorPresenter.h"
 #include "MantidQtWidgets/Common/IndexTypes.h"
 
@@ -33,6 +34,8 @@ public:
 
   void notifyPresenter(ViewEvent const &event, std::string const &arg1 = "",
                        std::string const &arg2 = "") override;
+  void notifyPresenter(ViewEvent const &event,
+                       FittingMode const &fittingMode) override;
 
   void openFitScriptGenerator() override;
 
@@ -49,6 +52,7 @@ private:
   void handleAttributeChanged(std::string const &attribute);
   void handleParameterTieChanged(std::string const &parameter,
                                  std::string const &tie);
+  void handleFittingModeChanged(FittingMode const &fittingMode);
 
   void setWorkspaces(QStringList const &workspaceNames, double startX,
                      double endX);

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/FitScriptGeneratorPresenter.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/FitScriptGeneratorPresenter.h
@@ -55,6 +55,9 @@ private:
   void handleAttributeChanged(std::string const &attribute);
   void handleParameterTieChanged(std::string const &parameter,
                                  std::string const &tie);
+  void handleParameterConstraintRemoved(std::string const &parameter);
+  void handleParameterConstraintChanged(std::string const &functionIndex,
+                                        std::string const &constraint);
   void handleFittingModeChanged(FittingMode const &fittingMode);
 
   void setWorkspaces(QStringList const &workspaceNames, double startX,

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/FitScriptGeneratorPresenter.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/FitScriptGeneratorPresenter.h
@@ -22,6 +22,7 @@ namespace MantidWidgets {
 
 class IFitScriptGeneratorModel;
 class IFitScriptGeneratorView;
+struct GlobalParameter;
 struct GlobalTie;
 
 class EXPORT_OPT_MANTIDQT_COMMON FitScriptGeneratorPresenter
@@ -36,11 +37,15 @@ public:
   void notifyPresenter(ViewEvent const &event, std::string const &arg1 = "",
                        std::string const &arg2 = "") override;
   void notifyPresenter(ViewEvent const &event,
+                       std::vector<std::string> const &vec) override;
+  void notifyPresenter(ViewEvent const &event,
                        FittingMode const &fittingMode) override;
 
   void openFitScriptGenerator() override;
 
   void setGlobalTies(std::vector<GlobalTie> const &globalTies) override;
+  void setGlobalParameters(
+      std::vector<GlobalParameter> const &globalParameters) override;
 
 private:
   void handleRemoveClicked();
@@ -58,6 +63,8 @@ private:
   void handleParameterConstraintRemoved(std::string const &parameter);
   void handleParameterConstraintChanged(std::string const &functionIndex,
                                         std::string const &constraint);
+  void handleGlobalParametersChanged(
+      std::vector<std::string> const &globalParameters);
   void handleFittingModeChanged(FittingMode const &fittingMode);
 
   void setWorkspaces(QStringList const &workspaceNames, double startX,
@@ -86,6 +93,12 @@ private:
                              std::vector<FitDomainIndex> const &domainIndices);
   void setFunctionForDomains(std::string const &function,
                              std::vector<FitDomainIndex> const &domainIndices);
+
+  void updateParameterTie(std::string const &workspaceName,
+                          WorkspaceIndex workspaceIndex,
+                          std::string const &parameter, std::string const &tie);
+
+  [[nodiscard]] std::vector<FitDomainIndex> getRowIndices() const;
 
   void checkForWarningMessages();
 

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/FitScriptGeneratorPresenter.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/FitScriptGeneratorPresenter.h
@@ -69,6 +69,14 @@ private:
   void updateEndX(std::string const &workspaceName,
                   WorkspaceIndex workspaceIndex, double endX);
 
+  void
+  removeFunctionForDomains(std::string const &function,
+                           std::vector<FitDomainIndex> const &domainIndices);
+  void addFunctionForDomains(std::string const &function,
+                             std::vector<FitDomainIndex> const &domainIndices);
+  void setFunctionForDomains(std::string const &function,
+                             std::vector<FitDomainIndex> const &domainIndices);
+
   void checkForWarningMessages();
 
   std::vector<std::string> m_warnings;

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/FitScriptGeneratorPresenter.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/FitScriptGeneratorPresenter.h
@@ -31,8 +31,8 @@ public:
                               double startX = 0.0, double endX = 0.0);
   ~FitScriptGeneratorPresenter() override;
 
-  void notifyPresenter(ViewEvent const &event,
-                       std::string const &arg = "") override;
+  void notifyPresenter(ViewEvent const &event, std::string const &arg1 = "",
+                       std::string const &arg2 = "") override;
 
   void openFitScriptGenerator() override;
 
@@ -47,6 +47,8 @@ private:
   void handleFunctionReplaced(std::string const &function);
   void handleParameterChanged(std::string const &parameter);
   void handleAttributeChanged(std::string const &attribute);
+  void handleParameterTieChanged(std::string const &parameter,
+                                 std::string const &tie);
 
   void setWorkspaces(QStringList const &workspaceNames, double startX,
                      double endX);

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/FitScriptGeneratorPresenter.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/FitScriptGeneratorPresenter.h
@@ -41,6 +41,7 @@ private:
   void handleAddWorkspaceClicked();
   void handleStartXChanged();
   void handleEndXChanged();
+  void handleSelectionChanged();
   void handleFunctionAdded(std::string const &function);
   void handleFunctionRemoved(std::string const &function);
 

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/FitScriptGeneratorPresenter.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/FitScriptGeneratorPresenter.h
@@ -22,6 +22,7 @@ namespace MantidWidgets {
 
 class IFitScriptGeneratorModel;
 class IFitScriptGeneratorView;
+struct GlobalTie;
 
 class EXPORT_OPT_MANTIDQT_COMMON FitScriptGeneratorPresenter
     : public IFitScriptGeneratorPresenter {
@@ -38,6 +39,8 @@ public:
                        FittingMode const &fittingMode) override;
 
   void openFitScriptGenerator() override;
+
+  void setGlobalTies(std::vector<GlobalTie> const &globalTies) override;
 
 private:
   void handleRemoveClicked();

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/FitScriptGeneratorPresenter.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/FitScriptGeneratorPresenter.h
@@ -42,8 +42,9 @@ private:
   void handleStartXChanged();
   void handleEndXChanged();
   void handleSelectionChanged();
-  void handleFunctionAdded(std::string const &function);
   void handleFunctionRemoved(std::string const &function);
+  void handleFunctionAdded(std::string const &function);
+  void handleFunctionReplaced(std::string const &function);
   void handleParameterChanged(std::string const &parameter);
   void handleAttributeChanged(std::string const &attribute);
 

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/FitScriptGeneratorPresenter.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/FitScriptGeneratorPresenter.h
@@ -45,6 +45,7 @@ private:
   void handleFunctionAdded(std::string const &function);
   void handleFunctionRemoved(std::string const &function);
   void handleParameterChanged(std::string const &parameter);
+  void handleAttributeChanged(std::string const &attribute);
 
   void setWorkspaces(QStringList const &workspaceNames, double startX,
                      double endX);

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/FitScriptGeneratorView.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/FitScriptGeneratorView.h
@@ -104,6 +104,7 @@ private slots:
   void onParameterChanged(QString const &parameter);
   void onAttributeChanged(QString const &attribute);
   void onCopyFunctionToClipboard();
+  void onFunctionHelpRequested();
 
 private:
   void connectUiSignals();

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/FitScriptGeneratorView.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/FitScriptGeneratorView.h
@@ -73,7 +73,7 @@ public:
 
   void resetSelection() override;
 
-  bool isApplyFunctionChangesToAllChecked() const override;
+  bool isAddRemoveFunctionForAllChecked() const override;
 
   void clearFunction() override;
   void setFunction(Mantid::API::IFunction_sptr const &function) const override;

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/FitScriptGeneratorView.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/FitScriptGeneratorView.h
@@ -9,6 +9,7 @@
 #include "DllOption.h"
 #include "ui_FitScriptGenerator.h"
 
+#include "MantidAPI/CompositeFunction.h"
 #include "MantidAPI/MatrixWorkspace_fwd.h"
 #include "MantidQtWidgets/Common/AddWorkspaceDialog.h"
 #include "MantidQtWidgets/Common/FitOptionsBrowser.h"
@@ -68,6 +69,9 @@ public:
 
   bool isAddFunctionToAllDomainsChecked() const override;
 
+  void
+  setFunction(Mantid::API::CompositeFunction_sptr composite) const override;
+
   void displayWarning(std::string const &message) override;
 
 public:
@@ -87,6 +91,7 @@ private slots:
   void onRemoveClicked();
   void onAddWorkspaceClicked();
   void onCellChanged(int row, int column);
+  void onItemPressed();
   void onFunctionRemoved(const QString &function);
   void onFunctionAdded(const QString &function);
 

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/FitScriptGeneratorView.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/FitScriptGeneratorView.h
@@ -78,7 +78,7 @@ public:
   void clearFunction() override;
   void setFunction(Mantid::API::IFunction_sptr const &function) const override;
 
-  void showMultiDomainPrefix(bool showPrefix) override;
+  void setSimultaneousMode(bool simultaneousMode) override;
 
   void displayWarning(std::string const &message) override;
 

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/FitScriptGeneratorView.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/FitScriptGeneratorView.h
@@ -12,7 +12,7 @@
 #include "MantidAPI/MatrixWorkspace_fwd.h"
 #include "MantidQtWidgets/Common/AddWorkspaceDialog.h"
 #include "MantidQtWidgets/Common/FitOptionsBrowser.h"
-#include "MantidQtWidgets/Common/FunctionBrowser.h"
+#include "MantidQtWidgets/Common/FunctionTreeView.h"
 #include "MantidQtWidgets/Common/IFitScriptGeneratorView.h"
 #include "MantidQtWidgets/Common/IndexTypes.h"
 
@@ -49,6 +49,7 @@ public:
   [[nodiscard]] double startX(FitDomainIndex index) const override;
   [[nodiscard]] double endX(FitDomainIndex index) const override;
 
+  [[nodiscard]] std::vector<FitDomainIndex> allRows() const override;
   [[nodiscard]] std::vector<FitDomainIndex> selectedRows() const override;
 
   void removeWorkspaceDomain(std::string const &workspaceName,
@@ -64,6 +65,8 @@ public:
   getDialogWorkspaceIndices() const override;
 
   void resetSelection() override;
+
+  bool isAddFunctionToAllDomainsChecked() const override;
 
   void displayWarning(std::string const &message) override;
 
@@ -84,6 +87,8 @@ private slots:
   void onRemoveClicked();
   void onAddWorkspaceClicked();
   void onCellChanged(int row, int column);
+  void onFunctionRemoved(const QString &function);
+  void onFunctionAdded(const QString &function);
 
 private:
   void connectUiSignals();
@@ -95,7 +100,7 @@ private:
   IFitScriptGeneratorPresenter *m_presenter;
   std::unique_ptr<AddWorkspaceDialog> m_dialog;
   std::unique_ptr<FitScriptGeneratorDataTable> m_dataTable;
-  std::unique_ptr<FunctionBrowser> m_functionBrowser;
+  std::unique_ptr<FunctionTreeView> m_functionTreeView;
   std::unique_ptr<FitOptionsBrowser> m_fitOptionsBrowser;
   Ui::FitScriptGenerator m_ui;
 };

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/FitScriptGeneratorView.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/FitScriptGeneratorView.h
@@ -67,7 +67,7 @@ public:
 
   void resetSelection() override;
 
-  bool isAddFunctionToAllDomainsChecked() const override;
+  bool isApplyFunctionChangesToAllChecked() const override;
 
   void clearFunction() override;
   void

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/FitScriptGeneratorView.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/FitScriptGeneratorView.h
@@ -103,6 +103,7 @@ private slots:
   void onFunctionReplaced(QString const &function);
   void onParameterChanged(QString const &parameter);
   void onAttributeChanged(QString const &attribute);
+  void onParameterTieChanged(QString const &parameter, QString const &tie);
   void onCopyFunctionToClipboard();
   void onFunctionHelpRequested();
 

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/FitScriptGeneratorView.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/FitScriptGeneratorView.h
@@ -104,7 +104,7 @@ private slots:
   void onRemoveClicked();
   void onAddWorkspaceClicked();
   void onCellChanged(int row, int column);
-  void onItemPressed();
+  void onItemSelected();
   void onFunctionRemoved(QString const &function);
   void onFunctionAdded(QString const &function);
   void onFunctionReplaced(QString const &function);

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/FitScriptGeneratorView.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/FitScriptGeneratorView.h
@@ -55,6 +55,8 @@ public:
 
   [[nodiscard]] double
   parameterValue(std::string const &parameter) const override;
+  [[nodiscard]] Mantid::API::IFunction::Attribute
+  attributeValue(std::string const &attribute) const override;
 
   void removeWorkspaceDomain(std::string const &workspaceName,
                              WorkspaceIndex workspaceIndex) override;
@@ -96,9 +98,10 @@ private slots:
   void onAddWorkspaceClicked();
   void onCellChanged(int row, int column);
   void onItemPressed();
-  void onFunctionRemoved(const QString &function);
-  void onFunctionAdded(const QString &function);
-  void onParameterChanged(const QString &parameter);
+  void onFunctionRemoved(QString const &function);
+  void onFunctionAdded(QString const &function);
+  void onParameterChanged(QString const &parameter);
+  void onAttributeChanged(QString const &attribute);
 
 private:
   void connectUiSignals();

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/FitScriptGeneratorView.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/FitScriptGeneratorView.h
@@ -100,8 +100,10 @@ private slots:
   void onItemPressed();
   void onFunctionRemoved(QString const &function);
   void onFunctionAdded(QString const &function);
+  void onFunctionReplaced(QString const &function);
   void onParameterChanged(QString const &parameter);
   void onAttributeChanged(QString const &attribute);
+  void onCopyFunctionToClipboard();
 
 private:
   void connectUiSignals();

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/FitScriptGeneratorView.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/FitScriptGeneratorView.h
@@ -13,7 +13,6 @@
 #include "MantidAPI/MatrixWorkspace_fwd.h"
 #include "MantidQtWidgets/Common/AddWorkspaceDialog.h"
 #include "MantidQtWidgets/Common/FitOptionsBrowser.h"
-#include "MantidQtWidgets/Common/FittingMode.h"
 #include "MantidQtWidgets/Common/FunctionTreeView.h"
 #include "MantidQtWidgets/Common/IFitScriptGeneratorView.h"
 #include "MantidQtWidgets/Common/IndexTypes.h"
@@ -32,6 +31,7 @@ namespace MantidWidgets {
 
 class FitScriptGeneratorDataTable;
 class IFitScriptGeneratorPresenter;
+struct GlobalTie;
 
 class EXPORT_OPT_MANTIDQT_COMMON FitScriptGeneratorView
     : public IFitScriptGeneratorView {
@@ -79,6 +79,8 @@ public:
   void setFunction(Mantid::API::IFunction_sptr const &function) const override;
 
   void setSimultaneousMode(bool simultaneousMode) override;
+
+  void setGlobalTies(std::vector<GlobalTie> const &globalTies) override;
 
   void displayWarning(std::string const &message) override;
 

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/FitScriptGeneratorView.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/FitScriptGeneratorView.h
@@ -69,6 +69,7 @@ public:
 
   bool isAddFunctionToAllDomainsChecked() const override;
 
+  void clearFunction() override;
   void
   setFunction(Mantid::API::CompositeFunction_sptr composite) const override;
 

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/FitScriptGeneratorView.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/FitScriptGeneratorView.h
@@ -13,6 +13,7 @@
 #include "MantidAPI/MatrixWorkspace_fwd.h"
 #include "MantidQtWidgets/Common/AddWorkspaceDialog.h"
 #include "MantidQtWidgets/Common/FitOptionsBrowser.h"
+#include "MantidQtWidgets/Common/FittingMode.h"
 #include "MantidQtWidgets/Common/FunctionTreeView.h"
 #include "MantidQtWidgets/Common/IFitScriptGeneratorView.h"
 #include "MantidQtWidgets/Common/IndexTypes.h"
@@ -77,6 +78,8 @@ public:
   void clearFunction() override;
   void setFunction(Mantid::API::IFunction_sptr const &function) const override;
 
+  void showMultiDomainPrefix(bool showPrefix) override;
+
   void displayWarning(std::string const &message) override;
 
 public:
@@ -105,6 +108,8 @@ private slots:
   void onParameterTieChanged(QString const &parameter, QString const &tie);
   void onCopyFunctionToClipboard();
   void onFunctionHelpRequested();
+  void onChangeToSequentialFitting();
+  void onChangeToSimultaneousFitting();
 
 private:
   void connectUiSignals();

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/FitScriptGeneratorView.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/FitScriptGeneratorView.h
@@ -108,6 +108,9 @@ private slots:
   void onParameterChanged(QString const &parameter);
   void onAttributeChanged(QString const &attribute);
   void onParameterTieChanged(QString const &parameter, QString const &tie);
+  void onParameterConstraintRemoved(QString const &parameter);
+  void onParameterConstraintChanged(QString const &functionIndex,
+                                    QString const &constraint);
   void onCopyFunctionToClipboard();
   void onFunctionHelpRequested();
   void onChangeToSequentialFitting();

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/FitScriptGeneratorView.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/FitScriptGeneratorView.h
@@ -31,6 +31,7 @@ namespace MantidWidgets {
 
 class FitScriptGeneratorDataTable;
 class IFitScriptGeneratorPresenter;
+struct GlobalParameter;
 struct GlobalTie;
 
 class EXPORT_OPT_MANTIDQT_COMMON FitScriptGeneratorView
@@ -81,6 +82,8 @@ public:
   void setSimultaneousMode(bool simultaneousMode) override;
 
   void setGlobalTies(std::vector<GlobalTie> const &globalTies) override;
+  void setGlobalParameters(
+      std::vector<GlobalParameter> const &globalParameter) override;
 
   void displayWarning(std::string const &message) override;
 
@@ -111,6 +114,7 @@ private slots:
   void onParameterConstraintRemoved(QString const &parameter);
   void onParameterConstraintChanged(QString const &functionIndex,
                                     QString const &constraint);
+  void onGlobalParametersChanged(QStringList const &globalParameters);
   void onCopyFunctionToClipboard();
   void onFunctionHelpRequested();
   void onChangeToSequentialFitting();

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/FitScriptGeneratorView.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/FitScriptGeneratorView.h
@@ -9,7 +9,7 @@
 #include "DllOption.h"
 #include "ui_FitScriptGenerator.h"
 
-#include "MantidAPI/CompositeFunction.h"
+#include "MantidAPI/IFunction.h"
 #include "MantidAPI/MatrixWorkspace_fwd.h"
 #include "MantidQtWidgets/Common/AddWorkspaceDialog.h"
 #include "MantidQtWidgets/Common/FitOptionsBrowser.h"
@@ -75,8 +75,7 @@ public:
   bool isApplyFunctionChangesToAllChecked() const override;
 
   void clearFunction() override;
-  void
-  setFunction(Mantid::API::CompositeFunction_sptr composite) const override;
+  void setFunction(Mantid::API::IFunction_sptr const &function) const override;
 
   void displayWarning(std::string const &message) override;
 

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/FitScriptGeneratorView.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/FitScriptGeneratorView.h
@@ -53,6 +53,9 @@ public:
   [[nodiscard]] std::vector<FitDomainIndex> allRows() const override;
   [[nodiscard]] std::vector<FitDomainIndex> selectedRows() const override;
 
+  [[nodiscard]] double
+  parameterValue(std::string const &parameter) const override;
+
   void removeWorkspaceDomain(std::string const &workspaceName,
                              WorkspaceIndex workspaceIndex) override;
   void addWorkspaceDomain(std::string const &workspaceName,
@@ -95,6 +98,7 @@ private slots:
   void onItemPressed();
   void onFunctionRemoved(const QString &function);
   void onFunctionAdded(const QString &function);
+  void onParameterChanged(const QString &parameter);
 
 private:
   void connectUiSignals();

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/FitScriptGeneratorView.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/FitScriptGeneratorView.h
@@ -13,6 +13,7 @@
 #include "MantidAPI/MatrixWorkspace_fwd.h"
 #include "MantidQtWidgets/Common/AddWorkspaceDialog.h"
 #include "MantidQtWidgets/Common/FitOptionsBrowser.h"
+#include "MantidQtWidgets/Common/FittingMode.h"
 #include "MantidQtWidgets/Common/FunctionTreeView.h"
 #include "MantidQtWidgets/Common/IFitScriptGeneratorView.h"
 #include "MantidQtWidgets/Common/IndexTypes.h"
@@ -41,6 +42,7 @@ class EXPORT_OPT_MANTIDQT_COMMON FitScriptGeneratorView
 public:
   FitScriptGeneratorView(
       QWidget *parent = nullptr,
+      FittingMode fittingMode = FittingMode::SEQUENTIAL,
       QMap<QString, QString> const &fitOptions = QMap<QString, QString>());
   ~FitScriptGeneratorView() override;
 
@@ -124,8 +126,7 @@ private:
   void connectUiSignals();
 
   void setFitBrowserOptions(QMap<QString, QString> const &fitOptions);
-  void setFitBrowserOption(QString const &name, QString const &value);
-  void setFittingType(QString const &fitType);
+  void setFittingMode(FittingMode fittingMode);
 
   IFitScriptGeneratorPresenter *m_presenter;
   std::unique_ptr<AddWorkspaceDialog> m_dialog;

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/FittingGlobals.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/FittingGlobals.h
@@ -15,6 +15,8 @@ struct GlobalTie {
 
   GlobalTie(std::string const &parameter, std::string const &tie);
 
+  std::string removeTopIndex(std::string const &parameter) const;
+
   std::string m_parameter;
   std::string m_tie;
 };

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/FittingGlobals.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/FittingGlobals.h
@@ -1,0 +1,23 @@
+// Mantid Repository : https://github.com/mantidproject/mantid
+//
+// Copyright &copy; 2020 ISIS Rutherford Appleton Laboratory UKRI,
+//   NScD Oak Ridge National Laboratory, European Spallation Source,
+//   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+// SPDX - License - Identifier: GPL - 3.0 +
+#pragma once
+
+#include <string>
+
+namespace MantidQt {
+namespace MantidWidgets {
+
+struct GlobalTie {
+
+  GlobalTie(std::string const &parameter, std::string const &tie);
+
+  std::string m_parameter;
+  std::string m_tie;
+};
+
+} // namespace MantidWidgets
+} // namespace MantidQt

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/FittingGlobals.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/FittingGlobals.h
@@ -11,6 +11,27 @@
 namespace MantidQt {
 namespace MantidWidgets {
 
+/**
+ * This struct stores the name of a global parameter which is shared across
+ * ALL domains in a multi dataset fit. For example we might have two domains
+ * with a FlatBackground in a composite function. If we want the value of
+ * f0.f0.A0 and f1.f0.A0 to be shared (i.e. a global parameter), the parameter
+ * name stored here is f0.A0 (i.e. without the domain index at the start).
+ *
+ * This definition was created because it is more explicit.
+ */
+struct GlobalParameter {
+
+  GlobalParameter(std::string const &parameter);
+
+  std::string m_parameter;
+};
+
+/**
+ * This struct stores the data associated with a global tie. A global tie is
+ * where a parameter of a specific domain is tied to the value of a parameter
+ * in a different domain.
+ */
 struct GlobalTie {
 
   GlobalTie(std::string const &parameter, std::string const &tie);

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/FittingGlobals.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/FittingGlobals.h
@@ -6,6 +6,8 @@
 // SPDX - License - Identifier: GPL - 3.0 +
 #pragma once
 
+#include "DllOption.h"
+
 #include <string>
 
 namespace MantidQt {
@@ -20,7 +22,7 @@ namespace MantidWidgets {
  *
  * This definition was created because it is more explicit.
  */
-struct GlobalParameter {
+struct EXPORT_OPT_MANTIDQT_COMMON GlobalParameter {
 
   GlobalParameter(std::string const &parameter);
 
@@ -32,7 +34,7 @@ struct GlobalParameter {
  * where a parameter of a specific domain is tied to the value of a parameter
  * in a different domain.
  */
-struct GlobalTie {
+struct EXPORT_OPT_MANTIDQT_COMMON GlobalTie {
 
   GlobalTie(std::string const &parameter, std::string const &tie);
 

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/FittingGlobals.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/FittingGlobals.h
@@ -15,8 +15,6 @@ struct GlobalTie {
 
   GlobalTie(std::string const &parameter, std::string const &tie);
 
-  std::string removeTopIndex(std::string const &parameter) const;
-
   std::string m_parameter;
   std::string m_tie;
 };

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/FittingMode.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/FittingMode.h
@@ -6,18 +6,10 @@
 // SPDX - License - Identifier: GPL - 3.0 +
 #pragma once
 
-#include "DllOption.h"
-
 namespace MantidQt {
 namespace MantidWidgets {
 
-/*!
- * FittingMode can be used to specify what mode you are using for a fit. It is
- * also used by the FitPropertyBrowser to either allow the selection of
- * sequential fitting (SEQUENTIAL), simultaneous fitting (SIMULTANEOUS) or both
- * types (SIMULTANEOUS_SEQUENTIAL).
- */
-enum EXPORT_OPT_MANTIDQT_COMMON FittingMode {
+enum FittingMode {
   SIMULTANEOUS = 0,
   SEQUENTIAL = 1,
   SIMULTANEOUS_SEQUENTIAL = 2

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/FittingMode.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/FittingMode.h
@@ -16,6 +16,5 @@ enum EXPORT_OPT_MANTIDQT_COMMON FittingMode {
   SEQUENTIAL = 1,
   SIMULTANEOUS_SEQUENTIAL = 2
 };
-
 }
 } // namespace MantidQt

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/FittingMode.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/FittingMode.h
@@ -11,10 +11,17 @@
 namespace MantidQt {
 namespace MantidWidgets {
 
+/*!
+ * FittingMode can be used to specify what mode you are using for a fit. It is
+ * also used by the FitPropertyBrowser to either allow the selection of
+ * sequential fitting (SEQUENTIAL), simultaneous fitting (SIMULTANEOUS) or both
+ * types (SIMULTANEOUS_SEQUENTIAL).
+ */
 enum EXPORT_OPT_MANTIDQT_COMMON FittingMode {
   SIMULTANEOUS = 0,
   SEQUENTIAL = 1,
   SIMULTANEOUS_SEQUENTIAL = 2
 };
-}
+
+} // namespace MantidWidgets
 } // namespace MantidQt

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/FittingMode.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/FittingMode.h
@@ -1,0 +1,21 @@
+// Mantid Repository : https://github.com/mantidproject/mantid
+//
+// Copyright &copy; 2020 ISIS Rutherford Appleton Laboratory UKRI,
+//   NScD Oak Ridge National Laboratory, European Spallation Source,
+//   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+// SPDX - License - Identifier: GPL - 3.0 +
+#pragma once
+
+#include "DllOption.h"
+
+namespace MantidQt {
+namespace MantidWidgets {
+
+enum EXPORT_OPT_MANTIDQT_COMMON FittingMode {
+  Simultaneous,
+  Sequential,
+  SimultaneousAndSequential
+};
+
+}
+} // namespace MantidQt

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/FittingMode.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/FittingMode.h
@@ -12,9 +12,9 @@ namespace MantidQt {
 namespace MantidWidgets {
 
 enum EXPORT_OPT_MANTIDQT_COMMON FittingMode {
-  Simultaneous,
-  Sequential,
-  SimultaneousAndSequential
+  SIMULTANEOUS = 0,
+  SEQUENTIAL = 1,
+  SIMULTANEOUS_SEQUENTIAL = 2
 };
 
 }

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/FunctionBrowser/FunctionBrowserUtils.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/FunctionBrowser/FunctionBrowserUtils.h
@@ -45,6 +45,8 @@ splitFunctionPrefix(const QString &prefix);
 /// Split a constraint definition into a parameter name and a pair of bounds,
 /// for example -1 < f0.A1 < 2 ==> (f0.A1, (-1, 2))
 EXPORT_OPT_MANTIDQT_COMMON std::pair<QString, std::pair<QString, QString>>
+splitConstraintString(const std::string &constraint);
+EXPORT_OPT_MANTIDQT_COMMON std::pair<QString, std::pair<QString, QString>>
 splitConstraintString(const QString &constraint);
 
 /// Checks if a string contains a number, or whether it contains characters

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/FunctionBrowser/FunctionBrowserUtils.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/FunctionBrowser/FunctionBrowserUtils.h
@@ -11,6 +11,9 @@
 #include <QString>
 #include <boost/optional.hpp>
 
+#include <string>
+#include <vector>
+
 namespace MantidQt {
 namespace MantidWidgets {
 
@@ -43,6 +46,17 @@ splitFunctionPrefix(const QString &prefix);
 /// for example -1 < f0.A1 < 2 ==> (f0.A1, (-1, 2))
 EXPORT_OPT_MANTIDQT_COMMON std::pair<QString, std::pair<QString, QString>>
 splitConstraintString(const QString &constraint);
+
+/// Checks if a string contains a number, or whether it contains characters
+EXPORT_OPT_MANTIDQT_COMMON bool isNumber(std::string const &str);
+
+/// Splits the string by the given delimiters
+EXPORT_OPT_MANTIDQT_COMMON std::vector<std::string>
+splitStringBy(std::string const &str, std::string const &delimiter);
+
+/// Returns the function index found at index of a parameter
+EXPORT_OPT_MANTIDQT_COMMON std::size_t
+getFunctionIndexAt(std::string const &parameter, std::size_t const &index);
 
 class ScopedFalse {
   bool &m_ref;

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/FunctionTreeView.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/FunctionTreeView.h
@@ -8,6 +8,7 @@
 
 #include "DllOption.h"
 
+#include "MantidAPI/CompositeFunction.h"
 #include "MantidAPI/IFunction.h"
 #include "MantidKernel/EmptyValues.h"
 #include "MantidQtWidgets/Common/IFunctionView.h"
@@ -43,7 +44,6 @@ class QTreeWidgetItem;
 
 namespace Mantid {
 namespace API {
-class CompositeFunction;
 class Workspace;
 class ParameterTie;
 } // namespace API
@@ -155,9 +155,22 @@ protected:
   AProperty addAttributeProperty(QtProperty *parent, const QString &attName,
                                  const Mantid::API::IFunction::Attribute &att);
   /// Add attribute and parameter properties to a function property
-  void
-  addAttributeAndParameterProperties(QtProperty *prop,
-                                     const Mantid::API::IFunction_sptr &fun);
+  void addAttributeAndParameterProperties(
+      QtProperty *prop, const Mantid::API::IFunction_sptr &fun,
+      const Mantid::API::CompositeFunction_sptr &parentComposite = nullptr,
+      const std::size_t &parentIndex = 0);
+  /// Add tie to a parameter property. This will also work for ties across
+  /// functions in a composite function.
+  void addParameterTie(
+      QtProperty *property, const Mantid::API::IFunction_sptr &function,
+      const std::string &parameterName, const std::size_t &parameterIndex,
+      const Mantid::API::CompositeFunction_sptr &parentComposite = nullptr,
+      const std::size_t &parentIndex = 0);
+  /// Add tie to a parameter property stored within a composite function.
+  bool FunctionTreeView::addParameterTieInComposite(
+      QtProperty *property, const std::string &parameterName,
+      const Mantid::API::CompositeFunction_sptr &composite,
+      const std::size_t &index);
   /// Add property showing function's index in the composite function
   AProperty addIndexProperty(QtProperty *prop);
   /// Update function index properties

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/FunctionTreeView.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/FunctionTreeView.h
@@ -402,6 +402,9 @@ private:
   void setVectorAttribute(const QString &attrName,
                           std::vector<double> &val) override;
 
+  /// Gets the full tie when using the m_multiDomainFunctionPrefix
+  QString getFullTie(const QString &tie) const;
+
   // Intended for testing only
   QTreeWidgetItem *getPropertyWidgetItem(QtProperty *prop) const;
   QRect visualItemRect(QtProperty *prop) const;

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/FunctionTreeView.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/FunctionTreeView.h
@@ -11,6 +11,7 @@
 #include "MantidAPI/CompositeFunction.h"
 #include "MantidAPI/IFunction.h"
 #include "MantidKernel/EmptyValues.h"
+#include "MantidQtWidgets/Common/FittingGlobals.h"
 #include "MantidQtWidgets/Common/IFunctionView.h"
 
 #include <QMap>
@@ -54,6 +55,7 @@ namespace MantidWidgets {
 
 class CreateAttributePropertyForFunctionTreeView;
 class SelectFunctionDialog;
+struct GlobalTie;
 
 /**
  * Class FitPropertyBrowser implements QtPropertyBrowser to display
@@ -136,6 +138,8 @@ public:
   // Sets the function prefix of a domain to be displayed within a
   // MultiDomainFunction
   void setMultiDomainFunctionPrefix(const QString &functionPrefix);
+  // Sets the global ties to be displayed within a MultiDomainFunction
+  void setGlobalTies(std::vector<GlobalTie> const &globalTies);
 
 protected:
   /// Create the Qt property browser
@@ -384,6 +388,8 @@ protected:
   /// The function prefix of the domain with a MultiDomainFunction currently
   /// being displayed.
   QString m_multiDomainFunctionPrefix;
+  // A vector of global ties. E.g. f0.f0.A0=f1.f0.A0
+  std::vector<GlobalTie> m_globalTies;
   std::vector<std::string> m_allowedCategories;
   SelectFunctionDialog *m_selectFunctionDialog;
   QtProperty *m_selectedFunctionProperty;

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/FunctionTreeView.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/FunctionTreeView.h
@@ -175,7 +175,7 @@ protected:
       const Mantid::API::CompositeFunction_sptr &parentComposite = nullptr,
       const std::size_t &parentIndex = 0);
   /// Add tie to a parameter property stored within a composite function.
-  bool FunctionTreeView::addParameterTieInComposite(
+  bool addParameterTieInComposite(
       QtProperty *property, const std::string &parameterName,
       const Mantid::API::CompositeFunction_sptr &composite,
       const std::size_t &index);

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/FunctionTreeView.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/FunctionTreeView.h
@@ -133,6 +133,10 @@ public:
   // Show global boxes
   void showGlobals();
 
+  // Sets the function prefix of a domain to be displayed within a
+  // MultiDomainFunction
+  void setMultiDomainFunctionPrefix(const QString &functionPrefix);
+
 protected:
   /// Create the Qt property browser
   void createBrowser();
@@ -171,6 +175,9 @@ protected:
       QtProperty *property, const std::string &parameterName,
       const Mantid::API::CompositeFunction_sptr &composite,
       const std::size_t &index);
+  /// Adds an index property representing the function index of a specific
+  /// domain within a MultiDomainFunction.
+  void addMultiDomainIndexProperty(QtProperty *prop);
   /// Add property showing function's index in the composite function
   AProperty addIndexProperty(QtProperty *prop);
   /// Update function index properties
@@ -374,6 +381,9 @@ protected:
   /// Set true if the constructed function is intended to be used in a
   /// multi-dataset fit
   bool m_multiDataset;
+  /// The function prefix of the domain with a MultiDomainFunction currently
+  /// being displayed.
+  QString m_multiDomainFunctionPrefix;
   std::vector<std::string> m_allowedCategories;
   SelectFunctionDialog *m_selectFunctionDialog;
   QtProperty *m_selectedFunctionProperty;

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/FunctionTreeView.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/FunctionTreeView.h
@@ -179,6 +179,11 @@ protected:
       QtProperty *property, const std::string &parameterName,
       const Mantid::API::CompositeFunction_sptr &composite,
       const std::size_t &index);
+  /// Adds a global tie for a parameter if one exists
+  void
+  addGlobalParameterTie(QtProperty *property, const std::string &parameterName,
+                        const CompositeFunction_sptr &parentComposite = nullptr,
+                        const std::size_t &parentIndex = 0);
   /// Adds an index property representing the function index of a specific
   /// domain within a MultiDomainFunction.
   void addMultiDomainIndexProperty(QtProperty *prop);
@@ -229,7 +234,8 @@ protected:
   QtProperty *getTieProperty(QtProperty *prop) const;
 
   /// Add a tie property
-  void addTieProperty(QtProperty *prop, const QString &tie);
+  void addTieProperty(QtProperty *prop, const QString &tie,
+                      bool globalTie = false);
   /// Check if a parameter property has a tie
   bool hasTie(QtProperty *prop) const;
   /// Check if a property is a tie
@@ -410,6 +416,9 @@ private:
 
   /// Gets the full tie when using the m_multiDomainFunctionPrefix
   QString getFullTie(const QString &tie) const;
+  /// Gets the full parameter name when using the m_multiDomainFunctionPrefix
+  std::string getFullParameterName(const std::string &parameter,
+                                   int compositeIndex = -1) const;
 
   // Intended for testing only
   QTreeWidgetItem *getPropertyWidgetItem(QtProperty *prop) const;

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/FunctionTreeView.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/FunctionTreeView.h
@@ -29,6 +29,7 @@ class QtEnumPropertyManager;
 class QtProperty;
 class QtBrowserItem;
 class ParameterPropertyManager;
+class DoubleDialogEditorFactory;
 
 class QPushButton;
 class QLabel;
@@ -283,6 +284,9 @@ protected slots:
 
 protected:
   void removeConstraintsQuiet(QtProperty *paramProp);
+
+  /// Editor used for editing doubles.
+  DoubleDialogEditorFactory *m_doubleEditorFactory;
   /// Manager for function group properties
   QtGroupPropertyManager *m_functionManager;
   /// Manager for function parameter properties
@@ -387,6 +391,8 @@ public:
   QRect getVisualRectFunctionProperty(const QString &index) const;
   QRect getVisualRectParameterProperty(const QString &paramName) const;
   QTreeWidget *treeWidget() const;
+  QtTreePropertyBrowser *treeBrowser();
+  DoubleDialogEditorFactory *doubleEditorFactory();
   QWidget *getParamWidget(const QString &paramName) const;
 };
 

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/FunctionTreeView.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/FunctionTreeView.h
@@ -9,7 +9,7 @@
 #include "DllOption.h"
 
 #include "MantidAPI/CompositeFunction.h"
-#include "MantidAPI/IFunction.h"
+#include "MantidAPI/IFunction_fwd.h"
 #include "MantidKernel/EmptyValues.h"
 #include "MantidQtWidgets/Common/FittingGlobals.h"
 #include "MantidQtWidgets/Common/IFunctionView.h"

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/IFitScriptGeneratorModel.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/IFitScriptGeneratorModel.h
@@ -61,6 +61,10 @@ public:
                        WorkspaceIndex workspaceIndex,
                        std::string const &attribute,
                        Mantid::API::IFunction::Attribute const &newValue) = 0;
+  virtual void updateParameterTie(std::string const &workspaceName,
+                                  WorkspaceIndex workspaceIndex,
+                                  std::string const &parameter,
+                                  std::string const &tie) = 0;
 };
 
 } // namespace MantidWidgets

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/IFitScriptGeneratorModel.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/IFitScriptGeneratorModel.h
@@ -55,6 +55,9 @@ public:
   getEquivalentParameterForDomain(std::string const &workspaceName,
                                   WorkspaceIndex workspaceIndex,
                                   std::string const &fullParameter) const = 0;
+  [[nodiscard]] virtual std::string getEquivalentParameterTieForDomain(
+      std::string const &workspaceName, WorkspaceIndex workspaceIndex,
+      std::string const &fullParameter, std::string const &fullTie) const = 0;
 
   virtual void updateParameterValue(std::string const &workspaceName,
                                     WorkspaceIndex workspaceIndex,

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/IFitScriptGeneratorModel.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/IFitScriptGeneratorModel.h
@@ -51,27 +51,35 @@ public:
   getFunction(std::string const &workspaceName,
               WorkspaceIndex workspaceIndex) = 0;
 
-  [[nodiscard]] virtual std::string
-  getEquivalentParameterForDomain(std::string const &workspaceName,
-                                  WorkspaceIndex workspaceIndex,
-                                  std::string const &fullParameter) const = 0;
+  [[nodiscard]] virtual std::string getEquivalentFunctionIndexForDomain(
+      std::string const &workspaceName, WorkspaceIndex workspaceIndex,
+      std::string const &functionIndex) const = 0;
   [[nodiscard]] virtual std::string getEquivalentParameterTieForDomain(
       std::string const &workspaceName, WorkspaceIndex workspaceIndex,
       std::string const &fullParameter, std::string const &fullTie) const = 0;
 
   virtual void updateParameterValue(std::string const &workspaceName,
                                     WorkspaceIndex workspaceIndex,
-                                    std::string const &parameter,
+                                    std::string const &fullParameter,
                                     double newValue) = 0;
   virtual void
   updateAttributeValue(std::string const &workspaceName,
                        WorkspaceIndex workspaceIndex,
-                       std::string const &attribute,
+                       std::string const &fullAttribute,
                        Mantid::API::IFunction::Attribute const &newValue) = 0;
+
   virtual void updateParameterTie(std::string const &workspaceName,
                                   WorkspaceIndex workspaceIndex,
-                                  std::string const &parameter,
+                                  std::string const &fullParameter,
                                   std::string const &tie) = 0;
+
+  virtual void removeParameterConstraint(std::string const &workspaceName,
+                                         WorkspaceIndex workspaceIndex,
+                                         std::string const &fullParameter) = 0;
+  virtual void updateParameterConstraint(std::string const &workspaceName,
+                                         WorkspaceIndex workspaceIndex,
+                                         std::string const &functionIndex,
+                                         std::string const &constraint) = 0;
 
   virtual void setFittingMode(FittingMode const &fittingMode) = 0;
   [[nodiscard]] virtual FittingMode getFittingMode() const = 0;

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/IFitScriptGeneratorModel.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/IFitScriptGeneratorModel.h
@@ -7,8 +7,7 @@
 #pragma once
 
 #include "DllOption.h"
-#include "MantidAPI/CompositeFunction.h"
-#include "MantidAPI/IFunction_fwd.h"
+#include "MantidAPI/IFunction.h"
 #include "MantidQtWidgets/Common/IndexTypes.h"
 
 #include <string>
@@ -27,17 +26,12 @@ public:
                                   WorkspaceIndex workspaceIndex, double startX,
                                   double endX) = 0;
 
-  [[nodiscard]] virtual bool isStartXValid(std::string const &workspaceName,
-                                           WorkspaceIndex workspaceIndex,
-                                           double startX) const = 0;
-  [[nodiscard]] virtual bool isEndXValid(std::string const &workspaceName,
-                                         WorkspaceIndex workspaceIndex,
-                                         double endX) const = 0;
-
-  virtual void updateStartX(std::string const &workspaceName,
-                            WorkspaceIndex workspaceIndex, double startX) = 0;
-  virtual void updateEndX(std::string const &workspaceName,
-                          WorkspaceIndex workspaceIndex, double endX) = 0;
+  [[nodiscard]] virtual bool updateStartX(std::string const &workspaceName,
+                                          WorkspaceIndex workspaceIndex,
+                                          double startX) = 0;
+  [[nodiscard]] virtual bool updateEndX(std::string const &workspaceName,
+                                        WorkspaceIndex workspaceIndex,
+                                        double endX) = 0;
 
   virtual void removeFunction(std::string const &workspaceName,
                               WorkspaceIndex workspaceIndex,
@@ -48,7 +42,7 @@ public:
   virtual void setFunction(std::string const &workspaceName,
                            WorkspaceIndex workspaceIndex,
                            std::string const &function) = 0;
-  virtual Mantid::API::CompositeFunction_sptr
+  virtual Mantid::API::IFunction_sptr
   getFunction(std::string const &workspaceName,
               WorkspaceIndex workspaceIndex) = 0;
 

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/IFitScriptGeneratorModel.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/IFitScriptGeneratorModel.h
@@ -50,7 +50,7 @@ public:
                            std::string const &function) = 0;
   [[nodiscard]] virtual Mantid::API::IFunction_sptr
   getFunction(std::string const &workspaceName,
-              WorkspaceIndex workspaceIndex) = 0;
+              WorkspaceIndex workspaceIndex) const = 0;
 
   [[nodiscard]] virtual std::string getEquivalentFunctionIndexForDomain(
       std::string const &workspaceName, WorkspaceIndex workspaceIndex,

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/IFitScriptGeneratorModel.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/IFitScriptGeneratorModel.h
@@ -45,6 +45,9 @@ public:
   virtual void addFunction(std::string const &workspaceName,
                            WorkspaceIndex workspaceIndex,
                            std::string const &function) = 0;
+  virtual void setFunction(std::string const &workspaceName,
+                           WorkspaceIndex workspaceIndex,
+                           std::string const &function) = 0;
   virtual Mantid::API::CompositeFunction_sptr
   getFunction(std::string const &workspaceName,
               WorkspaceIndex workspaceIndex) = 0;

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/IFitScriptGeneratorModel.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/IFitScriptGeneratorModel.h
@@ -8,6 +8,7 @@
 
 #include "DllOption.h"
 #include "MantidAPI/IFunction.h"
+#include "MantidQtWidgets/Common/FittingMode.h"
 #include "MantidQtWidgets/Common/IndexTypes.h"
 
 #include <string>
@@ -59,6 +60,9 @@ public:
                                   WorkspaceIndex workspaceIndex,
                                   std::string const &parameter,
                                   std::string const &tie) = 0;
+
+  virtual void setFittingMode(FittingMode const &fittingMode) = 0;
+  virtual FittingMode getFittingMode() const = 0;
 };
 
 } // namespace MantidWidgets

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/IFitScriptGeneratorModel.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/IFitScriptGeneratorModel.h
@@ -85,7 +85,7 @@ public:
   virtual void
   setGlobalParameters(std::vector<std::string> const &parameters) = 0;
 
-  virtual void setFittingMode(FittingMode const &fittingMode) = 0;
+  virtual void setFittingMode(FittingMode fittingMode) = 0;
   [[nodiscard]] virtual FittingMode getFittingMode() const = 0;
 
   [[nodiscard]] virtual std::vector<GlobalTie> getGlobalTies() const = 0;

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/IFitScriptGeneratorModel.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/IFitScriptGeneratorModel.h
@@ -8,6 +8,7 @@
 
 #include "DllOption.h"
 #include "MantidAPI/CompositeFunction.h"
+#include "MantidAPI/IFunction_fwd.h"
 #include "MantidQtWidgets/Common/IndexTypes.h"
 
 #include <string>
@@ -52,6 +53,11 @@ public:
                                     WorkspaceIndex workspaceIndex,
                                     std::string const &parameter,
                                     double newValue) = 0;
+  virtual void
+  updateAttributeValue(std::string const &workspaceName,
+                       WorkspaceIndex workspaceIndex,
+                       std::string const &attribute,
+                       Mantid::API::IFunction::Attribute const &newValue) = 0;
 };
 
 } // namespace MantidWidgets

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/IFitScriptGeneratorModel.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/IFitScriptGeneratorModel.h
@@ -47,6 +47,11 @@ public:
   getFunction(std::string const &workspaceName,
               WorkspaceIndex workspaceIndex) = 0;
 
+  virtual std::string
+  getEquivalentParameterForDomain(std::string const &workspaceName,
+                                  WorkspaceIndex workspaceIndex,
+                                  std::string const &fullParameter) const = 0;
+
   virtual void updateParameterValue(std::string const &workspaceName,
                                     WorkspaceIndex workspaceIndex,
                                     std::string const &parameter,

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/IFitScriptGeneratorModel.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/IFitScriptGeneratorModel.h
@@ -16,10 +16,14 @@
 namespace MantidQt {
 namespace MantidWidgets {
 
+class IFitScriptGeneratorPresenter;
+
 class EXPORT_OPT_MANTIDQT_COMMON IFitScriptGeneratorModel {
 
 public:
   virtual ~IFitScriptGeneratorModel() = default;
+
+  virtual void subscribePresenter(IFitScriptGeneratorPresenter *presenter) = 0;
 
   virtual void removeWorkspaceDomain(std::string const &workspaceName,
                                      WorkspaceIndex workspaceIndex) = 0;
@@ -43,11 +47,11 @@ public:
   virtual void setFunction(std::string const &workspaceName,
                            WorkspaceIndex workspaceIndex,
                            std::string const &function) = 0;
-  virtual Mantid::API::IFunction_sptr
+  [[nodiscard]] virtual Mantid::API::IFunction_sptr
   getFunction(std::string const &workspaceName,
               WorkspaceIndex workspaceIndex) = 0;
 
-  virtual std::string
+  [[nodiscard]] virtual std::string
   getEquivalentParameterForDomain(std::string const &workspaceName,
                                   WorkspaceIndex workspaceIndex,
                                   std::string const &fullParameter) const = 0;
@@ -67,7 +71,9 @@ public:
                                   std::string const &tie) = 0;
 
   virtual void setFittingMode(FittingMode const &fittingMode) = 0;
-  virtual FittingMode getFittingMode() const = 0;
+  [[nodiscard]] virtual FittingMode getFittingMode() const = 0;
+
+  [[nodiscard]] virtual std::vector<GlobalTie> getGlobalTies() const = 0;
 };
 
 } // namespace MantidWidgets

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/IFitScriptGeneratorModel.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/IFitScriptGeneratorModel.h
@@ -31,6 +31,9 @@ public:
   virtual void addWorkspaceDomain(std::string const &workspaceName,
                                   WorkspaceIndex workspaceIndex, double startX,
                                   double endX) = 0;
+  [[nodiscard]] virtual bool
+  hasWorkspaceDomain(std::string const &workspaceName,
+                     WorkspaceIndex workspaceIndex) const = 0;
 
   [[nodiscard]] virtual bool updateStartX(std::string const &workspaceName,
                                           WorkspaceIndex workspaceIndex,

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/IFitScriptGeneratorModel.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/IFitScriptGeneratorModel.h
@@ -7,6 +7,7 @@
 #pragma once
 
 #include "DllOption.h"
+#include "MantidAPI/CompositeFunction.h"
 #include "MantidQtWidgets/Common/IndexTypes.h"
 
 #include <string>
@@ -43,6 +44,9 @@ public:
   virtual void addFunction(std::string const &workspaceName,
                            WorkspaceIndex workspaceIndex,
                            std::string const &function) = 0;
+  virtual Mantid::API::CompositeFunction_sptr
+  getFunction(std::string const &workspaceName,
+              WorkspaceIndex workspaceIndex) = 0;
 };
 
 } // namespace MantidWidgets

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/IFitScriptGeneratorModel.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/IFitScriptGeneratorModel.h
@@ -36,6 +36,13 @@ public:
                             WorkspaceIndex workspaceIndex, double startX) = 0;
   virtual void updateEndX(std::string const &workspaceName,
                           WorkspaceIndex workspaceIndex, double endX) = 0;
+
+  virtual void removeFunction(std::string const &workspaceName,
+                              WorkspaceIndex workspaceIndex,
+                              std::string const &function) = 0;
+  virtual void addFunction(std::string const &workspaceName,
+                           WorkspaceIndex workspaceIndex,
+                           std::string const &function) = 0;
 };
 
 } // namespace MantidWidgets

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/IFitScriptGeneratorModel.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/IFitScriptGeneratorModel.h
@@ -12,6 +12,7 @@
 #include "MantidQtWidgets/Common/IndexTypes.h"
 
 #include <string>
+#include <vector>
 
 namespace MantidQt {
 namespace MantidWidgets {
@@ -81,10 +82,15 @@ public:
                                          std::string const &functionIndex,
                                          std::string const &constraint) = 0;
 
+  virtual void
+  setGlobalParameters(std::vector<std::string> const &parameters) = 0;
+
   virtual void setFittingMode(FittingMode const &fittingMode) = 0;
   [[nodiscard]] virtual FittingMode getFittingMode() const = 0;
 
   [[nodiscard]] virtual std::vector<GlobalTie> getGlobalTies() const = 0;
+  [[nodiscard]] virtual std::vector<GlobalParameter>
+  getGlobalParameters() const = 0;
 };
 
 } // namespace MantidWidgets

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/IFitScriptGeneratorModel.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/IFitScriptGeneratorModel.h
@@ -47,6 +47,11 @@ public:
   virtual Mantid::API::CompositeFunction_sptr
   getFunction(std::string const &workspaceName,
               WorkspaceIndex workspaceIndex) = 0;
+
+  virtual void updateParameterValue(std::string const &workspaceName,
+                                    WorkspaceIndex workspaceIndex,
+                                    std::string const &parameter,
+                                    double newValue) = 0;
 };
 
 } // namespace MantidWidgets

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/IFitScriptGeneratorPresenter.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/IFitScriptGeneratorPresenter.h
@@ -17,6 +17,8 @@ namespace MantidWidgets {
 
 using ViewEvent = IFitScriptGeneratorView::Event;
 
+struct GlobalTie;
+
 class EXPORT_OPT_MANTIDQT_COMMON IFitScriptGeneratorPresenter {
 public:
   virtual ~IFitScriptGeneratorPresenter() = default;
@@ -28,6 +30,8 @@ public:
                                FittingMode const &fittingMode) = 0;
 
   virtual void openFitScriptGenerator() = 0;
+
+  virtual void setGlobalTies(std::vector<GlobalTie> const &globalTies) = 0;
 };
 
 } // namespace MantidWidgets

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/IFitScriptGeneratorPresenter.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/IFitScriptGeneratorPresenter.h
@@ -21,7 +21,8 @@ public:
   virtual ~IFitScriptGeneratorPresenter() = default;
 
   virtual void notifyPresenter(ViewEvent const &event,
-                               std::string const &arg = "") = 0;
+                               std::string const &arg1 = "",
+                               std::string const &arg2 = "") = 0;
 
   virtual void openFitScriptGenerator() = 0;
 };

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/IFitScriptGeneratorPresenter.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/IFitScriptGeneratorPresenter.h
@@ -11,12 +11,14 @@
 #include "MantidQtWidgets/Common/FittingMode.h"
 
 #include <string>
+#include <vector>
 
 namespace MantidQt {
 namespace MantidWidgets {
 
 using ViewEvent = IFitScriptGeneratorView::Event;
 
+struct GlobalParameter;
 struct GlobalTie;
 
 class EXPORT_OPT_MANTIDQT_COMMON IFitScriptGeneratorPresenter {
@@ -27,11 +29,15 @@ public:
                                std::string const &arg1 = "",
                                std::string const &arg2 = "") = 0;
   virtual void notifyPresenter(ViewEvent const &event,
+                               std::vector<std::string> const &vec) = 0;
+  virtual void notifyPresenter(ViewEvent const &event,
                                FittingMode const &fittingMode) = 0;
 
   virtual void openFitScriptGenerator() = 0;
 
   virtual void setGlobalTies(std::vector<GlobalTie> const &globalTies) = 0;
+  virtual void
+  setGlobalParameters(std::vector<GlobalParameter> const &globalParameters) = 0;
 };
 
 } // namespace MantidWidgets

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/IFitScriptGeneratorPresenter.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/IFitScriptGeneratorPresenter.h
@@ -8,6 +8,7 @@
 
 #include "DllOption.h"
 #include "IFitScriptGeneratorView.h"
+#include "MantidQtWidgets/Common/FittingMode.h"
 
 #include <string>
 
@@ -23,6 +24,8 @@ public:
   virtual void notifyPresenter(ViewEvent const &event,
                                std::string const &arg1 = "",
                                std::string const &arg2 = "") = 0;
+  virtual void notifyPresenter(ViewEvent const &event,
+                               FittingMode const &fittingMode) = 0;
 
   virtual void openFitScriptGenerator() = 0;
 };

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/IFitScriptGeneratorPresenter.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/IFitScriptGeneratorPresenter.h
@@ -31,7 +31,7 @@ public:
   virtual void notifyPresenter(ViewEvent const &event,
                                std::vector<std::string> const &vec) = 0;
   virtual void notifyPresenter(ViewEvent const &event,
-                               FittingMode const &fittingMode) = 0;
+                               FittingMode fittingMode) = 0;
 
   virtual void openFitScriptGenerator() = 0;
 

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/IFitScriptGeneratorPresenter.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/IFitScriptGeneratorPresenter.h
@@ -8,6 +8,7 @@
 
 #include "DllOption.h"
 #include "IFitScriptGeneratorView.h"
+#include "MantidQtWidgets/Common/FittingGlobals.h"
 #include "MantidQtWidgets/Common/FittingMode.h"
 
 #include <string>
@@ -17,9 +18,6 @@ namespace MantidQt {
 namespace MantidWidgets {
 
 using ViewEvent = IFitScriptGeneratorView::Event;
-
-struct GlobalParameter;
-struct GlobalTie;
 
 class EXPORT_OPT_MANTIDQT_COMMON IFitScriptGeneratorPresenter {
 public:
@@ -35,9 +33,11 @@ public:
 
   virtual void openFitScriptGenerator() = 0;
 
-  virtual void setGlobalTies(std::vector<GlobalTie> const &globalTies) = 0;
-  virtual void
-  setGlobalParameters(std::vector<GlobalParameter> const &globalParameters) = 0;
+  virtual void setGlobalTies(
+      std::vector<MantidQt::MantidWidgets::GlobalTie> const &globalTies) = 0;
+  virtual void setGlobalParameters(
+      std::vector<MantidQt::MantidWidgets::GlobalParameter> const
+          &globalParameters) = 0;
 };
 
 } // namespace MantidWidgets

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/IFitScriptGeneratorPresenter.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/IFitScriptGeneratorPresenter.h
@@ -9,6 +9,8 @@
 #include "DllOption.h"
 #include "IFitScriptGeneratorView.h"
 
+#include <string>
+
 namespace MantidQt {
 namespace MantidWidgets {
 
@@ -18,7 +20,8 @@ class EXPORT_OPT_MANTIDQT_COMMON IFitScriptGeneratorPresenter {
 public:
   virtual ~IFitScriptGeneratorPresenter() = default;
 
-  virtual void notifyPresenter(ViewEvent const &event) = 0;
+  virtual void notifyPresenter(ViewEvent const &event,
+                               std::string const &arg = "") = 0;
 
   virtual void openFitScriptGenerator() = 0;
 };

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/IFitScriptGeneratorView.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/IFitScriptGeneratorView.h
@@ -8,7 +8,7 @@
 
 #include "DllOption.h"
 
-#include "MantidAPI/CompositeFunction.h"
+#include "MantidAPI/IFunction.h"
 #include "MantidAPI/MatrixWorkspace_fwd.h"
 #include "MantidQtWidgets/Common/IndexTypes.h"
 #include "MantidQtWidgets/Common/MantidWidget.h"
@@ -85,7 +85,7 @@ public:
 
   virtual void clearFunction() = 0;
   virtual void
-  setFunction(Mantid::API::CompositeFunction_sptr composite) const = 0;
+  setFunction(Mantid::API::IFunction_sptr const &function) const = 0;
 
   virtual void displayWarning(std::string const &message) = 0;
 

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/IFitScriptGeneratorView.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/IFitScriptGeneratorView.h
@@ -27,6 +27,7 @@ namespace MantidWidgets {
 class AddWorkspaceDialog;
 class FitScriptGeneratorDataTable;
 class IFitScriptGeneratorPresenter;
+struct GlobalParameter;
 struct GlobalTie;
 
 class EXPORT_OPT_MANTIDQT_COMMON IFitScriptGeneratorView
@@ -48,6 +49,7 @@ public:
     ParameterTieChanged,
     ParameterConstraintRemoved,
     ParameterConstraintChanged,
+    GlobalParametersChanged,
     FittingModeChanged
   };
 
@@ -95,6 +97,8 @@ public:
   virtual void setSimultaneousMode(bool simultaneousMode) = 0;
 
   virtual void setGlobalTies(std::vector<GlobalTie> const &globalTies) = 0;
+  virtual void
+  setGlobalParameters(std::vector<GlobalParameter> const &globalParameter) = 0;
 
   virtual void displayWarning(std::string const &message) = 0;
 

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/IFitScriptGeneratorView.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/IFitScriptGeneratorView.h
@@ -33,13 +33,14 @@ class EXPORT_OPT_MANTIDQT_COMMON IFitScriptGeneratorView
 
 public:
   enum class Event {
-    AddClicked,
     RemoveClicked,
+    AddClicked,
     StartXChanged,
     EndXChanged,
     SelectionChanged,
-    FunctionAdded,
     FunctionRemoved,
+    FunctionAdded,
+    FunctionReplaced,
     ParameterChanged,
     AttributeChanged
   };

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/IFitScriptGeneratorView.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/IFitScriptGeneratorView.h
@@ -8,6 +8,7 @@
 
 #include "DllOption.h"
 
+#include "MantidAPI/CompositeFunction.h"
 #include "MantidAPI/MatrixWorkspace_fwd.h"
 #include "MantidQtWidgets/Common/IndexTypes.h"
 #include "MantidQtWidgets/Common/MantidWidget.h"
@@ -36,6 +37,7 @@ public:
     RemoveClicked,
     StartXChanged,
     EndXChanged,
+    SelectionChanged,
     FunctionAdded,
     FunctionRemoved
   };
@@ -71,6 +73,9 @@ public:
   virtual void resetSelection() = 0;
 
   virtual bool isAddFunctionToAllDomainsChecked() const = 0;
+
+  virtual void
+  setFunction(Mantid::API::CompositeFunction_sptr composite) const = 0;
 
   virtual void displayWarning(std::string const &message) = 0;
 

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/IFitScriptGeneratorView.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/IFitScriptGeneratorView.h
@@ -27,6 +27,7 @@ namespace MantidWidgets {
 class AddWorkspaceDialog;
 class FitScriptGeneratorDataTable;
 class IFitScriptGeneratorPresenter;
+struct GlobalTie;
 
 class EXPORT_OPT_MANTIDQT_COMMON IFitScriptGeneratorView
     : public API::MantidWidget {
@@ -90,6 +91,8 @@ public:
   setFunction(Mantid::API::IFunction_sptr const &function) const = 0;
 
   virtual void setSimultaneousMode(bool simultaneousMode) = 0;
+
+  virtual void setGlobalTies(std::vector<GlobalTie> const &globalTies) = 0;
 
   virtual void displayWarning(std::string const &message) = 0;
 

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/IFitScriptGeneratorView.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/IFitScriptGeneratorView.h
@@ -10,6 +10,7 @@
 
 #include "MantidAPI/IFunction.h"
 #include "MantidAPI/MatrixWorkspace_fwd.h"
+#include "MantidQtWidgets/Common/FittingMode.h"
 #include "MantidQtWidgets/Common/IndexTypes.h"
 #include "MantidQtWidgets/Common/MantidWidget.h"
 
@@ -43,7 +44,8 @@ public:
     FunctionReplaced,
     ParameterChanged,
     AttributeChanged,
-    ParameterTieChanged
+    ParameterTieChanged,
+    FittingModeChanged
   };
 
   IFitScriptGeneratorView(QWidget *parent = nullptr)
@@ -86,6 +88,8 @@ public:
   virtual void clearFunction() = 0;
   virtual void
   setFunction(Mantid::API::IFunction_sptr const &function) const = 0;
+
+  virtual void showMultiDomainPrefix(bool showPrefix) = 0;
 
   virtual void displayWarning(std::string const &message) = 0;
 

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/IFitScriptGeneratorView.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/IFitScriptGeneratorView.h
@@ -72,7 +72,7 @@ public:
 
   virtual void resetSelection() = 0;
 
-  virtual bool isAddFunctionToAllDomainsChecked() const = 0;
+  virtual bool isApplyFunctionChangesToAllChecked() const = 0;
 
   virtual void clearFunction() = 0;
   virtual void

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/IFitScriptGeneratorView.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/IFitScriptGeneratorView.h
@@ -74,6 +74,7 @@ public:
 
   virtual bool isAddFunctionToAllDomainsChecked() const = 0;
 
+  virtual void clearFunction() = 0;
   virtual void
   setFunction(Mantid::API::CompositeFunction_sptr composite) const = 0;
 

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/IFitScriptGeneratorView.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/IFitScriptGeneratorView.h
@@ -42,7 +42,8 @@ public:
     FunctionAdded,
     FunctionReplaced,
     ParameterChanged,
-    AttributeChanged
+    AttributeChanged,
+    ParameterTieChanged
   };
 
   IFitScriptGeneratorView(QWidget *parent = nullptr)

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/IFitScriptGeneratorView.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/IFitScriptGeneratorView.h
@@ -84,7 +84,7 @@ public:
 
   virtual void resetSelection() = 0;
 
-  virtual bool isApplyFunctionChangesToAllChecked() const = 0;
+  virtual bool isAddRemoveFunctionForAllChecked() const = 0;
 
   virtual void clearFunction() = 0;
   virtual void

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/IFitScriptGeneratorView.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/IFitScriptGeneratorView.h
@@ -89,7 +89,7 @@ public:
   virtual void
   setFunction(Mantid::API::IFunction_sptr const &function) const = 0;
 
-  virtual void showMultiDomainPrefix(bool showPrefix) = 0;
+  virtual void setSimultaneousMode(bool simultaneousMode) = 0;
 
   virtual void displayWarning(std::string const &message) = 0;
 

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/IFitScriptGeneratorView.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/IFitScriptGeneratorView.h
@@ -40,7 +40,8 @@ public:
     SelectionChanged,
     FunctionAdded,
     FunctionRemoved,
-    ParameterChanged
+    ParameterChanged,
+    AttributeChanged
   };
 
   IFitScriptGeneratorView(QWidget *parent = nullptr)
@@ -61,6 +62,8 @@ public:
 
   [[nodiscard]] virtual double
   parameterValue(std::string const &parameter) const = 0;
+  [[nodiscard]] virtual Mantid::API::IFunction::Attribute
+  attributeValue(std::string const &attribute) const = 0;
 
   virtual void removeWorkspaceDomain(std::string const &workspaceName,
                                      WorkspaceIndex workspaceIndex) = 0;

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/IFitScriptGeneratorView.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/IFitScriptGeneratorView.h
@@ -46,6 +46,8 @@ public:
     ParameterChanged,
     AttributeChanged,
     ParameterTieChanged,
+    ParameterConstraintRemoved,
+    ParameterConstraintChanged,
     FittingModeChanged
   };
 

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/IFitScriptGeneratorView.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/IFitScriptGeneratorView.h
@@ -39,7 +39,8 @@ public:
     EndXChanged,
     SelectionChanged,
     FunctionAdded,
-    FunctionRemoved
+    FunctionRemoved,
+    ParameterChanged
   };
 
   IFitScriptGeneratorView(QWidget *parent = nullptr)
@@ -57,6 +58,9 @@ public:
 
   [[nodiscard]] virtual std::vector<FitDomainIndex> allRows() const = 0;
   [[nodiscard]] virtual std::vector<FitDomainIndex> selectedRows() const = 0;
+
+  [[nodiscard]] virtual double
+  parameterValue(std::string const &parameter) const = 0;
 
   virtual void removeWorkspaceDomain(std::string const &workspaceName,
                                      WorkspaceIndex workspaceIndex) = 0;

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/IFitScriptGeneratorView.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/IFitScriptGeneratorView.h
@@ -31,7 +31,14 @@ class EXPORT_OPT_MANTIDQT_COMMON IFitScriptGeneratorView
   Q_OBJECT
 
 public:
-  enum class Event { AddClicked, RemoveClicked, StartXChanged, EndXChanged };
+  enum class Event {
+    AddClicked,
+    RemoveClicked,
+    StartXChanged,
+    EndXChanged,
+    FunctionAdded,
+    FunctionRemoved
+  };
 
   IFitScriptGeneratorView(QWidget *parent = nullptr)
       : API::MantidWidget(parent) {}
@@ -46,6 +53,7 @@ public:
   [[nodiscard]] virtual double startX(FitDomainIndex index) const = 0;
   [[nodiscard]] virtual double endX(FitDomainIndex index) const = 0;
 
+  [[nodiscard]] virtual std::vector<FitDomainIndex> allRows() const = 0;
   [[nodiscard]] virtual std::vector<FitDomainIndex> selectedRows() const = 0;
 
   virtual void removeWorkspaceDomain(std::string const &workspaceName,
@@ -61,6 +69,8 @@ public:
   getDialogWorkspaceIndices() const = 0;
 
   virtual void resetSelection() = 0;
+
+  virtual bool isAddFunctionToAllDomainsChecked() const = 0;
 
   virtual void displayWarning(std::string const &message) = 0;
 

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/IFunctionView.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/IFunctionView.h
@@ -77,6 +77,8 @@ signals:
   void functionAdded(const QString &funStr);
   /// User removes a function
   void functionRemoved(const QString &functionIndex);
+  /// User removes a function
+  void functionRemovedString(const QString &funStr);
   /// User selects a different (sub)function (or one of it's sub-properties)
   void currentFunctionChanged();
   /// Function parameter gets changed

--- a/qt/widgets/common/src/FitDomain.cpp
+++ b/qt/widgets/common/src/FitDomain.cpp
@@ -148,22 +148,29 @@ void FitDomain::setParameterValue(std::string const &parameter,
     m_function->setParameter(parameter, newValue);
 }
 
+double FitDomain::getParameterValue(std::string const &parameter) const {
+  if (hasParameter(parameter))
+    return m_function->getParameter(parameter);
+  throw std::runtime_error("The function does not contain this parameter.");
+}
+
 void FitDomain::setAttributeValue(std::string const &attribute,
                                   IFunction::Attribute newValue) {
   if (m_function && m_function->hasAttribute(attribute))
     m_function->setAttribute(attribute, newValue);
 }
 
+Mantid::API::IFunction::Attribute
+FitDomain::getAttributeValue(std::string const &attribute) const {
+  if (m_function && m_function->hasAttribute(attribute))
+    return m_function->getAttribute(attribute);
+  throw std::runtime_error("The function does not contain this attribute.");
+}
+
 bool FitDomain::hasParameter(std::string const &parameter) const {
   if (m_function)
     return m_function->hasParameter(parameter);
   return false;
-}
-
-double FitDomain::getParameterValue(std::string const &parameter) const {
-  if (hasParameter(parameter))
-    return m_function->getParameter(parameter);
-  throw std::runtime_error("The function does not contain this parameter.");
 }
 
 bool FitDomain::isParameterActive(std::string const &parameter) const {

--- a/qt/widgets/common/src/FitDomain.cpp
+++ b/qt/widgets/common/src/FitDomain.cpp
@@ -163,6 +163,13 @@ double FitDomain::getParameterValue(std::string const &parameter) const {
   throw std::runtime_error("The function does not contain this parameter.");
 }
 
+bool FitDomain::isParameterActive(std::string const &parameter) const {
+  if (hasParameter(parameter))
+    return m_function->getParameterStatus(m_function->parameterIndex(
+               parameter)) == IFunction::ParameterStatus::Active;
+  return false;
+}
+
 void FitDomain::clearParameterTie(std::string const &parameter) {
   if (hasParameter(parameter))
     m_function->removeTie(m_function->parameterIndex(parameter));

--- a/qt/widgets/common/src/FitDomain.cpp
+++ b/qt/widgets/common/src/FitDomain.cpp
@@ -260,8 +260,12 @@ bool FitDomain::isParameterValueWithinConstraints(std::string const &parameter,
   auto const parameterIndex = m_function->parameterIndex(parameter);
   if (auto const constraint = m_function->getConstraint(parameterIndex)) {
     auto const limits = splitConstraintString(constraint->asString()).second;
-    return limits.first.toDouble() <= value &&
-           value <= limits.second.toDouble();
+    auto const isValid =
+        limits.first.toDouble() <= value && value <= limits.second.toDouble();
+    if (!isValid)
+      g_log.warning("The provided value for " + parameter +
+                    " is not within its constraints.");
+    return isValid;
   }
   return true;
 }

--- a/qt/widgets/common/src/FitDomain.cpp
+++ b/qt/widgets/common/src/FitDomain.cpp
@@ -1,0 +1,203 @@
+// Mantid Repository : https://github.com/mantidproject/mantid
+//
+// Copyright &copy; 2020 ISIS Rutherford Appleton Laboratory UKRI,
+//   NScD Oak Ridge National Laboratory, European Spallation Source,
+//   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+// SPDX - License - Identifier: GPL - 3.0 +
+#include "MantidQtWidgets/Common/FitDomain.h"
+
+#include "MantidAPI/AnalysisDataService.h"
+#include "MantidAPI/FunctionFactory.h"
+#include "MantidAPI/MatrixWorkspace.h"
+
+#include <boost/algorithm/string.hpp>
+
+#include <algorithm>
+#include <stdexcept>
+
+using namespace Mantid::API;
+
+namespace {
+
+IFunction_sptr createIFunction(std::string const &functionString) {
+  return FunctionFactory::Instance().createInitialized(functionString);
+}
+
+CompositeFunction_sptr toComposite(IFunction_sptr function) {
+  return std::dynamic_pointer_cast<CompositeFunction>(function);
+}
+
+CompositeFunction_sptr createEmptyComposite() {
+  return toComposite(createIFunction("name=CompositeFunction"));
+}
+
+std::vector<std::string> splitStringBy(std::string const &str,
+                                       std::string const &delimiter) {
+  std::vector<std::string> subStrings;
+  boost::split(subStrings, str, boost::is_any_of(delimiter));
+  subStrings.erase(std::remove_if(subStrings.begin(), subStrings.end(),
+                                  [](std::string const &subString) {
+                                    return subString.empty();
+                                  }),
+                   subStrings.cend());
+  return subStrings;
+}
+
+std::vector<std::string>
+getFunctionNamesInString(std::string const &functionString) {
+  std::vector<std::string> functionNames;
+  for (auto const &str : splitStringBy(functionString, ",();"))
+    if (str.substr(0, 5) == "name=")
+      functionNames.emplace_back(str.substr(5));
+  return functionNames;
+}
+
+} // namespace
+
+namespace MantidQt {
+namespace MantidWidgets {
+
+FitDomain::FitDomain(std::string const &workspaceName,
+                     WorkspaceIndex workspaceIndex, double startX, double endX)
+    : m_workspaceName(workspaceName), m_workspaceIndex(workspaceIndex),
+      m_startX(startX), m_endX(endX), m_function(nullptr) {}
+
+bool FitDomain::setStartX(double startX) {
+  auto const validStartX = isValidStartX(startX);
+  if (validStartX)
+    m_startX = startX;
+  return validStartX;
+}
+
+bool FitDomain::setEndX(double endX) {
+  auto const validEndX = isValidStartX(endX);
+  if (validEndX)
+    m_endX = endX;
+  return validEndX;
+}
+
+void FitDomain::setFunction(Mantid::API::IFunction_sptr const &function) {
+  m_function = function;
+}
+
+Mantid::API::IFunction_sptr FitDomain::getFunction() const {
+  if (m_function)
+    return m_function->clone();
+  return nullptr;
+}
+
+void FitDomain::removeFunction(std::string const &function) {
+  if (m_function) {
+    if (auto composite = toComposite(m_function))
+      removeFunctionFromComposite(function, composite);
+    else
+      removeFunctionFromIFunction(function, m_function);
+  }
+}
+
+void FitDomain::removeFunctionFromIFunction(std::string const &function,
+                                            IFunction_sptr &iFunction) {
+  for (auto const &functionName : getFunctionNamesInString(function)) {
+    if (iFunction->name() == functionName) {
+      iFunction = nullptr;
+      break;
+    }
+  }
+}
+
+void FitDomain::removeFunctionFromComposite(std::string const &function,
+                                            CompositeFunction_sptr &composite) {
+  for (auto const &functionName : getFunctionNamesInString(function))
+    if (composite->hasFunction(functionName))
+      composite->removeFunction(composite->functionIndex(functionName));
+
+  if (composite->nFunctions() == 0)
+    m_function = nullptr;
+  else if (composite->nFunctions() == 1)
+    m_function = composite->getFunction(0);
+}
+
+void FitDomain::addFunction(IFunction_sptr const &function) {
+  if (m_function) {
+    addFunctionToExisting(function);
+  } else {
+    m_function = function;
+  }
+}
+
+void FitDomain::addFunctionToExisting(IFunction_sptr const &function) {
+  if (auto composite = toComposite(m_function)) {
+    composite->addFunction(function);
+  } else {
+    auto newComposite = createEmptyComposite();
+    newComposite->addFunction(m_function->clone());
+    newComposite->addFunction(function);
+    m_function = newComposite;
+  }
+}
+
+void FitDomain::setParameterValue(std::string const &parameter,
+                                  double newValue) {
+  if (m_function->hasParameter(parameter))
+    m_function->setParameter(parameter, newValue);
+}
+
+void FitDomain::setAttributeValue(std::string const &attribute,
+                                  IFunction::Attribute newValue) {
+  if (m_function->hasAttribute(attribute))
+    m_function->setAttribute(attribute, newValue);
+}
+
+void FitDomain::updateParameterTie(std::string const &parameter,
+                                   std::string const &tie) {
+  if (m_function->hasParameter(parameter)) {
+    if (tie.empty()) {
+      m_function->removeTie(m_function->parameterIndex(parameter));
+    } else {
+
+      try {
+        m_function->tie(parameter, tie);
+      } catch (std::invalid_argument const &ex) {
+        // g_log.error(ex.what());
+      } catch (std::runtime_error const &ex) {
+        // g_log.error(ex.what());
+      }
+    }
+  }
+}
+
+bool FitDomain::isValidStartX(double startX) const {
+  auto const limits = xLimits();
+  return limits.first <= startX && startX <= limits.second && startX < m_endX;
+}
+
+bool FitDomain::isValidEndX(double endX) const {
+  auto const limits = xLimits();
+  return limits.first <= endX && endX <= limits.second && endX > m_startX;
+}
+
+std::pair<double, double> FitDomain::xLimits() const {
+  auto &ads = AnalysisDataService::Instance();
+  if (ads.doesExist(m_workspaceName))
+    return xLimits(ads.retrieveWS<MatrixWorkspace>(m_workspaceName),
+                   m_workspaceIndex);
+
+  throw std::invalid_argument("The domain '" + m_workspaceName + " (" +
+                              std::to_string(m_workspaceIndex.value) +
+                              ")' could not be found.");
+}
+
+std::pair<double, double>
+FitDomain::xLimits(MatrixWorkspace_const_sptr const &workspace,
+                   WorkspaceIndex workspaceIndex) const {
+  if (workspace) {
+    auto const xData = workspace->x(workspaceIndex.value);
+    return std::pair<double, double>(xData.front(), xData.back());
+  }
+
+  throw std::invalid_argument("The workspace '" + m_workspaceName +
+                              "' is not a matrix workspace.");
+}
+
+} // namespace MantidWidgets
+} // namespace MantidQt

--- a/qt/widgets/common/src/FitDomain.cpp
+++ b/qt/widgets/common/src/FitDomain.cpp
@@ -35,18 +35,6 @@ CompositeFunction_sptr createEmptyComposite() {
   return toComposite(createIFunction("name=CompositeFunction"));
 }
 
-std::vector<std::string> splitStringBy(std::string const &str,
-                                       std::string const &delimiter) {
-  std::vector<std::string> subStrings;
-  boost::split(subStrings, str, boost::is_any_of(delimiter));
-  subStrings.erase(std::remove_if(subStrings.begin(), subStrings.end(),
-                                  [](std::string const &subString) {
-                                    return subString.empty();
-                                  }),
-                   subStrings.cend());
-  return subStrings;
-}
-
 std::vector<std::string>
 getFunctionNamesInString(std::string const &functionString) {
   std::vector<std::string> functionNames;
@@ -116,9 +104,10 @@ void FitDomain::removeFunctionFromIFunction(std::string const &function,
 
 void FitDomain::removeFunctionFromComposite(std::string const &function,
                                             CompositeFunction_sptr &composite) {
-  for (auto const &functionName : getFunctionNamesInString(function))
+  for (auto const &functionName : getFunctionNamesInString(function)) {
     if (composite->hasFunction(functionName))
       composite->removeFunction(composite->functionIndex(functionName));
+  }
 
   if (composite->nFunctions() == 0)
     m_function = nullptr;
@@ -285,9 +274,10 @@ void FitDomain::appendParametersTiedTo(
     std::vector<std::string> &tiedParameters, std::string const &parameter,
     std::size_t const &parameterIndex) const {
   if (auto const tie = m_function->getTie(parameterIndex)) {
-    for (auto rhsParameter : tie->getRHSParameters())
+    for (auto rhsParameter : tie->getRHSParameters()) {
       if (parameter == rhsParameter.parameterName())
         tiedParameters.emplace_back(m_function->parameterName(parameterIndex));
+    }
   }
 }
 

--- a/qt/widgets/common/src/FitDomain.cpp
+++ b/qt/widgets/common/src/FitDomain.cpp
@@ -140,7 +140,7 @@ void FitDomain::addFunctionToExisting(IFunction_sptr const &function) {
 
 void FitDomain::setParameterValue(std::string const &parameter,
                                   double newValue) {
-  if (m_function && m_function->hasParameter(parameter))
+  if (hasParameter(parameter))
     m_function->setParameter(parameter, newValue);
 }
 
@@ -150,9 +150,15 @@ void FitDomain::setAttributeValue(std::string const &attribute,
     m_function->setAttribute(attribute, newValue);
 }
 
+bool FitDomain::hasParameter(std::string const &parameter) const {
+  if (m_function)
+    return m_function->hasParameter(parameter);
+  return false;
+}
+
 bool FitDomain::updateParameterTie(std::string const &parameter,
                                    std::string const &tie) {
-  if (m_function && m_function->hasParameter(parameter)) {
+  if (hasParameter(parameter)) {
     if (tie.empty())
       m_function->removeTie(m_function->parameterIndex(parameter));
     else
@@ -174,6 +180,11 @@ bool FitDomain::setParameterTie(std::string const &parameter,
     g_log.warning(ex.what());
     return false;
   }
+}
+
+void FitDomain::clearParameterTie(std::string const &parameter) {
+  if (hasParameter(parameter))
+    m_function->removeTie(m_function->parameterIndex(parameter));
 }
 
 bool FitDomain::isValidStartX(double startX) const {

--- a/qt/widgets/common/src/FitDomain.cpp
+++ b/qt/widgets/common/src/FitDomain.cpp
@@ -129,6 +129,9 @@ void FitDomain::addFunction(IFunction_sptr const &function) {
 }
 
 void FitDomain::addFunctionToExisting(IFunction_sptr const &function) {
+  if (auto const isComposite = toComposite(function))
+    throw std::invalid_argument("Nested composite functions are not supported");
+
   if (auto composite = toComposite(m_function)) {
     composite->addFunction(function);
   } else {

--- a/qt/widgets/common/src/FitDomain.cpp
+++ b/qt/widgets/common/src/FitDomain.cpp
@@ -73,7 +73,7 @@ bool FitDomain::setStartX(double startX) {
 }
 
 bool FitDomain::setEndX(double endX) {
-  auto const validEndX = isValidStartX(endX);
+  auto const validEndX = isValidEndX(endX);
   if (validEndX)
     m_endX = endX;
   return validEndX;
@@ -141,7 +141,7 @@ void FitDomain::addFunctionToExisting(IFunction_sptr const &function) {
 
 void FitDomain::setParameterValue(std::string const &parameter,
                                   double newValue) {
-  if (hasParameter(parameter))
+  if (hasParameter(parameter) && isValidParameterValue(parameter, newValue))
     m_function->setParameter(parameter, newValue);
 }
 
@@ -221,6 +221,17 @@ void FitDomain::updateParameterConstraint(CompositeFunction_sptr &composite,
     if (function->hasParameter(parameter))
       function->addConstraints(constraint);
   }
+}
+
+bool FitDomain::isValidParameterValue(std::string const &parameter,
+                                      double value) const {
+  auto const parameterIndex = m_function->parameterIndex(parameter);
+  if (auto const constraint = m_function->getConstraint(parameterIndex)) {
+    auto const limits = splitConstraintString(constraint->asString()).second;
+    return limits.first.toDouble() <= value &&
+           value <= limits.second.toDouble();
+  }
+  return true;
 }
 
 bool FitDomain::isValidStartX(double startX) const {

--- a/qt/widgets/common/src/FitDomain.cpp
+++ b/qt/widgets/common/src/FitDomain.cpp
@@ -156,6 +156,12 @@ bool FitDomain::hasParameter(std::string const &parameter) const {
   return false;
 }
 
+double FitDomain::getParameterValue(std::string const &parameter) const {
+  if (hasParameter(parameter))
+    return m_function->getParameter(parameter);
+  throw std::runtime_error("The function does not contain this parameter.");
+}
+
 bool FitDomain::updateParameterTie(std::string const &parameter,
                                    std::string const &tie) {
   if (hasParameter(parameter)) {

--- a/qt/widgets/common/src/FitDomain.cpp
+++ b/qt/widgets/common/src/FitDomain.cpp
@@ -77,7 +77,7 @@ void FitDomain::setFunction(Mantid::API::IFunction_sptr const &function) {
   m_function = function;
 }
 
-Mantid::API::IFunction_sptr FitDomain::getFunction() const {
+Mantid::API::IFunction_sptr FitDomain::getFunctionCopy() const {
   if (m_function)
     return m_function->clone();
   return nullptr;

--- a/qt/widgets/common/src/FitOptionsBrowser.cpp
+++ b/qt/widgets/common/src/FitOptionsBrowser.cpp
@@ -49,7 +49,7 @@ namespace MantidWidgets {
  * @param parent :: The parent widget.
  * @param fitType :: The type of the underlying fitting algorithm.
  */
-FitOptionsBrowser::FitOptionsBrowser(QWidget *parent, FittingType fitType)
+FitOptionsBrowser::FitOptionsBrowser(QWidget *parent, FittingMode fitType)
     : QWidget(parent), m_fittingTypeProp(nullptr), m_minimizer(nullptr),
       m_decimals(6), m_fittingType(fitType) {
   // create m_browser
@@ -118,9 +118,10 @@ void FitOptionsBrowser::initFittingTypeProp() {
   types << "Simultaneous"
         << "Sequential";
   m_enumManager->setEnumNames(m_fittingTypeProp, types);
-  if (m_fittingType == SimultaneousAndSequential) {
+  if (m_fittingType == FittingMode::SimultaneousAndSequential) {
     m_browser->addProperty(m_fittingTypeProp);
-  } else if (m_fittingType == Simultaneous || m_fittingType == Sequential) {
+  } else if (m_fittingType == FittingMode::Simultaneous ||
+             m_fittingType == FittingMode::Sequential) {
     this->lockCurrentFittingType(m_fittingType);
   }
 }
@@ -131,12 +132,12 @@ void FitOptionsBrowser::initFittingTypeProp() {
 void FitOptionsBrowser::createProperties() {
   initFittingTypeProp();
   createCommonProperties();
-  if (m_fittingType == Simultaneous ||
-      m_fittingType == SimultaneousAndSequential) {
+  if (m_fittingType == FittingMode::Simultaneous ||
+      m_fittingType == FittingMode::SimultaneousAndSequential) {
     createSimultaneousFitProperties();
   }
-  if (m_fittingType == Sequential ||
-      m_fittingType == SimultaneousAndSequential) {
+  if (m_fittingType == FittingMode::Sequential ||
+      m_fittingType == FittingMode::SimultaneousAndSequential) {
     createSequentialFitProperties();
   }
 }
@@ -423,6 +424,7 @@ void FitOptionsBrowser::displayNormalFitProperties() {
   foreach (QtProperty *prop, m_sequentialProperties) {
     m_browser->removeProperty(prop);
   }
+  emit changedToSimultaneousFitting();
 }
 
 /**
@@ -713,18 +715,16 @@ void FitOptionsBrowser::loadSettings(const QSettings &settings) {
  * Get the current fitting type, ie which algorithm to use:
  *    Simultaneous for Fit and Sequential for PlotPeakByLogValue.
  */
-FitOptionsBrowser::FittingType
-FitOptionsBrowser::getCurrentFittingType() const {
+FittingMode FitOptionsBrowser::getCurrentFittingType() const {
   auto value = m_enumManager->value(m_fittingTypeProp);
-  return static_cast<FitOptionsBrowser::FittingType>(value);
+  return static_cast<FittingMode>(value);
 }
 
 /**
  * Set the current fitting type, ie which algorithm to use:
  *    Simultaneous for Fit and Sequential for PlotPeakByLogValue.
  */
-void FitOptionsBrowser::setCurrentFittingType(
-    FitOptionsBrowser::FittingType fitType) {
+void FitOptionsBrowser::setCurrentFittingType(FittingMode fitType) {
   m_enumManager->setValue(m_fittingTypeProp, fitType);
 }
 
@@ -733,8 +733,7 @@ void FitOptionsBrowser::setCurrentFittingType(
  * option.
  * @param fitType :: Fitting type to lock the browser in.
  */
-void FitOptionsBrowser::lockCurrentFittingType(
-    FitOptionsBrowser::FittingType fitType) {
+void FitOptionsBrowser::lockCurrentFittingType(FittingMode fitType) {
   m_enumManager->setValue(m_fittingTypeProp, fitType);
   m_fittingTypeProp->setEnabled(false);
 }

--- a/qt/widgets/common/src/FitOptionsBrowser.cpp
+++ b/qt/widgets/common/src/FitOptionsBrowser.cpp
@@ -118,10 +118,10 @@ void FitOptionsBrowser::initFittingTypeProp() {
   types << "Simultaneous"
         << "Sequential";
   m_enumManager->setEnumNames(m_fittingTypeProp, types);
-  if (m_fittingType == FittingMode::SimultaneousAndSequential) {
+  if (m_fittingType == FittingMode::SIMULTANEOUS_SEQUENTIAL) {
     m_browser->addProperty(m_fittingTypeProp);
-  } else if (m_fittingType == FittingMode::Simultaneous ||
-             m_fittingType == FittingMode::Sequential) {
+  } else if (m_fittingType == FittingMode::SIMULTANEOUS ||
+             m_fittingType == FittingMode::SEQUENTIAL) {
     this->lockCurrentFittingType(m_fittingType);
   }
 }
@@ -132,12 +132,12 @@ void FitOptionsBrowser::initFittingTypeProp() {
 void FitOptionsBrowser::createProperties() {
   initFittingTypeProp();
   createCommonProperties();
-  if (m_fittingType == FittingMode::Simultaneous ||
-      m_fittingType == FittingMode::SimultaneousAndSequential) {
+  if (m_fittingType == FittingMode::SIMULTANEOUS ||
+      m_fittingType == FittingMode::SIMULTANEOUS_SEQUENTIAL) {
     createSimultaneousFitProperties();
   }
-  if (m_fittingType == FittingMode::Sequential ||
-      m_fittingType == FittingMode::SimultaneousAndSequential) {
+  if (m_fittingType == FittingMode::SEQUENTIAL ||
+      m_fittingType == FittingMode::SIMULTANEOUS_SEQUENTIAL) {
     createSequentialFitProperties();
   }
 }

--- a/qt/widgets/common/src/FitOptionsBrowser.cpp
+++ b/qt/widgets/common/src/FitOptionsBrowser.cpp
@@ -249,16 +249,17 @@ void FitOptionsBrowser::createSimultaneousFitProperties() {
 
 void FitOptionsBrowser::createSequentialFitProperties() {
   // Create FitType property, a property of algorithm PlotPeakByLogValue
-  m_fitType = m_enumManager->addProperty("Fit Type");
+  m_plotPeakByLogValueFitType = m_enumManager->addProperty("Fit Type");
   {
     QStringList types;
     types << "Sequential"
           << "Individual";
-    m_enumManager->setEnumNames(m_fitType, types);
-    m_enumManager->setValue(m_fitType, 0);
-    addProperty("FitType", m_fitType, &FitOptionsBrowser::getStringEnumProperty,
+    m_enumManager->setEnumNames(m_plotPeakByLogValueFitType, types);
+    m_enumManager->setValue(m_plotPeakByLogValueFitType, 0);
+    addProperty("FitType", m_plotPeakByLogValueFitType,
+                &FitOptionsBrowser::getStringEnumProperty,
                 &FitOptionsBrowser::setStringEnumProperty);
-    m_sequentialProperties << m_fitType;
+    m_sequentialProperties << m_plotPeakByLogValueFitType;
   }
 
   // Create OutputWorkspace property

--- a/qt/widgets/common/src/FitScriptGeneratorDataTable.cpp
+++ b/qt/widgets/common/src/FitScriptGeneratorDataTable.cpp
@@ -114,8 +114,8 @@ FitScriptGeneratorDataTable::FitScriptGeneratorDataTable(QWidget *parent)
   this->setItemDelegateForColumn(
       ColumnIndex::EndX, new CustomItemDelegate(this, ColumnIndex::EndX));
 
-  connect(this, SIGNAL(itemPressed(QTableWidgetItem *)), this,
-          SLOT(handleItemPressed(QTableWidgetItem *)));
+  connect(this, SIGNAL(itemClicked(QTableWidgetItem *)), this,
+          SLOT(handleItemClicked(QTableWidgetItem *)));
   connect(this, SIGNAL(itemSelectionChanged()), this,
           SLOT(handleItemSelectionChanged()));
 }
@@ -133,7 +133,7 @@ bool FitScriptGeneratorDataTable::eventFilter(QObject *widget, QEvent *event) {
   return QTableWidget::eventFilter(widget, event);
 }
 
-void FitScriptGeneratorDataTable::handleItemPressed(QTableWidgetItem *item) {
+void FitScriptGeneratorDataTable::handleItemClicked(QTableWidgetItem *item) {
   m_selectedRows = selectedRows();
   m_selectedColumn = item->column();
   if (m_selectedColumn == ColumnIndex::StartX ||

--- a/qt/widgets/common/src/FitScriptGeneratorDataTable.cpp
+++ b/qt/widgets/common/src/FitScriptGeneratorDataTable.cpp
@@ -24,6 +24,7 @@ double X_EXTENT(100000.0);
 int X_PRECISION(5);
 
 QStringList const COLUMN_HEADINGS({"Name", "WS Index", "StartX", "EndX"});
+QColor const FUNCTION_INDEX_COLOR(QColor(30, 144, 255));
 QString const TABLE_STYLESHEET("QTableWidget {\n"
                                "    font-size: 8pt;\n"
                                "    border: 1px solid #828790;\n"
@@ -71,6 +72,10 @@ QTableWidgetItem *createXTableItem(double value,
                                    bool editable) {
   return createTableItem(QString::number(value, 'f', X_PRECISION), alignment,
                          editable);
+}
+
+QString toFunctionIndex(MantidQt::MantidWidgets::FitDomainIndex index) {
+  return "f" + QString::number(index.value) + ".";
 }
 
 } // namespace
@@ -254,8 +259,8 @@ void FitScriptGeneratorDataTable::addDomain(
   this->insertRow(rowIndex);
 
   this->setVerticalHeaderItem(
-      rowIndex, createTableItem("f" + QString::number(rowIndex) + ".",
-                                Qt::AlignCenter, false, QColor(30, 144, 255)));
+      rowIndex, createTableItem(toFunctionIndex(FitDomainIndex(rowIndex)),
+                                Qt::AlignCenter, false, FUNCTION_INDEX_COLOR));
   this->setItem(rowIndex, ColumnIndex::WorkspaceName,
                 createTableItem(workspaceName, Qt::AlignVCenter, false));
   this->setItem(rowIndex, ColumnIndex::WorkspaceIndex,
@@ -275,10 +280,11 @@ void FitScriptGeneratorDataTable::addDomain(
 }
 
 void FitScriptGeneratorDataTable::updateVerticalHeaders() {
-  for (auto rowIndex = 0; rowIndex < this->rowCount(); ++rowIndex)
-    this->setVerticalHeaderItem(
-        rowIndex, createTableItem("f" + QString::number(rowIndex) + ".",
-                                  Qt::AlignCenter, false, QColor(35, 140, 35)));
+  for (auto i = FitDomainIndex(0); i < FitDomainIndex(this->rowCount()); ++i)
+    this->setVerticalHeaderItem(static_cast<int>(i.value),
+                                createTableItem(toFunctionIndex(i),
+                                                Qt::AlignCenter, false,
+                                                FUNCTION_INDEX_COLOR));
 }
 
 int FitScriptGeneratorDataTable::indexOfDomain(

--- a/qt/widgets/common/src/FitScriptGeneratorDataTable.cpp
+++ b/qt/widgets/common/src/FitScriptGeneratorDataTable.cpp
@@ -307,6 +307,10 @@ void FitScriptGeneratorDataTable::resetSelection() {
   setSelectedXValue(m_selectedValue);
 }
 
+void FitScriptGeneratorDataTable::setFunctionPrefixVisible(bool visible) {
+  this->verticalHeader()->setVisible(visible);
+}
+
 void FitScriptGeneratorDataTable::setSelectedXValue(double xValue) {
   this->blockSignals(true);
   if (!m_selectedRows.empty())

--- a/qt/widgets/common/src/FitScriptGeneratorDataTable.cpp
+++ b/qt/widgets/common/src/FitScriptGeneratorDataTable.cpp
@@ -155,6 +155,9 @@ void FitScriptGeneratorDataTable::handleItemSelectionChanged() {
   if (!selectionModel->hasSelection()) {
     this->blockSignals(true);
 
+    // Makes sure that multi-selection rows are stored within the selectionModel
+    // as should be expected. This prevents a bug where not all selected rows
+    // were being stored in the selection model.
     auto itemSelection = selectionModel->selection();
     for (auto const &selectedRow : m_selectedRows) {
       this->selectRow(static_cast<int>(selectedRow.value));

--- a/qt/widgets/common/src/FitScriptGeneratorDataTable.cpp
+++ b/qt/widgets/common/src/FitScriptGeneratorDataTable.cpp
@@ -226,6 +226,11 @@ void FitScriptGeneratorDataTable::removeDomain(
     this->removeRow(removeIndex);
 
   m_selectedRows = selectedRows();
+
+  if (m_selectedRows.empty() && this->rowCount() > 0)
+    this->selectRow(0);
+
+  m_selectedRows = selectedRows();
 }
 
 void FitScriptGeneratorDataTable::addDomain(

--- a/qt/widgets/common/src/FitScriptGeneratorDataTable.cpp
+++ b/qt/widgets/common/src/FitScriptGeneratorDataTable.cpp
@@ -119,6 +119,8 @@ FitScriptGeneratorDataTable::FitScriptGeneratorDataTable(QWidget *parent)
           SLOT(handleItemClicked(QTableWidgetItem *)));
   connect(this, SIGNAL(itemSelectionChanged()), this,
           SLOT(handleItemSelectionChanged()));
+  disconnect(this->verticalHeader(), SIGNAL(sectionPressed(int)), this,
+             SLOT(selectRow(int)));
 }
 
 bool FitScriptGeneratorDataTable::eventFilter(QObject *widget, QEvent *event) {
@@ -253,7 +255,7 @@ void FitScriptGeneratorDataTable::addDomain(
 
   this->setVerticalHeaderItem(
       rowIndex, createTableItem("f" + QString::number(rowIndex) + ".",
-                                Qt::AlignCenter, false, QColor(35, 140, 35)));
+                                Qt::AlignCenter, false, QColor(30, 144, 255)));
   this->setItem(rowIndex, ColumnIndex::WorkspaceName,
                 createTableItem(workspaceName, Qt::AlignVCenter, false));
   this->setItem(rowIndex, ColumnIndex::WorkspaceIndex,

--- a/qt/widgets/common/src/FitScriptGeneratorDataTable.cpp
+++ b/qt/widgets/common/src/FitScriptGeneratorDataTable.cpp
@@ -219,6 +219,13 @@ std::vector<FitDomainIndex> FitScriptGeneratorDataTable::selectedRows() const {
   return rowIndices;
 }
 
+QString FitScriptGeneratorDataTable::selectedDomainFunctionPrefix() const {
+  auto const rows = selectedRows();
+  if (rows.empty())
+    return "";
+  return this->verticalHeaderItem(static_cast<int>(rows[0].value))->text();
+}
+
 void FitScriptGeneratorDataTable::removeDomain(
     std::string const &workspaceName,
     MantidWidgets::WorkspaceIndex workspaceIndex) {

--- a/qt/widgets/common/src/FitScriptGeneratorModel.cpp
+++ b/qt/widgets/common/src/FitScriptGeneratorModel.cpp
@@ -292,13 +292,13 @@ void FitScriptGeneratorModel::updateParameterValue(
 }
 
 void FitScriptGeneratorModel::updateParameterValuesWithGlobalTieTo(
-    std::string const &fullTie) {
+    std::string const &parameter) {
   for (auto const &globalTie : m_globalTies) {
-    if (fullTie == globalTie.m_tie) {
+    if (parameter == globalTie.m_tie) {
       auto const domainIndex = getFunctionIndexAt(globalTie.m_parameter, 0);
       m_fitDomains[domainIndex].setParameterValue(
           removeTopFunctionIndex(globalTie.m_parameter),
-          getParameterValue(fullTie));
+          getParameterValue(parameter));
     }
   }
 }

--- a/qt/widgets/common/src/FitScriptGeneratorModel.cpp
+++ b/qt/widgets/common/src/FitScriptGeneratorModel.cpp
@@ -262,14 +262,13 @@ void FitScriptGeneratorModel::updateParameterValuesWithGlobalTieTo(
   auto const globalTies = m_globalTies;
   for (auto const &globalTie : globalTies)
     if (fullParameter == globalTie.m_tie)
-      updateParameterValueInGlobalTie(globalTie, newValue);
+      updateParameterValueInGlobalTie(domainIndex, globalTie, newValue);
 }
 
 void FitScriptGeneratorModel::updateParameterValueInGlobalTie(
-    GlobalTie const &globalTie, double newValue) {
+    FitDomainIndex domainIndex, GlobalTie const &globalTie, double newValue) {
   if (validGlobalTie(globalTie.m_parameter, globalTie.m_tie)) {
-    auto const domainIndex = getFunctionIndexAt(globalTie.m_parameter, 0);
-    m_fitDomains[domainIndex]->setParameterValue(
+    m_fitDomains[domainIndex.value]->setParameterValue(
         getAdjustedFunctionIndex(globalTie.m_parameter), newValue);
   } else {
     clearGlobalTie(globalTie.m_parameter);

--- a/qt/widgets/common/src/FitScriptGeneratorModel.cpp
+++ b/qt/widgets/common/src/FitScriptGeneratorModel.cpp
@@ -252,6 +252,25 @@ void FitScriptGeneratorModel::updateEndX(std::string const &workspaceName,
   m_fitDomains[domainIndex].m_endX = endX;
 }
 
+void FitScriptGeneratorModel::removeFunction(std::string const &workspaceName,
+                                             WorkspaceIndex workspaceIndex,
+                                             std::string const &function) {
+  auto const domainIndex = findDomainIndex(workspaceName, workspaceIndex);
+
+  auto composite = toComposite(m_function->getFunction(domainIndex));
+  if (composite && composite->hasFunction(function))
+    composite->removeFunction(composite->functionIndex(function));
+}
+
+void FitScriptGeneratorModel::addFunction(std::string const &workspaceName,
+                                          WorkspaceIndex workspaceIndex,
+                                          std::string const &function) {
+  auto const domainIndex = findDomainIndex(workspaceName, workspaceIndex);
+
+  if (auto composite = toComposite(m_function->getFunction(domainIndex)))
+    composite->addFunction(createIFunction(function));
+}
+
 void FitScriptGeneratorModel::removeCompositeAtPrefix(
     std::string const &functionPrefix) {
   removeCompositeAtIndex(getPrefixIndexAt(functionPrefix, 0));

--- a/qt/widgets/common/src/FitScriptGeneratorModel.cpp
+++ b/qt/widgets/common/src/FitScriptGeneratorModel.cpp
@@ -347,25 +347,29 @@ void FitScriptGeneratorModel::updateParameterTie(
   auto const domainIndex = findDomainIndex(workspaceName, workspaceIndex);
 
   if (auto composite = toComposite(m_function->getFunction(domainIndex))) {
-    auto fullParameterName = parameter;
-    if (composite->nFunctions() == 1)
-      fullParameterName = "f0." + fullParameterName;
 
-    if (composite->hasParameter(fullParameterName))
-      updateParameterTie(composite, parameter, tie);
+    if (composite->nFunctions() == 1) {
+      auto function = composite->getFunction(0);
+      if (function->hasParameter(parameter))
+        updateParameterTie(function, parameter, tie);
+    } else {
+      if (composite->hasParameter(parameter))
+        updateParameterTie(composite, parameter, tie);
+    }
   }
 }
 
-void FitScriptGeneratorModel::updateParameterTie(
-    CompositeFunction_sptr const &composite, std::string const &parameter,
-    std::string const &tie) {
+void FitScriptGeneratorModel::updateParameterTie(IFunction_sptr const &function,
+                                                 std::string const &parameter,
+                                                 std::string const &tie) {
   if (tie.empty()) {
-    composite->removeTie(composite->parameterIndex(parameter));
+    function->removeTie(function->parameterIndex(parameter));
   } else {
     auto const tieSplit = splitStringBy(tie, "=");
     auto const tieValue = tieSplit.size() > 1 ? tieSplit[1] : tieSplit[0];
+
     try {
-      composite->tie(parameter, tieValue);
+      function->tie(parameter, tieValue);
     } catch (std::invalid_argument const &ex) {
       g_log.error(ex.what());
     } catch (std::runtime_error const &ex) {

--- a/qt/widgets/common/src/FitScriptGeneratorModel.cpp
+++ b/qt/widgets/common/src/FitScriptGeneratorModel.cpp
@@ -256,7 +256,8 @@ void FitScriptGeneratorModel::updateParameterValuesWithLocalTieTo(
 
 void FitScriptGeneratorModel::updateParameterValuesWithGlobalTieTo(
     std::string const &fullParameter, double newValue) {
-  // Deep copy so that global ties can be removed whilst in this for loop
+  // Deep copy so that global ties can be removed whilst in this for loop. This
+  // will happen if a global tie has been invalidated.
   auto const globalTies = m_globalTies;
   for (auto const &globalTie : globalTies)
     if (fullParameter == globalTie.m_tie)

--- a/qt/widgets/common/src/FitScriptGeneratorModel.cpp
+++ b/qt/widgets/common/src/FitScriptGeneratorModel.cpp
@@ -240,8 +240,7 @@ void FitScriptGeneratorModel::updateParameterValue(
 
     updateParameterValuesWithLocalTieTo(domainIndex, parameter, newValue);
     if (m_fittingMode == FittingMode::SIMULTANEOUS) {
-      updateParameterValuesWithGlobalTieTo(domainIndex, fullParameter,
-                                           newValue);
+      updateParameterValuesWithGlobalTieTo(fullParameter, newValue);
     }
   }
 }
@@ -256,19 +255,19 @@ void FitScriptGeneratorModel::updateParameterValuesWithLocalTieTo(
 }
 
 void FitScriptGeneratorModel::updateParameterValuesWithGlobalTieTo(
-    FitDomainIndex domainIndex, std::string const &fullParameter,
-    double newValue) {
+    std::string const &fullParameter, double newValue) {
   // Deep copy so that global ties can be removed whilst in this for loop
   auto const globalTies = m_globalTies;
   for (auto const &globalTie : globalTies)
     if (fullParameter == globalTie.m_tie)
-      updateParameterValueInGlobalTie(domainIndex, globalTie, newValue);
+      updateParameterValueInGlobalTie(globalTie, newValue);
 }
 
 void FitScriptGeneratorModel::updateParameterValueInGlobalTie(
-    FitDomainIndex domainIndex, GlobalTie const &globalTie, double newValue) {
+    GlobalTie const &globalTie, double newValue) {
   if (validGlobalTie(globalTie.m_parameter, globalTie.m_tie)) {
-    m_fitDomains[domainIndex.value]->setParameterValue(
+    auto const domainIndex = getFunctionIndexAt(globalTie.m_parameter, 0);
+    m_fitDomains[domainIndex]->setParameterValue(
         getAdjustedFunctionIndex(globalTie.m_parameter), newValue);
   } else {
     clearGlobalTie(globalTie.m_parameter);

--- a/qt/widgets/common/src/FitScriptGeneratorModel.cpp
+++ b/qt/widgets/common/src/FitScriptGeneratorModel.cpp
@@ -314,6 +314,10 @@ void FitScriptGeneratorModel::removeCompositeAtIndex(
   if (functionIndex > numberOfDomains())
     throw std::runtime_error("The composite prefix provided does not exist");
 
+  auto composite = toComposite(m_function->getFunction(functionIndex));
+  for (auto i = composite->nFunctions() - 1u; i < composite->nFunctions(); --i)
+    composite->removeFunction(i);
+
   m_function->removeFunction(functionIndex);
 }
 

--- a/qt/widgets/common/src/FitScriptGeneratorModel.cpp
+++ b/qt/widgets/common/src/FitScriptGeneratorModel.cpp
@@ -282,6 +282,21 @@ FitScriptGeneratorModel::getFunction(std::string const &workspaceName,
   return toComposite(m_function->getFunction(domainIndex));
 }
 
+void FitScriptGeneratorModel::updateParameterValue(
+    std::string const &workspaceName, WorkspaceIndex workspaceIndex,
+    std::string const &parameter, double newValue) {
+  auto const domainIndex = findDomainIndex(workspaceName, workspaceIndex);
+
+  if (auto composite = toComposite(m_function->getFunction(domainIndex))) {
+    auto fullParameterName = parameter;
+    if (composite->nFunctions() == 1)
+      fullParameterName = "f0." + fullParameterName;
+
+    if (composite->hasParameter(fullParameterName))
+      composite->setParameter(fullParameterName, newValue);
+  }
+}
+
 void FitScriptGeneratorModel::removeCompositeAtPrefix(
     std::string const &functionPrefix) {
   removeCompositeAtIndex(getPrefixIndexAt(functionPrefix, 0));

--- a/qt/widgets/common/src/FitScriptGeneratorModel.cpp
+++ b/qt/widgets/common/src/FitScriptGeneratorModel.cpp
@@ -9,6 +9,7 @@
 #include "MantidAPI/AnalysisDataService.h"
 #include "MantidAPI/FunctionFactory.h"
 #include "MantidAPI/MatrixWorkspace.h"
+#include "MantidAPI/ParameterTie.h"
 #include "MantidKernel/Logger.h"
 
 #include <boost/algorithm/string.hpp>
@@ -52,25 +53,14 @@ std::string removeTopFunctionIndex(std::string const &functionPrefix) {
   return resultPrefix;
 }
 
-bool isTieNumber(std::string const &tie) {
-  return !tie.empty() &&
-         tie.find_first_not_of("0123456789.-") == std::string::npos;
-}
-
 std::string getTieRHS(std::string const &tie) {
   auto const tieSplit = splitStringBy(tie, "=");
   return tieSplit.size() > 1 ? tieSplit[1] : tieSplit[0];
 }
 
-std::string getTieForFitType(std::string const &tie, bool isSimultaneous) {
-  if (isSimultaneous)
-    return isTieNumber(tie) ? tie : removeTopFunctionIndex(tie);
-  return tie;
-}
-
 std::string getTieExpression(std::string const &tie, bool isSimultaneous) {
-  if (!tie.empty())
-    return getTieForFitType(getTieRHS(tie), isSimultaneous);
+  if (!tie.empty() && isSimultaneous)
+    return removeTopFunctionIndex(getTieRHS(tie));
   return tie;
 }
 

--- a/qt/widgets/common/src/FitScriptGeneratorModel.cpp
+++ b/qt/widgets/common/src/FitScriptGeneratorModel.cpp
@@ -11,7 +11,6 @@
 #include "MantidAPI/AnalysisDataService.h"
 #include "MantidAPI/FunctionFactory.h"
 #include "MantidAPI/MatrixWorkspace.h"
-#include "MantidAPI/ParameterTie.h"
 #include "MantidKernel/Logger.h"
 
 #include <algorithm>
@@ -320,10 +319,8 @@ void FitScriptGeneratorModel::updateParameterConstraint(
     std::string const &functionIndex, std::string const &constraint) {
   auto const domainIndex = findDomainIndex(workspaceName, workspaceIndex);
 
-  auto const constraintSplit =
-      splitConstraintString(QString::fromStdString(constraint));
-
-  auto const parameterName = constraintSplit.first.toStdString();
+  auto const parameterName =
+      splitConstraintString(constraint).first.toStdString();
   m_fitDomains[domainIndex].updateParameterConstraint(
       getAdjustedFunctionIndex(functionIndex), parameterName, constraint);
 }

--- a/qt/widgets/common/src/FitScriptGeneratorModel.cpp
+++ b/qt/widgets/common/src/FitScriptGeneratorModel.cpp
@@ -244,7 +244,9 @@ void FitScriptGeneratorModel::updateParameterValue(
 void FitScriptGeneratorModel::updateParameterValuesWithGlobalTieTo(
     std::string const &fullParameter) {
   auto const newValue = getParameterValue(fullParameter);
-  for (auto const &globalTie : m_globalTies)
+  // Deep copy so that global ties can be removed whilst in this for loop
+  auto const globalTies = m_globalTies;
+  for (auto const &globalTie : globalTies)
     if (fullParameter == globalTie.m_tie)
       updateParameterValueInGlobalTie(globalTie, newValue);
 }
@@ -403,8 +405,10 @@ bool FitScriptGeneratorModel::isParameterValueWithinConstraints(
 
 void FitScriptGeneratorModel::clearGlobalTie(std::string const &fullParameter) {
   auto const removeIter = findGlobalTie(fullParameter);
-  if (removeIter != m_globalTies.cend())
+  if (removeIter != m_globalTies.cend()) {
     m_globalTies.erase(removeIter);
+    m_presenter->setGlobalTies(m_globalTies);
+  }
 }
 
 void FitScriptGeneratorModel::checkGlobalTies() {

--- a/qt/widgets/common/src/FitScriptGeneratorModel.cpp
+++ b/qt/widgets/common/src/FitScriptGeneratorModel.cpp
@@ -7,7 +7,6 @@
 #include "MantidQtWidgets/Common/FitScriptGeneratorModel.h"
 
 #include "MantidAPI/AnalysisDataService.h"
-#include "MantidAPI/CompositeFunction.h"
 #include "MantidAPI/FunctionFactory.h"
 #include "MantidAPI/IFunction.h"
 #include "MantidAPI/MatrixWorkspace.h"
@@ -87,6 +86,10 @@ IFunction_sptr getFunctionAtPrefix(std::string const &functionPrefix,
   } catch (std::exception const &) {
     return IFunction_sptr();
   }
+}
+
+std::string getFunctionNameFromString(std::string const &functionString) {
+  return splitStringBy(splitStringBy(functionString, ",")[0], "=")[1];
 }
 
 } // namespace
@@ -258,8 +261,9 @@ void FitScriptGeneratorModel::removeFunction(std::string const &workspaceName,
   auto const domainIndex = findDomainIndex(workspaceName, workspaceIndex);
 
   auto composite = toComposite(m_function->getFunction(domainIndex));
-  if (composite && composite->hasFunction(function))
-    composite->removeFunction(composite->functionIndex(function));
+  auto const functionName = getFunctionNameFromString(function);
+  if (composite && composite->hasFunction(functionName))
+    composite->removeFunction(composite->functionIndex(functionName));
 }
 
 void FitScriptGeneratorModel::addFunction(std::string const &workspaceName,
@@ -269,6 +273,13 @@ void FitScriptGeneratorModel::addFunction(std::string const &workspaceName,
 
   if (auto composite = toComposite(m_function->getFunction(domainIndex)))
     composite->addFunction(createIFunction(function));
+}
+
+CompositeFunction_sptr
+FitScriptGeneratorModel::getFunction(std::string const &workspaceName,
+                                     WorkspaceIndex workspaceIndex) {
+  auto const domainIndex = findDomainIndex(workspaceName, workspaceIndex);
+  return toComposite(m_function->getFunction(domainIndex));
 }
 
 void FitScriptGeneratorModel::removeCompositeAtPrefix(

--- a/qt/widgets/common/src/FitScriptGeneratorModel.cpp
+++ b/qt/widgets/common/src/FitScriptGeneratorModel.cpp
@@ -297,6 +297,21 @@ void FitScriptGeneratorModel::updateParameterValue(
   }
 }
 
+void FitScriptGeneratorModel::updateAttributeValue(
+    std::string const &workspaceName, WorkspaceIndex workspaceIndex,
+    std::string const &attribute, IFunction::Attribute const &newValue) {
+  auto const domainIndex = findDomainIndex(workspaceName, workspaceIndex);
+
+  if (auto composite = toComposite(m_function->getFunction(domainIndex))) {
+    auto fullAttributeName = attribute;
+    if (composite->nFunctions() == 1)
+      fullAttributeName = "f0." + fullAttributeName;
+
+    if (composite->hasAttribute(fullAttributeName))
+      composite->setAttribute(fullAttributeName, newValue);
+  }
+}
+
 void FitScriptGeneratorModel::removeCompositeAtPrefix(
     std::string const &functionPrefix) {
   removeCompositeAtIndex(getPrefixIndexAt(functionPrefix, 0));

--- a/qt/widgets/common/src/FitScriptGeneratorModel.cpp
+++ b/qt/widgets/common/src/FitScriptGeneratorModel.cpp
@@ -8,7 +8,6 @@
 
 #include "MantidAPI/AnalysisDataService.h"
 #include "MantidAPI/FunctionFactory.h"
-#include "MantidAPI/IFunction.h"
 #include "MantidAPI/MatrixWorkspace.h"
 #include "MantidKernel/Logger.h"
 
@@ -27,20 +26,6 @@ IFunction_sptr createIFunction(std::string const &functionString) {
   return FunctionFactory::Instance().createInitialized(functionString);
 }
 
-CompositeFunction_sptr toComposite(IFunction_sptr function) {
-  return std::dynamic_pointer_cast<CompositeFunction>(function);
-}
-
-CompositeFunction_sptr createEmptyComposite() {
-  return toComposite(createIFunction("name=CompositeFunction"));
-}
-
-MultiDomainFunction_sptr
-createMultiDomainFunction(std::size_t const &numberOfDomains) {
-  return FunctionFactory::Instance().createInitializedMultiDomainFunction(
-      "name=CompositeFunction", numberOfDomains);
-}
-
 std::vector<std::string> splitStringBy(std::string const &str,
                                        std::string const &delimiter) {
   std::vector<std::string> subStrings;
@@ -53,50 +38,23 @@ std::vector<std::string> splitStringBy(std::string const &str,
   return subStrings;
 }
 
-bool isSingleFunctionPrefix(std::string const &functionPrefix) {
-  auto const subStrings = splitStringBy(functionPrefix, "f.");
-  return subStrings.size() == 1;
-}
-
 std::size_t getPrefixIndexAt(std::string const &functionPrefix,
                              std::size_t const &index) {
   auto const subStrings = splitStringBy(functionPrefix, "f.");
   return std::stoull(subStrings[index]);
 }
 
-std::string getTopFunctionPrefix(std::string const &functionPrefix) {
-  auto topPrefix = functionPrefix;
-  auto const firstDotIndex = topPrefix.find(".");
+std::string removeTopFunctionIndex(std::string const &functionPrefix) {
+  auto resultPrefix = functionPrefix;
+  auto const firstDotIndex = resultPrefix.find(".");
   if (firstDotIndex != std::string::npos)
-    topPrefix.erase(firstDotIndex, topPrefix.size() - firstDotIndex);
-  return topPrefix;
+    resultPrefix.erase(0, firstDotIndex + 1);
+  return resultPrefix;
 }
 
-IFunction_sptr getFunctionAtPrefix(std::string const &functionPrefix,
-                                   IFunction_sptr const &function,
-                                   bool isLastFunction = false) {
-  if (isLastFunction)
-    return function;
-
-  auto const isLast = isSingleFunctionPrefix(functionPrefix);
-  auto const topPrefix = getTopFunctionPrefix(functionPrefix);
-  auto const firstIndex = getPrefixIndexAt(functionPrefix, 0);
-
-  try {
-    return getFunctionAtPrefix(topPrefix, function->getFunction(firstIndex),
-                               isLast);
-  } catch (std::exception const &) {
-    return IFunction_sptr();
-  }
-}
-
-std::vector<std::string>
-getFunctionNamesInString(std::string const &functionString) {
-  std::vector<std::string> functionNames;
-  for (auto const &str : splitStringBy(functionString, ",();"))
-    if (str.substr(0, 5) == "name=")
-      functionNames.emplace_back(str.substr(5));
-  return functionNames;
+bool isTieNumber(std::string const &tie) {
+  return !tie.empty() &&
+         tie.find_first_not_of("0123456789.-") == std::string::npos;
 }
 
 } // namespace
@@ -104,21 +62,7 @@ getFunctionNamesInString(std::string const &functionString) {
 namespace MantidQt {
 namespace MantidWidgets {
 
-/**
- * FitDomain struct methods.
- */
-
-FitDomain::FitDomain(std::string const &workspaceName,
-                     WorkspaceIndex workspaceIndex, double startX, double endX)
-    : m_workspaceName(workspaceName), m_workspaceIndex(workspaceIndex),
-      m_startX(startX), m_endX(endX) {}
-
-/**
- * FitScriptGeneratorModel class methods.
- */
-
-FitScriptGeneratorModel::FitScriptGeneratorModel()
-    : m_fitDomains(), m_function(createMultiDomainFunction(0)) {}
+FitScriptGeneratorModel::FitScriptGeneratorModel() : m_fitDomains() {}
 
 FitScriptGeneratorModel::~FitScriptGeneratorModel() {}
 
@@ -128,7 +72,6 @@ void FitScriptGeneratorModel::removeWorkspaceDomain(
   if (removeIter != m_fitDomains.cend()) {
     auto const removeIndex = std::distance(m_fitDomains.cbegin(), removeIter);
 
-    removeCompositeAtDomainIndex(removeIndex);
     if (removeIter != m_fitDomains.cend())
       m_fitDomains.erase(removeIter);
   }
@@ -142,7 +85,6 @@ void FitScriptGeneratorModel::addWorkspaceDomain(
                                 std::to_string(workspaceIndex.value) +
                                 ")' domain already exists.");
 
-  addEmptyCompositeAtDomainIndex(numberOfDomains());
   m_fitDomains.emplace_back(
       FitDomain(workspaceName, workspaceIndex, startX, endX));
 }
@@ -163,8 +105,8 @@ std::vector<FitDomain>::const_iterator
 FitScriptGeneratorModel::findWorkspaceDomain(
     std::string const &workspaceName, WorkspaceIndex workspaceIndex) const {
   auto const isMatch = [&](FitDomain const &fitDomain) {
-    return fitDomain.m_workspaceName == workspaceName &&
-           fitDomain.m_workspaceIndex == workspaceIndex;
+    return fitDomain.workspaceName() == workspaceName &&
+           fitDomain.workspaceIndex() == workspaceIndex;
   };
 
   return std::find_if(m_fitDomains.cbegin(), m_fitDomains.cend(), isMatch);
@@ -176,142 +118,62 @@ bool FitScriptGeneratorModel::hasWorkspaceDomain(
          m_fitDomains.end();
 }
 
-bool FitScriptGeneratorModel::isStartXValid(std::string const &workspaceName,
-                                            WorkspaceIndex workspaceIndex,
-                                            double startX) const {
-  auto const domainIndex = findDomainIndex(workspaceName, workspaceIndex);
-
-  auto const limits = xLimits(workspaceName, workspaceIndex);
-  return limits.first <= startX && startX <= limits.second &&
-         startX < m_fitDomains[domainIndex].m_endX;
-}
-
-bool FitScriptGeneratorModel::isEndXValid(std::string const &workspaceName,
-                                          WorkspaceIndex workspaceIndex,
-                                          double endX) const {
-  auto const domainIndex = findDomainIndex(workspaceName, workspaceIndex);
-
-  auto const limits = xLimits(workspaceName, workspaceIndex);
-  return limits.first <= endX && endX <= limits.second &&
-         endX > m_fitDomains[domainIndex].m_startX;
-}
-
-std::pair<double, double>
-FitScriptGeneratorModel::xLimits(std::string const &workspaceName,
-                                 WorkspaceIndex workspaceIndex) const {
-  auto &ads = AnalysisDataService::Instance();
-  if (ads.doesExist(workspaceName))
-    return xLimits(ads.retrieveWS<MatrixWorkspace>(workspaceName),
-                   workspaceIndex);
-
-  throw std::invalid_argument("The domain '" + workspaceName + " (" +
-                              std::to_string(workspaceIndex.value) +
-                              ")' could not be found.");
-}
-
-std::pair<double, double>
-FitScriptGeneratorModel::xLimits(MatrixWorkspace_const_sptr const &workspace,
-                                 WorkspaceIndex workspaceIndex) const {
-  if (workspace) {
-    auto const xData = workspace->x(workspaceIndex.value);
-    return std::pair<double, double>(xData.front(), xData.back());
-  }
-
-  throw std::invalid_argument("The workspace '" + workspace->getName() +
-                              "' is not a matrix workspace.");
-}
-
-void FitScriptGeneratorModel::updateStartX(std::string const &workspaceName,
+bool FitScriptGeneratorModel::updateStartX(std::string const &workspaceName,
                                            WorkspaceIndex workspaceIndex,
                                            double startX) {
   auto const domainIndex = findDomainIndex(workspaceName, workspaceIndex);
-  m_fitDomains[domainIndex].m_startX = startX;
+  return m_fitDomains[domainIndex].setStartX(startX);
 }
 
-void FitScriptGeneratorModel::updateEndX(std::string const &workspaceName,
+bool FitScriptGeneratorModel::updateEndX(std::string const &workspaceName,
                                          WorkspaceIndex workspaceIndex,
                                          double endX) {
   auto const domainIndex = findDomainIndex(workspaceName, workspaceIndex);
-  m_fitDomains[domainIndex].m_endX = endX;
+  return m_fitDomains[domainIndex].setEndX(endX);
 }
 
 void FitScriptGeneratorModel::removeFunction(std::string const &workspaceName,
                                              WorkspaceIndex workspaceIndex,
                                              std::string const &function) {
   auto const domainIndex = findDomainIndex(workspaceName, workspaceIndex);
-
-  if (auto composite = toComposite(m_function->getFunction(domainIndex))) {
-    for (auto const functionName : getFunctionNamesInString(function))
-      if (composite->hasFunction(functionName))
-        composite->removeFunction(composite->functionIndex(functionName));
-  }
+  m_fitDomains[domainIndex].removeFunction(function);
 }
 
 void FitScriptGeneratorModel::addFunction(std::string const &workspaceName,
                                           WorkspaceIndex workspaceIndex,
                                           std::string const &function) {
-  addFunction(workspaceName, workspaceIndex, createIFunction(function));
-}
-
-void FitScriptGeneratorModel::addFunction(std::string const &workspaceName,
-                                          WorkspaceIndex workspaceIndex,
-                                          IFunction_sptr const &function) {
   auto const domainIndex = findDomainIndex(workspaceName, workspaceIndex);
-
-  if (auto composite = toComposite(m_function->getFunction(domainIndex)))
-    composite->addFunction(function);
+  m_fitDomains[domainIndex].addFunction(createIFunction(function));
 }
 
 void FitScriptGeneratorModel::setFunction(std::string const &workspaceName,
                                           WorkspaceIndex workspaceIndex,
                                           std::string const &function) {
-  clearCompositeAtDomainIndex(findDomainIndex(workspaceName, workspaceIndex));
-
-  if (auto const iFunction = createIFunction(function)) {
-    if (auto const composite = toComposite(iFunction)) {
-      for (auto i = 0u; i < composite->nFunctions(); ++i)
-        addFunction(workspaceName, workspaceIndex, composite->getFunction(i));
-    } else {
-      addFunction(workspaceName, workspaceIndex, iFunction);
-    }
-  }
+  auto const domainIndex = findDomainIndex(workspaceName, workspaceIndex);
+  m_fitDomains[domainIndex].setFunction(createIFunction(function));
 }
 
-CompositeFunction_sptr
+IFunction_sptr
 FitScriptGeneratorModel::getFunction(std::string const &workspaceName,
                                      WorkspaceIndex workspaceIndex) {
   auto const domainIndex = findDomainIndex(workspaceName, workspaceIndex);
-  return toComposite(m_function->getFunction(domainIndex));
+  return m_fitDomains[domainIndex].getFunction();
 }
 
 void FitScriptGeneratorModel::updateParameterValue(
     std::string const &workspaceName, WorkspaceIndex workspaceIndex,
     std::string const &parameter, double newValue) {
   auto const domainIndex = findDomainIndex(workspaceName, workspaceIndex);
-
-  if (auto composite = toComposite(m_function->getFunction(domainIndex))) {
-    auto fullParameterName = parameter;
-    if (composite->nFunctions() == 1)
-      fullParameterName = "f0." + fullParameterName;
-
-    if (composite->hasParameter(fullParameterName))
-      composite->setParameter(fullParameterName, newValue);
-  }
+  m_fitDomains[domainIndex].setParameterValue(removeTopFunctionIndex(parameter),
+                                              newValue);
 }
 
 void FitScriptGeneratorModel::updateAttributeValue(
     std::string const &workspaceName, WorkspaceIndex workspaceIndex,
     std::string const &attribute, IFunction::Attribute const &newValue) {
   auto const domainIndex = findDomainIndex(workspaceName, workspaceIndex);
-
-  if (auto composite = toComposite(m_function->getFunction(domainIndex))) {
-    auto fullAttributeName = attribute;
-    if (composite->nFunctions() == 1)
-      fullAttributeName = "f0." + fullAttributeName;
-
-    if (composite->hasAttribute(fullAttributeName))
-      composite->setAttribute(fullAttributeName, newValue);
-  }
+  m_fitDomains[domainIndex].setAttributeValue(removeTopFunctionIndex(attribute),
+                                              newValue);
 }
 
 void FitScriptGeneratorModel::updateParameterTie(
@@ -319,68 +181,45 @@ void FitScriptGeneratorModel::updateParameterTie(
     std::string const &parameter, std::string const &tie) {
   auto const domainIndex = findDomainIndex(workspaceName, workspaceIndex);
 
-  if (auto composite = toComposite(m_function->getFunction(domainIndex))) {
+  auto const tieSplit = splitStringBy(tie, "=");
+  auto const tieValue = tieSplit.size() > 1 ? tieSplit[1] : tieSplit[0];
 
-    if (composite->nFunctions() == 1) {
-      auto function = composite->getFunction(0);
-      if (function->hasParameter(parameter))
-        updateParameterTie(function, parameter, tie);
-    } else {
-      if (composite->hasParameter(parameter))
-        updateParameterTie(composite, parameter, tie);
-    }
-  }
+  auto const tieExpression =
+      isTieNumber(tieValue) ? tieValue : removeTopFunctionIndex(tieValue);
+
+  m_fitDomains[domainIndex].updateParameterTie(
+      removeTopFunctionIndex(parameter), tieExpression);
+
+  // if (auto composite = toComposite(m_function->getFunction(domainIndex))) {
+
+  //  if (composite->nFunctions() == 1) {
+  //    auto function = composite->getFunction(0);
+  //    if (function->hasParameter(parameter))
+  //      updateParameterTie(function, parameter, tie);
+  //  } else {
+  //    if (composite->hasParameter(parameter))
+  //      updateParameterTie(composite, parameter, tie);
+  //  }
+  //}
 }
 
 void FitScriptGeneratorModel::updateParameterTie(IFunction_sptr const &function,
                                                  std::string const &parameter,
                                                  std::string const &tie) {
-  if (tie.empty()) {
-    function->removeTie(function->parameterIndex(parameter));
-  } else {
-    auto const tieSplit = splitStringBy(tie, "=");
-    auto const tieValue = tieSplit.size() > 1 ? tieSplit[1] : tieSplit[0];
+  // if (tie.empty()) {
+  //  function->removeTie(function->parameterIndex(parameter));
+  //} else {
+  //  auto const tieSplit = splitStringBy(tie, "=");
+  //  auto const tieValue = tieSplit.size() > 1 ? tieSplit[1] : tieSplit[0];
 
-    try {
-      function->tie(parameter, tieValue);
-    } catch (std::invalid_argument const &ex) {
-      g_log.error(ex.what());
-    } catch (std::runtime_error const &ex) {
-      g_log.error(ex.what());
-    }
-  }
-}
-
-void FitScriptGeneratorModel::removeCompositeAtDomainIndex(
-    std::size_t const &domainIndex) {
-  if (domainIndex >= numberOfDomains())
-    throw std::runtime_error("The domain index provided does not exist");
-
-  clearCompositeAtDomainIndex(domainIndex);
-  m_function->removeFunction(domainIndex);
-}
-
-void FitScriptGeneratorModel::clearCompositeAtDomainIndex(
-    std::size_t const &domainIndex) {
-  if (domainIndex >= numberOfDomains())
-    throw std::runtime_error("The domain index provided does not exist");
-
-  auto composite = toComposite(m_function->getFunction(domainIndex));
-  for (auto i = composite->nFunctions() - 1u; i < composite->nFunctions(); --i)
-    composite->removeFunction(i);
-}
-
-void FitScriptGeneratorModel::addEmptyCompositeAtDomainIndex(
-    std::size_t const &domainIndex) {
-  if (domainIndex != numberOfDomains())
-    throw std::runtime_error("The domain index provided is invalid.");
-
-  m_function->addFunction(createEmptyComposite());
-  m_function->setDomainIndex(domainIndex, domainIndex);
-}
-
-std::string FitScriptGeneratorModel::nextAvailableDomainPrefix() const {
-  return "f" + std::to_string(numberOfDomains());
+  //  try {
+  //    function->tie(parameter, tieValue);
+  //  } catch (std::invalid_argument const &ex) {
+  //    g_log.error(ex.what());
+  //  } catch (std::runtime_error const &ex) {
+  //    g_log.error(ex.what());
+  //  }
+  //}
 }
 
 } // namespace MantidWidgets

--- a/qt/widgets/common/src/FitScriptGeneratorModel.cpp
+++ b/qt/widgets/common/src/FitScriptGeneratorModel.cpp
@@ -5,6 +5,7 @@
 //   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
 // SPDX - License - Identifier: GPL - 3.0 +
 #include "MantidQtWidgets/Common/FitScriptGeneratorModel.h"
+#include "MantidQtWidgets/Common/FunctionBrowser/FunctionBrowserUtils.h"
 #include "MantidQtWidgets/Common/IFitScriptGeneratorPresenter.h"
 
 #include "MantidAPI/AnalysisDataService.h"
@@ -12,8 +13,6 @@
 #include "MantidAPI/MatrixWorkspace.h"
 #include "MantidAPI/ParameterTie.h"
 #include "MantidKernel/Logger.h"
-
-#include <boost/algorithm/string.hpp>
 
 #include <algorithm>
 #include <iterator>
@@ -29,34 +28,18 @@ IFunction_sptr createIFunction(std::string const &functionString) {
   return FunctionFactory::Instance().createInitialized(functionString);
 }
 
-std::vector<std::string> splitStringBy(std::string const &str,
-                                       std::string const &delimiter) {
-  std::vector<std::string> subStrings;
-  boost::split(subStrings, str, boost::is_any_of(delimiter));
-  subStrings.erase(std::remove_if(subStrings.begin(), subStrings.end(),
-                                  [](std::string const &subString) {
-                                    return subString.empty();
-                                  }),
-                   subStrings.cend());
-  return subStrings;
-}
-
-std::size_t getFunctionIndexAt(std::string const &parameter,
-                               std::size_t const &index) {
-  auto subStrings = splitStringBy(parameter, "f.");
-  subStrings.pop_back();
-  if (index < subStrings.size())
-    return std::stoull(subStrings[index]);
-
-  throw std::invalid_argument("Incorrect function index provided.");
-}
-
-std::string removeTopFunctionIndex(std::string const &functionPrefix) {
-  auto resultPrefix = functionPrefix;
+std::string removeTopFunctionIndex(std::string const &functionIndex) {
+  auto resultPrefix = functionIndex;
   auto const firstDotIndex = resultPrefix.find(".");
   if (firstDotIndex != std::string::npos)
     resultPrefix.erase(0, firstDotIndex + 1);
   return resultPrefix;
+}
+
+std::string replaceTopFunctionIndexWith(std::string const &functionIndex,
+                                        std::size_t const &newIndex) {
+  return "f" + std::to_string(newIndex) + "." +
+         removeTopFunctionIndex(functionIndex);
 }
 
 std::string getTieRHS(std::string const &tie) {
@@ -71,27 +54,6 @@ std::string getLocalTie(std::string const &tie,
   return tie;
 }
 
-std::string getLocalParameter(std::string const &parameter,
-                              FittingMode const &fittingMode) {
-  if (parameter.empty())
-    return parameter;
-
-  switch (fittingMode) {
-  case FittingMode::Sequential:
-    return parameter;
-  case FittingMode::Simultaneous:
-    return removeTopFunctionIndex(parameter);
-  default:
-    throw std::invalid_argument(
-        "Fitting mode must be Sequential or Simultaneous.");
-  }
-}
-
-bool isNumber(std::string const &str) {
-  return !str.empty() &&
-         str.find_first_not_of("0123456789.-") == std::string::npos;
-}
-
 bool isFunctionIndex(std::string const &str) {
   auto const subStrings = splitStringBy(str, "f");
   if (subStrings.size() == 1)
@@ -104,23 +66,6 @@ bool isSameDomain(std::size_t const &domainIndex,
   if (!parameter.empty() && !isNumber(parameter))
     return domainIndex == getFunctionIndexAt(parameter, 0);
   return true;
-}
-
-bool validTie(std::string const &tie, FittingMode const &fittingMode) {
-  if (tie.empty() || isNumber(tie))
-    return true;
-
-  auto const subStrings = splitStringBy(tie, ".");
-  switch (fittingMode) {
-  case FittingMode::Sequential:
-    return 1 <= subStrings.size() && subStrings.size() <= 2;
-  case FittingMode::Simultaneous:
-    return 2 <= subStrings.size() && subStrings.size() <= 3 &&
-           isFunctionIndex(subStrings[0]);
-  default:
-    throw std::invalid_argument(
-        "Fitting mode must be Sequential or Simultaneous.");
-  }
 }
 
 } // namespace
@@ -233,39 +178,28 @@ FitScriptGeneratorModel::getFunction(std::string const &workspaceName,
   return m_fitDomains[domainIndex].getFunction();
 }
 
-std::string FitScriptGeneratorModel::getEquivalentParameterForDomain(
+std::string FitScriptGeneratorModel::getEquivalentFunctionIndexForDomain(
     std::string const &workspaceName, WorkspaceIndex workspaceIndex,
-    std::string const &fullParameter) const {
-  auto const domainIndex = findDomainIndex(workspaceName, workspaceIndex);
-
-  switch (m_fittingMode) {
-  case FittingMode::Sequential:
-    return fullParameter;
-  case FittingMode::Simultaneous:
-    return "f" + std::to_string(domainIndex) + "." +
-           removeTopFunctionIndex(fullParameter);
-  default:
-    throw std::invalid_argument(
-        "Fitting mode must be Sequential or Simultaneous.");
+    std::string const &functionIndex) const {
+  if (!functionIndex.empty() && m_fittingMode == FittingMode::Simultaneous) {
+    auto const domainIndex = findDomainIndex(workspaceName, workspaceIndex);
+    return replaceTopFunctionIndexWith(functionIndex, domainIndex);
   }
+  return functionIndex;
 }
 
 std::string FitScriptGeneratorModel::getEquivalentParameterTieForDomain(
     std::string const &workspaceName, WorkspaceIndex workspaceIndex,
     std::string const &fullParameter, std::string const &fullTie) const {
-  if (fullTie.empty() || isNumber(fullTie) || !validTie(fullTie, m_fittingMode))
+  if (fullTie.empty() || isNumber(fullTie) || !validTie(fullTie))
     return fullTie;
 
-  switch (m_fittingMode) {
-  case FittingMode::Sequential:
+  if (m_fittingMode == FittingMode::Sequential)
     return fullTie;
-  case FittingMode::Simultaneous:
-    return getEquivalentParameterTieForDomain(
-        findDomainIndex(workspaceName, workspaceIndex), fullParameter, fullTie);
-  default:
-    throw std::invalid_argument(
-        "Fitting mode must be Sequential or Simultaneous.");
-  }
+
+  auto const domainIndex = findDomainIndex(workspaceName, workspaceIndex);
+  return getEquivalentParameterTieForDomain(domainIndex, fullParameter,
+                                            fullTie);
 }
 
 std::string FitScriptGeneratorModel::getEquivalentParameterTieForDomain(
@@ -273,21 +207,29 @@ std::string FitScriptGeneratorModel::getEquivalentParameterTieForDomain(
     std::string const &fullTie) const {
   auto const parameterDomainIndex = getFunctionIndexAt(fullParameter, 0);
   auto const tieDomainIndex = getFunctionIndexAt(fullTie, 0);
-  if (parameterDomainIndex != tieDomainIndex)
-    return fullTie;
+  if (parameterDomainIndex == tieDomainIndex)
+    return replaceTopFunctionIndexWith(fullTie, domainIndex);
+  return fullTie;
+}
 
-  return "f" + std::to_string(domainIndex) + "." +
-         removeTopFunctionIndex(fullTie);
+std::string FitScriptGeneratorModel::getAdjustedFunctionIndex(
+    std::string const &parameter) const {
+  if (parameter.empty() || isNumber(parameter))
+    return parameter;
+
+  if (m_fittingMode == FittingMode::Sequential)
+    return parameter;
+  return removeTopFunctionIndex(parameter);
 }
 
 void FitScriptGeneratorModel::updateParameterValue(
     std::string const &workspaceName, WorkspaceIndex workspaceIndex,
-    std::string const &parameter, double newValue) {
+    std::string const &fullParameter, double newValue) {
   auto const domainIndex = findDomainIndex(workspaceName, workspaceIndex);
-  if (!hasGlobalTie(parameter)) {
-    m_fitDomains[domainIndex].setParameterValue(
-        removeTopFunctionIndex(parameter), newValue);
-    updateParameterValuesWithGlobalTieTo(parameter);
+  if (!hasGlobalTie(fullParameter)) {
+    auto const parameter = getAdjustedFunctionIndex(fullParameter);
+    m_fitDomains[domainIndex].setParameterValue(parameter, newValue);
+    updateParameterValuesWithGlobalTieTo(fullParameter);
   }
 }
 
@@ -297,7 +239,7 @@ void FitScriptGeneratorModel::updateParameterValuesWithGlobalTieTo(
     if (parameter == globalTie.m_tie) {
       auto const domainIndex = getFunctionIndexAt(globalTie.m_parameter, 0);
       m_fitDomains[domainIndex].setParameterValue(
-          removeTopFunctionIndex(globalTie.m_parameter),
+          getAdjustedFunctionIndex(globalTie.m_parameter),
           getParameterValue(parameter));
     }
   }
@@ -305,18 +247,18 @@ void FitScriptGeneratorModel::updateParameterValuesWithGlobalTieTo(
 
 void FitScriptGeneratorModel::updateAttributeValue(
     std::string const &workspaceName, WorkspaceIndex workspaceIndex,
-    std::string const &attribute, IFunction::Attribute const &newValue) {
+    std::string const &fullAttribute, IFunction::Attribute const &newValue) {
   auto const domainIndex = findDomainIndex(workspaceName, workspaceIndex);
-  m_fitDomains[domainIndex].setAttributeValue(removeTopFunctionIndex(attribute),
-                                              newValue);
+  m_fitDomains[domainIndex].setAttributeValue(
+      getAdjustedFunctionIndex(fullAttribute), newValue);
 }
 
 void FitScriptGeneratorModel::updateParameterTie(
     std::string const &workspaceName, WorkspaceIndex workspaceIndex,
-    std::string const &parameter, std::string const &tie) {
-  if (validTie(tie, m_fittingMode)) {
+    std::string const &fullParameter, std::string const &tie) {
+  if (validTie(tie)) {
     auto const domainIndex = findDomainIndex(workspaceName, workspaceIndex);
-    updateParameterTie(domainIndex, parameter, tie);
+    updateParameterTie(domainIndex, fullParameter, tie);
   } else {
     g_log.warning("Invalid tie '" + tie + "' provided.");
   }
@@ -335,7 +277,7 @@ void FitScriptGeneratorModel::updateParameterTie(
 void FitScriptGeneratorModel::updateLocalParameterTie(
     std::size_t const &domainIndex, std::string const &fullParameter,
     std::string const &fullTie) {
-  auto const parameter = getLocalParameter(fullParameter, m_fittingMode);
+  auto const parameter = getAdjustedFunctionIndex(fullParameter);
   auto const tie = getLocalTie(fullTie, m_fittingMode);
 
   if (parameter != tie && validParameter(fullParameter)) {
@@ -353,9 +295,11 @@ void FitScriptGeneratorModel::updateGlobalParameterTie(
     if (validGlobalTie(fullTie)) {
       clearGlobalTie(fullParameter);
 
-      m_fitDomains[domainIndex].clearParameterTie(fullParameter);
-      m_fitDomains[domainIndex].setParameterValue(
-          removeTopFunctionIndex(fullParameter), getParameterValue(fullTie));
+      auto const parameter = getAdjustedFunctionIndex(fullParameter);
+      m_fitDomains[domainIndex].clearParameterTie(parameter);
+      m_fitDomains[domainIndex].setParameterValue(parameter,
+                                                  getParameterValue(fullTie));
+
       m_globalTies.emplace_back(GlobalTie(fullParameter, fullTie));
     } else {
       g_log.warning("Invalid tie '" + fullTie + "' provided.");
@@ -363,10 +307,31 @@ void FitScriptGeneratorModel::updateGlobalParameterTie(
   }
 }
 
+void FitScriptGeneratorModel::removeParameterConstraint(
+    std::string const &workspaceName, WorkspaceIndex workspaceIndex,
+    std::string const &fullParameter) {
+  auto const domainIndex = findDomainIndex(workspaceName, workspaceIndex);
+  m_fitDomains[domainIndex].removeParameterConstraint(
+      getAdjustedFunctionIndex(fullParameter));
+}
+
+void FitScriptGeneratorModel::updateParameterConstraint(
+    std::string const &workspaceName, WorkspaceIndex workspaceIndex,
+    std::string const &functionIndex, std::string const &constraint) {
+  auto const domainIndex = findDomainIndex(workspaceName, workspaceIndex);
+
+  auto const constraintSplit =
+      splitConstraintString(QString::fromStdString(constraint));
+
+  auto const parameterName = constraintSplit.first.toStdString();
+  m_fitDomains[domainIndex].updateParameterConstraint(
+      getAdjustedFunctionIndex(functionIndex), parameterName, constraint);
+}
+
 double FitScriptGeneratorModel::getParameterValue(
     std::string const &fullParameter) const {
   auto const domainIndex = getFunctionIndexAt(fullParameter, 0);
-  auto const parameter = getLocalParameter(fullParameter, m_fittingMode);
+  auto const parameter = getAdjustedFunctionIndex(fullParameter);
   if (domainIndex < numberOfDomains())
     return m_fitDomains[domainIndex].getParameterValue(parameter);
 
@@ -376,10 +341,27 @@ double FitScriptGeneratorModel::getParameterValue(
 bool FitScriptGeneratorModel::validParameter(
     std::string const &fullParameter) const {
   auto const domainIndex = getFunctionIndexAt(fullParameter, 0);
-  auto const parameter = getLocalParameter(fullParameter, m_fittingMode);
+  auto const parameter = getAdjustedFunctionIndex(fullParameter);
   if (domainIndex < numberOfDomains())
     return m_fitDomains[domainIndex].hasParameter(parameter);
   return false;
+}
+
+bool FitScriptGeneratorModel::validTie(std::string const &tie) const {
+  if (tie.empty() || isNumber(tie))
+    return true;
+
+  auto const subStrings = splitStringBy(tie, ".");
+  switch (m_fittingMode) {
+  case FittingMode::Sequential:
+    return 1 <= subStrings.size() && subStrings.size() <= 2;
+  case FittingMode::Simultaneous:
+    return 2 <= subStrings.size() && subStrings.size() <= 3 &&
+           isFunctionIndex(subStrings[0]);
+  default:
+    throw std::invalid_argument(
+        "Fitting mode must be Sequential or Simultaneous.");
+  }
 }
 
 bool FitScriptGeneratorModel::validGlobalTie(std::string const &fullTie) const {

--- a/qt/widgets/common/src/FitScriptGeneratorModel.cpp
+++ b/qt/widgets/common/src/FitScriptGeneratorModel.cpp
@@ -177,7 +177,7 @@ void FitScriptGeneratorModel::setFunction(std::string const &workspaceName,
 
 IFunction_sptr
 FitScriptGeneratorModel::getFunction(std::string const &workspaceName,
-                                     WorkspaceIndex workspaceIndex) {
+                                     WorkspaceIndex workspaceIndex) const {
   auto const domainIndex = findDomainIndex(workspaceName, workspaceIndex);
   return m_fitDomains[domainIndex.value]->getFunction();
 }

--- a/qt/widgets/common/src/FitScriptGeneratorModel.cpp
+++ b/qt/widgets/common/src/FitScriptGeneratorModel.cpp
@@ -61,9 +61,9 @@ bool isFunctionIndex(std::string const &str) {
 }
 
 bool isSameDomain(std::size_t const &domainIndex,
-                  std::string const &parameter) {
-  if (!parameter.empty() && !isNumber(parameter))
-    return domainIndex == getFunctionIndexAt(parameter, 0);
+                  std::string const &fullParameter) {
+  if (!fullParameter.empty() && !isNumber(fullParameter))
+    return domainIndex == getFunctionIndexAt(fullParameter, 0);
   return true;
 }
 
@@ -183,7 +183,7 @@ IFunction_sptr
 FitScriptGeneratorModel::getFunction(std::string const &workspaceName,
                                      WorkspaceIndex workspaceIndex) const {
   auto const domainIndex = findDomainIndex(workspaceName, workspaceIndex);
-  return m_fitDomains[domainIndex.value]->getFunction();
+  return m_fitDomains[domainIndex.value]->getFunctionCopy();
 }
 
 std::string FitScriptGeneratorModel::getEquivalentFunctionIndexForDomain(

--- a/qt/widgets/common/src/FitScriptGeneratorPresenter.cpp
+++ b/qt/widgets/common/src/FitScriptGeneratorPresenter.cpp
@@ -98,8 +98,8 @@ void FitScriptGeneratorPresenter::notifyPresenter(
   throw std::runtime_error("Failed to notify the FitScriptGeneratorPresenter.");
 }
 
-void FitScriptGeneratorPresenter::notifyPresenter(
-    ViewEvent const &event, FittingMode const &fittingMode) {
+void FitScriptGeneratorPresenter::notifyPresenter(ViewEvent const &event,
+                                                  FittingMode fittingMode) {
   switch (event) {
   case ViewEvent::FittingModeChanged:
     handleFittingModeChanged(fittingMode);
@@ -157,7 +157,7 @@ void FitScriptGeneratorPresenter::handleEndXChanged() {
 
 void FitScriptGeneratorPresenter::handleSelectionChanged() {
   m_view->setSimultaneousMode(m_model->getFittingMode() ==
-                              FittingMode::Simultaneous);
+                              FittingMode::SIMULTANEOUS);
 
   auto const selectedRows = m_view->selectedRows();
   if (!selectedRows.empty()) {
@@ -289,7 +289,7 @@ void FitScriptGeneratorPresenter::handleGlobalParametersChanged(
 }
 
 void FitScriptGeneratorPresenter::handleFittingModeChanged(
-    FittingMode const &fittingMode) {
+    FittingMode fittingMode) {
   m_model->setFittingMode(fittingMode);
   handleSelectionChanged();
 }

--- a/qt/widgets/common/src/FitScriptGeneratorPresenter.cpp
+++ b/qt/widgets/common/src/FitScriptGeneratorPresenter.cpp
@@ -9,6 +9,7 @@
 #include "MantidQtWidgets/Common/IFitScriptGeneratorView.h"
 
 #include "MantidAPI/AnalysisDataService.h"
+#include "MantidAPI/IFunction.h"
 #include "MantidAPI/MatrixWorkspace.h"
 
 #include <algorithm>
@@ -130,8 +131,8 @@ void FitScriptGeneratorPresenter::handleSelectionChanged() {
     auto const workspaceName = m_view->workspaceName(selectedRows[0]);
     auto const workspaceIndex = m_view->workspaceIndex(selectedRows[0]);
 
-    auto const composite = m_model->getFunction(workspaceName, workspaceIndex);
-    m_view->setFunction(composite);
+    auto const function = m_model->getFunction(workspaceName, workspaceIndex);
+    m_view->setFunction(function);
   } else {
     m_view->clearFunction();
   }
@@ -269,9 +270,7 @@ void FitScriptGeneratorPresenter::addWorkspace(std::string const &workspaceName,
 void FitScriptGeneratorPresenter::updateStartX(std::string const &workspaceName,
                                                WorkspaceIndex workspaceIndex,
                                                double startX) {
-  if (m_model->isStartXValid(workspaceName, workspaceIndex, startX))
-    m_model->updateStartX(workspaceName, workspaceIndex, startX);
-  else {
+  if (!m_model->updateStartX(workspaceName, workspaceIndex, startX)) {
     m_view->resetSelection();
     m_view->displayWarning("The StartX provided must be within the x limits of "
                            "its workspace, and less than the EndX.");
@@ -281,9 +280,7 @@ void FitScriptGeneratorPresenter::updateStartX(std::string const &workspaceName,
 void FitScriptGeneratorPresenter::updateEndX(std::string const &workspaceName,
                                              WorkspaceIndex workspaceIndex,
                                              double endX) {
-  if (m_model->isEndXValid(workspaceName, workspaceIndex, endX))
-    m_model->updateEndX(workspaceName, workspaceIndex, endX);
-  else {
+  if (!m_model->updateEndX(workspaceName, workspaceIndex, endX)) {
     m_view->resetSelection();
     m_view->displayWarning("The EndX provided must be within the x limits of "
                            "its workspace, and greater than the StartX.");

--- a/qt/widgets/common/src/FitScriptGeneratorPresenter.cpp
+++ b/qt/widgets/common/src/FitScriptGeneratorPresenter.cpp
@@ -82,9 +82,10 @@ void FitScriptGeneratorPresenter::notifyPresenter(ViewEvent const &event,
   case ViewEvent::ParameterConstraintChanged:
     handleParameterConstraintChanged(arg1, arg2);
     return;
+  default:
+    throw std::runtime_error(
+        "Failed to notify the FitScriptGeneratorPresenter.");
   }
-
-  throw std::runtime_error("Failed to notify the FitScriptGeneratorPresenter.");
 }
 
 void FitScriptGeneratorPresenter::notifyPresenter(
@@ -93,9 +94,10 @@ void FitScriptGeneratorPresenter::notifyPresenter(
   case ViewEvent::GlobalParametersChanged:
     handleGlobalParametersChanged(vec);
     return;
+  default:
+    throw std::runtime_error(
+        "Failed to notify the FitScriptGeneratorPresenter.");
   }
-
-  throw std::runtime_error("Failed to notify the FitScriptGeneratorPresenter.");
 }
 
 void FitScriptGeneratorPresenter::notifyPresenter(ViewEvent const &event,
@@ -104,9 +106,10 @@ void FitScriptGeneratorPresenter::notifyPresenter(ViewEvent const &event,
   case ViewEvent::FittingModeChanged:
     handleFittingModeChanged(fittingMode);
     return;
+  default:
+    throw std::runtime_error(
+        "Failed to notify the FitScriptGeneratorPresenter.");
   }
-
-  throw std::runtime_error("Failed to notify the FitScriptGeneratorPresenter.");
 }
 
 void FitScriptGeneratorPresenter::openFitScriptGenerator() { m_view->show(); }

--- a/qt/widgets/common/src/FitScriptGeneratorPresenter.cpp
+++ b/qt/widgets/common/src/FitScriptGeneratorPresenter.cpp
@@ -148,6 +148,8 @@ void FitScriptGeneratorPresenter::handleFunctionRemoved(
     auto const workspaceIndex = m_view->workspaceIndex(rowIndex);
     m_model->removeFunction(workspaceName, workspaceIndex, function);
   }
+
+  handleSelectionChanged();
 }
 
 void FitScriptGeneratorPresenter::handleFunctionAdded(
@@ -187,6 +189,8 @@ void FitScriptGeneratorPresenter::handleParameterChanged(
     m_model->updateParameterValue(workspaceName, workspaceIndex, parameter,
                                   newValue);
   }
+
+  handleSelectionChanged();
 }
 
 void FitScriptGeneratorPresenter::handleAttributeChanged(
@@ -211,6 +215,8 @@ void FitScriptGeneratorPresenter::handleParameterTieChanged(
     auto const workspaceIndex = m_view->workspaceIndex(rowIndex);
     m_model->updateParameterTie(workspaceName, workspaceIndex, parameter, tie);
   }
+
+  handleSelectionChanged();
 }
 
 void FitScriptGeneratorPresenter::setWorkspaces(

--- a/qt/widgets/common/src/FitScriptGeneratorPresenter.cpp
+++ b/qt/widgets/common/src/FitScriptGeneratorPresenter.cpp
@@ -76,6 +76,12 @@ void FitScriptGeneratorPresenter::notifyPresenter(ViewEvent const &event,
   case ViewEvent::ParameterTieChanged:
     handleParameterTieChanged(arg1, arg2);
     return;
+  case ViewEvent::ParameterConstraintRemoved:
+    handleParameterConstraintRemoved(arg1);
+    return;
+  case ViewEvent::ParameterConstraintChanged:
+    handleParameterConstraintChanged(arg1, arg2);
+    return;
   }
 
   throw std::runtime_error("Failed to notify the FitScriptGeneratorPresenter.");
@@ -200,8 +206,9 @@ void FitScriptGeneratorPresenter::handleParameterChanged(
   for (auto const &rowIndex : rowIndices) {
     auto const workspaceName = m_view->workspaceName(rowIndex);
     auto const workspaceIndex = m_view->workspaceIndex(rowIndex);
-    auto const equivalentParameter = m_model->getEquivalentParameterForDomain(
-        workspaceName, workspaceIndex, parameter);
+    auto const equivalentParameter =
+        m_model->getEquivalentFunctionIndexForDomain(workspaceName,
+                                                     workspaceIndex, parameter);
     m_model->updateParameterValue(workspaceName, workspaceIndex,
                                   equivalentParameter, newValue);
   }
@@ -229,8 +236,9 @@ void FitScriptGeneratorPresenter::handleParameterTieChanged(
   for (auto const &rowIndex : rowIndices) {
     auto const workspaceName = m_view->workspaceName(rowIndex);
     auto const workspaceIndex = m_view->workspaceIndex(rowIndex);
-    auto const equivalentParameter = m_model->getEquivalentParameterForDomain(
-        workspaceName, workspaceIndex, parameter);
+    auto const equivalentParameter =
+        m_model->getEquivalentFunctionIndexForDomain(workspaceName,
+                                                     workspaceIndex, parameter);
     auto const equivalentTie = m_model->getEquivalentParameterTieForDomain(
         workspaceName, workspaceIndex, parameter, tie);
     m_model->updateParameterTie(workspaceName, workspaceIndex,
@@ -238,6 +246,37 @@ void FitScriptGeneratorPresenter::handleParameterTieChanged(
   }
 
   setGlobalTies(m_model->getGlobalTies());
+  handleSelectionChanged();
+}
+
+void FitScriptGeneratorPresenter::handleParameterConstraintRemoved(
+    std::string const &parameter) {
+  auto const rowIndices = m_view->allRows();
+
+  for (auto const &rowIndex : rowIndices) {
+    auto const workspaceName = m_view->workspaceName(rowIndex);
+    auto const workspaceIndex = m_view->workspaceIndex(rowIndex);
+    m_model->removeParameterConstraint(workspaceName, workspaceIndex,
+                                       parameter);
+  }
+
+  handleSelectionChanged();
+}
+
+void FitScriptGeneratorPresenter::handleParameterConstraintChanged(
+    std::string const &functionIndex, std::string const &constraint) {
+  auto const rowIndices = m_view->allRows();
+
+  for (auto const &rowIndex : rowIndices) {
+    auto const workspaceName = m_view->workspaceName(rowIndex);
+    auto const workspaceIndex = m_view->workspaceIndex(rowIndex);
+    auto const equivalentFunctionIndex =
+        m_model->getEquivalentFunctionIndexForDomain(
+            workspaceName, workspaceIndex, functionIndex);
+    m_model->updateParameterConstraint(workspaceName, workspaceIndex,
+                                       equivalentFunctionIndex, constraint);
+  }
+
   handleSelectionChanged();
 }
 

--- a/qt/widgets/common/src/FitScriptGeneratorPresenter.cpp
+++ b/qt/widgets/common/src/FitScriptGeneratorPresenter.cpp
@@ -143,13 +143,10 @@ void FitScriptGeneratorPresenter::handleFunctionRemoved(
                               ? m_view->allRows()
                               : m_view->selectedRows();
 
-  for (auto const &rowIndex : rowIndices) {
-    auto const workspaceName = m_view->workspaceName(rowIndex);
-    auto const workspaceIndex = m_view->workspaceIndex(rowIndex);
-    m_model->removeFunction(workspaceName, workspaceIndex, function);
+  if (!rowIndices.empty()) {
+    removeFunctionForDomains(function, rowIndices);
+    handleSelectionChanged();
   }
-
-  handleSelectionChanged();
 }
 
 void FitScriptGeneratorPresenter::handleFunctionAdded(
@@ -158,10 +155,11 @@ void FitScriptGeneratorPresenter::handleFunctionAdded(
                               ? m_view->allRows()
                               : m_view->selectedRows();
 
-  for (auto const &rowIndex : rowIndices) {
-    auto const workspaceName = m_view->workspaceName(rowIndex);
-    auto const workspaceIndex = m_view->workspaceIndex(rowIndex);
-    m_model->addFunction(workspaceName, workspaceIndex, function);
+  if (!rowIndices.empty()) {
+    addFunctionForDomains(function, rowIndices);
+  } else {
+    m_view->displayWarning("Data needs to be loaded before adding a function.");
+    m_view->clearFunction();
   }
 }
 
@@ -171,10 +169,11 @@ void FitScriptGeneratorPresenter::handleFunctionReplaced(
                               ? m_view->allRows()
                               : m_view->selectedRows();
 
-  for (auto const &rowIndex : rowIndices) {
-    auto const workspaceName = m_view->workspaceName(rowIndex);
-    auto const workspaceIndex = m_view->workspaceIndex(rowIndex);
-    m_model->setFunction(workspaceName, workspaceIndex, function);
+  if (!rowIndices.empty()) {
+    setFunctionForDomains(function, rowIndices);
+  } else {
+    m_view->displayWarning("Data needs to be loaded before adding a function.");
+    m_view->clearFunction();
   }
 }
 
@@ -288,6 +287,36 @@ void FitScriptGeneratorPresenter::updateEndX(std::string const &workspaceName,
     m_view->resetSelection();
     m_view->displayWarning("The EndX provided must be within the x limits of "
                            "its workspace, and greater than the StartX.");
+  }
+}
+
+void FitScriptGeneratorPresenter::removeFunctionForDomains(
+    std::string const &function,
+    std::vector<FitDomainIndex> const &domainIndices) {
+  for (auto const &domainIndex : domainIndices) {
+    auto const workspaceName = m_view->workspaceName(domainIndex);
+    auto const workspaceIndex = m_view->workspaceIndex(domainIndex);
+    m_model->removeFunction(workspaceName, workspaceIndex, function);
+  }
+}
+
+void FitScriptGeneratorPresenter::addFunctionForDomains(
+    std::string const &function,
+    std::vector<FitDomainIndex> const &domainIndices) {
+  for (auto const &domainIndex : domainIndices) {
+    auto const workspaceName = m_view->workspaceName(domainIndex);
+    auto const workspaceIndex = m_view->workspaceIndex(domainIndex);
+    m_model->addFunction(workspaceName, workspaceIndex, function);
+  }
+}
+
+void FitScriptGeneratorPresenter::setFunctionForDomains(
+    std::string const &function,
+    std::vector<FitDomainIndex> const &domainIndices) {
+  for (auto const &domainIndex : domainIndices) {
+    auto const workspaceName = m_view->workspaceName(domainIndex);
+    auto const workspaceIndex = m_view->workspaceIndex(domainIndex);
+    m_model->setFunction(workspaceName, workspaceIndex, function);
   }
 }
 

--- a/qt/widgets/common/src/FitScriptGeneratorPresenter.cpp
+++ b/qt/widgets/common/src/FitScriptGeneratorPresenter.cpp
@@ -200,8 +200,10 @@ void FitScriptGeneratorPresenter::handleParameterChanged(
   for (auto const &rowIndex : rowIndices) {
     auto const workspaceName = m_view->workspaceName(rowIndex);
     auto const workspaceIndex = m_view->workspaceIndex(rowIndex);
-    m_model->updateParameterValue(workspaceName, workspaceIndex, parameter,
-                                  newValue);
+    auto const equivalentParameter = m_model->getEquivalentParameterForDomain(
+        workspaceName, workspaceIndex, parameter);
+    m_model->updateParameterValue(workspaceName, workspaceIndex,
+                                  equivalentParameter, newValue);
   }
 
   handleSelectionChanged();
@@ -229,8 +231,10 @@ void FitScriptGeneratorPresenter::handleParameterTieChanged(
     auto const workspaceIndex = m_view->workspaceIndex(rowIndex);
     auto const equivalentParameter = m_model->getEquivalentParameterForDomain(
         workspaceName, workspaceIndex, parameter);
+    auto const equivalentTie = m_model->getEquivalentParameterTieForDomain(
+        workspaceName, workspaceIndex, parameter, tie);
     m_model->updateParameterTie(workspaceName, workspaceIndex,
-                                equivalentParameter, tie);
+                                equivalentParameter, equivalentTie);
   }
 
   setGlobalTies(m_model->getGlobalTies());

--- a/qt/widgets/common/src/FitScriptGeneratorPresenter.cpp
+++ b/qt/widgets/common/src/FitScriptGeneratorPresenter.cpp
@@ -6,6 +6,7 @@
 // SPDX - License - Identifier: GPL - 3.0 +
 #include "MantidQtWidgets/Common/FitScriptGeneratorPresenter.h"
 #include "MantidQtWidgets/Common/FitScriptGeneratorModel.h"
+#include "MantidQtWidgets/Common/FittingGlobals.h"
 #include "MantidQtWidgets/Common/IFitScriptGeneratorView.h"
 
 #include "MantidAPI/AnalysisDataService.h"
@@ -26,6 +27,7 @@ FitScriptGeneratorPresenter::FitScriptGeneratorPresenter(
     IFitScriptGeneratorView *view, IFitScriptGeneratorModel *model,
     QStringList const &workspaceNames, double startX, double endX)
     : m_warnings(), m_view(view), m_model(model) {
+  m_model->subscribePresenter(this);
   m_view->subscribePresenter(this);
   setWorkspaces(workspaceNames, startX, endX);
 }
@@ -231,6 +233,7 @@ void FitScriptGeneratorPresenter::handleParameterTieChanged(
                                 equivalentParameter, tie);
   }
 
+  setGlobalTies(m_model->getGlobalTies());
   handleSelectionChanged();
 }
 
@@ -238,6 +241,11 @@ void FitScriptGeneratorPresenter::handleFittingModeChanged(
     FittingMode const &fittingMode) {
   m_model->setFittingMode(fittingMode);
   handleSelectionChanged();
+}
+
+void FitScriptGeneratorPresenter::setGlobalTies(
+    std::vector<GlobalTie> const &globalTies) {
+  m_view->setGlobalTies(globalTies);
 }
 
 void FitScriptGeneratorPresenter::setWorkspaces(

--- a/qt/widgets/common/src/FitScriptGeneratorPresenter.cpp
+++ b/qt/widgets/common/src/FitScriptGeneratorPresenter.cpp
@@ -154,7 +154,7 @@ void FitScriptGeneratorPresenter::handleSelectionChanged() {
 
 void FitScriptGeneratorPresenter::handleFunctionRemoved(
     std::string const &function) {
-  auto const rowIndices = m_view->isApplyFunctionChangesToAllChecked()
+  auto const rowIndices = m_view->isAddRemoveFunctionForAllChecked()
                               ? m_view->allRows()
                               : m_view->selectedRows();
 
@@ -166,7 +166,7 @@ void FitScriptGeneratorPresenter::handleFunctionRemoved(
 
 void FitScriptGeneratorPresenter::handleFunctionAdded(
     std::string const &function) {
-  auto const rowIndices = m_view->isApplyFunctionChangesToAllChecked()
+  auto const rowIndices = m_view->isAddRemoveFunctionForAllChecked()
                               ? m_view->allRows()
                               : m_view->selectedRows();
 
@@ -180,7 +180,7 @@ void FitScriptGeneratorPresenter::handleFunctionAdded(
 
 void FitScriptGeneratorPresenter::handleFunctionReplaced(
     std::string const &function) {
-  auto const rowIndices = m_view->isApplyFunctionChangesToAllChecked()
+  auto const rowIndices = m_view->isAddRemoveFunctionForAllChecked()
                               ? m_view->allRows()
                               : m_view->selectedRows();
 

--- a/qt/widgets/common/src/FitScriptGeneratorPresenter.cpp
+++ b/qt/widgets/common/src/FitScriptGeneratorPresenter.cpp
@@ -49,6 +49,9 @@ void FitScriptGeneratorPresenter::notifyPresenter(ViewEvent const &event,
   case ViewEvent::EndXChanged:
     handleEndXChanged();
     return;
+  case ViewEvent::SelectionChanged:
+    handleSelectionChanged();
+    return;
   case ViewEvent::FunctionRemoved:
     handleFunctionRemoved(arg);
     return;
@@ -102,6 +105,16 @@ void FitScriptGeneratorPresenter::handleEndXChanged() {
 
     updateEndX(workspaceName, workspaceIndex, endX);
   }
+}
+
+void FitScriptGeneratorPresenter::handleSelectionChanged() {
+  auto const firstRowIndex = m_view->selectedRows()[0];
+
+  auto const workspaceName = m_view->workspaceName(firstRowIndex);
+  auto const workspaceIndex = m_view->workspaceIndex(firstRowIndex);
+
+  auto const composite = m_model->getFunction(workspaceName, workspaceIndex);
+  m_view->setFunction(composite);
 }
 
 void FitScriptGeneratorPresenter::handleFunctionRemoved(

--- a/qt/widgets/common/src/FitScriptGeneratorPresenter.cpp
+++ b/qt/widgets/common/src/FitScriptGeneratorPresenter.cpp
@@ -124,7 +124,7 @@ void FitScriptGeneratorPresenter::handleSelectionChanged() {
 
 void FitScriptGeneratorPresenter::handleFunctionRemoved(
     std::string const &function) {
-  auto const rowIndices = m_view->isAddFunctionToAllDomainsChecked()
+  auto const rowIndices = m_view->isApplyFunctionChangesToAllChecked()
                               ? m_view->allRows()
                               : m_view->selectedRows();
 
@@ -137,7 +137,7 @@ void FitScriptGeneratorPresenter::handleFunctionRemoved(
 
 void FitScriptGeneratorPresenter::handleFunctionAdded(
     std::string const &function) {
-  auto const rowIndices = m_view->isAddFunctionToAllDomainsChecked()
+  auto const rowIndices = m_view->isApplyFunctionChangesToAllChecked()
                               ? m_view->allRows()
                               : m_view->selectedRows();
 

--- a/qt/widgets/common/src/FitScriptGeneratorPresenter.cpp
+++ b/qt/widgets/common/src/FitScriptGeneratorPresenter.cpp
@@ -156,8 +156,8 @@ void FitScriptGeneratorPresenter::handleEndXChanged() {
 }
 
 void FitScriptGeneratorPresenter::handleSelectionChanged() {
-  m_view->setSimultaneousMode(m_model->getFittingMode() ==
-                              FittingMode::SIMULTANEOUS);
+  auto const fittingMode = m_model->getFittingMode();
+  m_view->setSimultaneousMode(fittingMode == FittingMode::SIMULTANEOUS);
 
   auto const selectedRows = m_view->selectedRows();
   if (!selectedRows.empty()) {

--- a/qt/widgets/common/src/FitScriptGeneratorPresenter.cpp
+++ b/qt/widgets/common/src/FitScriptGeneratorPresenter.cpp
@@ -225,7 +225,10 @@ void FitScriptGeneratorPresenter::handleParameterTieChanged(
   for (auto const &rowIndex : rowIndices) {
     auto const workspaceName = m_view->workspaceName(rowIndex);
     auto const workspaceIndex = m_view->workspaceIndex(rowIndex);
-    m_model->updateParameterTie(workspaceName, workspaceIndex, parameter, tie);
+    auto const equivalentParameter = m_model->getEquivalentParameterForDomain(
+        workspaceName, workspaceIndex, parameter);
+    m_model->updateParameterTie(workspaceName, workspaceIndex,
+                                equivalentParameter, tie);
   }
 
   handleSelectionChanged();

--- a/qt/widgets/common/src/FitScriptGeneratorPresenter.cpp
+++ b/qt/widgets/common/src/FitScriptGeneratorPresenter.cpp
@@ -58,6 +58,9 @@ void FitScriptGeneratorPresenter::notifyPresenter(ViewEvent const &event,
   case ViewEvent::FunctionAdded:
     handleFunctionAdded(arg);
     return;
+  case ViewEvent::FunctionReplaced:
+    handleFunctionReplaced(arg);
+    return;
   case ViewEvent::ParameterChanged:
     handleParameterChanged(arg);
     return;
@@ -151,6 +154,19 @@ void FitScriptGeneratorPresenter::handleFunctionAdded(
     auto const workspaceName = m_view->workspaceName(rowIndex);
     auto const workspaceIndex = m_view->workspaceIndex(rowIndex);
     m_model->addFunction(workspaceName, workspaceIndex, function);
+  }
+}
+
+void FitScriptGeneratorPresenter::handleFunctionReplaced(
+    std::string const &function) {
+  auto const rowIndices = m_view->isApplyFunctionChangesToAllChecked()
+                              ? m_view->allRows()
+                              : m_view->selectedRows();
+
+  for (auto const &rowIndex : rowIndices) {
+    auto const workspaceName = m_view->workspaceName(rowIndex);
+    auto const workspaceIndex = m_view->workspaceIndex(rowIndex);
+    m_model->setFunction(workspaceName, workspaceIndex, function);
   }
 }
 

--- a/qt/widgets/common/src/FitScriptGeneratorPresenter.cpp
+++ b/qt/widgets/common/src/FitScriptGeneratorPresenter.cpp
@@ -73,6 +73,8 @@ void FitScriptGeneratorPresenter::handleRemoveClicked() {
     m_view->removeWorkspaceDomain(workspaceName, workspaceIndex);
     m_model->removeWorkspaceDomain(workspaceName, workspaceIndex);
   }
+
+  handleSelectionChanged();
 }
 
 void FitScriptGeneratorPresenter::handleAddWorkspaceClicked() {
@@ -108,13 +110,16 @@ void FitScriptGeneratorPresenter::handleEndXChanged() {
 }
 
 void FitScriptGeneratorPresenter::handleSelectionChanged() {
-  auto const firstRowIndex = m_view->selectedRows()[0];
+  auto const selectedRows = m_view->selectedRows();
+  if (!selectedRows.empty()) {
+    auto const workspaceName = m_view->workspaceName(selectedRows[0]);
+    auto const workspaceIndex = m_view->workspaceIndex(selectedRows[0]);
 
-  auto const workspaceName = m_view->workspaceName(firstRowIndex);
-  auto const workspaceIndex = m_view->workspaceIndex(firstRowIndex);
-
-  auto const composite = m_model->getFunction(workspaceName, workspaceIndex);
-  m_view->setFunction(composite);
+    auto const composite = m_model->getFunction(workspaceName, workspaceIndex);
+    m_view->setFunction(composite);
+  } else {
+    m_view->clearFunction();
+  }
 }
 
 void FitScriptGeneratorPresenter::handleFunctionRemoved(

--- a/qt/widgets/common/src/FitScriptGeneratorPresenter.cpp
+++ b/qt/widgets/common/src/FitScriptGeneratorPresenter.cpp
@@ -58,6 +58,9 @@ void FitScriptGeneratorPresenter::notifyPresenter(ViewEvent const &event,
   case ViewEvent::FunctionAdded:
     handleFunctionAdded(arg);
     return;
+  case ViewEvent::ParameterChanged:
+    handleParameterChanged(arg);
+    return;
   }
 
   throw std::runtime_error("Failed to notify the FitScriptGeneratorPresenter.");
@@ -145,6 +148,19 @@ void FitScriptGeneratorPresenter::handleFunctionAdded(
     auto const workspaceName = m_view->workspaceName(rowIndex);
     auto const workspaceIndex = m_view->workspaceIndex(rowIndex);
     m_model->addFunction(workspaceName, workspaceIndex, function);
+  }
+}
+
+void FitScriptGeneratorPresenter::handleParameterChanged(
+    std::string const &parameter) {
+  auto const rowIndices = m_view->allRows();
+  auto const newValue = m_view->parameterValue(parameter);
+
+  for (auto const &rowIndex : rowIndices) {
+    auto const workspaceName = m_view->workspaceName(rowIndex);
+    auto const workspaceIndex = m_view->workspaceIndex(rowIndex);
+    m_model->updateParameterValue(workspaceName, workspaceIndex, parameter,
+                                  newValue);
   }
 }
 

--- a/qt/widgets/common/src/FitScriptGeneratorPresenter.cpp
+++ b/qt/widgets/common/src/FitScriptGeneratorPresenter.cpp
@@ -137,8 +137,8 @@ void FitScriptGeneratorPresenter::handleEndXChanged() {
 }
 
 void FitScriptGeneratorPresenter::handleSelectionChanged() {
-  m_view->showMultiDomainPrefix(m_model->getFittingMode() ==
-                                FittingMode::Simultaneous);
+  m_view->setSimultaneousMode(m_model->getFittingMode() ==
+                              FittingMode::Simultaneous);
 
   auto const selectedRows = m_view->selectedRows();
   if (!selectedRows.empty()) {

--- a/qt/widgets/common/src/FitScriptGeneratorPresenter.cpp
+++ b/qt/widgets/common/src/FitScriptGeneratorPresenter.cpp
@@ -5,8 +5,8 @@
 //   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
 // SPDX - License - Identifier: GPL - 3.0 +
 #include "MantidQtWidgets/Common/FitScriptGeneratorPresenter.h"
-#include "MantidQtWidgets/Common/FitScriptGeneratorModel.h"
 #include "MantidQtWidgets/Common/FittingGlobals.h"
+#include "MantidQtWidgets/Common/IFitScriptGeneratorModel.h"
 #include "MantidQtWidgets/Common/IFitScriptGeneratorView.h"
 
 #include "MantidAPI/AnalysisDataService.h"

--- a/qt/widgets/common/src/FitScriptGeneratorPresenter.cpp
+++ b/qt/widgets/common/src/FitScriptGeneratorPresenter.cpp
@@ -61,6 +61,9 @@ void FitScriptGeneratorPresenter::notifyPresenter(ViewEvent const &event,
   case ViewEvent::ParameterChanged:
     handleParameterChanged(arg);
     return;
+  case ViewEvent::AttributeChanged:
+    handleAttributeChanged(arg);
+    return;
   }
 
   throw std::runtime_error("Failed to notify the FitScriptGeneratorPresenter.");
@@ -160,6 +163,19 @@ void FitScriptGeneratorPresenter::handleParameterChanged(
     auto const workspaceName = m_view->workspaceName(rowIndex);
     auto const workspaceIndex = m_view->workspaceIndex(rowIndex);
     m_model->updateParameterValue(workspaceName, workspaceIndex, parameter,
+                                  newValue);
+  }
+}
+
+void FitScriptGeneratorPresenter::handleAttributeChanged(
+    std::string const &attribute) {
+  auto const rowIndices = m_view->allRows();
+  auto const newValue = m_view->attributeValue(attribute);
+
+  for (auto const &rowIndex : rowIndices) {
+    auto const workspaceName = m_view->workspaceName(rowIndex);
+    auto const workspaceIndex = m_view->workspaceIndex(rowIndex);
+    m_model->updateAttributeValue(workspaceName, workspaceIndex, attribute,
                                   newValue);
   }
 }

--- a/qt/widgets/common/src/FitScriptGeneratorPresenter.cpp
+++ b/qt/widgets/common/src/FitScriptGeneratorPresenter.cpp
@@ -79,6 +79,17 @@ void FitScriptGeneratorPresenter::notifyPresenter(ViewEvent const &event,
   throw std::runtime_error("Failed to notify the FitScriptGeneratorPresenter.");
 }
 
+void FitScriptGeneratorPresenter::notifyPresenter(
+    ViewEvent const &event, FittingMode const &fittingMode) {
+  switch (event) {
+  case ViewEvent::FittingModeChanged:
+    handleFittingModeChanged(fittingMode);
+    return;
+  }
+
+  throw std::runtime_error("Failed to notify the FitScriptGeneratorPresenter.");
+}
+
 void FitScriptGeneratorPresenter::openFitScriptGenerator() { m_view->show(); }
 
 void FitScriptGeneratorPresenter::handleRemoveClicked() {
@@ -126,13 +137,14 @@ void FitScriptGeneratorPresenter::handleEndXChanged() {
 }
 
 void FitScriptGeneratorPresenter::handleSelectionChanged() {
+  m_view->showMultiDomainPrefix(m_model->getFittingMode() ==
+                                FittingMode::Simultaneous);
+
   auto const selectedRows = m_view->selectedRows();
   if (!selectedRows.empty()) {
     auto const workspaceName = m_view->workspaceName(selectedRows[0]);
     auto const workspaceIndex = m_view->workspaceIndex(selectedRows[0]);
-
-    auto const function = m_model->getFunction(workspaceName, workspaceIndex);
-    m_view->setFunction(function);
+    m_view->setFunction(m_model->getFunction(workspaceName, workspaceIndex));
   } else {
     m_view->clearFunction();
   }
@@ -216,6 +228,12 @@ void FitScriptGeneratorPresenter::handleParameterTieChanged(
     m_model->updateParameterTie(workspaceName, workspaceIndex, parameter, tie);
   }
 
+  handleSelectionChanged();
+}
+
+void FitScriptGeneratorPresenter::handleFittingModeChanged(
+    FittingMode const &fittingMode) {
+  m_model->setFittingMode(fittingMode);
   handleSelectionChanged();
 }
 

--- a/qt/widgets/common/src/FitScriptGeneratorPresenter.cpp
+++ b/qt/widgets/common/src/FitScriptGeneratorPresenter.cpp
@@ -32,9 +32,12 @@ FitScriptGeneratorPresenter::FitScriptGeneratorPresenter(
 FitScriptGeneratorPresenter::~FitScriptGeneratorPresenter() {}
 
 void FitScriptGeneratorPresenter::notifyPresenter(ViewEvent const &event,
-                                                  std::string const &arg) {
-  if (arg.empty())
-    UNUSED_ARG(arg);
+                                                  std::string const &arg1,
+                                                  std::string const &arg2) {
+  if (arg1.empty())
+    UNUSED_ARG(arg1);
+  if (arg2.empty())
+    UNUSED_ARG(arg2);
 
   switch (event) {
   case ViewEvent::RemoveClicked:
@@ -53,19 +56,22 @@ void FitScriptGeneratorPresenter::notifyPresenter(ViewEvent const &event,
     handleSelectionChanged();
     return;
   case ViewEvent::FunctionRemoved:
-    handleFunctionRemoved(arg);
+    handleFunctionRemoved(arg1);
     return;
   case ViewEvent::FunctionAdded:
-    handleFunctionAdded(arg);
+    handleFunctionAdded(arg1);
     return;
   case ViewEvent::FunctionReplaced:
-    handleFunctionReplaced(arg);
+    handleFunctionReplaced(arg1);
     return;
   case ViewEvent::ParameterChanged:
-    handleParameterChanged(arg);
+    handleParameterChanged(arg1);
     return;
   case ViewEvent::AttributeChanged:
-    handleAttributeChanged(arg);
+    handleAttributeChanged(arg1);
+    return;
+  case ViewEvent::ParameterTieChanged:
+    handleParameterTieChanged(arg1, arg2);
     return;
   }
 
@@ -193,6 +199,17 @@ void FitScriptGeneratorPresenter::handleAttributeChanged(
     auto const workspaceIndex = m_view->workspaceIndex(rowIndex);
     m_model->updateAttributeValue(workspaceName, workspaceIndex, attribute,
                                   newValue);
+  }
+}
+
+void FitScriptGeneratorPresenter::handleParameterTieChanged(
+    std::string const &parameter, std::string const &tie) {
+  auto const rowIndices = m_view->allRows();
+
+  for (auto const &rowIndex : rowIndices) {
+    auto const workspaceName = m_view->workspaceName(rowIndex);
+    auto const workspaceIndex = m_view->workspaceIndex(rowIndex);
+    m_model->updateParameterTie(workspaceName, workspaceIndex, parameter, tie);
   }
 }
 

--- a/qt/widgets/common/src/FitScriptGeneratorPresenter.cpp
+++ b/qt/widgets/common/src/FitScriptGeneratorPresenter.cpp
@@ -184,11 +184,16 @@ void FitScriptGeneratorPresenter::handleFunctionAdded(
     std::string const &function) {
   auto const rowIndices = getRowIndices();
 
-  if (!rowIndices.empty()) {
-    addFunctionForDomains(function, rowIndices);
-  } else {
+  if (rowIndices.empty()) {
     m_view->displayWarning("Data needs to be loaded before adding a function.");
     m_view->clearFunction();
+    return;
+  }
+
+  try {
+    addFunctionForDomains(function, rowIndices);
+  } catch (std::invalid_argument const &ex) {
+    m_view->displayWarning(ex.what());
   }
 }
 

--- a/qt/widgets/common/src/FitScriptGeneratorPresenter.cpp
+++ b/qt/widgets/common/src/FitScriptGeneratorPresenter.cpp
@@ -31,7 +31,11 @@ FitScriptGeneratorPresenter::FitScriptGeneratorPresenter(
 
 FitScriptGeneratorPresenter::~FitScriptGeneratorPresenter() {}
 
-void FitScriptGeneratorPresenter::notifyPresenter(ViewEvent const &event) {
+void FitScriptGeneratorPresenter::notifyPresenter(ViewEvent const &event,
+                                                  std::string const &arg) {
+  if (arg.empty())
+    UNUSED_ARG(arg);
+
   switch (event) {
   case ViewEvent::RemoveClicked:
     handleRemoveClicked();
@@ -44,6 +48,12 @@ void FitScriptGeneratorPresenter::notifyPresenter(ViewEvent const &event) {
     return;
   case ViewEvent::EndXChanged:
     handleEndXChanged();
+    return;
+  case ViewEvent::FunctionRemoved:
+    handleFunctionRemoved(arg);
+    return;
+  case ViewEvent::FunctionAdded:
+    handleFunctionAdded(arg);
     return;
   }
 
@@ -91,6 +101,32 @@ void FitScriptGeneratorPresenter::handleEndXChanged() {
     auto const endX = m_view->endX(selectedRows[0]);
 
     updateEndX(workspaceName, workspaceIndex, endX);
+  }
+}
+
+void FitScriptGeneratorPresenter::handleFunctionRemoved(
+    std::string const &function) {
+  auto const rowIndices = m_view->isAddFunctionToAllDomainsChecked()
+                              ? m_view->allRows()
+                              : m_view->selectedRows();
+
+  for (auto const &rowIndex : rowIndices) {
+    auto const workspaceName = m_view->workspaceName(rowIndex);
+    auto const workspaceIndex = m_view->workspaceIndex(rowIndex);
+    m_model->removeFunction(workspaceName, workspaceIndex, function);
+  }
+}
+
+void FitScriptGeneratorPresenter::handleFunctionAdded(
+    std::string const &function) {
+  auto const rowIndices = m_view->isAddFunctionToAllDomainsChecked()
+                              ? m_view->allRows()
+                              : m_view->selectedRows();
+
+  for (auto const &rowIndex : rowIndices) {
+    auto const workspaceName = m_view->workspaceName(rowIndex);
+    auto const workspaceIndex = m_view->workspaceIndex(rowIndex);
+    m_model->addFunction(workspaceName, workspaceIndex, function);
   }
 }
 

--- a/qt/widgets/common/src/FitScriptGeneratorView.cpp
+++ b/qt/widgets/common/src/FitScriptGeneratorView.cpp
@@ -287,10 +287,15 @@ bool FitScriptGeneratorView::isApplyFunctionChangesToAllChecked() const {
 
 void FitScriptGeneratorView::clearFunction() { m_functionTreeView->clear(); }
 
-void FitScriptGeneratorView::showMultiDomainPrefix(bool showPrefix) {
-  m_dataTable->setFunctionPrefixVisible(showPrefix);
+void FitScriptGeneratorView::setSimultaneousMode(bool simultaneousMode) {
+  m_dataTable->setFunctionPrefixVisible(simultaneousMode);
   m_functionTreeView->setMultiDomainFunctionPrefix(
-      showPrefix ? m_dataTable->selectedDomainFunctionPrefix() : "");
+      simultaneousMode ? m_dataTable->selectedDomainFunctionPrefix() : "");
+
+  if (simultaneousMode)
+    m_functionTreeView->showGlobals();
+  else
+    m_functionTreeView->hideGlobals();
 }
 
 void FitScriptGeneratorView::setFunction(IFunction_sptr const &function) const {

--- a/qt/widgets/common/src/FitScriptGeneratorView.cpp
+++ b/qt/widgets/common/src/FitScriptGeneratorView.cpp
@@ -88,6 +88,8 @@ void FitScriptGeneratorView::connectUiSignals() {
           SLOT(onAttributeChanged(const QString &)));
   connect(m_functionTreeView.get(), SIGNAL(copyToClipboardRequest()), this,
           SLOT(onCopyFunctionToClipboard()));
+  connect(m_functionTreeView.get(), SIGNAL(functionHelpRequest()), this,
+          SLOT(onFunctionHelpRequested()));
 
   /// Disconnected because it causes a crash when selecting a table row while
   /// editing a parameters value. This is because selecting a different row will
@@ -178,6 +180,12 @@ void FitScriptGeneratorView::onCopyFunctionToClipboard() {
   if (auto const function = m_functionTreeView->getSelectedFunction())
     QApplication::clipboard()->setText(
         QString::fromStdString(function->asString()));
+}
+
+void FitScriptGeneratorView::onFunctionHelpRequested() {
+  if (auto const function = m_functionTreeView->getSelectedFunction())
+    m_functionTreeView->showFunctionHelp(
+        QString::fromStdString(function->name()));
 }
 
 std::string FitScriptGeneratorView::workspaceName(FitDomainIndex index) const {

--- a/qt/widgets/common/src/FitScriptGeneratorView.cpp
+++ b/qt/widgets/common/src/FitScriptGeneratorView.cpp
@@ -40,11 +40,12 @@ std::vector<std::string> convertToStdVector(QStringList const &qList) {
   return vec;
 }
 
-QStringList convertToQStringList(std::vector<GlobalParameter> const &vec) {
+QStringList convertToQStringList(
+    std::vector<MantidQt::MantidWidgets::GlobalParameter> const &vec) {
   QStringList qList;
   qList.reserve(static_cast<int>(vec.size()));
   std::transform(vec.cbegin(), vec.cend(), std::back_inserter(qList),
-                 [](GlobalParameter const &element) {
+                 [](MantidQt::MantidWidgets::GlobalParameter const &element) {
                    return QString::fromStdString(element.m_parameter);
                  });
   return qList;

--- a/qt/widgets/common/src/FitScriptGeneratorView.cpp
+++ b/qt/widgets/common/src/FitScriptGeneratorView.cpp
@@ -77,6 +77,9 @@ void FitScriptGeneratorView::connectUiSignals() {
           this, SLOT(onFunctionAdded(const QString &)));
   connect(m_functionTreeView.get(), SIGNAL(parameterChanged(const QString &)),
           this, SLOT(onParameterChanged(const QString &)));
+  connect(m_functionTreeView.get(),
+          SIGNAL(attributePropertyChanged(const QString &)), this,
+          SLOT(onAttributeChanged(const QString &)));
 }
 
 void FitScriptGeneratorView::setFitBrowserOptions(
@@ -145,6 +148,11 @@ void FitScriptGeneratorView::onParameterChanged(QString const &parameter) {
                                parameter.toStdString());
 }
 
+void FitScriptGeneratorView::onAttributeChanged(QString const &attribute) {
+  m_presenter->notifyPresenter(ViewEvent::AttributeChanged,
+                               attribute.toStdString());
+}
+
 std::string FitScriptGeneratorView::workspaceName(FitDomainIndex index) const {
   return m_dataTable->workspaceName(index);
 }
@@ -173,6 +181,11 @@ std::vector<FitDomainIndex> FitScriptGeneratorView::selectedRows() const {
 double
 FitScriptGeneratorView::parameterValue(std::string const &parameter) const {
   return m_functionTreeView->getParameter(QString::fromStdString(parameter));
+}
+
+IFunction::Attribute
+FitScriptGeneratorView::attributeValue(std::string const &attribute) const {
+  return m_functionTreeView->getAttribute(QString::fromStdString(attribute));
 }
 
 void FitScriptGeneratorView::removeWorkspaceDomain(

--- a/qt/widgets/common/src/FitScriptGeneratorView.cpp
+++ b/qt/widgets/common/src/FitScriptGeneratorView.cpp
@@ -200,6 +200,8 @@ bool FitScriptGeneratorView::isAddFunctionToAllDomainsChecked() const {
   return m_ui.ckAddFunctionForAllDomains->isChecked();
 }
 
+void FitScriptGeneratorView::clearFunction() { m_functionTreeView->clear(); }
+
 void FitScriptGeneratorView::setFunction(
     CompositeFunction_sptr composite) const {
   if (composite->nFunctions() > 1)

--- a/qt/widgets/common/src/FitScriptGeneratorView.cpp
+++ b/qt/widgets/common/src/FitScriptGeneratorView.cpp
@@ -6,6 +6,7 @@
 // SPDX - License - Identifier: GPL - 3.0 +
 #include "MantidQtWidgets/Common/FitScriptGeneratorView.h"
 #include "MantidQtWidgets/Common/FitScriptGeneratorDataTable.h"
+#include "MantidQtWidgets/Common/FittingGlobals.h"
 #include "MantidQtWidgets/Common/IFitScriptGeneratorPresenter.h"
 #include "MantidQtWidgets/Common/QtPropertyBrowser/DoubleDialogEditor.h"
 #include "MantidQtWidgets/Common/QtPropertyBrowser/qttreepropertybrowser.h"
@@ -303,6 +304,11 @@ void FitScriptGeneratorView::setFunction(IFunction_sptr const &function) const {
     m_functionTreeView->setFunction(function);
   else
     m_functionTreeView->clear();
+}
+
+void FitScriptGeneratorView::setGlobalTies(
+    std::vector<GlobalTie> const &globalTies) {
+  m_functionTreeView->setGlobalTies(globalTies);
 }
 
 void FitScriptGeneratorView::displayWarning(std::string const &message) {

--- a/qt/widgets/common/src/FitScriptGeneratorView.cpp
+++ b/qt/widgets/common/src/FitScriptGeneratorView.cpp
@@ -37,7 +37,6 @@ namespace MantidQt {
 namespace MantidWidgets {
 
 using ColumnIndex = FitScriptGeneratorDataTable::ColumnIndex;
-using FittingType = FitOptionsBrowser::FittingType;
 using ViewEvent = IFitScriptGeneratorView::Event;
 
 FitScriptGeneratorView::FitScriptGeneratorView(
@@ -47,14 +46,12 @@ FitScriptGeneratorView::FitScriptGeneratorView(
       m_dataTable(std::make_unique<FitScriptGeneratorDataTable>()),
       m_functionTreeView(std::make_unique<FunctionTreeView>(nullptr, true)),
       m_fitOptionsBrowser(std::make_unique<FitOptionsBrowser>(
-          nullptr, FittingType::SimultaneousAndSequential)) {
+          nullptr, FittingMode::SimultaneousAndSequential)) {
   m_ui.setupUi(this);
 
   m_ui.fDataTable->layout()->addWidget(m_dataTable.get());
   m_ui.splitter->addWidget(m_functionTreeView.get());
   m_ui.splitter->addWidget(m_fitOptionsBrowser.get());
-
-  m_functionTreeView->setMultiDomainFunctionPrefix("f0.");
 
   setFitBrowserOptions(fitOptions);
   connectUiSignals();
@@ -96,6 +93,11 @@ void FitScriptGeneratorView::connectUiSignals() {
   connect(m_functionTreeView.get(), SIGNAL(functionHelpRequest()), this,
           SLOT(onFunctionHelpRequested()));
 
+  connect(m_fitOptionsBrowser.get(), SIGNAL(changedToSequentialFitting()), this,
+          SLOT(onChangeToSequentialFitting()));
+  connect(m_fitOptionsBrowser.get(), SIGNAL(changedToSimultaneousFitting()),
+          this, SLOT(onChangeToSimultaneousFitting()));
+
   /// Disconnected because it causes a crash when selecting a table row while
   /// editing a parameters value. This is because selecting a different row will
   /// change the current function in the FunctionTreeView. The closeEditor slot
@@ -121,9 +123,9 @@ void FitScriptGeneratorView::setFitBrowserOption(QString const &name,
 
 void FitScriptGeneratorView::setFittingType(QString const &fitType) {
   if (fitType == "Sequential")
-    m_fitOptionsBrowser->setCurrentFittingType(FittingType::Sequential);
+    m_fitOptionsBrowser->setCurrentFittingType(FittingMode::Sequential);
   else if (fitType == "Simultaneous")
-    m_fitOptionsBrowser->setCurrentFittingType(FittingType::Simultaneous);
+    m_fitOptionsBrowser->setCurrentFittingType(FittingMode::Simultaneous);
   else
     throw std::invalid_argument("Invalid fitting type '" +
                                 fitType.toStdString() + "' provided.");
@@ -132,6 +134,8 @@ void FitScriptGeneratorView::setFittingType(QString const &fitType) {
 void FitScriptGeneratorView::subscribePresenter(
     IFitScriptGeneratorPresenter *presenter) {
   m_presenter = presenter;
+  m_presenter->notifyPresenter(ViewEvent::FittingModeChanged,
+                               m_fitOptionsBrowser->getCurrentFittingType());
 }
 
 void FitScriptGeneratorView::onRemoveClicked() {
@@ -197,6 +201,16 @@ void FitScriptGeneratorView::onFunctionHelpRequested() {
   if (auto const function = m_functionTreeView->getSelectedFunction())
     m_functionTreeView->showFunctionHelp(
         QString::fromStdString(function->name()));
+}
+
+void FitScriptGeneratorView::onChangeToSequentialFitting() {
+  m_presenter->notifyPresenter(ViewEvent::FittingModeChanged,
+                               FittingMode::Sequential);
+}
+
+void FitScriptGeneratorView::onChangeToSimultaneousFitting() {
+  m_presenter->notifyPresenter(ViewEvent::FittingModeChanged,
+                               FittingMode::Simultaneous);
 }
 
 std::string FitScriptGeneratorView::workspaceName(FitDomainIndex index) const {
@@ -273,10 +287,13 @@ bool FitScriptGeneratorView::isApplyFunctionChangesToAllChecked() const {
 
 void FitScriptGeneratorView::clearFunction() { m_functionTreeView->clear(); }
 
-void FitScriptGeneratorView::setFunction(IFunction_sptr const &function) const {
+void FitScriptGeneratorView::showMultiDomainPrefix(bool showPrefix) {
+  m_dataTable->setFunctionPrefixVisible(showPrefix);
   m_functionTreeView->setMultiDomainFunctionPrefix(
-      m_dataTable->selectedDomainFunctionPrefix());
+      showPrefix ? m_dataTable->selectedDomainFunctionPrefix() : "");
+}
 
+void FitScriptGeneratorView::setFunction(IFunction_sptr const &function) const {
   if (function)
     m_functionTreeView->setFunction(function);
   else

--- a/qt/widgets/common/src/FitScriptGeneratorView.cpp
+++ b/qt/widgets/common/src/FitScriptGeneratorView.cpp
@@ -75,6 +75,8 @@ void FitScriptGeneratorView::connectUiSignals() {
           SLOT(onFunctionRemoved(const QString &)));
   connect(m_functionTreeView.get(), SIGNAL(functionAdded(const QString &)),
           this, SLOT(onFunctionAdded(const QString &)));
+  connect(m_functionTreeView.get(), SIGNAL(parameterChanged(const QString &)),
+          this, SLOT(onParameterChanged(const QString &)));
 }
 
 void FitScriptGeneratorView::setFitBrowserOptions(
@@ -138,6 +140,11 @@ void FitScriptGeneratorView::onFunctionAdded(QString const &function) {
                                function.toStdString());
 }
 
+void FitScriptGeneratorView::onParameterChanged(QString const &parameter) {
+  m_presenter->notifyPresenter(ViewEvent::ParameterChanged,
+                               parameter.toStdString());
+}
+
 std::string FitScriptGeneratorView::workspaceName(FitDomainIndex index) const {
   return m_dataTable->workspaceName(index);
 }
@@ -161,6 +168,11 @@ std::vector<FitDomainIndex> FitScriptGeneratorView::allRows() const {
 
 std::vector<FitDomainIndex> FitScriptGeneratorView::selectedRows() const {
   return m_dataTable->selectedRows();
+}
+
+double
+FitScriptGeneratorView::parameterValue(std::string const &parameter) const {
+  return m_functionTreeView->getParameter(QString::fromStdString(parameter));
 }
 
 void FitScriptGeneratorView::removeWorkspaceDomain(

--- a/qt/widgets/common/src/FitScriptGeneratorView.cpp
+++ b/qt/widgets/common/src/FitScriptGeneratorView.cpp
@@ -282,8 +282,8 @@ FitScriptGeneratorView::getDialogWorkspaceIndices() const {
 
 void FitScriptGeneratorView::resetSelection() { m_dataTable->resetSelection(); }
 
-bool FitScriptGeneratorView::isApplyFunctionChangesToAllChecked() const {
-  return m_ui.ckApplyFunctionChangesToAll->isChecked();
+bool FitScriptGeneratorView::isAddRemoveFunctionForAllChecked() const {
+  return m_ui.ckAddRemoveFunctionForAllDatasets->isChecked();
 }
 
 void FitScriptGeneratorView::clearFunction() { m_functionTreeView->clear(); }

--- a/qt/widgets/common/src/FitScriptGeneratorView.cpp
+++ b/qt/widgets/common/src/FitScriptGeneratorView.cpp
@@ -75,20 +75,27 @@ void FitScriptGeneratorView::connectUiSignals() {
           SLOT(onItemPressed()));
 
   connect(m_functionTreeView.get(),
-          SIGNAL(functionRemovedString(const QString &)), this,
-          SLOT(onFunctionRemoved(const QString &)));
-  connect(m_functionTreeView.get(), SIGNAL(functionAdded(const QString &)),
+          SIGNAL(functionRemovedString(QString const &)), this,
+          SLOT(onFunctionRemoved(QString const &)));
+  connect(m_functionTreeView.get(), SIGNAL(functionAdded(QString const &)),
           this, SLOT(onFunctionAdded(const QString &)));
-  connect(m_functionTreeView.get(), SIGNAL(functionReplaced(const QString &)),
-          this, SLOT(onFunctionReplaced(const QString &)));
-  connect(m_functionTreeView.get(), SIGNAL(parameterChanged(const QString &)),
-          this, SLOT(onParameterChanged(const QString &)));
+  connect(m_functionTreeView.get(), SIGNAL(functionReplaced(QString const &)),
+          this, SLOT(onFunctionReplaced(QString const &)));
+  connect(m_functionTreeView.get(), SIGNAL(parameterChanged(QString const &)),
+          this, SLOT(onParameterChanged(QString const &)));
   connect(m_functionTreeView.get(),
-          SIGNAL(attributePropertyChanged(const QString &)), this,
-          SLOT(onAttributeChanged(const QString &)));
+          SIGNAL(attributePropertyChanged(QString const &)), this,
+          SLOT(onAttributeChanged(QString const &)));
   connect(m_functionTreeView.get(),
-          SIGNAL(parameterTieChanged(const QString &, const QString &)), this,
-          SLOT(onParameterTieChanged(const QString &, const QString &)));
+          SIGNAL(parameterTieChanged(QString const &, QString const &)), this,
+          SLOT(onParameterTieChanged(QString const &, QString const &)));
+  connect(m_functionTreeView.get(),
+          SIGNAL(parameterConstraintRemoved(QString const &)), this,
+          SLOT(onParameterConstraintRemoved(QString const &)));
+  connect(m_functionTreeView.get(),
+          SIGNAL(parameterConstraintAdded(QString const &, QString const &)),
+          this,
+          SLOT(onParameterConstraintChanged(QString const &, QString const &)));
   connect(m_functionTreeView.get(), SIGNAL(copyToClipboardRequest()), this,
           SLOT(onCopyFunctionToClipboard()));
   connect(m_functionTreeView.get(), SIGNAL(functionHelpRequest()), this,
@@ -190,6 +197,19 @@ void FitScriptGeneratorView::onParameterTieChanged(QString const &parameter,
                                                    QString const &tie) {
   m_presenter->notifyPresenter(ViewEvent::ParameterTieChanged,
                                parameter.toStdString(), tie.toStdString());
+}
+
+void FitScriptGeneratorView::onParameterConstraintRemoved(
+    QString const &parameter) {
+  m_presenter->notifyPresenter(ViewEvent::ParameterConstraintRemoved,
+                               parameter.toStdString());
+}
+
+void FitScriptGeneratorView::onParameterConstraintChanged(
+    QString const &functionIndex, QString const &constraint) {
+  m_presenter->notifyPresenter(ViewEvent::ParameterConstraintChanged,
+                               functionIndex.toStdString(),
+                               constraint.toStdString());
 }
 
 void FitScriptGeneratorView::onCopyFunctionToClipboard() {

--- a/qt/widgets/common/src/FitScriptGeneratorView.cpp
+++ b/qt/widgets/common/src/FitScriptGeneratorView.cpp
@@ -86,6 +86,9 @@ void FitScriptGeneratorView::connectUiSignals() {
   connect(m_functionTreeView.get(),
           SIGNAL(attributePropertyChanged(const QString &)), this,
           SLOT(onAttributeChanged(const QString &)));
+  connect(m_functionTreeView.get(),
+          SIGNAL(parameterTieChanged(const QString &, const QString &)), this,
+          SLOT(onParameterTieChanged(const QString &, const QString &)));
   connect(m_functionTreeView.get(), SIGNAL(copyToClipboardRequest()), this,
           SLOT(onCopyFunctionToClipboard()));
   connect(m_functionTreeView.get(), SIGNAL(functionHelpRequest()), this,
@@ -174,6 +177,12 @@ void FitScriptGeneratorView::onParameterChanged(QString const &parameter) {
 void FitScriptGeneratorView::onAttributeChanged(QString const &attribute) {
   m_presenter->notifyPresenter(ViewEvent::AttributeChanged,
                                attribute.toStdString());
+}
+
+void FitScriptGeneratorView::onParameterTieChanged(QString const &parameter,
+                                                   QString const &tie) {
+  m_presenter->notifyPresenter(ViewEvent::ParameterTieChanged,
+                               parameter.toStdString(), tie.toStdString());
 }
 
 void FitScriptGeneratorView::onCopyFunctionToClipboard() {

--- a/qt/widgets/common/src/FitScriptGeneratorView.cpp
+++ b/qt/widgets/common/src/FitScriptGeneratorView.cpp
@@ -7,6 +7,8 @@
 #include "MantidQtWidgets/Common/FitScriptGeneratorView.h"
 #include "MantidQtWidgets/Common/FitScriptGeneratorDataTable.h"
 #include "MantidQtWidgets/Common/IFitScriptGeneratorPresenter.h"
+#include "MantidQtWidgets/Common/QtPropertyBrowser/DoubleDialogEditor.h"
+#include "MantidQtWidgets/Common/QtPropertyBrowser/qttreepropertybrowser.h"
 
 #include "MantidAPI/MatrixWorkspace.h"
 
@@ -80,6 +82,14 @@ void FitScriptGeneratorView::connectUiSignals() {
   connect(m_functionTreeView.get(),
           SIGNAL(attributePropertyChanged(const QString &)), this,
           SLOT(onAttributeChanged(const QString &)));
+
+  /// Disconnected because it causes a crash when selecting a table row while
+  /// editing a parameters value. This is because selecting a different row will
+  /// change the current function in the FunctionTreeView. The closeEditor slot
+  /// is then called after this, but the memory location of the old function is
+  /// now a nullptr so there is a read access violation.
+  disconnect(m_functionTreeView->doubleEditorFactory(), SIGNAL(closeEditor()),
+             m_functionTreeView->treeBrowser(), SLOT(closeEditor()));
 }
 
 void FitScriptGeneratorView::setFitBrowserOptions(

--- a/qt/widgets/common/src/FitScriptGeneratorView.cpp
+++ b/qt/widgets/common/src/FitScriptGeneratorView.cpp
@@ -273,15 +273,12 @@ bool FitScriptGeneratorView::isApplyFunctionChangesToAllChecked() const {
 
 void FitScriptGeneratorView::clearFunction() { m_functionTreeView->clear(); }
 
-void FitScriptGeneratorView::setFunction(
-    CompositeFunction_sptr composite) const {
+void FitScriptGeneratorView::setFunction(IFunction_sptr const &function) const {
   m_functionTreeView->setMultiDomainFunctionPrefix(
       m_dataTable->selectedDomainFunctionPrefix());
 
-  if (composite->nFunctions() > 1)
-    m_functionTreeView->setFunction(composite);
-  else if (composite->nFunctions() == 1)
-    m_functionTreeView->setFunction(composite->getFunction(0));
+  if (function)
+    m_functionTreeView->setFunction(function);
   else
     m_functionTreeView->clear();
 }

--- a/qt/widgets/common/src/FitScriptGeneratorView.cpp
+++ b/qt/widgets/common/src/FitScriptGeneratorView.cpp
@@ -54,6 +54,8 @@ FitScriptGeneratorView::FitScriptGeneratorView(
   m_ui.splitter->addWidget(m_functionTreeView.get());
   m_ui.splitter->addWidget(m_fitOptionsBrowser.get());
 
+  m_functionTreeView->setMultiDomainFunctionPrefix("f0.");
+
   setFitBrowserOptions(fitOptions);
   connectUiSignals();
 }
@@ -273,6 +275,9 @@ void FitScriptGeneratorView::clearFunction() { m_functionTreeView->clear(); }
 
 void FitScriptGeneratorView::setFunction(
     CompositeFunction_sptr composite) const {
+  m_functionTreeView->setMultiDomainFunctionPrefix(
+      m_dataTable->selectedDomainFunctionPrefix());
+
   if (composite->nFunctions() > 1)
     m_functionTreeView->setFunction(composite);
   else if (composite->nFunctions() == 1)

--- a/qt/widgets/common/src/FitScriptGeneratorView.cpp
+++ b/qt/widgets/common/src/FitScriptGeneratorView.cpp
@@ -67,6 +67,8 @@ void FitScriptGeneratorView::connectUiSignals() {
           SLOT(onAddWorkspaceClicked()));
   connect(m_dataTable.get(), SIGNAL(cellChanged(int, int)), this,
           SLOT(onCellChanged(int, int)));
+  connect(m_dataTable.get(), SIGNAL(itemPressed(QTableWidgetItem *)), this,
+          SLOT(onItemPressed()));
 
   connect(m_functionTreeView.get(),
           SIGNAL(functionRemovedString(const QString &)), this,
@@ -120,6 +122,10 @@ void FitScriptGeneratorView::onCellChanged(int row, int column) {
     m_presenter->notifyPresenter(ViewEvent::StartXChanged);
   else if (column == ColumnIndex::EndX)
     m_presenter->notifyPresenter(ViewEvent::EndXChanged);
+}
+
+void FitScriptGeneratorView::onItemPressed() {
+  m_presenter->notifyPresenter(ViewEvent::SelectionChanged);
 }
 
 void FitScriptGeneratorView::onFunctionRemoved(QString const &function) {
@@ -192,6 +198,16 @@ void FitScriptGeneratorView::resetSelection() { m_dataTable->resetSelection(); }
 
 bool FitScriptGeneratorView::isAddFunctionToAllDomainsChecked() const {
   return m_ui.ckAddFunctionForAllDomains->isChecked();
+}
+
+void FitScriptGeneratorView::setFunction(
+    CompositeFunction_sptr composite) const {
+  if (composite->nFunctions() > 1)
+    m_functionTreeView->setFunction(composite);
+  else if (composite->nFunctions() == 1)
+    m_functionTreeView->setFunction(composite->getFunction(0));
+  else
+    m_functionTreeView->clear();
 }
 
 void FitScriptGeneratorView::displayWarning(std::string const &message) {

--- a/qt/widgets/common/src/FitScriptGeneratorView.cpp
+++ b/qt/widgets/common/src/FitScriptGeneratorView.cpp
@@ -89,8 +89,8 @@ void FitScriptGeneratorView::connectUiSignals() {
           SLOT(onAddWorkspaceClicked()));
   connect(m_dataTable.get(), SIGNAL(cellChanged(int, int)), this,
           SLOT(onCellChanged(int, int)));
-  connect(m_dataTable.get(), SIGNAL(itemPressed(QTableWidgetItem *)), this,
-          SLOT(onItemPressed()));
+  connect(m_dataTable.get(), SIGNAL(itemSelectionChanged()), this,
+          SLOT(onItemSelected()));
 
   connect(m_functionTreeView.get(),
           SIGNAL(functionRemovedString(QString const &)), this,
@@ -184,7 +184,7 @@ void FitScriptGeneratorView::onCellChanged(int row, int column) {
     m_presenter->notifyPresenter(ViewEvent::EndXChanged);
 }
 
-void FitScriptGeneratorView::onItemPressed() {
+void FitScriptGeneratorView::onItemSelected() {
   m_presenter->notifyPresenter(ViewEvent::SelectionChanged);
 }
 

--- a/qt/widgets/common/src/FitScriptGeneratorView.cpp
+++ b/qt/widgets/common/src/FitScriptGeneratorView.cpp
@@ -17,7 +17,7 @@
 #include <iterator>
 
 #include <QApplication>
-#include <QClipBoard>
+#include <QClipboard>
 #include <QMessageBox>
 
 namespace {

--- a/qt/widgets/common/src/FitScriptGeneratorView.cpp
+++ b/qt/widgets/common/src/FitScriptGeneratorView.cpp
@@ -196,8 +196,8 @@ FitScriptGeneratorView::getDialogWorkspaceIndices() const {
 
 void FitScriptGeneratorView::resetSelection() { m_dataTable->resetSelection(); }
 
-bool FitScriptGeneratorView::isAddFunctionToAllDomainsChecked() const {
-  return m_ui.ckAddFunctionForAllDomains->isChecked();
+bool FitScriptGeneratorView::isApplyFunctionChangesToAllChecked() const {
+  return m_ui.ckApplyFunctionChangesToAll->isChecked();
 }
 
 void FitScriptGeneratorView::clearFunction() { m_functionTreeView->clear(); }

--- a/qt/widgets/common/src/FittingGlobals.cpp
+++ b/qt/widgets/common/src/FittingGlobals.cpp
@@ -1,0 +1,16 @@
+// Mantid Repository : https://github.com/mantidproject/mantid
+//
+// Copyright &copy; 2020 ISIS Rutherford Appleton Laboratory UKRI,
+//   NScD Oak Ridge National Laboratory, European Spallation Source,
+//   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+// SPDX - License - Identifier: GPL - 3.0 +
+#include "MantidQtWidgets/Common/FittingGlobals.h"
+
+namespace MantidQt {
+namespace MantidWidgets {
+
+GlobalTie::GlobalTie(std::string const &parameter, std::string const &tie)
+    : m_parameter(parameter), m_tie(tie) {}
+
+} // namespace MantidWidgets
+} // namespace MantidQt

--- a/qt/widgets/common/src/FittingGlobals.cpp
+++ b/qt/widgets/common/src/FittingGlobals.cpp
@@ -12,5 +12,13 @@ namespace MantidWidgets {
 GlobalTie::GlobalTie(std::string const &parameter, std::string const &tie)
     : m_parameter(parameter), m_tie(tie) {}
 
+std::string GlobalTie::removeTopIndex(std::string const &parameter) const {
+  auto result = parameter;
+  auto const firstDotIndex = result.find(".");
+  if (firstDotIndex != std::string::npos)
+    result.erase(0, firstDotIndex + 1);
+  return result;
+}
+
 } // namespace MantidWidgets
 } // namespace MantidQt

--- a/qt/widgets/common/src/FittingGlobals.cpp
+++ b/qt/widgets/common/src/FittingGlobals.cpp
@@ -12,13 +12,5 @@ namespace MantidWidgets {
 GlobalTie::GlobalTie(std::string const &parameter, std::string const &tie)
     : m_parameter(parameter), m_tie(tie) {}
 
-std::string GlobalTie::removeTopIndex(std::string const &parameter) const {
-  auto result = parameter;
-  auto const firstDotIndex = result.find(".");
-  if (firstDotIndex != std::string::npos)
-    result.erase(0, firstDotIndex + 1);
-  return result;
-}
-
 } // namespace MantidWidgets
 } // namespace MantidQt

--- a/qt/widgets/common/src/FittingGlobals.cpp
+++ b/qt/widgets/common/src/FittingGlobals.cpp
@@ -9,6 +9,9 @@
 namespace MantidQt {
 namespace MantidWidgets {
 
+GlobalParameter::GlobalParameter(std::string const &parameter)
+    : m_parameter(parameter) {}
+
 GlobalTie::GlobalTie(std::string const &parameter, std::string const &tie)
     : m_parameter(parameter), m_tie(tie) {}
 

--- a/qt/widgets/common/src/FunctionBrowser/FunctionBrowserUtils.cpp
+++ b/qt/widgets/common/src/FunctionBrowser/FunctionBrowserUtils.cpp
@@ -101,8 +101,7 @@ splitConstraintString(const QString &constraint) {
     try // find position of the parameter name in expression
     {
       boost::lexical_cast<double>(expr[1].name());
-    }
-    catch (...) {
+    } catch (...) {
       paramPos = 1;
     }
     std::string op = expr[1].operator_name();

--- a/qt/widgets/common/src/FunctionBrowser/FunctionBrowserUtils.cpp
+++ b/qt/widgets/common/src/FunctionBrowser/FunctionBrowserUtils.cpp
@@ -7,6 +7,8 @@
 #include "MantidQtWidgets/Common/FunctionBrowser/FunctionBrowserUtils.h"
 #include "MantidAPI/CompositeFunction.h"
 #include "MantidAPI/Expression.h"
+
+#include <boost/algorithm/string.hpp>
 #include <boost/lexical_cast.hpp>
 
 namespace MantidQt {
@@ -121,6 +123,32 @@ splitConstraintString(const QString &constraint) {
   }
   return std::make_pair(paramName,
                         std::make_pair(lowerBoundStr, upperBoundStr));
+}
+
+bool isNumber(std::string const &str) {
+  return !str.empty() &&
+         str.find_first_not_of("0123456789.-") == std::string::npos;
+}
+
+std::vector<std::string> splitStringBy(std::string const &str,
+                                       std::string const &delimiter) {
+  std::vector<std::string> subStrings;
+  boost::split(subStrings, str, boost::is_any_of(delimiter));
+  subStrings.erase(std::remove_if(subStrings.begin(), subStrings.end(),
+                                  [](std::string const &subString) {
+                                    return subString.empty();
+                                  }),
+                   subStrings.cend());
+  return subStrings;
+}
+
+std::size_t getFunctionIndexAt(std::string const &parameter,
+                               std::size_t const &index) {
+  auto subStrings = splitStringBy(parameter, "f.");
+  if (index < subStrings.size())
+    return std::stoull(subStrings[index]);
+
+  throw std::invalid_argument("Incorrect function index provided.");
 }
 
 } // namespace MantidWidgets

--- a/qt/widgets/common/src/FunctionBrowser/FunctionBrowserUtils.cpp
+++ b/qt/widgets/common/src/FunctionBrowser/FunctionBrowserUtils.cpp
@@ -101,7 +101,8 @@ splitConstraintString(const QString &constraint) {
     try // find position of the parameter name in expression
     {
       boost::lexical_cast<double>(expr[1].name());
-    } catch (...) {
+    }
+    catch (...) {
       paramPos = 1;
     }
     std::string op = expr[1].operator_name();
@@ -149,11 +150,14 @@ std::vector<std::string> splitStringBy(std::string const &str,
 
 std::size_t getFunctionIndexAt(std::string const &parameter,
                                std::size_t const &index) {
-  auto subStrings = splitStringBy(parameter, "f.");
-  if (index < subStrings.size())
-    return std::stoull(subStrings[index]);
+  auto const subStrings = splitStringBy(parameter, ".");
+  if (index < subStrings.size()) {
+    auto const functionIndex = splitStringBy(subStrings[index], "f");
+    if (functionIndex.size() == 1 && isNumber(functionIndex[0]))
+      return std::stoull(functionIndex[0]);
+  }
 
-  throw std::invalid_argument("Incorrect function index provided.");
+  throw std::invalid_argument("No function index was found.");
 }
 
 } // namespace MantidWidgets

--- a/qt/widgets/common/src/FunctionBrowser/FunctionBrowserUtils.cpp
+++ b/qt/widgets/common/src/FunctionBrowser/FunctionBrowserUtils.cpp
@@ -63,6 +63,11 @@ std::pair<QString, int> splitFunctionPrefix(const QString &prefix) {
 }
 
 std::pair<QString, std::pair<QString, QString>>
+splitConstraintString(const std::string &constraint) {
+  return splitConstraintString(QString::fromStdString(constraint));
+}
+
+std::pair<QString, std::pair<QString, QString>>
 splitConstraintString(const QString &constraint) {
   std::pair<QString, std::pair<QString, QString>> error;
   if (constraint.isEmpty())

--- a/qt/widgets/common/src/FunctionTreeView.cpp
+++ b/qt/widgets/common/src/FunctionTreeView.cpp
@@ -729,8 +729,9 @@ void FunctionTreeView::addAttributeAndParameterProperties(
         addGlobalParameterTie(ap.prop, name.toStdString(), parentComposite,
                               parentIndex);
 
-      if (auto c = fun->getConstraint(i)) {
-        addConstraintProperties(ap.prop, QString::fromStdString(c->asString()));
+      if (const auto constraint = fun->getConstraint(i)) {
+        addConstraintProperties(ap.prop,
+                                QString::fromStdString(constraint->asString()));
       }
     }
   }

--- a/qt/widgets/common/src/FunctionTreeView.cpp
+++ b/qt/widgets/common/src/FunctionTreeView.cpp
@@ -68,6 +68,16 @@ QString removePrefix(QString &param) {
     return param;
   }
 }
+
+bool isTieConstant(std::string const &tie) {
+  return !tie.empty() &&
+         tie.find_first_not_of("0123456789.-") == std::string::npos;
+}
+
+bool containsOneOf(std::string const &str, std::string const &delimiters) {
+  return !str.empty() && str.find_first_of(delimiters) != std::string::npos;
+}
+
 // These attributes require the function to be fully reconstructed, as a
 // different number of properties will be required
 const std::vector<QString> REQUIRESRECONSTRUCTIONATTRIBUTES = {QString("n")};
@@ -1048,7 +1058,7 @@ void FunctionTreeView::addTieProperty(QtProperty *prop, const QString &tie) {
   // Create and add a QtProperty for the tie.
   m_tieManager->blockSignals(true);
   QtProperty *tieProp = m_tieManager->addProperty("Tie");
-  m_tieManager->setValue(tieProp, tie);
+  m_tieManager->setValue(tieProp, getFullTie(tie));
   addProperty(prop, tieProp);
   m_tieManager->blockSignals(false);
 
@@ -1059,6 +1069,19 @@ void FunctionTreeView::addTieProperty(QtProperty *prop, const QString &tie) {
   atie.paramName = parName;
   atie.tieProp = tieProp;
   m_ties.insert(funProp, atie);
+}
+
+/**
+ * Returns the full tie to add as a Tie property. This will add the
+ * m_multiDomainFunctionPrefix to the start if we are using multiple datasets.
+ * @param tie :: The original tie.
+ * @returns The full tue to use as a tie property.
+ */
+QString FunctionTreeView::getFullTie(const QString &tie) const {
+  if (!isTieConstant(tie.toStdString()) &&
+      !containsOneOf(tie.toStdString(), "="))
+    return m_multiDomainFunctionPrefix + tie;
+  return tie;
 }
 
 /**

--- a/qt/widgets/common/src/FunctionTreeView.cpp
+++ b/qt/widgets/common/src/FunctionTreeView.cpp
@@ -778,7 +778,7 @@ void FunctionTreeView::addParameterTie(
 bool FunctionTreeView::addParameterTieInComposite(
     QtProperty *property, const std::string &parameterName,
     const CompositeFunction_sptr &composite, const std::size_t &index) {
-  for (auto i = 0; i < composite->nParams(); ++i) {
+  for (auto i = 0u; i < composite->nParams(); ++i) {
     const auto fullName = "f" + std::to_string(index) + "." + parameterName;
     if (fullName == composite->parameterName(i)) {
       if (const auto tie = composite->getTie(i)) {

--- a/qt/widgets/common/src/FunctionTreeView.cpp
+++ b/qt/widgets/common/src/FunctionTreeView.cpp
@@ -2142,6 +2142,17 @@ void FunctionTreeView::setMultiDomainFunctionPrefix(
 }
 
 /**
+ * The global ties within a multi-domain function. It is used when we don't want
+ * to display an entire MultiDomainFunction, and so we have to store the
+ * GlobalTies manually in this vector.
+ * @param globalTies :: A vector of global ties to be displayed within the
+ * function tree.
+ */
+void FunctionTreeView::setGlobalTies(std::vector<GlobalTie> const &globalTies) {
+  m_globalTies = globalTies;
+}
+
+/**
  * Emit a signal when any of the Global options change.
  */
 void FunctionTreeView::globalChanged(QtProperty *, const QString &, bool) {

--- a/qt/widgets/common/src/FunctionTreeView.cpp
+++ b/qt/widgets/common/src/FunctionTreeView.cpp
@@ -2269,7 +2269,12 @@ void FunctionTreeView::setGlobalParameters(const QStringList &globals) {
     auto prop = ap.prop;
     if (!prop->hasOption(globalOptionName))
       continue;
-    auto isGlobal = globals.contains(getParameterName(prop));
+
+    auto const parameterName = getParameterName(prop);
+    auto const isGlobal = std::any_of(
+        globals.cbegin(), globals.cend(), [&](QString const &global) {
+          return m_multiDomainFunctionPrefix + global == parameterName;
+        });
     prop->setOption(globalOptionName, isGlobal);
   }
 }

--- a/qt/widgets/common/src/FunctionTreeView.cpp
+++ b/qt/widgets/common/src/FunctionTreeView.cpp
@@ -1608,6 +1608,8 @@ void FunctionTreeView::removeFunction() {
   QtProperty *prop = item->property();
   if (!isFunction(prop))
     return;
+  auto const functionString =
+      QString::fromStdString(getFunction(prop)->asString());
   auto const functionIndex = getIndex(prop);
   removeProperty(prop);
   updateFunctionIndices();
@@ -1646,6 +1648,7 @@ void FunctionTreeView::removeFunction() {
       }
     }
   }
+  emit functionRemovedString(functionString);
   emit functionRemoved(functionIndex);
   setGlobalParameters(globalParameters);
   emit globalsChanged(globalParameters);

--- a/qt/widgets/common/src/FunctionTreeView.cpp
+++ b/qt/widgets/common/src/FunctionTreeView.cpp
@@ -1907,7 +1907,8 @@ void FunctionTreeView::addConstraints() {
     return;
   QString functionIndex, name;
   std::tie(functionIndex, name) = splitParameterName(getParameterName(prop));
-  auto const constraint = "0<" + name + "<0";
+  auto const value = QString::number(getParameter(prop));
+  auto const constraint = value + "<" + name + "<" + value;
   addConstraintProperties(prop, constraint);
   emit parameterConstraintAdded(functionIndex, constraint);
 }

--- a/qt/widgets/common/src/FunctionTreeView.cpp
+++ b/qt/widgets/common/src/FunctionTreeView.cpp
@@ -797,7 +797,9 @@ bool FunctionTreeView::addParameterTieInComposite(
  * parameter.
  * @param property :: A function property.
  * @param parameterName :: The name of the parameter to check for a global tie.
- * @param parameterIndex :: The index of the parameter within its function.
+ * @param parentComposite :: The composite function the parameter is in. This is
+ * a nullptr if the parameter is not in a composite function.
+ * @param parentIndex :: The index of the parameter within its composite.
  */
 void FunctionTreeView::addGlobalParameterTie(
     QtProperty *property, const std::string &parameterName,
@@ -1067,6 +1069,7 @@ QtProperty *FunctionTreeView::getFunctionProperty(const QString &index) const {
  * Add a tie property
  * @param prop :: Parent parameter property
  * @param tie :: A tie string
+ * @param globalTie :: true if the tie is a global tie.
  */
 void FunctionTreeView::addTieProperty(QtProperty *prop, const QString &tie,
                                       bool globalTie) {
@@ -1112,6 +1115,8 @@ QString FunctionTreeView::getFullTie(const QString &tie) const {
  * m_multiDomainFunctionPrefix to the start if we are using multiple datasets,
  * and will add the composite index if it is within a composite.
  * @param parameter :: The original parameter.
+ * @param compositeIndex :: The index of the function within the composite that
+ * the parameter is in.
  * @returns The full parameter name.
  */
 std::string FunctionTreeView::getFullParameterName(const std::string &parameter,

--- a/qt/widgets/common/src/FunctionTreeView.cpp
+++ b/qt/widgets/common/src/FunctionTreeView.cpp
@@ -69,11 +69,6 @@ QString removePrefix(QString &param) {
   }
 }
 
-bool isTieConstant(std::string const &tie) {
-  return !tie.empty() &&
-         tie.find_first_not_of("0123456789.-") == std::string::npos;
-}
-
 bool containsOneOf(std::string const &str, std::string const &delimiters) {
   return !str.empty() && str.find_first_of(delimiters) != std::string::npos;
 }
@@ -1107,8 +1102,7 @@ void FunctionTreeView::addTieProperty(QtProperty *prop, const QString &tie,
  * @returns The full tie to use as a tie property.
  */
 QString FunctionTreeView::getFullTie(const QString &tie) const {
-  if (!isTieConstant(tie.toStdString()) &&
-      !containsOneOf(tie.toStdString(), "="))
+  if (!isNumber(tie.toStdString()) && !containsOneOf(tie.toStdString(), "="))
     return m_multiDomainFunctionPrefix + tie;
   return tie;
 }

--- a/qt/widgets/common/src/FunctionTreeView.cpp
+++ b/qt/widgets/common/src/FunctionTreeView.cpp
@@ -151,15 +151,15 @@ void FunctionTreeView::createBrowser() {
   QtAbstractEditorFactory<ParameterPropertyManager> *parameterEditorFactory(
       nullptr);
   if (m_multiDataset) {
-    auto buttonFactory = new DoubleDialogEditorFactory(this);
+    m_doubleEditorFactory = new DoubleDialogEditorFactory(this);
     auto compositeFactory =
-        new CompositeEditorFactory<ParameterPropertyManager>(this,
-                                                             buttonFactory);
+        new CompositeEditorFactory<ParameterPropertyManager>(
+            this, m_doubleEditorFactory);
     compositeFactory->setSecondaryFactory(globalOptionName, paramEditorFactory);
     parameterEditorFactory = compositeFactory;
-    connect(buttonFactory, SIGNAL(buttonClicked(QtProperty *)), this,
+    connect(m_doubleEditorFactory, SIGNAL(buttonClicked(QtProperty *)), this,
             SLOT(parameterButtonClicked(QtProperty *)));
-    connect(buttonFactory, SIGNAL(closeEditor()), m_browser,
+    connect(m_doubleEditorFactory, SIGNAL(closeEditor()), m_browser,
             SLOT(closeEditor()));
   } else {
     parameterEditorFactory = paramEditorFactory;
@@ -2156,6 +2156,12 @@ QWidget *FunctionTreeView::getParamWidget(const QString &paramName) const {
 
 QTreeWidget *FunctionTreeView::treeWidget() const {
   return m_browser->treeWidget();
+}
+
+QtTreePropertyBrowser *FunctionTreeView::treeBrowser() { return m_browser; }
+
+DoubleDialogEditorFactory *FunctionTreeView::doubleEditorFactory() {
+  return m_doubleEditorFactory;
 }
 
 } // namespace MantidWidgets

--- a/qt/widgets/common/test/FitDomainTest.h
+++ b/qt/widgets/common/test/FitDomainTest.h
@@ -1,0 +1,469 @@
+// Mantid Repository : https://github.com/mantidproject/mantid
+//
+// Copyright &copy; 2020 ISIS Rutherford Appleton Laboratory UKRI,
+//   NScD Oak Ridge National Laboratory, European Spallation Source,
+//   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+// SPDX - License - Identifier: GPL - 3.0 +
+#pragma once
+
+#include "MantidAPI/AnalysisDataService.h"
+#include "MantidAPI/CompositeFunction.h"
+#include "MantidAPI/FrameworkManager.h"
+#include "MantidAPI/FunctionFactory.h"
+#include "MantidAPI/IFunction.h"
+#include "MantidAPI/MatrixWorkspace.h"
+#include "MantidQtWidgets/Common/FitDomain.h"
+#include "MantidTestHelpers/WorkspaceCreationHelper.h"
+
+#include <cxxtest/TestSuite.h>
+
+using namespace MantidQt::MantidWidgets;
+using namespace WorkspaceCreationHelper;
+
+namespace {
+
+Mantid::API::IFunction_sptr createIFunction(std::string const &functionString) {
+  return Mantid::API::FunctionFactory::Instance().createInitialized(
+      functionString);
+}
+
+Mantid::API::CompositeFunction_sptr
+toComposite(Mantid::API::IFunction_sptr function) {
+  return std::dynamic_pointer_cast<Mantid::API::CompositeFunction>(function);
+}
+
+Mantid::API::CompositeFunction_sptr createEmptyComposite() {
+  return toComposite(createIFunction("name=CompositeFunction"));
+}
+
+} // namespace
+
+class FitDomainTest : public CxxTest::TestSuite {
+
+public:
+  FitDomainTest()
+      : m_wsName("Name"), m_wsIndex(WorkspaceIndex(0)),
+        m_workspace(create2DWorkspace(3, 3)),
+        m_startX(m_workspace->x(m_wsIndex.value).front()),
+        m_endX(m_workspace->x(m_wsIndex.value).back()) {
+    Mantid::API::FrameworkManager::Instance();
+  }
+
+  static FitDomainTest *createSuite() { return new FitDomainTest; }
+
+  static void destroySuite(FitDomainTest *suite) { delete suite; }
+
+  void setUp() override {
+    m_flatBackground = createIFunction("name=FlatBackground");
+    m_expDecay = createIFunction("name=ExpDecay");
+
+    auto composite = createEmptyComposite();
+    composite->addFunction(createIFunction("name=FlatBackground"));
+    composite->addFunction(createIFunction("name=ExpDecay"));
+    m_composite = composite;
+
+    Mantid::API::AnalysisDataService::Instance().addOrReplace(m_wsName,
+                                                              m_workspace);
+    m_fitDomain =
+        std::make_unique<FitDomain>(m_wsName, m_wsIndex, m_startX, m_endX);
+  }
+
+  void tearDown() override {
+
+    Mantid::API::AnalysisDataService::Instance().clear();
+  }
+
+  void test_that_the_FitDomain_has_been_instantiated_with_the_correct_data() {
+    TS_ASSERT_EQUALS(m_fitDomain->workspaceName(), m_wsName);
+    TS_ASSERT_EQUALS(m_fitDomain->workspaceIndex(), m_wsIndex);
+    TS_ASSERT_EQUALS(m_fitDomain->startX(), m_startX);
+    TS_ASSERT_EQUALS(m_fitDomain->endX(), m_endX);
+    TS_ASSERT_EQUALS(m_fitDomain->getFunction(), nullptr);
+  }
+
+  void
+  test_that_setStartX_will_not_set_the_startX_if_the_value_is_out_of_range() {
+    TS_ASSERT(!m_fitDomain->setStartX(-1.0));
+    TS_ASSERT_EQUALS(m_fitDomain->startX(), m_startX);
+  }
+
+  void
+  test_that_setStartX_will_not_set_the_startX_if_the_value_is_larger_than_the_endX() {
+    TS_ASSERT(m_fitDomain->setEndX(2.0));
+
+    TS_ASSERT(!m_fitDomain->setStartX(2.5));
+    TS_ASSERT_EQUALS(m_fitDomain->startX(), m_startX);
+  }
+
+  void test_that_setStartX_will_set_the_startX_if_the_value_is_valid() {
+    double startX(2.0);
+
+    TS_ASSERT(m_fitDomain->setStartX(startX));
+    TS_ASSERT_EQUALS(m_fitDomain->startX(), startX);
+  }
+
+  void test_that_setEndX_will_not_set_the_endX_if_the_value_is_out_of_range() {
+    TS_ASSERT(!m_fitDomain->setEndX(4.0));
+    TS_ASSERT_EQUALS(m_fitDomain->endX(), m_endX);
+  }
+
+  void
+  test_that_setEndX_will_not_set_the_endX_if_the_value_is_smaller_than_the_startX() {
+    TS_ASSERT(m_fitDomain->setStartX(2.0));
+
+    TS_ASSERT(!m_fitDomain->setEndX(1.0));
+    TS_ASSERT_EQUALS(m_fitDomain->endX(), m_endX);
+  }
+
+  void test_that_setEndX_will_set_the_endX_if_the_value_is_valid() {
+    double endX(2.0);
+
+    TS_ASSERT(m_fitDomain->setEndX(endX));
+    TS_ASSERT_EQUALS(m_fitDomain->endX(), endX);
+  }
+
+  void test_that_setFunction_will_set_the_function_as_expected() {
+    m_fitDomain->setFunction(m_flatBackground);
+    TS_ASSERT_EQUALS(m_fitDomain->getFunction()->asString(),
+                     m_flatBackground->asString());
+  }
+
+  void test_that_getFunction_returns_a_clone_of_the_function() {
+    m_fitDomain->setFunction(m_flatBackground);
+
+    auto modifiedFunction = m_fitDomain->getFunction();
+    modifiedFunction->setParameter("A0", 5.0);
+
+    TS_ASSERT_DIFFERS(m_fitDomain->getFunction()->asString(),
+                      modifiedFunction->asString());
+  }
+
+  void
+  test_that_removeFunction_will_remove_the_function_with_the_given_name_from_a_non_composite_function() {
+    m_fitDomain->setFunction(m_flatBackground);
+
+    m_fitDomain->removeFunction(m_flatBackground->asString());
+
+    TS_ASSERT_EQUALS(m_fitDomain->getFunction(), nullptr);
+  }
+
+  void
+  test_that_removeFunction_will_remove_the_function_with_the_given_name_from_a_composite_function() {
+    m_fitDomain->setFunction(m_composite);
+
+    m_fitDomain->removeFunction(m_flatBackground->asString());
+
+    TS_ASSERT_EQUALS(m_fitDomain->getFunction()->asString(),
+                     m_expDecay->asString());
+  }
+
+  void
+  test_that_removeFunction_will_not_throw_if_the_stored_function_is_a_nullptr() {
+    TS_ASSERT_THROWS_NOTHING(
+        m_fitDomain->removeFunction(m_flatBackground->asString()));
+  }
+
+  void
+  test_that_removeFunction_will_not_remove_a_function_if_the_function_specified_does_not_exist() {
+    m_fitDomain->setFunction(m_flatBackground);
+
+    TS_ASSERT_THROWS_NOTHING(
+        m_fitDomain->removeFunction(m_expDecay->asString()));
+    TS_ASSERT_EQUALS(m_fitDomain->getFunction()->asString(),
+                     m_flatBackground->asString());
+  }
+
+  void
+  test_that_addFunction_will_add_a_function_correctly_for_a_single_ifunction() {
+    m_fitDomain->addFunction(m_flatBackground);
+    TS_ASSERT_EQUALS(m_fitDomain->getFunction()->asString(),
+                     m_flatBackground->asString());
+  }
+
+  void
+  test_that_addFunction_will_add_a_second_function_correctly_to_create_a_composite() {
+    m_fitDomain->addFunction(m_flatBackground);
+    m_fitDomain->addFunction(m_expDecay);
+
+    TS_ASSERT_EQUALS(m_fitDomain->getFunction()->asString(),
+                     m_composite->asString());
+  }
+
+  void
+  test_that_addFunction_will_throw_if_attempting_to_create_a_nested_composite_function() {
+    m_fitDomain->addFunction(m_flatBackground);
+    TS_ASSERT_THROWS(m_fitDomain->addFunction(m_composite),
+                     std::invalid_argument const &);
+  }
+
+  void test_that_getParameterValue_will_get_the_parameter_value_if_it_exists() {
+    m_fitDomain->setFunction(m_flatBackground);
+    TS_ASSERT_EQUALS(m_fitDomain->getParameterValue("A0"), 0.0);
+  }
+
+  void
+  test_that_getParameterValue_will_throw_if_the_stored_function_is_a_nullptr() {
+    TS_ASSERT_THROWS(m_fitDomain->getParameterValue("A0"),
+                     std::runtime_error const &);
+  }
+
+  void
+  test_that_getParameterValue_will_throw_if_the_parameter_does_not_exist() {
+    m_fitDomain->setFunction(m_flatBackground);
+    TS_ASSERT_THROWS(m_fitDomain->getParameterValue("Height"),
+                     std::runtime_error const &);
+  }
+
+  void
+  test_that_setParameterValue_will_not_throw_if_the_stored_function_is_a_nullptr() {
+    TS_ASSERT_THROWS_NOTHING(m_fitDomain->setParameterValue("A0", 2.0));
+  }
+
+  void
+  test_that_setParameterValue_will_not_throw_if_the_stored_function_does_not_have_the_specified_parameter() {
+    m_fitDomain->setFunction(m_flatBackground);
+    TS_ASSERT_THROWS_NOTHING(m_fitDomain->setParameterValue("Height", 2.0));
+  }
+
+  void
+  test_that_setParameterValue_will_not_set_the_parameters_value_if_the_new_value_is_outside_the_constraints() {
+    m_fitDomain->setFunction(m_flatBackground);
+    m_fitDomain->updateParameterConstraint("", "A0", "0<A0<2");
+
+    m_fitDomain->setParameterValue("A0", 3.0);
+
+    TS_ASSERT_EQUALS(m_fitDomain->getParameterValue("A0"), 0.0);
+  }
+
+  void
+  test_that_setParameterValue_will_set_the_parameter_value_ok_if_it_is_valid() {
+    m_fitDomain->setFunction(m_flatBackground);
+
+    m_fitDomain->setParameterValue("A0", 3.0);
+
+    TS_ASSERT_EQUALS(m_fitDomain->getParameterValue("A0"), 3.0);
+  }
+
+  void test_that_getAttributeValue_will_get_the_attribute_value_if_it_exists() {
+    m_fitDomain->setFunction(m_composite);
+    TS_ASSERT(!m_fitDomain->getAttributeValue("NumDeriv").asBool());
+  }
+
+  void
+  test_that_getAttributeValue_will_throw_if_the_stored_function_is_a_nullptr() {
+    TS_ASSERT_THROWS(m_fitDomain->getAttributeValue("A0"),
+                     std::runtime_error const &);
+  }
+
+  void
+  test_that_getAttributeValue_will_throw_if_the_attribute_does_not_exist() {
+    m_fitDomain->setFunction(m_flatBackground);
+    TS_ASSERT_THROWS(m_fitDomain->getAttributeValue("Height"),
+                     std::runtime_error const &);
+  }
+
+  void
+  test_that_setAttributeValue_will_not_throw_if_the_stored_function_is_a_nullptr() {
+    Mantid::API::IFunction::Attribute value(true);
+    TS_ASSERT_THROWS_NOTHING(m_fitDomain->setAttributeValue("NumDeriv", value));
+  }
+
+  void
+  test_that_setAttributeValue_will_not_throw_if_the_stored_function_does_not_have_the_specified_attribute() {
+    Mantid::API::IFunction::Attribute value(true);
+    m_fitDomain->setFunction(m_flatBackground);
+
+    TS_ASSERT_THROWS_NOTHING(m_fitDomain->setAttributeValue("NumDeriv", value));
+  }
+
+  void
+  test_that_setAttributeValue_will_set_the_attribute_value_ok_if_it_is_valid() {
+    Mantid::API::IFunction::Attribute value(true);
+    m_fitDomain->setFunction(m_composite);
+
+    m_fitDomain->setAttributeValue("NumDeriv", value);
+
+    TS_ASSERT(m_fitDomain->getAttributeValue("NumDeriv").asBool());
+  }
+
+  void
+  test_that_hasParameter_returns_false_if_the_stored_function_is_a_nullptr() {
+    TS_ASSERT(!m_fitDomain->hasParameter("A0"));
+  }
+
+  void
+  test_that_hasParameter_returns_false_if_the_function_does_not_have_a_parameter() {
+    m_fitDomain->setFunction(m_flatBackground);
+    TS_ASSERT(!m_fitDomain->hasParameter("Height"));
+  }
+
+  void
+  test_that_hasParameter_returns_false_if_the_function_does_have_a_parameter() {
+    m_fitDomain->setFunction(m_flatBackground);
+    TS_ASSERT(m_fitDomain->hasParameter("A0"));
+  }
+
+  void
+  test_that_isParameterActive_returns_false_if_the_stored_function_is_a_nullptr() {
+    TS_ASSERT(!m_fitDomain->isParameterActive("A0"));
+  }
+
+  void
+  test_that_isParameterActive_returns_false_if_the_function_does_not_have_the_specified_parameter() {
+    m_fitDomain->setFunction(m_flatBackground);
+    TS_ASSERT(!m_fitDomain->isParameterActive("Height"));
+  }
+
+  void test_that_isParameterActive_returns_false_if_a_parameter_is_tied() {
+    m_fitDomain->setFunction(m_composite);
+    TS_ASSERT(m_fitDomain->updateParameterTie("f0.A0", "f1.Height"));
+
+    TS_ASSERT(!m_fitDomain->isParameterActive("f0.A0"));
+    TS_ASSERT(m_fitDomain->isParameterActive("f1.Height"));
+  }
+
+  void
+  test_that_isParameterActive_returns_true_if_a_parameter_is_constrained() {
+    m_fitDomain->setFunction(m_flatBackground);
+    m_fitDomain->updateParameterConstraint("", "A0", "0<A0<2");
+
+    TS_ASSERT(m_fitDomain->isParameterActive("A0"));
+  }
+
+  void test_that_isParameterActive_returns_true_if_a_parameter_is_active() {
+    m_fitDomain->setFunction(m_flatBackground);
+    TS_ASSERT(m_fitDomain->isParameterActive("A0"));
+  }
+
+  void
+  test_that_updateParameterTie_returns_true_by_default_if_the_stored_function_is_a_nullptr() {
+    TS_ASSERT(m_fitDomain->updateParameterTie("f0.A0", "f1.Height"));
+  }
+
+  void
+  test_that_updateParameterTie_returns_true_by_default_if_the_stored_function_does_not_have_a_parameter() {
+    m_fitDomain->setFunction(m_flatBackground);
+    TS_ASSERT(m_fitDomain->updateParameterTie("f0.A0", "f1.Height"));
+  }
+
+  void
+  test_that_updateParameterTie_will_give_a_parameter_a_tie_if_both_are_valid() {
+    m_fitDomain->setFunction(m_composite);
+
+    TS_ASSERT(m_fitDomain->updateParameterTie("f0.A0", "f1.Height"));
+    TS_ASSERT(!m_fitDomain->isParameterActive("f0.A0"));
+  }
+
+  void
+  test_that_updateParameterTie_will_not_throw_and_return_false_if_a_tie_is_invalid() {
+    m_fitDomain->setFunction(m_composite);
+
+    TS_ASSERT(!m_fitDomain->updateParameterTie("f0.A0", "f1.f0.BadData"));
+    TS_ASSERT(m_fitDomain->isParameterActive("f0.A0"));
+  }
+
+  void
+  test_that_updateParameterTie_will_clear_all_ties_if_the_provided_tie_is_a_blank_string() {
+    m_fitDomain->setFunction(m_composite);
+
+    TS_ASSERT(m_fitDomain->updateParameterTie("f0.A0", "f1.Height"));
+    TS_ASSERT(!m_fitDomain->isParameterActive("f0.A0"));
+
+    TS_ASSERT(m_fitDomain->updateParameterTie("f0.A0", ""));
+    TS_ASSERT(m_fitDomain->isParameterActive("f0.A0"));
+  }
+
+  void
+  test_that_clearParameterTie_does_not_throw_if_the_stored_function_is_a_nullptr() {
+    TS_ASSERT_THROWS_NOTHING(m_fitDomain->clearParameterTie("f0.A0"));
+  }
+
+  void
+  test_that_clearParameterTie_does_not_throw_if_the_stored_function_does_not_have_a_parameter() {
+    m_fitDomain->setFunction(m_flatBackground);
+    TS_ASSERT_THROWS_NOTHING(m_fitDomain->clearParameterTie("f0.A0"));
+  }
+
+  void test_that_clearParameterTie_will_clear_the_tie_on_a_parameter() {
+    m_fitDomain->setFunction(m_composite);
+
+    TS_ASSERT(m_fitDomain->updateParameterTie("f0.A0", "f1.Height"));
+    TS_ASSERT(!m_fitDomain->isParameterActive("f0.A0"));
+
+    m_fitDomain->clearParameterTie("f0.A0");
+    TS_ASSERT(m_fitDomain->isParameterActive("f0.A0"));
+  }
+
+  void
+  test_that_updateParameterConstraint_will_not_throw_if_the_stored_function_is_a_nullptr() {
+    TS_ASSERT_THROWS_NOTHING(
+        m_fitDomain->updateParameterConstraint("", "A0", "0<A0<2"));
+  }
+
+  void
+  test_that_updateParameterConstraint_will_not_throw_if_the_stored_function_does_not_have_a_parameter() {
+    m_fitDomain->setFunction(m_flatBackground);
+    TS_ASSERT_THROWS_NOTHING(
+        m_fitDomain->updateParameterConstraint("", "Height", "0<Height<2"));
+  }
+
+  void
+  test_that_updateParameterConstraint_will_add_a_constraint_as_expected_to_a_non_composite_function() {
+    std::string const constraint("0<A0<2");
+    m_fitDomain->setFunction(m_flatBackground);
+
+    m_fitDomain->updateParameterConstraint("", "A0", constraint);
+
+    TS_ASSERT_EQUALS(m_flatBackground->getConstraint(0)->asString(),
+                     constraint);
+  }
+
+  void
+  test_that_updateParameterConstraint_will_add_a_constraint_as_expected_to_a_composite_function() {
+    std::string const constraint("0<Height<2");
+    m_fitDomain->setFunction(m_composite);
+
+    m_fitDomain->updateParameterConstraint("f1.", "Height", constraint);
+
+    TS_ASSERT_EQUALS(m_composite->getConstraint(1)->asString(), constraint);
+  }
+
+  void
+  test_that_removeParameterConstraint_will_not_throw_if_the_stored_function_is_a_nullptr() {
+    TS_ASSERT_THROWS_NOTHING(m_fitDomain->removeParameterConstraint("A0"));
+  }
+
+  void
+  test_that_removeParameterConstraint_will_not_throw_if_the_stored_function_does_not_have_a_parameter() {
+    m_fitDomain->setFunction(m_flatBackground);
+    TS_ASSERT_THROWS_NOTHING(m_fitDomain->removeParameterConstraint("Height"));
+  }
+
+  void
+  test_that_removeParameterConstraint_will_not_throw_if_the_parameter_does_not_have_a_constraint_to_remove() {
+    m_fitDomain->setFunction(m_flatBackground);
+    TS_ASSERT_THROWS_NOTHING(m_fitDomain->removeParameterConstraint("A0"));
+  }
+
+  void
+  test_that_removeParameterConstraint_will_remove_the_constraint_on_a_parameter() {
+    m_fitDomain->setFunction(m_flatBackground);
+    m_fitDomain->updateParameterConstraint("", "A0", "0<A0<2");
+
+    m_fitDomain->removeParameterConstraint("A0");
+
+    TS_ASSERT_EQUALS(m_flatBackground->getConstraint(0), nullptr);
+  }
+
+private:
+  std::string m_wsName;
+  WorkspaceIndex m_wsIndex;
+  Mantid::API::MatrixWorkspace_sptr m_workspace;
+  double m_startX;
+  double m_endX;
+  Mantid::API::IFunction_sptr m_flatBackground;
+  Mantid::API::IFunction_sptr m_expDecay;
+  Mantid::API::IFunction_sptr m_composite;
+
+  std::unique_ptr<FitDomain> m_fitDomain;
+};

--- a/qt/widgets/common/test/FitDomainTest.h
+++ b/qt/widgets/common/test/FitDomainTest.h
@@ -478,6 +478,26 @@ public:
     TS_ASSERT(m_fitDomain->getParameterValue("Height"), 1.0);
   }
 
+  void
+  test_that_updateParameterConstraint_will_not_update_the_constraint_if_the_lower_bound_does_not_encompass_the_value_of_the_parameter() {
+    m_fitDomain->setFunction(m_expDecay);
+
+    // The value of Height is automatically 1.0
+    m_fitDomain->updateParameterConstraint("", "Height", "1.1<Height<1.5");
+
+    TS_ASSERT_EQUALS(m_fitDomain->getFunction()->getConstraint(0), nullptr);
+  }
+
+  void
+  test_that_updateParameterConstraint_will_not_update_the_constraint_if_the_upper_bound_does_not_encompass_the_value_of_the_parameter() {
+    m_fitDomain->setFunction(m_expDecay);
+
+    // The value of Height is automatically 1.0
+    m_fitDomain->updateParameterConstraint("", "Height", "0.5<Height<0.9");
+
+    TS_ASSERT_EQUALS(m_fitDomain->getFunction()->getConstraint(0), nullptr);
+  }
+
 private:
   std::string m_wsName;
   WorkspaceIndex m_wsIndex;

--- a/qt/widgets/common/test/FitDomainTest.h
+++ b/qt/widgets/common/test/FitDomainTest.h
@@ -454,6 +454,30 @@ public:
     TS_ASSERT_EQUALS(m_flatBackground->getConstraint(0), nullptr);
   }
 
+  void
+  test_that_setting_the_value_of_a_parameter_to_a_value_outside_of_the_constraints_of_another_parameter_tied_to_it_will_remove_the_tie() {
+    m_fitDomain->setFunction(m_expDecay);
+    m_fitDomain->updateParameterConstraint("", "Height", "0.5<Height<1.5");
+    m_fitDomain->updateParameterTie("Height", "Lifetime");
+
+    m_fitDomain->setParameterValue("Lifetime", 2.0);
+
+    TS_ASSERT(m_fitDomain->isParameterActive("Height"));
+    TS_ASSERT(m_fitDomain->getParameterValue("Height"), 1.0);
+  }
+
+  void
+  test_that_attempting_to_tie_a_parameter_to_another_parameter_with_a_value_outside_the_allowed_constraints_will_not_perform_the_tie() {
+    m_fitDomain->setFunction(m_expDecay);
+    m_fitDomain->updateParameterConstraint("", "Height", "0.5<Height<1.5");
+    m_fitDomain->setParameterValue("Lifetime", 2.0);
+
+    m_fitDomain->updateParameterTie("Height", "Lifetime");
+
+    TS_ASSERT(m_fitDomain->isParameterActive("Height"));
+    TS_ASSERT(m_fitDomain->getParameterValue("Height"), 1.0);
+  }
+
 private:
   std::string m_wsName;
   WorkspaceIndex m_wsIndex;

--- a/qt/widgets/common/test/FitDomainTest.h
+++ b/qt/widgets/common/test/FitDomainTest.h
@@ -69,7 +69,6 @@ public:
   }
 
   void tearDown() override {
-
     Mantid::API::AnalysisDataService::Instance().clear();
   }
 

--- a/qt/widgets/common/test/FitDomainTest.h
+++ b/qt/widgets/common/test/FitDomainTest.h
@@ -463,7 +463,7 @@ public:
     m_fitDomain->setParameterValue("Lifetime", 2.0);
 
     TS_ASSERT(m_fitDomain->isParameterActive("Height"));
-    TS_ASSERT(m_fitDomain->getParameterValue("Height"), 1.0);
+    TS_ASSERT_EQUALS(m_fitDomain->getParameterValue("Height"), 1.0);
   }
 
   void
@@ -475,7 +475,7 @@ public:
     m_fitDomain->updateParameterTie("Height", "Lifetime");
 
     TS_ASSERT(m_fitDomain->isParameterActive("Height"));
-    TS_ASSERT(m_fitDomain->getParameterValue("Height"), 1.0);
+    TS_ASSERT_EQUALS(m_fitDomain->getParameterValue("Height"), 1.0);
   }
 
   void
@@ -496,6 +496,38 @@ public:
     m_fitDomain->updateParameterConstraint("", "Height", "0.5<Height<0.9");
 
     TS_ASSERT_EQUALS(m_fitDomain->getFunction()->getConstraint(0), nullptr);
+  }
+
+  void
+  test_that_isParameterValueWithinConstraints_returns_true_if_the_value_is_within_the_parameters_constraints() {
+    m_fitDomain->setFunction(m_expDecay);
+
+    m_fitDomain->updateParameterConstraint("", "Height", "0<Height<2");
+
+    TS_ASSERT(m_fitDomain->isParameterValueWithinConstraints("Height", 0.0));
+    TS_ASSERT(m_fitDomain->isParameterValueWithinConstraints("Height", 1.0));
+    TS_ASSERT(m_fitDomain->isParameterValueWithinConstraints("Height", 2.0));
+  }
+
+  void
+  test_that_isParameterValueWithinConstraints_returns_false_if_the_value_is_not_within_the_parameters_constraints() {
+    m_fitDomain->setFunction(m_expDecay);
+
+    m_fitDomain->updateParameterConstraint("", "Height", "0<Height<2");
+
+    TS_ASSERT(!m_fitDomain->isParameterValueWithinConstraints("Height", -0.1));
+    TS_ASSERT(!m_fitDomain->isParameterValueWithinConstraints("Height", 2.1));
+  }
+
+  void
+  test_that_getParametersTiedTo_will_return_the_names_of_parameters_tied_to_the_given_parameter() {
+    m_fitDomain->setFunction(m_expDecay);
+    m_fitDomain->updateParameterTie("Height", "Lifetime");
+
+    auto const tiedParameters = std::vector<std::string>{"Height"};
+    TS_ASSERT_EQUALS(m_fitDomain->getParametersTiedTo("Height").size(), 0);
+    TS_ASSERT_EQUALS(m_fitDomain->getParametersTiedTo("Lifetime"),
+                     tiedParameters);
   }
 
 private:

--- a/qt/widgets/common/test/FitDomainTest.h
+++ b/qt/widgets/common/test/FitDomainTest.h
@@ -58,8 +58,8 @@ public:
     m_expDecay = createIFunction("name=ExpDecay");
 
     auto composite = createEmptyComposite();
-    composite->addFunction(createIFunction("name=FlatBackground"));
-    composite->addFunction(createIFunction("name=ExpDecay"));
+    composite->addFunction(m_flatBackground->clone());
+    composite->addFunction(m_expDecay->clone());
     m_composite = composite;
 
     Mantid::API::AnalysisDataService::Instance().addOrReplace(m_wsName,

--- a/qt/widgets/common/test/FitDomainTest.h
+++ b/qt/widgets/common/test/FitDomainTest.h
@@ -77,7 +77,7 @@ public:
     TS_ASSERT_EQUALS(m_fitDomain->workspaceIndex(), m_wsIndex);
     TS_ASSERT_EQUALS(m_fitDomain->startX(), m_startX);
     TS_ASSERT_EQUALS(m_fitDomain->endX(), m_endX);
-    TS_ASSERT_EQUALS(m_fitDomain->getFunction(), nullptr);
+    TS_ASSERT_EQUALS(m_fitDomain->getFunctionCopy(), nullptr);
   }
 
   void
@@ -123,17 +123,17 @@ public:
 
   void test_that_setFunction_will_set_the_function_as_expected() {
     m_fitDomain->setFunction(m_flatBackground);
-    TS_ASSERT_EQUALS(m_fitDomain->getFunction()->asString(),
+    TS_ASSERT_EQUALS(m_fitDomain->getFunctionCopy()->asString(),
                      m_flatBackground->asString());
   }
 
   void test_that_getFunction_returns_a_clone_of_the_function() {
     m_fitDomain->setFunction(m_flatBackground);
 
-    auto modifiedFunction = m_fitDomain->getFunction();
+    auto modifiedFunction = m_fitDomain->getFunctionCopy();
     modifiedFunction->setParameter("A0", 5.0);
 
-    TS_ASSERT_DIFFERS(m_fitDomain->getFunction()->asString(),
+    TS_ASSERT_DIFFERS(m_fitDomain->getFunctionCopy()->asString(),
                       modifiedFunction->asString());
   }
 
@@ -143,7 +143,7 @@ public:
 
     m_fitDomain->removeFunction(m_flatBackground->asString());
 
-    TS_ASSERT_EQUALS(m_fitDomain->getFunction(), nullptr);
+    TS_ASSERT_EQUALS(m_fitDomain->getFunctionCopy(), nullptr);
   }
 
   void
@@ -152,7 +152,7 @@ public:
 
     m_fitDomain->removeFunction(m_flatBackground->asString());
 
-    TS_ASSERT_EQUALS(m_fitDomain->getFunction()->asString(),
+    TS_ASSERT_EQUALS(m_fitDomain->getFunctionCopy()->asString(),
                      m_expDecay->asString());
   }
 
@@ -168,14 +168,14 @@ public:
 
     TS_ASSERT_THROWS_NOTHING(
         m_fitDomain->removeFunction(m_expDecay->asString()));
-    TS_ASSERT_EQUALS(m_fitDomain->getFunction()->asString(),
+    TS_ASSERT_EQUALS(m_fitDomain->getFunctionCopy()->asString(),
                      m_flatBackground->asString());
   }
 
   void
   test_that_addFunction_will_add_a_function_correctly_for_a_single_ifunction() {
     m_fitDomain->addFunction(m_flatBackground);
-    TS_ASSERT_EQUALS(m_fitDomain->getFunction()->asString(),
+    TS_ASSERT_EQUALS(m_fitDomain->getFunctionCopy()->asString(),
                      m_flatBackground->asString());
   }
 
@@ -184,7 +184,7 @@ public:
     m_fitDomain->addFunction(m_flatBackground);
     m_fitDomain->addFunction(m_expDecay);
 
-    TS_ASSERT_EQUALS(m_fitDomain->getFunction()->asString(),
+    TS_ASSERT_EQUALS(m_fitDomain->getFunctionCopy()->asString(),
                      m_composite->asString());
   }
 
@@ -485,7 +485,7 @@ public:
     // The value of Height is automatically 1.0
     m_fitDomain->updateParameterConstraint("", "Height", "1.1<Height<1.5");
 
-    TS_ASSERT_EQUALS(m_fitDomain->getFunction()->getConstraint(0), nullptr);
+    TS_ASSERT_EQUALS(m_fitDomain->getFunctionCopy()->getConstraint(0), nullptr);
   }
 
   void
@@ -495,7 +495,7 @@ public:
     // The value of Height is automatically 1.0
     m_fitDomain->updateParameterConstraint("", "Height", "0.5<Height<0.9");
 
-    TS_ASSERT_EQUALS(m_fitDomain->getFunction()->getConstraint(0), nullptr);
+    TS_ASSERT_EQUALS(m_fitDomain->getFunctionCopy()->getConstraint(0), nullptr);
   }
 
   void

--- a/qt/widgets/common/test/FitScriptGeneratorDataTableTest.h
+++ b/qt/widgets/common/test/FitScriptGeneratorDataTableTest.h
@@ -74,6 +74,17 @@ public:
     TS_ASSERT_EQUALS(m_dataTable->rowCount(), 0);
   }
 
+  void test_that_allRows_will_return_all_of_the_existing_row_indices() {
+    m_dataTable->show();
+    m_dataTable->addDomain("Name", WorkspaceIndex(0), 0.0, 2.0);
+    m_dataTable->addDomain("Name2", WorkspaceIndex(0), 0.0, 2.0);
+    m_dataTable->addDomain("Name3", WorkspaceIndex(0), 0.0, 2.0);
+
+    auto const allIndices = m_dataTable->allRows();
+    auto const expectedIndices = std::vector<FitDomainIndex>{2, 1, 0};
+    TS_ASSERT_EQUALS(allIndices, expectedIndices);
+  }
+
   void test_that_selectedRows_will_return_the_currently_selected_row() {
     int rowIndex(1);
 
@@ -82,18 +93,26 @@ public:
     m_dataTable->addDomain("Name2", WorkspaceIndex(0), 0.0, 2.0);
     m_dataTable->addDomain("Name3", WorkspaceIndex(0), 0.0, 2.0);
 
-    // Retrieve the pixel position of the first column cell at rowIndex
-    int xPos = m_dataTable->columnViewportPosition(0) + 5;
-    int yPos = m_dataTable->rowViewportPosition(rowIndex) + 10;
-
-    // Click the table cell, thereby selecting a row
-    QWidget *pViewport = m_dataTable->viewport();
-    QTest::mouseClick(pViewport, Qt::LeftButton, NULL, QPoint(xPos, yPos));
-    QTest::qWait(500);
+    selectRowInTable(rowIndex);
 
     auto const selectedIndices = m_dataTable->selectedRows();
     TS_ASSERT_EQUALS(selectedIndices.size(), 1);
     TS_ASSERT_EQUALS(selectedIndices[0].value, rowIndex);
+  }
+
+  void
+  test_that_selectedDomainFunctionPrefix_will_return_the_currently_selected_function_index() {
+    int rowIndex(1);
+
+    m_dataTable->show();
+    m_dataTable->addDomain("Name", WorkspaceIndex(0), 0.0, 2.0);
+    m_dataTable->addDomain("Name2", WorkspaceIndex(0), 0.0, 2.0);
+    m_dataTable->addDomain("Name3", WorkspaceIndex(0), 0.0, 2.0);
+
+    selectRowInTable(rowIndex);
+
+    auto const selectedPrefix = m_dataTable->selectedDomainFunctionPrefix();
+    TS_ASSERT_EQUALS(selectedPrefix, "f1.");
   }
 
 private:
@@ -103,6 +122,17 @@ private:
 
   void assertNoTopLevelWidgets() {
     TS_ASSERT_EQUALS(0, QApplication::topLevelWidgets().size());
+  }
+
+  void selectRowInTable(int row) {
+    // Retrieve the pixel position of the first column cell at rowIndex
+    int xPos = m_dataTable->columnViewportPosition(0) + 5;
+    int yPos = m_dataTable->rowViewportPosition(row) + 10;
+
+    // Click the table cell, thereby selecting a row
+    QWidget *pViewport = m_dataTable->viewport();
+    QTest::mouseClick(pViewport, Qt::LeftButton, NULL, QPoint(xPos, yPos));
+    QApplication::sendPostedEvents();
   }
 
   std::unique_ptr<FitScriptGeneratorDataTable> m_dataTable;

--- a/qt/widgets/common/test/FitScriptGeneratorModelTest.h
+++ b/qt/widgets/common/test/FitScriptGeneratorModelTest.h
@@ -675,6 +675,32 @@ public:
     TS_ASSERT_EQUALS(m_model->getGlobalTies().size(), 0);
   }
 
+  void
+  test_that_all_previously_tied_parameters_have_the_same_value_when_a_global_tie_is_removed() {
+    m_model->setFittingMode(FittingMode::SIMULTANEOUS);
+
+    m_model->addWorkspaceDomain(m_wsName, m_wsIndex, m_startX, m_endX);
+    m_model->addWorkspaceDomain("Name2", m_wsIndex, m_startX, m_endX);
+
+    m_model->setFunction(m_wsName, m_wsIndex, m_expDecay->asString());
+    m_model->setFunction("Name2", m_wsIndex, m_expDecay->asString());
+
+    m_model->updateParameterTie(m_wsName, m_wsIndex, "f0.Height",
+                                "f1.Lifetime");
+    m_model->updateParameterTie("Name2", m_wsIndex, "f1.Height", "f1.Lifetime");
+
+    m_model->updateParameterValue("Name2", m_wsIndex, "f1.Lifetime", 2.0);
+
+    // Remove the ties
+    m_model->updateParameterTie(m_wsName, m_wsIndex, "f0.Height", "");
+    m_model->updateParameterTie("Name2", m_wsIndex, "f1.Height", "");
+
+    TS_ASSERT_EQUALS(
+        m_model->getFunction(m_wsName, m_wsIndex)->getParameter("Height"), 2.0);
+    TS_ASSERT_EQUALS(
+        m_model->getFunction("Name2", m_wsIndex)->getParameter("Height"), 2.0);
+  }
+
 private:
   void setup_model_data() {
     m_model->addWorkspaceDomain(m_wsName, m_wsIndex, m_startX, m_endX);

--- a/qt/widgets/common/test/FitScriptGeneratorModelTest.h
+++ b/qt/widgets/common/test/FitScriptGeneratorModelTest.h
@@ -18,8 +18,10 @@
 #include "MantidTestHelpers/WorkspaceCreationHelper.h"
 
 #include <cxxtest/TestSuite.h>
+#include <gmock/gmock.h>
 
 #include <memory>
+#include <vector>
 
 using namespace MantidQt::MantidWidgets;
 using namespace WorkspaceCreationHelper;
@@ -41,6 +43,8 @@ Mantid::API::CompositeFunction_sptr createEmptyComposite() {
 }
 
 } // namespace
+
+MATCHER_P(VectorSize, expectedSize, "") { return arg.size() == expectedSize; }
 
 class FitScriptGeneratorModelTest : public CxxTest::TestSuite {
 
@@ -80,9 +84,591 @@ public:
     Mantid::API::AnalysisDataService::Instance().clear();
   }
 
-  void test_end() {}
+  void
+  test_that_the_model_has_been_instantiated_with_the_expected_member_variables() {
+    TS_ASSERT_EQUALS(m_model->getGlobalTies().size(), 0);
+    TS_ASSERT_EQUALS(m_model->getGlobalParameters().size(), 0);
+    TS_ASSERT_EQUALS(m_model->getFittingMode(), FittingMode::SEQUENTIAL);
+  }
+
+  void
+  test_that_addWorkspaceDomain_throws_nothing_when_a_domain_is_added_successfully() {
+    TS_ASSERT_THROWS_NOTHING(
+        m_model->addWorkspaceDomain(m_wsName, m_wsIndex, m_startX, m_endX));
+    TS_ASSERT(m_model->hasWorkspaceDomain(m_wsName, m_wsIndex));
+    TS_ASSERT_EQUALS(m_model->getFunction(m_wsName, m_wsIndex), nullptr);
+  }
+
+  void test_that_addWorkspaceDomain_throws_when_a_domain_already_exists() {
+    m_model->addWorkspaceDomain(m_wsName, m_wsIndex, m_startX, m_endX);
+    TS_ASSERT_THROWS(
+        m_model->addWorkspaceDomain(m_wsName, m_wsIndex, m_startX, m_endX),
+        std::invalid_argument const &);
+  }
+
+  void
+  test_that_removeWorkspaceDomain_will_not_throw_if_it_does_not_have_the_specified_domain() {
+    TS_ASSERT_THROWS_NOTHING(
+        m_model->removeWorkspaceDomain(m_wsName, m_wsIndex));
+  }
+
+  void test_that_removeWorkspaceDomain_will_remove_the_specified_domain() {
+    m_model->addWorkspaceDomain(m_wsName, m_wsIndex, m_startX, m_endX);
+    m_model->removeWorkspaceDomain(m_wsName, m_wsIndex);
+
+    TS_ASSERT(!m_model->hasWorkspaceDomain(m_wsName, m_wsIndex));
+  }
+
+  void
+  test_that_removeWorkspaceDomain_will_clear_the_global_ties_that_have_expired() {
+    setup_simultaneous_fit_with_global_tie();
+
+    TS_ASSERT_EQUALS(m_model->getGlobalTies().size(), 1);
+    m_model->removeWorkspaceDomain(m_wsName, m_wsIndex);
+    TS_ASSERT_EQUALS(m_model->getGlobalTies().size(), 0);
+  }
+
+  void
+  test_that_hasWorkspaceDomain_returns_false_if_a_workspace_domain_does_not_exist() {
+    TS_ASSERT(!m_model->hasWorkspaceDomain(m_wsName, m_wsIndex));
+  }
+
+  void
+  test_that_hasWorkspaceDomain_returns_true_if_a_workspace_domain_exists() {
+    m_model->addWorkspaceDomain(m_wsName, m_wsIndex, m_startX, m_endX);
+    TS_ASSERT(m_model->hasWorkspaceDomain(m_wsName, m_wsIndex));
+  }
+
+  void
+  test_that_updateStartX_will_throw_if_the_domain_specified_does_not_exist() {
+    TS_ASSERT_THROWS(m_model->updateStartX(m_wsName, m_wsIndex, 1.0),
+                     std::invalid_argument const &);
+  }
+
+  void
+  test_that_updateStartX_will_return_false_if_the_value_provided_is_out_of_range() {
+    m_model->addWorkspaceDomain(m_wsName, m_wsIndex, m_startX, m_endX);
+    TS_ASSERT(!m_model->updateStartX(m_wsName, m_wsIndex, -1.0));
+  }
+
+  void
+  test_that_updateStartX_will_return_false_if_the_value_provided_is_larger_than_the_endX() {
+    m_model->addWorkspaceDomain(m_wsName, m_wsIndex, m_startX, m_endX);
+
+    TS_ASSERT(m_model->updateEndX(m_wsName, m_wsIndex, 2.0));
+    TS_ASSERT(!m_model->updateStartX(m_wsName, m_wsIndex, 2.5));
+  }
+
+  void
+  test_that_updateStartX_will_return_true_if_the_value_provided_is_valid() {
+    m_model->addWorkspaceDomain(m_wsName, m_wsIndex, m_startX, m_endX);
+    TS_ASSERT(m_model->updateStartX(m_wsName, m_wsIndex, 1.0));
+  }
+
+  void
+  test_that_updateEndX_will_throw_if_the_domain_specified_does_not_exist() {
+    TS_ASSERT_THROWS(m_model->updateEndX(m_wsName, m_wsIndex, 1.0),
+                     std::invalid_argument const &);
+  }
+
+  void
+  test_that_updateEndX_will_return_false_if_the_value_provided_is_out_of_range() {
+    m_model->addWorkspaceDomain(m_wsName, m_wsIndex, m_startX, m_endX);
+    TS_ASSERT(!m_model->updateEndX(m_wsName, m_wsIndex, 5.0));
+  }
+
+  void
+  test_that_updateEndX_will_return_false_if_the_value_provided_is_smaller_than_the_startX() {
+    m_model->addWorkspaceDomain(m_wsName, m_wsIndex, m_startX, m_endX);
+
+    TS_ASSERT(m_model->updateStartX(m_wsName, m_wsIndex, 2.0));
+    TS_ASSERT(!m_model->updateEndX(m_wsName, m_wsIndex, 1.0));
+  }
+
+  void test_that_updateEndX_will_return_true_if_the_value_provided_is_valid() {
+    m_model->addWorkspaceDomain(m_wsName, m_wsIndex, m_startX, m_endX);
+    TS_ASSERT(m_model->updateEndX(m_wsName, m_wsIndex, 2.0));
+  }
+
+  void
+  test_that_addFunction_will_throw_if_the_domain_specified_does_not_exist() {
+    TS_ASSERT_THROWS(
+        m_model->addFunction(m_wsName, m_wsIndex, m_flatBackground->asString()),
+        std::invalid_argument const &);
+  }
+
+  void test_that_addFunction_will_add_the_function_to_the_correct_domain() {
+    m_model->addWorkspaceDomain(m_wsName, m_wsIndex, m_startX, m_endX);
+    m_model->addFunction(m_wsName, m_wsIndex, m_flatBackground->asString());
+
+    TS_ASSERT_EQUALS(m_model->getFunction(m_wsName, m_wsIndex)->asString(),
+                     m_flatBackground->asString());
+  }
+
+  void test_that_addFunction_will_clear_the_global_ties_that_have_expired() {
+    setup_simultaneous_fit_with_global_tie();
+
+    TS_ASSERT_EQUALS(m_model->getGlobalTies().size(), 1);
+    m_model->addFunction(m_wsName, m_wsIndex, m_expDecay->asString());
+    TS_ASSERT_EQUALS(m_model->getGlobalTies().size(), 0);
+  }
+
+  void test_that_addFunction_will_throw_if_provided_a_composite_function() {
+    m_model->addWorkspaceDomain(m_wsName, m_wsIndex, m_startX, m_endX);
+    m_model->addFunction(m_wsName, m_wsIndex, m_flatBackground->asString());
+
+    TS_ASSERT_THROWS(
+        m_model->addFunction(m_wsName, m_wsIndex, m_composite->asString()),
+        std::invalid_argument const &);
+  }
+
+  void
+  test_that_setFunction_will_throw_if_the_domain_specified_does_not_exist() {
+    TS_ASSERT_THROWS(
+        m_model->setFunction(m_wsName, m_wsIndex, m_flatBackground->asString()),
+        std::invalid_argument const &);
+  }
+
+  void test_that_setFunction_will_set_the_function_in_the_correct_domain() {
+    m_model->addWorkspaceDomain(m_wsName, m_wsIndex, m_startX, m_endX);
+    m_model->addFunction(m_wsName, m_wsIndex, m_expDecay->asString());
+
+    m_model->setFunction(m_wsName, m_wsIndex, m_flatBackground->asString());
+
+    TS_ASSERT_EQUALS(m_model->getFunction(m_wsName, m_wsIndex)->asString(),
+                     m_flatBackground->asString());
+  }
+
+  void test_that_setFunction_will_clear_the_global_ties_that_have_expired() {
+    setup_simultaneous_fit_with_global_tie();
+
+    TS_ASSERT_EQUALS(m_model->getGlobalTies().size(), 1);
+    m_model->setFunction(m_wsName, m_wsIndex, m_expDecay->asString());
+    TS_ASSERT_EQUALS(m_model->getGlobalTies().size(), 0);
+  }
+
+  void
+  test_that_removeFunction_will_throw_if_the_domain_specified_does_not_exist() {
+    TS_ASSERT_THROWS(m_model->removeFunction(m_wsName, m_wsIndex,
+                                             m_flatBackground->asString()),
+                     std::invalid_argument const &);
+  }
+
+  void
+  test_that_removeFunction_will_remove_the_function_in_the_correct_domain() {
+    m_model->addWorkspaceDomain(m_wsName, m_wsIndex, m_startX, m_endX);
+    m_model->addFunction(m_wsName, m_wsIndex, m_flatBackground->asString());
+
+    m_model->removeFunction(m_wsName, m_wsIndex, m_flatBackground->asString());
+
+    TS_ASSERT_EQUALS(m_model->getFunction(m_wsName, m_wsIndex), nullptr);
+  }
+
+  void test_that_removeFunction_will_clear_the_global_ties_that_have_expired() {
+    setup_simultaneous_fit_with_global_tie();
+
+    TS_ASSERT_EQUALS(m_model->getGlobalTies().size(), 1);
+    m_model->removeFunction(m_wsName, m_wsIndex, m_flatBackground->asString());
+    TS_ASSERT_EQUALS(m_model->getGlobalTies().size(), 0);
+  }
+
+  void
+  test_that_getFunction_will_throw_if_the_domain_specified_does_not_exist() {
+    TS_ASSERT_THROWS(m_model->getFunction(m_wsName, m_wsIndex),
+                     std::invalid_argument const &);
+  }
+
+  void
+  test_that_getEquivalentFunctionIndexForDomain_will_throw_if_the_domain_specified_does_not_exist() {
+    setup_simultaneous_fit_with_global_tie();
+    TS_ASSERT_THROWS(m_model->getEquivalentFunctionIndexForDomain(
+                         "BadName", m_wsIndex, "f0.f0."),
+                     std::invalid_argument const &);
+  }
+
+  void
+  test_that_getEquivalentFunctionIndexForDomain_will_return_the_correct_function_index_for_simultaneous_mode() {
+    setup_simultaneous_fit_with_global_tie();
+
+    auto const equivalentIndex = m_model->getEquivalentFunctionIndexForDomain(
+        "Name2", m_wsIndex, "f0.f0.");
+    TS_ASSERT_EQUALS(equivalentIndex, "f1.f0.");
+  }
+
+  void
+  test_that_getEquivalentFunctionIndexForDomain_just_returns_the_index_if_it_is_an_empty_string() {
+    setup_simultaneous_fit_with_global_tie();
+
+    auto const equivalentIndex =
+        m_model->getEquivalentFunctionIndexForDomain("Name2", m_wsIndex, "");
+    TS_ASSERT_EQUALS(equivalentIndex, "");
+  }
+
+  void
+  test_that_getEquivalentFunctionIndexForDomain_just_returns_the_index_if_it_is_in_sequential_mode() {
+    auto const equivalentIndex = m_model->getEquivalentFunctionIndexForDomain(
+        m_wsName, m_wsIndex, "f0.");
+    TS_ASSERT_EQUALS(equivalentIndex, "f0.");
+  }
+
+  void
+  test_that_getEquivalentParameterTieForDomain_will_throw_if_the_domain_specified_does_not_exist() {
+    setup_simultaneous_fit_with_global_tie();
+    TS_ASSERT_THROWS(m_model->getEquivalentParameterTieForDomain(
+                         "BadName", m_wsIndex, "f0.f0.A0", "f0.f1.Height"),
+                     std::invalid_argument const &);
+  }
+
+  void
+  test_that_getEquivalentParameterTieForDomain_will_just_return_the_string_if_its_a_number_or_empty() {
+    m_model->setFittingMode(FittingMode::SIMULTANEOUS);
+
+    TS_ASSERT_EQUALS(m_model->getEquivalentParameterTieForDomain(
+                         m_wsName, m_wsIndex, "f0.f0.A0", "0"),
+                     "0");
+    TS_ASSERT_EQUALS(m_model->getEquivalentParameterTieForDomain(
+                         m_wsName, m_wsIndex, "f0.f0.A0", "-1.0"),
+                     "-1.0");
+    TS_ASSERT_EQUALS(m_model->getEquivalentParameterTieForDomain(
+                         m_wsName, m_wsIndex, "f0.f0.A0", ""),
+                     "");
+    TS_ASSERT_EQUALS(m_model->getEquivalentParameterTieForDomain(
+                         m_wsName, m_wsIndex, "f0.f0.A0", "bad.parameter"),
+                     "bad.parameter");
+  }
+
+  void
+  test_that_getEquivalentParameterTieForDomain_will_just_return_the_original_tie_if_its_sequential_mode() {
+    setup_simultaneous_fit_with_no_ties();
+    TS_ASSERT_EQUALS(m_model->getEquivalentParameterTieForDomain(
+                         m_wsName, m_wsIndex, "f0.A0", "f1.Height"),
+                     "f1.Height");
+  }
+
+  void
+  test_that_getEquivalentParameterTieForDomain_will_return_a_tie_in_the_same_domain_if_the_parameter_domain_is_equal_to_the_tie_domain() {
+    setup_simultaneous_fit_with_no_ties();
+    TS_ASSERT_EQUALS(m_model->getEquivalentParameterTieForDomain(
+                         m_wsName, m_wsIndex, "f0.f0.A0", "f0.f1.Height"),
+                     "f0.f1.Height");
+  }
+
+  void
+  test_that_getEquivalentParameterTieForDomain_will_return_the_correct_tie_if_the_parameter_domain_and_tie_domain_are_different() {
+    setup_simultaneous_fit_with_no_ties();
+    TS_ASSERT_EQUALS(m_model->getEquivalentParameterTieForDomain(
+                         m_wsName, m_wsIndex, "f1.f0.A0", "f0.f1.Height"),
+                     "f0.f1.Height");
+  }
+
+  void
+  test_that_updateParameterValue_will_not_update_a_parameter_value_if_it_has_a_global_tie() {
+    setup_simultaneous_fit_with_global_tie();
+
+    m_model->updateParameterValue(m_wsName, m_wsIndex, "f0.A0", 2.0);
+
+    TS_ASSERT_EQUALS(
+        m_model->getFunction(m_wsName, m_wsIndex)->getParameter("A0"), 0.0);
+  }
+
+  void
+  test_that_updateParameterValue_will_update_a_parameter_value_if_it_does_not_have_a_global_tie() {
+    setup_simultaneous_fit_with_no_ties();
+
+    m_model->updateParameterValue(m_wsName, m_wsIndex, "f0.A0", 2.0);
+
+    TS_ASSERT_EQUALS(
+        m_model->getFunction(m_wsName, m_wsIndex)->getParameter("A0"), 2.0);
+    TS_ASSERT_EQUALS(
+        m_model->getFunction("Name2", m_wsIndex)->getParameter("A0"), 0.0);
+  }
+
+  void
+  test_that_updateParameterValue_will_update_all_parameter_values_globally_tied_to_the_specified_parameter() {
+    setup_simultaneous_fit_with_global_tie();
+
+    m_model->updateParameterValue("Name2", m_wsIndex, "f1.A0", 2.0);
+
+    TS_ASSERT_EQUALS(
+        m_model->getFunction(m_wsName, m_wsIndex)->getParameter("A0"), 2.0);
+    TS_ASSERT_EQUALS(
+        m_model->getFunction("Name2", m_wsIndex)->getParameter("A0"), 2.0);
+  }
+
+  void
+  test_that_updateAttributeValue_will_throw_if_the_domain_specified_does_not_exist() {
+    TS_ASSERT_THROWS(m_model->updateAttributeValue(m_wsName, m_wsIndex, "A0",
+                                                   IFunction::Attribute(true)),
+                     std::invalid_argument const &);
+  }
+
+  void
+  test_that_updateAttributeValue_will_not_throw_if_the_attribute_specified_does_not_exist() {
+    m_model->addWorkspaceDomain(m_wsName, m_wsIndex, m_startX, m_endX);
+    m_model->addFunction(m_wsName, m_wsIndex, m_flatBackground->asString());
+
+    TS_ASSERT_THROWS_NOTHING(m_model->updateAttributeValue(
+        m_wsName, m_wsIndex, "FakeAttribute", IFunction::Attribute(true)));
+  }
+
+  void
+  test_that_updateAttributeValue_will_update_an_attribute_as_expected_when_it_exists() {
+    m_model->addWorkspaceDomain(m_wsName, m_wsIndex, m_startX, m_endX);
+
+    m_model->addFunction(m_wsName, m_wsIndex, m_flatBackground->asString());
+    m_model->addFunction(m_wsName, m_wsIndex, m_expDecay->asString());
+
+    TS_ASSERT(!m_model->getFunction(m_wsName, m_wsIndex)
+                   ->getAttribute("NumDeriv")
+                   .asBool());
+    m_model->updateAttributeValue(m_wsName, m_wsIndex, "NumDeriv",
+                                  IFunction::Attribute(true));
+    TS_ASSERT(m_model->getFunction(m_wsName, m_wsIndex)
+                  ->getAttribute("NumDeriv")
+                  .asBool());
+  }
+
+  void test_that_updateParameterTie_will_not_throw_if_the_tie_is_invalid() {
+    setup_sequential_fit_with_no_ties();
+    TS_ASSERT_THROWS_NOTHING(
+        m_model->updateParameterTie(m_wsName, m_wsIndex, "A0", "BadParameter"));
+  }
+
+  void test_that_updateParameterTie_will_throw_if_the_parameter_is_global() {
+    setup_simultaneous_fit_with_global_parameter();
+    TS_ASSERT_THROWS(
+        m_model->updateParameterTie(m_wsName, m_wsIndex, "f0.A0", "0"),
+        std::invalid_argument const &);
+  }
+
+  void
+  test_that_updateParameterTie_will_add_a_local_tie_when_in_sequential_mode() {
+    setup_sequential_fit_with_no_ties();
+
+    m_model->updateParameterTie(m_wsName, m_wsIndex, "A0", "0");
+
+    TS_ASSERT_EQUALS(
+        m_model->getFunction(m_wsName, m_wsIndex)->getParameterStatus(0),
+        IFunction::ParameterStatus::Fixed);
+  }
+
+  void
+  test_that_updateParameterTie_will_add_a_local_tie_when_in_simultaneous_mode_but_the_tie_has_the_same_domain_as_the_parameter() {
+    setup_simultaneous_fit_with_no_ties();
+
+    m_model->updateParameterTie(m_wsName, m_wsIndex, "f0.A0", "0");
+
+    TS_ASSERT_EQUALS(
+        m_model->getFunction(m_wsName, m_wsIndex)->getParameterStatus(0),
+        IFunction::ParameterStatus::Fixed);
+  }
+
+  void
+  test_that_updateParameterTie_will_add_a_global_tie_when_in_simultaneous_mode_and_the_tie_has_a_different_domain_to_the_parameter() {
+    setup_simultaneous_fit_with_no_ties();
+
+    m_model->updateParameterTie(m_wsName, m_wsIndex, "f0.A0", "f1.A0");
+
+    auto const globalTie = m_model->getGlobalTies()[0];
+    TS_ASSERT_EQUALS(globalTie.m_parameter, "f0.A0");
+    TS_ASSERT_EQUALS(globalTie.m_tie, "f1.A0");
+  }
+
+  void
+  test_that_updateParameterTie_will_remove_a_local_tie_when_the_tie_is_empty() {
+    setup_sequential_fit_with_no_ties();
+
+    m_model->updateParameterTie(m_wsName, m_wsIndex, "A0", "0");
+    m_model->updateParameterTie(m_wsName, m_wsIndex, "A0", "");
+
+    TS_ASSERT_EQUALS(
+        m_model->getFunction(m_wsName, m_wsIndex)->getParameterStatus(0),
+        IFunction::ParameterStatus::Active);
+  }
+
+  void
+  test_that_updateParameterTie_will_remove_a_global_tie_when_in_simultaneous_mode_and_the_tie_is_empty() {
+    setup_simultaneous_fit_with_no_ties();
+
+    m_model->updateParameterTie(m_wsName, m_wsIndex, "f0.A0", "f1.A0");
+    m_model->updateParameterTie(m_wsName, m_wsIndex, "f0.A0", "");
+
+    TS_ASSERT_EQUALS(m_model->getGlobalTies().size(), 0);
+  }
+
+  void
+  test_that_updateParameterConstraint_will_throw_if_the_domain_specified_does_not_exist() {
+    TS_ASSERT_THROWS(m_model->updateParameterConstraint(m_wsName, m_wsIndex,
+                                                        "f0.", "0<A0<1"),
+                     std::invalid_argument const &);
+  }
+
+  void
+  test_that_updateParameterConstraint_will_add_a_constraint_as_expected_for_sequential_mode() {
+    std::string const constraint("0<A0<1");
+    setup_sequential_fit_with_no_ties();
+
+    m_model->updateParameterConstraint(m_wsName, m_wsIndex, "", constraint);
+
+    TS_ASSERT_EQUALS(
+        m_model->getFunction(m_wsName, m_wsIndex)->getConstraint(0)->asString(),
+        constraint);
+  }
+
+  void
+  test_that_updateParameterConstraint_will_add_a_constraint_as_expected_for_simultaneous_mode() {
+    std::string const constraint("0<A0<1");
+    setup_simultaneous_fit_with_no_ties();
+
+    m_model->updateParameterConstraint(m_wsName, m_wsIndex, "f0.", constraint);
+
+    TS_ASSERT_EQUALS(
+        m_model->getFunction(m_wsName, m_wsIndex)->getConstraint(0)->asString(),
+        constraint);
+  }
+
+  void
+  test_that_removeParameterConstraint_will_throw_if_the_domain_specified_does_not_exist() {
+    TS_ASSERT_THROWS(
+        m_model->removeParameterConstraint(m_wsName, m_wsIndex, "f0.A0"),
+        std::invalid_argument const &);
+  }
+
+  void
+  test_that_removeParameterConstraint_will_add_a_constraint_as_expected_for_sequential_mode() {
+    std::string const constraint("0<A0<1");
+    setup_sequential_fit_with_no_ties();
+
+    m_model->updateParameterConstraint(m_wsName, m_wsIndex, "", constraint);
+    m_model->removeParameterConstraint(m_wsName, m_wsIndex, "A0");
+
+    TS_ASSERT_EQUALS(
+        m_model->getFunction(m_wsName, m_wsIndex)->getConstraint(0), nullptr);
+  }
+
+  void
+  test_that_removeParameterConstraint_will_add_a_constraint_as_expected_for_simultaneous_mode() {
+    std::string const constraint("0<A0<1");
+    setup_simultaneous_fit_with_no_ties();
+
+    m_model->updateParameterConstraint(m_wsName, m_wsIndex, "f0.", constraint);
+    m_model->removeParameterConstraint(m_wsName, m_wsIndex, "f0.A0");
+
+    TS_ASSERT_EQUALS(
+        m_model->getFunction(m_wsName, m_wsIndex)->getConstraint(0), nullptr);
+  }
+
+  void
+  test_that_setGlobalParameters_will_throw_if_the_global_parameter_provided_is_not_in_all_domains() {
+    m_model->setFittingMode(FittingMode::SIMULTANEOUS);
+
+    m_model->addWorkspaceDomain(m_wsName, m_wsIndex, m_startX, m_endX);
+    m_model->addWorkspaceDomain("Name2", m_wsIndex, m_startX, m_endX);
+
+    m_model->setFunction(m_wsName, m_wsIndex, m_flatBackground->asString());
+
+    TS_ASSERT_THROWS(
+        m_model->setGlobalParameters(std::vector<std::string>{"A0"}),
+        std::invalid_argument const &);
+  }
+
+  void
+  test_that_setGlobalParameters_will_throw_if_the_global_parameter_provided_has_a_local_tie() {
+    m_model->setFittingMode(FittingMode::SIMULTANEOUS);
+
+    m_model->addWorkspaceDomain(m_wsName, m_wsIndex, m_startX, m_endX);
+    m_model->addWorkspaceDomain("Name2", m_wsIndex, m_startX, m_endX);
+
+    m_model->setFunction(m_wsName, m_wsIndex, m_expDecay->asString());
+    m_model->setFunction("Name2", m_wsIndex, m_expDecay->asString());
+
+    m_model->updateParameterTie(m_wsName, m_wsIndex, "f0.Height",
+                                "f0.Lifetime");
+
+    TS_ASSERT_THROWS(
+        m_model->setGlobalParameters(std::vector<std::string>{"Height"}),
+        std::invalid_argument const &);
+  }
+
+  void
+  test_that_setGlobalParameters_will_throw_if_the_global_parameter_provided_has_a_global_tie() {
+    setup_simultaneous_fit_with_global_tie();
+    TS_ASSERT_THROWS(
+        m_model->setGlobalParameters(std::vector<std::string>{"A0"}),
+        std::invalid_argument const &);
+  }
+
+  void
+  test_that_setGlobalParameters_will_set_the_global_parameters_as_expected_when_they_are_valid() {
+    setup_simultaneous_fit_with_no_ties();
+
+    m_model->setGlobalParameters(std::vector<std::string>{"A0"});
+
+    auto const globalParameter = m_model->getGlobalParameters()[0];
+    TS_ASSERT_EQUALS(globalParameter.m_parameter, "A0");
+  }
+
+  void test_that_setFittingMode_will_throw_if_given_an_invalid_fitting_mode() {
+    TS_ASSERT_THROWS(
+        m_model->setFittingMode(FittingMode::SIMULTANEOUS_SEQUENTIAL),
+        std::invalid_argument const &);
+  }
+
+  void
+  test_that_setFittingMode_will_clear_the_global_ties_and_tell_the_presenter() {
+    setup_simultaneous_fit_with_global_tie();
+
+    EXPECT_CALL(*m_presenter, setGlobalTies(VectorSize(0))).Times(1);
+    m_model->setFittingMode(FittingMode::SEQUENTIAL);
+
+    m_model->updateParameterTie(m_wsName, m_wsIndex, "f0.A0", "f1.A0");
+
+    EXPECT_CALL(*m_presenter, setGlobalTies(VectorSize(0))).Times(1);
+    m_model->setFittingMode(FittingMode::SIMULTANEOUS);
+  }
+
+  void
+  test_that_setFittingMode_will_clear_the_global_parameters_and_tell_the_presenter() {
+    setup_simultaneous_fit_with_global_parameter();
+
+    EXPECT_CALL(*m_presenter, setGlobalParameters(VectorSize(0))).Times(1);
+    m_model->setFittingMode(FittingMode::SEQUENTIAL);
+
+    m_model->setGlobalParameters(std::vector<std::string>{"A0"});
+
+    EXPECT_CALL(*m_presenter, setGlobalParameters(VectorSize(0))).Times(1);
+    m_model->setFittingMode(FittingMode::SIMULTANEOUS);
+  }
 
 private:
+  void setup_model_data() {
+    m_model->addWorkspaceDomain(m_wsName, m_wsIndex, m_startX, m_endX);
+    m_model->addWorkspaceDomain("Name2", m_wsIndex, m_startX, m_endX);
+
+    m_model->setFunction(m_wsName, m_wsIndex, m_flatBackground->asString());
+    m_model->setFunction("Name2", m_wsIndex, m_flatBackground->asString());
+  }
+
+  void setup_sequential_fit_with_no_ties() {
+    m_model->setFittingMode(FittingMode::SEQUENTIAL);
+    setup_model_data();
+  }
+
+  void setup_simultaneous_fit_with_no_ties() {
+    m_model->setFittingMode(FittingMode::SIMULTANEOUS);
+    setup_model_data();
+  }
+
+  void setup_simultaneous_fit_with_global_tie() {
+    setup_simultaneous_fit_with_no_ties();
+    m_model->updateParameterTie(m_wsName, m_wsIndex, "f0.A0", "f1.A0");
+  }
+
+  void setup_simultaneous_fit_with_global_parameter() {
+    setup_simultaneous_fit_with_no_ties();
+    m_model->setGlobalParameters(std::vector<std::string>{"A0"});
+  }
+
   std::string m_wsName;
   MantidQt::MantidWidgets::WorkspaceIndex m_wsIndex;
   Mantid::API::MatrixWorkspace_sptr m_workspace;

--- a/qt/widgets/common/test/FitScriptGeneratorModelTest.h
+++ b/qt/widgets/common/test/FitScriptGeneratorModelTest.h
@@ -12,6 +12,7 @@
 #include "MantidAPI/FunctionFactory.h"
 #include "MantidAPI/IFunction.h"
 #include "MantidAPI/MatrixWorkspace.h"
+#include "MantidKernel/WarningSuppressions.h"
 #include "MantidQtWidgets/Common/FitDomain.h"
 #include "MantidQtWidgets/Common/FitScriptGeneratorMockObjects.h"
 #include "MantidQtWidgets/Common/FitScriptGeneratorModel.h"
@@ -44,7 +45,11 @@ Mantid::API::CompositeFunction_sptr createEmptyComposite() {
 
 } // namespace
 
+GNU_DIAG_OFF_SUGGEST_OVERRIDE
+
 MATCHER_P(VectorSize, expectedSize, "") { return arg.size() == expectedSize; }
+
+GNU_DIAG_ON_SUGGEST_OVERRIDE
 
 class FitScriptGeneratorModelTest : public CxxTest::TestSuite {
 
@@ -618,12 +623,12 @@ public:
   test_that_setFittingMode_will_clear_the_global_ties_and_tell_the_presenter() {
     setup_simultaneous_fit_with_global_tie();
 
-    EXPECT_CALL(*m_presenter, setGlobalTies(VectorSize(0))).Times(1);
+    EXPECT_CALL(*m_presenter, setGlobalTies(VectorSize(0u))).Times(1);
     m_model->setFittingMode(FittingMode::SEQUENTIAL);
 
     m_model->updateParameterTie(m_wsName, m_wsIndex, "f0.A0", "f1.A0");
 
-    EXPECT_CALL(*m_presenter, setGlobalTies(VectorSize(0))).Times(1);
+    EXPECT_CALL(*m_presenter, setGlobalTies(VectorSize(0u))).Times(1);
     m_model->setFittingMode(FittingMode::SIMULTANEOUS);
   }
 
@@ -631,12 +636,12 @@ public:
   test_that_setFittingMode_will_clear_the_global_parameters_and_tell_the_presenter() {
     setup_simultaneous_fit_with_global_parameter();
 
-    EXPECT_CALL(*m_presenter, setGlobalParameters(VectorSize(0))).Times(1);
+    EXPECT_CALL(*m_presenter, setGlobalParameters(VectorSize(0u))).Times(1);
     m_model->setFittingMode(FittingMode::SEQUENTIAL);
 
     m_model->setGlobalParameters(std::vector<std::string>{"A0"});
 
-    EXPECT_CALL(*m_presenter, setGlobalParameters(VectorSize(0))).Times(1);
+    EXPECT_CALL(*m_presenter, setGlobalParameters(VectorSize(0u))).Times(1);
     m_model->setFittingMode(FittingMode::SIMULTANEOUS);
   }
 

--- a/qt/widgets/common/test/FitScriptGeneratorModelTest.h
+++ b/qt/widgets/common/test/FitScriptGeneratorModelTest.h
@@ -1,0 +1,97 @@
+// Mantid Repository : https://github.com/mantidproject/mantid
+//
+// Copyright &copy; 2020 ISIS Rutherford Appleton Laboratory UKRI,
+//   NScD Oak Ridge National Laboratory, European Spallation Source,
+//   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+// SPDX - License - Identifier: GPL - 3.0 +
+#pragma once
+
+#include "MantidAPI/AnalysisDataService.h"
+#include "MantidAPI/CompositeFunction.h"
+#include "MantidAPI/FrameworkManager.h"
+#include "MantidAPI/FunctionFactory.h"
+#include "MantidAPI/IFunction.h"
+#include "MantidAPI/MatrixWorkspace.h"
+#include "MantidQtWidgets/Common/FitDomain.h"
+#include "MantidQtWidgets/Common/FitScriptGeneratorMockObjects.h"
+#include "MantidQtWidgets/Common/FitScriptGeneratorModel.h"
+#include "MantidTestHelpers/WorkspaceCreationHelper.h"
+
+#include <cxxtest/TestSuite.h>
+
+#include <memory>
+
+using namespace MantidQt::MantidWidgets;
+using namespace WorkspaceCreationHelper;
+
+namespace {
+
+Mantid::API::IFunction_sptr createIFunction(std::string const &functionString) {
+  return Mantid::API::FunctionFactory::Instance().createInitialized(
+      functionString);
+}
+
+Mantid::API::CompositeFunction_sptr
+toComposite(Mantid::API::IFunction_sptr function) {
+  return std::dynamic_pointer_cast<Mantid::API::CompositeFunction>(function);
+}
+
+Mantid::API::CompositeFunction_sptr createEmptyComposite() {
+  return toComposite(createIFunction("name=CompositeFunction"));
+}
+
+} // namespace
+
+class FitScriptGeneratorModelTest : public CxxTest::TestSuite {
+
+public:
+  FitScriptGeneratorModelTest()
+      : m_wsName("Name"), m_wsIndex(MantidQt::MantidWidgets::WorkspaceIndex(0)),
+        m_workspace(create2DWorkspace(3, 3)),
+        m_startX(m_workspace->x(m_wsIndex.value).front()),
+        m_endX(m_workspace->x(m_wsIndex.value).back()) {
+    Mantid::API::FrameworkManager::Instance();
+  }
+
+  static FitScriptGeneratorModelTest *createSuite() {
+    return new FitScriptGeneratorModelTest;
+  }
+
+  static void destroySuite(FitScriptGeneratorModelTest *suite) { delete suite; }
+
+  void setUp() override {
+    m_flatBackground = createIFunction("name=FlatBackground");
+    m_expDecay = createIFunction("name=ExpDecay");
+
+    auto composite = createEmptyComposite();
+    composite->addFunction(createIFunction("name=FlatBackground"));
+    composite->addFunction(createIFunction("name=ExpDecay"));
+    m_composite = composite;
+
+    Mantid::API::AnalysisDataService::Instance().addOrReplace(m_wsName,
+                                                              m_workspace);
+
+    m_model = std::make_unique<FitScriptGeneratorModel>();
+    m_presenter =
+        std::make_unique<MockFitScriptGeneratorPresenter>(m_model.get());
+  }
+
+  void tearDown() override {
+    Mantid::API::AnalysisDataService::Instance().clear();
+  }
+
+  void test_end() {}
+
+private:
+  std::string m_wsName;
+  MantidQt::MantidWidgets::WorkspaceIndex m_wsIndex;
+  Mantid::API::MatrixWorkspace_sptr m_workspace;
+  double m_startX;
+  double m_endX;
+  Mantid::API::IFunction_sptr m_flatBackground;
+  Mantid::API::IFunction_sptr m_expDecay;
+  Mantid::API::IFunction_sptr m_composite;
+
+  std::unique_ptr<FitScriptGeneratorModel> m_model;
+  std::unique_ptr<MockFitScriptGeneratorPresenter> m_presenter;
+};

--- a/qt/widgets/common/test/FitScriptGeneratorModelTest.h
+++ b/qt/widgets/common/test/FitScriptGeneratorModelTest.h
@@ -645,6 +645,36 @@ public:
     m_model->setFittingMode(FittingMode::SIMULTANEOUS);
   }
 
+  void
+  test_that_setting_the_value_of_a_parameter_to_a_value_outside_of_the_constraints_of_another_parameter_globally_tied_to_it_will_remove_the_tie() {
+    setup_simultaneous_fit_with_no_ties();
+
+    m_model->updateParameterConstraint(m_wsName, m_wsIndex, "f0.",
+                                       "0.0<A0<1.0");
+    m_model->updateParameterTie(m_wsName, m_wsIndex, "f0.A0", "f1.A0");
+
+    m_model->updateParameterValue("Name2", m_wsIndex, "f1.A0", 2.0);
+
+    auto const function = m_model->getFunction(m_wsName, m_wsIndex);
+    TS_ASSERT_EQUALS(function->getParameter("A0"), 0.0);
+    TS_ASSERT_EQUALS(m_model->getGlobalTies().size(), 0);
+  }
+
+  void
+  test_that_attempting_to_globally_tie_a_parameter_to_another_parameter_with_a_value_outside_the_allowed_constraints_will_not_perform_the_tie() {
+    setup_simultaneous_fit_with_no_ties();
+
+    m_model->updateParameterConstraint(m_wsName, m_wsIndex, "f0.",
+                                       "0.0<A0<1.0");
+    m_model->updateParameterValue("Name2", m_wsIndex, "f1.A0", 2.0);
+
+    m_model->updateParameterTie(m_wsName, m_wsIndex, "f0.A0", "f1.A0");
+
+    auto const function = m_model->getFunction(m_wsName, m_wsIndex);
+    TS_ASSERT_EQUALS(function->getParameter("A0"), 0.0);
+    TS_ASSERT_EQUALS(m_model->getGlobalTies().size(), 0);
+  }
+
 private:
   void setup_model_data() {
     m_model->addWorkspaceDomain(m_wsName, m_wsIndex, m_startX, m_endX);

--- a/qt/widgets/common/test/FitScriptGeneratorModelTest.h
+++ b/qt/widgets/common/test/FitScriptGeneratorModelTest.h
@@ -119,9 +119,11 @@ public:
 
   void test_that_removeWorkspaceDomain_will_remove_the_specified_domain() {
     m_model->addWorkspaceDomain(m_wsName, m_wsIndex, m_startX, m_endX);
+    m_model->addWorkspaceDomain("Name2", m_wsIndex, m_startX, m_endX);
     m_model->removeWorkspaceDomain(m_wsName, m_wsIndex);
 
     TS_ASSERT(!m_model->hasWorkspaceDomain(m_wsName, m_wsIndex));
+    TS_ASSERT(m_model->hasWorkspaceDomain("Name2", m_wsIndex));
   }
 
   void
@@ -236,12 +238,14 @@ public:
 
   void test_that_setFunction_will_set_the_function_in_the_correct_domain() {
     m_model->addWorkspaceDomain(m_wsName, m_wsIndex, m_startX, m_endX);
+    m_model->addWorkspaceDomain("Name2", m_wsIndex, m_startX, m_endX);
     m_model->addFunction(m_wsName, m_wsIndex, m_expDecay->asString());
 
     m_model->setFunction(m_wsName, m_wsIndex, m_flatBackground->asString());
 
     TS_ASSERT_EQUALS(m_model->getFunction(m_wsName, m_wsIndex)->asString(),
                      m_flatBackground->asString());
+    TS_ASSERT_EQUALS(m_model->getFunction("Name2", m_wsIndex), nullptr);
   }
 
   void test_that_setFunction_will_clear_the_global_ties_that_have_expired() {
@@ -263,10 +267,12 @@ public:
   test_that_removeFunction_will_remove_the_function_in_the_correct_domain() {
     m_model->addWorkspaceDomain(m_wsName, m_wsIndex, m_startX, m_endX);
     m_model->addFunction(m_wsName, m_wsIndex, m_flatBackground->asString());
+    m_model->addFunction(m_wsName, m_wsIndex, m_expDecay->asString());
 
     m_model->removeFunction(m_wsName, m_wsIndex, m_flatBackground->asString());
 
-    TS_ASSERT_EQUALS(m_model->getFunction(m_wsName, m_wsIndex), nullptr);
+    TS_ASSERT_EQUALS(m_model->getFunction(m_wsName, m_wsIndex)->asString(),
+                     m_expDecay->asString());
   }
 
   void test_that_removeFunction_will_clear_the_global_ties_that_have_expired() {

--- a/qt/widgets/common/test/FitScriptGeneratorPresenterTest.h
+++ b/qt/widgets/common/test/FitScriptGeneratorPresenterTest.h
@@ -12,7 +12,7 @@
 #include "MantidAPI/FunctionFactory.h"
 #include "MantidAPI/IFunction.h"
 #include "MantidAPI/MatrixWorkspace.h"
-#include "MantidKernel/WarningSuppressions.h"
+#include "MantidQtWidgets/Common/FitScriptGeneratorMockObjects.h"
 #include "MantidQtWidgets/Common/FitScriptGeneratorPresenter.h"
 #include "MantidQtWidgets/Common/FittingGlobals.h"
 #include "MantidQtWidgets/Common/IFitScriptGeneratorModel.h"
@@ -38,138 +38,8 @@ Mantid::API::IFunction_sptr createIFunction(std::string const &functionString) {
 
 } // namespace
 
-GNU_DIAG_OFF_SUGGEST_OVERRIDE
-
-class MockFitScriptGeneratorView : public IFitScriptGeneratorView {
-
-public:
-  MOCK_METHOD1(subscribePresenter,
-               void(IFitScriptGeneratorPresenter *presenter));
-
-  MOCK_CONST_METHOD1(workspaceName, std::string(FitDomainIndex index));
-  MOCK_CONST_METHOD1(workspaceIndex, WorkspaceIndex(FitDomainIndex index));
-  MOCK_CONST_METHOD1(startX, double(FitDomainIndex index));
-  MOCK_CONST_METHOD1(endX, double(FitDomainIndex index));
-
-  MOCK_CONST_METHOD0(allRows, std::vector<FitDomainIndex>());
-  MOCK_CONST_METHOD0(selectedRows, std::vector<FitDomainIndex>());
-
-  MOCK_CONST_METHOD1(parameterValue, double(std::string const &parameter));
-  MOCK_CONST_METHOD1(attributeValue, Mantid::API::IFunction::Attribute(
-                                         std::string const &attribute));
-
-  MOCK_METHOD2(removeWorkspaceDomain, void(std::string const &workspaceName,
-                                           WorkspaceIndex workspaceIndex));
-  MOCK_METHOD4(addWorkspaceDomain,
-               void(std::string const &workspaceName,
-                    WorkspaceIndex workspaceIndex, double startX, double endX));
-
-  MOCK_METHOD0(openAddWorkspaceDialog, bool());
-  MOCK_METHOD0(getDialogWorkspaces,
-               std::vector<Mantid::API::MatrixWorkspace_const_sptr>());
-  MOCK_CONST_METHOD0(getDialogWorkspaceIndices, std::vector<WorkspaceIndex>());
-
-  MOCK_METHOD0(resetSelection, void());
-
-  MOCK_CONST_METHOD0(isAddRemoveFunctionForAllChecked, bool());
-
-  MOCK_METHOD0(clearFunction, void());
-  MOCK_CONST_METHOD1(setFunction,
-                     void(Mantid::API::IFunction_sptr const &function));
-
-  MOCK_METHOD1(setSimultaneousMode, void(bool simultaneousMode));
-
-  MOCK_METHOD1(setGlobalTies, void(std::vector<GlobalTie> const &globalTies));
-  MOCK_METHOD1(setGlobalParameters,
-               void(std::vector<GlobalParameter> const &globalParameter));
-
-  MOCK_METHOD1(displayWarning, void(std::string const &message));
-
-  MOCK_CONST_METHOD0(tableWidget, FitScriptGeneratorDataTable *());
-  MOCK_CONST_METHOD0(removeButton, QPushButton *());
-  MOCK_CONST_METHOD0(addWorkspaceButton, QPushButton *());
-  MOCK_CONST_METHOD0(addWorkspaceDialog, AddWorkspaceDialog *());
-};
-
-class MockFitScriptGeneratorModel : public IFitScriptGeneratorModel {
-
-public:
-  MOCK_METHOD1(subscribePresenter,
-               void(IFitScriptGeneratorPresenter *presenter));
-
-  MOCK_METHOD2(removeWorkspaceDomain, void(std::string const &workspaceName,
-                                           WorkspaceIndex workspaceIndex));
-  MOCK_METHOD4(addWorkspaceDomain,
-               void(std::string const &workspaceName,
-                    WorkspaceIndex workspaceIndex, double startX, double endX));
-
-  MOCK_METHOD3(updateStartX,
-               bool(std::string const &workspaceName,
-                    WorkspaceIndex workspaceIndex, double startX));
-  MOCK_METHOD3(updateEndX, bool(std::string const &workspaceName,
-                                WorkspaceIndex workspaceIndex, double endX));
-
-  MOCK_METHOD3(removeFunction, void(std::string const &workspaceName,
-                                    WorkspaceIndex workspaceIndex,
-                                    std::string const &function));
-  MOCK_METHOD3(addFunction, void(std::string const &workspaceName,
-                                 WorkspaceIndex workspaceIndex,
-                                 std::string const &function));
-  MOCK_METHOD3(setFunction, void(std::string const &workspaceName,
-                                 WorkspaceIndex workspaceIndex,
-                                 std::string const &function));
-  MOCK_CONST_METHOD2(
-      getFunction, Mantid::API::IFunction_sptr(std::string const &workspaceName,
-                                               WorkspaceIndex workspaceIndex));
-
-  MOCK_CONST_METHOD3(getEquivalentFunctionIndexForDomain,
-                     std::string(std::string const &workspaceName,
-                                 WorkspaceIndex workspaceIndex,
-                                 std::string const &functionIndex));
-  MOCK_CONST_METHOD4(getEquivalentParameterTieForDomain,
-                     std::string(std::string const &workspaceName,
-                                 WorkspaceIndex workspaceIndex,
-                                 std::string const &fullParameter,
-                                 std::string const &fullTie));
-
-  MOCK_METHOD4(updateParameterValue,
-               void(std::string const &workspaceName,
-                    WorkspaceIndex workspaceIndex,
-                    std::string const &fullParameter, double newValue));
-  MOCK_METHOD4(updateAttributeValue,
-               void(std::string const &workspaceName,
-                    WorkspaceIndex workspaceIndex,
-                    std::string const &fullAttribute,
-                    Mantid::API::IFunction::Attribute const &newValue));
-
-  MOCK_METHOD4(updateParameterTie,
-               void(std::string const &workspaceName,
-                    WorkspaceIndex workspaceIndex,
-                    std::string const &fullParameter, std::string const &tie));
-
-  MOCK_METHOD3(removeParameterConstraint,
-               void(std::string const &workspaceName,
-                    WorkspaceIndex workspaceIndex,
-                    std::string const &fullParameter));
-  MOCK_METHOD4(updateParameterConstraint, void(std::string const &workspaceName,
-                                               WorkspaceIndex workspaceIndex,
-                                               std::string const &functionIndex,
-                                               std::string const &constraint));
-
-  MOCK_METHOD1(setGlobalParameters,
-               void(std::vector<std::string> const &parameters));
-
-  MOCK_METHOD1(setFittingMode, void(FittingMode fittingMode));
-  MOCK_CONST_METHOD0(getFittingMode, FittingMode());
-
-  MOCK_CONST_METHOD0(getGlobalTies, std::vector<GlobalTie>());
-  MOCK_CONST_METHOD0(getGlobalParameters, std::vector<GlobalParameter>());
-};
-
 MATCHER_P(VectorSize, expectedSize, "") { return arg.size() == expectedSize; }
 MATCHER_P(BoolAttributeValue, value, "") { return arg.asBool() == value; }
-
-GNU_DIAG_ON_SUGGEST_OVERRIDE
 
 class FitScriptGeneratorPresenterTest : public CxxTest::TestSuite {
 
@@ -187,7 +57,7 @@ public:
 
   void setUp() override {
     m_wsName = "Name";
-    m_wsIndex = WorkspaceIndex(0);
+    m_wsIndex = MantidQt::MantidWidgets::WorkspaceIndex(0);
     m_workspace = create2DWorkspace(3, 3);
     m_startX = m_workspace->x(m_wsIndex.value).front();
     m_endX = m_workspace->x(m_wsIndex.value).back();
@@ -264,7 +134,8 @@ public:
   test_that_a_add_domain_event_will_attempt_to_add_a_domain_in_the_view_and_model() {
     auto const workspaces =
         std::vector<Mantid::API::MatrixWorkspace_const_sptr>{m_workspace};
-    auto const workspaceIndices = std::vector<WorkspaceIndex>{m_wsIndex};
+    auto const workspaceIndices =
+        std::vector<MantidQt::MantidWidgets::WorkspaceIndex>{m_wsIndex};
 
     ON_CALL(*m_view, openAddWorkspaceDialog()).WillByDefault(Return(true));
     ON_CALL(*m_view, getDialogWorkspaces()).WillByDefault(Return(workspaces));
@@ -868,7 +739,7 @@ private:
   }
 
   std::string m_wsName;
-  WorkspaceIndex m_wsIndex;
+  MantidQt::MantidWidgets::WorkspaceIndex m_wsIndex;
   Mantid::API::MatrixWorkspace_sptr m_workspace;
   double m_startX;
   double m_endX;

--- a/qt/widgets/common/test/FitScriptGeneratorPresenterTest.h
+++ b/qt/widgets/common/test/FitScriptGeneratorPresenterTest.h
@@ -12,6 +12,7 @@
 #include "MantidAPI/FunctionFactory.h"
 #include "MantidAPI/IFunction.h"
 #include "MantidAPI/MatrixWorkspace.h"
+#include "MantidKernel/WarningSuppressions.h"
 #include "MantidQtWidgets/Common/FitScriptGeneratorMockObjects.h"
 #include "MantidQtWidgets/Common/FitScriptGeneratorPresenter.h"
 #include "MantidQtWidgets/Common/FittingGlobals.h"
@@ -38,8 +39,12 @@ Mantid::API::IFunction_sptr createIFunction(std::string const &functionString) {
 
 } // namespace
 
-MATCHER_P(VectorSize, expectedSize, "") { return arg.size() == expectedSize; }
+GNU_DIAG_OFF_SUGGEST_OVERRIDE
+
 MATCHER_P(BoolAttributeValue, value, "") { return arg.asBool() == value; }
+MATCHER_P(VectorSize, expectedSize, "") { return arg.size() == expectedSize; }
+
+GNU_DIAG_ON_SUGGEST_OVERRIDE
 
 class FitScriptGeneratorPresenterTest : public CxxTest::TestSuite {
 
@@ -125,7 +130,7 @@ public:
     EXPECT_CALL(*m_view, setFunction(m_function)).Times(1);
 
     EXPECT_CALL(*m_model, getGlobalParameters()).Times(1);
-    EXPECT_CALL(*m_view, setGlobalParameters(VectorSize(0))).Times(1);
+    EXPECT_CALL(*m_view, setGlobalParameters(VectorSize(0u))).Times(1);
 
     m_presenter->notifyPresenter(ViewEvent::RemoveClicked);
   }
@@ -558,7 +563,7 @@ public:
         .Times(1);
 
     EXPECT_CALL(*m_model, getGlobalTies()).Times(1);
-    EXPECT_CALL(*m_view, setGlobalTies(VectorSize(0))).Times(1);
+    EXPECT_CALL(*m_view, setGlobalTies(VectorSize(0u))).Times(1);
 
     EXPECT_CALL(*m_view, selectedRows()).Times(1);
 

--- a/qt/widgets/common/test/FitScriptGeneratorPresenterTest.h
+++ b/qt/widgets/common/test/FitScriptGeneratorPresenterTest.h
@@ -167,6 +167,7 @@ public:
 };
 
 MATCHER_P(VectorSize, expectedSize, "") { return arg.size() == expectedSize; }
+MATCHER_P(BoolAttributeValue, value, "") { return arg.asBool() == value; }
 
 GNU_DIAG_ON_SUGGEST_OVERRIDE
 
@@ -429,7 +430,443 @@ public:
     m_presenter->notifyPresenter(ViewEvent::EndXChanged);
   }
 
+  void
+  test_that_SelectionChanged_will_set_the_function_in_the_view_when_a_row_exists() {
+    set_selection_changed_expectations(FitDomainIndex(0));
+    m_presenter->notifyPresenter(ViewEvent::SelectionChanged);
+  }
+
+  void test_that_SelectionChanged_will_clear_the_function_when_no_rows_exist() {
+    set_selection_changed_expectations(FitDomainIndex(0), true);
+    m_presenter->notifyPresenter(ViewEvent::SelectionChanged);
+  }
+
+  void
+  test_that_FunctionRemoved_will_remove_the_function_from_the_relevant_domains() {
+    auto const selectedRow = FitDomainIndex(0);
+    auto const selectedRows = std::vector<FitDomainIndex>{selectedRow};
+
+    ON_CALL(*m_view, isAddRemoveFunctionForAllChecked())
+        .WillByDefault(Return(false));
+    ON_CALL(*m_view, selectedRows()).WillByDefault(Return(selectedRows));
+    ON_CALL(*m_view, workspaceName(selectedRow))
+        .WillByDefault(Return(m_wsName));
+    ON_CALL(*m_view, workspaceIndex(selectedRow))
+        .WillByDefault(Return(m_wsIndex));
+
+    EXPECT_CALL(*m_view, isAddRemoveFunctionForAllChecked)
+        .Times(1)
+        .WillOnce(Return(false));
+    EXPECT_CALL(*m_view, selectedRows())
+        .Times(2)
+        .WillRepeatedly(Return(selectedRows));
+    EXPECT_CALL(*m_view, workspaceName(selectedRow))
+        .Times(2)
+        .WillRepeatedly(Return(m_wsName));
+    EXPECT_CALL(*m_view, workspaceIndex(selectedRow))
+        .Times(2)
+        .WillRepeatedly(Return(m_wsIndex));
+    EXPECT_CALL(*m_model,
+                removeFunction(m_wsName, m_wsIndex, m_function->asString()))
+        .Times(1);
+
+    set_selection_changed_expectations(selectedRow, false, true);
+
+    m_presenter->notifyPresenter(ViewEvent::FunctionRemoved,
+                                 m_function->asString());
+  }
+
+  void
+  test_that_FunctionAdded_will_clear_the_function_in_the_view_if_no_data_exists() {
+    auto const selectedRows = std::vector<FitDomainIndex>{};
+
+    ON_CALL(*m_view, isAddRemoveFunctionForAllChecked())
+        .WillByDefault(Return(false));
+    ON_CALL(*m_view, selectedRows()).WillByDefault(Return(selectedRows));
+
+    EXPECT_CALL(*m_view, isAddRemoveFunctionForAllChecked)
+        .Times(1)
+        .WillOnce(Return(false));
+    EXPECT_CALL(*m_view, selectedRows())
+        .Times(1)
+        .WillOnce(Return(selectedRows));
+    EXPECT_CALL(
+        *m_view,
+        displayWarning("Data needs to be loaded before adding a function."))
+        .Times(1);
+    EXPECT_CALL(*m_view, clearFunction()).Times(1);
+
+    m_presenter->notifyPresenter(ViewEvent::FunctionAdded,
+                                 m_function->asString());
+  }
+
+  void
+  test_that_FunctionAdded_will_add_the_function_in_the_relevant_domains_when_data_exists() {
+    auto const selectedRow = FitDomainIndex(0);
+    auto const selectedRows = std::vector<FitDomainIndex>{selectedRow};
+
+    ON_CALL(*m_view, isAddRemoveFunctionForAllChecked())
+        .WillByDefault(Return(false));
+    ON_CALL(*m_view, selectedRows()).WillByDefault(Return(selectedRows));
+
+    EXPECT_CALL(*m_view, isAddRemoveFunctionForAllChecked)
+        .Times(1)
+        .WillOnce(Return(false));
+    EXPECT_CALL(*m_view, selectedRows())
+        .Times(1)
+        .WillOnce(Return(selectedRows));
+    EXPECT_CALL(*m_view, workspaceName(selectedRow))
+        .Times(1)
+        .WillOnce(Return(m_wsName));
+    EXPECT_CALL(*m_view, workspaceIndex(selectedRow))
+        .Times(1)
+        .WillOnce(Return(m_wsIndex));
+    EXPECT_CALL(*m_model,
+                addFunction(m_wsName, m_wsIndex, m_function->asString()))
+        .Times(1);
+
+    m_presenter->notifyPresenter(ViewEvent::FunctionAdded,
+                                 m_function->asString());
+  }
+
+  void
+  test_that_FunctionReplaced_will_clear_the_function_in_the_view_if_no_data_exists() {
+    auto const selectedRows = std::vector<FitDomainIndex>{};
+
+    ON_CALL(*m_view, isAddRemoveFunctionForAllChecked())
+        .WillByDefault(Return(false));
+    ON_CALL(*m_view, selectedRows()).WillByDefault(Return(selectedRows));
+
+    EXPECT_CALL(*m_view, isAddRemoveFunctionForAllChecked)
+        .Times(1)
+        .WillOnce(Return(false));
+    EXPECT_CALL(*m_view, selectedRows())
+        .Times(1)
+        .WillOnce(Return(selectedRows));
+    EXPECT_CALL(
+        *m_view,
+        displayWarning("Data needs to be loaded before adding a function."))
+        .Times(1);
+    EXPECT_CALL(*m_view, clearFunction()).Times(1);
+
+    m_presenter->notifyPresenter(ViewEvent::FunctionReplaced,
+                                 m_function->asString());
+  }
+
+  void
+  test_that_FunctionReplaced_will_set_the_function_in_the_relevant_domains_when_data_exists() {
+    auto const selectedRow = FitDomainIndex(0);
+    auto const selectedRows = std::vector<FitDomainIndex>{selectedRow};
+
+    ON_CALL(*m_view, isAddRemoveFunctionForAllChecked())
+        .WillByDefault(Return(false));
+    ON_CALL(*m_view, selectedRows()).WillByDefault(Return(selectedRows));
+    ON_CALL(*m_view, workspaceName(selectedRow))
+        .WillByDefault(Return(m_wsName));
+    ON_CALL(*m_view, workspaceIndex(selectedRow))
+        .WillByDefault(Return(m_wsIndex));
+
+    EXPECT_CALL(*m_view, isAddRemoveFunctionForAllChecked)
+        .Times(1)
+        .WillOnce(Return(false));
+    EXPECT_CALL(*m_view, selectedRows())
+        .Times(1)
+        .WillOnce(Return(selectedRows));
+    EXPECT_CALL(*m_view, workspaceName(selectedRow))
+        .Times(1)
+        .WillOnce(Return(m_wsName));
+    EXPECT_CALL(*m_view, workspaceIndex(selectedRow))
+        .Times(1)
+        .WillOnce(Return(m_wsIndex));
+    EXPECT_CALL(*m_model,
+                setFunction(m_wsName, m_wsIndex, m_function->asString()))
+        .Times(1);
+
+    m_presenter->notifyPresenter(ViewEvent::FunctionReplaced,
+                                 m_function->asString());
+  }
+
+  void test_that_ParameterChanged_will_update_the_relevant_parameter_values() {
+    std::string const parameter("A0");
+    double parameterValue(1.0);
+    auto const row = FitDomainIndex(0);
+    auto const allRows = std::vector<FitDomainIndex>{row};
+
+    ON_CALL(*m_view, parameterValue(parameter))
+        .WillByDefault(Return(parameterValue));
+    ON_CALL(*m_view, selectedRows()).WillByDefault(Return(allRows));
+    ON_CALL(*m_view, allRows()).WillByDefault(Return(allRows));
+    ON_CALL(*m_view, workspaceName(row)).WillByDefault(Return(m_wsName));
+    ON_CALL(*m_view, workspaceIndex(row)).WillByDefault(Return(m_wsIndex));
+    ON_CALL(*m_model,
+            getEquivalentFunctionIndexForDomain(m_wsName, m_wsIndex, parameter))
+        .WillByDefault(Return(parameter));
+
+    EXPECT_CALL(*m_view, parameterValue(parameter)).Times(1);
+    EXPECT_CALL(*m_view, allRows()).Times(1);
+    EXPECT_CALL(*m_view, workspaceName(row))
+        .Times(2)
+        .WillRepeatedly(Return(m_wsName));
+    EXPECT_CALL(*m_view, workspaceIndex(row))
+        .Times(2)
+        .WillRepeatedly(Return(m_wsIndex));
+    EXPECT_CALL(*m_model, getEquivalentFunctionIndexForDomain(
+                              m_wsName, m_wsIndex, parameter))
+        .Times(1);
+    EXPECT_CALL(*m_model, updateParameterValue(m_wsName, m_wsIndex, parameter,
+                                               parameterValue))
+        .Times(1);
+    EXPECT_CALL(*m_view, selectedRows()).Times(1);
+
+    set_selection_changed_expectations(row, false, true);
+
+    m_presenter->notifyPresenter(ViewEvent::ParameterChanged, parameter);
+  }
+
+  void test_that_AttributeChanged_will_update_the_relevant_attribute_values() {
+    std::string const attribute("NumDeriv");
+    Mantid::API::IFunction::Attribute attributeValue(true);
+    auto const row = FitDomainIndex(0);
+    auto const allRows = std::vector<FitDomainIndex>{row};
+
+    ON_CALL(*m_view, attributeValue(attribute))
+        .WillByDefault(Return(attributeValue));
+    ON_CALL(*m_view, allRows()).WillByDefault(Return(allRows));
+    ON_CALL(*m_view, workspaceName(row)).WillByDefault(Return(m_wsName));
+    ON_CALL(*m_view, workspaceIndex(row)).WillByDefault(Return(m_wsIndex));
+
+    EXPECT_CALL(*m_view, attributeValue(attribute)).Times(1);
+    EXPECT_CALL(*m_view, allRows()).Times(1);
+    EXPECT_CALL(*m_view, workspaceName(row))
+        .Times(1)
+        .WillOnce(Return(m_wsName));
+    EXPECT_CALL(*m_view, workspaceIndex(row))
+        .Times(1)
+        .WillOnce(Return(m_wsIndex));
+    EXPECT_CALL(*m_model, updateAttributeValue(
+                              m_wsName, m_wsIndex, attribute,
+                              BoolAttributeValue(attributeValue.asBool())))
+        .Times(1);
+
+    m_presenter->notifyPresenter(ViewEvent::AttributeChanged, attribute);
+  }
+
+  void
+  test_that_ParameterTieChanged_will_attempt_to_update_the_ties_in_the_model() {
+    std::string const parameter("A0");
+    std::string const tie("A1");
+    auto const row = FitDomainIndex(0);
+    auto const allRows = std::vector<FitDomainIndex>{row};
+    auto const globalTies = std::vector<GlobalTie>{};
+
+    ON_CALL(*m_view, allRows()).WillByDefault(Return(allRows));
+    ON_CALL(*m_view, selectedRows()).WillByDefault(Return(allRows));
+    ON_CALL(*m_model,
+            getEquivalentFunctionIndexForDomain(m_wsName, m_wsIndex, parameter))
+        .WillByDefault(Return(parameter));
+    ON_CALL(*m_model, getEquivalentParameterTieForDomain(m_wsName, m_wsIndex,
+                                                         parameter, tie))
+        .WillByDefault(Return(tie));
+    ON_CALL(*m_model, getGlobalTies()).WillByDefault(Return(globalTies));
+
+    EXPECT_CALL(*m_view, allRows()).Times(1);
+    EXPECT_CALL(*m_view, workspaceName(row))
+        .Times(2)
+        .WillRepeatedly(Return(m_wsName));
+    EXPECT_CALL(*m_view, workspaceIndex(row))
+        .Times(2)
+        .WillRepeatedly(Return(m_wsIndex));
+    EXPECT_CALL(*m_model, getEquivalentFunctionIndexForDomain(
+                              m_wsName, m_wsIndex, parameter))
+        .Times(1);
+    EXPECT_CALL(*m_model, getEquivalentParameterTieForDomain(
+                              m_wsName, m_wsIndex, parameter, tie))
+        .Times(1);
+    EXPECT_CALL(*m_model,
+                updateParameterTie(m_wsName, m_wsIndex, parameter, tie))
+        .Times(1);
+
+    EXPECT_CALL(*m_model, getGlobalTies()).Times(1);
+    EXPECT_CALL(*m_view, setGlobalTies(VectorSize(0))).Times(1);
+
+    EXPECT_CALL(*m_view, selectedRows()).Times(1);
+
+    set_selection_changed_expectations(row, false, true);
+
+    m_presenter->notifyPresenter(ViewEvent::ParameterTieChanged, parameter,
+                                 tie);
+  }
+
+  void
+  test_that_ParameterConstraintRemoved_will_attempt_to_remove_the_constraint_in_the_model() {
+    std::string const parameter("A0");
+    auto const row = FitDomainIndex(0);
+    auto const allRows = std::vector<FitDomainIndex>{row};
+
+    ON_CALL(*m_view, allRows()).WillByDefault(Return(allRows));
+    ON_CALL(*m_view, selectedRows()).WillByDefault(Return(allRows));
+
+    EXPECT_CALL(*m_view, allRows()).Times(1);
+    EXPECT_CALL(*m_view, workspaceName(row))
+        .Times(2)
+        .WillRepeatedly(Return(m_wsName));
+    EXPECT_CALL(*m_view, workspaceIndex(row))
+        .Times(2)
+        .WillRepeatedly(Return(m_wsIndex));
+    EXPECT_CALL(*m_model,
+                removeParameterConstraint(m_wsName, m_wsIndex, parameter))
+        .Times(1);
+    EXPECT_CALL(*m_view, selectedRows()).Times(1);
+
+    set_selection_changed_expectations(row, false, true);
+
+    m_presenter->notifyPresenter(ViewEvent::ParameterConstraintRemoved,
+                                 parameter);
+  }
+
+  void
+  test_that_ParameterConstraintChanged_will_attempt_to_update_the_ties_in_the_model() {
+    std::string const functionIndex("");
+    std::string const constraint("0<A0<1");
+    auto const row = FitDomainIndex(0);
+    auto const allRows = std::vector<FitDomainIndex>{row};
+
+    ON_CALL(*m_view, allRows()).WillByDefault(Return(allRows));
+    ON_CALL(*m_view, selectedRows()).WillByDefault(Return(allRows));
+    ON_CALL(*m_model, getEquivalentFunctionIndexForDomain(m_wsName, m_wsIndex,
+                                                          functionIndex))
+        .WillByDefault(Return(functionIndex));
+
+    EXPECT_CALL(*m_view, allRows()).Times(1);
+    EXPECT_CALL(*m_view, workspaceName(row))
+        .Times(2)
+        .WillRepeatedly(Return(m_wsName));
+    EXPECT_CALL(*m_view, workspaceIndex(row))
+        .Times(2)
+        .WillRepeatedly(Return(m_wsIndex));
+    EXPECT_CALL(*m_model, getEquivalentFunctionIndexForDomain(
+                              m_wsName, m_wsIndex, functionIndex))
+        .Times(1);
+    EXPECT_CALL(*m_model, updateParameterConstraint(m_wsName, m_wsIndex,
+                                                    functionIndex, constraint))
+        .Times(1);
+
+    EXPECT_CALL(*m_view, selectedRows()).Times(1);
+
+    set_selection_changed_expectations(row, false, true);
+
+    m_presenter->notifyPresenter(ViewEvent::ParameterConstraintChanged,
+                                 functionIndex, constraint);
+  }
+
+  void
+  test_that_GlobalParametersChanged_updates_the_globals_stored_in_the_model() {
+    std::string const globalParameter("A0");
+    auto const globalsVector = std::vector<std::string>{globalParameter};
+    auto const globals =
+        std::vector<GlobalParameter>{GlobalParameter(globalParameter)};
+
+    EXPECT_CALL(*m_model, setGlobalParameters(globalsVector)).Times(1);
+
+    set_selection_changed_expectations(FitDomainIndex(0), false, false,
+                                       globals);
+
+    m_presenter->notifyPresenter(ViewEvent::GlobalParametersChanged,
+                                 globalsVector);
+  }
+
+  void
+  test_that_FittingModeChanged_will_update_the_fitting_mode_stored_by_the_model() {
+    auto const fittingMode(FittingMode::SIMULTANEOUS);
+
+    EXPECT_CALL(*m_model, setFittingMode(fittingMode)).Times(1);
+
+    set_selection_changed_expectations(FitDomainIndex(0));
+
+    m_presenter->notifyPresenter(ViewEvent::FittingModeChanged, fittingMode);
+  }
+
+  void
+  test_that_setGlobalTies_will_set_the_global_ties_displayed_by_the_view() {
+    auto const globalTies = std::vector<GlobalTie>{GlobalTie("f0.A0", "f1.A0")};
+
+    EXPECT_CALL(*m_view, setGlobalTies(VectorSize(globalTies.size()))).Times(1);
+
+    m_presenter->setGlobalTies(globalTies);
+  }
+
+  void
+  test_that_setGlobalParameters_will_set_the_global_parameters_displayed_by_the_view() {
+    auto const globalParameters =
+        std::vector<GlobalParameter>{GlobalParameter("A0")};
+
+    EXPECT_CALL(*m_view,
+                setGlobalParameters(VectorSize(globalParameters.size())))
+        .Times(1);
+
+    m_presenter->setGlobalParameters(globalParameters);
+  }
+
 private:
+  void set_selection_changed_expectations(
+      FitDomainIndex selectedRow, bool noSelection = false,
+      bool ignoreNameIndexRetrieval = false,
+      std::vector<GlobalParameter> const &globals =
+          std::vector<GlobalParameter>()) {
+    auto selectedRows = std::vector<FitDomainIndex>{selectedRow};
+
+    if (noSelection)
+      selectedRows = std::vector<FitDomainIndex>{};
+
+    ON_CALL(*m_view, selectedRows()).WillByDefault(Return(selectedRows));
+
+    ON_CALL(*m_model, getFittingMode())
+        .WillByDefault(Return(FittingMode::SEQUENTIAL));
+
+    if (!selectedRows.empty()) {
+      ON_CALL(*m_view, workspaceName(selectedRow))
+          .WillByDefault(Return(m_wsName));
+      ON_CALL(*m_view, workspaceIndex(selectedRow))
+          .WillByDefault(Return(m_wsIndex));
+
+      ON_CALL(*m_model, getFunction(m_wsName, m_wsIndex))
+          .WillByDefault(Return(m_function));
+
+      ON_CALL(*m_model, getGlobalParameters()).WillByDefault(Return(globals));
+
+      if (!ignoreNameIndexRetrieval) {
+        EXPECT_CALL(*m_view, selectedRows())
+            .Times(1)
+            .WillOnce(Return(selectedRows));
+        EXPECT_CALL(*m_view, workspaceName(selectedRow))
+            .Times(1)
+            .WillOnce(Return(m_wsName));
+        EXPECT_CALL(*m_view, workspaceIndex(selectedRow))
+            .Times(1)
+            .WillOnce(Return(m_wsIndex));
+      }
+
+      EXPECT_CALL(*m_model, getFittingMode()).Times(1);
+      EXPECT_CALL(*m_view, setSimultaneousMode(false)).Times(1);
+
+      EXPECT_CALL(*m_model, getFunction(m_wsName, m_wsIndex)).Times(1);
+      EXPECT_CALL(*m_view, setFunction(m_function)).Times(1);
+
+      EXPECT_CALL(*m_model, getGlobalParameters()).Times(1);
+      EXPECT_CALL(*m_view, setGlobalParameters(VectorSize(globals.size())))
+          .Times(1);
+    } else {
+      EXPECT_CALL(*m_view, selectedRows())
+          .Times(1)
+          .WillOnce(Return(selectedRows));
+
+      EXPECT_CALL(*m_model, getFittingMode()).Times(1);
+      EXPECT_CALL(*m_view, setSimultaneousMode(false)).Times(1);
+
+      EXPECT_CALL(*m_view, clearFunction()).Times(1);
+    }
+  }
+
   std::string m_wsName;
   WorkspaceIndex m_wsIndex;
   Mantid::API::MatrixWorkspace_sptr m_workspace;

--- a/qt/widgets/common/test/FitScriptGeneratorViewTest.h
+++ b/qt/widgets/common/test/FitScriptGeneratorViewTest.h
@@ -13,8 +13,8 @@
 #include "MantidAPI/IFunction.h"
 #include "MantidAPI/MatrixWorkspace.h"
 #include "MantidAPI/WorkspaceGroup.h"
-#include "MantidKernel/WarningSuppressions.h"
 #include "MantidQtWidgets/Common/FitScriptGeneratorDataTable.h"
+#include "MantidQtWidgets/Common/FitScriptGeneratorMockObjects.h"
 #include "MantidQtWidgets/Common/FitScriptGeneratorView.h"
 #include "MantidQtWidgets/Common/IFitScriptGeneratorPresenter.h"
 #include "MantidTestHelpers/WorkspaceCreationHelper.h"
@@ -51,41 +51,6 @@ CompositeFunction_sptr createEmptyComposite() {
 }
 
 } // namespace
-
-GNU_DIAG_OFF_SUGGEST_OVERRIDE
-
-class MockFitScriptGeneratorPresenter : public IFitScriptGeneratorPresenter {
-
-public:
-  MockFitScriptGeneratorPresenter(FitScriptGeneratorView *view) {
-    m_view = view;
-    m_view->subscribePresenter(this);
-  }
-
-  void notifyPresenter(ViewEvent const &ev, std::string const &arg1 = "",
-                       std::string const &arg2 = "") override {
-    notifyPresenterImpl(ev, arg1, arg2);
-  }
-
-  MOCK_METHOD3(notifyPresenterImpl,
-               void(ViewEvent const &ev, std::string const &arg1,
-                    std::string const &arg2));
-  MOCK_METHOD2(notifyPresenter,
-               void(ViewEvent const &ev, std::vector<std::string> const &vec));
-  MOCK_METHOD2(notifyPresenter,
-               void(ViewEvent const &ev, FittingMode fittingMode));
-
-  MOCK_METHOD0(openFitScriptGenerator, void());
-
-  MOCK_METHOD1(setGlobalTies, void(std::vector<GlobalTie> const &globalTies));
-  MOCK_METHOD1(setGlobalParameters,
-               void(std::vector<GlobalParameter> const &globalParameters));
-
-private:
-  FitScriptGeneratorView *m_view;
-};
-
-GNU_DIAG_ON_SUGGEST_OVERRIDE
 
 class FitScriptGeneratorViewTest : public CxxTest::TestSuite {
 

--- a/qt/widgets/common/test/FitScriptGeneratorViewTest.h
+++ b/qt/widgets/common/test/FitScriptGeneratorViewTest.h
@@ -212,8 +212,8 @@ public:
   test_that_parameterValue_will_return_the_correct_value_of_the_specified_parameter() {
     openFitScriptGeneratorWidget();
     m_view->addWorkspaceDomain(m_wsName, m_wsIndex, 0.0, 2.0);
-    m_view->setFunction(m_function);
     m_function->addFunction(createIFunction("name=LinearBackground"));
+    m_view->setFunction(m_function);
 
     TS_ASSERT_EQUALS(m_view->parameterValue("f0.A0"), 0.0);
     TS_ASSERT_EQUALS(m_view->parameterValue("f1.Height"), 1.0);

--- a/qt/widgets/common/test/FitScriptGeneratorViewTest.h
+++ b/qt/widgets/common/test/FitScriptGeneratorViewTest.h
@@ -213,9 +213,12 @@ public:
     openFitScriptGeneratorWidget();
     m_view->addWorkspaceDomain(m_wsName, m_wsIndex, 0.0, 2.0);
     m_view->setFunction(m_function);
+    m_function->addFunction(createIFunction("name=LinearBackground"));
 
     TS_ASSERT_EQUALS(m_view->parameterValue("f0.A0"), 0.0);
     TS_ASSERT_EQUALS(m_view->parameterValue("f1.Height"), 1.0);
+    TS_ASSERT_EQUALS(m_view->parameterValue("f2.A0"), 0.0);
+    TS_ASSERT_EQUALS(m_view->parameterValue("f2.A1"), 0.0);
   }
 
   void

--- a/scripts/Muon/GUI/Common/fitting_tab_widget/fitting_tab_presenter.py
+++ b/scripts/Muon/GUI/Common/fitting_tab_widget/fitting_tab_presenter.py
@@ -7,7 +7,7 @@
 from Muon.GUI.Common.ADSHandler.workspace_naming import get_run_numbers_as_string_from_workspace_name
 from Muon.GUI.Common.fitting_tab_widget.fitting_tab_model import FitPlotInformation
 from mantidqt.utils.observer_pattern import GenericObserver, GenericObserverWithArgPassing, GenericObservable
-from mantidqt.widgets.fitscriptgenerator import (FitScriptGeneratorModel, FitScriptGeneratorPresenter,
+from mantidqt.widgets.fitscriptgenerator import (FittingMode, FitScriptGeneratorModel, FitScriptGeneratorPresenter,
                                                  FitScriptGeneratorView)
 from Muon.GUI.Common.thread_model_wrapper import ThreadModelWrapperWithOutput
 from Muon.GUI.Common.contexts.frequency_domain_analysis_context import FrequencyDomainAnalysisContext
@@ -105,12 +105,11 @@ class FittingTabPresenter(object):
         return self._end_x
 
     def handle_fit_generator_clicked(self):
-        fit_options = {"FittingType": "Simultaneous" if self.view.is_simul_fit else "Sequential",
-                       "Minimizer": self.view.minimizer,
-                       "EvaluationType": self.view.evaluation_type}
+        fitting_mode = FittingMode.SIMULTANEOUS if self.view.is_simul_fit else FittingMode.SEQUENTIAL
+        fit_options = {"Minimizer": self.view.minimizer, "EvaluationType": self.view.evaluation_type}
 
         self.fsg_model = FitScriptGeneratorModel()
-        self.fsg_view = FitScriptGeneratorView(None, fit_options)
+        self.fsg_view = FitScriptGeneratorView(None, fitting_mode, fit_options)
         self.fsg_presenter = FitScriptGeneratorPresenter(self.fsg_view, self.fsg_model, self.view.loaded_workspaces,
                                                          self.view.start_time, self.view.end_time)
 

--- a/scripts/Muon/GUI/Common/fitting_tab_widget/fitting_tab_view.py
+++ b/scripts/Muon/GUI/Common/fitting_tab_widget/fitting_tab_view.py
@@ -49,7 +49,7 @@ class FittingTabView(QtWidgets.QWidget, ui_fitting_tab):
             self.end_time = DEFAULT_FREQUENCY_FIT_END_X
 
         # Comment out this line to show the 'Fit Generator' button
-        #self.fit_generator_button.hide()
+        self.fit_generator_button.hide()
 
     def update_displayed_data_combo_box(self, data_list):
         self.parameter_display_combo.blockSignals(True)

--- a/scripts/Muon/GUI/Common/fitting_tab_widget/fitting_tab_view.py
+++ b/scripts/Muon/GUI/Common/fitting_tab_widget/fitting_tab_view.py
@@ -49,7 +49,7 @@ class FittingTabView(QtWidgets.QWidget, ui_fitting_tab):
             self.end_time = DEFAULT_FREQUENCY_FIT_END_X
 
         # Comment out this line to show the 'Fit Generator' button
-        self.fit_generator_button.hide()
+        #self.fit_generator_button.hide()
 
     def update_displayed_data_combo_box(self, data_list):
         self.parameter_display_combo.blockSignals(True)


### PR DESCRIPTION
**Description of work.**
This PR follows on from #30068 . It connects the `FunctionTreeView` to the data table, and same with the check box above the `FunctionTreeView`. The following is now possible:

- Selecting individual or multiple datasets, and then add or remove functions to the `FunctionTreeView` for only these datasets by unticking the tick box.
- Add  or remove functions to all datasets by ticking the checkbox.
- Selecting between datasets will display the functions related to that dataset.
- Switching between Sequential and Simultaneous fitting will hide/show the global parameter column and multi domain index

It is also now possible to do the following:
- Editing parameter and attribute values
- Local and global ties
- constraints
- global parameters

The `EditLocalParameter` dialog will be added in a different PR.

Roughly half of this PR ~ 2000 lines are additions to unit tests including:
- [x] New `FitDomainTest` 
- [x] New `FitScriptGeneratorModelTest` 
- [x] System test for opening this interface (`FitScriptGeneratorStartupTest`)
- [x] Additions to `FitScriptGeneratorPresenterTest`
- [x] Additions to `FitScriptGeneratorViewTest`
- [x] Additions to `CompositeFunctionTest`

**To test:**
1. Comment out Line 52 in `fitting_tab_view.py`
1. `Muon Interface`
2. Load any data and go to fitting tab.
3. Click `Fit Generator` to open the new interface
4. Load more data using `Add Workspace` so that you have at least 2 rows in the data table.
5. Choose `Simultaneous` in the FitOptionsBrowser (bottom right). This should show the global column in the FunctionTreeView (top right), and the multi domain index on the left of the data table.
6. Add a FlatBackground for both datasets (keeping checkbox ticked).
7. Untick the checkbox, and select the first table row
8. Add an ExpDecay function.
9. Switch between the rows to make sure only the top row has the `ExpDecay`. Also notice that the function index at the top of the FunctionTreeView will change when switching between the table rows.
10. Remove the `ExpDecay`. Tick the checkbox. Add the `ExpDecay` function. It should now be there for every domain.
11. Try a local tie: Select the first row, and right click `f0.f1.Height` and tie it to `f0.f0.A0`. Remove the tie.
12. Try a global tie: Select the first row, and right click `f0.f1.Height` and tie it to `f1.f0.A0`. ie the domain index is different.
13. Remove this tie. Try ticking a parameter to make it global. Global parameters will not be allowed if:
 - The parameter does not exist in ALL domains
 - The parameter already has a local or global tie
14. Try a constraint

Closes #30198

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
