### PR TITLE
Fix pre-commit on windows install command

### DIFF
--- a/buildconfig/CMake/CommonSetup.cmake
+++ b/buildconfig/CMake/CommonSetup.cmake
@@ -416,7 +416,6 @@ if (ENABLE_PRECOMMIT)
     HINTS
     ~/.local/bin/
     "${MSVC_PYTHON_EXECUTABLE_DIR}/Scripts/")
-  message(WARNING ${PRE_COMMIT_EXE})
   if (NOT PRE_COMMIT_EXE)
     message ( FATAL_ERROR "Failed to find pre-commit see https://developer.mantidproject.org/GettingStarted.html" )
   endif ()

--- a/buildconfig/CMake/CommonSetup.cmake
+++ b/buildconfig/CMake/CommonSetup.cmake
@@ -413,16 +413,16 @@ if (ENABLE_PRECOMMIT)
   find_program(PRE_COMMIT_EXE
     NAMES
     pre-commit
-    pre-commit.cmd
     HINTS
     ~/.local/bin/
     "${MSVC_PYTHON_EXECUTABLE_DIR}/Scripts/")
+  message(WARNING ${PRE_COMMIT_EXE})
   if (NOT PRE_COMMIT_EXE)
     message ( FATAL_ERROR "Failed to find pre-commit see https://developer.mantidproject.org/GettingStarted.html" )
   endif ()
 
   if (MSVC)
-    execute_process(COMMAND "${PRE_COMMIT_EXE} install --overwrite" WORKING_DIRECTORY ${PROJECT_SOURCE_DIR} RESULT_VARIABLE PRE_COMMIT_RESULT)
+    execute_process(COMMAND "${PRE_COMMIT_EXE}.cmd" install --overwrite WORKING_DIRECTORY ${PROJECT_SOURCE_DIR} RESULT_VARIABLE PRE_COMMIT_RESULT)
     if(NOT PRE_COMMIT_RESULT EQUAL "0")
         message(FATAL_ERROR "Pre-commit install failed with ${PRE_COMMIT_RESULT}")
     endif()


### PR DESCRIPTION
**Description of work.**
Fixes an issue that fails to properly call pre-commit install on CMake configure

**To test:**
Run CMake on Windows and Linux to confirm it works on these platforms

<!-- Instructions for testing. -->

*There is no associated issue.*

*This does not require release notes* because it is developer facing

<!-- Ensure the base of this PR is correct (e.g. release-next or master)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
