### PR TITLE
Fix seg fault in MonteCarloAbsorption

### DIFF
--- a/Framework/Algorithms/src/SampleCorrections/MCInteractionVolume.cpp
+++ b/Framework/Algorithms/src/SampleCorrections/MCInteractionVolume.cpp
@@ -9,7 +9,6 @@
 #include "MantidGeometry/Instrument/SampleEnvironment.h"
 #include "MantidGeometry/Objects/CSGObject.h"
 #include "MantidGeometry/Objects/Track.h"
-#include "MantidKernel/Material.h"
 #include "MantidKernel/PseudoRandomNumberGenerator.h"
 #include <iomanip>
 

--- a/Framework/Geometry/src/Objects/CSGObject.cpp
+++ b/Framework/Geometry/src/Objects/CSGObject.cpp
@@ -406,9 +406,9 @@ CSGObject::CSGObject(const std::string &shapeXML)
       m_objNum(0), m_handler(), bGeometryCaching(false),
       vtkCacheReader(std::shared_ptr<vtkGeometryCacheReader>()),
       vtkCacheWriter(std::shared_ptr<vtkGeometryCacheWriter>()),
-      m_shapeXML(shapeXML), m_id(), m_material() // empty by default
-{
+      m_shapeXML(shapeXML), m_id() {
   m_handler = std::make_shared<GeometryHandler>(this);
+  m_material = std::make_unique<Material>();
 }
 
 /**
@@ -460,12 +460,7 @@ void CSGObject::setMaterial(const Kernel::Material &material) {
 /**
  * @return The Material that the object is composed from
  */
-const Kernel::Material &CSGObject::material() const {
-  if (!m_material) {
-    m_material = std::make_unique<Material>();
-  }
-  return *m_material;
-}
+const Kernel::Material &CSGObject::material() const { return *m_material; }
 
 /**
  * Returns whether this object has a valid shape

--- a/Framework/PythonInterface/test/python/plugins/algorithms/WorkflowAlgorithms/PaalmanPingsMonteCarloAbsorptionTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/WorkflowAlgorithms/PaalmanPingsMonteCarloAbsorptionTest.py
@@ -26,6 +26,7 @@ class PaalmanPingsMonteCarloAbsorptionTest(unittest.TestCase):
         Load('irs26176_graphite002_red.nxs', OutputWorkspace='geoms_ws')
         # set this workspace to have defined sample and can geometries to test the preset option
         SetSample('geoms_ws', Geometry={'Shape': 'Cylinder', 'Height': 4.0, 'Radius': 2.0, 'Center': [0., 0., 0.]},
+                  Material={'ChemicalFormula': 'Ni'},
                   ContainerGeometry={'Shape': 'HollowCylinder', 'Height': 4.0, 'InnerRadius': 2.0,
                                      'OuterRadius': 3.5})
 
@@ -73,13 +74,13 @@ class PaalmanPingsMonteCarloAbsorptionTest(unittest.TestCase):
         test_func('Annulus')
 
     def _preset_with_override_material_test(self, test_func):
-        test_func(shape='Preset', sample_ws=self._geoms_ws, with_container=True)
+        test_func(shape='Preset', sample_ws=self._geoms_ws)
 
     def _preset_without_override_material_test(self, test_func):
         self._arguments = {'EventsPerPoint': 200,
                            'BeamHeight': 3.5,
                            'BeamWidth': 4.0}
-        test_func(shape='Preset', sample_ws=self._geoms_ws, with_container=True)
+        test_func(shape='Preset', sample_ws=self._geoms_ws)
 
     def _material_with_cross_section_test(self, test_func):
         self._test_arguments['SampleWidth'] = 2.0
@@ -135,7 +136,7 @@ class PaalmanPingsMonteCarloAbsorptionTest(unittest.TestCase):
                                                      **arguments)
         self._test_corrections_workspaces(corrected, spectrum_axis, with_container)
 
-    def _run_correction_with_container_test(self, shape):
+    def _run_correction_with_container_test(self, shape, sample_ws=None):
         self._test_arguments.update(self._container_args)
 
         if shape == 'FlatPlate':
@@ -145,7 +146,7 @@ class PaalmanPingsMonteCarloAbsorptionTest(unittest.TestCase):
         elif shape == 'Annulus':
             self._setup_annulus_container()
 
-        self._run_correction_and_test(shape=shape, with_container=True)
+        self._run_correction_and_test(shape=shape, sample_ws=sample_ws, with_container=True)
 
     def _run_indirect_elastic_test(self, shape):
         self._expected_unit = "MomentumTransfer"
@@ -196,10 +197,10 @@ class PaalmanPingsMonteCarloAbsorptionTest(unittest.TestCase):
         self._annulus_test(self._run_correction_and_test)
 
     def test_preset_with_override_material(self):
-        self._preset_with_override_material_test(self._run_correction_and_test)
+        self._preset_with_override_material_test(self._run_correction_with_container_test)
 
     def test_preset_without_overriding_material(self):
-        self._preset_without_override_material_test(self._run_correction_and_test)
+        self._preset_without_override_material_test(self._run_correction_with_container_test)
 
     def test_flat_plate_with_container(self):
         self._flat_plate_test(self._run_correction_with_container_test)

--- a/docs/source/algorithms/PaalmanPingsMonteCarloAbsorption-v1.rst
+++ b/docs/source/algorithms/PaalmanPingsMonteCarloAbsorption-v1.rst
@@ -222,10 +222,6 @@ Usage
 
 **Example - Preset Shape**
 
-.. testsetup:: Preset
-   # Currently an issue with multithreading in this test 
-   FrameworkManager.Instance().setNumOMPThreads(1)
-
 .. testcode:: Preset
 
     sample_ws = CreateSampleWorkspace(Function="Quasielastic",
@@ -243,7 +239,8 @@ Usage
     SetSample(sample_ws, Geometry={'Shape': 'Cylinder', 'Height': 4.0, 'Radius': 2.0, 'Center': [0.,0.,0.]},
                 Material={'ChemicalFormula': 'Ni', 'MassDensity': 7.0},
                 ContainerGeometry={'Shape': 'HollowCylinder', 'Height': 4.0, 'InnerRadius': 2.0,
-                'OuterRadius': 3.5})
+                'OuterRadius': 3.5},
+                ContainerMaterial={'ChemicalFormula': 'V'})
 
     corrections = PaalmanPingsMonteCarloAbsorption(
             InputWorkspace=sample_ws,
@@ -275,7 +272,6 @@ Usage
     print("Y-Unit Label of " + str(acc_ws.getName()) + ": " + str(acc_ws.YUnitLabel()))
 
 .. testcleanup:: Preset
-    FrameworkManager.Instance().setNumOMPThreadsToConfigValue()
     mtd.clear()
 
 .. testoutput:: Preset

--- a/docs/source/release/v6.1.0/framework.rst
+++ b/docs/source/release/v6.1.0/framework.rst
@@ -58,5 +58,6 @@ Bugfixes
 ########
 
 - Fix problem with dictionary parameters on :ref:`SetSample <algm-SetSample>` algorithm when running from the algorithm dialog
+- Fix segmentation fault when running :ref:`MonteCarloAbsorption <algm-MonteCarloAbsorption>` algorithm on Ubuntu without a material defined on one of the sample\environment shapes
 
 :ref:`Release 6.1.0 <v6.1.0>`


### PR DESCRIPTION
**Description of work.**

MonteCarloAbsorption would occasionally crash when running on Ubuntu\OSX when a material on one of the shapes wasn't defined. In this situation the code in one of the threads would create the missing material on the shape which is shared between the threads. Sometimes multiple threads would create the missing material and it appears this wasn't thread safe.

This problem showed up in various places on Jenkins: nightly build for OSX (PaalmanPingsMonteCarloAbsorption doc tests) and pull requests on Ubuntu (doc tests and occasionally also the unit tests for the PaalmanPingsMonteCarloAbsorption alg). PaalmanPingsMonteCarloAbsorption is a workflow algorithm that calls MonteCarloAbsorption.

I have changed CSGObject::material so it doesn't create a dummy material if it is missing. I have also removed the temporary workaround in the PaalmanPingsMonteCarloAbsorption doc test that was created in #30773

**To test:**

The problem was initially identified in the Jenkins jobs for the OSX nightly build and it appears it is most easily reproduced on OSX. You can also see it on Ubuntu but I found that you had to write a loop in a python script to call MonteCarloAbsorption ~100 times to see it there.

To test run the following script and check it doesn't crash workbench. I sometimes had to run the whole thing twice to get workbench to crash on Ubuntu 18.04:

```
# import mantid algorithms, numpy and matplotlib
from mantid.simpleapi import *
import matplotlib.pyplot as plt
import numpy as np

sample_ws = CreateSampleWorkspace(Function="Powder Diffraction",
                                      XUnit="Wavelength",
                                      XMin=-0.5,
                                      XMax=0.5,
                                      BinWidth=0.01)

def run():

    # define example geometries for the Sample and Container but omit a material for the Container
    SetSample(sample_ws, Geometry={'Shape': 'Cylinder', 'Height': 4.0, 'Radius': 2.0, 'Center': [0.,0.,0.]},
                Material={'ChemicalFormula': 'Ni', 'MassDensity': 7.0},
                ContainerGeometry={'Shape': 'HollowCylinder', 'Height': 4.0, 'InnerRadius': 2.0,
                'OuterRadius': 3.5})

    corrections = MonteCarloAbsorption(InputWorkspace=sample_ws, EventsPerPoint=1000)

for i in range(100):
    run()
```

Fixes #30779.


---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
