### PR TITLE
add method intensityError

### DIFF
--- a/Framework/API/inc/MantidAPI/IPeakFunction.h
+++ b/Framework/API/inc/MantidAPI/IPeakFunction.h
@@ -35,6 +35,9 @@ public:
   /// Returns the integral intensity of the peak
   virtual double intensity() const;
 
+  /// Returns the uncertainty associated to the integral intensity of the peak
+  virtual double intensityError() const;
+
   /// Sets the integral intensity of the peak
   virtual void setIntensity(const double newIntensity);
 

--- a/Framework/API/src/IPeakFunction.cpp
+++ b/Framework/API/src/IPeakFunction.cpp
@@ -184,6 +184,11 @@ double IPeakFunction::intensity() const {
   return result.result;
 }
 
+/// Returns the uncertainty associated to the integral intensity of the peak function
+double IPeakFunction::intensityError() const {
+  return NAN;
+}
+
 /// Sets the integral intensity of the peak by adjusting the height.
 void IPeakFunction::setIntensity(const double newIntensity) {
   double currentHeight = height();

--- a/Framework/API/src/IPeakFunction.cpp
+++ b/Framework/API/src/IPeakFunction.cpp
@@ -185,9 +185,7 @@ double IPeakFunction::intensity() const {
 }
 
 /// Returns the uncertainty associated to the integral intensity of the peak function
-double IPeakFunction::intensityError() const {
-  return NAN;
-}
+double IPeakFunction::intensityError() const { return NAN; }
 
 /// Sets the integral intensity of the peak by adjusting the height.
 void IPeakFunction::setIntensity(const double newIntensity) {


### PR DESCRIPTION
**Description of work.**  
- Default implementation of `IPeakFunction.intensityError` returns `nan`

- There is no associated issue
---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
