### PR TITLE
Remove WindowsError that is a subclass of OSError

### DIFF
--- a/qt/python/mantidqt/project/projectsaver.py
+++ b/qt/python/mantidqt/project/projectsaver.py
@@ -19,8 +19,7 @@ class ProjectSaver(object):
     def __init__(self, project_file_ext):
         self.project_file_ext = project_file_ext
 
-    def save_project(self, file_name, workspace_to_save=None, plots_to_save=None, interfaces_to_save=None,
-                     project_recovery=True):
+    def save_project(self, file_name, workspace_to_save=None, plots_to_save=None, interfaces_to_save=None, project_recovery=True):
         """
         The method that will actually save the project and call relevant savers for workspaces, plots, interfaces etc.
         :param file_name: String; The file_name of the
@@ -99,8 +98,7 @@ class ProjectWriter(object):
         Write out the project file that contains workspace names, interfaces information, plot preferences etc.
         """
         # Get the JSON string versions
-        to_save_dict = {"workspaces": self.workspace_names, "plots": self.plots_to_save,
-                        "interfaces": self.interfaces_to_save}
+        to_save_dict = {"workspaces": self.workspace_names, "plots": self.plots_to_save, "interfaces": self.interfaces_to_save}
 
         # Open file and save the string to it alongside the workspace_names
         if self.project_file_ext not in os.path.basename(self.file_name):
@@ -111,7 +109,7 @@ class ProjectWriter(object):
         except KeyboardInterrupt:
             # Catch any exception and log it
             raise
-        except (IOError, OSError, WindowsError) as e:
+        except (IOError, OSError) as e:
             logger.warning("JSON project file unable to be opened/written to.")
             logger.debug("Full error: {}".format(e))
         except Exception as e:

--- a/qt/python/mantidqt/project/test/test_projectsaver.py
+++ b/qt/python/mantidqt/project/test/test_projectsaver.py
@@ -246,6 +246,22 @@ class ProjectWriterTest(unittest.TestCase):
         self.assertTrue(plots_string in file_string)
         self.assertTrue(interface_string in file_string)
 
+    @mock.patch('mantidqt.project.projectsaver.logger')
+    def test_exception_in_open_logs_error(self, mock_logger):
+        workspace_list = []
+        plots_to_save = []
+        interfaces_to_save = []
+        project_writer = projectsaver.ProjectWriter(save_location=working_project_file, workspace_names=workspace_list,
+                                                    project_file_ext=project_file_ext, plots_to_save=plots_to_save,
+                                                    interfaces_to_save=interfaces_to_save)
+        mock_open = mock.mock_open()
+        with mock.patch('mantidqt.project.projectsaver.open', mock_open):
+            mock_open.side_effect = OSError
+            project_writer.write_out()
+
+        mock_logger.warning.assert_called_once()
+        mock_logger.debug.assert_called_once()
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
**Description of work.**

On macOS/Linux, if an exception was generated by `open` then during project save you would see an error:


```python
During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/Applications/MantidWorkbenchNightly.app/Contents/MacOS/mantidqt/widgets/saveprojectdialog/presenter.py", line 66, in save_as
    self.project.save_as(path=self.view.get_location())
  File "/Applications/MantidWorkbenchNightly.app/Contents/MacOS/mantidqt/project/project.py", line 108, in save_as
    task.start()
  File "/Applications/MantidWorkbenchNightly.app/Contents/MacOS/mantidqt/utils/asynchronous.py", line 144, in start
    raise self.recv.exc_value
  File "/Applications/MantidWorkbenchNightly.app/Contents/MacOS/mantidqt/utils/asynchronous.py", line 65, in run
    out = self.target(*self.args, **self.kwargs)
  File "/Applications/MantidWorkbenchNightly.app/Contents/MacOS/mantidqt/project/project.py", line 149, in _save
    project_saver.save_project(file_name=self.last_project_location, workspace_to_save=workspaces_to_save,
  File "/Applications/MantidWorkbenchNightly.app/Contents/MacOS/mantidqt/project/projectsaver.py", line 69, in save_project
    writer.write_out()
  File "/Applications/MantidWorkbenchNightly.app/Contents/MacOS/mantidqt/project/projectsaver.py", line 114, in write_out
    except (IOError, OSError, WindowsError) as e:
NameError: name 'WindowsError' is not defined
```

`WindowsError` is a subclass of `OSError` that is already captured so is not required. A unit test has been added.


<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

**To test:**


*There is no associated issue.*

*This does not require release notes* because **it was a regression this development cycle.**

<!-- Ensure the base of this PR is correct (e.g. release-next or master)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
