### PR TITLE
Fix bug in release notes generator script

### DIFF
--- a/tools/release_generator/release.py
+++ b/tools/release_generator/release.py
@@ -262,7 +262,6 @@ def toMilestoneName(version):
 
 def addToReleaseList(release_root, version):
     filename = os.path.join(release_root, 'index.rst')
-    newversion = '   %s <%s/index>\n' % (version, version)
 
     # read in the entire old version
     with open(filename, 'r') as handle:
@@ -273,9 +272,9 @@ def addToReleaseList(release_root, version):
         search_for_insertion = True
         for i in range(len(oldtext)):
             line = oldtext[i].strip()
-            if search_for_insertion and line.startswith('v') and line.endswith('/index>'):
+            if search_for_insertion and line.startswith('* :doc:`v') and line.endswith('/index>`'):
                 if version not in line:
-                    handle.write(newversion)
+                    handle.write(f"* :doc:`{version} <{version}/index>`\n")
                 search_for_insertion = False
             handle.write(oldtext[i])
 


### PR DESCRIPTION
**Description of work.**
This PR fixes a bug where the index for the new release docs is not added to the `index.rst` file in the root directory of the release notes when running [this](https://github.com/mantidproject/mantid/blob/master/tools/release_generator/release.py) script.

**To test:**
Run the release.py python script from the cmd or terminal with:
```
python ../mantid/tools/release_generator/release.py --release 10.0.0 --milestone "Release 10.0"
```

Check the `index.rst` file in the root directory of the release notes. You should see `* :doc:v10.0.0 <v10.0.0/index>` at the top of the indexed files.

<!-- Instructions for testing. -->

Part of #30663

*This does not require release notes* because **it is an internal change.**

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
