### PR TITLE
Muon Analysis - Prevent errors when TF Asymmetry mode ticked

### DIFF
--- a/docs/source/release/v6.0.0/muon.rst
+++ b/docs/source/release/v6.0.0/muon.rst
@@ -25,6 +25,8 @@ Bug fixes
 - Fixed a bug where editing constraints would result in a crash.
 - Fixed a bug where global parameter values would reset when changing the displayed dataset.
 - Fixed a crash when adding the DynamicKuboToyabe function on the fitting tab of Muon Analysis.
+- Fixed an error caused by switching to Simultaneous fitting when TF Asymmetry mode is ticked.
+- Fixed an error caused by switching between the Run and Group/Pair selection when TF Asymmetry mode is ticked.
 
 ALC
 ---

--- a/scripts/Muon/GUI/Common/fitting_tab_widget/fitting_tab_presenter.py
+++ b/scripts/Muon/GUI/Common/fitting_tab_widget/fitting_tab_presenter.py
@@ -153,9 +153,9 @@ class FittingTabPresenter(object):
         self.update_model_from_view(fit_to_raw=self.view.fit_to_raw)
 
     def handle_fit_type_changed(self):
-        if self.view.tf_asymmetry_mode and self.view.is_simul_fit:
-            self.view.warning_popup("Cannot switch to simultaneous fitting while TF Asymmetry Mode is checked.")
-            self.view.is_simul_fit = False
+        if self.view.tf_asymmetry_mode:
+            self.view.warning_popup("Cannot change Fitting Mode while TF Asymmetry Mode is checked.")
+            self.view.is_simul_fit = not self.view.is_simul_fit
             return
 
         self.view.undo_fit_button.setEnabled(False)
@@ -398,6 +398,11 @@ class FittingTabPresenter(object):
         self.selected_single_fit_notifier.notify_subscribers(self.get_selected_fit_workspaces())
 
     def handle_fit_by_changed(self):
+        if self.view.tf_asymmetry_mode:
+            self.view.warning_popup("Cannot change Run - Group/Pair selection while TF Asymmetry Mode is checked.")
+            self.view.simultaneous_fit_by = "Run" if self.view.simultaneous_fit_by == "Group/Pair" else "Group/Pair"
+            return
+
         self.manual_selection_made = False  # reset manual selection flag
         self.update_selected_workspace_list_for_fit()
         self.view.simul_fit_by_specifier.setEnabled(True)

--- a/scripts/Muon/GUI/Common/fitting_tab_widget/fitting_tab_view.py
+++ b/scripts/Muon/GUI/Common/fitting_tab_widget/fitting_tab_view.py
@@ -224,6 +224,14 @@ class FittingTabView(QtWidgets.QWidget, ui_fitting_tab):
     def simultaneous_fit_by(self):
         return self.simul_fit_by_combo.currentText()
 
+    @simultaneous_fit_by.setter
+    def simultaneous_fit_by(self, fit_by_text):
+        index = self.simul_fit_by_combo.findText(fit_by_text)
+        if index != -1:
+            self.simul_fit_by_combo.blockSignals(True)
+            self.simul_fit_by_combo.setCurrentIndex(index)
+            self.simul_fit_by_combo.blockSignals(False)
+
     @property
     def simultaneous_fit_by_specifier(self):
         return self.simul_fit_by_specifier.currentText()

--- a/scripts/Muon/GUI/Common/fitting_tab_widget/fitting_tab_view.py
+++ b/scripts/Muon/GUI/Common/fitting_tab_widget/fitting_tab_view.py
@@ -98,7 +98,7 @@ class FittingTabView(QtWidgets.QWidget, ui_fitting_tab):
             self.fit_status_chi_squared.setText('Chi squared: {}'.format(output_chi_squared))
             return
 
-        if self.is_simul_fit():
+        if self.is_simul_fit:
             self.function_browser.blockSignals(True)
             self.function_browser.updateMultiDatasetParameters(fit_function)
             self.function_browser.blockSignals(False)
@@ -296,8 +296,15 @@ class FittingTabView(QtWidgets.QWidget, ui_fitting_tab):
         self.simul_fit_by_combo.setEnabled(True)
         self.simul_fit_by_specifier.setEnabled(True)
 
+    @property
     def is_simul_fit(self):
         return self.simul_fit_checkbox.isChecked()
+
+    @is_simul_fit.setter
+    def is_simul_fit(self, simultaneous):
+        self.simul_fit_checkbox.blockSignals(True)
+        self.simul_fit_checkbox.setChecked(simultaneous)
+        self.simul_fit_checkbox.blockSignals(False)
 
     def setup_fit_by_specifier(self, choices):
         self.simul_fit_by_specifier.blockSignals(True)

--- a/scripts/test/Muon/fitting_tab_widget/fitting_tab_presenter_test.py
+++ b/scripts/test/Muon/fitting_tab_widget/fitting_tab_presenter_test.py
@@ -240,7 +240,7 @@ class FittingTabPresenterTest(unittest.TestCase):
     def test_on_function_structure_changed_updates_stored_fit_function_for_simultaneous_fit(self):
         self.presenter.selected_data = ['MUSR22725; Group; top; Asymmetry', 'MUSR22725; Group; bottom; Asymmetry']
 
-        self.view.is_simul_fit = mock.MagicMock(return_value=True)
+        self.view.is_simul_fit = True
         self.view.function_browser.setFunction(EXAMPLE_MULTI_DOMAIN_FUNCTION)
 
         self.assertEqual(str(self.presenter._fit_function[0]), EXAMPLE_MULTI_DOMAIN_FUNCTION)
@@ -248,7 +248,7 @@ class FittingTabPresenterTest(unittest.TestCase):
     def test_updating_function_parameters_updates_relevant_stored_function_for_single_fit(self):
         self.presenter.selected_data = ['MUSR22725; Group; top; Asymmetry', 'MUSR22725; Group; bottom; Asymmetry',
                                         'MUSR22725; Group; fwd; Asymmetry']
-        self.view.is_simul_fit = mock.MagicMock(return_value=False)
+        self.view.is_simul_fit = False
         self.view.function_browser.setFunction(EXAMPLE_MULTI_DOMAIN_FUNCTION)
         self.view.parameter_display_combo.setCurrentIndex(2)
 
@@ -262,7 +262,7 @@ class FittingTabPresenterTest(unittest.TestCase):
     def test_updating_function_parameters_updates_relevant_stored_function_for_simul_fit(self):
         self.presenter.selected_data = ['MUSR22725; Group; top; Asymmetry', 'MUSR22725; Group; bottom; Asymmetry',
                                         'MUSR22725; Group; fwd; Asymmetry']
-        self.view.is_simul_fit = mock.MagicMock(return_value=True)
+        self.view.is_simul_fit = True
         self.view.function_browser.setFunction(EXAMPLE_MULTI_DOMAIN_FUNCTION)
         self.view.parameter_display_combo.setCurrentIndex(1)
         self.view.function_browser.setParameter('A', 3)
@@ -388,7 +388,7 @@ class FittingTabPresenterTest(unittest.TestCase):
         self.assertEqual(self.presenter.get_workspace_selected_list.call_count, 1)
 
     def test_update_selected_ws_guess_non(self):
-        self.view.is_simul_fit = mock.MagicMock(return_value=True)
+        self.view.is_simul_fit = True
         self.presenter.manual_selection_made = True
         self.presenter.update_selected_time_workspace_guess = mock.Mock()
         self.presenter.update_selected_frequency_workspace_guess = mock.Mock()
@@ -614,7 +614,7 @@ class FittingTabPresenterTest(unittest.TestCase):
         self.view.tf_asymmetry_mode = True
         self.presenter._tf_asymmetry_mode = True
         self.view.tf_asymmetry_mode_checkbox.blockSignals(False)
-        self.view.is_simul_fit = mock.MagicMock(return_value=False)
+        self.view.is_simul_fit = False
         fit_function = FunctionFactory.createInitialized('name=GausOsc,A=0.2,Sigma=0.2,Frequency=0.1,Phi=0')
         self.presenter.model.convert_to_tf_function.return_value = fit_function
 
@@ -634,7 +634,7 @@ class FittingTabPresenterTest(unittest.TestCase):
         self.view.tf_asymmetry_mode = True
         self.presenter._tf_asymmetry_mode = True
         self.view.tf_asymmetry_mode_checkbox.blockSignals(False)
-        self.view.is_simul_fit = mock.MagicMock(return_value=True)
+        self.view.is_simul_fit = True
         fit_function = FunctionFactory.createInitialized('name=GausOsc,A=0.2,Sigma=0.2,Frequency=0.1,Phi=0')
         self.presenter.model.convert_to_tf_function.return_value = fit_function
 
@@ -706,7 +706,7 @@ class FittingTabPresenterTest(unittest.TestCase):
         self.presenter.model.update_model_fit_options.assert_called_once_with(fit_to_raw=True)
 
     def test_that_model_is_updated_when_new_data_is_loaded_in_simultaneous_mode(self):
-        self.view.is_simul_fit = mock.MagicMock(return_value=True)
+        self.view.is_simul_fit = True
 
         self.presenter.handle_new_data_loaded()
 

--- a/scripts/test/Muon/fitting_tab_widget/fitting_tab_presenter_test.py
+++ b/scripts/test/Muon/fitting_tab_widget/fitting_tab_presenter_test.py
@@ -526,17 +526,21 @@ class FittingTabPresenterTest(unittest.TestCase):
                                   'Mode': 'Extract', 'CopyTies': False})
 
     def test_handle_fit_type_changed_reverts_changed_and_shows_error_tf_asymmetry_mode_is_on(self):
+        self.view.tf_asymmetry_mode_checkbox.blockSignals(True)
         self.view.tf_asymmetry_mode = True
+        self.view.tf_asymmetry_mode_checkbox.blockSignals(False)
 
         self.view.is_simul_fit = True
-        self.presenter.handle_fit_by_changed()
+        self.presenter.handle_fit_type_changed()
 
         self.view.warning_popup.assert_called_once_with(
             "Cannot change Fitting Mode while TF Asymmetry Mode is checked.")
         self.assertEqual(self.view.is_simul_fit, False)
 
     def test_handle_fit_by_changed_reverts_changed_and_shows_error_tf_asymmetry_mode_is_on(self):
+        self.view.tf_asymmetry_mode_checkbox.blockSignals(True)
         self.view.tf_asymmetry_mode = True
+        self.view.tf_asymmetry_mode_checkbox.blockSignals(False)
 
         self.view.simultaneous_fit_by = "Group/Pair"
         self.presenter.handle_fit_by_changed()

--- a/scripts/test/Muon/fitting_tab_widget/fitting_tab_presenter_test.py
+++ b/scripts/test/Muon/fitting_tab_widget/fitting_tab_presenter_test.py
@@ -525,6 +525,26 @@ class FittingTabPresenterTest(unittest.TestCase):
         self.assertEqual(result, {'InputFunction': fit_function, 'WorkspaceList': [new_workspace_list[0]],
                                   'Mode': 'Extract', 'CopyTies': False})
 
+    def test_handle_fit_type_changed_reverts_changed_and_shows_error_tf_asymmetry_mode_is_on(self):
+        self.view.tf_asymmetry_mode = True
+
+        self.view.is_simul_fit = True
+        self.presenter.handle_fit_by_changed()
+
+        self.view.warning_popup.assert_called_once_with(
+            "Cannot change Fitting Mode while TF Asymmetry Mode is checked.")
+        self.assertEqual(self.view.is_simul_fit, False)
+
+    def test_handle_fit_by_changed_reverts_changed_and_shows_error_tf_asymmetry_mode_is_on(self):
+        self.view.tf_asymmetry_mode = True
+
+        self.view.simultaneous_fit_by = "Group/Pair"
+        self.presenter.handle_fit_by_changed()
+
+        self.view.warning_popup.assert_called_once_with(
+            "Cannot change Run - Group/Pair selection while TF Asymmetry Mode is checked.")
+        self.assertEqual(self.view.simultaneous_fit_by, "Run")
+
     def test_handle_asymmetry_mode_changed_reverts_changed_and_shows_error_if_non_group_selected(self):
         new_workspace_list = ['MUSR22725; Group; top; Asymmetry', 'MUSR22725; Group; bottom; Asymmetry',
                               'MUSR22725; Pair; fwd; Long']


### PR DESCRIPTION
**Description of work.**
This PR fixes an error when:
- switching between the `Run` and `Group/Pair` selection in Simultaneous mode when `TF Asymmetry mode` is ticked.
- switching between Simultaneous and Single fitting when `TF Asymmetry mode` is ticked.

**To test:**
Follow the testing instructions in the issue. A popup warning message should appear, and the GUI reset to the previous state.

Fixes #30149

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
