### PR TITLE
Fix Crash From Broken e Notation In Axis Limits Of Plot Settings

### DIFF
--- a/docs/source/release/v6.0.0/mantidworkbench.rst
+++ b/docs/source/release/v6.0.0/mantidworkbench.rst
@@ -63,5 +63,6 @@ Bugfixes
 - Fixed a bug in SliceViewer that caused shown data to not update correctly when changing axis selection.
 - Fixed bug supplying rebin arguments for non-orthogonal data in sliceviewer that meant that not all the availible data within the axes limits were being plotted.
 - Fixed a crash in SliceViewer when hovering the cursor over Direct or Indirect data.
+- Fixed a crash when using broken e notation for axis limits in plot settings
 
 :ref:`Release 6.0.0 <v6.0.0>`

--- a/qt/python/mantidqt/widgets/plotconfigdialog/axestabwidget/presenter.py
+++ b/qt/python/mantidqt/widgets/plotconfigdialog/axestabwidget/presenter.py
@@ -8,6 +8,7 @@
 
 from mpl_toolkits.mplot3d.axes3d import Axes3D
 
+from mantid import logger
 from mantid.plots import convert_color_to_hex
 from mantidqt.widgets.plotconfigdialog import generate_ax_name, get_axes_names_dict
 from mantidqt.widgets.plotconfigdialog.axestabwidget import AxProperties
@@ -259,7 +260,21 @@ class AxesTabWidgetPresenter:
         self.current_view_props['title'] = self.view.get_title()
         self.current_view_props['minor_ticks'] = self.view.get_show_minor_ticks()
         self.current_view_props['minor_gridlines'] = self.view.get_show_minor_gridlines()
-        self.current_view_props[f"{ax}lim"] = (self.view.get_lower_limit(), self.view.get_upper_limit())
+        try:
+            lower_lim = self.view.get_lower_limit()
+            lower_lim = float(lower_lim)
+        except ValueError:
+            logger.warning("Could not set lower axis limit to " + lower_lim + ". Using 0.0 instead")
+            lower_lim = 0.0
+            self.view.set_lower_limit(lower_lim)
+        try:
+            upper_lim = self.view.get_upper_limit()
+            upper_lim = float(upper_lim)
+        except ValueError:
+            logger.warning("Could not set upper axis limit to " + upper_lim + ". Using 1.0 instead")
+            upper_lim = 1.0
+            self.view.set_upper_limit(upper_lim)
+        self.current_view_props[f"{ax}lim"] = (lower_lim,upper_lim)
         self.current_view_props[f"{ax}label"] = self.view.get_label()
         self.current_view_props[f"{ax}scale"] = self.view.get_scale()
         self.current_view_props[f"{ax}autoscale"] = self.view.get_autoscale_enabled()

--- a/qt/python/mantidqt/widgets/plotconfigdialog/axestabwidget/test/test_axestabwidgetpresenter.py
+++ b/qt/python/mantidqt/widgets/plotconfigdialog/axestabwidget/test/test_axestabwidgetpresenter.py
@@ -263,6 +263,44 @@ class AxesTabWidgetPresenterTest(unittest.TestCase):
         mock_view.get_autoscale_enabled.assert_called_once_with()
         mock_view.set_limit_input_enabled.assert_called_once_with(False)
 
+    def test_broken_e_notation_for_lower_axis_lims(self):
+        mock_view = mock.Mock(get_lower_limit=mock.Mock(return_value="e"),
+                              get_upper_limit=mock.Mock(return_value="10"),
+                              get_selected_ax_name=lambda: "My Axes: (0, 0)",
+                              get_axis=lambda: "x",
+                              get_properties=lambda: {})
+
+        presenter = Presenter(self.fig, view=mock_view)
+        presenter.get_selected_ax_name = 'x'
+        presenter.axis_changed()
+
+        self.assertEqual(presenter.current_view_props["xlim"], (0.0, 10.0))
+
+    def test_broken_e_notation_for_upper_axis_lims(self):
+        mock_view = mock.Mock(get_lower_limit=mock.Mock(return_value="-1"),
+                              get_upper_limit=mock.Mock(return_value="e"),
+                              get_selected_ax_name=lambda: "My Axes: (0, 0)",
+                              get_axis=lambda: "x",
+                              get_properties=lambda: {})
+
+        presenter = Presenter(self.fig, view=mock_view)
+        presenter.get_selected_ax_name = 'x'
+        presenter.axis_changed()
+
+        self.assertEqual(presenter.current_view_props["xlim"], (-1.0, 1.0))
+
+    def test_ax_limits_set_correctly(self):
+        mock_view = mock.Mock(get_lower_limit=mock.Mock(return_value="-1"),
+                              get_upper_limit=mock.Mock(return_value="10"),
+                              get_selected_ax_name=lambda: "My Axes: (0, 0)",
+                              get_axis=lambda: "x",
+                              get_properties=lambda: {})
+
+        presenter = Presenter(self.fig, view=mock_view)
+        presenter.get_selected_ax_name = 'x'
+        presenter.axis_changed()
+
+        self.assertEqual(presenter.current_view_props["xlim"], (-1.0, 10.0))
 
 if __name__ == '__main__':
     unittest.main()

--- a/qt/python/mantidqt/widgets/plotconfigdialog/axestabwidget/test/test_axestabwidgetpresenter.py
+++ b/qt/python/mantidqt/widgets/plotconfigdialog/axestabwidget/test/test_axestabwidgetpresenter.py
@@ -302,5 +302,6 @@ class AxesTabWidgetPresenterTest(unittest.TestCase):
 
         self.assertEqual(presenter.current_view_props["xlim"], (-1.0, 10.0))
 
+
 if __name__ == '__main__':
     unittest.main()

--- a/qt/python/mantidqt/widgets/plotconfigdialog/axestabwidget/view.py
+++ b/qt/python/mantidqt/widgets/plotconfigdialog/axestabwidget/view.py
@@ -83,20 +83,10 @@ class AxesTabWidgetView(QWidget):
         self.show_minor_gridlines_check_box.setEnabled(eneabled)
 
     def get_lower_limit(self):
-        try:
-            return float(self.lower_limit_line_edit.text())
-        except ValueError:
-            logger.warning(f"Could not set axis limit to {self.lower_limit_line_edit.text()}. Using 0 instead" )
-            self.set_lower_limit(0)
-            return 0
+        return self.lower_limit_line_edit.text()
 
     def get_upper_limit(self):
-        try:
-            return float(self.upper_limit_line_edit.text())
-        except ValueError:
-            logger.warning(f"Could not set axis limit to {self.lower_limit_line_edit.text()}. Using 1 instead")
-            self.set_upper_limit(1)
-            return 0
+        return self.upper_limit_line_edit.text()
 
     def get_label(self):
         return self.label_line_edit.text()

--- a/qt/python/mantidqt/widgets/plotconfigdialog/axestabwidget/view.py
+++ b/qt/python/mantidqt/widgets/plotconfigdialog/axestabwidget/view.py
@@ -13,7 +13,6 @@ from qtpy.QtWidgets import QWidget, QTabBar
 from mantidqt.utils.qt import load_ui
 from mantidqt.widgets.plotconfigdialog.axestabwidget import AxProperties
 from mantidqt.widgets.plotconfigdialog.colorselector import ColorSelector
-from mantid import logger
 
 
 class AxesTabWidgetView(QWidget):

--- a/qt/python/mantidqt/widgets/plotconfigdialog/axestabwidget/view.py
+++ b/qt/python/mantidqt/widgets/plotconfigdialog/axestabwidget/view.py
@@ -13,6 +13,7 @@ from qtpy.QtWidgets import QWidget, QTabBar
 from mantidqt.utils.qt import load_ui
 from mantidqt.widgets.plotconfigdialog.axestabwidget import AxProperties
 from mantidqt.widgets.plotconfigdialog.colorselector import ColorSelector
+from mantid import logger
 
 
 class AxesTabWidgetView(QWidget):
@@ -82,10 +83,20 @@ class AxesTabWidgetView(QWidget):
         self.show_minor_gridlines_check_box.setEnabled(eneabled)
 
     def get_lower_limit(self):
-        return float(self.lower_limit_line_edit.text())
+        try:
+            return float(self.lower_limit_line_edit.text())
+        except ValueError:
+            logger.warning(f"Could not set axis limit to {self.lower_limit_line_edit.text()}. Using 0 instead" )
+            self.set_lower_limit(0)
+            return 0
 
     def get_upper_limit(self):
-        return float(self.upper_limit_line_edit.text())
+        try:
+            return float(self.upper_limit_line_edit.text())
+        except ValueError:
+            logger.warning(f"Could not set axis limit to {self.lower_limit_line_edit.text()}. Using 1 instead")
+            self.set_upper_limit(1)
+            return 0
 
     def get_label(self):
         return self.label_line_edit.text()


### PR DESCRIPTION
**Description of work.**
Caught exception from broken e notation and set as default values instead, logging warning to user

**To test:**

1. Load some data
2. Make a plot
3. Open plot settings

Fixes #30334 

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
