### PR TITLE
Sliceviewer exception when zooming in

### DIFF
--- a/docs/source/release/v6.0.0/mantidworkbench.rst
+++ b/docs/source/release/v6.0.0/mantidworkbench.rst
@@ -54,5 +54,6 @@ Bugfixes
 - The colorfill plot on ragged workspaces will have the correct horizontal extent.
 - Fix replot of colorfill image after a workspace is replaced.
 - Fixed a bug causing an error when double clicking a ragged workspace.
+- Fixed a bug which caused a terminate dialogue to be raised if the user zoomed in far enough while using the SliceViewer on MDE workspaces.
 
 :ref:`Release 6.0.0 <v6.0.0>`

--- a/qt/python/mantidqt/widgets/sliceviewer/model.py
+++ b/qt/python/mantidqt/widgets/sliceviewer/model.py
@@ -21,6 +21,8 @@ from .transform import NonOrthogonalTransform
 # Constants
 PROJ_MATRIX_LOG_NAME = "W_MATRIX"
 LOG_GET_WS_MDE_ALGORITHM_CALLS = False
+# min width between data limits (data_min, data_max)
+MIN_WIDTH = 1e-5
 
 
 class WS_TYPE(Enum):
@@ -31,6 +33,7 @@ class WS_TYPE(Enum):
 
 class SliceViewerModel:
     """Store the workspace to be plotted. Can be MatrixWorkspace, MDEventWorkspace or MDHistoWorkspace"""
+
     def __init__(self, ws):
         # reference to the workspace requested to be viewed
         self._ws = ws
@@ -346,14 +349,14 @@ class SliceViewerModel:
             limits = limits[1], limits[0]
         xindex, yindex = _display_indices(slicepoint)
         dim_limits = _dimension_limits(workspace, slicepoint, limits)
-        # Construct paramters to integrate everything first and overrid per cut
-        params = {f'P{n+1}Bin': [*dim_limits[n]] for n in range(workspace.getNumDims())}
+        # Construct parameters to integrate everything first and override per cut
+        params = {f'P{n + 1}Bin': [*dim_limits[n]] for n in range(workspace.getNumDims())}
 
         xdim_min, xdim_max = dim_limits[xindex]
         ydim_min, ydim_max = dim_limits[yindex]
         params['OutputWorkspace'] = self._roi_name
-        params[f'P{xindex+1}Bin'] = [xdim_min, 0, xdim_max]
-        params[f'P{yindex+1}Bin'] = [ydim_min, 0, ydim_max]
+        params[f'P{xindex + 1}Bin'] = [xdim_min, 0, xdim_max]
+        params[f'P{yindex + 1}Bin'] = [ydim_min, 0, ydim_max]
         IntegrateMDHistoWorkspace(InputWorkspace=workspace, **params)
         if transpose:
             _inplace_transposemd(self._roi_name, axes=[yindex, xindex])
@@ -379,7 +382,7 @@ class SliceViewerModel:
             limits = limits[1], limits[0]
         dim_limits = _dimension_limits(workspace, slicepoint, limits)
         # Construct paramters to integrate everything first and overrid per cut
-        params = {f'P{n+1}Bin': [*dim_limits[n]] for n in range(workspace.getNumDims())}
+        params = {f'P{n + 1}Bin': [*dim_limits[n]] for n in range(workspace.getNumDims())}
         xindex, yindex = _display_indices(slicepoint, transpose)
 
         xcut_name, ycut_name, help_msg = self._cut_names(cut)
@@ -387,13 +390,13 @@ class SliceViewerModel:
         ydim_min, ydim_max = dim_limits[yindex]
         if xcut_name:
             params['OutputWorkspace'] = xcut_name
-            params[f'P{xindex+1}Bin'] = [xdim_min, 0, xdim_max]
+            params[f'P{xindex + 1}Bin'] = [xdim_min, 0, xdim_max]
             IntegrateMDHistoWorkspace(InputWorkspace=workspace, **params)
             _keep_dimensions(xcut_name, xindex)
         if ycut_name:
             params['OutputWorkspace'] = ycut_name
-            params[f'P{xindex+1}Bin'] = [xdim_min, xdim_max]
-            params[f'P{yindex+1}Bin'] = [ydim_min, 0, ydim_max]
+            params[f'P{xindex + 1}Bin'] = [xdim_min, xdim_max]
+            params[f'P{yindex + 1}Bin'] = [ydim_min, 0, ydim_max]
             IntegrateMDHistoWorkspace(InputWorkspace=workspace, **params)
             _keep_dimensions(ycut_name, yindex)
 
@@ -544,6 +547,8 @@ def _roi_binmd_parameters(workspace, slicepoint: Sequence[Optional[float]],
         else:
             dim_min, dim_max = slice_pt - nbins / 2, slice_pt + nbins / 2
             nbins = 1
+        if dim_max - dim_min < MIN_WIDTH:
+            dim_max = dim_min + MIN_WIDTH
         params[f'BasisVector{n}'] = f'{dimension.name},{dimension.getUnits()},{basis_vec_n}'
         output_extents.append(dim_min)
         output_extents.append(dim_max)

--- a/qt/python/mantidqt/widgets/sliceviewer/test/test_sliceviewer_model.py
+++ b/qt/python/mantidqt/widgets/sliceviewer/test/test_sliceviewer_model.py
@@ -20,7 +20,7 @@ import numpy as np
 
 # Mock out simpleapi to import expensive import of something we patch out anyway
 sys.modules['mantid.simpleapi'] = MagicMock()
-from mantidqt.widgets.sliceviewer.model import SliceViewerModel, WS_TYPE  # noqa: E402
+from mantidqt.widgets.sliceviewer.model import SliceViewerModel, WS_TYPE, MIN_WIDTH  # noqa: E402
 
 
 # Mock helpers
@@ -69,7 +69,7 @@ def _create_mock_mdeventworkspace(ndims: int, coords: SpecialCoordinateSystem, e
     :param isq: Boolean for each dimension defining if Q or not
     """
     ws = _create_mock_workspace(IMDEventWorkspace, coords, has_oriented_lattice=False, ndims=ndims)
-    return _add_dimensions(ws, names, isq, extents, nbins=(1, ) * ndims, units=units)
+    return _add_dimensions(ws, names, isq, extents, nbins=(1,) * ndims, units=units)
 
 
 def _create_mock_matrixworkspace(x_axis: tuple,
@@ -338,6 +338,28 @@ class SliceViewerModelTest(unittest.TestCase):
 
         model.get_data((None, None, 0), (1, 2, 4), ((-2, 2), (-1, 1)))
         mock_binmd.assert_called_once_with(**call_params)
+
+    @patch('mantidqt.widgets.sliceviewer.model.BinMD')
+    def test_get_ws_mde_sets_minimum_width_on_data_limits(self, mock_binmd):
+        model = SliceViewerModel(self.ws_MDE_3D)
+        mock_binmd.return_value = self.ws_MD_3D
+        xmin = -5e-8
+        xmax = 5e-8
+
+        self.assertNotEqual(model.get_ws((None, None, 0), (1, 2, 4), ((xmin, xmax), (-1, 1))),
+                            self.ws_MDE_3D)
+
+        call_params = dict(AxisAligned=False,
+                           BasisVector0='h,rlu,1.0,0.0,0.0',
+                           BasisVector1='k,rlu,0.0,1.0,0.0',
+                           BasisVector2='l,rlu,0.0,0.0,1.0',
+                           EnableLogging=False,
+                           InputWorkspace=self.ws_MDE_3D,
+                           OutputBins=[1, 2, 1],
+                           OutputExtents=[xmin, xmin + MIN_WIDTH, -1, 1, -2.0, 2.0],
+                           OutputWorkspace='ws_MDE_3D_svrebinned')
+        mock_binmd.assert_called_once_with(**call_params)
+        mock_binmd.reset_mock()
 
     def test_model_matrix(self):
         model = SliceViewerModel(self.ws2d_histo)
@@ -824,9 +846,8 @@ class SliceViewerModelTest(unittest.TestCase):
                                                                 mock_binmd):
         def assert_error_returned_in_help(workspace, export_type, mock_alg, err_msg):
             model = SliceViewerModel(workspace)
-            slicepoint, bin_params = MagicMock(), MagicMock()
+            slicepoint, bin_params = (None, None, None), MagicMock()
             mock_alg.side_effect = RuntimeError(err_msg)
-
             try:
                 if export_type == 'r':
                     help_msg = model.export_roi_to_workspace(slicepoint, bin_params,


### PR DESCRIPTION
**Description of work.**
This PR fixes an exception in the sliceviewer when zooming far enough in on an MDE workspace. This was due to the difference between the matplotlib extents becoming small enough such that the C++ code treated them as equal. This meant that the vectors used to define the planes could become zero vectors.

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

**To test:**
Run the following script

```
from mantid.simpleapi import *
SXD23767 = Load(Filename='/SXD23767.raw', LoadMonitors='Exclude',SpectrumMax=1000)
SetUB(SXD23767,a=1,b=1,c=1,alpha=90,beta=90,gamma=120)
mdws=ConvertToMD( InputWorkspace=SXD23767, QDimensions="Q3D", Q3DFrames='HKL',
                                  dEAnalysisMode="Elastic", QConversionScales="Q in A^-1",
   	                              LorentzCorrection='1',
                                  SplitInto='2', SplitThreshold='50',MaxRecursionDepth='14' )

```
and just keep zooming, it should no longer give you a terminate dialogue. Try this in the non-orthognal view as well (click the set of three axis on the plot toolbar)

Fixes #30178. <!-- and fix #xxxx or close #xxxx xor resolves #xxxx -->
<!-- alternative
*There is no associated issue.*
-->

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or master)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
