### PR TITLE
Fix sequential fitting crash

### DIFF
--- a/qt/widgets/common/src/SequentialFitDialog.cpp
+++ b/qt/widgets/common/src/SequentialFitDialog.cpp
@@ -324,8 +324,15 @@ void SequentialFitDialog::accept() {
   alg->initialize();
   alg->setPropertyValue("Input", inputStr.join(";").toStdString());
   alg->setProperty("WorkspaceIndex", m_fitBrowser->workspaceIndex());
-  alg->setProperty("StartX", m_fitBrowser->startX());
-  alg->setProperty("EndX", m_fitBrowser->endX());
+  // Create an array property of start and end X times, each pair startX[i]
+  // endX[i] will be used for the ith fit.
+  // At the moment we read the startX and endX from the single entry in the fit
+  // browser - and duplicate it for each input
+  auto nInputs = rowCount();
+  auto startX = m_fitBrowser->startX();
+  auto endX = m_fitBrowser->endX();
+  alg->setProperty("StartX", std::vector<double>(nInputs, startX));
+  alg->setProperty("EndX", std::vector<double>(nInputs, endX));
   alg->setPropertyValue("OutputWorkspace", m_outputName);
   alg->setPropertyValue("Function", funStr);
   alg->setProperty("CreateOutput", ui.ckCreateOutput->isChecked());
@@ -336,7 +343,7 @@ void SequentialFitDialog::accept() {
     std::string logName = ui.cbLogValue->currentText().toStdString();
     alg->setPropertyValue("LogValue", logName);
     observeFinish(alg);
-  } else if (rowCount() > 1) {
+  } else if (nInputs > 1) {
     alg->setPropertyValue("LogValue", "SourceName");
   } else {
     observeFinish(alg);


### PR DESCRIPTION
**Description of work.**
This PR fixes a crash with sequential fitting in the fit property browser. It was due to the startX and endX expecting arrays of the values due to an underlying change to the PlotPeaksByLogValue algorithm.


**To test:**

1.  Load a workspace e.g MUSR62260
2.  Plot spectra 1-4
3.  Open the fit browser
4.  Add a function e.g expdecay
5.  Go to fit -> Sequential fit
6.  Populate the table by clicking add workspace and set the spectrum numbers
7.  Click fit
8.  It should no longer crash

<!-- Instructions for testing. -->

Fixes #30312 . <!-- and fix #xxxx or close #xxxx xor resolves #xxxx -->
<!-- alternative
*There is no associated issue.*
-->

*This does not require release notes* because it was an issue introduced this release.

<!-- Ensure the base of this PR is correct (e.g. release-next or master)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
