### PR TITLE
Allow full reduction for lambda workspaces

### DIFF
--- a/Framework/Reflectometry/src/ReflectometryReductionOne2.cpp
+++ b/Framework/Reflectometry/src/ReflectometryReductionOne2.cpp
@@ -255,17 +255,11 @@ void ReflectometryReductionOne2::exec() {
   findTheta0();
 
   // Check whether conversion, normalisation, summation etc. need to be done
-  m_convertUnits = true;
+  m_convertUnits = (xUnitID != "Wavelength");
   m_normaliseMonitors = true;
   m_normaliseTransmission = true;
-  m_sum = true;
-  if (xUnitID == "Wavelength") {
-    // Already converted converted to wavelength
-    m_convertUnits = false;
-    // Assume it's also already been normalised by monitors and summed
-    m_normaliseMonitors = false;
-    m_sum = false;
-  }
+  m_normaliseMonitors = true;
+  m_sum = (m_runWS->getNumberHistograms() > 1);
 
   // Create the output workspace in wavelength
   MatrixWorkspace_sptr IvsLam = makeIvsLam();


### PR DESCRIPTION
This PR is experimental work and should not be merged.

This PR removes an assumption that summation and normalisation by monitors should not be done if the workspace is in wavelength. Creating a PR so we can do some testing with lambda workspaces.

**Description of work.**

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

**To test:**

<!-- Instructions for testing. -->

Fixes #xxxx. <!-- and fix #xxxx or close #xxxx xor resolves #xxxx -->
<!-- alternative
*There is no associated issue.*
-->

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or master)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
