### PR TITLE
Access diffractometer constants from spectrum info in EngDiff UI

### DIFF
--- a/Framework/PythonInterface/mantid/api/src/Exports/SpectrumInfo.cpp
+++ b/Framework/PythonInterface/mantid/api/src/Exports/SpectrumInfo.cpp
@@ -81,11 +81,9 @@ void export_SpectrumInfo() {
            "index.")
       .def("detectorCount", &SpectrumInfo::detectorCount, arg("self"),
            "Returns the total number of detectors used across spectrum info.")
-      .def("difcUncalibrated", &SpectrumInfo::difcUncalibrated,
-           (arg("self"), arg("index")),
+      .def("difcUncalibrated", &SpectrumInfo::difcUncalibrated, (arg("self"), arg("index")),
            "Return the uncalibrated difc diffractometer constant")
       .def("diffractometerConstants",
-           (UnitParametersMap(SpectrumInfo::*)(const size_t) const) &
-               SpectrumInfo::diffractometerConstants,
+           (UnitParametersMap(SpectrumInfo::*)(const size_t) const) & SpectrumInfo::diffractometerConstants,
            (arg("self"), arg("index")), "Return the diffractometer constants");
 }

--- a/Framework/PythonInterface/mantid/api/src/Exports/SpectrumInfo.cpp
+++ b/Framework/PythonInterface/mantid/api/src/Exports/SpectrumInfo.cpp
@@ -20,6 +20,7 @@ using Mantid::SpectrumDefinition;
 using Mantid::API::SpectrumInfo;
 using Mantid::API::SpectrumInfoItem;
 using Mantid::API::SpectrumInfoIterator;
+using Mantid::Kernel::UnitParametersMap;
 using Mantid::PythonInterface::SpectrumInfoPythonIterator;
 using namespace boost::python;
 
@@ -79,5 +80,12 @@ void export_SpectrumInfo() {
            "Returns the SpectrumDefinition of the spectrum with the given "
            "index.")
       .def("detectorCount", &SpectrumInfo::detectorCount, arg("self"),
-           "Returns the total number of detectors used across spectrum info.");
+           "Returns the total number of detectors used across spectrum info.")
+      .def("difcUncalibrated", &SpectrumInfo::difcUncalibrated,
+           (arg("self"), arg("index")),
+           "Return the uncalibrated difc diffractometer constant")
+      .def("diffractometerConstants",
+           (UnitParametersMap(SpectrumInfo::*)(const size_t) const) &
+               SpectrumInfo::diffractometerConstants,
+           (arg("self"), arg("index")), "Return the diffractometer constants");
 }


### PR DESCRIPTION
**Description of work.**

Since PR #30163 spectra have an associated difc, tzero and difa. This PR includes a commit from @DannyHindson in branch 
https://github.com/mantidproject/mantid/tree/31021_NewDIFCAveragingForPOLARIS
that exposes the `diffractometerConstants()` method of `spectrumInfo`. The EngDiff UI fitting tab has then been altered to retrieve the diffractometer constants using this method and the tests have been updated. Note that a test for getting the diffractometer constants has been removed as we no longer calculate these from L1, L2 and two-theta (i.e. don't need to check the equation is correctly accessing those values).

**To test:**

Follow instructions in PR #30534

*There is no associated issue.*


*This does not require release notes* because **it is an internal change for developers that is not related to any bugs**


<!-- Ensure the base of this PR is correct (e.g. release-next or master)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
