### PR TITLE
Fix failure in HB3AFindPeaks when switching to crystallographic convention

### DIFF
--- a/Framework/MDAlgorithms/src/ConvertHFIRSCDtoMDE.cpp
+++ b/Framework/MDAlgorithms/src/ConvertHFIRSCDtoMDE.cpp
@@ -201,6 +201,11 @@ void ConvertHFIRSCDtoMDE::exec() {
   MDEventInserter<MDEventWorkspace<MDEvent<3>, 3>::sptr> inserter(mdws_mdevt_3);
 
   float k = boost::math::float_constants::two_pi / static_cast<float>(wavelength);
+  // check convention to determine the sign of k
+  std::string convention = Kernel::ConfigService::Instance().getString("Q.convention");
+  if (convention == "Crystallography") {
+    k *= -1.f;
+  }
   std::vector<Eigen::Vector3f> q_lab_pre;
   q_lab_pre.reserve(azimuthal.size());
   for (size_t m = 0; m < azimuthal.size(); ++m) {

--- a/Framework/PythonInterface/plugins/algorithms/ConvertWANDSCDtoQ.py
+++ b/Framework/PythonInterface/plugins/algorithms/ConvertWANDSCDtoQ.py
@@ -8,6 +8,7 @@ from mantid.api import (PythonAlgorithm, AlgorithmFactory,
                         PropertyMode, WorkspaceProperty, Progress,
                         IMDHistoWorkspaceProperty, mtd)
 from mantid.kernel import Direction, FloatArrayProperty, FloatArrayLengthValidator, StringListValidator, FloatBoundedValidator
+from mantid import config
 from mantid import logger
 import numpy as np
 
@@ -252,6 +253,9 @@ class ConvertWANDSCDtoQ(PythonAlgorithm):
             if inWS.getExperimentInfo(0).getInstrument().getName() == 'HB3A':
                 azim = azim.reshape(512*3, 512).T.flatten()
 
+        # check convention to determine the sign
+        if config['Q.convention'] == 'Crystallography':
+            k *= -1.0
         qlab = np.vstack((np.sin(polar)*np.cos(azim),
                           np.sin(polar)*np.sin(azim),
                           np.cos(polar) - 1)).T * -k # Kf - Ki(0,0,1)

--- a/docs/source/release/v6.1.0/diffraction.rst
+++ b/docs/source/release/v6.1.0/diffraction.rst
@@ -82,6 +82,8 @@ Known Defects
 Bugfixes
 ########
 - :ref:`SCDCalibratePanels <algm-SCDCalibratePanels-v2>` no longer returns null calibration outputs.
+- Fix failure in :ref:`HB3AFindPeaks <algm-HB3AFindPeaks>` when switching to crystallographic convention.
+- Make :ref:`ConvertWANDSCDtoQ <algm-ConvertWANDSCDtoQ>` awear of k convention.
 
 LeanElasticPeak
 ###############


### PR DESCRIPTION
**Description of work.**

- Related Gitlab task: [SCD205](https://code.ornl.gov/sns-hfir-scse/diffraction/single-crystal/single-crystal-diffraction/-/issues/283)
- This is #31066  into `master`

This PR fixes an issue where `HB3AFindPeaks` will fail when using crystallographic convention.
A similar issue in `ConvertWANDSCDtoQ` is also patched so that toggling convention will not results in error.

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

**To test:**
Use the following script on analysis cluster

```python
import numpy as np
from mantid.simpleapi import *

IPTS = 24655
exp = 724
scans = [183, 184] #34, 182

van_IPTS = 24612
van_exp = 722
van_scan = 220

Wavelength = 1.0008

# Adust detector
DetectorHeightOffset = 0
DetectorDistanceOffset = 0
OutputAsMDEventWorkspace = True
MergeInputs = False

min_values = [-10, -10, -10]
max_values = [10, 10, 10]

binning_0 = [-8.02, 8.02, 401]
binning_1 = [-2.52, 2.52, 126]
binning_2 = [-8.02, 8.02, 401]

# Find peaks
CellType = 'Orthorhombic'
Centering = 'F'
MaxPeaks = 1000
PeakDistanceThreshold = 0.25
DensityThresholdFactor = 2000

UseLattice = True
LatticeA = 5
LatticeB = 5
LatticeC = 5
LatticeAlpha = 90
LatticeBeta = 90
LatticeGamma = 90

# Integrate peaks
PeakRadius = 0.25
BackgroundInnerRadius = 0
BackgroundOuterRadius = 0
ApplyLorentz = True
OutputFormat = 'SHELX'
OutputFile = './integrated_peaks.hkl'

# Predict peaks
ReflectionCondition='B-face centred'

# Convert to HKL
h_extents = [-5.1, 5.1]
k_extents = [-2.1, 2.1]
l_extents = [-20.1, 20.1]
binning = [251, 101, 1001]

# ---

rootname = '/HFIR/HB3A/IPTS-'

filename = rootname+'{}/shared/autoreduce/HB3A_exp{:04}_scan{:04}.nxs'
data_files = ', '.join([filename.format(IPTS,exp,s) for s in scans])

vanfilename = rootname+'{}/shared/autoreduce/HB3A_exp{:04}_scan{:04}.nxs'.format(van_IPTS,van_exp,van_scan)

MinValues = str(min_values[0])+','+str(min_values[1])+','+str(min_values[2])
MaxValues = str(max_values[0])+','+str(max_values[1])+','+str(max_values[2])

BinningDim0 = str(binning_0[0])+','+str(binning_0[1])+','+str(binning_0[2])
BinningDim1 = str(binning_1[0])+','+str(binning_1[1])+','+str(binning_1[2])
BinningDim2 = str(binning_2[0])+','+str(binning_2[1])+','+str(binning_2[2])

Extents = str(h_extents[0])+','+str(h_extents[1])+','\
        + str(k_extents[0])+','+str(k_extents[1])+','\
        + str(l_extents[0])+','+str(l_extents[1])
        
Bins = str(binning[0])+','+str(binning[1])+','+str(binning[2])

from mantid import config
config['Q.convention'] = "Inelastic"
config['Q.convention'] = "Crystallography"


data = HB3AAdjustSampleNorm(Filename=data_files, 
#                            VanadiumFile=vanfilename,
                            DetectorHeightOffset=DetectorHeightOffset,
                            DetectorDistanceOffset=DetectorDistanceOffset,
                            OutputAsMDEventWorkspace=OutputAsMDEventWorkspace,
                            MergeInputs=MergeInputs,
                            MinValues=MinValues,
                            MaxValues=MaxValues,
                            BinningDim0=BinningDim0,
                            BinningDim1=BinningDim1,
                            BinningDim2=BinningDim2)
                         
peaks = HB3AFindPeaks(InputWorkspace=data,
                      CellType=CellType,
                      Centering=Centering,
                      PeakDistanceThreshold=PeakDistanceThreshold,
                      Wavelength=Wavelength)
```
No error should occur during the run.

<!-- Instructions for testing. -->

Fixes #31067. <!-- and fix #xxxx or close #xxxx xor resolves #xxxx -->
<!-- alternative
*There is no associated issue.*
-->

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or master)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
