### PR TITLE
Fix gap in validation on the Energy unit

### DIFF
--- a/Framework/Algorithms/src/GetAllEi.cpp
+++ b/Framework/Algorithms/src/GetAllEi.cpp
@@ -244,7 +244,7 @@ void GetAllEi::exec() {
         "Can not find any chopper opening time within TOF range: " + boost::lexical_cast<std::string>(TOF_range.first) +
         ':' + boost::lexical_cast<std::string>(TOF_range.second));
   } else {
-    destUnit->initialize(mon1Distance, static_cast<int>(Kernel::DeltaEMode::Elastic), {});
+    destUnit->initialize(mon1Distance, static_cast<int>(Kernel::DeltaEMode::Elastic), {{Kernel::UnitParams::l2, 0.}});
     printDebugModeInfo(guess_opening, TOF_range, destUnit);
   }
   std::pair<double, double> Mon1_Erange = monitorWS->getSpectrum(0).getXDataRange();
@@ -257,7 +257,7 @@ void GetAllEi::exec() {
   // convert to energy
   std::vector<double> guess_ei;
   guess_ei.reserve(guess_opening.size());
-  destUnit->initialize(mon1Distance, static_cast<int>(Kernel::DeltaEMode::Elastic), {});
+  destUnit->initialize(mon1Distance, static_cast<int>(Kernel::DeltaEMode::Elastic), {{Kernel::UnitParams::l2, 0.}});
   for (double time : guess_opening) {
     double eGuess = destUnit->singleFromTOF(time);
     if (eGuess > eMin && eGuess < eMax) {

--- a/Framework/Kernel/inc/MantidKernel/Unit.h
+++ b/Framework/Kernel/inc/MantidKernel/Unit.h
@@ -346,6 +346,7 @@ public:
   Energy();
 
 protected:
+  void validateUnitParams(const int emode, const UnitParametersMap &params) override;
   double factorTo;   ///< Constant factor for to conversion
   double factorFrom; ///< Constant factor for from conversion
 };

--- a/Framework/Kernel/src/Unit.cpp
+++ b/Framework/Kernel/src/Unit.cpp
@@ -439,6 +439,14 @@ Energy::Energy() : Unit(), factorTo(DBL_MIN), factorFrom(DBL_MIN) {
   addConversion("Momentum", 2 * M_PI / factor, 0.5);
 }
 
+void Energy::validateUnitParams(const int, const UnitParametersMap &params) {
+  if (!ParamPresent(params, UnitParams::l2)) {
+    throw std::runtime_error("An l2 value must be supplied in the extra "
+                             "parameters when initialising " +
+                             this->unitID() + " for conversion via TOF");
+  }
+}
+
 void Energy::init() {
   double l2 = 0.0;
   ParamPresentAndSet(m_params, UnitParams::l2, l2);

--- a/Framework/Kernel/test/UnitTest.h
+++ b/Framework/Kernel/test/UnitTest.h
@@ -391,6 +391,11 @@ public:
     }
   }
 
+  void testWavelength_WithoutParams() {
+    std::vector<double> x(1, 2.0), y(1, 1.0);
+    TS_ASSERT_THROWS(lambda.fromTOF(x, y, 1.0, 1, {}), const std::runtime_error &)
+  }
+
   //----------------------------------------------------------------------
   // Energy tests
   //----------------------------------------------------------------------
@@ -460,6 +465,11 @@ public:
     }
   }
 
+  void testEnergy_WithoutParams() {
+    std::vector<double> x(1, 4.0), y(1, 1.0);
+    TS_ASSERT_THROWS(energy.fromTOF(x, y, 1.0, 1, {}), const std::runtime_error &)
+  }
+
   //----------------------------------------------------------------------
   // Energy_inWavenumber tests
   //----------------------------------------------------------------------
@@ -513,6 +523,11 @@ public:
     energyk.toTOF(x2, x2, 99.0, 99, {{UnitParams::l2, 99.0}});
     lambda.fromTOF(x2, x2, 99.0, 99, {{UnitParams::l2, 99.0}, {UnitParams::efixed, 99.0}});
     TS_ASSERT_DELTA(x2[0], result, 1.0e-15)
+  }
+
+  void testEnergy_inWavenumber_WithoutParams() {
+    std::vector<double> x(1, 2.0), y(1, 1.0);
+    TS_ASSERT_THROWS(energyk.fromTOF(x, y, 1.0, 1, {}), const std::runtime_error &)
   }
 
   //----------------------------------------------------------------------
@@ -583,6 +598,11 @@ public:
         d.fromTOF(x, y, 1.0, 1, {{UnitParams::difc, 3.0}, {UnitParams::difa, -2.0}, {UnitParams::tzero, 1.0}}))
     TS_ASSERT_DELTA(x[0], 1.5, 0.0001)
     TS_ASSERT(yy == y)
+  }
+
+  void testdSpacing_WithoutParams() {
+    std::vector<double> x(1, 2.0), y(1, 1.0);
+    TS_ASSERT_THROWS(d.fromTOF(x, y, 1.0, 1, {}), const std::runtime_error &)
   }
 
   void testdSpacing_quickConversions() {
@@ -727,6 +747,11 @@ public:
     }
   }
 
+  void testdSpacingPerpendicular_WithoutParams() {
+    std::vector<double> x(1, 2.0), y(1, 1.0);
+    TS_ASSERT_THROWS(dp.fromTOF(x, y, 1.0, 1, {}), const std::runtime_error &)
+  }
+
   //----------------------------------------------------------------------
   // Momentum Transfer tests
   //----------------------------------------------------------------------
@@ -804,6 +829,12 @@ public:
                          rezult[i] / sample[i], 1., 10 * FLT_EPSILON);
       }
     }
+  }
+
+  void testMomentumTransfer_WithoutParams() {
+    std::vector<double> x(1, 2.0), y(1, 1.0);
+    TS_ASSERT_THROWS(q.fromTOF(x, y, 1.0, 1, {}), const std::runtime_error &)
+    TS_ASSERT_THROWS(q.fromTOF(x, y, 1.0, 1, {{UnitParams::l2, 1.0}}), const std::runtime_error &)
   }
 
   //----------------------------------------------------------------------
@@ -889,6 +920,12 @@ public:
     }
   }
 
+  void testQ2_WithoutParams() {
+    std::vector<double> x(1, 2.0), y(1, 1.0);
+    TS_ASSERT_THROWS(q2.fromTOF(x, y, 1.0, 1, {}), const std::runtime_error &)
+    TS_ASSERT_THROWS(q2.fromTOF(x, y, 1.0, 1, {{UnitParams::l2, 1.0}}), const std::runtime_error &)
+  }
+
   //----------------------------------------------------------------------
   // Energy transfer tests
   //----------------------------------------------------------------------
@@ -970,6 +1007,14 @@ public:
                      10 * FLT_EPSILON);
     TSM_ASSERT_DELTA("Indirect energy transfer limits Failed for conversion e_max: ", sample[3], rezult[3],
                      10 * FLT_EPSILON);
+  }
+
+  void testDeltaE_WithoutParams() {
+    std::vector<double> x(1, 2.0), y(1, 1.0);
+    TS_ASSERT_THROWS(dE.fromTOF(x, y, 1.0, 1, {}), const std::invalid_argument &)
+    TS_ASSERT_THROWS(dE.fromTOF(x, y, 1.0, 2, {}), const std::runtime_error &)
+    TS_ASSERT_THROWS(dE.fromTOF(x, y, 1.0, 2, {{UnitParams::l2, 1.0}}), const std::runtime_error &)
+    TS_ASSERT_THROWS(dE.fromTOF(x, y, 1.0, 1, {{UnitParams::efixed, -1.0}}), const std::runtime_error &)
   }
 
   //----------------------------------------------------------------------
@@ -1254,6 +1299,12 @@ public:
                          rezult[i] / sample[i], 1., 10 * FLT_EPSILON);
       }
     }
+  }
+
+  void testK_WithoutParams() {
+    std::vector<double> x(1, 2.0), y(1, 1.0);
+    TS_ASSERT_THROWS(k_i.fromTOF(x, y, 1.0, 0, {}), const std::runtime_error &)
+    TS_ASSERT_THROWS(k_i.fromTOF(x, y, 1.0, 1, {{UnitParams::l2, 1.0}}), const std::runtime_error &)
   }
 
   //----------------------------------------------------------------------


### PR DESCRIPTION
**Description of work.**

A gap in the validation logic for the Energy unit was causing a crash in one of the MARI scripts. The cause was a spectrum without any detectors that couldn't undergo a unit conversion to Energy due to the absence of an L2 value. This was not being masked in a call to ConvertUnits and a later part of the MARI script wasn't handling this situation properly.

Also tighten up unit tests on the validations applied on various units

GetAllEi wasn't supplying an L2 value when doing an energy unit conversion because it stuffs L_tot into the L1 field. Have supplied an L2 value of 0 here to avoid the new validation logic on the Energy unit

**To test:**

Run script on linked issue. I also needed this file in order for the script to complete:

[mari_res2013.zip](https://github.com/mantidproject/mantid/files/6506925/mari_res2013.zip)


Fixes #31501

*This does not require release notes* because **the bug was introduced in this release cycle in PR #30163 **

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
