### PR TITLE
Stop sliceviewer rebinning histo ws if have different number dimensions than origional

### DIFF
--- a/qt/python/mantidqt/widgets/sliceviewer/dimensionwidget.py
+++ b/qt/python/mantidqt/widgets/sliceviewer/dimensionwidget.py
@@ -46,8 +46,7 @@ class DimensionWidget(QWidget):
         self.dims, self.qflags = [], []
         for n, dim in enumerate(dims_info):
             self.qflags.append(dim['qdim'])
-            dim_type = dim['type']
-            if dim_type == 'MDE' or (dim_type == 'MDH' and dim['has_original']):
+            if dim['can_rebin']:
                 self.dims.append(DimensionNonIntegrated(dim, number=n, parent=self))
             else:
                 self.dims.append(Dimension(dim, number=n, parent=self))

--- a/qt/python/mantidqt/widgets/sliceviewer/model.py
+++ b/qt/python/mantidqt/widgets/sliceviewer/model.py
@@ -122,8 +122,8 @@ class SliceViewerModel:
         Check if the given workspace can multiple BinMD calls.
         """
         ws_type = self.get_ws_type()
-        return ws_type == WS_TYPE.MDE or (ws_type == WS_TYPE.MDH
-                                          and self._get_ws().hasOriginalWorkspace(0))
+        return ws_type == WS_TYPE.MDE or (ws_type == WS_TYPE.MDH and self._get_ws().hasOriginalWorkspace(0)
+                               and self._get_ws().getOriginalWorkspace(0).getNumDims() == self._get_ws().getNumDims())
 
     def get_ws_name(self) -> str:
         """Return the name of the workspace being viewed"""
@@ -196,7 +196,7 @@ class SliceViewerModel:
     def get_dim_info(self, n: int) -> dict:
         """
         returns dict of (minimum :float, maximum :float, number_of_bins :int,
-                         width :float, name :str, units :str, type :str, has_original: bool, qdim: bool) for dimension n
+                         width :float, name :str, units :str, type :str, can_rebin: bool, qdim: bool) for dimension n
         """
         workspace = self._get_ws()
         dim = workspace.getDimension(n)
@@ -208,7 +208,7 @@ class SliceViewerModel:
             'name': dim.name,
             'units': dim.getUnits(),
             'type': self.get_ws_type().name,
-            'has_original': workspace.hasOriginalWorkspace(0),
+            'can_rebin': self.can_support_dynamic_rebinning(),
             'qdim': dim.getMDFrame().isQ()
         }
 

--- a/qt/python/mantidqt/widgets/sliceviewer/model.py
+++ b/qt/python/mantidqt/widgets/sliceviewer/model.py
@@ -122,8 +122,8 @@ class SliceViewerModel:
         Check if the given workspace can multiple BinMD calls.
         """
         ws_type = self.get_ws_type()
-        return ws_type == WS_TYPE.MDE or (ws_type == WS_TYPE.MDH and self._get_ws().hasOriginalWorkspace(0)
-                               and self._get_ws().getOriginalWorkspace(0).getNumDims() == self._get_ws().getNumDims())
+        return ws_type == WS_TYPE.MDE or (ws_type == WS_TYPE.MDH and self._get_ws().hasOriginalWorkspace(
+            0) and self._get_ws().getOriginalWorkspace(0).getNumDims() == self._get_ws().getNumDims())
 
     def get_ws_name(self) -> str:
         """Return the name of the workspace being viewed"""

--- a/qt/python/mantidqt/widgets/sliceviewer/view.py
+++ b/qt/python/mantidqt/widgets/sliceviewer/view.py
@@ -49,6 +49,7 @@ class SliceViewerCanvas(ScrollZoomMixin, MantidFigureCanvas):
 
 class SliceViewerDataView(QWidget):
     """The view for the data portion of the sliceviewer"""
+
     def __init__(self, presenter, dims_info, can_normalise, parent=None, conf=None):
         super().__init__(parent)
 


### PR DESCRIPTION
**Description of work.**
Stop sliceviewer not longer tries to dynamically rebin the original workspace (e.g. when permuting axes of changing bin width) if the histo workspace plotted has a different number of dimensions (this is because the full information to re-rebin the already integrated dimension is not accessible).  Also fixed bug in view that displayed spinbox widgets even though rebinning not supported

**To test:**
(1) Run script in original issue, 
(2) Check you can no longer see (and therefore change) the number of bins along non-integrated dimensions
(3) Try changing the viewing axes, this should not cause any exception

Fixes #30322

*This does not require release notes* because **it fixes a small bug found in manual testing**

<!-- Ensure the base of this PR is correct (e.g. release-next or master)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
