### PR TITLE
Add clear setups button in fit browser

### DIFF
--- a/docs/source/release/v6.0.0/framework.rst
+++ b/docs/source/release/v6.0.0/framework.rst
@@ -30,6 +30,7 @@ Fitting
 -------
 
 - Corrected a bug in the calculation of uncertainty bands on the calculated fit curve. This correction has been tested against the python fitting package `kmpfit`, where an agreement between the two was seen.
+- Added button to clear all custom setups in Setup > Manage Setups menu
 
 Data Objects
 ------------

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/FitPropertyBrowser.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/FitPropertyBrowser.h
@@ -349,6 +349,7 @@ public slots:
   void executeSetupManageMenu(const QString & /*item*/);
   void workspaceDoubleClicked(QListWidgetItem *item);
   void executeCustomSetupRemove(const QString &name);
+  void executeClearCustomSetups();
 
 signals:
   void currentChanged() const;

--- a/qt/widgets/common/src/FitPropertyBrowser.cpp
+++ b/qt/widgets/common/src/FitPropertyBrowser.cpp
@@ -447,6 +447,8 @@ void FitPropertyBrowser::initBasicLayout(QWidget *w) {
   QMenu *setupSubMenuManage = new QMenu(this);
   QAction *setupActionSave = new QAction("Save Setup", this);
   m_setupActionRemove = new QAction("Remove Setup", this);
+  QAction *setupActionClear = new QAction("Clear Setups", this);
+  setupActionClear->setObjectName("action_ClearSetups");
   QAction *setupActionCopyToClipboard = new QAction("Copy To Clipboard", this);
   setupActionCopyToClipboard->setObjectName("action_CopyToClipboard");
   QAction *setupActionLoadFromString = new QAction("Load From String", this);
@@ -455,15 +457,19 @@ void FitPropertyBrowser::initBasicLayout(QWidget *w) {
   setupManageMapper->setMapping(setupActionSave, "SaveSetup");
   setupManageMapper->setMapping(setupActionCopyToClipboard, "CopyToClipboard");
   setupManageMapper->setMapping(setupActionLoadFromString, "LoadFromString");
+  setupManageMapper->setMapping(setupActionClear, "ClearSetups");
   connect(setupActionSave, SIGNAL(triggered()), setupManageMapper, SLOT(map()));
   connect(setupActionCopyToClipboard, SIGNAL(triggered()), setupManageMapper,
           SLOT(map()));
   connect(setupActionLoadFromString, SIGNAL(triggered()), setupManageMapper,
           SLOT(map()));
+  connect(setupActionClear, SIGNAL(triggered()), setupManageMapper,
+          SLOT(map()));
   connect(setupManageMapper, SIGNAL(mapped(const QString &)), this,
           SLOT(executeSetupManageMenu(const QString &)));
   setupSubMenuManage->addAction(setupActionSave);
   setupSubMenuManage->addAction(m_setupActionRemove);
+  setupSubMenuManage->addAction(setupActionClear);
   setupSubMenuManage->addAction(setupActionCopyToClipboard);
   setupSubMenuManage->addAction(setupActionLoadFromString);
   setupActionManageSetup->setMenu(setupSubMenuManage);
@@ -667,6 +673,14 @@ void FitPropertyBrowser::executeCustomSetupRemove(const QString &name) {
   updateSetupMenus();
 }
 
+void FitPropertyBrowser::executeClearCustomSetups() {
+  QSettings settings;
+  settings.beginGroup("Mantid/FitBrowser/SavedFunctions");
+
+  settings.clear();
+  updateSetupMenus();
+}
+
 /**
  * Recursively updates structure tooltips for all the functions
  */
@@ -705,6 +719,8 @@ void FitPropertyBrowser::executeSetupMenu(const QString &item) {
 void FitPropertyBrowser::executeSetupManageMenu(const QString &item) {
   if (item == "SaveSetup")
     saveFunction();
+  if (item == "ClearSetups")
+    executeClearCustomSetups();
   if (item == "CopyToClipboard")
     copy();
   if (item == "LoadFromString")


### PR DESCRIPTION
**Description of work.**

Added button to clear custom setups in Setup > Manage Setups menu.
The Eng Diff UI fitting generates setups automatically and it can be time consuming to remove each setup individually.

**To test:**
(1) Plot a spectrum and open the fit browser
(2) If you don't have any custom setups add some by either adding some functions or pasting the below in Setup > Manage Setup > Load From String  and saving by clicking Save Setup > Manage Setup > Save Setup
`composite=CompositeFunction,NumDeriv=true;name=BackToBackExponential,I=1665.21,A=0.03754,B=0.020528,X0=38819.8,S=27.1533,ties=(A=0.03754);name=BackToBackExponential,I=630.816,A=0.0323526,B=0.0185908,X0=33621.4,S=27.1533,constraints=(30000<X0<40000),ties=(A=0.0323526);name=FlatBackground,A0=0.0337338;ties=(f1.S=f0.S)`
(3)  Open the Setup > Manage Setup menu, there should be a "Clear Setups" button.
(4) Click Clear Setups and check all the setups have been removed.

*There is no associated issue.*

<!-- Ensure the base of this PR is correct (e.g. release-next or master)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
