### PR TITLE
SCD221 add optional UB calculation in SCDCalibratePanels2 (master)

### DIFF
--- a/Framework/Crystal/inc/MantidCrystal/SCDCalibratePanels2.h
+++ b/Framework/Crystal/inc/MantidCrystal/SCDCalibratePanels2.h
@@ -68,6 +68,9 @@ private:
   void parseLatticeConstant(
       std::shared_ptr<Mantid::DataObjects::PeaksWorkspace> pws);
 
+  /// Update the UB matrix
+  void updateUBMatrix(std::shared_ptr<Mantid::DataObjects::PeaksWorkspace> pws);
+
   /// Private function for getting names of banks to be calibrated
   void getBankNames(std::shared_ptr<Mantid::DataObjects::PeaksWorkspace> pws);
 

--- a/Framework/Crystal/src/SCDCalibratePanels2.cpp
+++ b/Framework/Crystal/src/SCDCalibratePanels2.cpp
@@ -55,7 +55,8 @@ void SCDCalibratePanels2::init() {
   // Lattice constant group
   auto mustBePositive = std::make_shared<BoundedValidator<double>>();
   mustBePositive->setLower(0.0);
-  declareProperty("RecalculateUB", true);
+  declareProperty("RecalculateUB", true,
+                  "Recalculate UB matrix using given lattice constants");
   declareProperty("a", EMPTY_DBL(), mustBePositive,
                   "Lattice Parameter a (Leave empty to use lattice constants "
                   "in peaks workspace)");
@@ -188,6 +189,22 @@ std::map<std::string, std::string> SCDCalibratePanels2::validateInputs() {
   if (calibrateT0)
     issues["CalibrateT0"] = "Caliration of T0 is not ready for production, "
                             "please set it to False to continue";
+
+  // Lattice constants are required if no UB is attached to the input
+  // peak workspace
+  PeaksWorkspace_sptr pws = getProperty("PeakWorkspace");
+  double a = getProperty("a");
+  double b = getProperty("b");
+  double c = getProperty("c");
+  double alpha = getProperty("alpha");
+  double beta = getProperty("beta");
+  double gamma = getProperty("gamma");
+  if ((a == EMPTY_DBL() || b == EMPTY_DBL() || c == EMPTY_DBL() ||
+       alpha == EMPTY_DBL() || beta == EMPTY_DBL() || gamma == EMPTY_DBL()) &&
+      (!pws->sample().hasOrientedLattice())) {
+    issues["RecalculateUB"] = "Lattice constants are needed for peak "
+                              "workspace without a UB mattrix";
+  }
 
   return issues;
 }

--- a/Framework/Crystal/src/SCDCalibratePanels2ObjFunc.cpp
+++ b/Framework/Crystal/src/SCDCalibratePanels2ObjFunc.cpp
@@ -143,8 +143,8 @@ void SCDCalibratePanels2ObjFunc::function1D(double *out, const double *xValues,
     V3D hkl =
         V3D(boost::math::iround(pk.getH()), boost::math::iround(pk.getK()),
             boost::math::iround(pk.getL()));
-    if (hkl == UNSET_HKL)
-      throw std::runtime_error("Found unindexed peak in input workspace!");
+    // if (hkl == UNSET_HKL)
+    //   throw std::runtime_error("Found unindexed peak in input workspace!");
 
     // construct the out vector (Qvectors)
     Units::Wavelength wl;

--- a/Framework/Crystal/test/SCDCalibratePanels2Test.h
+++ b/Framework/Crystal/test/SCDCalibratePanels2Test.h
@@ -497,8 +497,8 @@ private:
     sub_alg->initialize();
     sub_alg->setLogging(LOGCHILDALG);
     sub_alg->setProperty("Workspace", wsname);
-    sub_alg->setProperty("u", "1,0,0");
-    sub_alg->setProperty("v", "0,1,0");
+    sub_alg->setProperty("u", "0.5,0.8660254037844387,0");
+    sub_alg->setProperty("v", "-0.8660254037844387,0.5,0");
     sub_alg->setProperty("a", silicon_a);
     sub_alg->setProperty("b", silicon_b);
     sub_alg->setProperty("c", silicon_c);

--- a/docs/source/release/v6.1.0/diffraction.rst
+++ b/docs/source/release/v6.1.0/diffraction.rst
@@ -32,5 +32,6 @@ Improvements
 ############
 - :ref:`IntegratePeaksMD <algm-IntegratePeaksMD>` now allows ellipsoidal shapes to be manually defined for the PeakRadius and Background radii options.
 - :ref:`SNSPowderReduction <algm-SNSPowderReduction>` now check if previous container is created using the same method before reusing it.
+- :ref:`SCDCalibratePanels <algm-SCDCalibratePanels-v2>` now update attached UB matrix with given lattice constants (optional).
 
 :ref:`Release 6.1.0 <v6.1.0>`


### PR DESCRIPTION
**Description of work.**

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

Current `SCDCalibratePanels` (version 2) does not utilize the input lattice constants to update the UB matrix attached to the input peak workspace.
This PR addresses this issue and make the update UB optional in case the user would like to use a fixed UB matrix for the calibration process.
Here is a screenshot of the new interface
 
![image](https://user-images.githubusercontent.com/5064852/108127439-3ce61f00-7079-11eb-8a4c-0afa3d82d05b.png)

> - Related Gitlab task [SCD214](https://code.ornl.gov/sns-hfir-scse/diffraction/single-crystal/single-crystal-diffraction/-/issues/214)  
> - This is #30711 into `master`

**To test:**

Use the following code in MantidWorkbench to test `SCDCalibratePanels` (v2)
```python
# necessary import
import numpy as np
from collections import namedtuple
from mantid.simpleapi import *


def convert(dictionary):
    return namedtuple('GenericDict', dictionary.keys())(**dictionary)


import os
directory = os.path.dirname(os.path.realpath(__file__))
lc_natrolite = {
    "a": 18.29,  # A
    "b": 18.64,  # A
    "c": 6.56,  # A
    "alpha": 90,  # deg
    "beta": 90,  # deg
    "gamma": 90,  # deg
}
natrolite = convert(lc_natrolite)
pws = LoadIsawPeaks('data/Natrolite_runs_133752_133812.peaks')

SCDCalibratePanels(
    PeakWorkspace='pws',
    a=natrolite.a,
    b=natrolite.b,
    c=natrolite.c,
    alpha=natrolite.alpha,
    beta=natrolite.beta,
    gamma=natrolite.gamma,
    CalibrateT0=False,
    CalibrateL1=True,
    CalibrateBanks=True,
    OutputWorkspace="testCaliTable",
    DetCalFilename=directory + "/test.DetCal",
    CSVFilename=directory + "/test.csv",
    XmlFilename=directory + "/test.xml",
    ToleranceOfTranslation=0.0005,
    ToleranceOfReorientation=0.05,
    TranslationSearchRadius=0.05,
    RotationSearchRadius=5,
    SourceShiftSearchRadius=0.1,
    VerboseOutput=True,
)
```

> - testing data: [data.tar.gz](https://github.com/mantidproject/mantid/files/5991908/data.tar.gz)

<!-- Instructions for testing. -->

Fixes #30712. <!-- and fix #xxxx or close #xxxx xor resolves #xxxx -->
<!-- alternative
*There is no associated issue.*
-->

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or master)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
