### PR TITLE
Display debug messages logged during workbench startup

### DIFF
--- a/docs/source/release/v6.1.0/mantidworkbench.rst
+++ b/docs/source/release/v6.1.0/mantidworkbench.rst
@@ -11,4 +11,6 @@ New and Improved
 Bugfixes
 --------
 
+- Display Debug and Information messages generated during workbench start up
+
 :ref:`Release 6.1.0 <v6.1.0>`

--- a/qt/applications/workbench/workbench/app/mainwindow.py
+++ b/qt/applications/workbench/workbench/app/mainwindow.py
@@ -135,6 +135,8 @@ class MainWindow(QMainWindow):
         self.messagedisplay = LogMessageDisplay(self)
         # this takes over stdout/stderr
         self.messagedisplay.register_plugin()
+        # read settings early so that logging level is in place before framework mgr created
+        self.messagedisplay.readSettings(CONF)
         self.widgets.append(self.messagedisplay)
 
         self.set_splash("Loading Algorithm Selector")
@@ -722,8 +724,8 @@ class MainWindow(QMainWindow):
         # read in settings for children
         AlgorithmInputHistory().readSettings(settings)
         for widget in self.widgets:
-            if hasattr(widget, 'readSettings'):
-                widget.readSettings(settings)
+            if hasattr(widget, 'readSettingsIfNotDone'):
+                widget.readSettingsIfNotDone(settings)
 
     def writeSettings(self, settings):
         settings.set('MainWindow/size', self.size())  # QSize

--- a/qt/applications/workbench/workbench/plugins/base.py
+++ b/qt/applications/workbench/workbench/plugins/base.py
@@ -25,6 +25,7 @@ class PluginWidget(QWidget):
 
         self.dockwidget = None
         self.main = main_window
+        self.settings_read = False
 
 # ----------------- Plugin API --------------------
 
@@ -35,9 +36,15 @@ class PluginWidget(QWidget):
         raise NotImplementedError()
 
     def readSettings(self, qsettings):
+        """Load user configuration"""
+        raise NotImplementedError()
+
+    def readSettingsIfNotDone(self, qsettings):
         """Called by the main window to ask the plugin to
         load user configuration"""
-        raise NotImplementedError()
+        if not self.settings_read:
+            self.readSettings(qsettings)
+            self.settings_read = True
 
     def writeSettings(self, qsettings):
         """Called by the main window to ask the plugin to


### PR DESCRIPTION
**Description of work.**

Messages of level Debug and Information that are created during the start up of workbench were not being displayed in the workbench log. This was happening because the logging level was read in after C++ objects like the framework manager were created. Until the user's logging level is read in a default logging level of Notice is used.

These changes read in the logging level in as soon as the message display widget is created so that it's always set before the framework manager is created

**To test:**

Start up workbench with logging level set to debug and observe extra messages like the following in the log:

```
Loading libraries from 'C:/mantid/build/bin/Debug/', excluding 'Qt4;Qt5'
Opening all libraries in C:/mantid/build/bin/Debug/
Setting maximum number of threads to 2
FrameworkManager created.
```

If the workbench logging level isn't at debug you will need to start it up first, set the logging level, shut down and restart workbench

Fixes #30348. 

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
