### PR TITLE
Bug DrILL export with no default save directory

### DIFF
--- a/scripts/Interface/ui/drill/model/DrillExportModel.py
+++ b/scripts/Interface/ui/drill/model/DrillExportModel.py
@@ -190,7 +190,10 @@ class DrillExportModel:
         """
         exportPath = config.getString("defaultsave.directory")
         if not exportPath:
-            exportPath = os.getcwd()
+            logger.warning("Default save directory is not defined. There will "
+                           "be no export from DrILL until this parameter is "
+                           "set in Mantid settings.")
+            return
         workspaceName = sample.getOutputName()
 
         try:


### PR DESCRIPTION
**Description of work.**

With DrILL, processed data are automatically exported in the default save directory. When this setting is empty, the user is warned and the automatic export is aborted. This avoid saving data in the current directory (i.e. binary directory).

**To test:**

Clear the default save directory setting and process some data through DrILL. With data from `SystemTest/ILL/D11/`:

* open the interface
* write 2888 in `SampleRuns` column
* process the row
* observe the logs

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
