### PR TITLE
Add brew install marker to fix mantid-developer

### DIFF
--- a/buildconfig/osx_brew_marker.conf
+++ b/buildconfig/osx_brew_marker.conf
@@ -1,0 +1,2 @@
+# Marker to trick brew into thinking we did something when a user
+# runs brew install mantid-developer


### PR DESCRIPTION
**Description of work.**

Brew requires us to do "something" when we install. Since the patch file
we previously used has gone away lets put in a text file with a comment
instead. This fixes the brew install for mantid-developer failing.

**To test:**
On OSX:
- `brew edit mantid-developer` with the change here: https://github.com/mantidproject/homebrew-mantid/pull/2
- (You may need to point to https://raw.githubusercontent.com/DavidFair/mantid/Fix_brew_formula/buildconfig/osx_brew_marker.conf instead)
- brew install mantid-developer

*There is no associated issue.*

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or master)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
