### PR TITLE
Fix bug with X mask in IndirectDataAnalysis

### DIFF
--- a/Framework/CurveFitting/inc/MantidCurveFitting/Algorithms/PlotPeakByLogValue.h
+++ b/Framework/CurveFitting/inc/MantidCurveFitting/Algorithms/PlotPeakByLogValue.h
@@ -61,6 +61,7 @@ public:
 private:
   // Overridden Algorithm methods
   void init() override;
+  std::map<std::string, std::string> validateInputs() override;
   void exec() override;
 
   /// Set any WorkspaceIndex attributes in the fitting function
@@ -71,7 +72,7 @@ private:
   runSingleFit(bool createFitOutput, bool outputCompositeMembers,
                bool outputConvolvedMembers, const API::IFunction_sptr &ifun,
                const InputSpectraToFit &data, double startX, double endX,
-               std::vector<double> exclude);
+               const std::string &exclude);
 
   double calculateLogValue(const std::string &logName,
                            const InputSpectraToFit &data);
@@ -101,8 +102,8 @@ private:
   std::string getMinimizerString(const std::string &wsName,
                                  const std::string &wsIndex);
 
-  /// Create a vecotr of linked exclude starts and ends
-  std::vector<std::vector<double>> getExclude(size_t numSpectra);
+  /// Create a vector of linked exclude starts and ends
+  std::vector<std::string> getExclude(const size_t numSpectra);
 
   /// Base name of output workspace
   std::string m_baseName;

--- a/Framework/CurveFitting/inc/MantidCurveFitting/Algorithms/PlotPeakByLogValue.h
+++ b/Framework/CurveFitting/inc/MantidCurveFitting/Algorithms/PlotPeakByLogValue.h
@@ -70,7 +70,8 @@ private:
   std::shared_ptr<Algorithm>
   runSingleFit(bool createFitOutput, bool outputCompositeMembers,
                bool outputConvolvedMembers, const API::IFunction_sptr &ifun,
-               const InputSpectraToFit &data, double startX, double endX);
+               const InputSpectraToFit &data, double startX, double endX,
+               std::vector<double> exclude);
 
   double calculateLogValue(const std::string &logName,
                            const InputSpectraToFit &data);
@@ -99,6 +100,9 @@ private:
   /// Create a minimizer string based on template string provided
   std::string getMinimizerString(const std::string &wsName,
                                  const std::string &wsIndex);
+
+  /// Create a vecotr of linked exclude starts and ends
+  std::vector<std::vector<double>> getExclude(size_t numSpectra);
 
   /// Base name of output workspace
   std::string m_baseName;

--- a/Framework/CurveFitting/src/Algorithms/PlotPeakByLogValue.cpp
+++ b/Framework/CurveFitting/src/Algorithms/PlotPeakByLogValue.cpp
@@ -182,7 +182,7 @@ std::map<std::string, std::string> PlotPeakByLogValue::validateInputs() {
   const std::vector<InputSpectraToFit> wsNames =
       makeNames(inputList, default_wi, default_spec);
   std::vector<std::string> excludeList = getProperty("ExcludeMultiple");
-  if (!wsNames.size() == excludeList.size()) {
+  if (!excludeList.empty() && excludeList.size() != wsNames.size()) {
     errors["ExcludeMultiple"] =
         "ExcludeMultiple must be the same size has the number of spectra.";
   }

--- a/Framework/CurveFitting/src/Algorithms/PlotPeakByLogValue.cpp
+++ b/Framework/CurveFitting/src/Algorithms/PlotPeakByLogValue.cpp
@@ -159,10 +159,11 @@ void PlotPeakByLogValue::init() {
                   "A list of pairs of real numbers, defining the regions to "
                   "exclude from the fit for all spectra.");
 
-  declareProperty(std::make_unique<ArrayProperty<std::string>>("ExcludeMultiple", ""),
-                  "A list of Exclusion ranges, defining the regions to "
-                  "exclude from the fit for each spectra. Must have the "
-                  "same number of sets as the number of the spectra.");
+  declareProperty(
+      std::make_unique<ArrayProperty<std::string>>("ExcludeMultiple", ""),
+      "A list of Exclusion ranges, defining the regions to "
+      "exclude from the fit for each spectra. Must have the "
+      "same number of sets as the number of the spectra.");
 
   declareProperty("IgnoreInvalidData", false,
                   "Flag to ignore infinities, NaNs and data with zero errors.");

--- a/Framework/CurveFitting/src/Algorithms/PlotPeakByLogValue.cpp
+++ b/Framework/CurveFitting/src/Algorithms/PlotPeakByLogValue.cpp
@@ -566,8 +566,9 @@ std::vector<std::string>
 PlotPeakByLogValue::getExclude(const size_t numSpectra) {
   std::string exclude = getPropertyValue("Exclude");
   std::vector<std::string> excludeList = getProperty("ExcludeMultiple");
-  if (excludeList.size() == 0) {
+  if (excludeList.empty()) {
     std::vector<std::string> excludeVector;
+    excludeVector.reserve(numSpectra);
     for (size_t i = 0; i < numSpectra; i++) {
       excludeVector.emplace_back(exclude);
     }

--- a/Framework/CurveFitting/src/Algorithms/PlotPeakByLogValue.cpp
+++ b/Framework/CurveFitting/src/Algorithms/PlotPeakByLogValue.cpp
@@ -157,7 +157,12 @@ void PlotPeakByLogValue::init() {
 
   declareProperty(std::make_unique<ArrayProperty<double>>("Exclude", ""),
                   "A list of pairs of real numbers, defining the regions to "
-                  "exclude from the fit.");
+                  "exclude from the fit for all spectra.");
+
+  declareProperty(std::make_unique<ArrayProperty<std::string>>("ExcludeMultiple", ""),
+                  "A list of Exclusion ranges, defining the regions to "
+                  "exclude from the fit for each spectra. Must have the "
+                  "same number of sets as the number of the spectra.");
 
   declareProperty("IgnoreInvalidData", false,
                   "Flag to ignore infinities, NaNs and data with zero errors.");
@@ -166,6 +171,21 @@ void PlotPeakByLogValue::init() {
       "OutputFitStatus", false,
       "Flag to output fit status information which consists of the fit "
       "OutputStatus and the OutputChiSquared");
+}
+
+std::map<std::string, std::string> PlotPeakByLogValue::validateInputs() {
+  std::map<std::string, std::string> errors;
+  std::string inputList = getPropertyValue("Input");
+  int default_wi = getProperty("WorkspaceIndex");
+  int default_spec = getProperty("Spectrum");
+  const std::vector<InputSpectraToFit> wsNames =
+      makeNames(inputList, default_wi, default_spec);
+  std::vector<std::string> excludeList = getProperty("ExcludeMultiple");
+  if (!wsNames.size() == excludeList.size()) {
+    errors["ExcludeMultiple"] =
+        "ExcludeMultiple must be the same size has the number of spectra.";
+  }
+  return errors;
 }
 
 /**
@@ -190,7 +210,7 @@ void PlotPeakByLogValue::exec() {
   m_baseName = getPropertyValue("OutputWorkspace");
   std::vector<double> startX = getProperty("StartX");
   std::vector<double> endX = getProperty("EndX");
-  std::vector<std::vector<double>> exclude = getExclude(wsNames.size());
+  std::vector<std::string> exclude = getExclude(wsNames.size());
 
   bool isDataName = false; // if true first output column is of type string and
                            // is the data source name
@@ -430,7 +450,7 @@ std::shared_ptr<Algorithm> PlotPeakByLogValue::runSingleFit(
     bool createFitOutput, bool outputCompositeMembers,
     bool outputConvolvedMembers, const IFunction_sptr &ifun,
     const InputSpectraToFit &data, double startX, double endX,
-    std::vector<double> exclude) {
+    const std::string &exclude) {
   g_log.debug() << "Fitting " << data.ws->getName() << " index " << data.i
                 << " with \n";
   g_log.debug() << ifun->asString() << '\n';
@@ -541,20 +561,19 @@ std::string PlotPeakByLogValue::getMinimizerString(const std::string &wsName,
   return format;
 }
 
-std::vector<std::vector<double>>
-PlotPeakByLogValue::getExclude(size_t numSpectra) {
-  std::vector<double> excludeList = getProperty("Exclude");
-  std::vector<std::vector<double>> excludeVector;
-  for (size_t i = 0; i < numSpectra * 2; i += 2) {
-    if (i < excludeList.size()) {
-      std::vector<double> excludePair = {excludeList[i], excludeList[i + 1]};
-      excludeVector.push_back(std::vector<double>(excludePair));
-    } else {
-      std::vector<double> excludePair = {0.0, 0.0};
-      excludeVector.push_back(std::vector<double>(excludePair));
+std::vector<std::string>
+PlotPeakByLogValue::getExclude(const size_t numSpectra) {
+  std::string exclude = getPropertyValue("Exclude");
+  std::vector<std::string> excludeList = getProperty("ExcludeMultiple");
+  if (excludeList.size() == 0) {
+    std::vector<std::string> excludeVector;
+    for (size_t i = 0; i < numSpectra; i++) {
+      excludeVector.emplace_back(exclude);
     }
+    return excludeVector;
+  } else {
+    return excludeList;
   }
-  return excludeVector;
 }
 
 } // namespace Algorithms

--- a/Framework/CurveFitting/src/Algorithms/PlotPeakByLogValue.cpp
+++ b/Framework/CurveFitting/src/Algorithms/PlotPeakByLogValue.cpp
@@ -261,13 +261,11 @@ void PlotPeakByLogValue::exec() {
                          outputConvolvedMembers, ifun, data, EMPTY_DBL(),
                          EMPTY_DBL(), exclude[i]);
     } else if (startX.size() == 1) {
-      fit =
-          runSingleFit(createFitOutput, outputCompositeMembers,
+      fit = runSingleFit(createFitOutput, outputCompositeMembers,
                          outputConvolvedMembers, ifun, data, startX[0], endX[0],
                          exclude[i]);
     } else {
-      fit =
-          runSingleFit(createFitOutput, outputCompositeMembers,
+      fit = runSingleFit(createFitOutput, outputCompositeMembers,
                          outputConvolvedMembers, ifun, data, startX[i], endX[i],
                          exclude[i]);
     }
@@ -543,10 +541,11 @@ std::string PlotPeakByLogValue::getMinimizerString(const std::string &wsName,
   return format;
 }
 
-std::vector<std::vector<double>> PlotPeakByLogValue::getExclude(size_t numSpectra) {
+std::vector<std::vector<double>>
+PlotPeakByLogValue::getExclude(size_t numSpectra) {
   std::vector<double> excludeList = getProperty("Exclude");
   std::vector<std::vector<double>> excludeVector;
-  for (size_t i = 0; i < numSpectra*2; i += 2) {
+  for (size_t i = 0; i < numSpectra * 2; i += 2) {
     if (i < excludeList.size()) {
       std::vector<double> excludePair = {excludeList[i], excludeList[i + 1]};
       excludeVector.push_back(std::vector<double>(excludePair));

--- a/Framework/CurveFitting/src/Algorithms/QENSFitSequential.cpp
+++ b/Framework/CurveFitting/src/Algorithms/QENSFitSequential.cpp
@@ -504,6 +504,12 @@ void QENSFitSequential::init() {
                   "A list of pairs of real numbers, defining the regions to "
                   "exclude from the fit.");
 
+  declareProperty(
+      std::make_unique<ArrayProperty<std::string>>("ExcludeMultiple", ""),
+      "A list of Exclusion ranges, defining the regions to "
+      "exclude from the fit for each spectra. Must have the "
+      "same number of sets as the number of the spectra.");
+
   declareProperty("IgnoreInvalidData", false,
                   "Flag to ignore infinities, NaNs and data with zero errors.");
 
@@ -812,6 +818,8 @@ void QENSFitSequential::renameGroupWorkspace(
 ITableWorkspace_sptr QENSFitSequential::performFit(const std::string &input,
                                                    const std::string &output) {
   const std::vector<double> exclude = getProperty("Exclude");
+  const std::vector<std::string> excludeMultiple =
+      getProperty("ExcludeMultiple");
   const bool convolveMembers = getProperty("ConvolveMembers");
   const bool outputCompositeMembers = getProperty("OutputCompositeMembers");
   const bool passWsIndex = getProperty("PassWSIndexToFunction");
@@ -827,6 +835,7 @@ ITableWorkspace_sptr QENSFitSequential::performFit(const std::string &input,
   plotPeaks->setProperty("StartX", getPropertyValue("StartX"));
   plotPeaks->setProperty("EndX", getPropertyValue("EndX"));
   plotPeaks->setProperty("Exclude", exclude);
+  plotPeaks->setProperty("ExcludeMultiple", excludeMultiple);
   plotPeaks->setProperty("IgnoreInvalidData", ignoreInvalidData);
   plotPeaks->setProperty("FitType", "Sequential");
   plotPeaks->setProperty("CreateOutput", true);

--- a/Framework/CurveFitting/test/Algorithms/ConvolutionFitSequentialTest.h
+++ b/Framework/CurveFitting/test/Algorithms/ConvolutionFitSequentialTest.h
@@ -184,7 +184,6 @@ public:
     // Check oringal Log was copied correctly
     auto &memberRun = matrixMember->mutableRun();
     auto &originalRun = redWs->mutableRun();
-    auto foo = memberRun.getLogData();
     TS_ASSERT_EQUALS(memberRun.getLogData().at(3)->value(),
                      originalRun.getLogData().at(1)->value());
 

--- a/Framework/CurveFitting/test/Algorithms/PlotPeakByLogValueTest.h
+++ b/Framework/CurveFitting/test/Algorithms/PlotPeakByLogValueTest.h
@@ -569,18 +569,11 @@ public:
   }
 
   void test_single_exclude_range_single_Spectra() {
-    HistogramData::Points points{-2, -1, 0, 1, 2};
-    HistogramData::Counts counts(points.size(), 0.0);
-    // This value should be excluded.
-    counts.mutableData()[2] = 10.0;
-    MatrixWorkspace_sptr ws(DataObjects::create<Workspace2D>(
-                                1, HistogramData::Histogram(points, counts))
-                                .release());
-    AnalysisDataService::Instance().addOrReplace("InputWS", ws);
+    createData();
 
     PlotPeakByLogValue alg;
     alg.initialize();
-    alg.setPropertyValue("Input", "InputWS,i0");
+    alg.setPropertyValue("Input", "PlotPeakGroup_0");
     alg.setPropertyValue("Exclude", "-0.5, 0.5");
     alg.setPropertyValue("OutputWorkspace", "PlotPeakResult");
     alg.setProperty("CreateOutput", true);
@@ -589,22 +582,17 @@ public:
     alg.execute();
 
     TS_ASSERT(alg.isExecuted());
-    AnalysisDataService::Instance().remove("InputWS");
+
+    deleteData();
+    WorkspaceCreationHelper::removeWS("PlotPeakResult");
   }
 
   void test_single_exclude_range_multiple_Spectra() {
-    HistogramData::Points points{-2, -1, 0, 1, 2};
-    HistogramData::Counts counts(points.size(), 0.0);
-    // This value should be excluded.
-    counts.mutableData()[2] = 10.0;
-    MatrixWorkspace_sptr ws(DataObjects::create<Workspace2D>(
-                                2, HistogramData::Histogram(points, counts))
-                                .release());
-    AnalysisDataService::Instance().addOrReplace("InputWS", ws);
+    createData();
 
     PlotPeakByLogValue alg;
     alg.initialize();
-    alg.setPropertyValue("Input", "InputWS,i0");
+    alg.setPropertyValue("Input", "PlotPeakGroup_0;PlotPeakGroup_1");
     alg.setPropertyValue("Exclude", "-0.5, 0.5");
     alg.setPropertyValue("OutputWorkspace", "PlotPeakResult");
     alg.setProperty("CreateOutput", true);
@@ -613,24 +601,19 @@ public:
     alg.execute();
 
     TS_ASSERT(alg.isExecuted());
-    AnalysisDataService::Instance().remove("InputWS");
+
+    deleteData();
+    WorkspaceCreationHelper::removeWS("PlotPeakResult");
   }
 
   void test_multiple_exclude_range_multiple_Spectra() {
-    HistogramData::Points points{-2, -1, 0, 1, 2};
-    HistogramData::Counts counts(points.size(), 0.0);
-    // This value should be excluded.
-    counts.mutableData()[2] = 10.0;
-    MatrixWorkspace_sptr ws(DataObjects::create<Workspace2D>(
-                                2, HistogramData::Histogram(points, counts))
-                                .release());
-    AnalysisDataService::Instance().addOrReplace("InputWS", ws);
+    createData();
     std::vector<std::string> excludeRanges;
     excludeRanges.emplace_back("-0.5, 0.0");
     excludeRanges.emplace_back("0.5, 1.5");
     PlotPeakByLogValue alg;
     alg.initialize();
-    alg.setPropertyValue("Input", "InputWS,i0");
+    alg.setPropertyValue("Input", "PlotPeakGroup_0;PlotPeakGroup_1");
     alg.setProperty("ExcludeMultiple", excludeRanges);
     alg.setPropertyValue("OutputWorkspace", "PlotPeakResult");
     alg.setProperty("CreateOutput", true);
@@ -639,7 +622,9 @@ public:
     alg.execute();
 
     TS_ASSERT(alg.isExecuted());
-    AnalysisDataService::Instance().remove("InputWS");
+
+    deleteData();
+    WorkspaceCreationHelper::removeWS("PlotPeakResult");
   }
 
   void test_startX_single_value() {

--- a/Framework/CurveFitting/test/Algorithms/PlotPeakByLogValueTest.h
+++ b/Framework/CurveFitting/test/Algorithms/PlotPeakByLogValueTest.h
@@ -625,11 +625,13 @@ public:
                                 2, HistogramData::Histogram(points, counts))
                                 .release());
     AnalysisDataService::Instance().addOrReplace("InputWS", ws);
-
+    std::vector<std::string> excludeRanges;
+    excludeRanges.emplace_back("-0.5, 0.0");
+    excludeRanges.emplace_back("0.5, 1.5");
     PlotPeakByLogValue alg;
     alg.initialize();
     alg.setPropertyValue("Input", "InputWS,i0");
-    alg.setPropertyValue("Exclude", "-0.5, 0.5, 0.5, 0.5");
+    alg.setProperty("ExcludeMultiple", excludeRanges);
     alg.setPropertyValue("OutputWorkspace", "PlotPeakResult");
     alg.setProperty("CreateOutput", true);
     alg.setPropertyValue("Function", "name=FlatBackground,A0=2");

--- a/Framework/CurveFitting/test/Algorithms/PlotPeakByLogValueTest.h
+++ b/Framework/CurveFitting/test/Algorithms/PlotPeakByLogValueTest.h
@@ -568,7 +568,7 @@ public:
     AnalysisDataService::Instance().clear();
   }
 
-  void test_exclude_range() {
+  void test_single_exclude_range_single_Spectra() {
     HistogramData::Points points{-2, -1, 0, 1, 2};
     HistogramData::Counts counts(points.size(), 0.0);
     // This value should be excluded.
@@ -582,6 +582,54 @@ public:
     alg.initialize();
     alg.setPropertyValue("Input", "InputWS,i0");
     alg.setPropertyValue("Exclude", "-0.5, 0.5");
+    alg.setPropertyValue("OutputWorkspace", "PlotPeakResult");
+    alg.setProperty("CreateOutput", true);
+    alg.setPropertyValue("Function", "name=FlatBackground,A0=2");
+    alg.setPropertyValue("MaxIterations", "50");
+    alg.execute();
+
+    TS_ASSERT(alg.isExecuted());
+    AnalysisDataService::Instance().remove("InputWS");
+  }
+
+  void test_single_exclude_range_multiple_Spectra() {
+    HistogramData::Points points{-2, -1, 0, 1, 2};
+    HistogramData::Counts counts(points.size(), 0.0);
+    // This value should be excluded.
+    counts.mutableData()[2] = 10.0;
+    MatrixWorkspace_sptr ws(DataObjects::create<Workspace2D>(
+                                2, HistogramData::Histogram(points, counts))
+                                .release());
+    AnalysisDataService::Instance().addOrReplace("InputWS", ws);
+
+    PlotPeakByLogValue alg;
+    alg.initialize();
+    alg.setPropertyValue("Input", "InputWS,i0");
+    alg.setPropertyValue("Exclude", "-0.5, 0.5");
+    alg.setPropertyValue("OutputWorkspace", "PlotPeakResult");
+    alg.setProperty("CreateOutput", true);
+    alg.setPropertyValue("Function", "name=FlatBackground,A0=2");
+    alg.setPropertyValue("MaxIterations", "50");
+    alg.execute();
+
+    TS_ASSERT(alg.isExecuted());
+    AnalysisDataService::Instance().remove("InputWS");
+  }
+
+  void test_multiple_exclude_range_multiple_Spectra() {
+    HistogramData::Points points{-2, -1, 0, 1, 2};
+    HistogramData::Counts counts(points.size(), 0.0);
+    // This value should be excluded.
+    counts.mutableData()[2] = 10.0;
+    MatrixWorkspace_sptr ws(DataObjects::create<Workspace2D>(
+                                2, HistogramData::Histogram(points, counts))
+                                .release());
+    AnalysisDataService::Instance().addOrReplace("InputWS", ws);
+
+    PlotPeakByLogValue alg;
+    alg.initialize();
+    alg.setPropertyValue("Input", "InputWS,i0");
+    alg.setPropertyValue("Exclude", "-0.5, 0.5, 0.5, 0.5");
     alg.setPropertyValue("OutputWorkspace", "PlotPeakResult");
     alg.setProperty("CreateOutput", true);
     alg.setPropertyValue("Function", "name=FlatBackground,A0=2");

--- a/docs/source/algorithms/PlotPeakByLogValue-v1.rst
+++ b/docs/source/algorithms/PlotPeakByLogValue-v1.rst
@@ -95,6 +95,20 @@ The possible flags are:
 :code:`$OutputFitStatus`
   Optional flag determining whether to output fit status and chi square for each fit
 
+Exclusion
+#########
+
+It is possible to include exclusion regions that will not be used when calculating the fit.
+This can be done with the `Exclude` parameter which will use the same range for each
+spectra being fitted. This range is given as a list or string containing an even number of
+values defining exclusion boundaries e.g. `"-0.1, -0.05, 0.05, 0.3"` will exclude values
+between -0.1 and -0.05, and 0.05 and 0.3.
+If each spectra requires different exclusion ranges `ExcludeMultiple` can be used, this parameter
+contains a list of `Exclude` style parameters. For example if there are 3 spectra being fitted
+the to use `ExcludeMultiple` you would need to give a list with 3 values e.g.
+`["-0.1, -0.05", "0.05, 0.3", "0.0,0.0"]` will mask the first between -0.1 and -0.05, the second
+between 0.05 and 0.3. The third spectra will me masked between 0.0 and 0.0 i.e. it will not be
+masked.
 
 Usage
 -----
@@ -135,6 +149,8 @@ Output:
 
     True
 
+**Example - sequentially fitting a workspace with Output Status:**
+
 .. testcode:: ExPlotPeakByLogValueSeqWithOutputStatus
 
     import numpy as np
@@ -161,6 +177,8 @@ Output:
        1.73025195e-11   2.45555803e-12   4.06465408e-13   1.04496124e-13
        4.79987355e-14   3.01813222e-14]
 
+**Example - Fitting multiDomain function:**
+
 .. testcode:: MultiDomainFunctionExample
 
     ws = CreateSampleWorkspace()
@@ -184,6 +202,32 @@ Output:
     Fit chi2 = [  5.09648779e-08   6.89426130e-09   9.33124574e-10   1.26539259e-10
        1.73025195e-11   2.45555803e-12   4.06465408e-13   1.04496124e-13
        4.79987355e-14   3.01813222e-14]
+
+**Example - :**
+
+.. testcode:: ExPlotPeakByLogValueSeqWithExclusionRange
+
+    ws = CreateSampleWorkspace(BankPixelWidth=3)
+    function = "name=Gaussian,Height=10.0041,PeakCentre=10098.6,Sigma=48.8581;name=FlatBackground,A0=0.3"
+
+    #create string of workspaces to fit (ws,i0; ws,i1, ws,i2 ...)
+    workspaces = [ws.name() + ',i%d' % i for i in range(3)]
+    workspaces = ';'.join(workspaces)
+
+    exclude_range = ["5000,7500", "7500,12500", "0.0,0.0"]
+
+    peaks, status, chi2 = PlotPeakByLogValue(workspaces, function, Spectrum=1, OutputFitStatus=True, ExcludeMultiple=exclude_range)
+
+    # Print status of first 10 fits
+    print("Fit status = {}".format(status[0:3]))
+    print("Fit chi2 = [{0:.4e}, {1:.4e}, {2:.4e}]".format(chi2[0], chi2[1], chi2[2]))
+
+Output:
+
+.. testoutput:: ExPlotPeakByLogValueSeqWithExclusionRange
+
+    Fit status = ['success', 'success', 'success']
+    Fit chi2 = [5.0965e-08, 0.0000e+00, 6.8943e-09]
 
 .. categories::
 

--- a/docs/source/release/v6.0.0/indirect_geometry.rst
+++ b/docs/source/release/v6.0.0/indirect_geometry.rst
@@ -30,5 +30,6 @@ Bug Fixes
 - Fixed a bug in Indirect Data Reduction causing the colon separator in Custom Grouping to act like a dash separator. This colon separator should now act
   as expected (i.e. `1:5` means the same as `1,2,3,4,5`).
 - Fixed a crash on Indirect Bayes ResNorm when clicking `Plot Current Preview` without a workspace loaded.
+- A bug has been fixed that caused fitting tabs in data reduction to use the X mask of the first spectra for every single spectra.
 
 :ref:`Release 6.0.0 <v6.0.0>`

--- a/docs/source/release/v6.0.0/indirect_geometry.rst
+++ b/docs/source/release/v6.0.0/indirect_geometry.rst
@@ -22,6 +22,7 @@ Improvements
 - The context menu for plots in the  indirect data analysis GUI is now enabled.
 - The function browser in the ConvFit tab should now correctly show Q values for Q dependent functions.
 - The ConvFit tab in the Indirect Data Analysis GUI will now set default parameters for the FWHM when a resolution file is loaded.
+- QENSFitSequential and PlotPeakByLogValue can accept a different mask range for each spectra via the `ExcludeMultiple` Parameter.
 
 Bug Fixes
 #########
@@ -30,6 +31,6 @@ Bug Fixes
 - Fixed a bug in Indirect Data Reduction causing the colon separator in Custom Grouping to act like a dash separator. This colon separator should now act
   as expected (i.e. `1:5` means the same as `1,2,3,4,5`).
 - Fixed a crash on Indirect Bayes ResNorm when clicking `Plot Current Preview` without a workspace loaded.
-- A bug has been fixed that caused fitting tabs in data reduction to use the X mask of the first spectra for every single spectra.
+- A bug has been fixed that caused fitting tabs in data analysis to use the X mask of the first spectra for every single spectra.
 
 :ref:`Release 6.0.0 <v6.0.0>`

--- a/qt/scientific_interfaces/Indirect/IIndirectFitDataModel.h
+++ b/qt/scientific_interfaces/Indirect/IIndirectFitDataModel.h
@@ -89,6 +89,8 @@ public:
   virtual std::vector<double>
   getExcludeRegionVector(FitDomainIndex index) const = 0;
   virtual std::string getExcludeRegion(FitDomainIndex index) const = 0;
+  virtual void setExcludeRegion(const std::string &exclude,
+                                FitDomainIndex index) = 0;
 
   virtual std::pair<TableDatasetIndex, WorkspaceIndex>
       getSubIndices(FitDomainIndex) const = 0;

--- a/qt/scientific_interfaces/Indirect/IndirectFitDataModel.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectFitDataModel.cpp
@@ -369,6 +369,15 @@ std::string IndirectFitDataModel::getExcludeRegion(FitDomainIndex index) const {
   return getExcludeRegion(subIndices.first, subIndices.second);
 }
 
+void IndirectFitDataModel::setExcludeRegion(const std::string &exclude,
+                                            FitDomainIndex index) {
+  if (m_fittingData->empty())
+    return;
+  auto subIndices = getSubIndices(index);
+  m_fittingData->at(subIndices.first.value)
+      .setExcludeRegionString(exclude, subIndices.second);
+}
+
 std::pair<TableDatasetIndex, WorkspaceIndex>
 IndirectFitDataModel::getSubIndices(FitDomainIndex index) const {
   size_t sum{0};

--- a/qt/scientific_interfaces/Indirect/IndirectFitDataModel.h
+++ b/qt/scientific_interfaces/Indirect/IndirectFitDataModel.h
@@ -88,7 +88,8 @@ public:
   std::vector<double>
   getExcludeRegionVector(FitDomainIndex index) const override;
   std::string getExcludeRegion(FitDomainIndex index) const override;
-  void setExcludeRegion(const std::string &exclude, FitDomainIndex index);
+  void setExcludeRegion(const std::string &exclude,
+                        FitDomainIndex index) override;
   std::pair<TableDatasetIndex, WorkspaceIndex>
       getSubIndices(FitDomainIndex) const override;
 

--- a/qt/scientific_interfaces/Indirect/IndirectFitDataModel.h
+++ b/qt/scientific_interfaces/Indirect/IndirectFitDataModel.h
@@ -88,6 +88,7 @@ public:
   std::vector<double>
   getExcludeRegionVector(FitDomainIndex index) const override;
   std::string getExcludeRegion(FitDomainIndex index) const override;
+  void setExcludeRegion(const std::string &exclude, FitDomainIndex index);
   std::pair<TableDatasetIndex, WorkspaceIndex>
       getSubIndices(FitDomainIndex) const override;
 

--- a/qt/scientific_interfaces/Indirect/IndirectFittingModel.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectFittingModel.cpp
@@ -689,6 +689,7 @@ IndirectFittingModel::createSequentialFit(const IFunction_sptr &function,
   fitAlgorithm->setProperty("EndX", endX.str());
 
   std::vector<std::string> excludeRegions;
+  excludeRegions.reserve(m_fitDataModel->getNumberOfDomains());
   for (size_t i = 0; i < m_fitDataModel->getNumberOfDomains(); i++) {
     if (!m_fitDataModel->getExcludeRegionVector(FitDomainIndex{i}).empty()) {
       excludeRegions.emplace_back(

--- a/qt/scientific_interfaces/Indirect/IndirectFittingModel.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectFittingModel.cpp
@@ -691,7 +691,8 @@ IndirectFittingModel::createSequentialFit(const IFunction_sptr &function,
   std::vector<std::string> excludeRegions;
   for (size_t i = 0; i < m_fitDataModel->getNumberOfDomains(); i++) {
     if (!m_fitDataModel->getExcludeRegionVector(FitDomainIndex{i}).empty()) {
-      excludeRegions.emplace_back(m_fitDataModel->getExcludeRegion(FitDomainIndex{i}));
+      excludeRegions.emplace_back(
+          m_fitDataModel->getExcludeRegion(FitDomainIndex{i}));
     } else {
       excludeRegions.emplace_back("");
     }

--- a/qt/scientific_interfaces/Indirect/IndirectFittingModel.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectFittingModel.cpp
@@ -688,17 +688,15 @@ IndirectFittingModel::createSequentialFit(const IFunction_sptr &function,
   fitAlgorithm->setProperty("StartX", startX.str());
   fitAlgorithm->setProperty("EndX", endX.str());
 
-  std::stringstream excludeRegions;
+  std::vector<std::string> excludeRegions;
   for (size_t i = 0; i < m_fitDataModel->getNumberOfDomains(); i++) {
     if (!m_fitDataModel->getExcludeRegionVector(FitDomainIndex{i}).empty()) {
-      excludeRegions << m_fitDataModel->getExcludeRegion(FitDomainIndex{i})
-                     << ",";
+      excludeRegions.emplace_back(m_fitDataModel->getExcludeRegion(FitDomainIndex{i}));
     } else {
-      excludeRegions << "0.0,0.0,";
+      excludeRegions.emplace_back("");
     }
   }
-  auto regeanstring = excludeRegions.str();
-  fitAlgorithm->setProperty("Exclude", regeanstring);
+  fitAlgorithm->setProperty("ExcludeMultiple", excludeRegions);
 
   return fitAlgorithm;
 }

--- a/qt/scientific_interfaces/Indirect/IndirectFittingModel.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectFittingModel.cpp
@@ -688,11 +688,17 @@ IndirectFittingModel::createSequentialFit(const IFunction_sptr &function,
   fitAlgorithm->setProperty("StartX", startX.str());
   fitAlgorithm->setProperty("EndX", endX.str());
 
-  auto excludeRegion =
-      m_fitDataModel->getExcludeRegionVector(FitDomainIndex{0});
-  if (!excludeRegion.empty()) {
-    fitAlgorithm->setProperty("Exclude", excludeRegion);
+  std::stringstream excludeRegions;
+  for (size_t i = 0; i < m_fitDataModel->getNumberOfDomains(); i++) {
+    if (!m_fitDataModel->getExcludeRegionVector(FitDomainIndex{i}).empty()) {
+      excludeRegions << m_fitDataModel->getExcludeRegion(FitDomainIndex{i})
+                     << ",";
+    } else {
+      excludeRegions << "0.0,0.0,";
+    }
   }
+  auto regeanstring = excludeRegions.str();
+  fitAlgorithm->setProperty("Exclude", regeanstring);
 
   return fitAlgorithm;
 }


### PR DESCRIPTION
**Description of work.**

This PR fixes a bug in Indirect Data Analysis fitting tabs that caused then to use the X masking for the first spectra for all spectra in sequential fitting.

**To test:**

1. open indirect Data analysis
2. Go to one of the fitting tabs (test for each in turn)
3. switch to multiple input
4. load multiple spectra
5. add a fitting function
6. add X masks to multiple spectra
7. do a sequential fit
8. check that the corect mask has been applied to each spectra.

This is a partial fix for #30179 the duplicated methods of adding X masks will be addressed seperatly.

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
