### PR TITLE
ISIS SANS Fix crash when browsing files in sum run tab 

### DIFF
--- a/docs/source/release/v6.0.0/sans.rst
+++ b/docs/source/release/v6.0.0/sans.rst
@@ -42,5 +42,7 @@ Bugfixes
   throw a Runtime Error.
 - ISIS SANS will print the name of any missing maskfiles instead of an empty name.
 - Fixed a bug in ISIS SANS GUI with the `Save Other` dialog.
+- Fixed a bug in ISIS SANS GUI sum runs tab, where clicking browse and then cancelling the file picker dialog caused
+  a crash.
 
 :ref:`Release 6.0.0 <v6.0.0>`

--- a/scripts/Interface/ui/sans_isis/run_selector_widget.py
+++ b/scripts/Interface/ui/sans_isis/run_selector_widget.py
@@ -35,7 +35,7 @@ class RunSelectorWidget(QtWidgets.QWidget, Ui_RunSelectorWidget):
         default_directory = search_directories[0]
         directory = self._previous_or_default_directory(previous_directories, default_directory)
         file_filter = self._filter_for_extensions(extensions)
-        chosen_files = QtWidgets.QFileDialog.getOpenFileNames(self, "Select files", directory, file_filter)
+        chosen_files, _ = QtWidgets.QFileDialog.getOpenFileNames(self, "Select files", directory, file_filter)
         if chosen_files:
             self._store_previous_directory(previous_directories, chosen_files[0])
         return [str(chosen_file) for chosen_file in chosen_files]


### PR DESCRIPTION
Fixes a crash in the ISIS SANS sum run gui when the user is browsing files, and then presses cancel. This was due to the Qt api for `QFileDialog.getOpenFileNames` changing.

**To test:**
1. Open ISIS SANS
2. Go to sum runs and click browse
3. Cancel the file picker dialog, verify that no exceptions occur
4. Click browse and select a file, verify that no exceptions occur (you will have to set an instrument in the first tab for this.)

Fixes #30303 
Related: #27530

<!-- Ensure the base of this PR is correct (e.g. release-next or master)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
