### PR TITLE
Catch exceptions by reference (ornl-next)

### DIFF
--- a/Framework/API/src/SpectrumInfo.cpp
+++ b/Framework/API/src/SpectrumInfo.cpp
@@ -236,7 +236,7 @@ void SpectrumInfo::getDetectorValues(const Kernel::Unit &inputUnit, const Kernel
       try {
         pmap[UnitParams::efixed] = m_experimentInfo.getEFixedGivenEMode(det, emode);
         g_log.debug() << "Detector: " << det->getID() << " EFixed: " << pmap[UnitParams::efixed] << "\n";
-      } catch (std::runtime_error) {
+      } catch (std::runtime_error &) {
         // let the unit classes work out if this is a problem
       }
     }

--- a/Framework/Algorithms/src/ConvertUnits.cpp
+++ b/Framework/Algorithms/src/ConvertUnits.cpp
@@ -425,7 +425,7 @@ MatrixWorkspace_sptr ConvertUnits::convertViaTOF(Kernel::Unit_const_sptr fromUni
     checkFromUnit->toTOF(checkXValues, emptyVec, l1, emode, pmap);
     // Convert from time-of-flight to the desired unit
     checkOutputUnit->fromTOF(checkXValues, emptyVec, l1, emode, pmap);
-  } catch (std::runtime_error) { // if it's a detector specific problem then ignore
+  } catch (std::runtime_error &) { // if it's a detector specific problem then ignore
   }
 
   // create the output workspace
@@ -462,7 +462,7 @@ MatrixWorkspace_sptr ConvertUnits::convertViaTOF(Kernel::Unit_const_sptr fromUni
       if (m_inputEvents) {
         eventWS->getSpectrum(i).convertUnitsViaTof(localFromUnit.get(), localOutputUnit.get());
       }
-    } catch (std::runtime_error) {
+    } catch (std::runtime_error &) {
       // Get to here if exception thrown in unit conversion eg when calculating
       // distance to detector
       failedDetectorCount++;

--- a/Framework/Muon/src/PSIBackgroundSubtraction.cpp
+++ b/Framework/Muon/src/PSIBackgroundSubtraction.cpp
@@ -81,12 +81,12 @@ std::map<std::string, std::string> PSIBackgroundSubtraction::validateInputs() {
     int lastGood = 0;
     try {
       firstGood = std::stoi(run.getProperty(FIRST_GOOD + std::to_string(index))->value());
-    } catch (Kernel::Exception::NotFoundError) {
+    } catch (Kernel::Exception::NotFoundError &) {
       errors["InputWorkspace"] = "Input Workspace should should contain first food data. ";
     }
     try {
       lastGood = std::stoi(run.getProperty(LAST_GOOD + std::to_string(index))->value());
-    } catch (Kernel::Exception::NotFoundError) {
+    } catch (Kernel::Exception::NotFoundError &) {
       errors["InputWorkspace"] += "\n Input Workspace should should contain last food data. ";
     }
     if (lastGood <= firstGood) {


### PR DESCRIPTION
This is a minor change to catch exceptions by reference as caught by gcc9.

The version into `master` is #31522.