### PR TITLE
Allow suffixes in macOS workbench executable name in system test

### DIFF
--- a/Testing/SystemTests/tests/qt/WorkbenchStartupTest.py
+++ b/Testing/SystemTests/tests/qt/WorkbenchStartupTest.py
@@ -16,7 +16,7 @@ from tempfile import NamedTemporaryFile
 TEST_MESSAGE = "Hello Mantid!"
 
 EXECUTABLE_SWITCHER = {"linux": ["launch_mantidworkbench.sh", "mantidworkbench"],
-                       "darwin": ["MantidWorkbench"],
+                       "darwin": ["MantidWorkbench", "MantidWorkbenchNightly", "MantidWorkbenchUnstable"],
                        "win32": ["MantidWorkbench.exe"]}
 
 


### PR DESCRIPTION
**Description of work.**

The macOS executable is suffixed with the package suffix so that it can be distinguished alongside an official version if running side-by-side. Updates the system test installer script to take account of this.

**To test:**

* Download the latest nightly build and place it in the root build directory
* Run `python3 <source_root>/Testing/SystemTests/scripts/InstallerTests.py -o -d . -R WorkbenchStartup` from that directory
* The workbench startup test should pass.

*There is no associated issue.*

*This does not require release notes* because **we the suffixes were only added in this release cycle.**

<!-- Ensure the base of this PR is correct (e.g. release-next or master)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
