### PR TITLE
Set QT_PLUGIN_PATH variable in mantidpython on Windows

### DIFF
--- a/buildconfig/CMake/Packaging/mantidpython.bat.in
+++ b/buildconfig/CMake/Packaging/mantidpython.bat.in
@@ -27,6 +27,7 @@ set _IPYTHON_CMD=%PYTHONHOME%\Scripts\ipython.cmd
 :: QtPy should use Qt5 by unless specified
 if "%QT_API%"=="" (
   set QT_API=pyqt5
+  set QT_PLUGIN_PATH=%_BIN_DIR%\..\plugins\qt5
 )
 
 :: Matplotlib backend should default to Qt if not set (requires matplotlib >= 1.5)


### PR DESCRIPTION
**Description of work.**

The installer places the plugins inside the package plugins\qt5 directory.
Qt needs to know where these are so that a QApplication can be created.

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

**To test:**

* You will need to [build a package](https://developer.mantidproject.org/BuildingWithCMake.html?highlight=nsis#building-the-installer-package). The built .exe installer will be left in the build directory.
* Once built install the package
* In a command prompt run `C:\MantidUnstableInstall\bin\mantidpython.bat` to start IPython
  * Enter and run `from qtpy import QtWidgets`
  * followed by `qapp = QApplication(['TestApp'])`
  * and both lines should complete successfully

*There is no associated issue.*

*This does not require release notes* because **it is an internal change**

<!-- Ensure the base of this PR is correct (e.g. release-next or master)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
