### PR TITLE
Resolve confusing variable names in SaveGDA algorithm

### DIFF
--- a/Framework/DataHandling/inc/MantidDataHandling/SaveGDA.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/SaveGDA.h
@@ -31,7 +31,7 @@ public:
 
 private:
   struct CalibrationParams {
-    CalibrationParams(const double _difa, const double _difc,
+    CalibrationParams(const double _difc, const double _difa,
                       const double _tzero);
     const double difa;
     const double difc;

--- a/Framework/DataHandling/src/SaveGDA.cpp
+++ b/Framework/DataHandling/src/SaveGDA.cpp
@@ -89,8 +89,8 @@ getParamLinesFromGSASFile(const std::string &paramsFilename) {
 
 DECLARE_ALGORITHM(SaveGDA)
 
-SaveGDA::CalibrationParams::CalibrationParams(const double _difa,
-                                              const double _difc,
+SaveGDA::CalibrationParams::CalibrationParams(const double _difc,
+                                              const double _difa,
                                               const double _tzero)
     : difa(_difa), difc(_difc), tzero(_tzero) {}
 
@@ -176,8 +176,8 @@ void SaveGDA::exec() {
     tofScaled.reserve(d.size());
     std::transform(d.begin(), d.end(), std::back_inserter(tofScaled),
                    [&bankCalibParams](const double dVal) {
-                     return (dVal * bankCalibParams.difa +
-                             dVal * dVal * bankCalibParams.difc +
+                     return (dVal * bankCalibParams.difc +
+                             dVal * dVal * bankCalibParams.difa +
                              bankCalibParams.tzero) *
                             tofScale;
                    });


### PR DESCRIPTION
**Description of work.**

The difc and difa diffractometer constants were read into variables called difa and difc respectively. This "mistake" was then corrected in the formula where the unit conversion occurs but it was a bit obscure. Wanted to tidy this up before a bigger rework of the dSpacing unit conversions

**To test:**

Just code review, no functional change. Jenkins tests should have covered checks that algorithm still runs as required

Fixes #30876.

*This does not require release notes* because **no functional change - just code tidy up**

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
