### PR TITLE
Add Mesh_Plots to toctree and add link to other plothelp page

### DIFF
--- a/docs/source/plotting/1DPlotsHelp.rst
+++ b/docs/source/plotting/1DPlotsHelp.rst
@@ -14,6 +14,7 @@ Basic 1D and Tiled Plots
 * :ref:`Waterfall_Plots`
 * :ref:`Colorfill_Plots`
 * :ref:`3D_Plots`
+* :ref:`Mesh_Plots`
 
 **General Plot Help**
 

--- a/docs/source/plotting/ColorfillPlotsHelp.rst
+++ b/docs/source/plotting/ColorfillPlotsHelp.rst
@@ -11,6 +11,7 @@ Colorfill and Contour Plots
 * :ref:`Basic_1D_Plots`
 * :ref:`Waterfall_Plots`
 * :ref:`3D_Plots`
+* :ref:`Mesh_Plots`
 
 **General Plot Help**
 

--- a/docs/source/plotting/MeshPlotHelp.rst
+++ b/docs/source/plotting/MeshPlotHelp.rst
@@ -32,9 +32,6 @@ Mesh Plots
 
 **Mesh Plots can only be accessed with a script, not through the Workbench interface**
 
-|
-|
-
 Scripting
 ---------
 

--- a/docs/source/plotting/WaterfallPlotsHelp.rst
+++ b/docs/source/plotting/WaterfallPlotsHelp.rst
@@ -14,6 +14,7 @@ Waterfall Plots
 * :ref:`Basic_1D_Plots`
 * :ref:`Colorfill_Plots`
 * :ref:`3D_Plots`
+* :ref:`Mesh_Plots`
 
 **General Plot Help**
 

--- a/docs/source/plotting/index.rst
+++ b/docs/source/plotting/index.rst
@@ -13,6 +13,7 @@ Matplotlib in Mantid
    WaterfallPlotsHelp
    ColorfillPlotsHelp
    3DPlotsHelp
+   MeshPlotHelp
 
 **Other Plotting Documentation**
 
@@ -26,6 +27,7 @@ Matplotlib in Mantid
 * :ref:`Waterfall_Plots`
 * :ref:`Colorfill_Plots`
 * :ref:`3D_Plots`
+* :ref:`Mesh_Plots`
 
 .. contents:: Table of contents
     :local:


### PR DESCRIPTION
Is merging this into release-next correct?? I think so but I'd like the reviewers opinion!

**To test:**
Check doc tests pass
If you build the docs-html target, the Mesh Plots page has the navigation arrows at the bottom of the page (back to 3D plots and forward to release notes) as it is now in the toctree (line 16 in index.rst).

*This does not require release notes* because **Fixes build problem on master**

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
