### PR TITLE
Change the default fit function in F(Q) fit to none

### DIFF
--- a/docs/source/release/v6.1.0/indirect_geometry.rst
+++ b/docs/source/release/v6.1.0/indirect_geometry.rst
@@ -14,4 +14,8 @@ New Features
 - Three fitting functions `IsoRotDiff`, `DiffSphere` and `DiffRotDiscreteCircle` have been made available in the fitting browser
 - `DiffSphere` and `DiffRotDiscreteCircle` have been added to the function options in Indirect Data Analysis ConvFit.
 
+Improvements
+############
+- In Indirect Data Analysis F(Q) fit the default fitting function remains None when switching to EISF.
+
 :ref:`Release 6.1.0 <v6.1.0>`

--- a/qt/scientific_interfaces/Indirect/FQFitConstants.h
+++ b/qt/scientific_interfaces/Indirect/FQFitConstants.h
@@ -34,7 +34,8 @@ static const std::map<std::string, std::string> widthFits{
           "name=TeixeiraWater, Tau=1, L=1.5, constraints=(Tau>0, L>0)")}}};
 
 static const std::map<std::string, std::string> EISFFits{
-    {{std::string("EISFDiffCylinder"),
+    {{"None", ""},
+     {std::string("EISFDiffCylinder"),
       std::string(
           "name=EISFDiffCylinder, A=1, R=1, L=2, constraints=(A>0, R>0, L>0)")},
      {std::string("EISFDiffSphere"),
@@ -44,7 +45,8 @@ static const std::map<std::string, std::string> EISFFits{
                   "constraints=(A>0, Rmin>0, Rmax>0)")}}};
 
 static const std::map<std::string, std::string> AllFits{
-    {{std::string("ChudleyElliot"),
+    {{"None", ""},
+     {std::string("ChudleyElliot"),
       std::string(
           "name=ChudleyElliot, Tau=1, L=1.5, constraints=(Tau>0, L>0)")},
      {std::string("HallRoss"),


### PR DESCRIPTION
**Description of work.**

This PR adds None to the list of fit functions in Indirect Data Analysis F(Q) fit for EISF.

**To test:**

1. Open IndirectData analysis
2. Switch to F(Q) fit
3. Load some data with EISF data.
4. switch to EISF.
5. check that None is selected as the fit function by default.
6. in multiple input add both Width and EISF data and check that the default is still none.

Fixes #29229

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
