### PR TITLE
30155 fix error every updating plot settings

### DIFF
--- a/docs/source/release/v6.0.0/mantidworkbench.rst
+++ b/docs/source/release/v6.0.0/mantidworkbench.rst
@@ -68,5 +68,6 @@ Bugfixes
 - Fixed bug supplying rebin arguments for non-orthogonal data in sliceviewer that meant that not all the availible data within the axes limits were being plotted.
 - Fixed a crash in SliceViewer when hovering the cursor over Direct or Indirect data.
 - Fixed a crash when using broken e notation for axis limits in plot settings
+- Fixed a bug in error bars tab in plot settings where the Error Every property was not being shown correctly
 
 :ref:`Release 6.0.0 <v6.0.0>`

--- a/qt/applications/workbench/workbench/plotting/test/test_figureinteraction.py
+++ b/qt/applications/workbench/workbench/plotting/test/test_figureinteraction.py
@@ -231,6 +231,7 @@ class FigureInteractionTest(unittest.TestCase):
 
     def test_add_error_bars_menu(self):
         self.ax.errorbar([0, 15000], [0, 14000], yerr=[10, 10000], label='MyLabel 2')
+        self.ax.containers[0][2][0].axes.creation_args = [{'errorevery': 1}]
         main_menu = QMenu()
         self.interactor.add_error_bars_menu(main_menu, self.ax)
 
@@ -278,6 +279,7 @@ class FigureInteractionTest(unittest.TestCase):
     def test_context_menu_added_for_scripted_plot_with_errors(self):
         self.ax.plot([0, 15000], [0, 15000], label='MyLabel')
         self.ax.errorbar([0, 15000], [0, 14000], yerr=[10, 10000], label='MyLabel 2')
+        self.ax.containers[0][2][0].axes.creation_args = [{'errorevery': 1}]
 
         main_menu = QMenu()
         # QMenu always seems to have 1 child when empty,
@@ -328,6 +330,7 @@ class FigureInteractionTest(unittest.TestCase):
     def test_scripted_plot_show_and_hide_all(self):
         self.ax.plot([0, 15000], [0, 15000], label='MyLabel')
         self.ax.errorbar([0, 15000], [0, 14000], yerr=[10, 10000], label='MyLabel 2')
+        self.ax.containers[0][2][0].axes.creation_args = [{'errorevery': 1}]
 
         anonymous_menu = QMenu()
         # this initialises some of the class internals

--- a/qt/python/mantidqt/widgets/plotconfigdialog/curvestabwidget/__init__.py
+++ b/qt/python/mantidqt/widgets/plotconfigdialog/curvestabwidget/__init__.py
@@ -205,7 +205,7 @@ class CurveProperties(dict):
         # So to get this property take from errorbar lines curve
         try:
             barlines = curve[2][0]
-            props['errorevery'] = int(barlines.axes.creation_args[barlines.axes.creation_args.__len__()-1]['errorevery'])
+            props['errorevery'] = int(barlines.axes.creation_args[len(barlines.axes.creation_args)-1]['errorevery'])
         except (IndexError, TypeError, KeyError):
             props['errorevery'] = 1
         try:

--- a/qt/python/mantidqt/widgets/plotconfigdialog/curvestabwidget/__init__.py
+++ b/qt/python/mantidqt/widgets/plotconfigdialog/curvestabwidget/__init__.py
@@ -205,7 +205,7 @@ class CurveProperties(dict):
         # So to get this property take from errorbar lines curve
         try:
             barlines = curve[2][0]
-            props['errorevery'] = int(barlines.axes.creation_args[0]['errorevery'])
+            props['errorevery'] = int(barlines.axes.creation_args[barlines.axes.creation_args.__len__()-1]['errorevery'])
         except (IndexError, TypeError, KeyError):
             props['errorevery'] = 1
         try:

--- a/qt/python/mantidqt/widgets/plotconfigdialog/curvestabwidget/__init__.py
+++ b/qt/python/mantidqt/widgets/plotconfigdialog/curvestabwidget/__init__.py
@@ -206,7 +206,7 @@ class CurveProperties(dict):
         try:
             barlines = curve[2][0]
             props['errorevery'] = int(barlines.axes.creation_args[0]['errorevery'])
-        except (IndexError, TypeError):
+        except (IndexError, TypeError, KeyError):
             props['errorevery'] = 1
         try:
             caps = curve[1]

--- a/qt/python/mantidqt/widgets/plotconfigdialog/curvestabwidget/__init__.py
+++ b/qt/python/mantidqt/widgets/plotconfigdialog/curvestabwidget/__init__.py
@@ -201,7 +201,13 @@ class CurveProperties(dict):
         """Get a curve's errorbar properties and add to props dict"""
         props['hide_errors'] = getattr(curve, 'hide_errors',
                                        errorbars_hidden(curve))
-        props['errorevery'] = getattr(curve, 'errorevery', 1)
+        # ErrorbarContainer does not have 'errorevery' as an attribute directly
+        # So to get this property take from errorbar lines curve
+        try:
+            barlines = curve[2][0]
+            props['errorevery'] = int(barlines.axes.creation_args[0]['errorevery'])
+        except (IndexError, TypeError):
+            props['errorevery'] = 1
         try:
             caps = curve[1]
             props['capsize'] = float(caps[0].get_markersize() / 2)

--- a/qt/python/mantidqt/widgets/plotconfigdialog/curvestabwidget/test/test_curveproperties.py
+++ b/qt/python/mantidqt/widgets/plotconfigdialog/curvestabwidget/test/test_curveproperties.py
@@ -39,6 +39,7 @@ class CurvePropertiesTest(unittest.TestCase):
         ax1 = fig0.add_subplot(212)
         ax1.errorbar([0, 2, 4], [0, 2, 4], xerr=[0, 0.1, 0.2],
                      yerr=[0, 0.1, 0.2], fmt='none', label='ax1')
+        ax1.containers[0][2][0].axes.creation_args = [{'errorevery': 1}]
         cls.props = CurveProperties.from_curve(ax0.get_lines()[0])
         cls.error_props = CurveProperties.from_curve(ax1.containers[0])
 

--- a/qt/python/mantidqt/widgets/plotconfigdialog/curvestabwidget/test/test_curvestabwidgetpresenter.py
+++ b/qt/python/mantidqt/widgets/plotconfigdialog/curvestabwidget/test/test_curvestabwidgetpresenter.py
@@ -37,6 +37,7 @@ class CurvesTabWidgetPresenterTest(unittest.TestCase):
         cls.curve0 = cls.ax0.errorbar(cls.ws, specNum=1, fmt=':g', marker=1,
                                       label='Workspace')
         cls.ax0.plot([0, 1], [2, 3], '--r', marker='v', lw=1.1, label='noerrors')
+        cls.ax0.creation_args = [{'errorevery': 1}]
 
         ax1 = cls.fig.add_subplot(222)
         ax1.set_title("Image")
@@ -242,6 +243,7 @@ class CurvesTabWidgetPresenterTest(unittest.TestCase):
         ax = fig.add_subplot(111)
         ax.errorbar([0, 1, 2, 4], [0, 1, 2, 4], yerr=[0.1, 0.2, 0.3, 0.4],
                     label='errorbar_plot')
+        ax.containers[0][2][0].axes.creation_args = [{'errorevery': 1}]
         mock_view_props = Mock(get_plot_kwargs=lambda: {'visible': False},
                                hide_errors=False, hide=True,
                                __getitem__=lambda s, x: False)

--- a/qt/python/mantidqt/widgets/plotconfigdialog/test/test_apply_all_properties.py
+++ b/qt/python/mantidqt/widgets/plotconfigdialog/test/test_apply_all_properties.py
@@ -118,6 +118,7 @@ def _run_apply_properties_on_figure_with_curve(curve_view_mock):
     fig = figure()
     ax = fig.add_subplot(111)
     ax.errorbar([0, 1], [0, 1], yerr=[0.1, 0.2], label='old label')
+    ax.containers[0][2][0].axes.creation_args = [{'errorevery': 2}]
     curve_view_mock.get_current_curve_name = CurveNameSideEffect('old label', 'New label', switch_count=6)
 
     with patch.object(AxesTabWidgetPresenter, 'update_view', mock_axes_tab_presenter_update_view):


### PR DESCRIPTION
**Description of work.**
Changed how the errorevery property is obtained when getting this property from curve

**To test:**
Load some data and make a plot

1. Open the plot settings and go to the curves tab > error bars
2. Uncheck hide and change the error every property
3. Zoom in on the plot to check this has been applied
4. The value you changed it to should also remain in the GUI (previously reset to 1 every time)
5. Close the settings
6. Reopen them and check value is still correct

Fixes #30155 

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
