### PR TITLE
Fix absorption correction caching setting in reduction GUI

### DIFF
--- a/scripts/Interface/reduction_gui/reduction/diffraction/diffraction_adv_setup_script.py
+++ b/scripts/Interface/reduction_gui/reduction/diffraction/diffraction_adv_setup_script.py
@@ -83,7 +83,7 @@ class AdvancedSetupScript(BaseScriptElement):
     def cache_dir(self):
         """Passing all three candidates back as one list"""
         # A comma ',' is used here since it is the default delimiter in mantid
-        return self.cache_dir_scan_save + "," + self.cache_dir_scan_1 + "," + self.cache_dir_scan_2
+        return ",".join((self.cache_dir_scan_save, self.cache_dir_scan_1, self.cache_dir_scan_2))
 
     def __init__(self, inst_name):
         """ Initialization
@@ -195,7 +195,7 @@ class AdvancedSetupScript(BaseScriptElement):
                 # special map for bool type
                 value = '1' if value else '0'
             else:
-                value = str(value)
+                value = self.cache_dir.replace(",", ";") if keyname == "CacheDir" else str(value)
 
             xml += f"<{keyname.lower()}>{value}</{keyname.lower()}>\n"
         xml += "</AdvancedSetup>\n"
@@ -290,7 +290,7 @@ class AdvancedSetupScript(BaseScriptElement):
             # NOTE: there should only be three entries, if not, let it fail early
             try:
                 self.cache_dir_scan_save, self.cache_dir_scan_1, self.cache_dir_scan_2 = BaseScriptElement.getStringElement(
-                    instrument_dom, 'cachedir', default=",,").split(",")
+                    instrument_dom, 'cachedir', default=";;").split(";")
             except ValueError:
                 self.cache_dir_scan_save = ''
                 self.cache_dir_scan_1 = ''

--- a/scripts/Interface/reduction_gui/reduction/diffraction/diffraction_adv_setup_script.py
+++ b/scripts/Interface/reduction_gui/reduction/diffraction/diffraction_adv_setup_script.py
@@ -195,7 +195,7 @@ class AdvancedSetupScript(BaseScriptElement):
                 # special map for bool type
                 value = '1' if value else '0'
             else:
-                value = self.cache_dir.replace(",", ";") if keyname == "CacheDir" else str(value)
+                value = str(value)
 
             xml += f"<{keyname.lower()}>{value}</{keyname.lower()}>\n"
         xml += "</AdvancedSetup>\n"
@@ -290,7 +290,7 @@ class AdvancedSetupScript(BaseScriptElement):
             # NOTE: there should only be three entries, if not, let it fail early
             try:
                 self.cache_dir_scan_save, self.cache_dir_scan_1, self.cache_dir_scan_2 = BaseScriptElement.getStringElement(
-                    instrument_dom, 'cachedir', default=";;").split(";")
+                    instrument_dom, 'cachedir', default=";;").replace(";", ",").split(",")
             except ValueError:
                 self.cache_dir_scan_save = ''
                 self.cache_dir_scan_1 = ''

--- a/scripts/Interface/reduction_gui/reduction/diffraction/diffraction_adv_setup_script.py
+++ b/scripts/Interface/reduction_gui/reduction/diffraction/diffraction_adv_setup_script.py
@@ -83,7 +83,7 @@ class AdvancedSetupScript(BaseScriptElement):
     def cache_dir(self):
         """Passing all three candidates back as one list"""
         # A comma ',' is used here since it is the default delimiter in mantid
-        return ",".join(self.cache_dir_scan_save, self.cache_dir_scan_1, self.cache_dir_scan_2)
+        return self.cache_dir_scan_save + "," + self.cache_dir_scan_1 + "," + self.cache_dir_scan_2
 
     def __init__(self, inst_name):
         """ Initialization
@@ -179,7 +179,7 @@ class AdvancedSetupScript(BaseScriptElement):
         pardict["SampleNumberDensity"] = self.samplenumberdensity
         pardict["ContainerShape"] = self.containershape
         #Caching options
-        pardict['CacheDir'] = ";".join(self.cache_dir)
+        pardict['CacheDir'] = self.cache_dir
         pardict['CleanCache'] = str(int(self.clean_cache))
 
         return pardict
@@ -195,7 +195,7 @@ class AdvancedSetupScript(BaseScriptElement):
                 # special map for bool type
                 value = '1' if value else '0'
             else:
-                value = ";".join(self.cache_dir) if keyname == "CacheDir" else str(value)
+                value = str(value)
 
             xml += f"<{keyname.lower()}>{value}</{keyname.lower()}>\n"
         xml += "</AdvancedSetup>\n"
@@ -288,8 +288,13 @@ class AdvancedSetupScript(BaseScriptElement):
             # Caching options
             # split it into the three cache dirs
             # NOTE: there should only be three entries, if not, let it fail early
-            self.cache_dir_scan_save, self.cache_dir_scan_1, self.cache_dir_scan_2 = BaseScriptElement.getStringElement(
-                instrument_dom, 'cachedir', default=";;").split(";")
+            try:
+                self.cache_dir_scan_save, self.cache_dir_scan_1, self.cache_dir_scan_2 = BaseScriptElement.getStringElement(
+                    instrument_dom, 'cachedir', default=",,").split(",")
+            except ValueError:
+                self.cache_dir_scan_save = ''
+                self.cache_dir_scan_1 = ''
+                self.cache_dir_scan_2 = ''
 
             tempbool = BaseScriptElement.getStringElement(instrument_dom,
                                                           "cleancache",


### PR DESCRIPTION
**Description of work.**

Fixes the cache directory settings from being loaded and saved when using the Diffraction reduction GUI in Workbench.

**To test:**

- Load Workbench and open the Powder Diffraction Reduction GUI menu (Interfaces->Diffraction->Powder Diffraction Reduction).
- Open `/SNS/NOM/shared/User_story_test/PG3_US-137_Test/us_137_testing.xml`.
- Verify the cache directories are populated under "Caching Options" in Advanced Setup (second tab)
- Save the settings to a new file (File->Save As). Clear the setup by starting a new reduction (File->New Reduction). Load the new settings file that was just made and verify the directories are populated again in Advanced Setup.
- Click "Reduce" to make sure the reduction works with the cache directories.


*This does not require release notes* because it is an internal change to the existing gui.

<!-- Ensure the base of this PR is correct (e.g. release-next or master)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

Version into `ornl-next` #30996 

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
