### PR TITLE
Add Splitter on Muon GUIs plotting canvas

### DIFF
--- a/docs/source/release/v6.2.0/muon.rst
+++ b/docs/source/release/v6.2.0/muon.rst
@@ -5,8 +5,12 @@ MuSR Changes
 .. contents:: Table of Contents
    :local:
 
-.. warning:: **Developers:** Sort changes under appropriate heading
-    putting new features at the top of the section, followed by
-    improvements, followed by bug fixes.
+Muon Analysis 2 and Frequency Domain Analysis
+---------------------------------------------
+
+Improvements
+############
+
+- It is now possible to do a vertical resize of the plot in Muon Analysis and Frequency Domain Analysis.
 
 :ref:`Release 6.2.0 <v6.2.0>`

--- a/scripts/Muon/GUI/Common/plot_widget/plotting_canvas/plotting_canvas_view.py
+++ b/scripts/Muon/GUI/Common/plot_widget/plotting_canvas/plotting_canvas_view.py
@@ -7,7 +7,7 @@
 from typing import List
 
 from matplotlib.container import ErrorbarContainer
-from qtpy import QtWidgets
+from qtpy import QtWidgets, QtCore
 from Muon.GUI.Common.plot_widget.plotting_canvas.plot_toolbar import PlotToolbar
 from Muon.GUI.Common.plot_widget.plotting_canvas.plotting_canvas_model import WorkspacePlotInformation
 from Muon.GUI.Common.plot_widget.plotting_canvas.plotting_canvas_view_interface import PlottingCanvasViewInterface
@@ -65,11 +65,18 @@ class PlottingCanvasView(QtWidgets.QWidget, PlottingCanvasViewInterface):
         self._number_of_axes = 1
         self._color_queue = [ColorQueue(DEFAULT_COLOR_CYCLE)]
 
+        # Add a splitter for the plotting canvas and quick edit toolbar
+        splitter = QtWidgets.QSplitter(QtCore.Qt.Vertical)
+        splitter.addWidget(self.fig.canvas)
+        self._quick_edit = quick_edit
+        splitter.addWidget(self._quick_edit)
+        splitter.setStretchFactor(0, 9)
+        splitter.setStretchFactor(1, 1)
+        splitter.setCollapsible(1, False)
+
         layout = QtWidgets.QVBoxLayout()
         layout.addWidget(self.toolBar)
-        layout.addWidget(self.fig.canvas)
-        self._quick_edit = quick_edit
-        layout.addWidget(self._quick_edit)
+        layout.addWidget(splitter)
         self.setLayout(layout)
 
         self._plot_information_list = []  # type : List[PlotInformation}

--- a/scripts/Muon/GUI/Common/plot_widget/plotting_canvas/plotting_canvas_view.py
+++ b/scripts/Muon/GUI/Common/plot_widget/plotting_canvas/plotting_canvas_view.py
@@ -57,6 +57,7 @@ class PlottingCanvasView(QtWidgets.QWidget, PlottingCanvasViewInterface):
         # create the figure
         self.fig = Figure()
         self.fig.canvas = FigureCanvas(self.fig)
+        self.fig.canvas.setMinimumHeight(500)
         self.toolBar = PlotToolbar(self.fig.canvas, self)
 
         # Create a set of Mantid axis for the figure
@@ -70,9 +71,7 @@ class PlottingCanvasView(QtWidgets.QWidget, PlottingCanvasViewInterface):
         splitter.addWidget(self.fig.canvas)
         self._quick_edit = quick_edit
         splitter.addWidget(self._quick_edit)
-        splitter.setStretchFactor(0, 9)
-        splitter.setStretchFactor(1, 1)
-        splitter.setCollapsible(1, False)
+        splitter.setChildrenCollapsible(False)
 
         layout = QtWidgets.QVBoxLayout()
         layout.addWidget(self.toolBar)


### PR DESCRIPTION
**Description of work.**
A new splitter has been added between the plot and the quick edit bar in the GUIs used by Muon Analysis and Frequency Domain Analysis. This will allow the user to make the most use of the available space for the plot.

**To test:**
1) Open Mantid
2) Open Muon Analysis GUI
3) Load data (either latest run or load MUSR00015189.nxs from the Training dataset)
4) Find the splitter at the bottom of the plot and drag it up and down to see if the plot area resizes.

There is no associated issue. Spotted and commented on by users during beta testing.

This does not require release notes because it is a minor change to the GUI.

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
