### PR TITLE
Add SNS instruments to PyChop

### DIFF
--- a/docs/source/release/v6.1.0/direct_geometry.rst
+++ b/docs/source/release/v6.1.0/direct_geometry.rst
@@ -19,6 +19,7 @@ New
 Improvements
 ############
 * :ref:`MDNorm <algm-MDNorm>` algorithm can now efficiently process background.
+* Added SNS instruments to :ref:`PyChop <PyChop>`
 
 MSlice
 ------

--- a/scripts/PyChop.py
+++ b/scripts/PyChop.py
@@ -27,7 +27,7 @@ else:
         parent, flags = get_window_config()
     else:
         parent, flags = None, None
- 
+
 window = PyChopGui.PyChopGui(parent, flags)
 window.show()
 if not within_mantid:

--- a/scripts/PyChop.py
+++ b/scripts/PyChop.py
@@ -12,16 +12,22 @@ Module to import and run the PyChop GUI for use either on the commandline or as 
 
 import sys
 from PyChop import PyChopGui
-from mantidqt.gui_helper import set_matplotlib_backend, get_qapplication
-set_matplotlib_backend()  # must be called before anything tries to use matplotlib
-
-app, within_mantid = get_qapplication()
-if 'workbench' in sys.modules:
-    from workbench.config import get_window_config
-
-    parent, flags = get_window_config()
-else:
+try:
+    from mantidqt.gui_helper import set_matplotlib_backend, get_qapplication
+except ImportError:
+    within_mantid = False
+    from qtpy.QtWidgets import QApplication
+    app = QApplication(sys.argv)
     parent, flags = None, None
+else:
+    set_matplotlib_backend()  # must be called before anything tries to use matplotlib
+    app, within_mantid = get_qapplication()
+    if 'workbench' in sys.modules:
+        from workbench.config import get_window_config
+        parent, flags = get_window_config()
+    else:
+        parent, flags = None, None
+ 
 window = PyChopGui.PyChopGui(parent, flags)
 window.show()
 if not within_mantid:

--- a/scripts/PyChop/PyChopGui.py
+++ b/scripts/PyChop/PyChopGui.py
@@ -25,12 +25,30 @@ from qtpy.QtCore import (QEventLoop, Qt)  # noqa
 from qtpy.QtWidgets import (QAction, QCheckBox, QComboBox, QDialog, QFileDialog, QGridLayout, QHBoxLayout, QMenu, QLabel,
                             QLineEdit, QMainWindow, QMessageBox, QPushButton, QSizePolicy, QSpacerItem, QTabWidget,
                             QTextEdit, QVBoxLayout, QWidget)  # noqa
-from mantid.plots.utility import legend_set_draggable
-from mantidqt.MPLwidgets import FigureCanvasQTAgg as FigureCanvas
-from mantidqt.MPLwidgets import NavigationToolbar2QT as NavigationToolbar
 import matplotlib
 from matplotlib.figure import Figure
 from matplotlib.widgets import Slider
+try:
+    from mantid.plots.utility import legend_set_draggable
+    from mantidqt.MPLwidgets import FigureCanvasQTAgg as FigureCanvas
+    from mantidqt.MPLwidgets import NavigationToolbar2QT as NavigationToolbar
+except ImportError:
+    from qtpy import PYQT4, PYQT5, PYSIDE, PYSIDE2  # noqa
+    if PYQT4 or PYSIDE:
+        from matplotlib.backends.backend_qt4agg import FigureCanvasQTAgg as FigureCanvas
+        from matplotlib.backends.backend_qt4agg import NavigationToolbar2QT as NavigationToolbar
+    elif PYQT5 or PYSIDE2:
+        from matplotlib.backends.backend_qt5agg import FigureCanvasQTAgg as FigureCanvas
+        from matplotlib.backends.backend_qt5agg import NavigationToolbar2QT as NavigationToolbar
+    else:
+        raise RuntimeError('Do not know which matplotlib backend to set')
+    from matplotlib.legend import Legend
+    if hasattr(Legend, "set_draggable"):
+        SET_DRAGGABLE_METHOD = "set_draggable"
+    else:
+        SET_DRAGGABLE_METHOD = "draggable"
+    def legend_set_draggable(legend, state, use_blit=False, update='loc'):
+        getattr(legend, SET_DRAGGABLE_METHOD)(state, use_blit, update)
 
 
 class PyChopGui(QMainWindow):
@@ -43,6 +61,7 @@ class PyChopGui(QMainWindow):
     choppers = {}
     minE = {}
     maxE = {}
+    hyspecS2 = 35.
 
     def __init__(self, parent=None, window_flags=None):
         super(PyChopGui, self).__init__(parent)
@@ -127,6 +146,14 @@ class PyChopGui(QMainWindow):
         self.tabs.setTabEnabled(self.qetabID, False)
         if self.engine.has_detector and hasattr(self.engine.detector, 'tthlims'):
             self.tabs.setTabEnabled(self.qetabID, True)
+        # show s2 for HYSPEC only
+        if 'HYSPEC' in str(instname):
+            self.widgets[f"S2Edit"]['Edit'].show()
+            self.widgets[f"S2Edit"]['Edit'].setText(str(self.hyspecS2))
+            self.widgets[f"S2Edit"]['Label'].show()
+        else:
+            self.widgets[f"S2Edit"]['Edit'].hide()
+            self.widgets[f"S2Edit"]['Label'].hide()
 
     def setChopper(self, choppername):
         """
@@ -182,6 +209,18 @@ class PyChopGui(QMainWindow):
         except ValueError:
             raise ValueError('No Ei specified, or Ei string not understood')
 
+    def setS2(self):
+        """
+        Sets the S2 tank rotation for HYSPEC instrument
+        """
+        try:
+            S2txt = float(self.widgets['S2Edit']['Edit'].text())
+        except:
+            raise ValueError('No S2 specified, or S2 string not understood')
+        if np.abs(S2txt) > 150:
+            raise ValueError('S2 must be between -150 and 150 degrees')
+        self.hyspecS2 = S2txt
+
     def calc_callback(self):
         """
         Calls routines to calculate the resolution / flux and to update the Matplotlib graphs.
@@ -190,6 +229,8 @@ class PyChopGui(QMainWindow):
             if self.engine.getChopper() is None:
                 self.setChopper(self.widgets['ChopperCombo']['Combo'].currentText())
             self.setEi()
+            if self.engine.name=='HYSPEC':
+                self.setS2()
             self.setFreq()
             self.calculate()
             if self.errormess:
@@ -292,6 +333,12 @@ class PyChopGui(QMainWindow):
         E2q, meV2J = (2. * constants.m_n / (constants.hbar ** 2), constants.e / 1000.)
         en = np.linspace(-Ei / 5., Ei, 100)
         q2 = []
+        if self.engine.name == 'HYSPEC':
+            if abs(self.hyspecS2) <= 30:
+                self.engine.detector.tthlims = [0, abs(self.hyspecS2) + 30]
+            else:
+                self.engine.detector.tthlims = [abs(self.hyspecS2) - 30, abs(self.hyspecS2) + 30] 
+            label_text += '_S2={}'.format(self.hyspecS2)
         for tth in self.engine.detector.tthlims:
             q = np.sqrt(E2q * (2 * Ei - en - 2 * np.sqrt(Ei * (Ei - en)) * np.cos(np.deg2rad(tth))) * meV2J) / 1e10
             q2.append(np.concatenate((np.flipud(q), q)))
@@ -718,6 +765,7 @@ class PyChopGui(QMainWindow):
             ['pair', 'hide', 'Pulse remover chopper freq', 'combo', '', self.setFreq, 'PulseRemoverCombo'],
             ['pair', 'show', 'Ei', 'edit', '', self.setEi, 'EiEdit'],
             ['pair', 'hide', 'Chopper 2 phase delay time', 'edit', '5', self.setFreq, 'Chopper2Phase'],
+            ['pair', 'hide', 'S2', 'edit', '', self.setS2, 'S2Edit'],
             ['spacer'],
             ['single', 'show', 'Calculate and Plot', 'button', self.calc_callback, 'CalculateButton'],
             ['single', 'show', 'Hold current plot', 'check', lambda: None, 'HoldCheck'],

--- a/scripts/PyChop/PyChopGui.py
+++ b/scripts/PyChop/PyChopGui.py
@@ -47,6 +47,7 @@ except ImportError:
         SET_DRAGGABLE_METHOD = "set_draggable"
     else:
         SET_DRAGGABLE_METHOD = "draggable"
+
     def legend_set_draggable(legend, state, use_blit=False, update='loc'):
         getattr(legend, SET_DRAGGABLE_METHOD)(state, use_blit, update)
 
@@ -337,7 +338,7 @@ class PyChopGui(QMainWindow):
             if abs(self.hyspecS2) <= 30:
                 self.engine.detector.tthlims = [0, abs(self.hyspecS2) + 30]
             else:
-                self.engine.detector.tthlims = [abs(self.hyspecS2) - 30, abs(self.hyspecS2) + 30] 
+                self.engine.detector.tthlims = [abs(self.hyspecS2) - 30, abs(self.hyspecS2) + 30]
             label_text += '_S2={}'.format(self.hyspecS2)
         for tth in self.engine.detector.tthlims:
             q = np.sqrt(E2q * (2 * Ei - en - 2 * np.sqrt(Ei * (Ei - en)) * np.cos(np.deg2rad(tth))) * meV2J) / 1e10

--- a/scripts/PyChop/arcs.yaml
+++ b/scripts/PyChop/arcs.yaml
@@ -86,10 +86,10 @@ chopper_system:
   default_frequencies:
     [300]
 
-sample: 
+sample:
   name: ARCS Sample Can
   isam: 0                       # Sample type: 0==flat plate, 1==ellipse, 2==annulus, 3==sphere, 4==solid cylinder
-  sx: 2.0                       # Thickness (mm) 
+  sx: 2.0                       # Thickness (mm)
   sy: 48.0                      # Width (mm)
   sz: 48.0                      # Height (mm)
   gamma: 0.0                    # Angle of x-axis to ki (degrees)

--- a/scripts/PyChop/arcs.yaml
+++ b/scripts/PyChop/arcs.yaml
@@ -1,0 +1,121 @@
+name: ARCS
+# Input file for PyChop for the ARCS spectrometer at SNS.
+
+chopper_system:
+  name: ARCS chopper system
+  chop_sam: 2.0                 # Distance (x1) from final chopper to sample (m)
+  sam_det: 3.0                  # Distance (x2) from sample to detector (m)
+  aperture_width: 0.1751        # Width of aperture at moderator face (m)
+  aperture_height: 0.1955       # Height of aperture at moderator face (m)
+  choppers:
+    -                           # Each entry must have a dash on an otherwise empty line!
+      name: ARCS Fermi
+      distance: 11.61           # Distance from moderator to this chopper in metres
+      aperture_distance: 9.342  # Distance from aperture (moderator face) to this chopper (only for Fermi)
+      packages:                 # A hash of chopper packages
+        ARCS-100-1.5-AST:
+          name: ARCS 100 meV Sloppy
+          pslit: 1.52           # Neutron transparent slit width (mm)
+          pslat: 0.35           # Neutron absorbing slat width (mm)
+          radius: 50.0          # Chopper package radius (mm)
+          rho: 580.0            # Chopper package curvature (mm)
+          tjit: 0.0             # Jitter time (us)
+          fluxcorr: 3.0         # (Empirical/Fudge) factor to scale calculated flux by
+          isPi: False           # Should the PI pulse (at 180 deg rotation) be transmitted by this package?
+        ARCS-700-1.5-AST:
+          name: ARCS 700 meV Sloppy
+          pslit: 1.52           # Neutron transparent slit width (mm)
+          pslat: 0.35           # Neutron absorbing slat width (mm)
+          radius: 50.0          # Chopper package radius (mm)
+          rho: 1535.0           # Chopper package curvature (mm)
+          tjit: 0.0             # Jitter time (us)
+          fluxcorr: 3.0         # (Empirical/Fudge) factor to scale calculated flux by
+          isPi: False           # Should the PI pulse (at 180 deg rotation) be transmitted by this package?
+        ARCS-700-0.5-AST:
+          name: ARCS 700 meV Fine
+          pslit: 0.51           # Neutron transparent slit width (mm)
+          pslat: 0.35           # Neutron absorbing slat width (mm)
+          radius: 50.0          # Chopper package radius (mm)
+          rho: 1535.0           # Chopper package curvature (mm)
+          tjit: 0.0             # Jitter time (us)
+          fluxcorr: 3.0         # (Empirical/Fudge) factor to scale calculated flux by
+          isPi: False           # Should the PI pulse (at 180 deg rotation) be transmitted by this package?
+        ARCS-100-1.5-SMI:
+          name: ARCS 100 meV Sloppy
+          pslit: 1.52           # Neutron transparent slit width (mm)
+          pslat: 0.41           # Neutron absorbing slat width (mm)
+          radius: 50.0          # Chopper package radius (mm)
+          rho: 580.0            # Chopper package curvature (mm)
+          tjit: 0.0             # Jitter time (us)
+          fluxcorr: 3.0         # (Empirical/Fudge) factor to scale calculated flux by
+          isPi: False           # Should the PI pulse (at 180 deg rotation) be transmitted by this package?
+        ARCS-700-1.5-SMI:
+          name: ARCS 700 meV Sloppy
+          pslit: 1.52           # Neutron transparent slit width (mm)
+          pslat: 0.41           # Neutron absorbing slat width (mm)
+          radius: 50.0          # Chopper package radius (mm)
+          rho: 1535.0           # Chopper package curvature (mm)
+          tjit: 0.0             # Jitter time (us)
+          fluxcorr: 3.0         # (Empirical/Fudge) factor to scale calculated flux by
+          isPi: False           # Should the PI pulse (at 180 deg rotation) be transmitted by this package?
+        SEQ-100-2.0-AST:
+          name: ARCS 100 meV Sloppy
+          pslit: 2.03           # Neutron transparent slit width (mm)
+          pslat: 0.35           # Neutron absorbing slat width (mm)
+          radius: 50.0          # Chopper package radius (mm)
+          rho: 580.0            # Chopper package curvature (mm)
+          tjit: 0.0             # Jitter time (us)
+          fluxcorr: 3.0         # (Empirical/Fudge) factor to scale calculated flux by
+          isPi: False           # Should the PI pulse (at 180 deg rotation) be transmitted by this package?
+        SEQ-700-3.5-AST:
+          name: ARCS 700 meV Sloppy
+          pslit: 3.56           # Neutron transparent slit width (mm)
+          pslat: 0.35           # Neutron absorbing slat width (mm)
+          radius: 50.0          # Chopper package radius (mm)
+          rho: 1535.0           # Chopper package curvature (mm)
+          tjit: 0.0             # Jitter time (us)
+          fluxcorr: 3.0         # (Empirical/Fudge) factor to scale calculated flux by
+          isPi: False           # Should the PI pulse (at 180 deg rotation) be transmitted by this package?
+  # Now define how the frequencies of the choppers should be related
+  # This is an NxM matrix A where N is the number of choppers and M is the number of indepdent frequencies
+  # Such that A.F will give the N required frequencies for each chopper from the M input frequencies
+  frequency_matrix:
+    [[1]]                       # f1 is the Fermi frequency
+  max_frequencies:
+    [600]                       # Maximum frequencies (Hz)
+  default_frequencies:
+    [300]
+
+sample: 
+  name: ARCS Sample Can
+  isam: 0                       # Sample type: 0==flat plate, 1==ellipse, 2==annulus, 3==sphere, 4==solid cylinder
+  sx: 2.0                       # Thickness (mm) 
+  sy: 48.0                      # Width (mm)
+  sz: 48.0                      # Height (mm)
+  gamma: 0.0                    # Angle of x-axis to ki (degrees)
+
+detector:
+  name: He3 PSD tubes
+  idet: 2                       # Detector type: 1==He tube binned together, 2==He tube
+  dd: 0.025                     # Detector depth (diameter for tube) in metres
+  tbin: 0.0                     # Detector time bins (microseconds)
+  phi: 0.0                      # Detector scattering angle (degrees)
+  tthlims: [2.373, 135.955]     # Min and max 2-theta angles of detectors (for Q-E plot)
+
+moderator:
+  name: Ambient Water           # A==water, AP==poisoned water, CH4==methane, H2==hydrogen. This is only used for analytical calculations
+                                # of the flux distribution for ISIS TS1 moderators. If measured_flux is defined below, name can be anything
+  imod: 1                       # Moderator time profile type: 0==chi^2, 1==Old_Ikeda-Carpenter, 2==modified chi^2, 3==polynomial, 4==Tobyfit Ikeda-Carpenter
+  mod_pars: [119.63, 33.618,    # Parameters for time profile (for I-K is: [S1, S2, B1, B2, Emod]
+             .037, .17, 172.42] #    where tau_f=1/(sqrt(Ei)*E2V*sqrt(S1^2+(S2*lam)^2), tau_s=B1 for E<=130meV, B2 otherwise, R=exp(-Ei/Emod)
+  theta: -13.75                 # Angle beamline makes with moderator face (degrees)
+  source_rep: 60                # Frequency of source (Hz)
+  measured_flux:                # Table of measured flux vs wavelength. Wavelength in Angstrom. Flux in n/cm^2/s/uA/Angstrom
+    scale_factor: 10000000      # A factor to scale the flux values below by
+    wavelength: [0.0285984265, 0.2335051748, 0.2859842653, 0.310193488, 0.3418165757, 0.3856211047, 0.4521808267, 0.4834016372,
+                 0.522133444, 0.5719685306, 0.6394802577, 0.6936137254, 0.7643250991, 0.8255654628, 0.9043616533, 0.9809179374,
+                 1.0809189212, 1.2194410046, 1.4299213265, 1.5286501982, 1.6511309256, 1.8087233066, 2.0222141331, 2.3350517482]
+    flux: [1, 1, 1.0769418795, 1.0912234366, 1.1117847541, 1.143928794, 1.201252718, 1.2318227972, 1.2731629789, 1.3321623679,
+           1.4236719322, 1.5075346925, 1.6322258496, 1.7551658109, 1.9353360797, 2.1356198518, 2.4386575654, 2.9461376015,
+           3.8879041876, 4.331779711, 4.8546361998, 5.4701373626, 6.1966620127, 7.3007339739]
+

--- a/scripts/PyChop/cncs.yaml
+++ b/scripts/PyChop/cncs.yaml
@@ -38,9 +38,9 @@ chopper_system:
       isDouble: False           # Is this a double disk system?
       isPhaseIndependent: False # Is this disk to be phased independently?
     -
-      name: CNCS Chopper 4 
+      name: CNCS Chopper 4
       distance: 34.785          # Distance from moderator to this chopper in metres
-      slot_width: 110           # Slot width in mm.  angle/360.*2*pi*R. angle=9.0 deg. 
+      slot_width: 110           # Slot width in mm.  angle/360.*2*pi*R. angle=9.0 deg.
       guide_width: 12           # Width of guide after chopper in mm
       nslot: 1                  # Number of slots. (Assume all slots equally spaced)
       radius: 282.5             # Disk radius
@@ -77,7 +77,7 @@ chopper_system:
         -
         -
         -
-          slot_width: 32        # angle/360.*2*pi*R. angle=4.4 deg. 
+          slot_width: 32        # angle/360.*2*pi*R. angle=4.4 deg.
     High Resolution:
       choppers:                 # Note that we need to leave the required number of dashes to indicate
         -
@@ -98,7 +98,7 @@ moderator:
   name: TS2 Hydrogen            # A==water, AP==poisoned water, CH4==methane, H2==hydrogen. This is only used for analytical calculations
                                 # of the flux distribution for ISIS TS1 moderators. If measured_flux is defined below, name can be anything
   imod: 3                       # Moderator time profile type: 0==chi^2, 1==Ikeda-Carpenter, 2==modified chi^2
-  mod_pars: [0.0] 
+  mod_pars: [0.0]
                                 # imod==3 is polynomial. Pars are coeff from highest order to lowest
   theta: 32.0                   # Angle beamline makes with moderator face (degrees)
   source_rep: 60                # Frequency of source (Hz)
@@ -151,10 +151,10 @@ moderator:
            0.0938, 0.0902, 0.0866, 0.0834, 0.0801, 0.077, 0.0741, 0.0712, 0.0686,
            0.066, 0.0637, 0.0614, 0.0593, 0.0571, 0.0551, 0.0532, 0.0512, 0.0494,
            0.0477, 0.0461, 0.0445, 0.043, 0.0415, 0.0401, 0.0387]
-sample: 
+sample:
   name: Sample Can
   isam: 2                       # Sample type: 0==flat plate, 1==ellipse, 2==annulus, 3==sphere, 4==solid cylinder
-  sx: 10.0                      # Thickness (mm) 
+  sx: 10.0                      # Thickness (mm)
   sy: 10.0                      # Width (mm)
   sz: 60.0                      # Height (mm)
   gamma: 0.                     # Angle of x-axis to ki (degrees)

--- a/scripts/PyChop/cncs.yaml
+++ b/scripts/PyChop/cncs.yaml
@@ -1,0 +1,160 @@
+name: CNCS
+# Input file for PyChop for the CNCS spectrometer at SNS.
+# At a minium, the "chopper_system" and "moderator" entries must be present
+
+# This file uses pulse widths data computed from the SNS_IRP2_TD_BL5_30o70p_fit_fit.dat file
+# See https://jupyter.sns.gov/user/lj7/notebooks/dv/sns-chops/resolution/CNCS/moderator%20fitfit.ipynb#
+
+chopper_system:
+  name: CNCS chopper system
+  chop_sam: 1.48                # Distance (x1) from final chopper to sample (m)
+  sam_det: 3.5                  # Distance (x2) from sample to detector (m)
+  choppers:
+    -                           # Each entry must have a dash on an otherwise empty line!
+      name: CNCS Fermi Chopper
+      distance: 6.413           # Distance from moderator to this chopper in metres
+      slot_width: 20            # Slot width in mm
+      guide_width: 2            # Width of guide after chopper in mm
+      nslot: 2                  # Number of slots. (Assume all slots equally spaced)
+      radius: 20                # Disk radius
+      isDouble: False           # Is this a double disk system?
+      isPhaseIndependent: False # Is this disk to be phased independently?
+    -
+      name: CNCS Chopper 2
+      distance: 7.515           # Distance from moderator to this chopper in metres
+      slot_width: 61            # Slot width in mm
+      guide_width: 40           # Width of guide after chopper in mm
+      nslot: 1                  # Number of slots. (Assume all slots equally spaced)
+      radius: 250               # Disk radius
+      isDouble: False           # Is this a double disk system?
+      isPhaseIndependent: False # Is this disk to be phased independently?
+    -
+      name: CNCS Chopper 3
+      distance: 33.02           # Distance from moderator to this chopper in metres
+      slot_width: 61            # Slot width in mm
+      guide_width: 40           # Width of guide after chopper in mm
+      nslot: 1                  # Number of slots. (Assume all slots equally spaced)
+      radius: 250               # Disk radius
+      isDouble: False           # Is this a double disk system?
+      isPhaseIndependent: False # Is this disk to be phased independently?
+    -
+      name: CNCS Chopper 4 
+      distance: 34.785          # Distance from moderator to this chopper in metres
+      slot_width: 110           # Slot width in mm.  angle/360.*2*pi*R. angle=9.0 deg. 
+      guide_width: 12           # Width of guide after chopper in mm
+      nslot: 1                  # Number of slots. (Assume all slots equally spaced)
+      radius: 282.5             # Disk radius
+      isDouble: True            # Is this a double disk system?
+      isPhaseIndependent: False # Is this disk to be phased independently?
+  # Now define how the frequencies of the choppers should be related
+  # This is an NxM matrix A where N is the number of choppers and M is the number of indepdent frequencies
+  # Such that A.F will give the N required frequencies for each chopper from the M input frequencies
+  frequency_matrix:             # CNCS is run with two main frequencies:
+    [[0, 1],                    #   f1: The frequency of the resolution chopper (Chopper 4)
+     [0, 0],                    #   f2: The frequency of the Fermi chopper (Chopper 1)
+     [0, 0],
+     [1, 0]]
+  constant_frequencies:         # This specifies if a chopper should be run at a fixed constant frequency
+    [0, 60., 60., 0.]           # On CNCS, the rep/frame-overlap choppers should always run at 60 Hz
+  frequency_names:
+    - 'Resolution disk frequency'
+    - 'Fermi frequency'
+  max_frequencies:
+    [300, 300]                  # Maximum frequencies (Hz)
+  default_frequencies:
+    [300, 60]
+  overlap_ei_frac: 0.9          # Fraction of energy loss Ei to plot ToF lines in time-distance plots
+  ei_limits: [0, 30]            # Limits on ei for multirep calculations (reps outside range ignored)
+  flux_ref_slot: 20             # Reference slot width (mm) for flux transmission calculation (disk choppers only)
+  flux_ref_freq: 150            # Reference final chopper freq (Hz) for flux transmission calc (disk choppers only)
+  # Can define variants which overide one of the above parameters
+  variants:                     # On CNCS the final chopper has 3 sets of slots with different widths
+    High Flux:                  # This is the default mode (uses the widest 31mm slot).
+      default: True             # If this key is omitted, the variant without any option is used as default
+    Intermediate:
+      choppers:                 # Note that we need to leave the required number of dashes to indicate
+        -                       #   choppers whos parameters have not changed.
+        -
+        -
+        -
+          slot_width: 32        # angle/360.*2*pi*R. angle=4.4 deg. 
+    High Resolution:
+      choppers:                 # Note that we need to leave the required number of dashes to indicate
+        -
+        -
+        -
+        -
+          slot_width: 9.86      # angle/360.*2*pi*R. angle=2.0 deg.
+
+detector:
+  name: He3 PSD tubes
+  idet: 2                       # Detector type: 1==He tube binned together, 2==He tube
+  dd: 0.025                     # Detector depth (diameter for tube) in metres
+  tbin: 0.0                     # Detector time bins (microseconds)
+  phi: 60.0                     # Detector scattering angle (degrees)
+  tthlims: [3.806, 132.609]     # Min and max 2-theta angles of detectors (for Q-E plot)
+
+moderator:
+  name: TS2 Hydrogen            # A==water, AP==poisoned water, CH4==methane, H2==hydrogen. This is only used for analytical calculations
+                                # of the flux distribution for ISIS TS1 moderators. If measured_flux is defined below, name can be anything
+  imod: 3                       # Moderator time profile type: 0==chi^2, 1==Ikeda-Carpenter, 2==modified chi^2
+  mod_pars: [0.0] 
+                                # imod==3 is polynomial. Pars are coeff from highest order to lowest
+  theta: 32.0                   # Angle beamline makes with moderator face (degrees)
+  source_rep: 60                # Frequency of source (Hz)
+  n_frame: 6                    # Number of frames to calculate time-distance diagram for
+  emission_time: 3500           # Time width of source pulse in microseconds (only used to determine spurious reps in multi-rep mode)
+  measured_width:
+    wavelength: [28.60141458, 26.65479018, 24.84065387, 23.14998844, 21.57439041,
+               20.10602826, 18.73760346, 17.46231422, 16.27382172, 15.16621852,
+               14.13399926, 13.17203328, 12.27553911, 11.44006072, 10.66144534,
+                9.93582285,  9.25958654,  8.62937515,  8.04205622,  7.49471047,
+                6.9846173 ,  6.50924128,  6.06621956,  5.65335009,  5.26858069,
+                4.90999885,  4.57582225,  4.26438985,  3.97415367,  3.70367109,
+                3.45159766,  3.21668046,  2.99775183,  2.79372357,  2.60358156,
+                2.42638069,  2.2612402 ,  2.10733923,  1.96391283,  1.83024809,
+                1.70568063,  1.58959128,  1.48140303,  1.38057811,  1.28661538,
+                1.19904779,  1.11744009,  1.04138664,  0.97050943,  0.90445614]
+    width:       [349.37, 354.02, 358.23, 361.74, 364.36, 365.84, 366.  , 364.71,
+       361.86, 357.47, 351.6 , 344.4 , 336.06, 326.81, 316.87, 306.49,
+       295.86, 285.14, 274.45, 263.89, 253.48, 243.24, 233.12, 223.05,
+       212.97, 202.77, 192.43, 181.89, 171.24, 160.57, 150.08, 139.97,
+       130.4 , 121.38, 112.68, 103.81,  94.24,  83.71,  72.47,  61.31,
+        51.03,  42.13,  34.74,  28.75,  23.98,  20.19,  17.17,  14.77,
+        12.85,  11.29 ]
+    isSigma: false
+  measured_flux:                # Table of measured flux vs wavelength. Wavelength in Angstrom. Flux in n/cm^2/s/uA/Angstrom
+    scale_factor: 63276.8362    # A factor to scale the flux values below by
+    wavelength: [0.5,   0.6,   0.7,   0.8,   0.9,   1. ,   1.1,   1.2,   1.3,
+                 1.4,   1.5,   1.6,   1.7,   1.8,   1.9,   2. ,   2.1,   2.2,
+                 2.3,   2.4,   2.5,   2.6,   2.7,   2.8,   2.9,   3. ,   3.1,
+                 3.2,   3.3,   3.4,   3.5,   3.6,   3.7,   3.8,   3.9,   4. ,
+                 4.1,   4.2,   4.3,   4.4,   4.5,   4.6,   4.7,   4.8,   4.9,
+                 5.0,   5.1,   5.2,   5.3,   5.4,   5.5,   5.6,   5.7,   5.8,
+                 5.9,   6.0,   6.1,   6.2,   6.3,   6.4,   6.5,   6.6,   6.7,
+                 6.8,   6.9,   7.0,   7.1,   7.2,   7.3,   7.4,   7.5,   7.6,
+                 7.7,   7.8,   7.9,   8.0,   8.1,   8.2,   8.3,   8.4,   8.5,
+                 8.6,   8.7,   8.8,   8.9,   9.0,   9.1,   9.2,   9.3,   9.4,
+                 9.5,   9.6,   9.7,   9.8,   9.9,  10.0,  10.1,  10.2,  10.3,
+                10.4,  10.5,  10.6,  10.7,  10.8,  10.9,  11.0,  11.1,  11.2,
+                11.3,  11.4,  11.5,  11.6,  11.7,  11.8,  11.9]
+    flux: [0.0889, 0.1003, 0.1125, 0.1213, 0.1274, 0.1358, 0.1455, 0.1562, 0.1702,
+           0.1902, 0.2149, 0.2496, 0.2938, 0.3537, 0.4315, 0.5244, 0.6415, 0.7856,
+           0.9341, 1.0551, 1.1437, 1.1955, 1.2004, 1.1903, 1.1662, 1.1428, 1.1176,
+           1.0875, 1.0641, 1.0562, 1.0242, 0.9876, 0.9586, 0.9415, 0.924, 0.8856,
+           0.8865, 0.8727, 0.842, 0.8125, 0.7849, 0.7596, 0.7417, 0.7143, 0.6869,
+           0.6608, 0.6341, 0.6073, 0.581, 0.5548, 0.5304, 0.507, 0.4849, 0.4639,
+           0.4445, 0.425, 0.407, 0.3902, 0.3737, 0.3579, 0.3427, 0.3274, 0.3129,
+           0.2989, 0.2854, 0.2724, 0.2601, 0.2483, 0.2371, 0.2267, 0.2167, 0.2072,
+           0.1984, 0.19, 0.1821, 0.1743, 0.1669, 0.1599, 0.1532, 0.1467, 0.1404,
+           0.1346, 0.1291, 0.1238, 0.1189, 0.1141, 0.1097, 0.1053, 0.1014, 0.0975,
+           0.0938, 0.0902, 0.0866, 0.0834, 0.0801, 0.077, 0.0741, 0.0712, 0.0686,
+           0.066, 0.0637, 0.0614, 0.0593, 0.0571, 0.0551, 0.0532, 0.0512, 0.0494,
+           0.0477, 0.0461, 0.0445, 0.043, 0.0415, 0.0401, 0.0387]
+sample: 
+  name: Sample Can
+  isam: 2                       # Sample type: 0==flat plate, 1==ellipse, 2==annulus, 3==sphere, 4==solid cylinder
+  sx: 10.0                      # Thickness (mm) 
+  sy: 10.0                      # Width (mm)
+  sz: 60.0                      # Height (mm)
+  gamma: 0.                     # Angle of x-axis to ki (degrees)

--- a/scripts/PyChop/hyspec.yaml
+++ b/scripts/PyChop/hyspec.yaml
@@ -1,0 +1,120 @@
+name: HYSPEC
+# Input file for PyChop for the HYSPEC spectrometer at SNS.
+# At a minium, the "chopper_system" and "moderator" entries must be present
+
+# This file uses pulse widths data computed from the SNS_IRP2_TD_BL5_30o70p_fit_fit.dat file
+# See https://jupyter.sns.gov/user/lj7/notebooks/dv/sns-chops/resolution/HYSPEC/moderator%20fitfit.ipynb#
+
+chopper_system:
+  name: HYSPEC chopper system
+  chop_sam: 3.61                # Distance (x1) from final chopper to sample (m)
+  sam_det: 4.5                  # Distance (x2) from sample to detector (m)
+  choppers:
+    -
+      name: HYSPEC T1A Chopper
+      distance: 9.400           # Distance from moderator to this chopper in metres
+      slot_width: 94.7          # Slot width in mm.  angle/360.*2*pi*R. angle=21.7 deg.(from SING14B-20-EQ0007-R00 p 17)
+      guide_width: 40           # Width of guide after chopper in mm (from SING14B-20-EQ0005-R00 p 15)
+      nslot: 1                  # Number of slots. (Assume all slots equally spaced)
+      radius: 250               # Disk radius (assume middle of beam...) (from SING14B-20-EQ0007-R00 p 17)
+      isDouble: False           # Is this a double disk system?
+      isPhaseIndependent: False # Is this disk to be phased independently?
+    -
+      name: HYSPEC T1B Chopper
+      distance: 36.46           # Distance from moderator to this chopper in metres
+      slot_width: 94.7          # Slot width in mm.  angle/360.*2*pi*R. angle=21.7 deg.(from SING14B-20-EQ0007-R00 p 17)
+      guide_width: 40           # Width of guide after chopper in mm (from SING14B-20-EQ0005-R00 p 15)
+      nslot: 1                  # Number of slots. (Assume all slots equally spaced)
+      radius: 250               # Disk radius (from SING14B-20-EQ0007-R00 p 17)
+      isDouble: False           # Is this a double disk system?
+      isPhaseIndependent: False # Is this disk to be phased independently?
+    -
+      name: HYSPEC Fermi Chopper 
+      distance: 37.17           # Distance from moderator to this chopper in metres
+      aperture_distance: 37.0   # Distance from aperture (moderator face) to this chopper (only for Fermi)
+      packages:                 # A hash of chopper packages
+        OnlyOne:
+          name: HYSPEC Only Chopper
+          pslit: 0.6            # Neutron transparent slit width (mm) SING14B-20-EQ0006-R00 p 12
+          pslat: 0.06           # Neutron absorbing slat width (mm) SING14B-20-EQ0006-R00 p 12
+          radius: 5.0          # Chopper package radius (mm) 10 mm long, SING14B-20-EQ0006-R00 p 12
+          rho: 1000000.0        # Chopper package curvature (mm) (it is flat, so approx with large number)
+          tjit: 0.0             # Jitter time (us)
+          fluxcorr: 1.0         # (Empirical/Fudge) factor to scale calculated flux by
+          isPi: True            # Should the PI pulse (at 180 deg rotation) be transmitted by this package?
+#      slot_width: 110           # Slot width in mm.  angle/360.*2*pi*R. angle=9.0 deg. 
+#      guide_width: 40           # Width of guide after chopper in mm
+#      nslot: 2                  # Number of slots. (Assume all slots equally spaced)
+#      radius: 282.5             # Disk radius
+#      isDouble: False           # Is this a double disk system?
+#      isPhaseIndependent: False # Is this disk to be phased independently?
+  # Now define how the frequencies of the choppers should be related
+  # This is an NxM matrix A where N is the number of choppers and M is the number of indepdent frequencies
+  # Such that A.F will give the N required frequencies for each chopper from the M input frequencies
+  frequency_matrix:             # HYSPEC is run with one main frequency:
+    [[0],                    
+     [0],
+     [1]]                       #   f1: The frequency of the resolution chopper (Chopper 4)
+  constant_frequencies:         # This specifies if a chopper should be run at a fixed constant frequency
+    [60., 60., 0.]              # On HYSPEC, the rep/frame-overlap choppers should always run at 60 Hz
+  frequency_names:
+    - 'Fermi frequency'
+  max_frequencies:
+    [420]                  # Maximum frequencies (Hz)
+  default_frequencies:
+    [180]
+  overlap_ei_frac: 0.9          # Fraction of energy loss Ei to plot ToF lines in time-distance plots
+  ei_limits: [3.6, 61.0]            # Limits on ei for multirep calculations (reps outside range ignored)
+  flux_ref_slot: 40             # Reference slot width (mm) for flux transmission calculation (disk choppers only)
+  flux_ref_freq: 180            # Reference final chopper freq (Hz) for flux transmission calc (disk choppers only)
+  # Can define variants which overide one of the above parameters
+
+detector:
+  name: He3 PSD tubes
+  idet: 2                       # Detector type: 1==He tube binned together, 2==He tube
+  dd: 0.025                     # Detector depth (diameter for tube) in metres
+  tbin: 0.0                     # Detector time bins (microseconds)
+  phi: 60.0                     # Detector scattering angle (degrees)
+  tthlims: [5.0, 65.0]          # Min and max 2-theta angles of detectors (for Q-E plot)
+# for HYSPEC we will need
+
+moderator:
+  name: TS2 Hydrogen            # A==water, AP==poisoned water, CH4==methane, H2==hydrogen. This is only used for analytical calculations
+                                # of the flux distribution for ISIS TS1 moderators. If measured_flux is defined below, name can be anything
+  imod: 3                       # Moderator time profile type: 0==chi^2, 1==Ikeda-Carpenter, 2==modified chi^2
+  mod_pars: [0.0] 
+                                # imod==3 is polynomial. Pars are coeff from highest order to lowest
+  theta: 32.0                   # Angle beamline makes with moderator face (degrees)
+  source_rep: 60                # Frequency of source (Hz)
+  n_frame: 6                    # Number of frames to calculate time-distance diagram for
+  emission_time: 3500           # Time width of source pulse in microseconds (only used to determine spurious reps in multi-rep mode)
+  measured_width:
+    wavelength: [28.60141458, 26.65479018, 24.84065387, 23.14998844, 21.57439041,
+               20.10602826, 18.73760346, 17.46231422, 16.27382172, 15.16621852,
+               14.13399926, 13.17203328, 12.27553911, 11.44006072, 10.66144534,
+                9.93582285,  9.25958654,  8.62937515,  8.04205622,  7.49471047,
+                6.9846173 ,  6.50924128,  6.06621956,  5.65335009,  5.26858069,
+                4.90999885,  4.57582225,  4.26438985,  3.97415367,  3.70367109,
+                3.45159766,  3.21668046,  2.99775183,  2.79372357,  2.60358156,
+                2.42638069,  2.2612402 ,  2.10733923,  1.96391283,  1.83024809,
+                1.70568063,  1.58959128,  1.48140303,  1.38057811,  1.28661538,
+                1.19904779,  1.11744009,  1.04138664,  0.97050943,  0.90445614]
+    width:       [349.37, 354.02, 358.23, 361.74, 364.36, 365.84, 366.  , 364.71,
+       361.86, 357.47, 351.6 , 344.4 , 336.06, 326.81, 316.87, 306.49,
+       295.86, 285.14, 274.45, 263.89, 253.48, 243.24, 233.12, 223.05,
+       212.97, 202.77, 192.43, 181.89, 171.24, 160.57, 150.08, 139.97,
+       130.4 , 121.38, 112.68, 103.81,  94.24,  83.71,  72.47,  61.31,
+        51.03,  42.13,  34.74,  28.75,  23.98,  20.19,  17.17,  14.77,
+        12.85,  11.29 ]
+    isSigma: false
+  measured_flux:                # Table of measured flux vs wavelength. Wavelength in Angstrom. Flux in n/cm^2/s/uA/Angstrom
+    scale_factor: 1.0    # A factor to scale the flux values below by
+    wavelength: [1.28,1.53,1.74,2.02,2.34,3.3,3.69,4.04,4.64]
+    flux: [4.23,8.42,12.52,21.27,30.67,24.92,18.72,12.33,11.60] #from V_fits2, sheet PGApr2014, yellow
+sample: 
+  name: Sample Can
+  isam: 2                       # Sample type: 0==flat plate, 1==ellipse, 2==annulus, 3==sphere, 4==solid cylinder
+  sx: 10.0                      # Thickness (mm) 
+  sy: 10.0                      # Width (mm)
+  sz: 30.0                      # Height (mm)
+  gamma: 0.                     # Angle of x-axis to ki (degrees)

--- a/scripts/PyChop/hyspec.yaml
+++ b/scripts/PyChop/hyspec.yaml
@@ -29,7 +29,7 @@ chopper_system:
       isDouble: False           # Is this a double disk system?
       isPhaseIndependent: False # Is this disk to be phased independently?
     -
-      name: HYSPEC Fermi Chopper 
+      name: HYSPEC Fermi Chopper
       distance: 37.17           # Distance from moderator to this chopper in metres
       aperture_distance: 37.0   # Distance from aperture (moderator face) to this chopper (only for Fermi)
       packages:                 # A hash of chopper packages
@@ -42,7 +42,7 @@ chopper_system:
           tjit: 0.0             # Jitter time (us)
           fluxcorr: 1.0         # (Empirical/Fudge) factor to scale calculated flux by
           isPi: True            # Should the PI pulse (at 180 deg rotation) be transmitted by this package?
-#      slot_width: 110           # Slot width in mm.  angle/360.*2*pi*R. angle=9.0 deg. 
+#      slot_width: 110           # Slot width in mm.  angle/360.*2*pi*R. angle=9.0 deg.
 #      guide_width: 40           # Width of guide after chopper in mm
 #      nslot: 2                  # Number of slots. (Assume all slots equally spaced)
 #      radius: 282.5             # Disk radius
@@ -52,7 +52,7 @@ chopper_system:
   # This is an NxM matrix A where N is the number of choppers and M is the number of indepdent frequencies
   # Such that A.F will give the N required frequencies for each chopper from the M input frequencies
   frequency_matrix:             # HYSPEC is run with one main frequency:
-    [[0],                    
+    [[0],
      [0],
      [1]]                       #   f1: The frequency of the resolution chopper (Chopper 4)
   constant_frequencies:         # This specifies if a chopper should be run at a fixed constant frequency
@@ -82,7 +82,7 @@ moderator:
   name: TS2 Hydrogen            # A==water, AP==poisoned water, CH4==methane, H2==hydrogen. This is only used for analytical calculations
                                 # of the flux distribution for ISIS TS1 moderators. If measured_flux is defined below, name can be anything
   imod: 3                       # Moderator time profile type: 0==chi^2, 1==Ikeda-Carpenter, 2==modified chi^2
-  mod_pars: [0.0] 
+  mod_pars: [0.0]
                                 # imod==3 is polynomial. Pars are coeff from highest order to lowest
   theta: 32.0                   # Angle beamline makes with moderator face (degrees)
   source_rep: 60                # Frequency of source (Hz)
@@ -111,10 +111,10 @@ moderator:
     scale_factor: 1.0    # A factor to scale the flux values below by
     wavelength: [1.28,1.53,1.74,2.02,2.34,3.3,3.69,4.04,4.64]
     flux: [4.23,8.42,12.52,21.27,30.67,24.92,18.72,12.33,11.60] #from V_fits2, sheet PGApr2014, yellow
-sample: 
+sample:
   name: Sample Can
   isam: 2                       # Sample type: 0==flat plate, 1==ellipse, 2==annulus, 3==sphere, 4==solid cylinder
-  sx: 10.0                      # Thickness (mm) 
+  sx: 10.0                      # Thickness (mm)
   sy: 10.0                      # Width (mm)
   sz: 30.0                      # Height (mm)
   gamma: 0.                     # Angle of x-axis to ki (degrees)

--- a/scripts/PyChop/sequoia.yaml
+++ b/scripts/PyChop/sequoia.yaml
@@ -104,10 +104,10 @@ chopper_system:
   default_frequencies:
     [300]
 
-sample: 
+sample:
   name: SEQUOIA Sample Can
   isam: 0                       # Sample type: 0==flat plate, 1==ellipse, 2==annulus, 3==sphere, 4==solid cylinder
-  sx: 2.0                       # Thickness (mm) 
+  sx: 2.0                       # Thickness (mm)
   sy: 48.0                      # Width (mm)
   sz: 48.0                      # Height (mm)
   gamma: 0.0                    # Angle of x-axis to ki (degrees)

--- a/scripts/PyChop/sequoia.yaml
+++ b/scripts/PyChop/sequoia.yaml
@@ -1,0 +1,138 @@
+name: SEQUOIA
+# Input file for PyChop for the SEQUOIA spectrometer at SNS.
+
+chopper_system:
+  name: SEQUOIA chopper system
+  chop_sam: 2.0                 # Distance (x1) from final chopper to sample (m)
+  sam_det: 5.5                  # Distance (x2) from sample to detector (m)
+  aperture_width: 0.050         # Width of aperture at moderator face (m)
+  aperture_height: 0.050        # Height of aperture at moderator face (m)
+  choppers:
+    -                           # Each entry must have a dash on an otherwise empty line!
+      name: SEQUOIA Fermi
+      distance: 18.01           # Distance from moderator to this chopper in metres
+      aperture_distance: 17.0   # Distance from aperture (moderator face) to this chopper (only for Fermi)
+      packages:                 # A hash of chopper packages
+        Fine:
+          name: SEQUOIA Fine resolution 100meV
+          pslit: 1.087          # Neutron transparent slit width (mm)
+          pslat: 0.534          # Neutron absorbing slat width (mm)
+          radius: 49.0          # Chopper package radius (mm)
+          rho: 1300.0           # Chopper package curvature (mm)
+          tjit: 0.0             # Jitter time (us)
+          fluxcorr: 3.0         # (Empirical/Fudge) factor to scale calculated flux by
+          isPi: False           # Should the PI pulse (at 180 deg rotation) be transmitted by this package?
+        Sloppy:
+          name: SEQUOIA Sloppy resolution 700meV
+          pslit: 1.812          # Neutron transparent slit width (mm)
+          pslat: 0.534          # Neutron absorbing slat width (mm)
+          radius: 49.0          # Chopper package radius (mm)
+          rho: 920.0            # Chopper package curvature (mm)
+          tjit: 0.0             # Jitter time (us)
+          fluxcorr: 3.0         # (Empirical/Fudge) factor to scale calculated flux by
+          isPi: False           # Should the PI pulse (at 180 deg rotation) be transmitted by this package?
+        SEQ-100-2.0-AST:
+          name: SEQUOIA 100 meV Sloppy
+          pslit: 2.03           # Neutron transparent slit width (mm)
+          pslat: 0.35           # Neutron absorbing slat width (mm)
+          radius: 50.0          # Chopper package radius (mm)
+          rho: 580.0            # Chopper package curvature (mm)
+          tjit: 0.0             # Jitter time (us)
+          fluxcorr: 3.0         # (Empirical/Fudge) factor to scale calculated flux by
+          isPi: False           # Should the PI pulse (at 180 deg rotation) be transmitted by this package?
+        SEQ-700-3.5-AST:
+          name: SEQUOIA 700 meV Sloppy
+          pslit: 3.56           # Neutron transparent slit width (mm)
+          pslat: 0.35           # Neutron absorbing slat width (mm)
+          radius: 50.0          # Chopper package radius (mm)
+          rho: 1535.0           # Chopper package curvature (mm)
+          tjit: 0.0             # Jitter time (us)
+          fluxcorr: 3.0         # (Empirical/Fudge) factor to scale calculated flux by
+          isPi: False           # Should the PI pulse (at 180 deg rotation) be transmitted by this package?
+        ARCS-100-1.5-AST:
+          name: ARCS 100 meV Sloppy
+          pslit: 1.52           # Neutron transparent slit width (mm)
+          pslat: 0.35           # Neutron absorbing slat width (mm)
+          radius: 50.0          # Chopper package radius (mm)
+          rho: 580.0            # Chopper package curvature (mm)
+          tjit: 0.0             # Jitter time (us)
+          fluxcorr: 3.0         # (Empirical/Fudge) factor to scale calculated flux by
+          isPi: False           # Should the PI pulse (at 180 deg rotation) be transmitted by this package?
+        ARCS-700-1.5-AST:
+          name: ARCS 700 meV Sloppy
+          pslit: 1.52           # Neutron transparent slit width (mm)
+          pslat: 0.35           # Neutron absorbing slat width (mm)
+          radius: 50.0          # Chopper package radius (mm)
+          rho: 1535.0           # Chopper package curvature (mm)
+          tjit: 0.0             # Jitter time (us)
+          fluxcorr: 3.0         # (Empirical/Fudge) factor to scale calculated flux by
+          isPi: False           # Should the PI pulse (at 180 deg rotation) be transmitted by this package?
+        ARCS-700-0.5-AST:
+          name: ARCS 700 meV Fine
+          pslit: 0.51           # Neutron transparent slit width (mm)
+          pslat: 0.35           # Neutron absorbing slat width (mm)
+          radius: 50.0          # Chopper package radius (mm)
+          rho: 1535.0           # Chopper package curvature (mm)
+          tjit: 0.0             # Jitter time (us)
+          fluxcorr: 3.0         # (Empirical/Fudge) factor to scale calculated flux by
+          isPi: False           # Should the PI pulse (at 180 deg rotation) be transmitted by this package?
+        ARCS-100-1.5-SMI:
+          name: ARCS 100 meV Sloppy
+          pslit: 1.52           # Neutron transparent slit width (mm)
+          pslat: 0.41           # Neutron absorbing slat width (mm)
+          radius: 50.0          # Chopper package radius (mm)
+          rho: 580.0            # Chopper package curvature (mm)
+          tjit: 0.0             # Jitter time (us)
+          fluxcorr: 3.0         # (Empirical/Fudge) factor to scale calculated flux by
+          isPi: False           # Should the PI pulse (at 180 deg rotation) be transmitted by this package?
+        ARCS-700-1.5-SMI:
+          name: ARCS 700 meV Sloppy
+          pslit: 1.52           # Neutron transparent slit width (mm)
+          pslat: 0.41           # Neutron absorbing slat width (mm)
+          radius: 50.0          # Chopper package radius (mm)
+          rho: 1535.0           # Chopper package curvature (mm)
+          tjit: 0.0             # Jitter time (us)
+          fluxcorr: 3.0         # (Empirical/Fudge) factor to scale calculated flux by
+          isPi: False           # Should the PI pulse (at 180 deg rotation) be transmitted by this package?
+  # Now define how the frequencies of the choppers should be related
+  # This is an NxM matrix A where N is the number of choppers and M is the number of indepdent frequencies
+  # Such that A.F will give the N required frequencies for each chopper from the M input frequencies
+  frequency_matrix:
+    [[1]]                       # f1 is the Fermi frequency
+  max_frequencies:
+    [600]                       # Maximum frequencies (Hz)
+  default_frequencies:
+    [300]
+
+sample: 
+  name: SEQUOIA Sample Can
+  isam: 0                       # Sample type: 0==flat plate, 1==ellipse, 2==annulus, 3==sphere, 4==solid cylinder
+  sx: 2.0                       # Thickness (mm) 
+  sy: 48.0                      # Width (mm)
+  sz: 48.0                      # Height (mm)
+  gamma: 0.0                    # Angle of x-axis to ki (degrees)
+
+detector:
+  name: He3 PSD tubes
+  idet: 2                       # Detector type: 1==He tube binned together, 2==He tube
+  dd: 0.025                     # Detector depth (diameter for tube) in metres
+  tbin: 0.0                     # Detector time bins (microseconds)
+  phi: 0.0                      # Detector scattering angle (degrees)
+  tthlims: [1.997, 61.926]      # Min and max 2-theta angles of detectors (for Q-E plot)
+
+moderator:
+  name: Ambient Water           # A==water, AP==poisoned water, CH4==methane, H2==hydrogen. This is only used for analytical calculations
+                                # of the flux distribution for ISIS TS1 moderators. If measured_flux is defined below, name can be anything
+  imod: 1                       # Moderator time profile type: 0==chi^2, 1==Ikeda-Carpenter, 2==modified chi^2, 3==polynomial
+  mod_pars: [119.63, 33.618,    # Parameters for time profile (for I-K is: [S1, S2, B1, B2, Emod]
+             .037, .17, 172.42] #    where tau_f=1/(sqrt(Ei)*E2V*sqrt(S1^2+(S2*lam)^2), tau_s=B1 for E<=130meV, B2 otherwise, R=exp(-Ei/Emod)
+  theta: -13.75                 # Angle beamline makes with moderator face (degrees)
+  source_rep: 60                # Frequency of source (Hz)
+  measured_flux:                # Table of measured flux vs wavelength. Wavelength in Angstrom. Flux in n/cm^2/s/uA/Angstrom
+    scale_factor: 10000000      # A factor to scale the flux values below by
+    wavelength: [0.0285984265, 0.2335051748, 0.2859842653, 0.310193488, 0.3418165757, 0.3856211047, 0.4521808267, 0.4834016372,
+                 0.522133444, 0.5719685306, 0.6394802577, 0.6936137254, 0.7643250991, 0.8255654628, 0.9043616533, 0.9809179374,
+                 1.0809189212, 1.2194410046, 1.4299213265, 1.5286501982, 1.6511309256, 1.8087233066, 2.0222141331, 2.3350517482]
+    flux: [1, 1, 1.0769418795, 1.0912234366, 1.1117847541, 1.143928794, 1.201252718, 1.2318227972, 1.2731629789, 1.3321623679,
+           1.4236719322, 1.5075346925, 1.6322258496, 1.7551658109, 1.9353360797, 2.1356198518, 2.4386575654, 2.9461376015,
+           3.8879041876, 4.331779711, 4.8546361998, 5.4701373626, 6.1966620127, 7.3007339739]

--- a/scripts/test/PyChopTest.py
+++ b/scripts/test/PyChopTest.py
@@ -7,6 +7,9 @@
 """Test suite for the PyChop package
 """
 import unittest
+from unittest import mock
+from unittest.mock import patch
+import builtins
 import warnings
 import numpy as np
 
@@ -83,6 +86,184 @@ class PyChop2Tests(unittest.TestCase):
             assert issubclass(w[0].category, UserWarning)
             assert "Cannot calculate for energy transfer greater than Ei" in str(w[0].message)
             assert np.isnan(res[0])
+
+
+class MockedModule(mock.MagicMock):
+    # A class which is meant to act like a module
+    def __init__(self, *args, mock_class=mock.MagicMock, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.mock_class = mock_class
+    def __call__(self, *args, **kwargs):
+        return self.mock_class(*args, **kwargs)
+
+
+class MockImports():
+    """
+    Class to mock imports. Meant to be used with patch on `builtins.__import__`
+    Fake modules can be access using the dot notation on this object, e.g.
+    >>> mockmods = MockImports(include='numpy')
+    >>> with patch('builtins.__import__', mockmods.import_func):
+    >>>     import numpy.sin
+    >>>     print(numpy.sin)
+    >>> print(mockmods.numpy.sin)
+    """
+
+    def __init__(self, include=None, replace=None):
+        # By default all imports will be mocked.
+        # Use the include list to mock only specified modules (and submodules)
+        # Use replace to specify a object to substitute for the real module
+        self.include = include
+        self.replace = replace
+        self.real_import = builtins.__import__
+        self.loaded_modules = {}  # Stores mocks of loaded fake modules
+        self.loaded_from = {}     # Stores mocks of "from" syntax
+        if replace:
+            for replacement_mock in replace:
+                if replacement_mock not in self.include:
+                    self.include.append(replacement_mock)
+
+    def _check_dot_names(self, name, ref_list):
+        for ref_name in ref_list:
+            level = ref_name.count('.') + 1
+            requested = '.'.join(name.split('.')[:level])
+            if ref_name == requested:
+                return name
+        return None
+
+    def is_module_included(self, module_name):
+        if not self.include:
+            return True
+        check_includes = self._check_dot_names(module_name, self.include)
+        return True if check_includes is not None else False
+
+    def get_mock(self, name, fromlist):
+        replacement = self._check_dot_names(name, self.replace)
+        root_name = name.split('.')[0]
+        save = False
+        if replacement is not None:
+            rv = self.replace[replacement]
+        elif root_name in self.loaded_modules:
+            rv = self.loaded_modules[root_name]
+        elif name in self.loaded_from:
+            rv = self.loaded_from[name]
+        else:
+            rv = mock.MagicMock()
+            save = True
+        if fromlist and replacement is None:
+            for mods in fromlist:
+                replacement = self._check_dot_names(mods, self.replace)
+                if replacement is not None:
+                    setattr(rv, mods, self.replace[replacement])
+        if save:
+            self.save_module(name, fromlist, rv)
+        return rv
+
+    def save_module(self, name, fromlist, mock_object):
+        root_name = name.split('.')[0]
+        self.loaded_modules[root_name] = mock_object
+        if fromlist:
+            for mods in fromlist:
+                self.loaded_from[mods] = mock_object
+
+    def import_func(self, name, globals=None, locals=None, fromlist=(), level=0):
+        prf = f'name:{name}, from:{fromlist}, level:{level}'
+        if self.include:
+            if self.is_module_included(name):
+                return self.get_mock(name, fromlist)
+            else:
+                return self.real_import(name, globals, locals, fromlist, level)
+        else:
+            return MockedModule()
+
+    def __getattr__(self, module_name):
+        if module_name in self.loaded_modules:
+            return self.loaded_modules[module_name]
+        if module_name in self.loaded_from:
+            return getattr(self.loaded_from[module_name], module_name)
+
+
+class PyChopGuiTests(unittest.TestCase):
+    # Tests GUI routines
+
+    @classmethod
+    def setUpClass(cls):
+        class fake_QMainWindow():
+            def __init__(self, *args, **kwargs):
+                self.menuBar = mock.MagicMock()
+                self.setCentralWidget = mock.MagicMock()
+                self.setWindowTitle = mock.MagicMock()
+            def setWindowFlags(self, *args, **kwargs):
+                pass
+            def show(self):
+                pass
+        class fake_QCombo(mock.MagicMock):
+            def __init__(self, *args, **kwargs):
+                super().__init__(*args, **kwargs)
+                self.clear()
+            def clear(self):
+                self.items = []
+                self.currentIndex = 0
+            def addItem(self, item):
+                self.items.append(item)
+            def currentText(self):
+                return self.items[self.currentIndex]
+            def count(self):
+                return len(self.items)
+            def itemText(self, idx):
+                return self.items[idx]
+            def setCurrentIndex(self, idx):
+                self.currentIndex = idx
+            def __getattr__(self, attribute):
+                if attribute not in self.__dict__:
+                    self.__dict__[attribute] = mock.MagicMock()
+                return self.__dict__[attribute]
+        class fake_Line(mock.MagicMock):
+            def __init__(self, parent, *args, **kwargs):
+                super().__init__(*args, **kwargs)
+                self.parent = parent
+            def set_label(self, label):
+                parent.legends[self] = label
+        class fake_Axes(mock.MagicMock):
+            def __init__(self, *args, **kwargs):
+                super().__init__(*args, **kwargs)
+                self.legends = {}
+            def plot(self, *args, **kwargs):
+                self.lines.append(fake_Line(self))
+                return self.lines[-1],
+            def get_legend_handles_labels(self):
+                labels = [self.legends[line] for line in self.lines]
+                return self.lines, labels
+        class fake_Figure(mock.MagicMock):
+            def add_subplot(self, *args, **kwargs):
+                return fake_Axes()
+        class fake_Slider(mock.MagicMock):
+            def __init__(self, parent, label, valmin, valmax, **kwargs):
+                super().__init__(parent, label, valmin, valmax, **kwargs)
+                self.parent, self.label, self.valmin, self.valmax = parent, label, valmin, valmax
+                self.val = kwargs.pop('valinit', 0.5)
+                self.valtext = mock.MagicMock()
+                self.on_changed = mock.MagicMock()
+        cls.mock_modules = MockImports(include=['qtpy', 'matplotlib', 'mantidqt', 'mantid.plots'],
+                                       replace={'QMainWindow':fake_QMainWindow,
+                                                'QComboBox':MockedModule(mock_class=fake_QCombo),
+                                                'Figure':MockedModule(mock_class=fake_Figure),
+                                                'Slider':MockedModule(mock_class=fake_Slider)})
+        # Mess around with import mechanism _inside_ PyChopGui so GUI libs not really imported
+        with patch('builtins.__import__', cls.mock_modules.import_func):
+            from PyChop import PyChopGui
+            cls.window = PyChopGui.PyChopGui()
+            cls.window.eiPlots.isChecked = mock.MagicMock(return_value=False)
+            cls.mock_modules.matplotlib.__version__ = '2.1.0'
+
+    def test_hyspec(self):
+        # Tests that Hyspec routines are only called when the instrument is Hyspec
+        with patch.object(self.window, 'setS2') as setS2:
+            self.window.setInstrument('MAPS')
+            self.window.calc_callback()
+            setS2.assert_not_called()
+            self.window.setInstrument('HYSPEC')
+            self.window.calc_callback()
+            setS2.assert_called()
 
 
 if __name__ == "__main__":

--- a/scripts/test/PyChopTest.py
+++ b/scripts/test/PyChopTest.py
@@ -93,6 +93,7 @@ class MockedModule(mock.MagicMock):
     def __init__(self, *args, mock_class=mock.MagicMock, **kwargs):
         super().__init__(*args, **kwargs)
         self.mock_class = mock_class
+
     def __call__(self, *args, **kwargs):
         return self.mock_class(*args, **kwargs)
 
@@ -192,51 +193,51 @@ class PyChopGuiTests(unittest.TestCase):
                 self.menuBar = mock.MagicMock()
                 self.setCentralWidget = mock.MagicMock()
                 self.setWindowTitle = mock.MagicMock()
-            def setWindowFlags(self, *args, **kwargs):
+            def setWindowFlags(self, *args, **kwargs):            # noqa: E306
                 pass
-            def show(self):
+            def show(self):                                       # noqa: E306
                 pass
-        class fake_QCombo(mock.MagicMock):
+        class fake_QCombo(mock.MagicMock):                        # noqa: E306
             def __init__(self, *args, **kwargs):
                 super().__init__(*args, **kwargs)
                 self.clear()
-            def clear(self):
+            def clear(self):                                      # noqa: E306
                 self.items = []
                 self.currentIndex = 0
-            def addItem(self, item):
+            def addItem(self, item):                              # noqa: E306
                 self.items.append(item)
-            def currentText(self):
+            def currentText(self):                                # noqa: E306
                 return self.items[self.currentIndex]
-            def count(self):
+            def count(self):                                      # noqa: E306
                 return len(self.items)
-            def itemText(self, idx):
+            def itemText(self, idx):                              # noqa: E306
                 return self.items[idx]
-            def setCurrentIndex(self, idx):
+            def setCurrentIndex(self, idx):                       # noqa: E306
                 self.currentIndex = idx
-            def __getattr__(self, attribute):
+            def __getattr__(self, attribute):                     # noqa: E306
                 if attribute not in self.__dict__:
                     self.__dict__[attribute] = mock.MagicMock()
                 return self.__dict__[attribute]
-        class fake_Line(mock.MagicMock):
+        class fake_Line(mock.MagicMock):                          # noqa: E306
             def __init__(self, parent, *args, **kwargs):
                 super().__init__(*args, **kwargs)
                 self.parent = parent
-            def set_label(self, label):
+            def set_label(self, label):                           # noqa: E306
                 parent.legends[self] = label
-        class fake_Axes(mock.MagicMock):
+        class fake_Axes(mock.MagicMock):                          # noqa: E306
             def __init__(self, *args, **kwargs):
                 super().__init__(*args, **kwargs)
                 self.legends = {}
-            def plot(self, *args, **kwargs):
+            def plot(self, *args, **kwargs):                      # noqa: E306
                 self.lines.append(fake_Line(self))
                 return self.lines[-1],
-            def get_legend_handles_labels(self):
+            def get_legend_handles_labels(self):                  # noqa: E306
                 labels = [self.legends[line] for line in self.lines]
                 return self.lines, labels
-        class fake_Figure(mock.MagicMock):
+        class fake_Figure(mock.MagicMock):                        # noqa: E306
             def add_subplot(self, *args, **kwargs):
                 return fake_Axes()
-        class fake_Slider(mock.MagicMock):
+        class fake_Slider(mock.MagicMock):                        # noqa: E306
             def __init__(self, parent, label, valmin, valmax, **kwargs):
                 super().__init__(parent, label, valmin, valmax, **kwargs)
                 self.parent, self.label, self.valmin, self.valmax = parent, label, valmin, valmax


### PR DESCRIPTION
**Description of work.**

**Report to:** A. Savici / G. Sala (SNS)

**To test:**

<!-- Instructions for testing. -->
* Build and run. Interface->Direct->PyChop. 
* Check that the SNS instruments (`ARCS`, `CNCS`, `HYSPEC` and `SEQUOIA`) are now included in the instruments list
* Select `HYSPEC` - check there is an extra edit box labelled `S2`. Click `Calculate and Plot`. Click on the `Q-E` tab. Now change the `S2` value and click `Calculate and Plot` again, verify that the `Q-E` tab plot changes. The wedge should move to a lower |Q| if `S2` is low, and vice versa.
* Select each of the SNS instruments and check that the frequencies are multiples of 60Hz. (ISIS instruments would have multiples of 50Hz for TS1 or 10Hz for TS2).

Fixes #29966
<!-- alternative
*There is no associated issue.*
-->

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or master)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
