### PR TITLE
Easier method of removing curves from plots

### DIFF
--- a/docs/source/release/v6.0.0/mantidworkbench.rst
+++ b/docs/source/release/v6.0.0/mantidworkbench.rst
@@ -39,6 +39,7 @@ Improvements
 - Add an autoscale checkbox to plot config dialog.
 - Add a Python function to replace the workspace being shown by an instrument window.
 - Slice Viewer replots the workspace when it is modified outside the Slice Viewer.
+- In the plot config, multiple curves can be selected and removed at once. The delete key was added as a shortcut.
 
 Bugfixes
 ########

--- a/qt/python/mantidqt/widgets/plotconfigdialog/curvestabwidget/curves_tab.ui
+++ b/qt/python/mantidqt/widgets/plotconfigdialog/curvestabwidget/curves_tab.ui
@@ -79,12 +79,6 @@
          <height>0</height>
         </size>
        </property>
-       <property name="maximumSize">
-        <size>
-         <width>1500000</width>
-         <height>22</height>
-        </size>
-       </property>
        <property name="text">
         <string>Remove</string>
        </property>

--- a/qt/python/mantidqt/widgets/plotconfigdialog/curvestabwidget/curves_tab.ui
+++ b/qt/python/mantidqt/widgets/plotconfigdialog/curvestabwidget/curves_tab.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>378</width>
-    <height>534</height>
+    <width>818</width>
+    <height>622</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -63,20 +63,7 @@
    <item row="4" column="0">
     <layout class="QHBoxLayout" name="horizontalLayout">
      <item>
-      <widget class="QComboBox" name="select_curve_combo_box">
-       <property name="sizePolicy">
-        <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-         <horstretch>0</horstretch>
-         <verstretch>0</verstretch>
-        </sizepolicy>
-       </property>
-       <property name="minimumSize">
-        <size>
-         <width>250</width>
-         <height>0</height>
-        </size>
-       </property>
-      </widget>
+      <widget class="QListWidget" name="select_curve_list"/>
      </item>
      <item>
       <widget class="QPushButton" name="remove_curve_button">
@@ -241,7 +228,6 @@
  </widget>
  <tabstops>
   <tabstop>select_axes_combo_box</tabstop>
-  <tabstop>select_curve_combo_box</tabstop>
   <tabstop>remove_curve_button</tabstop>
   <tabstop>hide_curve_check_box</tabstop>
   <tabstop>curve_label_line_edit</tabstop>

--- a/qt/python/mantidqt/widgets/plotconfigdialog/curvestabwidget/presenter.py
+++ b/qt/python/mantidqt/widgets/plotconfigdialog/curvestabwidget/presenter.py
@@ -44,6 +44,8 @@ class CurvesTabWidgetPresenter:
             self.on_curves_row_changed)
         self.view.remove_curve_button.clicked.connect(
             self.remove_selected_curves)
+        self.view.delete_key_pressed.connect(
+            self.remove_selected_curves)
         self.view.line.apply_to_all_button.clicked.connect(
             self.line_apply_to_all)
         self.view.marker.apply_to_all_button.clicked.connect(

--- a/qt/python/mantidqt/widgets/plotconfigdialog/curvestabwidget/view.py
+++ b/qt/python/mantidqt/widgets/plotconfigdialog/curvestabwidget/view.py
@@ -56,6 +56,11 @@ class CurvesTabWidgetView(QWidget):
         current_item = self.select_curve_list.currentItem()
         self.select_curve_list.removeItemWidget(current_item)
 
+    def remove_select_curve_list_selected_items(self):
+        selection = self.select_curve_list.selectionModel().selectedIndexes()
+        for index in selection:
+            _ = self.select_curve_list.takeItem(index.row())
+
     # Tab enablers and disablers
     def set_errorbars_tab_enabled(self, enable):
         self.tab_container.setTabEnabled(2, enable)
@@ -64,8 +69,11 @@ class CurvesTabWidgetView(QWidget):
     def get_selected_ax_name(self):
         return self.select_axes_combo_box.currentText()
 
-    def get_selected_curve_name(self):
+    def get_current_curve_name(self):
         return self.select_curve_list.currentItem().text()
+
+    def get_selected_curves_names(self):
+        return [item.text() for item in self.select_curve_list.selectedItems()]
 
     def set_curve_label(self, label):
         self.curve_label_line_edit.setText(label)

--- a/qt/python/mantidqt/widgets/plotconfigdialog/curvestabwidget/view.py
+++ b/qt/python/mantidqt/widgets/plotconfigdialog/curvestabwidget/view.py
@@ -7,7 +7,7 @@
 #  This file is part of the mantid workbench.
 
 from qtpy.QtCore import Qt
-from qtpy.QtWidgets import QWidget
+from qtpy.QtWidgets import QWidget, QAbstractItemView
 
 from mantidqt.widgets.plotconfigdialog.curvestabwidget.errorbarstabwidget.view import ErrorbarsTabWidgetView
 from mantidqt.widgets.plotconfigdialog.curvestabwidget.linetabwidget.view import LineTabWidgetView
@@ -31,28 +31,30 @@ class CurvesTabWidgetView(QWidget):
         self.errorbars = ErrorbarsTabWidgetView(parent=self)
         self.tab_container.addTab(self.errorbars, "Errorbars")
         self.setAttribute(Qt.WA_DeleteOnClose, True)
+        self.select_curve_list.setSelectionMode(QAbstractItemView.ExtendedSelection)
 
     def populate_select_axes_combo_box(self, axes_names):
         with block_signals(self.select_axes_combo_box):
             self.select_axes_combo_box.clear()
             self.select_axes_combo_box.addItems(axes_names)
 
-    def populate_select_curve_combo_box(self, curve_names):
-        with block_signals(self.select_curve_combo_box):
-            self.select_curve_combo_box.clear()
-            self.select_curve_combo_box.addItems(curve_names)
+    def populate_select_curve_list(self, curve_names):
+        with block_signals(self.select_curve_list):
+            self.select_curve_list.clear()
+            self.select_curve_list.addItems(curve_names)
+            self.select_curve_list.setCurrentRow(0)
 
     def set_selected_curve_selector_text(self, new_text):
-        current_index = self.select_curve_combo_box.currentIndex()
-        self.select_curve_combo_box.setItemText(current_index, new_text)
+        current_item = self.select_curve_list.currentItem()
+        current_item.setText(new_text)
 
     def remove_select_axes_combo_box_selected_item(self):
         current_index = self.select_axes_combo_box.currentIndex()
         self.select_axes_combo_box.removeItem(current_index)
 
-    def remove_select_curve_combo_box_selected_item(self):
-        current_index = self.select_curve_combo_box.currentIndex()
-        self.select_curve_combo_box.removeItem(current_index)
+    def remove_select_curve_list_current_item(self):
+        current_item = self.select_curve_list.currentItem()
+        self.select_curve_list.removeItemWidget(current_item)
 
     # Tab enablers and disablers
     def set_errorbars_tab_enabled(self, enable):
@@ -63,7 +65,7 @@ class CurvesTabWidgetView(QWidget):
         return self.select_axes_combo_box.currentText()
 
     def get_selected_curve_name(self):
-        return self.select_curve_combo_box.currentText()
+        return self.select_curve_list.currentItem().text()
 
     def set_curve_label(self, label):
         self.curve_label_line_edit.setText(label)
@@ -90,3 +92,10 @@ class CurvesTabWidgetView(QWidget):
         self.line.update_fields(curve_props)
         self.marker.update_fields(curve_props)
         self.errorbars.update_fields(curve_props)
+
+    def enable_curve_config(self, enable=True):
+        self.hide_curve_check_box.setEnabled(enable)
+        self.curve_label_line_edit.setEnabled(enable)
+        tab_count = self.tab_container.count()
+        for i in range(0, tab_count):
+            self.tab_container.setTabEnabled(i, enable)

--- a/qt/python/mantidqt/widgets/plotconfigdialog/curvestabwidget/view.py
+++ b/qt/python/mantidqt/widgets/plotconfigdialog/curvestabwidget/view.py
@@ -6,7 +6,7 @@
 # SPDX - License - Identifier: GPL - 3.0 +
 #  This file is part of the mantid workbench.
 
-from qtpy.QtCore import Qt
+from qtpy.QtCore import Qt, Signal
 from qtpy.QtWidgets import QWidget, QAbstractItemView
 
 from mantidqt.widgets.plotconfigdialog.curvestabwidget.errorbarstabwidget.view import ErrorbarsTabWidgetView
@@ -17,6 +17,8 @@ from mantidqt.utils.qt import load_ui, block_signals
 
 
 class CurvesTabWidgetView(QWidget):
+
+    delete_key_pressed = Signal()
 
     def __init__(self, parent=None):
         super(CurvesTabWidgetView, self).__init__(parent=parent)
@@ -32,6 +34,10 @@ class CurvesTabWidgetView(QWidget):
         self.tab_container.addTab(self.errorbars, "Errorbars")
         self.setAttribute(Qt.WA_DeleteOnClose, True)
         self.select_curve_list.setSelectionMode(QAbstractItemView.ExtendedSelection)
+
+    def keyPressEvent(self, event):
+        if event.key() == Qt.Key_Delete:
+            self.delete_key_pressed.emit()
 
     def populate_select_axes_combo_box(self, axes_names):
         with block_signals(self.select_axes_combo_box):

--- a/qt/python/mantidqt/widgets/plotconfigdialog/test/test_apply_all_properties.py
+++ b/qt/python/mantidqt/widgets/plotconfigdialog/test/test_apply_all_properties.py
@@ -118,7 +118,7 @@ def _run_apply_properties_on_figure_with_curve(curve_view_mock):
     fig = figure()
     ax = fig.add_subplot(111)
     ax.errorbar([0, 1], [0, 1], yerr=[0.1, 0.2], label='old label')
-    curve_view_mock.get_selected_curve_name = CurveNameSideEffect('old label', 'New label', switch_count=6)
+    curve_view_mock.get_current_curve_name = CurveNameSideEffect('old label', 'New label', switch_count=6)
 
     with patch.object(AxesTabWidgetPresenter, 'update_view', mock_axes_tab_presenter_update_view):
         presenter = PlotConfigDialogPresenter(fig, view=Mock())
@@ -154,7 +154,7 @@ def _run_apply_properties_on_figure_with_legend(curve_view_mock):
     ax.plot([1, 2, 3], label='old label')
     legend = ax.legend()
     legend.get_frame().set_alpha(0.5)
-    curve_view_mock.get_selected_curve_name = CurveNameSideEffect('old label', 'New label', switch_count=3)
+    curve_view_mock.get_current_curve_name = CurveNameSideEffect('old label', 'New label', switch_count=3)
 
     with patch.object(AxesTabWidgetPresenter, 'update_view', mock_axes_tab_presenter_update_view):
         presenter = PlotConfigDialogPresenter(fig, view=Mock())


### PR DESCRIPTION
This PR replaces the combobox in the curves tab on the plotconfig gui with a list widget, so that multiple curves can be selected and deleted at once. Curves may also be deleted by pressing the delete key.

**To test:**
1. Open a plot with many curves and navigate to the curves tab in the plot config dialog
2. Test that selecting another curve updates the rest of the curves tab
3. Test that selecting multiple curves disables the rest of the curves tab and that returning to a single selection enables it again.
4. Test that removing multiple curves at once works
5. Test that the delete key removes the curves in the selection 

Fixes #29735

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
