### PR TITLE
Add missing categories directive to some doc pages

### DIFF
--- a/docs/source/algorithms/AddAbsorptionWeightedPathLengths-v1.rst
+++ b/docs/source/algorithms/AddAbsorptionWeightedPathLengths-v1.rst
@@ -102,3 +102,7 @@ References
           `doi: 10.1107/S0365110X57002212 <http://dx.doi.org/10.1107/S0365110X57002212>`_
 .. [#SAB] Sabine, T. M., *International Tables for Crystallography*, Vol. C, Page 609, Ed. Wilson, A. J. C and Prince, E. Kluwer Publishers (2004)
           `doi: 10.1107/97809553602060000103 <http://dx.doi.org/10.1107/97809553602060000103>`_
+
+.. categories::
+
+.. sourcelink::

--- a/docs/source/algorithms/MatchAndMergeWorkspaces-v1.rst
+++ b/docs/source/algorithms/MatchAndMergeWorkspaces-v1.rst
@@ -65,3 +65,7 @@ Workflow
 ########
 
 .. diagram:: MatchAndMergeWorkspaces-v1_wkflw.dot
+
+.. categories::
+
+.. sourcelink::

--- a/docs/source/algorithms/Segfault-v1.rst
+++ b/docs/source/algorithms/Segfault-v1.rst
@@ -13,3 +13,7 @@ Description
 The purpose of this algorithm is to crash mantid. Do **not** run it
 unless you want that to happen. This runs a variation the example code
 on `wikipedia <https://en.wikipedia.org/wiki/Segmentation_fault>`_.
+
+.. categories::
+
+.. sourcelink::

--- a/docs/source/algorithms/TotScatCalculateSelfScattering-v1.rst
+++ b/docs/source/algorithms/TotScatCalculateSelfScattering-v1.rst
@@ -29,3 +29,7 @@ Workflow
 ########
 
 .. diagram:: TotScatCalculateSelfScattering-v1_wkflw.dot
+
+.. categories::
+
+.. sourcelink::


### PR DESCRIPTION
**Description of work.**

The AddAbsorptionWeightedPathLengths algorithm wasn't showing up on the Algorithms Index page because it was missing a .. categories:: line in the .rst file. I've added this in and have also added in for a few other doc pages that were also missing it

**To test:**

Build docs and go to algorithms index page (Help, Algorithm Descriptions and then scroll to bottom to see link to Algorithms Index page)
Check AddAbsorptionWeightedPathLengths algorithm is now present

Fixes #30509.

*This does not require release notes* because **v minor change to algorithm index page**

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
