### PR TITLE
Change DrILL data directory on Linux

### DIFF
--- a/scripts/Interface/ui/drill/model/DrillModel.py
+++ b/scripts/Interface/ui/drill/model/DrillModel.py
@@ -28,7 +28,7 @@ class DrillModel(QObject):
     """
     Data directory on Linux.
     """
-    LINUX_BASE_DATA_PATH = "/net/serdon/illdata/"
+    LINUX_BASE_DATA_PATH = "/net4/serdon/illdata/"
 
     """
     Data directory on MacOS.


### PR DESCRIPTION
**Description of work.**

This PR changes the default ILL data directory on Linux from `/net/...` to `/net4/...` in DrILL.

**To test:**

Code review.

Part of #30872 

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
