### PR TITLE
MaxEnt in FDA crash

### DIFF
--- a/docs/source/release/v6.0.0/muon.rst
+++ b/docs/source/release/v6.0.0/muon.rst
@@ -28,6 +28,7 @@ Bug fixes
 - Fixed a crash when adding the DynamicKuboToyabe function on the fitting tab of Muon Analysis.
 - Fixed an error caused by switching to Simultaneous fitting when TF Asymmetry mode is ticked.
 - Fixed an error caused by switching between the Run and Group/Pair selection when TF Asymmetry mode is ticked.
+- Fixed a bug that can sometimes cause the MaxEnt calculation to fail in frequency domain analysis.
 
 ALC
 ---

--- a/scripts/Muon/GUI/Common/contexts/muon_context.py
+++ b/scripts/Muon/GUI/Common/contexts/muon_context.py
@@ -408,6 +408,7 @@ class MuonContext(object):
         if self.gui_context['DeadTimeSource'] == 'FromADS':
             return self.gui_context['DeadTimeTable']
         elif self.gui_context['DeadTimeSource'] == 'FromFile':
+            print(run, "moo")
             return self.data_context.get_loaded_data_for_run([float(run)])["DataDeadTimeTable"]
         elif self.gui_context['DeadTimeSource'] == 'None':
             return None

--- a/scripts/Muon/GUI/Common/contexts/muon_context.py
+++ b/scripts/Muon/GUI/Common/contexts/muon_context.py
@@ -408,7 +408,6 @@ class MuonContext(object):
         if self.gui_context['DeadTimeSource'] == 'FromADS':
             return self.gui_context['DeadTimeTable']
         elif self.gui_context['DeadTimeSource'] == 'FromFile':
-            print(run, "moo")
             return self.data_context.get_loaded_data_for_run([float(run)])["DataDeadTimeTable"]
         elif self.gui_context['DeadTimeSource'] == 'None':
             return None

--- a/scripts/Muon/GUI/FrequencyDomainAnalysis/MaxEnt/maxent_presenter_new.py
+++ b/scripts/Muon/GUI/FrequencyDomainAnalysis/MaxEnt/maxent_presenter_new.py
@@ -69,10 +69,6 @@ class MaxEntPresenter(object):
         if self.maxent_alg is not None:
             self.maxent_alg.cancel()
 
-            # Need to set this as sent as part of calculation finished signal
-            self._maxent_output_workspace_name = get_maxent_workspace_name(
-                self.get_parameters_for_maxent_calculation()['InputWorkspace'])
-
     # turn on button
     def activate(self):
         self.view.activateCalculateButton()
@@ -83,6 +79,8 @@ class MaxEntPresenter(object):
 
     def createThread(self):
         self.maxent_alg = mantid.AlgorithmManager.create("MuonMaxent")
+        self._maxent_output_workspace_name = get_maxent_workspace_name(
+            self.get_parameters_for_maxent_calculation()['InputWorkspace'])
         calculation_function = functools.partial(self.calculate_maxent, self.maxent_alg)
         self._maxent_calculation_model = ThreadModelWrapper(calculation_function)
         return thread_model.ThreadModel(self._maxent_calculation_model)
@@ -118,7 +116,7 @@ class MaxEntPresenter(object):
         inputs = {}
 
         inputs['InputWorkspace'] = self.view.input_workspace
-        run = [float(re.search('[0-9]+', inputs['InputWorkspace']).group())]
+        run = float(re.search('[0-9]+', inputs['InputWorkspace']).group())
 
         if self.view.phase_table != 'Construct':
             inputs['InputPhaseTable'] = self.view.phase_table
@@ -126,9 +124,9 @@ class MaxEntPresenter(object):
         if self.load.dead_time_table(run):
             inputs['InputDeadTimeTable'] = self.load.dead_time_table(run)
 
-        inputs['FirstGoodTime'] = self.load.first_good_data(run)
+        inputs['FirstGoodTime'] = self.load.first_good_data([run])
 
-        inputs['LastGoodTime'] = self.load.last_good_data(run)
+        inputs['LastGoodTime'] = self.load.last_good_data([run])
 
         inputs['Npts'] = self.view.num_points
 


### PR DESCRIPTION
**Description of work.**
This does not happen on every machine. I think it is some sort of race condition. This fix removes the condition. Please check that  you can reproduce the original bug to ensure it is fixed.
<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

**To test:**
Open Frequency domain analysis
Load MUSR 62260
Go to the transform tab
Press calculate an FFT
Change the combo box at the top of the tab to MaxEnt
Press calculate
Press cancel - it shouldn't crash
Press calculate again, let it complete
You should get a nice plot - it use to crash.
<!-- Instructions for testing. -->

Fixes #30188. <!-- and fix #xxxx or close #xxxx xor resolves #xxxx -->
<!-- alternative
*There is no associated issue.*
-->

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or master)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
