### PR TITLE
Squash python implicit cast warning (ornlnext)

### DIFF
--- a/qt/applications/workbench/workbench/app/mainwindow.py
+++ b/qt/applications/workbench/workbench/app/mainwindow.py
@@ -56,8 +56,8 @@ def _get_splash_image():
 
     # the proportion of the whole window size for the splash screen
     splash_screen_scaling = 0.25
-    return QPixmap(':/images/MantidSplashScreen_4k.jpg').scaled(width * splash_screen_scaling,
-                                                                height * splash_screen_scaling,
+    return QPixmap(':/images/MantidSplashScreen_4k.jpg').scaled(int(width * splash_screen_scaling),
+                                                                int(height * splash_screen_scaling),
                                                                 Qt.KeepAspectRatio,
                                                                 Qt.SmoothTransformation)
 


### PR DESCRIPTION
This is the version of #30694 into `ornl-next`.