### PR TITLE
Get home limits from full extent of SamplingImage if sliceviewer plotting a matrix workspace

### DIFF
--- a/docs/source/release/v6.1.0/framework.rst
+++ b/docs/source/release/v6.1.0/framework.rst
@@ -68,6 +68,7 @@ Improvements
 Bugfixes
 ########
 
+- Axes limits correctly reset when home clicked on sliceviewer plot of ragged matrix workspace.
 - Fix problem with dictionary parameters on :ref:`SetSample <algm-SetSample>` algorithm when running from the algorithm dialog
 - Fix segmentation fault when running :ref:`MonteCarloAbsorption <algm-MonteCarloAbsorption>` algorithm on Ubuntu without a material defined on one of the sample\environment shapes
 - Fix calculation of region where scattering points are sampled in :ref:`MonteCarloAbsorption <algm-MonteCarloAbsorption>` when a shape is defined for the environment but not the sample

--- a/qt/python/mantidqt/widgets/sliceviewer/model.py
+++ b/qt/python/mantidqt/widgets/sliceviewer/model.py
@@ -194,6 +194,12 @@ class SliceViewerModel:
         xdim, ydim = workspace.getDimension(xindex), workspace.getDimension(yindex)
         return (xdim.getMinimum(), xdim.getMaximum()), (ydim.getMinimum(), ydim.getMaximum())
 
+    def is_ragged_matrix_plotted(self):
+        """
+        :return: bool for if workspace is matrix workspace with non common bins
+        """
+        return self.get_ws_type() == WS_TYPE.MATRIX and not self._get_ws().isCommonBins()
+
     def get_dim_info(self, n: int) -> dict:
         """
         returns dict of (minimum :float, maximum :float, number_of_bins :int,

--- a/qt/python/mantidqt/widgets/sliceviewer/presenter.py
+++ b/qt/python/mantidqt/widgets/sliceviewer/presenter.py
@@ -199,8 +199,14 @@ class SliceViewer(ObservingPresenter):
 
     def show_all_data_requested(self):
         """Instructs the view to show all data"""
-        self.set_axes_limits(*self.model.get_dim_limits(self.get_slicepoint(),
-                                                        self.view.data_view.dimensions.transpose))
+        if self.model.is_ragged_matrix_plotted():
+            # get limits from full extent of image (which was calculated by looping over all spectra excl. monitors)
+            x0, x1, y0, y1 = self.view.data_view.get_full_extent()
+            limits = ((x0, x1), (y0, y1))
+        else:
+            # otherwise query data model based on slice info and transpose
+            limits = self.model.get_dim_limits(self.get_slicepoint(), self.view.data_view.dimensions.transpose)
+        self.set_axes_limits(*limits)
 
     def set_axes_limits(self, xlim, ylim, auto_transform=True):
         """Set the axes limits on the view.

--- a/qt/python/mantidqt/widgets/sliceviewer/view.py
+++ b/qt/python/mantidqt/widgets/sliceviewer/view.py
@@ -11,6 +11,7 @@ import sys
 # 3rd party imports
 
 import mantid.api
+from mantid.plots.resampling_image import samplingimage
 from mantid.plots.axesfunctions import _pcolormesh_nonortho as pcolormesh_nonorthogonal
 from mantid.plots.datafunctions import get_normalize_by_bin_width
 from matplotlib.figure import Figure
@@ -440,6 +441,16 @@ class SliceViewerDataView(QWidget):
             return None
         else:
             return self.ax.get_xlim(), self.ax.get_ylim()
+
+    def get_full_extent(self):
+        """
+        Return the full extent of image - only applicable for plots of matrix workspaces
+        """
+        if self.image and isinstance(self.image, samplingimage.SamplingImage):
+            return self.image.get_full_extent()
+        else:
+            return None
+
 
     def set_axes_limits(self, xlim, ylim):
         """


### PR DESCRIPTION
**Description of work.**

When plotting a ragged matrix workspace the extent of the data is determined by looping over all spectra (excl. monitors) and getting the min and max x-value. However when the home button is pressed in sliceviewer the limits were recalculated in the model based on `ws.getDimension(xindex).getMinimum()` and  `.getMaximum()` - which is determined from the extent of the first spectrum (if this is a monitor then this will get the TOF extent rather than e.g. the d-spacing so can be orders of magnitude out!).

This work checks to see if the plotted workspace is a ragged matrix workspace, if it is then it gets the limits from the full_extent of the image rather than determining it again from the workspace dimensions.

**To test:**

(1) Run this script (the run is part of system test data)

```
Load(Filename=r'SXD23767.raw', OutputWorkspace='SXD23767')
ConvertUnits(InputWorkspace='SXD23767', OutputWorkspace='SXD23767', Target='dSpacing')
```

(2) Plot workspace in sliceviewer
(3) Press the home button - the  limits should be unchanged
(4) Zoom in on a region and press home - the limits should return to the original limits
(5) Transpose the data and repeat steps (3-4)


<!-- Instructions for testing. -->

Fixes #31240


<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or master)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
