### PR TITLE
Unset factories for tree data managers just to be safe

### DIFF
--- a/qt/scientific_interfaces/Indirect/FunctionTemplateBrowser.cpp
+++ b/qt/scientific_interfaces/Indirect/FunctionTemplateBrowser.cpp
@@ -38,12 +38,12 @@ FunctionTemplateBrowser::FunctionTemplateBrowser(QWidget *parent)
     : QWidget(parent), m_decimals(6) {}
 
 FunctionTemplateBrowser::~FunctionTemplateBrowser() {
-  // m_browser->unsetFactoryForManager(m_stringManager);
-  // m_browser->unsetFactoryForManager(m_doubleManager);
-  // m_browser->unsetFactoryForManager(m_intManager);
-  // m_browser->unsetFactoryForManager(m_boolManager);
-  // m_browser->unsetFactoryForManager(m_enumManager);
-  // m_browser->unsetFactoryForManager(m_parameterManager);
+  m_browser->unsetFactoryForManager(m_stringManager);
+  m_browser->unsetFactoryForManager(m_doubleManager);
+  m_browser->unsetFactoryForManager(m_intManager);
+  m_browser->unsetFactoryForManager(m_boolManager);
+  m_browser->unsetFactoryForManager(m_enumManager);
+  m_browser->unsetFactoryForManager(m_parameterManager);
 }
 
 void FunctionTemplateBrowser::createBrowser() {

--- a/qt/scientific_interfaces/Indirect/FunctionTemplateBrowser.cpp
+++ b/qt/scientific_interfaces/Indirect/FunctionTemplateBrowser.cpp
@@ -37,6 +37,15 @@ namespace IDA {
 FunctionTemplateBrowser::FunctionTemplateBrowser(QWidget *parent)
     : QWidget(parent), m_decimals(6) {}
 
+FunctionTemplateBrowser::~FunctionTemplateBrowser() {
+  // m_browser->unsetFactoryForManager(m_stringManager);
+  // m_browser->unsetFactoryForManager(m_doubleManager);
+  // m_browser->unsetFactoryForManager(m_intManager);
+  // m_browser->unsetFactoryForManager(m_boolManager);
+  // m_browser->unsetFactoryForManager(m_enumManager);
+  // m_browser->unsetFactoryForManager(m_parameterManager);
+}
+
 void FunctionTemplateBrowser::createBrowser() {
   m_stringManager = new QtStringPropertyManager(this);
   m_doubleManager = new QtDoublePropertyManager(this);

--- a/qt/scientific_interfaces/Indirect/FunctionTemplateBrowser.h
+++ b/qt/scientific_interfaces/Indirect/FunctionTemplateBrowser.h
@@ -44,7 +44,7 @@ class MANTIDQT_INDIRECT_DLL FunctionTemplateBrowser : public QWidget {
   Q_OBJECT
 public:
   FunctionTemplateBrowser(QWidget *parent);
-  virtual ~FunctionTemplateBrowser() = default;
+  virtual ~FunctionTemplateBrowser();
   void init();
 
   virtual void setFunction(const QString &funStr) = 0;

--- a/qt/scientific_interfaces/Indirect/ISISCalibration.cpp
+++ b/qt/scientific_interfaces/Indirect/ISISCalibration.cpp
@@ -195,10 +195,10 @@ ISISCalibration::ISISCalibration(IndirectDataReduction *idrUI, QWidget *parent)
                                QString const &)));
 }
 
-//----------------------------------------------------------------------------------------------
-/** Destructor
- */
-ISISCalibration::~ISISCalibration() {}
+ISISCalibration::~ISISCalibration() {
+  m_propTrees["CalPropTree"]->unsetFactoryForManager(m_dblManager);
+  m_propTrees["ResPropTree"]->unsetFactoryForManager(m_dblManager);
+}
 
 std::pair<double, double> ISISCalibration::peakRange() const {
   return std::make_pair(m_dblManager->value(m_properties["CalPeakMin"]),

--- a/qt/scientific_interfaces/Indirect/ISISDiagnostics.cpp
+++ b/qt/scientific_interfaces/Indirect/ISISDiagnostics.cpp
@@ -149,7 +149,10 @@ ISISDiagnostics::ISISDiagnostics(IndirectDataReduction *idrUI, QWidget *parent)
 //----------------------------------------------------------------------------------------------
 /** Destructor
  */
-ISISDiagnostics::~ISISDiagnostics() {}
+ISISDiagnostics::~ISISDiagnostics() {
+  m_propTrees["SlicePropTree"]->unsetFactoryForManager(m_dblManager);
+  m_propTrees["SlicePropTree"]->unsetFactoryForManager(m_blnManager);
+}
 
 void ISISDiagnostics::setup() {}
 

--- a/qt/scientific_interfaces/Indirect/IndirectBayesTab.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectBayesTab.cpp
@@ -18,7 +18,9 @@ IndirectBayesTab::IndirectBayesTab(QWidget *parent)
           SLOT(updateProperties(QtProperty *, double)));
 }
 
-IndirectBayesTab::~IndirectBayesTab() {}
+IndirectBayesTab::~IndirectBayesTab() {
+  m_propTree->unsetFactoryForManager(m_dblManager);
+}
 
 /**
  * Prevents the loading of data with incorrect naming if passed true

--- a/qt/scientific_interfaces/Indirect/IndirectDataAnalysisElwinTab.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectDataAnalysisElwinTab.cpp
@@ -105,6 +105,11 @@ IndirectDataAnalysisElwinTab::IndirectDataAnalysisElwinTab(QWidget *parent)
       m_uiForm.ipoPlotOptions, this, PlotWidget::Spectra));
 }
 
+IndirectDataAnalysisElwinTab::~IndirectDataAnalysisElwinTab() {
+  m_elwTree->unsetFactoryForManager(m_dblManager);
+  m_elwTree->unsetFactoryForManager(m_blnManager);
+}
+
 void IndirectDataAnalysisElwinTab::setup() {
   // Create QtTreePropertyBrowser object
   m_elwTree = new QtTreePropertyBrowser();

--- a/qt/scientific_interfaces/Indirect/IndirectDataAnalysisElwinTab.h
+++ b/qt/scientific_interfaces/Indirect/IndirectDataAnalysisElwinTab.h
@@ -18,6 +18,7 @@ class DLLExport IndirectDataAnalysisElwinTab : public IndirectDataAnalysisTab {
 
 public:
   IndirectDataAnalysisElwinTab(QWidget *parent = nullptr);
+  ~IndirectDataAnalysisElwinTab();
 
 private:
   void run() override;

--- a/qt/scientific_interfaces/Indirect/IndirectDataAnalysisIqtTab.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectDataAnalysisIqtTab.cpp
@@ -155,6 +155,10 @@ IndirectDataAnalysisIqtTab::IndirectDataAnalysisIqtTab(QWidget *parent)
       m_uiForm.ipoPlotOptions, this, PlotWidget::SpectraTiled));
 }
 
+IndirectDataAnalysisIqtTab::~IndirectDataAnalysisIqtTab() {
+  m_iqtTree->unsetFactoryForManager(m_dblManager);
+}
+
 void IndirectDataAnalysisIqtTab::setup() {
   m_iqtTree = new QtTreePropertyBrowser();
   m_uiForm.properties->addWidget(m_iqtTree);

--- a/qt/scientific_interfaces/Indirect/IndirectDataAnalysisIqtTab.h
+++ b/qt/scientific_interfaces/Indirect/IndirectDataAnalysisIqtTab.h
@@ -17,6 +17,7 @@ class DLLExport IndirectDataAnalysisIqtTab : public IndirectDataAnalysisTab {
 
 public:
   IndirectDataAnalysisIqtTab(QWidget *parent = nullptr);
+  ~IndirectDataAnalysisIqtTab();
 
 private:
   void run() override;

--- a/qt/scientific_interfaces/Indirect/IndirectMoments.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectMoments.cpp
@@ -84,7 +84,9 @@ IndirectMoments::IndirectMoments(IndirectDataReduction *idrUI, QWidget *parent)
 //----------------------------------------------------------------------------------------------
 /** Destructor
  */
-IndirectMoments::~IndirectMoments() {}
+IndirectMoments::~IndirectMoments() {
+  m_propTrees["MomentsPropTree"]->unsetFactoryForManager(m_dblManager);
+}
 
 void IndirectMoments::setup() {}
 

--- a/qt/scientific_interfaces/Indirect/IndirectSymmetrise.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectSymmetrise.cpp
@@ -162,10 +162,9 @@ IndirectSymmetrise::IndirectSymmetrise(IndirectDataReduction *idrUI,
   m_uiForm.dsInput->isForRunFiles(false);
 }
 
-//----------------------------------------------------------------------------------------------
-/** Destructor
- */
-IndirectSymmetrise::~IndirectSymmetrise() {}
+IndirectSymmetrise::~IndirectSymmetrise() {
+  m_propTrees["SymmPropTree"]->unsetFactoryForManager(m_dblManager);
+}
 
 void IndirectSymmetrise::setup() {}
 

--- a/qt/scientific_interfaces/Indirect/test/CMakeLists.txt
+++ b/qt/scientific_interfaces/Indirect/test/CMakeLists.txt
@@ -4,6 +4,9 @@ set(
   ConvFitDataPresenterTest.h
   ConvFitModelTest.h
   ConvFunctionModelTest.h
+  FqFitDataPresenterTest.h
+  FqFitModelTest.h
+  IDAFunctionParameterEstimationTest.h
   IndirectDataValidationHelperTest.h
   IndirectDataTablePresenterTest.h
   IndirectFitAnalysisTabTest.h
@@ -22,9 +25,6 @@ set(
   IndirectSettingsPresenterTest.h
   IndirectSpectrumSelectionPresenterTest.h
   IqtFitModelTest.h
-  FqFitDataPresenterTest.h
-  FqFitModelTest.h
-  IDAFunctionParameterEstimationTest.h
 )
 
 set(CXXTEST_EXTRA_HEADER_INCLUDE

--- a/qt/widgets/instrumentview/inc/MantidQtWidgets/InstrumentView/InstrumentWidgetMaskTab.h
+++ b/qt/widgets/instrumentview/inc/MantidQtWidgets/InstrumentView/InstrumentWidgetMaskTab.h
@@ -73,6 +73,7 @@ public:
   };
 
   explicit InstrumentWidgetMaskTab(InstrumentWidget *instrWidget);
+  ~InstrumentWidgetMaskTab();
   void initSurface() override;
   void setMode(Mode mode);
   void selectTool(Activity tool);

--- a/qt/widgets/instrumentview/src/InstrumentWidgetMaskTab.cpp
+++ b/qt/widgets/instrumentview/src/InstrumentWidgetMaskTab.cpp
@@ -370,6 +370,10 @@ InstrumentWidgetMaskTab::InstrumentWidgetMaskTab(InstrumentWidget *instrWidget)
           SLOT(enableApplyButtons()));
 }
 
+InstrumentWidgetMaskTab::~InstrumentWidgetMaskTab() {
+  m_browser->unsetFactoryForManager(m_doubleManager);
+}
+
 /**
  * Initialize the tab when new projection surface is created.
  */


### PR DESCRIPTION
**Description of work.**
This PR ensures that the factories for managers used in a `QtTreePropertyBrowser` are unset when an interface is destroyed. This is a safety precaution against potential unreliable errors that could occur as seen in #30418 .

The majority of the changes required were in the Indirect interfaces.

*No release notes required as this bug is hard to reproduce, and so will not have been noticed by a user.*

**To test:**
Code review

Fixes #30419

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
