### PR TITLE
Fix running check for NSIS installer

### DIFF
--- a/buildconfig/CMake/NSIS.template.in
+++ b/buildconfig/CMake/NSIS.template.in
@@ -826,7 +826,7 @@ FunctionEnd
 ;---------------------------------------------
 ; Check if mantid is running
 Function in.abortIfRunning
-  !insertmacro HandleRunningMantid "MantidPlot.exe" "$INSTDIR" "$INSTDIR\bin\MantidPlot.exe appears to be running. Please shut down MantidPlot and try again."
+  !insertmacro HandleRunningMantid "MantidWorkbench.exe" "$INSTDIR" "$INSTDIR\bin\MantidWorkbench.exe appears to be running. Please shut down MantidWorkbench and try again."
 FunctionEnd
 
 ;---------------------------------------------


### PR DESCRIPTION
**Description of work.**

The Windows installer contains a check if `MantidPlot` is running but this now useless and should check for Workbench. This fixes the check so if workbench is running the installer will warn about it and refuse to proceed.

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

**To test:**

* Grab the last release package for Windows and install it but change the install location to `C:\MantidTestingRunningInstall`
* Build a package, either on the CI or [locally](https://developer.mantidproject.org/BuildingWithCMake.html?highlight=nsis#building-the-installer-package)
* Start the workbench from the above location
* Run the newly built package from these changes and a popup should show up that says workbench is running.


*There is no associated issue.*

*This does not require release notes* because **it's a minor fix after removing MantidPlot**

<!-- Ensure the base of this PR is correct (e.g. release-next or master)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
