### PR TITLE
Move Workspace Selector Widget to BasicFittingWidget in Muon Analysis

### DIFF
--- a/scripts/Muon/GUI/Common/contexts/data_analysis_context.py
+++ b/scripts/Muon/GUI/Common/contexts/data_analysis_context.py
@@ -17,7 +17,7 @@ class DataAnalysisContext(MuonContext):
         self.base_directory = 'Muon Data'
 
     def get_names_of_workspaces_to_fit(
-            self, runs='', group_and_pair='', rebin=False, freq="None"):
+            self, runs='', group_and_pair='', rebin=False):
         return self.get_names_of_time_domain_workspaces_to_fit(
             runs=runs, group_and_pair=group_and_pair, rebin=rebin)
 
@@ -40,6 +40,14 @@ class DataAnalysisContext(MuonContext):
     @property
     def default_fitting_plot_range(self):
         return self.default_data_plot_range
+
+    @property
+    def default_end_x(self):
+        return 15.0
+
+    @property
+    def guess_workspace_prefix(self):
+        return "__muon_analysis_fitting_guess"
 
     @property
     def window_title(self):

--- a/scripts/Muon/GUI/Common/contexts/frequency_domain_analysis_context.py
+++ b/scripts/Muon/GUI/Common/contexts/frequency_domain_analysis_context.py
@@ -29,6 +29,14 @@ class FrequencyDomainAnalysisContext(MuonContext):
     def default_fitting_plot_range(self):
         return self._freq_plotting_context.default_xlims
 
+    @property
+    def default_end_x(self):
+        return 250.0
+
+    @property
+    def guess_workspace_prefix(self):
+        return "__frequency_domain_analysis_fitting_guess"
+
     def get_workspace_names_for_FFT_analysis(self, use_raw=True):
         groups_and_pairs = ','.join(self.group_pair_context.selected_groups_and_pairs)
         workspace_options = self.get_names_of_time_domain_workspaces_to_fit(
@@ -36,10 +44,10 @@ class FrequencyDomainAnalysisContext(MuonContext):
         return workspace_options
 
     def get_names_of_workspaces_to_fit(self, runs='', group_and_pair='',
-                                       phasequad=False, rebin=False, freq="None"):
+                                       phasequad=False, rebin=False):
 
         return self.get_names_of_frequency_domain_workspaces_to_fit(
-            runs=runs, group_and_pair=group_and_pair, frequency_type=freq)
+            runs=runs, group_and_pair=group_and_pair, frequency_type=self._frequency_context.plot_type)
 
     def get_names_of_frequency_domain_workspaces_to_fit(
             self, runs='', group_and_pair='', frequency_type="None"):

--- a/scripts/Muon/GUI/Common/contexts/frequency_domain_analysis_context.py
+++ b/scripts/Muon/GUI/Common/contexts/frequency_domain_analysis_context.py
@@ -31,7 +31,7 @@ class FrequencyDomainAnalysisContext(MuonContext):
 
     @property
     def default_end_x(self):
-        return 250.0
+        return self._freq_plotting_context.default_xlims[1]
 
     @property
     def guess_workspace_prefix(self):

--- a/scripts/Muon/GUI/Common/fitting_tab_widget/fitting_tab_widget.py
+++ b/scripts/Muon/GUI/Common/fitting_tab_widget/fitting_tab_widget.py
@@ -24,11 +24,13 @@ class FittingTabWidget(object):
         is_frequency_domain = isinstance(context, FrequencyDomainAnalysisContext)
 
         if is_frequency_domain:
-            self.fitting_tab_view = BasicFittingView(parent, is_frequency_domain)
+            self.fitting_tab_view = BasicFittingView(parent)
+            self.fitting_tab_view.hide_fit_raw_checkbox()
             self.fitting_tab_model = BasicFittingModel(context, is_frequency_domain)
             self.fitting_tab_presenter = BasicFittingPresenter(self.fitting_tab_view, self.fitting_tab_model)
         else:
-            self.fitting_tab_view = TFAsymmetryFittingView(parent, is_frequency_domain)
+            self.fitting_tab_view = TFAsymmetryFittingView(parent)
+            self.fitting_tab_view.set_start_and_end_x_labels("Time Start", "Time End")
             self.fitting_tab_model = TFAsymmetryFittingModel(context, is_frequency_domain)
             self.fitting_tab_presenter = TFAsymmetryFittingPresenter(self.fitting_tab_view, self.fitting_tab_model)
 

--- a/scripts/Muon/GUI/Common/fitting_tab_widget/fitting_tab_widget.py
+++ b/scripts/Muon/GUI/Common/fitting_tab_widget/fitting_tab_widget.py
@@ -5,9 +5,9 @@
 #   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
 # SPDX - License - Identifier: GPL - 3.0 +
 from Muon.GUI.Common.contexts.frequency_domain_analysis_context import FrequencyDomainAnalysisContext
-from Muon.GUI.Common.fitting_widgets.general_fitting.general_fitting_model import GeneralFittingModel
-from Muon.GUI.Common.fitting_widgets.general_fitting.general_fitting_presenter import GeneralFittingPresenter
-from Muon.GUI.Common.fitting_widgets.general_fitting.general_fitting_view import GeneralFittingView
+from Muon.GUI.Common.fitting_widgets.basic_fitting.basic_fitting_model import BasicFittingModel
+from Muon.GUI.Common.fitting_widgets.basic_fitting.basic_fitting_presenter import BasicFittingPresenter
+from Muon.GUI.Common.fitting_widgets.basic_fitting.basic_fitting_view import BasicFittingView
 from Muon.GUI.Common.fitting_widgets.tf_asymmetry_fitting.tf_asymmetry_fitting_model import TFAsymmetryFittingModel
 from Muon.GUI.Common.fitting_widgets.tf_asymmetry_fitting.tf_asymmetry_fitting_presenter \
     import TFAsymmetryFittingPresenter
@@ -24,9 +24,9 @@ class FittingTabWidget(object):
         is_frequency_domain = isinstance(context, FrequencyDomainAnalysisContext)
 
         if is_frequency_domain:
-            self.fitting_tab_view = GeneralFittingView(parent, is_frequency_domain)
-            self.fitting_tab_model = GeneralFittingModel(context, is_frequency_domain)
-            self.fitting_tab_presenter = GeneralFittingPresenter(self.fitting_tab_view, self.fitting_tab_model)
+            self.fitting_tab_view = BasicFittingView(parent, is_frequency_domain)
+            self.fitting_tab_model = BasicFittingModel(context, is_frequency_domain)
+            self.fitting_tab_presenter = BasicFittingPresenter(self.fitting_tab_view, self.fitting_tab_model)
         else:
             self.fitting_tab_view = TFAsymmetryFittingView(parent, is_frequency_domain)
             self.fitting_tab_model = TFAsymmetryFittingModel(context, is_frequency_domain)

--- a/scripts/Muon/GUI/Common/fitting_tab_widget/fitting_tab_widget.py
+++ b/scripts/Muon/GUI/Common/fitting_tab_widget/fitting_tab_widget.py
@@ -17,7 +17,7 @@ from Muon.GUI.Common.fitting_widgets.tf_asymmetry_fitting.tf_asymmetry_fitting_v
 class FittingTabWidget(object):
     """
     The FittingTabWidget creates the tab used for fitting. Muon Analysis uses the TF Asymmetry fitting widget, and
-    Frequency Domain Analysis uses the General fitting widget.
+    Frequency Domain Analysis uses the Basic fitting widget.
     """
 
     def __init__(self, context, parent):

--- a/scripts/Muon/GUI/Common/fitting_tab_widget/fitting_tab_widget.py
+++ b/scripts/Muon/GUI/Common/fitting_tab_widget/fitting_tab_widget.py
@@ -26,12 +26,12 @@ class FittingTabWidget(object):
         if is_frequency_domain:
             self.fitting_tab_view = BasicFittingView(parent)
             self.fitting_tab_view.hide_fit_raw_checkbox()
-            self.fitting_tab_model = BasicFittingModel(context, is_frequency_domain)
+            self.fitting_tab_model = BasicFittingModel(context)
             self.fitting_tab_presenter = BasicFittingPresenter(self.fitting_tab_view, self.fitting_tab_model)
         else:
             self.fitting_tab_view = TFAsymmetryFittingView(parent)
             self.fitting_tab_view.set_start_and_end_x_labels("Time Start", "Time End")
-            self.fitting_tab_model = TFAsymmetryFittingModel(context, is_frequency_domain)
+            self.fitting_tab_model = TFAsymmetryFittingModel(context)
             self.fitting_tab_presenter = TFAsymmetryFittingPresenter(self.fitting_tab_view, self.fitting_tab_model)
 
         self.fitting_tab_presenter.disable_fitting_notifier.add_subscriber(self.fitting_tab_view.disable_tab_observer)

--- a/scripts/Muon/GUI/Common/fitting_widgets/basic_fitting/basic_fitting_model.py
+++ b/scripts/Muon/GUI/Common/fitting_widgets/basic_fitting/basic_fitting_model.py
@@ -4,7 +4,7 @@
 #   NScD Oak Ridge National Laboratory, European Spallation Source,
 #   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
 # SPDX - License - Identifier: GPL - 3.0 +
-from mantid import AlgorithmManager, AnalysisDataService, logger
+from mantid import AlgorithmManager, logger
 from mantid.api import CompositeFunction, IAlgorithm, IFunction
 from mantid.simpleapi import CopyLogs, EvaluateFunction
 
@@ -576,7 +576,7 @@ class BasicFittingModel:
     @staticmethod
     def _check_data_exists(workspace_names: list) -> list:
         """Returns only the workspace names that exist in the ADS."""
-        return [workspace_name for workspace_name in workspace_names if AnalysisDataService.doesExist(workspace_name)]
+        return [workspace_name for workspace_name in workspace_names if check_if_workspace_exist(workspace_name)]
 
     def get_selected_runs_groups_and_pairs(self) -> tuple:
         """Returns the runs, groups and pairs to use for single fit mode."""

--- a/scripts/Muon/GUI/Common/fitting_widgets/basic_fitting/basic_fitting_model.py
+++ b/scripts/Muon/GUI/Common/fitting_widgets/basic_fitting/basic_fitting_model.py
@@ -4,12 +4,14 @@
 #   NScD Oak Ridge National Laboratory, European Spallation Source,
 #   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
 # SPDX - License - Identifier: GPL - 3.0 +
-from mantid import AlgorithmManager, logger
+from mantid import AlgorithmManager, AnalysisDataService, logger
 from mantid.api import CompositeFunction, IAlgorithm, IFunction
 from mantid.simpleapi import CopyLogs, EvaluateFunction, RenameWorkspace
 
 from Muon.GUI.Common.ADSHandler.ADS_calls import check_if_workspace_exist, retrieve_ws
-from Muon.GUI.Common.ADSHandler.workspace_naming import create_fitted_workspace_name, create_parameter_table_name
+from Muon.GUI.Common.ADSHandler.workspace_naming import (create_fitted_workspace_name, create_parameter_table_name,
+                                                         get_group_or_pair_from_name,
+                                                         get_run_number_from_workspace_name)
 from Muon.GUI.Common.ADSHandler.muon_workspace_wrapper import MuonWorkspaceWrapper
 from Muon.GUI.Common.contexts.fitting_context import FitInformation
 from Muon.GUI.Common.contexts.muon_context import MuonContext
@@ -58,6 +60,9 @@ class BasicFittingModel:
     def __init__(self, context: MuonContext, is_frequency_domain: bool = False):
         """Initializes the model with empty fit data."""
         self.context = context
+
+        self._x_data_type = self.context._frequency_context.plot_type if is_frequency_domain else "None"
+        self._group_or_pair_index = {}
 
         self._default_end_x = DEFAULT_FDA_END_X if is_frequency_domain else DEFAULT_MA_END_X
 
@@ -395,11 +400,6 @@ class BasicFittingModel:
         """Returns true if the fitting mode is simultaneous. Override this method if you require simultaneous."""
         return False
 
-    @property
-    def global_parameters(self) -> list:
-        """Returns the global parameters stored in the model. Override this method if you require global parameters."""
-        return []
-
     def update_parameter_value(self, full_parameter: str, value: float) -> None:
         """Update the value of a parameter in the fit function."""
         if self.current_single_fit_function is not None:
@@ -542,9 +542,59 @@ class BasicFittingModel:
         else:
             return []
 
-    def get_workspace_names_to_display_from_context(self) -> None:
-        """Returns the workspace names to display in the view and store in the model."""
-        raise NotImplementedError("This method must be overridden by a child class.")
+    def get_workspace_names_to_display_from_context(self) -> list:
+        """Returns the workspace names to display in the view based on the selected run and group/pair options."""
+        runs, groups_and_pairs = self.get_selected_runs_groups_and_pairs()
+
+        display_workspaces = []
+        for group_and_pair in groups_and_pairs:
+            display_workspaces += self._get_workspace_names_to_display_from_context(runs, group_and_pair)
+
+        return self._sort_workspace_names(display_workspaces)
+
+    def _get_workspace_names_to_display_from_context(self, runs: list, group_and_pair: str) -> list:
+        """Returns the workspace names for the given runs and group/pair to be displayed in the view."""
+        return self.context.get_names_of_workspaces_to_fit(runs=runs, group_and_pair=group_and_pair,
+                                                           rebin=not self.fit_to_raw, freq=self._x_data_type)
+
+    def _sort_workspace_names(self, workspace_names: list) -> list:
+        """Sort the workspace names and check the workspaces exist in the ADS."""
+        workspace_names = list(set(self._check_data_exists(workspace_names)))
+        if len(workspace_names) > 1:
+            workspace_names.sort(key=self._workspace_list_sorter)
+        return workspace_names
+
+    def _workspace_list_sorter(self, workspace_name: str) -> int:
+        """Used to sort a list of workspace names based on run number and group/pair name."""
+        run_number = get_run_number_from_workspace_name(workspace_name, self.context.data_context.instrument)
+        grp_pair_number = self._transform_group_or_pair_to_float(workspace_name)
+        return int(run_number) + grp_pair_number
+
+    def _transform_group_or_pair_to_float(self, workspace_name: str) -> int:
+        """Converts the workspace group or pair name to a float which is used in sorting the workspace list."""
+        group_or_pair_name = get_group_or_pair_from_name(workspace_name)
+        if group_or_pair_name not in self._group_or_pair_index:
+            self._group_or_pair_index[group_or_pair_name] = len(self._group_or_pair_index)
+
+        group_or_pair_values = list(self._group_or_pair_index.values())
+        if len(self._group_or_pair_index) > 1:
+            return ((self._group_or_pair_index[group_or_pair_name] - group_or_pair_values[0])
+                    / (group_or_pair_values[-1] - group_or_pair_values[0])) * 0.99
+        else:
+            return 0
+
+    @staticmethod
+    def _check_data_exists(workspace_names: list) -> list:
+        """Returns only the workspace names that exist in the ADS."""
+        return [workspace_name for workspace_name in workspace_names if AnalysisDataService.doesExist(workspace_name)]
+
+    def get_selected_runs_groups_and_pairs(self) -> tuple:
+        """Returns the runs, groups and pairs to use for single fit mode."""
+        return "All", self._get_selected_groups_and_pairs()
+
+    def _get_selected_groups_and_pairs(self) -> list:
+        """Returns the groups and pairs currently selected in the context."""
+        return self.context.group_pair_context.selected_groups_and_pairs
 
     def perform_fit(self) -> tuple:
         """Performs a single fit and returns the resulting function, status and chi squared."""

--- a/scripts/Muon/GUI/Common/fitting_widgets/basic_fitting/basic_fitting_view.py
+++ b/scripts/Muon/GUI/Common/fitting_widgets/basic_fitting/basic_fitting_view.py
@@ -23,14 +23,14 @@ class BasicFittingView(QWidget, ui_fitting_layout):
     The BasicFittingView has a FitControlsView and a FitFunctionOptionsView. It can be used for Single Fitting.
     """
 
-    def __init__(self, parent: QWidget = None, is_frequency_domain: bool = False):
+    def __init__(self, parent: QWidget = None):
         """Initialize the BasicFittingView and create the FitControlsView and a FitFunctionOptionsView."""
         super(BasicFittingView, self).__init__(parent)
         self.setupUi(self)
 
         self.fit_controls = FitControlsView(self)
         self.workspace_selector = WorkspaceSelectorView(self)
-        self.fit_function_options = FitFunctionOptionsView(self, is_frequency_domain)
+        self.fit_function_options = FitFunctionOptionsView(self)
 
         self.fit_controls_layout.addWidget(self.fit_controls)
         self.workspace_selector_layout.addWidget(self.workspace_selector)
@@ -233,6 +233,14 @@ class BasicFittingView(QWidget, ui_fitting_layout):
     def switch_to_single(self) -> None:
         """Switches the view to single fit mode."""
         self.fit_function_options.switch_to_single()
+
+    def hide_fit_raw_checkbox(self) -> None:
+        """Hides the Fit Raw checkbox in the fitting options."""
+        self.fit_function_options.hide_fit_raw_checkbox()
+
+    def set_start_and_end_x_labels(self, start_x_label: str, end_x_label: str) -> None:
+        """Sets the labels to use for the start and end X labels in the fit options table."""
+        self.fit_function_options.set_start_and_end_x_labels(start_x_label, end_x_label)
 
     def disable_view(self) -> None:
         """Disable all widgets in this fitting widget."""

--- a/scripts/Muon/GUI/Common/fitting_widgets/basic_fitting/basic_fitting_view.py
+++ b/scripts/Muon/GUI/Common/fitting_widgets/basic_fitting/basic_fitting_view.py
@@ -10,6 +10,7 @@ from mantidqt.utils.qt import load_ui
 
 from Muon.GUI.Common.fitting_widgets.basic_fitting.fit_controls_view import FitControlsView
 from Muon.GUI.Common.fitting_widgets.basic_fitting.fit_function_options_view import FitFunctionOptionsView
+from Muon.GUI.Common.fitting_widgets.basic_fitting.workspace_selector_view import WorkspaceSelectorView
 from Muon.GUI.Common.message_box import warning
 
 from qtpy.QtWidgets import QWidget
@@ -28,9 +29,11 @@ class BasicFittingView(QWidget, ui_fitting_layout):
         self.setupUi(self)
 
         self.fit_controls = FitControlsView(self)
+        self.workspace_selector = WorkspaceSelectorView(self)
         self.fit_function_options = FitFunctionOptionsView(self, is_frequency_domain)
 
         self.fit_controls_layout.addWidget(self.fit_controls)
+        self.workspace_selector_layout.addWidget(self.workspace_selector)
         self.fit_function_options_layout.addWidget(self.fit_function_options)
 
         self.disable_tab_observer = GenericObserver(self.disable_view)
@@ -53,6 +56,10 @@ class BasicFittingView(QWidget, ui_fitting_layout):
     def set_slot_for_plot_guess_changed(self, slot) -> None:
         """Connect the slot for the Plot Guess checkbox."""
         self.fit_controls.set_slot_for_plot_guess_changed(slot)
+
+    def set_slot_for_dataset_changed(self, slot) -> None:
+        """Connect the slot for the display workspace combo box being changed."""
+        self.workspace_selector.set_slot_for_dataset_changed(slot)
 
     def set_slot_for_fit_name_changed(self, slot) -> None:
         """Connect the slot for the fit name being changed by the user."""
@@ -86,6 +93,10 @@ class BasicFittingView(QWidget, ui_fitting_layout):
         """Connect the slot for the Use raw option."""
         self.fit_function_options.set_slot_for_use_raw_changed(slot)
 
+    def set_workspace_combo_box_label(self, text: str) -> None:
+        """Sets the label text next to the workspace selector combobox."""
+        self.workspace_selector.set_workspace_combo_box_label(text)
+
     def set_datasets_in_function_browser(self, dataset_names: list) -> None:
         """Sets the datasets stored in the FunctionBrowser."""
         self.fit_function_options.set_datasets_in_function_browser(dataset_names)
@@ -94,6 +105,10 @@ class BasicFittingView(QWidget, ui_fitting_layout):
         """Sets the index of the current dataset."""
         if dataset_index is not None:
             self.fit_function_options.set_current_dataset_index(dataset_index)
+
+    def update_dataset_name_combo_box(self, dataset_names: list) -> None:
+        """Update the data in the parameter display combo box."""
+        self.workspace_selector.update_dataset_name_combo_box(dataset_names)
 
     def update_local_fit_status_and_chi_squared(self, fit_status: str, chi_squared: float) -> None:
         """Updates the view to show the status and results from a fit."""
@@ -109,6 +124,25 @@ class BasicFittingView(QWidget, ui_fitting_layout):
     def update_fit_function(self, fit_function: IFunction) -> None:
         """Updates the parameters of a fit function shown in the view."""
         self.fit_function_options.update_function_browser_parameters(False, fit_function)
+
+    @property
+    def current_dataset_name(self) -> str:
+        """Returns the selected dataset name."""
+        return self.workspace_selector.current_dataset_name
+
+    @current_dataset_name.setter
+    def current_dataset_name(self, dataset_name: str) -> None:
+        """Sets the currently selected dataset name."""
+        self.workspace_selector.current_dataset_name = dataset_name
+
+    def number_of_datasets(self) -> int:
+        """Returns the number of dataset names loaded into the widget."""
+        return self.workspace_selector.number_of_datasets()
+
+    @property
+    def current_dataset_index(self) -> str:
+        """Returns the index of the currently displayed dataset."""
+        return self.workspace_selector.current_dataset_index
 
     @property
     def fit_object(self) -> IFunction:
@@ -178,10 +212,6 @@ class BasicFittingView(QWidget, ui_fitting_layout):
     def function_name(self, function_name: str) -> None:
         """Sets the function name being used."""
         self.fit_function_options.function_name = function_name
-
-    def number_of_datasets(self) -> int:
-        """Returns the number of dataset names loaded into the widget."""
-        return self.fit_function_options.number_of_datasets()
 
     def warning_popup(self, message: str) -> None:
         """Displays a warning message."""

--- a/scripts/Muon/GUI/Common/fitting_widgets/basic_fitting/fit_controls.ui
+++ b/scripts/Muon/GUI/Common/fitting_widgets/basic_fitting/fit_controls.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>595</width>
-    <height>23</height>
+    <height>25</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -26,6 +26,25 @@
    <property name="bottomMargin">
     <number>0</number>
    </property>
+   <item row="0" column="0">
+    <widget class="QCheckBox" name="plot_guess_checkbox">
+     <property name="minimumSize">
+      <size>
+       <width>250</width>
+       <height>0</height>
+      </size>
+     </property>
+     <property name="maximumSize">
+      <size>
+       <width>250</width>
+       <height>16777215</height>
+      </size>
+     </property>
+     <property name="text">
+      <string>Plot guess</string>
+     </property>
+    </widget>
+   </item>
    <item row="0" column="1">
     <widget class="QFrame" name="frame">
      <layout class="QHBoxLayout" name="horizontalLayout">
@@ -79,25 +98,6 @@
        </widget>
       </item>
      </layout>
-    </widget>
-   </item>
-   <item row="0" column="0">
-    <widget class="QCheckBox" name="plot_guess_checkbox">
-     <property name="minimumSize">
-      <size>
-       <width>180</width>
-       <height>0</height>
-      </size>
-     </property>
-     <property name="maximumSize">
-      <size>
-       <width>180</width>
-       <height>16777215</height>
-      </size>
-     </property>
-     <property name="text">
-      <string>Plot guess</string>
-     </property>
     </widget>
    </item>
   </layout>

--- a/scripts/Muon/GUI/Common/fitting_widgets/basic_fitting/fit_function_options_view.py
+++ b/scripts/Muon/GUI/Common/fitting_widgets/basic_fitting/fit_function_options_view.py
@@ -30,7 +30,7 @@ class FitFunctionOptionsView(QWidget, ui_fit_function_options):
     widget. It also holds the Fit Status and Chi Squared labels.
     """
 
-    def __init__(self, parent: QWidget = None, is_frequency_domain: bool = False):
+    def __init__(self, parent: QWidget = None):
         """Initializes the FitFunctionOptionsView and sets up the fit options table and FunctionBrowser."""
         super(FitFunctionOptionsView, self).__init__(parent)
         self.setupUi(self)
@@ -50,11 +50,6 @@ class FitFunctionOptionsView(QWidget, ui_fit_function_options):
         self.function_browser.setErrorsEnabled(True)
         self.function_browser.hideGlobalCheckbox()
         self.function_browser.setStretchLastColumn(True)
-
-        if is_frequency_domain:
-            self.fit_options_table.hideRow(RAW_DATA_TABLE_ROW)
-            table_utils.setRowName(self.fit_options_table, START_X_TABLE_ROW, "Start X")
-            table_utils.setRowName(self.fit_options_table, END_X_TABLE_ROW, "End X")
 
     def set_slot_for_fit_name_changed(self, slot) -> None:
         """Connect the slot for the fit name being changed by the user."""
@@ -222,6 +217,15 @@ class FitFunctionOptionsView(QWidget, ui_fit_function_options):
         self.function_browser.hideGlobalCheckbox()
         self.function_browser.setGlobalParameters([])
 
+    def hide_fit_raw_checkbox(self) -> None:
+        """Hides the Fit Raw checkbox in the fitting options."""
+        self.fit_options_table.hideRow(RAW_DATA_TABLE_ROW)
+
+    def set_start_and_end_x_labels(self, start_x_label: str, end_x_label: str) -> None:
+        """Sets the labels to use for the start and end X labels in the fit options table."""
+        table_utils.setRowName(self.fit_options_table, START_X_TABLE_ROW, start_x_label)
+        table_utils.setRowName(self.fit_options_table, END_X_TABLE_ROW, end_x_label)
+
     def _setup_fit_options_table(self) -> None:
         """Setup the fit options table with the appropriate options."""
         self.fit_options_table.setRowCount(5)
@@ -231,11 +235,11 @@ class FitFunctionOptionsView(QWidget, ui_fit_function_options):
         self.fit_options_table.horizontalHeader().setStretchLastSection(True)
         self.fit_options_table.setHorizontalHeaderLabels(["Property", "Value"])
 
-        table_utils.setRowName(self.fit_options_table, START_X_TABLE_ROW, "Time Start")
+        table_utils.setRowName(self.fit_options_table, START_X_TABLE_ROW, "Start X")
         self.start_x_line_edit, self.start_x_validator = table_utils.addDoubleToTable(self.fit_options_table, 0.0,
                                                                                       START_X_TABLE_ROW, 1)
 
-        table_utils.setRowName(self.fit_options_table, END_X_TABLE_ROW, "Time End")
+        table_utils.setRowName(self.fit_options_table, END_X_TABLE_ROW, "End X")
         self.end_x_line_edit, self.end_x_validator = table_utils.addDoubleToTable(self.fit_options_table, 15.0,
                                                                                   END_X_TABLE_ROW, 1)
 

--- a/scripts/Muon/GUI/Common/fitting_widgets/basic_fitting/fitting_layout.ui
+++ b/scripts/Muon/GUI/Common/fitting_widgets/basic_fitting/fitting_layout.ui
@@ -27,6 +27,9 @@
     <layout class="QGridLayout" name="general_fitting_options_layout"/>
    </item>
    <item>
+    <layout class="QGridLayout" name="workspace_selector_layout"/>
+   </item>
+   <item>
     <layout class="QGridLayout" name="tf_asymmetry_fitting_options_layout"/>
    </item>
    <item>

--- a/scripts/Muon/GUI/Common/fitting_widgets/basic_fitting/workspace_selector.ui
+++ b/scripts/Muon/GUI/Common/fitting_widgets/basic_fitting/workspace_selector.ui
@@ -30,7 +30,7 @@
     <widget class="QLabel" name="workspace_combo_box_label">
      <property name="minimumSize">
       <size>
-       <width>120</width>
+       <width>250</width>
        <height>0</height>
       </size>
      </property>

--- a/scripts/Muon/GUI/Common/fitting_widgets/basic_fitting/workspace_selector.ui
+++ b/scripts/Muon/GUI/Common/fitting_widgets/basic_fitting/workspace_selector.ui
@@ -1,0 +1,100 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>workspace_selector</class>
+ <widget class="QWidget" name="workspace_selector">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>606</width>
+    <height>25</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Form</string>
+  </property>
+  <layout class="QHBoxLayout" name="horizontalLayout">
+   <property name="leftMargin">
+    <number>0</number>
+   </property>
+   <property name="topMargin">
+    <number>0</number>
+   </property>
+   <property name="rightMargin">
+    <number>0</number>
+   </property>
+   <property name="bottomMargin">
+    <number>0</number>
+   </property>
+   <item>
+    <widget class="QLabel" name="workspace_combo_box_label">
+     <property name="minimumSize">
+      <size>
+       <width>120</width>
+       <height>0</height>
+      </size>
+     </property>
+     <property name="maximumSize">
+      <size>
+       <width>300</width>
+       <height>16777215</height>
+      </size>
+     </property>
+     <property name="text">
+      <string>Select Workspace</string>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QPushButton" name="decrement_parameter_display_button">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="maximumSize">
+      <size>
+       <width>27</width>
+       <height>16777215</height>
+      </size>
+     </property>
+     <property name="text">
+      <string>&lt;&lt;</string>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QComboBox" name="dataset_name_combo_box">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QPushButton" name="increment_parameter_display_button">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="maximumSize">
+      <size>
+       <width>27</width>
+       <height>16777215</height>
+      </size>
+     </property>
+     <property name="text">
+      <string>&gt;&gt;</string>
+     </property>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections/>
+</ui>

--- a/scripts/Muon/GUI/Common/fitting_widgets/basic_fitting/workspace_selector_view.py
+++ b/scripts/Muon/GUI/Common/fitting_widgets/basic_fitting/workspace_selector_view.py
@@ -1,0 +1,96 @@
+# Mantid Repository : https://github.com/mantidproject/mantid
+#
+# Copyright &copy; 2021 ISIS Rutherford Appleton Laboratory UKRI,
+#   NScD Oak Ridge National Laboratory, European Spallation Source,
+#   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+# SPDX - License - Identifier: GPL - 3.0 +
+from mantidqt.utils.qt import load_ui
+
+from qtpy.QtWidgets import QWidget
+
+ui_workspace_selector, _ = load_ui(__file__, "workspace_selector.ui")
+
+
+class WorkspaceSelectorView(QWidget, ui_workspace_selector):
+    """
+    The WorkspaceSelectorView is the cyclic workspace selector combobox, and is used to choose the workspace that
+    is currently active in an interface.
+    """
+
+    def __init__(self, parent: QWidget = None):
+        """Initialize the WorkspaceSelectorView."""
+        super(WorkspaceSelectorView, self).__init__(parent)
+        self.setupUi(self)
+
+        self.increment_parameter_display_button.clicked.connect(self.increment_dataset_name_combo_box)
+        self.decrement_parameter_display_button.clicked.connect(self.decrement_dataset_name_combo_box)
+
+    def set_slot_for_dataset_changed(self, slot) -> None:
+        """Connect the slot for the display workspace combo box being changed."""
+        self.dataset_name_combo_box.currentIndexChanged.connect(slot)
+
+    def update_dataset_name_combo_box(self, dataset_names: list) -> None:
+        """Update the data in the parameter display combo box."""
+        old_name = self.dataset_name_combo_box.currentText()
+
+        self.update_dataset_names_combo_box(dataset_names)
+
+        new_index = self.dataset_name_combo_box.findText(old_name)
+        new_index = new_index if new_index != -1 else 0
+
+        self.dataset_name_combo_box.setCurrentIndex(new_index)
+        # This signal isn't always sent, so I will emit it manually.
+        self.dataset_name_combo_box.currentIndexChanged.emit(new_index)
+
+    def update_dataset_names_combo_box(self, dataset_names: list) -> None:
+        """Update the datasets displayed in the dataset name combobox."""
+        self.dataset_name_combo_box.blockSignals(True)
+        self.dataset_name_combo_box.clear()
+        self.dataset_name_combo_box.addItems(dataset_names)
+        self.dataset_name_combo_box.blockSignals(False)
+
+    def increment_dataset_name_combo_box(self) -> None:
+        """Increment the parameter display combo box."""
+        index = self.dataset_name_combo_box.currentIndex()
+        count = self.dataset_name_combo_box.count()
+
+        if index < count - 1:
+            self.dataset_name_combo_box.setCurrentIndex(index + 1)
+        else:
+            self.dataset_name_combo_box.setCurrentIndex(0)
+
+    def decrement_dataset_name_combo_box(self) -> None:
+        """Decrement the parameter display combo box."""
+        index = self.dataset_name_combo_box.currentIndex()
+        count = self.dataset_name_combo_box.count()
+
+        if index != 0:
+            self.dataset_name_combo_box.setCurrentIndex(index - 1)
+        else:
+            self.dataset_name_combo_box.setCurrentIndex(count - 1)
+
+    @property
+    def current_dataset_name(self) -> str:
+        """Returns the selected dataset name."""
+        return str(self.dataset_name_combo_box.currentText())
+
+    @current_dataset_name.setter
+    def current_dataset_name(self, dataset_name: str) -> None:
+        """Sets the currently selected dataset name."""
+        index = self.dataset_name_combo_box.findText(dataset_name)
+        if index != -1:
+            self.dataset_name_combo_box.setCurrentIndex(index)
+
+    def number_of_datasets(self) -> int:
+        """Returns the number of dataset names loaded into the widget."""
+        return self.dataset_name_combo_box.count()
+
+    @property
+    def current_dataset_index(self) -> int:
+        """Returns the index of the currently displayed dataset."""
+        current_index = self.dataset_name_combo_box.currentIndex()
+        return current_index if current_index != -1 else None
+
+    def set_workspace_combo_box_label(self, text: str) -> None:
+        """Sets the label text next to the workspace selector combobox."""
+        self.workspace_combo_box_label.setText(text)

--- a/scripts/Muon/GUI/Common/fitting_widgets/basic_fitting/workspace_selector_view.py
+++ b/scripts/Muon/GUI/Common/fitting_widgets/basic_fitting/workspace_selector_view.py
@@ -38,8 +38,11 @@ class WorkspaceSelectorView(QWidget, ui_workspace_selector):
         new_index = self.dataset_name_combo_box.findText(old_name)
         new_index = new_index if new_index != -1 else 0
 
+        self.dataset_name_combo_box.blockSignals(True)
         self.dataset_name_combo_box.setCurrentIndex(new_index)
-        # This signal isn't always sent, so I will emit it manually.
+        self.dataset_name_combo_box.blockSignals(False)
+
+        # Signal is emitted manually in case the dataset index has not changed (but the loaded dataset may be different)
         self.dataset_name_combo_box.currentIndexChanged.emit(new_index)
 
     def update_dataset_names_combo_box(self, dataset_names: list) -> None:

--- a/scripts/Muon/GUI/Common/fitting_widgets/general_fitting/general_fitting_model.py
+++ b/scripts/Muon/GUI/Common/fitting_widgets/general_fitting/general_fitting_model.py
@@ -21,9 +21,9 @@ class GeneralFittingModel(BasicFittingModel):
     The GeneralFittingModel derives from BasicFittingModel. It adds the ability to do simultaneous fitting.
     """
 
-    def __init__(self, context: MuonContext, is_frequency_domain: bool = False):
+    def __init__(self, context: MuonContext):
         """Initialize the GeneralFittingModel with emtpy fit data."""
-        super(GeneralFittingModel, self).__init__(context, is_frequency_domain)
+        super(GeneralFittingModel, self).__init__(context)
 
         # This is a MultiDomainFunction if there are multiple domains in the function browser.
         self._simultaneous_fit_function = None

--- a/scripts/Muon/GUI/Common/fitting_widgets/general_fitting/general_fitting_model.py
+++ b/scripts/Muon/GUI/Common/fitting_widgets/general_fitting/general_fitting_model.py
@@ -9,8 +9,7 @@ from mantid.simpleapi import RenameWorkspace, CopyLogs
 
 from Muon.GUI.Common.ADSHandler.workspace_naming import (create_fitted_workspace_name,
                                                          create_multi_domain_fitted_workspace_name,
-                                                         create_parameter_table_name, get_group_or_pair_from_name,
-                                                         get_run_number_from_workspace_name,
+                                                         create_parameter_table_name,
                                                          get_run_numbers_as_string_from_workspace_name)
 from Muon.GUI.Common.contexts.muon_context import MuonContext
 from Muon.GUI.Common.fitting_widgets.basic_fitting.basic_fitting_model import BasicFittingModel
@@ -25,10 +24,6 @@ class GeneralFittingModel(BasicFittingModel):
     def __init__(self, context: MuonContext, is_frequency_domain: bool = False):
         """Initialize the GeneralFittingModel with emtpy fit data."""
         super(GeneralFittingModel, self).__init__(context, is_frequency_domain)
-
-        self._x_data_type = self.context._frequency_context.plot_type if is_frequency_domain else "None"
-
-        self._group_or_pair_index = {}
 
         # This is a MultiDomainFunction if there are multiple domains in the function browser.
         self._simultaneous_fit_function = None
@@ -218,16 +213,6 @@ class GeneralFittingModel(BasicFittingModel):
             return self._get_selected_groups_and_pairs()
         return []
 
-    def get_workspace_names_to_display_from_context(self) -> list:
-        """Returns the workspace names to display in the view based on the selected run and group/pair options."""
-        runs, groups_and_pairs = self.get_selected_runs_groups_and_pairs()
-
-        display_workspaces = []
-        for group_and_pair in groups_and_pairs:
-            display_workspaces += self._get_workspace_names_to_display_from_context(runs, group_and_pair)
-
-        return self._sort_workspace_names(display_workspaces)
-
     def get_fit_function_parameters(self) -> list:
         """Returns the names of the fit parameters in the fit functions."""
         if self.simultaneous_fitting_mode:
@@ -264,7 +249,7 @@ class GeneralFittingModel(BasicFittingModel):
         if self.simultaneous_fitting_mode:
             return self._get_selected_runs_groups_and_pairs_for_simultaneous_fit_mode()
         else:
-            return self._get_selected_runs_groups_and_pairs_for_single_fit_mode()
+            return super().get_selected_runs_groups_and_pairs()
 
     def _get_selected_runs_groups_and_pairs_for_simultaneous_fit_mode(self) -> tuple:
         """Returns the runs, groups and pairs that are currently selected for simultaneous fit mode."""
@@ -275,14 +260,6 @@ class GeneralFittingModel(BasicFittingModel):
         elif self.simultaneous_fit_by == "Group/Pair":
             groups_and_pairs = [self.simultaneous_fit_by_specifier]
         return runs, groups_and_pairs
-
-    def _get_selected_runs_groups_and_pairs_for_single_fit_mode(self) -> tuple:
-        """Returns the runs, groups and pairs to use for single fit mode."""
-        return "All", self._get_selected_groups_and_pairs()
-
-    def _get_selected_groups_and_pairs(self) -> list:
-        """Returns the groups and pairs currently selected in the context."""
-        return self.context.group_pair_context.selected_groups_and_pairs
 
     def _get_selected_runs(self) -> list:
         """Returns an ordered list of run numbers currently selected in the context."""
@@ -304,42 +281,6 @@ class GeneralFittingModel(BasicFittingModel):
         workspace_list = self.context.data_context.current_data["OutputWorkspace"]
         return [get_run_numbers_as_string_from_workspace_name(workspace.workspace_name, instrument)
                 for workspace in workspace_list]
-
-    def _get_workspace_names_to_display_from_context(self, runs: list, group_and_pair: str) -> list:
-        """Returns the workspace names for the given runs and group/pair to be displayed in the view."""
-        return self.context.get_names_of_workspaces_to_fit(runs=runs, group_and_pair=group_and_pair,
-                                                           rebin=not self.fit_to_raw, freq=self._x_data_type)
-
-    def _sort_workspace_names(self, workspace_names: list) -> list:
-        """Sort the workspace names and check the workspaces exist in the ADS."""
-        workspace_names = list(set(self._check_data_exists(workspace_names)))
-        if len(workspace_names) > 1:
-            workspace_names.sort(key=self._workspace_list_sorter)
-        return workspace_names
-
-    def _workspace_list_sorter(self, workspace_name: str) -> int:
-        """Used to sort a list of workspace names based on run number and group/pair name."""
-        run_number = get_run_number_from_workspace_name(workspace_name, self.context.data_context.instrument)
-        grp_pair_number = self._transform_group_or_pair_to_float(workspace_name)
-        return int(run_number) + grp_pair_number
-
-    def _transform_group_or_pair_to_float(self, workspace_name: str) -> int:
-        """Converts the workspace group or pair name to a float which is used in sorting the workspace list."""
-        group_or_pair_name = get_group_or_pair_from_name(workspace_name)
-        if group_or_pair_name not in self._group_or_pair_index:
-            self._group_or_pair_index[group_or_pair_name] = len(self._group_or_pair_index)
-
-        group_or_pair_values = list(self._group_or_pair_index.values())
-        if len(self._group_or_pair_index) > 1:
-            return ((self._group_or_pair_index[group_or_pair_name] - group_or_pair_values[0])
-                    / (group_or_pair_values[-1] - group_or_pair_values[0])) * 0.99
-        else:
-            return 0
-
-    @staticmethod
-    def _check_data_exists(workspace_names: list) -> list:
-        """Returns only the workspace names that exist in the ADS."""
-        return [workspace_name for workspace_name in workspace_names if AnalysisDataService.doesExist(workspace_name)]
 
     def perform_fit(self) -> tuple:
         """Performs a single or simultaneous fit and returns the resulting function, status and chi squared."""

--- a/scripts/Muon/GUI/Common/fitting_widgets/general_fitting/general_fitting_model.py
+++ b/scripts/Muon/GUI/Common/fitting_widgets/general_fitting/general_fitting_model.py
@@ -253,7 +253,7 @@ class GeneralFittingModel(BasicFittingModel):
 
     def _get_selected_runs_groups_and_pairs_for_simultaneous_fit_mode(self) -> tuple:
         """Returns the runs, groups and pairs that are currently selected for simultaneous fit mode."""
-        runs, groups_and_pairs = self._get_selected_runs_groups_and_pairs_for_single_fit_mode()
+        runs, groups_and_pairs = super().get_selected_runs_groups_and_pairs()
 
         if self.simultaneous_fit_by == "Run":
             runs = self.simultaneous_fit_by_specifier

--- a/scripts/Muon/GUI/Common/fitting_widgets/general_fitting/general_fitting_options.ui
+++ b/scripts/Muon/GUI/Common/fitting_widgets/general_fitting/general_fitting_options.ui
@@ -13,7 +13,7 @@
   <property name="windowTitle">
    <string>Form</string>
   </property>
-  <layout class="QVBoxLayout" name="verticalLayout">
+  <layout class="QHBoxLayout" name="horizontalLayout">
    <property name="leftMargin">
     <number>0</number>
    </property>
@@ -27,47 +27,29 @@
     <number>0</number>
    </property>
    <item>
-    <widget class="QFrame" name="frame">
-     <layout class="QGridLayout" name="gridLayout_2">
-      <property name="leftMargin">
-       <number>0</number>
-      </property>
-      <property name="topMargin">
-       <number>0</number>
-      </property>
-      <property name="rightMargin">
-       <number>0</number>
-      </property>
-      <property name="bottomMargin">
-       <number>0</number>
-      </property>
-      <item row="0" column="3" colspan="2">
-       <widget class="QComboBox" name="simul_fit_by_specifier"/>
-      </item>
-      <item row="0" column="0">
-       <widget class="QCheckBox" name="simul_fit_checkbox">
-        <property name="minimumSize">
-         <size>
-          <width>120</width>
-          <height>0</height>
-         </size>
-        </property>
-        <property name="maximumSize">
-         <size>
-          <width>300</width>
-          <height>16777215</height>
-         </size>
-        </property>
-        <property name="text">
-         <string>Simultaneous over</string>
-        </property>
-       </widget>
-      </item>
-      <item row="0" column="1" colspan="2">
-       <widget class="QComboBox" name="simul_fit_by_combo"/>
-      </item>
-     </layout>
+    <widget class="QCheckBox" name="simul_fit_checkbox">
+     <property name="minimumSize">
+      <size>
+       <width>250</width>
+       <height>0</height>
+      </size>
+     </property>
+     <property name="maximumSize">
+      <size>
+       <width>300</width>
+       <height>16777215</height>
+      </size>
+     </property>
+     <property name="text">
+      <string>Simultaneous over</string>
+     </property>
     </widget>
+   </item>
+   <item>
+    <widget class="QComboBox" name="simul_fit_by_combo"/>
+   </item>
+   <item>
+    <widget class="QComboBox" name="simul_fit_by_specifier"/>
    </item>
   </layout>
  </widget>

--- a/scripts/Muon/GUI/Common/fitting_widgets/general_fitting/general_fitting_options.ui
+++ b/scripts/Muon/GUI/Common/fitting_widgets/general_fitting/general_fitting_options.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>610</width>
-    <height>55</height>
+    <height>20</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -41,73 +41,6 @@
       <property name="bottomMargin">
        <number>0</number>
       </property>
-      <item row="2" column="0">
-       <widget class="QLabel" name="workspace_combo_box_label">
-        <property name="minimumSize">
-         <size>
-          <width>220</width>
-          <height>0</height>
-         </size>
-        </property>
-        <property name="maximumSize">
-         <size>
-          <width>220</width>
-          <height>16777215</height>
-         </size>
-        </property>
-        <property name="text">
-         <string>Select Workspace</string>
-        </property>
-       </widget>
-      </item>
-      <item row="2" column="1">
-       <widget class="QPushButton" name="decrement_parameter_display_button">
-        <property name="sizePolicy">
-         <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
-          <horstretch>0</horstretch>
-          <verstretch>0</verstretch>
-         </sizepolicy>
-        </property>
-        <property name="maximumSize">
-         <size>
-          <width>27</width>
-          <height>27</height>
-         </size>
-        </property>
-        <property name="text">
-         <string>&lt;&lt;</string>
-        </property>
-       </widget>
-      </item>
-      <item row="2" column="4">
-       <widget class="QPushButton" name="increment_parameter_display_button">
-        <property name="sizePolicy">
-         <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
-          <horstretch>0</horstretch>
-          <verstretch>0</verstretch>
-         </sizepolicy>
-        </property>
-        <property name="maximumSize">
-         <size>
-          <width>27</width>
-          <height>27</height>
-         </size>
-        </property>
-        <property name="text">
-         <string>&gt;&gt;</string>
-        </property>
-       </widget>
-      </item>
-      <item row="2" column="2" colspan="2">
-       <widget class="QComboBox" name="dataset_name_combo_box">
-        <property name="sizePolicy">
-         <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-          <horstretch>0</horstretch>
-          <verstretch>0</verstretch>
-         </sizepolicy>
-        </property>
-       </widget>
-      </item>
       <item row="0" column="3" colspan="2">
        <widget class="QComboBox" name="simul_fit_by_specifier"/>
       </item>
@@ -132,22 +65,6 @@
       </item>
       <item row="0" column="1" colspan="2">
        <widget class="QComboBox" name="simul_fit_by_combo"/>
-      </item>
-      <item row="1" column="0" colspan="5">
-       <spacer name="verticalSpacer">
-        <property name="orientation">
-         <enum>Qt::Vertical</enum>
-        </property>
-        <property name="sizeType">
-         <enum>QSizePolicy::Maximum</enum>
-        </property>
-        <property name="sizeHint" stdset="0">
-         <size>
-          <width>20</width>
-          <height>10</height>
-         </size>
-        </property>
-       </spacer>
       </item>
      </layout>
     </widget>

--- a/scripts/Muon/GUI/Common/fitting_widgets/general_fitting/general_fitting_options_view.py
+++ b/scripts/Muon/GUI/Common/fitting_widgets/general_fitting/general_fitting_options_view.py
@@ -18,17 +18,14 @@ class GeneralFittingOptionsView(QWidget, ui_general_fitting_options):
     The GeneralFittingOptionsView includes the Simultaneous fitting options, and the cyclic dataset display combobox.
     """
 
-    def __init__(self, parent: QWidget = None, is_frequency_domain: bool = False):
+    def __init__(self, parent: QWidget = None):
         """Initializes the GeneralFittingOptionsView. By default the simultaneous options are disabled."""
         super(GeneralFittingOptionsView, self).__init__(parent)
         self.setupUi(self)
 
         self.disable_simultaneous_fit_options()
 
-        if is_frequency_domain:
-            self.hide_simultaneous_fit_options()
-        else:
-            self._setup_simultaneous_fit_by_combo_box(MA_FIT_BY_OPTIONS)
+        self._setup_simultaneous_fit_by_combo_box(MA_FIT_BY_OPTIONS)
 
     def set_slot_for_fitting_mode_changed(self, slot) -> None:
         """Connect the slot for the simultaneous fit check box."""

--- a/scripts/Muon/GUI/Common/fitting_widgets/general_fitting/general_fitting_options_view.py
+++ b/scripts/Muon/GUI/Common/fitting_widgets/general_fitting/general_fitting_options_view.py
@@ -63,12 +63,6 @@ class GeneralFittingOptionsView(QWidget, ui_general_fitting_options):
         """Returns the run, group or pair name."""
         return self.simul_fit_by_specifier.currentText()
 
-    def hide_simultaneous_fit_options(self) -> None:
-        """Hides the simultaneous fit options."""
-        self.simul_fit_checkbox.hide()
-        self.simul_fit_by_combo.hide()
-        self.simul_fit_by_specifier.hide()
-
     def disable_simultaneous_fit_options(self) -> None:
         """Disables the simultaneous fit options."""
         self.simul_fit_by_combo.setEnabled(False)

--- a/scripts/Muon/GUI/Common/fitting_widgets/general_fitting/general_fitting_options_view.py
+++ b/scripts/Muon/GUI/Common/fitting_widgets/general_fitting/general_fitting_options_view.py
@@ -11,8 +11,6 @@ from qtpy.QtWidgets import QWidget
 ui_general_fitting_options, _ = load_ui(__file__, "general_fitting_options.ui")
 
 MA_FIT_BY_OPTIONS = ["Run", "Group/Pair"]
-SINGLE_FIT_LABEL = "Select Workspace"
-SIMULTANEOUS_FIT_LABEL = "Display parameters for"
 
 
 class GeneralFittingOptionsView(QWidget, ui_general_fitting_options):
@@ -25,19 +23,12 @@ class GeneralFittingOptionsView(QWidget, ui_general_fitting_options):
         super(GeneralFittingOptionsView, self).__init__(parent)
         self.setupUi(self)
 
-        self.increment_parameter_display_button.clicked.connect(self.increment_dataset_name_combo_box)
-        self.decrement_parameter_display_button.clicked.connect(self.decrement_dataset_name_combo_box)
-
         self.disable_simultaneous_fit_options()
 
         if is_frequency_domain:
             self.hide_simultaneous_fit_options()
         else:
             self._setup_simultaneous_fit_by_combo_box(MA_FIT_BY_OPTIONS)
-
-    def set_slot_for_dataset_changed(self, slot) -> None:
-        """Connect the slot for the display workspace combo box being changed."""
-        self.dataset_name_combo_box.currentIndexChanged.connect(slot)
 
     def set_slot_for_fitting_mode_changed(self, slot) -> None:
         """Connect the slot for the simultaneous fit check box."""
@@ -51,66 +42,10 @@ class GeneralFittingOptionsView(QWidget, ui_general_fitting_options):
         """Connect the slot for the fit specifier combo box being changed."""
         self.simul_fit_by_specifier.currentIndexChanged.connect(slot)
 
-    def update_dataset_name_combo_box(self, dataset_names: list) -> None:
-        """Update the data in the parameter display combo box."""
-        old_name = self.dataset_name_combo_box.currentText()
-
-        self.update_dataset_names_combo_box(dataset_names)
-
-        new_index = self.dataset_name_combo_box.findText(old_name)
-        new_index = new_index if new_index != -1 else 0
-
-        self.dataset_name_combo_box.setCurrentIndex(new_index)
-        # This signal isn't always sent, so I will emit it manually.
-        self.dataset_name_combo_box.currentIndexChanged.emit(new_index)
-
-    def update_dataset_names_combo_box(self, dataset_names: list) -> None:
-        """Update the datasets displayed in the dataset name combobox."""
-        self.dataset_name_combo_box.blockSignals(True)
-        self.dataset_name_combo_box.clear()
-        self.dataset_name_combo_box.addItems(dataset_names)
-        self.dataset_name_combo_box.blockSignals(False)
-
-    def increment_dataset_name_combo_box(self) -> None:
-        """Increment the parameter display combo box."""
-        index = self.dataset_name_combo_box.currentIndex()
-        count = self.dataset_name_combo_box.count()
-
-        if index < count - 1:
-            self.dataset_name_combo_box.setCurrentIndex(index + 1)
-        else:
-            self.dataset_name_combo_box.setCurrentIndex(0)
-
-    def decrement_dataset_name_combo_box(self) -> None:
-        """Decrement the parameter display combo box."""
-        index = self.dataset_name_combo_box.currentIndex()
-        count = self.dataset_name_combo_box.count()
-
-        if index != 0:
-            self.dataset_name_combo_box.setCurrentIndex(index - 1)
-        else:
-            self.dataset_name_combo_box.setCurrentIndex(count - 1)
-
     def _setup_simultaneous_fit_by_combo_box(self, fit_by_options: list) -> None:
         """Populate the simultaneous fit by combo box."""
         for item in fit_by_options:
             self.simul_fit_by_combo.addItem(item)
-
-    @property
-    def current_dataset_name(self) -> str:
-        """Returns the selected dataset name."""
-        return str(self.dataset_name_combo_box.currentText())
-
-    @current_dataset_name.setter
-    def current_dataset_name(self, dataset_name: str) -> None:
-        """Sets the currently selected dataset name."""
-        index = self.dataset_name_combo_box.findText(dataset_name)
-        if index != -1:
-            self.dataset_name_combo_box.setCurrentIndex(index)
-
-    def number_of_datasets(self) -> int:
-        """Returns the number of dataset names loaded into the widget."""
-        return self.dataset_name_combo_box.count()
 
     @property
     def simultaneous_fit_by(self) -> str:
@@ -130,22 +65,6 @@ class GeneralFittingOptionsView(QWidget, ui_general_fitting_options):
     def simultaneous_fit_by_specifier(self) -> str:
         """Returns the run, group or pair name."""
         return self.simul_fit_by_specifier.currentText()
-
-    @property
-    def current_dataset_index(self) -> int:
-        """Returns the index of the currently displayed dataset."""
-        current_index = self.dataset_name_combo_box.currentIndex()
-        return current_index if current_index != -1 else None
-
-    def switch_to_simultaneous(self) -> None:
-        """Switches the view to simultaneous fit mode."""
-        self.set_workspace_combo_box_label(SIMULTANEOUS_FIT_LABEL)
-        self.enable_simultaneous_fit_options()
-
-    def switch_to_single(self) -> None:
-        """Switches the view to single fit mode."""
-        self.set_workspace_combo_box_label(SINGLE_FIT_LABEL)
-        self.disable_simultaneous_fit_options()
 
     def hide_simultaneous_fit_options(self) -> None:
         """Hides the simultaneous fit options."""
@@ -174,9 +93,6 @@ class GeneralFittingOptionsView(QWidget, ui_general_fitting_options):
         self.simul_fit_checkbox.blockSignals(True)
         self.simul_fit_checkbox.setChecked(simultaneous)
         self.simul_fit_checkbox.blockSignals(False)
-
-    def set_workspace_combo_box_label(self, text: str) -> None:
-        self.workspace_combo_box_label.setText(text)
 
     def setup_fit_by_specifier(self, choices: list) -> None:
         """Setup the fit by specifier combo box."""

--- a/scripts/Muon/GUI/Common/fitting_widgets/general_fitting/general_fitting_presenter.py
+++ b/scripts/Muon/GUI/Common/fitting_widgets/general_fitting/general_fitting_presenter.py
@@ -5,7 +5,7 @@
 #   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
 # SPDX - License - Identifier: GPL - 3.0 +
 from mantid.api import IFunction
-from mantidqt.utils.observer_pattern import GenericObserver, GenericObservable, GenericObserverWithArgPassing
+from mantidqt.utils.observer_pattern import GenericObserver, GenericObservable
 
 from Muon.GUI.Common.fitting_widgets.basic_fitting.basic_fitting_presenter import BasicFittingPresenter
 from Muon.GUI.Common.fitting_widgets.general_fitting.general_fitting_model import GeneralFittingModel
@@ -24,11 +24,8 @@ class GeneralFittingPresenter(BasicFittingPresenter):
         self.fitting_mode_changed_notifier = GenericObservable()
         self.simultaneous_fit_by_specifier_changed = GenericObservable()
 
-        self.selected_group_pair_observer = GenericObserver(self.handle_selected_group_pair_changed)
-        self.instrument_changed_observer = GenericObserver(self.handle_instrument_changed)
         self.fit_parameter_updated_observer = GenericObserver(self.update_fit_function_in_view_from_model)
 
-        self.double_pulse_observer = GenericObserverWithArgPassing(self.handle_pulse_type_changed)
         self.model.context.gui_context.add_non_calc_subscriber(self.double_pulse_observer)
 
         self.view.set_slot_for_fitting_mode_changed(self.handle_fitting_mode_changed)
@@ -43,27 +40,6 @@ class GeneralFittingPresenter(BasicFittingPresenter):
         self.model.simultaneous_fit_by = self.view.simultaneous_fit_by
         self.model.simultaneous_fit_by_specifier = self.view.simultaneous_fit_by_specifier
         self.model.global_parameters = self.view.global_parameters
-
-    def handle_instrument_changed(self) -> None:
-        """Handles when an instrument is changed and switches to normal fitting mode. Overridden by child."""
-        self._update_plot = False
-        self.update_and_reset_all_data()
-        self._update_plot = True
-        self.clear_cached_fit_functions()
-        self.model.remove_all_fits_from_context()
-
-    def handle_pulse_type_changed(self, updated_variables: dict) -> None:
-        """Handles when double pulse mode is switched on and switches to normal fitting mode."""
-        if "DoublePulseEnabled" in updated_variables:
-            self._update_plot = False
-            self.update_and_reset_all_data()
-            self._update_plot = True
-
-    def handle_selected_group_pair_changed(self) -> None:
-        """Update the displayed workspaces when the selected group/pairs change in grouping tab."""
-        self._update_plot = False
-        self.update_and_reset_all_data()
-        self._update_plot = True
 
     def handle_fitting_mode_changed(self) -> None:
         """Handle when the fitting mode is changed to or from simultaneous fitting."""
@@ -132,6 +108,11 @@ class GeneralFittingPresenter(BasicFittingPresenter):
     def update_simultaneous_fit_by_specifiers_in_view(self) -> None:
         """Updates the entries in the simultaneous fit by specifier combo box."""
         self.view.setup_fit_by_specifier(self.model.get_simultaneous_fit_by_specifiers_to_display_from_context())
+
+    def update_fit_function_in_view_from_model(self) -> None:
+        """Updates the parameters of a fit function shown in the view."""
+        self.view.set_current_dataset_index(self.model.current_dataset_index)
+        self.view.update_fit_function(self.model.get_active_fit_function(), self.model.global_parameters)
 
     def update_fit_functions_in_model_from_view(self) -> None:
         """Updates the fit functions stored in the model using the view."""

--- a/scripts/Muon/GUI/Common/fitting_widgets/general_fitting/general_fitting_presenter.py
+++ b/scripts/Muon/GUI/Common/fitting_widgets/general_fitting/general_fitting_presenter.py
@@ -21,9 +21,6 @@ class GeneralFittingPresenter(BasicFittingPresenter):
         """Initialize the GeneralFittingPresenter. Sets up the slots and event observers."""
         super(GeneralFittingPresenter, self).__init__(view, model)
 
-        # This prevents plotting the wrong data when selecting different group/pairs on the grouping tab
-        self._update_plot = True
-
         self.fitting_mode_changed_notifier = GenericObservable()
         self.simultaneous_fit_by_specifier_changed = GenericObservable()
 
@@ -34,7 +31,6 @@ class GeneralFittingPresenter(BasicFittingPresenter):
         self.double_pulse_observer = GenericObserverWithArgPassing(self.handle_pulse_type_changed)
         self.model.context.gui_context.add_non_calc_subscriber(self.double_pulse_observer)
 
-        self.view.set_slot_for_dataset_changed(self.handle_dataset_name_changed)
         self.view.set_slot_for_fitting_mode_changed(self.handle_fitting_mode_changed)
         self.view.set_slot_for_simultaneous_fit_by_changed(self.handle_simultaneous_fit_by_changed)
         self.view.set_slot_for_simultaneous_fit_by_specifier_changed(self.handle_simultaneous_fit_by_specifier_changed)
@@ -68,17 +64,6 @@ class GeneralFittingPresenter(BasicFittingPresenter):
         self._update_plot = False
         self.update_and_reset_all_data()
         self._update_plot = True
-
-    def handle_fitting_finished(self, fit_function, fit_status, chi_squared) -> None:
-        """Handle when fitting is finished."""
-        self.update_fit_statuses_and_chi_squared_in_model(fit_status, chi_squared)
-        self.update_fit_function_in_model(fit_function)
-
-        self.update_fit_statuses_and_chi_squared_in_view_from_model()
-        self.update_fit_function_in_view_from_model()
-
-        self.selected_fit_results_changed.notify_subscribers(self.model.get_active_fit_results())
-        self.fit_parameter_changed_notifier.notify_subscribers()
 
     def handle_fitting_mode_changed(self) -> None:
         """Handle when the fitting mode is changed to or from simultaneous fitting."""
@@ -117,23 +102,6 @@ class GeneralFittingPresenter(BasicFittingPresenter):
 
         self.simultaneous_fit_by_specifier_changed.notify_subscribers()
 
-    def handle_dataset_name_changed(self) -> None:
-        """Handle when the display workspace combo box is changed."""
-        self.model.current_dataset_index = self.view.current_dataset_index
-
-        self.update_fit_statuses_and_chi_squared_in_view_from_model()
-        self.update_fit_function_in_view_from_model()
-        self.update_start_and_end_x_in_view_from_model()
-
-        if self._update_plot:
-            self.selected_fit_results_changed.notify_subscribers(self.model.get_active_fit_results())
-            self.model.update_plot_guess(self.view.plot_guess)
-
-    def set_selected_dataset(self, dataset_name: str) -> None:
-        """Sets the workspace to be displayed in the view programmatically."""
-        # Triggers handle_dataset_name_changed which updates the model
-        self.view.current_dataset_name = dataset_name
-
     def switch_fitting_mode_in_view(self) -> None:
         """Switches the fitting mode by updating the relevant labels and checkboxes in the view."""
         if self.model.simultaneous_fitting_mode:
@@ -152,25 +120,18 @@ class GeneralFittingPresenter(BasicFittingPresenter):
             self.model.fit_statuses = [fit_status] * self.model.number_of_datasets
             self.model.chi_squared = [chi_squared] * self.model.number_of_datasets
         else:
-            self.model.current_fit_status = fit_status
-            self.model.current_chi_squared = chi_squared
+            super().update_fit_statuses_and_chi_squared_in_model(fit_status, chi_squared)
 
     def update_fit_function_in_model(self, fit_function: IFunction) -> None:
         """Updates the fit function stored in the model. This is used after a fit."""
         if self.model.simultaneous_fitting_mode:
             self.model.simultaneous_fit_function = fit_function
         else:
-            self.model.current_single_fit_function = fit_function
+            super().update_fit_function_in_model(fit_function)
 
     def update_simultaneous_fit_by_specifiers_in_view(self) -> None:
         """Updates the entries in the simultaneous fit by specifier combo box."""
         self.view.setup_fit_by_specifier(self.model.get_simultaneous_fit_by_specifiers_to_display_from_context())
-
-    def update_dataset_names_in_view_and_model(self) -> None:
-        """Updates the datasets currently displayed. The simultaneous fit by specifier must be updated before this."""
-        super().update_dataset_names_in_view_and_model()
-        self.view.update_dataset_name_combo_box(self.model.dataset_names)
-        self.model.current_dataset_index = self.view.current_dataset_index
 
     def update_fit_functions_in_model_from_view(self) -> None:
         """Updates the fit functions stored in the model using the view."""

--- a/scripts/Muon/GUI/Common/fitting_widgets/general_fitting/general_fitting_view.py
+++ b/scripts/Muon/GUI/Common/fitting_widgets/general_fitting/general_fitting_view.py
@@ -20,11 +20,11 @@ class GeneralFittingView(BasicFittingView):
     The GeneralFittingView derives from the BasicFittingView. It adds the GeneralFittingOptionsView to the widget.
     """
 
-    def __init__(self, parent: QWidget = None, is_frequency_domain: bool = False):
+    def __init__(self, parent: QWidget = None):
         """Initializes the GeneralFittingView, and adds the GeneralFittingOptionsView widget."""
         super(GeneralFittingView, self).__init__(parent)
 
-        self.general_fitting_options = GeneralFittingOptionsView(self, is_frequency_domain)
+        self.general_fitting_options = GeneralFittingOptionsView(self)
         self.general_fitting_options_layout.addWidget(self.general_fitting_options)
 
     def set_slot_for_fitting_mode_changed(self, slot) -> None:

--- a/scripts/Muon/GUI/Common/fitting_widgets/general_fitting/general_fitting_view.py
+++ b/scripts/Muon/GUI/Common/fitting_widgets/general_fitting/general_fitting_view.py
@@ -79,10 +79,6 @@ class GeneralFittingView(BasicFittingView):
         self.set_workspace_combo_box_label(SINGLE_FIT_LABEL)
         self.general_fitting_options.disable_simultaneous_fit_options()
 
-    def hide_simultaneous_fit_options(self) -> None:
-        """Hides the simultaneous fit options."""
-        self.general_fitting_options.hide_simultaneous_fit_options()
-
     def disable_simultaneous_fit_options(self) -> None:
         """Disables the simultaneous fit options."""
         self.general_fitting_options.disable_simultaneous_fit_options()

--- a/scripts/Muon/GUI/Common/fitting_widgets/general_fitting/general_fitting_view.py
+++ b/scripts/Muon/GUI/Common/fitting_widgets/general_fitting/general_fitting_view.py
@@ -11,6 +11,9 @@ from Muon.GUI.Common.fitting_widgets.general_fitting.general_fitting_options_vie
 
 from qtpy.QtWidgets import QWidget
 
+SINGLE_FIT_LABEL = "Select Workspace"
+SIMULTANEOUS_FIT_LABEL = "Display parameters for"
+
 
 class GeneralFittingView(BasicFittingView):
     """
@@ -24,10 +27,6 @@ class GeneralFittingView(BasicFittingView):
         self.general_fitting_options = GeneralFittingOptionsView(self, is_frequency_domain)
         self.general_fitting_options_layout.addWidget(self.general_fitting_options)
 
-    def set_slot_for_dataset_changed(self, slot) -> None:
-        """Connect the slot for the display workspace combo box being changed."""
-        self.general_fitting_options.set_slot_for_dataset_changed(slot)
-
     def set_slot_for_fitting_mode_changed(self, slot) -> None:
         """Connect the slot for the simultaneous fit check box."""
         self.general_fitting_options.set_slot_for_fitting_mode_changed(slot)
@@ -39,10 +38,6 @@ class GeneralFittingView(BasicFittingView):
     def set_slot_for_simultaneous_fit_by_specifier_changed(self, slot) -> None:
         """Connect the slot for the fit specifier combo box being changed."""
         self.general_fitting_options.set_slot_for_simultaneous_fit_by_specifier_changed(slot)
-
-    def update_dataset_name_combo_box(self, dataset_names: list) -> None:
-        """Update the data in the parameter display combo box."""
-        self.general_fitting_options.update_dataset_name_combo_box(dataset_names)
 
     def update_global_fit_status(self, fit_statuses: list, index: int) -> None:
         """Updates the global fit status label."""
@@ -56,20 +51,6 @@ class GeneralFittingView(BasicFittingView):
         """Updates the parameters of a fit function shown in the view."""
         self.fit_function_options.update_function_browser_parameters(self.simultaneous_fitting_mode, fit_function,
                                                                      global_parameters)
-
-    @property
-    def current_dataset_name(self) -> str:
-        """Returns the selected dataset name."""
-        return self.general_fitting_options.current_dataset_name
-
-    @current_dataset_name.setter
-    def current_dataset_name(self, dataset_name: str) -> None:
-        """Sets the currently selected dataset name."""
-        self.general_fitting_options.current_dataset_name = dataset_name
-
-    def number_of_datasets(self) -> int:
-        """Returns the number of dataset names loaded into the widget."""
-        return self.general_fitting_options.number_of_datasets()
 
     @property
     def simultaneous_fit_by(self) -> str:
@@ -86,20 +67,17 @@ class GeneralFittingView(BasicFittingView):
         """Returns the run, group or pair name."""
         return self.general_fitting_options.simultaneous_fit_by_specifier
 
-    @property
-    def current_dataset_index(self) -> str:
-        """Returns the index of the currently displayed dataset."""
-        return self.general_fitting_options.current_dataset_index
-
     def switch_to_simultaneous(self) -> None:
         """Switches the view to simultaneous fit mode."""
         super().switch_to_simultaneous()
-        self.general_fitting_options.switch_to_simultaneous()
+        self.set_workspace_combo_box_label(SIMULTANEOUS_FIT_LABEL)
+        self.general_fitting_options.enable_simultaneous_fit_options()
 
     def switch_to_single(self) -> None:
         """Switches the view to single fit mode."""
         super().switch_to_single()
-        self.general_fitting_options.switch_to_single()
+        self.set_workspace_combo_box_label(SINGLE_FIT_LABEL)
+        self.general_fitting_options.disable_simultaneous_fit_options()
 
     def hide_simultaneous_fit_options(self) -> None:
         """Hides the simultaneous fit options."""

--- a/scripts/Muon/GUI/Common/fitting_widgets/tf_asymmetry_fitting/tf_asymmetry_fitting_model.py
+++ b/scripts/Muon/GUI/Common/fitting_widgets/tf_asymmetry_fitting/tf_asymmetry_fitting_model.py
@@ -33,9 +33,9 @@ class TFAsymmetryFittingModel(GeneralFittingModel):
     The TFAsymmetryFittingModel derives from GeneralFittingModel. It adds the ability to do TF Asymmetry fitting.
     """
 
-    def __init__(self, context: MuonContext, is_frequency_domain: bool = False):
+    def __init__(self, context: MuonContext):
         """Initialize the TFAsymmetryFittingModel with emtpy fit data."""
-        super(TFAsymmetryFittingModel, self).__init__(context, is_frequency_domain)
+        super(TFAsymmetryFittingModel, self).__init__(context)
 
         self._tf_asymmetry_mode = False
         self._tf_asymmetry_single_functions = []

--- a/scripts/Muon/GUI/Common/fitting_widgets/tf_asymmetry_fitting/tf_asymmetry_fitting_options.ui
+++ b/scripts/Muon/GUI/Common/fitting_widgets/tf_asymmetry_fitting/tf_asymmetry_fitting_options.ui
@@ -7,13 +7,13 @@
     <x>0</x>
     <y>0</y>
     <width>610</width>
-    <height>18</height>
+    <height>19</height>
    </rect>
   </property>
   <property name="windowTitle">
    <string>Form</string>
   </property>
-  <layout class="QVBoxLayout" name="verticalLayout">
+  <layout class="QHBoxLayout" name="horizontalLayout_2">
    <property name="leftMargin">
     <number>0</number>
    </property>
@@ -27,8 +27,30 @@
     <number>0</number>
    </property>
    <item>
-    <widget class="QFrame" name="frame">
-     <layout class="QGridLayout" name="gridLayout_2">
+    <widget class="QCheckBox" name="fix_normalisation_checkbox">
+     <property name="minimumSize">
+      <size>
+       <width>250</width>
+       <height>0</height>
+      </size>
+     </property>
+     <property name="maximumSize">
+      <size>
+       <width>300</width>
+       <height>16777215</height>
+      </size>
+     </property>
+     <property name="text">
+      <string>Fix Normalisation</string>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QFrame" name="frame_2">
+     <layout class="QHBoxLayout" name="horizontalLayout">
+      <property name="spacing">
+       <number>0</number>
+      </property>
       <property name="leftMargin">
        <number>0</number>
       </property>
@@ -41,81 +63,41 @@
       <property name="bottomMargin">
        <number>0</number>
       </property>
-      <item row="0" column="0">
-       <widget class="QCheckBox" name="fix_normalisation_checkbox">
+      <item>
+       <widget class="QLineEdit" name="normalisation_line_edit">
+        <property name="styleSheet">
+         <string notr="true">QLineEdit {
+  border-width: 1px;
+  border-style: solid;
+  border-color: #7a7a7a white #7a7a7a #7a7a7a;
+}</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QLineEdit" name="normalisation_error_line_edit">
         <property name="minimumSize">
          <size>
-          <width>120</width>
+          <width>100</width>
           <height>0</height>
          </size>
         </property>
         <property name="maximumSize">
          <size>
-          <width>120</width>
+          <width>100</width>
           <height>16777215</height>
          </size>
         </property>
-        <property name="text">
-         <string>Fix Normalisation</string>
-        </property>
-       </widget>
-      </item>
-      <item row="0" column="1">
-       <widget class="QFrame" name="frame_2">
-        <layout class="QHBoxLayout" name="horizontalLayout">
-         <property name="spacing">
-          <number>0</number>
-         </property>
-         <property name="leftMargin">
-          <number>0</number>
-         </property>
-         <property name="topMargin">
-          <number>0</number>
-         </property>
-         <property name="rightMargin">
-          <number>0</number>
-         </property>
-         <property name="bottomMargin">
-          <number>0</number>
-         </property>
-         <item>
-          <widget class="QLineEdit" name="normalisation_line_edit">
-           <property name="styleSheet">
-            <string notr="true">QLineEdit {
-  border-width: 1px;
-  border-style: solid;
-  border-color: #7a7a7a white #7a7a7a #7a7a7a;
-}</string>
-           </property>
-          </widget>
-         </item>
-         <item>
-          <widget class="QLineEdit" name="normalisation_error_line_edit">
-           <property name="minimumSize">
-            <size>
-             <width>100</width>
-             <height>0</height>
-            </size>
-           </property>
-           <property name="maximumSize">
-            <size>
-             <width>100</width>
-             <height>16777215</height>
-            </size>
-           </property>
-           <property name="styleSheet">
-            <string notr="true">QLineEdit {
+        <property name="styleSheet">
+         <string notr="true">QLineEdit {
   border-width: 1px;
   border-style: solid;
   border-color: #7a7a7a #7a7a7a #7a7a7a white;
 }</string>
-           </property>
-           <property name="readOnly">
-            <bool>true</bool>
-           </property>
-          </widget>
-         </item>
-        </layout>
+        </property>
+        <property name="readOnly">
+         <bool>true</bool>
+        </property>
        </widget>
       </item>
      </layout>

--- a/scripts/Muon/GUI/Common/fitting_widgets/tf_asymmetry_fitting/tf_asymmetry_fitting_view.py
+++ b/scripts/Muon/GUI/Common/fitting_widgets/tf_asymmetry_fitting/tf_asymmetry_fitting_view.py
@@ -19,9 +19,9 @@ class TFAsymmetryFittingView(GeneralFittingView):
     widget.
     """
 
-    def __init__(self, parent: QWidget = None, is_frequency_domain: bool = False):
+    def __init__(self, parent: QWidget = None):
         """Initializes the TFAsymmetryFittingView, and adds the TFAsymmetryFittingOptionsView widget."""
-        super(TFAsymmetryFittingView, self).__init__(parent, is_frequency_domain)
+        super(TFAsymmetryFittingView, self).__init__(parent)
 
         self.tf_asymmetry_mode_switcher = TFAsymmetryModeSwitcherView(self)
         self.tf_asymmetry_mode_switcher_layout.addWidget(self.tf_asymmetry_mode_switcher)

--- a/scripts/Muon/GUI/Common/fitting_widgets/tf_asymmetry_fitting/tf_asymmetry_mode_switcher.ui
+++ b/scripts/Muon/GUI/Common/fitting_widgets/tf_asymmetry_fitting/tf_asymmetry_mode_switcher.ui
@@ -13,7 +13,7 @@
   <property name="windowTitle">
    <string>Form</string>
   </property>
-  <layout class="QGridLayout" name="gridLayout">
+  <layout class="QHBoxLayout" name="horizontalLayout">
    <property name="leftMargin">
     <number>0</number>
    </property>
@@ -26,17 +26,17 @@
    <property name="bottomMargin">
     <number>0</number>
    </property>
-   <item row="0" column="0">
+   <item>
     <widget class="QLabel" name="fitting_type_label">
      <property name="minimumSize">
       <size>
-       <width>120</width>
+       <width>250</width>
        <height>0</height>
       </size>
      </property>
      <property name="maximumSize">
       <size>
-       <width>150</width>
+       <width>250</width>
        <height>16777215</height>
       </size>
      </property>
@@ -45,7 +45,7 @@
      </property>
     </widget>
    </item>
-   <item row="0" column="1">
+   <item>
     <widget class="QComboBox" name="fitting_type_combo_box">
      <item>
       <property name="text">

--- a/scripts/Muon/GUI/Common/plot_widget/plotting_canvas/plotting_canvas_model.py
+++ b/scripts/Muon/GUI/Common/plot_widget/plotting_canvas/plotting_canvas_model.py
@@ -7,7 +7,6 @@
 from typing import NamedTuple, List
 from Muon.GUI.Common.ADSHandler.workspace_naming import *
 from Muon.GUI.Common.contexts.muon_context import MuonContext
-from Muon.GUI.Common.fitting_widgets.basic_fitting.basic_fitting_model import MA_GUESS_WORKSPACE, FDA_GUESS_WORKSPACE
 
 FIT_FUNCTION_GUESS_LABEL = "Fit function guess"
 
@@ -173,7 +172,4 @@ class PlottingCanvasModel(object):
         return label
 
     def _is_guess_workspace(self, workspace_name):
-        if MA_GUESS_WORKSPACE in workspace_name or FDA_GUESS_WORKSPACE in workspace_name:
-            return True
-        else:
-            return False
+        return self._context.guess_workspace_prefix in workspace_name

--- a/scripts/test/Muon/CMakeLists.txt
+++ b/scripts/test/Muon/CMakeLists.txt
@@ -41,9 +41,11 @@ set ( TEST_PY_FILES
    fitting_widgets/basic_fitting/basic_fitting_view_test.py
    fitting_widgets/basic_fitting/fit_controls_view_test.py
    fitting_widgets/basic_fitting/fit_function_options_view_test.py
+   fitting_widgets/basic_fitting/workspace_selector_view_test.py
    fitting_widgets/general_fitting/general_fitting_model_test.py
    fitting_widgets/general_fitting/general_fitting_presenter_test.py
    fitting_widgets/general_fitting/general_fitting_options_view_test.py
+   fitting_widgets/general_fitting/general_fitting_view_test.py
    fitting_widgets/tf_asymmetry_fitting/tf_asymmetry_fitting_model_test.py
    fitting_widgets/tf_asymmetry_fitting/tf_asymmetry_fitting_options_view_test.py
    fitting_widgets/tf_asymmetry_fitting/tf_asymmetry_fitting_presenter_test.py

--- a/scripts/test/Muon/fitting_widgets/basic_fitting/basic_fitting_model_test.py
+++ b/scripts/test/Muon/fitting_widgets/basic_fitting/basic_fitting_model_test.py
@@ -399,6 +399,7 @@ class BasicFittingModelTest(unittest.TestCase):
         self.assertEqual(self.model.get_active_fit_results(), [])
 
     def test_update_plot_guess_will_evaluate_the_function(self):
+        guess_workspace_name = "__frequency_domain_analysis_fitting_guessName1"
         self.model.dataset_names = self.dataset_names
         self.model.single_fit_functions = self.single_fit_functions
         self.model.start_xs = [0.0, 1.0]
@@ -407,6 +408,7 @@ class BasicFittingModelTest(unittest.TestCase):
 
         self.model.context = mock.Mock()
         self.model._double_pulse_enabled = mock.Mock(return_value=False)
+        self.model._get_plot_guess_name = mock.Mock(return_value=guess_workspace_name)
         with mock.patch('Muon.GUI.Common.fitting_widgets.basic_fitting.basic_fitting_model.EvaluateFunction') as mock_evaluate:
             self.model._get_guess_parameters = mock.Mock(return_value=['func', 'ws'])
             self.model.update_plot_guess(True)
@@ -414,7 +416,7 @@ class BasicFittingModelTest(unittest.TestCase):
                                              Function=self.model.current_single_fit_function,
                                              StartX=self.model.current_start_x,
                                              EndX=self.model.current_end_x,
-                                             OutputWorkspace="__frequency_domain_analysis_fitting_guessName1")
+                                             OutputWorkspace=guess_workspace_name)
 
     @mock.patch('Muon.GUI.Common.fitting_widgets.basic_fitting.basic_fitting_model.EvaluateFunction')
     def test_update_plot_guess_notifies_subscribers_with_the_guess_workspace_name_if_plot_guess_is_true(self, mock_evaluate):
@@ -427,7 +429,9 @@ class BasicFittingModelTest(unittest.TestCase):
 
         self.model.context = mock.Mock()
         self.model._double_pulse_enabled = mock.Mock(return_value=False)
+        self.model._get_plot_guess_name = mock.Mock(return_value=guess_workspace_name)
         self.model.update_plot_guess(True)
+
         mock_evaluate.assert_called_with(InputWorkspace=self.model.current_dataset_name,
                                          Function=self.model.current_single_fit_function,
                                          StartX=self.model.current_start_x,
@@ -450,6 +454,7 @@ class BasicFittingModelTest(unittest.TestCase):
         self.model.context.fitting_context.notify_plot_guess_changed.assert_called_with(False, None)
 
     def test_update_plot_guess_will_evaluate_the_function_when_in_double_fit_mode(self):
+        guess_workspace_name = "__frequency_domain_analysis_fitting_guessName1"
         self.model.dataset_names = self.dataset_names
         self.model.single_fit_functions = self.single_fit_functions
         self.model.start_xs = [0.0, 1.0]
@@ -459,12 +464,13 @@ class BasicFittingModelTest(unittest.TestCase):
         self.model.context = mock.Mock()
         self.model._double_pulse_enabled = mock.Mock(return_value=True)
         self.model._get_guess_parameters = mock.Mock(return_value=['func', 'ws'])
+        self.model._get_plot_guess_name = mock.Mock(return_value=guess_workspace_name)
         self.model._evaluate_double_pulse_function = mock.Mock()
 
         self.model.update_plot_guess(True)
 
         self.model._evaluate_double_pulse_function.assert_called_once_with(
-            self.model.current_single_fit_function, "__frequency_domain_analysis_fitting_guessName1")
+            self.model.current_single_fit_function, guess_workspace_name)
 
     def test_perform_fit_will_call_the_correct_function_for_a_single_fit(self):
         self.model.dataset_names = self.dataset_names

--- a/scripts/test/Muon/fitting_widgets/basic_fitting/basic_fitting_presenter_test.py
+++ b/scripts/test/Muon/fitting_widgets/basic_fitting/basic_fitting_presenter_test.py
@@ -407,7 +407,7 @@ class BasicFittingPresenterTest(unittest.TestCase):
     def test_that_update_fit_function_in_view_from_model_will_update_the_function_and_index_in_the_view(self):
         self.presenter.update_fit_function_in_view_from_model()
 
-        self.view.update_fit_function.assert_called_once_with(self.fit_function, [])
+        self.view.update_fit_function.assert_called_once_with(self.fit_function)
         self.view.set_current_dataset_index.assert_called_once_with(self.current_dataset_index)
 
     def test_that_update_fit_functions_in_model_from_view_will_update_the_single_fit_functions_and_notify(self):

--- a/scripts/test/Muon/fitting_widgets/basic_fitting/basic_fitting_view_test.py
+++ b/scripts/test/Muon/fitting_widgets/basic_fitting/basic_fitting_view_test.py
@@ -63,13 +63,14 @@ class BasicFittingViewTest(unittest.TestCase, QtWidgetFinder):
         self.assertEqual(self.view.fit_controls.global_fit_status_label.text(), "2 of 5 fits failed")
 
     def test_that_the_view_has_been_initialized_with_the_raw_data_option_shown_when_it_is_not_a_frequency_domain(self):
-        self.view = BasicFittingView(is_frequency_domain=False)
+        self.view = BasicFittingView()
         self.view.show()
 
         self.assertTrue(not self.view.fit_function_options.fit_options_table.isRowHidden(RAW_DATA_TABLE_ROW))
 
     def test_that_the_view_has_been_initialized_with_the_raw_data_option_hidden_when_it_is_a_frequency_domain(self):
-        self.view = BasicFittingView(is_frequency_domain=True)
+        self.view = BasicFittingView()
+        self.view.hide_fit_raw_checkbox()
         self.view.show()
 
         self.assertTrue(self.view.fit_function_options.fit_options_table.isRowHidden(RAW_DATA_TABLE_ROW))

--- a/scripts/test/Muon/fitting_widgets/basic_fitting/basic_fitting_view_test.py
+++ b/scripts/test/Muon/fitting_widgets/basic_fitting/basic_fitting_view_test.py
@@ -103,7 +103,7 @@ class BasicFittingViewTest(unittest.TestCase, QtWidgetFinder):
 
         self.view.set_datasets_in_function_browser(dataset_names)
 
-        self.assertEqual(self.view.number_of_datasets(), 3)
+        self.assertEqual(self.view.fit_function_options.number_of_datasets(), 3)
 
     def test_that_set_current_dataset_index_will_set_the_current_dataset_index_in_the_function_browser(self):
         dataset_names = ["Name1", "Name2", "Name3"]

--- a/scripts/test/Muon/fitting_widgets/basic_fitting/fit_function_options_view_test.py
+++ b/scripts/test/Muon/fitting_widgets/basic_fitting/fit_function_options_view_test.py
@@ -32,14 +32,15 @@ class FitFunctionOptionsViewTest(unittest.TestCase, QtWidgetFinder):
         self.assertTrue(self.view.close())
         QApplication.sendPostedEvents()
 
-    def test_that_the_view_has_been_initialized_with_the_raw_data_option_shown_when_it_is_not_a_frequency_domain(self):
-        self.view = FitFunctionOptionsView(is_frequency_domain=False)
+    def test_that_the_view_has_been_initialized_with_the_raw_data_option_shown(self):
+        self.view = FitFunctionOptionsView()
         self.view.show()
 
         self.assertTrue(not self.view.fit_options_table.isRowHidden(RAW_DATA_TABLE_ROW))
 
-    def test_that_the_view_has_been_initialized_with_the_raw_data_option_hidden_when_it_is_a_frequency_domain(self):
-        self.view = FitFunctionOptionsView(is_frequency_domain=True)
+    def test_that_the_view_has_been_initialized_with_the_raw_data_option_hidden(self):
+        self.view = FitFunctionOptionsView()
+        self.view.hide_fit_raw_checkbox()
         self.view.show()
 
         self.assertTrue(self.view.fit_options_table.isRowHidden(RAW_DATA_TABLE_ROW))

--- a/scripts/test/Muon/fitting_widgets/basic_fitting/workspace_selector_view_test.py
+++ b/scripts/test/Muon/fitting_widgets/basic_fitting/workspace_selector_view_test.py
@@ -1,0 +1,110 @@
+# Mantid Repository : https://github.com/mantidproject/mantid
+#
+# Copyright &copy; 2021 ISIS Rutherford Appleton Laboratory UKRI,
+#   NScD Oak Ridge National Laboratory, European Spallation Source,
+#   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+# SPDX - License - Identifier: GPL - 3.0 +
+import unittest
+
+from mantidqt.utils.qt.testing import start_qapplication
+from mantidqt.utils.qt.testing.qt_widget_finder import QtWidgetFinder
+
+from Muon.GUI.Common.fitting_widgets.basic_fitting.workspace_selector_view import WorkspaceSelectorView
+
+from qtpy.QtWidgets import QApplication
+
+
+@start_qapplication
+class WorkspaceSelectorViewTest(unittest.TestCase, QtWidgetFinder):
+
+    def setUp(self):
+        self.view = WorkspaceSelectorView()
+        self.view.show()
+        self.assert_widget_created()
+
+    def tearDown(self):
+        self.assertTrue(self.view.close())
+        QApplication.sendPostedEvents()
+
+    def test_that_update_dataset_name_combo_box_will_set_the_names_in_the_dataset_name_combobox(self):
+        dataset_names = ["Name1", "Name2", "Name3"]
+
+        self.view.update_dataset_name_combo_box(dataset_names)
+
+        data = [self.view.dataset_name_combo_box.itemText(i) for i in range(self.view.dataset_name_combo_box.count())]
+        self.assertTrue(data, dataset_names)
+
+    def test_that_update_dataset_name_combo_box_will_select_the_previously_selected_item_if_it_still_exists(self):
+        selected_dataset = "Name3"
+        dataset_names = ["Name1", "Name2", selected_dataset]
+
+        self.view.update_dataset_name_combo_box(dataset_names)
+        self.view.dataset_name_combo_box.setCurrentIndex(2)
+
+        new_dataset_names = ["Name4", selected_dataset, "Name5"]
+        self.view.update_dataset_name_combo_box(new_dataset_names)
+
+        self.assertTrue(self.view.current_dataset_name, selected_dataset)
+
+    def test_that_increment_dataset_name_combo_box_will_increment_the_dataset_which_is_selected(self):
+        dataset_names = ["Name1", "Name2", "Name3"]
+
+        self.view.update_dataset_name_combo_box(dataset_names)
+        self.view.dataset_name_combo_box.setCurrentIndex(2)
+        self.assertTrue(self.view.current_dataset_name, "Name3")
+
+        self.view.increment_dataset_name_combo_box()
+        self.assertTrue(self.view.current_dataset_name, "Name1")
+
+    def test_that_decrement_dataset_name_combo_box_will_decrement_the_dataset_which_is_selected(self):
+        dataset_names = ["Name1", "Name2", "Name3"]
+
+        self.view.update_dataset_name_combo_box(dataset_names)
+        self.view.dataset_name_combo_box.setCurrentIndex(2)
+        self.assertTrue(self.view.current_dataset_name, "Name1")
+
+        self.view.decrement_dataset_name_combo_box()
+        self.assertTrue(self.view.current_dataset_name, "Name3")
+
+    def test_that_the_current_dataset_name_can_be_set_as_expected(self):
+        selected_dataset = "Name2"
+        dataset_names = ["Name1", selected_dataset, "Name3"]
+
+        self.view.update_dataset_name_combo_box(dataset_names)
+        self.assertEqual(self.view.current_dataset_name, "Name1")
+
+        self.view.current_dataset_name = selected_dataset
+        self.assertEqual(self.view.current_dataset_name, selected_dataset)
+
+    def test_that_the_current_dataset_name_will_not_change_the_selected_dataset_if_the_provided_dataset_does_not_exist(self):
+        selected_dataset = "Name3"
+        dataset_names = ["Name1", "Name2", selected_dataset]
+
+        self.view.update_dataset_name_combo_box(dataset_names)
+        self.view.current_dataset_name = selected_dataset
+        self.assertEqual(self.view.current_dataset_name, selected_dataset)
+
+        self.view.current_dataset_name = "Does not exist"
+        self.assertEqual(self.view.current_dataset_name, selected_dataset)
+
+    def test_that_number_of_datasets_will_return_the_expected_number_of_datasets(self):
+        dataset_names = ["Name1", "Name2", "Name3"]
+
+        self.view.update_dataset_name_combo_box(dataset_names)
+
+        self.assertEqual(self.view.number_of_datasets(), len(dataset_names))
+
+    def test_that_current_dataset_index_will_return_the_expected_dataset_index(self):
+        dataset_names = ["Name1", "Name2", "Name3"]
+
+        self.view.update_dataset_name_combo_box(dataset_names)
+        self.view.current_dataset_name = "Name2"
+
+        self.assertEqual(self.view.current_dataset_index, 1)
+
+    def test_that_current_dataset_index_will_return_none_when_there_is_nothing_selected_in_the_combobox(self):
+        self.assertEqual(self.view.current_dataset_index, None)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/scripts/test/Muon/fitting_widgets/general_fitting/general_fitting_model_test.py
+++ b/scripts/test/Muon/fitting_widgets/general_fitting/general_fitting_model_test.py
@@ -339,21 +339,21 @@ class GeneralFittingModelTest(unittest.TestCase):
 
         self.assertEqual(1, self.model._get_selected_runs_groups_and_pairs_for_simultaneous_fit_mode.call_count)
 
-    def test_that_get_selected_runs_groups_and_pairs_will_attempt_to_get_runs_and_groups_for_single_fit_mode(self):
-        runs = ["62260"]
+    def test_that_get_selected_runs_groups_and_pairs_will_attempt_to_get_run_and_groups_for_single_fit_mode(self):
+        run = "62260"
         group_or_pair = "long"
         self.model.simultaneous_fitting_mode = True
+        self.model.simultaneous_fit_by = "Run"
+        self.model.simultaneous_fit_by_specifier = run
 
-        self.model._get_selected_runs_groups_and_pairs_for_single_fit_mode = \
-            mock.MagicMock(return_value=(runs, [group_or_pair]))
+        self.model._get_selected_groups_and_pairs = mock.MagicMock(return_value=[group_or_pair])
 
         output_runs, output_group_pairs = self.model.get_selected_runs_groups_and_pairs()
-        self.assertEqual(output_runs, runs)
+        self.assertEqual(output_runs, run)
         self.assertEqual(output_group_pairs, [group_or_pair])
 
-        self.model._get_selected_runs_groups_and_pairs_for_single_fit_mode.assert_called_with()
-
-        self.assertEqual(1, self.model._get_selected_runs_groups_and_pairs_for_single_fit_mode.call_count)
+        self.model._get_selected_groups_and_pairs.assert_called_with()
+        self.assertEqual(1, self.model._get_selected_groups_and_pairs.call_count)
 
     def test_that_get_active_fit_function_will_return_the_simultaneous_fit_function_if_in_simultaneous_mode(self):
         self.model.dataset_names = self.dataset_names

--- a/scripts/test/Muon/fitting_widgets/general_fitting/general_fitting_model_test.py
+++ b/scripts/test/Muon/fitting_widgets/general_fitting/general_fitting_model_test.py
@@ -276,23 +276,22 @@ class GeneralFittingModelTest(unittest.TestCase):
                                                                                                                       mock_sort,
                                                                                                                       mock_get_workspaces):
         workspace_names = ["Name"]
-        runs = ["62260"]
+        runs = "All"
         group_or_pair = "long"
         self.model.simultaneous_fitting_mode = False
 
-        self.model._get_selected_runs_groups_and_pairs_for_single_fit_mode = \
-            mock.MagicMock(return_value=(runs, [group_or_pair]))
+        self.model._get_selected_groups_and_pairs = mock.MagicMock(return_value=([group_or_pair]))
 
         mock_get_workspaces.return_value = workspace_names
         mock_sort.return_value = workspace_names
 
         self.assertEqual(self.model.get_workspace_names_to_display_from_context(), workspace_names)
 
-        self.model._get_selected_runs_groups_and_pairs_for_single_fit_mode.assert_called_with()
+        self.model._get_selected_groups_and_pairs.assert_called_with()
         mock_get_workspaces.assert_called_with(runs, group_or_pair)
         mock_sort.assert_called_with(workspace_names)
 
-        self.assertEqual(1, self.model._get_selected_runs_groups_and_pairs_for_single_fit_mode.call_count)
+        self.assertEqual(1, self.model._get_selected_groups_and_pairs.call_count)
         self.assertEqual(1, mock_get_workspaces.call_count)
         self.assertEqual(1, mock_sort.call_count)
 

--- a/scripts/test/Muon/fitting_widgets/general_fitting/general_fitting_options_view_test.py
+++ b/scripts/test/Muon/fitting_widgets/general_fitting/general_fitting_options_view_test.py
@@ -26,21 +26,9 @@ class GeneralFittingOptionsViewTest(unittest.TestCase, QtWidgetFinder):
         self.assertTrue(self.view.close())
         QApplication.sendPostedEvents()
 
-    def test_that_the_view_has_been_initialized_with_the_simultaneous_options_shown_when_it_is_not_a_frequency_domain(self):
-        self.view = GeneralFittingOptionsView(is_frequency_domain=False)
+    def test_that_the_view_can_be_initialized_without_an_error(self):
+        self.view = GeneralFittingOptionsView()
         self.view.show()
-
-        self.assertTrue(not self.view.simul_fit_checkbox.isHidden())
-        self.assertTrue(not self.view.simul_fit_by_combo.isHidden())
-        self.assertTrue(not self.view.simul_fit_by_specifier.isHidden())
-
-    def test_that_the_view_has_been_initialized_with_the_simultaneous_options_hidden_when_it_is_a_frequency_domain(self):
-        self.view = GeneralFittingOptionsView(is_frequency_domain=True)
-        self.view.show()
-
-        self.assertTrue(self.view.simul_fit_checkbox.isHidden())
-        self.assertTrue(self.view.simul_fit_by_combo.isHidden())
-        self.assertTrue(self.view.simul_fit_by_specifier.isHidden())
 
     def test_that_the_simultaneous_fit_by_can_be_set_as_expected(self):
         self.assertEqual(self.view.simultaneous_fit_by, "Run")
@@ -48,17 +36,6 @@ class GeneralFittingOptionsViewTest(unittest.TestCase, QtWidgetFinder):
         self.view.simultaneous_fit_by = "Group/Pair"
 
         self.assertEqual(self.view.simultaneous_fit_by, "Group/Pair")
-
-    def test_that_hide_simultaneous_fit_options_will_hide_the_simultaneous_fitting_options(self):
-        self.assertTrue(not self.view.simul_fit_checkbox.isHidden())
-        self.assertTrue(not self.view.simul_fit_by_combo.isHidden())
-        self.assertTrue(not self.view.simul_fit_by_specifier.isHidden())
-
-        self.view.hide_simultaneous_fit_options()
-
-        self.assertTrue(self.view.simul_fit_checkbox.isHidden())
-        self.assertTrue(self.view.simul_fit_by_combo.isHidden())
-        self.assertTrue(self.view.simul_fit_by_specifier.isHidden())
 
     def test_that_enable_simultaneous_fit_options_will_hide_the_simultaneous_fitting_options(self):
         self.assertTrue(not self.view.simul_fit_by_combo.isEnabled())

--- a/scripts/test/Muon/fitting_widgets/general_fitting/general_fitting_options_view_test.py
+++ b/scripts/test/Muon/fitting_widgets/general_fitting/general_fitting_options_view_test.py
@@ -9,9 +9,7 @@ import unittest
 from mantidqt.utils.qt.testing import start_qapplication
 from mantidqt.utils.qt.testing.qt_widget_finder import QtWidgetFinder
 
-from Muon.GUI.Common.fitting_widgets.general_fitting.general_fitting_options_view import (GeneralFittingOptionsView,
-                                                                                          SIMULTANEOUS_FIT_LABEL,
-                                                                                          SINGLE_FIT_LABEL)
+from Muon.GUI.Common.fitting_widgets.general_fitting.general_fitting_options_view import GeneralFittingOptionsView
 
 from qtpy.QtWidgets import QApplication
 
@@ -44,100 +42,12 @@ class GeneralFittingOptionsViewTest(unittest.TestCase, QtWidgetFinder):
         self.assertTrue(self.view.simul_fit_by_combo.isHidden())
         self.assertTrue(self.view.simul_fit_by_specifier.isHidden())
 
-    def test_that_update_dataset_name_combo_box_will_set_the_names_in_the_dataset_name_combobox(self):
-        dataset_names = ["Name1", "Name2", "Name3"]
-
-        self.view.update_dataset_name_combo_box(dataset_names)
-
-        data = [self.view.dataset_name_combo_box.itemText(i) for i in range(self.view.dataset_name_combo_box.count())]
-        self.assertTrue(data, dataset_names)
-
-    def test_that_update_dataset_name_combo_box_will_select_the_previously_selected_item_if_it_still_exists(self):
-        selected_dataset = "Name3"
-        dataset_names = ["Name1", "Name2", selected_dataset]
-
-        self.view.update_dataset_name_combo_box(dataset_names)
-        self.view.dataset_name_combo_box.setCurrentIndex(2)
-
-        new_dataset_names = ["Name4", selected_dataset, "Name5"]
-        self.view.update_dataset_name_combo_box(new_dataset_names)
-
-        self.assertTrue(self.view.current_dataset_name, selected_dataset)
-
-    def test_that_increment_dataset_name_combo_box_will_increment_the_dataset_which_is_selected(self):
-        dataset_names = ["Name1", "Name2", "Name3"]
-
-        self.view.update_dataset_name_combo_box(dataset_names)
-        self.view.dataset_name_combo_box.setCurrentIndex(2)
-        self.assertTrue(self.view.current_dataset_name, "Name3")
-
-        self.view.increment_dataset_name_combo_box()
-        self.assertTrue(self.view.current_dataset_name, "Name1")
-
-    def test_that_decrement_dataset_name_combo_box_will_decrement_the_dataset_which_is_selected(self):
-        dataset_names = ["Name1", "Name2", "Name3"]
-
-        self.view.update_dataset_name_combo_box(dataset_names)
-        self.view.dataset_name_combo_box.setCurrentIndex(2)
-        self.assertTrue(self.view.current_dataset_name, "Name1")
-
-        self.view.decrement_dataset_name_combo_box()
-        self.assertTrue(self.view.current_dataset_name, "Name3")
-
-    def test_that_the_current_dataset_name_can_be_set_as_expected(self):
-        selected_dataset = "Name2"
-        dataset_names = ["Name1", selected_dataset, "Name3"]
-
-        self.view.update_dataset_name_combo_box(dataset_names)
-        self.assertEqual(self.view.current_dataset_name, "Name1")
-
-        self.view.current_dataset_name = selected_dataset
-        self.assertEqual(self.view.current_dataset_name, selected_dataset)
-
-    def test_that_the_current_dataset_name_will_not_change_the_selected_dataset_if_the_provided_dataset_does_not_exist(self):
-        selected_dataset = "Name3"
-        dataset_names = ["Name1", "Name2", selected_dataset]
-
-        self.view.update_dataset_name_combo_box(dataset_names)
-        self.view.current_dataset_name = selected_dataset
-        self.assertEqual(self.view.current_dataset_name, selected_dataset)
-
-        self.view.current_dataset_name = "Does not exist"
-        self.assertEqual(self.view.current_dataset_name, selected_dataset)
-
-    def test_that_number_of_datasets_will_return_the_expected_number_of_datasets(self):
-        dataset_names = ["Name1", "Name2", "Name3"]
-
-        self.view.update_dataset_name_combo_box(dataset_names)
-
-        self.assertEqual(self.view.number_of_datasets(), len(dataset_names))
-
     def test_that_the_simultaneous_fit_by_can_be_set_as_expected(self):
         self.assertEqual(self.view.simultaneous_fit_by, "Run")
 
         self.view.simultaneous_fit_by = "Group/Pair"
 
         self.assertEqual(self.view.simultaneous_fit_by, "Group/Pair")
-
-    def test_that_current_dataset_index_will_return_the_expected_dataset_index(self):
-        dataset_names = ["Name1", "Name2", "Name3"]
-
-        self.view.update_dataset_name_combo_box(dataset_names)
-        self.view.current_dataset_name = "Name2"
-
-        self.assertEqual(self.view.current_dataset_index, 1)
-
-    def test_that_current_dataset_index_will_return_none_when_there_is_nothing_selected_in_the_combobox(self):
-        self.assertEqual(self.view.current_dataset_index, None)
-
-    def test_that_switch_to_simultaneous_will_change_the_relevant_label(self):
-        self.view.switch_to_simultaneous()
-        self.assertEqual(self.view.workspace_combo_box_label.text(), SIMULTANEOUS_FIT_LABEL)
-
-    def test_that_switch_to_single_will_change_the_relevant_label(self):
-        self.view.switch_to_simultaneous()
-        self.view.switch_to_single()
-        self.assertEqual(self.view.workspace_combo_box_label.text(), SINGLE_FIT_LABEL)
 
     def test_that_hide_simultaneous_fit_options_will_hide_the_simultaneous_fitting_options(self):
         self.assertTrue(not self.view.simul_fit_checkbox.isHidden())

--- a/scripts/test/Muon/fitting_widgets/general_fitting/general_fitting_view_test.py
+++ b/scripts/test/Muon/fitting_widgets/general_fitting/general_fitting_view_test.py
@@ -9,9 +9,9 @@ import unittest
 from mantidqt.utils.qt.testing import start_qapplication
 from mantidqt.utils.qt.testing.qt_widget_finder import QtWidgetFinder
 
-from Muon.GUI.Common.fitting_widgets.general_fitting.general_fitting_options_view import (SIMULTANEOUS_FIT_LABEL,
-                                                                                          SINGLE_FIT_LABEL)
-from Muon.GUI.Common.fitting_widgets.general_fitting.general_fitting_view import GeneralFittingView
+from Muon.GUI.Common.fitting_widgets.general_fitting.general_fitting_view import (GeneralFittingView,
+                                                                                  SIMULTANEOUS_FIT_LABEL,
+                                                                                  SINGLE_FIT_LABEL)
 
 from qtpy.QtWidgets import QApplication
 
@@ -49,8 +49,8 @@ class GeneralFittingViewTest(unittest.TestCase, QtWidgetFinder):
 
         self.view.update_dataset_name_combo_box(dataset_names)
 
-        data = [self.view.general_fitting_options.dataset_name_combo_box.itemText(i)
-                for i in range(self.view.general_fitting_options.dataset_name_combo_box.count())]
+        data = [self.view.workspace_selector.dataset_name_combo_box.itemText(i)
+                for i in range(self.view.workspace_selector.dataset_name_combo_box.count())]
         self.assertTrue(data, dataset_names)
 
     def test_that_update_dataset_name_combo_box_will_select_the_previously_selected_item_if_it_still_exists(self):
@@ -58,7 +58,7 @@ class GeneralFittingViewTest(unittest.TestCase, QtWidgetFinder):
         dataset_names = ["Name1", "Name2", selected_dataset]
 
         self.view.update_dataset_name_combo_box(dataset_names)
-        self.view.general_fitting_options.dataset_name_combo_box.setCurrentIndex(2)
+        self.view.workspace_selector.dataset_name_combo_box.setCurrentIndex(2)
 
         new_dataset_names = ["Name4", selected_dataset, "Name5"]
         self.view.update_dataset_name_combo_box(new_dataset_names)
@@ -113,12 +113,12 @@ class GeneralFittingViewTest(unittest.TestCase, QtWidgetFinder):
 
     def test_that_switch_to_simultaneous_will_change_the_relevant_label(self):
         self.view.switch_to_simultaneous()
-        self.assertEqual(self.view.general_fitting_options.workspace_combo_box_label.text(), SIMULTANEOUS_FIT_LABEL)
+        self.assertEqual(self.view.workspace_selector.workspace_combo_box_label.text(), SIMULTANEOUS_FIT_LABEL)
 
     def test_that_switch_to_single_will_change_the_relevant_label(self):
         self.view.switch_to_simultaneous()
         self.view.switch_to_single()
-        self.assertEqual(self.view.general_fitting_options.workspace_combo_box_label.text(), SINGLE_FIT_LABEL)
+        self.assertEqual(self.view.workspace_selector.workspace_combo_box_label.text(), SINGLE_FIT_LABEL)
 
     def test_that_hide_simultaneous_fit_options_will_hide_the_simultaneous_fitting_options(self):
         self.assertTrue(not self.view.general_fitting_options.simul_fit_checkbox.isHidden())
@@ -130,32 +130,6 @@ class GeneralFittingViewTest(unittest.TestCase, QtWidgetFinder):
         self.assertTrue(self.view.general_fitting_options.simul_fit_checkbox.isHidden())
         self.assertTrue(self.view.general_fitting_options.simul_fit_by_combo.isHidden())
         self.assertTrue(self.view.general_fitting_options.simul_fit_by_specifier.isHidden())
-
-    def test_that_enable_simultaneous_fit_options_will_hide_the_simultaneous_fitting_options(self):
-        self.assertTrue(not self.view.general_fitting_options.simul_fit_by_combo.isEnabled())
-        self.assertTrue(not self.view.general_fitting_options.simul_fit_by_specifier.isEnabled())
-
-        self.view.enable_simultaneous_fit_options()
-
-        self.assertTrue(self.view.general_fitting_options.simul_fit_by_combo.isEnabled())
-        self.assertTrue(self.view.general_fitting_options.simul_fit_by_specifier.isEnabled())
-
-    def test_that_disable_simultaneous_fit_options_will_hide_the_simultaneous_fitting_options(self):
-        self.view.enable_simultaneous_fit_options()
-        self.assertTrue(self.view.general_fitting_options.simul_fit_by_combo.isEnabled())
-        self.assertTrue(self.view.general_fitting_options.simul_fit_by_specifier.isEnabled())
-
-        self.view.disable_simultaneous_fit_options()
-
-        self.assertTrue(not self.view.general_fitting_options.simul_fit_by_combo.isEnabled())
-        self.assertTrue(not self.view.general_fitting_options.simul_fit_by_specifier.isEnabled())
-
-    def test_that_is_simultaneous_fit_ticked_will_change_the_fitting_mode_as_expected(self):
-        self.assertTrue(not self.view.general_fitting_options.simul_fit_checkbox.isChecked())
-
-        self.view.is_simultaneous_fit_ticked = True
-
-        self.assertTrue(self.view.general_fitting_options.simul_fit_checkbox.isChecked())
 
     def test_that_setup_fit_by_specifier_will_add_fit_specifiers_to_the_relevant_checkbox(self):
         fit_specifiers = ["long", "fwd", "bwd"]

--- a/scripts/test/Muon/fitting_widgets/general_fitting/general_fitting_view_test.py
+++ b/scripts/test/Muon/fitting_widgets/general_fitting/general_fitting_view_test.py
@@ -28,21 +28,9 @@ class GeneralFittingViewTest(unittest.TestCase, QtWidgetFinder):
         self.assertTrue(self.view.close())
         QApplication.sendPostedEvents()
 
-    def test_that_the_view_has_been_initialized_with_the_simultaneous_options_shown_when_it_is_not_a_frequency_domain(self):
-        self.view = GeneralFittingView(is_frequency_domain=False)
+    def test_that_the_view_can_be_initialized_without_an_error(self):
+        self.view = GeneralFittingView()
         self.view.show()
-
-        self.assertTrue(not self.view.general_fitting_options.simul_fit_checkbox.isHidden())
-        self.assertTrue(not self.view.general_fitting_options.simul_fit_by_combo.isHidden())
-        self.assertTrue(not self.view.general_fitting_options.simul_fit_by_specifier.isHidden())
-
-    def test_that_the_view_has_been_initialized_with_the_simultaneous_options_hidden_when_it_is_a_frequency_domain(self):
-        self.view = GeneralFittingView(is_frequency_domain=True)
-        self.view.show()
-
-        self.assertTrue(self.view.general_fitting_options.simul_fit_checkbox.isHidden())
-        self.assertTrue(self.view.general_fitting_options.simul_fit_by_combo.isHidden())
-        self.assertTrue(self.view.general_fitting_options.simul_fit_by_specifier.isHidden())
 
     def test_that_update_dataset_name_combo_box_will_set_the_names_in_the_dataset_name_combobox(self):
         dataset_names = ["Name1", "Name2", "Name3"]
@@ -119,17 +107,6 @@ class GeneralFittingViewTest(unittest.TestCase, QtWidgetFinder):
         self.view.switch_to_simultaneous()
         self.view.switch_to_single()
         self.assertEqual(self.view.workspace_selector.workspace_combo_box_label.text(), SINGLE_FIT_LABEL)
-
-    def test_that_hide_simultaneous_fit_options_will_hide_the_simultaneous_fitting_options(self):
-        self.assertTrue(not self.view.general_fitting_options.simul_fit_checkbox.isHidden())
-        self.assertTrue(not self.view.general_fitting_options.simul_fit_by_combo.isHidden())
-        self.assertTrue(not self.view.general_fitting_options.simul_fit_by_specifier.isHidden())
-
-        self.view.hide_simultaneous_fit_options()
-
-        self.assertTrue(self.view.general_fitting_options.simul_fit_checkbox.isHidden())
-        self.assertTrue(self.view.general_fitting_options.simul_fit_by_combo.isHidden())
-        self.assertTrue(self.view.general_fitting_options.simul_fit_by_specifier.isHidden())
 
     def test_that_setup_fit_by_specifier_will_add_fit_specifiers_to_the_relevant_checkbox(self):
         fit_specifiers = ["long", "fwd", "bwd"]

--- a/scripts/test/Muon/muon_context_with_frequency_test.py
+++ b/scripts/test/Muon/muon_context_with_frequency_test.py
@@ -67,21 +67,24 @@ class MuonContextWithFrequencyTest(unittest.TestCase):
 
     def test_get_workspace_names_returns_nothing_if_no_parameters_passed(self):
         self.populate_ADS()
-        workspace_list = self.context.get_names_of_workspaces_to_fit(freq = "All")
+        self.context._frequency_context.plot_type = "All"
+        workspace_list = self.context.get_names_of_workspaces_to_fit()
 
         self.assertEqual(workspace_list, [])
 
     def test_get_workspaces_names_copes_with_no_freq_runs(self):
         self.populate_ADS()
+        self.context._frequency_context.plot_type = "All"
         workspace_list = self.context.get_names_of_workspaces_to_fit(runs='19489', group_and_pair='fwd, bwd, long, random, wrong',
-                                                                     phasequad=True, freq="All")
+                                                                     phasequad=True)
 
         self.assertEqual(Counter(workspace_list),
                          Counter([]))
 
     def test_call_freq_workspace_names(self):
         self.context.get_names_of_frequency_domain_workspaces_to_fit = mock.Mock()
-        self.context.get_names_of_workspaces_to_fit(runs='19489', group_and_pair='fwd, bwd', freq="All")
+        self.context._frequency_context.plot_type = "All"
+        self.context.get_names_of_workspaces_to_fit(runs='19489', group_and_pair='fwd, bwd')
         self.context.get_names_of_frequency_domain_workspaces_to_fit.assert_called_once_with(runs='19489', group_and_pair='fwd, bwd',
                                                                                              frequency_type="All")
 

--- a/scripts/test/Muon/plotting_canvas/plotting_canvas_model_test.py
+++ b/scripts/test/Muon/plotting_canvas/plotting_canvas_model_test.py
@@ -19,6 +19,7 @@ class PlottingCanvasModelTest(unittest.TestCase):
 
     def test_create_workspace_plot_information_calls_get_plot_axis_correctly(self):
         self.model._get_workspace_plot_axis = mock.MagicMock(return_value=1)
+        self.model._is_guess_workspace = mock.MagicMock(return_value=True)
         test_ws_names = ["MUSR62260; Group; fwd", "MUSR62260; Group; fwd"]
         test_indies = [0, 0]
         self.model.create_workspace_plot_information(test_ws_names, test_indies, errors=False)
@@ -31,6 +32,7 @@ class PlottingCanvasModelTest(unittest.TestCase):
         axis = 2
         self.model._get_workspace_plot_axis = mock.MagicMock(return_value=2)
         self.model.create_plot_information = mock.MagicMock()
+        self.model._is_guess_workspace = mock.MagicMock(return_value=False)
         test_ws_names = ["MUSR62260; Group; fwd", "MUSR62260; Group; fwd"]
         test_indies = [0, 0]
         self.model.create_workspace_plot_information(test_ws_names, test_indies, errors=False)


### PR DESCRIPTION
**Description of work.**
This PR moves the Workspace Selector widget from the GeneralFittingWidget to the BasicFittingWidget. It makes more sense for it to be here because previously the BasicFittingModel would be able to hold the dataset names, however there would be no means of selecting the datasets names from the BasicFittingView. 

It is also a good idea to more this workspace selector widget because it is required for Model Analysis which will be in development in the next sprint, and this Model Analysis can just inherit the BasicFittingWidget to get most of the widgets it needs.

**To test:**
@AnthonyLim23 is best to review this.

Test Muon Analysis and it should all work as previously. **It is also important to test Frequency Domain Analysis as this now uses the BasicFittingWidget instead of the GeneralFittingWidget.**

*No release notes required as this is an internal change*

Part of #31349

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
