### PR TITLE
Add default peak function setting to EngDiff UI

### DIFF
--- a/docs/source/interfaces/diffraction/Engineering Diffraction.rst
+++ b/docs/source/interfaces/diffraction/Engineering Diffraction.rst
@@ -36,7 +36,11 @@ Settings
     providing the option to change the default output directory and force the
     recalculation of the vanadium correction files. The user can also select the
     log values from a list which are loaded with data in the fitting tab and select
-    a log by which to sort the runs in a sequential fit.
+    a log by which to sort the runs in a sequential fit. There is also an option to
+    specify a peak function to fit (limited to a subset of all peak functions that
+    are recommended for the UI) which will be set on opening the interface. Note that
+    the user can select any peak function to fit (even a non-recommended one) at a
+    later point when adding a peak in the fitting tab.
 
 Close
     Close the interface.
@@ -186,13 +190,12 @@ Fitting
 
 This tab will allow for single peak fitting of focused run files.
 
-Focused run files can be loaded from the file system into mantid from the interface and converted to units TOF or d-sapcing. The interface will keep track of all the
-workspaces that it has created from these files. When a focussed run is loaded, the proton charge weighted average (and standard deviation) of the log values set in the
+Focused run files can be loaded from the file system into mantid from the interface and converted to units TOF or d-spacing. The interface will keep track of all the
+workspaces that it has created from these files. When a focused run is loaded, the proton charge weighted average (and standard deviation) of the log values set in the
 settings options are calculated and stored in a grouped workspace accessible in the main mantid window.
 
 Loaded workspaces can be plotted in the interface and the mantid fitting capability can be accessed from the 'Fit' button on the plot toolbar.
-This allows for the user to select peaks of any supported type (e.g. :ref:`Pseudo-Voigt <func-PseudoVoigt>` and
-:ref:`BackToBackExponential <func-BackToBackExponential>`) by right-clicking on the plot. The inital parameters can be varied interactively by dragging sliders (vertical lines on the plot).
+This allows for the user to select peaks of any supported type (the default is :ref:`BackToBackExponential <func-BackToBackExponential>`) by right-clicking on the plot. The initial parameters can be varied interactively by dragging sliders (vertical lines on the plot).
 After a successful fit the best-fit model is stored as a setup in the fit browser (Setup > Custom Setup) with the name of the workspace fitted.
 Selecting this loads the function and the parameters and the curve can be inspected by doing Display > Plot Guess.
 

--- a/docs/source/release/v6.1.0/diffraction.rst
+++ b/docs/source/release/v6.1.0/diffraction.rst
@@ -70,6 +70,7 @@ New features
 ############
 
 - New IDF for upgraded VULCAN instrument
+- New setting for default peak function to fit in the Engineering Diffraction interface (initial default is :ref:`BackToBackExponential <func-BackToBackExponential>`).
 
 Improvements
 ############

--- a/qt/python/mantidqt/widgets/fitpropertybrowser/fitpropertybrowser.py
+++ b/qt/python/mantidqt/widgets/fitpropertybrowser/fitpropertybrowser.py
@@ -159,7 +159,6 @@ class FitPropertyBrowser(FitPropertyBrowserBase):
         super(FitPropertyBrowser, self).show()
         self.tool = FitInteractiveTool(self.canvas,
                                        self.toolbar_manager,
-                                       current_peak_type=self.defaultPeakType(),
                                        default_background=self.defaultBackgroundType())
         self.tool.fit_range_changed.connect(self.set_fit_range)
         self.tool.peak_added.connect(self.peak_added_slot)
@@ -320,7 +319,6 @@ class FitPropertyBrowser(FitPropertyBrowserBase):
         if self.tool is not None:
             self.tool.add_to_menu(menu,
                                   peak_names=self.registeredPeaks(),
-                                  current_peak_type=self.defaultPeakType(),
                                   background_names=self.registeredBackgrounds(),
                                   other_names=self.registeredOthers())
         return menu

--- a/scripts/Engineering/gui/engineering_diffraction/presenter.py
+++ b/scripts/Engineering/gui/engineering_diffraction/presenter.py
@@ -71,6 +71,7 @@ class EngineeringDiffractionPresenter(object):
         settings_view = SettingsView(view)
         settings_presenter = SettingsPresenter(settings_model, settings_view)
         settings_presenter.load_settings_from_file_or_default()
+        settings_presenter.set_peak_function_from_settings()  # to update mantid settigns based on UI settigns
         self.settings_presenter = settings_presenter
         self.setup_savedir_notifier(view)
 

--- a/scripts/Engineering/gui/engineering_diffraction/settings/settings_presenter.py
+++ b/scripts/Engineering/gui/engineering_diffraction/settings/settings_presenter.py
@@ -6,7 +6,6 @@
 # SPDX - License - Identifier: GPL - 3.0 +
 # pylint: disable=invalid-name
 from os import path
-from mantid.api import FunctionFactory
 from mantid.kernel import ConfigService
 from mantidqt.utils.observer_pattern import Observable
 
@@ -61,7 +60,11 @@ class SettingsPresenter(object):
 
     def show(self):
         # get current peak function in case user has changed it
-        self.settings["default_peak"] = ConfigService.getString("curvefitting.defaultPeak")
+        current_peak = ConfigService.getString("curvefitting.defaultPeak")
+        if current_peak in ALL_PEAKS:
+            self.settings['default_peak'] = current_peak
+        else:
+            self.set_peak_function_from_settings()
         self._show_settings_in_view()
         self.view.show()
 
@@ -136,7 +139,7 @@ class SettingsPresenter(object):
             save_valid = save_location != ""
             log_valid = settings["logs"] != ""
             ascending_valid = settings["sort_ascending"] != ""
-            peak_valid = settings["default_peak"] in FunctionFactory.Instance().getPeakFunctionNames()
+            peak_valid = settings["default_peak"] in ALL_PEAKS
             return all_keys and not_none and save_valid and log_valid and ascending_valid and peak_valid
         except KeyError:  # Settings contained invalid key.
             return False

--- a/scripts/Engineering/gui/engineering_diffraction/settings/settings_view.py
+++ b/scripts/Engineering/gui/engineering_diffraction/settings/settings_view.py
@@ -30,6 +30,7 @@ class SettingsView(QtWidgets.QDialog, Ui_settings):
         self.primary_log_label.setText(
             "Sort workspaces by selected log average in sequential fitting (default is ascending order)\n"
             "If the box below is empty the workspaces will be fitted in the order they appear in the table.")
+        self.peak_list_label.setText("Default Peak Function")
 
     # ===============
     # Slot Connectors
@@ -53,6 +54,9 @@ class SettingsView(QtWidgets.QDialog, Ui_settings):
     def set_on_check_descending_changed(self, slot):
         self.check_descending.stateChanged.connect(slot)
 
+    def set_on_peak_func_changed(self, slot):
+        self.peak_list.currentTextChanged.connect(slot)
+
     # =================
     # Component Getters
     # =================
@@ -75,6 +79,9 @@ class SettingsView(QtWidgets.QDialog, Ui_settings):
 
     def get_ascending_checked(self):
         return self.check_ascending.isChecked()
+
+    def get_peak_function(self):
+        return self.peak_list.currentText()
 
     # =================
     # Component Setters
@@ -118,6 +125,13 @@ class SettingsView(QtWidgets.QDialog, Ui_settings):
 
     def set_descending_checked(self, checked):
         self.check_descending.setChecked(checked)
+
+    def set_peak_function(self, peak_name):
+        self.peak_list.setCurrentText(peak_name)
+
+    def populate_peak_function_list(self, peak_names):
+        self.peak_list.addItems(peak_names.split(','))
+        # self.peak_func.setCurrentText(peak_names[0])  # required?
 
     # =================
     # Force Actions

--- a/scripts/Engineering/gui/engineering_diffraction/settings/settings_widget.ui
+++ b/scripts/Engineering/gui/engineering_diffraction/settings/settings_widget.ui
@@ -106,6 +106,12 @@ QGroupBox:title {
 	    </item>
 	   </layout>
 	  </item>
+	  <item row="4" column="0">
+	   <widget class="QLabel" name="peak_list_label"></widget>
+	  </item>
+	  <item row="5" column="0">
+       <widget class="QComboBox" name="peak_list"></widget>
+      </item>
      </layout>
     </widget>
    </item>

--- a/scripts/Engineering/gui/engineering_diffraction/settings/test/test_settings_presenter.py
+++ b/scripts/Engineering/gui/engineering_diffraction/settings/test/test_settings_presenter.py
@@ -8,7 +8,7 @@
 import unittest
 
 from unittest import mock
-
+from unittest.mock import patch
 from Engineering.gui.engineering_diffraction.settings import settings_model, settings_view, settings_presenter
 
 
@@ -23,7 +23,8 @@ class SettingsPresenterTest(unittest.TestCase):
                          "recalc_vanadium": False,
                          "logs": "some,logs",
                          "primary_log": "some",
-                         "sort_ascending": True
+                         "sort_ascending": True,
+                         "default_peak": "BackToBackExponential"
                          }
 
     def test_load_existing_settings(self):
@@ -61,6 +62,7 @@ class SettingsPresenterTest(unittest.TestCase):
         self.view.get_checked_logs.return_value = self.settings['logs'][:]
         self.view.get_primary_log.return_value = self.settings['primary_log'][:]
         self.view.get_ascending_checked.return_value = self.settings['sort_ascending']
+        self.view.get_peak_function.return_value = self.settings["default_peak"]
         self.presenter.savedir_notifier = mock.MagicMock()
 
         self.presenter.save_new_settings()
@@ -70,7 +72,9 @@ class SettingsPresenterTest(unittest.TestCase):
         self.model.set_settings_dict.assert_called_with(self.settings)
         self.assertEqual(self.presenter.savedir_notifier.notify_subscribers.call_count, 1)
 
-    def test_show(self):
+    @patch("Engineering.gui.engineering_diffraction.settings.settings_presenter.ConfigService")
+    def test_show(self, mock_config):
+        mock_config.getString.return_value = self.settings["default_peak"]
         self.presenter.settings = self.settings.copy()
 
         self.presenter.show()
@@ -82,6 +86,16 @@ class SettingsPresenterTest(unittest.TestCase):
         self.view.set_checked_logs.assert_called_with(self.settings["logs"])
         self.view.set_primary_log_combobox.assert_called_with(self.settings["primary_log"])
         self.view.set_ascending_checked.assert_called_with(self.settings["sort_ascending"])
+        self.view.set_peak_function.assert_called_with(self.settings["default_peak"])
+
+    @patch("Engineering.gui.engineering_diffraction.settings.settings_presenter.ConfigService")
+    def test_show_ignores_unsupported_default_peak(self, mock_config):
+        mock_config.getString.return_value = "IkedaCarpenterPV"  # not supported as default peak in UI
+        self.presenter.settings = self.settings.copy()
+
+        self.presenter.show()
+
+        self.view.set_peak_function.assert_called_with(self.settings["default_peak"])
 
     def test_save_settings_and_close(self):
         self.view.get_save_location.return_value = self.settings['save_location'][:]
@@ -90,6 +104,7 @@ class SettingsPresenterTest(unittest.TestCase):
         self.view.get_checked_logs.return_value = self.settings['logs'][:]
         self.view.get_primary_log.return_value = self.settings['primary_log'][:]
         self.view.get_ascending_checked.return_value = self.settings['sort_ascending']
+        self.view.get_peak_function.return_value = self.settings["default_peak"]
         self.presenter.savedir_notifier = mock.MagicMock()
 
         self.presenter.save_and_close_dialog()


### PR DESCRIPTION
**Description of work.**
Added setting for default peak function in the EngDiff UI. This presents the user with a drop-down box of a few relevant functions (the users can still select from the full list in the interactive tool when the fit property browser is open, but the aim of this is to not overwhelm the user with similarly named functions - in particular the back-to-back exponential based ones). The default peak function has been set to BackToBackExponential for which coefficients have been refined for ENGIN-X (stored in the parameters.xml file). The default peak will be overwritten with the last used supported peak type.

**To test:**
(1) In the main workbench settings, set the peak function to a Gaussian (File > Settings >Fitting > Default peak shape)
(2) Open the EngDiff UI (Interfaces > Diffraction > Engineering Diffraction)
(3) Open the workbench settings and check the default peak shape is now BackToBackExponential
(4) Open the UI settings (cog on bottom left) and change the peak function to something else (e.g. Lorentzian) and click OK
(5) Open the workbench settings and check the default peak shape is now whatever you selected.
(6) Go to the fitting tab, load in some focussed data (to make focussed data follow the instructions in Test 1 here https://developer.mantidproject.org/Testing/EngineeringDiffraction/EngineeringDiffractionTestGuide.html)
(7) Plot the data
(8) Open the fit browser (Fit button on toolbar), right-click on the plot and select peak type - change the peak to a valid one - i.e. one of the functions in the drop-down list of the UI settings (e.g. back to BackToBackExponential)
(9) When you open the UI settings again the peak function should be whatever was chosen
(10) Change the peak function in the UI settings and add a peak to the plotted data, it should add the correct function.
(11) Repeat step (8-9) but choose an invalid peak function (e.g. IkedaCarpenterPV), when you open the UI settings it should be set to the last peak selected in the settings.

To-Do
- Add release notes
- Update UI docs

Fixes #31490
<!-- alternative
*There is no associated issue.*
-->

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or master)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
