### PR TITLE
Indirect - Only exclude first detector group for SaveDetectorsGrouping xmls

### DIFF
--- a/scripts/Inelastic/IndirectReductionCommon.py
+++ b/scripts/Inelastic/IndirectReductionCommon.py
@@ -742,6 +742,7 @@ def group_spectra_of(workspace, masked_detectors, method, group_file=None, group
         # Get the filename for the grouping file
         if group_file is not None:
             grouping_file = group_file
+            group_detectors.setProperty("ExcludeGroupNumbers", [0])
         else:
             try:
                 grouping_file = instrument.getStringParameter('Workflow.GroupingFile')[0]
@@ -762,7 +763,6 @@ def group_spectra_of(workspace, masked_detectors, method, group_file=None, group
 
         # Apply the grouping
         group_detectors.setProperty("MapFile", grouping_file)
-        group_detectors.setProperty("ExcludeGroupNumbers", [0])
 
     elif grouping_method == 'Workspace':
         # Apply the grouping


### PR DESCRIPTION
**Description of work.**
This PR fixes a bug where the first detector grouping in the TOSCA IPF was being ignored because of a recent addition to the GroupDetectors algorithm which can be used to ignore the detectors in a specific group.

This is required because the xml files produced by `SaveDetectorsGrouping` will place the unused detectors in the first group, giving it a group ID of 0. These detectors are meant to be ignored, and therefore when loading these xml files back into the indirect interface we do not want to do `GroupDetectors` for this first group.

The TOSCA IPF xml does not have this first group of ignored detectors, and so we were ignoring a perfectly valid grouping.

*No release notes required as this is a regression from the last release*
*No tests have been added in this because this bug should be covered by the ISISIndirectInelastic system test. We need to figure out why this currently isn't being run*

**To test:**
1. Indirect -> `Data Reduction`
2. Select TOSCA as instrument
3. Enter runs 26911-26917
4. Tick Sum Files
5. Click Run and wait
6. The produced workspace should have three histograms.

Fixes #30546

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
