### PR TITLE
Remove generated file for doxygen

### DIFF
--- a/Framework/Doxygen/CMakeLists.txt
+++ b/Framework/Doxygen/CMakeLists.txt
@@ -89,4 +89,10 @@ if(DOXYGEN_FOUND)
       ${CMAKE_CURRENT_BINARY_DIR}/Mantid.doxyfile
       ${CMAKE_CURRENT_BINARY_DIR}/../../doxygen/html/Mantid_Logo_Transparent.png
       ${CMAKE_CURRENT_BINARY_DIR}/doxy_header.html)
+
+  # remove file that was configured for mantidplot
+  if (EXISTS "${CMAKE_SOURCE_DIR}/Framework/Kernel/src/ParaViewVersion.cpp")
+    file (REMOVE "${CMAKE_SOURCE_DIR}/Framework/Kernel/src/ParaViewVersion.cpp")
+  endif()
+
 endif(DOXYGEN_FOUND)

--- a/Framework/PythonInterface/test/python/plugins/algorithms/WorkflowAlgorithms/CorelliPowderCalibrationCreateTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/WorkflowAlgorithms/CorelliPowderCalibrationCreateTest.py
@@ -65,11 +65,6 @@ class CorelliPowderCalibrationCreateTest(unittest.TestCase):
         row = mtd['cal_adjustments'].row(1)
         target_position, target_orientation, target_rotation = [5.18, -0.32,  0.20], [0.001, 0.999, -0.027], 98.0
         # ToDO investigate the relatively large tolerance required for some operative systems, atol=0.05
-        assert_allclose([row[name] for name in ('Xposition', 'Yposition', 'Zposition')], [0., 0., -10.0], atol=0.001)
-        # Check position of first bank
-        row = mtd['cal_adjustments'].row(1)
-        target_position, target_orientation, target_rotation = [5.18, -0.32,  0.20], [0.001, 0.999, -0.027], 98.0
-        # ToDO investigate the relatively large tolerance required for some operative systems, atol=0.05
         assert_allclose([row[name] for name in ('Xposition', 'Yposition', 'Zposition')], target_position, atol=0.05)
         assert_allclose([row[name] for name in ('XdirectionCosine', 'YdirectionCosine', 'ZdirectionCosine')],
                         target_orientation, atol=0.05)


### PR DESCRIPTION
During #30450 doxygen would pickup a generated file from previous PR builds. This removes that file if it is found.

**To test:**

If doxygen builds pass, it is fine.

*There is no associated issue.*

*This does not require release notes* because it is an issue with the build servers only.

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
