### PR TITLE
Allow PaalmanPingsMonteCarloAbsorption to use shape defined in workspace

### DIFF
--- a/Framework/PythonInterface/mantid/api/src/Exports/Sample.cpp
+++ b/Framework/PythonInterface/mantid/api/src/Exports/Sample.cpp
@@ -79,6 +79,8 @@ void export_Sample() {
       .def("getShape", &Sample::getShape, arg("self"),
            "Returns a shape of a Sample object.",
            return_value_policy<reference_existing_object>())
+      .def("hasEnvironment", &Sample::hasEnvironment, arg("self"), 
+          "Returns True if the sample has an environment defined")
       // -------------------------Operators
       // -------------------------------------
       .def("__len__", &Sample::size, arg("self"),

--- a/Framework/PythonInterface/mantid/api/src/Exports/Sample.cpp
+++ b/Framework/PythonInterface/mantid/api/src/Exports/Sample.cpp
@@ -79,8 +79,8 @@ void export_Sample() {
       .def("getShape", &Sample::getShape, arg("self"),
            "Returns a shape of a Sample object.",
            return_value_policy<reference_existing_object>())
-      .def("hasEnvironment", &Sample::hasEnvironment, arg("self"), 
-          "Returns True if the sample has an environment defined")
+      .def("hasEnvironment", &Sample::hasEnvironment, arg("self"),
+           "Returns True if the sample has an environment defined")
       // -------------------------Operators
       // -------------------------------------
       .def("__len__", &Sample::size, arg("self"),

--- a/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/PaalmanPingsMonteCarloAbsorption.py
+++ b/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/PaalmanPingsMonteCarloAbsorption.py
@@ -120,7 +120,7 @@ class PaalmanPingsMonteCarloAbsorption(DataProcessorAlgorithm):
         self.setPropertyGroup('BeamWidth', 'Beam Options')
 
         # Shape Options
-        self.declareProperty(name='Shape', defaultValue='Preset',
+        self.declareProperty(name='Shape', defaultValue='FlatPlate',
                              validator=StringListValidator(['Preset', 'FlatPlate', 'Cylinder', 'Annulus']),
                              doc='Geometric shape of the sample environment')
 

--- a/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/PaalmanPingsMonteCarloAbsorption.py
+++ b/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/PaalmanPingsMonteCarloAbsorption.py
@@ -293,6 +293,13 @@ class PaalmanPingsMonteCarloAbsorption(DataProcessorAlgorithm):
         self.setPropertyGroup('ContainerDensityType', 'Container Material')
         self.setPropertyGroup('ContainerNumberDensityUnit', 'Container Material')
         self.setPropertyGroup('ContainerDensity', 'Container Material')
+        self.setPropertySettings('ContainerChemicalFormula', not_preset_condition)
+        self.setPropertySettings('ContainerCoherentXSection', not_preset_condition)
+        self.setPropertySettings('ContainerIncoherentXSection', not_preset_condition)
+        self.setPropertySettings('ContainerAttenuationXSection', not_preset_condition)
+        self.setPropertySettings('ContainerDensityType', not_preset_condition)
+        self.setPropertySettings('ContainerNumberDensityUnit', not_preset_condition)
+        self.setPropertySettings('ContainerDensity', not_preset_condition)
 
         # Output Workspace Group
         self.declareProperty(WorkspaceGroupProperty(name='CorrectionsWorkspace',
@@ -302,7 +309,7 @@ class PaalmanPingsMonteCarloAbsorption(DataProcessorAlgorithm):
                              doc='Name of the workspace group to save correction factors')
 
     def PyExec(self):
-        progess_steps = 1.
+        progess_steps = 1. if not self._has_can else 0.25
         input_wave_ws = self._convert_to_wavelength(self._input_ws)
         self._set_beam(input_wave_ws)
         if self._is_override_sample:

--- a/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/PaalmanPingsMonteCarloAbsorption.py
+++ b/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/PaalmanPingsMonteCarloAbsorption.py
@@ -22,9 +22,9 @@ class PaalmanPingsMonteCarloAbsorption(DataProcessorAlgorithm):
     _shape = None
     _height = None
     _isis_instrument = None
-    _is_override_sample = None
-    _has_can = None
-    _is_override_material_only = None
+    _override_shape = None
+    _has_container = None
+    _override_sample_material_only = None
 
     # Sample variables
     _sample_angle = None
@@ -317,7 +317,7 @@ class PaalmanPingsMonteCarloAbsorption(DataProcessorAlgorithm):
             self._set_sample(input_wave_ws, ['Sample'])
         elif self._is_override_material_only:
             # in this instance, setsample will not be called again so this material change only needs to happen once
-            self._set_sample_material_only(self._input_ws)
+            self._set_sample_material_only(input_wave_ws)
         monte_carlo_alg = self.createChildAlgorithm("MonteCarloAbsorption", enableLogging=True,
                                                     startProgress=0, endProgress=progess_steps)
         self._set_algorithm_properties(monte_carlo_alg, self._monte_carlo_kwargs)

--- a/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/PolDiffILLReduction.py
+++ b/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/PolDiffILLReduction.py
@@ -568,10 +568,9 @@ class PolDiffILLReduction(PythonAlgorithm):
             PaalmanPingsAbsorptionCorrection(InputWorkspace=mock_geometry_ws, OutputWorkspace=attenuation_ws,
                                              ElementSize=kwargs['ElementSize'])
         elif attenuation_method == 'MonteCarlo':
-            PaalmanPingsMonteCarloAbsorption(SampleWorkspace=mock_geometry_ws,
+            PaalmanPingsMonteCarloAbsorption(InputWorkspace=mock_geometry_ws,
                                              Shape=sample_geometry_type,
                                              CorrectionsWorkspace=attenuation_ws,
-                                             ContainerWorkspace=mock_geometry_ws,
                                              **kwargs)
         if self.getPropertyValue('ClearCache'):
             DeleteWorkspace(Workspace=mock_geometry_ws)

--- a/Framework/PythonInterface/test/python/plugins/algorithms/WorkflowAlgorithms/PaalmanPingsMonteCarloAbsorptionTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/WorkflowAlgorithms/PaalmanPingsMonteCarloAbsorptionTest.py
@@ -12,14 +12,12 @@ import unittest
 class PaalmanPingsMonteCarloAbsorptionTest(unittest.TestCase):
 
     _red_ws = None
-    _container_ws = None
     _indirect_elastic_ws = None
     _indirect_fws_ws = None
 
     @classmethod
     def setUpClass(cls):
         Load('irs26176_graphite002_red.nxs', OutputWorkspace='red_ws')
-        Load('irs26173_graphite002_red.nxs', OutputWorkspace='container_ws')
         Load('osi104367_elf.nxs', OutputWorkspace='indirect_elastic_ws')
         Load('ILL_IN16B_FWS_Reduced.nxs', OutputWorkspace='indirect_fws_ws')
         Load('HRP38692a.nxs', OutputWorkspace='elastic_ws')
@@ -27,7 +25,6 @@ class PaalmanPingsMonteCarloAbsorptionTest(unittest.TestCase):
 
     def setUp(self):
         self._red_ws = mtd['red_ws']
-        self._container_ws = mtd['container_ws']
         self._indirect_elastic_ws = mtd['indirect_elastic_ws']
         self._indirect_fws_ws = mtd['indirect_fws_ws']
         self._elastic_ws = mtd['elastic_ws']
@@ -43,12 +40,11 @@ class PaalmanPingsMonteCarloAbsorptionTest(unittest.TestCase):
                            'EventsPerPoint': 200,
                            'BeamHeight': 3.5,
                            'BeamWidth': 4.0,
-                           'Height': 2.0 }
+                           'Height': 2.0}
 
-        self._container_args = {'ContainerWorkspace':self._container_ws,
-                                'ContainerChemicalFormula':'Al',
-                                'ContainerDensityType':'Mass Density',
-                                'ContainerDensity':1.0 }
+        self._container_args = {'ContainerChemicalFormula': 'Al',
+                                'ContainerDensityType': 'Mass Density',
+                                'ContainerDensity': 1.0}
         self._test_arguments = dict()
 
     @classmethod
@@ -113,13 +109,12 @@ class PaalmanPingsMonteCarloAbsorptionTest(unittest.TestCase):
             self._test_corrections_workspace(workspace, spectrum_axis)
 
     def _run_correction_and_test(self, shape, sample_ws=None, spectrum_axis=None, with_container=False):
-
         if sample_ws is None:
             sample_ws = self._red_ws
 
         arguments = self._arguments.copy()
         arguments.update(self._test_arguments)
-        corrected = PaalmanPingsMonteCarloAbsorption(SampleWorkspace=sample_ws,
+        corrected = PaalmanPingsMonteCarloAbsorption(InputWorkspace=sample_ws,
                                                      Shape=shape,
                                                      **arguments)
         self._test_corrections_workspaces(corrected, spectrum_axis, with_container)
@@ -166,7 +161,7 @@ class PaalmanPingsMonteCarloAbsorptionTest(unittest.TestCase):
         self._expected_blocksize = 23987
         self._run_correction_and_test(shape, self._elastic_ws, 'Label')
 
-    def _run_direct_test(self,shape):
+    def _run_direct_test(self, shape):
         self._expected_unit = "DeltaE"
         self._expected_hist = 285
         self._expected_blocksize = 294
@@ -216,6 +211,7 @@ class PaalmanPingsMonteCarloAbsorptionTest(unittest.TestCase):
 
     def test_cylinder_direct(self):
         self._cylinder_test(self._run_direct_test)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/Testing/SystemTests/tests/framework/PaalmanPingsMonteCarloAbsorptionTest.py
+++ b/Testing/SystemTests/tests/framework/PaalmanPingsMonteCarloAbsorptionTest.py
@@ -28,7 +28,7 @@ class FlatPlateTest(systemtesting.MantidSystemTest):
 
     def runTest(self):
         PaalmanPingsMonteCarloAbsorption(
-            SampleWorkspace='sample',
+            InputWorkspace='sample',
             Shape='FlatPlate',
             BeamHeight=2.0,
             BeamWidth=2.0,
@@ -37,7 +37,6 @@ class FlatPlateTest(systemtesting.MantidSystemTest):
             SampleThickness=0.1,
             SampleChemicalFormula='H2-O',
             SampleDensity=1.0,
-            ContainerWorkspace='container',
             ContainerFrontThickness=0.02,
             ContainerBackThickness=0.02,
             ContainerChemicalFormula='V',
@@ -66,7 +65,7 @@ class CylinderTest(systemtesting.MantidSystemTest):
 
     def runTest(self):
         PaalmanPingsMonteCarloAbsorption(
-            SampleWorkspace='sample',
+            InputWorkspace='sample',
             Shape='Cylinder',
             BeamHeight=2.0,
             BeamWidth=2.0,
@@ -74,7 +73,6 @@ class CylinderTest(systemtesting.MantidSystemTest):
             SampleRadius=0.2,
             SampleChemicalFormula='H2-O',
             SampleDensity=1.0,
-            ContainerWorkspace='container',
             ContainerRadius=0.22,
             ContainerChemicalFormula='V',
             ContainerDensity=6.0,
@@ -102,7 +100,7 @@ class AnnulusTest(systemtesting.MantidSystemTest):
 
     def runTest(self):
         PaalmanPingsMonteCarloAbsorption(
-            SampleWorkspace='sample',
+            InputWorkspace='sample',
             Shape='Annulus',
             BeamHeight=2.0,
             BeamWidth=2.0,
@@ -111,7 +109,6 @@ class AnnulusTest(systemtesting.MantidSystemTest):
             SampleOuterRadius=0.4,
             SampleChemicalFormula='H2-O',
             SampleDensity=1.0,
-            ContainerWorkspace='container',
             ContainerInnerRadius=0.19,
             ContainerOuterRadius=0.41,
             ContainerChemicalFormula='V',

--- a/docs/source/algorithms/PaalmanPingsMonteCarloAbsorption-v1.rst
+++ b/docs/source/algorithms/PaalmanPingsMonteCarloAbsorption-v1.rst
@@ -13,6 +13,8 @@ This algorithm calculates the attenuation factors in the Paalman Pings formalism
 
 Three simple shapes are supported: *FlatPlate*, *Cylinder*, and *Annulus*. Each shape is defined by the corresponding set of geometric parameters.
 
+If the shape is left as the default value *Preset*, the algorithm will use the sample and container shapes defined in the workspace.
+
 Inelastic, quasielastic and elastic measurements are supported, both for direct and indirect geometry instruments.
 
 *Height* is a common property for the sample and container regardless the shape.
@@ -88,7 +90,7 @@ Usage
         ParameterName='Efixed', ParameterType='Number', Value='4.1')
 
     corrections = PaalmanPingsMonteCarloAbsorption(
-            SampleWorkspace=sample_ws,
+            InputWorkspace=sample_ws,
             Shape='FlatPlate',
             BeamHeight=2.0,
             BeamWidth=2.0,
@@ -97,7 +99,6 @@ Usage
             SampleThickness=0.1,
             SampleChemicalFormula='H2-O',
             SampleDensity=1.0,
-            ContainerWorkspace=container_ws,
             ContainerFrontThickness=0.02,
             ContainerBackThickness=0.02,
             ContainerChemicalFormula='V',
@@ -150,7 +151,7 @@ Usage
         ParameterName='Efixed', ParameterType='Number', Value='4.1')
 
     corrections = PaalmanPingsMonteCarloAbsorption(
-            SampleWorkspace=sample_ws,
+            InputWorkspace=sample_ws,
             Shape='Cylinder',
             BeamHeight=2.0,
             BeamWidth=2.0,
@@ -158,7 +159,6 @@ Usage
             SampleRadius=0.2,
             SampleChemicalFormula='H2-O',
             SampleDensity=1.0,
-            ContainerWorkspace=container_ws,
             ContainerRadius=0.22,
             ContainerChemicalFormula='V',
             ContainerDensity=6.0,
@@ -210,7 +210,7 @@ Usage
         ParameterName='Efixed', ParameterType='Number', Value='4.1')
 
     corrections = PaalmanPingsMonteCarloAbsorption(
-            SampleWorkspace=sample_ws,
+            InputWorkspace=sample_ws,
             Shape='Annulus',
             BeamHeight=2.0,
             BeamWidth=2.0,
@@ -219,7 +219,6 @@ Usage
             SampleOuterRadius=0.4,
             SampleChemicalFormula='H2-O',
             SampleDensity=1.0,
-            ContainerWorkspace=container_ws,
             ContainerInnerRadius=0.19,
             ContainerOuterRadius=0.41,
             ContainerChemicalFormula='V',

--- a/docs/source/algorithms/PaalmanPingsMonteCarloAbsorption-v1.rst
+++ b/docs/source/algorithms/PaalmanPingsMonteCarloAbsorption-v1.rst
@@ -59,9 +59,6 @@ The corrections should be applied by the :ref:`ApplyPaalmanPingsCorrection <algm
 
   All the shape arguments are supposed to be in centimeters.
 
-.. note::
-
-  This algorithm does not support predefined shapes or materials yet.
 
 Usage
 -----
@@ -79,14 +76,6 @@ Usage
     # Fake it here
     inst_name = sample_ws.getInstrument().getName()
     SetInstrumentParameter(sample_ws, ComponentName=inst_name,
-        ParameterName='Efixed', ParameterType='Number', Value='4.1')
-
-    container_ws = CreateSampleWorkspace(Function="Quasielastic",
-                                         XUnit="Wavelength",
-                                         XMin=-0.5,
-                                         XMax=0.5,
-                                         BinWidth=0.01)
-    SetInstrumentParameter(container_ws, ComponentName=inst_name,
         ParameterName='Efixed', ParameterType='Number', Value='4.1')
 
     corrections = PaalmanPingsMonteCarloAbsorption(
@@ -142,14 +131,6 @@ Usage
     SetInstrumentParameter(sample_ws, ComponentName=inst_name,
         ParameterName='Efixed', ParameterType='Number', Value='4.1')
 
-    container_ws = CreateSampleWorkspace(Function="Quasielastic",
-                                         XUnit="Wavelength",
-                                         XMin=-0.5,
-                                         XMax=0.5,
-                                         BinWidth=0.01)
-    SetInstrumentParameter(container_ws, ComponentName=inst_name,
-        ParameterName='Efixed', ParameterType='Number', Value='4.1')
-
     corrections = PaalmanPingsMonteCarloAbsorption(
             InputWorkspace=sample_ws,
             Shape='Cylinder',
@@ -201,14 +182,6 @@ Usage
     SetInstrumentParameter(sample_ws, ComponentName=inst_name,
         ParameterName='Efixed', ParameterType='Number', Value='4.1')
 
-    container_ws = CreateSampleWorkspace(Function="Quasielastic",
-                                         XUnit="Wavelength",
-                                         XMin=-0.5,
-                                         XMax=0.5,
-                                         BinWidth=0.01)
-    SetInstrumentParameter(container_ws, ComponentName=inst_name,
-        ParameterName='Efixed', ParameterType='Number', Value='4.1')
-
     corrections = PaalmanPingsMonteCarloAbsorption(
             InputWorkspace=sample_ws,
             Shape='Annulus',
@@ -241,6 +214,67 @@ Usage
     mtd.clear()
 
 .. testoutput:: Annulus
+
+    Y-Unit Label of annulus_corr_ass: Attenuation factor
+    Y-Unit Label of annulus_corr_assc: Attenuation factor
+    Y-Unit Label of annulus_corr_acsc: Attenuation factor
+    Y-Unit Label of annulus_corr_acc: Attenuation factor
+
+**Example - Preset Shape**
+
+.. testcode:: Preset
+
+    sample_ws = CreateSampleWorkspace(Function="Quasielastic",
+                                      XUnit="Wavelength",
+                                      XMin=-0.5,
+                                      XMax=0.5,
+                                      BinWidth=0.01)
+    # Efixed is generally defined as part of the IDF for real data.
+    # Fake it here
+    inst_name = sample_ws.getInstrument().getName()
+    SetInstrumentParameter(sample_ws, ComponentName=inst_name,
+        ParameterName='Efixed', ParameterType='Number', Value='4.1')
+
+    # define example geometries for the Sample and Container
+    SetSample(sample_ws, Geometry={'Shape': 'Cylinder', 'Height': 4.0, 'Radius': 2.0, 'Center': [0.,0.,0.]},
+                Material={'ChemicalFormula': 'Ni', 'MassDensity': 7.0},
+                ContainerGeometry={'Shape': 'HollowCylinder', 'Height': 4.0, 'InnerRadius': 2.0,
+                'OuterRadius': 3.5})
+
+    corrections = PaalmanPingsMonteCarloAbsorption(
+            InputWorkspace=sample_ws,
+            Shape='Preset',
+            BeamHeight=2.0,
+            BeamWidth=2.0,
+            CorrectionsWorkspace='annulus_corr'
+        )
+
+    # alternatively, run the corrections with the sample material overridden but preset shape used
+    corrections = PaalmanPingsMonteCarloAbsorption(
+            InputWorkspace=sample_ws,
+            Shape='Preset',
+            BeamHeight=2.0,
+            BeamWidth=2.0,
+            SampleChemicalFormula='H2-O',
+            SampleDensity=1.0,
+            CorrectionsWorkspace='annulus_corr'
+        )
+
+    ass_ws = corrections[0]
+    assc_ws = corrections[1]
+    acsc_ws = corrections[2]
+    acc_ws = corrections[3]
+
+    print("Y-Unit Label of " + str(ass_ws.getName()) + ": " + str(ass_ws.YUnitLabel()))
+    print("Y-Unit Label of " + str(assc_ws.getName()) + ": " + str(assc_ws.YUnitLabel()))
+    print("Y-Unit Label of " + str(acsc_ws.getName()) + ": " + str(acsc_ws.YUnitLabel()))
+    print("Y-Unit Label of " + str(acc_ws.getName()) + ": " + str(acc_ws.YUnitLabel()))
+
+.. testcleanup:: Preset
+
+    mtd.clear()
+
+.. testoutput:: Preset
 
     Y-Unit Label of annulus_corr_ass: Attenuation factor
     Y-Unit Label of annulus_corr_assc: Attenuation factor

--- a/docs/source/algorithms/PaalmanPingsMonteCarloAbsorption-v1.rst
+++ b/docs/source/algorithms/PaalmanPingsMonteCarloAbsorption-v1.rst
@@ -13,7 +13,7 @@ This algorithm calculates the attenuation factors in the Paalman Pings formalism
 
 Three simple shapes are supported: *FlatPlate*, *Cylinder*, and *Annulus*. Each shape is defined by the corresponding set of geometric parameters.
 
-If the shape is left as the default value *Preset*, the algorithm will use the sample and container shapes defined in the workspace.
+If the *Preset* shape option is chosen, the algorithm will use the sample and container shapes defined in the workspace.
 
 Inelastic, quasielastic and elastic measurements are supported, both for direct and indirect geometry instruments.
 

--- a/docs/source/interfaces/Indirect Corrections.rst
+++ b/docs/source/interfaces/Indirect Corrections.rst
@@ -273,14 +273,12 @@ absorption corrections.
 Options
 ~~~~~~~
 
-Sample Input
+Workspace Input
   Either a reduced file (*_red.nxs*) or workspace (*_red*) or an :math:`S(Q,
   \omega)` file (*_sqw.nxs*) or workspace (*_sqw*).
 
 Use Container
-  If checked allows you to select a workspace for the container in the format of
-  either a reduced file (*_red.nxs*) or workspace (*_red*) or an :math:`S(Q,
-  \omega)` file (*_sqw.nxs*) or workspace (*_sqw*).
+  If checked, allows you to input container geometries for use in the absorption corrections.
 
 Number Wavelengths
   The number of wavelength points for which a simulation is attempted.
@@ -304,7 +302,7 @@ Beam Width
   The width of the beam in :math:`cm`.
 
 Shape Details
-  Select the shape of the sample (see specific geometry options below).
+  Select the shape of the sample (see specific geometry options below). Alternatively, select 'Preset' to use the Sample and Container geometries defined on the input workspace.
 
 Sample Details Method
   Choose to use a Chemical Formula or Cross Sections to set the neutron information in the sample using
@@ -341,6 +339,14 @@ Shape Details
 
 Depending on the shape of the sample different parameters for the sample
 dimension are required and are detailed below.
+
+Preset
+######
+
+.. interface:: Corrections
+   :widget: pgAbsCorPreset
+
+This option will use the Sample and Container geometries as defined in the input workspace. No further geometry inputs will be taken, though the Sample material can still be overridden.
 
 Flat Plate
 ##########

--- a/docs/source/interfaces/Indirect Corrections.rst
+++ b/docs/source/interfaces/Indirect Corrections.rst
@@ -277,9 +277,6 @@ Workspace Input
   Either a reduced file (*_red.nxs*) or workspace (*_red*) or an :math:`S(Q,
   \omega)` file (*_sqw.nxs*) or workspace (*_sqw*).
 
-Use Container
-  If checked, allows you to input container geometries for use in the absorption corrections.
-
 Number Wavelengths
   The number of wavelength points for which a simulation is attempted.
 
@@ -303,6 +300,9 @@ Beam Width
 
 Shape Details
   Select the shape of the sample (see specific geometry options below). Alternatively, select 'Preset' to use the Sample and Container geometries defined on the input workspace.
+
+Use Container
+  If checked, allows you to input container geometries for use in the absorption corrections.
 
 Sample Details Method
   Choose to use a Chemical Formula or Cross Sections to set the neutron information in the sample using

--- a/docs/source/interfaces/Indirect Corrections.rst
+++ b/docs/source/interfaces/Indirect Corrections.rst
@@ -344,7 +344,6 @@ Preset
 ######
 
 .. interface:: Corrections
-   :widget: pgAbsCorPreset
 
 This option will use the Sample and Container geometries as defined in the input workspace. No further geometry inputs will be taken, though the Sample material can still be overridden.
 

--- a/docs/source/interfaces/Indirect Corrections.rst
+++ b/docs/source/interfaces/Indirect Corrections.rst
@@ -343,8 +343,6 @@ dimension are required and are detailed below.
 Preset
 ######
 
-.. interface:: Corrections
-
 This option will use the Sample and Container geometries as defined in the input workspace. No further geometry inputs will be taken, though the Sample material can still be overridden.
 
 Flat Plate

--- a/docs/source/release/v6.0.0/diffraction.rst
+++ b/docs/source/release/v6.0.0/diffraction.rst
@@ -50,6 +50,7 @@ Improvements
 - The :ref:`HB2AReduce <algm-HB2AReduce>` now can save reduced data to GSAS or XYE file.
 - The :ref:`D7YIGPositionCalibration <algm-D7YIGPositionCalibration>` now can do the YIG Bragg peak fitting individually or simultaneously, or not at all and provide feedback on the initial guess quality
 - :ref:`PDCalibration <algm-PDCalibration>` now intitialises A,B and S of BackToBackExponential if correpsonding coeficients are in the instrument parameter.xml file.
+- PaalmanPingsMonteCarloAbsorption can now make use of predefined sample and container geometries
 
 Bugfixes
 ########

--- a/qt/scientific_interfaces/Indirect/AbsorptionCorrections.cpp
+++ b/qt/scientific_interfaces/Indirect/AbsorptionCorrections.cpp
@@ -406,9 +406,6 @@ void AbsorptionCorrections::validateSampleGeometryInputs(
     double const sampleThickness = m_uiForm.spFlatSampleThickness->value();
     hasZero = hasZero || isValueZero(sampleThickness);
 
-    double const sampleAngle = m_uiForm.spFlatSampleAngle->value();
-    hasZero = hasZero || isValueZero(sampleAngle);
-
   } else if (shape == "Annulus") {
     double const sampleHeight = m_uiForm.spAnnSampleHeight->value();
     hasZero = hasZero || isValueZero(sampleHeight);

--- a/qt/scientific_interfaces/Indirect/AbsorptionCorrections.cpp
+++ b/qt/scientific_interfaces/Indirect/AbsorptionCorrections.cpp
@@ -136,6 +136,8 @@ AbsorptionCorrections::AbsorptionCorrections(QWidget *parent)
   // Change of input
   connect(m_uiForm.dsSampleInput, SIGNAL(dataReady(const QString &)), this,
           SLOT(getParameterDefaults(const QString &)));
+  connect(m_uiForm.cbShape, SIGNAL(currentIndexChanged(int)), this,
+          SLOT(setCanCbState(int)));
   // Handle algorithm completion
   connect(m_batchAlgoRunner, SIGNAL(batchComplete(bool)), this,
           SLOT(algorithmComplete(bool)));
@@ -644,6 +646,15 @@ void AbsorptionCorrections::setCanDensity(double value) {
     m_canDensities->setMassDensity(value);
   else
     m_canDensities->setNumberDensity(value);
+}
+
+void AbsorptionCorrections::setCanCbState(int index) {
+  if (index == 0) {
+    m_uiForm.cbUseCan->setChecked(true);
+    m_uiForm.cbUseCan->setEnabled(false);
+  } else {
+    m_uiForm.cbUseCan->setEnabled(true);
+  }
 }
 
 std::vector<std::string>

--- a/qt/scientific_interfaces/Indirect/AbsorptionCorrections.cpp
+++ b/qt/scientific_interfaces/Indirect/AbsorptionCorrections.cpp
@@ -214,7 +214,7 @@ void AbsorptionCorrections::run() {
   if (!isPreset) {
 
     // Get correct corrections algorithm
-    
+
     monteCarloAbsCor->setProperty("Shape", sampleShape.toStdString());
 
     addShapeSpecificSampleOptions(monteCarloAbsCor, sampleShape);

--- a/qt/scientific_interfaces/Indirect/AbsorptionCorrections.cpp
+++ b/qt/scientific_interfaces/Indirect/AbsorptionCorrections.cpp
@@ -396,7 +396,6 @@ bool AbsorptionCorrections::validate() {
 void AbsorptionCorrections::validateSampleGeometryInputs(
     UserInputValidator &uiv, const QString &shape) {
   bool hasZero = false;
-  std::vector<double> inputs;
   if (shape == "FlatPlate") {
     double const sampleHeight = m_uiForm.spFlatSampleHeight->value();
     hasZero = hasZero || isValueZero(sampleHeight);
@@ -441,7 +440,6 @@ void AbsorptionCorrections::validateSampleGeometryInputs(
 void AbsorptionCorrections::validateContainerGeometryInputs(
     UserInputValidator &uiv, const QString &shape) {
   bool hasZero = false;
-  std::vector<double> inputs;
   if (shape == "FlatPlate") {
     double const canFrontThickness = m_uiForm.spFlatCanFrontThickness->value();
     hasZero = hasZero || isValueZero(canFrontThickness);

--- a/qt/scientific_interfaces/Indirect/AbsorptionCorrections.cpp
+++ b/qt/scientific_interfaces/Indirect/AbsorptionCorrections.cpp
@@ -212,12 +212,11 @@ void AbsorptionCorrections::run() {
 
   QString const sampleShape = m_uiForm.cbShape->currentText().replace(" ", "");
   const bool isPreset = sampleShape == "Preset";
+  monteCarloAbsCor->setProperty("Shape", sampleShape.toStdString());
 
   if (!isPreset) {
 
     // Get correct corrections algorithm
-
-    monteCarloAbsCor->setProperty("Shape", sampleShape.toStdString());
 
     addShapeSpecificSampleOptions(monteCarloAbsCor, sampleShape);
 

--- a/qt/scientific_interfaces/Indirect/AbsorptionCorrections.cpp
+++ b/qt/scientific_interfaces/Indirect/AbsorptionCorrections.cpp
@@ -407,6 +407,7 @@ void AbsorptionCorrections::validateSampleGeometryInputs(
     hasZero = hasZero || isValueZero(sampleThickness);
 
   } else if (shape == "Annulus") {
+
     double const sampleHeight = m_uiForm.spAnnSampleHeight->value();
     hasZero = hasZero || isValueZero(sampleHeight);
 
@@ -415,6 +416,12 @@ void AbsorptionCorrections::validateSampleGeometryInputs(
 
     double const sampleOuterRadius = m_uiForm.spAnnSampleOuterRadius->value();
     hasZero = hasZero || isValueZero(sampleOuterRadius);
+
+    if (sampleInnerRadius >= sampleOuterRadius) {
+      uiv.addErrorMessage(
+          "SampleOuterRadius must be greater than SampleInnerRadius.");
+      uiv.setErrorLabel(m_uiForm.lbAnnSampleOuterRadius, false);
+    }
 
   } else if (shape == "Cylinder") {
     double const sampleRadius = m_uiForm.spCylSampleRadius->value();
@@ -437,6 +444,7 @@ void AbsorptionCorrections::validateSampleGeometryInputs(
 void AbsorptionCorrections::validateContainerGeometryInputs(
     UserInputValidator &uiv, const QString &shape) {
   bool hasZero = false;
+
   if (shape == "FlatPlate") {
     double const canFrontThickness = m_uiForm.spFlatCanFrontThickness->value();
     hasZero = hasZero || isValueZero(canFrontThickness);
@@ -447,12 +455,31 @@ void AbsorptionCorrections::validateContainerGeometryInputs(
     double const canOuterRadius = m_uiForm.spCylCanOuterRadius->value();
     hasZero = hasZero || isValueZero(canOuterRadius);
 
+    double const sampleRadius = m_uiForm.spAnnSampleOuterRadius->value();
+    if (canOuterRadius <= sampleRadius) {
+      uiv.addErrorMessage("CanOuterRadius must be greater than SampleRadius.");
+      uiv.setErrorLabel(m_uiForm.lbCylCanOuterRadius, false);
+    }
+
   } else if (shape == "Annulus") {
     double const canInnerRadius = m_uiForm.spAnnCanInnerRadius->value();
     hasZero = hasZero || isValueZero(canInnerRadius);
 
     double const canOuterRadius = m_uiForm.spAnnCanOuterRadius->value();
     hasZero = hasZero || isValueZero(canOuterRadius);
+
+    double const sampleInnerRadius = m_uiForm.spAnnSampleInnerRadius->value();
+    double const sampleOuterRadius = m_uiForm.spAnnSampleOuterRadius->value();
+    if (canInnerRadius >= sampleInnerRadius) {
+      uiv.addErrorMessage(
+          "SampleInnerRadius must be greater than ContainerInnerRadius.");
+      uiv.setErrorLabel(m_uiForm.lbAnnSampleInnerRadius, false);
+    }
+    if (canOuterRadius <= sampleOuterRadius) {
+      uiv.addErrorMessage(
+          "ContainerOuterRadius must be greater than SampleOuterRadius.");
+      uiv.setErrorLabel(m_uiForm.lbAnnCanOuterRadius, false);
+    }
   }
   if (hasZero) {
     uiv.addErrorMessage("Container Geometry inputs cannot be zero-valued.");

--- a/qt/scientific_interfaces/Indirect/AbsorptionCorrections.cpp
+++ b/qt/scientific_interfaces/Indirect/AbsorptionCorrections.cpp
@@ -420,7 +420,6 @@ void AbsorptionCorrections::validateSampleGeometryInputs(
     if (sampleInnerRadius >= sampleOuterRadius) {
       uiv.addErrorMessage(
           "SampleOuterRadius must be greater than SampleInnerRadius.");
-      uiv.setErrorLabel(m_uiForm.lbAnnSampleOuterRadius, false);
     }
 
   } else if (shape == "Cylinder") {
@@ -458,7 +457,6 @@ void AbsorptionCorrections::validateContainerGeometryInputs(
     double const sampleRadius = m_uiForm.spAnnSampleOuterRadius->value();
     if (canOuterRadius <= sampleRadius) {
       uiv.addErrorMessage("CanOuterRadius must be greater than SampleRadius.");
-      uiv.setErrorLabel(m_uiForm.lbCylCanOuterRadius, false);
     }
 
   } else if (shape == "Annulus") {
@@ -473,12 +471,10 @@ void AbsorptionCorrections::validateContainerGeometryInputs(
     if (canInnerRadius >= sampleInnerRadius) {
       uiv.addErrorMessage(
           "SampleInnerRadius must be greater than ContainerInnerRadius.");
-      uiv.setErrorLabel(m_uiForm.lbAnnSampleInnerRadius, false);
     }
     if (canOuterRadius <= sampleOuterRadius) {
       uiv.addErrorMessage(
           "ContainerOuterRadius must be greater than SampleOuterRadius.");
-      uiv.setErrorLabel(m_uiForm.lbAnnCanOuterRadius, false);
     }
   }
   if (hasZero) {

--- a/qt/scientific_interfaces/Indirect/AbsorptionCorrections.cpp
+++ b/qt/scientific_interfaces/Indirect/AbsorptionCorrections.cpp
@@ -278,8 +278,7 @@ void AbsorptionCorrections::run() {
   if (nameCutIndex == -1)
     nameCutIndex = sampleWsName.length();
 
-  auto const outputWsName =
-      sampleWsName.left(nameCutIndex) + "_MC_Corrections";
+  auto const outputWsName = sampleWsName.left(nameCutIndex) + "_MC_Corrections";
 
   monteCarloAbsCor->setProperty("CorrectionsWorkspace",
                                 outputWsName.toStdString());

--- a/qt/scientific_interfaces/Indirect/AbsorptionCorrections.h
+++ b/qt/scientific_interfaces/Indirect/AbsorptionCorrections.h
@@ -41,6 +41,7 @@ private slots:
   void changeCanMaterialOptions(int index);
   void setSampleDensity(double value);
   void setCanDensity(double value);
+  void setCanCbState(int index);
   UserInputValidator doValidation();
 
 private:

--- a/qt/scientific_interfaces/Indirect/AbsorptionCorrections.h
+++ b/qt/scientific_interfaces/Indirect/AbsorptionCorrections.h
@@ -41,7 +41,7 @@ private slots:
   void changeCanMaterialOptions(int index);
   void setSampleDensity(double value);
   void setCanDensity(double value);
-  void setCanCbState(int index);
+  void handlePresetShapeChanges(int index);
   UserInputValidator doValidation();
 
 private:
@@ -50,6 +50,13 @@ private:
   bool validate() override;
   void loadSettings(const QSettings &settings) override;
   void setFileExtensionsByName(bool filter) override;
+
+  void
+  AbsorptionCorrections::validateSampleGeometryInputs(UserInputValidator &uiv,
+                                                      const QString &shape);
+  void
+  AbsorptionCorrections::validateContainerGeometryInputs(UserInputValidator &uiv,
+                                                      const QString &shape);
 
   void addSaveWorkspace(std::string const &wsName);
   void addShapeSpecificSampleOptions(const Mantid::API::IAlgorithm_sptr &alg,

--- a/qt/scientific_interfaces/Indirect/AbsorptionCorrections.h
+++ b/qt/scientific_interfaces/Indirect/AbsorptionCorrections.h
@@ -51,11 +51,10 @@ private:
   void loadSettings(const QSettings &settings) override;
   void setFileExtensionsByName(bool filter) override;
 
-  void
-  AbsorptionCorrections::validateSampleGeometryInputs(UserInputValidator &uiv,
-                                                      const QString &shape);
-  void AbsorptionCorrections::validateContainerGeometryInputs(
-      UserInputValidator &uiv, const QString &shape);
+  void validateSampleGeometryInputs(UserInputValidator &uiv,
+                                    const QString &shape);
+  void validateContainerGeometryInputs(UserInputValidator &uiv,
+                                       const QString &shape);
 
   void addSaveWorkspace(std::string const &wsName);
   void addShapeSpecificSampleOptions(const Mantid::API::IAlgorithm_sptr &alg,

--- a/qt/scientific_interfaces/Indirect/AbsorptionCorrections.h
+++ b/qt/scientific_interfaces/Indirect/AbsorptionCorrections.h
@@ -54,9 +54,8 @@ private:
   void
   AbsorptionCorrections::validateSampleGeometryInputs(UserInputValidator &uiv,
                                                       const QString &shape);
-  void
-  AbsorptionCorrections::validateContainerGeometryInputs(UserInputValidator &uiv,
-                                                      const QString &shape);
+  void AbsorptionCorrections::validateContainerGeometryInputs(
+      UserInputValidator &uiv, const QString &shape);
 
   void addSaveWorkspace(std::string const &wsName);
   void addShapeSpecificSampleOptions(const Mantid::API::IAlgorithm_sptr &alg,

--- a/qt/scientific_interfaces/Indirect/AbsorptionCorrections.ui
+++ b/qt/scientific_interfaces/Indirect/AbsorptionCorrections.ui
@@ -303,7 +303,7 @@
              </sizepolicy>
             </property>
             <property name="currentIndex">
-             <number>3</number>
+             <number>1</number>
             </property>
             <widget class="QWidget" name="pgAbsCorPreset"/>
             <widget class="QWidget" name="pgAbsCorFlatPlate">

--- a/qt/scientific_interfaces/Indirect/AbsorptionCorrections.ui
+++ b/qt/scientific_interfaces/Indirect/AbsorptionCorrections.ui
@@ -259,7 +259,10 @@
             <item>
              <widget class="QComboBox" name="cbShape">
               <property name="currentText">
-               <string>Preset</string>
+               <string>Flat Plate</string>
+              </property>
+              <property name="currentIndex">
+               <number>1</number>
               </property>
               <item>
                <property name="text">
@@ -294,7 +297,7 @@
              </sizepolicy>
             </property>
             <property name="currentIndex">
-             <number>0</number>
+             <number>3</number>
             </property>
             <widget class="QWidget" name="pgAbsCorPreset"/>
             <widget class="QWidget" name="pgAbsCorFlatPlate">
@@ -384,7 +387,7 @@
               <item row="3" column="1">
                <widget class="QDoubleSpinBox" name="spFlatCanFrontThickness">
                 <property name="enabled">
-                 <bool>false</bool>
+                 <bool>true</bool>
                 </property>
                 <property name="suffix">
                  <string> cm</string>
@@ -430,7 +433,7 @@
               <item row="3" column="3">
                <widget class="QDoubleSpinBox" name="spFlatCanBackThickness">
                 <property name="enabled">
-                 <bool>false</bool>
+                 <bool>true</bool>
                 </property>
                 <property name="suffix">
                  <string> cm</string>
@@ -462,7 +465,7 @@
               <item row="6" column="3">
                <widget class="QDoubleSpinBox" name="spAnnCanOuterRadius">
                 <property name="enabled">
-                 <bool>false</bool>
+                 <bool>true</bool>
                 </property>
                 <property name="suffix">
                  <string> cm</string>
@@ -478,7 +481,7 @@
               <item row="6" column="1">
                <widget class="QDoubleSpinBox" name="spAnnCanInnerRadius">
                 <property name="enabled">
-                 <bool>false</bool>
+                 <bool>true</bool>
                 </property>
                 <property name="suffix">
                  <string> cm</string>
@@ -640,7 +643,7 @@
               <item row="2" column="3">
                <widget class="QDoubleSpinBox" name="spCylCanOuterRadius">
                 <property name="enabled">
-                 <bool>false</bool>
+                 <bool>true</bool>
                 </property>
                 <property name="suffix">
                  <string> cm</string>
@@ -1465,6 +1468,86 @@
     <hint type="destinationlabel">
      <x>486</x>
      <y>589</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>cbUseCan</sender>
+   <signal>toggled(bool)</signal>
+   <receiver>lbFlatCanBackThickness</receiver>
+   <slot>setEnabled(bool)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>256</x>
+     <y>69</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>602</x>
+     <y>350</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>cbUseCan</sender>
+   <signal>toggled(bool)</signal>
+   <receiver>lbFlatCanFrontThickness</receiver>
+   <slot>setEnabled(bool)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>256</x>
+     <y>69</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>141</x>
+     <y>350</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>cbUseCan</sender>
+   <signal>toggled(bool)</signal>
+   <receiver>lbAnnCanInnerRadius</receiver>
+   <slot>setEnabled(bool)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>256</x>
+     <y>69</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>141</x>
+     <y>350</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>cbUseCan</sender>
+   <signal>toggled(bool)</signal>
+   <receiver>lbAnnCanOuterRadius</receiver>
+   <slot>setEnabled(bool)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>256</x>
+     <y>69</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>602</x>
+     <y>350</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>cbUseCan</sender>
+   <signal>toggled(bool)</signal>
+   <receiver>lbCylCanOuterRadius</receiver>
+   <slot>setEnabled(bool)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>256</x>
+     <y>69</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>602</x>
+     <y>340</y>
     </hint>
    </hints>
   </connection>

--- a/qt/scientific_interfaces/Indirect/AbsorptionCorrections.ui
+++ b/qt/scientific_interfaces/Indirect/AbsorptionCorrections.ui
@@ -38,7 +38,14 @@
           <string>Input</string>
          </property>
          <layout class="QGridLayout" name="gridLayout_11">
-          <item row="0" column="1">
+          <item row="1" column="0">
+           <widget class="QLabel" name="lbSampleInput">
+            <property name="text">
+             <string>Input Workspace:</string>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="1">
            <widget class="MantidQt::MantidWidgets::DataSelector" name="dsSampleInput" native="true">
             <property name="sizePolicy">
              <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
@@ -69,7 +76,7 @@
             </property>
            </widget>
           </item>
-          <item row="1" column="0">
+          <item row="2" column="0">
            <widget class="QCheckBox" name="cbUseCan">
             <property name="maximumSize">
              <size>
@@ -79,13 +86,6 @@
             </property>
             <property name="text">
              <string>Use Container</string>
-            </property>
-           </widget>
-          </item>
-          <item row="0" column="0">
-           <widget class="QLabel" name="lbSampleInput">
-            <property name="text">
-             <string>Input Workspace:</string>
             </property>
            </widget>
           </item>
@@ -616,20 +616,6 @@
                 </property>
                </widget>
               </item>
-              <item row="2" column="0">
-               <widget class="QLabel" name="lbCylSampleRadius">
-                <property name="text">
-                 <string>Sample Radius:</string>
-                </property>
-               </widget>
-              </item>
-              <item row="1" column="0">
-               <widget class="QLabel" name="lbCylSampleHeight">
-                <property name="text">
-                 <string>Sample Height:</string>
-                </property>
-               </widget>
-              </item>
               <item row="2" column="2">
                <widget class="QLabel" name="lbCylCanOuterRadius">
                 <property name="enabled">
@@ -653,6 +639,20 @@
                 </property>
                 <property name="singleStep">
                  <double>0.100000000000000</double>
+                </property>
+               </widget>
+              </item>
+              <item row="1" column="0">
+               <widget class="QLabel" name="lbCylSampleHeight">
+                <property name="text">
+                 <string>Sample Height:</string>
+                </property>
+               </widget>
+              </item>
+              <item row="2" column="0">
+               <widget class="QLabel" name="lbCylSampleRadius">
+                <property name="text">
+                 <string>Sample Radius:</string>
                 </property>
                </widget>
               </item>

--- a/qt/scientific_interfaces/Indirect/AbsorptionCorrections.ui
+++ b/qt/scientific_interfaces/Indirect/AbsorptionCorrections.ui
@@ -2,6 +2,9 @@
 <ui version="4.0">
  <class>AbsorptionCorrections</class>
  <widget class="QWidget" name="AbsorptionCorrections">
+  <property name="enabled">
+   <bool>true</bool>
+  </property>
   <property name="geometry">
    <rect>
     <x>0</x>
@@ -35,16 +38,6 @@
           <string>Input</string>
          </property>
          <layout class="QGridLayout" name="gridLayout_11">
-          <item row="1" column="0">
-           <widget class="QCheckBox" name="overrideShape">
-            <property name="text">
-             <string>Override Sample/Can from Workspace</string>
-            </property>
-            <property name="checked">
-             <bool>true</bool>
-            </property>
-           </widget>
-          </item>
           <item row="0" column="1">
            <widget class="MantidQt::MantidWidgets::DataSelector" name="dsSampleInput" native="true">
             <property name="sizePolicy">
@@ -73,6 +66,19 @@
             </property>
             <property name="ShowGroups" stdset="0">
              <bool>false</bool>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="0">
+           <widget class="QCheckBox" name="cbUseCan">
+            <property name="maximumSize">
+             <size>
+              <width>16777208</width>
+              <height>16777215</height>
+             </size>
+            </property>
+            <property name="text">
+             <string>Use Container</string>
             </property>
            </widget>
           </item>
@@ -252,6 +258,14 @@
             </item>
             <item>
              <widget class="QComboBox" name="cbShape">
+              <property name="currentText">
+               <string>Preset</string>
+              </property>
+              <item>
+               <property name="text">
+                <string>Preset</string>
+               </property>
+              </item>
               <item>
                <property name="text">
                 <string>Flat Plate</string>
@@ -282,6 +296,7 @@
             <property name="currentIndex">
              <number>0</number>
             </property>
+            <widget class="QWidget" name="pgAbsCorPreset"/>
             <widget class="QWidget" name="pgAbsCorFlatPlate">
              <layout class="QGridLayout" name="loFlatPlate">
               <property name="leftMargin">
@@ -359,7 +374,7 @@
               <item row="3" column="0">
                <widget class="QLabel" name="lbFlatCanFrontThickness">
                 <property name="enabled">
-                 <bool>false</bool>
+                 <bool>true</bool>
                 </property>
                 <property name="text">
                  <string>Container Front Thickness:</string>
@@ -405,7 +420,7 @@
               <item row="3" column="2">
                <widget class="QLabel" name="lbFlatCanBackThickness">
                 <property name="enabled">
-                 <bool>false</bool>
+                 <bool>true</bool>
                 </property>
                 <property name="text">
                  <string>Container Back Thickness:</string>
@@ -512,7 +527,7 @@
               <item row="6" column="0">
                <widget class="QLabel" name="lbAnnCanInnerRadius">
                 <property name="enabled">
-                 <bool>false</bool>
+                 <bool>true</bool>
                 </property>
                 <property name="text">
                  <string>Inner Container Inner Radius:</string>
@@ -522,7 +537,7 @@
               <item row="6" column="2">
                <widget class="QLabel" name="lbAnnCanOuterRadius">
                 <property name="enabled">
-                 <bool>false</bool>
+                 <bool>true</bool>
                 </property>
                 <property name="text">
                  <string>Outer Container Outer Radius:</string>
@@ -615,7 +630,7 @@
               <item row="2" column="2">
                <widget class="QLabel" name="lbCylCanOuterRadius">
                 <property name="enabled">
-                 <bool>false</bool>
+                 <bool>true</bool>
                 </property>
                 <property name="text">
                  <string>Container Outer Radius</string>
@@ -918,7 +933,7 @@
        <item>
         <widget class="QGroupBox" name="gbContainerDetails">
          <property name="enabled">
-          <bool>true</bool>
+          <bool>false</bool>
          </property>
          <property name="title">
           <string>Container Details</string>
@@ -1303,7 +1318,6 @@
   </customwidget>
  </customwidgets>
  <tabstops>
-  <tabstop>overrideShape</tabstop>
   <tabstop>spNumberEvents</tabstop>
   <tabstop>spBeamHeight</tabstop>
   <tabstop>spBeamWidth</tabstop>
@@ -1359,46 +1373,94 @@
    </hints>
   </connection>
   <connection>
-   <sender>overrideShape</sender>
+   <sender>cbUseCan</sender>
    <signal>toggled(bool)</signal>
-   <receiver>gbShapeDetails</receiver>
+   <receiver>spFlatCanBackThickness</receiver>
    <slot>setEnabled(bool)</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>334</x>
+     <x>256</x>
      <y>69</y>
     </hint>
     <hint type="destinationlabel">
-     <x>486</x>
-     <y>304</y>
+     <x>832</x>
+     <y>350</y>
     </hint>
    </hints>
   </connection>
   <connection>
-   <sender>overrideShape</sender>
+   <sender>cbUseCan</sender>
    <signal>toggled(bool)</signal>
-   <receiver>gbSampleDetails</receiver>
+   <receiver>spFlatCanFrontThickness</receiver>
    <slot>setEnabled(bool)</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>308</x>
+     <x>256</x>
      <y>69</y>
     </hint>
     <hint type="destinationlabel">
-     <x>486</x>
-     <y>445</y>
+     <x>371</x>
+     <y>350</y>
     </hint>
    </hints>
   </connection>
   <connection>
-   <sender>overrideShape</sender>
+   <sender>cbUseCan</sender>
+   <signal>toggled(bool)</signal>
+   <receiver>spAnnCanInnerRadius</receiver>
+   <slot>setEnabled(bool)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>256</x>
+     <y>69</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>371</x>
+     <y>350</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>cbUseCan</sender>
+   <signal>toggled(bool)</signal>
+   <receiver>spAnnCanOuterRadius</receiver>
+   <slot>setEnabled(bool)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>256</x>
+     <y>69</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>832</x>
+     <y>350</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>cbUseCan</sender>
+   <signal>toggled(bool)</signal>
+   <receiver>spCylCanOuterRadius</receiver>
+   <slot>setEnabled(bool)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>256</x>
+     <y>69</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>832</x>
+     <y>340</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>cbUseCan</sender>
    <signal>toggled(bool)</signal>
    <receiver>gbContainerDetails</receiver>
    <slot>setEnabled(bool)</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>38</x>
-     <y>66</y>
+     <x>256</x>
+     <y>69</y>
     </hint>
     <hint type="destinationlabel">
      <x>486</x>

--- a/qt/scientific_interfaces/Indirect/AbsorptionCorrections.ui
+++ b/qt/scientific_interfaces/Indirect/AbsorptionCorrections.ui
@@ -1,1585 +1,1410 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ui version="4.0">
-  <class>AbsorptionCorrections</class>
-  <widget class="QWidget" name="AbsorptionCorrections">
-    <property name="geometry">
-      <rect>
+ <class>AbsorptionCorrections</class>
+ <widget class="QWidget" name="AbsorptionCorrections">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>974</width>
+    <height>791</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Absorption Corrections</string>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout_2">
+   <item>
+    <widget class="QScrollArea" name="scrollArea">
+     <property name="widgetResizable">
+      <bool>true</bool>
+     </property>
+     <widget class="QWidget" name="scrollAreaWidgetContents">
+      <property name="geometry">
+       <rect>
         <x>0</x>
         <y>0</y>
-        <width>974</width>
-        <height>791</height>
-      </rect>
-    </property>
-    <property name="windowTitle">
-      <string>Absoprtion Corrections</string>
-    </property>
-    <layout class="QVBoxLayout" name="verticalLayout_2">
-      <item>
-        <widget class="QScrollArea" name="scrollArea">
-          <property name="widgetResizable">
-            <bool>true</bool>
-          </property>
-          <widget class="QWidget" name="scrollAreaWidgetContents">
-            <property name="geometry">
-              <rect>
-                <x>0</x>
-                <y>0</y>
-                <width>954</width>
-                <height>771</height>
-              </rect>
+        <width>954</width>
+        <height>771</height>
+       </rect>
+      </property>
+      <layout class="QVBoxLayout" name="verticalLayout">
+       <item>
+        <widget class="QGroupBox" name="gbInput">
+         <property name="title">
+          <string>Input</string>
+         </property>
+         <layout class="QGridLayout" name="gridLayout_11">
+          <item row="1" column="0">
+           <widget class="QCheckBox" name="overrideShape">
+            <property name="text">
+             <string>Override Sample/Can from Workspace</string>
             </property>
-            <layout class="QVBoxLayout" name="verticalLayout">
-              <item>
-                <widget class="QGroupBox" name="gbInput">
-                  <property name="title">
-                    <string>Input</string>
-                  </property>
-                  <layout class="QGridLayout" name="gridLayout_11">
-                    <item row="1" column="0">
-                      <widget class="QCheckBox" name="ckUseCan">
-                        <property name="text">
-                          <string>Use Container:</string>
-                        </property>
-                      </widget>
-                    </item>
-                    <item row="0" column="1">
-                      <widget class="MantidQt::MantidWidgets::DataSelector" name="dsSampleInput" native="true">
-                        <property name="sizePolicy">
-                          <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
-                            <horstretch>0</horstretch>
-                            <verstretch>0</verstretch>
-                          </sizepolicy>
-                        </property>
-                        <property name="autoLoad" stdset="0">
-                          <bool>true</bool>
-                        </property>
-                        <property name="workspaceSuffixes" stdset="0">
-                          <stringlist>
-                            <string>_red</string>
-                            <string>_sqw</string>
-                          </stringlist>
-                        </property>
-                        <property name="fileBrowserSuffixes" stdset="0">
-                          <stringlist>
-                            <string>_red.nxs</string>
-                            <string>_sqw.nxs</string>
-                          </stringlist>
-                        </property>
-                        <property name="showLoad" stdset="0">
-                          <bool>false</bool>
-                        </property>
-                        <property name="ShowGroups" stdset="0">
-                          <bool>false</bool>
-                        </property>
-                      </widget>
-                    </item>
-                    <item row="0" column="0">
-                      <widget class="QLabel" name="lbSampleInput">
-                        <property name="text">
-                          <string>Sample Input:</string>
-                        </property>
-                      </widget>
-                    </item>
-                    <item row="1" column="1">
-                      <widget class="MantidQt::MantidWidgets::DataSelector" name="dsCanInput" native="true">
-                        <property name="enabled">
-                          <bool>false</bool>
-                        </property>
-                        <property name="sizePolicy">
-                          <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
-                            <horstretch>0</horstretch>
-                            <verstretch>0</verstretch>
-                          </sizepolicy>
-                        </property>
-                        <property name="autoLoad" stdset="0">
-                          <bool>true</bool>
-                        </property>
-                        <property name="workspaceSuffixes" stdset="0">
-                          <stringlist>
-                            <string>_red</string>
-                            <string>_sqw</string>
-                          </stringlist>
-                        </property>
-                        <property name="fileBrowserSuffixes" stdset="0">
-                          <stringlist>
-                            <string>_red.nxs</string>
-                            <string>_sqw.nxs</string>
-                          </stringlist>
-                        </property>
-                        <property name="showLoad" stdset="0">
-                          <bool>false</bool>
-                        </property>
-                        <property name="ShowGroups" stdset="0">
-                          <bool>false</bool>
-                        </property>
-                      </widget>
-                    </item>
-                  </layout>
-                </widget>
-              </item>
-              <item>
-                <widget class="QGroupBox" name="gbMonteCarloDetails">
-                  <property name="title">
-                    <string>Monte Carlo</string>
-                  </property>
-                  <property name="flat">
-                    <bool>false</bool>
-                  </property>
-                  <property name="checkable">
-                    <bool>false</bool>
-                  </property>
-                  <layout class="QGridLayout" name="gridLayout_3">
-                    <item row="1" column="0">
-                      <widget class="QLabel" name="lbNumberEvents">
-                        <property name="text">
-                          <string>Events:</string>
-                        </property>
-                      </widget>
-                    </item>
-                    <item row="1" column="1">
-                      <widget class="QSpinBox" name="spNumberEvents">
-                        <property name="maximum">
-                          <number>1000000</number>
-                        </property>
-                        <property name="singleStep">
-                          <number>10</number>
-                        </property>
-                        <property name="value">
-                          <number>5000</number>
-                        </property>
-                      </widget>
-                    </item>
-                    <item row="2" column="0">
-                      <widget class="QLabel" name="label">
-                        <property name="text">
-                          <string>Interpolation:</string>
-                        </property>
-                      </widget>
-                    </item>
-                    <item row="2" column="2">
-                      <widget class="QLabel" name="label_2">
-                        <property name="text">
-                          <string>Maximum Scatter Point Attempts:</string>
-                        </property>
-                      </widget>
-                    </item>
-                    <item row="2" column="1">
-                      <widget class="QComboBox" name="cbInterpolation">
-                        <property name="currentIndex">
-                          <number>0</number>
-                        </property>
-                        <item>
-                          <property name="text">
-                            <string>Linear</string>
-                          </property>
-                        </item>
-                        <item>
-                          <property name="text">
-                            <string>CSpline</string>
-                          </property>
-                        </item>
-                      </widget>
-                    </item>
-                    <item row="2" column="4">
-                      <widget class="QSpinBox" name="spMaxScatterPtAttempts">
-                        <property name="minimum">
-                          <number>1</number>
-                        </property>
-                        <property name="maximum">
-                          <number>1000000</number>
-                        </property>
-                        <property name="singleStep">
-                          <number>100</number>
-                        </property>
-                        <property name="value">
-                          <number>5000</number>
-                        </property>
-                      </widget>
-                    </item>
-                  </layout>
-                </widget>
-              </item>
-              <item>
-                <widget class="QGroupBox" name="gbBeamDetails">
-                  <property name="title">
-                    <string>Beam Details</string>
-                  </property>
-                  <layout class="QGridLayout" name="gridLayout_4">
-                    <item row="0" column="1">
-                      <widget class="QDoubleSpinBox" name="spBeamHeight">
-                        <property name="enabled">
-                          <bool>true</bool>
-                        </property>
-                        <property name="suffix">
-                          <string> cm</string>
-                        </property>
-                        <property name="singleStep">
-                          <double>0.100000000000000</double>
-                        </property>
-                        <property name="value">
-                          <double>1.000000000000000</double>
-                        </property>
-                      </widget>
-                    </item>
-                    <item row="0" column="2">
-                      <widget class="QLabel" name="lbBeamWidth">
-                        <property name="enabled">
-                          <bool>true</bool>
-                        </property>
-                        <property name="text">
-                          <string>Beam Width:</string>
-                        </property>
-                      </widget>
-                    </item>
-                    <item row="0" column="3">
-                      <widget class="QDoubleSpinBox" name="spBeamWidth">
-                        <property name="enabled">
-                          <bool>true</bool>
-                        </property>
-                        <property name="suffix">
-                          <string> cm</string>
-                        </property>
-                        <property name="singleStep">
-                          <double>0.100000000000000</double>
-                        </property>
-                        <property name="value">
-                          <double>1.000000000000000</double>
-                        </property>
-                      </widget>
-                    </item>
-                    <item row="0" column="0">
-                      <widget class="QLabel" name="lbBeamHeight">
-                        <property name="enabled">
-                          <bool>true</bool>
-                        </property>
-                        <property name="text">
-                          <string>Beam Height:</string>
-                        </property>
-                      </widget>
-                    </item>
-                  </layout>
-                </widget>
-              </item>
-              <item>
-                <widget class="QGroupBox" name="gbShapeDetails">
-                  <property name="sizePolicy">
-                    <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-                      <horstretch>0</horstretch>
-                      <verstretch>0</verstretch>
-                    </sizepolicy>
-                  </property>
-                  <property name="title">
-                    <string>Shape Details</string>
-                  </property>
-                  <layout class="QVBoxLayout" name="verticalLayout_9">
-                    <item>
-                      <layout class="QHBoxLayout" name="loShape">
-                        <item>
-                          <widget class="QLabel" name="lbShape">
-                            <property name="text">
-                              <string>Shape:</string>
-                            </property>
-                          </widget>
-                        </item>
-                        <item>
-                          <widget class="QComboBox" name="cbShape">
-                            <item>
-                              <property name="text">
-                                <string>Flat Plate</string>
-                              </property>
-                            </item>
-                            <item>
-                              <property name="text">
-                                <string>Annulus</string>
-                              </property>
-                            </item>
-                            <item>
-                              <property name="text">
-                                <string>Cylinder</string>
-                              </property>
-                            </item>
-                          </widget>
-                        </item>
-                      </layout>
-                    </item>
-                    <item>
-                      <widget class="QStackedWidget" name="swShapeDetails">
-                        <property name="sizePolicy">
-                          <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-                            <horstretch>0</horstretch>
-                            <verstretch>0</verstretch>
-                          </sizepolicy>
-                        </property>
-                        <property name="currentIndex">
-                          <number>0</number>
-                        </property>
-                        <widget class="QWidget" name="pgAbsCorFlatPlate">
-                          <layout class="QGridLayout" name="loFlatPlate">
-                            <property name="leftMargin">
-                              <number>0</number>
-                            </property>
-                            <property name="topMargin">
-                              <number>0</number>
-                            </property>
-                            <property name="rightMargin">
-                              <number>0</number>
-                            </property>
-                            <property name="bottomMargin">
-                              <number>0</number>
-                            </property>
-                            <item row="1" column="1">
-                              <widget class="QDoubleSpinBox" name="spFlatSampleHeight">
-                                <property name="suffix">
-                                  <string> cm</string>
-                                </property>
-                                <property name="decimals">
-                                  <number>3</number>
-                                </property>
-                                <property name="singleStep">
-                                  <double>0.100000000000000</double>
-                                </property>
-                              </widget>
-                            </item>
-                            <item row="1" column="2">
-                              <widget class="QLabel" name="lbFlatSampleWidth">
-                                <property name="text">
-                                  <string>Sample Width:</string>
-                                </property>
-                              </widget>
-                            </item>
-                            <item row="1" column="3">
-                              <widget class="QDoubleSpinBox" name="spFlatSampleWidth">
-                                <property name="suffix">
-                                  <string> cm</string>
-                                </property>
-                                <property name="decimals">
-                                  <number>3</number>
-                                </property>
-                                <property name="singleStep">
-                                  <double>0.100000000000000</double>
-                                </property>
-                              </widget>
-                            </item>
-                            <item row="1" column="0">
-                              <widget class="QLabel" name="lbFlatSampleHeight">
-                                <property name="text">
-                                  <string>Sample Height:</string>
-                                </property>
-                              </widget>
-                            </item>
-                            <item row="2" column="1">
-                              <widget class="QDoubleSpinBox" name="spFlatSampleThickness">
-                                <property name="suffix">
-                                  <string> cm</string>
-                                </property>
-                                <property name="decimals">
-                                  <number>3</number>
-                                </property>
-                                <property name="singleStep">
-                                  <double>0.100000000000000</double>
-                                </property>
-                              </widget>
-                            </item>
-                            <item row="2" column="0">
-                              <widget class="QLabel" name="lbFlatSampleThickness">
-                                <property name="text">
-                                  <string>Sample Thickness:</string>
-                                </property>
-                              </widget>
-                            </item>
-                            <item row="3" column="0">
-                              <widget class="QLabel" name="lbFlatCanFrontThickness">
-                                <property name="enabled">
-                                  <bool>false</bool>
-                                </property>
-                                <property name="text">
-                                  <string>Container Front Thickness:</string>
-                                </property>
-                              </widget>
-                            </item>
-                            <item row="3" column="1">
-                              <widget class="QDoubleSpinBox" name="spFlatCanFrontThickness">
-                                <property name="enabled">
-                                  <bool>false</bool>
-                                </property>
-                                <property name="suffix">
-                                  <string> cm</string>
-                                </property>
-                                <property name="decimals">
-                                  <number>3</number>
-                                </property>
-                                <property name="singleStep">
-                                  <double>0.100000000000000</double>
-                                </property>
-                              </widget>
-                            </item>
-                            <item row="2" column="2">
-                              <widget class="QLabel" name="lbFlatSampleAngle">
-                                <property name="text">
-                                  <string>Sample Angle:</string>
-                                </property>
-                              </widget>
-                            </item>
-                            <item row="2" column="3">
-                              <widget class="QDoubleSpinBox" name="spFlatSampleAngle">
-                                <property name="suffix">
-                                  <string>°</string>
-                                </property>
-                                <property name="minimum">
-                                  <double>-180.000000000000000</double>
-                                </property>
-                                <property name="maximum">
-                                  <double>180.000000000000000</double>
-                                </property>
-                              </widget>
-                            </item>
-                            <item row="3" column="2">
-                              <widget class="QLabel" name="lbFlatCanBackThickness">
-                                <property name="enabled">
-                                  <bool>false</bool>
-                                </property>
-                                <property name="text">
-                                  <string>Container Back Thickness:</string>
-                                </property>
-                              </widget>
-                            </item>
-                            <item row="3" column="3">
-                              <widget class="QDoubleSpinBox" name="spFlatCanBackThickness">
-                                <property name="enabled">
-                                  <bool>false</bool>
-                                </property>
-                                <property name="suffix">
-                                  <string> cm</string>
-                                </property>
-                                <property name="decimals">
-                                  <number>3</number>
-                                </property>
-                                <property name="singleStep">
-                                  <double>0.100000000000000</double>
-                                </property>
-                              </widget>
-                            </item>
-                          </layout>
-                        </widget>
-                        <widget class="QWidget" name="pgAbsCorAnnulus">
-                          <layout class="QGridLayout" name="loAnnulus">
-                            <property name="leftMargin">
-                              <number>0</number>
-                            </property>
-                            <property name="topMargin">
-                              <number>0</number>
-                            </property>
-                            <property name="rightMargin">
-                              <number>0</number>
-                            </property>
-                            <property name="bottomMargin">
-                              <number>0</number>
-                            </property>
-                            <item row="6" column="3">
-                              <widget class="QDoubleSpinBox" name="spAnnCanOuterRadius">
-                                <property name="enabled">
-                                  <bool>false</bool>
-                                </property>
-                                <property name="suffix">
-                                  <string> cm</string>
-                                </property>
-                                <property name="decimals">
-                                  <number>3</number>
-                                </property>
-                                <property name="singleStep">
-                                  <double>0.100000000000000</double>
-                                </property>
-                              </widget>
-                            </item>
-                            <item row="6" column="1">
-                              <widget class="QDoubleSpinBox" name="spAnnCanInnerRadius">
-                                <property name="enabled">
-                                  <bool>false</bool>
-                                </property>
-                                <property name="suffix">
-                                  <string> cm</string>
-                                </property>
-                                <property name="decimals">
-                                  <number>3</number>
-                                </property>
-                                <property name="singleStep">
-                                  <double>0.100000000000000</double>
-                                </property>
-                              </widget>
-                            </item>
-                            <item row="2" column="1">
-                              <widget class="QDoubleSpinBox" name="spAnnSampleHeight">
-                                <property name="suffix">
-                                  <string> cm</string>
-                                </property>
-                                <property name="decimals">
-                                  <number>3</number>
-                                </property>
-                                <property name="singleStep">
-                                  <double>0.100000000000000</double>
-                                </property>
-                              </widget>
-                            </item>
-                            <item row="3" column="0">
-                              <widget class="QLabel" name="lbAnnSampleInnerRadius">
-                                <property name="text">
-                                  <string>Sample Inner Radius:</string>
-                                </property>
-                              </widget>
-                            </item>
-                            <item row="3" column="3">
-                              <widget class="QDoubleSpinBox" name="spAnnSampleOuterRadius">
-                                <property name="suffix">
-                                  <string> cm</string>
-                                </property>
-                                <property name="decimals">
-                                  <number>3</number>
-                                </property>
-                                <property name="singleStep">
-                                  <double>0.100000000000000</double>
-                                </property>
-                              </widget>
-                            </item>
-                            <item row="6" column="0">
-                              <widget class="QLabel" name="lbAnnCanInnerRadius">
-                                <property name="enabled">
-                                  <bool>false</bool>
-                                </property>
-                                <property name="text">
-                                  <string>Inner Container Inner Radius:</string>
-                                </property>
-                              </widget>
-                            </item>
-                            <item row="6" column="2">
-                              <widget class="QLabel" name="lbAnnCanOuterRadius">
-                                <property name="enabled">
-                                  <bool>false</bool>
-                                </property>
-                                <property name="text">
-                                  <string>Outer Container Outer Radius:</string>
-                                </property>
-                              </widget>
-                            </item>
-                            <item row="3" column="2">
-                              <widget class="QLabel" name="lbAnnSampleOuterRadius">
-                                <property name="text">
-                                  <string>Sample Outer Radius:</string>
-                                </property>
-                              </widget>
-                            </item>
-                            <item row="3" column="1">
-                              <widget class="QDoubleSpinBox" name="spAnnSampleInnerRadius">
-                                <property name="suffix">
-                                  <string> cm</string>
-                                </property>
-                                <property name="decimals">
-                                  <number>3</number>
-                                </property>
-                                <property name="singleStep">
-                                  <double>0.100000000000000</double>
-                                </property>
-                              </widget>
-                            </item>
-                            <item row="2" column="0">
-                              <widget class="QLabel" name="lbAnnSampleHeight">
-                                <property name="text">
-                                  <string>Sample Height:</string>
-                                </property>
-                              </widget>
-                            </item>
-                          </layout>
-                        </widget>
-                        <widget class="QWidget" name="pgAbsCorCylinder">
-                          <layout class="QGridLayout" name="loCylinder">
-                            <property name="leftMargin">
-                              <number>0</number>
-                            </property>
-                            <property name="topMargin">
-                              <number>0</number>
-                            </property>
-                            <property name="rightMargin">
-                              <number>0</number>
-                            </property>
-                            <property name="bottomMargin">
-                              <number>0</number>
-                            </property>
-                            <item row="1" column="1">
-                              <widget class="QDoubleSpinBox" name="spCylSampleHeight">
-                                <property name="suffix">
-                                  <string> cm</string>
-                                </property>
-                                <property name="decimals">
-                                  <number>3</number>
-                                </property>
-                                <property name="singleStep">
-                                  <double>0.100000000000000</double>
-                                </property>
-                              </widget>
-                            </item>
-                            <item row="2" column="1">
-                              <widget class="QDoubleSpinBox" name="spCylSampleRadius">
-                                <property name="suffix">
-                                  <string> cm</string>
-                                </property>
-                                <property name="decimals">
-                                  <number>3</number>
-                                </property>
-                                <property name="singleStep">
-                                  <double>0.100000000000000</double>
-                                </property>
-                              </widget>
-                            </item>
-                            <item row="2" column="0">
-                              <widget class="QLabel" name="lbCylSampleRadius">
-                                <property name="text">
-                                  <string>Sample Radius:</string>
-                                </property>
-                              </widget>
-                            </item>
-                            <item row="1" column="0">
-                              <widget class="QLabel" name="lbCylSampleHeight">
-                                <property name="text">
-                                  <string>Sample Height:</string>
-                                </property>
-                              </widget>
-                            </item>
-                            <item row="2" column="2">
-                              <widget class="QLabel" name="lbCylCanOuterRadius">
-                                <property name="enabled">
-                                  <bool>false</bool>
-                                </property>
-                                <property name="text">
-                                  <string>Container Outer Radius</string>
-                                </property>
-                              </widget>
-                            </item>
-                            <item row="2" column="3">
-                              <widget class="QDoubleSpinBox" name="spCylCanOuterRadius">
-                                <property name="enabled">
-                                  <bool>false</bool>
-                                </property>
-                                <property name="suffix">
-                                  <string> cm</string>
-                                </property>
-                                <property name="decimals">
-                                  <number>3</number>
-                                </property>
-                                <property name="singleStep">
-                                  <double>0.100000000000000</double>
-                                </property>
-                              </widget>
-                            </item>
-                          </layout>
-                        </widget>
-                      </widget>
-                    </item>
-                  </layout>
-                </widget>
-              </item>
-              <item>
-                <widget class="QGroupBox" name="gbSampleDetails">
-                  <property name="title">
-                    <string>Sample Details</string>
-                  </property>
-                  <layout class="QGridLayout" name="gridLayout">
-                    <item row="0" column="0" colspan="3">
-                      <widget class="QFrame" name="frame_2">
-                        <layout class="QHBoxLayout" name="horizontalLayout_8">
-                          <property name="leftMargin">
-                            <number>0</number>
-                          </property>
-                          <property name="topMargin">
-                            <number>0</number>
-                          </property>
-                          <property name="rightMargin">
-                            <number>0</number>
-                          </property>
-                          <property name="bottomMargin">
-                            <number>0</number>
-                          </property>
-                          <item>
-                            <widget class="QLabel" name="lbSampleMaterialsMethod">
-                              <property name="text">
-                                <string>Method:</string>
-                              </property>
-                            </widget>
-                          </item>
-                          <item>
-                            <widget class="QComboBox" name="cbSampleMaterialMethod">
-                              <property name="sizePolicy">
-                                <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-                                  <horstretch>0</horstretch>
-                                  <verstretch>0</verstretch>
-                                </sizepolicy>
-                              </property>
-                              <property name="minimumSize">
-                                <size>
-                                  <width>120</width>
-                                  <height>0</height>
-                                </size>
-                              </property>
-                              <item>
-                                <property name="text">
-                                  <string>Chemical Formula</string>
-                                </property>
-                              </item>
-                              <item>
-                                <property name="text">
-                                  <string>Cross-sections</string>
-                                </property>
-                              </item>
-                            </widget>
-                          </item>
-                        </layout>
-                      </widget>
-                    </item>
-                    <item row="1" column="0" colspan="3">
-                      <widget class="QFrame" name="frame_3">
-                        <layout class="QHBoxLayout" name="horizontalLayout_3">
-                          <property name="leftMargin">
-                            <number>0</number>
-                          </property>
-                          <property name="topMargin">
-                            <number>0</number>
-                          </property>
-                          <property name="rightMargin">
-                            <number>0</number>
-                          </property>
-                          <property name="bottomMargin">
-                            <number>0</number>
-                          </property>
-                          <item>
-                            <widget class="QComboBox" name="cbSampleDensity">
-                              <item>
-                                <property name="text">
-                                  <string>Mass Density</string>
-                                </property>
-                              </item>
-                              <item>
-                                <property name="text">
-                                  <string>Atom Number Density</string>
-                                </property>
-                              </item>
-                              <item>
-                                <property name="text">
-                                  <string>Formula Number Density</string>
-                                </property>
-                              </item>
-                            </widget>
-                          </item>
-                          <item>
-                            <widget class="QDoubleSpinBox" name="spSampleDensity">
-                              <property name="suffix">
-                                <string> g/cm3</string>
-                              </property>
-                              <property name="decimals">
-                                <number>4</number>
-                              </property>
-                              <property name="maximum">
-                                <double>9999.989999999999782</double>
-                              </property>
-                              <property name="singleStep">
-                                <double>0.100000000000000</double>
-                              </property>
-                              <property name="value">
-                                <double>1.000000000000000</double>
-                              </property>
-                            </widget>
-                          </item>
-                          <item>
-                            <widget class="QStackedWidget" name="swSampleMaterialDetails">
-                              <property name="sizePolicy">
-                                <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-                                  <horstretch>0</horstretch>
-                                  <verstretch>0</verstretch>
-                                </sizepolicy>
-                              </property>
-                              <property name="currentIndex">
-                                <number>0</number>
-                              </property>
-                              <widget class="QWidget" name="page">
-                                <layout class="QHBoxLayout" name="horizontalLayout_9">
-                                  <property name="leftMargin">
-                                    <number>0</number>
-                                  </property>
-                                  <property name="topMargin">
-                                    <number>0</number>
-                                  </property>
-                                  <property name="rightMargin">
-                                    <number>0</number>
-                                  </property>
-                                  <property name="bottomMargin">
-                                    <number>0</number>
-                                  </property>
-                                  <item>
-                                    <spacer name="horizontalSpacer_5">
-                                      <property name="orientation">
-                                        <enum>Qt::Horizontal</enum>
-                                      </property>
-                                      <property name="sizeHint" stdset="0">
-                                        <size>
-                                          <width>40</width>
-                                          <height>20</height>
-                                        </size>
-                                      </property>
-                                    </spacer>
-                                  </item>
-                                  <item>
-                                    <widget class="QLabel" name="lbSampleChemicalFormula">
-                                      <property name="text">
-                                        <string>Chemical Formula:</string>
-                                      </property>
-                                    </widget>
-                                  </item>
-                                  <item>
-                                    <widget class="QLineEdit" name="leSampleChemicalFormula">
-                                      <property name="sizePolicy">
-                                        <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-                                          <horstretch>0</horstretch>
-                                          <verstretch>0</verstretch>
-                                        </sizepolicy>
-                                      </property>
-                                      <property name="text">
-                                        <string/>
-                                      </property>
-                                    </widget>
-                                  </item>
-                                  <item>
-                                    <widget class="QLabel" name="valSampleChemicalFormula">
-                                      <property name="sizePolicy">
-                                        <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
-                                          <horstretch>0</horstretch>
-                                          <verstretch>0</verstretch>
-                                        </sizepolicy>
-                                      </property>
-                                      <property name="text">
-                                        <string/>
-                                      </property>
-                                    </widget>
-                                  </item>
-                                </layout>
-                              </widget>
-                              <widget class="QWidget" name="page_2">
-                                <layout class="QHBoxLayout" name="horizontalLayout_6">
-                                  <property name="leftMargin">
-                                    <number>0</number>
-                                  </property>
-                                  <property name="rightMargin">
-                                    <number>0</number>
-                                  </property>
-                                  <item>
-                                    <widget class="QLabel" name="lbCoherentXSection">
-                                      <property name="text">
-                                        <string>Coherent:</string>
-                                      </property>
-                                    </widget>
-                                  </item>
-                                  <item>
-                                    <widget class="QDoubleSpinBox" name="spSampleCoherentXSection">
-                                      <property name="suffix">
-                                        <string> b</string>
-                                      </property>
-                                      <property name="decimals">
-                                        <number>3</number>
-                                      </property>
-                                      <property name="maximum">
-                                        <double>1000000.000000000000000</double>
-                                      </property>
-                                      <property name="singleStep">
-                                        <double>0.100000000000000</double>
-                                      </property>
-                                    </widget>
-                                  </item>
-                                  <item>
-                                    <widget class="QLabel" name="lbIncoherentXSection">
-                                      <property name="text">
-                                        <string>Incoherent:</string>
-                                      </property>
-                                    </widget>
-                                  </item>
-                                  <item>
-                                    <widget class="QDoubleSpinBox" name="spSampleIncoherentXSection">
-                                      <property name="suffix">
-                                        <string> b</string>
-                                      </property>
-                                      <property name="decimals">
-                                        <number>3</number>
-                                      </property>
-                                      <property name="maximum">
-                                        <double>1000000.000000000000000</double>
-                                      </property>
-                                      <property name="singleStep">
-                                        <double>0.100000000000000</double>
-                                      </property>
-                                    </widget>
-                                  </item>
-                                  <item>
-                                    <widget class="QLabel" name="lbAttenuationXSection">
-                                      <property name="text">
-                                        <string>Attenuation:</string>
-                                      </property>
-                                    </widget>
-                                  </item>
-                                  <item>
-                                    <widget class="QDoubleSpinBox" name="spSampleAttenuationXSection">
-                                      <property name="suffix">
-                                        <string> b</string>
-                                      </property>
-                                      <property name="decimals">
-                                        <number>3</number>
-                                      </property>
-                                      <property name="maximum">
-                                        <double>1000000.000000000000000</double>
-                                      </property>
-                                      <property name="singleStep">
-                                        <double>0.100000000000000</double>
-                                      </property>
-                                    </widget>
-                                  </item>
-                                </layout>
-                              </widget>
-                            </widget>
-                          </item>
-                        </layout>
-                      </widget>
-                    </item>
-                  </layout>
-                </widget>
-              </item>
-              <item>
-                <widget class="QGroupBox" name="gbContainerDetails">
-                  <property name="enabled">
-                    <bool>false</bool>
-                  </property>
-                  <property name="title">
-                    <string>Container Details</string>
-                  </property>
-                  <layout class="QGridLayout" name="gridLayout_2">
-                    <item row="0" column="0" colspan="2">
-                      <widget class="QFrame" name="frame_4">
-                        <layout class="QHBoxLayout" name="horizontalLayout_10">
-                          <property name="leftMargin">
-                            <number>0</number>
-                          </property>
-                          <property name="topMargin">
-                            <number>0</number>
-                          </property>
-                          <property name="rightMargin">
-                            <number>0</number>
-                          </property>
-                          <property name="bottomMargin">
-                            <number>0</number>
-                          </property>
-                          <item>
-                            <widget class="QLabel" name="lbCanMaterialsMethod">
-                              <property name="text">
-                                <string>Method:</string>
-                              </property>
-                            </widget>
-                          </item>
-                          <item>
-                            <widget class="QComboBox" name="cbCanMaterialMethod">
-                              <property name="sizePolicy">
-                                <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-                                  <horstretch>0</horstretch>
-                                  <verstretch>0</verstretch>
-                                </sizepolicy>
-                              </property>
-                              <property name="minimumSize">
-                                <size>
-                                  <width>120</width>
-                                  <height>0</height>
-                                </size>
-                              </property>
-                              <item>
-                                <property name="text">
-                                  <string>Chemical Formula</string>
-                                </property>
-                              </item>
-                              <item>
-                                <property name="text">
-                                  <string>Cross-sections</string>
-                                </property>
-                              </item>
-                            </widget>
-                          </item>
-                        </layout>
-                      </widget>
-                    </item>
-                    <item row="1" column="0">
-                      <widget class="QFrame" name="frame_5">
-                        <layout class="QHBoxLayout" name="horizontalLayout_11">
-                          <property name="leftMargin">
-                            <number>0</number>
-                          </property>
-                          <property name="topMargin">
-                            <number>0</number>
-                          </property>
-                          <property name="rightMargin">
-                            <number>0</number>
-                          </property>
-                          <property name="bottomMargin">
-                            <number>0</number>
-                          </property>
-                          <item>
-                            <widget class="QComboBox" name="cbCanDensity">
-                              <item>
-                                <property name="text">
-                                  <string>Mass Density</string>
-                                </property>
-                              </item>
-                              <item>
-                                <property name="text">
-                                  <string>Atom Number Density</string>
-                                </property>
-                              </item>
-                              <item>
-                                <property name="text">
-                                  <string>Formula Number Density</string>
-                                </property>
-                              </item>
-                            </widget>
-                          </item>
-                          <item>
-                            <widget class="QDoubleSpinBox" name="spCanDensity">
-                              <property name="suffix">
-                                <string> g/cm3</string>
-                              </property>
-                              <property name="decimals">
-                                <number>4</number>
-                              </property>
-                              <property name="maximum">
-                                <double>9999.989999999999782</double>
-                              </property>
-                              <property name="singleStep">
-                                <double>0.100000000000000</double>
-                              </property>
-                              <property name="value">
-                                <double>1.000000000000000</double>
-                              </property>
-                            </widget>
-                          </item>
-                          <item>
-                            <widget class="QStackedWidget" name="swCanMaterialDetails">
-                              <widget class="QWidget" name="page_3">
-                                <layout class="QHBoxLayout" name="horizontalLayout_5">
-                                  <property name="leftMargin">
-                                    <number>0</number>
-                                  </property>
-                                  <property name="rightMargin">
-                                    <number>0</number>
-                                  </property>
-                                  <item>
-                                    <spacer name="horizontalSpacer_6">
-                                      <property name="orientation">
-                                        <enum>Qt::Horizontal</enum>
-                                      </property>
-                                      <property name="sizeHint" stdset="0">
-                                        <size>
-                                          <width>40</width>
-                                          <height>20</height>
-                                        </size>
-                                      </property>
-                                    </spacer>
-                                  </item>
-                                  <item>
-                                    <widget class="QLabel" name="lbCanChemicalFormula">
-                                      <property name="text">
-                                        <string>Chemical Formula:</string>
-                                      </property>
-                                    </widget>
-                                  </item>
-                                  <item>
-                                    <widget class="QLineEdit" name="leCanChemicalFormula">
-                                      <property name="sizePolicy">
-                                        <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-                                          <horstretch>0</horstretch>
-                                          <verstretch>0</verstretch>
-                                        </sizepolicy>
-                                      </property>
-                                    </widget>
-                                  </item>
-                                  <item>
-                                    <widget class="QLabel" name="valCanChemicalFormula">
-                                      <property name="sizePolicy">
-                                        <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
-                                          <horstretch>0</horstretch>
-                                          <verstretch>0</verstretch>
-                                        </sizepolicy>
-                                      </property>
-                                      <property name="text">
-                                        <string/>
-                                      </property>
-                                    </widget>
-                                  </item>
-                                </layout>
-                              </widget>
-                              <widget class="QWidget" name="page_4">
-                                <layout class="QHBoxLayout" name="horizontalLayout_7">
-                                  <property name="leftMargin">
-                                    <number>0</number>
-                                  </property>
-                                  <property name="rightMargin">
-                                    <number>0</number>
-                                  </property>
-                                  <item>
-                                    <widget class="QLabel" name="lbCoherentXSection_2">
-                                      <property name="text">
-                                        <string>Coherent:</string>
-                                      </property>
-                                    </widget>
-                                  </item>
-                                  <item>
-                                    <widget class="QDoubleSpinBox" name="spCanCoherentXSection">
-                                      <property name="suffix">
-                                        <string> b</string>
-                                      </property>
-                                      <property name="decimals">
-                                        <number>3</number>
-                                      </property>
-                                      <property name="maximum">
-                                        <double>1000000.000000000000000</double>
-                                      </property>
-                                      <property name="singleStep">
-                                        <double>0.100000000000000</double>
-                                      </property>
-                                    </widget>
-                                  </item>
-                                  <item>
-                                    <widget class="QLabel" name="lbIncoherentXSection_2">
-                                      <property name="text">
-                                        <string>Incoherent:</string>
-                                      </property>
-                                    </widget>
-                                  </item>
-                                  <item>
-                                    <widget class="QDoubleSpinBox" name="spCanIncoherentXSection">
-                                      <property name="suffix">
-                                        <string> b</string>
-                                      </property>
-                                      <property name="decimals">
-                                        <number>3</number>
-                                      </property>
-                                      <property name="maximum">
-                                        <double>1000000.000000000000000</double>
-                                      </property>
-                                      <property name="singleStep">
-                                        <double>0.100000000000000</double>
-                                      </property>
-                                    </widget>
-                                  </item>
-                                  <item>
-                                    <widget class="QLabel" name="lbAttenuationXSection_2">
-                                      <property name="text">
-                                        <string>Attenuation:</string>
-                                      </property>
-                                    </widget>
-                                  </item>
-                                  <item>
-                                    <widget class="QDoubleSpinBox" name="spCanAttenuationXSection">
-                                      <property name="suffix">
-                                        <string> b</string>
-                                      </property>
-                                      <property name="decimals">
-                                        <number>3</number>
-                                      </property>
-                                      <property name="maximum">
-                                        <double>1000000.000000000000000</double>
-                                      </property>
-                                      <property name="singleStep">
-                                        <double>0.100000000000000</double>
-                                      </property>
-                                    </widget>
-                                  </item>
-                                </layout>
-                              </widget>
-                            </widget>
-                          </item>
-                        </layout>
-                      </widget>
-                    </item>
-                  </layout>
-                </widget>
-              </item>
-              <item>
-                <widget class="QGroupBox" name="gbRun">
-                  <property name="minimumSize">
-                    <size>
-                      <width>0</width>
-                      <height>45</height>
-                    </size>
-                  </property>
-                  <property name="maximumSize">
-                    <size>
-                      <width>16777215</width>
-                      <height>45</height>
-                    </size>
-                  </property>
-                  <property name="title">
-                    <string>Run</string>
-                  </property>
-                  <layout class="QHBoxLayout" name="horizontalLayout">
-                    <property name="topMargin">
-                      <number>0</number>
-                    </property>
-                    <property name="bottomMargin">
-                      <number>3</number>
-                    </property>
-                    <item>
-                      <spacer name="horizontalSpacer">
-                        <property name="orientation">
-                          <enum>Qt::Horizontal</enum>
-                        </property>
-                        <property name="sizeHint" stdset="0">
-                          <size>
-                            <width>348</width>
-                            <height>20</height>
-                          </size>
-                        </property>
-                      </spacer>
-                    </item>
-                    <item>
-                      <widget class="QPushButton" name="pbRun">
-                        <property name="text">
-                          <string>Run</string>
-                        </property>
-                      </widget>
-                    </item>
-                    <item>
-                      <spacer name="horizontalSpacer_3">
-                        <property name="orientation">
-                          <enum>Qt::Horizontal</enum>
-                        </property>
-                        <property name="sizeHint" stdset="0">
-                          <size>
-                            <width>348</width>
-                            <height>20</height>
-                          </size>
-                        </property>
-                      </spacer>
-                    </item>
-                  </layout>
-                </widget>
-              </item>
-              <item>
-                <widget class="QGroupBox" name="gbOutput">
-                  <property name="sizePolicy">
-                    <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-                      <horstretch>0</horstretch>
-                      <verstretch>0</verstretch>
-                    </sizepolicy>
-                  </property>
-                  <property name="minimumSize">
-                    <size>
-                      <width>0</width>
-                      <height>56</height>
-                    </size>
-                  </property>
-                  <property name="title">
-                    <string>Output Options</string>
-                  </property>
-                  <layout class="QHBoxLayout" name="horizontalLayout_2">
-                    <property name="topMargin">
-                      <number>0</number>
-                    </property>
-                    <property name="bottomMargin">
-                      <number>7</number>
-                    </property>
-                    <item>
-                      <widget class="MantidQt::CustomInterfaces::IndirectPlotOptionsView" name="ipoPlotOptions" native="true"/>
-                    </item>
-                    <item>
-                      <spacer name="horizontalSpacer_2">
-                        <property name="orientation">
-                          <enum>Qt::Horizontal</enum>
-                        </property>
-                        <property name="sizeHint" stdset="0">
-                          <size>
-                            <width>40</width>
-                            <height>20</height>
-                          </size>
-                        </property>
-                      </spacer>
-                    </item>
-                    <item>
-                      <widget class="QPushButton" name="pbSave">
-                        <property name="enabled">
-                          <bool>false</bool>
-                        </property>
-                        <property name="text">
-                          <string>Save Result</string>
-                        </property>
-                      </widget>
-                    </item>
-                  </layout>
-                </widget>
-              </item>
-            </layout>
-          </widget>
+            <property name="checked">
+             <bool>true</bool>
+            </property>
+           </widget>
+          </item>
+          <item row="0" column="1">
+           <widget class="MantidQt::MantidWidgets::DataSelector" name="dsSampleInput" native="true">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+            <property name="autoLoad" stdset="0">
+             <bool>true</bool>
+            </property>
+            <property name="workspaceSuffixes" stdset="0">
+             <stringlist>
+              <string>_red</string>
+              <string>_sqw</string>
+             </stringlist>
+            </property>
+            <property name="fileBrowserSuffixes" stdset="0">
+             <stringlist>
+              <string>_red.nxs</string>
+              <string>_sqw.nxs</string>
+             </stringlist>
+            </property>
+            <property name="showLoad" stdset="0">
+             <bool>false</bool>
+            </property>
+            <property name="ShowGroups" stdset="0">
+             <bool>false</bool>
+            </property>
+           </widget>
+          </item>
+          <item row="0" column="0">
+           <widget class="QLabel" name="lbSampleInput">
+            <property name="text">
+             <string>Input Workspace:</string>
+            </property>
+           </widget>
+          </item>
+         </layout>
         </widget>
-      </item>
-    </layout>
-  </widget>
-  <customwidgets>
-    <customwidget>
-      <class>MantidQt::CustomInterfaces::IndirectPlotOptionsView</class>
-      <extends>QWidget</extends>
-      <header>IndirectPlotOptionsView.h</header>
-      <container>1</container>
-    </customwidget>
-    <customwidget>
-      <class>MantidQt::MantidWidgets::DataSelector</class>
-      <extends>QWidget</extends>
-      <header>MantidQtWidgets/Common/DataSelector.h</header>
-    </customwidget>
-  </customwidgets>
-  <tabstops>
-    <tabstop>ckUseCan</tabstop>
-    <tabstop>spNumberEvents</tabstop>
-    <tabstop>spBeamHeight</tabstop>
-    <tabstop>spBeamWidth</tabstop>
-    <tabstop>cbShape</tabstop>
-    <tabstop>spFlatSampleHeight</tabstop>
-    <tabstop>spFlatSampleWidth</tabstop>
-    <tabstop>spFlatSampleThickness</tabstop>
-    <tabstop>spFlatSampleAngle</tabstop>
-    <tabstop>spFlatCanFrontThickness</tabstop>
-    <tabstop>spFlatCanBackThickness</tabstop>
-    <tabstop>spCylSampleHeight</tabstop>
-    <tabstop>spCylSampleRadius</tabstop>
-    <tabstop>spCylCanOuterRadius</tabstop>
-    <tabstop>spAnnSampleHeight</tabstop>
-    <tabstop>spAnnSampleInnerRadius</tabstop>
-    <tabstop>spAnnSampleOuterRadius</tabstop>
-    <tabstop>spAnnCanInnerRadius</tabstop>
-    <tabstop>spAnnCanOuterRadius</tabstop>
-    <tabstop>pbSave</tabstop>
-  </tabstops>
-  <resources/>
-  <connections>
-    <connection>
-      <sender>cbShape</sender>
-      <signal>currentIndexChanged(int)</signal>
-      <receiver>swShapeDetails</receiver>
-      <slot>setCurrentIndex(int)</slot>
-      <hints>
-        <hint type="sourcelabel">
-          <x>783</x>
-          <y>324</y>
-        </hint>
-        <hint type="destinationlabel">
-          <x>315</x>
-          <y>370</y>
-        </hint>
-      </hints>
-    </connection>
-    <connection>
-      <sender>ckUseCan</sender>
-      <signal>toggled(bool)</signal>
-      <receiver>dsCanInput</receiver>
-      <slot>setEnabled(bool)</slot>
-      <hints>
-        <hint type="sourcelabel">
-          <x>194</x>
-          <y>69</y>
-        </hint>
-        <hint type="destinationlabel">
-          <x>784</x>
-          <y>67</y>
-        </hint>
-      </hints>
-    </connection>
-    <connection>
-      <sender>ckUseCan</sender>
-      <signal>toggled(bool)</signal>
-      <receiver>gbContainerDetails</receiver>
-      <slot>setEnabled(bool)</slot>
-      <hints>
-        <hint type="sourcelabel">
-          <x>194</x>
-          <y>69</y>
-        </hint>
-        <hint type="destinationlabel">
-          <x>305</x>
-          <y>571</y>
-        </hint>
-      </hints>
-    </connection>
-    <connection>
-      <sender>spFlatCanFrontThickness</sender>
-      <signal>valueChanged(double)</signal>
-      <receiver>spFlatCanBackThickness</receiver>
-      <slot>setValue(double)</slot>
-      <hints>
-        <hint type="sourcelabel">
-          <x>402</x>
-          <y>424</y>
-        </hint>
-        <hint type="destinationlabel">
-          <x>784</x>
-          <y>424</y>
-        </hint>
-      </hints>
-    </connection>
-    <connection>
-      <sender>ckUseCan</sender>
-      <signal>toggled(bool)</signal>
-      <receiver>lbFlatCanFrontThickness</receiver>
-      <slot>setEnabled(bool)</slot>
-      <hints>
-        <hint type="sourcelabel">
-          <x>140</x>
-          <y>69</y>
-        </hint>
-        <hint type="destinationlabel">
-          <x>175</x>
-          <y>424</y>
-        </hint>
-      </hints>
-    </connection>
-    <connection>
-      <sender>ckUseCan</sender>
-      <signal>toggled(bool)</signal>
-      <receiver>spFlatCanFrontThickness</receiver>
-      <slot>setEnabled(bool)</slot>
-      <hints>
-        <hint type="sourcelabel">
-          <x>241</x>
-          <y>69</y>
-        </hint>
-        <hint type="destinationlabel">
-          <x>402</x>
-          <y>424</y>
-        </hint>
-      </hints>
-    </connection>
-    <connection>
-      <sender>ckUseCan</sender>
-      <signal>toggled(bool)</signal>
-      <receiver>lbFlatCanBackThickness</receiver>
-      <slot>setEnabled(bool)</slot>
-      <hints>
-        <hint type="sourcelabel">
-          <x>255</x>
-          <y>69</y>
-        </hint>
-        <hint type="destinationlabel">
-          <x>593</x>
-          <y>424</y>
-        </hint>
-      </hints>
-    </connection>
-    <connection>
-      <sender>ckUseCan</sender>
-      <signal>toggled(bool)</signal>
-      <receiver>spFlatCanBackThickness</receiver>
-      <slot>setEnabled(bool)</slot>
-      <hints>
-        <hint type="sourcelabel">
-          <x>229</x>
-          <y>69</y>
-        </hint>
-        <hint type="destinationlabel">
-          <x>784</x>
-          <y>424</y>
-        </hint>
-      </hints>
-    </connection>
-    <connection>
-      <sender>ckUseCan</sender>
-      <signal>toggled(bool)</signal>
-      <receiver>lbAnnCanInnerRadius</receiver>
-      <slot>setEnabled(bool)</slot>
-      <hints>
-        <hint type="sourcelabel">
-          <x>169</x>
-          <y>69</y>
-        </hint>
-        <hint type="destinationlabel">
-          <x>65</x>
-          <y>424</y>
-        </hint>
-      </hints>
-    </connection>
-    <connection>
-      <sender>ckUseCan</sender>
-      <signal>toggled(bool)</signal>
-      <receiver>spAnnCanInnerRadius</receiver>
-      <slot>setEnabled(bool)</slot>
-      <hints>
-        <hint type="sourcelabel">
-          <x>246</x>
-          <y>69</y>
-        </hint>
-        <hint type="destinationlabel">
-          <x>282</x>
-          <y>424</y>
-        </hint>
-      </hints>
-    </connection>
-    <connection>
-      <sender>ckUseCan</sender>
-      <signal>toggled(bool)</signal>
-      <receiver>lbAnnCanOuterRadius</receiver>
-      <slot>setEnabled(bool)</slot>
-      <hints>
-        <hint type="sourcelabel">
-          <x>308</x>
-          <y>69</y>
-        </hint>
-        <hint type="destinationlabel">
-          <x>501</x>
-          <y>424</y>
-        </hint>
-      </hints>
-    </connection>
-    <connection>
-      <sender>ckUseCan</sender>
-      <signal>toggled(bool)</signal>
-      <receiver>spAnnCanOuterRadius</receiver>
-      <slot>setEnabled(bool)</slot>
-      <hints>
-        <hint type="sourcelabel">
-          <x>334</x>
-          <y>69</y>
-        </hint>
-        <hint type="destinationlabel">
-          <x>718</x>
-          <y>424</y>
-        </hint>
-      </hints>
-    </connection>
-    <connection>
-      <sender>ckUseCan</sender>
-      <signal>clicked(bool)</signal>
-      <receiver>lbCylCanOuterRadius</receiver>
-      <slot>setEnabled(bool)</slot>
-      <hints>
-        <hint type="sourcelabel">
-          <x>57</x>
-          <y>67</y>
-        </hint>
-        <hint type="destinationlabel">
-          <x>532</x>
-          <y>408</y>
-        </hint>
-      </hints>
-    </connection>
-    <connection>
-      <sender>ckUseCan</sender>
-      <signal>clicked(bool)</signal>
-      <receiver>spCylCanOuterRadius</receiver>
-      <slot>setEnabled(bool)</slot>
-      <hints>
-        <hint type="sourcelabel">
-          <x>38</x>
-          <y>66</y>
-        </hint>
-        <hint type="destinationlabel">
-          <x>646</x>
-          <y>411</y>
-        </hint>
-      </hints>
-    </connection>
-  </connections>
+       </item>
+       <item>
+        <widget class="QGroupBox" name="gbMonteCarloDetails">
+         <property name="title">
+          <string>Monte Carlo</string>
+         </property>
+         <property name="flat">
+          <bool>false</bool>
+         </property>
+         <property name="checkable">
+          <bool>false</bool>
+         </property>
+         <layout class="QGridLayout" name="gridLayout_3">
+          <item row="1" column="0">
+           <widget class="QLabel" name="lbNumberEvents">
+            <property name="text">
+             <string>Events:</string>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="1">
+           <widget class="QSpinBox" name="spNumberEvents">
+            <property name="maximum">
+             <number>1000000</number>
+            </property>
+            <property name="singleStep">
+             <number>10</number>
+            </property>
+            <property name="value">
+             <number>5000</number>
+            </property>
+           </widget>
+          </item>
+          <item row="2" column="0">
+           <widget class="QLabel" name="label">
+            <property name="text">
+             <string>Interpolation:</string>
+            </property>
+           </widget>
+          </item>
+          <item row="2" column="2">
+           <widget class="QLabel" name="label_2">
+            <property name="text">
+             <string>Maximum Scatter Point Attempts:</string>
+            </property>
+           </widget>
+          </item>
+          <item row="2" column="1">
+           <widget class="QComboBox" name="cbInterpolation">
+            <property name="currentIndex">
+             <number>0</number>
+            </property>
+            <item>
+             <property name="text">
+              <string>Linear</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>CSpline</string>
+             </property>
+            </item>
+           </widget>
+          </item>
+          <item row="2" column="4">
+           <widget class="QSpinBox" name="spMaxScatterPtAttempts">
+            <property name="minimum">
+             <number>1</number>
+            </property>
+            <property name="maximum">
+             <number>1000000</number>
+            </property>
+            <property name="singleStep">
+             <number>100</number>
+            </property>
+            <property name="value">
+             <number>5000</number>
+            </property>
+           </widget>
+          </item>
+         </layout>
+        </widget>
+       </item>
+       <item>
+        <widget class="QGroupBox" name="gbBeamDetails">
+         <property name="title">
+          <string>Beam Details</string>
+         </property>
+         <layout class="QGridLayout" name="gridLayout_4">
+          <item row="0" column="1">
+           <widget class="QDoubleSpinBox" name="spBeamHeight">
+            <property name="enabled">
+             <bool>true</bool>
+            </property>
+            <property name="suffix">
+             <string> cm</string>
+            </property>
+            <property name="singleStep">
+             <double>0.100000000000000</double>
+            </property>
+            <property name="value">
+             <double>1.000000000000000</double>
+            </property>
+           </widget>
+          </item>
+          <item row="0" column="2">
+           <widget class="QLabel" name="lbBeamWidth">
+            <property name="enabled">
+             <bool>true</bool>
+            </property>
+            <property name="text">
+             <string>Beam Width:</string>
+            </property>
+           </widget>
+          </item>
+          <item row="0" column="3">
+           <widget class="QDoubleSpinBox" name="spBeamWidth">
+            <property name="enabled">
+             <bool>true</bool>
+            </property>
+            <property name="suffix">
+             <string> cm</string>
+            </property>
+            <property name="singleStep">
+             <double>0.100000000000000</double>
+            </property>
+            <property name="value">
+             <double>1.000000000000000</double>
+            </property>
+           </widget>
+          </item>
+          <item row="0" column="0">
+           <widget class="QLabel" name="lbBeamHeight">
+            <property name="enabled">
+             <bool>true</bool>
+            </property>
+            <property name="text">
+             <string>Beam Height:</string>
+            </property>
+           </widget>
+          </item>
+         </layout>
+        </widget>
+       </item>
+       <item>
+        <widget class="QGroupBox" name="gbShapeDetails">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="title">
+          <string>Shape Details</string>
+         </property>
+         <layout class="QVBoxLayout" name="verticalLayout_9">
+          <item>
+           <layout class="QHBoxLayout" name="loShape">
+            <item>
+             <widget class="QLabel" name="lbShape">
+              <property name="text">
+               <string>Shape:</string>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QComboBox" name="cbShape">
+              <item>
+               <property name="text">
+                <string>Flat Plate</string>
+               </property>
+              </item>
+              <item>
+               <property name="text">
+                <string>Annulus</string>
+               </property>
+              </item>
+              <item>
+               <property name="text">
+                <string>Cylinder</string>
+               </property>
+              </item>
+             </widget>
+            </item>
+           </layout>
+          </item>
+          <item>
+           <widget class="QStackedWidget" name="swShapeDetails">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+            <property name="currentIndex">
+             <number>0</number>
+            </property>
+            <widget class="QWidget" name="pgAbsCorFlatPlate">
+             <layout class="QGridLayout" name="loFlatPlate">
+              <property name="leftMargin">
+               <number>0</number>
+              </property>
+              <property name="topMargin">
+               <number>0</number>
+              </property>
+              <property name="rightMargin">
+               <number>0</number>
+              </property>
+              <property name="bottomMargin">
+               <number>0</number>
+              </property>
+              <item row="1" column="1">
+               <widget class="QDoubleSpinBox" name="spFlatSampleHeight">
+                <property name="suffix">
+                 <string> cm</string>
+                </property>
+                <property name="decimals">
+                 <number>3</number>
+                </property>
+                <property name="singleStep">
+                 <double>0.100000000000000</double>
+                </property>
+               </widget>
+              </item>
+              <item row="1" column="2">
+               <widget class="QLabel" name="lbFlatSampleWidth">
+                <property name="text">
+                 <string>Sample Width:</string>
+                </property>
+               </widget>
+              </item>
+              <item row="1" column="3">
+               <widget class="QDoubleSpinBox" name="spFlatSampleWidth">
+                <property name="suffix">
+                 <string> cm</string>
+                </property>
+                <property name="decimals">
+                 <number>3</number>
+                </property>
+                <property name="singleStep">
+                 <double>0.100000000000000</double>
+                </property>
+               </widget>
+              </item>
+              <item row="1" column="0">
+               <widget class="QLabel" name="lbFlatSampleHeight">
+                <property name="text">
+                 <string>Sample Height:</string>
+                </property>
+               </widget>
+              </item>
+              <item row="2" column="1">
+               <widget class="QDoubleSpinBox" name="spFlatSampleThickness">
+                <property name="suffix">
+                 <string> cm</string>
+                </property>
+                <property name="decimals">
+                 <number>3</number>
+                </property>
+                <property name="singleStep">
+                 <double>0.100000000000000</double>
+                </property>
+               </widget>
+              </item>
+              <item row="2" column="0">
+               <widget class="QLabel" name="lbFlatSampleThickness">
+                <property name="text">
+                 <string>Sample Thickness:</string>
+                </property>
+               </widget>
+              </item>
+              <item row="3" column="0">
+               <widget class="QLabel" name="lbFlatCanFrontThickness">
+                <property name="enabled">
+                 <bool>false</bool>
+                </property>
+                <property name="text">
+                 <string>Container Front Thickness:</string>
+                </property>
+               </widget>
+              </item>
+              <item row="3" column="1">
+               <widget class="QDoubleSpinBox" name="spFlatCanFrontThickness">
+                <property name="enabled">
+                 <bool>false</bool>
+                </property>
+                <property name="suffix">
+                 <string> cm</string>
+                </property>
+                <property name="decimals">
+                 <number>3</number>
+                </property>
+                <property name="singleStep">
+                 <double>0.100000000000000</double>
+                </property>
+               </widget>
+              </item>
+              <item row="2" column="2">
+               <widget class="QLabel" name="lbFlatSampleAngle">
+                <property name="text">
+                 <string>Sample Angle:</string>
+                </property>
+               </widget>
+              </item>
+              <item row="2" column="3">
+               <widget class="QDoubleSpinBox" name="spFlatSampleAngle">
+                <property name="suffix">
+                 <string>°</string>
+                </property>
+                <property name="minimum">
+                 <double>-180.000000000000000</double>
+                </property>
+                <property name="maximum">
+                 <double>180.000000000000000</double>
+                </property>
+               </widget>
+              </item>
+              <item row="3" column="2">
+               <widget class="QLabel" name="lbFlatCanBackThickness">
+                <property name="enabled">
+                 <bool>false</bool>
+                </property>
+                <property name="text">
+                 <string>Container Back Thickness:</string>
+                </property>
+               </widget>
+              </item>
+              <item row="3" column="3">
+               <widget class="QDoubleSpinBox" name="spFlatCanBackThickness">
+                <property name="enabled">
+                 <bool>false</bool>
+                </property>
+                <property name="suffix">
+                 <string> cm</string>
+                </property>
+                <property name="decimals">
+                 <number>3</number>
+                </property>
+                <property name="singleStep">
+                 <double>0.100000000000000</double>
+                </property>
+               </widget>
+              </item>
+             </layout>
+            </widget>
+            <widget class="QWidget" name="pgAbsCorAnnulus">
+             <layout class="QGridLayout" name="loAnnulus">
+              <property name="leftMargin">
+               <number>0</number>
+              </property>
+              <property name="topMargin">
+               <number>0</number>
+              </property>
+              <property name="rightMargin">
+               <number>0</number>
+              </property>
+              <property name="bottomMargin">
+               <number>0</number>
+              </property>
+              <item row="6" column="3">
+               <widget class="QDoubleSpinBox" name="spAnnCanOuterRadius">
+                <property name="enabled">
+                 <bool>false</bool>
+                </property>
+                <property name="suffix">
+                 <string> cm</string>
+                </property>
+                <property name="decimals">
+                 <number>3</number>
+                </property>
+                <property name="singleStep">
+                 <double>0.100000000000000</double>
+                </property>
+               </widget>
+              </item>
+              <item row="6" column="1">
+               <widget class="QDoubleSpinBox" name="spAnnCanInnerRadius">
+                <property name="enabled">
+                 <bool>false</bool>
+                </property>
+                <property name="suffix">
+                 <string> cm</string>
+                </property>
+                <property name="decimals">
+                 <number>3</number>
+                </property>
+                <property name="singleStep">
+                 <double>0.100000000000000</double>
+                </property>
+               </widget>
+              </item>
+              <item row="2" column="1">
+               <widget class="QDoubleSpinBox" name="spAnnSampleHeight">
+                <property name="suffix">
+                 <string> cm</string>
+                </property>
+                <property name="decimals">
+                 <number>3</number>
+                </property>
+                <property name="singleStep">
+                 <double>0.100000000000000</double>
+                </property>
+               </widget>
+              </item>
+              <item row="3" column="0">
+               <widget class="QLabel" name="lbAnnSampleInnerRadius">
+                <property name="text">
+                 <string>Sample Inner Radius:</string>
+                </property>
+               </widget>
+              </item>
+              <item row="3" column="3">
+               <widget class="QDoubleSpinBox" name="spAnnSampleOuterRadius">
+                <property name="suffix">
+                 <string> cm</string>
+                </property>
+                <property name="decimals">
+                 <number>3</number>
+                </property>
+                <property name="singleStep">
+                 <double>0.100000000000000</double>
+                </property>
+               </widget>
+              </item>
+              <item row="6" column="0">
+               <widget class="QLabel" name="lbAnnCanInnerRadius">
+                <property name="enabled">
+                 <bool>false</bool>
+                </property>
+                <property name="text">
+                 <string>Inner Container Inner Radius:</string>
+                </property>
+               </widget>
+              </item>
+              <item row="6" column="2">
+               <widget class="QLabel" name="lbAnnCanOuterRadius">
+                <property name="enabled">
+                 <bool>false</bool>
+                </property>
+                <property name="text">
+                 <string>Outer Container Outer Radius:</string>
+                </property>
+               </widget>
+              </item>
+              <item row="3" column="2">
+               <widget class="QLabel" name="lbAnnSampleOuterRadius">
+                <property name="text">
+                 <string>Sample Outer Radius:</string>
+                </property>
+               </widget>
+              </item>
+              <item row="3" column="1">
+               <widget class="QDoubleSpinBox" name="spAnnSampleInnerRadius">
+                <property name="suffix">
+                 <string> cm</string>
+                </property>
+                <property name="decimals">
+                 <number>3</number>
+                </property>
+                <property name="singleStep">
+                 <double>0.100000000000000</double>
+                </property>
+               </widget>
+              </item>
+              <item row="2" column="0">
+               <widget class="QLabel" name="lbAnnSampleHeight">
+                <property name="text">
+                 <string>Sample Height:</string>
+                </property>
+               </widget>
+              </item>
+             </layout>
+            </widget>
+            <widget class="QWidget" name="pgAbsCorCylinder">
+             <layout class="QGridLayout" name="loCylinder">
+              <property name="leftMargin">
+               <number>0</number>
+              </property>
+              <property name="topMargin">
+               <number>0</number>
+              </property>
+              <property name="rightMargin">
+               <number>0</number>
+              </property>
+              <property name="bottomMargin">
+               <number>0</number>
+              </property>
+              <item row="1" column="1">
+               <widget class="QDoubleSpinBox" name="spCylSampleHeight">
+                <property name="suffix">
+                 <string> cm</string>
+                </property>
+                <property name="decimals">
+                 <number>3</number>
+                </property>
+                <property name="singleStep">
+                 <double>0.100000000000000</double>
+                </property>
+               </widget>
+              </item>
+              <item row="2" column="1">
+               <widget class="QDoubleSpinBox" name="spCylSampleRadius">
+                <property name="suffix">
+                 <string> cm</string>
+                </property>
+                <property name="decimals">
+                 <number>3</number>
+                </property>
+                <property name="singleStep">
+                 <double>0.100000000000000</double>
+                </property>
+               </widget>
+              </item>
+              <item row="2" column="0">
+               <widget class="QLabel" name="lbCylSampleRadius">
+                <property name="text">
+                 <string>Sample Radius:</string>
+                </property>
+               </widget>
+              </item>
+              <item row="1" column="0">
+               <widget class="QLabel" name="lbCylSampleHeight">
+                <property name="text">
+                 <string>Sample Height:</string>
+                </property>
+               </widget>
+              </item>
+              <item row="2" column="2">
+               <widget class="QLabel" name="lbCylCanOuterRadius">
+                <property name="enabled">
+                 <bool>false</bool>
+                </property>
+                <property name="text">
+                 <string>Container Outer Radius</string>
+                </property>
+               </widget>
+              </item>
+              <item row="2" column="3">
+               <widget class="QDoubleSpinBox" name="spCylCanOuterRadius">
+                <property name="enabled">
+                 <bool>false</bool>
+                </property>
+                <property name="suffix">
+                 <string> cm</string>
+                </property>
+                <property name="decimals">
+                 <number>3</number>
+                </property>
+                <property name="singleStep">
+                 <double>0.100000000000000</double>
+                </property>
+               </widget>
+              </item>
+             </layout>
+            </widget>
+           </widget>
+          </item>
+         </layout>
+        </widget>
+       </item>
+       <item>
+        <widget class="QGroupBox" name="gbSampleDetails">
+         <property name="title">
+          <string>Sample Details</string>
+         </property>
+         <layout class="QGridLayout" name="gridLayout">
+          <item row="0" column="0" colspan="3">
+           <widget class="QFrame" name="frame_2">
+            <layout class="QHBoxLayout" name="horizontalLayout_8">
+             <property name="leftMargin">
+              <number>0</number>
+             </property>
+             <property name="topMargin">
+              <number>0</number>
+             </property>
+             <property name="rightMargin">
+              <number>0</number>
+             </property>
+             <property name="bottomMargin">
+              <number>0</number>
+             </property>
+             <item>
+              <widget class="QLabel" name="lbSampleMaterialsMethod">
+               <property name="text">
+                <string>Method:</string>
+               </property>
+              </widget>
+             </item>
+             <item>
+              <widget class="QComboBox" name="cbSampleMaterialMethod">
+               <property name="sizePolicy">
+                <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+                 <horstretch>0</horstretch>
+                 <verstretch>0</verstretch>
+                </sizepolicy>
+               </property>
+               <property name="minimumSize">
+                <size>
+                 <width>120</width>
+                 <height>0</height>
+                </size>
+               </property>
+               <item>
+                <property name="text">
+                 <string>Chemical Formula</string>
+                </property>
+               </item>
+               <item>
+                <property name="text">
+                 <string>Cross-sections</string>
+                </property>
+               </item>
+              </widget>
+             </item>
+            </layout>
+           </widget>
+          </item>
+          <item row="1" column="0" colspan="3">
+           <widget class="QFrame" name="frame_3">
+            <layout class="QHBoxLayout" name="horizontalLayout_3">
+             <property name="leftMargin">
+              <number>0</number>
+             </property>
+             <property name="topMargin">
+              <number>0</number>
+             </property>
+             <property name="rightMargin">
+              <number>0</number>
+             </property>
+             <property name="bottomMargin">
+              <number>0</number>
+             </property>
+             <item>
+              <widget class="QComboBox" name="cbSampleDensity">
+               <item>
+                <property name="text">
+                 <string>Mass Density</string>
+                </property>
+               </item>
+               <item>
+                <property name="text">
+                 <string>Atom Number Density</string>
+                </property>
+               </item>
+               <item>
+                <property name="text">
+                 <string>Formula Number Density</string>
+                </property>
+               </item>
+              </widget>
+             </item>
+             <item>
+              <widget class="QDoubleSpinBox" name="spSampleDensity">
+               <property name="suffix">
+                <string> g/cm3</string>
+               </property>
+               <property name="decimals">
+                <number>4</number>
+               </property>
+               <property name="maximum">
+                <double>9999.989999999999782</double>
+               </property>
+               <property name="singleStep">
+                <double>0.100000000000000</double>
+               </property>
+               <property name="value">
+                <double>1.000000000000000</double>
+               </property>
+              </widget>
+             </item>
+             <item>
+              <widget class="QStackedWidget" name="swSampleMaterialDetails">
+               <property name="sizePolicy">
+                <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+                 <horstretch>0</horstretch>
+                 <verstretch>0</verstretch>
+                </sizepolicy>
+               </property>
+               <property name="currentIndex">
+                <number>0</number>
+               </property>
+               <widget class="QWidget" name="page">
+                <layout class="QHBoxLayout" name="horizontalLayout_9">
+                 <property name="leftMargin">
+                  <number>0</number>
+                 </property>
+                 <property name="topMargin">
+                  <number>0</number>
+                 </property>
+                 <property name="rightMargin">
+                  <number>0</number>
+                 </property>
+                 <property name="bottomMargin">
+                  <number>0</number>
+                 </property>
+                 <item>
+                  <spacer name="horizontalSpacer_5">
+                   <property name="orientation">
+                    <enum>Qt::Horizontal</enum>
+                   </property>
+                   <property name="sizeHint" stdset="0">
+                    <size>
+                     <width>40</width>
+                     <height>20</height>
+                    </size>
+                   </property>
+                  </spacer>
+                 </item>
+                 <item>
+                  <widget class="QLabel" name="lbSampleChemicalFormula">
+                   <property name="text">
+                    <string>Chemical Formula:</string>
+                   </property>
+                  </widget>
+                 </item>
+                 <item>
+                  <widget class="QLineEdit" name="leSampleChemicalFormula">
+                   <property name="sizePolicy">
+                    <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+                     <horstretch>0</horstretch>
+                     <verstretch>0</verstretch>
+                    </sizepolicy>
+                   </property>
+                   <property name="text">
+                    <string/>
+                   </property>
+                  </widget>
+                 </item>
+                 <item>
+                  <widget class="QLabel" name="valSampleChemicalFormula">
+                   <property name="sizePolicy">
+                    <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
+                     <horstretch>0</horstretch>
+                     <verstretch>0</verstretch>
+                    </sizepolicy>
+                   </property>
+                   <property name="text">
+                    <string/>
+                   </property>
+                  </widget>
+                 </item>
+                </layout>
+               </widget>
+               <widget class="QWidget" name="page_2">
+                <layout class="QHBoxLayout" name="horizontalLayout_6">
+                 <property name="leftMargin">
+                  <number>0</number>
+                 </property>
+                 <property name="rightMargin">
+                  <number>0</number>
+                 </property>
+                 <item>
+                  <widget class="QLabel" name="lbCoherentXSection">
+                   <property name="text">
+                    <string>Coherent:</string>
+                   </property>
+                  </widget>
+                 </item>
+                 <item>
+                  <widget class="QDoubleSpinBox" name="spSampleCoherentXSection">
+                   <property name="suffix">
+                    <string> b</string>
+                   </property>
+                   <property name="decimals">
+                    <number>3</number>
+                   </property>
+                   <property name="maximum">
+                    <double>1000000.000000000000000</double>
+                   </property>
+                   <property name="singleStep">
+                    <double>0.100000000000000</double>
+                   </property>
+                  </widget>
+                 </item>
+                 <item>
+                  <widget class="QLabel" name="lbIncoherentXSection">
+                   <property name="text">
+                    <string>Incoherent:</string>
+                   </property>
+                  </widget>
+                 </item>
+                 <item>
+                  <widget class="QDoubleSpinBox" name="spSampleIncoherentXSection">
+                   <property name="suffix">
+                    <string> b</string>
+                   </property>
+                   <property name="decimals">
+                    <number>3</number>
+                   </property>
+                   <property name="maximum">
+                    <double>1000000.000000000000000</double>
+                   </property>
+                   <property name="singleStep">
+                    <double>0.100000000000000</double>
+                   </property>
+                  </widget>
+                 </item>
+                 <item>
+                  <widget class="QLabel" name="lbAttenuationXSection">
+                   <property name="text">
+                    <string>Attenuation:</string>
+                   </property>
+                  </widget>
+                 </item>
+                 <item>
+                  <widget class="QDoubleSpinBox" name="spSampleAttenuationXSection">
+                   <property name="suffix">
+                    <string> b</string>
+                   </property>
+                   <property name="decimals">
+                    <number>3</number>
+                   </property>
+                   <property name="maximum">
+                    <double>1000000.000000000000000</double>
+                   </property>
+                   <property name="singleStep">
+                    <double>0.100000000000000</double>
+                   </property>
+                  </widget>
+                 </item>
+                </layout>
+               </widget>
+              </widget>
+             </item>
+            </layout>
+           </widget>
+          </item>
+         </layout>
+        </widget>
+       </item>
+       <item>
+        <widget class="QGroupBox" name="gbContainerDetails">
+         <property name="enabled">
+          <bool>true</bool>
+         </property>
+         <property name="title">
+          <string>Container Details</string>
+         </property>
+         <layout class="QGridLayout" name="gridLayout_2">
+          <item row="0" column="0" colspan="2">
+           <widget class="QFrame" name="frame_4">
+            <layout class="QHBoxLayout" name="horizontalLayout_10">
+             <property name="leftMargin">
+              <number>0</number>
+             </property>
+             <property name="topMargin">
+              <number>0</number>
+             </property>
+             <property name="rightMargin">
+              <number>0</number>
+             </property>
+             <property name="bottomMargin">
+              <number>0</number>
+             </property>
+             <item>
+              <widget class="QLabel" name="lbCanMaterialsMethod">
+               <property name="text">
+                <string>Method:</string>
+               </property>
+              </widget>
+             </item>
+             <item>
+              <widget class="QComboBox" name="cbCanMaterialMethod">
+               <property name="sizePolicy">
+                <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+                 <horstretch>0</horstretch>
+                 <verstretch>0</verstretch>
+                </sizepolicy>
+               </property>
+               <property name="minimumSize">
+                <size>
+                 <width>120</width>
+                 <height>0</height>
+                </size>
+               </property>
+               <item>
+                <property name="text">
+                 <string>Chemical Formula</string>
+                </property>
+               </item>
+               <item>
+                <property name="text">
+                 <string>Cross-sections</string>
+                </property>
+               </item>
+              </widget>
+             </item>
+            </layout>
+           </widget>
+          </item>
+          <item row="1" column="0">
+           <widget class="QFrame" name="frame_5">
+            <layout class="QHBoxLayout" name="horizontalLayout_11">
+             <property name="leftMargin">
+              <number>0</number>
+             </property>
+             <property name="topMargin">
+              <number>0</number>
+             </property>
+             <property name="rightMargin">
+              <number>0</number>
+             </property>
+             <property name="bottomMargin">
+              <number>0</number>
+             </property>
+             <item>
+              <widget class="QComboBox" name="cbCanDensity">
+               <item>
+                <property name="text">
+                 <string>Mass Density</string>
+                </property>
+               </item>
+               <item>
+                <property name="text">
+                 <string>Atom Number Density</string>
+                </property>
+               </item>
+               <item>
+                <property name="text">
+                 <string>Formula Number Density</string>
+                </property>
+               </item>
+              </widget>
+             </item>
+             <item>
+              <widget class="QDoubleSpinBox" name="spCanDensity">
+               <property name="suffix">
+                <string> g/cm3</string>
+               </property>
+               <property name="decimals">
+                <number>4</number>
+               </property>
+               <property name="maximum">
+                <double>9999.989999999999782</double>
+               </property>
+               <property name="singleStep">
+                <double>0.100000000000000</double>
+               </property>
+               <property name="value">
+                <double>1.000000000000000</double>
+               </property>
+              </widget>
+             </item>
+             <item>
+              <widget class="QStackedWidget" name="swCanMaterialDetails">
+               <widget class="QWidget" name="page_3">
+                <layout class="QHBoxLayout" name="horizontalLayout_5">
+                 <property name="leftMargin">
+                  <number>0</number>
+                 </property>
+                 <property name="rightMargin">
+                  <number>0</number>
+                 </property>
+                 <item>
+                  <spacer name="horizontalSpacer_6">
+                   <property name="orientation">
+                    <enum>Qt::Horizontal</enum>
+                   </property>
+                   <property name="sizeHint" stdset="0">
+                    <size>
+                     <width>40</width>
+                     <height>20</height>
+                    </size>
+                   </property>
+                  </spacer>
+                 </item>
+                 <item>
+                  <widget class="QLabel" name="lbCanChemicalFormula">
+                   <property name="text">
+                    <string>Chemical Formula:</string>
+                   </property>
+                  </widget>
+                 </item>
+                 <item>
+                  <widget class="QLineEdit" name="leCanChemicalFormula">
+                   <property name="sizePolicy">
+                    <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+                     <horstretch>0</horstretch>
+                     <verstretch>0</verstretch>
+                    </sizepolicy>
+                   </property>
+                  </widget>
+                 </item>
+                 <item>
+                  <widget class="QLabel" name="valCanChemicalFormula">
+                   <property name="sizePolicy">
+                    <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
+                     <horstretch>0</horstretch>
+                     <verstretch>0</verstretch>
+                    </sizepolicy>
+                   </property>
+                   <property name="text">
+                    <string/>
+                   </property>
+                  </widget>
+                 </item>
+                </layout>
+               </widget>
+               <widget class="QWidget" name="page_4">
+                <layout class="QHBoxLayout" name="horizontalLayout_7">
+                 <property name="leftMargin">
+                  <number>0</number>
+                 </property>
+                 <property name="rightMargin">
+                  <number>0</number>
+                 </property>
+                 <item>
+                  <widget class="QLabel" name="lbCoherentXSection_2">
+                   <property name="text">
+                    <string>Coherent:</string>
+                   </property>
+                  </widget>
+                 </item>
+                 <item>
+                  <widget class="QDoubleSpinBox" name="spCanCoherentXSection">
+                   <property name="suffix">
+                    <string> b</string>
+                   </property>
+                   <property name="decimals">
+                    <number>3</number>
+                   </property>
+                   <property name="maximum">
+                    <double>1000000.000000000000000</double>
+                   </property>
+                   <property name="singleStep">
+                    <double>0.100000000000000</double>
+                   </property>
+                  </widget>
+                 </item>
+                 <item>
+                  <widget class="QLabel" name="lbIncoherentXSection_2">
+                   <property name="text">
+                    <string>Incoherent:</string>
+                   </property>
+                  </widget>
+                 </item>
+                 <item>
+                  <widget class="QDoubleSpinBox" name="spCanIncoherentXSection">
+                   <property name="suffix">
+                    <string> b</string>
+                   </property>
+                   <property name="decimals">
+                    <number>3</number>
+                   </property>
+                   <property name="maximum">
+                    <double>1000000.000000000000000</double>
+                   </property>
+                   <property name="singleStep">
+                    <double>0.100000000000000</double>
+                   </property>
+                  </widget>
+                 </item>
+                 <item>
+                  <widget class="QLabel" name="lbAttenuationXSection_2">
+                   <property name="text">
+                    <string>Attenuation:</string>
+                   </property>
+                  </widget>
+                 </item>
+                 <item>
+                  <widget class="QDoubleSpinBox" name="spCanAttenuationXSection">
+                   <property name="suffix">
+                    <string> b</string>
+                   </property>
+                   <property name="decimals">
+                    <number>3</number>
+                   </property>
+                   <property name="maximum">
+                    <double>1000000.000000000000000</double>
+                   </property>
+                   <property name="singleStep">
+                    <double>0.100000000000000</double>
+                   </property>
+                  </widget>
+                 </item>
+                </layout>
+               </widget>
+              </widget>
+             </item>
+            </layout>
+           </widget>
+          </item>
+         </layout>
+        </widget>
+       </item>
+       <item>
+        <widget class="QGroupBox" name="gbRun">
+         <property name="minimumSize">
+          <size>
+           <width>0</width>
+           <height>45</height>
+          </size>
+         </property>
+         <property name="maximumSize">
+          <size>
+           <width>16777215</width>
+           <height>45</height>
+          </size>
+         </property>
+         <property name="title">
+          <string>Run</string>
+         </property>
+         <layout class="QHBoxLayout" name="horizontalLayout">
+          <property name="topMargin">
+           <number>0</number>
+          </property>
+          <property name="bottomMargin">
+           <number>3</number>
+          </property>
+          <item>
+           <spacer name="horizontalSpacer">
+            <property name="orientation">
+             <enum>Qt::Horizontal</enum>
+            </property>
+            <property name="sizeHint" stdset="0">
+             <size>
+              <width>348</width>
+              <height>20</height>
+             </size>
+            </property>
+           </spacer>
+          </item>
+          <item>
+           <widget class="QPushButton" name="pbRun">
+            <property name="text">
+             <string>Run</string>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <spacer name="horizontalSpacer_3">
+            <property name="orientation">
+             <enum>Qt::Horizontal</enum>
+            </property>
+            <property name="sizeHint" stdset="0">
+             <size>
+              <width>348</width>
+              <height>20</height>
+             </size>
+            </property>
+           </spacer>
+          </item>
+         </layout>
+        </widget>
+       </item>
+       <item>
+        <widget class="QGroupBox" name="gbOutput">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="minimumSize">
+          <size>
+           <width>0</width>
+           <height>56</height>
+          </size>
+         </property>
+         <property name="title">
+          <string>Output Options</string>
+         </property>
+         <layout class="QHBoxLayout" name="horizontalLayout_2">
+          <property name="topMargin">
+           <number>0</number>
+          </property>
+          <property name="bottomMargin">
+           <number>7</number>
+          </property>
+          <item>
+           <widget class="MantidQt::CustomInterfaces::IndirectPlotOptionsView" name="ipoPlotOptions" native="true"/>
+          </item>
+          <item>
+           <spacer name="horizontalSpacer_2">
+            <property name="orientation">
+             <enum>Qt::Horizontal</enum>
+            </property>
+            <property name="sizeHint" stdset="0">
+             <size>
+              <width>40</width>
+              <height>20</height>
+             </size>
+            </property>
+           </spacer>
+          </item>
+          <item>
+           <widget class="QPushButton" name="pbSave">
+            <property name="enabled">
+             <bool>false</bool>
+            </property>
+            <property name="text">
+             <string>Save Result</string>
+            </property>
+           </widget>
+          </item>
+         </layout>
+        </widget>
+       </item>
+      </layout>
+     </widget>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <customwidgets>
+  <customwidget>
+   <class>MantidQt::CustomInterfaces::IndirectPlotOptionsView</class>
+   <extends>QWidget</extends>
+   <header>IndirectPlotOptionsView.h</header>
+   <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>MantidQt::MantidWidgets::DataSelector</class>
+   <extends>QWidget</extends>
+   <header>MantidQtWidgets/Common/DataSelector.h</header>
+  </customwidget>
+ </customwidgets>
+ <tabstops>
+  <tabstop>overrideShape</tabstop>
+  <tabstop>spNumberEvents</tabstop>
+  <tabstop>spBeamHeight</tabstop>
+  <tabstop>spBeamWidth</tabstop>
+  <tabstop>cbShape</tabstop>
+  <tabstop>spFlatSampleHeight</tabstop>
+  <tabstop>spFlatSampleWidth</tabstop>
+  <tabstop>spFlatSampleThickness</tabstop>
+  <tabstop>spFlatSampleAngle</tabstop>
+  <tabstop>spFlatCanFrontThickness</tabstop>
+  <tabstop>spFlatCanBackThickness</tabstop>
+  <tabstop>spCylSampleHeight</tabstop>
+  <tabstop>spCylSampleRadius</tabstop>
+  <tabstop>spCylCanOuterRadius</tabstop>
+  <tabstop>spAnnSampleHeight</tabstop>
+  <tabstop>spAnnSampleInnerRadius</tabstop>
+  <tabstop>spAnnSampleOuterRadius</tabstop>
+  <tabstop>spAnnCanInnerRadius</tabstop>
+  <tabstop>spAnnCanOuterRadius</tabstop>
+  <tabstop>pbSave</tabstop>
+ </tabstops>
+ <resources/>
+ <connections>
+  <connection>
+   <sender>cbShape</sender>
+   <signal>currentIndexChanged(int)</signal>
+   <receiver>swShapeDetails</receiver>
+   <slot>setCurrentIndex(int)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>783</x>
+     <y>324</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>315</x>
+     <y>370</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>spFlatCanFrontThickness</sender>
+   <signal>valueChanged(double)</signal>
+   <receiver>spFlatCanBackThickness</receiver>
+   <slot>setValue(double)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>402</x>
+     <y>424</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>784</x>
+     <y>424</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>overrideShape</sender>
+   <signal>toggled(bool)</signal>
+   <receiver>gbShapeDetails</receiver>
+   <slot>setEnabled(bool)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>334</x>
+     <y>69</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>486</x>
+     <y>304</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>overrideShape</sender>
+   <signal>toggled(bool)</signal>
+   <receiver>gbSampleDetails</receiver>
+   <slot>setEnabled(bool)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>308</x>
+     <y>69</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>486</x>
+     <y>445</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>overrideShape</sender>
+   <signal>toggled(bool)</signal>
+   <receiver>gbContainerDetails</receiver>
+   <slot>setEnabled(bool)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>38</x>
+     <y>66</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>486</x>
+     <y>589</y>
+    </hint>
+   </hints>
+  </connection>
+ </connections>
 </ui>

--- a/qt/scientific_interfaces/Indirect/AbsorptionCorrections.ui
+++ b/qt/scientific_interfaces/Indirect/AbsorptionCorrections.ui
@@ -1,1585 +1,1585 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ui version="4.0">
- <class>AbsorptionCorrections</class>
- <widget class="QWidget" name="AbsorptionCorrections">
-  <property name="geometry">
-   <rect>
-    <x>0</x>
-    <y>0</y>
-    <width>974</width>
-    <height>791</height>
-   </rect>
-  </property>
-  <property name="windowTitle">
-   <string>Absoprtion Corrections</string>
-  </property>
-  <layout class="QVBoxLayout" name="verticalLayout_2">
-   <item>
-    <widget class="QScrollArea" name="scrollArea">
-     <property name="widgetResizable">
-      <bool>true</bool>
-     </property>
-     <widget class="QWidget" name="scrollAreaWidgetContents">
-      <property name="geometry">
-       <rect>
+  <class>AbsorptionCorrections</class>
+  <widget class="QWidget" name="AbsorptionCorrections">
+    <property name="geometry">
+      <rect>
         <x>0</x>
         <y>0</y>
-        <width>954</width>
-        <height>771</height>
-       </rect>
-      </property>
-      <layout class="QVBoxLayout" name="verticalLayout">
-       <item>
-        <widget class="QGroupBox" name="gbInput">
-         <property name="title">
-          <string>Input</string>
-         </property>
-         <layout class="QGridLayout" name="gridLayout_11">
-          <item row="1" column="0">
-           <widget class="QCheckBox" name="ckUseCan">
-            <property name="text">
-             <string>Use Container:</string>
+        <width>974</width>
+        <height>791</height>
+      </rect>
+    </property>
+    <property name="windowTitle">
+      <string>Absoprtion Corrections</string>
+    </property>
+    <layout class="QVBoxLayout" name="verticalLayout_2">
+      <item>
+        <widget class="QScrollArea" name="scrollArea">
+          <property name="widgetResizable">
+            <bool>true</bool>
+          </property>
+          <widget class="QWidget" name="scrollAreaWidgetContents">
+            <property name="geometry">
+              <rect>
+                <x>0</x>
+                <y>0</y>
+                <width>954</width>
+                <height>771</height>
+              </rect>
             </property>
-           </widget>
-          </item>
-          <item row="0" column="1">
-           <widget class="MantidQt::MantidWidgets::DataSelector" name="dsSampleInput" native="true">
-            <property name="sizePolicy">
-             <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
-              <horstretch>0</horstretch>
-              <verstretch>0</verstretch>
-             </sizepolicy>
-            </property>
-            <property name="autoLoad" stdset="0">
-             <bool>true</bool>
-            </property>
-            <property name="workspaceSuffixes" stdset="0">
-             <stringlist>
-              <string>_red</string>
-              <string>_sqw</string>
-             </stringlist>
-            </property>
-            <property name="fileBrowserSuffixes" stdset="0">
-             <stringlist>
-              <string>_red.nxs</string>
-              <string>_sqw.nxs</string>
-             </stringlist>
-            </property>
-            <property name="showLoad" stdset="0">
-             <bool>false</bool>
-            </property>
-            <property name="ShowGroups" stdset="0">
-             <bool>false</bool>
-            </property>
-           </widget>
-          </item>
-          <item row="0" column="0">
-           <widget class="QLabel" name="lbSampleInput">
-            <property name="text">
-             <string>Sample Input:</string>
-            </property>
-           </widget>
-          </item>
-          <item row="1" column="1">
-           <widget class="MantidQt::MantidWidgets::DataSelector" name="dsCanInput" native="true">
-            <property name="enabled">
-             <bool>false</bool>
-            </property>
-            <property name="sizePolicy">
-             <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
-              <horstretch>0</horstretch>
-              <verstretch>0</verstretch>
-             </sizepolicy>
-            </property>
-            <property name="autoLoad" stdset="0">
-             <bool>true</bool>
-            </property>
-            <property name="workspaceSuffixes" stdset="0">
-             <stringlist>
-              <string>_red</string>
-              <string>_sqw</string>
-             </stringlist>
-            </property>
-            <property name="fileBrowserSuffixes" stdset="0">
-             <stringlist>
-              <string>_red.nxs</string>
-              <string>_sqw.nxs</string>
-             </stringlist>
-            </property>
-            <property name="showLoad" stdset="0">
-             <bool>false</bool>
-            </property>
-            <property name="ShowGroups" stdset="0">
-             <bool>false</bool>
-            </property>
-           </widget>
-          </item>
-         </layout>
-        </widget>
-       </item>
-       <item>
-        <widget class="QGroupBox" name="gbMonteCarloDetails">
-         <property name="title">
-          <string>Monte Carlo</string>
-         </property>
-         <property name="flat">
-          <bool>false</bool>
-         </property>
-         <property name="checkable">
-          <bool>false</bool>
-         </property>
-         <layout class="QGridLayout" name="gridLayout_3">
-          <item row="1" column="0">
-           <widget class="QLabel" name="lbNumberEvents">
-            <property name="text">
-             <string>Events:</string>
-            </property>
-           </widget>
-          </item>
-          <item row="1" column="1">
-           <widget class="QSpinBox" name="spNumberEvents">
-            <property name="maximum">
-             <number>1000000</number>
-            </property>
-            <property name="singleStep">
-             <number>10</number>
-            </property>
-            <property name="value">
-             <number>5000</number>
-            </property>
-           </widget>
-          </item>
-          <item row="2" column="0">
-           <widget class="QLabel" name="label">
-            <property name="text">
-             <string>Interpolation:</string>
-            </property>
-           </widget>
-          </item>
-          <item row="2" column="2">
-           <widget class="QLabel" name="label_2">
-            <property name="text">
-             <string>Maximum Scatter Point Attempts:</string>
-            </property>
-           </widget>
-          </item>
-          <item row="2" column="1">
-           <widget class="QComboBox" name="cbInterpolation">
-            <property name="currentIndex">
-             <number>0</number>
-            </property>
-            <item>
-             <property name="text">
-              <string>Linear</string>
-             </property>
-            </item>
-            <item>
-             <property name="text">
-              <string>CSpline</string>
-             </property>
-            </item>
-           </widget>
-          </item>
-          <item row="2" column="4">
-           <widget class="QSpinBox" name="spMaxScatterPtAttempts">
-            <property name="minimum">
-             <number>1</number>
-            </property>
-            <property name="maximum">
-             <number>1000000</number>
-            </property>
-            <property name="singleStep">
-             <number>100</number>
-            </property>
-            <property name="value">
-             <number>5000</number>
-            </property>
-           </widget>
-          </item>
-         </layout>
-        </widget>
-       </item>
-       <item>
-        <widget class="QGroupBox" name="gbBeamDetails">
-         <property name="title">
-          <string>Beam Details</string>
-         </property>
-         <layout class="QGridLayout" name="gridLayout_4">
-          <item row="0" column="1">
-           <widget class="QDoubleSpinBox" name="spBeamHeight">
-            <property name="enabled">
-             <bool>true</bool>
-            </property>
-            <property name="suffix">
-             <string> cm</string>
-            </property>
-            <property name="singleStep">
-             <double>0.100000000000000</double>
-            </property>
-            <property name="value">
-             <double>1.000000000000000</double>
-            </property>
-           </widget>
-          </item>
-          <item row="0" column="2">
-           <widget class="QLabel" name="lbBeamWidth">
-            <property name="enabled">
-             <bool>true</bool>
-            </property>
-            <property name="text">
-             <string>Beam Width:</string>
-            </property>
-           </widget>
-          </item>
-          <item row="0" column="3">
-           <widget class="QDoubleSpinBox" name="spBeamWidth">
-            <property name="enabled">
-             <bool>true</bool>
-            </property>
-            <property name="suffix">
-             <string> cm</string>
-            </property>
-            <property name="singleStep">
-             <double>0.100000000000000</double>
-            </property>
-            <property name="value">
-             <double>1.000000000000000</double>
-            </property>
-           </widget>
-          </item>
-          <item row="0" column="0">
-           <widget class="QLabel" name="lbBeamHeight">
-            <property name="enabled">
-             <bool>true</bool>
-            </property>
-            <property name="text">
-             <string>Beam Height:</string>
-            </property>
-           </widget>
-          </item>
-         </layout>
-        </widget>
-       </item>
-       <item>
-        <widget class="QGroupBox" name="gbShapeDetails">
-         <property name="sizePolicy">
-          <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-           <horstretch>0</horstretch>
-           <verstretch>0</verstretch>
-          </sizepolicy>
-         </property>
-         <property name="title">
-          <string>Shape Details</string>
-         </property>
-         <layout class="QVBoxLayout" name="verticalLayout_9">
-          <item>
-           <layout class="QHBoxLayout" name="loShape">
-            <item>
-             <widget class="QLabel" name="lbShape">
-              <property name="text">
-               <string>Shape:</string>
-              </property>
-             </widget>
-            </item>
-            <item>
-             <widget class="QComboBox" name="cbShape">
+            <layout class="QVBoxLayout" name="verticalLayout">
               <item>
-               <property name="text">
-                <string>Flat Plate</string>
-               </property>
+                <widget class="QGroupBox" name="gbInput">
+                  <property name="title">
+                    <string>Input</string>
+                  </property>
+                  <layout class="QGridLayout" name="gridLayout_11">
+                    <item row="1" column="0">
+                      <widget class="QCheckBox" name="ckUseCan">
+                        <property name="text">
+                          <string>Use Container:</string>
+                        </property>
+                      </widget>
+                    </item>
+                    <item row="0" column="1">
+                      <widget class="MantidQt::MantidWidgets::DataSelector" name="dsSampleInput" native="true">
+                        <property name="sizePolicy">
+                          <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+                            <horstretch>0</horstretch>
+                            <verstretch>0</verstretch>
+                          </sizepolicy>
+                        </property>
+                        <property name="autoLoad" stdset="0">
+                          <bool>true</bool>
+                        </property>
+                        <property name="workspaceSuffixes" stdset="0">
+                          <stringlist>
+                            <string>_red</string>
+                            <string>_sqw</string>
+                          </stringlist>
+                        </property>
+                        <property name="fileBrowserSuffixes" stdset="0">
+                          <stringlist>
+                            <string>_red.nxs</string>
+                            <string>_sqw.nxs</string>
+                          </stringlist>
+                        </property>
+                        <property name="showLoad" stdset="0">
+                          <bool>false</bool>
+                        </property>
+                        <property name="ShowGroups" stdset="0">
+                          <bool>false</bool>
+                        </property>
+                      </widget>
+                    </item>
+                    <item row="0" column="0">
+                      <widget class="QLabel" name="lbSampleInput">
+                        <property name="text">
+                          <string>Sample Input:</string>
+                        </property>
+                      </widget>
+                    </item>
+                    <item row="1" column="1">
+                      <widget class="MantidQt::MantidWidgets::DataSelector" name="dsCanInput" native="true">
+                        <property name="enabled">
+                          <bool>false</bool>
+                        </property>
+                        <property name="sizePolicy">
+                          <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+                            <horstretch>0</horstretch>
+                            <verstretch>0</verstretch>
+                          </sizepolicy>
+                        </property>
+                        <property name="autoLoad" stdset="0">
+                          <bool>true</bool>
+                        </property>
+                        <property name="workspaceSuffixes" stdset="0">
+                          <stringlist>
+                            <string>_red</string>
+                            <string>_sqw</string>
+                          </stringlist>
+                        </property>
+                        <property name="fileBrowserSuffixes" stdset="0">
+                          <stringlist>
+                            <string>_red.nxs</string>
+                            <string>_sqw.nxs</string>
+                          </stringlist>
+                        </property>
+                        <property name="showLoad" stdset="0">
+                          <bool>false</bool>
+                        </property>
+                        <property name="ShowGroups" stdset="0">
+                          <bool>false</bool>
+                        </property>
+                      </widget>
+                    </item>
+                  </layout>
+                </widget>
               </item>
               <item>
-               <property name="text">
-                <string>Annulus</string>
-               </property>
+                <widget class="QGroupBox" name="gbMonteCarloDetails">
+                  <property name="title">
+                    <string>Monte Carlo</string>
+                  </property>
+                  <property name="flat">
+                    <bool>false</bool>
+                  </property>
+                  <property name="checkable">
+                    <bool>false</bool>
+                  </property>
+                  <layout class="QGridLayout" name="gridLayout_3">
+                    <item row="1" column="0">
+                      <widget class="QLabel" name="lbNumberEvents">
+                        <property name="text">
+                          <string>Events:</string>
+                        </property>
+                      </widget>
+                    </item>
+                    <item row="1" column="1">
+                      <widget class="QSpinBox" name="spNumberEvents">
+                        <property name="maximum">
+                          <number>1000000</number>
+                        </property>
+                        <property name="singleStep">
+                          <number>10</number>
+                        </property>
+                        <property name="value">
+                          <number>5000</number>
+                        </property>
+                      </widget>
+                    </item>
+                    <item row="2" column="0">
+                      <widget class="QLabel" name="label">
+                        <property name="text">
+                          <string>Interpolation:</string>
+                        </property>
+                      </widget>
+                    </item>
+                    <item row="2" column="2">
+                      <widget class="QLabel" name="label_2">
+                        <property name="text">
+                          <string>Maximum Scatter Point Attempts:</string>
+                        </property>
+                      </widget>
+                    </item>
+                    <item row="2" column="1">
+                      <widget class="QComboBox" name="cbInterpolation">
+                        <property name="currentIndex">
+                          <number>0</number>
+                        </property>
+                        <item>
+                          <property name="text">
+                            <string>Linear</string>
+                          </property>
+                        </item>
+                        <item>
+                          <property name="text">
+                            <string>CSpline</string>
+                          </property>
+                        </item>
+                      </widget>
+                    </item>
+                    <item row="2" column="4">
+                      <widget class="QSpinBox" name="spMaxScatterPtAttempts">
+                        <property name="minimum">
+                          <number>1</number>
+                        </property>
+                        <property name="maximum">
+                          <number>1000000</number>
+                        </property>
+                        <property name="singleStep">
+                          <number>100</number>
+                        </property>
+                        <property name="value">
+                          <number>5000</number>
+                        </property>
+                      </widget>
+                    </item>
+                  </layout>
+                </widget>
               </item>
               <item>
-               <property name="text">
-                <string>Cylinder</string>
-               </property>
+                <widget class="QGroupBox" name="gbBeamDetails">
+                  <property name="title">
+                    <string>Beam Details</string>
+                  </property>
+                  <layout class="QGridLayout" name="gridLayout_4">
+                    <item row="0" column="1">
+                      <widget class="QDoubleSpinBox" name="spBeamHeight">
+                        <property name="enabled">
+                          <bool>true</bool>
+                        </property>
+                        <property name="suffix">
+                          <string> cm</string>
+                        </property>
+                        <property name="singleStep">
+                          <double>0.100000000000000</double>
+                        </property>
+                        <property name="value">
+                          <double>1.000000000000000</double>
+                        </property>
+                      </widget>
+                    </item>
+                    <item row="0" column="2">
+                      <widget class="QLabel" name="lbBeamWidth">
+                        <property name="enabled">
+                          <bool>true</bool>
+                        </property>
+                        <property name="text">
+                          <string>Beam Width:</string>
+                        </property>
+                      </widget>
+                    </item>
+                    <item row="0" column="3">
+                      <widget class="QDoubleSpinBox" name="spBeamWidth">
+                        <property name="enabled">
+                          <bool>true</bool>
+                        </property>
+                        <property name="suffix">
+                          <string> cm</string>
+                        </property>
+                        <property name="singleStep">
+                          <double>0.100000000000000</double>
+                        </property>
+                        <property name="value">
+                          <double>1.000000000000000</double>
+                        </property>
+                      </widget>
+                    </item>
+                    <item row="0" column="0">
+                      <widget class="QLabel" name="lbBeamHeight">
+                        <property name="enabled">
+                          <bool>true</bool>
+                        </property>
+                        <property name="text">
+                          <string>Beam Height:</string>
+                        </property>
+                      </widget>
+                    </item>
+                  </layout>
+                </widget>
               </item>
-             </widget>
-            </item>
-           </layout>
-          </item>
-          <item>
-           <widget class="QStackedWidget" name="swShapeDetails">
-            <property name="sizePolicy">
-             <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-              <horstretch>0</horstretch>
-              <verstretch>0</verstretch>
-             </sizepolicy>
-            </property>
-            <property name="currentIndex">
-             <number>0</number>
-            </property>
-            <widget class="QWidget" name="pgAbsCorFlatPlate">
-             <layout class="QGridLayout" name="loFlatPlate">
-              <property name="leftMargin">
-               <number>0</number>
-              </property>
-              <property name="topMargin">
-               <number>0</number>
-              </property>
-              <property name="rightMargin">
-               <number>0</number>
-              </property>
-              <property name="bottomMargin">
-               <number>0</number>
-              </property>
-              <item row="1" column="1">
-               <widget class="QDoubleSpinBox" name="spFlatSampleHeight">
-                <property name="suffix">
-                 <string> cm</string>
-                </property>
-                <property name="decimals">
-                 <number>3</number>
-                </property>
-                <property name="singleStep">
-                 <double>0.100000000000000</double>
-                </property>
-               </widget>
-              </item>
-              <item row="1" column="2">
-               <widget class="QLabel" name="lbFlatSampleWidth">
-                <property name="text">
-                 <string>Sample Width:</string>
-                </property>
-               </widget>
-              </item>
-              <item row="1" column="3">
-               <widget class="QDoubleSpinBox" name="spFlatSampleWidth">
-                <property name="suffix">
-                 <string> cm</string>
-                </property>
-                <property name="decimals">
-                 <number>3</number>
-                </property>
-                <property name="singleStep">
-                 <double>0.100000000000000</double>
-                </property>
-               </widget>
-              </item>
-              <item row="1" column="0">
-               <widget class="QLabel" name="lbFlatSampleHeight">
-                <property name="text">
-                 <string>Sample Height:</string>
-                </property>
-               </widget>
-              </item>
-              <item row="2" column="1">
-               <widget class="QDoubleSpinBox" name="spFlatSampleThickness">
-                <property name="suffix">
-                 <string> cm</string>
-                </property>
-                <property name="decimals">
-                 <number>3</number>
-                </property>
-                <property name="singleStep">
-                 <double>0.100000000000000</double>
-                </property>
-               </widget>
-              </item>
-              <item row="2" column="0">
-               <widget class="QLabel" name="lbFlatSampleThickness">
-                <property name="text">
-                 <string>Sample Thickness:</string>
-                </property>
-               </widget>
-              </item>
-              <item row="3" column="0">
-               <widget class="QLabel" name="lbFlatCanFrontThickness">
-                <property name="enabled">
-                 <bool>false</bool>
-                </property>
-                <property name="text">
-                 <string>Container Front Thickness:</string>
-                </property>
-               </widget>
-              </item>
-              <item row="3" column="1">
-               <widget class="QDoubleSpinBox" name="spFlatCanFrontThickness">
-                <property name="enabled">
-                 <bool>false</bool>
-                </property>
-                <property name="suffix">
-                 <string> cm</string>
-                </property>
-                <property name="decimals">
-                 <number>3</number>
-                </property>
-                <property name="singleStep">
-                 <double>0.100000000000000</double>
-                </property>
-               </widget>
-              </item>
-              <item row="2" column="2">
-               <widget class="QLabel" name="lbFlatSampleAngle">
-                <property name="text">
-                 <string>Sample Angle:</string>
-                </property>
-               </widget>
-              </item>
-              <item row="2" column="3">
-               <widget class="QDoubleSpinBox" name="spFlatSampleAngle">
-                <property name="suffix">
-                 <string>°</string>
-                </property>
-                <property name="minimum">
-                 <double>-180.000000000000000</double>
-                </property>
-                <property name="maximum">
-                 <double>180.000000000000000</double>
-                </property>
-               </widget>
-              </item>
-              <item row="3" column="2">
-               <widget class="QLabel" name="lbFlatCanBackThickness">
-                <property name="enabled">
-                 <bool>false</bool>
-                </property>
-                <property name="text">
-                 <string>Container Back Thickness:</string>
-                </property>
-               </widget>
-              </item>
-              <item row="3" column="3">
-               <widget class="QDoubleSpinBox" name="spFlatCanBackThickness">
-                <property name="enabled">
-                 <bool>false</bool>
-                </property>
-                <property name="suffix">
-                 <string> cm</string>
-                </property>
-                <property name="decimals">
-                 <number>3</number>
-                </property>
-                <property name="singleStep">
-                 <double>0.100000000000000</double>
-                </property>
-               </widget>
-              </item>
-             </layout>
-            </widget>
-            <widget class="QWidget" name="pgAbsCorAnnulus">
-             <layout class="QGridLayout" name="loAnnulus">
-              <property name="leftMargin">
-               <number>0</number>
-              </property>
-              <property name="topMargin">
-               <number>0</number>
-              </property>
-              <property name="rightMargin">
-               <number>0</number>
-              </property>
-              <property name="bottomMargin">
-               <number>0</number>
-              </property>
-              <item row="6" column="3">
-               <widget class="QDoubleSpinBox" name="spAnnCanOuterRadius">
-                <property name="enabled">
-                 <bool>false</bool>
-                </property>
-                <property name="suffix">
-                 <string> cm</string>
-                </property>
-                <property name="decimals">
-                 <number>3</number>
-                </property>
-                <property name="singleStep">
-                 <double>0.100000000000000</double>
-                </property>
-               </widget>
-              </item>
-              <item row="6" column="1">
-               <widget class="QDoubleSpinBox" name="spAnnCanInnerRadius">
-                <property name="enabled">
-                 <bool>false</bool>
-                </property>
-                <property name="suffix">
-                 <string> cm</string>
-                </property>
-                <property name="decimals">
-                 <number>3</number>
-                </property>
-                <property name="singleStep">
-                 <double>0.100000000000000</double>
-                </property>
-               </widget>
-              </item>
-              <item row="2" column="1">
-               <widget class="QDoubleSpinBox" name="spAnnSampleHeight">
-                <property name="suffix">
-                 <string> cm</string>
-                </property>
-                <property name="decimals">
-                 <number>3</number>
-                </property>
-                <property name="singleStep">
-                 <double>0.100000000000000</double>
-                </property>
-               </widget>
-              </item>
-              <item row="3" column="0">
-               <widget class="QLabel" name="lbAnnSampleInnerRadius">
-                <property name="text">
-                 <string>Sample Inner Radius:</string>
-                </property>
-               </widget>
-              </item>
-              <item row="3" column="3">
-               <widget class="QDoubleSpinBox" name="spAnnSampleOuterRadius">
-                <property name="suffix">
-                 <string> cm</string>
-                </property>
-                <property name="decimals">
-                 <number>3</number>
-                </property>
-                <property name="singleStep">
-                 <double>0.100000000000000</double>
-                </property>
-               </widget>
-              </item>
-              <item row="6" column="0">
-               <widget class="QLabel" name="lbAnnCanInnerRadius">
-                <property name="enabled">
-                 <bool>false</bool>
-                </property>
-                <property name="text">
-                 <string>Inner Container Inner Radius:</string>
-                </property>
-               </widget>
-              </item>
-              <item row="6" column="2">
-               <widget class="QLabel" name="lbAnnCanOuterRadius">
-                <property name="enabled">
-                 <bool>false</bool>
-                </property>
-                <property name="text">
-                 <string>Outer Container Outer Radius:</string>
-                </property>
-               </widget>
-              </item>
-              <item row="3" column="2">
-               <widget class="QLabel" name="lbAnnSampleOuterRadius">
-                <property name="text">
-                 <string>Sample Outer Radius:</string>
-                </property>
-               </widget>
-              </item>
-              <item row="3" column="1">
-               <widget class="QDoubleSpinBox" name="spAnnSampleInnerRadius">
-                <property name="suffix">
-                 <string> cm</string>
-                </property>
-                <property name="decimals">
-                 <number>3</number>
-                </property>
-                <property name="singleStep">
-                 <double>0.100000000000000</double>
-                </property>
-               </widget>
-              </item>
-              <item row="2" column="0">
-               <widget class="QLabel" name="lbAnnSampleHeight">
-                <property name="text">
-                 <string>Sample Height:</string>
-                </property>
-               </widget>
-              </item>
-             </layout>
-            </widget>
-            <widget class="QWidget" name="pgAbsCorCylinder">
-             <layout class="QGridLayout" name="loCylinder">
-              <property name="leftMargin">
-               <number>0</number>
-              </property>
-              <property name="topMargin">
-               <number>0</number>
-              </property>
-              <property name="rightMargin">
-               <number>0</number>
-              </property>
-              <property name="bottomMargin">
-               <number>0</number>
-              </property>
-              <item row="1" column="1">
-               <widget class="QDoubleSpinBox" name="spCylSampleHeight">
-                <property name="suffix">
-                 <string> cm</string>
-                </property>
-                <property name="decimals">
-                 <number>3</number>
-                </property>
-                <property name="singleStep">
-                 <double>0.100000000000000</double>
-                </property>
-               </widget>
-              </item>
-              <item row="2" column="1">
-               <widget class="QDoubleSpinBox" name="spCylSampleRadius">
-                <property name="suffix">
-                 <string> cm</string>
-                </property>
-                <property name="decimals">
-                 <number>3</number>
-                </property>
-                <property name="singleStep">
-                 <double>0.100000000000000</double>
-                </property>
-               </widget>
-              </item>
-              <item row="2" column="0">
-               <widget class="QLabel" name="lbCylSampleRadius">
-                <property name="text">
-                 <string>Sample Radius:</string>
-                </property>
-               </widget>
-              </item>
-              <item row="1" column="0">
-               <widget class="QLabel" name="lbCylSampleHeight">
-                <property name="text">
-                 <string>Sample Height:</string>
-                </property>
-               </widget>
-              </item>
-              <item row="2" column="2">
-               <widget class="QLabel" name="lbCylCanOuterRadius">
-                <property name="enabled">
-                 <bool>false</bool>
-                </property>
-                <property name="text">
-                 <string>Container Outer Radius</string>
-                </property>
-               </widget>
-              </item>
-              <item row="2" column="3">
-               <widget class="QDoubleSpinBox" name="spCylCanOuterRadius">
-                <property name="enabled">
-                 <bool>false</bool>
-                </property>
-                <property name="suffix">
-                 <string> cm</string>
-                </property>
-                <property name="decimals">
-                 <number>3</number>
-                </property>
-                <property name="singleStep">
-                 <double>0.100000000000000</double>
-                </property>
-               </widget>
-              </item>
-             </layout>
-            </widget>
-           </widget>
-          </item>
-         </layout>
-        </widget>
-       </item>
-       <item>
-        <widget class="QGroupBox" name="gbSampleDetails">
-         <property name="title">
-          <string>Sample Details</string>
-         </property>
-         <layout class="QGridLayout" name="gridLayout">
-          <item row="0" column="0" colspan="3">
-           <widget class="QFrame" name="frame_2">
-            <layout class="QHBoxLayout" name="horizontalLayout_8">
-             <property name="leftMargin">
-              <number>0</number>
-             </property>
-             <property name="topMargin">
-              <number>0</number>
-             </property>
-             <property name="rightMargin">
-              <number>0</number>
-             </property>
-             <property name="bottomMargin">
-              <number>0</number>
-             </property>
-             <item>
-              <widget class="QLabel" name="lbSampleMaterialsMethod">
-               <property name="text">
-                <string>Method:</string>
-               </property>
-              </widget>
-             </item>
-             <item>
-              <widget class="QComboBox" name="cbSampleMaterialMethod">
-               <property name="sizePolicy">
-                <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-                 <horstretch>0</horstretch>
-                 <verstretch>0</verstretch>
-                </sizepolicy>
-               </property>
-               <property name="minimumSize">
-                <size>
-                 <width>120</width>
-                 <height>0</height>
-                </size>
-               </property>
-               <item>
-                <property name="text">
-                 <string>Chemical Formula</string>
-                </property>
-               </item>
-               <item>
-                <property name="text">
-                 <string>Cross-sections</string>
-                </property>
-               </item>
-              </widget>
-             </item>
-            </layout>
-           </widget>
-          </item>
-          <item row="1" column="0" colspan="3">
-           <widget class="QFrame" name="frame_3">
-            <layout class="QHBoxLayout" name="horizontalLayout_3">
-             <property name="leftMargin">
-              <number>0</number>
-             </property>
-             <property name="topMargin">
-              <number>0</number>
-             </property>
-             <property name="rightMargin">
-              <number>0</number>
-             </property>
-             <property name="bottomMargin">
-              <number>0</number>
-             </property>
-             <item>
-              <widget class="QComboBox" name="cbSampleDensity">
-               <item>
-                <property name="text">
-                 <string>Mass Density</string>
-                </property>
-               </item>
-               <item>
-                <property name="text">
-                 <string>Atom Number Density</string>
-                </property>
-               </item>
-               <item>
-                <property name="text">
-                 <string>Formula Number Density</string>
-                </property>
-               </item>
-              </widget>
-             </item>
-             <item>
-              <widget class="QDoubleSpinBox" name="spSampleDensity">
-               <property name="suffix">
-                <string> g/cm3</string>
-               </property>
-               <property name="decimals">
-                <number>4</number>
-               </property>
-               <property name="maximum">
-                <double>9999.989999999999782</double>
-               </property>
-               <property name="singleStep">
-                <double>0.100000000000000</double>
-               </property>
-               <property name="value">
-                <double>1.000000000000000</double>
-               </property>
-              </widget>
-             </item>
-             <item>
-              <widget class="QStackedWidget" name="swSampleMaterialDetails">
-               <property name="sizePolicy">
-                <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-                 <horstretch>0</horstretch>
-                 <verstretch>0</verstretch>
-                </sizepolicy>
-               </property>
-               <property name="currentIndex">
-                <number>0</number>
-               </property>
-               <widget class="QWidget" name="page">
-                <layout class="QHBoxLayout" name="horizontalLayout_9">
-                 <property name="leftMargin">
-                  <number>0</number>
-                 </property>
-                 <property name="topMargin">
-                  <number>0</number>
-                 </property>
-                 <property name="rightMargin">
-                  <number>0</number>
-                 </property>
-                 <property name="bottomMargin">
-                  <number>0</number>
-                 </property>
-                 <item>
-                  <spacer name="horizontalSpacer_5">
-                   <property name="orientation">
-                    <enum>Qt::Horizontal</enum>
-                   </property>
-                   <property name="sizeHint" stdset="0">
-                    <size>
-                     <width>40</width>
-                     <height>20</height>
-                    </size>
-                   </property>
-                  </spacer>
-                 </item>
-                 <item>
-                  <widget class="QLabel" name="lbSampleChemicalFormula">
-                   <property name="text">
-                    <string>Chemical Formula:</string>
-                   </property>
-                  </widget>
-                 </item>
-                 <item>
-                  <widget class="QLineEdit" name="leSampleChemicalFormula">
-                   <property name="sizePolicy">
+              <item>
+                <widget class="QGroupBox" name="gbShapeDetails">
+                  <property name="sizePolicy">
                     <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-                     <horstretch>0</horstretch>
-                     <verstretch>0</verstretch>
+                      <horstretch>0</horstretch>
+                      <verstretch>0</verstretch>
                     </sizepolicy>
-                   </property>
-                   <property name="text">
-                    <string/>
-                   </property>
-                  </widget>
-                 </item>
-                 <item>
-                  <widget class="QLabel" name="valSampleChemicalFormula">
-                   <property name="sizePolicy">
-                    <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
-                     <horstretch>0</horstretch>
-                     <verstretch>0</verstretch>
-                    </sizepolicy>
-                   </property>
-                   <property name="text">
-                    <string/>
-                   </property>
-                  </widget>
-                 </item>
-                </layout>
-               </widget>
-               <widget class="QWidget" name="page_2">
-                <layout class="QHBoxLayout" name="horizontalLayout_6">
-                 <property name="leftMargin">
-                  <number>0</number>
-                 </property>
-                 <property name="rightMargin">
-                  <number>0</number>
-                 </property>
-                 <item>
-                  <widget class="QLabel" name="lbCoherentXSection">
-                   <property name="text">
-                    <string>Coherent:</string>
-                   </property>
-                  </widget>
-                 </item>
-                 <item>
-                  <widget class="QDoubleSpinBox" name="spSampleCoherentXSection">
-                   <property name="suffix">
-                    <string> b</string>
-                   </property>
-                   <property name="decimals">
-                    <number>3</number>
-                   </property>
-                   <property name="maximum">
-                    <double>1000000.000000000000000</double>
-                   </property>
-                   <property name="singleStep">
-                    <double>0.100000000000000</double>
-                   </property>
-                  </widget>
-                 </item>
-                 <item>
-                  <widget class="QLabel" name="lbIncoherentXSection">
-                   <property name="text">
-                    <string>Incoherent:</string>
-                   </property>
-                  </widget>
-                 </item>
-                 <item>
-                  <widget class="QDoubleSpinBox" name="spSampleIncoherentXSection">
-                   <property name="suffix">
-                    <string> b</string>
-                   </property>
-                   <property name="decimals">
-                    <number>3</number>
-                   </property>
-                   <property name="maximum">
-                    <double>1000000.000000000000000</double>
-                   </property>
-                   <property name="singleStep">
-                    <double>0.100000000000000</double>
-                   </property>
-                  </widget>
-                 </item>
-                 <item>
-                  <widget class="QLabel" name="lbAttenuationXSection">
-                   <property name="text">
-                    <string>Attenuation:</string>
-                   </property>
-                  </widget>
-                 </item>
-                 <item>
-                  <widget class="QDoubleSpinBox" name="spSampleAttenuationXSection">
-                   <property name="suffix">
-                    <string> b</string>
-                   </property>
-                   <property name="decimals">
-                    <number>3</number>
-                   </property>
-                   <property name="maximum">
-                    <double>1000000.000000000000000</double>
-                   </property>
-                   <property name="singleStep">
-                    <double>0.100000000000000</double>
-                   </property>
-                  </widget>
-                 </item>
-                </layout>
-               </widget>
-              </widget>
-             </item>
-            </layout>
-           </widget>
-          </item>
-         </layout>
-        </widget>
-       </item>
-       <item>
-        <widget class="QGroupBox" name="gbContainerDetails">
-         <property name="enabled">
-          <bool>false</bool>
-         </property>
-         <property name="title">
-          <string>Container Details</string>
-         </property>
-         <layout class="QGridLayout" name="gridLayout_2">
-          <item row="0" column="0" colspan="2">
-           <widget class="QFrame" name="frame_4">
-            <layout class="QHBoxLayout" name="horizontalLayout_10">
-             <property name="leftMargin">
-              <number>0</number>
-             </property>
-             <property name="topMargin">
-              <number>0</number>
-             </property>
-             <property name="rightMargin">
-              <number>0</number>
-             </property>
-             <property name="bottomMargin">
-              <number>0</number>
-             </property>
-             <item>
-              <widget class="QLabel" name="lbCanMaterialsMethod">
-               <property name="text">
-                <string>Method:</string>
-               </property>
-              </widget>
-             </item>
-             <item>
-              <widget class="QComboBox" name="cbCanMaterialMethod">
-               <property name="sizePolicy">
-                <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-                 <horstretch>0</horstretch>
-                 <verstretch>0</verstretch>
-                </sizepolicy>
-               </property>
-               <property name="minimumSize">
-                <size>
-                 <width>120</width>
-                 <height>0</height>
-                </size>
-               </property>
-               <item>
-                <property name="text">
-                 <string>Chemical Formula</string>
-                </property>
-               </item>
-               <item>
-                <property name="text">
-                 <string>Cross-sections</string>
-                </property>
-               </item>
-              </widget>
-             </item>
-            </layout>
-           </widget>
-          </item>
-          <item row="1" column="0">
-           <widget class="QFrame" name="frame_5">
-            <layout class="QHBoxLayout" name="horizontalLayout_11">
-             <property name="leftMargin">
-              <number>0</number>
-             </property>
-             <property name="topMargin">
-              <number>0</number>
-             </property>
-             <property name="rightMargin">
-              <number>0</number>
-             </property>
-             <property name="bottomMargin">
-              <number>0</number>
-             </property>
-             <item>
-              <widget class="QComboBox" name="cbCanDensity">
-               <item>
-                <property name="text">
-                 <string>Mass Density</string>
-                </property>
-               </item>
-               <item>
-                <property name="text">
-                 <string>Atom Number Density</string>
-                </property>
-               </item>
-               <item>
-                <property name="text">
-                 <string>Formula Number Density</string>
-                </property>
-               </item>
-              </widget>
-             </item>
-             <item>
-              <widget class="QDoubleSpinBox" name="spCanDensity">
-               <property name="suffix">
-                <string> g/cm3</string>
-               </property>
-               <property name="decimals">
-                <number>4</number>
-               </property>
-               <property name="maximum">
-                <double>9999.989999999999782</double>
-               </property>
-               <property name="singleStep">
-                <double>0.100000000000000</double>
-               </property>
-               <property name="value">
-                <double>1.000000000000000</double>
-               </property>
-              </widget>
-             </item>
-             <item>
-              <widget class="QStackedWidget" name="swCanMaterialDetails">
-               <widget class="QWidget" name="page_3">
-                <layout class="QHBoxLayout" name="horizontalLayout_5">
-                 <property name="leftMargin">
-                  <number>0</number>
-                 </property>
-                 <property name="rightMargin">
-                  <number>0</number>
-                 </property>
-                 <item>
-                  <spacer name="horizontalSpacer_6">
-                   <property name="orientation">
-                    <enum>Qt::Horizontal</enum>
-                   </property>
-                   <property name="sizeHint" stdset="0">
+                  </property>
+                  <property name="title">
+                    <string>Shape Details</string>
+                  </property>
+                  <layout class="QVBoxLayout" name="verticalLayout_9">
+                    <item>
+                      <layout class="QHBoxLayout" name="loShape">
+                        <item>
+                          <widget class="QLabel" name="lbShape">
+                            <property name="text">
+                              <string>Shape:</string>
+                            </property>
+                          </widget>
+                        </item>
+                        <item>
+                          <widget class="QComboBox" name="cbShape">
+                            <item>
+                              <property name="text">
+                                <string>Flat Plate</string>
+                              </property>
+                            </item>
+                            <item>
+                              <property name="text">
+                                <string>Annulus</string>
+                              </property>
+                            </item>
+                            <item>
+                              <property name="text">
+                                <string>Cylinder</string>
+                              </property>
+                            </item>
+                          </widget>
+                        </item>
+                      </layout>
+                    </item>
+                    <item>
+                      <widget class="QStackedWidget" name="swShapeDetails">
+                        <property name="sizePolicy">
+                          <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+                            <horstretch>0</horstretch>
+                            <verstretch>0</verstretch>
+                          </sizepolicy>
+                        </property>
+                        <property name="currentIndex">
+                          <number>0</number>
+                        </property>
+                        <widget class="QWidget" name="pgAbsCorFlatPlate">
+                          <layout class="QGridLayout" name="loFlatPlate">
+                            <property name="leftMargin">
+                              <number>0</number>
+                            </property>
+                            <property name="topMargin">
+                              <number>0</number>
+                            </property>
+                            <property name="rightMargin">
+                              <number>0</number>
+                            </property>
+                            <property name="bottomMargin">
+                              <number>0</number>
+                            </property>
+                            <item row="1" column="1">
+                              <widget class="QDoubleSpinBox" name="spFlatSampleHeight">
+                                <property name="suffix">
+                                  <string> cm</string>
+                                </property>
+                                <property name="decimals">
+                                  <number>3</number>
+                                </property>
+                                <property name="singleStep">
+                                  <double>0.100000000000000</double>
+                                </property>
+                              </widget>
+                            </item>
+                            <item row="1" column="2">
+                              <widget class="QLabel" name="lbFlatSampleWidth">
+                                <property name="text">
+                                  <string>Sample Width:</string>
+                                </property>
+                              </widget>
+                            </item>
+                            <item row="1" column="3">
+                              <widget class="QDoubleSpinBox" name="spFlatSampleWidth">
+                                <property name="suffix">
+                                  <string> cm</string>
+                                </property>
+                                <property name="decimals">
+                                  <number>3</number>
+                                </property>
+                                <property name="singleStep">
+                                  <double>0.100000000000000</double>
+                                </property>
+                              </widget>
+                            </item>
+                            <item row="1" column="0">
+                              <widget class="QLabel" name="lbFlatSampleHeight">
+                                <property name="text">
+                                  <string>Sample Height:</string>
+                                </property>
+                              </widget>
+                            </item>
+                            <item row="2" column="1">
+                              <widget class="QDoubleSpinBox" name="spFlatSampleThickness">
+                                <property name="suffix">
+                                  <string> cm</string>
+                                </property>
+                                <property name="decimals">
+                                  <number>3</number>
+                                </property>
+                                <property name="singleStep">
+                                  <double>0.100000000000000</double>
+                                </property>
+                              </widget>
+                            </item>
+                            <item row="2" column="0">
+                              <widget class="QLabel" name="lbFlatSampleThickness">
+                                <property name="text">
+                                  <string>Sample Thickness:</string>
+                                </property>
+                              </widget>
+                            </item>
+                            <item row="3" column="0">
+                              <widget class="QLabel" name="lbFlatCanFrontThickness">
+                                <property name="enabled">
+                                  <bool>false</bool>
+                                </property>
+                                <property name="text">
+                                  <string>Container Front Thickness:</string>
+                                </property>
+                              </widget>
+                            </item>
+                            <item row="3" column="1">
+                              <widget class="QDoubleSpinBox" name="spFlatCanFrontThickness">
+                                <property name="enabled">
+                                  <bool>false</bool>
+                                </property>
+                                <property name="suffix">
+                                  <string> cm</string>
+                                </property>
+                                <property name="decimals">
+                                  <number>3</number>
+                                </property>
+                                <property name="singleStep">
+                                  <double>0.100000000000000</double>
+                                </property>
+                              </widget>
+                            </item>
+                            <item row="2" column="2">
+                              <widget class="QLabel" name="lbFlatSampleAngle">
+                                <property name="text">
+                                  <string>Sample Angle:</string>
+                                </property>
+                              </widget>
+                            </item>
+                            <item row="2" column="3">
+                              <widget class="QDoubleSpinBox" name="spFlatSampleAngle">
+                                <property name="suffix">
+                                  <string>°</string>
+                                </property>
+                                <property name="minimum">
+                                  <double>-180.000000000000000</double>
+                                </property>
+                                <property name="maximum">
+                                  <double>180.000000000000000</double>
+                                </property>
+                              </widget>
+                            </item>
+                            <item row="3" column="2">
+                              <widget class="QLabel" name="lbFlatCanBackThickness">
+                                <property name="enabled">
+                                  <bool>false</bool>
+                                </property>
+                                <property name="text">
+                                  <string>Container Back Thickness:</string>
+                                </property>
+                              </widget>
+                            </item>
+                            <item row="3" column="3">
+                              <widget class="QDoubleSpinBox" name="spFlatCanBackThickness">
+                                <property name="enabled">
+                                  <bool>false</bool>
+                                </property>
+                                <property name="suffix">
+                                  <string> cm</string>
+                                </property>
+                                <property name="decimals">
+                                  <number>3</number>
+                                </property>
+                                <property name="singleStep">
+                                  <double>0.100000000000000</double>
+                                </property>
+                              </widget>
+                            </item>
+                          </layout>
+                        </widget>
+                        <widget class="QWidget" name="pgAbsCorAnnulus">
+                          <layout class="QGridLayout" name="loAnnulus">
+                            <property name="leftMargin">
+                              <number>0</number>
+                            </property>
+                            <property name="topMargin">
+                              <number>0</number>
+                            </property>
+                            <property name="rightMargin">
+                              <number>0</number>
+                            </property>
+                            <property name="bottomMargin">
+                              <number>0</number>
+                            </property>
+                            <item row="6" column="3">
+                              <widget class="QDoubleSpinBox" name="spAnnCanOuterRadius">
+                                <property name="enabled">
+                                  <bool>false</bool>
+                                </property>
+                                <property name="suffix">
+                                  <string> cm</string>
+                                </property>
+                                <property name="decimals">
+                                  <number>3</number>
+                                </property>
+                                <property name="singleStep">
+                                  <double>0.100000000000000</double>
+                                </property>
+                              </widget>
+                            </item>
+                            <item row="6" column="1">
+                              <widget class="QDoubleSpinBox" name="spAnnCanInnerRadius">
+                                <property name="enabled">
+                                  <bool>false</bool>
+                                </property>
+                                <property name="suffix">
+                                  <string> cm</string>
+                                </property>
+                                <property name="decimals">
+                                  <number>3</number>
+                                </property>
+                                <property name="singleStep">
+                                  <double>0.100000000000000</double>
+                                </property>
+                              </widget>
+                            </item>
+                            <item row="2" column="1">
+                              <widget class="QDoubleSpinBox" name="spAnnSampleHeight">
+                                <property name="suffix">
+                                  <string> cm</string>
+                                </property>
+                                <property name="decimals">
+                                  <number>3</number>
+                                </property>
+                                <property name="singleStep">
+                                  <double>0.100000000000000</double>
+                                </property>
+                              </widget>
+                            </item>
+                            <item row="3" column="0">
+                              <widget class="QLabel" name="lbAnnSampleInnerRadius">
+                                <property name="text">
+                                  <string>Sample Inner Radius:</string>
+                                </property>
+                              </widget>
+                            </item>
+                            <item row="3" column="3">
+                              <widget class="QDoubleSpinBox" name="spAnnSampleOuterRadius">
+                                <property name="suffix">
+                                  <string> cm</string>
+                                </property>
+                                <property name="decimals">
+                                  <number>3</number>
+                                </property>
+                                <property name="singleStep">
+                                  <double>0.100000000000000</double>
+                                </property>
+                              </widget>
+                            </item>
+                            <item row="6" column="0">
+                              <widget class="QLabel" name="lbAnnCanInnerRadius">
+                                <property name="enabled">
+                                  <bool>false</bool>
+                                </property>
+                                <property name="text">
+                                  <string>Inner Container Inner Radius:</string>
+                                </property>
+                              </widget>
+                            </item>
+                            <item row="6" column="2">
+                              <widget class="QLabel" name="lbAnnCanOuterRadius">
+                                <property name="enabled">
+                                  <bool>false</bool>
+                                </property>
+                                <property name="text">
+                                  <string>Outer Container Outer Radius:</string>
+                                </property>
+                              </widget>
+                            </item>
+                            <item row="3" column="2">
+                              <widget class="QLabel" name="lbAnnSampleOuterRadius">
+                                <property name="text">
+                                  <string>Sample Outer Radius:</string>
+                                </property>
+                              </widget>
+                            </item>
+                            <item row="3" column="1">
+                              <widget class="QDoubleSpinBox" name="spAnnSampleInnerRadius">
+                                <property name="suffix">
+                                  <string> cm</string>
+                                </property>
+                                <property name="decimals">
+                                  <number>3</number>
+                                </property>
+                                <property name="singleStep">
+                                  <double>0.100000000000000</double>
+                                </property>
+                              </widget>
+                            </item>
+                            <item row="2" column="0">
+                              <widget class="QLabel" name="lbAnnSampleHeight">
+                                <property name="text">
+                                  <string>Sample Height:</string>
+                                </property>
+                              </widget>
+                            </item>
+                          </layout>
+                        </widget>
+                        <widget class="QWidget" name="pgAbsCorCylinder">
+                          <layout class="QGridLayout" name="loCylinder">
+                            <property name="leftMargin">
+                              <number>0</number>
+                            </property>
+                            <property name="topMargin">
+                              <number>0</number>
+                            </property>
+                            <property name="rightMargin">
+                              <number>0</number>
+                            </property>
+                            <property name="bottomMargin">
+                              <number>0</number>
+                            </property>
+                            <item row="1" column="1">
+                              <widget class="QDoubleSpinBox" name="spCylSampleHeight">
+                                <property name="suffix">
+                                  <string> cm</string>
+                                </property>
+                                <property name="decimals">
+                                  <number>3</number>
+                                </property>
+                                <property name="singleStep">
+                                  <double>0.100000000000000</double>
+                                </property>
+                              </widget>
+                            </item>
+                            <item row="2" column="1">
+                              <widget class="QDoubleSpinBox" name="spCylSampleRadius">
+                                <property name="suffix">
+                                  <string> cm</string>
+                                </property>
+                                <property name="decimals">
+                                  <number>3</number>
+                                </property>
+                                <property name="singleStep">
+                                  <double>0.100000000000000</double>
+                                </property>
+                              </widget>
+                            </item>
+                            <item row="2" column="0">
+                              <widget class="QLabel" name="lbCylSampleRadius">
+                                <property name="text">
+                                  <string>Sample Radius:</string>
+                                </property>
+                              </widget>
+                            </item>
+                            <item row="1" column="0">
+                              <widget class="QLabel" name="lbCylSampleHeight">
+                                <property name="text">
+                                  <string>Sample Height:</string>
+                                </property>
+                              </widget>
+                            </item>
+                            <item row="2" column="2">
+                              <widget class="QLabel" name="lbCylCanOuterRadius">
+                                <property name="enabled">
+                                  <bool>false</bool>
+                                </property>
+                                <property name="text">
+                                  <string>Container Outer Radius</string>
+                                </property>
+                              </widget>
+                            </item>
+                            <item row="2" column="3">
+                              <widget class="QDoubleSpinBox" name="spCylCanOuterRadius">
+                                <property name="enabled">
+                                  <bool>false</bool>
+                                </property>
+                                <property name="suffix">
+                                  <string> cm</string>
+                                </property>
+                                <property name="decimals">
+                                  <number>3</number>
+                                </property>
+                                <property name="singleStep">
+                                  <double>0.100000000000000</double>
+                                </property>
+                              </widget>
+                            </item>
+                          </layout>
+                        </widget>
+                      </widget>
+                    </item>
+                  </layout>
+                </widget>
+              </item>
+              <item>
+                <widget class="QGroupBox" name="gbSampleDetails">
+                  <property name="title">
+                    <string>Sample Details</string>
+                  </property>
+                  <layout class="QGridLayout" name="gridLayout">
+                    <item row="0" column="0" colspan="3">
+                      <widget class="QFrame" name="frame_2">
+                        <layout class="QHBoxLayout" name="horizontalLayout_8">
+                          <property name="leftMargin">
+                            <number>0</number>
+                          </property>
+                          <property name="topMargin">
+                            <number>0</number>
+                          </property>
+                          <property name="rightMargin">
+                            <number>0</number>
+                          </property>
+                          <property name="bottomMargin">
+                            <number>0</number>
+                          </property>
+                          <item>
+                            <widget class="QLabel" name="lbSampleMaterialsMethod">
+                              <property name="text">
+                                <string>Method:</string>
+                              </property>
+                            </widget>
+                          </item>
+                          <item>
+                            <widget class="QComboBox" name="cbSampleMaterialMethod">
+                              <property name="sizePolicy">
+                                <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+                                  <horstretch>0</horstretch>
+                                  <verstretch>0</verstretch>
+                                </sizepolicy>
+                              </property>
+                              <property name="minimumSize">
+                                <size>
+                                  <width>120</width>
+                                  <height>0</height>
+                                </size>
+                              </property>
+                              <item>
+                                <property name="text">
+                                  <string>Chemical Formula</string>
+                                </property>
+                              </item>
+                              <item>
+                                <property name="text">
+                                  <string>Cross-sections</string>
+                                </property>
+                              </item>
+                            </widget>
+                          </item>
+                        </layout>
+                      </widget>
+                    </item>
+                    <item row="1" column="0" colspan="3">
+                      <widget class="QFrame" name="frame_3">
+                        <layout class="QHBoxLayout" name="horizontalLayout_3">
+                          <property name="leftMargin">
+                            <number>0</number>
+                          </property>
+                          <property name="topMargin">
+                            <number>0</number>
+                          </property>
+                          <property name="rightMargin">
+                            <number>0</number>
+                          </property>
+                          <property name="bottomMargin">
+                            <number>0</number>
+                          </property>
+                          <item>
+                            <widget class="QComboBox" name="cbSampleDensity">
+                              <item>
+                                <property name="text">
+                                  <string>Mass Density</string>
+                                </property>
+                              </item>
+                              <item>
+                                <property name="text">
+                                  <string>Atom Number Density</string>
+                                </property>
+                              </item>
+                              <item>
+                                <property name="text">
+                                  <string>Formula Number Density</string>
+                                </property>
+                              </item>
+                            </widget>
+                          </item>
+                          <item>
+                            <widget class="QDoubleSpinBox" name="spSampleDensity">
+                              <property name="suffix">
+                                <string> g/cm3</string>
+                              </property>
+                              <property name="decimals">
+                                <number>4</number>
+                              </property>
+                              <property name="maximum">
+                                <double>9999.989999999999782</double>
+                              </property>
+                              <property name="singleStep">
+                                <double>0.100000000000000</double>
+                              </property>
+                              <property name="value">
+                                <double>1.000000000000000</double>
+                              </property>
+                            </widget>
+                          </item>
+                          <item>
+                            <widget class="QStackedWidget" name="swSampleMaterialDetails">
+                              <property name="sizePolicy">
+                                <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+                                  <horstretch>0</horstretch>
+                                  <verstretch>0</verstretch>
+                                </sizepolicy>
+                              </property>
+                              <property name="currentIndex">
+                                <number>0</number>
+                              </property>
+                              <widget class="QWidget" name="page">
+                                <layout class="QHBoxLayout" name="horizontalLayout_9">
+                                  <property name="leftMargin">
+                                    <number>0</number>
+                                  </property>
+                                  <property name="topMargin">
+                                    <number>0</number>
+                                  </property>
+                                  <property name="rightMargin">
+                                    <number>0</number>
+                                  </property>
+                                  <property name="bottomMargin">
+                                    <number>0</number>
+                                  </property>
+                                  <item>
+                                    <spacer name="horizontalSpacer_5">
+                                      <property name="orientation">
+                                        <enum>Qt::Horizontal</enum>
+                                      </property>
+                                      <property name="sizeHint" stdset="0">
+                                        <size>
+                                          <width>40</width>
+                                          <height>20</height>
+                                        </size>
+                                      </property>
+                                    </spacer>
+                                  </item>
+                                  <item>
+                                    <widget class="QLabel" name="lbSampleChemicalFormula">
+                                      <property name="text">
+                                        <string>Chemical Formula:</string>
+                                      </property>
+                                    </widget>
+                                  </item>
+                                  <item>
+                                    <widget class="QLineEdit" name="leSampleChemicalFormula">
+                                      <property name="sizePolicy">
+                                        <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+                                          <horstretch>0</horstretch>
+                                          <verstretch>0</verstretch>
+                                        </sizepolicy>
+                                      </property>
+                                      <property name="text">
+                                        <string/>
+                                      </property>
+                                    </widget>
+                                  </item>
+                                  <item>
+                                    <widget class="QLabel" name="valSampleChemicalFormula">
+                                      <property name="sizePolicy">
+                                        <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
+                                          <horstretch>0</horstretch>
+                                          <verstretch>0</verstretch>
+                                        </sizepolicy>
+                                      </property>
+                                      <property name="text">
+                                        <string/>
+                                      </property>
+                                    </widget>
+                                  </item>
+                                </layout>
+                              </widget>
+                              <widget class="QWidget" name="page_2">
+                                <layout class="QHBoxLayout" name="horizontalLayout_6">
+                                  <property name="leftMargin">
+                                    <number>0</number>
+                                  </property>
+                                  <property name="rightMargin">
+                                    <number>0</number>
+                                  </property>
+                                  <item>
+                                    <widget class="QLabel" name="lbCoherentXSection">
+                                      <property name="text">
+                                        <string>Coherent:</string>
+                                      </property>
+                                    </widget>
+                                  </item>
+                                  <item>
+                                    <widget class="QDoubleSpinBox" name="spSampleCoherentXSection">
+                                      <property name="suffix">
+                                        <string> b</string>
+                                      </property>
+                                      <property name="decimals">
+                                        <number>3</number>
+                                      </property>
+                                      <property name="maximum">
+                                        <double>1000000.000000000000000</double>
+                                      </property>
+                                      <property name="singleStep">
+                                        <double>0.100000000000000</double>
+                                      </property>
+                                    </widget>
+                                  </item>
+                                  <item>
+                                    <widget class="QLabel" name="lbIncoherentXSection">
+                                      <property name="text">
+                                        <string>Incoherent:</string>
+                                      </property>
+                                    </widget>
+                                  </item>
+                                  <item>
+                                    <widget class="QDoubleSpinBox" name="spSampleIncoherentXSection">
+                                      <property name="suffix">
+                                        <string> b</string>
+                                      </property>
+                                      <property name="decimals">
+                                        <number>3</number>
+                                      </property>
+                                      <property name="maximum">
+                                        <double>1000000.000000000000000</double>
+                                      </property>
+                                      <property name="singleStep">
+                                        <double>0.100000000000000</double>
+                                      </property>
+                                    </widget>
+                                  </item>
+                                  <item>
+                                    <widget class="QLabel" name="lbAttenuationXSection">
+                                      <property name="text">
+                                        <string>Attenuation:</string>
+                                      </property>
+                                    </widget>
+                                  </item>
+                                  <item>
+                                    <widget class="QDoubleSpinBox" name="spSampleAttenuationXSection">
+                                      <property name="suffix">
+                                        <string> b</string>
+                                      </property>
+                                      <property name="decimals">
+                                        <number>3</number>
+                                      </property>
+                                      <property name="maximum">
+                                        <double>1000000.000000000000000</double>
+                                      </property>
+                                      <property name="singleStep">
+                                        <double>0.100000000000000</double>
+                                      </property>
+                                    </widget>
+                                  </item>
+                                </layout>
+                              </widget>
+                            </widget>
+                          </item>
+                        </layout>
+                      </widget>
+                    </item>
+                  </layout>
+                </widget>
+              </item>
+              <item>
+                <widget class="QGroupBox" name="gbContainerDetails">
+                  <property name="enabled">
+                    <bool>false</bool>
+                  </property>
+                  <property name="title">
+                    <string>Container Details</string>
+                  </property>
+                  <layout class="QGridLayout" name="gridLayout_2">
+                    <item row="0" column="0" colspan="2">
+                      <widget class="QFrame" name="frame_4">
+                        <layout class="QHBoxLayout" name="horizontalLayout_10">
+                          <property name="leftMargin">
+                            <number>0</number>
+                          </property>
+                          <property name="topMargin">
+                            <number>0</number>
+                          </property>
+                          <property name="rightMargin">
+                            <number>0</number>
+                          </property>
+                          <property name="bottomMargin">
+                            <number>0</number>
+                          </property>
+                          <item>
+                            <widget class="QLabel" name="lbCanMaterialsMethod">
+                              <property name="text">
+                                <string>Method:</string>
+                              </property>
+                            </widget>
+                          </item>
+                          <item>
+                            <widget class="QComboBox" name="cbCanMaterialMethod">
+                              <property name="sizePolicy">
+                                <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+                                  <horstretch>0</horstretch>
+                                  <verstretch>0</verstretch>
+                                </sizepolicy>
+                              </property>
+                              <property name="minimumSize">
+                                <size>
+                                  <width>120</width>
+                                  <height>0</height>
+                                </size>
+                              </property>
+                              <item>
+                                <property name="text">
+                                  <string>Chemical Formula</string>
+                                </property>
+                              </item>
+                              <item>
+                                <property name="text">
+                                  <string>Cross-sections</string>
+                                </property>
+                              </item>
+                            </widget>
+                          </item>
+                        </layout>
+                      </widget>
+                    </item>
+                    <item row="1" column="0">
+                      <widget class="QFrame" name="frame_5">
+                        <layout class="QHBoxLayout" name="horizontalLayout_11">
+                          <property name="leftMargin">
+                            <number>0</number>
+                          </property>
+                          <property name="topMargin">
+                            <number>0</number>
+                          </property>
+                          <property name="rightMargin">
+                            <number>0</number>
+                          </property>
+                          <property name="bottomMargin">
+                            <number>0</number>
+                          </property>
+                          <item>
+                            <widget class="QComboBox" name="cbCanDensity">
+                              <item>
+                                <property name="text">
+                                  <string>Mass Density</string>
+                                </property>
+                              </item>
+                              <item>
+                                <property name="text">
+                                  <string>Atom Number Density</string>
+                                </property>
+                              </item>
+                              <item>
+                                <property name="text">
+                                  <string>Formula Number Density</string>
+                                </property>
+                              </item>
+                            </widget>
+                          </item>
+                          <item>
+                            <widget class="QDoubleSpinBox" name="spCanDensity">
+                              <property name="suffix">
+                                <string> g/cm3</string>
+                              </property>
+                              <property name="decimals">
+                                <number>4</number>
+                              </property>
+                              <property name="maximum">
+                                <double>9999.989999999999782</double>
+                              </property>
+                              <property name="singleStep">
+                                <double>0.100000000000000</double>
+                              </property>
+                              <property name="value">
+                                <double>1.000000000000000</double>
+                              </property>
+                            </widget>
+                          </item>
+                          <item>
+                            <widget class="QStackedWidget" name="swCanMaterialDetails">
+                              <widget class="QWidget" name="page_3">
+                                <layout class="QHBoxLayout" name="horizontalLayout_5">
+                                  <property name="leftMargin">
+                                    <number>0</number>
+                                  </property>
+                                  <property name="rightMargin">
+                                    <number>0</number>
+                                  </property>
+                                  <item>
+                                    <spacer name="horizontalSpacer_6">
+                                      <property name="orientation">
+                                        <enum>Qt::Horizontal</enum>
+                                      </property>
+                                      <property name="sizeHint" stdset="0">
+                                        <size>
+                                          <width>40</width>
+                                          <height>20</height>
+                                        </size>
+                                      </property>
+                                    </spacer>
+                                  </item>
+                                  <item>
+                                    <widget class="QLabel" name="lbCanChemicalFormula">
+                                      <property name="text">
+                                        <string>Chemical Formula:</string>
+                                      </property>
+                                    </widget>
+                                  </item>
+                                  <item>
+                                    <widget class="QLineEdit" name="leCanChemicalFormula">
+                                      <property name="sizePolicy">
+                                        <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+                                          <horstretch>0</horstretch>
+                                          <verstretch>0</verstretch>
+                                        </sizepolicy>
+                                      </property>
+                                    </widget>
+                                  </item>
+                                  <item>
+                                    <widget class="QLabel" name="valCanChemicalFormula">
+                                      <property name="sizePolicy">
+                                        <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
+                                          <horstretch>0</horstretch>
+                                          <verstretch>0</verstretch>
+                                        </sizepolicy>
+                                      </property>
+                                      <property name="text">
+                                        <string/>
+                                      </property>
+                                    </widget>
+                                  </item>
+                                </layout>
+                              </widget>
+                              <widget class="QWidget" name="page_4">
+                                <layout class="QHBoxLayout" name="horizontalLayout_7">
+                                  <property name="leftMargin">
+                                    <number>0</number>
+                                  </property>
+                                  <property name="rightMargin">
+                                    <number>0</number>
+                                  </property>
+                                  <item>
+                                    <widget class="QLabel" name="lbCoherentXSection_2">
+                                      <property name="text">
+                                        <string>Coherent:</string>
+                                      </property>
+                                    </widget>
+                                  </item>
+                                  <item>
+                                    <widget class="QDoubleSpinBox" name="spCanCoherentXSection">
+                                      <property name="suffix">
+                                        <string> b</string>
+                                      </property>
+                                      <property name="decimals">
+                                        <number>3</number>
+                                      </property>
+                                      <property name="maximum">
+                                        <double>1000000.000000000000000</double>
+                                      </property>
+                                      <property name="singleStep">
+                                        <double>0.100000000000000</double>
+                                      </property>
+                                    </widget>
+                                  </item>
+                                  <item>
+                                    <widget class="QLabel" name="lbIncoherentXSection_2">
+                                      <property name="text">
+                                        <string>Incoherent:</string>
+                                      </property>
+                                    </widget>
+                                  </item>
+                                  <item>
+                                    <widget class="QDoubleSpinBox" name="spCanIncoherentXSection">
+                                      <property name="suffix">
+                                        <string> b</string>
+                                      </property>
+                                      <property name="decimals">
+                                        <number>3</number>
+                                      </property>
+                                      <property name="maximum">
+                                        <double>1000000.000000000000000</double>
+                                      </property>
+                                      <property name="singleStep">
+                                        <double>0.100000000000000</double>
+                                      </property>
+                                    </widget>
+                                  </item>
+                                  <item>
+                                    <widget class="QLabel" name="lbAttenuationXSection_2">
+                                      <property name="text">
+                                        <string>Attenuation:</string>
+                                      </property>
+                                    </widget>
+                                  </item>
+                                  <item>
+                                    <widget class="QDoubleSpinBox" name="spCanAttenuationXSection">
+                                      <property name="suffix">
+                                        <string> b</string>
+                                      </property>
+                                      <property name="decimals">
+                                        <number>3</number>
+                                      </property>
+                                      <property name="maximum">
+                                        <double>1000000.000000000000000</double>
+                                      </property>
+                                      <property name="singleStep">
+                                        <double>0.100000000000000</double>
+                                      </property>
+                                    </widget>
+                                  </item>
+                                </layout>
+                              </widget>
+                            </widget>
+                          </item>
+                        </layout>
+                      </widget>
+                    </item>
+                  </layout>
+                </widget>
+              </item>
+              <item>
+                <widget class="QGroupBox" name="gbRun">
+                  <property name="minimumSize">
                     <size>
-                     <width>40</width>
-                     <height>20</height>
+                      <width>0</width>
+                      <height>45</height>
                     </size>
-                   </property>
-                  </spacer>
-                 </item>
-                 <item>
-                  <widget class="QLabel" name="lbCanChemicalFormula">
-                   <property name="text">
-                    <string>Chemical Formula:</string>
-                   </property>
-                  </widget>
-                 </item>
-                 <item>
-                  <widget class="QLineEdit" name="leCanChemicalFormula">
-                   <property name="sizePolicy">
+                  </property>
+                  <property name="maximumSize">
+                    <size>
+                      <width>16777215</width>
+                      <height>45</height>
+                    </size>
+                  </property>
+                  <property name="title">
+                    <string>Run</string>
+                  </property>
+                  <layout class="QHBoxLayout" name="horizontalLayout">
+                    <property name="topMargin">
+                      <number>0</number>
+                    </property>
+                    <property name="bottomMargin">
+                      <number>3</number>
+                    </property>
+                    <item>
+                      <spacer name="horizontalSpacer">
+                        <property name="orientation">
+                          <enum>Qt::Horizontal</enum>
+                        </property>
+                        <property name="sizeHint" stdset="0">
+                          <size>
+                            <width>348</width>
+                            <height>20</height>
+                          </size>
+                        </property>
+                      </spacer>
+                    </item>
+                    <item>
+                      <widget class="QPushButton" name="pbRun">
+                        <property name="text">
+                          <string>Run</string>
+                        </property>
+                      </widget>
+                    </item>
+                    <item>
+                      <spacer name="horizontalSpacer_3">
+                        <property name="orientation">
+                          <enum>Qt::Horizontal</enum>
+                        </property>
+                        <property name="sizeHint" stdset="0">
+                          <size>
+                            <width>348</width>
+                            <height>20</height>
+                          </size>
+                        </property>
+                      </spacer>
+                    </item>
+                  </layout>
+                </widget>
+              </item>
+              <item>
+                <widget class="QGroupBox" name="gbOutput">
+                  <property name="sizePolicy">
                     <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-                     <horstretch>0</horstretch>
-                     <verstretch>0</verstretch>
+                      <horstretch>0</horstretch>
+                      <verstretch>0</verstretch>
                     </sizepolicy>
-                   </property>
-                  </widget>
-                 </item>
-                 <item>
-                  <widget class="QLabel" name="valCanChemicalFormula">
-                   <property name="sizePolicy">
-                    <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
-                     <horstretch>0</horstretch>
-                     <verstretch>0</verstretch>
-                    </sizepolicy>
-                   </property>
-                   <property name="text">
-                    <string/>
-                   </property>
-                  </widget>
-                 </item>
-                </layout>
-               </widget>
-               <widget class="QWidget" name="page_4">
-                <layout class="QHBoxLayout" name="horizontalLayout_7">
-                 <property name="leftMargin">
-                  <number>0</number>
-                 </property>
-                 <property name="rightMargin">
-                  <number>0</number>
-                 </property>
-                 <item>
-                  <widget class="QLabel" name="lbCoherentXSection_2">
-                   <property name="text">
-                    <string>Coherent:</string>
-                   </property>
-                  </widget>
-                 </item>
-                 <item>
-                  <widget class="QDoubleSpinBox" name="spCanCoherentXSection">
-                   <property name="suffix">
-                    <string> b</string>
-                   </property>
-                   <property name="decimals">
-                    <number>3</number>
-                   </property>
-                   <property name="maximum">
-                    <double>1000000.000000000000000</double>
-                   </property>
-                   <property name="singleStep">
-                    <double>0.100000000000000</double>
-                   </property>
-                  </widget>
-                 </item>
-                 <item>
-                  <widget class="QLabel" name="lbIncoherentXSection_2">
-                   <property name="text">
-                    <string>Incoherent:</string>
-                   </property>
-                  </widget>
-                 </item>
-                 <item>
-                  <widget class="QDoubleSpinBox" name="spCanIncoherentXSection">
-                   <property name="suffix">
-                    <string> b</string>
-                   </property>
-                   <property name="decimals">
-                    <number>3</number>
-                   </property>
-                   <property name="maximum">
-                    <double>1000000.000000000000000</double>
-                   </property>
-                   <property name="singleStep">
-                    <double>0.100000000000000</double>
-                   </property>
-                  </widget>
-                 </item>
-                 <item>
-                  <widget class="QLabel" name="lbAttenuationXSection_2">
-                   <property name="text">
-                    <string>Attenuation:</string>
-                   </property>
-                  </widget>
-                 </item>
-                 <item>
-                  <widget class="QDoubleSpinBox" name="spCanAttenuationXSection">
-                   <property name="suffix">
-                    <string> b</string>
-                   </property>
-                   <property name="decimals">
-                    <number>3</number>
-                   </property>
-                   <property name="maximum">
-                    <double>1000000.000000000000000</double>
-                   </property>
-                   <property name="singleStep">
-                    <double>0.100000000000000</double>
-                   </property>
-                  </widget>
-                 </item>
-                </layout>
-               </widget>
-              </widget>
-             </item>
+                  </property>
+                  <property name="minimumSize">
+                    <size>
+                      <width>0</width>
+                      <height>56</height>
+                    </size>
+                  </property>
+                  <property name="title">
+                    <string>Output Options</string>
+                  </property>
+                  <layout class="QHBoxLayout" name="horizontalLayout_2">
+                    <property name="topMargin">
+                      <number>0</number>
+                    </property>
+                    <property name="bottomMargin">
+                      <number>7</number>
+                    </property>
+                    <item>
+                      <widget class="MantidQt::CustomInterfaces::IndirectPlotOptionsView" name="ipoPlotOptions" native="true"/>
+                    </item>
+                    <item>
+                      <spacer name="horizontalSpacer_2">
+                        <property name="orientation">
+                          <enum>Qt::Horizontal</enum>
+                        </property>
+                        <property name="sizeHint" stdset="0">
+                          <size>
+                            <width>40</width>
+                            <height>20</height>
+                          </size>
+                        </property>
+                      </spacer>
+                    </item>
+                    <item>
+                      <widget class="QPushButton" name="pbSave">
+                        <property name="enabled">
+                          <bool>false</bool>
+                        </property>
+                        <property name="text">
+                          <string>Save Result</string>
+                        </property>
+                      </widget>
+                    </item>
+                  </layout>
+                </widget>
+              </item>
             </layout>
-           </widget>
-          </item>
-         </layout>
+          </widget>
         </widget>
-       </item>
-       <item>
-        <widget class="QGroupBox" name="gbRun">
-         <property name="minimumSize">
-          <size>
-           <width>0</width>
-           <height>45</height>
-          </size>
-         </property>
-         <property name="maximumSize">
-          <size>
-           <width>16777215</width>
-           <height>45</height>
-          </size>
-         </property>
-         <property name="title">
-          <string>Run</string>
-         </property>
-         <layout class="QHBoxLayout" name="horizontalLayout">
-          <property name="topMargin">
-           <number>0</number>
-          </property>
-          <property name="bottomMargin">
-           <number>3</number>
-          </property>
-          <item>
-           <spacer name="horizontalSpacer">
-            <property name="orientation">
-             <enum>Qt::Horizontal</enum>
-            </property>
-            <property name="sizeHint" stdset="0">
-             <size>
-              <width>348</width>
-              <height>20</height>
-             </size>
-            </property>
-           </spacer>
-          </item>
-          <item>
-           <widget class="QPushButton" name="pbRun">
-            <property name="text">
-             <string>Run</string>
-            </property>
-           </widget>
-          </item>
-          <item>
-           <spacer name="horizontalSpacer_3">
-            <property name="orientation">
-             <enum>Qt::Horizontal</enum>
-            </property>
-            <property name="sizeHint" stdset="0">
-             <size>
-              <width>348</width>
-              <height>20</height>
-             </size>
-            </property>
-           </spacer>
-          </item>
-         </layout>
-        </widget>
-       </item>
-       <item>
-        <widget class="QGroupBox" name="gbOutput">
-         <property name="sizePolicy">
-          <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-           <horstretch>0</horstretch>
-           <verstretch>0</verstretch>
-          </sizepolicy>
-         </property>
-         <property name="minimumSize">
-          <size>
-           <width>0</width>
-           <height>56</height>
-          </size>
-         </property>
-         <property name="title">
-          <string>Output Options</string>
-         </property>
-         <layout class="QHBoxLayout" name="horizontalLayout_2">
-          <property name="topMargin">
-           <number>0</number>
-          </property>
-          <property name="bottomMargin">
-           <number>7</number>
-          </property>
-          <item>
-           <widget class="MantidQt::CustomInterfaces::IndirectPlotOptionsView" name="ipoPlotOptions" native="true"/>
-          </item>
-          <item>
-           <spacer name="horizontalSpacer_2">
-            <property name="orientation">
-             <enum>Qt::Horizontal</enum>
-            </property>
-            <property name="sizeHint" stdset="0">
-             <size>
-              <width>40</width>
-              <height>20</height>
-             </size>
-            </property>
-           </spacer>
-          </item>
-          <item>
-           <widget class="QPushButton" name="pbSave">
-            <property name="enabled">
-             <bool>false</bool>
-            </property>
-            <property name="text">
-             <string>Save Result</string>
-            </property>
-           </widget>
-          </item>
-         </layout>
-        </widget>
-       </item>
-      </layout>
-     </widget>
-    </widget>
-   </item>
-  </layout>
- </widget>
- <customwidgets>
-  <customwidget>
-   <class>MantidQt::CustomInterfaces::IndirectPlotOptionsView</class>
-   <extends>QWidget</extends>
-   <header>IndirectPlotOptionsView.h</header>
-   <container>1</container>
-  </customwidget>
-  <customwidget>
-   <class>MantidQt::MantidWidgets::DataSelector</class>
-   <extends>QWidget</extends>
-   <header>MantidQtWidgets/Common/DataSelector.h</header>
-  </customwidget>
- </customwidgets>
- <tabstops>
-  <tabstop>ckUseCan</tabstop>
-  <tabstop>spNumberEvents</tabstop>
-  <tabstop>spBeamHeight</tabstop>
-  <tabstop>spBeamWidth</tabstop>
-  <tabstop>cbShape</tabstop>
-  <tabstop>spFlatSampleHeight</tabstop>
-  <tabstop>spFlatSampleWidth</tabstop>
-  <tabstop>spFlatSampleThickness</tabstop>
-  <tabstop>spFlatSampleAngle</tabstop>
-  <tabstop>spFlatCanFrontThickness</tabstop>
-  <tabstop>spFlatCanBackThickness</tabstop>
-  <tabstop>spCylSampleHeight</tabstop>
-  <tabstop>spCylSampleRadius</tabstop>
-  <tabstop>spCylCanOuterRadius</tabstop>
-  <tabstop>spAnnSampleHeight</tabstop>
-  <tabstop>spAnnSampleInnerRadius</tabstop>
-  <tabstop>spAnnSampleOuterRadius</tabstop>
-  <tabstop>spAnnCanInnerRadius</tabstop>
-  <tabstop>spAnnCanOuterRadius</tabstop>
-  <tabstop>pbSave</tabstop>
- </tabstops>
- <resources/>
- <connections>
-  <connection>
-   <sender>cbShape</sender>
-   <signal>currentIndexChanged(int)</signal>
-   <receiver>swShapeDetails</receiver>
-   <slot>setCurrentIndex(int)</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>783</x>
-     <y>324</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>315</x>
-     <y>370</y>
-    </hint>
-   </hints>
-  </connection>
-  <connection>
-   <sender>ckUseCan</sender>
-   <signal>toggled(bool)</signal>
-   <receiver>dsCanInput</receiver>
-   <slot>setEnabled(bool)</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>194</x>
-     <y>69</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>784</x>
-     <y>67</y>
-    </hint>
-   </hints>
-  </connection>
-  <connection>
-   <sender>ckUseCan</sender>
-   <signal>toggled(bool)</signal>
-   <receiver>gbContainerDetails</receiver>
-   <slot>setEnabled(bool)</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>194</x>
-     <y>69</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>305</x>
-     <y>571</y>
-    </hint>
-   </hints>
-  </connection>
-  <connection>
-   <sender>spFlatCanFrontThickness</sender>
-   <signal>valueChanged(double)</signal>
-   <receiver>spFlatCanBackThickness</receiver>
-   <slot>setValue(double)</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>402</x>
-     <y>424</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>784</x>
-     <y>424</y>
-    </hint>
-   </hints>
-  </connection>
-  <connection>
-   <sender>ckUseCan</sender>
-   <signal>toggled(bool)</signal>
-   <receiver>lbFlatCanFrontThickness</receiver>
-   <slot>setEnabled(bool)</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>140</x>
-     <y>69</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>175</x>
-     <y>424</y>
-    </hint>
-   </hints>
-  </connection>
-  <connection>
-   <sender>ckUseCan</sender>
-   <signal>toggled(bool)</signal>
-   <receiver>spFlatCanFrontThickness</receiver>
-   <slot>setEnabled(bool)</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>241</x>
-     <y>69</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>402</x>
-     <y>424</y>
-    </hint>
-   </hints>
-  </connection>
-  <connection>
-   <sender>ckUseCan</sender>
-   <signal>toggled(bool)</signal>
-   <receiver>lbFlatCanBackThickness</receiver>
-   <slot>setEnabled(bool)</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>255</x>
-     <y>69</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>593</x>
-     <y>424</y>
-    </hint>
-   </hints>
-  </connection>
-  <connection>
-   <sender>ckUseCan</sender>
-   <signal>toggled(bool)</signal>
-   <receiver>spFlatCanBackThickness</receiver>
-   <slot>setEnabled(bool)</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>229</x>
-     <y>69</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>784</x>
-     <y>424</y>
-    </hint>
-   </hints>
-  </connection>
-  <connection>
-   <sender>ckUseCan</sender>
-   <signal>toggled(bool)</signal>
-   <receiver>lbAnnCanInnerRadius</receiver>
-   <slot>setEnabled(bool)</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>169</x>
-     <y>69</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>65</x>
-     <y>424</y>
-    </hint>
-   </hints>
-  </connection>
-  <connection>
-   <sender>ckUseCan</sender>
-   <signal>toggled(bool)</signal>
-   <receiver>spAnnCanInnerRadius</receiver>
-   <slot>setEnabled(bool)</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>246</x>
-     <y>69</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>282</x>
-     <y>424</y>
-    </hint>
-   </hints>
-  </connection>
-  <connection>
-   <sender>ckUseCan</sender>
-   <signal>toggled(bool)</signal>
-   <receiver>lbAnnCanOuterRadius</receiver>
-   <slot>setEnabled(bool)</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>308</x>
-     <y>69</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>501</x>
-     <y>424</y>
-    </hint>
-   </hints>
-  </connection>
-  <connection>
-   <sender>ckUseCan</sender>
-   <signal>toggled(bool)</signal>
-   <receiver>spAnnCanOuterRadius</receiver>
-   <slot>setEnabled(bool)</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>334</x>
-     <y>69</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>718</x>
-     <y>424</y>
-    </hint>
-   </hints>
-  </connection>
-  <connection>
-   <sender>ckUseCan</sender>
-   <signal>clicked(bool)</signal>
-   <receiver>lbCylCanOuterRadius</receiver>
-   <slot>setEnabled(bool)</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>57</x>
-     <y>67</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>532</x>
-     <y>408</y>
-    </hint>
-   </hints>
-  </connection>
-  <connection>
-   <sender>ckUseCan</sender>
-   <signal>clicked(bool)</signal>
-   <receiver>spCylCanOuterRadius</receiver>
-   <slot>setEnabled(bool)</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>38</x>
-     <y>66</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>646</x>
-     <y>411</y>
-    </hint>
-   </hints>
-  </connection>
- </connections>
+      </item>
+    </layout>
+  </widget>
+  <customwidgets>
+    <customwidget>
+      <class>MantidQt::CustomInterfaces::IndirectPlotOptionsView</class>
+      <extends>QWidget</extends>
+      <header>IndirectPlotOptionsView.h</header>
+      <container>1</container>
+    </customwidget>
+    <customwidget>
+      <class>MantidQt::MantidWidgets::DataSelector</class>
+      <extends>QWidget</extends>
+      <header>MantidQtWidgets/Common/DataSelector.h</header>
+    </customwidget>
+  </customwidgets>
+  <tabstops>
+    <tabstop>ckUseCan</tabstop>
+    <tabstop>spNumberEvents</tabstop>
+    <tabstop>spBeamHeight</tabstop>
+    <tabstop>spBeamWidth</tabstop>
+    <tabstop>cbShape</tabstop>
+    <tabstop>spFlatSampleHeight</tabstop>
+    <tabstop>spFlatSampleWidth</tabstop>
+    <tabstop>spFlatSampleThickness</tabstop>
+    <tabstop>spFlatSampleAngle</tabstop>
+    <tabstop>spFlatCanFrontThickness</tabstop>
+    <tabstop>spFlatCanBackThickness</tabstop>
+    <tabstop>spCylSampleHeight</tabstop>
+    <tabstop>spCylSampleRadius</tabstop>
+    <tabstop>spCylCanOuterRadius</tabstop>
+    <tabstop>spAnnSampleHeight</tabstop>
+    <tabstop>spAnnSampleInnerRadius</tabstop>
+    <tabstop>spAnnSampleOuterRadius</tabstop>
+    <tabstop>spAnnCanInnerRadius</tabstop>
+    <tabstop>spAnnCanOuterRadius</tabstop>
+    <tabstop>pbSave</tabstop>
+  </tabstops>
+  <resources/>
+  <connections>
+    <connection>
+      <sender>cbShape</sender>
+      <signal>currentIndexChanged(int)</signal>
+      <receiver>swShapeDetails</receiver>
+      <slot>setCurrentIndex(int)</slot>
+      <hints>
+        <hint type="sourcelabel">
+          <x>783</x>
+          <y>324</y>
+        </hint>
+        <hint type="destinationlabel">
+          <x>315</x>
+          <y>370</y>
+        </hint>
+      </hints>
+    </connection>
+    <connection>
+      <sender>ckUseCan</sender>
+      <signal>toggled(bool)</signal>
+      <receiver>dsCanInput</receiver>
+      <slot>setEnabled(bool)</slot>
+      <hints>
+        <hint type="sourcelabel">
+          <x>194</x>
+          <y>69</y>
+        </hint>
+        <hint type="destinationlabel">
+          <x>784</x>
+          <y>67</y>
+        </hint>
+      </hints>
+    </connection>
+    <connection>
+      <sender>ckUseCan</sender>
+      <signal>toggled(bool)</signal>
+      <receiver>gbContainerDetails</receiver>
+      <slot>setEnabled(bool)</slot>
+      <hints>
+        <hint type="sourcelabel">
+          <x>194</x>
+          <y>69</y>
+        </hint>
+        <hint type="destinationlabel">
+          <x>305</x>
+          <y>571</y>
+        </hint>
+      </hints>
+    </connection>
+    <connection>
+      <sender>spFlatCanFrontThickness</sender>
+      <signal>valueChanged(double)</signal>
+      <receiver>spFlatCanBackThickness</receiver>
+      <slot>setValue(double)</slot>
+      <hints>
+        <hint type="sourcelabel">
+          <x>402</x>
+          <y>424</y>
+        </hint>
+        <hint type="destinationlabel">
+          <x>784</x>
+          <y>424</y>
+        </hint>
+      </hints>
+    </connection>
+    <connection>
+      <sender>ckUseCan</sender>
+      <signal>toggled(bool)</signal>
+      <receiver>lbFlatCanFrontThickness</receiver>
+      <slot>setEnabled(bool)</slot>
+      <hints>
+        <hint type="sourcelabel">
+          <x>140</x>
+          <y>69</y>
+        </hint>
+        <hint type="destinationlabel">
+          <x>175</x>
+          <y>424</y>
+        </hint>
+      </hints>
+    </connection>
+    <connection>
+      <sender>ckUseCan</sender>
+      <signal>toggled(bool)</signal>
+      <receiver>spFlatCanFrontThickness</receiver>
+      <slot>setEnabled(bool)</slot>
+      <hints>
+        <hint type="sourcelabel">
+          <x>241</x>
+          <y>69</y>
+        </hint>
+        <hint type="destinationlabel">
+          <x>402</x>
+          <y>424</y>
+        </hint>
+      </hints>
+    </connection>
+    <connection>
+      <sender>ckUseCan</sender>
+      <signal>toggled(bool)</signal>
+      <receiver>lbFlatCanBackThickness</receiver>
+      <slot>setEnabled(bool)</slot>
+      <hints>
+        <hint type="sourcelabel">
+          <x>255</x>
+          <y>69</y>
+        </hint>
+        <hint type="destinationlabel">
+          <x>593</x>
+          <y>424</y>
+        </hint>
+      </hints>
+    </connection>
+    <connection>
+      <sender>ckUseCan</sender>
+      <signal>toggled(bool)</signal>
+      <receiver>spFlatCanBackThickness</receiver>
+      <slot>setEnabled(bool)</slot>
+      <hints>
+        <hint type="sourcelabel">
+          <x>229</x>
+          <y>69</y>
+        </hint>
+        <hint type="destinationlabel">
+          <x>784</x>
+          <y>424</y>
+        </hint>
+      </hints>
+    </connection>
+    <connection>
+      <sender>ckUseCan</sender>
+      <signal>toggled(bool)</signal>
+      <receiver>lbAnnCanInnerRadius</receiver>
+      <slot>setEnabled(bool)</slot>
+      <hints>
+        <hint type="sourcelabel">
+          <x>169</x>
+          <y>69</y>
+        </hint>
+        <hint type="destinationlabel">
+          <x>65</x>
+          <y>424</y>
+        </hint>
+      </hints>
+    </connection>
+    <connection>
+      <sender>ckUseCan</sender>
+      <signal>toggled(bool)</signal>
+      <receiver>spAnnCanInnerRadius</receiver>
+      <slot>setEnabled(bool)</slot>
+      <hints>
+        <hint type="sourcelabel">
+          <x>246</x>
+          <y>69</y>
+        </hint>
+        <hint type="destinationlabel">
+          <x>282</x>
+          <y>424</y>
+        </hint>
+      </hints>
+    </connection>
+    <connection>
+      <sender>ckUseCan</sender>
+      <signal>toggled(bool)</signal>
+      <receiver>lbAnnCanOuterRadius</receiver>
+      <slot>setEnabled(bool)</slot>
+      <hints>
+        <hint type="sourcelabel">
+          <x>308</x>
+          <y>69</y>
+        </hint>
+        <hint type="destinationlabel">
+          <x>501</x>
+          <y>424</y>
+        </hint>
+      </hints>
+    </connection>
+    <connection>
+      <sender>ckUseCan</sender>
+      <signal>toggled(bool)</signal>
+      <receiver>spAnnCanOuterRadius</receiver>
+      <slot>setEnabled(bool)</slot>
+      <hints>
+        <hint type="sourcelabel">
+          <x>334</x>
+          <y>69</y>
+        </hint>
+        <hint type="destinationlabel">
+          <x>718</x>
+          <y>424</y>
+        </hint>
+      </hints>
+    </connection>
+    <connection>
+      <sender>ckUseCan</sender>
+      <signal>clicked(bool)</signal>
+      <receiver>lbCylCanOuterRadius</receiver>
+      <slot>setEnabled(bool)</slot>
+      <hints>
+        <hint type="sourcelabel">
+          <x>57</x>
+          <y>67</y>
+        </hint>
+        <hint type="destinationlabel">
+          <x>532</x>
+          <y>408</y>
+        </hint>
+      </hints>
+    </connection>
+    <connection>
+      <sender>ckUseCan</sender>
+      <signal>clicked(bool)</signal>
+      <receiver>spCylCanOuterRadius</receiver>
+      <slot>setEnabled(bool)</slot>
+      <hints>
+        <hint type="sourcelabel">
+          <x>38</x>
+          <y>66</y>
+        </hint>
+        <hint type="destinationlabel">
+          <x>646</x>
+          <y>411</y>
+        </hint>
+      </hints>
+    </connection>
+  </connections>
 </ui>

--- a/qt/scientific_interfaces/Indirect/AbsorptionCorrections.ui
+++ b/qt/scientific_interfaces/Indirect/AbsorptionCorrections.ui
@@ -76,19 +76,6 @@
             </property>
            </widget>
           </item>
-          <item row="2" column="0">
-           <widget class="QCheckBox" name="cbUseCan">
-            <property name="maximumSize">
-             <size>
-              <width>16777208</width>
-              <height>16777215</height>
-             </size>
-            </property>
-            <property name="text">
-             <string>Use Container</string>
-            </property>
-           </widget>
-          </item>
          </layout>
         </widget>
        </item>
@@ -287,6 +274,25 @@
              </widget>
             </item>
            </layout>
+          </item>
+          <item>
+           <widget class="QCheckBox" name="cbUseCan">
+            <property name="enabled">
+             <bool>true</bool>
+            </property>
+            <property name="maximumSize">
+             <size>
+              <width>16777208</width>
+              <height>16777215</height>
+             </size>
+            </property>
+            <property name="text">
+             <string>Use Container</string>
+            </property>
+            <property name="checked">
+             <bool>true</bool>
+            </property>
+           </widget>
           </item>
           <item>
            <widget class="QStackedWidget" name="swShapeDetails">
@@ -936,7 +942,7 @@
        <item>
         <widget class="QGroupBox" name="gbContainerDetails">
          <property name="enabled">
-          <bool>false</bool>
+          <bool>true</bool>
          </property>
          <property name="title">
           <string>Container Details</string>


### PR DESCRIPTION
**Description of work.**

Previously PPMCA would require the user to define a new sample (and possibly container) shape before running, however there is now the option to use the shape preset in the workspace data.
If the preset shape is being used, there is still the option to override the sample material without affecting the sample and can geometries. 
As part of this, the algorithm now only takes one input workspace for both sample and container rather than one for each.
The Indirect Corrections Calculate Monte Carlo tab that uses this algorithm is updated to support these changes.

**To test:**
This test script runs the algorithm a few times using the preset shape, and once using a preset shape but overridden material.
[testscript.zip](https://github.com/mantidproject/mantid/files/5703743/testscript.zip)
1. Try this script out, test using some different shapes/parameters/materials etc
2. Try the Corrections interface (Interfaces -> Indirect -> Corrections) to ensure this reflects the updated functionality

Fixes #29899 .

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
