### PR TITLE
Speed up Windows installer creation

### DIFF
--- a/Framework/PostInstall/CMakeLists.txt
+++ b/Framework/PostInstall/CMakeLists.txt
@@ -17,7 +17,7 @@ set(EXCLUDE_REGEX ".*_template")
 set(COMPILE_SCRIPT "message ( \"Byte-compiling Python in ${PACKAGE_ROOT}\")")
 set(
   COMPILE_SCRIPT
-  "${COMPILE_SCRIPT}\n  execute_process ( COMMAND ${Python_EXECUTABLE} -m compileall -q -x \"${EXCLUDE_REGEX}\" \"${PACKAGE_ROOT}\" OUTPUT_QUIET ERROR_QUIET )"
+  "${COMPILE_SCRIPT}\n  execute_process ( COMMAND ${Python_EXECUTABLE} -m compileall -q -j 0 -x \"${EXCLUDE_REGEX}\" \"${PACKAGE_ROOT}\" OUTPUT_QUIET ERROR_QUIET )"
   )
 
 install(CODE ${COMPILE_SCRIPT})


### PR DESCRIPTION
**Description of work.**

~~Shinks the Windows bundle down by 10% by enabling SOLID compression, tweaking the dictionary size
Reduces the build time by using all cores to byte-compile, and disabling data optimization (which saves at most 1% more over LZMA)~~

Edit: See comments below on why I've changed this PR approach

This PR simply adds the -j0 threads flag introduced recently to use all available cores whilst byte-compiling the ever-increasing number of Python files 
**To test:**

- Download the Mantid installer from CI
~- Compare it to a recently master nightly build for file size~
- Ensure it still installs / starts locally


*There is no associated issue.*

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or master)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
