### PR TITLE
Fix sequential fitting crash on RHEL7 ornl-next

### DIFF
--- a/qt/widgets/common/src/SequentialFitDialog.cpp
+++ b/qt/widgets/common/src/SequentialFitDialog.cpp
@@ -402,8 +402,10 @@ void SequentialFitDialog::getFitResults() {
   auto columnNames = ws->getColumnNames();
 
   size_t rowNo = 0;
-  if (rowCount() > 1) {
-    // first column contains ws names
+  if (rowCount() > 1 && columnNames[0] == "SourceName") {
+    // first column contains ws names (only if the log value is SourceName)
+    // otherwise, the first column contains the values of the log value and
+    // cannot compare workspace names
     auto firstColumn = ws->getColumn(0);
     for (size_t i = 0; i < ws->rowCount(); ++i) {
       if (firstColumn->cell<std::string>(i) == m_fitBrowser->workspaceName()) {

--- a/qt/widgets/common/src/SequentialFitDialog.cpp
+++ b/qt/widgets/common/src/SequentialFitDialog.cpp
@@ -199,6 +199,8 @@ bool SequentialFitDialog::validateLogs(const QString &wsName) {
   if (ws) {
     const std::vector<Mantid::Kernel::Property *> logs = ws->run().getLogData();
     QStringList logNames;
+    // add the option that displays workspace names
+    logNames << "SourceName";
     for (auto log : logs) {
       Mantid::Kernel::TimeSeriesProperty<double> *p =
           dynamic_cast<Mantid::Kernel::TimeSeriesProperty<double> *>(log);


### PR DESCRIPTION
The version of #30755 into `ornl-next`.

Refer to gitlab defect [PD165](https://code.ornl.gov/sns-hfir-scse/diffraction/powder/powder-diffraction/-/issues/165).