### PR TITLE
Update open fitbrowser and tool with default peak func set in settings

### DIFF
--- a/qt/python/mantidqt/widgets/fitpropertybrowser/fitpropertybrowser.py
+++ b/qt/python/mantidqt/widgets/fitpropertybrowser/fitpropertybrowser.py
@@ -159,7 +159,6 @@ class FitPropertyBrowser(FitPropertyBrowserBase):
         super(FitPropertyBrowser, self).show()
         self.tool = FitInteractiveTool(self.canvas,
                                        self.toolbar_manager,
-                                       current_peak_type=self.defaultPeakType(),
                                        default_background=self.defaultBackgroundType())
         self.tool.fit_range_changed.connect(self.set_fit_range)
         self.tool.peak_added.connect(self.peak_added_slot)
@@ -320,7 +319,6 @@ class FitPropertyBrowser(FitPropertyBrowserBase):
         if self.tool is not None:
             self.tool.add_to_menu(menu,
                                   peak_names=self.registeredPeaks(),
-                                  current_peak_type=self.defaultPeakType(),
                                   background_names=self.registeredBackgrounds(),
                                   other_names=self.registeredOthers())
         return menu


### PR DESCRIPTION
**Description of work.**

The default peak function at the point the interactive tool (to add peaks and functions in plots) is initialised is saved as a member variable in the class, but it is updated if the default peak function is changed in the workbench settings. This change removes the member variable that stores the default peak function and instead retrieves it from the config settings (I thought this was preferable to an observer/notifier for when the function is changed in the settings - but let me know if there's a better solution).

**To test:**
Follow the instructions in the original issue - the function should now match the one set in the settings.

Fixes #31504 

*This does not require release notes* because it is an edge case that has not been reported by a user (but needs fixing for a change in EngDiff UI #31502)

<!-- Ensure the base of this PR is correct (e.g. release-next or master)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
