### PR TITLE
Quiet find boost python

### DIFF
--- a/buildconfig/CMake/FindBoostPython.cmake
+++ b/buildconfig/CMake/FindBoostPython.cmake
@@ -10,7 +10,7 @@ else ()
   # Try a known set of suffixes plus a user-defined set
   # Define a cache variable to supply additional suffxies. These are tried first
   set ( BOOST_PYTHON_ADDITIONAL_SUFFIXES "" CACHE STRING "Additional suffixes to try when searching for the boost python3 library. These are prepended to the default list" )
-  set ( _suffixes "${BOOST_PYTHON_ADDITIONAL_SUFFIXES};${Python_VERSION_MAJOR};-py${Python_VERSION_MAJOR}${Python_VERSION_MINOR};${Python_VERSION_MAJOR}${Python_VERSION_MINOR}")
+  set ( _suffixes "${BOOST_PYTHON_ADDITIONAL_SUFFIXES};${Python_VERSION_MAJOR}${Python_VERSION_MINOR};${Python_VERSION_MAJOR};-py${Python_VERSION_MAJOR}${Python_VERSION_MINOR}")
   foreach ( _suffix ${_suffixes})
     find_package ( Boost ${BOOST_VERSION_REQUIRED} COMPONENTS python${_suffix} )
     if ( Boost_FOUND )

--- a/buildconfig/Jenkins/buildscript
+++ b/buildconfig/Jenkins/buildscript
@@ -286,7 +286,7 @@ if [[ ${DO_BUILD_PKG} == true ]]; then
         fi
 
         if [[ ${ON_RHEL7} == true ]]; then
-            if [[ -n "${RELEASE_NUMBER}" ]]; then
+            if [[ -z "${RELEASE_NUMBER}" ]]; then
                 RELEASE_NUMBER="1"
             fi
             PACKAGINGVARS="${PACKAGINGVARS} -DCPACK_RPM_PACKAGE_RELEASE=${RELEASE_NUMBER}"

--- a/buildconfig/Jenkins/buildscript
+++ b/buildconfig/Jenkins/buildscript
@@ -6,7 +6,7 @@
 #
 # WORKSPACE, JOB_NAME, NODE_LABEL, PACKAGE_SUFFIX, GIT_COMMIT are
 # environment variables that are set by Jenkins. The last one
-# corresponds to any labels set on a slave.  BUILD_THREADS should 
+# corresponds to any labels set on a slave.  BUILD_THREADS should
 # be set in the configuration of each slave.
 ###############################################################################
 # Set all string comparisons to case insensitive (i.e. Release == release)
@@ -277,7 +277,7 @@ if [[ ${DO_BUILD_PKG} == true ]]; then
         if [[ ${JOB_NAME} == release* ]] && [[ -z "${PACKAGE_SUFFIX}" ]]; then
             # Traditional install path for release build
             PACKAGINGVARS="${PACKAGINGVARS} -DCMAKE_INSTALL_PREFIX=/opt/Mantid -DCPACK_PACKAGE_SUFFIX="
-        elif [[ ${JOB_NAME} == ornl ]] && [[ -z "${PACKAGE_SUFFIX}" ]]; then
+        elif [[ ${JOB_NAME} == ornl-stable ]] && [[ -z "${PACKAGE_SUFFIX}" ]]; then
             # Traditional install path for release build
             PACKAGINGVARS="${PACKAGINGVARS} -DCMAKE_INSTALL_PREFIX=/opt/Mantid -DCPACK_PACKAGE_SUFFIX="
         else

--- a/qt/widgets/common/src/SequentialFitDialog.cpp
+++ b/qt/widgets/common/src/SequentialFitDialog.cpp
@@ -199,6 +199,8 @@ bool SequentialFitDialog::validateLogs(const QString &wsName) {
   if (ws) {
     const std::vector<Mantid::Kernel::Property *> logs = ws->run().getLogData();
     QStringList logNames;
+    // add the option that displays workspace names
+    logNames << "SourceName";
     for (auto log : logs) {
       Mantid::Kernel::TimeSeriesProperty<double> *p =
           dynamic_cast<Mantid::Kernel::TimeSeriesProperty<double> *>(log);
@@ -402,8 +404,10 @@ void SequentialFitDialog::getFitResults() {
   auto columnNames = ws->getColumnNames();
 
   size_t rowNo = 0;
-  if (rowCount() > 1) {
-    // first column contains ws names
+  if (rowCount() > 1 && columnNames[0] == "SourceName") {
+    // first column contains ws names (only if the log value is SourceName)
+    // otherwise, the first column contains the values of the log value and
+    // cannot compare workspace names
     auto firstColumn = ws->getColumn(0);
     for (size_t i = 0; i < ws->rowCount(); ++i) {
       if (firstColumn->cell<std::string>(i) == m_fitBrowser->workspaceName()) {


### PR DESCRIPTION
Change the order of suffixes searched for when [finding boost-python](https://cmake.org/cmake/help/v3.14/module/FindBoost.html). This will get rid of (on many linuxes) erroneous error messages from cmake seen by developers.

The RHEL7 build now is less scary
```shell
17:40:10 -- Found Qt 5.9.7: /usr/lib64/cmake/Qt5
17:40:10 -- Found QScintilla2 linked against Qt5: /usr/lib64/libqscintilla2-qt5.so
17:40:10 -- Found Boost: /usr/include/boost169 (found suitable version "1.69.0", minimum required is "1.65.0") found components: python36 
17:40:11 -- Fetching/updating mslice
```

The only actual change is in ` buildconfig/CMake/FindBoostPython.cmake`. 

**To test:**

Run `cmake .` and see that the various "failed to find boost" errors no longer exist.

*There is no associated issue.*

*This does not require release notes* because it only affects logging during cmake configuration.

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
