### PR TITLE
Indirect - Fix Symmetrise range selectors not moving below zero

### DIFF
--- a/docs/source/release/v6.1.0/indirect_geometry.rst
+++ b/docs/source/release/v6.1.0/indirect_geometry.rst
@@ -30,6 +30,7 @@ Improvements
 
 Bug Fixes
 #########
+- Fixed a bug causing the x range markers on the Symmetrise plot of Data Reduction to be restricted in movement.
 - Fixed a bug causing the x range markers on the ISISDiagnostics plot of Data Reduction to go missing.
 
 :ref:`Release 6.1.0 <v6.1.0>`

--- a/qt/scientific_interfaces/Indirect/IndirectSymmetrise.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectSymmetrise.cpp
@@ -257,8 +257,12 @@ void IndirectSymmetrise::plotNewData(QString const &workspaceName) {
   double symmRange = std::max(fabs(axisRange.first), fabs(axisRange.second));
 
   // Set valid range for range selectors
-  m_uiForm.ppRawPlot->getRangeSelector("NegativeE")->setRange(-symmRange, 0);
-  m_uiForm.ppRawPlot->getRangeSelector("PositiveE")->setRange(0, symmRange);
+  auto negativeESelector = m_uiForm.ppRawPlot->getRangeSelector("NegativeE");
+  negativeESelector->setBounds(axisRange.first, axisRange.second);
+  negativeESelector->setRange(-symmRange, 0);
+  auto positiveESelector = m_uiForm.ppRawPlot->getRangeSelector("PositiveE");
+  positiveESelector->setBounds(axisRange.first, axisRange.second);
+  positiveESelector->setRange(0, symmRange);
 
   // Set some default (and valid) values for E range
   m_dblManager->setValue(m_properties["EMax"], axisRange.second);


### PR DESCRIPTION
**Description of work.**
This PR fixes a bug in the Symmetrise tab of Indirect Data Reduction where the range selectors could not be moved below zero. This was caused by the bounds not having been set for the range selectors. These bounds default to be between 0 and 1, and so the markers could not be moved as intended.

No tests added because this can't be tested easily.

**To test:**
1. Indirect->Data Reduction-> Symmetrise tab
2. You should be able to follow the example workflow in https://docs.mantidproject.org/nightly/interfaces/indirect/Indirect%20Data%20Reduction.html#symmetrise-example-workflow

There should be no difficulties in completing this workflow (i.e. no errors etc.)

Fixes #31248

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
