### PR TITLE
Workaround a Qt bug on macOS Big Sur

### DIFF
--- a/docs/source/release/v6.1.0/mantidworkbench.rst
+++ b/docs/source/release/v6.1.0/mantidworkbench.rst
@@ -43,5 +43,6 @@ Bugfixes
 - Fixed a crash that happens when multiple plot windows are open, and the users closes one of them.
 - The y-axis in the instrument view's pick tab will now rescale if the range changes.
 - On the instrument widget pick tab, when the integration range is changed the current tool will stay selected.
+- Fixed a bug where Workbench would hang on startup when running on Big Sur.
 
 :ref:`Release 6.1.0 <v6.1.0>`

--- a/qt/applications/workbench/workbench/app/start.py
+++ b/qt/applications/workbench/workbench/app/start.py
@@ -86,6 +86,18 @@ def initialize():
         # https://www.tornadoweb.org/en/stable/#installation
         import asyncio
         asyncio.set_event_loop_policy(asyncio.WindowsSelectorEventLoopPolicy())
+    if sys.platform == 'darwin':
+        # Force layer-backing on macOS >= Big Sur (11)
+        # or the application hangs
+        # A fix inside Qt is yet to be released:
+        # https://codereview.qt-project.org/gitweb?p=qt/qtbase.git;a=commitdiff;h=c5d904639dbd690a36306e2b455610029704d821
+        # A complication with Big Sur numbering means we check for 10.16 and 11:
+        #   https://eclecticlight.co/2020/08/13/macos-version-numbering-isnt-so-simple/
+        from distutils.version import LooseVersion
+        import platform
+        mac_vers = LooseVersion(platform.mac_ver()[0])
+        if mac_vers >= '11' or mac_vers == '10.16':
+            os.environ['QT_MAC_WANTS_LAYER'] = '1'
 
     app = qapplication()
 


### PR DESCRIPTION
**Description of work.**

The fix for Qt has yet to released so we need
to force layer-backed windows on Big Sur
and above

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

**To test:**

* Build a package on the CI servers
* Test the built package starts on Big Sur

Fixes #30681

<!-- Ensure the base of this PR is correct (e.g. release-next or master)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
