### PR TITLE
ALC Save Axis Scales

### DIFF
--- a/docs/source/release/v6.1.0/muon.rst
+++ b/docs/source/release/v6.1.0/muon.rst
@@ -58,6 +58,9 @@ Improvements
 - The interface saves previous settings if possible instead of resetting.
 - The interface can now load runs from different directories/cycles
 
+Bug fixes
+#########
+- Fixed a bug where after changing the axis scales of the plot, when loading new data the default scale would be used instead.
 
 Elemental Analysis
 ------------------

--- a/qt/widgets/plotting/inc/MantidQtWidgets/Plotting/Mpl/PreviewPlot.h
+++ b/qt/widgets/plotting/inc/MantidQtWidgets/Plotting/Mpl/PreviewPlot.h
@@ -182,6 +182,10 @@ private:
   char *m_style;
   bool m_useOffset;
 
+  // Axis scales
+  std::string m_xAxisScale;
+  std::string m_yAxisScale;
+
   // Context menu actions
   QActionGroup *m_contextPlotTools;
   QAction *m_contextResetView;

--- a/qt/widgets/plotting/src/Mpl/PreviewPlot.cpp
+++ b/qt/widgets/plotting/src/Mpl/PreviewPlot.cpp
@@ -57,8 +57,8 @@ namespace MantidWidgets {
 PreviewPlot::PreviewPlot(QWidget *parent, bool observeADS)
     : QWidget(parent), m_canvas{new FigureCanvasQt(111, MANTID_PROJECTION, parent)}, m_panZoomTool(m_canvas),
       m_wsRemovedObserver(*this, &PreviewPlot::onWorkspaceRemoved),
-      m_wsReplacedObserver(*this, &PreviewPlot::onWorkspaceReplaced), m_axis("both"), m_style("sci"),
-      m_useOffset(true) {
+      m_wsReplacedObserver(*this, &PreviewPlot::onWorkspaceReplaced), m_axis("both"), m_style("sci"), m_useOffset(true),
+      m_xAxisScale("linear"), m_yAxisScale("linear") {
   createLayout();
   createActions();
 
@@ -122,6 +122,8 @@ void PreviewPlot::addSpectrum(const QString &lineName, const Mantid::API::Matrix
   removeSpectrum(lineName);
 
   auto axes = m_canvas->gca<MantidAxes>();
+  axes.setXScale(m_xAxisScale.c_str());
+  axes.setYScale(m_yAxisScale.c_str());
   if (m_linesErrorsCache.value(lineName)) {
     m_lines[lineName] = true;
     axes.errorbar(ws, wsIndex, lineColour.name(QColor::HexRgb), lineName, plotKwargs);
@@ -699,9 +701,11 @@ void PreviewPlot::setScaleType(AxisID id, const QString &actionName) {
   switch (id) {
   case AxisID::XBottom:
     axes.setXScale(scaleType.constData());
+    m_xAxisScale = actionName.toLower().toStdString();
     break;
   case AxisID::YLeft:
     axes.setYScale(scaleType.constData());
+    m_yAxisScale = actionName.toLower().toStdString();
     break;
   default:
     break;


### PR DESCRIPTION
**Description of work.**
Created new member variables for the axis scales

**To test:**
Open ALC
Load some Data (e.g. HIFI110542)
Change the x and y scales of the plot (right click the plot window)
Change the run number to 110543 for example
After pressing load, the plot should have the same axis as what you changed them to before

Fixes #31554 

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
