### PR TITLE
Match logging from LoadInstrument

### DIFF
--- a/Framework/DataHandling/src/LoadIDFFromNexus.cpp
+++ b/Framework/DataHandling/src/LoadIDFFromNexus.cpp
@@ -139,12 +139,7 @@ void LoadIDFFromNexus::exec() {
       g_log.notice() << "Using correction parameter file: "
                      << corrParamFile.toString() << " to replace parameters.\n";
     }
-    bool ok = loadParameterFile(corrParamFile.toString(), localWorkspace);
-    if (!ok) {
-      g_log.error() << "Unable to load parameter file "
-                    << corrParamFile.toString() << " specified in "
-                    << corrFilePath.toString() << ".\n";
-    }
+    loadParameterFile(corrParamFile.toString(), localWorkspace);
   } else {
     g_log.notice() << "No correction parameter file applies to the date for "
                       "correction file.\n";
@@ -326,11 +321,16 @@ bool LoadIDFFromNexus::loadParameterFile(
     g_log.notice() << "Instrument parameter file: " << fullPathName
                    << " has been loaded.\n\n";
     return true; // Success
-  } catch (std::runtime_error &) {
-    g_log.debug() << "Instrument parameter file: " << fullPathName
-                  << " not found or un-parsable.\n";
-    return false; // Failure
+  } catch (std::invalid_argument &e) {
+    g_log.information(
+        "LoadParameterFile: No parameter file found for this instrument");
+    g_log.information(e.what());
+  } catch (std::runtime_error &e) {
+    g_log.information(
+        "Unable to successfully run LoadParameterFile Child Algorithm");
+    g_log.information(e.what());
   }
+  return false;
 }
 
 } // namespace DataHandling


### PR DESCRIPTION
`LoadIDFFromNexus` had different log messages and levels from `LoadInstrument`. This copies the [logging from `LoadInstrument`](https://github.com/mantidproject/mantid/blob/master/Framework/DataHandling/src/LoadInstrument.cpp#L270-L293) so there is a consistent behavior and messages for the logging.

**To test:**

Only the logging messages have been changed so there is nothing to test beyond reading the changeset.

*There is no associated issue.*

*This does not require release notes* because only the logging messages have been changed.

The sibling PR into `ornl-next` is #30570.

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
