### PR TITLE
fix powgen issue with multiple run number input

### DIFF
--- a/Framework/API/src/FileFinder.cpp
+++ b/Framework/API/src/FileFinder.cpp
@@ -612,7 +612,6 @@ std::vector<std::string> FileFinderImpl::findRuns(const std::string &hintstr, co
           path = findRun(p1.first + run, exts, useExtsOnly);
         }
 
-        std::string path = findRun(p1.first + run, exts, useExtsOnly);
         if (!path.empty()) {
           // Cache successfully found path and extension
           auto tempPath = Poco::Path(path);

--- a/Framework/API/src/FileFinder.cpp
+++ b/Framework/API/src/FileFinder.cpp
@@ -539,6 +539,7 @@ std::vector<std::string> FileFinderImpl::findRuns(const std::string &hintstr, co
   static const boost::regex digits("[0-9]+");
   auto h = hints.begin();
 
+  std::string instrSName;
   for (; h != hints.end(); ++h) {
     // Quick check for a filename
     bool fileSuspected = false;
@@ -559,6 +560,9 @@ std::vector<std::string> FileFinderImpl::findRuns(const std::string &hintstr, co
       throw std::invalid_argument("Malformed range of runs: " + *h);
     } else if ((range.count() == 2) && (!fileSuspected)) {
       std::pair<std::string, std::string> p1 = toInstrumentAndNumber(range[0]);
+      if (boost::algorithm::istarts_with(hint, "PG3")) {
+        instrSName = "PG3";
+      }
       std::string run = p1.second;
       size_t nZero = run.size(); // zero padding
       if (range[1].size() > nZero) {
@@ -601,6 +605,13 @@ std::vector<std::string> FileFinderImpl::findRuns(const std::string &hintstr, co
           }
         }
 
+        std::string path;
+        if (boost::algorithm::istarts_with(hint, "PG3")) {
+          path = findRun(instrSName + run, exts, useExtsOnly);
+        } else {
+          path = findRun(p1.first + run, exts, useExtsOnly);
+        }
+
         std::string path = findRun(p1.first + run, exts, useExtsOnly);
         if (!path.empty()) {
           // Cache successfully found path and extension
@@ -613,7 +624,18 @@ std::vector<std::string> FileFinderImpl::findRuns(const std::string &hintstr, co
         }
       }
     } else {
-      std::string path = findRun(*h, exts, useExtsOnly);
+      std::string path;
+      // Special check for "PG3", to cope with situation like '48314,48316'.
+      if (boost::algorithm::istarts_with(hint, "PG3")) {
+        if (h == hints.begin()) {
+          instrSName = "PG3";
+          path = findRun(*h, exts, useExtsOnly);
+        } else {
+          path = findRun(instrSName + *h, exts, useExtsOnly);
+        }
+      } else {
+        path = findRun(*h, exts, useExtsOnly);
+      }
       if (!path.empty()) {
         res.emplace_back(path);
       } else {

--- a/docs/source/release/v6.1.0/diffraction.rst
+++ b/docs/source/release/v6.1.0/diffraction.rst
@@ -44,6 +44,7 @@ Improvements
 Bugfixes
 ########
 
+- Fix the issue with SNS Powder Reduction interface when multiple run numbers are provided and separated with comma.
 - Fix an issue when saving reduced data as GSAS format using :ref:`HB2AReduce <algm-HB2AReduce>`.
 - Fix the format inconsistency (with data saved from autoreduction workflow) issue for saving GSAS data using :ref:`HB2AReduce <algm-HB2AReduce>` - both are now using :ref:`SaveGSSCW <algm-SaveGSSCW>` for saving GSAS data.
 - Fix out-of-range bug in :ref:`FitPeaks <algm-FitPeaks>` for histogram data.


### PR DESCRIPTION
**Description of work.**

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

This PR is to fix the issue with SNS Powder Reduction interface -- when multiple run number are provided and are separated with comma, the previous behavior was that only the first run number in the list can be found and the program will complain about not being able to find all the following run numbers.

**To test:**

<!-- Instructions for testing. -->

Open SNS Powder Reduction interface and load in the provided XML file to test out whether the issue is fixed -- if the program can run smoothly without popping up warning window complaining about not being able to find runs, that indicates the issue has been fixed.

Here is the XML file to be imported (included in the zipped file): 
[powgen_gui_test.zip](https://github.com/mantidproject/mantid/files/6446876/powgen_gui_test.zip)


<!-- Ensure the base of this PR is correct (e.g. release-next or master)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.