### PR TITLE
Temporary bug fix to stop crash when trying to compare None in peaksviewer

### DIFF
--- a/docs/source/release/v6.1.0/framework.rst
+++ b/docs/source/release/v6.1.0/framework.rst
@@ -74,5 +74,6 @@ Bugfixes
 - Fix calculation of region where scattering points are sampled in :ref:`MonteCarloAbsorption <algm-MonteCarloAbsorption>` when a shape is defined for the environment but not the sample
 - Fix crash on macOS when creating a UnitLabel with non-ascii characters using the single argument constructor
 - Fix bug in the ass calculation in :ref:`PaalmanPingsMonteCarloAbsorption <algm-PaalmanPingsMonteCarloAbsorption>` when run on shapes already present on input workspace
+- Prevent crash when attempting to sort invalid data when overlaying a peaks workspace in sliceviewer.
 
 :ref:`Release 6.1.0 <v6.1.0>`

--- a/qt/python/mantidqt/widgets/sliceviewer/peaksviewer/view.py
+++ b/qt/python/mantidqt/widgets/sliceviewer/peaksviewer/view.py
@@ -20,19 +20,24 @@ class _LessThanOperatorSortFilterModel(QSortFilterProxyModel):
     support for some basic types and resorts to string comparisons
     for the rest: https://doc.qt.io/qt-5/qsortfilterproxymodel.html#lessThan
     """
+
     def lessThan(self, left_index, right_index):
         """Return True if the data at left_index
         is considered less than the data at the right_index.
         """
         left = left_index.model().data(left_index, self.sortRole())
         right = right_index.model().data(right_index, self.sortRole())
-        return left < right
+        try:
+            return left < right
+        except TypeError:
+            return True
 
 
 class _PeaksWorkspaceTableView(TableWorkspaceDisplayView):
     """Specialization of a table view to display peaks
     Designed specifically to be used by PeaksViewerView
     """
+
     def __init__(self, *args, **kwargs):
         self._key_handler = kwargs.pop('key_handler')
         TableWorkspaceDisplayView.__init__(self, *args, **kwargs)
@@ -183,6 +188,7 @@ class PeaksViewerView(QWidget):
 class PeaksViewerCollectionView(QWidget):
     """Display a collection of PeaksViewerView objects in a scrolling view.
     """
+
     def __init__(self, painter, sliceinfo_provider, parent=None):
         """
         :param painter: An object responsible for draw the peaks representations


### PR DESCRIPTION
**Description of work.**

Difficult to reproduce bug when overlaying peaks workspaces - code to sort crashes when comparing Non types. Have added a try/except to catch the TypeError and in that instance return True so no sorting will occur. 

**To test:**

Unfortunately it has not been possible to reproduce this crash with a specific workspacxe, hopefully the try/except will not cause any harm.

Fixes #31301
<!-- alternative
*There is no associated issue.*
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or master)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
