### PR TITLE
Fit Script Generator - Dynamically update global parameters & ties

### DIFF
--- a/qt/widgets/common/inc/MantidQtWidgets/Common/FitScriptGeneratorModel.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/FitScriptGeneratorModel.h
@@ -99,15 +99,15 @@ public:
                                  std::string const &functionIndex,
                                  std::string const &constraint) override;
 
-  [[nodiscard]] inline std::vector<GlobalTie>
-  getGlobalTies() const noexcept override {
+  [[nodiscard]] inline std::vector<GlobalTie> getGlobalTies() const
+      noexcept override {
     return m_globalTies;
   }
 
   void setGlobalParameters(std::vector<std::string> const &parameters) override;
 
-  [[nodiscard]] inline std::vector<GlobalParameter>
-  getGlobalParameters() const noexcept override {
+  [[nodiscard]] inline std::vector<GlobalParameter> getGlobalParameters() const
+      noexcept override {
     return m_globalParameters;
   }
 

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/FitScriptGeneratorModel.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/FitScriptGeneratorModel.h
@@ -99,15 +99,15 @@ public:
                                  std::string const &functionIndex,
                                  std::string const &constraint) override;
 
-  [[nodiscard]] inline std::vector<GlobalTie> getGlobalTies() const
-      noexcept override {
+  [[nodiscard]] inline std::vector<GlobalTie>
+  getGlobalTies() const noexcept override {
     return m_globalTies;
   }
 
   void setGlobalParameters(std::vector<std::string> const &parameters) override;
 
-  [[nodiscard]] inline std::vector<GlobalParameter> getGlobalParameters() const
-      noexcept override {
+  [[nodiscard]] inline std::vector<GlobalParameter>
+  getGlobalParameters() const noexcept override {
     return m_globalParameters;
   }
 
@@ -153,6 +153,7 @@ private:
   getParameterValue(FitDomainIndex domainIndex,
                     std::string const &fullParameter) const;
 
+  [[nodiscard]] bool validParameter(std::string const &fullParameter) const;
   [[nodiscard]] bool validParameter(FitDomainIndex domainIndex,
                                     std::string const &fullParameter) const;
   [[nodiscard]] bool validTie(std::string const &fullTie) const;
@@ -177,6 +178,9 @@ private:
   void checkParameterIsInAllDomains(std::string const &globalParameter) const;
   void checkGlobalParameterhasNoTies(std::string const &globalParameter) const;
   void checkParameterIsNotGlobal(std::string const &fullParameter) const;
+
+  void tryToAdjustParameterInGlobalTieIfInvalidated(GlobalTie &globalTie);
+  void tryToAdjustTieInGlobalTieIfInvalidated(GlobalTie &globalTie);
 
   IFitScriptGeneratorPresenter *m_presenter;
   std::vector<std::unique_ptr<FitDomain>> m_fitDomains;

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/FittingGlobals.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/FittingGlobals.h
@@ -38,6 +38,9 @@ struct EXPORT_OPT_MANTIDQT_COMMON GlobalTie {
 
   GlobalTie(std::string const &parameter, std::string const &tie);
 
+  std::string toCompositeParameter(std ::string const &fullParameter) const;
+  std::string toNonCompositeParameter(std ::string const &fullParameter) const;
+
   std::string m_parameter;
   std::string m_tie;
 };

--- a/qt/widgets/common/src/FitDomain.cpp
+++ b/qt/widgets/common/src/FitDomain.cpp
@@ -283,6 +283,9 @@ void FitDomain::appendParametersTiedTo(
 
 bool FitDomain::isParameterValueWithinConstraints(std::string const &parameter,
                                                   double value) const {
+  if (!hasParameter(parameter))
+    return false;
+
   auto isValid = true;
 
   auto const parameterIndex = m_function->parameterIndex(parameter);

--- a/qt/widgets/common/src/FitScriptGeneratorModel.cpp
+++ b/qt/widgets/common/src/FitScriptGeneratorModel.cpp
@@ -368,6 +368,11 @@ double FitScriptGeneratorModel::getParameterValue(
 }
 
 bool FitScriptGeneratorModel::validParameter(
+    std::string const &fullParameter) const {
+  return validParameter(getDomainIndexOf(fullParameter), fullParameter);
+}
+
+bool FitScriptGeneratorModel::validParameter(
     FitDomainIndex domainIndex, std::string const &fullParameter) const {
   if (domainIndex.value < numberOfDomains()) {
     auto const parameter = getAdjustedFunctionIndex(fullParameter);
@@ -395,8 +400,7 @@ bool FitScriptGeneratorModel::validTie(std::string const &tie) const {
 
 bool FitScriptGeneratorModel::validGlobalTie(std::string const &fullParameter,
                                              std::string const &fullTie) const {
-  if (!fullTie.empty() && !isNumber(fullTie) &&
-      validParameter(getDomainIndexOf(fullTie), fullTie)) {
+  if (!fullTie.empty() && !isNumber(fullTie) && validParameter(fullTie)) {
     auto const domainIndex = getDomainIndexOf(fullParameter);
     auto const tieDomainIndex = getDomainIndexOf(fullTie);
     return isParameterValueWithinConstraints(
@@ -425,18 +429,50 @@ void FitScriptGeneratorModel::clearGlobalTie(std::string const &fullParameter) {
 }
 
 void FitScriptGeneratorModel::checkGlobalTies() {
-  auto const isTieInvalid = [&](GlobalTie const &globalTie) {
-    return !validParameter(getDomainIndexOf(globalTie.m_parameter),
-                           globalTie.m_parameter) ||
+  auto const isTieInvalid = [&](GlobalTie &globalTie) {
+    tryToAdjustParameterInGlobalTieIfInvalidated(globalTie);
+    tryToAdjustTieInGlobalTieIfInvalidated(globalTie);
+
+    return !validParameter(globalTie.m_parameter) ||
            !validGlobalTie(globalTie.m_parameter, globalTie.m_tie);
   };
 
   auto const iter =
       std::remove_if(m_globalTies.begin(), m_globalTies.end(), isTieInvalid);
 
-  if (iter != m_globalTies.cend()) {
+  if (iter != m_globalTies.cend())
     m_globalTies.erase(iter, m_globalTies.cend());
-    m_presenter->setGlobalTies(m_globalTies);
+
+  m_presenter->setGlobalTies(m_globalTies);
+}
+
+void FitScriptGeneratorModel::tryToAdjustParameterInGlobalTieIfInvalidated(
+    GlobalTie &globalTie) {
+  if (!validParameter(globalTie.m_parameter)) {
+    auto const promotedParam =
+        globalTie.toCompositeParameter(globalTie.m_parameter);
+    auto const demotedParam =
+        globalTie.toNonCompositeParameter(globalTie.m_parameter);
+
+    if (validParameter(promotedParam)) {
+      globalTie.m_parameter = promotedParam;
+    } else if (validParameter(demotedParam)) {
+      globalTie.m_parameter = demotedParam;
+    }
+  }
+}
+
+void FitScriptGeneratorModel::tryToAdjustTieInGlobalTieIfInvalidated(
+    GlobalTie &globalTie) {
+  if (!validGlobalTie(globalTie.m_parameter, globalTie.m_tie)) {
+    auto const promotedTie = globalTie.toCompositeParameter(globalTie.m_tie);
+    auto const demotedTie = globalTie.toNonCompositeParameter(globalTie.m_tie);
+
+    if (validGlobalTie(globalTie.m_parameter, promotedTie)) {
+      globalTie.m_tie = promotedTie;
+    } else if (validGlobalTie(globalTie.m_parameter, demotedTie)) {
+      globalTie.m_tie = demotedTie;
+    }
   }
 }
 

--- a/qt/widgets/common/src/FittingGlobals.cpp
+++ b/qt/widgets/common/src/FittingGlobals.cpp
@@ -15,5 +15,28 @@ GlobalParameter::GlobalParameter(std::string const &parameter)
 GlobalTie::GlobalTie(std::string const &parameter, std::string const &tie)
     : m_parameter(parameter), m_tie(tie) {}
 
+std::string
+GlobalTie::toCompositeParameter(std ::string const &fullParameter) const {
+  auto const dotIndex = fullParameter.find(".");
+  if (dotIndex != std::string::npos) {
+    return fullParameter.substr(0, dotIndex + 1) + "f0." +
+           fullParameter.substr(dotIndex + 1);
+  }
+  return fullParameter;
+}
+
+std::string
+GlobalTie::toNonCompositeParameter(std ::string const &fullParameter) const {
+  auto const firstDotIndex = fullParameter.find(".");
+  if (firstDotIndex != std::string::npos) {
+    auto const secondDotIndex = fullParameter.find(".", firstDotIndex + 1);
+    if (secondDotIndex != std::string::npos) {
+      return fullParameter.substr(0, firstDotIndex + 1) +
+             fullParameter.substr(secondDotIndex + 1);
+    }
+  }
+  return fullParameter;
+}
+
 } // namespace MantidWidgets
 } // namespace MantidQt

--- a/qt/widgets/common/src/FunctionTreeView.cpp
+++ b/qt/widgets/common/src/FunctionTreeView.cpp
@@ -56,11 +56,18 @@ using namespace Mantid::API;
 namespace {
 const char *globalOptionName = "Global";
 Mantid::Kernel::Logger g_log("Function Browser");
-QString addPrefix(QString &param) { return QString("f0.") + param; }
 const std::regex PREFIX_REGEX("(^[f][0-9](.*))");
 inline bool variableIsPrefixed(const std::string &name) {
   return std::regex_match(name, PREFIX_REGEX);
 }
+
+QString insertPrefix(const QString &param) {
+  return param.left(param.indexOf(".") + 1) + QString("f0.") +
+         param.right(param.size() - param.indexOf(".") - 1);
+}
+
+QString addPrefix(const QString &param) { return QString("f0.") + param; }
+
 QString removePrefix(QString &param) {
   if (variableIsPrefixed(param.toStdString()))
     return param.split(QString("."))[1];
@@ -1418,7 +1425,9 @@ void FunctionTreeView::addFunctionEnd(int result) {
       if (f0) {
         // Modify the previous globals so they have a function prefix
         std::transform(globalParameters.begin(), globalParameters.end(),
-                       globalParameters.begin(), addPrefix);
+                       globalParameters.begin(),
+                       m_multiDomainFunctionPrefix.isEmpty() ? addPrefix
+                                                             : insertPrefix);
         cf->addFunction(f0);
       }
       cf->addFunction(f);

--- a/qt/widgets/common/test/FitScriptGeneratorModelTest.h
+++ b/qt/widgets/common/test/FitScriptGeneratorModelTest.h
@@ -212,12 +212,24 @@ public:
                      m_flatBackground->asString());
   }
 
-  void test_that_addFunction_will_clear_the_global_ties_that_have_expired() {
+  void
+  test_that_addFunction_will_dynamically_adjust_the_global_ties_that_have_changed_function_index() {
     setup_simultaneous_fit_with_global_tie();
 
-    TS_ASSERT_EQUALS(m_model->getGlobalTies().size(), 1);
+    auto const globalTiesBefore = m_model->getGlobalTies();
+    TS_ASSERT_EQUALS(globalTiesBefore.size(), 1);
+    TS_ASSERT_EQUALS(globalTiesBefore[0].m_parameter, "f0.A0");
+    TS_ASSERT_EQUALS(globalTiesBefore[0].m_tie, "f1.A0");
+
+    // Add a function (thereby creating a composite)
     m_model->addFunction(m_wsName, m_wsIndex, m_expDecay->asString());
-    TS_ASSERT_EQUALS(m_model->getGlobalTies().size(), 0);
+    m_model->addFunction("Name2", m_wsIndex, m_expDecay->asString());
+
+    // The global tie has shifted up one index because it is now a composite.
+    auto const globalTiesAfter = m_model->getGlobalTies();
+    TS_ASSERT_EQUALS(globalTiesAfter.size(), 1);
+    TS_ASSERT_EQUALS(globalTiesAfter[0].m_parameter, "f0.f0.A0");
+    TS_ASSERT_EQUALS(globalTiesAfter[0].m_tie, "f1.f0.A0");
   }
 
   void test_that_addFunction_will_throw_if_provided_a_composite_function() {
@@ -280,7 +292,34 @@ public:
 
     TS_ASSERT_EQUALS(m_model->getGlobalTies().size(), 1);
     m_model->removeFunction(m_wsName, m_wsIndex, m_flatBackground->asString());
+    m_model->removeFunction("Name2", m_wsIndex, m_flatBackground->asString());
     TS_ASSERT_EQUALS(m_model->getGlobalTies().size(), 0);
+  }
+
+  void
+  test_that_removeFunction_will_dynamically_adjust_the_global_ties_that_have_changed_function_index() {
+    setup_simultaneous_fit_with_no_ties();
+
+    // Add a function to create a composite
+    m_model->addFunction(m_wsName, m_wsIndex, m_expDecay->asString());
+    m_model->addFunction("Name2", m_wsIndex, m_expDecay->asString());
+    m_model->updateParameterTie("Name2", m_wsIndex, "f1.f1.Height",
+                                "f0.f1.Height");
+
+    auto const globalTiesBefore = m_model->getGlobalTies();
+    TS_ASSERT_EQUALS(globalTiesBefore.size(), 1);
+    TS_ASSERT_EQUALS(globalTiesBefore[0].m_parameter, "f1.f1.Height");
+    TS_ASSERT_EQUALS(globalTiesBefore[0].m_tie, "f0.f1.Height");
+
+    // Remove the flat background (thereby elimating the need for a composite)
+    m_model->removeFunction(m_wsName, m_wsIndex, m_flatBackground->asString());
+    m_model->removeFunction("Name2", m_wsIndex, m_flatBackground->asString());
+
+    // The global tie has shifted down one index because the composite is gone.
+    auto const globalTiesAfter = m_model->getGlobalTies();
+    TS_ASSERT_EQUALS(globalTiesAfter.size(), 1);
+    TS_ASSERT_EQUALS(globalTiesAfter[0].m_parameter, "f1.Height");
+    TS_ASSERT_EQUALS(globalTiesAfter[0].m_tie, "f0.Height");
   }
 
   void


### PR DESCRIPTION
**Description of work.**
This PR improves upon how the global parameters and global ties are updated in the FitScriptGenerator (FSG) when a function becomes a composite, or is 'demoted' to a non composite function.

Previously, any invalidated global ties or global parameters would be cleared when adding a function to the function tree that changed the function to a composite because the function index of all the parameters change.

Now, the FSG will check to see if the global tie or global parameter still exists with a slightly different function index. If it does, it will update the function index in the model, otherwise it will just remove it as previously done.

**To test:**
1. Comment out this line
https://github.com/mantidproject/mantid/blob/44daa7417226a56f8d1896ea6b2f2b1bc576a5d1/scripts/Muon/GUI/Common/fitting_tab_widget/fitting_tab_view.py#L52
2. Go to Muon Analysis interface
3. click `Load Current Run`
4. Go to Fitting tab and click `Fit Generator`
5. Click `Add Workspaces`. Select the first workspace and click add.
6. Select Simultaneous mode
6. Add a `Exp Decay` to the Function browser
7. Create a global tie by:
- Selecting the first table row.
- Right click `Height` -> `Add Tie` and input `f1.Height`
- The global tie should say `f1.Height` in the browser
8. Add another function to the function browser like `Flat Background`
9. The global tie should now say `f1.f0.Height`
10. Remove the Flat Background
11. The global tie should now say `f1.Height`

Fixes #30685

*No Release notes required as the FSG is not visible to users at the moment*

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
