### PR TITLE
Move to newer pre-commit clang-format hook (ornl-next)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,7 +19,7 @@ repos:
         args: [--allow-multiple-documents]
 
   - repo: https://github.com/mantidproject/pre-commit-hooks.git
-    rev: 05b2d4cfe17dcb36e29c249705364c19eeccced5
+    rev: 8809bbab4c8b9609f559e2428e6255e9407c3efe
     hooks:
       - id: clang-format
         exclude: Testing/Tools/cxxtest|tools


### PR DESCRIPTION
This is the version of #31523 into `ornl-next`.