### PR TITLE
Fix Unreliable X Display issue

### DIFF
--- a/buildconfig/Jenkins/buildscript
+++ b/buildconfig/Jenkins/buildscript
@@ -28,9 +28,9 @@ function onexit {
 
 function run_with_xvfb {
     if [ $(command -v xvfb-run) ]; then
-        # -e=--error-file. A bug in Xvfb on RHEL7 means --error-file
-        # produces an error: https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=337703;msg=2
-        xvfb-run -e /dev/stderr --server-args="-screen 0 640x480x24" \
+        # Use -e because a bug on RHEL7 means --error-file produces an error: https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=337703;msg=2
+        # Use -noreset because of an X Display bug caused by a race condition in xvfb: https://gitlab.freedesktop.org/xorg/xserver/-/issues/1102
+        xvfb-run -e /dev/stderr --server-args="-core -noreset -screen 0 640x480x24" \
         --server-num=${XVFB_SERVER_NUM} $@
     else
         eval $@


### PR DESCRIPTION
**Description of work.**
This PR fixes an unreliable failure in the unit tests on the build servers
```
QStandardPaths: XDG_RUNTIME_DIR not set, defaulting to '/tmp/runtime-abc'
qt.qpa.screen: QXcbConnection: Could not connect to display :101
Could not connect to any X display.
```
such as 

https://builds.mantidproject.org/job/pull_requests-ubuntu/44954/testReport/junit/projectroot.qt/python/mantidqt_qt5_test_projectloader_test_projectloader/

https://builds.mantidproject.org/job/pull_requests-ubuntu/44897/testReport/junit/projectroot.scripts.test/Muon/python_MuonQt5_transform_widget_new_test_transform_widget_new_test/


I believe the issue is being caused by a race condition in `xvfb` as described in https://gitlab.freedesktop.org/xorg/xserver/-/issues/1102 . We can avoid this bug by setting the `-noreset` flag. I have also set `-core` as this supposedly will give a core dump if there is any fatal issues in the future.

If a similar issue with `xvfb` happens in the future, there are a couple of things I found useful:
- Use the `-audit 4` flag to get more info on the connect/disconnect of clients. More flags are found here https://www.x.org/archive/X11R6.8.1/doc/Xserver.1.html
- Change the following line to only run tests involving qt using `-R "widget|view|qt"`. This will make the build speed far faster
https://github.com/mantidproject/mantid/blob/8872e2fd8ebed0e5193bdb9c3af8590bd8c214a7/buildconfig/Jenkins/buildscript#L414

**To test:**
Look at https://builds.mantidproject.org/job/unreliabletests-diagnostic-ubuntu/ . 

The flag `-noreset` was first introduced for build `#9`, and there has been no failure in the unit tests since then. Look in the console output to see that the tests have run 137/137 . In `#7` you can see a test has failed due to an X display issue.

*There is no associated issue.*

*This does not require release notes* because **it fixes an unreliable issue**

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
