### PR TITLE
Address negative intensity from IntegrateEllipsoids

### DIFF
--- a/Framework/MDAlgorithms/src/IntegrateQLabEvents.cpp
+++ b/Framework/MDAlgorithms/src/IntegrateQLabEvents.cpp
@@ -8,6 +8,7 @@
 #include "MantidDataObjects/NoShape.h"
 #include "MantidDataObjects/PeakShapeEllipsoid.h"
 #include "MantidGeometry/Crystal/IndexingUtils.h"
+#include "MantidKernel/Logger.h"
 #include "MantidKernel/MultiThreaded.h"
 
 #include <boost/math/special_functions/round.hpp>
@@ -35,6 +36,11 @@ namespace MDAlgorithms {
 using namespace std;
 using Mantid::Kernel::DblMatrix;
 using Mantid::Kernel::V3D;
+
+namespace {
+/// static logger
+Kernel::Logger g_log("CostFuncUnweightedLeastSquares");
+} // namespace
 
 IntegrateQLabEvents::IntegrateQLabEvents(const SlimEvents &peak_q_list, double radius,
                                          const bool useOnePercentBackgroundCorrection)
@@ -102,6 +108,7 @@ IntegrateQLabEvents::ellipseIntegrateEvents(const std::vector<V3D> &E1Vec, V3D c
   return ellipseIntegrateEvents(std::move(E1Vec), peak_q, some_events, eigen_vectors, sigmas, specify_size, peak_radius,
                                 back_inner_radius, back_outer_radius, axes_radii, inti, sigi);
 }
+
 std::pair<double, double> IntegrateQLabEvents::numInEllipsoid(SlimEvents const &events,
                                                               std::vector<V3D> const &directions,
                                                               std::vector<double> const &sizes) {
@@ -300,6 +307,25 @@ PeakShapeEllipsoid_const_sptr IntegrateQLabEvents::ellipseIntegrateEvents(
 
   inti = peak_w_back.first - ratio * backgrd.first;
   sigi = sqrt(peak_w_back.second + ratio * ratio * backgrd.second);
+
+  if (inti < 0) {
+    std::ostringstream msg;
+    msg << "Negative intensity found: " << inti << "\n"
+        << "You might want to adjust the size of peak and background shell.\n";
+    g_log.notice() << msg.str();
+    // debug message
+    std::ostringstream debugmsg;
+    debugmsg << "peak_radius = " << peak_radius << "\n"
+             << "back_inner_radius = " << back_inner_radius << "\n"
+             << "back_outer_radius = " << back_outer_radius << "\n"
+             << "sigmas = (" << sigmas[0] << "," << sigmas[1] << "," << sigmas[2] << ")\n"
+             << "r1, r2, r3 = " << r1 << "," << r2 << "," << r3 << "\n"
+             << "peak_w_back.first = " << peak_w_back.first << "\n"
+             << "backgrd.first = " << backgrd.first << "\n"
+             << "ratio = " << ratio << "\n"
+             << "inti = peak_w_back.first - ratio * backgrd.first = " << inti << "\n";
+    g_log.debug() << debugmsg.str();
+  }
 
   // Make the shape and return it.
   return std::make_shared<const PeakShapeEllipsoid>(directions, abcRadii, abcBackgroundInnerRadii,


### PR DESCRIPTION
**Description of work.**
- Related Gitlab Task: [SCD245](https://code.ornl.gov/sns-hfir-scse/diffraction/single-crystal/single-crystal-diffraction/-/issues/245)
- This is #31050 into `master`.

This PR adds some warning messages when negative intensity was found due to specific selection of specified radius.

- The current background estimation will inevitably return negative values if
  - other (satellite) peaks are caught in the background shell
  - the selected shell is too thin

Therefore, we are providing a warning to the user when negative intensity is found.
A better way to estimate the background will (probably) be explored in a separate user story.

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

**To test:**
```
# import mantid algorithms, numpy and matplotlib
from mantid.simpleapi import *
import matplotlib.pyplot as plt
import numpy as np

from mantid import config
config['Q.convention'] = "Inelastic"
                       
ws = CreateSimulationWorkspace(Instrument='TOPAZ',
                               BinParams='1,100,10000',
                               UnitX='TOF')
                               
SetGoniometer(Workspace=ws, Axis0='30,0,1,0,1')      

# add peak
pws = CreatePeaksWorkspace(InstrumentWorkspace=ws, 
                           NumberOfPeaks=0, 
                           OutputWorkspace='peaks')
                           
SetUB('peaks', 2*np.pi, 2*np.pi, 2*np.pi, 90, 90, 90)

p = pws.createPeak([5,1,6]) 
pws.addPeak(p)

p = pws.createPeak([4,2,1]) 
pws.addPeak(p)

p = pws.createPeak([2,3,1]) 
pws.addPeak(p)

IndexPeaks(pws, Tolerance=1)

# integrate              
IntegrateEllipsoids(InputWorkspace=ws, 
                    PeaksWorkspace=pws, 
                    RegionRadius=0.14, 
                    SpecifySize=True, 
                    PeakSize=0.07, 
                    BackgroundInnerSize=0.09,
                    BackgroundOuterSize=0.11, 
                    OutputWorkspace=pws)
```
You should see a warning for the second peak, which has a negative intensity due to the selected background shell.
If you increase `BackgroundOuterSize` to 0.12, this negative value will go away.

<!-- Instructions for testing. -->

Fixes #31051. <!-- and fix #xxxx or close #xxxx xor resolves #xxxx -->
<!-- alternative
*There is no associated issue.*
-->

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or master)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
