### PR TITLE
Improve incremental builds of Qt .ui files

### DIFF
--- a/buildconfig/CMake/QtTargetFunctions.cmake
+++ b/buildconfig/CMake/QtTargetFunctions.cmake
@@ -123,6 +123,17 @@ function (mtd_add_qt_target)
   else ()
     message (FATAL_ERROR "Unknown Qt version. Please specify only the major version.")
   endif()
+
+  if (UI_HEADERS)
+    file(GLOB EXISTING_UI_HEADERS ${CMAKE_CURRENT_BINARY_DIR}/ui_*.h)
+    foreach(_existing_hdr ${EXISTING_UI_HEADERS})
+      if (NOT _existing_hdr IN_LIST UI_HEADERS)
+        message("Deleting orphaned ui_*.h file: " ${_existing_hdr})
+        file(REMOVE ${_existing_hdr})
+      endif()
+    endforeach ()
+  endif()
+
   set (CMAKE_CURRENT_BINARY_DIR ${_binary_dir_on_entry})
 
   if (PARSED_NO_SUFFIX)

--- a/buildconfig/Jenkins/buildscript
+++ b/buildconfig/Jenkins/buildscript
@@ -185,8 +185,6 @@ fi
 #                            the links helps keep it fresh
 #   - build/Testing/**: old ctest xml files will change over time and removing
 #                       the links helps keep it fresh
-#   - build/qt/**/ui_*.h: Header files produced from .ui files can remain stale
-#                         if a .ui file is removed from a CMakeLists.txt file
 ###############################################################################
 if [ -z "$BUILD_DIR" ]; then
     echo "Build directory not set. Cannot continue"
@@ -201,7 +199,7 @@ mkdir -p $BUILD_DIR
 
 # Tidy build dir
 rm -rf ${BUILD_DIR:?}/bin ${BUILD_DIR:?}/ExternalData ${BUILD_DIR:?}/Testing
-find ${BUILD_DIR:?} \( -name 'ui_*.h' -o -name 'TEST-*.xml' -o -name 'Test.xml' \) -delete
+find ${BUILD_DIR:?} \( -name 'TEST-*.xml' -o -name 'Test.xml' \) -delete
 
 if [[ -n ${CLEAN_EXTERNAL_PROJECTS} && "${CLEAN_EXTERNAL_PROJECTS}" == true ]]; then
     rm -rf $BUILD_DIR/eigen-*

--- a/buildconfig/Jenkins/buildscript.bat
+++ b/buildconfig/Jenkins/buildscript.bat
@@ -126,9 +126,6 @@ if EXIST %BUILD_DIR% (
   rmdir /S /Q %BUILD_DIR%\bin %BUILD_DIR%\ExternalData %BUILD_DIR%\Testing
   pushd %BUILD_DIR%
   for /f %%F in ('dir /b /a-d /S "TEST-*.xml"') do del /Q %%F >/nul
-  pushd qt
-  for /f %%F in ('dir /b /a-d /S "ui_*.h"') do del /Q %%F >/nul
-  popd
   popd
   if "!CLEAN_EXTERNAL_PROJECTS!" == "true" (
     rmdir /S /Q %BUILD_DIR%\eigen-prefix


### PR DESCRIPTION
**Description of work.**

All the ui\_\*.h files are deleted from the build directory prior to the start of a non-clean build on Jenkins to ensure that no stale
ui_*.h files are left behind in the scenario where a .ui file has been deleted. For Windows builds this was triggering a lot of unnecessary recompilation in targets using Qt and increasing the compilation time (extra ~7 mins per job)

To avoid this the ui\_\*.h deletion has been moved in cmake where it can be made more targeted ie the list of actual ui_*.h files
can be compared to the ones that should be present and only the extras removed

As part of this I've removed the ui_*.h deletion from the linux build script as well because the cmake rule will apply there. Unclear whether the original problem affected linux builds though - the CCache incremental build process may not have been affected as much by this

**To test:**

Although the aim of this is to speed up the Windows build the cmake change can be tested on any platform.

- Create a dummy ui_*.h file in one of the target specific subdirectories in the build directory eg in C:\mantid\build\qt\widgets\common\qt5

- It doesn't matter what the content of the file is. Also the file name shouldn't equal the stem of an of the .ui files for this target

- Run cmake and check that the dummy ui_*.h file has been deleted

The changes to the buildscript.bat (Windows) and buildscript (Linux) should be validated by the fact that the jobs have run successfully on this PR. 

Note - I have also tested the updated buildscript.bat by running it on my machine. It cleans the build, source tree and third party directories as part of the processing and takes quite a long time so you may not want to repeat and I'm not sure it's necessary. If you're feeling keen you can repeat this but you'll need to set some environment variables first eg for the Windows buildscript.bat (replace paths with ones appropriate for your machine):

set WORKSPACE="c:\mantid"
set BUILD_THREADS="1"
set MANTID_DATA_STORE="c:\MantidExternalData"

Fixes #30469.

*This does not require release notes* because **it has no functional impact, it's just a technical change to the build process**

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
