### PR TITLE
Fix using enter on row, then hitting load causes exception in SANS

### DIFF
--- a/docs/source/release/v6.1.0/sans.rst
+++ b/docs/source/release/v6.1.0/sans.rst
@@ -19,6 +19,7 @@ Bugfixes
 
 - Fix a bug that made it impossible to process flux in SANSILLAutoprocess.
 - On D16 using :ref:`SANSILLAutoProcess <algm-SANSILLAutoProcess>`, now use the correct monitor for normalization, fix a bug where processing transmission would yield undefined values at 90 degrees when using ThetaDependent correction, and improve the q binning used.
+- Fixed the ISIS SANS interface crashing if a new row is created using the enter key, then the user immediately uses process or load without clicking away.
 
 Improvements
 ############

--- a/scripts/Interface/ui/sans_isis/sans_data_processor_gui.py
+++ b/scripts/Interface/ui/sans_isis/sans_data_processor_gui.py
@@ -116,10 +116,6 @@ class SANSDataProcessorGui(QMainWindow,
             pass
 
         @abstractmethod
-        def on_row_inserted(self):
-            pass
-
-        @abstractmethod
         def on_rows_removed(self):
             pass
 

--- a/scripts/Interface/ui/sans_isis/sans_data_processor_gui.py
+++ b/scripts/Interface/ui/sans_isis/sans_data_processor_gui.py
@@ -484,6 +484,7 @@ class SANSDataProcessorGui(QMainWindow,
     def _row_inserted(self, row_location):
         if row_location.depth() > 1:
             self.data_processor_table.removeRowAt(row_location)
+        self._call_settings_listeners(lambda listener: listener.on_insert_row())
 
     def _append_and_edit_at_child_row_requested(self):
         self.data_processor_table.appendAndEditAtChildRow()

--- a/scripts/SANS/sans/gui_logic/models/table_model.py
+++ b/scripts/SANS/sans/gui_logic/models/table_model.py
@@ -44,11 +44,9 @@ class TableModel(object):
     def add_multiple_table_entries(self, table_index_model_list):
         for row in table_index_model_list:
             self._add_single_table_entry(row_entry=row)
-        self.notify_subscribers()
 
     def append_table_entry(self, table_index_model):
         self._add_single_table_entry(row_entry=table_index_model)
-        self.notify_subscribers()
 
     def get_all_rows(self):
         return self._table_entries
@@ -63,7 +61,6 @@ class TableModel(object):
         # Insert a None to effectively bookmark the space
         self._table_entries.insert(row_index, None)
         self._add_single_table_entry(row_entry=row_entry, row_index=row_index)
-        self.notify_subscribers()
 
     def replace_table_entry(self, row_index, row_entry):
         self._add_single_table_entry(row_index=row_index, row_entry=row_entry)


### PR DESCRIPTION
**Description of work.**
Fixes an issue where hitting enter then load will cause the SANS GUI to throw an unexpected exception. See each commit for more details

**Report to:** @smk78 

**To test:**
- Download the ISIS Training Dataset
- Ensure the LOQ folder is present, and in your data directory (so that LOQ74044 is present)
- In the SANS GUI set the user file to either the .txt or .toml file in that directory
- In the first column + first row enter 74044
- Hit enter, then immediately click load without doing anything else. It should correctly load row 0 instead of erroring

Fixes #31202

<!-- Ensure the base of this PR is correct (e.g. release-next or master)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
