### PR TITLE
Added reminder for updating MSlice SHA to release checklist

### DIFF
--- a/dev-docs/source/ReleaseChecklist.rst
+++ b/dev-docs/source/ReleaseChecklist.rst
@@ -200,6 +200,9 @@ Once the unscripted testing has passed:
 * Disable release deploy jobs by executing
   `close-release-testing <https://builds.mantidproject.org/view/All/job/close-release-testing>`__
   job.
+* On the ``release-next`` branch, update the git SHA for MSlice 
+  accordingly in ``scripts/ExternalInterfaces/CMakeLists`` in 
+  case MSlice has to be updated.
 * On the ``release-next`` branch, update major & minor versions
   accordingly in ``buildconfig/CMake/VersionNumber.cmake``. Also
   uncomment ``VERSION_PATCH`` and set it to ``0``.


### PR DESCRIPTION
In the section 'Release (technical tasks)' I've added a reminder to update the SHA for MSlice in case there are MSlice updates to be included (for instance bug fixes after beta fixes).

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
