### PR TITLE
Fix StartX EndX Function Parameters Not Updating In MA

### DIFF
--- a/scripts/Muon/GUI/Common/fitting_tab_widget/fitting_tab_presenter.py
+++ b/scripts/Muon/GUI/Common/fitting_tab_widget/fitting_tab_presenter.py
@@ -199,6 +199,11 @@ class FittingTabPresenter(object):
         if len(self.selected_data) < 1:
             self.view.warning_popup('No data selected to fit')
             return
+        # Some attributes of fit functions do not cause an update to the model
+        # Do one final update to ensure using most recent values
+        if self._fit_function != self._get_fit_function():
+            self._fit_function = self._get_fit_function()
+            self.update_model_from_view(fit_function=self._fit_function[0])
         self.perform_fit()
 
     def handle_started(self):
@@ -547,7 +552,7 @@ class FittingTabPresenter(object):
         if self.view.is_simul_fit:
             return [self.view.fit_object]  # return the fit function stored in the browser
         else:  # we need to convert stored function into equiv
-            if self.view.fit_object:  # make sure thers a fit function in the browser
+            if self.view.fit_object:  # make sure there's a fit function in the browser
                 if isinstance(self.view.fit_object, MultiDomainFunction):
                     equiv_fit_funtion = self.view.fit_object.createEquivalentFunctions()
                     single_domain_fit_function = equiv_fit_funtion

--- a/scripts/test/Muon/fitting_tab_widget/fitting_tab_presenter_test.py
+++ b/scripts/test/Muon/fitting_tab_widget/fitting_tab_presenter_test.py
@@ -320,6 +320,8 @@ class FittingTabPresenterTest(unittest.TestCase):
         self.view.function_browser.setFunction('name=GausOsc,A=0.2,Sigma=0.2,Frequency=0.1,Phi=0')
         fit_function = FunctionFactory.createInitialized('name=GausOsc,A=0.5,Sigma=0.5,Frequency=1,Phi=0')
         self.view.is_simul_fit = mock.MagicMock(return_value=False)
+        function = FunctionFactory.createInitialized('name=GausOsc,A=0.2,Sigma=0.2,Frequency=0.1,Phi=0')
+        self.presenter._get_fit_function = mock.Mock(return_value=[function]*3)
         self.presenter.fitting_calculation_model = mock.MagicMock()
         self.presenter.model.evaluate_single_fit.return_value = (fit_function, 'Fit Succeeded', 0.5)
 


### PR DESCRIPTION
**Description of work.**
I've added a final get function before the fit is performed to make sure the most recent data is being used

**To test:**

1. Go to Muon Analysis
2. Select HIFI instrument and run 83934
3. Go to Fitting Tab
4. Add functions Chebyshev and ExpDecayOsc
5. Set EndX = 0.0, StartX = 15.0
6. Set the n parameter in Chebyshev to 2
7. Set the Frequency parameter in ExpDecayOsc to 0.6
8. Click Fit. An invalid x-range warning appears correctly.
9. Switch the EndX = 15.0 and StartX = 0.0
10. Click Fit again, should work this time

Fixes #30525 

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
