### PR TITLE
Add semi axis length options to IntegratePeaksMD for ellipsoid integration

### DIFF
--- a/Framework/Crystal/src/PeakIntensityVsRadius.cpp
+++ b/Framework/Crystal/src/PeakIntensityVsRadius.cpp
@@ -187,9 +187,11 @@ void PeakIntensityVsRadius::exec() {
                                    progStep *double(step + 1), false);
     alg->setProperty("InputWorkspace", inWS);
     alg->setProperty("PeaksWorkspace", peaksWS);
-    alg->setProperty("PeakRadius", radius);
-    alg->setProperty("BackgroundOuterRadius", OuterRadius);
-    alg->setProperty("BackgroundInnerRadius", InnerRadius);
+    alg->setProperty<std::vector<double>>("PeakRadius", {radius});
+    alg->setProperty<std::vector<double>>("BackgroundOuterRadius",
+                                          {OuterRadius});
+    alg->setProperty<std::vector<double>>("BackgroundInnerRadius",
+                                          {InnerRadius});
     alg->setPropertyValue("OutputWorkspace", "__tmp__PeakIntensityVsRadius");
     alg->execute();
     if (alg->isExecuted()) {

--- a/Framework/MDAlgorithms/inc/MantidMDAlgorithms/IntegratePeaksMD2.h
+++ b/Framework/MDAlgorithms/inc/MantidMDAlgorithms/IntegratePeaksMD2.h
@@ -52,6 +52,8 @@ private:
   /// Run the algorithm
   void exec() override;
 
+  std::map<std::string, std::string> validateInputs() override;
+
   template <typename MDE, size_t nd>
   void integrate(typename DataObjects::MDEventWorkspace<MDE, nd>::sptr ws);
 

--- a/Framework/MDAlgorithms/src/IntegratePeaksMD2.cpp
+++ b/Framework/MDAlgorithms/src/IntegratePeaksMD2.cpp
@@ -445,27 +445,10 @@ void IntegratePeaksMD2::integrate(typename MDEventWorkspace<MDE, nd>::sptr ws) {
               bgDensity, eigenvects, eigenvals);
         } else {
           eigenvals = PeakRadius;
-          Matrix<double> idenMat = Matrix<double>(3, 3, true);
-          // idenMat = idenMat * eigenvals;
-          eigenvects.push_back(
-              V3D(idenMat[0][0], idenMat[0][1], idenMat[0][2]));
-          eigenvects.push_back(
-              V3D(idenMat[1][0], idenMat[1][1], idenMat[1][2]));
-          eigenvects.push_back(
-              V3D(idenMat[2][0], idenMat[2][1], idenMat[2][2]));
+          eigenvects.push_back(V3D(1.0, 0.0, 0.0));
+          eigenvects.push_back(V3D(0.0, 1.0, 0.0));
+          eigenvects.push_back(V3D(0.0, 0.0, 1.0));
         }
-
-        /*
-        g_log.notice() << "----- Eigenvects: \n";
-        for(uint ii = 0; ii < eigenvects.size(); ii++) {
-          g_log.notice() << ii << ": " << eigenvects[ii].X() << ", " <<
-        eigenvects[ii].Y() << ", " << eigenvects[ii].Z() << "\n";
-        }
-        g_log.notice() << "----- Eigenvals: \n";
-        for(uint ii = 0; ii < eigenvals.size(); ii++) {
-          g_log.notice() << ii << ": " << eigenvals[ii] << "\n";
-        }
-        */
 
         // transform ellispoid onto sphere of radius = R
         getRadiusSq =

--- a/Framework/MDAlgorithms/src/IntegratePeaksMD2.cpp
+++ b/Framework/MDAlgorithms/src/IntegratePeaksMD2.cpp
@@ -503,7 +503,9 @@ void IntegratePeaksMD2::integrate(typename MDEventWorkspace<MDE, nd>::sptr ws) {
         } else {
           // Use the manually specified radii instead of finding them via
           // findEllipsoid
-          eigenvals = PeakRadius;
+          std::transform(PeakRadius.begin(), PeakRadius.end(),
+                         std::back_inserter(eigenvals),
+                         [](double &r) { return std::pow(r, 2.0); });
           eigenvects.push_back(V3D(1.0, 0.0, 0.0));
           eigenvects.push_back(V3D(0.0, 1.0, 0.0));
           eigenvects.push_back(V3D(0.0, 0.0, 1.0));

--- a/Framework/MDAlgorithms/src/IntegratePeaksMD2.cpp
+++ b/Framework/MDAlgorithms/src/IntegratePeaksMD2.cpp
@@ -541,24 +541,9 @@ void IntegratePeaksMD2::integrate(typename MDEventWorkspace<MDE, nd>::sptr ws) {
           std::vector<double> backgroundOuterRadii(3, 0.0);
           for (size_t irad = 0; irad < peakRadii.size(); irad++) {
             auto scale = pow(eigenvals[irad], 0.5) / max_stdev;
-            if (manualEllip) {
-              peakRadii[irad] = PeakRadius[irad];
-            } else {
-              peakRadii[irad] = PeakRadiusVector[i] * scale;
-            }
-
-            if (BackgroundInnerRadius.size() == 1) {
-              backgroundInnerRadii[irad] =
-                  BackgroundInnerRadiusVector[i] * scale;
-            } else {
-              backgroundInnerRadii[irad] = BackgroundInnerRadius[irad];
-            }
-            if (BackgroundOuterRadius.size() == 1) {
-              backgroundOuterRadii[irad] =
-                  BackgroundOuterRadiusVector[i] * scale;
-            } else {
-              backgroundOuterRadii[irad] = BackgroundOuterRadius[irad];
-            }
+            peakRadii[irad] = PeakRadiusVector[i] * scale;
+            backgroundInnerRadii[irad] = BackgroundInnerRadiusVector[i] * scale;
+            backgroundOuterRadii[irad] = BackgroundOuterRadiusVector[i] * scale;
           }
           PeakShape *ellipsoidShape = new PeakShapeEllipsoid(
               eigenvects, peakRadii, backgroundInnerRadii, backgroundOuterRadii,

--- a/Framework/MDAlgorithms/test/IntegratePeaksMD2Test.h
+++ b/Framework/MDAlgorithms/test/IntegratePeaksMD2Test.h
@@ -52,7 +52,7 @@ public:
 
   //-------------------------------------------------------------------------------
   /** Run the IntegratePeaksMD2 with the given peak radius integration param */
-  static void doRun(double PeakRadius, double BackgroundRadius,
+  static void doRun(std::vector<double> PeakRadius, double BackgroundRadius,
                     std::string OutputWorkspace = "IntegratePeaksMD2Test_peaks",
                     double BackgroundStartRadius = 0.0, bool edge = true,
                     bool cyl = false, std::string fnct = "NoFit",
@@ -219,7 +219,7 @@ public:
     AnalysisDataService::Instance().add("IntegratePeaksMD2Test_peaks", peakWS0);
 
     // ------------- Integrating with cylinder ------------------------
-    doRun(0.1, 0.0, "IntegratePeaksMD2Test_peaks", 0.0, true, true);
+    doRun({0.1}, 0.0, "IntegratePeaksMD2Test_peaks", 0.0, true, true);
 
     TS_ASSERT_DELTA(peakWS0->getPeak(0).getIntensity(), 2.0, 1e-2);
 
@@ -228,7 +228,7 @@ public:
 
     // Test profile Gaussian
     std::string fnct = "Gaussian";
-    doRun(0.1, 0.0, "IntegratePeaksMD2Test_peaks", 0.0, true, true, fnct);
+    doRun({0.1}, 0.0, "IntegratePeaksMD2Test_peaks", 0.0, true, true, fnct);
     // More accurate integration changed values
     TS_ASSERT_DELTA(peakWS0->getPeak(0).getIntensity(), 2.0, 1e-2);
     // Error is also calculated
@@ -240,7 +240,7 @@ public:
 
     // Test profile back to back exponential
     fnct = "BackToBackExponential";
-    doRun(0.1, 0.0, "IntegratePeaksMD2Test_peaks", 0.0, true, true, fnct);
+    doRun({0.1}, 0.0, "IntegratePeaksMD2Test_peaks", 0.0, true, true, fnct);
 
     // TS_ASSERT_DELTA( peakWS0->getPeak(0).getIntensity(), 2.0, 0.2);
     // Error is also calculated
@@ -262,7 +262,7 @@ public:
     // ------------- Adaptive Integration r=MQ+b where b is PeakRadius and m is
     // 0.01 ------------------------
     peakWS0->addPeak(Peak(inst, 15050, 1.0, V3D(2., 3., 4.)));
-    doRun(0.1, 0.0, "IntegratePeaksMD2Test_peaks", 0.0, true, false, "NoFit",
+    doRun({0.1}, 0.0, "IntegratePeaksMD2Test_peaks", 0.0, true, false, "NoFit",
           0.01);
     TS_ASSERT_DELTA(peakWS0->getPeak(1).getIntensity(), 29.0, 1e-2);
 
@@ -271,7 +271,7 @@ public:
 
     // ------------- Integrate with 0.1 radius but IntegrateIfOnEdge
     // false------------------------
-    doRun(0.1, 0.0, "IntegratePeaksMD2Test_peaks", 0.0, false);
+    doRun({0.1}, 0.0, "IntegratePeaksMD2Test_peaks", 0.0, false);
 
     TS_ASSERT_DELTA(peakWS0->getPeak(0).getIntensity(), 2.0, 1e-2);
 
@@ -290,7 +290,7 @@ public:
     AnalysisDataService::Instance().add("IntegratePeaksMD2Test_peaks", peakWS);
 
     // ------------- Integrate with 1.0 radius ------------------------
-    doRun(1.0, 0.0);
+    doRun({1.0}, 0.0);
 
     TS_ASSERT_DELTA(peakWS->getPeak(0).getIntensity(), 1000.0, 1e-2);
     TS_ASSERT_DELTA(peakWS->getPeak(1).getIntensity(), 1000.0, 1e-2);
@@ -304,7 +304,7 @@ public:
                     sqrt(peakWS->getPeak(2).getIntensity()), 1e-2);
 
     // ------------- Let's do it again with 2.0 radius ------------------------
-    doRun(2.0, 0.0);
+    doRun({2.0}, 0.0);
 
     // All peaks are fully contained
     TS_ASSERT_DELTA(peakWS->getPeak(0).getIntensity(), 1000.0, 1e-2);
@@ -312,7 +312,7 @@ public:
     TS_ASSERT_DELTA(peakWS->getPeak(2).getIntensity(), 1000.0, 1e-2);
 
     // ------------- Let's do it again with 0.5 radius ------------------------
-    doRun(0.5, 0.0);
+    doRun({0.5}, 0.0);
 
     TS_ASSERT_DELTA(peakWS->getPeak(0).getIntensity(), 125.0, 10.0);
     TS_ASSERT_DELTA(peakWS->getPeak(1).getIntensity(), 1000.0, 1e-2);
@@ -324,7 +324,7 @@ public:
 
     // ------------- Integrate with 1.0 radius and 2.0
     // background------------------------
-    doRun(1.0, 2.0);
+    doRun({1.0}, 2.0);
     // Same 1000 since the background (~125) was subtracted, with some random
     // variation of the BG around
     //    TS_ASSERT_DELTA( peakWS->getPeak(0).getIntensity(), 1000.0, 10.0);
@@ -346,7 +346,7 @@ public:
 
     // ------------- Integrating without the background gives higher counts
     // ------------------------
-    doRun(1.0, 0.0);
+    doRun({1.0}, 0.0);
 
     // +125 counts due to background
     TS_ASSERT_DELTA(peakWS->getPeak(0).getIntensity(), 1125.0, 10.0);
@@ -374,7 +374,7 @@ public:
     AnalysisDataService::Instance().add("IntegratePeaksMD2Test_peaks", peakWS);
 
     // Integrate and copy to a new peaks workspace
-    doRun(1.0, 0.0, "IntegratePeaksMD2Test_peaks_out");
+    doRun({1.0}, 0.0, "IntegratePeaksMD2Test_peaks_out");
 
     // Old workspace is unchanged
     TS_ASSERT_EQUALS(peakWS->getPeak(0).getIntensity(), 0.0);
@@ -412,7 +412,7 @@ public:
                                                  peakWS);
 
     // First, a check with no background
-    doRun(1.0, 0.0, "IntegratePeaksMD2Test_peaks", 0.0);
+    doRun({1.0}, 0.0, "IntegratePeaksMD2Test_peaks", 0.0);
     // approx. + 500 + 333 counts due to 2 backgrounds
     TS_ASSERT_DELTA(peakWS->getPeak(0).getIntensity(), 1000 + 500 + 333, 30.0);
     TSM_ASSERT_DELTA("Simple sqrt() error",
@@ -421,7 +421,7 @@ public:
     // Set background from 2.0 to 3.0.
     // So the 1/2 density background remains, we subtract the 1/3 density =
     // about 1500 counts
-    doRun(1.0, 3.0, "IntegratePeaksMD2Test_peaks", 2.0);
+    doRun({1.0}, 3.0, "IntegratePeaksMD2Test_peaks", 2.0);
     TS_ASSERT_DELTA(peakWS->getPeak(0).getIntensity(), 1000 + 500, 80.0);
     // Error is larger, since it is error of peak + error of background
     TSM_ASSERT_DELTA("Error has increased",
@@ -429,7 +429,7 @@ public:
 
     // Now do the same without the background start radius
     // So we subtract both densities = a lower count
-    doRun(1.0, 3.0);
+    doRun({1.0}, 3.0);
     TSM_ASSERT_LESS_THAN("Peak intensity is lower if you do not include the "
                          "spacer shell (higher background)",
                          peakWS->getPeak(0).getIntensity(), 1500);
@@ -503,7 +503,7 @@ public:
                                                  peakWS);
 
     // Integrate and copy to a new peaks workspace
-    doRun(peakRadius, bgOuterRadius, "IntegratePeaksMD2Test_peaks_out",
+    doRun({peakRadius}, bgOuterRadius, "IntegratePeaksMD2Test_peaks_out",
           bgInnerRadius, false, /* edge correction */
           false,                /* cylinder*/
           "NoFit", 0.0,         /* adaptive*/
@@ -593,7 +593,7 @@ public:
     const double backgroundOuterRadius = 3;
     const double backgroundInnerRadius = 2.5;
 
-    doRun(peakRadius, backgroundOuterRadius, "OutWS", backgroundInnerRadius);
+    doRun({peakRadius}, backgroundOuterRadius, "OutWS", backgroundInnerRadius);
 
     auto outWS =
         AnalysisDataService::Instance().retrieveWS<PeaksWorkspace>("OutWS");
@@ -631,7 +631,7 @@ public:
     const double backgroundOuterRadius = 3;
     const double backgroundInnerRadius = 2.5;
 
-    doRun(peakRadius, backgroundOuterRadius, "OutWS", backgroundInnerRadius);
+    doRun({peakRadius}, backgroundOuterRadius, "OutWS", backgroundInnerRadius);
 
     PeaksWorkspace_sptr outWS =
         AnalysisDataService::Instance().retrieveWS<PeaksWorkspace>("OutWS");
@@ -731,7 +731,7 @@ public:
 
   void test_performance_NoBackground() {
     for (size_t i = 0; i < 10; i++) {
-      IntegratePeaksMD2Test::doRun(0.02, 0.0);
+      IntegratePeaksMD2Test::doRun({0.02}, 0.0);
     }
     // All peaks should be at least 1000 counts (some might be more if they
     // overla)
@@ -745,7 +745,7 @@ public:
 
   void test_performance_WithBackground() {
     for (size_t i = 0; i < 10; i++) {
-      IntegratePeaksMD2Test::doRun(0.02, 0.03);
+      IntegratePeaksMD2Test::doRun({0.02}, 0.03);
     }
   }
 };

--- a/Framework/MDAlgorithms/test/IntegratePeaksMD2Test.h
+++ b/Framework/MDAlgorithms/test/IntegratePeaksMD2Test.h
@@ -710,7 +710,7 @@ public:
         rad *= ellipsoidRadii[0];
       }
 
-      int ind = isort[ivect];
+      size_t ind = isort[ivect];
       if (ellipsoidRadii.size() == 3) {
         ind = ivect;
       }

--- a/Framework/MDAlgorithms/test/IntegratePeaksMD2Test.h
+++ b/Framework/MDAlgorithms/test/IntegratePeaksMD2Test.h
@@ -561,7 +561,6 @@ public:
     // Test an ellipsoid against theoretical vol
     size_t numEvents = 2000000;
     V3D pos(0.0, 0.0, 0.0); // peak position
-    double peakRad = 1.0;
 
     createMDEW();
 
@@ -570,7 +569,6 @@ public:
     PeaksWorkspace_sptr peakWS(new PeaksWorkspace());
     addUniform(numEvents, {std::make_pair(-0.5, 0.5), std::make_pair(-0.5, 0.5),
                            std::make_pair(-0.5, 0.5)});
-    // addPeak(numEvents, pos[0], pos[1], pos[2], peakRad);
     peakWS->addPeak(Peak(inst, 1, 1.0, pos));
     AnalysisDataService::Instance().addOrReplace("IntegratePeaksMD2Test_peaks",
                                                  peakWS);
@@ -586,7 +584,7 @@ public:
     TS_ASSERT(peakResult);
 
     double ellipInten = peakResult->getPeak(0).getIntensity();
-    double ellipVol = (4.0 / 3.0) * M_PI * numEvents *
+    double ellipVol = (4.0 / 3.0) * M_PI * static_cast<double>(numEvents) *
                       std::accumulate(radii.begin(), radii.end(), 1.0,
                                       std::multiplies<double>());
     TS_ASSERT_DELTA(ellipInten, ellipVol,

--- a/docs/source/algorithms/IntegratePeaksMD-v2.rst
+++ b/docs/source/algorithms/IntegratePeaksMD-v2.rst
@@ -44,12 +44,16 @@ the provided radii. Errors are also summed in quadrature.
    IntegratePeaksMD\_graph1.png
 
 -  All the Radii are specified in :math:`\AA^{-1}`
--  A sphere of radius **PeakRadius** is integrated around the center of
+-  A sphere or ellipsoid of radius **PeakRadius** is integrated around the center of
    each peak.
 
    -  This gives the summed intensity :math:`I_{peak}` and the summed
       squared error :math:`\sigma I_{peak}^2`.
    -  The volume of integration is :math:`V_{peak}`.
+   -  An ellipsoidal shape is integrated when the **Ellipsoid** option is enabled (the following also applies to BackgroundInnerRadius and BackgroundOuterRadius):
+
+      -  When only one value for PeakRadius is given, then the ellipsoidal shape is calculated automatically with axes proportional to the sqrt of the eigenvalues of the covariance matrix.
+      -  Three values for PeakRadius can be given, which correspond to the semi-axis lengths (a,b,c) of the ellipsoid.
 
 -  If **BackgroundOuterRadius** is specified, then a shell, with radius
    r where **BackgroundInnerRadius** < r < **BackgroundOuterRadius**, is

--- a/docs/source/release/v6.1.0/diffraction.rst
+++ b/docs/source/release/v6.1.0/diffraction.rst
@@ -22,4 +22,8 @@ Single Crystal Diffraction
 --------------------------
 - New version of algorithm :ref:`SCDCalibratePanels <algm-SCDCalibratePanels-v2>` provides more accurate calibration results for CORELLI instrument.
 
+Improvements
+############
+- :ref:`IntegratePeaksMD <algm-IntegratePeaksMD>` now allows ellipsoidal shapes to be manually defined for the PeakRadius and Background radii options.
+
 :ref:`Release 6.1.0 <v6.1.0>`


### PR DESCRIPTION
**Description of work.**

This expands the PeakRadius, BackgroundInnerRadius, and BackgroundOuterRadius options in `IntegratePeaksMD` to allow three values to be specified describing the semi-axis lengths of an ellipsoid shape. These can only be specified when the Ellipsoid option is enabled.

**To test:**

<!-- Instructions for testing. -->

Verify that the same result is obtained between normal spherical integration with radius r, and when using Ellipsoid=True with a PeakRadius of r, r, r.

Run the unit tests  `MDAlgorithmsTest IntegratePeaksMD2Test` to make sure they pass.

*There is no associated issue.*

The version into `ornl-next` - #30431

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
