### PR TITLE
Replace/Remove Uses Of UNUSED_ARG With [[maybe_unused]] Attribute

### DIFF
--- a/Framework/API/inc/MantidAPI/DataProcessorAlgorithm.h
+++ b/Framework/API/inc/MantidAPI/DataProcessorAlgorithm.h
@@ -52,7 +52,7 @@ protected:
   /// MPI option. If false, we will use one job event if MPI is available
   bool m_useMPI;
   Workspace_sptr assemble(Workspace_sptr partialWS);
-  Workspace_sptr assemble(const std::string &partialWSName, const std::string &outputWSName);
+  Workspace_sptr assemble(const std::string &partialWSName, [[maybe_unused]] const std::string &outputWSName);
   void saveNexus(const std::string &outputWSName, const std::string &outputFile);
   bool isMainThread();
   int getNThreads();

--- a/Framework/API/inc/MantidAPI/MatrixWorkspace.h
+++ b/Framework/API/inc/MantidAPI/MatrixWorkspace.h
@@ -137,7 +137,8 @@ public:
   Types::Core::DateAndTime getLastPulseTime() const;
 
   /// Returns the y index which corresponds to the X Value provided
-  std::size_t yIndexOfX(const double xValue, const std::size_t &index = 0, const double tolerance = 0.0) const;
+  std::size_t yIndexOfX(const double xValue, const std::size_t &index = 0,
+                        [[maybe_unused]] const double tolerance = 0.0) const;
 
   //----------------------------------------------------------------------
   // DATA ACCESSORS
@@ -470,7 +471,7 @@ private:
                             size_t stop, size_t width, size_t indexStart, size_t indexEnd) const;
   /// Copy data from an image.
   void setImage(MantidVec &(MatrixWorkspace::*dataVec)(const std::size_t), const MantidImage &image, size_t start,
-                bool parallelExecution);
+                [[maybe_unused]] bool parallelExecution);
 
   void setIndexInfoWithoutISpectrumUpdate(const Indexing::IndexInfo &indexInfo);
   void buildDefaultSpectrumDefinitions();

--- a/Framework/API/src/DataProcessorAlgorithm.cpp
+++ b/Framework/API/src/DataProcessorAlgorithm.cpp
@@ -236,7 +236,7 @@ template <class Base> Workspace_sptr GenericDataProcessorAlgorithm<Base>::assemb
  */
 template <class Base>
 Workspace_sptr GenericDataProcessorAlgorithm<Base>::assemble(const std::string &partialWSName,
-                                                             const std::string &outputWSName) {
+                                                             [[maybe_unused]] const std::string &outputWSName) {
 #ifdef MPI_BUILD
   std::string threadOutput = partialWSName;
   Workspace_sptr partialWS = AnalysisDataService::Instance().retrieve(partialWSName);
@@ -251,7 +251,6 @@ Workspace_sptr GenericDataProcessorAlgorithm<Base>::assemble(const std::string &
   if (isMainThread())
     threadOutput = outputWSName;
 #else
-  UNUSED_ARG(outputWSName)
   const std::string &threadOutput = partialWSName;
 
 #endif

--- a/Framework/API/src/MatrixWorkspace.cpp
+++ b/Framework/API/src/MatrixWorkspace.cpp
@@ -1303,7 +1303,8 @@ Types::Core::DateAndTime MatrixWorkspace::getLastPulseTime() const {
  *                     stored value (default = 0.0). Used for point data only.
  * @returns The index corresponding to the X value provided
  */
-std::size_t MatrixWorkspace::yIndexOfX(const double xValue, const std::size_t &index, const double tolerance) const {
+std::size_t MatrixWorkspace::yIndexOfX(const double xValue, const std::size_t &index,
+                                       [[maybe_unused]] const double tolerance) const {
   if (index >= getNumberHistograms())
     throw std::out_of_range("MatrixWorkspace::yIndexOfX - Index out of range.");
 
@@ -1313,8 +1314,6 @@ std::size_t MatrixWorkspace::yIndexOfX(const double xValue, const std::size_t &i
   const auto maxX = ascendingOrder ? xValues.back() : xValues.front();
 
   if (isHistogramDataByIndex(index)) {
-    UNUSED_ARG(tolerance);
-
     if (xValue < minX || xValue > maxX)
       throw std::out_of_range("MatrixWorkspace::yIndexOfX - X value is out of "
                               "the range of the min and max bin edges.");
@@ -1969,7 +1968,7 @@ std::pair<size_t, double> MatrixWorkspace::getXIndex(size_t i, double x, bool is
  * @param parallelExecution :: Should inner loop run as parallel operation
  */
 void MatrixWorkspace::setImage(MantidVec &(MatrixWorkspace::*dataVec)(const std::size_t), const MantidImage &image,
-                               size_t start, bool parallelExecution) {
+                               size_t start, [[maybe_unused]] bool parallelExecution) {
 
   if (image.empty())
     return;
@@ -2000,8 +1999,6 @@ void MatrixWorkspace::setImage(MantidVec &(MatrixWorkspace::*dataVec)(const std:
       (this->*dataVec)(spec)[0] = *pixel;
     }
   }
-  // suppress warning when built without openmp.
-  UNUSED_ARG(parallelExecution)
 }
 
 /**

--- a/Framework/Crystal/src/PeakIntegration.cpp
+++ b/Framework/Crystal/src/PeakIntegration.cpp
@@ -288,7 +288,6 @@ void PeakIntegration::retrieveProperties() {
 
 int PeakIntegration::fitneighbours(int ipeak, const std::string &det_name, int x0, int y0, int idet, double qspan,
                                    PeaksWorkspace_sptr &Peaks, const detid2index_map &pixel_to_wi) {
-  UNUSED_ARG(ipeak);
   UNUSED_ARG(det_name);
   UNUSED_ARG(x0);
   UNUSED_ARG(y0);

--- a/Framework/DataHandling/inc/MantidDataHandling/LoadSampleEnvironment.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/LoadSampleEnvironment.h
@@ -52,8 +52,9 @@ private:
 
   void loadEnvironmentFromSTL(const std::string filename, API::Sample &sample, const bool add, std::string debugString);
 
-  void loadEnvironmentFrom3MF(API::MatrixWorkspace_const_sptr inputWS, const std::string filename, API::Sample &sample,
-                              const bool add, std::string debugString);
+  void loadEnvironmentFrom3MF([[maybe_unused]] API::MatrixWorkspace_const_sptr inputWS,
+                              [[maybe_unused]] const std::string filename, [[maybe_unused]] API::Sample &sample,
+                              [[maybe_unused]] const bool add, std::string debugString);
 };
 
 } // end namespace DataHandling

--- a/Framework/DataHandling/src/LoadSampleEnvironment.cpp
+++ b/Framework/DataHandling/src/LoadSampleEnvironment.cpp
@@ -281,8 +281,10 @@ void LoadSampleEnvironment::loadEnvironmentFromSTL(const std::string filename, S
  * be added to any pre-existing components already in the environment
  * @param debugString Debug string that can be appended to by this function
  */
-void LoadSampleEnvironment::loadEnvironmentFrom3MF(MatrixWorkspace_const_sptr inputWS, const std::string filename,
-                                                   Sample &sample, const bool add, std::string debugString) {
+void LoadSampleEnvironment::loadEnvironmentFrom3MF([[maybe_unused]] MatrixWorkspace_const_sptr inputWS,
+                                                   [[maybe_unused]] const std::string filename,
+                                                   [[maybe_unused]] Sample &sample, [[maybe_unused]] const bool add,
+                                                   [[maybe_unused]] std::string debugString) {
 #ifdef ENABLE_LIB3MF
   std::unique_ptr<Geometry::SampleEnvironment> environment = nullptr;
   Mantid3MFFileIO MeshLoader;
@@ -318,11 +320,6 @@ void LoadSampleEnvironment::loadEnvironmentFrom3MF(MatrixWorkspace_const_sptr in
   // Put Environment into sample.
   sample.setEnvironment(std::move(environment));
 #else
-  UNUSED_ARG(inputWS)
-  UNUSED_ARG(filename)
-  UNUSED_ARG(sample)
-  UNUSED_ARG(add)
-  UNUSED_ARG(debugString)
   throw std::runtime_error("3MF format not supported on this platform");
 #endif
 }

--- a/Framework/DataObjects/inc/MantidDataObjects/Workspace2D.h
+++ b/Framework/DataObjects/inc/MantidDataObjects/Workspace2D.h
@@ -79,7 +79,7 @@ public:
   void setImageE(const API::MantidImage &image, size_t start = 0, bool parallelExecution = true) override;
   /// Copy the data from an image to this workspace's (Y's) and errors.
   void setImageYAndE(const API::MantidImage &imageY, const API::MantidImage &imageE, size_t start = 0,
-                     bool loadAsRectImg = false, double scale_1 = 1.0, bool parallelExecution = true);
+                     bool loadAsRectImg = false, double scale_1 = 1.0, [[maybe_unused]] bool parallelExecution = true);
 
 protected:
   /// Protected copy constructor. May be used by childs for cloning.

--- a/Framework/DataObjects/src/Workspace2D.cpp
+++ b/Framework/DataObjects/src/Workspace2D.cpp
@@ -204,9 +204,7 @@ void Workspace2D::setImageE(const MantidImage &image, size_t start, bool paralle
  * @param parallelExecution :: Should inner loop run as parallel operation
  */
 void Workspace2D::setImageYAndE(const API::MantidImage &imageY, const API::MantidImage &imageE, size_t start,
-                                bool loadAsRectImg, double scale_1, bool parallelExecution) {
-  UNUSED_ARG(parallelExecution) // for parallel for
-
+                                bool loadAsRectImg, double scale_1, [[maybe_unused]] bool parallelExecution) {
   if (imageY.empty() && imageE.empty())
     return;
   if (imageY.empty() && imageE[0].empty())

--- a/Framework/Kernel/inc/MantidKernel/ConfigService.h
+++ b/Framework/Kernel/inc/MantidKernel/ConfigService.h
@@ -160,7 +160,7 @@ public:
   // Return the full path to the executable
   std::string getPathToExecutable() const;
   // Check if the path is on a network drive
-  bool isNetworkDrive(const std::string &path);
+  bool isNetworkDrive([[maybe_unused]] const std::string &path);
   //@}
 
   /// Returns the directory where the Mantid.properties file is found.

--- a/Framework/Kernel/src/ConfigService.cpp
+++ b/Framework/Kernel/src/ConfigService.cpp
@@ -1268,7 +1268,7 @@ std::string ConfigServiceImpl::getPathToExecutable() const {
  * @param path :: The path to be checked
  * @return True if the path is on a network drive.
  */
-bool ConfigServiceImpl::isNetworkDrive(const std::string &path) {
+bool ConfigServiceImpl::isNetworkDrive([[maybe_unused]] const std::string &path) {
 #ifdef _WIN32
   // if path is relative get the full one
   char buff[MAX_PATH];
@@ -1335,7 +1335,6 @@ bool ConfigServiceImpl::isNetworkDrive(const std::string &path) {
   }
   return false;
 #else
-  UNUSED_ARG(path);
   // Not yet implemented for the mac
   return false;
 #endif

--- a/Framework/MDAlgorithms/src/UserFunctionMD.cpp
+++ b/Framework/MDAlgorithms/src/UserFunctionMD.cpp
@@ -35,10 +35,7 @@ UserFunctionMD::UserFunctionMD() {
 std::vector<std::string> UserFunctionMD::getAttributeNames() const { return std::vector<std::string>(1, "Formula"); }
 
 /// Has attribute "Formula"
-bool UserFunctionMD::hasAttribute(const std::string &attName) const {
-  UNUSED_ARG(attName);
-  return attName == "Formula";
-}
+bool UserFunctionMD::hasAttribute(const std::string &attName) const { return attName == "Formula"; }
 
 /// Return Formula
 UserFunctionMD::Attribute UserFunctionMD::getAttribute(const std::string &attName) const {


### PR DESCRIPTION
**Description of work.**
Searched the code base and removed/replaced some uses of the UNUSED_ARG macro with [[maybe_unused]] attribute instead in places I thought made sense.

**To test:**
Make sure builds okay and no compiler warnings
Does removing unused arg in each case make sense

Fixes #29466 

*This does not require release notes* because **it is maintenance**

<!-- Ensure the base of this PR is correct (e.g. release-next or master)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
