### PR TITLE
Disable overplot when there is no active plot

### DIFF
--- a/qt/applications/workbench/workbench/plugins/workspacewidget.py
+++ b/qt/applications/workbench/workbench/plugins/workspacewidget.py
@@ -76,6 +76,8 @@ class WorkspaceWidget(PluginWidget):
             partial(self._do_plot_3D, plot_type='wireframe'))
         self.workspacewidget.plotContourClicked.connect(
             partial(self._do_plot_3D, plot_type='contour'))
+        self.workspacewidget.contextMenuAboutToShow.connect(
+            self._on_context_menu)
 
         self.workspacewidget.workspaceDoubleClicked.connect(self._action_double_click_workspace)
 
@@ -94,6 +96,13 @@ class WorkspaceWidget(PluginWidget):
         pass
 
     # ----------------- Behaviour --------------------
+
+    def _on_context_menu(self):
+        """
+        Triggered when the context menu is about to be displayed.
+        """
+        ableToOverplot, _ = can_overplot()
+        self.workspacewidget.setOverplotDisabled(not ableToOverplot)
 
     def _do_plot_spectrum(self, names, errors, overplot, advanced=False):
         """

--- a/qt/applications/workbench/workbench/plugins/workspacewidget.py
+++ b/qt/applications/workbench/workbench/plugins/workspacewidget.py
@@ -7,7 +7,7 @@
 #
 #
 from functools import partial
-from qtpy.QtWidgets import QApplication, QMessageBox, QVBoxLayout
+from qtpy.QtWidgets import QApplication, QVBoxLayout
 
 from mantid.api import AnalysisDataService, WorkspaceGroup
 from mantid.kernel import logger
@@ -101,7 +101,7 @@ class WorkspaceWidget(PluginWidget):
         """
         Triggered when the context menu is about to be displayed.
         """
-        ableToOverplot, _ = can_overplot()
+        ableToOverplot = can_overplot()
         self.workspacewidget.setOverplotDisabled(not ableToOverplot)
 
     def _do_plot_spectrum(self, names, errors, overplot, advanced=False):
@@ -115,11 +115,6 @@ class WorkspaceWidget(PluginWidget):
         :param advanced: If true then the advanced options will be shown in
                          the spectra selector dialog.
         """
-        if overplot:
-            compatible, error_msg = can_overplot()
-            if not compatible:
-                QMessageBox.warning(self, "", error_msg)
-                return
         try:
             plot_from_names(names, errors, overplot, advanced=advanced)
         except RuntimeError as re:
@@ -135,11 +130,6 @@ class WorkspaceWidget(PluginWidget):
                                    and it is a compatible figure
         :return:
         """
-        if overplot:
-            compatible, error_msg = can_overplot()
-            if not compatible:
-                QMessageBox.warning(self, "", error_msg)
-                return
         try:
             plot_md_ws_from_names(names, errors, overplot)
         except RuntimeError as re:
@@ -154,11 +144,6 @@ class WorkspaceWidget(PluginWidget):
         :param overplot: If true then the add to the current figure if one
                          exists and it is a compatible figure
         """
-        if overplot:
-            compatible, error_msg = can_overplot()
-            if not compatible:
-                QMessageBox.warning(self, "", error_msg)
-                return
         plot_kwargs = {"axis": MantidAxType.BIN}
         plot(self._ads.retrieveWorkspaces(names, unrollGroups=True),
              errors=errors,

--- a/qt/python/mantidqt/_common.sip
+++ b/qt/python/mantidqt/_common.sip
@@ -374,6 +374,7 @@ public:
   WorkspaceTreeWidgetSimple(bool viewOnly=false, QWidget *parent /TransferThis/ = nullptr);
   void refreshWorkspaces();
   void enableDeletePrompt(bool enable);
+  void setOverplotDisabled(bool disabled);
 
 signals:
   void plotSpectrumClicked(const QStringList & workspaceNames);

--- a/qt/python/mantidqt/plotting/functions.py
+++ b/qt/python/mantidqt/plotting/functions.py
@@ -56,15 +56,13 @@ def can_overplot():
     compatible.
     """
     compatible = False
-    msg = "Unable to overplot on currently active plot type.\n" \
-          "Please select another plot."
     fig = current_figure_or_none()
     if fig is not None:
         figtype = figure_type(fig)
         if figtype in [FigureType.Line, FigureType.Errorbar, FigureType.Waterfall]:
-            compatible, msg = True, None
+            compatible = True
 
-    return compatible, msg
+    return compatible
 
 
 def current_figure_or_none():

--- a/qt/python/mantidqt/plotting/test/test_functions.py
+++ b/qt/python/mantidqt/plotting/test/test_functions.py
@@ -78,17 +78,16 @@ class FunctionsTest(TestCase):
         plt.close('all')
 
     def test_can_overplot_returns_false_with_no_active_plots(self):
-        self.assertFalse(can_overplot()[0])
+        self.assertFalse(can_overplot())
 
     def test_can_overplot_returns_true_for_active_line_plot(self):
         plt.plot([1, 2])
-        self.assertTrue(can_overplot()[0])
+        self.assertTrue(can_overplot())
 
     def test_can_overplot_returns_false_for_active_patch_plot(self):
         plt.pcolormesh(np.arange(9.).reshape(3, 3))
-        allowed, msg = can_overplot()
+        allowed = can_overplot()
         self.assertFalse(allowed)
-        self.assertGreater(len(msg), 0)
 
     def test_current_figure_or_none_returns_none_if_no_figures_exist(self):
         self.assertEqual(current_figure_or_none(), None)

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/WorkspacePresenter/WorkspaceTreeWidgetSimple.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/WorkspacePresenter/WorkspaceTreeWidgetSimple.h
@@ -40,6 +40,7 @@ public:
 
   // Context Menu Handlers
   void popupContextMenu() override;
+  void setOverplotDisabled(bool disabled);
 
 signals:
   void plotSpectrumClicked(const QStringList &workspaceNames);
@@ -58,6 +59,7 @@ signals:
   void plotSurfaceClicked(const QStringList &workspaceNames);
   void plotWireframeClicked(const QStringList &workspaceNames);
   void plotContourClicked(const QStringList &workspaceNames);
+  void contextMenuAboutToShow(void);
 
   void workspaceDoubleClicked(const QString &workspaceName);
   void treeSelectionChanged();

--- a/qt/widgets/common/src/WorkspacePresenter/WorkspaceTreeWidgetSimple.cpp
+++ b/qt/widgets/common/src/WorkspacePresenter/WorkspaceTreeWidgetSimple.cpp
@@ -111,7 +111,13 @@ WorkspaceTreeWidgetSimple::WorkspaceTreeWidgetSimple(bool viewOnly,
 
 WorkspaceTreeWidgetSimple::~WorkspaceTreeWidgetSimple() {}
 
+void WorkspaceTreeWidgetSimple::setOverplotDisabled(bool disabled) {
+  m_overplotSpectrum->setDisabled(disabled);
+  m_overplotSpectrumWithErrs->setDisabled(disabled);
+}
+
 void WorkspaceTreeWidgetSimple::popupContextMenu() {
+  emit contextMenuAboutToShow();
   QTreeWidgetItem *treeItem = m_tree->itemAt(m_menuPosition);
   selectedWsName = "";
   if (treeItem)


### PR DESCRIPTION
**Description of work.**

With this PR, the options to overplot (overplot and overplot with error) are disabled from the workspace widget context menu if there is no active plot.

**To test:**

Try to plot and overplot data.

Fixes #27814 

*This does not require release notes*, internal changes only.

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
