### PR TITLE
Remove trailling and leading spaces in DrILL CustomOptions

### DIFF
--- a/scripts/Interface/ui/drill/presenter/DrillPresenter.py
+++ b/scripts/Interface/ui/drill/presenter/DrillPresenter.py
@@ -114,8 +114,8 @@ class DrillPresenter:
                                       "separated key=value pairs.")
                     return
                 try:
-                    name = option.split("=")[0]
-                    value = option.split("=")[1]
+                    name = option.split("=")[0].strip()
+                    value = option.split("=")[1].strip()
                 except:
                     self.onParamError(row, column, "Please provide semicolon "
                                       "separated key=value pairs.")


### PR DESCRIPTION
**Description of work.**

When parsing the `CustomOptions` column in DrILL, the trailing and leading spaces are removed.

**To test:**

Try to write something like `Clear2DWorkspace=False ; ThetaDependent=False ` in the CustomOptions column in DrILL and observe that no error is reported.

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
