### PR TITLE
Fix bad calculation in PEARLTransVoigt function

### DIFF
--- a/Framework/PythonInterface/plugins/algorithms/PEARLTransfit.py
+++ b/Framework/PythonInterface/plugins/algorithms/PEARLTransfit.py
@@ -293,7 +293,7 @@ class PEARLTransfit(PythonAlgorithm):
                 firstFileName = fnNoExt
             fileName_Raw = fnNoExt + '_raw'
             fileName_3 = fnNoExt + '_3'
-            LoadRaw(Filename=fileName, OutputWorkspace=fileName_Raw)
+            LoadRaw(Filename=file, OutputWorkspace=fileName_Raw)
             CropWorkspace(InputWorkspace=fileName_Raw, OutputWorkspace=fileName_Raw, XMin=100, XMax=19990)
             NormaliseByCurrent(InputWorkspace=fileName_Raw, OutputWorkspace=fileName_Raw)
             ExtractSingleSpectrum(InputWorkspace=fileName_Raw, OutputWorkspace=fileName_3, WorkspaceIndex=3)

--- a/Framework/PythonInterface/plugins/functions/PEARLTransVoigt.py
+++ b/Framework/PythonInterface/plugins/functions/PEARLTransVoigt.py
@@ -75,7 +75,7 @@ class PEARLTransVoigt(IFunction1D):
         #
         # Legacy background function included from Transfit v1
         # Define background function
-        bg = bg0 + bg1 ** xvals + bg2 * xvals * xvals
+        bg = bg0 + bg1 * xvals + bg2 * xvals * xvals
         # Correct using Beer's law to fit measured absorption, not Xsection
         # np.sqrt(np.log(2)) replaced with 1 as legacy
         width = 1 / gaussFWHM

--- a/Framework/PythonInterface/test/python/plugins/functions/PEARLTransVoigtTest.py
+++ b/Framework/PythonInterface/test/python/plugins/functions/PEARLTransVoigtTest.py
@@ -19,7 +19,7 @@ class PEARLTransVoigtTest(unittest.TestCase):
 
     def test_function_output(self):
         input = [1092, 1094, 1096, 1098]
-        expected = [14.106022, 14.074826, 14.062504, 14.069141]
+        expected = [23.348288, 23.313542, 23.310007, 23.337891]
         tolerance = 1.0e-05
         status, output = check_output("PEARLTransVoigt", input, expected, tolerance, Position=1096.3, LorentzianFWHM=45.8,
                                       GaussianFWHM=25.227, Bg0=25.0, Bg1=0.015, Bg2=0.0)
@@ -29,8 +29,8 @@ class PEARLTransVoigtTest(unittest.TestCase):
 
     def test_do_fit(self):
         do_a_fit(np.arange(0.1, 16, 0.2), 'PEARLTransVoigt', guess=dict(Position=1096, LorentzianFWHM=45.5,
-                                                                            GaussianFWHM=25.4, Bg0=25.2, Bg1=0.017,
-                                                                            Bg2=0.0),
+                                                                        GaussianFWHM=25.4, Bg0=25.2, Bg1=0.017,
+                                                                        Bg2=0.0),
                  target=dict(Position=1096.3, LorentzianFWHM=45.8, GaussianFWHM=25.227, Bg0=25.0, Bg1=0.015, Bg2=0.0),
                  atol=0.01)
 

--- a/docs/source/release/v6.1.0/diffraction.rst
+++ b/docs/source/release/v6.1.0/diffraction.rst
@@ -63,6 +63,7 @@ Bugfixes
 - :ref:`D7AbsoluteCrossSections <algm-D7AbsoluteCrossSections>` fixed the wrong assumption on the order of spin-flip and non-spin-flip data, and fixed the relative normalisation issues.
 - Fix crashing issue in :ref:`AlignAndFocusPowder<algm-AlignAndFocusPowder>` due to using new unit conversion APIs.
 - Support for data with x-axis unit of TOF has been deprecated in :ref:`DiffractionFocussing version 2 <algm-DiffractionFocussing-v2>`, please use :ref:`GroupDetectors <algm-GroupDetectors>` instead.
+- Fixed an error in the final calculation for the PEARLTransVoigt function, used in PEARLTransfit
 
 Engineering Diffraction
 -----------------------


### PR DESCRIPTION
**Description of work.**

There was an error in PEARLTransVoigt with a `**` power operator rather than `*` multiply.

New values from the PEARLTransfit algorithm (which uses this function) have been confirmed against values from Chris Ridley who provided the original code.

**To test:**
1. Run PEARLTransfit with PEARL115780 firstly in calibration (S) mode then in Temperature mod
2. Check that the sample temp output to the console is ~279K +/- 36

Fixes #31551 . 

<!-- Ensure the base of this PR is correct (e.g. release-next or master)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
