### PR TITLE
Fix Crash In MA When Pressing Clear All And Try To Simul Fit

### DIFF
--- a/docs/source/release/v6.0.0/muon.rst
+++ b/docs/source/release/v6.0.0/muon.rst
@@ -28,6 +28,7 @@ Bug fixes
 - Fixed a crash when adding the DynamicKuboToyabe function on the fitting tab of Muon Analysis.
 - Fixed an error caused by switching to Simultaneous fitting when TF Asymmetry mode is ticked.
 - Fixed an error caused by switching between the Run and Group/Pair selection when TF Asymmetry mode is ticked.
+- Fixed a crash when trying to do a simultaneous fit with no data loaded after pressing clear all.
 
 ALC
 ---

--- a/scripts/Muon/GUI/Common/fitting_tab_widget/fitting_tab_presenter.py
+++ b/scripts/Muon/GUI/Common/fitting_tab_widget/fitting_tab_presenter.py
@@ -70,7 +70,9 @@ class FittingTabPresenter(object):
         self.disable_editing_notifier = GenericObservable()
 
     def disable_view(self):
-        self.view.setEnabled(False)
+        self.update_selected_workspace_list_for_fit()
+        if not self.selected_data:
+            self.view.setEnabled(False)
 
     def enable_view(self):
         if self.selected_data:

--- a/scripts/Muon/GUI/Common/phase_table_widget/phase_table_presenter.py
+++ b/scripts/Muon/GUI/Common/phase_table_widget/phase_table_presenter.py
@@ -225,6 +225,11 @@ class PhaseTablePresenter(object):
         self.view.set_group_combo_boxes(self.context.group_pair_context.group_names)
         self.update_model_from_view()
 
+        if self.view.input_workspace == "":
+            self.view.disable_widget()
+        else:
+            self.view.setEnabled(True)
+
     def update_current_groups_list(self):
         self.view.set_group_combo_boxes(self.context.group_pair_context.group_names)
         self.update_model_from_view()

--- a/scripts/Muon/GUI/Common/phase_table_widget/phase_table_view.py
+++ b/scripts/Muon/GUI/Common/phase_table_widget/phase_table_view.py
@@ -22,6 +22,7 @@ class PhaseTableView(QtWidgets.QWidget, ui_muon_phases_tab):
 
         self.backward_group_combo.currentIndexChanged.connect(self.ensure_groups_different)
         self.forward_group_combo.currentIndexChanged.connect(self.ensure_groups_different)
+        self.setEnabled(False)
 
     @property
     def first_good_time(self):

--- a/scripts/Muon/GUI/Common/seq_fitting_tab_widget/seq_fitting_tab_view.py
+++ b/scripts/Muon/GUI/Common/seq_fitting_tab_widget/seq_fitting_tab_view.py
@@ -22,6 +22,7 @@ class SeqFittingTabView(QtWidgets.QWidget, ui_seq_fitting_tab):
         self.setupUi(self)
         self.fit_table = SequentialTableWidget(parent)
         self.tableLayout.addWidget(self.fit_table.widget)
+        self.setEnabled(False)
 
     def warning_popup(self, message):
         warning(message, parent=self)

--- a/scripts/Muon/GUI/FrequencyDomainAnalysis/Transform/transform_widget.py
+++ b/scripts/Muon/GUI/FrequencyDomainAnalysis/Transform/transform_widget.py
@@ -35,6 +35,7 @@ class TransformWidget(QtWidgets.QWidget):
         self.updateDisplay('FFT')
         self.update_view_from_model_observer = GenericObserver(
             self.update_view_from_model)
+        self.disable_view()
         # to make it compatable with the old GUI
         try:
             self.load.update_view_from_model_notifier.add_subscriber(
@@ -71,6 +72,10 @@ class TransformWidget(QtWidgets.QWidget):
     def handle_new_data_loaded(self):
         self._maxent.runChanged()
         self._fft.runChanged()
+        if self.getViews()["FFT"].workspace == "":
+            self.disable_view()
+        else:
+            self.enable_view()
 
     def handle_new_instrument(self):
         self._maxent.clear()

--- a/scripts/Muon/GUI/FrequencyDomainAnalysis/frequency_domain_analysis_2.py
+++ b/scripts/Muon/GUI/FrequencyDomainAnalysis/frequency_domain_analysis_2.py
@@ -252,6 +252,9 @@ class FrequencyAnalysisGui(QtWidgets.QMainWindow):
         self.load_widget.load_widget.loadNotifier.add_subscriber(
             self.phase_tab.phase_table_presenter.run_change_observer)
 
+        self.load_widget.load_widget.loadNotifier.add_subscriber(
+            self.fitting_tab.fitting_tab_presenter.disable_tab_observer)
+
     def setup_gui_variable_observers(self):
         self.context.gui_context.gui_variables_notifier.add_subscriber(
             self.grouping_tab_widget.group_tab_presenter.gui_variables_observer

--- a/scripts/Muon/GUI/MuonAnalysis/muon_analysis_2.py
+++ b/scripts/Muon/GUI/MuonAnalysis/muon_analysis_2.py
@@ -232,6 +232,9 @@ class MuonAnalysisGui(QtWidgets.QMainWindow):
         self.load_widget.load_widget.loadNotifier.add_subscriber(
             self.fitting_tab.fitting_tab_presenter.disable_tab_observer)
 
+        self.load_widget.load_widget.loadNotifier.add_subscriber(
+            self.seq_fitting_tab.seq_fitting_tab_presenter.disable_tab_observer)
+
     def setup_gui_variable_observers(self):
         self.context.gui_context.gui_variables_notifier.add_subscriber(
             self.grouping_tab_widget.group_tab_presenter.gui_variables_observer)

--- a/scripts/Muon/GUI/MuonAnalysis/muon_analysis_2.py
+++ b/scripts/Muon/GUI/MuonAnalysis/muon_analysis_2.py
@@ -229,6 +229,9 @@ class MuonAnalysisGui(QtWidgets.QMainWindow):
         self.load_widget.load_widget.loadNotifier.add_subscriber(
             self.phase_tab.phase_table_presenter.run_change_observer)
 
+        self.load_widget.load_widget.loadNotifier.add_subscriber(
+            self.fitting_tab.fitting_tab_presenter.disable_tab_observer)
+
     def setup_gui_variable_observers(self):
         self.context.gui_context.gui_variables_notifier.add_subscriber(
             self.grouping_tab_widget.group_tab_presenter.gui_variables_observer)

--- a/scripts/test/Muon/phase_table_widget/phase_table_presenter_test.py
+++ b/scripts/test/Muon/phase_table_widget/phase_table_presenter_test.py
@@ -93,15 +93,16 @@ class PhaseTablePresenterTest(unittest.TestCase):
         workspace_wrapper.show.assert_called_once_with()
 
     @mock.patch('Muon.GUI.Common.phase_table_widget.phase_table_presenter.run_CalMuonDetectorPhases')
-    def test_handle_calculate_phase_table_clicked_behaves_correctly_for_succesful_calculation(self, run_algorith_mock):
+    def test_handle_calculate_phase_table_clicked_behaves_correctly_for_succesful_calculation(self, run_algorithm_mock):
         detector_table_mock = mock.MagicMock()
         self.view.set_input_combo_box(['MUSR22222_raw_data_period_1'])
         self.context.getGroupedWorkspaceNames = mock.MagicMock(return_value=['MUSR22222_raw_data_period_1'])
         self.context.phase_context.options_dict['input_workspace'] = 'MUSR22222_raw_data_period_1'
         self.presenter.update_view_from_model()
-        run_algorith_mock.return_value = (detector_table_mock, mock.MagicMock())
+        run_algorithm_mock.return_value = (detector_table_mock, mock.MagicMock())
         self.presenter.add_phase_table_to_ADS = mock.MagicMock()
 
+        self.presenter.update_current_run_list()
         self.presenter.handle_calulate_phase_table_clicked()
         self.wait_for_thread(self.presenter.calculation_thread)
 
@@ -109,14 +110,16 @@ class PhaseTablePresenterTest(unittest.TestCase):
         self.assertTrue(self.view.isEnabled())
 
     @mock.patch('Muon.GUI.Common.phase_table_widget.phase_table_presenter.run_CalMuonDetectorPhases')
-    def test_handle_calculate_phase_table_clicked_behaves_correctly_for_error_in_calculation(self, run_algorith_mock):
+    def test_handle_calculate_phase_table_clicked_behaves_correctly_for_error_in_calculation(self, run_algorithm_mock):
+        self.context.getGroupedWorkspaceNames = mock.MagicMock(return_value=['MUSR22222_raw_data_period_1'])
         self.context.phase_context.options_dict['input_workspace'] = 'MUSR22222_raw_data_period_1'
         self.presenter.update_view_from_model()
-        run_algorith_mock.side_effect = RuntimeError('CalMuonDetectorPhases has failed')
+        run_algorithm_mock.side_effect = RuntimeError('CalMuonDetectorPhases has failed')
         self.presenter.add_phase_table_to_ADS = mock.MagicMock()
         self.presenter.calculate_base_name_and_group = mock.MagicMock(
             return_value=('MUSR22222_raw_data_period_1', 'MUSR22222 PhaseTable'))
 
+        self.presenter.update_current_run_list()
         self.presenter.handle_calulate_phase_table_clicked()
         self.wait_for_thread(self.presenter.calculation_thread)
 


### PR DESCRIPTION
**Description of work.**
Added subscriber to disable fitting tab when clear all pressed

**To test:**
1. Load in some data
2. Press clear all
3. Check fitting tab is disabled

Fixes #30166 

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
