### PR TITLE
Tweak system test tolerance to cover all platforms

### DIFF
--- a/Testing/SystemTests/tests/framework/CorelliPowderCalibrationTest.py
+++ b/Testing/SystemTests/tests/framework/CorelliPowderCalibrationTest.py
@@ -34,7 +34,7 @@ class CorelliPowderCalibrationCreateTest(MantidSystemTest):
         assert_allclose(table.row(0)['Zposition'], -19.994, atol=0.002)
         # Check position of bank42
         assert_allclose([table.row(1)[x] for x in ('Xposition', 'Yposition', 'Zposition')],
-                        [2.594, 0.063, 0.087], atol=0.005)
+                        [2.594, 0.063, 0.087], atol=0.006)
         # Check rotation of bank87
         assert_allclose([table.row(2)[x] for x in ('XdirectionCosine', 'YdirectionCosine', 'ZdirectionCosine')],
                         [-0.01, -1.00, 0.03], atol=0.05)


### PR DESCRIPTION
**Description of work.**

Tests on Ubuntu 18.04/macOS with GSL2 were failing due
to a difference just over the tolerance for the first value.

**To test:**

Code review and check system tests still pass

*There is no associated issue.*

*This does not require release notes* because **fixes an internal test for new functionality**

<!-- Ensure the base of this PR is correct (e.g. release-next or master)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
