### PR TITLE
Interface help

### DIFF
--- a/docs/source/release/v6.1.0/mantidworkbench.rst
+++ b/docs/source/release/v6.1.0/mantidworkbench.rst
@@ -18,5 +18,6 @@ Bugfixes
 - The background shell of spherical and elliptical peaks is now correctly plotted when viewing slices that do not cut through the peak center
 - For the elliptical shell of integrated peaks, the background is correct when plotting with varying background thicknesses
 - Fixed a bug which occurred when switching to a log scale in sliceviewer with negative data.
+- Fixed a bug that use wrong help links in certain interfaces
 
 :ref:`Release 6.1.0 <v6.1.0>`

--- a/qt/python/mantidqt/gui_helper.py
+++ b/qt/python/mantidqt/gui_helper.py
@@ -83,8 +83,8 @@ def show_interface_help(mantidplot_name, assistant_process, collection_file, qt_
         event.accept()
     '''
     try:
-        import pymantidplot
-        pymantidplot.proxies.showCustomInterfaceHelp(mantidplot_name)
+        import mantidqt
+        mantidqt.interfacemanager.InterfaceManager().showCustomInterfaceHelp(mantidplot_name)
     except: #(ImportError, ModuleNotFoundError) raises the wrong type of error
         assistant_process.close()
         assistant_process.waitForFinished()

--- a/scripts/DGSPlanner/DGSPlannerGUI.py
+++ b/scripts/DGSPlanner/DGSPlannerGUI.py
@@ -133,7 +133,7 @@ class DGSPlannerGUI(QtWidgets.QWidget):
         self.collection_file = os.path.join(mantid._bindir, '../docs/qthelp/MantidProject.qhc')
         version = ".".join(mantid.__version__.split(".")[:2])
         self.qt_url = 'qthelp://org.sphinx.mantidproject.' + version + '/doc/interfaces/DGS Planner.html'
-        self.external_url = 'http://docs.mantidproject.org/nightly/interfaces/DGS Planner.html'
+        self.external_url = 'http://docs.mantidproject.org/nightly/interfaces/framework/DGS Planner.html'
         # control for cancel button
         self.iterations = 0
         self.progress_canceled = False

--- a/scripts/FilterEvents/eventFilterGUI.py
+++ b/scripts/FilterEvents/eventFilterGUI.py
@@ -1069,8 +1069,8 @@ class MainWindow(QMainWindow):
 
     def helpClicked(self):
         try:
-            from pymantidplot.proxies import showCustomInterfaceHelp
-            showCustomInterfaceHelp("Filter Events")
+            import mantidqt
+            mantidqt.interfacemanager.InterfaceManager().showCustomInterfaceHelp("Filter Events")
         except ImportError:
             url = ("http://docs.mantidproject.org/nightly/interfaces/{}.html"
                    "".format("Filter Events"))

--- a/scripts/Interface/ui/sans_isis/SANSSaveOtherWindow.py
+++ b/scripts/Interface/ui/sans_isis/SANSSaveOtherWindow.py
@@ -13,15 +13,6 @@ from mantid import UsageService
 from mantid.kernel import FeatureType
 from sans.common.enums import SaveType
 
-from qtpy import PYQT4
-if PYQT4:
-    IN_MANTIDPLOT = False
-    try:
-        from pymantidplot import proxies
-        IN_MANTIDPLOT = True
-    except ImportError:
-        pass
-
 
 Ui_SaveOtherDialog, _ = load_ui(__file__, "save_other_dialog.ui")
 
@@ -105,8 +96,11 @@ class SANSSaveOtherDialog(QtWidgets.QDialog, Ui_SaveOtherDialog):
         self.filename_label.setText(name)
 
     def _on_help_button_clicked(self):
-        if PYQT4:
-            proxies.showCustomInterfaceHelp('sans_save_other')
+        try:
+            import mantidqt
+            mantidqt.interfacemanager.InterfaceManager().showCustomInterfaceHelp('sans_save_other')
+        except:
+            pass
 
     @property
     def progress_bar_minimum(self):

--- a/scripts/PyChop/PyChopGui.py
+++ b/scripts/PyChop/PyChopGui.py
@@ -680,8 +680,8 @@ class PyChopGui(QMainWindow):
         Shows the help page
         """
         try:
-            from pymantidplot.proxies import showCustomInterfaceHelp
-            showCustomInterfaceHelp("PyChop")
+            import mantidqt
+            mantidqt.interfacemanager.InterfaceManager().showCustomInterfaceHelp("PyChop")
         except ImportError:
             helpTxt = "PyChop is a tool to allow direct inelastic neutron\nscattering users to estimate the inelastic resolution\n"
             helpTxt += "and incident flux for a given spectrometer setting.\n\nFirst select the instrument, chopper settings and\n"

--- a/scripts/QECoverage/QECoverageGUI.py
+++ b/scripts/QECoverage/QECoverageGUI.py
@@ -209,7 +209,7 @@ class QECoverageGUI(QtWidgets.QWidget):
         self.collection_file = os.path.join(mantid._bindir, '../docs/qthelp/MantidProject.qhc')
         version = ".".join(mantid.__version__.split(".")[:2])
         self.qt_url = 'qthelp://org.sphinx.mantidproject.' + version + '/doc/interfaces/QE Coverage.html'
-        self.external_url = 'http://docs.mantidproject.org/nightly/interfaces/QE Coverage.html'
+        self.external_url = 'http://docs.mantidproject.org/nightly/interfaces/utility/QE Coverage.html'
         #register startup
         mantid.UsageService.registerFeatureUsage(mantid.kernel.FeatureType.Interface,"QECoverage",False)
 

--- a/scripts/TofConverter/converterGUI.py
+++ b/scripts/TofConverter/converterGUI.py
@@ -85,7 +85,7 @@ class MainWindow(QMainWindow):
         self.collection_file = os.path.join(mantid._bindir, '../docs/qthelp/MantidProject.qhc')
         version = ".".join(mantid.__version__.split(".")[:2])
         self.qt_url = 'qthelp://org.sphinx.mantidproject.' + version + '/doc/interfaces/TOF Converter.html'
-        self.external_url = 'http://docs.mantidproject.org/nightly/interfaces/TOF Converter.html'
+        self.external_url = 'http://docs.mantidproject.org/nightly/interfaces/utility/TOF Converter.html'
 
         try:
             import mantid


### PR DESCRIPTION
**Description of work.**

Fixed the help link in certain interfaces, and use workbench help framework(mantidplot no longer exists)

**To test:**
Build without qthelp (or rename `docs/qthelp/MantidProject.qhc` to something else). Try to run
* Direct-> DGS Planner
* Utility-> QE Coverage
* Utility-> TOF Converter
Clicking the help button (?) both within workbench and from the terminal should open the appropriate webpage

Build with qthelp (or get back the  `docs/qthelp/MantidProject.qhc` file)
Clicking the help button (?) within workbench will open MantidHelp window, and from the terminal will open qtassitant (if available)

Fixes #30690


<!-- Ensure the base of this PR is correct (e.g. release-next or master)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
