### PR TITLE
Fix segfault in PredictPeaks when instrument sample position unset

### DIFF
--- a/Framework/Crystal/src/PredictPeaks.cpp
+++ b/Framework/Crystal/src/PredictPeaks.cpp
@@ -427,7 +427,10 @@ void PredictPeaks::setRunNumberFromInputWorkspace(const ExperimentInfo_sptr &inW
 
 /// Checks that the beam direction is +Z, throws exception otherwise.
 void PredictPeaks::checkBeamDirection() const {
-  V3D samplePos = m_inst->getSample()->getPos();
+  const auto sample = m_inst->getSample();
+  if (!sample)
+    throw std::runtime_error("Instrument sample position has not been set");
+  const V3D samplePos = sample->getPos();
 
   // L1 path and direction
   V3D beamDir = m_inst->getSource()->getPos() - samplePos;

--- a/docs/source/release/v6.1.0/diffraction.rst
+++ b/docs/source/release/v6.1.0/diffraction.rst
@@ -81,6 +81,7 @@ Known Defects
 
 Bugfixes
 ########
+- :ref:`PredictPeaks <algm-PredictPeaks>` no longer segfaults when the instrument of the input workspace doesn't have the sample position set
 - :ref:`SCDCalibratePanels <algm-SCDCalibratePanels-v2>` no longer returns null calibration outputs.
 
 LeanElasticPeak


### PR DESCRIPTION
**Description of work.**

The following causes a segfault. This appears to have existed for a long time, it happens in Mantid `3.10` and probably much older versions.

```python
ws = CreatePeaksWorkspace()
p = PredictPeaks(ws)
```


---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
