### PR TITLE
Absorption correction cache prefix option

### DIFF
--- a/Framework/PythonInterface/mantid/utils/absorptioncorrutils.py
+++ b/Framework/PythonInterface/mantid/utils/absorptioncorrutils.py
@@ -111,7 +111,7 @@ def _getCacheName(wkspname, wksp_prefix, cache_dir, abs_method):
     return cache_path, signature
 
 
-def _getCachedData(absName, abs_method, sha1, cache_file_name, wksp_prefix=""):
+def _getCachedData(absName, abs_method, sha1, cache_file_name):
     """
     Check both memory and disk to locate cache data.  Returns ("", "")
     if no cache can be found.
@@ -284,7 +284,12 @@ def calculate_absorption_correction(
         #      - load from cache nxs file
         #    - if cache is not found, wsn_as and wsn_ac will both be None
         #      - standard calculation will be kicked off as before
-        wsn_as, wsn_ac = _getCachedData(absName, abs_method, sha1, cache_filename, cache_prefix)
+        # Update absName with the cache prefix to find workspaces in memory
+        if prefix == "SHA":
+            absName = cache_prefix + "_" + sha1 + "_abs_correction"
+        else:
+            absName = cache_prefix + "_abs_correction"
+        wsn_as, wsn_ac = _getCachedData(absName, abs_method, sha1, cache_filename)
 
         # NOTE:
         # -- one algorithm with three very different behavior, why not split them to

--- a/Framework/PythonInterface/plugins/algorithms/SNSPowderReduction.py
+++ b/Framework/PythonInterface/plugins/algorithms/SNSPowderReduction.py
@@ -418,6 +418,7 @@ class SNSPowderReduction(DistributedDataProcessorAlgorithm):
             self._elementSize,  # Size of one side of the integration element cube in mm
             metaws,  # Optional workspace containing metadata
             self.getProperty("CacheDir").value,  # Cache dir for absoption correction workspace
+            "SHA", # Use cache files named with sha rather than a filename prefix
         )
 
         if self.getProperty("Sum").value and len(samRuns) > 1:

--- a/Framework/PythonInterface/test/python/mantid/utils/absorptioncorrutilsTest.py
+++ b/Framework/PythonInterface/test/python/mantid/utils/absorptioncorrutilsTest.py
@@ -7,7 +7,7 @@
 import unittest
 import tempfile
 from mantid.kernel import PropertyManagerDataService
-from mantid.simpleapi import Load, PDLoadCharacterizations, PDDetermineCharacterizations, DeleteWorkspaces
+from mantid.simpleapi import Load, PDLoadCharacterizations, PDDetermineCharacterizations, DeleteWorkspaces, mtd
 from mantid.utils import absorptioncorrutils
 
 
@@ -52,6 +52,58 @@ class AbsorptionCorrUtilsTest(unittest.TestCase):
 
         self.assertIsNone(sample_ws)
         self.assertIsNone(container_ws)
+
+    def test_instr_name_helper(self):
+        fname = "PG3_46577.nxs.h5"
+
+        # Test if name retrieved from filename
+        instr_name = absorptioncorrutils._getInstrName(fname)
+        self.assertEqual("PG3", instr_name)
+
+        # Use dummy file name but make sure it is retrieved from workspace
+        data = Load(Filename=fname, MetaDataOnly=True, AllowList="SampleFormula")
+        instr_name = absorptioncorrutils._getInstrName("fakeinstrument", data)
+        self.assertEqual("PG3", instr_name)
+
+    def test_cache_filename_prefix(self):
+        fname = "PG3_46577.nxs.h5"
+        charfile = "PG3_char_2020_01_04_PAC_limit_1.4MW.txt"
+        charTable = PDLoadCharacterizations(Filename=charfile)
+        char = charTable[0]
+
+        data = Load(Filename=fname, MetaDataOnly=True)
+        PDDetermineCharacterizations(InputWorkspace=data,
+                                     Characterizations=char,
+                                     ReductionProperties="props")
+        props = PropertyManagerDataService.retrieve("props")
+
+        cachedir = tempfile.gettempdir()
+        abs_s, abs_c = absorptioncorrutils.calculate_absorption_correction(fname,
+                                                                           "SampleOnly",
+                                                                           props,
+                                                                           "Si",
+                                                                           1.165,
+                                                                           element_size=2,
+                                                                           cache_dir=cachedir,
+                                                                           prefix="FILENAME")
+        self.assertIsNotNone(abs_s)
+
+        # Compare against expected name using FILENAME prefix
+        cached_wsname = absorptioncorrutils._getBasename(fname) + "_abs_correction_ass"
+        self.assertEqual(mtd.doesExist(cached_wsname), True)
+
+        # Remove the workspace from ADS and verify it can be found from disk
+        DeleteWorkspaces(cached_wsname)
+
+        abs_s, abs_c = absorptioncorrutils.calculate_absorption_correction(fname,
+                                                                           "SampleOnly",
+                                                                           props,
+                                                                           "Si",
+                                                                           1.165,
+                                                                           element_size=2,
+                                                                           cache_dir=cachedir,
+                                                                           prefix="FILENAME")
+        self.assertIsNotNone(abs_s)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
**Description of work.**

Adds a `prefix` parameter to the `mantid.utils.absorptioncorrutils.calculate_absorption_correction` function to specify whether the cache file and workspaces should have the filename as prefix, or SHA of the algorithm properties instead.

`SNSPowderReduction` is changed to use the SHA option for caching.

**To test:**

Run the unit tests for the utils module with `ctest -R python.utils.absorptioncorrutilsTest` and verify the SNSPowderRedux system test.

*This does not require release notes* because it is an internal change to how caching files are named.

Version into `ornl-next` #30602 

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
