### PR TITLE
Fixed Bug In Ma/FDA When Using Group Asymmetry Range Source Checkbox

### DIFF
--- a/docs/source/release/v6.1.0/muon.rst
+++ b/docs/source/release/v6.1.0/muon.rst
@@ -24,6 +24,8 @@ Bug fixes
 - Fixed a bug where removing a pair in use would cause a crash.
 - Fixed a bug where an error message would appear in workbench after loading a run in both MA and FDA.
 - Fixed a bug where rows in the difference table were not being highlighted correctly. 
+- Fixed a bug in the Grouping tab where an error message would appear when changing the source of 
+  Group Asymmetry Range with no data loaded.
 
 ALC
 ---

--- a/scripts/Muon/GUI/Common/grouping_tab_widget/grouping_tab_widget_model.py
+++ b/scripts/Muon/GUI/Common/grouping_tab_widget/grouping_tab_widget_model.py
@@ -258,7 +258,7 @@ class GroupingTabModel(object):
                 self._data.get_loaded_data_for_run(self._data.current_runs[-1])['OutputWorkspace'][0].workspace.dataX(
                     0)), 3)
         else:
-            return 0.0
+            return 1.0
 
     def get_first_good_data_from_file(self):
         if self._data.current_runs:

--- a/scripts/Muon/GUI/Common/grouping_table_widget/grouping_table_widget_view.py
+++ b/scripts/Muon/GUI/Common/grouping_table_widget/grouping_table_widget_view.py
@@ -54,7 +54,7 @@ class GroupingTableView(QtWidgets.QWidget):
 
         self.group_range_label = QtWidgets.QLabel()
         self.group_range_label.setText('Group Asymmetry Range from:')
-        self.group_range_min = QtWidgets.QLineEdit()
+        self.group_range_min = QtWidgets.QLineEdit("0.0")
         self.group_range_min.setEnabled(False)
         positive_float_validator = QtGui.QDoubleValidator(0.0, sys.float_info.max, 5)
         self.group_range_min.setValidator(positive_float_validator)
@@ -63,7 +63,7 @@ class GroupingTableView(QtWidgets.QWidget):
         self.group_range_use_first_good_data.setText(u"\u03BCs (From data file)")
 
         self.group_range_use_first_good_data.setChecked(True)
-        self.group_range_max = QtWidgets.QLineEdit()
+        self.group_range_max = QtWidgets.QLineEdit("1.0")
         self.group_range_max.setEnabled(False)
         self.group_range_max.setValidator(positive_float_validator)
 


### PR DESCRIPTION
**Description of work.**
Fixed a bug where mantid would crash when changing the source of group asymmetry range with no data loaded

**To test:**
Open Muon Analysis
Go to the grouping tab
Check and uncheck from file for both min and max range values of group asymmetry
There should be no crashes and the tab should not disable itself to be unusable anymore

Fixes #30922 

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
