### PR TITLE
Fix TF Asymmetry bug when a pair is loaded

### DIFF
--- a/scripts/Muon/GUI/Common/fitting_widgets/tf_asymmetry_fitting/tf_asymmetry_fitting_model.py
+++ b/scripts/Muon/GUI/Common/fitting_widgets/tf_asymmetry_fitting/tf_asymmetry_fitting_model.py
@@ -129,7 +129,8 @@ class TFAsymmetryFittingModel(GeneralFittingModel):
 
     def recalculate_tf_asymmetry_functions(self) -> bool:
         """Recalculates the TF Asymmetry functions based on the datasets and normal functions in the model."""
-        if self.tf_asymmetry_mode and self.check_datasets_are_tf_asymmetry_compliant():
+        tf_compliant, _ = self.check_datasets_are_tf_asymmetry_compliant()
+        if self.tf_asymmetry_mode and tf_compliant:
             try:
                 self._recalculate_tf_asymmetry_functions()
             except RuntimeError:
@@ -230,8 +231,8 @@ class TFAsymmetryFittingModel(GeneralFittingModel):
 
     def check_datasets_are_tf_asymmetry_compliant(self) -> bool:
         """Returns true if the datasets stored in the model are compatible with TF Asymmetry mode."""
-        non_compliant_workspaces = [item for item in self.dataset_names if "Group" not in item]
-        return len(non_compliant_workspaces) == 0
+        pair_names = [get_group_or_pair_from_name(item) for item in self.dataset_names if "Group" not in item]
+        return len(pair_names) == 0, pair_names
 
     def get_all_fit_functions(self) -> list:
         """Returns all the fit functions for the current fitting mode."""

--- a/scripts/Muon/GUI/Common/fitting_widgets/tf_asymmetry_fitting/tf_asymmetry_fitting_model.py
+++ b/scripts/Muon/GUI/Common/fitting_widgets/tf_asymmetry_fitting/tf_asymmetry_fitting_model.py
@@ -233,7 +233,9 @@ class TFAsymmetryFittingModel(GeneralFittingModel):
         """Returns true if the datasets stored in the model are compatible with TF Asymmetry mode."""
         workspace_names = self.dataset_names if workspace_names is None else workspace_names
         pair_names = [get_group_or_pair_from_name(name) for name in workspace_names if "Group" not in name]
-        return len(pair_names) == 0, pair_names
+        # Remove duplicates from the list
+        pair_names = list(dict.fromkeys(pair_names))
+        return len(pair_names) == 0, "'" + "', '".join(pair_names) + "'"
 
     def get_all_fit_functions(self) -> list:
         """Returns all the fit functions for the current fitting mode."""

--- a/scripts/Muon/GUI/Common/fitting_widgets/tf_asymmetry_fitting/tf_asymmetry_fitting_model.py
+++ b/scripts/Muon/GUI/Common/fitting_widgets/tf_asymmetry_fitting/tf_asymmetry_fitting_model.py
@@ -229,9 +229,10 @@ class TFAsymmetryFittingModel(GeneralFittingModel):
             if self.tf_asymmetry_mode:
                 self.function_name += TF_ASYMMETRY_FUNCTION_NAME_APPENDAGE
 
-    def check_datasets_are_tf_asymmetry_compliant(self) -> bool:
+    def check_datasets_are_tf_asymmetry_compliant(self, workspace_names: list = None) -> bool:
         """Returns true if the datasets stored in the model are compatible with TF Asymmetry mode."""
-        pair_names = [get_group_or_pair_from_name(item) for item in self.dataset_names if "Group" not in item]
+        workspace_names = self.dataset_names if workspace_names is None else workspace_names
+        pair_names = [get_group_or_pair_from_name(name) for name in workspace_names if "Group" not in name]
         return len(pair_names) == 0, pair_names
 
     def get_all_fit_functions(self) -> list:

--- a/scripts/Muon/GUI/Common/fitting_widgets/tf_asymmetry_fitting/tf_asymmetry_fitting_model.py
+++ b/scripts/Muon/GUI/Common/fitting_widgets/tf_asymmetry_fitting/tf_asymmetry_fitting_model.py
@@ -129,7 +129,7 @@ class TFAsymmetryFittingModel(GeneralFittingModel):
 
     def recalculate_tf_asymmetry_functions(self) -> bool:
         """Recalculates the TF Asymmetry functions based on the datasets and normal functions in the model."""
-        if self.tf_asymmetry_mode:
+        if self.tf_asymmetry_mode and self.check_datasets_are_tf_asymmetry_compliant():
             try:
                 self._recalculate_tf_asymmetry_functions()
             except RuntimeError:

--- a/scripts/Muon/GUI/Common/fitting_widgets/tf_asymmetry_fitting/tf_asymmetry_fitting_presenter.py
+++ b/scripts/Muon/GUI/Common/fitting_widgets/tf_asymmetry_fitting/tf_asymmetry_fitting_presenter.py
@@ -126,6 +126,11 @@ class TFAsymmetryFittingPresenter(GeneralFittingPresenter):
         else:
             super().update_fit_function_in_model(fit_function)
 
+    def update_dataset_names_in_view_and_model(self):
+        """Updates the datasets currently displayed. TF Asymmetry mode is switched off if the datasets don't comply."""
+        super().update_dataset_names_in_view_and_model()
+        self._check_tf_asymmetry_compliance(self.model.tf_asymmetry_mode)
+
     def update_fit_function_in_view_from_model(self) -> None:
         """Updates the parameters of a fit function shown in the view."""
         super().update_fit_function_in_view_from_model()

--- a/scripts/Muon/GUI/Common/fitting_widgets/tf_asymmetry_fitting/tf_asymmetry_fitting_presenter.py
+++ b/scripts/Muon/GUI/Common/fitting_widgets/tf_asymmetry_fitting/tf_asymmetry_fitting_presenter.py
@@ -144,8 +144,11 @@ class TFAsymmetryFittingPresenter(GeneralFittingPresenter):
 
     def _check_tf_asymmetry_compliance(self, tf_asymmetry_on: bool) -> None:
         """Check that the current datasets are compatible with TF Asymmetry fitting mode."""
-        if tf_asymmetry_on and not self.model.check_datasets_are_tf_asymmetry_compliant():
-            self.view.warning_popup("Only Groups can be fitted in TF Asymmetry mode.")
+        tf_compliant, pair_names = self.model.check_datasets_are_tf_asymmetry_compliant()
+        if tf_asymmetry_on and not tf_compliant:
+            pair_names_str = "'" + "', '".join(pair_names) + "'"
+            self.view.warning_popup(f"Only Groups can be fitted in TF Asymmetry mode. Please unselect the following "
+                                    f"Pairs/Diffs in the grouping tab: {pair_names_str}")
             self._switch_to_normal_fitting()
             return False
         return True

--- a/scripts/Muon/GUI/Common/fitting_widgets/tf_asymmetry_fitting/tf_asymmetry_fitting_presenter.py
+++ b/scripts/Muon/GUI/Common/fitting_widgets/tf_asymmetry_fitting/tf_asymmetry_fitting_presenter.py
@@ -146,8 +146,9 @@ class TFAsymmetryFittingPresenter(GeneralFittingPresenter):
         """Check that the current datasets are compatible with TF Asymmetry fitting mode."""
         tf_compliant, non_compliant_names = self.model.check_datasets_are_tf_asymmetry_compliant()
         if tf_asymmetry_on and not tf_compliant:
-            self.view.warning_popup(f"Only Groups can be fitted in TF Asymmetry mode. Please unselect the following "
-                                    f"Pairs/Diffs in the grouping tab: {non_compliant_names}")
+            self.view.warning_popup(f"Switching to Normal Fitting mode because only Groups can be fitted in TF "
+                                    f"Asymmetry mode. Please unselect the following Pairs/Diffs in the grouping tab: "
+                                    f"{non_compliant_names}")
             self._switch_to_normal_fitting()
             return False
         return True

--- a/scripts/Muon/GUI/Common/fitting_widgets/tf_asymmetry_fitting/tf_asymmetry_fitting_presenter.py
+++ b/scripts/Muon/GUI/Common/fitting_widgets/tf_asymmetry_fitting/tf_asymmetry_fitting_presenter.py
@@ -144,11 +144,10 @@ class TFAsymmetryFittingPresenter(GeneralFittingPresenter):
 
     def _check_tf_asymmetry_compliance(self, tf_asymmetry_on: bool) -> None:
         """Check that the current datasets are compatible with TF Asymmetry fitting mode."""
-        tf_compliant, pair_names = self.model.check_datasets_are_tf_asymmetry_compliant()
+        tf_compliant, non_compliant_names = self.model.check_datasets_are_tf_asymmetry_compliant()
         if tf_asymmetry_on and not tf_compliant:
-            pair_names_str = "'" + "', '".join(pair_names) + "'"
             self.view.warning_popup(f"Only Groups can be fitted in TF Asymmetry mode. Please unselect the following "
-                                    f"Pairs/Diffs in the grouping tab: {pair_names_str}")
+                                    f"Pairs/Diffs in the grouping tab: {non_compliant_names}")
             self._switch_to_normal_fitting()
             return False
         return True

--- a/scripts/Muon/GUI/Common/fitting_widgets/tf_asymmetry_fitting/tf_asymmetry_fitting_presenter.py
+++ b/scripts/Muon/GUI/Common/fitting_widgets/tf_asymmetry_fitting/tf_asymmetry_fitting_presenter.py
@@ -38,11 +38,6 @@ class TFAsymmetryFittingPresenter(GeneralFittingPresenter):
         self._switch_to_normal_fitting()
         super().handle_instrument_changed()
 
-    def handle_selected_group_pair_changed(self) -> None:
-        """Disable TF Asymmetry mode when the selected group/pairs change in the grouping tab."""
-        self._switch_to_normal_fitting()
-        super().handle_selected_group_pair_changed()
-
     def handle_ads_clear_or_remove_workspace_event(self, _: str = None) -> None:
         """Handle when there is a clear or remove workspace event in the ADS."""
         super().handle_ads_clear_or_remove_workspace_event()

--- a/scripts/Muon/GUI/Common/seq_fitting_tab_widget/seq_fitting_tab_presenter.py
+++ b/scripts/Muon/GUI/Common/seq_fitting_tab_widget/seq_fitting_tab_presenter.py
@@ -92,10 +92,11 @@ class SeqFittingTabPresenter(object):
         self.view.fit_table.block_signals(False)
 
     def handle_sequential_fit_requested(self):
-        if self.model.get_active_fit_function() is None or len(self.selected_rows) == 0:
+        workspace_names = [self.get_workspaces_for_row_in_fit_table(row) for row in self.selected_rows]
+
+        if not self.validate_sequential_fit(workspace_names):
             return
 
-        workspace_names = [self.get_workspaces_for_row_in_fit_table(row) for row in self.selected_rows]
         parameter_values = [self.view.fit_table.get_fit_parameter_values_from_row(row) for row in self.selected_rows]
 
         calculation_function = functools.partial(self.model.perform_sequential_fit, workspace_names, parameter_values,
@@ -133,6 +134,25 @@ class SeqFittingTabPresenter(object):
     def handle_updated_fit_parameter_in_table(self, index):
         self._update_parameter_values_in_fitting_model_for_row(index.row())
         self.fit_parameter_changed_notifier.notify_subscribers()
+
+    def validate_sequential_fit(self, workspace_names):
+        if self.model.get_active_fit_function() is None or len(workspace_names) == 0:
+            self.view.warning_popup("No data or fit function selected for fitting.")
+            return False
+
+        if self.model.tf_asymmetry_mode:
+            tf_compliant, pair_names = self.model.check_datasets_are_tf_asymmetry_compliant(
+                self._flatten_workspace_names(workspace_names))
+            if not tf_compliant:
+                pair_names_str = "'" + "', '".join(pair_names) + "'"
+                self.view.warning_popup(f"Only Groups can be fitted in TF Asymmetry mode. Please unselect the "
+                                        f"following Pairs/Diffs in the grouping tab: {pair_names_str}")
+                return False
+        return True
+
+    @staticmethod
+    def _flatten_workspace_names(workspaces: list) -> list:
+        return [workspace for fit_workspaces in workspaces for workspace in fit_workspaces]
 
     def _update_parameter_values_in_fitting_model_for_row(self, row):
         workspaces = self.get_workspaces_for_row_in_fit_table(row)

--- a/scripts/Muon/GUI/Common/seq_fitting_tab_widget/seq_fitting_tab_presenter.py
+++ b/scripts/Muon/GUI/Common/seq_fitting_tab_widget/seq_fitting_tab_presenter.py
@@ -139,15 +139,15 @@ class SeqFittingTabPresenter(object):
         if self.model.get_active_fit_function() is None or len(workspace_names) == 0:
             self.view.warning_popup("No data or fit function selected for fitting.")
             return False
+        else:
+            return self._check_tf_asymmetry_compliance(self._flatten_workspace_names(workspace_names))
 
-        if self.model.tf_asymmetry_mode:
-            tf_compliant, pair_names = self.model.check_datasets_are_tf_asymmetry_compliant(
-                self._flatten_workspace_names(workspace_names))
-            if not tf_compliant:
-                pair_names_str = "'" + "', '".join(pair_names) + "'"
-                self.view.warning_popup(f"Only Groups can be fitted in TF Asymmetry mode. Please unselect the "
-                                        f"following Pairs/Diffs in the grouping tab: {pair_names_str}")
-                return False
+    def _check_tf_asymmetry_compliance(self, workspace_names):
+        tf_compliant, non_compliant_names = self.model.check_datasets_are_tf_asymmetry_compliant(workspace_names)
+        if self.model.tf_asymmetry_mode and not tf_compliant:
+            self.view.warning_popup(f"Only Groups can be fitted in TF Asymmetry mode. Please unselect the following "
+                                    f"Pairs/Diffs in the grouping tab: {non_compliant_names}")
+            return False
         return True
 
     @staticmethod

--- a/scripts/test/Muon/fitting_widgets/tf_asymmetry_fitting/tf_asymmetry_fitting_model_test.py
+++ b/scripts/test/Muon/fitting_widgets/tf_asymmetry_fitting/tf_asymmetry_fitting_model_test.py
@@ -44,8 +44,8 @@ class TFAsymmetryFittingModelTest(unittest.TestCase):
 
     def setUp(self):
         self.model = TFAsymmetryFittingModel(setup_context())
-        self.dataset_names = ["Name1 Group", "Name2 Group"]
-        self.tf_non_compliant_dataset_names = ["Name1 Group", "Name2 Pair"]
+        self.dataset_names = ["EMU20884; Group; fwd; Asymmetry", "EMU20884; Group; top; Asymmetry"]
+        self.tf_non_compliant_dataset_names = ["EMU20884; Group; fwd; Asymmetry", "EMU20884; Pair Asym; long; Asymmetry"]
         self.fit_function = FunctionFactory.createFunction("FlatBackground")
         self.single_fit_functions = [self.fit_function.clone(), self.fit_function.clone()]
         self.simultaneous_fit_function = FunctionFactory.createInitializedMultiDomainFunction(str(self.fit_function),
@@ -150,7 +150,7 @@ class TFAsymmetryFittingModelTest(unittest.TestCase):
         self.assertEqual(str(self.model.tf_asymmetry_simultaneous_function), str(self.tf_simultaneous_fit_function))
 
     def test_that_update_tf_asymmetry_simultaneous_fit_function_will_update_the_current_functions_when_using_one_dataset(self):
-        self.model.dataset_names = ["Name1"]
+        self.model.dataset_names = self.dataset_names[:1]
         self.model._get_normal_fit_function_from = mock.Mock(return_value=self.simultaneous_fit_function)
 
         self.model.update_tf_asymmetry_simultaneous_fit_function(self.tf_simultaneous_fit_function)
@@ -170,7 +170,7 @@ class TFAsymmetryFittingModelTest(unittest.TestCase):
         self.assertEqual(str(self.model.tf_asymmetry_simultaneous_function), str(self.tf_simultaneous_fit_function))
 
     def test_that_get_domain_tf_asymmetry_fit_function_returns_the_correct_function_when_there_is_only_one_dataset(self):
-        self.model.dataset_names = ["Name1"]
+        self.model.dataset_names = self.dataset_names[:1]
         self.assertEqual(str(self.model.get_domain_tf_asymmetry_fit_function(self.tf_single_function, 0)),
                          str(self.tf_single_function))
 
@@ -338,11 +338,19 @@ class TFAsymmetryFittingModelTest(unittest.TestCase):
 
     def test_that_check_datasets_are_tf_asymmetry_compliant_returns_false_if_none_of_the_dataset_names_contains_Group(self):
         self.model.dataset_names = self.tf_non_compliant_dataset_names
-        self.assertTrue(not self.model.check_datasets_are_tf_asymmetry_compliant())
+
+        tf_compliant, non_compliant_names = self.model.check_datasets_are_tf_asymmetry_compliant()
+
+        self.assertTrue(not tf_compliant)
+        self.assertEqual(non_compliant_names, "'long'")
 
     def test_that_check_datasets_are_tf_asymmetry_compliant_returns_true_if_all_of_the_dataset_names_contains_Group(self):
         self.model.dataset_names = self.dataset_names
-        self.assertTrue(self.model.check_datasets_are_tf_asymmetry_compliant())
+
+        tf_compliant, non_compliant_names = self.model.check_datasets_are_tf_asymmetry_compliant()
+
+        self.assertTrue(tf_compliant)
+        self.assertEqual(non_compliant_names, "''")
 
     def test_that_get_fit_function_parameter_values_returns_the_expected_parameter_values(self):
         self.model.dataset_names = self.dataset_names
@@ -396,7 +404,7 @@ class TFAsymmetryFittingModelTest(unittest.TestCase):
         self.model.tf_asymmetry_single_functions = self.tf_single_fit_functions
         self.model.tf_asymmetry_mode = True
 
-        self.model._set_normalisation_for_dataset("Name2 Group", normalisation)
+        self.model._set_normalisation_for_dataset(self.model.dataset_names[1], normalisation)
 
         self.assertEqual(self.model.get_fit_function_parameter_values(self.tf_single_fit_functions[0]),
                          [0.0, 0.0, 0.0, 0.2, 0.2])
@@ -411,7 +419,7 @@ class TFAsymmetryFittingModelTest(unittest.TestCase):
         self.model.simultaneous_fitting_mode = True
         self.model.tf_asymmetry_mode = True
 
-        self.model._set_normalisation_for_dataset("Name2 Group", normalisation)
+        self.model._set_normalisation_for_dataset(self.model.dataset_names[1], normalisation)
 
         self.assertEqual(self.model.get_fit_function_parameter_values(self.model.tf_asymmetry_simultaneous_function),
                          [0.0, 0.0, 0.0, 0.2, 0.2, normalisation, 0.0, 0.0, 0.2, 0.2])
@@ -484,7 +492,7 @@ class TFAsymmetryFittingModelTest(unittest.TestCase):
         self.model.simultaneous_fitting_mode = False
         self.model.tf_asymmetry_mode = True
 
-        self.model._set_normalisation_for_dataset("Name2 Group", normalisation)
+        self.model._set_normalisation_for_dataset(self.model.dataset_names[1], normalisation)
 
         self.assertEqual(self.model.get_all_fit_function_parameter_values_for(
             self.model.tf_asymmetry_single_functions[1]), [normalisation, 0.0])
@@ -497,7 +505,7 @@ class TFAsymmetryFittingModelTest(unittest.TestCase):
         self.model.simultaneous_fitting_mode = True
         self.model.tf_asymmetry_mode = True
 
-        self.model._set_normalisation_for_dataset("Name2 Group", normalisation)
+        self.model._set_normalisation_for_dataset(self.model.dataset_names[1], normalisation)
 
         self.assertEqual(self.model.get_all_fit_function_parameter_values_for(
             self.model.tf_asymmetry_simultaneous_function), [0.0, 0.0, normalisation, 0.0])
@@ -510,7 +518,7 @@ class TFAsymmetryFittingModelTest(unittest.TestCase):
         self.model.simultaneous_fitting_mode = False
         self.model.tf_asymmetry_mode = True
 
-        self.model._set_normalisation_for_dataset("Name2 Group", normalisation)
+        self.model._set_normalisation_for_dataset(self.model.dataset_names[1], normalisation)
 
         self.assertEqual(self.model._get_normalisation_from_tf_fit_function(
             self.model.tf_asymmetry_single_functions[0]), 0.0)
@@ -525,7 +533,7 @@ class TFAsymmetryFittingModelTest(unittest.TestCase):
         self.model.simultaneous_fitting_mode = True
         self.model.tf_asymmetry_mode = True
 
-        self.model._set_normalisation_for_dataset("Name2 Group", normalisation)
+        self.model._set_normalisation_for_dataset(self.model.dataset_names[1], normalisation)
 
         self.assertEqual(self.model._get_normalisation_from_tf_fit_function(
             self.model.tf_asymmetry_simultaneous_function, 0), 0.0)
@@ -597,7 +605,7 @@ class TFAsymmetryFittingModelTest(unittest.TestCase):
         self.model.single_fit_functions = self.single_fit_functions
         self.model.simultaneous_fitting_mode = False
 
-        self.model.update_ws_fit_function_parameters(["Name1 Group"], [1.0])
+        self.model.update_ws_fit_function_parameters(self.model.dataset_names[:1], [1.0])
 
         self.assertEqual(self.model.get_fit_function_parameter_values(self.model.single_fit_functions[0]), [1.0])
         self.assertEqual(self.model.get_fit_function_parameter_values(self.model.single_fit_functions[1]), [0.0])
@@ -607,10 +615,10 @@ class TFAsymmetryFittingModelTest(unittest.TestCase):
         self.model.simultaneous_fit_function = self.simultaneous_fit_function
         self.model.simultaneous_fitting_mode = True
 
-        self.model.update_ws_fit_function_parameters(["Name1 Group"], [1.0, 0.0])
+        self.model.update_ws_fit_function_parameters(self.model.dataset_names[:1], [1.0, 0.0])
         self.assertEqual(self.model.get_fit_function_parameter_values(self.model.simultaneous_fit_function), [1.0, 0.0])
 
-        self.model.update_ws_fit_function_parameters(["Name2 Group"], [1.0, 2.0])
+        self.model.update_ws_fit_function_parameters(self.model.dataset_names[1:], [1.0, 2.0])
         self.assertEqual(self.model.get_fit_function_parameter_values(self.model.simultaneous_fit_function), [1.0, 2.0])
 
     def test_that_update_ws_fit_function_parameters_will_update_the_parameters_when_in_TF_asymmetry_simultaneous_mode(self):
@@ -682,8 +690,8 @@ class TFAsymmetryFittingModelTest(unittest.TestCase):
                           "MUSR3; PhaseQuad; phase2_Im_; MA"], result)
 
     def test_that_perform_sequential_fit_will_call_the_correct_functions_when_not_in_tf_asymmetry_mode(self):
-        workspaces = [["Name1"], ["Name2"]]
-        flattened_workspaces = ["Name1", "Name2"]
+        workspaces = [self.dataset_names[:1], self.dataset_names[1:]]
+        flattened_workspaces = self.dataset_names
         parameter_values = [[0.0], [1.0]]
         functions = ["FakeFunc"]
         fit_statuses = ["Success"]
@@ -708,7 +716,7 @@ class TFAsymmetryFittingModelTest(unittest.TestCase):
             flattened_workspaces, fit_statuses, chi_squared)
 
     def test_that_perform_sequential_fit_will_call_the_correct_functions_when_in_tf_asymmetry_mode(self):
-        workspaces = [["Name1"], ["Name2"]]
+        workspaces = [self.dataset_names[:1], self.dataset_names[1:]]
         parameter_values = [[0.0], [1.0]]
         use_initial_values = True
         functions = ["FakeFunc"]
@@ -739,7 +747,7 @@ class TFAsymmetryFittingModelTest(unittest.TestCase):
         self.assertTrue(self.model._are_same_workspaces_as_the_datasets(self.dataset_names))
 
     def test_that_are_same_workspaces_as_the_datasets_returns_false_if_one_of_the_dataset_names_does_not_match(self):
-        dataset_names = self.dataset_names + ["Name3"]
+        dataset_names = self.dataset_names + ["EMU20884; Group; bottom; Asymmetry"]
         self.model.dataset_names = self.dataset_names
         self.assertTrue(not self.model._are_same_workspaces_as_the_datasets(dataset_names))
 

--- a/scripts/test/Muon/fitting_widgets/tf_asymmetry_fitting/tf_asymmetry_fitting_model_test.py
+++ b/scripts/test/Muon/fitting_widgets/tf_asymmetry_fitting/tf_asymmetry_fitting_model_test.py
@@ -44,7 +44,8 @@ class TFAsymmetryFittingModelTest(unittest.TestCase):
 
     def setUp(self):
         self.model = TFAsymmetryFittingModel(setup_context())
-        self.dataset_names = ["Name1", "Name2"]
+        self.dataset_names = ["Name1 Group", "Name2 Group"]
+        self.tf_non_compliant_dataset_names = ["Name1 Group", "Name2 Pair"]
         self.fit_function = FunctionFactory.createFunction("FlatBackground")
         self.single_fit_functions = [self.fit_function.clone(), self.fit_function.clone()]
         self.simultaneous_fit_function = FunctionFactory.createInitializedMultiDomainFunction(str(self.fit_function),
@@ -97,6 +98,14 @@ class TFAsymmetryFittingModelTest(unittest.TestCase):
         self.model.dataset_names = self.dataset_names
 
         self.assertEqual(self.model.dataset_names, self.dataset_names)
+        self.assertEqual(self.model.tf_asymmetry_single_functions, [None] * self.model.number_of_datasets)
+        self.assertEqual(self.model.tf_asymmetry_simultaneous_function, None)
+
+    def test_that_setting_the_dataset_names_will_recalculate_the_tf_asymmetry_functions_to_be_empty_for_non_compliant_data(self):
+        self.model.tf_asymmetry_mode = True
+        self.model.dataset_names = self.tf_non_compliant_dataset_names
+
+        self.assertEqual(self.model.dataset_names, self.tf_non_compliant_dataset_names)
         self.assertEqual(self.model.tf_asymmetry_single_functions, [None] * self.model.number_of_datasets)
         self.assertEqual(self.model.tf_asymmetry_simultaneous_function, None)
 
@@ -328,11 +337,11 @@ class TFAsymmetryFittingModelTest(unittest.TestCase):
         self.assertEqual(self.model.function_name, " FlatBackground,TFAsymmetry")
 
     def test_that_check_datasets_are_tf_asymmetry_compliant_returns_false_if_none_of_the_dataset_names_contains_Group(self):
-        self.model.dataset_names = self.dataset_names
+        self.model.dataset_names = self.tf_non_compliant_dataset_names
         self.assertTrue(not self.model.check_datasets_are_tf_asymmetry_compliant())
 
     def test_that_check_datasets_are_tf_asymmetry_compliant_returns_true_if_all_of_the_dataset_names_contains_Group(self):
-        self.model.dataset_names = ["Name1_Group", "Name2_Group"]
+        self.model.dataset_names = self.dataset_names
         self.assertTrue(self.model.check_datasets_are_tf_asymmetry_compliant())
 
     def test_that_get_fit_function_parameter_values_returns_the_expected_parameter_values(self):
@@ -387,7 +396,7 @@ class TFAsymmetryFittingModelTest(unittest.TestCase):
         self.model.tf_asymmetry_single_functions = self.tf_single_fit_functions
         self.model.tf_asymmetry_mode = True
 
-        self.model._set_normalisation_for_dataset("Name2", normalisation)
+        self.model._set_normalisation_for_dataset("Name2 Group", normalisation)
 
         self.assertEqual(self.model.get_fit_function_parameter_values(self.tf_single_fit_functions[0]),
                          [0.0, 0.0, 0.0, 0.2, 0.2])
@@ -402,7 +411,7 @@ class TFAsymmetryFittingModelTest(unittest.TestCase):
         self.model.simultaneous_fitting_mode = True
         self.model.tf_asymmetry_mode = True
 
-        self.model._set_normalisation_for_dataset("Name2", normalisation)
+        self.model._set_normalisation_for_dataset("Name2 Group", normalisation)
 
         self.assertEqual(self.model.get_fit_function_parameter_values(self.model.tf_asymmetry_simultaneous_function),
                          [0.0, 0.0, 0.0, 0.2, 0.2, normalisation, 0.0, 0.0, 0.2, 0.2])
@@ -475,7 +484,7 @@ class TFAsymmetryFittingModelTest(unittest.TestCase):
         self.model.simultaneous_fitting_mode = False
         self.model.tf_asymmetry_mode = True
 
-        self.model._set_normalisation_for_dataset("Name2", normalisation)
+        self.model._set_normalisation_for_dataset("Name2 Group", normalisation)
 
         self.assertEqual(self.model.get_all_fit_function_parameter_values_for(
             self.model.tf_asymmetry_single_functions[1]), [normalisation, 0.0])
@@ -488,7 +497,7 @@ class TFAsymmetryFittingModelTest(unittest.TestCase):
         self.model.simultaneous_fitting_mode = True
         self.model.tf_asymmetry_mode = True
 
-        self.model._set_normalisation_for_dataset("Name2", normalisation)
+        self.model._set_normalisation_for_dataset("Name2 Group", normalisation)
 
         self.assertEqual(self.model.get_all_fit_function_parameter_values_for(
             self.model.tf_asymmetry_simultaneous_function), [0.0, 0.0, normalisation, 0.0])
@@ -501,7 +510,7 @@ class TFAsymmetryFittingModelTest(unittest.TestCase):
         self.model.simultaneous_fitting_mode = False
         self.model.tf_asymmetry_mode = True
 
-        self.model._set_normalisation_for_dataset("Name2", normalisation)
+        self.model._set_normalisation_for_dataset("Name2 Group", normalisation)
 
         self.assertEqual(self.model._get_normalisation_from_tf_fit_function(
             self.model.tf_asymmetry_single_functions[0]), 0.0)
@@ -516,7 +525,7 @@ class TFAsymmetryFittingModelTest(unittest.TestCase):
         self.model.simultaneous_fitting_mode = True
         self.model.tf_asymmetry_mode = True
 
-        self.model._set_normalisation_for_dataset("Name2", normalisation)
+        self.model._set_normalisation_for_dataset("Name2 Group", normalisation)
 
         self.assertEqual(self.model._get_normalisation_from_tf_fit_function(
             self.model.tf_asymmetry_simultaneous_function, 0), 0.0)
@@ -588,7 +597,7 @@ class TFAsymmetryFittingModelTest(unittest.TestCase):
         self.model.single_fit_functions = self.single_fit_functions
         self.model.simultaneous_fitting_mode = False
 
-        self.model.update_ws_fit_function_parameters(["Name1"], [1.0])
+        self.model.update_ws_fit_function_parameters(["Name1 Group"], [1.0])
 
         self.assertEqual(self.model.get_fit_function_parameter_values(self.model.single_fit_functions[0]), [1.0])
         self.assertEqual(self.model.get_fit_function_parameter_values(self.model.single_fit_functions[1]), [0.0])
@@ -598,10 +607,10 @@ class TFAsymmetryFittingModelTest(unittest.TestCase):
         self.model.simultaneous_fit_function = self.simultaneous_fit_function
         self.model.simultaneous_fitting_mode = True
 
-        self.model.update_ws_fit_function_parameters(["Name1"], [1.0, 0.0])
+        self.model.update_ws_fit_function_parameters(["Name1 Group"], [1.0, 0.0])
         self.assertEqual(self.model.get_fit_function_parameter_values(self.model.simultaneous_fit_function), [1.0, 0.0])
 
-        self.model.update_ws_fit_function_parameters(["Name2"], [1.0, 2.0])
+        self.model.update_ws_fit_function_parameters(["Name2 Group"], [1.0, 2.0])
         self.assertEqual(self.model.get_fit_function_parameter_values(self.model.simultaneous_fit_function), [1.0, 2.0])
 
     def test_that_update_ws_fit_function_parameters_will_update_the_parameters_when_in_TF_asymmetry_simultaneous_mode(self):
@@ -614,7 +623,7 @@ class TFAsymmetryFittingModelTest(unittest.TestCase):
         self.model.simultaneous_fitting_mode = True
         self.model.tf_asymmetry_mode = True
 
-        self.model.update_ws_fit_function_parameters(["Name1", "Name2"], [normalisation1, param1, normalisation2, param2])
+        self.model.update_ws_fit_function_parameters(self.dataset_names, [normalisation1, param1, normalisation2, param2])
         self.assertEqual(self.model.get_fit_function_parameter_values(self.model.tf_asymmetry_simultaneous_function),
                          [normalisation1, 0.0, param1, 0.2, 0.2, normalisation2, 0.0, param2, 0.2, 0.2])
 

--- a/scripts/test/Muon/fitting_widgets/tf_asymmetry_fitting/tf_asymmetry_fitting_presenter_test.py
+++ b/scripts/test/Muon/fitting_widgets/tf_asymmetry_fitting/tf_asymmetry_fitting_presenter_test.py
@@ -157,14 +157,6 @@ class TFAsymmetryFittingPresenterTest(unittest.TestCase):
         self.assertEqual(self.mock_view_tf_asymmetry_mode.call_count, 2)
         self.assertEqual(self.mock_model_tf_asymmetry_mode.call_count, 2)
 
-    def test_that_handle_selected_group_pair_changed_will_turn_off_tf_asymmetry_mode(self):
-        self.presenter.handle_selected_group_pair_changed()
-
-        self.mock_view_tf_asymmetry_mode.assert_called_with(False)
-        self.mock_model_tf_asymmetry_mode.assert_called_with(False)
-        self.assertEqual(self.mock_view_tf_asymmetry_mode.call_count, 2)
-        self.assertEqual(self.mock_model_tf_asymmetry_mode.call_count, 2)
-
     def test_that_handle_function_structure_changed_will_attempt_to_update_the_tf_asymmetry_functions(self):
         self.presenter.update_tf_asymmetry_functions_in_model_and_view = mock.Mock()
 

--- a/scripts/test/Muon/seq_fitting_tab_widget/seq_fitting_tab_presenter_test.py
+++ b/scripts/test/Muon/seq_fitting_tab_widget/seq_fitting_tab_presenter_test.py
@@ -99,12 +99,13 @@ class SeqFittingTabPresenterTest(unittest.TestCase):
         parameter_values = [0.2, 0.1, 0, 0]
         self.view.fit_table.get_selected_rows = mock.MagicMock(return_value=[0])
         self._setup_test_fit_function([0.2, 0.1, 0, 0])
-        self.presenter.get_workspaces_for_row_in_fit_table = mock.MagicMock(return_value=workspace)
+        self.presenter.get_workspaces_for_row_in_fit_table = mock.MagicMock(return_value=[workspace])
         self.view.fit_table.get_fit_parameter_values_from_row = mock.MagicMock(return_value=parameter_values)
+        self.model.check_datasets_are_tf_asymmetry_compliant = mock.MagicMock(return_value=(True, ""))
 
         self.presenter.handle_fit_selected_pressed()
 
-        mock_function_tools.partial.assert_called_once_with(self.model.perform_sequential_fit, [workspace],
+        mock_function_tools.partial.assert_called_once_with(self.model.perform_sequential_fit, [[workspace]],
                                                             [parameter_values], False)
 
     @mock.patch('Muon.GUI.Common.seq_fitting_tab_widget.seq_fitting_tab_presenter.functools')
@@ -148,6 +149,7 @@ class SeqFittingTabPresenterTest(unittest.TestCase):
         self.view.fit_table.get_number_of_fits = mock.MagicMock(return_value=number_of_entries)
         self.view.fit_table.get_fit_parameter_values_from_row = mock.Mock(return_value=parameters_values)
         self.presenter.get_workspaces_for_row_in_fit_table = mock.MagicMock(return_value=workspaces)
+        self.model.check_datasets_are_tf_asymmetry_compliant = mock.MagicMock(return_value=(True, ""))
 
         self.presenter.handle_sequential_fit_pressed()
 


### PR DESCRIPTION
**Description of work.**
This PR fixes a bug where the fitting tab would get confused in Muon Analysis after the dataset names combobox is updated and contains a pair when in TF Asymmety mode. The solution is to check the TF Asymmetry mode compliance when loading new datasets, and then to display a warning dialog and switch to normal fitting mode if there are any pairs or diffs.

**To test:**
See the intructions in the issue. Instead of an error in the log, you should see a popup warning saying that only groups are allowed to be fitted in TF Asymmetry mode. When you click ok, the fitting mode is changed to Normal.

Fixes #31411 

*No release notes required as this is related to the refactor that occurred recently in Muon*

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
