### PR TITLE
Use proper rounding to get row and col number in CentroidPeaks

### DIFF
--- a/Framework/Crystal/src/CentroidPeaks.cpp
+++ b/Framework/Crystal/src/CentroidPeaks.cpp
@@ -139,11 +139,11 @@ void CentroidPeaks::integrate() {
       }
     }
     // Set pixelID to change row and col
-    row = std::round(rowcentroid / intensity);
+    row = (int)std::lround(rowcentroid / intensity);
     boost::algorithm::clamp(row, 0, nRows - 1);
-    col = std::round(colcentroid / intensity);
+    col = (int)std::lround(colcentroid / intensity);
     boost::algorithm::clamp(col, 0, nCols - 1);
-    chan = std::round(chancentroid / intensity);
+    chan = (int)std::lround(chancentroid / intensity);
     boost::algorithm::clamp(chan, 0, inBlocksize);
 
     // Set wavelength to change tof for peak object

--- a/Framework/Crystal/src/CentroidPeaks.cpp
+++ b/Framework/Crystal/src/CentroidPeaks.cpp
@@ -139,11 +139,11 @@ void CentroidPeaks::integrate() {
       }
     }
     // Set pixelID to change row and col
-    row = int(rowcentroid / intensity);
+    row = std::round(rowcentroid / intensity);
     boost::algorithm::clamp(row, 0, nRows - 1);
-    col = int(colcentroid / intensity);
+    col = std::round(colcentroid / intensity);
     boost::algorithm::clamp(col, 0, nCols - 1);
-    chan = int(chancentroid / intensity);
+    chan = std::round(chancentroid / intensity);
     boost::algorithm::clamp(chan, 0, inBlocksize);
 
     // Set wavelength to change tof for peak object


### PR DESCRIPTION
**Description of work.**

- Original Gitlab task: [SCD304](https://code.ornl.gov/sns-hfir-scse/diffraction/single-crystal/single-crystal-diffraction/-/issues/304)
- This is #31332  into `master`

This PR switch to `std::round` from `int` when setting the detector ID in CentroidPeaks, which should provide a slightly more accurate detector position.

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

**To test:**
The change here is very minor, no testing needed.

<!-- Instructions for testing. -->

Fixes #xxxx. <!-- and fix #xxxx or close #xxxx xor resolves #xxxx -->
<!-- alternative
*There is no associated issue.*
-->

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or master)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
