### PR TITLE
Bug in DrILL array settings validation

### DIFF
--- a/scripts/Interface/ui/drill/view/DrillSettingsDialog.py
+++ b/scripts/Interface/ui/drill/view/DrillSettingsDialog.py
@@ -191,9 +191,7 @@ class DrillSettingsDialog(QDialog):
         for (n, t) in types.items():
             label = QLabel(n, self)
             self.settings[n] = DrillSetting(n, values[n], types[n], doc[n])
-            self.settings[n].valueChanged.connect(
-                    lambda p : self.valueChanged.emit(p)
-                    )
+            self.settings[n].valueChanged.connect(self.onValueChanged)
             self.settings[n].fileChecked.connect(
                     lambda v, n=n : self.onSettingValidation(n, v)
                     )
@@ -202,6 +200,20 @@ class DrillSettingsDialog(QDialog):
             widget.setToolTip(doc[n])
 
             self.formLayout.addRow(label, widget)
+
+    def onValueChanged(self, setting):
+        """
+        Check the get value before sending the signal.
+
+        Args:
+            setting (str): name of the setting
+        """
+        try:
+            self.getSettingValue(setting)
+            self.valueChanged.emit(setting)
+        except:
+            self.onSettingValidation(setting, False, "Unable to parse the "
+                                     "value. Check the input")
 
     def setSettings(self, settings):
         """


### PR DESCRIPTION
**Description of work.**

This PR adds a try-catch around the `getValue` method used in the widgets of the setting dialog. This will catch any exception raised when putting something different from a number in a setting that is waiting for an array of float or int.

**To test:**

To reproduce the bug:
* open DrILL
* select D11 and SANS
* open the settings (gear icon)
* put a letter in BeamRadius

With this PR, the exception is caught and the cell is noted as invalid with a tooltip explaining the error.

Part of #30592 

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
