### PR TITLE
Bugs in DrILL

### DIFF
--- a/scripts/Interface/ui/drill/model/DrillModel.py
+++ b/scripts/Interface/ui/drill/model/DrillModel.py
@@ -444,7 +444,7 @@ class DrillModel(QObject):
             value (str): new value
         """
         self.samples[sampleIndex].changeParameter(name, value)
-        if (value == "DEFAULT") or not value:
+        if (value == "DEFAULT") or value == "":
             self.paramOk.emit(sampleIndex, name)
         else:
             self.checkParameter(name, value, sampleIndex)

--- a/scripts/Interface/ui/drill/presenter/DrillPresenter.py
+++ b/scripts/Interface/ui/drill/presenter/DrillPresenter.py
@@ -443,6 +443,7 @@ class DrillPresenter:
         QDialog only if no file was previously used to load or save.
         """
         if self.model.getIOFile():
+            self.model.setVisualSettings(self.view.getVisualSettings())
             self.model.exportRundexData()
             self.view.setWindowModified(False)
         else:


### PR DESCRIPTION
**Description of work.**

This PR corrects two bugs in DrILL. See issue description.

**To test:**
1st bug:
* Open DrILL
* Save the rundex with `save as`
* Reorder the columns
* Save again using `save`
* Reload the file and observe the order of columns

2nd:
* Open DrILL
* Write `param=False` in custom options cell
* The cell should be marked as invalid (i.e. red)

Fixes #31568 

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
