### PR TITLE
Remove Qt usage from Framework plotting

### DIFF
--- a/Framework/PythonInterface/mantid/plots/mantidimage.py
+++ b/Framework/PythonInterface/mantid/plots/mantidimage.py
@@ -6,7 +6,6 @@
 # SPDX - License - Identifier: GPL - 3.0 +
 import matplotlib.image as mimage
 import numpy as np
-from qtpy.QtCore import Qt
 
 from enum import Enum
 
@@ -20,7 +19,8 @@ class ImageIntensity(Enum):
 
 
 class MantidImage(mimage.AxesImage):
-    def __init__(self, ax,
+    def __init__(self,
+                 ax,
                  cmap=None,
                  norm=None,
                  interpolation=None,
@@ -41,47 +41,12 @@ class MantidImage(mimage.AxesImage):
                          resample=resample,
                          **kwargs)
 
-        # Increase the default pen thickness
-        self.update_pen_thickness(1.5)
-
-    def draw(self, renderer, *args, **kwargs):
-        self.update_pen_color()
-        super().draw(renderer, *args, **kwargs)
-
-    def update_pen_color(self, color=None):
-        """Update the pen color used to draw tool in the matplotlib toolbar, e.g
-        the zoombox. If no color is specified the color is automatically determined
-        by considering how dark, or light the image is and setting a pen appropriately.
-        If the canvas is not a MantidFigureCanvas, the method will be skipped.
-        :param color: A qt color instance
-        """
-        from workbench.plotting.mantidfigurecanvas import MantidFigureCanvas
-        if not isinstance(self.axes.get_figure().canvas, MantidFigureCanvas):
-            return
-        if color is None:
-            image_intensity = self._calculate_greyscale_intensity()
-            if image_intensity == ImageIntensity.DARK:
-                color = Qt.white
-            else:
-                color = Qt.black
-        self.axes.get_figure().canvas.pen_color = color
-
-    def update_pen_thickness(self, value):
-        """Update the pen thickness used to draw tool in the matplotlib toolbar, e.g
-        the zoombox.
-        If the canvas is not a MantidFigureCanvas, the method will be skipped.
-        :param value: Thickness of the pen line
-        """
-        from workbench.plotting.mantidfigurecanvas import MantidFigureCanvas
-        if isinstance(self.axes.get_figure().canvas, MantidFigureCanvas):
-            self.axes.get_figure().canvas.pen_thickness = value
-
-    def _calculate_greyscale_intensity(self) -> ImageIntensity:
+    def calculate_greyscale_intensity(self) -> ImageIntensity:
         """
         Calculate the intensity of the image in greyscale.
         The intensity is given in the range [0, 255] where:
-        -0 is black - i.e. a dark image and
-        -255 is white, a light image.
+        - 0 is black - i.e. a dark image and
+        - 255 is white, a light image.
         """
         rgb = self.to_rgba(self._A, alpha=None, bytes=True, norm=True)
         r, g, b = rgb[:, :, 0], rgb[:, :, 1], rgb[:, :, 2]

--- a/Testing/SystemTests/tests/qt/CppInterfacesStartupTest.py
+++ b/Testing/SystemTests/tests/qt/CppInterfacesStartupTest.py
@@ -6,14 +6,15 @@
 # SPDX - License - Identifier: GPL - 3.0 +
 import systemtesting
 
-# Must be imported after systemtesting to avoid an error.
-import sip
-
 from mantidqt.interfacemanager import InterfaceManager
 from mantidqt.usersubwindowfactory import UserSubWindowFactory
 from mantidqt.utils.qt.testing import get_application
 
 from qtpy.QtCore import Qt
+# Import sip after Qt. Modern versions of PyQt ship an internal sip module
+# located at PyQt5X.sip. Importing PyQt first sets a shim sip module to point
+# to the correct place
+import sip
 
 
 class CppInterfacesStartupTest(systemtesting.MantidSystemTest):

--- a/qt/applications/workbench/workbench/plotting/mantidfigurecanvas.py
+++ b/qt/applications/workbench/workbench/plotting/mantidfigurecanvas.py
@@ -12,14 +12,14 @@ from qtpy.QtCore import Qt
 from qtpy.QtGui import QPen
 from matplotlib.backends.backend_qt5agg import (  # noqa: F401
     FigureCanvasQTAgg, draw_if_interactive, show)
+from mantid.plots.mantidimage import MantidImage, ImageIntensity
 
 
 class MantidFigureCanvas(FigureCanvasQTAgg):
-
     def __init__(self, figure):
         super().__init__(figure=figure)
         self._pen_color = Qt.black
-        self._pen_thickness = 1
+        self._pen_thickness = 1.5
 
     # options controlling the pen used by tools that manipulate the graph - e.g the zoom box
     @property
@@ -40,16 +40,38 @@ class MantidFigureCanvas(FigureCanvasQTAgg):
 
     # Method used by the zoom box tool on the matplotlib toolbar
     def drawRectangle(self, rect):
+        self.update_pen_color()
         # Draw the zoom rectangle to the QPainter.  _draw_rect_callback needs
         # to be called at the end of paintEvent.
         if rect is not None:
+
             def _draw_rect_callback(painter):
-                pen = QPen(self.pen_color, self.pen_thickness / self._dpi_ratio,
-                           Qt.DotLine)
+                pen = QPen(self.pen_color, self.pen_thickness / self._dpi_ratio, Qt.DotLine)
                 painter.setPen(pen)
                 painter.drawRect(*(pt / self._dpi_ratio for pt in rect))
         else:
+
             def _draw_rect_callback(painter):
                 return
+
         self._draw_rect_callback = _draw_rect_callback
         self.update()
+
+    def update_pen_color(self):
+        """Update the pen color used to draw tool in the matplotlib toolbar, e.g
+        the zoombox. The color is automatically determined
+        by considering how dark, or light the image is and setting a pen appropriately.
+        Only works if the figure contains a MantidImage.
+        """
+        for ax in self.figure.get_axes():
+            for img in ax.get_images():
+                if (not isinstance(img, MantidImage)):
+                    continue
+                intensity = img.calculate_greyscale_intensity()
+                if intensity == ImageIntensity.DARK:
+                    color = Qt.white
+                else:
+                    color = Qt.black
+                self.pen_color = color
+                # break after we find the first MantidImage
+                break


### PR DESCRIPTION
**Description of work.**
Removes qt usage from framework plotting.
<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

**To test:**

- Load some data, or do `ws=CreateSampleWorkspace()`
- Open sliceviewer
- Test the magnification tool, it will be white to start with as the image is “dark”
- Zoom in on the high counting data, as you go further in the tool will change to black (as yellow fills the screen)
- Go back to the home view
- Click reverse
- The tool should now be black

<!-- Instructions for testing. -->

*There is no associated issue.*

*This does not require release notes as this is fixing an internal issue*

<!-- Ensure the base of this PR is correct (e.g. release-next or master)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
