### PR TITLE
FitPeaks bugfixes

### DIFF
--- a/Framework/Algorithms/inc/MantidAlgorithms/FitPeaks.h
+++ b/Framework/Algorithms/inc/MantidAlgorithms/FitPeaks.h
@@ -183,16 +183,6 @@ private:
                         const std::vector<double> &vec_y,
                         const std::vector<double> &vec_e);
 
-  /// Esitmate background by 'observation'
-  void estimateBackground(const HistogramData::Histogram &histogram,
-                          const std::pair<double, double> &peak_window,
-                          const API::IBackgroundFunction_sptr &bkgd_function);
-  /// estimate linear background
-  void estimateLinearBackground(const HistogramData::Histogram &histogram,
-                                double left_window_boundary,
-                                double right_window_boundary, double &bkgd_a0,
-                                double &bkgd_a1);
-
   /// Estimate peak parameters by 'observation'
   int estimatePeakParameters(const HistogramData::Histogram &histogram,
                              const std::pair<double, double> &peak_window,

--- a/Framework/Algorithms/inc/MantidAlgorithms/FitPeaks.h
+++ b/Framework/Algorithms/inc/MantidAlgorithms/FitPeaks.h
@@ -19,6 +19,8 @@
 #include "MantidDataObjects/TableWorkspace.h"
 #include "MantidKernel/cow_ptr.h"
 
+#include <utility>
+
 namespace Mantid {
 namespace HistogramData {
 class HistogramX;
@@ -149,9 +151,10 @@ private:
                        bool estimate_peak_width, bool estimate_background);
 
   double fitFunctionMD(API::IFunction_sptr fit_function,
-                       const API::MatrixWorkspace_sptr &dataws, size_t wsindex,
-                       std::vector<double> &vec_xmin,
-                       std::vector<double> &vec_xmax);
+                       const API::MatrixWorkspace_sptr &dataws,
+                       const size_t wsindex,
+                       const std::pair<double, double> &vec_xmin,
+                       const std::pair<double, double> &vec_xmax);
 
   /// fit a single peak with high background
   double fitFunctionHighBackground(

--- a/Framework/Algorithms/inc/MantidAlgorithms/FitPeaks.h
+++ b/Framework/Algorithms/inc/MantidAlgorithms/FitPeaks.h
@@ -146,7 +146,7 @@ private:
                        const API::IPeakFunction_sptr &peak_function,
                        const API::IBackgroundFunction_sptr &bkgd_function,
                        const API::MatrixWorkspace_sptr &dataws, size_t wsindex,
-                       double xmin, double xmax,
+                       const std::pair<double, double> &peak_range,
                        const double &expected_peak_center,
                        bool estimate_peak_width, bool estimate_background);
 
@@ -185,7 +185,7 @@ private:
 
   /// Estimate peak parameters by 'observation'
   int estimatePeakParameters(const HistogramData::Histogram &histogram,
-                             const std::pair<double, double> &peak_window,
+                             const std::pair<size_t, size_t> &peak_window,
                              const API::IPeakFunction_sptr &peakfunction,
                              const API::IBackgroundFunction_sptr &bkgdfunction,
                              bool observe_peak_width);

--- a/Framework/Algorithms/test/XrayAbsorptionCorrectionTest.h
+++ b/Framework/Algorithms/test/XrayAbsorptionCorrectionTest.h
@@ -119,7 +119,7 @@ public:
     algo.setProperty("OutputWorkspace", "outputWS");
     algo.setProperty("DetectorDistance", 10.0);
     algo.setProperty("DetectorAngle", 45.0);
-    TS_ASSERT_THROWS(algo.execute(), std::runtime_error);
+    TS_ASSERT_THROWS(algo.execute(), std::runtime_error &);
   }
 
 private:

--- a/docs/source/algorithms/FitPeaks-v1.rst
+++ b/docs/source/algorithms/FitPeaks-v1.rst
@@ -417,8 +417,7 @@ Output:
 .. testoutput::  ExFitVanadiumPeaks
 
   Spectrum 1: Expected right most 3 peaks at 2.1401000, 1.5133000, 1.2356000
-  Spectrum 1: Found    right most 3 peaks at 2.1485553, 1.5190663, 1.2403992
-
+  Spectrum 1: Found    right most 3 peaks at 2.1485553, 1.5190662, 1.2404027
 
 **Example - Fit back-to-back exponential peaks (Vulcan diamond):**
 

--- a/docs/source/release/v6.1.0/diffraction.rst
+++ b/docs/source/release/v6.1.0/diffraction.rst
@@ -28,6 +28,7 @@ Bugfixes
 ########
 
 - Fix out-of-range bug in :ref:`FitPeaks <algm-FitPeaks>` for histogram data.
+- Fix bug in :ref:`FitPeaks <algm-FitPeaks>` not correctly checking right window for an individual peak
 - Fix bug to actually implement intended sequential fit of DIFC, DIFA, TZERO in :ref:`PDCalibration <algm-PDCalibration>`.
 - New options, including three "cache directory" and one "clean cache" in the Advanced Setup tab of the SNS Powder Reduction interface
 - New caching feature is added to :ref:`SNSPowderReduction <algm-SNSPowderReduction>` to speed up calculation using same sample and container.


### PR DESCRIPTION
**Description of work.**

There is a fair amount of refactoring, but the actual bugfix is essentially ignoring the data range when examining the right side of the background window in `FitPeaks::fitBackground`.

**To test:**

The issue was found when `HighBackground=True`.

*There is no associated issue.*

The version into `ornl-next` is #30860

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
