### PR TITLE
Fix position of new widgets when upgrading workbench versions

### DIFF
--- a/docs/source/release/v6.1.0/mantidworkbench.rst
+++ b/docs/source/release/v6.1.0/mantidworkbench.rst
@@ -22,7 +22,7 @@ New and Improved
 - Added an algorithm ProfileChiSquared1D to profile chi squared after a fit. This can be used
   to find better estimates of parameter errors.
 - Instrument view: when in tube selection mode, the sum of pixel counts is now output to the selection pane.
-- Added memory widget to display total memory usage.
+- Added memory widget to display total memory usage. This means that your widget layout will be reset when starting workbench v6.1.0 for the first time. Previously saved layouts accessible from ``View > User Layouts`` may need to be saved again to include the memory bar widget.
 
 
 Bugfixes

--- a/qt/applications/workbench/workbench/app/mainwindow.py
+++ b/qt/applications/workbench/workbench/app/mainwindow.py
@@ -779,7 +779,7 @@ class MainWindow(QMainWindow):
         reply = QMessageBox.question(
             self,
             "Layout Restoration",
-            "The selected layout is incompatible with this version of Workbench. Workbench will attempt to restore \\"
+            "The selected layout is incompatible with this version of Workbench. Workbench will attempt to restore "
             "the layout, but it may appear differently from before.\nDo you wish to continue?",
             QMessageBox.Yes | QMessageBox.No)
         if not reply == QMessageBox.Yes:
@@ -790,7 +790,7 @@ class MainWindow(QMainWindow):
                 QMessageBox.information(
                     self,
                     "Success",
-                    "The layout was successfully restored.\nTo hide this warning in the future, delete the old \\"
+                    "The layout was successfully restored.\nTo hide this warning in the future, delete the old "
                     "layout in File > Settings, and save this as a new layout."
                 )
                 return

--- a/qt/applications/workbench/workbench/app/mainwindow.py
+++ b/qt/applications/workbench/workbench/app/mainwindow.py
@@ -772,8 +772,7 @@ class MainWindow(QMainWindow):
         builtins.input = QAppThreadCall(input_qinputdialog)
 
     def attempt_to_restore_state(self, state):
-        success = self.restoreState(state, SAVE_STATE_VERSION)
-        if success:
+        if self.restoreState(state, SAVE_STATE_VERSION):
             return
 
         # The version number of the supplied state is older than the current version
@@ -787,8 +786,7 @@ class MainWindow(QMainWindow):
             return
 
         for version in range(0, SAVE_STATE_VERSION):
-            success = self.restoreState(state, version)
-            if success:
+            if self.restoreState(state, version):
                 QMessageBox.information(
                     self,
                     "Success",

--- a/qt/applications/workbench/workbench/app/mainwindow.py
+++ b/qt/applications/workbench/workbench/app/mainwindow.py
@@ -72,6 +72,10 @@ SPLASH.showMessage("Starting...", Qt.AlignBottom | Qt.AlignLeft
 # The event loop has not started - force event processing
 QApplication.processEvents(QEventLoop.AllEvents)
 
+# MainWindow state encodes widget layout (among other things).
+# Increment this when the state of the next version is incompatible with the previous.
+SAVE_STATE_VERSION = 1
+
 # -----------------------------------------------------------------------------
 # MainWindow
 # -----------------------------------------------------------------------------
@@ -740,7 +744,7 @@ class MainWindow(QMainWindow):
 
         # restore window state
         if settings.has('MainWindow/state'):
-            self.restoreState(settings.get('MainWindow/state'))
+            self.restoreState(settings.get('MainWindow/state'), SAVE_STATE_VERSION)
         else:
             self.setWindowState(Qt.WindowMaximized)
 
@@ -753,7 +757,7 @@ class MainWindow(QMainWindow):
     def writeSettings(self, settings):
         settings.set('MainWindow/size', self.size())  # QSize
         settings.set('MainWindow/position', self.pos())  # QPoint
-        settings.set('MainWindow/state', self.saveState())  # QByteArray
+        settings.set('MainWindow/state', self.saveState(SAVE_STATE_VERSION))  # QByteArray
 
         # write out settings for children
         AlgorithmInputHistory().writeSettings(settings)

--- a/qt/applications/workbench/workbench/app/mainwindow.py
+++ b/qt/applications/workbench/workbench/app/mainwindow.py
@@ -130,6 +130,8 @@ class MainWindow(QMainWindow):
         self.interface_executor = None
         self.interface_list = None
 
+        self.could_restore_state = False
+
     def setup(self):
         # menus must be done first so they can be filled by the
         # plugins in register_plugin
@@ -741,7 +743,10 @@ class MainWindow(QMainWindow):
 
         # restore window state
         if settings.has('MainWindow/state'):
-            self.restoreState(settings.get('MainWindow/state'), SAVE_STATE_VERSION)
+            if not self.restoreState(settings.get('MainWindow/state'), SAVE_STATE_VERSION):
+                logger.warning(
+                    "The previous layout of workbench is not compatible with this version, reverting to default layout."
+                )
         else:
             self.setWindowState(Qt.WindowMaximized)
 

--- a/qt/applications/workbench/workbench/config/__init__.py
+++ b/qt/applications/workbench/workbench/config/__init__.py
@@ -83,6 +83,10 @@ DEFAULTS = {
     }
 }
 
+# State encodes widget layout (among other things).
+# Increment this when the state of the next version is incompatible with the previous.
+SAVE_STATE_VERSION = 1
+
 # 'Singleton' instance
 QSettings.setDefaultFormat(QSettings.IniFormat)
 CONF = UserConfig(ORGANIZATION, APPNAME, defaults=DEFAULTS)

--- a/qt/applications/workbench/workbench/widgets/settings/general/presenter.py
+++ b/qt/applications/workbench/workbench/widgets/settings/general/presenter.py
@@ -9,7 +9,7 @@
 #
 from mantid.kernel import ConfigService
 from mantidqt.widgets import instrumentselector
-from workbench.config import CONF
+from workbench.config import CONF, SAVE_STATE_VERSION
 from workbench.widgets.settings.general.view import GeneralSettingsView
 
 from qtpy.QtCore import Qt
@@ -231,7 +231,7 @@ class GeneralSettings(object):
         filename = self.view.new_layout_name.text()
         if filename != "":
             layout_dict = self.get_layout_dict()
-            layout_dict[filename] = self.parent.saveState()
+            layout_dict[filename] = self.parent.saveState(SAVE_STATE_VERSION)
             CONF.set(GeneralProperties.USER_LAYOUT.value, layout_dict)
             self.view.new_layout_name.clear()
             self.fill_layout_display()
@@ -242,7 +242,7 @@ class GeneralSettings(object):
         if hasattr(item, "text"):
             layout = item.text()
             layout_dict = self.get_layout_dict()
-            self.parent.restoreState(layout_dict[layout])
+            self.parent.restoreState(layout_dict[layout], SAVE_STATE_VERSION)
 
     def delete_layout(self):
         item = self.view.layout_display.currentItem()

--- a/qt/applications/workbench/workbench/widgets/settings/general/test/test_general_settings.py
+++ b/qt/applications/workbench/workbench/widgets/settings/general/test/test_general_settings.py
@@ -11,6 +11,7 @@ from unittest.mock import call, patch, MagicMock, Mock
 from mantidqt.utils.qt.testing import start_qapplication
 from mantidqt.utils.testing.strict_mock import StrictMock
 from workbench.widgets.settings.general.presenter import GeneralSettings, GeneralProperties
+from workbench.config import SAVE_STATE_VERSION
 from qtpy.QtCore import Qt
 
 
@@ -354,7 +355,7 @@ class GeneralSettingsTest(unittest.TestCase):
 
         calls = [call(GeneralProperties.USER_LAYOUT.value), call(GeneralProperties.USER_LAYOUT.value)]
         mock_CONF.get.assert_has_calls(calls)
-        mock_parent.saveState.assert_called_once_with()
+        mock_parent.saveState.assert_called_once_with(SAVE_STATE_VERSION)
         mock_parent.populate_layout_menu.assert_called_once_with()
 
     @patch(WORKBENCH_CONF_CLASSPATH)
@@ -374,7 +375,7 @@ class GeneralSettingsTest(unittest.TestCase):
         presenter.load_layout()
 
         mock_CONF.get.assert_called_once_with(GeneralProperties.USER_LAYOUT.value)
-        mock_parent.restoreState.assert_called_once_with(test_dict['a'])
+        mock_parent.restoreState.assert_called_once_with(test_dict['a'], SAVE_STATE_VERSION)
 
     @patch(WORKBENCH_CONF_CLASSPATH)
     def test_delete_layout(self, mock_CONF):


### PR DESCRIPTION
Workbench v6.1.0 adds a memory bar widget. If there is an existing `.ini` file from a previous version of workbench, the mainwindow state from this old version will be restored. Since the old state does not include the new widget, it gets plonked on its own in a new column (see #31177). 

This PR adds a version number to the state of the mainwindow. When restoring the state, if the version numbers mismatch, the state will not be applied and the default layout will remain. 

When applying a layout saved by the user on an old version, accessible from `View > User Layouts`, the user will be warned that workbench will attempt to restore the layout, and that it may look a bit off. If workbench is able to restore the layout, by iterating over the version numbers, the user will be informed how to remove the warning. Otherwise, the layout will not be restored.

**To test:**
1. Checkout to a commit before the memory bar widget was added to master, e.g. `git checkout e0c3d704~1`
2. Launch workbench and modify the layout.
3. Save this as a new layout in `File > Settings` 
4. Close workbench.
3. `git test-pr 31194`
4. Launch workbench, now the correct default layout should be shown. 
5. Load the old layout `View > User Layouts`. The warning should appear. 
6. Check that workbench did it's best at restoring the layout if successful.

Fixes #31177

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
