### PR TITLE
Refactor from std::vector to std::array

### DIFF
--- a/Framework/DataObjects/inc/MantidDataObjects/CoordTransformDistance.h
+++ b/Framework/DataObjects/inc/MantidDataObjects/CoordTransformDistance.h
@@ -44,6 +44,11 @@ public:
       const std::vector<Kernel::V3D> &eigenvects = std::vector<Kernel::V3D>(0),
       const std::vector<double> &eigenvals = std::vector<double>(0, 0.0));
 
+  CoordTransformDistance(const size_t inD, const coord_t *center,
+                         const bool *dimensionsUsed, const size_t outD,
+                         const std::array<Kernel::V3D, 3> &eigenvects,
+                         const std::array<double, 3> &eigenvals);
+
   CoordTransform *clone() const override;
   std::string toXMLString() const override;
   std::string id() const override;

--- a/Framework/DataObjects/inc/MantidDataObjects/PeakShapeEllipsoid.h
+++ b/Framework/DataObjects/inc/MantidDataObjects/PeakShapeEllipsoid.h
@@ -19,23 +19,23 @@ namespace DataObjects {
 class DLLExport PeakShapeEllipsoid : public PeakShapeBase {
 public:
   /// Constructor
-  PeakShapeEllipsoid(const std::vector<Mantid::Kernel::V3D> &directions,
-                     const std::vector<double> &abcRadii,
-                     const std::vector<double> &abcRadiiBackgroundInner,
-                     const std::vector<double> &abcRadiiBackgroundOuter,
+  PeakShapeEllipsoid(const std::array<Mantid::Kernel::V3D, 3> &directions,
+                     const std::array<double, 3> &abcRadii,
+                     const std::array<double, 3> &abcRadiiBackgroundInner,
+                     const std::array<double, 3> &abcRadiiBackgroundOuter,
                      Kernel::SpecialCoordinateSystem frame,
                      std::string algorithmName = std::string(),
                      int algorithmVersion = -1);
   /// Equals operator
   bool operator==(const PeakShapeEllipsoid &other) const;
   /// Get radii
-  const std::vector<double> &abcRadii() const;
+  const std::array<double, 3> &abcRadii() const;
   /// Get background inner radii
-  const std::vector<double> &abcRadiiBackgroundInner() const;
+  const std::array<double, 3> &abcRadiiBackgroundInner() const;
   /// Get background outer radii
-  const std::vector<double> &abcRadiiBackgroundOuter() const;
+  const std::array<double, 3> &abcRadiiBackgroundOuter() const;
   /// Get ellipsoid directions
-  const std::vector<Mantid::Kernel::V3D> &directions() const;
+  const std::array<Mantid::Kernel::V3D, 3> &directions() const;
   /// Get ellipsoid directions in a specified frame
   std::vector<Kernel::V3D> getDirectionInSpecificFrame(
       Kernel::Matrix<double> &invertedGoniometerMatrix) const;
@@ -54,13 +54,13 @@ public:
 
 private:
   /// principle axis
-  std::vector<Mantid::Kernel::V3D> m_directions;
+  std::array<Mantid::Kernel::V3D, 3> m_directions;
   /// radii
-  std::vector<double> m_abc_radii;
+  std::array<double, 3> m_abc_radii;
   /// inner radii
-  std::vector<double> m_abc_radiiBackgroundInner;
+  std::array<double, 3> m_abc_radiiBackgroundInner;
   /// outer radii
-  std::vector<double> m_abc_radiiBackgroundOuter;
+  std::array<double, 3> m_abc_radiiBackgroundOuter;
 };
 
 using PeakShapeEllipsoid_sptr = std::shared_ptr<PeakShapeEllipsoid>;

--- a/Framework/DataObjects/src/CoordTransformDistance.cpp
+++ b/Framework/DataObjects/src/CoordTransformDistance.cpp
@@ -54,6 +54,28 @@ CoordTransformDistance::CoordTransformDistance(
   }
 }
 
+CoordTransformDistance::CoordTransformDistance(
+    const size_t inD, const coord_t *center, const bool *dimensionsUsed,
+    const size_t outD, const std::array<Kernel::V3D, 3> &eigenvects,
+    const std::array<double, 3> &eigenvals)
+    : CoordTransform(inD, outD) {
+
+  m_center.reserve(inD);
+  m_dimensionsUsed.reserve(inD);
+  m_eigenvals.reserve(inD);
+  m_maxEigenval = 0.0;
+  for (size_t d = 0; d < inD; d++) {
+    m_center.push_back(center[d]);
+    m_dimensionsUsed.push_back(dimensionsUsed[d]);
+    if (eigenvals.size() == inD && eigenvects.size() == inD) {
+      // coord transform for n-ellipsoid specified
+      m_eigenvals.push_back(eigenvals[d]);
+      m_eigenvects.push_back(eigenvects[d]);
+      m_maxEigenval = std::max(m_maxEigenval, eigenvals[d]);
+    }
+  }
+}
+
 //----------------------------------------------------------------------------------------------
 /** Virtual cloner
  * @return a copy of this object  */

--- a/Framework/DataObjects/src/PeakShapeEllipsoid.cpp
+++ b/Framework/DataObjects/src/PeakShapeEllipsoid.cpp
@@ -14,29 +14,35 @@ namespace Mantid {
 namespace DataObjects {
 
 PeakShapeEllipsoid::PeakShapeEllipsoid(
-    const std::vector<Kernel::V3D> &directions,
-    const std::vector<double> &abcRadii,
-    const std::vector<double> &abcRadiiBackgroundInner,
-    const std::vector<double> &abcRadiiBackgroundOuter,
+    const std::array<Kernel::V3D, 3> &directions,
+    const std::array<double, 3> &abcRadii,
+    const std::array<double, 3> &abcRadiiBackgroundInner,
+    const std::array<double, 3> &abcRadiiBackgroundOuter,
     Kernel::SpecialCoordinateSystem frame, std::string algorithmName,
     int algorithmVersion)
-    : PeakShapeBase(frame, std::move(algorithmName), algorithmVersion),
-      m_directions(directions), m_abc_radii(abcRadii),
-      m_abc_radiiBackgroundInner(abcRadiiBackgroundInner),
-      m_abc_radiiBackgroundOuter(abcRadiiBackgroundOuter) {
+    : PeakShapeBase(frame, std::move(algorithmName), algorithmVersion) {
 
   if (directions.size() != 3) {
     throw std::invalid_argument("directions must be of size 3");
   }
+  std::copy_n(directions.begin(), 3, m_directions.begin());
+
   if (abcRadii.size() != 3) {
     throw std::invalid_argument("radii must be of size 3");
   }
+  std::copy_n(abcRadii.begin(), 3, m_abc_radii.begin());
+
   if (abcRadiiBackgroundInner.size() != 3) {
     throw std::invalid_argument("radii inner must be of size 3");
   }
+  std::copy_n(abcRadiiBackgroundInner.begin(), 3,
+              m_abc_radiiBackgroundInner.begin());
+
   if (abcRadiiBackgroundOuter.size() != 3) {
     throw std::invalid_argument("radii outer must be of size 3");
   }
+  std::copy_n(abcRadiiBackgroundOuter.begin(), 3,
+              m_abc_radiiBackgroundOuter.begin());
 }
 
 bool PeakShapeEllipsoid::operator==(const PeakShapeEllipsoid &other) const {
@@ -47,19 +53,21 @@ bool PeakShapeEllipsoid::operator==(const PeakShapeEllipsoid &other) const {
          other.abcRadiiBackgroundOuter() == this->abcRadiiBackgroundOuter();
 }
 
-const std::vector<double> &PeakShapeEllipsoid::abcRadii() const {
+const std::array<double, 3> &PeakShapeEllipsoid::abcRadii() const {
   return m_abc_radii;
 }
 
-const std::vector<double> &PeakShapeEllipsoid::abcRadiiBackgroundInner() const {
+const std::array<double, 3> &
+PeakShapeEllipsoid::abcRadiiBackgroundInner() const {
   return m_abc_radiiBackgroundInner;
 }
 
-const std::vector<double> &PeakShapeEllipsoid::abcRadiiBackgroundOuter() const {
+const std::array<double, 3> &
+PeakShapeEllipsoid::abcRadiiBackgroundOuter() const {
   return m_abc_radiiBackgroundOuter;
 }
 
-const std::vector<Kernel::V3D> &PeakShapeEllipsoid::directions() const {
+const std::array<Kernel::V3D, 3> &PeakShapeEllipsoid::directions() const {
   return m_directions;
 }
 
@@ -114,21 +122,21 @@ std::string PeakShapeEllipsoid::shapeName() const {
 }
 
 boost::optional<double> PeakShapeEllipsoid::radius(RadiusType type) const {
-  std::vector<double>::const_iterator it;
+  boost::optional<double> radius;
   switch (type) {
   case (RadiusType::Radius):
-    it = std::max_element(m_abc_radii.cbegin(), m_abc_radii.cend());
+    radius = *std::max_element(m_abc_radii.cbegin(), m_abc_radii.cend());
     break;
   case (RadiusType::OuterRadius):
-    it = std::max_element(m_abc_radiiBackgroundOuter.cbegin(),
-                          m_abc_radiiBackgroundOuter.cend());
+    radius = *std::max_element(m_abc_radiiBackgroundOuter.cbegin(),
+                               m_abc_radiiBackgroundOuter.cend());
     break;
   case (RadiusType::InnerRadius):
-    it = std::max_element(m_abc_radiiBackgroundInner.cbegin(),
-                          m_abc_radiiBackgroundInner.cend());
+    radius = *std::max_element(m_abc_radiiBackgroundInner.cbegin(),
+                               m_abc_radiiBackgroundInner.cend());
     break;
   }
-  return boost::optional<double>{*it};
+  return radius;
 }
 
 const std::string PeakShapeEllipsoid::ellipsoidShapeName() {

--- a/Framework/DataObjects/src/PeakShapeEllipsoidFactory.cpp
+++ b/Framework/DataObjects/src/PeakShapeEllipsoidFactory.cpp
@@ -34,25 +34,22 @@ PeakShapeEllipsoidFactory::create(const std::string &source) const {
       const int algorithmVersion(root["algorithm_version"].asInt());
       const auto frame(
           static_cast<SpecialCoordinateSystem>(root["frame"].asInt()));
-      std::vector<double> abcRadii, abcRadiiBackgroundInner,
-          abcRadiiBackgroundOuter;
-      abcRadii.emplace_back(root["radius0"].asDouble());
-      abcRadii.emplace_back(root["radius1"].asDouble());
-      abcRadii.emplace_back(root["radius2"].asDouble());
-      abcRadiiBackgroundInner.emplace_back(
-          root["background_inner_radius0"].asDouble());
-      abcRadiiBackgroundInner.emplace_back(
-          root["background_inner_radius1"].asDouble());
-      abcRadiiBackgroundInner.emplace_back(
-          root["background_inner_radius2"].asDouble());
-      abcRadiiBackgroundOuter.emplace_back(
-          root["background_outer_radius0"].asDouble());
-      abcRadiiBackgroundOuter.emplace_back(
-          root["background_outer_radius1"].asDouble());
-      abcRadiiBackgroundOuter.emplace_back(
-          root["background_outer_radius2"].asDouble());
+      std::array<double, 3> abcRadii;
+      abcRadii[0] = root["radius0"].asDouble();
+      abcRadii[1] = root["radius1"].asDouble();
+      abcRadii[2] = root["radius2"].asDouble();
 
-      std::vector<V3D> directions(3);
+      std::array<double, 3> abcRadiiBackgroundInner;
+      abcRadiiBackgroundInner[0] = root["background_inner_radius0"].asDouble();
+      abcRadiiBackgroundInner[1] = root["background_inner_radius1"].asDouble();
+      abcRadiiBackgroundInner[2] = root["background_inner_radius2"].asDouble();
+
+      std::array<double, 3> abcRadiiBackgroundOuter;
+      abcRadiiBackgroundOuter[0] = root["background_outer_radius0"].asDouble();
+      abcRadiiBackgroundOuter[1] = root["background_outer_radius1"].asDouble();
+      abcRadiiBackgroundOuter[2] = root["background_outer_radius2"].asDouble();
+
+      std::array<V3D, 3> directions;
       directions[0].fromString(root["direction0"].asString());
       directions[1].fromString(root["direction1"].asString());
       directions[2].fromString(root["direction2"].asString());

--- a/Framework/DataObjects/test/PeakShapeEllipsoidFactoryTest.h
+++ b/Framework/DataObjects/test/PeakShapeEllipsoidFactoryTest.h
@@ -72,10 +72,11 @@ public:
 
   void test_create() {
 
-    auto directions = {V3D(1, 0, 0), V3D(0, 1, 0), V3D(0, 0, 1)};
-    const MantidVec abcRadii = {2, 3, 4};
-    const MantidVec abcInnerRadii = {5, 6, 7};
-    const MantidVec abcOuterRadii = {8, 9, 10};
+    const std::array<V3D, 3> directions{
+        {V3D(1, 0, 0), V3D(0, 1, 0), V3D(0, 0, 1)}};
+    const std::array<double, 3> abcRadii{{2, 3, 4}};
+    const std::array<double, 3> abcInnerRadii{{5, 6, 7}};
+    const std::array<double, 3> abcOuterRadii{{8, 9, 10}};
     const SpecialCoordinateSystem frame = Mantid::Kernel::HKL;
     const std::string algorithmName = "foo";
     const int algorithmVersion = 3;

--- a/Framework/DataObjects/test/PeakShapeEllipsoidTest.h
+++ b/Framework/DataObjects/test/PeakShapeEllipsoidTest.h
@@ -30,10 +30,11 @@ public:
   static void destroySuite(PeakShapeEllipsoidTest *suite) { delete suite; }
 
   void test_constructor() {
-    auto directions = {(V3D(1, 0, 0)), (V3D(0, 1, 0)), (V3D(0, 0, 1))};
-    const MantidVec abcRadii = {2, 3, 4};
-    const MantidVec abcInnerRadii = {5, 6, 7};
-    const MantidVec abcOuterRadii = {8, 9, 10};
+    const std::array<V3D, 3> directions{(V3D(1, 0, 0)), (V3D(0, 1, 0)),
+                                        (V3D(0, 0, 1))};
+    const std::array<double, 3> abcRadii{{2, 3, 4}};
+    const std::array<double, 3> abcInnerRadii{{5, 6, 7}};
+    const std::array<double, 3> abcOuterRadii{{8, 9, 10}};
     const SpecialCoordinateSystem frame = Mantid::Kernel::HKL;
     const std::string algorithmName = "foo";
     const int algorithmVersion = 3;
@@ -51,41 +52,12 @@ public:
     TS_ASSERT_EQUALS(algorithmVersion, shape.algorithmVersion());
   }
 
-  void test_constructor_throws() {
-    auto directions = {V3D(1, 0, 0), V3D(0, 1, 0), V3D(0, 0, 1)};
-    auto bad_directions = {V3D(1, 0, 0)};
-    const MantidVec abcRadii = {2, 3, 4};
-    const MantidVec bad_abcRadii = {2, 3, 4, 5};
-    const MantidVec abcInnerRadii = {5, 6, 7};
-    const MantidVec bad_abcInnerRadii = {5, 6};
-    const MantidVec abcOuterRadii = {8, 9, 10};
-    const MantidVec bad_abcOuterRadii = {8, 9, 10, 11};
-    const SpecialCoordinateSystem frame = Mantid::Kernel::HKL;
-
-    TSM_ASSERT_THROWS("Should throw, bad directions",
-                      PeakShapeEllipsoid(bad_directions, abcRadii,
-                                         abcInnerRadii, abcOuterRadii, frame),
-                      std::invalid_argument &);
-    TSM_ASSERT_THROWS("Should throw, bad radii",
-                      PeakShapeEllipsoid(directions, bad_abcRadii,
-                                         abcInnerRadii, abcOuterRadii, frame),
-                      std::invalid_argument &);
-    TSM_ASSERT_THROWS("Should throw, bad inner radii",
-                      PeakShapeEllipsoid(directions, abcRadii,
-                                         bad_abcInnerRadii, abcOuterRadii,
-                                         frame),
-                      std::invalid_argument &);
-    TSM_ASSERT_THROWS("Should throw, bad outer radii",
-                      PeakShapeEllipsoid(directions, abcRadii, abcInnerRadii,
-                                         bad_abcOuterRadii, frame),
-                      std::invalid_argument &);
-  }
-
   void test_copy_constructor() {
-    auto directions = {V3D(1, 0, 0), V3D(0, 1, 0), V3D(0, 0, 1)};
-    const MantidVec abcRadii = {2, 3, 4};
-    const MantidVec abcInnerRadii = {5, 6, 7};
-    const MantidVec abcOuterRadii = {8, 9, 10};
+    const std::array<V3D, 3> directions{
+        {V3D(1, 0, 0), V3D(0, 1, 0), V3D(0, 0, 1)}};
+    const std::array<double, 3> abcRadii{{2, 3, 4}};
+    const std::array<double, 3> abcInnerRadii{{5, 6, 7}};
+    const std::array<double, 3> abcOuterRadii{{8, 9, 10}};
     const SpecialCoordinateSystem frame = Mantid::Kernel::HKL;
     const std::string algorithmName = "foo";
     const int algorithmVersion = 3;
@@ -124,7 +96,7 @@ public:
 
   void test_radius() {
 
-    std::vector<double> radius = {1, 2, 3};
+    std::array<double, 3> radius{{1, 2, 3}};
 
     PeakShapeEllipsoid shape({V3D(1, 0, 0), V3D(0, 1, 0), V3D(0, 0, 1)}, radius,
                              radius, radius, Mantid::Kernel::HKL);
@@ -156,10 +128,11 @@ public:
 
   void test_toJSON() {
 
-    std::vector<V3D> directions = {V3D(1, 0, 0), V3D(0, 1, 0), V3D(0, 0, 1)};
-    const MantidVec abcRadii = {2, 3, 4};
-    const MantidVec abcInnerRadii = {5, 6, 7};
-    const MantidVec abcOuterRadii = {8, 9, 10};
+    const std::array<V3D, 3> directions{
+        {V3D(1, 0, 0), V3D(0, 1, 0), V3D(0, 0, 1)}};
+    const std::array<double, 3> abcRadii{{2, 3, 4}};
+    const std::array<double, 3> abcInnerRadii{{5, 6, 7}};
+    const std::array<double, 3> abcOuterRadii{{8, 9, 10}};
     const SpecialCoordinateSystem frame = Mantid::Kernel::HKL;
     const std::string algorithmName = "foo";
     const int algorithmVersion = 3;
@@ -192,10 +165,11 @@ public:
   }
 
   void test_directionsInSpecificFrameThrowsForMatrixWithInvalidDimensions() {
-    auto directions = {V3D(1, 0, 0), V3D(0, 1, 0), V3D(0, 0, 1)};
-    const MantidVec abcRadii = {2, 3, 4};
-    const MantidVec abcInnerRadii = {5, 6, 7};
-    const MantidVec abcOuterRadii = {8, 9, 10};
+    const std::array<V3D, 3> directions{
+        {V3D(1, 0, 0), V3D(0, 1, 0), V3D(0, 0, 1)}};
+    const std::array<double, 3> abcRadii{{2, 3, 4}};
+    const std::array<double, 3> abcInnerRadii{{5, 6, 7}};
+    const std::array<double, 3> abcOuterRadii{{8, 9, 10}};
     const SpecialCoordinateSystem frame = Mantid::Kernel::QLab;
     const std::string algorithmName = "foo";
     const int algorithmVersion = 3;
@@ -222,10 +196,11 @@ public:
   }
 
   void test_directionsInSepcificFrame() {
-    auto directions = {V3D(1, 0, 0), V3D(0, 1, 0), V3D(0, 0, 1)};
-    const MantidVec abcRadii = {2, 3, 4};
-    const MantidVec abcInnerRadii = {5, 6, 7};
-    const MantidVec abcOuterRadii = {8, 9, 10};
+    const std::array<V3D, 3> directions{
+        {V3D(1, 0, 0), V3D(0, 1, 0), V3D(0, 0, 1)}};
+    const std::array<double, 3> abcRadii{{2, 3, 4}};
+    const std::array<double, 3> abcInnerRadii{{5, 6, 7}};
+    const std::array<double, 3> abcOuterRadii{{8, 9, 10}};
     const SpecialCoordinateSystem frame = Mantid::Kernel::QLab;
     const std::string algorithmName = "foo";
     const int algorithmVersion = 3;

--- a/Framework/MDAlgorithms/inc/MantidMDAlgorithms/Integrate3DEvents.h
+++ b/Framework/MDAlgorithms/inc/MantidMDAlgorithms/Integrate3DEvents.h
@@ -82,7 +82,7 @@ public:
   std::shared_ptr<const Mantid::Geometry::PeakShape> ellipseIntegrateEvents(
       const std::vector<Kernel::V3D> &E1Vec, Mantid::Kernel::V3D const &peak_q,
       bool specify_size, double peak_radius, double back_inner_radius,
-      double back_outer_radius, std::vector<double> &axes_radii, double &inti,
+      double back_outer_radius, std::array<double, 3> &axes_radii, double &inti,
       double &sigi);
 
   /// Find the net integrated intensity of a modulated peak, using ellipsoidal
@@ -91,7 +91,7 @@ public:
       const std::vector<Kernel::V3D> &E1Vec, Mantid::Kernel::V3D const &peak_q,
       Mantid::Kernel::V3D const &hkl, Mantid::Kernel::V3D const &mnp,
       bool specify_size, double peak_radius, double back_inner_radius,
-      double back_outer_radius, std::vector<double> &axes_radii, double &inti,
+      double back_outer_radius, std::array<double, 3> &axes_radii, double &inti,
       double &sigi);
 
   /// Find the net integrated intensity of a peak, using ellipsoidal volumes
@@ -118,26 +118,26 @@ private:
   getEvents(const Mantid::Kernel::V3D &peak_q);
 
   bool correctForDetectorEdges(std::tuple<double, double, double> &radii,
-                               const std::vector<Mantid::Kernel::V3D> &E1Vecs,
+                               const std::vector<Kernel::V3D> &E1Vecs,
                                const Mantid::Kernel::V3D &peak_q,
-                               const std::vector<double> &axesRadii,
-                               const std::vector<double> &bkgInnerRadii,
-                               const std::vector<double> &bkgOuterRadii);
+                               const std::array<double, 3> &axesRadii,
+                               const std::array<double, 3> &bkgInnerRadii,
+                               const std::array<double, 3> &bkgOuterRadii);
 
   /// Calculate the number of events in an ellipsoid centered at 0,0,0
   static std::pair<double, double>
   numInEllipsoid(std::vector<std::pair<std::pair<double, double>,
                                        Mantid::Kernel::V3D>> const &events,
-                 std::vector<Mantid::Kernel::V3D> const &directions,
-                 std::vector<double> const &sizes);
+                 std::array<Mantid::Kernel::V3D, 3> const &directions,
+                 std::array<double, 3> const &sizes);
 
   /// Calculate the number of events in an ellipsoid centered at 0,0,0
   static std::pair<double, double>
   numInEllipsoidBkg(std::vector<std::pair<std::pair<double, double>,
                                           Mantid::Kernel::V3D>> const &events,
-                    std::vector<Mantid::Kernel::V3D> const &directions,
-                    std::vector<double> const &sizes,
-                    std::vector<double> const &sizesIn,
+                    const std::array<Kernel::V3D, 3> &directions,
+                    std::array<double, 3> const &sizes,
+                    std::array<double, 3> const &sizesIn,
                     const bool useOnePercentBackgroundCorrection);
 
   /// Calculate the 3x3 covariance matrix of a list of Q-vectors at 0,0,0
@@ -148,8 +148,8 @@ private:
 
   /// Calculate the eigen vectors of a 3x3 real symmetric matrix
   static void getEigenVectors(Kernel::DblMatrix const &cov_matrix,
-                              std::vector<Mantid::Kernel::V3D> &eigen_vectors,
-                              std::vector<double> &eigen_values);
+                              std::array<Kernel::V3D, 3> &eigen_vectors,
+                              std::array<double, 3> &eigen_values);
 
   /// Form a map key as 10^12*h + 10^6*k + l from the integers h, k, l
   static int64_t getHklKey(int h, int k, int l);
@@ -176,15 +176,15 @@ private:
       const std::vector<Kernel::V3D> &E1Vec, Kernel::V3D const &peak_q,
       std::vector<std::pair<std::pair<double, double>,
                             Mantid::Kernel::V3D>> const &ev_list,
-      std::vector<Mantid::Kernel::V3D> const &directions,
-      std::vector<double> const &sigmas, bool specify_size, double peak_radius,
-      double back_inner_radius, double back_outer_radius,
-      std::vector<double> &axes_radii, double &inti, double &sigi);
+      std::array<Mantid::Kernel::V3D, 3> const &directions,
+      std::array<double, 3> const &sigmas, bool specify_size,
+      double peak_radius, double back_inner_radius, double back_outer_radius,
+      std::array<double, 3> &axes_radii, double &inti, double &sigi);
 
   /// Compute if a particular Q falls on the edge of a detector
   double detectorQ(const std::vector<Kernel::V3D> &E1Vec,
                    const Mantid::Kernel::V3D QLabFrame,
-                   const std::vector<double> &r);
+                   const std::array<double, 3> &r);
 
   std::tuple<double, double, double>
   calculateRadiusFactors(const IntegrationParameters &params,

--- a/Framework/MDAlgorithms/inc/MantidMDAlgorithms/IntegratePeaksMD2.h
+++ b/Framework/MDAlgorithms/inc/MantidMDAlgorithms/IntegratePeaksMD2.h
@@ -66,8 +66,8 @@ private:
                      const Mantid::Kernel::V3D &pos,
                      const coord_t &radiusSquared, const bool &qAxisBool,
                      const double &bgDensity,
-                     std::vector<Mantid::Kernel::V3D> &eigenvects,
-                     std::vector<double> &eigenvals);
+                     std::array<Mantid::Kernel::V3D, 3> &eigenvects,
+                     std::array<double, 3> &eigenvals);
 
   // get matrix to transform from Qlab to plane perp to Q
   void getPinv(const Mantid::Kernel::V3D &q,

--- a/Framework/MDAlgorithms/src/Integrate3DEvents.cpp
+++ b/Framework/MDAlgorithms/src/Integrate3DEvents.cpp
@@ -152,11 +152,11 @@ Integrate3DEvents::integrateStrongPeak(const IntegrationParameters &params,
   DblMatrix cov_matrix(3, 3);
   makeCovarianceMatrix(events, cov_matrix, params.regionRadius);
 
-  std::vector<V3D> eigen_vectors;
-  std::vector<double> eigen_values;
+  std::array<V3D, 3> eigen_vectors;
+  std::array<double, 3> eigen_values;
   getEigenVectors(cov_matrix, eigen_vectors, eigen_values);
 
-  std::vector<double> sigmas(3);
+  std::array<double, 3> sigmas;
   for (int i = 0; i < 3; i++) {
     sigmas[i] = sqrt(eigen_values[i]);
   }
@@ -177,12 +177,12 @@ Integrate3DEvents::integrateStrongPeak(const IntegrationParameters &params,
   auto &r1 = std::get<0>(rValues), r2 = std::get<1>(rValues),
        r3 = std::get<2>(rValues);
 
-  std::vector<double> abcBackgroundOuterRadii, abcBackgroundInnerRadii;
-  std::vector<double> peakRadii;
+  std::array<double, 3> abcBackgroundOuterRadii, abcBackgroundInnerRadii;
+  std::array<double, 3> peakRadii;
   for (int i = 0; i < 3; i++) {
-    abcBackgroundOuterRadii.emplace_back(r3 * sigmas[i]);
-    abcBackgroundInnerRadii.emplace_back(r2 * sigmas[i]);
-    peakRadii.emplace_back(r1 * sigmas[i]);
+    abcBackgroundOuterRadii[i] = r3 * sigmas[i];
+    abcBackgroundInnerRadii[i] = r2 * sigmas[i];
+    peakRadii[i] = r1 * sigmas[i];
   }
 
   const auto isPeakOnDetector =
@@ -301,11 +301,11 @@ double Integrate3DEvents::estimateSignalToNoiseRatio(
   DblMatrix cov_matrix(3, 3);
   makeCovarianceMatrix(events, cov_matrix, params.regionRadius);
 
-  std::vector<V3D> eigen_vectors;
-  std::vector<double> eigen_values;
+  std::array<V3D, 3> eigen_vectors;
+  std::array<double, 3> eigen_values;
   getEigenVectors(cov_matrix, eigen_vectors, eigen_values);
 
-  std::vector<double> sigmas(3);
+  std::array<double, 3> sigmas;
   for (int i = 0; i < 3; i++) {
     sigmas[i] = sqrt(eigen_values[i]);
   }
@@ -318,22 +318,22 @@ double Integrate3DEvents::estimateSignalToNoiseRatio(
   auto rValues = calculateRadiusFactors(params, max_sigma);
   auto &r1 = std::get<0>(rValues), r2 = std::get<1>(rValues),
        r3 = std::get<2>(rValues);
-  std::vector<double> abcBackgroundOuterRadii, abcBackgroundInnerRadii;
-  std::vector<double> peakRadii;
+  std::array<double, 3> abcBackgroundOuterRadii, abcBackgroundInnerRadii;
+  std::array<double, 3> peakRadii;
   if (forceSpherical) {
     // test for spherically symmeteric peak (within tolerance)
     if ((max_sigma - min_sigma) / max_sigma > sphericityTol)
       return .0;
     for (int i = 0; i < 3; i++) {
-      abcBackgroundOuterRadii.emplace_back(r3 * max_sigma);
-      abcBackgroundInnerRadii.emplace_back(r2 * max_sigma);
-      peakRadii.emplace_back(r1 * max_sigma);
+      abcBackgroundOuterRadii[i] = r3 * max_sigma;
+      abcBackgroundInnerRadii[i] = r2 * max_sigma;
+      peakRadii[i] = r1 * max_sigma;
     }
   } else {
     for (int i = 0; i < 3; i++) {
-      abcBackgroundOuterRadii.emplace_back(r3 * sigmas[i]);
-      abcBackgroundInnerRadii.emplace_back(r2 * sigmas[i]);
-      peakRadii.emplace_back(r1 * sigmas[i]);
+      abcBackgroundOuterRadii[i] = r3 * sigmas[i];
+      abcBackgroundInnerRadii[i] = r2 * sigmas[i];
+      peakRadii[i] = r1 * sigmas[i];
     }
   }
 
@@ -374,9 +374,9 @@ Integrate3DEvents::getEvents(const V3D &peak_q) {
 
 bool Integrate3DEvents::correctForDetectorEdges(
     std::tuple<double, double, double> &radii, const std::vector<V3D> &E1Vecs,
-    const V3D &peak_q, const std::vector<double> &axesRadii,
-    const std::vector<double> &bkgInnerRadii,
-    const std::vector<double> &bkgOuterRadii) {
+    const V3D &peak_q, const std::array<double, 3> &axesRadii,
+    const std::array<double, 3> &bkgInnerRadii,
+    const std::array<double, 3> &bkgOuterRadii) {
 
   if (E1Vecs.empty())
     return true;
@@ -446,7 +446,7 @@ Mantid::Geometry::PeakShape_const_sptr
 Integrate3DEvents::ellipseIntegrateEvents(
     const std::vector<V3D> &E1Vec, V3D const &peak_q, bool specify_size,
     double peak_radius, double back_inner_radius, double back_outer_radius,
-    std::vector<double> &axes_radii, double &inti, double &sigi) {
+    std::array<double, 3> &axes_radii, double &inti, double &sigi) {
   inti = 0.0; // default values, in case something
   sigi = 0.0; // is wrong with the peak.
 
@@ -472,11 +472,11 @@ Integrate3DEvents::ellipseIntegrateEvents(
   DblMatrix cov_matrix(3, 3);
   makeCovarianceMatrix(some_events, cov_matrix, m_radius);
 
-  std::vector<V3D> eigen_vectors;
-  std::vector<double> eigen_values;
+  std::array<V3D, 3> eigen_vectors;
+  std::array<double, 3> eigen_values;
   getEigenVectors(cov_matrix, eigen_vectors, eigen_values);
 
-  std::vector<double> sigmas(3);
+  std::array<double, 3> sigmas;
   for (int i = 0; i < 3; i++) {
     sigmas[i] = sqrt(eigen_values[i]);
   }
@@ -502,7 +502,7 @@ Integrate3DEvents::ellipseIntegrateModEvents(
     const std::vector<V3D> &E1Vec, V3D const &peak_q, V3D const &hkl,
     V3D const &mnp, bool specify_size, double peak_radius,
     double back_inner_radius, double back_outer_radius,
-    std::vector<double> &axes_radii, double &inti, double &sigi) {
+    std::array<double, 3> &axes_radii, double &inti, double &sigi) {
   inti = 0.0; // default values, in case something
   sigi = 0.0; // is wrong with the peak.
 
@@ -534,11 +534,11 @@ Integrate3DEvents::ellipseIntegrateModEvents(
   else
     makeCovarianceMatrix(some_events, cov_matrix, s_radius);
 
-  std::vector<V3D> eigen_vectors;
-  std::vector<double> eigen_values;
+  std::array<V3D, 3> eigen_vectors;
+  std::array<double, 3> eigen_values;
   getEigenVectors(cov_matrix, eigen_vectors, eigen_values);
 
-  std::vector<double> sigmas(3);
+  std::array<double, 3> sigmas;
   for (int i = 0; i < 3; i++)
     sigmas[i] = sqrt(eigen_values[i]);
 
@@ -572,7 +572,7 @@ Integrate3DEvents::ellipseIntegrateModEvents(
  */
 std::pair<double, double> Integrate3DEvents::numInEllipsoid(
     std::vector<std::pair<std::pair<double, double>, V3D>> const &events,
-    std::vector<V3D> const &directions, std::vector<double> const &sizes) {
+    std::array<V3D, 3> const &directions, const std::array<double, 3> &sizes) {
 
   std::pair<double, double> count(0, 0);
   for (const auto &event : events) {
@@ -608,8 +608,8 @@ std::pair<double, double> Integrate3DEvents::numInEllipsoid(
  */
 std::pair<double, double> Integrate3DEvents::numInEllipsoidBkg(
     std::vector<std::pair<std::pair<double, double>, V3D>> const &events,
-    std::vector<V3D> const &directions, std::vector<double> const &sizes,
-    std::vector<double> const &sizesIn,
+    std::array<V3D, 3> const &directions, const std::array<double, 3> &sizes,
+    const std::array<double, 3> &sizesIn,
     const bool useOnePercentBackgroundCorrection) {
   std::pair<double, double> count(0, 0);
   std::vector<std::pair<double, double>> eventVec;
@@ -702,9 +702,9 @@ void Integrate3DEvents::makeCovarianceMatrix(
  *  @param eigen_values   3 eigenvalues of matrix
  */
 void Integrate3DEvents::getEigenVectors(DblMatrix const &cov_matrix,
-                                        std::vector<V3D> &eigen_vectors,
-                                        std::vector<double> &eigen_values) {
-  unsigned int size = 3;
+                                        std::array<V3D, 3> &eigen_vectors,
+                                        std::array<double, 3> &eigen_values) {
+  const unsigned int size = 3;
 
   gsl_matrix *matrix = gsl_matrix_alloc(size, size);
   gsl_vector *eigen_val = gsl_vector_alloc(size);
@@ -721,10 +721,10 @@ void Integrate3DEvents::getEigenVectors(DblMatrix const &cov_matrix,
 
   // copy the resulting eigen vectors to output vector
   for (size_t col = 0; col < size; col++) {
-    eigen_vectors.emplace_back(gsl_matrix_get(eigen_vec, 0, col),
-                               gsl_matrix_get(eigen_vec, 1, col),
-                               gsl_matrix_get(eigen_vec, 2, col));
-    eigen_values.emplace_back(gsl_vector_get(eigen_val, col));
+    eigen_vectors[col] = V3D(gsl_matrix_get(eigen_vec, 0, col),
+                             gsl_matrix_get(eigen_vec, 1, col),
+                             gsl_matrix_get(eigen_vec, 2, col));
+    eigen_values[col] = gsl_vector_get(eigen_val, col);
   }
 
   gsl_matrix_free(matrix);
@@ -1107,9 +1107,9 @@ PeakShapeEllipsoid_const_sptr Integrate3DEvents::ellipseIntegrateEvents(
     const std::vector<V3D> &E1Vec, V3D const &peak_q,
     std::vector<std::pair<std::pair<double, double>, Mantid::Kernel::V3D>> const
         &ev_list,
-    std::vector<V3D> const &directions, std::vector<double> const &sigmas,
+    std::array<V3D, 3> const &directions, std::array<double, 3> const &sigmas,
     bool specify_size, double peak_radius, double back_inner_radius,
-    double back_outer_radius, std::vector<double> &axes_radii, double &inti,
+    double back_outer_radius, std::array<double, 3> &axes_radii, double &inti,
     double &sigi) {
   // r1, r2 and r3 will give the sizes of the major axis of
   // the peak ellipsoid, and of the inner and outer surface
@@ -1147,15 +1147,14 @@ PeakShapeEllipsoid_const_sptr Integrate3DEvents::ellipseIntegrateEvents(
     }
   }
 
-  axes_radii.clear();
-  std::vector<double> abcBackgroundOuterRadii;
-  std::vector<double> abcBackgroundInnerRadii;
-  std::vector<double> abcRadii;
+  std::array<double, 3> abcBackgroundOuterRadii;
+  std::array<double, 3> abcBackgroundInnerRadii;
+  std::array<double, 3> abcRadii;
   for (int i = 0; i < 3; i++) {
-    abcBackgroundOuterRadii.emplace_back(r3 * sigmas[i]);
-    abcBackgroundInnerRadii.emplace_back(r2 * sigmas[i]);
-    abcRadii.emplace_back(r1 * sigmas[i]);
-    axes_radii.emplace_back(r1 * sigmas[i]);
+    abcBackgroundOuterRadii[i] = r3 * sigmas[i];
+    abcBackgroundInnerRadii[i] = r2 * sigmas[i];
+    abcRadii[i] = r1 * sigmas[i];
+    axes_radii[i] = r1 * sigmas[i];
   }
 
   if (!E1Vec.empty()) {
@@ -1209,9 +1208,9 @@ PeakShapeEllipsoid_const_sptr Integrate3DEvents::ellipseIntegrateEvents(
  * @param QLabFrame: The Peak center.
  * @param r: Peak radius.
  */
-double Integrate3DEvents::detectorQ(const std::vector<V3D> &E1Vec,
+double Integrate3DEvents::detectorQ(const std::vector<Kernel::V3D> &E1Vec,
                                     const V3D QLabFrame,
-                                    const std::vector<double> &r) {
+                                    const std::array<double, 3> &r) {
   double quot = 1.0;
   for (auto &E1 : E1Vec) {
     V3D distv =

--- a/Framework/MDAlgorithms/src/IntegrateEllipsoids.cpp
+++ b/Framework/MDAlgorithms/src/IntegrateEllipsoids.cpp
@@ -549,7 +549,7 @@ void IntegrateEllipsoids::exec() {
       BackgroundInnerRadiusVector[i] = adaptiveBack_inner_radius;
       BackgroundOuterRadiusVector[i] = adaptiveBack_outer_radius;
 
-      std::vector<double> axes_radii;
+      std::array<double, 3> axes_radii;
       Mantid::Geometry::PeakShape_const_sptr shape =
           integrator.ellipseIntegrateModEvents(
               E1Vec, peak_q, hkl, mnp, specify_size, adaptiveRadius,
@@ -653,7 +653,7 @@ void IntegrateEllipsoids::exec() {
         if (Geometry::IndexingUtils::ValidIndex(hkl, 1.0) ||
             Geometry::IndexingUtils::ValidIndex(mnp, 1.0)) {
           const V3D peak_q = peaks[i].getQLabFrame();
-          std::vector<double> axes_radii;
+          std::array<double, 3> axes_radii;
           integrator.ellipseIntegrateModEvents(
               E1Vec, peak_q, hkl, mnp, specify_size, peak_radius,
               back_inner_radius, back_outer_radius, axes_radii, inti, sigi);

--- a/Framework/MDAlgorithms/test/Integrate3DEventsTest.h
+++ b/Framework/MDAlgorithms/test/Integrate3DEventsTest.h
@@ -102,7 +102,7 @@ public:
     double peak_radius = 1.2;
     double back_inner_radius = 1.2;
     double back_outer_radius = 1.3;
-    std::vector<double> new_sigma;
+    std::array<double, 3> new_sigma;
     std::vector<Kernel::V3D> E1Vec;
     double inti;
     double sigi;
@@ -221,7 +221,7 @@ public:
     double peak_radius = 0.3;
     double back_inner_radius = 0.3;
     double back_outer_radius = 0.35;
-    std::vector<double> new_sigma;
+    std::array<double, 3> new_sigma;
     std::vector<Kernel::V3D> E1Vec;
     double inti;
     double sigi;


### PR DESCRIPTION
Since the underlying objects for Ellipsoids are always length 3, change the code to use fixed length arrays. There are various knock-on effects for other code that intersects this, but it should allow the compiler to deal with memory more efficiently which should have a positive effect on performance with a larger number of peaks (think protein crystallography).

**To test:**

This is a refactor with no other intended effects. If the tests pass, it was done correctly.

*There is no associated issue.*

*This does not require release notes* because it is a change to internal data structures.

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
