### PR TITLE
Allow Multiple Directories To Be Used In ALC

### DIFF
--- a/Framework/Muon/src/PlotAsymmetryByLogValue.cpp
+++ b/Framework/Muon/src/PlotAsymmetryByLogValue.cpp
@@ -279,8 +279,7 @@ void PlotAsymmetryByLogValue::checkProperties(size_t &firstRunNumber, size_t &la
 
   // If file names empty, first and last provided so need to populate vector
   if (m_fileNames.empty()) {
-    populateFileNamesFromFirstLast(getProperty("FirstRun"),
-                                   getProperty("LastRun"));
+    populateFileNamesFromFirstLast(getProperty("FirstRun"), getProperty("LastRun"));
   }
 
   // Extract run numbers for all runs and map to filenames

--- a/Framework/Muon/src/PlotAsymmetryByLogValue.cpp
+++ b/Framework/Muon/src/PlotAsymmetryByLogValue.cpp
@@ -279,18 +279,8 @@ void PlotAsymmetryByLogValue::checkProperties(size_t &firstRunNumber, size_t &la
 
   // If file names empty, first and last provided so need to populate vector
   if (m_fileNames.empty()) {
-    populateFileNamesFromFirstLast(getProperty("FirstRun"), getProperty("LastRun"));
-  } else {
-    // Get directory of first file
-    const auto firstDir = getDirectoryFromFileName(m_fileNames[0]);
-
-    // Check all directories match
-    for (const auto &file : m_fileNames) {
-      if (firstDir != getDirectoryFromFileName(file)) {
-        // Error
-        throw std::runtime_error("All Files are not in the same directory (" + firstDir + ").");
-      }
-    }
+    populateFileNamesFromFirstLast(getProperty("FirstRun"),
+                                   getProperty("LastRun"));
   }
 
   // Extract run numbers for all runs and map to filenames

--- a/docs/source/release/v6.1.0/muon.rst
+++ b/docs/source/release/v6.1.0/muon.rst
@@ -37,6 +37,7 @@ Improvements
 ############
 - Exported workspaces now have history.
 - The interface saves previous settings if possible instead of resetting.
+- The interface can now load runs from different directories/cycles
 
 Bug fixes
 ##########

--- a/qt/scientific_interfaces/Muon/ALCDataLoadingPresenter.cpp
+++ b/qt/scientific_interfaces/Muon/ALCDataLoadingPresenter.cpp
@@ -348,19 +348,17 @@ void ALCDataLoadingPresenter::updateAvailableInfo() {
   m_numDetectors = ws->getInstrument()->getNumberDetectors();
 }
 
-std::string ALCDataLoadingPresenter::getPathFromFiles() {
-  std::string returnPath;
-  auto files = m_view->getFiles();
-  for (auto path : files) {
-    auto currentPath = path.substr(0, path.find_last_of("/\\"));
-    if (returnPath.empty())
-      returnPath = currentPath;
-    else if (currentPath != returnPath) {
-      returnPath = "Multiple Directories";
-      break; // End loop no need to check anymore
-    }
-  }
-  return returnPath;
+std::string ALCDataLoadingPresenter::getPathFromFiles() const {
+  const auto files = m_view->getFiles();
+  if (files.empty())
+    return "";
+  const auto firstDirectory = files[0u].substr(0u, files[0u].find_last_of("/\\"));
+  // Lambda to compare directories from a path
+  const auto hasSameDirectory = [&firstDirectory](const auto &path) {
+    return path.substr(0u, path.find_last_of("/\\")) == firstDirectory;
+  };
+  const auto sameDirectory = std::all_of(files.cbegin(), files.cend(), hasSameDirectory);
+  return sameDirectory ? firstDirectory : "Multiple Directories";
 }
 
 MatrixWorkspace_sptr ALCDataLoadingPresenter::exportWorkspace() {

--- a/qt/scientific_interfaces/Muon/ALCDataLoadingPresenter.cpp
+++ b/qt/scientific_interfaces/Muon/ALCDataLoadingPresenter.cpp
@@ -284,7 +284,8 @@ void ALCDataLoadingPresenter::updateAvailableInfo() {
     loadedWs = loadAlg->getProperty("OutputWorkspace");
     firstGoodData = loadAlg->getProperty("FirstGoodData");
     timeZero = loadAlg->getProperty("TimeZero");
-  } catch (const std::exception &error) {
+  }
+  catch (const std::exception &error) {
     m_view->setAvailableInfoToEmpty();
     throw std::runtime_error(error.what());
   }

--- a/qt/scientific_interfaces/Muon/ALCDataLoadingPresenter.cpp
+++ b/qt/scientific_interfaces/Muon/ALCDataLoadingPresenter.cpp
@@ -347,7 +347,7 @@ void ALCDataLoadingPresenter::updateAvailableInfo() {
   m_numDetectors = ws->getInstrument()->getNumberDetectors();
 }
 
-std::string ALCDataLoadingPresenter::getPathFromFiles() { 
+std::string ALCDataLoadingPresenter::getPathFromFiles() {
   std::string returnPath;
   auto files = m_view->getFiles();
   for (auto path : files) {

--- a/qt/scientific_interfaces/Muon/ALCDataLoadingPresenter.h
+++ b/qt/scientific_interfaces/Muon/ALCDataLoadingPresenter.h
@@ -92,6 +92,9 @@ private:
   /// Check the group is valid
   std::string isCustomGroupingValid(const std::string &group, bool &isValid);
 
+  /// Get path from files
+  std::string getPathFromFiles();
+
   /// View which the object works with
   IALCDataLoadingView *const m_view;
 

--- a/qt/scientific_interfaces/Muon/ALCDataLoadingPresenter.h
+++ b/qt/scientific_interfaces/Muon/ALCDataLoadingPresenter.h
@@ -93,7 +93,7 @@ private:
   std::string isCustomGroupingValid(const std::string &group, bool &isValid);
 
   /// Get path from files
-  std::string getPathFromFiles();
+  std::string getPathFromFiles() const;
 
   /// View which the object works with
   IALCDataLoadingView *const m_view;

--- a/qt/scientific_interfaces/Muon/ALCDataLoadingView.cpp
+++ b/qt/scientific_interfaces/Muon/ALCDataLoadingView.cpp
@@ -221,7 +221,12 @@ bool ALCDataLoadingView::setCurrentLog(const QString &log) {
  * Set list of available periods in both boxes
  * @param periods :: [input] List of periods
  */
-void ALCDataLoadingView::setAvailablePeriods(const std::vector<std::string> &periods) {
+void ALCDataLoadingView::setAvailablePeriods(
+    const std::vector<std::string> &periods) {
+  if (periods.size() == m_numPeriods)
+    return;
+  m_numPeriods = periods.size();
+
   setAvailableItems(m_ui.redPeriod, periods);
   setAvailableItems(m_ui.greenPeriod, periods);
 

--- a/qt/scientific_interfaces/Muon/ALCDataLoadingView.cpp
+++ b/qt/scientific_interfaces/Muon/ALCDataLoadingView.cpp
@@ -221,12 +221,7 @@ bool ALCDataLoadingView::setCurrentLog(const QString &log) {
  * Set list of available periods in both boxes
  * @param periods :: [input] List of periods
  */
-void ALCDataLoadingView::setAvailablePeriods(
-    const std::vector<std::string> &periods) {
-  if (periods.size() == m_numPeriods)
-    return;
-  m_numPeriods = periods.size();
-
+void ALCDataLoadingView::setAvailablePeriods(const std::vector<std::string> &periods) {
   setAvailableItems(m_ui.redPeriod, periods);
   setAvailableItems(m_ui.greenPeriod, periods);
 

--- a/qt/scientific_interfaces/Muon/test/ALCDataLoadingPresenterTest.h
+++ b/qt/scientific_interfaces/Muon/test/ALCDataLoadingPresenterTest.h
@@ -474,4 +474,26 @@ public:
 
     m_view->emitRunsEditingSignal();
   }
+
+  void test_get_path_from_files_multiple_directories() {
+    std::vector<std::string> files = {"path1/file.nxs", "path2/file.nxs"};
+    ON_CALL(*m_view, getFiles())
+        .WillByDefault(Return(files));
+    EXPECT_CALL(*m_view, setPath(std::string{"Multiple Directories"})).Times(1);
+    m_view->foundRuns();
+  }
+
+  void test_get_path_from_files_single_directory() {
+    std::vector<std::string> files = {"path/file1.nxs", "path/file2.nxs"};
+    ON_CALL(*m_view, getFiles()).WillByDefault(Return(files));
+    EXPECT_CALL(*m_view, setPath(std::string{"path"})).Times(1);
+    m_view->foundRuns();
+  }
+
+  void test_get_path_from_empty_files() {
+    std::vector<std::string> files = {};
+    ON_CALL(*m_view, getFiles()).WillByDefault(Return(files));
+    EXPECT_CALL(*m_view, setPath(std::string{""})).Times(1);
+    m_view->foundRuns();
+  }
 };

--- a/qt/scientific_interfaces/Muon/test/ALCDataLoadingPresenterTest.h
+++ b/qt/scientific_interfaces/Muon/test/ALCDataLoadingPresenterTest.h
@@ -477,8 +477,7 @@ public:
 
   void test_get_path_from_files_multiple_directories() {
     std::vector<std::string> files = {"path1/file.nxs", "path2/file.nxs"};
-    ON_CALL(*m_view, getFiles())
-        .WillByDefault(Return(files));
+    ON_CALL(*m_view, getFiles()).WillByDefault(Return(files));
     EXPECT_CALL(*m_view, setPath(std::string{"Multiple Directories"})).Times(1);
     m_view->foundRuns();
   }


### PR DESCRIPTION
**Description of work.**
Removed checks for same directory in PABLV. The work for displaying a warning instead of an error is low priority and so has been excluded from this pr given the amount of work required to make that work.

**To test:**
Open Muon ALC
Then try to load runs from different directories e.g. MUSR 15189, MUSR62260
It should say multiple directories now instead of using the first one
Everything should function as before

Fixes part of #30747 

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
