### PR TITLE
override label() in bin edge axis

### DIFF
--- a/Framework/API/inc/MantidAPI/Axis.h
+++ b/Framework/API/inc/MantidAPI/Axis.h
@@ -82,6 +82,8 @@ public:
   virtual bool operator==(const Axis &) const = 0;
 
   /// Returns a text label of for a value
+  /// Note that the index here is not the index of a value, but the effective
+  /// index of the bin
   virtual std::string label(const std::size_t &index) const = 0;
 
 protected:

--- a/Framework/API/inc/MantidAPI/BinEdgeAxis.h
+++ b/Framework/API/inc/MantidAPI/BinEdgeAxis.h
@@ -28,6 +28,7 @@ public:
   std::vector<double> createBinBoundaries() const override;
   void setValue(const std::size_t &index, const double &value) override;
   size_t indexOfValue(const double value) const override;
+  std::string label(const std::size_t &index) const override;
 };
 
 } // namespace API

--- a/Framework/API/inc/MantidAPI/NumericAxis.h
+++ b/Framework/API/inc/MantidAPI/NumericAxis.h
@@ -59,6 +59,9 @@ protected:
 
   /// A vector holding the centre values.
   std::vector<double> m_values;
+
+  /// Get number label
+  std::string formatLabel(const double value) const;
 };
 
 } // namespace API

--- a/Framework/API/src/BinEdgeAxis.cpp
+++ b/Framework/API/src/BinEdgeAxis.cpp
@@ -93,8 +93,7 @@ size_t BinEdgeAxis::indexOfValue(const double value) const {
  */
 std::string BinEdgeAxis::label(const std::size_t &index) const {
   if (index >= length() - 1) {
-    throw Kernel::Exception::IndexError(index, length() - 2,
-                                        "BinEdgeAxis: Bin index out of range.");
+    throw Kernel::Exception::IndexError(index, length() - 2, "BinEdgeAxis: Bin index out of range.");
   }
   return formatLabel(((*this)(index) + (*this)(index + 1)) / 2);
 }

--- a/Framework/API/src/BinEdgeAxis.cpp
+++ b/Framework/API/src/BinEdgeAxis.cpp
@@ -84,5 +84,18 @@ size_t BinEdgeAxis::indexOfValue(const double value) const {
   return Mantid::Kernel::VectorHelper::indexOfValueFromEdges(m_values, value);
 }
 
+/** Returns a text label which shows the value at bin index and identifies the
+ *  type of the axis.
+ *  @param index :: The bin index of the bin edge axis
+ *  @return string of the center of that bin
+ * @throw IndexError if the bin index is out of range
+ */
+std::string BinEdgeAxis::label(const std::size_t &index) const {
+  if (index >= length() - 1) {
+    throw Kernel::Exception::IndexError(index, length() - 1,
+                                        "BinEdgeAxis: Bin index out of range.");
+  }
+  return formatLabel(((*this)(index) + (*this)(index + 1)) / 2);
+}
 } // namespace API
 } // namespace Mantid

--- a/Framework/API/src/BinEdgeAxis.cpp
+++ b/Framework/API/src/BinEdgeAxis.cpp
@@ -84,15 +84,16 @@ size_t BinEdgeAxis::indexOfValue(const double value) const {
   return Mantid::Kernel::VectorHelper::indexOfValueFromEdges(m_values, value);
 }
 
-/** Returns a text label which shows the value at bin index and identifies the
- *  type of the axis.
- *  @param index :: The bin index of the bin edge axis
- *  @return string of the center of that bin
+/** Returns a text label which shows the value at the given bin index.
+ * Note that the bin index doesn't match the index in the value array for this
+ * type of axis. The value array has one more element than number of bins.
+ * @param index :: The bin index of the bin edge axis
+ * @return string of the center of that bin
  * @throw IndexError if the bin index is out of range
  */
 std::string BinEdgeAxis::label(const std::size_t &index) const {
   if (index >= length() - 1) {
-    throw Kernel::Exception::IndexError(index, length() - 1,
+    throw Kernel::Exception::IndexError(index, length() - 2,
                                         "BinEdgeAxis: Bin index out of range.");
   }
   return formatLabel(((*this)(index) + (*this)(index + 1)) / 2);

--- a/Framework/API/src/NumericAxis.cpp
+++ b/Framework/API/src/NumericAxis.cpp
@@ -131,18 +131,17 @@ bool NumericAxis::equalWithinTolerance(const Axis &axis2, const double tolerance
   return std::equal(m_values.begin(), m_values.end(), spec2->m_values.begin(), comparison);
 }
 
-/** Returns a text label which shows the value at index and identifies the
- *  type of the axis.
- *  @param index :: The index of an axis value
- *  @return the label of the requested axis
+/** Returns a text label which shows the value corresponding to a bin index.
+ *  @param index :: The index of the bin, matches with the index of the value
+ *  @return the formatted string
  */
 std::string NumericAxis::label(const std::size_t &index) const {
   return formatLabel((*this)(index));
 }
 
 /**
- * @brief Formats the label to a string
- * @param value: the value of the axis at an index
+ * @brief Formats a numeric label to a string
+ * @param value: the numeric value of the label
  * @return formatted value as string
  */
 std::string NumericAxis::formatLabel(const double value) const {

--- a/Framework/API/src/NumericAxis.cpp
+++ b/Framework/API/src/NumericAxis.cpp
@@ -137,7 +137,16 @@ bool NumericAxis::equalWithinTolerance(const Axis &axis2, const double tolerance
  *  @return the label of the requested axis
  */
 std::string NumericAxis::label(const std::size_t &index) const {
-  std::string numberLabel = boost::str(boost::format("%.13f") % (*this)(index));
+  return formatLabel((*this)(index));
+}
+
+/**
+ * @brief Formats the label to a string
+ * @param value: the value of the axis at an index
+ * @return formatted value as string
+ */
+std::string NumericAxis::formatLabel(const double value) const {
+  std::string numberLabel = boost::str(boost::format("%.13f") % value);
 
   // Remove all zeros up to the decimal place or a non zero value
   auto it = numberLabel.end() - 1;

--- a/Framework/API/src/NumericAxis.cpp
+++ b/Framework/API/src/NumericAxis.cpp
@@ -135,9 +135,7 @@ bool NumericAxis::equalWithinTolerance(const Axis &axis2, const double tolerance
  *  @param index :: The index of the bin, matches with the index of the value
  *  @return the formatted string
  */
-std::string NumericAxis::label(const std::size_t &index) const {
-  return formatLabel((*this)(index));
-}
+std::string NumericAxis::label(const std::size_t &index) const { return formatLabel((*this)(index)); }
 
 /**
  * @brief Formats a numeric label to a string

--- a/Framework/API/test/BinEdgeAxisTest.h
+++ b/Framework/API/test/BinEdgeAxisTest.h
@@ -31,8 +31,7 @@ public:
     delete copy;
   }
 
-  void
-  test_Clone_With_Only_Length_And_Workspace_Returns_BinEdgeAxis_With_New_Length() {
+  void test_Clone_With_Only_Length_And_Workspace_Returns_BinEdgeAxis_With_New_Length() {
     BinEdgeAxis ax1(10);
     Mantid::API::Axis *copy = ax1.clone(20, nullptr);
     auto *typedCopy = dynamic_cast<BinEdgeAxis *>(copy);
@@ -96,10 +95,8 @@ public:
     auto edges = ax1.createBinBoundaries();
     TS_ASSERT_EQUALS(length, edges.size());
     // label index can be [0,8]
-    TS_ASSERT_THROWS_EQUALS(
-        ax1.label(9), const Mantid::Kernel::Exception::IndexError &re,
-        std::string(re.what()),
-        "IndexError: BinEdgeAxis: Bin index out of range. 9 :: 0 <==> 8");
+    TS_ASSERT_THROWS_EQUALS(ax1.label(9), const Mantid::Kernel::Exception::IndexError &re, std::string(re.what()),
+                            "IndexError: BinEdgeAxis: Bin index out of range. 9 :: 0 <==> 8");
   }
 
   void test_indexOfValue_Throws_OutOfRange_For_Invalid_Value() {

--- a/Framework/API/test/BinEdgeAxisTest.h
+++ b/Framework/API/test/BinEdgeAxisTest.h
@@ -9,6 +9,8 @@
 #include <cxxtest/TestSuite.h>
 
 #include "MantidAPI/BinEdgeAxis.h"
+#include "MantidKernel/Exception.h"
+#include "MantidKernel/VectorHelper.h"
 
 using Mantid::API::BinEdgeAxis;
 
@@ -29,7 +31,8 @@ public:
     delete copy;
   }
 
-  void test_Clone_With_Only_Length_And_Workspace_Returns_BinEdgeAxis_With_New_Length() {
+  void
+  test_Clone_With_Only_Length_And_Workspace_Returns_BinEdgeAxis_With_New_Length() {
     BinEdgeAxis ax1(10);
     Mantid::API::Axis *copy = ax1.clone(20, nullptr);
     auto *typedCopy = dynamic_cast<BinEdgeAxis *>(copy);
@@ -66,7 +69,38 @@ public:
     }
   }
 
+  void test_label() {
+    const size_t length(10); // 9 bin centres
+    BinEdgeAxis ax1(length);
+    for (size_t i = 0; i < length; ++i) {
+      ax1.setValue(i, static_cast<double>(i + 1));
+    }
+    auto edges = ax1.createBinBoundaries();
+    std::vector<double> centers;
+    centers.reserve(9);
+    Mantid::Kernel::VectorHelper::convertToBinCentre(edges, centers);
+    TS_ASSERT_EQUALS(length, edges.size());
+    for (size_t i = 0; i < length - 1; ++i) {
+      TS_ASSERT_EQUALS(ax1.label(i), std::to_string(centers[i]).substr(0, 3));
+    }
+  }
+
   // ------------------------- Failure cases -----------------------------------
+
+  void test_fail_label_out_of_range() {
+    const size_t length(10); // 9 bin centres
+    BinEdgeAxis ax1(length);
+    for (size_t i = 0; i < length; ++i) {
+      ax1.setValue(i, static_cast<double>(i + 1));
+    }
+    auto edges = ax1.createBinBoundaries();
+    TS_ASSERT_EQUALS(length, edges.size());
+    // label index can be [0,8]
+    TS_ASSERT_THROWS_EQUALS(
+        ax1.label(9), const Mantid::Kernel::Exception::IndexError &re,
+        std::string(re.what()),
+        "IndexError: BinEdgeAxis: Bin index out of range. 9 :: 0 <==> 8");
+  }
 
   void test_indexOfValue_Throws_OutOfRange_For_Invalid_Value() {
     const size_t length(10); // 9 bin centres
@@ -75,7 +109,9 @@ public:
       ax1.setValue(i, static_cast<double>(i + 1));
     }
 
-    TS_ASSERT_THROWS(ax1.indexOfValue(0.9), const std::out_of_range &);  // start
-    TS_ASSERT_THROWS(ax1.indexOfValue(10.1), const std::out_of_range &); // end
+    TS_ASSERT_THROWS(ax1.indexOfValue(0.9),
+                     const std::out_of_range &); // start
+    TS_ASSERT_THROWS(ax1.indexOfValue(10.1),
+                     const std::out_of_range &); // end
   }
 };

--- a/Framework/PythonInterface/test/python/mantid/plots/datafunctionsTest.py
+++ b/Framework/PythonInterface/test/python/mantid/plots/datafunctionsTest.py
@@ -192,7 +192,7 @@ class DataFunctionsTest(unittest.TestCase):
         index, dist, kwargs = funcs.get_wksp_index_dist_and_label(self.ws2d_histo, specNum=2)
         self.assertEqual(index, 1)
         self.assertTrue(dist)
-        self.assertEqual(kwargs['label'], 'ws2d_histo: 6')
+        self.assertEqual(kwargs['label'], 'ws2d_histo: 7')
         # get info from default spectrum in the 1d case
         index, dist, kwargs = funcs.get_wksp_index_dist_and_label(self.ws1d_point, wkspIndex=0)
         self.assertEqual(index, 0)

--- a/docs/source/release/v6.1.0/framework.rst
+++ b/docs/source/release/v6.1.0/framework.rst
@@ -29,6 +29,7 @@ Data Objects
 ------------
 
 - exposed ``geographicalAngles`` method on :py:obj:`mantid.api.SpectrumInfo`
+- :ref:`BinEdgeAxis <mantid.api.BinEdgeAxis>` now overrides the label in order to return the bin center and not the edge
 - :ref:`Run <mantid.api.Run>` has been modified to allow multiple goniometers to be stored.
 - :ref:`FileFinder <mantid.api.FileFinderImpl>` has been modified to improve search times when loading multiple runs on the same instrument.
 

--- a/docs/source/release/v6.1.0/framework.rst
+++ b/docs/source/release/v6.1.0/framework.rst
@@ -29,7 +29,7 @@ Data Objects
 ------------
 
 - exposed ``geographicalAngles`` method on :py:obj:`mantid.api.SpectrumInfo`
-- :ref:`BinEdgeAxis <mantid.api.BinEdgeAxis>` now overrides the label in order to return the bin center and not the edge
+- ``BinEdgeAxis`` now overrides the label in order to return the bin center and not the edge
 - :ref:`Run <mantid.api.Run>` has been modified to allow multiple goniometers to be stored.
 - :ref:`FileFinder <mantid.api.FileFinderImpl>` has been modified to improve search times when loading multiple runs on the same instrument.
 

--- a/docs/source/release/v6.1.0/mantidworkbench.rst
+++ b/docs/source/release/v6.1.0/mantidworkbench.rst
@@ -33,6 +33,7 @@ Bugfixes
 - Fixed a bug which occurred when switching to a log scale in sliceviewer with negative data.
 - Fixed a bug that use wrong help links in certain interfaces
 - Fixed a bug that would not let the user input the bounding box of a shape in the instrument viewer.
+- The label of 1D curves in the legend of the plots is corrected to match the vertical axis bin center, if it is a BinEdgeAxis
 - If the facility in Mantid.user.properties is empty, it is consistently reflected as empty in the GUI
 - First time dialog box will not appear recurrently, if user selected their choice of facility
   and instrument at least once and checked "Do not show again until next version".

--- a/qt/python/mantidqt/widgets/workspacedisplay/matrix/table_view_model.py
+++ b/qt/python/mantidqt/widgets/workspacedisplay/matrix/table_view_model.py
@@ -92,11 +92,7 @@ class MatrixWorkspaceTableViewModel(QAbstractTableModel):
 
     def _makeVerticalHeader(self, section, role):
         def _numeric_axis_value_unit(axis):
-            # binned/point data
-            if axis.length() == self.ws.getNumberHistograms() + 1:
-                value = 0.5 * (float(axis.label(section)) + float(axis.label(section + 1)))
-            else:
-                value = float(axis.label(section))
+            value = float(axis.label(section))
             return value, axis.getUnit().symbol().utf8()
 
         axis_index = 1

--- a/qt/python/mantidqt/widgets/workspacedisplay/matrix/test/test_matrixworkspacedisplay_table_view_model.py
+++ b/qt/python/mantidqt/widgets/workspacedisplay/matrix/test/test_matrixworkspacedisplay_table_view_model.py
@@ -412,7 +412,7 @@ class MatrixWorkspaceDisplayTableViewModelTest(unittest.TestCase):
         # single spectrum with length 2 axis
         ws.getNumberHistograms.return_value = 1
         mock_axis.length.return_value = 2
-        mock_axis.label = MagicMock(side_effect=["0", "1"])
+        mock_axis.label = MagicMock(side_effect=["0.5"])
         mock_axis.getUnit().symbol().utf8.return_value = dummy_unit
         ws.getAxis.return_value = mock_axis
 

--- a/qt/python/mantidqt/widgets/workspacedisplay/matrix/test/test_matrixworkspacedisplay_table_view_model.py
+++ b/qt/python/mantidqt/widgets/workspacedisplay/matrix/test/test_matrixworkspacedisplay_table_view_model.py
@@ -456,7 +456,7 @@ class MatrixWorkspaceDisplayTableViewModelTest(unittest.TestCase):
         mock_axis.isNumeric.return_value = True
         ws.getNumberHistograms.return_value = 1
         mock_axis.length.return_value = 2
-        mock_axis.label = MagicMock(side_effect=["0", "1"])
+        mock_axis.label = MagicMock(side_effect=["0.5"])
         mock_axis.getUnit().symbol().utf8.return_value = dummy_unit
         ws.getAxis.return_value = mock_axis
 


### PR DESCRIPTION
**Description of work.**
Overrides label() in `BinEdgeAxis` to return the bin center and not the edge.

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

**To test:**
Run the script in the issue.
Open the matrix view (Show Data in context menu).
Observe the vertical axis values.
Plot all the spectra.
Make sure the labels of the curves in the legend match what you see in the matrix view.

<!-- Instructions for testing. -->

Fixes #30969 . <!-- and fix #xxxx or close #xxxx xor resolves #xxxx -->
<!-- alternative
*There is no associated issue.*
-->

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or master)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
