### PR TITLE
Update INTER IDF to put detectors at 2theta

### DIFF
--- a/instrument/INTER_Definition_2020.xml
+++ b/instrument/INTER_Definition_2020.xml
@@ -139,7 +139,7 @@
   <component type="panel" idstart="2001" idfillbyfirst="y" idstep="1" idstepbyrow="1">
     <location z="3.163" name="linear-detector"/>
     <parameter name="y">
-      <logfile id="Theta" eq="3.163*tan(1*value*0.0174533)" extract-single-value-as="last_value"/>
+      <logfile id="Theta" eq="3.163*tan(2*value*0.0174533)" extract-single-value-as="last_value"/>
     </parameter>
 
   </component>


### PR DESCRIPTION
***Merge PR #29764 first***

This IDF change is being made in conjunction with PR #29764, which changes to ConvertToReflectometryQ which make the algorithm work with detectors at 2theta rather than theta.

Refs #20327

**Description of work.**

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

**To test:**

- Load INTER58920.
- Right-click and Show detectors
- Theta for detector 2001 is 0.3477
- Run LoadInstrument with the new IDF
- Theta for detector 2001 is now 0.1523

*This does not require release notes* because **IDF changes are not associated with any release**


---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
