### PR TITLE
Make the Indirect unit tests run on Qt5

### DIFF
--- a/qt/scientific_interfaces/Indirect/test/CMakeLists.txt
+++ b/qt/scientific_interfaces/Indirect/test/CMakeLists.txt
@@ -32,7 +32,7 @@ set(CXXTEST_EXTRA_HEADER_INCLUDE
 
 mtd_add_qt_tests(
   TARGET_NAME MantidQtInterfacesIndirectTest
-  QT_VERSION 4
+  QT_VERSION 5
   SRC ${TEST_FILES}
   INCLUDE_DIRS
     ../../../../Framework/CurveFitting/inc
@@ -53,11 +53,16 @@ mtd_add_qt_tests(
     gmock
     ${POCO_LIBRARIES}
     ${Boost_LIBRARIES}
-  QT4_LINK_LIBS
-    Qwt5
+    PythonInterfaceCore
+    ${PYTHON_LIBRARIES}
+  QT5_LINK_LIBS
+    Qt5::OpenGL
+    Qt5::Concurrent
   MTD_QT_LINK_LIBS
     MantidScientificInterfacesIndirect
     MantidQtWidgetsCommon
     MantidQtWidgetsPlotting
+    MantidQtWidgetsMplCpp
   PARENT_DEPENDENCIES
     GUITests)
+

--- a/qt/scientific_interfaces/Indirect/test/IndirectDataTablePresenterTest.h
+++ b/qt/scientific_interfaces/Indirect/test/IndirectDataTablePresenterTest.h
@@ -110,6 +110,8 @@ public:
                     IDA::WorkspaceIndex spectrum));
   MOCK_METHOD2(setResolution,
                void(const std::string &name, TableDatasetIndex index));
+  MOCK_METHOD2(setExcludeRegion,
+               void(const std::string &exclude, FitDomainIndex index));
 
   MOCK_CONST_METHOD1(getWorkspace,
                      Mantid::API::MatrixWorkspace_sptr(FitDomainIndex index));

--- a/qt/scientific_interfaces/Indirect/test/IndirectPlotterTest.h
+++ b/qt/scientific_interfaces/Indirect/test/IndirectPlotterTest.h
@@ -16,6 +16,7 @@
 #include "MantidAPI/MatrixWorkspace.h"
 #include "MantidDataObjects/Workspace2D.h"
 #include "MantidKernel/WarningSuppressions.h"
+#include "MantidQtWidgets/MplCpp/BackendQt.h"
 #include "MantidTestHelpers/WorkspaceCreationHelper.h"
 
 using namespace Mantid::API;
@@ -60,6 +61,7 @@ GNU_DIAG_ON_SUGGEST_OVERRIDE
 class IndirectPlotterTest : public CxxTest::TestSuite {
 public:
   IndirectPlotterTest() : m_ads(AnalysisDataService::Instance()) {
+    MantidQt::Widgets::MplCpp::backendModule();
     m_ads.clear();
   }
 
@@ -86,22 +88,18 @@ public:
     TS_ASSERT(m_plotter);
   }
 
-  void
-  test_that_plotSpectra_will_attempt_to_run_python_code_using_the_IPyRunner() {
+  void test_that_plotSpectra_will_not_throw() {
     m_ads.addOrReplace(WORKSPACE_NAME, createMatrixWorkspace(5, 5));
 
-    EXPECT_CALL(*m_pyRunner, runPythonCode(_)).Times(1);
-
-    m_plotter->plotSpectra(WORKSPACE_NAME, WORKSPACE_INDICES);
+    TS_ASSERT_THROWS_NOTHING(
+        m_plotter->plotSpectra(WORKSPACE_NAME, WORKSPACE_INDICES));
   }
 
-  void
-  test_that_plotBins_will_attempt_to_run_python_code_using_the_IPyRunner() {
+  void test_that_plotBins_will_not_throw() {
     m_ads.addOrReplace(WORKSPACE_NAME, createMatrixWorkspace(5, 5));
 
-    EXPECT_CALL(*m_pyRunner, runPythonCode(_)).Times(1);
-
-    m_plotter->plotBins(WORKSPACE_NAME, WORKSPACE_INDICES);
+    TS_ASSERT_THROWS_NOTHING(
+        m_plotter->plotBins(WORKSPACE_NAME, WORKSPACE_INDICES));
   }
 
   void

--- a/qt/scientific_interfaces/Indirect/test/InterfacesIndirectTestInitialization.h
+++ b/qt/scientific_interfaces/Indirect/test/InterfacesIndirectTestInitialization.h
@@ -6,6 +6,7 @@
 // SPDX - License - Identifier: GPL - 3.0 +
 #pragma once
 
+#include "MantidPythonInterface/core/Testing/PythonInterpreterGlobalFixture.h"
 #include "MantidQtWidgets/Common/Testing/QApplicationGlobalFixture.h"
 
 //------------------------------------------------------------------------------
@@ -14,4 +15,5 @@
 // We rely on cxxtest only including this file once so that the following
 // statements do not cause multiple-definition errors.
 //------------------------------------------------------------------------------
+static PythonInterpreterGlobalFixture PYTHON_INTERPRETER;
 static QApplicationGlobalFixture MAIN_QAPPLICATION;


### PR DESCRIPTION
**Description of work.**

This PR makes the indirect interface unit tests run on Qt5

**To test:**

check that the indirect unit test project is in the Qt5 set and that they run on jenkins

Fixes #30422 

*This does not require release notes* because it is an internal chaneg to the unit tests.

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
