### PR TITLE
Add parseNames to CreateMDHistoWorkspace

### DIFF
--- a/Framework/MDAlgorithms/inc/MantidMDAlgorithms/ImportMDHistoWorkspaceBase.h
+++ b/Framework/MDAlgorithms/inc/MantidMDAlgorithms/ImportMDHistoWorkspaceBase.h
@@ -39,6 +39,7 @@ private:
   size_t m_bin_product = 0;
   Mantid::Geometry::MDFrame_uptr createMDFrame(const std::string &frame, const std::string &unit);
   bool checkIfFrameValid(const std::string &frame, const std::vector<std::string> &targetFrames);
+  std::vector<std::string> parseNames(const std::string &names_string);
 };
 
 } // namespace MDAlgorithms

--- a/Framework/MDAlgorithms/src/ImportMDHistoWorkspaceBase.cpp
+++ b/Framework/MDAlgorithms/src/ImportMDHistoWorkspaceBase.cpp
@@ -17,11 +17,14 @@
 #include "MantidKernel/CompositeValidator.h"
 #include "MantidKernel/MandatoryValidator.h"
 #include <algorithm>
+#include <boost/algorithm/string.hpp>
+#include <boost/regex.hpp>
 
 using namespace Mantid::API;
 using namespace Mantid::DataObjects;
 using namespace Mantid::Geometry;
 using namespace Mantid::Kernel;
+using boost::regex;
 
 namespace Mantid {
 namespace MDAlgorithms {
@@ -87,7 +90,8 @@ MDHistoWorkspace_sptr ImportMDHistoWorkspaceBase::createEmptyOutputWorkspace() {
   }
   std::vector<double> extents = getProperty("Extents");
   std::vector<int> nbins = getProperty("NumberOfBins");
-  std::vector<std::string> names = getProperty("Names");
+  std::string dimensions_string = getPropertyValue("Names");
+  std::vector<std::string> names = parseNames(dimensions_string);
   std::vector<std::string> units = getProperty("Units");
   std::vector<std::string> frames = getProperty("Frames");
 
@@ -189,6 +193,30 @@ bool ImportMDHistoWorkspaceBase::checkIfFrameValid(const std::string &frame,
                                                    const std::vector<std::string> &targetFrames) {
   return std::any_of(targetFrames.cbegin(), targetFrames.cend(),
                      [&frame](const auto &targetFrame) { return targetFrame == frame; });
+}
+
+/*
+ * The list of dimension names often looks like "[H,0,0],[0,K,0]" with "[H,0,0]"
+ * being the first dimension but getProperty returns a vector of
+ * the string split on every comma
+ * This function parses the string, and does not split on commas within brackets
+ */
+std::vector<std::string> ImportMDHistoWorkspaceBase::parseNames(const std::string &names_string) {
+
+  // This regex has two parts which are separated by the "|" (or)
+  // The first part matches anything which is bounded by square brackets
+  // unless they contain square brackets (so that it only matches inner pairs)
+  // The second part matches anything that doesn't contain a comma
+  // NB, the order of the two parts matters
+
+  regex expression(R"(\[([^\[]*)\]|[^,]+)");
+
+  boost::sregex_token_iterator iter(names_string.begin(), names_string.end(), expression, 0);
+  boost::sregex_token_iterator end;
+
+  std::vector<std::string> names_result(iter, end);
+
+  return names_result;
 }
 
 } // namespace MDAlgorithms

--- a/docs/source/release/v6.2.0/framework.rst
+++ b/docs/source/release/v6.2.0/framework.rst
@@ -47,4 +47,6 @@ Improvements
 Bugfixes
 ########
 
+- Added parser for input Names to :ref:`algm-CreateMDHistoWorkspace` to allow inputs such as `Names='[H,0,0],[0,K,0],[0,0,L]'`.
+
 :ref:`Release 6.2.0 <v6.2.0>`


### PR DESCRIPTION
Found by 2 users, including on the [forum](https://forum.mantidproject.org/t/deltapdf3d-algorithm/733). 

CreateMDWorkspace has parseNames for the input param Names
Now this parser has been added to CreateMDHistoWorkspace

This is because the `Names` input parameter wants 3 inputs (for 3 dimensions), so `Names=('[H,0,0]','[0,K,0]','[0,0,L]')` is the workaround. BUT, CreateMDWorkspace has a parser to correctly read `Names='[H,0,0],[0,K,0],[0,0,L]'`. Now I've moved this parser to CreateMD**Histo**Workspace (really it's base class `ImportMDHistoWorkspaceBase`) , it solves the problem that the user ran into on the forum.

**Description of work.**

**To test:**
Testing script:

```
# import mantid algorithms, numpy and matplotlib
from mantid.simpleapi import *
import matplotlib.pyplot as plt
import numpy as np
 
S  =range(0,1000);
ERR=range(0,1000);
 
DeltaPDF3D_MDH=CreateMDHistoWorkspace(Dimensionality=3,Extents='-3,3,-10,10,-1,1',SignalInput=S,ErrorInput=ERR,\
                          NumberOfBins='10,10,10',Names='[H,0,0],[0,K,0],[0,0,L]',\
                          Units='rlu,rlu,rlu')
                         
DeltaPDF3D(InputWorkspace='DeltaPDF3D_MDH',OutputWorkspace='fft',
           Method='None', WindowFunction='None')
```

- On master, if you run this testing script in MantidWorkbench, you will get the error:

```
Error in execution of algorithm CreateMDHistoWorkspace:
You must specify as many names as there are dimensions.
ValueError: You must specify as many names as there are dimensions.
  File "<string>", line 16, in <module>
  File "/home/danielmurphy/mantid/Framework/PythonInterface/mantid/simpleapi.py", line 1041, in __call__
    algm.execute()
```
- Checkout this PR branch and notice the error doesn't occur, and CreateMDHistoWorkspace completes successful


Fixes #31412 





<!-- Ensure the base of this PR is correct (e.g. release-next or master)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
