### PR TITLE
PredictPeaks for LeanElasticPeaks and new HFIRCalculateGoniometer algorithm

### DIFF
--- a/Framework/Crystal/inc/MantidCrystal/PredictPeaks.h
+++ b/Framework/Crystal/inc/MantidCrystal/PredictPeaks.h
@@ -70,8 +70,7 @@ private:
   void calculateQAndAddToOutput(const Kernel::V3D &hkl, const Kernel::DblMatrix &orientedUB,
                                 const Kernel::DblMatrix &goniometerMatrix);
 
-  void calculateQAndAddToOutputLeanElastic(const Kernel::V3D &hkl, const Kernel::DblMatrix &UB,
-                                           const Kernel::DblMatrix &goniometerMatrix);
+  void calculateQAndAddToOutputLeanElastic(const Kernel::V3D &hkl, const Kernel::DblMatrix &UB);
 
 private:
   /// Get the predicted detector direction from Q

--- a/Framework/Crystal/inc/MantidCrystal/PredictPeaks.h
+++ b/Framework/Crystal/inc/MantidCrystal/PredictPeaks.h
@@ -70,9 +70,8 @@ private:
   void calculateQAndAddToOutput(const Kernel::V3D &hkl, const Kernel::DblMatrix &orientedUB,
                                 const Kernel::DblMatrix &goniometerMatrix);
 
-  void calculateQAndAddToOutputLeanElastic(const Kernel::V3D &hkl,
-					   const Kernel::DblMatrix &UB,
-					   const Kernel::DblMatrix &goniometerMatrix);
+  void calculateQAndAddToOutputLeanElastic(const Kernel::V3D &hkl, const Kernel::DblMatrix &UB,
+                                           const Kernel::DblMatrix &goniometerMatrix);
 
 private:
   /// Get the predicted detector direction from Q

--- a/Framework/Crystal/inc/MantidCrystal/PredictPeaks.h
+++ b/Framework/Crystal/inc/MantidCrystal/PredictPeaks.h
@@ -8,8 +8,8 @@
 
 #include "MantidAPI/Algorithm.h"
 #include "MantidAPI/DetectorSearcher.h"
+#include "MantidAPI/IPeaksWorkspace.h"
 #include "MantidCrystal/DllConfig.h"
-#include "MantidDataObjects/PeaksWorkspace.h"
 #include "MantidGeometry/Crystal/OrientedLattice.h"
 #include "MantidGeometry/Crystal/ReflectionCondition.h"
 #include "MantidGeometry/Crystal/StructureFactorCalculator.h"
@@ -62,7 +62,7 @@ private:
   void fillPossibleHKLsUsingGenerator(const Geometry::OrientedLattice &orientedLattice,
                                       std::vector<Kernel::V3D> &possibleHKLs) const;
 
-  void fillPossibleHKLsUsingPeaksWorkspace(const DataObjects::PeaksWorkspace_sptr &peaksWorkspace,
+  void fillPossibleHKLsUsingPeaksWorkspace(const API::IPeaksWorkspace_sptr &peaksWorkspace,
                                            std::vector<Kernel::V3D> &possibleHKLs) const;
 
   void setStructureFactorCalculatorFromSample(const API::Sample &sample);
@@ -93,7 +93,7 @@ private:
   /// Direction of the beam for this instrument
   Kernel::V3D m_refBeamDir;
   /// Output peaks workspace
-  Mantid::DataObjects::PeaksWorkspace_sptr m_pw;
+  Mantid::API::IPeaksWorkspace_sptr m_pw;
   Geometry::StructureFactorCalculator_sptr m_sfCalculator;
 
   double m_qConventionFactor;

--- a/Framework/Crystal/inc/MantidCrystal/PredictPeaks.h
+++ b/Framework/Crystal/inc/MantidCrystal/PredictPeaks.h
@@ -70,6 +70,10 @@ private:
   void calculateQAndAddToOutput(const Kernel::V3D &hkl, const Kernel::DblMatrix &orientedUB,
                                 const Kernel::DblMatrix &goniometerMatrix);
 
+  void calculateQAndAddToOutputLeanElastic(const Kernel::V3D &hkl,
+					   const Kernel::DblMatrix &UB,
+					   const Kernel::DblMatrix &goniometerMatrix);
+
 private:
   /// Get the predicted detector direction from Q
   std::tuple<Kernel::V3D, double> getPeakParametersFromQ(const Kernel::V3D &q) const;
@@ -95,6 +99,7 @@ private:
   /// Output peaks workspace
   Mantid::API::IPeaksWorkspace_sptr m_pw;
   Geometry::StructureFactorCalculator_sptr m_sfCalculator;
+  bool m_leanElasticPeak = false;
 
   double m_qConventionFactor;
 };

--- a/Framework/Crystal/src/PredictPeaks.cpp
+++ b/Framework/Crystal/src/PredictPeaks.cpp
@@ -242,10 +242,12 @@ void PredictPeaks::exec() {
     gonioVec.emplace_back(DblMatrix(3, 3, true));
   }
 
-  setInstrumentFromInputWorkspace(inputExperimentInfo);
-  setRunNumberFromInputWorkspace(inputExperimentInfo);
-  setReferenceFrameAndBeamDirection();
-  checkBeamDirection();
+  if (!(m_leanElasticPeak && !leanElasticPeak_calculate_wl)) {
+    setInstrumentFromInputWorkspace(inputExperimentInfo);
+    setRunNumberFromInputWorkspace(inputExperimentInfo);
+    setReferenceFrameAndBeamDirection();
+    checkBeamDirection();
+  }
 
   // Create the output
   if (m_leanElasticPeak) {
@@ -285,7 +287,8 @@ void PredictPeaks::exec() {
   Progress prog(this, 0.0, 1.0, possibleHKLs.size() * gonioVec.size());
   prog.setNotifyStep(0.01);
 
-  m_detectorCacheSearch = std::make_unique<DetectorSearcher>(m_inst, m_pw->detectorInfo());
+  if (!(m_leanElasticPeak && !leanElasticPeak_calculate_wl))
+    m_detectorCacheSearch = std::make_unique<DetectorSearcher>(m_inst, m_pw->detectorInfo());
 
   if (m_leanElasticPeak && !leanElasticPeak_calculate_wl) {
     Kernel::Matrix<double> identityGoniometer(3, 3, true);

--- a/Framework/Crystal/src/PredictPeaks.cpp
+++ b/Framework/Crystal/src/PredictPeaks.cpp
@@ -365,7 +365,8 @@ void PredictPeaks::exec() {
   // adjacent
   std::vector<std::pair<std::string, bool>> criteria;
   criteria.emplace_back("RunNumber", true);
-  criteria.emplace_back("BankName", true);
+  if (!m_leanElasticPeak)
+    criteria.emplace_back("BankName", true);
   m_pw->sort(criteria);
 
   for (int i = 0; i < static_cast<int>(m_pw->getNumberPeaks()); ++i) {

--- a/Framework/Crystal/src/PredictPeaks.cpp
+++ b/Framework/Crystal/src/PredictPeaks.cpp
@@ -142,14 +142,14 @@ void PredictPeaks::init() {
   setPropertySettings("ReflectionCondition", makeSet());
 
   std::vector<std::string> peakTypes = {"Peak", "LeanElasticPeak"};
-  declareProperty("OutputPeakType", "Peak", std::make_shared<StringListValidator>(peakTypes),
+  declareProperty("OutputType", "Peak", std::make_shared<StringListValidator>(peakTypes),
                   "Type of Peak in OutputWorkspace");
   declareProperty("CalculateWavelength", true,
-                  "When OutputPeakType is LeanElasticPeak you can choose to calculate the "
+                  "When OutputType is LeanElasticPeak you can choose to calculate the "
                   "wavelength of the peak using the instrument and check it is in the "
                   "valid range or alternatively just accept every peak and set the "
                   "goniometer.");
-  setPropertySettings("CalculateWavelength", std::make_unique<EnabledWhenProperty>("OutputPeakType", IS_NOT_DEFAULT));
+  setPropertySettings("CalculateWavelength", std::make_unique<EnabledWhenProperty>("OutputType", IS_NOT_DEFAULT));
 
   declareProperty(std::make_unique<WorkspaceProperty<IPeaksWorkspace>>("OutputWorkspace", "", Direction::Output),
                   "An output PeaksWorkspace.");
@@ -170,7 +170,7 @@ void PredictPeaks::exec() {
   // Get the input properties
   Workspace_sptr rawInputWorkspace = getProperty("InputWorkspace");
   m_edge = this->getProperty("EdgePixels");
-  m_leanElasticPeak = (getPropertyValue("OutputPeakType") == "LeanElasticPeak");
+  m_leanElasticPeak = (getPropertyValue("OutputType") == "LeanElasticPeak");
   bool leanElasticPeak_calculate_wl = getProperty("CalculateWavelength");
 
   ExperimentInfo_sptr inputExperimentInfo = std::dynamic_pointer_cast<ExperimentInfo>(rawInputWorkspace);

--- a/Framework/Crystal/src/PredictPeaks.cpp
+++ b/Framework/Crystal/src/PredictPeaks.cpp
@@ -291,11 +291,8 @@ void PredictPeaks::exec() {
     m_detectorCacheSearch = std::make_unique<DetectorSearcher>(m_inst, m_pw->detectorInfo());
 
   if (m_leanElasticPeak && !leanElasticPeak_calculate_wl) {
-    Kernel::Matrix<double> identityGoniometer(3, 3, true);
-    // identityGoniometer.identityMatrix();
-    // Geometry::Goniometer identityGoniometer();
     for (auto &possibleHKL : possibleHKLs) {
-      calculateQAndAddToOutputLeanElastic(possibleHKL, ub, identityGoniometer);
+      calculateQAndAddToOutputLeanElastic(possibleHKL, ub, gonioVec.front());
     }
   } else if (getProperty("CalculateGoniometerForCW")) {
     size_t allowedPeakCount = 0;

--- a/Framework/Crystal/test/PredictPeaksTest.h
+++ b/Framework/Crystal/test/PredictPeaksTest.h
@@ -283,10 +283,8 @@ public:
     std::string outWSName("PredictPeaksTest_OutputWS");
 
     // Make the fake input workspace
-    MatrixWorkspace_sptr inWS =
-        WorkspaceCreationHelper::create2DWorkspace(10000, 1);
-    Instrument_sptr inst =
-        ComponentCreationHelper::createTestInstrumentRectangular(1, 100);
+    MatrixWorkspace_sptr inWS = WorkspaceCreationHelper::create2DWorkspace(10000, 1);
+    Instrument_sptr inst = ComponentCreationHelper::createTestInstrumentRectangular(1, 100);
     inWS->setInstrument(inst);
 
     // Set ub and Goniometer rotation
@@ -296,24 +294,19 @@ public:
     PredictPeaks alg;
     TS_ASSERT_THROWS_NOTHING(alg.initialize())
     TS_ASSERT(alg.isInitialized())
-    TS_ASSERT_THROWS_NOTHING(alg.setProperty(
-        "InputWorkspace", std::dynamic_pointer_cast<Workspace>(inWS)));
-    TS_ASSERT_THROWS_NOTHING(
-        alg.setPropertyValue("OutputWorkspace", outWSName));
+    TS_ASSERT_THROWS_NOTHING(alg.setProperty("InputWorkspace", std::dynamic_pointer_cast<Workspace>(inWS)));
+    TS_ASSERT_THROWS_NOTHING(alg.setPropertyValue("OutputWorkspace", outWSName));
     TS_ASSERT_THROWS_NOTHING(alg.setProperty("CalculateGoniometerForCW", true));
     TS_ASSERT_THROWS_NOTHING(alg.setPropertyValue("Wavelength", "1.5"));
     TS_ASSERT_THROWS_NOTHING(alg.setPropertyValue("MinAngle", "0"));
     TS_ASSERT_THROWS_NOTHING(alg.setPropertyValue("MaxAngle", "5.0"));
-    TS_ASSERT_THROWS_NOTHING(
-        alg.setPropertyValue("OutputPeakType", "LeanElasticPeak"));
+    TS_ASSERT_THROWS_NOTHING(alg.setPropertyValue("OutputType", "LeanElasticPeak"));
     TS_ASSERT_THROWS_NOTHING(alg.execute(););
     TS_ASSERT(alg.isExecuted());
 
     // Retrieve the workspace from data service.
     LeanElasticPeaksWorkspace_sptr ws;
-    TS_ASSERT_THROWS_NOTHING(
-        ws = AnalysisDataService::Instance()
-                 .retrieveWS<LeanElasticPeaksWorkspace>(outWSName));
+    TS_ASSERT_THROWS_NOTHING(ws = AnalysisDataService::Instance().retrieveWS<LeanElasticPeaksWorkspace>(outWSName));
     TS_ASSERT(ws);
     if (!ws)
       return;
@@ -330,27 +323,21 @@ public:
 
   void test_exec_LeanElasticPeak_no_instrument() {
     auto inWS = WorkspaceFactory::Instance().createPeaks();
-    inWS->mutableSample().setOrientedLattice(
-        std::make_unique<OrientedLattice>(2., 2., 2., 90., 90., 90.));
+    inWS->mutableSample().setOrientedLattice(std::make_unique<OrientedLattice>(2., 2., 2., 90., 90., 90.));
     PredictPeaks alg;
     std::string outWSName("PredictPeaksTest_OutputWS");
     TS_ASSERT_THROWS_NOTHING(alg.initialize())
     TS_ASSERT(alg.isInitialized())
-    TS_ASSERT_THROWS_NOTHING(alg.setProperty(
-        "InputWorkspace", std::dynamic_pointer_cast<Workspace>(inWS)));
-    TS_ASSERT_THROWS_NOTHING(
-        alg.setPropertyValue("OutputWorkspace", outWSName));
-    TS_ASSERT_THROWS_NOTHING(
-        alg.setPropertyValue("OutputPeakType", "LeanElasticPeak"));
+    TS_ASSERT_THROWS_NOTHING(alg.setProperty("InputWorkspace", std::dynamic_pointer_cast<Workspace>(inWS)));
+    TS_ASSERT_THROWS_NOTHING(alg.setPropertyValue("OutputWorkspace", outWSName));
+    TS_ASSERT_THROWS_NOTHING(alg.setPropertyValue("OutputType", "LeanElasticPeak"));
     TS_ASSERT_THROWS_NOTHING(alg.setProperty("CalculateWavelength", false));
     TS_ASSERT_THROWS_NOTHING(alg.execute(););
     TS_ASSERT(alg.isExecuted());
 
     // Retrieve the workspace from data service.
     LeanElasticPeaksWorkspace_sptr ws;
-    TS_ASSERT_THROWS_NOTHING(
-        ws = AnalysisDataService::Instance()
-                 .retrieveWS<LeanElasticPeaksWorkspace>(outWSName));
+    TS_ASSERT_THROWS_NOTHING(ws = AnalysisDataService::Instance().retrieveWS<LeanElasticPeaksWorkspace>(outWSName));
     TS_ASSERT(ws);
     if (!ws)
       return;

--- a/Framework/Crystal/test/PredictPeaksTest.h
+++ b/Framework/Crystal/test/PredictPeaksTest.h
@@ -8,6 +8,7 @@
 
 #include "MantidAPI/Sample.h"
 #include "MantidCrystal/PredictPeaks.h"
+#include "MantidDataObjects/LeanElasticPeaksWorkspace.h"
 #include "MantidDataObjects/PeaksWorkspace.h"
 #include "MantidDataObjects/Workspace2D.h"
 #include "MantidGeometry/IDTypes.h"
@@ -271,6 +272,95 @@ public:
     AnalysisDataService::Instance().remove(outWSName);
 
     ConfigService::Instance().setString("Q.convention", origQConv);
+  }
+
+  void test_exec_with_CalculateGoniometerForCW_LeanElasticPeak() {
+    using Kernel::ConfigService;
+    auto origQConv = ConfigService::Instance().getString("Q.convention");
+    ConfigService::Instance().setString("Q.convention", "Crystallography");
+
+    // Name of the output workspace.
+    std::string outWSName("PredictPeaksTest_OutputWS");
+
+    // Make the fake input workspace
+    MatrixWorkspace_sptr inWS =
+        WorkspaceCreationHelper::create2DWorkspace(10000, 1);
+    Instrument_sptr inst =
+        ComponentCreationHelper::createTestInstrumentRectangular(1, 100);
+    inWS->setInstrument(inst);
+
+    // Set ub and Goniometer rotation
+    WorkspaceCreationHelper::setOrientedLattice(inWS, 12.0, 12.0, 12.0);
+    WorkspaceCreationHelper::setGoniometer(inWS, 0., 0., 0.);
+
+    PredictPeaks alg;
+    TS_ASSERT_THROWS_NOTHING(alg.initialize())
+    TS_ASSERT(alg.isInitialized())
+    TS_ASSERT_THROWS_NOTHING(alg.setProperty(
+        "InputWorkspace", std::dynamic_pointer_cast<Workspace>(inWS)));
+    TS_ASSERT_THROWS_NOTHING(
+        alg.setPropertyValue("OutputWorkspace", outWSName));
+    TS_ASSERT_THROWS_NOTHING(alg.setProperty("CalculateGoniometerForCW", true));
+    TS_ASSERT_THROWS_NOTHING(alg.setPropertyValue("Wavelength", "1.5"));
+    TS_ASSERT_THROWS_NOTHING(alg.setPropertyValue("MinAngle", "0"));
+    TS_ASSERT_THROWS_NOTHING(alg.setPropertyValue("MaxAngle", "5.0"));
+    TS_ASSERT_THROWS_NOTHING(
+        alg.setPropertyValue("OutputPeakType", "LeanElasticPeak"));
+    TS_ASSERT_THROWS_NOTHING(alg.execute(););
+    TS_ASSERT(alg.isExecuted());
+
+    // Retrieve the workspace from data service.
+    LeanElasticPeaksWorkspace_sptr ws;
+    TS_ASSERT_THROWS_NOTHING(
+        ws = AnalysisDataService::Instance()
+                 .retrieveWS<LeanElasticPeaksWorkspace>(outWSName));
+    TS_ASSERT(ws);
+    if (!ws)
+      return;
+
+    TS_ASSERT_EQUALS(ws->getNumberPeaks(), 1);
+    TS_ASSERT_EQUALS(ws->getPeak(0).getHKL(), V3D(1, 0, 0));
+    TS_ASSERT_DELTA(ws->getPeak(0).getWavelength(), 1.5, 1e-6);
+
+    // Remove workspace from the data service.
+    AnalysisDataService::Instance().remove(outWSName);
+
+    ConfigService::Instance().setString("Q.convention", origQConv);
+  }
+
+  void test_exec_LeanElasticPeak_no_instrument() {
+    auto inWS = WorkspaceFactory::Instance().createPeaks();
+    inWS->mutableSample().setOrientedLattice(
+        std::make_unique<OrientedLattice>(2., 2., 2., 90., 90., 90.));
+    PredictPeaks alg;
+    std::string outWSName("PredictPeaksTest_OutputWS");
+    TS_ASSERT_THROWS_NOTHING(alg.initialize())
+    TS_ASSERT(alg.isInitialized())
+    TS_ASSERT_THROWS_NOTHING(alg.setProperty(
+        "InputWorkspace", std::dynamic_pointer_cast<Workspace>(inWS)));
+    TS_ASSERT_THROWS_NOTHING(
+        alg.setPropertyValue("OutputWorkspace", outWSName));
+    TS_ASSERT_THROWS_NOTHING(
+        alg.setPropertyValue("OutputPeakType", "LeanElasticPeak"));
+    TS_ASSERT_THROWS_NOTHING(alg.setProperty("CalculateWavelength", false));
+    TS_ASSERT_THROWS_NOTHING(alg.execute(););
+    TS_ASSERT(alg.isExecuted());
+
+    // Retrieve the workspace from data service.
+    LeanElasticPeaksWorkspace_sptr ws;
+    TS_ASSERT_THROWS_NOTHING(
+        ws = AnalysisDataService::Instance()
+                 .retrieveWS<LeanElasticPeaksWorkspace>(outWSName));
+    TS_ASSERT(ws);
+    if (!ws)
+      return;
+
+    TS_ASSERT_EQUALS(ws->getNumberPeaks(), 32);
+    TS_ASSERT_EQUALS(ws->getPeak(0).getHKL(), V3D(-2, 0, 0));
+    TS_ASSERT_EQUALS(ws->getPeak(31).getHKL(), V3D(2, 0, 0));
+
+    // Remove workspace from the data service.
+    AnalysisDataService::Instance().remove(outWSName);
   }
 };
 

--- a/Framework/DataObjects/inc/MantidDataObjects/LeanElasticPeak.h
+++ b/Framework/DataObjects/inc/MantidDataObjects/LeanElasticPeak.h
@@ -33,7 +33,7 @@ public:
   LeanElasticPeak();
   LeanElasticPeak(const Mantid::Kernel::V3D &QSampleFrame);
   LeanElasticPeak(const Mantid::Kernel::V3D &QSampleFrame, const Mantid::Kernel::Matrix<double> &goniometer,
-                  boost::optional<std::shared_ptr<Geometry::ReferenceFrame>> refFrame = boost::none);
+                  boost::optional<std::shared_ptr<const Geometry::ReferenceFrame>> refFrame = boost::none);
   LeanElasticPeak(const Mantid::Kernel::V3D &QSampleFrame, double wavelength);
 
   /// Copy constructor
@@ -84,7 +84,7 @@ public:
   LeanElasticPeak &operator=(const LeanElasticPeak &other);
 
 private:
-  void setReferenceFrame(std::shared_ptr<Geometry::ReferenceFrame> frame);
+  void setReferenceFrame(std::shared_ptr<const Geometry::ReferenceFrame> frame);
 
   /// Q_sample vector
   Mantid::Kernel::V3D m_Qsample;
@@ -92,7 +92,7 @@ private:
   /// Wavelength of neutrons at the peak
   double m_wavelength;
 
-  std::shared_ptr<Geometry::ReferenceFrame> m_refFrame;
+  std::shared_ptr<const Geometry::ReferenceFrame> m_refFrame;
 
   /// Static logger
   static Mantid::Kernel::Logger g_log;

--- a/Framework/DataObjects/src/LeanElasticPeak.cpp
+++ b/Framework/DataObjects/src/LeanElasticPeak.cpp
@@ -170,7 +170,8 @@ void LeanElasticPeak::setQSampleFrame(const Mantid::Kernel::V3D &QSampleFrame,
     double wl = calculateWavelengthFromQLab(qLab);
     setWavelength(wl);
   } catch (std::exception &e) {
-    g_log.warning() << "Unable to determine wavelength from q-lab\n" << e.what() << '\n';
+    g_log.information() << "Unable to automatically determine wavelength from q-lab\n"
+                        << e.what() << ", goniometer is likely not correct\n";
   }
 }
 

--- a/Framework/DataObjects/src/LeanElasticPeak.cpp
+++ b/Framework/DataObjects/src/LeanElasticPeak.cpp
@@ -51,7 +51,7 @@ LeanElasticPeak::LeanElasticPeak(const Mantid::Kernel::V3D &QSampleFrame)
  */
 LeanElasticPeak::LeanElasticPeak(const Mantid::Kernel::V3D &QSampleFrame,
                                  const Mantid::Kernel::Matrix<double> &goniometer,
-                                 boost::optional<std::shared_ptr<Geometry::ReferenceFrame>> refFrame)
+                                 boost::optional<std::shared_ptr<const Geometry::ReferenceFrame>> refFrame)
     : BasePeak() {
   if (refFrame.is_initialized())
     setReferenceFrame(refFrame.get());
@@ -99,7 +99,7 @@ std::shared_ptr<const Geometry::ReferenceFrame> LeanElasticPeak::getReferenceFra
 Setter for the reference frame.
 @param frame : reference frame object to use.
 */
-void LeanElasticPeak::setReferenceFrame(std::shared_ptr<ReferenceFrame> frame) { m_refFrame = std::move(frame); }
+void LeanElasticPeak::setReferenceFrame(std::shared_ptr<const ReferenceFrame> frame) { m_refFrame = std::move(frame); }
 
 // -------------------------------------------------------------------------------------
 /** Return the neutron wavelength (in angstroms) */

--- a/Framework/DataObjects/test/LeanElasticPeakTest.h
+++ b/Framework/DataObjects/test/LeanElasticPeakTest.h
@@ -100,8 +100,8 @@ public:
 
     // different reference frame should cause different wavelength to be
     // calculated
-    auto refFrame =
-        std::make_shared<ReferenceFrame>(Mantid::Geometry::Y /*up*/, Mantid::Geometry::X /*along*/, Left, "0,0,0");
+    auto refFrame = std::make_shared<const ReferenceFrame>(Mantid::Geometry::Y /*up*/, Mantid::Geometry::X /*along*/,
+                                                           Left, "0,0,0");
 
     LeanElasticPeak p(V3D(1, 2, 3), gon, refFrame);
 

--- a/Framework/MDAlgorithms/src/ConvertHFIRSCDtoMDE.cpp
+++ b/Framework/MDAlgorithms/src/ConvertHFIRSCDtoMDE.cpp
@@ -235,6 +235,12 @@ void ConvertHFIRSCDtoMDE::exec() {
 
   outputWS->refreshCache();
   outputWS->copyExperimentInfos(*inputWS);
+  auto &outRun = outputWS->getExperimentInfo(0)->mutableRun();
+  if (outRun.hasProperty("wavelength")) {
+    outRun.removeLogData("wavelength");
+  }
+  outRun.addLogData(new PropertyWithValue<double>("wavelength", wavelength));
+  outRun.getProperty("wavelength")->setUnits("Angstrom");
 
   auto user_convention = Kernel::ConfigService::Instance().getString("Q.convention");
   auto ws_convention = outputWS->getConvention();

--- a/Framework/PythonInterface/mantid/geometry/src/Exports/Goniometer.cpp
+++ b/Framework/PythonInterface/mantid/geometry/src/Exports/Goniometer.cpp
@@ -34,6 +34,12 @@ GNU_DIAG_ON("unused-local-typedef")
 
 /// Set the U vector via a numpy array
 void setR(Goniometer &self, const object &data) { self.setR(Converters::PyObjectToMatrix(data)()); }
+
+/// calc goniometer with V3D sample position input
+void calcFromQSampleAndWavelength(Goniometer &self, const object &position, double wavelength, bool flip_x,
+                                  bool inner) {
+  self.calcFromQSampleAndWavelength(Converters::PyObjectToV3D(position)(), wavelength, flip_x, inner);
+}
 } // namespace
 
 void export_Goniometer() {
@@ -48,5 +54,7 @@ void export_Goniometer() {
            getEulerAngles_overloads(args("self", "convention"), "Default convention is \'YZX\'. Universal "
                                                                 "goniometer is \'YZY\'"))
       .def("getR", &Goniometer::getR, arg("self"), return_readonly_numpy())
-      .def("setR", &setR, (arg("self"), arg("rot")));
+      .def("setR", &setR, (arg("self"), arg("rot")))
+      .def("calcFromQSampleAndWavelength", &calcFromQSampleAndWavelength,
+           (arg("self"), arg("positions"), arg("wavelength"), arg("flip_x") = false, arg("inner") = false));
 }

--- a/Framework/PythonInterface/plugins/CMakeLists.txt
+++ b/Framework/PythonInterface/plugins/CMakeLists.txt
@@ -81,6 +81,7 @@ set(PYTHON_PLUGINS
     algorithms/HB3AFindPeaks.py
     algorithms/HB3AIntegratePeaks.py
     algorithms/HB3APredictPeaks.py
+    algorithms/HFIRCalculateGoniometer.py
     algorithms/HFIRSANS2Wavelength.py
     algorithms/IndexSatellitePeaks.py
     algorithms/IndirectTransmission.py

--- a/Framework/PythonInterface/plugins/algorithms/ConvertWANDSCDtoQ.py
+++ b/Framework/PythonInterface/plugins/algorithms/ConvertWANDSCDtoQ.py
@@ -355,6 +355,7 @@ class ConvertWANDSCDtoQ(PythonAlgorithm):
 
         outWS.getExperimentInfo(0).run().addProperty('RUBW_MATRIX', list(UBW.flatten()), True)
         outWS.getExperimentInfo(0).run().addProperty('W_MATRIX', list(W.flatten()), True)
+        outWS.getExperimentInfo(0).run().addProperty('wavelength', self.getProperty("Wavelength").value, True)
         try:
             if outWS.getExperimentInfo(0).sample().hasOrientedLattice():
                 outWS.getExperimentInfo(0).sample().getOrientedLattice().setUB(UB)

--- a/Framework/PythonInterface/plugins/algorithms/HFIRCalculateGoniometer.py
+++ b/Framework/PythonInterface/plugins/algorithms/HFIRCalculateGoniometer.py
@@ -27,7 +27,7 @@ class HFIRCalculateGoniometer(PythonAlgorithm):
         return "HFIRCalculateGoniometer"
 
     def seeAlso(self):
-        return ["FindPeaksMD", "PredictPeaks"]
+        return ["FindPeaksMD", "PredictPeaks", 'SetGoniometer']
 
     def PyInit(self):
         self.declareProperty(IPeaksWorkspaceProperty('Workspace', '', direction=Direction.InOut),
@@ -66,10 +66,12 @@ class HFIRCalculateGoniometer(PythonAlgorithm):
             else:
                 inner = False
 
+        starting_goniometer = peaks.run().getGoniometer().getR()
+
         for n in range(peaks.getNumberPeaks()):
             p = peaks.getPeak(n)
             g = Goniometer()
-            g.setR(p.getGoniometerMatrix())
+            g.setR(starting_goniometer)
             g.calcFromQSampleAndWavelength(V3D(*p.getQSampleFrame()), wavelength, flip_x, inner)
             logger.information("Found goniometer omega={:.2f} chi={:.2f} phi={:.2f} for peak {} with Q_sample {}"
                                .format(*g.getEulerAngles('YZY'), n, p.getQSampleFrame()))

--- a/Framework/PythonInterface/plugins/algorithms/HFIRCalculateGoniometer.py
+++ b/Framework/PythonInterface/plugins/algorithms/HFIRCalculateGoniometer.py
@@ -1,0 +1,80 @@
+# Mantid Repository : https://github.com/mantidproject/mantid
+#
+# Copyright &copy; 2020 ISIS Rutherford Appleton Laboratory UKRI,
+#   NScD Oak Ridge National Laboratory, European Spallation Source,
+#   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+# SPDX - License - Identifier: GPL - 3.0 +
+
+import math
+from mantid.api import AlgorithmFactory, PythonAlgorithm, IPeaksWorkspaceProperty
+from mantid.kernel import Direction, Property, V3D, FloatBoundedValidator, VisibleWhenProperty, PropertyCriterion
+from mantid.geometry import Goniometer
+from mantid import logger
+
+
+class HFIRCalculateGoniometer(PythonAlgorithm):
+    def category(self):
+        return 'Diffraction\\Reduction'
+
+    def summary(self):
+        """
+        summary of the algorithm
+        :return:
+        """
+        return "Calculate the goniometer for peak making an assumption for constant wavelength and goniometer rotation axes"
+
+    def name(self):
+        return "HFIRCalculateGoniometer"
+
+    def seeAlso(self):
+        return ["FindPeaksMD", "PredictPeaks"]
+
+    def PyInit(self):
+        self.declareProperty(IPeaksWorkspaceProperty('Workspace', '', direction=Direction.InOut),
+                             doc='Peaks Workspace to be modified')
+        self.declareProperty("Wavelength", Property.EMPTY_DBL, validator=FloatBoundedValidator(0.0),
+                             doc="Wavelength to set the workspace, will be the value set on workspace if not provided.")
+        self.declareProperty("OverrideProperty", False,
+                             "If False then the value for InnerGoniometer and FlipX will be determiend from the workspace, "
+                             "it True then the properties will be used")
+        condition = VisibleWhenProperty("OverrideProperty", PropertyCriterion.IsNotDefault)
+
+        self.declareProperty("InnerGoniometer", False,
+                             "Whether the goniometer to be calculated is the most inner (phi) or most outer (omega)")
+        self.setPropertySettings("InnerGoniometer", condition)
+        self.declareProperty("FlipX", False,
+                             "Used when calculating goniometer angle if the q_lab x value should be negative, "
+                             "hence the detector of the other side (right) of the beam")
+        self.setPropertySettings("FlipX", condition)
+
+    def PyExec(self):
+
+        peaks = self.getProperty('Workspace').value
+
+        wavelength = self.getProperty("Wavelength").value
+        if wavelength == Property.EMPTY_DBL:
+            wavelength = peaks.run()['wavelength'].value
+
+        if self.getProperty("OverrideProperty").value:
+            flip_x = self.getProperty("FlipX").value
+            inner = self.getProperty("InnerGoniometer").value
+        else:
+            flip_x = peaks.getInstrument().getName() == "HB3A"
+
+            if peaks.getInstrument().getName() == "HB3A":
+                inner = math.isclose(peaks.run().getTimeAveragedStd("omega"), 0.0)
+            else:
+                inner = False
+
+        for n in range(peaks.getNumberPeaks()):
+            p = peaks.getPeak(n)
+            g = Goniometer()
+            g.setR(p.getGoniometerMatrix())
+            g.calcFromQSampleAndWavelength(V3D(*p.getQSampleFrame()), wavelength, flip_x, inner)
+            logger.information("Found goniometer omega={:.2f} chi={:.2f} phi={:.2f} for peak {} with Q_sample {}"
+                               .format(*g.getEulerAngles('YZY'), n, p.getQSampleFrame()))
+            p.setWavelength(wavelength)
+            p.setGoniometerMatrix(g.getR())
+
+
+AlgorithmFactory.subscribe(HFIRCalculateGoniometer)

--- a/Framework/PythonInterface/test/python/plugins/algorithms/CMakeLists.txt
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/CMakeLists.txt
@@ -52,6 +52,7 @@ set(TEST_PY_FILES
     HB3AFindPeaksTest.py
     HB3AIntegratePeaksTest.py
     HB3APredictPeaksTest.py
+    HFIRCalculateGoniometerTest.py
     HFIRSANS2WavelengthTest.py
     IndirectTransmissionTest.py
     IndexSatellitePeaksTest.py

--- a/Framework/PythonInterface/test/python/plugins/algorithms/HFIRCalculateGoniometerTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/HFIRCalculateGoniometerTest.py
@@ -75,8 +75,9 @@ class HFIRCalculateGoniometerTest(unittest.TestCase):
         peaks = CreatePeaksWorkspace(OutputType="LeanElasticPeak", NumberOfPeaks=0)
 
         p = peaks.createPeakQSample(q_sample)
-        p.setGoniometerMatrix(np.dot(R2, R3)) # don't set omega
         peaks.addPeak(p)
+
+        SetGoniometer(Workspace=peaks, Axis0='-3,0,0,1,-1', Axis1='23,0,1,0,-1') # don't set omega
 
         HFIRCalculateGoniometer(peaks, wl)
 
@@ -117,7 +118,7 @@ class HFIRCalculateGoniometerTest(unittest.TestCase):
 
         peaks = CreatePeaksWorkspace(OutputType="LeanElasticPeak", NumberOfPeaks=0)
         AddSampleLog(peaks, "Wavelength", str(wl), "Number")
-        SetGoniometer(peaks, Axis0='42,0,1,0,-1', Axis1='-3,0,0,1,-1')
+        SetGoniometer(peaks, Axis0='42,0,1,0,-1', Axis1='-3,0,0,1,-1') # don't set phi
 
         p = peaks.createPeakQSample(q_sample)
         peaks.addPeak(p)

--- a/Framework/PythonInterface/test/python/plugins/algorithms/HFIRCalculateGoniometerTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/HFIRCalculateGoniometerTest.py
@@ -1,0 +1,138 @@
+# Mantid Repository : https://github.com/mantidproject/mantid
+#
+# Copyright &copy; 2020 ISIS Rutherford Appleton Laboratory UKRI,
+#   NScD Oak Ridge National Laboratory, European Spallation Source,
+#   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+# SPDX - License - Identifier: GPL - 3.0 +
+import unittest
+import numpy as np
+from mantid.simpleapi import HFIRCalculateGoniometer, CreatePeaksWorkspace, AddSampleLog, SetGoniometer
+from mantid.geometry import Goniometer
+
+
+class HFIRCalculateGoniometerTest(unittest.TestCase):
+
+    def test_HFIRCalculateGoniometer_HB2C_omega(self):
+        omega = np.deg2rad(42)
+
+        R = np.array([[np.cos(omega), 0, np.sin(omega)],
+                      [0, 1, 0],
+                      [-np.sin(omega), 0, np.cos(omega)]])
+
+        wl = 1.54
+        k = 2*np.pi/wl
+        theta = np.deg2rad(47)
+        phi = np.deg2rad(13)
+
+        q_lab = np.array([-np.sin(theta)*np.cos(phi),
+                          -np.sin(theta)*np.sin(phi),
+                          1 - np.cos(theta)]) * k
+
+        q_sample = np.dot(np.linalg.inv(R), q_lab)
+
+        peaks = CreatePeaksWorkspace(OutputType="LeanElasticPeak", NumberOfPeaks=0)
+
+        p = peaks.createPeakQSample(q_sample)
+        peaks.addPeak(p)
+
+        HFIRCalculateGoniometer(peaks, wl)
+
+        g = Goniometer()
+        g.setR(peaks.getPeak(0).getGoniometerMatrix())
+        YZY = g.getEulerAngles('YZY')
+        self.assertAlmostEqual(YZY[0], 42, delta=1e-10) # omega
+        self.assertAlmostEqual(YZY[1], 0, delta=1e-10) # chi
+        self.assertAlmostEqual(YZY[2], 0, delta=1e-10) # phi
+
+        self.assertAlmostEqual(peaks.getPeak(0).getWavelength(), 1.54, delta=1e-10)
+
+    def test_HFIRCalculateGoniometer_HB3A_omega(self):
+        omega = np.deg2rad(42)
+        chi = np.deg2rad(-3)
+        phi = np.deg2rad(23)
+        R1 = np.array([[np.cos(omega), 0, -np.sin(omega)], # omega 0,1,0,-1
+                       [               0, 1,                 0],
+                       [np.sin(omega), 0,  np.cos(omega)]])
+        R2 = np.array([[ np.cos(chi),  np.sin(chi), 0], # chi 0,0,1,-1
+                       [-np.sin(chi),  np.cos(chi), 0],
+                       [              0,               0, 1]])
+        R3 = np.array([[np.cos(phi), 0, -np.sin(phi)], # phi 0,1,0,-1
+                       [             0, 1,               0],
+                       [np.sin(phi), 0,  np.cos(phi)]])
+        R = np.dot(np.dot(R1, R2), R3)
+
+        wl = 1.54
+        k = 2*np.pi/wl
+        theta = np.deg2rad(47)
+        phi = np.deg2rad(13)
+
+        q_lab = np.array([-np.sin(theta)*np.cos(phi),
+                          -np.sin(theta)*np.sin(phi),
+                          1 - np.cos(theta)]) * k
+
+        q_sample = np.dot(np.linalg.inv(R), q_lab)
+
+        peaks = CreatePeaksWorkspace(OutputType="LeanElasticPeak", NumberOfPeaks=0)
+
+        p = peaks.createPeakQSample(q_sample)
+        p.setGoniometerMatrix(np.dot(R2, R3)) # don't set omega
+        peaks.addPeak(p)
+
+        HFIRCalculateGoniometer(peaks, wl)
+
+        g = Goniometer()
+        g.setR(peaks.getPeak(0).getGoniometerMatrix())
+        YZY = g.getEulerAngles('YZY')
+        self.assertAlmostEqual(YZY[0], -42, delta=1e-10) # omega
+        self.assertAlmostEqual(YZY[1], 3, delta=1e-10) # chi
+        self.assertAlmostEqual(YZY[2], -23, delta=1e-10) # phi
+
+        self.assertAlmostEqual(peaks.getPeak(0).getWavelength(), 1.54, delta=1e-10)
+
+    def test_HFIRCalculateGoniometer_HB3A_phi(self):
+        omega = np.deg2rad(42)
+        chi = np.deg2rad(-3)
+        phi = np.deg2rad(23)
+        R1 = np.array([[np.cos(omega), 0, -np.sin(omega)], # omega 0,1,0,-1
+                       [               0, 1,                 0],
+                       [np.sin(omega), 0,  np.cos(omega)]])
+        R2 = np.array([[ np.cos(chi),  np.sin(chi), 0], # chi 0,0,1,-1
+                       [-np.sin(chi),  np.cos(chi), 0],
+                       [              0,               0, 1]])
+        R3 = np.array([[np.cos(phi), 0, -np.sin(phi)], # phi 0,1,0,-1
+                       [             0, 1,               0],
+                       [np.sin(phi), 0,  np.cos(phi)]])
+        R = np.dot(np.dot(R1, R2), R3)
+
+        wl = 1.54
+        k = 2*np.pi/wl
+        theta = np.deg2rad(47)
+        phi = np.deg2rad(13)
+
+        q_lab = np.array([-np.sin(theta)*np.cos(phi),
+                          -np.sin(theta)*np.sin(phi),
+                          1 - np.cos(theta)]) * k
+
+        q_sample = np.dot(np.linalg.inv(R), q_lab)
+
+        peaks = CreatePeaksWorkspace(OutputType="LeanElasticPeak", NumberOfPeaks=0)
+        AddSampleLog(peaks, "Wavelength", str(wl), "Number")
+        SetGoniometer(peaks, Axis0='42,0,1,0,-1', Axis1='-3,0,0,1,-1')
+
+        p = peaks.createPeakQSample(q_sample)
+        peaks.addPeak(p)
+
+        HFIRCalculateGoniometer(peaks, OverrideProperty=True, InnerGoniometer=True)
+
+        g = Goniometer()
+        g.setR(peaks.getPeak(0).getGoniometerMatrix())
+        YZY = g.getEulerAngles('YZY')
+        self.assertAlmostEqual(YZY[0], -42, delta=1e-10) # omega
+        self.assertAlmostEqual(YZY[1], 3, delta=1e-10) # chi
+        self.assertAlmostEqual(YZY[2], -23, delta=1e-1) # phi
+
+        self.assertAlmostEqual(peaks.getPeak(0).getWavelength(), 1.54, delta=1e-10)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/Testing/SystemTests/tests/framework/ConvertHFIRSCDtoMDETest.py
+++ b/Testing/SystemTests/tests/framework/ConvertHFIRSCDtoMDETest.py
@@ -57,6 +57,12 @@ class ConvertHFIRSCDtoMDETest(systemtesting.MantidSystemTest):
                                        atol=0.005,
                                        err_msg=f"mismatch for peak {p}")
 
+        HFIRCalculateGoniometer(ConvertHFIRSCDtoMDETest_peaks3)
+        peak0 = ConvertHFIRSCDtoMDETest_peaks3.getPeak(0)
+        self.assertDelta(peak0.getWavelength(), 1.488, 1e-8)
+        g=peak0.getGoniometerMatrix()
+        self.assertDelta(np.rad2deg(np.arccos(g[0][0])), 77.5, 1e-2)
+
 
 class ConvertHFIRSCDtoMDE_HB3A_Test(systemtesting.MantidSystemTest):
     def requiredMemoryMB(self):

--- a/Testing/SystemTests/tests/framework/PredictPeaksTest.py
+++ b/Testing/SystemTests/tests/framework/PredictPeaksTest.py
@@ -7,7 +7,7 @@
 # pylint: disable=no-init,too-few-public-methods
 import systemtesting
 from mantid.simpleapi import *
-from mantid.geometry import CrystalStructure
+from mantid.geometry import CrystalStructure, Goniometer
 
 
 # The reference data for these tests were created with PredictPeaks in the state at Release 3.5,
@@ -172,3 +172,22 @@ class PredictPeaksTestDEMAND(systemtesting.MantidSystemTest):
         self.assertDelta(q_sample[0], 4.45541, 1e-5)
         self.assertDelta(q_sample[1], -0.420383, 1e-5)
         self.assertDelta(q_sample[2], 0.0913072, 1e-5)
+
+        g = Goniometer()
+        g.setR(peak0.getGoniometerMatrix())
+        YZY = g.getEulerAngles('YZY')
+        self.assertDelta(YZY[0], -20.4997, 1e-7)
+        self.assertDelta(YZY[1], 0.0003, 1e-7)
+        self.assertDelta(YZY[2], 90, 1e-7)
+        self.assertDelta(peak0.getWavelength(), 0, 1e-9)
+
+        HFIRCalculateGoniometer(filtered_peaks)
+
+        peak0 = filtered_peaks.getPeak(0)
+        g = Goniometer()
+        g.setR(peak0.getGoniometerMatrix())
+        YZY = g.getEulerAngles('YZY')
+        self.assertDelta(YZY[0], -20.4997, 1e-7)
+        self.assertDelta(YZY[1], 0.0003, 1e-7)
+        self.assertDelta(YZY[2], 0.5340761720854811, 1e-7)
+        self.assertDelta(peak0.getWavelength(), 1.008, 1e-9)

--- a/Testing/SystemTests/tests/framework/PredictPeaksTest.py
+++ b/Testing/SystemTests/tests/framework/PredictPeaksTest.py
@@ -176,9 +176,9 @@ class PredictPeaksTestDEMAND(systemtesting.MantidSystemTest):
         g = Goniometer()
         g.setR(peak0.getGoniometerMatrix())
         YZY = g.getEulerAngles('YZY')
-        self.assertDelta(YZY[0], -20.4997, 1e-7)
-        self.assertDelta(YZY[1], 0.0003, 1e-7)
-        self.assertDelta(YZY[2], 90, 1e-7)
+        self.assertDelta(YZY[0], 0, 1e-7)
+        self.assertDelta(YZY[1], 0, 1e-7)
+        self.assertDelta(YZY[2], 0, 1e-7)
         self.assertDelta(peak0.getWavelength(), 0, 1e-9)
 
         HFIRCalculateGoniometer(filtered_peaks)

--- a/Testing/SystemTests/tests/framework/PredictPeaksTest.py
+++ b/Testing/SystemTests/tests/framework/PredictPeaksTest.py
@@ -80,7 +80,7 @@ class PredictPeaksTestTOPAZ(systemtesting.MantidSystemTest):
         leanelasticpeaks = PredictPeaks(simulationWorkspace,
                                         WavelengthMin=0.5, WavelengthMax=6,
                                         MinDSpacing=0.5, MaxDSpacing=10,
-                                        OutputPeakType='LeanElasticPeak')
+                                        OutputType='LeanElasticPeak')
         self.assertEqual(peaks.getNumberPeaks(), leanelasticpeaks.getNumberPeaks())
         # sorting is different, just compare peak [1, 0, 2]
         peak102 = peaks.getPeak(117)
@@ -155,7 +155,7 @@ class PredictPeaksTestDEMAND(systemtesting.MantidSystemTest):
         # test predicting with LeanElasticPeak, filter any peak with 0 intensity
         PredictPeaks("data",
                      ReflectionCondition='B-face centred',
-                     OutputPeakType='LeanElasticPeak',
+                     OutputType='LeanElasticPeak',
                      CalculateWavelength=False,
                      OutputWorkspace="leanelasticpeaks")
 

--- a/docs/source/algorithms/HFIRCalculateGoniometer-v1.rst
+++ b/docs/source/algorithms/HFIRCalculateGoniometer-v1.rst
@@ -1,0 +1,107 @@
+.. algorithm::
+
+.. summary::
+
+.. relatedalgorithms::
+
+.. properties::
+
+Description
+-----------
+
+This algorithm calculates the goniometer of peaks from the q_sample
+and wavelength. It makes use of the
+:meth:`mantid.geometry.Goniometer.calcFromQSampleAndWavelength`
+method.
+
+The wavelength will be read from the workspace property `wavelength`
+unless one is provided as input.
+
+The goniometer is calculated by the following method. It only works
+for a constant wavelength source. It also assumes the goniometer
+rotation is around the y-axis only.
+
+You can specify if the goniometer to calculated is omega or phi, outer
+or inner respectively, by setting the option InnerGoniometer. The
+existing goniometer on the peak will then be taken into account
+correctly.
+
+The goniometer (:math:`G`) is calculated from
+:math:`\textbf{Q}_{sample}` for a given wavelength (:math:`\lambda`)
+by:
+
+First calculate the :math:`\textbf{Q}_{lab}` using
+:math:`\textbf{Q}_{sample}` and :math:`\lambda`.
+
+.. math:: k = \frac{2 \pi}{\lambda}
+
+.. math:: G \textbf{Q}_{sample} = \textbf{Q}_{lab} = \left(\begin{array}{c}
+          -k\sin(\theta)\cos(\phi) \\
+          -k\sin(\theta)\sin(\phi) \\
+          k (1-\cos(\theta))
+          \end{array}\right) (1)
+
+.. math:: |\textbf{Q}_{sample}|^2 = |\textbf{Q}_{lab}|^2 = 2 k^2 (1-\cos(\theta))
+
+:math:`\therefore`
+
+.. math:: \theta = \cos^{-1}(1-\frac{|\textbf{Q}_{sample}|^2}{2k^2})
+
+.. math:: \phi = \sin^{-1}(-\frac{\textbf{Q}_{sample}^y}{k \sin(\theta)})
+
+where :math:`\theta` is from 0 to :math:`\pi` and :math:`\phi` is from
+:math:`-\pi/2` to :math:`\pi/2`. This means that it will assume your
+detector position is on the left of the beam even it it's not, unless
+the option FlipX is set to True then the :math:`\textbf{Q}_{lab}^x = -\textbf{Q}_{lab}^x`.
+
+Now you have :math:`\theta`, :math:`\phi` and k you can get :math:`\textbf{Q}_{lab}` using (1).
+
+We need to now solve :math:`G \textbf{Q}_{sample} =
+\textbf{Q}_{lab}`. For a rotation around y-axis only we want to find
+:math:`\psi` for:
+
+.. math:: G = \begin{bmatrix}
+	  \cos(\psi)  & 0 & \sin(\psi) \\
+	  0           & 1 & 0 \\
+	  -\sin(\psi) & 0 & \cos(\psi)
+	  \end{bmatrix} (2)
+
+which gives two equations
+
+.. math:: \cos(\psi)\textbf{Q}_{sample}^x+\sin(\psi)\textbf{Q}_{sample}^z = \textbf{Q}_{lab}^x
+.. math:: -\sin(\psi)\textbf{Q}_{sample}^x+\cos(\psi)\textbf{Q}_{sample}^z = \textbf{Q}_{lab}^z
+
+make
+
+.. math:: A = \begin{bmatrix}
+          \textbf{Q}_{sample}^x & \textbf{Q}_{sample}^z \\
+          \textbf{Q}_{sample}^z & -\textbf{Q}_{sample}^x
+          \end{bmatrix}
+
+.. math:: B = \begin{bmatrix}
+	  \textbf{Q}_{lab}^x \\
+	  \textbf{Q}_{lab}^z
+	  \end{bmatrix}
+
+Then we need to solve :math:`A X = B` for :math:`X` where
+
+.. math:: X = \begin{bmatrix}
+              \cos{\psi} \\
+              \sin{\psi}
+              \end{bmatrix} = A^{-1} B
+
+then
+
+.. math:: \psi = \tan^{-1}\left(\frac{\sin{\psi}}{\cos{\psi}}\right)
+
+Put :math:`\psi` into (2) and you have the goniometer for that peak.
+
+.. note::
+
+   If the instrument is HB3A and the `InnerGoniometer` and `FlipX`
+   properties are left empty then these values will be set correctly
+   automatically.
+
+.. categories::
+
+.. sourcelink::

--- a/docs/source/release/v6.1.0/diffraction.rst
+++ b/docs/source/release/v6.1.0/diffraction.rst
@@ -94,11 +94,14 @@ made to facilitate this.
 - New LeanElasticPeak and LeanElasticPeakWorkspace has been created :ref:`LeanElasticPeaksWorkspace <LeanElasticPeaksWorkspace>`
 - :ref:`CreatePeaksWorkspace <algm-CreatePeaksWorkspace>` has been modified to optionally create a :ref:`LeanElasticPeaksWorkspace <LeanElasticPeaksWorkspace>`.
 - :ref:`FindPeaksMD <algm-FindPeaksMD>` has been modified to optionally create a :ref:`LeanElasticPeaksWorkspace <LeanElasticPeaksWorkspace>`.
+- :ref:`PredictPeaks <algm-PredictPeaks>` has been modified to optionally create a :ref:`LeanElasticPeaksWorkspace <LeanElasticPeaksWorkspace>`.
+- New algorithm :ref:`HFIRCalculateGoniometer <algm-HFIRCalculateGoniometer>` allows the goniometer to be found for constant wavelength peaks after creation, work with :ref:`LeanElasticPeaksWorkspace <LeanElasticPeaksWorkspace>`.
 - These following other algorithms have either been made to work or confirmed to already work with the LeanElasticPeak:
 
    - :ref:`algm-AddPeakHKL`
    - :ref:`algm-CalculatePeaksHKL`
    - :ref:`algm-CentroidPeaksMD`
+   - :ref:`algm-CompareWorkspaces`
    - :ref:`algm-CombinePeaksWorkspaces`
    - :ref:`algm-FilterPeaks`
    - :ref:`algm-FindUBUsingFFT`
@@ -111,6 +114,7 @@ made to facilitate this.
    - :ref:`algm-SaveNexusProcessed`
    - :ref:`algm-SelectCellOfType`
    - :ref:`algm-SelectCellWithForm`
+   - :ref:`algm-SortPeaksWorkspace`
    - :ref:`algm-ShowPossibleCells`
    - :ref:`algm-TransformHKL`
 


### PR DESCRIPTION
**Description of work.**

This changes PredictPeaks to work with LeanElasticPeaks. And add a new algorithm for calculated the goniometer rotation after FindPeaksMD or PredcitPeaks for special cases.

[SCD253](https://code.ornl.gov/sns-hfir-scse/diffraction/single-crystal/single-crystal-diffraction/-/issues/253) and [SCD268](https://code.ornl.gov/sns-hfir-scse/diffraction/single-crystal/single-crystal-diffraction/-/issues/268)

**To test:**

### HFIRCalculateGoniometer

```python
omega = np.deg2rad(42)

R = np.array([[np.cos(omega), 0, np.sin(omega)],
              [0, 1, 0],
              [-np.sin(omega), 0, np.cos(omega)]])

wl = 1.54
k = 2*np.pi/wl
theta = np.deg2rad(47)
phi = np.deg2rad(13)

q_lab = np.array([-np.sin(theta)*np.cos(phi),
                   -np.sin(theta)*np.sin(phi),
                   1 - np.cos(theta)]) * k

q_sample = np.dot(np.linalg.inv(R), q_lab)

peaks = CreatePeaksWorkspace(OutputType="LeanElasticPeak", NumberOfPeaks=0)

p = peaks.createPeakQSample(q_sample)
peaks.addPeak(p)

HFIRCalculateGoniometer(peaks, wl, OverrideProperty=True, InnerGoniometer=True)

g = Goniometer()
g.setR(peaks.getPeak(0).getGoniometerMatrix())
print(g.getEulerAngles('YZY'))
assert np.isclose(g.getEulerAngles('YZY')[0], 42)
```

### PredictPeaks

```python
HB3AAdjustSampleNorm(Filename="HB3A_exp0724_scan0183.nxs", OutputWorkspace='data')

# PeaksWorkspace
peaks = PredictPeaks("data",
                     ReflectionCondition='B-face centred',
                     CalculateGoniometerForCW=True,
                     Wavelength=1.008,
                     InnerGoniometer=True,
                     FlipX=True,
                     MinAngle=-2,
                     MaxAngle=90)

# LeanElasticPeaksWorkspace
leanelasticpeaks = PredictPeaks("data",
                                ReflectionCondition='B-face centred',
                                CalculateGoniometerForCW=True,
                                Wavelength=1.008,
                                InnerGoniometer=True,
                                FlipX=True,
                                MinAngle=-2,
                                MaxAngle=90,
                                OutputType='LeanElasticPeak')
```
For the above case `peaks` and `leanelasticpeaks` should be identical except different workspace type.

```python
leanelasticpeaks2 = PredictPeaks("data",
                                ReflectionCondition='B-face centred',
                                OutputType='LeanElasticPeak', CalculateWavelength=False)
```

`leanelasticpeaks2` should contain all possible peaks in the range provided (default 1->100). It will not attempt to calculate the goniometer or set the wavelength. But it can be _fixed_ with `HFIRCalculateGoniometer`

```python
HFIRCalculateGoniometer(leanelasticpeaks2)
```

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
