### PR TITLE
Replace pythons input to raise a QInputDialog

### DIFF
--- a/docs/source/release/v6.1.0/mantidworkbench.rst
+++ b/docs/source/release/v6.1.0/mantidworkbench.rst
@@ -7,14 +7,15 @@ Mantid Workbench Changes
 
 New and Improved
 ----------------
-Added Floating/On Top setting for all the windows that are opened by workbench (plots, interfaces, etc.)
 
+- Added Floating/On Top setting for all the windows that are opened by workbench (plots, interfaces, etc.)
 - New plot interactions: Double click a legend to hide it, double click a curve to open it in the plot config dialog.
 - It is now possible to overplot bin data from the matrix workspace view.
 - Improved the performance of the table workspace display for large datasets
 - Added a sample material dialog that is accessed via the context menu in the workspace widget.
 - When a workspace is renamed it now updates the relevant plot labels with the new workspace name.
 - Add a checkbox to freeze the rotation in the instrument viewer in Full 3D mode.
+- Calling python's `input` now raises an input dialog in the script editor and the iPython shell.
 
 - A new empty facility with empty instrument is the default facility now, and
   user has to select their choice of facility (including ISIS) and instrument for the first time

--- a/qt/applications/workbench/workbench/app/mainwindow.py
+++ b/qt/applications/workbench/workbench/app/mainwindow.py
@@ -10,6 +10,7 @@
 """
 Defines the QMainWindow of the application and the main() entry point.
 """
+import builtins
 import os
 
 from mantid.api import FrameworkManager
@@ -39,6 +40,7 @@ from workbench.config import CONF  # noqa
 from workbench.plotting.globalfiguremanager import GlobalFigureManager  # noqa
 from workbench.utils.windowfinder import find_all_windows_that_are_savable  # noqa
 from workbench.utils.workspacehistorygeneration import get_all_workspace_history_from_ads  # noqa
+from workbench.utils.io import input_qinputdialog
 from workbench.projectrecovery.projectrecovery import ProjectRecovery  # noqa
 from workbench.utils.recentlyclosedscriptsmenu import RecentlyClosedScriptsMenu # noqa
 from mantidqt.utils.asynchronous import BlockingAsyncTaskWithCallback  # noqa
@@ -196,6 +198,8 @@ class MainWindow(QMainWindow):
         self.create_actions()
         self.readSettings(CONF)
         self.config_updated()
+
+        self.override_python_input()
 
     def post_mantid_init(self):
         """Run any setup that requires mantid
@@ -752,3 +756,7 @@ class MainWindow(QMainWindow):
         for widget in self.widgets:
             if hasattr(widget, 'writeSettings'):
                 widget.writeSettings(settings)
+
+    def override_python_input(self):
+        """Replace python input with a call to a qinputdialog"""
+        builtins.input = QAppThreadCall(input_qinputdialog)

--- a/qt/applications/workbench/workbench/app/start.py
+++ b/qt/applications/workbench/workbench/app/start.py
@@ -15,7 +15,6 @@ from functools import partial
 from mantid.api import FrameworkManagerImpl
 from mantid.kernel import ConfigService, UsageService, version_str as mantid_version_str
 from mantidqt.utils.qt import plugins
-from mantidqt.utils.qt.qappthreadcall import QAppThreadCall
 
 # Find Qt plugins for development builds on some platforms
 plugins.setup_library_paths()
@@ -29,7 +28,6 @@ from workbench.app.resources import qCleanupResources  # noqa
 from workbench.config import APPNAME, ORG_DOMAIN, ORGANIZATION  # noqa
 from workbench.plugins.exception_handler import exception_logger  # noqa
 from workbench.widgets.about.presenter import AboutPresenter  # noqa
-from workbench.utils.io import input_qinputdialog
 
 # Constants
 SYSCHECK_INTERVAL = 50

--- a/qt/applications/workbench/workbench/app/start.py
+++ b/qt/applications/workbench/workbench/app/start.py
@@ -15,6 +15,7 @@ from functools import partial
 from mantid.api import FrameworkManagerImpl
 from mantid.kernel import ConfigService, UsageService, version_str as mantid_version_str
 from mantidqt.utils.qt import plugins
+from mantidqt.utils.qt.qappthreadcall import QAppThreadCall
 
 # Find Qt plugins for development builds on some platforms
 plugins.setup_library_paths()
@@ -28,6 +29,7 @@ from workbench.app.resources import qCleanupResources  # noqa
 from workbench.config import APPNAME, ORG_DOMAIN, ORGANIZATION  # noqa
 from workbench.plugins.exception_handler import exception_logger  # noqa
 from workbench.widgets.about.presenter import AboutPresenter  # noqa
+from workbench.utils.io import input_qinputdialog
 
 # Constants
 SYSCHECK_INTERVAL = 50

--- a/qt/applications/workbench/workbench/plugins/jupyterconsole.py
+++ b/qt/applications/workbench/workbench/plugins/jupyterconsole.py
@@ -27,7 +27,8 @@ from ..plugins.base import PluginWidget # noqa
 # from mantidqt.utils.qt import toQSettings when readSettings/writeSettings are implemented
 
 # should we share this with plugins.editor?
-STARTUP_CODE = """from __future__ import (absolute_import, division, print_function, unicode_literals)
+STARTUP_CODE = """
+from __future__ import (absolute_import, division, print_function, unicode_literals)
 from mantid.simpleapi import *
 import matplotlib.pyplot as plt
 import numpy as np

--- a/qt/applications/workbench/workbench/plugins/jupyterconsole.py
+++ b/qt/applications/workbench/workbench/plugins/jupyterconsole.py
@@ -28,7 +28,6 @@ from ..plugins.base import PluginWidget # noqa
 
 # should we share this with plugins.editor?
 STARTUP_CODE = """
-from __future__ import (absolute_import, division, print_function, unicode_literals)
 from mantid.simpleapi import *
 import matplotlib.pyplot as plt
 import numpy as np

--- a/qt/applications/workbench/workbench/test/mainwindowtest.py
+++ b/qt/applications/workbench/workbench/test/mainwindowtest.py
@@ -337,6 +337,14 @@ class MainWindowTest(unittest.TestCase):
         }
         self.assertDictEqual(expected_interfaces, all_interfaces)
 
+    @patch('workbench.app.mainwindow.input_qinputdialog')
+    def test_override_python_input_replaces_input_with_qinputdialog(self, mock_input):
+        self.main_window.override_python_input()
+
+        input("prompt")
+
+        mock_input.assert_called_with("prompt")
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/qt/applications/workbench/workbench/utils/io.py
+++ b/qt/applications/workbench/workbench/utils/io.py
@@ -1,0 +1,24 @@
+# Mantid Repository : https://github.com/mantidproject/mantid
+#
+# Copyright &copy; 2021 ISIS Rutherford Appleton Laboratory UKRI,
+#   NScD Oak Ridge National Laboratory, European Spallation Source,
+#   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+# SPDX - License - Identifier: GPL - 3.0 +
+#  This file is part of the mantidworkbench package
+from qtpy.QtWidgets import QInputDialog
+
+
+def input_qinputdialog(prompt: str = "") -> str:
+    """
+    Raises a QInputDialog with a given prompt and returns the user input as a string.
+    If the user cancels the dialog, a RuntimeError is raised.
+    Intended to be used to override python's `input` function to be more user friendly.
+    """
+    dlg = QInputDialog()
+    dlg.setInputMode(QInputDialog.TextInput)
+    dlg.setLabelText(str(prompt) if prompt is not None else "")
+    accepted = dlg.exec_()
+    if accepted:
+        return dlg.textValue()
+    else:
+        raise RuntimeError("User input request cancelled")

--- a/qt/applications/workbench/workbench/utils/io.py
+++ b/qt/applications/workbench/workbench/utils/io.py
@@ -11,7 +11,7 @@ from qtpy.QtWidgets import QInputDialog
 def input_qinputdialog(prompt: str = "") -> str:
     """
     Raises a QInputDialog with a given prompt and returns the user input as a string.
-    If the user cancels the dialog, a RuntimeError is raised.
+    If the user cancels the dialog, an EOFError is raised.
     Intended to be used to override python's `input` function to be more user friendly.
     """
     dlg = QInputDialog()
@@ -21,4 +21,4 @@ def input_qinputdialog(prompt: str = "") -> str:
     if accepted:
         return dlg.textValue()
     else:
-        raise RuntimeError("User input request cancelled")
+        raise EOFError("User input request cancelled")

--- a/qt/applications/workbench/workbench/utils/test/test_io.py
+++ b/qt/applications/workbench/workbench/utils/test/test_io.py
@@ -1,0 +1,43 @@
+# Mantid Repository : https://github.com/mantidproject/mantid
+#
+# Copyright &copy; 2021 ISIS Rutherford Appleton Laboratory UKRI,
+#   NScD Oak Ridge National Laboratory, European Spallation Source,
+#   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+# SPDX - License - Identifier: GPL - 3.0 +
+#  This file is part of the mantidworkbench package
+from unittest import TestCase
+from unittest.mock import patch
+
+from PyQt5.QtWidgets import QInputDialog
+from workbench.utils.io import input_qinputdialog
+
+
+class IOTest(TestCase):
+
+    @patch('workbench.utils.io.QInputDialog')
+    def test_input_qinputdialog_setup_is_correct(self, mock_QInputDialogClass):
+        mock_QInputDialogClass.TextInput = QInputDialog.TextInput
+        mock_QInputDialog = mock_QInputDialogClass()
+
+        _ = input_qinputdialog("prompt")
+
+        mock_QInputDialog.setInputMode.assert_called_with(QInputDialog.TextInput)
+        mock_QInputDialog.setLabelText.assert_called_with("prompt")
+
+    @patch('workbench.utils.io.QInputDialog')
+    def test_input_qinputdialog_return_value_is_correct_when_dialog_accepted(self, mock_QInputDialogClass):
+        mock_QInputDialog = mock_QInputDialogClass()
+        mock_QInputDialog.exec_.return_value = True
+        mock_QInputDialog.textValue.return_value = "their input"
+
+        user_input = input_qinputdialog()
+
+        self.assertEqual(user_input, "their input")
+
+    @patch('workbench.utils.io.QInputDialog')
+    def test_input_qinputdialog_raises_RuntimeError_when_input_cancelled(self, mock_QInputDialogClass):
+        mock_QInputDialog = mock_QInputDialogClass()
+        mock_QInputDialog.exec_.return_value = False
+
+        self.assertRaises(RuntimeError, input_qinputdialog)
+

--- a/qt/applications/workbench/workbench/utils/test/test_io.py
+++ b/qt/applications/workbench/workbench/utils/test/test_io.py
@@ -40,4 +40,3 @@ class IOTest(TestCase):
         mock_QInputDialog.exec_.return_value = False
 
         self.assertRaises(RuntimeError, input_qinputdialog)
-

--- a/qt/applications/workbench/workbench/utils/test/test_io.py
+++ b/qt/applications/workbench/workbench/utils/test/test_io.py
@@ -39,4 +39,4 @@ class IOTest(TestCase):
         mock_QInputDialog = mock_QInputDialogClass()
         mock_QInputDialog.exec_.return_value = False
 
-        self.assertRaises(RuntimeError, input_qinputdialog)
+        self.assertRaises(EOFError, input_qinputdialog)

--- a/qt/applications/workbench/workbench/utils/test/test_io.py
+++ b/qt/applications/workbench/workbench/utils/test/test_io.py
@@ -8,7 +8,7 @@
 from unittest import TestCase
 from unittest.mock import patch
 
-from PyQt5.QtWidgets import QInputDialog
+from qtpy.QtWidgets import QInputDialog
 from workbench.utils.io import input_qinputdialog
 
 

--- a/qt/python/mantidqt/widgets/jupyterconsole.py
+++ b/qt/python/mantidqt/widgets/jupyterconsole.py
@@ -26,7 +26,8 @@ except ImportError:
 # local imports
 from inspect import getfullargspec
 from mantidqt.utils.asynchronous import BlockingAsyncTaskWithCallback
-
+from mantidqt.utils.qt.qappthreadcall import QAppThreadCall
+from workbench.utils.io import input_qinputdialog
 
 class InProcessJupyterConsole(RichJupyterWidget):
 
@@ -61,6 +62,9 @@ class InProcessJupyterConsole(RichJupyterWidget):
 
         self.kernel_manager = kernel_manager
         self.kernel_client = kernel_client
+
+        # Override python input to raise a QInputDialog.
+        kernel.raw_input = QAppThreadCall(input_qinputdialog)
 
     def keyPressEvent(self, event):
         if QApplication.keyboardModifiers() & Qt.ControlModifier and (event.key() == Qt.Key_Equal):

--- a/qt/python/mantidqt/widgets/jupyterconsole.py
+++ b/qt/python/mantidqt/widgets/jupyterconsole.py
@@ -29,6 +29,7 @@ from mantidqt.utils.asynchronous import BlockingAsyncTaskWithCallback
 from mantidqt.utils.qt.qappthreadcall import QAppThreadCall
 from workbench.utils.io import input_qinputdialog
 
+
 class InProcessJupyterConsole(RichJupyterWidget):
 
     def __init__(self, *args, **kwargs):

--- a/qt/python/mantidqt/widgets/test/test_jupyterconsole.py
+++ b/qt/python/mantidqt/widgets/test/test_jupyterconsole.py
@@ -14,6 +14,7 @@ try:
 except ImportError:
     pass
 import unittest
+from unittest.mock import patch
 
 # third-party library imports
 
@@ -37,6 +38,18 @@ class InProcessJupyterConsoleTest(unittest.TestCase):
     def test_construction_with_startup_code_adds_to_banner_and_executes(self):
         widget = InProcessJupyterConsole(startup_code="x = 1")
         self.assertEqual(1, widget.kernel_manager.kernel.shell.user_ns['x'])
+        self._pre_delete_console_cleanup(widget)
+        widget.kernel_manager.shutdown_kernel()
+        del widget
+
+    @patch('mantidqt.widgets.jupyterconsole.input_qinputdialog')
+    def test_construction_overrides_python_input_with_qinputdialog(self, mock_input):
+        widget = InProcessJupyterConsole()
+        kernel = widget.kernel_manager.kernel
+        kernel.raw_input("prompt")
+
+        mock_input.assert_called_with("prompt")
+
         self._pre_delete_console_cleanup(widget)
         widget.kernel_manager.shutdown_kernel()
         del widget


### PR DESCRIPTION
When the user calls `input()` in workbench script editor or in the iPython shell it will raise a `QInputDialog` to allow the user to enter a text input, rather than typing in the shell.

**To test:**
- Code review
- In both the script editor and iPython:
  - Test `input` raises a `QInputDialog`
  - Test accepting the dialog returns the correct value
  - Test cancelling the dialog raises a `RuntimeError`
 
You can use this handy script (the print statements will appear as normal):
```
name = input("What is your name?")
print("Hello {}, nice to meet you".format(name))

num = int(input("What is your favourite number?"))
if num == 7:
    print("You have good taste :)")
else:
    print("Your number is boring :(")

input()
print("What? I didn't say anything!")
```

Fixes #28176

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
