### PR TITLE
Update curve labels when a workspace is renamed

### DIFF
--- a/docs/source/release/v6.1.0/mantidworkbench.rst
+++ b/docs/source/release/v6.1.0/mantidworkbench.rst
@@ -9,6 +9,7 @@ New and Improved
 ----------------
 
 - It is now possible to overplot bin data from the matrix workspace view.
+- When a workspace is renamed it now updates the relevant plot labels with the new workspace name.
 
 Bugfixes
 --------

--- a/qt/applications/workbench/workbench/plotting/figuremanager.py
+++ b/qt/applications/workbench/workbench/plotting/figuremanager.py
@@ -12,6 +12,7 @@ import copy
 from distutils.version import LooseVersion
 import io
 import sys
+import re
 from functools import wraps
 import matplotlib
 from matplotlib._pylab_helpers import Gcf
@@ -41,6 +42,10 @@ from workbench.plotting.figurewindow import FigureWindow
 from workbench.plotting.plotscriptgenerator import generate_script
 from workbench.plotting.toolbar import WorkbenchNavigationToolbar, ToolbarStateManager
 from workbench.plotting.plothelppages import PlotHelpPages
+
+
+def _replace_workspace_name_in_string(old_name, new_name, string):
+    return re.sub(rf'\b{old_name}\b', new_name, string)
 
 
 def _catch_exceptions(func):
@@ -137,17 +142,18 @@ class FigureManagerADSObserver(AnalysisDataServiceObserver):
         :param oldName: The old name of the workspace.
         :param newName: The new name of the workspace
         """
-
         for ax in self.canvas.figure.axes:
             if isinstance(ax, MantidAxes):
                 ws = AnalysisDataService.retrieve(newName)
                 if isinstance(ws, MatrixWorkspace):
-                    for ws_name in list(ax.tracked_workspaces.keys()):
-                        # loop over list as items is iterable of object that is changed (throws error)
-                        if ws_name == oldName:
-                            ax.tracked_workspaces[newName] = ax.tracked_workspaces.pop(oldName)
+                    ax.rename_workspace_artists(newName, oldName)
                 elif isinstance(ws, ITableWorkspace):
                     ax.wsName = newName
+                ax.make_legend()
+            ax.set_title(_replace_workspace_name_in_string(oldName, newName, ax.get_title()))
+        self.canvas.set_window_title(
+            _replace_workspace_name_in_string(oldName, newName, self.canvas.get_window_title()))
+        self.canvas.draw()
 
 
 class FigureManagerWorkbench(FigureManagerBase, QObject):


### PR DESCRIPTION
**Description of work.**
This PR implements a method to re-label a plot when a workspace is renamed in the ADS. 


**To test:**
- Load some data
- Make a 1d plot
- Rename the workspace
- Things should update on the plot (legend, title)
- Try this multiple times for different plots/ different data. It should work
<!-- Instructions for testing. -->

Fixes #29947.


<!-- Ensure the base of this PR is correct (e.g. release-next or master)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
