### PR TITLE
SANS Handle workspaces not in the ADS

### DIFF
--- a/scripts/SANS/sans/algorithm_detail/batch_execution.py
+++ b/scripts/SANS/sans/algorithm_detail/batch_execution.py
@@ -1149,7 +1149,7 @@ def delete_reduced_workspaces(reduction_packages, include_non_transmission=True)
     def _delete_workspaces(_delete_alg, _workspaces):
         for _workspace in _workspaces:
             if _workspace is not None:
-                _delete_alg.setProperty("Workspace", _workspace.name())
+                _delete_alg.setProperty("Workspace", _workspace)
                 _delete_alg.execute()
     # Get all names which were saved out to workspaces
     # Delete each workspace


### PR DESCRIPTION
**Description of work.**
The SANS algorithm will skip placing workspaces into the ADS if we are
only saving to a file. This was causing problems later on when the ADS
is assumed by calling .getName()

Instead delete by pointer, and let Mantid figure out which is the best
way to delete the workspace

**Report to:** @smk78 

**To test:**
- Download the ISIS Training Data
- Extract the folder and take note of the LoqDemo folder
- Open the ISIS SANS Gui
- Set user file to either the .txt or .toml file from the LoqDemo folder
- Load the .csv file as a batch file from the same directory
- Ensure that save options in the bottom right is set to **File only**, not memory or both
- Process the first line, it should not give any errors

Fixes #31211 

*This does not require release notes* because it's a regression from this release 

<!-- Ensure the base of this PR is correct (e.g. release-next or master)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
