### PR TITLE
Fix workbench hang on clean install

### DIFF
--- a/qt/applications/workbench/CMakeLists.txt
+++ b/qt/applications/workbench/CMakeLists.txt
@@ -164,6 +164,7 @@ set(TEST_FILES
     workbench/plugins/test/test_jupyterconsole.py
     workbench/plugins/test/test_workspacewidget.py
     workbench/utils/test/test_workspacehistorygeneration.py
+    workbench/widgets/about/test/test_about_presenter.py
     workbench/widgets/plotselector/test/test_plotselector_model.py
     workbench/widgets/plotselector/test/test_plotselector_presenter.py
     workbench/widgets/plotselector/test/test_plotselector_view.py

--- a/qt/applications/workbench/workbench/widgets/about/presenter.py
+++ b/qt/applications/workbench/workbench/widgets/about/presenter.py
@@ -95,10 +95,9 @@ class AboutPresenter(object):
             return
         self.view.cb_facility.addItems(facilities)
 
-        try:
-            default_facility = ConfigService.getFacility().name()
-        except RuntimeError:
-            default_facility = facilities[0]
+        current_facility = self._get_current_facility()
+        default_facility = current_facility if current_facility is not None else facilities[0]
+
         self.view.cb_facility.setCurrentIndex(self.view.cb_facility.findText(default_facility))
         self.action_facility_changed(default_facility)
         self.view.cb_facility.currentTextChanged.connect(self.action_facility_changed)
@@ -108,19 +107,26 @@ class AboutPresenter(object):
         When the facility is changed, refreshes all available instruments that can be selected in the dropdown.
         :param new_facility: The name of the new facility that was selected
         """
-        current_value = ConfigService.getFacility().name()
+        current_facility = self._get_current_facility()
         self.store_facility(new_facility)
         # refresh the instrument selection to contain instruments about the selected facility only
         self.view.cb_instrument.facility = new_facility
-        if new_facility != current_value:
+        if new_facility != current_facility:
             self.view.cb_instrument.setCurrentIndex(0)
 
     def store_facility(self, new_facility):
-        current_value = ConfigService.getFacility().name()
-        if new_facility != current_value:
+        current_facility = self._get_current_facility()
+        if new_facility != current_facility:
             ConfigService.setFacility(new_facility)
             return True
         return False
+
+    @staticmethod
+    def _get_current_facility() -> str:
+        try:
+            return ConfigService.getFacility().name()
+        except RuntimeError:
+            return None
 
     def action_instrument_changed(self, new_instrument):
         current_value = ConfigService.getString(self.INSTRUMENT)

--- a/qt/applications/workbench/workbench/widgets/about/test/test_about_presenter.py
+++ b/qt/applications/workbench/workbench/widgets/about/test/test_about_presenter.py
@@ -7,7 +7,7 @@
 #  This file is part of the mantid workbench
 from unittest import TestCase
 
-from unittest.mock import call, patch
+from unittest.mock import call, Mock, patch
 from mantidqt.utils.qt.testing import start_qapplication
 from mantidqt.utils.testing.strict_mock import StrictMock
 from workbench.widgets.about.presenter import AboutPresenter
@@ -123,45 +123,49 @@ class AboutPresenterTest(TestCase):
         self.assertEqual(0, mock_ConfigService.mock_instrument.name.call_count)
         presenter = AboutPresenter(None)
         self.assertEqual(0, mock_ConfigService.setFacility.call_count)
-        self.assertEqual(2, mock_ConfigService.getFacility.call_count)
-        self.assertEqual(2, mock_ConfigService.mock_facility.name.call_count)
-        self.assert_connected_once(presenter.view.cbFacility, presenter.view.cbFacility.currentTextChanged)
-
-        mock_ConfigService.getInstrument.assert_called_once_with()
-        self.assertEqual(2, mock_ConfigService.mock_instrument.name.call_count)
-        self.assert_connected_once(presenter.view.cbInstrument, presenter.view.cbInstrument.currentTextChanged)
+        self.assertEqual(3, mock_ConfigService.getFacility.call_count)
+        self.assertEqual(3, mock_ConfigService.mock_facility.name.call_count)
+        self.assert_connected_once(presenter.view.cb_facility, presenter.view.cb_facility.currentTextChanged)
 
     def test_setup_checkbox_signals(self):
         presenter = AboutPresenter(None)
 
-        self.assert_connected_once(presenter.view.chkDoNotShowUntilNextRelease,
-                                   presenter.view.chkDoNotShowUntilNextRelease.stateChanged)
+        self.assert_connected_once(presenter.view.chk_do_not_show_until_next_release,
+                                   presenter.view.chk_do_not_show_until_next_release.stateChanged)
 
-        self.assert_connected_once(presenter.view.chkAllowUsageData,
-                                   presenter.view.chkAllowUsageData.stateChanged)
+        self.assert_connected_once(presenter.view.chk_allow_usage_data,
+                                   presenter.view.chk_allow_usage_data.stateChanged)
 
     def test_setup_button_signals(self):
         presenter = AboutPresenter(None)
 
-        self.assert_connected_once(presenter.view.clbReleaseNotes,
-                                   presenter.view.clbReleaseNotes.clicked)
-        self.assert_connected_once(presenter.view.clbSampleDatasets,
-                                   presenter.view.clbSampleDatasets.clicked)
-        self.assert_connected_once(presenter.view.clbMantidIntroduction,
-                                   presenter.view.clbMantidIntroduction.clicked)
-        self.assert_connected_once(presenter.view.clbPythonIntroduction,
-                                   presenter.view.clbPythonIntroduction.clicked)
-        self.assert_connected_once(presenter.view.clbPythonInMantid,
-                                   presenter.view.clbPythonInMantid.clicked)
-        self.assert_connected_once(presenter.view.clbExtendingMantid,
-                                   presenter.view.clbExtendingMantid.clicked)
-        self.assert_connected_once(presenter.view.pbMUD,
-                                   presenter.view.pbMUD.clicked)
-        self.assert_connected_once(presenter.view.lblPrivacyPolicy,
-                                   presenter.view.lblPrivacyPolicy.linkActivated)
+        self.assert_connected_once(presenter.view.clb_release_notes,
+                                   presenter.view.clb_release_notes.clicked)
+        self.assert_connected_once(presenter.view.clb_sample_datasets,
+                                   presenter.view.clb_sample_datasets.clicked)
+        self.assert_connected_once(presenter.view.clb_mantid_introduction,
+                                   presenter.view.clb_mantid_introduction.clicked)
+        self.assert_connected_once(presenter.view.clb_python_introduction,
+                                   presenter.view.clb_python_introduction.clicked)
+        self.assert_connected_once(presenter.view.clb_python_in_mantid,
+                                   presenter.view.clb_python_in_mantid.clicked)
+        self.assert_connected_once(presenter.view.clb_extending_mantid,
+                                   presenter.view.clb_extending_mantid.clicked)
+        self.assert_connected_once(presenter.view.pb_manage_user_directories,
+                                   presenter.view.pb_manage_user_directories.clicked)
+        self.assert_connected_once(presenter.view.lbl_privacy_policy,
+                                   presenter.view.lbl_privacy_policy.linkActivated)
 
     def test_setup_link_signals(self):
         presenter = AboutPresenter(None)
 
-        self.assert_connected_once(presenter.view.clbReleaseNotes,
-                                   presenter.view.clbReleaseNotes.clicked)
+        self.assert_connected_once(presenter.view.clb_release_notes,
+                                   presenter.view.clb_release_notes.clicked)
+
+    @patch(CONFIG_SERVICE_CLASSPATH, new_callable=MockConfigService)
+    def test_that_about_presenter_is_instantiated_without_error_when_getFacility_causes_exception(self, MockConfigService):
+        MockConfigService.getFacility.side_effect = RuntimeError(Mock(status=101), "No facility")
+        presenter = AboutPresenter(None)
+
+        self.assertEqual(3, MockConfigService.getFacility.call_count)
+        self.assertEqual(presenter._get_current_facility(), None)


### PR DESCRIPTION
**Description of work.**
This PR fixes a crash by workbench when starting up a clean install of Mantid workbench with an empty facility.

**To test:**
Follow the testing instructions in the issue and make sure mantid opens ok #31354 

Fixes #31354

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
