### PR TITLE
Fix Crash In MA When Autoscale Y Pressed With No Data

### DIFF
--- a/docs/source/release/v6.0.0/muon.rst
+++ b/docs/source/release/v6.0.0/muon.rst
@@ -35,6 +35,7 @@ Bug fixes
 - Fixed a crash when trying to do a simultaneous fit with no data loaded after pressing clear all.
 - Fixed a bug where changing rebin wouldn't update the plot in the GUI
 - Fixed a bug where the plot would update incorrectly when changing plot raw and plot difference
+- Fixed a crash when pressing autoscale y without any data loaded
 
 ALC
 ---

--- a/scripts/MultiPlotting/QuickEdit/quickEdit_view.py
+++ b/scripts/MultiPlotting/QuickEdit/quickEdit_view.py
@@ -35,6 +35,7 @@ class QuickEditView(QtWidgets.QWidget):
             self.autoscale.setStyleSheet("background-color:lightgrey")
         else:
             self.autoscale = QtWidgets.QCheckBox("Autoscale y")
+            self.autoscale.setChecked(True)
             self.autoscale.setToolTip("While pan or zoom are enabled autoscale is disabled")
 
         self.y_axis_changer = AxisChangerPresenter(AxisChangerView("Y"))

--- a/scripts/Muon/GUI/Common/plot_widget/plot_widget_presenter.py
+++ b/scripts/Muon/GUI/Common/plot_widget/plot_widget_presenter.py
@@ -73,6 +73,7 @@ class PlotWidgetPresenterCommon(HomeTabSubWidget):
         self.plot_selected_fit_observer = GenericObserverWithArgPassing(self.handle_plot_selected_fits)
         self.plot_guess_observer = GenericObserver(self.handle_plot_guess_changed)
         self.rebin_options_set_observer = GenericObserver(self.handle_rebin_options_changed)
+        self.new_data_loaded_observer = GenericObserver(self.handle_data_updated)
         self.plot_type_changed_notifier = GenericObservable()
 
     def _setup_view_connections(self):
@@ -359,6 +360,10 @@ class PlotWidgetPresenterCommon(HomeTabSubWidget):
         workspace_list, indices = self._model.get_workspace_list_and_indices_to_plot(self._view.is_raw_plot(),
                                                                                      self._view.get_plot_type())
 
+        if workspace_list:
+            self._view.setEnabled(True)
+        else:
+            self._view.setEnabled(False)
         self._figure_presenter.plot_workspaces(workspace_list, indices, hold_on=hold_on, autoscale=autoscale)
 
     def _check_if_counts_and_groups_selected(self):

--- a/scripts/Muon/GUI/Common/plot_widget/plot_widget_view.py
+++ b/scripts/Muon/GUI/Common/plot_widget/plot_widget_view.py
@@ -23,6 +23,7 @@ class PlotWidgetView(QtWidgets.QWidget, PlotWidgetViewInterface, ui_plotting_vie
         super().__init__(parent=parent)
         self.setupUi(self)
         self.setMinimumSize(600,600)
+        self.setEnabled(False)
 
     def show_plot_diff(self):
         self.plot_diff_checkbox.setVisible(True)

--- a/scripts/Muon/GUI/FrequencyDomainAnalysis/frequency_domain_analysis_2.py
+++ b/scripts/Muon/GUI/FrequencyDomainAnalysis/frequency_domain_analysis_2.py
@@ -255,6 +255,9 @@ class FrequencyAnalysisGui(QtWidgets.QMainWindow):
         self.load_widget.load_widget.loadNotifier.add_subscriber(
             self.fitting_tab.fitting_tab_presenter.disable_tab_observer)
 
+        self.load_widget.load_widget.loadNotifier.add_subscriber(
+            self.plot_widget.presenter.new_data_loaded_observer)
+
     def setup_gui_variable_observers(self):
         self.context.gui_context.gui_variables_notifier.add_subscriber(
             self.grouping_tab_widget.group_tab_presenter.gui_variables_observer)

--- a/scripts/Muon/GUI/MuonAnalysis/muon_analysis_2.py
+++ b/scripts/Muon/GUI/MuonAnalysis/muon_analysis_2.py
@@ -235,6 +235,9 @@ class MuonAnalysisGui(QtWidgets.QMainWindow):
         self.load_widget.load_widget.loadNotifier.add_subscriber(
             self.seq_fitting_tab.seq_fitting_tab_presenter.disable_tab_observer)
 
+        self.load_widget.load_widget.loadNotifier.add_subscriber(
+            self.plot_widget.presenter.new_data_loaded_observer)
+
     def setup_gui_variable_observers(self):
         self.context.gui_context.gui_variables_notifier.add_subscriber(
             self.grouping_tab_widget.group_tab_presenter.gui_variables_observer)

--- a/scripts/test/Muon/plot_widget/plot_widget_presenter_test.py
+++ b/scripts/test/Muon/plot_widget/plot_widget_presenter_test.py
@@ -314,6 +314,15 @@ class PlotWidgetPresenterCommonTest(unittest.TestCase):
         ws_rebin_names = ['MUSR62260; Group; bottom; Asymmetry; Rebin; MA']
         self.assertEqual(self.presenter.match_raw_selection(ws_rebin_names, False), ws_rebin_names)
 
+    def test_tab_enabled_with_data_loaded(self):
+        self.presenter.plot_all_selected_data(False, False)
+        self.view.setEnabled.assert_called_once_with(True)
+
+    def test_tab_disbaled_with_no_data_loaded(self):
+        self.model.get_workspace_list_and_indices_to_plot.return_value = [[], indices]
+        self.presenter.plot_all_selected_data(False, False)
+        self.view.setEnabled.assert_called_once_with(False)
+
 
 if __name__ == '__main__':
     unittest.main(buffer=False, verbosity=2)

--- a/scripts/test/Muon/plot_widget/plot_widget_presenter_test.py
+++ b/scripts/test/Muon/plot_widget/plot_widget_presenter_test.py
@@ -33,6 +33,7 @@ class PlotWidgetPresenterCommonTest(unittest.TestCase):
         self.model = mock.Mock(spec=PlotWidgetModel)
         self.view = mock.Mock(spec=PlotWidgetViewInterface)
         self.view.warning_popup = mock.MagicMock()
+        self.view.setEnabled = mock.MagicMock()
         self.external_plotting_model = mock.Mock(spec=ExternalPlottingModel)
         self.external_plotting_view = mock.Mock(spec=ExternalPlottingView)
         self.figure_presenter = mock.Mock(spec=PlottingCanvasPresenterInterface)


### PR DESCRIPTION
**Description of work.**
Disabled plot window until data is loaded

**To test:**
1. Open Muon Analysis
2. Plot window should be disabled which stops being able to check autoscale y which prevents any crashes
3. Check that the plot window is re-enabled when data loaded
4. And pressing clear all disables it again
5. Do the same for Frequency Domain Analysis

Fixes #30267 

<!-- Ensure the base of this PR is correct (e.g. release-next or master)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
