### PR TITLE
Add option to use bounding box for theta width calculation

### DIFF
--- a/Framework/Reflectometry/inc/MantidReflectometry/ReflectometrySumInQ.h
+++ b/Framework/Reflectometry/inc/MantidReflectometry/ReflectometrySumInQ.h
@@ -77,6 +77,10 @@ private:
   Angles referenceAngles(const API::SpectrumInfo &spectrumInfo);
   API::MatrixWorkspace_sptr sumInQ(const API::MatrixWorkspace &detectorWS,
                                    const Indexing::SpectrumIndexSet &indices);
+  Mantid::Reflectometry::ReflectometrySumInQ::MinMax
+  twoThetaWidth(const size_t wsIndex,
+                const Mantid::API::SpectrumInfo &spectrumInfo,
+                const Mantid::API::MatrixWorkspace &workspace);
 };
 
 } // namespace Reflectometry


### PR DESCRIPTION
*Experimental work*

Add an option to ReflectometrySumInQ to use the bounding box to calculate the theta size of pixels. The original calculation uses the distance between adjacent pixel centres but our scientists think that this may not always be ideal if there are significant gaps between pixels.

There is no urgent requirement for this but we are planning to use ReflectometrySumInQ in ReflectometryReductionOne, and the latter currently uses the bounding box method, so we would like to stick with that for instruments where we know the bounding box.