### PR TITLE
Fix 'Apply to All' crash in plot config curves tab 

### DIFF
--- a/qt/python/mantidqt/widgets/plotconfigdialog/curvestabwidget/presenter.py
+++ b/qt/python/mantidqt/widgets/plotconfigdialog/curvestabwidget/presenter.py
@@ -353,14 +353,14 @@ class CurvesTabWidgetPresenter:
         """
         Applies the settings in the line tab for the current curve to all other curves.
         """
-        current_curve_index = self.view.select_curve_list.currentIndex()
+        current_curve_index = self.view.select_curve_list.currentRow()
 
         line_style = self.view.line.get_style()
         draw_style = self.view.line.get_draw_style()
         width = self.view.line.get_width()
 
         for i in range(len(self.curve_names_dict)):
-            self.view.select_curve_list.setCurrentIndex(i)
+            self.view.select_curve_list.setCurrentRow(i)
 
             self.view.line.set_style(line_style)
             self.view.line.set_draw_style(draw_style)
@@ -369,16 +369,16 @@ class CurvesTabWidgetPresenter:
             self.apply_properties()
 
         self.fig.canvas.draw()
-        self.view.select_curve_list.setCurrentIndex(current_curve_index)
+        self.view.select_curve_list.setCurrentRow(current_curve_index)
 
     def marker_apply_to_all(self):
-        current_curve_index = self.view.select_curve_list.currentIndex()
+        current_curve_index = self.view.select_curve_list.currentRow()
 
         marker_style = self.view.marker.get_style()
         marker_size = self.view.marker.get_size()
 
         for i in range(len(self.curve_names_dict)):
-            self.view.select_curve_list.setCurrentIndex(i)
+            self.view.select_curve_list.setCurrentRow(i)
 
             self.view.marker.set_style(marker_style)
             self.view.marker.set_size(marker_size)
@@ -386,10 +386,10 @@ class CurvesTabWidgetPresenter:
             self.apply_properties()
 
         self.fig.canvas.draw()
-        self.view.select_curve_list.setCurrentIndex(current_curve_index)
+        self.view.select_curve_list.setCurrentRow(current_curve_index)
 
     def errorbars_apply_to_all(self):
-        current_curve_index = self.view.select_curve_list.currentIndex()
+        current_curve_index = self.view.select_curve_list.currentRow()
 
         checked = self.view.errorbars.get_hide()
 
@@ -400,7 +400,7 @@ class CurvesTabWidgetPresenter:
             error_every = self.view.errorbars.get_error_every()
 
         for i in range(len(self.curve_names_dict)):
-            self.view.select_curve_list.setCurrentIndex(i)
+            self.view.select_curve_list.setCurrentRow(i)
 
             self.view.errorbars.set_hide(checked)
 
@@ -413,7 +413,7 @@ class CurvesTabWidgetPresenter:
             self.apply_properties()
 
         self.fig.canvas.draw()
-        self.view.select_curve_list.setCurrentIndex(current_curve_index)
+        self.view.select_curve_list.setCurrentRow(current_curve_index)
 
     def on_curves_selection_changed(self):
         if len(self.view.select_curve_list.selectedItems()) > 1:


### PR DESCRIPTION
This PR fixes a crash that occurred in the curves tab of the plot config dialog when the user clicked 'Apply to All' in any of the line, marker, or errorbar tabs. This was because the method of selecting curves changed from a QComboBox to a QListWidget, and the api is slightly different. This was not picked up by a test because the view, and all of the Qt api, is mocked out. 

**To test:**
1. Open a plot with many spectra
2. Open the plot config and navigate to the curves tab
3. In all of the _lines, markers_, and _errorbars_ tabs: Check that modifying settings and clicking _Apply to All_ does not cause a crash and correctly applies the settings to all curves.

Fixes #30329

*This does not require release notes* because it was introduced in the last development cycle.

<!-- Ensure the base of this PR is correct (e.g. release-next or master)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
