### PR TITLE
Expose the geographical angles to python

### DIFF
--- a/Framework/PythonInterface/mantid/api/src/Exports/SpectrumInfo.cpp
+++ b/Framework/PythonInterface/mantid/api/src/Exports/SpectrumInfo.cpp
@@ -14,6 +14,7 @@
 #include <boost/python/copy_const_reference.hpp>
 #include <boost/python/list.hpp>
 #include <boost/python/return_value_policy.hpp>
+#include <boost/python/tuple.hpp>
 
 using Mantid::SpectrumDefinition;
 using Mantid::API::SpectrumInfo;
@@ -25,6 +26,11 @@ using namespace boost::python;
 // Helper method to make the python iterator
 SpectrumInfoPythonIterator make_pyiterator(SpectrumInfo &spectrumInfo) {
   return SpectrumInfoPythonIterator(spectrumInfo);
+}
+
+PyObject *geographicalAngles(SpectrumInfo &spectrumInfo, const size_t index) {
+  const auto angles = spectrumInfo.geographicalAngles(index);
+  return incref(make_tuple(angles.first, angles.second).ptr());
 }
 
 // Export SpectrumInfo
@@ -55,6 +61,10 @@ void export_SpectrumInfo() {
            "Returns the out-of-plane angle in radians angle w.r.t. to "
            "vecPointingHorizontal "
            "direction.")
+      .def("geographicalAngles", &geographicalAngles,
+           (arg("self"), arg("index")),
+           "Returns the latitude and longitude for given spectrum index. "
+           "The returned value is a pair of (latitude, longitude)")
       .def("l1", &SpectrumInfo::l1, arg("self"),
            "Returns the distance from the source to the sample.")
       .def("l2", &SpectrumInfo::l2, (arg("self"), arg("index")),

--- a/Framework/PythonInterface/test/python/mantid/api/SpectrumInfoTest.py
+++ b/Framework/PythonInterface/test/python/mantid/api/SpectrumInfoTest.py
@@ -45,7 +45,6 @@ class SpectrumInfoTest(unittest.TestCase):
         # One detector cleared. So not counted.
         self.assertEqual(info.detectorCount(), 2)
 
-
     def test_isMonitor(self):
         """ Check if a monitor is present. """
         info = self._ws.spectrumInfo()
@@ -72,6 +71,13 @@ class SpectrumInfoTest(unittest.TestCase):
         """ See if the returned value is a double (float in Python). """
         info = self._ws.spectrumInfo()
         self.assertEqual(type(info.twoTheta(1)), float)
+
+    def test_geogAngles(self):
+        """ See if the returned value is a double (float in Python). """
+        info = self._ws.spectrumInfo()
+        lat, lon = info.geographicalAngles(1)
+        self.assertEqual(type(lat), float)
+        self.assertEqual(type(lon), float)
 
     def test_signedTwoTheta(self):
         """ See if the returned value is a double (float in Python). """
@@ -127,7 +133,7 @@ class SpectrumInfoTest(unittest.TestCase):
     """
     def test_basic_iteration(self):
         info = self._ws.spectrumInfo()
-        expected_iterations = len(info) 
+        expected_iterations = len(info)
         actual_iterations = len(list(iter(info)))
         self.assertEqual(expected_iterations, actual_iterations)
 
@@ -138,10 +144,10 @@ class SpectrumInfoTest(unittest.TestCase):
         next(it) # skip first as detectors cleared
         for item in it:
             self.assertFalse(item.isMonitor)
-            
+
     def test_iterator_for_masked(self):
         info = self._ws.spectrumInfo()
-        # nothing should be masked 
+        # nothing should be masked
         it = iter(info)
         next(it) # skip first as detectors cleared
         for item in it:
@@ -149,7 +155,7 @@ class SpectrumInfoTest(unittest.TestCase):
 
     def test_iterator_for_setting_masked(self):
         info = self._ws.spectrumInfo()
-        # nothing should be masked 
+        # nothing should be masked
         it = iter(info)
         next(it) # skip first as detectors cleared
         for item in it:
@@ -217,7 +223,6 @@ class SpectrumInfoTest(unittest.TestCase):
         info = self._ws.spectrumInfo()
         with self.assertRaises(OverflowError):
             info.position(-1)
-
 
     """
     ----------------------------------------------------------------------------
@@ -316,7 +321,6 @@ class SpectrumInfoTest(unittest.TestCase):
         with self.assertRaises(TypeError):
             info.samplePosition(0.0)
 
-
     """
     ----------------------------------------------------------------------------
     SpectrumDefinition Tests
@@ -364,6 +368,7 @@ class SpectrumInfoTest(unittest.TestCase):
         info = self._ws.spectrumInfo()
         spectrumDefinition = info.getSpectrumDefinition(1)
         self.assertEqual(spectrumDefinition[0], (1, 0))
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/docs/source/release/v6.1.0/framework.rst
+++ b/docs/source/release/v6.1.0/framework.rst
@@ -23,6 +23,7 @@ Algorithms
 Data Objects
 ------------
 
+- exposed ``geographicalAngles`` method on :py:obj:`mantid.api.SpectrumInfo`
 - :ref:`Run <mantid.api.Run>` has been modified to allow multiple goniometers to be stored.
 
 Python


### PR DESCRIPTION
The result is a read-only tuple. This is meant to simplify work elsewhere.

None of the python bindings for `SpectrumInfo` have testing so this does not add one.

**To test:**

Load any file with an instrument, then get the geographical angles out of the `SpectrumInfo`. 

*There is no associated issue.*

The version into `ornl-next` is #30830.

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
