### PR TITLE
Unicode axis label crash

### DIFF
--- a/Framework/Kernel/inc/MantidKernel/UnitLabel.h
+++ b/Framework/Kernel/inc/MantidKernel/UnitLabel.h
@@ -32,7 +32,7 @@ public:
   UnitLabel(const AsciiString &ascii, const Utf8String &unicode, const AsciiString &latex);
   /// Constructor creating all labels from the ascii string
   UnitLabel(const AsciiString &ascii);
-  /// Constructor giving all labels as ascii using a C-style string
+  /// Constructor creating all labels using a C-style string
   UnitLabel(const char *ascii);
 
   /// Equality operator with other label

--- a/Framework/Kernel/inc/MantidKernel/UnitLabel.h
+++ b/Framework/Kernel/inc/MantidKernel/UnitLabel.h
@@ -30,9 +30,9 @@ public:
 
   /// Constructor giving labels as ascii, unicode, and latex respectively
   UnitLabel(const AsciiString &ascii, const Utf8String &unicode, const AsciiString &latex);
-  /// Constructor giving both labels as ascii
+  /// Constructor creating all labels from the ascii string
   UnitLabel(const AsciiString &ascii);
-  /// Constructor giving both labels as ascii using a C-style string
+  /// Constructor giving all labels as ascii using a C-style string
   UnitLabel(const char *ascii);
 
   /// Equality operator with other label

--- a/Framework/Kernel/src/UnitLabel.cpp
+++ b/Framework/Kernel/src/UnitLabel.cpp
@@ -5,7 +5,8 @@
 //   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
 // SPDX - License - Identifier: GPL - 3.0 +
 #include "MantidKernel/UnitLabel.h"
-#include <cstring>
+#include <codecvt>
+#include <locale>
 
 namespace Mantid {
 namespace Kernel {
@@ -22,15 +23,19 @@ UnitLabel::UnitLabel(const AsciiString &ascii, const Utf8String &unicode, const 
  * Use an ASCII string for the unicode variant too
  * @param ascii A plain-text label containing only ascii characters
  */
-UnitLabel::UnitLabel(const UnitLabel::AsciiString &ascii)
-    : m_ascii(ascii), m_utf8(ascii.begin(), ascii.end()), m_latex(ascii) {}
-
+UnitLabel::UnitLabel(const UnitLabel::AsciiString &ascii) : m_ascii(ascii), m_latex(ascii) {
+  std::wstring_convert<std::codecvt_utf8_utf16<wchar_t>> converter;
+  m_utf8 = converter.from_bytes(m_ascii);
+}
 /**
  * Use an ASCII string for the unicode variant too, given
  * as a C-style string
  * @param ascii A plain-text label
  */
-UnitLabel::UnitLabel(const char *ascii) : m_ascii(ascii), m_utf8(m_ascii.begin(), m_ascii.end()), m_latex(ascii) {}
+UnitLabel::UnitLabel(const char *ascii) : m_ascii(ascii), m_latex(ascii) {
+  std::wstring_convert<std::codecvt_utf8_utf16<wchar_t>> converter;
+  m_utf8 = converter.from_bytes(m_ascii);
+}
 
 /**
  * Test if two objects are considered equal

--- a/Framework/Kernel/src/UnitLabel.cpp
+++ b/Framework/Kernel/src/UnitLabel.cpp
@@ -6,6 +6,7 @@
 // SPDX - License - Identifier: GPL - 3.0 +
 #include "MantidKernel/UnitLabel.h"
 #include <codecvt>
+#include <cstring>
 #include <locale>
 
 namespace Mantid {

--- a/Framework/Kernel/src/UnitLabel.cpp
+++ b/Framework/Kernel/src/UnitLabel.cpp
@@ -23,7 +23,7 @@ UnitLabel::UnitLabel(const AsciiString &ascii, const Utf8String &unicode, const 
  * Use an ASCII string for the unicode variant too
  * @param ascii A plain-text label containing only ascii characters
  */
-UnitLabel::UnitLabel(const UnitLabel::AsciiString &ascii) : m_ascii(ascii), m_latex(ascii) {
+UnitLabel::UnitLabel(const AsciiString &ascii) : m_ascii(ascii), m_latex(ascii) {
   std::wstring_convert<std::codecvt_utf8_utf16<wchar_t>> converter;
   m_utf8 = converter.from_bytes(m_ascii);
 }
@@ -32,10 +32,7 @@ UnitLabel::UnitLabel(const UnitLabel::AsciiString &ascii) : m_ascii(ascii), m_la
  * as a C-style string
  * @param ascii A plain-text label
  */
-UnitLabel::UnitLabel(const char *ascii) : m_ascii(ascii), m_latex(ascii) {
-  std::wstring_convert<std::codecvt_utf8_utf16<wchar_t>> converter;
-  m_utf8 = converter.from_bytes(m_ascii);
-}
+UnitLabel::UnitLabel(const char *ascii) : UnitLabel(AsciiString(ascii)) {}
 
 /**
  * Test if two objects are considered equal

--- a/Framework/PythonInterface/test/python/mantid/kernel/UnitLabelTest.py
+++ b/Framework/PythonInterface/test/python/mantid/kernel/UnitLabelTest.py
@@ -12,11 +12,11 @@ import sys
 class UnitLabelTest(unittest.TestCase):
 
     def test_UnitLabel_can_be_built_from_simple_string(self):
-      label = UnitLabel("MyLabel")
-      self.assertEqual("MyLabel", label.ascii())
+        label = UnitLabel("MyLabel")
+        self.assertEqual("MyLabel", label.ascii())
 
     def test_UnitLabel_can_be_built_simple_string_and_unicode_object(self):
-        label = UnitLabel("MyLabel", u"\u03bcs","\mu s")
+        label = UnitLabel("MyLabel", u"\u03bcs", "\mu s")
         self.assertEqual("MyLabel", label.ascii())
         self.assertEqual(u"\u03bcs", label.utf8())
         self.assertEqual("\mu s", label.latex())
@@ -29,9 +29,18 @@ class UnitLabelTest(unittest.TestCase):
         self.assertEqual("\mu s", unit_lbl.latex())
 
     def test_str_function_produces_ascii_string_from_label(self):
-        label = UnitLabel("MyLabel", u"\u03bcs","\mu s")
+        label = UnitLabel("MyLabel", u"\u03bcs", "\mu s")
         self.assertTrue(isinstance(str(label), str))
         self.assertEqual("MyLabel", str(label))
+
+    def test_utf8_with_ascii_only_constructor(self):
+        """
+        Check that the single argument constructor of UnitLabel sets an appropriate UTF-8 string when a non-ascii
+        string is passed.
+        """
+        microseconds = u"\u00B5s"
+        label = UnitLabel(microseconds)
+        self.assertEqual(microseconds, label.utf8())
 
 
 if __name__ == '__main__':

--- a/docs/source/release/v6.1.0/framework.rst
+++ b/docs/source/release/v6.1.0/framework.rst
@@ -64,5 +64,6 @@ Bugfixes
 - Fix problem with dictionary parameters on :ref:`SetSample <algm-SetSample>` algorithm when running from the algorithm dialog
 - Fix segmentation fault when running :ref:`MonteCarloAbsorption <algm-MonteCarloAbsorption>` algorithm on Ubuntu without a material defined on one of the sample\environment shapes
 - Fix calculation of region where scattering points are sampled in :ref:`MonteCarloAbsorption <algm-MonteCarloAbsorption>` when a shape is defined for the environment but not the sample
+- Fix crash on macOS when creating a UnitLabel with non-ascii characters using the single argument constructor
 
 :ref:`Release 6.1.0 <v6.1.0>`

--- a/qt/python/mantidqt/widgets/workspacedisplay/matrix/test/test_matrixworkspacedisplay_table_view_model.py
+++ b/qt/python/mantidqt/widgets/workspacedisplay/matrix/test/test_matrixworkspacedisplay_table_view_model.py
@@ -623,7 +623,7 @@ class MatrixWorkspaceDisplayTableViewModelTest(unittest.TestCase):
         """
         Set the label of the x-axis using ascii only with a non-ascii character and make sure it's handled properly.
         """
-        ws = CreateWorkspace(DataX=[0,1,2],DataY=[3,7,5],DataE=[0.2,0.3,0.1],NSpec=1)
+        ws = CreateWorkspace(DataX=[0, 1, 2], DataY=[3, 7, 5], DataE=[0.2, 0.3, 0.1], NSpec=1)
         label_unit = ws.getAxis(0).setUnit("Label")
         microseconds = "\u00B5s"
         # Second argument will implicitly call the ascii only constructor of UnitLabel.

--- a/qt/python/mantidqt/widgets/workspacedisplay/matrix/test/test_matrixworkspacedisplay_table_view_model.py
+++ b/qt/python/mantidqt/widgets/workspacedisplay/matrix/test/test_matrixworkspacedisplay_table_view_model.py
@@ -19,6 +19,8 @@ from mantidqt.utils.testing.mocks.mock_mantid import AXIS_INDEX_FOR_HORIZONTAL, 
 from mantidqt.utils.testing.mocks.mock_qt import MockQModelIndex
 from mantidqt.widgets.workspacedisplay.matrix.table_view_model import MatrixWorkspaceTableViewModel, \
     MatrixWorkspaceTableViewModelType
+from mantid.simpleapi import CreateWorkspace
+from mantid.kernel import UnitLabel
 
 
 def setup_common_for_test_data():
@@ -616,6 +618,24 @@ class MatrixWorkspaceDisplayTableViewModelTest(unittest.TestCase):
         model = MatrixWorkspaceTableViewModel(ws, model_type)
 
         self.assertEqual(data_len, model.columnCount())
+
+    def test_set_unicode_unit_label(self):
+        """
+        Set the label of the x-axis using ascii only with a non-ascii character and make sure it's handled properly.
+        """
+        ws = CreateWorkspace(DataX=[0,1,2],DataY=[3,7,5],DataE=[0.2,0.3,0.1],NSpec=1)
+        label_unit = ws.getAxis(0).setUnit("Label")
+        microseconds = "\u00B5s"
+        # Second argument will implicitly call the ascii only constructor of UnitLabel.
+        # We are intentionally passing a non-ascii string to try and break it.
+        label_unit.setLabel("Time", microseconds)
+
+        model_type = MatrixWorkspaceTableViewModelType.y
+        model = MatrixWorkspaceTableViewModel(ws, model_type)
+        header = model.headerData(0, Qt.Horizontal, Qt.DisplayRole)
+
+        # Header should contain the microseconds unicode string.
+        self.assertTrue(microseconds in header)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
**Description of work.**
The following script was causing problems because the second argument in the `setLabel()` function call was implicitly constructing an object that assumed it was being passed an ASCII string:
```
from mantid.simpleapi import *

W=CreateWorkspace(DataX=[0,1,2],DataY=[3,7,5],DataE=[0.2,0.3,0.1],NSpec=1)
lbl=W.getAxis(0).setUnit("Label")
lbl.setLabel("Time",u"\u00B5s") # microseconds
W.setYUnitLabel(u"Distance in \u00C5") # Angstrom symbol
```
When right clicking the workspace and clicking "Show Data" the column headers were garbled, and crashing was reported on macOS.

To solve the problem, the "ASCII only" construtor has been modified to support utf8 strings.

**To test:**
Run the above script, right click the newly created workspace and click "Show Data". The colum headers in the Y values and E values tables should correctly display the microseconds string.

Fixes #28654

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
