### PR TITLE
Stop StartX and EndX Going Beyond Limits Of The Data In ALC Baseline Modelling

### DIFF
--- a/docs/source/release/v6.0.0/muon.rst
+++ b/docs/source/release/v6.0.0/muon.rst
@@ -63,7 +63,7 @@ Bug fixes
 - A bug has been fixed where exported results were unintentionally being mixed together in their group workspaces.
 - A bug has been fixed where the Load button had to be pressed twice after an initial batch of runs had already been loaded.
 - A bug has been fixed where the log was being reset when loading runs after an initial batch of runs.
-- Fixed a bug where you could move startx and endx markers past the limits of the data in baseline modelling.
+- A bug has been fixed where you could move startx and endx markers past the limits of the data in baseline modelling.
 
 Elemental Analysis
 ------------------

--- a/docs/source/release/v6.0.0/muon.rst
+++ b/docs/source/release/v6.0.0/muon.rst
@@ -63,7 +63,7 @@ Bug fixes
 - A bug has been fixed where exported results were unintentionally being mixed together in their group workspaces.
 - A bug has been fixed where the Load button had to be pressed twice after an initial batch of runs had already been loaded.
 - A bug has been fixed where the log was being reset when loading runs after an initial batch of runs.
-- Fixed a bug where you could move startx and endx markers past the limits of the data in baseline modelling 
+- Fixed a bug where you could move startx and endx markers past the limits of the data in baseline modelling.
 
 Elemental Analysis
 ------------------

--- a/docs/source/release/v6.0.0/muon.rst
+++ b/docs/source/release/v6.0.0/muon.rst
@@ -63,6 +63,7 @@ Bug fixes
 - A bug has been fixed where exported results were unintentionally being mixed together in their group workspaces.
 - A bug has been fixed where the Load button had to be pressed twice after an initial batch of runs had already been loaded.
 - A bug has been fixed where the log was being reset when loading runs after an initial batch of runs.
+- Fixed a bug where you could move startx and endx markers past the limits of the data in baseline modelling 
 
 Elemental Analysis
 ------------------

--- a/qt/scientific_interfaces/Muon/ALCBaselineModellingView.cpp
+++ b/qt/scientific_interfaces/Muon/ALCBaselineModellingView.cpp
@@ -168,6 +168,7 @@ void ALCBaselineModellingView::addSectionSelector(
 
   // Set initial values
   newSelector->setRange(values.first, values.second);
+  newSelector->setBounds(values.first, values.second);
   setSelectorValues(newSelector, values);
 
   m_ui.dataPlot->replot();

--- a/qt/widgets/plotting/inc/MantidQtWidgets/Plotting/Mpl/RangeSelector.h
+++ b/qt/widgets/plotting/inc/MantidQtWidgets/Plotting/Mpl/RangeSelector.h
@@ -38,6 +38,7 @@ public:
   double getMaximum() const;
 
   void setVisible(bool visible);
+  void setBounds(const double min, const double max);
 
   void detach();
 
@@ -54,7 +55,7 @@ private slots:
   void handleMouseMove(const QPoint &point);
   void handleMouseUp(const QPoint &point);
 
-  void resetBounds();
+  // void resetBounds();
   void redrawMarker();
 
 private:

--- a/qt/widgets/plotting/inc/MantidQtWidgets/Plotting/Mpl/RangeSelector.h
+++ b/qt/widgets/plotting/inc/MantidQtWidgets/Plotting/Mpl/RangeSelector.h
@@ -55,7 +55,6 @@ private slots:
   void handleMouseMove(const QPoint &point);
   void handleMouseUp(const QPoint &point);
 
-  // void resetBounds();
   void redrawMarker();
 
 private:

--- a/qt/widgets/plotting/src/Mpl/PreviewPlot.cpp
+++ b/qt/widgets/plotting/src/Mpl/PreviewPlot.cpp
@@ -152,7 +152,6 @@ void PreviewPlot::addSpectrum(const QString &lineName,
   regenerateLegend();
   axes.relim();
 
-  emit resetSelectorBounds();
   replot();
 }
 

--- a/qt/widgets/plotting/src/Mpl/RangeSelector.cpp
+++ b/qt/widgets/plotting/src/Mpl/RangeSelector.cpp
@@ -40,7 +40,7 @@ RangeSelector::RangeSelector(PreviewPlot *plot, SelectType type, bool visible,
           SLOT(handleMouseMove(QPoint)));
   connect(m_plot, SIGNAL(mouseUp(QPoint)), this, SLOT(handleMouseUp(QPoint)));
 
-  connect(m_plot, SIGNAL(resetSelectorBounds()), this, SLOT(resetBounds()));
+  // connect(m_plot, SIGNAL(resetSelectorBounds()), this, SLOT(resetBounds()));
   connect(m_plot, SIGNAL(redraw()), this, SLOT(redrawMarker()));
 }
 
@@ -67,10 +67,10 @@ QString RangeSelector::selectTypeAsQString(const SelectType &type) const {
                            "XMINMAX and YMINMAX.");
 }
 
-void RangeSelector::resetBounds() {
-  auto const axisRange = getAxisRange(m_type);
-  m_rangeMarker->setBounds(std::get<0>(axisRange), std::get<1>(axisRange));
-}
+// void RangeSelector::resetBounds() {
+//  auto const axisRange = getAxisRange(m_type);
+//  m_rangeMarker->setBounds(std::get<0>(axisRange), std::get<1>(axisRange));
+//}
 
 void RangeSelector::setRange(const std::pair<double, double> &range) {
   setRange(range.first, range.second);
@@ -108,6 +108,10 @@ double RangeSelector::getMaximum() const { return m_rangeMarker->getMaximum(); }
 void RangeSelector::setVisible(bool visible) {
   m_visible = visible;
   m_plot->replot();
+}
+
+void RangeSelector::setBounds(const double min, const double max) {
+  m_rangeMarker->setBounds(min, max);
 }
 
 void RangeSelector::detach() {

--- a/qt/widgets/plotting/src/Mpl/RangeSelector.cpp
+++ b/qt/widgets/plotting/src/Mpl/RangeSelector.cpp
@@ -39,8 +39,6 @@ RangeSelector::RangeSelector(PreviewPlot *plot, SelectType type, bool visible,
   connect(m_plot, SIGNAL(mouseMove(QPoint)), this,
           SLOT(handleMouseMove(QPoint)));
   connect(m_plot, SIGNAL(mouseUp(QPoint)), this, SLOT(handleMouseUp(QPoint)));
-
-  // connect(m_plot, SIGNAL(resetSelectorBounds()), this, SLOT(resetBounds()));
   connect(m_plot, SIGNAL(redraw()), this, SLOT(redrawMarker()));
 }
 
@@ -66,11 +64,6 @@ QString RangeSelector::selectTypeAsQString(const SelectType &type) const {
   throw std::runtime_error("Incorrect SelectType provided. Select types are "
                            "XMINMAX and YMINMAX.");
 }
-
-// void RangeSelector::resetBounds() {
-//  auto const axisRange = getAxisRange(m_type);
-//  m_rangeMarker->setBounds(std::get<0>(axisRange), std::get<1>(axisRange));
-//}
 
 void RangeSelector::setRange(const std::pair<double, double> &range) {
   setRange(range.first, range.second);


### PR DESCRIPTION
**Description of work.**
In the baseline modelling interface of the ALC, prevent the section markers from going beyond the limits of the data

**To test:**
1. open ALC
2. Load some data
3. Go to baseline modelling
4. Add a section
5. Drag section markers and check they stay within limits of the data

Fixes #30442 

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
