### PR TITLE
30738 tube counts instrument view

### DIFF
--- a/docs/source/release/v6.1.0/mantidworkbench.rst
+++ b/docs/source/release/v6.1.0/mantidworkbench.rst
@@ -17,7 +17,8 @@ New and Improved
 
 - A new empty facility with empty instrument is the default facility now, and
   user has to select their choice of facility (including ISIS) and instrument for the first time
-
+- Instrument view: when in tube selection mode, the sum of pixel counts is now output to the selection pane.
+  
 Bugfixes
 --------
 

--- a/qt/widgets/instrumentview/inc/MantidQtWidgets/InstrumentView/InstrumentWidgetPickTab.h
+++ b/qt/widgets/instrumentview/inc/MantidQtWidgets/InstrumentView/InstrumentWidgetPickTab.h
@@ -90,6 +90,7 @@ public:
   void loadSettings(const QSettings &settings) override;
   bool addToDisplayContextMenu(QMenu & /*unused*/) const override;
   void selectTool(const ToolType tool);
+  SelectionType getSelectionType() const { return m_selectionType; }
   std::shared_ptr<ProjectionSurface> getSurface() const;
   const InstrumentWidget *getInstrumentWidget() const;
   void clearWidgets();

--- a/qt/widgets/instrumentview/src/InstrumentWidgetPickTab.cpp
+++ b/qt/widgets/instrumentview/src/InstrumentWidgetPickTab.cpp
@@ -973,7 +973,26 @@ QString ComponentInfoController::displayDetectorInfo(size_t index) {
     const QString counts = integrated == InstrumentActor::INVALID_VALUE
                                ? "N/A"
                                : QString::number(integrated);
-    text += "Counts: " + counts + '\n';
+    text += "Pixel counts: " + counts + '\n';
+
+    // Display tube counts if the tube selection tool is active.
+    if (m_tab->getSelectionType() == InstrumentWidgetPickTab::Tube) {
+      int64_t tubeCounts = 0;
+
+      auto tube = componentInfo.parent(index);
+      auto tubeDetectors = componentInfo.detectorsInSubtree(tube);
+
+      for (auto detector : tubeDetectors) {
+        if (componentInfo.isDetector(detector)) {
+          const double pixelCounts = actor.getIntegratedCounts(detector);
+          if (pixelCounts != InstrumentActor::INVALID_VALUE) {
+            tubeCounts += pixelCounts;
+          }
+        }
+      }
+      text += "Tube counts: " + QString::number(tubeCounts) + '\n';
+    }
+
     // display info about peak overlays
     text += actor.getParameterInfo(index);
   }

--- a/qt/widgets/instrumentview/src/InstrumentWidgetPickTab.cpp
+++ b/qt/widgets/instrumentview/src/InstrumentWidgetPickTab.cpp
@@ -986,7 +986,7 @@ QString ComponentInfoController::displayDetectorInfo(size_t index) {
         if (componentInfo.isDetector(detector)) {
           const double pixelCounts = actor.getIntegratedCounts(detector);
           if (pixelCounts != InstrumentActor::INVALID_VALUE) {
-            tubeCounts += pixelCounts;
+            tubeCounts += static_cast<int64_t>(pixelCounts);
           }
         }
       }


### PR DESCRIPTION
**Description of work.**

Added additional information to the selection pane in the pick tab of the instrument view. When using the tube selection tool, "Tube counts" are now shown. This is a sum of all of the pixel counts within the parent of the pixel that is currently hovered over.

**To test:**

- Load a workspace and open the instrument view.
- Go to the pick tab.
- Using the pixel selection tool, hover over a pixel. The pixel count will be shown in the selection pane.
- Using the tube selection tool, hover over a pixel. The tube count is also shown.

Fixes #30738 


---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
