### PR TITLE
Only enable errorbar tab if data contains errors

### DIFF
--- a/qt/python/mantidqt/widgets/plotconfigdialog/curvestabwidget/presenter.py
+++ b/qt/python/mantidqt/widgets/plotconfigdialog/curvestabwidget/presenter.py
@@ -420,3 +420,4 @@ class CurvesTabWidgetPresenter:
             self.view.enable_curve_config(False)
         else:
             self.view.enable_curve_config(True)
+            self.set_errorbars_tab_enabled()


### PR DESCRIPTION
**Report to:** Malcolm / ESS

In the Curves tab, when a new curve is selected in the list widget
all tabs were enabled. Now the errorbar tab is only enabled if the data
relating to that curve has errors.

**To test:**

Use this script:
```
from mantid.simpleapi import *
import matplotlib.pyplot as plt

x = [1,2,3,4,5]
y1 = [1,2,3,4,5]
y2 = [2,4,6,8,10]
y3 = [1,3,5,7,9]
e = y2

ws1 = CreateWorkspace(x,y1)
ws2 = CreateWorkspace(x,y2)
ws3 = CreateWorkspace(x,y3,e)
plotSpectrum([ws1,ws2,ws3],0)
```
Then change between the different curves in the curves list in the curves tab, and check that ws1 and ws2 have the Errorbar tab disabled, but it is enabled for ws3.

Maybe also worth testing some of the functionality added here: https://github.com/mantidproject/mantid/pull/30167
such as selecting multiple curves.

Fixes #30383

*This does not require release notes* because **This has only been broken since the last release**


<!-- Ensure the base of this PR is correct (e.g. release-next or master)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
