### PR TITLE
Updated LoadElementalAnalysisData to crop workspaces

### DIFF
--- a/Framework/PythonInterface/plugins/algorithms/LoadElementalAnalysisData.py
+++ b/Framework/PythonInterface/plugins/algorithms/LoadElementalAnalysisData.py
@@ -12,7 +12,8 @@ from mantid import config
 from mantid.api import AlgorithmFactory, AnalysisDataService, PythonAlgorithm, TextAxis, WorkspaceGroup, \
     WorkspaceGroupProperty
 from mantid.kernel import Direction, IntBoundedValidator
-from mantid.simpleapi import ConvertToHistogram, ConvertToPointData, DeleteWorkspace, LoadAscii, WorkspaceFactory
+from mantid.simpleapi import ConvertToHistogram, ConvertToPointData, DeleteWorkspace, LoadAscii, WorkspaceFactory, \
+    CropWorkspaceRagged
 
 
 TYPE_KEYS = {"10": "Prompt", "20": "Delayed", "99": "Total"}
@@ -60,7 +61,7 @@ class LoadElementalAnalysisData(PythonAlgorithm):
         workspaces = unique_workspaces
 
         self.format_workspace(workspaces)
-        self.merge_workspaces(workspaces.values())
+        self.merge_and_crop_workspaces(workspaces.values())
 
     def pad_run(self):
         """ Pads run number: i.e. 123 -> 00123; 2695 -> 02695 """
@@ -94,7 +95,7 @@ class LoadElementalAnalysisData(PythonAlgorithm):
             workspace = LoadAscii(path, OutputWorkspace=output)
             workspace.getAxis(0).setUnit("Label").setLabel("Energy", "keV")
 
-    def merge_workspaces(self, workspaces):
+    def merge_and_crop_workspaces(self, workspaces):
         """ where workspaces is a tuple of form:
                 (filepath, ws name)
         """
@@ -120,6 +121,13 @@ class LoadElementalAnalysisData(PythonAlgorithm):
                 # create merged workspace
                 merged_ws = self.create_merged_workspace(workspace_list)
                 ConvertToHistogram(InputWorkspace=merged_ws, OutputWorkspace=detector)
+                minX, maxX = [], []
+                ws = AnalysisDataService.retrieve(detector)
+                for i in range(ws.getNumberHistograms()):
+                    xdata = ws.readX(i)
+                    minX.append(xdata[0])
+                    maxX.append(xdata[-1] - 1)
+                CropWorkspaceRagged(InputWorkspace=detector, OutputWorkspace=detector, xmin = minX, xmax = maxX)
                 overall_ws.addWorkspace(AnalysisDataService.retrieve(detector))
         self.setProperty("GroupWorkspace", overall_ws)
 

--- a/Framework/PythonInterface/plugins/algorithms/LoadElementalAnalysisData.py
+++ b/Framework/PythonInterface/plugins/algorithms/LoadElementalAnalysisData.py
@@ -126,7 +126,10 @@ class LoadElementalAnalysisData(PythonAlgorithm):
                 for i in range(ws.getNumberHistograms()):
                     xdata = ws.readX(i)
                     minX.append(xdata[0])
-                    maxX.append(xdata[-1] - 1)
+                    if i == 2:
+                        maxX.append(xdata[-1])
+                    else:
+                        maxX.append(xdata[-1] - 1)
                 CropWorkspaceRagged(InputWorkspace=detector, OutputWorkspace=detector, xmin = minX, xmax = maxX)
                 overall_ws.addWorkspace(AnalysisDataService.retrieve(detector))
         self.setProperty("GroupWorkspace", overall_ws)

--- a/Testing/SystemTests/tests/framework/LoadElementalAnalysisTest.py
+++ b/Testing/SystemTests/tests/framework/LoadElementalAnalysisTest.py
@@ -36,21 +36,18 @@ class LoadElementalAnalysisTest(systemtesting.MantidSystemTest):
         detectorSpectrumAxis = detector1_ws.getAxis(1)
         self.assertEqual(detectorSpectrumAxis.length(), 3)
         # Check that Bin 3318 of the Prompt spectra of the workspace of Detector 1 is 0.206791
-        self.assertAlmostEqual(detector1_ws.extractY()[1, 3318], 0.206791, places=4, delta=0.0001)
+        self.assertAlmostEqual(detector1_ws.readY(1)[3318], 0.206791, places=4, delta=0.0001)
         # Check that Bin 230 of the Total spectra of the workspace of Detector 2 is 243.729
         detector2_ws = AnalysisDataService.retrieve('9999; Detector 2')
-        self.assertAlmostEqual(detector2_ws.extractY()[2, 230], 243.729, places=4, delta=0.0001)
+        self.assertAlmostEqual(detector2_ws.readY(2)[230], 243.729, places=4, delta=0.0001)
         # Check that Bin 6029 of the Delayed spectra of the workspace of Detector 3 is 62.0691
         detector3_ws = AnalysisDataService.retrieve('9999; Detector 3')
-        self.assertAlmostEqual(detector3_ws.extractY()[0, 6029], 62.0691, places=4, delta=0.0001)
+        self.assertAlmostEqual(detector3_ws.readY(0)[2915], 99.0456, places=4, delta=0.0001)
         # Check that the Bin 4083 of the Total spectra of the workspace of Detecror 4 is 120.457
         detector4_ws = AnalysisDataService.retrieve('9999; Detector 4')
-        self.assertAlmostEqual(detector4_ws.extractY()[2, 4083], 120.457, places=4, delta=0.0001)
+        self.assertAlmostEqual(detector4_ws.readY(2)[4083], 120.457, places=4, delta=0.0001)
         # Check that the directory output is not empty
         self.assertIsNotNone(ws[1])
-
-    def validate(self):
-        return ['9999', 'ElementalAnalysisLoad.nxs']
 
 
 class LoadPartialElementalAnalysisTest(systemtesting.MantidSystemTest):
@@ -76,19 +73,16 @@ class LoadPartialElementalAnalysisTest(systemtesting.MantidSystemTest):
         self.assertEqual(detectorSpectrumAxis.length(), 3)
         # Check that the Prompt and Delay Spectra in Dectector 1 workspace do not contain any values
         # and therefore max and min should be 0
-        detector1_prompt = detector1_ws.extractY()[0, :]
-        detector1_delay = detector1_ws.extractY()[1, :]
+        detector1_prompt = detector1_ws.readY(0)
+        detector1_delay = detector1_ws.readY(1)
         self.assertEqual(np.amax(detector1_prompt), 0.0)
         self.assertEqual(np.amax(detector1_delay), 0.0)
         self.assertEqual(np.amin(detector1_prompt), 0.0)
         self.assertEqual(np.amin(detector1_delay), 0.0)
         # Check that Bin 5237 of the Total spectra of the workspace of Detector 1 is 4.0
-        self.assertAlmostEqual(detector1_ws.extractY()[2, 5237], 4.0, places=4, delta=0.0001)
+        self.assertAlmostEqual(detector1_ws.readY(2)[5237], 4.0, places=4, delta=0.0001)
         # Check that Bin 4697 of the Total spectra of the workspace of Detector 3 is 10.0
         detector3_ws = AnalysisDataService.retrieve('2683; Detector 3')
-        self.assertAlmostEqual(detector3_ws.extractY()[2, 4697], 10.0, places=4, delta=0.0001)
+        self.assertAlmostEqual(detector3_ws.readY(2)[4697], 10.0, places=4, delta=0.0001)
         # Check that the directory output is not empty
         self.assertIsNotNone(ws[1])
-
-    def validate(self):
-        return ['2683', 'PartialElementalAnalysisLoad.nxs']

--- a/docs/source/release/v6.1.0/muon.rst
+++ b/docs/source/release/v6.1.0/muon.rst
@@ -9,9 +9,6 @@ MuSR Changes
     putting new features at the top of the section, followed by
     improvements, followed by bug fixes.
 	
-Algorithms
-----------
-- Updated :ref:`LoadElementalAnalysisData <algm-LoadElementalAnalysisData>` algorithm to crop workspace.
 
 Muon Analysis 2 and Frequency Domain Analysis
 ---------------------------------------------
@@ -47,6 +44,7 @@ New Features
 
 Bug fixes
 #########
+- Updated :ref:`LoadElementalAnalysisData <algm-LoadElementalAnalysisData>` algorithm to crop workspace.
 
 Algorithms
 ----------

--- a/docs/source/release/v6.1.0/muon.rst
+++ b/docs/source/release/v6.1.0/muon.rst
@@ -8,6 +8,10 @@ MuSR Changes
 .. warning:: **Developers:** Sort changes under appropriate heading
     putting new features at the top of the section, followed by
     improvements, followed by bug fixes.
+	
+Algorithms
+----------
+- Updated :ref:`LoadElementalAnalysisData <algm-LoadElementalAnalysisData>` algorithm to crop workspace.
 
 Muon Analysis 2 and Frequency Domain Analysis
 ---------------------------------------------


### PR DESCRIPTION
**Description of work.**

Updated LoadELementalAnalysisData algorithm to use CropWorkspacesRagged algorithm to crop workspace so as to remove bins with zero bin widths

**To test:**
1. Put Sundials into your Data search directories in MUD (Contact myself or @AnthonyLim23)
2. Execute the LoadElementalAnalysisData and run Algorithm with 2695.
3. Show data in any workspace in group and confirm that the first 2 spectrums  has half the number of of bin (4000) as the last spectrum (8000).


Fixes #30618 .

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
