### PR TITLE
Added support for LeanElasticPeaksWorkspace

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -186,3 +186,6 @@ Third_Party/
 win64/
 dbg/
 rel/
+
+# NFS files
+*.nfs*

--- a/Framework/Crystal/CMakeLists.txt
+++ b/Framework/Crystal/CMakeLists.txt
@@ -263,6 +263,9 @@ add_subdirectory(test)
 
 # Auto-generate exports header
 target_include_directories(Crystal PUBLIC ${CMAKE_BINARY_DIR}/Framework/Crystal)
+target_include_directories( Crystal PUBLIC
+                           ${CMAKE_SOURCE_DIR}/Framework/Geometry/inc/MantidGeometry/Crystal )
+
 generate_mantid_export_header(Crystal FALSE)
 
 # Installation settings

--- a/Framework/Crystal/inc/MantidCrystal/PredictSatellitePeaks.h
+++ b/Framework/Crystal/inc/MantidCrystal/PredictSatellitePeaks.h
@@ -6,9 +6,11 @@
 // SPDX - License - Identifier: GPL - 3.0 +
 #pragma once
 
+#include "IPeak.h"
 #include "MantidAPI/Algorithm.h"
 #include "MantidAPI/IPeaksWorkspace.h"
 #include "MantidCrystal/DllConfig.h"
+#include "MantidDataObjects/LeanElasticPeaksWorkspace.h"
 #include "MantidDataObjects/PeaksWorkspace.h"
 #include "MantidGeometry/Crystal/HKLFilterWavelength.h"
 #include "MantidKernel/System.h"
@@ -41,10 +43,23 @@ public:
   /// Algorithm's category for identification
   const std::string category() const override { return "Crystal\\Peaks"; }
 
+  /* Determine which type of workspace we're dealing with */
+  enum class workspace_type_enum { regular_peaks, lean_elastic_peaks, invalid };
+
 private:
+  workspace_type_enum determine_workspace_type(API::IPeaksWorkspace_sptr const &iPeaksWorkspace) const;
+
+  std::shared_ptr<Geometry::IPeak> createPeakForOutputWorkspace(Kernel::Matrix<double> const &goniometer,
+                                                                Kernel::V3D const &satellite_hkl);
+
+  void addPeakToOutputWorkspace(std::shared_ptr<Geometry::IPeak> iPeak,
+                                Kernel::Matrix<double> const &peak_goniometer_matrix, Kernel::V3D const &hkl,
+                                Kernel::V3D const &satelliteHKL, int const RunNumber,
+                                std::vector<std::vector<int>> &AlreadyDonePeaks, Kernel::V3D const &mnp);
+
   const size_t MAX_NUMBER_HKLS = 10000000000;
   double m_qConventionFactor;
-  DataObjects::PeaksWorkspace_sptr Peaks;
+  API::IPeaksWorkspace_sptr Peaks;
   API::IPeaksWorkspace_sptr outPeaks;
   /// Initialise the properties
   void init() override;

--- a/Framework/Crystal/src/PredictSatellitePeaks.cpp
+++ b/Framework/Crystal/src/PredictSatellitePeaks.cpp
@@ -36,8 +36,6 @@ using namespace Mantid::Kernel;
 namespace Crystal {
 
 // handy shortcuts
-using Mantid::DataObjects::Peak_uptr;
-using Mantid::Geometry::IPeak_uptr;
 
 DECLARE_ALGORITHM(PredictSatellitePeaks)
 
@@ -49,11 +47,11 @@ PredictSatellitePeaks::PredictSatellitePeaks() : m_qConventionFactor(qConvention
 /// Initialise the properties
 void PredictSatellitePeaks::init() {
   auto latticeValidator = std::make_shared<OrientedLatticeValidator>();
-  declareProperty(std::make_unique<WorkspaceProperty<PeaksWorkspace>>("Peaks", "", Direction::Input, latticeValidator),
+  declareProperty(std::make_unique<WorkspaceProperty<IPeaksWorkspace>>("Peaks", "", Direction::Input, latticeValidator),
                   "Workspace of Peaks with orientation matrix that indexed the peaks and "
                   "instrument loaded");
 
-  declareProperty(std::make_unique<WorkspaceProperty<PeaksWorkspace>>("SatellitePeaks", "", Direction::Output),
+  declareProperty(std::make_unique<WorkspaceProperty<IPeaksWorkspace>>("SatellitePeaks", "", Direction::Output),
                   "Workspace of Peaks with peaks with fractional h,k, and/or l values");
   declareProperty(std::make_unique<Kernel::ArrayProperty<double>>(string("ModVector1"), "0.0,0.0,0.0"),
                   "Offsets for h, k, l directions ");
@@ -103,8 +101,9 @@ void PredictSatellitePeaks::init() {
 void PredictSatellitePeaks::exec() {
   bool includePeaksInRange = getProperty("IncludeAllPeaksInRange");
   Peaks = getProperty("Peaks");
+
   if (!Peaks)
-    throw std::invalid_argument("Input workspace is not a PeaksWorkspace. Type=" + Peaks->id());
+    throw std::invalid_argument("Input workspace is not a IPeaksWorkspace. Type=" + Peaks->id());
   if (!includePeaksInRange) {
     exec_peaks();
     return;
@@ -140,7 +139,7 @@ void PredictSatellitePeaks::exec() {
 
   const auto instrument = Peaks->getInstrument();
 
-  outPeaks = std::dynamic_pointer_cast<IPeaksWorkspace>(WorkspaceFactory::Instance().createPeaks());
+  outPeaks = std::dynamic_pointer_cast<IPeaksWorkspace>(WorkspaceFactory::Instance().createPeaks(Peaks->id()));
   outPeaks->setInstrument(instrument);
   outPeaks->mutableSample().setOrientedLattice(std::move(lattice));
 
@@ -251,7 +250,7 @@ void PredictSatellitePeaks::exec_peaks() {
 
   const auto instrument = Peaks->getInstrument();
 
-  outPeaks = std::dynamic_pointer_cast<IPeaksWorkspace>(WorkspaceFactory::Instance().createPeaks());
+  outPeaks = std::dynamic_pointer_cast<IPeaksWorkspace>(WorkspaceFactory::Instance().createPeaks(Peaks->id()));
   outPeaks->setInstrument(instrument);
   outPeaks->mutableSample().setOrientedLattice(std::move(lattice));
 
@@ -260,12 +259,15 @@ void PredictSatellitePeaks::exec_peaks() {
   outPeaks->mutableRun().addProperty<std::vector<double>>("Offset1", offsets1, true);
   outPeaks->mutableRun().addProperty<std::vector<double>>("Offset2", offsets2, true);
   outPeaks->mutableRun().addProperty<std::vector<double>>("Offset3", offsets3, true);
-  std::vector<Peak> peaks = Peaks->getPeaks();
-  for (auto it = peaks.begin(); it != peaks.end(); ++it) {
-    auto peak = *it;
-    Kernel::Matrix<double> const peak_goniometer_matrix = peak.getGoniometerMatrix();
-    int run_number = peak.getRunNumber();
-    V3D hkl = peak.getHKL();
+
+  for (int i = 0; i < static_cast<int>(Peaks->getNumberPeaks()); ++i) {
+
+    Kernel::Matrix<double> const peak_goniometer_matrix = Peaks->getPeak(i).getGoniometerMatrix();
+
+    int run_number = Peaks->getPeak(i).getRunNumber();
+
+    V3D hkl = Peaks->getPeak(i).getHKL();
+
     if (crossTerms) {
       predictOffsetsWithCrossTerms(offsets1, offsets2, offsets3, maxOrder, run_number, peak_goniometer_matrix, hkl,
                                    lambdaFilter, includePeaksInRange, includeOrderZero, AlreadyDonePeaks);
@@ -284,7 +286,12 @@ void PredictSatellitePeaks::exec_peaks() {
   // adjacent
   std::vector<std::pair<std::string, bool>> criteria;
   criteria.emplace_back("RunNumber", true);
-  criteria.emplace_back("BankName", true);
+
+  workspace_type_enum const workspace_type = determine_workspace_type(Peaks);
+  if (workspace_type == workspace_type_enum::regular_peaks) {
+    criteria.emplace_back("BankName", true);
+  }
+
   criteria.emplace_back("h", true);
   criteria.emplace_back("k", true);
   criteria.emplace_back("l", true);
@@ -297,14 +304,27 @@ void PredictSatellitePeaks::exec_peaks() {
   setProperty("SatellitePeaks", outPeaks);
 }
 
+PredictSatellitePeaks::workspace_type_enum
+PredictSatellitePeaks::determine_workspace_type(API::IPeaksWorkspace_sptr const &iPeaksWorkspace) const {
+  if (std::dynamic_pointer_cast<PeaksWorkspace>(iPeaksWorkspace) != nullptr) {
+    return workspace_type_enum::regular_peaks;
+  }
+
+  else if (std::dynamic_pointer_cast<LeanElasticPeaksWorkspace>(iPeaksWorkspace) != nullptr) {
+    return workspace_type_enum::lean_elastic_peaks;
+  }
+
+  else {
+    return workspace_type_enum::invalid;
+  }
+}
+
 void PredictSatellitePeaks::predictOffsets(int indexModulatedVector, V3D offsets, int &maxOrder, int RunNumber,
                                            Kernel::Matrix<double> const &goniometer, V3D &hkl,
                                            HKLFilterWavelength &lambdaFilter, bool &includePeaksInRange,
                                            bool &includeOrderZero, vector<vector<int>> &AlreadyDonePeaks) {
   if (offsets == V3D(0, 0, 0) && !includeOrderZero)
     return;
-  const Kernel::DblMatrix &UB = Peaks->sample().getOrientedLattice().getUB();
-  Geometry::InstrumentRayTracer tracer(Peaks->getInstrument());
   for (int order = -maxOrder; order <= maxOrder; order++) {
     if (order == 0 && !includeOrderZero)
       continue; // exclude order 0
@@ -314,37 +334,12 @@ void PredictSatellitePeaks::predictOffsets(int indexModulatedVector, V3D offsets
     if (!lambdaFilter.isAllowed(satelliteHKL) && includePeaksInRange)
       continue;
 
-    Kernel::V3D Qs = goniometer * UB * satelliteHKL * 2.0 * M_PI * m_qConventionFactor;
+    std::shared_ptr<IPeak> satellite_iPeak = createPeakForOutputWorkspace(goniometer, satelliteHKL);
 
-    // Check if Q is non-physical
-    if (Qs.Z() * m_qConventionFactor <= 0)
-      continue;
-
-    IPeak_uptr iPeak = Peaks->createPeak(Qs, 1);
-    Peak_uptr peak(static_cast<DataObjects::Peak *>(iPeak.release()));
-
-    peak->setGoniometerMatrix(goniometer);
-
-    if (!peak->findDetector(tracer))
-      continue;
-    vector<int> SavPk{RunNumber, boost::math::iround(1000.0 * satelliteHKL[0]),
-                      boost::math::iround(1000.0 * satelliteHKL[1]), boost::math::iround(1000.0 * satelliteHKL[2])};
-
-    bool foundPeak = binary_search(AlreadyDonePeaks.begin(), AlreadyDonePeaks.end(), SavPk);
-
-    if (!foundPeak) {
-      AlreadyDonePeaks.emplace_back(SavPk);
-    } else {
-      continue;
-    }
-
-    peak->setHKL(satelliteHKL * m_qConventionFactor);
-    peak->setIntHKL(hkl * m_qConventionFactor);
-    peak->setRunNumber(RunNumber);
     V3D mnp;
     mnp[indexModulatedVector] = order;
-    peak->setIntMNP(mnp * m_qConventionFactor);
-    outPeaks->addPeak(*peak);
+
+    addPeakToOutputWorkspace(satellite_iPeak, goniometer, hkl, satelliteHKL, RunNumber, AlreadyDonePeaks, mnp);
   }
 }
 
@@ -356,8 +351,6 @@ void PredictSatellitePeaks::predictOffsetsWithCrossTerms(V3D offsets1, V3D offse
                                                          vector<vector<int>> &AlreadyDonePeaks) {
   if (offsets1 == V3D(0, 0, 0) && offsets2 == V3D(0, 0, 0) && offsets3 == V3D(0, 0, 0) && !includeOrderZero)
     return;
-  const Kernel::DblMatrix &UB = Peaks->sample().getOrientedLattice().getUB();
-  Geometry::InstrumentRayTracer tracer(Peaks->getInstrument());
   DblMatrix offsetsMat(3, 3);
   offsetsMat.setColumn(0, offsets1);
   offsetsMat.setColumn(1, offsets2);
@@ -382,36 +375,85 @@ void PredictSatellitePeaks::predictOffsetsWithCrossTerms(V3D offsets1, V3D offse
         if (!lambdaFilter.isAllowed(satelliteHKL) && includePeaksInRange)
           continue;
 
-        Kernel::V3D Qs = peak_goniometer_matrix * UB * satelliteHKL * 2.0 * M_PI * m_qConventionFactor;
+        std::shared_ptr<IPeak> satellite_iPeak = createPeakForOutputWorkspace(peak_goniometer_matrix, satelliteHKL);
 
-        // Check if Q is non-physical
-        if (Qs.Z() * m_qConventionFactor <= 0)
-          continue;
-
-        IPeak_uptr iPeak(Peaks->createPeak(Qs, 1));
-        Peak_uptr peak(static_cast<DataObjects::Peak *>(iPeak.release()));
-
-        peak->setGoniometerMatrix(peak_goniometer_matrix);
-
-        if (!peak->findDetector(tracer))
-          continue;
-        vector<int> SavPk{RunNumber, boost::math::iround(1000.0 * satelliteHKL[0]),
-                          boost::math::iround(1000.0 * satelliteHKL[1]), boost::math::iround(1000.0 * satelliteHKL[2])};
-
-        bool foundPeak = binary_search(AlreadyDonePeaks.begin(), AlreadyDonePeaks.end(), SavPk);
-
-        if (!foundPeak) {
-          AlreadyDonePeaks.emplace_back(SavPk);
-        } else {
-          continue;
-        }
-
-        peak->setHKL(satelliteHKL * m_qConventionFactor);
-        peak->setIntHKL(hkl * m_qConventionFactor);
-        peak->setRunNumber(RunNumber);
-        peak->setIntMNP(V3D(m, n, p) * m_qConventionFactor);
-        outPeaks->addPeak(*peak);
+        addPeakToOutputWorkspace(satellite_iPeak, peak_goniometer_matrix, hkl, satelliteHKL, RunNumber,
+                                 AlreadyDonePeaks, mnp);
       }
+}
+
+std::shared_ptr<Geometry::IPeak>
+PredictSatellitePeaks::createPeakForOutputWorkspace(Kernel::Matrix<double> const &peak_goniometer_matrix,
+                                                    Kernel::V3D const &satelliteHKL) {
+  workspace_type_enum workspace_type = determine_workspace_type(Peaks);
+
+  const Kernel::DblMatrix &UB = Peaks->sample().getOrientedLattice().getUB();
+  if (workspace_type == workspace_type_enum::regular_peaks) {
+    Kernel::V3D const Qs = peak_goniometer_matrix * UB * satelliteHKL * 2.0 * M_PI * m_qConventionFactor;
+
+    // Check if Q is non-physical
+    if (Qs.Z() * m_qConventionFactor <= 0)
+      return nullptr;
+
+    std::shared_ptr<IPeak> satellite_iPeak = Peaks->createPeak(Qs, 1);
+
+    return satellite_iPeak;
+  }
+
+  else if (workspace_type == workspace_type_enum::lean_elastic_peaks) {
+    Kernel::V3D const Qs = UB * satelliteHKL * 2.0 * M_PI * m_qConventionFactor;
+
+    std::shared_ptr<IPeak> satellite_iPeak = Peaks->createPeakQSample(Qs);
+
+    return satellite_iPeak;
+  }
+
+  else
+    return nullptr;
+}
+
+void PredictSatellitePeaks::addPeakToOutputWorkspace(std::shared_ptr<IPeak> satellite_iPeak,
+                                                     Kernel::Matrix<double> const &peak_goniometer_matrix,
+                                                     Kernel::V3D const &hkl, Kernel::V3D const &satelliteHKL,
+                                                     int const RunNumber,
+                                                     std::vector<std::vector<int>> &AlreadyDonePeaks,
+                                                     Kernel::V3D const &mnp) {
+  if (satellite_iPeak == nullptr)
+    return;
+
+  workspace_type_enum const workspace_type = determine_workspace_type(Peaks);
+
+  if (workspace_type == workspace_type_enum::regular_peaks) {
+    Geometry::InstrumentRayTracer const tracer(Peaks->getInstrument());
+
+    std::shared_ptr<Peak> const peak = std::dynamic_pointer_cast<Peak>(satellite_iPeak);
+
+    if (!peak->findDetector(tracer))
+      return;
+  }
+
+  std::vector<int> const SavPk{RunNumber, boost::math::iround(1000.0 * satelliteHKL[0]),
+                               boost::math::iround(1000.0 * satelliteHKL[1]),
+                               boost::math::iround(1000.0 * satelliteHKL[2])};
+
+  bool const foundPeak = binary_search(AlreadyDonePeaks.begin(), AlreadyDonePeaks.end(), SavPk);
+
+  if (!foundPeak) {
+    AlreadyDonePeaks.emplace_back(SavPk);
+  }
+
+  else
+    return;
+
+  satellite_iPeak->setGoniometerMatrix(peak_goniometer_matrix);
+  satellite_iPeak->setHKL(satelliteHKL * m_qConventionFactor);
+  satellite_iPeak->setIntHKL(hkl * m_qConventionFactor);
+  satellite_iPeak->setRunNumber(RunNumber);
+  satellite_iPeak->setIntMNP(mnp * m_qConventionFactor);
+
+  outPeaks->addPeak(*satellite_iPeak);
+
+  return;
 }
 
 V3D PredictSatellitePeaks::getOffsetVector(const std::string &label) {

--- a/Framework/Crystal/test/PredictSatellitePeaksTest.h
+++ b/Framework/Crystal/test/PredictSatellitePeaksTest.h
@@ -53,7 +53,7 @@ public:
     TS_ASSERT(alg1.execute());
     TS_ASSERT(alg1.isExecuted());
 
-    PeaksWorkspace_sptr ws;
+    IPeaksWorkspace_sptr ws;
     TS_ASSERT_THROWS_NOTHING(
         ws = std::dynamic_pointer_cast<PeaksWorkspace>(AnalysisDataService::Instance().retrieve("Modulated")));
     TS_ASSERT(ws);
@@ -78,7 +78,7 @@ public:
     TS_ASSERT(alg.execute());
     TS_ASSERT(alg.isExecuted());
     alg.setPropertyValue("SatellitePeaks", "SatellitePeaks");
-    PeaksWorkspace_sptr SatellitePeaks = alg.getProperty("SatellitePeaks");
+    IPeaksWorkspace_sptr SatellitePeaks = alg.getProperty("SatellitePeaks");
     TS_ASSERT(SatellitePeaks);
 
     TS_ASSERT_EQUALS(SatellitePeaks->getNumberPeaks(), 40);
@@ -108,7 +108,7 @@ public:
     TS_ASSERT(alg4.execute())
     TS_ASSERT(alg4.isExecuted());
     alg4.setPropertyValue("SatellitePeaks", "SatellitePeaks");
-    PeaksWorkspace_sptr SatellitePeaks2 = alg4.getProperty("SatellitePeaks");
+    IPeaksWorkspace_sptr SatellitePeaks2 = alg4.getProperty("SatellitePeaks");
     TS_ASSERT(SatellitePeaks2);
 
     TS_ASSERT_EQUALS(SatellitePeaks2->getNumberPeaks(), 939);
@@ -159,13 +159,15 @@ public:
     TS_ASSERT(alg.isExecuted());
 
     alg.setPropertyValue("SatellitePeaks", "SatellitePeaks");
-    PeaksWorkspace_sptr SatellitePeaks2 = alg.getProperty("SatellitePeaks");
+
+    IPeaksWorkspace_sptr SatelliteIPeaks2 = alg.getProperty("SatellitePeaks");
+    PeaksWorkspace_sptr SatellitePeaks2 = std::dynamic_pointer_cast<PeaksWorkspace>(SatelliteIPeaks2);
+
     TS_ASSERT(SatellitePeaks2);
+    TS_ASSERT_EQUALS(SatellitePeaks2->getNumberPeaks(), 4);
 
     /* pull out the satellite peaks */
     std::vector<Peak> const &satellite_peaks = SatellitePeaks2->getPeaks();
-
-    TS_ASSERT_EQUALS(satellite_peaks.size(), 4);
 
     /* check goniometer matrices */
 
@@ -182,6 +184,86 @@ public:
     /* check peak HKL coordinates */
     TS_ASSERT_EQUALS(satellite_peaks[0].getHKL(), Mantid::Kernel::V3D(1.2, 1, 0));
     TS_ASSERT_EQUALS(satellite_peaks[1].getHKL(), Mantid::Kernel::V3D(0.8, 1, 0));
+    TS_ASSERT_EQUALS(satellite_peaks[2].getHKL(), Mantid::Kernel::V3D(-1.2, -1, 0));
+    TS_ASSERT_EQUALS(satellite_peaks[3].getHKL(), Mantid::Kernel::V3D(-0.8, -1, 0));
+
+    /* check run numbers */
+    TS_ASSERT_EQUALS(satellite_peaks[0].getRunNumber(), 0);
+    TS_ASSERT_EQUALS(satellite_peaks[1].getRunNumber(), 0);
+    TS_ASSERT_EQUALS(satellite_peaks[2].getRunNumber(), 1);
+    TS_ASSERT_EQUALS(satellite_peaks[3].getRunNumber(), 1);
+
+    AnalysisDataService::Instance().remove("peaks");
+  }
+
+  void test_exec_multiple_goniometers_lean() {
+
+    /* Add it to a Peaks workspace */
+    TS_ASSERT_THROWS_NOTHING(FrameworkManager::Instance().exec(
+        "CreatePeaksWorkspace", 6, "NumberOfPeaks", "0", "OutputWorkspace", "peaks", "OutputType", "LeanElasticPeak"));
+
+    /* retrieve a handle to the peaks workspace created in the FrameworkManager
+     */
+    LeanElasticPeaksWorkspace_sptr peaks_workspace;
+    TS_ASSERT_THROWS_NOTHING(peaks_workspace = std::dynamic_pointer_cast<LeanElasticPeaksWorkspace>(
+                                 AnalysisDataService::Instance().retrieve("peaks")));
+
+    /* set uniform background */
+    FrameworkManager::Instance().exec("SetUB", 8, "Workspace", "peaks", "a", "2", "b", "2", "c", "2");
+
+    /* create 2 peaks */
+    FrameworkManager::Instance().exec("AddPeakHKL", 4, "Workspace", "peaks", "HKL", "1,1,0");
+
+    peaks_workspace->getPeak(0).setRunNumber(0);
+
+    /* move the goniometer to point to the 2nd peak */
+    FrameworkManager::Instance().exec("SetGoniometer", 4, "Workspace", "peaks", "Axis0", "180,0,1,0,1");
+
+    FrameworkManager::Instance().exec("AddPeakHKL", 4, "Workspace", "peaks", "HKL", "-1,-1,0");
+
+    peaks_workspace->getPeak(1).setRunNumber(1);
+
+    /* algorithm to test */
+    PredictSatellitePeaks alg;
+
+    TS_ASSERT_THROWS_NOTHING(alg.initialize());
+    TS_ASSERT(alg.isInitialized());
+
+    alg.setProperty("Peaks", "peaks");
+    alg.setProperty("SatellitePeaks", std::string("SatellitePeaks"));
+    alg.setProperty("ModVector1", "0.2,0,0");
+    alg.setProperty("MaxOrder", "1");
+    alg.setProperty("IncludeIntegerHKL", false);
+    TS_ASSERT(alg.execute());
+    TS_ASSERT(alg.isExecuted());
+
+    alg.setPropertyValue("SatellitePeaks", "SatellitePeaks");
+
+    IPeaksWorkspace_sptr SatelliteIPeaks2 = alg.getProperty("SatellitePeaks");
+    LeanElasticPeaksWorkspace_sptr SatellitePeaks2 =
+        std::dynamic_pointer_cast<LeanElasticPeaksWorkspace>(SatelliteIPeaks2);
+
+    TS_ASSERT(SatellitePeaks2);
+    TS_ASSERT_EQUALS(SatellitePeaks2->getNumberPeaks(), 4);
+
+    /* pull out the satellite peaks */
+    std::vector<LeanElasticPeak> const &satellite_peaks = SatellitePeaks2->getPeaks();
+
+    /* check goniometer matrices */
+
+    TS_ASSERT_EQUALS(satellite_peaks[0].getGoniometerMatrix(), Mantid::Kernel::Matrix<double>(3, 3, true));
+
+    TS_ASSERT_EQUALS(satellite_peaks[1].getGoniometerMatrix(), Mantid::Kernel::Matrix<double>(3, 3, true));
+
+    TS_ASSERT_EQUALS(satellite_peaks[2].getGoniometerMatrix(),
+                     Mantid::Kernel::Matrix<double>({-1, 0, 0, 0, 1, 0, 0, 0, -1}));
+
+    TS_ASSERT_EQUALS(satellite_peaks[3].getGoniometerMatrix(),
+                     Mantid::Kernel::Matrix<double>({-1, 0, 0, 0, 1, 0, 0, 0, -1}));
+
+    TS_ASSERT_EQUALS(satellite_peaks[1].getHKL(), Mantid::Kernel::V3D(1.2, 1, 0));
+    TS_ASSERT_EQUALS(satellite_peaks[0].getHKL(), Mantid::Kernel::V3D(0.8, 1, 0));
+
     TS_ASSERT_EQUALS(satellite_peaks[2].getHKL(), Mantid::Kernel::V3D(-1.2, -1, 0));
     TS_ASSERT_EQUALS(satellite_peaks[3].getHKL(), Mantid::Kernel::V3D(-0.8, -1, 0));
 


### PR DESCRIPTION
**Description of work.**
PredictSatellitePeaks algorithm currently only supports PeaksWorkspace and contained Peaks. This PR adds support for LeanElasticPeaks workspace and contained LeanElasticPeaks.

Linked issue: https://code.ornl.gov/sns-hfir-scse/diffraction/single-crystal/single-crystal-diffraction/-/issues/254

PR ---> ornl-next: https://github.com/mantidproject/mantid/pull/31083

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

**To test:**
cd <mantid_build_dir>/bin;
./CrystalTest PredictSatellitePeaksTest test_exec_multiple_goniometers_lean

<!-- Instructions for testing. -->

Fixes #xxxx. <!-- and fix #xxxx or close #xxxx xor resolves #xxxx -->
<!-- alternative
*There is no associated issue.*
-->

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or master)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
