### PR TITLE
Fixed bug to get correct extent of bin arguments from axes limits of sliceviewer

### DIFF
--- a/docs/source/release/v6.0.0/mantidworkbench.rst
+++ b/docs/source/release/v6.0.0/mantidworkbench.rst
@@ -60,5 +60,6 @@ Bugfixes
 - Fixed a bug which caused a terminate dialogue to be raised if the user zoomed in far enough while using the SliceViewer on MDE workspaces.
 - Fixed a crash in the plot config when removing the last curve on a plot
 - Fixed a bug in SliceViewer that caused shown data to not update correctly when changing axis selection.
+- Fixed bug supplying rebin arguments for non-orthogonal data in sliceviewer that meant that not all the availible data within the axes limits were being plotted.
 
 :ref:`Release 6.0.0 <v6.0.0>`

--- a/qt/python/mantidqt/widgets/sliceviewer/presenter.py
+++ b/qt/python/mantidqt/widgets/sliceviewer/presenter.py
@@ -317,6 +317,7 @@ class SliceViewer(ObservingPresenter):
             data_view.disable_tool_button(ToolItemText.LINEPLOTS)
             data_view.create_axes_nonorthogonal(
                 self.model.create_nonorthogonal_transform(self.get_sliceinfo()))
+            self.show_all_data_requested()
         else:
             data_view.create_axes_orthogonal()
             data_view.enable_tool_button(ToolItemText.LINEPLOTS)

--- a/qt/python/mantidqt/widgets/sliceviewer/presenter.py
+++ b/qt/python/mantidqt/widgets/sliceviewer/presenter.py
@@ -95,8 +95,9 @@ class SliceViewer(ObservingPresenter):
             # model frame
             if data_view.nonorthogonal_mode:
                 inv_tr = data_view.nonortho_transform.inv_tr
-                xmin_p, ymin_p = inv_tr(xlim[0], ylim[0])
-                xmax_p, ymax_p = inv_tr(xlim[1], ylim[1])
+                # viewing axis y not aligned with plot axis
+                xmin_p, ymax_p = inv_tr(xlim[0], ylim[1])
+                xmax_p, ymin_p = inv_tr(xlim[1], ylim[0])
                 xlim, ylim = (xmin_p, xmax_p), (ymin_p, ymax_p)
             if data_view.dimensions.transpose:
                 limits = ylim, xlim


### PR DESCRIPTION
**Description of work.**

Fixed bug that was not getting the proper extent for binning arguments when rebinning non-orthogonal data based on axes limits in sliceviewer. The y-axis is not aligned with the vertical plot axis which wasn't reflected in the determination of the limits (xmin,xmax).

**To test:**
(1) Make a non-orthog MD workspace with this script
```
ws = CreateMDWorkspace(Dimensions='3', Extents='-5,5,-5,5,-5,5',
                       Names='H,K,L', Units='r.l.u.,r.l.u.,r.l.u.',
                       Frames='HKL,HKL,HKL',
                       SplitInto='2', SplitThreshold='50')
expt_info = CreateSampleWorkspace()
ws.addExperimentInfo(expt_info)
SetUB(ws, 1,1,2,90,90,120)
FakeMDEventData(ws, PeakParams='1e+06,0,1,0,0.5', RandomSeed='3873875')
```
(2) Plot in sliceviewer with non-orthog view
(3) Zoom in using scroll or dragging the mouse, the data available data should fill the screen as expected (not produce a lot of whitespace as in original issue)

Fixes #29165 
<!-- alternative
*There is no associated issue.*
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or master)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
