### PR TITLE
Fix issues with plotting ellipsoid peak shapes in sliceviewer

### DIFF
--- a/docs/source/release/v6.0.0/mantidworkbench.rst
+++ b/docs/source/release/v6.0.0/mantidworkbench.rst
@@ -54,6 +54,7 @@ Bugfixes
 - Show spectrum numbers instead of workspace index in plotBin
 - Fixed a bug which would cause unrealistic errorbars on the fit calc curve.
 - Fix sort order of peaks in the peaks overlay on SliceViewer.
+- Fixed a number of issues with displaying ellipsoid peak shapes.
 - The colorfill plot on ragged workspaces will have the correct horizontal extent.
 - Fix replot of colorfill image after a workspace is replaced.
 - Fixed a bug in generating plot scripts for figures containing data for a particular bin.

--- a/qt/python/mantidqt/widgets/sliceviewer/dimensionwidget.py
+++ b/qt/python/mantidqt/widgets/sliceviewer/dimensionwidget.py
@@ -187,6 +187,7 @@ class Dimension(QWidget):
         self.slider = QSlider(Qt.Horizontal)
         self.slider.setRange(0, self.nbins - 1)
         self.slider.valueChanged.connect(self.slider_changed)
+        self.update_value_from_slider = True
 
         self.spinbox = QDoubleSpinBox()
         self.spinbox.setDecimals(3)
@@ -264,7 +265,8 @@ class Dimension(QWidget):
         self.update_slider()
 
     def slider_changed(self):
-        self.value = self.get_bin_center(self.slider.value())
+        if self.update_value_from_slider:
+            self.value = self.get_bin_center(self.slider.value())
         self.update_spinbox()
         self.valueChanged.emit()
 
@@ -281,7 +283,6 @@ class Dimension(QWidget):
     def set_value(self, value):
         self.value = value
         self.update_slider()
-        self.update_spinbox()
 
     def get_value(self):
         return self.value
@@ -354,3 +355,17 @@ class DimensionNonIntegrated(Dimension):
             self.spinBins.hide()
             self.spinThick.hide()
             self.rebinLabel.hide()
+
+    def set_value(self, value):
+        """Override the set_value for MDE, this allows the exact value to be
+        set instead of limiting to the value of the slider. This
+        allows when selecting a peak to go to the exact layer where
+        the peak is.
+
+        """
+        self.value = value
+        # temporary disable updating value from slider change
+        self.update_value_from_slider = False
+        self.update_slider()
+        self.update_value_from_slider = True
+        self.update_spinbox()

--- a/qt/python/mantidqt/widgets/sliceviewer/peaksviewer/model.py
+++ b/qt/python/mantidqt/widgets/sliceviewer/peaksviewer/model.py
@@ -99,7 +99,13 @@ class PeaksViewerModel(TableWorkspaceDisplayModel):
         that slice point has been updated so it contains this peak
         :param index: Index of peak in list
         """
-        return self._representations[index].viewlimits()
+        rep = self._representations[index]
+
+        # Sometimes the integration volume may not intersect the slices of data
+        if rep is None:
+            return ((None, None), (None, None))
+
+        return rep.viewlimits()
 
     def _frame_to_slice_fn(self, frame):
         """

--- a/qt/python/mantidqt/widgets/sliceviewer/peaksviewer/presenter.py
+++ b/qt/python/mantidqt/widgets/sliceviewer/peaksviewer/presenter.py
@@ -39,7 +39,7 @@ class PeaksWorkspaceDataPresenter(TableWorkspaceDataPresenter):
         return item
 
 
-class PeaksViewerPresenter(object):
+class PeaksViewerPresenter():
     """Controls a PeaksViewerView with a given model to display
     the peaks table and interaction controls for single workspace.
     """
@@ -140,7 +140,7 @@ class PeaksViewerPresenter(object):
             raise ValueError("Expected a PeaksWorkspace. Found {}.".format(type(ws)))
 
 
-class PeaksViewerCollectionPresenter(object):
+class PeaksViewerCollectionPresenter():
     """Controls a widget comprising of multiple PeasViewerViews to display and
     interact with multiple PeaksWorkspaces"""
 

--- a/qt/python/mantidqt/widgets/sliceviewer/peaksviewer/representation/noshape.py
+++ b/qt/python/mantidqt/widgets/sliceviewer/peaksviewer/representation/noshape.py
@@ -11,7 +11,7 @@ from .alpha import compute_alpha
 from .painter import Painted
 
 
-class NonIntegratedPeakRepresentation(object):
+class NonIntegratedPeakRepresentation():
     """Create a collection of PeakDrawable objects for a non-integrated Peak"""
     VIEW_FRACTION = 0.015
 

--- a/qt/python/mantidqt/widgets/sliceviewer/peaksviewer/representation/painter.py
+++ b/qt/python/mantidqt/widgets/sliceviewer/peaksviewer/representation/painter.py
@@ -77,7 +77,7 @@ class EllipticalShell(Patch):
         return self._path
 
 
-class MplPainter(object):
+class MplPainter():
     """
     Implementation of a PeakPainter that uses matplotlib to draw
     """
@@ -174,7 +174,7 @@ class MplPainter(object):
             to_data_coords.transform(artist_bbox.max)
 
 
-class Painted(object):
+class Painted():
     """Combine a collection of artists with the painter that created them"""
     def __init__(self, painter, artists, effective_bbox=None):
         """

--- a/qt/python/mantidqt/widgets/sliceviewer/peaksviewer/representation/spherical.py
+++ b/qt/python/mantidqt/widgets/sliceviewer/peaksviewer/representation/spherical.py
@@ -17,7 +17,7 @@ from .ellipsoid import slice_ellipsoid_matrix
 from .painter import Painted
 
 
-class SphericallyIntergratedPeakRepresentation(object):
+class SphericallyIntergratedPeakRepresentation():
     """Provide methods to display a representation of a slice through an
     Spherically intgerated region around a Peak"""
     @classmethod

--- a/qt/python/mantidqt/widgets/sliceviewer/peaksviewer/test/test_peaksviewer_model.py
+++ b/qt/python/mantidqt/widgets/sliceviewer/peaksviewer/test/test_peaksviewer_model.py
@@ -98,6 +98,15 @@ class PeaksViewerModelTest(unittest.TestCase):
         assert_allclose((-0.13, 1.13), xlim)
         assert_allclose((-0.43, 0.83), ylim)
 
+        # Force case where no representation are able to be draw
+        # This can happen when the peak integration volume doesn't intersect any planes of data
+        model._representations = [None]
+
+        xlim, ylim = model.viewlimits(0)
+
+        self.assertEqual((None, None), xlim)
+        self.assertEqual((None, None), ylim)
+
     # -------------------------- Failure Tests --------------------------------
     def test_model_accepts_only_peaks_workspaces(self):
         self.assertRaises(ValueError, PeaksViewerModel, create_autospec(MatrixWorkspace), 'w',

--- a/qt/python/mantidqt/widgets/sliceviewer/peaksviewer/workspaceselection.py
+++ b/qt/python/mantidqt/widgets/sliceviewer/peaksviewer/workspaceselection.py
@@ -14,7 +14,7 @@ from qtpy.QtCore import Qt
 from qtpy.QtWidgets import QDialog, QDialogButtonBox, QTableWidget, QTableWidgetItem, QVBoxLayout
 
 
-class PeaksWorkspaceSelectorModel(object):
+class PeaksWorkspaceSelectorModel():
     """Data model for selecting PeaksWorkspaces from an object capable of providing
     a access to the available list of workspaces.
     """
@@ -47,7 +47,7 @@ class PeaksWorkspaceSelectorModel(object):
         return name_status
 
 
-class PeaksWorkspaceSelectorPresenter(object):
+class PeaksWorkspaceSelectorPresenter():
     """Present the list of available PeaksWorkspaces to the user and allow them
     to select them.
     """


### PR DESCRIPTION
3 issues were addressed

 1. The shape plotted may not intersect any slice of the data, this happens if the radius is too small
 2. The bounding box of the ellipsoid was always calculated from the background shell even when it wasn't used
 3. The dimension widget was changed for MDE so that you can go to the exact position of a selected peak instead of the positions limited by the slider

This error was made more prominent by #29771 because the number of step in the slide axis for MDEvent was decreased from 1000 to 100, this means larger gaps between layers and you are more likely to have a sphere that doesn't intersect the data.

To Do:
 - Add tests
 - Add release notes

**To test:**

On master you get the following error

```python
Load(Filename='SXD23767.raw', OutputWorkspace='SXD23767', LoaderName='LoadRaw', LoaderVersion='3')
ConvertToDiffractionMDWorkspace(InputWorkspace='SXD23767', OutputWorkspace='SXD23767MD', OneEventPerBin='0')
FindSXPeaks(InputWorkspace='SXD23767', PeakFindingStrategy='AllPeaks', AbsoluteBackground=2000,
             ResolutionStrategy='AbsoluteResolution', XResolution=200, PhiResolution=3, TwoThetaResolution=3,
             OutputWorkspace='peaks')
```
Then integrate with different options, overlay peaks in sliceviewer and select a peak.

### without background
```python
IntegratePeaksMD(InputWorkspace='SXD23767MD', PeakRadius=1,  Ellipsoid=True, PeaksWorkspace='peaks', OutputWorkspace='peaks_int', UseOnePercentBackgroundCorrection=False)
```
 
```
  File "/home/rwp/src/mantid/qt/python/mantidqt/widgets/sliceviewer/peaksviewer/representation/ellipsoid.py", line 230, in slice_ellipsoid_matrix     
    eigvalues, eigvectors = linalg.eig(MM)                                                                                                            
  File "<__array_function__ internals>", line 5, in eig                                                                                               
  File "/home/rwp/.local/lib/python3.8/site-packages/numpy/linalg/linalg.py", line 1318, in eig                                                       
    _assert_finite(a)                                                                                                                                 
  File "/home/rwp/.local/lib/python3.8/site-packages/numpy/linalg/linalg.py", line 209, in _assert_finite                                             
    raise LinAlgError("Array must not contain infs or NaNs")                                                                                          
numpy.linalg.LinAlgError: Array must not contain infs or NaNs                                                                                         
```

### peak radius too small
```python
IntegratePeaksMD(InputWorkspace='SXD23767MD', PeakRadius=0.01, BackgroundInnerRadius=0.35, BackgroundOuterRadius=0.5, Ellipsoid=True, PeaksWorkspace= 'peaks', OutputWorkspace='peaks_int', UseOnePercentBackgroundCorrection=False)
```

```                                                                                                                                                   
Python-[Error] Traceback (most recent call last):                                                                                                     
  File "/home/rwp/src/mantid/qt/python/mantidqt/widgets/sliceviewer/peaksviewer/view.py", line 166, in _on_row_clicked                                
    self._row_selected()                                                                                                                              
  File "/home/rwp/src/mantid/qt/python/mantidqt/widgets/sliceviewer/peaksviewer/view.py", line 172, in _row_selected                                  
    self._presenter.notify(self._presenter.Event.PeakSelected)                                                                                        
  File "/home/rwp/src/mantid/qt/python/mantidqt/widgets/sliceviewer/peaksviewer/presenter.py", line 89, in notify                                     
    self._peak_selected()                                                                                                                             
  File "/home/rwp/src/mantid/qt/python/mantidqt/widgets/sliceviewer/peaksviewer/presenter.py", line 124, in _peak_selected                            
    self._view.set_axes_limits(*self.model.viewlimits(selected_index), auto_transform=False)                                                          
  File "/home/rwp/src/mantid/qt/python/mantidqt/widgets/sliceviewer/peaksviewer/model.py", line 102, in viewlimits                                    
    return self._representations[index].viewlimits()                                                                                                  
AttributeError: 'NoneType' object has no attribute 'viewlimits'                                                                                       
```                                                                                 

After these changes, there should be no errors and when selecting a peak you should fo to the exact layer for MDE that the peak is in, not limited to the slider values.


*There is no associated issue.*


<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or master)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
