### PR TITLE
Use RefRoi instead of ConvertUnits when summing in Q

### DIFF
--- a/Framework/Reflectometry/test/ReflectometryReductionOne2Test.h
+++ b/Framework/Reflectometry/test/ReflectometryReductionOne2Test.h
@@ -760,6 +760,15 @@ public:
     TS_ASSERT_THROWS(alg.execute(), const std::invalid_argument &);
   }
 
+  void test_requesting_angle_for_sum_in_q_throws_for_multiple_groups() {
+    ReflectometryReductionOne2 alg;
+    setupAlgorithm(alg, 1.5, 15.0, "3+4, 4");
+    alg.setProperty("ThetaIn", 22.0);
+    alg.setProperty("SummationType", "SumInQ");
+    alg.setProperty("ReductionType", "DivergentBeam");
+    TS_ASSERT_THROWS(alg.execute(), const std::invalid_argument &);
+  }
+
   void test_angle_correction_is_not_done_for_sum_in_q_for_single_detector() {
     ReflectometryReductionOne2 alg;
     setupAlgorithm(alg, 1.5, 15.0, "4");
@@ -803,33 +812,6 @@ public:
     MatrixWorkspace_sptr outQ = alg.getProperty("OutputWorkspace");
     checkAngleCorrection(outLam, outQ, detectorTheta);
     checkDetector3And4SummedInQ(outLam, outQ);
-  }
-
-  void test_angle_correction_is_not_done_for_sum_in_q_for_multiple_groups() {
-    ReflectometryReductionOne2 alg;
-    setupAlgorithm(alg, 1.5, 15.0, "3+4, 4");
-
-    double const detectorTheta = twoThetaForDetector3() / 2.0;
-    double const thetaIn = 22.0;
-    auto inputWS = MatrixWorkspace_sptr(m_multiDetectorWS->clone());
-    setYValuesToWorkspace(*inputWS);
-
-    alg.setProperty("InputWorkspace", inputWS);
-    alg.setProperty("ThetaIn", thetaIn);
-    alg.setProperty("SummationType", "SumInQ");
-    alg.setProperty("ReductionType", "DivergentBeam");
-    alg.execute();
-
-    MatrixWorkspace_sptr outLam = alg.getProperty("OutputWorkspaceWavelength");
-    MatrixWorkspace_sptr outQ = alg.getProperty("OutputWorkspace");
-    checkAngleCorrection(outLam, outQ, detectorTheta);
-
-    // The output workspace has two spectra, containing the results for each
-    // group. Note that the cropping in wavelength is done based on all groups
-    // so the results for detector 4 here are slightly different to other tests
-    // that process this detector in a solo group
-    checkDetector3And4SummedInQ(outLam, outQ);
-    checkDetector4SummedInQCroppedToDetector3And4(outLam, outQ, 1);
   }
 
   void test_outputs_when_debug_is_false_and_IvsLam_name_not_set() {
@@ -1079,7 +1061,7 @@ public:
     auto outputWS = std::dynamic_pointer_cast<MatrixWorkspace>(
         AnalysisDataService::Instance().retrieve("IvsQ"));
     checkWorkspaceHistory(outputWS,
-                          {"ConvertUnits", "CropWorkspace", "ConvertUnits"});
+                          {"ConvertUnits", "CropWorkspace", "RefRoi"});
   }
 
   void test_history_for_sum_in_q_with_monitor_normalisation() {
@@ -1096,7 +1078,7 @@ public:
     checkWorkspaceHistory(outputWS,
                           {"ConvertUnits", "CropWorkspace", "ConvertUnits",
                            "CalculateFlatBackground", "RebinToWorkspace",
-                           "Divide", "CropWorkspace", "ConvertUnits"});
+                           "Divide", "CropWorkspace", "RefRoi"});
   }
 
   void test_history_for_sum_in_q_with_transmission_normalisation() {
@@ -1110,10 +1092,9 @@ public:
     alg.execute();
     auto outputWS = std::dynamic_pointer_cast<MatrixWorkspace>(
         AnalysisDataService::Instance().retrieve("IvsQ"));
-    checkWorkspaceHistory(outputWS,
-                          {"ConvertUnits", "CreateTransmissionWorkspace",
-                           "RebinToWorkspace", "Divide", "CropWorkspace",
-                           "ConvertUnits"});
+    checkWorkspaceHistory(
+        outputWS, {"ConvertUnits", "CreateTransmissionWorkspace",
+                   "RebinToWorkspace", "Divide", "CropWorkspace", "RefRoi"});
   }
 
   void test_IvsQ_is_not_distribution_data() {
@@ -1182,7 +1163,7 @@ public:
         AnalysisDataService::Instance().retrieve("IvsQ"));
     checkWorkspaceHistory(outputWS,
                           {"ReflectometryBackgroundSubtraction", "ConvertUnits",
-                           "CropWorkspace", "ConvertUnits"});
+                           "CropWorkspace", "RefRoi"});
   }
 
 private:

--- a/Framework/Reflectometry/test/ReflectometryReductionOne2Test.h
+++ b/Framework/Reflectometry/test/ReflectometryReductionOne2Test.h
@@ -554,7 +554,7 @@ public:
     TS_ASSERT_DELTA(outLam->y(0)[5], 2.193650, 1e-6);
     TS_ASSERT_DELTA(outLam->y(0)[9], 2.255101, 1e-6);
 
-    checkConversionToQ(alg, twoThetaForDetector4() / 2.0, false, false);
+    checkConversionToQ(alg, twoThetaForDetector4() / 2.0, false);
 
     TS_ASSERT_DELTA(sumCounts(outLam->counts(0)), 66.514113, 1e-6);
   }
@@ -577,7 +577,7 @@ public:
     TS_ASSERT_DELTA(outLam->y(0)[3], 0.888541, 1e-6);
     TS_ASSERT_DELTA(outLam->y(0)[7], 0.886874, 1e-6);
 
-    checkConversionToQ(alg, twoThetaForDetector3() / 2.0, true, false);
+    checkConversionToQ(alg, twoThetaForDetector3() / 2.0, false);
 
     TS_ASSERT_DELTA(sumCounts(outLam->counts(0)), 21.030473, 1e-6);
   }
@@ -1264,13 +1264,10 @@ private:
    *
    * @param alg : the algorithm, which has already been executed
    * @param theta : the theta to use in the conversion in degrees
-   * @param invert : if true, the Q bins are in inverted order to the lambda
-   * bins
    * @param checkCounts : if true, also check the counts in the bins are the
    * same
    */
   void checkConversionToQ(ReflectometryReductionOne2 &alg, const double theta,
-                          const bool invert = true,
                           const bool checkCounts = true) {
     // Extract arrays for convenience
     MatrixWorkspace_sptr outLam = alg.getProperty("OutputWorkspaceWavelength");
@@ -1284,22 +1281,17 @@ private:
     TS_ASSERT_EQUALS(edgesLam.size(), edgesQ.size());
     TS_ASSERT_EQUALS(countsLam.size(), countsQ.size());
 
-    // Convenience function for optionally inverting an index
-    auto lamIdx = [&invert](auto const idx, auto const len) {
-      return invert ? len - 1 - idx : idx;
-    };
-
     // Check converting the lambda value to Q gives the result we got
     auto const nEdges = edgesQ.size();
     auto const factor = 4 * M_PI * std::sin(theta * degToRad);
     for (size_t i = 0; i < nEdges; ++i)
-      TS_ASSERT_DELTA(edgesQ[i], factor / edgesLam[lamIdx(i, nEdges)], 1e-6);
+      TS_ASSERT_DELTA(edgesQ[i], factor / edgesLam[nEdges - 1 - i], 1e-6);
 
     if (checkCounts) {
       // Counts should be the same in matching bins
       auto const nCounts = countsQ.size();
       for (size_t i = 0; i < nCounts; ++i)
-        TS_ASSERT_DELTA(countsQ[i], countsLam[lamIdx(i, nCounts)], 1e-6);
+        TS_ASSERT_DELTA(countsQ[i], countsLam[nCounts - 1 - i], 1e-6);
     }
   }
 


### PR DESCRIPTION
Use RefRoi instead of ConvertUnits when summing in Q in ReflectometryReductionOne

This is pre-work for a change to make the reference twoTheta arbitrary rather than being constrained to using the detector twoTheta, which ConvertUnits forces us to do

Note that this solves a bug where the output workspace in Q is not reversed with respect to the workspace in lambda in a particular test case where we (oddly) have a negative value for lambda for the final bin edge. ConvertUnits
only does the reversal if the first edge value is greater than the final edge value and this negative value messes that up. RefRoi does not have this problem so it does the reversal corectly. This means we can remove workaround in the tests.

**To test:**

<!-- Instructions for testing. -->

- Ensure your default save directory is set, and that it is also in your search directories for loading.
- Run the following script in v5.1.1:
```
Load(Filename='INTER43583', OutputWorkspace='INTER43583')
ReflectometryReductionOne(InputWorkspace='INTER43583', WavelengthMin=1.5, WavelengthMax=17.0,
                          ThetaIn=1.3, ProcessingInstructions='47-61',
                          SummationType='SumInQ', ReductionType='DivergentBeam')
SaveNexus(InputWorkspace='IvsQ_43583', Filename='IvsQ_43583_reference.nxs')
```
- Run this script in this dev version
```
Load(Filename='INTER43583', OutputWorkspace='INTER43583')
ReflectometryReductionOne(InputWorkspace='INTER43583', WavelengthMin=1.5, WavelengthMax=17.0,
                          ThetaIn=1.3, ProcessingInstructions='47-61',
                          SummationType='SumInQ', ReductionType='DivergentBeam')
#SaveNexus(InputWorkspace='IvsQ_43583', Filename='IvsQ_43583_reference.nxs')
Load(Filename='IvsQ_43583_reference.nxs', OutputWorkspace='IvsQ_43583_reference')
RebinToWorkspace('IvsQ_43583', 'IvsQ_43583_reference', OutputWorkspace='IvsQ_43583')
CompareWorkspaces(Workspace1='IvsQ_43583', Workspace2='IvsQ_43583_reference', Tolerance=1e-08, ToleranceRelErr=True, CheckAllData=True)
```
- The CompareWorkspaces step should indicate that the workspaces match
- Check the history for `IvsQ_43583`. The final step should be a call to `RefRoi` with ScatteringAngle `1.32145` (the twoTheta angle of the output workspace's detector divided by 2, which is the angle `ConvertUnits` would have used).

Refs #23011

*This does not require release notes* because **it does not change outputs seen by users (except the child algorithm history, which is a very minor change)**


---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
