### PR TITLE
Update AlignAndFocusPowder unit conversion calculation to use new APIs

### DIFF
--- a/Framework/DataHandling/src/ApplyDiffCal.cpp
+++ b/Framework/DataHandling/src/ApplyDiffCal.cpp
@@ -191,16 +191,26 @@ void ApplyDiffCal::exec() {
     Column_const_sptr difaColumn = m_calibrationWS->getColumn("difa");
     Column_const_sptr tzeroColumn = m_calibrationWS->getColumn("tzero");
 
+    auto detids = instrument->getDetectorIDs();
+
     for (size_t i = 0; i < m_calibrationWS->rowCount(); ++i) {
       auto detid = static_cast<detid_t>((*detIdColumn)[i]);
       double difc = (*difcColumn)[i];
       double difa = (*difaColumn)[i];
       double tzero = (*tzeroColumn)[i];
 
-      auto det = instrument->getDetector(detid);
-      paramMap.addDouble(det->getComponentID(), "DIFC", difc);
-      paramMap.addDouble(det->getComponentID(), "DIFA", difa);
-      paramMap.addDouble(det->getComponentID(), "TZERO", tzero);
+      // auto det = instrument->getDetector(detid);
+      auto it = std::find(detids.begin(), detids.end(), detid);
+      if (it != detids.end()) {
+        // found the detector
+        auto det = instrument->getDetector(detid);
+        paramMap.addDouble(det->getComponentID(), "DIFC", difc);
+        paramMap.addDouble(det->getComponentID(), "DIFA", difa);
+        paramMap.addDouble(det->getComponentID(), "TZERO", tzero);
+      } else {
+        // cannot find the detector, use default zero for difc, difa, and tzero
+        g_log.information() << "Cannot find det " << detid << ", skipping.\n";
+      }
     }
   }
 }

--- a/Framework/WorkflowAlgorithms/src/AlignAndFocusPowder.cpp
+++ b/Framework/WorkflowAlgorithms/src/AlignAndFocusPowder.cpp
@@ -516,13 +516,17 @@ void AlignAndFocusPowder::exec() {
 
   if (m_maskWS) {
     g_log.information() << "running MaskDetectors started at " << Types::Core::DateAndTime::getCurrentTime() << "\n";
-    const auto &maskedDetectors = m_maskWS->getMaskedDetectors();
-    API::IAlgorithm_sptr maskAlg = createChildAlgorithm("MaskInstrument");
-    maskAlg->setProperty("InputWorkspace", m_outputW);
-    maskAlg->setProperty("OutputWorkspace", m_outputW);
-    maskAlg->setProperty("DetectorIDs", std::vector<detid_t>(maskedDetectors.begin(), maskedDetectors.end()));
-    maskAlg->executeAsChildAlg();
-    m_outputW = maskAlg->getProperty("OutputWorkspace");
+
+    API::IAlgorithm_sptr maskDetAlg = createChildAlgorithm("MaskDetectors");
+    // cast to Workspace for MaksDetectors alg
+    Workspace_sptr outputw = std::dynamic_pointer_cast<Workspace>(m_outputW);
+    maskDetAlg->setProperty("Workspace", outputw);
+    MatrixWorkspace_sptr mksws = std::dynamic_pointer_cast<MatrixWorkspace>(m_maskWS);
+    maskDetAlg->setProperty("MaskedWorkspace", mksws);
+    maskDetAlg->executeAsChildAlg();
+    outputw = maskDetAlg->getProperty("Workspace");
+    // casting
+    m_outputW = std::dynamic_pointer_cast<MatrixWorkspace>(outputw);
     m_outputEW = std::dynamic_pointer_cast<EventWorkspace>(m_outputW);
   }
   m_progress->report();

--- a/docs/source/algorithms/AlignDetectors-v1.rst
+++ b/docs/source/algorithms/AlignDetectors-v1.rst
@@ -6,6 +6,13 @@
 
 .. properties::
 
+.. note:: As of 2021-01-04, this algorithm is officially deprecated.
+          As a result, developers and users are recommend to use
+          :ref:`ApplyDiffCal<algm-ApplyDiffCal>`, followed by
+          :ref:`ConvertUnits<algm-ConvertUnits>`, followed by
+          :ref:`ApplyDiffCal<algm-ApplyDiffCal>` (ClearCalibration=true) to
+          produce the equivalent results.
+
 Description
 -----------
 

--- a/docs/source/release/v6.1.0/diffraction.rst
+++ b/docs/source/release/v6.1.0/diffraction.rst
@@ -54,6 +54,7 @@ Bugfixes
 - Saved filenames for summed empty workspaces now include spline properties to avoid long_mode confusion when focussing.
 - Fix segmentation violation issues for ILL instruments D1B, D2B, and D20, caused by change of scanned data type
 - :ref:`D7AbsoluteCrossSections <algm-D7AbsoluteCrossSections>` fixed the wrong assumption on the order of spin-flip and non-spin-flip data, and fixed the relative normalisation issues.
+- Fix crashing issue in :ref:`AlignAndFocusPowder<algm-AlignAndFocusPowder>` due to using new unit conversion APIs.
 
 Engineering Diffraction
 -----------------------


### PR DESCRIPTION
**Description of work.**

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

- Original Gitlab Defect: [PD242](https://code.ornl.gov/sns-hfir-scse/diffraction/powder/powder-diffraction/-/issues/242)
- This is equivalent of #31437 but targeting `release-next`

**To test:**
Build the branch and run the unit test, `AlignAndFocusPowderTest`.

<!-- Instructions for testing. -->

<!-- and fix #xxxx or close #xxxx xor resolves #xxxx -->
<!-- alternative
*There is no associated issue.*
-->

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or master)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
