### PR TITLE
Fix pre-commit repo url's that prevented cloning with old git versions

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,7 +6,7 @@ exclude: ^$|instrument
 repos:
 
   # Run fast code improvement/checks before running PR specific helpers.
-  - repo: https://github.com/pre-commit/pre-commit-hooks
+  - repo: https://github.com/pre-commit/pre-commit-hooks.git
     rev: 2618198e9658cccb4a53f04af0f7d642109f3b54
     hooks:
       - id: trailing-whitespace
@@ -18,13 +18,13 @@ repos:
       - id: check-yaml
         args: [--allow-multiple-documents]
 
-  - repo: https://github.com/mantidproject/pre-commit-hooks
+  - repo: https://github.com/mantidproject/pre-commit-hooks.git
     rev: 05b2d4cfe17dcb36e29c249705364c19eeccced5
     hooks:
       - id: clang-format
         exclude: Testing/Tools/cxxtest|tools
 
-  - repo: https://gitlab.com/pycqa/flake8
+  - repo: https://gitlab.com/pycqa/flake8.git
     rev: 3.7.9
     hooks:
       - id: flake8


### PR DESCRIPTION
**Description of work.**

When running `pre-commit`

```
[INFO] Initializing environment for https://gitlab.com/pycqa/flake8.
An unexpected error has occurred: CalledProcessError: command: ('/usr/bin/git', 'fetch', 'origin', '--tags')
return code: 128
expected return code: 0
stdout: (none)
stderr:
    error: RPC failed; result=22, HTTP code = 422
    fatal: The remote end hung up unexpectedly
```

On RHEL7, the default git version `1.8.3.1` fails to clone fails because of the missing `.git`

```
$ git clone https://gitlab.com/pycqa/flake8
Cloning into 'flake8'...
error: RPC failed; result=22, HTTP code = 422
fatal: The remote end hung up unexpectedly
```

This fixes that.

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

**To test:**


*This does not require release notes* because developer change only.

<!-- Ensure the base of this PR is correct (e.g. release-next or master)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
