### PR TITLE
Documentation: math mode use in Mantid docs

### DIFF
--- a/Framework/Algorithms/src/GetEi2.cpp
+++ b/Framework/Algorithms/src/GetEi2.cpp
@@ -88,13 +88,14 @@ void GetEi2::init()
       "The energy of neutron in meV, it is also printed to the Mantid's log",
       Direction::Output);
 
-  declareProperty("FirstMonitorPeak", -1.0,
-                  "The time in :math:`\text{\\mu}`s when the count rate of the "
-                  "first monitor, which defaults to the last monitor the beam "
-                  "hits before the sample, is greatest. It is the mean X value "
-                  "for the bin with the highest number of counts per second "
-                  "and is also writen to Mantid's log.",
-                  Direction::Output);
+  declareProperty(
+      "FirstMonitorPeak", -1.0,
+      "The time in :math:`\\rm{\\mu s}` when the count rate of the "
+      "first monitor, which defaults to the last monitor the beam "
+      "hits before the sample, is greatest. It is the mean X value "
+      "for the bin with the highest number of counts per second "
+      "and is also writen to Mantid's log.",
+      Direction::Output);
 
   declareProperty(
       "FirstMonitorIndex", 0,
@@ -109,7 +110,7 @@ void GetEi2::init()
   declareProperty("PeakSearchRange", 0.1, inRange0toOne,
                   "Specifies the relative TOF range where the algorithm tries "
                   "to find the monitor peak. Search occurs within "
-                  ":math:`PEAK_TOF_Guess\cdot(1 \pm PeakSearchRange)` ranges.\n"
+                  "PEAK_TOF_Guess * (1 +/- PeakSearchRange) ranges.\n"
                   "Defaults are almost always sufficient but decrease this "
                   "value for very narrow peaks and increase for wide.",
                   Direction::Input);

--- a/Framework/Algorithms/src/GetEi2.cpp
+++ b/Framework/Algorithms/src/GetEi2.cpp
@@ -89,7 +89,7 @@ void GetEi2::init()
       Direction::Output);
 
   declareProperty("FirstMonitorPeak", -1.0,
-                  "The time in <math>\\mu s</math> when the count rate of the "
+                  "The time in :math:`\text{\\mu}`s when the count rate of the "
                   "first monitor, which defaults to the last monitor the beam "
                   "hits before the sample, is greatest. It is the mean X value "
                   "for the bin with the highest number of counts per second "
@@ -109,7 +109,7 @@ void GetEi2::init()
   declareProperty("PeakSearchRange", 0.1, inRange0toOne,
                   "Specifies the relative TOF range where the algorithm tries "
                   "to find the monitor peak. Search occurs within "
-                  "PEAK_TOF_Guess*(1+-PeakSearchRange) ranges.\n"
+                  ":math:`PEAK_TOF_Guess\cdot(1 \pm PeakSearchRange)` ranges.\n"
                   "Defaults are almost always sufficient but decrease this "
                   "value for very narrow peaks and increase for wide.",
                   Direction::Input);

--- a/Framework/Algorithms/src/GetEi2.cpp
+++ b/Framework/Algorithms/src/GetEi2.cpp
@@ -88,14 +88,13 @@ void GetEi2::init()
       "The energy of neutron in meV, it is also printed to the Mantid's log",
       Direction::Output);
 
-  declareProperty(
-      "FirstMonitorPeak", -1.0,
-      "The time in :math:`\\rm{\\mu s}` when the count rate of the "
-      "first monitor, which defaults to the last monitor the beam "
-      "hits before the sample, is greatest. It is the mean X value "
-      "for the bin with the highest number of counts per second "
-      "and is also writen to Mantid's log.",
-      Direction::Output);
+  declareProperty("FirstMonitorPeak", -1.0,
+                  "The time in :math:`\\rm{\\mu s}` when the count rate of the "
+                  "first monitor, which defaults to the last monitor the beam "
+                  "hits before the sample, is greatest. It is the mean X value "
+                  "for the bin with the highest number of counts per second "
+                  "and is also writen to Mantid's log.",
+                  Direction::Output);
 
   declareProperty(
       "FirstMonitorIndex", 0,

--- a/Framework/Algorithms/src/Q1DWeighted.cpp
+++ b/Framework/Algorithms/src/Q1DWeighted.cpp
@@ -53,7 +53,8 @@ void Q1DWeighted::init() {
   declareProperty(
       std::make_unique<ArrayProperty<double>>(
           "OutputBinning", std::make_shared<RebinParamsValidator>()),
-      "The new bin boundaries in the form: :math:`x_1,\\Delta x_1,x_2,\\Delta x_2,\\dots,x_n`");
+      "The new bin boundaries in the form: :math:`x_1,\\Delta x_1,x_2,\\Delta "
+      "x_2,\\dots,x_n`");
 
   auto positiveInt = std::make_shared<BoundedValidator<int>>();
   positiveInt->setLower(0);

--- a/Framework/Algorithms/src/Q1DWeighted.cpp
+++ b/Framework/Algorithms/src/Q1DWeighted.cpp
@@ -53,8 +53,7 @@ void Q1DWeighted::init() {
   declareProperty(
       std::make_unique<ArrayProperty<double>>(
           "OutputBinning", std::make_shared<RebinParamsValidator>()),
-      "The new bin boundaries in the form: <math>x_1,\\Delta x_1,x_2,\\Delta "
-      "x_2,\\dots,x_n</math>");
+      "The new bin boundaries in the form: :math:`x_1,\\Delta x_1,x_2,\\Delta x_2,\\dots,x_n`");
 
   auto positiveInt = std::make_shared<BoundedValidator<int>>();
   positiveInt->setLower(0);

--- a/Framework/MDAlgorithms/src/ConvertToDiffractionMDWorkspace.cpp
+++ b/Framework/MDAlgorithms/src/ConvertToDiffractionMDWorkspace.cpp
@@ -115,7 +115,7 @@ void ConvertToDiffractionMDWorkspace::init() {
       "Optional. If specified, then all the boxes will be split to this "
       "minimum recursion depth. 1 = one level of splitting, etc.\n"
       "Be careful using this since it can quickly create a huge number of "
-      ":math:`boxes = SplitInto^{MinRercursionDepth \times NumDimensions}`.\n"
+      ":math:`boxes = SplitInto^{MinRercursionDepth \\times NumDimensions}`.\n"
       "But setting this property equal to MaxRecursionDepth property is "
       "necessary if one wants to generate multiple file based workspaces in "
       "order to merge them later\n");

--- a/Framework/MDAlgorithms/src/ConvertToDiffractionMDWorkspace.cpp
+++ b/Framework/MDAlgorithms/src/ConvertToDiffractionMDWorkspace.cpp
@@ -115,7 +115,7 @@ void ConvertToDiffractionMDWorkspace::init() {
       "Optional. If specified, then all the boxes will be split to this "
       "minimum recursion depth. 1 = one level of splitting, etc.\n"
       "Be careful using this since it can quickly create a huge number of "
-      "boxes = (SplitInto ^ (MinRercursionDepth x NumDimensions)).\n"
+      ":math:`boxes = SplitInto^{MinRercursionDepth \times NumDimensions}`.\n"
       "But setting this property equal to MaxRecursionDepth property is "
       "necessary if one wants to generate multiple file based workspaces in "
       "order to merge them later\n");

--- a/Framework/MDAlgorithms/src/ConvertToMD.cpp
+++ b/Framework/MDAlgorithms/src/ConvertToMD.cpp
@@ -93,8 +93,8 @@ void ConvertToMD::init() {
       "Optional. If specified, then all the boxes will be split to this "
       "minimum recursion depth. 0 = no splitting, "
       "1 = one level of splitting, etc. \n Be careful using this since it can "
-      "quickly create a huge number of boxes = "
-      "(SplitInto ^ (MinRercursionDepth * NumDimensions)). \n But setting this "
+      "quickly create a huge number of :math:`boxes = "
+      "SplitInto^{MinRercursionDepth \times NumDimensions}`. \n But setting this "
       "property equal to MaxRecursionDepth "
       "property is necessary if one wants to generate multiple file based "
       "workspaces in order to merge them later.");

--- a/Framework/MDAlgorithms/src/ConvertToMD.cpp
+++ b/Framework/MDAlgorithms/src/ConvertToMD.cpp
@@ -94,9 +94,9 @@ void ConvertToMD::init() {
       "minimum recursion depth. 0 = no splitting, "
       "1 = one level of splitting, etc. \n Be careful using this since it can "
       "quickly create a huge number of :math:`boxes = "
-      "SplitInto^{MinRercursionDepth \times NumDimensions}`. \n But setting this "
-      "property equal to MaxRecursionDepth "
-      "property is necessary if one wants to generate multiple file based "
+      "SplitInto^{MinRercursionDepth \\times NumDimensions}`. \n But setting "
+      "this property equal to MaxRecursionDepth "
+      "is necessary if one wants to generate multiple file based "
       "workspaces in order to merge them later.");
   setPropertyGroup("MinRecursionDepth", getBoxSettingsGroupName());
 

--- a/docs/source/algorithms/AnvredCorrection-v1.rst
+++ b/docs/source/algorithms/AnvredCorrection-v1.rst
@@ -11,7 +11,7 @@ Description
 
 Following A.J.Schultz's anvred, the weight factors should be:
 
-:math:`sin^2(theta) / (lambda^4 * spec * eff * trans)`
+:math:`\text{sin}^2(theta) / (lambda^4 * spec * eff * trans)`
 
 where
 
@@ -21,11 +21,11 @@ where
 -  eff = pixel efficiency
 -  trans = absorption correction
 
-The quantity: :math:`sin^2(theta) / eff` depends only on the pixel and can be
+The quantity: :math:`\text{sin}^2(theta) / eff` depends only on the pixel and can be
 pre-calculated for each pixel. It could be saved in array pix_weight[].
 
 For now, pix_weight[] is calculated by the method ``BuildPixWeights()``
-and just holds the :math:`sin^2(theta)` values. The wavelength dependent portion
+and just holds the :math:`\text{sin}^2(theta)` values. The wavelength dependent portion
 of the correction is saved in the array lamda_weight[].
 
 The time-of-flight is converted to wave length by multiplying by

--- a/docs/source/algorithms/ComputeIncoherentDOS-v1.rst
+++ b/docs/source/algorithms/ComputeIncoherentDOS-v1.rst
@@ -97,17 +97,13 @@ measurement of a large Aluminium sample from the neutron training course.
 This example uses a generated dataset so that it will run on automated tests
 of the build system where the above datafiles do not exist.
 
-.. testcode:: ExGenerated
+.. code:: python
 
     ws = CreateSampleWorkspace(binWidth = 0.1, XMin = 0, XMax = 50, XUnit = 'DeltaE')
     ws = ScaleX(ws, -25, "Add")
     LoadInstrument(ws, InstrumentName='MARI', RewriteSpectraMap = True)
     ws = SofQW(ws, [0, 0.05, 8], 'Direct', 25)
     ws_DOS = ComputeIncoherentDOS(ws)
-
-Output
-
-.. testoutput:: ExGenerated
 
 References
 ----------

--- a/docs/source/algorithms/ComputeIncoherentDOS-v1.rst
+++ b/docs/source/algorithms/ComputeIncoherentDOS-v1.rst
@@ -16,7 +16,7 @@ for the 1-phonon incoherent scattering function [#CHAPLOT]_:
 
 .. math::
 
-    S^{(1)}_{\mathrm{inc}}(Q,E) = \exp\left(-2\bar{W}(Q)\right) \frac{Q^2}{E} \langle n+\frac{1}{2}\pm\frac{1}{2} \rangle \left[ \sum_k \frac{\sigma_k^{\mathrm{scatt}}}{2m_k} g_k(E) \right],
+    S^{(1)}_{\mathrm{inc}}(Q,E) = \exp\left(-2\bar{W}(Q)\right) \frac{Q^2}{E} \left< n+\frac{1}{2}\pm\frac{1}{2} \right> \left[ \sum_k \frac{\sigma_k^{\mathrm{scatt}}}{2m_k} g_k(E) \right],
 
 where the term in square brackets is the neutron weighted density of 
 states which is calculated by this algorithm, and :math:`g_k(E)` is

--- a/docs/source/algorithms/ConvertCWSDExpToMomentum-v1.rst
+++ b/docs/source/algorithms/ConvertCWSDExpToMomentum-v1.rst
@@ -16,8 +16,6 @@ This algorithms is to convert an experiment done on reactor-based four-circle in
 In this algorithm's name, ConvertCWSDToMomentum, *CW* stands for constant wave 
 (reactor-source instrument); *SD* stands for single crystal diffraction.
 
-This algorithm takes ??? as inputs.
-
 Furthermore, the unit of the output matrix workspace can be converted to 
 momentum transfer (Q).
 

--- a/docs/source/algorithms/D7YIGPositionCalibration-v1.rst
+++ b/docs/source/algorithms/D7YIGPositionCalibration-v1.rst
@@ -11,7 +11,7 @@
 Description
 -----------
 
-This is the algorithm that performs wavelength and position calibration for both individual detectors and detector banks using measurement of a sample of powdered :math:`\text{Y}_{3}\text{Fe}_{5}\text{O}_{12}` (YIG). This data is fitted with Gaussian distributions at the expected peak positions. The output is an :ref:`Instrument Parameter File <InstrumentParameterFile>` readable by the :ref:`LoadILLPolarizedDiffraction <algm-LoadILLPolarizedDiffraction>` algorithm that will place the detector banks and detectors using the output of this algorithm.
+This is the algorithm that performs wavelength and position calibration for both individual detectors and detector banks using measurement of a sample of powdered :math:`\text{Y}_{3}\text{Fe}_{5}\text{O}_{12}` (YIG). This data is fitted with Gaussian distributions at the expected peak positions. The output is an :ref:`Instrument Parameter File <InstrumentParameterFile>` readable by the :ref:`LoadILLPolarizedDiffraction <algm-LoadILLPolarizedDiffraction>` algorithm that will place the detector banks and detectors using the output of this algorithm. The algorithm implements method described in Ref. [#Fennell]_.
 
 It is crucial for a reliable calibration to first run a test without setting the `BankOffsets` parameter and with `FittingMethod` set to `None`. This allows checking the positions of the initial guesses for the positions of YIG Bragg peaks in the `conjoined_input` workspace. Then, the BankOffsets can be obtained by comparing the peak positions coming from the detectors with their expected location, coming from known d-spacings for YIG.
 
@@ -22,15 +22,15 @@ The property `MaskedBinsRange` allows to mask multiple :math:`2\theta` ranges of
 Calibration method
 ##################
 
-A YIG scan data is loaded into a single 2D Workspace where the X axis contains detector positions during each step of the scan, and the Y axis the measured intensities normalized to monitor. The Y axis data is also 2D with each row representing full scan for a single detector. It is recommended to mask scan points located between -25 and 15 to remove the impact of the direct neutron beam.
+A YIG scan data is loaded into a single 2D Workspace where the X axis contains detector positions during each step of the scan, and the Y axis the measured intensities normalized to monitor. The Y axis data is also 2D with each row representing full scan for a single detector. It is recommended to mask scan points located between -35 and 15 degrees to remove the impact of the direct neutron beam.
 
-The provided YIG d-spacing values are loaded from an XML list. The default d-spacing is coming from Ref. [2]. The peak positions are converted into 2theta positions using the initial assumption of the neutron wavelength. All peaks that would require the :math:`2\theta` to be above 180 degrees are removed.
+The provided YIG d-spacing values are loaded from an XML list. The default d-spacing is coming from Ref. [#Nakatsuka]_. The peak positions are converted into 2theta positions using the initial assumption of the neutron wavelength. All peaks that would require the :math:`2\theta` to be above 180 degrees are removed.
 
 YIG peaks in the detector's scan are fitted using a Gaussian distribution. The Bragg peaks are fitted either separately, when the `FittingMethod` property is set to `Individual`, or all peaks measured by a detector are fitted together, when the `FittingMethod` property is set to `Global`. The fitting results are stored in a new workspace, where the Y axis contains the fitted peak centres and the X axis the calculated peak positions.
 
 The workspace containing the peak fitting results is then fitted using a `Multidomain` function of the form:
 
-.. math:: 2\theta_{fit} = m \cdot (2.0 \cdot \text{asin} ( \lambda / 2d ) + offset_{\text{pixel}} + offset_{\text{bank}}),
+.. math:: 2\theta_{\text{fit}} = m \cdot (2.0 \cdot \text{asin} ( \lambda / 2d ) + offset_{\text{pixel}} + offset_{\text{bank}}),
 
 where `m` is the bank slope, :math:`offset_{\text{pixel}}` is the relative offset to the initial assumption of the position inside the detector bank, and :math:`offset_{\text{bank}}` is the offset of the entire bank. This function allows to extract the information about the wavelength, detector bank slopes and offsets, and the distribution of detector offsets.
 
@@ -80,12 +80,13 @@ Output:
    The bank3 gradient is: 1.0
    The bank4 gradient is: 1.0
 
-#. T. Fennell, L. Mangin-Thro, H.Mutka, G.J. Nilsen, A.R. Wildes.
+
+.. [#Fennell] T. Fennell, L. Mangin-Thro, H.Mutka, G.J. Nilsen, A.R. Wildes.
    *Wavevector and energy resolution of the polarized diffuse scattering spectrometer D7*,
    Nuclear Instruments and Methods in Physics Research A **857** (2017) 24–30
    `doi: 10.1016/j.nima.2017.03.024 <https://doi.org/10.1016/j.nima.2017.03.024>`_
 
-#. A. Nakatsuka, A. Yoshiasa, and S. Takeno.
+.. [#Nakatsuka] A. Nakatsuka, A. Yoshiasa, and S. Takeno.
    *Site preference of cations and structural variation in Y3Fe5O12 solid solutions with garnet structure*,
    Acta Crystallographica Section B **51** (1995) 737–745
    `doi: 10.1107/S0108768194014813 <https://doi.org/10.1107/S0108768194014813>`_

--- a/docs/source/algorithms/DetectorEfficiencyCorUser-v1.rst
+++ b/docs/source/algorithms/DetectorEfficiencyCorUser-v1.rst
@@ -27,7 +27,7 @@ The output data will be corrected as:
 
 where :math:`eff` is
 
-:math:`eff = \frac{f(Ei - \Delta E)}{f(E_i)}`
+:math:`eff = \frac{f(E_{i} - \Delta E)}{f(E_i)}`
 
 The function :math:`f` is defined as "formula\_eff" in the IDF. To date
 this has been implemented at the ILL for ILL IN4, IN5 and IN6, and at

--- a/docs/source/algorithms/DetectorEfficiencyCorUser-v1.rst
+++ b/docs/source/algorithms/DetectorEfficiencyCorUser-v1.rst
@@ -42,8 +42,8 @@ accounting for a number of additional instrument specific factors.
 As example, for `TOFTOF <http://www.mlz-garching.de/toftof>`_ instrument, the energy-dependent intensity 
 loss factor accounts also for absorption of neutrons by the Ar gas in the flight chamber, Al windows 
 of sample environment etc.
-The formula used by DetectorEfficiencyCorUser algorithm is derived for TOFTOF in paper of 
-T. Unruh, 2007, doi:10.1016/j.nima.2007.07.015 and is set up in the TOFTOF instrument parameters file. 
+The formula used by DetectorEfficiencyCorUser algorithm is derived for TOFTOF in Ref. [#Unruh]_,
+and is set up in the TOFTOF instrument parameters file.
 
 
 Usage
@@ -83,6 +83,10 @@ Output:
     The correct value in bin 30 is 0.30 compared to 0.30
 
 
+.. [#Unruh] T. Unruh, J. Neuhaus, W. Petry,
+   *The high-resolution time-of-flight spectrometer TOFTOF*,
+   Nuclear Instruments and Methods in Physics Research Section A, **580** (2007), 1414-1422.
+   `doi:101016/jnima200707015 <https://doi.org/10.1016/j.nima.2007.07.015>`_
 
 .. categories::
 

--- a/docs/source/algorithms/DivideMD-v1.rst
+++ b/docs/source/algorithms/DivideMD-v1.rst
@@ -27,7 +27,7 @@ The error of :math:`f = a / b` is propagated with
 
    -  This is not allowed.
 
--  **:ref:`MDEventWorkspace <MDWorkspace>`'s**
+-  :ref:`MDEventWorkspace <MDWorkspace>`'s
 
    -  This operation is not supported, as it is not clear what its
       meaning would be.

--- a/docs/source/algorithms/EnggCalibrateFull-v1.rst
+++ b/docs/source/algorithms/EnggCalibrateFull-v1.rst
@@ -50,7 +50,7 @@ In the output table the calibrated positions for every detector are
 found by calculating the *L2* values from the *DIFC* values as
 follows:
 
-.. math:: L2 = \left(\frac{DIFC} { 252.816 * 2 * sin \left(\frac{2\theta} {2.0}\right)}\right) - 50
+.. math:: L2 = \left(\frac{DIFC} { 252.816 * 2 * \sin \left(\frac{2\theta} {2.0}\right)}\right) - 50
 
 where the *DIFC* values are obtained from the fitting of expected
 peaks. See the algorithm :ref:`algm-EnggFitPeaks` for details on how

--- a/docs/source/algorithms/GenerateEventsFilter-v1.rst
+++ b/docs/source/algorithms/GenerateEventsFilter-v1.rst
@@ -193,11 +193,11 @@ filtering events.
 Double value log
 ================
 
-Let user-specified minimum log value to be :math:`L_{min}`, 
+Let user-specified minimum log value to be :math:`L_{\text{min}}`,
 LogValueTolerance to be :math:`t`, and LogValueInterval to be :math:`\delta`, 
 then the log value intervals are 
 
-.. math:: [L_{min}-t, L_{min}-tol+\delta), [L_{min}-tol+\delta, L_{min}-tol+2\cdot\delta), \cdots
+.. math:: [L_{\text{min}}-t, L_{\text{min}}-tol+\delta), [L_{\text{min}}-tol+\delta, L_{\text{min}}-tol+2\cdot\delta), \cdots
 
 The default value of LogValueTolerance is LogValueInterval divided by 2.
 

--- a/docs/source/algorithms/GenerateEventsFilter-v1.rst
+++ b/docs/source/algorithms/GenerateEventsFilter-v1.rst
@@ -56,10 +56,10 @@ event splitters that are supported by this algorithm.
    the amount of generated event splitters are not huge;
 -  :ref:`MatrixWorkspace <MatrixWorkspace>`: It uses X-axis to store time
    stamp in total nanoseconds and Y-axis to store target workspace. For
-   example, x\_i, x\_i+1 and y\_i construct an event filter as start
-   time is x\_i, stop time is x\_i+1, and target workspace is y\_i-th
-   workspace. If y\_i is less than 0, then it means that all events
-   between time x\_i and x\_i+1 will be discarded. This type of
+   example, :math:`x_{i}, x_{i+1}` and :math:`y_{i}` construct an event filter as start
+   time is :math:`x_{i}`, stop time is :math:`x_{i+1}`, and target workspace is :math:`y_{i}` -th
+   workspace. If :math:`y_{i}` is less than 0, then it means that all events
+   between time :math:`x_{i}` and :math:`x_{i+1}` will be discarded. This type of
    workspace is appropriate for the case that the amount of generated
    event splitters are huge, because processing a
    :ref:`MatrixWorkspace <MatrixWorkspace>` is way faster than a
@@ -95,8 +95,8 @@ this algorithm:
 -  A series filters containing one or multiple time intervals according
    to specified log values incremented by a constant value. Any log
    value of the time that falls into the selected time intervals is
-   equal or within the tolerance of the log value as v\_0 + n x delta\_v
-   +/- tolerance\_v.
+   equal or within the tolerance of the log value as
+   :math:`v_{0}  + n \cdot \Delta_{v} \pm tolerance_{v}`.
 
 .. _filterbytime-GenerateEventFilter-ref:
 

--- a/docs/source/algorithms/GetEi-v2.rst
+++ b/docs/source/algorithms/GetEi-v2.rst
@@ -9,8 +9,7 @@
 Description
 -----------
 
-Uses :math:`E=\frac{1}{2}mv^2`
-to calculate the energy of neutrons leaving the
+Uses :math:`E=\frac{1}{2}mv^2` to calculate the energy of neutrons leaving the
 source. The velocity is calculated from the time it takes for the
 neutron pulse to travel between the two monitors whose spectra were
 specified. If no spectra are specified, the algorithm will use the

--- a/docs/source/algorithms/He3TubeEfficiency-v1.rst
+++ b/docs/source/algorithms/He3TubeEfficiency-v1.rst
@@ -13,13 +13,13 @@ This algorithm corrects the detection efficiency of He3 tubes using an
 exponential function and certain detector properties. The correction
 scheme is given by the following:
 
-:math:`\epsilon = \frac{A}{1-e^{\frac{-\alpha P (L - 2W) \lambda}{T sin(\theta)}}}`
+:math:`\epsilon = \frac{A}{1-e^{\frac{-\alpha P (L - 2W) \lambda}{T \sin(\theta)}}}`
 
 where *A* is a dimensionless scaling factor, :math:`\alpha` is a
-constant with units :math:`(Kelvin / (metres\: \AA\: atm))`, *P* is
+constant with units :math:`(\text{Kelvin} / (\text{metres} \: \AA\: \text{atm}))`, *P* is
 pressure in units of *atm*, *L* is the tube diameter in units of
-*metres*, *W* is the tube thickness in units of *metres*, *T* is the
-temperature in units of *Kelvin*, :math:`sin(\theta)` is the angle
+metres, *W* is the tube thickness in units of metres, *T* is the
+temperature in units of Kelvin, :math:`\sin(\theta)` is the angle
 of the neutron trajectory with respect to the long axis of the He3 tube
 and :math:`\lambda` is in units of :math:`\AA`.
 

--- a/docs/source/algorithms/IntegrateEllipsoids-v1.rst
+++ b/docs/source/algorithms/IntegrateEllipsoids-v1.rst
@@ -187,7 +187,7 @@ For every point on the edge, the trajectory in reciprocal space is a straight li
 Calculate a point at a fixed momentum, say k=1.
 Q in the lab frame:
 
-:math:`\vec{E}=(-k \cdot \sin(\theta) * \cos(\phi), -k \cdot \sin(\theta) \cdot \sin(\phi), k - k \cdot \cos(\phi))`
+:math:`\vec{E}=(-k \cdot \sin(\theta) \cdot \cos(\phi), -k \cdot \sin(\theta) \cdot \sin(\phi), k - k \cdot \cos(\phi))`
 
 Normalize E to 1:
 

--- a/docs/source/algorithms/IntegrateEllipsoids-v1.rst
+++ b/docs/source/algorithms/IntegrateEllipsoids-v1.rst
@@ -187,15 +187,15 @@ For every point on the edge, the trajectory in reciprocal space is a straight li
 Calculate a point at a fixed momentum, say k=1.
 Q in the lab frame:
 
-:math:`\vec{E}=(-k*sin(\theta)*cos(\phi),-k*sin(\theta)*sin(\phi),k-k*cos(\phi))`
+:math:`\vec{E}=(-k \cdot \sin(\theta) * \cos(\phi), -k \cdot \sin(\theta) \cdot \sin(\phi), k - k \cdot \cos(\phi))`
 
 Normalize E to 1:
 
-:math:`\vec{E}=\vec{E}*(1./\left|\vec{E}\right|)`
+:math:`\vec{E}=\vec{E} \cdot (1./\left|\vec{E}\right|)`
 
 The distance from C to OE is given by:
 
-:math:`dv=\vec{C}-\vec{E}*(\vec{C} \cdot \vec{E})`
+:math:`dv=\vec{C}-\vec{E} \cdot (\vec{C} \cdot \vec{E})`
 
 If:
 

--- a/docs/source/algorithms/IntegratePeaksMD-v2.rst
+++ b/docs/source/algorithms/IntegratePeaksMD-v2.rst
@@ -117,15 +117,15 @@ For every point on the edge, the trajectory in reciprocal space is a straight li
 Calculate a point at a fixed momentum, say k=1. 
 Q in the lab frame:
 
-:math:`\vec{E}=(-k*sin(\theta)*cos(\phi),-k*sin(\theta)*sin(\phi),k-k*cos(\phi))`
+:math:`\vec{E}=(-k \cdot \sin(\theta) \cdot \cos(\phi),-k \cdot \sin(\theta) \cdot \sin(\phi),k-k \cdot \cos(\phi))`
 
 Normalize E to 1: 
 
-:math:`\vec{E}=\vec{E}*(1./\left|\vec{E}\right|)`
+:math:`\vec{E}=\vec{E} \cdot (1./\left|\vec{E}\right|)`
 
 The distance from C to OE is given by:
 
-:math:`dv=\vec{C}-\vec{E}*(\vec{C} \cdot \vec{E})`
+:math:`dv=\vec{C}-\vec{E} \cdot (\vec{C} \cdot \vec{E})`
 
 If:
 
@@ -143,13 +143,13 @@ is true and the minimum dv is less than PeakRadius or BackgroundOuterRadius.
 
 For the background if
 
-:math:`\left|dv\right|_{min}<BackgroundOuterRadius` 
+:math:`\left|dv\right|_{\text{min}}<BackgroundOuterRadius`
 
-:math:`h = BackgroundOuterRadius - \left|dv\right|_{min}`
+:math:`h = BackgroundOuterRadius - \left|dv\right|_{\text{min}}`
 
 From the minimum of dv the volume of the cap of the sphere is found:
 
-:math:`V_{cap} = \pi h^2 / 3 (3 * BackgroundOuterRadius - h)`
+:math:`V_{cap} = \pi h^2 / 3 (3 \cdot BackgroundOuterRadius - h)`
 
 The volume of the total sphere is calculated and for the background the volume of the inner radius must be subtracted:
 
@@ -162,15 +162,15 @@ The integrated intensity is multiplied by the ratio of the volume of the sphere 
 
 For the peak assume that the shape is Gaussian.  If
 
-:math:`\left|dv\right|_{min}<PeakRadius`
+:math:`\left|dv\right|_{\text{min}}<PeakRadius`
 
 :math:`\sigma = PeakRadius / 3`
 
-:math:`h = PeakRadius * exp(-\left|dv\right|_{min}^2 / (2 \sigma^2)`
+:math:`h = PeakRadius \cdot \exp(-\left|dv\right|_{min}^2 / (2 \sigma^2)`
 
 From the minimum of dv the volume of the cap of the sphere is found:
 
-:math:`V_{cap} = \pi h^2 / 3 (3 * PeakRadius - h)`
+:math:`V_{cap} = \pi h^2 / 3 (3 \cdot PeakRadius - h)`
 
 and the volume of the sphere is calculated
 

--- a/docs/source/algorithms/LoadVesuvio-v1.rst
+++ b/docs/source/algorithms/LoadVesuvio-v1.rst
@@ -10,10 +10,10 @@ Description
 -----------
 
 The `Vesuvio <http://www.isis.stfc.ac.uk/instruments/vesuvio/vesuvio4837.html>`__ instrument at ISIS produces
-`RAW <http://www.mantidproject.org/Raw File>` files in the standard format. However, due to the unique design
+`RAW <http://www.mantidproject.org/Raw File>`__ files in the standard format. However, due to the unique design
 of the instrument the raw counts from the input files must be manipulated before they are considered useful.
 
-This algorithm wraps calls to :ref:`LoadRaw <algm-LoadRaw>` and computes the counts (:math:`\mu s^{-1}`) using the
+This algorithm wraps calls to :ref:`LoadRaw <algm-LoadRaw>` and computes the counts (:math:`\mu \text{s}^{-1}`) using the
 foil-cycling method described `here <http://m.iopscience.iop.org/0957-0233/23/4/045902/pdf/0957-0233_23_4_045902.pdf>`__.
 
 The output is point data and not a histogram.

--- a/docs/source/algorithms/LorentzCorrection-v1.rst
+++ b/docs/source/algorithms/LorentzCorrection-v1.rst
@@ -19,7 +19,7 @@ The Lorentz correction for time-of-flight single crystal diffraction, ``L``, is 
 Where :math:`\theta` is the scattering angle. For time-of-flight powder diffraction it is calculated according to
 
 .. math::
-   L = \sin{theta}
+   L = \sin{\theta}
 
 The calculations performed in this Algorithm are a subset of those performed by the :ref:`algm-AnvredCorrection` for single crystal measurements
 

--- a/docs/source/algorithms/NormaliseByDetector-v1.rst
+++ b/docs/source/algorithms/NormaliseByDetector-v1.rst
@@ -11,7 +11,7 @@ Description
 
 This algorithm is designed to normalise a workspace via detector
 efficiency functions. **For this algorithm to work, the Instrument
-Definition File :ref:`IDF <InstrumentDefinitionFile>` must have fitting functions on the
+Definition File** (:ref:`IDF<InstrumentDefinitionFile>`) **must have fitting functions on the
 component tree**. The setup information for this, as well as some
 examples, are provided below.
 
@@ -45,7 +45,7 @@ Background
 In brief, the components in the IDF file form a tree structure.
 Detectors and Instruments are both types of component. Detectors are
 ultimately children of Instruments in the tree structure. For a more
-complete description see :ref:`IDF <InstrumentDefinitionFile>`. The tree structure of the
+complete description see :ref:`IDF<InstrumentDefinitionFile>`. The tree structure of the
 components, mean that fitting functions do not necessarily have to be
 assigned on a detector-by-detector basis. Applying a fit function to the
 instrument, will ensure that all subcomponents (including detectors),

--- a/docs/source/algorithms/RefinePowderInstrumentParameters-v3.rst
+++ b/docs/source/algorithms/RefinePowderInstrumentParameters-v3.rst
@@ -14,8 +14,8 @@ diffractomers. The parameters that can be refined are Dtt1, Zero, Dtt1t,
 Dtt2t, Zerot, Width and Tcross.
 
 It serves as the second step to fit/refine instrumental parameters that
-will be introduced in Le Bail Fit. It uses the outcome from algorithm
-FitPowderDiffPeaks().
+will be introduced in Le Bail Fit. It uses the outcome from
+:ref:`FitPowderDiffPeaks <algm-FitPowderDiffPeaks>` algorithm.
 
 
 Introduction

--- a/docs/source/algorithms/RefinePowderInstrumentParameters-v3.rst
+++ b/docs/source/algorithms/RefinePowderInstrumentParameters-v3.rst
@@ -32,10 +32,11 @@ It means that each diffraction peak is a back-to-back exponential,
 
 with peak parameter :math:`A`, :math:`B`, :math:`X_0` and :math:`S`
 
-And their corresponding peak parameters are functions described as 
+And their corresponding peak parameters are functions described as:
+
 .. math::
 
-   n_{cross} = \frac{1}{2} erfc(Width(xcross\cdot d^{-1}))
+   n_{cross} = \frac{1}{2} \text{erfc}(Width(xcross\cdot d^{-1}))
 
    TOF_e = Zero + Dtt1\cdot d
 
@@ -78,13 +79,13 @@ For :math:`\sigma_G` and :math:`\gamma_L`, which represent the standard deviatio
 
 The analysis formula for the convoluted peak at :math:`d_h`
 
-.. math:: \Omega(TOF(d_h)) = (1-\eta(d_h))N\{e^uerfc(y)+e^verfc(z)\} - \frac{2N\eta}{\pi}\{\Im[e^pE_1(p)]+\Im[e^qE_1(q)]\}
+.. math:: \Omega(TOF(d_h)) = (1-\eta(d_h))N\{e^u\text{erfc}(y)+e^v\text{erfc}(z)\} - \frac{2N\eta}{\pi}\{\Im[e^pE_1(p)]+\Im[e^qE_1(q)]\}
 
 where
 
 .. math::
 
-   erfc(x) = 1-erf(x) = 1-\frac{2}{\sqrt{\pi}}\int_0^xe^{-u^2}du
+   \text{erfc}(x) = 1-\text{erf}(x) = 1-\frac{2}{\sqrt{\pi}}\int_0^xe^{-u^2}du
 
    E_1(z) = \int_z^{\infty}\frac{e^{-t}}{t}dt
 
@@ -100,7 +101,7 @@ where
 
    q = -\beta(d_h)x + \frac{i\beta(d_h)H(d_h)}{2}
 
-:math:`erfc(x)` and :math:`E_1(z)` will be calculated numerically.
+:math:`\text{erfc}(x)` and :math:`E_1(z)` will be calculated numerically.
 
 
 Break down the problem
@@ -131,7 +132,7 @@ The function to fit is
 
 with constraint:
 
-.. math:: n = 1/2 erfc(W\cdot (1-Tcross/d))
+.. math:: n = 1/2 \text{erfc}(W\cdot (1-Tcross/d))
 
 The coefficients in this function are strongly correlated to each other.
 

--- a/docs/source/algorithms/SpecularReflectionPositionCorrect-v1.rst
+++ b/docs/source/algorithms/SpecularReflectionPositionCorrect-v1.rst
@@ -13,7 +13,7 @@ Uses the specular reflection condition :math:`\theta_{In} \equiv \theta_{Out}` a
 
 .. math:: 
 
-   2\centerdot\theta = tan^{-1}\left(\frac{UpOffset}{BeamOffset}\right)
+   2\theta = \tan^{-1}\left(\frac{UpOffset}{BeamOffset}\right)
 
 For LineDetectors and MultiDetectors, the algorithm uses an average of
 grouped detector locations to determine the detector position.

--- a/docs/source/algorithms/XrayAbsorptionCorrection-v1.rst
+++ b/docs/source/algorithms/XrayAbsorptionCorrection-v1.rst
@@ -12,8 +12,11 @@ Description
 This algorithm calculates the correction factors due to the absorption of Xrays 
 by the sample. This is done by determining path of an xray from a 
 muon in sample to detector and using the calculated distance travelled by emitted xray in sample to 
-calculate correction factor using 
-.. math:: \exp(-absorptioncoefficient(energy) * distance)
+calculate correction factor using
+
+.. math::
+
+   \exp(-absorptionCoefficient(energy) \cdot distance) .
 
 Input Workspace Requirements
 ############################

--- a/docs/source/algorithms/XrayAbsorptionCorrection-v1.rst
+++ b/docs/source/algorithms/XrayAbsorptionCorrection-v1.rst
@@ -24,11 +24,11 @@ Input Workspace Requirements
 The algorithm will compute the correction factors on a bin-by-bin basis for each spectrum within
 the input workspace. The following assumptions on the input workspace are made:
    
-     - properties of the sample and optionally its environment have been set with :ref:`SetSample <algm-SetSample>`
-	 
-     - Xray Attenuation profile data is provided by using :ref:`SetSampleMaterial <algm-SetSampleMaterial>`
+- properties of the sample and optionally its environment have been set with :ref:`SetSample <algm-SetSample>`
 
-     - Muon Implantation Profile has a single spectrum. The x data is the muon depth in cm and the y data is intensity in counts.
+- Xray Attenuation profile data is provided by using :ref:`SetSampleMaterial <algm-SetSampleMaterial>`
+
+- Muon Implantation Profile has a single spectrum. The x data is the muon depth in cm and the y data is intensity in counts.
 
 Usage
 -----

--- a/docs/source/fitting/fitfunctions/DiffRotDiscreteCircle.rst
+++ b/docs/source/fitting/fitfunctions/DiffRotDiscreteCircle.rst
@@ -34,11 +34,11 @@ the two fundamental fitting parameters of the structure factor
 
 .. math::
 
-   A_l(Q,r) = \frac{1}{N} \sum_{k=1}^{N} j_0( 2 Q r sin(\frac{\pi k}{N}) ) cos(\frac{2\pi lk}{N})
+   A_l(Q,r) = \frac{1}{N} \sum_{k=1}^{N} j_0( 2 Q r \sin(\frac{\pi k}{N}) ) \cos(\frac{2\pi lk}{N})
 
 .. math::
 
-   \tau_l^{-1} = 4 \tau^{-1} sin^2(\frac{\pi l}{N})
+   \tau_l^{-1} = 4 \tau^{-1} \sin^2(\frac{\pi l}{N})
 
 The transition rate, expressed in units of energy is :math:`h\tau^{-1}`,
 with h = 4.135665616 meV ps.

--- a/docs/source/fitting/fitfunctions/EISFDiffCylinder.rst
+++ b/docs/source/fitting/fitfunctions/EISFDiffCylinder.rst
@@ -13,9 +13,9 @@ This fitting function models the diffusion of a particle confined in a
 cylinder of radius :math:`R` and length :math:`L` [1]_.
 
 .. math::
-    A_0(Q_z) = (\frac{j_0(Q R cos(\theta))}{Q R cos(\theta)})^2
-    B_0^0(Q_{\perp}) = (3 \frac{j_1(Q L sin(\theta))}{Q L sin(\theta)})^2
-   \frac{1}{2} \int_0^{\pi} d\theta sin(\theta)
+    A_0(Q_z) = (\frac{j_0(Q R \cos(\theta))}{Q R \cos(\theta)})^2
+    B_0^0(Q_{\perp}) = (3 \frac{j_1(Q L \sin(\theta))}{Q L \sin(\theta)})^2
+   \frac{1}{2} \int_0^{\pi} d\theta \sin(\theta)
 
 :math:`A_0(Q_z)` implements diffusion along the cylinder axis.
 :math:`B_0^0(Q_{\perp})` implements diffusion perpendicular to the cylinder

--- a/docs/source/fitting/fitfunctions/FickDiffusion.rst
+++ b/docs/source/fitting/fitfunctions/FickDiffusion.rst
@@ -13,7 +13,11 @@ Models the Q dependence of the QENS line width (Gamma (hwhm)), diffusion coeffic
 residence times (tau) and jump lengths (l) to extract the associated long range diffusive
 motions of molecules. Fick's law for diffusion has the form:
 
-.. math:: Gamma(Q) = D*Q^2 where D=<l^2>*Q^2/6*tau
+.. math::
+
+   Gamma(Q) = D \cdot Q^{2},
+
+where :math:`D=<l^{2}> \cdot \frac{Q^2}{6} \cdot tau`
 
 .. attributes::
 

--- a/docs/source/fitting/fitfunctions/FickDiffusion.rst
+++ b/docs/source/fitting/fitfunctions/FickDiffusion.rst
@@ -17,7 +17,7 @@ motions of molecules. Fick's law for diffusion has the form:
 
    Gamma(Q) = D \cdot Q^{2},
 
-where :math:`D=<l^{2}> \cdot \frac{Q^2}{6} \cdot tau`
+where :math:`D=\langle l^{2} \rangle \cdot \frac{Q^2}{6} \cdot tau`
 
 .. attributes::
 

--- a/docs/source/fitting/fitfunctions/GramCharlier.rst
+++ b/docs/source/fitting/fitfunctions/GramCharlier.rst
@@ -20,9 +20,9 @@ The function definition is given by:
 
 .. math::
 
-   f(x) = A\frac{exp(-z^2)}{\sqrt{2\pi\sigma^2}}(1 + \frac{C4}{(2^4(4/2)!)}H_4(z) +
+   f(x) = A\frac{\exp(-z^2)}{\sqrt{2\pi\sigma^2}}(1 + \frac{C4}{(2^4(4/2)!)}H_4(z) +
      \frac{C6}{(2^6(6/2)!)}H_6(z) + \frac{C8}{(2^8(8/2)!)}H_8(z) + \frac{C10}{(2^10(10/2)!)}H_{10}(z)) +
-          Afse\frac{\sigma\sqrt{2}}{12\sqrt{2\pi\sigma^2}}exp(-z^2)H_3(z)
+          Afse\frac{\sigma\sqrt{2}}{12\sqrt{2\pi\sigma^2}}\exp(-z^2)H_3(z)
 
 where :math:`z=\frac{(x-X_0)}{\sqrt{2\sigma^2}}`, :math:`H_n(z)` is the nth-order
 `Hermite polynomial <http://mathworld.wolfram.com/HermitePolynomial.html>`_ and the other parameters are

--- a/docs/source/fitting/fitfunctions/HallRoss.rst
+++ b/docs/source/fitting/fitfunctions/HallRoss.rst
@@ -15,13 +15,13 @@ associated long range diffusive motions of molecules.
 
 The Hall-Ross Jump diffusion model [1]_ has the form:
 
-.. math:: Gamma(Q) = \frac{\hbar}{\tau} \cdot (1-exp(-\frac{l^2 Q^2}{2}))
+.. math:: Gamma(Q) = \frac{\hbar}{\tau} \cdot (1-\exp(-\frac{l^2 Q^2}{2}))
 
 Units of :math:`l` are inverse units of :math:`Q`.
 
-Units of :math:`Gamma` are :math:`meV` if units of :math:`\tau` are *ps*.
-Alternatively, units of :math:`Gamma` are :math:`\mu eV` if units of
-:math:`\tau` are *ns*.
+Units of :math:`Gamma` are meV if units of :math:`\tau` are ps.
+Alternatively, units of :math:`Gamma` are :math:`\mu`eV if units of
+:math:`\tau` are ns.
 
 Mean square diffusion jump length :math:`= 3 l^2 \ \AA^2`.
 

--- a/docs/source/fitting/fitfunctions/InelasticDiffRotDiscreteCircle.rst
+++ b/docs/source/fitting/fitfunctions/InelasticDiffRotDiscreteCircle.rst
@@ -23,11 +23,11 @@ type of discrete rotational diffusion in a circle.
 
 .. math::
 
-   A_l(Q,r) = \frac{1}{N} \sum_{k=1}^{N} j_0( 2 Q r sin(\frac{\pi k}{N}) ) cos(\frac{2\pi lk}{N})
+   A_l(Q,r) = \frac{1}{N} \sum_{k=1}^{N} j_0( 2 Q r \sin(\frac{\pi k}{N}) ) \cos(\frac{2\pi lk}{N})
 
 .. math::
 
-   \tau_l^{-1} = 4 \tau^{-1} sin^2(\frac{\pi l}{N})
+   \tau_l^{-1} = 4 \tau^{-1} \sin^2(\frac{\pi l}{N})
 
 with h = 4.135665616 meV ps.
 

--- a/docs/source/fitting/fitfunctions/LogNormal.rst
+++ b/docs/source/fitting/fitfunctions/LogNormal.rst
@@ -11,7 +11,9 @@ Description
 
 The LogNormal fit function is defined by
 
-.. math:: \frac{Height}{x} \cdot exp^{-\frac{ln(x)-Location}{2 \times Scale^2}}
+.. math::
+
+   \frac{Height}{x} \cdot \exp^{-\frac{\ln(x)-Location}{2 \times Scale^2}}
 
 .. attributes::
 

--- a/docs/source/fitting/fitfunctions/Meier.rst
+++ b/docs/source/fitting/fitfunctions/Meier.rst
@@ -23,7 +23,7 @@ Time dependence of the polarization function for a static muon interacting with 
 
 .. math:: W_m = \{(\omega_D+\omega_Q)^2(2m-1)^2+\omega_D^2[J(J+1)-m(m-1)]\}^\frac{1}{2},
 
-.. math:: tan(2\alpha_m)=\frac{\omega_D[J(J+1)-m(m-1)]^\frac{1}{2}}{(1-2m)(\omega_D+\omega_Q)},
+.. math:: \tan(2\alpha_m)=\frac{\omega_D[J(J+1)-m(m-1)]^\frac{1}{2}}{(1-2m)(\omega_D+\omega_Q)},
 
 :math:`\omega_D` is the angular frequency due to dipolar coupling,
 

--- a/docs/source/fitting/fitfunctions/MultivariateGaussianComptonProfile.rst
+++ b/docs/source/fitting/fitfunctions/MultivariateGaussianComptonProfile.rst
@@ -15,10 +15,10 @@ Romanelli. [1]_.
 .. math::
   J(y) = \frac{1}{\sqrt{2\pi} \sigma_{x} \sigma_{y} \sigma_{z}}
          \frac{2}{\pi}
-         \int_{0}^{1} d(cos \theta)
+         \int_{0}^{1} d(\cos \theta)
          \int_{0}^{\frac{\pi}{2}} d \phi
          S^{2}(\theta, \phi)
-         exp
+         \exp
          \left(
            -\frac{y^{2}}
                  {2 S^{2}(\theta, \phi)}
@@ -28,9 +28,9 @@ Where :math:`S^{2}(\theta, \phi)` is given by:
 
 .. math::
   \frac{1}{S^{2}(\theta, \phi)}
-      = \frac{sin^{2}\theta cos^{2}\phi}{\sigma_{x}^{2}}
-      + \frac{sin^{2}\theta sin^{2}\phi}{\sigma_{y}^{2}}
-      + \frac{cos^{2}\theta}{\sigma_{z}^{2}}
+      = \frac{\sin^{2}\theta \cos^{2}\phi}{\sigma_{x}^{2}}
+      + \frac{\sin^{2}\theta \sin^{2}\phi}{\sigma_{y}^{2}}
+      + \frac{\cos^{2}\theta}{\sigma_{z}^{2}}
 
 The :math:`A_{3}` Final State Effects (FSE) correction is applied as an additive
 correction expressed as:
@@ -40,14 +40,14 @@ correction expressed as:
   -A_{3}(q)\frac{d^{3}}{dy^{3}}J(y) =
     \frac{\sigma_{x}^{4} + \sigma_{x}^{4} + \sigma_{x}^{4}}
          {9 \sqrt{2 \pi} \sigma_{x} \sigma_{y} \sigma_{z} q}
-    \int_{0}^{1} d(cos \theta)
+    \int_{0}^{1} d(\cos \theta)
     \int_{0}^{\frac{\pi}{2}} d \phi
     \left[
       \frac{y^{3}}{S^{2}(\theta, \phi)^{4}}
       -3 \frac{y}{S^{2}(\theta, \phi)^{2}}
     \right]
     S^{2}(\theta, \phi)
-    exp
+    \exp
     \left(
       -\frac{y^{2}}
             {2 S^{2}(\theta, \phi)}

--- a/docs/source/fitting/fitfunctions/Voigt.rst
+++ b/docs/source/fitting/fitfunctions/Voigt.rst
@@ -12,7 +12,9 @@ Description
 A Voigt function is a convolution between a Lorentzian and Gaussian and
 is defined as:
 
-.. math:: V(X,Y) = \frac{Y}{\pi}\int_{-\infty}^{+\infty}dz\frac{exp^{-z^2}}{Y^2 + (X - z)^2}
+.. math::
+
+   V(X,Y) = \frac{Y}{\pi}\int_{-\infty}^{+\infty}dz\frac{\exp^{-z^2}}{Y^2 + (X - z)^2},
 
 where
 

--- a/docs/source/techniques/PolarisedDiffractionILL.rst
+++ b/docs/source/techniques/PolarisedDiffractionILL.rst
@@ -83,15 +83,15 @@ Output:
 Wavelength and position calibration
 ===================================
 
-The first step of working with D7 data is to ensure that there exist a proper calibration of the wavelength, bank positions, and detector positions relative to their bank. This calibration can be either taken from a previous experiment performed in comparable conditions or obtained from the :math:`\text{Y}_{3}\text{Fe}_{5}\text{O}_{12}` (YIG) scan data using a dedicated algorithm :ref:`D7YIGPositionCalibration <algm-D7YIGPositionCalibration>`. The method follows the description presented in Ref. [1].
+The first step of working with D7 data is to ensure that there exist a proper calibration of the wavelength, bank positions, and detector positions relative to their bank. This calibration can be either taken from a previous experiment performed in comparable conditions or obtained from the :math:`\text{Y}_{3}\text{Fe}_{5}\text{O}_{12}` (YIG) scan data using a dedicated algorithm :ref:`D7YIGPositionCalibration <algm-D7YIGPositionCalibration>`. The method follows the description presented in Ref. [#Fennell]_.
 
 This algorithm performs wavelength and position calibration for both individual detectors and detector banks using measurement of a sample of powdered YIG. This data is fitted with Gaussian distributions at the expected peak positions. The output is an :ref:`Instrument Parameter File <InstrumentParameterFile>` readable by the :ref:`LoadILLPolarizedDiffraction <algm-LoadILLPolarizedDiffraction>` algorithm that will place the detector banks and detectors using the output of this algorithm.
 
-The provided YIG d-spacing values are loaded from an XML list. The default d-spacing distribution for YIG is coming from Ref. [2]. The peak positions are converted into :math:`2\theta` positions using the initial assumption of the neutron wavelength. YIG peaks in the detector's scan are fitted separately using a Gaussian distribution.
+The provided YIG d-spacing values are loaded from an XML list. The default d-spacing distribution for YIG is coming from Ref. [#Nakatsuka]_. The peak positions are converted into :math:`2\theta` positions using the initial assumption of the neutron wavelength. YIG peaks in the detector's scan are fitted separately using a Gaussian distribution.
 
 The workspace containing the peak fitting results is then fitted using a `Multidomain` function of the form:
 
-.. math:: 2\theta_{fit} = m \cdot (2.0 \cdot \text{asin} ( \lambda / 2d ) + offset_{\text{pixel}} + offset_{\text{bank}}),
+.. math:: 2\theta_{\text{fit}} = m \cdot (2.0 \cdot \text{asin} ( \lambda / 2d ) + offset_{\text{pixel}} + offset_{\text{bank}}),
 
 where `m` is the bank slope, :math:`offset_{\text{pixel}}` is the relative offset to the initial assumption of the position inside the detector bank, and :math:`offset_{\text{bank}}` is the offset of the entire bank. This function allows to extract the information about the wavelength, detector bank slopes and offsets, and the distribution of detector offsets.
 
@@ -589,7 +589,7 @@ normalisation. It is possible to use only one of the possibilities, for example,
 data without the normalisation subroutines to be invoked. This is especially useful for diagnostic purposes.
 
 
-The cross-section separation is done according to formulae presented in Ref. [3-5]. More details on the exact calculations is given in
+The cross-section separation is done according to formulae presented in Ref. [#Sharpf]_ [#Steward]_ [#Ehlers]_. More details on the exact calculations is given in
 documentation of the :ref:`D7AbsoluteCrossSections <algm-D7AbsoluteCrossSections>` algorithm. It is possible to perform uniaxial,
 6-point (or XYZ), and 10-point measurement separation of magnetic, nuclear coherent, and nuclear-spin-incoherent components of the total
 measured scattering cross-section. The specifics of the 10-point measurement as a set of two separate 6-point measurements are taken into account.
@@ -797,27 +797,27 @@ Output:
 References
 ----------
 
-#. T. Fennell, L. Mangin-Thro, H.Mutka, G.J. Nilsen, A.R. Wildes.
+.. [#Fennell] T. Fennell, L. Mangin-Thro, H.Mutka, G.J. Nilsen, A.R. Wildes.
    *Wavevector and energy resolution of the polarized diffuse scattering spectrometer D7*,
    Nuclear Instruments and Methods in Physics Research A **857** (2017) 24–30
    `doi: 10.1016/j.nima.2017.03.024 <https://doi.org/10.1016/j.nima.2017.03.024>`_
 
-#. A. Nakatsuka, A. Yoshiasa, and S. Takeno.
+.. [#Nakatsuka] A. Nakatsuka, A. Yoshiasa, and S. Takeno.
    *Site preference of cations and structural variation in Y3Fe5O12 solid solutions with garnet structure*,
    Acta Crystallographica Section B **51** (1995) 737–745
    `doi: 10.1107/S0108768194014813 <https://doi.org/10.1107/S0108768194014813>`_
 
-#. Scharpf, O. and Capellmann, H.
+.. [#Sharpf] Scharpf, O. and Capellmann, H.
    *The XYZ‐Difference Method with Polarized Neutrons and the Separation of Coherent, Spin Incoherent, and Magnetic Scattering Cross Sections in a Multidetector*
    Physica Status Solidi (A) **135** (1993) 359-379
    `doi: 10.1002/pssa.2211350204 <https://doi.org/10.1002/pssa.2211350204>`_
 
-#. Stewart, J. R. and Deen, P. P. and Andersen, K. H. and Schober, H. and Barthelemy, J.-F. and Hillier, J. M. and Murani, A. P. and Hayes, T. and Lindenau, B.
+.. [#Steward] Stewart, J. R. and Deen, P. P. and Andersen, K. H. and Schober, H. and Barthelemy, J.-F. and Hillier, J. M. and Murani, A. P. and Hayes, T. and Lindenau, B.
    *Disordered materials studied using neutron polarization analysis on the multi-detector spectrometer, D7*
    Journal of Applied Crystallography **42** (2009) 69-84
    `doi: 10.1107/S0021889808039162 <https://doi.org/10.1107/S0021889808039162>`_
 
-#. G. Ehlers, J. R. Stewart, A. R. Wildes, P. P. Deen, and K. H. Andersen
+.. [#Ehlers] G. Ehlers, J. R. Stewart, A. R. Wildes, P. P. Deen, and K. H. Andersen
    *Generalization of the classical xyz-polarization analysis technique to out-of-plane and inelastic scattering*
    Review of Scientific Instruments **84** (2013), 093901
    `doi: 10.1063/1.4819739 <https://doi.org/10.1063/1.4819739>`_


### PR DESCRIPTION
This PR is a result of investigation of Latex and math-mode use in Mantid documentation started by #30679 . The use of roman vs italic characters in math-mode of units and functions has been corrected wherever spotted. Intended use of math in algorithm property descriptions using <math></math> blocks has been replaced with form readable by Sphinx. Spotted issues in references and links have also been corrected.

The one spotted issue that this PR does not address is the observed issue with default parameters for certain dbl list properties that are not broken during creation of restructured text by Sphinx and result in overflowing horizontal dimensions of the document. One of the examples is  [EnggFitPeaks](https://docs.mantidproject.org/nightly/algorithms/EnggFitPeaks-v1.html) algorithm.

List of changes by category is as follows:
1. Corrected algorithm property description:

`GetEi2`, `ConvertToDiffractionMDWorkspace`, `ConvertToMD` 

2. Changed units and functions to roman:

`AnvredCorrection`, `EnggCalibrateFull`, `He3TubeEfficiency`, `IntegrateEllipsoids`, `IntegratePeaksMD`-v2, `LorentzCorrection`, `SpecularReflectionPositionCorrect`, `DiffRotDiscreteCircle`, `EISFDiffCylinder`, `GramCharlier`, `HallRoss`, `InelasticDiffRotDiscreteCircle`, `Meier`, `MultivariateGaussianComptonProfile`, `Voigt`

3. Corrected or improved references to either bibliography or other algorithms:

`D7YIGPositionCalibration`, `DetectorEfficiencyCorUser`, `DivideMD`, `LoadVesuvio`, `NormaliseByDetector`, `RefinePowderInstrumentParameters`, `PolarisedDiffractionILL`

4. Other formatting changes:

`ComputeIncoherentDOS`, `ConvertCWSDExpToMomentum`, `GetEi`-v2, `XrayAbsorptionCorrection`, `FickDiffusion`, `LogNormal`, `GenerateEventsFilter`

**To test:**

1. Build the documentation with docs-html as target
2. Make sure the introduced changes are well formatted and work as described.

<!-- Instructions for testing. -->

Fixes #30704. 

*This does not require release notes* because it is a change of formatting of math mode and corrections of typos in documentation.

<!-- Ensure the base of this PR is correct (e.g. release-next or master)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
