### PR TITLE
Create SetValueWhenProperty method and edit IntegratePeaksMD dialog

### DIFF
--- a/Framework/Algorithms/inc/MantidAlgorithms/NormaliseToMonitor.h
+++ b/Framework/Algorithms/inc/MantidAlgorithms/NormaliseToMonitor.h
@@ -128,7 +128,8 @@ public:
         is_enabled(true) {}
   // if input to this property is enabled
   bool isEnabled(const Mantid::Kernel::IPropertyManager *algo) const override;
-  bool isConditionChanged(const Mantid::Kernel::IPropertyManager *algo) const override;
+  bool isConditionChanged(const Mantid::Kernel::IPropertyManager *algo,
+                          const std::string &changedPropName = "") const override;
   void applyChanges(const Mantid::Kernel::IPropertyManager *algo, Kernel::Property *const pProp) override;
 
   // interface needs it but if indeed proper clone used -- do not know.

--- a/Framework/Algorithms/src/NormaliseToMonitor.cpp
+++ b/Framework/Algorithms/src/NormaliseToMonitor.cpp
@@ -64,7 +64,8 @@ bool MonIDPropChanger::isEnabled(const IPropertyManager *algo) const {
 
 // method checks if other properties have changed and these changes affected
 // MonID property
-bool MonIDPropChanger::isConditionChanged(const IPropertyManager *algo) const {
+bool MonIDPropChanger::isConditionChanged(const IPropertyManager *algo, const std::string &changedPropName) const {
+  UNUSED_ARG(changedPropName);
   // is enabled is based on other properties:
   if (!is_enabled)
     return false;

--- a/Framework/Kernel/CMakeLists.txt
+++ b/Framework/Kernel/CMakeLists.txt
@@ -1,4 +1,5 @@
 set(SRC_FILES
+    src/SetValueWhenProperty.cpp
     src/ANN_complete.cpp
     src/ArrayBoundedValidator.cpp
     src/ArrayLengthValidator.cpp
@@ -139,6 +140,7 @@ set(SRC_UNITY_IGNORE_FILES
     src/System.cpp)
 
 set(INC_FILES
+    inc/MantidKernel/SetValueWhenProperty.h
     inc/MantidKernel/ANN/ANN.h
     inc/MantidKernel/ANN/ANNperf.h
     inc/MantidKernel/ANN/ANNx.h

--- a/Framework/Kernel/inc/MantidKernel/IPropertySettings.h
+++ b/Framework/Kernel/inc/MantidKernel/IPropertySettings.h
@@ -7,6 +7,7 @@
 #pragma once
 
 #include "MantidKernel/System.h"
+#include <string>
 
 namespace Mantid {
 namespace Kernel {
@@ -44,18 +45,20 @@ public:
   }
   /** to verify if the properties, this one depends on have changed
       or other special condition occurs which needs the framework to react to */
-  virtual bool isConditionChanged(const IPropertyManager *algo) const {
+  virtual bool isConditionChanged(const IPropertyManager *algo, const std::string &changedPropName = "") const {
     UNUSED_ARG(algo);
+    UNUSED_ARG(changedPropName);
     return false;
   }
-  /** The function user have to overload it in his custom code to modify the
+
+  /** The function user have to overload it in their custom code to modify the
    property
       according to the changes to other properties.
    *
    *  Currently it has been tested to modify the property values as function of
    other properties
    *
-   *  Allowed property valies are obtrained from property's allowedValues
+   *  Allowed property values are obtained from property's allowedValues
    function, and the purpose the
    *  function interfaced here is to modify its output.
    *

--- a/Framework/Kernel/inc/MantidKernel/SetValueWhenProperty.h
+++ b/Framework/Kernel/inc/MantidKernel/SetValueWhenProperty.h
@@ -6,11 +6,9 @@
 // SPDX - License - Identifier: GPL - 3.0 +
 #pragma once
 
+#include "MantidKernel/DllConfig.h"
 #include "MantidKernel/IPropertySettings.h"
-#include "MantidKernel/System.h"
 #include <functional>
-#include <iostream>
-#include <memory>
 #include <string>
 
 namespace Mantid {
@@ -20,7 +18,7 @@ namespace Kernel {
 class IPropertyManager;
 class Property;
 
-class DLLExport SetValueWhenProperty : public IPropertySettings {
+class MANTID_KERNEL_DLL SetValueWhenProperty : public IPropertySettings {
 public:
   /// Constructs an SetValueWhenProperty object which checks the
   /// watched property with name given and uses the given

--- a/Framework/Kernel/inc/MantidKernel/SetValueWhenProperty.h
+++ b/Framework/Kernel/inc/MantidKernel/SetValueWhenProperty.h
@@ -1,0 +1,56 @@
+// Mantid Repository : https://github.com/mantidproject/mantid
+//
+// Copyright &copy; 2021 ISIS Rutherford Appleton Laboratory UKRI,
+//   NScD Oak Ridge National Laboratory, European Spallation Source,
+//   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+// SPDX - License - Identifier: GPL - 3.0 +
+#pragma once
+
+#include "MantidKernel/IPropertySettings.h"
+#include "MantidKernel/System.h"
+#include <functional>
+#include <iostream>
+#include <memory>
+#include <string>
+
+namespace Mantid {
+namespace Kernel {
+
+// Forward declarations
+class IPropertyManager;
+class Property;
+
+class DLLExport SetValueWhenProperty : public IPropertySettings {
+public:
+  /// Constructs an SetValueWhenProperty object which checks the
+  /// watched property with name given and uses the given
+  /// function to check if changes should be applied
+  SetValueWhenProperty(const std::string &watchedPropName,
+                       const std::function<std::string(std::string, std::string)> &changeCriterion)
+      : IPropertySettings(), m_watchedPropName{watchedPropName}, m_changeCriterion{changeCriterion} {}
+
+  /// Return true always
+  bool isConditionChanged(const IPropertyManager *algo, const std::string &changedPropName) const override;
+
+  /// If a new value should be set, the change is applied here
+  void applyChanges(const Mantid::Kernel::IPropertyManager *algo, Kernel::Property *const pProp) override;
+
+  /// Stub function to satisfy the interface.
+  void modify_allowed_values(Property *const);
+
+  /// Checks the algorithm and property are both valid and attempts
+  /// to get the value associated with the property
+  std::string getPropertyValue(const IPropertyManager *algo) const;
+  /// Make a copy of the present type of IPropertySettings
+  IPropertySettings *clone() const override;
+
+private:
+  /// Name of the watched property, based on which we may
+  /// set the value of the current property
+  std::string m_watchedPropName;
+  /// Function to check if changes should be applied
+  std::function<std::string(std::string, std::string)> m_changeCriterion;
+};
+
+} // namespace Kernel
+} // namespace Mantid

--- a/Framework/Kernel/src/SetValueWhenProperty.cpp
+++ b/Framework/Kernel/src/SetValueWhenProperty.cpp
@@ -1,0 +1,81 @@
+// Mantid Repository : https://github.com/mantidproject/mantid
+//
+// Copyright &copy; 2021 ISIS Rutherford Appleton Laboratory UKRI,
+//   NScD Oak Ridge National Laboratory, European Spallation Source,
+//   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+// SPDX - License - Identifier: GPL - 3.0 +
+#include "MantidKernel/SetValueWhenProperty.h"
+
+#include "MantidKernel/Exception.h"
+#include "MantidKernel/IPropertyManager.h"
+#include "MantidKernel/IPropertySettings.h"
+#include "MantidKernel/Property.h"
+
+#include <boost/lexical_cast.hpp>
+#include <cassert>
+#include <exception>
+#include <iostream>
+#include <memory>
+#include <stdexcept>
+
+using namespace Mantid::Kernel;
+
+namespace Mantid {
+namespace Kernel {
+
+/**
+ * Checks the algorithm given is in a valid state and the property
+ * exists then proceeds to try to get the value associated
+ *
+ * @param algo :: The pointer to the algorithm to process
+ * @return :: The value contained by said property
+ * @throw :: Throws if anything is wrong with the property or algorithm
+ */
+std::string SetValueWhenProperty::getPropertyValue(const IPropertyManager *algo) const {
+  // Find the property
+  if (algo == nullptr)
+    throw std::runtime_error("Algorithm properties passed to SetValueWhenProperty was null");
+
+  Property *prop = nullptr;
+  try {
+    prop = algo->getPointerToProperty(m_watchedPropName);
+  } catch (Exception::NotFoundError &) {
+    prop = nullptr; // Ensure we still have null pointer
+  }
+  if (!prop)
+    throw std::runtime_error("Property " + m_watchedPropName + " was not found in SetValueWhenProperty");
+  return prop->value();
+}
+
+/**
+ * Always returns true as SetValueWhenProperty always wants to check
+ * if the property it depends on has changed
+ *
+ * @param algo :: Pointer to the algorithm containing the property
+ * @param changedPropName :: Name of the property that has just been changed by the user
+ * @return  :: True if the Property we are watching is the property that just changed, otherwise False
+ */
+bool SetValueWhenProperty::isConditionChanged(const IPropertyManager *algo, const std::string &changedPropName) const {
+  auto watchedProp = algo->getPointerToProperty(m_watchedPropName);
+  bool hasWatchedPropChanged = 0;
+  if (watchedProp->name() == changedPropName) {
+    hasWatchedPropChanged = 1;
+  }
+
+  return hasWatchedPropChanged;
+}
+
+void SetValueWhenProperty::applyChanges(const IPropertyManager *algo, Kernel::Property *const currentProperty) {
+  const std::string watchedPropertyValue = getPropertyValue(algo);
+
+  std::string newValue = m_changeCriterion(currentProperty->value(), watchedPropertyValue);
+  currentProperty->setValue(newValue);
+}
+
+/// Does nothing in this case and put here to satisfy the interface.
+void SetValueWhenProperty::modify_allowed_values(Property *const /*unused*/) {}
+
+IPropertySettings *SetValueWhenProperty::clone() const { return new SetValueWhenProperty(*this); }
+
+} // namespace Kernel
+} // namespace Mantid

--- a/Framework/Kernel/src/SetValueWhenProperty.cpp
+++ b/Framework/Kernel/src/SetValueWhenProperty.cpp
@@ -14,8 +14,6 @@
 #include <boost/lexical_cast.hpp>
 #include <cassert>
 #include <exception>
-#include <iostream>
-#include <memory>
 #include <stdexcept>
 
 using namespace Mantid::Kernel;

--- a/Framework/MDAlgorithms/inc/MantidMDAlgorithms/IntegratePeaksMD2.h
+++ b/Framework/MDAlgorithms/inc/MantidMDAlgorithms/IntegratePeaksMD2.h
@@ -33,7 +33,9 @@ public:
   /// Summary of algorithms purpose
   const std::string summary() const override {
     return "Integrate single-crystal peaks in reciprocal space, for "
-           "MDEventWorkspaces.";
+           "MDEventWorkspaces. \n\n"
+           "Sphere is the default shape: tick Ellipsoid or Cylinder "
+           "to change shape.";
   }
 
   /// Algorithm's version for identification

--- a/Framework/MDAlgorithms/src/IntegratePeaksMD2.cpp
+++ b/Framework/MDAlgorithms/src/IntegratePeaksMD2.cpp
@@ -245,8 +245,6 @@ void IntegratePeaksMD2::init() {
   setPropertySettings("MaxIterations", std::make_unique<VisibleWhenProperty>("Ellipsoid", IS_EQUAL_TO, "1"));
 
   // Disable / greyed out these Properties based on the value of another
-  setPropertySettings("AdaptiveQMultiplier",
-                      std::make_unique<Kernel::EnabledWhenProperty>("AdaptiveQBackground", IS_EQUAL_TO, "1"));
   setPropertySettings("CorrectIfOnEdge",
                       std::make_unique<Kernel::EnabledWhenProperty>("IntegrateIfOnEdge", IS_EQUAL_TO, "1"));
 }
@@ -258,6 +256,7 @@ std::map<std::string, std::string> IntegratePeaksMD2::validateInputs() {
   std::vector<double> BackgroundInnerRadius = getProperty("BackgroundInnerRadius");
   std::vector<double> BackgroundOuterRadius = getProperty("BackgroundOuterRadius");
   bool ellipsoid = getProperty("Ellipsoid");
+  bool cylinder = getProperty("Cylinder");
 
   if (PeakRadius.size() != 1 && PeakRadius.size() != 3) {
     std::stringstream errmsg;
@@ -293,6 +292,13 @@ std::map<std::string, std::string> IntegratePeaksMD2::validateInputs() {
     std::stringstream errmsg;
     errmsg << "One value must be specified when Ellipsoid is false";
     result["BackgroundOuterRadius"] = errmsg.str();
+  }
+
+  if (ellipsoid && cylinder) {
+    std::stringstream errmsg;
+    errmsg << "Ellipsoid and Cylinder cannot both be true";
+    result["Ellipsoid"] = errmsg.str();
+    result["Cylinder"] = errmsg.str();
   }
 
   return result;

--- a/Framework/MDAlgorithms/src/IntegratePeaksMD2.cpp
+++ b/Framework/MDAlgorithms/src/IntegratePeaksMD2.cpp
@@ -31,9 +31,12 @@
 #include "MantidHistogramData/LinearGenerator.h"
 #include "MantidKernel/ArrayBoundedValidator.h"
 #include "MantidKernel/ArrayProperty.h"
+#include "MantidKernel/EnabledWhenProperty.h"
 #include "MantidKernel/ListValidator.h"
+#include "MantidKernel/SetValueWhenProperty.h"
 #include "MantidKernel/System.h"
 #include "MantidKernel/Utils.h"
+#include "MantidKernel/VisibleWhenProperty.h"
 #include "MantidMDAlgorithms/GSLFunctions.h"
 #include "MantidMDAlgorithms/MDBoxMaskFunction.h"
 
@@ -109,11 +112,9 @@ void IntegratePeaksMD2::init() {
                   "BackgroundOuterRadius + AdaptiveQMultiplier * **|Q|** and "
                   "BackgroundInnerRadius + AdaptiveQMultiplier * **|Q|**");
 
-  std::string ellip_grp = "Ellipsoid Integration";
   declareProperty("Ellipsoid", false, "Default is sphere.");
-  setPropertyGroup("Ellipsoid", ellip_grp);
+
   declareProperty("FixQAxis", false, "Fix one axis of ellipsoid to be along direction of Q.");
-  setPropertyGroup("FixQAxis", ellip_grp);
 
   declareProperty("Cylinder", false, "Default is sphere.  Use next five parameters for cylinder.");
 
@@ -166,17 +167,88 @@ void IntegratePeaksMD2::init() {
                   "PeakRadius. If False then the ellipsoid radii are set to "
                   "3 times the sqrt of the eigenvalues of the covariance "
                   "matrix");
-  setPropertyGroup("FixMajorAxisLength", ellip_grp);
+
   declareProperty("UseCentroid", false,
                   "Perform integration on estimated centroid not peak position "
                   "(ignored if all three peak radii are specified).");
-  setPropertyGroup("UseCentroid", ellip_grp);
+
   auto maxIterValidator = std::make_shared<BoundedValidator<int>>();
   maxIterValidator->setLower(1);
   declareProperty("MaxIterations", 1, maxIterValidator,
                   "Number of iterations in covariance estimation (ignored if all "
                   "peak radii are specified). 2-3 should be sufficient.");
+
+  // Group Properties
+  std::string general_grp = "General Inputs";
+  std::string cylin_grp = "Cylindrical Integration";
+  std::string ellip_grp = "Ellipsoid Integration";
+
+  setPropertyGroup("InputWorkspace", general_grp);
+  setPropertyGroup("PeakRadius", general_grp);
+  setPropertyGroup("BackgroundInnerRadius", general_grp);
+  setPropertyGroup("BackgroundOuterRadius", general_grp);
+  setPropertyGroup("PeaksWorkspace", general_grp);
+  setPropertyGroup("OutputWorkspace", general_grp);
+  setPropertyGroup("ReplaceIntensity", general_grp);
+  setPropertyGroup("IntegrateIfOnEdge", general_grp);
+  setPropertyGroup("AdaptiveQBackground", general_grp);
+
+  setPropertyGroup("Ellipsoid", ellip_grp);
+  setPropertyGroup("FixQAxis", ellip_grp);
+
+  setPropertyGroup("Cylinder", cylin_grp);
+  setPropertyGroup("CylinderLength", cylin_grp);
+  setPropertyGroup("PercentBackground", cylin_grp);
+  setPropertyGroup("ProfileFunction", cylin_grp);
+  setPropertyGroup("IntegrationOption", cylin_grp);
+  setPropertyGroup("ProfilesFile", cylin_grp);
+
+  setPropertyGroup("AdaptiveQMultiplier", general_grp);
+  setPropertyGroup("CorrectIfOnEdge", general_grp);
+  setPropertyGroup("UseOnePercentBackgroundCorrection", general_grp);
+
+  setPropertyGroup("FixMajorAxisLength", ellip_grp);
+  setPropertyGroup("UseCentroid", ellip_grp);
   setPropertyGroup("MaxIterations", ellip_grp);
+
+  // SetValue when another property value changes
+  setPropertySettings(
+      "Ellipsoid", std::make_unique<SetValueWhenProperty>("Cylinder", [](std::string ellipsoid, std::string cylinder) {
+        // Set Ellipsoid to 0, if user has set Cylinder to 1
+        if (ellipsoid == "1" && cylinder == "1") {
+          return std::string{"0"};
+        } else {
+          return ellipsoid;
+        };
+      }));
+  setPropertySettings(
+      "Cylinder", std::make_unique<SetValueWhenProperty>("Ellipsoid", [](std::string cylinder, std::string ellipsoid) {
+        // Set Cylinder to 0, if user has set Ellipsoid to 1
+        if (cylinder == "1" && ellipsoid == "1") {
+          return std::string{"0"};
+        } else {
+          return cylinder;
+        };
+      }));
+
+  // Set these Properties as visible only when Cylinder = 1
+  setPropertySettings("CylinderLength", std::make_unique<VisibleWhenProperty>("Cylinder", IS_EQUAL_TO, "1"));
+  setPropertySettings("PercentBackground", std::make_unique<VisibleWhenProperty>("Cylinder", IS_EQUAL_TO, "1"));
+  setPropertySettings("ProfileFunction", std::make_unique<VisibleWhenProperty>("Cylinder", IS_EQUAL_TO, "1"));
+  setPropertySettings("IntegrationOption", std::make_unique<VisibleWhenProperty>("Cylinder", IS_EQUAL_TO, "1"));
+  setPropertySettings("ProfilesFile", std::make_unique<VisibleWhenProperty>("Cylinder", IS_EQUAL_TO, "1"));
+
+  // Set these Properties as visible only when Ellipsoid = 1
+  setPropertySettings("FixQAxis", std::make_unique<VisibleWhenProperty>("Ellipsoid", IS_EQUAL_TO, "1"));
+  setPropertySettings("FixMajorAxisLength", std::make_unique<VisibleWhenProperty>("Ellipsoid", IS_EQUAL_TO, "1"));
+  setPropertySettings("UseCentroid", std::make_unique<VisibleWhenProperty>("Ellipsoid", IS_EQUAL_TO, "1"));
+  setPropertySettings("MaxIterations", std::make_unique<VisibleWhenProperty>("Ellipsoid", IS_EQUAL_TO, "1"));
+
+  // Disable / greyed out these Properties based on the value of another
+  setPropertySettings("AdaptiveQMultiplier",
+                      std::make_unique<Kernel::EnabledWhenProperty>("AdaptiveQBackground", IS_EQUAL_TO, "1"));
+  setPropertySettings("CorrectIfOnEdge",
+                      std::make_unique<Kernel::EnabledWhenProperty>("IntegrateIfOnEdge", IS_EQUAL_TO, "1"));
 }
 
 std::map<std::string, std::string> IntegratePeaksMD2::validateInputs() {

--- a/docs/source/release/v6.1.0/diffraction.rst
+++ b/docs/source/release/v6.1.0/diffraction.rst
@@ -76,6 +76,7 @@ Single Crystal Diffraction
 Improvements
 ############
 - :ref:`IntegratePeaksMD <algm-IntegratePeaksMD>` now allows ellipsoidal shapes to be manually defined for the PeakRadius and Background radii options.
+- The :ref:`IntegratePeaksMD <algm-IntegratePeaksMD>` input dialog has been reorganised to present the many input properties in a more user-friendly manner.
 - :ref:`SNSPowderReduction <algm-SNSPowderReduction>` now check if previous container is created using the same method before reusing it.
 - :ref:`SCDCalibratePanels <algm-SCDCalibratePanels-v2>` now update attached UB matrix with given lattice constants (optional).
 - :ref:`FilterPeaks <algm-FilterPeaks>` now can select banks in addition to filtering by values.

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/AlgorithmPropertiesWidget.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/AlgorithmPropertiesWidget.h
@@ -52,7 +52,7 @@ public:
 
   void addEnabledAndDisableLists(const QStringList &enabled, const QStringList &disabled);
 
-  void hideOrDisableProperties();
+  void hideOrDisableProperties(const QString &changedPropName = "");
 
   void saveInput();
 
@@ -70,7 +70,7 @@ public:
 
 public slots:
   /// Any property changed
-  void propertyChanged(const QString &pName);
+  void propertyChanged(const QString &changedPropName);
 
   /// Replace WS button was clicked
   void replaceWSClicked(const QString &propName);

--- a/qt/widgets/common/src/BoolPropertyWidget.cpp
+++ b/qt/widgets/common/src/BoolPropertyWidget.cpp
@@ -20,6 +20,10 @@ BoolPropertyWidget::BoolPropertyWidget(Mantid::Kernel::PropertyWithValue<bool> *
     : PropertyWidget(prop, parent, layout, row) {
   m_checkBox = new QCheckBox(QString::fromStdString(prop->name()), m_parent);
   m_checkBox->setToolTip(m_doc);
+  // Make current value visible
+  this->setValue(QString::fromStdString(m_prop->value()));
+
+  // Make sure the connection comes after updating any values
   connect(m_checkBox, SIGNAL(stateChanged(int)), this, SLOT(userEditedProperty()));
   m_widgets.push_back(m_checkBox);
 

--- a/qt/widgets/common/src/FilePropertyWidget.cpp
+++ b/qt/widgets/common/src/FilePropertyWidget.cpp
@@ -25,6 +25,9 @@ FilePropertyWidget::FilePropertyWidget(Mantid::Kernel::Property *prop, QWidget *
 
   // Create a browse button
   m_browseButton = new QPushButton(tr("Browse"), m_parent);
+  // Make current value visible
+  this->setValue(QString::fromStdString(m_prop->value()));
+  // Make sure the connection comes after updating any values
   connect(m_browseButton, SIGNAL(clicked()), this, SLOT(browseClicked()));
   m_widgets.push_back(m_browseButton);
 

--- a/qt/widgets/common/src/TextPropertyWidget.cpp
+++ b/qt/widgets/common/src/TextPropertyWidget.cpp
@@ -29,6 +29,9 @@ TextPropertyWidget::TextPropertyWidget(Mantid::Kernel::Property *prop, QWidget *
   m_textbox = new QLineEdit(m_parent);
   m_textbox->setToolTip(m_doc);
   setFieldPlaceholderText(prop, m_textbox);
+  // Make current value visible
+  this->setValue(QString::fromStdString(m_prop->value()));
+  // Make sure the connection comes after updating any values
   connect(m_textbox, SIGNAL(editingFinished()), this, SLOT(userEditedProperty()));
   m_gridLayout->addWidget(m_textbox, m_row, 1, nullptr);
   m_widgets.push_back(m_textbox);


### PR DESCRIPTION
### This is my first C++ PR so please review harshly!

**Description of work.**
This PR is to organise the algorithm dialog for IntegratePeaksMD (version 2) and make it more user friendly: 
- Input properties have been grouped by general, ellipsoid and cylinder properties

- `CorrectIfOnEdge` is greyed out/ disabled unless `IntegrateIfOnEdge` is ticked.

- `Ellipsoid` and `Cylinder` grouped inputs are only visible when the correct tickbox is ticked
- `Ellipsoid` and `Cylinder` tickboxes cannot be ticked at the same time (force the other to untick).
- To achieve this forced untick, I've created `SetValueWhenProperty` which takes a std::function to work out when to  set one input value by another. This is somewhat based on `Enable/VisibleWhenProperty`.

Note that for IntegratePeaksMD the integration shape is Sphere by default and Ellipsoid or Cylinder only if one of these boxes is ticked.

Last thing: As a possible nice to have, it was mentioned that I could force the `Ellipsoid` tickbox to be ticked if PeakRadius was given 3 input values. I tried to do this with the code below, but found that the problems with this setting Ellipsoid, to potentially untick Cylinder and hide the cylindrical inputs was not handled nicely, and outweighed the slight benefit.
```
  setPropertySettings(
      “Ellipsoid”,
      std::make_unique<SetValueWhenProperty>(
          “PeakRadius”, [](std::string ellipsoid, std::string peakRadius) {
            // Set Ellipsoid to 1, if PeakRadius has 3 input values (2 separating commas)
            if (ellipsoid == “0” && std::count(peakRadius.begin(), peakRadius.end(), ‘,’) == 2) {
              return std::string{“1"};
            } 
            // Set Ellipsoid to 0, if PeakRadius has 1 input value (0 separating commas)
            if (ellipsoid == “1” && std::count(peakRadius.begin(), peakRadius.end(), ‘,’) == 0) {
              return std::string{“0"};
            } 
            else {
              return ellipsoid;
            };
          }));
```

**To test:**

Build and open the IntegratePeaksMD input dialog. Notice how the ellipsoid options are only visible when the ellipsoid tickbox is ticked. This is the same for Cylinder. Notice that ticking Cylinder will untick ellipsoid and vice versa. Check the disabling behaviour for AdaptiveQ*** and ***IfOnEdge mentioned above. 

Thorough code review!!!

Fixes #30797 

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
