### PR TITLE
Fix RuntimeError: std::bad_cast when using LeanElastic PeakColumn

### DIFF
--- a/Framework/DataObjects/src/PeakColumn.cpp
+++ b/Framework/DataObjects/src/PeakColumn.cpp
@@ -281,7 +281,7 @@ template <class T> void *PeakColumn<T>::void_pointer(size_t index) {
  */
 template <class T> const void *PeakColumn<T>::void_pointer(size_t index) const {
   const T &peak = m_peaks[index];
-  auto fatPeak = dynamic_cast<const DataObjects::Peak &>(peak); // additional methods available in class Peak
+  auto fullPeak = dynamic_cast<const DataObjects::Peak *>(&peak); // additional methods available in class Peak
 
   // The cell() api requires that the value exist somewhere in memory, however,
   // some of the values from a Peak are calculated on the fly so a reference
@@ -303,11 +303,11 @@ template <class T> const void *PeakColumn<T>::void_pointer(size_t index) const {
   } else if (m_name == "PeakNumber") {
     value = peak.getPeakNumber();
     return boost::get<int>(&value);
-  } else if (m_name == "DetID") {
-    value = fatPeak.getDetectorID();
+  } else if (m_name == "DetID" && fullPeak) {
+    value = fullPeak->getDetectorID();
     return boost::get<int>(&value);
-  } else if (m_name == "BankName") {
-    value = fatPeak.getBankName();
+  } else if (m_name == "BankName" && fullPeak) {
+    value = fullPeak->getBankName();
     return boost::get<std::string>(&value);
   } else if (m_name == "QLab") {
     value = peak.getQLabFrame();

--- a/Framework/DataObjects/test/LeanElasticPeaksWorkspaceTest.h
+++ b/Framework/DataObjects/test/LeanElasticPeaksWorkspaceTest.h
@@ -46,6 +46,23 @@ public:
     TS_ASSERT_EQUALS(pw->rowCount(), 1);
     TS_ASSERT_EQUALS(pw->getNumberPeaks(), 1);
     TS_ASSERT_DELTA(pw->getPeak(0).getWavelength(), 3.0, 1e-9);
+
+    // check column printing
+    std::ostringstream s;
+    for (int n = 0; n < 14; n++) {
+      pw->getColumn(n)->print(0, s);
+      s << " ";
+    }
+    TS_ASSERT_EQUALS(s.str(), "0 0.00 0.00 0.00 3 9.1 6.3 0 0 0 0 [1,0,0] [1,0,0] 0 ");
+
+    // check some cell values
+    TS_ASSERT_EQUALS(pw->cell<int>(0, 0), 0);
+    TS_ASSERT_EQUALS(pw->cell<double>(0, 1), 0);
+    TS_ASSERT_EQUALS(pw->cell<double>(0, 2), 0);
+    TS_ASSERT_EQUALS(pw->cell<double>(0, 3), 0);
+    TS_ASSERT_EQUALS(pw->cell<double>(0, 4), 3);
+    TS_ASSERT_DELTA(pw->cell<double>(0, 5), 9.0893558317, 1e-7);
+    TS_ASSERT_DELTA(pw->cell<double>(0, 6), 6.2831853017, 1e-7);
   }
 
   void test_copyConstructor() {

--- a/Framework/DataObjects/test/PeakTest.h
+++ b/Framework/DataObjects/test/PeakTest.h
@@ -172,7 +172,8 @@ public:
     TS_ASSERT_DELTA(plp.getFinalEnergy(), peak.getFinalEnergy(), tolerance);
     //
     TS_ASSERT_EQUALS(plp.getAzimuthal(), peak.getAzimuthal());
-    TS_ASSERT_THROWS_NOTHING(plp.getDetectorID());
+    // Actually check that we found the same detector ID
+    TS_ASSERT_EQUALS(plp.getDetectorID(), 19999);
 
     std::ostringstream msg;
     msg.precision(16);


### PR DESCRIPTION
**Description of work.**

Fixes a bug introduced by #31022

**To test:**

```python
peaks = CreatePeaksWorkspace(NumberOfPeaks=1, OutputType="LeanElasticPeak")
print(peaks.row(0))
```

was giving

```
---------------------------------------------------------------------------
RuntimeError                              Traceback (most recent call last)
<ipython-input-3-b8bcfa872bd7> in <module>
----> 1 print(peaks.row(0))

RuntimeError: std::bad_cast
```

now it should print

```
{'RunNumber': 0, 'h': 0.0, 'k': 0.0, 'l': 0.0, 'Wavelength': 0.0, 'Energy': inf, 'DSpacing': inf, 'Intens': 0.0, 'SigInt': 0.0, 'Intens/SigInt': 0.0, 'BinCount': 0.0, 'QLab': [0,0,0], 'QSample': [0,0,0], 'PeakNumber': 0}
```



*This does not require release notes* because fixing a bug that was just introduced.


<!-- Ensure the base of this PR is correct (e.g. release-next or master)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
