### PR TITLE
Hard crash in InstrumentViewer while 'extracting the mask'

### DIFF
--- a/qt/widgets/instrumentview/src/InstrumentActor.cpp
+++ b/qt/widgets/instrumentview/src/InstrumentActor.cpp
@@ -1058,8 +1058,7 @@ void InstrumentActor::setDataIntegrationRange(const double &xmin,
       // Ignore monitors if they are masked on the view
       if (spectrumDefinition.size() == 1 &&
           (std::find(monitorIndices.begin(), monitorIndices.end(), i) !=
-               monitorIndices.end() ||
-           maskWksp->isMasked(static_cast<int>(i))))
+               monitorIndices.end() || (maskWksp && maskWksp->isMasked(static_cast<int>(i)))))
         continue;
 
       auto sum = m_specIntegrs[i];

--- a/qt/widgets/instrumentview/src/InstrumentActor.cpp
+++ b/qt/widgets/instrumentview/src/InstrumentActor.cpp
@@ -800,7 +800,8 @@ void InstrumentActor::initMaskHelper() const {
   } catch (...) {
     // don't know what to do here yet ...
     QMessageBox::warning(nullptr, "Mantid - Warning",
-                         "An error occurred when extracting the mask.", "OK");
+                         "An error occurred when extracting the mask. "
+                         "Instrument Viewer is not supported yet for workspaces containing a detector scan.", "OK");
   }
 }
 


### PR DESCRIPTION
This PR fixes the hard crash found when trying to interact with InstrumentViewer on a `ScanningWorkspace`, that does is not supported. This issue is  caused by non-existing mask workspace. This small fix leads to expected flow resulting in a warning message for the user, explaining (in a way) that this workspace type is not supported: 
```
Could not show instrument for workspace 'workspace_id':
DetectorInfo accessed without time index but the beamline has time-dependent (moving) detectors.
```

While an exception related to this mask workspace being a `nullptr` is caught in L802 of InstrumentActor.cpp, the issue then propagates until there was an attempt to call a `isMasked` method on a `nullptr` workspace resulting in a segmentation violation. A warning dialog is displayed to the user with a message that might not be something they expect. I propose to add a line to this message that attempts to explain the situation more: 'This workspace may not be supported by the InstrumentView', but please provide your suggestions.

**To test:**

1. Load any D2B data from either UnitTest or SystemTest directory, e.g. SystemTest/ILL/D2B/532009.nxs
2. Show instrument.

There should be no hard crash and a warning dialog should be displayed and after that the lines shown above describing that this workspace cannot be displayed.

Fixes #31521 . 

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or master)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
