### PR TITLE
Fix no discard warning in FitDomainTest

### DIFF
--- a/qt/widgets/common/test/FitDomainTest.h
+++ b/qt/widgets/common/test/FitDomainTest.h
@@ -458,7 +458,7 @@ public:
   test_that_setting_the_value_of_a_parameter_to_a_value_outside_of_the_constraints_of_another_parameter_tied_to_it_will_remove_the_tie() {
     m_fitDomain->setFunction(m_expDecay);
     m_fitDomain->updateParameterConstraint("", "Height", "0.5<Height<1.5");
-    m_fitDomain->updateParameterTie("Height", "Lifetime");
+    TS_ASSERT(m_fitDomain->updateParameterTie("Height", "Lifetime"));
 
     m_fitDomain->setParameterValue("Lifetime", 2.0);
 
@@ -472,7 +472,7 @@ public:
     m_fitDomain->updateParameterConstraint("", "Height", "0.5<Height<1.5");
     m_fitDomain->setParameterValue("Lifetime", 2.0);
 
-    m_fitDomain->updateParameterTie("Height", "Lifetime");
+    TS_ASSERT(m_fitDomain->updateParameterTie("Height", "Lifetime"));
 
     TS_ASSERT(m_fitDomain->isParameterActive("Height"));
     TS_ASSERT_EQUALS(m_fitDomain->getParameterValue("Height"), 1.0);
@@ -522,7 +522,7 @@ public:
   void
   test_that_getParametersTiedTo_will_return_the_names_of_parameters_tied_to_the_given_parameter() {
     m_fitDomain->setFunction(m_expDecay);
-    m_fitDomain->updateParameterTie("Height", "Lifetime");
+    TS_ASSERT(m_fitDomain->updateParameterTie("Height", "Lifetime"));
 
     auto const tiedParameters = std::vector<std::string>{"Height"};
     TS_ASSERT_EQUALS(m_fitDomain->getParametersTiedTo("Height").size(), 0);


### PR DESCRIPTION
**Description of work.**
This PR fixes a no discard warning in the windows master pipeline build caused in the FitDomainTest.

**To test:**
Code review and make sure FitDomainTest passes.

*There is no associated issue.*

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
