### PR TITLE
Prevent show full function resetting fit in indirect data analysis

### DIFF
--- a/docs/source/release/v6.1.0/indirect_geometry.rst
+++ b/docs/source/release/v6.1.0/indirect_geometry.rst
@@ -26,5 +26,6 @@ Bug Fixes
 - In IsoRotDiff, DiffSphere, and DiffRotDiscreteCircle Aliases have been removed to avoid clashes with interfaces.
 - Fixed a bug that caused an error warning when adding EISF data to F(q) fit if Width has already been added.
 - Fixed a bug that caused the spectra list in F(q) fit to be blank when reopening the add workspace dialog.
+- Fixed a bug that erased previous fits in the Indirect Data Analysis fit tabs when changing to the full function view.
 
 :ref:`Release 6.1.0 <v6.1.0>`

--- a/qt/scientific_interfaces/Indirect/IndirectFitPropertyBrowser.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectFitPropertyBrowser.cpp
@@ -117,20 +117,24 @@ QStringList IndirectFitPropertyBrowser::getLocalParameters() const {
 void IndirectFitPropertyBrowser::syncFullBrowserWithTemplate() {
   auto const fun = m_templateBrowser->getFunction();
   if (fun) {
+    m_functionBrowser->blockSignals(true);
     m_functionBrowser->setFunction(fun);
     m_functionBrowser->updateMultiDatasetParameters(*m_templateBrowser->getGlobalFunction());
     m_functionBrowser->setGlobalParameters(m_templateBrowser->getGlobalParameters());
     m_functionBrowser->setCurrentDataset(m_templateBrowser->getCurrentDataset());
+    m_functionBrowser->blockSignals(false);
   }
 }
 
 void IndirectFitPropertyBrowser::syncTemplateBrowserWithFull() {
   auto const funStr = m_functionBrowser->getFunctionString();
   if (auto const fun = m_functionBrowser->getGlobalFunction()) {
+    m_templateBrowser->blockSignals(true);
     m_templateBrowser->setFunction(funStr);
     m_templateBrowser->updateMultiDatasetParameters(*fun);
     m_templateBrowser->setGlobalParameters(m_functionBrowser->getGlobalParameters());
     m_templateBrowser->setCurrentDataset(m_functionBrowser->getCurrentDataset());
+    m_templateBrowser->blockSignals(false);
   }
 }
 

--- a/qt/scientific_interfaces/Indirect/IndirectFitPropertyBrowser.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectFitPropertyBrowser.cpp
@@ -40,6 +40,14 @@ namespace MantidQt {
 namespace CustomInterfaces {
 namespace IDA {
 
+struct ScopedSignalBlocker {
+  // block signals on construction
+  ScopedSignalBlocker(QWidget *myObject) : m_object(myObject) { m_object->blockSignals(true); }
+  // enable signals on destruction
+  ~ScopedSignalBlocker() { m_object->blockSignals(false); }
+  QWidget *m_object;
+};
+
 /**
  * Constructor
  * @param parent :: The parent widget - must be an ApplicationWindow
@@ -116,25 +124,23 @@ QStringList IndirectFitPropertyBrowser::getLocalParameters() const {
 
 void IndirectFitPropertyBrowser::syncFullBrowserWithTemplate() {
   auto const fun = m_templateBrowser->getFunction();
+  auto signalBlocker = ScopedSignalBlocker(m_functionBrowser);
   if (fun) {
-    m_functionBrowser->blockSignals(true);
     m_functionBrowser->setFunction(fun);
     m_functionBrowser->updateMultiDatasetParameters(*m_templateBrowser->getGlobalFunction());
     m_functionBrowser->setGlobalParameters(m_templateBrowser->getGlobalParameters());
     m_functionBrowser->setCurrentDataset(m_templateBrowser->getCurrentDataset());
-    m_functionBrowser->blockSignals(false);
   }
 }
 
 void IndirectFitPropertyBrowser::syncTemplateBrowserWithFull() {
   auto const funStr = m_functionBrowser->getFunctionString();
+  auto signalBlocker = ScopedSignalBlocker(m_templateBrowser);
   if (auto const fun = m_functionBrowser->getGlobalFunction()) {
-    m_templateBrowser->blockSignals(true);
     m_templateBrowser->setFunction(funStr);
     m_templateBrowser->updateMultiDatasetParameters(*fun);
     m_templateBrowser->setGlobalParameters(m_functionBrowser->getGlobalParameters());
     m_templateBrowser->setCurrentDataset(m_functionBrowser->getCurrentDataset());
-    m_templateBrowser->blockSignals(false);
   }
 }
 


### PR DESCRIPTION
This PR fixes a bug fixes a bug that caused previous fits to be erased when showing the full fit function in indirect data analysis.

**Report to:** @SpencerHowells

**To test:**

1. open indirect data analysis.
2. in each of the fit tabs:
3. load data
4. run a fit.
5. see full function, check that the plotted fit is not erased.

Fixes #29888

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
