### PR TITLE
Cleanup IPeak interface: remove findDetector

### DIFF
--- a/Framework/Crystal/src/PredictSatellitePeaks.cpp
+++ b/Framework/Crystal/src/PredictSatellitePeaks.cpp
@@ -36,8 +36,8 @@ using namespace Mantid::Kernel;
 namespace Crystal {
 
 // handy shortcuts
-using Mantid::Geometry::IPeak_uptr;
 using Mantid::DataObjects::Peak_uptr;
+using Mantid::Geometry::IPeak_uptr;
 
 DECLARE_ALGORITHM(PredictSatellitePeaks)
 
@@ -363,7 +363,7 @@ void PredictSatellitePeaks::predictOffsets(
       continue;
 
     IPeak_uptr iPeak = Peaks->createPeak(Qs, 1);
-    Peak_uptr peak(static_cast<DataObjects::Peak*>(iPeak.release()));
+    Peak_uptr peak(static_cast<DataObjects::Peak *>(iPeak.release()));
 
     peak->setGoniometerMatrix(goniometer);
 
@@ -436,7 +436,7 @@ void PredictSatellitePeaks::predictOffsetsWithCrossTerms(
           continue;
 
         IPeak_uptr iPeak(Peaks->createPeak(Qs, 1));
-        Peak_uptr peak(static_cast<DataObjects::Peak*>(iPeak.release()));
+        Peak_uptr peak(static_cast<DataObjects::Peak *>(iPeak.release()));
 
         peak->setGoniometerMatrix(goniometer);
 

--- a/Framework/Crystal/src/PredictSatellitePeaks.cpp
+++ b/Framework/Crystal/src/PredictSatellitePeaks.cpp
@@ -35,6 +35,10 @@ using namespace Mantid::Kernel;
 
 namespace Crystal {
 
+// handy shortcuts
+using Mantid::Geometry::IPeak_uptr;
+using Mantid::DataObjects::Peak_uptr;
+
 DECLARE_ALGORITHM(PredictSatellitePeaks)
 
 /** Constructor
@@ -358,7 +362,8 @@ void PredictSatellitePeaks::predictOffsets(
     if (Qs.Z() * m_qConventionFactor <= 0)
       continue;
 
-    auto peak(Peaks->createPeak(Qs, 1));
+    IPeak_uptr iPeak = Peaks->createPeak(Qs, 1);
+    Peak_uptr peak(static_cast<DataObjects::Peak*>(iPeak.release()));
 
     peak->setGoniometerMatrix(goniometer);
 
@@ -430,7 +435,8 @@ void PredictSatellitePeaks::predictOffsetsWithCrossTerms(
         if (Qs.Z() * m_qConventionFactor <= 0)
           continue;
 
-        auto peak(Peaks->createPeak(Qs, 1));
+        IPeak_uptr iPeak(Peaks->createPeak(Qs, 1));
+        Peak_uptr peak(static_cast<DataObjects::Peak*>(iPeak.release()));
 
         peak->setGoniometerMatrix(goniometer);
 

--- a/Framework/DataObjects/inc/MantidDataObjects/LeanElasticPeak.h
+++ b/Framework/DataObjects/inc/MantidDataObjects/LeanElasticPeak.h
@@ -69,8 +69,10 @@ public:
   std::shared_ptr<const Geometry::ReferenceFrame>
   getReferenceFrame() const override;
 
+  /*
   bool findDetector() override;
   bool findDetector(const Geometry::InstrumentRayTracer &) override;
+  */
 
   void setSamplePos(double, double, double) override;
   void setSamplePos(const Mantid::Kernel::V3D &) override;

--- a/Framework/DataObjects/inc/MantidDataObjects/LeanElasticPeak.h
+++ b/Framework/DataObjects/inc/MantidDataObjects/LeanElasticPeak.h
@@ -69,11 +69,6 @@ public:
   std::shared_ptr<const Geometry::ReferenceFrame>
   getReferenceFrame() const override;
 
-  /*
-  bool findDetector() override;
-  bool findDetector(const Geometry::InstrumentRayTracer &) override;
-  */
-
   void setSamplePos(double, double, double) override;
   void setSamplePos(const Mantid::Kernel::V3D &) override;
 

--- a/Framework/DataObjects/inc/MantidDataObjects/Peak.h
+++ b/Framework/DataObjects/inc/MantidDataObjects/Peak.h
@@ -88,8 +88,12 @@ public:
   std::shared_ptr<const Geometry::ReferenceFrame>
   getReferenceFrame() const override;
 
+  /*
   bool findDetector() override;
   bool findDetector(const Geometry::InstrumentRayTracer &tracer) override;
+  */
+  bool findDetector();
+  bool findDetector(const Geometry::InstrumentRayTracer &tracer);
 
   void setSamplePos(double samX, double samY, double samZ) override;
   void setSamplePos(const Mantid::Kernel::V3D &XYZ) override;
@@ -162,6 +166,8 @@ private:
   /// Static logger
   static Mantid::Kernel::Logger g_log;
 };
+
+using Peak_uptr = std::unique_ptr<Peak>;
 
 } // namespace DataObjects
 } // namespace Mantid

--- a/Framework/DataObjects/src/LeanElasticPeak.cpp
+++ b/Framework/DataObjects/src/LeanElasticPeak.cpp
@@ -345,10 +345,12 @@ LeanElasticPeak &LeanElasticPeak::operator=(const LeanElasticPeak &other) {
  *
  * @return true if the detector ID was found.
  */
+/*
 bool LeanElasticPeak::findDetector() {
   throw Exception::NotImplementedError(
       "LeanElasticPeak has no detector information");
 }
+*/
 
 /**
  * Performs the same algorithm as findDetector() but uses a pre-existing
@@ -357,10 +359,12 @@ bool LeanElasticPeak::findDetector() {
  * over the same instrument.
  * @return true if the detector ID was found.
  */
+/*
 bool LeanElasticPeak::findDetector(const InstrumentRayTracer &) {
   throw Exception::NotImplementedError(
       "LeanElasticPeak has no detector information");
 }
+*/
 
 /**
  Forwarding function. Exposes the detector position directly.

--- a/Framework/DataObjects/src/LeanElasticPeak.cpp
+++ b/Framework/DataObjects/src/LeanElasticPeak.cpp
@@ -336,36 +336,6 @@ LeanElasticPeak &LeanElasticPeak::operator=(const LeanElasticPeak &other) {
   return *this;
 }
 
-/** After creating a peak using the Q in the lab frame,
- * the detPos is set to the direction of the detector (but the detector is
- *unknown)
- *
- * Using the instrument set in the peak, perform ray tracing
- * to find the exact detector.
- *
- * @return true if the detector ID was found.
- */
-/*
-bool LeanElasticPeak::findDetector() {
-  throw Exception::NotImplementedError(
-      "LeanElasticPeak has no detector information");
-}
-*/
-
-/**
- * Performs the same algorithm as findDetector() but uses a pre-existing
- * InstrumentRayTracer object to be able to take adavtange of its caches.
- * This method should be preferred if findDetector is to be called many times
- * over the same instrument.
- * @return true if the detector ID was found.
- */
-/*
-bool LeanElasticPeak::findDetector(const InstrumentRayTracer &) {
-  throw Exception::NotImplementedError(
-      "LeanElasticPeak has no detector information");
-}
-*/
-
 /**
  Forwarding function. Exposes the detector position directly.
  */

--- a/Framework/DataObjects/src/PeaksWorkspace.cpp
+++ b/Framework/DataObjects/src/PeaksWorkspace.cpp
@@ -391,7 +391,7 @@ PeaksWorkspace::peakInfo(const Kernel::V3D &qFrame, bool labCoords) const {
 
   try {
     IPeak_uptr iPeak = createPeak(Qlab);
-    Peak_uptr peak(static_cast<DataObjects::Peak*>(iPeak.release()));
+    Peak_uptr peak(static_cast<DataObjects::Peak *>(iPeak.release()));
 
     if (sample().hasOrientedLattice()) {
 

--- a/Framework/DataObjects/src/PeaksWorkspace.cpp
+++ b/Framework/DataObjects/src/PeaksWorkspace.cpp
@@ -390,7 +390,9 @@ PeaksWorkspace::peakInfo(const Kernel::V3D &qFrame, bool labCoords) const {
   }
 
   try {
-    auto peak = createPeak(Qlab);
+    IPeak_uptr iPeak = createPeak(Qlab);
+    Peak_uptr peak(static_cast<DataObjects::Peak*>(iPeak.release()));
+
     if (sample().hasOrientedLattice()) {
 
       peak->setGoniometerMatrix(Gon);

--- a/Framework/DataObjects/test/LeanElasticPeakTest.h
+++ b/Framework/DataObjects/test/LeanElasticPeakTest.h
@@ -41,7 +41,9 @@ public:
     TS_ASSERT_EQUALS(p.getDetectorID(), -1)
     TS_ASSERT_THROWS(p.getDetector(), const Exception::NotImplementedError &)
     TS_ASSERT_THROWS(p.getInstrument(), const Exception::NotImplementedError &)
+    /*
     TS_ASSERT_THROWS(p.findDetector(), const Exception::NotImplementedError &)
+    */
     TS_ASSERT_THROWS(p.getDetectorPosition(),
                      const Exception::NotImplementedError &)
     TS_ASSERT_THROWS(p.getDetectorPositionNoCheck(),

--- a/Framework/DataObjects/test/LeanElasticPeakTest.h
+++ b/Framework/DataObjects/test/LeanElasticPeakTest.h
@@ -41,9 +41,6 @@ public:
     TS_ASSERT_EQUALS(p.getDetectorID(), -1)
     TS_ASSERT_THROWS(p.getDetector(), const Exception::NotImplementedError &)
     TS_ASSERT_THROWS(p.getInstrument(), const Exception::NotImplementedError &)
-    /*
-    TS_ASSERT_THROWS(p.findDetector(), const Exception::NotImplementedError &)
-    */
     TS_ASSERT_THROWS(p.getDetectorPosition(),
                      const Exception::NotImplementedError &)
     TS_ASSERT_THROWS(p.getDetectorPositionNoCheck(),

--- a/Framework/DataObjects/test/PeakTest.h
+++ b/Framework/DataObjects/test/PeakTest.h
@@ -39,7 +39,7 @@ operator<<(std::basic_ostream<CharType, CharTrait> &out,
 class PeakTest : public CxxTest::TestSuite {
 private:
   /// Common instrument
-  Instrument_sptr inst;
+  Instrument_sptr inddinst;
   Instrument_sptr m_minimalInstrument;
 
 public:

--- a/Framework/DataObjects/test/PeakTest.h
+++ b/Framework/DataObjects/test/PeakTest.h
@@ -39,7 +39,7 @@ operator<<(std::basic_ostream<CharType, CharTrait> &out,
 class PeakTest : public CxxTest::TestSuite {
 private:
   /// Common instrument
-  Instrument_sptr inddinst;
+  Instrument_sptr inst;
   Instrument_sptr m_minimalInstrument;
 
 public:

--- a/Framework/Geometry/inc/MantidGeometry/Crystal/IPeak.h
+++ b/Framework/Geometry/inc/MantidGeometry/Crystal/IPeak.h
@@ -62,9 +62,10 @@ public:
 
   virtual Mantid::Kernel::V3D getQLabFrame() const = 0;
   virtual Mantid::Kernel::V3D getQSampleFrame() const = 0;
+  /*
   virtual bool findDetector() = 0;
   virtual bool findDetector(const InstrumentRayTracer &tracer) = 0;
-
+  */
   virtual void setQSampleFrame(const Mantid::Kernel::V3D &QSampleFrame,
                                boost::optional<double> detectorDistance) = 0;
   virtual void setQLabFrame(const Mantid::Kernel::V3D &QLabFrame,
@@ -115,6 +116,8 @@ public:
   virtual void setAbsorptionWeightedPathLength(double pathLength) = 0;
   virtual double getAbsorptionWeightedPathLength() const = 0;
 };
+
+using IPeak_uptr = std::unique_ptr<IPeak>;
 
 } // namespace Geometry
 } // namespace Mantid

--- a/Framework/Geometry/inc/MantidGeometry/Crystal/IPeak.h
+++ b/Framework/Geometry/inc/MantidGeometry/Crystal/IPeak.h
@@ -62,10 +62,6 @@ public:
 
   virtual Mantid::Kernel::V3D getQLabFrame() const = 0;
   virtual Mantid::Kernel::V3D getQSampleFrame() const = 0;
-  /*
-  virtual bool findDetector() = 0;
-  virtual bool findDetector(const InstrumentRayTracer &tracer) = 0;
-  */
   virtual void setQSampleFrame(const Mantid::Kernel::V3D &QSampleFrame,
                                boost::optional<double> detectorDistance) = 0;
   virtual void setQLabFrame(const Mantid::Kernel::V3D &QLabFrame,

--- a/Framework/Geometry/test/MockObjects.h
+++ b/Framework/Geometry/test/MockObjects.h
@@ -97,9 +97,11 @@ public:
   MOCK_METHOD1(setSamplePos, void(const Mantid::Kernel::V3D &XYZ));
   MOCK_CONST_METHOD0(getQLabFrame, Mantid::Kernel::V3D());
   MOCK_CONST_METHOD0(getQSampleFrame, Mantid::Kernel::V3D());
+  /*
   MOCK_METHOD0(findDetector, bool());
   MOCK_METHOD1(findDetector,
                bool(const Mantid::Geometry::InstrumentRayTracer &tracer));
+  */
   MOCK_METHOD2(setQSampleFrame, void(const Mantid::Kernel::V3D &QSampleFrame,
                                      boost::optional<double> detectorDistance));
   MOCK_METHOD2(setQLabFrame, void(const Mantid::Kernel::V3D &QLabFrame,

--- a/Framework/Geometry/test/MockObjects.h
+++ b/Framework/Geometry/test/MockObjects.h
@@ -97,11 +97,6 @@ public:
   MOCK_METHOD1(setSamplePos, void(const Mantid::Kernel::V3D &XYZ));
   MOCK_CONST_METHOD0(getQLabFrame, Mantid::Kernel::V3D());
   MOCK_CONST_METHOD0(getQSampleFrame, Mantid::Kernel::V3D());
-  /*
-  MOCK_METHOD0(findDetector, bool());
-  MOCK_METHOD1(findDetector,
-               bool(const Mantid::Geometry::InstrumentRayTracer &tracer));
-  */
   MOCK_METHOD2(setQSampleFrame, void(const Mantid::Kernel::V3D &QSampleFrame,
                                      boost::optional<double> detectorDistance));
   MOCK_METHOD2(setQLabFrame, void(const Mantid::Kernel::V3D &QLabFrame,

--- a/Framework/MDAlgorithms/src/CentroidPeaksMD.cpp
+++ b/Framework/MDAlgorithms/src/CentroidPeaksMD.cpp
@@ -99,8 +99,7 @@ void CentroidPeaksMD::integrate(typename MDEventWorkspace<MDE, nd>::sptr ws) {
   // cppcheck-suppress syntaxError
     PRAGMA_OMP(parallel for schedule(dynamic, 10) )
     for (int i = 0; i < int(peakWS->getNumberPeaks()); ++i) {
-      // Get a direct ref to that peak.
-      IPeak &p = peakWS->getPeak(i);
+      Peak &p = peakWS->getPeak(i);
       double detectorDistance = p.getL2();
 
       // Get the peak center as a position in the dimensions of the workspace

--- a/Framework/MDAlgorithms/src/CentroidPeaksMD2.cpp
+++ b/Framework/MDAlgorithms/src/CentroidPeaksMD2.cpp
@@ -83,7 +83,7 @@ void CentroidPeaksMD2::integrate(typename MDEventWorkspace<MDE, nd>::sptr ws) {
     PRAGMA_OMP(parallel for schedule(dynamic, 10) )
     for (int i = 0; i < int(peakWS->getNumberPeaks()); ++i) {
       // Get a direct ref to that peak.
-      IPeak &p = peakWS->getPeak(i);
+      Peak &p = peakWS->getPeak(i);
       double detectorDistance = p.getL2();
 
       // Get the peak center as a position in the dimensions of the workspace

--- a/Framework/PythonInterface/mantid/api/src/Exports/IPeak.cpp
+++ b/Framework/PythonInterface/mantid/api/src/Exports/IPeak.cpp
@@ -123,13 +123,6 @@ void export_IPeak() {
            ":class:`~mantid.geometry.Goniometer` rotation was NOT taken "
            "out.\n"
            "Note: There is no 2*pi factor used, so \\|Q| = 1/wavelength.")
-      /*
-      .def("findDetector", (bool (IPeak::*)()) & IPeak::findDetector,
-           arg("self"),
-           "Using the :class:`~mantid.geometry.Instrument` set in the peak, "
-           "perform ray tracing to find "
-           "the exact :class:`~mantid.geometry.Detector`.")
-      */
       .def("getQSampleFrame", &IPeak::getQSampleFrame, arg("self"),
            "Return the Q change (of the lattice, k_i - k_f) for this peak."
            "The Q is in the Sample frame: the "

--- a/Framework/PythonInterface/mantid/api/src/Exports/IPeak.cpp
+++ b/Framework/PythonInterface/mantid/api/src/Exports/IPeak.cpp
@@ -123,11 +123,13 @@ void export_IPeak() {
            ":class:`~mantid.geometry.Goniometer` rotation was NOT taken "
            "out.\n"
            "Note: There is no 2*pi factor used, so \\|Q| = 1/wavelength.")
+      /*
       .def("findDetector", (bool (IPeak::*)()) & IPeak::findDetector,
            arg("self"),
            "Using the :class:`~mantid.geometry.Instrument` set in the peak, "
            "perform ray tracing to find "
            "the exact :class:`~mantid.geometry.Detector`.")
+      */
       .def("getQSampleFrame", &IPeak::getQSampleFrame, arg("self"),
            "Return the Q change (of the lattice, k_i - k_f) for this peak."
            "The Q is in the Sample frame: the "


### PR DESCRIPTION
**Description of work.**
- [x] Comment declarations of `findDetector` in `IPeak` and `LeanElasticPeak`
- [x] clean up affected algorithms and unit tests
- [x] remove commented code
- [x] release notes not necessary since this is an internal change

Refs #30857 

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
