### PR TITLE
Backward compatibility in DrILL file loading

### DIFF
--- a/scripts/Interface/ui/drill/model/DrillModel.py
+++ b/scripts/Interface/ui/drill/model/DrillModel.py
@@ -20,7 +20,6 @@ from .DrillAlgorithmPool import DrillAlgorithmPool
 from .DrillTask import DrillTask
 from .DrillParameterController import DrillParameter, DrillParameterController
 from .DrillRundexIO import DrillRundexIO
-from .DrillSample import DrillSample
 
 
 class DrillModel(QObject):
@@ -760,16 +759,14 @@ class DrillModel(QObject):
 
         return self.columns, tooltips
 
-    def addSample(self, index, params=None):
+    def addSample(self, index, sample):
         """
-        Add an empty sample.
+        Add a sample to the model.
 
         Args:
             index (int): sample index; if -1 the sample is added to the end
+            sample (DrillSample): sample
         """
-        sample = DrillSample()
-        if params:
-            sample.setParameters(params)
         if (index == -1):
             self.samples.append(sample)
         else:

--- a/scripts/Interface/ui/drill/model/DrillRundexIO.py
+++ b/scripts/Interface/ui/drill/model/DrillRundexIO.py
@@ -10,6 +10,7 @@ import json
 from mantid.kernel import *
 
 from .configurations import RundexSettings
+from .DrillSample import DrillSample
 
 
 class DrillRundexIO:
@@ -96,7 +97,13 @@ class DrillRundexIO:
         # samples
         if ((RundexSettings.SAMPLES_JSON_KEY in json_data)
                 and (json_data[RundexSettings.SAMPLES_JSON_KEY])):
-            for sample in json_data[RundexSettings.SAMPLES_JSON_KEY]:
+            for sampleJson in json_data[RundexSettings.SAMPLES_JSON_KEY]:
+                # for backward compatibility
+                if "CustomOptions" in sampleJson:
+                    sampleJson.update(sampleJson["CustomOptions"])
+                    del sampleJson["CustomOptions"]
+                sample = DrillSample()
+                sample.setParameters(sampleJson)
                 drill.addSample(-1, sample)
         else:
             logger.warning("No sample found when importing {0}."

--- a/scripts/Interface/ui/drill/model/DrillSample.py
+++ b/scripts/Interface/ui/drill/model/DrillSample.py
@@ -27,10 +27,6 @@ class DrillSample:
             parameters (dict(str:str)): parameter key:value pairs
         """
         self._parameters = {k:v for k,v in parameters.items()}
-        # for backward compatibility
-        if "CustomOptions" in self._parameters:
-            self._parameters.update(self._parameters["CustomOptions"])
-            del self._parameters["CustomOptions"]
 
     def getParameters(self):
         """

--- a/scripts/Interface/ui/drill/model/DrillSample.py
+++ b/scripts/Interface/ui/drill/model/DrillSample.py
@@ -27,6 +27,10 @@ class DrillSample:
             parameters (dict(str:str)): parameter key:value pairs
         """
         self._parameters = {k:v for k,v in parameters.items()}
+        # for backward compatibility
+        if "CustomOptions" in self._parameters:
+            self._parameters.update(self._parameters["CustomOptions"])
+            del self._parameters["CustomOptions"]
 
     def getParameters(self):
         """

--- a/scripts/Interface/ui/drill/presenter/DrillPresenter.py
+++ b/scripts/Interface/ui/drill/presenter/DrillPresenter.py
@@ -9,6 +9,7 @@ from qtpy.QtWidgets import QFileDialog, QMessageBox
 
 from ..view.DrillSettingsDialog import DrillSettingsDialog
 from ..model.DrillModel import DrillModel
+from ..model.DrillSample import DrillSample
 from .DrillContextMenuPresenter import DrillContextMenuPresenter
 
 
@@ -44,7 +45,8 @@ class DrillPresenter:
         self.view.acquisitionModeChanged.connect(self.acquisitionModeChanged)
         self.view.cycleAndExperimentChanged.connect(
                 self.model.setCycleAndExperiment)
-        self.view.rowAdded.connect(self.model.addSample)
+        self.view.rowAdded.connect(
+                lambda position : self.model.addSample(position, DrillSample()))
         self.view.rowDeleted.connect(self.model.deleteSample)
         self.view.dataChanged.connect(self.onDataChanged)
         self.view.groupSelectedRows.connect(self.onGroupSelectedRows)
@@ -440,7 +442,7 @@ class DrillPresenter:
         self.view.set_table(columns, tooltips)
         if not samples:
             self.view.add_row_after()
-            self.model.addSample(-1)
+            self.model.addSample(-1, DrillSample())
         else:
             for i in range(len(samples)):
                 self.view.add_row_after()

--- a/scripts/Interface/ui/drill/test/CMakeLists.txt
+++ b/scripts/Interface/ui/drill/test/CMakeLists.txt
@@ -9,6 +9,7 @@ set(TEST_PY_FILES
   DrillTest.py
   DrillParameterControllerTest.py
   DrillSettingsDialogTest.py
+  DrillSampleTest.py
   )
 
 check_tests_valid(${CMAKE_CURRENT_SOURCE_DIR} ${TEST_PY_FILES})

--- a/scripts/Interface/ui/drill/test/DrillModelTest.py
+++ b/scripts/Interface/ui/drill/test/DrillModelTest.py
@@ -577,9 +577,9 @@ class DrillModelTest(unittest.TestCase):
 
     def test_addSample(self):
         self.assertEqual(self.model.samples, [])
-        self.model.addSample(0)
+        self.model.addSample(0, mock.Mock())
         self.assertEqual(len(self.model.samples), 1)
-        self.model.addSample(0)
+        self.model.addSample(0, mock.Mock())
         self.assertEqual(len(self.model.samples), 2)
 
     def test_deleteSample(self):

--- a/scripts/Interface/ui/drill/test/DrillRundexIOTest.py
+++ b/scripts/Interface/ui/drill/test/DrillRundexIOTest.py
@@ -31,27 +31,119 @@ class DrillRundexIOTest(unittest.TestCase):
     def test_getFilename(self):
         self.assertEqual(self.model.getFilename(), self.filename)
 
-    def test_load(self):
+    @mock.patch("Interface.ui.drill.model.DrillRundexIO.DrillSample")
+    def test_loadRundexV1(self, mSample):
         self.mJson.load.return_value = {
                 "Instrument": "i1",
                 "AcquisitionMode": "a1",
                 "CycleNumber": "cycle",
                 "ExperimentID": "exp",
-                "VisualSettings": {},
-                "GlobalSettings": {},
-                "Samples": [{"param1": "value1"}],
-                "SamplesGroups": {"A": 0},
-                "MasterSamples": {"A": 0}
+                "VisualSettings": {
+                    "FoldedColumns": [
+                        "c1",
+                        "c2",
+                        "c3"
+                        ],
+                    "HiddenColumns": [
+                        "c4",
+                        "c5"
+                        ],
+                    "ColumnsOrder": [
+                        "c1",
+                        "c2",
+                        "c3",
+                        "c4",
+                        "c5"
+                        ]
+                    },
+                "GlobalSettings": {
+                    "param1": True,
+                    "param2": "value1",
+                    "param3": 0.1,
+                    "param4": [0.1, 0.2, 0.3],
+                    "param5": [],
+                    },
+                "Samples": [
+                        {
+                            "param6": "value1",
+                            "param7": "value2",
+                            "CustomOptions": {
+                                "param1": False
+                                }
+                            }
+                        ]
                 }
         self.model.load()
         self.mOpen.assert_called_once_with("test")
         self.mJson.load.assert_called_once()
         mD = self.mDrillModel
         mD.setCycleAndExperiment.assert_called_once_with("cycle", "exp")
-        mD.setVisualSettings.assert_called_once_with({})
-        mD.addSample.assert_called_once_with(-1, {"param1": "value1"})
-        mD.setSamplesGroups.assert_called_once_with({"A": 0})
-        mD.setMasterSamples.assert_called_once_with({"A": 0})
+        mD.setVisualSettings.assert_called_once()
+        sample = mSample.return_value
+        sample.setParameters.assert_called_once_with(
+                {
+                    "param6": "value1",
+                    "param7": "value2",
+                    "param1": False
+                    }
+                )
+        mD.addSample.assert_called_once_with(-1, sample)
+
+    @mock.patch("Interface.ui.drill.model.DrillRundexIO.DrillSample")
+    def test_loadRundexV2(self, mSample):
+        self.mJson.load.return_value = {
+                "Instrument": "i1",
+                "AcquisitionMode": "a1",
+                "CycleNumber": "cycle",
+                "ExperimentID": "exp",
+                "VisualSettings": {
+                    "FoldedColumns": [
+                        "c1",
+                        "c2",
+                        "c3"
+                        ],
+                    "HiddenColumns": [
+                        "c4",
+                        "c5"
+                        ],
+                    "ColumnsOrder": [
+                        "c1",
+                        "c2",
+                        "c3",
+                        "c4",
+                        "c5"
+                        ]
+                    },
+                "GlobalSettings": {
+                    "param1": True,
+                    "param2": "value1",
+                    "param3": 0.1,
+                    "param4": [0.1, 0.2, 0.3],
+                    "param5": [],
+                    },
+                "Samples": [
+                        {
+                            "param6": "value1",
+                            "param7": "value2",
+                            "param1": False
+                            }
+                        ]
+                }
+        self.model.load()
+        self.mOpen.assert_called_once_with("test")
+        self.mJson.load.assert_called_once()
+        mD = self.mDrillModel
+        mD.setCycleAndExperiment.assert_called_once_with("cycle", "exp")
+        mD.setVisualSettings.assert_called_once()
+        sample = mSample.return_value
+        sample.setParameters.assert_called_once_with(
+                {
+                    "param6": "value1",
+                    "param7": "value2",
+                    "param1": False
+                    }
+                )
+        mD.addSample.assert_called_once_with(-1, sample)
 
     def test_save(self):
         mD = self.mDrillModel

--- a/scripts/Interface/ui/drill/test/DrillSampleTest.py
+++ b/scripts/Interface/ui/drill/test/DrillSampleTest.py
@@ -19,22 +19,7 @@ class DrillSampleTest(unittest.TestCase):
         self.assertDictEqual(self.sample._parameters, {})
 
     def test_setParameters(self):
-        oldRundex = {
-                "SampleRuns": "7909+7925,7893,7877",
-                "SampleTransmissionRuns": "7860",
-                "AbsorberRuns": "7847+8209,7837+8187,7827+8165",
-                "BeamRuns": "7846,7836,7826",
-                "ContainerRuns": "8367,8349,8331",
-                "TransmissionBeamRuns": "7815+7825+7872+7944-7953",
-                "OutputWorkspace": "GM110",
-                "CustomOptions": {
-                    "SampleThickness": "0.2"
-                    },
-                "MaskFiles": "maskBeamLowQ,maskBeamMiddleQ,maskBeamHighQ",
-                "ContainerTransmissionRuns": "8313",
-                "ReferenceFiles": "007845_Sample,007845_Sample,007835_Sample"
-                }
-        newRundex = {
+        params = {
                 "SampleRuns": "7909+7925,7893,7877",
                 "SampleTransmissionRuns": "7860",
                 "AbsorberRuns": "7847+8209,7837+8187,7827+8165",
@@ -47,10 +32,8 @@ class DrillSampleTest(unittest.TestCase):
                 "ReferenceFiles": "007845_Sample,007845_Sample,007835_Sample",
                 "SampleThickness": "0.2"
                 }
-        self.sample.setParameters(newRundex)
-        self.assertDictEqual(self.sample._parameters, newRundex)
-        self.sample.setParameters(oldRundex)
-        self.assertDictEqual(self.sample._parameters, newRundex)
+        self.sample.setParameters(params)
+        self.assertDictEqual(self.sample._parameters, params)
 
     def test_getParameters(self):
         self.sample._parameters = {"p1": "v1", "p2": "v2"}

--- a/scripts/Interface/ui/drill/test/DrillSampleTest.py
+++ b/scripts/Interface/ui/drill/test/DrillSampleTest.py
@@ -1,0 +1,71 @@
+# Mantid Repository : https://github.com/mantidproject/mantid
+#
+# Copyright &copy; 2018 ISIS Rutherford Appleton Laboratory UKRI,
+#     NScD Oak Ridge National Laboratory, European Spallation Source
+#     & Institut Laue - Langevin
+# SPDX - License - Identifier: GPL - 3.0 +
+
+import unittest
+
+from Interface.ui.drill.model.DrillSample import DrillSample
+
+
+class DrillSampleTest(unittest.TestCase):
+
+    def setUp(self):
+        self.sample = DrillSample()
+
+    def test_init(self):
+        self.assertDictEqual(self.sample._parameters, {})
+
+    def test_setParameters(self):
+        oldRundex = {
+                "SampleRuns": "7909+7925,7893,7877",
+                "SampleTransmissionRuns": "7860",
+                "AbsorberRuns": "7847+8209,7837+8187,7827+8165",
+                "BeamRuns": "7846,7836,7826",
+                "ContainerRuns": "8367,8349,8331",
+                "TransmissionBeamRuns": "7815+7825+7872+7944-7953",
+                "OutputWorkspace": "GM110",
+                "CustomOptions": {
+                    "SampleThickness": "0.2"
+                    },
+                "MaskFiles": "maskBeamLowQ,maskBeamMiddleQ,maskBeamHighQ",
+                "ContainerTransmissionRuns": "8313",
+                "ReferenceFiles": "007845_Sample,007845_Sample,007835_Sample"
+                }
+        newRundex = {
+                "SampleRuns": "7909+7925,7893,7877",
+                "SampleTransmissionRuns": "7860",
+                "AbsorberRuns": "7847+8209,7837+8187,7827+8165",
+                "BeamRuns": "7846,7836,7826",
+                "ContainerRuns": "8367,8349,8331",
+                "TransmissionBeamRuns": "7815+7825+7872+7944-7953",
+                "OutputWorkspace": "GM110",
+                "MaskFiles": "maskBeamLowQ,maskBeamMiddleQ,maskBeamHighQ",
+                "ContainerTransmissionRuns": "8313",
+                "ReferenceFiles": "007845_Sample,007845_Sample,007835_Sample",
+                "SampleThickness": "0.2"
+                }
+        self.sample.setParameters(newRundex)
+        self.assertDictEqual(self.sample._parameters, newRundex)
+        self.sample.setParameters(oldRundex)
+        self.assertDictEqual(self.sample._parameters, newRundex)
+
+    def test_getParameters(self):
+        self.sample._parameters = {"p1": "v1", "p2": "v2"}
+        self.assertDictEqual(self.sample.getParameters(),
+                             {"p1": "v1", "p2": "v2"})
+
+    def test_changeParameter(self):
+        self.sample._parameters = {"p1": "v1", "p2": "v2"}
+        self.sample.changeParameter("p1", "v1'")
+        self.assertDictEqual(self.sample._parameters,
+                             {"p1": "v1'", "p2": "v2"})
+        self.sample.changeParameter("p2", "")
+        self.assertDictEqual(self.sample._parameters,
+                             {"p1": "v1'"})
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
**Description of work.**

With this PR, the DrILL interface can load new and old rundex files.
#29782 changed the way the rundex files are exported and imported. This PR introduce a backward compatibility.

**To test:**

* copy the two following json in separate files
* open the DrILL interface
* observe that both files load fine and produce the same table in DrILL

<details><summary>oldRundex.mrd</summary><p>

```json
{
    "Instrument": "D11",
    "AcquisitionMode": "SANS",
    "VisualSettings": {
        "FoldedColumns": [
            "SampleTransmissionRuns",
            "AbsorberRuns",
            "BeamRuns",
            "FluxRuns",
            "ContainerRuns",
            "ContainerTransmissionRuns",
            "TransmissionAbsorberRuns",
            "TransmissionBeamRuns",
            "MaskFiles",
            "ReferenceFiles",
            "OutputWorkspace"
        ],
        "HiddenColumns": [],
        "ColumnsOrder": [
            "SampleRuns",
            "SampleTransmissionRuns",
            "AbsorberRuns",
            "BeamRuns",
            "FluxRuns",
            "ContainerRuns",
            "ContainerTransmissionRuns",
            "TransmissionAbsorberRuns",
            "TransmissionBeamRuns",
            "MaskFiles",
            "ReferenceFiles",
            "OutputWorkspace",
            "SampleThickness",
            "CustomOptions"
        ]
    },
    "GlobalSettings": {
        "ThetaDependent": true,
        "SensitivityMaps": "",
        "DefaultMaskFile": "",
        "NormaliseBy": "Timer",
        "SampleThickness": 0.1,
        "BeamRadius": [
            0.1
        ],
        "TransmissionBeamRadius": 0.1,
        "WaterCrossSection": 1.0,
        "OutputType": "I(Q)",
        "CalculateResolution": "None",
        "DefaultQBinning": "PixelSizeBased",
        "BinningFactor": 1.0,
        "OutputBinning": [],
        "NPixelDivision": 1,
        "NumberOfWedges": 0,
        "WedgeAngle": 30.0,
        "WedgeOffset": 0.0,
        "AsymmetricWedges": false,
        "MaxQxy": [
            -1.0
        ],
        "DeltaQ": [
            -1.0
        ],
        "IQxQyLogBinning": false,
        "OutputPanels": false
    },
    "Samples": [
        {
            "SampleRuns": "2889",
            "CustomOptions": {
                "ThetaDependent": true
            }
        }
    ]
}
```
</p></details>


<details><summary>newRundex.mrd</summary><p>

```json
{
    "Instrument": "D11",
    "AcquisitionMode": "SANS",
    "VisualSettings": {
        "FoldedColumns": [
            "SampleTransmissionRuns",
            "AbsorberRuns",
            "BeamRuns",
            "FluxRuns",
            "ContainerRuns",
            "ContainerTransmissionRuns",
            "TransmissionAbsorberRuns",
            "TransmissionBeamRuns",
            "MaskFiles",
            "ReferenceFiles",
            "OutputWorkspace"
        ],
        "HiddenColumns": [],
        "ColumnsOrder": [
            "SampleRuns",
            "SampleTransmissionRuns",
            "AbsorberRuns",
            "BeamRuns",
            "FluxRuns",
            "ContainerRuns",
            "ContainerTransmissionRuns",
            "TransmissionAbsorberRuns",
            "TransmissionBeamRuns",
            "MaskFiles",
            "ReferenceFiles",
            "OutputWorkspace",
            "SampleThickness",
            "CustomOptions"
        ]
    },
    "GlobalSettings": {
        "ThetaDependent": true,
        "SensitivityMaps": "",
        "DefaultMaskFile": "",
        "NormaliseBy": "Timer",
        "SampleThickness": 0.1,
        "BeamRadius": [
            0.1
        ],
        "TransmissionBeamRadius": 0.1,
        "WaterCrossSection": 1.0,
        "OutputType": "I(Q)",
        "CalculateResolution": "None",
        "DefaultQBinning": "PixelSizeBased",
        "BinningFactor": 1.0,
        "OutputBinning": [],
        "NPixelDivision": 1,
        "NumberOfWedges": 0,
        "WedgeAngle": 30.0,
        "WedgeOffset": 0.0,
        "AsymmetricWedges": false,
        "MaxQxy": [
            -1.0
        ],
        "DeltaQ": [
            -1.0
        ],
        "IQxQyLogBinning": false,
        "OutputPanels": false
    },
    "Samples": [
        {
            "SampleRuns": "2889",
            "ThetaDependent": true
        }
    ]
}
```
</p></details>

*This does not require release notes*, internal changes only.

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
