### PR TITLE
SANS Plotting - Force axis to linear

### DIFF
--- a/Framework/PythonInterface/mantid/plots/plotfunctions.py
+++ b/Framework/PythonInterface/mantid/plots/plotfunctions.py
@@ -128,7 +128,7 @@ def plot(workspaces, spectrum_nums=None, wksp_indices=None, errors=False,
     will be done on the axis passed in
     :param fig: If not None then use this Figure object to plot
     :param plot_kwargs: Arguments that will be passed onto the plot function
-    :param ax_properties: A dict of axes properties. E.g. {'yscale': 'log'}
+    :param ax_properties: A dict of axes properties. E.g. {'yscale': 'log', 'xscale': 'linear'}
     :param window_title: A string denoting name of the GUI window which holds the graph
     :param tiled: An optional flag controlling whether to do a tiled or overlayed plot
     :param waterfall: An optional flag controlling whether or not to do a waterfall plot

--- a/scripts/SANS/sans/algorithm_detail/batch_execution.py
+++ b/scripts/SANS/sans/algorithm_detail/batch_execution.py
@@ -253,18 +253,20 @@ def plot_workspace_mantidqt(reduction_package, output_graph, plotting_module):
 
     plot_kwargs = {"scalex": True,
                    "scaley": True}
+    ax_options = {"xscale": "linear", "yscale": "linear"}
+
     if reduction_package.reduction_mode == ReductionMode.ALL:
         plot([reduction_package.reduced_hab, reduction_package.reduced_lab],
-             wksp_indices=[0], overplot=True, fig=output_graph, plot_kwargs=plot_kwargs)
+             wksp_indices=[0], overplot=True, fig=output_graph, plot_kwargs=plot_kwargs, ax_properties=ax_options)
     elif reduction_package.reduction_mode == ReductionMode.HAB:
         plot([reduction_package.reduced_hab],
-             wksp_indices=[0], overplot=True, fig=output_graph, plot_kwargs=plot_kwargs)
+             wksp_indices=[0], overplot=True, fig=output_graph, plot_kwargs=plot_kwargs, ax_properties=ax_options)
     elif reduction_package.reduction_mode == ReductionMode.LAB:
         plot([reduction_package.reduced_lab],
-             wksp_indices=[0], overplot=True, fig=output_graph, plot_kwargs=plot_kwargs)
+             wksp_indices=[0], overplot=True, fig=output_graph, plot_kwargs=plot_kwargs, ax_properties=ax_options)
     elif reduction_package.reduction_mode == ReductionMode.MERGED:
         plot([reduction_package.reduced_merged, reduction_package.reduced_hab, reduction_package.reduced_lab],
-             wksp_indices=[0], overplot=True, fig=output_graph, plot_kwargs=plot_kwargs)
+             wksp_indices=[0], overplot=True, fig=output_graph, plot_kwargs=plot_kwargs, ax_properties=ax_options)
 
 
 # ----------------------------------------------------------------------------------------------------------------------


### PR DESCRIPTION
**Description of work.**
Matplotlib automatic detection of scale means we now have triggered log
plots which look "wrong". Instead force the x and y axis to be linear
so that user plots continue to look correct

**To test:**
- Download the ISIS Training data
- Ensure the LOQ demo folder is present
- Open the ISIS SANS GUI
- Set the user file to the .toml or .txt file in LOQ Demo
- Open the batch file (.csv) in the LOQ demo folder
- Select the first row, ensure plotting is enabled in the bottom right
- Process the row
- The final graph should look like a L
- Right click and check the x and y axis are set to lin

There is no associated issue. - Noticed whilst updating the testing instructions

*This does not require release notes* because it regressed between 6.0 and 6.1 so hasn't been reported


---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
