### PR TITLE
Change the name of the output workspaces in SANSILLAutoProcess

### DIFF
--- a/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/SANSILLAutoProcess.py
+++ b/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/SANSILLAutoProcess.py
@@ -458,7 +458,16 @@ class SANSILLAutoProcess(DataProcessorAlgorithm):
 
         # group panels
         if panel_output_groups:
-            GroupWorkspaces(InputWorkspaces=panel_output_groups,
+            panelWs = []
+            for groupName in panel_output_groups:
+                wsNames = mtd[groupName].getNames()
+                UnGroupWorkspace(InputWorkspace=groupName)
+                for ws in wsNames:
+                    suffix = self.createCustomSuffix(ws)
+                    RenameWorkspace(InputWorkspace=ws,
+                                    OutputWorkspace=ws + suffix)
+                    panelWs.append(ws + suffix)
+            GroupWorkspaces(InputWorkspaces=panelWs,
                             OutputWorkspace=self.output_panels)
 
     def processTransmissions(self):

--- a/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/SANSILLAutoProcess.py
+++ b/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/SANSILLAutoProcess.py
@@ -634,8 +634,6 @@ class SANSILLAutoProcess(DataProcessorAlgorithm):
 
     def createCustomSuffix(self, ws):
         DISTANCE_LOG = "L2"
-        if "front_detector" in ws:
-            DISTANCE_LOG = "detector.det1_calc"
         COLLIMATION_LOG = "collimation.actual_position"
         WAVELENGTH_LOG1 = "wavelength"
         WAVELENGTH_LOG2 = "selector.wavelength"
@@ -645,7 +643,16 @@ class SANSILLAutoProcess(DataProcessorAlgorithm):
 
         distance = None
         try:
-            distance = float(logs[DISTANCE_LOG])
+            instrument = mtd[ws].getInstrument()
+            components = instrument.getStringParameter('detector_panels')
+            if components:
+                components = components[0].split(',')
+                for c in components:
+                    if c in ws:
+                        distance = instrument.getComponentByName(c).getPos()[2]
+                        break
+            if not distance:
+                distance = float(logs[DISTANCE_LOG])
             if distance < 0.0:
                 distance = None
                 raise ValueError

--- a/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/SANSILLAutoProcess.py
+++ b/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/SANSILLAutoProcess.py
@@ -710,8 +710,10 @@ class SANSILLAutoProcess(DataProcessorAlgorithm):
             collimation = float(logs["collimation.actual_position"])
             if collimation > 0.0:
                 suffix += "_c{:.1f}m".format(collimation)
-        if "selector.wavelength" in logs:
-            wavelength = float(logs["selector.wavelength"])
+        if "wavelength" in logs:
+            wavelength = float(logs["wavelength"])
+            if wavelength <= 0.0 and "selector.wavelength" in logs:
+                wavelength = float(logs["selector.wavelength"])
             if wavelength > 0.0:
                 suffix += "_w{:.1f}A".format(wavelength)
         if not suffix:

--- a/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/SANSILLAutoProcess.py
+++ b/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/SANSILLAutoProcess.py
@@ -410,7 +410,7 @@ class SANSILLAutoProcess(DataProcessorAlgorithm):
 
         # convert to point data and remove nan and 0 from wedges
         for i in range(self.dimensionality):
-            for j in range(self.n_wedges):
+            for j in range(len(outputWedges[i])):
                 ws = outputWedges[i][j]
                 ConvertToPointData(InputWorkspace=ws, OutputWorkspace=ws)
                 ReplaceSpecialValues(InputWorkspace=ws, OutputWorkspace=ws,
@@ -423,7 +423,7 @@ class SANSILLAutoProcess(DataProcessorAlgorithm):
                               XMax=x[nonzero][-1], OutputWorkspace=ws)
 
         # stitch if possible and group
-        for i in range(self.n_wedges):
+        for i in range(len(outputWedges[0])):
             inWs = [outputWedges[d][i] for d in range(self.dimensionality)]
             try:
                 stitched = self.output + "_wedge_" + str(i + 1) + "_stitched"

--- a/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/SANSILLAutoProcess.py
+++ b/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/SANSILLAutoProcess.py
@@ -634,6 +634,8 @@ class SANSILLAutoProcess(DataProcessorAlgorithm):
 
     def createCustomSuffix(self, ws):
         DISTANCE_LOG = "L2"
+        if "front_detector" in ws:
+            DISTANCE_LOG = "detector.det1_calc"
         COLLIMATION_LOG = "collimation.actual_position"
         WAVELENGTH_LOG1 = "wavelength"
         WAVELENGTH_LOG2 = "selector.wavelength"

--- a/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/SANSILLAutoProcess.py
+++ b/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/SANSILLAutoProcess.py
@@ -633,12 +633,17 @@ class SANSILLAutoProcess(DataProcessorAlgorithm):
         return container_name
 
     def createCustomSuffix(self, ws):
+        DISTANCE_LOG = "L2"
+        COLLIMATION_LOG = "collimation.actual_position"
+        WAVELENGTH_LOG1 = "wavelength"
+        WAVELENGTH_LOG2 = "selector.wavelength"
+
         logs = mtd[ws].run().getProperties()
         logs = {log.name:log.value for log in logs}
 
         distance = None
         try:
-            distance = float(logs["L2"])
+            distance = float(logs[DISTANCE_LOG])
             if distance < 0.0:
                 distance = None
                 raise ValueError
@@ -647,7 +652,7 @@ class SANSILLAutoProcess(DataProcessorAlgorithm):
                           "the sample logs.")
         collimation = None
         try:
-            collimation = float(logs["collimation.actual_position"])
+            collimation = float(logs[COLLIMATION_LOG])
             if collimation < 0.0:
                 collimation = None
                 raise ValueError
@@ -656,13 +661,13 @@ class SANSILLAutoProcess(DataProcessorAlgorithm):
                           "the sample logs.")
         wavelength = None
         try:
-            wavelength = float(logs["wavelength"])
+            wavelength = float(logs[WAVELENGTH_LOG1])
             if wavelength < 0.0:
                 wavelength = None
                 raise ValueError
         except:
             try:
-                wavelength = float(logs["selector.wavelength"])
+                wavelength = float(logs[WAVELENGTH_LOG2])
                 if wavelength < 0.0:
                     wavelength = None
                     raise ValueError

--- a/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/SANSILLAutoProcess.py
+++ b/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/SANSILLAutoProcess.py
@@ -758,7 +758,7 @@ class SANSILLAutoProcess(DataProcessorAlgorithm):
             wedges_old_names = [output_wedges + "_" + str(w + 1)
                                 for w in range(self.n_wedges)]
             wedges_new_names = [self.output + "_wedge_" + str(w + 1)
-                                + "_" + str(i + 1)
+                                + "_" + suffix
                                 for w in range(self.n_wedges)]
             UnGroupWorkspace(InputWorkspace=output_wedges)
             RenameWorkspaces(InputWorkspaces=wedges_old_names,

--- a/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/SANSILLAutoProcess.py
+++ b/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/SANSILLAutoProcess.py
@@ -716,8 +716,7 @@ class SANSILLAutoProcess(DataProcessorAlgorithm):
                 wavelength = float(logs["selector.wavelength"])
             if wavelength > 0.0:
                 suffix += "_w{:.1f}A".format(wavelength)
-        if not suffix:
-            suffix = "_{}".format(i + 1)
+        suffix += "_{}".format(i + 1)
 
         if self.getProperty('OutputPanels').value:
             panel_ws_group = self.output_panels + '_' + str(i + 1)

--- a/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/SANSILLAutoProcess.py
+++ b/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/SANSILLAutoProcess.py
@@ -745,8 +745,11 @@ class SANSILLAutoProcess(DataProcessorAlgorithm):
                 self.getProperty('WaterCrossSection').value,
                 )
 
+        suffix = self.createCustomSuffix(sample_name, i)
+        output_sample = self.output + suffix
+
         if self.getProperty('OutputPanels').value:
-            panel_ws_group = self.output_panels + '_' + str(i + 1)
+            panel_ws_group = self.output_panels + suffix
         else:
             panel_ws_group = ""
 
@@ -754,9 +757,6 @@ class SANSILLAutoProcess(DataProcessorAlgorithm):
             output_wedges = self.output + "_wedge_d" + str(i + 1)
         else:
             output_wedges = ""
-
-        suffix = self.createCustomSuffix(sample_name, i)
-        output_sample = self.output + suffix
 
         if self.getProperty('SensitivityWithOffsets').value:
             CloneWorkspace(InputWorkspace=sample_name, OutputWorkspace=output_sens)

--- a/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/SANSILLAutoProcess.py
+++ b/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/SANSILLAutoProcess.py
@@ -379,8 +379,8 @@ class SANSILLAutoProcess(DataProcessorAlgorithm):
                 container = self.processContainer(d, beam, absorber,
                                                   container_transmission)
                 sample, wedges, panels, sensitivity = \
-                        self.processSample(d, flux, sample_transmission, beam,
-                                           absorber, container)
+                    self.processSample(d, flux, sample_transmission, beam,
+                                       absorber, container)
                 outputSamples.append(sample)
                 outputWedges.append(wedges)
 
@@ -395,7 +395,7 @@ class SANSILLAutoProcess(DataProcessorAlgorithm):
             ConvertToPointData(InputWorkspace=output,
                                OutputWorkspace=output)
         if (len(outputSamples) > 1
-            and self.getPropertyValue('OutputType') == 'I(Q)'):
+           and self.getPropertyValue('OutputType') == 'I(Q)'):
             try:
                 stitched = self.output + "_stitched"
                 Stitch1DMany(InputWorkspaces=outputSamples,

--- a/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/SANSILLAutoProcess.py
+++ b/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/SANSILLAutoProcess.py
@@ -380,7 +380,20 @@ class SANSILLAutoProcess(DataProcessorAlgorithm):
                 sample, panels, sensitivity = self.processSample(d, flux,
                                                                  sample_transmission, beam,
                                                                  absorber, container)
-                outputs.append(sample)
+                # set the sample suffix
+                logs = mtd[sample].run().getProperties()
+                logs = {log.name:log.value for log in logs}
+                distance = logs["L2"]
+                collimation = logs["collimation.actual_position"]
+                wavelength = logs["wavelength"]
+                suffix = "d{:.1f}m_c{:.1f}m_w{:.1f}A".format(float(distance),
+                                                             float(collimation),
+                                                             float(wavelength))
+                sampleSuffix = sample[0:-len(str(d))] + suffix
+                RenameWorkspace(InputWorkspace=sample,
+                                OutputWorkspace=sampleSuffix)
+                outputs.append(sampleSuffix)
+
                 if sensitivity:
                     sensitivity_outputs.append(sensitivity)
                 if panels:

--- a/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/SANSILLAutoProcess.py
+++ b/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/SANSILLAutoProcess.py
@@ -704,13 +704,16 @@ class SANSILLAutoProcess(DataProcessorAlgorithm):
         suffix = ""
         if "L2" in logs:
             distance = float(logs["L2"])
-            suffix += "_d{:.1f}m".format(distance)
+            if distance > 0.0:
+                suffix += "_d{:.1f}m".format(distance)
         if "collimation.actual_position" in logs:
             collimation = float(logs["collimation.actual_position"])
-            suffix += "_c{:.1f}m".format(collimation)
+            if collimation > 0.0:
+                suffix += "_c{:.1f}m".format(collimation)
         if "selector.wavelength" in logs:
             wavelength = float(logs["selector.wavelength"])
-            suffix += "_w{:.1f}A".format(wavelength)
+            if wavelength > 0.0:
+                suffix += "_w{:.1f}A".format(wavelength)
         if not suffix:
             suffix = "_{}".format(i + 1)
 

--- a/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/SANSILLAutoProcess.py
+++ b/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/SANSILLAutoProcess.py
@@ -703,7 +703,7 @@ class SANSILLAutoProcess(DataProcessorAlgorithm):
         logs = {log.name:log.value for log in logs}
         distance = logs["L2"]
         collimation = logs["collimation.actual_position"]
-        wavelength = logs["wavelength"]
+        wavelength = logs["selector.wavelength"]
         suffix = "d{:.1f}m_c{:.1f}m_w{:.1f}A".format(float(distance),
                                                      float(collimation),
                                                      float(wavelength))

--- a/Testing/SystemTests/tests/framework/SANSILLAutoProcessTest.py
+++ b/Testing/SystemTests/tests/framework/SANSILLAutoProcessTest.py
@@ -124,15 +124,15 @@ class D11_AutoProcess_Wedges_Test(systemtesting.MantidSystemTest):
             )
 
         GroupWorkspaces(
-            InputWorkspaces=['iq_d39.0m_c40.5m_w5.6A',
-                             'iq_d8.0m_c8.0m_w5.6A',
-                             'iq_d2.0m_c5.5m_w5.6A',
-                             'iq_wedge_1_d39.0m_c40.5m_w5.6A',
-                             'iq_wedge_1_d8.0m_c8.0m_w5.6A',
-                             'iq_wedge_1_d2.0m_c5.5m_w5.6A',
-                             'iq_wedge_2_d39.0m_c40.5m_w5.6A',
-                             'iq_wedge_2_d8.0m_c8.0m_w5.6A',
-                             'iq_wedge_2_d2.0m_c5.5m_w5.6A'],
+            InputWorkspaces=['iq_d39.0m_c40.5m_w5.6A_1',
+                             'iq_d8.0m_c8.0m_w5.6A_2',
+                             'iq_d2.0m_c5.5m_w5.6A_3',
+                             'iq_wedge_1_d39.0m_c40.5m_w5.6A_1',
+                             'iq_wedge_1_d8.0m_c8.0m_w5.6A_2',
+                             'iq_wedge_1_d2.0m_c5.5m_w5.6A_3',
+                             'iq_wedge_2_d39.0m_c40.5m_w5.6A_1',
+                             'iq_wedge_2_d8.0m_c8.0m_w5.6A_2',
+                             'iq_wedge_2_d2.0m_c5.5m_w5.6A_3'],
             OutputWorkspace='out'
             )
 

--- a/Testing/SystemTests/tests/framework/SANSILLAutoProcessTest.py
+++ b/Testing/SystemTests/tests/framework/SANSILLAutoProcessTest.py
@@ -124,15 +124,15 @@ class D11_AutoProcess_Wedges_Test(systemtesting.MantidSystemTest):
             )
 
         GroupWorkspaces(
-            InputWorkspaces=['iq_d39.0m_c40.5m_w5.6A_1',
-                             'iq_d8.0m_c8.0m_w5.6A_2',
-                             'iq_d2.0m_c5.5m_w5.6A_3',
-                             'iq_wedge_1_d39.0m_c40.5m_w5.6A_1',
-                             'iq_wedge_1_d8.0m_c8.0m_w5.6A_2',
-                             'iq_wedge_1_d2.0m_c5.5m_w5.6A_3',
-                             'iq_wedge_2_d39.0m_c40.5m_w5.6A_1',
-                             'iq_wedge_2_d8.0m_c8.0m_w5.6A_2',
-                             'iq_wedge_2_d2.0m_c5.5m_w5.6A_3'],
+            InputWorkspaces=['iq_1_d39.0m_c40.5m_w5.6A',
+                             'iq_2_d8.0m_c8.0m_w5.6A',
+                             'iq_3_d2.0m_c5.5m_w5.6A',
+                             'iq_wedge_1_1_d39.0m_c40.5m_w5.6A',
+                             'iq_wedge_1_2_d8.0m_c8.0m_w5.6A',
+                             'iq_wedge_1_3_d2.0m_c5.5m_w5.6A',
+                             'iq_wedge_2_1_d39.0m_c40.5m_w5.6A',
+                             'iq_wedge_2_2_d8.0m_c8.0m_w5.6A',
+                             'iq_wedge_2_3_d2.0m_c5.5m_w5.6A'],
             OutputWorkspace='out'
             )
 

--- a/Testing/SystemTests/tests/framework/SANSILLAutoProcessTest.py
+++ b/Testing/SystemTests/tests/framework/SANSILLAutoProcessTest.py
@@ -124,9 +124,15 @@ class D11_AutoProcess_Wedges_Test(systemtesting.MantidSystemTest):
             )
 
         GroupWorkspaces(
-            InputWorkspaces=['iq_1', 'iq_2', 'iq_3',
-                             'iq_wedge_1_1', 'iq_wedge_1_2', 'iq_wedge_1_3',
-                             'iq_wedge_2_1', 'iq_wedge_2_2', 'iq_wedge_2_3'],
+            InputWorkspaces=['iq_d39.0m_c40.5m_w5.6A',
+                             'iq_d8.0m_c8.0m_w5.6A',
+                             'iq_d2.0m_c5.5m_w5.6A',
+                             'iq_wedge_1_d39.0m_c40.5m_w5.6A',
+                             'iq_wedge_1_d8.0m_c8.0m_w5.6A',
+                             'iq_wedge_1_d2.0m_c5.5m_w5.6A',
+                             'iq_wedge_2_d39.0m_c40.5m_w5.6A',
+                             'iq_wedge_2_d8.0m_c8.0m_w5.6A',
+                             'iq_wedge_2_d2.0m_c5.5m_w5.6A'],
             OutputWorkspace='out'
             )
 

--- a/docs/source/algorithms/SANSILLAutoProcess-v1.rst
+++ b/docs/source/algorithms/SANSILLAutoProcess-v1.rst
@@ -63,12 +63,12 @@ When multiple runs are summed, the run number of the first run is attributed to 
             OutputWorkspace='iq_s' + str(i + 1)
         )
 
-    print('Distance 1 Q-range:{0:4f}-{1:4f} AA'.format(mtd['iq_s1_d39.0m_c40.5m_w5.6A_1'].readX(0)[0],
-                                                       mtd['iq_s1_d39.0m_c40.5m_w5.6A_1'].readX(0)[-1]))
-    print('Distance 2 Q-range:{0:4f}-{1:4f} AA'.format(mtd['iq_s1_d8.0m_c8.0m_w5.6A_2'].readX(0)[0],
-                                                       mtd['iq_s1_d8.0m_c8.0m_w5.6A_2'].readX(0)[-1]))
-    print('Distance 3 Q-range:{0:4f}-{1:4f} AA'.format(mtd['iq_s1_d2.0m_c5.5m_w5.6A_3'].readX(0)[0],
-                                                       mtd['iq_s1_d2.0m_c5.5m_w5.6A_3'].readX(0)[-1]))
+    print('Distance 1 Q-range:{0:4f}-{1:4f} AA'.format(mtd['iq_s1_1_d39.0m_c40.5m_w5.6A'].readX(0)[0],
+                                                       mtd['iq_s1_1_d39.0m_c40.5m_w5.6A'].readX(0)[-1]))
+    print('Distance 2 Q-range:{0:4f}-{1:4f} AA'.format(mtd['iq_s1_2_d8.0m_c8.0m_w5.6A'].readX(0)[0],
+                                                       mtd['iq_s1_2_d8.0m_c8.0m_w5.6A'].readX(0)[-1]))
+    print('Distance 3 Q-range:{0:4f}-{1:4f} AA'.format(mtd['iq_s1_3_d2.0m_c5.5m_w5.6A'].readX(0)[0],
+                                                       mtd['iq_s1_3_d2.0m_c5.5m_w5.6A'].readX(0)[-1]))
 
 Output:
 

--- a/docs/source/algorithms/SANSILLAutoProcess-v1.rst
+++ b/docs/source/algorithms/SANSILLAutoProcess-v1.rst
@@ -63,9 +63,12 @@ When multiple runs are summed, the run number of the first run is attributed to 
             OutputWorkspace='iq_s' + str(i + 1)
         )
 
-    print('Distance 1 Q-range:{0:4f}-{1:4f} AA'.format(mtd['iq_s1_1'].readX(0)[0], mtd['iq_s1_1'].readX(0)[-1]))
-    print('Distance 2 Q-range:{0:4f}-{1:4f} AA'.format(mtd['iq_s1_2'].readX(0)[0], mtd['iq_s1_2'].readX(0)[-1]))
-    print('Distance 3 Q-range:{0:4f}-{1:4f} AA'.format(mtd['iq_s1_3'].readX(0)[0], mtd['iq_s1_3'].readX(0)[-1]))
+    print('Distance 1 Q-range:{0:4f}-{1:4f} AA'.format(mtd['iq_s1_d39.0m_c40.5m_w5.6A_1'].readX(0)[0],
+                                                       mtd['iq_s1_d39.0m_c40.5m_w5.6A_1'].readX(0)[-1]))
+    print('Distance 2 Q-range:{0:4f}-{1:4f} AA'.format(mtd['iq_s1_d8.0m_c8.0m_w5.6A_2'].readX(0)[0],
+                                                       mtd['iq_s1_d8.0m_c8.0m_w5.6A_2'].readX(0)[-1]))
+    print('Distance 3 Q-range:{0:4f}-{1:4f} AA'.format(mtd['iq_s1_d2.0m_c5.5m_w5.6A_3'].readX(0)[0],
+                                                       mtd['iq_s1_d2.0m_c5.5m_w5.6A_3'].readX(0)[-1]))
 
 Output:
 

--- a/docs/source/release/v6.1.0/sans.rst
+++ b/docs/source/release/v6.1.0/sans.rst
@@ -9,4 +9,9 @@ SANS Changes
     putting new features at the top of the section, followed by
     improvements, followed by bug fixes.
 
+Improvements
+############
+
+- With SANSILLAutoProcess, the detector distance, the collimation position and the wavelength are appended to the names of the output workspaces (values are taken from the sample logs).
+
 :ref:`Release 6.1.0 <v6.1.0>`


### PR DESCRIPTION
**Description of work.**

This PR changes the naming convention of the output workspaces of SANSILLAutoProcess. The detector distance, the collimation distance and the wavelength are appended to the `OutputWorkspace` parameter value.

This applies for:
* the sample output workspaces
* the panels output workspaces (`OutputPanels == true`)
* the wedges output workspaces (`OutputType == I(Q) && NumberOfWedges != 0`)

**To test:**

With data from `SystemTest/ILL/D11/`
```python
SANSILLAutoProcess(SampleRuns="2889,2885,2881", OutputWorkspace="ws")
```
Check that you obtain a group workspace named `ws` that contains 1 workspace per distance and a stitched one. Check that the values in the names of the individual reduction correspond to the sample logs value found in `002889.nxs`, `002885.nxs` and `002881.nxs`:
* `dX.Xm`: detector distance. `L2` key in the sample logs
* `cX.Xm`: collimation position. `collimation.actual_position` key of the sample logs
* `wX.XA`: wavelength. `wavelength` key (or `selector.wavelength` if `wavelength` does not exist) of the sample logs

---

```python
SANSILLAutoProcess(SampleRuns="2889,2885,2881", OutputWorkspace="ws", NumberOfWedges=2)
```
Idem for the sample output workspaces. Check that you also obtain two other group workspaces `ws_wedge_1` and `ws_wedge_2` which contain workspaces with names following the same scheme.

---

With data from `UnitTest/ILL/D33/`:
```python
SANSILLAutoProcess(SampleRuns="001464", OutputWorkspace="ws", OutputPanels=True)
```
Idem but with a `ws_panels` group workspace. In this case, the panel distance is used.


Part of #30343 

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
