### PR TITLE
Muon Fitting Refactor 3 - Make Sequential Fitting tab work

### DIFF
--- a/scripts/Muon/GUI/Common/fitting_widgets/basic_fitting/basic_fitting_model.py
+++ b/scripts/Muon/GUI/Common/fitting_widgets/basic_fitting/basic_fitting_model.py
@@ -450,6 +450,18 @@ class BasicFittingModel:
         except AttributeError:
             return DEFAULT_START_X
 
+    def get_fit_function_parameters(self) -> list:
+        """Returns the names of the fit parameters in the fit functions."""
+        if len(self.single_fit_functions) > 0:
+            fit_function = self.single_fit_functions[0]
+            if fit_function is not None:
+                return [fit_function.parameterName(i) for i in range(fit_function.nParams())]
+        return []
+
+    def get_all_fit_functions(self) -> list:
+        """Returns all the fit functions for the current fitting mode."""
+        return self.single_fit_functions
+
     def get_active_fit_function(self) -> IFunction:
         """Returns the fit function that is active and will be used for a fit."""
         return self.current_single_fit_function

--- a/scripts/Muon/GUI/Common/fitting_widgets/basic_fitting/basic_fitting_model.py
+++ b/scripts/Muon/GUI/Common/fitting_widgets/basic_fitting/basic_fitting_model.py
@@ -483,7 +483,8 @@ class BasicFittingModel:
 
     def perform_fit(self) -> tuple:
         """Performs a single fit and returns the resulting function, status and chi squared."""
-        function, fit_status, chi_squared = self._do_single_fit(self._get_parameters_for_single_fit())
+        function, fit_status, chi_squared = self._do_single_fit(self._get_parameters_for_single_fit(
+            self.current_dataset_name, self.current_single_fit_function))
         return function, fit_status, chi_squared
 
     def _do_single_fit(self, parameters: dict) -> tuple:
@@ -503,18 +504,18 @@ class BasicFittingModel:
         CopyLogs(InputWorkspace=self.current_dataset_name, OutputWorkspace=output_workspace, StoreInADS=False)
         return output_workspace, parameter_table, function, fit_status, chi_squared, covariance_matrix
 
-    def _get_parameters_for_single_fit(self) -> dict:
+    def _get_parameters_for_single_fit(self, dataset_name: str, single_fit_function: IFunction) -> dict:
         """Returns the parameters used for a single fit."""
         params = self._get_common_parameters()
-        params["InputWorkspace"] = self.current_dataset_name
+        params["Function"] = single_fit_function
+        params["InputWorkspace"] = dataset_name
         params["StartX"] = self.current_start_x
         params["EndX"] = self.current_end_x
         return params
 
     def _get_common_parameters(self) -> dict:
         """Returns the parameters which are common across different fitting modes."""
-        return {"Function": self.get_active_fit_function(),
-                "Minimizer": self.minimizer,
+        return {"Minimizer": self.minimizer,
                 "EvaluationType": self.evaluation_type}
 
     def _create_fit_algorithm(self) -> IAlgorithm:

--- a/scripts/Muon/GUI/Common/fitting_widgets/basic_fitting/basic_fitting_model.py
+++ b/scripts/Muon/GUI/Common/fitting_widgets/basic_fitting/basic_fitting_model.py
@@ -483,16 +483,15 @@ class BasicFittingModel:
 
     def perform_fit(self) -> tuple:
         """Performs a single fit and returns the resulting function, status and chi squared."""
-        function, fit_status, chi_squared = self._do_single_fit(self._get_parameters_for_single_fit(
-            self.current_dataset_name, self.current_single_fit_function))
-        return function, fit_status, chi_squared
+        params = self._get_parameters_for_single_fit(self.current_dataset_name, self.current_single_fit_function)
+        return self._do_single_fit(params)
 
     def _do_single_fit(self, parameters: dict) -> tuple:
         """Does a single fit and returns the fit function, status and chi squared. Adds the results to the ADS."""
         output_workspace, parameter_table, function, fit_status, chi_squared, covariance_matrix = \
             self._do_single_fit_and_return_workspace_parameters_and_fit_function(parameters)
 
-        self._add_single_fit_results_to_ADS_and_context(self.current_dataset_name, parameter_table, output_workspace,
+        self._add_single_fit_results_to_ADS_and_context(parameters["InputWorkspace"], parameter_table, output_workspace,
                                                         covariance_matrix)
         return function, fit_status, chi_squared
 

--- a/scripts/Muon/GUI/Common/fitting_widgets/basic_fitting/basic_fitting_model.py
+++ b/scripts/Muon/GUI/Common/fitting_widgets/basic_fitting/basic_fitting_model.py
@@ -452,7 +452,7 @@ class BasicFittingModel:
 
     def get_fit_function_parameters(self) -> list:
         """Returns the names of the fit parameters in the fit functions."""
-        if len(self.single_fit_functions) > 0:
+        if self.single_fit_functions:
             fit_function = self.single_fit_functions[0]
             if fit_function is not None:
                 return [fit_function.parameterName(i) for i in range(fit_function.nParams())]

--- a/scripts/Muon/GUI/Common/fitting_widgets/general_fitting/general_fitting_model.py
+++ b/scripts/Muon/GUI/Common/fitting_widgets/general_fitting/general_fitting_model.py
@@ -314,8 +314,8 @@ class GeneralFittingModel(BasicFittingModel):
         output_workspace, parameter_table, function, fit_status, chi_squared, covariance_matrix = \
             self._do_simultaneous_fit_and_return_workspace_parameters_and_fit_function(parameters)
 
-        self._add_simultaneous_fit_results_to_ADS_and_context(parameter_table, output_workspace, covariance_matrix,
-                                                              global_parameters)
+        self._add_simultaneous_fit_results_to_ADS_and_context(parameters["InputWorkspace"], parameter_table,
+                                                              output_workspace, covariance_matrix, global_parameters)
         return function, fit_status, chi_squared
 
     def _do_simultaneous_fit_and_return_workspace_parameters_and_fit_function(self, parameters: dict) -> tuple:
@@ -324,19 +324,19 @@ class GeneralFittingModel(BasicFittingModel):
         output_workspace, parameter_table, function, fit_status, chi_squared, covariance_matrix = run_simultaneous_Fit(
             parameters, alg)
 
-        self._copy_logs(output_workspace)
+        self._copy_logs(parameters["InputWorkspace"], output_workspace)
         return output_workspace, parameter_table, function, fit_status, chi_squared, covariance_matrix
 
-    def _copy_logs(self, output_workspace: str) -> None:
+    def _copy_logs(self, input_workspaces, output_workspace: str) -> None:
         """Copy the logs from the input workspace(s) to the output workspaces."""
         if self.number_of_datasets == 1:
-            CopyLogs(InputWorkspace=self.current_dataset_name, OutputWorkspace=output_workspace, StoreInADS=False)
+            CopyLogs(InputWorkspace=input_workspaces, OutputWorkspace=output_workspace, StoreInADS=False)
         else:
-            self._copy_logs_for_all_datsets(output_workspace)
+            self._copy_logs_for_all_datsets(input_workspaces, output_workspace)
 
-    def _copy_logs_for_all_datsets(self, output_group: str) -> None:
+    def _copy_logs_for_all_datsets(self, input_workspaces: list, output_group: str) -> None:
         """Copy the logs from the input workspaces to the output workspaces."""
-        for input_workspace, output in zip(self.dataset_names, self._get_names_in_group_workspace(output_group)):
+        for input_workspace, output in zip(input_workspaces, self._get_names_in_group_workspace(output_group)):
             CopyLogs(InputWorkspace=input_workspace, OutputWorkspace=output, StoreInADS=False)
 
     def _get_parameters_for_simultaneous_fit(self, dataset_names: list, simultaneous_function: IFunction) -> dict:
@@ -348,28 +348,30 @@ class GeneralFittingModel(BasicFittingModel):
         params["EndX"] = self.end_xs
         return params
 
-    def _add_simultaneous_fit_results_to_ADS_and_context(self, parameter_table, output_workspace, covariance_matrix,
+    def _add_simultaneous_fit_results_to_ADS_and_context(self, input_workspace_names: list, parameter_table,
+                                                         output_workspace, covariance_matrix,
                                                          global_parameters: list) -> None:
         """Adds the results of a simultaneous fit to the ADS and fitting context."""
         if self.number_of_datasets > 1:
-            workspace_names, table_name, table_directory = self._add_multiple_fit_workspaces_to_ADS(output_workspace,
-                                                                                                    covariance_matrix)
+            workspace_names, table_name, table_directory = self._add_multiple_fit_workspaces_to_ADS(
+                input_workspace_names, output_workspace, covariance_matrix)
         else:
             workspace_name, table_name, table_directory = self._add_single_fit_workspaces_to_ADS(
-                self.current_dataset_name, output_workspace, covariance_matrix)
+                input_workspace_names[0], output_workspace, covariance_matrix)
             workspace_names = [workspace_name]
 
         self._add_fit_to_context(self._add_workspace_to_ADS(parameter_table, table_name, table_directory),
-                                 self.dataset_names, workspace_names, global_parameters)
+                                 input_workspace_names, workspace_names, global_parameters)
 
-    def _add_multiple_fit_workspaces_to_ADS(self, output_workspace, covariance_matrix) -> tuple:
+    def _add_multiple_fit_workspaces_to_ADS(self, input_workspace_names: list, output_workspace, covariance_matrix):
         """Adds the results of a simultaneous fit to the ADS and fitting context if multiple workspaces were fitted."""
         suffix = self.function_name
-        workspace_names, workspace_directory = create_multi_domain_fitted_workspace_name(self.dataset_names[0], suffix)
-        table_name, table_directory = create_parameter_table_name(self.dataset_names[0] + "+ ...", suffix)
+        workspace_names, workspace_directory = create_multi_domain_fitted_workspace_name(input_workspace_names[0],
+                                                                                         suffix)
+        table_name, table_directory = create_parameter_table_name(input_workspace_names[0] + "+ ...", suffix)
 
         self._add_workspace_to_ADS(output_workspace, workspace_names, "")
-        workspace_names = self._rename_members_of_fitted_workspace_group(workspace_names)
+        workspace_names = self._rename_members_of_fitted_workspace_group(input_workspace_names, workspace_names)
         self._add_workspace_to_ADS(covariance_matrix, workspace_names[0] + "_CovarianceMatrix", table_directory)
 
         return workspace_names, table_name, table_directory
@@ -381,11 +383,11 @@ class GeneralFittingModel(BasicFittingModel):
         else:
             return []
 
-    def _rename_members_of_fitted_workspace_group(self, group_workspace: str) -> list:
+    def _rename_members_of_fitted_workspace_group(self, input_workspace_names: list, group_workspace: str) -> list:
         """Renames the fit result workspaces within a group workspace."""
         self.context.ads_observer.observeRename(False)
         output_names = [self._rename_workspace(input_name, workspace_name) for input_name, workspace_name in
-                        zip(self.dataset_names, self._get_names_in_group_workspace(group_workspace))]
+                        zip(input_workspace_names, self._get_names_in_group_workspace(group_workspace))]
         self.context.ads_observer.observeRename(True)
 
         return output_names

--- a/scripts/Muon/GUI/Common/fitting_widgets/general_fitting/general_fitting_model.py
+++ b/scripts/Muon/GUI/Common/fitting_widgets/general_fitting/general_fitting_model.py
@@ -184,6 +184,23 @@ class GeneralFittingModel(BasicFittingModel):
 
         return self._sort_workspace_names(display_workspaces)
 
+    def get_fit_function_parameters(self) -> list:
+        """Returns the names of the fit parameters in the fit functions."""
+        if self.simultaneous_fitting_mode:
+            if self.simultaneous_fit_function is not None:
+                return [self.simultaneous_fit_function.parameterName(i)
+                        for i in range(self.simultaneous_fit_function.nParams())]
+            return []
+        else:
+            return super().get_fit_function_parameters()
+
+    def get_all_fit_functions(self) -> list:
+        """Returns all the fit functions for the current fitting mode."""
+        if self.simultaneous_fitting_mode:
+            return [self.simultaneous_fit_function]
+        else:
+            return super().get_all_fit_functions()
+
     def get_active_fit_function(self) -> IFunction:
         """Returns the fit function that is active and will be used for a fit."""
         if self.simultaneous_fitting_mode:

--- a/scripts/Muon/GUI/Common/fitting_widgets/general_fitting/general_fitting_model.py
+++ b/scripts/Muon/GUI/Common/fitting_widgets/general_fitting/general_fitting_model.py
@@ -304,7 +304,8 @@ class GeneralFittingModel(BasicFittingModel):
     def perform_fit(self) -> tuple:
         """Performs a single or simultaneous fit and returns the resulting function, status and chi squared."""
         if self.simultaneous_fitting_mode:
-            return self._do_simultaneous_fit(self._get_parameters_for_simultaneous_fit(), self.global_parameters)
+            return self._do_simultaneous_fit(self._get_parameters_for_simultaneous_fit(
+                self.dataset_names, self.simultaneous_fit_function), self.global_parameters)
         else:
             return super().perform_fit()
 
@@ -338,10 +339,11 @@ class GeneralFittingModel(BasicFittingModel):
         for input_workspace, output in zip(self.dataset_names, self._get_names_in_group_workspace(output_group)):
             CopyLogs(InputWorkspace=input_workspace, OutputWorkspace=output, StoreInADS=False)
 
-    def _get_parameters_for_simultaneous_fit(self) -> dict:
+    def _get_parameters_for_simultaneous_fit(self, dataset_names: list, simultaneous_function: IFunction) -> dict:
         """Gets the parameters to use for a simultaneous fit."""
         params = self._get_common_parameters()
-        params["InputWorkspace"] = self.dataset_names
+        params["Function"] = simultaneous_function
+        params["InputWorkspace"] = dataset_names
         params["StartX"] = self.start_xs
         params["EndX"] = self.end_xs
         return params

--- a/scripts/Muon/GUI/Common/fitting_widgets/general_fitting/general_fitting_presenter.py
+++ b/scripts/Muon/GUI/Common/fitting_widgets/general_fitting/general_fitting_presenter.py
@@ -82,12 +82,13 @@ class GeneralFittingPresenter(BasicFittingPresenter):
         """Handle when the fitting mode is changed to or from simultaneous fitting."""
         self.model.simultaneous_fitting_mode = self.view.simultaneous_fitting_mode
         self.switch_fitting_mode_in_view()
-        self.automatically_update_function_name()
 
         self.update_fit_functions_in_model_from_view()
 
         # Triggers handle_dataset_name_changed
         self.update_dataset_names_in_view_and_model()
+
+        self.automatically_update_function_name()
 
         self.reset_fit_status_and_chi_squared_information()
         self.clear_cached_fit_functions()

--- a/scripts/Muon/GUI/Common/fitting_widgets/general_fitting/general_fitting_presenter.py
+++ b/scripts/Muon/GUI/Common/fitting_widgets/general_fitting/general_fitting_presenter.py
@@ -28,8 +28,8 @@ class GeneralFittingPresenter(BasicFittingPresenter):
         self.simultaneous_fit_by_specifier_changed = GenericObservable()
 
         self.selected_group_pair_observer = GenericObserver(self.handle_selected_group_pair_changed)
-
         self.instrument_changed_observer = GenericObserver(self.handle_instrument_changed)
+        self.fit_parameter_updated_observer = GenericObserver(self.update_fit_function_in_view_from_model)
 
         self.double_pulse_observer = GenericObserverWithArgPassing(self.handle_pulse_type_changed)
         self.model.context.gui_context.add_non_calc_subscriber(self.double_pulse_observer)
@@ -93,6 +93,7 @@ class GeneralFittingPresenter(BasicFittingPresenter):
         self.clear_cached_fit_functions()
 
         self.fitting_mode_changed_notifier.notify_subscribers()
+        self.fit_function_changed_notifier.notify_subscribers()
 
     def handle_simultaneous_fit_by_changed(self) -> None:
         """Handle when the simultaneous fit by combo box is changed."""
@@ -181,8 +182,6 @@ class GeneralFittingPresenter(BasicFittingPresenter):
         else:
             self.model.clear_simultaneous_fit_function()
             self.update_single_fit_functions_in_model()
-
-        self.fit_function_changed_notifier.notify_subscribers()
 
     def update_simultaneous_fit_function_in_model(self) -> None:
         """Updates the simultaneous fit function in the model using the view."""

--- a/scripts/Muon/GUI/Common/fitting_widgets/general_fitting/general_fitting_presenter.py
+++ b/scripts/Muon/GUI/Common/fitting_widgets/general_fitting/general_fitting_presenter.py
@@ -25,6 +25,7 @@ class GeneralFittingPresenter(BasicFittingPresenter):
         self._update_plot = True
 
         self.fitting_mode_changed_notifier = GenericObservable()
+        self.simultaneous_fit_by_specifier_changed = GenericObservable()
 
         self.selected_group_pair_observer = GenericObserver(self.handle_selected_group_pair_changed)
 
@@ -110,6 +111,8 @@ class GeneralFittingPresenter(BasicFittingPresenter):
         self.reset_start_xs_and_end_xs()
         self.reset_fit_status_and_chi_squared_information()
         self.clear_cached_fit_functions()
+
+        self.simultaneous_fit_by_specifier_changed.notify_subscribers()
 
     def handle_dataset_name_changed(self) -> None:
         """Handle when the display workspace combo box is changed."""

--- a/scripts/Muon/GUI/Common/fitting_widgets/tf_asymmetry_fitting/tf_asymmetry_fitting_model.py
+++ b/scripts/Muon/GUI/Common/fitting_widgets/tf_asymmetry_fitting/tf_asymmetry_fitting_model.py
@@ -77,7 +77,7 @@ class TFAsymmetryFittingModel(GeneralFittingModel):
         else:
             return DEFAULT_SINGLE_FIT_FUNCTION
 
-    def update_tf_single_fit_function(self, dataset_index: int, fit_function: IFunction) -> None:
+    def update_tf_asymmetry_single_fit_function(self, dataset_index: int, fit_function: IFunction) -> None:
         """Updates the specified TF Asymmetry and ordinary single fit function."""
         self.tf_asymmetry_single_functions[dataset_index] = fit_function
         self.single_fit_functions[dataset_index] = self._get_normal_fit_function_from(fit_function)
@@ -92,7 +92,7 @@ class TFAsymmetryFittingModel(GeneralFittingModel):
         """Sets the simultaneous TF Asymmetry fit function stored in the model."""
         self._tf_asymmetry_simultaneous_function = tf_asymmetry_simultaneous_function
 
-    def update_simultaneous_fit_functions(self, tf_asymmetry_simultaneous_function: IFunction) -> None:
+    def update_tf_asymmetry_simultaneous_fit_function(self, tf_asymmetry_simultaneous_function: IFunction) -> None:
         """Updates the TF Asymmetry and normal simultaneous fit function based on the function from a TFA fit."""
         self.tf_asymmetry_simultaneous_function = tf_asymmetry_simultaneous_function
 
@@ -888,30 +888,46 @@ class TFAsymmetryFittingModel(GeneralFittingModel):
         self._set_fit_function_parameter_values(self._get_normal_fit_function_from(tf_domain_function),
                                                 parameter_values_for_domain)
 
-    def _update_fit_functions_after_sequential_fit(self, workspaces, functions):
+    def _update_fit_functions_after_sequential_fit(self, workspaces: list, functions: list) -> None:
+        """Updates the fit functions after a sequential fit has been run on the Sequential fitting tab."""
         if self.tf_asymmetry_mode:
             if self.simultaneous_fitting_mode:
-                pass
+                self._update_tf_asymmetry_simultaneous_fit_function_after_sequential(workspaces, functions)
             else:
                 self._update_tf_asymmetry_single_fit_functions_after_sequential(workspaces, functions)
         else:
             if self.simultaneous_fitting_mode:
-                pass
+                self._update_simultaneous_fit_function_after_sequential(workspaces, functions)
             else:
                 self._update_single_fit_functions_after_sequential(workspaces, functions)
 
     def _update_single_fit_functions_after_sequential(self, workspaces: list, functions: list) -> None:
-        """Updates the single fit data after a sequential fit has been run on the Sequential fitting tab."""
+        """Updates the single fit functions after a sequential fit has been run on the Sequential fitting tab."""
         for workspace_index, workspace_name in enumerate(workspaces):
             if workspace_name in self.dataset_names:
                 dataset_index = self.dataset_names.index(workspace_name)
                 self.single_fit_functions[dataset_index] = functions[workspace_index]
 
     def _update_tf_asymmetry_single_fit_functions_after_sequential(self, workspaces: list, functions: list) -> None:
+        """Updates the TF single fit functions after a sequential fit has been run on the Sequential fitting tab."""
         for workspace_index, workspace_name in enumerate(workspaces):
             if workspace_name in self.dataset_names:
                 dataset_index = self.dataset_names.index(workspace_name)
-                self.update_tf_single_fit_function(dataset_index, functions[workspace_index])
+                self.update_tf_asymmetry_single_fit_function(dataset_index, functions[workspace_index])
+
+    def _update_simultaneous_fit_function_after_sequential(self, workspaces: list, functions: list) -> None:
+        """Updates the single fit functions after a sequential fit has been run on the Sequential fitting tab."""
+        for fit_index, workspace_names in enumerate(workspaces):
+            if self._are_same_workspaces_as_the_datasets(workspace_names):
+                self.simultaneous_fit_function = functions[fit_index]
+                break
+
+    def _update_tf_asymmetry_simultaneous_fit_function_after_sequential(self, workspaces: list, functions: list) -> None:
+        """Updates the single fit functions after a sequential fit has been run on the Sequential fitting tab."""
+        for fit_index, workspace_names in enumerate(workspaces):
+            if self._are_same_workspaces_as_the_datasets(workspace_names):
+                self.update_tf_asymmetry_simultaneous_fit_function(functions[fit_index])
+                break
 
     def _update_fit_statuses_and_chi_squared_after_sequential_fit(self, workspaces, fit_statuses, chi_squared_list):
         """Updates the fit statuses and chi squared after a sequential fit."""

--- a/scripts/Muon/GUI/Common/fitting_widgets/tf_asymmetry_fitting/tf_asymmetry_fitting_model.py
+++ b/scripts/Muon/GUI/Common/fitting_widgets/tf_asymmetry_fitting/tf_asymmetry_fitting_model.py
@@ -5,13 +5,15 @@
 #   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
 # SPDX - License - Identifier: GPL - 3.0 +
 from mantid import AlgorithmManager, logger
-from mantid.api import IFunction, MultiDomainFunction
+from mantid.api import IFunction
 from mantid.simpleapi import CopyLogs, ConvertFitFunctionForMuonTFAsymmetry
 
 from Muon.GUI.Common.ADSHandler.workspace_naming import (check_phasequad_name, create_fitted_workspace_name,
                                                          create_multi_domain_fitted_workspace_name,
-                                                         get_diff_asymmetry_name, get_group_asymmetry_name, get_group_or_pair_from_name,
-                                                         get_pair_asymmetry_name, get_pair_phasequad_name, get_run_numbers_as_string_from_workspace_name)
+                                                         get_diff_asymmetry_name, get_group_asymmetry_name,
+                                                         get_group_or_pair_from_name, get_pair_asymmetry_name,
+                                                         get_pair_phasequad_name,
+                                                         get_run_numbers_as_string_from_workspace_name)
 from Muon.GUI.Common.contexts.muon_context import MuonContext
 from Muon.GUI.Common.fitting_widgets.basic_fitting.basic_fitting_model import DEFAULT_SINGLE_FIT_FUNCTION
 from Muon.GUI.Common.fitting_widgets.general_fitting.general_fitting_model import GeneralFittingModel

--- a/scripts/Muon/GUI/Common/fitting_widgets/tf_asymmetry_fitting/tf_asymmetry_fitting_model.py
+++ b/scripts/Muon/GUI/Common/fitting_widgets/tf_asymmetry_fitting/tf_asymmetry_fitting_model.py
@@ -681,10 +681,10 @@ class TFAsymmetryFittingModel(GeneralFittingModel):
     def _update_tf_fit_function_parameters_for_simultaneous_fit(self, dataset_names: list, parameter_values: list):
         """Updates the tf asymmetry function parameters for the given dataset names if in simultaneous fit mode."""
         number_parameters_per_domain = int(len(parameter_values) / len(dataset_names))
-        for dataset_index, name in enumerate(dataset_names):
+        for name in dataset_names:
             if name in self.dataset_names:
                 self._set_parameter_values_in_tf_asymmetry_simultaneous_function_domain(
-                    self.tf_asymmetry_simultaneous_function, dataset_index, parameter_values,
+                    self.tf_asymmetry_simultaneous_function, self.dataset_names.index(name), parameter_values,
                     number_parameters_per_domain)
 
     def get_fit_workspace_names_from_groups_and_runs(self, runs: list, groups_and_pairs: list) -> list:

--- a/scripts/Muon/GUI/Common/fitting_widgets/tf_asymmetry_fitting/tf_asymmetry_fitting_model.py
+++ b/scripts/Muon/GUI/Common/fitting_widgets/tf_asymmetry_fitting/tf_asymmetry_fitting_model.py
@@ -476,8 +476,9 @@ class TFAsymmetryFittingModel(GeneralFittingModel):
         output_workspace, parameter_table, function, fit_status, chi_squared, covariance_matrix = \
             self._run_tf_asymmetry_fit(parameters)
 
-        CopyLogs(InputWorkspace=self.current_dataset_name, OutputWorkspace=output_workspace, StoreInADS=False)
-        self._add_single_fit_results_to_ADS_and_context(self.current_dataset_name, parameter_table, output_workspace,
+        dataset_name = parameters["ReNormalizedWorkspaceList"]
+        CopyLogs(InputWorkspace=dataset_name, OutputWorkspace=output_workspace, StoreInADS=False)
+        self._add_single_fit_results_to_ADS_and_context(dataset_name, parameter_table, output_workspace,
                                                         covariance_matrix)
         return function, fit_status, chi_squared
 
@@ -486,9 +487,10 @@ class TFAsymmetryFittingModel(GeneralFittingModel):
         output_workspace, parameter_table, function, fit_status, chi_squared, covariance_matrix = \
             self._run_tf_asymmetry_fit(parameters)
 
-        self._copy_logs(output_workspace)
-        self._add_simultaneous_fit_results_to_ADS_and_context(parameter_table, output_workspace, covariance_matrix,
-                                                              global_parameters)
+        dataset_names = parameters["ReNormalizedWorkspaceList"]
+        self._copy_logs(dataset_names, output_workspace)
+        self._add_simultaneous_fit_results_to_ADS_and_context(dataset_names, parameter_table, output_workspace,
+                                                              covariance_matrix, global_parameters)
         return function, fit_status, chi_squared
 
     def _run_tf_asymmetry_fit(self, parameters: dict) -> tuple:
@@ -756,7 +758,6 @@ class TFAsymmetryFittingModel(GeneralFittingModel):
         functions, fit_statuses, chi_squared_list = [], [], []
 
         for row_index, row_workspaces in enumerate(workspace_names):
-            logger.warning(str(row_workspaces))
             function, fit_status, chi_squared = fitting_func(row_index, row_workspaces, parameter_values[row_index],
                                                              functions, use_initial_values)
 

--- a/scripts/Muon/GUI/Common/fitting_widgets/tf_asymmetry_fitting/tf_asymmetry_fitting_model.py
+++ b/scripts/Muon/GUI/Common/fitting_widgets/tf_asymmetry_fitting/tf_asymmetry_fitting_model.py
@@ -733,14 +733,16 @@ class TFAsymmetryFittingModel(GeneralFittingModel):
 
     def _get_runs_groups_and_pairs_for_simultaneous_fit_by_runs(self):
         """Returns the runs and group/pairs for the selected data in simultaneous fit by runs mode."""
+        runs = self._get_selected_runs()
         groups_and_pairs = [get_group_or_pair_from_name(name) for name in self.dataset_names]
-        return [self.simultaneous_fit_by_specifier], [";".join(groups_and_pairs)]
+        return runs, [";".join(groups_and_pairs)] * len(runs)
 
     def _get_runs_groups_and_pairs_for_simultaneous_fit_by_groups_and_pairs(self):
         """Returns the runs and group/pairs for the selected data in simultaneous fit by group/pairs mode."""
         runs = [get_run_numbers_as_string_from_workspace_name(name, self.context.data_context.instrument)
                 for name in self.dataset_names]
-        return [";".join(runs)], [self.simultaneous_fit_by_specifier]
+        groups_and_pairs = self._get_selected_groups_and_pairs()
+        return [";".join(runs)] * len(groups_and_pairs), groups_and_pairs
 
     def perform_sequential_fit(self, workspaces: list, parameter_values: list, use_initial_values: bool = False):
         """Performs a sequential fit of the workspace names provided for the current fitting mode.

--- a/scripts/Muon/GUI/Common/fitting_widgets/tf_asymmetry_fitting/tf_asymmetry_fitting_model.py
+++ b/scripts/Muon/GUI/Common/fitting_widgets/tf_asymmetry_fitting/tf_asymmetry_fitting_model.py
@@ -485,10 +485,14 @@ class TFAsymmetryFittingModel(GeneralFittingModel):
         params["OutputFitWorkspace"] = fit_workspace_name
         return params
 
-    def _get_parameters_for_tf_asymmetry_simultaneous_fit(self) -> dict:
+    def _get_parameters_for_tf_asymmetry_simultaneous_fit(self, tf_simultaneous_function: IFunction = None) -> dict:
         """Returns the parameters to use for a simultaneous TF Asymmetry fit."""
         params = self._get_common_tf_asymmetry_parameters()
-        params["InputFunction"] = str(self.tf_asymmetry_simultaneous_function) + self._construct_global_tie_appendage()
+        if tf_simultaneous_function is not None:
+            params["InputFunction"] = str(tf_simultaneous_function)
+        else:
+            params["InputFunction"] = str(self.tf_asymmetry_simultaneous_function)
+        params["InputFunction"] += self._construct_global_tie_appendage()
         params["ReNormalizedWorkspaceList"] = self.dataset_names
         params["UnNormalizedWorkspaceList"] = self._get_unnormalised_workspace_list(self.dataset_names)
 
@@ -676,3 +680,113 @@ class TFAsymmetryFittingModel(GeneralFittingModel):
         runs = [get_run_numbers_as_string_from_workspace_name(name, self.context.data_context.instrument)
                 for name in self.dataset_names]
         return [";".join(runs)], [self.simultaneous_fit_by_specifier]
+
+    def evaluate_sequential_fit(self, workspaces, use_initial_values):
+        pass
+    #     # workspaces are stored as list of list [[Fit1 workspaces], [Fit2 workspaces], [Fit3 workspaces]]
+    #     if self.fitting_options["fit_type"] == "Single":
+    #         # flatten the workspace list
+    #         workspace_list = [workspace for fit_workspaces in workspaces for workspace in fit_workspaces]
+    #         if self.fitting_options["tf_asymmetry_mode"]:
+    #             function_object, output_status, output_chi_squared = self.do_sequential_tf_fit(workspace_list,
+    #                                                                                            use_initial_values)
+    #         else:
+    #             function_object, output_status, output_chi_squared = self.do_sequential_fit(workspace_list,
+    #                                                                                         use_initial_values)
+    #     else:
+    #         # in a simultaneous-sequential fit, each fit corresponds to a list of workspaces
+    #         if self.fitting_options["tf_asymmetry_mode"]:
+    #             function_object, output_status, output_chi_squared = \
+    #                 self.do_sequential_simultaneous_tf_fit(workspaces, use_initial_values)
+    #         else:
+    #             function_object, output_status, output_chi_squared = \
+    #                 self.do_sequential_simultaneous_fit(workspaces, use_initial_values)
+    #
+    #     return function_object, output_status, output_chi_squared
+    #
+    # def do_sequential_fit(self, workspace_list, use_initial_values=False):
+    #     function_object_list = []
+    #     output_status_list = []
+    #     output_chi_squared_list = []
+    #
+    #     for i, input_workspace in enumerate(workspace_list):
+    #         params = self.get_parameters_for_single_fit(input_workspace)
+    #
+    #         if not use_initial_values and i >= 1:
+    #             previous_values = self.get_fit_function_parameter_values(function_object_list[i - 1])
+    #             self.set_fit_function_parameter_values(params['Function'],
+    #                                                    previous_values)
+    #
+    #         function_object, output_status, output_chi_squared = self.do_single_fit(params)
+    #
+    #         function_object_list.append(function_object)
+    #         output_status_list.append(output_status)
+    #         output_chi_squared_list.append(output_chi_squared)
+    #
+    #     return function_object_list, output_status_list, output_chi_squared_list
+    #
+    # def do_sequential_simultaneous_fit(self, workspaces, use_initial_values=False):
+    #     function_object_list = []
+    #     output_status_list = []
+    #     output_chi_squared_list = []
+    #
+    #     # workspaces defines a list of lists [[ws1,ws2],[ws1,ws2]...]
+    #     for i, workspace_list in enumerate(workspaces):
+    #         params = self.get_parameters_for_simultaneous_fit(workspace_list)
+    #
+    #         if not use_initial_values and i >= 1:
+    #             previous_values = self.get_fit_function_parameter_values(function_object_list[i - 1])
+    #             self.set_fit_function_parameter_values(params['Function'], previous_values)
+    #
+    #         function_object, output_status, output_chi_squared = \
+    #             self.do_simultaneous_fit(params, self.fitting_options["global_parameters"])
+    #         function_object_list.append(function_object)
+    #         output_status_list.append(output_status)
+    #         output_chi_squared_list.append(output_chi_squared)
+    #
+    #     return function_object_list, output_status_list, output_chi_squared_list
+    #
+    # def do_sequential_tf_fit(self, workspace_list, use_initial_values=False):
+    #     function_object_list = []
+    #     output_status_list = []
+    #     output_chi_squared_list = []
+    #
+    #     for i, input_workspace in enumerate(workspace_list):
+    #         params = self.get_parameters_for_single_tf_fit(input_workspace)
+    #
+    #         if not use_initial_values and i >= 1:
+    #             previous_values = self.get_fit_function_parameter_values(function_object_list[i - 1])
+    #             self.set_fit_function_parameter_values(params['InputFunction'],
+    #                                                    previous_values)
+    #
+    #         function_object, output_status, output_chi_squared = self.do_single_tf_fit(params)
+    #
+    #         function_object_list.append(function_object)
+    #         output_status_list.append(output_status)
+    #         output_chi_squared_list.append(output_chi_squared)
+    #
+    #     return function_object_list, output_status_list, output_chi_squared_list
+    #
+    # def do_sequential_simultaneous_tf_fit(self, workspaces, use_initial_values=False):
+    #     functions = []
+    #     fit_statuses = []
+    #     chi_squared_list = []
+    #
+    #     for i, workspace_list in enumerate(workspaces):
+    #         if not use_initial_values and i >= 1:
+    #             params = self._get_parameters_for_tf_asymmetry_simultaneous_fit(workspace_list)
+    #         else:
+    #             params = self._get_parameters_for_tf_asymmetry_simultaneous_fit(workspace_list)
+    #
+    #         if not use_initial_values and i >= 1:
+    #             previous_values = self._get_parameters_for_tf_asymmetry_simultaneous_fit(functions[i - 1])
+    #             self.set_fit_function_parameter_values(params["InputFunction"], previous_values)
+    #
+    #         function, fit_status, chi_squared = self._do_tf_asymmetry_simultaneous_fit(
+    #             params, self._get_global_parameters_for_tf_asymmetry_fit())
+    #
+    #         functions.append(function)
+    #         fit_statuses.append(fit_status)
+    #         chi_squared_list.append(chi_squared)
+    #
+    #     return functions, fit_statuses, chi_squared_list

--- a/scripts/Muon/GUI/Common/fitting_widgets/tf_asymmetry_fitting/tf_asymmetry_fitting_model.py
+++ b/scripts/Muon/GUI/Common/fitting_widgets/tf_asymmetry_fitting/tf_asymmetry_fitting_model.py
@@ -804,7 +804,7 @@ class TFAsymmetryFittingModel(GeneralFittingModel):
     def _do_sequential_fit(self, row_index: int, workspace_name: str, parameter_values: list, functions: list,
                            use_initial_values: bool = False):
         """Performs a sequential fit of the single fit data."""
-        single_function = functions[row_index - 1] if not use_initial_values and row_index >= 1 else \
+        single_function = functions[row_index - 1].clone() if not use_initial_values and row_index >= 1 else \
             self._get_single_function_with_parameters(parameter_values)
 
         params = self._get_parameters_for_single_fit(workspace_name, single_function)
@@ -820,7 +820,7 @@ class TFAsymmetryFittingModel(GeneralFittingModel):
     def _do_sequential_simultaneous_fits(self, row_index: int, workspace_names: list, parameter_values: list,
                                          functions: list, use_initial_values: bool = False):
         """Performs a number of simultaneous fits, sequentially."""
-        simultaneous_function = functions[row_index - 1] if not use_initial_values and row_index >= 1 else \
+        simultaneous_function = functions[row_index - 1].clone() if not use_initial_values and row_index >= 1 else \
             self._get_simultaneous_function_with_parameters(parameter_values)
 
         params = self._get_parameters_for_simultaneous_fit(workspace_names, simultaneous_function)
@@ -836,7 +836,7 @@ class TFAsymmetryFittingModel(GeneralFittingModel):
     def _do_sequential_tf_asymmetry_fit(self, row_index: int, workspace_name: str, parameter_values: list,
                                         functions: list, use_initial_values: bool = False):
         """Performs a sequential fit of the TF Asymmetry single fit data."""
-        tf_single_function = functions[row_index - 1] if not use_initial_values and row_index >= 1 else \
+        tf_single_function = functions[row_index - 1].clone() if not use_initial_values and row_index >= 1 else \
             self._get_tf_asymmetry_single_function_with_parameters(parameter_values)
 
         params = self._get_parameters_for_tf_asymmetry_single_fit(workspace_name, tf_single_function)
@@ -858,7 +858,7 @@ class TFAsymmetryFittingModel(GeneralFittingModel):
                                                       parameter_values: list, functions: list,
                                                       use_initial_values: bool = False):
         """Performs a number of TF Asymmetry simultaneous fits, sequentially."""
-        tf_simultaneous_function = functions[row_index - 1] if not use_initial_values and row_index >= 1 else \
+        tf_simultaneous_function = functions[row_index - 1].clone() if not use_initial_values and row_index >= 1 else \
             self._get_tf_asymmetry_simultaneous_function_with_parameters(parameter_values)
 
         params = self._get_parameters_for_tf_asymmetry_simultaneous_fit(workspace_names, tf_simultaneous_function)

--- a/scripts/Muon/GUI/Common/fitting_widgets/tf_asymmetry_fitting/tf_asymmetry_fitting_model.py
+++ b/scripts/Muon/GUI/Common/fitting_widgets/tf_asymmetry_fitting/tf_asymmetry_fitting_model.py
@@ -264,23 +264,21 @@ class TFAsymmetryFittingModel(GeneralFittingModel):
         else:
             return parameters
 
-    def get_all_fit_function_parameter_values_for(self, fit_function: IFunction, tf_function_index: int) -> list:
+    def get_all_fit_function_parameter_values_for(self, fit_function: IFunction) -> list:
         """Returns the values of the fit function parameters. Also returns the normalisation for TF Asymmetry mode."""
         if self.tf_asymmetry_mode:
             if self.simultaneous_fitting_mode:
                 return self._get_all_fit_function_parameter_values_for_tf_simultaneous_function(fit_function)
             else:
-                return self._get_all_fit_function_parameter_values_for_tf_single_function(fit_function,
-                                                                                          tf_function_index)
+                return self._get_all_fit_function_parameter_values_for_tf_single_function(fit_function)
         else:
             return self.get_fit_function_parameter_values(fit_function)
 
-    def _get_all_fit_function_parameter_values_for_tf_single_function(self, tf_single_function: IFunction,
-                                                                      tf_function_index: int) -> list:
+    def _get_all_fit_function_parameter_values_for_tf_single_function(self, tf_single_function: IFunction) -> list:
         """Returns the required parameters values including normalisation from a TF asymmetry single function."""
         normal_single_function = self._get_normal_fit_function_from(tf_single_function)
         parameter_values = self.get_fit_function_parameter_values(normal_single_function)
-        return [self._get_normalisation_from_tf_fit_function(tf_single_function, tf_function_index)] + parameter_values
+        return [self._get_normalisation_from_tf_fit_function(tf_single_function)] + parameter_values
 
     def _get_all_fit_function_parameter_values_for_tf_simultaneous_function(self, tf_simultaneous_function: IFunction) -> list:
         """Returns the required parameters values including normalisation from a TF asymmetry simultaneous function."""
@@ -373,7 +371,7 @@ class TFAsymmetryFittingModel(GeneralFittingModel):
                 "Mode": "Construct" if self.tf_asymmetry_mode else "Extract",
                 "CopyTies": False}
 
-    def _get_normalisation_from_tf_fit_function(self, tf_function: IFunction, function_index: int) -> float:
+    def _get_normalisation_from_tf_fit_function(self, tf_function: IFunction, function_index: int = 0) -> float:
         """Returns the normalisation in the specified TF Asymmetry fit function."""
         if self.simultaneous_fitting_mode:
             return self._get_normalisation_from_tf_asymmetry_simultaneous_function(tf_function, function_index)

--- a/scripts/Muon/GUI/Common/fitting_widgets/tf_asymmetry_fitting/tf_asymmetry_fitting_presenter.py
+++ b/scripts/Muon/GUI/Common/fitting_widgets/tf_asymmetry_fitting/tf_asymmetry_fitting_presenter.py
@@ -77,10 +77,10 @@ class TFAsymmetryFittingPresenter(GeneralFittingPresenter):
 
         self.update_tf_asymmetry_functions_in_model_and_view()
 
+        self.automatically_update_function_name()
+
         self.reset_fit_status_and_chi_squared_information()
         self.clear_cached_fit_functions()
-
-        self.automatically_update_function_name()
 
         if self._update_plot:
             self.selected_fit_results_changed.notify_subscribers(self.model.get_active_fit_results())

--- a/scripts/Muon/GUI/Common/fitting_widgets/tf_asymmetry_fitting/tf_asymmetry_fitting_presenter.py
+++ b/scripts/Muon/GUI/Common/fitting_widgets/tf_asymmetry_fitting/tf_asymmetry_fitting_presenter.py
@@ -114,7 +114,7 @@ class TFAsymmetryFittingPresenter(GeneralFittingPresenter):
             if self.model.simultaneous_fitting_mode:
                 self.model.update_simultaneous_fit_functions(fit_function)
             else:
-                self.model.update_current_single_fit_functions(fit_function)
+                self.model.update_tf_single_fit_function(self.model.current_dataset_index, fit_function)
         else:
             super().update_fit_function_in_model(fit_function)
 

--- a/scripts/Muon/GUI/Common/fitting_widgets/tf_asymmetry_fitting/tf_asymmetry_fitting_presenter.py
+++ b/scripts/Muon/GUI/Common/fitting_widgets/tf_asymmetry_fitting/tf_asymmetry_fitting_presenter.py
@@ -5,6 +5,7 @@
 #   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
 # SPDX - License - Identifier: GPL - 3.0 +
 from mantid.api import IFunction
+from mantidqt.utils.observer_pattern import GenericObserver
 
 from Muon.GUI.Common.fitting_widgets.general_fitting.general_fitting_presenter import GeneralFittingPresenter
 from Muon.GUI.Common.fitting_widgets.tf_asymmetry_fitting.tf_asymmetry_fitting_model import TFAsymmetryFittingModel
@@ -20,6 +21,8 @@ class TFAsymmetryFittingPresenter(GeneralFittingPresenter):
     def __init__(self, view: TFAsymmetryFittingView, model: TFAsymmetryFittingModel):
         """Initialize the TFAsymmetryFittingPresenter. Sets up the slots and event observers."""
         super(TFAsymmetryFittingPresenter, self).__init__(view, model)
+
+        self.sequential_fit_finished_observer = GenericObserver(self.handle_sequential_fit_finished)
 
         self.view.set_slot_for_fitting_type_changed(self.handle_tf_asymmetry_mode_changed)
         self.view.set_slot_for_normalisation_changed(self.handle_normalisation_changed)
@@ -96,6 +99,11 @@ class TFAsymmetryFittingPresenter(GeneralFittingPresenter):
         """Handles when the value of the current normalisation has been fixed or unfixed."""
         self.model.fix_current_normalisation(is_fixed)
 
+    def handle_sequential_fit_finished(self) -> None:
+        """Handles when a sequential fit has been performed and has finished executing in the sequential fitting tab."""
+        self.update_fit_function_in_view_from_model()
+        self.update_fit_statuses_and_chi_squared_in_view_from_model()
+
     def update_and_reset_all_data(self) -> None:
         """Updates the various data displayed in the fitting widget. Resets and clears previous fit information."""
         super().update_and_reset_all_data()
@@ -112,9 +120,9 @@ class TFAsymmetryFittingPresenter(GeneralFittingPresenter):
         """Updates the fit function stored in the model. This is used after a fit."""
         if self.model.tf_asymmetry_mode:
             if self.model.simultaneous_fitting_mode:
-                self.model.update_simultaneous_fit_functions(fit_function)
+                self.model.update_tf_asymmetry_simultaneous_fit_function(fit_function)
             else:
-                self.model.update_tf_single_fit_function(self.model.current_dataset_index, fit_function)
+                self.model.update_tf_asymmetry_single_fit_function(self.model.current_dataset_index, fit_function)
         else:
             super().update_fit_function_in_model(fit_function)
 

--- a/scripts/Muon/GUI/Common/seq_fitting_tab_widget/seq_fitting_tab_presenter.py
+++ b/scripts/Muon/GUI/Common/seq_fitting_tab_widget/seq_fitting_tab_presenter.py
@@ -9,7 +9,7 @@ from mantidqt.utils.observer_pattern import GenericObserver, GenericObserverWith
 from Muon.GUI.Common.thread_model_wrapper import ThreadModelWrapperWithOutput
 from Muon.GUI.Common import thread_model
 
-# import functools
+import functools
 
 
 class SeqFittingTabPresenter(object):
@@ -85,23 +85,20 @@ class SeqFittingTabPresenter(object):
         self.view.fit_table.block_signals(False)
 
     def handle_sequential_fit_requested(self):
-        pass
-        # if self.model.fit_function is None or len(self.selected_rows) == 0:
-        #     return
-        #
-        # workspace_names = []
-        # for row in self.selected_rows:
-        #     workspace_names += [self.get_workspaces_for_row_in_fit_table(row)]
-        #
-        # calculation_function = functools.partial(
-        #     self.model.evaluate_sequential_fit, workspace_names, self.view.use_initial_values_for_fits())
-        # self.calculation_thread = self.create_thread(
-        #     calculation_function)
-        #
-        # self.calculation_thread.threadWrapperSetUp(on_thread_start_callback=self.handle_fit_started,
-        #                                            on_thread_end_callback=self.handle_seq_fit_finished,
-        #                                            on_thread_exception_callback=self.handle_fit_error)
-        # self.calculation_thread.start()
+        if self.model.get_active_fit_function() is None or len(self.selected_rows) == 0:
+            return
+
+        workspace_names = [self.get_workspaces_for_row_in_fit_table(row) for row in self.selected_rows]
+
+        calculation_function = functools.partial(
+            self.model.evaluate_sequential_fit, workspace_names, self.view.use_initial_values_for_fits())
+        self.calculation_thread = self.create_thread(
+            calculation_function)
+
+        self.calculation_thread.threadWrapperSetUp(on_thread_start_callback=self.handle_fit_started,
+                                                   on_thread_end_callback=self.handle_seq_fit_finished,
+                                                   on_thread_exception_callback=self.handle_fit_error)
+        self.calculation_thread.start()
 
     def handle_seq_fit_finished(self):
         if self.fitting_calculation_model.result is None:

--- a/scripts/Muon/GUI/Common/seq_fitting_tab_widget/seq_fitting_tab_presenter.py
+++ b/scripts/Muon/GUI/Common/seq_fitting_tab_widget/seq_fitting_tab_presenter.py
@@ -107,7 +107,9 @@ class SeqFittingTabPresenter(object):
         fit_functions, fit_statuses, fit_chi_squareds = self.fitting_calculation_model.result
         for fit_function, fit_status, fit_chi_squared, row in zip(fit_functions, fit_statuses, fit_chi_squareds,
                                                                   self.selected_rows):
-            parameter_values = self.model.get_fit_function_parameter_values(fit_function)
+            parameter_values = self.model.get_all_fit_function_parameter_values_for(fit_function, row)
+            from mantid import logger
+            logger.warning(str(parameter_values))
             self.view.fit_table.set_parameter_values_for_row(row, parameter_values)
             self.view.fit_table.set_fit_quality(row, fit_status, fit_chi_squared)
 
@@ -122,12 +124,13 @@ class SeqFittingTabPresenter(object):
             self.handle_fit_selected_in_table()
 
     def handle_updated_fit_parameter_in_table(self, index):
-        row = index.row()
+        self._update_parameter_values_in_fitting_model_for_row(index.row())
+        self.fit_parameter_changed_notifier.notify_subscribers()
+
+    def _update_parameter_values_in_fitting_model_for_row(self, row):
         workspaces = self.get_workspaces_for_row_in_fit_table(row)
         parameter_values = self.view.fit_table.get_fit_parameter_values_from_row(row)
         self.model.update_ws_fit_function_parameters(workspaces, parameter_values)
-
-        self.fit_parameter_changed_notifier.notify_subscribers()
 
     def handle_fit_selected_in_table(self):
         rows = self.view.fit_table.get_selected_rows()

--- a/scripts/Muon/GUI/Common/seq_fitting_tab_widget/seq_fitting_tab_presenter.py
+++ b/scripts/Muon/GUI/Common/seq_fitting_tab_widget/seq_fitting_tab_presenter.py
@@ -89,8 +89,7 @@ class SeqFittingTabPresenter(object):
             return
 
         workspace_names = [self.get_workspaces_for_row_in_fit_table(row) for row in self.selected_rows]
-
-        parameter_values = []
+        parameter_values = [self.view.fit_table.get_fit_parameter_values_from_row(row) for row in self.selected_rows]
 
         calculation_function = functools.partial(self.model.perform_sequential_fit, workspace_names, parameter_values,
                                                  self.view.use_initial_values_for_fits())

--- a/scripts/Muon/GUI/Common/seq_fitting_tab_widget/seq_fitting_tab_presenter.py
+++ b/scripts/Muon/GUI/Common/seq_fitting_tab_widget/seq_fitting_tab_presenter.py
@@ -90,7 +90,9 @@ class SeqFittingTabPresenter(object):
 
         workspace_names = [self.get_workspaces_for_row_in_fit_table(row) for row in self.selected_rows]
 
-        calculation_function = functools.partial(self.model.perform_sequential_fit, workspace_names,
+        parameter_values = []
+
+        calculation_function = functools.partial(self.model.perform_sequential_fit, workspace_names, parameter_values,
                                                  self.view.use_initial_values_for_fits())
         self.calculation_thread = self.create_thread(calculation_function)
 

--- a/scripts/Muon/GUI/Common/seq_fitting_tab_widget/seq_fitting_tab_presenter.py
+++ b/scripts/Muon/GUI/Common/seq_fitting_tab_widget/seq_fitting_tab_presenter.py
@@ -90,10 +90,9 @@ class SeqFittingTabPresenter(object):
 
         workspace_names = [self.get_workspaces_for_row_in_fit_table(row) for row in self.selected_rows]
 
-        calculation_function = functools.partial(
-            self.model.evaluate_sequential_fit, workspace_names, self.view.use_initial_values_for_fits())
-        self.calculation_thread = self.create_thread(
-            calculation_function)
+        calculation_function = functools.partial(self.model.perform_sequential_fit, workspace_names,
+                                                 self.view.use_initial_values_for_fits())
+        self.calculation_thread = self.create_thread(calculation_function)
 
         self.calculation_thread.threadWrapperSetUp(on_thread_start_callback=self.handle_fit_started,
                                                    on_thread_end_callback=self.handle_seq_fit_finished,

--- a/scripts/Muon/GUI/Common/seq_fitting_tab_widget/seq_fitting_tab_presenter.py
+++ b/scripts/Muon/GUI/Common/seq_fitting_tab_widget/seq_fitting_tab_presenter.py
@@ -54,7 +54,7 @@ class SeqFittingTabPresenter(object):
             self.view.fit_table.set_parameters_and_values(parameters, parameter_values)
 
     def _get_fit_function_parameter_values_from_fitting_model(self):
-        parameter_values = [self.model.get_all_fit_function_parameter_values_for(fit_function, row)
+        parameter_values = [self.model.get_all_fit_function_parameter_values_for(fit_function)
                             for row, fit_function in enumerate(self.model.get_all_fit_functions())]
         if len(parameter_values) != self.view.fit_table.get_number_of_fits():
             parameter_values *= self.view.fit_table.get_number_of_fits()
@@ -63,7 +63,7 @@ class SeqFittingTabPresenter(object):
     def handle_fit_function_parameter_changed(self):
         self.view.fit_table.reset_fit_quality()
         for row, fit_function in enumerate(self.model.get_all_fit_functions()):
-            parameter_values = self.model.get_all_fit_function_parameter_values_for(fit_function, row)
+            parameter_values = self.model.get_all_fit_function_parameter_values_for(fit_function)
             self.view.fit_table.set_parameter_values_for_row(row, parameter_values)
 
     def handle_selected_workspaces_changed(self):
@@ -114,7 +114,7 @@ class SeqFittingTabPresenter(object):
         fit_functions, fit_statuses, fit_chi_squareds = self.fitting_calculation_model.result
         for fit_function, fit_status, fit_chi_squared, row in zip(fit_functions, fit_statuses, fit_chi_squareds,
                                                                   self.selected_rows):
-            parameter_values = self.model.get_all_fit_function_parameter_values_for(fit_function, row)
+            parameter_values = self.model.get_all_fit_function_parameter_values_for(fit_function)
             self.view.fit_table.set_parameter_values_for_row(row, parameter_values)
             self.view.fit_table.set_fit_quality(row, fit_status, fit_chi_squared)
 

--- a/scripts/Muon/GUI/Common/seq_fitting_tab_widget/seq_fitting_tab_presenter.py
+++ b/scripts/Muon/GUI/Common/seq_fitting_tab_widget/seq_fitting_tab_presenter.py
@@ -25,6 +25,7 @@ class SeqFittingTabPresenter(object):
         self.fitting_calculation_model = None
 
         self.fit_parameter_changed_notifier = GenericObservable()
+        self.sequential_fit_finished_notifier = GenericObservable()
 
         # Observers
         self.selected_workspaces_observer = GenericObserver(self.handle_selected_workspaces_changed)
@@ -108,8 +109,6 @@ class SeqFittingTabPresenter(object):
         for fit_function, fit_status, fit_chi_squared, row in zip(fit_functions, fit_statuses, fit_chi_squareds,
                                                                   self.selected_rows):
             parameter_values = self.model.get_all_fit_function_parameter_values_for(fit_function, row)
-            from mantid import logger
-            logger.warning(str(parameter_values))
             self.view.fit_table.set_parameter_values_for_row(row, parameter_values)
             self.view.fit_table.set_fit_quality(row, fit_status, fit_chi_squared)
 
@@ -122,6 +121,8 @@ class SeqFittingTabPresenter(object):
             self.view.fit_table.set_selection_to_last_row()
         else:
             self.handle_fit_selected_in_table()
+
+        self.sequential_fit_finished_notifier.notify_subscribers()
 
     def handle_updated_fit_parameter_in_table(self, index):
         self._update_parameter_values_in_fitting_model_for_row(index.row())

--- a/scripts/Muon/GUI/Common/seq_fitting_tab_widget/seq_fitting_tab_presenter.py
+++ b/scripts/Muon/GUI/Common/seq_fitting_tab_widget/seq_fitting_tab_presenter.py
@@ -68,11 +68,9 @@ class SeqFittingTabPresenter(object):
         #     self.view.fit_table.set_parameter_values_for_row(row, parameter_values)
 
     def handle_selected_workspaces_changed(self):
-        pass
-        # runs, groups_and_pairs = self.model.get_selected_runs_groups_and_pairs()
-        # self.view.fit_table.set_fit_workspaces(runs, groups_and_pairs)
-        # self.model.create_ws_fit_function_map()
-        # self.handle_fit_function_updated()
+        runs, groups_and_pairs = self.model.get_runs_groups_and_pairs_for_fits()
+        self.view.fit_table.set_fit_workspaces(runs, groups_and_pairs)
+        self.handle_fit_function_updated()
 
     def handle_fit_selected_pressed(self):
         self.selected_rows = self.view.fit_table.get_selected_rows()
@@ -135,11 +133,12 @@ class SeqFittingTabPresenter(object):
             self.handle_fit_selected_in_table()
 
     def handle_updated_fit_parameter_in_table(self, index):
-        pass
-        # row = index.row()
-        # workspaces = self.get_workspaces_for_row_in_fit_table(row)
-        # parameter_values = self.view.fit_table.get_fit_parameter_values_from_row(row)
-        # self.model.update_ws_fit_function_parameters(workspaces, parameter_values)
+        from mantid import logger
+        logger.warning("HERE")
+        row = index.row()
+        workspaces = self.get_workspaces_for_row_in_fit_table(row)
+        parameter_values = self.view.fit_table.get_fit_parameter_values_from_row(row)
+        self.model.update_ws_fit_function_parameters(workspaces, parameter_values)
 
     def handle_fit_selected_in_table(self):
         rows = self.view.fit_table.get_selected_rows()

--- a/scripts/Muon/GUI/Common/seq_fitting_tab_widget/seq_fitting_tab_presenter.py
+++ b/scripts/Muon/GUI/Common/seq_fitting_tab_widget/seq_fitting_tab_presenter.py
@@ -50,9 +50,15 @@ class SeqFittingTabPresenter(object):
             self.view.fit_table.clear_fit_parameters()
             self.view.fit_table.reset_fit_quality()
         else:
-            parameter_values = [self.model.get_all_fit_function_parameter_values_for(fit_function, row)
-                                for row, fit_function in enumerate(self.model.get_all_fit_functions())]
+            parameter_values = self._get_fit_function_parameter_values_from_fitting_model()
             self.view.fit_table.set_parameters_and_values(parameters, parameter_values)
+
+    def _get_fit_function_parameter_values_from_fitting_model(self):
+        parameter_values = [self.model.get_all_fit_function_parameter_values_for(fit_function, row)
+                            for row, fit_function in enumerate(self.model.get_all_fit_functions())]
+        if len(parameter_values) != self.view.fit_table.get_number_of_fits():
+            parameter_values *= self.view.fit_table.get_number_of_fits()
+        return parameter_values
 
     def handle_fit_function_parameter_changed(self):
         self.view.fit_table.reset_fit_quality()

--- a/scripts/Muon/GUI/Common/seq_fitting_tab_widget/seq_fitting_tab_presenter.py
+++ b/scripts/Muon/GUI/Common/seq_fitting_tab_widget/seq_fitting_tab_presenter.py
@@ -46,7 +46,7 @@ class SeqFittingTabPresenter(object):
     def handle_fit_function_updated(self):
         parameters = self.model.get_fit_function_parameters()
 
-        if len(parameters) == 0:
+        if not parameters:
             self.view.fit_table.clear_fit_parameters()
             self.view.fit_table.reset_fit_quality()
         else:

--- a/scripts/Muon/GUI/MuonAnalysis/muon_analysis_2.py
+++ b/scripts/Muon/GUI/MuonAnalysis/muon_analysis_2.py
@@ -299,6 +299,9 @@ class MuonAnalysisGui(QtWidgets.QMainWindow):
         self.fitting_tab.fitting_tab_presenter.fitting_mode_changed_notifier.add_subscriber(
             self.seq_fitting_tab.seq_fitting_tab_presenter.fit_type_changed_observer)
 
+        self.fitting_tab.fitting_tab_presenter.simultaneous_fit_by_specifier_changed.add_subscriber(
+            self.seq_fitting_tab.seq_fitting_tab_presenter.selected_workspaces_observer)
+
         self.fitting_tab.fitting_tab_presenter.selected_fit_results_changed.add_subscriber(
             self.plot_widget.presenter.plot_selected_fit_observer)
 

--- a/scripts/Muon/GUI/MuonAnalysis/muon_analysis_2.py
+++ b/scripts/Muon/GUI/MuonAnalysis/muon_analysis_2.py
@@ -296,6 +296,9 @@ class MuonAnalysisGui(QtWidgets.QMainWindow):
         self.fitting_tab.fitting_tab_presenter.fit_parameter_changed_notifier.add_subscriber(
             self.seq_fitting_tab.seq_fitting_tab_presenter.fit_parameter_updated_observer)
 
+        self.seq_fitting_tab.seq_fitting_tab_presenter.fit_parameter_changed_notifier.add_subscriber(
+            self.fitting_tab.fitting_tab_presenter.fit_parameter_updated_observer)
+
         self.fitting_tab.fitting_tab_presenter.fitting_mode_changed_notifier.add_subscriber(
             self.seq_fitting_tab.seq_fitting_tab_presenter.fit_type_changed_observer)
 

--- a/scripts/Muon/GUI/MuonAnalysis/muon_analysis_2.py
+++ b/scripts/Muon/GUI/MuonAnalysis/muon_analysis_2.py
@@ -299,6 +299,9 @@ class MuonAnalysisGui(QtWidgets.QMainWindow):
         self.seq_fitting_tab.seq_fitting_tab_presenter.fit_parameter_changed_notifier.add_subscriber(
             self.fitting_tab.fitting_tab_presenter.fit_parameter_updated_observer)
 
+        self.seq_fitting_tab.seq_fitting_tab_presenter.sequential_fit_finished_notifier.add_subscriber(
+            self.fitting_tab.fitting_tab_presenter.sequential_fit_finished_observer)
+
         self.fitting_tab.fitting_tab_presenter.fitting_mode_changed_notifier.add_subscriber(
             self.seq_fitting_tab.seq_fitting_tab_presenter.fit_type_changed_observer)
 

--- a/scripts/test/Muon/CMakeLists.txt
+++ b/scripts/test/Muon/CMakeLists.txt
@@ -90,7 +90,7 @@ set ( TEST_PY_FILES
    plotting_canvas/plotting_canvas_presenter_test.py
    results_tab_widget/results_tab_model_test.py
    results_tab_widget/results_tab_presenter_test.py
-   # seq_fitting_tab_widget/seq_fitting_tab_presenter_test.py
+   seq_fitting_tab_widget/seq_fitting_tab_presenter_test.py
    seq_fitting_tab_widget/sequential_table_test.py
    transform_widget_new_test.py
    transformWidget_test.py

--- a/scripts/test/Muon/fitting_widgets/basic_fitting/basic_fitting_model_test.py
+++ b/scripts/test/Muon/fitting_widgets/basic_fitting/basic_fitting_model_test.py
@@ -443,7 +443,8 @@ class BasicFittingModelTest(unittest.TestCase):
 
         self.model.perform_fit()
 
-        self.model._do_single_fit.assert_called_once_with(self.model._get_parameters_for_single_fit())
+        self.model._do_single_fit.assert_called_once_with(self.model._get_parameters_for_single_fit(
+            self.model.current_dataset_name, self.model.current_single_fit_function))
 
 
 if __name__ == '__main__':

--- a/scripts/test/Muon/fitting_widgets/basic_fitting/basic_fitting_model_test.py
+++ b/scripts/test/Muon/fitting_widgets/basic_fitting/basic_fitting_model_test.py
@@ -446,6 +446,27 @@ class BasicFittingModelTest(unittest.TestCase):
         self.model._do_single_fit.assert_called_once_with(self.model._get_parameters_for_single_fit(
             self.model.current_dataset_name, self.model.current_single_fit_function))
 
+    def test_that_get_fit_function_parameters_will_return_a_list_of_parameter_names_for_the_current_single_functions(self):
+        self.model.dataset_names = self.dataset_names
+        self.model.single_fit_functions = self.single_fit_functions
+
+        self.assertEqual(self.model.get_fit_function_parameters(), ["A0"])
+
+        self.fit_function = FunctionFactory.createFunction("ExpDecay")
+        self.model.single_fit_functions = [self.fit_function.clone(), self.fit_function.clone()]
+
+        self.assertEqual(self.model.get_fit_function_parameters(), ["Height", "Lifetime"])
+
+    def test_that_get_fit_function_parameters_returns_an_empty_list_if_the_single_fit_functions_are_empty(self):
+        self.model.dataset_names = self.dataset_names
+        self.assertEqual(self.model.get_fit_function_parameters(), [])
+
+    def test_that_get_all_fit_functions_returns_the_single_fit_functions(self):
+        self.model.dataset_names = self.dataset_names
+        self.model.single_fit_functions = self.single_fit_functions
+
+        self.assertEqual(self.model.get_all_fit_functions(), self.model.single_fit_functions)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/scripts/test/Muon/fitting_widgets/general_fitting/general_fitting_model_test.py
+++ b/scripts/test/Muon/fitting_widgets/general_fitting/general_fitting_model_test.py
@@ -402,7 +402,8 @@ class GeneralFittingModelTest(unittest.TestCase):
 
         self.model.perform_fit()
 
-        self.model._do_single_fit.assert_called_once_with(self.model._get_parameters_for_single_fit())
+        self.model._do_single_fit.assert_called_once_with(self.model._get_parameters_for_single_fit(
+            self.model.current_dataset_name, self.model.current_single_fit_function))
 
     def test_perform_fit_will_call_the_correct_function_for_a_simultaneous_fit(self):
         self.model.dataset_names = self.dataset_names
@@ -416,8 +417,8 @@ class GeneralFittingModelTest(unittest.TestCase):
 
         self.model.perform_fit()
 
-        self.model._do_simultaneous_fit.assert_called_once_with(self.model._get_parameters_for_simultaneous_fit(),
-                                                                global_parameters)
+        self.model._do_simultaneous_fit.assert_called_once_with(self.model._get_parameters_for_simultaneous_fit(
+            self.model.dataset_names, self.model.simultaneous_fit_function), global_parameters)
 
 
 if __name__ == '__main__':

--- a/scripts/test/Muon/fitting_widgets/general_fitting/general_fitting_model_test.py
+++ b/scripts/test/Muon/fitting_widgets/general_fitting/general_fitting_model_test.py
@@ -420,6 +420,37 @@ class GeneralFittingModelTest(unittest.TestCase):
         self.model._do_simultaneous_fit.assert_called_once_with(self.model._get_parameters_for_simultaneous_fit(
             self.model.dataset_names, self.model.simultaneous_fit_function), global_parameters)
 
+    def test_that_get_fit_function_parameters_will_return_a_list_of_parameter_names_when_in_single_fit_mode(self):
+        self.model.dataset_names = self.dataset_names
+        self.model.single_fit_functions = self.single_fit_functions
+
+        self.assertEqual(self.model.get_fit_function_parameters(), ["A0"])
+
+        self.fit_function = FunctionFactory.createFunction("ExpDecay")
+        self.model.single_fit_functions = [self.fit_function.clone(), self.fit_function.clone()]
+
+        self.assertEqual(self.model.get_fit_function_parameters(), ["Height", "Lifetime"])
+
+    def test_that_get_fit_function_parameters_will_return_a_list_of_parameter_names_when_in_simultaneous_fit_mode(self):
+        self.model.dataset_names = self.dataset_names
+        self.model.simultaneous_fit_function = self.simultaneous_fit_function
+        self.model.simultaneous_fitting_mode = True
+
+        self.assertEqual(self.model.get_fit_function_parameters(), ["f0.A0", "f1.A0"])
+
+    def test_that_get_fit_function_parameters_returns_an_empty_list_if_the_simultaneous_function_is_none_in_simultaneous_fit_mode(self):
+        self.model.dataset_names = self.dataset_names
+        self.model.simultaneous_fitting_mode = True
+
+        self.assertEqual(self.model.get_fit_function_parameters(), [])
+
+    def test_that_get_all_fit_functions_returns_the_simultaneous_fitting_function_in_a_list_when_in_simultaneous_mode(self):
+        self.model.dataset_names = self.dataset_names
+        self.model.simultaneous_fit_function = self.simultaneous_fit_function
+        self.model.simultaneous_fitting_mode = True
+
+        self.assertEqual(self.model.get_all_fit_functions(), [self.model.simultaneous_fit_function])
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/scripts/test/Muon/fitting_widgets/general_fitting/general_fitting_presenter_test.py
+++ b/scripts/test/Muon/fitting_widgets/general_fitting/general_fitting_presenter_test.py
@@ -139,6 +139,7 @@ class GeneralFittingPresenterTest(unittest.TestCase):
         self.presenter.reset_fit_status_and_chi_squared_information.assert_called_once_with()
         self.presenter.clear_cached_fit_functions.assert_called_once_with()
         self.presenter.fitting_mode_changed_notifier.notify_subscribers.assert_called_once_with()
+        self.presenter.fit_function_changed_notifier.notify_subscribers.assert_called_once_with()
 
     def test_that_handle_simultaneous_fit_by_changed_will_update_the_model(self):
         self.presenter.update_simultaneous_fit_by_specifiers_in_view = mock.Mock()
@@ -164,6 +165,7 @@ class GeneralFittingPresenterTest(unittest.TestCase):
         self.presenter.reset_start_xs_and_end_xs.assert_called_once_with()
         self.presenter.reset_fit_status_and_chi_squared_information.assert_called_once_with()
         self.presenter.clear_cached_fit_functions.assert_called_once_with()
+        self.presenter.simultaneous_fit_by_specifier_changed.notify_subscribers.assert_called_once_with()
 
     def test_that_handle_dataset_name_changed_will_update_the_model_and_view(self):
         self.presenter.update_fit_statuses_and_chi_squared_in_view_from_model = mock.Mock()
@@ -444,6 +446,7 @@ class GeneralFittingPresenterTest(unittest.TestCase):
         self.presenter.fit_function_changed_notifier.notify_subscribers = mock.Mock()
         self.presenter.fit_parameter_changed_notifier.notify_subscribers = mock.Mock()
         self.presenter.fitting_mode_changed_notifier.notify_subscribers = mock.Mock()
+        self.presenter.simultaneous_fit_by_specifier_changed.notify_subscribers = mock.Mock()
 
 
 if __name__ == '__main__':

--- a/scripts/test/Muon/fitting_widgets/general_fitting/general_fitting_presenter_test.py
+++ b/scripts/test/Muon/fitting_widgets/general_fitting/general_fitting_presenter_test.py
@@ -314,8 +314,6 @@ class GeneralFittingPresenterTest(unittest.TestCase):
         self.model.clear_single_fit_functions.assert_called_once_with()
         self.presenter.update_simultaneous_fit_function_in_model.assert_called_once_with()
 
-        self.presenter.fit_function_changed_notifier.notify_subscribers.assert_called_once_with()
-
     def test_that_update_fit_functions_in_model_from_view_will_update_the_single_function_if_in_single_mode(self):
         self.mock_model_simultaneous_fitting_mode = mock.PropertyMock(return_value=False)
         type(self.model).simultaneous_fitting_mode = self.mock_model_simultaneous_fitting_mode
@@ -326,8 +324,6 @@ class GeneralFittingPresenterTest(unittest.TestCase):
 
         self.model.clear_simultaneous_fit_function.assert_called_once_with()
         self.presenter.update_single_fit_functions_in_model.assert_called_once_with()
-
-        self.presenter.fit_function_changed_notifier.notify_subscribers.assert_called_once_with()
 
     def test_that_update_simultaneous_fit_function_in_model_will_set_the_simultaneous_function_in_the_model(self):
         self.presenter.update_simultaneous_fit_function_in_model()

--- a/scripts/test/Muon/fitting_widgets/tf_asymmetry_fitting/tf_asymmetry_fitting_model_test.py
+++ b/scripts/test/Muon/fitting_widgets/tf_asymmetry_fitting/tf_asymmetry_fitting_model_test.py
@@ -467,7 +467,7 @@ class TFAsymmetryFittingModelTest(unittest.TestCase):
         self.assertEqual(self.model.get_all_fit_function_parameter_values_for(self.simultaneous_fit_function),
                          [0.0, 0.0])
 
-    def test_that_get_all_fit_function_parameter_values_for_will_return_the_parameters_values_including_normalisation_for_single_mode(self):
+    def test_that_get_all_fit_function_parameter_values_will_return_the_parameters_values_including_normalisation_for_single_mode(self):
         normalisation = 1.234
         self.model.dataset_names = self.dataset_names
         self.model.single_fit_functions = self.single_fit_functions
@@ -480,7 +480,7 @@ class TFAsymmetryFittingModelTest(unittest.TestCase):
         self.assertEqual(self.model.get_all_fit_function_parameter_values_for(
             self.model.tf_asymmetry_single_functions[1]), [normalisation, 0.0])
 
-    def test_that_get_all_fit_function_parameter_values_for_will_return_the_param_values_including_normalisation_for_simultaenous_mode(self):
+    def test_that_get_all_fit_function_parameter_values_will_return_the_param_values_including_normalisation_for_simultaenous_mode(self):
         normalisation = 1.234
         self.model.dataset_names = self.dataset_names
         self.model.single_fit_functions = self.single_fit_functions

--- a/scripts/test/Muon/fitting_widgets/tf_asymmetry_fitting/tf_asymmetry_fitting_model_test.py
+++ b/scripts/test/Muon/fitting_widgets/tf_asymmetry_fitting/tf_asymmetry_fitting_model_test.py
@@ -380,9 +380,204 @@ class TFAsymmetryFittingModelTest(unittest.TestCase):
         self.model._get_global_parameters_for_tf_asymmetry_fit.assert_called_once_with()
         self.model._do_tf_asymmetry_simultaneous_fit.assert_called_once_with(fit_variables, [])
 
+    def test_that_set_normalisation_for_dataset_will_set_the_normalisation_as_expected_in_single_fit_mode(self):
+        normalisation = 1.234
+        self.model.dataset_names = self.dataset_names
+        self.model.single_fit_functions = self.single_fit_functions
+        self.model.tf_asymmetry_single_functions = self.tf_single_fit_functions
+        self.model.tf_asymmetry_mode = True
+
+        self.model._set_normalisation_for_dataset("Name2", normalisation)
+
+        self.assertEqual(self.model.get_fit_function_parameter_values(self.tf_single_fit_functions[0]),
+                         [0.0, 0.0, 0.0, 0.2, 0.2])
+        self.assertEqual(self.model.get_fit_function_parameter_values(self.tf_single_fit_functions[1]),
+                         [normalisation, 0.0, 0.0, 0.2, 0.2])
+
+    def test_that_set_normalisation_for_dataset_will_set_the_normalisation_as_expected_in_simultaneous_fit_mode(self):
+        normalisation = 1.234
+        self.model.dataset_names = self.dataset_names
+        self.model.simultaneous_fit_function = self.simultaneous_fit_function
+        self.model.tf_asymmetry_simultaneous_function = self.tf_simultaneous_fit_function
+        self.model.simultaneous_fitting_mode = True
+        self.model.tf_asymmetry_mode = True
+
+        self.model._set_normalisation_for_dataset("Name2", normalisation)
+
+        self.assertEqual(self.model.get_fit_function_parameter_values(self.model.tf_asymmetry_simultaneous_function),
+                         [0.0, 0.0, 0.0, 0.2, 0.2, normalisation, 0.0, 0.0, 0.2, 0.2])
+
+    def test_that_get_all_fit_functions_will_return_the_tf_single_functions_when_in_single_fit_tf_asymmetry_mode(self):
+        self.model.dataset_names = self.dataset_names
+        self.model.single_fit_functions = self.single_fit_functions
+        self.model.tf_asymmetry_single_functions = self.tf_single_fit_functions
+        self.model.simultaneous_fitting_mode = False
+        self.model.tf_asymmetry_mode = True
+
+        self.assertEqual(self.model.get_all_fit_functions(), self.model.tf_asymmetry_single_functions)
+
+    def test_that_get_all_fit_functions_will_return_the_tf_simultaneous_function_when_in_simultaneous_fit_tf_asymmetry_mode(self):
+        self.model.dataset_names = self.dataset_names
+        self.model.simultaneous_fit_function = self.simultaneous_fit_function
+        self.model.tf_asymmetry_simultaneous_function = self.tf_simultaneous_fit_function
+        self.model.simultaneous_fitting_mode = True
+        self.model.tf_asymmetry_mode = True
+
+        self.assertEqual(self.model.get_all_fit_functions(), [self.model.tf_asymmetry_simultaneous_function])
+
+    def test_that_get_fit_function_parameters_will_return_the_normal_parameters_when_not_in_tf_asymmetry_mode(self):
+        self.model.dataset_names = self.dataset_names
+        self.model.single_fit_functions = self.single_fit_functions
+        self.model.simultaneous_fit_function = self.simultaneous_fit_function
+        self.model.tf_asymmetry_mode = False
+
+        self.model.simultaneous_fitting_mode = False
+        self.assertEqual(self.model.get_fit_function_parameters(), ["A0"])
+
+        self.model.simultaneous_fitting_mode = True
+        self.assertEqual(self.model.get_fit_function_parameters(), ["f0.A0", "f1.A0"])
+
+    def test_that_get_fit_function_parameters_will_return_the_parameters_including_normalisation_for_single_tf_fit_mode(self):
+        self.model.dataset_names = self.dataset_names
+        self.model.single_fit_functions = self.single_fit_functions
+        self.model.tf_asymmetry_single_functions = self.tf_single_fit_functions
+        self.model.simultaneous_fitting_mode = False
+        self.model.tf_asymmetry_mode = True
+
+        self.assertEqual(self.model.get_fit_function_parameters(), ["N0", "A0"])
+
+    def test_that_get_fit_function_parameters_will_return_the_parameters_including_normalisation_for_simultaneous_tf_fit_mode(self):
+        self.model.dataset_names = self.dataset_names
+        self.model.simultaneous_fit_function = self.simultaneous_fit_function
+        self.model.tf_asymmetry_simultaneous_function = self.tf_simultaneous_fit_function
+        self.model.simultaneous_fitting_mode = True
+        self.model.tf_asymmetry_mode = True
+
+        self.assertEqual(self.model.get_fit_function_parameters(), ["f0.N0", "f0.A0", "f1.N0", "f1.A0"])
+
+    def test_that_get_all_fit_function_parameter_values_for_will_return_the_normal_parameter_values_when_not_in_tf_asymmetry_mode(self):
+        self.model.dataset_names = self.dataset_names
+        self.model.tf_asymmetry_mode = False
+
+        self.model.simultaneous_fitting_mode = False
+        self.assertEqual(self.model.get_all_fit_function_parameter_values_for(self.single_fit_functions[0]),
+                         [0.0])
+
+        self.model.simultaneous_fitting_mode = True
+        self.assertEqual(self.model.get_all_fit_function_parameter_values_for(self.simultaneous_fit_function),
+                         [0.0, 0.0])
+
+    def test_that_get_all_fit_function_parameter_values_for_will_return_the_parameters_values_including_normalisation_for_single_mode(self):
+        normalisation = 1.234
+        self.model.dataset_names = self.dataset_names
+        self.model.single_fit_functions = self.single_fit_functions
+        self.model.tf_asymmetry_single_functions = self.tf_single_fit_functions
+        self.model.simultaneous_fitting_mode = False
+        self.model.tf_asymmetry_mode = True
+
+        self.model._set_normalisation_for_dataset("Name2", normalisation)
+
+        self.assertEqual(self.model.get_all_fit_function_parameter_values_for(
+            self.model.tf_asymmetry_single_functions[1]), [normalisation, 0.0])
+
+    def test_that_get_all_fit_function_parameter_values_for_will_return_the_param_values_including_normalisation_for_simultaenous_mode(self):
+        normalisation = 1.234
+        self.model.dataset_names = self.dataset_names
+        self.model.single_fit_functions = self.single_fit_functions
+        self.model.tf_asymmetry_simultaneous_function = self.tf_simultaneous_fit_function
+        self.model.simultaneous_fitting_mode = True
+        self.model.tf_asymmetry_mode = True
+
+        self.model._set_normalisation_for_dataset("Name2", normalisation)
+
+        self.assertEqual(self.model.get_all_fit_function_parameter_values_for(
+            self.model.tf_asymmetry_simultaneous_function), [0.0, 0.0, normalisation, 0.0])
+
+    def test_that_get_normalisation_from_tf_fit_function_will_return_the_expected_normalisation_for_single_fit_mode(self):
+        normalisation = 1.234
+        self.model.dataset_names = self.dataset_names
+        self.model.single_fit_functions = self.single_fit_functions
+        self.model.tf_asymmetry_single_functions = self.tf_single_fit_functions
+        self.model.simultaneous_fitting_mode = False
+        self.model.tf_asymmetry_mode = True
+
+        self.model._set_normalisation_for_dataset("Name2", normalisation)
+
+        self.assertEqual(self.model._get_normalisation_from_tf_fit_function(
+            self.model.tf_asymmetry_single_functions[0]), 0.0)
+        self.assertEqual(self.model._get_normalisation_from_tf_fit_function(
+            self.model.tf_asymmetry_single_functions[1]), normalisation)
+
+    def test_that_get_normalisation_from_tf_fit_function_will_return_the_expected_normalisation_for_simultaneous_fit_mode(self):
+        normalisation = 1.234
+        self.model.dataset_names = self.dataset_names
+        self.model.single_fit_functions = self.single_fit_functions
+        self.model.tf_asymmetry_simultaneous_function = self.tf_simultaneous_fit_function
+        self.model.simultaneous_fitting_mode = True
+        self.model.tf_asymmetry_mode = True
+
+        self.model._set_normalisation_for_dataset("Name2", normalisation)
+
+        self.assertEqual(self.model._get_normalisation_from_tf_fit_function(
+            self.model.tf_asymmetry_simultaneous_function, 0), 0.0)
+        self.assertEqual(self.model._get_normalisation_from_tf_fit_function(
+            self.model.tf_asymmetry_simultaneous_function, 1), normalisation)
+
     """
     Tests for functions used by the Sequential fitting tab.
     """
+
+    def test_that_parse_parameter_values_will_parse_the_parameters_into_normal_params_and_normalisations_for_single_mode(self):
+        all_parameter_values = [1.234, 5.0, 6.0]
+        self.model.dataset_names = self.dataset_names
+        self.model.simultaneous_fitting_mode = False
+        self.model.tf_asymmetry_mode = True
+
+        parameter_values, normalisations = self.model._parse_parameter_values(all_parameter_values)
+        self.assertEqual(parameter_values, [5.0, 6.0])
+        self.assertEqual(normalisations, [1.234])
+
+    def test_that_parse_parameter_values_will_parse_the_parameters_into_normal_params_and_normalisations_for_simultaneous_mode(self):
+        all_parameter_values = [1.234, 5.0, 6.0, 2.234, 7.0, 8.0]
+        self.model.dataset_names = self.dataset_names
+        self.model.simultaneous_fitting_mode = True
+        self.model.tf_asymmetry_mode = True
+
+        parameter_values, normalisations = self.model._parse_parameter_values(all_parameter_values)
+        self.assertEqual(parameter_values, [5.0, 6.0, 7.0, 8.0])
+        self.assertEqual(normalisations, [1.234, 2.234])
+
+    def test_that_get_runs_groups_and_pairs_for_fits_will_attempt_to_get_the_runs_groups_and_pairs_when_in_single_fit_mode(self):
+        self.model._get_runs_groups_and_pairs_for_single_fit = mock.Mock(return_value=(["62260"], ["fwd", "bwd"]))
+
+        runs, groups_and_pairs = self.model.get_runs_groups_and_pairs_for_fits()
+        self.assertEqual(runs, ["62260"])
+        self.assertEqual(groups_and_pairs, ["fwd", "bwd"])
+
+        self.model._get_runs_groups_and_pairs_for_single_fit.assert_called_once_with()
+
+    def test_that_get_runs_groups_and_pairs_for_fits_will_attempt_to_get_it_by_runs_when_in_simultaneous_fitting_mode(self):
+        self.model._get_runs_groups_and_pairs_for_simultaneous_fit_by_runs = mock.Mock(return_value=(["62260"], ["fwd;bwd;long"]))
+        self.model.simultaneous_fitting_mode = True
+        self.model.simultaneous_fit_by = "Run"
+
+        runs, groups_and_pairs = self.model.get_runs_groups_and_pairs_for_fits()
+        self.assertEqual(runs, ["62260"])
+        self.assertEqual(groups_and_pairs, ["fwd;bwd;long"])
+
+        self.model._get_runs_groups_and_pairs_for_simultaneous_fit_by_runs.assert_called_once_with()
+
+    def test_that_get_runs_groups_and_pairs_for_fits_will_attempt_to_get_it_by_groups_when_in_simultaneous_fitting_mode(self):
+        self.model._get_runs_groups_and_pairs_for_simultaneous_fit_by_groups_and_pairs = \
+            mock.Mock(return_value=(["62260;62261;62262"], ["fwd", "bwd"]))
+        self.model.simultaneous_fitting_mode = True
+        self.model.simultaneous_fit_by = "Group/Pair"
+
+        runs, groups_and_pairs = self.model.get_runs_groups_and_pairs_for_fits()
+        self.assertEqual(runs, ["62260;62261;62262"])
+        self.assertEqual(groups_and_pairs, ["fwd", "bwd"])
+
+        self.model._get_runs_groups_and_pairs_for_simultaneous_fit_by_groups_and_pairs.assert_called_once_with()
 
     def test_that_get_fit_function_parameter_values_will_return_the_parameter_values_in_the_specified_function(self):
         self.assertEqual(self.model.get_fit_function_parameter_values(self.single_fit_functions[0]), [0.0])
@@ -476,6 +671,68 @@ class TFAsymmetryFittingModelTest(unittest.TestCase):
                           "MUSR3; Pair Asym; long; MA",
                           "MUSR3; PhaseQuad; phase_Re_; MA",
                           "MUSR3; PhaseQuad; phase2_Im_; MA"], result)
+
+    def test_that_perform_sequential_fit_will_call_the_correct_functions_when_not_in_tf_asymmetry_mode(self):
+        workspaces = [["Name1"], ["Name2"]]
+        flattened_workspaces = ["Name1", "Name2"]
+        parameter_values = [[0.0], [1.0]]
+        functions = ["FakeFunc"]
+        fit_statuses = ["Success"]
+        chi_squared = [1.2]
+
+        self.model._get_sequential_fitting_func_for_normal_fitting_mode = mock.Mock(return_value=None)
+        self.model._flatten_workspace_names = mock.Mock(return_value=flattened_workspaces)
+        self.model._evaluate_sequential_fit = mock.Mock(return_value=(functions, fit_statuses, chi_squared))
+        self.model._update_fit_functions_after_sequential_fit = mock.Mock()
+        self.model._update_fit_statuses_and_chi_squared_after_sequential_fit = mock.Mock()
+
+        self.model.simultaneous_fitting_mode = False
+        self.model.tf_asymmetry_mode = False
+
+        self.model.perform_sequential_fit(workspaces, parameter_values)
+
+        self.model._get_sequential_fitting_func_for_normal_fitting_mode.assert_called_once_with()
+        self.model._flatten_workspace_names.assert_called_once_with(workspaces)
+        self.model._evaluate_sequential_fit.assert_called_once_with(None, flattened_workspaces, parameter_values, False)
+        self.model._update_fit_functions_after_sequential_fit.assert_called_once_with(flattened_workspaces, functions)
+        self.model._update_fit_statuses_and_chi_squared_after_sequential_fit.assert_called_once_with(
+            flattened_workspaces, fit_statuses, chi_squared)
+
+    def test_that_perform_sequential_fit_will_call_the_correct_functions_when_in_tf_asymmetry_mode(self):
+        workspaces = [["Name1"], ["Name2"]]
+        parameter_values = [[0.0], [1.0]]
+        use_initial_values = True
+        functions = ["FakeFunc"]
+        fit_statuses = ["Success"]
+        chi_squared = [1.2]
+
+        self.model._get_sequential_fitting_func_for_tf_asymmetry_fitting_mode = mock.Mock(return_value=None)
+        self.model._flatten_workspace_names = mock.Mock()
+        self.model._evaluate_sequential_fit = mock.Mock(return_value=(functions, fit_statuses, chi_squared))
+        self.model._update_fit_functions_after_sequential_fit = mock.Mock()
+        self.model._update_fit_statuses_and_chi_squared_after_sequential_fit = mock.Mock()
+
+        self.model.simultaneous_fitting_mode = True
+        self.model.tf_asymmetry_mode = True
+
+        self.model.perform_sequential_fit(workspaces, parameter_values, use_initial_values)
+
+        self.model._get_sequential_fitting_func_for_tf_asymmetry_fitting_mode.assert_called_once_with()
+        self.assertTrue(not self.model._flatten_workspace_names.called)
+        self.model._evaluate_sequential_fit.assert_called_once_with(None, workspaces, parameter_values,
+                                                                    use_initial_values)
+        self.model._update_fit_functions_after_sequential_fit.assert_called_once_with(workspaces, functions)
+        self.model._update_fit_statuses_and_chi_squared_after_sequential_fit.assert_called_once_with(
+            workspaces, fit_statuses, chi_squared)
+
+    def test_that_are_same_workspaces_as_the_datasets_returns_true_if_all_the_dataset_names_match(self):
+        self.model.dataset_names = self.dataset_names
+        self.assertTrue(self.model._are_same_workspaces_as_the_datasets(self.dataset_names))
+
+    def test_that_are_same_workspaces_as_the_datasets_returns_false_if_one_of_the_dataset_names_does_not_match(self):
+        dataset_names = self.dataset_names + ["Name3"]
+        self.model.dataset_names = self.dataset_names
+        self.assertTrue(not self.model._are_same_workspaces_as_the_datasets(dataset_names))
 
 
 if __name__ == '__main__':

--- a/scripts/test/Muon/fitting_widgets/tf_asymmetry_fitting/tf_asymmetry_fitting_presenter_test.py
+++ b/scripts/test/Muon/fitting_widgets/tf_asymmetry_fitting/tf_asymmetry_fitting_presenter_test.py
@@ -270,6 +270,15 @@ class TFAsymmetryFittingPresenterTest(unittest.TestCase):
         self.model.update_tf_asymmetry_single_fit_function.assert_called_once_with(self.model.current_dataset_index,
                                                                                    self.fit_function)
 
+    def test_that_handle_sequential_fit_finished_will_update_the_fit_functions_and_statuses_in_the_view_and_model(self):
+        self.presenter.update_fit_function_in_view_from_model = mock.Mock()
+        self.presenter.update_fit_statuses_and_chi_squared_in_view_from_model = mock.Mock()
+
+        self.presenter.handle_sequential_fit_finished()
+
+        self.presenter.update_fit_function_in_view_from_model.assert_called_once_with()
+        self.presenter.update_fit_statuses_and_chi_squared_in_view_from_model.assert_called_once_with()
+
     def _setup_mock_view(self):
         self.view = mock.Mock(spec=TFAsymmetryFittingView)
 

--- a/scripts/test/Muon/fitting_widgets/tf_asymmetry_fitting/tf_asymmetry_fitting_presenter_test.py
+++ b/scripts/test/Muon/fitting_widgets/tf_asymmetry_fitting/tf_asymmetry_fitting_presenter_test.py
@@ -252,22 +252,23 @@ class TFAsymmetryFittingPresenterTest(unittest.TestCase):
         self.view.set_normalisation.assert_called_with(self.normalisation, self.normalisation_error)
 
     def test_that_update_fit_function_in_model_will_update_the_simultaneous_fit_functions_when_in_simultaneous_mode(self):
-        self.model.update_simultaneous_fit_functions = mock.Mock()
+        self.model.update_tf_asymmetry_simultaneous_fit_function = mock.Mock()
         self.mock_model_simultaneous_fitting_mode = mock.PropertyMock(return_value=True)
         type(self.model).simultaneous_fitting_mode = self.mock_model_simultaneous_fitting_mode
 
         self.presenter.update_fit_function_in_model(self.fit_function)
 
-        self.model.update_simultaneous_fit_functions.assert_called_once_with(self.fit_function)
+        self.model.update_tf_asymmetry_simultaneous_fit_function.assert_called_once_with(self.fit_function)
 
     def test_that_update_fit_function_in_model_will_update_the_current_fit_function_when_in_single_mode(self):
-        self.model.update_current_single_fit_functions = mock.Mock()
+        self.model.update_tf_asymmetry_single_fit_function = mock.Mock()
         self.mock_model_simultaneous_fitting_mode = mock.PropertyMock(return_value=False)
         type(self.model).simultaneous_fitting_mode = self.mock_model_simultaneous_fitting_mode
 
         self.presenter.update_fit_function_in_model(self.fit_function)
 
-        self.model.update_current_single_fit_functions.assert_called_once_with(self.fit_function)
+        self.model.update_tf_asymmetry_single_fit_function.assert_called_once_with(self.model.current_dataset_index,
+                                                                                   self.fit_function)
 
     def _setup_mock_view(self):
         self.view = mock.Mock(spec=TFAsymmetryFittingView)

--- a/scripts/test/Muon/seq_fitting_tab_widget/seq_fitting_tab_presenter_test.py
+++ b/scripts/test/Muon/seq_fitting_tab_widget/seq_fitting_tab_presenter_test.py
@@ -65,14 +65,18 @@ class SeqFittingTabPresenterTest(unittest.TestCase):
         self.view.fit_table.set_fit_workspaces.assert_called_with(run_list, group_pair_list)
 
     def test_handle_fit_function_changed_correctly_updates_fit_table_parameters(self):
+        parameters = ['A', 'Sigma', 'Frequency', 'Phi']
         fit_values = [0.2, 0.2, 0.1, 0]
+        self.model.get_fit_function_parameters = mock.Mock(return_value=parameters)
+        self.model.get_all_fit_function_parameter_values_for = mock.Mock(return_value=fit_values)
+        self.model.get_all_fit_functions = mock.Mock(return_value=[None, None])
+
         self._setup_test_fit_function(fit_values)
         self.view.fit_table.get_number_of_fits.return_value = 2
 
         self.presenter.handle_fit_function_updated()
 
-        self.view.fit_table.set_parameters_and_values.assert_called_once_with(['A', 'Sigma', 'Frequency', 'Phi'],
-                                                                              [fit_values, fit_values])
+        self.view.fit_table.set_parameters_and_values.assert_called_once_with(parameters, [fit_values, fit_values])
 
     def test_handle_fit_started_updates_view(self):
         self.presenter.handle_fit_started()
@@ -92,17 +96,20 @@ class SeqFittingTabPresenterTest(unittest.TestCase):
     @mock.patch('Muon.GUI.Common.seq_fitting_tab_widget.seq_fitting_tab_presenter.functools')
     def test_handle_fit_selected_correctly_sets_up_fit(self, mock_function_tools):
         workspace = "EMU20884; Group; fwd; Asymmetry"
+        parameter_values = [0.2, 0.1, 0, 0]
         self.view.fit_table.get_selected_rows = mock.MagicMock(return_value=[0])
         self._setup_test_fit_function([0.2, 0.1, 0, 0])
         self.presenter.get_workspaces_for_row_in_fit_table = mock.MagicMock(return_value=workspace)
+        self.view.fit_table.get_fit_parameter_values_from_row = mock.MagicMock(return_value=parameter_values)
 
         self.presenter.handle_fit_selected_pressed()
 
-        mock_function_tools.partial.assert_called_once_with(self.model.evaluate_sequential_fit, [workspace], False)
+        mock_function_tools.partial.assert_called_once_with(self.model.perform_sequential_fit, [workspace],
+                                                            [parameter_values], False)
 
     @mock.patch('Muon.GUI.Common.seq_fitting_tab_widget.seq_fitting_tab_presenter.functools')
     def test_handle_fit_selected_does_nothing_if_fit_function_is_none(self, mock_function_tools):
-        self.model.fit_function = None
+        self.model.get_active_fit_function = mock.Mock(return_value=None)
         self.view.fit_table.get_selected_rows = mock.MagicMock(return_value=[0, 1])
 
         self.presenter.handle_fit_selected_pressed()
@@ -122,28 +129,32 @@ class SeqFittingTabPresenterTest(unittest.TestCase):
         selected_row = 2
         fit_values = [0.6, 0.9, 0.1, 1]
         fit_function = self._setup_test_fit_function(fit_values)
+        self.model.get_all_fit_function_parameter_values_for = mock.Mock(return_value=fit_values)
         self.presenter.fitting_calculation_model.result = ([fit_function], ['Success'], [1.07])
         self.presenter.selected_rows = [selected_row]
 
         self.presenter.handle_seq_fit_finished()
 
-        self.view.fit_table.set_parameter_values_for_row.assert_called_once_with(2, [0.6, 0.9, 0.1, 1])
+        self.view.fit_table.set_parameter_values_for_row.assert_called_once_with(2, fit_values)
         self.view.fit_table.set_fit_quality.assert_called_once_with(2, 'Success', 1.07)
         self.view.fit_selected_button.setEnabled.assert_called_once_with(True)
 
     @mock.patch('Muon.GUI.Common.seq_fitting_tab_widget.seq_fitting_tab_presenter.functools')
     def test_handle_sequential_fit_correctly_sets_up_fit(self, mock_function_tools):
         workspaces = ["EMU20884; Group; fwd; Asymmetry"]
+        parameters_values = [0.2, 0.2, 0.1, 0]
         number_of_entries = 3
-        self._setup_test_fit_function([0.2, 0.2, 0.1, 0])
+        self._setup_test_fit_function(parameters_values)
         self.view.fit_table.get_number_of_fits = mock.MagicMock(return_value=number_of_entries)
+        self.view.fit_table.get_fit_parameter_values_from_row = mock.Mock(return_value=parameters_values)
         self.presenter.get_workspaces_for_row_in_fit_table = mock.MagicMock(return_value=workspaces)
 
         self.presenter.handle_sequential_fit_pressed()
 
         self.assertEqual(self.presenter.get_workspaces_for_row_in_fit_table.call_count, number_of_entries)
-        mock_function_tools.partial.assert_called_once_with(self.model.evaluate_sequential_fit,
-                                                            [workspaces] * number_of_entries, False)
+        mock_function_tools.partial.assert_called_once_with(self.model.perform_sequential_fit,
+                                                            [workspaces] * number_of_entries,
+                                                            [parameters_values] * number_of_entries, False)
 
     @mock.patch('Muon.GUI.Common.seq_fitting_tab_widget.seq_fitting_tab_presenter.functools')
     def test_handle_sequential_fit_does_nothing_if_fit_function_is_none(self, mock_function_tools):
@@ -161,6 +172,7 @@ class SeqFittingTabPresenterTest(unittest.TestCase):
         fit_status = ['Success'] * num_fits
         fit_quality = [1.3, 2.4, 1.9]
         self.presenter.fitting_calculation_model.result = (fit_functions, fit_status, fit_quality)
+        self.model.get_all_fit_function_parameter_values_for = mock.Mock(return_value=values)
 
         self.presenter.handle_seq_fit_finished()
 


### PR DESCRIPTION
Follows on from #30772
---------------------------
**Description of work.**
This PR ensures the sequential fitting tab works with the refactored fitting widgets in the fitting tab.

It also:
- [x] Updates tests for `TFAsymmetryFittingModel`
- [x] Fixes and re-enable `SeqFittingTabPresenterTest`

**To test:**

<!-- Instructions for testing. -->

Fixes #29892

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
