### PR TITLE
Modify CreatePeaksWorkspace to make LeanElasticPeaksWorkspace

### DIFF
--- a/Framework/Algorithms/test/CreatePeaksWorkspaceTest.h
+++ b/Framework/Algorithms/test/CreatePeaksWorkspaceTest.h
@@ -8,6 +8,7 @@
 
 #include "MantidAPI/MatrixWorkspace.h"
 #include "MantidAlgorithms/CreatePeaksWorkspace.h"
+#include "MantidDataObjects/LeanElasticPeaksWorkspace.h"
 #include "MantidDataObjects/PeaksWorkspace.h"
 #include "MantidDataObjects/Workspace2D.h"
 #include "MantidKernel/Timer.h"
@@ -50,6 +51,37 @@ public:
     TS_ASSERT_THROWS_NOTHING(
         ws = AnalysisDataService::Instance().retrieveWS<PeaksWorkspace>(
             outWSName));
+    // Check that this is a PeaksWorkspace
+    TS_ASSERT(ws);
+    if (!ws)
+      return;
+
+    // Check the results
+    TS_ASSERT_EQUALS(ws->getNumberPeaks(), 13);
+
+    // Remove workspace from the data service.
+    AnalysisDataService::Instance().remove(outWSName);
+  }
+
+  void test_exec_no_instr() {
+    // Name of the output workspace.
+    std::string outWSName("CreatePeaksWorkspaceTest_OutputWS2");
+
+    CreatePeaksWorkspace alg;
+    TS_ASSERT_THROWS_NOTHING(alg.initialize())
+    TS_ASSERT(alg.isInitialized())
+    TS_ASSERT_THROWS_NOTHING(
+        alg.setPropertyValue("OutputWorkspace", outWSName));
+    TS_ASSERT_THROWS_NOTHING(alg.setProperty("NumberOfPeaks", 13));
+    TS_ASSERT_THROWS_NOTHING(alg.execute();)
+    TS_ASSERT(alg.isExecuted());
+
+    // Retrieve the workspace from data service.
+    LeanElasticPeaksWorkspace_sptr ws;
+    TS_ASSERT_THROWS_NOTHING(
+        ws = AnalysisDataService::Instance()
+                 .retrieveWS<LeanElasticPeaksWorkspace>(outWSName));
+    // Check that this is a LeanElasticPeaksWorkspace
     TS_ASSERT(ws);
     if (!ws)
       return;

--- a/docs/source/algorithms/CreatePeaksWorkspace-v1.rst
+++ b/docs/source/algorithms/CreatePeaksWorkspace-v1.rst
@@ -21,17 +21,17 @@ If the input workspace is a MDWorkspace then the instrument from the
 first experiment info is used.
 
 If the `InstrumentWorkspace` is not provided then a
-:ref:`LeanElasticPeaksWorkspace` is created instead of a
-:ref:`PeaksWorkspace`.
+:ref:`LeanElasticPeaksWorkspace <LeanElasticPeaksWorkspace>` is
+created instead of a :ref:`PeaksWorkspace <PeaksWorkspace>`
 
 Usage
 -----
 
-**Example: An empty table, not tied to an instrument**
+**Example: Create an empty LeanElasticPeaksWorkspace, not tied to an instrument**
 
 .. testcode:: ExEmptyTable
 
-    ws = CreatePeaksWorkspace()
+    ws = CreatePeaksWorkspace(NumberOfPeaks=0)
     print("Created a {} with {} rows".format(ws.id(), ws.rowCount()))
 
 Output:

--- a/docs/source/algorithms/CreatePeaksWorkspace-v1.rst
+++ b/docs/source/algorithms/CreatePeaksWorkspace-v1.rst
@@ -20,6 +20,10 @@ for example.
 If the input workspace is a MDWorkspace then the instrument from the
 first experiment info is used.
 
+If the `InstrumentWorkspace` is not provided then a
+:ref:`LeanElasticPeaksWorkspace` is created instead of a
+:ref:`PeaksWorkspace`.
+
 Usage
 -----
 
@@ -34,7 +38,7 @@ Output:
 
 .. testoutput:: ExEmptyTable
 
-    Created a PeaksWorkspace with 0 rows
+    Created a LeanElasticPeaksWorkspace with 0 rows
 
 **Example: With a few peaks in place**
 

--- a/docs/source/concepts/LeanElasticPeaksWorkspace.rst
+++ b/docs/source/concepts/LeanElasticPeaksWorkspace.rst
@@ -1,0 +1,96 @@
+.. _LeanElasticPeaksWorkspace:
+
+LeanElasticPeaks Workspace
+==========================
+
+The LeanElasticPeaksWorkspace is a special Workspace that holds a list
+of single crystal LeanElasticPeak objects. It is the equivalent to the
+:ref:`PeaksWorkspace <PeaksWorkspace>` for Peak objects.
+
+Creating a LeanElasticPeaksWorkspace
+------------------------------------
+
+* :ref:`CreatePeaksWorkspace <algm-CreatePeaksWorkspace>` will create an empty LeanElasticPeaksWorkspace that you can then edit.
+
+Viewing a LeanElasticPeaksWorkspace
+-----------------------------------
+
+* Double-click a LeanElasticPeaksWorkspace to see the full list of data of each Peak object.
+* The LeanElasticPeaksWorkspace can be overlay onto of data using the Mantid Workbench Sliceviewer
+
+The LeanElasticPeak Object
+--------------------------
+
+Each peak object contains several pieces of information. Not all of them are necessary:
+
+* Q position (in q-sample frame)
+* H K L indices (optional)
+* Goniometer rotation matrix (for finding Q in the lab frame)
+* Wavelength
+* Integrated intensity and error (optional)
+* An integration shape (see below)
+
+The LeanElasticPeak Shape
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+This is the same as the Peak object, see :ref:`PeaksWorkspace #The Peak Shape
+<the-peak-shape>`.
+
+Using LeanElasticPeaksWorkspaces in Python
+------------------------------------------
+
+The LeanElasticPeaksWorkspace and LeanElasticPeak objects are exposed to python.
+
+LeanElasticPeaksWorkspace Python Interface
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+See :class:`IPeaksWorkspace <mantid.api.IPeaksWorkspace>` for
+complete API.
+
+.. code-block:: python
+
+    pws = mtd['name_of_peaks_workspace']
+    pws.getNumberPeaks()
+    p = pws.getPeak(12)
+    pws.removePeak(34)
+
+LeanElasticPeak Python Interface
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+See :class:`IPeak <mantid.api.IPeak>` for complete API.
+
+You can get a handle to an existing peak with:
+
+.. code-block:: python
+
+    p = pws.getPeak(12)
+
+Or you can create a new peak in this way:
+
+.. code-block:: python
+
+    qsample = V3D(1.23, 3.45, 2.22) # Q in the lab frame of the peak
+    p = pws.createPeak(qsample)
+    # The peak can later be added to the workspace
+    pws.addPeak(p)
+
+Once you have a handle on a peak "p" you have several methods to query/modify its values:
+
+.. code-block:: python
+
+    hkl = p.getHKL()
+    p.setHKL(-5, 4, 3)
+
+    q = p.getQSampleFrame()
+    q = p.getQLabFrame()
+
+    p.setIntensity(1000.0)
+    p.setSigmaIntensity(31.6)
+    counts = p.getIntensity()
+
+    wl = p.getWavelength()
+    d = p.getDSpacing()
+    shape = p.getPeakShape()
+
+
+.. categories:: Concepts

--- a/docs/source/concepts/PeaksWorkspace.rst
+++ b/docs/source/concepts/PeaksWorkspace.rst
@@ -35,6 +35,8 @@ Each peak object contains several pieces of information. Not all of them are nec
 * Row/column of detector (only for :ref:`RectangularDetectors <RectangularDetector>` )
 * An integration shape (see below)
 
+.. _the-peak-shape:
+
 The Peak Shape
 ~~~~~~~~~~~~~~~
 

--- a/docs/source/release/v6.1.0/diffraction.rst
+++ b/docs/source/release/v6.1.0/diffraction.rst
@@ -75,4 +75,15 @@ Bugfixes
 ########
 - :ref:`SCDCalibratePanels <algm-SCDCalibratePanels-v2>` no longer returns null calibration outputs.
 
+LeanElasticPeak
+###############
+
+A new Peak concept has been create, a LeanElasticPeak where the
+instrument is not included as part of Peak. The only requirement for
+this peak is a Q-sample vector. There are a number of modifications
+made to facilitate this.
+
+- New LeanElasticPeak and LeanElasticPeakWorkspace has been created :ref:`LeanElasticPeaksWorkspace <LeanElasticPeaksWorkspace>`
+- :ref:`CreatePeaksWorkspace <algm-CreatePeaksWorkspace>` has been modified to optionally create a  :ref:`LeanElasticPeaksWorkspace <LeanElasticPeaksWorkspace>`.
+
 :ref:`Release 6.1.0 <v6.1.0>`


### PR DESCRIPTION
**Description of work.**

If you don't provide an `InstrumentWorkspace` to CreatePeaksWorkspace it will now create a LeanElasticPeaksWorkspace instead of a PeaksWorkspace

This PR also includes a quick pass at the concept page and release notes for all the LeanElasticPeak stuff. There is a separate issue ([SCD241](https://code.ornl.gov/sns-hfir-scse/diffraction/single-crystal/single-crystal-diffraction/-/issues/241)) to finalize this documentation but I am only including it now so that I can reference it in the CreatePeaksWorkspace docs.

**To test:**

```python
ws = LoadEmptyInstrument(InstrumentName='TOPAZ')
peaks = CreatePeaksWorkspace(ws)
print(peaks.id()) # PeaksWorkspace

leanpeaks = CreatePeaksWorkspace()
print(leanpeaks.id()) # LeanElasticPeaksWorkspace
```
#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
