### PR TITLE
Improved FileFinder Search Speed

### DIFF
--- a/docs/source/api/python/mantid/api/FileFinderImpl.rst
+++ b/docs/source/api/python/mantid/api/FileFinderImpl.rst
@@ -1,3 +1,5 @@
+.. _mantid.api.FileFinderImpl:
+
 ================
  FileFinderImpl
 ================

--- a/docs/source/release/v6.1.0/framework.rst
+++ b/docs/source/release/v6.1.0/framework.rst
@@ -24,7 +24,7 @@ Data Objects
 ------------
 
 - :ref:`Run <mantid.api.Run>` has been modified to allow multiple goniometers to be stored.
-- :ref:`FileFinder <mantid.api.FileFinderImpl>` has been modified to improve search times in some cases.
+- :ref:`FileFinder <mantid.api.FileFinderImpl>` has been modified to improve search times when loading multiple runs on the same instrument.
 
 Python
 ------

--- a/docs/source/release/v6.1.0/framework.rst
+++ b/docs/source/release/v6.1.0/framework.rst
@@ -24,6 +24,7 @@ Data Objects
 ------------
 
 - :ref:`Run <mantid.api.Run>` has been modified to allow multiple goniometers to be stored.
+- :ref:`FileFinder <mantid.api.FileFinderImpl>` has been modified to improve search times in some cases.
 
 Python
 ------

--- a/qt/scientific_interfaces/Muon/CMakeLists.txt
+++ b/qt/scientific_interfaces/Muon/CMakeLists.txt
@@ -191,7 +191,7 @@ mtd_add_qt_library(TARGET_NAME MantidScientificInterfacesMuon
                      ${JSONCPP_LIBRARIES}
                    MTD_QT_LINK_LIBS
                      MantidQtWidgetsCommon
-     		     MantidQtWidgetsMplCpp
+                     MantidQtWidgetsMplCpp
                      MantidQtWidgetsPlotting
                    INSTALL_DIR_BASE
                      ${WORKBENCH_PLUGINS_DIR}


### PR DESCRIPTION
**Description of work.**
When searching for multiple runs, added a check to see if the file exists using the current run number and the previous path and extension. This provides a great speed benefit particularly if the runs are stored on the archive in one directory, which is the most common use case, by limiting calls made to the web api.

**To test:**
I have been using this script for testing. But you should see overall improvements when loading runs in interfaces as well (default instrument EMU)
```
# Worst case every file in different directory 
archive_search_10_dirs = "70993, 72589, 74374, 76366, 78873, 83480, 86490, 88127, 91955, 95162" 

# Baseline
ten_archive_files = "70993-71003" 

# Some cases interfaces would like to load in hundreds of runs and were limited by long search times
one_hundred_archive_files = "70993-71093" 
two_hundred_archive_files = "70993-71193" 

# I have also been testing local files but you will need to set this up yourself

n_times = 3 # how many times to run the search
average = 0

for i in range(1, n_times+1):
    start = time.time()
    runs = FileFinder.findRuns(hintstr=one_hundred_archive_files) # Add in what you are searching for here as the parameter hintstr
    end = time.time()
    print("Elapsed time {}: {} seconds".format(i, end-start))
    average += end-start

print("Average time: {}".format(average/n_times))
```

Fixes #30408 

These are the results from my own testing with and without the changes from this PR:
```
Without Changes:
10 files in 10 different archive directories* - 
	Elapsed time 1 2.343200445175171 seconds
	Elapsed time 2 2.2812581062316895 seconds
	Elapsed time 3 2.296821117401123 seconds
	Average time 2.3070932229359946
10 files in 10 different local directories - 
	Elapsed time 1 0.12475180625915527 seconds
	Elapsed time 2 0.01560068130493164 seconds
	Elapsed time 3 0.03126859664916992 seconds
	Average time 0.05720702807108561
10 files in 1 archive directory -
	Elapsed time 1 2.7340285778045654 seconds
	Elapsed time 2 2.5316970348358154 seconds
	Elapsed time 3 2.7501251697540283 seconds
	Average time 2.6719502607981362
10 files in 1 local directory - 
	Elapsed time 1 0.0156552791595459 seconds
	Elapsed time 2 0.0 seconds
	Elapsed time 3 0.015536069869995117 seconds
	Average time 0.010397116343180338
100 files in 1 archive directory - 
	Elapsed time 1 24.585033178329468 seconds
	Elapsed time 2 25.843957901000977 seconds
	Elapsed time 3 26.253194093704224 seconds
	Average time 25.560728391011555
200 files in 1 archive directory - 
	Elapsed time 1 49.61705946922302 seconds
	Elapsed time 2 49.03502941131592 seconds
	Elapsed time 3 48.783374547958374 seconds
	Average time 49.14515447616577

With Changes:
10 files in 10 different archive directories* - 
	Elapsed time 1 2.342933416366577 seconds
	Elapsed time 2 2.2974653244018555 seconds
	Elapsed time 3 2.2344136238098145 seconds
	Average time 2.2916041215260825
10 files in 10 different local directories - 
	Elapsed time 1 0.062261104583740234 seconds
	Elapsed time 2 0.031131982803344727 seconds
	Elapsed time 3 0.04710721969604492 seconds
	Average time 0.046833435694376625
10 files in 1 archive directory - 
	Elapsed time 1 0.3748657703399658 seconds
	Elapsed time 2 0.2499403953552246 seconds
	Elapsed time 3 0.20333147048950195 seconds
	Average time 0.2760458787282308
10 files in 1 local directory - 
	Elapsed time 1 0.10909771919250488 seconds
	Elapsed time 2 0.0 seconds
	Elapsed time 3 0.0 seconds
	Average time 0.036365906397501625
100 files in 1 archive directory - 
	Elapsed time 1 0.5618562698364258 seconds
	Elapsed time 2 0.266071081161499 seconds
	Elapsed time 3 0.2651832103729248 seconds
	Average time 0.3643701871236165
200 files in 1 archive directory - 
	Elapsed time 1 0.7649815082550049 seconds
	Elapsed time 2 0.2968416213989258 seconds
	Elapsed time 3 0.31253862380981445 seconds
	Average time 0.45812058448791504
* Using (EMU 70993, 72589, 74374, 76366, 78873, 83480, 86490, 88127, 91955, 95162)
```
---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
