### PR TITLE
Fix crash caused by instrument viewer pick tab plot

### DIFF
--- a/docs/source/release/v6.1.0/mantidworkbench.rst
+++ b/docs/source/release/v6.1.0/mantidworkbench.rst
@@ -33,6 +33,6 @@ Bugfixes
 - If the facility in Mantid.user.properties is empty, it is consistently reflected as empty in the GUI
 - First time dialog box will not appear recurrently, if user selected their choice of facility
   and instrument at least once and checked "Do not show again until next version"
-- Fixed a bug that would cause a crash if the user right clicked on the plot in the instrument view pick tab after the stored curves were cleared. 
+- Fixed a bug that would cause a crash if the user right clicked on the plot in the instrument view pick tab after the stored curves were cleared.
 
 :ref:`Release 6.1.0 <v6.1.0>`

--- a/docs/source/release/v6.1.0/mantidworkbench.rst
+++ b/docs/source/release/v6.1.0/mantidworkbench.rst
@@ -33,5 +33,6 @@ Bugfixes
 - If the facility in Mantid.user.properties is empty, it is consistently reflected as empty in the GUI
 - First time dialog box will not appear recurrently, if user selected their choice of facility
   and instrument at least once and checked "Do not show again until next version"
+- Fixed a bug that would cause a crash if the user right clicked on the plot in the instrument view pick tab after the stored curves were cleared. 
 
 :ref:`Release 6.1.0 <v6.1.0>`

--- a/docs/source/release/v6.1.0/mantidworkbench.rst
+++ b/docs/source/release/v6.1.0/mantidworkbench.rst
@@ -19,7 +19,7 @@ Added Floating/On Top setting for all the windows that are opened by workbench (
 - A new empty facility with empty instrument is the default facility now, and
   user has to select their choice of facility (including ISIS) and instrument for the first time
 - Instrument view: when in tube selection mode, the sum of pixel counts is now output to the selection pane.
-  
+
 Bugfixes
 --------
 

--- a/qt/widgets/instrumentview/src/MiniPlotMpl.cpp
+++ b/qt/widgets/instrumentview/src/MiniPlotMpl.cpp
@@ -265,8 +265,9 @@ void MiniPlotMpl::setYLinearScale() {
 void MiniPlotMpl::clearAll() {
   // active curve, labels etc
   clearCurve();
-  // any stored curves
+  // any stored curves and labels
   m_lines.clear();
+  m_storedCurveLabels.clear();
   replot();
 }
 


### PR DESCRIPTION
**Description of work.**
The plot in the pick tab of the instrument view would cause a crash if it was right clicked after the stored curves were cleared. There was just a missing call to clear the stored curve names.

**To test:**

<!-- Instructions for testing. -->
1. Load a workspace, open the instrument view and navigate to the "Pick" tab
2. Store at least one curve on the plot by right clicking a pixel and choosing "store curve"
3. Click the eraser tool, which will remove the stored curves (other tools will do the same)
4. Right click the plot

This would previously cause a crash, but will now display the context menu as expected.

Fixes #30811

<!-- Ensure the base of this PR is correct (e.g. release-next or master)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
