### PR TITLE
Allow an empty Engineering Diffraction GUI instance to save

### DIFF
--- a/scripts/Engineering/gui/engineering_diffraction/engineering_diffraction_io.py
+++ b/scripts/Engineering/gui/engineering_diffraction/engineering_diffraction_io.py
@@ -61,36 +61,40 @@ class EngineeringDiffractionDecoder(EngineeringDiffractionUIAttributes):
         if obj_dic["encoder_version"] != IO_VERSION:
             logger.error("Engineering Diffraction Interface encoder used different version, restoration may fail")
 
-        ws_names = obj_dic["data_loaded_workspaces"]  # workspaces are in ADS, need restoring into interface
+        ws_names = obj_dic.get("data_loaded_workspaces", None)  # workspaces are in ADS, need restoring into interface
         gui = EngineeringDiffractionGui()
         presenter = gui.presenter
         gui.tabs.setCurrentIndex(obj_dic["current_tab"])
         presenter.settings_presenter.model.set_settings_dict(obj_dic["settings_dict"])
         presenter.settings_presenter.settings = obj_dic["settings_dict"]
-        fit_data_widget = presenter.fitting_presenter.data_widget
-        fit_data_widget.model._bg_params = obj_dic["background_params"]
-        fit_data_widget.model.restore_files(ws_names)
-        fit_data_widget.presenter.plotted = set(obj_dic["plotted_workspaces"])
-        fit_data_widget.presenter.restore_table()
+        if ws_names:
+            fit_data_widget = presenter.fitting_presenter.data_widget
+            fit_data_widget.model._bg_params = obj_dic["background_params"]
+            fit_data_widget.model.restore_files(ws_names)
+            fit_data_widget.presenter.plotted = set(obj_dic["plotted_workspaces"])
+            fit_data_widget.presenter.restore_table()
 
-        if obj_dic["fit_results"]:
-            fit_data_widget.model._fit_results = obj_dic["fit_results"]
-            fit_data_widget.model.create_fit_tables()
+            fit_results = obj_dic.get("fit_results", None)
+            if fit_results:
+                fit_data_widget.model._fit_results = fit_results
+                fit_data_widget.model.create_fit_tables()
 
-        if obj_dic["fit_properties"]:
-            fit_browser = presenter.fitting_presenter.plot_widget.view.fit_browser
-            fit_browser.show()  # show the fit browser, default is off
-            fit_props = obj_dic["fit_properties"]["properties"]
-            fit_function = fit_props["Function"]
-            output_name = fit_props["Output"]
-            is_plot_diff = obj_dic["plot_diff"]
-            fit_browser.setWorkspaceName(output_name)
-            fit_browser.setStartX(fit_props["StartX"])
-            fit_browser.setEndX(fit_props["EndX"])
-            fit_browser.loadFunction(fit_function)
-            fit_browser.setOutputName(output_name)
-            ws_name = output_name + '_Workspace'
-            fit_browser.do_plot(ADS.retrieve(ws_name), is_plot_diff)
+            fit_properties = obj_dic.get("fit_properties", None)
+            if fit_properties:
+                fit_browser = presenter.fitting_presenter.plot_widget.view.fit_browser
+                fit_browser.show()  # show the fit browser, default is off
+                presenter.fitting_presenter.plot_widget.view.fit_toggle()  # show the fit browser, default is off
+                fit_props = fit_properties["properties"]
+                fit_function = fit_props["Function"]
+                output_name = fit_props["Output"]
+                is_plot_diff = obj_dic["plot_diff"]
+                fit_browser.setWorkspaceName(output_name)
+                fit_browser.setStartX(fit_props["StartX"])
+                fit_browser.setEndX(fit_props["EndX"])
+                fit_browser.loadFunction(fit_function)
+                fit_browser.setOutputName(output_name)
+                ws_name = output_name + '_Workspace'
+                fit_browser.do_plot(ADS.retrieve(ws_name), is_plot_diff)
         return gui
 
     @classmethod

--- a/scripts/Engineering/gui/engineering_diffraction/engineering_diffraction_io.py
+++ b/scripts/Engineering/gui/engineering_diffraction/engineering_diffraction_io.py
@@ -67,7 +67,7 @@ class EngineeringDiffractionDecoder(EngineeringDiffractionUIAttributes):
         gui.tabs.setCurrentIndex(obj_dic["current_tab"])
         presenter.settings_presenter.model.set_settings_dict(obj_dic["settings_dict"])
         presenter.settings_presenter.settings = obj_dic["settings_dict"]
-        if ws_names:
+        if ws_names is not None:
             fit_data_widget = presenter.fitting_presenter.data_widget
             fit_data_widget.model._bg_params = obj_dic["background_params"]
             fit_data_widget.model.restore_files(ws_names)
@@ -75,12 +75,12 @@ class EngineeringDiffractionDecoder(EngineeringDiffractionUIAttributes):
             fit_data_widget.presenter.restore_table()
 
             fit_results = obj_dic.get("fit_results", None)
-            if fit_results:
+            if fit_results is not None:
                 fit_data_widget.model._fit_results = fit_results
                 fit_data_widget.model.create_fit_tables()
 
             fit_properties = obj_dic.get("fit_properties", None)
-            if fit_properties:
+            if fit_properties is not None:
                 fit_browser = presenter.fitting_presenter.plot_widget.view.fit_browser
                 fit_browser.show()  # show the fit browser, default is off
                 presenter.fitting_presenter.plot_widget.view.fit_toggle()  # show the fit browser, default is off

--- a/scripts/Engineering/gui/engineering_diffraction/test/engineering_diffraction_io_test.py
+++ b/scripts/Engineering/gui/engineering_diffraction/test/engineering_diffraction_io_test.py
@@ -88,7 +88,6 @@ class EngineeringDiffractionEncoderTest(unittest.TestCase):
         self.mock_tabs.currentIndex.return_value = 0
         self.encoder = EngineeringDiffractionEncoder()
         self.decoder = EngineeringDiffractionDecoder()
-        self.io_version = 1
         self.fit_ws = None
 
     def create_test_focus_presenter(self):
@@ -122,27 +121,27 @@ class EngineeringDiffractionEncoderTest(unittest.TestCase):
     def test_blank_gui_encodes(self):
         self.mock_tabs.currentIndex.return_value = 0
         test_dic = self.encoder.encode(self.mock_view)
-        self.assertEqual({'encoder_version': self.io_version, 'current_tab': 0, 'settings_dict': SETTINGS_DICT},
+        self.assertEqual({'encoder_version': IO_VERSION, 'current_tab': 0, 'settings_dict': SETTINGS_DICT},
                          test_dic)
 
     def test_loaded_workspaces_encode(self):
         self.presenter.fitting_presenter.data_widget.presenter.model.load_files(TEST_FILE, 'TOF')
         self.fitprop_browser.read_current_fitprop.return_value = None
         test_dic = self.encoder.encode(self.mock_view)
-        self.assertEqual({'encoder_version': self.io_version, 'current_tab': 0, 'data_loaded_workspaces':
-                          [TEST_WS], 'plotted_workspaces': [], 'fit_properties': None, 'fit_results': {},
-                          'settings_dict': SETTINGS_DICT, 'background_params':
-                              {'ENGINX_277208_focused_bank_2_TOF': []}}, test_dic)
+        self.assertEqual({'encoder_version': IO_VERSION, 'current_tab': 0, 'data_loaded_workspaces':
+                         [TEST_WS], 'plotted_workspaces': [], 'fit_properties': None, 'fit_results': {},
+                          'settings_dict': SETTINGS_DICT, 'background_params': {'ENGINX_277208_focused_bank_2_TOF': []}}
+                         , test_dic)
 
     def test_background_params_encode(self):
         self.presenter.fitting_presenter.data_widget.presenter.model.load_files(TEST_FILE, 'TOF')
         self.fitprop_browser.read_current_fitprop.return_value = None
         self.presenter.fitting_presenter.data_widget.model._bg_params = {TEST_WS: [True, 70, 4000, True]}
         test_dic = self.encoder.encode(self.mock_view)
-        self.assertEqual({'encoder_version': self.io_version, 'current_tab': 0, 'data_loaded_workspaces':
-                          [TEST_WS], 'plotted_workspaces': [], 'fit_properties': None, 'fit_results': {},
-                          'settings_dict': SETTINGS_DICT,
-                          'background_params': {TEST_WS: [True, 70, 4000, True]}}, test_dic)
+        self.assertEqual({'encoder_version': IO_VERSION, 'current_tab': 0, 'data_loaded_workspaces':
+                         [TEST_WS], 'plotted_workspaces': [], 'fit_properties': None, 'fit_results': {},
+                          'settings_dict': SETTINGS_DICT, 'background_params': {TEST_WS: [True, 70, 4000, True]}},
+                         test_dic)
 
     def test_fits_encode(self):
         self.presenter.fitting_presenter.data_widget.presenter.model.load_files(TEST_FILE, 'TOF')
@@ -151,10 +150,10 @@ class EngineeringDiffractionEncoderTest(unittest.TestCase):
         self.fitprop_browser.plotDiff.return_value = True
         self.presenter.fitting_presenter.data_widget.presenter.plotted = {FIT_WS}
         test_dic = self.encoder.encode(self.mock_view)
-        self.assertEqual({'encoder_version': self.io_version, 'current_tab': 0, 'data_loaded_workspaces':
-                          [TEST_WS], 'plotted_workspaces': [FIT_WS], 'fit_properties': FIT_DICT,
-                          'fit_results': FIT_RESULTS, 'plot_diff': 'True', 'settings_dict': SETTINGS_DICT,
-                          'background_params': {'ENGINX_277208_focused_bank_2_TOF': []}}, test_dic)
+        self.assertEqual({'encoder_version': IO_VERSION, 'current_tab': 0, 'data_loaded_workspaces':
+                          [TEST_WS], 'plotted_workspaces': [FIT_WS], 'fit_properties': FIT_DICT, 'fit_results':
+                          FIT_RESULTS, 'plot_diff': 'True', 'settings_dict': SETTINGS_DICT, 'background_params': {
+                                'ENGINX_277208_focused_bank_2_TOF': []}}, test_dic)
 
 
 @start_qapplication
@@ -165,6 +164,11 @@ class EngineeringDiffractionDecoderTest(unittest.TestCase):
         self.decoder = EngineeringDiffractionDecoder()
         _load_test_file()
         _create_fit_workspace()
+
+    def test_blank_gui_decodes(self):
+        blank_dict = {'encoder_version': IO_VERSION, 'current_tab': 0, 'settings_dict': SETTINGS_DICT}
+        self.gui = self.decoder.decode(blank_dict)
+        self.assertEqual(blank_dict, self.encoder.encode(self.gui))
 
     def test_decode_produces_gui_returning_same_dict(self):
         self.gui = self.decoder.decode(ENCODED_DICT)


### PR DESCRIPTION
**Description of work.**

Fixes a bug where the gui would not save if no workspaces had been loaded in the fitting tab

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

**To test:**

1. Open up Engineering Diffraction
2. Do nothing
3. Save the project
4. Try to open it again, confirm the same empty gui loads

*There is no associated issue.*


*This does not require release notes* because **it is a very minor bug introduced this release**


<!-- Ensure the base of this PR is correct (e.g. release-next or master)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
