### PR TITLE
Improve detector finding when dealing with peaks falling between gaps of tubes

### DIFF
--- a/Framework/DataObjects/src/Peak.cpp
+++ b/Framework/DataObjects/src/Peak.cpp
@@ -673,9 +673,16 @@ bool Peak::findDetector(const Mantid::Kernel::V3D &beam, const InstrumentRayTrac
         tracer.traceFromSample(normalize(beam2));
         IDetector_const_sptr det2 = tracer.getDetectorResult();
         if (det1 && det2) {
-          // Set the detector ID to one of the neighboring pixels
-          this->setDetectorID(static_cast<int>(det1->getID()));
-          detPos = det1->getPos();
+          // compute the cosAngle to select the detector closes to beam
+          if (beam1.cosAngle(beam) > beam2.cosAngle(beam)) {
+            // det1 is closer, use det1
+            this->setDetectorID(static_cast<int>(det1->getID()));
+            detPos = det1->getPos();
+          } else {
+            // det2 is closer, let's use det2
+            this->setDetectorID(static_cast<int>(det2->getID()));
+            detPos = det2->getPos();
+          }
           found = true;
           break;
         }

--- a/docs/source/release/v6.2.0/diffraction.rst
+++ b/docs/source/release/v6.2.0/diffraction.rst
@@ -33,6 +33,7 @@ New features
 
 Improvements
 ############
+- Find detector in peaks will check which det is closer when dealing with peak-in-gap situation for tube-type detectors.
 
 Bugfixes
 ########


### PR DESCRIPTION
**Description of work.**

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

- Original Gitlab Task: [SCD303](https://code.ornl.gov/sns-hfir-scse/diffraction/single-crystal/single-crystal-diffraction/-/issues/303)
- This is #31560  into `master`

This PR provides a small improvement for the following situations:

_**If the peaks fall in the gaps between two tubes (only relevant for tube-type detectors), Mantid will now check which neighboring detector is closer instead of biasing towards the one along (+x, +y, +z) quadrant.**_

<!-- Instructions for testing. -->

> no test is really necessary given the small scale of this change here (minor improvement that only relevant for rare cases related to tube detector).

<!-- alternative
*There is no associated issue.*
-->

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or master)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
