### PR TITLE
Generate cppcheck suppressions based on ENABLE_MANTIDPLOT

### DIFF
--- a/buildconfig/CMake/CppCheckSetup.cmake
+++ b/buildconfig/CMake/CppCheckSetup.cmake
@@ -5,7 +5,11 @@ if ( CPPCHECK_EXECUTABLE )
   # We must export the compile commands for cppcheck to be able to check
   # everything correctly
   set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
-
+  if(ENABLE_MANTIDPLOT)
+    set(MANTIDPLOT_CPPCHECK_SUPPRESSIONS "*:${CMAKE_SOURCE_DIR}/MantidPlot/src/zlib123/*
+*:${CMAKE_SOURCE_DIR}/MantidPlot/src/origin/tree.hh
+*:${CMAKE_SOURCE_DIR}/MantidPlot/src/nrutil.cpp")
+  endif()
   configure_file(${CMAKE_SOURCE_DIR}/buildconfig/CMake/CppCheck_Suppressions.txt.in ${CMAKE_BINARY_DIR}/CppCheck_Suppressions.txt)
 
   # setup the standard arguments
@@ -34,7 +38,7 @@ if ( CPPCHECK_EXECUTABLE )
     list( APPEND _cppcheck_xml_args  ${_cppcheck_source_dirs} )
   endif (CPPCHECK_GENERATE_XML)
 
-  
+
 
   # generate the target
   if (NOT TARGET cppcheck)

--- a/buildconfig/CMake/CppCheck_Suppressions.txt.in
+++ b/buildconfig/CMake/CppCheck_Suppressions.txt.in
@@ -45,8 +45,6 @@ syntaxError:${CMAKE_SOURCE_DIR}/Framework/API/src/MatrixWorkspace.cpp
 
 // Mantid Plot specific ones we probably won't fix before removal
 
-*:${CMAKE_SOURCE_DIR}/MantidPlot/src/origin/tree.hh
-*:${CMAKE_SOURCE_DIR}/MantidPlot/src/nrutil.cpp
 
 pureVirtualCall:${CMAKE_SOURCE_DIR}/qt/scientific_interfaces/Indirect/IndirectBayesTab.cpp
 pureVirtualCall:${CMAKE_SOURCE_DIR}/qt/scientific_interfaces/Indirect/IndirectBayesTab.h
@@ -95,4 +93,4 @@ noCopyConstructor:${CMAKE_SOURCE_DIR}/Framework/Geometry/inc/MantidGeometry/Rend
 *:${CMAKE_SOURCE_DIR}/Framework/ICat/src/GSoap/*
 *:${CMAKE_SOURCE_DIR}/Framework/ICat/src/ICat3/GSoapGenerated/*
 *:${CMAKE_SOURCE_DIR}/Framework/ICat/src/ICat4/GSoapGenerated/*
-*:${CMAKE_SOURCE_DIR}/MantidPlot/src/zlib123/*
+${MANTIDPLOT_CPPCHECK_SUPPRESSIONS}


### PR DESCRIPTION
**Description of work.**

When we disabled MantidPlot by default in CMake we caused cppcheck to start issuing unmatched suppression warnings like [this](https://builds.mantidproject.org/job/pull_requests-cppcheck/42189/cppcheckResult/)

This generates the suppressions based on the flag. Currently the Jenkins job has been hardcoded to set `-DENABLE_MANTIDPLOT=ON` but once this is merged it can be set back to just running the `cppcheck.sh` script.

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

**To test:**

* Run cppcheck against a config with ENABLE_MANTIDPLOT=OFF and it should no longer produce any cppcheck warnings.

*There is no associated issue.*

*This does not require release notes* because **it is an internal change**

<!-- Ensure the base of this PR is correct (e.g. release-next or master)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
