### PR TITLE
Fix error when removing all curves from plot

### DIFF
--- a/qt/python/mantidqt/widgets/plotconfigdialog/curvestabwidget/presenter.py
+++ b/qt/python/mantidqt/widgets/plotconfigdialog/curvestabwidget/presenter.py
@@ -283,7 +283,7 @@ class CurvesTabWidgetPresenter:
         # Then update the rest of the view to reflect the selected combo items.
         curve = self.get_current_curve()
         if curve:
-            curve_props = CurveProperties.from_curve(self.get_current_curve())
+            curve_props = CurveProperties.from_curve(curve)
             self.view.update_fields(curve_props)
             self.set_errorbars_tab_enabled()
             self.current_view_properties = curve_props

--- a/qt/python/mantidqt/widgets/plotconfigdialog/curvestabwidget/presenter.py
+++ b/qt/python/mantidqt/widgets/plotconfigdialog/curvestabwidget/presenter.py
@@ -99,7 +99,10 @@ class CurvesTabWidgetPresenter:
     def get_current_curve(self):
         """Get selected Line2D or ErrorbarContainer object"""
         name = self.view.get_current_curve_name()
-        return self.curve_names_dict[name]
+        if name:
+            return self.curve_names_dict[name]
+        else:
+            return None
 
     def get_selected_curves(self):
         """Get a list of selected Line2D or ErrorbarContainer objects"""
@@ -278,10 +281,12 @@ class CurvesTabWidgetPresenter:
         self.set_apply_to_all_buttons_enabled()
 
         # Then update the rest of the view to reflect the selected combo items.
-        curve_props = CurveProperties.from_curve(self.get_current_curve())
-        self.view.update_fields(curve_props)
-        self.set_errorbars_tab_enabled()
-        self.current_view_properties = curve_props
+        curve = self.get_current_curve()
+        if curve:
+            curve_props = CurveProperties.from_curve(self.get_current_curve())
+            self.view.update_fields(curve_props)
+            self.set_errorbars_tab_enabled()
+            self.current_view_properties = curve_props
 
     # Private methods
     def _generate_curve_name(self, curve, label):

--- a/qt/python/mantidqt/widgets/plotconfigdialog/curvestabwidget/view.py
+++ b/qt/python/mantidqt/widgets/plotconfigdialog/curvestabwidget/view.py
@@ -77,7 +77,10 @@ class CurvesTabWidgetView(QWidget):
         return self.select_axes_combo_box.currentText()
 
     def get_current_curve_name(self):
-        return self.select_curve_list.currentItem().text()
+        if self.select_curve_list.count() > 0:
+            return self.select_curve_list.currentItem().text()
+        else:
+            return None
 
     def get_selected_curves_names(self):
         return [item.text() for item in self.select_curve_list.selectedItems()]


### PR DESCRIPTION
**Description of work.**

Small bug fix to check if there QList of curves is empty before trying to retrieve the text of current item.

**To test:**

See instructions on original issue.

Fixes #30484 

*This does not require release notes* because **small fix for bug that was unreported - found during work on another issue**


<!-- Ensure the base of this PR is correct (e.g. release-next or master)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
