### PR TITLE
Fix a bounding box bug in the instrument viewer

### DIFF
--- a/docs/source/release/v6.1.0/mantidworkbench.rst
+++ b/docs/source/release/v6.1.0/mantidworkbench.rst
@@ -23,5 +23,6 @@ Bugfixes
 - For the elliptical shell of integrated peaks, the background is correct when plotting with varying background thicknesses
 - Fixed a bug which occurred when switching to a log scale in sliceviewer with negative data.
 - Fixed a bug that use wrong help links in certain interfaces
+- Fixed a bug that would not let the user input the bounding box of a shape in the instrument viewer.
 
 :ref:`Release 6.1.0 <v6.1.0>`

--- a/qt/widgets/common/src/QtPropertyBrowser/DoubleEditorFactory.cpp
+++ b/qt/widgets/common/src/QtPropertyBrowser/DoubleEditorFactory.cpp
@@ -27,7 +27,6 @@ DoubleEditor::DoubleEditor(QtProperty *property, QWidget *parent)
   setValidator(new QDoubleValidator(mgr->minimum(property),
                                     mgr->maximum(property), 20, this));
   connect(this, SIGNAL(editingFinished()), this, SLOT(updateProperty()));
-  // double val = mgr->value(property);
   setValue(mgr->value(property));
 }
 
@@ -36,11 +35,16 @@ DoubleEditor::~DoubleEditor() {}
 void DoubleEditor::setValue(const double &d) { setText(formatValue(d)); }
 
 void DoubleEditor::updateProperty() {
+  if (!this->isModified())
+    return;
+  // Ignore second signal if two were triggered by pressing the Enter key
+  // see https://bugreports.qt.io/browse/QTBUG-40
+  this->setModified(false);
+
   auto mgr =
       dynamic_cast<QtDoublePropertyManager *>(m_property->propertyManager());
-  if (mgr) {
+  if (mgr)
     mgr->setValue(m_property, text().toDouble());
-  }
 }
 
 /**

--- a/qt/widgets/instrumentview/src/InstrumentWidgetMaskTab.cpp
+++ b/qt/widgets/instrumentview/src/InstrumentWidgetMaskTab.cpp
@@ -764,10 +764,9 @@ void InstrumentWidgetMaskTab::doubleChanged(QtProperty *prop) {
         m_instrWidget->getSurface()->setCurrentPoint(name, p);
       }
     }
-    // when the user validates the edit of the field, the view is immediatly
-    // updated this way
-    m_instrWidget->updateInstrumentView();
   }
+  // when the user validates the field's edit, the view is immediatly updated
+  m_instrWidget->updateInstrumentView();
   m_instrWidget->update();
 }
 

--- a/qt/widgets/instrumentview/src/InstrumentWidgetMaskTab.cpp
+++ b/qt/widgets/instrumentview/src/InstrumentWidgetMaskTab.cpp
@@ -625,9 +625,9 @@ void InstrumentWidgetMaskTab::shapeChanged() {
       false; // this prevents resetting shape properties by doubleChanged(...)
   RectF rect = m_instrWidget->getSurface()->getCurrentBoundingRect();
   m_doubleManager->setValue(m_left, rect.x0());
-  m_doubleManager->setValue(m_top, rect.y1());
+  m_doubleManager->setValue(m_top, rect.y0());
   m_doubleManager->setValue(m_right, rect.x1());
-  m_doubleManager->setValue(m_bottom, rect.y0());
+  m_doubleManager->setValue(m_bottom, rect.y1());
   for (QMap<QtProperty *, QString>::iterator it = m_doublePropertyMap.begin();
        it != m_doublePropertyMap.end(); ++it) {
     m_doubleManager->setValue(


### PR DESCRIPTION
**Description of work.**
This fixes the bug that prevented the user from setting the ``top`` and ``bottom`` value of the bounding box of a shape in the instrument viewer.
Note that the user still cannot set these values for the sector shape, due to how it is designed.

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

**To test:**
- Open the instrument viewer on some data
- Go to the ``Draw`` tab
- Draw a shape (not a sector)
- In the editable fields on the left, change the value of ``top`` or ``bottom``
- Validate and hover over the instrument view to update it, and check that the shape has been correctly changed, along with the bounding box.

- Change the value of top to be less than bottom (and so on), and check that the values are swapped instantly so they stay coherent with their respective label.
- Also check the view is updated on finishing the edition of the field, and no longer requires hovering above the instrument view for that.

<!-- Instructions for testing. -->

Fixes #30832 #30816 . <!-- and fix #xxxx or close #xxxx xor resolves #xxxx -->
<!-- alternative
*There is no associated issue.*
-->

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or master)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
