### PR TITLE
Fix legend script generator tests

### DIFF
--- a/qt/applications/workbench/workbench/plotting/plotscriptgenerator/legend.py
+++ b/qt/applications/workbench/workbench/plotting/plotscriptgenerator/legend.py
@@ -152,11 +152,11 @@ def _remove_kwargs_if_default(kwargs):
     # Font size defaults are string values (e.g. 'medium', 'large', 'x-large'), so we need to convert the defaults to
     # point sizes before comparing.
     if 'title_size' in kwargs:
-        if _convert_to_point_size(kwargs['title_size']) == _convert_to_point_size(mpl_default_kwargs['title_size']):
+        if convert_to_point_size(kwargs['title_size']) == convert_to_point_size(mpl_default_kwargs['title_size']):
             kwargs.pop('title_size')
 
     if 'entries_size' in kwargs:
-        if _convert_to_point_size(kwargs['entries_size']) == _convert_to_point_size(mpl_default_kwargs['entries_size']):
+        if convert_to_point_size(kwargs['entries_size']) == convert_to_point_size(mpl_default_kwargs['entries_size']):
             kwargs.pop('entries_size')
 
     # Hex values of colours may not be the same case, so convert to lower before comparing.
@@ -169,7 +169,7 @@ def _remove_kwargs_if_default(kwargs):
             kwargs.pop('edge_color')
 
 
-def _convert_to_point_size(font_size):
+def convert_to_point_size(font_size):
     """
     Convert font size (may be int or string, e.g. 'medium', 'large', ...) to point size.
     """

--- a/qt/applications/workbench/workbench/plotting/plotscriptgenerator/test/test_plotscriptgeneratorlegend.py
+++ b/qt/applications/workbench/workbench/plotting/plotscriptgenerator/test/test_plotscriptgeneratorlegend.py
@@ -59,7 +59,7 @@ class PlotScriptGeneratorLegendTest(unittest.TestCase):
         title = legend.get_title()
         title.set_fontname(self.test_font)
         title.set_color(TEST_FONT_COLOUR)
-        test_font_size = TEST_FONT_SIZE
+        test_font_size = convert_to_point_size(TEST_FONT_SIZE)
         title.set_fontsize(test_font_size)
         title_font_commands = generate_title_font_commands(legend, "legend")
 
@@ -67,11 +67,11 @@ class PlotScriptGeneratorLegendTest(unittest.TestCase):
         for value in DEFAULT_TITLE_FONT_KWARGS.values():
             self.assertFalse(any(str(value) in command for command in title_font_commands))
         # The new font name should appear in the list of commands.
-        self.assertTrue(self.test_font in command for command in title_font_commands)
+        self.assertTrue(any(self.test_font in command for command in title_font_commands))
         # The new colour should appear in the list of commands.
-        self.assertTrue(TEST_FONT_COLOUR in command for command in title_font_commands)
+        self.assertTrue(any(TEST_FONT_COLOUR in command for command in title_font_commands))
         # The new font size should appear in the list of commands.
-        self.assertTrue(test_font_size in command for command in title_font_commands)
+        self.assertTrue(any(str(test_font_size) in command for command in title_font_commands))
         # There should be three lines of commands (font name, size, and colour).
         self.assertEqual(3, len(title_font_commands))
 
@@ -88,9 +88,9 @@ class PlotScriptGeneratorLegendTest(unittest.TestCase):
         for value in DEFAULT_LABEL_FONT_KWARGS.values():
             self.assertFalse(any(str(value) in command for command in label_font_commands))
         # The new font name should appear in the list of commands.
-        self.assertTrue(self.test_font in command for command in label_font_commands)
+        self.assertTrue(any(self.test_font in command for command in label_font_commands))
         # The new colour should appear in the list of commands.
-        self.assertTrue(TEST_FONT_COLOUR in command for command in label_font_commands)
+        self.assertTrue(any(TEST_FONT_COLOUR in command for command in label_font_commands))
         # There should be two lines of commands, one to set the font name, and the other to set the colour.
         self.assertEqual(2, len(label_font_commands))
 

--- a/qt/applications/workbench/workbench/plotting/plotscriptgenerator/test/test_plotscriptgeneratorlegend.py
+++ b/qt/applications/workbench/workbench/plotting/plotscriptgenerator/test/test_plotscriptgeneratorlegend.py
@@ -40,8 +40,6 @@ class PlotScriptGeneratorLegendTest(unittest.TestCase):
                                       NSpec=2,
                                       OutputWorkspace='test_ws')
 
-        cls.test_font = cls.get_non_default_font()
-
     def setUp(self):
         fig = plt.figure()
         self.ax = fig.add_subplot(1, 1, 1, projection='mantid')
@@ -57,7 +55,6 @@ class PlotScriptGeneratorLegendTest(unittest.TestCase):
         """
         legend = self.ax.legend(title="Legend title")
         title = legend.get_title()
-        title.set_fontname(self.test_font)
         title.set_color(TEST_FONT_COLOUR)
         test_font_size = convert_to_point_size(TEST_FONT_SIZE)
         title.set_fontsize(test_font_size)
@@ -66,14 +63,12 @@ class PlotScriptGeneratorLegendTest(unittest.TestCase):
         # Default arguments should not appear in the list of commands.
         for value in DEFAULT_TITLE_FONT_KWARGS.values():
             self.assertFalse(any(str(value) in command for command in title_font_commands))
-        # The new font name should appear in the list of commands.
-        self.assertTrue(any(self.test_font in command for command in title_font_commands))
         # The new colour should appear in the list of commands.
         self.assertTrue(any(TEST_FONT_COLOUR in command for command in title_font_commands))
         # The new font size should appear in the list of commands.
         self.assertTrue(any(str(test_font_size) in command for command in title_font_commands))
-        # There should be three lines of commands (font name, size, and colour).
-        self.assertEqual(3, len(title_font_commands))
+        # There should be two lines of commands (size, and colour).
+        self.assertEqual(2, len(title_font_commands))
 
     def test_label_font_commands(self):
         """
@@ -81,18 +76,15 @@ class PlotScriptGeneratorLegendTest(unittest.TestCase):
         """
         legend = self.ax.legend()
         for label in legend.get_texts():
-            label.set_fontname(self.test_font)
             label.set_color(TEST_FONT_COLOUR)
         label_font_commands = generate_label_font_commands(legend, "legend")
         # Default arguments should not appear in the list of commands.
         for value in DEFAULT_LABEL_FONT_KWARGS.values():
             self.assertFalse(any(str(value) in command for command in label_font_commands))
-        # The new font name should appear in the list of commands.
-        self.assertTrue(any(self.test_font in command for command in label_font_commands))
         # The new colour should appear in the list of commands.
         self.assertTrue(any(TEST_FONT_COLOUR in command for command in label_font_commands))
-        # There should be two lines of commands, one to set the font name, and the other to set the colour.
-        self.assertEqual(2, len(label_font_commands))
+        # There should be only one line of commands (to set the colour).
+        self.assertEqual(1, len(label_font_commands))
 
     def test_legend_kwargs(self):
         """
@@ -155,21 +147,6 @@ class PlotScriptGeneratorLegendTest(unittest.TestCase):
         visible_command = generate_visible_command(legend, "legend")
         # Should now contain a single entry.
         self.assertEqual(1, len(visible_command))
-
-    @classmethod
-    def get_non_default_font(cls):
-        """
-        Find a font that is different to the default values.
-        """
-        font_list = matplotlib.font_manager.findSystemFonts()
-        for font_name in font_list:
-            if font_name != mpl_default_kwargs['title_font'] and font_name != mpl_default_kwargs['title_font']:
-                # This try-except is for a known matplotlib bug where get_name() causes an error for certain fonts.
-                try:
-                    font = matplotlib.font_manager.FontProperties(fname=font_name).get_name()
-                except RuntimeError:
-                    continue
-                return font
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
**Description of work.**

Unit tests added in pull request #31146 have been unreliable on linux systems. See for example:
https://builds.mantidproject.org/job/pull_requests-ubuntu/44252/testReport/junit/projectroot.qt.applications/workbench/workbench_test_plotscriptgeneratorlegend_test_plotscriptgeneratorlegend/

Therefore, the asserts to check whether a change in font name results in the correct script lines have been removed. It was pointed out that some test machines may not have enough fonts installed for this test to work properly.

Additionally, a few other asserts were corrected (they were missing `any()` function calls).

*There is no associated issue.*

*This does not require release notes* because it is an update to the unit tests and is not visible to the end-user.

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
