### PR TITLE
Unreliability in DrillTest

### DIFF
--- a/scripts/Interface/ui/drill/test/DrillTest.py
+++ b/scripts/Interface/ui/drill/test/DrillTest.py
@@ -135,10 +135,6 @@ class DrillTest(unittest.TestCase):
     ###########################################################################
 
     def setUp(self):
-        self.facility = config['default.facility']
-        self.instrument = config['default.instrument']
-        config['default.facility'] = "ILL"
-        config['default.instrument'] = "D11"
         # avoid popup messages
         patch = mock.patch('Interface.ui.drill.view.DrillView.QMessageBox')
         self.mMessageBox = patch.start()
@@ -167,6 +163,11 @@ class DrillTest(unittest.TestCase):
         # shown window
         self.view.isHidden = mock.Mock()
         self.view.isHidden.return_value = False
+
+        self.facility = config['default.facility']
+        self.instrument = config['default.instrument']
+        config['default.facility'] = "ILL"
+        config['default.instrument'] = "D11"
 
     def tearDown(self):
         config['default.facility'] = self.facility


### PR DESCRIPTION
**Description of work.**

This PR corrects the unreliability observed with DrillTest. The reported error was:
`AttributeError: 'DrillControllerSignals' does not have a signal with the signature instrumentChanged(QString)`

The error is most likely due to a race condition when running the tests suite. This led to a function call on the wrong object.

Because InstrumentSelector widget observes the ConfigService, changes of the configuration are now moved after that the InstrumentSelector listener is properly constructed. With this, the signal emitted by InstrumentSelector when the configuration is modified must find its way to the correct slot.

**To test:**

The bug can be reproduced in the `mantidproject/mantid-development-centos7` docker container.

*This does not require release notes*, internal changes only.

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
