### PR TITLE
Updated plotting section in CrystalField documentation

### DIFF
--- a/docs/source/interfaces/indirect/Crystal Field Python Interface.rst
+++ b/docs/source/interfaces/indirect/Crystal Field Python Interface.rst
@@ -170,6 +170,19 @@ Alternatively, the x-values can be taken from a workspace::
   sp = cf.getSpectrum(ws, i)
 
 
+Plotting
+----------------------
+
+To plot a spectrum using the graphing facilities of Mantid `CrystalField` has method `plot`. It has the same arguments as `getSpectrum`
+and opens a window with a plot, e.g.::
+
+  cf.plot()
+
+In addition to plotting, the `plot` method creates a workspace named `CrystalField_<Ion>` with the plot data. Subsequent calls to `plot`
+for the same `CrystalField` object will use the same plot window as created by the first call unless this window has been closed in the
+mean time.
+
+
 Adding a Background
 -------------------
 


### PR DESCRIPTION
**Description of work.**

The section 'Plotting in MantidPlot' in the documentation for the Crystal Field Python Interface was not valid anymore after removing MantidPlot. Since the corresponding code for plotting was updated to use mantid.simpleapi instead of mantidplot (https://github.com/mantidproject/mantid/pull/31562/) the documentation matches now the current implementation.

**To test:**

Read the corresponding section in the documentation for the Crystal Field Python Interface.

Fixes [#30826](https://github.com/mantidproject/mantid/issues/30826).

*This does not require release notes* because **it is an update for outdated documentation.**

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
