### PR TITLE
sliceviewer handle inf axes limits

### DIFF
--- a/Framework/PythonInterface/mantid/plots/resampling_image/samplingimage.py
+++ b/Framework/PythonInterface/mantid/plots/resampling_image/samplingimage.py
@@ -195,16 +195,19 @@ def imshow_sampling(axes,
             # for MatrixWorkspace the x extent obtained from dimension 0 corresponds to the first spectrum
             # this is not correct in case of ragged workspaces, where we need to obtain the global xmin and xmax
             # moreover the axis might be in ascending or descending order, so x[0] is not necessarily the minimum
+            si = workspace.spectrumInfo()
             for i in range(workspace.getNumberHistograms()):
-                x_axis = workspace.readX(i)
-                x_i_first = x_axis[0]
-                x_i_last = x_axis[-1]
-                x_i_min = min(x_i_first, x_i_last)
-                x_i_max = max(x_i_first, x_i_last)
-                if x_i_min < x0:
-                    x0 = x_i_min
-                if x_i_max > x1:
-                    x1 = x_i_max 
+                if si.hasDetectors(i) and not si.isMonitor(i):
+                    x_axis = workspace.readX(i)
+                    x_i_first = x_axis[0]
+                    x_i_last = x_axis[-1]
+                    x_i_min = min([x_i_first, x_i_last])
+                    x_i_max = max([x_i_first, x_i_last])
+                    # effectively ignore spectra with nan or inf values
+                    if np.isfinite(x_i_min) and x_i_min < x0:
+                        x0 = x_i_min
+                    if np.isfinite(x_i_max) and x_i_max > x1:
+                        x1 = x_i_max
 
         if workspace.getDimension(1).getNBins() == workspace.getAxis(1).length():
             width = workspace.getDimension(1).getBinWidth()

--- a/Framework/PythonInterface/mantid/plots/resampling_image/samplingimage.py
+++ b/Framework/PythonInterface/mantid/plots/resampling_image/samplingimage.py
@@ -195,6 +195,7 @@ def imshow_sampling(axes,
             # for MatrixWorkspace the x extent obtained from dimension 0 corresponds to the first spectrum
             # this is not correct in case of ragged workspaces, where we need to obtain the global xmin and xmax
             # moreover the axis might be in ascending or descending order, so x[0] is not necessarily the minimum
+            xmax, xmin = None, None  # don't initialise with values from first spectrum as could be a monitor
             si = workspace.spectrumInfo()
             for i in range(workspace.getNumberHistograms()):
                 if si.hasDetectors(i) and not si.isMonitor(i):
@@ -204,10 +205,12 @@ def imshow_sampling(axes,
                     x_i_min = min([x_i_first, x_i_last])
                     x_i_max = max([x_i_first, x_i_last])
                     # effectively ignore spectra with nan or inf values
-                    if np.isfinite(x_i_min) and x_i_min < x0:
-                        x0 = x_i_min
-                    if np.isfinite(x_i_max) and x_i_max > x1:
-                        x1 = x_i_max
+                    if np.isfinite(x_i_min):
+                        xmin = min([x_i_min, xmin]) if xmin else x_i_min
+                    if np.isfinite(x_i_max):
+                        xmax = max([x_i_max, xmax]) if xmax else x_i_max
+            x0 = xmin if xmin else x0
+            x1 = xmax if xmax else x1
 
         if workspace.getDimension(1).getNBins() == workspace.getAxis(1).length():
             width = workspace.getDimension(1).getBinWidth()

--- a/docs/source/release/v6.0.0/mantidworkbench.rst
+++ b/docs/source/release/v6.0.0/mantidworkbench.rst
@@ -46,6 +46,7 @@ Improvements
 Bugfixes
 ########
 
+- Fix bug in determining axes limits in sliceviewer - it now ignores monitor spectra and spectra with nan or inf.
 - Only display slice viewer widget for MDEventWorkspaces with 2 or more dimensions.
 - Fix Workbench crashes upon deleting rows or columns in a TableWorkspace.
 - Fix crash on second call to ManageUserDirectories after pressing Esc to close it.

--- a/qt/python/mantidqt/widgets/sliceviewer/test/test_sliceviewer_view.py
+++ b/qt/python/mantidqt/widgets/sliceviewer/test/test_sliceviewer_view.py
@@ -8,6 +8,8 @@
 import io
 import sys
 import unittest
+from unittest.mock import patch
+from numpy import hstack
 
 import matplotlib as mpl
 
@@ -236,6 +238,30 @@ class SliceViewerViewTest(unittest.TestCase, QtWidgetFinder):
 
         self.assert_no_toplevel_widgets()
         self.assertEqual(pres.ads_observer, None)
+
+    def test_plot_matrix_xlimits_ignores_monitors(self):
+        xmin = 5000
+        xmax = 10000
+        ws = CreateSampleWorkspace(NumBanks=1, NumMonitors=1, BankPixelWidth=1, XMin=xmin, XMax=xmax)
+        ws.setX(0, 2 * ws.readX(0))  # change x limits of monitor spectrum
+        pres = SliceViewer(ws)
+
+        pres.view.data_view.plot_matrix(ws)
+
+        self.assertEqual(pres.view.data_view.get_axes_limits()[0], (xmin, xmax))
+
+    @patch("mantidqt.widgets.sliceviewer.dimensionwidget.Dimension.update_slider")
+    def test_plot_matrix_xlimits_ignores_nans(self, mock_update_slider):
+        # need to mock update slider as doesn't handle inf when initialising SliceViewer in this manner
+        xmin = 5000
+        xmax = 10000
+        ws = CreateSampleWorkspace(NumBanks=2, BankPixelWidth=2, XMin=xmin, XMax=xmax)  # two non-monitor spectra
+        ws.setX(0, hstack([2 * ws.readX(0)[0:-1], inf]))  # change x limits of spectrum and put inf in last element
+        pres = SliceViewer(ws)
+
+        pres.view.data_view.plot_matrix(ws)
+
+        self.assertEqual(pres.view.data_view.get_axes_limits()[0], (xmin, xmax))
 
 
 # private helper functions


### PR DESCRIPTION
**Description of work.**
Sliceviewer determines limits form spectra that are not monitors and ignores spectra with nan or inf values.

**To test:**
See instructions in original issue.
<!-- Instructions for testing. -->

Fixes #30364



<!-- Ensure the base of this PR is correct (e.g. release-next or master)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
