### PR TITLE
Correct CreateSampleWorkspace's event workspace simulation (ornl-next)

### DIFF
--- a/Framework/Algorithms/src/CreateSampleWorkspace.cpp
+++ b/Framework/Algorithms/src/CreateSampleWorkspace.cpp
@@ -392,7 +392,7 @@ EventWorkspace_sptr CreateSampleWorkspace::createEventWorkspace(int numPixels, i
       auto eventsInBin = static_cast<int>(yValues[i]);
       for (int q = 0; q < eventsInBin; q++) {
         DateAndTime pulseTime = run_start + (m_randGen->nextValue() * hourInSeconds);
-        el += TofEvent((i + m_randGen->nextValue()) * binDelta, pulseTime);
+        el += TofEvent((i + m_randGen->nextValue()) * binDelta + x0, pulseTime);
       }
     }
     workspaceIndex++;

--- a/Framework/Algorithms/test/CreateSampleWorkspaceTest.h
+++ b/Framework/Algorithms/test/CreateSampleWorkspaceTest.h
@@ -243,6 +243,26 @@ public:
     AnalysisDataService::Instance().remove(outWSName);
   }
 
+  // Test create sample workspace with DeltaE as X unit
+  void test_event_deltae() {
+    // Name of the output workspace.
+    std::string outWSName("CreateSampleWorkspaceTest_OutputWS_DeltaE");
+
+    auto ws = std::dynamic_pointer_cast<IEventWorkspace>(createSampleWorkspace(
+        outWSName, "Event", "Flat background", "", 2, 1, 1000, false, "DeltaE", -10., 19., 0.5, 1));
+    TS_ASSERT_EQUALS(ws->getNumberEvents(), 1972);
+    TS_ASSERT_EQUALS(ws->readY(0).size(), 58);
+    TS_ASSERT_EQUALS(ws->getNumberHistograms(), 2);
+
+    for (auto i = 0; i < 58; ++i) {
+      for (auto j = 0; j < 2; ++j)
+        TS_ASSERT_DELTA(ws->readY(j)[i], 17., 1E-7);
+    }
+
+    // Remove workspace from the data service.
+    AnalysisDataService::Instance().remove(outWSName);
+  }
+
   void test_event_MoreBanksMoreDetectorsLessEvents() {
     // Name of the output workspace.
     std::string outWSName("CreateSampleWorkspaceTest_OutputWS_MoreBanksMoreDetectors");

--- a/Framework/Algorithms/test/PDCalibrationTest.h
+++ b/Framework/Algorithms/test/PDCalibrationTest.h
@@ -13,6 +13,7 @@
 #include "MantidAPI/FrameworkManager.h"
 #include "MantidAPI/ITableWorkspace.h"
 #include "MantidAPI/MatrixWorkspace.h"
+#include "MantidAlgorithms/ChangeBinOffset.h"
 #include "MantidAlgorithms/ConvertToMatrixWorkspace.h"
 #include "MantidAlgorithms/CreateSampleWorkspace.h"
 #include "MantidAlgorithms/CropWorkspace.h"
@@ -23,6 +24,7 @@
 #include "MantidDataObjects/TableColumn.h"
 #include "MantidKernel/Unit.h"
 
+using Mantid::Algorithms::ChangeBinOffset;
 using Mantid::Algorithms::ConvertToMatrixWorkspace;
 using Mantid::Algorithms::CreateSampleWorkspace;
 using Mantid::Algorithms::CropWorkspace;
@@ -84,6 +86,15 @@ void createSampleWS() {
   createSampleWS.setProperty("PixelSpacing", .02); // 2cm pixels
   createSampleWS.setPropertyValue("OutputWorkspace", "PDCalibrationTest_WS");
   createSampleWS.execute();
+
+  // In order to make it same as before CreateSampleWorkspace is fixed by shifting TOF back -TOF_MIN
+  // such that peaks' positions will be kept unchanged.
+  ChangeBinOffset changeBinOffset;
+  changeBinOffset.initialize();
+  changeBinOffset.setPropertyValue("InputWorkspace", "PDCalibrationTest_WS");
+  changeBinOffset.setPropertyValue("OutputWorkspace", "PDCalibrationTest_WS");
+  changeBinOffset.setProperty("Offset", -1 * TOF_MIN);
+  changeBinOffset.execute();
 
   // move it to the right place - DIFC of this location vary from 5308 to 5405
   RotateInstrumentComponent rotateInstr;

--- a/Framework/PythonInterface/test/python/plugins/algorithms/CalculateEfficiencyCorrectionTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/CalculateEfficiencyCorrectionTest.py
@@ -7,7 +7,7 @@
 import unittest
 from mantid.simpleapi import \
     CalculateEfficiencyCorrection, CloneWorkspace, ConvertToPointData, \
-    CreateSampleWorkspace, DeleteWorkspace, LoadAscii, Multiply
+    CreateSampleWorkspace, DeleteWorkspace, LoadAscii, Multiply, ChangeBinOffset
 from testhelpers import run_algorithm
 from mantid.api import AnalysisDataService
 
@@ -57,7 +57,7 @@ class CalculateEfficiencyCorrectionTest(unittest.TestCase):
         self.assertEqual(output_wksp.getAxis(0).getUnit().unitID(), 'Wavelength')
         self.assertAlmostEqual(output_wksp.readX(0)[79], 0.995)
         if eventCheck:
-            self.assertAlmostEqual(output_wksp.readY(0)[79], 62.22517501)
+            self.assertAlmostEqual(output_wksp.readY(0)[79], 66.23970242900438)
         else:
             if xsection == "AttenuationXSection":
                 self.assertAlmostEqual(output_wksp.readY(0)[79], 3250.28183501)

--- a/Framework/WorkflowAlgorithms/test/AlignAndFocusPowderTest.h
+++ b/Framework/WorkflowAlgorithms/test/AlignAndFocusPowderTest.h
@@ -13,6 +13,7 @@
 #include "MantidAPI/TableRow.h"
 #include "MantidAlgorithms/AddSampleLog.h"
 #include "MantidAlgorithms/AddTimeSeriesLog.h"
+#include "MantidAlgorithms/ChangeBinOffset.h"
 #include "MantidAlgorithms/ConvertUnits.h"
 #include "MantidAlgorithms/CreateGroupingWorkspace.h"
 #include "MantidAlgorithms/CreateSampleWorkspace.h"
@@ -87,10 +88,12 @@ public:
     docheckEventInputWksp();
 
     // Test the output
-    TS_ASSERT_DELTA(m_outWS->x(0)[80], 1609.2800, 0.0001);
-    TS_ASSERT_EQUALS(m_outWS->y(0)[80], 20);
-    TS_ASSERT_DELTA(m_outWS->x(0)[880], 14702.0800, 0.0001);
-    TS_ASSERT_EQUALS(m_outWS->y(0)[880], 587);
+    // [99] 1920.2339999999983, 41
+    TS_ASSERT_DELTA(m_outWS->x(0)[99], 1920.23400, 0.0001);
+    TS_ASSERT_EQUALS(m_outWS->y(0)[99], 41.);
+    // [899] 673.0, 15013.033999999987
+    TS_ASSERT_DELTA(m_outWS->x(0)[899], 15013.03400, 0.0001);
+    TS_ASSERT_EQUALS(m_outWS->y(0)[899], 673.0);
   }
 
   void testEventWksp_preserveEvents_useGroupAll() {
@@ -109,10 +112,12 @@ public:
     docheckEventInputWksp();
 
     // Test the output
-    TS_ASSERT_DELTA(m_outWS->x(0)[423], 1634.3791, 0.0001);
-    TS_ASSERT_EQUALS(m_outWS->y(0)[423], 2702);
-    TS_ASSERT_DELTA(m_outWS->x(0)[970], 14719.8272, 0.0001);
-    TS_ASSERT_EQUALS(m_outWS->y(0)[970], 149165);
+    // [465] 1934.8418434567402, 3086.0
+    TS_ASSERT_DELTA(m_outWS->x(0)[465], 1934.8418, 0.0001);
+    TS_ASSERT_EQUALS(m_outWS->y(0)[465], 3086.0);
+    // [976] 15079.01917808858: 55032.0
+    TS_ASSERT_DELTA(m_outWS->x(0)[976], 15079.019178, 0.0001);
+    TS_ASSERT_EQUALS(m_outWS->y(0)[976], 55032.0);
   }
 
   void testEventWksp_doNotPreserveEvents() {
@@ -131,10 +136,12 @@ public:
     docheckEventInputWksp();
 
     // Test the output
-    TS_ASSERT_DELTA(m_outWS->x(0)[80], 1609.2800, 0.0001);
-    TS_ASSERT_EQUALS(m_outWS->y(0)[80], 20);
-    TS_ASSERT_DELTA(m_outWS->x(0)[880], 14702.0800, 0.0001);
-    TS_ASSERT_EQUALS(m_outWS->y(0)[880], 587);
+    // [99] 1920.2339999999983, 41
+    TS_ASSERT_DELTA(m_outWS->x(0)[99], 1920.23400, 0.0001);
+    TS_ASSERT_EQUALS(m_outWS->y(0)[99], 41.);
+    // [899] 673.0, 15013.033999999987
+    TS_ASSERT_DELTA(m_outWS->x(0)[899], 15013.03400, 0.0001);
+    TS_ASSERT_EQUALS(m_outWS->y(0)[899], 673.0);
   }
 
   void testEventWksp_doNotPreserveEvents_useGroupAll() {
@@ -153,10 +160,12 @@ public:
     docheckEventInputWksp();
 
     // Test the output
-    TS_ASSERT_DELTA(m_outWS->x(0)[423], 1634.3791, 0.0001);
-    TS_ASSERT_DELTA(m_outWS->y(0)[423], 2419.5680, 0.0001);
-    TS_ASSERT_DELTA(m_outWS->x(0)[970], 14719.8272, 0.0001);
-    TS_ASSERT_DELTA(m_outWS->y(0)[970], 148503.3853, 0.0001);
+    // [465] 1934.8418434567402, 3086.0
+    TS_ASSERT_DELTA(m_outWS->x(0)[465], 1934.8418, 0.0001);
+    TS_ASSERT_DELTA(m_outWS->y(0)[465], 2699.3, 0.1);
+    // [976] 15079.01917808858: 55032.0
+    TS_ASSERT_DELTA(m_outWS->x(0)[976], 15079.019178, 0.0001);
+    TS_ASSERT_DELTA(m_outWS->y(0)[976], 55549.5, 0.1);
   }
 
   void testEventWksp_rebin_preserveEvents() {
@@ -172,16 +181,16 @@ public:
     doTestEventWksp();
 
     // Test the input
-    TS_ASSERT_DELTA(m_inWS->x(0)[170], 1628.3764, 0.0001);
-    TS_ASSERT_EQUALS(m_inWS->y(0)[170], 48);
-    TS_ASSERT_DELTA(m_inWS->x(0)[391], 14681.7696, 0.0001);
-    TS_ASSERT_EQUALS(m_inWS->y(0)[391], 2540);
+    TS_ASSERT_DELTA(m_inWS->x(0)[187], 1928.4933786037175, 0.0001);
+    TS_ASSERT_EQUALS(m_inWS->y(0)[187], 53);
+    TS_ASSERT_DELTA(m_inWS->x(0)[393], 14976.873144731135, 0.0001);
+    TS_ASSERT_EQUALS(m_inWS->y(0)[393], 2580);
 
     // Test the output
-    TS_ASSERT_DELTA(m_outWS->x(0)[1693], 1629.3502, 0.0001);
-    TS_ASSERT_EQUALS(m_outWS->y(0)[1693], 6);
-    TS_ASSERT_DELTA(m_outWS->x(0)[3895], 14718.1436, 0.0001);
-    TS_ASSERT_EQUALS(m_outWS->y(0)[3895], 612);
+    TS_ASSERT_DELTA(m_outWS->x(0)[1872], 1948.5623011850066, 0.0001);
+    TS_ASSERT_EQUALS(m_outWS->y(0)[1872], 4);
+    TS_ASSERT_DELTA(m_outWS->x(0)[3915], 15015.319796791482, 0.0001);
+    TS_ASSERT_EQUALS(m_outWS->y(0)[3915], 620);
   }
 
   void testEventWksp_preserveEvents_dmin_dmax() {
@@ -206,10 +215,10 @@ public:
     docheckEventInputWksp();
 
     // Test the output
-    TS_ASSERT_DELTA(m_outWS->x(0)[116], 3270.3908, 0.0001);
-    TS_ASSERT_EQUALS(m_outWS->y(0)[116], 37);
-    TS_ASSERT_DELTA(m_outWS->x(0)[732], 6540.7817, 0.0001);
-    TS_ASSERT_EQUALS(m_outWS->y(0)[732], 25);
+    TS_ASSERT_DELTA(m_outWS->x(0)[172], 3567.6990819051966, 0.0001);
+    TS_ASSERT_EQUALS(m_outWS->y(0)[172], 37);
+    TS_ASSERT_DELTA(m_outWS->x(0)[789], 6843.398982999533, 0.0001);
+    TS_ASSERT_EQUALS(m_outWS->y(0)[789], 27);
   }
 
   void testEventWksp_preserveEvents_tmin_tmax() {
@@ -221,7 +230,7 @@ public:
     m_useGroupAll = false;
     m_useResamplex = true;
     m_tmin = "2000.0";
-    m_tmax = "10000.0";
+    m_tmax = "12000.0";
 
     // Run the main test function
     doTestEventWksp();
@@ -234,10 +243,10 @@ public:
     docheckEventInputWksp();
 
     // Test the output
-    TS_ASSERT_DELTA(m_outWS->x(0)[149], 3270.7563, 0.0001);
-    TS_ASSERT_EQUALS(m_outWS->y(0)[149], 51);
-    TS_ASSERT_DELTA(m_outWS->x(0)[982], 9814.5378, 0.0001);
-    TS_ASSERT_EQUALS(m_outWS->y(0)[982], 138);
+    TS_ASSERT_DELTA(m_outWS->x(0)[149], 3563.380399999972, 0.0001);
+    TS_ASSERT_EQUALS(m_outWS->y(0)[149], 63);
+    TS_ASSERT_DELTA(m_outWS->x(0)[816], 10113.053600000023, 0.0001);
+    TS_ASSERT_EQUALS(m_outWS->y(0)[816], 175);
   }
 
   void testEventWksp_preserveEvents_lambdamin_lambdamax() {
@@ -262,12 +271,12 @@ public:
     docheckEventInputWksp();
 
     // Test the output
-    TS_ASSERT_DELTA(m_outWS->x(0)[181], 3262.2460, 0.0001);
-    TS_ASSERT_EQUALS(m_outWS->y(0)[181], 105);
-    TS_ASSERT_DELTA(m_outWS->x(0)[581], 9808.6460, 0.0001);
-    TS_ASSERT_EQUALS(m_outWS->y(0)[581], 290);
-    TS_ASSERT_DELTA(m_outWS->x(0)[880], 14702.0800, 0.0001);
-    TS_ASSERT_EQUALS(m_outWS->y(0)[880], 0);
+    TS_ASSERT_DELTA(m_outWS->x(0)[199], 3556.833999999997, 0.0001);
+    TS_ASSERT_EQUALS(m_outWS->y(0)[199], 92.);
+    TS_ASSERT_DELTA(m_outWS->x(0)[599], 10103.233999999991, 0.0001);
+    TS_ASSERT_EQUALS(m_outWS->y(0)[599], 277.);
+    TS_ASSERT_DELTA(m_outWS->x(0)[899], 15013.033999999987, 0.0001);
+    TS_ASSERT_EQUALS(m_outWS->y(0)[899], 0);
   }
 
   void testEventWksp_preserveEvents_maskbins() {
@@ -290,12 +299,12 @@ public:
     docheckEventInputWksp();
 
     // Test the output
-    TS_ASSERT_DELTA(m_outWS->x(0)[181], 3262.2460, 0.0001);
-    TS_ASSERT_EQUALS(m_outWS->y(0)[181], 105);
-    TS_ASSERT_DELTA(m_outWS->x(0)[581], 9808.6460, 0.0001);
-    TS_ASSERT_EQUALS(m_outWS->y(0)[581], 290);
-    TS_ASSERT_DELTA(m_outWS->x(0)[880], 14702.0800, 0.0001);
-    TS_ASSERT_EQUALS(m_outWS->y(0)[880], 0);
+    TS_ASSERT_DELTA(m_outWS->x(0)[199], 3556.833999999997, 0.0001);
+    TS_ASSERT_EQUALS(m_outWS->y(0)[199], 92.);
+    TS_ASSERT_DELTA(m_outWS->x(0)[599], 10103.233999999991, 0.0001);
+    TS_ASSERT_EQUALS(m_outWS->y(0)[599], 277.);
+    TS_ASSERT_DELTA(m_outWS->x(0)[899], 15013.033999999987, 0.0001);
+    TS_ASSERT_EQUALS(m_outWS->y(0)[899], 0);
   }
 
   void testEventWksp_preserveEvents_noCompressTolerance() {
@@ -318,12 +327,12 @@ public:
     docheckEventInputWksp();
 
     // Test the output
-    TS_ASSERT_DELTA(m_outWS->x(0)[181], 3262.2460, 0.0001);
-    TS_ASSERT_EQUALS(m_outWS->y(0)[181], 105);
-    TS_ASSERT_DELTA(m_outWS->x(0)[581], 9808.6460, 0.0001);
-    TS_ASSERT_EQUALS(m_outWS->y(0)[581], 290);
-    TS_ASSERT_DELTA(m_outWS->x(0)[880], 14702.0800, 0.0001);
-    TS_ASSERT_EQUALS(m_outWS->y(0)[880], 587);
+    TS_ASSERT_DELTA(m_outWS->x(0)[199], 3556.833999999997, 0.0001);
+    TS_ASSERT_EQUALS(m_outWS->y(0)[199], 92.);
+    TS_ASSERT_DELTA(m_outWS->x(0)[599], 10103.233999999991, 0.0001);
+    TS_ASSERT_EQUALS(m_outWS->y(0)[599], 277.);
+    TS_ASSERT_DELTA(m_outWS->x(0)[899], 15013.033999999987, 0.0001);
+    TS_ASSERT_EQUALS(m_outWS->y(0)[899], 673.);
   }
 
   void testEventWksp_preserveEvents_highCompressTolerance() {
@@ -346,12 +355,12 @@ public:
     docheckEventInputWksp();
 
     // Test the output
-    TS_ASSERT_DELTA(m_outWS->x(0)[181], 3262.2460, 0.0001);
-    TS_ASSERT_EQUALS(m_outWS->y(0)[181], 96);
-    TS_ASSERT_DELTA(m_outWS->x(0)[581], 9808.6460, 0.0001);
-    TS_ASSERT_EQUALS(m_outWS->y(0)[581], 427);
-    TS_ASSERT_DELTA(m_outWS->x(0)[880], 14702.0800, 0.0001);
-    TS_ASSERT_EQUALS(m_outWS->y(0)[880], 672);
+    TS_ASSERT_DELTA(m_outWS->x(0)[199], 3556.833999999997, 0.0001);
+    TS_ASSERT_EQUALS(m_outWS->y(0)[199], 119.);
+    TS_ASSERT_DELTA(m_outWS->x(0)[599], 10103.233999999991, 0.0001);
+    TS_ASSERT_EQUALS(m_outWS->y(0)[599], 263.);
+    TS_ASSERT_DELTA(m_outWS->x(0)[899], 15013.033999999987, 0.0001);
+    TS_ASSERT_EQUALS(m_outWS->y(0)[899], 827.);
   }
 
   void testEventWksp_preserveEvents_compressWallClockTolerance() {
@@ -374,13 +383,14 @@ public:
     // Test the input
     docheckEventInputWksp();
 
-    // Test the output
-    TS_ASSERT_DELTA(m_outWS->x(0)[181], 3262.2460, 0.0001);
-    TS_ASSERT_EQUALS(m_outWS->y(0)[181], 105);
-    TS_ASSERT_DELTA(m_outWS->x(0)[581], 9808.6460, 0.0001);
-    TS_ASSERT_EQUALS(m_outWS->y(0)[581], 290);
-    TS_ASSERT_DELTA(m_outWS->x(0)[880], 14702.0800, 0.0001);
-    TS_ASSERT_EQUALS(m_outWS->y(0)[880], 587);
+    // Test the output: expected result shall be same as testEventWksp_preserveEvents_noCompressTolerance
+    // because comparess time clock won't change the result
+    TS_ASSERT_DELTA(m_outWS->x(0)[199], 3556.833999999997, 0.0001);
+    TS_ASSERT_EQUALS(m_outWS->y(0)[199], 92.);
+    TS_ASSERT_DELTA(m_outWS->x(0)[599], 10103.233999999991, 0.0001);
+    TS_ASSERT_EQUALS(m_outWS->y(0)[599], 277.);
+    TS_ASSERT_DELTA(m_outWS->x(0)[899], 15013.033999999987, 0.0001);
+    TS_ASSERT_EQUALS(m_outWS->y(0)[899], 673.);
   }
 
   void testEventWksp_preserveEvents_removePromptPulse() {
@@ -404,10 +414,10 @@ public:
     docheckEventInputWksp();
 
     // Test the output
-    TS_ASSERT_DELTA(m_outWS->x(0)[181], 3262.2460, 0.0001);
-    TS_ASSERT_EQUALS(m_outWS->y(0)[181], 105);
-    TS_ASSERT_DELTA(m_outWS->x(0)[581], 9808.6460, 0.0001);
-    TS_ASSERT_EQUALS(m_outWS->y(0)[581], 0);
+    TS_ASSERT_DELTA(m_outWS->x(0)[199], 3556.833999999997, 0.0001);
+    TS_ASSERT_EQUALS(m_outWS->y(0)[199], 92.);
+    TS_ASSERT_DELTA(m_outWS->x(0)[599], 10103.233999999991, 0.0001);
+    TS_ASSERT_EQUALS(m_outWS->y(0)[599], 0.);
   }
 
   void testEventWksp_preserveEvents_compressStartTime() {
@@ -433,10 +443,10 @@ public:
     docheckEventInputWksp();
 
     // Test the output
-    TS_ASSERT_DELTA(m_outWS->x(0)[181], 3262.2460, 0.0001);
-    TS_ASSERT_EQUALS(m_outWS->y(0)[181], 72);
-    TS_ASSERT_DELTA(m_outWS->x(0)[581], 9808.6460, 0.0001);
-    TS_ASSERT_EQUALS(m_outWS->y(0)[581], 197);
+    TS_ASSERT_DELTA(m_outWS->x(0)[199], 3556.833999999997, 0.0001);
+    TS_ASSERT_EQUALS(m_outWS->y(0)[199], 68.);
+    TS_ASSERT_DELTA(m_outWS->x(0)[599], 10103.233999999991, 0.0001);
+    TS_ASSERT_EQUALS(m_outWS->y(0)[599], 190.);
   }
 
   /** Setup for testing HRPD NeXus data */
@@ -552,16 +562,21 @@ public:
   }
 
   void docheckEventInputWksp() {
-    TS_ASSERT_DELTA(m_inWS->x(0)[8], 1609.2800, 0.0001);
-    TS_ASSERT_EQUALS(m_inWS->y(0)[8], 97);
-    TS_ASSERT_DELTA(m_inWS->x(0)[18], 3245.8800, 0.0001);
-    TS_ASSERT_EQUALS(m_inWS->y(0)[18], 237);
-    TS_ASSERT_DELTA(m_inWS->x(0)[38], 6519.0800, 0.0001);
-    TS_ASSERT_EQUALS(m_inWS->y(0)[38], 199);
-    TS_ASSERT_DELTA(m_inWS->x(0)[58], 9792.2800, 0.0001);
-    TS_ASSERT_EQUALS(m_inWS->y(0)[58], 772);
-    TS_ASSERT_DELTA(m_inWS->x(0)[88], 14702.0800, 0.0001);
-    TS_ASSERT_EQUALS(m_inWS->y(0)[88], 2162);
+    // peak 0
+    TS_ASSERT_DELTA(m_inWS->x(0)[9], 1772.94, 0.01);
+    TS_ASSERT_EQUALS(m_inWS->y(0)[9], 50);
+    // peak 1
+    TS_ASSERT_DELTA(m_inWS->x(0)[19], 3409.54, 0.01);
+    TS_ASSERT_EQUALS(m_inWS->y(0)[19], 125);
+    // peak 3: index = 39  6682.74  118
+    TS_ASSERT_DELTA(m_inWS->x(0)[39], 6682.74, 0.01);
+    TS_ASSERT_EQUALS(m_inWS->y(0)[39], 118);
+    // peak 5: index = 59  9955.94  483
+    TS_ASSERT_DELTA(m_inWS->x(0)[59], 9955.94, 0.01);
+    TS_ASSERT_EQUALS(m_inWS->y(0)[59], 483);
+    // peak 7: index = 89  14865.7  1524
+    TS_ASSERT_DELTA(m_inWS->x(0)[89], 14865.7, 0.1);
+    TS_ASSERT_EQUALS(m_inWS->y(0)[89], 1524);
   }
 
   void doTestEventWksp() {
@@ -724,7 +739,7 @@ public:
     TableRow row1 = m_maskBinTableWS->appendRow();
     row1 << "" << 0.0 << 2000.0;
     TableRow row2 = m_maskBinTableWS->appendRow();
-    row2 << "" << 10000.0 << m_xmax + 1000.0;
+    row2 << "" << 12000.0 << m_xmax + 1000.0;
     return m_maskBinTableWS;
   }
 

--- a/docs/source/algorithms/CalculateEfficiencyCorrection-v1.rst
+++ b/docs/source/algorithms/CalculateEfficiencyCorrection-v1.rst
@@ -122,10 +122,10 @@ Ouptut:
 
 .. testoutput:: ExBasicCalcualteEfficiencyCorrectionWithDensity
 
-    Input workspace: [ 38.  38.  38.  38.  38.]
+    Input workspace: [ 40.  40.  40.  40.  40.]
     Correction workspace: [ 24.40910309  23.29738394  22.28449939  21.35783225  20.50682528]
-    Output workspace: [ 927.54591732  885.30058981  846.81097679  811.59762534  779.25936055]
-    Output workspace using WavelengthRange: [ 927.54591732  885.30058981  846.81097679  811.59762534  779.25936055]
+    Output workspace: [ 976.3641235   931.8953577   891.37997557  854.31328983  820.2730111 ]
+    Output workspace using WavelengthRange: [ 976.3641235   931.8953577   891.37997557  854.31328983  820.2730111 ]
 
 **Example - Basics of running CalculateEfficiencyCorrection with MeasuredEfficiency and ChemicalFormula.**
 
@@ -161,12 +161,12 @@ Ouptut:
 
 .. testoutput:: ExBasicCalcualteEfficiencyCorrectionWithEfficiency
 
-    Input workspace: [ 38.  38.  38.  38.  38.]
+    Input workspace: [ 40.  40.  40.  40.  40.]
     Correction workspace: [ 873.27762699  832.68332786  795.69741128  761.85923269  730.78335476]
-    Output workspace: [ 33184.54982567  31641.9664586   30236.50162877  28950.65084207
-      27769.76748099]
-    Output workspace using WavelengthRange: [ 33184.54982567  31641.9664586   30236.50162877  28950.65084207
-      27769.76748099]
+    Output workspace: [ 34931.10507965  33307.33311431  31827.89645133  30474.36930745
+      29231.33419051]
+    Output workspace using WavelengthRange: [ 34931.10507965  33307.33311431  31827.89645133  30474.36930745
+      29231.33419051]
 
 **Example - Basics of running CalculateEfficiencyCorrection with MeasuredEfficiency and ChemicalFormula using the total cross section.**
 
@@ -204,12 +204,12 @@ Ouptut:
 
 .. testoutput:: ExBasicCalcualteEfficiencyCorrectionWithEfficiency
 
-    Input workspace: [ 38.  38.  38.  38.  38.]
+    Input workspace: [ 40.  40.  40.  40.  40.]
     Correction workspace: [ 865.7208838   825.85320701  789.49774383  756.20995361  725.61727932]
-    Output workspace: [ 32897.39358441  31382.42186624  30000.91426562  28735.97823706
-      27573.45661411]
-    Output workspace using WavelengthRange: [ 32897.39358441  31382.42186624  30000.91426562  28735.97823706
-      27573.45661411]
+    Output workspace: [ 34628.83535201  33034.12828025  31579.90975329  30248.39814428
+      29024.69117275]
+    Output workspace using WavelengthRange: [ 34628.83535201  33034.12828025  31579.90975329  30248.39814428
+      29024.69117275]
 
 The transmission of a sample can be measured as :math:`e^{-\rho T \sigma_t (\lambda)}` where :math:`\sigma_t (\lambda) = \sigma_s + \sigma_a (\lambda)` is the total cross-section. This can be calculatd directly by the :ref:`algm-CalculateSampleTransmission-v1` algorithm. Yet, we can also back out the transmission with the ``CalculateEfficiencyCorrection`` algorithm. The example below shows how:
 

--- a/docs/source/algorithms/CalculateEfficiencyCorrection-v1.rst
+++ b/docs/source/algorithms/CalculateEfficiencyCorrection-v1.rst
@@ -85,10 +85,10 @@ Ouptut:
 
 .. testoutput:: ExBasicCalcualteEfficiencyCorrectionWithAlpha
 
-    Input workspace: [ 38.  38.  38.  38.  38.]
+    Input workspace: [ 40.  40.  40.  40.  40.]
     Correction workspace: [ 10.26463773   9.81128219   9.39826191   9.02042771   8.67347109]
-    Output workspace: [ 390.05623383  372.82872321  357.13395265  342.77625306  329.59190131]
-    Output workspace using WavelengthRange: [ 390.05623383  372.82872321  357.13395265  342.77625306  329.59190131]
+    Output workspace: [ 410.58550929  392.45128759  375.93047648  360.81710849  346.93884349]
+    Output workspace using WavelengthRange: [ 410.58550929  392.45128759  375.93047648  360.81710849  346.93884349]
 
 **Example - Basics of running CalculateEfficiencyCorrection with Density and ChemicalFormula.**
 


### PR DESCRIPTION
**Description of work.**

Correct how CreateSampleWorkspace simulate events related to energy transfer.

**To test:**

```
CreateSampleWorkspace(OutputWorkspace='we', WorkspaceType='Event', Function='Flat background', BankPixelWidth=1, XUnit='DeltaE', XMin=-10, XMax=19, BinWidth=0.5)
```

The output energy transfer - events curve shall be flat at 17 (value).

Fixes #31297. 

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or master)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
