### PR TITLE
Fix error when saving plots with normalisation

### DIFF
--- a/Framework/PythonInterface/mantid/plots/axesfunctions.py
+++ b/Framework/PythonInterface/mantid/plots/axesfunctions.py
@@ -157,6 +157,10 @@ def _plot_impl(axes, workspace, args, kwargs):
         kwargs['drawstyle'] = 'steps-post'
     else:
         normalize_by_bin_width, kwargs = get_normalize_by_bin_width(workspace, axes, **kwargs)
+        # the get... function returns kwargs without 'normalize_by_bin_width', but it is needed in _get_data_for_plot to
+        # avoid reverting to the default norm setting, in the event that this function is being called as part of a plot
+        # restoration
+        kwargs['normalize_by_bin_width'] = normalize_by_bin_width
         x, y, _, _, indices, axis, kwargs = _get_data_for_plot(axes, workspace, kwargs)
         if kwargs.pop('update_axes_labels', True):
             _setLabels1D(axes,

--- a/Framework/PythonInterface/mantid/plots/mantidaxes.py
+++ b/Framework/PythonInterface/mantid/plots/mantidaxes.py
@@ -657,7 +657,7 @@ class MantidAxes(Axes):
 
             with autoscale_on_update(self, autoscale_on):
                 artist = self.track_workspace_artist(workspace,
-                                                     axesfunctions.plot(self, normalize_by_bin_width = is_normalized,
+                                                     axesfunctions.plot(self, normalize_by_bin_width=is_normalized,
                                                                         *args, **kwargs),
                                                      _data_update, spec_num, is_normalized,
                                                      MantidAxes.is_axis_of_type(MantidAxType.SPECTRUM, kwargs),

--- a/qt/python/mantidqt/plotting/functions.py
+++ b/qt/python/mantidqt/plotting/functions.py
@@ -289,7 +289,7 @@ def pcolormesh_on_axis(ax, ws, normalize_by_bin_width=None):
                         norm=scale(), normalize_by_bin_width=normalize_by_bin_width)
         # remove normalize_by_bin_width from cargs if present so that this can be toggled in future
         for cargs in pcm.axes.creation_args:
-            _ = cargs.pop('normalize_by_bin_width')
+            cargs.pop('normalize_by_bin_width')
     else:
         pcm = ax.pcolormesh(ws, cmap=ConfigService.getString("plots.images.Colormap"), norm=scale())
 

--- a/qt/python/mantidqt/plotting/functions.py
+++ b/qt/python/mantidqt/plotting/functions.py
@@ -209,12 +209,14 @@ def use_imshow(ws):
 
 
 @manage_workspace_names
-def pcolormesh(workspaces, fig=None):
+def pcolormesh(workspaces, fig=None, normalize_by_bin_width=None):
     """
     Create a figure containing pcolor subplots
 
     :param workspaces: A list of workspace handles
     :param fig: An optional figure to contain the new plots. Its current contents will be cleared
+    :param normalize_by_bin_width: Optional and only to be used in the event that the function is being called as part
+    of a plot restore
     :returns: The figure containing the plots
     """
     # check inputs
@@ -232,7 +234,7 @@ def pcolormesh(workspaces, fig=None):
         ax = axes[row_idx][col_idx]
         if subplot_idx < workspaces_len:
             ws = workspaces[subplot_idx]
-            pcm = pcolormesh_on_axis(ax, ws)
+            pcm = pcolormesh_on_axis(ax, ws, normalize_by_bin_width)
             plots.append(pcm)
             if col_idx < ncols - 1:
                 col_idx += 1
@@ -271,11 +273,12 @@ def pcolormesh(workspaces, fig=None):
     return fig
 
 
-def pcolormesh_on_axis(ax, ws):
+def pcolormesh_on_axis(ax, ws, normalize_by_bin_width=None):
     """
     Plot a pcolormesh plot of the given workspace on the given axis
     :param ax: A matplotlib axes instance
     :param ws: A mantid workspace instance
+    :param normalize_by_bin_width: Optional keyword argument to pass to imshow in the event of a plot restoration
     :return:
     """
     ax.clear()
@@ -283,7 +286,10 @@ def pcolormesh_on_axis(ax, ws):
     scale = _get_colorbar_scale()
     if use_imshow(ws):
         pcm = ax.imshow(ws, cmap=ConfigService.getString("plots.images.Colormap"), aspect='auto', origin='lower',
-                        norm=scale())
+                        norm=scale(), normalize_by_bin_width=normalize_by_bin_width)
+        # remove normalize_by_bin_width from cargs if present so that this can be toggled in future
+        for cargs in pcm.axes.creation_args:
+            _ = cargs.pop('normalize_by_bin_width')
     else:
         pcm = ax.pcolormesh(ws, cmap=ConfigService.getString("plots.images.Colormap"), norm=scale())
 

--- a/qt/python/mantidqt/project/plotsloader.py
+++ b/qt/python/mantidqt/project/plotsloader.py
@@ -74,7 +74,8 @@ class PlotsLoader(object):
                     self.workspace_plot_func(workspace, ax, ax.figure, cargs)
                 elif "function" in cargs:
                     self.plot_func(ax, cargs)
-
+            for cargs in creation_args_copy:
+                cargs.pop('normalize_by_bin_width', None)
             ax.creation_args = creation_args_copy
 
         # Update the fig
@@ -122,11 +123,7 @@ class PlotsLoader(object):
         func = function_dict[function_to_call]
         # Plotting is done via an Axes object unless a colorbar needs to be added
         if function_to_call in ["imshow", "pcolormesh"]:
-            if creation_arg['normalize_by_bin_width']:
-                is_norm = creation_arg.pop('normalize_by_bin_width')
-                func([workspace], fig, normalize_by_bin_width=is_norm)
-            else:
-                func([workspace], fig)
+            func([workspace], fig, normalize_by_bin_width=creation_arg['normalize_by_bin_width'])
             self.color_bar_remade = True
         else:
             func(workspace, **creation_arg)

--- a/qt/python/mantidqt/project/plotsloader.py
+++ b/qt/python/mantidqt/project/plotsloader.py
@@ -31,7 +31,6 @@ class PlotsLoader(object):
     def load_plots(self, plots_list):
         if plots_list is None:
             return
-
         for plot_ in plots_list:
             try:
                 self.make_fig(plot_)
@@ -64,7 +63,6 @@ class PlotsLoader(object):
             for cargs_dict in sublist:
                 if 'norm' in cargs_dict and type(cargs_dict['norm']) is dict:
                     cargs_dict['norm'] = self.restore_normalise_obj_from_dict(cargs_dict['norm'])
-
         fig, axes_matrix, _, _ = create_subplots(len(creation_args))
         axes_list = axes_matrix.flatten().tolist()
         for ax, cargs_list in zip(axes_list, creation_args):
@@ -124,7 +122,11 @@ class PlotsLoader(object):
         func = function_dict[function_to_call]
         # Plotting is done via an Axes object unless a colorbar needs to be added
         if function_to_call in ["imshow", "pcolormesh"]:
-            func([workspace], fig)
+            if creation_arg['normalize_by_bin_width']:
+                is_norm = creation_arg.pop('normalize_by_bin_width')
+                func([workspace], fig, normalize_by_bin_width=is_norm)
+            else:
+                func([workspace], fig)
             self.color_bar_remade = True
         else:
             func(workspace, **creation_arg)

--- a/qt/python/mantidqt/project/plotsloader.py
+++ b/qt/python/mantidqt/project/plotsloader.py
@@ -41,6 +41,10 @@ class PlotsLoader(object):
                     raise KeyboardInterrupt(str(e))
                 logger.warning("A plot was unable to be loaded from the save file. Error: " + str(e))
 
+    def restore_normalise_obj_from_dict(self, norm_dict):
+        norm = matplotlib.colors.Normalize(norm_dict['vmin'], norm_dict['vmax'], norm_dict['clip'])
+        return norm
+
     def make_fig(self, plot_dict, create_plot=True):
         """
         This method currently only considers single matplotlib.axes.Axes based figures as that is the most common case
@@ -55,6 +59,11 @@ class PlotsLoader(object):
                 "A plot could not be loaded from the save file, as it did not have creation_args. "
                 "The original plot title was: {}".format(plot_dict["label"]))
             return
+
+        for sublist in creation_args:
+            for cargs_dict in sublist:
+                if 'norm' in cargs_dict and type(cargs_dict['norm']) is dict:
+                    cargs_dict['norm'] = self.restore_normalise_obj_from_dict(cargs_dict['norm'])
 
         fig, axes_matrix, _, _ = create_subplots(len(creation_args))
         axes_list = axes_matrix.flatten().tolist()

--- a/qt/python/mantidqt/project/plotssaver.py
+++ b/qt/python/mantidqt/project/plotssaver.py
@@ -14,13 +14,7 @@ from matplotlib.image import AxesImage
 from mantid import logger
 from mantid.plots.legend import LegendProperties
 
-try:
-    from matplotlib.colors import to_hex, Normalize
-except ImportError:
-    from matplotlib.colors import colorConverter, rgb2hex, Normalize
-
-    def to_hex(color):
-        return rgb2hex(colorConverter.to_rgb(color))
+from matplotlib.colors import to_hex, Normalize
 
 
 class PlotsSaver(object):

--- a/qt/python/mantidqt/project/plotssaver.py
+++ b/qt/python/mantidqt/project/plotssaver.py
@@ -78,7 +78,8 @@ class PlotsSaver(object):
                 continue
             axes_list.append(self.get_dict_for_axes(ax))
 
-        self._add_normalisation_kwargs(create_list, axes_list)
+        if create_list and axes_list:
+            self._add_normalisation_kwargs(create_list, axes_list)
         fig_dict = {"creationArguments": create_list,
                     "axes": axes_list,
                     "label": fig._label,

--- a/qt/python/mantidqt/project/test/test_plotssaver.py
+++ b/qt/python/mantidqt/project/test/test_plotssaver.py
@@ -135,7 +135,8 @@ class PlotsSaverTest(unittest.TestCase):
         self.fig.axes[0].creation_args = [{u"specNum": 2, "function": "plot"}]
         return_value = self.plot_saver.get_dict_from_fig(self.fig)
 
-        self.loader_plot_dict[u'creationArguments'] = [[{u"specNum": 2, "function": "plot"}]]
+        self.loader_plot_dict[u'creationArguments'] = [[{u"specNum": 2, "function": "plot", u"normalize_by_bin_width":
+                                                                                            True}]]
 
         self.maxDiff = None
         self.assertDictEqual(return_value, self.loader_plot_dict)
@@ -144,6 +145,7 @@ class PlotsSaverTest(unittest.TestCase):
         self.plot_saver.figure_creation_args = [{"function": "plot"}]
         return_value = self.plot_saver.get_dict_for_axes(self.fig.axes[0])
 
+        self.loader_plot_dict["axes"][0]['_is_norm'] = True
         expected_value = self.loader_plot_dict["axes"][0]
 
         self.maxDiff = None


### PR DESCRIPTION
**Description of work.**

In the dict that is encoded for plots, normalise settings were saved in place as Normalise objects which cannot be serialised. This adds a conversion to dict and a Normalise construction from the dict to the encoder and decoder respectively.

**To test:**
1. Load a workspace, plot a colourfill and a single spectra plot
2. Set one or the other to Normalisation -> Bin width and leave the other off
3. Wait for project save to kick in or save the project manually, make sure no errors occur for saving the plots
4. Segfault and restore, or restart mantid and load project
5. Check that the plots have survived as they were with the correct normalisation options

Fixes #30315  <!-- and fix #xxxx or close #xxxx xor resolves #xxxx -->
<!-- alternative
*There is no associated issue.*
-->

*This does not require release notes* because **it fixes a small bug discovered in manual testing**


<!-- Ensure the base of this PR is correct (e.g. release-next or master)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
