### PR TITLE
FIx bugs with IndirectDataAnalysis f(q) fit add workspace Dialog

### DIFF
--- a/docs/source/release/v6.1.0/indirect_geometry.rst
+++ b/docs/source/release/v6.1.0/indirect_geometry.rst
@@ -23,5 +23,7 @@ Bug Fixes
 - Fixed a bug causing the x range markers on the ISISDiagnostics plot of Data Reduction to go missing.
 - Fixed a crash on the Data Analysis interface when attempting to drag the Start and End X sliders on the preview plot.
 - In IsoRotDiff, DiffSphere, and DiffRotDiscreteCircle Aliases have been removed to avoid clashes with interfaces.
+- Fixed a bug that caused an error warning when adding EISF data to F(q) fit if Width has already been added.
+- Fixed a bug that caused the spectra list in F(q) fit to be blank when reopening the add workspace dialog.
 
 :ref:`Release 6.1.0 <v6.1.0>`

--- a/qt/scientific_interfaces/Indirect/FqFitDataPresenter.cpp
+++ b/qt/scientific_interfaces/Indirect/FqFitDataPresenter.cpp
@@ -141,6 +141,7 @@ void FqFitDataPresenter::dialogParameterTypeUpdated(FqFitAddWorkspaceDialog *dia
 
 void FqFitDataPresenter::updateParameterOptions(FqFitAddWorkspaceDialog *dialog) {
   setDataIndexToCurrentWorkspace(dialog);
+  setActiveParameterType(dialog->parameterType());
   if (m_activeParameterType == "Width")
     dialog->setParameterNames(m_fqFitModel->getWidths(m_dataIndex));
   else if (m_activeParameterType == "EISF")

--- a/qt/scientific_interfaces/Indirect/IAddWorkspaceDialog.h
+++ b/qt/scientific_interfaces/Indirect/IAddWorkspaceDialog.h
@@ -23,7 +23,7 @@ public:
 
   virtual void updateSelectedSpectra() = 0;
 
-  void closeEvent(QCloseEvent *event) override { emit closeDialog(); }
+  void closeEvent(QCloseEvent *) override { emit closeDialog(); }
 
 signals:
   void addData();

--- a/qt/scientific_interfaces/Indirect/IAddWorkspaceDialog.h
+++ b/qt/scientific_interfaces/Indirect/IAddWorkspaceDialog.h
@@ -23,6 +23,8 @@ public:
 
   virtual void updateSelectedSpectra() = 0;
 
+  void closeEvent(QCloseEvent *event) override { emit closeDialog(); }
+
 signals:
   void addData();
   void closeDialog();

--- a/qt/scientific_interfaces/Indirect/IndirectFitAnalysisTab.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectFitAnalysisTab.cpp
@@ -689,9 +689,13 @@ void IndirectFitAnalysisTab::respondToDataChanged() {
 void IndirectFitAnalysisTab::respondToSingleDataViewSelected() {
   m_spectrumPresenter->setActiveIndexToZero();
   m_plotPresenter->hideMultipleDataSelection();
+  m_plotPresenter->updateDataSelection();
 }
 
-void IndirectFitAnalysisTab::respondToMultipleDataViewSelected() { m_plotPresenter->showMultipleDataSelection(); }
+void IndirectFitAnalysisTab::respondToMultipleDataViewSelected() {
+  m_plotPresenter->showMultipleDataSelection();
+  m_plotPresenter->updateDataSelection();
+}
 
 void IndirectFitAnalysisTab::respondToDataAdded() {
   updateDataReferences();

--- a/qt/scientific_interfaces/Indirect/IndirectFitDataPresenter.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectFitDataPresenter.cpp
@@ -192,6 +192,7 @@ void IndirectFitDataPresenter::closeDialog() {
   disconnect(m_addWorkspaceDialog.get(), SIGNAL(addData()), this, SLOT(addData()));
   disconnect(m_addWorkspaceDialog.get(), SIGNAL(closeDialog()), this, SLOT(closeDialog()));
   m_addWorkspaceDialog->close();
+  m_addWorkspaceDialog = nullptr;
 }
 
 void IndirectFitDataPresenter::addData(IAddWorkspaceDialog const *dialog) {

--- a/qt/scientific_interfaces/Indirect/IndirectFitPlotPresenter.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectFitPlotPresenter.cpp
@@ -167,6 +167,7 @@ void IndirectFitPlotPresenter::updateDataSelection() {
   for (TableDatasetIndex i{0}; i < m_model->numberOfWorkspaces(); ++i)
     m_view->appendToDataSelection(m_model->getFitDataName(i));
   setActiveIndex(TableDatasetIndex{0});
+  setActiveSpectrum(WorkspaceIndex{0});
   updateAvailableSpectra();
   emitSelectedFitDataChanged();
 }

--- a/qt/scientific_interfaces/Indirect/test/IndirectFitPlotPresenterTest.h
+++ b/qt/scientific_interfaces/Indirect/test/IndirectFitPlotPresenterTest.h
@@ -555,6 +555,26 @@ public:
     m_presenter->updateDataSelection();
   }
 
+  void test_updateDataSelection_sets_active_spectra_to_zero() {
+    TableDatasetIndex const index1(0);
+    TableDatasetIndex const index2(1);
+
+    ON_CALL(*m_view, dataSelectionSize()).WillByDefault(Return(TableDatasetIndex(2)));
+    ON_CALL(*m_fittingModel, getNumberOfWorkspaces()).WillByDefault(Return(2));
+    ON_CALL(*m_fittingModel, createDisplayName(TableDatasetIndex(0))).WillByDefault(Return("DisplayName-0"));
+    ON_CALL(*m_fittingModel, createDisplayName(TableDatasetIndex(1))).WillByDefault(Return("DisplayName-1"));
+    ON_CALL(*m_fittingModel, getWorkspace(index1)).WillByDefault(Return(m_ads->retrieveWorkspace("WorkspaceName")));
+    ON_CALL(*m_fittingModel, getWorkspace(index2)).WillByDefault(Return(m_ads->retrieveWorkspace("WorkspaceName")));
+
+    EXPECT_CALL(*m_view, clearDataSelection()).Times(1);
+    EXPECT_CALL(*m_view, appendToDataSelection("DisplayName-0")).Times(1);
+    EXPECT_CALL(*m_view, appendToDataSelection("DisplayName-1")).Times(1);
+    EXPECT_CALL(*m_view, setPlotSpectrum(IDA::WorkspaceIndex{0})).Times(1);
+    TS_ASSERT_EQUALS(m_presenter->getSelectedSpectrum(), IDA::WorkspaceIndex{0});
+
+    m_presenter->updateDataSelection();
+  }
+
   void test_updateAvailableSpectra_uses_minmax_if_spectra_is_continuous() {
     auto spectra = FunctionModelSpectra("0-9");
     auto minmax = spectra.getMinMax();

--- a/qt/scientific_interfaces/Indirect/test/IndirectFitPlotPresenterTest.h
+++ b/qt/scientific_interfaces/Indirect/test/IndirectFitPlotPresenterTest.h
@@ -569,7 +569,7 @@ public:
     EXPECT_CALL(*m_view, clearDataSelection()).Times(1);
     EXPECT_CALL(*m_view, appendToDataSelection("DisplayName-0")).Times(1);
     EXPECT_CALL(*m_view, appendToDataSelection("DisplayName-1")).Times(1);
-    EXPECT_CALL(*m_view, setPlotSpectrum(IDA::WorkspaceIndex{0})).Times(1);
+    EXPECT_CALL(*m_view, setPlotSpectrum(IDA::WorkspaceIndex{0})).Times(2);
     TS_ASSERT_EQUALS(m_presenter->getSelectedSpectrum(), IDA::WorkspaceIndex{0});
 
     m_presenter->updateDataSelection();


### PR DESCRIPTION
**Description of work.**

This PR fixes bugs in the indirect data analysis F(Q) fit that caused errors when:
1. Removing all spectra and then trying to add a new one.
2. Closing and reopening the add workspace dialogue leaving drop down menus empty.

**Report to:** @SpencerHowell

**To test:**

1. open f(q) fit
2. go to multiple input
3. load data with both Width and EISF but only add the width
4. close the dialog
5. reopen the dialoge it should be reset
6. close the dialog
7. remove the spectra you had add
8. Add the EISF data, the plot should show that and there should be no error.

Fixes #30464

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
