### PR TITLE
Additional command line options in workbench

### DIFF
--- a/docs/source/release/v6.1.0/mantidworkbench.rst
+++ b/docs/source/release/v6.1.0/mantidworkbench.rst
@@ -10,6 +10,7 @@ New and Improved
 
 - New plot interactions: Double click a legend to hide it, double click a curve to open it in the plot config dialog.
 - It is now possible to overplot bin data from the matrix workspace view.
+- New command line options ``--version`` will print the version on mantid and exit. ``--error-on-warning`` will convert python warnings into exceptions. This is intended for developers so they can find deprecation warnings more easily.
 - Improved the performance of the table workspace display for large datasets
 - A new empty facility with empty instrument is the default facility now, and
   user has to select their choice of facility (including ISIS) and instrument for the first time

--- a/qt/applications/workbench/workbench/app/main.py
+++ b/qt/applications/workbench/workbench/app/main.py
@@ -7,12 +7,15 @@
 #  This file is part of the mantid workbench.
 import argparse
 import os
+from mantid import __version__ as mtd_version
+import warnings
 
 
 def main():
     # setup command line arguments
     parser = argparse.ArgumentParser(description='Mantid Workbench')
     parser.add_argument('script', nargs='?')
+    parser.add_argument('--version', action='version', version=mtd_version)
     parser.add_argument('-x',
                         '--execute',
                         action='store_true',
@@ -24,6 +27,10 @@ def main():
     parser.add_argument('--profile',
                         action='store',
                         help='Run workbench with execution profiling. Specify a path for the output file.')
+    parser.add_argument('--error-on-warning',
+                        action='store_true',
+                        help='Convert python warnings to exceptions')
+
     try:
         # set up bash completion as a soft dependency
         import argcomplete
@@ -33,6 +40,10 @@ def main():
 
     # parse the command line options
     options = parser.parse_args()
+
+    if options.error_on_warning:
+        warnings.simplefilter("error") # Change the filter in this process
+        os.environ["PYTHONWARNINGS"] = "error" # Also affect subprocesses
 
     if options.profile:
         import cProfile


### PR DESCRIPTION
For some reason, mantidworkbench did not have a `--version` option

Also added a command line option to convert warnings to exceptions. This
was used to squash various deprecation warnings that appear when using
newer versions of python libraries.

**To test:**

Try workbench with the new options!

*There is no associated issue.*

The version into `ornl-next` is #31046.

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
