### PR TITLE
list q values as q elastic on reduced ws

### DIFF
--- a/Framework/Algorithms/src/CreateDetectorTable.cpp
+++ b/Framework/Algorithms/src/CreateDetectorTable.cpp
@@ -179,7 +179,7 @@ std::vector<std::pair<std::string, std::string>> createColumns(const bool isScan
   colNames.emplace_back("double", "R");
   colNames.emplace_back("double", "Theta");
   if (calcQ) {
-    colNames.emplace_back("double", "Q");
+    colNames.emplace_back("double", "Q elastic");
   }
   colNames.emplace_back("double", "Phi");
   colNames.emplace_back("str", "Monitor");

--- a/docs/source/release/v6.1.0/indirect_geometry.rst
+++ b/docs/source/release/v6.1.0/indirect_geometry.rst
@@ -19,6 +19,7 @@ Improvements
 - In Indirect Data Analysis F(Q) fit the default fitting function remains None when switching to EISF.
 - Added a scroll bar to the Bayes interface tabs and Elwin and I(Q, t) in data analysis for users on small screens.
 - IN16B's single detectors are now correctly taken into account when computing the energy transfer in :ref:`IndirectILLEnergyTransfer <algm-IndirectILLEnergyTransfer>`.
+- Detector tables produced from `_red` and `_sqw` workspaces now use `Q elastic` as the label for its column instead of `Q`.
 
 Bug Fixes
 #########


### PR DESCRIPTION
**Description of work.**

This PR adds a condition to createDetectorTable to identify when a ws has specific suffixes output from Indirect data reduction that should have a Q elastic column in their detector column.

**To test:**

1. Load a `_sqw` ws, a `_red` ws and another ws with Q data.
2. show detector table for each.
3. on the `_sqw` ws, a `_red` ws it should have a `Q elastic` column, and on the other it should have a `Q` column.

Fixes #31427

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
