### PR TITLE
Remove validation on sample angle in PaalmanPingsMonteCarloAbsorption

### DIFF
--- a/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/PaalmanPingsMonteCarloAbsorption.py
+++ b/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/PaalmanPingsMonteCarloAbsorption.py
@@ -152,7 +152,7 @@ class PaalmanPingsMonteCarloAbsorption(DataProcessorAlgorithm):
         self.declareProperty(name='SampleCenter', defaultValue=0.0,
                              doc='Center of the sample environment')
         self.declareProperty(name='SampleAngle', defaultValue=0.0,
-                             validator=FloatBoundedValidator(0.0),
+                             validator=FloatBoundedValidator(-180.0, 180.0),
                              doc='Angle of the sample environment with respect to the beam (degrees)')
 
         self.setPropertySettings('SampleWidth', flat_plate_visible)

--- a/Framework/PythonInterface/test/python/plugins/algorithms/WorkflowAlgorithms/PaalmanPingsMonteCarloAbsorptionTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/WorkflowAlgorithms/PaalmanPingsMonteCarloAbsorptionTest.py
@@ -62,6 +62,8 @@ class PaalmanPingsMonteCarloAbsorptionTest(unittest.TestCase):
     def _flat_plate_test(self, test_func):
         self._test_arguments['SampleWidth'] = 2.0
         self._test_arguments['SampleThickness'] = 2.0
+        self._test_arguments['SampleCenter'] = 1.0
+        self._test_arguments['SampleAngle'] = -10.0
         test_func('FlatPlate')
 
     def _cylinder_test(self, test_func):

--- a/docs/source/release/v6.1.0/framework.rst
+++ b/docs/source/release/v6.1.0/framework.rst
@@ -31,6 +31,7 @@ Algorithms
 Improvements
 ------------
 - Loading a CORELLI tube calibration returns a ``MaskWorkspace``.
+- The algorithm :ref:`PaalmanPingsMonteCarloAbsorption <algm-PaalmanPingsMonteCarloAbsorption>` now accepts a negative angle for the SampleAngle parameter of the FlatPlate shape
 
 Data Objects
 ------------


### PR DESCRIPTION
**Description of work.**

Previously, when the PaalmanPingsMonteCarloAbsorption algorithm was run with Shape=FlatPlate, it only accepted angles that were >=0. This has been changed to accept negative angles now

**To test:**

Run this script (which is a slight modification of one of the doc test examples for the algorithm) and check it runs OK:
```
sample_ws = CreateSampleWorkspace(Function="Quasielastic",
                                  XUnit="Wavelength",
                                  XMin=-0.5,
                                  XMax=0.5,
                                  BinWidth=0.01)
# Efixed is generally defined as part of the IDF for real data.
# Fake it here
inst_name = sample_ws.getInstrument().getName()
SetInstrumentParameter(sample_ws, ComponentName=inst_name,
    ParameterName='Efixed', ParameterType='Number', Value='4.1')

corrections = PaalmanPingsMonteCarloAbsorption(
        InputWorkspace=sample_ws,
        Shape='FlatPlate',
        BeamHeight=2.0,
        BeamWidth=2.0,
        Height=2.0,
        SampleWidth=2.0,
        SampleThickness=0.1,
        SampleAngle=-10.0,
        SampleChemicalFormula='H2-O',
        SampleDensity=1.0,
        ContainerFrontThickness=0.02,
        ContainerBackThickness=0.02,
        ContainerChemicalFormula='V',
        ContainerDensity=6.0,
        CorrectionsWorkspace='flat_plate_corr'
    )
```

Fixes #30699.

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
