### PR TITLE
Make unit test .exes run in VS without visual-studio.bat

### DIFF
--- a/buildconfig/CMake/FindCxxTest.cmake
+++ b/buildconfig/CMake/FindCxxTest.cmake
@@ -168,6 +168,15 @@ macro(CXXTEST_ADD_TEST _cxxtest_testname)
     # The TESTHELPER_SRCS variable can be set outside the macro and used to pass in test helper classes
     add_executable(${_cxxtest_testname} EXCLUDE_FROM_ALL ${_cxxtest_cpp_files} ${_cxxtest_h_files} ${TESTHELPER_SRCS} )
 
+    set (_misc_bin ${CMAKE_SOURCE_DIR}/external/src/ThirdParty/bin)
+    set (_qt5_bin ${CMAKE_SOURCE_DIR}/external/src/ThirdParty/lib/qt5/bin ${CMAKE_SOURCE_DIR}/external/src/ThirdParty/lib/qt5/lib)
+    set (_qt_qpa_platform_plugin ${CMAKE_SOURCE_DIR}/external/src/ThirdParty/lib/qt5/plugins)
+    set (_python_home ${CMAKE_SOURCE_DIR}/external/src/ThirdParty/lib/python3.8)
+    # Note: %PATH% isn't understood by cmake but it is by Visual Studio\Windows where it gets used
+    set_target_properties(${_cxxtest_testname} PROPERTIES VS_DEBUGGER_ENVIRONMENT "PATH=${_misc_bin};${_qt5_bin};${_python_home};${_python_home}/Scripts;%PATH%\n\
+QT_QPA_PLATFORM_PLUGIN_PATH=${_qt_qpa_platform_plugin}\n\
+PYTHONHOME=${_python_home}")
+
     # only the package wide test is added to check
     add_dependencies(check ${_cxxtest_testname})
 
@@ -182,7 +191,17 @@ macro(CXXTEST_ADD_TEST _cxxtest_testname)
 
       set_tests_properties ( ${_cxxtest_separate_name} PROPERTIES
                              TIMEOUT ${TESTING_TIMEOUT} )
-
+      if(WIN32)
+        set_property( TEST ${_cxxtest_separate_name} APPEND PROPERTY
+           ENVIRONMENT "QT_QPA_PLATFORM_PLUGIN_PATH=${_qt_qpa_platform_plugin}")
+        set_property( TEST ${_cxxtest_separate_name} APPEND PROPERTY
+           ENVIRONMENT "PYTHONHOME=${_python_home}")
+        set (_new_path ${_misc_bin} ${_qt5_bin} ${_python_home} ${_python_home}/Scripts $ENV{PATH})
+        # the value used for PATH has to have explicit semi colons for some reason
+        string(REPLACE ";" "\;" _new_path "${_new_path}")
+        set_property( TEST ${_cxxtest_separate_name} APPEND PROPERTY
+            ENVIRONMENT "PATH=${_new_path}")
+      endif()
       if (CXXTEST_ADD_PERFORMANCE)
         # ------ Performance test version -------
         # Name of the possibly-existing Performance test suite

--- a/buildconfig/CMake/FindCxxTest.cmake
+++ b/buildconfig/CMake/FindCxxTest.cmake
@@ -168,10 +168,10 @@ macro(CXXTEST_ADD_TEST _cxxtest_testname)
     # The TESTHELPER_SRCS variable can be set outside the macro and used to pass in test helper classes
     add_executable(${_cxxtest_testname} EXCLUDE_FROM_ALL ${_cxxtest_cpp_files} ${_cxxtest_h_files} ${TESTHELPER_SRCS} )
 
-    set (_misc_bin ${CMAKE_SOURCE_DIR}/external/src/ThirdParty/bin)
-    set (_qt5_bin ${CMAKE_SOURCE_DIR}/external/src/ThirdParty/lib/qt5/bin ${CMAKE_SOURCE_DIR}/external/src/ThirdParty/lib/qt5/lib)
-    set (_qt_qpa_platform_plugin ${CMAKE_SOURCE_DIR}/external/src/ThirdParty/lib/qt5/plugins)
-    set (_python_home ${CMAKE_SOURCE_DIR}/external/src/ThirdParty/lib/python3.8)
+    set (_misc_bin ${THIRD_PARTY_DIR}/bin)
+    set (_qt5_bin ${THIRD_PARTY_DIR}/lib/qt5/bin ${THIRD_PARTY_DIR}/lib/qt5/lib)
+    set (_qt_qpa_platform_plugin ${THIRD_PARTY_DIR}/lib/qt5/plugins)
+    set (_python_home ${THIRD_PARTY_DIR}/lib/python3.8)
     # Note: %PATH% isn't understood by cmake but it is by Visual Studio\Windows where it gets used
     set_target_properties(${_cxxtest_testname} PROPERTIES VS_DEBUGGER_ENVIRONMENT "PATH=${_misc_bin};${_qt5_bin};${_python_home};${_python_home}/Scripts;%PATH%\n\
 QT_QPA_PLATFORM_PLUGIN_PATH=${_qt_qpa_platform_plugin}\n\


### PR DESCRIPTION
**Description of work.**

Populate the VS_DEBUGGER_ENVIRONMENT cmake property with values for the PATH, QT_QPA_PLATFORM_PLUGIN_PATH and PYTHONHOME environment variables on all of the Unit test targets so that they complete OK when run from an instance of Visual Studio opened up from the Mantid.sln file. These changes help the tests find various third party dlls. This cmake property is ignored for generators other than Visual Studio.

I think this is the last remaining reason why the visual-studio.bat file couldn't be required. Some work in this area was also done in #29088 and #28374

I have also made it possible to run the tests from the command line using a ctest command without needing to use command-prompt.bat by making a similar cmake change

Note that it's also possible to run the unit tests in a 3rd way by running the executable directly from a command prompt. This still requires the command prompt to have been opened using command-prompt.bat. I'm not sure there's anyway around this.

**To test:**

Before this change some of the unit test executables (eg GeometryTest) gave errors relating to third party dlls not being found when they're run from inside Visual Studio or from a standard command prompt. For me the cause of the error was only reported from within Visual Studio - when running ctest (even using the --output-on-failure switch) it simply said failed with an error code.

Open up Visual Studio by double clicking Mantid.sln
Right click on GeometryTest and select "Set as Startup Project"
Run GeometryTest from inside Visual Studio (you can run all the tests, it doesn't take v long)
Observe it completes without errors (before it gave an error about not finding libNeXusCPP-0D.dll)

Open up a normal command prompt without using command-prompt.bat
Run ```ctest -R MantidQtScientificInterfacesTestQt5 -C Debug``` from the build directory
Observe it completes without errors

Fixes #28263.

*This does not require release notes* because **it's an internal technical change relevant to developers only**

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
