### PR TITLE
Fix a SliceViewer crash when x axis is not labelled TOF

### DIFF
--- a/docs/source/release/v6.0.0/mantidworkbench.rst
+++ b/docs/source/release/v6.0.0/mantidworkbench.rst
@@ -62,5 +62,6 @@ Bugfixes
 - Fixed a crash in the plot config when removing the last curve on a plot
 - Fixed a bug in SliceViewer that caused shown data to not update correctly when changing axis selection.
 - Fixed bug supplying rebin arguments for non-orthogonal data in sliceviewer that meant that not all the availible data within the axes limits were being plotted.
+- Fixed a crash in SliceViewer when hovering the cursor over Direct or Indirect data.
 
 :ref:`Release 6.0.0 <v6.0.0>`

--- a/qt/widgets/common/src/ImageInfoModelMatrixWS.cpp
+++ b/qt/widgets/common/src/ImageInfoModelMatrixWS.cpp
@@ -119,8 +119,6 @@ void ImageInfoModelMatrixWS::setUnitsInfo(ImageInfoModel::ImageInfo *info,
     try {
       tof =
           m_xunit->convertSingleToTOF(x, l1, l2, twoTheta, emode, efixed, 0.0);
-      info->setValue(infoIndex, defaultFormat(tof));
-      ++infoIndex;
     } catch (std::exception &exc) {
       // without TOF we can't get to the other units
       if (g_log.is(Logger::Priority::PRIO_DEBUG))


### PR DESCRIPTION
**Description of work.**
This PR fixes a crash on the SliceViewer when hovering the cursor over the loaded direct/indirect data. This occurs when the x unit of the loaded workspace isn't TOF.

The PR adds a test that would have previously failed.

Thanks to @mducle and @DanielMurphy22 for their help.

**To test:**
1. Load `MAR27689_Ei19.95meV.nxspe`
2. Show data in Sliceviewer
3. Move mouse over data image or try to zoom in.
4. There should be no crash!

**Data**
[MAR25087_Ei40.00meV.zip](https://github.com/mantidproject/mantid/files/5815746/MAR25087_Ei40.00meV.zip)

Fixes #30360

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
