### PR TITLE
Fix Autoscale y in Muon Analysis

### DIFF
--- a/docs/source/release/v6.0.0/muon.rst
+++ b/docs/source/release/v6.0.0/muon.rst
@@ -38,6 +38,7 @@ Bug fixes
 - A bug has been fixed where changing rebin wouldn't update the plot in the GUI.
 - A bug has been fixed where the plot would update incorrectly when changing plot raw and plot difference.
 - A bug has been fixed where pressing autoscale y without any data loaded would cause a crash.
+- A bug has been fixed where autoscale y would not calculate the y limits correctly.
 
 ALC
 ---

--- a/scripts/Muon/GUI/Common/plot_widget/plotting_canvas/plotting_canvas_presenter.py
+++ b/scripts/Muon/GUI/Common/plot_widget/plotting_canvas/plotting_canvas_presenter.py
@@ -39,7 +39,9 @@ class PlottingCanvasPresenter(PlottingCanvasPresenterInterface):
 
     def _setup_autoscale_observer(self):
         self.uncheck_autoscale_observer = GenericObserver(self._options_presenter.uncheck_autoscale)
+        self.enable_yaxis_changer_observer = GenericObserver(self._options_presenter.enable_yaxis_changer)
         self._view.add_uncheck_autoscale_subscriber(self.uncheck_autoscale_observer)
+        self._view.add_uncheck_autoscale_subscriber(self.enable_yaxis_changer_observer)
 
         self.enable_autoscale_observer = GenericObserver(self._options_presenter.enable_autoscale)
         self._view.add_enable_autoscale_subscriber(self.enable_autoscale_observer)
@@ -234,9 +236,13 @@ class PlottingCanvasPresenter(PlottingCanvasPresenterInterface):
             self._view.autoscale_y_axes()
         else:
             self._view.set_axes_limits(xlims, ylims)
-            # override y values
-            if autoscale:
-                self._view.autoscale_y_axes()
+
+        if autoscale:
+            self._options_presenter.disable_yaxis_changer()
+            self._view.autoscale_y_axes()
+        else:
+            self._options_presenter.enable_yaxis_changer()
+
         titles = self._model.create_axes_titles()
         for axis_number, title in enumerate(titles):
             self._view.set_title(axis_number, title)


### PR DESCRIPTION
**Description of work.**
This PR fixes the autoscale y option in Muon Analysis. Previously there was no margin on the upper part of the plot. It also corrects a minor issue where the y axis changer option goes out-of-sync with the autoscale y option.

**To test:**
1. Open Muon Analysis
2. `Load Current Run`
3. Check that the line plotted fits well onto the plot in the y direction. There should be a margin in the y axis of around 20%.

Fixes #30496

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
