### PR TITLE
Fix link to git cheatsheet

### DIFF
--- a/dev-docs/source/GitWorkflow.rst
+++ b/dev-docs/source/GitWorkflow.rst
@@ -18,7 +18,9 @@ This page describes the workflow used in conjunction with `Git
 those who have push access to the repository.
 
 Go `here
-<https://services.github.com/on-demand/downloads/github-git-cheat-sheet.pdf>`__
+<https://education.github.com/git-cheat-sheet-education.pdf>`__
+or `here
+<https://www.atlassian.com/git/tutorials/atlassian-git-cheatsheet>`__
 for a cheatsheet of Git commands.
 
 Go `here <https://github.com/k88hudson/git-flight-rules>`__ for a


### PR DESCRIPTION
**Description of work.**
The link to a GitHub cheatsheet needed updating here:
https://developer.mantidproject.org/GitWorkflow.html
I've added an additional link to a BitBucket git cheatsheet that contains a few more advanced commands.

**To test:**
- Build dev-docs-html
- Open <mantid-build>/dev-docs/html/GitWorkflow.html
- Check the links to git cheatsheets function correctly.


*There is no associated issue.*


*This does not require release notes* because it it a minor update to developer docs.

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
