### PR TITLE
Muon Analysis - Do not reset start and end x when stepping to new run

### DIFF
--- a/docs/source/release/v6.1.0/muon.rst
+++ b/docs/source/release/v6.1.0/muon.rst
@@ -45,6 +45,7 @@ Bug fixes
   Group Asymmetry Range with no data loaded.
 - Fixed a crash caused when switching between tabs in Muon Analysis.
 - Fixed a usability issue where tabs became unattached too easily. It is now possible to unattach the tabs only by double clicking on them.
+- Fixed a bug where the start and end X would reset in the fitting tab when stepping to the next or previous run.
 
 ALC
 ---

--- a/scripts/Muon/GUI/Common/fitting_widgets/basic_fitting/basic_fitting_model.py
+++ b/scripts/Muon/GUI/Common/fitting_widgets/basic_fitting/basic_fitting_model.py
@@ -463,23 +463,27 @@ class BasicFittingModel:
 
     def _get_new_start_xs_and_end_xs_using_existing_datasets(self, new_dataset_names: list) -> tuple:
         """Returns the start and end Xs to use for the new datasets. It tries to use existing ranges if possible."""
-        start_xs = [self._get_new_start_x_for(name) for name in new_dataset_names]
-        end_xs = [self._get_new_end_x_for(name) for name in new_dataset_names]
-        return start_xs, end_xs
+        if len(self.dataset_names) == len(new_dataset_names):
+            return self.start_xs, self.end_xs
+        else:
+            start_xs = [self._get_new_start_x_for(name) for name in new_dataset_names]
+            end_xs = [self._get_new_end_x_for(name) for name in new_dataset_names]
+            return start_xs, end_xs
 
     def _get_new_start_x_for(self, new_dataset_name: str) -> float:
         """Returns the start X to use for the new dataset. It tries to use an existing start X if possible."""
         if new_dataset_name in self.dataset_names:
             return self.start_xs[self.dataset_names.index(new_dataset_name)]
         else:
-            return self.retrieve_first_good_data_from_run(new_dataset_name)
+            return self.current_start_x if self.current_dataset_index is not None \
+                else self.retrieve_first_good_data_from_run(new_dataset_name)
 
     def _get_new_end_x_for(self, new_dataset_name: str) -> float:
         """Returns the end X to use for the new dataset. It tries to use an existing end X if possible."""
         if new_dataset_name in self.dataset_names:
             return self.end_xs[self.dataset_names.index(new_dataset_name)]
         else:
-            return self.current_end_x if len(self.end_xs) > 0 else self._default_end_x
+            return self.current_end_x if self.current_dataset_index is not None else self._default_end_x
 
     def _get_new_functions_using_existing_datasets(self, new_dataset_names: list) -> list:
         """Returns the functions to use for the new datasets. It tries to use the existing functions if possible."""

--- a/scripts/Muon/GUI/Common/fitting_widgets/basic_fitting/basic_fitting_model.py
+++ b/scripts/Muon/GUI/Common/fitting_widgets/basic_fitting/basic_fitting_model.py
@@ -458,8 +458,7 @@ class BasicFittingModel:
 
     def _reset_end_xs(self) -> None:
         """Resets the end Xs stored by the model."""
-        end_x = self.current_end_x if len(self.end_xs) > 0 else self._default_end_x
-        self.end_xs = [end_x] * self.number_of_datasets
+        self.end_xs = [self.current_end_x] * self.number_of_datasets
 
     def _get_new_start_xs_and_end_xs_using_existing_datasets(self, new_dataset_names: list) -> tuple:
         """Returns the start and end Xs to use for the new datasets. It tries to use existing ranges if possible."""
@@ -483,7 +482,7 @@ class BasicFittingModel:
         if new_dataset_name in self.dataset_names:
             return self.end_xs[self.dataset_names.index(new_dataset_name)]
         else:
-            return self.current_end_x if self.current_dataset_index is not None else self._default_end_x
+            return self.current_end_x
 
     def _get_new_functions_using_existing_datasets(self, new_dataset_names: list) -> list:
         """Returns the functions to use for the new datasets. It tries to use the existing functions if possible."""

--- a/scripts/Muon/GUI/Common/fitting_widgets/basic_fitting/basic_fitting_presenter.py
+++ b/scripts/Muon/GUI/Common/fitting_widgets/basic_fitting/basic_fitting_presenter.py
@@ -283,6 +283,11 @@ class BasicFittingPresenter:
                                                           self.model.current_chi_squared)
         self.view.update_global_fit_status(self.model.fit_statuses, self.model.current_dataset_index)
 
+    def update_start_and_end_x_in_view_from_model(self) -> None:
+        """Updates the start and end x in the view using the current values in the model."""
+        self.view.start_x = self.model.current_start_x
+        self.view.end_x = self.model.current_end_x
+
     def _get_single_fit_functions_from_view(self) -> list:
         """Returns the fit functions corresponding to each domain as a list."""
         if self.view.fit_object:

--- a/scripts/Muon/GUI/Common/fitting_widgets/general_fitting/general_fitting_presenter.py
+++ b/scripts/Muon/GUI/Common/fitting_widgets/general_fitting/general_fitting_presenter.py
@@ -112,7 +112,6 @@ class GeneralFittingPresenter(BasicFittingPresenter):
         # Triggers handle_dataset_name_changed
         self.update_dataset_names_in_view_and_model()
 
-        self.reset_start_xs_and_end_xs()
         self.reset_fit_status_and_chi_squared_information()
         self.clear_cached_fit_functions()
 
@@ -122,11 +121,9 @@ class GeneralFittingPresenter(BasicFittingPresenter):
         """Handle when the display workspace combo box is changed."""
         self.model.current_dataset_index = self.view.current_dataset_index
 
-        self.view.start_x = self.model.current_start_x
-        self.view.end_x = self.model.current_end_x
-
         self.update_fit_statuses_and_chi_squared_in_view_from_model()
         self.update_fit_function_in_view_from_model()
+        self.update_start_and_end_x_in_view_from_model()
 
         if self._update_plot:
             self.selected_fit_results_changed.notify_subscribers(self.model.get_active_fit_results())

--- a/scripts/test/Muon/fitting_widgets/basic_fitting/basic_fitting_model_test.py
+++ b/scripts/test/Muon/fitting_widgets/basic_fitting/basic_fitting_model_test.py
@@ -54,8 +54,29 @@ class BasicFittingModelTest(unittest.TestCase):
 
         self.model.dataset_names = ["NewName", "Name1"]
 
-        self.assertEqual(self.model.start_xs, [0.0, 2.0])
-        self.assertEqual(self.model.end_xs, [4.0, 4.0])
+        self.assertEqual(self.model.start_xs, [2.0, 3.0])
+        self.assertEqual(self.model.end_xs, [4.0, 5.0])
+
+    def test_that_the_currently_selected_start_and_end_xs_are_used_for_when_a_larger_number_of_new_datasets_are_loaded(self):
+        self.model.dataset_names = self.dataset_names
+        self.model.current_dataset_index = 1
+        self.model.start_xs = [2.0, 3.0]
+        self.model.end_xs = [4.0, 5.0]
+
+        self.model.dataset_names = ["Name1", "Name2", "Name3"]
+
+        self.assertEqual(self.model.start_xs, [2.0, 3.0, 3.0])
+        self.assertEqual(self.model.end_xs, [4.0, 5.0, 5.0])
+
+    def test_that_newly_loaded_datasets_will_reuse_the_existing_xs_when_there_are_fewer_new_datasets(self):
+        self.model.dataset_names = self.dataset_names
+        self.model.start_xs = [2.0, 3.0]
+        self.model.end_xs = [4.0, 5.0]
+
+        self.model.dataset_names = ["Name2"]
+
+        self.assertEqual(self.model.start_xs, [3.0])
+        self.assertEqual(self.model.end_xs, [5.0])
 
     def test_that_current_dataset_index_will_raise_if_the_index_is_greater_than_or_equal_to_the_number_of_datasets(self):
         self.model.dataset_names = self.dataset_names

--- a/scripts/test/Muon/fitting_widgets/basic_fitting/basic_fitting_presenter_test.py
+++ b/scripts/test/Muon/fitting_widgets/basic_fitting/basic_fitting_presenter_test.py
@@ -388,6 +388,14 @@ class BasicFittingPresenterTest(unittest.TestCase):
         self.view.update_global_fit_status.assert_called_once_with([self.fit_status] * len(self.dataset_names),
                                                                    self.current_dataset_index)
 
+    def test_that_update_start_and_end_x_in_view_from_model_will_update_the_start_and_end_x_in_the_view(self):
+        self.presenter.update_start_and_end_x_in_view_from_model()
+
+        self.mock_model_current_start_x.assert_called_once_with()
+        self.mock_view_start_x.assert_called_once_with(self.start_x)
+        self.mock_model_current_end_x.assert_called_once_with()
+        self.mock_view_end_x.assert_called_once_with(self.end_x)
+
     def _setup_mock_view(self):
         self.view = mock.Mock(spec=BasicFittingView)
         self.view = add_mock_methods_to_basic_fitting_view(self.view)

--- a/scripts/test/Muon/fitting_widgets/general_fitting/general_fitting_presenter_test.py
+++ b/scripts/test/Muon/fitting_widgets/general_fitting/general_fitting_presenter_test.py
@@ -156,7 +156,6 @@ class GeneralFittingPresenterTest(unittest.TestCase):
 
     def test_that_handle_simultaneous_fit_by_specifier_changed_will_update_the_model(self):
         self.presenter.update_dataset_names_in_view_and_model = mock.Mock()
-        self.presenter.reset_start_xs_and_end_xs = mock.Mock()
         self.presenter.reset_fit_status_and_chi_squared_information = mock.Mock()
         self.presenter.clear_cached_fit_functions = mock.Mock()
 
@@ -166,7 +165,6 @@ class GeneralFittingPresenterTest(unittest.TestCase):
         self.mock_model_simultaneous_fit_by_specifier.assert_called_with(self.simultaneous_fit_by_specifier)
 
         self.presenter.update_dataset_names_in_view_and_model.assert_called_once_with()
-        self.presenter.reset_start_xs_and_end_xs.assert_called_once_with()
         self.presenter.reset_fit_status_and_chi_squared_information.assert_called_once_with()
         self.presenter.clear_cached_fit_functions.assert_called_once_with()
         self.presenter.simultaneous_fit_by_specifier_changed.notify_subscribers.assert_called_once_with()
@@ -174,19 +172,16 @@ class GeneralFittingPresenterTest(unittest.TestCase):
     def test_that_handle_dataset_name_changed_will_update_the_model_and_view(self):
         self.presenter.update_fit_statuses_and_chi_squared_in_view_from_model = mock.Mock()
         self.presenter.update_fit_function_in_view_from_model = mock.Mock()
+        self.presenter.update_start_and_end_x_in_view_from_model = mock.Mock()
 
         self.presenter.handle_dataset_name_changed()
 
         self.mock_view_current_dataset_index.assert_called_once_with()
         self.mock_model_current_dataset_index.assert_called_once_with(self.current_dataset_index)
 
-        self.mock_model_current_start_x.assert_called_once_with()
-        self.mock_model_current_end_x.assert_called_once_with()
-        self.mock_view_start_x.assert_called_once_with(self.start_x)
-        self.mock_view_end_x.assert_called_once_with(self.end_x)
-
         self.presenter.update_fit_statuses_and_chi_squared_in_view_from_model.assert_called_once_with()
         self.presenter.update_fit_function_in_view_from_model.assert_called_once_with()
+        self.presenter.update_start_and_end_x_in_view_from_model.assert_called_once_with()
 
         self.mock_view_plot_guess.assert_called_once_with()
         self.model.update_plot_guess.assert_called_once_with(self.plot_guess)


### PR DESCRIPTION
**Description of work.**
This PR ensures the start and end x on the fitting tab are not reset when stepping to a new run on Muon Analysis. It tries to reuse the start and end Xs that are currently loaded in the gui.

**To test:**
Open muon analysis
MUSR 62260
Change the Time Start and Time End in the fitting tab. Make them different for each dataset in the combobox

Step to the next run using the `>` button next to the run box. The time start and end should be reused.

Fixes #31460

*This does not require release notes* because **it is part of the recent refactor**

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
