### PR TITLE
Re-enable keyboard shortcuts in DrILL with "on top" setting

### DIFF
--- a/scripts/Drill.py
+++ b/scripts/Drill.py
@@ -22,21 +22,8 @@ else:
         from Interface.ui.drill.view.DrillView import DrillView
 
         app, within_mantid = get_qapplication()
-        if 'workbench' in sys.modules:
-            from workbench.config import get_window_config
-
-            parent, flags = get_window_config()
-        else:
-            parent, flags = None, None
-
         if 'drillInterface' not in globals():
-            drillInterface = DrillView(parent, flags)
-        if 'drillInterface' in globals():
-            # 'unresolved reference drillInterface' if we use an else statement.
-            # This is necessary to ensure settings for 'On top'/'Floating' window behaviour are propagated to DRILL
-            # if they are changed by the user after DRILL has been opened.
-            drillInterface.setParent(parent)
-            drillInterface.setWindowFlags(flags)
+            drillInterface = DrillView()
         drillInterface.show()
         if not within_mantid:
             sys.exit(app.exec_())

--- a/scripts/Interface/ui/drill/view/DrillView.py
+++ b/scripts/Interface/ui/drill/view/DrillView.py
@@ -468,6 +468,27 @@ class DrillView(QMainWindow):
                 and event.modifiers() == Qt.ControlModifier):
             self.setMasterRow.emit()
 
+    def event(self, event):
+        """
+        Override of QMainWindow::event. This method catches the keyboard
+        shortcuts when the window in in "on top" mode in mantid settings.
+        """
+        if event.type() == QEvent.ShortcutOverride:
+            if event.modifiers() == Qt.ControlModifier:
+                if event.key() == Qt.Key_S:
+                    self.actionSave.trigger()
+                    event.accept()
+                    return True
+                elif event.key() == Qt.Key_O:
+                    self.actionLoadRundex.trigger()
+                    event.accept()
+                    return True
+                elif event.key() == Qt.Key_Q:
+                    self.close()
+                    event.accept()
+                    return True
+        return super().event(event)
+
     def show_directory_manager(self):
         """
         Open the Mantid user directories manager.

--- a/scripts/Interface/ui/drill/view/DrillView.py
+++ b/scripts/Interface/ui/drill/view/DrillView.py
@@ -468,31 +468,6 @@ class DrillView(QMainWindow):
                 and event.modifiers() == Qt.ControlModifier):
             self.setMasterRow.emit()
 
-    def event(self, event):
-        """
-        Override of QMainWindow::event. This method catches the keyboard
-        shortcuts when the window in in "on top" mode in mantid settings.
-        """
-        if event.type() == QEvent.ShortcutOverride:
-            if event.modifiers() == Qt.ControlModifier:
-                if event.key() == Qt.Key_S:
-                    self.actionSave.trigger()
-                    event.accept()
-                    return True
-                elif event.key() == Qt.Key_O:
-                    self.actionLoadRundex.trigger()
-                    event.accept()
-                    return True
-                elif event.key() == Qt.Key_Q:
-                    self.close()
-                    event.accept()
-                    return True
-                elif event.key() == Qt.Key_N:
-                    self.actionNew.trigger()
-                    event.accept()
-                    return True
-        return super().event(event)
-
     def show_directory_manager(self):
         """
         Open the Mantid user directories manager.

--- a/scripts/Interface/ui/drill/view/DrillView.py
+++ b/scripts/Interface/ui/drill/view/DrillView.py
@@ -487,6 +487,10 @@ class DrillView(QMainWindow):
                     self.close()
                     event.accept()
                     return True
+                elif event.key() == Qt.Key_N:
+                    self.actionNew.trigger()
+                    event.accept()
+                    return True
         return super().event(event)
 
     def show_directory_manager(self):

--- a/scripts/Interface/ui/drill/view/ui/main.ui
+++ b/scripts/Interface/ui/drill/view/ui/main.ui
@@ -625,6 +625,9 @@
    <property name="text">
     <string>&amp;New</string>
    </property>
+   <property name="shortcut">
+    <string>Ctrl+N</string>
+   </property>
   </action>
   <action name="actionProcessGroup">
    <property name="text">


### PR DESCRIPTION
**Description of work.**

~~This PR follows #30129 and re-enable the keyboard shortcuts as mentioned in the discussion.~~
The method discussed in #30129 does not really work on MacOS; actions are triggered two times.

Moreover, the flags introduce some inconsistency in the menu bar. When DrILL is opened and then closed, its menu bar is displayed for interfaces opened later.

We decided to provide this quick fix for now. This is reverting what has been done in #30129 for DrILL only.

**To test:**

* open DrILL and try the following keyboard shortcuts: `ctrl-Q`, `ctrl-S`, `ctrl-O` and `ctrl-N`
* "on top" setting should have no effect on DrILL

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
