### PR TITLE
Resize SelectFunctionDialog for 4k screens

### DIFF
--- a/qt/widgets/common/inc/MantidQtWidgets/Common/SelectFunctionDialog.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/SelectFunctionDialog.h
@@ -48,6 +48,8 @@ private:
   /// Construct QTreeWidget with categories and functions
   void constructFunctionTree(const std::map<std::string, std::vector<std::string>> &categoryFunctionsMap,
                              const std::vector<std::string> &restrictions);
+  /// Sets the minimum height of the function tree so that all catagories are visible
+  void setMinimumHeightOfFunctionTree();
 
 private slots:
   void searchBoxChanged(const QString &text);

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/SelectFunctionDialog.ui
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/SelectFunctionDialog.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>305</width>
-    <height>264</height>
+    <height>300</height>
    </rect>
   </property>
   <property name="windowTitle">

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/SelectFunctionDialog.ui
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/SelectFunctionDialog.ui
@@ -7,14 +7,8 @@
     <x>0</x>
     <y>0</y>
     <width>305</width>
-    <height>300</height>
+    <height>264</height>
    </rect>
-  </property>
-  <property name="minimumSize">
-   <size>
-    <width>0</width>
-    <height>300</height>
-   </size>
   </property>
   <property name="windowTitle">
    <string>Select a function type</string>

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/SelectFunctionDialog.ui
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/SelectFunctionDialog.ui
@@ -10,6 +10,12 @@
     <height>300</height>
    </rect>
   </property>
+  <property name="minimumSize">
+   <size>
+    <width>0</width>
+    <height>300</height>
+   </size>
+  </property>
   <property name="windowTitle">
    <string>Select a function type</string>
   </property>

--- a/qt/widgets/common/src/SelectFunctionDialog.cpp
+++ b/qt/widgets/common/src/SelectFunctionDialog.cpp
@@ -25,6 +25,7 @@
 #include <QIcon>
 #include <QLabel>
 #include <QPushButton>
+#include <QTreeWidget>
 #include <QVBoxLayout>
 
 namespace MantidQt {
@@ -74,6 +75,7 @@ SelectFunctionDialog::SelectFunctionDialog(QWidget *parent, const std::vector<st
   // Construct the QTreeWidget based on the map information of categories and
   // their respective fit functions.
   constructFunctionTree(categories, restrictions);
+  setMinimumHeightOfFunctionTree();
 
   connect(m_form->fitTree, SIGNAL(itemDoubleClicked(QTreeWidgetItem *, int)), this,
           SLOT(functionDoubleClicked(QTreeWidgetItem *)));
@@ -168,6 +170,19 @@ void SelectFunctionDialog::constructFunctionTree(
 }
 
 SelectFunctionDialog::~SelectFunctionDialog() { delete m_form; }
+
+/**
+ * Sets the minimum height of the function tree to ensure that all catagories are visible when the dialog is opened.
+ * This method ensures the correct minimum size is used for any screen resolution.
+ */
+void SelectFunctionDialog::setMinimumHeightOfFunctionTree() {
+  auto const numberOfTopLevelItems = m_form->fitTree->topLevelItemCount();
+  if (numberOfTopLevelItems > 0) {
+    auto const firstItem = m_form->fitTree->topLevelItem(0);
+    auto const itemHeight = m_form->fitTree->visualItemRect(firstItem).height();
+    m_form->fitTree->setMinimumHeight(itemHeight * numberOfTopLevelItems);
+  }
+}
 
 /**
  * Return selected function


### PR DESCRIPTION
**Description of work.**
This PR makes the SelectFunctionDialog slightly larger in height so that all the function categories can be seen when it is opened on a 4k screen.

**To test:**
Test on a 4k screen
1. Muon Analysis, MUSR 62260-1
2. Go to fitting tab.
3. Right click FunctionBrowser and select `Add Function`
4. You should be able to see all the function categories without having to expand the dialog.

*There is no associated issue.*

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
