### PR TITLE
Expose IFunction method setMatrixWorkspace to python

### DIFF
--- a/Framework/API/inc/MantidAPI/FunctionFactory.h
+++ b/Framework/API/inc/MantidAPI/FunctionFactory.h
@@ -54,9 +54,6 @@ public:
   /// Creates an instance of a function
   std::shared_ptr<IFunction> createInitialized(const std::string &input) const;
 
-  std::shared_ptr<IPeakFunction>
-  createInitializedPeakFunction(const std::string &name) const;
-
   /// Creates an instnce of an inizialised multidomain function where each
   /// domain has the same function.
   std::shared_ptr<MultiDomainFunction>
@@ -92,6 +89,8 @@ private:
   std::shared_ptr<IFunction>
   createSimple(const Expression &expr,
                std::map<std::string, std::string> &parentAttributes) const;
+  std::shared_ptr<IPeakFunction>
+  createPeakFunction(const Expression &expr, const std::string &name) const;
   /// Create a composite function
   std::shared_ptr<CompositeFunction>
   createComposite(const Expression &expr,

--- a/Framework/API/inc/MantidAPI/FunctionFactory.h
+++ b/Framework/API/inc/MantidAPI/FunctionFactory.h
@@ -10,6 +10,7 @@
 // Includes
 //----------------------------------------------------------------------
 #include "MantidAPI/DllConfig.h"
+#include "MantidAPI/IPeakFunction.h"
 #include "MantidKernel/DynamicFactory.h"
 #include "MantidKernel/SingletonHolder.h"
 #include <vector>
@@ -52,6 +53,9 @@ public:
 
   /// Creates an instance of a function
   std::shared_ptr<IFunction> createInitialized(const std::string &input) const;
+
+  std::shared_ptr<IPeakFunction>
+  createInitializedPeakFunction(const std::string &name) const;
 
   /// Creates an instnce of an inizialised multidomain function where each
   /// domain has the same function.

--- a/Framework/API/src/FunctionFactory.cpp
+++ b/Framework/API/src/FunctionFactory.cpp
@@ -74,6 +74,21 @@ FunctionFactoryImpl::createInitialized(const std::string &input) const {
   return createSimple(e, parentAttributes);
 }
 
+IPeakFunction_sptr
+FunctionFactoryImpl::createInitializedPeakFunction(const std::string &name) const {
+
+  IPeakFunction_sptr peakFun;
+  if (peakFun) {
+    std::cout << "hello";
+  }
+  auto fun = createFunction(name);
+  peakFun = std::dynamic_pointer_cast<IPeakFunction>(fun);
+  if (!peakFun) {
+    inputError(name);
+  }
+  return peakFun;
+}
+
 /**
  * @param input :: An input string which defines the function and initial values
  * for the parameters.

--- a/Framework/API/src/FunctionFactory.cpp
+++ b/Framework/API/src/FunctionFactory.cpp
@@ -74,21 +74,6 @@ FunctionFactoryImpl::createInitialized(const std::string &input) const {
   return createSimple(e, parentAttributes);
 }
 
-IPeakFunction_sptr
-FunctionFactoryImpl::createInitializedPeakFunction(const std::string &name) const {
-
-  IPeakFunction_sptr peakFun;
-  if (peakFun) {
-    std::cout << "hello";
-  }
-  auto fun = createFunction(name);
-  peakFun = std::dynamic_pointer_cast<IPeakFunction>(fun);
-  if (!peakFun) {
-    inputError(name);
-  }
-  return peakFun;
-}
-
 /**
  * @param input :: An input string which defines the function and initial values
  * for the parameters.

--- a/Framework/PythonInterface/mantid/api/src/Exports/FunctionFactory.cpp
+++ b/Framework/PythonInterface/mantid/api/src/Exports/FunctionFactory.cpp
@@ -147,6 +147,24 @@ PyObject *getPeakFunctionNames(FunctionFactoryImpl &self) {
 
 //------------------------------------------------------------------------------------------------------
 /**
+ * Return an IPeakFunction (if possible to cast from IFunction)
+ * @param self :: Enables it to be called as a member function on the
+ * FunctionFactory class
+ * @param name :: Peak function name
+ */
+Mantid::API::IPeakFunction_sptr createPeakFunction(FunctionFactoryImpl &self,
+                                                   const std::string &name) {
+
+  auto fun = self.createFunction(name);
+  auto peakFun = std::dynamic_pointer_cast<Mantid::API::IPeakFunction>(fun);
+  if (!peakFun) {
+    throw std::invalid_argument(name + " is not a PeakFunction");
+  }
+  return peakFun;
+}
+
+//------------------------------------------------------------------------------------------------------
+/**
  * Something that makes Function Factory return to python a composite function
  * for Product function, Convolution or
  * any similar superclass of composite function.
@@ -243,8 +261,7 @@ void export_FunctionFactory() {
            "Returns a list of the currently available background functions")
       .def("getPeakFunctionNames", &getPeakFunctionNames, arg("self"),
            "Returns a list of the currently available peak functions")
-      .def("createInitializedPeakFunction",
-           &FunctionFactoryImpl::createInitializedPeakFunction,
+      .def("createPeakFunction", &createPeakFunction,
            (arg("self"), arg("name")), "Return pointer to peak function.")
       .staticmethod("Instance");
 }

--- a/Framework/PythonInterface/mantid/api/src/Exports/FunctionFactory.cpp
+++ b/Framework/PythonInterface/mantid/api/src/Exports/FunctionFactory.cpp
@@ -72,6 +72,7 @@ PythonObjectInstantiator<IFunction>::createInstance() const {
   instancePtr.reset(instancePtr.get(), GILSharedPtrDeleter(*deleter));
   return instancePtr;
 }
+
 } // namespace PythonInterface
 } // namespace Mantid
 
@@ -242,5 +243,8 @@ void export_FunctionFactory() {
            "Returns a list of the currently available background functions")
       .def("getPeakFunctionNames", &getPeakFunctionNames, arg("self"),
            "Returns a list of the currently available peak functions")
+      .def("createInitializedPeakFunction",
+           &FunctionFactoryImpl::createInitializedPeakFunction,
+           (arg("self"), arg("name")), "Return pointer to peak function.")
       .staticmethod("Instance");
 }

--- a/Framework/PythonInterface/mantid/api/src/Exports/IFunction.cpp
+++ b/Framework/PythonInterface/mantid/api/src/Exports/IFunction.cpp
@@ -16,7 +16,6 @@
 #include <boost/python/def.hpp>
 #include <boost/python/overloads.hpp>
 #include <boost/python/register_ptr_to_python.hpp>
-#include <MantidAPI\MatrixWorkspace.h>
 
 using Mantid::API::IFunction;
 using Mantid::API::IFunction_sptr;

--- a/Framework/PythonInterface/mantid/api/src/Exports/IFunction.cpp
+++ b/Framework/PythonInterface/mantid/api/src/Exports/IFunction.cpp
@@ -15,6 +15,7 @@
 #include <boost/python/def.hpp>
 #include <boost/python/overloads.hpp>
 #include <boost/python/register_ptr_to_python.hpp>
+#include <MantidAPI\MatrixWorkspace.h>
 
 using Mantid::API::IFunction;
 using Mantid::API::IFunction_sptr;
@@ -88,6 +89,16 @@ using removeTieByName = void (IFunction::*)(const std::string &);
 GNU_DIAG_ON("conversion")
 GNU_DIAG_ON("unused-local-typedef")
 ///@endcond
+
+void setMatrixWorkspace(IFunction &self, const boost::python::object &workspace,
+                        int wi, float startX, float endX) {
+  Mantid::API::MatrixWorkspace_sptr matWS =
+      std::dynamic_pointer_cast<Mantid::API::MatrixWorkspace>(
+          Mantid::PythonInterface::ExtractSharedPtr<Mantid::API::Workspace>(
+              workspace)());
+  self.setMatrixWorkspace(matWS, wi, startX, endX);
+}
+
 } // namespace
 
 void export_IFunction() {
@@ -278,6 +289,12 @@ void export_IFunction() {
 
       .def("nDomains", &IFunction::getNumberDomains, arg("self"),
            "Get the number of domains.")
+
+      .def("setMatrixWorkspace", &setMatrixWorkspace,
+           (arg("self"), arg("workspace"), arg("wi"),
+            arg("startX"), arg("endX")),
+           "Changes the integral intensity of the peak function by setting its "
+           "height.")
 
       //-- Deprecated functions that have the wrong names --
       .def("categories", &getCategories, arg("self"),

--- a/Framework/PythonInterface/mantid/api/src/Exports/IFunction.cpp
+++ b/Framework/PythonInterface/mantid/api/src/Exports/IFunction.cpp
@@ -5,6 +5,7 @@
 //   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
 // SPDX - License - Identifier: GPL - 3.0 +
 #include "MantidAPI/CompositeFunction.h"
+#include "MantidAPI/MatrixWorkspace.h"
 #include "MantidKernel/WarningSuppressions.h"
 #include "MantidPythonInterface/api/FitFunctions/IFunctionAdapter.h"
 #include "MantidPythonInterface/core/GetPointer.h"
@@ -291,10 +292,9 @@ void export_IFunction() {
            "Get the number of domains.")
 
       .def("setMatrixWorkspace", &setMatrixWorkspace,
-           (arg("self"), arg("workspace"), arg("wi"),
-            arg("startX"), arg("endX")),
-           "Changes the integral intensity of the peak function by setting its "
-           "height.")
+           (arg("self"), arg("workspace"), arg("wi"), arg("startX"),
+            arg("endX")),
+           "Set matrix workspace to parse Parameters.xml")
 
       //-- Deprecated functions that have the wrong names --
       .def("categories", &getCategories, arg("self"),

--- a/Framework/PythonInterface/mantid/api/src/Exports/IPeakFunction.cpp
+++ b/Framework/PythonInterface/mantid/api/src/Exports/IPeakFunction.cpp
@@ -7,6 +7,7 @@
 #include "MantidAPI/IPeakFunction.h"
 #include "MantidPythonInterface/api/FitFunctions/IPeakFunctionAdapter.h"
 #include <boost/python/class.hpp>
+#include <boost/python/register_ptr_to_python.hpp>
 
 using Mantid::API::IFunction1D;
 using Mantid::API::IPeakFunction;
@@ -14,6 +15,9 @@ using Mantid::PythonInterface::IPeakFunctionAdapter;
 using namespace boost::python;
 
 void export_IPeakFunction() {
+
+  register_ptr_to_python<std::shared_ptr<IPeakFunction>>();
+
   class_<IPeakFunction, bases<IFunction1D>,
          std::shared_ptr<IPeakFunctionAdapter>, boost::noncopyable>(
       "IPeakFunction", "Base class for peak Fit functions")
@@ -23,6 +27,8 @@ void export_IPeakFunction() {
            (arg("self"), arg("vec_x")),
            "Calculate the values of the function for the given x values. The "
            "output should be stored in the out array")
+      .def("fwhm", &IPeakFunction::fwhm, arg("self"),
+           "Returns the fwhm of the peak function.")
       .def("intensity", &IPeakFunction::intensity, arg("self"),
            "Returns the integral intensity of the peak function.")
       .def("setIntensity", &IPeakFunction::setIntensity,

--- a/Framework/PythonInterface/test/python/mantid/api/FunctionFactoryTest.py
+++ b/Framework/PythonInterface/test/python/mantid/api/FunctionFactoryTest.py
@@ -6,7 +6,7 @@
 # SPDX - License - Identifier: GPL - 3.0 +
 import unittest
 
-from mantid.api import FrameworkManagerImpl, IFunction1D, FunctionFactory
+from mantid.api import FrameworkManagerImpl, IFunction1D, FunctionFactory, IPeakFunction
 
 
 class TestFunctionNoAttrs(IFunction1D):
@@ -54,6 +54,13 @@ class FunctionFactoryTest(unittest.TestCase):
         self.assertEqual(func.name(),  name)
         self.assertGreater(len(func.__repr__()), len(name))
         self.assertTrue("Peak" in func.categories())
+
+    def test_get_Gaussian_as_IPeakFunction(self):
+        func = FunctionFactory.createPeakFunction("Gaussian")
+        self.assertTrue(isinstance(func, IPeakFunction))
+
+    def test_LinearBackground_not_IPeakFunction(self):
+        self.assertRaises(ValueError, FunctionFactory.createPeakFunction, "LinearBackground")
 
     def test_function_subscription_of_non_class_type_raises_error(self):
         def not_a_fit_function(*args, **kwargs):

--- a/Framework/PythonInterface/test/python/mantid/api/IPeakFunctionTest.py
+++ b/Framework/PythonInterface/test/python/mantid/api/IPeakFunctionTest.py
@@ -6,6 +6,7 @@
 # SPDX - License - Identifier: GPL - 3.0 +
 import unittest
 from mantid.api import *
+from mantid.simpleapi import LoadEmptyInstrument, LoadParameterFile
 import numpy as np
 
 
@@ -17,7 +18,7 @@ class MyPeak(IPeakFunction):
         self.declareAttribute("Width", 1.5)
 
     def functionLocal(self, xvals):
-        return 5*xvals
+        return 5 * xvals
 
 
 class RectangularFunction(IPeakFunction):
@@ -50,7 +51,7 @@ class RectangularFunction(IPeakFunction):
         height = self.getParameterValue("Height")
 
         values = np.zeros(xvals.shape)
-        nonZero = (xvals > (center - fwhm/2.0)) & (xvals < (center + fwhm / 2.0))
+        nonZero = (xvals > (center - fwhm / 2.0)) & (xvals < (center + fwhm / 2.0))
         values[nonZero] = height
 
         return values
@@ -74,7 +75,7 @@ class IPeakFunctionTest(unittest.TestCase):
     def test_functionLocal_can_be_called_directly(self):
         func = MyPeak()
         func.initialize()
-        xvals=np.array([1.,2.,3.])
+        xvals = np.array([1., 2., 3.])
         out = func.functionLocal(xvals)
         self.assertEqual(3, out.shape[0])
         self.assertEqual(5., out[0])
@@ -98,6 +99,19 @@ class IPeakFunctionTest(unittest.TestCase):
         self.assertEqual(func.fwhm(), 3.0)
         self.assertAlmostEquals(func.height(), 4.0, places=10)
         self.assertAlmostEquals(func.intensity(), 12.0, places=10)
+
+    def test_get_set_matrix_workspace(self):
+        ws = LoadEmptyInstrument(InstrumentName='ENGIN-X', OutputWorkspace='ws')
+        LoadParameterFile(Workspace=ws, Filename='ENGIN-X_Parameters.xml')
+        axis = ws.getAxis(0)
+        unit = axis.getUnit()
+        axis.setUnit("TOF")
+
+        func = FunctionFactory.Instance().createPeakFunction("BackToBackExponential")
+        func.setParameter(3, 24000)  # set centre
+        func.setMatrixWorkspace(ws, 800, 0.0, 0.0)  # calculate A,B,S
+        self.assertTrue(func.isExplicitlySet(1))
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
**Description of work.**
Expose IFunction method setMatrixWorkspace to python so can make get calculated parameter values by parsing the  Parameters.xml file associated with instrument. This will be used to estimate the integration range of single-crystal peaks (using the Parameters.xml file to calculate values for BackToBackExponential parameters A,B and S and hence the fwhm of the peak). This will then be used to estimate an integration radius (input to IntegratePEaksMD)

This involved adding a method tot he FunctionFactory to create an IPeakFunction instead of an IFunction and exposing the fwhm() of the IPEakFunction to python.

Thanks to @martyngigg, @Pasarus and @StephenSmith25 for their help!

**To test:**
(1) Run this script
```
ws = LoadEmptyInstrument(InstrumentName='ENGIN-X', OutputWorkspace='ws')
LoadParameterFile(Workspace=ws, Filename='C:/mantid/instrument/ENGIN-X_Parameters.xml')
axis = ws.getAxis(0)
unit = axis.getUnit()
axis.setUnit("TOF")

func = BackToBackExponential()
print('Initialised param values:', [func.function.getParameterValue(ii) for ii in range(func.nParams())])
func.function.setParameter(3, 24000) # set centre
func.function.setMatrixWorkspace(ws, 800, 0.0,0.0) # calculate A,B,S
print('Calc param values:', [func.function.getParameterValue(ii) for ii in range(func.nParams())])
```
(2) The printed output should be
```
Initialised param values: [0.0, 1.0, 0.05, 0.0, 1.0]
Calc param values: [0.0, 0.0709293, 0.0251457, 24000.0, 17.342028614131035]
```

(3) Check we can do the same with an IPeakFunction and use this to calculate the fwhm
```
func = FunctionFactory.Instance().createPeakFunction("BackToBackExponential")
print('Initialised param values:', [func.getParameterValue(ii) for ii in range(func.nParams())])
print('Initial fwhm = ', func.fwhm())
func.setParameter(3, 24000) # set centre
func.setMatrixWorkspace(ws, 800, 0.0,0.0) # calculate A,B,S
print('Calc param values:', [func.getParameterValue(ii) for ii in range(func.nParams())])
print('explicitly set:', [func.isExplicitlySet(ii) for ii in range(func.nParams())])
print('fwhm = ', func.fwhm())
```
(4) The printed output should look like 
```
Initialised param values: [0.0, 1.0, 0.05, 0.0, 1.0]
Initial fwhm =  16.5684305715229
Calc param values: [0.0, 0.0709293, 0.0251457, 24000.0, 17.342028614131035]
explicitly set: [False, True, True, True, True]
fwhm =  72.62347002386443
```
(5) Check you get an error if you try to make a IPEakFunction from a function name that is not a peak e.g.
```
func = FunctionFactory.Instance().createPeakFunction("LinearBackground") # should throw ValueError
```

*There is no associated issue.*

*This does not require release notes* because small change to API that has not been requested externally.


<!-- Ensure the base of this PR is correct (e.g. release-next or master)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
