### PR TITLE
Fix ellipsoid background shape plotting

### DIFF
--- a/docs/source/release/v6.1.0/mantidworkbench.rst
+++ b/docs/source/release/v6.1.0/mantidworkbench.rst
@@ -12,5 +12,7 @@ Bugfixes
 --------
 
 - Display Debug and Information messages generated during workbench start up
+- The background shell of spherical and elliptical peaks is now correctly plotted when viewing slices that do not cut through the peak center
+- For the elliptical shell of integrated peaks, the background is correct when plotting with varying background thicknesses
 
 :ref:`Release 6.1.0 <v6.1.0>`

--- a/qt/python/mantidqt/widgets/sliceviewer/peaksviewer/representation/ellipsoid.py
+++ b/qt/python/mantidqt/widgets/sliceviewer/peaksviewer/representation/ellipsoid.py
@@ -36,7 +36,7 @@ class EllipsoidalIntergratedPeakRepresentation():
         axes, signal_radii = _signal_ellipsoid_info(shape_info)
         peak_origin = slice_info.transform(peak_origin)
 
-        slice_origin, major_radius, minor_radius, angle = slice_ellipsoid(
+        slice_origin, major_radius, minor_radius, angle, isort = slice_ellipsoid(
             peak_origin, *axes, *signal_radii, slice_info.z_value, slice_info.transform)
         if not np.any(np.isfinite((major_radius, minor_radius))):
             # slice not possible
@@ -69,12 +69,17 @@ class EllipsoidalIntergratedPeakRepresentation():
         ]
 
         # add background shell
-        a, b, c, shell_thick = _bkgd_ellipsoid_info(shape_info)
+        a, b, c, inner_a, inner_b, inner_c = _bkgd_ellipsoid_info(shape_info)
         # only add background shell if it is greater than 0
-        if shell_thick > 0:
-            _, major_radius, minor_radius, angle = slice_ellipsoid(peak_origin, *axes, a, b, c,
-                                                                   slice_info.z_value, slice_info.transform)
+        if min([a, b, c]) > 1e-15 and (a > inner_a or b > inner_b or c > inner_c):
+            _, major_radius, minor_radius, _, _ = slice_ellipsoid(peak_origin, *axes, a, b, c,
+                                                                  slice_info.z_value, slice_info.transform, isort)
             bkgd_width, bkgd_height = 2 * major_radius, 2 * minor_radius
+            _, inner_major_radius, inner_minor_radius, _, _ = slice_ellipsoid(peak_origin, *axes, inner_a, inner_b, inner_c,
+                                                                              slice_info.z_value, slice_info.transform, isort)
+
+            shell_thick = ((major_radius-inner_major_radius)/major_radius,
+                           (minor_radius-inner_minor_radius)/minor_radius)
 
             artists.append(
                 painter.elliptical_shell(
@@ -118,18 +123,13 @@ def _bkgd_ellipsoid_info(shape_info):
     """
     a, b, c = float(shape_info["background_outer_radius0"]), float(
         shape_info["background_outer_radius1"]), float(shape_info["background_outer_radius2"])
-    if min([a, b, c]) > 1e-15:
-        inner_a, inner_b, inner_c = float(shape_info["background_inner_radius0"]), float(
-            shape_info["background_inner_radius1"]), float(shape_info["background_inner_radius2"])
-        width = (max((a, b, c)) - max((inner_a, inner_b, inner_c))) / max((a, b, c))  # fractional width of shell
-    else:
-        # no background specified (inner bg defaults to peak radius) assign unphysical width
-        width = -1
+    inner_a, inner_b, inner_c = float(shape_info["background_inner_radius0"]), float(
+        shape_info["background_inner_radius1"]), float(shape_info["background_inner_radius2"])
 
-    return a, b, c, width
+    return (a, b, c, inner_a, inner_b, inner_c)
 
 
-def slice_ellipsoid(origin, axis_a, axis_b, axis_c, a, b, c, zp, transform):
+def slice_ellipsoid(origin, axis_a, axis_b, axis_c, a, b, c, zp, transform, isort=None):
     """Return semi-axes lengths and angle of ellipse formed
     by cutting the ellipsoid with a plane at z=zp
     :param origin: Origin of ellipsoid
@@ -141,6 +141,7 @@ def slice_ellipsoid(origin, axis_a, axis_b, axis_c, a, b, c, zp, transform):
     :param c: Axis 2 radius
     :param zp: Slice point in slice dimension
     :param transform: Callable to move to the slice frame
+    :param isort: eigenvector sorting order if provided otherwise determined from size of eigenvalues
     :return (slice_origin, major_radius, minor_radius, angle):
     """
     # From  https://en.wikipedia.org/wiki/Ellipsoid#As_quadric:
@@ -172,7 +173,7 @@ def slice_ellipsoid(origin, axis_a, axis_b, axis_c, a, b, c, zp, transform):
     #
     #  c = m22*zk^2
     return slice_ellipsoid_matrix(origin, zp,
-                                  calculate_ellipsoid_matrix(axis_a, axis_b, axis_c, a, b, c, transform))
+                                  calculate_ellipsoid_matrix(axis_a, axis_b, axis_c, a, b, c, transform), isort)
 
 
 def calculate_ellipsoid_matrix(axis_a, axis_b, axis_c, a, b, c, transform):
@@ -198,11 +199,12 @@ def calculate_ellipsoid_matrix(axis_a, axis_b, axis_c, a, b, c, transform):
     return axes_dir @ axes_lengths @ np.transpose(axes_dir)
 
 
-def slice_ellipsoid_matrix(origin, zp, ellipMatrix):
+def slice_ellipsoid_matrix(origin, zp, ellipMatrix, isort=None):
     """
     :param origin: Origin of the ellipsoid
     :param zp: Slice point in the slicing dimension
     :param ellipMatrix: Ellipsoid Matrix. See `calculate_ellipsoid_matrix` for definition
+    :param isort: eigenvector sorting order if provided otherwise determined from size of eigenvalues
     """
     # slice point in frame with ellipsoid at origin
     z = zp - origin[2]
@@ -236,12 +238,13 @@ def slice_ellipsoid_matrix(origin, zp, ellipMatrix):
     MM = A / (0.25 * np.transpose(B) @ linalg.inv(A) @ B - (c - 1))
     try:
         eigvalues, eigvectors = linalg.eig(MM)
-        isort = np.argsort(eigvalues)  # smallest eigenvalue corresponds to largest axis length
+        if isort is None:
+            isort = np.argsort(eigvalues)  # smallest eigenvalue corresponds to largest axis length
         eigvalues = eigvalues[isort]
         eigvectors = eigvectors[:, isort]
     except np.linalg.LinAlgError:
         # Sometimes the integration volume may not intersect the slices of data
-        return origin, np.nan, np.nan, 0
+        return origin, np.nan, np.nan, 0, None
     minor_radius, major_radius = 1 / np.sqrt(eigvalues[1]), 1 / np.sqrt(eigvalues[0])
     major_axis = eigvectors[:, 0]
     angle = np.rad2deg(np.arctan2(major_axis[1], major_axis[0]))
@@ -249,4 +252,4 @@ def slice_ellipsoid_matrix(origin, zp, ellipMatrix):
     slice_origin = np.array(
         (slice_origin_xy[0] + origin[0], slice_origin_xy[1] + origin[1], z + origin[2]))
 
-    return slice_origin, major_radius, minor_radius, angle
+    return slice_origin, major_radius, minor_radius, angle, isort

--- a/qt/python/mantidqt/widgets/sliceviewer/peaksviewer/representation/painter.py
+++ b/qt/python/mantidqt/widgets/sliceviewer/peaksviewer/representation/painter.py
@@ -49,7 +49,9 @@ class EllipticalShell(Patch):
         arc = Path.arc(theta1=0.0, theta2=360.0)
         # Draw the outer unit circle followed by a reversed and scaled inner circle
         v1 = arc.vertices
-        v2 = arc.vertices[::-1] * float(1.0 - self.frac_thick)
+        v2 = np.zeros_like(v1)
+        v2[:, 0] = v1[::-1, 0] * float(1.0 - self.frac_thick[0])
+        v2[:, 1] = v1[::-1, 1] * float(1.0 - self.frac_thick[1])
         v = np.vstack([v1, v2, v1[0, :], (0, 0)])
         c = np.hstack([arc.codes, arc.codes, Path.MOVETO, Path.CLOSEPOLY])
         c[len(arc.codes)] = Path.MOVETO

--- a/qt/python/mantidqt/widgets/sliceviewer/peaksviewer/representation/spherical.py
+++ b/qt/python/mantidqt/widgets/sliceviewer/peaksviewer/representation/spherical.py
@@ -67,10 +67,11 @@ class SphericallyIntergratedPeakRepresentation():
         # yapf: enable
 
         # add background if we have one
-        bkgd_radius_thick = _bkgd_radius_info(shape_info)
-        if bkgd_radius_thick is not None:
-            bkgd_outer_radius, thickness = bkgd_radius_thick
+        bkgd_inner_radius, bkgd_outer_radius = _bkgd_radius_info(shape_info)
+        if bkgd_outer_radius is not None:
             _, bkgd_circle_radius = slice_sphere(peak_origin, bkgd_outer_radius, slice_info.z_value)
+            _, bkgd_circle_radius_inner = slice_sphere(peak_origin, bkgd_inner_radius, slice_info.z_value)
+            thickness = bkgd_circle_radius - bkgd_circle_radius_inner
             # yapf: disable
             artists.append(
                 painter.shell(
@@ -104,13 +105,7 @@ def _bkgd_radius_info(shape_info):
     :param shape_info: A reference to a a dictionary of parameters from a PeakShape object
     :return: 2-tuple of (outer_radius, thickness) or None if no background region is defined
     """
-    bg_inner_radius = shape_info.get("background_inner_radius", None)
-    bg_outer_radius = shape_info.get("background_outer_radius", None)
-    radius_thickness = None
-    if bg_inner_radius and bg_outer_radius:
-        radius_thickness = (bg_outer_radius, bg_outer_radius - bg_inner_radius)
-
-    return radius_thickness
+    return shape_info.get("background_inner_radius", None), shape_info.get("background_outer_radius", None)
 
 
 def slice_sphere(peak_origin, radius, zp):

--- a/qt/python/mantidqt/widgets/sliceviewer/peaksviewer/representation/spherical.py
+++ b/qt/python/mantidqt/widgets/sliceviewer/peaksviewer/representation/spherical.py
@@ -120,8 +120,8 @@ def slice_sphere(peak_origin, radius, zp):
     :param zp: Slice point in slice dimension
     """
     # Sphere is just a special case of an ellipse
-    slice_origin, circle_radius, _, __ = slice_ellipsoid_matrix(peak_origin, zp,
-                                                                calculate_spherical_matrix(radius))
+    slice_origin, circle_radius, _, __, _ = slice_ellipsoid_matrix(peak_origin, zp,
+                                                                   calculate_spherical_matrix(radius))
     return slice_origin, circle_radius
 
 

--- a/qt/python/mantidqt/widgets/sliceviewer/peaksviewer/representation/test/test_peaksviewer_representation_painter.py
+++ b/qt/python/mantidqt/widgets/sliceviewer/peaksviewer/representation/test/test_peaksviewer_representation_painter.py
@@ -64,7 +64,7 @@ class MplPainterTest(unittest.TestCase):
     def test_ellipticalshell(self):
         view = MagicMock()
         painter = MplPainter(view)
-        x, y, outer_width, outer_height, thick = 1, 2, 0.8, 1.0, 0.2
+        x, y, outer_width, outer_height, thick = 1, 2, 0.8, 1.0, (0.2, 0.2)
         alpha = 1.0
 
         painter.elliptical_shell(x, y, outer_width, outer_height, thick, alpha=alpha)


### PR DESCRIPTION
**Description of work.**

This addresses a few issues with plotting the ellipsoids when manually specifying the radii in sliceviewer using the work first introduced in #30430 and fixed in #30623.

It also fixes issues with plotting sphere and ellipsoid backgrounds for the cases when the slice is doesn't go through the peak centre.

**To test:**


```python
ws = CreateMDWorkspace(Dimensions='3', Extents='-2,2,-2,2,-2,2',
                       Names='Q_lab_x,Q_lab_y,Q_lab_z', Units='U,U,U',
                       Frames='QLab,QLab,QLab',
                       SplitInto='2', SplitThreshold='50')
expt_info = CreateSampleWorkspace()
ws.addExperimentInfo(expt_info)

# add peak
p = CreatePeaksWorkspace(InstrumentWorkspace='ws', NumberOfPeaks=0, OutputWorkspace='peaks')
SetUB('peaks', 1,1,1,90,90,90)
pk = p.createPeak([1,1,1]) # axes aligned with viewing axes
p.addPeak(pk)


IntegratePeaksMD(InputWorkspace='ws', PeakRadius=0.5, BackgroundOuterRadius=1.0, PeaksWorkspace='peaks', OutputWorkspace='sphere')
IntegratePeaksMD(InputWorkspace='ws', PeakRadius=[0.5,0.5,0.5], BackgroundOuterRadius=[1.0,1.0,1.0], Ellipsoid=True, PeaksWorkspace='peaks', OutputWorkspace='ellipse')
```
Look at the `sphere` and `ellipse` peaks in sliceviewer at the 1.42 layer and compare to master

### master looks like this, but the background inner radius should follow the peak radius

![sphere_1 42_master](https://user-images.githubusercontent.com/5595210/107393676-0fbdcd80-6ac9-11eb-8fc9-910fd6924223.png)

### see that this is now fixed

![sphere_1 42](https://user-images.githubusercontent.com/5595210/107393675-0fbdcd80-6ac9-11eb-876f-f475258e6882.png)

### play with different `PeakRadius`, ` BackgroundInnerRadius` and  `BackgroundOuterRadius` and check that everything is plotted correctly, _e.g._

```python
IntegratePeaksMD(InputWorkspace='ws', PeakRadius=[0.5,0.4,0.3], BackgroundInnerRadius=[0.6,0.4,0.5], BackgroundOuterRadius=[1.0,0.4,1.0], Ellipsoid=True, PeaksWorkspace='peaks', OutputWorkspace='ellipse2')
```

![ellipese](https://user-images.githubusercontent.com/5595210/107393674-0f253700-6ac9-11eb-9bb0-8353ae876733.png)

*There is no associated issue.*

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
