### PR TITLE
Fix sphere background shell plot when inner radius equals peak radius

### DIFF
--- a/Framework/DataObjects/src/PeakShapeSpherical.cpp
+++ b/Framework/DataObjects/src/PeakShapeSpherical.cpp
@@ -44,9 +44,6 @@ PeakShapeSpherical::PeakShapeSpherical(const double &peakRadius,
     : PeakShapeBase(frame, std::move(algorithmName), algorithmVersion),
       m_radius(peakRadius), m_backgroundInnerRadius(peakInnerRadius),
       m_backgroundOuterRadius(peakOuterRadius) {
-  if (peakRadius == m_backgroundInnerRadius) {
-    m_backgroundInnerRadius.reset();
-  }
   if (peakRadius == m_backgroundOuterRadius) {
     m_backgroundOuterRadius.reset();
   }

--- a/Framework/DataObjects/test/PeakShapeSphericalTest.h
+++ b/Framework/DataObjects/test/PeakShapeSphericalTest.h
@@ -85,9 +85,8 @@ public:
     PeakShapeSpherical badShape(radius, radius, radius, frame, algorithmName,
                                 algorithmVersion);
 
-    TSM_ASSERT(
-        "Background inner radius should be unset since is same as radius",
-        !badShape.backgroundInnerRadius().is_initialized());
+    TSM_ASSERT("Background inner radius should be set even when same as radius",
+               badShape.backgroundInnerRadius().is_initialized());
     TSM_ASSERT(
         "Background outer radius should be unset since is same as radius",
         !badShape.backgroundOuterRadius().is_initialized());

--- a/docs/source/release/v6.0.0/mantidworkbench.rst
+++ b/docs/source/release/v6.0.0/mantidworkbench.rst
@@ -106,6 +106,7 @@ SliceViewer
 - Ellipsoid axes of integrated peaks are correctly transformed when axes swapped
 - A number of issues with displaying ellipsoid peak shapes have been fixed
 - For the elliptical shell of integrated peaks, the inner background radius is now correct
+- The background shell of spherical peaks is now plotted if inner radius equals the peak radius
 - The sort order of peaks in the peaks overlay has been corrected
 - Now the correct view is displayed for orthogonal axis indices in non-orthogonal view
 - Displayed peaks update if the underlying PeaksWorkspace has been changed, removed or cleared


### PR DESCRIPTION
This is still a valid configuration and does get integrated correctly, it was just not showing to background shell in the sliceviewer.

This is a valid option, see https://docs.mantidproject.org/nightly/algorithms/IntegratePeaksMD-v2.html#if-backgroundinnerradius-is-omitted

**To test:**
```python
ws = CreateMDWorkspace(Dimensions='3', Extents='-2,2,-2,2,-2,2',
                       Names='Q_lab_x,Q_lab_y,Q_lab_z', Units='U,U,U',
                       Frames='QLab,QLab,QLab',
                       SplitInto='2', SplitThreshold='50')
expt_info = CreateSampleWorkspace()
ws.addExperimentInfo(expt_info)

# add peak
p = CreatePeaksWorkspace(InstrumentWorkspace='ws', NumberOfPeaks=0, OutputWorkspace='peaks')
SetUB('peaks', 1,1,1,90,90,90)
pk = p.createPeak([1,1,1]) # axes aligned with viewing axes
p.addPeak(pk)

IntegratePeaksMD(InputWorkspace='ws', PeakRadius=0.3, BackgroundInnerRadius=0.3, BackgroundOuterRadius=0.5, PeaksWorkspace='peaks', OutputWorkspace='sphere_bkg')
```

Overplot the peaks in sliceviewer and select the peak


Currently you don't see the background shell,

![sphere_bkg](https://user-images.githubusercontent.com/5595210/106923556-30a6ad00-66dc-11eb-83f3-bd762c8126b4.png)


After this fix,
![sphere_bkg_fixed](https://user-images.githubusercontent.com/5595210/106923582-39977e80-66dc-11eb-8838-02f2898512fb.png)
 you should see it




*There is no associated issue.*


<!-- Ensure the base of this PR is correct (e.g. release-next or master)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
