### PR TITLE
Bug in DrILL custom options cell validation

### DIFF
--- a/scripts/Interface/ui/drill/presenter/DrillPresenter.py
+++ b/scripts/Interface/ui/drill/presenter/DrillPresenter.py
@@ -27,6 +27,11 @@ class DrillPresenter:
     """
     _processError = set()
 
+    """
+    Set of custom options. Used to keep an history of the previous values.
+    """
+    _customOptions = set()
+
     def __init__(self, view):
         """
         Initialize the presenter by giving a view and a model. This method
@@ -40,6 +45,7 @@ class DrillPresenter:
         self.view = view
         self._invalidCells = set()
         self._processError = set()
+        self._customOptions = set()
 
         # view signals connection
         self.view.instrumentChanged.connect(self.instrumentChanged)
@@ -95,6 +101,9 @@ class DrillPresenter:
             params = {}
             if not contents:
                 self.onParamOk(row, column)
+                for name in self._customOptions:
+                    self.model.changeParameter(row, name, "")
+                self._customOptions = set()
                 return
             for option in contents.split(';'):
                 if option and '=' not in option:
@@ -118,8 +127,13 @@ class DrillPresenter:
                 if value in ['false', 'False', 'FALSE']:
                     value = False
                 params[name] = value
+                currentOptions = set()
             for name,value in params.items():
+                currentOptions.add(name)
                 self.model.changeParameter(row, name, value)
+            for name in self._customOptions.difference(currentOptions):
+                self.model.changeParameter(row, name, "")
+            self._customOptions = currentOptions
         else:
             self.model.changeParameter(row, column, contents)
 


### PR DESCRIPTION
**Description of work.**

This PR resolves a bug with the validation of DrILL custom options. When an invalid custom option was written and then removed, the interface was still using it for the processing.

**To test:**

Try to reproduce the bug described in #30814

Fixes #30814 

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
