### PR TITLE
Fix workbench plot settings not being reproduced on project load

### DIFF
--- a/qt/python/mantidqt/project/plotsloader.py
+++ b/qt/python/mantidqt/project/plotsloader.py
@@ -295,6 +295,14 @@ class PlotsLoader(object):
             LegendProperties.create_legend(legend, ax)
 
     def update_properties(self, ax, properties):
+        # Support for additonal plot options accessible from general settings
+        if "tickParams" in properties.keys():
+            ax.xaxis.set_tick_params(which="major", **properties["tickParams"]["xaxis"]["major"])
+            ax.xaxis.set_tick_params(which="minor", **properties["tickParams"]["xaxis"]["minor"])
+
+            ax.yaxis.set_tick_params(which="major", **properties["tickParams"]["yaxis"]["major"])
+            ax.yaxis.set_tick_params(which="minor", **properties["tickParams"]["yaxis"]["minor"])
+
         if properties["bounds"]:
             ax.set_position(properties["bounds"])
         ax.set_navigate(properties["dynamic"])
@@ -322,18 +330,25 @@ class PlotsLoader(object):
         if "yAxisProperties" in properties:
             self.update_axis(ax.yaxis, properties["yAxisProperties"])
 
-    def update_axis(self, axis_, properties):
-        if isinstance(axis_, matplotlib.axis.XAxis):
-            if properties["position"] == "top":
-                axis_.tick_top()
-            else:
-                axis_.tick_bottom()
+        if 'spineWidths' in properties:
+            for (spine, width) in properties['spineWidths'].items():
+                ax.spines[spine].set_linewidth(width)
 
-        if isinstance(axis_, matplotlib.axis.YAxis):
-            if properties["position"] == "right":
-                axis_.tick_right()
-            else:
-                axis_.tick_left()
+    def update_axis(self, axis_, properties):
+        if "position" in properties.keys():
+            # Support for older .mtdproj files that did not include additional
+            # plot settings introduced in PR #30121
+            if isinstance(axis_, matplotlib.axis.XAxis):
+                if properties["position"] == "top":
+                    axis_.tick_top()
+                else:
+                    axis_.tick_bottom()
+
+            if isinstance(axis_, matplotlib.axis.YAxis):
+                if properties["position"] == "right":
+                    axis_.tick_right()
+                else:
+                    axis_.tick_left()
 
         labels = axis_.get_ticklabels()
         if properties["fontSize"] != "":

--- a/qt/python/mantidqt/project/plotssaver.py
+++ b/qt/python/mantidqt/project/plotssaver.py
@@ -158,7 +158,9 @@ class PlotsSaver(object):
                 "yAxisScale": ax.yaxis.get_scale(),
                 "yLim": ax.get_ylim(),
                 "yAutoScale": ax.get_autoscaley_on(),
-                "showMinorGrid": hasattr(ax, 'show_minor_gridlines') and ax.show_minor_gridlines}
+                "showMinorGrid": hasattr(ax, 'show_minor_gridlines') and ax.show_minor_gridlines,
+                "tickParams": self.get_dict_from_tick_properties(ax),
+                "spineWidths": self.get_dict_from_spine_widths(ax)}
 
     def get_dict_from_axis_properties(self, ax):
         prop_dict = {"majorTickLocator": type(ax.get_major_locator()).__name__,
@@ -167,19 +169,8 @@ class PlotsSaver(object):
                      "minorTickFormatter": type(ax.get_minor_formatter()).__name__,
                      "gridStyle": self.get_dict_for_grid_style(ax),
                      "visible": ax.get_visible()}
-        label1On = ax._major_tick_kw.get('label1On', True)
 
-        if isinstance(ax, matplotlib.axis.XAxis):
-            if label1On:
-                prop_dict["position"] = "Bottom"
-            else:
-                prop_dict["position"] = "Top"
-        elif isinstance(ax, matplotlib.axis.YAxis):
-            if label1On:
-                prop_dict["position"] = "Left"
-            else:
-                prop_dict["position"] = "Right"
-        else:
+        if not (isinstance(ax, matplotlib.axis.YAxis) or isinstance(ax, matplotlib.axis.XAxis)):
             raise ValueError("Value passed is not a valid axis")
 
         if isinstance(ax.get_major_locator(), ticker.FixedLocator):
@@ -283,3 +274,62 @@ class PlotsSaver(object):
     @staticmethod
     def get_dict_from_fig_properties(fig):
         return {"figWidth": fig.get_figwidth(), "figHeight": fig.get_figheight(), "dpi": fig.dpi}
+
+    @staticmethod
+    def get_dict_from_tick_properties(ax):
+        xaxis_major_kw = ax.xaxis._major_tick_kw
+        xaxis_minor_kw = ax.xaxis._minor_tick_kw
+
+        yaxis_major_kw = ax.yaxis._major_tick_kw
+        yaxis_minor_kw = ax.yaxis._minor_tick_kw
+
+        return {
+            "xaxis": {
+                "major": {
+                    "bottom": xaxis_major_kw['tick1On'],
+                    "top": xaxis_major_kw['tick2On'],
+                    "labelbottom": xaxis_major_kw['label1On'],
+                    "labeltop": xaxis_major_kw['label2On'],
+                    "direction": xaxis_major_kw['tickdir'],
+                    "width": xaxis_major_kw['width'],
+                    "size": xaxis_major_kw['size']
+                },
+                "minor": {
+                    "bottom": xaxis_minor_kw['tick1On'],
+                    "top": xaxis_minor_kw['tick2On'],
+                    "labelbottom": xaxis_minor_kw['label1On'],
+                    "labeltop": xaxis_minor_kw['label2On'],
+                    "direction": xaxis_minor_kw['tickdir'],
+                    "width": xaxis_minor_kw['width'],
+                    "size": xaxis_minor_kw['size']
+                },
+            },
+            "yaxis": {
+                "major": {
+                    "left": yaxis_major_kw['tick1On'],
+                    "right": yaxis_major_kw['tick2On'],
+                    "labelleft": yaxis_major_kw['label1On'],
+                    "labelright": yaxis_major_kw['label2On'],
+                    "direction": yaxis_major_kw['tickdir'],
+                    "width": yaxis_major_kw['width'],
+                    "size": yaxis_major_kw['size']
+                },
+                "minor": {
+                    "left": yaxis_minor_kw['tick1On'],
+                    "right": yaxis_minor_kw['tick2On'],
+                    "labelleft": yaxis_minor_kw['label1On'],
+                    "labelright": yaxis_minor_kw['label2On'],
+                    "direction": yaxis_minor_kw['tickdir'],
+                    "width": yaxis_minor_kw['width'],
+                    "size": yaxis_minor_kw['size']
+                },
+            }
+        }
+
+    @staticmethod
+    def get_dict_from_spine_widths(ax):
+        return {
+            'left': ax.spines['left']._linewidth,
+            'right': ax.spines['right']._linewidth,
+            'bottom': ax.spines['bottom']._linewidth,
+            'top': ax.spines['top']._linewidth}

--- a/qt/python/mantidqt/project/test/test_plotssaver.py
+++ b/qt/python/mantidqt/project/test/test_plotssaver.py
@@ -77,7 +77,6 @@ class PlotsSaverTest(unittest.TestCase):
                                                      u'minorTickFormatter': u'NullFormatter',
                                                      u'minorTickLocator': u'NullLocator',
                                                      u'minorTickLocatorValues': None,
-                                                     u'position': u'Bottom',
                                                      u'visible': True},
                                 u'xAxisScale': u'linear',
                                 u'xLim': (0.0, 1.0),u"xAutoScale":False,
@@ -91,11 +90,45 @@ class PlotsSaverTest(unittest.TestCase):
                                                      u'minorTickFormatter': u'NullFormatter',
                                                      u'minorTickLocator': u'NullLocator',
                                                      u'minorTickLocatorValues': None,
-                                                     u'position': u'Left',
                                                      u'visible': True},
                                 u'yAxisScale': u'linear',
                                 u'yLim': (0.0, 1.0),u"yAutoScale":False,
-                                u'showMinorGrid': False},
+                                u'showMinorGrid': False,
+                                u'tickParams': {
+                                    'xaxis': {
+                                        'major': {
+                                            'bottom': True,
+                                            'top': True,
+                                            'labelbottom': True,
+                                            'labeltop': True,
+                                            'direction': 'inout',
+                                            'width': 1,
+                                            'size': 6},
+                                        'minor': {
+                                            'bottom': True,
+                                            'top': True,
+                                            'labelbottom': True,
+                                            'labeltop': True,
+                                            'direction': 'inout',
+                                            'width': 1,
+                                            'size': 3}},
+                                    'yaxis': {
+                                        'major': {
+                                            'left': True,
+                                            'right': True,
+                                            'labelleft': True,
+                                            'labelright': True,
+                                            'direction': 'inout',
+                                            'width': 1, 'size': 6},
+                                        'minor': {
+                                            'left': True,
+                                            'right': True,
+                                            'labelleft': True,
+                                            'labelright': True,
+                                            'direction': 'inout',
+                                            'width': 1,
+                                            'size': 3}}},
+                                u'spineWidths': {'left': 0.4, 'right': 0.4, 'bottom': 0.4, 'top': 0.4}},
                 u'textFromArtists': {},
                 u'texts': [{u'position': (0, 0),
                             u'style': {u'alpha': 1,
@@ -158,6 +191,20 @@ class PlotsSaverTest(unittest.TestCase):
         expected_value = self.loader_plot_dict["axes"][0]["properties"]
 
         self.maxDiff = None
+        self.assertDictEqual(return_value, expected_value)
+
+    def test_get_dict_from_tick_properties(self):
+        return_value = self.plot_saver.get_dict_from_tick_properties(self.fig.axes[0])
+
+        expected_value = self.loader_plot_dict["axes"][0]["properties"]["tickParams"]
+
+        self.assertDictEqual(return_value, expected_value)
+
+    def test_get_dict_from_spine_widths(self):
+        return_value = self.plot_saver.get_dict_from_spine_widths(self.fig.axes[0])
+
+        expected_value = self.loader_plot_dict["axes"][0]["properties"]["spineWidths"]
+
         self.assertDictEqual(return_value, expected_value)
 
     def test_get_dict_from_axis_properties(self):


### PR DESCRIPTION
Adds support for saving and loading plots with the following plot options introduced by PR #30121:
- Major and Minor tick length, width, and direction
- Tick and label positions (any combination of the left, right, top, bottom sides of the plot)
- Axes spine widths.

Also ensures previous project files are still able to be loaded, as only certain tick positions were supported.

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

**To test:**
1. Change some of the plot settings in `File > Settings > Plots`, such as tick direction and length
2. Plot a workspace and save it as a project.
3. Close the plot
4. Open the project
5. Check the plot looks identical as before.

Also check nothing else is broken when loading plots during project load!
<!-- Instructions for testing. -->

Fixes #31253 

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
