### PR TITLE
Fix compiler warning on gcc 7.5

### DIFF
--- a/Framework/MDAlgorithms/src/CentroidPeaksMD2.cpp
+++ b/Framework/MDAlgorithms/src/CentroidPeaksMD2.cpp
@@ -15,8 +15,6 @@
 #include "MantidKernel/System.h"
 #include "MantidMDAlgorithms/IntegratePeaksMD.h"
 
-using Mantid::DataObjects::PeaksWorkspace;
-
 namespace Mantid {
 namespace MDAlgorithms {
 
@@ -85,7 +83,7 @@ void CentroidPeaksMD2::integrate(typename MDEventWorkspace<MDE, nd>::sptr ws) {
       // Get a direct ref to that peak.
       IPeak &p = peakWS->getPeak(i);
       Peak *peak = dynamic_cast<Peak *>(&p);
-      double detectorDistance;
+      double detectorDistance = 0.;
       if (peak)
         detectorDistance = p.getL2();
 


### PR DESCRIPTION
warning: ‘detectorDistance’ may be used uninitialized in this function

This was introduced by #30921

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

**To test:**

<!-- Instructions for testing. -->

Fixes #xxxx. <!-- and fix #xxxx or close #xxxx xor resolves #xxxx -->
<!-- alternative
*There is no associated issue.*
-->

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or master)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
