### PR TITLE
Fit Script Generator - Implement Edit Local Parameter dialog

### DIFF
--- a/qt/widgets/common/inc/MantidQtWidgets/Common/FitDomain.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/FitDomain.h
@@ -29,6 +29,7 @@ class EXPORT_OPT_MANTIDQT_COMMON FitDomain {
 public:
   FitDomain(std::string const &workspaceName, WorkspaceIndex workspaceIndex, double startX, double endX);
 
+  [[nodiscard]] std::string domainName() const;
   [[nodiscard]] std::string workspaceName() const noexcept { return m_workspaceName; }
   [[nodiscard]] WorkspaceIndex workspaceIndex() const noexcept { return m_workspaceIndex; }
 
@@ -46,11 +47,16 @@ public:
   void setParameterValue(std::string const &parameter, double newValue);
   [[nodiscard]] double getParameterValue(std::string const &parameter) const;
 
+  void setParameterFixed(std::string const &parameter, bool fix) const;
+  [[nodiscard]] bool isParameterFixed(std::string const &parameter) const;
+
   void setAttributeValue(std::string const &attribute, Mantid::API::IFunction::Attribute newValue);
   [[nodiscard]] Mantid::API::IFunction::Attribute getAttributeValue(std::string const &attribute) const;
 
   [[nodiscard]] bool hasParameter(std::string const &parameter) const;
   [[nodiscard]] bool isParameterActive(std::string const &parameter) const;
+  [[nodiscard]] std::string getParameterTie(std::string const &parameter) const;
+  [[nodiscard]] std::string getParameterConstraint(std::string const &parameter) const;
 
   void clearParameterTie(std::string const &parameter);
   [[nodiscard]] bool updateParameterTie(std::string const &parameter, std::string const &tie);

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/FitScriptGeneratorMockObjects.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/FitScriptGeneratorMockObjects.h
@@ -87,6 +87,14 @@ public:
   MOCK_METHOD0(getDialogWorkspaces, std::vector<Mantid::API::MatrixWorkspace_const_sptr>());
   MOCK_CONST_METHOD0(getDialogWorkspaceIndices, std::vector<MantidQt::MantidWidgets::WorkspaceIndex>());
 
+  MOCK_METHOD7(openEditLocalParameterDialog,
+               void(std::string const &parameter, std::vector<std::string> const &workspaceNames,
+                    std::vector<std::string> const &domainNames, std::vector<double> const &values,
+                    std::vector<bool> const &fixes, std::vector<std::string> const &ties,
+                    std::vector<std::string> const &constraints));
+  MOCK_CONST_METHOD0(getEditLocalParameterResults, std::tuple<std::string, std::vector<double>, std::vector<bool>,
+                                                              std::vector<std::string>, std::vector<std::string>>());
+
   MOCK_METHOD0(resetSelection, void());
 
   MOCK_CONST_METHOD0(applyFunctionChangesToAll, bool());
@@ -139,10 +147,16 @@ public:
                      std::string(std::string const &workspaceName,
                                  MantidQt::MantidWidgets::WorkspaceIndex workspaceIndex,
                                  std::string const &functionIndex));
+  MOCK_CONST_METHOD2(getEquivalentFunctionIndexForDomain,
+                     std::string(MantidQt::MantidWidgets::FitDomainIndex, std::string const &functionIndex));
   MOCK_CONST_METHOD4(getEquivalentParameterTieForDomain,
                      std::string(std::string const &workspaceName,
                                  MantidQt::MantidWidgets::WorkspaceIndex workspaceIndex,
                                  std::string const &fullParameter, std::string const &fullTie));
+  MOCK_CONST_METHOD1(getAdjustedFunctionIndex, std::string(std::string const &parameter));
+  MOCK_CONST_METHOD2(getFullParameter,
+                     std::string(MantidQt::MantidWidgets::FitDomainIndex, std::string const &parameter));
+  MOCK_CONST_METHOD2(getFullTie, std::string(MantidQt::MantidWidgets::FitDomainIndex, std::string const &tie));
 
   MOCK_METHOD4(updateParameterValue,
                void(std::string const &workspaceName, MantidQt::MantidWidgets::WorkspaceIndex workspaceIndex,
@@ -167,6 +181,30 @@ public:
   MOCK_METHOD1(setFittingMode, void(FittingMode fittingMode));
   MOCK_CONST_METHOD0(getFittingMode, FittingMode());
   MOCK_CONST_METHOD0(isSimultaneousMode, bool());
+
+  MOCK_CONST_METHOD2(hasParameter,
+                     bool(MantidQt::MantidWidgets::FitDomainIndex domainIndex, std::string const &parameter));
+
+  MOCK_METHOD3(setParameterValue, void(MantidQt::MantidWidgets::FitDomainIndex domainIndex,
+                                       std::string const &fullParameter, double value));
+  MOCK_METHOD3(setParameterFixed,
+               void(MantidQt::MantidWidgets::FitDomainIndex domainIndex, std::string const &fullParameter, bool fix));
+  MOCK_METHOD3(setParameterTie, void(MantidQt::MantidWidgets::FitDomainIndex domainIndex,
+                                     std::string const &fullParameter, std::string const &tie));
+  MOCK_METHOD3(setParameterConstraint, void(MantidQt::MantidWidgets::FitDomainIndex domainIndex,
+                                            std::string const &fullParameter, std::string const &constraint));
+
+  MOCK_CONST_METHOD1(getDomainName, std::string(MantidQt::MantidWidgets::FitDomainIndex domainIndex));
+  MOCK_CONST_METHOD2(getParameterValue,
+                     double(MantidQt::MantidWidgets::FitDomainIndex domainIndex, std::string const &fullParameter));
+  MOCK_CONST_METHOD2(isParameterFixed,
+                     bool(MantidQt::MantidWidgets::FitDomainIndex domainIndex, std::string const &fullParameter));
+  MOCK_CONST_METHOD2(getParameterTie, std::string(MantidQt::MantidWidgets::FitDomainIndex domainIndex,
+                                                  std::string const &fullParameter));
+  MOCK_CONST_METHOD2(getParameterConstraint, std::string(MantidQt::MantidWidgets::FitDomainIndex domainIndex,
+                                                         std::string const &fullParameter));
+
+  MOCK_CONST_METHOD0(numberOfDomains, std::size_t());
 
   MOCK_CONST_METHOD0(getGlobalTies, std::vector<GlobalTie>());
   MOCK_CONST_METHOD0(getGlobalParameters, std::vector<GlobalParameter>());

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/FitScriptGeneratorPresenter.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/FitScriptGeneratorPresenter.h
@@ -58,6 +58,8 @@ private:
   void handleParameterConstraintRemoved(std::string const &parameter);
   void handleParameterConstraintChanged(std::string const &functionIndex, std::string const &constraint);
   void handleGlobalParametersChanged(std::vector<std::string> const &globalParameters);
+  void handleEditLocalParameterClicked(std::string const &parameter);
+  void handleEditLocalParameterFinished();
   void handleFittingModeChanged(FittingMode fittingMode);
 
   void setWorkspaces(QStringList const &workspaceNames, double startX, double endX);
@@ -103,6 +105,21 @@ private:
   void invokeFunctionForDomain(FitDomainIndex domainIndex, Function &&func, Args... arguments);
 
   [[nodiscard]] std::vector<FitDomainIndex> getRowIndices() const;
+
+  void insertLocalParameterData(std::string const &parameter, std::vector<std::string> &workspaceNames,
+                                std::vector<std::string> &domainNames, std::vector<double> &values,
+                                std::vector<bool> &fixes, std::vector<std::string> &ties,
+                                std::vector<std::string> &constraints) const;
+  void insertLocalParameterDataForDomain(FitDomainIndex domainIndex, std::string const &parameter,
+                                         std::vector<std::string> &workspaceNames,
+                                         std::vector<std::string> &domainNames, std::vector<double> &values,
+                                         std::vector<bool> &fixes, std::vector<std::string> &ties,
+                                         std::vector<std::string> &constraints) const;
+
+  void setLocalParameterDataForDomain(FitDomainIndex domainIndex, std::string const &parameter, double value, bool fix,
+                                      std::string const &tie, std::string const &constraint);
+
+  std::vector<FitDomainIndex> getDomainsWithLocalParameter(std::string const &parameter) const;
 
   std::tuple<std::string, std::string> convertFunctionIndexOfParameterTie(std::string const &workspaceName,
                                                                           WorkspaceIndex workspaceIndex,

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/FitScriptGeneratorView.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/FitScriptGeneratorView.h
@@ -20,6 +20,7 @@
 
 #include <memory>
 #include <string>
+#include <tuple>
 #include <vector>
 
 #include <QMap>
@@ -31,6 +32,7 @@ namespace MantidQt {
 namespace MantidWidgets {
 
 class FitScriptGeneratorDataTable;
+class EditLocalParameterDialog;
 class IFitScriptGeneratorPresenter;
 struct GlobalParameter;
 struct GlobalTie;
@@ -66,6 +68,13 @@ public:
   [[nodiscard]] bool openAddWorkspaceDialog() override;
   [[nodiscard]] std::vector<Mantid::API::MatrixWorkspace_const_sptr> getDialogWorkspaces() override;
   [[nodiscard]] std::vector<WorkspaceIndex> getDialogWorkspaceIndices() const override;
+
+  void openEditLocalParameterDialog(std::string const &parameter, std::vector<std::string> const &workspaceNames,
+                                    std::vector<std::string> const &domainNames, std::vector<double> const &values,
+                                    std::vector<bool> const &fixes, std::vector<std::string> const &ties,
+                                    std::vector<std::string> const &constraints) override;
+  std::tuple<std::string, std::vector<double>, std::vector<bool>, std::vector<std::string>, std::vector<std::string>>
+  getEditLocalParameterResults() const override;
 
   void resetSelection() override;
 
@@ -105,6 +114,8 @@ private slots:
   void onCopyFunctionToClipboard();
   void onFunctionHelpRequested();
   void onFittingModeChanged(FittingMode fittingMode);
+  void onEditLocalParameterClicked(QString const &parameter);
+  void onEditLocalParameterFinished(int result);
 
 private:
   void connectUiSignals();
@@ -117,6 +128,7 @@ private:
   std::unique_ptr<FitScriptGeneratorDataTable> m_dataTable;
   std::unique_ptr<FunctionTreeView> m_functionTreeView;
   std::unique_ptr<BasicFitOptionsBrowser> m_fitOptionsBrowser;
+  EditLocalParameterDialog *m_editLocalParameterDialog;
   Ui::FitScriptGenerator m_ui;
 };
 

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/FunctionBrowser/FunctionBrowserUtils.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/FunctionBrowser/FunctionBrowserUtils.h
@@ -37,6 +37,7 @@ EXPORT_OPT_MANTIDQT_COMMON IFunction_sptr getFunctionWithPrefix(const QString &p
 
 /// Split a function (eg f0.f3.f1.) into the parent prefix (f0.f3.) and the
 /// index of the child function (1).
+EXPORT_OPT_MANTIDQT_COMMON std::pair<QString, int> splitFunctionPrefix(const std::string &prefix);
 EXPORT_OPT_MANTIDQT_COMMON std::pair<QString, int> splitFunctionPrefix(const QString &prefix);
 
 /// Split a constraint definition into a parameter name and a pair of bounds,

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/IFitScriptGeneratorModel.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/IFitScriptGeneratorModel.h
@@ -49,10 +49,16 @@ public:
   [[nodiscard]] virtual std::string getEquivalentFunctionIndexForDomain(std::string const &workspaceName,
                                                                         WorkspaceIndex workspaceIndex,
                                                                         std::string const &functionIndex) const = 0;
+  [[nodiscard]] virtual std::string getEquivalentFunctionIndexForDomain(FitDomainIndex domainIndex,
+                                                                        std::string const &functionIndex) const = 0;
   [[nodiscard]] virtual std::string getEquivalentParameterTieForDomain(std::string const &workspaceName,
                                                                        WorkspaceIndex workspaceIndex,
                                                                        std::string const &fullParameter,
                                                                        std::string const &fullTie) const = 0;
+  [[nodiscard]] virtual std::string getAdjustedFunctionIndex(std::string const &parameter) const = 0;
+  [[nodiscard]] virtual std::string getFullParameter(FitDomainIndex domainIndex,
+                                                     std::string const &parameter) const = 0;
+  [[nodiscard]] virtual std::string getFullTie(FitDomainIndex domainIndex, std::string const &tie) const = 0;
 
   virtual void updateParameterValue(std::string const &workspaceName, WorkspaceIndex workspaceIndex,
                                     std::string const &fullParameter, double newValue) = 0;
@@ -77,6 +83,26 @@ public:
   [[nodiscard]] virtual std::vector<GlobalParameter> getGlobalParameters() const = 0;
 
   [[nodiscard]] virtual bool isSimultaneousMode() const = 0;
+
+  [[nodiscard]] virtual bool hasParameter(FitDomainIndex domainIndex, std::string const &fullParameter) const = 0;
+
+  virtual void setParameterValue(FitDomainIndex domainIndex, std::string const &fullParameter, double value) = 0;
+  virtual void setParameterFixed(FitDomainIndex domainIndex, std::string const &fullParameter, bool fix) = 0;
+  virtual void setParameterTie(FitDomainIndex domainIndex, std::string const &fullParameter,
+                               std::string const &tie) = 0;
+  virtual void setParameterConstraint(FitDomainIndex domainIndex, std::string const &fullParameter,
+                                      std::string const &constraint) = 0;
+
+  [[nodiscard]] virtual std::string getDomainName(FitDomainIndex domainIndex) const = 0;
+  [[nodiscard]] virtual double getParameterValue(FitDomainIndex domainIndex,
+                                                 std::string const &fullParameter) const = 0;
+  [[nodiscard]] virtual bool isParameterFixed(FitDomainIndex domainIndex, std::string const &fullParameter) const = 0;
+  [[nodiscard]] virtual std::string getParameterTie(FitDomainIndex domainIndex,
+                                                    std::string const &fullParameter) const = 0;
+  [[nodiscard]] virtual std::string getParameterConstraint(FitDomainIndex domainIndex,
+                                                           std::string const &fullParameter) const = 0;
+
+  [[nodiscard]] virtual std::size_t numberOfDomains() const = 0;
 };
 
 } // namespace MantidWidgets

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/IFitScriptGeneratorView.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/IFitScriptGeneratorView.h
@@ -49,6 +49,8 @@ public:
     ParameterConstraintRemoved,
     ParameterConstraintChanged,
     GlobalParametersChanged,
+    EditLocalParameterClicked,
+    EditLocalParameterFinished,
     FittingModeChanged
   };
 
@@ -78,6 +80,16 @@ public:
   [[nodiscard]] virtual bool openAddWorkspaceDialog() = 0;
   [[nodiscard]] virtual std::vector<Mantid::API::MatrixWorkspace_const_sptr> getDialogWorkspaces() = 0;
   [[nodiscard]] virtual std::vector<WorkspaceIndex> getDialogWorkspaceIndices() const = 0;
+
+  virtual void openEditLocalParameterDialog(std::string const &parameter,
+                                            std::vector<std::string> const &workspaceNames,
+                                            std::vector<std::string> const &domainNames,
+                                            std::vector<double> const &values, std::vector<bool> const &fixes,
+                                            std::vector<std::string> const &ties,
+                                            std::vector<std::string> const &constraints) = 0;
+  virtual std::tuple<std::string, std::vector<double>, std::vector<bool>, std::vector<std::string>,
+                     std::vector<std::string>>
+  getEditLocalParameterResults() const = 0;
 
   virtual void resetSelection() = 0;
 

--- a/qt/widgets/common/src/FitScriptGeneratorDataTable.cpp
+++ b/qt/widgets/common/src/FitScriptGeneratorDataTable.cpp
@@ -187,7 +187,7 @@ std::vector<FitDomainIndex> FitScriptGeneratorDataTable::allRows() const {
   for (auto index = 0; index < this->rowCount(); ++index)
     rowIndices.emplace_back(FitDomainIndex(index));
 
-  std::sort(rowIndices.rbegin(), rowIndices.rend());
+  std::reverse(rowIndices.begin(), rowIndices.end());
   return rowIndices;
 }
 
@@ -200,7 +200,7 @@ std::vector<FitDomainIndex> FitScriptGeneratorDataTable::selectedRows() const {
     for (auto const &rowIndex : selectionModel->selectedRows())
       rowIndices.emplace_back(FitDomainIndex(static_cast<std::size_t>(rowIndex.row())));
 
-    std::sort(rowIndices.rbegin(), rowIndices.rend());
+    std::reverse(rowIndices.begin(), rowIndices.end());
   }
   return rowIndices;
 }

--- a/qt/widgets/common/src/FitScriptGeneratorPresenter.cpp
+++ b/qt/widgets/common/src/FitScriptGeneratorPresenter.cpp
@@ -454,6 +454,7 @@ FitScriptGeneratorPresenter::getDomainsWithLocalParameter(std::string const &par
   auto domainIndices = m_view->allRows();
   domainIndices.erase(std::remove_if(domainIndices.begin(), domainIndices.end(), doesNotHaveParameter),
                       domainIndices.end());
+  std::reverse(domainIndices.begin(), domainIndices.end());
   return domainIndices;
 }
 

--- a/qt/widgets/common/src/FunctionBrowser/FunctionBrowserUtils.cpp
+++ b/qt/widgets/common/src/FunctionBrowser/FunctionBrowserUtils.cpp
@@ -48,6 +48,10 @@ IFunction_sptr getFunctionWithPrefix(const QString &prefix, const IFunction_sptr
   return getFunctionWithPrefix(prefix.mid(j + 1), compFun->getFunction(funIndex));
 }
 
+std::pair<QString, int> splitFunctionPrefix(const std::string &prefix) {
+  return splitFunctionPrefix(QString::fromStdString(prefix));
+}
+
 std::pair<QString, int> splitFunctionPrefix(const QString &prefix) {
   if (prefix.isEmpty())
     return std::make_pair("", -1);


### PR DESCRIPTION
**Description of work.**
This PR implements the Edit Local Parameter dialog for the Fit Script Generator interface. It is now possible to select a local parameter using the `...` button in the function tree and edit the values/ties/fixes/constraints for this parameter across all the domains that it exists in.

**To test:**
1. Comment out this line
https://github.com/mantidproject/mantid/blob/44daa7417226a56f8d1896ea6b2f2b1bc576a5d1/scripts/Muon/GUI/Common/fitting_tab_widget/fitting_tab_view.py#L52
2. Go to Muon Analysis interface
3. click `Load Current Run`
4. Go to Fitting tab and click `Fit Generator`
5. Click `Add Workspaces`. Select the first workspace and click add.
6. Right click the function browser and add a `FlatBackground` and then `ExpDecay`
7. Select a parameter and click the `...`. The Edit Local Parameter dialog should open.
8. Try out fixing, tying and constraining the parameter. Click `Ok` each time and check the changes have been applied within the function tree. 
9. Opening the dialog should also load in the current fixes/ties/constraints seen in the function tree.

Fixes #30684 

*This does not require release notes* because **the Fit Script Generator is inaccessible to users at the moment.**

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
