### PR TITLE
Mock view in home_runinfo_presenter_test

### DIFF
--- a/scripts/test/Muon/home_runinfo_presenter_test.py
+++ b/scripts/test/Muon/home_runinfo_presenter_test.py
@@ -7,6 +7,7 @@
 import unittest
 from mantid.api import FileFinder
 from unittest import mock
+from unittest.mock import call
 
 import Muon.GUI.Common.utilities.load_utils as load_utils
 from Muon.GUI.Common.home_runinfo_widget.home_runinfo_widget_model import HomeRunInfoWidgetModel
@@ -42,22 +43,22 @@ class HomeTabRunInfoPresenterTest(unittest.TestCase):
 
         self.presenter.update_view_from_model()
 
-        add_text_line_calls = [mock.call("Instrument                : MUSR"),
-                               mock.call("Run                       : 22725"),
-                               mock.call("Title                     : FeTeSe T=1 F=100"),
-                               mock.call("Comment                   : FC first sample"),
-                               mock.call("Start                     : 2009-03-24T04:18:58"),
-                               mock.call("End                       : 2009-03-24T04:56:26"),
-                               mock.call("Counts (MEv)              : 20.076704"),
-                               mock.call("Good Frames               : 88540"),
-                               mock.call("Counts per Good Frame     : 226.753"),
-                               mock.call("Counts per Good Frame per det : 3.543"),
-                               mock.call("Average Temperature (K)   : 19.69992"),
-                               mock.call("Sample Temperature (K)    : 1.0"),
-                               mock.call("Sample Magnetic Field (G) : 100.0"),
-                               mock.call("Number of DAQ Periods     : 1")]
+        expected = [call("Instrument                : MUSR"),
+                    call("Run                       : 22725"),
+                    call("Title                     : FeTeSe T=1 F=100"),
+                    call("Comment                   : FC first sample"),
+                    call("Start                     : 2009-03-24T04:18:58"),
+                    call("End                       : 2009-03-24T04:56:26"),
+                    call("Counts (MEv)              : 20.076704"),
+                    call("Good Frames               : 88540"),
+                    call("Counts per Good Frame     : 226.753"),
+                    call("Counts per Good Frame per det : 3.543"),
+                    call("Average Temperature (K)   : 19.69992"),
+                    call("Sample Temperature (K)    : 1.0"),
+                    call("Sample Magnetic Field (G) : 100.0"),
+                    call("Number of DAQ Periods     : 1")]
 
-        self.view.add_text_line.assert_has_calls(add_text_line_calls)
+        self.assertEqual(self.view.add_text_line.call_args_list, expected)
 
 
 if __name__ == '__main__':

--- a/scripts/test/Muon/home_runinfo_presenter_test.py
+++ b/scripts/test/Muon/home_runinfo_presenter_test.py
@@ -7,8 +7,6 @@
 import unittest
 from mantid.api import FileFinder
 from unittest import mock
-from mantidqt.utils.qt.testing import start_qapplication
-from qtpy.QtWidgets import QWidget
 
 import Muon.GUI.Common.utilities.load_utils as load_utils
 from Muon.GUI.Common.home_runinfo_widget.home_runinfo_widget_model import HomeRunInfoWidgetModel
@@ -19,20 +17,18 @@ from Muon.GUI.Common.muon_pair import MuonPair
 from Muon.GUI.Common.test_helpers.context_setup import setup_context_for_tests
 
 
-@start_qapplication
 class HomeTabRunInfoPresenterTest(unittest.TestCase):
     def setUp(self):
-        self.obj = QWidget()
         setup_context_for_tests(self)
         self.data_context.instrument = 'MUSR'
-        self.view = HomeRunInfoWidgetView(self.obj)
+
+        self.view = mock.Mock(spec=HomeRunInfoWidgetView)
+        self.view.clear = mock.Mock()
+        self.view.warning_popup = mock.Mock()
+        self.view.add_text_line = mock.Mock()
+
         self.model = HomeRunInfoWidgetModel(self.context)
         self.presenter = HomeRunInfoWidgetPresenter(self.view, self.model)
-
-        self.view.warning_popup = mock.MagicMock()
-
-    def tearDown(self):
-        self.obj = None
 
     def test_runinfo_correct(self):
         file_path = FileFinder.findRuns('MUSR00022725.nxs')[0]
@@ -46,14 +42,22 @@ class HomeTabRunInfoPresenterTest(unittest.TestCase):
 
         self.presenter.update_view_from_model()
 
-        expected_string_list = ['Instrument:MUSR', 'Run:22725', 'Title:FeTeSeT=1F=100', 'Comment:FCfirstsample',
-                                'Start:2009-03-24T04:18:58', 'End:2009-03-24T04:56:26', 'Counts(MEv):20.076704',
-                                'GoodFrames:88540', 'CountsperGoodFrame:226.753',
-                                'CountsperGoodFrameperdet:3.543', 'AverageTemperature(K):19.69992',
-                                'SampleTemperature(K):1.0', 'SampleMagneticField(G):100.0',
-                                'NumberofDAQPeriods:1']
+        add_text_line_calls = [mock.call("Instrument                : MUSR"),
+                               mock.call("Run                       : 22725"),
+                               mock.call("Title                     : FeTeSe T=1 F=100"),
+                               mock.call("Comment                   : FC first sample"),
+                               mock.call("Start                     : 2009-03-24T04:18:58"),
+                               mock.call("End                       : 2009-03-24T04:56:26"),
+                               mock.call("Counts (MEv)              : 20.076704"),
+                               mock.call("Good Frames               : 88540"),
+                               mock.call("Counts per Good Frame     : 226.753"),
+                               mock.call("Counts per Good Frame per det : 3.543"),
+                               mock.call("Average Temperature (K)   : 19.69992"),
+                               mock.call("Sample Temperature (K)    : 1.0"),
+                               mock.call("Sample Magnetic Field (G) : 100.0"),
+                               mock.call("Number of DAQ Periods     : 1")]
 
-        self.assertEqual(str(self.view.run_info_box.toPlainText()).replace(' ', '').splitlines(), expected_string_list)
+        self.view.add_text_line.assert_has_calls(add_text_line_calls)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
**Description of work.**
This PR mocks out the view from the `home_runinfo_presenter_test` . This helps avoid an unreliable issue similar to this https://builds.mantidproject.org/job/pull_requests-ubuntu/44897/testReport/junit/projectroot.scripts.test/Muon/python_MuonQt5_transform_widget_new_test_transform_widget_new_test/ 

Mocking out Qt negates the X Display issue which is caused by a disconnect from the X Server while running a test involving Qt. Presenter tests shouldn't know anything about Qt, so it makes sense to mock this out.

**To test:**
Make sure the `home_runinfo_presenter_test` passes ok. A code review

*There is no associated issue.*

*This does not require release notes* because **it is an internal change.**

<!-- Ensure the base of this PR is correct (e.g. release-next or master)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
