### PR TITLE
Plot Script Generator: Add support for ticks and gridlines

### DIFF
--- a/docs/source/release/v6.0.0/mantidworkbench.rst
+++ b/docs/source/release/v6.0.0/mantidworkbench.rst
@@ -43,6 +43,7 @@ Improvements
 - A system to group samples and avoid repetition in DrILL has been added. See the :ref:`DrILL documentation <DrILL-ref>` for more information.
 - In the plot config, multiple curves can be selected and removed at once. The delete key was added as a shortcut.
 - A bug has been fixed in SliceViewer where attempting to plot a workspace with a text axis would cause a crash when zoomed out.
+- Improved plot generated scripts to better support major and minor tick settings at time of generation.
 
 Bugfixes
 ########

--- a/qt/applications/workbench/workbench/plotting/plotscriptgenerator/__init__.py
+++ b/qt/applications/workbench/workbench/plotting/plotscriptgenerator/__init__.py
@@ -15,8 +15,7 @@ from workbench.plotting.plotscriptgenerator.axes import (generate_axis_limit_com
                                                          generate_axis_label_commands,
                                                          generate_set_title_command,
                                                          generate_axis_scale_commands,
-                                                         generate_tick_commands,
-                                                         generate_grid_commands)
+                                                         generate_tick_commands)
 from workbench.plotting.plotscriptgenerator.figure import generate_subplots_command
 from workbench.plotting.plotscriptgenerator.lines import generate_plot_command
 from workbench.plotting.plotscriptgenerator.colorfills import generate_plot_2d_command
@@ -73,7 +72,6 @@ def generate_script(fig, exclude_headers=False):
             plot_commands.extend(get_plot_cmds(ax, ax_object_var))  # ax.plot
 
         plot_commands.extend(generate_tick_commands(ax))
-        plot_commands.extend(generate_grid_commands(ax))
         plot_commands.extend(get_title_cmds(ax, ax_object_var))  # ax.set_title
         plot_commands.extend(get_axis_label_cmds(ax, ax_object_var))  # ax.set_label
         plot_commands.extend(get_axis_limit_cmds(ax, ax_object_var))  # ax.set_lim

--- a/qt/applications/workbench/workbench/plotting/plotscriptgenerator/axes.py
+++ b/qt/applications/workbench/workbench/plotting/plotscriptgenerator/axes.py
@@ -53,26 +53,23 @@ def generate_axis_scale_commands(ax):
     return commands
 
 
+def generate_tick_params_kwargs(axis, tick_type="major"):
+    return getattr(axis, f"_{tick_type}_tick_kw")
+
+
 def generate_tick_commands(ax):
     commands = []
-    if not isinstance(ax.xaxis.minor.locator, NullLocator):
-        commands.append("axes.minorticks_on()")
+    
+    for tick_type in ["minor", "major"]:
+        if not isinstance(getattr(ax.xaxis, tick_type).locator, NullLocator):
+            if tick_type == "minor":
+                commands.append("axes.minorticks_on()")
 
-        if hasattr(ax, 'show_minor_gridlines'):
-            commands.append(f"axes.show_minor_gridlines = {ax.show_minor_gridlines}")
+            if isinstance(getattr(ax.xaxis, f"{tick_type}Ticks"), list) and \
+                    len(getattr(ax.xaxis, f"{tick_type}Ticks")) > 0:
+                commands.append(f"axes.tick_params(axis='x', which='{tick_type}', **"
+                                f"{generate_tick_params_kwargs(ax.xaxis, tick_type)})")
+                commands.append(f"axes.tick_params(axis='y', which='{tick_type}', **"
+                                f"{generate_tick_params_kwargs(ax.yaxis, tick_type)})")
 
     return commands
-
-
-def generate_grid_commands(ax):
-    if ax.xaxis._gridOnMajor and ax.yaxis._gridOnMajor:
-        axis = 'both'
-    elif ax.xaxis._gridOnMajor:
-        axis = 'x'
-    elif ax.yaxis._gridOnMajor:
-        axis = 'y'
-    else:
-        return []
-
-    which = 'both' if hasattr(ax, 'show_minor_gridlines') and ax.show_minor_gridlines else 'major'
-    return [f"axes.grid(True, axis='{axis}', which='{which}')"]

--- a/qt/applications/workbench/workbench/plotting/plotscriptgenerator/axes.py
+++ b/qt/applications/workbench/workbench/plotting/plotscriptgenerator/axes.py
@@ -59,7 +59,7 @@ def generate_tick_params_kwargs(axis, tick_type="major"):
 
 def generate_tick_commands(ax):
     commands = []
-    
+
     for tick_type in ["minor", "major"]:
         if not isinstance(getattr(ax.xaxis, tick_type).locator, NullLocator):
             if tick_type == "minor":

--- a/qt/applications/workbench/workbench/plotting/plotscriptgenerator/test/test_plotscriptgenerator.py
+++ b/qt/applications/workbench/workbench/plotting/plotscriptgenerator/test/test_plotscriptgenerator.py
@@ -216,51 +216,6 @@ class PlotScriptGeneratorTest(unittest.TestCase):
 
         self.assertIn('axes.minorticks_on()', generate_script(mock_fig))
 
-    @patch(GET_AUTOSCALE_LIMITS)
-    @patch(GEN_WS_RETRIEVAL_CMDS)
-    @patch(GEN_PLOT_CMDS)
-    @patch(GEN_SUBPLOTS_CMD)
-    def test_generate_script_adds_show_minor_gridlines_command_if_axes_has_attribute(self,
-                                                                                     mock_subplots_cmd,
-                                                                                     mock_plot_cmd,
-                                                                                     mock_retrieval_cmd,
-                                                                                     mock_autoscale_lims):
-        mock_retrieval_cmd.return_value = self.retrieval_cmds
-        mock_subplots_cmd.return_value = self.subplots_cmd
-        mock_plot_cmd.return_value = self.plot_cmd
-        mock_autoscale_lims.return_value = (-0.02, 1.02)
-
-        mock_ax = self._gen_mock_axes()
-        mock_ax.xaxis.minor.locator = Mock()
-        mock_ax.show_minor_gridlines = True
-        mock_fig = Mock(get_axes=lambda: [mock_ax])
-        mock_fig.canvas.manager.fit_browser.fit_result_ws_name = ""
-
-        self.assertIn('axes.show_minor_gridlines = True', generate_script(mock_fig))
-
-    @patch(GET_AUTOSCALE_LIMITS)
-    @patch(GEN_WS_RETRIEVAL_CMDS)
-    @patch(GEN_PLOT_CMDS)
-    @patch(GEN_SUBPLOTS_CMD)
-    def test_generate_script_adds_grid_command_if_axes_has_grid(self,
-                                                                mock_subplots_cmd,
-                                                                mock_plot_cmd,
-                                                                mock_retrieval_cmd,
-                                                                mock_autoscale_lims):
-        mock_retrieval_cmd.return_value = self.retrieval_cmds
-        mock_subplots_cmd.return_value = self.subplots_cmd
-        mock_plot_cmd.return_value = self.plot_cmd
-        mock_autoscale_lims.return_value = (-0.02, 1.02)
-
-        mock_ax = self._gen_mock_axes()
-        mock_ax.show_minor_gridlines = True
-        mock_ax.xaxis._gridOnMajor = True
-        mock_ax.yaxis._gridOnMajor = True
-        mock_fig = Mock(get_axes=lambda: [mock_ax])
-        mock_fig.canvas.manager.fit_browser.fit_result_ws_name = ""
-
-        self.assertIn('axes.grid(True, axis=\'both\', which=\'both\')', generate_script(mock_fig))
-
     @patch(GET_FIT_COMMANDS)
     @patch(GET_AUTOSCALE_LIMITS)
     @patch(GEN_AXIS_LIMIT_CMDS)
@@ -292,6 +247,43 @@ class PlotScriptGeneratorTest(unittest.TestCase):
 
         output_script = generate_script(mock_fig, exclude_headers=True)
         self.assertEqual(SAMPLE_SCRIPT_WITH_FIT, output_script)
+
+    @patch(GET_AUTOSCALE_LIMITS)
+    @patch(GEN_WS_RETRIEVAL_CMDS)
+    @patch(GEN_PLOT_CMDS)
+    @patch(GEN_SUBPLOTS_CMD)
+    def test_generate_script_adds_minor_and_major_tick_kw(self,
+                                                          mock_subplots_cmd,
+                                                          mock_plot_cmd,
+                                                          mock_retrieval_cmd,
+                                                          mock_autoscale_lims):
+        mock_retrieval_cmd.return_value = self.retrieval_cmds
+        mock_subplots_cmd.return_value = self.subplots_cmd
+        mock_plot_cmd.return_value = self.plot_cmd
+        mock_autoscale_lims.return_value = (-0.02, 1.02)
+
+        mock_ax = self._gen_mock_axes()
+        mock_ax.xaxis.minor.locator = Mock()
+        mock_ax.xaxis.major.locator = Mock()
+        mock_ax.xaxis.majorTicks = [None]
+        mock_ax.xaxis.minorTicks = [None]
+
+        # If this fails then the internals of matplotlib have changed, and axes.py for ticks needs to be re-thought.
+        # This fails because it is an object being made to the spec defined in matplotlib so should definetely contain
+        # This object, mock or not.
+        self.assertTrue(hasattr(mock_ax.xaxis, "_major_tick_kw"))
+        self.assertTrue(hasattr(mock_ax.xaxis, "_minor_tick_kw"))
+        mock_minor_kw = "{gridOn: False, show: True, width: 6, length: 10}"
+        mock_major_kw = "{gridOn: True, show: True, width: 20, length: 15}"
+        mock_ax.xaxis._major_tick_kw = mock_major_kw
+        mock_ax.xaxis._minor_tick_kw = mock_minor_kw
+
+        mock_fig = Mock(get_axes=lambda: [mock_ax])
+        mock_fig.canvas.manager.fit_browser.fit_result_ws_name = ""
+
+        commands = generate_script(mock_fig)
+        self.assertIn(mock_major_kw, commands)
+        self.assertIn(mock_minor_kw, commands)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
**Description of work.**
Adds support for minor ticks and minor gridlines to the generation of scripts.

**To test:**
Go to settings > Plots
Check show Minor Ticks and Minor Gridlines
Check all ticks positions
Change the width/length of major and minor ticks to exaggerated values to see a difference
Close
Load some data
Plot some spectra and see the plot has the settings of what you just changed
Now copy script to clipboard
Now close the plot, paste the script and run
The plot should be the same
<!-- Instructions for testing. -->

Fixes #30337  <!-- and fix #xxxx or close #xxxx xor resolves #xxxx -->

<!-- Ensure the base of this PR is correct (e.g. release-next or master)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
