### PR TITLE
Fix Race Condition in test_interpreter

### DIFF
--- a/qt/python/mantidqt/utils/asynchronous.py
+++ b/qt/python/mantidqt/utils/asynchronous.py
@@ -90,7 +90,7 @@ class AsyncTask(threading.Thread):
         time.sleep(0.1)
 
 
-class Receiver(object):
+class _Receiver(object):
 
     def __init__(self, success_cb=None, error_cb=None):
         self.output = None
@@ -137,7 +137,7 @@ class BlockingAsyncTaskWithCallback(AsyncTask):
         self.success_cb = create_callback(success_cb)
         self.error_cb = create_callback(error_cb)
 
-        self.recv = Receiver(success_cb=self.success_cb, error_cb=self.error_cb)
+        self.recv = _Receiver(success_cb=self.success_cb, error_cb=self.error_cb)
         self.task = AsyncTask(target, args, kwargs, success_cb=self.recv.on_success, error_cb=self.recv.on_error)
 
     def start(self):

--- a/qt/python/mantidqt/utils/asynchronous.py
+++ b/qt/python/mantidqt/utils/asynchronous.py
@@ -91,9 +91,11 @@ class AsyncTask(threading.Thread):
 
 
 class Receiver(object):
-    output, exc_value = None, None
 
     def __init__(self, success_cb=None, error_cb=None):
+        self.output = None
+        self.exc_value = None
+
         self.success_cb = success_cb
         self.error_cb = error_cb
 

--- a/qt/python/mantidqt/utils/asynchronous.py
+++ b/qt/python/mantidqt/utils/asynchronous.py
@@ -90,6 +90,24 @@ class AsyncTask(threading.Thread):
         time.sleep(0.1)
 
 
+class Receiver(object):
+    output, exc_value = None, None
+
+    def __init__(self, success_cb=None, error_cb=None):
+        self.success_cb = success_cb
+        self.error_cb = error_cb
+
+    def on_success(self, result):
+        self.output = result.output
+        if self.success_cb is not None:
+            self.success_cb(result)
+
+    def on_error(self, result):
+        self.exc_value = result.exc_value
+        if self.error_cb is not None:
+            self.error_cb(result)
+
+
 class BlockingAsyncTaskWithCallback(AsyncTask):
     def __init__(self, target, args=(), kwargs=None, success_cb=None, error_cb=None, blocking_cb=None,
                  period_secs=0.05):
@@ -117,20 +135,7 @@ class BlockingAsyncTaskWithCallback(AsyncTask):
         self.success_cb = create_callback(success_cb)
         self.error_cb = create_callback(error_cb)
 
-        class Receiver(object):
-            output, exc_value = None, None
-
-            def on_success(self, result):
-                self.output = result.output
-                if success_cb is not None:
-                    success_cb(result)
-
-            def on_error(self, result):
-                self.exc_value = result.exc_value
-                if error_cb is not None:
-                    error_cb(result)
-
-        self.recv = Receiver()
+        self.recv = Receiver(success_cb=self.success_cb, error_cb=self.error_cb)
         self.task = AsyncTask(target, args, kwargs, success_cb=self.recv.on_success, error_cb=self.recv.on_error)
 
     def start(self):

--- a/qt/python/mantidqt/widgets/codeeditor/test/test_interpreter.py
+++ b/qt/python/mantidqt/widgets/codeeditor/test/test_interpreter.py
@@ -57,8 +57,8 @@ class PythonFileInterpreterTest(unittest.TestCase):
     @mock.patch("mantidqt.utils.asynchronous.Receiver.on_error")
     def test_variables_reset(self, mock_on_error):
         w = PythonFileInterpreter(content='x=\'this is a string\'\r\nprint(x)')
-        w.code_completer.update_completion_api = mock.MagicMock()
-        w.code_completer.add_simpleapi_to_completions_if_required = mock.MagicMock()
+        w.sig_editor_modified = mock.MagicMock()
+        w._presenter.model.sig_exec_success = mock.MagicMock()
         w.execute_async_blocking()
         self.assertTrue('x' in w._presenter.model._globals_ns.keys())
 

--- a/qt/python/mantidqt/widgets/codeeditor/test/test_interpreter.py
+++ b/qt/python/mantidqt/widgets/codeeditor/test/test_interpreter.py
@@ -54,7 +54,7 @@ class PythonFileInterpreterTest(unittest.TestCase):
                 self.assertEqual(w.clear_key_binding(key_combo), None,
                                  msg=fail_msg)
 
-    @mock.patch("mantidqt.utils.asynchronous.Receiver.on_error")
+    @mock.patch("mantidqt.utils.asynchronous._Receiver.on_error")
     def test_variables_reset(self, mock_on_error):
         w = PythonFileInterpreter(content='x=\'this is a string\'\r\nprint(x)')
         w.sig_editor_modified = mock.MagicMock()


### PR DESCRIPTION
**Description of work.**
This PR fixes an unreliable test called `test_interpreter`:
https://builds.mantidproject.org/job/pull_requests-rhel7/43892/testReport/junit/projectroot.qt/python/mantidqt_qt5_test_interpreter_test_interpreter/

I think there were two problems:
-  A race condition caused by the asyc execution of a python script meant an assertion was made before the execution was finished.
- A timeout caused by a seg fault when reading/writing to a variable at the same time from different threads 

The solution to both of these problems is to wait for the async execution to finish using `execute_async_blocking` before continuing with the rest of the test.

**To test:**
A code review 

*There is no associated issue.*

*This does not require release notes* because **it is a unit test change**


#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
