### PR TITLE
Update OSX brew instructions

### DIFF
--- a/dev-docs/source/BuildingOnOSX.rst
+++ b/dev-docs/source/BuildingOnOSX.rst
@@ -17,67 +17,58 @@ The minimum supported version of macOS is High Sierra (10.13).
 
 These instructions are from the assumptions of a blank newly installed version of High Sierra using Homebrew for dependency management.
 
-1. Install Xcode 10.1
+#. Install Xcode
 
-2. Install Apple's Command Line tools (required by Homebrew)
+#. Install Apple's Command Line tools (required by Homebrew)
 
-.. code-block:: sh
+   .. code-block:: sh
 
-   xcode-select --install
+      xcode-select --install
 
-3. Install `Homebrew <http://brew.sh>`_.
+#. Install `Homebrew <http://brew.sh>`_.
 
-.. code-block:: sh
+   .. code-block:: sh
 
-   ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"
+      ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"
 
-4. Add the necessary 'taps':
+#. Add the necessary 'taps':
 
-In order to be able to 'tap' the ``mantidproject/mantid`` 'tap' we need to have a couple of packages installed
+   In order to be able to 'tap' the ``mantidproject/mantid`` 'tap' we need to have a couple of packages installed
 
-.. code-block:: sh
+   .. code-block:: sh
 
-   brew install git
-   brew tap mantidproject/mantid
-   brew tap homebrew/cask
-   brew cask install xquartz
-   brew cask install mactex
+      brew install git
+      brew tap mantidproject/mantid
+      brew tap homebrew/cask
+      brew install --cask xquartz
+      brew install --cask mactex
+      brew install mantid-developer
 
-5. Install ``mantid-developer`` formula (this may take a while depending on your network speed)
+#. Python is now keg-only. Add the appropriate version to ``PATH`` in shell profile and restart the terminal:
 
-.. code-block:: sh
+   .. code-block:: sh
 
-   brew install mantid-developer
+      # Assume we are using bash
+      echo 'export PATH="/usr/local/opt/python@3.8/bin:$PATH"' >> ~/.bash_profile
 
-6. Homebrew can stop early for reasons that are unclear. Repeat the above command until Homebrew states: *Warning: mantidproject/mantid/mantid-developer ?.? is already installed and up-to-date*.
+      # If you have enabled Zsh
+      echo 'export PATH="/usr/local/opt/python@3.8/bin:$PATH"' >> ~/.zshenv
 
-7. Unlink ``qscintilla2``
+#. Downgrade setuptools to 48.0.0 until https://github.com/mantidproject/mantid/issues/29010 is fixed.
 
-.. code-block:: sh
+   .. code-block:: sh
 
-   brew unlink qscintilla2
+      python3 -m pip install setuptools==48.0.0
 
-8. Python is now keg-only. Add the appropriate version to ``PATH`` in shell profile and restart the terminal:
+#. Install python requirements
 
-.. code-block:: sh
+   .. code-block:: sh
 
-   # Assume we are using bash
-   echo 'export PATH="/usr/local/opt/python@3.8/bin:$PATH"' >> ~/.bash_profile
+      # Note this export assumes Intel, if you are using
+      # M1 please contact us, as Pycifrw requires upstream work
+      export ARCHFLAGS="-arch x86_64"
 
-   # If you have enabled Zsh
-   echo 'export PATH="/usr/local/opt/python@3.8/bin:$PATH"' >> ~/.zshenv
-
-9. Downgrade setuptools to 48.0.0 until https://github.com/mantidproject/mantid/issues/29010 is fixed.
-
-.. code-block:: sh
-
-   python3 -m pip install setuptools==48.0.0
-
-10. Install python requirements
-
-.. code-block:: sh
-
-   python3 -m pip install -r /usr/local/Homebrew/Library/Taps/mantidproject/homebrew-mantid/requirements.txt
+      python3 -m pip install -r /usr/local/Homebrew/Library/Taps/mantidproject/homebrew-mantid/requirements.txt
 
 
 Instructions for Historic Versions


### PR DESCRIPTION
**Description of work.**
Updates the OSX instructions:
- Combines some steps together like all the brew installs
- Use automatic sphinx numbering
- Remove the note about brew sometimes failing, as I haven't seen it in
6+ months
- Switch from brew cask install to brew install --cask which is relevant
to brew 3.0+

**To test:**
Wipe your brew install by doing:
- `brew remove --force $(brew list) --ignore-dependencies && brew cleanup`
- Follow instructions

<!-- Instructions for testing. -->

*There is no associated issue.*

<!-- delete this if you added release notes
This does not require release notes
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or master)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
