### PR TITLE
Stop Period Pop Up In Muon Analysis Falling Behind Main Workbench Window

### DIFF
--- a/scripts/Muon/GUI/Common/grouping_tab_widget/grouping_tab_widget.py
+++ b/scripts/Muon/GUI/Common/grouping_tab_widget/grouping_tab_widget.py
@@ -18,7 +18,7 @@ from Muon.GUI.Common.difference_table_widget.difference_widget_presenter import 
 
 
 class GroupingTabWidget(object):
-    def __init__(self, context, parent):
+    def __init__(self, context, parent=None):
 
         self.group_tab_model = GroupingTabModel(context)
 

--- a/scripts/Muon/GUI/Common/grouping_tab_widget/grouping_tab_widget.py
+++ b/scripts/Muon/GUI/Common/grouping_tab_widget/grouping_tab_widget.py
@@ -18,7 +18,7 @@ from Muon.GUI.Common.difference_table_widget.difference_widget_presenter import 
 
 
 class GroupingTabWidget(object):
-    def __init__(self, context):
+    def __init__(self, context, parent):
 
         self.group_tab_model = GroupingTabModel(context)
 
@@ -34,6 +34,6 @@ class GroupingTabWidget(object):
         self.group_tab_presenter = GroupingTabPresenter(self.group_tab_view,
                                                         self.group_tab_model,
                                                         self.grouping_table_widget,
-                                                        self.pairing_table_widget, self.diff_table)
+                                                        self.pairing_table_widget, self.diff_table, parent)
 
         context.update_view_from_model_notifier.add_subscriber(self.group_tab_presenter.update_view_from_model_observer)

--- a/scripts/Muon/GUI/Common/grouping_tab_widget/grouping_tab_widget_presenter.py
+++ b/scripts/Muon/GUI/Common/grouping_tab_widget/grouping_tab_widget_presenter.py
@@ -35,14 +35,15 @@ class GroupingTabPresenter(object):
     def __init__(self, view, model,
                  grouping_table_widget=None,
                  pairing_table_widget=None,
-                 diff_table=None):
+                 diff_table=None,
+                 parent=None):
         self._view = view
         self._model = model
 
         self.grouping_table_widget = grouping_table_widget
         self.pairing_table_widget = pairing_table_widget
         self.diff_table = diff_table
-        self.period_info_widget = MuonPeriodInfoWidget()
+        self.period_info_widget = MuonPeriodInfoWidget(parent=parent)
 
         self._view.set_description_text('')
         self._view.on_add_pair_requested(self.add_pair_from_grouping_table)

--- a/scripts/Muon/GUI/FrequencyDomainAnalysis/frequency_domain_analysis_2.py
+++ b/scripts/Muon/GUI/FrequencyDomainAnalysis/frequency_domain_analysis_2.py
@@ -113,7 +113,7 @@ class FrequencyAnalysisGui(QtWidgets.QMainWindow):
 
         # construct all the widgets.
         self.load_widget = LoadWidget(self.loaded_data, self.context, self)
-        self.grouping_tab_widget = GroupingTabWidget(self.context)
+        self.grouping_tab_widget = GroupingTabWidget(self.context, parent)
         self.home_tab = HomeTabWidget(self.context, self)
         self.phase_tab = PhaseTabWidget(self.context, self)
         self.transform = TransformWidget(

--- a/scripts/Muon/GUI/MuonAnalysis/muon_analysis_2.py
+++ b/scripts/Muon/GUI/MuonAnalysis/muon_analysis_2.py
@@ -113,7 +113,7 @@ class MuonAnalysisGui(QtWidgets.QMainWindow):
         # set up other widgets
         self.load_widget = LoadWidget(self.loaded_data, self.context, self)
         self.home_tab = HomeTabWidget(self.context, self)
-        self.grouping_tab_widget = GroupingTabWidget(self.context)
+        self.grouping_tab_widget = GroupingTabWidget(self.context, parent)
         self.phase_tab = PhaseTabWidget(self.context, self)
         self.seq_fitting_tab = SeqFittingTabWidget(self.context, self.fitting_tab.fitting_tab_model, self)
         self.results_tab = ResultsTabWidget(self.context.fitting_context, self.context, self)


### PR DESCRIPTION
**Description of work.**
Added a parent to the widget

**To test:**

1. Open Muon Analysis go to the grouping tab and click the periods button.
2. This will bring up a pop up which when you click on Muon analysis should fall behind but not behind the main workbench window
3. Check same is for Frequency Domain Analysis

Fixes #31208 

*This does not require release notes* because **this was added in this release**

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
