### PR TITLE
Fix display formatting issues on Muon plotting and Fitting tabs for 4k displays

### DIFF
--- a/scripts/Muon/GUI/Common/fitting_widgets/basic_fitting/fit_controls.ui
+++ b/scripts/Muon/GUI/Common/fitting_widgets/basic_fitting/fit_controls.ui
@@ -85,13 +85,13 @@
     <widget class="QCheckBox" name="plot_guess_checkbox">
      <property name="minimumSize">
       <size>
-       <width>120</width>
+       <width>180</width>
        <height>0</height>
       </size>
      </property>
      <property name="maximumSize">
       <size>
-       <width>120</width>
+       <width>180</width>
        <height>16777215</height>
       </size>
      </property>

--- a/scripts/Muon/GUI/Common/fitting_widgets/basic_fitting/fit_function_options.ui
+++ b/scripts/Muon/GUI/Common/fitting_widgets/basic_fitting/fit_function_options.ui
@@ -123,7 +123,7 @@
         </property>
         <property name="maximumSize">
          <size>
-          <width>50</width>
+          <width>120</width>
           <height>16777215</height>
          </size>
         </property>

--- a/scripts/Muon/GUI/Common/fitting_widgets/general_fitting/general_fitting_options.ui
+++ b/scripts/Muon/GUI/Common/fitting_widgets/general_fitting/general_fitting_options.ui
@@ -45,13 +45,13 @@
        <widget class="QLabel" name="workspace_combo_box_label">
         <property name="minimumSize">
          <size>
-          <width>120</width>
+          <width>220</width>
           <height>0</height>
          </size>
         </property>
         <property name="maximumSize">
          <size>
-          <width>120</width>
+          <width>220</width>
           <height>16777215</height>
          </size>
         </property>
@@ -121,7 +121,7 @@
         </property>
         <property name="maximumSize">
          <size>
-          <width>120</width>
+          <width>300</width>
           <height>16777215</height>
          </size>
         </property>

--- a/scripts/Muon/GUI/Common/fitting_widgets/tf_asymmetry_fitting/tf_asymmetry_mode_switcher.ui
+++ b/scripts/Muon/GUI/Common/fitting_widgets/tf_asymmetry_fitting/tf_asymmetry_mode_switcher.ui
@@ -36,7 +36,7 @@
      </property>
      <property name="maximumSize">
       <size>
-       <width>120</width>
+       <width>150</width>
        <height>16777215</height>
       </size>
      </property>

--- a/scripts/Muon/GUI/Common/plot_widget/quick_edit/quick_edit_view.py
+++ b/scripts/Muon/GUI/Common/plot_widget/quick_edit/quick_edit_view.py
@@ -46,7 +46,6 @@ class QuickEditView(QtWidgets.QWidget):
         button_layout.addWidget(self.y_axis_changer.view)
         button_layout.addWidget(self.errors)
         self.setLayout(button_layout)
-        self.setFixedHeight(65)
 
     """ plot selection """
     def add_subplot(self, name):


### PR DESCRIPTION
**Description of work.**
This fixes display issues caused by using Muon Analysis and Frequency Domain Analysis with a 4k display.

**To test:**
1. Open Mantid
2. Open Interfaces >> Muon >> Frequency Domain Analysis
3. Check that X max, X min, Y max and Y min appears beneath the plotting window
4. Open the Fitting Tab 
5. Check that Plot Guess, Selected Workspace and Fit Status on the left hand side of the screen can be read in full.
6. Close The Frequency Domain Analysis GUI
7. Open Interfaces >> Muon >> Muon Analysis
8. Check that X max, X min, Y max and Y min appears beneath the plotting window
9. Open the Fitting Tab
10. Check that Fitting Type, Plot Guess, Simultaneous over, Select Workspace and Fit Status on the left hand side of the screen can be read in full.

Fixes #31234 .

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
