### PR TITLE
Added Number Of Periods To Run Info And Change Tooltip in MA/FDA

### DIFF
--- a/docs/source/release/v6.0.0/muon.rst
+++ b/docs/source/release/v6.0.0/muon.rst
@@ -21,6 +21,8 @@ Improvements
 - Input validation has been added to First and Last good Data in the Phase Table tab.
 - When using co-add and creating a phasequad, the deadtime table will now be taken from the first file only.
 - If the start time of a fit is greater than the end time the interface will swap the two.
+- Number of Periods has now been added to the end of Run Information.
+- The tool tip for periods in the grouping table has been updated for more clarification.
 
 Bug fixes
 #########

--- a/scripts/Muon/GUI/Common/contexts/muon_data_context.py
+++ b/scripts/Muon/GUI/Common/contexts/muon_data_context.py
@@ -197,11 +197,6 @@ class MuonDataContext(object):
             return 1
 
     def num_periods(self, run):
-        print("i am run")
-        temp =  self._loaded_data.get_data(run=run, instrument=self.instrument)
-        temp1 = temp['workspace']
-        temp2 = temp1['OutputWorkspace']
-        print("success " + str(len(temp2)))
         return len(self._loaded_data.get_data(run=run, instrument=self.instrument)['workspace']['OutputWorkspace'])
 
     @property

--- a/scripts/Muon/GUI/Common/contexts/muon_data_context.py
+++ b/scripts/Muon/GUI/Common/contexts/muon_data_context.py
@@ -197,6 +197,11 @@ class MuonDataContext(object):
             return 1
 
     def num_periods(self, run):
+        print("i am run")
+        temp =  self._loaded_data.get_data(run=run, instrument=self.instrument)
+        temp1 = temp['workspace']
+        temp2 = temp1['OutputWorkspace']
+        print("success " + str(len(temp2)))
         return len(self._loaded_data.get_data(run=run, instrument=self.instrument)['workspace']['OutputWorkspace'])
 
     @property

--- a/scripts/Muon/GUI/Common/grouping_table_widget/grouping_table_widget_view.py
+++ b/scripts/Muon/GUI/Common/grouping_table_widget/grouping_table_widget_view.py
@@ -133,7 +133,7 @@ class GroupingTableView(QtWidgets.QWidget):
         self.grouping_table.horizontalHeaderItem(0).setToolTip("The name of the group :"
                                                                "\n    - The name must be unique across all groups/pairs"
                                                                "\n    - The name can only use digits, characters and _")
-        self.grouping_table.horizontalHeaderItem(1).setToolTip("Periods to use when calculating this group.")
+        self.grouping_table.horizontalHeaderItem(1).setToolTip("Sum of periods to use when calculating this group.")
         self.grouping_table.horizontalHeaderItem(2).setToolTip("Whether to include this group in the analysis.")
 
         self.grouping_table.horizontalHeaderItem(3).setToolTip("The sorted list of detectors :"

--- a/scripts/Muon/GUI/Common/home_runinfo_widget/home_runinfo_widget_model.py
+++ b/scripts/Muon/GUI/Common/home_runinfo_widget/home_runinfo_widget_model.py
@@ -70,8 +70,5 @@ class HomeRunInfoWidgetModel(object):
         ws = self._data.current_workspace
         return ws.getComment()
 
-    def get_periods(self, run):
-        try:
-            return self._data.num_periods(run) if self._data.current_run else ''
-        except Exception:
-            return ''
+    def get_periods(self):
+        return self._data.num_periods(self._data.current_run) if self._data.current_run else ''

--- a/scripts/Muon/GUI/Common/home_runinfo_widget/home_runinfo_widget_model.py
+++ b/scripts/Muon/GUI/Common/home_runinfo_widget/home_runinfo_widget_model.py
@@ -69,3 +69,9 @@ class HomeRunInfoWidgetModel(object):
     def get_workspace_comment(self):
         ws = self._data.current_workspace
         return ws.getComment()
+
+    def get_periods(self, run):
+        try:
+            return self._data.num_periods(run) if self._data.current_run else ''
+        except Exception:
+            return ''

--- a/scripts/Muon/GUI/Common/home_runinfo_widget/home_runinfo_widget_presenter.py
+++ b/scripts/Muon/GUI/Common/home_runinfo_widget/home_runinfo_widget_presenter.py
@@ -35,7 +35,7 @@ class HomeRunInfoWidgetPresenter(HomeTabSubWidget):
         self._view.add_text_line("Average Temperature (K)   : "+str(self._model.get_average_temperature()))
         self._view.add_text_line(self.create_text_line("Sample Temperature (K)   ", "sample_temp"))
         self._view.add_text_line(self.create_text_line("Sample Magnetic Field (G)", "sample_magn_field"))
-        self._view.add_text_line("Number of Periods         : " + str(self._model.get_periods(run)))
+        self._view.add_text_line("Number of Periods         : " + str(self._model.get_periods()))
 
     def create_text_line(self, name, log_name):
         log = self._model.get_log_value(log_name)

--- a/scripts/Muon/GUI/Common/home_runinfo_widget/home_runinfo_widget_presenter.py
+++ b/scripts/Muon/GUI/Common/home_runinfo_widget/home_runinfo_widget_presenter.py
@@ -35,6 +35,7 @@ class HomeRunInfoWidgetPresenter(HomeTabSubWidget):
         self._view.add_text_line("Average Temperature (K)   : "+str(self._model.get_average_temperature()))
         self._view.add_text_line(self.create_text_line("Sample Temperature (K)   ", "sample_temp"))
         self._view.add_text_line(self.create_text_line("Sample Magnetic Field (G)", "sample_magn_field"))
+        self._view.add_text_line("Number of Periods         : " + str(self._model.get_periods(run)))
 
     def create_text_line(self, name, log_name):
         log = self._model.get_log_value(log_name)

--- a/scripts/test/Muon/home_runinfo_presenter_test.py
+++ b/scripts/test/Muon/home_runinfo_presenter_test.py
@@ -50,7 +50,8 @@ class HomeTabRunInfoPresenterTest(unittest.TestCase):
                                 'Start:2009-03-24T04:18:58', 'End:2009-03-24T04:56:26', 'Counts(MEv):20.076704',
                                 'GoodFrames:88540', 'CountsperGoodFrame:226.753',
                                 'CountsperGoodFrameperdet:3.543', 'AverageTemperature(K):19.69992',
-                                'SampleTemperature(K):1.0', 'SampleMagneticField(G):100.0']
+                                'SampleTemperature(K):1.0', 'SampleMagneticField(G):100.0',
+                                'NumberofPeriods:1']
 
         self.assertEqual(str(self.view.run_info_box.toPlainText()).replace(' ', '').splitlines(), expected_string_list)
 


### PR DESCRIPTION
**Description of work.**
Updated the tooltip of periods in the grouping table and added number of periods to run info

**To test:**

1. Open Muon Analysis
2. Load in some runs and check in the run info box the number of periods is as expected
3. Go to the grouping tab and check the tooltip for periods has changed to explicitly state it is the sum of the periods
4. Double check FDA also has been updated

*There is no associated issue.*

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
