### PR TITLE
Muon ALC - Fix 'mixing together' of exported results

### DIFF
--- a/docs/source/release/v6.0.0/muon.rst
+++ b/docs/source/release/v6.0.0/muon.rst
@@ -59,6 +59,7 @@ Improvements
 Bug fixes
 ##########
 - Stopped scientific notation when plotting run numbers on x axis.
+- A bug has been fixed where exported results were unintentionally being mixed together in their group workspaces.
 
 Elemental Analysis
 ------------------

--- a/qt/scientific_interfaces/Muon/ALCInterface.cpp
+++ b/qt/scientific_interfaces/Muon/ALCInterface.cpp
@@ -187,14 +187,18 @@ void ALCInterface::exportResults() {
 
   std::map<std::string, Workspace_sptr> results;
 
-  results["Loaded_Data"] = m_dataLoading->exportWorkspace();
-
-  results["Baseline_Workspace"] = m_baselineModellingModel->exportWorkspace();
-  results["Baseline_Sections"] = m_baselineModellingModel->exportSections();
-  results["Baseline_Model"] = m_baselineModellingModel->exportModel();
-
-  results["Peaks_Workspace"] = m_peakFittingModel->exportWorkspace();
-  results["Peaks_FitResults"] = m_peakFittingModel->exportFittedPeaks();
+  if (const auto loadedData = m_dataLoading->exportWorkspace())
+    results["Loaded_Data"] = loadedData->clone();
+  if (const auto baseline = m_baselineModellingModel->exportWorkspace())
+    results["Baseline_Workspace"] = baseline->clone();
+  if (const auto baselineSections = m_baselineModellingModel->exportSections())
+    results["Baseline_Sections"] = baselineSections->clone();
+  if (const auto baselineModel = m_baselineModellingModel->exportModel())
+    results["Baseline_Model"] = baselineModel->clone();
+  if (const auto peaksWorkspace = m_peakFittingModel->exportWorkspace())
+    results["Peaks_Workspace"] = peaksWorkspace->clone();
+  if (const auto peaksResults = m_peakFittingModel->exportFittedPeaks())
+    results["Peaks_FitResults"] = peaksResults->clone();
 
   // Check if any of the above is not empty
   bool nothingToExport = true;


### PR DESCRIPTION
**Description of work.**
This PR ensures the exported results from the Muon ALC interface do not get 'mixed together' in their workspace groups by cloning the workspaces being exported.

**To test:**
1. Open Muon ALC interface
2. Instrument is HIFI. Runs 83929-49 and press enter. Wait for them to be found
3. Click `Load`
5. Go to `Baseline Modelling`
6. Select Linear Background
7. Add two sections and put them on either side of the data. Do a Fit
8. Go to `Peak Fitting`
9. Add a Linear background and lorentzian. Change Peakcentre to something appropriate.
11. Amplitude = -0.005
10. Click `Fit`. Export results to a group named `ALC1`
11. Notice a group workspace was created and contains workspaces starting with `ALC1_`
12. Click Export results again and name it `ALC2`
13. Make sure this group constrains workspaces starting with `ALC2_`. The ALC1 group should remain the same.

Fixes #30528

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
