### PR TITLE
New ApplyInstrumentToPeaks algorithm

### DIFF
--- a/Framework/Algorithms/CMakeLists.txt
+++ b/Framework/Algorithms/CMakeLists.txt
@@ -1,6 +1,5 @@
 set(SRC_FILES
     src/AbsorptionCorrection.cpp
-    src/PaalmanPingsAbsorptionCorrection.cpp
     src/AddAbsorptionWeightedPathLengths.cpp
     src/AddLogDerivative.cpp
     src/AddNote.cpp
@@ -15,6 +14,7 @@ set(SRC_FILES
     src/ApplyCalibration.cpp
     src/ApplyDetailedBalance.cpp
     src/ApplyFloodWorkspace.cpp
+    src/ApplyInstrumentToPeaks.cpp
     src/ApplyTransmissionCorrection.cpp
     src/AverageLogData.cpp
     src/Bin2DPowderDiffraction.cpp
@@ -71,9 +71,9 @@ set(SRC_FILES
     src/CopyInstrumentParameters.cpp
     src/CopyLogs.cpp
     src/CopySample.cpp
-    src/CorelliCrossCorrelate.cpp
     src/CorelliCalibrationApply.cpp
     src/CorelliCalibrationDatabase.cpp
+    src/CorelliCrossCorrelate.cpp
     src/CorrectKiKf.cpp
     src/CorrectTOFAxis.cpp
     src/CorrectToFile.cpp
@@ -220,6 +220,7 @@ set(SRC_FILES
     src/PDDetermineCharacterizations.cpp
     src/PDFFourierTransform.cpp
     src/PDFFourierTransform2.cpp
+    src/PaalmanPingsAbsorptionCorrection.cpp
     src/PaddingAndApodization.cpp
     src/ParallaxCorrection.cpp
     src/Pause.cpp
@@ -332,7 +333,6 @@ set(SRC_FILES
 
 set(INC_FILES
     inc/MantidAlgorithms/AbsorptionCorrection.h
-    inc/MantidAlgorithms/PaalmanPingsAbsorptionCorrection.h
     inc/MantidAlgorithms/AddAbsorptionWeightedPathLengths.h
     inc/MantidAlgorithms/AddLogDerivative.h
     inc/MantidAlgorithms/AddNote.h
@@ -347,6 +347,7 @@ set(INC_FILES
     inc/MantidAlgorithms/ApplyCalibration.h
     inc/MantidAlgorithms/ApplyDetailedBalance.h
     inc/MantidAlgorithms/ApplyFloodWorkspace.h
+    inc/MantidAlgorithms/ApplyInstrumentToPeaks.h
     inc/MantidAlgorithms/ApplyTransmissionCorrection.h
     inc/MantidAlgorithms/AverageLogData.h
     inc/MantidAlgorithms/Bin2DPowderDiffraction.h
@@ -403,9 +404,9 @@ set(INC_FILES
     inc/MantidAlgorithms/CopyInstrumentParameters.h
     inc/MantidAlgorithms/CopyLogs.h
     inc/MantidAlgorithms/CopySample.h
-    inc/MantidAlgorithms/CorelliCrossCorrelate.h
     inc/MantidAlgorithms/CorelliCalibrationApply.h
     inc/MantidAlgorithms/CorelliCalibrationDatabase.h
+    inc/MantidAlgorithms/CorelliCrossCorrelate.h
     inc/MantidAlgorithms/CorrectKiKf.h
     inc/MantidAlgorithms/CorrectTOFAxis.h
     inc/MantidAlgorithms/CorrectToFile.h
@@ -556,6 +557,7 @@ set(INC_FILES
     inc/MantidAlgorithms/PDDetermineCharacterizations.h
     inc/MantidAlgorithms/PDFFourierTransform.h
     inc/MantidAlgorithms/PDFFourierTransform2.h
+    inc/MantidAlgorithms/PaalmanPingsAbsorptionCorrection.h
     inc/MantidAlgorithms/PaddingAndApodization.h
     inc/MantidAlgorithms/ParallaxCorrection.h
     inc/MantidAlgorithms/Pause.h
@@ -683,7 +685,6 @@ if(UNITY_BUILD)
 endif(UNITY_BUILD)
 
 set(TEST_FILES
-    PaalmanPingsAbsorptionCorrectionTest.h
     AddAbsorptionWeightedPathLengthsTest.h
     AddLogDerivativeTest.h
     AddNoteTest.h
@@ -697,6 +698,7 @@ set(TEST_FILES
     ApplyCalibrationTest.h
     ApplyDetailedBalanceTest.h
     ApplyFloodWorkspaceTest.h
+    ApplyInstrumentToPeaksTest.h
     ApplyTransmissionCorrectionTest.h
     AverageLogDataTest.h
     Bin2DPowderDiffractionTest.h
@@ -755,9 +757,9 @@ set(TEST_FILES
     CopyInstrumentParametersTest.h
     CopyLogsTest.h
     CopySampleTest.h
-    CorelliCrossCorrelateTest.h
     CorelliCalibrationApplyTest.h
     CorelliCalibrationDatabaseTest.h
+    CorelliCrossCorrelateTest.h
     CorrectKiKfTest.h
     CorrectTOFAxisTest.h
     CorrectToFileTest.h
@@ -776,8 +778,8 @@ set(TEST_FILES
     CreateUserDefinedBackgroundTest.h
     CreateWorkspaceTest.h
     CropToComponentTest.h
-    CropWorkspaceTest.h
     CropWorkspaceRaggedTest.h
+    CropWorkspaceTest.h
     CrossCorrelateTest.h
     CuboidGaugeVolumeAbsorptionTest.h
     CylinderAbsorptionTest.h
@@ -900,6 +902,7 @@ set(TEST_FILES
     PDDetermineCharacterizationsTest.h
     PDFFourierTransform2Test.h
     PDFFourierTransformTest.h
+    PaalmanPingsAbsorptionCorrectionTest.h
     PaddingAndApodizationTest.h
     ParallaxCorrectionTest.h
     PauseTest.h

--- a/Framework/Algorithms/inc/MantidAlgorithms/ApplyInstrumentToPeaks.h
+++ b/Framework/Algorithms/inc/MantidAlgorithms/ApplyInstrumentToPeaks.h
@@ -1,0 +1,21 @@
+// Mantid Repository : https://github.com/mantidproject/mantid
+//
+// Copyright &copy; 2021 ISIS Rutherford Appleton Laboratory UKRI,
+//   NScD Oak Ridge National Laboratory, European Spallation Source,
+//   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+// SPDX - License - Identifier: GPL - 3.0 +
+#pragma once
+
+#include "MantidAlgorithms/DllConfig.h"
+
+namespace Mantid {
+namespace Algorithms {
+
+/** ApplyInstrumentToPeaks : TODO: DESCRIPTION
+ */
+class MANTID_ALGORITHMS_DLL ApplyInstrumentToPeaks {
+public:
+};
+
+} // namespace Algorithms
+} // namespace Mantid

--- a/Framework/Algorithms/inc/MantidAlgorithms/ApplyInstrumentToPeaks.h
+++ b/Framework/Algorithms/inc/MantidAlgorithms/ApplyInstrumentToPeaks.h
@@ -6,15 +6,26 @@
 // SPDX - License - Identifier: GPL - 3.0 +
 #pragma once
 
+#include "MantidAPI/Algorithm.h"
 #include "MantidAlgorithms/DllConfig.h"
-
 namespace Mantid {
 namespace Algorithms {
 
 /** ApplyInstrumentToPeaks : TODO: DESCRIPTION
  */
-class MANTID_ALGORITHMS_DLL ApplyInstrumentToPeaks {
+class MANTID_ALGORITHMS_DLL ApplyInstrumentToPeaks : public API::Algorithm {
 public:
+  const std::string name() const override { return "ApplyInstrumentToPeaks"; }
+  int version() const override { return 1; };
+  const std::vector<std::string> seeAlso() const override { return {}; }
+  const std::string category() const override { return "Crystal\\Peaks"; }
+  const std::string summary() const override {
+    return "Update the peaks within a PeaksWorkspace with a different instrument, keeping the same detectorID and TOF";
+  }
+
+private:
+  void init() override;
+  void exec() override;
 };
 
 } // namespace Algorithms

--- a/Framework/Algorithms/inc/MantidAlgorithms/ApplyInstrumentToPeaks.h
+++ b/Framework/Algorithms/inc/MantidAlgorithms/ApplyInstrumentToPeaks.h
@@ -16,11 +16,12 @@ namespace Algorithms {
 class MANTID_ALGORITHMS_DLL ApplyInstrumentToPeaks : public API::Algorithm {
 public:
   const std::string name() const override { return "ApplyInstrumentToPeaks"; }
-  int version() const override { return 1; };
+  int version() const override { return 1; }
   const std::vector<std::string> seeAlso() const override { return {}; }
   const std::string category() const override { return "Crystal\\Peaks"; }
   const std::string summary() const override {
-    return "Update the peaks within a PeaksWorkspace with a different instrument, keeping the same detectorID and TOF";
+    return "Update the instrument attached to peaks within a PeaksWorkspace to match the one provided or the one "
+           "attached to the input workspace while keeping detectorID and TOF unchanged";
   }
 
 private:

--- a/Framework/Algorithms/src/ApplyInstrumentToPeaks.cpp
+++ b/Framework/Algorithms/src/ApplyInstrumentToPeaks.cpp
@@ -1,0 +1,12 @@
+// Mantid Repository : https://github.com/mantidproject/mantid
+//
+// Copyright &copy; 2021 ISIS Rutherford Appleton Laboratory UKRI,
+//   NScD Oak Ridge National Laboratory, European Spallation Source,
+//   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+// SPDX - License - Identifier: GPL - 3.0 +
+
+#include "MantidAlgorithms/ApplyInstrumentToPeaks.h"
+
+namespace Mantid {
+namespace Algorithms {} // namespace Algorithms
+} // namespace Mantid

--- a/Framework/Algorithms/src/ApplyInstrumentToPeaks.cpp
+++ b/Framework/Algorithms/src/ApplyInstrumentToPeaks.cpp
@@ -6,7 +6,62 @@
 // SPDX - License - Identifier: GPL - 3.0 +
 
 #include "MantidAlgorithms/ApplyInstrumentToPeaks.h"
+#include "MantidDataObjects/PeaksWorkspace.h"
 
 namespace Mantid {
-namespace Algorithms {} // namespace Algorithms
+namespace Algorithms {
+
+DECLARE_ALGORITHM(ApplyInstrumentToPeaks)
+
+using namespace Mantid::Kernel;
+using namespace Mantid::API;
+using namespace Mantid::DataObjects;
+
+void ApplyInstrumentToPeaks::init() {
+  declareProperty(std::make_unique<WorkspaceProperty<PeaksWorkspace>>("InputWorkspace", "", Direction::Input),
+                  "Input peaks workspace.");
+  declareProperty(std::make_unique<WorkspaceProperty<Workspace>>("InstrumentWorkspace", "", Direction::Input,
+                                                                 PropertyMode::Optional),
+                  "Workspace from which the instrument will be copied from. If none is provided then the instrument on "
+                  "the input workspace is used.");
+  declareProperty(std::make_unique<WorkspaceProperty<PeaksWorkspace>>("OutputWorkspace", "", Direction::Output),
+                  "Output peaks workspace.");
+}
+
+void ApplyInstrumentToPeaks::exec() {
+  /// Peak workspace to integrate
+  PeaksWorkspace_sptr inputWS = getProperty("InputWorkspace");
+
+  /// Output peaks workspace, create if needed
+  PeaksWorkspace_sptr outputWS = getProperty("OutputWorkspace");
+  if (outputWS != inputWS)
+    outputWS = inputWS->clone();
+
+  Mantid::Geometry::Instrument_const_sptr instrument;
+
+  Workspace_sptr instWS = this->getProperty("InstrumentWorkspace");
+  if (instWS) {
+    ExperimentInfo_sptr ei = std::dynamic_pointer_cast<ExperimentInfo>(instWS);
+    if (!ei)
+      throw std::invalid_argument("Wrong type of workspace");
+    instrument = ei->getInstrument();
+    outputWS->setInstrument(instrument);
+  } else {
+    instrument = outputWS->getInstrument();
+  }
+
+  for (int i = 0; i < outputWS->getNumberPeaks(); ++i) {
+    Peak &peak = outputWS->getPeak(i);
+    const auto tof = peak.getTOF();
+    peak.setInstrument(instrument);
+    peak.setDetectorID(peak.getDetectorID());
+    const double energy = pow((peak.getL1() + peak.getL2()) / tof * 1e6, 2) * PhysicalConstants::NeutronMass / 2.0 /
+                          PhysicalConstants::meV;
+    peak.setInitialEnergy(energy);
+    peak.setFinalEnergy(energy);
+  }
+
+  setProperty("OutputWorkspace", outputWS);
+}
+} // namespace Algorithms
 } // namespace Mantid

--- a/Framework/Algorithms/src/ApplyInstrumentToPeaks.cpp
+++ b/Framework/Algorithms/src/ApplyInstrumentToPeaks.cpp
@@ -50,13 +50,17 @@ void ApplyInstrumentToPeaks::exec() {
     instrument = outputWS->getInstrument();
   }
 
+  Units::Energy energyUnit;
   for (int i = 0; i < outputWS->getNumberPeaks(); ++i) {
     Peak &peak = outputWS->getPeak(i);
+
     const auto tof = peak.getTOF();
+
     peak.setInstrument(instrument);
     peak.setDetectorID(peak.getDetectorID());
-    const double energy = pow((peak.getL1() + peak.getL2()) / tof * 1e6, 2) * PhysicalConstants::NeutronMass / 2.0 /
-                          PhysicalConstants::meV;
+
+    energyUnit.initialize(peak.getL1(), 0, {{UnitParams::l2, peak.getL2()}});
+    const double energy = energyUnit.singleFromTOF(tof);
     peak.setInitialEnergy(energy);
     peak.setFinalEnergy(energy);
   }

--- a/Framework/Algorithms/test/ApplyInstrumentToPeaksTest.h
+++ b/Framework/Algorithms/test/ApplyInstrumentToPeaksTest.h
@@ -1,0 +1,42 @@
+// Mantid Repository : https://github.com/mantidproject/mantid
+//
+// Copyright &copy; 2021 ISIS Rutherford Appleton Laboratory UKRI,
+//   NScD Oak Ridge National Laboratory, European Spallation Source,
+//   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+// SPDX - License - Identifier: GPL - 3.0 +
+#pragma once
+
+#include <cxxtest/TestSuite.h>
+
+#include "MantidAlgorithms/ApplyInstrumentToPeaks.h"
+#include "MantidTestHelpers/WorkspaceCreationHelper.h"
+
+using namespace Mantid;
+using namespace Mantid::API;
+using namespace Mantid::DataHandling;
+using namespace Mantid::DataObjects;
+using namespace Mantid::Geometry;
+
+using Mantid::Algorithms::ApplyInstrumentToPeaks;
+
+class ApplyInstrumentToPeaksTest : public CxxTest::TestSuite {
+public:
+  // This pair of boilerplate methods prevent the suite being created statically
+  // This means the constructor isn't called when running other tests
+  static ApplyInstrumentToPeaksTest *createSuite() { return new ApplyInstrumentToPeaksTest(); }
+  static void destroySuite(ApplyInstrumentToPeaksTest *suite) { delete suite; }
+
+  void test_Something() {
+    auto ws = prepareWorkspace();
+
+    TS_FAIL("You forgot to write a test!");
+  }
+
+private:
+  // Create workspace
+  MatrixWorkspace_sptr prepareWorkspace() {
+    const int nvectors(2), nbins(10);
+    MatrixWorkspace_sptr inputWS = WorkspaceCreationHelper::create2DWorkspaceWithFullInstrument(nvectors, nbins);
+    return inputWS;
+  }
+};

--- a/Framework/Algorithms/test/ApplyInstrumentToPeaksTest.h
+++ b/Framework/Algorithms/test/ApplyInstrumentToPeaksTest.h
@@ -8,7 +8,10 @@
 
 #include <cxxtest/TestSuite.h>
 
+#include "MantidAPI/AlgorithmManager.h"
 #include "MantidAlgorithms/ApplyInstrumentToPeaks.h"
+#include "MantidDataObjects/PeaksWorkspace.h"
+#include "MantidTestHelpers/ComponentCreationHelper.h"
 #include "MantidTestHelpers/WorkspaceCreationHelper.h"
 
 using namespace Mantid;
@@ -26,17 +29,136 @@ public:
   static ApplyInstrumentToPeaksTest *createSuite() { return new ApplyInstrumentToPeaksTest(); }
   static void destroySuite(ApplyInstrumentToPeaksTest *suite) { delete suite; }
 
-  void test_Something() {
-    auto ws = prepareWorkspace();
+  void test_ApplyInstrumentToPeaks() {
 
-    TS_FAIL("You forgot to write a test!");
+    // create input workspace
+    const auto inputWS = prepareWorkspace(1., 1000.);
+
+    // now set a different instrument on the peaks workspace, double the distance of everything
+    const auto new_inst = prepareInstrument(2.);
+    inputWS->setInstrument(new_inst);
+
+    std::string outWSName("ApplyInstrumenttoPeaksTestWS");
+
+    ApplyInstrumentToPeaks alg;
+    TS_ASSERT_THROWS_NOTHING(alg.initialize())
+    TS_ASSERT(alg.isInitialized())
+    TS_ASSERT_THROWS_NOTHING(alg.setProperty("InputWorkspace", inputWS));
+    TS_ASSERT_THROWS_NOTHING(alg.setPropertyValue("OutputWorkspace", outWSName));
+    TS_ASSERT_THROWS_NOTHING(alg.execute();)
+    TS_ASSERT(alg.isExecuted());
+
+    PeaksWorkspace_sptr outWS = AnalysisDataService::Instance().retrieveWS<PeaksWorkspace>(outWSName);
+
+    TS_ASSERT_EQUALS(outWS->getNumberPeaks(), 3);
+
+    PeaksWorkspace_sptr expectedOutWS = prepareWorkspace(2., 1000.);
+
+    for (int n = 0; n < outWS->getNumberPeaks(); n++) {
+      const auto p0 = inputWS->getPeak(n);
+      const auto p = outWS->getPeak(n);
+      const auto p2 = expectedOutWS->getPeak(n);
+
+      TS_ASSERT_EQUALS(p.getDetectorID(), p2.getDetectorID());
+      TS_ASSERT_EQUALS(p.getDetectorID(), p0.getDetectorID());
+
+      TS_ASSERT_EQUALS(p.getTOF(), p2.getTOF());
+      TS_ASSERT_EQUALS(p.getTOF(), p0.getTOF());
+
+      TS_ASSERT_DELTA(p.getWavelength(), p2.getWavelength(), 1e-12);
+      TS_ASSERT_DELTA(p.getWavelength(), p0.getWavelength() / 2., 1e-12);
+
+      const auto q = p.getQSampleFrame();
+
+      const auto q2 = p2.getQSampleFrame();
+      TS_ASSERT_DELTA(q.X(), q2.X(), 1e-12);
+      TS_ASSERT_DELTA(q.Y(), q2.Y(), 1e-12);
+      TS_ASSERT_DELTA(q.Z(), q2.Z(), 1e-12);
+
+      const auto q0 = p0.getQSampleFrame();
+      TS_ASSERT_DELTA(q.X(), q0.X() * 2, 1e-12);
+      TS_ASSERT_DELTA(q.Y(), q0.Y() * 2, 1e-12);
+      TS_ASSERT_DELTA(q.Z(), q0.Z() * 2, 1e-12);
+    }
+  }
+
+  void test_ApplyInstrumentToPeaks_InstrumentWorkspace() {
+
+    // create input workspace
+    const auto inputWS = prepareWorkspace(1., 1000.);
+
+    // now set a different instrument on the peaks workspace, double the distance of everything
+    const auto new_inst = prepareInstrument(2.);
+    inputWS->setInstrument(new_inst);
+
+    PeaksWorkspace_sptr expectedOutWS = prepareWorkspace(2., 1000.);
+
+    std::string outWSName("ApplyInstrumenttoPeaksTestWS");
+
+    ApplyInstrumentToPeaks alg;
+    TS_ASSERT_THROWS_NOTHING(alg.initialize())
+    TS_ASSERT(alg.isInitialized())
+    TS_ASSERT_THROWS_NOTHING(alg.setProperty("InputWorkspace", inputWS));
+    TS_ASSERT_THROWS_NOTHING(alg.setProperty("InstrumentWorkspace", expectedOutWS));
+    TS_ASSERT_THROWS_NOTHING(alg.setPropertyValue("OutputWorkspace", outWSName));
+    TS_ASSERT_THROWS_NOTHING(alg.execute();)
+    TS_ASSERT(alg.isExecuted());
+
+    PeaksWorkspace_sptr outWS = AnalysisDataService::Instance().retrieveWS<PeaksWorkspace>(outWSName);
+
+    TS_ASSERT_EQUALS(outWS->getNumberPeaks(), 3);
+
+    for (int n = 0; n < outWS->getNumberPeaks(); n++) {
+      const auto p0 = inputWS->getPeak(n);
+      const auto p = outWS->getPeak(n);
+      const auto p2 = expectedOutWS->getPeak(n);
+
+      TS_ASSERT_EQUALS(p.getDetectorID(), p2.getDetectorID());
+      TS_ASSERT_EQUALS(p.getDetectorID(), p0.getDetectorID());
+
+      TS_ASSERT_EQUALS(p.getTOF(), p2.getTOF());
+      TS_ASSERT_EQUALS(p.getTOF(), p0.getTOF());
+
+      TS_ASSERT_DELTA(p.getWavelength(), p2.getWavelength(), 1e-12);
+      TS_ASSERT_DELTA(p.getWavelength(), p0.getWavelength() / 2., 1e-12);
+
+      const auto q = p.getQSampleFrame();
+
+      const auto q2 = p2.getQSampleFrame();
+      TS_ASSERT_DELTA(q.X(), q2.X(), 1e-12);
+      TS_ASSERT_DELTA(q.Y(), q2.Y(), 1e-12);
+      TS_ASSERT_DELTA(q.Z(), q2.Z(), 1e-12);
+
+      const auto q0 = p0.getQSampleFrame();
+      TS_ASSERT_DELTA(q.X(), q0.X() * 2, 1e-12);
+      TS_ASSERT_DELTA(q.Y(), q0.Y() * 2, 1e-12);
+      TS_ASSERT_DELTA(q.Z(), q0.Z() * 2, 1e-12);
+    }
   }
 
 private:
+  // Create instrument
+  Instrument_const_sptr prepareInstrument(const double &L) {
+    // create starting instrument
+    // moderator is set to z=-L
+    std::vector<double> L2{L, L, L};
+    std::vector<double> polar{M_PI_2, M_PI_2, M_PI_4};
+    std::vector<double> azimuthal{0., M_PI_2, M_PI_4};
+    const auto inst = ComponentCreationHelper::createCylInstrumentWithDetInGivenPositions(L2, polar, azimuthal);
+    return inst;
+  }
+
   // Create workspace
-  MatrixWorkspace_sptr prepareWorkspace() {
-    const int nvectors(2), nbins(10);
-    MatrixWorkspace_sptr inputWS = WorkspaceCreationHelper::create2DWorkspaceWithFullInstrument(nvectors, nbins);
-    return inputWS;
+  PeaksWorkspace_sptr prepareWorkspace(const double &L, const double &tof) {
+
+    PeaksWorkspace_sptr ws = std::dynamic_pointer_cast<PeaksWorkspace>(WorkspaceFactory::Instance().createPeaks());
+    const auto inst = prepareInstrument(L);
+    ws->setInstrument(inst);
+
+    const double wl = PhysicalConstants::h / (PhysicalConstants::NeutronMass * (2 * L * 1e6 / tof)) * 1e10;
+    ws->addPeak(Peak(inst, 1, wl));
+    ws->addPeak(Peak(inst, 2, wl));
+    ws->addPeak(Peak(inst, 3, wl));
+    return ws;
   }
 };

--- a/Framework/Algorithms/test/ApplyInstrumentToPeaksTest.h
+++ b/Framework/Algorithms/test/ApplyInstrumentToPeaksTest.h
@@ -62,8 +62,8 @@ public:
       TS_ASSERT_EQUALS(p.getDetectorID(), p2.getDetectorID());
       TS_ASSERT_EQUALS(p.getDetectorID(), p0.getDetectorID());
 
-      TS_ASSERT_EQUALS(p.getTOF(), p2.getTOF());
-      TS_ASSERT_EQUALS(p.getTOF(), p0.getTOF());
+      TS_ASSERT_DELTA(p.getTOF(), p2.getTOF(), 1e-12);
+      TS_ASSERT_DELTA(p.getTOF(), p0.getTOF(), 1e-12);
 
       TS_ASSERT_DELTA(p.getWavelength(), p2.getWavelength(), 1e-12);
       TS_ASSERT_DELTA(p.getWavelength(), p0.getWavelength() / 2., 1e-12);
@@ -116,8 +116,8 @@ public:
       TS_ASSERT_EQUALS(p.getDetectorID(), p2.getDetectorID());
       TS_ASSERT_EQUALS(p.getDetectorID(), p0.getDetectorID());
 
-      TS_ASSERT_EQUALS(p.getTOF(), p2.getTOF());
-      TS_ASSERT_EQUALS(p.getTOF(), p0.getTOF());
+      TS_ASSERT_DELTA(p.getTOF(), p2.getTOF(), 1e-12);
+      TS_ASSERT_DELTA(p.getTOF(), p0.getTOF(), 1e-12);
 
       TS_ASSERT_DELTA(p.getWavelength(), p2.getWavelength(), 1e-12);
       TS_ASSERT_DELTA(p.getWavelength(), p0.getWavelength() / 2., 1e-12);

--- a/docs/source/algorithms/ApplyInstrumentToPeaks-v1.rst
+++ b/docs/source/algorithms/ApplyInstrumentToPeaks-v1.rst
@@ -1,0 +1,96 @@
+.. algorithm::
+
+.. summary::
+
+.. relatedalgorithms::
+
+.. properties::
+
+Description
+-----------
+
+ApplyInstrumentToPeaks will update the instrument contained within
+peaks of a :ref:`PeaksWorkspace <PeaksWorkspace>`. It will keep the
+same detector ID and TOF but recalculate the detector positions and
+therefore the Q-vectors.
+
+The issue this is trying to address is that the instrument in the
+PeaksWorkspace can be different to the instrument within the peaks and
+when the instrument of the PeaksWorkspace is modified (by
+:ref:`MoveInstrumentComponent <algm-MoveInstrumentComponent>`,
+:ref:`RotateInstrumentComponent <algm-RotateInstrumentComponent>`,
+:ref:`LoadIsawDetCal <algm-LoadIsawDetCal>`, *etc*) then instrument in
+the peaks is not updated.
+
+If a workspace is provided to the ``InstrumentWorkspace`` property
+then the instrument from that workspace will be used, otherwise the
+instrument in the ``InputWorkspace`` will be used.
+
+Usage
+-----
+
+**Example**
+
+First create a peaks workspace with 3 peaks with ``L1 == L2 == 1``
+
+.. testcode:: example
+
+   ws = CreateSampleWorkspace(NumBanks=3, BankPixelWidth=1)
+   MoveInstrumentComponent(ws, ComponentName='moderator', RelativePosition=False, X=0, Y=0, Z=-1)
+   MoveInstrumentComponent(ws, ComponentName='bank1', RelativePosition=False, X=1, Y=0, Z=0) # θ=90, ϕ=0
+   MoveInstrumentComponent(ws, ComponentName='bank2', RelativePosition=False, X=0, Y=1, Z=0) # θ=90, ϕ=90
+   MoveInstrumentComponent(ws, ComponentName='bank3', RelativePosition=False, X=0.5, Y=0.5, Z=np.sqrt(2)/2) # θ=45, ϕ=45
+   peaks = CreatePeaksWorkspace(ws, NumberOfPeaks=0)
+
+   AddPeak(peaks, ws, TOF=10000, DetectorID=1) # θ=90, ϕ=0
+   AddPeak(peaks, ws, TOF=5000, DetectorID=2) # θ=90, ϕ=90
+   AddPeak(peaks, ws, TOF=1234, DetectorID=3) # θ=45, ϕ=45
+
+   for n in range(peaks.getNumberPeaks()):
+       print("DetID={DetID} TOF={TOF:.1f}μs λ={Wavelength:.4f}Å Qsample={QSample}".format(**peaks.row(n)))
+
+.. testoutput:: example
+
+   DetID=1 TOF=10000.0μs λ=19.7802Å Qsample=[-0.317651,0,0.317651]
+   DetID=2 TOF=5000.0μs λ=9.8901Å Qsample=[0,-0.635301,0.635301]
+   DetID=3 TOF=1234.0μs λ=2.4409Å Qsample=[-1.28708,-1.28708,0.753953]
+
+Now move source and detectors so ``L1 == L2 == 2``.  When you look at
+the peaks nothing has been updated.
+
+.. testcode:: example
+
+   MoveInstrumentComponent(peaks, ComponentName='moderator', RelativePosition=False, X=0, Y=0, Z=-2)
+   MoveInstrumentComponent(peaks, ComponentName='bank1', RelativePosition=False, X=2, Y=0, Z=0)
+   MoveInstrumentComponent(peaks, ComponentName='bank2', RelativePosition=False, X=0, Y=2, Z=0)
+   MoveInstrumentComponent(peaks, ComponentName='bank3', RelativePosition=False, X=1, Y=1, Z=np.sqrt(2))
+
+   for n in range(peaks.getNumberPeaks()):
+       print("DetID={DetID} TOF={TOF:.1f}μs λ={Wavelength:.4f}Å Qsample={QSample}".format(**peaks.row(n)))
+
+.. testoutput:: example
+
+   DetID=1 TOF=10000.0μs λ=19.7802Å Qsample=[-0.317651,0,0.317651]
+   DetID=2 TOF=5000.0μs λ=9.8901Å Qsample=[0,-0.635301,0.635301]
+   DetID=3 TOF=1234.0μs λ=2.4409Å Qsample=[-1.28708,-1.28708,0.753953]
+
+So we apply this algorithm and the peaks are updated, the wavelength
+is halved and the q-vector doubled as expected while keeping the same
+detector ID and TOF.
+
+.. testcode:: example
+
+   peaks = ApplyInstrumentToPeaks(peaks)
+
+   for n in range(peaks.getNumberPeaks()):
+       print("DetID={DetID} TOF={TOF:.1f}μs λ={Wavelength:.4f}Å Qsample={QSample}".format(**peaks.row(n)))
+
+.. testoutput:: example
+
+   DetID=1 TOF=10000.0μs λ=9.8901Å Qsample=[-0.635301,0,0.635301]
+   DetID=2 TOF=5000.0μs λ=4.9450Å Qsample=[0,-1.2706,1.2706]
+   DetID=3 TOF=1234.0μs λ=1.2204Å Qsample=[-2.57415,-2.57415,1.50791]
+
+.. categories::
+
+.. sourcelink::

--- a/docs/source/release/v6.2.0/diffraction.rst
+++ b/docs/source/release/v6.2.0/diffraction.rst
@@ -26,6 +26,7 @@ Engineering Diffraction
 Single Crystal Diffraction
 --------------------------
 - New algorithm :ref:`HB3AIntegrateDetectorPeaks <algm-HB3AIntegrateDetectorPeaks>` for integrating four-circle data from HB3A in detector space.
+- New algorithm :ref:`ApplyInstrumentToPeaks <algm-ApplyInstrumentToPeaks>` to update the instrument of peaks within a PeaksWorkspace.
 
 
 :ref:`Release 6.2.0 <v6.2.0>`


### PR DESCRIPTION
**Description of work.**

New algorithm to update the peaks within a PeaksWorkspace with a different instrument, keeping the same detectorID and TOF. [SCD319](https://code.ornl.gov/sns-hfir-scse/diffraction/single-crystal/single-crystal-diffraction/-/issues/319)


**To test:**

Look at the usage example or try

```python
ws=LoadIsawPeaks("TOPAZ_3007.peaks")

# this will affect only the first peak in ws
MoveInstrumentComponent(ws, ComponentName='bank17', Y=1)

ws=ApplyInstrumentToPeaks(ws)
```

And see that the wavelength and q-vectors have changed for the first peak.

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
