### PR TITLE
Muon ALC - Disable load when editing runs begins

### DIFF
--- a/docs/source/release/v6.0.0/muon.rst
+++ b/docs/source/release/v6.0.0/muon.rst
@@ -61,6 +61,8 @@ Bug fixes
 ##########
 - Stopped scientific notation when plotting run numbers on x axis.
 - A bug has been fixed where exported results were unintentionally being mixed together in their group workspaces.
+- A bug has been fixed where the Load button had to be pressed twice after an initial batch of runs had already been loaded.
+- A bug has been fixed where the log was being reset when loading runs after an initial batch of runs.
 
 Elemental Analysis
 ------------------

--- a/qt/scientific_interfaces/Muon/ALCDataLoadingPresenter.cpp
+++ b/qt/scientific_interfaces/Muon/ALCDataLoadingPresenter.cpp
@@ -67,6 +67,7 @@ void ALCDataLoadingPresenter::handleRunsEditing() {
 void ALCDataLoadingPresenter::handleRunsEditingFinished() {
   // Make sure everything is reset
   m_view->enableRunsAutoAdd(false);
+  m_view->enablePlotByLogGroup(false);
 
   if (m_previousFirstRun !=
       m_view->getInstrument() + m_view->getRunsFirstRunText())
@@ -121,6 +122,7 @@ void ALCDataLoadingPresenter::handleLoadRequested() {
     m_view->setLoadStatus("Error", "red");
     m_view->displayError("The list of files to load is empty");
     m_view->enableRunsAutoAdd(false);
+    m_view->enablePlotByLogGroup(false);
     return;
   }
 
@@ -142,6 +144,7 @@ void ALCDataLoadingPresenter::handleLoadRequested() {
                               m_view->getRunsText(),
                           "green");
     m_view->enableRunsAutoAdd(true);
+    m_view->enablePlotByLogGroup(true);
 
     // If alpha empty, default used is 1 so update interface
     if (m_view->getAlphaValue() == "1.0" && m_view->isAlphaEnabled())
@@ -150,6 +153,7 @@ void ALCDataLoadingPresenter::handleLoadRequested() {
     m_view->setLoadStatus("Error", "red");
     m_view->displayError(errorLoadFiles.what());
     m_view->enableRunsAutoAdd(false);
+    m_view->enablePlotByLogGroup(false);
     m_view->enableAll();
     m_loadingData = false;
   }

--- a/qt/scientific_interfaces/Muon/ALCDataLoadingPresenter.cpp
+++ b/qt/scientific_interfaces/Muon/ALCDataLoadingPresenter.cpp
@@ -47,7 +47,9 @@ void ALCDataLoadingPresenter::initialize() {
   connect(m_view, SIGNAL(loadRequested()), SLOT(handleLoadRequested()));
   connect(m_view, SIGNAL(instrumentChangedSignal(std::string)),
           SLOT(handleInstrumentChanged(std::string)));
-  connect(m_view, SIGNAL(runsChangedSignal()), SLOT(handleRunsChanged()));
+  connect(m_view, SIGNAL(runsEditingSignal()), SLOT(handleRunsEditing()));
+  connect(m_view, SIGNAL(runsEditingFinishedSignal()),
+          SLOT(handleRunsEditingFinished()));
   connect(m_view, SIGNAL(manageDirectoriesClicked()),
           SLOT(handleManageDirectories()));
   connect(m_view, SIGNAL(runsFoundSignal()), SLOT(handleRunsFound()));
@@ -57,10 +59,13 @@ void ALCDataLoadingPresenter::initialize() {
           SLOT(updateDirectoryChangedFlag(const QString &)));
 }
 
-void ALCDataLoadingPresenter::handleRunsChanged() {
-  // Make sure everything is reset
+void ALCDataLoadingPresenter::handleRunsEditing() {
   m_view->enableLoad(false);
   m_view->setPath(std::string{});
+}
+
+void ALCDataLoadingPresenter::handleRunsEditingFinished() {
+  // Make sure everything is reset
   m_view->enableRunsAutoAdd(false);
 
   if (m_previousFirstRun !=

--- a/qt/scientific_interfaces/Muon/ALCDataLoadingPresenter.cpp
+++ b/qt/scientific_interfaces/Muon/ALCDataLoadingPresenter.cpp
@@ -67,7 +67,6 @@ void ALCDataLoadingPresenter::handleRunsEditing() {
 void ALCDataLoadingPresenter::handleRunsEditingFinished() {
   // Make sure everything is reset
   m_view->enableRunsAutoAdd(false);
-  m_view->enablePlotByLogGroup(false);
 
   if (m_previousFirstRun !=
       m_view->getInstrument() + m_view->getRunsFirstRunText())
@@ -122,7 +121,6 @@ void ALCDataLoadingPresenter::handleLoadRequested() {
     m_view->setLoadStatus("Error", "red");
     m_view->displayError("The list of files to load is empty");
     m_view->enableRunsAutoAdd(false);
-    m_view->enablePlotByLogGroup(false);
     return;
   }
 
@@ -144,7 +142,6 @@ void ALCDataLoadingPresenter::handleLoadRequested() {
                               m_view->getRunsText(),
                           "green");
     m_view->enableRunsAutoAdd(true);
-    m_view->enablePlotByLogGroup(true);
 
     // If alpha empty, default used is 1 so update interface
     if (m_view->getAlphaValue() == "1.0" && m_view->isAlphaEnabled())
@@ -153,7 +150,6 @@ void ALCDataLoadingPresenter::handleLoadRequested() {
     m_view->setLoadStatus("Error", "red");
     m_view->displayError(errorLoadFiles.what());
     m_view->enableRunsAutoAdd(false);
-    m_view->enablePlotByLogGroup(false);
     m_view->enableAll();
     m_loadingData = false;
   }

--- a/qt/scientific_interfaces/Muon/ALCDataLoadingPresenter.h
+++ b/qt/scientific_interfaces/Muon/ALCDataLoadingPresenter.h
@@ -50,8 +50,11 @@ private slots:
   /// Updates the list of logs and number of periods
   void updateAvailableInfo();
 
-  /// Handle for when runs line edit changed
-  void handleRunsChanged();
+  /// Handle for when runs editing starts
+  void handleRunsEditing();
+
+  /// Handle for when runs editing finishes
+  void handleRunsEditingFinished();
 
   /// Handle for when instrument changed
   void handleInstrumentChanged(std::string instrument);

--- a/qt/scientific_interfaces/Muon/ALCDataLoadingView.cpp
+++ b/qt/scientific_interfaces/Muon/ALCDataLoadingView.cpp
@@ -333,6 +333,7 @@ void ALCDataLoadingView::disableAll() {
 void ALCDataLoadingView::enableAll() {
 
   // Enable all the widgets in the view
+  m_ui.plotByLogGroup->setEnabled(true);
   m_ui.deadTimeGroup->setEnabled(true);
   m_ui.dataGroup->setEnabled(true);
   m_ui.detectorGroupingGroup->setEnabled(true);
@@ -350,6 +351,10 @@ void ALCDataLoadingView::instrumentChanged(QString instrument) {
 
 void ALCDataLoadingView::enableLoad(bool enable) {
   m_ui.load->setEnabled(enable);
+}
+
+void ALCDataLoadingView::enablePlotByLogGroup(bool enable) {
+  m_ui.plotByLogGroup->setEnabled(enable);
 }
 
 void ALCDataLoadingView::setPath(const std::string &path) {

--- a/qt/scientific_interfaces/Muon/ALCDataLoadingView.cpp
+++ b/qt/scientific_interfaces/Muon/ALCDataLoadingView.cpp
@@ -43,7 +43,10 @@ void ALCDataLoadingView::initialize() {
   connect(m_ui.help, SIGNAL(clicked()), this, SLOT(help()));
   connect(m_ui.instrument, SIGNAL(currentTextChanged(QString)), this,
           SLOT(instrumentChanged(QString)));
-  connect(m_ui.runs, SIGNAL(findingFiles()), SIGNAL(runsChangedSignal()));
+  connect(m_ui.runs, SIGNAL(fileTextChanged(const QString &)),
+          SIGNAL(runsEditingSignal()));
+  connect(m_ui.runs, SIGNAL(findingFiles()),
+          SIGNAL(runsEditingFinishedSignal()));
   connect(m_ui.runs, SIGNAL(fileFindingFinished()), SIGNAL(runsFoundSignal()));
   connect(m_ui.manageDirectoriesButton, SIGNAL(clicked()),
           SIGNAL(manageDirectoriesClicked()));

--- a/qt/scientific_interfaces/Muon/ALCDataLoadingView.cpp
+++ b/qt/scientific_interfaces/Muon/ALCDataLoadingView.cpp
@@ -19,13 +19,15 @@
 
 using namespace Mantid::API;
 
+const QString DEFAULT_LOG("run_number");
 const std::vector<std::string> INSTRUMENTS{"ARGUS", "CHRONUS", "EMU", "HIFI",
                                            "MUSR"};
 
 namespace MantidQt {
 namespace CustomInterfaces {
 
-ALCDataLoadingView::ALCDataLoadingView(QWidget *widget) : m_widget(widget) {}
+ALCDataLoadingView::ALCDataLoadingView(QWidget *widget)
+    : m_widget(widget), m_selectedLog(DEFAULT_LOG) {}
 
 ALCDataLoadingView::~ALCDataLoadingView() {}
 
@@ -227,14 +229,28 @@ bool ALCDataLoadingView::displayWarning(const std::string &warning) {
  */
 void ALCDataLoadingView::setAvailableLogs(
     const std::vector<std::string> &logs) {
+  const auto currentLog = m_ui.logValueSelector->getLog();
+  if (!currentLog.isEmpty())
+    m_selectedLog = currentLog;
+
   setAvailableItems(m_ui.logValueSelector->getLogComboBox(), logs);
-  // Set defualt as run number
-  if (!logs.empty()) {
-    auto index =
-        m_ui.logValueSelector->getLogComboBox()->findText("run_number");
-    if (index >= 0)
-      m_ui.logValueSelector->getLogComboBox()->setCurrentIndex(index);
+
+  if (!setCurrentLog(m_selectedLog))
+    setCurrentLog(DEFAULT_LOG);
+}
+
+/**
+ * Set the currently selected log
+ * @param log :: The log to search for and select.
+ * @returns true if the log was found and selected.
+ */
+bool ALCDataLoadingView::setCurrentLog(const QString &log) {
+  const auto index = m_ui.logValueSelector->getLogComboBox()->findText(log);
+  if (index >= 0) {
+    m_ui.logValueSelector->getLogComboBox()->setCurrentIndex(index);
+    m_selectedLog = log;
   }
+  return index >= 0;
 }
 
 /**

--- a/qt/scientific_interfaces/Muon/ALCDataLoadingView.cpp
+++ b/qt/scientific_interfaces/Muon/ALCDataLoadingView.cpp
@@ -322,6 +322,7 @@ void ALCDataLoadingView::help() {
 void ALCDataLoadingView::disableAll() {
 
   // Disable all the widgets in the view
+  m_ui.plotByLogGroup->setEnabled(false);
   m_ui.dataGroup->setEnabled(false);
   m_ui.deadTimeGroup->setEnabled(false);
   m_ui.detectorGroupingGroup->setEnabled(false);
@@ -351,10 +352,6 @@ void ALCDataLoadingView::instrumentChanged(QString instrument) {
 
 void ALCDataLoadingView::enableLoad(bool enable) {
   m_ui.load->setEnabled(enable);
-}
-
-void ALCDataLoadingView::enablePlotByLogGroup(bool enable) {
-  m_ui.plotByLogGroup->setEnabled(enable);
 }
 
 void ALCDataLoadingView::setPath(const std::string &path) {

--- a/qt/scientific_interfaces/Muon/ALCDataLoadingView.h
+++ b/qt/scientific_interfaces/Muon/ALCDataLoadingView.h
@@ -69,7 +69,6 @@ public:
   void setAvailableInfoToEmpty() override;
   void instrumentChanged(QString instrument) override;
   void enableLoad(bool enable) override;
-  void enablePlotByLogGroup(bool enable) override;
   void setPath(const std::string &path) override;
   void enableRunsAutoAdd(bool enable) override;
   void setInstrument(const std::string &instrument) override;

--- a/qt/scientific_interfaces/Muon/ALCDataLoadingView.h
+++ b/qt/scientific_interfaces/Muon/ALCDataLoadingView.h
@@ -94,11 +94,15 @@ private:
   void setAvailableItems(QComboBox *comboBox,
                          const std::vector<std::string> &items);
 
+  bool setCurrentLog(const QString &log);
+
   /// UI form
   Ui::ALCDataLoadingView m_ui;
 
   /// The widget used
   QWidget *const m_widget;
+
+  QString m_selectedLog;
 };
 
 } // namespace CustomInterfaces

--- a/qt/scientific_interfaces/Muon/ALCDataLoadingView.h
+++ b/qt/scientific_interfaces/Muon/ALCDataLoadingView.h
@@ -69,6 +69,7 @@ public:
   void setAvailableInfoToEmpty() override;
   void instrumentChanged(QString instrument) override;
   void enableLoad(bool enable) override;
+  void enablePlotByLogGroup(bool enable) override;
   void setPath(const std::string &path) override;
   void enableRunsAutoAdd(bool enable) override;
   void setInstrument(const std::string &instrument) override;

--- a/qt/scientific_interfaces/Muon/IALCDataLoadingView.h
+++ b/qt/scientific_interfaces/Muon/IALCDataLoadingView.h
@@ -148,6 +148,9 @@ public slots:
   /// Enables/Disables the load button when ready
   virtual void enableLoad(bool enable) = 0;
 
+  /// Enables/Disables the Plot by log group
+  virtual void enablePlotByLogGroup(bool enable) = 0;
+
   /// Sets path from where data loaded from
   virtual void setPath(const std::string &path) = 0;
 

--- a/qt/scientific_interfaces/Muon/IALCDataLoadingView.h
+++ b/qt/scientific_interfaces/Muon/IALCDataLoadingView.h
@@ -148,9 +148,6 @@ public slots:
   /// Enables/Disables the load button when ready
   virtual void enableLoad(bool enable) = 0;
 
-  /// Enables/Disables the Plot by log group
-  virtual void enablePlotByLogGroup(bool enable) = 0;
-
   /// Sets path from where data loaded from
   virtual void setPath(const std::string &path) = 0;
 

--- a/qt/scientific_interfaces/Muon/IALCDataLoadingView.h
+++ b/qt/scientific_interfaces/Muon/IALCDataLoadingView.h
@@ -180,8 +180,11 @@ signals:
   /// Request to load data
   void loadRequested();
 
-  /// User has changed runs
-  void runsChangedSignal();
+  /// User has started editing the runs
+  void runsEditingSignal();
+
+  /// User has finished editing the runs
+  void runsEditingFinishedSignal();
 
   /// New data have been loaded
   void dataChanged();

--- a/qt/scientific_interfaces/Muon/test/ALCDataLoadingPresenterTest.h
+++ b/qt/scientific_interfaces/Muon/test/ALCDataLoadingPresenterTest.h
@@ -73,6 +73,7 @@ public:
   MOCK_METHOD0(initInstruments, void());
   MOCK_METHOD1(instrumentChanged, void(QString));
   MOCK_METHOD1(enableLoad, void(bool));
+  MOCK_METHOD1(enablePlotByLogGroup, void(bool));
   MOCK_METHOD1(setPath, void(const std::string &));
   MOCK_METHOD1(enableRunsAutoAdd, void(bool));
   MOCK_METHOD1(setInstrument, void(const std::string &));

--- a/qt/scientific_interfaces/Muon/test/ALCDataLoadingPresenterTest.h
+++ b/qt/scientific_interfaces/Muon/test/ALCDataLoadingPresenterTest.h
@@ -73,7 +73,6 @@ public:
   MOCK_METHOD0(initInstruments, void());
   MOCK_METHOD1(instrumentChanged, void(QString));
   MOCK_METHOD1(enableLoad, void(bool));
-  MOCK_METHOD1(enablePlotByLogGroup, void(bool));
   MOCK_METHOD1(setPath, void(const std::string &));
   MOCK_METHOD1(enableRunsAutoAdd, void(bool));
   MOCK_METHOD1(setInstrument, void(const std::string &));

--- a/qt/scientific_interfaces/Muon/test/ALCDataLoadingPresenterTest.h
+++ b/qt/scientific_interfaces/Muon/test/ALCDataLoadingPresenterTest.h
@@ -88,7 +88,8 @@ public:
   MOCK_METHOD1(showAlphaMessage, void(const bool));
 
   // Some dummy signals
-  void changeRuns() { emit runsChangedSignal(); }
+  void emitRunsEditingSignal() { emit runsEditingSignal(); }
+  void changeRuns() { emit runsEditingFinishedSignal(); }
   void foundRuns() { emit runsFoundSignal(); }
   void requestLoading() { emit loadRequested(); }
 };
@@ -517,5 +518,12 @@ public:
                                             WorkspaceY(0, 0, 0.29773, 1E-5)),
                                       0));
     TS_ASSERT_THROWS_NOTHING(m_view->requestLoading());
+  }
+
+  void test_that_the_runsEditingSignal_will_disable_the_load_button() {
+    EXPECT_CALL(*m_view, enableLoad(false)).Times(1);
+    EXPECT_CALL(*m_view, setPath(std::string{})).Times(1);
+
+    m_view->emitRunsEditingSignal();
   }
 };


### PR DESCRIPTION
**Description of work.**
This PR fixes two minor bugs:
- One where it takes two clicks of the Load button to load the runs. The problem was caused by the load button being disabled milliseconds before the actual press of the Load button, so it appears it has been pressed when actually it hadn't. The fix was to disable the load button when editing of the runs begins, rather than when the editing of the runs end. This prevents the confusion seen in this issue.
- The sample log being reset whenever new runs are entered. It should just keep the old log when possible.

**To test:**
1. Open Muon ALC interface
2. Instrument is HIFI. Runs 83929-49
3. Press the enter key and wait for the runs to be found.
4. Select log `sample_mgn_field`
5. Click `Load`
6. Enter a new batch of runs 83951-71. The Load button should be disabled when the editing begins.
7. Press the enter key and wait for the runs to be found.
8. When the files are found the Log should have remainded the same `sample_mgn_field` and not have been reset.
7. Click `Load`. It should load it all successfully.

Fixes #30527

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
