### PR TITLE
Allow CPP Interfaces to open when Floating

### DIFF
--- a/qt/applications/workbench/workbench/app/mainwindow.py
+++ b/qt/applications/workbench/workbench/app/mainwindow.py
@@ -353,10 +353,7 @@ class MainWindow(QMainWindow):
             interface.setObjectName(object_name)
             interface.setAttribute(Qt.WA_DeleteOnClose, True)
             parent, flags = get_window_config()
-            if submenu == "Indirect":
-                # always make indirect interfaces children of workbench
-                interface.setParent(self, interface.windowFlags())
-            else:
+            if parent:
                 interface.setParent(parent, flags)
             interface.show()
         else:


### PR DESCRIPTION
**Description of work.**

If the Additional Window Behaviour is set to `On Top` , we enter the `if parent:` statement and set it as the child of the main window. If it is set to `Floating` then there is no parent to set, so we do not try.

This change removes the specific behaviour that Indirect Data Analysis ALWAYS stays `on top`, but I assume this setting won't be changed from the default by these users.

**To test:**

- Check different Interfaces launch (including Indirect data analysis and ISIS Reflectometry) with Additional Windows Behaviour in File > Settings > General set to On Top (the default)
- Now check that these windows do stay on top of the main window, even if you click many times on say the script editor.
- Change the setting to `Floating` and try again to open these interfaces. These interfaces should disappear behind the main window when it is clicked on.



Fixes #31265 

*This does not require release notes* because **Corrects Harmonize Window Behaviour that went in early this release**


<!-- Ensure the base of this PR is correct (e.g. release-next or master)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
