### PR TITLE
Fix Muon Analysis tabs unattaching crash

### DIFF
--- a/docs/source/release/v6.1.0/muon.rst
+++ b/docs/source/release/v6.1.0/muon.rst
@@ -29,6 +29,8 @@ Bug fixes
   difficult to see.
 - Fixed a bug in the Grouping tab where an error message would appear when changing the source of
   Group Asymmetry Range with no data loaded.
+- Fixed a crash caused when switching between tabs in Muon Analysis.
+- Fixed a usability issue where tabs became unattached too easily. It is now possible to unattach the tabs only by double clicking on them.
 
 ALC
 ---

--- a/scripts/Muon/GUI/Common/dock/dockable_tabs.py
+++ b/scripts/Muon/GUI/Common/dock/dockable_tabs.py
@@ -418,14 +418,8 @@ class DetachableTabWidget(QtWidgets.QTabWidget):
                 if self.drag_end_pos.x() != 0 and self.drag_end_pos.y() != 0:
                     drop_action = QtCore.Qt.MoveAction
 
-                # If the drag completed outside of the tab bar, detach the tab and move
-                # the content to the current cursor position
-                if drop_action == QtCore.Qt.IgnoreAction:
-                    event.accept()
-                    self.onDetachTabSignal.emit(self.tabAt(self.drag_start_pos), self.mouse_cursor.pos())
-
-                # Else if the drag completed inside the tab bar, move the selected tab to the new position
-                elif drop_action == QtCore.Qt.MoveAction:
+                # If the drag completed inside the tab bar, move the selected tab to the new position
+                if drop_action == QtCore.Qt.MoveAction:
                     if not self.drag_end_pos.isNull():
                         event.accept()
                         self.onMoveTabSignal.emit(self.tabAt(self.drag_start_pos), self.tabAt(self.drag_end_pos))


### PR DESCRIPTION
**Description of work.**
This PR fixes a race condition causing a crash when a double click event is followed closely by a mouse drag event on an unattached tab in Muon Analysis (or FDA).

The fix was to remove the 'drag to unattach' behaviour. This has the added benefit of fixing a usability issue where tabs would become unattached too easily.

**To test:**
See the issue for testing instructions. It might take some practice to cause the crash so give it a go on the nightly before testing the PR.

Fixes #31454

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
