### PR TITLE
Avoid error in EnggFocus by not normalising by current if run has zero proton charge

### DIFF
--- a/Framework/PythonInterface/plugins/algorithms/EnggFocus.py
+++ b/Framework/PythonInterface/plugins/algorithms/EnggFocus.py
@@ -17,7 +17,7 @@ class EnggFocus(PythonAlgorithm):
         return "Diffraction\\Engineering"
 
     def seeAlso(self):
-        return [ "AlignDetectors","DiffractionFocussing" ]
+        return ["AlignDetectors", "DiffractionFocussing"]
 
     def name(self):
         return "EnggFocus"
@@ -39,23 +39,23 @@ class EnggFocus(PythonAlgorithm):
         self.declareProperty(MatrixWorkspaceProperty("VanadiumWorkspace", "", Direction.Input,
                                                      PropertyMode.Optional),
                              doc='Workspace with the Vanadium (correction and calibration) run. '
-                             'Alternatively, when the Vanadium run has been already processed, '
-                             'the properties can be used')
+                                 'Alternatively, when the Vanadium run has been already processed, '
+                                 'the properties can be used')
 
         self.declareProperty(ITableWorkspaceProperty('VanIntegrationWorkspace', '',
                                                      Direction.Input, PropertyMode.Optional),
                              doc='Results of integrating the spectra of a Vanadium run, with one column '
-                             '(integration result) and one row per spectrum. This can be used in '
-                             'combination with OutVanadiumCurveFits from a previous execution and '
-                             'VanadiumWorkspace to provide pre-calculated values for Vanadium correction.')
+                                 '(integration result) and one row per spectrum. This can be used in '
+                                 'combination with OutVanadiumCurveFits from a previous execution and '
+                                 'VanadiumWorkspace to provide pre-calculated values for Vanadium correction.')
 
         self.declareProperty(MatrixWorkspaceProperty('VanCurvesWorkspace', '', Direction.Input,
                                                      PropertyMode.Optional),
                              doc='A workspace2D with the fitting workspaces corresponding to '
-                             'the instrument banks. This workspace has three spectra per bank, as produced '
-                             'by the algorithm Fit. This is meant to be used as an alternative input '
-                             'VanadiumWorkspace for testing and performance reasons. If not given, no '
-                             'workspace is generated.')
+                                 'the instrument banks. This workspace has three spectra per bank, as produced '
+                                 'by the algorithm Fit. This is meant to be used as an alternative input '
+                                 'VanadiumWorkspace for testing and performance reasons. If not given, no '
+                                 'workspace is generated.')
 
         vana_grp = 'Vanadium (open beam) properties'
         self.setPropertyGroup('VanadiumWorkspace', vana_grp)
@@ -65,14 +65,14 @@ class EnggFocus(PythonAlgorithm):
         self.declareProperty("Bank", '', StringListValidator(EnggUtils.ENGINX_BANKS),
                              direction=Direction.Input,
                              doc="Which bank to focus: It can be specified as 1 or 2, or "
-                             "equivalently, North or South. See also " + self.INDICES_PROP_NAME + " "
-                             "for a more flexible alternative to select specific detectors")
+                                 "equivalently, North or South. See also " + self.INDICES_PROP_NAME + " "
+                                 "for a more flexible alternative to select specific detectors")
 
         self.declareProperty(self.INDICES_PROP_NAME, '', direction=Direction.Input,
                              doc='Sets the spectrum numbers for the detectors '
-                             'that should be considered in the focusing operation (all others will be '
-                             'ignored). This option cannot be used together with Bank, as they overlap. '
-                             'You can give multiple ranges, for example: "0-99", or "0-9, 50-59, 100-109".')
+                                 'that should be considered in the focusing operation (all others will be '
+                                 'ignored). This option cannot be used together with Bank, as they overlap. '
+                                 'You can give multiple ranges, for example: "0-99", or "0-9, 50-59, 100-109".')
 
         banks_grp = 'Banks / spectra'
         self.setPropertyGroup('Bank', banks_grp)
@@ -80,7 +80,8 @@ class EnggFocus(PythonAlgorithm):
 
         self.declareProperty('NormaliseByCurrent', True, direction=Direction.Input,
                              doc='Normalize the input data by applying the NormaliseByCurrent algorithm '
-                             'which use the log entry gd_proton_charge')
+                                 'which use the log entry gd_proton_charge. If there is no proton charge '
+                                 'the data are not normalised.')
 
         self.declareProperty(FloatArrayProperty('MaskBinsXMins', EnggUtils.ENGINX_MASK_BIN_MINS,
                                                 direction=Direction.Input),
@@ -98,8 +99,8 @@ class EnggFocus(PythonAlgorithm):
     def validateInputs(self):
         issues = dict()
 
-        if not self.getPropertyValue('MaskBinsXMins') and self.getPropertyValue('MaskBinsXMaxs') or\
-           self.getPropertyValue('MaskBinsXMins') and not self.getPropertyValue('MaskBinsXMaxs'):
+        if not self.getPropertyValue('MaskBinsXMins') and self.getPropertyValue('MaskBinsXMaxs') or \
+                self.getPropertyValue('MaskBinsXMins') and not self.getPropertyValue('MaskBinsXMaxs'):
             issues['MaskBinsXMins'] = "Both minimum and maximum values need to be given, or none"
 
         min_list = self.getProperty('MaskBinsXMins').value

--- a/Framework/PythonInterface/plugins/algorithms/EnggFocus.py
+++ b/Framework/PythonInterface/plugins/algorithms/EnggFocus.py
@@ -212,18 +212,13 @@ class EnggFocus(PythonAlgorithm):
 
         @param wks :: workspace (in/out, modified in place)
         """
-        p_charge = wks.getRun().getProtonCharge()
-        if p_charge <= 0:
-            self.log().warning("Cannot normalize by current because the proton charge log value "
-                               "is not positive!")
-
-        self.log().notice("Normalizing by current with proton charge: {0} uamp".
-                          format(p_charge))
-
-        alg = self.createChildAlgorithm('NormaliseByCurrent')
-        alg.setProperty('InputWorkspace', wks)
-        alg.setProperty('OutputWorkspace', wks)
-        alg.execute()
+        if wks.getRun().getProtonCharge() > 0:
+            alg = self.createChildAlgorithm('NormaliseByCurrent')
+            alg.setProperty('InputWorkspace', wks)
+            alg.setProperty('OutputWorkspace', wks)
+            alg.execute()
+        else:
+            self.log().warning(f"Cannot normalize by current because workspace {wks.name()} has invalid proton charge")
 
     def _apply_calibration(self, wks, detector_positions):
         """

--- a/Framework/PythonInterface/test/python/plugins/algorithms/EnggFocusTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/EnggFocusTest.py
@@ -5,18 +5,18 @@
 #   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
 # SPDX - License - Identifier: GPL - 3.0 +
 import unittest
+from testhelpers import assertRaisesNothing
 from mantid.simpleapi import *
 from mantid.api import *
 
 
 class EnggFocusTest(unittest.TestCase):
-
     _data_ws = None
     _van_curves_ws = None
     _van_integ_tbl = None
 
-    _expected_yvals_bank1  = [0.016676032919961604, 0.015995344072536975, 0.047449159145519233,
-                              0.15629648148139513, 0.11018845452876322, 0.017291707350351286]
+    _expected_yvals_bank1 = [0.016676032919961604, 0.015995344072536975, 0.047449159145519233,
+                             0.15629648148139513, 0.11018845452876322, 0.017291707350351286]
 
     _expected_yvals_bank2 = [0.0, 0.018310873111703541, 0.071387646720910913,
                              0.061783574337739511, 0.13102948781549345, 0.001766956921862095]
@@ -129,7 +129,7 @@ class EnggFocusTest(unittest.TestCase):
         self.assertEqual(wks.getNumDims(), 2)
         self.assertEqual(wks.YUnit(), 'Counts')
         dimX = wks.getXDimension()
-        self.assertAlmostEqual( dimX.getMaximum(), 36938.078125)
+        self.assertAlmostEqual(dimX.getMaximum(), 36938.078125)
         self.assertEqual(dimX.name, 'Time-of-flight')
         self.assertEqual(dimX.getUnits(), 'microsecond')
         dimY = wks.getYDimension()
@@ -230,13 +230,19 @@ class EnggFocusTest(unittest.TestCase):
         """
         Run focusing on one bank but on a ws with no proton charge
         """
+        assertRaisesNothing(self, self.run_with_zero_proton_charge)
+
+    def run_with_zero_proton_charge(self):
+        """
+        helper function so can run test test_no_error_when_zero_proton_charge with assertRaisesNothing
+        """
         # remove proton charge log (getProtonCharge will then return 0)
         ws = CloneWorkspace(self.__class__._data_ws)  # so don't interfere with other tests
         DeleteLog(Workspace=ws, Name='gd_prtn_chrg')
-        out_bank_south = EnggFocus(InputWorkspace=ws,
-                                   VanIntegrationWorkspace=self.__class__._van_integ_tbl,
-                                   VanCurvesWorkspace=self.__class__._van_curves_ws,
-                                   Bank='South', OutputWorkspace='out_bank_south')  # test passes if no RuntimeError
+        EnggFocus(InputWorkspace=ws,
+                  VanIntegrationWorkspace=self.__class__._van_integ_tbl,
+                  VanCurvesWorkspace=self.__class__._van_curves_ws,
+                  Bank='South', OutputWorkspace='out_bank_south')
 
 
 if __name__ == '__main__':

--- a/Framework/PythonInterface/test/python/plugins/algorithms/EnggFocusTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/EnggFocusTest.py
@@ -226,6 +226,18 @@ class EnggFocusTest(unittest.TestCase):
         self._check_output_ok(wks=out_bank_south, ws_name=out_name, y_dim_max=1201,
                               yvalues=self._expected_yvals_bank2)
 
+    def test_no_error_when_zero_proton_charge(self):
+        """
+        Run focusing on one bank but on a ws with no proton charge
+        """
+        # remove proton charge log (getProtonCharge will then return 0)
+        ws = CloneWorkspace(self.__class__._data_ws)  # so don't interfere with other tests
+        DeleteLog(Workspace=ws, Name='gd_prtn_chrg')
+        out_bank_south = EnggFocus(InputWorkspace=ws,
+                                   VanIntegrationWorkspace=self.__class__._van_integ_tbl,
+                                   VanCurvesWorkspace=self.__class__._van_curves_ws,
+                                   Bank='South', OutputWorkspace='out_bank_south')  # test passes if no RuntimeError
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/docs/source/release/v6.1.0/diffraction.rst
+++ b/docs/source/release/v6.1.0/diffraction.rst
@@ -77,6 +77,7 @@ Bugfixes
 - Engineering diffraction interface now converts fitted TOF centre to d-spacing using diffractometer constants post sequential fit (in a matrix workspace).
 - Error on the fitted peak centre converted from TOF to d-spacing will now be correct for non-zero difa (in preparation for supporting this in the interface).
 - Added checks on existance of non-zero proton charge before attempting to average log values weighted by proton charge in the fitting tab of the engineering difraction interface.
+- :ref:`EnggFocus <algm-EnggFocus>` algorithm doesn't attempt to normalise by current if the run has no proton charge and will not throw an error (but will print a warning to the log).
 
 
 Single Crystal Diffraction


### PR DESCRIPTION
**Description of work.**

Small bug fix checks whether a run has proton charge before running NormaliseByCurrent - which would throw a runtime error. This behaviour ahs been requested such that when the algorithm is used in the EngDiff UI workflow on multiple runs it doesn't stop on an empty run.

**To test:**
(1) Load this calibraiton in the calibration tab of the EnggDiff UI
[ENGINX_307521_305738_all_banks.zip](https://github.com/mantidproject/mantid/files/6377292/ENGINX_307521_305738_all_banks.zip)
(2) Go to the Focus tab, type 326016 in the sample run box and press Focus
(3) Focussing should execute without error (note the focussed workspace is full of zeros as there was no proton charge)

<!-- Instructions for testing. -->
*There is no associated issue.*


<!-- Ensure the base of this PR is correct (e.g. release-next or master)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
