### PR TITLE
Unique name check for componentinfo

### DIFF
--- a/Framework/Beamline/inc/MantidBeamline/ComponentInfo.h
+++ b/Framework/Beamline/inc/MantidBeamline/ComponentInfo.h
@@ -121,6 +121,7 @@ public:
   double l1() const;
   const std::string &name(const size_t componentIndex) const;
   size_t indexOfAny(const std::string &name) const;
+  bool uniqueName(const std::string &name) const;
   Eigen::Vector3d scaleFactor(const size_t componentIndex) const;
   void setScaleFactor(const size_t componentIndex, const Eigen::Vector3d &scaleFactor);
   ComponentType componentType(const size_t componentIndex) const;

--- a/Framework/Beamline/src/ComponentInfo.cpp
+++ b/Framework/Beamline/src/ComponentInfo.cpp
@@ -28,8 +28,7 @@ void checkScanInterval(const std::pair<int64_t, int64_t> &interval) {
   if (interval.first >= interval.second)
     throw std::runtime_error("ComponentInfo: cannot set scan interval with start >= end");
 }
-template <class T>
-bool unique_if_exists(const T &inputs, const typename T::value_type &arg) {
+template <class T> bool unique_if_exists(const T &inputs, const typename T::value_type &arg) {
   auto unique = false;
   auto it = std::find(inputs.begin(), inputs.end(), arg);
   if (it != inputs.end()) {
@@ -535,9 +534,7 @@ Eigen::Vector3d ComponentInfo::scaleFactor(const size_t componentIndex) const {
 
 const std::string &ComponentInfo::name(const size_t componentIndex) const { return (*m_names)[componentIndex]; }
 
-bool ComponentInfo::uniqueName(const std::string &name) const {
-  return unique_if_exists((*m_names), name);
-}
+bool ComponentInfo::uniqueName(const std::string &name) const { return unique_if_exists((*m_names), name); }
 
 size_t ComponentInfo::indexOfAny(const std::string &name) const {
   // Reverse iterate to hit top level components sooner

--- a/Framework/Beamline/src/ComponentInfo.cpp
+++ b/Framework/Beamline/src/ComponentInfo.cpp
@@ -28,6 +28,16 @@ void checkScanInterval(const std::pair<int64_t, int64_t> &interval) {
   if (interval.first >= interval.second)
     throw std::runtime_error("ComponentInfo: cannot set scan interval with start >= end");
 }
+template <class T>
+bool unique_if_exists(const T &inputs, const typename T::value_type &arg) {
+  auto unique = false;
+  auto it = std::find(inputs.begin(), inputs.end(), arg);
+  if (it != inputs.end()) {
+    it = std::find(++it, inputs.end(), arg);
+    unique = (it == inputs.end());
+  }
+  return unique;
+}
 } // namespace
 } // namespace
 
@@ -524,6 +534,10 @@ Eigen::Vector3d ComponentInfo::scaleFactor(const size_t componentIndex) const {
 }
 
 const std::string &ComponentInfo::name(const size_t componentIndex) const { return (*m_names)[componentIndex]; }
+
+bool ComponentInfo::uniqueName(const std::string &name) const {
+  return unique_if_exists((*m_names), name);
+}
 
 size_t ComponentInfo::indexOfAny(const std::string &name) const {
   // Reverse iterate to hit top level components sooner

--- a/Framework/Beamline/test/ComponentInfoTest.h
+++ b/Framework/Beamline/test/ComponentInfoTest.h
@@ -733,6 +733,14 @@ public:
     TS_ASSERT_EQUALS(compInfo.indexOfAny("root"), compInfo.root());
   }
 
+  void test_uniqueName() {
+    auto infos = makeFlatTree(PosVec(1), RotVec(1));
+    ComponentInfo &compInfo = *std::get<0>(infos);
+    TS_ASSERT(compInfo.uniqueName("det0"));
+    TS_ASSERT(compInfo.uniqueName("root"));
+    TS_ASSERT(!compInfo.uniqueName("phantom"));
+  }
+
   void test_scan_count_no_scanning() {
     ComponentInfo info;
     TS_ASSERT_EQUALS(info.scanCount(), 1);

--- a/Framework/Geometry/inc/MantidGeometry/Instrument/ComponentInfo.h
+++ b/Framework/Geometry/inc/MantidGeometry/Instrument/ComponentInfo.h
@@ -83,6 +83,7 @@ public:
   QuadrilateralComponent quadrilateralComponent(const size_t componentIndex) const;
   size_t indexOf(Geometry::IComponent *id) const;
   size_t indexOfAny(const std::string &name) const;
+  bool uniqueName(const std::string &name) const;
   bool isDetector(const size_t componentIndex) const;
   Kernel::V3D position(const size_t componentIndex) const;
   Kernel::V3D position(const std::pair<size_t, size_t> index) const;

--- a/Framework/Geometry/src/Instrument/ComponentInfo.cpp
+++ b/Framework/Geometry/src/Instrument/ComponentInfo.cpp
@@ -131,6 +131,8 @@ size_t ComponentInfo::indexOf(Geometry::IComponent *id) const { return m_compIDT
 
 size_t ComponentInfo::indexOfAny(const std::string &name) const { return m_componentInfo->indexOfAny(name); }
 
+bool ComponentInfo::uniqueName(const std::string &name) const { return m_componentInfo->uniqueName(name); }
+
 bool ComponentInfo::isDetector(const size_t componentIndex) const {
   return m_componentInfo->isDetector(componentIndex);
 }

--- a/Framework/PythonInterface/mantid/geometry/src/Exports/ComponentInfo.cpp
+++ b/Framework/PythonInterface/mantid/geometry/src/Exports/ComponentInfo.cpp
@@ -141,5 +141,8 @@ void export_ComponentInfo() {
            "Returns the index of any component matching name. Raises "
            "ValueError if name not found")
 
+      .def("uniqueName", &ComponentInfo::uniqueName, (arg("self"), arg("name")),
+           "Returns True if the name is a unique sincle occurance. Zero occurances yields False.")
+
       .def("root", &ComponentInfo::root, arg("self"), "Returns the index of the root component");
 }

--- a/Framework/PythonInterface/mantid/geometry/src/Exports/ComponentInfo.cpp
+++ b/Framework/PythonInterface/mantid/geometry/src/Exports/ComponentInfo.cpp
@@ -142,7 +142,7 @@ void export_ComponentInfo() {
            "ValueError if name not found")
 
       .def("uniqueName", &ComponentInfo::uniqueName, (arg("self"), arg("name")),
-           "Returns True if the name is a unique sincle occurance. Zero occurances yields False.")
+           "Returns True if the name is a unique single occurance. Zero occurances yields False.")
 
       .def("root", &ComponentInfo::root, arg("self"), "Returns the index of the root component");
 }

--- a/Framework/PythonInterface/test/python/mantid/geometry/ComponentInfoTest.py
+++ b/Framework/PythonInterface/test/python/mantid/geometry/ComponentInfoTest.py
@@ -210,10 +210,9 @@ class ComponentInfoTest(unittest.TestCase):
         self.assertEqual(index, info.root())
 
     def test_uniqueName(self):
-        ws = LoadEmptyInstrument(InstrumentName="POLARIS", StoreInADS=False)
-        info = ws.componentInfo()
-        self.assertFalse(info.uniqueName("monitor")) # duplicated for POLARIS
-        self.assertTrue(info.uniqueName("bank1"))
+        info = self._ws.componentInfo()
+        self.assertTrue(info.uniqueName(info.name(info.root())))
+        self.assertFalse(info.uniqueName("fictional-name"))
 
     def test_indexOfAny_throws(self):
         info = self._ws.componentInfo()

--- a/Framework/PythonInterface/test/python/mantid/geometry/ComponentInfoTest.py
+++ b/Framework/PythonInterface/test/python/mantid/geometry/ComponentInfoTest.py
@@ -211,7 +211,7 @@ class ComponentInfoTest(unittest.TestCase):
 
     def test_uniqueName(self):
         ws = LoadEmptyInstrument(InstrumentName="POLARIS", StoreInADS=False)
-        info = self.ws.componentInfo()
+        info = ws.componentInfo()
         self.assertFalse(info.uniqueName("monitor")) # duplicated for POLARIS
         self.assertTrue(info.uniqueName("bank1"))
 

--- a/Framework/PythonInterface/test/python/mantid/geometry/ComponentInfoTest.py
+++ b/Framework/PythonInterface/test/python/mantid/geometry/ComponentInfoTest.py
@@ -209,6 +209,12 @@ class ComponentInfoTest(unittest.TestCase):
         # Root index and the discovered index should be the same
         self.assertEqual(index, info.root())
 
+    def test_uniqueName(self):
+        ws = LoadEmptyInstrument(InstrumentName="POLARIS", StoreInADS=False)
+        info = self.ws.componentInfo()
+        self.assertFalse(info.uniqueName("monitor")) # duplicated for POLARIS
+        self.assertTrue(info.uniqueName("bank1"))
+
     def test_indexOfAny_throws(self):
         info = self._ws.componentInfo()
         with self.assertRaises(ValueError):


### PR DESCRIPTION
Mantid allows duplicate naming within the instrument tree, However, third-party applications might need to know that this is happening aprori.

**tester**

This is pretty well covered in the unit tests, but to test in addition you could
```python
from mantid.simpleapi import LoadEmptyInstrument
ws = LoadEmptyInstrument(InstrumentName='POLARIS')
ws.componentInfo().uniqueName('monitor') # Polaris has multiple monitors called "monitor", so NOT unique
ws.componentInfo().uniqueName('bank1') # This should be unique
ws.componentInfo().uniqueName('made-up-name') # Doesn't exist at all - should return False
```