### PR TITLE
Removing \tag from reST latex

### DIFF
--- a/docs/source/fitting/fitfunctions/GramCharlierComptonProfile.rst
+++ b/docs/source/fitting/fitfunctions/GramCharlierComptonProfile.rst
@@ -15,13 +15,13 @@ The Gram-Charlier expansion of the Neutron Compton profile, :math:`J(y)` is give
 expansion of Hermite polynomials,
 
 .. math::
-    J(y) = \frac{e^{-y^2/2\sigma^2}}{\sqrt{2\pi}\sigma}\left[ 1+ \sum_{n=2}^{\infty}\frac{a_n}{2^{2n}n!}H_{2n}\left(\frac{y}{\sqrt{2}\sigma}\right)\right]\label{a}  \tag{1}
+    J(y) = \frac{e^{-y^2/2\sigma^2}}{\sqrt{2\pi}\sigma}\left[ 1+ \sum_{n=2}^{\infty}\frac{a_n}{2^{2n}n!}H_{2n}\left(\frac{y}{\sqrt{2}\sigma}\right)\right]\label{a}
 
 where, :math:`\sigma` is the standard deviation (Gaussian width parameter), :math:`a_n` the hermite coefficients and :math:`H_n` the Hermite polynomial terms.
 As well as the even polynomial terms, a third order factor is included of the form,
 
 .. math::
-    \frac{A}{\sqrt{2\pi} \sigma} \times FSE \times \exp(-z^2) \times H_3 (z) \label{b}  \tag{2}
+    \frac{A}{\sqrt{2\pi} \sigma} \times FSE \times \exp(-z^2) \times H_3 (z) \label{b}
 
 where :math:`z=y/\sqrt{2\pi\sigma^2}` and :math:`FSE` is an input ampltiude scaling parameter. The Hermite coefficients, :math:`a_n`,
 are supplied to the function in the parameters :math:`C_0`, :math:`C_2` and :math:`C_4`. The attribute HermiteCoeffs may be used


### PR DESCRIPTION
**Description of work.**

The Windows amsmath package seems to choke on `\tag` in `math` it and it's holding up the builds currently. This just removes them until they are fixed properly. For example, [master_clean-windows/1499](https://builds.mantidproject.org/view/Master%20Pipeline/job/master_clean-windows/1499/console)

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

**To test:**

* Docs build should pass.

*There is no associated issue.*

*This does not require release notes* because **it is an internal issue that we introduced recently**

<!-- Ensure the base of this PR is correct (e.g. release-next or master)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
