### PR TITLE
Keep Fit Results In Muon Analysis When New Data Is Loaded 

### DIFF
--- a/Testing/SystemTests/tests/qt/PythonInterfacesStartupTest.py
+++ b/Testing/SystemTests/tests/qt/PythonInterfacesStartupTest.py
@@ -25,6 +25,8 @@ APP_NAME_SWITCHER = {"DGS_Reduction.py": "python",
                      "ORNL_SANS.py": "python",
                      "Powder_Diffraction_Reduction.py": "python"}
 
+CLOSE_CODE_SWITCHER = {"Muon_Analysis.py": "\nmuon_analysis.close()"}
+
 
 def set_instrument(interface_script_name):
     instrument = INSTRUMENT_SWITCHER.get(interface_script_name, None)
@@ -64,8 +66,10 @@ class PythonInterfacesStartupTest(systemtesting.MantidSystemTest):
         set_application_name(interface_script)
         # Prevents a QDialog popping up when opening certain interfaces
         set_instrument(interface_script)
+        # Some interfaces need to be closed after opening. This also ensures they process all their events
+        close_code = CLOSE_CODE_SWITCHER.get(interface_script, "")
 
         try:
-            exec(open(os.path.join(self._interface_directory, interface_script)).read())
+            exec(open(os.path.join(self._interface_directory, interface_script)).read() + close_code)
         except Exception as ex:
             self.fail(f"Exception thrown when attempting to open the {interface_script} interface: {ex}.")

--- a/scripts/Muon/GUI/Common/fitting_widgets/basic_fitting/basic_fitting_model.py
+++ b/scripts/Muon/GUI/Common/fitting_widgets/basic_fitting/basic_fitting_model.py
@@ -388,6 +388,10 @@ class BasicFittingModel:
         """Removes all fit results from the context."""
         self.context.fitting_context.remove_all_fits()
 
+    def remove_latest_fit_from_context(self) -> None:
+        """Removes the most recent fit performed from the fitting context"""
+        self.context.fitting_context.remove_latest_fit()
+
     def reset_current_dataset_index(self) -> None:
         """Resets the current dataset index stored by the model."""
         if self.number_of_datasets == 0:

--- a/scripts/Muon/GUI/Common/fitting_widgets/basic_fitting/basic_fitting_model.py
+++ b/scripts/Muon/GUI/Common/fitting_widgets/basic_fitting/basic_fitting_model.py
@@ -241,7 +241,6 @@ class BasicFittingModel:
     def clear_cached_fit_functions(self) -> None:
         """Clears the cached fit functions and removes all fits from the fitting context."""
         self.single_fit_functions_cache = [None] * self.number_of_datasets
-        self.remove_all_fits_from_context()
 
     @property
     def fit_statuses(self) -> list:

--- a/scripts/Muon/GUI/Common/fitting_widgets/basic_fitting/basic_fitting_presenter.py
+++ b/scripts/Muon/GUI/Common/fitting_widgets/basic_fitting/basic_fitting_presenter.py
@@ -107,6 +107,7 @@ class BasicFittingPresenter:
         """Handle when undo fit is clicked."""
         self.model.use_cached_function()
         self.clear_cached_fit_functions()
+        self.model.remove_all_fits_from_context()
 
         self.reset_fit_status_and_chi_squared_information()
 
@@ -231,7 +232,6 @@ class BasicFittingPresenter:
     def clear_cached_fit_functions(self) -> None:
         """Clear the cached fit functions."""
         self.view.enable_undo_fit(False)
-        self.model.remove_all_fits_from_context()
         self.model.clear_cached_fit_functions()
 
     def reset_fit_status_and_chi_squared_information(self) -> None:

--- a/scripts/Muon/GUI/Common/fitting_widgets/basic_fitting/basic_fitting_presenter.py
+++ b/scripts/Muon/GUI/Common/fitting_widgets/basic_fitting/basic_fitting_presenter.py
@@ -107,7 +107,7 @@ class BasicFittingPresenter:
         """Handle when undo fit is clicked."""
         self.model.use_cached_function()
         self.clear_cached_fit_functions()
-        self.model.remove_all_fits_from_context()
+        self.model.remove_latest_fit_from_context()
 
         self.reset_fit_status_and_chi_squared_information()
 

--- a/scripts/Muon/GUI/Common/fitting_widgets/basic_fitting/fit_controls.ui
+++ b/scripts/Muon/GUI/Common/fitting_widgets/basic_fitting/fit_controls.ui
@@ -51,7 +51,7 @@
       <item>
        <widget class="QPushButton" name="undo_fit_button">
         <property name="text">
-         <string>Undo Fits</string>
+         <string>Undo Fit</string>
         </property>
        </widget>
       </item>

--- a/scripts/Muon/GUI/Common/fitting_widgets/general_fitting/general_fitting_presenter.py
+++ b/scripts/Muon/GUI/Common/fitting_widgets/general_fitting/general_fitting_presenter.py
@@ -53,6 +53,8 @@ class GeneralFittingPresenter(BasicFittingPresenter):
         self._update_plot = False
         self.update_and_reset_all_data()
         self._update_plot = True
+        self.clear_cached_fit_functions()
+        self.model.remove_all_fits_from_context()
 
     def handle_pulse_type_changed(self, updated_variables: dict) -> None:
         """Handles when double pulse mode is switched on and switches to normal fitting mode."""

--- a/scripts/Muon/GUI/Common/results_tab_widget/results_tab_presenter.py
+++ b/scripts/Muon/GUI/Common/results_tab_widget/results_tab_presenter.py
@@ -80,7 +80,10 @@ class ResultsTabPresenter(QObject):
         self.view.set_fit_function_names(self.model.fit_functions())
         self._update_fit_results_view_on_new_fit()
         self._update_logs_view()
-        self.view.set_output_results_button_enabled(True)
+        if self.model._fit_context.fit_list:
+            self.view.set_output_results_button_enabled(True)
+        else:
+            self.view.set_output_results_button_enabled(False)
 
     def _get_workspace_list(self):
         fit_context = self.model._fit_context

--- a/scripts/Muon/GUI/Common/results_tab_widget/results_tab_widget.py
+++ b/scripts/Muon/GUI/Common/results_tab_widget/results_tab_widget.py
@@ -23,3 +23,4 @@ class ResultsTabWidget(object):
             self.results_tab_view, ResultsTabModel(fit_context))
 
         context.update_view_from_model_notifier.add_subscriber(self.results_tab_presenter.update_view_from_model_observer)
+        fit_context.fit_removed_notifier.add_subscriber(self.results_tab_presenter.new_fit_performed_observer)

--- a/scripts/test/Muon/fitting_widgets/basic_fitting/basic_fitting_presenter_test.py
+++ b/scripts/test/Muon/fitting_widgets/basic_fitting/basic_fitting_presenter_test.py
@@ -149,7 +149,7 @@ class BasicFittingPresenterTest(unittest.TestCase):
         self.presenter.reset_fit_status_and_chi_squared_information.assert_called_once_with()
         self.presenter.update_fit_function_in_view_from_model.assert_called_once_with()
         self.model.update_plot_guess.assert_called_once_with(True)
-        self.model.remove_all_fits_from_context.assert_called_once_with()
+        self.model.remove_latest_fit_from_context.assert_called_once_with()
         self.presenter.selected_fit_results_changed.notify_subscribers.assert_called_once_with([])
 
     def test_that_handle_fit_clicked_will_show_a_warning_if_no_data_is_loaded(self):

--- a/scripts/test/Muon/fitting_widgets/basic_fitting/basic_fitting_presenter_test.py
+++ b/scripts/test/Muon/fitting_widgets/basic_fitting/basic_fitting_presenter_test.py
@@ -149,6 +149,7 @@ class BasicFittingPresenterTest(unittest.TestCase):
         self.presenter.reset_fit_status_and_chi_squared_information.assert_called_once_with()
         self.presenter.update_fit_function_in_view_from_model.assert_called_once_with()
         self.model.update_plot_guess.assert_called_once_with(True)
+        self.model.remove_all_fits_from_context.assert_called_once_with()
         self.presenter.selected_fit_results_changed.notify_subscribers.assert_called_once_with([])
 
     def test_that_handle_fit_clicked_will_show_a_warning_if_no_data_is_loaded(self):
@@ -313,7 +314,6 @@ class BasicFittingPresenterTest(unittest.TestCase):
         self.presenter.clear_cached_fit_functions()
 
         self.view.enable_undo_fit.assert_called_once_with(False)
-        self.model.remove_all_fits_from_context.assert_called_once_with()
         self.model.clear_cached_fit_functions.assert_called_once_with()
 
     def test_that_reset_fit_status_and_chi_squared_information_will_reset_the_info_in_the_model(self):

--- a/scripts/test/Muon/fitting_widgets/general_fitting/general_fitting_presenter_test.py
+++ b/scripts/test/Muon/fitting_widgets/general_fitting/general_fitting_presenter_test.py
@@ -82,10 +82,14 @@ class GeneralFittingPresenterTest(unittest.TestCase):
 
     def test_that_handle_instrument_changed_will_update_and_reset_the_data(self):
         self.presenter.update_and_reset_all_data = mock.Mock()
+        self.presenter.clear_cached_fit_functions = mock.Mock()
+        self.presenter.model.remove_all_fits_from_context = mock.Mock()
 
         self.presenter.handle_instrument_changed()
 
         self.presenter.update_and_reset_all_data.assert_called_with()
+        self.presenter.clear_cached_fit_functions.assert_called_once_with()
+        self.presenter.model.remove_all_fits_from_context.assert_called_once_with()
 
     def test_that_handle_pulse_type_changed_will_update_and_reset_the_data_if_it_contains_DoublePulseEnabled(self):
         updated_variables = {"DoublePulseEnabled": True, "OtherVariable": False}

--- a/scripts/test/Muon/results_tab_widget/results_tab_presenter_test.py
+++ b/scripts/test/Muon/results_tab_widget/results_tab_presenter_test.py
@@ -23,6 +23,8 @@ class ResultsTabPresenterTest(unittest.TestCase):
         self.mock_view.function_selection_changed.connect = mock.MagicMock()
         self.mock_view.results_name_edited.connect = mock.MagicMock()
         self.mock_view.output_results_requested.connect = mock.MagicMock()
+        self.mock_context = mock.MagicMock()
+        self.mock_model._fit_context = self.mock_context
 
     def tearDown(self):
         self.view_patcher.stop()
@@ -71,6 +73,7 @@ class ResultsTabPresenterTest(unittest.TestCase):
         self.mock_model.fit_functions.return_value = test_functions
         self.mock_model.fit_selection.return_value = final_ws_list_state
         self.mock_view.fit_result_workspaces.return_value = orig_ws_list_state
+        self.mock_model._fit_context.fit_list = ["fit"]
 
         presenter = ResultsTabPresenter(self.mock_view, self.mock_model)
         presenter._get_workspace_list = mock.MagicMock(return_value=(['ws1', 'ws3'], "func1"))
@@ -86,6 +89,14 @@ class ResultsTabPresenterTest(unittest.TestCase):
             final_ws_list_state)
         self.mock_view.set_output_results_button_enabled.assert_called_once_with(
             True)
+
+    def test_if_no_fits_in_context_then_output_results_is_disabled(self):
+        self.mock_model._fit_context.fit_list = []
+        presenter = ResultsTabPresenter(self.mock_view, self.mock_model)
+        presenter.on_new_fit_performed()
+        expected_calls = [mock.call(False), mock.call(False)]  # Called once in init of view and once on new fit
+
+        self.mock_view.set_output_results_button_enabled.assert_has_calls(expected_calls)
 
     def test_adding_new_fit_updates_log_values(self):
         existing_selection = {


### PR DESCRIPTION
**Description of work.**
Removed some unnecessary lines of code that were clearing all fits when not needed from the fitting context

**To test:**

1. Open Muon Analysis
2. Load a run (e.g. MUSR62260)
3. Go to the fitting tab and fit any function (e.g. Linear background) and press fit (doesn't need to be a good fit)
4. Go to the results tab and verify the fit workspace is present
5. Go back to Fitting tab
6. Step to the next run by clicking the arrow next to run number
7. Once the data has loaded click fit once again and do this for several runs
8. Now go to the results tab
9. The results tab should include the results from all the fits you performed not just the last one
10. On the fitting tab click undo fit
11. The latest fit should now be removed from the results table
12. On the home tab change instrument
13. All fits should be removed from the results tab

Fixes #31298 

*This does not require release notes* because **this is a bug from this release not present in the previous release**

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
