### PR TITLE
Add properties to summed_empty filename to prevent long_mode confusion

### DIFF
--- a/docs/source/release/v6.1.0/diffraction.rst
+++ b/docs/source/release/v6.1.0/diffraction.rst
@@ -41,7 +41,7 @@ Bugfixes
 - Improve algorithm :ref:`FitPeaks <algm-FitPeaks>` to enable it to fit with multiple peaks in same spectrum with Back-to-back Exponential function starting from user specified parameters.
 - :ref:`SNSPowderReduction <algm-SNSPowderReduction>` has additional property, ``DeltaRagged``, which allows using :ref:`RebinRagged <algm-RebinRagged>` to bin each spectrum differently.
 - Allow a different number of spectra for absorption correction division of PEARL data. This allows ``create_vanadium`` to work for a non-standard dataset.
-
+- Saved filenames for summed empty workspaces now include spline properties to avoid long_mode confusion when focussing.
 
 Engineering Diffraction
 -----------------------

--- a/docs/source/techniques/ISISPowder-Pearl-v1.rst
+++ b/docs/source/techniques/ISISPowder-Pearl-v1.rst
@@ -459,7 +459,7 @@ When *long_mode* is **False** the TOF window processed is
 between 0-20,000 μs
 
 When *long_mode* is **True** the TOF window processed is
-between 0-40,000 μs
+between 20,000-40,000 μs
 
 This also affects the :ref:`advanced_parameters_pearl_isis-powder-diffraction-ref`
 used. More detail can be found for each individual parameter

--- a/scripts/Diffraction/isis_powder/pearl.py
+++ b/scripts/Diffraction/isis_powder/pearl.py
@@ -106,7 +106,7 @@ class Pearl(AbstractInst):
             add_spline = [self._inst_settings.tt_mode, "long"] if self._inst_settings.long_mode else \
                 [self._inst_settings.tt_mode]
 
-            self._cached_run_details[run_number_string_key].update_spline_properties(
+            self._cached_run_details[run_number_string_key].update_file_paths(
                 self._inst_settings, add_spline)
         yield
         # reset instrument settings
@@ -116,8 +116,7 @@ class Pearl(AbstractInst):
         add_spline = [self._inst_settings.tt_mode, "long"] if self._inst_settings.long_mode else \
             [self._inst_settings.tt_mode]
 
-        self._cached_run_details[run_number_string_key].update_spline_properties(self._inst_settings,
-                                                                                 add_spline)
+        self._cached_run_details[run_number_string_key].update_file_paths(self._inst_settings, add_spline)
 
     def _run_create_vanadium(self):
         # Provides a minimal wrapper so if we have tt_mode 'all' we can loop round

--- a/scripts/Diffraction/isis_powder/pearl.py
+++ b/scripts/Diffraction/isis_powder/pearl.py
@@ -44,6 +44,7 @@ class Pearl(AbstractInst):
     def create_vanadium(self, **kwargs):
         kwargs[
             "perform_attenuation"] = None  # Hard code this off as we do not need an attenuation file
+
         with self._apply_temporary_inst_settings(kwargs, kwargs.get("run_in_cycle")):
             if str(self._inst_settings.tt_mode).lower() == "all":
                 for new_tt_mode in ["tt35", "tt70", "tt88"]:
@@ -105,7 +106,7 @@ class Pearl(AbstractInst):
             add_spline = [self._inst_settings.tt_mode, "long"] if self._inst_settings.long_mode else \
                 [self._inst_settings.tt_mode]
 
-            self._cached_run_details[run_number_string_key].update_spline(
+            self._cached_run_details[run_number_string_key].update_spline_properties(
                 self._inst_settings, add_spline)
         yield
         # reset instrument settings
@@ -115,8 +116,8 @@ class Pearl(AbstractInst):
         add_spline = [self._inst_settings.tt_mode, "long"] if self._inst_settings.long_mode else \
             [self._inst_settings.tt_mode]
 
-        self._cached_run_details[run_number_string_key].update_spline(self._inst_settings,
-                                                                      add_spline)
+        self._cached_run_details[run_number_string_key].update_spline_properties(self._inst_settings,
+                                                                                 add_spline)
 
     def _run_create_vanadium(self):
         # Provides a minimal wrapper so if we have tt_mode 'all' we can loop round

--- a/scripts/Diffraction/isis_powder/routines/common.py
+++ b/scripts/Diffraction/isis_powder/routines/common.py
@@ -253,7 +253,7 @@ def generate_unsplined_name(vanadium_string, *args):
     return _generate_vanadium_name(vanadium_string, False, *args)
 
 
-def generate_summed_empty_name(empty_runs_string):
+def generate_summed_empty_name(empty_runs_string, *args):
     """
     Generates a name for the summed empty instrument runs
     so that the file can be later loaded.
@@ -261,8 +261,14 @@ def generate_summed_empty_name(empty_runs_string):
     :return: The generated file name
     """
     out_name = 'summed_empty'
-
     out_name += '_' + str(empty_runs_string)
+
+    for passed_arg in args:
+        if isinstance(passed_arg, list):
+            for arg in passed_arg:
+                out_name += '_' + str(arg)
+        else:
+            out_name += '_' + (str(passed_arg))
 
     out_name += ".nxs"
     return out_name

--- a/scripts/Diffraction/isis_powder/routines/common.py
+++ b/scripts/Diffraction/isis_powder/routines/common.py
@@ -263,12 +263,14 @@ def generate_summed_empty_name(empty_runs_string, *args):
     out_name = 'summed_empty'
     out_name += '_' + str(empty_runs_string)
 
+    # Only arg that may be added is long_mode. tt_mode and cal file are not needed.
     for passed_arg in args:
         if isinstance(passed_arg, list):
-            for arg in passed_arg:
-                out_name += '_' + str(arg)
+            if 'long' in passed_arg:
+                out_name += '_long'
         else:
-            out_name += '_' + (str(passed_arg))
+            if passed_arg == 'long':
+                out_name += '_long'
 
     out_name += ".nxs"
     return out_name

--- a/scripts/Diffraction/isis_powder/routines/run_details.py
+++ b/scripts/Diffraction/isis_powder/routines/run_details.py
@@ -39,7 +39,8 @@ def create_run_details_object(run_number_string, inst_settings, is_vanadium_run,
 
     splined_van_name = common.generate_splined_name(vanadium_string, new_splined_list)
     unsplined_van_name = common.generate_unsplined_name(vanadium_string, new_splined_list)
-    summed_empty_name = common.generate_summed_empty_name(empty_run_number)
+
+    summed_empty_name = common.generate_summed_empty_name(empty_run_number, new_splined_list)
 
     if is_vanadium_run:
         # The run number should be the vanadium number in this case
@@ -122,7 +123,7 @@ class _RunDetails(object):
         self.output_suffix = output_suffix
         self.van_paths = van_paths
 
-    def update_spline(self, inst_settings, new_splined_name_list):
+    def update_spline_properties(self, inst_settings, new_splined_name_list):
         """Updates the spline path using a new splined name list, this is necessary on instruments where the spline path
         may change e.g. Pearl due to long-mode
         :param inst_settings The current Instrument settings
@@ -133,9 +134,15 @@ class _RunDetails(object):
                                             cal_mapping_path=inst_settings.cal_mapping_path)
         offset_file_name = common.cal_map_dictionary_key_helper(dictionary=cal_map_dict, key="offset_file_name")
 
-        # Prepend the properties used for creating a van spline so we can fingerprint the file
+        # Prepend the properties used for creating a van spline so we can fingerprint the output files
         splined_list = new_splined_name_list if new_splined_name_list else []
         splined_list.append(os.path.basename(offset_file_name))
 
         splined_van_name = common.generate_splined_name(self.vanadium_run_numbers, splined_list)
         self.splined_vanadium_file_path = os.path.join(self.van_paths, splined_van_name)
+
+        unsplined_van_name = common.generate_unsplined_name(self.vanadium_run_numbers, splined_list)
+        self.unsplined_vanadium_file_path = os.path.join(self.van_paths, unsplined_van_name)
+
+        summed_empty_name = common.generate_summed_empty_name(self.empty_runs, splined_list)
+        self.summed_empty_file_path = os.path.join(self.van_paths, summed_empty_name)

--- a/scripts/Diffraction/isis_powder/routines/run_details.py
+++ b/scripts/Diffraction/isis_powder/routines/run_details.py
@@ -123,9 +123,9 @@ class _RunDetails(object):
         self.output_suffix = output_suffix
         self.van_paths = van_paths
 
-    def update_spline_properties(self, inst_settings, new_splined_name_list):
-        """Updates the spline path using a new splined name list, this is necessary on instruments where the spline path
-        may change e.g. Pearl due to long-mode
+    def update_file_paths(self, inst_settings, new_splined_name_list):
+        """Updates the file path for splined, unsplined and summed_empty files using a new splined name list,
+        this is necessary on instruments where the path may change e.g. Pearl due to long-mode
         :param inst_settings The current Instrument settings
         :param new_splined_name_list  List of unique properties to generate a splined vanadium name from
         """

--- a/scripts/Diffraction/isis_powder/test/ISISPowderRunDetailsTest.py
+++ b/scripts/Diffraction/isis_powder/test/ISISPowderRunDetailsTest.py
@@ -70,7 +70,8 @@ class ISISPowderInstrumentRunDetailsTest(unittest.TestCase):
         self.assertEqual(output_obj.vanadium_run_numbers, expected_vanadium_runs)
         self.assertEqual(output_obj.summed_empty_file_path,
                          os.path.join(mock_inst.calibration_dir, expected_label,
-                                      common.generate_summed_empty_name(expected_empty_runs)))
+                                      common.generate_summed_empty_name(expected_empty_runs,
+                                                                        expected_offset_file_name)))
 
     def test_create_run_details_object_when_van_cal(self):
         # When we are running the vanadium calibration we expected the run number to take the vanadium


### PR DESCRIPTION
**Description of work.**

*Issue:*
In the improvements introduced in #29709, a file for summed empty instrument workspaces in the create_vanadium step is saved. This is then loaded for the focussing step.
As this `summed_empty` file output from create_vanadium did not include spline properties, such as long_mode, in the filename, the next focus would incorrectly use the file with long_mode set, even when the focus had `long_mode=False`.

*Work:*
Now the filename for summed_empty includes the spline properties (long_mode, tt_mode and cal file) so that this confusion is avoided, and a saved file is only loaded if the focus properties match. This means that summed_empty filenames are created in a similar fashion to `Van_spline` output files.
To enable this bugfix to work, the function `update_splines` in `run_details.py` (introduced in #25816) now updates the filenames for summed_empty and unsplined as well as splined runs. This function seems like a dark way for create_vanadium on PEARL to get the right filename at the last moment as the run_details aren't correctly set without it.


**Report to:** Nick Funnell

**To test:**

- Download PEARL_files.zip from babylon/Public/DanielMurphy
- Extract the folder

- Firstly, on the current **master**, run the script `Calib_19_4_Dan.py` setting the paths in `pearl_focus` relevant to your machine.
- When the script completes, check the plots for the contained workspaces `Good_1_PRL112247-112253_tt70_mods1-9` and `Good_2_PRL112247-112253_tt70_mods1-9` look like:

![Good_CeO2](https://user-images.githubusercontent.com/55980573/110794010-2e9cb480-826d-11eb-8144-532f934a9452.PNG)

Notice that the contained workspace `Bad_PRL112247-112253_tt70_mods1-9` plotted looks like:
![Bad_CeO2](https://user-images.githubusercontent.com/55980573/110794120-4f650a00-826d-11eb-94e9-147e3142d501.PNG)
- Notice also that output to the calib_critical_files/16_4/ folder is `summed_empty_95648-85654.nxs`.
- Finally, checkout this pr and see that 
  - even a plot of the `Bad...mods1-9` workspace looks "Good" now.
  - in the calib_critical_files/16_4/ folder is `summed_empty_95648-95654_tt70_long_pearl_offset_16_4.cal.nxs` and `summed_empty_95648-95654_tt70_pearl_offset_16_4.cal.nxs` (Long_mode true and false)

**After code review, I have a few questions for _you_**:

- I have renamed the `update_spline` function to `update_spline_properties` in the search for a more general name. _Can you think of something better?_ I would also be up for renaming the variable `splines_list` which is this list of properties that is also now general enough to be used for unsplined and summed_empty runs also!
- The fix here has the (long_mode, tt_mode and cal file) properties added to the filename. Should I only be including long_mode in the filename? It is all that is needed for this fix here, but having all 3 provides a nice parallel with saved Van_spline filenames

*There is no associated issue.*

<!-- Ensure the base of this PR is correct (e.g. release-next or master)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
