### PR TITLE
Direct inelastic results compartible with indirect analysis

### DIFF
--- a/scripts/Inelastic/Direct/DirectEnergyConversion.py
+++ b/scripts/Inelastic/Direct/DirectEnergyConversion.py
@@ -882,6 +882,7 @@ class DirectEnergyConversion(object):
             GetEi(InputWorkspace=monitor_ws, Monitor1Spec=ei_mon_spectra[0],
                   Monitor2Spec=ei_mon_spectra[1],
                   EnergyEstimate=ei_guess,FixEi=fix_ei)
+        SetInstrumentParameter(data_ws,ParameterName='EFixed',ParameterType='Number', Value='{0}'.format(ei))
 
         # Store found incident energy in the class itself
         if self.prop_man.normalise_method == 'monitor-2' and not separate_monitors:
@@ -1293,6 +1294,8 @@ class DirectEnergyConversion(object):
                     SaveSPE(InputWorkspace=workspace,Filename= filename)
                     break
                 if case('nxs'):
+                    if save_file[-4:] != '_red':
+                        save_file = save_file+'_red'
                     filename = save_file + '.nxs'
                     SaveNexus(InputWorkspace=workspace,Filename= filename)
                     break

--- a/scripts/Inelastic/Direct/DirectEnergyConversion.py
+++ b/scripts/Inelastic/Direct/DirectEnergyConversion.py
@@ -1294,8 +1294,6 @@ class DirectEnergyConversion(object):
                     SaveSPE(InputWorkspace=workspace,Filename= filename)
                     break
                 if case('nxs'):
-                    if save_file[-4:] != '_red':
-                        save_file = save_file+'_red'
                     filename = save_file + '.nxs'
                     SaveNexus(InputWorkspace=workspace,Filename= filename)
                     break

--- a/scripts/test/DirectEnergyConversionTest.py
+++ b/scripts/test/DirectEnergyConversionTest.py
@@ -79,7 +79,7 @@ class DirectEnergyConversionTest(unittest.TestCase):
         tReducer.prop_man.save_format = ['spe', 'nxspe', 'nxs']
         tReducer.save_results(tws, 'save_formats_test_file.tt')
 
-        files = ['save_formats_test_file.spe', 'save_formats_test_file.nxspe', 'save_formats_test_file_red.nxs']
+        files = ['save_formats_test_file.spe', 'save_formats_test_file.nxspe', 'save_formats_test_file.nxs']
         verify_present_and_delete(files)
 
         tReducer.prop_man.save_format = None
@@ -90,7 +90,7 @@ class DirectEnergyConversionTest(unittest.TestCase):
 
         # save file with given extension on direct request:
         tReducer.save_results(tws, 'save_formats_test_file.nxs')
-        verify_present_and_delete(['save_formats_test_file_red.nxs'])
+        verify_present_and_delete(['save_formats_test_file.nxs'])
 
         tReducer.prop_man.save_format = []
         # do nothing
@@ -100,7 +100,7 @@ class DirectEnergyConversionTest(unittest.TestCase):
 
         # save files with extensions on request
         tReducer.save_results(tws, 'save_formats_test_file', ['nxs', '.nxspe'])
-        verify_present_and_delete(['save_formats_test_file.nxspe', 'save_formats_test_file_red.nxs'])
+        verify_present_and_delete(['save_formats_test_file.nxspe', 'save_formats_test_file.nxs'])
 
         # this is strange feature.
         self.assertEqual(len(tReducer.prop_man.save_format), 2)

--- a/scripts/test/DirectEnergyConversionTest.py
+++ b/scripts/test/DirectEnergyConversionTest.py
@@ -79,7 +79,7 @@ class DirectEnergyConversionTest(unittest.TestCase):
         tReducer.prop_man.save_format = ['spe', 'nxspe', 'nxs']
         tReducer.save_results(tws, 'save_formats_test_file.tt')
 
-        files = ['save_formats_test_file.spe', 'save_formats_test_file.nxspe', 'save_formats_test_file.nxs']
+        files = ['save_formats_test_file.spe', 'save_formats_test_file.nxspe', 'save_formats_test_file_red.nxs']
         verify_present_and_delete(files)
 
         tReducer.prop_man.save_format = None
@@ -90,7 +90,7 @@ class DirectEnergyConversionTest(unittest.TestCase):
 
         # save file with given extension on direct request:
         tReducer.save_results(tws, 'save_formats_test_file.nxs')
-        verify_present_and_delete(['save_formats_test_file.nxs'])
+        verify_present_and_delete(['save_formats_test_file_red.nxs'])
 
         tReducer.prop_man.save_format = []
         # do nothing
@@ -100,7 +100,7 @@ class DirectEnergyConversionTest(unittest.TestCase):
 
         # save files with extensions on request
         tReducer.save_results(tws, 'save_formats_test_file', ['nxs', '.nxspe'])
-        verify_present_and_delete(['save_formats_test_file.nxspe', 'save_formats_test_file.nxs'])
+        verify_present_and_delete(['save_formats_test_file.nxspe', 'save_formats_test_file_red.nxs'])
 
         # this is strange feature.
         self.assertEqual(len(tReducer.prop_man.save_format), 2)


### PR DESCRIPTION
**Description of work.**
This small changes add information necessary for the result of DirectInelastic reduction to be compatible with the indirect analysis.

**Report to:** [Tatiana Guidi]
<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
-->

**To test:**
Data reduced by DirectReduction on MARI can be submitted as input for IndirectAnalysis resolution fitting and it works. 
The results are already tested by instrument scientist and she is happy with it. 

fixes #30323

No release notes are necessary as changes are minor and instrument scientist concerning is already aware of them. 
<!-- Instructions for testing. -->


<!-- alternative
*There is no associated issue.*
-->

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or master)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
