### PR TITLE
Fix for crash of Damped GaussNewton minimizer with ties for CrystalFieldSpectrum

### DIFF
--- a/Framework/CurveFitting/src/Algorithms/Fit.cpp
+++ b/Framework/CurveFitting/src/Algorithms/Fit.cpp
@@ -291,8 +291,14 @@ void Fit::createOutput() {
           row << 100.0 * covar.get(ia, ja) / sqrt(covar.get(ia, ia) * covar.get(ja, ja));
         }
         ++ja;
+
+        if (ja >= covar.size2())
+          break;
       }
       ++ia;
+
+      if (ia >= covar.size1())
+        break;
     }
 
     setProperty("OutputNormalisedCovarianceMatrix", covariance);

--- a/Framework/CurveFitting/src/CostFunctions/CostFuncFitting.cpp
+++ b/Framework/CurveFitting/src/CostFunctions/CostFuncFitting.cpp
@@ -188,11 +188,17 @@ void CostFuncFitting::calFittingErrors(const GSLMatrix &covar, double chi2) {
         if (m_function->isActive(j)) {
           (*covarMatrix)[i][j] = covar.get(ia, ja);
           ++ja;
+
+          if (ja >= covar.size2())
+            break;
         }
       }
       double err = sqrt(covar.get(ia, ia));
       m_function->setError(i, err);
       ++ia;
+
+      if (ia >= covar.size1())
+        break;
     }
   }
   m_function->setCovarianceMatrix(covarMatrix);

--- a/Framework/CurveFitting/src/CostFunctions/CostFuncLeastSquares.cpp
+++ b/Framework/CurveFitting/src/CostFunctions/CostFuncLeastSquares.cpp
@@ -80,6 +80,7 @@ void CostFuncLeastSquares::addValDerivHessian(API::IFunction_sptr function, API:
   for (size_t ip = 0; ip < np; ++ip) {
     if (!function->isActive(ip))
       continue;
+
     double d = 0.0;
     for (size_t i = 0; i < ny; ++i) {
       double calc = values->getCalculated(i);
@@ -96,6 +97,9 @@ void CostFuncLeastSquares::addValDerivHessian(API::IFunction_sptr function, API:
       m_der.set(iActiveP, der + d);
     }
     ++iActiveP;
+
+    if (iActiveP >= m_der.size())
+      break;
   }
 
   PARALLEL_ATOMIC
@@ -128,8 +132,14 @@ void CostFuncLeastSquares::addValDerivHessian(API::IFunction_sptr function, API:
         }
       }
       ++i2;
+
+      if (i2 >= m_hessian.size2())
+        break;
     }
     ++i1;
+
+    if (i1 >= m_hessian.size1())
+      break;
   }
 }
 


### PR DESCRIPTION
**Description of work.**

When fitting the crystal field and peak parameters there are more peaks stored than actually fitted. The number of fitted peaks can both increase and decrease while iterating. In case a higher number of peaks was fitted than in the final iterations these peaks are still marked as active but not considered in the cost function and in the fit output. This can cause out of range errors for GSLVector and GSLMatrix. With this fix these additional peaks are ignored and out of range errors prevented.

**To test:**

On Linux the issue can be reproduced by directly running the script from the original issue (https://github.com/mantidproject/mantid/issues/31176). On Windows it can only be reproduced with the script when commenting out the line `cf.function.tie('B66','0.0008')` In both cases Mantid crashes with an out of range error in the GSLVector without this fix. With the fix there should not be a crash on either operating system.

Fixes #[31176](https://github.com/mantidproject/mantid/issues/31176). 

*This does not require release notes* because **it is an internal issue.**

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
