### PR TITLE
Fix Documentation example failing for rhel7 and windows

### DIFF
--- a/docs/source/algorithms/PSIBackgroundSubtraction-v1.rst
+++ b/docs/source/algorithms/PSIBackgroundSubtraction-v1.rst
@@ -83,7 +83,7 @@ Output:
     Background = 20
     Lambda = 0.5
     time = np.linspace(0, 10, 500)
-    func = lambda t: A*np.exp(-Lambda*t) + Background + 0.5*A*np.sin(43.2*t)
+    func = lambda t: A*np.exp(-Lambda*t) + Background + 0.5*A*np.sin(50.0*t)
     counts = np.array([func(ti) for ti in time])
 
     # Create workspaces


### PR DESCRIPTION
**Description of work.**
This PR fixes an issue where a documentation example yields different results depending on if the doc is run on windows, ubuntu or rhel7. Mac might also have a different answer but I haven't been able to check.

A very bad result was seen on a rhel7 build. It should be 20.0 instead of 0.0 https://builds.mantidproject.org/view/Master%20Pipeline/job/master_clean-rhel7/1548/testReport/

The CalculateBackgroundWithAdditionalFunction documentation example performs a Fit in order to find the background that should be subtracted from PSI data. There is a known issue with fitting where different results can be achieved for the same Fit on different operating systems. As a result the background calculated within the doc example was different:

- windows background=19.57
- ubuntu background=20.0 (correct)
- rhel7 background=0.0

The fix was to use better starting data within the example so that rhel7 and windows could perform the fit to a good standard.

**To test:**
Make sure the Ubuntu + Doc Tests job passes.

Run the following script on windows ( and if possible centos7) and make sure 20.0 is the resulting answer:

```
from mantid.simpleapi as *
import numpy as np

# Generate shifted ExpDecay data
A = 1200
Background = 20
Lambda = 0.5
time = np.linspace(0, 10, 500)
func = lambda t: A*np.exp(-Lambda*t) + Background + 0.5*A*np.sin(50.0*t)
counts = np.array([func(ti) for ti in time])

# Create workspaces
input_workspace = CreateWorkspace(time, counts)
input_workspace.setYUnit("Counts")
run = input_workspace.getRun()
run.addProperty("First good spectra 0", 10, "None", True)
run.addProperty("Last good spectra 0", 99, "None", True)
workspace_copy = input_workspace.clone()

# Run PSIBackgroundSubtraction Algorithm
function = "name=GausOsc,A=500,Sigma=0.2,Frequency=40,Phi=0"
PSIBackgroundSubtraction(input_workspace, StartX=5, EndX=10, Function=function)

# Find the difference between the workspaces
workspace_diff = Minus(workspace_copy, input_workspace)
diffs = np.round(workspace_diff.readY(0), 4)
# The counts in workspace diff should be a flat line corresponding to the background
print("Difference in first count is: {}".format(diffs[0]))
print("Difference in middle count is: {}".format(diffs[int(len(diffs)/2)]))
print("Difference in last count is: {}".format(diffs[-1]))
```

<!-- Instructions for testing. -->

*There is no associated issue.*

*This does not require release notes* because **it was an internal issue**

<!-- Ensure the base of this PR is correct (e.g. release-next or master)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
