### PR TITLE
Fix DynamicKuboToyabe Function Crash

### DIFF
--- a/Framework/CurveFitting/inc/MantidCurveFitting/Functions/DynamicKuboToyabe.h
+++ b/Framework/CurveFitting/inc/MantidCurveFitting/Functions/DynamicKuboToyabe.h
@@ -36,20 +36,8 @@ public:
   std::string name() const override { return "DynamicKuboToyabe"; }
   const std::string category() const override { return "Muon\\MuonGeneric"; }
 
-  /// Returns the number of attributes associated with the function
-  size_t nAttributes() const override { return 1; }
-
-  /// Returns a list of attribute names
-  std::vector<std::string> getAttributeNames() const override;
-
-  /// Return a value of attribute attName
-  Attribute getAttribute(const std::string &attName) const override;
-
   /// Set a value to attribute attName
   void setAttribute(const std::string &attName, const Attribute &) override;
-
-  /// Check if attribute attName exists
-  bool hasAttribute(const std::string &attName) const override;
 
 protected:
   void function1D(double *out, const double *xValues,

--- a/Framework/CurveFitting/src/Functions/DynamicKuboToyabe.cpp
+++ b/Framework/CurveFitting/src/Functions/DynamicKuboToyabe.cpp
@@ -5,12 +5,12 @@
 //   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
 // SPDX - License - Identifier: GPL - 3.0 +
 #include "MantidCurveFitting/Functions/DynamicKuboToyabe.h"
+
 #include "MantidAPI/FunctionFactory.h"
 #include "MantidAPI/Jacobian.h"
 #include "MantidAPI/MatrixWorkspace.h"
 #include "MantidKernel/PhysicalConstants.h"
 
-#include <iomanip>
 #include <sstream>
 #include <vector>
 
@@ -27,6 +27,7 @@ using namespace API;
 DECLARE_FUNCTION(DynamicKuboToyabe)
 
 void DynamicKuboToyabe::init() {
+  declareAttribute("BinWidth", Attribute(m_eps));
   declareParameter("Asym", 0.2, "Amplitude at time 0");
   declareParameter("Delta", 0.2, "Local field");
   declareParameter("Field", 0.0, "External field");
@@ -320,29 +321,6 @@ void DynamicKuboToyabe::setActiveParameter(size_t i, double value) {
 }
 
 //----------------------------------------------------------------------------------------------
-/** Get Attribute names
- * @return A list of attribute names
- */
-std::vector<std::string> DynamicKuboToyabe::getAttributeNames() const {
-  return {"BinWidth"};
-}
-
-//----------------------------------------------------------------------------------------------
-/** Get Attribute
- * @param attName :: Attribute name. If it is not "eps" an exception is thrown.
- * @return a value of attribute attName
- */
-API::IFunction::Attribute
-DynamicKuboToyabe::getAttribute(const std::string &attName) const {
-
-  if (attName == "BinWidth") {
-    return Attribute(m_eps);
-  }
-  throw std::invalid_argument("DynamicKuboToyabe: Unknown attribute " +
-                              attName);
-}
-
-//----------------------------------------------------------------------------------------------
 /** Set Attribute
  * @param attName :: The attribute name. If it is not "eps" exception is thrown.
  * @param att :: A double attribute containing a new positive value.
@@ -377,19 +355,12 @@ void DynamicKuboToyabe::setAttribute(const std::string &attName,
       init();
     }
     m_eps = newVal;
+    IFunction::setAttribute(attName, Attribute(m_eps));
 
   } else {
     throw std::invalid_argument("DynamicKuboToyabe: Unknown attribute " +
                                 attName);
   }
-}
-
-//----------------------------------------------------------------------------------------------
-/** Check if attribute attName exists
- * @param attName :: The attribute name.
- */
-bool DynamicKuboToyabe::hasAttribute(const std::string &attName) const {
-  return attName == "BinWidth";
 }
 
 } // namespace Functions

--- a/Framework/CurveFitting/src/Functions/DynamicKuboToyabe.cpp
+++ b/Framework/CurveFitting/src/Functions/DynamicKuboToyabe.cpp
@@ -11,6 +11,7 @@
 #include "MantidAPI/MatrixWorkspace.h"
 #include "MantidKernel/PhysicalConstants.h"
 
+#include <iomanip>
 #include <sstream>
 #include <vector>
 
@@ -18,11 +19,9 @@ namespace Mantid {
 namespace CurveFitting {
 namespace Functions {
 
-using namespace CurveFitting;
-
-using namespace Kernel;
-
 using namespace API;
+using namespace CurveFitting;
+using namespace Kernel;
 
 DECLARE_FUNCTION(DynamicKuboToyabe)
 

--- a/docs/source/release/v6.0.0/muon.rst
+++ b/docs/source/release/v6.0.0/muon.rst
@@ -24,6 +24,7 @@ Bug fixes
 - Fixed a bug to swap start and end time fit properties on the interface if start > end
 - Fixed a bug where editing constraints would result in a crash.
 - Fixed a bug where global parameter values would reset when changing the displayed dataset.
+- Fixed a crash when adding the DynamicKuboToyabe function on the fitting tab of Muon Analysis.
 
 ALC
 ---


### PR DESCRIPTION
**Description of work.**
This PR fixes a crash when adding the `DynamicKuboToyabe` function as part of a composite function in Muon Analysis fitting tab.

Its a simple fix and so tests are not required. The attribute `BinWidth` just needed to be declared properly using `declareAttribute`.

**To test:**
1. open muon analysis
2. load EMU51341
3. in the fit tab add a flat background
4. add DynamicKuboToyabe. There should be no crash!

--

1. open muon analysis
2. load EMU51341-3
3. in the fit tab add DynamicKuboToyabe
4. check Simultaneous fit over, change combo box from `Runs` to `Group/Pair`. There should be no crash!

Fixes #30147 

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
