### PR TITLE
Phasequad And Co-Add Fix

### DIFF
--- a/docs/source/interfaces/muon_phase_table_tab.rst
+++ b/docs/source/interfaces/muon_phase_table_tab.rst
@@ -29,7 +29,8 @@ Phase Quad Calculator
 
 The phase quad calcuator use the :ref:`PhaseQuad <algm-PhaseQuad>` algorithm combine the signals from multiple detectors
 into a quadrature phase signal.
-It will calculate the phasequad for all of the loaded runs using the selected phase table.
+It will calculate the phasequad for all of the loaded runs using the selected phase table. If you are using co-added runs, 
+the deadtime table is only taken from the first run during calculation.
 When the runs are changed all of the phasequads are removed.
 
 **PhaseTable** This selects the phase table used to calculate the phase quad.

--- a/docs/source/release/v6.0.0/muon.rst
+++ b/docs/source/release/v6.0.0/muon.rst
@@ -20,6 +20,7 @@ Improvements
 - Phasequads are now available for analysis in both GUI's.
 - Ticking co-add now works in the GUI's so you can analyse multiple runs as one run
 - Added some input validation to First and Last good Data in the Phase Table tab
+- When using co-add and creating a phasequad, the deadtime table will be taken from the first file only
 
 Bug fixes
 #########

--- a/scripts/Muon/GUI/Common/ADSHandler/workspace_naming.py
+++ b/scripts/Muon/GUI/Common/ADSHandler/workspace_naming.py
@@ -192,6 +192,26 @@ def get_run_numbers_as_string_from_workspace_name(workspace_name, instrument):
     return runs
 
 
+def get_first_run_from_run_string(run_string):
+    """
+    run_string will only be in the format 1-2,5,7,9-11
+    Return the first number only
+    """
+    return_string = run_string
+    index = -1
+    index_1 = run_string.find('-')
+    index_2 = run_string.find(',')
+    if index_1 != -1 and index_2 != -1:
+        index = index_1 if index_1 < index_2 else index_2
+    elif index_1 != -1:
+        index = index_1
+    elif index_2 != -1:
+        index = index_2
+    if index != -1:
+        return_string = return_string[:index]
+    return return_string
+
+
 def get_maxent_workspace_group_name(insertion_workspace_name, instrument, workspace_suffix):
     run = re.search('[0-9]+', insertion_workspace_name).group()
     group = get_base_run_name(run, instrument) + "".join([' ', MAXENT_STR]) + workspace_suffix + '/'

--- a/scripts/Muon/GUI/Common/ADSHandler/workspace_naming.py
+++ b/scripts/Muon/GUI/Common/ADSHandler/workspace_naming.py
@@ -202,7 +202,7 @@ def get_first_run_from_run_string(run_string):
     index_1 = run_string.find('-')
     index_2 = run_string.find(',')
     if index_1 != -1 and index_2 != -1:
-        index = index_1 if index_1 < index_2 else index_2
+        index = min(index_1, index_2)
     elif index_1 != -1:
         index = index_1
     elif index_2 != -1:

--- a/scripts/Muon/GUI/Common/contexts/muon_context.py
+++ b/scripts/Muon/GUI/Common/contexts/muon_context.py
@@ -408,6 +408,7 @@ class MuonContext(object):
         if self.gui_context['DeadTimeSource'] == 'FromADS':
             return self.gui_context['DeadTimeTable']
         elif self.gui_context['DeadTimeSource'] == 'FromFile':
+            run = wsName.get_first_run_from_run_string(run)
             return self.data_context.get_loaded_data_for_run([float(run)])["DataDeadTimeTable"]
         elif self.gui_context['DeadTimeSource'] == 'None':
             return None

--- a/scripts/Muon/GUI/Common/phase_table_widget/phase_table_presenter.py
+++ b/scripts/Muon/GUI/Common/phase_table_widget/phase_table_presenter.py
@@ -12,7 +12,8 @@ from mantidqt.utils.observer_pattern import Observable, GenericObserver, Generic
 import re
 from Muon.GUI.Common.ADSHandler.workspace_naming import get_phase_table_workspace_name, \
     get_fitting_workspace_name, get_base_data_directory, \
-    get_run_number_from_workspace_name
+    get_run_number_from_workspace_name, \
+    get_run_numbers_as_string_from_workspace_name
 from Muon.GUI.Common.ADSHandler.muon_workspace_wrapper import MuonWorkspaceWrapper
 from Muon.GUI.Common.utilities.run_string_utils import valid_name_regex
 import mantid
@@ -183,7 +184,7 @@ class PhaseTablePresenter(object):
         return parameters['DetectorTable']
 
     def add_phase_table_to_ADS(self, base_name):
-        run = re.search('[0-9]+', base_name).group()
+        run = get_run_numbers_as_string_from_workspace_name(base_name, self.context.data_context.instrument)
 
         directory = get_base_data_directory(self.context, run)
         muon_workspace_wrapper = MuonWorkspaceWrapper(directory + base_name)

--- a/scripts/test/Muon/ADSHandler/workspace_naming_test.py
+++ b/scripts/test/Muon/ADSHandler/workspace_naming_test.py
@@ -61,6 +61,18 @@ class WorkspaceNamingTest(unittest.TestCase):
         self.assertEqual(runs, get_run_numbers_as_string_from_workspace_name(
             workspace_name, instrument))
 
+    def test_get_first_run_from_run_string_one_number(self):
+        run_string = '62260'
+        self.assertEqual('62260', get_first_run_from_run_string(run_string))
+
+    def test_get_first_run_from_run_string_hyphen_first(self):
+        run_string = '62260-2,62264,62267-9'
+        self.assertEqual('62260', get_first_run_from_run_string(run_string))
+
+    def test_get_first_run_from_run_string_comma_first(self):
+        run_string = '62260,62262-62264,62267-9'
+        self.assertEqual('62260', get_first_run_from_run_string(run_string))
+
 
 if __name__ == '__main__':
     unittest.main(buffer=False, verbosity=2)


### PR DESCRIPTION
~~**Merge #30257 first**~~

**Description of work.**
The problem was that the run number for co add could not be converted to a float for dead time calculation. I have assumed that deadtime correction taken from a file can be taken from the first file if the runs are added through co add

**To test:**
1. Open Muon Analysis
2. Load in multiple runs (MUSR62260-2) and check co-add
3. Go to phase table tab
4. Make a phase table and try to make a phasequad
5. Before this did not work

Fixes #30169 

*This does not require release notes* because **phasetable changes haven't been released yet**

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
