### PR TITLE
Fix crash when removing last curve from plot

### DIFF
--- a/docs/source/release/v6.0.0/mantidworkbench.rst
+++ b/docs/source/release/v6.0.0/mantidworkbench.rst
@@ -57,5 +57,6 @@ Bugfixes
 - Fixed a bug in generating plot scripts for figures containing data for a particular bin.
 - Fixed a bug causing an error when double clicking a ragged workspace.
 - Fixed a bug which caused a terminate dialogue to be raised if the user zoomed in far enough while using the SliceViewer on MDE workspaces.
+- Fixed a crash in the plot config when removing the last curve on a plot
 
 :ref:`Release 6.0.0 <v6.0.0>`

--- a/qt/python/mantidqt/widgets/plotconfigdialog/curvestabwidget/presenter.py
+++ b/qt/python/mantidqt/widgets/plotconfigdialog/curvestabwidget/presenter.py
@@ -20,7 +20,7 @@ from workbench.plotting.figureerrorsmanager import FigureErrorsManager
 
 class CurvesTabWidgetPresenter:
 
-    def __init__(self, fig, view=None, parent=None, legend_tab=None):
+    def __init__(self, fig, view=None, parent=None, parent_presenter=None, legend_tab=None):
         self.fig = fig
 
         # The legend tab is passed in so that it can be removed if all curves are removed.
@@ -58,6 +58,8 @@ class CurvesTabWidgetPresenter:
             self.on_curves_selection_changed
         )
 
+        self.parent_presenter = parent_presenter
+
     def apply_properties(self):
         """Take properties from views and set them on the selected curve"""
         ax = self.get_selected_ax()
@@ -80,6 +82,7 @@ class CurvesTabWidgetPresenter:
 
     def close_tab(self):
         """Close the tab and set the view to None"""
+        self.parent_presenter.forget_tab_from_presenter(self)
         self.view.close()
         self.view = None
 
@@ -219,7 +222,7 @@ class CurvesTabWidgetPresenter:
         on the axes remove the axes entry from the 'select_axes_combo_box'. If
         no axes with curves remain close the tab and return True
         """
-        with block_signals(self.view.select_curve_list):
+        with block_signals(self.view.select_curve_list), block_signals(self.view.select_axes_combo_box):
             self.view.remove_select_curve_list_selected_items()
             if self.view.select_curve_list.count() == 0:
                 self.view.remove_select_axes_combo_box_selected_item()

--- a/qt/python/mantidqt/widgets/plotconfigdialog/curvestabwidget/presenter.py
+++ b/qt/python/mantidqt/widgets/plotconfigdialog/curvestabwidget/presenter.py
@@ -20,7 +20,7 @@ from workbench.plotting.figureerrorsmanager import FigureErrorsManager
 
 class CurvesTabWidgetPresenter:
 
-    def __init__(self, fig, view=None, parent=None, parent_presenter=None, legend_tab=None):
+    def __init__(self, fig, view=None, parent_view=None, parent_presenter=None, legend_tab=None):
         self.fig = fig
 
         # The legend tab is passed in so that it can be removed if all curves are removed.
@@ -28,7 +28,7 @@ class CurvesTabWidgetPresenter:
         self.legend_props = None
 
         if not view:
-            self.view = CurvesTabWidgetView(parent)
+            self.view = CurvesTabWidgetView(parent_view)
         else:
             self.view = view
 

--- a/qt/python/mantidqt/widgets/plotconfigdialog/legendtabwidget/presenter.py
+++ b/qt/python/mantidqt/widgets/plotconfigdialog/legendtabwidget/presenter.py
@@ -14,12 +14,12 @@ import matplotlib.font_manager
 
 
 class LegendTabWidgetPresenter:
-    def __init__(self, fig, view=None, parent=None, parent_presenter=None):
+    def __init__(self, fig, view=None, parent_view=None, parent_presenter=None):
         self.fig = fig
         self.axes = fig.get_axes()
 
         if not view:
-            self.view = LegendTabWidgetView(parent)
+            self.view = LegendTabWidgetView(parent_view)
         else:
             self.view = view
 

--- a/qt/python/mantidqt/widgets/plotconfigdialog/legendtabwidget/presenter.py
+++ b/qt/python/mantidqt/widgets/plotconfigdialog/legendtabwidget/presenter.py
@@ -14,7 +14,7 @@ import matplotlib.font_manager
 
 
 class LegendTabWidgetPresenter:
-    def __init__(self, fig, view=None, parent=None):
+    def __init__(self, fig, view=None, parent=None, parent_presenter=None):
         self.fig = fig
         self.axes = fig.get_axes()
 
@@ -26,6 +26,8 @@ class LegendTabWidgetPresenter:
         self.current_view_properties = None
         self.populate_font_combo_box()
         self.init_view()
+
+        self.parent_presenter = parent_presenter
 
         # Signals
         self.view.transparency_spin_box.valueChanged.connect(
@@ -184,5 +186,6 @@ class LegendTabWidgetPresenter:
 
     def close_tab(self):
         """Closes the tab and sets the view to None"""
+        self.parent_presenter.forget_tab_from_presenter(self)
         self.view.close()
         self.view = None

--- a/qt/python/mantidqt/widgets/plotconfigdialog/presenter.py
+++ b/qt/python/mantidqt/widgets/plotconfigdialog/presenter.py
@@ -38,12 +38,12 @@ class PlotConfigDialogPresenter:
             self.tab_widget_views[0] = (axes_tab.view, "Axes")
         # Legend tab
         if legend_in_figure(self.fig):
-            legend_tab = LegendTabWidgetPresenter(self.fig, parent=self.view)
+            legend_tab = LegendTabWidgetPresenter(self.fig, parent=self.view, parent_presenter=self)
             self.tab_widget_presenters[0] = legend_tab
             self.tab_widget_views[3] = (legend_tab.view, "Legend")
         # Curves tab
         if curve_in_figure(self.fig):
-            curves_tab = CurvesTabWidgetPresenter(self.fig, parent=self.view, legend_tab=legend_tab)
+            curves_tab = CurvesTabWidgetPresenter(self.fig, parent=self.view, parent_presenter=self, legend_tab=legend_tab)
             self.tab_widget_presenters[2] = curves_tab
             self.tab_widget_views[1] = (curves_tab.view, "Curves")
         # Images tab
@@ -93,3 +93,18 @@ class PlotConfigDialogPresenter:
             InterfaceManager().showHelpPage(HELP_URL + '#image-plots')
         else:
             InterfaceManager().showHelpPage(HELP_URL + '#figureoptionsgear-png-ptions-menu')
+
+    def forget_tab_from_presenter(self, tab_presenter):
+        """Given the presenter of a tab, forgets the tab's presenter and view
+        by setting them to none, for example when the tab view is closed."""
+        for index, view_name_pair in enumerate(self.tab_widget_views):
+            if view_name_pair:
+                view, name = view_name_pair
+                if view == tab_presenter.view:
+                    self.tab_widget_views[index] = None
+                    break
+
+        for index, presenter in enumerate(self.tab_widget_presenters):
+            if presenter == tab_presenter:
+                self.tab_widget_presenters[index] = None
+                return

--- a/qt/python/mantidqt/widgets/plotconfigdialog/presenter.py
+++ b/qt/python/mantidqt/widgets/plotconfigdialog/presenter.py
@@ -38,12 +38,12 @@ class PlotConfigDialogPresenter:
             self.tab_widget_views[0] = (axes_tab.view, "Axes")
         # Legend tab
         if legend_in_figure(self.fig):
-            legend_tab = LegendTabWidgetPresenter(self.fig, parent=self.view, parent_presenter=self)
+            legend_tab = LegendTabWidgetPresenter(self.fig, parent_view=self.view, parent_presenter=self)
             self.tab_widget_presenters[0] = legend_tab
             self.tab_widget_views[3] = (legend_tab.view, "Legend")
         # Curves tab
         if curve_in_figure(self.fig):
-            curves_tab = CurvesTabWidgetPresenter(self.fig, parent=self.view, parent_presenter=self, legend_tab=legend_tab)
+            curves_tab = CurvesTabWidgetPresenter(self.fig, parent_view=self.view, parent_presenter=self, legend_tab=legend_tab)
             self.tab_widget_presenters[2] = curves_tab
             self.tab_widget_views[1] = (curves_tab.view, "Curves")
         # Images tab

--- a/qt/python/mantidqt/widgets/plotconfigdialog/test/test_plotconfigdialogpresenter.py
+++ b/qt/python/mantidqt/widgets/plotconfigdialog/test/test_plotconfigdialogpresenter.py
@@ -183,6 +183,25 @@ class PlotConfigDialogPresenterTest(unittest.TestCase):
             call.mock_axes_presenter.update_view
         ])
 
+    def test_forget_tab_from_presenter_sets_presenter_and_view_to_none(self):
+        fig = figure()
+        ax = fig.add_subplot(111)
+        ax.plot([0], [0])
+        ax.legend()
+        mock_view = Mock()
+        presenter = PlotConfigDialogPresenter(fig, mock_view)
+
+        mock_curves_presenter = presenter.tab_widget_presenters[2]
+        mock_curves_view = mock_curves_presenter.view
+
+        self.assertTrue(mock_curves_presenter in presenter.tab_widget_presenters)
+        self.assertTrue((mock_curves_view, 'Curves') in presenter.tab_widget_views)
+
+        presenter.forget_tab_from_presenter(mock_curves_presenter)
+
+        self.assertTrue(mock_curves_presenter not in presenter.tab_widget_presenters)
+        self.assertTrue((mock_curves_view, 'Curves') not in presenter.tab_widget_views)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Fixes a crash that occurred when removing the last curve from a plot, and adds tests to cover this.

**To test:**
1. Load some data and open a 1D plot
2. Delete all the curves on the plot via the plot config
3. Verify that there is no exception, and that the only tab open is the axes tab

Fixes #30153

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
