### PR TITLE
Fix error in projected lambda range in RRO

### DIFF
--- a/Framework/Reflectometry/src/ReflectometryReductionOne2.cpp
+++ b/Framework/Reflectometry/src/ReflectometryReductionOne2.cpp
@@ -940,9 +940,11 @@ double ReflectometryReductionOne2::findIvsLamRangeMin(
   // For bLambda, use the average bin size for this spectrum
   const auto &xValues = detectorWS->x(spIdx);
   double bLambda = (xValues[xValues.size() - 1] - xValues[0]) /
-                   static_cast<int>(xValues.size());
+                   static_cast<int>(xValues.size() - 1);
   double dummy = 0.0;
-  getProjectedLambdaRange(lambda, twoTheta, bLambda, bTwoTheta, detectors,
+  // The projection assumes the given lambda is a bin centre
+  double lambdaCentre = lambda + bLambda / 2.0;
+  getProjectedLambdaRange(lambdaCentre, twoTheta, bLambda, bTwoTheta, detectors,
                           projectedMin, dummy, m_partialBins);
   return projectedMin;
 }
@@ -959,10 +961,12 @@ double ReflectometryReductionOne2::findIvsLamRangeMax(
   // For bLambda, use the average bin size for this spectrum
   const auto &xValues = detectorWS->x(spIdx);
   double bLambda = (xValues[xValues.size() - 1] - xValues[0]) /
-                   static_cast<int>(xValues.size());
+                   static_cast<int>(xValues.size() - 1);
 
   double dummy = 0.0;
-  getProjectedLambdaRange(lambda, twoTheta, bLambda, bTwoTheta, detectors,
+  // The projection assumes the given lambda is a bin centre
+  double lambdaCentre = lambda - bLambda / 2.0;
+  getProjectedLambdaRange(lambdaCentre, twoTheta, bLambda, bTwoTheta, detectors,
                           dummy, projectedMax, m_partialBins);
   return projectedMax;
 }

--- a/Framework/Reflectometry/test/ReflectometryReductionOne2Test.h
+++ b/Framework/Reflectometry/test/ReflectometryReductionOne2Test.h
@@ -459,7 +459,6 @@ public:
   }
 
   void test_sum_in_q_with_bad_reduction_type() {
-    // Test IvsLam workspace
     // No monitor normalization
     // No direct beam normalization
     // No transmission correction
@@ -473,7 +472,6 @@ public:
   }
 
   void test_sum_in_q_divergent_beam() {
-    // Test IvsLam workspace
     // No monitor normalization
     // No direct beam normalization
     // No transmission correction
@@ -484,18 +482,25 @@ public:
     alg.setProperty("SummationType", "SumInQ");
     alg.setProperty("ReductionType", "DivergentBeam");
     alg.setProperty("ThetaIn", 25.0);
-    MatrixWorkspace_sptr outLam = runAlgorithmLam(alg, 12);
 
+    MatrixWorkspace_sptr outLam = runAlgorithmLam(alg, 12);
     TS_ASSERT_DELTA(outLam->x(0)[0], 0.934992, 1e-6);
     TS_ASSERT_DELTA(outLam->x(0)[3], 5.173599, 1e-6);
     TS_ASSERT_DELTA(outLam->x(0)[7], 10.825076, 1e-6);
     TS_ASSERT_DELTA(outLam->y(0)[0], 2.768185, 1e-6);
     TS_ASSERT_DELTA(outLam->y(0)[3], 2.792649, 1e-6);
     TS_ASSERT_DELTA(outLam->y(0)[7], 2.787410, 1e-6);
+
+    MatrixWorkspace_sptr outQ = runAlgorithmQ(alg, 12);
+    TS_ASSERT_DELTA(outQ->x(0)[0], 0.265534, 1e-6);
+    TS_ASSERT_DELTA(outQ->x(0)[3], 0.347983, 1e-6);
+    TS_ASSERT_DELTA(outQ->x(0)[7], 0.593830, 1e-6);
+    TS_ASSERT_DELTA(outQ->y(0)[0], 2.816015, 1e-6);
+    TS_ASSERT_DELTA(outQ->y(0)[3], 2.794903, 1e-6);
+    TS_ASSERT_DELTA(outQ->y(0)[7], 2.654336, 1e-6);
   }
 
   void test_sum_in_q_non_flat_sample() {
-    // Test IvsLam workspace
     // No monitor normalization
     // No direct beam normalization
     // No transmission correction
@@ -506,18 +511,25 @@ public:
     setupAlgorithm(alg, 1.5, 15.0, "3");
     alg.setProperty("SummationType", "SumInQ");
     alg.setProperty("ReductionType", "NonFlatSample");
-    MatrixWorkspace_sptr outLam = runAlgorithmLam(alg, 10);
 
+    MatrixWorkspace_sptr outLam = runAlgorithmLam(alg, 10);
     TS_ASSERT_DELTA(outLam->x(0)[0], 0.825488, 1e-6);
     TS_ASSERT_DELTA(outLam->x(0)[3], 5.064095, 1e-6);
     TS_ASSERT_DELTA(outLam->x(0)[7], 10.715573, 1e-6);
     TS_ASSERT_DELTA(outLam->y(0)[0], 3.141859, 1e-6);
     TS_ASSERT_DELTA(outLam->y(0)[3], 3.141885, 1e-6);
     TS_ASSERT_DELTA(outLam->y(0)[7], 3.141920, 1e-6);
+
+    MatrixWorkspace_sptr outQ = runAlgorithmQ(alg, 10);
+    TS_ASSERT_DELTA(outQ->x(0)[0], 0.317653, 1e-6);
+    TS_ASSERT_DELTA(outQ->x(0)[3], 0.443303, 1e-6);
+    TS_ASSERT_DELTA(outQ->x(0)[7], 0.938025, 1e-6);
+    TS_ASSERT_DELTA(outQ->y(0)[0], 3.141937, 1e-6);
+    TS_ASSERT_DELTA(outQ->y(0)[3], 3.141912, 1e-6);
+    TS_ASSERT_DELTA(outQ->y(0)[7], 3.141877, 1e-6);
   }
 
   void test_sum_in_q_monitor_normalization() {
-    // Test IvsLam workspace
     // Monitor normalization
     // No direct beam normalization
     // No transmission correction
@@ -541,14 +553,22 @@ public:
     alg.setProperty("SummationType", "SumInQ");
     alg.setProperty("ReductionType", "DivergentBeam");
     alg.setProperty("ThetaIn", 25.0);
-    MatrixWorkspace_sptr outLam = runAlgorithmLam(alg, 13);
 
+    MatrixWorkspace_sptr outLam = runAlgorithmLam(alg, 13);
     TS_ASSERT_DELTA(outLam->x(0)[0], -0.748672, 1e-6);
     TS_ASSERT_DELTA(outLam->x(0)[5], 6.315674, 1e-6);
     TS_ASSERT_DELTA(outLam->x(0)[9], 11.967151, 1e-6);
     TS_ASSERT_DELTA(outLam->y(0)[0], 5.040302, 1e-6);
     TS_ASSERT_DELTA(outLam->y(0)[5], 2.193650, 1e-6);
     TS_ASSERT_DELTA(outLam->y(0)[9], 2.255101, 1e-6);
+
+    MatrixWorkspace_sptr outQ = runAlgorithmQ(alg, 13);
+    TS_ASSERT_DELTA(outQ->x(0)[0], -6.423295, 1e-6);
+    TS_ASSERT_DELTA(outQ->x(0)[5], 0.761430, 1e-6);
+    TS_ASSERT_DELTA(outQ->x(0)[9], 0.401845, 1e-6);
+    TS_ASSERT_DELTA(outQ->y(0)[0], 5.040302, 1e-6);
+    TS_ASSERT_DELTA(outQ->y(0)[5], 2.193650, 1e-6);
+    TS_ASSERT_DELTA(outQ->y(0)[9], 2.255101, 1e-6);
   }
 
   void test_sum_in_q_transmission_correction_run() {
@@ -560,14 +580,22 @@ public:
     alg.setProperty("SummationType", "SumInQ");
     alg.setProperty("ReductionType", "DivergentBeam");
     alg.setProperty("ThetaIn", 25.0);
-    MatrixWorkspace_sptr outLam = runAlgorithmLam(alg, 12);
 
+    MatrixWorkspace_sptr outLam = runAlgorithmLam(alg, 12);
     TS_ASSERT_DELTA(outLam->x(0)[0], 0.934992, 1e-6);
     TS_ASSERT_DELTA(outLam->x(0)[3], 5.173599, 1e-6);
     TS_ASSERT_DELTA(outLam->x(0)[7], 10.825076, 1e-6);
     TS_ASSERT_DELTA(outLam->y(0)[0], 0.631775, 1e-6);
     TS_ASSERT_DELTA(outLam->y(0)[3], 0.888541, 1e-6);
     TS_ASSERT_DELTA(outLam->y(0)[7], 0.886874, 1e-6);
+
+    MatrixWorkspace_sptr outQ = runAlgorithmQ(alg, 12);
+    TS_ASSERT_DELTA(outQ->x(0)[0], 0.265534, 1e-6);
+    TS_ASSERT_DELTA(outQ->x(0)[3], 0.347983, 1e-6);
+    TS_ASSERT_DELTA(outQ->x(0)[7], 0.593830, 1e-6);
+    TS_ASSERT_DELTA(outQ->y(0)[0], 3.959740, 1e-6);
+    TS_ASSERT_DELTA(outQ->y(0)[3], 0.889259, 1e-6);
+    TS_ASSERT_DELTA(outQ->y(0)[7], 0.844534, 1e-6);
   }
 
   void test_sum_in_q_exponential_correction() {
@@ -581,41 +609,25 @@ public:
     alg.setProperty("CorrectionAlgorithm", "ExponentialCorrection");
     alg.setProperty("C0", 0.2);
     alg.setProperty("C1", 0.1);
-    MatrixWorkspace_sptr outLam = runAlgorithmLam(alg, 11);
 
+    MatrixWorkspace_sptr outLam = runAlgorithmLam(alg, 11);
     TS_ASSERT_DELTA(outLam->x(0)[0], 0.920496, 1e-6);
     TS_ASSERT_DELTA(outLam->x(0)[3], 5.159104, 1e-6);
     TS_ASSERT_DELTA(outLam->x(0)[7], 10.810581, 1e-6);
     TS_ASSERT_DELTA(outLam->y(0)[0], 16.351599, 1e-6);
     TS_ASSERT_DELTA(outLam->y(0)[3], 23.963534, 1e-6);
     TS_ASSERT_DELTA(outLam->y(0)[7], 39.756736, 1e-6);
-  }
 
-  void test_sum_in_q_IvsQ() {
-    // Test IvsQ workspace
-    // No monitor normalization
-    // No direct beam normalization
-    // No transmission correction
-    // Processing instructions : 3
-
-    ReflectometryReductionOne2 alg;
-    setupAlgorithm(alg, 1.5, 15.0, "4");
-    alg.setProperty("SummationType", "SumInQ");
-    alg.setProperty("ReductionType", "DivergentBeam");
-    alg.setProperty("ThetaIn", 25.0);
     MatrixWorkspace_sptr outQ = runAlgorithmQ(alg, 11);
-
-    // X range in outQ
-    TS_ASSERT_DELTA(outQ->x(0)[0], 0.292122, 1e-6);
+    TS_ASSERT_DELTA(outQ->x(0)[0], 0.292123, 1e-6);
     TS_ASSERT_DELTA(outQ->x(0)[3], 0.393419, 1e-6);
-    TS_ASSERT_DELTA(outQ->x(0)[7], 0.731734, 1e-6);
-    // Y counts
-    TS_ASSERT_DELTA(outQ->y(0)[0], 2.852088, 1e-6);
-    TS_ASSERT_DELTA(outQ->y(0)[3], 2.833380, 1e-6);
-    TS_ASSERT_DELTA(outQ->y(0)[7], 2.841288, 1e-6);
+    TS_ASSERT_DELTA(outQ->x(0)[7], 0.731735, 1e-6);
+    TS_ASSERT_DELTA(outQ->y(0)[0], 58.425212, 1e-6);
+    TS_ASSERT_DELTA(outQ->y(0)[3], 39.756737, 1e-6);
+    TS_ASSERT_DELTA(outQ->y(0)[7], 23.963535, 1e-6);
   }
 
-  void test_sum_in_q_IvsQ_point_detector() {
+  void test_sum_in_q_point_detector() {
     // Test IvsQ workspace for a point detector
     // No monitor normalization
     // No direct beam normalization
@@ -648,14 +660,22 @@ public:
     alg.setProperty("ReductionType", "DivergentBeam");
     alg.setProperty("ThetaIn", 25.0);
     alg.setProperty("IncludePartialBins", "0");
-    MatrixWorkspace_sptr outLam = runAlgorithmLam(alg, 11);
 
+    MatrixWorkspace_sptr outLam = runAlgorithmLam(alg, 11);
     TS_ASSERT_DELTA(outLam->x(0)[0], 0.945877, 1e-6);
     TS_ASSERT_DELTA(outLam->x(0)[3], 5.184485, 1e-6);
     TS_ASSERT_DELTA(outLam->x(0)[7], 10.835962, 1e-6);
     TS_ASSERT_DELTA(outLam->y(0)[0], 2.767944, 1e-6);
     TS_ASSERT_DELTA(outLam->y(0)[3], 2.792424, 1e-6);
     TS_ASSERT_DELTA(outLam->y(0)[7], 2.787199, 1e-6);
+
+    MatrixWorkspace_sptr outQ = runAlgorithmQ(alg, 11);
+    TS_ASSERT_DELTA(outQ->x(0)[0], 0.288113, 1e-6);
+    TS_ASSERT_DELTA(outQ->x(0)[3], 0.387812, 1e-6);
+    TS_ASSERT_DELTA(outQ->x(0)[7], 0.720023, 1e-6);
+    TS_ASSERT_DELTA(outQ->y(0)[0], 2.808998, 1e-6);
+    TS_ASSERT_DELTA(outQ->y(0)[3], 2.787199, 1e-6);
+    TS_ASSERT_DELTA(outQ->y(0)[7], 2.792423, 1e-6);
   }
 
   void test_sum_in_q_exclude_partial_bins_multiple_detectors() {
@@ -666,14 +686,22 @@ public:
     alg.setProperty("ReductionType", "DivergentBeam");
     alg.setProperty("ThetaIn", 25.0);
     alg.setProperty("IncludePartialBins", "0");
-    MatrixWorkspace_sptr outLam = runAlgorithmLam(alg, 11);
 
+    MatrixWorkspace_sptr outLam = runAlgorithmLam(alg, 11);
     TS_ASSERT_DELTA(outLam->x(0)[0], 0.957564, 1e-6);
     TS_ASSERT_DELTA(outLam->x(0)[3], 5.196172, 1e-6);
     TS_ASSERT_DELTA(outLam->x(0)[7], 10.847649, 1e-6);
     TS_ASSERT_DELTA(outLam->y(0)[0], 8.458467, 1e-6);
     TS_ASSERT_DELTA(outLam->y(0)[3], 8.521195, 1e-6);
     TS_ASSERT_DELTA(outLam->y(0)[7], 8.306563, 1e-6);
+
+    MatrixWorkspace_sptr outQ = runAlgorithmQ(alg, 11);
+    TS_ASSERT_DELTA(outQ->x(0)[0], 0.291466, 1e-6);
+    TS_ASSERT_DELTA(outQ->x(0)[3], 0.392230, 1e-6);
+    TS_ASSERT_DELTA(outQ->x(0)[7], 0.727631, 1e-6);
+    TS_ASSERT_DELTA(outQ->y(0)[0], 8.554743, 1e-6);
+    TS_ASSERT_DELTA(outQ->y(0)[3], 8.306564, 1e-6);
+    TS_ASSERT_DELTA(outQ->y(0)[7], 8.521194, 1e-6);
   }
 
   void test_angle_correction_is_done_for_sum_in_lambda_when_theta_provided() {

--- a/Framework/Reflectometry/test/ReflectometryReductionOne2Test.h
+++ b/Framework/Reflectometry/test/ReflectometryReductionOne2Test.h
@@ -483,17 +483,17 @@ public:
     alg.setProperty("ReductionType", "DivergentBeam");
     alg.setProperty("ThetaIn", 25.0);
 
-    MatrixWorkspace_sptr outLam = runAlgorithmLam(alg, 12);
-    TS_ASSERT_DELTA(outLam->x(0)[0], 0.934992, 1e-6);
-    TS_ASSERT_DELTA(outLam->x(0)[3], 5.173599, 1e-6);
-    TS_ASSERT_DELTA(outLam->x(0)[7], 10.825076, 1e-6);
-    TS_ASSERT_DELTA(outLam->y(0)[0], 2.768185, 1e-6);
-    TS_ASSERT_DELTA(outLam->y(0)[3], 2.792649, 1e-6);
-    TS_ASSERT_DELTA(outLam->y(0)[7], 2.787410, 1e-6);
+    MatrixWorkspace_sptr outLam = runAlgorithmLam(alg, 10);
+    TS_ASSERT_DELTA(outLam->x(0)[0], 1.695454, 1e-6);
+    TS_ASSERT_DELTA(outLam->x(0)[3], 5.934062, 1e-6);
+    TS_ASSERT_DELTA(outLam->x(0)[7], 11.585539, 1e-6);
+    TS_ASSERT_DELTA(outLam->y(0)[0], 2.717365, 1e-6);
+    TS_ASSERT_DELTA(outLam->y(0)[3], 2.776916, 1e-6);
+    TS_ASSERT_DELTA(outLam->y(0)[7], 2.807281, 1e-6);
 
     checkConversionToQ(alg, twoThetaForDetector3() / 2.0);
 
-    TS_ASSERT_DELTA(sumCounts(outLam->counts(0)), 33.310938, 1e-6);
+    TS_ASSERT_DELTA(sumCounts(outLam->counts(0)), 27.512893, 1e-6);
   }
 
   void test_sum_in_q_non_flat_sample() {
@@ -508,17 +508,17 @@ public:
     alg.setProperty("SummationType", "SumInQ");
     alg.setProperty("ReductionType", "NonFlatSample");
 
-    MatrixWorkspace_sptr outLam = runAlgorithmLam(alg, 10);
-    TS_ASSERT_DELTA(outLam->x(0)[0], 0.825488, 1e-6);
-    TS_ASSERT_DELTA(outLam->x(0)[3], 5.064095, 1e-6);
-    TS_ASSERT_DELTA(outLam->x(0)[7], 10.715573, 1e-6);
-    TS_ASSERT_DELTA(outLam->y(0)[0], 3.141859, 1e-6);
-    TS_ASSERT_DELTA(outLam->y(0)[3], 3.141885, 1e-6);
-    TS_ASSERT_DELTA(outLam->y(0)[7], 3.141920, 1e-6);
+    MatrixWorkspace_sptr outLam = runAlgorithmLam(alg, 9);
+    TS_ASSERT_DELTA(outLam->x(0)[0], 1.496887, 1e-6);
+    TS_ASSERT_DELTA(outLam->x(0)[3], 5.735494, 1e-6);
+    TS_ASSERT_DELTA(outLam->x(0)[7], 11.386971, 1e-6);
+    TS_ASSERT_DELTA(outLam->y(0)[0], 3.148623, 1e-6);
+    TS_ASSERT_DELTA(outLam->y(0)[3], 3.148486, 1e-6);
+    TS_ASSERT_DELTA(outLam->y(0)[7], 3.148310, 1e-6);
 
     checkConversionToQ(alg, twoThetaForDetector3() / 2.0);
 
-    TS_ASSERT_DELTA(sumCounts(outLam->counts(0)), 31.418985, 1e-6);
+    TS_ASSERT_DELTA(sumCounts(outLam->counts(0)), 28.335984, 1e-6);
   }
 
   void test_sum_in_q_monitor_normalization() {
@@ -546,17 +546,17 @@ public:
     alg.setProperty("ReductionType", "DivergentBeam");
     alg.setProperty("ThetaIn", 25.0);
 
-    MatrixWorkspace_sptr outLam = runAlgorithmLam(alg, 13);
-    TS_ASSERT_DELTA(outLam->x(0)[0], -0.748672, 1e-6);
-    TS_ASSERT_DELTA(outLam->x(0)[5], 6.315674, 1e-6);
-    TS_ASSERT_DELTA(outLam->x(0)[9], 11.967151, 1e-6);
-    TS_ASSERT_DELTA(outLam->y(0)[0], 5.040302, 1e-6);
-    TS_ASSERT_DELTA(outLam->y(0)[5], 2.193650, 1e-6);
-    TS_ASSERT_DELTA(outLam->y(0)[9], 2.255101, 1e-6);
+    MatrixWorkspace_sptr outLam = runAlgorithmLam(alg, 11);
+    TS_ASSERT_DELTA(outLam->x(0)[0], 0.000000, 1e-6);
+    TS_ASSERT_DELTA(outLam->x(0)[5], 7.064346, 1e-6);
+    TS_ASSERT_DELTA(outLam->x(0)[9], 12.715824, 1e-6);
+    TS_ASSERT_DELTA(outLam->y(0)[0], 10.721647, 1e-6);
+    TS_ASSERT_DELTA(outLam->y(0)[5], 2.249948, 1e-6);
+    TS_ASSERT_DELTA(outLam->y(0)[9], 2.044359, 1e-6);
 
     checkConversionToQ(alg, twoThetaForDetector4() / 2.0, false, false);
 
-    TS_ASSERT_DELTA(sumCounts(outLam->counts(0)), 66.514113, 1e-6);
+    TS_ASSERT_DELTA(sumCounts(outLam->counts(0)), 61.622606, 1e-6);
   }
 
   void test_sum_in_q_transmission_correction_run() {
@@ -569,17 +569,17 @@ public:
     alg.setProperty("ReductionType", "DivergentBeam");
     alg.setProperty("ThetaIn", 25.0);
 
-    MatrixWorkspace_sptr outLam = runAlgorithmLam(alg, 12);
-    TS_ASSERT_DELTA(outLam->x(0)[0], 0.934992, 1e-6);
-    TS_ASSERT_DELTA(outLam->x(0)[3], 5.173599, 1e-6);
-    TS_ASSERT_DELTA(outLam->x(0)[7], 10.825076, 1e-6);
-    TS_ASSERT_DELTA(outLam->y(0)[0], 0.631775, 1e-6);
-    TS_ASSERT_DELTA(outLam->y(0)[3], 0.888541, 1e-6);
-    TS_ASSERT_DELTA(outLam->y(0)[7], 0.886874, 1e-6);
+    MatrixWorkspace_sptr outLam = runAlgorithmLam(alg, 10);
+    TS_ASSERT_DELTA(outLam->x(0)[0], 1.695454, 1e-6);
+    TS_ASSERT_DELTA(outLam->x(0)[3], 5.934062, 1e-6);
+    TS_ASSERT_DELTA(outLam->x(0)[7], 11.585539, 1e-6);
+    TS_ASSERT_DELTA(outLam->y(0)[0], 1.188741, 1e-6);
+    TS_ASSERT_DELTA(outLam->y(0)[3], 0.883535, 1e-6);
+    TS_ASSERT_DELTA(outLam->y(0)[7], 0.893197, 1e-6);
 
     checkConversionToQ(alg, twoThetaForDetector3() / 2.0, true, false);
 
-    TS_ASSERT_DELTA(sumCounts(outLam->counts(0)), 21.030473, 1e-6);
+    TS_ASSERT_DELTA(sumCounts(outLam->counts(0)), 12.865793, 1e-6);
   }
 
   void test_sum_in_q_exponential_correction() {
@@ -594,17 +594,17 @@ public:
     alg.setProperty("C0", 0.2);
     alg.setProperty("C1", 0.1);
 
-    MatrixWorkspace_sptr outLam = runAlgorithmLam(alg, 11);
-    TS_ASSERT_DELTA(outLam->x(0)[0], 0.920496, 1e-6);
-    TS_ASSERT_DELTA(outLam->x(0)[3], 5.159104, 1e-6);
-    TS_ASSERT_DELTA(outLam->x(0)[7], 10.810581, 1e-6);
-    TS_ASSERT_DELTA(outLam->y(0)[0], 16.351599, 1e-6);
-    TS_ASSERT_DELTA(outLam->y(0)[3], 23.963534, 1e-6);
-    TS_ASSERT_DELTA(outLam->y(0)[7], 39.756736, 1e-6);
+    MatrixWorkspace_sptr outLam = runAlgorithmLam(alg, 10);
+    TS_ASSERT_DELTA(outLam->x(0)[0], 1.669169, 1e-6);
+    TS_ASSERT_DELTA(outLam->x(0)[3], 5.907776, 1e-6);
+    TS_ASSERT_DELTA(outLam->x(0)[7], 11.559254, 1e-6);
+    TS_ASSERT_DELTA(outLam->y(0)[0], 17.132968, 1e-6);
+    TS_ASSERT_DELTA(outLam->y(0)[3], 25.610289, 1e-6);
+    TS_ASSERT_DELTA(outLam->y(0)[7], 42.722014, 1e-6);
 
     checkConversionToQ(alg, twoThetaForDetector4() / 2.0);
 
-    TS_ASSERT_DELTA(sumCounts(outLam->counts(0)), 365.843555, 1e-6);
+    TS_ASSERT_DELTA(sumCounts(outLam->counts(0)), 327.981277, 1e-6);
   }
 
   void test_sum_in_q_point_detector() {
@@ -620,18 +620,18 @@ public:
     alg.setProperty("SummationType", "SumInQ");
     alg.setProperty("ReductionType", "DivergentBeam");
     alg.setProperty("ThetaIn", 25.0);
-    MatrixWorkspace_sptr outQ = runAlgorithmQ(alg, 28);
+    MatrixWorkspace_sptr outQ = runAlgorithmQ(alg, 26);
 
     // X range in outQ
-    TS_ASSERT_DELTA(outQ->x(0)[0], 0.279882, 1e-6);
-    TS_ASSERT_DELTA(outQ->x(0)[3], 0.310524, 1e-6);
-    TS_ASSERT_DELTA(outQ->x(0)[7], 0.363599, 1e-6);
+    TS_ASSERT_DELTA(outQ->x(0)[0], 0.293891, 1e-6);
+    TS_ASSERT_DELTA(outQ->x(0)[3], 0.327862, 1e-6);
+    TS_ASSERT_DELTA(outQ->x(0)[7], 0.387600, 1e-6);
     // Y counts
-    TS_ASSERT_DELTA(outQ->y(0)[0], 2.900303, 1e-6);
-    TS_ASSERT_DELTA(outQ->y(0)[3], 2.886945, 1e-6);
-    TS_ASSERT_DELTA(outQ->y(0)[7], 2.607357, 1e-6);
+    TS_ASSERT_DELTA(outQ->y(0)[0], 2.632384, 1e-6);
+    TS_ASSERT_DELTA(outQ->y(0)[3], 2.891120, 1e-6);
+    TS_ASSERT_DELTA(outQ->y(0)[7], 2.871725, 1e-6);
 
-    TS_ASSERT_DELTA(sumCounts(outQ->counts(0)), 79.113420, 1e-6);
+    TS_ASSERT_DELTA(sumCounts(outQ->counts(0)), 73.065241, 1e-6);
   }
 
   void test_sum_in_q_exclude_partial_bins() {
@@ -643,17 +643,17 @@ public:
     alg.setProperty("ThetaIn", 25.0);
     alg.setProperty("IncludePartialBins", "0");
 
-    MatrixWorkspace_sptr outLam = runAlgorithmLam(alg, 11);
-    TS_ASSERT_DELTA(outLam->x(0)[0], 0.945877, 1e-6);
-    TS_ASSERT_DELTA(outLam->x(0)[3], 5.184485, 1e-6);
-    TS_ASSERT_DELTA(outLam->x(0)[7], 10.835962, 1e-6);
-    TS_ASSERT_DELTA(outLam->y(0)[0], 2.767944, 1e-6);
-    TS_ASSERT_DELTA(outLam->y(0)[3], 2.792424, 1e-6);
-    TS_ASSERT_DELTA(outLam->y(0)[7], 2.787199, 1e-6);
+    MatrixWorkspace_sptr outLam = runAlgorithmLam(alg, 10);
+    TS_ASSERT_DELTA(outLam->x(0)[0], 1.715192, 1e-6);
+    TS_ASSERT_DELTA(outLam->x(0)[3], 5.953800, 1e-6);
+    TS_ASSERT_DELTA(outLam->x(0)[7], 11.605277, 1e-6);
+    TS_ASSERT_DELTA(outLam->y(0)[0], 2.717365, 1e-6);
+    TS_ASSERT_DELTA(outLam->y(0)[3], 2.776507, 1e-6);
+    TS_ASSERT_DELTA(outLam->y(0)[7], 2.806906, 1e-6);
 
     checkConversionToQ(alg, twoThetaForDetector3() / 2.0);
 
-    TS_ASSERT_DELTA(sumCounts(outLam->counts(0)), 30.492737, 1e-6);
+    TS_ASSERT_DELTA(sumCounts(outLam->counts(0)), 27.509726, 1e-6);
   }
 
   void test_sum_in_q_exclude_partial_bins_multiple_detectors() {
@@ -665,17 +665,17 @@ public:
     alg.setProperty("ThetaIn", 25.0);
     alg.setProperty("IncludePartialBins", "0");
 
-    MatrixWorkspace_sptr outLam = runAlgorithmLam(alg, 11);
-    TS_ASSERT_DELTA(outLam->x(0)[0], 0.957564, 1e-6);
-    TS_ASSERT_DELTA(outLam->x(0)[3], 5.196172, 1e-6);
-    TS_ASSERT_DELTA(outLam->x(0)[7], 10.847649, 1e-6);
-    TS_ASSERT_DELTA(outLam->y(0)[0], 8.458467, 1e-6);
-    TS_ASSERT_DELTA(outLam->y(0)[3], 8.521195, 1e-6);
-    TS_ASSERT_DELTA(outLam->y(0)[7], 8.306563, 1e-6);
+    MatrixWorkspace_sptr outLam = runAlgorithmLam(alg, 10);
+    TS_ASSERT_DELTA(outLam->x(0)[0], 1.736385, 1e-6);
+    TS_ASSERT_DELTA(outLam->x(0)[3], 5.974993, 1e-6);
+    TS_ASSERT_DELTA(outLam->x(0)[7], 11.626470, 1e-6);
+    TS_ASSERT_DELTA(outLam->y(0)[0], 8.387969, 1e-6);
+    TS_ASSERT_DELTA(outLam->y(0)[3], 8.474204, 1e-6);
+    TS_ASSERT_DELTA(outLam->y(0)[7], 8.473021, 1e-6);
 
     checkConversionToQ(alg, twoThetaForDetector4() / 2.0);
 
-    TS_ASSERT_DELTA(sumCounts(outLam->counts(0)), 93.056874, 1e-6);
+    TS_ASSERT_DELTA(sumCounts(outLam->counts(0)), 84.540593, 1e-6);
   }
 
   void test_angle_correction_is_done_for_sum_in_lambda_when_theta_provided() {
@@ -1498,16 +1498,16 @@ private:
   void checkDetector4SummedInQ(MatrixWorkspace_sptr outLam,
                                MatrixWorkspace_sptr outQ, int const wsIdx = 0) {
     auto const &lamY = outLam->y(wsIdx);
-    TS_ASSERT_EQUALS(lamY.size(), 10);
-    TS_ASSERT_DELTA(lamY[0], 13.954514, 1e-6);
-    TS_ASSERT_DELTA(lamY[6], 60.379735, 1e-6);
-    TS_ASSERT_DELTA(lamY[9], 83.408536, 1e-6);
+    TS_ASSERT_EQUALS(lamY.size(), 9);
+    TS_ASSERT_DELTA(lamY[0], 17.593911, 1e-6);
+    TS_ASSERT_DELTA(lamY[6], 64.674833, 1e-6);
+    TS_ASSERT_DELTA(lamY[8], 80.012043, 1e-6);
 
     auto const &qY = outQ->y(wsIdx);
-    TS_ASSERT_EQUALS(qY.size(), 10);
-    TS_ASSERT_DELTA(qY[0], 83.408536, 1e-6);
-    TS_ASSERT_DELTA(qY[6], 37.016271, 1e-6);
-    TS_ASSERT_DELTA(qY[9], 13.954514, 1e-6);
+    TS_ASSERT_EQUALS(qY.size(), 9);
+    TS_ASSERT_DELTA(qY[0], 80.012043, 1e-6);
+    TS_ASSERT_DELTA(qY[6], 33.352157, 1e-6);
+    TS_ASSERT_DELTA(qY[8], 17.593911, 1e-6);
   }
 
   void
@@ -1515,32 +1515,32 @@ private:
                                                 MatrixWorkspace_sptr outQ,
                                                 int const wsIdx = 0) {
     auto const &lamY = outLam->y(wsIdx);
-    TS_ASSERT_EQUALS(lamY.size(), 10);
-    TS_ASSERT_DELTA(lamY[0], 13.906629, 1e-6);
-    TS_ASSERT_DELTA(lamY[6], 60.329214, 1e-6);
-    TS_ASSERT_DELTA(lamY[9], 83.364379, 1e-6);
+    TS_ASSERT_EQUALS(lamY.size(), 9);
+    TS_ASSERT_DELTA(lamY[0], 17.498454, 1e-6);
+    TS_ASSERT_DELTA(lamY[6], 64.597443, 1e-6);
+    TS_ASSERT_DELTA(lamY[8], 79.931971, 1e-6);
 
     auto const &qY = outQ->y(wsIdx);
-    TS_ASSERT_EQUALS(qY.size(), 10);
-    TS_ASSERT_DELTA(qY[0], 83.3643785180, 1e-6);
-    TS_ASSERT_DELTA(qY[6], 36.9686340548, 1e-6);
-    TS_ASSERT_DELTA(qY[9], 13.9066291140, 1e-6);
+    TS_ASSERT_EQUALS(qY.size(), 9);
+    TS_ASSERT_DELTA(qY[0], 79.931971, 1e-6);
+    TS_ASSERT_DELTA(qY[6], 33.265775, 1e-6);
+    TS_ASSERT_DELTA(qY[8], 17.498454, 1e-6);
   }
 
   void checkDetector3And4SummedInQ(MatrixWorkspace_sptr outLam,
                                    MatrixWorkspace_sptr outQ,
                                    int const wsIdx = 0) {
     auto const &lamY = outLam->y(wsIdx);
-    TS_ASSERT_EQUALS(lamY.size(), 10);
-    TS_ASSERT_DELTA(lamY[0], 24.275146, 1e-6);
-    TS_ASSERT_DELTA(lamY[6], 101.852986, 1e-6);
-    TS_ASSERT_DELTA(lamY[9], 140.267317, 1e-6);
+    TS_ASSERT_EQUALS(lamY.size(), 9);
+    TS_ASSERT_DELTA(lamY[0], 30.305029, 1e-6);
+    TS_ASSERT_DELTA(lamY[6], 108.995220, 1e-6);
+    TS_ASSERT_DELTA(lamY[8], 134.619316, 1e-6);
 
     auto const &qY = outQ->y(wsIdx);
-    TS_ASSERT_EQUALS(qY.size(), 10);
-    TS_ASSERT_DELTA(qY[0], 140.267317, 1e-6);
-    TS_ASSERT_DELTA(qY[6], 62.816137, 1e-6);
-    TS_ASSERT_DELTA(qY[9], 24.275146, 1e-6);
+    TS_ASSERT_EQUALS(qY.size(), 9);
+    TS_ASSERT_DELTA(qY[0], 134.619316, 1e-6);
+    TS_ASSERT_DELTA(qY[6], 56.637071, 1e-6);
+    TS_ASSERT_DELTA(qY[8], 30.305029, 1e-6);
   }
 
   double sumCounts(Mantid::HistogramData::Counts const &counts) {

--- a/Framework/Reflectometry/test/ReflectometryReductionOne2Test.h
+++ b/Framework/Reflectometry/test/ReflectometryReductionOne2Test.h
@@ -492,6 +492,8 @@ public:
     TS_ASSERT_DELTA(outLam->y(0)[7], 2.787410, 1e-6);
 
     checkConversionToQ(alg, twoThetaForDetector3() / 2.0);
+
+    TS_ASSERT_DELTA(sumCounts(outLam->counts(0)), 33.310938, 1e-6);
   }
 
   void test_sum_in_q_non_flat_sample() {
@@ -515,6 +517,8 @@ public:
     TS_ASSERT_DELTA(outLam->y(0)[7], 3.141920, 1e-6);
 
     checkConversionToQ(alg, twoThetaForDetector3() / 2.0);
+
+    TS_ASSERT_DELTA(sumCounts(outLam->counts(0)), 31.418985, 1e-6);
   }
 
   void test_sum_in_q_monitor_normalization() {
@@ -551,6 +555,8 @@ public:
     TS_ASSERT_DELTA(outLam->y(0)[9], 2.255101, 1e-6);
 
     checkConversionToQ(alg, twoThetaForDetector4() / 2.0, false, false);
+
+    TS_ASSERT_DELTA(sumCounts(outLam->counts(0)), 66.514113, 1e-6);
   }
 
   void test_sum_in_q_transmission_correction_run() {
@@ -572,6 +578,8 @@ public:
     TS_ASSERT_DELTA(outLam->y(0)[7], 0.886874, 1e-6);
 
     checkConversionToQ(alg, twoThetaForDetector3() / 2.0, true, false);
+
+    TS_ASSERT_DELTA(sumCounts(outLam->counts(0)), 21.030473, 1e-6);
   }
 
   void test_sum_in_q_exponential_correction() {
@@ -595,6 +603,8 @@ public:
     TS_ASSERT_DELTA(outLam->y(0)[7], 39.756736, 1e-6);
 
     checkConversionToQ(alg, twoThetaForDetector4() / 2.0);
+
+    TS_ASSERT_DELTA(sumCounts(outLam->counts(0)), 365.843555, 1e-6);
   }
 
   void test_sum_in_q_point_detector() {
@@ -620,6 +630,8 @@ public:
     TS_ASSERT_DELTA(outQ->y(0)[0], 2.900303, 1e-6);
     TS_ASSERT_DELTA(outQ->y(0)[3], 2.886945, 1e-6);
     TS_ASSERT_DELTA(outQ->y(0)[7], 2.607357, 1e-6);
+
+    TS_ASSERT_DELTA(sumCounts(outQ->counts(0)), 79.113420, 1e-6);
   }
 
   void test_sum_in_q_exclude_partial_bins() {
@@ -640,6 +652,8 @@ public:
     TS_ASSERT_DELTA(outLam->y(0)[7], 2.787199, 1e-6);
 
     checkConversionToQ(alg, twoThetaForDetector3() / 2.0);
+
+    TS_ASSERT_DELTA(sumCounts(outLam->counts(0)), 30.492737, 1e-6);
   }
 
   void test_sum_in_q_exclude_partial_bins_multiple_detectors() {
@@ -660,6 +674,8 @@ public:
     TS_ASSERT_DELTA(outLam->y(0)[7], 8.306563, 1e-6);
 
     checkConversionToQ(alg, twoThetaForDetector4() / 2.0);
+
+    TS_ASSERT_DELTA(sumCounts(outLam->counts(0)), 93.056874, 1e-6);
   }
 
   void test_angle_correction_is_done_for_sum_in_lambda_when_theta_provided() {
@@ -1525,5 +1541,9 @@ private:
     TS_ASSERT_DELTA(qY[0], 140.267317, 1e-6);
     TS_ASSERT_DELTA(qY[6], 62.816137, 1e-6);
     TS_ASSERT_DELTA(qY[9], 24.275146, 1e-6);
+  }
+
+  double sumCounts(Mantid::HistogramData::Counts const &counts) {
+    return std::accumulate(counts.cbegin(), counts.cend(), 0.0);
   }
 };

--- a/Framework/Reflectometry/test/ReflectometryReductionOne2Test.h
+++ b/Framework/Reflectometry/test/ReflectometryReductionOne2Test.h
@@ -554,7 +554,7 @@ public:
     TS_ASSERT_DELTA(outLam->y(0)[5], 2.249948, 1e-6);
     TS_ASSERT_DELTA(outLam->y(0)[9], 2.044359, 1e-6);
 
-    checkConversionToQ(alg, twoThetaForDetector4() / 2.0, false, false);
+    checkConversionToQ(alg, twoThetaForDetector4() / 2.0, false);
 
     TS_ASSERT_DELTA(sumCounts(outLam->counts(0)), 61.622606, 1e-6);
   }
@@ -577,7 +577,7 @@ public:
     TS_ASSERT_DELTA(outLam->y(0)[3], 0.883535, 1e-6);
     TS_ASSERT_DELTA(outLam->y(0)[7], 0.893197, 1e-6);
 
-    checkConversionToQ(alg, twoThetaForDetector3() / 2.0, true, false);
+    checkConversionToQ(alg, twoThetaForDetector3() / 2.0, false);
 
     TS_ASSERT_DELTA(sumCounts(outLam->counts(0)), 12.865793, 1e-6);
   }
@@ -1283,13 +1283,10 @@ private:
    *
    * @param alg : the algorithm, which has already been executed
    * @param theta : the theta to use in the conversion in degrees
-   * @param invert : if true, the Q bins are in inverted order to the lambda
-   * bins
    * @param checkCounts : if true, also check the counts in the bins are the
    * same
    */
   void checkConversionToQ(ReflectometryReductionOne2 &alg, const double theta,
-                          const bool invert = true,
                           const bool checkCounts = true) {
     // Extract arrays for convenience
     MatrixWorkspace_sptr outLam = alg.getProperty("OutputWorkspaceWavelength");
@@ -1303,22 +1300,17 @@ private:
     TS_ASSERT_EQUALS(edgesLam.size(), edgesQ.size());
     TS_ASSERT_EQUALS(countsLam.size(), countsQ.size());
 
-    // Convenience function for optionally inverting an index
-    auto lamIdx = [&invert](auto const idx, auto const len) {
-      return invert ? len - 1 - idx : idx;
-    };
-
     // Check converting the lambda value to Q gives the result we got
     auto const nEdges = edgesQ.size();
     auto const factor = 4 * M_PI * std::sin(theta * degToRad);
     for (size_t i = 0; i < nEdges; ++i)
-      TS_ASSERT_DELTA(edgesQ[i], factor / edgesLam[lamIdx(i, nEdges)], 1e-6);
+      TS_ASSERT_DELTA(edgesQ[i], factor / edgesLam[nEdges - 1 - i], 1e-6);
 
     if (checkCounts) {
       // Counts should be the same in matching bins
       auto const nCounts = countsQ.size();
       for (size_t i = 0; i < nCounts; ++i)
-        TS_ASSERT_DELTA(countsQ[i], countsLam[lamIdx(i, nCounts)], 1e-6);
+        TS_ASSERT_DELTA(countsQ[i], countsLam[nCounts - 1 - i], 1e-6);
     }
   }
 

--- a/Framework/Reflectometry/test/ReflectometryReductionOne2Test.h
+++ b/Framework/Reflectometry/test/ReflectometryReductionOne2Test.h
@@ -491,13 +491,7 @@ public:
     TS_ASSERT_DELTA(outLam->y(0)[3], 2.792649, 1e-6);
     TS_ASSERT_DELTA(outLam->y(0)[7], 2.787410, 1e-6);
 
-    MatrixWorkspace_sptr outQ = runAlgorithmQ(alg, 12);
-    TS_ASSERT_DELTA(outQ->x(0)[0], 0.265534, 1e-6);
-    TS_ASSERT_DELTA(outQ->x(0)[3], 0.347983, 1e-6);
-    TS_ASSERT_DELTA(outQ->x(0)[7], 0.593830, 1e-6);
-    TS_ASSERT_DELTA(outQ->y(0)[0], 2.816015, 1e-6);
-    TS_ASSERT_DELTA(outQ->y(0)[3], 2.794903, 1e-6);
-    TS_ASSERT_DELTA(outQ->y(0)[7], 2.654336, 1e-6);
+    checkConversionToQ(alg, twoThetaForDetector3() / 2.0);
   }
 
   void test_sum_in_q_non_flat_sample() {
@@ -520,13 +514,7 @@ public:
     TS_ASSERT_DELTA(outLam->y(0)[3], 3.141885, 1e-6);
     TS_ASSERT_DELTA(outLam->y(0)[7], 3.141920, 1e-6);
 
-    MatrixWorkspace_sptr outQ = runAlgorithmQ(alg, 10);
-    TS_ASSERT_DELTA(outQ->x(0)[0], 0.317653, 1e-6);
-    TS_ASSERT_DELTA(outQ->x(0)[3], 0.443303, 1e-6);
-    TS_ASSERT_DELTA(outQ->x(0)[7], 0.938025, 1e-6);
-    TS_ASSERT_DELTA(outQ->y(0)[0], 3.141937, 1e-6);
-    TS_ASSERT_DELTA(outQ->y(0)[3], 3.141912, 1e-6);
-    TS_ASSERT_DELTA(outQ->y(0)[7], 3.141877, 1e-6);
+    checkConversionToQ(alg, twoThetaForDetector3() / 2.0);
   }
 
   void test_sum_in_q_monitor_normalization() {
@@ -562,13 +550,7 @@ public:
     TS_ASSERT_DELTA(outLam->y(0)[5], 2.193650, 1e-6);
     TS_ASSERT_DELTA(outLam->y(0)[9], 2.255101, 1e-6);
 
-    MatrixWorkspace_sptr outQ = runAlgorithmQ(alg, 13);
-    TS_ASSERT_DELTA(outQ->x(0)[0], -6.423295, 1e-6);
-    TS_ASSERT_DELTA(outQ->x(0)[5], 0.761430, 1e-6);
-    TS_ASSERT_DELTA(outQ->x(0)[9], 0.401845, 1e-6);
-    TS_ASSERT_DELTA(outQ->y(0)[0], 5.040302, 1e-6);
-    TS_ASSERT_DELTA(outQ->y(0)[5], 2.193650, 1e-6);
-    TS_ASSERT_DELTA(outQ->y(0)[9], 2.255101, 1e-6);
+    checkConversionToQ(alg, twoThetaForDetector4() / 2.0, false, false);
   }
 
   void test_sum_in_q_transmission_correction_run() {
@@ -589,13 +571,7 @@ public:
     TS_ASSERT_DELTA(outLam->y(0)[3], 0.888541, 1e-6);
     TS_ASSERT_DELTA(outLam->y(0)[7], 0.886874, 1e-6);
 
-    MatrixWorkspace_sptr outQ = runAlgorithmQ(alg, 12);
-    TS_ASSERT_DELTA(outQ->x(0)[0], 0.265534, 1e-6);
-    TS_ASSERT_DELTA(outQ->x(0)[3], 0.347983, 1e-6);
-    TS_ASSERT_DELTA(outQ->x(0)[7], 0.593830, 1e-6);
-    TS_ASSERT_DELTA(outQ->y(0)[0], 3.959740, 1e-6);
-    TS_ASSERT_DELTA(outQ->y(0)[3], 0.889259, 1e-6);
-    TS_ASSERT_DELTA(outQ->y(0)[7], 0.844534, 1e-6);
+    checkConversionToQ(alg, twoThetaForDetector3() / 2.0, true, false);
   }
 
   void test_sum_in_q_exponential_correction() {
@@ -618,13 +594,7 @@ public:
     TS_ASSERT_DELTA(outLam->y(0)[3], 23.963534, 1e-6);
     TS_ASSERT_DELTA(outLam->y(0)[7], 39.756736, 1e-6);
 
-    MatrixWorkspace_sptr outQ = runAlgorithmQ(alg, 11);
-    TS_ASSERT_DELTA(outQ->x(0)[0], 0.292123, 1e-6);
-    TS_ASSERT_DELTA(outQ->x(0)[3], 0.393419, 1e-6);
-    TS_ASSERT_DELTA(outQ->x(0)[7], 0.731735, 1e-6);
-    TS_ASSERT_DELTA(outQ->y(0)[0], 58.425212, 1e-6);
-    TS_ASSERT_DELTA(outQ->y(0)[3], 39.756737, 1e-6);
-    TS_ASSERT_DELTA(outQ->y(0)[7], 23.963535, 1e-6);
+    checkConversionToQ(alg, twoThetaForDetector4() / 2.0);
   }
 
   void test_sum_in_q_point_detector() {
@@ -669,13 +639,7 @@ public:
     TS_ASSERT_DELTA(outLam->y(0)[3], 2.792424, 1e-6);
     TS_ASSERT_DELTA(outLam->y(0)[7], 2.787199, 1e-6);
 
-    MatrixWorkspace_sptr outQ = runAlgorithmQ(alg, 11);
-    TS_ASSERT_DELTA(outQ->x(0)[0], 0.288113, 1e-6);
-    TS_ASSERT_DELTA(outQ->x(0)[3], 0.387812, 1e-6);
-    TS_ASSERT_DELTA(outQ->x(0)[7], 0.720023, 1e-6);
-    TS_ASSERT_DELTA(outQ->y(0)[0], 2.808998, 1e-6);
-    TS_ASSERT_DELTA(outQ->y(0)[3], 2.787199, 1e-6);
-    TS_ASSERT_DELTA(outQ->y(0)[7], 2.792423, 1e-6);
+    checkConversionToQ(alg, twoThetaForDetector3() / 2.0);
   }
 
   void test_sum_in_q_exclude_partial_bins_multiple_detectors() {
@@ -695,13 +659,7 @@ public:
     TS_ASSERT_DELTA(outLam->y(0)[3], 8.521195, 1e-6);
     TS_ASSERT_DELTA(outLam->y(0)[7], 8.306563, 1e-6);
 
-    MatrixWorkspace_sptr outQ = runAlgorithmQ(alg, 11);
-    TS_ASSERT_DELTA(outQ->x(0)[0], 0.291466, 1e-6);
-    TS_ASSERT_DELTA(outQ->x(0)[3], 0.392230, 1e-6);
-    TS_ASSERT_DELTA(outQ->x(0)[7], 0.727631, 1e-6);
-    TS_ASSERT_DELTA(outQ->y(0)[0], 8.554743, 1e-6);
-    TS_ASSERT_DELTA(outQ->y(0)[3], 8.306564, 1e-6);
-    TS_ASSERT_DELTA(outQ->y(0)[7], 8.521194, 1e-6);
+    checkConversionToQ(alg, twoThetaForDetector4() / 2.0);
   }
 
   void test_angle_correction_is_done_for_sum_in_lambda_when_theta_provided() {
@@ -1302,6 +1260,50 @@ private:
     TS_ASSERT_EQUALS(outQ->blocksize(), blocksize);
 
     return outQ;
+  }
+
+  /** Check conversion of x values in a workspace in lambda to a workspace in Q
+   * has been done correctly. Optionally also check the counts.
+   *
+   * @param alg : the algorithm, which has already been executed
+   * @param theta : the theta to use in the conversion in degrees
+   * @param invert : if true, the Q bins are in inverted order to the lambda
+   * bins
+   * @param checkCounts : if true, also check the counts in the bins are the
+   * same
+   */
+  void checkConversionToQ(ReflectometryReductionOne2 &alg, const double theta,
+                          const bool invert = true,
+                          const bool checkCounts = true) {
+    // Extract arrays for convenience
+    MatrixWorkspace_sptr outLam = alg.getProperty("OutputWorkspaceWavelength");
+    MatrixWorkspace_sptr outQ = alg.getProperty("OutputWorkspace");
+    auto const &edgesLam = outLam->binEdges(0);
+    auto const &edgesQ = outQ->binEdges(0);
+    auto const &countsLam = outLam->counts(0);
+    auto const &countsQ = outQ->counts(0);
+
+    // Check lengths match
+    TS_ASSERT_EQUALS(edgesLam.size(), edgesQ.size());
+    TS_ASSERT_EQUALS(countsLam.size(), countsQ.size());
+
+    // Convenience function for optionally inverting an index
+    auto lamIdx = [&invert](auto const idx, auto const len) {
+      return invert ? len - 1 - idx : idx;
+    };
+
+    // Check converting the lambda value to Q gives the result we got
+    auto const nEdges = edgesQ.size();
+    auto const factor = 4 * M_PI * std::sin(theta * degToRad);
+    for (size_t i = 0; i < nEdges; ++i)
+      TS_ASSERT_DELTA(edgesQ[i], factor / edgesLam[lamIdx(i, nEdges)], 1e-6);
+
+    if (checkCounts) {
+      // Counts should be the same in matching bins
+      auto const nCounts = countsQ.size();
+      for (size_t i = 0; i < nCounts; ++i)
+        TS_ASSERT_DELTA(countsQ[i], countsLam[lamIdx(i, nCounts)], 1e-6);
+    }
   }
 
   void setYValuesToWorkspace(MatrixWorkspace &ws) {


### PR DESCRIPTION
*Experimental work*

This fixes a minor bug in ReflectometryReductionOne where an incorrect range was being used to construct the output workspace when summing in Q.

**To test:**
- Ensure your default save directory is set, and that it is also in your search directories for loading.
- Run the following script in v5.1.1:
```
Load(Filename='INTER43583', OutputWorkspace='INTER43583')
ReflectometryReductionOne(InputWorkspace='INTER43583', WavelengthMin=1.5, WavelengthMax=17.0,
                          ThetaIn=1.3, ProcessingInstructions='47-61',
                          SummationType='SumInQ', ReductionType='DivergentBeam')
SaveNexus(InputWorkspace='IvsQ_43583', Filename='IvsQ_43583_reference.nxs')
```
- Run this script in this dev version
```
Load(Filename='INTER43583', OutputWorkspace='INTER43583')
ReflectometryReductionOne(InputWorkspace='INTER43583', WavelengthMin=1.5, WavelengthMax=17.0,
                          ThetaIn=1.3, ProcessingInstructions='47-61',
                          SummationType='SumInQ', ReductionType='DivergentBeam')
#SaveNexus(InputWorkspace='IvsQ_43583', Filename='IvsQ_43583_reference.nxs')
Load(Filename='IvsQ_43583_reference.nxs', OutputWorkspace='IvsQ_43583_reference')
RebinToWorkspace('IvsQ_43583', 'IvsQ_43583_reference', OutputWorkspace='IvsQ_43583')
Divide('IvsQ_43583', 'IvsQ_43583_reference', OutputWorkspace='IvsQ_43583_difference')
```
- Plot `IvsQ_43583` and `IvsQ_43583_reference`. They should be very similar except the reference has a slightly larger range, and the binning is slightly different.
- Plot `IvsQ_43583_difference`. It should be close to 1 and not contain any structural information/pattern.

Refs #23012

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
-->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
