### PR TITLE
Save fit results during project save for EnggDiffUI

### DIFF
--- a/scripts/Engineering/gui/engineering_diffraction/engineering_diffraction_io.py
+++ b/scripts/Engineering/gui/engineering_diffraction/engineering_diffraction_io.py
@@ -37,6 +37,7 @@ class EngineeringDiffractionEncoder(EngineeringDiffractionUIAttributes):
             obj_dic["settings_dict"] = presenter.settings_presenter.model.get_settings_dict(SETTINGS_KEYS_TYPES)
         if data_widget.presenter.get_loaded_workspaces():
             obj_dic["data_loaded_workspaces"] = [*data_widget.presenter.get_loaded_workspaces().keys()]
+            obj_dic["fit_results"] = data_widget.model.get_fit_results()
             obj_dic["plotted_workspaces"] = [*data_widget.presenter.plotted]
             obj_dic["background_params"] = data_widget.model.get_bg_params()
             if plot_widget.view.fit_browser.read_current_fitprop():
@@ -71,6 +72,10 @@ class EngineeringDiffractionDecoder(EngineeringDiffractionUIAttributes):
         fit_data_widget.model.restore_files(ws_names)
         fit_data_widget.presenter.plotted = set(obj_dic["plotted_workspaces"])
         fit_data_widget.presenter.restore_table()
+
+        if obj_dic["fit_results"]:
+            fit_data_widget.model._fit_results = obj_dic["fit_results"]
+            fit_data_widget.model.create_fit_tables()
 
         if obj_dic["fit_properties"]:
             fit_browser = presenter.fitting_presenter.plot_widget.view.fit_browser

--- a/scripts/Engineering/gui/engineering_diffraction/tabs/fitting/data_handling/data_model.py
+++ b/scripts/Engineering/gui/engineering_diffraction/tabs/fitting/data_handling/data_model.py
@@ -296,6 +296,9 @@ class FittingDataModel(object):
     def get_bg_params(self):
         return self._bg_params
 
+    def get_fit_results(self):
+        return self._fit_results
+
     def create_or_update_bgsub_ws(self, ws_name, bg_params):
         ws = self._loaded_workspaces[ws_name]
         ws_bg = self._bg_sub_workspaces[ws_name]

--- a/scripts/Engineering/gui/engineering_diffraction/test/engineering_diffraction_io_test.py
+++ b/scripts/Engineering/gui/engineering_diffraction/test/engineering_diffraction_io_test.py
@@ -40,7 +40,12 @@ FIT_DICT = {'peak_centre_params': ['Gaussian_PeakCentre', 'Gaussian_PeakCentre']
                                        '4,Sigma=1284.55;name=Gaussian,Height=0.0190721,P'
                                        'eakCentre=21506.1,Sigma=1945.78',
                            'ConvolveMembers': True, 'OutputCompositeMembers': True}}
-
+FIT_RESULTS = {TEST_WS:
+               {"model": "name=Gaussian,Height=1.04675,PeakCentre=25099.4,Sigma=2178.57", "results":
+                {"Gaussian_Height": [[1.000336497251553, 0.00024401827516182785]], "Gaussian_PeakCentre":
+                 [[29069.5395105562, 1.9174607562252401]], "Gaussian_PeakCentre_dSpacing":
+                 [[1.579551616673174, 0.00010418906829614912]], "Gaussian_Sigma":
+                 [[8644.463151136386, 1.230307889326856]]}, "costFunction": 411.9019047115968}}
 SETTINGS_DICT = {
     "full_calibration": "",
     "save_location": path.join(path.expanduser("~"), "Engineering_Mantid"),
@@ -53,7 +58,8 @@ SETTINGS_DICT = {
 
 ENCODED_DICT = {'encoder_version': IO_VERSION, 'current_tab': 2, 'data_loaded_workspaces':
                 [TEST_WS], 'plotted_workspaces': [TEST_WS + 'bgsub'], 'fit_properties': FIT_DICT, 'plot_diff': 'True',
-                'settings_dict': SETTINGS_DICT, 'background_params': {TEST_WS: [True, 70, 4000, True]}}
+                'fit_results': FIT_RESULTS, 'settings_dict': SETTINGS_DICT,
+                'background_params': {TEST_WS: [True, 70, 4000, True]}}
 
 
 def _create_fit_workspace():
@@ -124,8 +130,9 @@ class EngineeringDiffractionEncoderTest(unittest.TestCase):
         self.fitprop_browser.read_current_fitprop.return_value = None
         test_dic = self.encoder.encode(self.mock_view)
         self.assertEqual({'encoder_version': self.io_version, 'current_tab': 0, 'data_loaded_workspaces':
-                          [TEST_WS], 'plotted_workspaces': [], 'fit_properties': None, 'settings_dict':
-                              SETTINGS_DICT, 'background_params': {'ENGINX_277208_focused_bank_2_TOF': []}}, test_dic)
+                          [TEST_WS], 'plotted_workspaces': [], 'fit_properties': None, 'fit_results': {},
+                          'settings_dict': SETTINGS_DICT, 'background_params':
+                              {'ENGINX_277208_focused_bank_2_TOF': []}}, test_dic)
 
     def test_background_params_encode(self):
         self.presenter.fitting_presenter.data_widget.presenter.model.load_files(TEST_FILE, 'TOF')
@@ -133,19 +140,21 @@ class EngineeringDiffractionEncoderTest(unittest.TestCase):
         self.presenter.fitting_presenter.data_widget.model._bg_params = {TEST_WS: [True, 70, 4000, True]}
         test_dic = self.encoder.encode(self.mock_view)
         self.assertEqual({'encoder_version': self.io_version, 'current_tab': 0, 'data_loaded_workspaces':
-                          [TEST_WS], 'plotted_workspaces': [], 'fit_properties': None, 'settings_dict':
-                              SETTINGS_DICT, 'background_params': {TEST_WS: [True, 70, 4000, True]}}, test_dic)
+                          [TEST_WS], 'plotted_workspaces': [], 'fit_properties': None, 'fit_results': {},
+                          'settings_dict': SETTINGS_DICT,
+                          'background_params': {TEST_WS: [True, 70, 4000, True]}}, test_dic)
 
     def test_fits_encode(self):
         self.presenter.fitting_presenter.data_widget.presenter.model.load_files(TEST_FILE, 'TOF')
+        self.presenter.fitting_presenter.data_widget.presenter.model._fit_results = FIT_RESULTS
         self.fitprop_browser.read_current_fitprop.return_value = FIT_DICT
         self.fitprop_browser.plotDiff.return_value = True
         self.presenter.fitting_presenter.data_widget.presenter.plotted = {FIT_WS}
         test_dic = self.encoder.encode(self.mock_view)
         self.assertEqual({'encoder_version': self.io_version, 'current_tab': 0, 'data_loaded_workspaces':
-                          [TEST_WS], 'plotted_workspaces': [FIT_WS], 'fit_properties': FIT_DICT, 'plot_diff':
-                              'True', 'settings_dict': SETTINGS_DICT, 'background_params': {
-                              'ENGINX_277208_focused_bank_2_TOF': []}}, test_dic)
+                          [TEST_WS], 'plotted_workspaces': [FIT_WS], 'fit_properties': FIT_DICT,
+                          'fit_results': FIT_RESULTS, 'plot_diff': 'True', 'settings_dict': SETTINGS_DICT,
+                          'background_params': {'ENGINX_277208_focused_bank_2_TOF': []}}, test_dic)
 
 
 @start_qapplication


### PR DESCRIPTION
**Description of work.**
This PR ensures that the fit tables created on the engineering diffraction UI are saved properly after saving/loading the gui as part of a mantid project.

**To test:**
1. Load focussed data (can be found on this pr if needed https://github.com/mantidproject/mantid/pull/29976)
2. Plot and make a fit
3. Open up the fit result table in the ADS, check the values
3. Save Project
4. Close the interface
5. Open project
6. Check the old values exist in the fit table

Fixes #31011 . <!-- and fix #xxxx or close #xxxx xor resolves #xxxx -->
<!-- alternative
*There is no associated issue.*
-->

*This does not require release notes* because **it is a fix for a minor bug introduced this release**


<!-- Ensure the base of this PR is correct (e.g. release-next or master)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
