### PR TITLE
Fix CppInterfacesStartupTest crash

### DIFF
--- a/Testing/SystemTests/tests/qt/CppInterfacesStartupTest.py
+++ b/Testing/SystemTests/tests/qt/CppInterfacesStartupTest.py
@@ -6,6 +6,9 @@
 # SPDX - License - Identifier: GPL - 3.0 +
 import systemtesting
 
+# Must be imported after systemtesting to avoid an error.
+import sip
+
 from mantidqt.interfacemanager import InterfaceManager
 from mantidqt.usersubwindowfactory import UserSubWindowFactory
 from mantidqt.utils.qt.testing import get_application
@@ -37,5 +40,11 @@ class CppInterfacesStartupTest(systemtesting.MantidSystemTest):
             interface.setAttribute(Qt.WA_DeleteOnClose, True)
             interface.show()
             interface.close()
+
+            # Delete the interface manually because the destructor is not being called as expected on close (even with
+            # Qt.WA_DeleteOnClose set to True).
+            sip.delete(interface)
+            self.assertTrue(sip.isdeleted(interface))
+
         except Exception as ex:
             self.fail(f"Exception thrown when attempting to open the {interface_name} interface: {ex}.")

--- a/Testing/SystemTests/tests/qt/CppInterfacesStartupTest.py
+++ b/Testing/SystemTests/tests/qt/CppInterfacesStartupTest.py
@@ -24,11 +24,6 @@ class CppInterfacesStartupTest(systemtesting.MantidSystemTest):
         self._interface_manager = InterfaceManager()
         self._cpp_interface_names = UserSubWindowFactory.Instance().keys()
 
-    def skipTests(self):
-        # skipping while the test is segfaulting. It does not appear to be a real
-        # failure
-        return True
-
     def runTest(self):
         if len(self._cpp_interface_names) == 0:
             self.fail("Failed to find the names of the c++ interfaces.")


### PR DESCRIPTION
**Description of work.**
This PR fixes a read access violation in the `CppInterfacesStartupTest` caused by the C++ interfaces not being destructed when being closed. This means that some of the widgets in the interfaces are still observing the ADS, and so when the ADS is cleared by the system test framework the ADS handlers in these widgets are called and a read access violation occurs.

The solution was to delete the interfaces manually using sip. This is only required in this system test, the interfaces are destructed as expected when opened normally from workbench.

**To test:**
Run the CppInterfacesStartupTest in your command prompt and make sure the test passes. For windows:
```
systemtest -C Debug -R CppInterfacesStartupTest
```

*There is no associated issue.*

*This does not require release notes* because **it is an internal change.**

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
