### PR TITLE
Remove qt4 sans

### DIFF
--- a/scripts/SANS/ISISCommandInterface.py
+++ b/scripts/SANS/ISISCommandInterface.py
@@ -33,14 +33,6 @@ warnings.simplefilter("ignore", category=DeprecationWarning)
 
 sanslog = Logger("SANS")
 
-# disable plotting if running outside Mantidplot
-try:
-    import mantidplot
-except (Exception, Warning):
-    mantidplot = None
-    # this should happen when this is called from outside Mantidplot and only then,
-    # the result is that attempting to plot will raise an exception
-
 try:
     from qtpy.QtWidgets import qApp
 
@@ -820,8 +812,9 @@ def CompWavRanges(wavelens, plot=True, combineDet=None, resetSetup=True):
     if resetSetup:
         _refresh_singleton()
 
-    if plot and mantidplot:
-        mantidplot.plotSpectrum(calculated, 0)
+    if plot:
+        raise NotImplementedError("Plotting on the deprecated ISISCommandInterface required MantidPlot and is no"
+                                  " longer implemented. Please switch to sans.command_interface.ISISCommandInterface")
 
     # return just the workspace name of the full range
     return calculated[0]
@@ -854,8 +847,9 @@ def PhiRanges(phis, plot=True):
     finally:
         _refresh_singleton()
 
-    if plot and mantidplot:
-        mantidplot.plotSpectrum(calculated, 0)
+    if plot:
+        raise NotImplementedError("Plotting on the deprecated ISISCommandInterface required MantidPlot and is no"
+                                  " longer implemented. Please switch to sans.command_interface.ISISCommandInterface")
 
     # return just the workspace name of the full range
     return calculated[0]
@@ -1018,28 +1012,8 @@ def PlotResult(workspace, canvas=None):
         @param canvas: optional handle to an existing graph to write the plot to
         @return: a handle to the graph that was written to
     """
-    if not mantidplot:
-        issueWarning('Plot functions are not available, is this being run from outside Mantidplot?')
-        return
-
-    # ensure that we are dealing with a workspace handle rather than its name
-    workspace = mtd[str(workspace)]
-    if isinstance(workspace, WorkspaceGroup):
-        numSpecs = workspace[0].getNumberHistograms()
-    else:
-        numSpecs = workspace.getNumberHistograms()
-
-    if numSpecs == 1:
-        graph = mantidplot.plotSpectrum(workspace, 0)
-    else:
-        graph = mantidplot.importMatrixWorkspace(workspace.name()).plotGraph2D()
-
-    if canvas is not None:
-        # we were given a handle to an existing graph, use it
-        mantidplot.mergePlots(canvas, graph)
-        graph = canvas
-
-    return graph
+    raise NotImplementedError("Plotting on the deprecated ISISCommandInterface required MantidPlot and is no"
+                              " longer implemented. Please switch to sans.command_interface.ISISCommandInterface")
 
 
 # #################### View mask details #####################################################
@@ -1218,8 +1192,6 @@ def FindBeamCentre(rlow, rupp, MaxIter=10, xstart=None, ystart=None, tolerance=1
 
     # take first trial step
     COORD1NEW, COORD2NEW = centre_positioner.increment_position(COORD1NEW, COORD2NEW)
-    graph_handle = None
-    it = 0
     for i in range(1, MaxIter + 1):
         it = i
         centre_reduction.set_beam_finder(
@@ -1231,17 +1203,6 @@ def FindBeamCentre(rlow, rupp, MaxIter=10, xstart=None, ystart=None, tolerance=1
 
         beam_center_logger.report_status(it, COORD1NEW, COORD2NEW, resCoord1, resCoord2)
 
-        if mantidplot:
-            try:
-                if not graph_handle:
-                    # once we have a plot it will be updated automatically when the workspaces are updated
-                    graph_handle = mantidplot.plotSpectrum(centre.QUADS, 0)
-                graph_handle.activeLayer().setTitle(
-                    beam_center_logger.get_status_message(it, COORD1NEW, COORD2NEW, resCoord1, resCoord2))
-            except (Exception, Warning):
-                # if plotting is not available it probably means we are running outside a GUI, in which case
-                # do everything but don't plot
-                pass
         # have we stepped across the y-axis that goes through the beam center?
         if resCoord1 > resCoord1_old:
             # yes with stepped across the middle, reverse direction and half the step size
@@ -2078,10 +2039,11 @@ def LimitsQ(*args):
 @deprecated
 def ViewCurrentMask():
     """
-        In MantidPlot this opens InstrumentView to display the masked
+        This opens InstrumentView to display the masked
         detectors in the bank in a different colour
     """
-    ReductionSingleton().ViewCurrentMask()
+    raise NotImplementedError("This is no longer implemented as it required MantidPlot, please switch"
+                              "to sans.command_interface.ISISCommandInterface instead")
 
 
 ###############################################################################

--- a/scripts/SANS/SANSBatchMode.py
+++ b/scripts/SANS/SANSBatchMode.py
@@ -176,7 +176,7 @@ def BatchReduce(filename, format, plotresults=False, saveAlgs={'SaveRKH':'txt'},
     """
         @param filename: the CSV file with the list of runs to analyse
         @param format: type of file to load, nxs for Nexus, etc.
-        @param plotresults: if true and this function is run Mantid a graph will be created for the results of each reduction
+        @param plotresults: if true and this function is run from Mantid a graph will be created for the results of each reduction
         @param saveAlgs: this named algorithm will be passed the name of the results workspace and filename (default = 'SaveRKH').
             Pass a tuple of strings to save to multiple file formats
         @param verbose: set to true to write more information to the log (default=False)

--- a/scripts/SANS/SANSBatchMode.py
+++ b/scripts/SANS/SANSBatchMode.py
@@ -176,7 +176,7 @@ def BatchReduce(filename, format, plotresults=False, saveAlgs={'SaveRKH':'txt'},
     """
         @param filename: the CSV file with the list of runs to analyse
         @param format: type of file to load, nxs for Nexus, etc.
-        @param plotresults: if true and this function is run from Mantidplot a graph will be created for the results of each reduction
+        @param plotresults: if true and this function is run Mantid a graph will be created for the results of each reduction
         @param saveAlgs: this named algorithm will be passed the name of the results workspace and filename (default = 'SaveRKH').
             Pass a tuple of strings to save to multiple file formats
         @param verbose: set to true to write more information to the log (default=False)

--- a/scripts/SANS/isis_instrument.py
+++ b/scripts/SANS/isis_instrument.py
@@ -6,9 +6,7 @@
 # SPDX - License - Identifier: GPL - 3.0 +
 # pylint: disable=too-many-lines, invalid-name, bare-except, too-many-instance-attributes
 import math
-import os
 import re
-import sys
 
 from mantid.simpleapi import *
 from mantid.api import WorkspaceGroup, Workspace
@@ -60,26 +58,6 @@ class BaseInstrument(object):
         if "SANS2D_Definition_Tubes" in self.idf_path:
             return "SANS2DTUBES"
         return self._NAME
-
-    def view(self, workspace_name=None):
-        """
-            Opens Mantidplot's InstrumentView displaying the current instrument. This
-            empty instrument created contained in the named workspace (a default name
-            is generated if this the argument is left blank) unless the workspace already
-            exists and then it's contents are displayed
-            @param workspace_name: the name of the workspace to create and/or display
-        """
-        if workspace_name is None:
-            workspace_name = self._NAME + '_instrument_view'
-            self.load_empty(workspace_name)
-        elif not AnalysisDataService.doesExist(workspace_name):
-            self.load_empty(workspace_name)
-
-        import mantidplot
-        instrument_win = mantidplot.getInstrumentView(workspace_name)
-        instrument_win.show()
-
-        return workspace_name
 
     def load_empty(self, workspace_name=None):
         """

--- a/scripts/SANS/isis_reducer.py
+++ b/scripts/SANS/isis_reducer.py
@@ -706,13 +706,6 @@ class ISISReducer(Reducer):
     def Q_string(self):
         return '    Q range: ' + self.to_Q.binning + '\n    QXY range: ' + self.QXY2 + '-' + self.DQXY
 
-    def ViewCurrentMask(self):
-        """
-            In MantidPlot this opens InstrumentView to display the masked
-            detectors in the bank in a different colour
-        """
-        self.mask.view(self.instrument)
-
     def reference(self):
         return self
 

--- a/scripts/SANS/sans/algorithm_detail/beamcentrefinder_plotting.py
+++ b/scripts/SANS/sans/algorithm_detail/beamcentrefinder_plotting.py
@@ -7,22 +7,17 @@
 import sys
 
 IN_WORKBENCH = False
-IN_MANTIDPLOT = False
 
-try:
-    import mantidplot
-    IN_MANTIDPLOT = True
-except (Exception, Warning):
-    if "workbench.app.mainwindow" in sys.modules:
+if "workbench.app.mainwindow" in sys.modules:
+    try:
+        from mantidqt.plotting.functions import plot
         IN_WORKBENCH = True
-        try:
-            from mantidqt.plotting.functions import plot
-        except ImportError:
-            pass
+    except ImportError:
+        pass
 
 
 def can_plot_beamcentrefinder():
-    return IN_WORKBENCH or IN_MANTIDPLOT
+    return IN_WORKBENCH
 
 
 def _plot_quartiles_matplotlib(output_workspaces, sample_scatter):
@@ -42,17 +37,6 @@ def _plot_quartiles_matplotlib(output_workspaces, sample_scatter):
          plot_kwargs=plot_kwargs, window_title=title)
 
 
-def _plot_quartiles(output_workspaces, sample_scatter):
-    title = '{}_beam_centre_finder'.format(sample_scatter)
-    graph_handle = mantidplot.plotSpectrum(output_workspaces, 0)
-    graph_handle.activeLayer().logLogAxes()
-    graph_handle.activeLayer().setTitle(title)
-    graph_handle.setName(title)
-    return graph_handle
-
-
 def plot_workspace_quartiles(output_workspaces, sample_scatter):
     if IN_WORKBENCH:
         _plot_quartiles_matplotlib(output_workspaces, sample_scatter)
-    elif IN_MANTIDPLOT:
-        _plot_quartiles(output_workspaces, sample_scatter)

--- a/scripts/SANS/sans/command_interface/ISISCommandInterface.py
+++ b/scripts/SANS/sans/command_interface/ISISCommandInterface.py
@@ -39,6 +39,8 @@ DefaultTrans = True
 # CommandInterfaceStateDirector global instance
 # ----------------------------------------------------------------------------------------------------------------------
 director = CommandInterfaceStateDirector(SANSFacility.ISIS)
+_plot_missing_str = "Plotting is not implemented for workbench yet, please contact us via the forum:\n" \
+                    "https://forum.mantidproject.org/"
 
 
 def deprecated(obj):
@@ -986,7 +988,7 @@ def CompWavRanges(wavelens, plot=True, combineDet=None, resetSetup=True):
         reduced_workspace_names.append(reduced_workspace_name)
 
     if plot:
-        raise NotImplementedError("Plotting is not implemented for workbench yet, please contact the dev team.")
+        raise NotImplementedError(_plot_missing_str)
 
     # Return just the workspace name of the full range
     return reduced_workspace_names[0]
@@ -1013,7 +1015,7 @@ def PhiRanges(phis, plot=True):
         reduced_workspace_names.append(reduced_workspace_name)
 
     if plot:
-        raise NotImplementedError("Plotting is not implemented for workbench yet, please contact the dev team.")
+        raise NotImplementedError(_plot_missing_str)
 
     # Return just the workspace name of the full range
     return reduced_workspace_names[0]
@@ -1068,7 +1070,7 @@ def PlotResult(workspace, canvas=None):
         @param canvas: optional handle to an existing graph to write the plot to
         @return: a handle to the graph that was written to
     """
-    raise NotImplementedError("Plotting is not implemented for workbench yet, please contact the dev team.")
+    raise NotImplementedError(_plot_missing_str)
 
     try:
         import mantidplot

--- a/scripts/SANS/sans/command_interface/ISISCommandInterface.py
+++ b/scripts/SANS/sans/command_interface/ISISCommandInterface.py
@@ -29,14 +29,6 @@ from sans.gui_logic.models.RowEntries import RowEntries
 from sans.sans_batch import SANSBatchReduction, SANSCentreFinder
 
 
-# Disable plotting if running outside Mantidplot
-try:
-    import mantidplot
-except (Exception, Warning):
-    mantidplot = None
-    # this should happen when this is called from outside Mantidplot and only then,
-    # the result is that attempting to plot will raise an exception
-
 # ----------------------------------------------------------------------------------------------------------------------
 # Globals
 # ----------------------------------------------------------------------------------------------------------------------
@@ -822,7 +814,7 @@ def BatchReduce(filename, format, plotresults=False, saveAlgs=None, verbose=Fals
     """
         @param filename: the CSV file with the list of runs to analyse
         @param format: type of file to load, nxs for Nexus, etc.
-        @param plotresults: if true and this function is run from Mantidplot a graph will be created for the results of each reduction
+        @param plotresults: if true and this function is run from mantid a graph will be created for the results of each reduction
         @param saveAlgs: this named algorithm will be passed the name of the results workspace and filename (default = 'SaveRKH').
             Pass a tuple of strings to save to multiple file formats
         @param verbose: set to true to write more information to the log (default=False)
@@ -993,8 +985,8 @@ def CompWavRanges(wavelens, plot=True, combineDet=None, resetSetup=True):
                                                    combineDet=combineDet, resetSetup=False)
         reduced_workspace_names.append(reduced_workspace_name)
 
-    if plot and mantidplot:
-        mantidplot.plotSpectrum(reduced_workspace_names, 0)
+    if plot:
+        raise NotImplementedError("Plotting is not implemented for workbench yet, please contact the dev team.")
 
     # Return just the workspace name of the full range
     return reduced_workspace_names[0]
@@ -1020,8 +1012,8 @@ def PhiRanges(phis, plot=True):
         reduced_workspace_name = WavRangeReduction()
         reduced_workspace_names.append(reduced_workspace_name)
 
-    if plot and mantidplot:
-        mantidplot.plotSpectrum(reduced_workspace_names, 0)
+    if plot:
+        raise NotImplementedError("Plotting is not implemented for workbench yet, please contact the dev team.")
 
     # Return just the workspace name of the full range
     return reduced_workspace_names[0]
@@ -1076,6 +1068,8 @@ def PlotResult(workspace, canvas=None):
         @param canvas: optional handle to an existing graph to write the plot to
         @return: a handle to the graph that was written to
     """
+    raise NotImplementedError("Plotting is not implemented for workbench yet, please contact the dev team.")
+
     try:
         import mantidplot
         workspace = AnalysisDataService.retrieve(str(workspace))

--- a/scripts/SANS/sans/gui_logic/presenter/masking_table_presenter.py
+++ b/scripts/SANS/sans/gui_logic/presenter/masking_table_presenter.py
@@ -19,16 +19,7 @@ from sans.common.enums import DetectorType
 from sans.common.constants import EMPTY_NAME
 from sans.common.general_functions import create_unmanaged_algorithm
 from ui.sans_isis.work_handler import WorkHandler
-
-from qtpy import PYQT4
-if PYQT4:
-    try:
-        import mantidplot
-        IN_MANTIDPLOT = True
-    except ImportError:
-        IN_MANTIDPLOT = False
-else:
-    from mantidqt.widgets.instrumentview.presenter import InstrumentViewPresenter
+from mantidqt.widgets.instrumentview.presenter import InstrumentViewPresenter
 
 masking_information = namedtuple("masking_information", "first, second, third")
 
@@ -449,9 +440,5 @@ class MaskingTablePresenter(object):
     @staticmethod
     def _display(masked_workspace):
         if masked_workspace and AnalysisDataService.doesExist(masked_workspace.name()):
-            if PYQT4:
-                instrument_win = mantidplot.getInstrumentView(masked_workspace.name())
-                instrument_win.show()
-            else:
-                instrument_win = InstrumentViewPresenter(masked_workspace)
-                instrument_win.container.show()
+            instrument_win = InstrumentViewPresenter(masked_workspace)
+            instrument_win.container.show()

--- a/scripts/SANS/sans/gui_logic/presenter/run_tab_presenter.py
+++ b/scripts/SANS/sans/gui_logic/presenter/run_tab_presenter.py
@@ -16,7 +16,6 @@ from contextlib import contextmanager
 from functools import wraps
 from typing import Optional
 
-from qtpy import PYQT4
 from ui.sans_isis import SANSSaveOtherWindow
 from ui.sans_isis.sans_data_processor_gui import SANSDataProcessorGui
 from ui.sans_isis.work_handler import WorkHandler
@@ -46,16 +45,7 @@ from sans.gui_logic.presenter.settings_adjustment_presenter import SettingsAdjus
 from sans.gui_logic.presenter.settings_diagnostic_presenter import SettingsDiagnosticPresenter
 from sans.sans_batch import SANSCentreFinder
 from sans.state.AllStates import AllStates
-
-IN_MANTIDPLOT = False
-if PYQT4:
-    try:
-        from mantidplot import graph, newGraph
-        IN_MANTIDPLOT = True
-    except ImportError:
-        pass
-else:
-    from mantid.plots.plotfunctions import get_plot_fig
+from mantid.plots.plotfunctions import get_plot_fig
 
 row_state_to_colour_mapping = {RowState.UNPROCESSED: '#FFFFFF', RowState.PROCESSED: '#d0f4d0',
                                RowState.ERROR: '#accbff'}
@@ -538,15 +528,11 @@ class RunTabPresenter(PresenterCommon):
         Plot a graph if continuous output specified.
         """
         if self._view.plot_results:
-            if IN_MANTIDPLOT:
-                if not graph(self.output_graph):
-                    newGraph(self.output_graph)
-            elif not PYQT4:
-                ax_properties = {'yscale': 'log',
-                                 'xscale': 'log'}
-                fig, _ = get_plot_fig(ax_properties=ax_properties, window_title=self.output_graph)
-                fig.show()
-                self.output_fig = fig
+            ax_properties = {'yscale': 'log',
+                             'xscale': 'log'}
+            fig, _ = get_plot_fig(ax_properties=ax_properties, window_title=self.output_graph)
+            fig.show()
+            self.output_fig = fig
 
     def _set_progress_bar(self, current, number_steps):
         """
@@ -583,14 +569,11 @@ class RunTabPresenter(PresenterCommon):
             self._plot_graph()
             save_can = self._view.save_can
 
-            # MantidPlot and Workbench have different approaches to plotting
-            output_graph = self.output_graph if PYQT4 else self.output_fig
-
             self.batch_process_runner.process_states(row_index_pair, self.get_states,
                                                      self._view.use_optimizations,
                                                      self._view.output_mode,
                                                      self._view.plot_results,
-                                                     output_graph,
+                                                     self.output_fig,
                                                      save_can)
 
         except Exception as e:


### PR DESCRIPTION
**Description of work.**

Removes MantidPlot imports and calls from the SANS codebase
In the majority of cases I've replaced them with NotImplementedErrors either because the module is deprecated, or because it's been broken since Mantid 6.0 without users having noticed it.

The intention is that instead of silently not plotting anything we explicitly tell users it's not working with workbench please contact us if you need this.

**To test:**
- Download ISIS Training data
- Ensure LOQDemo folder is present
- Open ISIS SANS interface
- Load a .txt or .toml file from the LOQ Demo folder
- Enter 74044 into the left hand column
- Hit load
- Go to Settings, Mask, ensure row 0 is selected (hit update rows if not)
- Display mask should open the instrument viewer

There is no associated issue. - This was noticed whilst working on plotting code

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
