### PR TITLE
Fix bug to ensure engdiffui fit tab gets correct focus filename

### DIFF
--- a/scripts/Engineering/gui/engineering_diffraction/tabs/focus/model.py
+++ b/scripts/Engineering/gui/engineering_diffraction/tabs/focus/model.py
@@ -73,8 +73,6 @@ class FocusModel(object):
                 output_workspaces.append([output_workspace_name])
                 self._save_output(instrument, sample_path, "cropped", output_workspace_name, rb_num)
                 self._output_sample_logs(instrument, run_no, sample_workspace, rb_num)
-        if self._last_path and self._last_path_ws:
-            self._last_path = path.join(self._last_path, self._last_path_ws)
         # Plot the output
         if plot_output:
             for ws_names in output_workspaces:
@@ -145,6 +143,8 @@ class FocusModel(object):
             output_path = path.join(path_handling.get_output_path(), 'User', rb_num, 'Focus')
             logger.notice(f"\n\nFocus files also saved to: \"{output_path}\"\n\n")
         self._last_path = output_path
+        if self._last_path and self._last_path_ws:
+            self._last_path = path.join(self._last_path, self._last_path_ws)
 
     def _save_focused_output_files_as_gss(self, instrument, sample_path, bank, sample_workspace,
                                           rb_num):

--- a/scripts/Engineering/gui/engineering_diffraction/tabs/focus/model.py
+++ b/scripts/Engineering/gui/engineering_diffraction/tabs/focus/model.py
@@ -61,8 +61,6 @@ class FocusModel(object):
                     workspaces_for_run.append(output_workspace_name)
                     # Save the output to the file system.
                     self._save_output(instrument, sample_path, name, output_workspace_name, rb_num)
-                    if name == banks[0] and sample_path == sample_paths[0]:
-                        self._last_path_ws = (instrument + '_' + run_no + '_bank_' + name + '.nxs')
                 output_workspaces.append(workspaces_for_run)
                 self._output_sample_logs(instrument, run_no, sample_workspace, rb_num)
         else:
@@ -75,10 +73,8 @@ class FocusModel(object):
                 output_workspaces.append([output_workspace_name])
                 self._save_output(instrument, sample_path, "cropped", output_workspace_name, rb_num)
                 self._output_sample_logs(instrument, run_no, sample_workspace, rb_num)
-        if rb_num:
-            self._last_path = path.join(path_handling.get_output_path(), rb_num, 'Focus', str(self._last_path_ws))
-        else:
-            self._last_path = path.join(path_handling.get_output_path(), 'Focus', str(self._last_path_ws))
+        if self._last_path and self._last_path_ws:
+            self._last_path = path.join(self._last_path, self._last_path_ws)
         # Plot the output
         if plot_output:
             for ws_names in output_workspaces:
@@ -143,10 +139,12 @@ class FocusModel(object):
                                                rb_num)
         self._save_focused_output_files_as_topas_xye(instrument, sample_path, bank, sample_workspace,
                                                      rb_num)
-        logger.notice(f"\n\nFocus files saved to: \"{path.join(path_handling.get_output_path(), 'Focus')}\"\n\n")
+        output_path = path.join(path_handling.get_output_path(), 'Focus')
+        logger.notice(f"\n\nFocus files saved to: \"{output_path}\"\n\n")
         if rb_num:
             output_path = path.join(path_handling.get_output_path(), 'User', rb_num, 'Focus')
-            logger.notice(f"\n\nFocus files saved to: \"{output_path}\"\n\n")
+            logger.notice(f"\n\nFocus files also saved to: \"{output_path}\"\n\n")
+        self._last_path = output_path
 
     def _save_focused_output_files_as_gss(self, instrument, sample_path, bank, sample_workspace,
                                           rb_num):
@@ -162,15 +160,15 @@ class FocusModel(object):
 
     def _save_focused_output_files_as_nexus(self, instrument, sample_path, bank, sample_workspace,
                                             rb_num):
+        file_name = self._generate_output_file_name(instrument, sample_path, bank, ".nxs")
         nexus_output_path = path.join(
-            path_handling.get_output_path(), "Focus",
-            self._generate_output_file_name(instrument, sample_path, bank, ".nxs"))
+            path_handling.get_output_path(), "Focus", file_name)
         SaveNexus(InputWorkspace=sample_workspace, Filename=nexus_output_path)
         if rb_num:
             nexus_output_path = path.join(
-                path_handling.get_output_path(), "User", rb_num, "Focus",
-                self._generate_output_file_name(instrument, sample_path, bank, ".nxs"))
+                path_handling.get_output_path(), "User", rb_num, "Focus", file_name)
             SaveNexus(InputWorkspace=sample_workspace, Filename=nexus_output_path)
+        self._last_path_ws = file_name
 
     def _save_focused_output_files_as_topas_xye(self, instrument, sample_path, bank,
                                                 sample_workspace, rb_num):

--- a/scripts/Engineering/gui/engineering_diffraction/tabs/focus/test/test_focus_model.py
+++ b/scripts/Engineering/gui/engineering_diffraction/tabs/focus/test/test_focus_model.py
@@ -160,6 +160,34 @@ class FocusModelTest(unittest.TestCase):
         self.assertEqual(1, mock_logger.information.call_count)
         self.assertEqual(4, mock_writer.writerow.call_count)
 
+    @patch(file_path + ".SaveFocusedXYE")
+    @patch(file_path + ".SaveGSS")
+    @patch(file_path + ".SaveNexus")
+    def test_last_path_updates_with_no_RB_number(self, nexus, gss, xye):
+        mocked_workspace = "mocked-workspace"
+        output_file = path.join(path_handling.get_output_path(), "Focus",
+                                "ENGINX_123_bank_North.nxs")
+
+        self.model._last_path_ws = 'ENGINX_123_bank_North.nxs'
+        self.model._save_output("ENGINX", "Path/To/ENGINX000123.whatever", "North",
+                                mocked_workspace, None)
+
+        self.assertEqual(self.model._last_path, output_file)
+
+    @patch(file_path + ".SaveFocusedXYE")
+    @patch(file_path + ".SaveGSS")
+    @patch(file_path + ".SaveNexus")
+    def test_last_path_updates_with_RB_number(self, nexus, gss, xye):
+        mocked_workspace = "mocked-workspace"
+        rb_num = '2'
+        output_file = path.join(path_handling.get_output_path(), "User", rb_num, "Focus", "ENGINX_123_bank_North.nxs")
+
+        self.model._last_path_ws = 'ENGINX_123_bank_North.nxs'
+        self.model._save_output("ENGINX", "Path/To/ENGINX000123.whatever", "North",
+                                mocked_workspace, rb_num)
+
+        self.assertEqual(self.model._last_path, output_file)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
**Description of work.**
The filename input in the fitting tab is supposed to update with the most recently focused .nxs file, but this would only work in the event that an rb number was not supplied, as this would change the directory. This fixes that to ensure that the correct filename will be displayed in any case

**To test:**
1. Interfaces -> Diffraction -> Engineering Diffraction
2. Load a calibration file e.g
[ENGINX_307521_305738_all_banks.zip](https://github.com/mantidproject/mantid/files/5848295/ENGINX_307521_305738_all_banks.zip)
3. Focus a run in the focus tab e.g 307561
4. Make sure the file path in the fitting tab is valid
5. Focus again after giving an rb number in the input at the top of the interface
6. Make sure the path is valid again

Fixes #30333 . <!-- and fix #xxxx or close #xxxx xor resolves #xxxx -->
<!-- alternative
*There is no associated issue.*
-->

*This does not require release notes* because **it is a very small bugfix**


<!-- Ensure the base of this PR is correct (e.g. release-next or master)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
