### PR TITLE
ADS return False when checking for None in python

### DIFF
--- a/Framework/PythonInterface/mantid/api/_aliases.py
+++ b/Framework/PythonInterface/mantid/api/_aliases.py
@@ -23,7 +23,7 @@ from mantid.kernel._aliases import lazy_instance_access
 # delete the python objects.
 # If you see a segfault late in a python process related to the GIL
 # it is likely an exit handler is missing.
-AnalysisDataService = lazy_instance_access(AnalysisDataServiceImpl)
+AnalysisDataService = lazy_instance_access(AnalysisDataServiceImpl, key_as_str=True)
 AlgorithmFactory = lazy_instance_access(AlgorithmFactoryImpl)
 AlgorithmManager = lazy_instance_access(AlgorithmManagerImpl)
 FileFinder = lazy_instance_access(FileFinderImpl)

--- a/Framework/PythonInterface/mantid/kernel/_aliases.py
+++ b/Framework/PythonInterface/mantid/kernel/_aliases.py
@@ -13,7 +13,7 @@
 from mantid.kernel import (ConfigServiceImpl, Logger, PropertyManagerDataServiceImpl, UnitFactoryImpl, UsageServiceImpl)
 
 
-def lazy_instance_access(cls):
+def lazy_instance_access(cls, key_as_str=False):
     """
     Takes a singleton class and wraps it in an LazySingletonHolder
     that constructs the instance on first access.
@@ -26,6 +26,9 @@ def lazy_instance_access(cls):
 
 
     :param cls: The singleton class type
+    :param key_as_str: When ``True``, the key supplied to ``__getitem__``, ``__setitem__``,
+    ``__delitem__``, and ``__contains__`` will be converted to a str. ``None`` wil return ``False``
+    for ``__contains__``
     :return: A new LazySingletonHolder wrapping cls
     """
 
@@ -44,16 +47,39 @@ def lazy_instance_access(cls):
             return cls.__getattribute__(cls.Instance(), "__len__")()
 
         def __getitem__(self, item):
+            if key_as_str:
+                if item is None:
+                    raise KeyError(item)
+                else:
+                    cls.__getattribute__(cls.Instance(), "__getitem__")(str(item))
             return cls.__getattribute__(cls.Instance(), "__getitem__")(item)
 
         def __setitem__(self, item, value):
+            if key_as_str:
+                if item is None:
+                    raise KeyError(item)
+                else:
+                    return cls.__getattribute__(cls.Instance(), "__setitem__")(str(item), value)
             return cls.__getattribute__(cls.Instance(), "__setitem__")(item, value)
 
         def __delitem__(self, item):
+            if key_as_str:
+                if item is None:
+                    raise KeyError(item)
+                else:
+                    return cls.__getattribute__(cls.Instance(), "__delitem__")(str(item))
             return cls.__getattribute__(cls.Instance(), "__delitem__")(item)
 
         def __contains__(self, item):
-            return cls.__getattribute__(cls.Instance(), "__contains__")(item)
+            if key_as_str:
+                # check for things that evaluate to False
+                if (item is None) or (not bool(item)):
+                    return False
+                else:
+                    # convert the ``item`` to a string
+                    return cls.__getattribute__(cls.Instance(), "__contains__")(str(item))
+            else:
+                return cls.__getattribute__(cls.Instance(), "__contains__")(item)
 
     return LazySingletonHolder()
 

--- a/Framework/PythonInterface/test/python/mantid/api/AnalysisDataServiceTest.py
+++ b/Framework/PythonInterface/test/python/mantid/api/AnalysisDataServiceTest.py
@@ -7,7 +7,7 @@
 import unittest
 from testhelpers import run_algorithm
 from mantid.api import (AnalysisDataService, AnalysisDataServiceImpl,
-                        FrameworkManagerImpl, MatrixWorkspace, Workspace)
+                        FrameworkManagerImpl, MatrixWorkspace)
 from mantid import mtd
 
 
@@ -41,6 +41,15 @@ class AnalysisDataServiceTest(unittest.TestCase):
         data = [1.0,2.0,3.0]
         alg = run_algorithm('CreateWorkspace',DataX=data,DataY=data,NSpec=1,UnitX='Wavelength', child=True)
         AnalysisDataService.addOrReplace(wsname, alg.getProperty("OutputWorkspace").value)
+
+    def test_contains(self):
+        # verify check against None
+        self.assertFalse(None in mtd)
+        # verify check against things that bool to False
+        self.assertFalse('' in mtd)
+        self.assertFalse(0 in mtd)
+        # verify check for converting checked value to string
+        self.assertFalse(1 in mtd)
 
     def test_len_increases_when_item_added(self):
         wsname = 'ADSTest_test_len_increases_when_item_added'
@@ -110,8 +119,8 @@ class AnalysisDataServiceTest(unittest.TestCase):
         for name in ws_names:
             self._run_createws(name)
         group_name = 'group1'
-        alg = run_algorithm('GroupWorkspaces', InputWorkspaces=ws_names,
-                            OutputWorkspace=group_name)
+        _ = run_algorithm('GroupWorkspaces', InputWorkspaces=ws_names,
+                          OutputWorkspace=group_name)
 
         workspaces = AnalysisDataService.retrieveWorkspaces([group_name], True)
         self.assertEqual(2, len(workspaces))


### PR DESCRIPTION
Since lots of places want to check for
```python
if value in mtd:
  ...
```
with randomly values, including `None`. This changes the interface to cleanly deal with such things by checking if they are `None` then converting the value to a string.

**To test:**

The additional unit test verifies this works.

*There is no associated issue.*

*This does not require release notes* because it is a minor improvement to usability.

The sibling PR into `master` is #30488.

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
