### PR TITLE
Indirect FQFit - Fix crash when loading data that has no EISF

### DIFF
--- a/qt/scientific_interfaces/Indirect/FqFitAddWorkspaceDialog.ui
+++ b/qt/scientific_interfaces/Indirect/FqFitAddWorkspaceDialog.ui
@@ -11,7 +11,7 @@
    </rect>
   </property>
   <property name="windowTitle">
-   <string>JumpFit Data Selection</string>
+   <string>F(Q) Fit Data Selection</string>
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
    <item>

--- a/qt/scientific_interfaces/Indirect/FqFitModel.cpp
+++ b/qt/scientific_interfaces/Indirect/FqFitModel.cpp
@@ -234,6 +234,8 @@ FqFitParameters &FqFitModel::addFqFitParameters(MatrixWorkspace *workspace, cons
   const auto parameters = createFqFitParameters(workspace);
   if (parameters.widths.empty() && parameters.eisf.empty())
     throw std::invalid_argument("Workspace contains no Width or EISF spectra.");
+  if (parameters.widths.empty())
+    throw std::invalid_argument("Workspace contains no Width spectra, only EISF spectra.");
   return m_fqFitParameters[hwhmName] = std::move(parameters);
 }
 

--- a/qt/scientific_interfaces/Indirect/FqFitModel.cpp
+++ b/qt/scientific_interfaces/Indirect/FqFitModel.cpp
@@ -235,7 +235,7 @@ FqFitParameters &FqFitModel::addFqFitParameters(MatrixWorkspace *workspace, cons
   if (parameters.widths.empty() && parameters.eisf.empty())
     throw std::invalid_argument("Workspace contains no Width or EISF spectra.");
   if (parameters.widths.empty())
-    throw std::invalid_argument("Workspace contains no Width spectra, only EISF spectra.");
+    throw std::invalid_argument("Workspace contains EISF spectra, but no Width spectra.");
   return m_fqFitParameters[hwhmName] = std::move(parameters);
 }
 

--- a/qt/scientific_interfaces/Indirect/FqFitModel.cpp
+++ b/qt/scientific_interfaces/Indirect/FqFitModel.cpp
@@ -234,10 +234,7 @@ FqFitParameters &FqFitModel::addFqFitParameters(MatrixWorkspace *workspace, cons
   const auto parameters = createFqFitParameters(workspace);
   if (parameters.widths.empty() && parameters.eisf.empty())
     throw std::invalid_argument("Workspace contains no Width or EISF spectra.");
-  if (parameters.eisf.empty())
-    return m_fqFitParameters[workspace->getName()] = std::move(parameters);
-  else
-    return m_fqFitParameters[hwhmName] = std::move(parameters);
+  return m_fqFitParameters[hwhmName] = std::move(parameters);
 }
 
 std::unordered_map<std::string, FqFitParameters>::const_iterator

--- a/qt/scientific_interfaces/Indirect/IndirectSpectrumSelectionPresenter.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectSpectrumSelectionPresenter.cpp
@@ -148,8 +148,8 @@ void IndirectSpectrumSelectionPresenter::setActiveIndexToZero() { setActiveModel
 
 void IndirectSpectrumSelectionPresenter::updateSpectra() {
   const auto ws = m_model->getWorkspace(m_activeIndex);
-  if (ws) {
-    const auto spectra = m_model->getSpectra(m_activeIndex);
+  const auto spectra = m_model->getSpectra(m_activeIndex);
+  if (ws && !spectra.empty()) {
     setSpectraRange(spectra.front(), spectra.back());
     SetViewSpectra(m_view.get())(spectra);
     enableView();

--- a/qt/scientific_interfaces/Indirect/test/FqFitModelTest.h
+++ b/qt/scientific_interfaces/Indirect/test/FqFitModelTest.h
@@ -53,88 +53,67 @@ public:
   }
 
   void test_that_the_model_is_instantiated_and_can_hold_a_workspace() {
-    FunctionModelSpectra const spectra = FunctionModelSpectra("0-1");
-
-    addWorkspacesToModel(spectra, m_workspace);
-
+    addWorkspacesToModel(m_workspace);
     TS_ASSERT_EQUALS(m_model->getNumberOfWorkspaces(), TableDatasetIndex{1});
   }
 
   void test_that_removeWorkspace_will_remove_the_specified_workspace_from_the_model() {
-    FunctionModelSpectra const spectra = FunctionModelSpectra("0-1");
-
-    addWorkspacesToModel(spectra, m_workspace);
+    addWorkspacesToModel(m_workspace);
     m_model->removeWorkspace(TableDatasetIndex{0});
 
     TS_ASSERT_EQUALS(m_model->getNumberOfWorkspaces(), TableDatasetIndex{0});
   }
 
   void test_that_zeroWidths_returns_false_if_the_workspace_contains_widths() {
-    FunctionModelSpectra const spectra = FunctionModelSpectra("0-1");
-
-    addWorkspacesToModel(spectra, m_workspace);
-
+    addWorkspacesToModel(m_workspace);
     TS_ASSERT(!m_model->zeroWidths(TableDatasetIndex{0}));
   }
 
   void test_that_zeroWidths_returns_true_if_the_workspace_contains_no_widths() {
-    FunctionModelSpectra const spectra = FunctionModelSpectra("0-1");
     auto const workspace2 = createWorkspaceWithTextAxis(2, getNoWidthLabels());
     m_ads->addOrReplace("Name2", workspace2);
+    addWorkspacesToModel(m_workspace);
 
-    addWorkspacesToModel(spectra, m_workspace, workspace2);
-
+    TS_ASSERT_THROWS(addWorkspacesToModel(workspace2), std::invalid_argument const &);
     TS_ASSERT(m_model->zeroWidths(TableDatasetIndex{1}));
+    TS_ASSERT(m_model->getWidths(TableDatasetIndex{1}).empty());
+    TS_ASSERT(!m_model->getWidthSpectrum(0, TableDatasetIndex{1}));
   }
 
   void test_that_zeroEISF_returns_false_if_the_workspace_contains_EISFs() {
-    FunctionModelSpectra const spectra = FunctionModelSpectra("0-1");
-
-    addWorkspacesToModel(spectra, m_workspace);
-
+    addWorkspacesToModel(m_workspace);
     TS_ASSERT(!m_model->zeroEISF(TableDatasetIndex{0}));
   }
 
   void test_that_zeroEISF_returns_true_if_the_workspace_contains_no_EISFs() {
-    FunctionModelSpectra const spectra = FunctionModelSpectra("0-1");
     auto const workspace2 = createWorkspaceWithTextAxis(2, getNoEISFLabels());
     m_ads->addOrReplace("Name2", workspace2);
 
-    addWorkspacesToModel(spectra, m_workspace, workspace2);
+    addWorkspacesToModel(m_workspace, workspace2);
 
     TS_ASSERT(m_model->zeroEISF(TableDatasetIndex{1}));
   }
 
   void test_that_isMultiFit_returns_false_if_the_model_contains_one_workspace() {
-    FunctionModelSpectra const spectra = FunctionModelSpectra("0-1");
-
-    addWorkspacesToModel(spectra, m_workspace);
-
+    addWorkspacesToModel(m_workspace);
     TS_ASSERT(!m_model->isMultiFit());
   }
 
   void test_that_isMultiFit_returns_true_if_the_model_contains_multiple_workspace() {
-    FunctionModelSpectra const spectra = FunctionModelSpectra("0-1");
     auto const workspace2 = createWorkspaceWithTextAxis(2, getNoEISFLabels());
     m_ads->addOrReplace("Name2", workspace2);
 
-    addWorkspacesToModel(spectra, m_workspace, workspace2);
-
+    addWorkspacesToModel(m_workspace, workspace2);
     TS_ASSERT(m_model->isMultiFit());
   }
 
   void test_that_isMultiFit_returns_false_if_the_model_contains_multiple_workspace_which_are_identical() {
-    FunctionModelSpectra const spectra = FunctionModelSpectra("0-1");
-
-    addWorkspacesToModel(spectra, m_workspace, m_workspace);
-
+    addWorkspacesToModel(m_workspace, m_workspace);
     TS_ASSERT(!m_model->isMultiFit());
   }
 
   void test_that_getFitParameterName_will_return_the_name_of_the_expected_parameter() {
-    FunctionModelSpectra const spectra = FunctionModelSpectra("0-1");
-
-    addWorkspacesToModel(spectra, m_workspace);
+    addWorkspacesToModel(m_workspace);
 
     TS_ASSERT_EQUALS(
         m_model->getFitParameterName(TableDatasetIndex{0}, MantidQt::CustomInterfaces::IDA::WorkspaceIndex{0}),
@@ -144,85 +123,54 @@ public:
         "f1.FWHM");
   }
 
-  void test_that_getWidths_will_return_an_empty_vector_if_there_are_no_widths() {
-    FunctionModelSpectra const spectra = FunctionModelSpectra("0-1");
-    auto const workspace2 = createWorkspaceWithTextAxis(2, getNoWidthLabels());
-    m_ads->addOrReplace("Name2", workspace2);
-
-    addWorkspacesToModel(spectra, m_workspace, workspace2);
-
-    TS_ASSERT(m_model->getWidths(TableDatasetIndex{1}).empty());
-  }
-
   void test_that_getWidths_will_return_the_width_parameter_names() {
-    FunctionModelSpectra const spectra = FunctionModelSpectra("0-1");
-
-    addWorkspacesToModel(spectra, m_workspace);
+    addWorkspacesToModel(m_workspace);
 
     TS_ASSERT_EQUALS(m_model->getWidths(TableDatasetIndex{0})[0], "f1.Width");
     TS_ASSERT_EQUALS(m_model->getWidths(TableDatasetIndex{0})[1], "f1.FWHM");
   }
 
   void test_that_getEISF_will_return_an_empty_vector_if_there_are_no_EISFs() {
-    FunctionModelSpectra const spectra = FunctionModelSpectra("0-1");
     auto const workspace2 = createWorkspaceWithTextAxis(2, getNoEISFLabels());
     m_ads->addOrReplace("Name2", workspace2);
 
-    addWorkspacesToModel(spectra, m_workspace, workspace2);
+    addWorkspacesToModel(m_workspace, workspace2);
 
     TS_ASSERT(m_model->getEISF(TableDatasetIndex{1}).empty());
   }
 
   void test_that_getEISF_will_return_the_EISF_parameter_names() {
-    FunctionModelSpectra const spectra = FunctionModelSpectra("0-1");
-
-    addWorkspacesToModel(spectra, m_workspace);
+    addWorkspacesToModel(m_workspace);
 
     TS_ASSERT_EQUALS(m_model->getEISF(TableDatasetIndex{0})[0], "f0.EISF");
     TS_ASSERT_EQUALS(m_model->getEISF(TableDatasetIndex{0})[1], "f1.EISF");
   }
 
-  void test_that_getWidthSpectrum_will_return_none_when_there_are_no_widths() {
-    FunctionModelSpectra const spectra = FunctionModelSpectra("0-1");
-    auto const workspace2 = createWorkspaceWithTextAxis(2, getNoWidthLabels());
-    m_ads->addOrReplace("Name2", workspace2);
-
-    addWorkspacesToModel(spectra, m_workspace, workspace2);
-
-    TS_ASSERT(!m_model->getWidthSpectrum(0, TableDatasetIndex{1}));
-  }
-
   void test_that_getWidthSpectrum_will_return_the_width_spectrum_number() {
-    FunctionModelSpectra const spectra = FunctionModelSpectra("0-1");
-
-    addWorkspacesToModel(spectra, m_workspace);
+    addWorkspacesToModel(m_workspace);
 
     TS_ASSERT_EQUALS(m_model->getWidthSpectrum(0, TableDatasetIndex{0}).get(), 1);
     TS_ASSERT_EQUALS(m_model->getWidthSpectrum(1, TableDatasetIndex{0}).get(), 2);
   }
 
   void test_that_getEISFSpectrum_will_return_none_when_there_are_no_EISFs() {
-    FunctionModelSpectra const spectra = FunctionModelSpectra("0-1");
     auto const workspace2 = createWorkspaceWithTextAxis(2, getNoEISFLabels());
     m_ads->addOrReplace("Name2", workspace2);
 
-    addWorkspacesToModel(spectra, m_workspace, workspace2);
+    addWorkspacesToModel(m_workspace, workspace2);
 
     TS_ASSERT(!m_model->getEISFSpectrum(0, TableDatasetIndex{1}));
   }
 
   void test_that_getEISFSpectrum_will_return_the_EISF_spectrum_number() {
-    FunctionModelSpectra const spectra = FunctionModelSpectra("0-1");
-
-    addWorkspacesToModel(spectra, m_workspace);
+    addWorkspacesToModel(m_workspace);
 
     TS_ASSERT_EQUALS(m_model->getEISFSpectrum(0, TableDatasetIndex{0}).get(), 0);
     TS_ASSERT_EQUALS(m_model->getEISFSpectrum(1, TableDatasetIndex{0}).get(), 3);
   }
 
   void test_that_setActiveWidth_will_replace_spectrum_in_single_mode() {
-    FunctionModelSpectra const spectra = FunctionModelSpectra("0-1");
-    addWorkspacesToModel(spectra, m_workspace);
+    addWorkspacesToModel(m_workspace);
 
     m_model->setActiveWidth(0, TableDatasetIndex{0}, true);
     TS_ASSERT_EQUALS(m_model->getSpectra(TableDatasetIndex{0}).size(), 1);
@@ -234,8 +182,7 @@ public:
   }
 
   void test_that_setActiveWidth_will_append_spectrum_in_multiple_mode() {
-    FunctionModelSpectra const spectra = FunctionModelSpectra("0-1");
-    addWorkspacesToModel(spectra, m_workspace);
+    addWorkspacesToModel(m_workspace);
 
     m_model->setActiveWidth(0, TableDatasetIndex{0}, false);
     TS_ASSERT_EQUALS(m_model->getSpectra(TableDatasetIndex{0}).size(), 1);
@@ -248,10 +195,9 @@ public:
   }
 
   void test_that_setActiveWidth_will_add_separate_spectrum() {
-    FunctionModelSpectra const spectra = FunctionModelSpectra("0-1");
     auto const workspace2 = createWorkspaceWithTextAxis(4, getParameterLabels());
     m_ads->addOrReplace("Name2", workspace2);
-    addWorkspacesToModel(spectra, m_workspace, workspace2);
+    addWorkspacesToModel(m_workspace, workspace2);
 
     m_model->setActiveWidth(0, TableDatasetIndex{0}, true);
     TS_ASSERT_EQUALS(m_model->getSpectra(TableDatasetIndex{0}).size(), 1);
@@ -265,8 +211,7 @@ public:
   }
 
   void test_that_setActiveEISF_will_replace_spectrum_in_single_mode() {
-    FunctionModelSpectra const spectra = FunctionModelSpectra("0-1");
-    addWorkspacesToModel(spectra, m_workspace);
+    addWorkspacesToModel(m_workspace);
 
     m_model->setActiveEISF(0, TableDatasetIndex{0}, true);
     TS_ASSERT_EQUALS(m_model->getSpectra(TableDatasetIndex{0}).size(), 1);
@@ -278,8 +223,7 @@ public:
   }
 
   void test_that_setActiveEISF_will_append_spectrum_in_multiple_mode() {
-    FunctionModelSpectra const spectra = FunctionModelSpectra("0-1");
-    addWorkspacesToModel(spectra, m_workspace);
+    addWorkspacesToModel(m_workspace);
 
     m_model->setActiveEISF(0, TableDatasetIndex{0}, false);
     TS_ASSERT_EQUALS(m_model->getSpectra(TableDatasetIndex{0}).size(), 1);
@@ -292,10 +236,9 @@ public:
   }
 
   void test_that_setActiveEISF_will_add_separate_spectrum() {
-    FunctionModelSpectra const spectra = FunctionModelSpectra("0-1");
     auto const workspace2 = createWorkspaceWithTextAxis(4, getParameterLabels());
     m_ads->addOrReplace("Name2", workspace2);
-    addWorkspacesToModel(spectra, m_workspace, workspace2);
+    addWorkspacesToModel(m_workspace, workspace2);
 
     m_model->setActiveEISF(0, TableDatasetIndex{0}, true);
     TS_ASSERT_EQUALS(m_model->getSpectra(TableDatasetIndex{0}).size(), 1);
@@ -311,15 +254,12 @@ public:
 
 private:
   template <typename Workspace, typename... Workspaces>
-  void addWorkspacesToModel(FunctionModelSpectra const &spectra, Workspace const &workspace,
-                            Workspaces const &...workspaces) {
+  void addWorkspacesToModel(Workspace const &workspace, Workspaces const &...workspaces) {
     m_model->addWorkspace(workspace->getName());
-    addWorkspacesToModel(spectra, workspaces...);
+    addWorkspacesToModel(workspaces...);
   }
 
-  void addWorkspacesToModel(FunctionModelSpectra const &, MatrixWorkspace_sptr const &workspace) {
-    m_model->addWorkspace(workspace->getName());
-  }
+  void addWorkspacesToModel(MatrixWorkspace_sptr const &workspace) { m_model->addWorkspace(workspace->getName()); }
 
   MatrixWorkspace_sptr m_workspace;
   std::unique_ptr<SetUpADSWithWorkspace> m_ads;


### PR DESCRIPTION
**Description of work.**
This PR fixes a crash in FQFit when loading data that has no EISF parameter.

**To test:**
1. Indirect Data Analysis interface
2. Go to FQFit tab
3. Load the data below. It might take a while to load, but it should not crash.
4. Choose any fit function and click `Run`
5. You should see a fit in the plot when it is finished fitting.
[irs26176_graphite002_red_Conv_seq_2L_0-50__Result.zip](https://github.com/mantidproject/mantid/files/6390047/irs26176_graphite002_red_Conv_seq_2L_0-50__Result.zip)

Fixes #31247

*This does not require release notes* because **it is a regression since last release introduced in #31089**

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
