### PR TITLE
Stop the peaks viewer overwriting all tables with last loaded

### DIFF
--- a/qt/python/mantidqt/widgets/workspacedisplay/table/view.py
+++ b/qt/python/mantidqt/widgets/workspacedisplay/table/view.py
@@ -35,9 +35,9 @@ class PreciseDoubleFactory(QItemEditorFactory):
 class TableWorkspaceDisplayView(QTableView):
     repaint_signal = Signal()
 
-    def __init__(self, presenter=None, parent=None, window_flags=Qt.Window, table_model=QStandardItemModel()):
+    def __init__(self, presenter=None, parent=None, window_flags=Qt.Window, table_model=None):
         super().__init__(parent)
-        self.table_model = table_model
+        self.table_model = table_model if table_model else QStandardItemModel(parent)
         self.setModel(self.table_model)
 
         self.presenter = presenter


### PR DESCRIPTION
**Description of work.**

When multiple peak tables were overlaid in the sliceviewer, the tables would be overwritten with the last table loaded, this was because the constructor of the table view would use the same model for all views if none was explicitly provided.
This bug was introduced in #30791 - thanks @StephenSmith25 who found this fix.

To-Do
- Will add release notes when PRs #31388 and #31391 are merged

**To test:**

(1) Run this script

```
ws = CreateMDWorkspace(Dimensions='3', Extents='-5,5,-5,5,-5,5',
                       Names='Q_lab_x,Q_lab_y,Q_lab_z', Units='U,U,U',
                       Frames='QLab,QLab,QLab',
                       SplitInto='2', SplitThreshold='50')
expt_info = CreateSampleWorkspace()
ws.addExperimentInfo(expt_info)
# add peak
p = CreatePeaksWorkspace(InstrumentWorkspace='ws', NumberOfPeaks=0, OutputWorkspace='peaks')
pk = p.createPeak([1,1,1]) # axes aligned with viewing axes
p.addPeak(pk)
CloneWorkspace(InputWorkspace=p, OutputWorkspace='peaks2')
# delete peak
DeleteTableRows(TableWorkspace='peaks', Rows='0')
```

(2) Open ws in the sliceviewer and overlay both peaks tables - one will be empty, the other will have a single peak.
(3) Follow instructions in #30791 and check that (normal table viewing) still works.

Fixes #31358 


<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or master)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
