### PR TITLE
Change default output type of CreatePeaksworkspace back to standard Peaksworkspace

### DIFF
--- a/Framework/Algorithms/src/CreatePeaksWorkspace.cpp
+++ b/Framework/Algorithms/src/CreatePeaksWorkspace.cpp
@@ -40,9 +40,9 @@ void CreatePeaksWorkspace::init() {
   // explicit control of output peak workspace tyep
   // Full: standar peak workspace
   // Lean: LeanElasticPeakWorkspace
-  const std::vector<std::string> peakworkspaceTypes{"Full", "Lean"};
+  const std::vector<std::string> peakworkspaceTypes{"Peak", "LeanElasticPeak"};
   declareProperty(
-      "OutputType", "Full",
+      "OutputType", "Peak",
       std::make_shared<StringListValidator>(peakworkspaceTypes),
       "Output peak workspace type, default to full peak workspace.");
 }
@@ -62,7 +62,7 @@ void CreatePeaksWorkspace::exec() {
   IPeaksWorkspace_sptr out;
   // By default, we generate a PeakWorkspace unless user explicitly
   // requires a LeanElasticPeakWorkspace
-  if (outputType == "Full") {
+  if (outputType == "Peak") {
     out = std::make_shared<PeaksWorkspace>();
     setProperty("OutputWorkspace", out);
 
@@ -93,7 +93,7 @@ void CreatePeaksWorkspace::exec() {
         progress.report();
       }
     }
-  } else if (outputType == "Lean") {
+  } else if (outputType == "LeanElasticPeak") {
     // use LeanElasticPeakWorkspace, which means no instrument related info
     out = std::make_shared<LeanElasticPeaksWorkspace>();
     setProperty("OutputWorkspace", out);

--- a/Framework/Algorithms/test/CreatePeaksWorkspaceTest.h
+++ b/Framework/Algorithms/test/CreatePeaksWorkspaceTest.h
@@ -63,7 +63,7 @@ public:
     AnalysisDataService::Instance().remove(outWSName);
   }
 
-  void test_exec_no_instr() {
+  void test_exec_leanElasticPeakWorkspace() {
     // Name of the output workspace.
     std::string outWSName("CreatePeaksWorkspaceTest_OutputWS2");
 
@@ -73,6 +73,7 @@ public:
     TS_ASSERT_THROWS_NOTHING(
         alg.setPropertyValue("OutputWorkspace", outWSName));
     TS_ASSERT_THROWS_NOTHING(alg.setProperty("NumberOfPeaks", 13));
+    TS_ASSERT_THROWS_NOTHING(alg.setProperty("OutputType", "Lean"));
     TS_ASSERT_THROWS_NOTHING(alg.execute();)
     TS_ASSERT(alg.isExecuted());
 

--- a/Framework/Algorithms/test/CreatePeaksWorkspaceTest.h
+++ b/Framework/Algorithms/test/CreatePeaksWorkspaceTest.h
@@ -73,7 +73,7 @@ public:
     TS_ASSERT_THROWS_NOTHING(
         alg.setPropertyValue("OutputWorkspace", outWSName));
     TS_ASSERT_THROWS_NOTHING(alg.setProperty("NumberOfPeaks", 13));
-    TS_ASSERT_THROWS_NOTHING(alg.setProperty("OutputType", "Lean"));
+    TS_ASSERT_THROWS_NOTHING(alg.setProperty("OutputType", "LeanElasticPeak"));
     TS_ASSERT_THROWS_NOTHING(alg.execute();)
     TS_ASSERT(alg.isExecuted());
 

--- a/docs/source/algorithms/CreatePeaksWorkspace-v1.rst
+++ b/docs/source/algorithms/CreatePeaksWorkspace-v1.rst
@@ -9,8 +9,12 @@
 Description
 -----------
 
-Create an empty :ref:`PeaksWorkspace <PeaksWorkspace>`. Use
-:ref:`algm-LoadIsawPeaks` or :ref:`algm-FindPeaksMD` to
+This algorithm can be used to create a:
+
+- :ref:`PeaksWorkspace <PeaksWorkspace>` (Default, or when `OutputType` is set to `Peak`.)
+- :ref:`LeanElasticPeaksWorkspace <LeanElasticPeaksWorkspace>` (when `OutputType` is set to `LeanElasticPeak`)
+
+Use :ref:`algm-LoadIsawPeaks` or :ref:`algm-FindPeaksMD` to
 create a peaks workspace with peaks.
 
 This workspace can serve as a starting point for modifying the
@@ -20,23 +24,32 @@ for example.
 If the input workspace is a MDWorkspace then the instrument from the
 first experiment info is used.
 
-If the `InstrumentWorkspace` is not provided then a
-:ref:`LeanElasticPeaksWorkspace <LeanElasticPeaksWorkspace>` is
-created instead of a :ref:`PeaksWorkspace <PeaksWorkspace>`
-
 Usage
 -----
 
-**Example: Create an empty LeanElasticPeaksWorkspace, not tied to an instrument**
+**Example: An empty table, not tied to an instrument**
 
-.. testcode:: ExEmptyTable
+.. testcode:: ExEmptyPeaksworkspaceTable
 
-    ws = CreatePeaksWorkspace(NumberOfPeaks=0)
+    ws = CreatePeaksWorkspace()
     print("Created a {} with {} rows".format(ws.id(), ws.rowCount()))
 
 Output:
 
-.. testoutput:: ExEmptyTable
+.. testoutput:: ExEmptyPeaksworkspaceTable
+
+    Created a PeaksWorkspace with 0 rows
+
+**Example: Create an empty LeanElasticPeaksWorkspace, not tied to an instrument**
+
+.. testcode:: ExEmptyLeanElasticPeaksworkspaceTable
+
+    ws = CreatePeaksWorkspace(NumberOfPeaks=0, OutputType="LeanElasticPeak")
+    print("Created a {} with {} rows".format(ws.id(), ws.rowCount()))
+
+Output:
+
+.. testoutput:: ExEmptyLeanElasticPeaksworkspaceTable
 
     Created a LeanElasticPeaksWorkspace with 0 rows
 


### PR DESCRIPTION
**Description of work.**
- Related Gitlab Task: [265](https://code.ornl.gov/sns-hfir-scse/diffraction/single-crystal/single-crystal-diffraction/-/issues/265)
- This is #30983 into `master`

This PR adds a new option, `OutputType`, to `CreatePeaksworkspace`, which can be toggled between "Peak" and "LeanElasticPeak".
- "Peak": use standard Peaksworkspace as output, this is the DEFAULT option
- "LeanElasticPeak": use new lean elastic Peaksworkspace, which does not have an instrument attached to it

![demo](https://user-images.githubusercontent.com/5064852/112643116-633a6f80-8e1a-11eb-9b89-1ed5d1ef56b9.png)

> Note: the arguments in the screenshot is outed, please use "LeanElasticPeak" to indicate that the output type should be lean elastic peak workspace.

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

**To test:**
Testing script
```python
from mantid.simpleapi import *

#-- default, regular PeaksWorkspaces with an instrument specified
sampleWs = CreateSampleWorkspace()
pws_withInst = CreatePeaksWorkspace(
    InstrumentWorkspace=sampleWs,
    NumberOfPeaks=3,
    )

#-- defualt, regular Peaksworkspace without specifying an instrument
pws_withoutInst = CreatePeaksWorkspace(NumberOfPeaks=3)

#-- lean pws, Lean Elastic Peaksworkspace without specifying an instrument
lpws = CreatePeaksWorkspace(
    NumberOfPeaks=3,
    OutputType="LeanElasticPeak",
    )

#-- lean pws, Lean Elastic Peakworkspace with specifying an instrument, which is ignored
lpws_ignoreInst = CreatePeaksWorkspace(
    InstrumentWorkspace=sampleWs,
    NumberOfPeaks=3,
    OutputType="LeanElasticPeak",
    )
```

<!-- Instructions for testing. -->

Fixes #30984. <!-- and fix #xxxx or close #xxxx xor resolves #xxxx -->
<!-- alternative
*There is no associated issue.*
-->

*This does not require release notes* because **we are switching back to the previous default behavior within the same release cycle.**

<!-- Ensure the base of this PR is correct (e.g. release-next or master)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
