### PR TITLE
Fix FileFinder crashes with specific characters

### DIFF
--- a/Framework/API/inc/MantidAPI/FileFinder.h
+++ b/Framework/API/inc/MantidAPI/FileFinder.h
@@ -64,6 +64,8 @@ private:
   FileFinderImpl(const FileFinderImpl &);
   /// Assignment operator
   FileFinderImpl &operator=(const FileFinderImpl &);
+  /// A method that returns error messages if the provided runs are invalid
+  std::string validateRuns(const std::string &searchText) const;
   std::string extractAllowedSuffix(std::string &userString) const;
   std::pair<std::string, std::string> toInstrumentAndNumber(const std::string &hint) const;
   std::string getArchivePath(const std::vector<IArchiveSearch_sptr> &archs, const std::set<std::string> &filenames,

--- a/Framework/API/src/FileFinder.cpp
+++ b/Framework/API/src/FileFinder.cpp
@@ -43,6 +43,11 @@ Mantid::Kernel::Logger g_log("FileFinder");
  * @returns true if extension contains a "*", else false.
  */
 bool containsWildCard(const std::string &ext) { return std::string::npos != ext.find('*'); }
+
+bool isASCII(const std::string &str) {
+  return !std::any_of(str.cbegin(), str.cend(), [](char c) { return static_cast<unsigned char>(c) > 127; });
+}
+
 } // namespace
 
 namespace Mantid {
@@ -494,6 +499,18 @@ void FileFinderImpl::getUniqueExtensions(const std::vector<std::string> &extensi
 }
 
 /**
+ * Performs validation on the search text entered into the File Finder. It will
+ * return an error message if a problem is found.
+ * @param searchText :: The text to validate.
+ * @return An error message if something is invalid.
+ */
+std::string FileFinderImpl::validateRuns(const std::string &searchText) const {
+  if (!isASCII(searchText))
+    return "An unsupported non-ASCII character was found in the search text.";
+  return "";
+}
+
+/**
  * Find a list of files file given a hint. Calls findRun internally.
  * @param hintstr :: Comma separated list of hints to findRun method.
  *  Can also include ranges of runs, e.g. 123-135 or equivalently 123-35.
@@ -510,6 +527,10 @@ void FileFinderImpl::getUniqueExtensions(const std::vector<std::string> &extensi
  */
 std::vector<std::string> FileFinderImpl::findRuns(const std::string &hintstr, const std::vector<std::string> &exts,
                                                   const bool useExtsOnly) const {
+  auto const error = validateRuns(hintstr);
+  if (!error.empty())
+    throw std::invalid_argument(error);
+
   std::string hint = Kernel::Strings::strip(hintstr);
   g_log.debug() << "findRuns hint = " << hint << "\n";
   std::vector<std::string> res;

--- a/Framework/API/src/FileFinder.cpp
+++ b/Framework/API/src/FileFinder.cpp
@@ -420,6 +420,9 @@ std::string FileFinderImpl::findRun(const std::string &hintstr, const std::vecto
     }
   }
 
+  if (filename.empty())
+    return "";
+
   // Look first at the original filename then for case variations. This is
   // important
   // on platforms where file names ARE case sensitive.

--- a/Framework/API/src/MultipleFileProperty.cpp
+++ b/Framework/API/src/MultipleFileProperty.cpp
@@ -55,6 +55,10 @@ const std::string ALPHA_PLUS_ALPHA(R"((?<=\D)\s*\+\s*(?=\D))");
 const std::string PLUS_OPERATORS = NUM_PLUS_ALPHA + "|" + ALPHA_PLUS_ALPHA;
 static const boost::regex REGEX_PLUS_OPERATORS(PLUS_OPERATORS, boost::regex_constants::perl);
 
+bool isASCII(const std::string &str) {
+  return !std::any_of(str.cbegin(), str.cend(), [](char c) { return static_cast<unsigned char>(c) > 127; });
+}
+
 } // anonymous namespace
 
 namespace Mantid {
@@ -242,6 +246,8 @@ std::string MultipleFileProperty::setValueAsMultipleFiles(const std::string &pro
   boost::smatch invalid_substring;
   if (!m_allowEmptyTokens && boost::regex_search(propValue.begin(), propValue.end(), invalid_substring, REGEX_INVALID))
     return "Unable to parse filename due to an empty token.";
+  if (!isASCII(propValue))
+    return "Unable to parse filename due to an unsupported non-ASCII character being found.";
 
   std::vector<std::vector<std::string>> fileNames;
 

--- a/Testing/Tools/cxxtest/python/cxxtest/cxxtest_parser.py
+++ b/Testing/Tools/cxxtest/python/cxxtest/cxxtest_parser.py
@@ -35,7 +35,7 @@ lineCont_re = re.compile('(.*)\\\s*$')
 
 def scanInputFile(fileName):
     '''Scan single input file for test suites'''
-    file = open(fileName)
+    file = open(fileName, encoding='utf-8')
     prev = ""
     lineNo = 0
     contNo = 0

--- a/qt/widgets/common/test/FindFilesWorkerTest.h
+++ b/qt/widgets/common/test/FindFilesWorkerTest.h
@@ -146,6 +146,7 @@ public:
     auto parameters = createFileSearch(searchText.toStdString());
     parameters.algorithmName = "";
     parameters.algorithmProperty = "";
+    parameters.isForRunFiles = true;
     const auto worker = new FindFilesWorker(parameters);
     const auto widget = createWidget(worker);
 

--- a/qt/widgets/common/test/FindFilesWorkerTest.h
+++ b/qt/widgets/common/test/FindFilesWorkerTest.h
@@ -127,9 +127,25 @@ public:
     TS_ASSERT_EQUALS(results.filenames.size(), 0)
   }
 
-  void test_that_a_non_ascii_symbol_does_not_cause_a_crash_when_file_searching() {
+  void test_that_a_non_ascii_symbol_does_not_cause_a_crash_when_file_searching_using_a_filename() {
     const auto searchText = QString("£");
-    const auto parameters = createFileSearch(searchText.toStdString());
+    auto parameters = createFileSearch(searchText.toStdString());
+    const auto worker = new FindFilesWorker(parameters);
+    const auto widget = createWidget(worker);
+
+    executeWorker(worker);
+
+    auto results = widget->getResults();
+    TS_ASSERT(widget->isFinishedSignalRecieved())
+    TS_ASSERT_DIFFERS(results.error, "")
+    TS_ASSERT_EQUALS(results.filenames.size(), 0)
+  }
+
+  void test_that_a_non_ascii_symbol_does_not_cause_a_crash_when_file_searching_using_runs() {
+    const auto searchText = QString("£");
+    auto parameters = createFileSearch(searchText.toStdString());
+    parameters.algorithmName = "";
+    parameters.algorithmProperty = "";
     const auto worker = new FindFilesWorker(parameters);
     const auto widget = createWidget(worker);
 

--- a/qt/widgets/common/test/FindFilesWorkerTest.h
+++ b/qt/widgets/common/test/FindFilesWorkerTest.h
@@ -114,20 +114,6 @@ public:
     TS_ASSERT_EQUALS(results.filenames.size(), 0)
   }
 
-  void test_that_the_pound_symbol_does_not_cause_a_crash_when_file_searching() {
-    const auto searchText = QString("£");
-    const auto parameters = createFileSearch(searchText.toStdString());
-    const auto worker = new FindFilesWorker(parameters);
-    const auto widget = createWidget(worker);
-
-    executeWorker(worker);
-
-    auto results = widget->getResults();
-    TS_ASSERT(widget->isFinishedSignalRecieved())
-    TS_ASSERT_DIFFERS(results.error, "")
-    TS_ASSERT_EQUALS(results.filenames.size(), 0)
-  }
-
   void test_that_a_single_dot_will_return_an_error_when_file_searching() {
     const auto parameters = createFileSearch(".");
     const auto worker = new FindFilesWorker(parameters);
@@ -135,12 +121,9 @@ public:
 
     executeWorker(worker);
 
-    auto results = widget->getResults();
+    const auto results = widget->getResults();
     TS_ASSERT(widget->isFinishedSignalRecieved())
-    TS_ASSERT_EQUALS(results.error,
-                     "Invalid value for property Filename (list of str lists) "
-                     "from string \".\": Unable to find file matching the "
-                     "string \".\", please check the data search directories.")
+    TS_ASSERT_DIFFERS(results.error, "")
     TS_ASSERT_EQUALS(results.filenames.size(), 0)
   }
 

--- a/qt/widgets/common/test/FindFilesWorkerTest.h
+++ b/qt/widgets/common/test/FindFilesWorkerTest.h
@@ -1,4 +1,4 @@
-﻿// Mantid Repository : https://github.com/mantidproject/mantid
+// Mantid Repository : https://github.com/mantidproject/mantid
 //
 // Copyright &copy; 2018 ISIS Rutherford Appleton Laboratory UKRI,
 //   NScD Oak Ridge National Laboratory, European Spallation Source,

--- a/qt/widgets/common/test/FindFilesWorkerTest.h
+++ b/qt/widgets/common/test/FindFilesWorkerTest.h
@@ -114,6 +114,36 @@ public:
     TS_ASSERT_EQUALS(results.filenames.size(), 0)
   }
 
+  void test_that_the_pound_symbol_does_not_cause_a_crash_when_file_searching() {
+    const auto searchText = QString("£");
+    const auto parameters = createFileSearch(searchText.toStdString());
+    const auto worker = new FindFilesWorker(parameters);
+    const auto widget = createWidget(worker);
+
+    executeWorker(worker);
+
+    auto results = widget->getResults();
+    TS_ASSERT(widget->isFinishedSignalRecieved())
+    TS_ASSERT_DIFFERS(results.error, "")
+    TS_ASSERT_EQUALS(results.filenames.size(), 0)
+  }
+
+  void test_that_a_single_dot_will_return_an_error_when_file_searching() {
+    const auto parameters = createFileSearch(".");
+    const auto worker = new FindFilesWorker(parameters);
+    const auto widget = createWidget(worker);
+
+    executeWorker(worker);
+
+    auto results = widget->getResults();
+    TS_ASSERT(widget->isFinishedSignalRecieved())
+    TS_ASSERT_EQUALS(results.error,
+                     "Invalid value for property Filename (list of str lists) "
+                     "from string \".\": Unable to find file matching the "
+                     "string \".\", please check the data search directories.")
+    TS_ASSERT_EQUALS(results.filenames.size(), 0)
+  }
+
 private:
   FindFilesSearchParameters createFileSearch(const std::string &searchText) {
     FindFilesSearchParameters parameters;

--- a/qt/widgets/common/test/FindFilesWorkerTest.h
+++ b/qt/widgets/common/test/FindFilesWorkerTest.h
@@ -1,4 +1,4 @@
-// Mantid Repository : https://github.com/mantidproject/mantid
+﻿// Mantid Repository : https://github.com/mantidproject/mantid
 //
 // Copyright &copy; 2018 ISIS Rutherford Appleton Laboratory UKRI,
 //   NScD Oak Ridge National Laboratory, European Spallation Source,
@@ -122,6 +122,20 @@ public:
     executeWorker(worker);
 
     const auto results = widget->getResults();
+    TS_ASSERT(widget->isFinishedSignalRecieved())
+    TS_ASSERT_DIFFERS(results.error, "")
+    TS_ASSERT_EQUALS(results.filenames.size(), 0)
+  }
+
+  void test_that_a_non_ascii_symbol_does_not_cause_a_crash_when_file_searching() {
+    const auto searchText = QString("£");
+    const auto parameters = createFileSearch(searchText.toStdString());
+    const auto worker = new FindFilesWorker(parameters);
+    const auto widget = createWidget(worker);
+
+    executeWorker(worker);
+
+    auto results = widget->getResults();
     TS_ASSERT(widget->isFinishedSignalRecieved())
     TS_ASSERT_DIFFERS(results.error, "")
     TS_ASSERT_EQUALS(results.filenames.size(), 0)


### PR DESCRIPTION
**Description of work.**
This PR fixes two cases where there would be a crash in the FileFinder widget:
1. Providing a single `.` character would cause a crash
2. Using a non-ASCII character in the FileFinder such as the `£` symbol would cause a crash.

The FileFinder now ensures that the string provided is all ASCII characters, and will also return early if the filename is empty (which is the case when providing a single `.` character).

**To test:**
1. Go to an interface with a FileFinder widget (e.g. Indirect Data Reduction)
2. In `Input Runs` type `.` and click enter. There should be no crash.
3. In `Input Runs` type a string containing a non-ASCII character such as `£` and click enter. There should be no crash again.

Fixes #20093

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
