### PR TITLE
Add plot interaction for removing legend and opening plot config

### DIFF
--- a/docs/source/release/v6.1.0/mantidworkbench.rst
+++ b/docs/source/release/v6.1.0/mantidworkbench.rst
@@ -7,6 +7,7 @@ Mantid Workbench Changes
 
 New and Improved
 ----------------
+- New plot interactions: Double click a legend to hide it, double click a curve to open it in the plot config dialog.
 
 - It is now possible to overplot bin data from the matrix workspace view.
 

--- a/qt/applications/workbench/workbench/plotting/figureinteraction.py
+++ b/qt/applications/workbench/workbench/plotting/figureinteraction.py
@@ -283,7 +283,7 @@ class FigureInteraction(object):
                 if remove_legend_flag:
                     action_taken = True
                     legend = ax.get_legend()
-                    legend.setVisible(False)
+                    legend.set_visible(False)
                     canvas.draw()
 
         return action_taken

--- a/qt/applications/workbench/workbench/plotting/figureinteraction.py
+++ b/qt/applications/workbench/workbench/plotting/figureinteraction.py
@@ -289,8 +289,18 @@ class FigureInteraction(object):
         return action_taken
 
     def _show_plot_options(self, event):
+        if not event.inaxes:
+            return
+
         axes = event.inaxes
-        self.fig_manager.launch_plot_options_on_curves_tab(axes)
+        clicked_curve = None
+        for curve in axes.lines:
+            if curve.contains(event)[0]:
+                clicked_curve = curve
+                break
+
+        # Launch with the first curve that contains the event
+        self.fig_manager.launch_plot_options_on_curves_tab(axes, clicked_curve)
 
     def _show_markers_menu(self, markers, event):
         """

--- a/qt/applications/workbench/workbench/plotting/figureinteraction.py
+++ b/qt/applications/workbench/workbench/plotting/figureinteraction.py
@@ -261,10 +261,18 @@ class FigureInteraction(object):
                 legend_set_draggable(ax.get_legend(), False)
                 legend_texts = ax.get_legend().get_texts()
                 active_lines = datafunctions.get_legend_handles(ax)
+
+                remove_legend_flag = True  # remove the legend if no curve texts were clicked
                 for legend_text, curve in zip(legend_texts, active_lines):
                     if legend_text.contains(event)[0]:
+                        remove_legend_flag = False
                         move_and_show(LegendEditor(canvas, legend_text, curve))
                 legend_set_draggable(ax.get_legend(), True)
+
+                if remove_legend_flag:
+                    legend = ax.get_legend()
+                    legend.setVisible(False)
+                    canvas.draw()
 
     def _show_markers_menu(self, markers, event):
         """

--- a/qt/applications/workbench/workbench/plotting/figureinteraction.py
+++ b/qt/applications/workbench/workbench/plotting/figureinteraction.py
@@ -75,11 +75,12 @@ class FigureInteraction(object):
         :param fig_manager: A reference to the figure manager containing the
         canvas that receives the events
         """
+        self.fig_manager = fig_manager
         # Check it looks like a FigureCanvasQT
-        if not hasattr(fig_manager.canvas, "buttond"):
+        if not hasattr(self.fig_manager.canvas, "buttond"):
             raise RuntimeError("Figure canvas does not look like a Qt canvas.")
 
-        canvas = fig_manager.canvas
+        canvas = self.fig_manager.canvas
         self._cids = []
         self._cids.append(canvas.mpl_connect('button_press_event', self.on_mouse_button_press))
         self._cids.append(canvas.mpl_connect('button_release_event', self.on_mouse_button_release))
@@ -93,7 +94,7 @@ class FigureInteraction(object):
         self.canvas = canvas
         self.toolbar_manager = ToolbarStateManager(self.canvas.toolbar)
         self.toolbar_manager.home_button_connect(self.redraw_annotations)
-        self.fit_browser = fig_manager.fit_browser
+        self.fit_browser = self.fig_manager.fit_browser
         self.errors_manager = FigureErrorsManager(self.canvas)
         self.markers = []
         self.valid_lines = VALID_LINE_STYLE
@@ -155,7 +156,8 @@ class FigureInteraction(object):
                 self._show_markers_menu(marker_selected, event)
         elif event.dblclick and event.button == canvas.buttond.get(Qt.LeftButton):
             if not marker_selected:
-                self._show_axis_editor(event)
+                if not self._show_axis_editor(event):
+                    self._show_plot_options(event)
             elif len(marker_selected) == 1:
                 self._edit_marker(marker_selected[0])
         elif event.button == canvas.buttond.get(Qt.MiddleButton):
@@ -223,13 +225,22 @@ class FigureInteraction(object):
             marker.mouse_move_stop()
 
     def _show_axis_editor(self, event):
+        """
+        Decides whether to show a dialog to edit axis information based on the contents of the
+        event. Shows a dialog if necessary.
+        @param event: the object representing the event
+        @return: a flag to denote whether an action was taken e.g. opening a dialog.
+        """
         # We assume this is used for editing axis information e.g. labels
         # which are outside of the axes so event.inaxes is no use.
         canvas = self.canvas
         figure = canvas.figure
         axes = figure.get_axes()
+        action_taken = False
 
         def move_and_show(editor):
+            nonlocal action_taken
+            action_taken = True
             editor.move(QCursor.pos())
             editor.exec_()
 
@@ -270,9 +281,16 @@ class FigureInteraction(object):
                 legend_set_draggable(ax.get_legend(), True)
 
                 if remove_legend_flag:
+                    action_taken = True
                     legend = ax.get_legend()
                     legend.setVisible(False)
                     canvas.draw()
+
+        return action_taken
+
+    def _show_plot_options(self, event):
+        axes = event.inaxes
+        self.fig_manager.launch_plot_options_on_curves_tab(axes)
 
     def _show_markers_menu(self, markers, event):
         """

--- a/qt/applications/workbench/workbench/plotting/figuremanager.py
+++ b/qt/applications/workbench/workbench/plotting/figuremanager.py
@@ -331,12 +331,9 @@ class FigureManagerWorkbench(FigureManagerBase, QObject):
     def launch_plot_options(self):
         self.plot_options_dialog = PlotConfigDialogPresenter(self.canvas.figure, parent=self.window)
 
-    def launch_plot_options_on_curves_tab(self, axes):
+    def launch_plot_options_on_curves_tab(self, axes, curve):
         self.plot_options_dialog = PlotConfigDialogPresenter(self.canvas.figure, parent=self.window)
-        try:
-            self.plot_options_dialog.activate_curves_tab(axes)
-        except ValueError:
-            pass
+        self.plot_options_dialog.focus_and_configure_curves_tab(axes, curve)
 
     def launch_plot_help(self):
         PlotHelpPages.show_help_page_for_figure(self.canvas.figure)

--- a/qt/applications/workbench/workbench/plotting/figuremanager.py
+++ b/qt/applications/workbench/workbench/plotting/figuremanager.py
@@ -333,7 +333,7 @@ class FigureManagerWorkbench(FigureManagerBase, QObject):
 
     def launch_plot_options_on_curves_tab(self, axes, curve):
         self.plot_options_dialog = PlotConfigDialogPresenter(self.canvas.figure, parent=self.window)
-        self.plot_options_dialog.focus_and_configure_curves_tab(axes, curve)
+        self.plot_options_dialog.configure_curves_tab(axes, curve)
 
     def launch_plot_help(self):
         PlotHelpPages.show_help_page_for_figure(self.canvas.figure)

--- a/qt/applications/workbench/workbench/plotting/figuremanager.py
+++ b/qt/applications/workbench/workbench/plotting/figuremanager.py
@@ -331,6 +331,13 @@ class FigureManagerWorkbench(FigureManagerBase, QObject):
     def launch_plot_options(self):
         self.plot_options_dialog = PlotConfigDialogPresenter(self.canvas.figure, parent=self.window)
 
+    def launch_plot_options_on_curves_tab(self, axes):
+        self.plot_options_dialog = PlotConfigDialogPresenter(self.canvas.figure, parent=self.window)
+        try:
+            self.plot_options_dialog.activate_curves_tab(axes)
+        except ValueError:
+            pass
+
     def launch_plot_help(self):
         PlotHelpPages.show_help_page_for_figure(self.canvas.figure)
 

--- a/qt/python/mantidqt/widgets/plotconfigdialog/curvestabwidget/presenter.py
+++ b/qt/python/mantidqt/widgets/plotconfigdialog/curvestabwidget/presenter.py
@@ -421,3 +421,19 @@ class CurvesTabWidgetPresenter:
         else:
             self.view.enable_curve_config(True)
             self.set_errorbars_tab_enabled()
+
+    def set_axes_combo_from_ax_object(self, axes_to_set):
+        """
+        Given the axes object, sets the selected index of the axes combo
+        to be the index corresponding to this object.
+        """
+        axes_index_to_set = None
+        for index, axes in enumerate(self.axes_names_dict.values()):
+            if axes_to_set == axes:
+                axes_index_to_set = index
+                break
+
+        if axes_index_to_set is None:  # could be 0, incorrectly raising error.
+            raise ValueError("Axes object does not exist in curves tab. There may be no curves on these axes.")
+
+        self.view.select_axes_combo_box.setCurrentIndex(axes_index_to_set)

--- a/qt/python/mantidqt/widgets/plotconfigdialog/curvestabwidget/presenter.py
+++ b/qt/python/mantidqt/widgets/plotconfigdialog/curvestabwidget/presenter.py
@@ -422,18 +422,35 @@ class CurvesTabWidgetPresenter:
             self.view.enable_curve_config(True)
             self.set_errorbars_tab_enabled()
 
-    def set_axes_combo_from_ax_object(self, axes_to_set):
+    def set_axes_from_object(self, axes_to_set):
         """
         Given the axes object, sets the selected index of the axes combo
         to be the index corresponding to this object.
         """
-        axes_index_to_set = None
+        index_to_set = None
         for index, axes in enumerate(self.axes_names_dict.values()):
             if axes_to_set == axes:
-                axes_index_to_set = index
+                index_to_set = index
                 break
 
-        if axes_index_to_set is None:  # could be 0, incorrectly raising error.
-            raise ValueError("Axes object does not exist in curves tab. There may be no curves on these axes.")
+        if index_to_set is None:  # could be 0, incorrectly raising error.
+            raise ValueError("Axes object does not exist in curves tab")
 
-        self.view.select_axes_combo_box.setCurrentIndex(axes_index_to_set)
+        self.view.select_axes_combo_box.setCurrentIndex(index_to_set)
+
+    def set_curve_from_object(self, curve_to_set):
+        """
+        Given the curve object, sets the selected index of the curves list
+        to be the index corresponding to this object.
+        """
+        index_to_set = None
+        for index, curve in enumerate(self.curve_names_dict.values()):
+            if curve_to_set == curve:
+                index_to_set = index
+                break
+
+        if index_to_set is None:
+            raise ValueError("Curve object does not exist in curves tab")
+
+        self.view.select_curve_list.setCurrentRow(index_to_set)
+        self.view.select_curve_list.item(index_to_set).setSelected(True)

--- a/qt/python/mantidqt/widgets/plotconfigdialog/curvestabwidget/test/test_curvestabwidgetpresenter.py
+++ b/qt/python/mantidqt/widgets/plotconfigdialog/curvestabwidget/test/test_curvestabwidgetpresenter.py
@@ -473,7 +473,7 @@ class CurvesTabWidgetPresenterTest(unittest.TestCase):
         # line should be index 1 in the curves list
         mock_view.select_curve_list.setCurrentRow.assert_called_with(1)
 
-    def test_set_curve_from_object_when_multiple_curves_exist_on_fig(self):
+    def test_set_axes_from_object_raises_error_when_curve_not_found(self):
         fig, axes = subplots(2, subplot_kw={'projection': 'mantid'})
         axes[0].plot(self.ws, specNum=1, label='Workspace')
         mock_view = Mock(get_selected_ax_name=lambda: "(0, 0)",

--- a/qt/python/mantidqt/widgets/plotconfigdialog/curvestabwidget/test/test_curvestabwidgetpresenter.py
+++ b/qt/python/mantidqt/widgets/plotconfigdialog/curvestabwidget/test/test_curvestabwidgetpresenter.py
@@ -436,6 +436,53 @@ class CurvesTabWidgetPresenterTest(unittest.TestCase):
             args, kwargs = presenter.view.update_fields.call_args
             self.assertEqual(args[0].errorevery, 7)
 
+    def test_set_axes_from_object_when_multiple_axes_exist_on_fig(self):
+        fig, axes = subplots(2, subplot_kw={'projection': 'mantid'})
+        axes[0].plot(self.ws, specNum=1, label='Workspace')
+        axes[1].plot(self.ws, specNum=1, label='Workspace')
+        mock_view = Mock(get_selected_ax_name=lambda: "(0, 0)",
+                         get_current_curve_name=lambda: "Workspace")
+        presenter = self._generate_presenter(fig=fig, mock_view=mock_view)
+
+        presenter.set_axes_from_object(axes[1])
+
+        # ax1 should be index 1 in the axes combo
+        mock_view.select_axes_combo_box.setCurrentIndex.assert_called_with(1)
+
+    def test_set_axes_from_object_raises_error_when_axes_not_found(self):
+        fig, axes = subplots(2, subplot_kw={'projection': 'mantid'})
+        axes[0].plot(self.ws, specNum=1, label='Workspace')
+        axes[1].plot(self.ws, specNum=1, label='Workspace')
+        mock_view = Mock(get_selected_ax_name=lambda: "(0, 0)",
+                         get_current_curve_name=lambda: "Workspace")
+        presenter = self._generate_presenter(fig=fig, mock_view=mock_view)
+
+        with self.assertRaises(ValueError):
+            presenter.set_axes_from_object(None)
+
+    def test_set_curve_from_object_when_multiple_curves_exist_on_fig(self):
+        fig = self.make_figure_with_multiple_curves()
+        ax0 = fig.get_axes()[0]
+        curve1 = ax0.lines[1]
+        mock_view = Mock(get_selected_ax_name=lambda: "Axes 0: (0, 0)",
+                         get_current_curve_name=lambda: "Workspace")
+        presenter = self._generate_presenter(fig=fig, mock_view=mock_view)
+
+        presenter.set_curve_from_object(curve1)
+
+        # line should be index 1 in the curves list
+        mock_view.select_curve_list.setCurrentRow.assert_called_with(1)
+
+    def test_set_curve_from_object_when_multiple_curves_exist_on_fig(self):
+        fig, axes = subplots(2, subplot_kw={'projection': 'mantid'})
+        axes[0].plot(self.ws, specNum=1, label='Workspace')
+        mock_view = Mock(get_selected_ax_name=lambda: "(0, 0)",
+                         get_current_curve_name=lambda: "Workspace")
+        presenter = self._generate_presenter(fig=fig, mock_view=mock_view)
+
+        with self.assertRaises(ValueError):
+            presenter.set_curve_from_object(None)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/qt/python/mantidqt/widgets/plotconfigdialog/presenter.py
+++ b/qt/python/mantidqt/widgets/plotconfigdialog/presenter.py
@@ -109,17 +109,26 @@ class PlotConfigDialogPresenter:
                 self.tab_widget_presenters[index] = None
                 return
 
-    def activate_curves_tab(self, axes):
+    def focus_and_configure_curves_tab(self, axes, curve):
         curves_tab_presenter = self.tab_widget_presenters[2]
         if not curves_tab_presenter:
             return
         curves_tab_widget, _ = self.tab_widget_views[1]
 
         try:
-            curves_tab_presenter.set_axes_combo_from_ax_object(axes)
-        except ValueError:
-            # The axes was not found in the curves tab widget. This can happen when there are no
-            # curves on the given axes. Return and do not set the current tab to be the curves tab.
-            return
+            curves_tab_presenter.set_axes_from_object(axes)
+        except ValueError as err:
+            if str(err) == "Axes object does not exist in curves tab":
+                # This can happen when there are no curves on the given axes.
+                return
+            raise err
 
         self.view.set_current_tab_widget(curves_tab_widget)
+
+        if curve:
+            try:
+                curves_tab_presenter.set_curve_from_object(curve)
+            except ValueError as err:
+                if str(err) == "Curve object does not exist in curves tab":
+                    return
+                raise err

--- a/qt/python/mantidqt/widgets/plotconfigdialog/presenter.py
+++ b/qt/python/mantidqt/widgets/plotconfigdialog/presenter.py
@@ -108,3 +108,18 @@ class PlotConfigDialogPresenter:
             if presenter == tab_presenter:
                 self.tab_widget_presenters[index] = None
                 return
+
+    def activate_curves_tab(self, axes):
+        curves_tab_presenter = self.tab_widget_presenters[2]
+        if not curves_tab_presenter:
+            return
+        curves_tab_widget, _ = self.tab_widget_views[1]
+
+        try:
+            curves_tab_presenter.set_axes_combo_from_ax_object(axes)
+        except ValueError:
+            # The axes was not found in the curves tab widget. This can happen when there are no
+            # curves on the given axes. Return and do not set the current tab to be the curves tab.
+            return
+
+        self.view.set_current_tab_widget(curves_tab_widget)

--- a/qt/python/mantidqt/widgets/plotconfigdialog/presenter.py
+++ b/qt/python/mantidqt/widgets/plotconfigdialog/presenter.py
@@ -109,7 +109,7 @@ class PlotConfigDialogPresenter:
                 self.tab_widget_presenters[index] = None
                 return
 
-    def focus_and_configure_curves_tab(self, axes, curve):
+    def configure_curves_tab(self, axes, curve):
         curves_tab_presenter = self.tab_widget_presenters[2]
         if not curves_tab_presenter:
             return

--- a/qt/python/mantidqt/widgets/plotconfigdialog/test/test_plotconfigdialogpresenter.py
+++ b/qt/python/mantidqt/widgets/plotconfigdialog/test/test_plotconfigdialogpresenter.py
@@ -11,7 +11,7 @@ from unittest.mock import Mock, call, patch
 
 from matplotlib import use as mpl_use
 mpl_use('Agg')  # noqa
-from matplotlib.pyplot import figure
+from matplotlib.pyplot import figure, subplots
 
 from mantidqt.widgets.plotconfigdialog.presenter import PlotConfigDialogPresenter
 
@@ -201,6 +201,61 @@ class PlotConfigDialogPresenterTest(unittest.TestCase):
 
         self.assertTrue(mock_curves_presenter not in presenter.tab_widget_presenters)
         self.assertTrue((mock_curves_view, 'Curves') not in presenter.tab_widget_views)
+
+    def test_configure_curves_tab_fails_silently_when_curves_tab_not_exists(self):
+        fig = figure()
+        ax = fig.add_subplot(111)
+        mock_view = Mock()
+        presenter = PlotConfigDialogPresenter(fig, mock_view)
+        self.assertIsNone(presenter.tab_widget_presenters[2])
+
+        presenter.configure_curves_tab(ax, None)
+
+        mock_view.set_current_tab_widget.assert_not_called()
+
+    def test_configure_curves_tab_fails_silently_when_no_curves_on_axes(self):
+        fig, (ax0, ax1) = subplots(2, subplot_kw={'projection': 'mantid'})
+        ax0.plot([0], [0])  # One axes must have a curve for curves tab to exist
+        mock_view = Mock()
+        presenter = PlotConfigDialogPresenter(fig, mock_view)
+        mock_curves_presenter = presenter.tab_widget_presenters[2]
+        mock_curves_presenter.set_axes_from_object.side_effect = ValueError("Axes object does not exist in curves tab")
+
+        presenter.configure_curves_tab(ax1, None)
+
+        mock_curves_presenter.set_axes_from_object.assert_called()
+        mock_view.set_current_tab_widget.assert_not_called()
+
+    def test_configure_curves_tab_fails_silently_when_curve_not_found_in_curves_tab(self):
+        fig = figure()
+        ax = fig.add_subplot(111)
+        ax.plot([0], [0])  # Must plot curve for curves tab to exist, hence why we dont use this in the call
+        mock_view = Mock()
+        presenter = PlotConfigDialogPresenter(fig, mock_view)
+        mock_curves_presenter = presenter.tab_widget_presenters[2]
+        mock_curves_presenter.set_curve_from_object.side_effect = ValueError("Curve object does not exist in curves tab")
+        mock_curves_view, _ = presenter.tab_widget_views[1]
+
+        presenter.configure_curves_tab(ax, Mock())
+
+        mock_curves_presenter.set_axes_from_object.assert_called()
+        mock_view.set_current_tab_widget.assert_called_with(mock_curves_view)
+        mock_view.set_current_tab_widget.assert_called()
+
+    def test_configure_curves_tab_succeeds_when_curve_and_axes_exist(self):
+        fig = figure()
+        ax = fig.add_subplot(111)
+        curve = ax.plot([0], [0])
+        mock_view = Mock()
+        presenter = PlotConfigDialogPresenter(fig, mock_view)
+        mock_curves_presenter = presenter.tab_widget_presenters[2]
+        mock_curves_view, _ = presenter.tab_widget_views[1]
+
+        presenter.configure_curves_tab(ax, curve)
+
+        mock_curves_presenter.set_axes_from_object.assert_called()
+        mock_view.set_current_tab_widget.assert_called_with(mock_curves_view)
+        mock_view.set_current_tab_widget.assert_called()
 
 
 if __name__ == '__main__':

--- a/qt/python/mantidqt/widgets/plotconfigdialog/view.py
+++ b/qt/python/mantidqt/widgets/plotconfigdialog/view.py
@@ -25,3 +25,6 @@ class PlotConfigDialogView(QDialog):
 
     def add_tab_widget(self, tab_widget):
         self.main_tab_widget.addTab(*tab_widget)
+
+    def set_current_tab_widget(self, tab_widget):
+        self.main_tab_widget.setCurrentWidget(tab_widget)


### PR DESCRIPTION
Adds the following plot interactions:
- Double click a legend to hide it
- Double click a curve or set of axes to open the plot config dialog
  - If a curve is double clicked, the curves tab will open with the appropriate axes and curve selected
  - If an axes is double clicked, the curves tab will open with the appropriate axes selected
  - If an axes is double clicked and there are no curves on that axes, the axes tab will open with that axes selected

These changes _shouldn't_ interfere with any other plot interactions, such as double clicking a label on the legend to change its name.

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

**To test:**
- Code review
- Test that the plot config dialog opens correctly when double clicking a curve, an axes, and an axes without any curves.
- Test the legend is hidden when double clicked, and can be restored through plot config dialog.
- Test the interactions listed above on various plot types (e.g. standard, waterfall)
- Test the various other plot interactions to check they are not broken.

Fixes #30597
Fixes #30598 

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
