### PR TITLE
Add new algorithm for SHELX76 constant wavelength format

### DIFF
--- a/Framework/Crystal/inc/MantidCrystal/SaveHKL.h
+++ b/Framework/Crystal/inc/MantidCrystal/SaveHKL.h
@@ -32,7 +32,7 @@ public:
   /// Algorithm's version for identification
   int version() const override { return 1; }
   const std::vector<std::string> seeAlso() const override {
-    return {"LoadHKL"};
+    return {"LoadHKL", "SaveHKLCW"};
   }
   /// Algorithm's category for identification
   const std::string category() const override {

--- a/Framework/PythonInterface/plugins/CMakeLists.txt
+++ b/Framework/PythonInterface/plugins/CMakeLists.txt
@@ -152,6 +152,7 @@ set(PYTHON_PLUGINS
     algorithms/SNSPowderReduction.py
     algorithms/SaveGEMMAUDParamFile.py
     algorithms/SaveGSSCW.py
+    algorithms/SaveHKLCW.py
     algorithms/SaveNexusPD.py
     algorithms/SaveP2D.py
     algorithms/SavePlot1DAsJson.py

--- a/Framework/PythonInterface/plugins/algorithms/SaveHKLCW.py
+++ b/Framework/PythonInterface/plugins/algorithms/SaveHKLCW.py
@@ -1,0 +1,95 @@
+# Mantid Repository : https://github.com/mantidproject/mantid
+#
+# Copyright &copy; 2020 ISIS Rutherford Appleton Laboratory UKRI,
+#   NScD Oak Ridge National Laboratory, European Spallation Source,
+#   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+# SPDX - License - Identifier: GPL - 3.0 +
+
+import numpy as np
+from mantid.api import (AlgorithmFactory, PythonAlgorithm, FileAction, FileProperty,
+                        IPeaksWorkspaceProperty)
+from mantid.kernel import Direction, logger
+
+
+class SaveHKLCW(PythonAlgorithm):
+    def category(self):
+        return 'Diffraction\\DataHandling'
+
+    def summary(self):
+        """
+        summary of the algorithm
+        :return:
+        """
+        return "Save a PeaksWorkspace to SHELX76 format required by WINGX"
+
+    def name(self):
+        return "SaveHKLCW"
+
+    def seeAlso(self):
+        return ["SaveHKL"]
+
+    def PyInit(self):
+        self.declareProperty(IPeaksWorkspaceProperty('Workspace', '', direction=Direction.Input),
+                             doc='PeaksWorkspace to be saved')
+        self.declareProperty(FileProperty('OutputFile',
+                                          '',
+                                          action=FileAction.Save,
+                                          extensions=['hkl', 'int'],
+                                          direction=Direction.Input),
+                             doc='Output File.')
+        self.declareProperty('Header',
+                             True,
+                             direction=Direction.Input,
+                             doc='If to include the header in the output')
+        self.declareProperty('DirectionCosines',
+                             False,
+                             direction=Direction.Input,
+                             doc='If to include the direction cosines output')
+
+    def PyExec(self):
+
+        peak_ws = self.getProperty('Workspace').value
+        outFile = self.getPropertyValue('OutputFile')
+        header = self.getProperty('Header').value
+        directionCosines = self.getProperty('DirectionCosines').value
+
+        with open(outFile, 'w') as f:
+            if header:
+                f.write("Single crystal data\n")
+                if directionCosines:
+                    f.write("(3i4,2f8.2,i4,6f8.5)\n")
+                else:
+                    f.write("(3i4,2f8.2,i4)\n")
+                wavelengths = [p.getWavelength() for p in peak_ws]
+                if np.std(wavelengths) > 0.01:
+                    logger.warning(
+                        "Large variation of wavelengths, this doesn't look like constant wavelength"
+                    )
+                wavelength = np.mean([p.getWavelength() for p in peak_ws])
+                f.write(f"{wavelength:.5f}  0   0\n")
+
+            if directionCosines:
+                U = peak_ws.sample().getOrientedLattice().getU()
+                sample_pos = peak_ws.getInstrument().getSample().getPos()
+                q_reverse_incident = peak_ws.getInstrument().getSource().getPos() - sample_pos
+                q_reverse_incident = np.array(q_reverse_incident) / q_reverse_incident.norm()
+
+            for p in peak_ws:
+                if directionCosines:
+                    R = p.getGoniometerMatrix()
+                    RU = np.dot(R, U)
+                    q_diffracted = p.getDetPos() - sample_pos
+                    q_diffracted = np.array(q_diffracted) / q_diffracted.norm()
+                    dir_cos_1 = np.dot(RU.T, q_reverse_incident)
+                    dir_cos_2 = np.dot(RU.T, q_diffracted)
+                    f.write(
+                        "{:4.0f}{:4.0f}{:4.0f}{:8.2f}{:8.2f}{:4d}{:8.5f}{:8.5f}{:8.5f}{:8.5f}{:8.5f}{:8.5f}\n"
+                        .format(p.getH(), p.getK(), p.getL(), p.getIntensity(),
+                                p.getSigmaIntensity(), 1, dir_cos_1[0], dir_cos_2[0], dir_cos_1[1],
+                                dir_cos_2[1], dir_cos_1[2], dir_cos_2[2]))
+                else:
+                    f.write("{:4.0f}{:4.0f}{:4.0f}{:8.2f}{:8.2f}{:4d}\n".format(
+                        p.getH(), p.getK(), p.getL(), p.getIntensity(), p.getSigmaIntensity(), 1))
+
+
+AlgorithmFactory.subscribe(SaveHKLCW)

--- a/Framework/PythonInterface/test/python/plugins/algorithms/CMakeLists.txt
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/CMakeLists.txt
@@ -92,6 +92,7 @@ set(TEST_PY_FILES
     SaveGEMMAUDParamFileTest.py
     SaveNexusPDTest.py
     SaveGSSCWTest.py
+    SaveHKLCWTest.py
     SavePlot1DAsJsonTest.py
     SaveReflectionsTest.py
     ExtractMonitorsTest.py

--- a/Framework/PythonInterface/test/python/plugins/algorithms/SaveHKLCWTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/SaveHKLCWTest.py
@@ -1,0 +1,79 @@
+# Mantid Repository : https://github.com/mantidproject/mantid
+#
+# Copyright &copy; 2020 ISIS Rutherford Appleton Laboratory UKRI,
+#   NScD Oak Ridge National Laboratory, European Spallation Source,
+#   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+# SPDX - License - Identifier: GPL - 3.0 +
+
+import unittest
+import tempfile
+import os
+from mantid.simpleapi import SaveHKLCW, CreateSampleWorkspace, CreatePeaksWorkspace, SetUB, DeleteWorkspace
+
+
+class SaveHKLCWTest(unittest.TestCase):
+    def setUp(self):
+        self._tmp_directory = tempfile.gettempdir()
+        self._ws_name = 'SaveHKLCWTest'
+        CreateSampleWorkspace(OutputWorkspace=self._ws_name)
+        peaks = CreatePeaksWorkspace(self._ws_name, NumberOfPeaks=0, OutputWorkspace=self._ws_name+"_peaks")
+        SetUB(peaks)
+        peaks.addPeak(peaks.createPeakHKL([1, 1, 1]))
+        peaks.addPeak(peaks.createPeakHKL([1, -1, 1]))
+
+    def tearDown(self):
+        DeleteWorkspace(self._ws_name, self._ws_name+"_peaks")
+
+    def testSaveHKL(self):
+        output_file = os.path.join(self._tmp_directory, self._ws_name+'.hkl')
+        SaveHKLCW(self._ws_name+"_peaks", output_file)
+
+        with open(output_file, 'r') as f:
+            lines = f.readlines()
+
+        self.assertEqual(len(lines), 5)
+        self.assertEqual(lines[0], 'Single crystal data\n')
+        self.assertEqual(lines[1], '(3i4,2f8.2,i4)\n')
+        self.assertEqual(lines[2], '0.66667  0   0\n')
+        self.assertEqual(lines[3], '   1   1   1    0.00    0.00   1\n')
+        self.assertEqual(lines[4], '   1  -1   1    0.00    0.00   1\n')
+
+    def testSaveHKL_no_header(self):
+        output_file = os.path.join(self._tmp_directory, self._ws_name+'_no_header.hkl')
+        SaveHKLCW(self._ws_name+"_peaks", output_file, Header=False)
+
+        with open(output_file, 'r') as f:
+            lines = f.readlines()
+
+        self.assertEqual(len(lines), 2)
+        self.assertEqual(lines[0], '   1   1   1    0.00    0.00   1\n')
+        self.assertEqual(lines[1], '   1  -1   1    0.00    0.00   1\n')
+
+    def testSaveHKL_direction_cosines(self):
+        output_file = os.path.join(self._tmp_directory, self._ws_name+'_dc.hkl')
+        SaveHKLCW(self._ws_name+"_peaks", output_file, DirectionCosines=True)
+
+        with open(output_file, 'r') as f:
+            lines = f.readlines()
+
+        self.assertEqual(len(lines), 5)
+        self.assertEqual(lines[0], 'Single crystal data\n')
+        self.assertEqual(lines[1], '(3i4,2f8.2,i4,6f8.5)\n')
+        self.assertEqual(lines[2], '0.66667  0   0\n')
+        self.assertEqual(lines[3], '   1   1   1    0.00    0.00   1-1.00000 0.33333 0.00000-0.66667 0.00000-0.66667\n')
+        self.assertEqual(lines[4], '   1  -1   1    0.00    0.00   1-1.00000 0.33333 0.00000 0.66667 0.00000-0.66667\n')
+
+    def testSaveHKL_direction_cosines_no_header(self):
+        output_file = os.path.join(self._tmp_directory, self._ws_name+'_dc_no_header.hkl')
+        SaveHKLCW(self._ws_name+"_peaks", output_file, DirectionCosines=True, Header=False)
+
+        with open(output_file, 'r') as f:
+            lines = f.readlines()
+
+        self.assertEqual(len(lines), 2)
+        self.assertEqual(lines[0], '   1   1   1    0.00    0.00   1-1.00000 0.33333 0.00000-0.66667 0.00000-0.66667\n')
+        self.assertEqual(lines[1], '   1  -1   1    0.00    0.00   1-1.00000 0.33333 0.00000 0.66667 0.00000-0.66667\n')
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/docs/source/algorithms/SaveHKLCW-v1.rst
+++ b/docs/source/algorithms/SaveHKLCW-v1.rst
@@ -1,0 +1,87 @@
+.. algorithm::
+
+.. summary::
+
+.. relatedalgorithms::
+
+.. properties::
+
+Description
+-----------
+
+Input
+#####
+
+This algorithm will save a peaks workspace to a SHELX76 formatted file
+which is made to be compatible with Fullprof and WINGX. This is a
+simplified version compared to :ref:`algm-SaveHKL` and it assumes a
+constant wavelength. It also assume integer HKL and will round to the
+nearest integer value.
+
+For output with direction cosines the format is.
+
++----+----+----+------+------------+----+------+------+------+------+------+------+
+| h  | k  | l  | F^2  | sigma(F^2) | N  | IX   | DX   | IY   | DY   | IZ   | DZ   |
++====+====+====+======+============+====+======+======+======+======+======+======+
+| I4 | I4 | I4 | F8.2 | F8.2       | I4 | F8.5 | F8.5 | F8.5 | F8.5 | F8.5 | F8.5 |
++----+----+----+------+------------+----+------+------+------+------+------+------+
+
+The corresponding format without direction cosines is.
+
++----+----+----+------+------------+----+
+| h  | k  | l  | F^2  | sigma(F^2) | N  |
++====+====+====+======+============+====+
+| I4 | I4 | I4 | F8.2 | F8.2       | I4 |
++----+----+----+------+------------+----+
+
+The output file contains a short header containing the default title,
+format string and wavelength.
+
+Usage
+-----
+
+**Example: Output with direction cosines**
+
+.. testcode:: SaveHKLCW
+
+    # create a temporary workspace
+    ws = CreateSampleWorkspace()
+    # create the peaks workspace
+    peaks = CreatePeaksWorkspace(ws, NumberOfPeaks=0)
+    # set the UB, require for direction cosine calculation
+    SetUB(peaks)
+    # add some peaks
+    peaks.addPeak(peaks.createPeakHKL([1, 1, 1]))
+    peaks.addPeak(peaks.createPeakHKL([1, -1, 1]))
+
+    # Save the output
+    file_name = "Usage_Example.hkl"
+    path = os.path.join(os.path.expanduser("~"), file_name)
+    SaveHKLCW(peaks, path, DirectionCosines=True)
+
+    # Does the file exist? If it exists, print it!
+    if os.path.isfile(path):
+        with open(path, 'r') as f:
+             data = f.readlines()
+        for entry in data:
+            print(entry[:-1]) # leave out the last character to remove unnecessary newlines
+
+.. testcleanup:: SaveHKLCW
+
+    os.remove(path)
+
+Output:
+The resulting output file (Usage_Example.hkl) looks like this
+
+.. testoutput:: SaveHKLCW
+
+    Single crystal data
+    (3i4,2f8.2,i4,6f8.5)
+    0.66667  0   0
+       1   1   1    0.00    0.00   1-1.00000 0.33333 0.00000-0.66667 0.00000-0.66667
+       1  -1   1    0.00    0.00   1-1.00000 0.33333 0.00000 0.66667 0.00000-0.66667
+
+
+.. categories::
+
+.. sourcelink::

--- a/docs/source/release/v6.0.0/diffraction.rst
+++ b/docs/source/release/v6.0.0/diffraction.rst
@@ -81,6 +81,7 @@ Single Crystal Diffraction
 New features
 ############
 - New algorithm :ref:`ConvertQtoHKLMDHisto <algm-ConvertQtoHKLMDHisto>` to convert from a QSample MDEventWorkspace to HKL MDHistoWorkspace with correct peak overlaying.
+- New algorithm :ref:`SaveHKLCW <algm-SaveHKLCW>` for SHELX76 constant wavelength format.
 - Scripts for pixel calibration of CORELLI 16-packs. Produce a calibration table, a masking table, and a goodness of fit workspace.
 - Fix problem that was causing matrix diagonalization to return NaNs in certain cases. The diagonalization is used in :ref:`CalculateUMatrix <algm-CalculateUMatrix>` and :ref:`IntegratePeaksMD <algm-IntegratePeaksMD>`
 - New algorithm :ref:`HB3AFindPeaks <algm-HB3AFindPeaks>` to find peaks and set the UB matrix for DEMAND data.


### PR DESCRIPTION
**Description of work.**

This algorithm will save a peaks workspace to a SHELX76 formatted file which is made to be compatible with Fullprof and WINGX. This is a simplified version compared to SaveHKL and it assumes a constant wavelength.

**To test:**
gunzip [peaks.nxs.gz](https://github.com/mantidproject/mantid/files/5691712/peaks.nxs.gz)

```python
peaks = LoadNexus('peaks.nxs')
SaveHKLCW(peaks, OutputFile='peaks.hkl', DirectionCosines=True)
```

the output should look like

```
Single crystal data
(3i4,2f8.2,i4,6f8.5)
1.00800  0   0
   0   0 -1023969.11  220.35   1-0.75750 0.75756-0.60035 0.60027 0.25646 0.25649
   0   0  -8  434.20   32.95   1-0.77022 0.77033-0.60387 0.60376 0.20516 0.20511
   0   1 -10  311.58   24.54   1-0.79355 0.79362-0.60495 0.41224 0.06560 0.44746
   0   1  -8  474.48   33.32   1-0.80037 0.80039-0.59874 0.40614-0.03049 0.44094
   1  -1  -9 2469.09   76.73   1-0.76064 0.56837-0.60132 0.79359 0.24461 0.21718
   1   0 -11  263.56   21.95   1-0.79578 0.60307-0.60402 0.60409 0.04352 0.52093
   1   0  -9  300.96   25.59   1-0.80098 0.60882-0.59537 0.59528-0.06296 0.52439
   1   0  -7  340.96   30.30   1-0.79462 0.60232-0.57501 0.57491-0.19478 0.55380
   1   1  -9 2935.60   75.39   1-0.78732 0.59466-0.56280 0.37039-0.25176 0.71358
   1   1  -7 1728.59   62.75   1-0.75424 0.56169-0.52035 0.32806-0.40044 0.75953
   1   1  -5 1128.82   55.43   1-0.68429 0.49187-0.44695 0.25416-0.57617 0.83275
   1   2  -9   79.24   11.66   1-0.77034 0.57806-0.53964 0.15491-0.33965 0.80116
   2  -1 -10  291.36   24.70   1-0.79320 0.40815-0.60506 0.79754 0.06878 0.44422
   2  -1  -8  269.67   26.19   1-0.80063 0.41571-0.59784 0.79020-0.03979 0.45030
   2   0 -10 1743.86   56.41   1-0.79456 0.40975-0.57491 0.57493-0.19533 0.70821
   2   0  -8 2561.42   73.46   1-0.77088 0.38595-0.54031 0.54025-0.33735 0.74778
   2   0  -6 9518.59  153.08   1-0.71795 0.33289-0.48089 0.48085-0.50329 0.81115
   2   0  -4 5937.85  130.53   1-0.61504 0.23014-0.38138 0.38155-0.69013 0.89524
   2   1  -8  256.36   21.45   1-0.72690 0.34198-0.49027 0.29773-0.48089 0.89129
   2   1  -6  349.06   26.42   1-0.65581 0.27082-0.41944 0.22709-0.62768 0.93546
   2   1  -4  438.80   31.11   1-0.54718 0.16266-0.32051 0.12808-0.77322 0.97833
   2   1  -2  698.18   40.62   1-0.39699 0.01222-0.19282 0.00024-0.89734 0.99993
   2   2  -4 1154.45   45.65   1-0.54066 0.15570-0.31478-0.06989-0.78013 0.98533
   2   2  -2  483.27   30.23   1-0.42092 0.03576-0.21266-0.17224-0.88182 0.98441
   2   2   030249.15  241.44   1-0.28383-0.10128-0.10102-0.28377-0.95354 0.95353
   3  -1  -9 3195.87   81.50   1-0.79984 0.22268-0.58736 0.77980-0.12352 0.58508
   3  -1  -7 1874.07   67.20   1-0.78487 0.20772-0.55914 0.75155-0.26710 0.62612
   3  -1  -5 1647.32   67.78   1-0.74180 0.16436-0.50635 0.69870-0.43970 0.69628
   3  -1  -3  366.75   33.90   1-0.64917 0.07178-0.41315 0.60550-0.63866 0.79260
   3  -1   1  162.61   22.47   1-0.26690-0.31059-0.08755 0.27992-0.95974 0.90839
   3   0  -7  266.57   22.43   1-0.71609 0.13887-0.47897 0.47875-0.50774 0.86690
   3   0  -5  416.26   29.31   1-0.63753 0.06026-0.40221 0.40219-0.65710 0.91357
   3   0  -3  597.22   36.30   1-0.52210-0.05495-0.29860 0.29860-0.79890 0.95280
   3   0  -1  347.79   28.11   1-0.37196-0.20552-0.17224 0.17238-0.91213 0.96335
   3   1  -3  302.61   23.17   1-0.47794-0.09925-0.26064 0.06822-0.83883 0.99272
   3   1  -1  296.97   23.22   1-0.35277-0.22426-0.15657-0.03582-0.92252 0.97387
```



<!-- Ensure the base of this PR is correct (e.g. release-next or master)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
