### PR TITLE
Forcibly terminate X sessions after running with xvfb

### DIFF
--- a/buildconfig/Jenkins/buildscript
+++ b/buildconfig/Jenkins/buildscript
@@ -37,19 +37,22 @@ function run_with_xvfb {
     fi
 }
 
+function terminate_xvfb_sessions() {
+    if [ $(command -v xvfb-run) ]; then
+        echo "Terminating existing Xvfb sessions"
+
+        # Kill Xvfb processes
+        killall Xvfb || true
+
+        # Remove Xvfb X server lock files
+        rm -f /tmp/.X${XVFB_SERVER_NUM}-lock
+    fi
+}
 
 ###############################################################################
 # Terminate existing Xvfb sessions
 ###############################################################################
-if [ $(command -v xvfb-run) ]; then
-    echo "Terminating existing Xvfb sessions"
-
-    # Kill Xvfb processes
-    killall Xvfb || true
-
-    # Remove Xvfb X server lock files
-    rm -f /tmp/.X${XVFB_SERVER_NUM}-lock
-fi
+terminate_xvfb_sessions
 
 ###############################################################################
 # System discovery
@@ -409,6 +412,7 @@ echo MultiThreaded.MaxCores=2 > $userprops_file
 
 if [[ ${DO_UNITTESTS} == true ]]; then
     run_with_xvfb $CTEST_EXE --no-compress-output -T Test -j${BUILD_THREADS:?} --schedule-random --output-on-failure
+    terminate_xvfb_sessions
 fi
 
 ###############################################################################
@@ -424,6 +428,7 @@ if [[ ${DO_DOCTESTS_USER} == true ]]; then
     fi
     # Build HTML to verify that no referencing errors have crept in.
     run_with_xvfb ${CMAKE_EXE} --build . --target docs-html
+    terminate_xvfb_sessions
     run_with_xvfb ${CMAKE_EXE} --build . --target docs-doctest
 fi
 


### PR DESCRIPTION
**Description of work.**

On Ubuntu builds occasionally the X server wont shut down quick enough and
starting another quickly results in an xvfb error. Ensure all sessions have been stopped before running the next command.

For an example see [this build](https://builds.mantidproject.org/job/master_incremental/5883/label=ubuntu-18.04-build/console).

**To test:**

Code review and builds pass.

*There is no associated issue.*

*This does not require release notes* because **it is an internal change.**

<!-- Ensure the base of this PR is correct (e.g. release-next or master)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
