### PR TITLE
Disable log scale if non-positive data in Sliceviewer

### DIFF
--- a/docs/source/release/v6.1.0/mantidworkbench.rst
+++ b/docs/source/release/v6.1.0/mantidworkbench.rst
@@ -14,5 +14,6 @@ Bugfixes
 - Display Debug and Information messages generated during workbench start up
 - The background shell of spherical and elliptical peaks is now correctly plotted when viewing slices that do not cut through the peak center
 - For the elliptical shell of integrated peaks, the background is correct when plotting with varying background thicknesses
+- Fixed a bug which occurred when switching to a log scale in sliceviewer with negative data.
 
 :ref:`Release 6.1.0 <v6.1.0>`

--- a/qt/python/mantidqt/widgets/colorbar/colorbar.py
+++ b/qt/python/mantidqt/widgets/colorbar/colorbar.py
@@ -18,7 +18,7 @@ from matplotlib.colors import Normalize, SymLogNorm, PowerNorm, LogNorm
 from matplotlib import cm
 import numpy as np
 from qtpy.QtWidgets import QWidget, QVBoxLayout, QHBoxLayout, QLineEdit, QComboBox, QCheckBox, QLabel
-from qtpy.QtCore import Signal
+from qtpy.QtCore import Signal, Qt
 from qtpy.QtGui import QDoubleValidator
 
 NORM_OPTS = ["Linear", "Log", "SymmetricLog10", "Power"]
@@ -319,14 +319,20 @@ class ColorbarWidget(QWidget):
         return Normalize(vmin=cmin, vmax=cmax)
 
     def _validate_mappable(self, mappable):
+        index = NORM_OPTS.index("Log")
         if mappable.get_array() is not None:
             if np.any(mappable.get_array() <= 0):
-                self.norm.model().item(NORM_OPTS.index("Log"), 0).setEnabled(False)
+                self.norm.model().item(index, 0).setEnabled(False)
+                self.norm.setItemData(index, "Log scale is disabled for non-positive data",
+                                      Qt.ToolTipRole)
                 if isinstance(mappable.norm, LogNorm):
                     mappable.norm = self._create_linear_normalize_object()
                     self.norm.blockSignals(True)
                     self.norm.setCurrentIndex(0)
                     self.norm.blockSignals(False)
             else:
-                self.norm.model().item(NORM_OPTS.index("Log"), 0).setEnabled(True)
+                if not self.norm.model().item(index, 0).isEnabled():
+                    self.norm.model().item(index, 0).setEnabled(True)
+                    self.norm.setItemData(index, "", Qt.ToolTipRole)
+
         return mappable

--- a/qt/python/mantidqt/widgets/sliceviewer/test/test_sliceviewer_view.py
+++ b/qt/python/mantidqt/widgets/sliceviewer/test/test_sliceviewer_view.py
@@ -12,10 +12,12 @@ import unittest
 from unittest.mock import patch
 
 import matplotlib as mpl
+from matplotlib.colors import Normalize
 from numpy import hstack
 
 mpl.use('Agg')
 from mantidqt.widgets.colorbar.colorbar import MIN_LOG_VALUE  # noqa: E402
+from mantidqt.widgets.sliceviewer.view import SCALENORM  # noqa: E402
 from mantid.simpleapi import (  # noqa: E402
     CreateMDHistoWorkspace, CreateMDWorkspace, CreateSampleWorkspace, DeleteWorkspace,
     FakeMDEventData, ConvertToDistribution, Scale, SetUB, RenameWorkspace)
@@ -26,6 +28,19 @@ from mantidqt.widgets.sliceviewer.presenter import SliceViewer  # noqa: E402
 from mantidqt.widgets.sliceviewer.toolbar import ToolItemText  # noqa: E402
 from qtpy.QtWidgets import QApplication  # noqa: E402
 from math import inf  # noqa: E402
+
+
+class MockConfig(object):
+    def get(self, name):
+        if name == SCALENORM:
+            return "Log"
+
+    def set(self, name):
+        pass
+
+    def has(self, name):
+        if name == SCALENORM:
+            return True
 
 
 @start_qapplication
@@ -40,6 +55,14 @@ class SliceViewerViewTest(unittest.TestCase, QtWidgetFinder):
                                               Names='Dim1,Dim2,Dim3',
                                               Units='MomentumTransfer,EnergyTransfer,Angstrom',
                                               OutputWorkspace='ws_MD_2d')
+        cls.histo_ws_positive = CreateMDHistoWorkspace(Dimensionality=3,
+                                                       Extents='-3,3,-10,10,-1,1',
+                                                       SignalInput=range(1, 101),
+                                                       ErrorInput=range(100),
+                                                       NumberOfBins='5,5,4',
+                                                       Names='Dim1,Dim2,Dim3',
+                                                       Units='MomentumTransfer,EnergyTransfer,Angstrom',
+                                                       OutputWorkspace='ws_MD_2d_pos')
         cls.hkl_ws = CreateMDWorkspace(Dimensions=3,
                                        Extents='-10,10,-9,9,-8,8',
                                        Names='A,B,C',
@@ -104,6 +127,7 @@ class SliceViewerViewTest(unittest.TestCase, QtWidgetFinder):
         pres.view.close()
 
     def test_clim_edits_prevent_negative_values_if_lognorm(self):
+
         pres = SliceViewer(self.histo_ws)
         colorbar = pres.view.data_view.colorbar
         colorbar.autoscale.setChecked(False)
@@ -119,8 +143,22 @@ class SliceViewerViewTest(unittest.TestCase, QtWidgetFinder):
 
         pres.view.close()
 
+    def test_norm_switches_if_workspace_contains_non_positive_data(self):
+        conf = MockConfig()
+        pres = SliceViewer(self.histo_ws, conf=conf)
+        colorbar = pres.view.data_view.colorbar
+        self.assertTrue(isinstance(colorbar.get_norm(), Normalize))
+        pres.view.close()
+
+    def test_log_norm_disabled_for_non_positive_data(self):
+        conf = MockConfig()
+        pres = SliceViewer(self.histo_ws, conf=conf)
+        colorbar = pres.view.data_view.colorbar
+        self.assertFalse(colorbar.norm.model().item(1, 0).isEnabled())
+        pres.view.close()
+
     def test_changing_norm_updates_clim_validators(self):
-        pres = SliceViewer(self.histo_ws)
+        pres = SliceViewer(self.histo_ws_positive)
         colorbar = pres.view.data_view.colorbar
         colorbar.autoscale.setChecked(False)
 
@@ -288,6 +326,7 @@ class SliceViewerViewTest(unittest.TestCase, QtWidgetFinder):
         pres.view.data_view.plot_matrix(ws)
 
         self.assertEqual(pres.view.data_view.get_axes_limits()[0], (xmin, xmax))
+
 
 # private helper functions
 


### PR DESCRIPTION
**Description of work.**
This PR fixes a bug with Sliceviewer and log scales for non-positive data.


**To test:**
Create 3 workspaces using the following script:
```
data_x = np.array([[1, 2, 3, 4, 5],[1, 2, 3, 4, 5]])
data_y = np.array([[-4, -5, -9, -10],[-1, 2, -3, 4]])
ws = CreateWorkspace(DataX=data_x, DataY=data_y, NSpec=2)
data_y = np.array([[5,9,10,11],[1,2,3,4]])
ws_pos = CreateWorkspace(DataX=data_x, DataY=data_y, NSpec=2)
mdws = CreateMDWorkspace(Dimensions=3, Extents='-10,10,-10,10,-10,10', Names='A,B,C', Units='U,U,U')
```
First open Sliceviewer on the `ws_pos` and switch to a log scale. Close this and open sliceviewer on `mdws`, you should notice that it switches to a linear scale and the log option should be disabled. The same should hold true for the workspace `ws`.

<!-- Instructions for testing. -->


Fixes #30707 . <!-- and fix #xxxx or close #xxxx xor resolves #xxxx -->
<!-- alternative
*There is no associated issue.*
-->


<!-- Ensure the base of this PR is correct (e.g. release-next or master)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
