### PR TITLE
Add a 1 msec delay when updating sliceviewer on workspace change

### DIFF
--- a/qt/python/mantidqt/widgets/sliceviewer/test/test_sliceviewer_view.py
+++ b/qt/python/mantidqt/widgets/sliceviewer/test/test_sliceviewer_view.py
@@ -205,6 +205,8 @@ class SliceViewerViewTest(unittest.TestCase, QtWidgetFinder):
 
         renamed = RenameWorkspace(ws)  # noqa F841
 
+        QApplication.sendPostedEvents()
+
         # View didn't close
         self.assertTrue(pres.view in self.find_widgets_of_type(str(type(pres.view))))
         self.assertNotEqual(pres.ads_observer, None)

--- a/qt/python/mantidqt/widgets/sliceviewer/view.py
+++ b/qt/python/mantidqt/widgets/sliceviewer/view.py
@@ -573,8 +573,11 @@ class SliceViewerView(QWidget, ObservingView):
 
     def delayed_refresh(self):
         """Post an event to the event loop that causes the view to
-        update on the next cycle"""
-        QTimer.singleShot(0, self.presenter.refresh_view)
+        update on the next cycle
+
+        A 1 msec delay is added to appease RHEL7 where in some cases
+        it fails"""
+        QTimer.singleShot(1, self.presenter.refresh_view)
 
     def peaks_overlay_clicked(self):
         """Peaks overlay button has been toggled


### PR DESCRIPTION
When this was 0 msec, in some cases on RHEL7 this would case the UI to completely freeze. This should have no user visible effect.

I only noticed this on RHEL7, you can reproduce the problem with https://github.com/mantidproject/mantid/pull/29980#issuecomment-749587211

It was fixed by #30242 for Ubuntu 20.04 but was still there on RHEL7. So this should fix it for RHEL7.

This does not require release notes because it was broken this dev cycle.

<!-- Ensure the base of this PR is correct (e.g. release-next or master)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
