### PR TITLE
Fix WorkspaceSelector so it does not remove optional blank row

### DIFF
--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Batch/BatchPresenter.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Batch/BatchPresenter.cpp
@@ -380,7 +380,6 @@ void BatchPresenter::renameHandle(const std::string &oldName,
 }
 
 void BatchPresenter::clearADSHandle() {
-  m_experimentPresenter->notifyAllWorkspacesDeleted();
   m_jobRunner->notifyAllWorkspacesDeleted();
   m_runsPresenter->notifyRowOutputsChanged();
   m_runsPresenter->notifyRowStateChanged();

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Experiment/ExperimentPresenter.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Experiment/ExperimentPresenter.cpp
@@ -379,10 +379,6 @@ void ExperimentPresenter::updateViewFromModel() {
   // Reconnect settings change notifications
   m_view->connectExperimentSettingsWidgets();
 }
-
-void ExperimentPresenter::notifyAllWorkspacesDeleted() {
-  m_view->refreshFloodWorkspaceList();
-}
 } // namespace ISISReflectometry
 } // namespace CustomInterfaces
 } // namespace MantidQt

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Experiment/ExperimentPresenter.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Experiment/ExperimentPresenter.h
@@ -67,7 +67,6 @@ public:
   void notifyAutoreductionPaused() override;
   void notifyAutoreductionResumed() override;
   void notifyInstrumentChanged(std::string const &instrumentName) override;
-  void notifyAllWorkspacesDeleted() override;
   void restoreDefaults() override;
 
 protected:

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Experiment/IExperimentPresenter.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Experiment/IExperimentPresenter.h
@@ -27,7 +27,6 @@ public:
   virtual void notifyAutoreductionPaused() = 0;
   virtual void notifyAutoreductionResumed() = 0;
   virtual void notifyInstrumentChanged(std::string const &instrumentName) = 0;
-  virtual void notifyAllWorkspacesDeleted() = 0;
   virtual void restoreDefaults() = 0;
 };
 } // namespace ISISReflectometry

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Experiment/IExperimentView.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Experiment/IExperimentView.h
@@ -113,7 +113,6 @@ public:
   virtual void setFloodCorrectionType(std::string const &correction) = 0;
   virtual std::string getFloodWorkspace() const = 0;
   virtual void setFloodWorkspace(std::string const &workspace) = 0;
-  virtual void refreshFloodWorkspaceList() = 0;
 
   virtual std::string getStitchOptions() const = 0;
   virtual void setStitchOptions(std::string const &stitchOptions) = 0;

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Experiment/QtExperimentView.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Experiment/QtExperimentView.cpp
@@ -681,10 +681,6 @@ void QtExperimentView::setFloodWorkspace(std::string const &workspace) {
   setSelected(*m_ui.floodWorkspaceWsSelector, workspace);
 }
 
-void QtExperimentView::refreshFloodWorkspaceList() {
-  m_ui.floodWorkspaceWsSelector->refresh();
-}
-
 std::string QtExperimentView::getAnalysisMode() const {
   return getText(*m_ui.analysisModeComboBox);
 }

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Experiment/QtExperimentView.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Experiment/QtExperimentView.h
@@ -82,7 +82,6 @@ public:
   void setFloodCorrectionType(std::string const &correction) override;
   std::string getFloodWorkspace() const override;
   void setFloodWorkspace(std::string const &workspace) override;
-  void refreshFloodWorkspaceList() override;
 
   std::string getStitchOptions() const override;
   void setStitchOptions(std::string const &stitchOptions) override;

--- a/qt/scientific_interfaces/test/ISISReflectometry/Batch/BatchPresenterTest.h
+++ b/qt/scientific_interfaces/test/ISISReflectometry/Batch/BatchPresenterTest.h
@@ -518,13 +518,6 @@ public:
     verifyAndClear();
   }
 
-  void testExperimentNotifiedOnClearADS() {
-    auto presenter = makePresenter();
-    EXPECT_CALL(*m_experimentPresenter, notifyAllWorkspacesDeleted());
-    presenter->clearADSHandle();
-    verifyAndClear();
-  }
-
 private:
   NiceMock<MockBatchView> m_view;
   NiceMock<MockBatchJobRunner> *m_jobRunner;

--- a/qt/scientific_interfaces/test/ISISReflectometry/Experiment/ExperimentPresenterTest.h
+++ b/qt/scientific_interfaces/test/ISISReflectometry/Experiment/ExperimentPresenterTest.h
@@ -734,13 +734,6 @@ public:
     runTestThatPolarizationCorrectionsAreEnabledForInstrument("CRISP");
   }
 
-  void testRefreshFloodWorkspaceListWhenAllWorkspacesDeleted() {
-    auto presenter = makePresenter();
-    EXPECT_CALL(m_view, refreshFloodWorkspaceList());
-    presenter.notifyAllWorkspacesDeleted();
-    verifyAndClear();
-  }
-
 private:
   NiceMock<MockExperimentView> m_view;
   NiceMock<MockBatchPresenter> m_mainPresenter;

--- a/qt/scientific_interfaces/test/ISISReflectometry/Experiment/MockExperimentView.h
+++ b/qt/scientific_interfaces/test/ISISReflectometry/Experiment/MockExperimentView.h
@@ -96,7 +96,6 @@ public:
   MOCK_METHOD1(setFloodCorrectionType, void(std::string const &));
   MOCK_CONST_METHOD0(getFloodWorkspace, std::string());
   MOCK_METHOD1(setFloodWorkspace, void(std::string const &));
-  MOCK_METHOD0(refreshFloodWorkspaceList, void());
   MOCK_CONST_METHOD0(getStitchOptions, std::string());
   MOCK_METHOD1(setStitchOptions, void(std::string const &));
   MOCK_METHOD2(showOptionLoadErrors,

--- a/qt/scientific_interfaces/test/ISISReflectometry/ReflMockObjects.h
+++ b/qt/scientific_interfaces/test/ISISReflectometry/ReflMockObjects.h
@@ -159,7 +159,6 @@ public:
   MOCK_METHOD0(notifyAutoreductionPaused, void());
   MOCK_METHOD0(notifyAutoreductionResumed, void());
   MOCK_METHOD1(notifyInstrumentChanged, void(std::string const &));
-  MOCK_METHOD0(notifyAllWorkspacesDeleted, void());
   MOCK_METHOD0(restoreDefaults, void());
 };
 

--- a/qt/widgets/common/src/WorkspaceSelector.cpp
+++ b/qt/widgets/common/src/WorkspaceSelector.cpp
@@ -201,6 +201,8 @@ void WorkspaceSelector::handleRemEvent(
 void WorkspaceSelector::handleClearEvent(
     Mantid::API::ClearADSNotification_ptr /*unused*/) {
   this->clear();
+  if (m_optional)
+    addItem("");
   emit emptied();
 }
 


### PR DESCRIPTION
This PR fixes a bug where the blank row in the workspace selector (which is required to make the selection of a workspace optional) is removed when the ADS is cleared.

This PR also removes the workaround from PR #30353 for a problem on the reflectometry GUI that was caused by this. 

Fixes #30317

**To test:**

Run the test in #30353

*This does not require release notes* because **the symptoms were already fixed and documented by the workaround**

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
