### PR TITLE
Make Sliceviewer Line Plots Respect Track Cursor State

### DIFF
--- a/docs/source/release/v6.1.0/framework.rst
+++ b/docs/source/release/v6.1.0/framework.rst
@@ -66,6 +66,8 @@ SliceViewer
 Improvements
 ############
 
+- The line plots now respect the status of the Track Cursor checkbox.
+
 Bugfixes
 ########
 

--- a/docs/source/release/v6.1.0/framework.rst
+++ b/docs/source/release/v6.1.0/framework.rst
@@ -66,7 +66,7 @@ SliceViewer
 Improvements
 ############
 
-- The line plots now respect the status of the Track Cursor checkbox.
+- Line plots now respect the status of the Track Cursor checkbox.
 
 Bugfixes
 ########

--- a/qt/python/mantidqt/widgets/sliceviewer/lineplots.py
+++ b/qt/python/mantidqt/widgets/sliceviewer/lineplots.py
@@ -265,7 +265,7 @@ class PixelLinePlot(CursorTracker, KeyHandler):
         """
         See RegionExtractionTool for parameter descriptions
         """
-        CursorTracker.__init__(self, image_axes=plotter.image_axes)
+        CursorTracker.__init__(self, image_axes=plotter.image_axes, autoconnect=False)
         KeyHandler.__init__(self, plotter, exporter)
 
         # cache most current cursor position

--- a/qt/python/mantidqt/widgets/sliceviewer/presenter.py
+++ b/qt/python/mantidqt/widgets/sliceviewer/presenter.py
@@ -235,6 +235,8 @@ class SliceViewer(ObservingPresenter):
         data_view = self.view.data_view
         if state:
             data_view.add_line_plots(tool, self)
+            if data_view.track_cursor_checked():
+                data_view._line_plots.connect()
         else:
             data_view.deactivate_tool(ToolItemText.REGIONSELECTION)
             data_view.remove_line_plots()

--- a/qt/python/mantidqt/widgets/sliceviewer/view.py
+++ b/qt/python/mantidqt/widgets/sliceviewer/view.py
@@ -64,6 +64,7 @@ class SliceViewerDataView(QWidget):
 
         self._line_plots = None
         self._image_info_tracker = None
+        self._region_selection_on = False
 
         # Dimension widget
         self.dimensions_layout = QGridLayout()
@@ -256,7 +257,7 @@ class SliceViewerDataView(QWidget):
                                     transpose=self.dimensions.transpose,
                                     norm=self.colorbar.get_norm(),
                                     **kwargs)
-        self.on_track_cursor_state_change(self.track_cursor.isChecked())
+        self.on_track_cursor_state_change(self.track_cursor_checked())
 
         # ensure the axes data limits are updated to match the
         # image. For example if the axes were zoomed and the
@@ -276,7 +277,7 @@ class SliceViewerDataView(QWidget):
                                               transpose=self.dimensions.transpose,
                                               norm=self.colorbar.get_norm(),
                                               **kwargs)
-        self.on_track_cursor_state_change(self.track_cursor.isChecked())
+        self.on_track_cursor_state_change(self.track_cursor_checked())
 
         # swapping dimensions in nonorthogonal mode currently resets back to the
         # full data limits as the whole axes has been recreated so we don't have
@@ -309,7 +310,7 @@ class SliceViewerDataView(QWidget):
                                     norm=self.colorbar.get_norm(),
                                     extent=old_extent,
                                     **kwargs)
-        self.on_track_cursor_state_change(self.track_cursor.isChecked())
+        self.on_track_cursor_state_change(self.track_cursor_checked())
 
         self.draw_plot()
 
@@ -372,12 +373,17 @@ class SliceViewerDataView(QWidget):
                 self.ax.set_ylim((extent[2], extent[3]))
         self.colorbar.update_clim()
 
+    def track_cursor_checked(self):
+        return self.track_cursor.isChecked() if self.track_cursor else False
+
     def on_track_cursor_state_change(self, state):
         """
         Called to notify the current state of the track cursor box
         """
         if self._image_info_tracker is not None:
             self._image_info_tracker.disconnect()
+        if self._line_plots is not None and not self._region_selection_on:
+            self._line_plots.disconnect()
 
         self._image_info_tracker = ImageInfoTracker(image=self.image,
                                                     transpose_xy=self.dimensions.transpose,
@@ -385,8 +391,12 @@ class SliceViewerDataView(QWidget):
 
         if state:
             self._image_info_tracker.connect()
+            if self._line_plots and not self._region_selection_on:
+                self._line_plots.connect()
         else:
             self._image_info_tracker.disconnect()
+            if self._line_plots and not self._region_selection_on:
+                self._line_plots.disconnect()
 
     def on_home_clicked(self):
         """Reset the view to encompass all of the data"""
@@ -399,6 +409,11 @@ class SliceViewerDataView(QWidget):
     def on_region_selection_toggle(self, state):
         """Switch state of the region selection"""
         self.presenter.region_selection(state)
+        self._region_selection_on = state
+        # If state is off and track cursor is on, make sure line plots are re-connected to move cursor
+        if not state and self.track_cursor_checked():
+            if self._line_plots:
+                self._line_plots.connect()
 
     def on_non_orthogonal_axes_toggle(self, state):
         """
@@ -501,6 +516,8 @@ class SliceViewerDataView(QWidget):
         self.canvas.setFocus()
         if event.button == 1:
             self._image_info_tracker.on_cursor_at(event.xdata, event.ydata)
+            if self.line_plots_active and not self._region_selection_on:
+                self._line_plots.on_cursor_at(event.xdata, event.ydata)
         if event.button == 3:
             self.on_home_clicked()
 


### PR DESCRIPTION
**Description of work.**
Instead of auto connecting line plots to track cursor, now follows the state of the track cursor checkbox

**To test:**
Load in some data for the slice viewer
Open the slice viewer
Turn on line plots
If track cursor is on then the line plots should update when the cursor is moved
If track cursor is off then the line plots should only update when the mouse is clicked on the plot
Also try using region select as this caused a few problems with the connecting and deconnecting to the cursor

Fixes #31355 

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
