### PR TITLE
Disable Unstable Test FitScriptGeneratorViewTest

### DIFF
--- a/qt/widgets/common/CMakeLists.txt
+++ b/qt/widgets/common/CMakeLists.txt
@@ -1062,7 +1062,7 @@ set(
   test/FitPropertyBrowserTest.h
   test/FitScriptGeneratorDataTableTest.h
   test/FitScriptGeneratorPresenterTest.h
-  test/FitScriptGeneratorViewTest.h
+  # test/FitScriptGeneratorViewTest.h
   test/ImageInfoModelMatrixWSTest.h
   test/ImageInfoModelMDTest.h
   test/ImageInfoPresenterTest.h


### PR DESCRIPTION
**Description of work.**
This PR disables the `FitScriptGeneratorViewTest` unstable test while we figure out what is going wrong. The FitScriptGenerator is currently inaccessible, so it is ok to disable this test.

Here is the unstable test:
https://builds.mantidproject.org/job/master_clean-windows/1454/testReport/junit/projectroot.qt.widgets/common/MantidQtWidgetsCommonTestQt5_FitScriptGeneratorViewTest/

The issue to fix this and enable the test is: #30362

**To test:**
Make sure `FitScriptGeneratorViewTest` is no longer running.

*There is no associated issue.*

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
