### PR TITLE
Set projections below 1e-10 to 0 in BinMD calls

### DIFF
--- a/Framework/MDAlgorithms/src/MDNorm.cpp
+++ b/Framework/MDAlgorithms/src/MDNorm.cpp
@@ -1008,7 +1008,8 @@ DataObjects::MDHistoWorkspace_sptr MDNorm::binInputWS(
         m_dEIntegrated = false;
       }
       if (!basisVector.str().empty()) {
-        for (auto const &proji : projection) {
+        for (auto proji : projection) {
+          proji = std::abs(proji) > 1e-10 ? proji : 0.0;
           basisVector << "," << proji;
         }
         value = basisVector.str();


### PR DESCRIPTION
**Description of work.**

Some cases reported errors when values like 5.37391e-49 were
passed as projections values and unable to be parsed out of the string
as a double. In reality these values should just be zero.



<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

**To test:**

* Run MDNormHyspec test on macOS or Windows

*There is no associated issue.*

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or master)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
