### PR TITLE
Add Workspace History To Exported Results From ALC

### DIFF
--- a/docs/source/release/v6.1.0/muon.rst
+++ b/docs/source/release/v6.1.0/muon.rst
@@ -30,6 +30,7 @@ New Features
 
 Improvements
 ############
+- Exported workspaces now have history.
 
 Bug fixes
 ##########

--- a/qt/scientific_interfaces/Muon/ALCBaselineModellingModel.cpp
+++ b/qt/scientific_interfaces/Muon/ALCBaselineModellingModel.cpp
@@ -23,7 +23,7 @@ namespace {
 MatrixWorkspace_sptr extractSpectrum(const MatrixWorkspace_sptr &inputWorkspace,
                                      const int workspaceIndex) {
   auto extracter = AlgorithmManager::Instance().create("ExtractSingleSpectrum");
-  extracter->setChild(true);
+  extracter->setAlwaysStoreInADS(false);
   extracter->setProperty("InputWorkspace", inputWorkspace);
   extracter->setProperty("WorkspaceIndex", workspaceIndex);
   extracter->setPropertyValue("OutputWorkspace", "__NotUsed__");
@@ -36,7 +36,7 @@ MatrixWorkspace_sptr
 evaluateFunction(const IFunction_const_sptr &function,
                  const MatrixWorkspace_sptr &inputWorkspace) {
   auto fit = AlgorithmManager::Instance().create("Fit");
-  fit->setChild(true);
+  fit->setAlwaysStoreInADS(false);
   fit->setProperty("Function", function->asString());
   fit->setProperty("InputWorkspace", inputWorkspace);
   fit->setProperty("MaxIterations", 0);
@@ -55,7 +55,7 @@ void ALCBaselineModellingModel::fit(IFunction_const_sptr function,
                                     const std::vector<Section> &sections) {
   // Create a copy of the data
   IAlgorithm_sptr clone = AlgorithmManager::Instance().create("CloneWorkspace");
-  clone->setChild(true);
+  clone->setAlwaysStoreInADS(false);
   clone->setProperty("InputWorkspace",
                      std::const_pointer_cast<MatrixWorkspace>(m_data));
   clone->setProperty("OutputWorkspace", "__NotUsed__");
@@ -72,7 +72,7 @@ void ALCBaselineModellingModel::fit(IFunction_const_sptr function,
       FunctionFactory::Instance().createInitialized(function->asString());
 
   IAlgorithm_sptr fit = AlgorithmManager::Instance().create("Fit");
-  fit->setChild(true);
+  fit->setAlwaysStoreInADS(false);
   fit->setProperty("Function", funcToFit);
   fit->setProperty("InputWorkspace", dataToFit);
   fit->setProperty("CreateOutput", true);

--- a/qt/scientific_interfaces/Muon/ALCDataLoadingPresenter.cpp
+++ b/qt/scientific_interfaces/Muon/ALCDataLoadingPresenter.cpp
@@ -196,7 +196,7 @@ void ALCDataLoadingPresenter::load(const std::vector<std::string> &files) {
   try {
     IAlgorithm_sptr alg =
         AlgorithmManager::Instance().create("PlotAsymmetryByLogValue");
-    alg->setChild(true); // Don't want workspaces in the ADS
+    alg->setAlwaysStoreInADS(false); // Don't want workspaces in the ADS
 
     // Change first last run to WorkspaceNames
     alg->setProperty("WorkspaceNames", files);
@@ -251,7 +251,7 @@ void ALCDataLoadingPresenter::load(const std::vector<std::string> &files) {
 
     MatrixWorkspace_sptr tmp = alg->getProperty("OutputWorkspace");
     IAlgorithm_sptr sortAlg = AlgorithmManager::Instance().create("SortXAxis");
-    sortAlg->setChild(true); // Don't want workspaces in the ADS
+    sortAlg->setAlwaysStoreInADS(false); // Don't want workspaces in the ADS
     sortAlg->setProperty("InputWorkspace", tmp);
     sortAlg->setProperty("Ordering", "Ascending");
     sortAlg->setProperty("OutputWorkspace", "__NotUsed__");

--- a/qt/scientific_interfaces/Muon/ALCPeakFittingModel.cpp
+++ b/qt/scientific_interfaces/Muon/ALCPeakFittingModel.cpp
@@ -25,7 +25,7 @@ namespace {
 MatrixWorkspace_sptr extractSpectrum(const MatrixWorkspace_sptr &inputWorkspace,
                                      const int workspaceIndex) {
   auto extracter = AlgorithmManager::Instance().create("ExtractSingleSpectrum");
-  extracter->setChild(true);
+  extracter->setAlwaysStoreInADS(false);
   extracter->setProperty("InputWorkspace", inputWorkspace);
   extracter->setProperty("WorkspaceIndex", workspaceIndex);
   extracter->setPropertyValue("OutputWorkspace", "__NotUsed__");
@@ -38,7 +38,7 @@ MatrixWorkspace_sptr
 evaluateFunction(const IFunction_const_sptr &function,
                  const MatrixWorkspace_sptr &inputWorkspace) {
   auto fit = AlgorithmManager::Instance().create("Fit");
-  fit->setChild(true);
+  fit->setAlwaysStoreInADS(false);
   fit->setProperty("Function", function->asString());
   fit->setProperty("InputWorkspace", inputWorkspace);
   fit->setProperty("MaxIterations", 0);
@@ -87,7 +87,7 @@ void ALCPeakFittingModel::setFittedPeaks(IFunction_const_sptr fittedPeaks) {
 
 void ALCPeakFittingModel::fitPeaks(IFunction_const_sptr peaks) {
   IAlgorithm_sptr fit = AlgorithmManager::Instance().create("Fit");
-  fit->setChild(true);
+  fit->setAlwaysStoreInADS(false);
   fit->setProperty("Function", peaks->asString());
   fit->setProperty("InputWorkspace",
                    std::const_pointer_cast<MatrixWorkspace>(m_data));


### PR DESCRIPTION
**Description of work.**
Instead of executing child algorithms, just choose not to store in ADS.

**To test:**

1. Open Muon ALC interface
2. Instrument is HIFI. Runs 83929-49 and press enter. Wait for them to be found
3. Select log sample_mgn_field
4. Click Load
5. Go to Baseline Modelling
6. Select Linear Background
7. Add two sections and put them on either side of the data. Do a Fit
8. Go to Peak Fitting
9. Add a Linear background and lorentzian. Change the centre and amplitude of the lorentzian to appropriate values.
10. Click Fit. Export results.
11. Now show history on the resulting workspaces and check it is as expected.

Fixes #30529 

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
