### PR TITLE
Fix anonymous fallback in GitHub api calls

### DIFF
--- a/Framework/Kernel/inc/MantidKernel/GitHubApiHelper.h.in
+++ b/Framework/Kernel/inc/MantidKernel/GitHubApiHelper.h.in
@@ -37,9 +37,7 @@ protected:
   virtual int sendRequestAndProcess(Poco::Net::HTTPClientSession &session,
     Poco::URI &uri, std::ostream &responseStream) override;
 private:
-  int processAnonymousRequest(const Poco::Net::HTTPResponse &response,
-    Poco::URI &uri,
-    std::ostream &responseStream);
+  int processAnonymousRequest(Poco::URI &uri, std::ostream &responseStream);
   void addAuthenticationToken() {
     addHeader("Authorization",
               "token @GITHUB_AUTHORIZATION_TOKEN@");

--- a/Framework/Kernel/src/GitHubApiHelper.cpp
+++ b/Framework/Kernel/src/GitHubApiHelper.cpp
@@ -115,17 +115,11 @@ std::string GitHubApiHelper::getRateLimitDescription() {
   return formatRateLimit(limit, remaining, expires);
 }
 
-int GitHubApiHelper::processAnonymousRequest(
-    const Poco::Net::HTTPResponse &response, Poco::URI &uri,
-    std::ostream &responseStream) {
-  if (!isAuthenticated()) {
-    g_log.debug("Repeating API call anonymously\n");
-    removeHeader("Authorization");
-    return this->sendRequest(uri.toString(), responseStream);
-  } else {
-    g_log.warning("Authentication failed and anonymous access refused\n");
-    return response.getStatus();
-  }
+int GitHubApiHelper::processAnonymousRequest(Poco::URI &uri,
+                                             std::ostream &responseStream) {
+  g_log.debug("Repeating API call anonymously\n");
+  removeHeader("Authorization");
+  return this->sendRequest(uri.toString(), responseStream);
 }
 
 int GitHubApiHelper::sendRequestAndProcess(HTTPClientSession &session,
@@ -153,7 +147,7 @@ int GitHubApiHelper::sendRequestAndProcess(HTTPClientSession &session,
              (retStatus == HTTP_NOT_FOUND)) {
     // If authentication fails you can get HTTP_UNAUTHORIZED or HTTP_NOT_FOUND
     // If the limit runs out you can get HTTP_FORBIDDEN
-    return this->processAnonymousRequest(*m_response, uri, responseStream);
+    return this->processAnonymousRequest(uri, responseStream);
   } else if (isRelocated(retStatus)) {
     return this->processRelocation(*m_response, responseStream);
   } else {

--- a/docs/source/release/v6.0.0/framework.rst
+++ b/docs/source/release/v6.0.0/framework.rst
@@ -48,6 +48,7 @@ Python
 Improvements
 ############
 - Member function: MDGeometry::getNumNonIntegratedDims() returns the number of non-integrated dimensions present.
+- When Mantid interacts with the GitHub API it tries an initial authenticated call and if that fails for any reason a fallback anonymous call is made. The anonymous call wasn't working properly and this has been fixed. This provides some extra reliability for processes such as the Instrument data download that is performed during startup of Workbench
 
 Bugfixes
 ########


### PR DESCRIPTION
**Description of work.**

This change is to improve the instrument update process when workbench starts up. If the authenticated call to the API to retrieve the instrument definitions fails this will ensure an anonymous call is made as a fallback. The anonymous call is subject to more stringent restrictions on number of calls that can be made to the API per hour but it's better than nothing.

The presence of the !isAuthenticated check inside processAnonymousRequest was stopping the anonymous call to the API being run

The check was originally without the ! and it was possibly there for one of of two reasons:
a) to avoid calling the API twice if the original call was anonymous - note this can't happen at the moment because a token is always supplied on the first attempt
b) to only erase the authorization entry from the m_headers map if it is present. Although erase would work OK even if not present

Either way there's no need to check isAuthenticated because it's checked in the calling code so I've just removed it

While doing this I noticed that debug\information level messages that are written during the start up of the Framework Manager don't get displayed in the workbench messages log. There is one of these in GitHubApiHelper.cpp. It seems like the log level of the message log is initially "notice" for a short time before the user specified log level kicks in. I think this is due to an ordering problem in start.py where the FrameworkManager instance is created earlier than expected. I will raise separate issue for this.

**To test:**

Set UpdateInstrumentDefinitions.OnStartup = 1 in Mantid.Properties
Start up workbench
Check the instrument definitions are updated OK and no errors are displayed in the log (they are not working right now using the authenticated call to the API because of a problem with the token)

Fixes #30340 .



---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
