### PR TITLE
Add requiredMemory check to AlignAndFocusPowderFromFiles.ChunkingCompare.

### DIFF
--- a/Testing/SystemTests/tests/framework/AlignAndFocusPowderFromFilesTest.py
+++ b/Testing/SystemTests/tests/framework/AlignAndFocusPowderFromFilesTest.py
@@ -85,6 +85,10 @@ class SimplestCompare(systemtesting.MantidSystemTest):
 
 class ChunkingCompare(systemtesting.MantidSystemTest):
     # this test is very similar to SNAPRedux.Simple
+
+    def requiredMemoryMB(self):
+        return 24*1024  # GiB
+
     def runTest(self):
         # 11MB file
         kwargs = {'Filename':'SNAP_45874',


### PR DESCRIPTION
**Description of work.**

The test requires a fair chunk of memory so should report it as so. The peak resident memory was determined using `/usr/bin/time`.

**To test:**

Check test still runs on the PR

*There is no associated issue.*

*This does not require release notes* because **it is an internal issue.**


<!-- Ensure the base of this PR is correct (e.g. release-next or master)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
