### PR TITLE
Catch Error When Plotting 3D Contour On Data Of Incorrect Size

### DIFF
--- a/docs/source/release/v6.1.0/mantidworkbench.rst
+++ b/docs/source/release/v6.1.0/mantidworkbench.rst
@@ -48,6 +48,7 @@ Bugfixes
 - Fixed a bug applying constraints with the conjugate gradient minimizer.
 - Fixed a bug where panning on a colour fill plot stretches dataset along spectrum axis instead of panning
 - Fixed a bug where TableWorkspace column names would not update correctly if the table was open.
+- Fixed a bug where plotting a 3D Contour plot would produce the error reporter in some cases.
 - Fixed a problem with scripts generated from tiled plots.
 
 Interfaces

--- a/qt/python/mantidqt/plotting/functions.py
+++ b/qt/python/mantidqt/plotting/functions.py
@@ -349,10 +349,12 @@ def plot_contour(workspaces, fig=None):
     for ws in workspaces:
         fig = pcolormesh(workspaces, fig)
         ax = fig.get_axes()[0]
-
-        ax.contour(ws, levels=DEFAULT_CONTOUR_LEVELS,
-                   colors=DEFAULT_CONTOUR_COLOUR,
-                   linewidths=DEFAULT_CONTOUR_WIDTH)
+        try:
+            ax.contour(ws, levels=DEFAULT_CONTOUR_LEVELS,
+                       colors=DEFAULT_CONTOUR_COLOUR,
+                       linewidths=DEFAULT_CONTOUR_WIDTH)
+        except TypeError as type_error:
+            LOGGER.warning(str(type_error))
 
         fig.show()
 


### PR DESCRIPTION
**Description of work.**
Added try catch when doing a contour plot. Send me a message for the data file to be used for testing.

**To test:**
Load the file
Try to do a contour plot
Previously error reporter would show, now a warning message should be seen

Fixes #31256 

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
