### PR TITLE
Instrument view: rescale plot y-axis when range changes

### DIFF
--- a/docs/source/release/v6.1.0/mantidworkbench.rst
+++ b/docs/source/release/v6.1.0/mantidworkbench.rst
@@ -37,5 +37,6 @@ Bugfixes
 - First time dialog box will not appear recurrently, if user selected their choice of facility
   and instrument at least once and checked "Do not show again until next version".
 - Fixed a bug that would cause a crash if the user right clicked on the plot in the instrument view pick tab after the stored curves were cleared.
+- The y-axis in the instrument view's pick tab will now rescale if the range changes.
 
 :ref:`Release 6.1.0 <v6.1.0>`

--- a/qt/widgets/instrumentview/src/MiniPlotMpl.cpp
+++ b/qt/widgets/instrumentview/src/MiniPlotMpl.cpp
@@ -124,6 +124,7 @@ void MiniPlotMpl::setData(std::vector<double> x, std::vector<double> y,
   // is very different we need ensure the scale is tight enough to
   // see newer plots so we force a recalculation from the data
   axes.relim();
+  axes.autoscaleView();
   replot();
 }
 


### PR DESCRIPTION
**Description of work.**
When creating a shape and moving it from a high to low occupancy region, it wouldn't update the y-axis range until you moved the shape again. The same was happening with other pick tools, but was harder to spot.

**To test:**

- Load a workspace
- Open the instrument view's pick tab
- Select the "Draw a rectangle" tool and draw a rectangle
- Move the rectangle around the instrument and verify that the y-axis of the mini plot always rescales appropriately

Fixes #30890.

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
