### PR TITLE
Muon ALC - Import data into all three pages

### DIFF
--- a/docs/source/release/v6.0.0/muon.rst
+++ b/docs/source/release/v6.0.0/muon.rst
@@ -55,6 +55,7 @@ New Features
 Improvements
 ############
 - An x label has been added to the plot in data loading.
+- Imported data will now be loaded into all three pages on the ALC interface.
 
 Bug fixes
 ##########

--- a/qt/scientific_interfaces/Muon/ALCInterface.h
+++ b/qt/scientific_interfaces/Muon/ALCInterface.h
@@ -55,6 +55,10 @@ private slots:
   void updatePeakData();
 
 private:
+  void importLoadedData(const std::string &workspaceName);
+  void importBaselineData(const std::string &workspaceName);
+  void importPeakData(const std::string &workspaceName);
+
   /// UI form
   Ui::ALCInterface m_ui;
 


### PR DESCRIPTION
**Description of work.**
This PR ensures imported data on the ALC interface is loaded into all three pages (Data Loading, Baseline modelling & peak fitting).

**To test:**
1. Load the data below into mantid.
2. Open the Muon ALC interface
2. Click `Import Results` and enter the name of the imported workspace. Click Ok.
4. The imported data should be plotted. 
5. Go to `Baseline modelling`, the data should be plotted here too. Also check it is plotted in peak fitting.

**Test data**
[ALC1.zip](https://github.com/mantidproject/mantid/files/5902961/ALC1.zip)


Fixes #30531

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
