### PR TITLE
Bug in DrILL export

### DIFF
--- a/scripts/Interface/ui/drill/model/DrillExportModel.py
+++ b/scripts/Interface/ui/drill/model/DrillExportModel.py
@@ -207,9 +207,8 @@ class DrillExportModel:
                               .format(outputWs, algo))
                 continue
 
-            for wsName in mtd.getObjectNames():
-                if ((workspaceName not in wsName)
-                        or (isinstance(mtd[wsName], WorkspaceGroup))):
+            for wsName in mtd.getObjectNames(contain=workspaceName):
+                if isinstance(mtd[wsName], WorkspaceGroup):
                     continue
 
                 filename = exportPath + wsName \

--- a/scripts/Interface/ui/drill/model/DrillExportModel.py
+++ b/scripts/Interface/ui/drill/model/DrillExportModel.py
@@ -110,8 +110,8 @@ class DrillExportModel:
         if not criteria:
             return True
 
-        processingAlgo = mtd[ws].getHistory().lastAlgorithm()
         try:
+            processingAlgo = mtd[ws].getHistory().lastAlgorithm()
             params = re.findall("%[a-zA-Z]*%", criteria)
             for param in params:
                 value = processingAlgo.getPropertyValue(param[1:-1])

--- a/scripts/Interface/ui/drill/model/DrillExportModel.py
+++ b/scripts/Interface/ui/drill/model/DrillExportModel.py
@@ -14,6 +14,7 @@ from .DrillAlgorithmPool import DrillAlgorithmPool
 from .DrillTask import DrillTask
 
 import re
+import os
 
 
 class DrillExportModel:
@@ -188,6 +189,8 @@ class DrillExportModel:
             sample (DrillSample): sample to be exported
         """
         exportPath = config.getString("defaultsave.directory")
+        if not exportPath:
+            exportPath = os.getcwd()
         workspaceName = sample.getOutputName()
 
         try:
@@ -211,8 +214,9 @@ class DrillExportModel:
                 if isinstance(mtd[wsName], WorkspaceGroup):
                     continue
 
-                filename = exportPath + wsName \
-                           + RundexSettings.EXPORT_ALGO_EXTENSION[algo]
+                filename = os.path.join(
+                        exportPath,
+                        wsName + RundexSettings.EXPORT_ALGO_EXTENSION[algo])
                 name = wsName + ":" + filename
                 if wsName not in self._exports:
                     self._exports[wsName] = set()

--- a/scripts/Interface/ui/drill/model/DrillExportModel.py
+++ b/scripts/Interface/ui/drill/model/DrillExportModel.py
@@ -194,9 +194,12 @@ class DrillExportModel:
         workspaceName = sample.getOutputName()
 
         try:
-            outputWsGroup = mtd[workspaceName]
-            names = outputWsGroup.getNames()
-            outputWs = names[0]
+            outputWs = mtd[workspaceName]
+            if isinstance(outputWs, WorkspaceGroup):
+                names = outputWs.getNames()
+                outputWs = names[0]
+            else:
+                outputWs = workspaceName
         except:
             return
 

--- a/scripts/Interface/ui/drill/test/DrillExportModelTest.py
+++ b/scripts/Interface/ui/drill/test/DrillExportModelTest.py
@@ -154,9 +154,11 @@ class DrillExportModelTest(unittest.TestCase):
         self.mConfig.getString.return_value = "/default/save/directory/"
         mSample = mock.Mock()
         mSample.getOutputName.return_value = "workspace"
+        mGroup = mock.Mock()
+        mGroup.getNames.return_value = ["workspace"]
+        self.mMtd.__getitem__.return_value = mGroup
         self.mMtd.getObjectNames.return_value = ["workspace_1",
-                                                 "workspace_2",
-                                                 "test_1"]
+                                                 "workspace_2"]
         self.exportModel._validCriteria = mock.Mock()
         self.exportModel._validCriteria.return_value = True
         self.exportModel.run(mSample)


### PR DESCRIPTION
**Description of work.**

During the automatic export in DrILL, criteria are applied on workspaces to verify that a specific export algorithm can be applied on the data. This is using the processing parameters found in the workspace history. This was causing a crash with workspaces with empty history (for example, panel workspaces in D11 data processing).

To resolve this problem, the algorithm history is now in a try-catch block and the criteria are validated once per sample on the output workspace.

**To test:**

Try to reproduce the issue #30813 


Fixes #30813 

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
