### PR TITLE
Update status of fit in fit browser during Sequential Fit in EngDiff UI

### DIFF
--- a/docs/source/release/v6.0.0/diffraction.rst
+++ b/docs/source/release/v6.0.0/diffraction.rst
@@ -73,6 +73,7 @@ Improvements
 ############
 - The user is no longer asked to overwrite an automatically generated model that is saved in as a Custom Setup in the fit browser (it is overwritten).
 - Generic Sequential Fit button removed from fit menu (users should use sequential fit button below the table in the fitting tab of the UI).
+- Status of fit updated in fit browser when Sequential Fit performed in the fittinng tab of the UI.
 
 New features
 ############

--- a/qt/python/mantidqt/_common.sip
+++ b/qt/python/mantidqt/_common.sip
@@ -594,7 +594,7 @@ signals:
     void sequentialFitDone() const;
     void workspaceClicked(const QString &);
     void removePlotSignal(PropertyHandler *);
-
+    void fitResultsChanged(const QString &);
 };
 
 // ---------------------------------

--- a/scripts/Engineering/gui/engineering_diffraction/tabs/fitting/plotting/plot_presenter.py
+++ b/scripts/Engineering/gui/engineering_diffraction/tabs/fitting/plotting/plot_presenter.py
@@ -8,6 +8,7 @@ from mantidqt.utils.observer_pattern import GenericObserverWithArgPassing, Gener
 from Engineering.gui.engineering_diffraction.tabs.fitting.plotting.plot_model import FittingPlotModel
 from Engineering.gui.engineering_diffraction.tabs.fitting.plotting.plot_view import FittingPlotView
 from mantid.simpleapi import Fit, logger
+from copy import deepcopy
 
 PLOT_KWARGS = {"linestyle": "", "marker": "x", "markersize": "3"}
 
@@ -59,6 +60,8 @@ class FittingPlotPresenter(object):
             fit_output = Fit(**fitprop['properties'])
             fitprop['properties']['Function'] = str(fit_output.Function.fun)
             # save setup in fitprop browser (updates browser for next iteration of loop)
-            self.view.update_browser_setup(fitprop['properties']['Function'], ws)
-            fitprop_list.append(fitprop)
+            self.view.update_browser(fit_output.OutputStatus, fitprop['properties']['Function'], ws)
+            # append a deep copy to output list
+            fitprop_list.append(deepcopy(fitprop))
+        logger.notice('Sequential fitting finished.')
         self.seq_fit_done_notifier.notify_subscribers(fitprop_list)

--- a/scripts/Engineering/gui/engineering_diffraction/tabs/fitting/plotting/plot_view.py
+++ b/scripts/Engineering/gui/engineering_diffraction/tabs/fitting/plotting/plot_view.py
@@ -145,10 +145,12 @@ class FittingPlotView(QtWidgets.QWidget, Ui_plot):
     def read_fitprop_from_browser(self):
         return self.fit_browser.read_current_fitprop()
 
-    def update_browser_setup(self, func_str, setup_name):
-        # update browser with output function and save setup
-        self.fit_browser.loadFunction(func_str)
-        self.fit_browser.save_current_setup(setup_name)
+    def update_browser(self, status, func_str, setup_name):
+        self.fit_browser.fitResultsChanged.emit(status)
+        # update browser with output function and save setup if successful
+        if "success" in status:
+            self.fit_browser.loadFunction(func_str)
+            self.fit_browser.save_current_setup(setup_name)
 
     # =================
     # Component Getters


### PR DESCRIPTION
**Description of work.**

Provides user with a visual prompt to indicate a fit has been performed. This meant exposing a public signal of Fit browser to python.  There is a change in behaviour, the fit browser function/setup will only be updated with the result of a successful fit - as a consequence it is the result of the last successful fit that is used as input to the subsequent fit.

Have also updated test, including checking notifier passes the right argument post completion of sequential fit - which required making a deepcopy of the fit output (this was not necessary for the actual usage of the UI)

**To test:**

This tests the sequential fitting capability of the UI (where the result of a fit to one workspace is used as the initial guess for the next).

1. Load in focussed runs in this zip file [ENGINX_data.zip](https://github.com/mantidproject/mantid/files/5392081/ENGINX_data.zip).
2. Plot a single run, open the fit browser and input a valid fit function (either manually by using the AddPeak etc. or from Setup > Custom Setup).

3. The Sequential Fit button below the table in the UI should now be enabled, click it!

Check the fit browser displays a status - it refers to the last run fitted, so if it is successful check there is a Setup saved in Setup > Custom Setup.

Check in the log at notice level that there is a line that says "Sequential fitting finished."

Fixes #30410 


<!-- Ensure the base of this PR is correct (e.g. release-next or master)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
