### PR TITLE
Fix flood workspace selection bug on reflectometry GUI

### DIFF
--- a/docs/source/release/v6.0.0/reflectometry.rst
+++ b/docs/source/release/v6.0.0/reflectometry.rst
@@ -15,9 +15,10 @@ ISIS Reflectometry Interface
 - You can now exclude or annotate runs in the search results list, e.g. to
   exclude them from autoprocessing. See the
   :ref:`ISIS Reflectometry Interface <interface-isis-refl>` documentation for details.
+- Fixed a bug where the flood workspace drop-down box was being accidentally populated with the first workspace created after clearing the workspaces list.
 
-Bugfixes
-########
+Algorithms
+##########
 
 - Fixed an issue where `import CaChannel` on Linux would cause a hard crash.
 - Fixed spurious error messages about transmission workspaces when running :ref:`algm-ReflectometryReductionOneAuto` on workspace groups

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Batch/BatchPresenter.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Batch/BatchPresenter.cpp
@@ -380,6 +380,7 @@ void BatchPresenter::renameHandle(const std::string &oldName,
 }
 
 void BatchPresenter::clearADSHandle() {
+  m_experimentPresenter->notifyAllWorkspacesDeleted();
   m_jobRunner->notifyAllWorkspacesDeleted();
   m_runsPresenter->notifyRowOutputsChanged();
   m_runsPresenter->notifyRowStateChanged();

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Experiment/ExperimentPresenter.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Experiment/ExperimentPresenter.cpp
@@ -379,6 +379,10 @@ void ExperimentPresenter::updateViewFromModel() {
   // Reconnect settings change notifications
   m_view->connectExperimentSettingsWidgets();
 }
+
+void ExperimentPresenter::notifyAllWorkspacesDeleted() {
+  m_view->refreshFloodWorkspaceList();
+}
 } // namespace ISISReflectometry
 } // namespace CustomInterfaces
 } // namespace MantidQt

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Experiment/ExperimentPresenter.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Experiment/ExperimentPresenter.h
@@ -67,6 +67,7 @@ public:
   void notifyAutoreductionPaused() override;
   void notifyAutoreductionResumed() override;
   void notifyInstrumentChanged(std::string const &instrumentName) override;
+  void notifyAllWorkspacesDeleted() override;
   void restoreDefaults() override;
 
 protected:

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Experiment/IExperimentPresenter.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Experiment/IExperimentPresenter.h
@@ -27,6 +27,7 @@ public:
   virtual void notifyAutoreductionPaused() = 0;
   virtual void notifyAutoreductionResumed() = 0;
   virtual void notifyInstrumentChanged(std::string const &instrumentName) = 0;
+  virtual void notifyAllWorkspacesDeleted() = 0;
   virtual void restoreDefaults() = 0;
 };
 } // namespace ISISReflectometry

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Experiment/IExperimentView.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Experiment/IExperimentView.h
@@ -113,6 +113,7 @@ public:
   virtual void setFloodCorrectionType(std::string const &correction) = 0;
   virtual std::string getFloodWorkspace() const = 0;
   virtual void setFloodWorkspace(std::string const &workspace) = 0;
+  virtual void refreshFloodWorkspaceList() = 0;
 
   virtual std::string getStitchOptions() const = 0;
   virtual void setStitchOptions(std::string const &stitchOptions) = 0;

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Experiment/QtExperimentView.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Experiment/QtExperimentView.cpp
@@ -681,6 +681,10 @@ void QtExperimentView::setFloodWorkspace(std::string const &workspace) {
   setSelected(*m_ui.floodWorkspaceWsSelector, workspace);
 }
 
+void QtExperimentView::refreshFloodWorkspaceList() {
+  m_ui.floodWorkspaceWsSelector->refresh();
+}
+
 std::string QtExperimentView::getAnalysisMode() const {
   return getText(*m_ui.analysisModeComboBox);
 }

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Experiment/QtExperimentView.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Experiment/QtExperimentView.h
@@ -82,6 +82,7 @@ public:
   void setFloodCorrectionType(std::string const &correction) override;
   std::string getFloodWorkspace() const override;
   void setFloodWorkspace(std::string const &workspace) override;
+  void refreshFloodWorkspaceList() override;
 
   std::string getStitchOptions() const override;
   void setStitchOptions(std::string const &stitchOptions) override;

--- a/qt/scientific_interfaces/test/ISISReflectometry/Batch/BatchPresenterTest.h
+++ b/qt/scientific_interfaces/test/ISISReflectometry/Batch/BatchPresenterTest.h
@@ -518,6 +518,13 @@ public:
     verifyAndClear();
   }
 
+  void testExperimentNotifiedOnClearADS() {
+    auto presenter = makePresenter();
+    EXPECT_CALL(*m_experimentPresenter, notifyAllWorkspacesDeleted());
+    presenter->clearADSHandle();
+    verifyAndClear();
+  }
+
 private:
   NiceMock<MockBatchView> m_view;
   NiceMock<MockBatchJobRunner> *m_jobRunner;

--- a/qt/scientific_interfaces/test/ISISReflectometry/Experiment/ExperimentPresenterTest.h
+++ b/qt/scientific_interfaces/test/ISISReflectometry/Experiment/ExperimentPresenterTest.h
@@ -734,6 +734,13 @@ public:
     runTestThatPolarizationCorrectionsAreEnabledForInstrument("CRISP");
   }
 
+  void testRefreshFloodWorkspaceListWhenAllWorkspacesDeleted() {
+    auto presenter = makePresenter();
+    EXPECT_CALL(m_view, refreshFloodWorkspaceList());
+    presenter.notifyAllWorkspacesDeleted();
+    verifyAndClear();
+  }
+
 private:
   NiceMock<MockExperimentView> m_view;
   NiceMock<MockBatchPresenter> m_mainPresenter;

--- a/qt/scientific_interfaces/test/ISISReflectometry/Experiment/MockExperimentView.h
+++ b/qt/scientific_interfaces/test/ISISReflectometry/Experiment/MockExperimentView.h
@@ -96,6 +96,7 @@ public:
   MOCK_METHOD1(setFloodCorrectionType, void(std::string const &));
   MOCK_CONST_METHOD0(getFloodWorkspace, std::string());
   MOCK_METHOD1(setFloodWorkspace, void(std::string const &));
+  MOCK_METHOD0(refreshFloodWorkspaceList, void());
   MOCK_CONST_METHOD0(getStitchOptions, std::string());
   MOCK_METHOD1(setStitchOptions, void(std::string const &));
   MOCK_METHOD2(showOptionLoadErrors,

--- a/qt/scientific_interfaces/test/ISISReflectometry/ReflMockObjects.h
+++ b/qt/scientific_interfaces/test/ISISReflectometry/ReflMockObjects.h
@@ -159,6 +159,7 @@ public:
   MOCK_METHOD0(notifyAutoreductionPaused, void());
   MOCK_METHOD0(notifyAutoreductionResumed, void());
   MOCK_METHOD1(notifyInstrumentChanged, void(std::string const &));
+  MOCK_METHOD0(notifyAllWorkspacesDeleted, void());
   MOCK_METHOD0(restoreDefaults, void());
 };
 


### PR DESCRIPTION
This PR fixes a bug where the reflectometry GUI picks up an incorrect workspace for the flood workspace. It is a temporary "safe" workaround in the reflectometry GUI for release 6.0.0. This workaround will be removed and replaced by a fix in the WorkspaceSelector in the next release (PR #30354 has already been created for this).

The problem is that the WorkspaceSelector's blank row (which is required to make the selection optional) is removed when the ADS is cleared. In the reflectometry GUI, the workspace selection for the flood workspace then essentially becomes mandatory, and when a workspace is next created it gets populated as the flood workspace, causing the reduction to fail. This workaround uses our own notification when the ADS is cleared to call `refresh` on the flood workspace's WorkspaceSelector, which re-adds the blank row.

Refs #30317

**To test:**

- Open the ISIS Reflectometry GUI and select the Experiment tab. Note that the flood workspace selection box is empty.
- In workbench, `ws=Load('INTER13460')`. The flood workspace remains empty.
- Click Clear to clear the workspaces list.
- Re-run `ws=Load('INTER13460')`. The flood workspace should still remain empty. Previously, it was getting set to `ws`.

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
