### PR TITLE
Restrict scroll wheel zooming

### DIFF
--- a/Framework/PythonInterface/mantid/plots/utility.py
+++ b/Framework/PythonInterface/mantid/plots/utility.py
@@ -180,11 +180,13 @@ def zoom_axis(ax, coord, x_or_y, factor):
     new_ax_min = coord - dist_to_min/factor
     new_ax_max = coord + dist_to_max/factor
 
-    # Don't allow further zooming out if we're beyond the limit.
-    if abs(new_ax_max) > ZOOM_LIMIT and new_ax_max > ax_max:
+    # Don't allow further zooming out if we're beyond the limit. Zooming in is allowed.
+    # The abs in the second half of the conditional statements accounts for the case when the min and max axis limits
+    # are flipped, which is possible in matplotlib.
+    if abs(new_ax_max) > ZOOM_LIMIT and abs(new_ax_max) > abs(ax_max):
         new_ax_max = ax_max
 
-    if abs(new_ax_min) > ZOOM_LIMIT and new_ax_min < ax_min:
+    if abs(new_ax_min) > ZOOM_LIMIT and abs(new_ax_min) > abs(ax_min):
         new_ax_min = ax_min
 
     set_lims((new_ax_min, new_ax_max))
@@ -222,6 +224,7 @@ def get_single_workspace_log_value(ws_index, *, log_values=None, matrix_ws=None,
             return 0
 
         return log_values[ws_index]
+
 
 def colormap_as_plot_color(number_colors: int, colormap_name: str = 'viridis', cmap=None):
     if not cmap:

--- a/Framework/PythonInterface/mantid/plots/utility.py
+++ b/Framework/PythonInterface/mantid/plots/utility.py
@@ -180,13 +180,15 @@ def zoom_axis(ax, coord, x_or_y, factor):
     new_ax_min = coord - dist_to_min/factor
     new_ax_max = coord + dist_to_max/factor
 
-    if abs(new_ax_max) > ZOOM_LIMIT:
+    # Don't allow further zooming out if we're beyond the limit.
+    if abs(new_ax_max) > ZOOM_LIMIT and new_ax_max > ax_max:
         new_ax_max = ax_max
 
-    if abs(new_ax_min) > ZOOM_LIMIT:
+    if abs(new_ax_min) > ZOOM_LIMIT and new_ax_min < ax_min:
         new_ax_min = ax_min
 
     set_lims((new_ax_min, new_ax_max))
+
     return new_ax_min, new_ax_max
 
 

--- a/Framework/PythonInterface/mantid/plots/utility.py
+++ b/Framework/PythonInterface/mantid/plots/utility.py
@@ -24,6 +24,8 @@ from matplotlib.container import ErrorbarContainer
 MPLVersionInfo = collections.namedtuple("MPLVersionInfo", ("major", "minor", "patch"))
 MATPLOTLIB_VERSION_INFO = MPLVersionInfo._make(map(int, mpl_version_str.split(".")))
 
+# Restrict zooming out of plots.
+ZOOM_LIMIT = 1e300
 
 # Use the correct draggable method based on the matplotlib version
 if hasattr(Legend, "set_draggable"):
@@ -177,6 +179,12 @@ def zoom_axis(ax, coord, x_or_y, factor):
     dist_to_max = ax_max - coord
     new_ax_min = coord - dist_to_min/factor
     new_ax_max = coord + dist_to_max/factor
+
+    if abs(new_ax_max) > ZOOM_LIMIT:
+        new_ax_max = ax_max
+
+    if abs(new_ax_min) > ZOOM_LIMIT:
+        new_ax_min = ax_min
 
     set_lims((new_ax_min, new_ax_max))
     return new_ax_min, new_ax_max

--- a/docs/source/release/v6.1.0/mantidworkbench.rst
+++ b/docs/source/release/v6.1.0/mantidworkbench.rst
@@ -49,6 +49,7 @@ Bugfixes
 - Fixed a bug where panning on a colour fill plot stretches dataset along spectrum axis instead of panning
 - Fixed a bug where TableWorkspace column names would not update correctly if the table was open.
 - Fixed a problem with scripts generated from tiled plots.
+- Restrict scroll wheel zooming out to +/-10^300 to avoid crash.
 
 Interfaces
 ----------

--- a/qt/applications/workbench/workbench/plotting/test/test_utility.py
+++ b/qt/applications/workbench/workbench/plotting/test/test_utility.py
@@ -52,7 +52,7 @@ class TestUtility(unittest.TestCase):
         zoom_point = [0, 0]
         zoom_factor = 1e-300
 
-        # zoom function will attempt to set the y-axis limits to +/-1e300.
+        # zoom function will attempt to set the y-axis limits to +/-1e310.
         assertRaisesNothing(self, zoom, ax, *zoom_point, zoom_factor)
 
 

--- a/qt/applications/workbench/workbench/plotting/test/test_utility.py
+++ b/qt/applications/workbench/workbench/plotting/test/test_utility.py
@@ -7,11 +7,14 @@
 #  This file is part of the mantid package
 import unittest
 
+import matplotlib
+matplotlib.use("Agg")  # noqa
 import matplotlib.pyplot as plt
 from mantid.plots.legend import LegendProperties
 from numpy import testing as np_testing
 
 from mantid.plots.utility import zoom, zoom_axis
+from testhelpers import assertRaisesNothing
 
 
 class TestUtility(unittest.TestCase):
@@ -38,6 +41,19 @@ class TestUtility(unittest.TestCase):
         legend_props = LegendProperties.from_legend(ax.legend_)
 
         self.assertEqual(legend_props['title'], '')
+
+    def test_zoom_out_really_far(self):
+        """
+        Attempt to zoom out far enough so that the new y-axis limits are beyond the maximum size of a float.
+        """
+        fig, ax = plt.subplots()
+        ax.plot([0, 1, 2], [1e10, -1e10, 1e10])
+
+        zoom_point = [0, 0]
+        zoom_factor = 1e-300
+
+        # zoom function will attempt to set the y-axis limits to +/-1e300.
+        assertRaisesNothing(self, zoom, ax, *zoom_point, zoom_factor)
 
 
 if __name__ == '__main__':

--- a/qt/applications/workbench/workbench/plotting/test/test_utility.py
+++ b/qt/applications/workbench/workbench/plotting/test/test_utility.py
@@ -13,7 +13,7 @@ import matplotlib.pyplot as plt
 from mantid.plots.legend import LegendProperties
 from numpy import testing as np_testing
 
-from mantid.plots.utility import zoom, zoom_axis
+from mantid.plots.utility import zoom, zoom_axis, ZOOM_LIMIT
 from testhelpers import assertRaisesNothing
 
 
@@ -54,6 +54,32 @@ class TestUtility(unittest.TestCase):
 
         # zoom function will attempt to set the y-axis limits to +/-1e310.
         assertRaisesNothing(self, zoom, ax, *zoom_point, zoom_factor)
+
+    def test_zoom_in_from_outside_zoom_limit(self):
+        """
+        Manually set the axis range so it is outside of the zoom out limit, and make sure it's possible to zoom in.
+        """
+        fig, ax = plt.subplots()
+        ax.plot([0, 1, 2], [1e10, -1e10, 1e10])
+
+        # Set axis limits outside of the maximum zoom out range.
+        axis_max = ZOOM_LIMIT * 2.0
+        axis_min = ZOOM_LIMIT * -2.0
+        ax.set_xlim([axis_min, axis_max])
+        ax.set_ylim([axis_min, axis_max])
+
+        # Attempt to zoom in.
+        zoom_point = [0, 0]
+        zoom_factor = 1.05
+        zoom(ax, *zoom_point, zoom_factor)
+
+        # Check that we were able to zoom in.
+        x_min, x_max = ax.get_xlim()
+        y_min, y_max = ax.get_ylim()
+        self.assertTrue(x_min > axis_min)
+        self.assertTrue(x_max < axis_max)
+        self.assertTrue(y_min > axis_min)
+        self.assertTrue(y_max < axis_max)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
**Description of work.**
Restrict zooming with the scroll wheel so that zooming out cannot produce axis limits that exceed +/-1e300. This avoids running into an unhandled exception.

**To test:**
- Open a plot and double click on an axis to open the "Edit axis" dialog.
- Set Min to -1e299 and Max to 1e299, and click OK.
- Using the scroll wheel, attempt to zoom out as far as you can - it should limit you to +/-1e300.

Other things to check
- Same as above, but set Max to -1e299 and Min to +1e299 so that the axis is flipped.
- Set the limits just outside of +/-1e300 and check you can still zoom in.


Fixes #31255.

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
