### PR TITLE
Track function usage statistics

### DIFF
--- a/Framework/API/inc/MantidAPI/CompositeFunction.h
+++ b/Framework/API/inc/MantidAPI/CompositeFunction.h
@@ -86,6 +86,8 @@ public:
   // Set an attribute value
   void setAttribute(const std::string &name,
                     const API::IFunction::Attribute &value) override;
+  // Register the functions usage
+  void registerFunctionUsage() override;
   /// Total number of parameters
   [[nodiscard]] size_t nParams() const override;
   // Total number of attributes, which includes global and local function

--- a/Framework/API/inc/MantidAPI/CompositeFunction.h
+++ b/Framework/API/inc/MantidAPI/CompositeFunction.h
@@ -87,7 +87,7 @@ public:
   void setAttribute(const std::string &name,
                     const API::IFunction::Attribute &value) override;
   // Register the functions usage
-  void registerFunctionUsage() override;
+  void registerFunctionUsage(bool internal) override;
   /// Total number of parameters
   [[nodiscard]] size_t nParams() const override;
   // Total number of attributes, which includes global and local function

--- a/Framework/API/inc/MantidAPI/IFunction.h
+++ b/Framework/API/inc/MantidAPI/IFunction.h
@@ -319,22 +319,24 @@ public:
   };
 
   //---------------------------------------------------------//
-
   /// Constructor
-  IFunction() : m_isParallel(false), m_handler(nullptr), m_chiSquared(0.0) {}
+  IFunction();
   /// Virtual destructor
   virtual ~IFunction();
   /// No copying
   IFunction(const IFunction &) = delete;
   /// No copying
   IFunction &operator=(const IFunction &) = delete;
-
   /// Returns the function's name
   virtual std::string name() const = 0;
   /// Writes itself into a string
   std::string asString() const;
   /// Virtual copy constructor
   virtual std::shared_ptr<IFunction> clone() const;
+
+  /** Registers the usage of the algorithm with the UsageService
+   */
+  virtual void registerFunctionUsage();
   /// Set the workspace.
   /// @param ws :: Shared pointer to a workspace
   virtual void setWorkspace(std::shared_ptr<const Workspace> ws) {
@@ -660,6 +662,8 @@ private:
   std::vector<std::unique_ptr<IConstraint>> m_constraints;
   /// Ties ordered in order of correct application
   std::vector<ParameterTie *> m_orderedTies;
+  /// whether the function usage has been registered
+  bool m_isRegistered{false};
 };
 
 /// shared pointer to the function base class

--- a/Framework/API/inc/MantidAPI/IFunction.h
+++ b/Framework/API/inc/MantidAPI/IFunction.h
@@ -336,7 +336,7 @@ public:
 
   /** Registers the usage of the algorithm with the UsageService
    */
-  virtual void registerFunctionUsage();
+  virtual void registerFunctionUsage(bool internal);
   /// Set the workspace.
   /// @param ws :: Shared pointer to a workspace
   virtual void setWorkspace(std::shared_ptr<const Workspace> ws) {

--- a/Framework/API/src/CompositeFunction.cpp
+++ b/Framework/API/src/CompositeFunction.cpp
@@ -872,6 +872,15 @@ void CompositeFunction::declareAttribute(
 }
 
 /**
+Registers the usage of the function with the UsageService
+ */
+void CompositeFunction::registerFunctionUsage() {
+  for (size_t i = 0; i < nFunctions(); i++) {
+    getFunction(i)->registerFunctionUsage();
+  }
+}
+
+/**
  * Prepare the function for a fit.
  */
 void CompositeFunction::setUpForFit() {

--- a/Framework/API/src/CompositeFunction.cpp
+++ b/Framework/API/src/CompositeFunction.cpp
@@ -874,9 +874,9 @@ void CompositeFunction::declareAttribute(
 /**
 Registers the usage of the function with the UsageService
  */
-void CompositeFunction::registerFunctionUsage() {
+void CompositeFunction::registerFunctionUsage(bool internal) {
   for (size_t i = 0; i < nFunctions(); i++) {
-    getFunction(i)->registerFunctionUsage();
+    getFunction(i)->registerFunctionUsage(internal);
   }
 }
 

--- a/Framework/API/src/IFunction.cpp
+++ b/Framework/API/src/IFunction.cpp
@@ -78,7 +78,7 @@ IFunction::~IFunction() { m_attrs.clear(); }
 /**
 Registers the usage of the function with the UsageService
  */
-void IFunction::registerFunctionUsage() {
+void IFunction::registerFunctionUsage(bool internal) {
   if (!Kernel::UsageService::Instance().isEnabled()) {
     return;
   }
@@ -87,7 +87,7 @@ void IFunction::registerFunctionUsage() {
       !m_isRegistered) {
     m_isRegistered = true;
     Kernel::UsageService::Instance().registerFeatureUsage(
-        Kernel::FeatureType::Function, name(), true);
+        Kernel::FeatureType::Function, name(), internal);
   }
 }
 /**

--- a/Framework/API/src/IFunction.cpp
+++ b/Framework/API/src/IFunction.cpp
@@ -30,6 +30,7 @@
 #include "MantidKernel/ProgressBase.h"
 #include "MantidKernel/Strings.h"
 #include "MantidKernel/UnitFactory.h"
+#include "MantidKernel/UsageService.h"
 
 #include <boost/lexical_cast.hpp>
 
@@ -61,13 +62,34 @@ struct TieNode {
            other.right.end();
   }
 };
+const std::vector<std::string> EXCLUDEUSAGE = {"CompositeFunction"};
 } // namespace
+/**
+ * Constructor
+ */
+IFunction ::IFunction()
+    : m_isParallel(false), m_handler(nullptr), m_chiSquared(0.0) {}
 
 /**
  * Destructor
  */
 IFunction::~IFunction() { m_attrs.clear(); }
 
+/**
+Registers the usage of the function with the UsageService
+ */
+void IFunction::registerFunctionUsage() {
+  if (!Kernel::UsageService::Instance().isEnabled()) {
+    return;
+  }
+  if (std::find(EXCLUDEUSAGE.cbegin(), EXCLUDEUSAGE.cend(), name()) ==
+          EXCLUDEUSAGE.cend() &&
+      !m_isRegistered) {
+    m_isRegistered = true;
+    Kernel::UsageService::Instance().registerFeatureUsage(
+        Kernel::FeatureType::Function, name(), true);
+  }
+}
 /**
  * Virtual copy constructor
  */

--- a/Framework/CurveFitting/src/Algorithms/Fit.cpp
+++ b/Framework/CurveFitting/src/Algorithms/Fit.cpp
@@ -120,6 +120,7 @@ void Fit::readProperties() {
   if (!contstraints.empty()) {
     m_function->addConstraints(contstraints);
   }
+  m_function->registerFunctionUsage();
 
   // Try to retrieve optional properties
   int intMaxIterations = getProperty("MaxIterations");

--- a/Framework/CurveFitting/src/Algorithms/Fit.cpp
+++ b/Framework/CurveFitting/src/Algorithms/Fit.cpp
@@ -120,7 +120,7 @@ void Fit::readProperties() {
   if (!contstraints.empty()) {
     m_function->addConstraints(contstraints);
   }
-  m_function->registerFunctionUsage();
+  m_function->registerFunctionUsage(isChild());
 
   // Try to retrieve optional properties
   int intMaxIterations = getProperty("MaxIterations");

--- a/Framework/Kernel/inc/MantidKernel/UsageService.h
+++ b/Framework/Kernel/inc/MantidKernel/UsageService.h
@@ -21,10 +21,10 @@
 namespace Mantid {
 namespace Kernel {
 
-/** An enum specifying the 3 possible features types that can be logged in the
+/** An enum specifying the 4 possible features types that can be logged in the
     usage service
 */
-enum class FeatureType { Algorithm, Interface, Feature };
+enum class FeatureType { Algorithm, Interface, Feature, Function };
 
 /** UsageReporter : The Usage reporter is responsible for collating, and sending
   all usage data.

--- a/Framework/Kernel/src/UsageService.cpp
+++ b/Framework/Kernel/src/UsageService.cpp
@@ -69,6 +69,8 @@ std::string FeatureUsage::featureTypeToString() const {
     return "Feature";
   case FeatureType::Interface:
     return "Interface";
+  case FeatureType::Function:
+    return "Function";
   }
   return "Unknown";
 }


### PR DESCRIPTION

**Description of work.**
This PR adds function usage tracking. This tracking is only performed when the function is about to be used in a fit. The alternative was to track the usage every time the function was created, however this resulted in a lot of usages which weren’t "true" usages.


<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

**To test:**
To test this you'll probably need to build the usage reporter server and re-route mantid to your docker instance https://github.com/mantidproject/reports. This may be a bit of a pain, but if you need a hand setting it up please slack me.
<!-- Instructions for testing. -->
- Code review
- With the server created and usage reports on:
    - Run some fits and check that the function usage appears correctly

Fixes #30451  <!-- and fix #xxxx or close #xxxx xor resolves #xxxx -->
<!-- alternative
*There is no associated issue.*
-->


*This does not require release notes* because its an internal change.


<!-- Ensure the base of this PR is correct (e.g. release-next or master)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
