### PR TITLE
Stop Plot Window From Disabling When New Data Is Loaded Muon Analysis

### DIFF
--- a/docs/source/release/v6.1.0/muon.rst
+++ b/docs/source/release/v6.1.0/muon.rst
@@ -44,6 +44,7 @@ Bug fixes
 - Fixed a bug in the Grouping tab where an error message would appear when changing the source of
   Group Asymmetry Range with no data loaded.
 - Fixed a crash caused when switching between tabs in Muon Analysis.
+- Fixed a bug where the plot window would sometimes become disabled when loading new data.
 - Fixed a usability issue where tabs became unattached too easily. It is now possible to unattach the tabs only by double clicking on them.
 
 ALC

--- a/scripts/Muon/GUI/Common/plot_widget/plot_widget_presenter.py
+++ b/scripts/Muon/GUI/Common/plot_widget/plot_widget_presenter.py
@@ -16,7 +16,7 @@ from Muon.GUI.Common.contexts.frequency_domain_analysis_context import Frequency
 from Muon.GUI.Common.plot_widget.plot_widget_model import PlotWidgetModel
 from Muon.GUI.Common.plot_widget.plot_widget_view_interface import PlotWidgetViewInterface
 from Muon.GUI.Common.contexts.plotting_context import PlotMode
-from mantidqt.utils.observer_pattern import GenericObserver, GenericObserverWithArgPassing, GenericObservable, Observer
+from mantidqt.utils.observer_pattern import GenericObserver, GenericObserverWithArgPassing, GenericObservable
 from mantid.dataobjects import Workspace2D
 
 
@@ -48,8 +48,8 @@ class PlotWidgetPresenterCommon(HomeTabSubWidget):
         # gui observers
         self._setup_gui_observers()
         self._setup_view_connections()
-        self.enable_observer = PlotWidgetPresenterCommon.EnableObserver(self)
-        self.disable_observer = PlotWidgetPresenterCommon.DisableObserver(self)
+        self.enable_observer = GenericObserver(self.enableView)
+        self.disable_observer = GenericObserver(self.disableView)
 
         self.update_view_from_model()
 
@@ -377,19 +377,3 @@ class PlotWidgetPresenterCommon(HomeTabSubWidget):
 
     def disableView(self):
         self._view.setEnabled(False)
-
-    class EnableObserver(Observer):
-        def __init__(self, outer):
-            Observer.__init__(self)
-            self.outer = outer
-
-        def update(self, observable, arg):
-            self.outer.enableView()
-
-    class DisableObserver(Observer):
-        def __init__(self, outer):
-            Observer.__init__(self)
-            self.outer = outer
-
-        def update(self, observable, arg):
-            self.outer.disableView()

--- a/scripts/Muon/GUI/FrequencyDomainAnalysis/frequency_domain_analysis_2.py
+++ b/scripts/Muon/GUI/FrequencyDomainAnalysis/frequency_domain_analysis_2.py
@@ -231,6 +231,8 @@ class FrequencyAnalysisGui(QtWidgets.QMainWindow):
 
         self.disable_notifier.add_subscriber(self.grouping_tab_widget.group_tab_presenter.disable_tab_observer)
 
+        self.disable_notifier.add_subscriber(self.plot_widget.presenter.disable_observer)
+
     def setup_enable_notifier(self):
 
         self.enable_notifier.add_subscriber(self.home_tab.home_tab_widget.enable_observer)
@@ -246,6 +248,8 @@ class FrequencyAnalysisGui(QtWidgets.QMainWindow):
         self.enable_notifier.add_subscriber(self.transform.enable_observer)
 
         self.enable_notifier.add_subscriber(self.grouping_tab_widget.group_tab_presenter.enable_tab_observer)
+
+        self.enable_notifier.add_subscriber(self.plot_widget.presenter.enable_observer)
 
     def setup_load_observers(self):
         self.load_widget.load_widget.loadNotifier.add_subscriber(

--- a/scripts/Muon/GUI/MuonAnalysis/load_widget/load_widget_presenter.py
+++ b/scripts/Muon/GUI/MuonAnalysis/load_widget/load_widget_presenter.py
@@ -150,7 +150,6 @@ class LoadWidgetPresenter(object):
             self.outer = outer
 
         def update(self, observable, arg):
-            print("update called : ", arg)
             self.outer.update_new_instrument(arg)
 
     class EnableObserver(Observer):

--- a/scripts/Muon/GUI/MuonAnalysis/muon_analysis_2.py
+++ b/scripts/Muon/GUI/MuonAnalysis/muon_analysis_2.py
@@ -209,6 +209,8 @@ class MuonAnalysisGui(QtWidgets.QMainWindow):
 
         self.disable_notifier.add_subscriber(self.grouping_tab_widget.group_tab_presenter.disable_tab_observer)
 
+        self.disable_notifier.add_subscriber(self.plot_widget.presenter.disable_observer)
+
     def setup_enable_notifier(self):
 
         self.enable_notifier.add_subscriber(self.home_tab.home_tab_widget.enable_observer)
@@ -224,6 +226,8 @@ class MuonAnalysisGui(QtWidgets.QMainWindow):
         self.enable_notifier.add_subscriber(self.seq_fitting_tab.seq_fitting_tab_presenter.enable_tab_observer)
 
         self.enable_notifier.add_subscriber(self.grouping_tab_widget.group_tab_presenter.enable_tab_observer)
+
+        self.enable_notifier.add_subscriber(self.plot_widget.presenter.enable_observer)
 
     def setup_load_observers(self):
         self.load_widget.load_widget.loadNotifier.add_subscriber(


### PR DESCRIPTION
**Description of work.**
Add the plot widget to the enable/disable notifiers

**To test:**
Load some data (e.g. EMU20884)
Go to the fitting tab
Step to the next run
The plot window should remain enabled

Fixes #31483 

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
