### PR TITLE
Fix Colourfill plots not allowing high precision and e notation

### DIFF
--- a/docs/source/release/v6.0.0/mantidworkbench.rst
+++ b/docs/source/release/v6.0.0/mantidworkbench.rst
@@ -44,6 +44,7 @@ Improvements
 - In the plot config, multiple curves can be selected and removed at once. The delete key was added as a shortcut.
 - A bug has been fixed in SliceViewer where attempting to plot a workspace with a text axis would cause a crash when zoomed out.
 - Improved plot generated scripts to better support major and minor tick settings at time of generation.
+- Allowed the use of greater precision and scientific notation when changing the colorbar limits on a colorfill plot from the Figure Options.
 
 Bugfixes
 ########

--- a/qt/python/CMakeLists.txt
+++ b/qt/python/CMakeLists.txt
@@ -87,6 +87,7 @@ if(ENABLE_MANTIDPLOT OR ENABLE_WORKBENCH)
       mantidqt/utils/test/test_modal_tester.py
       mantidqt/utils/test/test_qt_utils.py
       mantidqt/utils/test/test_writetosignal.py
+      mantidqt/utils/qt/test/test_line_edit_double_validator.py
       mantidqt/utils/qt/test/test_qappthreadcall.py
       mantidqt/widgets/test/test_messagedisplay.py
       mantidqt/widgets/test/test_fitpropertybrowser.py

--- a/qt/python/mantidqt/utils/qt/line_edit_double_validator.py
+++ b/qt/python/mantidqt/utils/qt/line_edit_double_validator.py
@@ -1,0 +1,34 @@
+# Mantid Repository : https://github.com/mantidproject/mantid
+#
+# Copyright &copy; 2021 ISIS Rutherford Appleton Laboratory UKRI,
+#   NScD Oak Ridge National Laboratory, European Spallation Source,
+#   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+# SPDX - License - Identifier: GPL - 3.0 +
+#  This file is part of the mantid workbench.
+from qtpy.QtGui import QDoubleValidator
+
+from mantid import logger
+
+
+class LineEditDoubleValidator(QDoubleValidator):
+    """
+    A class for validating a line edit for entering doubles in decimal format or e notation. It catches invalid input
+    such as empty strings and broken e notation, and then resets the value in the line edit to the last valid value.
+    """
+
+    def __init__(self, line_edit, initial_value):
+        """Create a line edit double validator."""
+        super(LineEditDoubleValidator, self).__init__(None)
+        self.last_valid_value = initial_value
+        self._line_edit = line_edit
+
+        self._line_edit.editingFinished.connect(self.on_editing_finished)
+
+    def on_editing_finished(self):
+        """Entered when the data input is valid according to QDoubleValidator."""
+        self.last_valid_value = self._line_edit.text()
+
+    def fixup(self, new_value):
+        """Entered when the data input is invalid according to QDoubleValidator (empty string or broken e notation)."""
+        logger.warning(f"An invalid value '{new_value}' was provided. Using '{self.last_valid_value}' instead.")
+        self._line_edit.setText(self.last_valid_value)

--- a/qt/python/mantidqt/utils/qt/line_edit_double_validator.py
+++ b/qt/python/mantidqt/utils/qt/line_edit_double_validator.py
@@ -31,4 +31,4 @@ class LineEditDoubleValidator(QDoubleValidator):
     def fixup(self, new_value):
         """Entered when the data input is invalid according to QDoubleValidator (empty string or broken e notation)."""
         logger.warning(f"An invalid value '{new_value}' was provided. Using '{self.last_valid_value}' instead.")
-        self._line_edit.setText(self.last_valid_value)
+        self._line_edit.setText(str(self.last_valid_value))

--- a/qt/python/mantidqt/utils/qt/test/test_line_edit_double_validator.py
+++ b/qt/python/mantidqt/utils/qt/test/test_line_edit_double_validator.py
@@ -1,0 +1,79 @@
+# Mantid Repository : https://github.com/mantidproject/mantid
+#
+# Copyright &copy; 2021 ISIS Rutherford Appleton Laboratory UKRI,
+#   NScD Oak Ridge National Laboratory, European Spallation Source,
+#   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+# SPDX - License - Identifier: GPL - 3.0 +
+#  This file is part of the mantid workbench.
+import unittest
+
+from mantidqt.utils.qt.line_edit_double_validator import LineEditDoubleValidator
+from mantidqt.utils.qt.testing import start_qapplication
+
+from qtpy.QtCore import Qt
+from qtpy.QtWidgets import QApplication, QLineEdit
+from qtpy.QtTest import QTest
+
+
+@start_qapplication
+class LineEditDoubleValidatorTest(unittest.TestCase):
+
+    def setUp(self):
+        self.initial_value = "0.0"
+
+        self.line_edit = QLineEdit(self.initial_value)
+        self.line_edit.show()
+
+    def tearDown(self):
+        self.assertTrue(self.line_edit.close())
+
+    def test_initialization_of_the_validator_does_not_raise(self):
+        try:
+            _ = self._create_validator()
+        except Exception as ex:
+            self.fail(f"An exception was thrown when attempting to create the validator {ex}.")
+
+    def test_that_editing_the_line_edit_with_a_valid_double_will_work(self):
+        valid_entry = "1.0"
+
+        self._validator = self._create_validator()
+        self._edit_line_edit(valid_entry)
+
+        self.assertEqual(self.line_edit.text(), valid_entry)
+
+    def test_that_editing_the_line_edit_with_a_valid_double_in_e_notation_will_work(self):
+        valid_entry = "3e5"
+
+        self._validator = self._create_validator()
+        self._edit_line_edit(valid_entry)
+
+        self.assertEqual(self.line_edit.text(), valid_entry)
+
+    def test_that_editing_the_line_edit_with_an_empty_string_will_reset_to_the_last_valid_value(self):
+        invalid_entry = ""
+
+        self._validator = self._create_validator()
+        self._edit_line_edit(invalid_entry)
+
+        self.assertEqual(self.line_edit.text(), self.initial_value)
+
+    def test_that_editing_the_line_edit_with_broken_e_notation_will_reset_to_the_last_valid_value(self):
+        invalid_entry = "e"
+
+        self._validator = self._create_validator()
+        self._edit_line_edit(invalid_entry)
+
+        self.assertEqual(self.line_edit.text(), self.initial_value)
+
+    def _create_validator(self):
+        validator = LineEditDoubleValidator(self.line_edit, self.initial_value)
+        self.line_edit.setValidator(validator)
+        return validator
+
+    def _edit_line_edit(self, key_entry):
+        QTest.mouseClick(self.line_edit, Qt.LeftButton)
+        self.line_edit.selectAll()
+        QTest.keyClick(self.line_edit, Qt.Key_Backspace)
+        QTest.keyClicks(self.line_edit, key_entry)
+        QTest.keyClick(self.line_edit, Qt.Key_Enter)
+        QApplication.sendPostedEvents()

--- a/qt/python/mantidqt/widgets/plotconfigdialog/axestabwidget/presenter.py
+++ b/qt/python/mantidqt/widgets/plotconfigdialog/axestabwidget/presenter.py
@@ -8,7 +8,6 @@
 
 from mpl_toolkits.mplot3d.axes3d import Axes3D
 
-from mantid import logger
 from mantid.plots import convert_color_to_hex
 from mantidqt.widgets.plotconfigdialog import generate_ax_name, get_axes_names_dict
 from mantidqt.widgets.plotconfigdialog.axestabwidget import AxProperties
@@ -260,21 +259,7 @@ class AxesTabWidgetPresenter:
         self.current_view_props['title'] = self.view.get_title()
         self.current_view_props['minor_ticks'] = self.view.get_show_minor_ticks()
         self.current_view_props['minor_gridlines'] = self.view.get_show_minor_gridlines()
-        try:
-            lower_lim = self.view.get_lower_limit()
-            lower_lim = float(lower_lim)
-        except ValueError:
-            logger.warning("Could not set lower axis limit to " + lower_lim + ". Using 0.0 instead")
-            lower_lim = 0.0
-            self.view.set_lower_limit(lower_lim)
-        try:
-            upper_lim = self.view.get_upper_limit()
-            upper_lim = float(upper_lim)
-        except ValueError:
-            logger.warning("Could not set upper axis limit to " + upper_lim + ". Using 1.0 instead")
-            upper_lim = 1.0
-            self.view.set_upper_limit(upper_lim)
-        self.current_view_props[f"{ax}lim"] = (lower_lim,upper_lim)
+        self.current_view_props[f"{ax}lim"] = (self.view.get_lower_limit(), self.view.get_upper_limit())
         self.current_view_props[f"{ax}label"] = self.view.get_label()
         self.current_view_props[f"{ax}scale"] = self.view.get_scale()
         self.current_view_props[f"{ax}autoscale"] = self.view.get_autoscale_enabled()

--- a/qt/python/mantidqt/widgets/plotconfigdialog/axestabwidget/test/test_axestabwidgetpresenter.py
+++ b/qt/python/mantidqt/widgets/plotconfigdialog/axestabwidget/test/test_axestabwidgetpresenter.py
@@ -263,35 +263,9 @@ class AxesTabWidgetPresenterTest(unittest.TestCase):
         mock_view.get_autoscale_enabled.assert_called_once_with()
         mock_view.set_limit_input_enabled.assert_called_once_with(False)
 
-    def test_broken_e_notation_for_lower_axis_lims(self):
-        mock_view = mock.Mock(get_lower_limit=mock.Mock(return_value="e"),
-                              get_upper_limit=mock.Mock(return_value="10"),
-                              get_selected_ax_name=lambda: "My Axes: (0, 0)",
-                              get_axis=lambda: "x",
-                              get_properties=lambda: {})
-
-        presenter = Presenter(self.fig, view=mock_view)
-        presenter.get_selected_ax_name = 'x'
-        presenter.axis_changed()
-
-        self.assertEqual(presenter.current_view_props["xlim"], (0.0, 10.0))
-
-    def test_broken_e_notation_for_upper_axis_lims(self):
-        mock_view = mock.Mock(get_lower_limit=mock.Mock(return_value="-1"),
-                              get_upper_limit=mock.Mock(return_value="e"),
-                              get_selected_ax_name=lambda: "My Axes: (0, 0)",
-                              get_axis=lambda: "x",
-                              get_properties=lambda: {})
-
-        presenter = Presenter(self.fig, view=mock_view)
-        presenter.get_selected_ax_name = 'x'
-        presenter.axis_changed()
-
-        self.assertEqual(presenter.current_view_props["xlim"], (-1.0, 1.0))
-
     def test_ax_limits_set_correctly(self):
-        mock_view = mock.Mock(get_lower_limit=mock.Mock(return_value="-1"),
-                              get_upper_limit=mock.Mock(return_value="10"),
+        mock_view = mock.Mock(get_lower_limit=mock.Mock(return_value=-1.0),
+                              get_upper_limit=mock.Mock(return_value=10.0),
                               get_selected_ax_name=lambda: "My Axes: (0, 0)",
                               get_axis=lambda: "x",
                               get_properties=lambda: {})

--- a/qt/python/mantidqt/widgets/plotconfigdialog/axestabwidget/view.py
+++ b/qt/python/mantidqt/widgets/plotconfigdialog/axestabwidget/view.py
@@ -7,10 +7,10 @@
 #  This file is part of the mantid workbench.
 
 from qtpy.QtCore import Qt
-from qtpy.QtGui import QDoubleValidator
 from qtpy.QtWidgets import QWidget, QTabBar
 
 from mantidqt.utils.qt import load_ui
+from mantidqt.utils.qt.line_edit_double_validator import LineEditDoubleValidator
 from mantidqt.widgets.plotconfigdialog.axestabwidget import AxProperties
 from mantidqt.widgets.plotconfigdialog.colorselector import ColorSelector
 
@@ -36,11 +36,10 @@ class AxesTabWidgetView(QWidget):
         self.x_tab = self.axis_tab_bar.addTab("z")
         self.axis_tab_bar_layout.replaceWidget(self.dummy_axis_tab_bar, self.axis_tab_bar)
 
-        # Set validator for the axis limit spin boxes
-        for limit in ['upper', 'lower']:
-            line_edit = getattr(self, f'{limit}_limit_line_edit')
-            validator = QDoubleValidator()
-            line_edit.setValidator(validator)
+        self.lower_limit_validator = LineEditDoubleValidator(self.lower_limit_line_edit, 0.0)
+        self.upper_limit_validator = LineEditDoubleValidator(self.upper_limit_line_edit, 1.0)
+        self.lower_limit_line_edit.setValidator(self.lower_limit_validator)
+        self.upper_limit_line_edit.setValidator(self.upper_limit_validator)
 
     def populate_select_axes_combo_box(self, axes_names):
         self.select_axes_combo_box.addItems(axes_names)
@@ -82,10 +81,10 @@ class AxesTabWidgetView(QWidget):
         self.show_minor_gridlines_check_box.setEnabled(enabled)
 
     def get_lower_limit(self):
-        return self.lower_limit_line_edit.text()
+        return float(self.lower_limit_line_edit.text())
 
     def get_upper_limit(self):
-        return self.upper_limit_line_edit.text()
+        return float(self.upper_limit_line_edit.text())
 
     def get_label(self):
         return self.label_line_edit.text()
@@ -103,9 +102,11 @@ class AxesTabWidgetView(QWidget):
         return self.axis_tab_bar.currentIndex() == 2
 
     def set_lower_limit(self, limit):
+        self.lower_limit_validator.last_valid_value = str(limit)
         self.lower_limit_line_edit.setText(str(limit))
 
     def set_upper_limit(self, limit):
+        self.upper_limit_validator.last_valid_value = str(limit)
         self.upper_limit_line_edit.setText(str(limit))
 
     def set_label(self, label):

--- a/qt/python/mantidqt/widgets/plotconfigdialog/axestabwidget/view.py
+++ b/qt/python/mantidqt/widgets/plotconfigdialog/axestabwidget/view.py
@@ -78,8 +78,8 @@ class AxesTabWidgetView(QWidget):
         self.show_minor_gridlines_check_box.setVisible(visible)
         self.show_minor_ticks_check_box.setVisible(visible)
 
-    def set_minor_gridlines_check_box_enabled(self, eneabled):
-        self.show_minor_gridlines_check_box.setEnabled(eneabled)
+    def set_minor_gridlines_check_box_enabled(self, enabled):
+        self.show_minor_gridlines_check_box.setEnabled(enabled)
 
     def get_lower_limit(self):
         return self.lower_limit_line_edit.text()

--- a/qt/python/mantidqt/widgets/plotconfigdialog/imagestabwidget/images_tab.ui
+++ b/qt/python/mantidqt/widgets/plotconfigdialog/imagestabwidget/images_tab.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>361</width>
-    <height>367</height>
+    <height>390</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -176,25 +176,6 @@
        </property>
       </spacer>
      </item>
-     <item row="4" column="2">
-      <widget class="QDoubleSpinBox" name="min_value_spin_box">
-       <property name="sizePolicy">
-        <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-         <horstretch>0</horstretch>
-         <verstretch>0</verstretch>
-        </sizepolicy>
-       </property>
-       <property name="minimumSize">
-        <size>
-         <width>190</width>
-         <height>22</height>
-        </size>
-       </property>
-       <property name="decimals">
-        <number>4</number>
-       </property>
-      </widget>
-     </item>
      <item row="5" column="1">
       <spacer name="horizontalSpacer_29">
        <property name="orientation">
@@ -301,31 +282,18 @@
        </property>
       </spacer>
      </item>
-     <item row="5" column="2">
-      <widget class="QDoubleSpinBox" name="max_value_spin_box">
-       <property name="sizePolicy">
-        <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-         <horstretch>0</horstretch>
-         <verstretch>0</verstretch>
-        </sizepolicy>
-       </property>
-       <property name="minimumSize">
-        <size>
-         <width>190</width>
-         <height>22</height>
-        </size>
-       </property>
-       <property name="decimals">
-        <number>4</number>
-       </property>
-      </widget>
-     </item>
      <item row="3" column="2">
       <widget class="QCheckBox" name="reverse_colormap_check_box">
        <property name="text">
         <string>Reverse colormap</string>
        </property>
       </widget>
+     </item>
+     <item row="4" column="2">
+      <widget class="QLineEdit" name="min_value_line_edit"/>
+     </item>
+     <item row="5" column="2">
+      <widget class="QLineEdit" name="max_value_line_edit"/>
      </item>
     </layout>
    </item>
@@ -395,8 +363,6 @@
   <tabstop>label_line_edit</tabstop>
   <tabstop>colormap_combo_box</tabstop>
   <tabstop>reverse_colormap_check_box</tabstop>
-  <tabstop>min_value_spin_box</tabstop>
-  <tabstop>max_value_spin_box</tabstop>
   <tabstop>interpolation_combo_box</tabstop>
   <tabstop>scale_combo_box</tabstop>
  </tabstops>

--- a/qt/python/mantidqt/widgets/plotconfigdialog/imagestabwidget/presenter.py
+++ b/qt/python/mantidqt/widgets/plotconfigdialog/imagestabwidget/presenter.py
@@ -24,10 +24,6 @@ class ImagesTabWidgetPresenter:
         else:
             self.view = view
 
-        # This connection is here so that when the view is updated below the min/max spin boxes have the correct range
-        # for the scale.
-        self.view.scale_combo_box.currentTextChanged.connect(self.scale_changed)
-
         self.image_names_dict = dict()
         self.populate_select_image_combo_box_and_update_view()
 
@@ -118,6 +114,3 @@ class ImagesTabWidgetPresenter:
                 self.generate_image_name(img[0]), img, self.image_names_dict)
         self.view.populate_select_image_combo_box(
             sorted(self.image_names_dict.keys()))
-
-    def scale_changed(self, scale):
-        self.view.set_min_max_ranges(scale)

--- a/qt/python/mantidqt/widgets/plotconfigdialog/imagestabwidget/view.py
+++ b/qt/python/mantidqt/widgets/plotconfigdialog/imagestabwidget/view.py
@@ -10,7 +10,7 @@ import numpy as np
 from matplotlib.colors import LogNorm, Normalize
 from matplotlib import cm
 from qtpy.QtCore import Qt
-from qtpy.QtGui import QPixmap, QIcon, QImage
+from qtpy.QtGui import QDoubleValidator, QPixmap, QIcon, QImage
 from qtpy.QtWidgets import QWidget
 
 from mantid.plots.utility import get_colormap_names
@@ -40,18 +40,11 @@ class ImagesTabWidgetView(QWidget):
         self._populate_interpolation_combo_box()
         self._populate_scale_combo_box()
 
-        self.set_min_max_ranges(self.get_scale())
-
         self.max_min_value_warning.setVisible(False)
 
-    def set_min_max_ranges(self, scale):
-        # Set maximum and minimum for the min/max spin boxes
-        for bound in ['min', 'max']:
-            spin_box = getattr(self, '%s_value_spin_box' % bound)
-            if scale == "Linear":
-                spin_box.setRange(np.finfo(np.float32).min, np.finfo(np.float32).max)
-            else:
-                spin_box.setRange(0.0001, np.finfo(np.float32).max)
+        validator = QDoubleValidator()
+        self.min_value_line_edit.setValidator(validator)
+        self.max_value_line_edit.setValidator(validator)
 
     def _populate_colormap_combo_box(self):
         for cmap_name in get_colormap_names():
@@ -100,16 +93,16 @@ class ImagesTabWidgetView(QWidget):
         self.reverse_colormap_check_box.setCheckState(qt_checked)
 
     def get_min_value(self):
-        return self.min_value_spin_box.value()
+        return float(self.min_value_line_edit.text())
 
     def set_min_value(self, value):
-        self.min_value_spin_box.setValue(value)
+        self.min_value_line_edit.setText(str(value))
 
     def get_max_value(self):
-        return self.max_value_spin_box.value()
+        return float(self.max_value_line_edit.text())
 
     def set_max_value(self, value):
-        self.max_value_spin_box.setValue(value)
+        self.max_value_line_edit.setText(str(value))
 
     def get_interpolation(self):
         return self.interpolation_combo_box.currentText()

--- a/qt/python/mantidqt/widgets/plotconfigdialog/imagestabwidget/view.py
+++ b/qt/python/mantidqt/widgets/plotconfigdialog/imagestabwidget/view.py
@@ -13,6 +13,7 @@ from qtpy.QtCore import Qt
 from qtpy.QtGui import QDoubleValidator, QPixmap, QIcon, QImage
 from qtpy.QtWidgets import QWidget
 
+from mantid import logger
 from mantid.plots.utility import get_colormap_names
 from mantidqt.utils.qt import load_ui
 from mantidqt.widgets.plotconfigdialog.imagestabwidget import ImageProperties
@@ -45,6 +46,9 @@ class ImagesTabWidgetView(QWidget):
         validator = QDoubleValidator()
         self.min_value_line_edit.setValidator(validator)
         self.max_value_line_edit.setValidator(validator)
+
+        self.min_value = 0.0
+        self.max_value = 1.0
 
     def _populate_colormap_combo_box(self):
         for cmap_name in get_colormap_names():
@@ -93,16 +97,30 @@ class ImagesTabWidgetView(QWidget):
         self.reverse_colormap_check_box.setCheckState(qt_checked)
 
     def get_min_value(self):
-        return float(self.min_value_line_edit.text())
+        min_value = self.min_value_line_edit.text()
+        try:
+            return float(min_value)
+        except ValueError:
+            logger.warning(f"Failed to set max value to '{min_value}'. Using '{self.min_value}' instead.")
+            self.set_min_value(self.min_value)
+            return self.min_value
 
     def set_min_value(self, value):
-        self.min_value_line_edit.setText(str(value))
+        self.min_value = value
+        self.min_value_line_edit.setText(str(self.min_value))
 
     def get_max_value(self):
-        return float(self.max_value_line_edit.text())
+        max_value = self.max_value_line_edit.text()
+        try:
+            return float(max_value)
+        except ValueError:
+            logger.warning(f"Failed to set max value to '{max_value}'. Using '{self.max_value}' instead.")
+            self.set_max_value(self.max_value)
+            return self.max_value
 
     def set_max_value(self, value):
-        self.max_value_line_edit.setText(str(value))
+        self.max_value = value
+        self.max_value_line_edit.setText(str(self.max_value))
 
     def get_interpolation(self):
         return self.interpolation_combo_box.currentText()

--- a/qt/python/mantidqt/widgets/plotconfigdialog/imagestabwidget/view.py
+++ b/qt/python/mantidqt/widgets/plotconfigdialog/imagestabwidget/view.py
@@ -10,12 +10,12 @@ import numpy as np
 from matplotlib.colors import LogNorm, Normalize
 from matplotlib import cm
 from qtpy.QtCore import Qt
-from qtpy.QtGui import QDoubleValidator, QPixmap, QIcon, QImage
+from qtpy.QtGui import QPixmap, QIcon, QImage
 from qtpy.QtWidgets import QWidget
 
-from mantid import logger
 from mantid.plots.utility import get_colormap_names
 from mantidqt.utils.qt import load_ui
+from mantidqt.utils.qt.line_edit_double_validator import LineEditDoubleValidator
 from mantidqt.widgets.plotconfigdialog.imagestabwidget import ImageProperties
 
 INTERPOLATIONS = [
@@ -32,25 +32,6 @@ def create_colormap_img(cmap_name, width=50, height=20):
     return QImage(img_array, width, height, QImage.Format_RGBA8888_Premultiplied)
 
 
-class MinMaxDoubleValidator(QDoubleValidator):
-
-    def __init__(self, line_edit, initial_value):
-        super(MinMaxDoubleValidator, self).__init__(None)
-        self.last_valid_value = initial_value
-        self._line_edit = line_edit
-
-        self._line_edit.editingFinished.connect(self.on_editing_finished)
-
-    def on_editing_finished(self):
-        """Entered when the data input is valid according to QDoubleValidator."""
-        self.last_valid_value = self._line_edit.text()
-
-    def fixup(self, new_value):
-        """Entered when the data input is invalid according to QDoubleValidator (empty string or broken e notation)."""
-        logger.warning(f"An invalid value '{new_value}' was provided. Using '{self.last_valid_value}' instead.")
-        self._line_edit.setText(self.last_valid_value)
-
-
 class ImagesTabWidgetView(QWidget):
     def __init__(self, parent=None):
         super(ImagesTabWidgetView, self).__init__(parent=parent)
@@ -62,8 +43,8 @@ class ImagesTabWidgetView(QWidget):
 
         self.max_min_value_warning.setVisible(False)
 
-        self.min_value_validator = MinMaxDoubleValidator(self.min_value_line_edit, 0.0)
-        self.max_value_validator = MinMaxDoubleValidator(self.max_value_line_edit, 1.0)
+        self.min_value_validator = LineEditDoubleValidator(self.min_value_line_edit, 0.0)
+        self.max_value_validator = LineEditDoubleValidator(self.max_value_line_edit, 1.0)
         self.min_value_line_edit.setValidator(self.min_value_validator)
         self.max_value_line_edit.setValidator(self.max_value_validator)
 


### PR DESCRIPTION
**Description of work.**
This PR allows higher precision for the limits of the colourfill plot colour bar when changed from the Figure Options. It also now allows e notation. This was done by switching the QSpinBox's for QLineEdits.

**To test:**
1. Load any data.
2. Right click workspace and `Plot Colorfill`.
3. Click the cog wheel above the plot.
4. Go to the image tab.
5. Change the min value and max value. Try high precisions better than 0.0001, and e notation. Try invalid input.

Fixes #30494

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
