### PR TITLE
Fix the bug preventing the user from moving the camera after using reset view

### DIFF
--- a/qt/widgets/instrumentview/src/InstrumentWidgetRenderTab.cpp
+++ b/qt/widgets/instrumentview/src/InstrumentWidgetRenderTab.cpp
@@ -627,6 +627,7 @@ void InstrumentWidgetRenderTab::flipUnwrappedView(bool on) {
 void InstrumentWidgetRenderTab::resetView() {
   // just recreate the surface from scratch
   m_instrWidget->setSurfaceType(int(m_instrWidget->getSurfaceType()));
+  m_instrWidget->getSurface()->setInteractionMode(ProjectionSurface::MoveMode);
 }
 
 /**


### PR DESCRIPTION
**Description of work.**
Allows the user to move the camera when they clicked `Reset view` in the instrument viewer.
Forces the interaction mode of the surface rendered back to `move` after resetting the view, instead of getting stuck in another mode.
<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

**To test:**
   - Open an instrument in the instrument viewer
   - Set the view to Full 3D
   - Go to the draw tab and check Draw Rectangle
   - Go back to the render tab and click Reset view
   - Try moving around

<!-- Instructions for testing. -->

Fixes #30394 . <!-- and fix #xxxx or close #xxxx xor resolves #xxxx -->
<!-- alternative
*There is no associated issue.*
-->

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or master)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
