### PR TITLE
Muon Analysis & FDA - Ensure the ordering of workspace names is same

### DIFF
--- a/docs/source/release/v6.2.0/muon.rst
+++ b/docs/source/release/v6.2.0/muon.rst
@@ -10,3 +10,11 @@ MuSR Changes
     improvements, followed by bug fixes.
 
 :ref:`Release 6.2.0 <v6.2.0>`
+
+
+Muon Analysis 2 and Frequency Domain Analysis
+---------------------------------------------
+
+Improvements
+############
+- There is now a consistent ordering of workspace names when comparing the grouping tab to the fitting tab and plot window.

--- a/scripts/Muon/GUI/Common/contexts/data_analysis_context.py
+++ b/scripts/Muon/GUI/Common/contexts/data_analysis_context.py
@@ -16,30 +16,21 @@ class DataAnalysisContext(MuonContext):
         self.workspace_suffix = ' MA'
         self.base_directory = 'Muon Data'
 
-    def get_names_of_workspaces_to_fit(
-            self, runs='', group_and_pair='', rebin=False, freq="None"):
-        return self.get_names_of_time_domain_workspaces_to_fit(
-            runs=runs, group_and_pair=group_and_pair, rebin=rebin)
-
-    def get_names_of_time_domain_workspaces_to_fit(
-            self, runs='', group_and_pair='', rebin=False):
-        group, pair = self.get_group_and_pair(group_and_pair)
-
-        if runs.find(',') != -1 or runs.find('-') != -1:
-            # Can assume to be all as if found then must be using co-add which is all runs
-            runs = 'All'
-        run_list = self.get_runs(runs)
-
-        group_names = self.group_pair_context.get_group_workspace_names(
-            run_list, group, rebin)
-        pair_names = self.group_pair_context.get_pair_workspace_names(
-            run_list, pair, rebin)
-
-        return group_names + pair_names
+    def get_workspace_names_of_fit_data_with_run(self, run: int, group_and_pair: str) -> list:
+        """Returns the workspace names of the data to fit with the provided run and group/pair."""
+        return self.get_workspace_names_of_data_with_run(run, group_and_pair)
 
     @property
     def default_fitting_plot_range(self):
         return self.default_data_plot_range
+
+    @property
+    def default_end_x(self):
+        return 15.0
+
+    @property
+    def guess_workspace_prefix(self):
+        return "__muon_analysis_fitting_guess"
 
     @property
     def window_title(self):

--- a/scripts/Muon/GUI/Common/contexts/frequency_domain_analysis_context.py
+++ b/scripts/Muon/GUI/Common/contexts/frequency_domain_analysis_context.py
@@ -29,25 +29,25 @@ class FrequencyDomainAnalysisContext(MuonContext):
     def default_fitting_plot_range(self):
         return self._freq_plotting_context.default_xlims
 
+    @property
+    def default_end_x(self):
+        return 250.0
+
+    @property
+    def guess_workspace_prefix(self):
+        return "__frequency_domain_analysis_fitting_guess"
+
     def get_workspace_names_for_FFT_analysis(self, use_raw=True):
         groups_and_pairs = ','.join(self.group_pair_context.selected_groups_and_pairs)
         workspace_options = self.get_names_of_time_domain_workspaces_to_fit(
             runs='All', group_and_pair=groups_and_pairs, rebin=not use_raw)
         return workspace_options
 
-    def get_names_of_workspaces_to_fit(self, runs='', group_and_pair='',
-                                       phasequad=False, rebin=False, freq="None"):
-
-        return self.get_names_of_frequency_domain_workspaces_to_fit(
-            runs=runs, group_and_pair=group_and_pair, frequency_type=freq)
-
-    def get_names_of_frequency_domain_workspaces_to_fit(
-            self, runs='', group_and_pair='', frequency_type="None"):
+    def get_workspace_names_of_fit_data_with_run(self, run: int, group_and_pair: str) -> list:
+        """Returns the workspace names of the data to fit with the provided run and group/pair."""
         group, pair = self.get_group_and_pair(group_and_pair)
-        run_list = self.get_runs(runs)
-        names = self._frequency_context.get_frequency_workspace_names(
-            run_list, group, pair, frequency_type)
-        return names
+        return self._frequency_context.get_frequency_workspace_names([run], group, pair,
+                                                                     self._frequency_context.plot_type)
 
     def get_names_of_time_domain_workspaces_to_fit(
             self, runs='', group_and_pair='', rebin=False):

--- a/scripts/Muon/GUI/Common/contexts/muon_context.py
+++ b/scripts/Muon/GUI/Common/contexts/muon_context.py
@@ -530,6 +530,40 @@ class MuonContext(object):
 
         return equivalent_list
 
+    def get_indices_to_reorder_workspace_names(self, unordered_names: list) -> list:
+        """Returns a list of indices used to reorder the provided names to match the order seen in the grouping tab."""
+        ordered_names = self.get_all_workspace_names_of_data()
+        order = []
+        for name1 in unordered_names:
+            for name2 in ordered_names:
+                if name2 in name1:
+                    order.append(ordered_names.index(name2))
+                    break
+        return order
+
+    def get_all_workspace_names_of_data(self) -> list:
+        """Returns the names of all workspaces loaded into the interface including non-selected workspaces."""
+        return self.get_workspace_names_for("All", self.group_pair_context.all_group_pair_and_diff_names,
+                                            self.get_workspace_names_of_data_with_run)
+
+    def get_workspace_names_for(self, runs: str, groups_and_pairs: list, get_workspace_names) -> list:
+        """Returns the workspace names for the provided runs and groups/pairs using a specific function."""
+        workspace_names = []
+        for run in self.get_runs(runs):
+            for group_and_pair in groups_and_pairs:
+                workspace_names += get_workspace_names(run, group_and_pair)
+
+        return workspace_names
+
+    def get_workspace_names_of_data_with_run(self, run: int, group_and_pair: str):
+        """Returns the workspace names of the loaded data with the provided run and group/pair."""
+        group, pair = self.get_group_and_pair(group_and_pair)
+
+        group_names = self.group_pair_context.get_group_workspace_names([run], group, not self.fitting_context.fit_raw)
+        pair_names = self.group_pair_context.get_pair_workspace_names([run], pair, not self.fitting_context.fit_raw)
+
+        return group_names + pair_names
+
     def remove_workspace(self, workspace):
         # required as the renameHandler returns a name instead of a workspace.
         if isinstance(workspace, str):

--- a/scripts/Muon/GUI/Common/contexts/muon_group_pair_context.py
+++ b/scripts/Muon/GUI/Common/contexts/muon_group_pair_context.py
@@ -155,20 +155,28 @@ class MuonGroupPairContext(object):
         return self.groups + self.pairs + self.diffs
 
     @property
-    def selected_pairs(self):
-        return self._selected_pairs
+    def all_group_pair_and_diff_names(self):
+        """Returns the names of all the groups, pairs and diffs in the order that they are displayed."""
+        return [item.name for item in self.all_groups_and_pairs]
 
     @property
-    def selected_groups(self):
-        return self._selected_groups
+    def selected_groups(self) -> list:
+        """Returns the selected group names. Ensures the order of the returned group names is correct."""
+        return [group.name for group in self.groups if group.name in self._selected_groups]
 
     @property
-    def selected_diffs(self):
-        return self._selected_diffs
+    def selected_pairs(self) -> list:
+        """Returns the selected pair names. Ensures the order of the returned pair names is correct."""
+        return [pair.name for pair in self.pairs if pair.name in self._selected_pairs]
+
+    @property
+    def selected_diffs(self) -> list:
+        """Returns the selected diff names. Ensures the order of the returned diff names is correct."""
+        return [diff.name for diff in self.diffs if diff.name in self._selected_diffs]
 
     @property
     def selected_groups_and_pairs(self):
-        return self.selected_groups+self.selected_pairs+self.selected_diffs
+        return self.selected_groups + self.selected_pairs + self.selected_diffs
 
     def clear(self):
         self.clear_groups()

--- a/scripts/Muon/GUI/Common/fitting_tab_widget/fitting_tab_widget.py
+++ b/scripts/Muon/GUI/Common/fitting_tab_widget/fitting_tab_widget.py
@@ -25,11 +25,11 @@ class FittingTabWidget(object):
 
         if is_frequency_domain:
             self.fitting_tab_view = GeneralFittingView(parent, is_frequency_domain)
-            self.fitting_tab_model = GeneralFittingModel(context, is_frequency_domain)
+            self.fitting_tab_model = GeneralFittingModel(context)
             self.fitting_tab_presenter = GeneralFittingPresenter(self.fitting_tab_view, self.fitting_tab_model)
         else:
             self.fitting_tab_view = TFAsymmetryFittingView(parent, is_frequency_domain)
-            self.fitting_tab_model = TFAsymmetryFittingModel(context, is_frequency_domain)
+            self.fitting_tab_model = TFAsymmetryFittingModel(context)
             self.fitting_tab_presenter = TFAsymmetryFittingPresenter(self.fitting_tab_view, self.fitting_tab_model)
 
         self.fitting_tab_presenter.disable_fitting_notifier.add_subscriber(self.fitting_tab_view.disable_tab_observer)

--- a/scripts/Muon/GUI/Common/fitting_widgets/basic_fitting/basic_fitting_model.py
+++ b/scripts/Muon/GUI/Common/fitting_widgets/basic_fitting/basic_fitting_model.py
@@ -6,7 +6,7 @@
 # SPDX - License - Identifier: GPL - 3.0 +
 from mantid import AlgorithmManager, logger
 from mantid.api import CompositeFunction, IAlgorithm, IFunction
-from mantid.simpleapi import CopyLogs, EvaluateFunction, RenameWorkspace
+from mantid.simpleapi import CopyLogs, EvaluateFunction
 
 from Muon.GUI.Common.ADSHandler.workspace_naming import create_fitted_workspace_name, create_parameter_table_name
 from Muon.GUI.Common.ADSHandler.muon_workspace_wrapper import MuonWorkspaceWrapper
@@ -22,13 +22,6 @@ DEFAULT_CHI_SQUARED = 0.0
 DEFAULT_FIT_STATUS = None
 DEFAULT_SINGLE_FIT_FUNCTION = None
 DEFAULT_START_X = 0.0
-DEFAULT_FDA_END_X = 250.0
-DEFAULT_MA_END_X = 15.0
-
-FDA_GUESS_WORKSPACE = "__frequency_domain_analysis_fitting_guess"
-MA_GUESS_WORKSPACE = "__muon_analysis_fitting_guess"
-FDA_SUFFIX = " FD"
-MA_SUFFIX = " MA"
 
 
 def get_function_name_for_composite(composite: CompositeFunction) -> str:
@@ -54,11 +47,9 @@ class BasicFittingModel:
     The BasicFittingModel stores the datasets, start Xs, end Xs, fit statuses and chi squared for Single Fitting.
     """
 
-    def __init__(self, context: MuonContext, is_frequency_domain: bool = False):
+    def __init__(self, context: MuonContext):
         """Initializes the model with empty fit data."""
         self.context = context
-
-        self._default_end_x = DEFAULT_FDA_END_X if is_frequency_domain else DEFAULT_MA_END_X
 
         self._current_dataset_index = None
         self._dataset_names = []
@@ -180,7 +171,7 @@ class BasicFittingModel:
         if self.current_dataset_index is not None:
             return self.end_xs[self.current_dataset_index]
         else:
-            return self._default_end_x
+            return self.context.default_end_x
 
     @current_end_x.setter
     def current_end_x(self, value: float) -> None:
@@ -700,20 +691,12 @@ class BasicFittingModel:
         alg.setProperty("Minimizer", self.minimizer)
         alg.setProperty("EvaluationType", self.evaluation_type)
         alg.setProperty("MaxIterations", 0)
-        alg.setProperty("Output", "__double_pulse_guess")
+        alg.setProperty("Output", output_workspace)
         alg.execute()
-
-        self.context.ads_observer.observeRename(False)
-        RenameWorkspace(InputWorkspace=alg.getPropertyValue("OutputWorkspace"),
-                        OutputWorkspace=output_workspace)
-        self.context.ads_observer.observeRename(True)
 
     def _get_plot_guess_name(self) -> str:
         """Returns the name to use for the plot guess workspace."""
-        if self.context.workspace_suffix == MA_SUFFIX:
-            return MA_GUESS_WORKSPACE + self.current_dataset_name
-        else:
-            return FDA_GUESS_WORKSPACE + self.current_dataset_name
+        return self.context.guess_workspace_prefix + self.current_dataset_name
 
     def _get_plot_guess_fit_function(self) -> IFunction:
         """Returns the fit function to evaluate when plotting a guess."""

--- a/scripts/Muon/GUI/Common/fitting_widgets/general_fitting/general_fitting_model.py
+++ b/scripts/Muon/GUI/Common/fitting_widgets/general_fitting/general_fitting_model.py
@@ -9,8 +9,7 @@ from mantid.simpleapi import RenameWorkspace, CopyLogs
 
 from Muon.GUI.Common.ADSHandler.workspace_naming import (create_fitted_workspace_name,
                                                          create_multi_domain_fitted_workspace_name,
-                                                         create_parameter_table_name, get_group_or_pair_from_name,
-                                                         get_run_number_from_workspace_name,
+                                                         create_parameter_table_name,
                                                          get_run_numbers_as_string_from_workspace_name)
 from Muon.GUI.Common.contexts.muon_context import MuonContext
 from Muon.GUI.Common.fitting_widgets.basic_fitting.basic_fitting_model import BasicFittingModel
@@ -22,13 +21,9 @@ class GeneralFittingModel(BasicFittingModel):
     The GeneralFittingModel derives from BasicFittingModel. It adds the ability to do simultaneous fitting.
     """
 
-    def __init__(self, context: MuonContext, is_frequency_domain: bool = False):
+    def __init__(self, context: MuonContext):
         """Initialize the GeneralFittingModel with emtpy fit data."""
-        super(GeneralFittingModel, self).__init__(context, is_frequency_domain)
-
-        self._x_data_type = self.context._frequency_context.plot_type if is_frequency_domain else "None"
-
-        self._group_or_pair_index = {}
+        super(GeneralFittingModel, self).__init__(context)
 
         # This is a MultiDomainFunction if there are multiple domains in the function browser.
         self._simultaneous_fit_function = None
@@ -221,12 +216,10 @@ class GeneralFittingModel(BasicFittingModel):
     def get_workspace_names_to_display_from_context(self) -> list:
         """Returns the workspace names to display in the view based on the selected run and group/pair options."""
         runs, groups_and_pairs = self.get_selected_runs_groups_and_pairs()
+        workspace_names = self.context.get_workspace_names_for(runs, groups_and_pairs,
+                                                               self.context.get_workspace_names_of_fit_data_with_run)
 
-        display_workspaces = []
-        for group_and_pair in groups_and_pairs:
-            display_workspaces += self._get_workspace_names_to_display_from_context(runs, group_and_pair)
-
-        return self._sort_workspace_names(display_workspaces)
+        return self._check_data_exists(workspace_names)
 
     def get_fit_function_parameters(self) -> list:
         """Returns the names of the fit parameters in the fit functions."""
@@ -304,37 +297,6 @@ class GeneralFittingModel(BasicFittingModel):
         workspace_list = self.context.data_context.current_data["OutputWorkspace"]
         return [get_run_numbers_as_string_from_workspace_name(workspace.workspace_name, instrument)
                 for workspace in workspace_list]
-
-    def _get_workspace_names_to_display_from_context(self, runs: list, group_and_pair: str) -> list:
-        """Returns the workspace names for the given runs and group/pair to be displayed in the view."""
-        return self.context.get_names_of_workspaces_to_fit(runs=runs, group_and_pair=group_and_pair,
-                                                           rebin=not self.fit_to_raw, freq=self._x_data_type)
-
-    def _sort_workspace_names(self, workspace_names: list) -> list:
-        """Sort the workspace names and check the workspaces exist in the ADS."""
-        workspace_names = list(set(self._check_data_exists(workspace_names)))
-        if len(workspace_names) > 1:
-            workspace_names.sort(key=self._workspace_list_sorter)
-        return workspace_names
-
-    def _workspace_list_sorter(self, workspace_name: str) -> int:
-        """Used to sort a list of workspace names based on run number and group/pair name."""
-        run_number = get_run_number_from_workspace_name(workspace_name, self.context.data_context.instrument)
-        grp_pair_number = self._transform_group_or_pair_to_float(workspace_name)
-        return int(run_number) + grp_pair_number
-
-    def _transform_group_or_pair_to_float(self, workspace_name: str) -> int:
-        """Converts the workspace group or pair name to a float which is used in sorting the workspace list."""
-        group_or_pair_name = get_group_or_pair_from_name(workspace_name)
-        if group_or_pair_name not in self._group_or_pair_index:
-            self._group_or_pair_index[group_or_pair_name] = len(self._group_or_pair_index)
-
-        group_or_pair_values = list(self._group_or_pair_index.values())
-        if len(self._group_or_pair_index) > 1:
-            return ((self._group_or_pair_index[group_or_pair_name] - group_or_pair_values[0])
-                    / (group_or_pair_values[-1] - group_or_pair_values[0])) * 0.99
-        else:
-            return 0
 
     @staticmethod
     def _check_data_exists(workspace_names: list) -> list:

--- a/scripts/Muon/GUI/Common/fitting_widgets/tf_asymmetry_fitting/tf_asymmetry_fitting_model.py
+++ b/scripts/Muon/GUI/Common/fitting_widgets/tf_asymmetry_fitting/tf_asymmetry_fitting_model.py
@@ -33,9 +33,9 @@ class TFAsymmetryFittingModel(GeneralFittingModel):
     The TFAsymmetryFittingModel derives from GeneralFittingModel. It adds the ability to do TF Asymmetry fitting.
     """
 
-    def __init__(self, context: MuonContext, is_frequency_domain: bool = False):
+    def __init__(self, context: MuonContext):
         """Initialize the TFAsymmetryFittingModel with emtpy fit data."""
-        super(TFAsymmetryFittingModel, self).__init__(context, is_frequency_domain)
+        super(TFAsymmetryFittingModel, self).__init__(context)
 
         self._tf_asymmetry_mode = False
         self._tf_asymmetry_single_functions = []

--- a/scripts/Muon/GUI/Common/plot_widget/plotting_canvas/plotting_canvas_model.py
+++ b/scripts/Muon/GUI/Common/plot_widget/plotting_canvas/plotting_canvas_model.py
@@ -7,7 +7,6 @@
 from typing import NamedTuple, List
 from Muon.GUI.Common.ADSHandler.workspace_naming import *
 from Muon.GUI.Common.contexts.muon_context import MuonContext
-from Muon.GUI.Common.fitting_widgets.basic_fitting.basic_fitting_model import MA_GUESS_WORKSPACE, FDA_GUESS_WORKSPACE
 
 FIT_FUNCTION_GUESS_LABEL = "Fit function guess"
 
@@ -173,7 +172,4 @@ class PlottingCanvasModel(object):
         return label
 
     def _is_guess_workspace(self, workspace_name):
-        if MA_GUESS_WORKSPACE in workspace_name or FDA_GUESS_WORKSPACE in workspace_name:
-            return True
-        else:
-            return False
+        return self._context.guess_workspace_prefix in workspace_name

--- a/scripts/Muon/GUI/Common/plot_widget/plotting_canvas/plotting_canvas_widget.py
+++ b/scripts/Muon/GUI/Common/plot_widget/plotting_canvas/plotting_canvas_widget.py
@@ -17,7 +17,7 @@ class PlottingCanvasWidget(object):
 
         self._figure_options = QuickEditWidget(context.plotting_context, parent)
         self._plotting_view = PlottingCanvasView(self._figure_options.widget, context.plotting_context.min_y_range,
-                                                 context.plotting_context.y_axis_margin, parent)
+                                                 context.plotting_context.y_axis_margin, context, parent=parent)
         self._model = PlottingCanvasModel(context)
         self._presenter = PlottingCanvasPresenter(self._plotting_view, self._model, self._figure_options,
                                                   context.plotting_context)

--- a/scripts/test/Muon/fitting_widgets/basic_fitting/basic_fitting_model_test.py
+++ b/scripts/test/Muon/fitting_widgets/basic_fitting/basic_fitting_model_test.py
@@ -398,6 +398,7 @@ class BasicFittingModelTest(unittest.TestCase):
         self.assertEqual(self.model.get_active_fit_results(), [])
 
     def test_update_plot_guess_will_evaluate_the_function(self):
+        guess_workspace_name = "__frequency_domain_analysis_fitting_guessName1"
         self.model.dataset_names = self.dataset_names
         self.model.single_fit_functions = self.single_fit_functions
         self.model.start_xs = [0.0, 1.0]
@@ -406,6 +407,7 @@ class BasicFittingModelTest(unittest.TestCase):
 
         self.model.context = mock.Mock()
         self.model._double_pulse_enabled = mock.Mock(return_value=False)
+        self.model._get_plot_guess_name = mock.Mock(return_value=guess_workspace_name)
         with mock.patch('Muon.GUI.Common.fitting_widgets.basic_fitting.basic_fitting_model.EvaluateFunction') as mock_evaluate:
             self.model._get_guess_parameters = mock.Mock(return_value=['func', 'ws'])
             self.model.update_plot_guess(True)
@@ -413,7 +415,7 @@ class BasicFittingModelTest(unittest.TestCase):
                                              Function=self.model.current_single_fit_function,
                                              StartX=self.model.current_start_x,
                                              EndX=self.model.current_end_x,
-                                             OutputWorkspace="__frequency_domain_analysis_fitting_guessName1")
+                                             OutputWorkspace=guess_workspace_name)
 
     @mock.patch('Muon.GUI.Common.fitting_widgets.basic_fitting.basic_fitting_model.EvaluateFunction')
     def test_update_plot_guess_notifies_subscribers_with_the_guess_workspace_name_if_plot_guess_is_true(self, mock_evaluate):
@@ -426,7 +428,9 @@ class BasicFittingModelTest(unittest.TestCase):
 
         self.model.context = mock.Mock()
         self.model._double_pulse_enabled = mock.Mock(return_value=False)
+        self.model._get_plot_guess_name = mock.Mock(return_value=guess_workspace_name)
         self.model.update_plot_guess(True)
+
         mock_evaluate.assert_called_with(InputWorkspace=self.model.current_dataset_name,
                                          Function=self.model.current_single_fit_function,
                                          StartX=self.model.current_start_x,
@@ -449,6 +453,7 @@ class BasicFittingModelTest(unittest.TestCase):
         self.model.context.fitting_context.notify_plot_guess_changed.assert_called_with(False, None)
 
     def test_update_plot_guess_will_evaluate_the_function_when_in_double_fit_mode(self):
+        guess_workspace_name = "__frequency_domain_analysis_fitting_guessName1"
         self.model.dataset_names = self.dataset_names
         self.model.single_fit_functions = self.single_fit_functions
         self.model.start_xs = [0.0, 1.0]
@@ -458,12 +463,13 @@ class BasicFittingModelTest(unittest.TestCase):
         self.model.context = mock.Mock()
         self.model._double_pulse_enabled = mock.Mock(return_value=True)
         self.model._get_guess_parameters = mock.Mock(return_value=['func', 'ws'])
+        self.model._get_plot_guess_name = mock.Mock(return_value=guess_workspace_name)
         self.model._evaluate_double_pulse_function = mock.Mock()
 
         self.model.update_plot_guess(True)
 
         self.model._evaluate_double_pulse_function.assert_called_once_with(
-            self.model.current_single_fit_function, "__frequency_domain_analysis_fitting_guessName1")
+            self.model.current_single_fit_function, guess_workspace_name)
 
     def test_perform_fit_will_call_the_correct_function_for_a_single_fit(self):
         self.model.dataset_names = self.dataset_names

--- a/scripts/test/Muon/fitting_widgets/general_fitting/general_fitting_model_test.py
+++ b/scripts/test/Muon/fitting_widgets/general_fitting/general_fitting_model_test.py
@@ -7,7 +7,8 @@
 import unittest
 from unittest import mock
 
-from mantid.api import CompositeFunction, FrameworkManager, FunctionFactory
+from mantid.api import AnalysisDataService, CompositeFunction, FrameworkManager, FunctionFactory
+from mantid.simpleapi import CreateSampleWorkspace
 
 from Muon.GUI.Common.fitting_widgets.general_fitting.general_fitting_model import GeneralFittingModel
 from Muon.GUI.Common.test_helpers.context_setup import setup_context
@@ -268,61 +269,51 @@ class GeneralFittingModelTest(unittest.TestCase):
     def test_that_get_simultaneous_fit_by_specifiers_to_display_from_context_returns_an_empty_list_if_fit_by_is_not_specified(self):
         self.assertEqual(self.model.get_simultaneous_fit_by_specifiers_to_display_from_context(), [])
 
-    @mock.patch('Muon.GUI.Common.fitting_widgets.general_fitting.general_fitting_model.GeneralFittingModel.'
-                '_get_workspace_names_to_display_from_context')
-    @mock.patch('Muon.GUI.Common.fitting_widgets.general_fitting.general_fitting_model.GeneralFittingModel.'
-                '_sort_workspace_names')
-    def test_that_get_workspace_names_to_display_from_context_will_attempt_to_get_runs_and_groups_for_single_fit_mode(self,
-                                                                                                                      mock_sort,
-                                                                                                                      mock_get_workspaces):
+    def test_that_get_workspace_names_to_display_from_context_will_attempt_to_get_runs_and_groups_for_single_fit_mode(self):
         workspace_names = ["Name"]
+        workspace = CreateSampleWorkspace()
+        AnalysisDataService.addOrReplace("Name", workspace)
         runs = ["62260"]
-        group_or_pair = "long"
+        group_or_pair = ["long"]
         self.model.simultaneous_fitting_mode = False
 
         self.model._get_selected_runs_groups_and_pairs_for_single_fit_mode = \
-            mock.MagicMock(return_value=(runs, [group_or_pair]))
+            mock.MagicMock(return_value=(runs, group_or_pair))
 
-        mock_get_workspaces.return_value = workspace_names
-        mock_sort.return_value = workspace_names
+        self.model.context.get_workspace_names_for = mock.MagicMock(return_value=workspace_names)
+        self.model.context.get_workspace_names_of_fit_data_with_run = mock.MagicMock()
 
         self.assertEqual(self.model.get_workspace_names_to_display_from_context(), workspace_names)
 
         self.model._get_selected_runs_groups_and_pairs_for_single_fit_mode.assert_called_with()
-        mock_get_workspaces.assert_called_with(runs, group_or_pair)
-        mock_sort.assert_called_with(workspace_names)
+        self.model.context.get_workspace_names_for.assert_called_with(runs, group_or_pair,
+                                                                      self.model.context.get_workspace_names_of_fit_data_with_run)
 
         self.assertEqual(1, self.model._get_selected_runs_groups_and_pairs_for_single_fit_mode.call_count)
-        self.assertEqual(1, mock_get_workspaces.call_count)
-        self.assertEqual(1, mock_sort.call_count)
+        self.assertEqual(1, self.model.context.get_workspace_names_for.call_count)
 
-    @mock.patch('Muon.GUI.Common.fitting_widgets.general_fitting.general_fitting_model.GeneralFittingModel.'
-                '_get_workspace_names_to_display_from_context')
-    @mock.patch('Muon.GUI.Common.fitting_widgets.general_fitting.general_fitting_model.GeneralFittingModel.'
-                '_sort_workspace_names')
-    def test_that_get_workspace_names_to_display_will_attempt_to_get_runs_and_groups_for_simultaneous_fit_mode(self,
-                                                                                                               mock_sort,
-                                                                                                               mock_get_workspaces):
+    def test_that_get_workspace_names_to_display_will_attempt_to_get_runs_and_groups_for_simultaneous_fit_mode(self):
         workspace_names = ["Name"]
+        workspace = CreateSampleWorkspace()
+        AnalysisDataService.addOrReplace("Name", workspace)
         runs = ["62260"]
-        group_or_pair = "long"
+        group_or_pair = ["long"]
         self.model.simultaneous_fitting_mode = True
 
         self.model._get_selected_runs_groups_and_pairs_for_simultaneous_fit_mode = \
-            mock.MagicMock(return_value=(runs, [group_or_pair]))
+            mock.MagicMock(return_value=(runs, group_or_pair))
 
-        mock_get_workspaces.return_value = workspace_names
-        mock_sort.return_value = workspace_names
+        self.model.context.get_workspace_names_for = mock.MagicMock(return_value=workspace_names)
+        self.model.context.get_workspace_names_of_fit_data_with_run = mock.MagicMock()
 
         self.assertEqual(self.model.get_workspace_names_to_display_from_context(), workspace_names)
 
         self.model._get_selected_runs_groups_and_pairs_for_simultaneous_fit_mode.assert_called_with()
-        mock_get_workspaces.assert_called_with(runs, group_or_pair)
-        mock_sort.assert_called_with(workspace_names)
+        self.model.context.get_workspace_names_for.assert_called_with(runs, group_or_pair,
+                                                                      self.model.context.get_workspace_names_of_fit_data_with_run)
 
         self.assertEqual(1, self.model._get_selected_runs_groups_and_pairs_for_simultaneous_fit_mode.call_count)
-        self.assertEqual(1, mock_get_workspaces.call_count)
-        self.assertEqual(1, mock_sort.call_count)
+        self.assertEqual(1, self.model.context.get_workspace_names_for.call_count)
 
     def test_that_get_selected_runs_groups_and_pairs_will_attempt_to_get_runs_and_groups_for_simultaneous_fit_mode(self):
         runs = ["62260"]

--- a/scripts/test/Muon/muon_context_test.py
+++ b/scripts/test/Muon/muon_context_test.py
@@ -285,23 +285,31 @@ class MuonContextTest(unittest.TestCase):
 
         self.assertEqual(deadtime_table, 'deadtime_table_name')
 
-    def test_get_workspace_names_returns_all_stored_workspaces_if_all_selected(self):
+    def test_get_all_workspace_names_of_data_returns_all_stored_workspaces_if_all_selected(self):
         self.populate_ADS()
-        workspace_list = self.context.get_names_of_workspaces_to_fit('19489', 'fwd, bwd, long')
+        workspace_list = self.context.get_all_workspace_names_of_data()
 
         self.assertEqual(Counter(workspace_list),
                          Counter(['EMU19489; Group; fwd; Asymmetry; MA', 'EMU19489; Group; bwd; Asymmetry; MA',
                                   'EMU19489; Pair Asym; long; MA']))
 
-    def test_get_workspace_names_returns_nothing_if_no_parameters_passed(self):
+    def test_get_workspace_names_for_returns_the_expected_data_names_for_the_provided_arguments(self):
         self.populate_ADS()
-        workspace_list = self.context.get_names_of_workspaces_to_fit()
+        workspace_list = self.context.get_workspace_names_for("19489", ["fwd", "long"],
+                                                              self.context.get_workspace_names_of_data_with_run)
 
-        self.assertEqual(workspace_list, [])
+        self.assertEqual(workspace_list, ['EMU19489; Group; fwd; Asymmetry; MA', 'EMU19489; Pair Asym; long; MA'])
+
+    def test_get_workspace_names_of_data_with_run_returns_the_expected_names_for_a_single_run_and_group_pair(self):
+        self.populate_ADS()
+        workspace_list = self.context.get_workspace_names_of_data_with_run([19489], "bwd")
+
+        self.assertEqual(workspace_list, ["EMU19489; Group; bwd; Asymmetry; MA"])
 
     def test_get_workspaces_names_copes_with_bad_groups(self):
         self.populate_ADS()
-        workspace_list = self.context.get_names_of_workspaces_to_fit('19489', 'fwd, bwd, long, random, wrong')
+        workspace_list = self.context.get_workspace_names_for('19489', ['fwd', 'bwd', 'long', 'random', 'wrong'],
+                                                              self.context.get_workspace_names_of_data_with_run)
 
         self.assertEqual(Counter(workspace_list),
                          Counter(['EMU19489; Group; fwd; Asymmetry; MA', 'EMU19489; Group; bwd; Asymmetry; MA',
@@ -310,7 +318,8 @@ class MuonContextTest(unittest.TestCase):
     def test_get_workspaces_names_copes_with_non_existent_runs(self):
         self.populate_ADS()
 
-        workspace_list = self.context.get_names_of_workspaces_to_fit('19489, 22222', 'fwd, bwd, long')
+        workspace_list = self.context.get_workspace_names_for('19489, 22222', ['fwd', 'bwd', 'long'],
+                                                              self.context.get_workspace_names_of_data_with_run)
 
         self.assertEqual(Counter(workspace_list),
                          Counter(['EMU19489; Group; fwd; Asymmetry; MA', 'EMU19489; Group; bwd; Asymmetry; MA',
@@ -319,7 +328,8 @@ class MuonContextTest(unittest.TestCase):
     def test_that_run_ranged_correctly_parsed(self):
         self.populate_ADS()
 
-        workspace_list = self.context.get_names_of_workspaces_to_fit('19489-95', 'fwd, bwd, long')
+        workspace_list = self.context.get_workspace_names_for('19489-95', ['fwd', 'bwd', 'long'],
+                                                              self.context.get_workspace_names_of_data_with_run)
 
         self.assertEqual(Counter(workspace_list),
                          Counter(['EMU19489; Group; fwd; Asymmetry; MA', 'EMU19489; Group; bwd; Asymmetry; MA',

--- a/scripts/test/Muon/muon_context_with_frequency_test.py
+++ b/scripts/test/Muon/muon_context_with_frequency_test.py
@@ -61,29 +61,30 @@ class MuonContextWithFrequencyTest(unittest.TestCase):
 
     def test_get_workspace_names_returns_no_time_domain_workspaces(self):
         self.populate_ADS()
-        workspace_list = self.context.get_names_of_workspaces_to_fit('19489', 'fwd, bwd, long', True)
+        workspace_list = self.context.get_workspace_names_of_fit_data_with_run([19489], 'fwd, bwd, long')
         self.assertEqual(Counter(workspace_list),
                          Counter())
 
     def test_get_workspace_names_returns_nothing_if_no_parameters_passed(self):
         self.populate_ADS()
-        workspace_list = self.context.get_names_of_workspaces_to_fit(freq = "All")
+        workspace_list = self.context.get_workspace_names_of_fit_data_with_run([], group_and_pair='')
 
         self.assertEqual(workspace_list, [])
 
     def test_get_workspaces_names_copes_with_no_freq_runs(self):
         self.populate_ADS()
-        workspace_list = self.context.get_names_of_workspaces_to_fit(runs='19489', group_and_pair='fwd, bwd, long, random, wrong',
-                                                                     phasequad=True, freq="All")
+        self.context._frequency_context.plot_type = "All"
+        workspace_list = self.context.get_workspace_names_of_fit_data_with_run([19489],
+                                                                               group_and_pair='fwd, bwd, long, random, wrong')
 
         self.assertEqual(Counter(workspace_list),
                          Counter([]))
 
     def test_call_freq_workspace_names(self):
-        self.context.get_names_of_frequency_domain_workspaces_to_fit = mock.Mock()
-        self.context.get_names_of_workspaces_to_fit(runs='19489', group_and_pair='fwd, bwd', freq="All")
-        self.context.get_names_of_frequency_domain_workspaces_to_fit.assert_called_once_with(runs='19489', group_and_pair='fwd, bwd',
-                                                                                             frequency_type="All")
+        self.context._frequency_context.get_frequency_workspace_names = mock.Mock()
+        self.context._frequency_context.plot_type = "All"
+        self.context.get_workspace_names_of_fit_data_with_run([19489], group_and_pair='fwd, bwd')
+        self.assertEqual(1, self.context._frequency_context.get_frequency_workspace_names.call_count)
 
 
 if __name__ == '__main__':

--- a/scripts/test/Muon/plot_widget/plot_widget_model_test.py
+++ b/scripts/test/Muon/plot_widget/plot_widget_model_test.py
@@ -137,7 +137,10 @@ class PlotWidgetModelTest(unittest.TestCase):
         self.assertEqual(expected_indices, indices)
 
     def test_create_tiled_keys_returns_correctly_for_tiled_by_group(self):
-        self.context.group_pair_context._selected_groups = ["fwd", "bwd", "top"]
+        self.context.group_pair_context.add_group(MuonGroup(group_name="bwd", detector_ids=[6, 7, 8, 9, 10]))
+        self.context.group_pair_context.add_group(MuonGroup(group_name="bottom", detector_ids=[11, 12, 13, 14, 15]))
+        self.context.group_pair_context.add_group(MuonGroup(group_name="top", detector_ids=[16, 17, 18, 19, 20]))
+        self.context.group_pair_context._selected_groups = ["bwd", "fwd", "top"]
 
         keys = self.model.create_tiled_keys(TILED_BY_GROUP_TYPE)
 

--- a/scripts/test/Muon/plotting_canvas/plotting_canvas_model_test.py
+++ b/scripts/test/Muon/plotting_canvas/plotting_canvas_model_test.py
@@ -19,6 +19,7 @@ class PlottingCanvasModelTest(unittest.TestCase):
 
     def test_create_workspace_plot_information_calls_get_plot_axis_correctly(self):
         self.model._get_workspace_plot_axis = mock.MagicMock(return_value=1)
+        self.model._is_guess_workspace = mock.MagicMock(return_value=True)
         test_ws_names = ["MUSR62260; Group; fwd", "MUSR62260; Group; fwd"]
         test_indies = [0, 0]
         self.model.create_workspace_plot_information(test_ws_names, test_indies, errors=False)
@@ -31,6 +32,7 @@ class PlottingCanvasModelTest(unittest.TestCase):
         axis = 2
         self.model._get_workspace_plot_axis = mock.MagicMock(return_value=2)
         self.model.create_plot_information = mock.MagicMock()
+        self.model._is_guess_workspace = mock.MagicMock(return_value=False)
         test_ws_names = ["MUSR62260; Group; fwd", "MUSR62260; Group; fwd"]
         test_indies = [0, 0]
         self.model.create_workspace_plot_information(test_ws_names, test_indies, errors=False)


### PR DESCRIPTION
**Description of work.**
This PR ensures that the order of the workspace names (in the fitting tab and plot) and group/pair/diff labels (in the grouping tab) have a consistent order. The inconsistent order of these names was brought up as a usability issue by James during beta testing.

**To test:**
This needs testing on Muon Analysis and Frequency Domain Analysis. 

Fixes #31380

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
