### PR TITLE
Allow and block options for LoadNexusLogs ornl-next

### DIFF
--- a/Framework/DataHandling/inc/MantidDataHandling/LoadNexusLogs.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/LoadNexusLogs.h
@@ -74,7 +74,9 @@ private:
    */
   void loadLogs(::NeXus::File &file, const std::string &absolute_entry_name,
                 const std::string &entry_class,
-                const std::shared_ptr<API::MatrixWorkspace> &workspace) const;
+                const std::shared_ptr<API::MatrixWorkspace> &workspace,
+                const std::vector<std::string> &allow_list,
+                const std::vector<std::string> &block_list) const;
 
   /**
    * Load an NXlog entry

--- a/Framework/DataHandling/src/LoadNexusLogs.cpp
+++ b/Framework/DataHandling/src/LoadNexusLogs.cpp
@@ -9,7 +9,6 @@
 #include "MantidAPI/LogManager.h"
 #include "MantidAPI/Run.h"
 #include "MantidKernel/ArrayProperty.h"
-#include "MantidKernel/Exception.h"
 #include "MantidKernel/TimeSeriesProperty.h"
 #include <locale>
 #include <nexus/NeXusException.hpp>
@@ -457,7 +456,7 @@ void LoadNexusLogs::execLoader() {
   std::string entry_name = getPropertyValue("NXentryName");
 
   std::string allow_list = getPropertyValue("AllowList");
-  const std::string block_list = getPropertyValue("BlockList");
+  std::string block_list = getPropertyValue("BlockList");
 
   // Find the entry name to use (normally "entry" for SNS, "raw_data_1" for
   // ISIS) if entry name is empty

--- a/Framework/DataHandling/src/LoadNexusLogs.cpp
+++ b/Framework/DataHandling/src/LoadNexusLogs.cpp
@@ -518,6 +518,8 @@ void LoadNexusLogs::execLoader() {
         "Please only enter values for one of these fields.");
   }
 
+  // TODO: Handle logs specified for AllowList and BlockList.
+
   const std::map<std::string, std::set<std::string>> &allEntries =
       getFileInfo()->getAllEntries();
 
@@ -530,14 +532,6 @@ void LoadNexusLogs::execLoader() {
     const std::set<std::string> &entries = itGroupClass->second;
     // still a linear search
     for (const std::string &entry : entries) {
-      // skip loading unneccessary logs
-      if (!allow_list.empty() &&
-          !(allow_list.find(entry) != std::string::npos)) {
-        break;
-      }
-      if (!block_list.empty() && block_list.find(entry) != std::string::npos) {
-        break;
-      }
       // match for 2nd level entry /a/b
       if (std::count(entry.begin(), entry.end(), '/') == 2) {
         if (isLog) {
@@ -564,16 +558,6 @@ void LoadNexusLogs::execLoader() {
       if (itGroupName == entries.end()) {
         continue;
       }
-      // skip loading unneccessary logs
-      if (!allow_list.empty() &&
-          !(allow_list.find(group_name) != std::string::npos)) {
-        break;
-      }
-      if (!block_list.empty() &&
-          (block_list.find(group_name) != std::string::npos)) {
-        break;
-      }
-
       // here we must search only in NxLogs and NXpositioner sets
       loadLogs(file, absoluteGroupName, group_class, workspace);
     }

--- a/Framework/DataHandling/src/LoadNexusLogs.cpp
+++ b/Framework/DataHandling/src/LoadNexusLogs.cpp
@@ -797,6 +797,8 @@ void LoadNexusLogs::loadNPeriods(
  * @param absolute_entry_name :: The name of the log entry
  * @param entry_class :: The class type of the log entry
  * @param workspace :: A pointer to the workspace to store the logs
+ * @param allow_list :: Names of specific log entries to load
+ * @param block_list :: Names of specific log entries to skip when loading
  */
 void LoadNexusLogs::loadLogs(
     ::NeXus::File &file, const std::string &absolute_entry_name,

--- a/Framework/DataHandling/test/LoadNexusLogsTest.h
+++ b/Framework/DataHandling/test/LoadNexusLogsTest.h
@@ -268,7 +268,7 @@ public:
     loader.initialize();
     loader.setProperty("Workspace", testWS);
     loader.setPropertyValue("Filename", "larmor_array_time_series_mock.nxs");
-    TS_ASSERT_THROWS_NOTHING(loader.execute())
+    TS_ASSERT_THROWS_NOTHING(loader.execute());
   }
 
   void test_last_time_series_log_entry_equals_end_time() {
@@ -349,6 +349,53 @@ public:
     TS_ASSERT_DELTA(pclogFiltered2->nthValue(0), 3, 1e-5);
     TS_ASSERT_DELTA(pclogFiltered2->nthValue(1), 5, 1e-5);
     TS_ASSERT_DELTA(pclogFiltered2->nthValue(2), 7, 1e-5);
+  }
+
+  // TODO: Check whether the correct logs are in the final workspace
+  void test_allow_list() {
+    auto testWS = createTestWorkspace();
+    auto run = testWS->run();
+
+    LoadNexusLogs loader;
+    loader.setChild(true);
+    loader.initialize();
+    loader.setProperty("Workspace", testWS);
+    loader.setPropertyValue("Filename", "LARMOR00003368.nxs");
+    loader.setPropertyValues("AllowList", ""); // Specify logs to allow here
+    loader.setPropertyValues("BlockList", "");
+    loader.execute();
+    TS_ASSERT_THROWS_NOTHING(loader.execute());
+  }
+
+  void test_block_list() {
+    auto testWS = createTestWorkspace();
+    auto run = testWS->run();
+
+    LoadNexusLogs loader;
+    loader.setChild(true);
+    loader.initialize();
+    loader.setProperty("Workspace", testWS);
+    loader.setPropertyValue("Filename", "LARMOR00003368.nxs");
+    loader.setPropertyValue("AllowList", "");
+    loader.setPropertyValue("BlockList", ""); // Specify logs to block here
+    loader.execute();
+    run = testWS->run();
+    TS_ASSERT_THROWS_NOTHING(loader.execute());
+  }
+
+  void test_allow_and_block_list() {
+    auto testWS = createTestWorkspace();
+    auto run = testWS->run();
+
+    LoadNexusLogs loader;
+    loader.setChild(true);
+    loader.initialize();
+    loader.setProperty("Workspace", testWS);
+    loader.setPropertyValue("Filename", "LARMOR00003368.nxs");
+    loader.setPropertyValue("AllowList", ""); // Specify nothing for either
+    loader.setPropertyValue("BlockList", ""); // To ensure logs load as expected
+    loader.execute();
+    TS_ASSERT_THROWS_NOTHING(loader.execute());
   }
 
 private:

--- a/Framework/DataHandling/test/LoadNexusLogsTest.h
+++ b/Framework/DataHandling/test/LoadNexusLogsTest.h
@@ -351,25 +351,58 @@ public:
     TS_ASSERT_DELTA(pclogFiltered2->nthValue(2), 7, 1e-5);
   }
 
-  // TODO: Check whether the correct logs are in the final workspace
   void test_allow_list() {
     auto testWS = createTestWorkspace();
-    auto run = testWS->run();
+    
+    std::vector<std::string> allowed = {"proton_charge", "S2HGap", "S2VGap"};
 
     LoadNexusLogs loader;
     loader.setChild(true);
     loader.initialize();
     loader.setProperty("Workspace", testWS);
     loader.setPropertyValue("Filename", "LARMOR00003368.nxs");
-    loader.setPropertyValues("AllowList", ""); // Specify logs to allow here
-    loader.setPropertyValues("BlockList", "");
+    loader.setProperty<std::vector<std::string>>("AllowList", allowed);
+    loader.setPropertyValue("BlockList", "");
     loader.execute();
     TS_ASSERT_THROWS_NOTHING(loader.execute());
+
+    // selog versions
+    allowed.push_back("selog_S2HGap");
+    allowed.push_back("selog_S2VGap");
+
+    // extra proton charge properties
+    allowed.push_back("gd_prtn_chrg");
+    allowed.push_back("proton_charge_by_period");
+    allowed.push_back("nperiods");
+
+    // The default logs that are always present:
+    allowed.push_back("start_time");
+    allowed.push_back("end_time");
+    allowed.push_back("run_title");
+
+    auto run = testWS->run();
+    auto properties = run.getProperties();
+
+    TS_ASSERT_EQUALS(properties.size(), allowed.size());
+
+    // Lookup each name in the workspace property list
+    for( const auto &name : allowed) {
+      bool found = false;
+      for (const auto &prop : properties) {
+        if(prop->name() == name) {
+          found = true;
+          break;
+        }
+      }
+      TS_ASSERT_EQUALS(found, true);
+    }
+
   }
 
   void test_block_list() {
     auto testWS = createTestWorkspace();
-    auto run = testWS->run();
+    
+    std::vector<std::string> blocked = {"proton_charge", "S2HGap", "S2VGap"};
 
     LoadNexusLogs loader;
     loader.setChild(true);
@@ -377,15 +410,32 @@ public:
     loader.setProperty("Workspace", testWS);
     loader.setPropertyValue("Filename", "LARMOR00003368.nxs");
     loader.setPropertyValue("AllowList", "");
-    loader.setPropertyValue("BlockList", ""); // Specify logs to block here
+    loader.setProperty<std::vector<std::string>>("BlockList", blocked);
     loader.execute();
-    run = testWS->run();
     TS_ASSERT_THROWS_NOTHING(loader.execute());
+
+    auto run = testWS->run();
+    auto properties = run.getProperties();
+
+    // add 2 to account for selog_ versions of properties
+    TS_ASSERT_EQUALS(properties.size(), 94 - blocked.size() - 2);
+
+    // Lookup each name in the workspace property list
+    for( const auto &name : blocked) {
+      bool found = false;
+      for (const auto &prop : properties) {
+        if(prop->name() == name) {
+          found = true;
+          break;
+        }
+      }
+      TS_ASSERT_EQUALS(found, false);
+    }
+
   }
 
   void test_allow_and_block_list() {
     auto testWS = createTestWorkspace();
-    auto run = testWS->run();
 
     LoadNexusLogs loader;
     loader.setChild(true);
@@ -396,6 +446,11 @@ public:
     loader.setPropertyValue("BlockList", ""); // To ensure logs load as expected
     loader.execute();
     TS_ASSERT_THROWS_NOTHING(loader.execute());
+
+    auto run = testWS->run();
+    auto properties = run.getProperties();
+
+    TS_ASSERT_EQUALS(properties.size(), 94);
   }
 
 private:

--- a/Framework/DataHandling/test/LoadNexusLogsTest.h
+++ b/Framework/DataHandling/test/LoadNexusLogsTest.h
@@ -395,6 +395,9 @@ public:
         }
       }
       TS_ASSERT_EQUALS(found, true);
+      if (!found) {
+        break;
+      }
     }
   }
 
@@ -429,6 +432,9 @@ public:
         }
       }
       TS_ASSERT_EQUALS(found, false);
+      if (found) {
+        break;
+      }
     }
   }
 

--- a/Framework/DataHandling/test/LoadNexusLogsTest.h
+++ b/Framework/DataHandling/test/LoadNexusLogsTest.h
@@ -353,7 +353,7 @@ public:
 
   void test_allow_list() {
     auto testWS = createTestWorkspace();
-    
+
     std::vector<std::string> allowed = {"proton_charge", "S2HGap", "S2VGap"};
 
     LoadNexusLogs loader;
@@ -386,22 +386,21 @@ public:
     TS_ASSERT_EQUALS(properties.size(), allowed.size());
 
     // Lookup each name in the workspace property list
-    for( const auto &name : allowed) {
+    for (const auto &name : allowed) {
       bool found = false;
       for (const auto &prop : properties) {
-        if(prop->name() == name) {
+        if (prop->name() == name) {
           found = true;
           break;
         }
       }
       TS_ASSERT_EQUALS(found, true);
     }
-
   }
 
   void test_block_list() {
     auto testWS = createTestWorkspace();
-    
+
     std::vector<std::string> blocked = {"proton_charge", "S2HGap", "S2VGap"};
 
     LoadNexusLogs loader;
@@ -421,17 +420,16 @@ public:
     TS_ASSERT_EQUALS(properties.size(), 94 - blocked.size() - 2);
 
     // Lookup each name in the workspace property list
-    for( const auto &name : blocked) {
+    for (const auto &name : blocked) {
       bool found = false;
       for (const auto &prop : properties) {
-        if(prop->name() == name) {
+        if (prop->name() == name) {
           found = true;
           break;
         }
       }
       TS_ASSERT_EQUALS(found, false);
     }
-
   }
 
   void test_allow_and_block_list() {

--- a/docs/source/algorithms/LoadNexusLogs-v1.rst
+++ b/docs/source/algorithms/LoadNexusLogs-v1.rst
@@ -65,6 +65,11 @@ Items missing from the Nexus file are simply not loaded.
 
 If the nexus file has a ``"proton_log"`` group, then this algorithm will do some event filtering to allow SANS2D files to load.
 
+The ``AllowList`` option skips loading of the entire sample log, and loads only log entries specified in the list. This can be
+useful if only particular log entries are needed. Likewise, the ``BlockList`` option will skip loading log entries specified in 
+the list, while loading all other sample log entries that are not found in the list. For both of these options, log entry names
+should be separated by a space. Both ``AllowList`` and ``BlockList`` cannot be set at the same time.
+
 Usage
 -----
 

--- a/docs/source/release/v6.1.0/framework.rst
+++ b/docs/source/release/v6.1.0/framework.rst
@@ -14,6 +14,7 @@ Concepts
 
 Algorithms
 ----------
+:ref:`LoadNexusLogs <algm-LoadNexusLogs>` has additional parameters to allow or block specific logs from being loaded.
 
 Data Objects
 ------------


### PR DESCRIPTION
Version of #30506 into `ornl-next`

Refer to gitlab task [PD161](https://code.ornl.gov/sns-hfir-scse/diffraction/powder/powder-diffraction/-/issues/161).

