### PR TITLE
Add constructor in Peak that allows converting from LeanPeak to Peak (SCD196)

### DIFF
--- a/Framework/DataObjects/inc/MantidDataObjects/Peak.h
+++ b/Framework/DataObjects/inc/MantidDataObjects/Peak.h
@@ -7,6 +7,7 @@
 #pragma once
 
 #include "MantidDataObjects/BasePeak.h"
+#include "MantidDataObjects/LeanElasticPeak.h"
 #include "MantidGeometry/Crystal/IPeak.h"
 #include "MantidGeometry/Crystal/PeakShape.h"
 #include "MantidGeometry/Instrument.h"
@@ -75,6 +76,11 @@ public:
   // Construct a peak from a reference to the interface
 
   explicit Peak(const Geometry::IPeak &ipeak);
+
+  // Construct a peak from LeanPeak
+  Peak(const Mantid::DataObjects::LeanElasticPeak &lpeak,
+       const Geometry::Instrument_const_sptr &inst,
+       boost::optional<double> detectorDistance = boost::none);
 
   void setDetectorID(int id) override;
   int getDetectorID() const override;

--- a/Framework/DataObjects/src/Peak.cpp
+++ b/Framework/DataObjects/src/Peak.cpp
@@ -126,6 +126,7 @@ Peak::Peak(const Geometry::Instrument_const_sptr &m_inst, int m_detectorID,
   this->setWavelength(m_Wavelength);
   this->setHKL(HKL);
 }
+
 //----------------------------------------------------------------------------------------------
 /** Constructor
  *
@@ -175,6 +176,14 @@ Peak::Peak(const Geometry::IPeak &ipeak)
   if (const auto *peak = dynamic_cast<const Peak *>(&ipeak)) {
     this->m_detIDs = peak->m_detIDs;
   }
+}
+
+//----------------------------------------------------------------------------------------------
+Peak::Peak(const Mantid::DataObjects::LeanElasticPeak &lpeak,
+           const Geometry::Instrument_const_sptr &inst,
+           boost::optional<double> detectorDistance) {
+  this->setInstrument(inst);
+  this->setQLabFrame(lpeak.getQLabFrame(), std::move(detectorDistance));
 }
 
 //----------------------------------------------------------------------------------------------

--- a/Framework/DataObjects/src/Peak.cpp
+++ b/Framework/DataObjects/src/Peak.cpp
@@ -181,7 +181,8 @@ Peak::Peak(const Geometry::IPeak &ipeak)
 //----------------------------------------------------------------------------------------------
 Peak::Peak(const Mantid::DataObjects::LeanElasticPeak &lpeak,
            const Geometry::Instrument_const_sptr &inst,
-           boost::optional<double> detectorDistance) {
+           boost::optional<double> detectorDistance)
+    : BasePeak(lpeak) {
   this->setInstrument(inst);
   this->setQLabFrame(lpeak.getQLabFrame(), std::move(detectorDistance));
 }

--- a/Framework/DataObjects/test/PeakTest.h
+++ b/Framework/DataObjects/test/PeakTest.h
@@ -123,6 +123,12 @@ public:
     check_Contributing_Detectors(p2, expectedIDs);
   }
 
+  void test_ConstructorFromLeanElasticPeak() {
+    const LeanElasticPeak &lpeak = p(V3D(1, 2, 3));
+
+    TS_ASSERT_THROWS_NOTHING(Peak p(lpeak, inst));
+  }
+
   void test_copyConstructor() {
     Peak p(inst, 10102, 2.0);
     p.setHKL(1, 2, 3);

--- a/Framework/DataObjects/test/PeakTest.h
+++ b/Framework/DataObjects/test/PeakTest.h
@@ -124,9 +124,72 @@ public:
   }
 
   void test_ConstructorFromLeanElasticPeak() {
-    const LeanElasticPeak &lpeak = LeanElasticPeak(V3D(1, 2, 3));
+    // step_1: constructing a peak (follow example in LeanElasticPeakTest)
+    Matrix<double> r(3, 3, false);
+    r[0][2] = 1;
+    r[1][1] = 1;
+    r[2][0] = -1;
+    // NOTE: the detector ID here (19999) is an arbitrary number and will most
+    //       likely no the same as the one from find_detector(). DO NOT compare
+    //       detector verbatim
+    Peak peak(inst, 19999, 2.0, V3D(1, 2, 3), r);
+    peak.setRunNumber(1234);
+    peak.setPeakNumber(42);
+    peak.setIntensity(900);
+    peak.setSigmaIntensity(30);
+    peak.setBinCount(90);
 
-    TS_ASSERT_THROWS_NOTHING(Peak p(lpeak, inst));
+    // step_2: extract qsample, goniometer, [wavelength] to construct a leanpeak
+    V3D qsample = peak.getQSampleFrame();
+    // NOTE: the goniometer matrix should be handled by BasePeak, and it should
+    // be an exact copy of r created above
+    auto goniometerMatrix = peak.getGoniometerMatrix();
+    // construct the LeanPeak using QSample and goniometerMatrix
+    const LeanElasticPeak &lpeak = LeanElasticPeak(qsample, goniometerMatrix);
+
+    // step_3: construct Peak based on leanpeak and check
+    //           - qlab
+    //           - qsample
+    //           - goniometer
+    //           - sacttering
+    //           - wavelength
+    //           - d-spacing
+    //           - initial and final energy
+    //           - getAzimuthal angle
+    //           - check detector id is any number (using LeanPeak test peak)
+    const double tolerance{1e-10};
+    Peak plp(lpeak, inst); // peak->leanpeak->peak
+    TS_ASSERT_EQUALS(plp.getQLabFrame(), peak.getQLabFrame());
+    TS_ASSERT_EQUALS(plp.getQSampleFrame(), peak.getQSampleFrame());
+    TS_ASSERT_EQUALS(plp.getGoniometerMatrix(), r);
+    TS_ASSERT_EQUALS(plp.getGoniometerMatrix(), goniometerMatrix);
+    TS_ASSERT_EQUALS(plp.getScattering(), peak.getScattering());
+    // NOTE: reasons to use TS_ASSERT_DELTA for some values
+    //                  LeanPeak          Peak
+    // wavelength    2.000000000000018    2
+    // dspacing      9.093899818222381    9.093899818222283
+    // initialEnergy 20.45105062499033    20.45105062499069
+    // finalEnergy   20.45105062499033    20.45105062499069
+    TS_ASSERT_DELTA(plp.getWavelength(), peak.getWavelength(), tolerance);
+    TS_ASSERT_DELTA(plp.getDSpacing(), peak.getDSpacing(), tolerance);
+    TS_ASSERT_DELTA(plp.getInitialEnergy(), peak.getInitialEnergy(), tolerance);
+    TS_ASSERT_DELTA(plp.getFinalEnergy(), peak.getFinalEnergy(), tolerance);
+    //
+    TS_ASSERT_EQUALS(plp.getAzimuthal(), peak.getAzimuthal());
+    TS_ASSERT_THROWS_NOTHING(plp.getDetectorID());
+
+    std::ostringstream msg;
+    msg.precision(16);
+    msg << "\t\tLeanPeak\t\tPeak\n"
+        << "wavelength\t\t" << plp.getWavelength() << "\t\t"
+        << peak.getWavelength() << "\n"
+        << "dspacing\t\t" << plp.getDSpacing() << "\t\t" << peak.getDSpacing()
+        << "\n"
+        << "initialEnergy\t\t" << plp.getInitialEnergy() << "\t\t"
+        << peak.getInitialEnergy() << "\n"
+        << "finalEnergy\t\t" << plp.getFinalEnergy() << "\t\t"
+        << peak.getFinalEnergy() << "\n";
+    std::cout << msg.str();
   }
 
   void test_copyConstructor() {

--- a/Framework/DataObjects/test/PeakTest.h
+++ b/Framework/DataObjects/test/PeakTest.h
@@ -124,7 +124,7 @@ public:
   }
 
   void test_ConstructorFromLeanElasticPeak() {
-    const LeanElasticPeak &lpeak = p(V3D(1, 2, 3));
+    const LeanElasticPeak &lpeak = LeanElasticPeak(V3D(1, 2, 3));
 
     TS_ASSERT_THROWS_NOTHING(Peak p(lpeak, inst));
   }


### PR DESCRIPTION
**Description of work.**

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

This PR add a new constructor to Peak class which can convert a LeanElasticPeak to Peak.

- Related Gitlab task: [SCD196](https://code.ornl.gov/sns-hfir-scse/diffraction/single-crystal/single-crystal-diffraction/-/issues/196)
- This is PR #30866 into `master`

**To test:**
Build Mantid and run unittest `ctest -R PeakTest`.

<!-- Instructions for testing. -->

Fixes #30867 . <!-- and fix #xxxx or close #xxxx xor resolves #xxxx -->
<!-- alternative
*There is no associated issue.*
-->

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or master)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
