### PR TITLE
Pd144 double check method before reusing container for SNSPowderReduction (master)

### DIFF
--- a/Framework/PythonInterface/plugins/algorithms/SNSPowderReduction.py
+++ b/Framework/PythonInterface/plugins/algorithms/SNSPowderReduction.py
@@ -1287,7 +1287,7 @@ class SNSPowderReduction(DistributedDataProcessorAlgorithm):
 
     def _generate_container_run_name(self, can_run_numbers, samRunIndex):
         """generate container workspace name based on given info
-        
+
         :param can_run_numbers:
         :param samRunIndex:
 

--- a/Framework/PythonInterface/plugins/algorithms/SNSPowderReduction.py
+++ b/Framework/PythonInterface/plugins/algorithms/SNSPowderReduction.py
@@ -493,8 +493,7 @@ class SNSPowderReduction(DistributedDataProcessorAlgorithm):
                     last_absMethod = hstry.getHistory().getAlgorithm(0).getPropertyValue("TypeOfCorrection")
                     if last_absMethod != self._absMethod:
                         self.log().information(
-                            f"Remove existing container workspace {can_run_ws_name} generated with a different method"
-                        )
+                            f"Remove {can_run_ws_name} as it is generated with a different method")
                         mtd.remove(can_run_ws_name)
 
             can_run_ws_name = self._process_container_runs(can_run_numbers,

--- a/Framework/PythonInterface/plugins/algorithms/SNSPowderReduction.py
+++ b/Framework/PythonInterface/plugins/algorithms/SNSPowderReduction.py
@@ -479,7 +479,7 @@ class SNSPowderReduction(DistributedDataProcessorAlgorithm):
             can_run_numbers = self._info["container"].value
             can_run_numbers = ['%s_%d' % (self._instrument, value) for value in can_run_numbers]
             # Check if existing container
-            #  - has history
+            #  - has history and is using SNSPowderReduction
             #    - was created using the same method
             #       -> carry on as usual
             #    - was created with a different method
@@ -490,11 +490,13 @@ class SNSPowderReduction(DistributedDataProcessorAlgorithm):
             if can_run_ws_name in mtd:
                 hstry = mtd[can_run_ws_name].getHistory()
                 if not hstry.empty():
-                    last_absMethod = hstry.getAlgorithm(0).getPropertyValue("TypeOfCorrection")
-                    if last_absMethod != self._absMethod:
-                        self.log().information(
-                            f"Remove {can_run_ws_name} as it is generated with a different method")
-                        mtd.remove(can_run_ws_name)
+                    alg = hstry.getAlgorithm(0)
+                    if alg.name() == "SNSPowderReduction":
+                        if alg.getPropertyValue("TypeOfCorrection") != self._absMethod:
+                            self.log().information(
+                                f"Remove {can_run_ws_name} as it is generated with a different method"
+                            )
+                            mtd.remove(can_run_ws_name)
 
             can_run_ws_name = self._process_container_runs(can_run_numbers,
                                                            samRunIndex,

--- a/Framework/PythonInterface/plugins/algorithms/SNSPowderReduction.py
+++ b/Framework/PythonInterface/plugins/algorithms/SNSPowderReduction.py
@@ -478,7 +478,29 @@ class SNSPowderReduction(DistributedDataProcessorAlgorithm):
             # process the container
             can_run_numbers = self._info["container"].value
             can_run_numbers = ['%s_%d' % (self._instrument, value) for value in can_run_numbers]
-            can_run_ws_name = self._process_container_runs(can_run_numbers, samRunIndex, preserveEvents, absorptionWksp=a_container)
+            # Check if existing container
+            #  - has history
+            #    - was created using the same method
+            #       -> carry on as usual
+            #    - was created with a different method
+            #       -> delete the current one, then carry on
+            #  - no history (processing list of runs)
+            #    -> carry on as a single call wiht list of runs ensures that same method is used.
+            can_run_ws_name, _ = self._generate_container_run_name(can_run_numbers, samRunIndex)
+            if can_run_ws_name in mtd:
+                hstry = mtd[can_run_ws_name].getHistory()
+                if not hstry.empty():
+                    last_absMethod = hstry.getHistory().getAlgorithm(0).getPropertyValue("TypeOfCorrection")
+                    if last_absMethod != self._absMethod:
+                        self.log().information(
+                            f"Remove existing container workspace {can_run_ws_name} generated with a different method"
+                        )
+                        mtd.remove(can_run_ws_name)
+
+            can_run_ws_name = self._process_container_runs(can_run_numbers,
+                                                           samRunIndex,
+                                                           preserveEvents,
+                                                           absorptionWksp=a_container)
             if can_run_ws_name is not None:
                 workspacelist.append(can_run_ws_name)
 
@@ -1264,19 +1286,23 @@ class SNSPowderReduction(DistributedDataProcessorAlgorithm):
 
         return do_split_raw_wksp, num_out_wksp
 
-    def _process_container_runs(self, can_run_numbers, samRunIndex, preserveEvents, absorptionWksp=None):
-        """ Process container runs
+    def _generate_container_run_name(self, can_run_numbers, samRunIndex):
+        """generate container workspace name based on given info
+        
         :param can_run_numbers:
-        :return:
+        :param samRunIndex:
+
+        :return can_run_ws_name:
+        :return can_run_number:
         """
         assert isinstance(samRunIndex, int)
 
         if noRunSpecified(can_run_numbers):
             # no container run is specified
             can_run_ws_name = None
+            can_run_number = None
         else:
             # reduce container run such that it can be removed from sample run
-
             if len(can_run_numbers) == 1:
                 # only 1 container run
                 can_run_number = can_run_numbers[0]
@@ -1286,6 +1312,21 @@ class SNSPowderReduction(DistributedDataProcessorAlgorithm):
 
             # get reference to container run
             can_run_ws_name = getBasename(can_run_number)
+        return can_run_ws_name, can_run_number
+
+    def _process_container_runs(self,
+                                can_run_numbers,
+                                samRunIndex,
+                                preserveEvents,
+                                absorptionWksp=None):
+        """ Process container runs
+        :param can_run_numbers:
+        :return:
+        """
+        can_run_ws_name, can_run_number = self._generate_container_run_name(
+            can_run_numbers, samRunIndex)
+
+        if can_run_ws_name is not None:
             self.log().notice('Processing empty container {}'.format(can_run_ws_name))
             if self.does_workspace_exist(can_run_ws_name):
                 # container run exists to get reference from mantid
@@ -1296,7 +1337,10 @@ class SNSPowderReduction(DistributedDataProcessorAlgorithm):
                 fileArg = [can_run_number]
                 if self.getProperty("Sum").value:
                     fileArg = can_run_numbers
-                self._focusAndSum(fileArg, preserveEvents, final_name=can_run_ws_name, absorptionWksp=absorptionWksp)
+                self._focusAndSum(fileArg,
+                                  preserveEvents,
+                                  final_name=can_run_ws_name,
+                                  absorptionWksp=absorptionWksp)
 
                 # smooth background
                 smoothParams = self.getProperty("BackgroundSmoothParams").value

--- a/Framework/PythonInterface/plugins/algorithms/SNSPowderReduction.py
+++ b/Framework/PythonInterface/plugins/algorithms/SNSPowderReduction.py
@@ -490,7 +490,7 @@ class SNSPowderReduction(DistributedDataProcessorAlgorithm):
             if can_run_ws_name in mtd:
                 hstry = mtd[can_run_ws_name].getHistory()
                 if not hstry.empty():
-                    last_absMethod = hstry.getHistory().getAlgorithm(0).getPropertyValue("TypeOfCorrection")
+                    last_absMethod = hstry.getAlgorithm(0).getPropertyValue("TypeOfCorrection")
                     if last_absMethod != self._absMethod:
                         self.log().information(
                             f"Remove {can_run_ws_name} as it is generated with a different method")

--- a/docs/source/release/v6.1.0/diffraction.rst
+++ b/docs/source/release/v6.1.0/diffraction.rst
@@ -26,5 +26,6 @@ Single Crystal Diffraction
 Improvements
 ############
 - :ref:`IntegratePeaksMD <algm-IntegratePeaksMD>` now allows ellipsoidal shapes to be manually defined for the PeakRadius and Background radii options.
+- :ref:`SNSPowderReduction <algm-SNSPowderReduction>` now check if previous container is created using the same method before reusing it.
 
 :ref:`Release 6.1.0 <v6.1.0>`


### PR DESCRIPTION
**Description of work.**

This PR adds a new check in `SNSPowderReduction` where Mantid will check if the existing container workspace in memory was calculated using the same method.
If not, the existing container workspace will be deleted from memory so that the correct one can be generated.

- relates to Gitlab task [PD177](https://code.ornl.gov/sns-hfir-scse/diffraction/powder/powder-diffraction/-/issues/177)
- the version of #30666 into `master`

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

**To test:**

On analysis cluster, use the following code to reduce data with "SampleOnly" method.

```python
from mantid.simpleapi import SNSPowderReduction, mtd

# Sample Only Absorption Correction
SNSPowderReduction("PG3_46214.nxs.h5",
                   CalibrationFile="/SNS/PG3/shared/CALIBRATION/2020_1_11A_CAL/PG3_PAC_HR_d46168_2020_05_06.h5",
                   CharacterizationRunsFile="/SNS/PG3/shared/CALIBRATION/2020_2_11A_CAL/PG3_char_2020_01_04_PAC_limit_1.4MW.txt,/SNS/PG3/shared/CALIBRATION/2020_2_11A_CAL/PG3_char_2020_05_06-HighRes-PAC_1.4 MW.txt",
                   Binning=-0.001,
                   SaveAs="topas",
                   TypeOfCorrection="SampleOnly",
                   SampleFormula="La-(B11)5.94-(B10)0.06",
                   MeasuredMassDensity=2.36,
                   ContainerShape="PAC06",
                   OutputFilePrefix='Sample_absorption_',
                   OutputDirectory="LaB6_reduction_out")
```

Now without doing any cleaning, redo the reduction again with a different method

```python
SNSPowderReduction("PG3_46214.nxs.h5",
                   CalibrationFile="/SNS/PG3/shared/CALIBRATION/2020_1_11A_CAL/PG3_PAC_HR_d46168_2020_05_06.h5",
                   CharacterizationRunsFile="/SNS/PG3/shared/CALIBRATION/2020_2_11A_CAL/PG3_char_2020_01_04_PAC_limit_1.4MW.txt,/SNS/PG3/shared/CALIBRATION/2020_2_11A_CAL/PG3_char_2020_05_06-HighRes-PAC_1.4 MW.txt",
                   Binning=-0.001,
                   SaveAs="topas",
                   TypeOfCorrection="SampleAndContainer",
                   SampleFormula="La-(B11)5.94-(B10)0.06",
                   MeasuredMassDensity=2.36,
                   ContainerShape="PAC06",
                   OutputFilePrefix='SC_absorption_',
                   OutputDirectory="LaB6_reduction_out")
```

One should notice that the container workspace `PG3_46190` will be deleted (disappear) from the list, then repopulated.


Fixes #30667. <!-- and fix #xxxx or close #xxxx xor resolves #xxxx -->
<!-- alternative
*There is no associated issue.*
-->

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or master)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
