### PR TITLE
IndexPeaks shall not accept invalid mod vectors

### DIFF
--- a/Framework/Crystal/src/IndexPeaks.cpp
+++ b/Framework/Crystal/src/IndexPeaks.cpp
@@ -82,8 +82,14 @@ struct IndexPeaksArgs {
       maxOrderToUse = lattice.getMaxOrder(); // the lattice can return a 0 here
       // if lattice has maxOrder, we will use the modVec from it, otherwise
       // stick to the input got from previous assignment
+      // NOTE:
+      // The non-zero modVectors check are turned off in the initilization step
+      // as it will lead to unexpected errors for users not relying on this
+      // feature.  For projects/processing that relyies on non-zero modVectors,
+      // it is the application responsibility to ensure that non-zero vectors
+      // are passed to IndexPeaks.
       if (maxOrderToUse > 0) {
-        modVectorsToUse = validModulationVectors(
+        modVectorsToUse = addModulationVectors(
             lattice.getModVec(0), lattice.getModVec(1), lattice.getModVec(2));
       }
     }

--- a/Framework/Crystal/src/IndexPeaks.cpp
+++ b/Framework/Crystal/src/IndexPeaks.cpp
@@ -319,6 +319,12 @@ indexPeaks(const std::vector<Peak *> &peaks, DblMatrix ub,
         peak->setIntMNP(std::get<1>(satelliteInfo));
         stats.satellites.numIndexed++;
         stats.satellites.error += std::get<2>(satelliteInfo) / 3.;
+      } else {
+        // clear these to make sure leftover values from previous index peaks
+        // run are not used
+        peak->setHKL(V3D(0, 0, 0));
+        peak->setIntHKL(V3D(0, 0, 0));
+        peak->setIntMNP(V3D(0, 0, 0));
       }
     } else {
       peak->setHKL(V3D(0, 0, 0));
@@ -459,8 +465,8 @@ std::map<std::string, std::string> IndexPeaks::validateInputs() {
   const bool isSave = this->getProperty(Prop::SAVEMODINFO);
   const bool isMOZero = (args.satellites.maxOrder == 0);
   bool isAllVecZero = true;
-  // parse() validates all the mod vectors. There should not be any modulated vector
-  // in modVectors is equal to (0, 0, 0)
+  // parse() validates all the mod vectors. There should not be any modulated
+  // vector in modVectors is equal to (0, 0, 0)
   for (size_t vecNo = 0; vecNo < args.satellites.modVectors.size(); vecNo++) {
     if (args.satellites.modVectors[vecNo] != V3D(0.0, 0.0, 0.0)) {
       isAllVecZero = false;
@@ -510,18 +516,21 @@ void IndexPeaks::exec() {
       lattice.setModVec1(args.satellites.modVectors[0]);
     } else {
       g_log.warning("empty modVector 1, skipping saving");
+      lattice.setModVec1(V3D(0.0, 0.0, 0.0));
     }
 
     if (args.satellites.modVectors.size() >= 2) {
       lattice.setModVec2(args.satellites.modVectors[1]);
     } else {
       g_log.warning("empty modVector 2, skipping saving");
+      lattice.setModVec2(V3D(0.0, 0.0, 0.0));
     }
 
     if (args.satellites.modVectors.size() >= 3) {
       lattice.setModVec3(args.satellites.modVectors[2]);
     } else {
       g_log.warning("empty modVector 3, skipping saving");
+      lattice.setModVec3(V3D(0.0, 0.0, 0.0));
     }
   }
 

--- a/Framework/Crystal/test/IndexPeaksTest.h
+++ b/Framework/Crystal/test/IndexPeaksTest.h
@@ -485,6 +485,32 @@ public:
     TS_ASSERT_EQUALS(true, lattice.getCrossTerm())
   }
 
+  void test_exec_mod_vectors_save_cleared_across_runs() {
+    const auto peakWS = createTestPeaksWorkspaceWithSatellites();
+
+    auto alg = indexPeaks(peakWS, {{"RoundHKLs", "0"},
+                                   {"MaxOrder", "1"},
+                                   {"ModVector1", "0.333, 0.667, -0.333"},
+                                   {"ModVector2", "-0.333, 0.667, 0.333"},
+                                   {"ModVector3", "0.333, -0.667, 0.333"},
+                                   {"SaveModulationInfo", "1"}});
+
+    // Repeat indexPeaks with 1 mod vector, verify lattice only has one set
+    alg = indexPeaks(peakWS, {{"RoundHKLs", "0"},
+                              {"MaxOrder", "1"},
+                              {"ModVector1", "0.333, 0.667, -0.333"},
+                              {"SaveModulationInfo", "1"}});
+
+    const auto &lattice = peakWS->sample().getOrientedLattice();
+    TS_ASSERT_EQUALS(1, lattice.getMaxOrder())
+    TS_ASSERT_DELTA(V3D(0.333, 0.667, -0.333).norm(),
+                    lattice.getModVec(0).norm(), 1e-8)
+    TS_ASSERT_DELTA(V3D(0.0, 0.0, 0.0).norm(), lattice.getModVec(1).norm(),
+                    1e-8)
+    TS_ASSERT_DELTA(V3D(0.0, 0.0, 0.0).norm(), lattice.getModVec(2).norm(),
+                    1e-8)
+  }
+
   // --------------------------- Failure tests -----------------------------
 
   std::shared_ptr<IndexPeaks> setup_validate_inputs_test_alg() {

--- a/Framework/Crystal/test/IndexPeaksTest.h
+++ b/Framework/Crystal/test/IndexPeaksTest.h
@@ -488,18 +488,20 @@ public:
   void test_exec_mod_vectors_save_cleared_across_runs() {
     const auto peakWS = createTestPeaksWorkspaceWithSatellites();
 
-    auto alg = indexPeaks(peakWS, {{"RoundHKLs", "0"},
-                                   {"MaxOrder", "1"},
-                                   {"ModVector1", "0.333, 0.667, -0.333"},
-                                   {"ModVector2", "-0.333, 0.667, 0.333"},
-                                   {"ModVector3", "0.333, -0.667, 0.333"},
-                                   {"SaveModulationInfo", "1"}});
+    const auto alg_three_mod =
+        indexPeaks(peakWS, {{"RoundHKLs", "0"},
+                            {"MaxOrder", "1"},
+                            {"ModVector1", "0.333, 0.667, -0.333"},
+                            {"ModVector2", "-0.333, 0.667, 0.333"},
+                            {"ModVector3", "0.333, -0.667, 0.333"},
+                            {"SaveModulationInfo", "1"}});
 
     // Repeat indexPeaks with 1 mod vector, verify lattice only has one set
-    alg = indexPeaks(peakWS, {{"RoundHKLs", "0"},
-                              {"MaxOrder", "1"},
-                              {"ModVector1", "0.333, 0.667, -0.333"},
-                              {"SaveModulationInfo", "1"}});
+    const auto alg_one_mod =
+        indexPeaks(peakWS, {{"RoundHKLs", "0"},
+                            {"MaxOrder", "1"},
+                            {"ModVector1", "0.333, 0.667, -0.333"},
+                            {"SaveModulationInfo", "1"}});
 
     const auto &lattice = peakWS->sample().getOrientedLattice();
     TS_ASSERT_EQUALS(1, lattice.getMaxOrder())
@@ -509,6 +511,54 @@ public:
                     1e-8)
     TS_ASSERT_DELTA(V3D(0.0, 0.0, 0.0).norm(), lattice.getModVec(2).norm(),
                     1e-8)
+  }
+
+  void test_exec_compare_after_modvec_changes() {
+    const std::vector<double> ub = {0.0971,  0.1179, 0.0433, 0.1056, -0.0305,
+                                    -0.0190, 0.0311, 0.0820, -0.0698};
+
+    constexpr int npeaks{5};
+    constexpr int run{39056};
+    // peak numbers 7, 25, 66, 72, and 76 from TOPAZ_39056
+    constexpr std::array<MinimalPeak, npeaks> testPeaksInfo = {
+        MinimalPeak{run, V3D(-1.44683, 1.07978, 2.06781)},
+        MinimalPeak{run, V3D(-1.70476, 1.12522, 2.46955)},
+        MinimalPeak{run, V3D(1.22626, 1.20112, 4.88867)},
+        MinimalPeak{run, V3D(0.934964, 1.19063, 4.15398)},
+        MinimalPeak{run, V3D(1.19216, 1.75244, 4.69207)}};
+
+    const auto peakWS_onemod = createPeaksWorkspace<npeaks>(testPeaksInfo, ub);
+    const auto peakWS = createPeaksWorkspace<npeaks>(testPeaksInfo, ub);
+
+    // Index with one modulation vector on the first peaks workspace
+    const auto alg_one_mod =
+        indexPeaks(peakWS_onemod, {{"RoundHKLs", "0"},
+                                   {"MaxOrder", "1"},
+                                   {"ModVector1", "0.5, 0.5, 0"},
+                                   {"SaveModulationInfo", "1"}});
+
+    // Re-index using two modulation vectors
+    const auto alg_two_mod = indexPeaks(peakWS, {{"RoundHKLs", "0"},
+                                                 {"MaxOrder", "1"},
+                                                 {"ModVector1", "0.5, 0, 0"},
+                                                 {"ModVector2", "0, 0.5, 0"},
+                                                 {"SaveModulationInfo", "1"}});
+
+    // Re-index with one modulation vector, and compare to before
+    const auto alg = indexPeaks(peakWS, {{"RoundHKLs", "0"},
+                                         {"MaxOrder", "1"},
+                                         {"ModVector1", "0.5, 0.5, 0"},
+                                         {"SaveModulationInfo", "1"}});
+
+    for (auto i = 0u; i < peakWS->getNumberPeaks(); ++i) {
+      const auto &peak_onemod = peakWS_onemod->getPeak(i);
+      const auto &peak = peakWS->getPeak(i);
+      // Verify the HKL and MNP of each peak since these would change if the
+      // last indexPeaks call was using a second modulation vector
+      TS_ASSERT(peak_onemod.getHKL() == peak.getHKL());
+      TS_ASSERT(peak_onemod.getIntHKL() == peak.getIntHKL());
+      TS_ASSERT(peak_onemod.getIntMNP() == peak.getIntMNP());
+    }
   }
 
   // --------------------------- Failure tests -----------------------------

--- a/Framework/Crystal/test/IndexPeaksTest.h
+++ b/Framework/Crystal/test/IndexPeaksTest.h
@@ -550,7 +550,7 @@ public:
                                          {"ModVector1", "0.5, 0.5, 0"},
                                          {"SaveModulationInfo", "1"}});
 
-    for (auto i = 0u; i < peakWS->getNumberPeaks(); ++i) {
+    for (int i = 0; i < peakWS->getNumberPeaks(); ++i) {
       const auto &peak_onemod = peakWS_onemod->getPeak(i);
       const auto &peak = peakWS->getPeak(i);
       // Verify the HKL and MNP of each peak since these would change if the


### PR DESCRIPTION
**Description of work.**

Reported issue:

_In Mantid > 50 (e.g. Mantid 51), the indexing of peaks with modulation vectors and finding the UB matrix results in odd behavior._

_First, re-indexing peaks with one modulation vector outputs one modulation vector._
_Then, re-indexing peaks with two modulation vector outputs three modulation vectors._
_Finally, re-indexing peaks with one modulation vector again still outputs three modulation vectors._ 

The reported error is caused by invalid (actually not-specified) mod vectors.  A validation to all 3 mod vectors from input properties shall be validated.
Furthermore, a previous PR https://github.com/mantidproject/mantid/issues/29609 introduced a bug that prevents the algorithm to retrieve mod vectors from input workspace when a non-zero MaxOrder is specified but no mod vector is.  Since it is a strongly correlated issue, this bug will be resolved in this task too.

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

**To test:**

Run the following script. Verify that no third modulation vector is printed by the message from `FindUBUsingIndexedPeaks` and that only one modulation vector is used when the workspace is re-indexed with only one vector after it was indexed with two modulation vectors previously.

```
from mantid.simpleapi import *

LoadIsawPeaks(Filename='/SNS/TOPAZ/shared/test/Issue with mantid51/TOPAZ_39056_hex_P.integrate', \
              OutputWorkspace='TOPAZ_39056_peaks')
FindUBUsingIndexedPeaks(PeaksWorkspace='TOPAZ_39056_peaks', \
                        Tolerance=0.12, \
                        ToleranceForSatellite=0.12)

IndexPeaks(PeaksWorkspace='TOPAZ_39056_peaks', \
           Tolerance=0.12, \
           RoundHKLs=False, \
           ModVector1='0.5,0,0', \
           ModVector2='0,0.5,0', \
           MaxOrder=1, \
           CrossTerms=False, \
           SaveModulationInfo=True)
FindUBUsingIndexedPeaks(PeaksWorkspace='TOPAZ_39056_peaks', \
                        Tolerance=0.12, \
                        ToleranceForSatellite=0.12)

# When trying to index the peaks with only one modulation vector, mantid 
# still keeps the q-vectors from previous input.
IndexPeaks(PeaksWorkspace='TOPAZ_39056_peaks', \
           Tolerance=0.12, \
           RoundHKLs=False, \
           ModVector1='0.5,0.5,0', \
           MaxOrder=1, \
           SaveModulationInfo=True)
FindUBUsingIndexedPeaks(PeaksWorkspace='TOPAZ_39056_peaks', \
                        Tolerance=0.12, \
                        ToleranceForSatellite=0.12)
```

<!-- Instructions for testing. -->

*There is no associated issue.*

*It is a fix to https://code.ornl.gov/sns-hfir-scse/diffraction/single-crystal/single-crystal-diffraction/-/issues/169*

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or master)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
