### PR TITLE
Updated Links For Introduction To Python Course

### DIFF
--- a/docs/source/tutorials/index.rst
+++ b/docs/source/tutorials/index.rst
@@ -44,6 +44,6 @@ capabilities of Mantid, by developing your own scripts.
 
 * :ref:`mantid_basic_course`
 * :ref:`muon_GUI_course`
-* `Introduction To Python <http://www.mantidproject.org/Introduction_To_Python>`_
+* :ref:`introduction_to_python`
 * :ref:`pim_intro`
 * `Extending Mantid with Python <http://www.mantidproject.org/Extending_Mantid_With_Python>`_

--- a/docs/source/tutorials/python_in_mantid/index.rst
+++ b/docs/source/tutorials/python_in_mantid/index.rst
@@ -16,7 +16,7 @@ Python In Mantid
    solutions/index
 
 
-The following tutorial introduces how to interact with Mantid through Python. Some knowledge of Python is assumed (see `Introduction to Python <https://www.mantidproject.org/Introduction_To_Python>`_).
+The following tutorial introduces how to interact with Mantid through Python. Some knowledge of Python is assumed (see :ref:`introduction_to_python`).
 
 
 **Contents**


### PR DESCRIPTION
**Description of work.**
We were still using html links for the introduction to python course even though we have the docs in our source folder. Update the links for the course to use the user docs version

~~**The wiki needs to be updated**~~

**To test:**
Build docs check links still work for the introduction to python page
Check wiki links go to docs version

*There is no associated issue.*

<!-- delete this if you added release notes
*This does not require release notes* because **it is an internal change**

<!-- Ensure the base of this PR is correct (e.g. release-next or master)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
