### PR TITLE
Support project save/load with colorfill plots with LogNorm

### DIFF
--- a/docs/source/release/v6.1.0/mantidworkbench.rst
+++ b/docs/source/release/v6.1.0/mantidworkbench.rst
@@ -82,6 +82,7 @@ Plotting
 - Fixed a bug where plotting a 3D Contour plot would produce the error reporter in some cases.
 - Fixed a problem with scripts generated from tiled plots.
 - Restrict scroll wheel zooming out to +/-10^300 to avoid crash.
+- Fixed a bug where colorfill plots with a Log scale could not be saved during project save.
 
 
 :ref:`Release 6.1.0 <v6.1.0>`

--- a/qt/python/mantidqt/plotting/functions.py
+++ b/qt/python/mantidqt/plotting/functions.py
@@ -207,7 +207,7 @@ def use_imshow(ws):
 
 
 @manage_workspace_names
-def pcolormesh(workspaces, fig=None, normalize_by_bin_width=None):
+def pcolormesh(workspaces, fig=None, norm=None, normalize_by_bin_width=None):
     """
     Create a figure containing pcolor subplots
 
@@ -232,7 +232,7 @@ def pcolormesh(workspaces, fig=None, normalize_by_bin_width=None):
         ax = axes[row_idx][col_idx]
         if subplot_idx < workspaces_len:
             ws = workspaces[subplot_idx]
-            pcm = pcolormesh_on_axis(ax, ws, normalize_by_bin_width)
+            pcm = pcolormesh_on_axis(ax, ws, norm, normalize_by_bin_width)
             plots.append(pcm)
             if col_idx < ncols - 1:
                 col_idx += 1
@@ -271,25 +271,27 @@ def pcolormesh(workspaces, fig=None, normalize_by_bin_width=None):
     return fig
 
 
-def pcolormesh_on_axis(ax, ws, normalize_by_bin_width=None):
+def pcolormesh_on_axis(ax, ws, norm=None, normalize_by_bin_width=None):
     """
     Plot a pcolormesh plot of the given workspace on the given axis
     :param ax: A matplotlib axes instance
     :param ws: A mantid workspace instance
+    :param norm: A matplotlib.colours Normalize instance (or any of its subclasses)
     :param normalize_by_bin_width: Optional keyword argument to pass to imshow in the event of a plot restoration
     :return:
     """
     ax.clear()
     ax.set_title(ws.name())
-    scale = _get_colorbar_scale()
+    scale = _get_colorbar_scale() if not norm else norm
+
     if use_imshow(ws):
         pcm = ax.imshow(ws, cmap=ConfigService.getString("plots.images.Colormap"), aspect='auto', origin='lower',
-                        norm=scale(), normalize_by_bin_width=normalize_by_bin_width)
+                        norm=scale, normalize_by_bin_width=normalize_by_bin_width)
         # remove normalize_by_bin_width from cargs if present so that this can be toggled in future
         for cargs in pcm.axes.creation_args:
             cargs.pop('normalize_by_bin_width')
     else:
-        pcm = ax.pcolormesh(ws, cmap=ConfigService.getString("plots.images.Colormap"), norm=scale())
+        pcm = ax.pcolormesh(ws, cmap=ConfigService.getString("plots.images.Colormap"), norm=scale)
 
     return pcm
 
@@ -303,9 +305,9 @@ def _get_colorbar_scale():
     """Get the scale type (Linear, Log) for the colorbar in image type plots"""
     scale = ConfigService.getString("plots.images.ColorBarScale")
     if scale == "Log":
-        return matplotlib.colors.LogNorm
+        return matplotlib.colors.LogNorm()
     else:
-        return matplotlib.colors.Normalize
+        return matplotlib.colors.Normalize()
 
 
 @manage_workspace_names

--- a/qt/python/mantidqt/plotting/functions.py
+++ b/qt/python/mantidqt/plotting/functions.py
@@ -207,7 +207,7 @@ def use_imshow(ws):
 
 
 @manage_workspace_names
-def pcolormesh(workspaces, fig=None, norm=None, normalize_by_bin_width=None):
+def pcolormesh(workspaces, fig=None, color_norm=None, normalize_by_bin_width=None):
     """
     Create a figure containing pcolor subplots
 
@@ -232,7 +232,7 @@ def pcolormesh(workspaces, fig=None, norm=None, normalize_by_bin_width=None):
         ax = axes[row_idx][col_idx]
         if subplot_idx < workspaces_len:
             ws = workspaces[subplot_idx]
-            pcm = pcolormesh_on_axis(ax, ws, norm, normalize_by_bin_width)
+            pcm = pcolormesh_on_axis(ax, ws, color_norm, normalize_by_bin_width)
             plots.append(pcm)
             if col_idx < ncols - 1:
                 col_idx += 1
@@ -271,18 +271,18 @@ def pcolormesh(workspaces, fig=None, norm=None, normalize_by_bin_width=None):
     return fig
 
 
-def pcolormesh_on_axis(ax, ws, norm=None, normalize_by_bin_width=None):
+def pcolormesh_on_axis(ax, ws, color_norm=None, normalize_by_bin_width=None):
     """
     Plot a pcolormesh plot of the given workspace on the given axis
     :param ax: A matplotlib axes instance
     :param ws: A mantid workspace instance
-    :param norm: A matplotlib.colours Normalize instance (or any of its subclasses)
+    :param color_norm: A matplotlib.colours Normalize instance (or any of its subclasses)
     :param normalize_by_bin_width: Optional keyword argument to pass to imshow in the event of a plot restoration
     :return:
     """
     ax.clear()
     ax.set_title(ws.name())
-    scale = _get_colorbar_scale() if not norm else norm
+    scale = _get_colorbar_scale() if not color_norm else color_norm
 
     if use_imshow(ws):
         pcm = ax.imshow(ws, cmap=ConfigService.getString("plots.images.Colormap"), aspect='auto', origin='lower',

--- a/qt/python/mantidqt/project/plotsloader.py
+++ b/qt/python/mantidqt/project/plotsloader.py
@@ -136,7 +136,7 @@ class PlotsLoader(object):
         func = function_dict[function_to_call]
         # Plotting is done via an Axes object unless a colorbar needs to be added
         if function_to_call in ["imshow", "pcolormesh"]:
-            func([workspace], fig, norm=creation_arg['norm'], normalize_by_bin_width=creation_arg['normalize_by_bin_width'])
+            func([workspace], fig, color_norm=creation_arg['norm'], normalize_by_bin_width=creation_arg['normalize_by_bin_width'])
             self.color_bar_remade = True
         else:
             func(workspace, **creation_arg)

--- a/qt/python/mantidqt/project/plotsloader.py
+++ b/qt/python/mantidqt/project/plotsloader.py
@@ -41,8 +41,21 @@ class PlotsLoader(object):
                 logger.warning("A plot was unable to be loaded from the save file. Error: " + str(e))
 
     def restore_normalise_obj_from_dict(self, norm_dict):
-        norm = matplotlib.colors.Normalize(norm_dict['vmin'], norm_dict['vmax'], norm_dict['clip'])
-        return norm
+        supported_norm_types = {
+            # matplotlib norms that are supported.
+            'Normalize': matplotlib.colors.Normalize,
+            'LogNorm': matplotlib.colors.LogNorm,
+        }
+        # If there is a norm dict, but the type is not specified, default to base Normalize class.
+        type = norm_dict['type'] if 'type' in norm_dict.keys() else 'Normalize'
+
+        if type not in supported_norm_types.keys():
+            logger.debug(
+                f"Color normalisation of type {norm_dict['type']} is not supported. Normalisation will not be set on this plot")
+            return None
+
+        norm = supported_norm_types[type]
+        return norm(vmin=norm_dict['vmin'], vmax=norm_dict['vmax'], clip=norm_dict['clip'])
 
     def make_fig(self, plot_dict, create_plot=True):
         """
@@ -123,7 +136,7 @@ class PlotsLoader(object):
         func = function_dict[function_to_call]
         # Plotting is done via an Axes object unless a colorbar needs to be added
         if function_to_call in ["imshow", "pcolormesh"]:
-            func([workspace], fig, normalize_by_bin_width=creation_arg['normalize_by_bin_width'])
+            func([workspace], fig, norm=creation_arg['norm'], normalize_by_bin_width=creation_arg['normalize_by_bin_width'])
             self.color_bar_remade = True
         else:
             func(workspace, **creation_arg)

--- a/qt/python/mantidqt/project/plotssaver.py
+++ b/qt/python/mantidqt/project/plotssaver.py
@@ -45,7 +45,7 @@ class PlotsSaver(object):
 
     @staticmethod
     def _convert_normalise_obj_to_dict(norm):
-        norm_dict = {'clip': norm.clip, 'vmin': norm.vmin, 'vmax': norm.vmax}
+        norm_dict = {'type': type(norm).__name__, 'clip': norm.clip, 'vmin': norm.vmin, 'vmax': norm.vmax}
         return norm_dict
 
     @staticmethod
@@ -62,7 +62,7 @@ class PlotsSaver(object):
                 creation_args = deepcopy(ax.creation_args)
                 # convert the normalise object (if present) into a dict so that it can be json serialised
                 for args_dict in creation_args:
-                    if 'norm' in args_dict.keys() and type(args_dict['norm']) is Normalize:
+                    if 'norm' in args_dict.keys() and isinstance(args_dict['norm'], Normalize):
                         norm_dict = self._convert_normalise_obj_to_dict(args_dict['norm'])
                         args_dict['norm'] = norm_dict
                 create_list.append(creation_args)

--- a/qt/python/mantidqt/project/test/test_plotsloader.py
+++ b/qt/python/mantidqt/project/test/test_plotsloader.py
@@ -153,3 +153,28 @@ class PlotsLoaderTest(unittest.TestCase):
     def test_load_plot_from_dict(self, pass_func):
         # The fact this runs is the test
         self.plots_loader.load_plots([self.dictionary])
+
+    @mock.patch("matplotlib.colors.LogNorm", autospec=True)
+    def test_restore_normalise_obj_from_dict_creates_correct_norm_instance_from_supported_norm(self, mock_LogNorm):
+        norm_dict = {'type': 'LogNorm', 'vmin': 1, 'vmax': 2, 'clip': True}
+
+        _ = self.plots_loader.restore_normalise_obj_from_dict(norm_dict)
+
+        mock_LogNorm.assert_called_once_with(norm_dict['vmin'], norm_dict['vmax'], norm_dict['clip'])
+
+    def test_restore_normalise_obj_from_dict_returns_none_with_unsupported_norm(self):
+        norm_dict = {'type': 'unsupported_norm', 'vmin': 1, 'vmax': 2, 'clip': True}
+
+        return_value = self.plots_loader.restore_normalise_obj_from_dict(norm_dict)
+
+        self.assertIsNone(return_value)
+
+    @mock.patch("matplotlib.colors.Normalize", autospec=True)
+    def test_restore_normalise_obj_from_dict_returns_Normalize_type_with_unspecified_norm(self, mock_Normalize):
+        """If the type of the norm is unspecified, the method should return a Normalize object,
+        which is the most general norm and is subclassed by LogNorm, etc."""
+        norm_dict = {'vmin': 1, 'vmax': 2, 'clip': True}
+
+        _ = self.plots_loader.restore_normalise_obj_from_dict(norm_dict)
+
+        mock_Normalize.assert_called_once_with(norm_dict['vmin'], norm_dict['vmax'], norm_dict['clip'])

--- a/qt/python/mantidqt/project/test/test_plotssaver.py
+++ b/qt/python/mantidqt/project/test/test_plotssaver.py
@@ -13,6 +13,7 @@ from mantid.api import AnalysisDataService as ADS
 from mantid.simpleapi import CreateSampleWorkspace
 from mantidqt.project.plotsloader import PlotsLoader
 from mantidqt.project.plotssaver import PlotsSaver
+from matplotlib.colors import LogNorm
 
 matplotlib.use('AGG')
 
@@ -205,6 +206,17 @@ class PlotsSaverTest(unittest.TestCase):
         expected_value = {u'dpi': 100.0, u'figHeight': 4.8, u'figWidth': 6.4}
 
         self.assertDictEqual(return_value, expected_value)
+
+    def test_get_dict_from_fig_with_LogNorm(self):
+        self.fig.axes[0].creation_args = [{u"specNum": None, "function": "pcolormesh",
+                                                         "norm": LogNorm()}]
+        return_value = self.plot_saver.get_dict_from_fig(self.fig)
+        expected_creation_args = [[{'specNum': None, 'function': 'pcolormesh', 'norm':
+                                    {'type': 'LogNorm', 'clip': False, 'vmin': None, 'vmax': None}, 'normalize_by_bin_width': True}]]
+
+        self.loader_plot_dict[u'creationArguments'] = expected_creation_args
+
+        self.assertDictEqual(return_value, self.loader_plot_dict)
 
 
 if __name__ == "__main__":

--- a/qt/python/mantidqt/project/test/test_plotssaver.py
+++ b/qt/python/mantidqt/project/test/test_plotssaver.py
@@ -13,7 +13,7 @@ from mantid.api import AnalysisDataService as ADS
 from mantid.simpleapi import CreateSampleWorkspace
 from mantidqt.project.plotsloader import PlotsLoader
 from mantidqt.project.plotssaver import PlotsSaver
-from matplotlib.colors import LogNorm
+from matplotlib.colors import Normalize, LogNorm
 
 matplotlib.use('AGG')
 
@@ -206,6 +206,17 @@ class PlotsSaverTest(unittest.TestCase):
         expected_value = {u'dpi': 100.0, u'figHeight': 4.8, u'figWidth': 6.4}
 
         self.assertDictEqual(return_value, expected_value)
+
+    def test_get_dict_from_fig_with_Normalize(self):
+        self.fig.axes[0].creation_args = [{u"specNum": None, "function": "pcolormesh",
+                                                         "norm": Normalize()}]
+        return_value = self.plot_saver.get_dict_from_fig(self.fig)
+        expected_creation_args = [[{'specNum': None, 'function': 'pcolormesh', 'norm':
+                                    {'type': 'Normalize', 'clip': False, 'vmin': None, 'vmax': None}, 'normalize_by_bin_width': True}]]
+
+        self.loader_plot_dict[u'creationArguments'] = expected_creation_args
+
+        self.assertDictEqual(return_value, self.loader_plot_dict)
 
     def test_get_dict_from_fig_with_LogNorm(self):
         self.fig.axes[0].creation_args = [{u"specNum": None, "function": "pcolormesh",


### PR DESCRIPTION
#30350 implemented project save support for colorfill plots with `matplotlib.colors.Normalize` normalisation. However, if the user has the colorfill scale set to logarithmic, the normalisation becomes a `matplotlib.colors.LogNorm`, which is a subclass of `Normalize`.

This PR adds support for saving and loading colorfill plots with `LogNorm`. This fixes the immediate issue but is scope in the future to support [other normalisations](https://github.com/matplotlib/matplotlib/blob/ad0c1e14a2eb621d986e92cea934fea5390b0d41/lib/matplotlib/colors.py#L1601). As far as I'm aware, the only time this would cause an error is if a user called `pcolormesh` or `imshow` themselves with a different normalisation, [as our code only calls `LogNorm` and `Normalize`](https://github.com/mantidproject/mantid/blob/7acaa520018dcfe8fba3dfdc8f3db2cd88463a10/qt/python/mantidqt/plotting/functions.py#L302)

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

**To test:**
1. Load some data e.g. `ws = CreateSampleWorkspace(function='Exp Decay')`
2. Open a colorfill plot.
3. Change the colorfill scale in `File > Settings > Plots`
4. Open another colorfill plot, the scale should be different.
5. Save the project and close the plots
6. Open the project
7. The plots should be identical to when you saved them

Fixes #31338

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
