### PR TITLE
ALC No Longer Empty's Interface On New Runs

### DIFF
--- a/docs/source/release/v6.1.0/muon.rst
+++ b/docs/source/release/v6.1.0/muon.rst
@@ -31,6 +31,7 @@ New Features
 Improvements
 ############
 - Exported workspaces now have history.
+- The interface saves previous settings if possible instead of resetting.
 
 Bug fixes
 ##########

--- a/qt/scientific_interfaces/Muon/ALCDataLoadingView.cpp
+++ b/qt/scientific_interfaces/Muon/ALCDataLoadingView.cpp
@@ -262,10 +262,19 @@ void ALCDataLoadingView::setAvailablePeriods(
   setAvailableItems(m_ui.redPeriod, periods);
   setAvailableItems(m_ui.greenPeriod, periods);
 
+  // Reset this so not checked incorrectly
+  m_ui.subtractCheckbox->setChecked(false);
+
   // If single period, disable "Subtract" checkbox and green period box
   const bool multiPeriod = periods.size() > 1;
   m_ui.subtractCheckbox->setEnabled(multiPeriod);
   m_ui.greenPeriod->setEnabled(multiPeriod);
+
+  // If two periods, default to 1 minus 2
+  if (periods.size() == 2) {
+    m_ui.subtractCheckbox->setChecked(true);
+    m_ui.greenPeriod->setCurrentIndex(1);
+  }
 }
 
 /**

--- a/qt/scientific_interfaces/Muon/ALCDataLoadingView.cpp
+++ b/qt/scientific_interfaces/Muon/ALCDataLoadingView.cpp
@@ -27,7 +27,7 @@ namespace MantidQt {
 namespace CustomInterfaces {
 
 ALCDataLoadingView::ALCDataLoadingView(QWidget *widget)
-    : m_widget(widget), m_selectedLog(DEFAULT_LOG) {}
+    : m_widget(widget), m_selectedLog(DEFAULT_LOG), m_numPeriods(0) {}
 
 ALCDataLoadingView::~ALCDataLoadingView() {}
 
@@ -262,19 +262,23 @@ void ALCDataLoadingView::setAvailablePeriods(
   setAvailableItems(m_ui.redPeriod, periods);
   setAvailableItems(m_ui.greenPeriod, periods);
 
-  // Reset this so not checked incorrectly
-  m_ui.subtractCheckbox->setChecked(false);
+  // Reset subtraction if single period as not possible
+  if (periods.size() < 2)
+    m_ui.subtractCheckbox->setChecked(false);
 
   // If single period, disable "Subtract" checkbox and green period box
   const bool multiPeriod = periods.size() > 1;
   m_ui.subtractCheckbox->setEnabled(multiPeriod);
   m_ui.greenPeriod->setEnabled(multiPeriod);
 
-  // If two periods, default to 1 minus 2
-  if (periods.size() == 2) {
+  // If two or more periods and number of periods has changed, default to 1
+  // minus 2
+  if (periods.size() >= 2 && m_numPeriods != periods.size()) {
     m_ui.subtractCheckbox->setChecked(true);
-    m_ui.greenPeriod->setCurrentIndex(1);
+    m_ui.redPeriod->setCurrentText("1");
+    m_ui.greenPeriod->setCurrentText("2");
   }
+  m_numPeriods = periods.size();
 }
 
 /**

--- a/qt/scientific_interfaces/Muon/ALCDataLoadingView.h
+++ b/qt/scientific_interfaces/Muon/ALCDataLoadingView.h
@@ -103,6 +103,7 @@ private:
   QWidget *const m_widget;
 
   QString m_selectedLog;
+  size_t m_numPeriods;
 };
 
 } // namespace CustomInterfaces

--- a/qt/scientific_interfaces/Muon/ALCDataLoadingView.ui
+++ b/qt/scientific_interfaces/Muon/ALCDataLoadingView.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>943</width>
-    <height>646</height>
+    <height>668</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -182,12 +182,6 @@
                 <horstretch>0</horstretch>
                 <verstretch>2</verstretch>
                </sizepolicy>
-              </property>
-              <property name="minimumSize">
-               <size>
-                <width>0</width>
-                <height>80</height>
-               </size>
               </property>
               <property name="toolTip">
                <string>Status of the interface. Green: Success; Yellow: Processing; Red: Error</string>
@@ -870,8 +864,8 @@
   </connection>
  </connections>
  <buttongroups>
-  <buttongroup name="calculationType"/>
   <buttongroup name="detectorGroupingType"/>
   <buttongroup name="deadTimeCorrType"/>
+  <buttongroup name="calculationType"/>
  </buttongroups>
 </ui>


### PR DESCRIPTION
**Ready**

~~**Merge #30628 first**~~ **Merged**

**Description of work.**
Updated sorting of logs to fix bug. 
Stopped setting interface to empty unless parameters can't be reused.
Defaulted to 1 minus 2 if only 2 periods

**To test:**
Open ALC
First Load 2 period Data (EMU74470)
Notice it now the interface has 1 subtract 2 for periods
Check logs are now alphabetically sorted (ignoring problems with underscores)(before some logs were in the wrong place if they started with the same letter)
Change all the settings in the interface
Change periods to 2 subtract 1
Now Load EMU74471 (also 2 period)
All settings should remain the same including the periods
Load single period data EMU20883
periods should have changed

Fixes #30067 

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
