### PR TITLE
Fix crash when deleting all curves from plot in figure options

### DIFF
--- a/docs/source/release/v6.0.0/framework.rst
+++ b/docs/source/release/v6.0.0/framework.rst
@@ -58,5 +58,6 @@ Bugfixes
 - A bug has been fixed when plotting bin plots on a workspace with numerical axis.
 - A bug is fixed when setting the same axis to multiple workspaces, which would cause a crash when deleting the workspaces.
 - Give warning when instrument in Facilities.xml has errors
+- A bug has been fixed where workbench crashed when deleting all the curves from a plot in the figure options dialog
 
 :ref:`Release 6.0.0 <v6.0.0>`

--- a/qt/python/mantidqt/widgets/plotconfigdialog/curvestabwidget/view.py
+++ b/qt/python/mantidqt/widgets/plotconfigdialog/curvestabwidget/view.py
@@ -64,6 +64,7 @@ class CurvesTabWidgetView(QWidget):
 
     def remove_select_curve_list_selected_items(self):
         selection = self.select_curve_list.selectionModel().selectedIndexes()
+        selection.sort(reverse=True)
         for index in selection:
             _ = self.select_curve_list.takeItem(index.row())
 


### PR DESCRIPTION
**Description of work.**

This change fixes a crash that happened when the user deleted all the curves from a plot in the figure options dialog (curves tab)

As an aside it seems a bit strange that the dialog has apply, cancel buttons yet the action of removing a curve is applied immediately. So even if the user cancels and returns to the plot the curve is still removed. That's not part of this issue though...

**To test:**

Load some data
Plot multiple spectra
Go to plot settings
In the curves tab, use shift click to select all curves, or use ctrl, then try to remove them all at once

Fixes #30331.

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
