### PR TITLE
Check if fit should be enabled after functions removed from fit browser

### DIFF
--- a/docs/source/release/v6.0.0/mantidworkbench.rst
+++ b/docs/source/release/v6.0.0/mantidworkbench.rst
@@ -70,5 +70,6 @@ Bugfixes
 - Fixed a crash in SliceViewer when hovering the cursor over Direct or Indirect data.
 - Fixed a crash when using broken e notation for axis limits in plot settings
 - Fixed a bug in error bars tab in plot settings where the Error Every property was not being shown correctly
+- Fixed a bug where the fit action (Fit > Fit) in the fit browser wasn't disabled if all the functions were individually removed.
 
 :ref:`Release 6.0.0 <v6.0.0>`

--- a/qt/widgets/common/src/PropertyHandler.cpp
+++ b/qt/widgets/common/src/PropertyHandler.cpp
@@ -465,6 +465,7 @@ void PropertyHandler::removeFunction() {
       }
     }
     ph->renameChildren();
+    m_browser->setFitEnabled(cf->nFunctions() > 0);
   }
 }
 


### PR DESCRIPTION
**Description of work.**

Small bug fix to disable fit action (Fit > Fit) in fit browser if there are no functions present.

**To test:**

See instructions on original issue.

Fixes #30415 


<!-- Ensure the base of this PR is correct (e.g. release-next or master)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
