### PR TITLE
Muon Analysis Fix Fit Line Being Same Color As Data Line

### DIFF
--- a/docs/source/release/v6.1.0/muon.rst
+++ b/docs/source/release/v6.1.0/muon.rst
@@ -25,6 +25,8 @@ Bug fixes
 - Fixed a bug where removing a pair in use would cause a crash.
 - Fixed a bug where an error message would appear in workbench after loading a run in both MA and FDA.
 - Fixed a bug where rows in the difference table were not being highlighted correctly.
+- Fixed a bug where the color of the fitted line would sometimes match the color of the raw data line, making it
+  difficult to see.
 - Fixed a bug in the Grouping tab where an error message would appear when changing the source of
   Group Asymmetry Range with no data loaded.
 


### PR DESCRIPTION
**Description of work.**
Added a check before adding colors back to the color queue when lines are removed

**To test:**
Open Muon Analysis
You need to load data so that there are more than 10 plots (10 is the current number of colors)
An example is EMU20883-20893 or MUSR62260-62262
You should see that the colors are repeated for some lines 
Go to the fitting tab
Do a fit
The fit line should not be the same color as the raw data line
Check stepping through workspaces on the fitting tab keeps the raw data line as blue and the fit line orange
On the grouping tab, try adding and removing plots and see that everything is as you would expect

Fixes #30526 

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
