### PR TITLE
Fix problem with spectrum axis when panning on colour fill plots

### DIFF
--- a/Framework/PythonInterface/mantid/plots/datafunctions.py
+++ b/Framework/PythonInterface/mantid/plots/datafunctions.py
@@ -545,7 +545,7 @@ def _workspace_indices(y_bins, workspace):
             workspace_index = workspace.getAxis(1).indexOfValue(y)
             workspace_indices.append(workspace_index)
         except IndexError:
-            continue
+            workspace_indices.append(-1)
     return workspace_indices
 
 
@@ -560,7 +560,7 @@ def _workspace_indices_maxpooling(y_bins, workspace):
             workspace_index = workspace_range[np.argmax(summed_spectra[workspace_range])]
             workspace_indices.append(workspace_index)
         except IndexError:
-            continue
+            workspace_indices.append(-1)
     return workspace_indices
 
 
@@ -585,6 +585,9 @@ def interpolate_y_data(workspace, x, y, normalize_by_bin_width, spectrum_info=No
     index = -1
     for workspace_index in workspace_indices:
         index += 1
+        # if workspace axis is beyond limits carry on
+        if workspace_index == -1:
+            continue
         # avoid repeating calculations
         if previous_index == workspace_index:
             counts[index, :] = counts[index - 1]

--- a/Framework/PythonInterface/test/python/mantid/plots/datafunctionsTest.py
+++ b/Framework/PythonInterface/test/python/mantid/plots/datafunctionsTest.py
@@ -472,10 +472,11 @@ class DataFunctionsTest(unittest.TestCase):
                                              extent=[2, 6, -5, 9], xbins=8, ybins=5)
         np.testing.assert_allclose(x, np.array([2, 2.5, 3, 3.5, 4, 4.5, 5, 5.5, 6]))
         np.testing.assert_allclose(y, np.array([-5, -1.5, 2, 5.5, 9]))
-        allmasked = np.ma.array(np.full((8),np.inf), mask=[1]*8)
         # first z array is off the spectrum axis scale so should be masked
-        np.testing.assert_array_equal(z[0], allmasked)
-        np.testing.assert_array_equal(z[4], [2.0]*8)
+        np.testing.assert_array_equal(z[0].data, [np.nan]*8)
+        np.testing.assert_array_equal(z[0].mask, [1] * 8)
+        np.testing.assert_array_equal(z[4].data, [2.0]*8)
+        np.testing.assert_array_equal(z[4].mask, [0] * 8)
 
     def test_get_matrix_2d_ragged_when_transpose_is_true(self):
         x, y, z_transposed = funcs.get_matrix_2d_ragged(self.ws2d_histo_rag, False, histogram2D=True,

--- a/Framework/PythonInterface/test/python/mantid/plots/datafunctionsTest.py
+++ b/Framework/PythonInterface/test/python/mantid/plots/datafunctionsTest.py
@@ -468,6 +468,15 @@ class DataFunctionsTest(unittest.TestCase):
         np.testing.assert_allclose(x, np.array([2, 2.5, 3, 3.5, 4, 4.5, 5, 5.5, 6]))
         np.testing.assert_allclose(y, np.array([5, 6, 7, 8, 9]))
 
+        x, y, z = funcs.get_matrix_2d_ragged(self.ws2d_histo_rag, False, histogram2D=True,
+                                             extent=[2, 6, -5, 9], xbins=8, ybins=5)
+        np.testing.assert_allclose(x, np.array([2, 2.5, 3, 3.5, 4, 4.5, 5, 5.5, 6]))
+        np.testing.assert_allclose(y, np.array([-5, -1.5, 2, 5.5, 9]))
+        allmasked = np.ma.array(np.full((8),np.inf), mask=[1]*8)
+        # first z array is off the spectrum axis scale so should be masked
+        np.testing.assert_array_equal(z[0], allmasked)
+        np.testing.assert_array_equal(z[4], [2.0]*8)
+
     def test_get_matrix_2d_ragged_when_transpose_is_true(self):
         x, y, z_transposed = funcs.get_matrix_2d_ragged(self.ws2d_histo_rag, False, histogram2D=True,
                                                         extent=[5, 9, 2, 6], xbins=8, ybins=5, transpose=True)

--- a/docs/source/release/v6.1.0/mantidworkbench.rst
+++ b/docs/source/release/v6.1.0/mantidworkbench.rst
@@ -46,6 +46,7 @@ Bugfixes
 - On the instrument widget pick tab, when the integration range is changed the current tool will stay selected.
 - Fixed a bug where Workbench would hang on startup when running on Big Sur.
 - Fixed a bug applying constraints with the conjugate gradient minimizer.
+- Fixed a bug where panning on a colour fill plot stretches dataset along spectrum axis instead of panning
 
 Interfaces
 ----------


### PR DESCRIPTION
**Description of work.**

When panning along the spectrum axis on a colour fill plot the data was being stretched instead of panning. If you now pan beyond the spectrum axis limits (eg to negative spectrum values) you see white\blank which is the same as happens if you pan beyond the x axis limits

**To test:**

See test on the linked issue

Fixes #31266, fixes #30677


<!-- Ensure the base of this PR is correct (e.g. release-next or master)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
