### PR TITLE
Fix sequential fitting crash on RHEL7

### DIFF
--- a/qt/widgets/common/src/SequentialFitDialog.cpp
+++ b/qt/widgets/common/src/SequentialFitDialog.cpp
@@ -402,8 +402,10 @@ void SequentialFitDialog::getFitResults() {
   auto columnNames = ws->getColumnNames();
 
   size_t rowNo = 0;
-  if (rowCount() > 1) {
-    // first column contains ws names
+  if (rowCount() > 1 && columnNames[0] == "SourceName") {
+    // first column contains ws names (only if the log value is SourceName)
+    // otherwise, the first column contains the values of the log value and
+    // cannot compare workspace names
     auto firstColumn = ws->getColumn(0);
     for (size_t i = 0; i < ws->rowCount(); ++i) {
       if (firstColumn->cell<std::string>(i) == m_fitBrowser->workspaceName()) {

--- a/qt/widgets/common/src/SequentialFitDialog.cpp
+++ b/qt/widgets/common/src/SequentialFitDialog.cpp
@@ -199,6 +199,8 @@ bool SequentialFitDialog::validateLogs(const QString &wsName) {
   if (ws) {
     const std::vector<Mantid::Kernel::Property *> logs = ws->run().getLogData();
     QStringList logNames;
+    // add the option that displays workspace names
+    logNames << "SourceName";
     for (auto log : logs) {
       Mantid::Kernel::TimeSeriesProperty<double> *p =
           dynamic_cast<Mantid::Kernel::TimeSeriesProperty<double> *>(log);


### PR DESCRIPTION
**Description of work.**

This fixes a crash on RHEL7 at the cell function because the first column of the result fit workspace did not contain workspace names, but log values instead. This caused issues when casting the data to a string for comparison. This adds a check to make sure the column is SourceName before trying to find the appropriate workspace.

**To test:**

Compile on the analysis cluster and run a sequential fit over multiple workspaces. Workbench should no longer crash during the fitting process.

*This does not require release notes* because it is an internal change to the sequential fit dialog.


<!-- Ensure the base of this PR is correct (e.g. release-next or master)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

Version into `ornl-next` #30756

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
