### PR TITLE
Update stale comment to clarify Never Stale

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -4,19 +4,27 @@ daysUntilStale: 180
 daysUntilClose: 7
 # Issues with these labels will never be considered stale
 exemptLabels:
-  - Never Stale
+  - Roadmap
 # Label to use when marking an issue as stale
 staleLabel: Stale
 # Comment to post when marking an issue as stale. Set to `false` to disable
 markComment: >
   This issue has been automatically marked as stale because it has not had
-  recent activity. It will be closed in 7 days if no further activity occurs. 
-  If you feel this is incorrect please comment to keep it alive, with a reason
-  why. 
+  activity in 6 months. It will be closed in 7 days if no further activity occurs. 
+
+  Allowing issues to close as stale helps us filter out issues which can wait
+  for future development time. All issues closed by stale bot act like normal issues; they can be searched for, commented on or reopened at any point.
+
+  If you'd like a closed stale issue to be considered,
+  feel free to either re-open the issue directly or contact a developer.
    
-  To prevent closure, e.g. for long-term planning issues,
-  add the "Never Stale" label.
+  To extend the lifetime of an issue please comment below,
+  it helps us see that this is still affecting you and you want
+  it fixed in the near-future. Extending the lifetime of an issue
+  may cause the development team to prioritise it over other issues,
+  which may be closed as stale instead.
+
 # Comment to post when closing a stale issue. Set to `false` to disable
 closeComment: >
   This issue has been closed automatically. If this still affects you please
-  re-open this issue with a comment so we can look into resolving it.
+  re-open this issue with a comment or contact us so we can look into resolving it.


### PR DESCRIPTION
**Description of work.**
I'm currently getting notifications for a large number of issues being
tagged as never stale incorrectly. These aren't meta-issues, and aren't
likely to be resolved in the next 6 months. Let's really steer people to help
them understand that this is them marking said issues as important 
(ignoring planning) and need doing now.

Whilst they are still valid, letting them rot open in an issue tracker
"in-case" unfortunately just will get us back to where we were. Instead
we should really encourage people to just let them be closed until they
really become a problem.

**To test:**
Read updated comment, does it help steer you in a users / developers shoes to correctly bump the life-time if it's something I want doing now, and let close if it's not on the horizon for 6 months?

*There is no associated issue.*

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
