### PR TITLE
Fix identical sequential fitting log values

### DIFF
--- a/scripts/Muon/GUI/Common/fitting_widgets/basic_fitting/basic_fitting_model.py
+++ b/scripts/Muon/GUI/Common/fitting_widgets/basic_fitting/basic_fitting_model.py
@@ -500,7 +500,7 @@ class BasicFittingModel:
         alg = self._create_fit_algorithm()
         output_workspace, parameter_table, function, fit_status, chi_squared, covariance_matrix = run_Fit(parameters,
                                                                                                           alg)
-        CopyLogs(InputWorkspace=self.current_dataset_name, OutputWorkspace=output_workspace, StoreInADS=False)
+        CopyLogs(InputWorkspace=parameters["InputWorkspace"], OutputWorkspace=output_workspace, StoreInADS=False)
         return output_workspace, parameter_table, function, fit_status, chi_squared, covariance_matrix
 
     def _get_parameters_for_single_fit(self, dataset_name: str, single_fit_function: IFunction) -> dict:


### PR DESCRIPTION
In the muon analysis gui, fixes identical log values in the output table of a sequential fit.

**To test:**
- Load EMU 20918-20
- Add a fit function
- Do a sequential fit
- Go to results table
- Tick the run_number option
- Click Output results
- Check that the run numbers are correct

Fixes #31242.

*This does not require release notes* because **it was introduced in this release cycle**

<!-- Ensure the base of this PR is correct (e.g. release-next or master)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
