### PR TITLE
WAND2 correction for wide beam

### DIFF
--- a/Framework/MDAlgorithms/src/ConvertHFIRSCDtoMDE.cpp
+++ b/Framework/MDAlgorithms/src/ConvertHFIRSCDtoMDE.cpp
@@ -147,6 +147,8 @@ void ConvertHFIRSCDtoMDE::init() {
                   "this list will be ignored");
   // Box controller properties. These are the defaults
   this->initBoxControllerProps("5" /*SplitInto*/, 1000 /*SplitThreshold*/, 20 /*MaxRecursionDepth*/);
+  declareProperty(std::make_unique<PropertyWithValue<double>>("ObliquityParallaxCoefficient", 1.0, Direction::Input),
+                  "Geometrical correction for shift in vertical beam position due to wide beam.");
   declareProperty(std::make_unique<WorkspaceProperty<API::IMDEventWorkspace>>("OutputWorkspace", "", Direction::Output),
                   "An output workspace.");
 }
@@ -200,6 +202,8 @@ void ConvertHFIRSCDtoMDE::exec() {
   auto mdws_mdevt_3 = std::dynamic_pointer_cast<MDEventWorkspace<MDEvent<3>, 3>>(outputWS);
   MDEventInserter<MDEventWorkspace<MDEvent<3>, 3>::sptr> inserter(mdws_mdevt_3);
 
+  double cop = this->getProperty("ObliquityParallaxCoefficient");
+
   float k = boost::math::float_constants::two_pi / static_cast<float>(wavelength);
   // check convention to determine the sign of k
   std::string convention = Kernel::ConfigService::Instance().getString("Q.convention");
@@ -211,7 +215,8 @@ void ConvertHFIRSCDtoMDE::exec() {
   for (size_t m = 0; m < azimuthal.size(); ++m) {
     auto twotheta_f = static_cast<float>(twotheta[m]);
     auto azimuthal_f = static_cast<float>(azimuthal[m]);
-    q_lab_pre.push_back({-sin(twotheta_f) * cos(azimuthal_f) * k, -sin(twotheta_f) * sin(azimuthal_f) * k,
+    q_lab_pre.push_back({-sin(twotheta_f) * cos(azimuthal_f) * k, 
+                         -sin(twotheta_f) * sin(azimuthal_f) * k * cop,
                          (1.f - cos(twotheta_f)) * k});
   }
   const auto run = inputWS->getExperimentInfo(0)->run();

--- a/Framework/MDAlgorithms/src/ConvertHFIRSCDtoMDE.cpp
+++ b/Framework/MDAlgorithms/src/ConvertHFIRSCDtoMDE.cpp
@@ -203,6 +203,7 @@ void ConvertHFIRSCDtoMDE::exec() {
   MDEventInserter<MDEventWorkspace<MDEvent<3>, 3>::sptr> inserter(mdws_mdevt_3);
 
   double cop = this->getProperty("ObliquityParallaxCoefficient");
+  float coeff = static_cast<float>(cop);
 
   float k = boost::math::float_constants::two_pi / static_cast<float>(wavelength);
   // check convention to determine the sign of k
@@ -215,8 +216,7 @@ void ConvertHFIRSCDtoMDE::exec() {
   for (size_t m = 0; m < azimuthal.size(); ++m) {
     auto twotheta_f = static_cast<float>(twotheta[m]);
     auto azimuthal_f = static_cast<float>(azimuthal[m]);
-    q_lab_pre.push_back({-sin(twotheta_f) * cos(azimuthal_f) * k, 
-                         -sin(twotheta_f) * sin(azimuthal_f) * k * cop,
+    q_lab_pre.push_back({-sin(twotheta_f) * cos(azimuthal_f) * k, -sin(twotheta_f) * sin(azimuthal_f) * k * coeff,
                          (1.f - cos(twotheta_f)) * k});
   }
   const auto run = inputWS->getExperimentInfo(0)->run();

--- a/Framework/MDAlgorithms/test/ConvertHFIRSCDtoMDETest.h
+++ b/Framework/MDAlgorithms/test/ConvertHFIRSCDtoMDETest.h
@@ -60,7 +60,6 @@ public:
     TS_ASSERT(alg.isInitialized())
     TS_ASSERT_THROWS_NOTHING(alg.setProperty("InputWorkspace", "ConvertHFIRSCDtoMDETest_data"));
     TS_ASSERT_THROWS_NOTHING(alg.setProperty("Wavelength", "1.008"));
-    TS_ASSERT_THROWS_NOTHING(alg.setProperty("ObliquityParallaxCoefficient", 1.5));
     TS_ASSERT_THROWS_NOTHING(alg.setPropertyValue("OutputWorkspace", "_unused_for_child"));
     TS_ASSERT_THROWS_NOTHING(alg.execute(););
     TS_ASSERT(alg.isExecuted());

--- a/Framework/MDAlgorithms/test/ConvertHFIRSCDtoMDETest.h
+++ b/Framework/MDAlgorithms/test/ConvertHFIRSCDtoMDETest.h
@@ -60,6 +60,7 @@ public:
     TS_ASSERT(alg.isInitialized())
     TS_ASSERT_THROWS_NOTHING(alg.setProperty("InputWorkspace", "ConvertHFIRSCDtoMDETest_data"));
     TS_ASSERT_THROWS_NOTHING(alg.setProperty("Wavelength", "1.008"));
+    TS_ASSERT_THROWS_NOTHING(alg.setProperty("ObliquityParallaxCoefficient", 1.5));
     TS_ASSERT_THROWS_NOTHING(alg.setPropertyValue("OutputWorkspace", "_unused_for_child"));
     TS_ASSERT_THROWS_NOTHING(alg.execute(););
     TS_ASSERT(alg.isExecuted());
@@ -89,7 +90,9 @@ public:
     // check other things
     TS_ASSERT_EQUALS(1, outWS->getNumExperimentInfo());
     TS_ASSERT_EQUALS(9038, outWS->getNEvents());
-    const Mantid::coord_t coords[3] = {-0.42f, 1.71f, 2.3f}; // roughly the location of maximum instenity
+    Mantid::coord_t coords[3] = {-0.42f, 1.71f, 2.3f}; // roughly the location of maximum instenity
+    float coeff = std::stof(alg.getPropertyValue("ObliquityParallaxCoefficient"));
+    coords[1] = coeff*coords[1];
     TS_ASSERT_DELTA(outWS->getSignalAtCoord(coords, Mantid::API::NoNormalization), 568, 1e-5);
   }
 };

--- a/Framework/MDAlgorithms/test/ConvertHFIRSCDtoMDETest.h
+++ b/Framework/MDAlgorithms/test/ConvertHFIRSCDtoMDETest.h
@@ -88,11 +88,26 @@ public:
     TS_ASSERT_EQUALS(10, outWS->getDimension(2)->getMaximum());
 
     // check other things
+    const Mantid::coord_t coords[3] = {-0.42f, 1.71f, 2.3f}; // roughly the location of maximum instenity
     TS_ASSERT_EQUALS(1, outWS->getNumExperimentInfo());
     TS_ASSERT_EQUALS(9038, outWS->getNEvents());
-    Mantid::coord_t coords[3] = {-0.42f, 1.71f, 2.3f}; // roughly the location of maximum instenity
-    float coeff = std::stof(alg.getPropertyValue("ObliquityParallaxCoefficient"));
-    coords[1] = coeff*coords[1];
     TS_ASSERT_DELTA(outWS->getSignalAtCoord(coords, Mantid::API::NoNormalization), 568, 1e-5);
+
+    // check coeff behavior
+    TS_ASSERT_THROWS_NOTHING(alg.initialize())
+    TS_ASSERT(alg.isInitialized())
+    TS_ASSERT_THROWS_NOTHING(alg.setProperty("InputWorkspace", "ConvertHFIRSCDtoMDETest_data"));
+    TS_ASSERT_THROWS_NOTHING(alg.setProperty("Wavelength", "1.008"));
+    TS_ASSERT_THROWS_NOTHING(alg.setProperty("ObliquityParallaxCoefficient", "1.5"));
+    TS_ASSERT_THROWS_NOTHING(alg.setPropertyValue("OutputWorkspace", "_unused_for_child"));
+    TS_ASSERT_THROWS_NOTHING(alg.execute(););
+    TS_ASSERT(alg.isExecuted());
+
+    outWS = alg.getProperty("OutputWorkspace");
+    TS_ASSERT(outWS);
+
+    TS_ASSERT_EQUALS(1, outWS->getNumExperimentInfo());
+    TS_ASSERT_EQUALS(9038, outWS->getNEvents());
+    TS_ASSERT_DELTA(outWS->getSignalAtCoord(coords, Mantid::API::NoNormalization), 453, 1e-5);
   }
 };

--- a/Framework/PythonInterface/plugins/algorithms/ConvertWANDSCDtoQ.py
+++ b/Framework/PythonInterface/plugins/algorithms/ConvertWANDSCDtoQ.py
@@ -258,7 +258,7 @@ class ConvertWANDSCDtoQ(PythonAlgorithm):
         # check convention to determine the sign
         if config['Q.convention'] == 'Crystallography':
             k *= -1.0
-            
+
         cop = self.getProperty('ObliquityParallaxCoefficient').value
 
         qlab = np.vstack((np.sin(polar)*np.cos(azim),

--- a/Framework/PythonInterface/plugins/algorithms/ConvertWANDSCDtoQ.py
+++ b/Framework/PythonInterface/plugins/algorithms/ConvertWANDSCDtoQ.py
@@ -66,7 +66,7 @@ class ConvertWANDSCDtoQ(PythonAlgorithm):
                              "format: 'minimum,maximum,number_of_bins'.")
         self.declareProperty('KeepTemporaryWorkspaces', False,
                              "If True the normalization and data workspaces in addition to the normalized data will be outputted")
-        self.declareProperty("ObliquityParallaxCoefficient", 1.0, validator=FloatBoundedValidator(0.0)
+        self.declareProperty("ObliquityParallaxCoefficient", 1.0, validator=FloatBoundedValidator(0.0),
                              "Geometrical correction for shift in vertical beam position due to wide beam'.")
         self.declareProperty(WorkspaceProperty("OutputWorkspace", "",
                                                optional=PropertyMode.Mandatory,

--- a/Framework/PythonInterface/plugins/algorithms/ConvertWANDSCDtoQ.py
+++ b/Framework/PythonInterface/plugins/algorithms/ConvertWANDSCDtoQ.py
@@ -66,6 +66,8 @@ class ConvertWANDSCDtoQ(PythonAlgorithm):
                              "format: 'minimum,maximum,number_of_bins'.")
         self.declareProperty('KeepTemporaryWorkspaces', False,
                              "If True the normalization and data workspaces in addition to the normalized data will be outputted")
+        self.declareProperty("ObliquityParallaxCoefficient", 1.0, validator=FloatBoundedValidator(0.0)
+                             "Geometrical correction for shift in vertical beam position due to wide beam'.")
         self.declareProperty(WorkspaceProperty("OutputWorkspace", "",
                                                optional=PropertyMode.Mandatory,
                                                direction=Direction.Output),
@@ -256,8 +258,11 @@ class ConvertWANDSCDtoQ(PythonAlgorithm):
         # check convention to determine the sign
         if config['Q.convention'] == 'Crystallography':
             k *= -1.0
+            
+        cop = self.getProperty('ObliquityParallaxCoefficient').value
+
         qlab = np.vstack((np.sin(polar)*np.cos(azim),
-                          np.sin(polar)*np.sin(azim),
+                          np.sin(polar)*np.sin(azim)*cop,
                           np.cos(polar) - 1)).T * -k # Kf - Ki(0,0,1)
 
         progress.report('Calculating Q volume')

--- a/Framework/PythonInterface/plugins/algorithms/ConvertWANDSCDtoQ.py
+++ b/Framework/PythonInterface/plugins/algorithms/ConvertWANDSCDtoQ.py
@@ -67,7 +67,7 @@ class ConvertWANDSCDtoQ(PythonAlgorithm):
         self.declareProperty('KeepTemporaryWorkspaces', False,
                              "If True the normalization and data workspaces in addition to the normalized data will be outputted")
         self.declareProperty("ObliquityParallaxCoefficient", 1.0, validator=FloatBoundedValidator(0.0),
-                             "Geometrical correction for shift in vertical beam position due to wide beam'.")
+                             doc="Geometrical correction for shift in vertical beam position due to wide beam.")
         self.declareProperty(WorkspaceProperty("OutputWorkspace", "",
                                                optional=PropertyMode.Mandatory,
                                                direction=Direction.Output),

--- a/Framework/PythonInterface/test/python/plugins/algorithms/ConvertWANDSCDtoQTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/ConvertWANDSCDtoQTest.py
@@ -111,6 +111,36 @@ class ConvertWANDSCDtoQTest(unittest.TestCase):
 
         ConvertWANDSCDtoQTest_out.delete()
 
+    def test_COP(self):
+        ConvertWANDSCDtoQTest_out = ConvertWANDSCDtoQ('ConvertWANDSCDtoQTest_data', BinningDim0='-8.08,8.08,101',
+                                                      BinningDim1='-1.68,1.68,21', BinningDim2='-8.08,8.08,101',
+                                                      NormaliseBy='None')
+
+        ConvertWANDSCDtoQTest_cop = ConvertWANDSCDtoQ('ConvertWANDSCDtoQTest_data', BinningDim0='-8.08,8.08,101',
+                                                      BinningDim1='-1.68,1.68,21', BinningDim2='-8.08,8.08,101',
+                                                      NormaliseBy='None', ObliquityParallaxCoefficient=1.5)
+
+        self.assertTrue(ConvertWANDSCDtoQTest_out)
+        self.assertTrue(ConvertWANDSCDtoQTest_cop)
+        
+        Test_out = ConvertWANDSCDtoQTest_out.getSignalArray().copy()
+        Test_cop = ConvertWANDSCDtoQTest_cop.getSignalArray().copy()
+
+        x, y, z = np.meshgrid(np.linspace(-8,8,101), 
+                              np.linspace(-1.6,1.6,21), 
+                              np.linspace(-8,8,101), indexing='ij')
+
+        Test_out_max_Qy = y[~np.isnan(Test_out)].max()
+        Test_cop_max_Qy = y[~np.isnan(Test_cop)].max()
+
+        # Test whether Qy is scaled by ObliquityParallaxCoefficient correctly
+        proportion = Test_cop_max_Qy/Test_out_max_Qy
+
+        self.assertAlmostEquals(proportion, 1.5, 5)
+
+        ConvertWANDSCDtoQTest_out.delete()
+        ConvertWANDSCDtoQTest_cop.delete()
+
     def test_HKL_norm_and_KeepTemporary(self):
         ConvertWANDSCDtoQTest_out = ConvertWANDSCDtoQ('ConvertWANDSCDtoQTest_data',
                                                       NormalisationWorkspace='ConvertWANDSCDtoQTest_norm',

--- a/Framework/PythonInterface/test/python/plugins/algorithms/ConvertWANDSCDtoQTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/ConvertWANDSCDtoQTest.py
@@ -122,12 +122,12 @@ class ConvertWANDSCDtoQTest(unittest.TestCase):
 
         self.assertTrue(ConvertWANDSCDtoQTest_out)
         self.assertTrue(ConvertWANDSCDtoQTest_cop)
-        
+
         Test_out = ConvertWANDSCDtoQTest_out.getSignalArray().copy()
         Test_cop = ConvertWANDSCDtoQTest_cop.getSignalArray().copy()
 
-        x, y, z = np.meshgrid(np.linspace(-8,8,101), 
-                              np.linspace(-1.6,1.6,21), 
+        x, y, z = np.meshgrid(np.linspace(-8,8,101),
+                              np.linspace(-1.6,1.6,21),
                               np.linspace(-8,8,101), indexing='ij')
 
         Test_out_max_Qy = y[~np.isnan(Test_out)].max()

--- a/docs/source/release/v6.1.0/diffraction.rst
+++ b/docs/source/release/v6.1.0/diffraction.rst
@@ -63,6 +63,8 @@ Single Crystal Diffraction
 - Modified some logs in output workspace from :ref:`LoadWANDSCD <algm-LoadWANDSCD>` to be TimeSeriesProperty so they work with :ref:`SetGoniometer <algm-SetGoniometer>`.
 - :ref:`IntegratePeaksMD <algm-IntegratePeaksMD>` has option to integrate ellipsoids around estimated centroid instead of nominal position.
 - :ref:`IntegratePeaksMD <algm-IntegratePeaksMD>` has option to determine ellipsoid covariance iteratively and to use the estimated standard deviation rather than scale the major axis of the ellipsoid to the spherical radius.
+- :ref:`ConvertHFIRSCDtoMDE <algm-ConvertHFIRSCDtoMDE>` has new geometrical correction factor `ObliquityParallaxCoefficient` for shift in vertical beam position due to wide beam.
+- :ref:`ConvertWANDSCDtoQ <algm-ConvertWANDSCDtoQ>` has new geometrical correction factor `ObliquityParallaxCoefficient` for shift in vertical beam position due to wide beam.
 
 Improvements
 ############


### PR DESCRIPTION
**Description of work.**

This adds a new keyword argument to `ConvertWANDSCDtoQ` and `ConvertHFIRSCDtoMDE` for an obliquity and parallax correction due to wide beam and flat detector along the vertical direction. New keyword argument `ObliquityParallaxCoefficient=1` is added to both algorithms and simply multiplies the Qy component. This approximates a scaling of the vertical angle by `delta+k*tan(delta)` which translates to `ObliquityParallaxCoefficient=1+k` which mainly affects the WAND2 instrument.

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

**To test:**

<!-- Instructions for testing. -->

For **`ConvertWANDSCDtoQ`**
```python
# import mantid algorithms, numpy and matplotlib
from mantid.simpleapi import *
import matplotlib.pyplot as plt
import numpy as np
from mantid import plots

import os
directory = os.path.dirname(os.path.realpath(__file__))

LoadWANDSCD(IPTS=7776, RunNumbers=26509, OutputWorkspace='norm',Grouping='4x4') # Vanadium
LoadWANDSCD(IPTS=7776, RunNumbers='26640-27944', OutputWorkspace='data',Grouping='4x4')

ConvertWANDSCDtoQ(InputWorkspace='data',
                  NormalisationWorkspace='norm',
                  OutputWorkspace='Q',
                  BinningDim2='-1,1,1')

fig, ax = plt.subplots(subplot_kw={'projection':'mantid'})
c = ax.pcolormesh(mtd['Q'], vmax=1)
cbar=fig.colorbar(c)
cbar.set_label('Intensity (arb. units)')
fig.show()

ConvertWANDSCDtoQ(InputWorkspace='data',
                  NormalisationWorkspace='norm',
                  OutputWorkspace='Q',
                  BinningDim2='-1,1,1',
                  ObliquityParallaxCoefficient=1.2)
                  
fig, ax = plt.subplots(subplot_kw={'projection':'mantid'})
c = ax.pcolormesh(mtd['Q'], vmax=1)
cbar=fig.colorbar(c)
cbar.set_label('Intensity (arb. units)')
fig.show()
```

Before:  
![uncorrected](https://user-images.githubusercontent.com/13754794/113780048-9de6b680-96fc-11eb-8a7e-5b892cfc8923.png)
After:  
![corrected](https://user-images.githubusercontent.com/13754794/113780044-9cb58980-96fc-11eb-90eb-8b51d91b0c64.png)

For **`ConvertHFIRSCDtoMDE`**
```
# import mantid algorithms, numpy and matplotlib
from mantid.simpleapi import *
import matplotlib.pyplot as plt
import numpy as np
from mantid import plots

import os
directory = os.path.dirname(os.path.realpath(__file__))

LoadWANDSCD(IPTS=7776, RunNumbers='26640-27944', OutputWorkspace='data',Grouping='4x4')

ConvertHFIRSCDtoMDE(InputWorkspace='data',
                    Wavelength=1.488,
                    OutputWorkspace='Q')

ConvertHFIRSCDtoMDE(InputWorkspace='data',
                    Wavelength=1.488,
                    OutputWorkspace='Q_cor',
                    ObliquityParallaxCoefficient=2)
```
Before:  
![hfir_uncorrected](https://user-images.githubusercontent.com/13754794/113780047-9d4e2000-96fc-11eb-823d-d9cf949db81d.png)
After:  
![hfir_corrected](https://user-images.githubusercontent.com/13754794/113780046-9d4e2000-96fc-11eb-8bb5-270c041d75bc.png)

Fixes [SCD158](https://code.ornl.gov/sns-hfir-scse/diffraction/single-crystal/single-crystal-diffraction/-/issues/158). <!-- and fix #xxxx or close #xxxx xor resolves #xxxx -->
<!-- alternative
*There is no associated issue.*
-->

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or master)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
