### PR TITLE
Muon Analysis - Cache fit status and chi squared

### DIFF
--- a/scripts/Muon/GUI/Common/fitting_widgets/basic_fitting/basic_fitting_model.py
+++ b/scripts/Muon/GUI/Common/fitting_widgets/basic_fitting/basic_fitting_model.py
@@ -70,7 +70,10 @@ class BasicFittingModel:
         self._single_fit_functions_cache = []
 
         self._fit_statuses = []
+        self._fit_statuses_cache = []
+
         self._chi_squared = []
+        self._chi_squared_cache = []
 
         self._function_name = ""
         self._function_name_auto_update = True
@@ -238,10 +241,14 @@ class BasicFittingModel:
     def cache_the_current_fit_functions(self) -> None:
         """Caches the existing single fit functions. Used before a fit is performed to save the old state."""
         self.single_fit_functions_cache = [self._clone_function(function) for function in self.single_fit_functions]
+        self.fit_statuses_cache = self.fit_statuses.copy()
+        self.chi_squared_cache = self.chi_squared.copy()
 
     def clear_cached_fit_functions(self) -> None:
         """Clears the cached fit functions and removes all fits from the fitting context."""
         self.single_fit_functions_cache = [None] * self.number_of_datasets
+        self.fit_statuses_cache = [None] * self.number_of_datasets
+        self.chi_squared_cache = [None] * self.number_of_datasets
 
     @property
     def fit_statuses(self) -> list:
@@ -255,6 +262,19 @@ class BasicFittingModel:
             raise RuntimeError(f"The provided number of fit statuses is not equal to the number of datasets.")
 
         self._fit_statuses = fit_statuses
+
+    @property
+    def fit_statuses_cache(self) -> list:
+        """Returns all of the cached fit statuses in a list."""
+        return self._fit_statuses_cache
+
+    @fit_statuses_cache.setter
+    def fit_statuses_cache(self, fit_statuses: list) -> None:
+        """Sets the value of the cached fit statuses."""
+        if len(fit_statuses) != self.number_of_datasets:
+            raise RuntimeError(f"The provided number of fit statuses is not equal to the number of datasets.")
+
+        self._fit_statuses_cache = fit_statuses
 
     @property
     def current_fit_status(self) -> str:
@@ -281,6 +301,19 @@ class BasicFittingModel:
             raise RuntimeError(f"The provided number of chi squared is not equal to the number of datasets.")
 
         self._chi_squared = chi_squared
+
+    @property
+    def chi_squared_cache(self) -> list:
+        """Returns all of the cached chi squares in a list."""
+        return self._chi_squared_cache
+
+    @chi_squared_cache.setter
+    def chi_squared_cache(self, chi_squared: list) -> None:
+        """Sets the value of the cached fit statuses."""
+        if len(chi_squared) != self.number_of_datasets:
+            raise RuntimeError(f"The provided number of chi squared is not equal to the number of datasets.")
+
+        self._chi_squared_cache = chi_squared
 
     @property
     def current_chi_squared(self) -> float:
@@ -379,6 +412,8 @@ class BasicFittingModel:
     def use_cached_function(self) -> None:
         """Sets the current function as being the cached function."""
         self.single_fit_functions = self.single_fit_functions_cache
+        self.fit_statuses = self.fit_statuses_cache.copy()
+        self.chi_squared = self.chi_squared_cache.copy()
 
     def update_plot_guess(self, plot_guess: bool) -> None:
         """Updates the guess plot using the current dataset and function."""

--- a/scripts/Muon/GUI/Common/fitting_widgets/basic_fitting/basic_fitting_presenter.py
+++ b/scripts/Muon/GUI/Common/fitting_widgets/basic_fitting/basic_fitting_presenter.py
@@ -109,9 +109,8 @@ class BasicFittingPresenter:
         self.clear_cached_fit_functions()
         self.model.remove_latest_fit_from_context()
 
-        self.reset_fit_status_and_chi_squared_information()
-
         self.update_fit_function_in_view_from_model()
+        self.update_fit_statuses_and_chi_squared_in_view_from_model()
 
         self.model.update_plot_guess(self.view.plot_guess)
 

--- a/scripts/test/Muon/fitting_widgets/basic_fitting/basic_fitting_model_test.py
+++ b/scripts/test/Muon/fitting_widgets/basic_fitting/basic_fitting_model_test.py
@@ -210,6 +210,8 @@ class BasicFittingModelTest(unittest.TestCase):
     def test_that_clear_cached_fit_functions_will_clear_the_cache_of_fit_functions(self):
         self.model.dataset_names = self.dataset_names
         self.model.single_fit_functions = [self.fit_function, None]
+        self.model.fit_statuses = ["success", None]
+        self.model.chi_squared = [1.0, None]
 
         self.model.cache_the_current_fit_functions()
         self.model.clear_cached_fit_functions()
@@ -217,6 +219,8 @@ class BasicFittingModelTest(unittest.TestCase):
         self.assertEqual(len(self.model.single_fit_functions), 2)
         self.assertEqual(self.model.single_fit_functions_cache[0], None)
         self.assertEqual(self.model.single_fit_functions_cache[1], None)
+        self.assertEqual(self.model.fit_statuses_cache, [None, None])
+        self.assertEqual(self.model.chi_squared_cache, [None, None])
 
     def test_that_setting_the_fit_statuses_will_raise_if_the_number_of_fit_statuses_is_not_equal_to_the_number_of_datasets(self):
         self.model.dataset_names = self.dataset_names
@@ -281,13 +285,19 @@ class BasicFittingModelTest(unittest.TestCase):
     def test_that_use_cached_function_will_replace_the_single_functions_with_the_cached_functions(self):
         self.model.dataset_names = self.dataset_names
         self.model.single_fit_functions = [self.fit_function, None]
+        self.model.fit_statuses = ["success", "success"]
+        self.model.chi_squared = [1.0, 2.0]
         self.model.cache_the_current_fit_functions()
         self.model.single_fit_functions = [None, None]
+        self.model.fit_statuses = [None, None]
+        self.model.chi_squared = [None, None]
 
         self.model.use_cached_function()
 
         self.assertEqual(str(self.model.single_fit_functions[0]), "name=FlatBackground,A0=0")
         self.assertEqual(self.model.single_fit_functions[1], None)
+        self.assertEqual(self.model.fit_statuses, ["success", "success"])
+        self.assertEqual(self.model.chi_squared, [1.0, 2.0])
 
     def test_that_the_minimizer_property_can_be_set_as_expected(self):
         minimizer = "A Minimizer"

--- a/scripts/test/Muon/fitting_widgets/basic_fitting/basic_fitting_presenter_test.py
+++ b/scripts/test/Muon/fitting_widgets/basic_fitting/basic_fitting_presenter_test.py
@@ -139,15 +139,15 @@ class BasicFittingPresenterTest(unittest.TestCase):
 
     def test_that_handle_undo_fit_clicked_will_attempt_to_reset_the_fit_data_and_notify_that_the_data_has_changed(self):
         self.presenter.clear_cached_fit_functions = mock.Mock()
-        self.presenter.reset_fit_status_and_chi_squared_information = mock.Mock()
         self.presenter.update_fit_function_in_view_from_model = mock.Mock()
+        self.presenter.update_fit_statuses_and_chi_squared_in_view_from_model = mock.Mock()
 
         self.presenter.handle_undo_fit_clicked()
 
         self.model.use_cached_function.assert_called_once_with()
         self.presenter.clear_cached_fit_functions.assert_called_once_with()
-        self.presenter.reset_fit_status_and_chi_squared_information.assert_called_once_with()
         self.presenter.update_fit_function_in_view_from_model.assert_called_once_with()
+        self.presenter.update_fit_statuses_and_chi_squared_in_view_from_model.assert_called_once_with()
         self.model.update_plot_guess.assert_called_once_with(True)
         self.model.remove_latest_fit_from_context.assert_called_once_with()
         self.presenter.selected_fit_results_changed.notify_subscribers.assert_called_once_with([])


### PR DESCRIPTION
**Description of work.**
This PR makes sure the fit statuses and chi squares are cached so that the undo fit feature will not undo ALL fit statuses and chi squared, just the latest.

I believe this is a bug in the previous version of Mantid as well.

**To test:**
1. Muon Analysis, MUSR 62260-1
2. Fitting tab, Add a Gaus Osc function
3. Do a fit. Step to the next dataset, do another fit.
4. Click `Undo Fit` and the fit function, fit status and chi squared should be reset for the selected dataset.
5. Step backwards to the previous dataset and the fit status and chi squared for this should still be there. The fit function should also be unchanged. 

Fixes #31417

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
