### PR TITLE
Muon Analysis - Do better at reusing a fit function when loading new data

### DIFF
--- a/scripts/Muon/GUI/Common/fitting_widgets/basic_fitting/basic_fitting_model.py
+++ b/scripts/Muon/GUI/Common/fitting_widgets/basic_fitting/basic_fitting_model.py
@@ -101,13 +101,14 @@ class BasicFittingModel:
     def dataset_names(self, names: list) -> None:
         """Sets the dataset names stored by the model. Resets the other fitting data."""
         start_xs, end_xs = self._get_new_start_xs_and_end_xs_using_existing_datasets(names)
+        functions = self._get_new_functions_using_existing_datasets(names)
 
         self._dataset_names = names
 
         self.start_xs = start_xs
         self.end_xs = end_xs
 
-        self.reset_fit_functions()
+        self.reset_fit_functions(functions)
         self.reset_current_dataset_index()
         self.reset_fit_statuses_and_chi_squared()
         self.clear_cached_fit_functions()
@@ -406,10 +407,9 @@ class BasicFittingModel:
         self.fit_statuses = [DEFAULT_FIT_STATUS] * self.number_of_datasets
         self.chi_squared = [DEFAULT_CHI_SQUARED] * self.number_of_datasets
 
-    def reset_fit_functions(self) -> None:
+    def reset_fit_functions(self, new_functions: list) -> None:
         """Reset the fit functions stored by the model. Attempts to use the currently selected function."""
-        fit_function = None if len(self.single_fit_functions) == 0 else self.current_single_fit_function
-        self.single_fit_functions = [self._clone_function(fit_function)] * self.number_of_datasets
+        self.single_fit_functions = new_functions
 
     def _reset_start_xs(self) -> None:
         """Resets the start Xs stored by the model."""
@@ -442,6 +442,20 @@ class BasicFittingModel:
             return self.end_xs[self.dataset_names.index(new_dataset_name)]
         else:
             return self.current_end_x if len(self.end_xs) > 0 else self._default_end_x
+
+    def _get_new_functions_using_existing_datasets(self, new_dataset_names: list) -> list:
+        """Returns the functions to use for the new datasets. It tries to use the existing functions if possible."""
+        if len(self.dataset_names) == len(new_dataset_names):
+            return self.single_fit_functions
+        else:
+            return [self._get_new_function_for(name) for name in new_dataset_names]
+
+    def _get_new_function_for(self, new_dataset_name: str) -> IFunction:
+        """Returns the function to use for the new dataset. It tries to use an existing function if possible."""
+        if new_dataset_name in self.dataset_names:
+            return self._clone_function(self.single_fit_functions[self.dataset_names.index(new_dataset_name)])
+        else:
+            return self._clone_function(self.current_single_fit_function)
 
     def retrieve_first_good_data_from_run(self, workspace_name: str) -> float:
         """Returns the first good data value from a run number within a workspace name."""

--- a/scripts/Muon/GUI/Common/fitting_widgets/general_fitting/general_fitting_model.py
+++ b/scripts/Muon/GUI/Common/fitting_widgets/general_fitting/general_fitting_model.py
@@ -4,7 +4,7 @@
 #   NScD Oak Ridge National Laboratory, European Spallation Source,
 #   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
 # SPDX - License - Identifier: GPL - 3.0 +
-from mantid.api import AnalysisDataService, FunctionFactory, IFunction, MultiDomainFunction
+from mantid.api import AnalysisDataService, IFunction, MultiDomainFunction
 from mantid.simpleapi import RenameWorkspace, CopyLogs
 
 from Muon.GUI.Common.ADSHandler.workspace_naming import (create_fitted_workspace_name,
@@ -150,26 +150,49 @@ class GeneralFittingModel(BasicFittingModel):
         self.simultaneous_fit_function = self.simultaneous_fit_function_cache
         super().use_cached_function()
 
-    def reset_fit_functions(self) -> None:
+    def reset_fit_functions(self, new_functions: list) -> None:
         """Reset the fit functions stored by the model. Attempts to use the currently selected function."""
-        if self.number_of_datasets == 0:
+        if len(new_functions) == 0 or None in new_functions:
             self.simultaneous_fit_function = None
-
-        if self.simultaneous_fit_function is not None:
-            single_function = self.current_domain_fit_function()
-            if single_function is not None:
-                single_function = single_function.clone()
-            self._construct_new_simultaneous_function_from(single_function)
-
-        super().reset_fit_functions()
-
-    def _construct_new_simultaneous_function_from(self, single_function: IFunction) -> None:
-        """Constructs the new simultaneous function using a single domain function."""
-        if self.number_of_datasets == 1:
-            self.simultaneous_fit_function = single_function
+        elif len(new_functions) == 1:
+            self.simultaneous_fit_function = new_functions[0]
         else:
-            self.simultaneous_fit_function = self._create_multi_domain_function_from(single_function)
+            self._create_multi_domain_function_using(new_functions)
             self._add_global_ties_to_simultaneous_function()
+
+        super().reset_fit_functions(new_functions)
+
+    def _create_multi_domain_function_using(self, domain_functions: list) -> None:
+        """Creates a new MultiDomainFunction using the provided functions corresponding to a domain each."""
+        self.simultaneous_fit_function = MultiDomainFunction()
+        for i, function in enumerate(domain_functions):
+            self.simultaneous_fit_function.add(function)
+            self.simultaneous_fit_function.setDomainIndex(i, i)
+
+    def _get_new_functions_using_existing_datasets(self, new_dataset_names: list) -> list:
+        """Returns the functions to use for the new datasets. It tries to use the existing functions if possible."""
+        if self.simultaneous_fitting_mode:
+            return self._get_new_domain_functions_using_existing_datasets(new_dataset_names)
+        else:
+            return super()._get_new_functions_using_existing_datasets(new_dataset_names)
+
+    def _get_new_domain_functions_using_existing_datasets(self, new_dataset_names: list) -> list:
+        """Returns the domain functions to use within a MultiDomainFunction for the new datasets."""
+        if len(self.dataset_names) == len(new_dataset_names) and self.simultaneous_fit_function is not None:
+            return [self.simultaneous_fit_function.getFunction(i).clone()
+                    for i in range(self.simultaneous_fit_function.nFunctions())]
+        elif len(self.dataset_names) <= 1:
+            return [self._clone_function(self.simultaneous_fit_function) for _ in range(len(new_dataset_names))]
+        else:
+            return [self._get_new_domain_function_for(name) for name in new_dataset_names]
+
+    def _get_new_domain_function_for(self, new_dataset_name: str) -> IFunction:
+        """Returns the function to use for a specific domain when new datasets are loaded."""
+        if new_dataset_name in self.dataset_names and self.simultaneous_fit_function is not None:
+            return self._clone_function(self.simultaneous_fit_function.getFunction(
+                self.dataset_names.index(new_dataset_name)))
+        else:
+            return self._clone_function(self.current_domain_fit_function())
 
     def _add_global_ties_to_simultaneous_function(self) -> None:
         """Creates and adds ties to the simultaneous function to represent the global parameters."""
@@ -183,10 +206,6 @@ class GeneralFittingModel(BasicFittingModel):
                 for i in range(self.simultaneous_fit_function.nFunctions()) if i != index]
         ties.append("f" + str(index) + "." + global_parameter)
         return "=".join(ties)
-
-    def _create_multi_domain_function_from(self, fit_function: IFunction) -> MultiDomainFunction:
-        """Create a MultiDomainFunction containing the same fit function for each domain."""
-        return FunctionFactory.createInitializedMultiDomainFunction(str(fit_function), self.number_of_datasets)
 
     def get_simultaneous_fit_by_specifiers_to_display_from_context(self) -> list:
         """Returns the simultaneous fit by specifiers to display in the view from the context."""

--- a/scripts/Muon/GUI/Common/fitting_widgets/general_fitting/general_fitting_model.py
+++ b/scripts/Muon/GUI/Common/fitting_widgets/general_fitting/general_fitting_model.py
@@ -179,8 +179,11 @@ class GeneralFittingModel(BasicFittingModel):
     def _get_new_domain_functions_using_existing_datasets(self, new_dataset_names: list) -> list:
         """Returns the domain functions to use within a MultiDomainFunction for the new datasets."""
         if len(self.dataset_names) == len(new_dataset_names) and self.simultaneous_fit_function is not None:
-            return [self.simultaneous_fit_function.getFunction(i).clone()
-                    for i in range(self.simultaneous_fit_function.nFunctions())]
+            if len(self.dataset_names) == 1:
+                return [self.simultaneous_fit_function.clone()]
+            else:
+                return [self.simultaneous_fit_function.getFunction(i).clone()
+                        for i in range(self.simultaneous_fit_function.nFunctions())]
         elif len(self.dataset_names) <= 1:
             return [self._clone_function(self.simultaneous_fit_function) for _ in range(len(new_dataset_names))]
         else:

--- a/scripts/test/Muon/fitting_widgets/basic_fitting/basic_fitting_model_test.py
+++ b/scripts/test/Muon/fitting_widgets/basic_fitting/basic_fitting_model_test.py
@@ -467,6 +467,46 @@ class BasicFittingModelTest(unittest.TestCase):
 
         self.assertEqual(self.model.get_all_fit_functions(), self.model.single_fit_functions)
 
+    def test_that_the_existing_functions_are_reused_when_new_datasets_are_loaded(self):
+        self.model.dataset_names = self.dataset_names
+        self.model.single_fit_functions = self.single_fit_functions
+        self.model.current_dataset_index = 0
+        self.model.single_fit_functions[0].setParameter("A0", 1)
+        self.model.single_fit_functions[1].setParameter("A0", 5)
+
+        self.model.dataset_names = ["New Name1", "New Name2"]
+
+        self.assertEqual(str(self.model.single_fit_functions[0]), "name=FlatBackground,A0=1")
+        self.assertEqual(str(self.model.single_fit_functions[1]), "name=FlatBackground,A0=5")
+
+    def test_that_the_currently_selected_function_is_copied_for_when_a_larger_number_of_new_datasets_are_loaded(self):
+        self.model.dataset_names = self.dataset_names
+        self.model.single_fit_functions = self.single_fit_functions
+        self.model.current_dataset_index = 0
+        self.model.single_fit_functions[0].setParameter("A0", 1)
+        self.model.single_fit_functions[1].setParameter("A0", 5)
+
+        # The last two datasets are the same as the previously loaded datasets. This means their functions should be
+        # reused for these last two single fit functions. The first two single fit functions are completely new, and so
+        # are just given a copy of the previous currently selected function (i.e. A0=1).
+        self.model.dataset_names = ["New Name1", "New Name2", "Name1", "Name2"]
+
+        self.assertEqual(str(self.model.single_fit_functions[0]), "name=FlatBackground,A0=1")
+        self.assertEqual(str(self.model.single_fit_functions[1]), "name=FlatBackground,A0=1")
+        self.assertEqual(str(self.model.single_fit_functions[2]), "name=FlatBackground,A0=1")
+        self.assertEqual(str(self.model.single_fit_functions[3]), "name=FlatBackground,A0=5")
+
+    def test_that_newly_loaded_datasets_will_reuse_the_existing_functions_when_there_are_fewer_new_datasets(self):
+        self.model.dataset_names = self.dataset_names
+        self.model.single_fit_functions = self.single_fit_functions
+        self.model.current_dataset_index = 0
+        self.model.single_fit_functions[0].setParameter("A0", 1)
+        self.model.single_fit_functions[1].setParameter("A0", 5)
+
+        # This dataset is the second dataset previously and so the A0=5 fit function should be reused.
+        self.model.dataset_names = ["Name2"]
+        self.assertEqual(str(self.model.single_fit_functions[0]), "name=FlatBackground,A0=5")
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/scripts/test/Muon/fitting_widgets/general_fitting/general_fitting_model_test.py
+++ b/scripts/test/Muon/fitting_widgets/general_fitting/general_fitting_model_test.py
@@ -451,6 +451,52 @@ class GeneralFittingModelTest(unittest.TestCase):
 
         self.assertEqual(self.model.get_all_fit_functions(), [self.model.simultaneous_fit_function])
 
+    def test_that_the_existing_functions_are_reused_when_new_datasets_are_loaded(self):
+        self.model.dataset_names = self.dataset_names
+        self.model.simultaneous_fit_function = self.simultaneous_fit_function
+        self.model.simultaneous_fitting_mode = True
+        self.model.current_dataset_index = 0
+        self.model.simultaneous_fit_function.setParameter("f0.A0", 1)
+        self.model.simultaneous_fit_function.setParameter("f1.A0", 5)
+
+        self.model.dataset_names = ["New Name1", "New Name2"]
+
+        self.assertEqual(str(self.model.simultaneous_fit_function), "composite=MultiDomainFunction,NumDeriv=true;"
+                                                                    "name=FlatBackground,A0=1,$domains=i;"
+                                                                    "name=FlatBackground,A0=5,$domains=i")
+
+    def test_that_the_currently_selected_function_is_copied_for_when_a_larger_number_of_new_datasets_are_loaded(self):
+        self.model.dataset_names = self.dataset_names
+        self.model.simultaneous_fit_function = self.simultaneous_fit_function
+        self.model.simultaneous_fitting_mode = True
+        self.model.current_dataset_index = 0
+        self.model.simultaneous_fit_function.setParameter("f0.A0", 1)
+        self.model.simultaneous_fit_function.setParameter("f1.A0", 5)
+
+        # The last two datasets are the same as the previously loaded datasets. This means their functions should be
+        # reused for these last two domains. The first two domain functions are completely new, and so
+        # are just given a copy of the previous currently selected function (i.e. A0=1).
+        self.model.dataset_names = ["New Name1", "New Name2", "Name1", "Name2"]
+
+        self.assertEqual(str(self.model.simultaneous_fit_function), "composite=MultiDomainFunction,NumDeriv=true;"
+                                                                    "name=FlatBackground,A0=1,$domains=i;"
+                                                                    "name=FlatBackground,A0=1,$domains=i;"
+                                                                    "name=FlatBackground,A0=1,$domains=i;"
+                                                                    "name=FlatBackground,A0=5,$domains=i")
+
+    def test_that_newly_loaded_datasets_will_reuse_the_existing_functions_when_there_are_fewer_new_datasets(self):
+        self.model.dataset_names = self.dataset_names
+        self.model.simultaneous_fit_function = self.simultaneous_fit_function
+        self.model.simultaneous_fitting_mode = True
+        self.model.current_dataset_index = 0
+        self.model.simultaneous_fit_function.setParameter("f0.A0", 1)
+        self.model.simultaneous_fit_function.setParameter("f1.A0", 5)
+
+        # This dataset is the second dataset previously and so the A0=5 fit function should be reused. There is also
+        # now only one domain, so a MultiDomainFunction is no longer used.
+        self.model.dataset_names = ["Name2"]
+        self.assertEqual(str(self.model.simultaneous_fit_function), "name=FlatBackground,A0=5")
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/scripts/test/Muon/fitting_widgets/general_fitting/general_fitting_model_test.py
+++ b/scripts/test/Muon/fitting_widgets/general_fitting/general_fitting_model_test.py
@@ -497,6 +497,18 @@ class GeneralFittingModelTest(unittest.TestCase):
         self.model.dataset_names = ["Name2"]
         self.assertEqual(str(self.model.simultaneous_fit_function), "name=FlatBackground,A0=5")
 
+    def test_that_reseting_the_simultaneous_fit_function_does_not_crash_when_there_is_a_single_domain(self):
+        self.model.dataset_names = ["Name1"]
+        self.model.simultaneous_fit_function = self.fit_function
+        self.model.simultaneous_fitting_mode = False
+        self.model.current_dataset_index = 0
+        self.model.simultaneous_fit_function.setParameter("A0", 5)
+
+        self.model.simultaneous_fitting_mode = True
+        self.model.dataset_names = ["Name2"]
+
+        self.assertEqual(str(self.model.simultaneous_fit_function), "name=FlatBackground,A0=5")
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
**Description of work.**
This PR makes a change which improves the re-using of the current single fit functions and simultaneous fit functions when new data is loaded into Muon Analysis.

**To test:**
Open Muon Analysis
Load MUSR 62260
Go to fitting tab
Click simultaneous
Add a GausOsc function
Share Frequency (set to 1) and Sigma
Do a fit

Notice that the A and Phi values are different for each group
Load the next run (62261)
Notice that the A and Phi values should be the same as previously. The values should be preserved for each group/pair.

*No release notes required because this is part of the Muon refactor which has happened over the past release cycle*

Fixes #31312

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
