### PR TITLE
Fix LoadNexusLogs allow and block list property description

### DIFF
--- a/Framework/DataHandling/src/LoadNexusLogs.cpp
+++ b/Framework/DataHandling/src/LoadNexusLogs.cpp
@@ -413,11 +413,11 @@ void LoadNexusLogs::init() {
   declareProperty(std::make_unique<PropertyWithValue<std::vector<std::string>>>("AllowList", std::vector<std::string>(),
                                                                                 Direction::Input),
                   "If specified, only these logs will be loaded from the file (each "
-                  "separated by a space).");
+                  "separated by a comma).");
   declareProperty(std::make_unique<PropertyWithValue<std::vector<std::string>>>("BlockList", std::vector<std::string>(),
                                                                                 Direction::Input),
                   "If specified, these logs will NOT be loaded from the file (each "
-                  "separated by a space).");
+                  "separated by a comma).");
 }
 
 /** Executes the algorithm. Reading in the file and creating and populating

--- a/Framework/LiveData/src/FileEventDataListener.cpp
+++ b/Framework/LiveData/src/FileEventDataListener.cpp
@@ -41,14 +41,15 @@ FileEventDataListener::FileEventDataListener()
     } else {
       auto loader = FileLoaderRegistry::Instance().chooseLoader(m_filename);
       m_loaderName = loader->name();
-      if (m_loaderName.find("Nexus") != std::string::npos &&
-          (m_loaderName.find("Pre") != std::string::npos || m_loaderName.find("Event") != std::string::npos)) {
-        if (m_loaderName.find("Pre") != std::string::npos && m_loaderName.find("Event") != std::string::npos) {
-          m_filePropName = "EventFilename";
-          m_canLoadMonitors = false;
-        }
+      if (m_loaderName.compare("LoadEventPreNexus") == 0) {
+        m_filePropName = "EventFilename";
+        m_canLoadMonitors = false;
+      } else if (m_loaderName.compare("LoadEventNexus") == 0) {
+        m_filePropName = "Filename";
+        m_canLoadMonitors = true;
       } else {
-        g_log.error("No loader for " + m_filename + " that supports chunking. The algorithm will fail.");
+        g_log.error("No loader for " + m_filename + " that supports chunking (found loader '" + m_loaderName +
+                    "'). The algorithm will fail.");
       }
     }
   }
@@ -129,7 +130,7 @@ std::shared_ptr<Workspace> FileEventDataListener::extractData() {
   // If the loading of the chunk isn't finished, then we need to wait
   m_chunkload->wait();
   if (!m_chunkload->data()) {
-    throw std::runtime_error("LoadEventPreNexus failed for some reason.");
+    throw std::runtime_error(m_loaderName + " failed for some reason with file '" + m_filename + "'.");
   }
   // The loading succeeded: get the workspace from the ADS.
   MatrixWorkspace_sptr chunk = AnalysisDataService::Instance().retrieveWS<MatrixWorkspace>(m_tempWSname);

--- a/Framework/LiveData/src/FileEventDataListener.cpp
+++ b/Framework/LiveData/src/FileEventDataListener.cpp
@@ -10,6 +10,7 @@
 #include "MantidAPI/FileFinder.h"
 #include "MantidAPI/FileLoaderRegistry.h"
 #include "MantidAPI/LiveListenerFactory.h"
+#include "MantidAPI/Run.h"
 #include "MantidKernel/ConfigService.h"
 
 using namespace Mantid::Kernel;
@@ -148,6 +149,12 @@ std::shared_ptr<Workspace> FileEventDataListener::extractData() {
   }
 
   m_runNumber = chunk->getRunNumber();
+
+  if (!m_loaderName.compare("LoadEventNexus")) {
+    // Scale the proton charge by the number of chunks
+    double charge = chunk->run().getProtonCharge();
+    chunk->mutableRun().setProtonCharge(charge / m_numChunks);
+  }
 
   return chunk;
 }

--- a/Framework/LiveData/test/FileEventDataListenerTest.h
+++ b/Framework/LiveData/test/FileEventDataListenerTest.h
@@ -100,7 +100,7 @@ public:
     TS_ASSERT_EQUALS(buffer.use_count(), 1)
     TS_ASSERT_EQUALS(buffer->getNumberHistograms(), 49152)
 
-    int events = buffer->getNumberEvents();
+    size_t events = buffer->getNumberEvents();
 
     for (int i = 0; i < nchunks - 1; i++) {
       TS_ASSERT_EQUALS(listener->runStatus(), ILiveListener::Running)

--- a/Framework/PythonInterface/mantid/utils/absorptioncorrutils.py
+++ b/Framework/PythonInterface/mantid/utils/absorptioncorrutils.py
@@ -452,9 +452,9 @@ def create_absorption_input(
     absName = metaws
     if metaws is None:
         absName = '__{}_abs'.format(_getBasename(filename))
-        allowed_log = " ".join([
+        allowed_log = ",".join([
             'SampleFormula', 'SampleDensity', "BL11A:CS:ITEMS:HeightInContainerUnits",
-            "SampleContainer"
+            "SampleContainer", "SampleMass"
         ])
         Load(Filename=filename, OutputWorkspace=absName, MetaDataOnly=True, AllowList=allowed_log)
 

--- a/dev-docs/source/Testing/LiveData/LiveDataTests.rst
+++ b/dev-docs/source/Testing/LiveData/LiveDataTests.rst
@@ -60,19 +60,27 @@ ISIS Histogram
 ADARA Fake Event
 ################
 
-This approach reads from an SNS pre-nexus file to recreate realistic event data, however It is a little more fiddly to setup.
+This approach reads from an SNS pre-nexus file or an event-nexus file to recreate realistic event data, however It is a little more fiddly to setup.
 
 #. Find the file ``Mantid.user.properties``. Its location will be:
 
    - Windows: ``C:\MantidInstall\bin``
    - Mac or linux: ``~/.mantid`` (i.e. in a ``.mantid`` directory under your home directory)
 
-#. To use the ``REF_L_32035_neutron_event.dat`` file (located in the ``TrainingCourseData`` folder), open ``Mantid.user.properties`` in your favorite text editor and add the following lines:
+#. To use a pre-nexus file, use the ``REF_L_32035_neutron_event.dat`` file (located in the ``TrainingCourseData`` folder), open ``Mantid.user.properties`` in your favorite text editor and add the following lines:
 
    ::
 
     fileeventdatalistener.filename=REF_L_32035_neutron_event.dat
     fileeventdatalistener.chunks=300
+
+   A event nexus file can also be used instead, for example:
+
+   ::
+
+    fileeventdatalistener.filename=EQSANS_6071_event.nxs
+
+   Chunking for files can be determined by using the :ref:`DetermineChunking <algm-DetermineChunking>` algorithm.
 
 #. Start MantidPlot
 #. Use the instrument ``ADARA_FileReader`` in the ``TEST_LIVE`` facility in the First Time Setup dialog (MantidPlot) or Settings dialog (MantidWorkbench).  There is no need to stop this fake instrument.


### PR DESCRIPTION
**Description of work.**

Fixes the property description of the allow and block list options to the LoadNexusLogs algorithm. It was expecting comma separated values instead of space-separated values. As a result, this fixes the sample log issue in the absorption correction donor workspace function.

Other minor changes include a slight modification to the FileEventDataListener class to have a more descriptive error message and clarify the supported loader types. Adds an example of EventNexus files to the ADARA FileReader instrument setup documentation.

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

**To test:**

<!-- Instructions for testing. -->

Using `LoadNexusLogs` with log names separated by commas should no longer produce a "could not load entry '...' that was specified in the allow list", and logs should appear in the workspace. If you repeat with space as the separator, you should see no logs being produced and the error message.

<!-- Ensure the base of this PR is correct (e.g. release-next or master)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

Version into `ornl-next` #31141

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
