### PR TITLE
Find pre-commit executable

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,7 +6,7 @@ exclude: ^$|instrument
 repos:
 
   # Run fast code improvement/checks before running PR specific helpers.
-  - repo: https://github.com/pre-commit/pre-commit-hooks
+  - repo: https://github.com/pre-commit/pre-commit-hooks.git
     rev: 2618198e9658cccb4a53f04af0f7d642109f3b54
     hooks:
       - id: trailing-whitespace
@@ -18,13 +18,13 @@ repos:
       - id: check-yaml
         args: [--allow-multiple-documents]
 
-  - repo: https://github.com/mantidproject/pre-commit-hooks
+  - repo: https://github.com/mantidproject/pre-commit-hooks.git
     rev: 05b2d4cfe17dcb36e29c249705364c19eeccced5
     hooks:
       - id: clang-format
         exclude: Testing/Tools/cxxtest|tools
 
-  - repo: https://gitlab.com/pycqa/flake8
+  - repo: https://gitlab.com/pycqa/flake8.git
     rev: 3.7.9
     hooks:
       - id: flake8

--- a/buildconfig/CMake/CommonSetup.cmake
+++ b/buildconfig/CMake/CommonSetup.cmake
@@ -408,19 +408,29 @@ endif()
 # ##############################################################################
 option(ENABLE_PRECOMMIT "Enable pre-commit framework" ON)
 if (ENABLE_PRECOMMIT)
+  # Windows should use downloaded ThirdParty version of pre-commit.cmd
+  # Everybody else should find one in their PATH
+  find_program(PRE_COMMIT_EXE
+    NAMES
+    pre-commit
+    pre-commit.cmd
+    HINTS
+    ~/.local/bin/
+    "${MSVC_PYTHON_EXECUTABLE_DIR}/Scripts/")
+  if (NOT PRE_COMMIT_EXE)
+    message ( FATAL_ERROR "Failed to find pre-commit see https://developer.mantidproject.org/GettingStarted.html" )
+  endif ()
+
   if (MSVC)
-    # Use downloaded ThirdParty version of pre-commit
-    execute_process(COMMAND "${MSVC_PYTHON_EXECUTABLE_DIR}/Scripts/pre-commit.cmd" install --overwrite WORKING_DIRECTORY ${PROJECT_SOURCE_DIR} RESULT_VARIABLE PRE_COMMIT_RESULT)
+    execute_process(COMMAND "${PRE_COMMIT_EXE} install --overwrite" WORKING_DIRECTORY ${PROJECT_SOURCE_DIR} RESULT_VARIABLE PRE_COMMIT_RESULT)
     if(NOT PRE_COMMIT_RESULT EQUAL "0")
         message(FATAL_ERROR "Pre-commit install failed with ${PRE_COMMIT_RESULT}")
     endif()
     # Create pre-commit script wrapper to use mantid third party python for pre-commit
     file(RENAME "${PROJECT_SOURCE_DIR}/.git/hooks/pre-commit" "${PROJECT_SOURCE_DIR}/.git/hooks/pre-commit-script.py")
     file(WRITE "${PROJECT_SOURCE_DIR}/.git/hooks/pre-commit" "#!/usr/bin/env sh\n${MSVC_PYTHON_EXECUTABLE_DIR}/python.exe ${PROJECT_SOURCE_DIR}/.git/hooks/pre-commit-script.py")
-  else()
-    # Use system installed pre-commit if not present it should just fail but
-    # continue anyway.
-    execute_process(COMMAND bash -c "pre-commit install" WORKING_DIRECTORY ${PROJECT_SOURCE_DIR} RESULT_VARIABLE STATUS)
+  else()  # linux as osx
+    execute_process(COMMAND bash -c "${PRE_COMMIT_EXE} install" WORKING_DIRECTORY ${PROJECT_SOURCE_DIR} RESULT_VARIABLE STATUS)
     if (STATUS AND NOT STATUS EQUAL 0)
       message(FATAL_ERROR "Pre-commit tried to install itself into your repository, but failed to do so. Is it installed on your system?")
     endif()


### PR DESCRIPTION
Rather than assuming the name for `pre-commit`, have cmake find it and print out a more useful error message.

**To test:**

Re-running `cmake` should be enough.

*There is no associated issue.*


*This does not require release notes* because it is a change that only affects developers.

The version into `ornl-next` is #31039.

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
