### PR TITLE
Fix Engg system test on non-Windows/RHEL7 platforms

### DIFF
--- a/Testing/SystemTests/tests/framework/EnggCalibrationTest.py
+++ b/Testing/SystemTests/tests/framework/EnggCalibrationTest.py
@@ -293,7 +293,7 @@ class EnginXCalibrateFullThenCalibrateTest(systemtesting.MantidSystemTest):
             self.assertTrue(abs(self.pos_table.cell(1199, 9)) < 15)
 
             # === check difc, zero parameters for GSAS produced by EnggCalibrate
-            if sys.platform == "win32":  # Windows performs the fit differently enough to cause problems.
+            if not systemtesting.using_gsl_v1():  # GSLv1/v2 difference.
                 # Bank 1
                 self.assertTrue(rel_err_less_delta(self.difa, -4.07055, exdelta_special),
                                 "difa parameter for bank 1 is not what was expected, got: %f" % self.difa)


### PR DESCRIPTION
**Description of work.**

Alter check for platform to be check against GSL version. The test is then more flexible as other platforms have migrated too.

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

**To test:**

* On macOS or Ubuntu run `./systemtest -R EnginXCalibrateFullThenCalibrateTest`

*There is no associated issue.*

*This does not require release notes* because **it fixes an internal test**

<!-- Ensure the base of this PR is correct (e.g. release-next or master)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
