### PR TITLE
Update URL for ISIS ext. data cache

### DIFF
--- a/buildconfig/CMake/MantidExternalData.cmake
+++ b/buildconfig/CMake/MantidExternalData.cmake
@@ -37,7 +37,7 @@ list(APPEND ExternalData_URL_TEMPLATES
 list(APPEND ExternalData_URL_TEMPLATES
      "file:///Users/builder/MantidExternalData-readonly/%(algo)/%(hash)" )
 list(APPEND ExternalData_URL_TEMPLATES
-     "http://mantidweb.nd.rl.ac.uk/externaldata/isis-readonly/%(algo)/%(hash)" )
+     "http://ndw1598.isis.cclrc.ac.uk/externaldata/%(algo)/%(hash)" )
 # This should always be last as it's the main read/write cache
 list(APPEND ExternalData_URL_TEMPLATES
      "http://198.74.56.37/ftp/external-data/%(algo)/%(hash)" )


### PR DESCRIPTION
**Description of work.**

Update URL from mantid-web to ndw1598 following the decomissioning of
the former. 

This should help us reduce outbound bandwidth on our instance but most importantly speed up
 getting external data by avoiding an international hop. It should also reduce the number of developers
who have issues with timeouts...etc. trying to work from home on the VPN

**To test:**
Whilst connected to the STFC VPN:

- Go to http://ndw1598.isis.cclrc.ac.uk/externaldata/MD5/401b30e3b8b5d629635a5c613cdb7919 in a browser and check it downloads
- Go to builds directory, delete a random (large-ish) file and rebuild Standard / System test data, make a note of the hash 
- Go to MantidExternalData and delete that hash file, and the file above again. Re-run System / Standard Test data target and check the URL it downloads from is above


<!-- Ensure the base of this PR is correct (e.g. release-next or master)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
