### PR TITLE
Protect against window flags set to None

### DIFF
--- a/scripts/Drill.py
+++ b/scripts/Drill.py
@@ -36,7 +36,8 @@ else:
             # This is necessary to ensure settings for 'On top'/'Floating' window behaviour are propagated to DRILL
             # if they are changed by the user after DRILL has been opened.
             drillInterface.setParent(parent)
-            drillInterface.setWindowFlags(flags)
+            if flags is not None:
+                drillInterface.setWindowFlags(flags)
         drillInterface.show()
         if not within_mantid:
             sys.exit(app.exec_())


### PR DESCRIPTION
**Description of work.**

setWindowFlags will not accept None so make sure we only set if supplied

While attempting to reproduce and fix [this forum](https://forum.mantidproject.org/t/mantiplot-bat-standalone-pyhthon-raises-cannot-find-qt-platform-plugin-windows/730) issue it showed that the startup script for Drill did not work outside of workbench.


**To test:**

* Run `bin/mantidpython`
* Type `cd path-to-scripts-dir-in-source`
* Type `%run Drill.py`

Drill should pop up.

*There is no associated issue.*

*This does not require release notes* because **it is a very minor issue.**

<!-- Ensure the base of this PR is correct (e.g. release-next or master)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
