### PR TITLE
Add a Sliceviewer page to the user documentation

### DIFF
--- a/docs/source/algorithms/BASISCrystalDiffraction-v1.rst
+++ b/docs/source/algorithms/BASISCrystalDiffraction-v1.rst
@@ -33,7 +33,7 @@ The default range is [5.86, 6.75].
 **OutputWorkspace**: a two-dimensional :ref:`MDHistoWorkspace <MDHistoWorkspace>`
 containing the intensities projected onto the reciprocal slice, integrated over
 the independent axis *Wproj*. The diffraction pattern can be visualized with
-the `SliceViewer <http://www.mantidproject.org/SliceViewer>`_.
+the :ref:`sliceviewer`.
 
 **Background runs**: one or more run numbers to describe the background, and a
 scaling factor between zero and one.
@@ -112,5 +112,3 @@ Usage
 .. categories::
 
 .. sourcelink::
-
-

--- a/docs/source/algorithms/BASISDiffraction-v1.rst
+++ b/docs/source/algorithms/BASISDiffraction-v1.rst
@@ -33,7 +33,7 @@ The default range is [5.86, 6.75].
 **OutputWorkspace**: a two-dimensional :ref:`MDHistoWorkspace <MDHistoWorkspace>`
 containing the intensities projected onto the reciprocal slice, integrated over
 the independent axis *Wproj*. The diffraction pattern can be visualized with
-the `SliceViewer <http://www.mantidproject.org/SliceViewer>`_.
+the :ref:`sliceviewer`.
 
 **Background runs**: one or more run numbers to describe the background, and a
 scaling factor between zero and one.
@@ -113,5 +113,3 @@ Usage
 .. categories::
 
 .. sourcelink::
-
-

--- a/docs/source/algorithms/BinMD-v1.rst
+++ b/docs/source/algorithms/BinMD-v1.rst
@@ -124,7 +124,7 @@ Output:
 
     Number of events = 250734
 
-The output looks like the following in the `SliceViewer <http://www.mantidproject.org/MantidPlot:_SliceViewer>`_:
+The output looks like the following in the :ref:`sliceviewer`:
 
 .. image:: /images/BinMD_AxisAligned.png
     :alt: The sliceveiwer with the axis aligned cut
@@ -147,7 +147,7 @@ Output:
 
     Number of events = 300000
 
-The output looks like the following in the `SliceViewer <http://www.mantidproject.org/MantidPlot:_SliceViewer>`_:
+The output looks like the following in the :ref:`sliceviewer`:
 
 .. image:: /images/BinMD_NonAxisAligned.png
     :alt: The sliceveiwer with the non axis aligned cut

--- a/docs/source/algorithms/CalculateCoverageDGS-v1.rst
+++ b/docs/source/algorithms/CalculateCoverageDGS-v1.rst
@@ -13,7 +13,7 @@ Description
 The algorithm calculates what part of the reciprocal space is covered by direct geometry spectrometers. It is supposed to be used
 in planning tools. The input workspace should contain the incident energy log, a goniometer, and the :ref:`UB matrix <Lattice>`. The
 incident energy can be overwritten by setting the IncidentEnergy parameter. The output is an MDHisto workspace. You can visualize it with
-SliceViewer.
+:ref:`sliceviewer`.
 
 
 The parameters Q1Basis, Q2Basis, Q3Basis can be used to look at different directions in the reciprocal space, such as [H,H,0]

--- a/docs/source/algorithms/ConvertToDetectorFaceMD-v1.rst
+++ b/docs/source/algorithms/ConvertToDetectorFaceMD-v1.rst
@@ -11,7 +11,7 @@ Description
 
 This algorithm takes a a :ref:`MatrixWorkspace <MatrixWorkspace>` and
 converts it into a :ref:`MDEventWorkspace <MDWorkspace>` that can be
-viewed in the `SliceViewer <http://www.mantidproject.org/SliceViewer>`_.
+viewed in the :ref:`sliceviewer`.
 
 The algorithm currently only works for instruments with
 :ref:`rectangular detectors <Creating Rectangular Area Detectors>`. The coordinates of the
@@ -26,7 +26,7 @@ Each MDEvent created has a weight given by the number of counts in that
 bin. Zero bins are not converted to events (saving memory).
 
 Once created, the :ref:`MDEventWorkspace <MDWorkspace>` can be viewed
-in the `SliceViewer <http://www.mantidproject.org/SliceViewer>`_. It can also be rebinned with
+in the :ref:`sliceviewer`. It can also be rebinned with
 different parameters using :ref:`algm-BinMD`. This allows you to view
 the data in detector-space. For example, you might use this feature to
 look at your detector's sensitivity as a function of position, as well

--- a/docs/source/algorithms/ConvertToDiffractionMDWorkspace-v1.rst
+++ b/docs/source/algorithms/ConvertToDiffractionMDWorkspace-v1.rst
@@ -61,7 +61,7 @@ of the workspace, **including zeros**.
 
 This can be useful in cases where the experimental coverage needs to be
 tracked. With one MDEvent for each bin, you can count which regions in
-Q-space have been measured. The `SliceViewer <http://www.mantidproject.org/SliceViewer>`__ has an
+Q-space have been measured. The :ref:`sliceviewer` has an
 option to view normalized by number of events. This means that, for
 example, areas with overlap from two runs will appear scaled down.
 

--- a/docs/source/algorithms/FakeMDEventData-v1.rst
+++ b/docs/source/algorithms/FakeMDEventData-v1.rst
@@ -36,7 +36,7 @@ Output:
 
     Number of events = 1000000
 
-The output looks like the following in the `SliceViewer <http://www.mantidproject.org/MantidPlot:_SliceViewer>`_:
+The output looks like the following in the :ref:`sliceviewer`:
 
 .. image:: /images/FakeMDEventData_Uniform2D.png
     :alt: Uniform 2D FakeMDEventData
@@ -62,7 +62,7 @@ Output:
 
     Number of events = 150000
 
-The output looks like the following in the `SliceViewer <http://www.mantidproject.org/MantidPlot:_SliceViewer>`_:
+The output looks like the following in the :ref:`sliceviewer`:
 
 .. image:: /images/FakeMDEventData_Peaks3D.png
     :alt: Peaks 3D FakeMDEventData
@@ -86,7 +86,7 @@ Output:
 
     Number of events = 1000000
 
-The output looks like the following in the `SliceViewer <http://www.mantidproject.org/MantidPlot:_SliceViewer>`_ when
+The output looks like the following in the :ref:`sliceviewer` when
 the T slider is moved to ~5K:
 
 .. image:: /images/FakeMDEventData_Peaks4D.png

--- a/docs/source/algorithms/IntegratePeaksHybrid-v1.rst
+++ b/docs/source/algorithms/IntegratePeaksHybrid-v1.rst
@@ -29,7 +29,9 @@ work.
 .. figure:: /images/ClusterImage.png
    :alt: ClusterImage.png
 
-   Cluster Label region displayed in the SliceViewer. Peak centre is marked with an X. The green circle illustrates the integration region used by :ref:`algm-IntegratePeaksMD`
+   Cluster Label region displayed in the :ref:`sliceviewer`.
+   Peak centre is marked with an X.
+   The green circle illustrates the integration region used by :ref:`algm-IntegratePeaksMD`
 
 Warnings and Logging
 --------------------

--- a/docs/source/algorithms/IntegratePeaksUsingClusters-v1.rst
+++ b/docs/source/algorithms/IntegratePeaksUsingClusters-v1.rst
@@ -38,8 +38,7 @@ considered background.
 This algorithm uses an imaging technique, and it is therefore important
 that the MDHistoWorkspace you are using is binned to a sufficient
 resolution via :ref:`algm-BinMD`. You can overlay the integrated peaks
-workspace in the `Slice
-Viewer <MantidPlot:_SliceViewer#Viewing_Peaks_Workspaces>`__ over the
+workspace in the :ref:`Sliceviewer <sliceviewer_peaks_overlay>` over the
 generated Cluster Labeled OutputWorkspaceMD to see what the iteration
 region used for each peak amounts to.
 

--- a/docs/source/concepts/MDHistoWorkspace.rst
+++ b/docs/source/concepts/MDHistoWorkspace.rst
@@ -36,8 +36,7 @@ Viewing a MDHistoWorkspace
 
    -  **Plot MD**: to perform a 1D plot of the signal in the workspace
       (only works on 1D MDHistoWorkspaces).
-   -  **Show Slice Viewer**: to open the `Slice
-      Viewer <http://www.mantidproject.org/MantidPlot:_SliceViewer>`__, which shows 2D slices of the
+   -  **Show Slice Viewer**: to open the :ref:`sliceviewer`, which shows 2D slices of the
       multiple-dimension workspace.
 
 

--- a/docs/source/concepts/MDWorkspace.rst
+++ b/docs/source/concepts/MDWorkspace.rst
@@ -98,13 +98,8 @@ Viewing MDWorkspaces
 
 -  Right-click on a MDWorkspace and select:
 
-   -  **Show Slice Viewer**: to open the `Slice
-      Viewer <http://www.mantidproject.org/MantidPlot:_SliceViewer>`__, which shows 2D slices of the
+   -  **Show Slice Viewer**: to open the :ref:`sliceviewer`, which shows 2D slices of the
       multiple-dimensional workspace.
-
--  You can also `use Python script to open the
-   SliceViewer <http://www.mantidproject.org/SliceViewer_Python_Interface>`__.
-
 
 
 Working with Table Workspaces in Python

--- a/docs/source/concepts/PeaksWorkspace.rst
+++ b/docs/source/concepts/PeaksWorkspace.rst
@@ -21,9 +21,7 @@ Viewing a PeaksWorkspace
 * Double-click a PeaksWorkspace to see the full list of data of each Peak object.
 * In MantidWorkbench, you can drag/drop a PeaksWorkspace from the list of workspaces onto the
   :ref:`Instrument View <InstrumentViewer>`. This will overlay the peaks onto the detector face.
-* `PeaksViewer <http://www.mantidproject.org/PeaksViewer>`__ in the
-  `SliceViewer <http://www.mantidproject.org/SliceViewer>`__.
-
+* :ref:`Peaks overlay <sliceviewer_peaks_overlay>` in the :ref:`sliceviewer`.
 
 Each peak object contains several pieces of information. Not all of them are necessary
 

--- a/docs/source/workbench/sliceviewer.rst
+++ b/docs/source/workbench/sliceviewer.rst
@@ -1,40 +1,42 @@
-.. _sliceviewer_release:
+.. _sliceviewer:
 
-===================
-Sliceviewer Changes
-===================
+===========
+Sliceviewer
+===========
 
 .. contents:: Table of Contents
    :local:
 
-New Features
-------------
+Overview
+--------
 
-The new Sliceviewer provided in mantidworkbench has acquired several new features in this release including:
+.. figure:: ../images/wb-sliceviewer51-roi.png
+   :class: screenshot
+   :align: center
+
+The Sliceviewer is a viewer supporting :ref:`MDEventWorkspace <MDWorkspace>`, :ref:`MDHistoWorkspace <MDWorkspace>` & :ref:`MatrixWorkspace`.
+For multi-dimensional workspaces, you can view both MDWorkspaces and MDHistoWorkspaces, a 2D "slice" of the higher dimensional space
+is shown, whereas a MarixWorkspace simply shows the 2 defined dimensions.
+
+Some of the key features of the Sliceviewer provided are:
 
 - Overlay of peaks workspaces
 - Non-orthogonal axes view mode, including peaks workspace overlays
 - ROI preview and extraction
-- New cursor information widget that, for a MatrixWorkspace, includes quantities such as :math:`l1, l2, 2\theta` etc
+- Cursor information widget that, for a MatrixWorkspace, includes quantities such as :math:`l1, l2, 2\theta` etc
 - Arrow keys can now be used to move the cursor a pixel at a time when single-pixel line plots are enabled
-- Zoom mode is now selected by default
-- Removed reverse colormaps and added a checkbox
-- Colormap follows default in settings
-- Colorbar scale remains set when reopened
-- Width of line plot lines has been reduced
-- The intensity scale on the line plots now follows the scaling set on the colorbar
-- The figure options button has been removed as most options did not apply to it.
 
-The following sections illustrate some of these key new features.
+The following sections illustrate some of these key features.
+
+.. _sliceviewer_peaks_overlay:
 
 PeaksWorkspace Overlay
-######################
+----------------------
 
-The peaks overlay button allows selection of one or more PeaksWorkspaces
-to display on top of the main data image.
+The peaks overlay button allows selection of one or more PeaksWorkspaces to display on top of the main data image.
 This is only enabled for MD workspaces.
 
-.. figure:: ../../images/wb-sliceviewer51-peaksbutton.png
+.. figure:: ../images/wb-sliceviewer51-peaksbutton.png
    :class: screenshot
    :align: center
 
@@ -42,38 +44,38 @@ Peaks are displayed at the locations defined by each peak center
 with an 'x', while optionally displaying any peak shape if a given peak has
 been integrated.
 
-.. figure:: ../../images/wb-sliceviewer51-peaksoverlay.png
+.. figure:: ../images/wb-sliceviewer51-peaksoverlay.png
    :class: screenshot
    :width: 75%
    :align: center
 
 
 Non-Orthogonal Axes View
-^^^^^^^^^^^^^^^^^^^^^^^^
+------------------------
 
 If the units of an MDWorkspace are HKL and the workspace has an attached
 UB matrix then the option to display the image using axes aligned with the
 crystal (so-called non-orthogonal view) will be now be visible:
 
-.. figure:: ../../images/wb-sliceviewer51-nonorthobutton.png
+.. figure:: ../images/wb-sliceviewer51-nonorthobutton.png
    :class: screenshot
    :align: center
 
 Activating this option transforms the axes taking into account the lattice
 angles encoded by the UB matrix:
 
-.. figure:: ../../images/wb-sliceviewer51-nonorthogonal.png
+.. figure:: ../images/wb-sliceviewer51-nonorthogonal.png
    :class: screenshot
    :width: 75%
    :align: center
 
 ROI Preview & Extraction
-########################
+------------------------
 
 In addition to the single-pixel line plots that were present in the previous release,
 a new tool to allow selection of a rectangular region of interest has been added:
 
-.. figure:: ../../images/wb-sliceviewer51-roibutton.png
+.. figure:: ../images/wb-sliceviewer51-roibutton.png
    :class: screenshot
    :align: center
 
@@ -81,7 +83,7 @@ Selecting this tool enables the line plots attached to the image axes but instea
 the line plots being the sum over a single pixel in the orthogonal direction the sum
 is now limited to the selected region:
 
-.. figure:: ../../images/wb-sliceviewer51-roi.png
+.. figure:: ../images/wb-sliceviewer51-roi.png
    :class: screenshot
    :width: 75%
    :align: center
@@ -90,8 +92,10 @@ A new status bar has been added at the bottom to indicate that the cuts can be e
 to separate workspaces by using the relevant keys. Similar keys and status information is
 presented in the single-pixel line plots mode.
 
+.. _sliceviewer_cursor:
+
 Cursor Information Widget
-#########################
+-------------------------
 
 The revamped Sliceviewer has merged several features from the SpectrumViewer
 in MantidPlot. One of these new features is the ability to show information
@@ -110,7 +114,7 @@ shows the following quantities for a MatrixWorkspace:
 - \|Q\|
 
 
-.. figure:: ../../images/wb-sliceviewer51-cursorinfo-matrix.png
+.. figure:: ../images/wb-sliceviewer51-cursorinfo-matrix.png
    :class: screenshot
    :width: 75%
    :align: center
@@ -122,10 +126,12 @@ and for an MDWorkspace:
 - x
 - y
 
-.. figure:: ../../images/wb-sliceviewer51-cursorinfo-md.png
+.. figure:: ../images/wb-sliceviewer51-cursorinfo-md.png
    :class: screenshot
    :width: 75%
    :align: center
 
-
-:ref:`Release 5.1.0 <v5.1.0>`
+Underneath the cursor there is a checkbox labelled ``Track Cursor``.
+When checked, the information in the table is updated as the cursor moves
+around the image. If unchecked, the information within the table is updated
+only when the left-mouse button is clicked within the image.


### PR DESCRIPTION
**Description of work.**

The Sliceviewer documentation was still on the wiki. This creates a page for the new Sliceviewer under the workbench directory in the docs and changes all of the references internally to this page.

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

**To test:**

* Build the docs
* Review the new page

*There is no associated issue.*

*This does not require release notes* because **it is not a new feature**

<!-- Ensure the base of this PR is correct (e.g. release-next or master)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
