### PR TITLE
Import Qt before mantid in docs build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -132,7 +132,7 @@ set(DOCS_BUILDDIR ${CMAKE_BINARY_DIR}/docs)
 
 # Framework Build options
 option(CXXTEST_ADD_PERFORMANCE
-       "Switch to add Performance tests to the list of tests run by ctest?")
+       "Switch to add performance tests to the list of tests run by ctest?")
 
 add_subdirectory(Framework)
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -12,14 +12,24 @@
 # and simply amounts to importing readline before a QApplication is created in the screenshots
 # directive
 import sys
-if sys.platform == "linux" or sys.platform == "linux2" or sys.platform == "darwin":
+if sys.platform.startswith('linux') or sys.platform == "darwin":
     import readline
+
+# Workaround module destruction order issues. If Qt is imported after
+# mantid then any active Qt widgets are deleted before the mantid
+# atexit handlers kick in. Some widgets, e.g. WorkspaceSelector,
+# subscribe to mantid notifications and deleting the widget references leaves
+# dangling references in the notification centre that cause a segfault
+import qtpy.QtCore
+
+from distutils.version import LooseVersion
 import os
-from sphinx import __version__ as sphinx_version
-import sphinx_bootstrap_theme  # checked at cmake time
+
 import mantid
 from mantid.kernel import ConfigService
-from distutils.version import LooseVersion
+from sphinx import __version__ as sphinx_version
+import sphinx_bootstrap_theme
+
 
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the


### PR DESCRIPTION
**Description of work.**

The docs build on macOS started segfaulting after #31341 was merged. It appears we have a issue with the
order of destruction within the docs build relating to how the `atexit` handlers registered by importing mantid
are handled vs the location of the Qt import. 

When mantid is imported first it registers an `atexit` handler that hooks up `FrameworkManager::shutdown` on Python exit. This in turn invokes `AnalysisDataService::clear`. If the docs build has created widgets, such as `WorkspaceSelector` that listen to mantid notficiations then they still receive these events at Python exit because the Qt module has been destroyed and the widget left a dangling reference in the DataService notification handler.

Importing Qt first causes mantid to call its atexit handlers while the Qt objects are still alive.

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

**To test:**

* Attempt to build a package on the build servers. The builds should pass.

*There is no associated issue.*


*This does not require release notes* because **it is a developer regression**

<!-- Ensure the base of this PR is correct (e.g. release-next or master)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
