### PR TITLE
Add keyword argument to TransformHKL to skip optimization

### DIFF
--- a/Framework/Crystal/src/TransformHKL.cpp
+++ b/Framework/Crystal/src/TransformHKL.cpp
@@ -66,7 +66,6 @@ void TransformHKL::init() {
 
   this->declareProperty(std::make_unique<PropertyWithValue<double>>("AverageError", 0.0, Direction::Output),
                         "Gets set with the average HKL indexing error.");
-
 }
 
 /** Execute the algorithm.
@@ -121,8 +120,7 @@ void TransformHKL::exec() {
   if (redetermine_error) {
     SelectCellWithForm::DetermineErrors(sigabc, UB, ws, tolerance);
     o_lattice.setError(sigabc[0], sigabc[1], sigabc[2], sigabc[3], sigabc[4], sigabc[5]);
-  }
-  else {
+  } else {
     o_lattice.setError(0, 0, 0, 0, 0, 0);
   }
 

--- a/Framework/Crystal/test/TransformHKLTest.h
+++ b/Framework/Crystal/test/TransformHKLTest.h
@@ -169,11 +169,13 @@ public:
     TS_ASSERT_EQUALS(ws->getPeak(1).getHKL(), V3D(2, 0, 0))
     TS_ASSERT_EQUALS(ws->getPeak(2).getHKL(), V3D(0, 0, -3))
 
-    TS_ASSERT_EQUALS(lattice.errora(), 0.0)
-    TS_ASSERT_EQUALS(lattice.errorb(), 0.0)
-    TS_ASSERT_EQUALS(lattice.errorc(), 0.0)
-    TS_ASSERT_EQUALS(lattice.erroralpha(), 0.0)
-    TS_ASSERT_EQUALS(lattice.errorbeta(), 0.0)
-    TS_ASSERT_EQUALS(lattice.errorgamma(), 0.0)
+    auto lat = ws->sample().getOrientedLattice();
+
+    TS_ASSERT_DELTA(lat.errora(), 0.0, 1e-6)
+    TS_ASSERT_DELTA(lat.errorb(), 0.0, 1e-6)
+    TS_ASSERT_DELTA(lat.errorc(), 0.0, 1e-6)
+    TS_ASSERT_DELTA(lat.erroralpha(), 0.0, 1e-6)
+    TS_ASSERT_DELTA(lat.errorbeta(), 0.0, 1e-6)
+    TS_ASSERT_DELTA(lat.errorgamma(), 0.0, 1e-6)
   }
 };

--- a/Framework/Crystal/test/TransformHKLTest.h
+++ b/Framework/Crystal/test/TransformHKLTest.h
@@ -147,8 +147,7 @@ public:
     AnalysisDataService::Instance().addOrReplace("ws", ws);
     auto lattice = std::make_unique<Mantid::Geometry::OrientedLattice>(5, 6, 7, 90, 90, 120);
     ws->mutableSample().setOrientedLattice(std::move(lattice));
-    ws->addPeak(V3D(1, 0, 0), SpecialCoordinateSystem::HKL);
-    ws->addPeak(V3D(0, 2, 0), SpecialCoordinateSystem::HKL);
+    ws->addPeak(V3D(1, 2, 0), SpecialCoordinateSystem::HKL);
     ws->addPeak(V3D(0, 0, 3), SpecialCoordinateSystem::HKL);
 
     TransformHKL alg;
@@ -165,9 +164,8 @@ public:
     TS_ASSERT_THROWS_NOTHING(alg.execute(););
     TS_ASSERT(alg.isExecuted());
 
-    TS_ASSERT_EQUALS(ws->getPeak(0).getHKL(), V3D(0, 1, 0))
-    TS_ASSERT_EQUALS(ws->getPeak(1).getHKL(), V3D(2, 0, 0))
-    TS_ASSERT_EQUALS(ws->getPeak(2).getHKL(), V3D(0, 0, -3))
+    TS_ASSERT_EQUALS(ws->getPeak(0).getHKL(), V3D(2, 1, 0))
+    TS_ASSERT_EQUALS(ws->getPeak(1).getHKL(), V3D(0, 0, -3))
 
     auto lat = ws->sample().getOrientedLattice();
 

--- a/Framework/Crystal/test/TransformHKLTest.h
+++ b/Framework/Crystal/test/TransformHKLTest.h
@@ -158,7 +158,7 @@ public:
     TS_ASSERT_THROWS_NOTHING(alg.setPropertyValue("Tolerance", "0.1"));
 
     // skip error calculation for lattice parameters
-    TS_ASSERT_THROWS_NOTHING(alg.setPropertyValue("FindError", false));
+    TS_ASSERT_THROWS_NOTHING(alg.setProperty("FindError", false));
 
     // specify a matrix that will swap H and K and negate L
     TS_ASSERT_THROWS_NOTHING(alg.setPropertyValue("HKLTransform", "0,1,0,1,0,0,0,0,-1"));

--- a/Framework/Crystal/test/TransformHKLTest.h
+++ b/Framework/Crystal/test/TransformHKLTest.h
@@ -141,4 +141,39 @@ public:
     TS_ASSERT_EQUALS(ws->getPeak(1).getHKL(), V3D(2, 0, 0))
     TS_ASSERT_EQUALS(ws->getPeak(2).getHKL(), V3D(0, 0, -3))
   }
+
+  void test_exec_skip_FindError() {
+    auto ws = std::make_shared<LeanElasticPeaksWorkspace>();
+    AnalysisDataService::Instance().addOrReplace("ws", ws);
+    auto lattice = std::make_unique<Mantid::Geometry::OrientedLattice>(5, 6, 7, 90, 90, 120);
+    ws->mutableSample().setOrientedLattice(std::move(lattice));
+    ws->addPeak(V3D(1, 0, 0), SpecialCoordinateSystem::HKL);
+    ws->addPeak(V3D(0, 2, 0), SpecialCoordinateSystem::HKL);
+    ws->addPeak(V3D(0, 0, 3), SpecialCoordinateSystem::HKL);
+
+    TransformHKL alg;
+    TS_ASSERT_THROWS_NOTHING(alg.initialize())
+    TS_ASSERT(alg.isInitialized())
+    TS_ASSERT_THROWS_NOTHING(alg.setPropertyValue("PeaksWorkspace", "ws"));
+    TS_ASSERT_THROWS_NOTHING(alg.setPropertyValue("Tolerance", "0.1"));
+
+    // skip error calculation for lattice parameters
+    TS_ASSERT_THROWS_NOTHING(alg.setPropertyValue("FindError", false));
+
+    // specify a matrix that will swap H and K and negate L
+    TS_ASSERT_THROWS_NOTHING(alg.setPropertyValue("HKLTransform", "0,1,0,1,0,0,0,0,-1"));
+    TS_ASSERT_THROWS_NOTHING(alg.execute(););
+    TS_ASSERT(alg.isExecuted());
+
+    TS_ASSERT_EQUALS(ws->getPeak(0).getHKL(), V3D(0, 1, 0))
+    TS_ASSERT_EQUALS(ws->getPeak(1).getHKL(), V3D(2, 0, 0))
+    TS_ASSERT_EQUALS(ws->getPeak(2).getHKL(), V3D(0, 0, -3))
+
+    TS_ASSERT_EQUALS(lattice.errora(), 0.0)
+    TS_ASSERT_EQUALS(lattice.errorb(), 0.0)
+    TS_ASSERT_EQUALS(lattice.errorc(), 0.0)
+    TS_ASSERT_EQUALS(lattice.erroralpha(), 0.0)
+    TS_ASSERT_EQUALS(lattice.errorbeta(), 0.0)
+    TS_ASSERT_EQUALS(lattice.errorgamma(), 0.0)
+  }
 };

--- a/docs/source/algorithms/TransformHKL-v1.rst
+++ b/docs/source/algorithms/TransformHKL-v1.rst
@@ -56,7 +56,7 @@ Output:
 
 **Example - skipping error calculation**
 
-In special cases, users may not have enough peaks to find the error. 
+In special cases, users may not have enough peaks to find the error.
 For example, if peaks are constrained to two dimensions in HKL space,
 the error calculation will fail. In this case, `FindError=False` can be
 specified to skip the calculation. In this case, the lattice parameter

--- a/docs/source/algorithms/TransformHKL-v1.rst
+++ b/docs/source/algorithms/TransformHKL-v1.rst
@@ -15,7 +15,7 @@ change :math:`UB` to :math:`UBM^{-1}` and map each :math:`(HKL)` vector to :math
 For example, the transformation with elements 0,1,0,1,0,0,0,0,-1 will
 interchange the :math:`H` and :math:`K` values and negate :math:`L`.
 This algorithm should allow
-the usr to perform any required transformation of the Miller indices,
+the user to perform any required transformation of the Miller indices,
 provided that transformation has a positive determinant. If a transformation
 with a negative or zero determinant is entered, the algorithm with throw an
 exception. The 9 elements of the transformation must be specified as a
@@ -54,6 +54,48 @@ Output:
      [ 0.00178069 -0.11654506  0.00458823]
      [-0.08973552 -0.02737294  0.02525994]]
 
+**Example - skipping error calculation**
+
+In special cases, users may not have enough peaks to find the error. 
+For example, if peaks are constrained to two dimensions in HKL space,
+the error calculation will fail. In this case, `FindError=False` can be
+specified to skip the calculation. In this case, the lattice parameter
+error will be set to zero.
+
+.. code-block:: python
+
+    ws = CreatePeaksWorkspace(OutputType='LeanElasticPeak', NumberOfPeaks=0)
+
+    SetUB(ws, 5, 6, 7, 90, 90, 120)
+
+    ws.addPeak(ws.createPeakHKL([1, 2, 0]))
+    ws.addPeak(ws.createPeakHKL([0, 0, 3]))
+
+    TransformHKL(ws, tolerance=0.15, HKLTransform='0,1,0,1,0,0,0,0,-1', FindError=False)
+
+    print('peak(0) = ', ws.getPeak(0).getHKL())
+    print('peak(1) = ', ws.getPeak(1).getHKL())
+
+    ol = ws.sample().getOrientedLattice()
+    print('ea = ', ol.errora())
+    print('eb = ', ol.errorb())
+    print('ec = ', ol.errorc())
+    print('ealpha = ', ol.erroralpha())
+    print('ebeta = ', ol.errorbeta())
+    print('egamma = ', ol.errorgamma())
+
+gives
+
+.. code-block:: text
+
+    peak(0) =  [2,1,0]
+    peak(1) =  [0,0,-3]
+    ea =  0.0
+    eb =  0.0
+    ec =  0.0
+    ealpha =  0.0
+    ebeta =  0.0
+    egamma =  0.0
 
 .. categories::
 

--- a/docs/source/release/v6.1.0/diffraction.rst
+++ b/docs/source/release/v6.1.0/diffraction.rst
@@ -68,6 +68,7 @@ Single Crystal Diffraction
 - :ref:`IntegratePeaksMD <algm-IntegratePeaksMD>` has option to determine ellipsoid covariance iteratively and to use the estimated standard deviation rather than scale the major axis of the ellipsoid to the spherical radius.
 - :ref:`ConvertHFIRSCDtoMDE <algm-ConvertHFIRSCDtoMDE>` has new geometrical correction factor `ObliquityParallaxCoefficient` for shift in vertical beam position due to wide beam.
 - :ref:`ConvertWANDSCDtoQ <algm-ConvertWANDSCDtoQ>` has new geometrical correction factor `ObliquityParallaxCoefficient` for shift in vertical beam position due to wide beam.
+- :ref:`TransformHKL <algm-TransformHKL>` has new keyword argument `FindError` allowing the lattice parameter error calculation to be skipped. This can be used to transform HKL of a peaks workspace without enough peaks to do an optimization so they are simply set to zero.
 
 Improvements
 ############


### PR DESCRIPTION
**Description of work.**

This addresses issue [SCD151](https://code.ornl.gov/sns-hfir-scse/diffraction/single-crystal/single-crystal-diffraction/-/issues/151).

This work is to add a keyword argument to TransformHKL algorithm to skip the error calculation for the lattice parameters. The errors are determined with `SelectCellWithForm::DetermineErrors` which does a UB optimization to determine the errors. On some beamlines, there are not enough peaks to optimize a UB so the algorithm will fail. By skipping this step and setting the error to zero, the beamline users should be able to perform a transform.

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

**To test:**
```python
# import mantid algorithms, numpy and matplotlib
from mantid.simpleapi import *
import matplotlib.pyplot as plt
import numpy as np

#LoadEmptyInstrument(InstrumentName='TOPAZ', OutputWorkspace='topaz')
#ws = CreatePeaksWorkspace(InstrumentWorkspace='topaz', NumberOfPeaks=0)

ws = CreatePeaksWorkspace(OutputType='LeanElasticPeak', NumberOfPeaks=0)

SetUB(ws, 5, 6, 7, 90, 90, 120)

ws.addPeak(ws.createPeakHKL([1, 0, 0]))
ws.addPeak(ws.createPeakHKL([0, 2, 0]))
ws.addPeak(ws.createPeakHKL([0, 0, 3]))

TransformHKL(ws, tolerance=0.15, HKLTransform="0,1,0,1,0,0,0,0,-1", FindError=False)

ol = ws.sample().getOrientedLattice()
print('da = ', ol.errora())
print('db = ', ol.errorb())
print('dc = ', ol.errorc())
print('dalpha = ', ol.erroralpha())
print('dbeta = ', ol.errorbeta())
print('dgamma = ', ol.errorgamma())

TransformHKL(ws, tolerance=0.15, HKLTransform="0,1,0,1,0,0,0,0,-1", FindError=True)

ol = ws.sample().getOrientedLattice()
print('da = ', ol.errora())
print('db = ', ol.errorb())
print('dc = ', ol.errorc())
print('dalpha = ', ol.erroralpha())
print('dbeta = ', ol.errorbeta())
print('dgamma = ', ol.errorgamma())
```

The first call should result in all zeros output for the lattice parameter errors. This is not the case of the second where `FindError=True`

<!-- Instructions for testing. -->

Fixes [SCD151](https://code.ornl.gov/sns-hfir-scse/diffraction/single-crystal/single-crystal-diffraction/-/issues/151) <!-- and fix #xxxx or close #xxxx xor resolves #xxxx -->
<!-- alternative
*There is no associated issue.*
-->

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or master)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
