### PR TITLE
Fix bug with ISISSans 'Save Other' functionality

### DIFF
--- a/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/SANS/SANSSave.py
+++ b/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/SANS/SANSSave.py
@@ -10,7 +10,7 @@
 
 from mantid.api import (DataProcessorAlgorithm, MatrixWorkspaceProperty, AlgorithmFactory, PropertyMode,
                         FileProperty, FileAction, Progress)
-from mantid.kernel import (Direction)
+from mantid.kernel import (Direction, logger)
 from sans.algorithm_detail.save_workspace import (save_to_file, get_zero_error_free_workspace, file_format_with_append)
 from sans.common.enums import (SaveType)
 
@@ -115,7 +115,13 @@ class SANSSave(DataProcessorAlgorithm):
             progress_message = "Saving to {0}.".format(file_format.file_format.value)
             progress.report(progress_message)
             progress.report(progress_message)
-            save_to_file(workspace, file_format, file_name, transmission_workspaces, additional_run_numbers)
+            try:
+                save_to_file(workspace, file_format, file_name, transmission_workspaces, additional_run_numbers)
+            except (RuntimeError, ValueError):
+                logger.warning(f"Cannot save workspace using SANSSave. "
+                               "This workspace needs to be the result of a SANS reduction, "
+                               "i.e. it can only be 1D or 2D if the second axis "
+                               "is numeric.")
         progress.report("Finished saving workspace to files.")
 
     def validateInputs(self):

--- a/docs/source/release/v6.0.0/sans.rst
+++ b/docs/source/release/v6.0.0/sans.rst
@@ -40,5 +40,6 @@ Bugfixes
 - Wavelength limits entered with comma ranges larger than 10, e.g. `1,5,10,15` no longer
   throw a Runtime Error.
 - ISIS SANS will print the name of any missing maskfiles instead of an empty name.
+- Fixed a bug in ISIS SANS GUI with the `Save Other` dialog.
 
 :ref:`Release 6.0.0 <v6.0.0>`

--- a/scripts/SANS/sans/gui_logic/presenter/save_other_presenter.py
+++ b/scripts/SANS/sans/gui_logic/presenter/save_other_presenter.py
@@ -9,6 +9,7 @@ from mantid import AnalysisDataService
 from sans.algorithm_detail.batch_execution import save_workspace_to_file
 import os
 from mantid.api import WorkspaceGroup
+from mantid.kernel import logger
 
 
 class SaveOtherPresenter(object):
@@ -38,12 +39,19 @@ class SaveOtherPresenter(object):
             return
         selected_workspaces = self.get_workspaces()
         selected_filenames = self.get_filenames(selected_workspaces, self.filename)
+        additional_run_numbers = {}
 
         self._view.progress_bar_minimum = 0
         self._view.progress_bar_maximum = len(selected_workspaces)
         self._view.progress_bar_value = 0
         for name_to_save, filename in zip(selected_workspaces, selected_filenames):
-            save_workspace_to_file(name_to_save, file_formats, filename)
+            try:
+                save_workspace_to_file(name_to_save, file_formats, filename, additional_run_numbers)
+            except RuntimeError:
+                logger.warning(f"Cannot save {name_to_save} using SANSSave. "
+                               "This workspace needs to be the result of a SANS reduction, "
+                               "i.e. it can only be 1D or 2D if the second axis "
+                               "is numeric.")
             self._view.increment_progress()
 
     def on_item_selection_changed(self):


### PR DESCRIPTION
**Description of work.**
This PR fixes a bug with the _Save Other_ dialog in the ISIS Sans GUI. This was due to a missing argument to the SANSSave call. This argument is only used when saving NXcanSAS and CanSAS files. The additional run numbers are descirbed in the SANSSave algorithm:

```
SampleTransmissionRunNumber | The run number for the Sample Transmission workspace used in the reduction. Can be blank.
SampleDirectRunNumber | The run number for the Sample Direct workspace used in the reduction. Can be blank.
CanScatterRunNumber | The run number for the Can Scatter workspace used in the reduction. Can be blank.
CanDirectRunNumber | The run number for the Can Direct workspace used in the reduction. Can be blank.
```
This information should be retrievable from the GUI, but for the time being if they are left blank the _Save Other_ dialog works as expected. Additionally, the list of workspaces in the dialog is unfiltered, meaning it gives you the option to save unsupported workspace types, which leads to unhandled exceptions. To avoid these errors, these exceptions are now caught.


**Report to:** Richard Heenan


**To test:**

- Open the ISIS Sans GUI
- Assuming you have the training data load the user file /loqdemo/MaskFile.toml and the batch file /loqdemo/batch_mode_reduction.csv
- Click process all
- Now open the Save Other dialog
- Set a save directory and filename and tick all the save formats
- Try save the reduction workspaces e.g second_time_HAB_.. 
- You should be able to locate the saved file for each of the save formats
- Try save a differnt workspace, e.g the sans_interface_raw data, a warning in the logger should appear.

<!-- Instructions for testing. -->

Fixes #30298 . <!-- and fix #xxxx or close #xxxx xor resolves #xxxx -->
<!-- alternative
*There is no associated issue.*
-->

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or master)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
