### PR TITLE
Set max cores to 1 in PaalmanPingsMonteCarloAbsorption-v1 test

### DIFF
--- a/docs/source/algorithms/PaalmanPingsMonteCarloAbsorption-v1.rst
+++ b/docs/source/algorithms/PaalmanPingsMonteCarloAbsorption-v1.rst
@@ -222,6 +222,10 @@ Usage
 
 **Example - Preset Shape**
 
+.. testsetup:: Preset
+   # Currently an issue with multithreading in this test 
+   FrameworkManager.Instance().setNumOMPThreads(1)
+
 .. testcode:: Preset
 
     sample_ws = CreateSampleWorkspace(Function="Quasielastic",
@@ -271,7 +275,7 @@ Usage
     print("Y-Unit Label of " + str(acc_ws.getName()) + ": " + str(acc_ws.YUnitLabel()))
 
 .. testcleanup:: Preset
-
+    FrameworkManager.Instance().setNumOMPThreadsToConfigValue()
     mtd.clear()
 
 .. testoutput:: Preset


### PR DESCRIPTION
**Description of work.**

Wraps a doctest for `PaalmanPingsMonteCarlo` and sets the max threads to 1. There seems to be an issue that macOS has shown up with memory corruption if using > 1 threads, e.g. [master_clean-osx/1556](https://builds.mantidproject.org/view/Master%20Pipeline/job/master_clean-osx/1556/console)

**To test:**

* Code review
* Ensure the doc tests pass

*There is no associated issue.*

*This does not require release notes* because **fixes an internal testing issue.**

<!-- Ensure the base of this PR is correct (e.g. release-next or master)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
