### PR TITLE
Indirect Fix Bayes ResNorm Crash when plotting current preview

### DIFF
--- a/docs/source/release/v6.0.0/indirect_geometry.rst
+++ b/docs/source/release/v6.0.0/indirect_geometry.rst
@@ -25,5 +25,6 @@ Bug Fixes
 - A bug in Indirect Data Analysis causing logs not to load in the Edit Local Fit Parameters dialog has been fixed.
 - Fixed a bug in Indirect Data Reduction causing the colon separator in Custom Grouping to act like a dash separator. This colon separator should now act
   as expected (i.e. `1:5` means the same as `1,2,3,4,5`).
+- Fixed a crash on Indirect Bayes ResNorm when clicking `Plot Current Preview` without a workspace loaded.
 
 :ref:`Release 6.0.0 <v6.0.0>`

--- a/qt/scientific_interfaces/Indirect/IndirectPlotter.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectPlotter.cpp
@@ -242,6 +242,8 @@ void IndirectPlotter::plotSpectra(std::string const &workspaceName,
 void IndirectPlotter::plotCorrespondingSpectra(
     std::vector<std::string> const &workspaceNames,
     std::vector<int> const &workspaceIndices) {
+  if (workspaceNames.empty() || workspaceIndices.empty())
+    return;
   if (workspaceNames.size() > 1 &&
       workspaceNames.size() != workspaceIndices.size())
     return;

--- a/qt/scientific_interfaces/Indirect/test/IndirectPlotterTest.h
+++ b/qt/scientific_interfaces/Indirect/test/IndirectPlotterTest.h
@@ -105,6 +105,20 @@ public:
   }
 
   void
+  test_that_plotCorrespondingSpectra_will_not_cause_an_exception_when_the_workspaces_names_are_empty() {
+    std::vector<std::string> workspaceNames;
+    std::vector<int> workspaceIndices{0};
+    m_plotter->plotCorrespondingSpectra(workspaceNames, workspaceIndices);
+  }
+
+  void
+  test_that_plotCorrespondingSpectra_will_not_cause_an_exception_when_the_workspaces_indices_are_empty() {
+    std::vector<std::string> workspaceNames{WORKSPACE_NAME};
+    std::vector<int> workspaceIndices;
+    m_plotter->plotCorrespondingSpectra(workspaceNames, workspaceIndices);
+  }
+
+  void
   test_that_validate_will_return_true_if_the_matrix_workspace_and_workspace_indices_exist() {
     m_ads.addOrReplace(WORKSPACE_NAME, createMatrixWorkspace(5, 5));
 


### PR DESCRIPTION
**Description of work.**
This PR prevents a crash when clicking `Plot Current Preview` on Indirect Bayes ResNorm with no workspace loaded.

**To test:**
1. Open Indirect Bayes interface.
2. Go to ResNorm tab
3. Click `Plot Current Preview`. There should be no crash.

Fixes #30158 

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
