### PR TITLE
Print missing mask files instead of blank line

### DIFF
--- a/docs/source/release/v6.0.0/sans.rst
+++ b/docs/source/release/v6.0.0/sans.rst
@@ -35,5 +35,6 @@ Bugfixes
   in a colour fill plot on Workbench.
 - Wavelength limits entered with comma ranges larger than 10, e.g. `1,5,10,15` no longer
   throw a Runtime Error.
+- ISIS SANS will print the name of any missing maskfiles instead of an empty name.
 
 :ref:`Release 6.0.0 <v6.0.0>`

--- a/scripts/SANS/sans/algorithm_detail/mask_workspace.py
+++ b/scripts/SANS/sans/algorithm_detail/mask_workspace.py
@@ -127,10 +127,17 @@ def mask_with_mask_files(mask_info, inst_info, workspace):
         load_alg = create_unmanaged_algorithm(load_name, **load_options)
         mask_alg = create_unmanaged_algorithm("MaskDetectors")
 
-        # Masker
-        for mask_file in mask_files:
-            mask_file = find_full_file_path(mask_file)
+        file_paths = [find_full_file_path(i) for i in mask_files]
+        # Find full file path returns an empty string, so we need to remake it
+        missing_file_paths = [mask_files[i] for i, path in enumerate(file_paths) if not path]
 
+        if missing_file_paths:
+            err_str = "The following mask files are missing:"
+            err_str += "\n".join(missing_file_paths)
+            raise FileNotFoundError(err_str)
+
+        # Masker
+        for mask_file in file_paths:
             # Get the detector ids which need to be masked
             load_alg.setProperty("InputFile", mask_file)
             load_alg.execute()

--- a/scripts/test/SANS/algorithm_detail/CMakeLists.txt
+++ b/scripts/test/SANS/algorithm_detail/CMakeLists.txt
@@ -9,6 +9,7 @@ set(TEST_PY_FILES
     create_sans_wavelength_pixel_adjustment_test.py
     convert_to_q_test.py
     crop_helper_test.py
+    mask_workspace_test.py
     mask_sans_workspace_test.py
     merge_reductions_test.py
     move_sans_instrument_component_test.py

--- a/scripts/test/SANS/algorithm_detail/mask_workspace_test.py
+++ b/scripts/test/SANS/algorithm_detail/mask_workspace_test.py
@@ -1,0 +1,33 @@
+# Mantid Repository : https://github.com/mantidproject/mantid
+#
+# Copyright &copy; 2020 ISIS Rutherford Appleton Laboratory UKRI,
+#     NScD Oak Ridge National Laboratory, European Spallation Source
+#     & Institut Laue - Langevin
+# SPDX - License - Identifier: GPL - 3.0 +
+import unittest
+from unittest import mock
+
+from sans.algorithm_detail.mask_workspace import mask_with_mask_files
+
+
+class MaskWorkspaceTest(unittest.TestCase):
+    @mock.patch("sans.algorithm_detail.mask_workspace.find_full_file_path")
+    @mock.patch("sans.algorithm_detail.mask_workspace.create_unmanaged_algorithm")
+    def test_raises_if_file_not_found(self, _1, finder):
+        mask_info, inst_info = mock.Mock(), mock.Mock()
+        mask_info.mask_files = ["filename", "filename2"]
+        finder.return_value = None
+        with self.assertRaisesRegex(FileNotFoundError, "(?=filename)(?=filename2)"):
+            mask_with_mask_files(mask_info, inst_info, workspace=None)
+
+    @mock.patch("sans.algorithm_detail.mask_workspace.find_full_file_path")
+    @mock.patch("sans.algorithm_detail.mask_workspace.create_unmanaged_algorithm")
+    def test_does_not_raise_if_found(self, _1, finder):
+        finder.return_value = "some_path"
+        mask_info, inst_info = mock.Mock(), mock.Mock()
+        mask_info.mask_files = [mock.Mock(), mock.Mock()]
+        self.assertIsNotNone(mask_with_mask_files(mask_info, inst_info, workspace=None))
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
**Description of work.**

File finder will return an empty string if the path does not exist. This
means the error message that is produced is also blank.

As most user files use multiple mask files we should instead print every
missing file up-front, rather than one at a time too


**To test:**
- Download and extract the ISIS Training data
- Open the LOQ demo folder and modify `maskfile.txt`, add the following line anywhere:
`MASKFILE=tubes_beg_18_4.xml,not_there2.xml`
- Open Mantid -> SANS -> ISIS SANS
- Click User file, change the file type selector from TOML to txt
- Open Maskfile.txt
- Click batch file, go to Loq Demo and select CSV
- Select the first row, hit process
- You should get an error with the two file names above
- Go back to the LOQ Demo folder and remove that line
- Re-open the mask file in the GUI, to load in the changes
- Hit process again, this should work

There is no associated issue.
<!-- Ensure the base of this PR is correct (e.g. release-next or master)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
