### PR TITLE
Filter out empty cache directory items

### DIFF
--- a/Framework/PythonInterface/plugins/algorithms/SNSPowderReduction.py
+++ b/Framework/PythonInterface/plugins/algorithms/SNSPowderReduction.py
@@ -322,7 +322,8 @@ class SNSPowderReduction(DistributedDataProcessorAlgorithm):
         self._offsetFactor = self.getProperty("OffsetData").value
         self._outDir = self.getProperty("OutputDirectory").value
         # Caching options
-        self._cache_dirs = [os.path.abspath(me.strip()) for me in self.getProperty("CacheDir").value.split(',')]
+        self._cache_dirs = [os.path.abspath(me.strip()) for me in self.getProperty("CacheDir").value.split(',')
+                            if me.strip()]  # filter out empty elements
         self._cache_dir = self._cache_dirs[0] if self._cache_dirs else ""
         self._clean_cache = self.getProperty("CleanCache").value
 


### PR DESCRIPTION
There was an error where caching was going to a directory named `' '` on the build servers. This filters out empty directory names to remove that issue.

*There is no associated issue.*

*This does not require release notes* because it is fixing a bug in a change that was introduced during the development cycle.

The version into `ornl-next` is #30942.

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
