### PR TITLE
Fix ModUB initialization

### DIFF
--- a/Framework/Geometry/src/Crystal/OrientedLattice.cpp
+++ b/Framework/Geometry/src/Crystal/OrientedLattice.cpp
@@ -23,6 +23,7 @@ OrientedLattice::OrientedLattice(const DblMatrix &Umatrix) : UnitCell() {
   if (Umatrix.isRotation()) {
     U = Umatrix;
     UB = U * getB();
+    ModUB = UB * getModHKL();
   } else
     throw std::invalid_argument("U is not a proper rotation");
 }
@@ -41,6 +42,7 @@ OrientedLattice::OrientedLattice(const double _a, const double _b, const double 
   if (Umatrix.isRotation()) {
     U = Umatrix;
     UB = U * getB();
+    ModUB = UB * getModHKL();
   } else
     throw std::invalid_argument("U is not a proper rotation");
 }
@@ -61,6 +63,7 @@ OrientedLattice::OrientedLattice(const double _a, const double _b, const double 
   if (Umatrix.isRotation()) {
     U = Umatrix;
     UB = U * getB();
+    ModUB = UB * getModHKL();
   } else
     throw std::invalid_argument("U is not a proper rotation");
 }
@@ -73,6 +76,7 @@ OrientedLattice::OrientedLattice(const UnitCell &uc, const DblMatrix &Umatrix) :
   if (Umatrix.isRotation()) {
     U = Umatrix;
     UB = U * getB();
+    ModUB = UB * getModHKL();
   } else
     throw std::invalid_argument("U is not a proper rotation");
 }

--- a/Framework/Geometry/test/OrientedLatticeTest.h
+++ b/Framework/Geometry/test/OrientedLatticeTest.h
@@ -32,6 +32,11 @@ public:
     u2.seta(13);
     TS_ASSERT_DELTA(u2.a(), 13, 1e-10);
     TS_ASSERT_DELTA(u2.getUB()[0][0], 1. / 13., 1e-10);
+
+    // Check that the ModUB is initialized correctly
+    const DblMatrix &modUB = u1.getModUB();
+    DblMatrix expected(3, 3);
+    TS_ASSERT(modUB.equals(expected, 1e-8));
   }
 
   void test_hklFromQ() {


### PR DESCRIPTION
**Description of work.**

Fix ModUB initialization

**To test:**

This was segfaulting, now it doesn't

```python
from mantid.geometry import OrientedLattice
ol = OrientedLattice()
print(ol.getModUB())
```

*This does not require release notes* because it's a minor bug fix that doesn't change any behaviour, it just stops a segfault.


<!-- Ensure the base of this PR is correct (e.g. release-next or master)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
