### PR TITLE
Add a selection of tests to the MainWindow class

### DIFF
--- a/qt/applications/workbench/workbench/app/mainwindow.py
+++ b/qt/applications/workbench/workbench/app/mainwindow.py
@@ -76,6 +76,8 @@ QApplication.processEvents(QEventLoop.AllEvents)
 
 class MainWindow(QMainWindow):
     DOCKOPTIONS = QMainWindow.AllowTabbedDocks | QMainWindow.AllowNestedDocks
+    # list of custom interfaces that are not qt4/qt5 compatible
+    PYTHON_GUI_BLACKLIST = ['Frequency_Domain_Analysis_Old.py']
 
     def __init__(self):
         QMainWindow.__init__(self)
@@ -350,7 +352,7 @@ class MainWindow(QMainWindow):
         """Populate then Interfaces menu with all Python and C++ interfaces"""
         self.interfaces_menu.clear()
         interface_dir = ConfigService['mantidqt.python_interfaces_directory']
-        self.interface_list = self._discover_python_interfaces(interface_dir)
+        self.interface_list = self._discover_python_interfaces(interface_dir, self.PYTHON_GUI_BLACKLIST)
         self._discover_cpp_interfaces(self.interface_list)
 
         hidden_interfaces = ConfigService['interfaces.categories.hidden'].split(';')
@@ -385,11 +387,9 @@ class MainWindow(QMainWindow):
 
         warnings.showwarning = to_mantid_warning
 
-    def _discover_python_interfaces(self, interface_dir):
+    def _discover_python_interfaces(self, interface_dir, gui_blacklist):
         """Return a dictionary mapping a category to a set of named Python interfaces"""
         items = ConfigService['mantidqt.python_interfaces'].split()
-        # list of custom interfaces that are not qt4/qt5 compatible
-        GUI_BLACKLIST = ['Frequency_Domain_Analysis_Old.py']
 
         # detect the python interfaces
         interfaces = {}
@@ -399,7 +399,7 @@ class MainWindow(QMainWindow):
                 logger.warning('Failed to find script "{}" in "{}"'.format(
                     scriptname, interface_dir))
                 continue
-            if scriptname in GUI_BLACKLIST:
+            if scriptname in gui_blacklist:
                 logger.information('Not adding gui "{}"'.format(scriptname))
                 continue
             interfaces.setdefault(key, []).append(scriptname)

--- a/qt/applications/workbench/workbench/app/mainwindow.py
+++ b/qt/applications/workbench/workbench/app/mainwindow.py
@@ -352,7 +352,7 @@ class MainWindow(QMainWindow):
         """Populate then Interfaces menu with all Python and C++ interfaces"""
         self.interfaces_menu.clear()
         interface_dir = ConfigService['mantidqt.python_interfaces_directory']
-        self.interface_list = self._discover_python_interfaces(interface_dir, self.PYTHON_GUI_BLACKLIST)
+        self.interface_list = self._discover_python_interfaces(interface_dir)
         self._discover_cpp_interfaces(self.interface_list)
 
         hidden_interfaces = ConfigService['interfaces.categories.hidden'].split(';')
@@ -387,7 +387,7 @@ class MainWindow(QMainWindow):
 
         warnings.showwarning = to_mantid_warning
 
-    def _discover_python_interfaces(self, interface_dir, gui_blacklist):
+    def _discover_python_interfaces(self, interface_dir):
         """Return a dictionary mapping a category to a set of named Python interfaces"""
         items = ConfigService['mantidqt.python_interfaces'].split()
 
@@ -399,7 +399,7 @@ class MainWindow(QMainWindow):
                 logger.warning('Failed to find script "{}" in "{}"'.format(
                     scriptname, interface_dir))
                 continue
-            if scriptname in gui_blacklist:
+            if scriptname in self.PYTHON_GUI_BLACKLIST:
                 logger.information('Not adding gui "{}"'.format(scriptname))
                 continue
             interfaces.setdefault(key, []).append(scriptname)

--- a/qt/applications/workbench/workbench/test/mainwindowtest.py
+++ b/qt/applications/workbench/workbench/test/mainwindowtest.py
@@ -102,23 +102,37 @@ class MainWindowTest(unittest.TestCase):
 
     @patch('workbench.app.mainwindow.add_actions')
     def test_file_view_and_help_menus_are_correct(self, mock_add_actions):
+        def convert_action_to_text(menu_item):
+            """Takes an item on a mainwindow menu, and returns a representation of the item
+            so we can assert whether menus look right to the user. """
+            if isinstance(menu_item, QAction):
+                return menu_item.text()
+            if not menu_item:
+                return None
+            return type(menu_item)
+
         self.main_window.editor = Mock()
         self.main_window.populate_interfaces_menu = Mock()
-        expected_file_menu_items = ['Open Script', 'Open Project', None, 'Save Script', 'Save Script as...', RecentlyClosedScriptsMenu, 'Generate Recovery Script', None, 'Save Project', 'Save Project as...', None, 'Settings', None, 'Manage User Directories', None, 'Script Repository', None, 'Clear All Memory', None, '&Quit']
-        expected_view_menu_items = ['Restore Default Layout', None]  # There are no wigets on this instance of MainWindow, so they will not appear on the view menu.
-        expected_help_menu_items = ['Mantid Help', 'Mantid Concepts', 'Algorithm Descriptions', None, 'Mantid Homepage', 'Mantid Forum', None, 'About Mantid Workbench']
-
-        convert_actions_to_texts = lambda menu_actions: \
-            [a.text() if isinstance(a, QAction) else a if not a else type(a) for a in menu_actions]
+        expected_file_menu_items = [
+            'Open Script', 'Open Project', None, 'Save Script', 'Save Script as...', RecentlyClosedScriptsMenu,
+            'Generate Recovery Script', None, 'Save Project', 'Save Project as...', None, 'Settings', None,
+            'Manage User Directories', None, 'Script Repository', None, 'Clear All Memory', None, '&Quit'
+        ]
+        # There are no wigets on this instance of MainWindow, so they will not appear on the view menu.
+        expected_view_menu_items = ['Restore Default Layout', None]
+        expected_help_menu_items = [
+            'Mantid Help', 'Mantid Concepts', 'Algorithm Descriptions', None, 'Mantid Homepage', 'Mantid Forum', None,
+            'About Mantid Workbench'
+        ]
 
         self.main_window.create_menus()
         self.main_window.create_actions()
         self.main_window.populate_menus()
 
         self.main_window.populate_interfaces_menu.assert_called()
-        actual_file_menu_items = convert_actions_to_texts(self.main_window.file_menu_actions)
-        actual_view_menu_items = convert_actions_to_texts(self.main_window.view_menu_actions)
-        actual_help_menu_items = convert_actions_to_texts(self.main_window.help_menu_actions)
+        actual_file_menu_items = list(map(convert_action_to_text, self.main_window.file_menu_actions))
+        actual_view_menu_items = list(map(convert_action_to_text, self.main_window.view_menu_actions))
+        actual_help_menu_items = list(map(convert_action_to_text, self.main_window.help_menu_actions))
         self.assertEqual(expected_file_menu_items, actual_file_menu_items)
         self.assertEqual(expected_view_menu_items, actual_view_menu_items)
         self.assertEqual(expected_help_menu_items, actual_help_menu_items)

--- a/qt/applications/workbench/workbench/test/mainwindowtest.py
+++ b/qt/applications/workbench/workbench/test/mainwindowtest.py
@@ -14,6 +14,9 @@ import unittest
 import sys
 
 from unittest.mock import patch, Mock, MagicMock, call
+
+import matplotlib
+
 from mantidqt.utils.qt.testing import start_qapplication
 from mantid.api import FrameworkManager
 from qtpy.QtWidgets import QMessageBox, QAction, QMenu
@@ -81,6 +84,7 @@ class MainWindowTest(unittest.TestCase):
         original_stderr = sys.stderr
 
         try:
+            matplotlib.use("agg")
             self.main_window.setup()
             print('test stdout')
             print('test stderr', file=sys.stderr)

--- a/qt/applications/workbench/workbench/test/mainwindowtest.py
+++ b/qt/applications/workbench/workbench/test/mainwindowtest.py
@@ -182,7 +182,7 @@ class MainWindowTest(unittest.TestCase):
             self.main_window.populate_interfaces_menu()
 
         self.main_window._discover_python_interfaces.assert_called_with(
-            interface_dir, self.main_window.PYTHON_GUI_BLACKLIST
+            interface_dir
         )
         self.main_window._discover_cpp_interfaces.assert_called_with(
             self.main_window._discover_python_interfaces.return_value
@@ -281,9 +281,10 @@ class MainWindowTest(unittest.TestCase):
         interfaces = ['Muon/Frequency_Domain_Analysis.py', 'ILL/Drill.py']
         interfaces_str = " ".join(interfaces)  # config service returns them as a whole string.
         mock_os_path_exists.return_value = lambda path: path in interfaces
+        self.main_window.PYTHON_GUI_BLACKLIST = []
 
         with patch('workbench.app.mainwindow.ConfigService', new={'mantidqt.python_interfaces': interfaces_str}):
-            returned_interfaces = self.main_window._discover_python_interfaces('', [])
+            returned_interfaces = self.main_window._discover_python_interfaces('')
 
         expected_interfaces = {'Muon': ['Frequency_Domain_Analysis.py'], 'ILL': ['Drill.py']}
         self.assertDictEqual(expected_interfaces, returned_interfaces)
@@ -293,9 +294,10 @@ class MainWindowTest(unittest.TestCase):
     def test_that_non_existent_python_interface_is_ignored_gracefully(self, mock_os_path_exists, mock_logger):
         interface_str = 'fake/interface.py'
         mock_os_path_exists.return_value = False
+        self.main_window.PYTHON_GUI_BLACKLIST = []
 
         with patch('workbench.app.mainwindow.ConfigService', new={'mantidqt.python_interfaces': interface_str}):
-            returned_interfaces = self.main_window._discover_python_interfaces('', [])
+            returned_interfaces = self.main_window._discover_python_interfaces('')
 
         self.assertDictEqual({}, returned_interfaces)
         mock_logger.warning.assert_called()
@@ -304,10 +306,11 @@ class MainWindowTest(unittest.TestCase):
     @patch('os.path.exists')
     def test_that_blacklisted_python_interface_is_ignored_gracefully(self, mock_os_path_exists, mock_logger):
         interface_str = 'blacklisted/interface.py'
+        self.main_window.PYTHON_GUI_BLACKLIST = 'interface.py'
         mock_os_path_exists.return_value = True
 
         with patch('workbench.app.mainwindow.ConfigService', new={'mantidqt.python_interfaces': interface_str}):
-            returned_interfaces = self.main_window._discover_python_interfaces('', 'interface.py')
+            returned_interfaces = self.main_window._discover_python_interfaces('')
 
         self.assertDictEqual({}, returned_interfaces)
         mock_logger.information.assert_called()

--- a/qt/applications/workbench/workbench/test/mainwindowtest.py
+++ b/qt/applications/workbench/workbench/test/mainwindowtest.py
@@ -223,6 +223,25 @@ class MainWindowTest(unittest.TestCase):
         self.assertDictEqual({}, returned_interfaces)
         mock_logger.information.assert_called()
 
+    @patch('workbench.app.mainwindow.UserSubWindowFactory')
+    def test_cpp_interfaces_are_discovered_correctly(self, mock_UserSubWindowFactory):
+        """Assuming we have already found some python interfaces, test that
+        cpp interfaces are discovered correctly using the Direct interfaces as an example."""
+
+        cpp_interface_factory = Mock()
+        cpp_interface_factory.keys.return_value = ['ALF View', 'TOFCalculator']
+        cpp_interface_factory.categories.side_effect = lambda name: ['Direct'] if name == 'ALF View' else []
+        mock_UserSubWindowFactory.Instance.return_value = cpp_interface_factory
+
+        all_interfaces = self.main_window._discover_cpp_interfaces(
+            {'Direct': ['DGS_Reduction.py', 'DGSPlanner.py', 'PyChop.py', 'MSlice.py']})
+
+        expected_interfaces = {
+            'Direct': ['DGS_Reduction.py', 'DGSPlanner.py', 'PyChop.py', 'MSlice.py', 'ALF View'],
+            'General': ['TOFCalculator']
+        }
+        self.assertDictEqual(expected_interfaces, all_interfaces)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/qt/python/mantidqt/utils/test/test_writetosignal.py
+++ b/qt/python/mantidqt/utils/test/test_writetosignal.py
@@ -67,5 +67,6 @@ class WriteToSignalTest(unittest.TestCase):
             writer = WriteToSignal(mock_stdout)
             self.assertEqual(writer._original_out, None)
 
+
 if __name__ == "__main__":
     unittest.main()

--- a/qt/python/mantidqt/utils/test/test_writetosignal.py
+++ b/qt/python/mantidqt/utils/test/test_writetosignal.py
@@ -13,6 +13,7 @@ import unittest
 from unittest.mock import patch
 from mantidqt.utils.qt.testing import start_qapplication
 from mantidqt.utils.writetosignal import WriteToSignal
+from io import UnsupportedOperation
 
 
 class Receiver(QObject):
@@ -57,6 +58,14 @@ class WriteToSignalTest(unittest.TestCase):
             writer = WriteToSignal(mock_stdout)
             self.assertEqual(writer._original_out, None)
 
+    def test_with_fileno_throw_AttributeError(self):
+        def raise_UnsupportedOperation():
+            raise UnsupportedOperation
+
+        with patch('sys.stdout') as mock_stdout:
+            mock_stdout.fileno.side_effect = raise_UnsupportedOperation
+            writer = WriteToSignal(mock_stdout)
+            self.assertEqual(writer._original_out, None)
 
 if __name__ == "__main__":
     unittest.main()

--- a/qt/python/mantidqt/utils/writetosignal.py
+++ b/qt/python/mantidqt/utils/writetosignal.py
@@ -8,6 +8,7 @@
 #
 #
 from qtpy.QtCore import QObject, Signal
+from io import UnsupportedOperation
 
 
 class WriteToSignal(QObject):
@@ -21,10 +22,14 @@ class WriteToSignal(QObject):
     def __init__(self, original_out):
         QObject.__init__(self)
         # If the file descriptor of the stream is < 0 then we are running in a no-external-console mode
-        if not hasattr(original_out, 'fileno') or original_out.fileno() < 0:
-            self._original_out = None
-        else:
+        try:
             self._original_out = original_out
+            if not hasattr(original_out, 'fileno') or original_out.fileno() < 0:
+                self._original_out = None
+        except UnsupportedOperation:
+            # In some cases fileno may be defined but throw this instead,
+            # such as in the case of io.StringIO
+            self._original_out = None
 
     def closed(self):
         return False


### PR DESCRIPTION
Adds a selection of unittests to the mainwindow class including
- Check menus look correct
- Check cpp and python interfaces are discovered
- Check LogMessageDisplay captures stdout/stderr
- Closing behaviour

**To test:**
- Ensure that all the tests pass (including in `writetosignal.py`)
- Test everything still appears in the workbench messages pane.

Fixes #28542 

<!-- delete this if you added release notes
*This does not require release notes* because **it is not a user facing feature**
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or master)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
