### PR TITLE
Fix qt-help documentation errors

### DIFF
--- a/Framework/Algorithms/inc/MantidAlgorithms/CorelliPowderCalibrationApply.h
+++ b/Framework/Algorithms/inc/MantidAlgorithms/CorelliPowderCalibrationApply.h
@@ -44,8 +44,7 @@ public:
 
   /// Extra help info
   const std::vector<std::string> seeAlso() const override {
-    return {"CorelliPowderCalibrationGenerate",
-            "CorelliPowderCalibrationDatabase", "CorelliPowderCalibrationLoad"};
+    return {"CorelliPowderCalibrationDatabase"};
   };
 
 private:

--- a/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/CorelliPowderCalibrationCreate.py
+++ b/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/CorelliPowderCalibrationCreate.py
@@ -94,8 +94,7 @@ class CorelliPowderCalibrationCreate(DataProcessorAlgorithm):
         return 'Diffraction\\Reduction'
 
     def seeAlso(self):
-        return ['PDCalibration', 'AlignDetectors', 'AlignComponents',
-                'CORELLIPowderCalibrationDatabase', 'CORELLIPowderCalibrationLoad', 'CORELLIPowderCalibrationApply']
+        return ['PDCalibration', 'AlignDetectors', 'AlignComponents']
 
     def summary(self):
         return "Adjust bank positions and orientations to optimize peak determination in d-spacing"

--- a/docs/source/concepts/CrystalField.rst
+++ b/docs/source/concepts/CrystalField.rst
@@ -213,10 +213,8 @@ properties of the material, such as its low temperature heat capacity and magnet
 magnetic fields, the Zeeman term,
 
 .. math::
-    \begin{eqnarray}
-      \mathcal{H}_{\mathrm{Z}} &=& -\mu_B \mathbf{H} \cdot \left( \mathbf{L} + 2 \mathbf{S} \right) \mathrm{\qquad or\ } \\
-                               &=& -\mu_B \mathbf{H} \cdot \left( g_J \mathbf{J} \right) ,
-    \end{eqnarray}
+      \mathcal{H}_{\mathrm{Z}} &= -\mu_B \mathbf{H} \cdot \left( \mathbf{L} + 2 \mathbf{S} \right) \mathrm{\qquad or\ } \\
+                               &= -\mu_B \mathbf{H} \cdot \left( g_J \mathbf{J} \right) ,
   :label: zeeman
 
 where the second equality applies in the case of the rare-earths, where :math:`L+2S=g_J J` and the Landé
@@ -251,12 +249,9 @@ value of the eigenvalues of the Hamiltonian, e.g. :math:`U = \frac{1}{Z}\sum_n E
 Thus the heat capacity is
 
 .. math::
-    \begin{multline}
-    C_v = \frac{1}{k_BT^2} \left\{ -\left(\frac{1}{Z}\sum_n E_n \exp(-\beta E_n)\right)^2 + %\right. \\
-                 %    \left.      
-                  \frac{1}{Z} \sum_n E_n^2 \exp(-\beta E_n) \right\},
-    \end{multline}
-  :label: heatcapacity
+    C_v = \frac{1}{k_BT^2} \left\{ -\left(\frac{1}{Z}\sum_n E_n \exp(-\beta E_n)\right)^2 +
+    \frac{1}{Z} \sum_n E_n^2 \exp(-\beta E_n) \right\},
+    :label: heatcapacity
 
 where :math:`\beta = 1/k_B T`.
 
@@ -328,12 +323,10 @@ because they transform in the same way under rotations as the :math:`C_{lm}` fun
 What this means is that they obey the same commutation relations with respects to the angular momentum operators:
 
 .. math::
-    \begin{align}
         [J_z,C_{lm}] &= m C_{lm}, \\
         [J_{\pm},C_{lm}] &= \sqrt{(l\mp m)(l\pm m+1)} C_{l,m\pm 1}, \\
         [J_z,T_q^{(k)}] &= q T_q^{(k)}, \\
         [J_{\pm},T_q^{(k)}] &= \sqrt{(k\mp q)(k\pm q+1)} T_{q\pm 1}^{(k)}.
-    \end{align}
 
 Now, it turns out the matrix elements of the tensor operators can expressed, via the Wigner-Eckart theorem, as the
 product of an angular momentum coupling (Clebsch-Gordan) coefficient, and a *reduced matrix element*,
@@ -408,10 +401,8 @@ The crystal field in Stevens normalisation used in Mantid is then defined by:
 so the Stevens :math:`A_q^k` and :math:`B_q^k` parameters are related to the real-valued Wybourne parameters by:
 
 .. math::
-    \begin{eqnarray}
-    A_q^k &=& \lambda_{k,|q|} L_q^k / \langle r^k \rangle \\
-    B_q^k &=& \lambda_{k,|q|} \theta_k L_q^k
-    \end{eqnarray}
+    A_q^k &= \lambda_{k,|q|} L_q^k / \langle r^k \rangle \\
+    B_q^k &= \lambda_{k,|q|} \theta_k L_q^k
 
 where :math:`\theta_k` are the Stevens operator equivalent factors tabulated in `Table 1`_.
 


### PR DESCRIPTION
**Description of work.**
Currently, windows builds of the release-next pacakge are not going though the builds servers due errors building the qt-help documentation.
This PR fixes issues due to the  math formatting environments e.g.` align` and `multiline`. When you start a sphinx math block it creates a `split` environment which allows you to do multiline equations.

When you nest another environment, it  throws up warnings as nesting of `split` and `align` isn't supported in Latex. You should be able to turn off the automatic wrapping the `:math:` environment provides using `:nowrap`, however this option seems to be unsupported in our configuration. With the `nowrap` option, the following multline equation would be supported,

```
.. math::
   :nowrap:
   \begin{eqnarray}
      y    & = & ax^2 + bx + c \\
      f(x) & = & x^2 + 2xy + y^2
   \end{eqnarray}
```



**To test:**
- Check builds pass and the windows package builds
- Build both the html docs and the qt-help docs and check the formatting.


*There is no associated issue.*


This does not require release notes as it is an interal change


<!-- Ensure the base of this PR is correct (e.g. release-next or master)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
