### PR TITLE
Iterate over list of dict items to prevent runtime error when renaming plotted workspace

### DIFF
--- a/qt/applications/workbench/workbench/plotting/figuremanager.py
+++ b/qt/applications/workbench/workbench/plotting/figuremanager.py
@@ -45,6 +45,7 @@ from workbench.plotting.plothelppages import PlotHelpPages
 
 def _catch_exceptions(func):
     """Catch all exceptions in method and print a traceback to stderr"""
+
     @wraps(func)
     def wrapper(*args, **kwargs):
         try:
@@ -136,11 +137,13 @@ class FigureManagerADSObserver(AnalysisDataServiceObserver):
         :param oldName: The old name of the workspace.
         :param newName: The new name of the workspace
         """
+
         for ax in self.canvas.figure.axes:
             if isinstance(ax, MantidAxes):
                 ws = AnalysisDataService.retrieve(newName)
                 if isinstance(ws, MatrixWorkspace):
-                    for ws_name, artists in ax.tracked_workspaces.items():
+                    for ws_name in list(ax.tracked_workspaces.keys()):
+                        # loop over list as items is iterable of object that is changed (throws error)
                         if ws_name == oldName:
                             ax.tracked_workspaces[newName] = ax.tracked_workspaces.pop(oldName)
                 elif isinstance(ws, ITableWorkspace):
@@ -161,6 +164,7 @@ class FigureManagerWorkbench(FigureManagerBase, QObject):
         The qt.QMainWindow
 
     """
+
     def __init__(self, canvas, num):
         assert QAppThreadCall.is_qapp_thread(
         ), "FigureManagerWorkbench cannot be created outside of the QApplication thread"
@@ -495,6 +499,7 @@ def new_figure_manager(num, *args, **kwargs):
 
 def new_figure_manager_given_figure(num, figure):
     """Create a new manager from a num & figure """
+
     def _new_figure_manager_given_figure_impl(num, figure):
         """Create a new figure manager instance for the given figure.
         Forces all public and non-dunder method calls onto the QApplication thread.


### PR DESCRIPTION
**Description of work.**

Small bug fix - Iterate over list of dict keys to prevent runtime error when renaming plotted workspace - this avoids a runtime error that arose due to change to the underlying dict of the items iterator.

**To test:**

(1) Plot spectrum
(2) Rename workspace

The legend and/or title (depending on the plot) won't change - but you can tell the tracked workspaces has been update because if you delete the workspace the ADS observer should lead to the plot being closed.

Partially Fixes #29947 - it would be nice to update the legend etc. but part of the problem is that the line label etc. might have been renamed/customised (and therefore not related to the woprkspace name anyway). Another problem the workspace hasn't been renamed at the point the renameHandle is called - maybe these things can be looked into after the release?

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or master)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
