### PR TITLE
Slim Eigen Build

### DIFF
--- a/buildconfig/CMake/Eigen.cmake
+++ b/buildconfig/CMake/Eigen.cmake
@@ -15,7 +15,7 @@ else()
   # Download and unpack Eigen at configure time
   configure_file(${CMAKE_SOURCE_DIR}/buildconfig/CMake/Eigen.in ${CMAKE_BINARY_DIR}/extern-eigen/CMakeLists.txt)
 
-  execute_process(COMMAND ${CMAKE_COMMAND} -G "${CMAKE_GENERATOR}" -DCMAKE_SYSTEM_VERSION=${CMAKE_SYSTEM_VERSION} . WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/extern-eigen )
+  execute_process(COMMAND ${CMAKE_COMMAND} -G "${CMAKE_GENERATOR}" -DBUILD_TESTING="OFF" -DCMAKE_SYSTEM_VERSION=${CMAKE_SYSTEM_VERSION} . WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/extern-eigen )
   execute_process(COMMAND ${CMAKE_COMMAND} --build . WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/extern-eigen )
 
   set(Eigen3_DIR "${CMAKE_BINARY_DIR}/extern-eigen/install/share/eigen3/cmake" CACHE PATH "")

--- a/buildconfig/CMake/Eigen.in
+++ b/buildconfig/CMake/Eigen.in
@@ -5,7 +5,7 @@ project(eigen-download NONE)
 include( ExternalProject )
 
 ExternalProject_Add(eigen
-  URL "https://github.com/eigenteam/eigen-git-mirror/archive/3.3.4.tar.gz"
+  URL "https://gitlab.com/libeigen/eigen/-/archive/3.3.9/eigen-3.3.9.tar.gz"
   URL_HASH "MD5=1896a1f682e6cdcffd91b6e5ba8286a2"
   DOWNLOAD_DIR ${CMAKE_CURRENT_BINARY_DIR}/extern-eigen/download
   SOURCE_DIR ${CMAKE_CURRENT_BINARY_DIR}/extern-eigen/source


### PR DESCRIPTION
When not applying `USING_SYSTEM_EIGEN` (default for all platforms except windows), we are unnecessarily building tests and bringing in dependencies to mantid that are not strictly required. See https://gitlab.com/libeigen/eigen/-/blob/master/CMakeLists.txt#L481-500

Notably `liblapack` and `blas`. In turn we might then remove these from our conda recipes. 