### PR TITLE
Indirect - Fix MSDFit and IqtFit crash when dragging range selectors

### DIFF
--- a/docs/source/release/v6.1.0/indirect_geometry.rst
+++ b/docs/source/release/v6.1.0/indirect_geometry.rst
@@ -31,5 +31,6 @@ Improvements
 Bug Fixes
 #########
 - Fixed a bug causing the x range markers on the ISISDiagnostics plot of Data Reduction to go missing.
+- Fixed a crash on the Data Analysis interface when attempting to drag the Start and End X sliders on the preview plot.
 
 :ref:`Release 6.1.0 <v6.1.0>`

--- a/qt/scientific_interfaces/Indirect/ConvFitDataTablePresenter.cpp
+++ b/qt/scientific_interfaces/Indirect/ConvFitDataTablePresenter.cpp
@@ -28,7 +28,7 @@ namespace CustomInterfaces {
 namespace IDA {
 
 ConvFitDataTablePresenter::ConvFitDataTablePresenter(ConvFitModel *model, QTableWidget *dataTable)
-    : IndirectDataTablePresenter(model->m_fitDataModel.get(), dataTable, convFitHeaders()) {
+    : IndirectDataTablePresenter(model->getFitDataModel(), dataTable, convFitHeaders()) {
   auto header = dataTable->horizontalHeader();
 #if QT_VERSION < QT_VERSION_CHECK(5, 0, 0)
   header->setResizeMode(1, QHeaderView::Stretch);

--- a/qt/scientific_interfaces/Indirect/FqFitDataPresenter.cpp
+++ b/qt/scientific_interfaces/Indirect/FqFitDataPresenter.cpp
@@ -207,7 +207,7 @@ void FqFitDataPresenter::setDataIndexToCurrentWorkspace(IAddWorkspaceDialog cons
   //  indirectFittingModel get table workspace index
   const auto wsName = dialog->workspaceName().append("_HWHM");
   // This a vector of workspace names currently loaded
-  auto wsVector = m_fqFitModel->m_fitDataModel->getWorkspaceNames();
+  auto wsVector = m_fqFitModel->getFitDataModel()->getWorkspaceNames();
   // this is an iterator pointing to the current wsName in wsVector
   auto wsIt = std::find(wsVector.begin(), wsVector.end(), wsName);
   // this is the index of the workspace.

--- a/qt/scientific_interfaces/Indirect/FqFitDataTablePresenter.cpp
+++ b/qt/scientific_interfaces/Indirect/FqFitDataTablePresenter.cpp
@@ -28,7 +28,7 @@ namespace CustomInterfaces {
 namespace IDA {
 
 FqFitDataTablePresenter::FqFitDataTablePresenter(FqFitModel *model, QTableWidget *dataTable)
-    : IndirectDataTablePresenter(model->m_fitDataModel.get(), dataTable, FqFitHeaders()) {
+    : IndirectDataTablePresenter(model->getFitDataModel(), dataTable, FqFitHeaders()) {
   auto header = dataTable->horizontalHeader();
 #if QT_VERSION < QT_VERSION_CHECK(5, 0, 0)
   header->setResizeMode(1, QHeaderView::Stretch);

--- a/qt/scientific_interfaces/Indirect/IIndirectFitDataView.h
+++ b/qt/scientific_interfaces/Indirect/IIndirectFitDataView.h
@@ -50,6 +50,7 @@ public:
   virtual UserInputValidator &validate(UserInputValidator &validator) = 0;
 
   virtual void setXRange(std::pair<double, double> const &range) = 0;
+  virtual std::pair<double, double> getXRange() const = 0;
 
 public slots:
   virtual void displayWarning(std::string const &warning) = 0;

--- a/qt/scientific_interfaces/Indirect/IIndirectFitPlotView.h
+++ b/qt/scientific_interfaces/Indirect/IIndirectFitPlotView.h
@@ -67,6 +67,7 @@ public:
   virtual void setFitRange(double minimum, double maximum) = 0;
   virtual void setFitRangeMinimum(double minimum) = 0;
   virtual void setFitRangeMaximum(double maximum) = 0;
+  virtual void setFitRangeBounds(std::pair<double, double> const &bounds) = 0;
 
   virtual void setBackgroundRangeVisible(bool visible) = 0;
   virtual void setHWHMRangeVisible(bool visible) = 0;

--- a/qt/scientific_interfaces/Indirect/IIndirectFittingModel.h
+++ b/qt/scientific_interfaces/Indirect/IIndirectFittingModel.h
@@ -98,7 +98,7 @@ public:
   getDataForParameterEstimation(const EstimationDataSelector &selector) const = 0;
   virtual void removeFittingData() = 0;
 
-  std::unique_ptr<IIndirectFitDataTableModel> m_fitDataModel;
+  virtual IIndirectFitDataTableModel *getFitDataModel() = 0;
 };
 
 } // namespace IDA

--- a/qt/scientific_interfaces/Indirect/IndirectDataAnalysisMSDFitTab.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectDataAnalysisMSDFitTab.cpp
@@ -51,7 +51,6 @@ IndirectDataAnalysisMSDFitTab::IndirectDataAnalysisMSDFitTab(QWidget *parent)
   m_uiForm->setupUi(parent);
 
   m_msdFittingModel = dynamic_cast<MSDFitModel *>(getFittingModel());
-
   setFitDataPresenter(std::make_unique<IndirectFitDataPresenter>(m_msdFittingModel, m_uiForm->dockArea->m_fitDataView));
   setPlotView(m_uiForm->dockArea->m_fitPlotView);
   setSpectrumSelectionView(m_uiForm->svSpectrumView);

--- a/qt/scientific_interfaces/Indirect/IndirectDataAnalysisMSDFitTab.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectDataAnalysisMSDFitTab.cpp
@@ -51,6 +51,7 @@ IndirectDataAnalysisMSDFitTab::IndirectDataAnalysisMSDFitTab(QWidget *parent)
   m_uiForm->setupUi(parent);
 
   m_msdFittingModel = dynamic_cast<MSDFitModel *>(getFittingModel());
+
   setFitDataPresenter(std::make_unique<IndirectFitDataPresenter>(m_msdFittingModel, m_uiForm->dockArea->m_fitDataView));
   setPlotView(m_uiForm->dockArea->m_fitPlotView);
   setSpectrumSelectionView(m_uiForm->svSpectrumView);

--- a/qt/scientific_interfaces/Indirect/IndirectFitAnalysisTab.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectFitAnalysisTab.cpp
@@ -678,6 +678,7 @@ void IndirectFitAnalysisTab::respondToDataChanged() {
   updateDataReferences();
   m_fittingModel->removeFittingData();
   m_spectrumPresenter->updateSpectra();
+  m_plotPresenter->setXBounds(m_dataPresenter->getXRange());
   m_plotPresenter->updateAvailableSpectra();
   m_plotPresenter->updatePlots();
   m_plotPresenter->updateGuessAvailability();

--- a/qt/scientific_interfaces/Indirect/IndirectFitDataPresenter.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectFitDataPresenter.cpp
@@ -16,8 +16,7 @@ namespace IDA {
 
 IndirectFitDataPresenter::IndirectFitDataPresenter(IIndirectFittingModel *model, IIndirectFitDataView *view)
     : IndirectFitDataPresenter(
-          model, view,
-          std::make_unique<IndirectDataTablePresenter>(model->m_fitDataModel.get(), view->getDataTable())) {}
+          model, view, std::make_unique<IndirectDataTablePresenter>(model->getFitDataModel(), view->getDataTable())) {}
 
 IndirectFitDataPresenter::IndirectFitDataPresenter(IIndirectFittingModel *model, IIndirectFitDataView *view,
                                                    std::unique_ptr<IndirectDataTablePresenter> tablePresenter)

--- a/qt/scientific_interfaces/Indirect/IndirectFitDataPresenter.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectFitDataPresenter.cpp
@@ -224,6 +224,8 @@ void IndirectFitDataPresenter::updateRanges() {
   }
 }
 
+std::pair<double, double> IndirectFitDataPresenter::getXRange() const { return m_view->getXRange(); }
+
 void IndirectFitDataPresenter::addModelData(const std::string &name) {
   try {
     m_model->addWorkspace(name);

--- a/qt/scientific_interfaces/Indirect/IndirectFitDataPresenter.h
+++ b/qt/scientific_interfaces/Indirect/IndirectFitDataPresenter.h
@@ -45,6 +45,8 @@ public:
   void setEndX(double endX, TableDatasetIndex dataIndex);
   void setExclude(const std::string &exclude, TableDatasetIndex dataIndex, WorkspaceIndex spectrumIndex);
 
+  std::pair<double, double> getXRange() const;
+
   void loadSettings(const QSettings &settings);
   UserInputValidator &validate(UserInputValidator &validator);
 

--- a/qt/scientific_interfaces/Indirect/IndirectFitDataView.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectFitDataView.cpp
@@ -117,6 +117,10 @@ void IndirectFitDataView::setXRange(std::pair<double, double> const &range) {
   m_dataForm->dsbEndX->setValue(range.second);
 }
 
+std::pair<double, double> IndirectFitDataView::getXRange() const {
+  return std::make_pair(m_dataForm->dsbStartX->value(), m_dataForm->dsbEndX->value());
+}
+
 void IndirectFitDataView::setStartX(double value) { m_dataForm->dsbStartX->setValue(value); }
 
 void IndirectFitDataView::setEndX(double value) { m_dataForm->dsbEndX->setValue(value); }

--- a/qt/scientific_interfaces/Indirect/IndirectFitDataView.h
+++ b/qt/scientific_interfaces/Indirect/IndirectFitDataView.h
@@ -51,6 +51,7 @@ public:
   UserInputValidator &validate(UserInputValidator &validator) override;
 
   void setXRange(std::pair<double, double> const &range) override;
+  std::pair<double, double> getXRange() const override;
   QComboBox *cbParameterType;
   QComboBox *cbParameter;
   QLabel *lbParameter;

--- a/qt/scientific_interfaces/Indirect/IndirectFitPlotPresenter.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectFitPlotPresenter.cpp
@@ -112,6 +112,10 @@ void IndirectFitPlotPresenter::setStartX(double startX) { m_view->setFitRangeMin
 
 void IndirectFitPlotPresenter::setEndX(double endX) { m_view->setFitRangeMaximum(endX); }
 
+void IndirectFitPlotPresenter::setXBounds(std::pair<double, double> const &bounds) {
+  m_view->setFitRangeBounds(bounds);
+}
+
 void IndirectFitPlotPresenter::updatePlotSpectrum(WorkspaceIndex spectrum) {
   setActiveSpectrum(spectrum);
   updatePlots();

--- a/qt/scientific_interfaces/Indirect/IndirectFitPlotPresenter.h
+++ b/qt/scientific_interfaces/Indirect/IndirectFitPlotPresenter.h
@@ -37,6 +37,8 @@ public:
   void setFitSingleSpectrumIsFitting(bool fitting);
   void setFitSingleSpectrumEnabled(bool enable);
 
+  void setXBounds(std::pair<double, double> const &bounds);
+
 public slots:
   void setStartX(double /*startX*/);
   void setEndX(double /*endX*/);

--- a/qt/scientific_interfaces/Indirect/IndirectFitPlotView.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectFitPlotView.cpp
@@ -210,6 +210,11 @@ void IndirectFitPlotView::setFitRangeMaximum(double maximum) {
   selector->setMaximum(maximum);
 }
 
+void IndirectFitPlotView::setFitRangeBounds(std::pair<double, double> const &bounds) {
+  auto selector = m_topPlot->getRangeSelector("FitRange");
+  selector->setBounds(bounds.first, bounds.second);
+}
+
 void IndirectFitPlotView::appendToDataSelection(const std::string &dataName) {
   MantidQt::API::SignalBlocker blocker(m_plotForm->cbDataSelection);
   m_plotForm->cbDataSelection->addItem(QString::fromStdString(dataName));

--- a/qt/scientific_interfaces/Indirect/IndirectFitPlotView.h
+++ b/qt/scientific_interfaces/Indirect/IndirectFitPlotView.h
@@ -104,6 +104,7 @@ public:
   void setFitRange(double minimum, double maximum) override;
   void setFitRangeMinimum(double minimum) override;
   void setFitRangeMaximum(double maximum) override;
+  void setFitRangeBounds(std::pair<double, double> const &bounds) override;
 
   void setBackgroundRangeVisible(bool visible) override;
   void setHWHMRangeVisible(bool visible) override;

--- a/qt/scientific_interfaces/Indirect/IndirectFittingModel.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectFittingModel.cpp
@@ -637,6 +637,8 @@ std::vector<std::pair<std::string, size_t>> IndirectFittingModel::getResolutions
   return std::vector<std::pair<std::string, size_t>>();
 }
 
+IIndirectFitDataTableModel *IndirectFittingModel::getFitDataModel() { return m_fitDataModel.get(); }
+
 } // namespace IDA
 } // namespace CustomInterfaces
 } // namespace MantidQt

--- a/qt/scientific_interfaces/Indirect/IndirectFittingModel.h
+++ b/qt/scientific_interfaces/Indirect/IndirectFittingModel.h
@@ -119,7 +119,8 @@ public:
   DataForParameterEstimationCollection
   getDataForParameterEstimation(const EstimationDataSelector &selector) const override;
   void removeFittingData() override;
-  std::unique_ptr<IIndirectFitDataTableModel> m_fitDataModel;
+
+  IIndirectFitDataTableModel *getFitDataModel() override;
 
 protected:
   std::string createOutputName(const std::string &fitMode) const;
@@ -130,6 +131,8 @@ protected:
   virtual std::unordered_map<std::string, std::string> mapDefaultParameterNames() const;
   std::string m_fitType = "FitType";
   std::string m_fitString = "FitString";
+
+  std::unique_ptr<IIndirectFitDataTableModel> m_fitDataModel;
 
 private:
   std::vector<std::string> getWorkspaceNames() const;

--- a/qt/scientific_interfaces/Indirect/test/ConvFitDataPresenterTest.h
+++ b/qt/scientific_interfaces/Indirect/test/ConvFitDataPresenterTest.h
@@ -69,6 +69,7 @@ public:
   MOCK_METHOD1(readSettings, void(QSettings const &settings));
   MOCK_METHOD1(validate, UserInputValidator &(UserInputValidator &validator));
   MOCK_METHOD1(setXRange, void(std::pair<double, double> const &range));
+  MOCK_CONST_METHOD0(getXRange, std::pair<double, double>());
 
   /// Public slots
   MOCK_METHOD1(displayWarning, void(std::string const &warning));
@@ -137,6 +138,15 @@ public:
   ///----------------------------------------------------------------------
   /// Unit Tests that test the signals, methods and slots of the presenter
   ///----------------------------------------------------------------------
+
+  void test_that_getXRange_calls_the_correct_method_in_the_view() {
+    auto const xRange = std::make_pair(0.0, 1.0);
+
+    ON_CALL(*m_view, getXRange()).WillByDefault(Return(xRange));
+    EXPECT_CALL(*m_view, getXRange()).Times(1);
+
+    TS_ASSERT_EQUALS(m_presenter->getXRange(), xRange);
+  }
 
 private:
   std::unique_ptr<QTableWidget> m_dataTable;

--- a/qt/scientific_interfaces/Indirect/test/FqFitDataPresenterTest.h
+++ b/qt/scientific_interfaces/Indirect/test/FqFitDataPresenterTest.h
@@ -76,6 +76,7 @@ public:
   MOCK_CONST_METHOD0(isResolutionHidden, bool());
   MOCK_METHOD1(setResolutionHidden, void(bool hide));
   MOCK_METHOD1(setXRange, void(std::pair<double, double> const &range));
+  MOCK_CONST_METHOD0(getXRange, std::pair<double, double>());
   MOCK_METHOD1(setStartX, void(double startX));
   MOCK_METHOD1(setEndX, void(double endX));
   MOCK_METHOD0(disableMultipleDataTab, void());
@@ -195,6 +196,15 @@ public:
   ///----------------------------------------------------------------------
   /// Unit Tests that test the signals, methods and slots of the presenter
   ///----------------------------------------------------------------------
+
+  void test_that_getXRange_calls_the_correct_method_in_the_view() {
+    auto const xRange = std::make_pair(0.0, 1.0);
+
+    ON_CALL(*m_view, getXRange()).WillByDefault(Return(xRange));
+    EXPECT_CALL(*m_view, getXRange()).Times(1);
+
+    TS_ASSERT_EQUALS(m_presenter->getXRange(), xRange);
+  }
 
 private:
   std::unique_ptr<QTableWidget> m_dataTable;

--- a/qt/scientific_interfaces/Indirect/test/IndirectFitDataPresenterTest.h
+++ b/qt/scientific_interfaces/Indirect/test/IndirectFitDataPresenterTest.h
@@ -55,6 +55,7 @@ public:
   MOCK_METHOD1(setResolutionWSSuffices, void(QStringList const &suffices));
   MOCK_METHOD1(setResolutionFBSuffices, void(QStringList const &suffices));
   MOCK_METHOD1(setXRange, void(std::pair<double, double> const &range));
+  MOCK_CONST_METHOD0(getXRange, std::pair<double, double>());
   MOCK_METHOD1(setStartX, void(double startX));
   MOCK_METHOD1(setEndX, void(double endX));
 
@@ -71,6 +72,8 @@ public:
 /// Mock object to mock the model
 class MockIndirectFitDataTableModel : public IIndirectFittingModel {
 public:
+  MockIndirectFitDataTableModel() : m_fitDataModel(std::make_unique<MockIndirectDataTableModel>()) {}
+
   /// Public Methods
   MOCK_CONST_METHOD2(isPreviouslyFit, bool(TableDatasetIndex dataIndex, IDA::WorkspaceIndex spectrum));
   MOCK_CONST_METHOD0(isInvalidFunction, boost::optional<std::string>());
@@ -149,6 +152,11 @@ public:
 
   MOCK_METHOD0(removeFittingData, void());
 
+  IIndirectFitDataTableModel *getFitDataModel() override { return m_fitDataModel.get(); }
+
+protected:
+  std::unique_ptr<IIndirectFitDataTableModel> m_fitDataModel;
+
 private:
   std::string sequentialFitOutputName() const { return ""; };
   std::string simultaneousFitOutputName() const { return ""; };
@@ -201,10 +209,11 @@ public:
   void setUp() override {
     m_view = std::make_unique<NiceMock<MockIIndirectFitDataView>>();
     m_model = std::make_unique<NiceMock<MockIndirectFitDataTableModel>>();
-    m_model->m_fitDataModel = std::make_unique<MockIndirectDataTableModel>();
     m_table = createEmptyTableWidget(5, 5);
     ON_CALL(*m_view, getDataTable()).WillByDefault(Return(m_table.get()));
     m_presenter = std::make_unique<IndirectFitDataPresenter>(std::move(m_model.get()), std::move(m_view.get()));
+
+    TS_ASSERT(m_model->getFitDataModel());
 
     SetUpADSWithWorkspace m_ads("WorkspaceName", createWorkspace(5));
     m_model->addWorkspace("WorkspaceName");
@@ -344,6 +353,15 @@ public:
     EXPECT_CALL(*m_model, getDataForParameterEstimation(NoCheck(nullptr))).Times(Exactly(1));
 
     m_presenter->getDataForParameterEstimation(selector);
+  }
+
+  void test_that_getXRange_calls_the_correct_method_in_the_view() {
+    auto const xRange = std::make_pair(0.0, 1.0);
+
+    ON_CALL(*m_view, getXRange()).WillByDefault(Return(xRange));
+    EXPECT_CALL(*m_view, getXRange()).Times(1);
+
+    TS_ASSERT_EQUALS(m_presenter->getXRange(), xRange);
   }
 
 private:

--- a/qt/scientific_interfaces/Indirect/test/IndirectFitPlotPresenterTest.h
+++ b/qt/scientific_interfaces/Indirect/test/IndirectFitPlotPresenterTest.h
@@ -112,6 +112,7 @@ public:
   MOCK_METHOD2(setFitRange, void(double minimum, double maximum));
   MOCK_METHOD1(setFitRangeMinimum, void(double minimum));
   MOCK_METHOD1(setFitRangeMaximum, void(double maximum));
+  MOCK_METHOD1(setFitRangeBounds, void(std::pair<double, double> const &bounds));
 
   MOCK_METHOD1(setBackgroundRangeVisible, void(bool visible));
   MOCK_METHOD1(setHWHMRangeVisible, void(bool visible));
@@ -583,6 +584,14 @@ public:
     EXPECT_CALL(*m_view, enablePlotGuess(false)).Times(1);
 
     m_presenter->updateFit();
+  }
+
+  void test_that_setXBounds_calls_the_correct_method_in_the_view() {
+    auto const bounds = std::make_pair(0.0, 1.0);
+
+    EXPECT_CALL(*m_view, setFitRangeBounds(bounds)).Times(1);
+
+    m_presenter->setXBounds(bounds);
   }
 
 private:


### PR DESCRIPTION
**Description of work.**
This PR fixes a crash on MSD Fit and Iqt Fit when attempting to drag the range sliders on a preview plot. It also ensures that the bounds of the RangeMarkers are set correctly so that they can be dragged to the full extent of the displayed data.

**To test:**
1. Indirect -> Data Analysis -> MSD Fit tab
2. Load the data below
3. The black sliders on the plot do not reflect the x range in the spin boxes.
3. Try to drag the black sliders on the plot to change the x range. There should be no crash!
4. The range selectors should also be in the same position as the start and end X spin boxes.

[osi92762_graphite002_elwin_eq.zip](https://github.com/mantidproject/mantid/files/6405211/osi92762_graphite002_elwin_eq.zip)

Fixes #31250

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
