### PR TITLE
Add missing unit tests for reflectometry interface Group class

### DIFF
--- a/qt/scientific_interfaces/ISISReflectometry/Reduction/Group.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/Reduction/Group.cpp
@@ -92,11 +92,6 @@ void Group::resetSkipped() {
       row->setSkipped(false);
 }
 
-bool Group::allRowsAreValid() const {
-  return std::all_of(m_rows.cbegin(), m_rows.cend(),
-                     [](boost::optional<Row> const &row) -> bool { return row.is_initialized(); });
-}
-
 std::vector<boost::optional<Row>> const &Group::rows() const { return m_rows; }
 
 std::vector<boost::optional<Row>> &Group::mutableRows() { return m_rows; }

--- a/qt/scientific_interfaces/ISISReflectometry/Reduction/Group.h
+++ b/qt/scientific_interfaces/ISISReflectometry/Reduction/Group.h
@@ -32,7 +32,6 @@ public:
   bool requiresProcessing(bool reprocessFailed) const override;
   bool requiresPostprocessing(bool reprocessFailed) const;
   std::string postprocessedWorkspaceName() const;
-  std::vector<std::string> workspaceNamesToPostprocess() const;
   void setOutputNames(std::vector<std::string> const &outputNames) override;
   void resetOutputs() override;
 
@@ -42,7 +41,6 @@ public:
   int insertRowSortedByAngle(boost::optional<Row> const &row);
   void removeRow(int rowIndex);
   void updateRow(int rowIndex, boost::optional<Row> const &row);
-  bool allRowsAreValid() const;
 
   int totalItems() const override;
   int completedItems() const override;

--- a/qt/scientific_interfaces/ISISReflectometry/test/Reduction/GroupTest.h
+++ b/qt/scientific_interfaces/ISISReflectometry/test/Reduction/GroupTest.h
@@ -22,10 +22,275 @@ public:
 
   ReductionWorkspaces workspaceNames() const { return ReductionWorkspaces({}, TransmissionRunPair{}); }
 
+  /** Construction
+   */
+
   void test_constructor_sets_group_name() {
     auto group = Group("Group1", {});
     TS_ASSERT_EQUALS("Group1", group.name());
   }
+
+  void test_is_group() {
+    auto group = makeEmptyGroup();
+    TS_ASSERT_EQUALS(group.isGroup(), true);
+  }
+
+  void test_set_name() {
+    auto group = makeEmptyGroup();
+    group.setName("new name");
+    TS_ASSERT_EQUALS(group.name(), "new name");
+  }
+
+  /** State
+   */
+
+  void test_set_success_marks_as_complete_and_success() {
+    auto group = makeEmptyGroup();
+    group.setSuccess();
+    TS_ASSERT(group.complete());
+    TS_ASSERT(group.success());
+  }
+
+  void test_set_error_marks_as_complete() {
+    auto group = makeEmptyGroup();
+    group.setError("test error");
+    TS_ASSERT(group.complete());
+    TS_ASSERT(!group.success());
+  }
+
+  void test_reset_state_clears_complete_and_success() {
+    auto group = makeEmptyGroup();
+    group.setSuccess();
+    group.resetState();
+    TS_ASSERT(!group.complete());
+    TS_ASSERT(!group.success());
+  }
+
+  void test_reset_state_does_not_clear_child_row_state() {
+    auto group = makeGroupWithOneRow();
+    group.mutableRows()[0]->setSuccess();
+    group.resetState(false);
+    TS_ASSERT(group[0]->success());
+  }
+
+  void test_reset_state_clears_child_row_state() {
+    auto group = makeGroupWithOneRow();
+    group.mutableRows()[0]->setSuccess();
+    group.resetState(true);
+    TS_ASSERT(!group[0]->success());
+  }
+
+  /** Processing - these tests check if a group has rows that require
+   * processing
+   */
+
+  void test_empty_group_does_not_require_processing() {
+    auto group = makeEmptyGroup();
+    checkDoesNotRequireProcessing(group);
+  }
+
+  void test_group_with_unprocessed_row_requires_processing() {
+    auto group = makeGroupWithOneRow();
+    checkRequiresProcessing(group);
+  }
+
+  void test_group_with_started_row_does_not_require_processing() {
+    auto group = makeGroupWithOneRow();
+    group.mutableRows()[0]->setStarting();
+    checkDoesNotRequireProcessing(group);
+  }
+
+  void test_group_with_running_row_does_not_require_processing() {
+    auto group = makeGroupWithOneRow();
+    group.mutableRows()[0]->setRunning();
+    checkDoesNotRequireProcessing(group);
+  }
+
+  void test_group_with_row_completed_does_not_require_processing() {
+    auto group = makeGroupWithOneRow();
+    group.mutableRows()[0]->setSuccess();
+    checkDoesNotRequireProcessing(group);
+  }
+
+  void test_group_with_row_error_does_not_require_processing() {
+    auto group = makeGroupWithOneRow();
+    group.mutableRows()[0]->setError("test error");
+    TS_ASSERT(!group.requiresProcessing(false));
+  }
+
+  void test_group_with_row_error_requires_reprocessing() {
+    auto group = makeGroupWithOneRow();
+    group.mutableRows()[0]->setError("test error");
+    TS_ASSERT(group.requiresProcessing(true));
+  }
+
+  void test_setting_error_sets_message() {
+    auto group = makeGroupWithOneRow();
+    group.mutableRows()[0]->setError("test error");
+    TS_ASSERT_EQUALS(group[0]->message(), "test error");
+  }
+
+  void test_skipped_row_does_not_require_processing() {
+    auto group = makeGroupWithOneRow();
+    group.mutableRows()[0]->setSkipped(true);
+    checkDoesNotRequireProcessing(group);
+  }
+
+  void test_resetting_skipped_makes_row_require_processing_again() {
+    auto group = makeGroupWithOneRow();
+    group.mutableRows()[0]->setSkipped(true);
+    group.resetSkipped();
+    checkRequiresProcessing(group);
+  }
+
+  /** Postprocessing - "hasPostprocessing" indicates whether postprocessing is
+   * applicable for a group, and "requiresPostprocessing" indicates whether
+   * postprocessing is outstanding i.e. has not already been done. These tests
+   * check these functions for a new group (i.e. default state)
+   */
+
+  void test_no_postprocessing_if_empty_group() {
+    auto group = makeEmptyGroup();
+    checkPostprocessingNotApplicable(group);
+  }
+
+  void test_no_postprocessing_if_one_row() {
+    auto group = makeGroupWithOneRow();
+    checkPostprocessingNotApplicable(group);
+  }
+
+  void test_no_postprocessing_if_one_valid_and_one_invalid_row() {
+    auto group = makeGroupWithOneRow();
+    group.appendRow(boost::none);
+    checkPostprocessingNotApplicable(group);
+  }
+
+  void test_has_postprocessing_if_two_rows() {
+    auto group = makeGroupWithTwoRows();
+    checkPostprocessingIsApplicable(group);
+    checkDoesNotRequirePostprocessing(group);
+  }
+
+  void test_has_postprocessing_if_two_valid_rows_and_one_invalid_row() {
+    auto group = makeGroupWithTwoRows();
+    group.appendRow(boost::none);
+    checkPostprocessingIsApplicable(group);
+    checkDoesNotRequirePostprocessing(group);
+  }
+
+  /** Postprocessing and row state - these tests check the
+   * requiresPostprocessing function for groups where some processing of rows
+   * has been done
+   */
+
+  void test_requires_postprocessing_if_all_rows_complete() {
+    auto group = makeGroupWithTwoCompleteRows();
+    checkRequiresPostprocessing(group);
+  }
+
+  void test_does_not_require_postprocessing_if_some_rows_not_started() {
+    auto group = makeGroupWithTwoRows();
+    group.mutableRows()[0]->setSuccess();
+    checkDoesNotRequirePostprocessing(group);
+  }
+
+  void test_does_not_require_postprocessing_if_some_rows_are_starting() {
+    auto group = makeGroupWithTwoRows();
+    group.mutableRows()[0]->setSuccess();
+    group.mutableRows()[1]->setStarting();
+    checkDoesNotRequirePostprocessing(group);
+  }
+
+  void test_does_not_require_postprocessing_if_some_rows_are_running() {
+    auto group = makeGroupWithTwoRows();
+    group.mutableRows()[0]->setSuccess();
+    group.mutableRows()[1]->setRunning();
+    checkDoesNotRequirePostprocessing(group);
+  }
+
+  void test_does_not_require_postprocessing_if_some_rows_have_failed() {
+    auto group = makeGroupWithTwoRows();
+    group.mutableRows()[0]->setSuccess();
+    group.mutableRows()[1]->setError("test error");
+    checkDoesNotRequirePostprocessing(group);
+  }
+
+  /** Postprocessing and group state - these tests check the
+   * requiresPostprocessing function where postprocessing for the group has
+   * already been done
+   */
+
+  void test_does_not_require_postprocessing_if_started() {
+    auto group = makeGroupWithTwoCompleteRows();
+    group.setStarting();
+    checkDoesNotRequirePostprocessing(group);
+  }
+
+  void test_does_not_require_postprocessing_if_running() {
+    auto group = makeGroupWithTwoCompleteRows();
+    group.setRunning();
+    checkDoesNotRequirePostprocessing(group);
+  }
+
+  void test_does_not_require_postprocessing_if_complete() {
+    auto group = makeGroupWithTwoCompleteRows();
+    group.setSuccess();
+    checkDoesNotRequirePostprocessing(group);
+  }
+
+  void test_does_not_require_postprocessing_if_failed() {
+    auto group = makeGroupWithTwoCompleteRows();
+    group.setError("test group error");
+    TS_ASSERT(!group.requiresPostprocessing(false));
+  }
+
+  void test_requires_reprocessing_if_postprocessing_failed() {
+    auto group = makeGroupWithTwoCompleteRows();
+    group.setError("test group error");
+    TS_ASSERT(group.requiresPostprocessing(true));
+  }
+
+  void test_does_not_require_postprocessing_if_skipped() {
+    auto group = makeGroupWithTwoCompleteRows();
+    group.setSkipped(true);
+    checkDoesNotRequirePostprocessing(group);
+  }
+
+  void test_requires_postprocessing_if_reset_skipped() {
+    auto group = makeGroupWithTwoCompleteRows();
+    group.setSkipped(true);
+    group.resetSkipped();
+    checkRequiresPostprocessing(group);
+  }
+
+  /** Workspace names
+   */
+
+  void test_setting_output_name() {
+    auto group = makeEmptyGroup();
+    group.setOutputNames({"test name"});
+    TS_ASSERT_EQUALS(group.postprocessedWorkspaceName(), "test name");
+  }
+
+  void test_setting_output_names_throws_if_more_than_one_name() {
+    auto group = makeEmptyGroup();
+    TS_ASSERT_THROWS(group.setOutputNames({"test name 1", "test name 2"}), const std::runtime_error &);
+  }
+
+  void test_setting_output_names_throws_if_empty() {
+    auto group = makeEmptyGroup();
+    TS_ASSERT_THROWS(group.setOutputNames({}), const std::runtime_error &);
+  }
+
+  void test_resetting_output_names() {
+    auto group = makeEmptyGroup();
+    group.setOutputNames({"test name"});
+    group.resetOutputs();
+    TS_ASSERT_EQUALS(group.postprocessedWorkspaceName(), "");
+  }
+
+  /** Adding rows
+   */
 
   void test_append_row() {
     auto group = makeEmptyGroup();
@@ -118,5 +383,194 @@ public:
     group.insertRowSortedByAngle(rowToAdd);
     TS_ASSERT_EQUALS(group.rows().size(), 1);
     TS_ASSERT_EQUALS(group[index].is_initialized(), false);
+  }
+
+  /** Removing rows
+   */
+
+  void test_remove_row() {
+    auto group = makeGroupWithThreeRows();
+    group.removeRow(1);
+    TS_ASSERT_EQUALS(group.rows().size(), 2);
+    TS_ASSERT_EQUALS(group[0]->runNumbers(), std::vector<std::string>{"12345"});
+    TS_ASSERT_EQUALS(group[1]->runNumbers(), std::vector<std::string>{"12347"});
+  }
+
+  void test_remove_row_resets_group_state() {
+    auto group = makeGroupWithThreeRows();
+    group.setSuccess();
+    group.removeRow(1);
+    TS_ASSERT(!group.success());
+  }
+
+  /** Updating rows
+   */
+
+  void test_update_row() {
+    auto group = makeGroupWithThreeRows();
+    auto row = makeRow("22345", 1.5);
+    group.updateRow(1, row);
+    TS_ASSERT_EQUALS(group.rows().size(), 3);
+    TS_ASSERT_EQUALS(group[1]->runNumbers(), std::vector<std::string>{"22345"});
+  }
+
+  void test_update_row_resets_state() {
+    auto group = makeGroupWithThreeRows();
+    group.setSuccess();
+    auto row = makeRow("22345", 1.5);
+    group.updateRow(1, row);
+    TS_ASSERT(!group.success());
+  }
+
+  void test_update_row_does_not_reset_state_if_row_not_changed() {
+    auto group = makeGroupWithThreeRows();
+    group.setSuccess();
+    auto row = makeRow("12346", 0.2);
+    group.updateRow(1, row);
+    TS_ASSERT(group.success());
+  }
+
+  /** Row statistics
+   */
+
+  void test_item_count_for_empty_group() {
+    auto group = makeEmptyGroup();
+    TS_ASSERT_EQUALS(group.totalItems(), 0);
+  }
+
+  void test_item_count_for_group_with_one_row() {
+    auto group = makeGroupWithOneRow();
+    TS_ASSERT_EQUALS(group.totalItems(), 1);
+  }
+
+  void test_item_count_for_group_with_two_rows() {
+    auto group = makeGroupWithTwoRows();
+    // count includes postprocessing for the group, as well as the two rows
+    TS_ASSERT_EQUALS(group.totalItems(), 3);
+  }
+
+  void test_completed_item_count_for_empty_group() {
+    auto group = makeEmptyGroup();
+    TS_ASSERT_EQUALS(group.completedItems(), 0);
+  }
+
+  void test_completed_item_count_for_group_with_one_incomplete_row() {
+    auto group = makeGroupWithOneRow();
+    TS_ASSERT_EQUALS(group.completedItems(), 0);
+  }
+
+  void test_completed_item_count_for_group_with_one_complete_row() {
+    auto group = makeGroupWithOneRow();
+    group.mutableRows()[0]->setSuccess();
+    TS_ASSERT_EQUALS(group.completedItems(), 1);
+  }
+
+  void test_completed_item_count_for_group_with_two_incomplte_rows() {
+    auto group = makeGroupWithTwoRows();
+    TS_ASSERT_EQUALS(group.completedItems(), 0);
+  }
+
+  void test_completed_item_count_for_group_with_one_complte_row_out_of_two() {
+    auto group = makeGroupWithTwoRows();
+    group.mutableRows()[0]->setSuccess();
+    TS_ASSERT_EQUALS(group.completedItems(), 1);
+  }
+
+  void test_completed_item_count_for_group_with_two_complted_rows() {
+    auto group = makeGroupWithTwoRows();
+    group.mutableRows()[0]->setSuccess();
+    group.mutableRows()[1]->setSuccess();
+    TS_ASSERT_EQUALS(group.completedItems(), 2);
+  }
+
+  void test_completed_item_count_for_completed_group() {
+    auto group = makeGroupWithTwoRows();
+    group.mutableRows()[0]->setSuccess();
+    group.mutableRows()[1]->setSuccess();
+    group.setSuccess();
+    TS_ASSERT_EQUALS(group.completedItems(), 3);
+  }
+
+  /** Row lookup
+   */
+
+  void test_index_of_row_with_theta_exact_match() {
+    auto group = makeGroupWithThreeRows();
+    auto maybeIndex = group.indexOfRowWithTheta(0.2, 0.01);
+    TS_ASSERT(maybeIndex.is_initialized());
+    if (maybeIndex.is_initialized())
+      TS_ASSERT_EQUALS(*maybeIndex, 1);
+  }
+
+  void test_index_of_row_with_theta_within_tolerance() {
+    auto group = makeGroupWithThreeRows();
+    auto maybeIndex = group.indexOfRowWithTheta(0.209, 0.01);
+    TS_ASSERT(maybeIndex.is_initialized());
+    if (maybeIndex.is_initialized())
+      TS_ASSERT_EQUALS(*maybeIndex, 1);
+  }
+
+  void test_index_of_row_with_theta_outside_tolerance() {
+    auto group = makeGroupWithThreeRows();
+    auto maybeIndex = group.indexOfRowWithTheta(0.23, 0.01);
+    TS_ASSERT(!maybeIndex.is_initialized());
+  }
+
+  void test_find_row_with_output_name() {
+    auto group = makeGroupWithThreeRows();
+    // mark the row complete as an easy way to check we find the right one
+    group.mutableRows()[1]->setOutputNames({"12346_Lam", "12346_Q", "12346_QBin"});
+    group.mutableRows()[1]->setSuccess();
+    auto maybeRow = group.getItemWithOutputWorkspaceOrNone("12346_Q");
+    TS_ASSERT(maybeRow.is_initialized());
+    if (maybeRow.is_initialized())
+      TS_ASSERT(maybeRow->success());
+  }
+
+  void test_find_row_by_output_name_fails() {
+    auto group = makeGroupWithThreeRows();
+    auto maybeRow = group.getItemWithOutputWorkspaceOrNone("99999");
+    TS_ASSERT(!maybeRow.is_initialized());
+  }
+
+private:
+  Group makeGroupWithThreeRows() {
+    return Group("three_row_group", std::vector<boost::optional<Row>>{makeRow("12345", 0.1), makeRow("12346", 0.2),
+                                                                      makeRow("12347", 0.3)});
+  }
+
+  Group makeGroupWithTwoCompleteRows() {
+    auto group = makeGroupWithTwoRows();
+    group.mutableRows()[0]->setSuccess();
+    group.mutableRows()[1]->setSuccess();
+    return group;
+  }
+
+  void checkRequiresProcessing(Group const &group) {
+    TS_ASSERT(group.requiresProcessing(false));
+    TS_ASSERT(group.requiresProcessing(true));
+  }
+
+  void checkDoesNotRequireProcessing(Group const &group) {
+    TS_ASSERT(!group.requiresProcessing(false));
+    TS_ASSERT(!group.requiresProcessing(true));
+  }
+
+  void checkPostprocessingIsApplicable(Group const &group) { TS_ASSERT(group.hasPostprocessing()); }
+
+  void checkPostprocessingNotApplicable(Group const &group) {
+    TS_ASSERT(!group.hasPostprocessing());
+    TS_ASSERT(!group.requiresPostprocessing(false));
+    TS_ASSERT(!group.requiresPostprocessing(true));
+  }
+
+  void checkRequiresPostprocessing(Group const &group) {
+    TS_ASSERT(group.requiresPostprocessing(false));
+    TS_ASSERT(group.requiresPostprocessing(true));
+  }
+
+  void checkDoesNotRequirePostprocessing(Group const &group) {
+    TS_ASSERT(!group.requiresPostprocessing(false));
+    TS_ASSERT(!group.requiresPostprocessing(true));
   }
 };


### PR DESCRIPTION
This PR adds missing unit tests for the reflectometry Group class. This class contains information about a group of rows on the reflectometry GUI table, so these tests relate to editing the rows/groups, checking state etc. There is quite a bit of complexity around whether a group requires postprocessing depending on the number/validity/state of the rows it contains, which is hopefully now documented by these tests.

**To test:**

There are no functional changes, so code review only.

Fixes #29460

*This does not require release notes* because **it concerns tests only**

<!-- Ensure the base of this PR is correct (e.g. release-next or master)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
