### PR TITLE
Fix plot script generator for tiled plots

### DIFF
--- a/docs/source/release/v6.1.0/mantidworkbench.rst
+++ b/docs/source/release/v6.1.0/mantidworkbench.rst
@@ -47,6 +47,7 @@ Bugfixes
 - Fixed a bug where Workbench would hang on startup when running on Big Sur.
 - Fixed a bug applying constraints with the conjugate gradient minimizer.
 - Fixed a bug where panning on a colour fill plot stretches dataset along spectrum axis instead of panning
+- Fixed a problem with scripts generated from tiled plots.
 
 Interfaces
 ----------

--- a/qt/applications/workbench/workbench/plotting/plotscriptgenerator/__init__.py
+++ b/qt/applications/workbench/workbench/plotting/plotscriptgenerator/__init__.py
@@ -76,7 +76,7 @@ def generate_script(fig, exclude_headers=False):
                 continue
             plot_commands.extend(get_plot_cmds(ax, ax_object_var))  # ax.plot
 
-        plot_commands.extend(generate_tick_commands(ax))
+        plot_commands.extend(get_tick_commands(ax, ax_object_var))
         plot_commands.extend(get_title_cmds(ax, ax_object_var))  # ax.set_title
         plot_commands.extend(get_axis_label_cmds(ax, ax_object_var))  # ax.set_label
         plot_commands.extend(get_axis_limit_cmds(ax, ax_object_var))  # ax.set_lim
@@ -162,6 +162,12 @@ def get_legend_cmds(ax, ax_object_var):
         cmds.extend(generate_label_font_commands(ax.legend_, LEGEND_VARIABLE))
         cmds.extend(generate_visible_command(ax.legend_, LEGEND_VARIABLE))
     return cmds
+
+
+def get_tick_commands(ax, ax_object_var):
+    """Get ax.tick_params commands for setting properties of tick marks and grid lines."""
+    tick_commands = generate_tick_commands(ax)
+    return ["{ax_obj}.{cmd}".format(ax_obj=ax_object_var, cmd=cmd) for cmd in tick_commands]
 
 
 def get_axes_object_variable(ax):

--- a/qt/applications/workbench/workbench/plotting/plotscriptgenerator/axes.py
+++ b/qt/applications/workbench/workbench/plotting/plotscriptgenerator/axes.py
@@ -63,13 +63,13 @@ def generate_tick_commands(ax):
     for tick_type in ["minor", "major"]:
         if not isinstance(getattr(ax.xaxis, tick_type).locator, NullLocator):
             if tick_type == "minor":
-                commands.append("axes.minorticks_on()")
+                commands.append("minorticks_on()")
 
             if isinstance(getattr(ax.xaxis, f"{tick_type}Ticks"), list) and \
                     len(getattr(ax.xaxis, f"{tick_type}Ticks")) > 0:
-                commands.append(f"axes.tick_params(axis='x', which='{tick_type}', **"
+                commands.append(f"tick_params(axis='x', which='{tick_type}', **"
                                 f"{generate_tick_params_kwargs(ax.xaxis, tick_type)})")
-                commands.append(f"axes.tick_params(axis='y', which='{tick_type}', **"
+                commands.append(f"tick_params(axis='y', which='{tick_type}', **"
                                 f"{generate_tick_params_kwargs(ax.yaxis, tick_type)})")
 
     return commands

--- a/qt/applications/workbench/workbench/plotting/plotscriptgenerator/test/test_plotscriptgeneratoraxes.py
+++ b/qt/applications/workbench/workbench/plotting/plotscriptgenerator/test/test_plotscriptgeneratoraxes.py
@@ -15,6 +15,7 @@ import matplotlib.pyplot as plt
 from unittest.mock import Mock
 from workbench.plotting.plotscriptgenerator.axes import (generate_axis_limit_commands,
                                                          generate_axis_label_commands)
+from workbench.plotting.plotscriptgenerator import generate_script
 
 
 class PlotGeneratorAxisTest(unittest.TestCase):
@@ -70,6 +71,20 @@ class PlotGeneratorAxisTest(unittest.TestCase):
         ax.set_ylim([0, 4])
         self.assertEqual(['set_xlim([-5.0, 5.0])', 'set_ylim([0.0, 4.0])'],
                          generate_axis_limit_commands(ax))
+        plt.close()
+        del fig
+
+    def test_generate_tick_commands_for_tiled_plot(self):
+        fig, axes = plt.subplots(ncols=2, nrows=2, subplot_kw={'projection': 'mantid'})
+        for ax in fig.get_axes():
+            ax.plot([-10, 10], [1, 2])
+        script = generate_script(fig)
+        # Should be axes[i][j].tick_params for multiple subplots.
+        self.assertNotIn("axes.tick_params", script)
+        self.assertIn("axes[0][0].tick_params", script)
+        self.assertIn("axes[0][1].tick_params", script)
+        self.assertIn("axes[1][0].tick_params", script)
+        self.assertIn("axes[1][1].tick_params", script)
         plt.close()
         del fig
 


### PR DESCRIPTION
**Description of work.**

When creating a script from a tiled plot, the indices for the subplots weren't being used in the tick parameter commands, so the script would fail. This has been resolved.

**To test:**
- Create a tiled plot, e.g. follow instructions here:
https://docs.mantidproject.org/nightly/tutorials/mantid_basic_course/loading_and_displaying_data/05_plotting_advanced.html
- Generate a script from the plot by clicking the script toolbar button and "Script to clipboard.
- Close the plot.
- Paste the script into the python editor.
- Run the script and check that it reproduces the plot.

Fixes #31267.

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
