### PR TITLE
Search by name in ADS

### DIFF
--- a/Framework/Kernel/inc/MantidKernel/DataService.h
+++ b/Framework/Kernel/inc/MantidKernel/DataService.h
@@ -470,8 +470,8 @@ public:
    * @param txt The search string
    * @return A vector of strings containing object names in the ADS
    */
-  std::vector<std::string> getObjectNamesStartWith(
-      const std::string &txt) const {
+  std::vector<std::string>
+  getObjectNamesStartWith(const std::string &txt) const {
     std::vector<std::string> foundNames;
     bool showHidden;
 
@@ -495,8 +495,7 @@ public:
    * @param txt The search string
    * @return A vector of strings containing object names in the ADS
    */
-  std::vector<std::string> getObjectNamesEndWith(
-      const std::string &txt) const {
+  std::vector<std::string> getObjectNamesEndWith(const std::string &txt) const {
     std::vector<std::string> foundNames;
     bool showHidden;
 
@@ -511,7 +510,7 @@ public:
         continue;
       }
       if (item.first.compare(item.first.length() - txt.length(), txt.length(),
-            txt) == 0) {
+                             txt) == 0) {
         foundNames.push_back(item.first);
       }
     }
@@ -524,8 +523,7 @@ public:
    * @param txt The search string
    * @return A vector of strings containing object names in the ADS
    */
-  std::vector<std::string> getObjectNamesContain(
-      const std::string &txt) const {
+  std::vector<std::string> getObjectNamesContain(const std::string &txt) const {
     std::vector<std::string> foundNames;
     bool showHidden;
 

--- a/Framework/Kernel/inc/MantidKernel/DataService.h
+++ b/Framework/Kernel/inc/MantidKernel/DataService.h
@@ -490,6 +490,35 @@ public:
     return foundNames;
   }
 
+  /**
+   * Returns the object names of the ADS that end with a specific string.
+   * @param txt The search string
+   * @return A vector of strings containing object names in the ADS
+   */
+  std::vector<std::string> getObjectNamesEndWith(
+      const std::string &txt) const {
+    std::vector<std::string> foundNames;
+    bool showHidden;
+
+    showHidden = showingHiddenObjects();
+
+    std::lock_guard<std::recursive_mutex> _lock(m_mutex);
+    for (const auto &item : datamap) {
+      if ((!showHidden) && (isHiddenDataServiceObject(item.first))) {
+        continue;
+      }
+      if (txt.length() > item.first.length()) {
+        continue;
+      }
+      if (item.first.compare(item.first.length() - txt.length(), txt.length(),
+            txt) == 0) {
+        foundNames.push_back(item.first);
+      }
+    }
+
+    return foundNames;
+  }
+
   /// Get a vector of the pointers to the data objects stored by the service
   std::vector<std::shared_ptr<T>>
   getObjects(DataServiceHidden includeHidden = DataServiceHidden::Auto) const {

--- a/Framework/Kernel/inc/MantidKernel/DataService.h
+++ b/Framework/Kernel/inc/MantidKernel/DataService.h
@@ -465,6 +465,31 @@ public:
     return foundNames;
   }
 
+  /**
+   * Returns the object names of the ADS that start with a specific string.
+   * @param txt The search string
+   * @return A vector of strings containing object names in the ADS
+   */
+  std::vector<std::string> getObjectNamesStartWith(
+      const std::string &txt) const {
+    std::vector<std::string> foundNames;
+    bool showHidden;
+
+    showHidden = showingHiddenObjects();
+
+    std::lock_guard<std::recursive_mutex> _lock(m_mutex);
+    for (const auto &item : datamap) {
+      if ((!showHidden) && (isHiddenDataServiceObject(item.first))) {
+        continue;
+      }
+      if (item.first.rfind(txt, 0) == 0) {
+        foundNames.push_back(item.first);
+      }
+    }
+
+    return foundNames;
+  }
+
   /// Get a vector of the pointers to the data objects stored by the service
   std::vector<std::shared_ptr<T>>
   getObjects(DataServiceHidden includeHidden = DataServiceHidden::Auto) const {

--- a/Framework/Kernel/inc/MantidKernel/DataService.h
+++ b/Framework/Kernel/inc/MantidKernel/DataService.h
@@ -466,59 +466,6 @@ public:
   }
 
   /**
-   * Returns the object names of the ADS that start with a specific string.
-   * @param txt The search string
-   * @return A vector of strings containing object names in the ADS
-   */
-  std::vector<std::string>
-  getObjectNamesStartWith(const std::string &txt) const {
-    std::vector<std::string> foundNames;
-    bool showHidden;
-
-    showHidden = showingHiddenObjects();
-
-    std::lock_guard<std::recursive_mutex> _lock(m_mutex);
-    for (const auto &item : datamap) {
-      if ((!showHidden) && (isHiddenDataServiceObject(item.first))) {
-        continue;
-      }
-      if (item.first.rfind(txt, 0) == 0) {
-        foundNames.push_back(item.first);
-      }
-    }
-
-    return foundNames;
-  }
-
-  /**
-   * Returns the object names of the ADS that end with a specific string.
-   * @param txt The search string
-   * @return A vector of strings containing object names in the ADS
-   */
-  std::vector<std::string> getObjectNamesEndWith(const std::string &txt) const {
-    std::vector<std::string> foundNames;
-    bool showHidden;
-
-    showHidden = showingHiddenObjects();
-
-    std::lock_guard<std::recursive_mutex> _lock(m_mutex);
-    for (const auto &item : datamap) {
-      if ((!showHidden) && (isHiddenDataServiceObject(item.first))) {
-        continue;
-      }
-      if (txt.length() > item.first.length()) {
-        continue;
-      }
-      if (item.first.compare(item.first.length() - txt.length(), txt.length(),
-                             txt) == 0) {
-        foundNames.push_back(item.first);
-      }
-    }
-
-    return foundNames;
-  }
-
-  /**
    * Returns the object names of the ADS that contain a specific string.
    * @param txt The search string
    * @return A vector of strings containing object names in the ADS

--- a/Framework/Kernel/inc/MantidKernel/DataService.h
+++ b/Framework/Kernel/inc/MantidKernel/DataService.h
@@ -419,6 +419,7 @@ public:
    * to unsorted
    * @param hiddenState Whether to include hidden objects, Defaults to
    * Auto which checks the current configuration to determine behavior.
+   * @param contain Include only object names that contain this string.
    * @return A vector of strings containing object names in the ADS
    */
   std::vector<std::string>

--- a/Framework/Kernel/inc/MantidKernel/DataService.h
+++ b/Framework/Kernel/inc/MantidKernel/DataService.h
@@ -519,6 +519,31 @@ public:
     return foundNames;
   }
 
+  /**
+   * Returns the object names of the ADS that contain a specific string.
+   * @param txt The search string
+   * @return A vector of strings containing object names in the ADS
+   */
+  std::vector<std::string> getObjectNamesContain(
+      const std::string &txt) const {
+    std::vector<std::string> foundNames;
+    bool showHidden;
+
+    showHidden = showingHiddenObjects();
+
+    std::lock_guard<std::recursive_mutex> _lock(m_mutex);
+    for (const auto &item : datamap) {
+      if ((!showHidden) && (isHiddenDataServiceObject(item.first))) {
+        continue;
+      }
+      if (item.first.find(txt) != std::string::npos) {
+        foundNames.push_back(item.first);
+      }
+    }
+
+    return foundNames;
+  }
+
   /// Get a vector of the pointers to the data objects stored by the service
   std::vector<std::shared_ptr<T>>
   getObjects(DataServiceHidden includeHidden = DataServiceHidden::Auto) const {

--- a/Framework/Kernel/test/DataServiceTest.h
+++ b/Framework/Kernel/test/DataServiceTest.h
@@ -336,57 +336,6 @@ public:
     TS_ASSERT_EQUALS(objects.at(std::distance(names.cbegin(), cit)), three);
   }
 
-  void test_getObjectNamesStartWith() {
-    svc.add("A1", std::make_shared<int>(1));
-    svc.add("B1", std::make_shared<int>(2));
-    svc.add("B2", std::make_shared<int>(3));
-
-    std::vector<std::string> names;
-
-    names = svc.getObjectNamesStartWith("A");
-    TS_ASSERT_EQUALS(names.size(), 1);
-    TS_ASSERT_DIFFERS(std::find(names.begin(), names.end(), "A1"), names.end())
-
-    names = svc.getObjectNamesStartWith("B");
-    TS_ASSERT_EQUALS(names.size(), 2);
-    TS_ASSERT_DIFFERS(std::find(names.begin(), names.end(), "B1"), names.end())
-    TS_ASSERT_DIFFERS(std::find(names.begin(), names.end(), "B2"), names.end())
-
-    names = svc.getObjectNamesStartWith("C");
-    TS_ASSERT_EQUALS(names.size(), 0);
-
-    names = svc.getObjectNamesStartWith("B2");
-    TS_ASSERT_EQUALS(names.size(), 1);
-    TS_ASSERT_DIFFERS(std::find(names.begin(), names.end(), "B2"), names.end())
-
-    names = svc.getObjectNamesStartWith("ABCDEF");
-    TS_ASSERT_EQUALS(names.size(), 0);
-  }
-
-  void test_getObjectNamesEndWith() {
-    svc.add("A1", std::make_shared<int>(1));
-    svc.add("A2", std::make_shared<int>(1));
-    svc.add("B11", std::make_shared<int>(2));
-    svc.add("C2", std::make_shared<int>(3));
-
-    std::vector<std::string> names;
-
-    names = svc.getObjectNamesEndWith("1");
-    TS_ASSERT_EQUALS(names.size(), 2);
-    TS_ASSERT_DIFFERS(std::find(names.begin(), names.end(), "A1"), names.end())
-    TS_ASSERT_DIFFERS(std::find(names.begin(), names.end(), "B11"), names.end())
-
-    names = svc.getObjectNamesEndWith("11");
-    TS_ASSERT_EQUALS(names.size(), 1);
-    TS_ASSERT_DIFFERS(std::find(names.begin(), names.end(), "B11"), names.end())
-
-    names = svc.getObjectNamesEndWith("C");
-    TS_ASSERT_EQUALS(names.size(), 0);
-
-    names = svc.getObjectNamesEndWith("ABCDEF");
-    TS_ASSERT_EQUALS(names.size(), 0);
-  }
-
   void test_getObjectNamesContain() {
     svc.add("A1B1", std::make_shared<int>(1));
     svc.add("C2B2", std::make_shared<int>(1));

--- a/Framework/Kernel/test/DataServiceTest.h
+++ b/Framework/Kernel/test/DataServiceTest.h
@@ -334,33 +334,15 @@ public:
     auto cit = std::find(names.cbegin(), names.cend(), "__Three");
     TS_ASSERT_DIFFERS(cit, names.cend());
     TS_ASSERT_EQUALS(objects.at(std::distance(names.cbegin(), cit)), three);
-  }
 
-  void test_getObjectNamesContain() {
-    svc.add("A1B1", std::make_shared<int>(1));
-    svc.add("C2B2", std::make_shared<int>(1));
-    svc.add("A1C2", std::make_shared<int>(2));
-    svc.add("ABC", std::make_shared<int>(3));
-
-    std::vector<std::string> names;
-
-    names = svc.getObjectNamesContain("A1");
-    TS_ASSERT_EQUALS(names.size(), 2);
-    TS_ASSERT_DIFFERS(std::find(names.begin(), names.end(), "A1B1"),
-                      names.end())
-    TS_ASSERT_DIFFERS(std::find(names.begin(), names.end(), "A1C2"),
-                      names.end())
-
-    names = svc.getObjectNamesContain("B");
-    TS_ASSERT_EQUALS(names.size(), 3);
-    TS_ASSERT_DIFFERS(std::find(names.begin(), names.end(), "A1B1"),
-                      names.end())
-    TS_ASSERT_DIFFERS(std::find(names.begin(), names.end(), "C2B2"),
-                      names.end())
-    TS_ASSERT_DIFFERS(std::find(names.begin(), names.end(), "ABC"), names.end())
-
-    names = svc.getObjectNamesContain("ABCDEF");
-    TS_ASSERT_EQUALS(names.size(), 0);
+    names = svc.getObjectNames(DataServiceSort::Unsorted,
+                               DataServiceHidden::Auto, "T");
+    TS_ASSERT_EQUALS(std::find(names.cbegin(), names.cend(), "One"),
+                     names.end());
+    TS_ASSERT_DIFFERS(std::find(names.cbegin(), names.cend(), "Two"),
+                      names.end());
+    TS_ASSERT_DIFFERS(std::find(names.cbegin(), names.cend(), "TwoAgain"),
+                      names.end());
   }
 
   void test_getObjectsReturnsConfigOption() {

--- a/Framework/Kernel/test/DataServiceTest.h
+++ b/Framework/Kernel/test/DataServiceTest.h
@@ -336,6 +336,84 @@ public:
     TS_ASSERT_EQUALS(objects.at(std::distance(names.cbegin(), cit)), three);
   }
 
+  void test_getObjectNamesStartWith() {
+    svc.add("A1", std::make_shared<int>(1));
+    svc.add("B1", std::make_shared<int>(2));
+    svc.add("B2", std::make_shared<int>(3));
+
+    std::vector<std::string> names;
+
+    names = svc.getObjectNamesStartWith("A");
+    TS_ASSERT_EQUALS(names.size(), 1);
+    TS_ASSERT_DIFFERS(std::find(names.begin(), names.end(), "A1"), names.end())
+
+    names = svc.getObjectNamesStartWith("B");
+    TS_ASSERT_EQUALS(names.size(), 2);
+    TS_ASSERT_DIFFERS(std::find(names.begin(), names.end(), "B1"), names.end())
+    TS_ASSERT_DIFFERS(std::find(names.begin(), names.end(), "B2"), names.end())
+
+    names = svc.getObjectNamesStartWith("C");
+    TS_ASSERT_EQUALS(names.size(), 0);
+
+    names = svc.getObjectNamesStartWith("B2");
+    TS_ASSERT_EQUALS(names.size(), 1);
+    TS_ASSERT_DIFFERS(std::find(names.begin(), names.end(), "B2"), names.end())
+
+    names = svc.getObjectNamesStartWith("ABCDEF");
+    TS_ASSERT_EQUALS(names.size(), 0);
+  }
+
+  void test_getObjectNamesEndWith() {
+    svc.add("A1", std::make_shared<int>(1));
+    svc.add("A2", std::make_shared<int>(1));
+    svc.add("B11", std::make_shared<int>(2));
+    svc.add("C2", std::make_shared<int>(3));
+
+    std::vector<std::string> names;
+
+    names = svc.getObjectNamesEndWith("1");
+    TS_ASSERT_EQUALS(names.size(), 2);
+    TS_ASSERT_DIFFERS(std::find(names.begin(), names.end(), "A1"), names.end())
+    TS_ASSERT_DIFFERS(std::find(names.begin(), names.end(), "B11"), names.end())
+
+    names = svc.getObjectNamesEndWith("11");
+    TS_ASSERT_EQUALS(names.size(), 1);
+    TS_ASSERT_DIFFERS(std::find(names.begin(), names.end(), "B11"), names.end())
+
+    names = svc.getObjectNamesEndWith("C");
+    TS_ASSERT_EQUALS(names.size(), 0);
+
+    names = svc.getObjectNamesEndWith("ABCDEF");
+    TS_ASSERT_EQUALS(names.size(), 0);
+  }
+
+  void test_getObjectNamesContain() {
+    svc.add("A1B1", std::make_shared<int>(1));
+    svc.add("C2B2", std::make_shared<int>(1));
+    svc.add("A1C2", std::make_shared<int>(2));
+    svc.add("ABC", std::make_shared<int>(3));
+
+    std::vector<std::string> names;
+
+    names = svc.getObjectNamesContain("A1");
+    TS_ASSERT_EQUALS(names.size(), 2);
+    TS_ASSERT_DIFFERS(std::find(names.begin(), names.end(), "A1B1"),
+                      names.end())
+    TS_ASSERT_DIFFERS(std::find(names.begin(), names.end(), "A1C2"),
+                      names.end())
+
+    names = svc.getObjectNamesContain("B");
+    TS_ASSERT_EQUALS(names.size(), 3);
+    TS_ASSERT_DIFFERS(std::find(names.begin(), names.end(), "A1B1"),
+                      names.end())
+    TS_ASSERT_DIFFERS(std::find(names.begin(), names.end(), "C2B2"),
+                      names.end())
+    TS_ASSERT_DIFFERS(std::find(names.begin(), names.end(), "ABC"), names.end())
+
+    names = svc.getObjectNamesContain("ABCDEF");
+    TS_ASSERT_EQUALS(names.size(), 0);
+  }
+
   void test_getObjectsReturnsConfigOption() {
     svc.clear();
 

--- a/Framework/PythonInterface/core/inc/MantidPythonInterface/core/DataServiceExporter.h
+++ b/Framework/PythonInterface/core/inc/MantidPythonInterface/core/DataServiceExporter.h
@@ -81,6 +81,10 @@ template <typename SvcType, typename SvcPtrType> struct DataServiceExporter {
                  &DataServiceExporter::getObjectNamesEndWithAsList,
                  (arg("self"), arg("txt")), "Return the list of names known to "
                  "the ADS that end with a specific string")
+             .def("getObjectNamesContain",
+                 &DataServiceExporter::getObjectNamesContainAsList,
+                 (arg("self"), arg("txt")), "Return the list of names known to "
+                 "the ADS that contain a specific string")
 
             // Make it act like a dictionary
             .def("__len__", &SvcType::size, arg("self"))
@@ -208,6 +212,24 @@ template <typename SvcType, typename SvcPtrType> struct DataServiceExporter {
           const std::string &txt) {
     boost::python::list names;
     const auto keys = self.getObjectNamesEndWith(txt);
+    for (auto itr = keys.begin(); itr != keys.end(); ++itr) {
+      names.append(*itr);
+    }
+    assert(names.attr("__len__")() == keys.size());
+    return names;
+  }
+
+  /**
+   * Return a Python list of object names that contain a specific string from
+   * the ADS.
+   * @param self A reference to the ADS
+   * @param txt The search string
+   * @return A python list of object names
+   */
+  static boost::python::list getObjectNamesContainAsList(SvcType &self,
+          const std::string &txt) {
+    boost::python::list names;
+    const auto keys = self.getObjectNamesContain(txt);
     for (auto itr = keys.begin(); itr != keys.end(); ++itr) {
       names.append(*itr);
     }

--- a/Framework/PythonInterface/core/inc/MantidPythonInterface/core/DataServiceExporter.h
+++ b/Framework/PythonInterface/core/inc/MantidPythonInterface/core/DataServiceExporter.h
@@ -160,6 +160,8 @@ template <typename SvcType, typename SvcPtrType> struct DataServiceExporter {
    * Return a Python list of object names from the ADS as this is
    * far easier to work with than a set
    * @param self :: A reference to the ADS object that called this method
+   * @param contain :: If provided, the function will return only names that
+   * contain this string
    * @returns A python list created from the set of strings
    */
   static boost::python::list getObjectNamesAsList(SvcType &self,

--- a/Framework/PythonInterface/core/inc/MantidPythonInterface/core/DataServiceExporter.h
+++ b/Framework/PythonInterface/core/inc/MantidPythonInterface/core/DataServiceExporter.h
@@ -73,6 +73,10 @@ template <typename SvcType, typename SvcPtrType> struct DataServiceExporter {
             .def("getObjectNames", &DataServiceExporter::getObjectNamesAsList,
                  arg("self"),
                  "Return the list of names currently known to the ADS")
+            .def("getObjectNamesStartWith",
+                 &DataServiceExporter::getObjectNamesStartWithAsList,
+                 (arg("self"), arg("txt")), "Return the list of names known to "
+                 "the ADS that start with a specific string")
 
             // Make it act like a dictionary
             .def("__len__", &SvcType::size, arg("self"))
@@ -164,6 +168,24 @@ template <typename SvcType, typename SvcPtrType> struct DataServiceExporter {
   static boost::python::list getObjectNamesAsList(SvcType &self) {
     boost::python::list names;
     const auto keys = self.getObjectNames();
+    for (auto itr = keys.begin(); itr != keys.end(); ++itr) {
+      names.append(*itr);
+    }
+    assert(names.attr("__len__")() == keys.size());
+    return names;
+  }
+
+  /**
+   * Return a Python list of object names that start with a specific string from
+   * the ADS.
+   * @param self A reference to the ADS
+   * @param txt The search string
+   * @return A python list of object names
+   */
+  static boost::python::list getObjectNamesStartWithAsList(SvcType &self,
+          const std::string &txt) {
+    boost::python::list names;
+    const auto keys = self.getObjectNamesStartWith(txt);
     for (auto itr = keys.begin(); itr != keys.end(); ++itr) {
       names.append(*itr);
     }

--- a/Framework/PythonInterface/core/inc/MantidPythonInterface/core/DataServiceExporter.h
+++ b/Framework/PythonInterface/core/inc/MantidPythonInterface/core/DataServiceExporter.h
@@ -75,15 +75,18 @@ template <typename SvcType, typename SvcPtrType> struct DataServiceExporter {
                  "Return the list of names currently known to the ADS")
             .def("getObjectNamesStartWith",
                  &DataServiceExporter::getObjectNamesStartWithAsList,
-                 (arg("self"), arg("txt")), "Return the list of names known to "
+                 (arg("self"), arg("txt")),
+                 "Return the list of names known to "
                  "the ADS that start with a specific string")
             .def("getObjectNamesEndWith",
                  &DataServiceExporter::getObjectNamesEndWithAsList,
-                 (arg("self"), arg("txt")), "Return the list of names known to "
+                 (arg("self"), arg("txt")),
+                 "Return the list of names known to "
                  "the ADS that end with a specific string")
-             .def("getObjectNamesContain",
+            .def("getObjectNamesContain",
                  &DataServiceExporter::getObjectNamesContainAsList,
-                 (arg("self"), arg("txt")), "Return the list of names known to "
+                 (arg("self"), arg("txt")),
+                 "Return the list of names known to "
                  "the ADS that contain a specific string")
 
             // Make it act like a dictionary
@@ -190,8 +193,8 @@ template <typename SvcType, typename SvcPtrType> struct DataServiceExporter {
    * @param txt The search string
    * @return A python list of object names
    */
-  static boost::python::list getObjectNamesStartWithAsList(SvcType &self,
-          const std::string &txt) {
+  static boost::python::list
+  getObjectNamesStartWithAsList(SvcType &self, const std::string &txt) {
     boost::python::list names;
     const auto keys = self.getObjectNamesStartWith(txt);
     for (auto itr = keys.begin(); itr != keys.end(); ++itr) {
@@ -208,8 +211,8 @@ template <typename SvcType, typename SvcPtrType> struct DataServiceExporter {
    * @param txt The search string
    * @return A python list of object names
    */
-  static boost::python::list getObjectNamesEndWithAsList(SvcType &self,
-          const std::string &txt) {
+  static boost::python::list
+  getObjectNamesEndWithAsList(SvcType &self, const std::string &txt) {
     boost::python::list names;
     const auto keys = self.getObjectNamesEndWith(txt);
     for (auto itr = keys.begin(); itr != keys.end(); ++itr) {
@@ -226,8 +229,8 @@ template <typename SvcType, typename SvcPtrType> struct DataServiceExporter {
    * @param txt The search string
    * @return A python list of object names
    */
-  static boost::python::list getObjectNamesContainAsList(SvcType &self,
-          const std::string &txt) {
+  static boost::python::list
+  getObjectNamesContainAsList(SvcType &self, const std::string &txt) {
     boost::python::list names;
     const auto keys = self.getObjectNamesContain(txt);
     for (auto itr = keys.begin(); itr != keys.end(); ++itr) {

--- a/Framework/PythonInterface/core/inc/MantidPythonInterface/core/DataServiceExporter.h
+++ b/Framework/PythonInterface/core/inc/MantidPythonInterface/core/DataServiceExporter.h
@@ -77,6 +77,10 @@ template <typename SvcType, typename SvcPtrType> struct DataServiceExporter {
                  &DataServiceExporter::getObjectNamesStartWithAsList,
                  (arg("self"), arg("txt")), "Return the list of names known to "
                  "the ADS that start with a specific string")
+            .def("getObjectNamesEndWith",
+                 &DataServiceExporter::getObjectNamesEndWithAsList,
+                 (arg("self"), arg("txt")), "Return the list of names known to "
+                 "the ADS that end with a specific string")
 
             // Make it act like a dictionary
             .def("__len__", &SvcType::size, arg("self"))
@@ -186,6 +190,24 @@ template <typename SvcType, typename SvcPtrType> struct DataServiceExporter {
           const std::string &txt) {
     boost::python::list names;
     const auto keys = self.getObjectNamesStartWith(txt);
+    for (auto itr = keys.begin(); itr != keys.end(); ++itr) {
+      names.append(*itr);
+    }
+    assert(names.attr("__len__")() == keys.size());
+    return names;
+  }
+
+  /**
+   * Return a Python list of object names that end with a specific string from
+   * the ADS.
+   * @param self A reference to the ADS
+   * @param txt The search string
+   * @return A python list of object names
+   */
+  static boost::python::list getObjectNamesEndWithAsList(SvcType &self,
+          const std::string &txt) {
+    boost::python::list names;
+    const auto keys = self.getObjectNamesEndWith(txt);
     for (auto itr = keys.begin(); itr != keys.end(); ++itr) {
       names.append(*itr);
     }

--- a/Framework/PythonInterface/core/inc/MantidPythonInterface/core/DataServiceExporter.h
+++ b/Framework/PythonInterface/core/inc/MantidPythonInterface/core/DataServiceExporter.h
@@ -73,16 +73,6 @@ template <typename SvcType, typename SvcPtrType> struct DataServiceExporter {
             .def("getObjectNames", &DataServiceExporter::getObjectNamesAsList,
                  arg("self"),
                  "Return the list of names currently known to the ADS")
-            .def("getObjectNamesStartWith",
-                 &DataServiceExporter::getObjectNamesStartWithAsList,
-                 (arg("self"), arg("txt")),
-                 "Return the list of names known to "
-                 "the ADS that start with a specific string")
-            .def("getObjectNamesEndWith",
-                 &DataServiceExporter::getObjectNamesEndWithAsList,
-                 (arg("self"), arg("txt")),
-                 "Return the list of names known to "
-                 "the ADS that end with a specific string")
             .def("getObjectNamesContain",
                  &DataServiceExporter::getObjectNamesContainAsList,
                  (arg("self"), arg("txt")),
@@ -179,42 +169,6 @@ template <typename SvcType, typename SvcPtrType> struct DataServiceExporter {
   static boost::python::list getObjectNamesAsList(SvcType &self) {
     boost::python::list names;
     const auto keys = self.getObjectNames();
-    for (auto itr = keys.begin(); itr != keys.end(); ++itr) {
-      names.append(*itr);
-    }
-    assert(names.attr("__len__")() == keys.size());
-    return names;
-  }
-
-  /**
-   * Return a Python list of object names that start with a specific string from
-   * the ADS.
-   * @param self A reference to the ADS
-   * @param txt The search string
-   * @return A python list of object names
-   */
-  static boost::python::list
-  getObjectNamesStartWithAsList(SvcType &self, const std::string &txt) {
-    boost::python::list names;
-    const auto keys = self.getObjectNamesStartWith(txt);
-    for (auto itr = keys.begin(); itr != keys.end(); ++itr) {
-      names.append(*itr);
-    }
-    assert(names.attr("__len__")() == keys.size());
-    return names;
-  }
-
-  /**
-   * Return a Python list of object names that end with a specific string from
-   * the ADS.
-   * @param self A reference to the ADS
-   * @param txt The search string
-   * @return A python list of object names
-   */
-  static boost::python::list
-  getObjectNamesEndWithAsList(SvcType &self, const std::string &txt) {
-    boost::python::list names;
-    const auto keys = self.getObjectNamesEndWith(txt);
     for (auto itr = keys.begin(); itr != keys.end(); ++itr) {
       names.append(*itr);
     }

--- a/Framework/PythonInterface/core/inc/MantidPythonInterface/core/DataServiceExporter.h
+++ b/Framework/PythonInterface/core/inc/MantidPythonInterface/core/DataServiceExporter.h
@@ -6,6 +6,7 @@
 // SPDX - License - Identifier: GPL - 3.0 +
 #pragma once
 
+#include "MantidKernel/DataService.h"
 #include "MantidKernel/Exception.h"
 #include "MantidPythonInterface/core/WeakPtr.h"
 
@@ -71,13 +72,8 @@ template <typename SvcType, typename SvcPtrType> struct DataServiceExporter {
             .def("size", &SvcType::size, arg("self"),
                  "Returns the number of objects within the service")
             .def("getObjectNames", &DataServiceExporter::getObjectNamesAsList,
-                 arg("self"),
+                 (arg("self"), arg("contain") = ""),
                  "Return the list of names currently known to the ADS")
-            .def("getObjectNamesContain",
-                 &DataServiceExporter::getObjectNamesContainAsList,
-                 (arg("self"), arg("txt")),
-                 "Return the list of names known to "
-                 "the ADS that contain a specific string")
 
             // Make it act like a dictionary
             .def("__len__", &SvcType::size, arg("self"))
@@ -166,27 +162,12 @@ template <typename SvcType, typename SvcPtrType> struct DataServiceExporter {
    * @param self :: A reference to the ADS object that called this method
    * @returns A python list created from the set of strings
    */
-  static boost::python::list getObjectNamesAsList(SvcType &self) {
+  static boost::python::list getObjectNamesAsList(SvcType &self,
+                                                  const std::string &contain) {
     boost::python::list names;
-    const auto keys = self.getObjectNames();
-    for (auto itr = keys.begin(); itr != keys.end(); ++itr) {
-      names.append(*itr);
-    }
-    assert(names.attr("__len__")() == keys.size());
-    return names;
-  }
-
-  /**
-   * Return a Python list of object names that contain a specific string from
-   * the ADS.
-   * @param self A reference to the ADS
-   * @param txt The search string
-   * @return A python list of object names
-   */
-  static boost::python::list
-  getObjectNamesContainAsList(SvcType &self, const std::string &txt) {
-    boost::python::list names;
-    const auto keys = self.getObjectNamesContain(txt);
+    const auto keys =
+        self.getObjectNames(Mantid::Kernel::DataServiceSort::Unsorted,
+                            Mantid::Kernel::DataServiceHidden::Auto, contain);
     for (auto itr = keys.begin(); itr != keys.end(); ++itr) {
       names.append(*itr);
     }


### PR DESCRIPTION
**Description of work.**

This PR adds a way to search workspaces by name in the ADS.
A parameter has been added to the `getObjectNames()` method of the ADS to restrict the output to names that contain a specific string.

**To test:**

Create some workspaces:
```python
CreateSampleWorkspace(OutputWorkspace="abc")
CreateSampleWorkspace(OutputWorkspace="def")
CreateSampleWorkspace(OutputWorkspace="abcdef")
...
```
And test the `getObjectNames` function:
```python
print(mtd.getObjectNames())               ->  ['abc', 'def', 'abcdef']
print(mtd.getObjectNames(contain="a"))    ->  ['abc', 'abcdef']
print(mtd.getObjectNames(contain="abcd")) ->  ['abcdef']
print(mtd.getObjectNames(contain="e"))    ->  ['abcdef', 'def']
...
```

Fixes #30564 

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
