### PR TITLE
CorelliPowderCalibrationCreate: Implement rotational constraint

### DIFF
--- a/Framework/PythonInterface/plugins/algorithms/AlignComponents.py
+++ b/Framework/PythonInterface/plugins/algorithms/AlignComponents.py
@@ -28,6 +28,16 @@ class AlignComponents(PythonAlgorithm):
     _optionsList = ["Xposition", "Yposition", "Zposition", "AlphaRotation", "BetaRotation", "GammaRotation"]
     adjustment_items = ['ComponentName', 'Xposition', 'Yposition', 'Zposition',
                         'XdirectionCosine', 'YdirectionCosine', 'ZdirectionCosine', 'RotationAngle']
+    r"""Items featuring the changes in position and orientation for each bank
+    - DeltaR: change in distance from Component to Sample (in mili-meter)
+    - DeltaX: change in X-coordinate of Component (in mili-meter)
+    - DeltaY: change in Y-coordinate of Component (in mili-meter)
+    - DeltaZ: change in Z-coordinate of Component (in mili-meter)
+    Changes in Euler Angles are understood once a Euler convention is selected. If `YXZ` is selected, then:
+    - DeltaAlpha: change in rotation around the Y-axis (in degrees)
+    - DeltaBeta: change in rotation around the X-axis (in degrees)
+    - DeltaGamma: change in rotation around the Z-axis (in degrees)
+    """
     displacement_items = ['ComponentName', 'DeltaR', 'DeltaX', 'DeltaY', 'DeltaZ', 'DeltaAlpha', 'DeltaBeta', 'DeltaGamma']
     _optionsDict = {}
     _initialPos = None
@@ -344,6 +354,7 @@ class AlignComponents(PythonAlgorithm):
 
         input_workspace = self.getProperty('InputWorkspace').value
 
+        # Table containing the optimized absolute locations and orientations for each component
         adjustments_table_name = self.getProperty('AdjustmentsTable').value
         if len(adjustments_table_name) > 0:
             adjustments_table = self._initialize_adjustments_table(adjustments_table_name)
@@ -351,6 +362,7 @@ class AlignComponents(PythonAlgorithm):
         else:
             saving_adjustments = False
 
+        # Table containing the relative changes in position and euler angles for each bank component
         displacements_table_name = self.getProperty('DisplacementsTable').value
         if len(displacements_table_name) > 0:
             displacements_table = self._initialize_displacements_table(displacements_table_name)

--- a/Framework/PythonInterface/plugins/algorithms/AlignComponents.py
+++ b/Framework/PythonInterface/plugins/algorithms/AlignComponents.py
@@ -28,6 +28,7 @@ class AlignComponents(PythonAlgorithm):
     _optionsList = ["Xposition", "Yposition", "Zposition", "AlphaRotation", "BetaRotation", "GammaRotation"]
     adjustment_items = ['ComponentName', 'Xposition', 'Yposition', 'Zposition',
                         'XdirectionCosine', 'YdirectionCosine', 'ZdirectionCosine', 'RotationAngle']
+    displacement_items = ['ComponentName', 'DeltaR', 'DeltaX', 'DeltaY', 'DeltaZ', 'DeltaAlpha', 'DeltaBeta', 'DeltaGamma']
     _optionsDict = {}
     _initialPos = None
     _move = False
@@ -72,6 +73,19 @@ class AlignComponents(PythonAlgorithm):
         [self.setPropertyGroup(name, 'Reference and Input Data') for name in properties]
 
         #
+        # Output Tables
+        self.declareProperty(
+            "AdjustmentsTable", "", direction=Direction.Input,
+            doc="Name of output table containing optimized locations and orientations for each component")
+
+        self.declareProperty(
+            "DisplacementsTable", "", direction=Direction.Input,
+            doc="Name of output table containing changes in position and euler angles for each bank component")
+
+        properties = ["AdjustmentsTable", "DisplacementsTable"]
+        [self.setPropertyGroup(name, 'Output Tables') for name in properties]
+
+        #
         # Selection of the instrument and mask
         self.declareProperty(
             MatrixWorkspaceProperty("MaskWorkspace", "", optional=PropertyMode.Optional, direction=Direction.Input),
@@ -96,10 +110,6 @@ class AlignComponents(PythonAlgorithm):
         #
         # Components
         self.declareProperty(
-            "AdjustmentsTable", "", direction=Direction.Input,
-            doc="Name of output table containing optimized locations and orientations for each component")
-
-        self.declareProperty(
             name="FitSourcePosition", defaultValue=False,
             doc="Fit the source position, changes L1 (source to sample) distance. "
                 "Uses entire instrument. Occurs before Components are Aligned.")
@@ -113,7 +123,7 @@ class AlignComponents(PythonAlgorithm):
             StringArrayProperty("ComponentList", direction=Direction.Input),
             doc="Comma separated list on instrument components to refine.")
 
-        properties = ["AdjustmentsTable", "FitSourcePosition", "FitSamplePosition", "ComponentList"]
+        properties = ["FitSourcePosition", "FitSamplePosition", "ComponentList"]
         [self.setPropertyGroup(name, 'Declaration of Components') for name in properties]
 
         #
@@ -341,6 +351,13 @@ class AlignComponents(PythonAlgorithm):
         else:
             saving_adjustments = False
 
+        displacements_table_name = self.getProperty('DisplacementsTable').value
+        if len(displacements_table_name) > 0:
+            displacements_table = self._initialize_displacements_table(displacements_table_name)
+            saving_displacements = True
+        else:
+            saving_displacements = False
+
         self._eulerConvention = self.getProperty('EulerConvention').value
 
         output_workspace = self.getPropertyValue("OutputWorkspace")
@@ -359,6 +376,7 @@ class AlignComponents(PythonAlgorithm):
             self._optionsDict[rotation_option] = False
 
         # First fit L1 if selected for Source and/or Sample
+        sample_position_begin = api.mtd[wks_name].getInstrument().getSample().getPos()
         for component in "Source", "Sample":  # fit first the source position, then the sample position
             if self.getProperty("Fit"+component+"Position").value:
                 self._move = True
@@ -408,6 +426,7 @@ class AlignComponents(PythonAlgorithm):
                 comp = api.mtd[wks_name].getInstrument().getComponentByName(componentName)
                 logger.notice("Finished " + componentName + " Final position is " + str(comp.getPos()))
                 self._move = False
+        sample_position_end = api.mtd[wks_name].getInstrument().getSample().getPos()
 
         # Now fit all the remaining components, if any
         components = self.getProperty("ComponentList").value
@@ -439,6 +458,9 @@ class AlignComponents(PythonAlgorithm):
             self._initialPos = [comp.getPos().getX(), comp.getPos().getY(), comp.getPos().getZ(),
                                 eulerAngles[0], eulerAngles[1], eulerAngles[2]]
 
+            # Distance between the original position of the sample and the original position of the component
+            comp_sample_distance_begin = (comp.getPos() - sample_position_begin).norm()
+
             boundsList = []
 
             if np.all(peaks_mask[firstIndex:lastIndex + 1].astype(bool)):
@@ -454,9 +476,12 @@ class AlignComponents(PythonAlgorithm):
             minimizer_selection = self.getProperty('Minimizer').value
             if minimizer_selection == 'L-BFGS-B':
                 # scipy.opimize.minimize with the L-BFGS-B algorithm
+                logger.error(f'Setting maxiter to 1')
+                options = dict(maxiter=1)
                 results: OptimizeResult = minimize(self._minimisation_func, x0=x0List, method='L-BFGS-B',
                                                    args=(wks_name, component, firstIndex, lastIndex),
-                                                   bounds=boundsList)
+                                                   bounds=boundsList,
+                                                   options=options)
             elif minimizer_selection == 'differential_evolution':
                 results: OptimizeResult = differential_evolution(self._minimisation_func,
                                                                  bounds=boundsList,
@@ -465,13 +490,21 @@ class AlignComponents(PythonAlgorithm):
             # Apply the results to the output workspace
             xmap = self._mapOptions(results.x)
 
+            comp = get_component(component)  # adjusted component
+            # Distance between the adjusted position of the sample and the adjusted position of the component
+            comp_sample_distance_end = (comp.getPos() - sample_position_end).norm()
+
             component_adjustments = [0.] * 7  # 3 for translation, 3 for rotation axis, 1 for rotation angle
+            component_displacements = [0.] * 7 # 1 for distnace, 3 for translation, 3 for Euler angles
+            component_displacements[0] = 1000 * (comp_sample_distance_end - comp_sample_distance_begin)  # in mili-meters
 
             if self._move:
                 kwargs = dict(X=xmap[0], Y=xmap[1], Z=xmap[2], RelativePosition=False, EnableLogging=False)
                 api.MoveInstrumentComponent(wks_name, component, **kwargs)  # adjust workspace
                 api.MoveInstrumentComponent(output_workspace, component, **kwargs)  # adjust workspace
                 component_adjustments[:3] = xmap[:3]
+                for i in range(3):
+                    component_displacements[i+1] = 1000 * (xmap[i] - self._initialPos[i])  # in mili-meters
 
             if self._rotate:
                 (rotw, rotx, roty, rotz) = self._eulerToAngleAxis(xmap[3], xmap[4], xmap[5], self._eulerConvention)
@@ -479,12 +512,17 @@ class AlignComponents(PythonAlgorithm):
                 api.RotateInstrumentComponent(wks_name, component, **kwargs)  # adjust workspace
                 api.RotateInstrumentComponent(output_workspace, component, **kwargs)  # adjust workspace
                 component_adjustments[3:] = [rotx, roty, rotz, rotw]
+                for i in range(3, 6):
+                    component_displacements[i+1] = xmap[i] - self._initialPos[i]  # in degrees
 
             if saving_adjustments and (self._move or self._rotate):
                 adjustments_table.addRow([component] + component_adjustments)
 
+            if saving_displacements and (self._move or self._rotate):
+                logger.error(f'component_displacements = {[component] + component_displacements}')
+                displacements_table.addRow([component] + component_displacements)
+
             # Need to grab the component object again, as things have changed
-            comp = get_component(component)
             logger.notice("Finished " + comp.getFullName() + " Final position is " + str(comp.getPos())
                           + " Final rotation is " + str(comp.getRotation().getEulerAngles(self._eulerConvention)))
 
@@ -496,10 +534,22 @@ class AlignComponents(PythonAlgorithm):
     def _initialize_adjustments_table(self, table_name):
         r"""Create a table with appropriate column names for saving the adjustments to each component"""
         table = api.CreateEmptyTableWorkspace(OutputWorkspace=table_name)
-        item_types = ['str',
-                      'double', 'double', 'double',
-                      'double', 'double', 'double', 'double']
+        item_types = ['str',  # component name
+                      'double', 'double', 'double',  # cartesian coordinates
+                      'double', 'double', 'double',  # direction cosines of axis of rotation
+                      'double']  # angle of rotation
         for column_name, column_type in zip(self.adjustment_items, item_types):
+            table.addColumn(name=column_name, type=column_type)
+        return table
+
+    def _initialize_displacements_table(self, table_name):
+        r"""Create a table with appropriate column names for saving the relative displacements to each component"""
+        table = api.CreateEmptyTableWorkspace(OutputWorkspace=table_name)
+        item_types = ['str',  # component name
+                      'double',  # change in the distance between the component and the sample
+                      'double', 'double', 'double',  # relative displacement in cartesian coordinates
+                      'double', 'double', 'double']  # relative displacement in Euler angles
+        for column_name, column_type in zip(self.displacement_items, item_types):
             table.addColumn(name=column_name, type=column_type)
         return table
 

--- a/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/CorelliPowderCalibrationCreate.py
+++ b/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/CorelliPowderCalibrationCreate.py
@@ -231,6 +231,7 @@ class CorelliPowderCalibrationCreate(DataProcessorAlgorithm):
         mtd[diagnostics_workspaces].add(difc_table + '_mask')
 
         adjustments_table_name = f'{prefix_output}adjustments'
+        displacements_table_name = f'{prefix_output}displacements'
         # Adjust the position of the source along the beam (Z) axis
         # The instrument in `input_workspace` is adjusted in-place
         if self.getProperty('AdjustSource').value is True:
@@ -274,6 +275,7 @@ class CorelliPowderCalibrationCreate(DataProcessorAlgorithm):
                       PeakPositions=self.getProperty('PeakPositions').value,
                       MaskWorkspace=f'{difc_table}_mask',
                       AdjustmentsTable=adjustments_table_name + '_banks',
+                      DisplacementsTable=displacements_table_name,
                       FitSourcePosition=False,
                       FitSamplePosition=False,
                       ComponentList=self.getProperty('ComponentList').value,

--- a/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/CorelliPowderCalibrationCreate.py
+++ b/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/CorelliPowderCalibrationCreate.py
@@ -231,7 +231,6 @@ class CorelliPowderCalibrationCreate(DataProcessorAlgorithm):
         mtd[diagnostics_workspaces].add(difc_table + '_mask')
 
         adjustments_table_name = f'{prefix_output}adjustments'
-        displacements_table_name = f'{prefix_output}displacements'
         # Adjust the position of the source along the beam (Z) axis
         # The instrument in `input_workspace` is adjusted in-place
         if self.getProperty('AdjustSource').value is True:
@@ -241,7 +240,6 @@ class CorelliPowderCalibrationCreate(DataProcessorAlgorithm):
                           PeakCentersTofTable=peak_centers_in_tof,
                           PeakPositions=self.getProperty('PeakPositions').value,
                           MaskWorkspace=f'{difc_table}_mask',
-                          AdjustmentsTable=adjustments_table_name,
                           FitSourcePosition=True,
                           FitSamplePosition=False,
                           Zposition=True, MinZPosition=-dz, MaxZPosition=dz,
@@ -269,6 +267,7 @@ class CorelliPowderCalibrationCreate(DataProcessorAlgorithm):
                             EulerConvention='YXZ')
 
         # Remaining options for AlignComponents
+        displacements_table_name = f'{prefix_output}displacements'
         kwargs = dict(InputWorkspace=input_workspace,
                       OutputWorkspace=input_workspace,
                       PeakCentersTofTable=peak_centers_in_tof,

--- a/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/CorelliPowderCalibrationCreate.py
+++ b/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/CorelliPowderCalibrationCreate.py
@@ -289,7 +289,6 @@ class CorelliPowderCalibrationCreate(DataProcessorAlgorithm):
 
         # Append the banks table to the source table, then delete the banks table.
         self._append_second_to_first(adjustments_table_name, adjustments_table_name + '_banks')
-
         # Create one spectra in d-spacing for each bank using the adjusted instrument geometry.
         # The spectra can be compare to those of prefix_output + 'PDCalibration_peaks_original'
         self.fitted_in_dspacing(fitted_in_tof=prefix_output + 'PDCalibration_diagnostics_fitted',

--- a/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/CorelliPowderCalibrationCreate.py
+++ b/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/CorelliPowderCalibrationCreate.py
@@ -145,9 +145,10 @@ class CorelliPowderCalibrationCreate(DataProcessorAlgorithm):
                              doc='Comma separated list on banks to refine')
         self.declareProperty(name='ComponentMaxTranslation', defaultValue=0.02,
                              doc='Maximum translation of each component along either of the X, Y, Z axes (m)')
+        self.declareProperty(name='FixYaw', defaultValue=True, doc="Prevent rotations around the axis normal to the bank")
         self.declareProperty(name='ComponentMaxRotation', defaultValue=3.0,
                              doc='Maximum rotation of each component along either of the X, Y, Z axes (deg)')
-        property_names = ['ComponentList', 'ComponentMaxTranslation', 'ComponentMaxRotation']
+        property_names = ['FixY', 'ComponentList', 'ComponentMaxTranslation', 'FixYaw', 'ComponentMaxRotation']
         [self.setPropertyGroup(name, 'Banks Calibration') for name in property_names]
 
         #
@@ -250,9 +251,23 @@ class CorelliPowderCalibrationCreate(DataProcessorAlgorithm):
             self._fixed_source_set_and_table(adjustments_table_name)
         # Translate and rotate the each bank, only after the source has been adjusted
         # The instrument in `input_workspace` is adjusted in-place
+
+        # Translation options to AlignComponents
         dt = self.getProperty('ComponentMaxTranslation').value  # maximum translation along either axis
-        dr = self.getProperty('ComponentMaxRotation').value  # maximum rotation along either axis
         move_y = False if self.getProperty('FixY').value is True else True
+        kwargs_transl = dict(Xposition=True, MinXPosition=-dt, MaxXPosition=dt,
+                             Yposition=move_y, MinYPosition=-dt, MaxYPosition=dt,
+                             Zposition=True, MinZPosition=-dt, MaxZPosition=dt)
+
+        # Rotation options for AlignComponents
+        dr = self.getProperty('ComponentMaxRotation').value  # maximum rotation along either axis
+        rot_z = False if self.getProperty('FixYaw').value is True else True
+        kwargs_rotat = dict(AlphaRotation=True, MinAlphaRotation=-dr, MaxAlphaRotation=dr,
+                            BetaRotation=True, MinBetaRotation=-dr, MaxBetaRotation=dr,
+                            GammaRotation=rot_z, MinGammaRotation=-dr, MaxGammaRotation=dr,
+                            EulerConvention='YXZ')
+
+        # Remaining options for AlignComponents
         kwargs = dict(InputWorkspace=input_workspace,
                       OutputWorkspace=input_workspace,
                       PeakCentersTofTable=peak_centers_in_tof,
@@ -262,16 +277,10 @@ class CorelliPowderCalibrationCreate(DataProcessorAlgorithm):
                       FitSourcePosition=False,
                       FitSamplePosition=False,
                       ComponentList=self.getProperty('ComponentList').value,
-                      Xposition=True, MinXPosition=-dt, MaxXPosition=dt,
-                      Yposition=move_y, MinYPosition=-dt, MaxYPosition=dt,
-                      Zposition=True, MinZPosition=-dt, MaxZPosition=dt,
-                      AlphaRotation=True, MinAlphaRotation=-dr, MaxAlphaRotation=dr,
-                      BetaRotation=True, MinBetaRotation=-dr, MaxBetaRotation=dr,
-                      GammaRotation=True, MinGammaRotation=-dr, MaxGammaRotation=dr,
-                      EulerConvention='YXZ',
                       Minimizer=self.getProperty('Minimizer').value,
                       MaxIterations=self.getProperty('MaxIterations').value)
-        self.run_algorithm('AlignComponents', 0.2, 0.97, **kwargs)
+
+        self.run_algorithm('AlignComponents', 0.2, 0.97, **kwargs, **kwargs_transl, **kwargs_rotat)
         progress.report('AlignComponents has been applied')
 
         # AlignComponents produces two unwanted workspaces

--- a/Framework/PythonInterface/test/python/plugins/algorithms/WorkflowAlgorithms/CorelliPowderCalibrationCreateTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/WorkflowAlgorithms/CorelliPowderCalibrationCreateTest.py
@@ -60,7 +60,7 @@ class CorelliPowderCalibrationCreateTest(unittest.TestCase):
             CorelliPowderCalibrationCreate(
                 InputWorkspace='perturbed', OutputWorkspacesPrefix='cal_',
                 TofBinning=[300, 1.0, 16666.7], PeakPositions=self.spacings_reference, SourceToSampleDistance=10.0,
-                FixY=False, ComponentList='bank1', ComponentMaxTranslation=0.03, FixYaw=False, ComponentMaxRotation=6,
+                ComponentList='bank1', FixY=False, ComponentMaxTranslation=0.03, FixYaw=False, ComponentMaxRotation=6,
                 Minimizer='differential_evolution', MaxIterations=10)
         ConvertUnits(InputWorkspace='perturbed', Target='dSpacing', EMode='Elastic', OutputWorkspace='perturbed_dS')
         results = CompareWorkspaces(Workspace1='test_workspace_dSpacing', Workspace2='perturbed_dS', Tolerance=0.001,
@@ -74,7 +74,7 @@ class CorelliPowderCalibrationCreateTest(unittest.TestCase):
             CorelliPowderCalibrationCreate(
                 InputWorkspace='test_workspace_TOF', OutputWorkspacesPrefix='cal_',
                 TofBinning=[300, 1.0, 16666.7], PeakPositions=self.spacings_reference, FixSource=True,
-                AdjustSource=True, FixY=False, ComponentList='bank1', ComponentMaxTranslation=0.2,
+                AdjustSource=True, ComponentList='bank1', FixY=False, ComponentMaxTranslation=0.2,
                 FixYaw=False, ComponentMaxRotation=10)
         except RuntimeError as error:
             assert 'Some invalid Properties found' in str(error)
@@ -84,7 +84,7 @@ class CorelliPowderCalibrationCreateTest(unittest.TestCase):
             CorelliPowderCalibrationCreate(
                 InputWorkspace='test_workspace_TOF', OutputWorkspacesPrefix='cal_',
                 TofBinning=[300, 1.0, 16666.7], PeakPositions=self.spacings_reference, FixSource=False,
-                AdjustSource=False, FixY=False, ComponentList='bank1', FixYaw=False, ComponentMaxTranslation=0.2,
+                AdjustSource=False, ComponentList='bank1', FixY=False, ComponentMaxTranslation=0.2,
                 FixYaw=False, ComponentMaxRotation=10)
         except RuntimeError as error:
             assert 'Some invalid Properties found' in str(error)
@@ -127,7 +127,7 @@ class CorelliPowderCalibrationCreateTest(unittest.TestCase):
         CorelliPowderCalibrationCreate(
             InputWorkspace='perturbed', OutputWorkspacesPrefix='cal_',
             TofBinning=[300, 1.0, 16666.7], PeakPositions=self.spacings_reference, SourceToSampleDistance=10.0,
-            FixY=True, ComponentList='bank1', ComponentMaxTranslation=0.2, ComponentMaxRotation=10,
+            ComponentList='bank1', FixY=True, ComponentMaxTranslation=0.2, ComponentMaxRotation=10,
             Minimizer='L-BFGS-B')
         # Check Y-position of first bank hasn't changed
         row = mtd['cal_adjustments'].row(1)

--- a/Framework/PythonInterface/test/python/plugins/algorithms/WorkflowAlgorithms/CorelliPowderCalibrationCreateTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/WorkflowAlgorithms/CorelliPowderCalibrationCreateTest.py
@@ -84,7 +84,7 @@ class CorelliPowderCalibrationCreateTest(unittest.TestCase):
             CorelliPowderCalibrationCreate(
                 InputWorkspace='test_workspace_TOF', OutputWorkspacesPrefix='cal_',
                 TofBinning=[300, 1.0, 16666.7], PeakPositions=self.spacings_reference, FixSource=False,
-                AdjustSource=False, FixY=False, ComponentList='bank1', FixY=False, ComponentMaxTranslation=0.2,
+                AdjustSource=False, FixY=False, ComponentList='bank1', FixYaw=False, ComponentMaxTranslation=0.2,
                 FixYaw=False, ComponentMaxRotation=10)
         except RuntimeError as error:
             assert 'Some invalid Properties found' in str(error)

--- a/Framework/PythonInterface/test/python/plugins/algorithms/WorkflowAlgorithms/CorelliPowderCalibrationCreateTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/WorkflowAlgorithms/CorelliPowderCalibrationCreateTest.py
@@ -60,7 +60,7 @@ class CorelliPowderCalibrationCreateTest(unittest.TestCase):
             CorelliPowderCalibrationCreate(
                 InputWorkspace='perturbed', OutputWorkspacesPrefix='cal_',
                 TofBinning=[300, 1.0, 16666.7], PeakPositions=self.spacings_reference, SourceToSampleDistance=10.0,
-                FixY=False, ComponentList='bank1', ComponentMaxTranslation=0.03, ComponentMaxRotation=6,
+                FixY=False, ComponentList='bank1', ComponentMaxTranslation=0.03, FixYaw=False, ComponentMaxRotation=6,
                 Minimizer='differential_evolution', MaxIterations=10)
         ConvertUnits(InputWorkspace='perturbed', Target='dSpacing', EMode='Elastic', OutputWorkspace='perturbed_dS')
         results = CompareWorkspaces(Workspace1='test_workspace_dSpacing', Workspace2='perturbed_dS', Tolerance=0.001,
@@ -75,7 +75,7 @@ class CorelliPowderCalibrationCreateTest(unittest.TestCase):
                 InputWorkspace='test_workspace_TOF', OutputWorkspacesPrefix='cal_',
                 TofBinning=[300, 1.0, 16666.7], PeakPositions=self.spacings_reference, FixSource=True,
                 AdjustSource=True, FixY=False, ComponentList='bank1', ComponentMaxTranslation=0.2,
-                ComponentMaxRotation=10)
+                FixYaw=False, ComponentMaxRotation=10)
         except RuntimeError as error:
             assert 'Some invalid Properties found' in str(error)
 
@@ -84,8 +84,8 @@ class CorelliPowderCalibrationCreateTest(unittest.TestCase):
             CorelliPowderCalibrationCreate(
                 InputWorkspace='test_workspace_TOF', OutputWorkspacesPrefix='cal_',
                 TofBinning=[300, 1.0, 16666.7], PeakPositions=self.spacings_reference, FixSource=False,
-                AdjustSource=False, FixY=False, ComponentList='bank1', ComponentMaxTranslation=0.2,
-                ComponentMaxRotation=10)
+                AdjustSource=False, FixY=False, ComponentList='bank1', FixY=False, ComponentMaxTranslation=0.2,
+                FixYaw=False, ComponentMaxRotation=10)
         except RuntimeError as error:
             assert 'Some invalid Properties found' in str(error)
 
@@ -134,6 +134,20 @@ class CorelliPowderCalibrationCreateTest(unittest.TestCase):
         self.assertAlmostEquals(row['Yposition'], y, places=5)
         DeleteWorkspaces(['perturbed'])
 
+    def test_fix_yaw(self) -> None:
+        CloneWorkspace(InputWorkspace='test_workspace_TOF', OutputWorkspace='perturbed')
+        RotateInstrumentComponent(Workspace='perturbed', ComponentName='bank1', X=0, Y=0, z=1, Angle=5,
+                                  RelativeRotation=True)
+        r"""Pass option FixYaw=True"""
+        CorelliPowderCalibrationCreate(
+            InputWorkspace='perturbed', OutputWorkspacesPrefix='cal_',
+            TofBinning=[300, 1.0, 16666.7], PeakPositions=self.spacings_reference, SourceToSampleDistance=10.0,
+            ComponentList='bank1', ComponentMaxTranslation=0.2, FixYaw=True, ComponentMaxRotation=10,
+            Minimizer='L-BFGS-B')
+        # Check no change in the rotations around Z-axis of first bank
+        row = mtd['cal_displacements'].row(1)
+        self.assertAlmostEquals(row['DeltaGamma'], 0.0, places=5)
+        DeleteWorkspaces(['perturbed'])
 
 if __name__ == '__main__':
     unittest.main()

--- a/Framework/PythonInterface/test/python/plugins/algorithms/WorkflowAlgorithms/CorelliPowderCalibrationCreateTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/WorkflowAlgorithms/CorelliPowderCalibrationCreateTest.py
@@ -145,7 +145,7 @@ class CorelliPowderCalibrationCreateTest(unittest.TestCase):
             ComponentList='bank1', ComponentMaxTranslation=0.2, FixYaw=True, ComponentMaxRotation=10,
             Minimizer='L-BFGS-B')
         # Check no change in the rotations around Z-axis of first bank
-        row = mtd['cal_displacements'].row(1)
+        row = mtd['cal_displacements'].row(0)
         self.assertAlmostEquals(row['DeltaGamma'], 0.0, places=5)
         DeleteWorkspaces(['perturbed'])
 

--- a/Testing/SystemTests/tests/framework/CorelliPowderCalibrationTest.py
+++ b/Testing/SystemTests/tests/framework/CorelliPowderCalibrationTest.py
@@ -36,7 +36,9 @@ class CorelliPowderCalibrationCreateTest(MantidSystemTest):
                                        PeakPositions=[1.3143, 1.3854, 1.6967, 1.8587, 2.0781, 2.3995, 2.9388, 4.1561],
                                        SourceMaxTranslation=0.1,
                                        ComponentList='bank42/sixteenpack,bank87/sixteenpack',
+                                       FixY=False,
                                        ComponentMaxTranslation=0.02,
+                                       FixYaw=False,
                                        ComponentMaxRotation=3.0)
         table = mtd['LaB6_adjustments']
         # Check position of the moderator

--- a/docs/source/algorithms/AlignComponents-v1.rst
+++ b/docs/source/algorithms/AlignComponents-v1.rst
@@ -78,6 +78,23 @@ example below).
 The source and sample positions (in that order) are aligned before any
 components are aligned.
 
+Displacements Table
+###################
+This table lists changes in position and orientation for each component
+other than the source and sample.
+
+- `DeltaR`: change in distance from Component to Sample (in mili-meter)
+- `DeltaX`: change in X-coordinate of Component (in mili-meter)
+- `DeltaY`: change in Y-coordinate of Component (in mili-meter)
+- `DeltaZ`: change in Z-coordinate of Component (in mili-meter)
+
+Changes in Euler Angles are understood once a Euler convention is selected. If
+`YXZ` is selected, then:
+
+- `DeltaAlpha`: change in rotation around the Y-axis (in degrees)
+- `DeltaBeta`: change in rotation around the X-axis (in degrees)
+- `DeltaGamma`: change in rotation around the Z-axis (in degrees)
+
 .. categories::
 
 .. sourcelink::

--- a/docs/source/algorithms/CorelliPowderCalibrationCreate-v1.rst
+++ b/docs/source/algorithms/CorelliPowderCalibrationCreate-v1.rst
@@ -86,6 +86,20 @@ In our example, we have adjusted the moderator and banks 42 and 87.
 - ``XdirectionCosine``, ``YdirectionCosine``, ``ZdirectionCosine``: direction cosines in the lab's frame of reference. They define a rotation axis to set the orientation of ``ComponentName``.
 - ``RotationAngle``: rotate this many degrees around the previous rotation axis to set the orientation of ``ComponentName``.
 
+While ``LaB6_adjustments`` contains absolute position and orientation values, table ``LaB6_displacements`` lists
+changes in position and orientation for each Bank, as follows:
+
+- `DeltaR`: change in distance from Component to Sample (in mili-meter)
+- `DeltaX`: change in X-coordinate of Component (in mili-meter)
+- `DeltaY`: change in Y-coordinate of Component (in mili-meter)
+- `DeltaZ`: change in Z-coordinate of Component (in mili-meter)
+- `DeltaAlpha`: change in rotation around the Y-axis (in degrees)
+- `DeltaBeta`: change in rotation around the X-axis (in degrees)
+- `DeltaGamma`: change in rotation around the Z-axis (in degrees)
+
+Option `FixY=True` will result in `DeltaY=0` for all banks. Similarly, option `FixYaw=True` will result in
+`DeltaGamma=0` for all banks.
+
 The diagnostics workspaces are stored within ``WorkspaceGroup LaB6_bank_adjustment_diagnostics``. These are:
 
 - ``LaB6_PDCalibration_peaks_original`` and ``LaB6_PDCalibration_peaks_adjustments`` contains one fitted-intensity spectrum per bank versus ``d-spacing`` before and after the banks are adjusted.

--- a/docs/source/release/v6.1.0/diffraction.rst
+++ b/docs/source/release/v6.1.0/diffraction.rst
@@ -30,6 +30,8 @@ Improvements
 - Differential evolution minimizer added to :ref:`AlignComponents <algm-AlignComponents>`.
 - Differential evolution minimizer added to :ref:`CorelliPowderCalibrationCreate <algm-CorelliPowderCalibrationCreate>`.
 - Added option to fix banks' vertical coordinate :ref:`CorelliPowderCalibrationCreate <algm-CorelliPowderCalibrationCreate>`.
+- :ref:`AlignComponents <algm-AlignComponents>` has option to output a table listing the changes in position and orientation for each component
+- :ref:`CorelliPowderCalibrationCreate <algm-CorelliPowderCalibrationCreate>` now outputs a table listing the changes in position and orientation for each bank
 
 Bugfixes
 ########


### PR DESCRIPTION
**Description of work.**
- [x] Option in `AlignComponents` to output table listing changes in position and orientation for each bank
- [x] Update documentation in `AlignComponents`
- [x] Option in `CorelliPowderCalibrationCreate` to prevent rotations of the bank around its normal axis
- [x] Update documentation in `CorelliPowderCalibrationCreate`
- [x] Unit test for fixed roation
- [x] Preserve existing system test with original options
- [x] Updated release notes

**To test:**  
In the analysis machines, run this scripts (takes ~15 minutes)
```python
from mantid.simpleapi import *
import matplotlib.pyplot as plt
import numpy as np
from corelli.calibration import load_calibration_set, apply_calibration
from corelli.calibration.powder import load_and_rebin

##############################################
# CREATE A POWDER CALIBRATION WITH Si SAMPLE
##############################################
Load(Filename='CORELLI_165752-165763',  # Silicon powder runs
     OutputWorkspace='Si',
     BankName='bank52, bank70', # only for testing purposes
     LoadLogs=False)

##############################################
# LOAD AND APPLY THE TUBE CALIBRATION
##############################################
load_calibration_set(input_workspace='Si', database_path='/SNS/CORELLI/shared/calibration/tube', output_calibration_name='tube_calibration')
apply_calibration(workspace='Si', output_workspace='Si', calibration_table='tube_calibration')

# Workspace Si_uncalibrated contains just the summed intensities and the uncalibrated instrument. Saves memory
Rebin(InputWorkspace='Si', OutputWorkspace='Si_uncalibrated', Params=[3000,13600,16660], PreserveEvents=False)

##############################################
# RUN THE POWDER CALIBRATION
##############################################
si_dspacings = [0.9179, 0.9600, 1.0451, 1.2458, 1.3576, 1.5677, 1.6374, 3.1353]
CorelliPowderCalibrationCreate(InputWorkspace='Si',
                               ComponentList='bank52/sixteenpack,bank70/sixteenpack',
                               TofBinning=[3000,-0.001,16660],
                               PeakPositions=si_dspacings,
                               OutputWorkspacesPrefix='Si_',
                               FixSource=True,
                               SourceToSampleDistance=20.04,
                               ComponentMaxTranslation=0.02,  # 2 cm
                               FixY=True,  # no displacements of the banks along the vertical axis
                               ComponentMaxRotation=3,  # 3 degree
                               FixYaw=True, # no rotations around the axis normal to the bank
                               Minimizer='L-BFGS-B')
# Workspace Si contains just the summed intensities and the uncalibrated instrument. Saves memory
Rebin(InputWorkspace='Si', OutputWorkspace='Si', Params=[3000,13600,16660], PreserveEvents=False)  # calibrated instrument
```
In table `Si_displacements`, check that `DeltaGamma` is zero for both banks

*There is no associated issue.*

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
