### PR TITLE
Check log exists in workspace before calculating average when loading focussed data in EngDiffUI fitting tab

### DIFF
--- a/docs/source/release/v6.0.0/diffraction.rst
+++ b/docs/source/release/v6.0.0/diffraction.rst
@@ -67,7 +67,9 @@ Engineering Diffraction
 
 Bugfixes
 ############
+- Check if log in settings exists in workspace before averaging when focussed data is loaded in EngDiff UI fitting tab.
 - Settings are now saved only when the Apply or OK button are clicked (i.e. clicking cancel will not update the settings).
+
 
 Improvements
 ############


### PR DESCRIPTION
**Description of work.**

Now check that a workspace has a log entry before calculating, this was previously just caught with a try/except. Now an error is avoided and a different warning is provided. This allows the user to distinguishes between two scenarios: the log doesn't exist in the workspace, or AverageLogData failed (which sometimes happens for very old data because I think the name of the proton_charge log was changed).

Added test coverage for the different scenarios when writing the log values to tables.

**To test:**

See instructions on original issue.
Check there is no error thrown and instead a warning is printed to the log saying the logs do not exist on the workspace. The log tables should be filled with NaN values.

Fixes #30427 
<!-- alternative
*There is no associated issue.*
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or master)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
