### PR TITLE
Remove instrument getters and setters from IPeak

### DIFF
--- a/Framework/Crystal/inc/MantidCrystal/IntegratePeakTimeSlices.h
+++ b/Framework/Crystal/inc/MantidCrystal/IntegratePeakTimeSlices.h
@@ -285,7 +285,7 @@ private:
                                const Mantid::HistogramData::HistogramX &X,
                                const int specNum, int &Centerchan);
 
-  double CalculatePositionSpan(Geometry::IPeak const &peak, const double dQ);
+  double CalculatePositionSpan(DataObjects::Peak const &peak, const double dQ);
 
   void InitializeColumnNamesInTableWorkspace(
       DataObjects::TableWorkspace_sptr &TabWS);
@@ -348,7 +348,7 @@ private:
   void FindPlane(Kernel::V3D &center, Kernel::V3D &xvec, Kernel::V3D &yvec,
                  double &ROW, double &COL, int &NROWS, int &NCOLS,
                  double &pixWidthx, double &pixHeighty,
-                 Geometry::IPeak const &peak) const;
+                 DataObjects::Peak const &peak) const;
 
   int findTimeChannel(const Mantid::HistogramData::HistogramX &X,
                       const double time);

--- a/Framework/Crystal/inc/MantidCrystal/PeakHKLErrors.h
+++ b/Framework/Crystal/inc/MantidCrystal/PeakHKLErrors.h
@@ -68,7 +68,7 @@ public:
    *parameters) and time adjusted.
    */
   static DataObjects::Peak
-  createNewPeak(const Geometry::IPeak &peak_old,
+  createNewPeak(const DataObjects::Peak &peak_old,
                 const Geometry::Instrument_sptr &instrNew, double T0,
                 double L0);
 

--- a/Framework/Crystal/src/IntegratePeakTimeSlices.cpp
+++ b/Framework/Crystal/src/IntegratePeakTimeSlices.cpp
@@ -224,7 +224,7 @@ void IntegratePeakTimeSlices::exec() {
 
   int indx = getProperty("PeakIndex");
 
-  IPeak &peak = peaksW->getPeak(indx);
+  Peak &peak = peaksW->getPeak(indx);
 
   //------------------------------- Get Panel
   //--------------------------------------
@@ -767,7 +767,7 @@ bool IntegratePeakTimeSlices::updateNeighbors(
  *  Also s=r*theta was used to transfer d ScatAng to distance on a bank.
  */
 double
-IntegratePeakTimeSlices::CalculatePositionSpan(Geometry::IPeak const &peak,
+IntegratePeakTimeSlices::CalculatePositionSpan(Peak const &peak,
                                                const double dQ) {
 
   try {
@@ -853,7 +853,7 @@ void IntegratePeakTimeSlices::FindPlane(V3D &center, V3D &xvec, V3D &yvec,
                                         double &ROW, double &COL, int &NROWS,
                                         int &NCOLS, double &pixWidthx,
                                         double &pixHeighty,
-                                        Geometry::IPeak const &peak) const {
+                                        DataObjects::Peak const &peak) const {
 
   NROWS = NCOLS = -1;
   IDetector_const_sptr det = peak.getDetector();

--- a/Framework/Crystal/src/IntegratePeakTimeSlices.cpp
+++ b/Framework/Crystal/src/IntegratePeakTimeSlices.cpp
@@ -766,9 +766,8 @@ bool IntegratePeakTimeSlices::updateNeighbors(
  * NOTE: differentials of Q =mv*sin(scatAng/2)/2 were used to calculate this
  *  Also s=r*theta was used to transfer d ScatAng to distance on a bank.
  */
-double
-IntegratePeakTimeSlices::CalculatePositionSpan(Peak const &peak,
-                                               const double dQ) {
+double IntegratePeakTimeSlices::CalculatePositionSpan(Peak const &peak,
+                                                      const double dQ) {
 
   try {
     double Q = 0, ScatAngle = 0, dScatAngle = 0, DetSpan = 0;

--- a/Framework/Crystal/src/PeakHKLErrors.cpp
+++ b/Framework/Crystal/src/PeakHKLErrors.cpp
@@ -385,7 +385,7 @@ void PeakHKLErrors::function1D(double *out, const double *xValues,
   double ChiSqTot = 0.0;
   for (size_t i = 0; i < nData; i += 3) {
     int peakNum = boost::math::iround(xValues[i]);
-    IPeak &peak_old = Peaks->getPeak(peakNum);
+    Peak &peak_old = Peaks->getPeak(peakNum);
 
     int runNum = peak_old.getRunNumber();
     std::string runNumStr = std::to_string(runNum);
@@ -484,7 +484,7 @@ void PeakHKLErrors::functionDeriv1D(Jacobian *out, const double *xValues,
 
   for (size_t i = 0; i < nData; i += 3) {
     int peakNum = boost::math::iround(xValues[i]);
-    IPeak &peak_old = Peaks->getPeak(peakNum);
+    Peak &peak_old = Peaks->getPeak(peakNum);
     Peak peak = createNewPeak(peak_old, instNew, 0, peak_old.getL1());
 
     int runNum = peak_old.getRunNumber();
@@ -642,7 +642,7 @@ void PeakHKLErrors::functionDeriv1D(Jacobian *out, const double *xValues,
   }
 }
 
-Peak PeakHKLErrors::createNewPeak(const Geometry::IPeak &peak_old,
+Peak PeakHKLErrors::createNewPeak(const DataObjects::Peak &peak_old,
                                   const Geometry::Instrument_sptr &instrNew,
                                   double T0, double L0) {
   Geometry::Instrument_const_sptr inst = peak_old.getInstrument();

--- a/Framework/DataObjects/inc/MantidDataObjects/LeanElasticPeak.h
+++ b/Framework/DataObjects/inc/MantidDataObjects/LeanElasticPeak.h
@@ -60,9 +60,7 @@ public:
   void setDetectorID(int) override;
   int getDetectorID() const override;
 
-  void setInstrument(const Geometry::Instrument_const_sptr &) override;
   Geometry::IDetector_const_sptr getDetector() const override;
-  Geometry::Instrument_const_sptr getInstrument() const override;
   std::shared_ptr<const Geometry::ReferenceFrame>
   getReferenceFrame() const override;
 

--- a/Framework/DataObjects/inc/MantidDataObjects/Peak.h
+++ b/Framework/DataObjects/inc/MantidDataObjects/Peak.h
@@ -29,7 +29,7 @@ namespace DataObjects {
 
 /** Structure describing a single-crystal peak. The peak is described
  * by the physical detector position (determined either from detector
- * infomation or calculated from Q-lab) and inital/final energy
+ * information or calculated from Q-lab) and initial/final energy
  * (calculated from Q-lab or provided wavelength)
  *
  */
@@ -85,9 +85,9 @@ public:
   void removeContributingDetector(const int id);
   const std::set<int> &getContributingDetIDs() const;
 
-  void setInstrument(const Geometry::Instrument_const_sptr &inst) override;
+  void setInstrument(const Geometry::Instrument_const_sptr &inst);
   Geometry::IDetector_const_sptr getDetector() const override;
-  Geometry::Instrument_const_sptr getInstrument() const override;
+  Geometry::Instrument_const_sptr getInstrument() const;
   std::shared_ptr<const Geometry::ReferenceFrame>
   getReferenceFrame() const override;
 

--- a/Framework/DataObjects/src/LeanElasticPeak.cpp
+++ b/Framework/DataObjects/src/LeanElasticPeak.cpp
@@ -118,27 +118,10 @@ int LeanElasticPeak::getDetectorID() const {
 }
 
 //----------------------------------------------------------------------------------------------
-/** Set the instrument (and save the source/sample pos).
- * Call setDetectorID AFTER this call.
- *
- */
-void LeanElasticPeak::setInstrument(const Geometry::Instrument_const_sptr &) {
-  throw Exception::NotImplementedError(
-      "LeanElasticPeak::setInstrument(): Can't set instrument on "
-      "LeanElasticPeak");
-}
-
-//----------------------------------------------------------------------------------------------
 /** Return a shared ptr to the detector at center of peak. */
 Geometry::IDetector_const_sptr LeanElasticPeak::getDetector() const {
   throw Exception::NotImplementedError(
       "LeanElasticPeak::getDetector(): Has no detector ID");
-}
-
-/** Return a shared ptr to the instrument for this peak. */
-Geometry::Instrument_const_sptr LeanElasticPeak::getInstrument() const {
-  throw Exception::NotImplementedError(
-      "LeanElasticPeak::setInstrument(): Has no instrument");
 }
 
 /** Return a shared ptr to the reference frame for this peak. */

--- a/Framework/DataObjects/src/Peak.cpp
+++ b/Framework/DataObjects/src/Peak.cpp
@@ -170,7 +170,8 @@ Peak::Peak(const Geometry::IPeak &ipeak)
       m_finalEnergy(ipeak.getFinalEnergy()) {
   const auto *peak = dynamic_cast<const Peak *>(&ipeak);
   if (!peak)
-    throw std::invalid_argument("Cannot construct a Peak from this non-Peak object");
+    throw std::invalid_argument(
+        "Cannot construct a Peak from this non-Peak object");
   setInstrument(peak->getInstrument());
   detid_t id = peak->getDetectorID();
   if (id >= 0)

--- a/Framework/DataObjects/src/Peak.cpp
+++ b/Framework/DataObjects/src/Peak.cpp
@@ -169,13 +169,13 @@ Peak::Peak(const Geometry::IPeak &ipeak)
       m_initialEnergy(ipeak.getInitialEnergy()),
       m_finalEnergy(ipeak.getFinalEnergy()) {
   const auto *peak = dynamic_cast<const Peak *>(&ipeak);
-  if (peak)
-    setInstrument(peak->getInstrument());
-  detid_t id = ipeak.getDetectorID();
+  if (!peak)
+    throw std::invalid_argument("Cannot construct a Peak from this non-Peak object");
+  setInstrument(peak->getInstrument());
+  detid_t id = peak->getDetectorID();
   if (id >= 0)
     setDetectorID(id);
-  if (peak)
-    this->m_detIDs = peak->m_detIDs;
+  this->m_detIDs = peak->m_detIDs;
 }
 
 //----------------------------------------------------------------------------------------------

--- a/Framework/DataObjects/src/Peak.cpp
+++ b/Framework/DataObjects/src/Peak.cpp
@@ -168,14 +168,14 @@ Peak::Peak(const Geometry::IPeak &ipeak)
     : BasePeak(ipeak), m_detectorID(ipeak.getDetectorID()),
       m_initialEnergy(ipeak.getInitialEnergy()),
       m_finalEnergy(ipeak.getFinalEnergy()) {
-  setInstrument(ipeak.getInstrument());
+  const auto *peak = dynamic_cast<const Peak *>(&ipeak);
+  if (peak)
+    setInstrument(peak->getInstrument());
   detid_t id = ipeak.getDetectorID();
-  if (id >= 0) {
+  if (id >= 0)
     setDetectorID(id);
-  }
-  if (const auto *peak = dynamic_cast<const Peak *>(&ipeak)) {
+  if (peak)
     this->m_detIDs = peak->m_detIDs;
-  }
 }
 
 //----------------------------------------------------------------------------------------------

--- a/Framework/DataObjects/test/LeanElasticPeakTest.h
+++ b/Framework/DataObjects/test/LeanElasticPeakTest.h
@@ -40,7 +40,6 @@ public:
 
     TS_ASSERT_THROWS(p.getDetectorID(), const Exception::NotImplementedError &)
     TS_ASSERT_THROWS(p.getDetector(), const Exception::NotImplementedError &)
-    TS_ASSERT_THROWS(p.getInstrument(), const Exception::NotImplementedError &)
     TS_ASSERT_THROWS(p.getDetectorPosition(),
                      const Exception::NotImplementedError &)
     TS_ASSERT_THROWS(p.getDetectorPositionNoCheck(),
@@ -334,8 +333,6 @@ public:
     TS_ASSERT_EQUALS(leanpeak.getBinCount(), 90);
 
     TS_ASSERT_THROWS(leanpeak.getDetector(),
-                     const Exception::NotImplementedError &)
-    TS_ASSERT_THROWS(leanpeak.getInstrument(),
                      const Exception::NotImplementedError &)
   }
 };

--- a/Framework/Geometry/inc/MantidGeometry/Crystal/IPeak.h
+++ b/Framework/Geometry/inc/MantidGeometry/Crystal/IPeak.h
@@ -26,13 +26,9 @@ class InstrumentRayTracer;
 class MANTID_GEOMETRY_DLL IPeak {
 public:
   virtual ~IPeak() = default;
-
-  virtual void setInstrument(const Geometry::Instrument_const_sptr &inst) = 0;
-
   virtual int getDetectorID() const = 0;
   virtual void setDetectorID(int m_DetectorID) = 0;
   virtual Geometry::IDetector_const_sptr getDetector() const = 0;
-  virtual Geometry::Instrument_const_sptr getInstrument() const = 0;
   virtual std::shared_ptr<const Geometry::ReferenceFrame>
   getReferenceFrame() const = 0;
 

--- a/Framework/Geometry/test/MockObjects.h
+++ b/Framework/Geometry/test/MockObjects.h
@@ -64,12 +64,9 @@ Mock IPeak
 ------------------------------------------------------------*/
 class MockIPeak : public Mantid::Geometry::IPeak {
 public:
-  MOCK_METHOD1(setInstrument,
-               void(const Geometry::Instrument_const_sptr &inst));
   MOCK_CONST_METHOD0(getDetectorID, int());
   MOCK_METHOD1(setDetectorID, void(int m_DetectorID));
   MOCK_CONST_METHOD0(getDetector, Geometry::IDetector_const_sptr());
-  MOCK_CONST_METHOD0(getInstrument, Geometry::Instrument_const_sptr());
   MOCK_CONST_METHOD0(getReferenceFrame,
                      std::shared_ptr<const Geometry::ReferenceFrame>());
   MOCK_CONST_METHOD0(getRunNumber, int());

--- a/qt/python/mantidqt/widgets/instrumentview/CMakeLists.txt
+++ b/qt/python/mantidqt/widgets/instrumentview/CMakeLists.txt
@@ -12,6 +12,7 @@ if(ENABLE_WORKBENCH)
                      SIP_SRCS _instrumentview.sip
                      PYQT_VERSION 5
                      LINK_LIBS
+                       DataObjects
                        ${common_link_libs}
                        MantidQtWidgetsInstrumentViewQt5
                        MantidQtWidgetsCommonQt5

--- a/qt/scientific_interfaces/Direct/CMakeLists.txt
+++ b/qt/scientific_interfaces/Direct/CMakeLists.txt
@@ -28,6 +28,7 @@ mtd_add_qt_library(TARGET_NAME MantidScientificInterfacesDirect
                    SYSTEM_INCLUDE_DIRS
                      ${Boost_INCLUDE_DIRS}
                    LINK_LIBS
+                     DataObjects
                      ${CORE_MANTIDLIBS}
                      ${POCO_LIBRARIES}
                      ${Boost_LIBRARIES}
@@ -60,6 +61,7 @@ mtd_add_qt_library(TARGET_NAME MantidScientificInterfacesDirect
                    DEFS
                      IN_MANTIDQT_DIRECT
                    LINK_LIBS
+                     DataObjects
                      ${CORE_MANTIDLIBS}
                      PythonInterfaceCore
                      ${POCO_LIBRARIES}

--- a/qt/widgets/instrumentview/CMakeLists.txt
+++ b/qt/widgets/instrumentview/CMakeLists.txt
@@ -169,6 +169,7 @@ mtd_add_qt_library(TARGET_NAME MantidQtWidgetsInstrumentView
                      ${Boost_INCLUDE_DIRS}
                    LINK_LIBS
                      ${CORE_MANTIDLIBS}
+                     DataObjects
                      ${POCO_LIBRARIES}
                      ${Boost_LIBRARIES}
                      ${PYTHON_LIBRARIES}
@@ -211,6 +212,7 @@ mtd_add_qt_library(TARGET_NAME MantidQtWidgetsInstrumentView
                    LINK_LIBS
                      ${CORE_MANTIDLIBS}
                      PythonInterfaceCore
+                     DataObjects
                      ${POCO_LIBRARIES}
                      ${OPENGL_gl_LIBRARY}
                      ${OPENGL_glu_LIBRARY}

--- a/qt/widgets/instrumentview/CMakeLists.txt
+++ b/qt/widgets/instrumentview/CMakeLists.txt
@@ -211,8 +211,8 @@ mtd_add_qt_library(TARGET_NAME MantidQtWidgetsInstrumentView
                      ../../../Framework/DataObjects/inc
                    LINK_LIBS
                      ${CORE_MANTIDLIBS}
-                     PythonInterfaceCore
                      DataObjects
+                     PythonInterfaceCore
                      ${POCO_LIBRARIES}
                      ${OPENGL_gl_LIBRARY}
                      ${OPENGL_glu_LIBRARY}

--- a/qt/widgets/instrumentview/CMakeLists.txt
+++ b/qt/widgets/instrumentview/CMakeLists.txt
@@ -164,6 +164,7 @@ mtd_add_qt_library(TARGET_NAME MantidQtWidgetsInstrumentView
                      IN_MANTIDQT_INSTRUMENTVIEW
                    INCLUDE_DIRS
                      inc
+                     ../../../Framework/DataObjects/inc
                    SYSTEM_INCLUDE_DIRS
                      ${Boost_INCLUDE_DIRS}
                    LINK_LIBS
@@ -206,6 +207,7 @@ mtd_add_qt_library(TARGET_NAME MantidQtWidgetsInstrumentView
                      IN_MANTIDQT_INSTRUMENTVIEW
                    INCLUDE_DIRS
                      inc
+                     ../../../Framework/DataObjects/inc
                    LINK_LIBS
                      ${CORE_MANTIDLIBS}
                      PythonInterfaceCore

--- a/qt/widgets/instrumentview/CMakeLists.txt
+++ b/qt/widgets/instrumentview/CMakeLists.txt
@@ -210,8 +210,8 @@ mtd_add_qt_library(TARGET_NAME MantidQtWidgetsInstrumentView
                      inc
                      ../../../Framework/DataObjects/inc
                    LINK_LIBS
-                     ${CORE_MANTIDLIBS}
                      DataObjects
+                     ${CORE_MANTIDLIBS}
                      PythonInterfaceCore
                      ${POCO_LIBRARIES}
                      ${OPENGL_gl_LIBRARY}

--- a/qt/widgets/instrumentview/inc/MantidQtWidgets/InstrumentView/InstrumentWidgetPickTab.h
+++ b/qt/widgets/instrumentview/inc/MantidQtWidgets/InstrumentView/InstrumentWidgetPickTab.h
@@ -118,9 +118,9 @@ private slots:
   void singleComponentPicked(size_t pickID);
   void alignPeaks(const std::vector<Mantid::Kernel::V3D> &planePeaks,
                   const Mantid::Geometry::IPeak *peak);
-  void comparePeaks(
-      const std::pair<std::vector<Mantid::Geometry::IPeak *>,
-                      std::vector<Mantid::Geometry::IPeak *>> &peaks);
+  void
+  comparePeaks(const std::pair<std::vector<Mantid::Geometry::IPeak *>,
+                               std::vector<Mantid::Geometry::IPeak *>> &peaks);
   void updateSelectionInfoDisplay();
   void shapeCreated();
   void updatePlotMultipleDetectors();

--- a/qt/widgets/instrumentview/inc/MantidQtWidgets/InstrumentView/InstrumentWidgetPickTab.h
+++ b/qt/widgets/instrumentview/inc/MantidQtWidgets/InstrumentView/InstrumentWidgetPickTab.h
@@ -11,8 +11,8 @@
 #include "MantidQtWidgets/InstrumentView/MiniPlot.h"
 
 #include "MantidAPI/MatrixWorkspace_fwd.h"
-#include "MantidGeometry/Crystal/IPeak.h"
 #include "MantidDataObjects/Peak.h"
+#include "MantidGeometry/Crystal/IPeak.h"
 #include "MantidGeometry/ICompAssembly.h"
 #include "MantidGeometry/IDTypes.h"
 
@@ -118,9 +118,9 @@ private slots:
   void singleComponentPicked(size_t pickID);
   void alignPeaks(const std::vector<Mantid::Kernel::V3D> &planePeaks,
                   const Mantid::DataObjects::Peak *peak);
-  void
-  comparePeaks(const std::pair<std::vector<Mantid::DataObjects::Peak *>,
-                               std::vector<Mantid::DataObjects::Peak *>> &peaks);
+  void comparePeaks(
+      const std::pair<std::vector<Mantid::DataObjects::Peak *>,
+                      std::vector<Mantid::DataObjects::Peak *>> &peaks);
   void updateSelectionInfoDisplay();
   void shapeCreated();
   void updatePlotMultipleDetectors();

--- a/qt/widgets/instrumentview/inc/MantidQtWidgets/InstrumentView/InstrumentWidgetPickTab.h
+++ b/qt/widgets/instrumentview/inc/MantidQtWidgets/InstrumentView/InstrumentWidgetPickTab.h
@@ -117,10 +117,10 @@ private slots:
   void singleComponentTouched(size_t pickID);
   void singleComponentPicked(size_t pickID);
   void alignPeaks(const std::vector<Mantid::Kernel::V3D> &planePeaks,
-                  const Mantid::DataObjects::Peak *peak);
+                  const Mantid::Geometry::IPeak *peak);
   void comparePeaks(
-      const std::pair<std::vector<Mantid::DataObjects::Peak *>,
-                      std::vector<Mantid::DataObjects::Peak *>> &peaks);
+      const std::pair<std::vector<Mantid::Geometry::IPeak *>,
+                      std::vector<Mantid::Geometry::IPeak *>> &peaks);
   void updateSelectionInfoDisplay();
   void shapeCreated();
   void updatePlotMultipleDetectors();
@@ -209,16 +209,16 @@ public:
 public slots:
   void displayInfo(size_t pickID);
   void displayComparePeaksInfo(
-      const std::pair<std::vector<Mantid::DataObjects::Peak *>,
-                      std::vector<Mantid::DataObjects::Peak *>> &peaks);
+      const std::pair<std::vector<Mantid::Geometry::IPeak *>,
+                      std::vector<Mantid::Geometry::IPeak *>> &peaks);
   void displayAlignPeaksInfo(const std::vector<Mantid::Kernel::V3D> &planePeaks,
-                             const Mantid::DataObjects::Peak *peak);
+                             const Mantid::Geometry::IPeak *peak);
   void clear();
 
 private:
   QString displayDetectorInfo(size_t index);
   QString displayNonDetectorInfo(Mantid::Geometry::ComponentID compID);
-  QString displayPeakInfo(Mantid::DataObjects::Peak *peak);
+  QString displayPeakInfo(Mantid::Geometry::IPeak *peak);
   QString displayPeakAngles(const std::pair<Mantid::Geometry::IPeak *,
                                             Mantid::Geometry::IPeak *> &peaks);
   QString getPeakOverlayInfo();

--- a/qt/widgets/instrumentview/inc/MantidQtWidgets/InstrumentView/InstrumentWidgetPickTab.h
+++ b/qt/widgets/instrumentview/inc/MantidQtWidgets/InstrumentView/InstrumentWidgetPickTab.h
@@ -12,6 +12,7 @@
 
 #include "MantidAPI/MatrixWorkspace_fwd.h"
 #include "MantidGeometry/Crystal/IPeak.h"
+#include "MantidDataObjects/Peak.h"
 #include "MantidGeometry/ICompAssembly.h"
 #include "MantidGeometry/IDTypes.h"
 
@@ -116,10 +117,10 @@ private slots:
   void singleComponentTouched(size_t pickID);
   void singleComponentPicked(size_t pickID);
   void alignPeaks(const std::vector<Mantid::Kernel::V3D> &planePeaks,
-                  const Mantid::Geometry::IPeak *peak);
+                  const Mantid::DataObjects::Peak *peak);
   void
-  comparePeaks(const std::pair<std::vector<Mantid::Geometry::IPeak *>,
-                               std::vector<Mantid::Geometry::IPeak *>> &peaks);
+  comparePeaks(const std::pair<std::vector<Mantid::DataObjects::Peak *>,
+                               std::vector<Mantid::DataObjects::Peak *>> &peaks);
   void updateSelectionInfoDisplay();
   void shapeCreated();
   void updatePlotMultipleDetectors();
@@ -208,16 +209,16 @@ public:
 public slots:
   void displayInfo(size_t pickID);
   void displayComparePeaksInfo(
-      const std::pair<std::vector<Mantid::Geometry::IPeak *>,
-                      std::vector<Mantid::Geometry::IPeak *>> &peaks);
+      const std::pair<std::vector<Mantid::DataObjects::Peak *>,
+                      std::vector<Mantid::DataObjects::Peak *>> &peaks);
   void displayAlignPeaksInfo(const std::vector<Mantid::Kernel::V3D> &planePeaks,
-                             const Mantid::Geometry::IPeak *peak);
+                             const Mantid::DataObjects::Peak *peak);
   void clear();
 
 private:
   QString displayDetectorInfo(size_t index);
   QString displayNonDetectorInfo(Mantid::Geometry::ComponentID compID);
-  QString displayPeakInfo(Mantid::Geometry::IPeak *peak);
+  QString displayPeakInfo(Mantid::DataObjects::Peak *peak);
   QString displayPeakAngles(const std::pair<Mantid::Geometry::IPeak *,
                                             Mantid::Geometry::IPeak *> &peaks);
   QString getPeakOverlayInfo();

--- a/qt/widgets/instrumentview/src/InstrumentWidgetPickTab.cpp
+++ b/qt/widgets/instrumentview/src/InstrumentWidgetPickTab.cpp
@@ -1007,7 +1007,7 @@ QString ComponentInfoController::displayNonDetectorInfo(
 QString
 ComponentInfoController::displayPeakInfo(Mantid::Geometry::IPeak *ipeak) {
   std::stringstream text;
-  auto peak = static_cast<Mantid::DataObjects::Peak*>(ipeak);
+  auto peak = static_cast<Mantid::DataObjects::Peak *>(ipeak);
   auto instrument = peak->getInstrument();
   auto sample = instrument->getSample()->getPos();
   auto source = instrument->getSource()->getPos();
@@ -1081,7 +1081,7 @@ void ComponentInfoController::displayAlignPeaksInfo(
 
   // find projection of beam direction onto plane
   // this is so we always orientate to a common reference direction
-  auto peak = static_cast<const Mantid::DataObjects::Peak*>(ipeak);
+  auto peak = static_cast<const Mantid::DataObjects::Peak *>(ipeak);
   const auto instrument = peak->getInstrument();
   const auto samplePos = instrument->getSample()->getPos();
   const auto sourcePos = instrument->getSource()->getPos();

--- a/qt/widgets/instrumentview/src/InstrumentWidgetPickTab.cpp
+++ b/qt/widgets/instrumentview/src/InstrumentWidgetPickTab.cpp
@@ -757,14 +757,14 @@ void InstrumentWidgetPickTab::singleComponentPicked(size_t pickID) {
 }
 
 void InstrumentWidgetPickTab::comparePeaks(
-    const std::pair<std::vector<Mantid::Geometry::IPeak *>,
-                    std::vector<Mantid::Geometry::IPeak *>> &peaks) {
+    const std::pair<std::vector<Mantid::DataObjects::Peak *>,
+                    std::vector<Mantid::DataObjects::Peak *>> &peaks) {
   m_infoController->displayComparePeaksInfo(peaks);
 }
 
 void InstrumentWidgetPickTab::alignPeaks(
     const std::vector<Mantid::Kernel::V3D> &planePeaks,
-    const Mantid::Geometry::IPeak *peak) {
+    const Mantid::DataObjects::Peak *peak) {
   m_infoController->displayAlignPeaksInfo(planePeaks, peak);
 }
 
@@ -1004,7 +1004,7 @@ QString ComponentInfoController::displayNonDetectorInfo(
 }
 
 QString
-ComponentInfoController::displayPeakInfo(Mantid::Geometry::IPeak *peak) {
+ComponentInfoController::displayPeakInfo(Mantid::DataObjects::Peak *peak) {
   std::stringstream text;
   auto instrument = peak->getInstrument();
   auto sample = instrument->getSample()->getPos();
@@ -1041,8 +1041,8 @@ QString ComponentInfoController::displayPeakAngles(
 }
 
 void ComponentInfoController::displayComparePeaksInfo(
-    const std::pair<std::vector<Mantid::Geometry::IPeak *>,
-                    std::vector<Mantid::Geometry::IPeak *>> &peaks) {
+    const std::pair<std::vector<Mantid::DataObjects::Peak *>,
+                    std::vector<Mantid::DataObjects::Peak *>> &peaks) {
   std::stringstream text;
 
   text << "Comparison Information\n";
@@ -1067,7 +1067,7 @@ void ComponentInfoController::displayComparePeaksInfo(
 
 void ComponentInfoController::displayAlignPeaksInfo(
     const std::vector<Mantid::Kernel::V3D> &planePeaks,
-    const Mantid::Geometry::IPeak *peak) {
+    const Mantid::DataObjects::Peak *peak) {
 
   using Mantid::Kernel::V3D;
 

--- a/qt/widgets/instrumentview/src/InstrumentWidgetPickTab.cpp
+++ b/qt/widgets/instrumentview/src/InstrumentWidgetPickTab.cpp
@@ -758,14 +758,14 @@ void InstrumentWidgetPickTab::singleComponentPicked(size_t pickID) {
 }
 
 void InstrumentWidgetPickTab::comparePeaks(
-    const std::pair<std::vector<Mantid::DataObjects::Peak *>,
-                    std::vector<Mantid::DataObjects::Peak *>> &peaks) {
+    const std::pair<std::vector<Mantid::Geometry::IPeak *>,
+                    std::vector<Mantid::Geometry::IPeak *>> &peaks) {
   m_infoController->displayComparePeaksInfo(peaks);
 }
 
 void InstrumentWidgetPickTab::alignPeaks(
     const std::vector<Mantid::Kernel::V3D> &planePeaks,
-    const Mantid::DataObjects::Peak *peak) {
+    const Mantid::Geometry::IPeak *peak) {
   m_infoController->displayAlignPeaksInfo(planePeaks, peak);
 }
 
@@ -1005,8 +1005,9 @@ QString ComponentInfoController::displayNonDetectorInfo(
 }
 
 QString
-ComponentInfoController::displayPeakInfo(Mantid::DataObjects::Peak *peak) {
+ComponentInfoController::displayPeakInfo(Mantid::Geometry::IPeak *ipeak) {
   std::stringstream text;
+  auto peak = static_cast<Mantid::DataObjects::Peak*>(ipeak);
   auto instrument = peak->getInstrument();
   auto sample = instrument->getSample()->getPos();
   auto source = instrument->getSource()->getPos();
@@ -1042,8 +1043,8 @@ QString ComponentInfoController::displayPeakAngles(
 }
 
 void ComponentInfoController::displayComparePeaksInfo(
-    const std::pair<std::vector<Mantid::DataObjects::Peak *>,
-                    std::vector<Mantid::DataObjects::Peak *>> &peaks) {
+    const std::pair<std::vector<Mantid::Geometry::IPeak *>,
+                    std::vector<Mantid::Geometry::IPeak *>> &peaks) {
   std::stringstream text;
 
   text << "Comparison Information\n";
@@ -1068,7 +1069,7 @@ void ComponentInfoController::displayComparePeaksInfo(
 
 void ComponentInfoController::displayAlignPeaksInfo(
     const std::vector<Mantid::Kernel::V3D> &planePeaks,
-    const Mantid::DataObjects::Peak *peak) {
+    const Mantid::Geometry::IPeak *ipeak) {
 
   using Mantid::Kernel::V3D;
 
@@ -1080,6 +1081,7 @@ void ComponentInfoController::displayAlignPeaksInfo(
 
   // find projection of beam direction onto plane
   // this is so we always orientate to a common reference direction
+  auto peak = static_cast<const Mantid::DataObjects::Peak*>(ipeak);
   const auto instrument = peak->getInstrument();
   const auto samplePos = instrument->getSample()->getPos();
   const auto sourcePos = instrument->getSource()->getPos();

--- a/qt/widgets/instrumentview/src/InstrumentWidgetPickTab.cpp
+++ b/qt/widgets/instrumentview/src/InstrumentWidgetPickTab.cpp
@@ -23,6 +23,7 @@
 #include "MantidAPI/MatrixWorkspace.h"
 #include "MantidAPI/Sample.h"
 #include "MantidAPI/WorkspaceFactory.h"
+#include "MantidDataObjects/Peak.h"
 #include "MantidGeometry/Crystal/OrientedLattice.h"
 #include "MantidGeometry/Instrument/ComponentInfo.h"
 #include "MantidGeometry/Instrument/DetectorInfo.h"

--- a/qt/widgets/instrumentview/src/InstrumentWidgetPickTab.cpp
+++ b/qt/widgets/instrumentview/src/InstrumentWidgetPickTab.cpp
@@ -1007,7 +1007,7 @@ QString ComponentInfoController::displayNonDetectorInfo(
 QString
 ComponentInfoController::displayPeakInfo(Mantid::Geometry::IPeak *ipeak) {
   std::stringstream text;
-  auto peak = static_cast<Mantid::DataObjects::Peak *>(ipeak);
+  auto peak = dynamic_cast<Mantid::DataObjects::Peak *>(ipeak);
   auto instrument = peak->getInstrument();
   auto sample = instrument->getSample()->getPos();
   auto source = instrument->getSource()->getPos();
@@ -1081,7 +1081,7 @@ void ComponentInfoController::displayAlignPeaksInfo(
 
   // find projection of beam direction onto plane
   // this is so we always orientate to a common reference direction
-  auto peak = static_cast<const Mantid::DataObjects::Peak *>(ipeak);
+  auto peak = dynamic_cast<const Mantid::DataObjects::Peak *>(ipeak);
   const auto instrument = peak->getInstrument();
   const auto samplePos = instrument->getSample()->getPos();
   const auto sourcePos = instrument->getSource()->getPos();


### PR DESCRIPTION
**Description of work.**
- [x] remove `IPeak.getInstrument` and `IPeak.setInstrument`
- [x] remove `LeanElasticPeak.getInstrument` and `LeanElasticPeak.setInstrument`
- [x] fix tests affected by the changes
- [x] fix algorithms and interfaces affected by the changes
- [x] release notes unnecessary (changes not exposed to the user)

Refs #30885

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
