### PR TITLE
Output xvfb-errors to stderr rather than ignoring them

### DIFF
--- a/buildconfig/Jenkins/buildscript
+++ b/buildconfig/Jenkins/buildscript
@@ -30,7 +30,7 @@ function run_with_xvfb {
     if [ $(command -v xvfb-run) ]; then
         # -e=--error-file. A bug in Xvfb on RHEL7 means --error-file
         # produces an error: https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=337703;msg=2
-        xvfb-run --server-args="-screen 0 640x480x24" \
+        xvfb-run -e /dev/stderr --server-args="-screen 0 640x480x24" \
         --server-num=${XVFB_SERVER_NUM} $@
     else
         eval $@


### PR DESCRIPTION
**Description of work.**

Occasionally we get "xvfb-run: error: Xvfb failed to start" errors but it is hard to debug them. This will output them to the Jenkins log.

**To test:**

Run:

`xvfb-run -n 0 ls`

and you will see `xvfb-run: error: Xvfb failed to start`. Run `xvfb-run -e /dev/stderr -n 0 ls` and you'll see

```
_XSERVTransSocketUNIXCreateListener: ...SocketCreateListener() failed
_XSERVTransMakeAllCOTSServerListeners: server already running
(EE) 
Fatal server error:
(EE) Cannot establish any listening sockets - Make sure an X server isn't already running(EE) 
xvfb-run: error: Xvfb failed to start
```


*There is no associated issue.*

*This does not require release notes* because **it is an internal change.**

<!-- Ensure the base of this PR is correct (e.g. release-next or master)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
