### PR TITLE
Bug on file loading in DrILL

### DIFF
--- a/scripts/Interface/ui/drill/presenter/DrillPresenter.py
+++ b/scripts/Interface/ui/drill/presenter/DrillPresenter.py
@@ -323,7 +323,7 @@ class DrillPresenter:
         QDialog to get the file path from the user.
         """
         filename = QFileDialog.getOpenFileName(self.view, 'Load rundex', '.',
-                                               "Rundex (*.mrd);;All (*.*)")
+                                               "Rundex (*.mrd);;All (*)")
         if not filename[0]:
             return
         self.model.setIOFile(filename[0])

--- a/scripts/Interface/ui/drill/presenter/DrillPresenter.py
+++ b/scripts/Interface/ui/drill/presenter/DrillPresenter.py
@@ -351,7 +351,7 @@ class DrillPresenter:
         """
         filename = QFileDialog.getSaveFileName(self.view, 'Save rundex',
                                                './*.mrd',
-                                               "Rundex (*.mrd);;All (*.*)")
+                                               "Rundex (*.mrd);;All (*)")
         if not filename[0]:
             return
         self.model.setIOFile(filename[0])


### PR DESCRIPTION
**Description of work.**

When loading or saving the rundex file in DrILL, the `QfileDialog` was applying a wrong filter on the files. It was then impossible to load a rundex file that has no extension.

**To test:**

To reproduce the bug:
* open DrILL
* open the load dialog
* change "All files" filter
* observe that any file without an extension is not displayed in the list

This PR changes the filter. The load and save dialogs are now listing all files.

Part of #30592 

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
