### PR TITLE
Muon Analysis - Better validation of start and end x

### DIFF
--- a/docs/source/release/v6.1.0/muon.rst
+++ b/docs/source/release/v6.1.0/muon.rst
@@ -30,9 +30,8 @@ Improvements
    :width: 500px
    :align: right
 
-Improvements
-############
 - Frequency Domain Analysis default values have been improved.
+- Improved the validation on the start and end X so that their values could not be outside the data x range.
 
 Bug fixes
 #########
@@ -47,6 +46,7 @@ Bug fixes
 - Fixed a usability issue where tabs became unattached too easily. It is now possible to unattach the tabs only by double clicking on them.
 - Fixed a bug that caused the `AutoScale` check box to reset when editing the selected groups/pairs.
 - Fixed a bug where the start and end X would reset in the fitting tab when stepping to the next or previous run.
+- Fixed a bug caused by entering an empty string into the start and end X fields.
 
 ALC
 ---

--- a/scripts/Muon/GUI/Common/context_example/context_example_view.py
+++ b/scripts/Muon/GUI/Common/context_example/context_example_view.py
@@ -35,18 +35,18 @@ class ContextExampleView(QtWidgets.QWidget):
         # row of groups
         table_utils.setRowName(self.table, 0, "Groups")
         group_name = ["a", "b", "c"]
-        self.ws0 = table_utils.addDoubleToTable(
+        self.ws0, _ = table_utils.addDoubleToTable(
             self.table, group_name[0], 0, 1)
-        self.ws1 = table_utils.addDoubleToTable(
+        self.ws1, _  = table_utils.addDoubleToTable(
             self.table, group_name[1], 0, 2)
-        self.ws2 = table_utils.addDoubleToTable(
+        self.ws2, _  = table_utils.addDoubleToTable(
             self.table, group_name[2], 0, 3)
 
         # row to describe a pair
         table_utils.setRowName(self.table, 1, "Pair")
         self.g1 = table_utils.addComboToTable(self.table, 1, group_name, 1)
         self.g2 = table_utils.addComboToTable(self.table, 1, group_name, 2)
-        self.alpha = table_utils.addDoubleToTable(self.table, "2.", 1, 3)
+        self.alpha, _ = table_utils.addDoubleToTable(self.table, "2.", 1, 3)
 
         # explicit update button
         btn = QtWidgets.QPushButton("print context", self)

--- a/scripts/Muon/GUI/Common/fitting_widgets/basic_fitting/basic_fitting_model.py
+++ b/scripts/Muon/GUI/Common/fitting_widgets/basic_fitting/basic_fitting_model.py
@@ -5,7 +5,7 @@
 #   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
 # SPDX - License - Identifier: GPL - 3.0 +
 from mantid import AlgorithmManager, logger
-from mantid.api import CompositeFunction, IAlgorithm, IFunction
+from mantid.api import AnalysisDataService, CompositeFunction, IAlgorithm, IFunction
 from mantid.simpleapi import CopyLogs, EvaluateFunction, RenameWorkspace
 
 from Muon.GUI.Common.ADSHandler.workspace_naming import create_fitted_workspace_name, create_parameter_table_name
@@ -408,6 +408,15 @@ class BasicFittingModel:
     def do_rebin(self) -> bool:
         """Returns true if rebin is selected within the context."""
         return self.context._do_rebin()
+
+    def x_limits_of_current_dataset(self) -> tuple:
+        """Returns the x data limits of the currently selected dataset."""
+        if self.current_dataset_index is not None:
+            workspace = AnalysisDataService.retrieve(self.current_dataset_name)
+            x_data = workspace.dataX(0)
+            return x_data[0], x_data[-1]
+        else:
+            return self.current_start_x, self.current_end_x
 
     def use_cached_function(self) -> None:
         """Sets the current function as being the cached function."""

--- a/scripts/Muon/GUI/Common/fitting_widgets/basic_fitting/basic_fitting_model.py
+++ b/scripts/Muon/GUI/Common/fitting_widgets/basic_fitting/basic_fitting_model.py
@@ -5,9 +5,10 @@
 #   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
 # SPDX - License - Identifier: GPL - 3.0 +
 from mantid import AlgorithmManager, logger
-from mantid.api import AnalysisDataService, CompositeFunction, IAlgorithm, IFunction
+from mantid.api import CompositeFunction, IAlgorithm, IFunction
 from mantid.simpleapi import CopyLogs, EvaluateFunction, RenameWorkspace
 
+from Muon.GUI.Common.ADSHandler.ADS_calls import retrieve_ws
 from Muon.GUI.Common.ADSHandler.workspace_naming import create_fitted_workspace_name, create_parameter_table_name
 from Muon.GUI.Common.ADSHandler.muon_workspace_wrapper import MuonWorkspaceWrapper
 from Muon.GUI.Common.contexts.fitting_context import FitInformation
@@ -412,11 +413,10 @@ class BasicFittingModel:
     def x_limits_of_current_dataset(self) -> tuple:
         """Returns the x data limits of the currently selected dataset."""
         if self.current_dataset_index is not None:
-            workspace = AnalysisDataService.retrieve(self.current_dataset_name)
-            x_data = workspace.dataX(0)
-            return x_data[0], x_data[-1]
-        else:
-            return self.current_start_x, self.current_end_x
+            x_data = retrieve_ws(self.current_dataset_name).dataX(0)
+            if len(x_data) > 0:
+                return x_data[0], x_data[-1]
+        return self.current_start_x, self.current_end_x
 
     def use_cached_function(self) -> None:
         """Sets the current function as being the cached function."""

--- a/scripts/Muon/GUI/Common/fitting_widgets/basic_fitting/basic_fitting_presenter.py
+++ b/scripts/Muon/GUI/Common/fitting_widgets/basic_fitting/basic_fitting_presenter.py
@@ -285,6 +285,9 @@ class BasicFittingPresenter:
 
     def update_start_and_end_x_in_view_from_model(self) -> None:
         """Updates the start and end x in the view using the current values in the model."""
+        x_lower, x_upper = self.model.x_limits_of_current_dataset()
+        self.view.set_x_data_limits(x_lower, x_upper)
+
         self.view.start_x = self.model.current_start_x
         self.view.end_x = self.model.current_end_x
 

--- a/scripts/Muon/GUI/Common/fitting_widgets/basic_fitting/basic_fitting_presenter.py
+++ b/scripts/Muon/GUI/Common/fitting_widgets/basic_fitting/basic_fitting_presenter.py
@@ -208,8 +208,13 @@ class BasicFittingPresenter:
         if self.view.start_x > self.view.end_x:
             self.view.start_x, self.view.end_x = self.view.end_x, self.view.start_x
             self.model.current_end_x = self.view.end_x
+        elif self.view.start_x == self.view.end_x:
+            self.view.start_x = self.model.current_start_x
 
         self.model.current_start_x = self.view.start_x
+
+        self._check_start_x_is_within_x_limits()
+        self._check_end_x_is_within_x_limits()
 
         self.model.update_plot_guess(self.view.plot_guess)
 
@@ -218,8 +223,13 @@ class BasicFittingPresenter:
         if self.view.end_x < self.view.start_x:
             self.view.start_x, self.view.end_x = self.view.end_x, self.view.start_x
             self.model.current_start_x = self.view.start_x
+        elif self.view.end_x == self.view.start_x:
+            self.view.end_x = self.model.current_end_x
 
         self.model.current_end_x = self.view.end_x
+
+        self._check_start_x_is_within_x_limits()
+        self._check_end_x_is_within_x_limits()
 
         self.model.update_plot_guess(self.view.plot_guess)
 
@@ -285,11 +295,24 @@ class BasicFittingPresenter:
 
     def update_start_and_end_x_in_view_from_model(self) -> None:
         """Updates the start and end x in the view using the current values in the model."""
-        x_lower, x_upper = self.model.x_limits_of_current_dataset()
-        self.view.set_x_data_limits(x_lower, x_upper)
-
         self.view.start_x = self.model.current_start_x
         self.view.end_x = self.model.current_end_x
+
+    def _check_start_x_is_within_x_limits(self) -> None:
+        """Checks the Start X is within the x limits of the current dataset. If not it is set to one of the limits."""
+        x_lower, x_upper = self.model.x_limits_of_current_dataset()
+        if self.view.start_x < x_lower:
+            self.view.start_x = x_lower
+        elif self.view.start_x > x_upper:
+            self.view.start_x = x_upper
+
+    def _check_end_x_is_within_x_limits(self) -> None:
+        """Checks the End X is within the x limits of the current dataset. If not it is set to one of the limits."""
+        x_lower, x_upper = self.model.x_limits_of_current_dataset()
+        if self.view.end_x < x_lower:
+            self.view.end_x = x_lower
+        elif self.view.end_x > x_upper:
+            self.view.end_x = x_upper
 
     def _get_single_fit_functions_from_view(self) -> list:
         """Returns the fit functions corresponding to each domain as a list."""

--- a/scripts/Muon/GUI/Common/fitting_widgets/basic_fitting/basic_fitting_presenter.py
+++ b/scripts/Muon/GUI/Common/fitting_widgets/basic_fitting/basic_fitting_presenter.py
@@ -300,7 +300,7 @@ class BasicFittingPresenter:
 
     def _check_start_x_is_within_x_limits(self) -> None:
         """Checks the Start X is within the x limits of the current dataset. If not it is set to one of the limits."""
-        x_lower, x_upper = self.model.x_limits_of_current_dataset()
+        x_lower, x_upper = self.model.x_limits_of_workspace(self.model.current_dataset_name)
         if self.view.start_x < x_lower:
             self.view.start_x = x_lower
         elif self.view.start_x > x_upper:
@@ -308,7 +308,7 @@ class BasicFittingPresenter:
 
     def _check_end_x_is_within_x_limits(self) -> None:
         """Checks the End X is within the x limits of the current dataset. If not it is set to one of the limits."""
-        x_lower, x_upper = self.model.x_limits_of_current_dataset()
+        x_lower, x_upper = self.model.x_limits_of_workspace(self.model.current_dataset_name)
         if self.view.end_x < x_lower:
             self.view.end_x = x_lower
         elif self.view.end_x > x_upper:

--- a/scripts/Muon/GUI/Common/fitting_widgets/basic_fitting/basic_fitting_view.py
+++ b/scripts/Muon/GUI/Common/fitting_widgets/basic_fitting/basic_fitting_view.py
@@ -95,10 +95,6 @@ class BasicFittingView(QWidget, ui_fitting_layout):
         if dataset_index is not None:
             self.fit_function_options.set_current_dataset_index(dataset_index)
 
-    def set_x_data_limits(self, x_lower: float, x_upper: float) -> None:
-        """Sets the minimum and maximum allowable x values for the start and end X."""
-        self.fit_function_options.set_x_data_limits(x_lower, x_upper)
-
     def update_local_fit_status_and_chi_squared(self, fit_status: str, chi_squared: float) -> None:
         """Updates the view to show the status and results from a fit."""
         if fit_status is not None:

--- a/scripts/Muon/GUI/Common/fitting_widgets/basic_fitting/basic_fitting_view.py
+++ b/scripts/Muon/GUI/Common/fitting_widgets/basic_fitting/basic_fitting_view.py
@@ -95,6 +95,10 @@ class BasicFittingView(QWidget, ui_fitting_layout):
         if dataset_index is not None:
             self.fit_function_options.set_current_dataset_index(dataset_index)
 
+    def set_x_data_limits(self, x_lower: float, x_upper: float) -> None:
+        """Sets the minimum and maximum allowable x values for the start and end X."""
+        self.fit_function_options.set_x_data_limits(x_lower, x_upper)
+
     def update_local_fit_status_and_chi_squared(self, fit_status: str, chi_squared: float) -> None:
         """Updates the view to show the status and results from a fit."""
         if fit_status is not None:

--- a/scripts/Muon/GUI/Common/fitting_widgets/basic_fitting/fit_function_options_view.py
+++ b/scripts/Muon/GUI/Common/fitting_widgets/basic_fitting/fit_function_options_view.py
@@ -117,13 +117,6 @@ class FitFunctionOptionsView(QWidget, ui_fit_function_options):
         """Sets the index of the current dataset."""
         self.function_browser.setCurrentDataset(dataset_index)
 
-    def set_x_data_limits(self, x_lower: float, x_upper: float) -> None:
-        """Sets the minimum and maximum allowable x values for the start and end X."""
-        self.start_x_validator.setBottom(x_lower)
-        self.start_x_validator.setTop(x_upper)
-        self.end_x_validator.setBottom(x_lower)
-        self.end_x_validator.setTop(x_upper)
-
     def update_function_browser_parameters(self, is_simultaneous_fit: bool, fit_function: IFunction,
                                            global_parameters: list = []) -> None:
         """Updates the parameters in the function browser."""
@@ -159,8 +152,8 @@ class FitFunctionOptionsView(QWidget, ui_fit_function_options):
     def start_x(self, value: float) -> None:
         """Sets the selected start X."""
         if value <= self.end_x:
-            self.start_x_validator.last_valid_value = str(value)
-            self.start_x_line_edit.setText(str(value))
+            self.start_x_validator.last_valid_value = f"{value:.3f}"
+            self.start_x_line_edit.setText(f"{value:.3f}")
 
     @property
     def end_x(self) -> float:
@@ -171,8 +164,8 @@ class FitFunctionOptionsView(QWidget, ui_fit_function_options):
     def end_x(self, value: float) -> None:
         """Sets the selected end X."""
         if value >= self.start_x:
-            self.end_x_validator.last_valid_value = str(value)
-            self.end_x_line_edit.setText(str(value))
+            self.end_x_validator.last_valid_value = f"{value:.3f}"
+            self.end_x_line_edit.setText(f"{value:.3f}")
 
     @property
     def evaluation_type(self) -> str:

--- a/scripts/Muon/GUI/Common/fitting_widgets/basic_fitting/fit_function_options_view.py
+++ b/scripts/Muon/GUI/Common/fitting_widgets/basic_fitting/fit_function_options_view.py
@@ -36,7 +36,9 @@ class FitFunctionOptionsView(QWidget, ui_fit_function_options):
         self.setupUi(self)
 
         self.start_x_line_edit = None
+        self.start_x_validator = None
         self.end_x_line_edit = None
+        self.end_x_validator = None
         self.minimizer_combo = None
         self.fit_to_raw_data_checkbox = None
         self.evaluation_combo = None
@@ -149,7 +151,8 @@ class FitFunctionOptionsView(QWidget, ui_fit_function_options):
     @start_x.setter
     def start_x(self, value: float) -> None:
         """Sets the selected start X."""
-        if value < self.end_x:
+        if value <= self.end_x:
+            self.start_x_validator.last_valid_value = str(value)
             self.start_x_line_edit.setText(str(value))
 
     @property
@@ -160,7 +163,8 @@ class FitFunctionOptionsView(QWidget, ui_fit_function_options):
     @end_x.setter
     def end_x(self, value: float) -> None:
         """Sets the selected end X."""
-        if value > self.start_x:
+        if value >= self.start_x:
+            self.end_x_validator.last_valid_value = str(value)
             self.end_x_line_edit.setText(str(value))
 
     @property
@@ -228,10 +232,12 @@ class FitFunctionOptionsView(QWidget, ui_fit_function_options):
         self.fit_options_table.setHorizontalHeaderLabels(["Property", "Value"])
 
         table_utils.setRowName(self.fit_options_table, START_X_TABLE_ROW, "Time Start")
-        self.start_x_line_edit = table_utils.addDoubleToTable(self.fit_options_table, 0.0, START_X_TABLE_ROW, 1)
+        self.start_x_line_edit, self.start_x_validator = table_utils.addDoubleToTable(self.fit_options_table, 0.0,
+                                                                                      START_X_TABLE_ROW, 1)
 
         table_utils.setRowName(self.fit_options_table, END_X_TABLE_ROW, "Time End")
-        self.end_x_line_edit = table_utils.addDoubleToTable(self.fit_options_table, 15.0, END_X_TABLE_ROW, 1)
+        self.end_x_line_edit, self.end_x_validator = table_utils.addDoubleToTable(self.fit_options_table, 15.0,
+                                                                                  END_X_TABLE_ROW, 1)
 
         table_utils.setRowName(self.fit_options_table, MINIMIZER_TABLE_ROW, "Minimizer")
         self.minimizer_combo = table_utils.addComboToTable(self.fit_options_table, MINIMIZER_TABLE_ROW, [])

--- a/scripts/Muon/GUI/Common/fitting_widgets/basic_fitting/fit_function_options_view.py
+++ b/scripts/Muon/GUI/Common/fitting_widgets/basic_fitting/fit_function_options_view.py
@@ -117,6 +117,13 @@ class FitFunctionOptionsView(QWidget, ui_fit_function_options):
         """Sets the index of the current dataset."""
         self.function_browser.setCurrentDataset(dataset_index)
 
+    def set_x_data_limits(self, x_lower: float, x_upper: float) -> None:
+        """Sets the minimum and maximum allowable x values for the start and end X."""
+        self.start_x_validator.setBottom(x_lower)
+        self.start_x_validator.setTop(x_upper)
+        self.end_x_validator.setBottom(x_lower)
+        self.end_x_validator.setTop(x_upper)
+
     def update_function_browser_parameters(self, is_simultaneous_fit: bool, fit_function: IFunction,
                                            global_parameters: list = []) -> None:
         """Updates the parameters in the function browser."""

--- a/scripts/Muon/GUI/Common/phase_table_widget/phase_table_view.py
+++ b/scripts/Muon/GUI/Common/phase_table_widget/phase_table_view.py
@@ -30,6 +30,7 @@ class PhaseTableView(QtWidgets.QWidget, ui_muon_phases_tab):
 
     @first_good_time.setter
     def first_good_time(self, value):
+        self.first_good_data_validator.last_valid_value = str(value)
         self.first_good_data_item.setText(str(value))
 
     @property
@@ -38,6 +39,7 @@ class PhaseTableView(QtWidgets.QWidget, ui_muon_phases_tab):
 
     @last_good_time.setter
     def last_good_time(self, value):
+        self.last_good_data_validator.last_valid_value = str(value)
         self.last_good_data_item.setText(str(value))
 
     @property
@@ -183,10 +185,12 @@ class PhaseTableView(QtWidgets.QWidget, ui_muon_phases_tab):
         self.backward_group_combo = table_utils.addComboToTable(self.phase_table_options_table, 2, options)
 
         table_utils.setRowName(self.phase_table_options_table, 3, "First Good Data")
-        self.first_good_data_item = table_utils.addDoubleToTable(self.phase_table_options_table, 0.1, 3)
+        self.first_good_data_item, self.first_good_data_validator = table_utils.addDoubleToTable(
+            self.phase_table_options_table, 0.1, 3)
 
         table_utils.setRowName(self.phase_table_options_table, 4, "Last Good Data")
-        self.last_good_data_item = table_utils.addDoubleToTable(self.phase_table_options_table, 15.0, 4)
+        self.last_good_data_item, self.last_good_data_validator = table_utils.addDoubleToTable(
+            self.phase_table_options_table, 15.0, 4)
 
         table_utils.setRowName(self.phase_table_options_table, 5, "Output fit information")
         self.output_fit_info_box = table_utils.addCheckBoxToTable(

--- a/scripts/Muon/GUI/Common/test_helpers/fitting_mock_setup.py
+++ b/scripts/Muon/GUI/Common/test_helpers/fitting_mock_setup.py
@@ -24,6 +24,7 @@ def add_mock_methods_to_basic_fitting_view(view):
 
     view.set_datasets_in_function_browser = mock.Mock()
     view.set_current_dataset_index = mock.Mock()
+    view.set_x_data_limits = mock.Mock()
     view.update_local_fit_status_and_chi_squared = mock.Mock()
     view.update_global_fit_status = mock.Mock()
     view.update_fit_function = mock.Mock()
@@ -36,7 +37,7 @@ def add_mock_methods_to_basic_fitting_view(view):
     return view
 
 
-def add_mock_methods_to_basic_fitting_model(model, dataset_names, current_dataset_index, fit_function, start_x,
+def add_mock_methods_to_basic_fitting_model(model, dataset_names, current_dataset_index, fit_function, start_x, end_x,
                                             fit_status, chi_squared):
     # Mock the methods of the model
     model.clear_single_fit_functions = mock.Mock()
@@ -51,6 +52,7 @@ def add_mock_methods_to_basic_fitting_model(model, dataset_names, current_datase
     model.reset_start_xs_and_end_xs = mock.Mock()
     model.reset_fit_statuses_and_chi_squared = mock.Mock()
     model.reset_fit_functions = mock.Mock()
+    model.x_limits_of_current_dataset = mock.Mock(return_value=(start_x, end_x))
     model.retrieve_first_good_data_from_run = mock.Mock(return_value=start_x)
     model.get_active_fit_function = mock.Mock(return_value=fit_function)
     model.get_active_workspace_names = mock.Mock(return_value=[dataset_names[current_dataset_index]])

--- a/scripts/Muon/GUI/Common/test_helpers/fitting_mock_setup.py
+++ b/scripts/Muon/GUI/Common/test_helpers/fitting_mock_setup.py
@@ -24,7 +24,6 @@ def add_mock_methods_to_basic_fitting_view(view):
 
     view.set_datasets_in_function_browser = mock.Mock()
     view.set_current_dataset_index = mock.Mock()
-    view.set_x_data_limits = mock.Mock()
     view.update_local_fit_status_and_chi_squared = mock.Mock()
     view.update_global_fit_status = mock.Mock()
     view.update_fit_function = mock.Mock()

--- a/scripts/Muon/GUI/Common/test_helpers/fitting_mock_setup.py
+++ b/scripts/Muon/GUI/Common/test_helpers/fitting_mock_setup.py
@@ -51,7 +51,7 @@ def add_mock_methods_to_basic_fitting_model(model, dataset_names, current_datase
     model.reset_start_xs_and_end_xs = mock.Mock()
     model.reset_fit_statuses_and_chi_squared = mock.Mock()
     model.reset_fit_functions = mock.Mock()
-    model.x_limits_of_current_dataset = mock.Mock(return_value=(start_x, end_x))
+    model.x_limits_of_workspace = mock.Mock(return_value=(start_x, end_x))
     model.retrieve_first_good_data_from_run = mock.Mock(return_value=start_x)
     model.get_active_fit_function = mock.Mock(return_value=fit_function)
     model.get_active_workspace_names = mock.Mock(return_value=[dataset_names[current_dataset_index]])

--- a/scripts/Muon/GUI/Common/utilities/table_utils.py
+++ b/scripts/Muon/GUI/Common/utilities/table_utils.py
@@ -6,7 +6,8 @@
 # SPDX - License - Identifier: GPL - 3.0 +
 from functools import wraps
 import sys
-from qtpy import QtWidgets, QtCore, QtGui
+from qtpy import QtWidgets, QtCore
+from mantidqt.utils.qt.line_edit_double_validator import LineEditDoubleValidator
 
 """
 This module contains the methods for
@@ -91,11 +92,15 @@ def addComboToTable(table,row,options,col=1):
     return combo
 
 
-def addDoubleToTable(table,value,row,col=1, minimum=0.0):
+def addDoubleToTable(table, value, row, col=1, minimum=0.0):
     number_widget = QtWidgets.QLineEdit(str(value))
-    number_widget.setValidator(QtGui.QDoubleValidator(minimum, sys.float_info.max, 3))
-    table.setCellWidget(row,col, number_widget)
-    return number_widget
+    validator = LineEditDoubleValidator(number_widget, float(value))
+    validator.setBottom(minimum)
+    validator.setTop(sys.float_info.max)
+    validator.setDecimals(3)
+    number_widget.setValidator(validator)
+    table.setCellWidget(row, col, number_widget)
+    return number_widget, validator
 
 
 def addCheckBoxToTable(table,state,row,col=1):

--- a/scripts/Muon/GUI/FrequencyDomainAnalysis/FFT/fft_view.py
+++ b/scripts/Muon/GUI/FrequencyDomainAnalysis/FFT/fft_view.py
@@ -62,18 +62,18 @@ class FFTView(QtWidgets.QWidget):
             self.FFTTable, True, self.shift_box_row)
 
         table_utils.setRowName(self.FFTTable, 4, "Shift")
-        self.shift = table_utils.addDoubleToTable(self.FFTTable, 0.0, 4)
+        self.shift, _ = table_utils.addDoubleToTable(self.FFTTable, 0.0, 4)
         self.FFTTable.hideRow(4)
 
         table_utils.setRowName(self.FFTTable, 5, "Use Raw data")
         self.Raw_box = table_utils.addCheckBoxToTable(self.FFTTable, True, 5)
 
         table_utils.setRowName(self.FFTTable, 6, "First Good Data")
-        self.x0 = table_utils.addDoubleToTable(self.FFTTable, 0.1, 6)
+        self.x0, _ = table_utils.addDoubleToTable(self.FFTTable, 0.1, 6)
         self.FFTTable.hideRow(6)
 
         table_utils.setRowName(self.FFTTable, 7, "Last Good Data")
-        self.xN = table_utils.addDoubleToTable(self.FFTTable, 15.0, 7)
+        self.xN, _ = table_utils.addDoubleToTable(self.FFTTable, 15.0, 7)
         self.FFTTable.hideRow(7)
 
         table_utils.setRowName(self.FFTTable, 8, "Construct Phase Table")

--- a/scripts/Muon/GUI/FrequencyDomainAnalysis/FFT/fft_view_new.py
+++ b/scripts/Muon/GUI/FrequencyDomainAnalysis/FFT/fft_view_new.py
@@ -62,7 +62,7 @@ class FFTView(QtWidgets.QWidget):
         self.FFTTable.hideRow(3)
 
         table_utils.setRowName(self.FFTTable, 4, "Shift")
-        self.shift = table_utils.addDoubleToTable(self.FFTTable, 0.0, 4)
+        self.shift, _ = table_utils.addDoubleToTable(self.FFTTable, 0.0, 4)
         self.FFTTable.hideRow(4)
 
         table_utils.setRowName(self.FFTTable, 5, "Use Raw data")
@@ -91,7 +91,7 @@ class FFTView(QtWidgets.QWidget):
             self.FFTTableA,
             1,
             "Decay Constant (micro seconds)")
-        self.decay = table_utils.addDoubleToTable(self.FFTTableA, 4.4, 1)
+        self.decay, _ = table_utils.addDoubleToTable(self.FFTTableA, 4.4, 1)
 
         table_utils.setRowName(self.FFTTableA, 2, "Negative Padding")
         self.negativePadding = table_utils.addCheckBoxToTable(

--- a/scripts/Muon/GUI/FrequencyDomainAnalysis/MaxEnt/maxent_view.py
+++ b/scripts/Muon/GUI/FrequencyDomainAnalysis/MaxEnt/maxent_view.py
@@ -52,10 +52,10 @@ class MaxEntView(QtWidgets.QWidget):
         self.ws = table_utils.addComboToTable(self.table, 0, options)
 
         table_utils.setRowName(self.table, 1, "First good time")
-        self.first_good = table_utils.addDoubleToTable(self.table, 0.1, 1)
+        self.first_good, _ = table_utils.addDoubleToTable(self.table, 0.1, 1)
 
         table_utils.setRowName(self.table, 2, "Last good time")
-        self.last_good = table_utils.addDoubleToTable(self.table, 15.0, 2)
+        self.last_good, _ = table_utils.addDoubleToTable(self.table, 15.0, 2)
 
         table_utils.setRowName(self.table, 3, "Fit dead times")
         self.dead_box = table_utils.addCheckBoxToTable(self.table, True, 3)
@@ -113,10 +113,10 @@ class MaxEntView(QtWidgets.QWidget):
         table_utils.setTableHeaders(self.tableA)
 
         table_utils.setRowName(self.tableA, 0, "Maximum entropy constant (A)")
-        self.AConst = table_utils.addDoubleToTable(self.tableA, 0.1, 0)
+        self.AConst, _ = table_utils.addDoubleToTable(self.tableA, 0.1, 0)
 
         table_utils.setRowName(self.tableA, 1, "Lagrange multiplier for chi^2")
-        self.factor = table_utils.addDoubleToTable(self.tableA, 1.04, 1)
+        self.factor, _ = table_utils.addDoubleToTable(self.tableA, 1.04, 1)
 
         table_utils.setRowName(self.tableA, 2, "Inner Iterations")
         self.inner_loop = table_utils.addSpinBoxToTable(self.tableA, 10, 2)
@@ -132,7 +132,7 @@ class MaxEntView(QtWidgets.QWidget):
         self.N_points = table_utils.addComboToTable(self.tableA, 5, options)
 
         table_utils.setRowName(self.tableA, 6, "Maximum Field ")
-        self.max_field = table_utils.addDoubleToTable(self.tableA, 1000.0, 6)
+        self.max_field, _ = table_utils.addDoubleToTable(self.tableA, 1000.0, 6)
 
         # layout
         # this is if complex data is unhidden

--- a/scripts/Muon/GUI/FrequencyDomainAnalysis/MaxEnt/maxent_view_new.py
+++ b/scripts/Muon/GUI/FrequencyDomainAnalysis/MaxEnt/maxent_view_new.py
@@ -91,10 +91,10 @@ class MaxEntView(QtWidgets.QWidget):
         table_utils.setTableHeaders(self.tableA)
 
         table_utils.setRowName(self.tableA, 0, "Maximum entropy constant (A)")
-        self.AConst = table_utils.addDoubleToTable(self.tableA, 0.1, 0)
+        self.AConst, _ = table_utils.addDoubleToTable(self.tableA, 0.1, 0)
 
         table_utils.setRowName(self.tableA, 1, "Lagrange multiplier for chi^2")
-        self.factor = table_utils.addDoubleToTable(self.tableA, 1.04, 1)
+        self.factor, _ = table_utils.addDoubleToTable(self.tableA, 1.04, 1)
 
         table_utils.setRowName(self.tableA, 2, "Inner Iterations")
         self.inner_loop = table_utils.addSpinBoxToTable(self.tableA, 10, 2)
@@ -110,7 +110,7 @@ class MaxEntView(QtWidgets.QWidget):
         self.N_points = table_utils.addComboToTable(self.tableA, 5, options)
 
         table_utils.setRowName(self.tableA, 6, "Maximum Field ")
-        self.max_field = table_utils.addDoubleToTable(self.tableA, 1000.0, 6)
+        self.max_field, _ = table_utils.addDoubleToTable(self.tableA, 1000.0, 6)
 
         # layout
         # this is if complex data is unhidden

--- a/scripts/test/Muon/fitting_widgets/basic_fitting/basic_fitting_model_test.py
+++ b/scripts/test/Muon/fitting_widgets/basic_fitting/basic_fitting_model_test.py
@@ -7,7 +7,8 @@
 import unittest
 from unittest import mock
 
-from mantid.api import FrameworkManager, FunctionFactory
+from mantid.api import AnalysisDataService, FrameworkManager, FunctionFactory
+from mantid.simpleapi import CreateSampleWorkspace
 
 from Muon.GUI.Common.fitting_widgets.basic_fitting.basic_fitting_model import BasicFittingModel, DEFAULT_START_X
 from Muon.GUI.Common.test_helpers.context_setup import setup_context
@@ -537,6 +538,22 @@ class BasicFittingModelTest(unittest.TestCase):
         # This dataset is the second dataset previously and so the A0=5 fit function should be reused.
         self.model.dataset_names = ["Name2"]
         self.assertEqual(str(self.model.single_fit_functions[0]), "name=FlatBackground,A0=5")
+
+    def test_that_x_limits_of_current_dataset_will_return_the_x_limits_of_the_workspace(self):
+        self.model.dataset_names = self.dataset_names
+        workspace = CreateSampleWorkspace()
+        AnalysisDataService.addOrReplace("Name1", workspace)
+
+        x_lower, x_upper = self.model.x_limits_of_current_dataset()
+
+        self.assertEqual(x_lower, 0.0)
+        self.assertEqual(x_upper, 20000.0)
+
+    def test_that_x_limits_of_current_dataset_will_return_the_default_x_values_if_there_are_no_workspaces_loaded(self):
+        x_lower, x_upper = self.model.x_limits_of_current_dataset()
+
+        self.assertEqual(x_lower, 0.0)
+        self.assertEqual(x_upper, 15.0)
 
 
 if __name__ == '__main__':

--- a/scripts/test/Muon/fitting_widgets/basic_fitting/basic_fitting_model_test.py
+++ b/scripts/test/Muon/fitting_widgets/basic_fitting/basic_fitting_model_test.py
@@ -544,13 +544,19 @@ class BasicFittingModelTest(unittest.TestCase):
         workspace = CreateSampleWorkspace()
         AnalysisDataService.addOrReplace("Name1", workspace)
 
-        x_lower, x_upper = self.model.x_limits_of_current_dataset()
+        x_lower, x_upper = self.model.x_limits_of_workspace(self.model.current_dataset_name)
 
         self.assertEqual(x_lower, 0.0)
         self.assertEqual(x_upper, 20000.0)
 
     def test_that_x_limits_of_current_dataset_will_return_the_default_x_values_if_there_are_no_workspaces_loaded(self):
-        x_lower, x_upper = self.model.x_limits_of_current_dataset()
+        x_lower, x_upper = self.model.x_limits_of_workspace(self.model.current_dataset_name)
+
+        self.assertEqual(x_lower, 0.0)
+        self.assertEqual(x_upper, 15.0)
+
+    def test_that_x_limits_of_current_dataset_will_return_the_default_x_values_if_the_workspace_does_not_exist(self):
+        x_lower, x_upper = self.model.x_limits_of_workspace("FakeName")
 
         self.assertEqual(x_lower, 0.0)
         self.assertEqual(x_upper, 15.0)

--- a/scripts/test/Muon/fitting_widgets/basic_fitting/basic_fitting_presenter_test.py
+++ b/scripts/test/Muon/fitting_widgets/basic_fitting/basic_fitting_presenter_test.py
@@ -288,9 +288,59 @@ class BasicFittingPresenterTest(unittest.TestCase):
         self.presenter.handle_start_x_updated()
         self.mock_model_current_start_x.assert_called_once_with(self.start_x)
 
+    def test_that_handle_start_x_updated_will_reset_the_start_x_if_it_equals_the_end_x(self):
+        self.mock_view_start_x = mock.PropertyMock(return_value=self.end_x)
+        type(self.view).start_x = self.mock_view_start_x
+
+        self.presenter.handle_start_x_updated()
+
+        calls = [mock.call(), mock.call(), mock.call(0.0), mock.call(), mock.call(), mock.call()]
+        self.mock_view_start_x.assert_has_calls(calls)
+
+    def test_that_handle_start_x_updated_will_use_the_min_start_x_when_the_set_start_x_is_too_small(self):
+        x_lower = 3.0
+        self.model.x_limits_of_current_dataset = mock.Mock(return_value=(x_lower, self.end_x))
+
+        self.presenter.handle_start_x_updated()
+
+        self.mock_view_start_x.assert_called_with(x_lower)
+
+    def test_that_handle_start_x_updated_will_use_the_max_start_x_when_the_set_start_x_is_too_large(self):
+        x_upper = -0.1
+        self.model.x_limits_of_current_dataset = mock.Mock(return_value=(self.start_x, x_upper))
+
+        self.presenter.handle_start_x_updated()
+
+        self.mock_view_start_x.assert_called_with(x_upper)
+
     def test_that_handle_end_x_updated_will_attempt_to_update_the_end_x_in_the_model(self):
         self.presenter.handle_end_x_updated()
         self.mock_model_current_end_x.assert_called_once_with(self.end_x)
+
+    def test_that_handle_end_x_updated_will_reset_the_end_x_if_it_equals_the_end_x(self):
+        self.mock_view_end_x = mock.PropertyMock(return_value=self.start_x)
+        type(self.view).end_x = self.mock_view_end_x
+
+        self.presenter.handle_end_x_updated()
+
+        calls = [mock.call(), mock.call(), mock.call(15.0), mock.call(), mock.call(), mock.call()]
+        self.mock_view_end_x.assert_has_calls(calls)
+
+    def test_that_handle_end_x_updated_will_use_the_min_end_x_when_the_set_end_x_is_too_small(self):
+        x_lower = 16.0
+        self.model.x_limits_of_current_dataset = mock.Mock(return_value=(x_lower, self.end_x))
+
+        self.presenter.handle_start_x_updated()
+
+        self.mock_view_end_x.assert_called_with(x_lower)
+
+    def test_that_handle_end_x_updated_will_use_the_max_end_x_when_the_set_end_x_is_too_large(self):
+        x_upper = -0.1
+        self.model.x_limits_of_current_dataset = mock.Mock(return_value=(self.start_x, x_upper))
+
+        self.presenter.handle_end_x_updated()
+
+        self.mock_view_end_x.assert_called_with(x_upper)
 
     def test_that_handle_use_rebin_changed_will_not_update_the_model_if_the_rebin_check_fails(self):
         self.presenter._check_rebin_options = mock.Mock(return_value=False)
@@ -390,9 +440,6 @@ class BasicFittingPresenterTest(unittest.TestCase):
 
     def test_that_update_start_and_end_x_in_view_from_model_will_update_the_start_and_end_x_in_the_view(self):
         self.presenter.update_start_and_end_x_in_view_from_model()
-
-        self.model.x_limits_of_current_dataset.assert_called_once_with()
-        self.view.set_x_data_limits.assert_called_once_with(self.start_x, self.end_x)
 
         self.mock_model_current_start_x.assert_called_once_with()
         self.mock_view_start_x.assert_called_once_with(self.start_x)

--- a/scripts/test/Muon/fitting_widgets/basic_fitting/basic_fitting_presenter_test.py
+++ b/scripts/test/Muon/fitting_widgets/basic_fitting/basic_fitting_presenter_test.py
@@ -299,7 +299,7 @@ class BasicFittingPresenterTest(unittest.TestCase):
 
     def test_that_handle_start_x_updated_will_use_the_min_start_x_when_the_set_start_x_is_too_small(self):
         x_lower = 3.0
-        self.model.x_limits_of_current_dataset = mock.Mock(return_value=(x_lower, self.end_x))
+        self.model.x_limits_of_workspace = mock.Mock(return_value=(x_lower, self.end_x))
 
         self.presenter.handle_start_x_updated()
 
@@ -307,7 +307,7 @@ class BasicFittingPresenterTest(unittest.TestCase):
 
     def test_that_handle_start_x_updated_will_use_the_max_start_x_when_the_set_start_x_is_too_large(self):
         x_upper = -0.1
-        self.model.x_limits_of_current_dataset = mock.Mock(return_value=(self.start_x, x_upper))
+        self.model.x_limits_of_workspace = mock.Mock(return_value=(self.start_x, x_upper))
 
         self.presenter.handle_start_x_updated()
 
@@ -328,7 +328,7 @@ class BasicFittingPresenterTest(unittest.TestCase):
 
     def test_that_handle_end_x_updated_will_use_the_min_end_x_when_the_set_end_x_is_too_small(self):
         x_lower = 16.0
-        self.model.x_limits_of_current_dataset = mock.Mock(return_value=(x_lower, self.end_x))
+        self.model.x_limits_of_workspace = mock.Mock(return_value=(x_lower, self.end_x))
 
         self.presenter.handle_start_x_updated()
 
@@ -336,7 +336,7 @@ class BasicFittingPresenterTest(unittest.TestCase):
 
     def test_that_handle_end_x_updated_will_use_the_max_end_x_when_the_set_end_x_is_too_large(self):
         x_upper = -0.1
-        self.model.x_limits_of_current_dataset = mock.Mock(return_value=(self.start_x, x_upper))
+        self.model.x_limits_of_workspace = mock.Mock(return_value=(self.start_x, x_upper))
 
         self.presenter.handle_end_x_updated()
 

--- a/scripts/test/Muon/fitting_widgets/basic_fitting/basic_fitting_presenter_test.py
+++ b/scripts/test/Muon/fitting_widgets/basic_fitting/basic_fitting_presenter_test.py
@@ -391,6 +391,9 @@ class BasicFittingPresenterTest(unittest.TestCase):
     def test_that_update_start_and_end_x_in_view_from_model_will_update_the_start_and_end_x_in_the_view(self):
         self.presenter.update_start_and_end_x_in_view_from_model()
 
+        self.model.x_limits_of_current_dataset.assert_called_once_with()
+        self.view.set_x_data_limits.assert_called_once_with(self.start_x, self.end_x)
+
         self.mock_model_current_start_x.assert_called_once_with()
         self.mock_view_start_x.assert_called_once_with(self.start_x)
         self.mock_model_current_end_x.assert_called_once_with()
@@ -421,8 +424,8 @@ class BasicFittingPresenterTest(unittest.TestCase):
     def _setup_mock_model(self):
         self.model = mock.Mock(spec=BasicFittingModel)
         self.model = add_mock_methods_to_basic_fitting_model(self.model, self.dataset_names, self.current_dataset_index,
-                                                             self.fit_function, self.start_x, self.fit_status,
-                                                             self.chi_squared)
+                                                             self.fit_function, self.start_x, self.end_x,
+                                                             self.fit_status, self.chi_squared)
 
         # Mock the properties of the model
         self.mock_model_current_dataset_index = mock.PropertyMock(return_value=self.current_dataset_index)

--- a/scripts/test/Muon/fitting_widgets/general_fitting/general_fitting_presenter_test.py
+++ b/scripts/test/Muon/fitting_widgets/general_fitting/general_fitting_presenter_test.py
@@ -371,8 +371,8 @@ class GeneralFittingPresenterTest(unittest.TestCase):
     def _setup_mock_model(self):
         self.model = mock.Mock(spec=GeneralFittingModel)
         self.model = add_mock_methods_to_basic_fitting_model(self.model, self.dataset_names, self.current_dataset_index,
-                                                             self.fit_function, self.start_x, self.fit_status,
-                                                             self.chi_squared)
+                                                             self.fit_function, self.start_x, self.end_x,
+                                                             self.fit_status, self.chi_squared)
         # Mock the context
         self.model.context = mock.Mock()
 

--- a/scripts/test/Muon/fitting_widgets/tf_asymmetry_fitting/tf_asymmetry_fitting_presenter_test.py
+++ b/scripts/test/Muon/fitting_widgets/tf_asymmetry_fitting/tf_asymmetry_fitting_presenter_test.py
@@ -422,6 +422,7 @@ class TFAsymmetryFittingPresenterTest(unittest.TestCase):
         self.model.reset_start_xs_and_end_xs = mock.Mock()
         self.model.reset_fit_statuses_and_chi_squared = mock.Mock()
         self.model.reset_fit_functions = mock.Mock()
+        self.model.x_limits_of_current_dataset = mock.Mock(return_value=(self.start_x, self.end_x))
         self.model.retrieve_first_good_data_from_run = mock.Mock(return_value=self.start_x)
         self.model.get_active_fit_function = mock.Mock(return_value=self.fit_function)
         self.model.get_active_workspace_names = mock.Mock(return_value=[self.dataset_names[self.current_dataset_index]])

--- a/scripts/test/Muon/fitting_widgets/tf_asymmetry_fitting/tf_asymmetry_fitting_presenter_test.py
+++ b/scripts/test/Muon/fitting_widgets/tf_asymmetry_fitting/tf_asymmetry_fitting_presenter_test.py
@@ -422,7 +422,7 @@ class TFAsymmetryFittingPresenterTest(unittest.TestCase):
         self.model.reset_start_xs_and_end_xs = mock.Mock()
         self.model.reset_fit_statuses_and_chi_squared = mock.Mock()
         self.model.reset_fit_functions = mock.Mock()
-        self.model.x_limits_of_current_dataset = mock.Mock(return_value=(self.start_x, self.end_x))
+        self.model.x_limits_of_workspace = mock.Mock(return_value=(self.start_x, self.end_x))
         self.model.retrieve_first_good_data_from_run = mock.Mock(return_value=self.start_x)
         self.model.get_active_fit_function = mock.Mock(return_value=self.fit_function)
         self.model.get_active_workspace_names = mock.Mock(return_value=[self.dataset_names[self.current_dataset_index]])


### PR DESCRIPTION
**Description of work.**
This PR fixes a couple of things:
- The time start and time end will not go past the x limits of the data which is loaded (0.0 to 34.0 ish for Muon Analysis)
- Entering an empty string, or broken e notation, will no longer cause a crash/error
- If a start X is provided and larger than end X, the start and end X are swapped. And vice versa if end X < start X.

The LineEditDoubleValidator now being used is already well tested and is used in other areas
https://github.com/mantidproject/mantid/blob/d0872d5641a9be426bd5d04fd556e3e61e854e97/qt/python/mantidqt/utils/qt/test/test_line_edit_double_validator.py#L19

**To test:**
1. Muon Analysis
2. MUSR 62260
3. Go to fitting tab.
4. Try make time start smaller than time end. The values should swap
4. Try make time end smaller than time start. The values should swap
5. Try enter an empty string or broken e notation in the time start and end. The previous value should be reused
6. Try enter a value for start and end X which is outside the x range of the data. (The data x range is usually between 0 and 34)


Fixes #31505

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
