### PR TITLE
Indirect ISIS Diagnostics - Fix Missing RangeMarkers on plot

### DIFF
--- a/docs/source/release/v6.1.0/indirect_geometry.rst
+++ b/docs/source/release/v6.1.0/indirect_geometry.rst
@@ -28,4 +28,8 @@ Improvements
 ############
 - In Indirect Data Analysis F(Q) fit the default fitting function remains None when switching to EISF.
 
+Bug Fixes
+#########
+- Fixed a bug causing the x range markers on the ISISDiagnostics plot of Data Reduction to go missing.
+
 :ref:`Release 6.1.0 <v6.1.0>`

--- a/qt/scientific_interfaces/Indirect/IndirectTab.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectTab.cpp
@@ -364,7 +364,7 @@ void IndirectTab::setPlotPropertyRange(RangeSelector *rs, QtProperty *min, QtPro
   m_dblManager->setMaximum(min, bounds.second);
   m_dblManager->setMinimum(max, bounds.first);
   m_dblManager->setMaximum(max, bounds.second);
-  rs->setRange(bounds.first, bounds.second);
+  rs->setBounds(bounds.first, bounds.second);
 }
 
 /**


### PR DESCRIPTION
**Description of work.**
This PR fixes an issue where the x range markers on the plot of ISIS Diagnostics had gone missing. The markers were hiding at x=0 and were unmovable being the bounds of the `RangeMarker` class hadn't been set properly.

No tests added because this cannot be tested easily. Also the file in question (IndirectTab) has no tests because it is not MVP.

**To test:**
1. Indirect -> Data Reduction -> ISIS Diagnostics
2. Enter run number 26176 and click enter. Wait for it to load.
3. You should see a black range marker on the plot. This should be draggable and should mirror the values seen in the table next to the plot.
4. If you tick Use 2 Ranges, a second RangeMarker will appear (in green). This should also be draggable and its values change in the table.

Fixes #31249

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
