### PR TITLE
Work Around For Bug When Loading A Run In Muon Analysis And Frequency Domain Analysis 

### DIFF
--- a/docs/source/release/v6.1.0/muon.rst
+++ b/docs/source/release/v6.1.0/muon.rst
@@ -21,6 +21,7 @@ Improvements
 Bug fixes
 #########
 - Fixed a bug where removing a pair in use would cause a crash.
+- Fixed a bug where an error message would appear in workbench after loading a run in both MA and FDA.
 
 ALC
 ---

--- a/scripts/Muon/GUI/Common/plot_widget/plot_widget_presenter.py
+++ b/scripts/Muon/GUI/Common/plot_widget/plot_widget_presenter.py
@@ -174,7 +174,10 @@ class PlotWidgetPresenterCommon(HomeTabSubWidget):
         Handles a workspace being deleted from ads by removing the workspace from the plot
         :param workspace: workspace 2D object
         """
-        workspace_name = workspace.name()
+        if isinstance(workspace, str):
+            workspace_name = workspace
+        else:
+            workspace_name = workspace.name()
         plotted_workspaces, _ = self._figure_presenter.get_plotted_workspaces_and_indices()
         if workspace_name in plotted_workspaces:
             self._figure_presenter.remove_workspace_from_plot(workspace)


### PR DESCRIPTION
**Description of work.**
An error would be printed when loading a run both in MA and FDA, I've added a check where the error occurred as a work around.

**To test:**
1. Set default instrument to HIFI
2. Interfaces->Muon->Frequency Domain Analysis
3. In the runs box, type 169778 and hit enter. Wait for data to load.
4. Keep FDA open. Go to Interfaces->Muon->Muon Analysis
5. In the runs box, type 169824 and hit enter.
6. There should be no error message now

Fixes #29428

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
