### PR TITLE
Add option to MatrixWorkspaceDisplay to overplot bins

### DIFF
--- a/docs/source/release/v6.1.0/mantidworkbench.rst
+++ b/docs/source/release/v6.1.0/mantidworkbench.rst
@@ -8,6 +8,8 @@ Mantid Workbench Changes
 New and Improved
 ----------------
 
+- It is now possible to overplot bin data from the matrix workspace view.
+
 Bugfixes
 --------
 

--- a/qt/python/mantidqt/widgets/workspacedisplay/matrix/presenter.py
+++ b/qt/python/mantidqt/widgets/workspacedisplay/matrix/presenter.py
@@ -167,7 +167,7 @@ class MatrixWorkspaceDisplay(ObservingPresenter, DataCopier):
     def action_copy_cells(self, table):
         self.copy_cells(table)
 
-    def _do_action_plot(self, table, axis, get_index, plot_errors=False):
+    def _do_action_plot(self, table, axis, get_index, plot_errors=False, overplot=False):
         if self.plot is None:
             raise ValueError("Trying to do a plot, but no plotting class dependency was injected in the constructor")
         selection_model = table.selectionModel()
@@ -189,7 +189,7 @@ class MatrixWorkspaceDisplay(ObservingPresenter, DataCopier):
 
         ws_list = [self.model._ws]
         self.plot(ws_list, wksp_indices=[get_index(index) for index in selected], errors=plot_errors,
-                  plot_kwargs=plot_kwargs)
+                  overplot=overplot, plot_kwargs=plot_kwargs)
 
     def action_plot_spectrum(self, table):
         self._do_action_plot(table, MantidAxType.SPECTRUM, lambda index: index.row())
@@ -197,11 +197,25 @@ class MatrixWorkspaceDisplay(ObservingPresenter, DataCopier):
     def action_plot_spectrum_with_errors(self, table):
         self._do_action_plot(table, MantidAxType.SPECTRUM, lambda index: index.row(), plot_errors=True)
 
+    def action_overplot_spectrum(self, table):
+        self._do_overaction_plot(table, MantidAxType.SPECTRUM, lambda index: index.row(),
+                                 plot_errors=False, overplot=True)
+
+    def action_overplot_spectrum_with_errors(self, table):
+        self._do_action_plot(table, MantidAxType.SPECTRUM, lambda index: index.row(),
+                             plot_errors=True, overplot=True)
+
     def action_plot_bin(self, table):
         self._do_action_plot(table, MantidAxType.BIN, lambda index: index.column())
 
     def action_plot_bin_with_errors(self, table):
         self._do_action_plot(table, MantidAxType.BIN, lambda index: index.column(), plot_errors=True)
+
+    def action_overplot_bin(self, table):
+        self._do_action_plot(table, MantidAxType.BIN, lambda index: index.column(), plot_errors=False, overplot=True)
+
+    def action_overplot_bin_with_errors(self, table):
+        self._do_action_plot(table, MantidAxType.BIN, lambda index: index.column(), plot_errors=True, overplot=True)
 
     def action_keypress_copy(self, table):
         selectionModel = table.selectionModel()

--- a/qt/python/mantidqt/widgets/workspacedisplay/matrix/presenter.py
+++ b/qt/python/mantidqt/widgets/workspacedisplay/matrix/presenter.py
@@ -198,8 +198,8 @@ class MatrixWorkspaceDisplay(ObservingPresenter, DataCopier):
         self._do_action_plot(table, MantidAxType.SPECTRUM, lambda index: index.row(), plot_errors=True)
 
     def action_overplot_spectrum(self, table):
-        self._do_overaction_plot(table, MantidAxType.SPECTRUM, lambda index: index.row(),
-                                 plot_errors=False, overplot=True)
+        self._do_action_plot(table, MantidAxType.SPECTRUM, lambda index: index.row(),
+                             plot_errors=False, overplot=True)
 
     def action_overplot_spectrum_with_errors(self, table):
         self._do_action_plot(table, MantidAxType.SPECTRUM, lambda index: index.row(),

--- a/qt/python/mantidqt/widgets/workspacedisplay/matrix/test/test_matrixworkspacedisplay_view.py
+++ b/qt/python/mantidqt/widgets/workspacedisplay/matrix/test/test_matrixworkspacedisplay_view.py
@@ -6,6 +6,8 @@
 # SPDX - License - Identifier: GPL - 3.0 +
 #  This file is part of the mantid workbench.
 import unittest
+from unittest import mock
+from unittest.mock import patch
 
 from mantid.simpleapi import CreateSampleWorkspace
 from mantidqt.utils.qt.testing import start_qapplication
@@ -46,3 +48,73 @@ class MatrixWorkspaceDisplayViewTest(unittest.TestCase, QtWidgetFinder):
         self.assertEqual(None, p.ads_observer)
         self.assert_widget_not_present("work")
         self.assert_no_toplevel_widgets()
+
+    def test_context_has_expected_function_when_plotting(self):
+        ws = CreateSampleWorkspace()
+        mock_plot = mock.MagicMock()
+        presenter = MatrixWorkspaceDisplay(ws, plot=mock_plot)
+        view = presenter.view
+        table = view.currentWidget()
+        table.selectColumn(1)
+
+        context_menu = view.setup_bin_context_menu(table)
+        actions = context_menu.actions()
+        # check we have 8 actions 2 separators - 2 copy - 2plot - 2 overplot
+        self.assertEqual(len(actions), 8)
+
+        # check triggering action 4 & 5 calls plot
+        actions[3].trigger()
+        presenter.plot.assert_called_with(mock.ANY, wksp_indices=mock.ANY, errors=False,
+                                          overplot=False, plot_kwargs=mock.ANY)
+        actions[4].trigger()
+        presenter.plot.assert_called_with(mock.ANY, wksp_indices=mock.ANY, errors=True,
+                                          overplot=False, plot_kwargs=mock.ANY)
+        presenter.close(ws.name())
+
+    @patch('mantidqt.widgets.workspacedisplay.matrix.view.can_overplot')
+    def test_context_has_expected_function_when_overplotting(self, mock_can_overplot):
+        mock_can_overplot.return_value = True
+        ws = CreateSampleWorkspace()
+        mock_plot = mock.MagicMock()
+        presenter = MatrixWorkspaceDisplay(ws, plot=mock_plot)
+        view = presenter.view
+        table = view.currentWidget()
+        table.selectColumn(1)
+
+        context_menu = view.setup_bin_context_menu(table)
+        actions = context_menu.actions()
+
+        # check triggering action 6 & 7 calls plot
+        actions[6].trigger()
+        presenter.plot.assert_called_with(mock.ANY, wksp_indices=mock.ANY, errors=False,
+                                          overplot=True, plot_kwargs=mock.ANY)
+        actions[7].trigger()
+        presenter.plot.assert_called_with(mock.ANY, wksp_indices=mock.ANY, errors=True,
+                                          overplot=True, plot_kwargs=mock.ANY)
+        presenter.close(ws.name())
+
+    @patch('mantidqt.widgets.workspacedisplay.matrix.view.can_overplot')
+    def test_context_menu_correctly_disables_and_enables_overplot_options(self, mock_can_overplot):
+        mock_can_overplot.return_value = False
+        ws = CreateSampleWorkspace()
+        mock_plot = mock.MagicMock()
+        presenter = MatrixWorkspaceDisplay(ws, plot=mock_plot)
+        view = presenter.view
+        table = view.currentWidget()
+
+        context_menu = view.setup_bin_context_menu(table)
+        actions = context_menu.actions()
+        self.assertEqual(actions[6].isEnabled(), False)
+        self.assertEqual(actions[7].isEnabled(), False)
+
+        mock_can_overplot.return_value = True
+        context_menu = view.setup_bin_context_menu(table)
+        actions = context_menu.actions()
+        self.assertEqual(actions[6].isEnabled(), True)
+        self.assertEqual(actions[7].isEnabled(), True)
+
+        presenter.close(ws.name())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/qt/python/mantidqt/widgets/workspacedisplay/matrix/view.py
+++ b/qt/python/mantidqt/widgets/workspacedisplay/matrix/view.py
@@ -12,10 +12,11 @@ from functools import partial
 from qtpy import QtGui
 from qtpy.QtCore import Qt
 from qtpy.QtGui import QKeySequence
-from qtpy.QtWidgets import (QAbstractItemView, QAction, QHeaderView, QMessageBox, QTabWidget, QTableView)
+from qtpy.QtWidgets import (QAbstractItemView, QAction, QHeaderView, QMessageBox, QTabWidget, QTableView, QMenu)
 
 import mantidqt.icons
 from mantidqt.widgets.workspacedisplay.matrix.table_view_model import MatrixWorkspaceTableViewModelType
+from mantidqt.plotting.functions import can_overplot
 
 
 class MatrixWorkspaceTableView(QTableView):
@@ -113,51 +114,14 @@ class MatrixWorkspaceDisplayView(QTabWidget):
         table.addAction(copy_action)
 
         horizontalHeader = table.horizontalHeader()
-        horizontalHeader.setContextMenuPolicy(Qt.ActionsContextMenu)
+        horizontalHeader.setContextMenuPolicy(Qt.CustomContextMenu)
         horizontalHeader.setSectionResizeMode(QHeaderView.Fixed)
-
-        copy_bin_values = QAction(self.COPY_ICON, "Copy", horizontalHeader)
-        copy_bin_values.triggered.connect(partial(self.presenter.action_copy_bin_values, table))
-        copy_bin_to_table = QAction(self.TABLE_ICON, "Copy bin to table", horizontalHeader)
-        copy_bin_to_table.triggered.connect(partial(self.presenter.action_copy_bin_to_table, table))
-
-        plot_bin_action = QAction(self.GRAPH_ICON, "Plot bin (values only)", horizontalHeader)
-        plot_bin_action.triggered.connect(partial(self.presenter.action_plot_bin, table))
-        plot_bin_with_errors_action = QAction(self.GRAPH_ICON, "Plot bin (values + errors)", horizontalHeader)
-        plot_bin_with_errors_action.triggered.connect(partial(self.presenter.action_plot_bin_with_errors, table))
-        separator1 = QAction(horizontalHeader)
-        separator1.setSeparator(True)
-
-        horizontalHeader.addAction(copy_bin_values)
-        horizontalHeader.addAction(copy_bin_to_table)
-        horizontalHeader.addAction(separator1)
-        horizontalHeader.addAction(plot_bin_action)
-        horizontalHeader.addAction(plot_bin_with_errors_action)
+        horizontalHeader.customContextMenuRequested.connect(self.bin_context_menu_opened)
 
         verticalHeader = table.verticalHeader()
-        verticalHeader.setContextMenuPolicy(Qt.ActionsContextMenu)
+        verticalHeader.setContextMenuPolicy(Qt.CustomContextMenu)
         verticalHeader.setSectionResizeMode(QHeaderView.Fixed)
-
-        copy_spectrum_values = QAction(self.COPY_ICON, "Copy", verticalHeader)
-        copy_spectrum_values.triggered.connect(
-            partial(self.presenter.action_copy_spectrum_values, table))
-        copy_spectrum_to_table = QAction(self.TABLE_ICON, "Copy spectrum to table", horizontalHeader)
-        copy_spectrum_to_table.triggered.connect(partial(self.presenter.action_copy_spectrum_to_table, table))
-
-        plot_spectrum_action = QAction(self.GRAPH_ICON, "Plot spectrum (values only)", verticalHeader)
-        plot_spectrum_action.triggered.connect(partial(self.presenter.action_plot_spectrum, table))
-        plot_spectrum_with_errors_action = QAction(self.GRAPH_ICON, "Plot spectrum (values + errors)",
-                                                   verticalHeader)
-        plot_spectrum_with_errors_action.triggered.connect(
-            partial(self.presenter.action_plot_spectrum_with_errors, table))
-        separator1 = QAction(verticalHeader)
-        separator1.setSeparator(True)
-
-        verticalHeader.addAction(copy_spectrum_values)
-        verticalHeader.addAction(copy_spectrum_to_table)
-        verticalHeader.addAction(separator1)
-        verticalHeader.addAction(plot_spectrum_action)
-        verticalHeader.addAction(plot_spectrum_with_errors_action)
+        verticalHeader.customContextMenuRequested.connect(self.spectra_context_menu_opened)
 
     def set_model(self, model_x, model_y, model_e, model_dx):
         self._set_table_model(self.table_x, model_x, MatrixWorkspaceTableViewModelType.x)
@@ -180,3 +144,88 @@ class MatrixWorkspaceDisplayView(QTabWidget):
         """
         reply = QMessageBox.question(self, title, message, QMessageBox.Yes, QMessageBox.No)
         return True if reply == QMessageBox.Yes else False
+
+    def setup_bin_context_menu(self, table):
+        context_menu = QMenu()
+        self.setup_copy_bin_actions(context_menu, table)
+        self.setup_plot_bin_actions(context_menu, table)
+        return context_menu
+
+    def setup_spectra_context_menu(self, table):
+        context_menu = QMenu()
+        self.setup_copy_spectrum_actions(context_menu, table)
+        self.setup_plot_spectrum_actions(context_menu, table)
+        return context_menu
+
+    def bin_context_menu_opened(self, position):
+        """
+        Open the context menu in the correct location
+        :param position: The position to open the menu, e.g. where
+                         the mouse button was clicked
+        """
+        context_menu = self.setup_bin_context_menu(self.currentWidget())
+        context_menu.exec_(self.currentWidget().horizontalHeader().mapToGlobal(position))
+
+    def spectra_context_menu_opened(self, position):
+        """
+        Open the context menu in the correct location
+        :param position: The position to open the menu, e.g. where
+                         the mouse button was clicked
+        """
+        context_menu = self.setup_spectra_context_menu(self.currentWidget())
+        context_menu.exec_(self.currentWidget().verticalHeader().mapToGlobal(position))
+
+    def setup_plot_bin_actions(self, context_menu, table):
+        plot_bin_action = QAction(self.GRAPH_ICON, "Plot bin (values only)", self)
+        plot_bin_action.triggered.connect(partial(self.presenter.action_plot_bin, table))
+        plot_bin_with_errors_action = QAction(self.GRAPH_ICON, "Plot bin (values + errors)", self)
+        plot_bin_with_errors_action.triggered.connect(partial(self.presenter.action_plot_bin_with_errors, table))
+        overplot_bin_action = QAction(self.GRAPH_ICON, "Overplot bin (values only)", self)
+        overplot_bin_action.triggered.connect(partial(self.presenter.action_overplot_bin, table))
+        overplot_bin_with_errors_action = QAction(self.GRAPH_ICON, "Overplot bin (values + errors)", self)
+        overplot_bin_with_errors_action.triggered.connect(partial(self.presenter.action_overplot_bin_with_errors,
+                                                                  table))
+        overplot_bin_action.setEnabled(can_overplot())
+        overplot_bin_with_errors_action.setEnabled(can_overplot())
+        separator = QAction(self)
+        separator.setSeparator(True)
+        list(map(context_menu.addAction, [plot_bin_action, plot_bin_with_errors_action, separator,
+                                          overplot_bin_action, overplot_bin_with_errors_action]))
+
+    def setup_plot_spectrum_actions(self, context_menu, table):
+        plot_spectrum_action = QAction(self.GRAPH_ICON, "Plot spectrum (values only)", self)
+        plot_spectrum_action.triggered.connect(partial(self.presenter.action_plot_spectrum, table))
+        plot_spectrum_with_errors_action = QAction(self.GRAPH_ICON, "Plot spectrum (values + errors)",
+                                                   self)
+        plot_spectrum_with_errors_action.triggered.connect(
+            partial(self.presenter.action_plot_spectrum_with_errors, table))
+        overplot_spectrum_action = QAction(self.GRAPH_ICON, "Overplot spectrum (values only)", self)
+        overplot_spectrum_action.triggered.connect(partial(self.presenter.action_overplot_spectrum, table))
+        overplot_spectrum_with_errors_action = QAction(self.GRAPH_ICON, "Overplot spectrum (values + errors)", self)
+        overplot_spectrum_with_errors_action.triggered.connect(partial(
+            self.presenter.action_overplot_spectrum_with_errors, table))
+        overplot_spectrum_action.setEnabled(can_overplot())
+        overplot_spectrum_with_errors_action.setEnabled(can_overplot())
+        separator = QAction(self)
+        separator.setSeparator(True)
+        list(map(context_menu.addAction, [plot_spectrum_action, plot_spectrum_with_errors_action, separator,
+                                          overplot_spectrum_action, overplot_spectrum_with_errors_action]))
+
+    def setup_copy_bin_actions(self, context_menu, table):
+        copy_bin_values = QAction(self.COPY_ICON, "Copy", self)
+        copy_bin_values.triggered.connect(partial(self.presenter.action_copy_bin_values, table))
+        copy_bin_to_table = QAction(self.TABLE_ICON, "Copy bin to table", self)
+        copy_bin_to_table.triggered.connect(partial(self.presenter.action_copy_bin_to_table, table))
+        separator = QAction(self)
+        separator.setSeparator(True)
+        list(map(context_menu.addAction, [copy_bin_values, copy_bin_to_table, separator]))
+
+    def setup_copy_spectrum_actions(self, context_menu, table):
+        copy_spectrum_values = QAction(self.COPY_ICON, "Copy", self)
+        copy_spectrum_values.triggered.connect(
+            partial(self.presenter.action_copy_spectrum_values, table))
+        copy_spectrum_to_table = QAction(self.TABLE_ICON, "Copy spectrum to table", self)
+        copy_spectrum_to_table.triggered.connect(partial(self.presenter.action_copy_spectrum_to_table, table))
+        separator = QAction(self)
+        separator.setSeparator(True)
+        list(map(context_menu.addAction, [copy_spectrum_values, copy_spectrum_to_table, separator]))


### PR DESCRIPTION
**Description of work.**
This PR adds the option to overplot bin data in the matrix workspace display.
<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

**To test:**

1. Load some data
2. Right click and show data
3. Select one of the columns and right click -> plot bin 
4. If you now select another column and right click you should be able to overplot this new bin.
5. Test this functionality and make sure it doesn't produce any unexpected behaviour.


<!-- Instructions for testing. -->

Fixes #30371 . <!-- and fix #xxxx or close #xxxx xor resolves #xxxx -->


<!-- Ensure the base of this PR is correct (e.g. release-next or master)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
