### PR TITLE
Update Plot In MA/FDA When Rebin Changed

### DIFF
--- a/docs/source/release/v6.0.0/muon.rst
+++ b/docs/source/release/v6.0.0/muon.rst
@@ -31,7 +31,7 @@ Bug fixes
 - Fixed an error caused by switching between the Run and Group/Pair selection when TF Asymmetry mode is ticked.
 - Fixed a bug that can sometimes cause the MaxEnt calculation to fail in frequency domain analysis.
 - Fixed a crash when trying to do a simultaneous fit with no data loaded after pressing clear all.
-
+- Fixed a bug where changing rebin wouldn't update the plot in the GUI
 
 ALC
 ---

--- a/scripts/Muon/GUI/FrequencyDomainAnalysis/frequency_domain_analysis_2.py
+++ b/scripts/Muon/GUI/FrequencyDomainAnalysis/frequency_domain_analysis_2.py
@@ -257,14 +257,16 @@ class FrequencyAnalysisGui(QtWidgets.QMainWindow):
 
     def setup_gui_variable_observers(self):
         self.context.gui_context.gui_variables_notifier.add_subscriber(
-            self.grouping_tab_widget.group_tab_presenter.gui_variables_observer
-        )
+            self.grouping_tab_widget.group_tab_presenter.gui_variables_observer)
 
         self.context.gui_context.gui_variables_notifier.add_subscriber(
             self.fitting_tab.fitting_tab_presenter.gui_context_observer)
 
         self.context.gui_context.gui_variable_non_calulation_notifier.add_subscriber(
             self.fitting_tab.fitting_tab_presenter.gui_context_observer)
+
+        self.context.gui_context.gui_variables_notifier.add_subscriber(
+            self.plot_widget.presenter.rebin_options_set_observer)
 
         self.grouping_tab_widget.pairing_table_widget.selected_pair_changed_notifier.add_subscriber(
             self.fitting_tab.fitting_tab_presenter.selected_group_pair_observer)

--- a/scripts/Muon/GUI/MuonAnalysis/muon_analysis_2.py
+++ b/scripts/Muon/GUI/MuonAnalysis/muon_analysis_2.py
@@ -242,6 +242,9 @@ class MuonAnalysisGui(QtWidgets.QMainWindow):
         self.context.gui_context.gui_variables_notifier.add_subscriber(
             self.fitting_tab.fitting_tab_presenter.gui_context_observer)
 
+        self.context.gui_context.gui_variables_notifier.add_subscriber(
+            self.plot_widget.presenter.rebin_options_set_observer)
+
         self.context.gui_context.gui_variable_non_calulation_notifier.add_subscriber(
             self.fitting_tab.fitting_tab_presenter.gui_context_observer)
 


### PR DESCRIPTION
**Description of work.**
Added subscribers so the plot on the GUI is updated when you change rebin settings

**To test:**
1. Open Muon Analysis
2. Load some data (EMU20918)
3. Change rebin settings from none to fixed with steps 5
4. The plot should update and look rebinned
5. To compare you can plot the same plot from the workspace in the workspace toolbox. If you loaded the dataset above then do this:
    1. Click external plot from the plotting window in the GUI to better see the plot
    2. In the main workbench window, click the group workspace ``EMU20918 MA`` to see each individual workspace
    3. Plot ``EMU20918; Pair Asym; long; Rebin; MA`` and change the scales to be similar to the external plot from earlier
    4. These should be the same
6. Check Variable rebin also works
7. Now do the same for the FDA interface

Fixes #30227 

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
