### PR TITLE
Muon ALC - Fix crash when changing to linear plot scale

### DIFF
--- a/docs/source/release/v6.1.0/muon.rst
+++ b/docs/source/release/v6.1.0/muon.rst
@@ -61,6 +61,7 @@ Improvements
 Bug fixes
 #########
 - Fixed a bug where after changing the axis scales of the plot, when loading new data the default scale would be used instead.
+- Fixed a crash when changing between log and linear scale on the preview plot.
 
 Elemental Analysis
 ------------------

--- a/qt/widgets/plotting/inc/MantidQtWidgets/Plotting/Mpl/PreviewPlot.h
+++ b/qt/widgets/plotting/inc/MantidQtWidgets/Plotting/Mpl/PreviewPlot.h
@@ -137,9 +137,6 @@ private:
   boost::optional<char const *> overrideAxisLabel(AxisID const &axisID);
   void setAxisLabel(AxisID const &axisID, char const *const label);
 
-  bool tickLabelFormatX(char *axis, char *style, bool useOffset);
-  bool tickLabelFormatY(char *axis, char *style, bool useOffset);
-
   // Block redrawing from taking place
   bool m_allowRedraws = true;
 

--- a/qt/widgets/plotting/inc/MantidQtWidgets/Plotting/Mpl/PreviewPlot.h
+++ b/qt/widgets/plotting/inc/MantidQtWidgets/Plotting/Mpl/PreviewPlot.h
@@ -137,6 +137,9 @@ private:
   boost::optional<char const *> overrideAxisLabel(AxisID const &axisID);
   void setAxisLabel(AxisID const &axisID, char const *const label);
 
+  bool tickLabelFormatX(char *axis, char *style, bool useOffset);
+  bool tickLabelFormatY(char *axis, char *style, bool useOffset);
+
   // Block redrawing from taking place
   bool m_allowRedraws = true;
 

--- a/qt/widgets/plotting/src/Mpl/PreviewPlot.cpp
+++ b/qt/widgets/plotting/src/Mpl/PreviewPlot.cpp
@@ -741,37 +741,22 @@ void PreviewPlot::toggleLegend(const bool checked) {
  * calculated as needed, False no offset will be used
  */
 void PreviewPlot::tickLabelFormat(char *axis, char *style, bool useOffset) {
-  const auto xTickLabelFormatChanged = tickLabelFormatX(axis, style, useOffset);
-  const auto yTickLabelFormatChanged = tickLabelFormatY(axis, style, useOffset);
+  auto axes = m_canvas->gca();
+  const auto formatXTicks = (*axis == 'x' || *axis == 'both') && axes.getXScale().toStdString() == "linear";
+  const auto formatYTicks = (*axis == 'y' || *axis == 'both') && axes.getYScale().toStdString() == "linear";
 
-  if (xTickLabelFormatChanged || yTickLabelFormatChanged) {
+  if (formatXTicks)
+    axes.tickLabelFormat(std::string("x").c_str(), style, useOffset);
+
+  if (formatYTicks)
+    axes.tickLabelFormat(std::string("y").c_str(), style, useOffset);
+
+  if (formatXTicks || formatYTicks) {
     // Need to save parameters to re-format on scale change
     m_axis = axis;
     m_style = style;
     m_useOffset = useOffset;
   }
-}
-
-bool PreviewPlot::tickLabelFormatX(char *axis, char *style, bool useOffset) {
-  auto axes = m_canvas->gca();
-  const auto isXLinear = (*axis == 'x' || *axis == 'both') && axes.getXScale().toStdString() == "linear";
-  if (isXLinear) {
-    char *axisType;
-    axisType = "x";
-    axes.tickLabelFormat(axisType, style, useOffset);
-  }
-  return isXLinear;
-}
-
-bool PreviewPlot::tickLabelFormatY(char *axis, char *style, bool useOffset) {
-  auto axes = m_canvas->gca();
-  const auto isYLinear = (*axis == 'y' || *axis == 'both') && axes.getYScale().toStdString() == "linear";
-  if (isYLinear) {
-    char *axisType;
-    axisType = "y";
-    axes.tickLabelFormat(axisType, style, useOffset);
-  }
-  return isYLinear;
 }
 
 } // namespace MantidWidgets

--- a/qt/widgets/plotting/src/Mpl/PreviewPlot.cpp
+++ b/qt/widgets/plotting/src/Mpl/PreviewPlot.cpp
@@ -30,7 +30,6 @@ using MantidQt::Widgets::MplCpp::FigureCanvasQt;
 using MantidQt::Widgets::MplCpp::Line2D;
 using MantidQt::Widgets::MplCpp::MantidAxes;
 namespace Python = MantidQt::Widgets::Common::Python;
-using Mantid::PythonInterface::PythonException;
 
 namespace {
 Mantid::Kernel::Logger g_log("PreviewPlot");

--- a/qt/widgets/plotting/src/Mpl/PreviewPlot.cpp
+++ b/qt/widgets/plotting/src/Mpl/PreviewPlot.cpp
@@ -712,9 +712,7 @@ void PreviewPlot::setScaleType(AxisID id, const QString &actionName) {
     break;
   }
 
-  // If linear scale need to reset tick labels
-  if (strcmp(scaleType.constData(), "linear") == 0)
-    tickLabelFormat(m_axis, m_style, m_useOffset);
+  tickLabelFormat(m_axis, m_style, m_useOffset);
 
   this->replot();
 }

--- a/qt/widgets/plotting/src/Mpl/PreviewPlot.cpp
+++ b/qt/widgets/plotting/src/Mpl/PreviewPlot.cpp
@@ -742,8 +742,8 @@ void PreviewPlot::toggleLegend(const bool checked) {
  */
 void PreviewPlot::tickLabelFormat(char *axis, char *style, bool useOffset) {
   auto axes = m_canvas->gca();
-  const auto formatXTicks = (*axis == 'x' || *axis == 'both') && axes.getXScale().toStdString() == "linear";
-  const auto formatYTicks = (*axis == 'y' || *axis == 'both') && axes.getYScale().toStdString() == "linear";
+  const auto formatXTicks = *axis != 'y' && axes.getXScale().toStdString() == "linear";
+  const auto formatYTicks = *axis != 'x' && axes.getYScale().toStdString() == "linear";
 
   if (formatXTicks)
     axes.tickLabelFormat(std::string("x").c_str(), style, useOffset);

--- a/qt/widgets/plotting/src/Mpl/PreviewPlot.cpp
+++ b/qt/widgets/plotting/src/Mpl/PreviewPlot.cpp
@@ -30,6 +30,7 @@ using MantidQt::Widgets::MplCpp::FigureCanvasQt;
 using MantidQt::Widgets::MplCpp::Line2D;
 using MantidQt::Widgets::MplCpp::MantidAxes;
 namespace Python = MantidQt::Widgets::Common::Python;
+using Mantid::PythonInterface::PythonException;
 
 namespace {
 Mantid::Kernel::Logger g_log("PreviewPlot");
@@ -743,12 +744,37 @@ void PreviewPlot::toggleLegend(const bool checked) {
  * calculated as needed, False no offset will be used
  */
 void PreviewPlot::tickLabelFormat(char *axis, char *style, bool useOffset) {
-  m_canvas->gca().tickLabelFormat(axis, style, useOffset);
+  const auto xTickLabelFormatChanged = tickLabelFormatX(axis, style, useOffset);
+  const auto yTickLabelFormatChanged = tickLabelFormatY(axis, style, useOffset);
 
-  // Need to save parameters to re-format on scale change
-  m_axis = axis;
-  m_style = style;
-  m_useOffset = useOffset;
+  if (xTickLabelFormatChanged || yTickLabelFormatChanged) {
+    // Need to save parameters to re-format on scale change
+    m_axis = axis;
+    m_style = style;
+    m_useOffset = useOffset;
+  }
+}
+
+bool PreviewPlot::tickLabelFormatX(char *axis, char *style, bool useOffset) {
+  auto axes = m_canvas->gca();
+  const auto isXLinear = (*axis == 'x' || *axis == 'both') && axes.getXScale().toStdString() == "linear";
+  if (isXLinear) {
+    char *axisType;
+    axisType = "x";
+    axes.tickLabelFormat(axisType, style, useOffset);
+  }
+  return isXLinear;
+}
+
+bool PreviewPlot::tickLabelFormatY(char *axis, char *style, bool useOffset) {
+  auto axes = m_canvas->gca();
+  const auto isYLinear = (*axis == 'y' || *axis == 'both') && axes.getYScale().toStdString() == "linear";
+  if (isYLinear) {
+    char *axisType;
+    axisType = "y";
+    axes.tickLabelFormat(axisType, style, useOffset);
+  }
+  return isYLinear;
 }
 
 } // namespace MantidWidgets


### PR DESCRIPTION
**Description of work.**
This PR fixes a crash when changing to linear scale for one axis when the other axis is still in log scale. 

**To test:**
Follow the instructions in the issue and make sure there is no crash.

Fixes #31571 

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
