### PR TITLE
Ignore .h5 files from generic Load system test

### DIFF
--- a/Testing/SystemTests/tests/framework/LoadLotsOfFiles.py
+++ b/Testing/SystemTests/tests/framework/LoadLotsOfFiles.py
@@ -62,7 +62,6 @@ BANNED_FILES = ['80_tubes_Top_and_Bottom_April_2015.xml',
                 'PG3_11485-1.dat',  # Generic load doesn't do very well with ASCII files
                 'PG3_char_2020_05_06-HighRes-PAC_1.4_MW.txt',
                 'PG3_char_2020_01_04_PAC_limit_1.4MW.txt',
-                'PG3_PAC_HR_d46168_2020_05_06.h5', # loaded by a different algorithm
                 'PG3_2538_event.nxs',  # Don't need to check all of the PG3 files
                 'PG3_9829_event.nxs',
                 'REF_M_9684_event.nxs',
@@ -144,7 +143,8 @@ BANNED_REGEXP = [r'SANS2D\d+.log$',
                  r'.*_pulseid\.dat',
                  r'.*\.phonon',
                  r'.*\.cif',
-                 r'.*\.toml']
+                 r'.*\.toml',
+                 r'.*\.h5']
 
 BANNED_DIRS = ["DocTest", "UnitTest", "reference"]
 


### PR DESCRIPTION
**Description of work.**

Ignores `.h5` files from generic Load system test. They are loaded by specialist algorithms so Load will not work with them.

**To test:**

* Code review

*There is no associated issue.*

*This does not require release notes* because **it affects an internal test**

<!-- Ensure the base of this PR is correct (e.g. release-next or master)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
