### PR TITLE
Convert python values to int to quiet warnings

### DIFF
--- a/buildconfig/CMake/LinuxPackageScripts.cmake
+++ b/buildconfig/CMake/LinuxPackageScripts.cmake
@@ -200,7 +200,7 @@ fi" )
 set ( ERROR_CMD "-m mantidqt.dialogs.errorreports.main --exitcode=\$?" )
 
 ##### Local dev version
-set ( PYTHON_ARGS "-Wdefault::DeprecationWarning" )
+set ( PYTHON_ARGS "-Wdefault::DeprecationWarning -Werror:::mantid -Werror:::mantidqt" )
 
 set ( LOCAL_PYPATH "\${INSTALLDIR}/bin" )
 

--- a/qt/applications/workbench/workbench/plotting/figuremanager.py
+++ b/qt/applications/workbench/workbench/plotting/figuremanager.py
@@ -504,7 +504,7 @@ def new_figure_manager(num, *args, **kwargs):
 def new_figure_manager_given_figure(num, figure):
     """Create a new manager from a num & figure """
 
-    def _new_figure_manager_given_figure_impl(num, figure):
+    def _new_figure_manager_given_figure_impl(num: int, figure):
         """Create a new figure manager instance for the given figure.
         Forces all public and non-dunder method calls onto the QApplication thread.
         """
@@ -512,4 +512,4 @@ def new_figure_manager_given_figure(num, figure):
         return force_method_calls_to_qapp_thread(FigureManagerWorkbench(canvas, num))
 
     # figure manager & canvas must be created on the QApplication thread
-    return QAppThreadCall(_new_figure_manager_given_figure_impl)(num, figure)
+    return QAppThreadCall(_new_figure_manager_given_figure_impl)(int(num), figure)

--- a/qt/applications/workbench/workbench/plotting/toolbar.py
+++ b/qt/applications/workbench/workbench/plotting/toolbar.py
@@ -105,7 +105,7 @@ class WorkbenchNavigationToolbar(NavigationToolbar2QT):
 
         # Adjust icon size or they are too small in PyQt5 by default
         dpi_ratio = QtWidgets.QApplication.instance().desktop().physicalDpiX() / 100
-        self.setIconSize(QtCore.QSize(24 * dpi_ratio, 24 * dpi_ratio))
+        self.setIconSize(QtCore.QSize(int(24 * dpi_ratio), int(24 * dpi_ratio)))
 
     def copy_to_clipboard(self):
         self.sig_copy_to_clipboard_triggered.emit()

--- a/qt/applications/workbench/workbench/widgets/plotselector/view.py
+++ b/qt/applications/workbench/workbench/widgets/plotselector/view.py
@@ -280,6 +280,7 @@ class PlotSelectorView(QWidget):
             widget = self.table_widget.cellWidget(row, Column.Name)
             if widget.plot_number == plot_number:
                 return row, widget
+        raise RuntimeError(f'Unable to find row and widget from plot_number {plot_number}')
 
     def remove_from_plot_list(self, plot_number):
         """
@@ -630,14 +631,14 @@ class PlotNameWidget(QWidget):
         self.hide_button = QPushButton(shown_icon, "")
         self.hide_button.setToolTip('Hide')
         self.hide_button.setFlat(True)
-        self.hide_button.setMaximumWidth(self.hide_button.iconSize().width() * 5 / 3)
+        self.hide_button.setMaximumWidth(int(self.hide_button.iconSize().width() * 5 / 3))
         self.hide_button.clicked.connect(self.toggle_visibility)
 
         rename_icon = get_icon('mdi.square-edit-outline')
         self.rename_button = QPushButton(rename_icon, "")
         self.rename_button.setToolTip('Rename')
         self.rename_button.setFlat(True)
-        self.rename_button.setMaximumWidth(self.rename_button.iconSize().width() * 5 / 3)
+        self.rename_button.setMaximumWidth(int(self.rename_button.iconSize().width() * 5 / 3))
         self.rename_button.setCheckable(True)
         self.rename_button.toggled.connect(self.rename_button_toggled)
 
@@ -645,7 +646,7 @@ class PlotNameWidget(QWidget):
         self.close_button = QPushButton(close_icon, "")
         self.close_button.setToolTip('Delete')
         self.close_button.setFlat(True)
-        self.close_button.setMaximumWidth(self.close_button.iconSize().width() * 5 / 3)
+        self.close_button.setMaximumWidth(int(self.close_button.iconSize().width() * 5 / 3))
         self.close_button.clicked.connect(lambda: self.close_pressed(self.plot_number))
 
         self.layout = QHBoxLayout()

--- a/qt/python/mantidqt/widgets/codeeditor/scriptcompatibility.py
+++ b/qt/python/mantidqt/widgets/codeeditor/scriptcompatibility.py
@@ -73,7 +73,11 @@ def mantid_api_import_needed(content):
 
 
 def mantid_api_imported(content):
+    # check for wild import
     if 'from mantid.simpleapi import *' in content:
+        return True
+    # check for importing specific objects
+    if 'from mantid.simpleapi import' in content:
         return True
     return False
 

--- a/qt/python/mantidqt/widgets/codeeditor/scriptcompatibility.py
+++ b/qt/python/mantidqt/widgets/codeeditor/scriptcompatibility.py
@@ -73,9 +73,6 @@ def mantid_api_import_needed(content):
 
 
 def mantid_api_imported(content):
-    # check for wild import
-    if 'from mantid.simpleapi import *' in content:
-        return True
     # check for importing specific objects
     if 'from mantid.simpleapi import' in content:
         return True


### PR DESCRIPTION
The main purpose of this is to quiet deprecation warnings in python 3.8 when interacting with matplotlib. The functionality is unchanged.

*There is no associated issue.*

*This does not require release notes* because it only affects developers and newer versions of dependencies than we currently support.

The version into `ornl-next` is #30950.

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
