### PR TITLE
Frequency domain analysis FFT default values

### DIFF
--- a/docs/source/release/v6.1.0/muon.rst
+++ b/docs/source/release/v6.1.0/muon.rst
@@ -20,6 +20,10 @@ New Features
 - Plotting ranges can now be edited individually for tile plots.
 - The muon fitting interface has been simplified.
 
+Improvements
+############
+- Frequency Domain Analysis default values have been improved.
+
 Bug fixes
 #########
 - Fixed a bug where removing a pair in use would cause a crash.

--- a/scripts/Muon/GUI/FrequencyDomainAnalysis/FFT/fft_view_new.py
+++ b/scripts/Muon/GUI/FrequencyDomainAnalysis/FFT/fft_view_new.py
@@ -49,15 +49,17 @@ class FFTView(QtWidgets.QWidget):
             self.Im_box_row,
             "Imaginary Data")
         self.Im_box = table_utils.addCheckBoxToTable(
-            self.FFTTable, True, self.Im_box_row)
+            self.FFTTable, False, self.Im_box_row)
 
         table_utils.setRowName(self.FFTTable, 2, "Imaginary Workspace")
         self.Im_ws = table_utils.addComboToTable(self.FFTTable, 2, options)
+        self.FFTTable.hideRow(2)
 
         self.shift_box_row = 3
         table_utils.setRowName(self.FFTTable, self.shift_box_row, "Auto shift")
         self.shift_box = table_utils.addCheckBoxToTable(
             self.FFTTable, True, self.shift_box_row)
+        self.FFTTable.hideRow(3)
 
         table_utils.setRowName(self.FFTTable, 4, "Shift")
         self.shift = table_utils.addDoubleToTable(self.FFTTable, 0.0, 4)

--- a/scripts/test/Muon/fft_presenter_context_interaction_test.py
+++ b/scripts/test/Muon/fft_presenter_context_interaction_test.py
@@ -168,8 +168,8 @@ class FFTPresenterTest(unittest.TestCase):
         self.presenter.getWorkspaceNames()
         self.view.ws.setCurrentIndex(1)
         self.assertEqual(self.presenter.get_fft_inputs('input_workspace', 'imaginary_input_workspace'),
-                         {'AcceptXRoundingErrors': True, 'AutoShift': True, 'Imaginary': 0,
-                          'InputImagWorkspace': 'imaginary_input_workspace', 'InputWorkspace': 'input_workspace',
+                         {'AcceptXRoundingErrors': True, 'AutoShift': True,
+                          'InputWorkspace': 'input_workspace',
                           'Real': 0, 'Transform': 'Forward'})
 
     def test_get_fft_inputs_with_no_imaginary_workspace_specified(self):


### PR DESCRIPTION
**Description of work.**
The think that the reason for the complaints about FFT's was because the default values were not helpful. 

I have made the FFT pure real by default and hidden the auto shift option. This is technically a regression in functionality. However, I do not think the shift was being set manually by users and I have not found an example where you would want to set it manually. I have just hidden it for now, so we can put it back in if the users want it.


<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

**To test:**

<!-- Instructions for testing. -->
Open frequency domain analysis
Load EMU 113083
Go to the transform tab
Click calculate - you should get a nice sharp peak around 20 Gauss
Tick the imaginary option and try a few different imaginary workspaces, when you press calculate the FFT should change
The imaginary workspace selector should only be visible when the imaginary option is ticked


Fixes #31150 . <!-- and fix #xxxx or close #xxxx xor resolves #xxxx -->
<!-- alternative
*There is no associated issue.*
-->

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or master)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
