### PR TITLE
Indirect Data Analysis - Fix wrong fit type being run.

### DIFF
--- a/qt/scientific_interfaces/Indirect/IndirectFitAnalysisTab.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectFitAnalysisTab.cpp
@@ -247,14 +247,6 @@ IndirectFittingModel *IndirectFitAnalysisTab::getFittingModel() const {
 }
 
 /**
- * @return  The fit type selected in the custom functions combo box, in the fit
- *          property browser.
- */
-QString IndirectFitAnalysisTab::getSelectedFitType() const {
-  return m_fitPropertyBrowser->selectedFitType();
-}
-
-/**
  * @param functionName  The name of the function.
  * @return              The number of custom functions, with the specified name,
  *                      included in the selected model.
@@ -605,12 +597,7 @@ void IndirectFitAnalysisTab::run() {
   setRunIsRunning(true);
   enableFitButtons(false);
   enableOutputOptions(false);
-  auto const fitType = m_fitPropertyBrowser->selectedFitType();
-  if (fitType == "Simultaneous") {
-    m_fittingModel->setFittingMode(FittingMode::SIMULTANEOUS);
-  } else {
-    m_fittingModel->setFittingMode(FittingMode::SEQUENTIAL);
-  }
+  m_fittingModel->setFittingMode(m_fitPropertyBrowser->getFittingMode());
   runFitAlgorithm(m_fittingModel->getFittingAlgorithm());
 }
 

--- a/qt/scientific_interfaces/Indirect/IndirectFitAnalysisTab.h
+++ b/qt/scientific_interfaces/Indirect/IndirectFitAnalysisTab.h
@@ -56,7 +56,6 @@ public:
   WorkspaceIndex getSelectedSpectrum() const;
   bool isRangeCurrentlySelected(TableDatasetIndex dataIndex,
                                 WorkspaceIndex spectrum) const;
-  QString getSelectedFitType() const;
   size_t getNumberOfCustomFunctions(const std::string &functionName) const;
   void setConvolveMembers(bool convolveMembers);
 

--- a/qt/scientific_interfaces/Indirect/IndirectFitPropertyBrowser.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectFitPropertyBrowser.cpp
@@ -312,13 +312,10 @@ void IndirectFitPropertyBrowser::updateFitStatus(const FitDomainIndex index) {
 }
 
 /**
- * @return  The selected fit type in the fit type combo box.
+ * @return  The currently active fitting mode (Sequential or Simultaneous).
  */
-QString IndirectFitPropertyBrowser::selectedFitType() const {
-  return m_fitOptionsBrowser->getCurrentFittingType() ==
-                 FittingMode::SIMULTANEOUS
-             ? "Simultaneous"
-             : "Sequential";
+FittingMode IndirectFitPropertyBrowser::getFittingMode() const {
+  return m_fitOptionsBrowser->getCurrentFittingType();
 }
 
 /**

--- a/qt/scientific_interfaces/Indirect/IndirectFitPropertyBrowser.h
+++ b/qt/scientific_interfaces/Indirect/IndirectFitPropertyBrowser.h
@@ -67,7 +67,7 @@ public:
   void updateFitStatusData(const std::vector<std::string> &status,
                            const std::vector<double> &chiSquared);
   void updateFitStatus(const FitDomainIndex index);
-  QString selectedFitType() const;
+  FittingMode getFittingMode() const;
   void setConvolveMembers(bool convolveEnabled);
   void setOutputCompositeMembers(bool outputEnabled);
   void setFitEnabled(bool enable);

--- a/qt/widgets/common/src/FitOptionsBrowser.cpp
+++ b/qt/widgets/common/src/FitOptionsBrowser.cpp
@@ -41,24 +41,6 @@
 #include <QVBoxLayout>
 #include <limits>
 
-namespace {
-using namespace MantidQt::MantidWidgets;
-
-int getFittingModeInt(FittingMode fitMode) {
-  switch (fitMode) {
-  case FittingMode::SIMULTANEOUS:
-    return 0;
-  case FittingMode::SEQUENTIAL:
-    return 1;
-  case FittingMode::SEQUENTIAL_AND_SIMULTANEOUS:
-    return 2;
-  default:
-    return 1;
-  }
-}
-
-} // namespace
-
 namespace MantidQt {
 namespace MantidWidgets {
 
@@ -133,8 +115,8 @@ void FitOptionsBrowser::createBrowser() {
 void FitOptionsBrowser::initFittingTypeProp() {
   m_fittingTypeProp = m_enumManager->addProperty("Fitting");
   QStringList types;
-  types << "Simultaneous"
-        << "Sequential";
+  types << "Sequential"
+        << "Simultaneous";
   m_enumManager->setEnumNames(m_fittingTypeProp, types);
   if (m_fittingType == FittingMode::SEQUENTIAL_AND_SIMULTANEOUS) {
     m_browser->addProperty(m_fittingTypeProp);
@@ -158,6 +140,7 @@ void FitOptionsBrowser::createProperties() {
       m_fittingType == FittingMode::SEQUENTIAL_AND_SIMULTANEOUS) {
     createSequentialFitProperties();
   }
+  switchFitType();
 }
 
 void FitOptionsBrowser::createCommonProperties() {
@@ -425,8 +408,8 @@ void FitOptionsBrowser::updateMinimizer() {
  * Switch the current fit type according to the value in the FitType property.
  */
 void FitOptionsBrowser::switchFitType() {
-  auto fitType = m_enumManager->value(m_fittingTypeProp);
-  if (fitType == 0) {
+  const auto fittingMode = getCurrentFittingType();
+  if (fittingMode == FittingMode::SIMULTANEOUS) {
     displayNormalFitProperties();
   } else {
     displaySequentialFitProperties();
@@ -744,7 +727,11 @@ FittingMode FitOptionsBrowser::getCurrentFittingType() const {
  *    Simultaneous for Fit and Sequential for PlotPeakByLogValue.
  */
 void FitOptionsBrowser::setCurrentFittingType(FittingMode fitType) {
-  m_enumManager->setValue(m_fittingTypeProp, getFittingModeInt(fitType));
+  if (fitType == FittingMode::SIMULTANEOUS) {
+    m_enumManager->setValue(m_fittingTypeProp, 1);
+  } else {
+    m_enumManager->setValue(m_fittingTypeProp, 0);
+  }
 }
 
 /**
@@ -753,7 +740,7 @@ void FitOptionsBrowser::setCurrentFittingType(FittingMode fitType) {
  * @param fitType :: Fitting type to lock the browser in.
  */
 void FitOptionsBrowser::lockCurrentFittingType(FittingMode fitType) {
-  m_enumManager->setValue(m_fittingTypeProp, getFittingModeInt(fitType));
+  setCurrentFittingType(fitType);
   m_fittingTypeProp->setEnabled(false);
 }
 

--- a/qt/widgets/common/test/FitOptionsBrowserTest.h
+++ b/qt/widgets/common/test/FitOptionsBrowserTest.h
@@ -52,6 +52,26 @@ public:
       m_fitOptionsBrowser = std::make_unique<FitOptionsBrowser>(nullptr);
   }
 
+  void
+  test_that_setting_the_fitting_mode_to_sequential_will_then_return_the_sequential_fitting_mode() {
+    m_fitOptionsBrowser = std::make_unique<FitOptionsBrowser>(nullptr);
+
+    m_fitOptionsBrowser->setCurrentFittingType(FittingMode::SEQUENTIAL);
+
+    TS_ASSERT_EQUALS(m_fitOptionsBrowser->getCurrentFittingType(),
+                     FittingMode::SEQUENTIAL);
+  }
+
+  void
+  test_that_setting_the_fitting_mode_to_simultaneous_will_then_return_the_simultaneous_fitting_mode() {
+    m_fitOptionsBrowser = std::make_unique<FitOptionsBrowser>(nullptr);
+
+    m_fitOptionsBrowser->setCurrentFittingType(FittingMode::SIMULTANEOUS);
+
+    TS_ASSERT_EQUALS(m_fitOptionsBrowser->getCurrentFittingType(),
+                     FittingMode::SIMULTANEOUS);
+  }
+
 private:
   std::size_t m_numberOfTries;
   std::unique_ptr<FitOptionsBrowser> m_fitOptionsBrowser;


### PR DESCRIPTION
**Description of work.**
This PR fixes a bug where the wrong fitting type is being run on the Indirect Data Analysis interface (see issue).

**To test:**
See the issue and make sure the correct fitting algorithm is being run.

Fixes #30822

*Release notes not required as this was introduced after the release of 6.0.*

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
