### PR TITLE
Add SliceViewer view test to check ads observer cleared on close

### DIFF
--- a/qt/python/mantidqt/widgets/sliceviewer/adsobsever.py
+++ b/qt/python/mantidqt/widgets/sliceviewer/adsobsever.py
@@ -43,9 +43,6 @@ class SliceViewerADSObserver(AnalysisDataServiceObserver):
         self.observeReplace(True)
         self.observeRename(True)
 
-    def __del__(self):
-        self.observeAll(False)
-
     @_catch_exceptions
     def clearHandle(self):
         """Called when the ADS is deleted all of its workspaces"""

--- a/qt/python/mantidqt/widgets/sliceviewer/presenter.py
+++ b/qt/python/mantidqt/widgets/sliceviewer/presenter.py
@@ -72,8 +72,6 @@ class SliceViewer(ObservingPresenter):
         self.ads_observer = SliceViewerADSObserver(self.replace_workspace, self.rename_workspace,
                                                    self.ADS_cleared, self.delete_workspace)
 
-        self.view.destroyed.connect(self._on_view_destroyed)
-
     def new_plot_MDH(self):
         """
         Tell the view to display a new plot of an MDHistoWorkspace
@@ -407,6 +405,7 @@ class SliceViewer(ObservingPresenter):
         self.view.emit_close()
 
     def clear_observer(self):
+        """Called by ObservingView on close event"""
         self.ads_observer = None
         if self._peaks_presenter is not None:
             self._peaks_presenter.clear_observer()
@@ -461,6 +460,3 @@ class SliceViewer(ObservingPresenter):
     def _close_view_with_message(self, message: str):
         self.view.emit_close()  # inherited from ObservingView
         self._logger.warning(message)
-
-    def _on_view_destroyed(self):
-        self.clear_observer()

--- a/qt/python/mantidqt/widgets/sliceviewer/test/test_sliceviewer_view.py
+++ b/qt/python/mantidqt/widgets/sliceviewer/test/test_sliceviewer_view.py
@@ -9,7 +9,7 @@
 import io
 import sys
 import unittest
-from unittest.mock import patch
+from unittest.mock import patch, MagicMock
 
 import matplotlib as mpl
 from matplotlib.colors import Normalize
@@ -327,6 +327,15 @@ class SliceViewerViewTest(unittest.TestCase, QtWidgetFinder):
 
         self.assertEqual(pres.view.data_view.get_axes_limits()[0], (xmin, xmax))
 
+    def test_close_event(self):
+        ws = CreateSampleWorkspace()
+        pres = SliceViewer(ws)
+        self.assert_widget_created()
+        pres.clear_observer = MagicMock()
+
+        pres.view.close()
+
+        pres.clear_observer.assert_called()
 
 # private helper functions
 


### PR DESCRIPTION
Reintroduces a failing test that checks whether the SliceViewerADSObserver is cleared when the view is closed. The test passed when ran individually, but failed when the whole suite ran. I believe this is because it used a workspace that is deleted by another test.

This PR also adds:
- Removed duplicate call to `SliceViewer.clear_observer` on the views `destroy` signal.
- Removed a call to `observeAll(False)` in the `SliceViewerADSObserver`. The `__del__` method it was in was not used, and this call should happen in the [destructor](https://github.com/mantidproject/mantid/blob/0b7d76567a9a0e178ea3f18c79bf403fe6770bfe/Framework/API/src/AnalysisDataServiceObserver.cpp#L35) of the underlying cpp object

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

**To test:**
- All view tests pass as a suite
- The `test_close_event` passes
- The SliceViewer still works as expected in workbench

Fixes #30455 . <!-- and fix #xxxx or close #xxxx xor resolves #xxxx -->
<!-- alternative
*There is no associated issue.*
-->

*This does not require release notes* because **it is an internal issue**

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
