### PR TITLE
Fix error in MaxEnt

### DIFF
--- a/scripts/Muon/GUI/Common/contexts/muon_context.py
+++ b/scripts/Muon/GUI/Common/contexts/muon_context.py
@@ -408,7 +408,8 @@ class MuonContext(object):
         if self.gui_context['DeadTimeSource'] == 'FromADS':
             return self.gui_context['DeadTimeTable']
         elif self.gui_context['DeadTimeSource'] == 'FromFile':
-            run = wsName.get_first_run_from_run_string(run)
+            if isinstance(run, str):
+                run = wsName.get_first_run_from_run_string(run)
             return self.data_context.get_loaded_data_for_run([float(run)])["DataDeadTimeTable"]
         elif self.gui_context['DeadTimeSource'] == 'None':
             return None


### PR DESCRIPTION
This PR fixes a bug in FDA where MaxEnt cannot be run because it expects a string for run name.

**To test:**

1. open Muon->Frequency Domain Analysis
2. Load MUSR 62260
3. go to transform tab
4. change FFT to MaxEnt
5. Click Calculate MaxEnt

Fixes #30341 

*This does not require release notes* because It was a bug introduced this release.

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
