### PR TITLE
CorelliPowderCalibrationCreate accepts MatrixWorkspaces

### DIFF
--- a/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/CorelliPowderCalibrationCreate.py
+++ b/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/CorelliPowderCalibrationCreate.py
@@ -10,7 +10,7 @@ import string
 from typing import List, Optional, Union
 
 from mantid.api import (
-    AlgorithmFactory, AnalysisDataService, DataProcessorAlgorithm, IEventWorkspaceProperty, mtd, Progress, TextAxis,
+    AlgorithmFactory, AnalysisDataService, DataProcessorAlgorithm, WorkspaceProperty, mtd, Progress, TextAxis,
     Workspace, WorkspaceGroup, WorkspaceUnitValidator)
 from mantid.dataobjects import TableWorkspace, Workspace2D
 from mantid.simpleapi import (
@@ -106,9 +106,9 @@ class CorelliPowderCalibrationCreate(DataProcessorAlgorithm):
 
     def PyInit(self):
         self.declareProperty(
-            IEventWorkspaceProperty('InputWorkspace', '',
-                                    direction=Direction.Input,
-                                    validator=WorkspaceUnitValidator('TOF')),
+            WorkspaceProperty('InputWorkspace', '',
+                              direction=Direction.Input,
+                              validator=WorkspaceUnitValidator('TOF')),
             doc='Powder event data, ideally from a highly symmetric space group',
         )
         self.declareProperty(name='OutputWorkspacesPrefix', defaultValue='pdcal_', direction=Direction.Input,

--- a/scripts/corelli/calibration/powder.py
+++ b/scripts/corelli/calibration/powder.py
@@ -21,8 +21,7 @@ def load_and_rebin(runs: List[int],
 
     This function assumes the runs are large and events cannot be all loaded into memory. Hence, a run is loaded
     at a time, rebinned to TOF counts, events are dropped, and counts are added to the cumulative histogram
-    resulting from loading the previous runs. This process typically results in a decrease in memory footprint
-    by a factor of 10 to 50.
+    resulting from loading the previous runs.
 
     @param runs : list of run numbers
     @param rebin_params : a triad of first, step, and last. A negative step indicates logarithmic binning

--- a/scripts/corelli/calibration/powder.py
+++ b/scripts/corelli/calibration/powder.py
@@ -1,0 +1,55 @@
+# Mantid Repository : https://github.com/mantidproject/mantid
+#
+# Copyright &copy; 2018 ISIS Rutherford Appleton Laboratory UKRI,
+#   NScD Oak Ridge National Laboratory, European Spallation Source,
+#   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+# SPDX - License - Identifier: GPL - 3.0 +
+
+from typing import List, Optional
+from mantid.api import mtd
+from mantid.dataobjects import Workspace2D
+from mantid.kernel import logger
+from mantid.simpleapi import DeleteWorkspace, LoadEventNexus, Plus, Rebin
+
+
+def load_and_rebin(run_numbers: List[int],
+                   output_workspace: str,
+                   rebin_params: List[float],
+                   banks: Optional[List[int]] = None) -> Workspace2D:
+    r"""
+    @brief Load a list of run numbers and rebin
+
+    This function assumes the runs are large and events cannot be all loaded into memory. Hence, a run is loaded
+    at a time, rebinned to TOF counts, events are dropped, and counts are added to the cumulative histogram
+    resulting from loading the previous runs. This process typically results in a decrease in memory footprint
+    by a factor of 10 to 50.
+
+    @param runs : list of run numbers
+    @param rebin_params : a triad of first, step, and last. A negative step indicates logarithmic binning
+    @param output_workspace : the name of the output `MatrixWorkspace`
+    @param banks : list of bank numbers, if one wants to load only certain banks.
+    @return handle to the output workspace
+    """
+    instrument = 'CORELLI'
+    kwargs = {} if banks is None else {'BankName': ','.join([f'bank{b}' for b in banks])}
+
+    # Load the first run
+    logger.info(f'Loading run {run_numbers[0]}. {len(run_numbers)} runs remaining to be loaded')
+    LoadEventNexus(Filename=f'{instrument}_{run_numbers[0]}', OutputWorkspace=output_workspace,
+                   LoadLogs=False, **kwargs)
+    if rebin_params is not None:
+        Rebin(InputWorkspace=output_workspace, OutputWorkspace=output_workspace,
+              Params=rebin_params, PreserveEvents=False)
+    # Iteratively load the remaining run, adding to the final workspace each time
+    try:
+        single_run = '__single_run_' + output_workspace
+        for i, run in enumerate(run_numbers[1:]):
+            logger.info(f'Loading run {run}. {len(run_numbers) - 1 - i} runs remaining to be loaded')
+            LoadEventNexus(Filename=f'{instrument}_{run}', OutputWorkspace=single_run, LoadLogs=False, **kwargs)
+            if rebin_params is not None:
+                Rebin(InputWorkspace=single_run, OutputWorkspace=single_run, Params=rebin_params, PreserveEvents=False)
+            Plus(LHSWorkspace=output_workspace, RHSWorkspace=single_run, OutputWorkspace=output_workspace)
+            DeleteWorkspace(single_run)  # save memory as quick as possible
+    except RuntimeError:
+        DeleteWorkspace(single_run)  # a bit of clean-up
+    return mtd[output_workspace]

--- a/scripts/corelli/calibration/powder.py
+++ b/scripts/corelli/calibration/powder.py
@@ -12,7 +12,7 @@ from mantid.kernel import logger
 from mantid.simpleapi import DeleteWorkspace, LoadEventNexus, Plus, Rebin
 
 
-def load_and_rebin(run_numbers: List[int],
+def load_and_rebin(runs: List[int],
                    output_workspace: str,
                    rebin_params: List[float],
                    banks: Optional[List[int]] = None) -> Workspace2D:
@@ -34,8 +34,8 @@ def load_and_rebin(run_numbers: List[int],
     kwargs = {} if banks is None else {'BankName': ','.join([f'bank{b}' for b in banks])}
 
     # Load the first run
-    logger.info(f'Loading run {run_numbers[0]}. {len(run_numbers)} runs remaining to be loaded')
-    LoadEventNexus(Filename=f'{instrument}_{run_numbers[0]}', OutputWorkspace=output_workspace,
+    logger.information(f'Loading run {runs[0]}. {len(runs)} runs remaining to be loaded')
+    LoadEventNexus(Filename=f'{instrument}_{runs[0]}', OutputWorkspace=output_workspace,
                    LoadLogs=False, **kwargs)
     if rebin_params is not None:
         Rebin(InputWorkspace=output_workspace, OutputWorkspace=output_workspace,
@@ -43,8 +43,8 @@ def load_and_rebin(run_numbers: List[int],
     # Iteratively load the remaining run, adding to the final workspace each time
     try:
         single_run = '__single_run_' + output_workspace
-        for i, run in enumerate(run_numbers[1:]):
-            logger.info(f'Loading run {run}. {len(run_numbers) - 1 - i} runs remaining to be loaded')
+        for i, run in enumerate(runs[1:]):
+            logger.information(f'Loading run {run}. {len(runs) - 1 - i} runs remaining to be loaded')
             LoadEventNexus(Filename=f'{instrument}_{run}', OutputWorkspace=single_run, LoadLogs=False, **kwargs)
             if rebin_params is not None:
                 Rebin(InputWorkspace=single_run, OutputWorkspace=single_run, Params=rebin_params, PreserveEvents=False)


### PR DESCRIPTION
**Description of work.**
- [x] Algorithm accepts matrix workspaces
- [x] utility function to load long runs
- [x]  no need to update the release notes because the algorithm is absent in the current stable release.
- [x] manual test

**To test:**
Run the following script

```python
# import mantid algorithms, numpy and matplotlib
from mantid.simpleapi import *
import matplotlib.pyplot as plt
import numpy as np
from corelli.calibration.powder import load_and_rebin


Load(Filename='CORELLI_124036-124037', BankName='bank55,bank80', OutputWorkspace='events', LoadLogs=False)
CorelliPowderCalibrationCreate(InputWorkspace='events',
                               OutputWorkspacesPrefix='events_',
                               TofBinning=[3000,-0.001,16660],
                               PeakPositions=[1.3143, 1.3854,1.6967, 1.8587, 2.0781, 2.3995, 2.9388, 4.1561],
                               ComponentList='bank55/sixteenpack,bank80/sixteenpack')
                               
load_and_rebin(runs=[124036, 124037], output_workspace='counts', rebin_params=[3000,-0.0001,16660], banks=[55, 80])
CorelliPowderCalibrationCreate(InputWorkspace='counts',
                               OutputWorkspacesPrefix='counts_',
                               TofBinning=[3000,-0.001,16660],
                               PeakPositions=[1.3143, 1.3854,1.6967, 1.8587, 2.0781, 2.3995, 2.9388, 4.1561],
                               ComponentList='bank55/sixteenpack,bank80/sixteenpack')
```
Although the tables  `events_adjustments` and `counts_adjustments` are not identical, both sets of adjustments produce a distribution  of peak deviations very similar.  Verify you obtain the below plot by plotting the same spectrum numbers for workspaces `events_percent_peak_deviations_adjusted`, `events_percent_peak_deviations_adjusted`, and `counts_percent_peak_deviations_adjusted`

<img width="889" alt="Capture" src="https://user-images.githubusercontent.com/1136006/103251648-89e62880-4947-11eb-9f13-8b672a728549.PNG">


Refs #30250

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
