### PR TITLE
Fix SANS cached Can details not using wav range for key

### DIFF
--- a/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/SANS/SANSSingleReduction.py
+++ b/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/SANS/SANSSingleReduction.py
@@ -283,7 +283,6 @@ class SANSSingleReduction(SANSSingleReductionBase):
     def set_transmission_workspaces_on_output(self, completed_event_slices, fit_state):
         calc_can, calc_sample = WorkspaceGroup(), WorkspaceGroup()
         unfit_can, unfit_sample = WorkspaceGroup(), WorkspaceGroup()
-
         output_hab_or_lab = None
         for bundle in completed_event_slices:
             if output_hab_or_lab is not None and output_hab_or_lab != bundle.output_bundle.reduction_mode:

--- a/scripts/SANS/sans/algorithm_detail/single_execution.py
+++ b/scripts/SANS/sans/algorithm_detail/single_execution.py
@@ -358,10 +358,11 @@ def run_optimized_for_can(reduction_alg, reduction_setting_bundle, event_slice_o
 
     def needs_reload(slice: ReducedSlice):
         output_parts_bundle = slice.parts_bundle
-        is_invalid_partial_workspaces = ((output_parts_bundle.output_workspace_count is None
-                                          and output_parts_bundle.output_workspace_norm is not None)
-                                         or (output_parts_bundle.output_workspace_count is not None
-                                             and output_parts_bundle.output_workspace_norm is None))
+
+        # Invalid partial when one is set to none, but not the other
+        is_invalid_partial_workspaces = \
+            (output_parts_bundle.output_workspace_count is None) ^ (output_parts_bundle.output_workspace_norm is None)
+
         output_transmission_bundle = slice.transmission_bundle
         is_invalid_transmission_workspaces = (output_transmission_bundle.calculated_transmission_workspace is None
                                               or output_transmission_bundle.unfitted_transmission_workspace is None)

--- a/scripts/SANS/sans/algorithm_detail/single_execution.py
+++ b/scripts/SANS/sans/algorithm_detail/single_execution.py
@@ -9,7 +9,7 @@ import sys
 from collections import OrderedDict
 from typing import List, Tuple
 
-from mantid.kernel import mpisetup
+from mantid.kernel import mpisetup, logger
 from sans.algorithm_detail.bundles import (EventSliceSettingBundle, OutputBundle,
                                            OutputPartsBundle, OutputTransmissionBundle, CompletedSlices, ReducedSlice)
 from sans.algorithm_detail.merge_reductions import MergeFactory
@@ -18,7 +18,7 @@ from sans.common.constants import EMPTY_NAME
 from sans.common.enums import (DetectorType, ReductionMode, OutputParts, TransmissionType, DataType)
 from sans.common.general_functions import (create_child_algorithm, get_reduced_can_workspace_from_ads,
                                            get_transmission_workspaces_from_ads,
-                                           write_hash_into_reduced_can_workspace)
+                                           write_hash_into_reduced_can_workspace, wav_range_to_str)
 from sans.state.Serializer import Serializer
 
 
@@ -342,26 +342,7 @@ def run_optimized_for_can(reduction_alg, reduction_setting_bundle, event_slice_o
     state = reduction_setting_bundle.state
     output_parts = reduction_setting_bundle.output_parts
     reduction_mode = reduction_setting_bundle.reduction_mode
-    data_type = reduction_setting_bundle.data_type
-    reduced_can_workspace, reduced_can_workspace_count, reduced_can_workspace_norm = \
-        get_reduced_can_workspace_from_ads(state, output_parts, reduction_mode)
-    output_calculated_transmission_workspace, output_unfitted_transmission_workspace = \
-        get_transmission_workspaces_from_ads(state, reduction_mode)
-    # Set the results on the output bundle
-    reduced_slices: CompletedSlices = []
-    wav_range = reduced_can_workspace.getRun().getProperty(
-        "Wavelength Range").valueAsStr if reduced_can_workspace else None
-    reduced_slices.append(ReducedSlice(
-        wav_range=wav_range,
-        output_bundle=OutputBundle(state=state, data_type=data_type, reduction_mode=reduction_mode,
-                                   output_workspace=reduced_can_workspace),
-        parts_bundle=OutputPartsBundle(state=state, data_type=data_type, reduction_mode=reduction_mode,
-                                       output_workspace_count=reduced_can_workspace_count,
-                                       output_workspace_norm=reduced_can_workspace_norm),
-        transmission_bundle=OutputTransmissionBundle(
-            state=reduction_setting_bundle.state, data_type=data_type,
-            calculated_transmission_workspace=output_calculated_transmission_workspace,
-            unfitted_transmission_workspace=output_unfitted_transmission_workspace)))
+    reduced_slices = _get_existing_cans(reduction_setting_bundle, state)
 
     # The logic table for the recalculation of the partial outputs is:
     # | output_parts | reduced_can_workspace_count is None |  reduced_can_workspace_norm is None | Recalculate |
@@ -375,18 +356,22 @@ def run_optimized_for_can(reduction_alg, reduction_setting_bundle, event_slice_o
     # |  True        |        False                        |           True                      |    True     |
     # |  True        |        False                        |           False                     |    False    |
 
-    output_parts_bundle = reduced_slices[0].parts_bundle
-    is_invalid_partial_workspaces = ((output_parts_bundle.output_workspace_count is None
-                                      and output_parts_bundle.output_workspace_norm is not None)
-                                     or (output_parts_bundle.output_workspace_count is not None
-                                         and output_parts_bundle.output_workspace_norm is None))
-    output_transmission_bundle = reduced_slices[0].transmission_bundle
-    is_invalid_transmission_workspaces = (output_transmission_bundle.calculated_transmission_workspace is None
-                                          or output_transmission_bundle.unfitted_transmission_workspace is None)
-    partial_output_require_reload = output_parts and is_invalid_partial_workspaces
+    def needs_reload(slice: ReducedSlice):
+        output_parts_bundle = slice.parts_bundle
+        is_invalid_partial_workspaces = ((output_parts_bundle.output_workspace_count is None
+                                          and output_parts_bundle.output_workspace_norm is not None)
+                                         or (output_parts_bundle.output_workspace_count is not None
+                                             and output_parts_bundle.output_workspace_norm is None))
+        output_transmission_bundle = slice.transmission_bundle
+        is_invalid_transmission_workspaces = (output_transmission_bundle.calculated_transmission_workspace is None
+                                              or output_transmission_bundle.unfitted_transmission_workspace is None)
+        partial_output_require_reload = output_parts and is_invalid_partial_workspaces
 
-    must_reload = reduced_slices[0].output_bundle.output_workspace is None \
-                  or partial_output_require_reload or is_invalid_transmission_workspaces
+        return slice.output_bundle.output_workspace is None\
+            or partial_output_require_reload or is_invalid_transmission_workspaces
+
+    must_reload = any(needs_reload(i) for i in reduced_slices)  # If any slice requires a reload
+
     if 'boost.mpi' in sys.modules:
         # In MPI runs the result is only present on rank 0 (result of Q1D2 integration),
         # so the reload flag must be broadcasted from rank 0.
@@ -394,8 +379,10 @@ def run_optimized_for_can(reduction_alg, reduction_setting_bundle, event_slice_o
 
     if not must_reload:
         # Return the cached can without doing anything else
+        logger.information("SANS single_execution: Using cached can workspaces")
         return reduced_slices
 
+    logger.information("SANS single_execution: Processing new/changed can workspaces")
     # We can't used a cached can, lets re-process
     if not event_slice_optimisation:
         reduced_slices = run_core_reduction(reduction_alg, reduction_setting_bundle)
@@ -405,30 +392,59 @@ def run_optimized_for_can(reduction_alg, reduction_setting_bundle, event_slice_o
     # Now we need to tag the workspaces and add it to the ADS
     for completed_slice in reduced_slices:
         out_bundle = completed_slice.output_bundle
+        wav_range = completed_slice.wav_range
         write_hash_into_reduced_can_workspace(state=out_bundle.state,
                                               workspace=out_bundle.output_workspace,
-                                              partial_type=None,
+                                              partial_type=None, wav_range=wav_range,
                                               reduction_mode=reduction_mode)
         trans_bundle = completed_slice.transmission_bundle
         if trans_bundle.calculated_transmission_workspace and trans_bundle.unfitted_transmission_workspace:
             write_hash_into_reduced_can_workspace(state=trans_bundle.state,
                                                   workspace=trans_bundle.calculated_transmission_workspace,
                                                   partial_type=TransmissionType.CALCULATED,
-                                                  reduction_mode=reduction_mode)
+                                                  reduction_mode=reduction_mode, wav_range=wav_range)
             write_hash_into_reduced_can_workspace(state=trans_bundle.state,
                                                   workspace=trans_bundle.unfitted_transmission_workspace,
                                                   partial_type=TransmissionType.UNFITTED,
-                                                  reduction_mode=reduction_mode)
+                                                  reduction_mode=reduction_mode, wav_range=None)
         parts_bundle = completed_slice.parts_bundle
         if parts_bundle.output_workspace_count and parts_bundle.output_workspace_norm:
             write_hash_into_reduced_can_workspace(state=parts_bundle.state,
                                                   workspace=parts_bundle.output_workspace_count,
                                                   partial_type=OutputParts.COUNT,
-                                                  reduction_mode=reduction_mode)
+                                                  reduction_mode=reduction_mode, wav_range=wav_range)
 
             write_hash_into_reduced_can_workspace(state=parts_bundle.state,
                                                   workspace=parts_bundle.output_workspace_norm,
                                                   partial_type=OutputParts.NORM,
-                                                  reduction_mode=reduction_mode)
+                                                  reduction_mode=reduction_mode, wav_range=wav_range)
 
     return reduced_slices
+
+
+def _get_existing_cans(reduction_setting_bundle, state):
+    output_parts = reduction_setting_bundle.output_parts
+    reduction_mode = reduction_setting_bundle.reduction_mode
+    data_type = reduction_setting_bundle.data_type
+
+    existing_slices = []
+    for wav_slice in state.wavelength.wavelength_interval.selected_ranges:
+        wav_string = wav_range_to_str(wav_slice)
+
+        reduced_can_workspace, reduced_can_workspace_count, reduced_can_workspace_norm = \
+            get_reduced_can_workspace_from_ads(state, output_parts, reduction_mode, wav_string)
+        output_calculated_transmission_workspace, output_unfitted_transmission_workspace = \
+            get_transmission_workspaces_from_ads(state, reduction_mode, wav_string)
+        # Set the results on the output bundle
+        existing_slices.append(ReducedSlice(
+            wav_range=wav_string,
+            output_bundle=OutputBundle(state=state, data_type=data_type, reduction_mode=reduction_mode,
+                                       output_workspace=reduced_can_workspace),
+            parts_bundle=OutputPartsBundle(state=state, data_type=data_type, reduction_mode=reduction_mode,
+                                           output_workspace_count=reduced_can_workspace_count,
+                                           output_workspace_norm=reduced_can_workspace_norm),
+            transmission_bundle=OutputTransmissionBundle(
+                state=reduction_setting_bundle.state, data_type=data_type,
+                calculated_transmission_workspace=output_calculated_transmission_workspace,
+                unfitted_transmission_workspace=output_unfitted_transmission_workspace)))
+    return existing_slices

--- a/scripts/test/SANS/common/general_functions_test.py
+++ b/scripts/test/SANS/common/general_functions_test.py
@@ -19,7 +19,7 @@ from sans.common.general_functions import (quaternion_to_angle_and_axis, create_
                                            convert_instrument_and_detector_type_to_bank_name,
                                            convert_bank_name_to_detector_type_isis,
                                            get_facility, parse_diagnostic_settings, get_transmission_output_name,
-                                           get_output_name, parse_event_slice_setting)
+                                           get_output_name, parse_event_slice_setting, wav_range_to_str)
 from sans.state.StateObjects.StateData import StateData
 from sans.test_helper.test_director import TestDirector
 
@@ -603,6 +603,11 @@ class SANSFunctionsTest(unittest.TestCase):
         alg_manager_mock.reset_mock()
         create_managed_non_child_algorithm("TestAlg", **{"test_val": 5})
         alg_manager_mock.create.assert_called_once_with("TestAlg")
+
+    def test_wav_range_to_str(self):
+        input_values = (2, 200)
+        expected_output = "2-200"
+        self.assertEqual(expected_output, wav_range_to_str(input_values))
 
 
 class SANSEventSliceParsing(unittest.TestCase):


### PR DESCRIPTION
**Description of work.**

Fixes the SANS Cached can details not using the current wavelength range
for the key. This means that every cache entry is a miss, and can cause
random workspaces to be selected as a candidate can instead.

This was primarily seen when running a reduction with RangeLin
wavelength slicing twice and the save set to Both, as a random WS would
be selected causing the save alg to choke.

Unfortunately, we can't add an automatic test as the API currently
doesn't have a way of setting wavelength slices unlike the GUI. When it
was originally written there was no advantage of doing your wavelength
slices in one single call vs in an outer loop. This feature request has
also caught us out on the user-base side where weirdly the GUI is
significantly faster than the API, because the API exposes less.

When we go to add an API we'll need to add a test that runs the system
test twice to confirm it's fixed. However, as we'll already be writing a
system test that runs it once (to verify the API) this will be trivial
to do.

Report to: @smk78 + ISIS SANS / Sarah

**To test:**
- Download the ISIS training dataset
- Extract and find the LoqDemo folder
- Open ISIS Sans GUI
- Set the user file to either the .txt or .toml file in the Loq Demo folder
- Set the batch file to the csv in said folder
- On the left, go to settings -> q, wavelength ...etc.
- Under the wavelength section change it to range lin and enter `2:1:16` to take 1A slices between 2-16
- Go back to the runs page on the left and ensure "Both" is ticked in save options
- Set the logger in Mantid to information
- Process all
- Check that both complete, additionally copy the text from the logger to an editor and search for `Using cached can workspaces`, this indicates the caching worked correctly

Fixes #31197 

*This does not require release notes* because it was a regression from work this release

<!-- Ensure the base of this PR is correct (e.g. release-next or master)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
