### PR TITLE
Output Bk2bkexp params to PRM file

### DIFF
--- a/docs/source/release/v6.1.0/diffraction.rst
+++ b/docs/source/release/v6.1.0/diffraction.rst
@@ -44,6 +44,11 @@ Bugfixes
 Engineering Diffraction
 -----------------------
 
+Improvements
+############
+
+- BackToBackExponential fitting parameters read from .xml file and output to .prm file for GSAS-II.
+
 Single Crystal Diffraction
 --------------------------
 - New version of algorithm :ref:`SCDCalibratePanels <algm-SCDCalibratePanels-v2>` provides more accurate calibration results for CORELLI instrument.

--- a/instrument/ENGIN-X_Parameters.xml
+++ b/instrument/ENGIN-X_Parameters.xml
@@ -1,28 +1,84 @@
 <?xml version="1.0" encoding="UTF-8" ?>
+
+<!--If North and South banks require different Bk2Bk params,
+the create a distinct ENTITY for each bank-->
+
+<!DOCTYPE parameter-file [
+        <!ENTITY alpha "0.0968">
+        <!ENTITY beta_0 "0.0216">
+        <!ENTITY beta_1 "0.0123">
+        <!ENTITY sigma_0_sq "0.0">
+        <!ENTITY sigma_1_sq "82.1321">
+        <!ENTITY sigma_2_sq "42.5988">
+]>
+
 <parameter-file instrument="ENGIN-X" valid-from="2020-10-23">
 
+
 <component-link name="NorthBank" >
+
+  <parameter name="alpha" type="number">
+    <value val="&alpha;" />
+  </parameter>
+  <parameter name="beta_0" type="number">
+    <value val="&beta_0;" />
+  </parameter>
+  <parameter name="beta_1" type="number">
+    <value val="&beta_1;" />
+  </parameter>
+  <parameter name="sigma_0_sq" type="number">
+    <value val="&sigma_0_sq;" />
+  </parameter>
+  <parameter name="sigma_1_sq" type="number">
+    <value val="&sigma_1_sq;" />
+  </parameter>
+  <parameter name="sigma_2_sq" type="number">
+    <value val="&sigma_2_sq;" />
+  </parameter>
+
   <parameter name="BackToBackExponential:S" type="fitting">
-    <formula eq="sqrt(42.5988*centre^4+82.1321*centre^2)" unit="dSpacing" result-unit="TOF" />
-  </parameter> 
+    <formula eq="sqrt((&sigma_2_sq;)*centre^4+(&sigma_1_sq;)*centre^2+(&sigma_0_sq;))" unit="dSpacing" result-unit="TOF" />
+  </parameter>
   <parameter name="BackToBackExponential:A" type="fitting">
-    <formula eq="(0.0968/centre)" unit="dSpacing" result-unit="1/TOF" /> <fixed />
-  </parameter>   
+    <formula eq="((&alpha;)/centre)" unit="dSpacing" result-unit="1/TOF" /> <fixed />
+  </parameter>
   <parameter name="BackToBackExponential:B" type="fitting">
-    <formula eq="(0.0216+0.0123/(centre^4))" unit="dSpacing" result-unit="1/TOF" /> <fixed />
-  </parameter>  
+    <formula eq="((&beta_0;)+(&beta_1;)/(centre^4))" unit="dSpacing" result-unit="1/TOF" /> <fixed />
+  </parameter>
+
 </component-link>
 
 <component-link name="SouthBank" >
+
+  <parameter name="alpha" type="number">
+    <value val="&alpha;" />
+  </parameter>
+  <parameter name="beta_0" type="number">
+    <value val="&beta_0;" />
+  </parameter>
+  <parameter name="beta_1" type="number">
+    <value val="&beta_1;" />
+  </parameter>
+  <parameter name="sigma_0_sq" type="number">
+    <value val="&sigma_0_sq;" />
+  </parameter>
+  <parameter name="sigma_1_sq" type="number">
+    <value val="&sigma_1_sq;" />
+  </parameter>
+  <parameter name="sigma_2_sq" type="number">
+    <value val="&sigma_2_sq;" />
+  </parameter>
+
   <parameter name="BackToBackExponential:S" type="fitting">
-    <formula eq="sqrt(42.5988*centre^4+82.1321*centre^2)" unit="dSpacing" result-unit="TOF" />
-  </parameter> 
+    <formula eq="sqrt((&sigma_2_sq;)*centre^4+(&sigma_1_sq;)*centre^2+(&sigma_0_sq;))" unit="dSpacing" result-unit="TOF" />
+  </parameter>
   <parameter name="BackToBackExponential:A" type="fitting">
-    <formula eq="(0.0968/centre)" unit="dSpacing" result-unit="1/TOF" /> <fixed />
-  </parameter>   
+    <formula eq="((&alpha;)/centre)" unit="dSpacing" result-unit="1/TOF" /> <fixed />
+  </parameter>
   <parameter name="BackToBackExponential:B" type="fitting">
-    <formula eq="(0.0216+0.0123/(centre^4))" unit="dSpacing" result-unit="1/TOF" /> <fixed />
-  </parameter>  
+    <formula eq="((&beta_0;)+(&beta_1;)/(centre^4))" unit="dSpacing" result-unit="1/TOF" /> <fixed />
+  </parameter>
+
 </component-link>
 
 </parameter-file>

--- a/scripts/Engineering/gui/engineering_diffraction/tabs/calibration/test/test_calib_model.py
+++ b/scripts/Engineering/gui/engineering_diffraction/tabs/calibration/test/test_calib_model.py
@@ -63,16 +63,16 @@ class CalibrationModelTest(unittest.TestCase):
                                              output_files, update_table, setting, path):
         path.return_value = True
         setting.return_value = "mocked/out/path"
-        van_corr.return_value = ("mocked_integration", "mocked_curves")
-        load_workspace.return_value = "mocked_workspace"
-        load_ascii.return_value = "mocked_det_pos"
+        mocked_integration = MagicMock()
+        mocked_curves = MagicMock()
+        van_corr.return_value = (mocked_integration, mocked_curves)
         self.model.create_new_calibration(VANADIUM_NUMBER, CERIUM_NUMBER, False, "ENGINX")
-        calibrate_alg.assert_called_with("mocked_workspace",
-                                         "mocked_integration",
-                                         "mocked_curves",
+        calibrate_alg.assert_called_with(load_workspace.return_value,
+                                         mocked_integration,
+                                         mocked_curves,
                                          None,
                                          None,
-                                         full_calib_ws="mocked_det_pos")
+                                         full_calib_ws=load_ascii.return_value)
 
     @patch(class_path + '.update_calibration_params_table')
     @patch(class_path + '.create_output_files')
@@ -174,6 +174,7 @@ class CalibrationModelTest(unittest.TestCase):
         output_name.return_value = filename
 
         self.model.create_output_files("test/", [2, 2], [0, 0], [1, 1],
+                                       [[0, 1, 2, 3, 4, 5], [0, 1, 2, 3, 4, 5]],
                                        sample_path,
                                        vanadium_path,
                                        "ENGINX",
@@ -183,6 +184,7 @@ class CalibrationModelTest(unittest.TestCase):
         self.assertEqual(make_dirs.call_count, 1)
         self.assertEqual(write_file.call_count, 3)
         write_file.assert_called_with("test/" + filename, [2], [0], [1],
+                                      [[0, 1, 2, 3, 4, 5], [0, 1, 2, 3, 4, 5]],
                                       bank_names=['South'],
                                       ceria_run="20",
                                       template_file="template_ENGINX_241391_236516_South_bank.prm",


### PR DESCRIPTION
**Description of work.**

The BackToBackExponential parameters in the ENGINX_Parameters.xml file (alpha, beta_0, beta_1, sigma_0_sq, sigma_1_sq, sigma_2_sq) have been separated so they can be accessed from an associated workspace. These are then set in our output .prm file for GSAS-II

The parameters set in instrument/ENGIN-X_Parameters.xml are set in the prm file as the four values on line "INS  xPRCF11" and the first two values on line "INS  xPRCF12" (the last two values on this line are namely gamma_0 and gamma_1). The output file is generated by replacing lines in a template file: scripts/Engineering/template_ENGINX_241391_236516_North_and_South_banks.prm

**To test:**

To create the output prm files, you simply need to run a calibration ([Test 1 in manual testing](https://developer.mantidproject.org/Testing/EngineeringDiffraction/EngineeringDiffractionTestGuide.html#test-1)).

- Check the values on the first six values across lines "PRCF11" and "PRCF12" are set according to the values in instrument/ENGIN-X_Parameters.xml. Check that gamma_0 and gamma_1 (last two values on line PRCF12) are preserved from the scripts/Engineering/template_ENGINX_241391_236516_North_and_South_banks.prm file

- Also check that fitting a BackToBackExponential peak still works:
    - Outside of the Engineering Diffraction interface, Load some ENGINX data from the archive (say ENGINX193749) 
    - then plot the first spectrum and click the Fit toolbar button
    - right-click and set peak type to `BackToBackExponential`
    - add a peak to the plot (DO NOT FIT!)
    - In the fit property browser, click the triangle to drop-down the list of initial parameters for the fit. If A = 1.0 and B = 0.05 these are the WRONG values. They should be around A ~ 0.2 and B ~0.02. 

Fixes #30289

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
