### PR TITLE
Minor change to the theta width calculation in ReflectometryTransform

### DIFF
--- a/Framework/DataObjects/inc/MantidDataObjects/ReflectometryTransform.h
+++ b/Framework/DataObjects/inc/MantidDataObjects/ReflectometryTransform.h
@@ -27,8 +27,8 @@ class TableWorkspace;
 Simple container for porting detector angular information
  */
 struct MANTID_DATAOBJECTS_DLL DetectorAngularCache {
-  std::vector<double> thetaWidths;
-  std::vector<double> thetas;
+  std::vector<double> twoThetaWidths;
+  std::vector<double> twoThetas;
   std::vector<double> detectorHeights;
 };
 
@@ -51,11 +51,6 @@ protected:
   const std::string m_d0ID;
   const std::string m_d1ID;
   std::shared_ptr<CalculateReflectometry> m_calculator;
-
-  /// Two theta angles cache
-  mutable std::vector<double> m_theta;
-  /// Two theta widths cache
-  mutable std::vector<double> m_thetaWidths;
 
   std::shared_ptr<DataObjects::MDEventWorkspace2Lean>
   createMDWorkspace(const Geometry::IMDDimension_sptr &,

--- a/Framework/DataObjects/src/ReflectometryTransform.cpp
+++ b/Framework/DataObjects/src/ReflectometryTransform.cpp
@@ -264,8 +264,9 @@ DetectorAngularCache initAngularCaches(const MatrixWorkspace *const workspace) {
     auto minPoint(bbox.minPoint());
     auto span = maxPoint - minPoint;
     detectorHeights[i] = span.scalar_prod(upDirVec);
-    twoThetaWidths[i] =
-        2.0 * std::fabs(std::atan((detectorHeights[i] / 2) / l2)) * rad2deg;
+    twoThetaWidths[i] = (std::atan(maxPoint.scalar_prod(upDirVec) / l2) -
+                         std::atan(minPoint.scalar_prod(upDirVec) / l2)) *
+                        rad2deg;
   }
   DetectorAngularCache cache;
   cache.twoThetas = twoThetas;

--- a/Framework/DataObjects/test/ReflectometryTransformTest.h
+++ b/Framework/DataObjects/test/ReflectometryTransformTest.h
@@ -48,13 +48,13 @@ public:
 
     TS_ASSERT_DELTA(0.04, cache.detectorHeights[0], 1e-6);
 
-    auto calculatedThetaW =
+    auto calculatedTwoThetaW =
         2.0 * std::fabs(std::atan((cache.detectorHeights[0] / 2) / l2)) *
         180.0 / M_PI;
 
     TSM_ASSERT_DELTA(
         "Calculated theta width should agree with detector height calculation",
-        cache.thetaWidths[0], calculatedThetaW, 1e-6)
+        cache.twoThetaWidths[0], calculatedTwoThetaW, 1e-6)
   }
 
   void test_cache_calculation_when_x_is_up() {


### PR DESCRIPTION
**Report to:** Max at ISIS

Scientists requested to change the calculation of theta widths in ReflectometryTransform (used by ConvertToReflectometryQ) because the original calculation did not seem to make sense. The difference should be very small - in fact there is no change in the unit test results to 1e-9.

This PR also does some tidying of variable names to make it clear that we are using twoTheta rather than theta (see also #29764)

**To test:**

Check that `ConvertToReflectometryQ` (which uses ReflectometryTransform) runs ok and produces sensible output, e.g. the example in the following script contains a bragg sheet, which displays as a vertical line when correctly converted to QxQz. Slight errors would cause this line to go off vertical.

```
name = "POLREF4699"

PIX=1.1E-3 #m
SC=75
avgDB=29
Load(Filename=name,OutputWorkspace=name)

ConvertUnits(InputWorkspace=name,OutputWorkspace=name,Target="Wavelength",AlignBins="1")
CropWorkspace(InputWorkspace=name,OutputWorkspace='Io',XMin=0.8,XMax=14.5,StartWorkspaceIndex=2,EndWorkspaceIndex=2)                                                                              
CropWorkspace(InputWorkspace=name,OutputWorkspace='D',XMin=0.8,XMax=14.5,StartWorkspaceIndex=3)
Divide(LHSWorkspace='D',RHSWorkspace='Io',OutputWorkspace='I', AllowDifferentNumberSpectra='1',ClearRHSWorkspace='1')
MoveInstrumentComponent(Workspace='I',ComponentName="lineardetector",X=0,Y=0,Z=-PIX*( (SC-avgDB)/2.0 +avgDB) )
ConvertSpectrumAxis(InputWorkspace='I',OutputWorkspace='SignedTheta_vs_Wavelength',Target='signed_theta')
QxQy, _QxQy_vertexes = ConvertToReflectometryQ(InputWorkspace='SignedTheta_vs_Wavelength',
    #OutputAsMDWorkspace=False,
    OutputDimensions='Q (lab frame)', Extents='-0.0005,0.0005,0,0.12')
```

![image](https://user-images.githubusercontent.com/12895056/103928743-2e205a00-5114-11eb-80c7-50a5d52550f7.png)

Refs #20327

*This does not require release notes* because **the difference in the results is negligible**

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
