### PR TITLE
Add QThread/Python threading adaptor

### DIFF
--- a/qt/python/CMakeLists.txt
+++ b/qt/python/CMakeLists.txt
@@ -73,6 +73,7 @@ if(ENABLE_WORKBENCH)
       mantidqt/project/test/test_workspacesaver.py
       mantidqt/project/test/test_projectparser_mantidplot.py
       mantidqt/utils/test/test_async.py
+      mantidqt/utils/test/test_async_qt_adaptor.py
       mantidqt/utils/test/test_modal_tester.py
       mantidqt/utils/test/test_qt_utils.py
       mantidqt/utils/test/test_writetosignal.py

--- a/qt/python/mantidqt/utils/async_qt_adaptor.py
+++ b/qt/python/mantidqt/utils/async_qt_adaptor.py
@@ -7,8 +7,8 @@
 from functools import wraps
 from typing import Any, Optional, Callable
 
-from PyQt5 import QtCore
-from PyQt5.QtCore import QObject, pyqtSignal
+from qtpy import QtCore
+from qtpy.QtCore import QObject, Signal
 
 from mantidqt.utils.asynchronous import AsyncTask, AsyncTaskFailure, AsyncTaskSuccess
 from mantid.kernel import Logger
@@ -107,9 +107,9 @@ class _QtSignals(QObject):
     """
     Wrapper class for the signals used to translate from Python threading -> Qt Signals/Slots
     """
-    success_signal = pyqtSignal(AsyncTaskSuccess)
-    error_signal = pyqtSignal(AsyncTaskFailure)
-    finished_signal = pyqtSignal()
+    success_signal = Signal(AsyncTaskSuccess)
+    error_signal = Signal(AsyncTaskFailure)
+    finished_signal = Signal()
 
 
 ErrorCbType = Optional[Callable[[AsyncTaskFailure], None]]
@@ -164,7 +164,7 @@ class AsyncTaskQtAdaptor(AsyncTask):
         )
 
     @staticmethod
-    def _wrap_signal(signal: pyqtSignal, slot: Optional[Callable]) -> Optional[Callable]:
+    def _wrap_signal(signal: Signal, slot: Optional[Callable]) -> Optional[Callable]:
         """
         Wraps a given signal so that the thread calls emit rather than the target directly.
         This allows us to complete the slot on the target, rather than trying

--- a/qt/python/mantidqt/utils/async_qt_adaptor.py
+++ b/qt/python/mantidqt/utils/async_qt_adaptor.py
@@ -1,0 +1,160 @@
+# Mantid Repository : https://github.com/mantidproject/mantid
+#
+# Copyright &copy; 2021 ISIS Rutherford Appleton Laboratory UKRI,
+#     NScD Oak Ridge National Laboratory, European Spallation Source
+#     & Institut Laue - Langevin
+# SPDX - License - Identifier: GPL - 3.0 +
+from functools import wraps
+from typing import Any, Optional, Callable
+
+from PyQt5 import QtCore
+from PyQt5.QtCore import QObject, pyqtSignal
+
+from mantidqt.utils.asynchronous import AsyncTask, AsyncTaskFailure, AsyncTaskSuccess
+from mantid.kernel import Logger
+
+
+class IQtAsync:
+    """
+    A base class which should be extended to write async methods. This allows the user to
+    optionally overwrite the callbacks they require, and automatically wires up the Qt signal
+    and slots.
+    This allows us to use native Python tooling that can't work the "Qt blackbox" whilst still
+    allowing us to use slots within the callbacks which cannot be done directly from a threading
+    callback. For more in-depth details see AsyncTaskQtAdaptor.
+
+    To make a Qt Async method simply:
+    - Inherit from this class and add any method(s) to run async
+    - Overwrite any of the below callbacks are required
+    - Annotate anything to run async with the @qt_async_task decorator
+    - Get yourself a nice coffee to celebrate a job well done
+
+    For the benefits of using this over QThreads see AsyncTaskQtAdaptor
+    """
+    def __init__(self):
+        self._worker = None
+
+    def success_cb_slot(self, result: AsyncTaskSuccess) -> None:
+        pass
+
+    def error_cb_slot(self, result: AsyncTaskFailure) -> None:
+        pass
+
+    def finished_cb_slot(self) -> None:
+        pass
+
+    def _internal_finished_handler(self):
+        self.finished_cb_slot()
+        self._worker = None
+
+
+def qt_async_task(method: Callable):
+    """
+    Decorator to mark a given method as async. This method must belong to a class that
+    inherits from IQtAsync.
+
+    Example:
+        class Bar(IQtAsync):
+            def __init__(self):
+                super().__init()
+
+            # Callback overrides omitted for brevity, see IQtAsync
+
+            @qt_async_task
+            def async_method(some_param_1, some_param_2, ...etc):
+                some_expensive_call(some_param_1, some_param_2) # Will run async
+    """
+    @wraps(method)
+    def _inner(self, *args, **kwargs):
+        # So that we can store the worker so it doesn't end up garbage collected with no refs
+        # also to make setting up callbacks easier too, as you can't use self.x within a decorator
+        assert isinstance(self, IQtAsync), "This class must inherit from IQtAsync"
+
+        if self._worker:
+            Logger("Qt Async Task").warning(
+                "Starting a new task, the task in progress has been cancelled")
+            self._worker.abort()
+
+        self._worker = AsyncTaskQtAdaptor(target=method, args=(self, *args), kwargs=kwargs,
+                                          success_cb=self.success_cb_slot,
+                                          error_cb=self.error_cb_slot,
+                                          finished_cb=self._internal_finished_handler)
+        self._worker.start()
+    return _inner
+
+
+class _QtSignals(QObject):
+    """
+    Wrapper class for the signals used to translate from Python threading -> Qt Signals/Slots
+    """
+    success_signal = pyqtSignal(AsyncTaskSuccess)
+    error_signal = pyqtSignal(AsyncTaskFailure)
+    finished_signal = pyqtSignal()
+
+
+ErrorCbType = Optional[Callable[[AsyncTaskFailure], None]]
+SuccessCbType = Optional[Callable[[AsyncTaskSuccess], None]]
+FinishedCbType = Optional[Callable[[None], None]]
+
+
+class AsyncTaskQtAdaptor(AsyncTask):
+    """
+    Adaptor between Python threading and Qt signals and slots.
+
+    Why?
+    ----
+    This allows us to get the best of both; clean tracebacks and native tooling (such as
+    profiling) are difficult to get right with Qt Threads.
+    This is further compounded by the fact someone who wants to simply run something async
+    on a GUI needs to then write signals, slots, connect them up ...etc.
+
+    However, if you naively try to get the GUI thread to do anything, such as update
+    or show a dialog box from a thread without the event loop you will quickly cause
+    the main thread to segmentation fault. Qt does not take kindly to widgets just randomly
+    doing things without it's control.
+
+    So from the end-user perspective they can literally write a method that sits alongside the
+    GUI thread, annotate their task with the decorator and they're done.
+
+    How
+    ---
+    Instead we simply use the fact that a QueuedConnection is thread safe to emit a message
+    to the slot. Because of duck-typing users don't even have to annotate their slot (though
+    the types need to be correct for similar reasons, hence providing an interface type).
+
+    Strictly speaking it means that there may be a brief window of time where the background
+    thread and GUI thread end up visually out of sync, especially if something is hogging the
+    main event loop. However, in this case it means something is incorrectly running something slow
+    on the main thread and is out of scope for this.
+    """
+
+    def __init__(self, target: Callable, args: Any = (), kwargs: Any = None,
+                 success_cb: SuccessCbType = None,
+                 error_cb: ErrorCbType = None,
+                 finished_cb: FinishedCbType = None):
+
+        self._signals = _QtSignals()
+        success_cb = self._wrap_signal(self._signals.success_signal, success_cb)
+        error_cb = self._wrap_signal(self._signals.error_signal, error_cb)
+        finished_cb = self._wrap_signal(self._signals.finished_signal, finished_cb)
+
+        super(AsyncTaskQtAdaptor, self).__init__(
+            target=target, args=args, kwargs=kwargs,
+            success_cb=success_cb, error_cb=error_cb, finished_cb=finished_cb
+        )
+
+    @staticmethod
+    def _wrap_signal(signal: pyqtSignal, slot: Optional[Callable]) -> Optional[Callable]:
+        """
+        Wraps a given signal so that the thread calls emit rather than the target directly.
+        This allows us to complete the slot on the target, rather than the
+        """
+        if not slot:
+            return None
+
+        signal.connect(slot, QtCore.Qt.QueuedConnection)
+
+        def emit_on_completion(*args, **kwargs):
+            signal.emit(*args, **kwargs)
+
+        return emit_on_completion if slot else None

--- a/qt/python/mantidqt/utils/async_qt_adaptor.py
+++ b/qt/python/mantidqt/utils/async_qt_adaptor.py
@@ -167,7 +167,8 @@ class AsyncTaskQtAdaptor(AsyncTask):
     def _wrap_signal(signal: pyqtSignal, slot: Optional[Callable]) -> Optional[Callable]:
         """
         Wraps a given signal so that the thread calls emit rather than the target directly.
-        This allows us to complete the slot on the target, rather than the
+        This allows us to complete the slot on the target, rather than trying
+        to invoke across threads causing Qt to assert / segfault
         """
         if not slot:
             return None

--- a/qt/python/mantidqt/utils/test/test_async_qt_adaptor.py
+++ b/qt/python/mantidqt/utils/test/test_async_qt_adaptor.py
@@ -1,0 +1,133 @@
+# Mantid Repository : https://github.com/mantidproject/mantid
+#
+# Copyright &copy; 2021 ISIS Rutherford Appleton Laboratory UKRI,
+#     NScD Oak Ridge National Laboratory, European Spallation Source
+#     & Institut Laue - Langevin
+# SPDX - License - Identifier: GPL - 3.0 +
+import unittest
+from unittest import mock
+
+from mantidqt.utils.async_qt_adaptor import IQtAsync, qt_async_task, AsyncTaskQtAdaptor
+
+
+class _StubbedCbHandler(IQtAsync):
+    def __init__(self):
+        super().__init__()
+        self.finished_called = False
+
+    def finished_cb_slot(self) -> None:
+        self.finished_called = True
+
+
+class IQtAsyncTest(unittest.TestCase):
+    def test_internal_finish_handler_cleans_up(self):
+        fixture = IQtAsync()
+        self.assertIsNone(fixture._worker)
+
+        fixture._worker = mock.Mock()
+        fixture._internal_finished_handler()
+        self.assertIsNone(fixture._worker)
+
+    def test_internal_finished_handler_calls_user_one(self):
+        fixture = _StubbedCbHandler()
+        fixture._internal_finished_handler()
+        self.assertTrue(fixture.finished_called)
+
+    def test_all_standard_cb_are_callable(self):
+        fixture = IQtAsync()
+        for f in [fixture.success_cb_slot, fixture.error_cb_slot]:
+            self.assertIsNone(f(mock.NonCallableMock()))
+
+        self.assertIsNone(fixture.finished_cb_slot())
+
+
+class StubTask(_StubbedCbHandler):
+    @qt_async_task
+    def some_task(self):
+        pass
+
+    @qt_async_task
+    def some_exception(self):
+        raise Exception("Some exception")
+
+
+@mock.patch("mantidqt.utils.async_qt_adaptor.AsyncTaskQtAdaptor", autospec=True)
+class QtAsyncTaskDecoratorTest(unittest.TestCase):
+    def test_start_called(self, mocked_adaptor):
+        tasks = StubTask()
+        tasks.some_task()
+
+        mocked_adaptor.return_value.start.assert_called_once()
+        mocked_adaptor.return_value.run.assert_not_called()
+        # This should not have run as we have mocked the async backend
+        # if it has run it's likely were calling 'method()' directly
+        # instead of using .start()
+        self.assertFalse(tasks.finished_called)
+
+    @mock.patch("mantidqt.utils.async_qt_adaptor.Logger", autospec=True)
+    def test_abort_called_in_progress(self, mocked_logger, mocked_adaptor):
+        task = StubTask()
+        original_worker = mock.Mock()
+        task._worker = original_worker
+
+        task.some_task()
+        mocked_logger.return_value.warning.assert_called_once()
+        original_worker.abort.assert_called_once()
+
+        self.assertNotEqual(original_worker, task._worker)
+        self.assertEqual(mocked_adaptor.return_value, task._worker)
+
+    def test_callbacks_passed_through_decorator(self, mocked_adaptor):
+        task = StubTask()
+        task.some_task()
+
+        mocked_adaptor.assert_called_with(
+            target=mock.ANY, args=mock.ANY, kwargs=mock.ANY,
+            error_cb=task.error_cb_slot,
+            success_cb=task.success_cb_slot,
+            # This is special as we have cleanup code afterwards
+            finished_cb=task._internal_finished_handler)
+
+
+@mock.patch("mantidqt.utils.async_qt_adaptor._QtSignals")
+class AsyncTaskQtAdaptorTest(unittest.TestCase):
+    def test_signal_connected_to_user_cb(self, mocked_signals):
+        signals_instance = mocked_signals.return_value
+        cb_class = IQtAsync()
+        AsyncTaskQtAdaptor(target=lambda: None, error_cb=cb_class.error_cb_slot,
+                           finished_cb=cb_class.finished_cb_slot, success_cb=cb_class.success_cb_slot)
+
+        for signal, slot in [(signals_instance.error_signal, cb_class.error_cb_slot),
+                             (signals_instance.success_signal, cb_class.success_cb_slot),
+                             (signals_instance.finished_signal, cb_class.finished_cb_slot)]:
+            signal.connect.assert_called_once_with(slot, mock.ANY)
+
+    def test_signal_can_handle_none_types(self, mocked_signals):
+        signals_instance = mocked_signals.return_value
+        cb_class = IQtAsync()
+        AsyncTaskQtAdaptor(target=lambda: None, error_cb=cb_class.error_cb_slot)
+
+        signals_instance.error_signal.connect.assert_called_once_with(cb_class.error_cb_slot, mock.ANY)
+
+        for signal in [signals_instance.success_signal, signals_instance.finished_signal]:
+            signal.connect.assert_not_called()
+
+    def test_async_cb_wrapped_into_emit(self, mocked_signals):
+        def null_task():
+            pass
+
+        fixture = AsyncTaskQtAdaptor(target=null_task, success_cb=null_task,
+                                          error_cb=null_task, finished_cb=null_task)
+
+        signals_instance = mocked_signals.return_value
+
+        for callback, signal in [(fixture.error_cb, signals_instance.error_signal),
+                                 (fixture.success_cb, signals_instance.success_signal),
+                                 (fixture.finished_cb, signals_instance.finished_signal)]:
+            signal.emit.assert_not_called()
+            callback()
+            signal.emit.assert_called_once()
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/qt/python/mantidqt/utils/test/test_async_qt_adaptor.py
+++ b/qt/python/mantidqt/utils/test/test_async_qt_adaptor.py
@@ -64,6 +64,21 @@ class QtAsyncTaskDecoratorTest(unittest.TestCase):
         # instead of using .start()
         self.assertFalse(tasks.finished_called)
 
+    def test_unit_test_mode_uses_run(self, mocked_adaptor):
+        class StubTestFixture(IQtAsync):
+            def __init__(self):
+                super().__init__()
+                self.set_unit_test_mode(True)
+
+            @qt_async_task
+            def run_synchronous(self):
+                pass
+
+        test_fixture = StubTestFixture()
+        test_fixture.run_synchronous()
+        mocked_adaptor.return_value.start.assert_not_called()
+        mocked_adaptor.return_value.run.assert_called_once()
+
     @mock.patch("mantidqt.utils.async_qt_adaptor.Logger", autospec=True)
     def test_abort_called_in_progress(self, mocked_logger, mocked_adaptor):
         task = StubTask()


### PR DESCRIPTION
**Description of work.**
Adds a widget that adapts between Python threading and QThreads. This
provides a number of advantages described in the docstring for
associated classes.

The short-version is it gives us (much) better stack traces, allows us
to get rid of some bare catch exceptions and avoids users having to wire
up Qt signals and slots to simply run something off the GUI thread.

Whilst it's not present in this commit, this has been tested with the
ISIS SANS interface to verify the functionality with Qt and also fix up
some API usability problems noticed whilst implementing this

**To test:**
- Ensure unit tests pass
- Further testing will be present in the follow up PR which replaces the ISIS SANS QThread implementation with this widget

Part of #27895 

This does not require release notes because it's an internal change, though if when we convert users of QThread to this we should explicitly add it as Python stack traces improve greatly

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
