### PR TITLE
Update Plot In MA/FDA When Plot Raw/Diff Changed

### DIFF
--- a/docs/source/release/v6.0.0/muon.rst
+++ b/docs/source/release/v6.0.0/muon.rst
@@ -32,6 +32,7 @@ Bug fixes
 - Fixed a bug that can sometimes cause the MaxEnt calculation to fail in frequency domain analysis.
 - Fixed a crash when trying to do a simultaneous fit with no data loaded after pressing clear all.
 - Fixed a bug where changing rebin wouldn't update the plot in the GUI
+- Fixed a bug where the plot would update incorrectly when changing plot raw and plot difference
 
 ALC
 ---

--- a/scripts/Muon/GUI/Common/plot_widget/plot_widget_presenter.py
+++ b/scripts/Muon/GUI/Common/plot_widget/plot_widget_presenter.py
@@ -82,6 +82,7 @@ class PlotWidgetPresenterCommon(HomeTabSubWidget):
         self._view.on_external_plot_pressed(self.handle_external_plot_requested)
         self._view.on_rebin_options_changed(self.handle_use_raw_workspaces_changed)
         self._view.on_plot_mode_changed(self.handle_plot_mode_changed_by_user)
+        self._view.on_plot_diff_checkbox_changed(self.handle_plot_diff_changed)
 
     def handle_data_updated(self, autoscale=False):
         """
@@ -164,6 +165,9 @@ class PlotWidgetPresenterCommon(HomeTabSubWidget):
 
         self.handle_plot_mode_changed(plot_mode)
 
+    def handle_plot_diff_changed(self):
+        self.update_plot()
+
     def handle_workspace_deleted_from_ads(self, workspace: Workspace2D):
         """
         Handles a workspace being deleted from ads by removing the workspace from the plot
@@ -238,6 +242,7 @@ class PlotWidgetPresenterCommon(HomeTabSubWidget):
         workspace_list, indices = self._model.get_workspace_list_and_indices_to_plot(self._view.is_raw_plot(),
                                                                                      self._view.get_plot_type())
         self._figure_presenter.plot_workspaces(workspace_list, indices, hold_on=False, autoscale=False)
+        self.update_plot()
 
     def handle_added_or_removed_group_or_pair_to_plot(self, group_pair_info: Dict):
         """


### PR DESCRIPTION
**Description of work.**
Added some update plot calls when these checkboxes are changed

**To test:**
#### Plot Diff

1. Open Muon Analysis
2. Load in some data (e.g. EMU20918)
3. Add a fit function (e.g. abragam)
4. Click fit
5. On the preview plot, check and un check Plot Difference
6. The difference curve should be added and remove as expected
7. Check behaves the same for FDA
8. Before fitting you will need to use the transform tab first

#### Plot raw
1. Back to Muon analysis 
2. Load some data (e.g. EMU20918)
3. Change rebin to fixed with 5 steps
4. Add a fit function (e.g. abragam)
5. Click fit
6. Check and uncheck Plot Raw
7. The data curve should change between rebinned and raw whilst the fit curve remains the same
8. Check same for FDA 

Fixes #30234 

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
