### PR TITLE
Remove Frequency_Domain_Analysis_Old script from mantid.properties

### DIFF
--- a/Framework/Properties/Mantid.properties.template
+++ b/Framework/Properties/Mantid.properties.template
@@ -21,7 +21,7 @@ Q.convention = Inelastic
 
 # Set of PyQt interfaces to add to the Interfaces menu, separated by a space.  Interfaces are seperated from their respective categories by a "/".
 
-mantidqt.python_interfaces = ILL/Drill.py Direct/DGS_Reduction.py Direct/DGSPlanner.py Direct/PyChop.py Direct/MSlice.py SANS/ORNL_SANS.py Utility/TofConverter.py Diffraction/Engineering_Diffraction.py Diffraction/Powder_Diffraction_Reduction.py Utility/FilterEvents.py Diffraction/HFIR_4Circle_Reduction.py Utility/QECoverage.py SANS/ISIS_SANS.py Muon/Frequency_Domain_Analysis.py Muon/Elemental_Analysis.py Muon/Frequency_Domain_Analysis_Old.py Muon/Muon_Analysis.py General/Sample_Transmission_Calculator.py
+mantidqt.python_interfaces = ILL/Drill.py Direct/DGS_Reduction.py Direct/DGSPlanner.py Direct/PyChop.py Direct/MSlice.py SANS/ORNL_SANS.py Utility/TofConverter.py Diffraction/Engineering_Diffraction.py Diffraction/Powder_Diffraction_Reduction.py Utility/FilterEvents.py Diffraction/HFIR_4Circle_Reduction.py Utility/QECoverage.py SANS/ISIS_SANS.py Muon/Frequency_Domain_Analysis.py Muon/Elemental_Analysis.py Muon/Muon_Analysis.py General/Sample_Transmission_Calculator.py
 
 mantidqt.python_interfaces_io_registry = Engineering_Diffraction_register.py
 

--- a/Testing/SystemTests/tests/qt/PythonInterfacesStartupTest.py
+++ b/Testing/SystemTests/tests/qt/PythonInterfacesStartupTest.py
@@ -13,9 +13,8 @@ from mantidqt.utils.qt.testing import get_application
 from qtpy.QtCore import QCoreApplication, QSettings
 
 
-# Frequency_Domain_Analysis_Old.py  -  Excluded because is being deleted in Mantid Version 6.0
 # Frequency_Domain_Analysis.py      -  Excluded because it is causing a crash
-EXCLUDED_SCRIPTS = ["Frequency_Domain_Analysis_Old.py", "Frequency_Domain_Analysis.py"]
+EXCLUDED_SCRIPTS = ["Frequency_Domain_Analysis.py"]
 
 INSTRUMENT_SWITCHER = {"DGS_Reduction.py": "ARCS",
                        "ORNL_SANS.py": "EQSANS",

--- a/qt/applications/workbench/workbench/app/mainwindow.py
+++ b/qt/applications/workbench/workbench/app/mainwindow.py
@@ -80,8 +80,6 @@ QApplication.processEvents(QEventLoop.AllEvents)
 
 class MainWindow(QMainWindow):
     DOCKOPTIONS = QMainWindow.AllowTabbedDocks | QMainWindow.AllowNestedDocks
-    # list of custom interfaces that are not qt4/qt5 compatible
-    PYTHON_GUI_BLACKLIST = ['Frequency_Domain_Analysis_Old.py']
 
     def __init__(self):
         QMainWindow.__init__(self)
@@ -424,9 +422,6 @@ class MainWindow(QMainWindow):
                 registers_to_run.setdefault(key, []).append(reg_name)
             if not os.path.exists(os.path.join(interface_dir, scriptname)):
                 logger.warning('Failed to find script "{}" in "{}"'.format(scriptname, interface_dir))
-                continue
-            if scriptname in self.PYTHON_GUI_BLACKLIST:
-                logger.information('Not adding gui "{}"'.format(scriptname))
                 continue
             interfaces.setdefault(key, []).append(scriptname)
 

--- a/qt/applications/workbench/workbench/test/mainwindowtest.py
+++ b/qt/applications/workbench/workbench/test/mainwindowtest.py
@@ -304,20 +304,6 @@ class MainWindowTest(unittest.TestCase):
         self.assertDictEqual({}, registration_files)
         mock_logger.warning.assert_called()
 
-    @patch('workbench.app.mainwindow.logger')
-    @patch('os.path.exists')
-    def test_that_blacklisted_python_interface_is_ignored_gracefully(self, mock_os_path_exists, mock_logger):
-        interface_str = 'blacklisted/interface.py'
-        self.main_window.PYTHON_GUI_BLACKLIST = 'interface.py'
-        mock_os_path_exists.return_value = True
-
-        with patch('workbench.app.mainwindow.ConfigService', new={'mantidqt.python_interfaces': interface_str}):
-            returned_interfaces, registration_files = self.main_window._discover_python_interfaces('')
-
-        self.assertDictEqual({}, returned_interfaces)
-        self.assertDictEqual({}, registration_files)
-        mock_logger.information.assert_called()
-
     @patch('workbench.app.mainwindow.UserSubWindowFactory')
     def test_cpp_interfaces_are_discovered_correctly(self, mock_UserSubWindowFactory):
         """Assuming we have already found some python interfaces, test that


### PR DESCRIPTION
**Description of work.**
This PR removes the `Frequency_Domain_Analysis_Old.py` python script from the mantid.properties file because it is no longer used.

**To test:**
1. Open workbench. Check that the old FDA interface is not available in the interfaces menu.

Fixes #0

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
