### PR TITLE
Fix FitScriptGeneratorStartupTest on Ubuntu

### DIFF
--- a/qt/python/mantidqt/_common.sip
+++ b/qt/python/mantidqt/_common.sip
@@ -1,4 +1,5 @@
 %ModuleCode
+#include "MantidQtWidgets/Common/FittingMode.h"
 #include "MantidQtWidgets/Common/Message.h"
 #include "MantidQtWidgets/Common/WorkspaceObserver.h"
 #include "MantidPythonInterface/core/VersionCompat.h"
@@ -1074,16 +1075,7 @@ public:
 // FittingMode
 // ----------------------------------------------------------------------------
 
-namespace MantidQt
-{
-namespace MantidWidgets
-{
-%TypeHeaderCode
-#include "MantidQtWidgets/Common/FittingMode.h"
-%End
-enum FittingMode {SIMULTANEOUS, SEQUENTIAL, SIMULTANEOUS_SEQUENTIAL};
-};
-};
+enum class FittingMode {SEQUENTIAL, SIMULTANEOUS, SEQUENTIAL_AND_SIMULTANEOUS};
 
 // ----------------------------------------------------------------------------
 // FitScriptGeneratorView
@@ -1096,7 +1088,7 @@ class FitScriptGeneratorView : QWidget {
 public:
     FitScriptGeneratorView(
         QWidget *parent = nullptr,
-        MantidQt::MantidWidgets::FittingMode fittingMode = MantidQt::MantidWidgets::SEQUENTIAL,
+        FittingMode fittingMode = FittingMode::SEQUENTIAL,
         const QMap<QString, QString> &fitOptions = QMap<QString, QString>()) /KeywordArgs="All"/;
 };
 

--- a/qt/python/mantidqt/widgets/fitscriptgenerator/__init__.py
+++ b/qt/python/mantidqt/widgets/fitscriptgenerator/__init__.py
@@ -6,7 +6,7 @@
 # SPDX - License - Identifier: GPL - 3.0 +
 from mantidqt.utils.qt import import_qt
 
-FittingMode = import_qt('..._common', 'mantidqt.widgets.fitscriptgenerator').MantidQt.MantidWidgets.FittingMode
+FittingMode = import_qt('..._common', 'mantidqt.widgets.fitscriptgenerator', 'FittingMode')
 
 FitScriptGeneratorView = import_qt('..._common', 'mantidqt.widgets.fitscriptgenerator', 'FitScriptGeneratorView')
 FitScriptGeneratorModel = import_qt('..._common', 'mantidqt.widgets.fitscriptgenerator', 'FitScriptGeneratorModel')

--- a/qt/python/mantidqt/widgets/test/test_fittingmode.py
+++ b/qt/python/mantidqt/widgets/test/test_fittingmode.py
@@ -1,0 +1,32 @@
+# Mantid Repository : https://github.com/mantidproject/mantid
+#
+# Copyright &copy; 2021 ISIS Rutherford Appleton Laboratory UKRI,
+#   NScD Oak Ridge National Laboratory, European Spallation Source,
+#   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+# SPDX - License - Identifier: GPL - 3.0 +
+#  This file is part of the mantid workbench.
+import unittest
+
+from mantidqt.widgets.fitscriptgenerator import FittingMode
+from testhelpers import assertRaisesNothing
+
+
+class FittingModeTest(unittest.TestCase):
+
+    def test_that_FittingMode_has_been_exported_to_python_correctly(self):
+        assertRaisesNothing(self, self._create_sequential_fitting_mode)
+        assertRaisesNothing(self, self._create_simultaneous_fitting_mode)
+        assertRaisesNothing(self, self._create_sequential_and_simultaneous_fitting_mode)
+
+    def _create_sequential_fitting_mode(self):
+        return FittingMode.SEQUENTIAL
+
+    def _create_simultaneous_fitting_mode(self):
+        return FittingMode.SIMULTANEOUS
+
+    def _create_sequential_and_simultaneous_fitting_mode(self):
+        return FittingMode.SEQUENTIAL_AND_SIMULTANEOUS
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/qt/scientific_interfaces/Indirect/IndirectFitPropertyBrowser.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectFitPropertyBrowser.cpp
@@ -79,7 +79,7 @@ void IndirectFitPropertyBrowser::initFitOptionsBrowser() {
   // which is a child of this class so the lifetime of this pointer is handled
   // by Qt
   m_fitOptionsBrowser =
-      new FitOptionsBrowser(nullptr, FittingMode::SIMULTANEOUS_SEQUENTIAL);
+      new FitOptionsBrowser(nullptr, FittingMode::SEQUENTIAL_AND_SIMULTANEOUS);
   m_fitOptionsBrowser->setObjectName("fitOptionsBrowser");
   m_fitOptionsBrowser->setCurrentFittingType(FittingMode::SEQUENTIAL);
 }

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/FittingMode.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/FittingMode.h
@@ -9,10 +9,10 @@
 namespace MantidQt {
 namespace MantidWidgets {
 
-enum FittingMode {
-  SIMULTANEOUS = 0,
-  SEQUENTIAL = 1,
-  SIMULTANEOUS_SEQUENTIAL = 2
+enum class FittingMode {
+  SEQUENTIAL,
+  SIMULTANEOUS,
+  SEQUENTIAL_AND_SIMULTANEOUS
 };
 
 } // namespace MantidWidgets

--- a/qt/widgets/common/src/FitOptionsBrowser.cpp
+++ b/qt/widgets/common/src/FitOptionsBrowser.cpp
@@ -41,6 +41,24 @@
 #include <QVBoxLayout>
 #include <limits>
 
+namespace {
+using namespace MantidQt::MantidWidgets;
+
+int getFittingModeInt(FittingMode fitMode) {
+  switch (fitMode) {
+  case FittingMode::SIMULTANEOUS:
+    return 0;
+  case FittingMode::SEQUENTIAL:
+    return 1;
+  case FittingMode::SEQUENTIAL_AND_SIMULTANEOUS:
+    return 2;
+  default:
+    return 1;
+  }
+}
+
+} // namespace
+
 namespace MantidQt {
 namespace MantidWidgets {
 
@@ -118,7 +136,7 @@ void FitOptionsBrowser::initFittingTypeProp() {
   types << "Simultaneous"
         << "Sequential";
   m_enumManager->setEnumNames(m_fittingTypeProp, types);
-  if (m_fittingType == FittingMode::SIMULTANEOUS_SEQUENTIAL) {
+  if (m_fittingType == FittingMode::SEQUENTIAL_AND_SIMULTANEOUS) {
     m_browser->addProperty(m_fittingTypeProp);
   } else if (m_fittingType == FittingMode::SIMULTANEOUS ||
              m_fittingType == FittingMode::SEQUENTIAL) {
@@ -133,11 +151,11 @@ void FitOptionsBrowser::createProperties() {
   initFittingTypeProp();
   createCommonProperties();
   if (m_fittingType == FittingMode::SIMULTANEOUS ||
-      m_fittingType == FittingMode::SIMULTANEOUS_SEQUENTIAL) {
+      m_fittingType == FittingMode::SEQUENTIAL_AND_SIMULTANEOUS) {
     createSimultaneousFitProperties();
   }
   if (m_fittingType == FittingMode::SEQUENTIAL ||
-      m_fittingType == FittingMode::SIMULTANEOUS_SEQUENTIAL) {
+      m_fittingType == FittingMode::SEQUENTIAL_AND_SIMULTANEOUS) {
     createSequentialFitProperties();
   }
 }
@@ -726,7 +744,7 @@ FittingMode FitOptionsBrowser::getCurrentFittingType() const {
  *    Simultaneous for Fit and Sequential for PlotPeakByLogValue.
  */
 void FitOptionsBrowser::setCurrentFittingType(FittingMode fitType) {
-  m_enumManager->setValue(m_fittingTypeProp, fitType);
+  m_enumManager->setValue(m_fittingTypeProp, getFittingModeInt(fitType));
 }
 
 /**
@@ -735,7 +753,7 @@ void FitOptionsBrowser::setCurrentFittingType(FittingMode fitType) {
  * @param fitType :: Fitting type to lock the browser in.
  */
 void FitOptionsBrowser::lockCurrentFittingType(FittingMode fitType) {
-  m_enumManager->setValue(m_fittingTypeProp, fitType);
+  m_enumManager->setValue(m_fittingTypeProp, getFittingModeInt(fitType));
   m_fittingTypeProp->setEnabled(false);
 }
 

--- a/qt/widgets/common/src/FitScriptGeneratorModel.cpp
+++ b/qt/widgets/common/src/FitScriptGeneratorModel.cpp
@@ -466,7 +466,7 @@ void FitScriptGeneratorModel::setGlobalParameters(
 }
 
 void FitScriptGeneratorModel::setFittingMode(FittingMode fittingMode) {
-  if (fittingMode == FittingMode::SIMULTANEOUS_SEQUENTIAL)
+  if (fittingMode == FittingMode::SEQUENTIAL_AND_SIMULTANEOUS)
     throw std::invalid_argument(
         "Fitting mode must be SEQUENTIAL or SIMULTANEOUS.");
 

--- a/qt/widgets/common/src/FitScriptGeneratorView.cpp
+++ b/qt/widgets/common/src/FitScriptGeneratorView.cpp
@@ -67,7 +67,7 @@ FitScriptGeneratorView::FitScriptGeneratorView(
       m_dataTable(std::make_unique<FitScriptGeneratorDataTable>()),
       m_functionTreeView(std::make_unique<FunctionTreeView>(nullptr, true)),
       m_fitOptionsBrowser(std::make_unique<FitOptionsBrowser>(
-          nullptr, FittingMode::SIMULTANEOUS_SEQUENTIAL)) {
+          nullptr, FittingMode::SEQUENTIAL_AND_SIMULTANEOUS)) {
   m_ui.setupUi(this);
 
   m_ui.fDataTable->layout()->addWidget(m_dataTable.get());
@@ -145,7 +145,7 @@ void FitScriptGeneratorView::setFitBrowserOptions(
 }
 
 void FitScriptGeneratorView::setFittingMode(FittingMode fittingMode) {
-  if (fittingMode == FittingMode::SIMULTANEOUS_SEQUENTIAL)
+  if (fittingMode == FittingMode::SEQUENTIAL_AND_SIMULTANEOUS)
     throw std::invalid_argument(
         "Fitting mode must be SEQUENTIAL or SIMULTANEOUS.");
 

--- a/qt/widgets/common/test/FitScriptGeneratorModelTest.h
+++ b/qt/widgets/common/test/FitScriptGeneratorModelTest.h
@@ -621,7 +621,7 @@ public:
 
   void test_that_setFittingMode_will_throw_if_given_an_invalid_fitting_mode() {
     TS_ASSERT_THROWS(
-        m_model->setFittingMode(FittingMode::SIMULTANEOUS_SEQUENTIAL),
+        m_model->setFittingMode(FittingMode::SEQUENTIAL_AND_SIMULTANEOUS),
         std::invalid_argument const &);
   }
 


### PR DESCRIPTION
**Description of work.**
This PR fixes the FitScriptGeneratorStartupTest on ubuntu by avoiding the use of namespaces in the sip file. This required the FittingMode to be changed to an enum class.

**To test:**
Run the `FitScriptGeneratorStartupTest` system test in an ubuntu setup and make sure it is successful.

*There is no associated issue.*
*Release notes are not required as this is an internal change.*

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
