### PR TITLE
Muon Analysis Fix Crash When Loading PSI Data In Co-Add Mode

### DIFF
--- a/docs/source/release/v6.1.0/muon.rst
+++ b/docs/source/release/v6.1.0/muon.rst
@@ -48,6 +48,7 @@ Bug fixes
 - Fixed a bug that caused the `AutoScale` check box to reset when editing the selected groups/pairs.
 - Fixed a bug where the start and end X would reset in the fitting tab when stepping to the next or previous run.
 - Fixed a bug caused by entering an empty string into the start and end X fields.
+- Fixed a bug when loading PSI data in co-add mode
 
 ALC
 ---

--- a/scripts/Muon/GUI/Common/utilities/load_utils.py
+++ b/scripts/Muon/GUI/Common/utilities/load_utils.py
@@ -291,7 +291,11 @@ def combine_loaded_runs(model, run_list, delete_added=False):
         running_total.append(running_total_item)
 
     return_ws_actual = {key: return_ws[key] for key in ['MainFieldDirection', 'TimeZero', 'FirstGoodData',
-                                                        'DeadTimeTable', 'DetectorGroupingTable']}
+                                                        'DeadTimeTable']}
+    try:
+        return_ws_actual['DetectorGroupingTable'] = return_ws['DetectorGroupingTable']
+    except KeyError:
+        pass  # PSI Data does not include Detector Grouping table as it's read from sample logs instead
     return_ws_actual["OutputWorkspace"] = [MuonWorkspaceWrapper(running_total_period) for running_total_period in
                                            running_total]
     return_ws_actual['DataDeadTimeTable'] = CloneWorkspace(InputWorkspace=return_ws['DataDeadTimeTable'],

--- a/scripts/Muon/GUI/Common/utilities/load_utils.py
+++ b/scripts/Muon/GUI/Common/utilities/load_utils.py
@@ -290,12 +290,15 @@ def combine_loaded_runs(model, run_list, delete_added=False):
 
         running_total.append(running_total_item)
 
-    return_ws_actual = {key: return_ws[key] for key in ['MainFieldDirection', 'TimeZero', 'FirstGoodData',
-                                                        'DeadTimeTable']}
+    return_ws_actual = {key: return_ws[key] for key in ['MainFieldDirection', 'TimeZero', 'FirstGoodData']}
     try:
         return_ws_actual['DetectorGroupingTable'] = return_ws['DetectorGroupingTable']
     except KeyError:
         pass  # PSI Data does not include Detector Grouping table as it's read from sample logs instead
+    try:
+        return_ws_actual['DeadTimeTable'] = return_ws['DeadTimeTable']
+    except KeyError:
+        pass  # Again, PSI data does not always include DeadTimeTable either
     return_ws_actual["OutputWorkspace"] = [MuonWorkspaceWrapper(running_total_period) for running_total_period in
                                            running_total]
     return_ws_actual['DataDeadTimeTable'] = CloneWorkspace(InputWorkspace=return_ws['DataDeadTimeTable'],

--- a/scripts/test/Muon/utilities/load_utils_test.py
+++ b/scripts/test/Muon/utilities/load_utils_test.py
@@ -11,6 +11,7 @@ import unittest
 from mantid import simpleapi
 from mantid.kernel import ConfigService
 from mantid.api import AnalysisDataService, ITableWorkspace
+from unittest import mock
 
 
 def create_simple_workspace(data_x, data_y, run_number=0):
@@ -86,8 +87,22 @@ class MuonFileUtilsTest(unittest.TestCase):
               "DeadTimeTable": "__notUsed",
               "DetectorGroupingTable": "__notUsed"}
 
-        alg, _ = utils.create_load_algorithm(filename,inputs)
+        alg, _ = utils.create_load_algorithm(filename, inputs)
         self.assertTrue(filename in alg.getProperty("Filename").value)
+
+    @mock.patch('Muon.GUI.Common.utilities.load_utils.CloneWorkspace')
+    def test_combine_loaded_runs_for_psi_data(self, clone_mock):
+        workspace = mock.MagicMock()
+        workspace.workspace.name = "name"
+        model = mock.MagicMock()
+        model._data_context.num_periods = mock.Mock(return_value=1)
+        # Workspace is missing DeadTimeTable and DetectorGroupingTable which should be handled without raising
+        model._loaded_data_store.get_data = mock.Mock(return_value={"workspace": {"OutputWorkspace": workspace,
+                                                                                  "MainFieldDirection": 0,
+                                                                                  "TimeZero": 0, "FirstGoodData": 0,
+                                                                                  "DataDeadTimeTable": "dtt"}})
+        run_list = [1529]
+        utils.combine_loaded_runs(model, run_list)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
**Description of work.**
Co-adding data tries to combine the loaded runs and expects the detector grouping table to be present in the the workspace. This isn't the case for PSI data

**To test:**
Open Muon Analysis
Change instrument to PSI
tick co-add
Load PSI data (use browse to browse to a PSI data fie e.g. delta_tdc_dolly_1529.bin)
The data should load successfully and a default grouping table be present.
Also try loading data from other instruments in coadd mode 

Fixes #31572 

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
