### PR TITLE
Fix broken batch button from 76fac4a58f04323d558ab3bb972ab53e042299b6

### DIFF
--- a/scripts/SANS/sans/gui_logic/presenter/run_tab_presenter.py
+++ b/scripts/SANS/sans/gui_logic/presenter/run_tab_presenter.py
@@ -476,6 +476,8 @@ class RunTabPresenter(PresenterCommon):
             self.sans_logger.error("Loading of the batch file failed. {}".format(str(e)))
             self.display_warning_box('Warning', 'Loading of the batch file failed', str(e))
 
+        self.on_update_rows()
+
     def _add_multiple_rows_to_table_model(self, rows):
         self._table_model.add_multiple_table_entries(table_index_model_list=rows)
 

--- a/scripts/test/SANS/gui_logic/run_tab_presenter_test.py
+++ b/scripts/test/SANS/gui_logic/run_tab_presenter_test.py
@@ -153,6 +153,7 @@ class RunTabPresenterTest(unittest.TestCase):
     def test_that_gets_states_from_view(self):
         # Arrange
         batch_file_path, user_file_path, _ = self._get_files_and_mock_presenter(BATCH_FILE_TEST_CONTENT_2)
+        self.presenter.on_update_rows = mock.Mock()
         self.presenter.on_user_file_load()
         self.presenter.on_batch_file_load()
 
@@ -186,6 +187,8 @@ class RunTabPresenterTest(unittest.TestCase):
 
         self.assertEqual(state0.all_states.reduction.reduction_dimensionality, ReductionDimensionality.ONE_DIM)
         self.assertEqual(state0.all_states.move.detectors['LAB'].sample_centre_pos1, 0.15544999999999998)
+
+        self.presenter.on_update_rows.assert_called_once()
 
         # Clean up
         self._remove_files(user_file_path=user_file_path, batch_file_path=batch_file_path)


### PR DESCRIPTION
**Description of work.**

Fixes the batch loading, which is not updating the GUI after 76fac4a58f04323d558ab3bb972ab53e042299b6
A simple revert wouldn't work, as it re-introduces a bug where we try to
access a table row that does not exist. Instead we explicitly call
the on_update_rows since the presenter / model has updated the rows

**To test:**
- Download the ISIS Training Data
- Ensure LOQ Demo folder is present
- Open the ISIS SANS GUI
- Hit batch file and point to the .csv file in the LOQ Demo folder
- Ensure rows appears (before nothing happened)
- Process the first row, it should complete

Fixes #31476 
Fixes #31485
<!-- alternative
*There is no associated issue.*
-->

*This does not require release notes* because regression was introduced in last 2 weeks

<!-- Ensure the base of this PR is correct (e.g. release-next or master)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
