### PR TITLE
Increase allowed bounds for range markers in IDA

### DIFF
--- a/docs/source/release/v6.1.0/indirect_geometry.rst
+++ b/docs/source/release/v6.1.0/indirect_geometry.rst
@@ -29,5 +29,6 @@ Bug Fixes
 - Fixed a bug that caused an error warning when adding EISF data to F(q) fit if Width has already been added.
 - Fixed a bug that caused the spectra list in F(q) fit to be blank when reopening the add workspace dialog.
 - Fixed a bug that erased previous fits in the Indirect Data Analysis fit tabs when changing to the full function view.
+- Fixed a bug that prevented fit ranges in Indirect Data Analysis from being negative.
 
 :ref:`Release 6.1.0 <v6.1.0>`

--- a/qt/scientific_interfaces/Indirect/IndirectDataAnalysisElwinTab.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectDataAnalysisElwinTab.cpp
@@ -132,11 +132,13 @@ void IndirectDataAnalysisElwinTab::setup() {
   // We always want one range selector... the second one can be controlled from
   // within the elwinTwoRanges(bool state) function
   auto integrationRangeSelector = m_uiForm.ppPlot->addRangeSelector("ElwinIntegrationRange");
+  integrationRangeSelector->setBounds(-1.0, 1.0);
   connect(integrationRangeSelector, SIGNAL(minValueChanged(double)), this, SLOT(minChanged(double)));
   connect(integrationRangeSelector, SIGNAL(maxValueChanged(double)), this, SLOT(maxChanged(double)));
   // create the second range
   auto backgroundRangeSelector = m_uiForm.ppPlot->addRangeSelector("ElwinBackgroundRange");
   backgroundRangeSelector->setColour(Qt::darkGreen); // dark green for background
+  backgroundRangeSelector->setBounds(-1.0, 1.0);
   connect(integrationRangeSelector, SIGNAL(selectionChanged(double, double)), backgroundRangeSelector,
           SLOT(setRange(double, double)));
   connect(backgroundRangeSelector, SIGNAL(minValueChanged(double)), this, SLOT(minChanged(double)));

--- a/qt/scientific_interfaces/Indirect/IndirectDataAnalysisIqtTab.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectDataAnalysisIqtTab.cpp
@@ -190,6 +190,7 @@ void IndirectDataAnalysisIqtTab::setup() {
   setPreviewSpectrumMaximum(0);
 
   auto xRangeSelector = m_uiForm.ppPlot->addRangeSelector("IqtRange");
+  xRangeSelector->setBounds(-1.0, 1.0);
 
   // signals / slots & validators
   connect(xRangeSelector, SIGNAL(selectionChanged(double, double)), this, SLOT(rangeChanged(double, double)));

--- a/qt/scientific_interfaces/Indirect/IndirectFitPlotView.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectFitPlotView.cpp
@@ -289,6 +289,7 @@ void IndirectFitPlotView::setHWHMMinimum(double maximum) {
 
 void IndirectFitPlotView::addFitRangeSelector() {
   auto fitRangeSelector = m_topPlot->addRangeSelector("FitRange");
+  fitRangeSelector->setBounds(-1.0, 1.0);
 
   connect(fitRangeSelector, SIGNAL(minValueChanged(double)), this, SIGNAL(startXChanged(double)));
   connect(fitRangeSelector, SIGNAL(maxValueChanged(double)), this, SIGNAL(endXChanged(double)));
@@ -315,6 +316,7 @@ void IndirectFitPlotView::setBackgroundBounds() {
 
 void IndirectFitPlotView::addHWHMRangeSelector() {
   auto hwhmRangeSelector = m_topPlot->addRangeSelector("HWHM");
+  hwhmRangeSelector->setBounds(-1.0, 1.0);
   hwhmRangeSelector->setColour(Qt::red);
   hwhmRangeSelector->setRange(0.0, 0.0);
   hwhmRangeSelector->setVisible(false);


### PR DESCRIPTION
This PR expands the bounds of the range markers in the indirect data analysis tabs so they can be negative.

**To test:**

In the Indirect Data Analysis Elwin and I(Q,t) check that the range selecters can be made negative.

*There is no associated issue.*

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
