### PR TITLE
Fixed bug with minor peak 

### DIFF
--- a/docs/source/release/v6.0.0/muon.rst
+++ b/docs/source/release/v6.0.0/muon.rst
@@ -59,7 +59,7 @@ Elemental Analysis
 New Features
 ############
 - Added a new XrayAbsorptionCorrection algorithm. See :ref:`XrayAbsorptionCorrection <algm-XrayAbsorptionCorrection>`
-- Fixed bug in GUI where minor peaks wouldn't be plotted on new detector when checkbox clicked.
+- Fixed bug in GUI where minor peaks wouldn't be added to a new detector subplot
 
 Bug fixes
 #########

--- a/docs/source/release/v6.0.0/muon.rst
+++ b/docs/source/release/v6.0.0/muon.rst
@@ -59,6 +59,7 @@ Elemental Analysis
 New Features
 ############
 - Added a new XrayAbsorptionCorrection algorithm. See :ref:`XrayAbsorptionCorrection <algm-XrayAbsorptionCorrection>`
+- Fixed bug in GUI where minor peaks wouldn't be plotted on new detector when checkbox clicked.
 
 Bug fixes
 #########

--- a/scripts/Muon/GUI/ElementalAnalysis/elemental_analysis.py
+++ b/scripts/Muon/GUI/ElementalAnalysis/elemental_analysis.py
@@ -357,6 +357,7 @@ class ElementalAnalysisGui(QtWidgets.QMainWindow):
         # not using load_last_run prevents two calls to last_loaded_run()
         if last_run is not None:
             self.load_run(detector, last_run)
+            self._update_checked_data()
 
     def del_plot(self, checkbox):
         if self.load_widget.last_loaded_run() is not None:


### PR DESCRIPTION
**Description of work.**
Fixed issue with minor peaks not plotting on a new detector when selected  on elemental analysis gui.

**Report to:** Adrian Hillier

<!-- Instructions for testing. -->
1.Put Sundials into your Data search directories in MUD (Contact myself or @AnthonyLim23)
2.Enter 2695 and click Load.
3.Plot detector GE1
4.Ensure major peaks and minor peaks are selected.
5.Select Fe button on periodic table.
6.Select Ge2 , All lines present in Ge1 should be present in Ge2.

Fixes #30387. 

<!-- Ensure the base of this PR is correct (e.g. release-next or master)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
