### PR TITLE
Bump scipy on OSX

### DIFF
--- a/installers/MacInstaller/requirements.txt
+++ b/installers/MacInstaller/requirements.txt
@@ -10,7 +10,7 @@ mock==4.0.2
 notebook==6.1.5
 numpy==1.18.4
 requests==2.23.0
-scipy==1.4.1
+scipy==1.6.2
 six==1.14.0
 sphinx==1.6.7
 sphinx_bootstrap_theme==0.7.1


### PR DESCRIPTION
**Description of work.**

Bumps Scipy to 1.6.2 on OSX, the blocking issue https://github.com/scipy/scipy/issues/11403
has been fixed as of 1.6.0. However, our pinned version 1.4.x is
incompatible for being pip installed with Intel Big Sur resulting in install
issues

Let's remove the pin until we need it again since the upstream problem
is seemingly resolved


**To test:**
- `python3 -m pip uninstall scipy`
- Attempt to reinstall scipy using the manually provided version or manually updating requirements.txt

*There is no associated issue.*

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or master)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
