### PR TITLE
About dialog scrollable if screen too small

### DIFF
--- a/docs/source/release/v6.2.0/mantidworkbench.rst
+++ b/docs/source/release/v6.2.0/mantidworkbench.rst
@@ -13,4 +13,6 @@ New and Improved
 Bugfixes
 --------
 
+- Scroll bars added to about dialog if screen resolution is too low.
+
 :ref:`Release 6.2.0 <v6.2.0>`

--- a/qt/applications/workbench/workbench/widgets/about/presenter.py
+++ b/qt/applications/workbench/workbench/widgets/about/presenter.py
@@ -28,30 +28,33 @@ class AboutPresenter(object):
         self.usage_reporting_verification_view = usage_reporting_verification_view \
             if usage_reporting_verification_view else UsageReportingVerificationView(parent, self)
         self.parent = parent
-        self.view.about_widget.clb_release_notes.clicked.connect(self.action_open_release_notes)
-        self.view.about_widget.clb_sample_datasets.clicked.connect(self.action_open_download_website)
-        self.view.about_widget.clb_mantid_introduction.clicked.connect(self.action_open_mantid_introduction)
-        self.view.about_widget.clb_python_introduction.clicked.connect(self.action_open_python_introduction)
-        self.view.about_widget.clb_python_in_mantid.clicked.connect(self.action_open_python_in_mantid)
-        self.view.about_widget.clb_extending_mantid.clicked.connect(self.action_open_extending_mantid)
-        self.view.about_widget.lbl_privacy_policy.linkActivated.connect(self.action_open_external_link)
-        self.view.about_widget.pb_manage_user_directories.clicked.connect(self.action_manage_user_directories)
-        self.view.about_widget.pb_close.clicked.connect(self.action_close)
+
+        about_widget = self.view.about_widget
+        about_widget.clb_release_notes.clicked.connect(self.action_open_release_notes)
+        about_widget.clb_sample_datasets.clicked.connect(self.action_open_download_website)
+        about_widget.clb_mantid_introduction.clicked.connect(self.action_open_mantid_introduction)
+        about_widget.clb_python_introduction.clicked.connect(self.action_open_python_introduction)
+        about_widget.clb_python_in_mantid.clicked.connect(self.action_open_python_in_mantid)
+        about_widget.clb_extending_mantid.clicked.connect(self.action_open_extending_mantid)
+        about_widget.lbl_privacy_policy.linkActivated.connect(self.action_open_external_link)
+        about_widget.pb_manage_user_directories.clicked.connect(self.action_manage_user_directories)
+        about_widget.pb_close.clicked.connect(self.action_close)
+
         self.setup_facilities_group()
 
         # set chk_allow_usage_data
         isUsageReportEnabled = ConfigService.getString(self.USAGE_REPORTING, True)
         if isUsageReportEnabled == "0":
-            self.view.about_widget.chk_allow_usage_data.setChecked(False)
-        self.view.about_widget.chk_allow_usage_data.stateChanged.connect(self.action_usage_data_changed)
+            about_widget.chk_allow_usage_data.setChecked(False)
+        about_widget.chk_allow_usage_data.stateChanged.connect(self.action_usage_data_changed)
 
         # set do not show
         qSettings = QSettings()
         qSettings.beginGroup(self.DO_NOT_SHOW_GROUP)
         doNotShowUntilNextRelease = int(qSettings.value(self.DO_NOT_SHOW, "0"))
         qSettings.endGroup()
-        self.view.about_widget.chk_do_not_show_until_next_release.setChecked(doNotShowUntilNextRelease)
-        self.view.about_widget.chk_do_not_show_until_next_release.stateChanged.connect(self.action_do_not_show_until_next_release)
+        about_widget.chk_do_not_show_until_next_release.setChecked(doNotShowUntilNextRelease)
+        about_widget.chk_do_not_show_until_next_release.stateChanged.connect(self.action_do_not_show_until_next_release)
 
     @staticmethod
     def should_show_on_startup():
@@ -78,7 +81,7 @@ class AboutPresenter(object):
 
         settings = QSettings()
         settings.beginGroup(AboutPresenter.DO_NOT_SHOW_GROUP)
-        doNotShowUntilNextRelease =int(settings.value(AboutPresenter.DO_NOT_SHOW, '0'))
+        doNotShowUntilNextRelease = int(settings.value(AboutPresenter.DO_NOT_SHOW, '0'))
         lastVersion = settings.value(AboutPresenter.LAST_VERSION, "")
         settings.endGroup()
 

--- a/qt/applications/workbench/workbench/widgets/about/presenter.py
+++ b/qt/applications/workbench/workbench/widgets/about/presenter.py
@@ -26,32 +26,32 @@ class AboutPresenter(object):
     def __init__(self, parent, view=None, usage_reporting_verification_view = None):
         self.view = view if view else AboutView(parent, self, version_str(), release_date().strip())
         self.usage_reporting_verification_view = usage_reporting_verification_view \
-            if usage_reporting_verification_view  else UsageReportingVerificationView(parent, self)
+            if usage_reporting_verification_view else UsageReportingVerificationView(parent, self)
         self.parent = parent
-        self.view.clb_release_notes.clicked.connect(self.action_open_release_notes)
-        self.view.clb_sample_datasets.clicked.connect(self.action_open_download_website)
-        self.view.clb_mantid_introduction.clicked.connect(self.action_open_mantid_introduction)
-        self.view.clb_python_introduction.clicked.connect(self.action_open_python_introduction)
-        self.view.clb_python_in_mantid.clicked.connect(self.action_open_python_in_mantid)
-        self.view.clb_extending_mantid.clicked.connect(self.action_open_extending_mantid)
-        self.view.lbl_privacy_policy.linkActivated.connect(self.action_open_external_link)
-        self.view.pb_manage_user_directories.clicked.connect(self.action_manage_user_directories)
-        self.view.pb_close.clicked.connect(self.action_close)
+        self.view.about_widget.clb_release_notes.clicked.connect(self.action_open_release_notes)
+        self.view.about_widget.clb_sample_datasets.clicked.connect(self.action_open_download_website)
+        self.view.about_widget.clb_mantid_introduction.clicked.connect(self.action_open_mantid_introduction)
+        self.view.about_widget.clb_python_introduction.clicked.connect(self.action_open_python_introduction)
+        self.view.about_widget.clb_python_in_mantid.clicked.connect(self.action_open_python_in_mantid)
+        self.view.about_widget.clb_extending_mantid.clicked.connect(self.action_open_extending_mantid)
+        self.view.about_widget.lbl_privacy_policy.linkActivated.connect(self.action_open_external_link)
+        self.view.about_widget.pb_manage_user_directories.clicked.connect(self.action_manage_user_directories)
+        self.view.about_widget.pb_close.clicked.connect(self.action_close)
         self.setup_facilities_group()
 
         # set chk_allow_usage_data
         isUsageReportEnabled = ConfigService.getString(self.USAGE_REPORTING, True)
         if isUsageReportEnabled == "0":
-            self.view.chk_allow_usage_data.setChecked(False)
-        self.view.chk_allow_usage_data.stateChanged.connect(self.action_usage_data_changed)
+            self.view.about_widget.chk_allow_usage_data.setChecked(False)
+        self.view.about_widget.chk_allow_usage_data.stateChanged.connect(self.action_usage_data_changed)
 
         # set do not show
         qSettings = QSettings()
         qSettings.beginGroup(self.DO_NOT_SHOW_GROUP)
         doNotShowUntilNextRelease = int(qSettings.value(self.DO_NOT_SHOW, "0"))
         qSettings.endGroup()
-        self.view.chk_do_not_show_until_next_release.setChecked(doNotShowUntilNextRelease)
-        self.view.chk_do_not_show_until_next_release.stateChanged.connect(self.action_do_not_show_until_next_release)
+        self.view.about_widget.chk_do_not_show_until_next_release.setChecked(doNotShowUntilNextRelease)
+        self.view.about_widget.chk_do_not_show_until_next_release.stateChanged.connect(self.action_do_not_show_until_next_release)
 
     @staticmethod
     def should_show_on_startup():
@@ -93,14 +93,14 @@ class AboutPresenter(object):
         facilities = sorted(ConfigService.getFacilityNames())
         if not facilities:
             return
-        self.view.cb_facility.addItems(facilities)
+        self.view.about_widget.cb_facility.addItems(facilities)
 
         current_facility = self._get_current_facility()
         default_facility = current_facility if current_facility is not None else facilities[0]
 
-        self.view.cb_facility.setCurrentIndex(self.view.cb_facility.findText(default_facility))
+        self.view.about_widget.cb_facility.setCurrentIndex(self.view.about_widget.cb_facility.findText(default_facility))
         self.action_facility_changed(default_facility)
-        self.view.cb_facility.currentTextChanged.connect(self.action_facility_changed)
+        self.view.about_widget.cb_facility.currentTextChanged.connect(self.action_facility_changed)
 
     def action_facility_changed(self, new_facility):
         """
@@ -110,9 +110,9 @@ class AboutPresenter(object):
         current_facility = self._get_current_facility()
         self.store_facility(new_facility)
         # refresh the instrument selection to contain instruments about the selected facility only
-        self.view.cb_instrument.facility = new_facility
+        self.view.about_widget.cb_instrument.facility = new_facility
         if new_facility != current_facility:
-            self.view.cb_instrument.setCurrentIndex(0)
+            self.view.about_widget.cb_instrument.setCurrentIndex(0)
 
     def store_facility(self, new_facility):
         current_facility = self._get_current_facility()
@@ -170,7 +170,7 @@ class AboutPresenter(object):
                 # No was clicked, or no button was clicked
                 # set the checkbox back to checked
                 checkedState = Qt.Checked
-                self.view.chk_allow_usage_data.setCheckState(checkedState)
+                self.view.about_widget.chk_allow_usage_data.setCheckState(checkedState)
 
         ConfigService.setString(self.USAGE_REPORTING, "1" if checkedState == Qt.Checked else "0")
 
@@ -189,7 +189,7 @@ class AboutPresenter(object):
         settings.beginGroup(self.DO_NOT_SHOW_GROUP)
         settings.setValue(self.LAST_VERSION, release_notes_url())
         settings.endGroup()
-        self.store_facility(self.view.cb_facility.currentText())
-        self.action_instrument_changed(self.view.cb_instrument.currentText())
+        self.store_facility(self.view.about_widget.cb_facility.currentText())
+        self.action_instrument_changed(self.view.about_widget.cb_instrument.currentText())
         ConfigService.saveConfig(ConfigService.getUserFilename())
         self.parent.config_updated()

--- a/qt/applications/workbench/workbench/widgets/about/test/test_about_presenter.py
+++ b/qt/applications/workbench/workbench/widgets/about/test/test_about_presenter.py
@@ -126,45 +126,50 @@ class AboutPresenterTest(TestCase):
         self.assertEqual(0, mock_ConfigService.setFacility.call_count)
         self.assertEqual(3, mock_ConfigService.getFacility.call_count)
         self.assertEqual(3, mock_ConfigService.mock_facility.name.call_count)
-        self.assert_connected_once(presenter.view.about_widget.cb_facility, presenter.view.about_widget.cb_facility.currentTextChanged)
+        self.assert_connected_once(presenter.view.about_widget.cb_facility,
+                                   presenter.view.about_widget.cb_facility.currentTextChanged)
 
     def test_setup_checkbox_signals(self):
         presenter = AboutPresenter(None)
+        about_widget = presenter.view.about_widget
 
-        self.assert_connected_once(presenter.view.about_widget.chk_do_not_show_until_next_release,
+        self.assert_connected_once(about_widget.chk_do_not_show_until_next_release,
                                    presenter.view.about_widget.chk_do_not_show_until_next_release.stateChanged)
 
-        self.assert_connected_once(presenter.view.about_widget.chk_allow_usage_data,
-                                   presenter.view.about_widget.chk_allow_usage_data.stateChanged)
+        self.assert_connected_once(about_widget.chk_allow_usage_data,
+                                   about_widget.chk_allow_usage_data.stateChanged)
 
     def test_setup_button_signals(self):
         presenter = AboutPresenter(None)
+        about_widget = presenter.view.about_widget
 
-        self.assert_connected_once(presenter.view.about_widget.clb_release_notes,
-                                   presenter.view.about_widget.clb_release_notes.clicked)
-        self.assert_connected_once(presenter.view.about_widget.clb_sample_datasets,
-                                   presenter.view.about_widget.clb_sample_datasets.clicked)
-        self.assert_connected_once(presenter.view.about_widget.clb_mantid_introduction,
-                                   presenter.view.about_widget.clb_mantid_introduction.clicked)
-        self.assert_connected_once(presenter.view.about_widget.clb_python_introduction,
-                                   presenter.view.about_widget.clb_python_introduction.clicked)
-        self.assert_connected_once(presenter.view.about_widget.clb_python_in_mantid,
-                                   presenter.view.about_widget.clb_python_in_mantid.clicked)
-        self.assert_connected_once(presenter.view.about_widget.clb_extending_mantid,
-                                   presenter.view.about_widget.clb_extending_mantid.clicked)
-        self.assert_connected_once(presenter.view.about_widget.pb_manage_user_directories,
-                                   presenter.view.about_widget.pb_manage_user_directories.clicked)
-        self.assert_connected_once(presenter.view.about_widget.lbl_privacy_policy,
-                                   presenter.view.about_widget.lbl_privacy_policy.linkActivated)
+        self.assert_connected_once(about_widget.clb_release_notes,
+                                   about_widget.clb_release_notes.clicked)
+        self.assert_connected_once(about_widget.clb_sample_datasets,
+                                   about_widget.clb_sample_datasets.clicked)
+        self.assert_connected_once(about_widget.clb_mantid_introduction,
+                                   about_widget.clb_mantid_introduction.clicked)
+        self.assert_connected_once(about_widget.clb_python_introduction,
+                                   about_widget.clb_python_introduction.clicked)
+        self.assert_connected_once(about_widget.clb_python_in_mantid,
+                                   about_widget.clb_python_in_mantid.clicked)
+        self.assert_connected_once(about_widget.clb_extending_mantid,
+                                   about_widget.clb_extending_mantid.clicked)
+        self.assert_connected_once(about_widget.pb_manage_user_directories,
+                                   about_widget.pb_manage_user_directories.clicked)
+        self.assert_connected_once(about_widget.lbl_privacy_policy,
+                                   about_widget.lbl_privacy_policy.linkActivated)
 
     def test_setup_link_signals(self):
         presenter = AboutPresenter(None)
+        about_widget = presenter.view.about_widget
 
-        self.assert_connected_once(presenter.view.about_widget.clb_release_notes,
-                                   presenter.view.about_widget.clb_release_notes.clicked)
+        self.assert_connected_once(about_widget.clb_release_notes,
+                                   about_widget.clb_release_notes.clicked)
 
     @patch(CONFIG_SERVICE_CLASSPATH, new_callable=MockConfigService)
-    def test_that_about_presenter_is_instantiated_without_error_when_getFacility_causes_exception(self, MockConfigService):
+    def test_that_about_presenter_is_instantiated_without_error_when_getFacility_causes_exception(self,
+                                                                                                  MockConfigService):
         MockConfigService.getFacility.side_effect = RuntimeError(Mock(status=101), "No facility")
         presenter = AboutPresenter(None)
 

--- a/qt/applications/workbench/workbench/widgets/about/test/test_about_presenter.py
+++ b/qt/applications/workbench/workbench/widgets/about/test/test_about_presenter.py
@@ -5,9 +5,10 @@
 #   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
 # SPDX - License - Identifier: GPL - 3.0 +
 #  This file is part of the mantid workbench
+import unittest
 from unittest import TestCase
-
 from unittest.mock import call, Mock, patch
+
 from mantidqt.utils.qt.testing import start_qapplication
 from mantidqt.utils.testing.strict_mock import StrictMock
 from workbench.widgets.about.presenter import AboutPresenter
@@ -92,8 +93,8 @@ class AboutPresenterTest(TestCase):
     @patch(CONFIG_SERVICE_CLASSPATH, new_callable=MockConfigService)
     def test_should_show_on_startup_do_not_show_same_version(self, MockConfigService):
         version_str = "the same every time"
-        with patch(self.QSETTINGS_CLASSPATH, return_value = FakeQSettings(version_str)):
-            with patch(self.RELEASE_NOTES_URL_CLASSPATH, return_value = version_str):
+        with patch(self.QSETTINGS_CLASSPATH, return_value=FakeQSettings(version_str)):
+            with patch(self.RELEASE_NOTES_URL_CLASSPATH, return_value=version_str):
                 self.assertFalse(AboutPresenter.should_show_on_startup(),
                                  "If do not show is in Qsettings then should_show_on_startup should always be False"
                                  + "for the same version")
@@ -105,8 +106,8 @@ class AboutPresenterTest(TestCase):
     @patch(CONFIG_SERVICE_CLASSPATH, new_callable=MockConfigService)
     def test_should_show_on_startup_do_not_show_different_versions(self, MockConfigService):
         version_str = "the same every time"
-        with patch(self.QSETTINGS_CLASSPATH, return_value = FakeQSettings(version_str)):
-            with patch(self.RELEASE_NOTES_URL_CLASSPATH, return_value = "not the " + version_str):
+        with patch(self.QSETTINGS_CLASSPATH, return_value=FakeQSettings(version_str)):
+            with patch(self.RELEASE_NOTES_URL_CLASSPATH, return_value="not the " + version_str):
                 self.assertTrue(AboutPresenter.should_show_on_startup(),
                                 "If do not show is in Qsettings then should_show_on_startup should always be True"
                                 + " for different versions")
@@ -125,42 +126,42 @@ class AboutPresenterTest(TestCase):
         self.assertEqual(0, mock_ConfigService.setFacility.call_count)
         self.assertEqual(3, mock_ConfigService.getFacility.call_count)
         self.assertEqual(3, mock_ConfigService.mock_facility.name.call_count)
-        self.assert_connected_once(presenter.view.cb_facility, presenter.view.cb_facility.currentTextChanged)
+        self.assert_connected_once(presenter.view.about_widget.cb_facility, presenter.view.about_widget.cb_facility.currentTextChanged)
 
     def test_setup_checkbox_signals(self):
         presenter = AboutPresenter(None)
 
-        self.assert_connected_once(presenter.view.chk_do_not_show_until_next_release,
-                                   presenter.view.chk_do_not_show_until_next_release.stateChanged)
+        self.assert_connected_once(presenter.view.about_widget.chk_do_not_show_until_next_release,
+                                   presenter.view.about_widget.chk_do_not_show_until_next_release.stateChanged)
 
-        self.assert_connected_once(presenter.view.chk_allow_usage_data,
-                                   presenter.view.chk_allow_usage_data.stateChanged)
+        self.assert_connected_once(presenter.view.about_widget.chk_allow_usage_data,
+                                   presenter.view.about_widget.chk_allow_usage_data.stateChanged)
 
     def test_setup_button_signals(self):
         presenter = AboutPresenter(None)
 
-        self.assert_connected_once(presenter.view.clb_release_notes,
-                                   presenter.view.clb_release_notes.clicked)
-        self.assert_connected_once(presenter.view.clb_sample_datasets,
-                                   presenter.view.clb_sample_datasets.clicked)
-        self.assert_connected_once(presenter.view.clb_mantid_introduction,
-                                   presenter.view.clb_mantid_introduction.clicked)
-        self.assert_connected_once(presenter.view.clb_python_introduction,
-                                   presenter.view.clb_python_introduction.clicked)
-        self.assert_connected_once(presenter.view.clb_python_in_mantid,
-                                   presenter.view.clb_python_in_mantid.clicked)
-        self.assert_connected_once(presenter.view.clb_extending_mantid,
-                                   presenter.view.clb_extending_mantid.clicked)
-        self.assert_connected_once(presenter.view.pb_manage_user_directories,
-                                   presenter.view.pb_manage_user_directories.clicked)
-        self.assert_connected_once(presenter.view.lbl_privacy_policy,
-                                   presenter.view.lbl_privacy_policy.linkActivated)
+        self.assert_connected_once(presenter.view.about_widget.clb_release_notes,
+                                   presenter.view.about_widget.clb_release_notes.clicked)
+        self.assert_connected_once(presenter.view.about_widget.clb_sample_datasets,
+                                   presenter.view.about_widget.clb_sample_datasets.clicked)
+        self.assert_connected_once(presenter.view.about_widget.clb_mantid_introduction,
+                                   presenter.view.about_widget.clb_mantid_introduction.clicked)
+        self.assert_connected_once(presenter.view.about_widget.clb_python_introduction,
+                                   presenter.view.about_widget.clb_python_introduction.clicked)
+        self.assert_connected_once(presenter.view.about_widget.clb_python_in_mantid,
+                                   presenter.view.about_widget.clb_python_in_mantid.clicked)
+        self.assert_connected_once(presenter.view.about_widget.clb_extending_mantid,
+                                   presenter.view.about_widget.clb_extending_mantid.clicked)
+        self.assert_connected_once(presenter.view.about_widget.pb_manage_user_directories,
+                                   presenter.view.about_widget.pb_manage_user_directories.clicked)
+        self.assert_connected_once(presenter.view.about_widget.lbl_privacy_policy,
+                                   presenter.view.about_widget.lbl_privacy_policy.linkActivated)
 
     def test_setup_link_signals(self):
         presenter = AboutPresenter(None)
 
-        self.assert_connected_once(presenter.view.clb_release_notes,
-                                   presenter.view.clb_release_notes.clicked)
+        self.assert_connected_once(presenter.view.about_widget.clb_release_notes,
+                                   presenter.view.about_widget.clb_release_notes.clicked)
 
     @patch(CONFIG_SERVICE_CLASSPATH, new_callable=MockConfigService)
     def test_that_about_presenter_is_instantiated_without_error_when_getFacility_causes_exception(self, MockConfigService):
@@ -169,3 +170,7 @@ class AboutPresenterTest(TestCase):
 
         self.assertEqual(3, MockConfigService.getFacility.call_count)
         self.assertEqual(presenter._get_current_facility(), None)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/qt/applications/workbench/workbench/widgets/about/view.py
+++ b/qt/applications/workbench/workbench/widgets/about/view.py
@@ -48,6 +48,18 @@ class AboutView(QDialog):
         self.deleteLater()
         super(AboutView, self).closeEvent(event)
 
+    def resizeEvent(self, event):
+        """
+        Hide the scroll bars if the dialog reaches the size of the about widget.
+        """
+        if hasattr(self, 'scroll_area'):
+            if self.width() < self.about_widget.width() or self.height() < self.about_widget.height():
+                self.scroll_area.setHorizontalScrollBarPolicy(Qt.ScrollBarAsNeeded)
+                self.scroll_area.setVerticalScrollBarPolicy(Qt.ScrollBarAsNeeded)
+            else:
+                self.scroll_area.setHorizontalScrollBarPolicy(Qt.ScrollBarAlwaysOff)
+                self.scroll_area.setVerticalScrollBarPolicy(Qt.ScrollBarAlwaysOff)
+
 
 class AboutViewWidget(QWidget):
     def __init__(self, parent, version_text, date_text):

--- a/qt/applications/workbench/workbench/widgets/about/view.py
+++ b/qt/applications/workbench/workbench/widgets/about/view.py
@@ -118,8 +118,8 @@ class AboutViewWidget(QWidget):
             screen = QGuiApplication.primaryScreen()
 
         if screen is not None:
-            screen_width = screen.size().width()
-            screen_height = screen.size().height()
+            screen_width = screen.availableSize().width()
+            screen_height = screen.availableSize().height()
 
             # the proportion of the whole window size for the about screen
             window_scaling = 0.4

--- a/qt/applications/workbench/workbench/widgets/about/view.py
+++ b/qt/applications/workbench/workbench/widgets/about/view.py
@@ -52,6 +52,7 @@ class AboutView(QDialog):
         """
         Hide the scroll bars if the dialog reaches the size of the about widget.
         """
+        super().resizeEvent(event)
         if hasattr(self, 'scroll_area'):
             if self.width() < self.about_widget.width() or self.height() < self.about_widget.height():
                 self.scroll_area.setHorizontalScrollBarPolicy(Qt.ScrollBarAsNeeded)

--- a/qt/applications/workbench/workbench/widgets/about/view.py
+++ b/qt/applications/workbench/workbench/widgets/about/view.py
@@ -9,18 +9,49 @@ from PyQt5.QtWidgets import QCommandLinkButton
 from qtpy.QtCore import Qt, QSize
 from qtpy.QtGui import QPixmap, QIcon, QGuiApplication, QPainter
 from qtpy.QtWidgets import QVBoxLayout, QHBoxLayout, QSpacerItem, QSizePolicy, QLabel, QDialog, \
-    QGroupBox, QFormLayout, QComboBox, QPushButton, QCheckBox
+    QGroupBox, QFormLayout, QComboBox, QPushButton, QCheckBox, QWidget, QScrollArea
 from mantidqt.widgets import instrumentselector
 
 REFERENCE_HEIGHT = 642
 REFERENCE_WIDTH = 745
 REFERENCE_ASPECT_RATIO = REFERENCE_WIDTH / REFERENCE_HEIGHT
-WIDESCREEN_ASPECT_RATIO = 16/9
+WIDESCREEN_ASPECT_RATIO = 16 / 9
 
 
 class AboutView(QDialog):
-    def __init__(self, parent, presenter, version_text, date_text = None):
+    """
+    Dialog that contains the about widget. If the screen is too small, the dialog will use a scroll area,
+    otherwise it will simply contain the about widget.
+    """
+
+    def __init__(self, parent, presenter, version_text, date_text=None):
         super(AboutView, self).__init__(parent)
+        self.presenter = presenter
+        self.about_widget = AboutViewWidget(self, version_text, date_text)
+
+        layout = QVBoxLayout()
+        layout.setContentsMargins(0, 0, 0, 0)
+        self.setLayout(layout)
+
+        if self.about_widget.is_widget_too_big:
+            self.scroll_area = QScrollArea()
+            self.scroll_area.setWidget(self.about_widget)
+            layout.addWidget(self.scroll_area)
+            self.setMaximumSize(self.about_widget.size())
+
+        else:
+            layout.addWidget(self.about_widget)
+            self.setFixedSize(self.about_widget.size())
+
+    def closeEvent(self, event):
+        self.presenter.save_on_closing()
+        self.deleteLater()
+        super(AboutView, self).closeEvent(event)
+
+
+class AboutViewWidget(QWidget):
+    def __init__(self, parent, version_text, date_text):
+        super(AboutViewWidget, self).__init__(parent)
         self.background_pixmap = QPixmap(':/images/First_use_Background.png')
         self.mantid_pixmap = QPixmap(':/images/mantid_smaller.png')
         self.lbl_version = QLabel()
@@ -37,9 +68,9 @@ class AboutView(QDialog):
         self.lbl_privacy_policy = QLabel()
         self.chk_do_not_show_until_next_release = QCheckBox()
         self.pb_close = QPushButton()
+        self.is_widget_too_big = False
         self.setupUI()
         self.customize_layout(version_text, date_text)
-        self.presenter = presenter
 
     def paintEvent(self, event):
         scaled_background = self.background_pixmap.scaled(self.rescale_w(self.background_pixmap.width()),
@@ -54,7 +85,7 @@ class AboutView(QDialog):
         qp = QPainter()
         qp.begin(self)
         qp.drawPixmap(0, 0, scaled_background)
-        qp.drawPixmap(self.width() - scaled_mantid.width(), self.height()-scaled_mantid.height(), scaled_mantid)
+        qp.drawPixmap(self.width() - scaled_mantid.width(), self.height() - scaled_mantid.height(), scaled_mantid)
         qp.end()
 
     def determine_dialog_dimensions(self):
@@ -63,8 +94,8 @@ class AboutView(QDialog):
 
         screen = None
         try:
-            if hasattr(QGuiApplication,"screenAt"):
-                screen = QGuiApplication.screenAt(self.parent().geometry().center())
+            if hasattr(QGuiApplication, "screenAt"):
+                screen = QGuiApplication.screenAt(self.parent().parent().geometry().center())
             else:
                 # get the screen from the last top level window
                 windows = QGuiApplication.topLevelWindows()
@@ -82,7 +113,7 @@ class AboutView(QDialog):
             width = int(screen_width * window_scaling)
 
             # also calculate the intended width but using the hieght and a standard screen aspect ratio
-            width_by_height= int(screen_height * WIDESCREEN_ASPECT_RATIO * window_scaling)
+            width_by_height = int(screen_height * WIDESCREEN_ASPECT_RATIO * window_scaling)
             # take the smaller of the width from the screen width and height
             if width_by_height < width:
                 width = width_by_height
@@ -94,6 +125,9 @@ class AboutView(QDialog):
             # calculate height from the width and aspect ratio
             height = int(width / REFERENCE_ASPECT_RATIO)
 
+            if width > screen_width or height > screen_height:
+                self.is_widget_too_big = True
+
         return width, height
 
     def rescale_w(self, value):
@@ -103,9 +137,9 @@ class AboutView(QDialog):
         return int(value * (self.height() / REFERENCE_HEIGHT))
 
     def setupUI(self):
-        width, height  = self.determine_dialog_dimensions()
+        width, height = self.determine_dialog_dimensions()
 
-        self.setMinimumSize(width, height)
+        self.setFixedSize(width, height)
         self.setSizePolicy(QSizePolicy.Fixed, QSizePolicy.Fixed)
         self.setWindowTitle("About Mantid Workbench")
         self.setStyleSheet(f"""QDialog {{
@@ -128,7 +162,7 @@ QCommandLinkButton:hover {{
 
         # version label section at th etop
         parent_layout = QVBoxLayout()
-        parent_layout.addSpacerItem(QSpacerItem(self.rescale_w(20),self.rescale_h(70),vPolicy=QSizePolicy.Fixed))
+        parent_layout.addSpacerItem(QSpacerItem(self.rescale_w(20), self.rescale_h(70), vPolicy=QSizePolicy.Fixed))
         self.lbl_version.setText("version ")
         self.lbl_version.setIndent(self.rescale_w(115))
         self.lbl_version.setStyleSheet(f"""color: rgb(215, 215, 215);
@@ -136,7 +170,7 @@ font: {self.rescale_w(28)}pt;
 font-weight: bold;
 font-size: {self.rescale_w(28)}px""")
         parent_layout.addWidget(self.lbl_version)
-        parent_layout.addSpacerItem(QSpacerItem(self.rescale_w(20),self.rescale_h(40),
+        parent_layout.addSpacerItem(QSpacerItem(self.rescale_w(20), self.rescale_h(40),
                                                 vPolicy=QSizePolicy.MinimumExpanding))
 
         # split into the two columns
@@ -244,7 +278,7 @@ font: {self.rescale_w(12)}px;
                                         r'Privacy Policy</span></a></p></body></html>')
         self.lbl_privacy_policy.setOpenExternalLinks(False)
         usagelayout.addWidget(self.lbl_privacy_policy)
-        personal_setup_form_layout.addRow(lbl_allow_usage_data,usagelayout)
+        personal_setup_form_layout.addRow(lbl_allow_usage_data, usagelayout)
         grp_personal_setup_layout.addLayout(personal_setup_form_layout)
         right_layout.addWidget(grp_personal_setup)
         right_layout.addSpacerItem(QSpacerItem(self.rescale_w(20), self.rescale_h(40), vPolicy=QSizePolicy.Expanding))
@@ -257,7 +291,7 @@ font: {self.rescale_w(12)}px;
         icon_layout_top.addWidget(self.create_label_with_image(112, 50, ':/images/ISIS_Logo_Transparent.gif'))
         icon_layout_top.addSpacerItem(QSpacerItem(self.rescale_w(10), self.rescale_h(20), hPolicy=QSizePolicy.Fixed))
         icon_layout_top.addWidget(self.create_label_with_image(94, 50, ':/images/ess_logo_transparent_small.png'))
-        icon_layout_top.addSpacerItem(QSpacerItem(self.rescale_w(40), 20,hPolicy=QSizePolicy.Expanding))
+        icon_layout_top.addSpacerItem(QSpacerItem(self.rescale_w(40), 20, hPolicy=QSizePolicy.Expanding))
         right_layout.addLayout(icon_layout_top)
         # Row two
         icon_layout_middle = QHBoxLayout()
@@ -291,9 +325,9 @@ font: {self.rescale_w(12)}px;
         do_not_show_layout = QVBoxLayout()
         do_not_show_layout.setContentsMargins(self.rescale_w(15), 0, 0, 0)
         do_not_show_layout.setSpacing(self.rescale_w(2))
-        do_not_show_layout.addSpacerItem(QSpacerItem(1,self.rescale_h(1), vPolicy=QSizePolicy.Expanding))
+        do_not_show_layout.addSpacerItem(QSpacerItem(1, self.rescale_h(1), vPolicy=QSizePolicy.Expanding))
         lbl_update = QLabel()
-        lbl_update.setMinimumSize(self.rescale_w(400),0)
+        lbl_update.setMinimumSize(self.rescale_w(400), 0)
         lbl_update.setStyleSheet("color: rgb(25,125,25);")
         lbl_update.setText('You can revisit this dialog by selecting "About" on the Help menu.')
         lbl_update.setAlignment(Qt.AlignBottom)
@@ -308,13 +342,13 @@ font: {self.rescale_w(12)}px;
         lbl_do_not_show.setStyleSheet("color: rgb(25,125,25);")
         lbl_do_not_show.setText('Do not show again until next release')
         do_not_show_checkbox_layout.addWidget(lbl_do_not_show)
-        do_not_show_checkbox_layout.addSpacerItem(QSpacerItem(self.rescale_w(40),10, hPolicy=QSizePolicy.Expanding))
+        do_not_show_checkbox_layout.addSpacerItem(QSpacerItem(self.rescale_w(40), 10, hPolicy=QSizePolicy.Expanding))
         do_not_show_layout.addLayout(do_not_show_checkbox_layout)
         footer_layout.addLayout(do_not_show_layout)
 
         # Close button
         close_button_layout = QVBoxLayout()
-        close_button_layout.addSpacerItem(QSpacerItem(20,self.rescale_h(15), vPolicy=QSizePolicy.Expanding))
+        close_button_layout.addSpacerItem(QSpacerItem(20, self.rescale_h(15), vPolicy=QSizePolicy.Expanding))
         self.pb_close.setText("Close")
         self.pb_close.setDefault(True)
         close_button_layout.addWidget(self.pb_close)
@@ -348,8 +382,3 @@ font: {self.rescale_w(12)}px;
             # strip off the first few characters that will be "day, "
             version_label += " ({0})".format(date_text[5:])
         self.lbl_version.setText(self.lbl_version.text() + version_label)
-
-    def closeEvent(self, event):
-        self.presenter.save_on_closing()
-        self.deleteLater()
-        super(AboutView, self).closeEvent(event)


### PR DESCRIPTION
**Description of work.**

If the about dialog is opened on a screen with resolution less than 745 x 642, it will now have scroll bars so that the dialog doesn't appear too big for the screen. Otherwise, with a standard monitor resolution it should behave exactly as it did before (same fixed size, and no scroll bars).

**To test:**

1. New functionality
- Open Mantid Workbench and move the application to a monitor with a resolution of less than 745 x 642.
- Click "Help->About Mantid Workbench".
- The about dialog should have scroll bars so that the entire thing is viewable.
2. Exisiting functionality
- Same as above, but with your regular monitor resolution (assuming it's > 745 x 642).
- The about dialog should perform exactly as in the previous Mantid version.

Compare both cases with your installed version of Mantid to verify the improvement, and check that it still behaves the same as it did before for a regular screen size.

Fixes #31428 

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
