### PR TITLE
Make plot toolbar non movable in EngDiffUI

### DIFF
--- a/scripts/Engineering/gui/engineering_diffraction/tabs/fitting/plotting/plot_view.py
+++ b/scripts/Engineering/gui/engineering_diffraction/tabs/fitting/plotting/plot_view.py
@@ -45,6 +45,7 @@ class FittingPlotView(QtWidgets.QWidget, Ui_plot):
         self.figure.add_subplot(111, projection="mantid")
         self.figure.tight_layout()
         self.toolbar = FittingPlotToolbar(self.figure.canvas, self, False)
+        self.toolbar.setMovable(False)
 
         self.dock_window = QMainWindow(self.group_plot)
         self.dock_window.setWindowFlags(Qt.Widget)


### PR DESCRIPTION
**Description of work.**
This fixes a small bug where the plot toolbar in the fitting tab of EngDiffUi had an option to drag it out of the interface, which was undesired and lead to exceptions in many cases.

**To test:**
1. Open the Engineering Diffraction interface
2. On the fitting tab, make sure the toolbar cannot be dragged
3. Check that the fit pane still undocks correctly with/without a plot or the fit browser open

*There is no associated issue.*

*This does not require release notes* because **it fixes a small bug introduced this dev cycle**


<!-- Ensure the base of this PR is correct (e.g. release-next or master)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
