### PR TITLE
Fix slice viewer bug with text axis

### DIFF
--- a/Framework/API/src/TextAxis.cpp
+++ b/Framework/API/src/TextAxis.cpp
@@ -10,6 +10,7 @@
 #include "MantidAPI/TextAxis.h"
 #include "MantidKernel/EmptyValues.h"
 #include "MantidKernel/Exception.h"
+#include "MantidKernel/VectorHelper.h"
 
 namespace Mantid {
 namespace API {
@@ -71,7 +72,14 @@ void TextAxis::setValue(const std::size_t &index, const double &value) {
  * Returns the value that has been passed to it as a size_t
  */
 size_t TextAxis::indexOfValue(const double value) const {
-  return static_cast<size_t>(value);
+  auto spec_num = length();
+  std::vector<double> spectraNumbers;
+  spectraNumbers.reserve(length());
+  for (size_t i = 0; i < length(); i++) {
+    spectraNumbers.push_back(static_cast<double>(i));
+  }
+  return Mantid::Kernel::VectorHelper::indexOfValueFromCenters(spectraNumbers,
+                                                               value);
 }
 
 /** Check if two axis defined as spectra or numeric axis are equivalent

--- a/Framework/API/src/TextAxis.cpp
+++ b/Framework/API/src/TextAxis.cpp
@@ -72,11 +72,10 @@ void TextAxis::setValue(const std::size_t &index, const double &value) {
  * Returns the value that has been passed to it as a size_t
  */
 size_t TextAxis::indexOfValue(const double value) const {
-  auto spec_num = length();
   std::vector<double> spectraNumbers;
   spectraNumbers.reserve(length());
   for (size_t i = 0; i < length(); i++) {
-    spectraNumbers.push_back(static_cast<double>(i));
+    spectraNumbers.emplace_back(static_cast<double>(i));
   }
   return Mantid::Kernel::VectorHelper::indexOfValueFromCenters(spectraNumbers,
                                                                value);

--- a/Framework/API/test/TextAxisTest.h
+++ b/Framework/API/test/TextAxisTest.h
@@ -132,6 +132,7 @@ public:
   void test_indexOfValue_Returns_Input_As_Index() {
     TextAxis ta(2);
     TS_ASSERT_EQUALS(static_cast<size_t>(1.5), ta.indexOfValue(1.5));
-    TS_ASSERT_EQUALS(static_cast<size_t>(-1), ta.indexOfValue(-1.5));
+    TS_ASSERT_THROWS(ta.indexOfValue(-1.5), const std::out_of_range &);
+    TS_ASSERT_THROWS(ta.indexOfValue(5), const std::out_of_range &);
   }
 };

--- a/docs/source/release/v6.0.0/mantidworkbench.rst
+++ b/docs/source/release/v6.0.0/mantidworkbench.rst
@@ -42,6 +42,7 @@ Improvements
 - Slice Viewer replots the workspace when it is modified outside the Slice Viewer.
 - A system to group samples and avoid repetition in DrILL has been added. See the :ref:`DrILL documentation <DrILL-ref>` for more information.
 - In the plot config, multiple curves can be selected and removed at once. The delete key was added as a shortcut.
+- A bug has been fixed in SliceViewer where attempting to plot a workspace with a text axis would cause a crash when zoomed out.
 
 Bugfixes
 ########


### PR DESCRIPTION
**Description of work.**

In issue was found with using slice viewer on the output of FFT, this was a result of an underflow in getting the index of a value from a TextAxis, this PR changes the function in TextAxis to be consistent with the same functions in other Axis objects.

**To test:**

1. Load a workspace with a text axis, or run:
```
ws = CreateSampleWorkspace(OutputWorkspace='ws')
ws = FFT(ws, AutoShift=True)
```
2. open the workspace in sliceviewer.
3. zoom out so that the plot range is outside of the range of spectra. this will produce an error in the log but will not crash. this error is already present in other workspaces when zoomed out.

Fixes #30344

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
