### PR TITLE
Fix ConfigService crash when using an invalid instrumentDefinition.directory

### DIFF
--- a/Framework/Kernel/src/ConfigService.cpp
+++ b/Framework/Kernel/src/ConfigService.cpp
@@ -1575,7 +1575,7 @@ const std::vector<std::string> ConfigServiceImpl::getFacilityFilenames(const std
   // update the iterator, this means we will skip the folder in HOME and
   // look in the instrument folder in mantid install directory or mantid source
   // code directory
-  if (!(updateInstrStr == "1" || updateInstrStr == "on" || updateInstrStr == "On")) {
+  if (!(updateInstrStr == "1" || updateInstrStr == "on" || updateInstrStr == "On") && directoryNames.size() > 1) {
     instrDir++;
   }
 


### PR DESCRIPTION
**Description of work.**
This PR fixes a crash caused by an invalid instrument directory when the ConfigService singleton is created. If this directory is invalid, the `%appdata%` instrument directory is the only remaining directory we can use, and so the `instDir` iterator should not be incremented in this case.

It is difficult to add a test to cover this bug as the bug would only occur when the ConfigService singleton is constructed (i.e. this happens only once). The offending line would need to be in a Mantid.user.properties file when this singleton is instantiated.

**To test:**
1. Add `instrumentDefinition.directory=./instrument` to the Mantid.user.properties file in `build/bin` directory
2. Open workbench, there should be no crash

Fixes #30622

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
