### PR TITLE
Improvements in DrILL interface

### DIFF
--- a/scripts/Interface/ui/drill/model/DrillModel.py
+++ b/scripts/Interface/ui/drill/model/DrillModel.py
@@ -205,6 +205,8 @@ class DrillModel(QObject):
         self.groups = dict()
         self.masterSamples = dict()
         self.visualSettings = dict()
+        if mode in RundexSettings.VISUAL_SETTINGS:
+            self.visualSettings = RundexSettings.VISUAL_SETTINGS[mode]
         self.acquisitionMode = mode
         self.columns = RundexSettings.COLUMNS[self.acquisitionMode]
         self.algorithm = RundexSettings.ALGORITHM[self.acquisitionMode]

--- a/scripts/Interface/ui/drill/model/configurations.py
+++ b/scripts/Interface/ui/drill/model/configurations.py
@@ -130,6 +130,12 @@ class RundexSettings(object):
             }
 
     VISUAL_SETTINGS = {
+            SANS_ACQ: {
+                "HiddenColumns": [
+                    "FluxRuns",
+                    "TransmissionAbsorberRuns"
+                    ]
+                }
             }
 
     # algo name for each acquisition mode

--- a/scripts/Interface/ui/drill/model/configurations.py
+++ b/scripts/Interface/ui/drill/model/configurations.py
@@ -129,6 +129,9 @@ class RundexSettings(object):
                 ],
             }
 
+    VISUAL_SETTINGS = {
+            }
+
     # algo name for each acquisition mode
     ALGORITHM = {
             SANS_ACQ:     "SANSILLAutoProcess",

--- a/scripts/Interface/ui/drill/presenter/DrillPresenter.py
+++ b/scripts/Interface/ui/drill/presenter/DrillPresenter.py
@@ -427,12 +427,14 @@ class DrillPresenter:
                                                "Rundex (*.mrd);;All (*)")
         if not filename[0]:
             return
+        self.view.blockSignals(True)
         self.model.setIOFile(filename[0])
         self.view.setWindowTitle(filename[0] + " [*]")
         self.model.importRundexData()
         self._syncViewHeader()
         self._syncViewTable()
         self.view.setWindowModified(False)
+        self.view.blockSignals(False)
 
     def onSave(self):
         """

--- a/scripts/Interface/ui/drill/presenter/DrillPresenter.py
+++ b/scripts/Interface/ui/drill/presenter/DrillPresenter.py
@@ -568,3 +568,4 @@ class DrillPresenter:
         if vs:
             self.view.setVisualSettings(vs)
         self.view.blockSignals(False)
+        self.view.setWindowModified(False)

--- a/scripts/Interface/ui/drill/presenter/DrillPresenter.py
+++ b/scripts/Interface/ui/drill/presenter/DrillPresenter.py
@@ -398,6 +398,7 @@ class DrillPresenter:
 
         self.model.setInstrument(instrument)
         self.model.resetIOFile()
+        self.view.setWindowTitle("Untitled [*]")
         self._syncViewHeader()
         self._syncViewTable()
 
@@ -413,6 +414,7 @@ class DrillPresenter:
 
         self.model.setAcquisitionMode(mode)
         self.model.resetIOFile()
+        self.view.setWindowTitle("Untitled [*]")
         self._syncViewHeader()
         self._syncViewTable()
 

--- a/scripts/Interface/ui/drill/presenter/DrillPresenter.py
+++ b/scripts/Interface/ui/drill/presenter/DrillPresenter.py
@@ -45,6 +45,8 @@ class DrillPresenter:
         """
         self.model = DrillModel()
         self.view = view
+        self._windowTitle = self.view.windowTitle()
+        self.view.setWindowTitle("Untitled [*] -- " + self._windowTitle)
         self._invalidCells = set()
         self._processError = set()
         self._customOptions = set()
@@ -425,6 +427,7 @@ class DrillPresenter:
         if not filename[0]:
             return
         self.model.setIOFile(filename[0])
+        self.view.setWindowTitle(filename[0] + "[*] -- " + self._windowTitle)
         self.model.importRundexData()
         self._syncViewHeader()
         self._syncViewTable()
@@ -453,6 +456,7 @@ class DrillPresenter:
         if not filename[0]:
             return
         self.model.setIOFile(filename[0])
+        self.view.setWindowTitle(filename[0] + "[*] -- " + self._windowTitle)
         self.model.setVisualSettings(self.view.getVisualSettings())
         self.model.exportRundexData()
         self.view.setWindowModified(False)
@@ -514,6 +518,7 @@ class DrillPresenter:
             self._saveDataQuestion()
         self.model.clear()
         self.model.resetIOFile()
+        self.view.setWindowTitle("Untitled [*] -- " + self._windowTitle)
         self._syncViewHeader()
         self._syncViewTable()
 

--- a/scripts/Interface/ui/drill/presenter/DrillPresenter.py
+++ b/scripts/Interface/ui/drill/presenter/DrillPresenter.py
@@ -463,6 +463,7 @@ class DrillPresenter:
         generates automatically its fields on the basis of settings types. It
         also connects the differents signals to get validation of user inputs.
         """
+        self.view.setDisabled(True)
         sw = DrillSettingsDialog(self.view)
         types, values, doc = self.model.getSettingsTypes()
         sw.initWidgets(types, values, doc)
@@ -479,6 +480,9 @@ class DrillPresenter:
                 )
         sw.accepted.connect(
                 lambda : self.model.setSettings(sw.getSettings())
+                )
+        sw.finished.connect(
+                lambda : self.view.setDisabled(False)
                 )
         sw.show()
 

--- a/scripts/Interface/ui/drill/presenter/DrillPresenter.py
+++ b/scripts/Interface/ui/drill/presenter/DrillPresenter.py
@@ -45,8 +45,7 @@ class DrillPresenter:
         """
         self.model = DrillModel()
         self.view = view
-        self._windowTitle = self.view.windowTitle()
-        self.view.setWindowTitle("Untitled [*] -- " + self._windowTitle)
+        self.view.setWindowTitle("Untitled [*]")
         self._invalidCells = set()
         self._processError = set()
         self._customOptions = set()
@@ -427,7 +426,7 @@ class DrillPresenter:
         if not filename[0]:
             return
         self.model.setIOFile(filename[0])
-        self.view.setWindowTitle(filename[0] + "[*] -- " + self._windowTitle)
+        self.view.setWindowTitle(filename[0] + " [*]")
         self.model.importRundexData()
         self._syncViewHeader()
         self._syncViewTable()
@@ -456,7 +455,7 @@ class DrillPresenter:
         if not filename[0]:
             return
         self.model.setIOFile(filename[0])
-        self.view.setWindowTitle(filename[0] + "[*] -- " + self._windowTitle)
+        self.view.setWindowTitle(filename[0] + " [*]")
         self.model.setVisualSettings(self.view.getVisualSettings())
         self.model.exportRundexData()
         self.view.setWindowModified(False)
@@ -518,7 +517,7 @@ class DrillPresenter:
             self._saveDataQuestion()
         self.model.clear()
         self.model.resetIOFile()
-        self.view.setWindowTitle("Untitled [*] -- " + self._windowTitle)
+        self.view.setWindowTitle("Untitled [*]")
         self._syncViewHeader()
         self._syncViewTable()
 

--- a/scripts/Interface/ui/drill/presenter/DrillPresenter.py
+++ b/scripts/Interface/ui/drill/presenter/DrillPresenter.py
@@ -6,6 +6,7 @@
 # SPDX - License - Identifier: GPL - 3.0 +
 
 import re
+import os
 
 from qtpy.QtWidgets import QFileDialog, QMessageBox
 
@@ -429,7 +430,7 @@ class DrillPresenter:
             return
         self.view.blockSignals(True)
         self.model.setIOFile(filename[0])
-        self.view.setWindowTitle(filename[0] + " [*]")
+        self.view.setWindowTitle(os.path.split(filename[0])[1] + " [*]")
         self.model.importRundexData()
         self._syncViewHeader()
         self._syncViewTable()
@@ -459,7 +460,7 @@ class DrillPresenter:
         if not filename[0]:
             return
         self.model.setIOFile(filename[0])
-        self.view.setWindowTitle(filename[0] + " [*]")
+        self.view.setWindowTitle(os.path.split(filename[0])[1] + " [*]")
         self.model.setVisualSettings(self.view.getVisualSettings())
         self.model.exportRundexData()
         self.view.setWindowModified(False)

--- a/scripts/Interface/ui/drill/test/DrillPresenterTest.py
+++ b/scripts/Interface/ui/drill/test/DrillPresenterTest.py
@@ -29,6 +29,7 @@ class DrillPresenterTest(unittest.TestCase):
         self.addCleanup(patch.stop)
 
         self.view = mock.Mock()
+        self.view.windowTitle.return_value = ""
         self.presenter = DrillPresenter(self.view)
         self.model = self.mModel.return_value
 

--- a/scripts/Interface/ui/drill/test/DrillPresenterTest.py
+++ b/scripts/Interface/ui/drill/test/DrillPresenterTest.py
@@ -38,7 +38,7 @@ class DrillPresenterTest(unittest.TestCase):
         self.presenter.onDataChanged(1, 2)
         self.view.getCellContents.assert_called_once_with(1, 2)
         self.view.unsetRowBackground.assert_not_called()
-        self.view.setWindowModified.assert_called_once_with(True)
+        self.view.setWindowModified.assert_called()
         self.presenter.onDataChanged(2, 2)
         self.view.unsetRowBackground.assert_called_once_with(2)
 
@@ -174,14 +174,14 @@ class DrillPresenterTest(unittest.TestCase):
         mDialog.getOpenFileName.return_value = ("test", "test")
         self.presenter.onLoad()
         self.model.setIOFile.assert_called_once_with("test")
-        self.view.setWindowModified.assert_called_once_with(False)
+        self.view.setWindowModified.assert_called()
 
     def test_onSave(self):
         self.presenter.onSaveAs = mock.Mock()
         self.model.getIOFile.return_value = 1
         self.presenter.onSave()
         self.model.exportRundexData.assert_called_once()
-        self.view.setWindowModified.assert_called_once_with(False)
+        self.view.setWindowModified.assert_called()
         self.presenter.onSaveAs.assert_not_called()
         self.model.getIOFile.return_value = None
         self.presenter.onSave()
@@ -193,7 +193,7 @@ class DrillPresenterTest(unittest.TestCase):
         self.presenter.onSaveAs()
         self.model.setIOFile.assert_called_once_with("test")
         self.model.exportRundexData.assert_called_once()
-        self.view.setWindowModified.assert_called_once_with(False)
+        self.view.setWindowModified.assert_called()
 
     def test_settingsWindow(self):
         self.model.getSettingsTypes.return_value = ({}, {}, {})

--- a/scripts/Interface/ui/drill/test/DrillTest.py
+++ b/scripts/Interface/ui/drill/test/DrillTest.py
@@ -123,6 +123,7 @@ class DrillTest(unittest.TestCase):
                 self.selectRow(n-1, Qt.NoModifier)
                 self.view.add_row_after()
             for c in range(self.view.table.columnCount()):
+                self.view.table.setColumnHidden(c, False)
                 self.setCellContents(n, c, text + str(n) + str(c))
             data.append(dict())
             data[-1].update(self.model.samples[n].getParameters())
@@ -288,14 +289,16 @@ class DrillTest(unittest.TestCase):
         self.model.setInstrument("D11")
         mFileDialog.getSaveFileName.return_value = ["test", "test"]
         QTest.mouseClick(self.view.save, Qt.LeftButton)
+        visualSettings = {
+                'FoldedColumns': [],
+                'HiddenColumns': [],
+                'ColumnsOrder': RundexSettings.COLUMNS['SANS']
+                }
+        visualSettings.update(RundexSettings.VISUAL_SETTINGS["SANS"])
         json = {
                 'Instrument': 'D11',
                 'AcquisitionMode': 'SANS',
-                'VisualSettings': {
-                    'FoldedColumns': [],
-                    'HiddenColumns': [],
-                    'ColumnsOrder': RundexSettings.COLUMNS['SANS']
-                    },
+                'VisualSettings': visualSettings,
                 'GlobalSettings': self.model.settings,
                 'ExportAlgorithms' : [
                     algo

--- a/scripts/Interface/ui/drill/view/DrillView.py
+++ b/scripts/Interface/ui/drill/view/DrillView.py
@@ -488,7 +488,11 @@ class DrillView(QMainWindow):
         """
         Open the export dialog.
         """
+        self.setDisabled(True)
         dialog = DrillExportDialog(self)
+        dialog.finished.connect(
+                lambda : self.setDisabled(False)
+                )
         self._presenter.onShowExportDialog(dialog)
         dialog.show()
 

--- a/scripts/Interface/ui/drill/view/ui/main.ui
+++ b/scripts/Interface/ui/drill/view/ui/main.ui
@@ -17,7 +17,7 @@
    </size>
   </property>
   <property name="windowTitle">
-   <string>DrILL - Data Reduction for ILL[*]</string>
+   <string>DrILL - Data Reduction for ILL</string>
   </property>
   <property name="styleSheet">
    <string notr="true"/>

--- a/scripts/Interface/ui/drill/view/ui/main.ui
+++ b/scripts/Interface/ui/drill/view/ui/main.ui
@@ -16,9 +16,6 @@
     <height>768</height>
    </size>
   </property>
-  <property name="windowTitle">
-   <string>DrILL - Data Reduction for ILL</string>
-  </property>
   <property name="styleSheet">
    <string notr="true"/>
   </property>
@@ -631,7 +628,7 @@
   </action>
   <action name="actionProcessGroup">
    <property name="text">
-    <string>Process selected group(s)</string>
+    <string>Process selected &amp;group(s)</string>
    </property>
   </action>
  </widget>


### PR DESCRIPTION
**Description of work.**

This PR introduces some changes in the DrILL interfaces requested by the users:
* technique specific setting to hide columns by default and hiding of `FluxRuns` and `TransmissionAbsorberRuns` for SANS
* rundex filename in the title bar of DrILL
* avoid asking to save a new empty table


**To test:**

Open DrILL interface (Interfaces ->ILL -> DrILL) and:
* open a file and observe that the window title changed with the file name
* check that `FluxRuns` and `TransmissionAbsorberRuns` columns are hidden for the SANS

Part of #30592 

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
