### PR TITLE
Indirect Save Detector Grouping in default directory.

### DIFF
--- a/qt/scientific_interfaces/Indirect/ISISEnergyTransfer.cpp
+++ b/qt/scientific_interfaces/Indirect/ISISEnergyTransfer.cpp
@@ -9,6 +9,7 @@
 #include "MantidAPI/AlgorithmManager.h"
 #include "MantidAPI/MatrixWorkspace.h"
 #include "MantidAPI/WorkspaceGroup.h"
+#include "MantidKernel/ConfigService.h"
 #include "MantidQtWidgets/Common/AlgorithmDialog.h"
 #include "MantidQtWidgets/Common/InterfaceManager.h"
 #include "MantidQtWidgets/Common/UserInputValidator.h"
@@ -622,9 +623,14 @@ void ISISEnergyTransfer::includeExtraGroupingOption(bool includeOption,
 void ISISEnergyTransfer::handleSaveCustomGroupingClicked() {
   createCustomGroupingWorkspace();
   if (doesExistInADS(GROUPING_WS_NAME)) {
+    auto const saveDirectory =
+        Mantid::Kernel::ConfigService::Instance().getString(
+            "defaultsave.directory");
+
     QHash<QString, QString> props;
     props["InputWorkspace"] = QString::fromStdString(GROUPING_WS_NAME);
-    props["OutputFile"] = QString::fromStdString(DEFAULT_GROUPING_FILENAME);
+    props["OutputFile"] =
+        QString::fromStdString(saveDirectory + DEFAULT_GROUPING_FILENAME);
 
     InterfaceManager interfaceManager;
     auto *dialog = interfaceManager.createDialogFromName(


### PR DESCRIPTION
**Description of work.**
This PR makes sure the detector grouping `.xml` file is saved by default in the default save directory.

**To test:**
Follow the instructions in #30133 to save a detector grouping to an xml file. Make sure the file is saved in your default save directory.

*No release notes required as is an addition to #30133*
*No related issue*

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
