### PR TITLE
Add algorithm name when throwing exceptions from invalid properties in python

### DIFF
--- a/Framework/DataHandling/src/SaveNexusProcessed.cpp
+++ b/Framework/DataHandling/src/SaveNexusProcessed.cpp
@@ -588,7 +588,7 @@ bool SaveNexusProcessed::processGroups() {
     for (size_t entry = 0; entry < workspaces.size(); entry++) {
       const Workspace_sptr ws = workspaces[entry];
       if (ws->isGroup()) {
-        throw std::runtime_error("SaveNexusProcessed: NeXus files do not "
+        throw std::runtime_error("NeXus files do not "
                                  "support nested groups of groups");
       }
       this->doExec(ws, nexusFile, entry > 0 /*keepFile*/, entry);

--- a/Framework/PythonInterface/mantid/simpleapi.py
+++ b/Framework/PythonInterface/mantid/simpleapi.py
@@ -138,12 +138,13 @@ def Load(*args, **kwargs):
     try:
         algm.setProperty('Filename', filename)  # Must be set first
     except ValueError as ve:
-        raise ValueError('Problem when setting Filename. This is the detailed error '
-                         'description: ' + str(ve) + '\nIf the file has been found '
-                                                     'but you got this error, you might not have read permissions '
-                                                     'or the file might be corrupted.\nIf the file has not been found, '
-                                                     'you might have forgotten to add its location in the data search '
-                                                     'directories.')
+        msg = 'Problem setting "Filename" in {}-v{}: {}'.format(name, algm.name(), algm.version(),
+                                                                str(ve))
+        raise ValueError(msg + '\nIf the file has been found '
+                               'but you got this error, you might not have read permissions '
+                               'or the file might be corrupted.\nIf the file has not been found, '
+                               'you might have forgotten to add its location in the data search '
+                               'directories.')
     # Remove from keywords so it is not set twice
     if 'Filename' in kwargs:
         del kwargs['Filename']
@@ -210,8 +211,8 @@ def StartLiveData(*args, **kwargs):
             algm.setProperty(name, value)
 
         except ValueError as ve:
-            raise ValueError('Problem when setting %s. This is the detailed error '
-                             'description: %s' % (name, str(ve)))
+            raise ValueError('Problem setting "{}" in {}-v{}: {}'.format(name, algm.name(),
+                                                                         algm.version(), str(ve)))
         except KeyError:
             pass  # ignore if kwargs[name] doesn't exist
 
@@ -929,10 +930,15 @@ def set_properties(alg_object, *args, **kwargs):
     def do_set_property(name, new_value):
         if new_value is None:
             return
-        if isinstance(new_value, _kernel.DataItem) and new_value.name():
-            alg_object.setPropertyValue(key, new_value.name())
-        else:
-            alg_object.setProperty(key, new_value)
+        try:
+            if isinstance(new_value, _kernel.DataItem) and new_value.name():
+                alg_object.setPropertyValue(key, new_value.name())
+            else:
+                alg_object.setProperty(key, new_value)
+        except RuntimeError as e:
+            msg = 'Problem setting "{}" in {}-v{}: {}'.format(name, alg_object.name(), alg_object.version(),
+                                                              str(e))
+            raise e.__class__(msg) from e
 
     # end
     if len(args) > 0:
@@ -1039,7 +1045,8 @@ def _create_algorithm_function(name, version, algm_object):
                         # Check for missing mandatory parameters
                         _check_mandatory_args(name, algm, e, *args, **kwargs)
                     else:
-                        raise
+                        msg = '{}-v{}: {}'.format(algm.name(), algm.version(), str(e))
+                        raise RuntimeError(msg) from e
 
                 return _gather_returns(name, lhs, algm)
         # Set the signature of the callable to be one that is only generated on request.
@@ -1131,7 +1138,7 @@ def _create_fake_function(name):
 
     # ------------------------------------------------------------------------------------------------
     def fake_function(*args, **kwargs):
-        raise RuntimeError("Mantid import error. The mock simple API functions have not been replaced!" +
+        raise RuntimeError("Mantid import error. The mock simple API functions have not been replaced!"
                            " This is an error in the core setup logic of the mantid module, "
                            "please contact the development team.")
 
@@ -1164,7 +1171,7 @@ def _mockup(plugins):
 
         # ------------------------------------------------------------------------------------------------
         def fake_function(*args, **kwargs):
-            raise RuntimeError("Mantid import error. The mock simple API functions have not been replaced!" +
+            raise RuntimeError("Mantid import error. The mock simple API functions have not been replaced!"
                                " This is an error in the core setup logic of the mantid module, "
                                "please contact the development team.")
 

--- a/Framework/PythonInterface/mantid/simpleapi.py
+++ b/Framework/PythonInterface/mantid/simpleapi.py
@@ -935,7 +935,7 @@ def set_properties(alg_object, *args, **kwargs):
                 alg_object.setPropertyValue(key, new_value.name())
             else:
                 alg_object.setProperty(key, new_value)
-        except RuntimeError as e:
+        except (RuntimeError, TypeError, ValueError) as e:
             msg = 'Problem setting "{}" in {}-v{}: {}'.format(name, alg_object.name(), alg_object.version(),
                                                               str(e))
             raise e.__class__(msg) from e

--- a/Framework/PythonInterface/test/python/plugins/algorithms/EnggFitPeaksTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/EnggFitPeaksTest.py
@@ -262,7 +262,7 @@ class EnggFitPeaksTest(unittest.TestCase):
         except RuntimeError as e:
             error_msg = e.args[0].split("\n")[0]
 
-        self.assertEqual(error_msg, "Expected peak centres lie outside the limits of the workspace x axis")
+        self.assertEqual(error_msg, "EnggFitPeaks-v1: Expected peak centres lie outside the limits of the workspace x axis")
 
     def test_expected_peaks_can_be_in_tof(self):
         """

--- a/Framework/PythonInterface/test/python/plugins/algorithms/GetEiT0atSNSTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/GetEiT0atSNSTest.py
@@ -30,8 +30,8 @@ class GetEiT0atSNSTest(unittest.TestCase):
         try:
             res=GetEiT0atSNS(w,0.1)
         except Exception as e:
-            s="Could not get Ei, and this is not a white beam run\nNo peak found for the monitor with spectra num: 2"
-            self.assertEqual(str(e).find(s),0)
+            s="GetEiT0atSNS-v1: Could not get Ei, and this is not a white beam run\nNo peak found for the monitor with spectra num: 2"
+            self.assertTrue(str(e).startswith(s))
         DeleteWorkspace(w)
 
 

--- a/Testing/SystemTests/tests/framework/LiquidsReflectometryReductionWithBackgroundTest.py
+++ b/Testing/SystemTests/tests/framework/LiquidsReflectometryReductionWithBackgroundTest.py
@@ -203,8 +203,12 @@ class TOFMismatchTest(systemtesting.MantidSystemTest):
                                           CropFirstAndLastPoints=False,
                                           OutputWorkspace='reflectivity_119816')
         except RuntimeError as err:
-            if str(err).startswith("Requested TOF range does not match data"):
+            msg_exp = "LiquidsReflectometryReduction-v1: Requested TOF range does not match data"
+            if str(err).startswith(msg_exp):
                 self.correct_exception_caught = True
+            else:
+                print("EXPECTED ERROR:", msg_exp)
+                print("OBSERVED ERROR:", str(err))
 
     def validate(self):
         return self.correct_exception_caught
@@ -244,8 +248,12 @@ class BadDataTOFRangeTest(systemtesting.MantidSystemTest):
                                           CropFirstAndLastPoints=False,
                                           OutputWorkspace='reflectivity_119816')
         except RuntimeError as err:
-            if str(err).startswith("Requested TOF range does not match data"):
+            msg_exp = "LiquidsReflectometryReduction-v1: Requested TOF range does not match data"
+            if str(err).startswith(msg_exp):
                 self.correct_exception_caught = True
+            else:
+                print("EXPECTED ERROR:", msg_exp)
+                print("OBSERVED ERROR:", str(err))
 
     def validate(self):
         return self.correct_exception_caught
@@ -284,8 +292,12 @@ class BadPeakSelectionTest(systemtesting.MantidSystemTest):
                                           CropFirstAndLastPoints=False,
                                           OutputWorkspace='reflectivity_119816')
         except RuntimeError as err:
-            if str(err).startswith("The reflectivity is all zeros"):
+            msg_exp = "LiquidsReflectometryReduction-v1: The reflectivity is all zeros"
+            if str(err).startswith(msg_exp):
                 self.correct_exception_caught = True
+            else:
+                print("EXPECTED ERROR:", msg_exp)
+                print("OBSERVED ERROR:", str(err))
 
     def validate(self):
         return self.correct_exception_caught

--- a/qt/python/mantidqt/project/test/test_workspacesaver.py
+++ b/qt/python/mantidqt/project/test/test_workspacesaver.py
@@ -88,7 +88,7 @@ class WorkspaceSaverTest(unittest.TestCase):
         ws_saver.save_workspaces(["group2"])
 
         self.assertListEqual(["group1", "group2", "ws1", "ws2", "ws3", "ws4"], ADS.getObjectNames())
-        logger.warning.assert_called_with(u'Couldn\'t save workspace in project: "group2" because SaveNexusProcessed: '
+        logger.warning.assert_called_with(u'Couldn\'t save workspace in project: "group2" because SaveNexusProcessed-v1: '
                                           u'NeXus files do not support nested groups of groups')
 
     def _load_MDWorkspace_and_test_it(self, save_name):


### PR DESCRIPTION
`simpleapi` did not give the name of the algorithm that had invalid properties set. This adds that information for many calls to make debugging easier.

*There is no associated issue.*

*This does not require release notes* because it clarifies error messages seen by users.

The version into `ornl-next` is #30951.

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
