### PR TITLE
Changes to SliceViewer view to enable Cursor widget to size properly

### DIFF
--- a/qt/python/mantidqt/widgets/sliceviewer/view.py
+++ b/qt/python/mantidqt/widgets/sliceviewer/view.py
@@ -81,14 +81,9 @@ class SliceViewerDataView(QWidget):
         self.track_cursor.setToolTip(
             "Update the image readout table when the cursor is over the plot. "
             "If unticked the table will update only when the plot is clicked")
-        md_type = dims_info[0]['type'].startswith('MD')
-        if md_type:
-            self.colorbar_layout.addWidget(self.image_info_widget, alignment=Qt.AlignCenter)
-            self.colorbar_layout.addWidget(self.track_cursor)
-        else:
-            self.dimensions_layout.setHorizontalSpacing(10)
-            self.dimensions_layout.addWidget(self.track_cursor, 0, 1, Qt.AlignRight)
-            self.dimensions_layout.addWidget(self.image_info_widget, 1, 1)
+        self.dimensions_layout.setHorizontalSpacing(10)
+        self.dimensions_layout.addWidget(self.track_cursor, 0, 1, Qt.AlignRight)
+        self.dimensions_layout.addWidget(self.image_info_widget, 1, 1)
         self.track_cursor.setChecked(True)
         self.track_cursor.stateChanged.connect(self.on_track_cursor_state_change)
 
@@ -118,8 +113,7 @@ class SliceViewerDataView(QWidget):
         self.colorbar.colorbarChanged.connect(self.update_data_clim)
         self.colorbar.scaleNormChanged.connect(self.scale_norm_changed)
         # make width larger to fit image readout table
-        if md_type:
-            self.colorbar.setMaximumWidth(155)
+        self.colorbar.setMaximumWidth(200)
 
         # MPL toolbar
         self.toolbar_layout = QHBoxLayout()


### PR DESCRIPTION
**Description of work.**
Removal of special view for MD workspaces and resizing of colorbar column so that SliceViewer can be used on different operating systems, regardless of display setup.

**To test:**
Test 1 (2D workspace)
Run this script to create an 2D MD workspace
```
ws=CreateMDHistoWorkspace(Dimensionality=2,Extents='-3,3,-10,10', \
SignalInput=range(0,100),ErrorInput=range(0,100),\
NumberOfBins='10,10',Names='Dim1,Dim2',Units='MomentumTransfer,EnergyTransfer') 
```
Right-click on the workspace and show sliceviewer. Check if the cursor widget (x, y, signal table on right hand side) is sized correctly when you hover the cursor over the image.

Test 2 (4D workspace)
Run this script to create an 4D MD workspace
```
mdWS = CreateMDWorkspace(Dimensions=4, Extents=[-1,1,-1,1,-1,1,-10,10], Names="H,K,L,E", Units="U,U,U,V")
```
Right-click on the workspace and show sliceviewer. Check if the cursor widget (x, y, signal table on right hand side) is sized correctly when you hover the cursor over the image. Also check that the automatic resizing of the cursor widget does not make the slider widgets too small.

Test 3 (Overlaying peaks)
1) Run this script
```
# SXD23767.raw is available in the TrainingCourseData from the downloads page
SXD23767 = Load(Filename='SXD23767.raw', LoadMonitors='Exclude')
# Set some UB with angles we can play with
SetUB(SXD23767, 1,1,2,90,90,120)
md_non_ortho = ConvertToDiffractionMDWorkspace(InputWorkspace='SXD23767', OutputDimensions='HKL')
```

2) Create a Peaks workspace by doing the following

- Open instrument viewer by right-clicking on the workspace``SXD23767``.
- On the Pick tab, select the PickTabAddPeakButton.png “Add a single crystal peak” button.
- Click on an intense bragg peak on the detectors, and then click on one or many of the intense peaks in the produced mini-plot.
- Repeat for a few different bragg peaks across the detectors.
- Notice that this has produced a SingleCrystalPeakTable.
- Rename the above workspace to peaks and in instrument viewer, select more peaks for a second peaksworkspace.

3) Create an integrated peaks workspace using the following script
```
peaks = mtd['peaks']
integrated_peaks = IntegratePeaksMD(InputWorkspace='md_non_ortho', PeaksWorkspace='peaks',\
     PeakRadius=0.12, BackgroundOuterRadius=0.2, BackgroundInnerRadius=0.16)
```

4) Right click on the md_non_ortho workspace and show sliceviewer. 
5) Click on the 'Add peaks overlay' button and select one or more peak workspaces to open
6) This will open one or more peak overlay tables to the right of the screen. Resize these and check that it does not obscure the cursor widget box (x, y, signal table on right hand side).


This needs to be tested on
- ~~Windows~~ (~~2k~~✔ and ~~4K~~ ✔ displays)
- ~~Mac~~ ✔
- ~~Ubuntu~~ ✔
- CentOS Linux
- Redhat Enterprise Linux

Please specify with OS and display settings used when testing.


Fixes #31214
Also fixes some of the view issues reported in #31276

*This does not require release notes* because it fixes a display issue.



---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
