### PR TITLE
Remove instances of AlignDetectors from ISIS powder scripts

### DIFF
--- a/scripts/Diffraction/isis_powder/gem_routines/gem_calibration_algs.py
+++ b/scripts/Diffraction/isis_powder/gem_routines/gem_calibration_algs.py
@@ -53,7 +53,9 @@ def adjust_calibration(calibration_runs, instrument, offset_file_name, grouping_
                                                            input_batching=INPUT_BATCHING.Summed)
 
     input_ws = input_ws_list[0]
-    input_ws = mantid.AlignDetectors(InputWorkspace=input_ws, CalibrationFile=original_cal)
+    mantid.ApplyDiffCal(InstrumentWorkspace=input_ws, CalibrationFile=original_cal)
+    input_ws = mantid.ConvertUnits(InputWorkspace=input_ws, Target="dSpacing")
+    mantid.ApplyDiffCal(InstrumentWorkspace=input_ws, ClearCalibration=True)
     offset_file = os.path.join(calibration_dir, offset_file_name)
     focused = _calibration_processing(calibration_dir, calibration_runs, cross_correlate_params, get_det_offset_params,
                                       grouping_file_name, input_ws, instrument, offset_file, rebin_1_params,

--- a/scripts/Diffraction/isis_powder/pearl_routines/pearl_calibration_algs.py
+++ b/scripts/Diffraction/isis_powder/pearl_routines/pearl_calibration_algs.py
@@ -45,7 +45,9 @@ def create_calibration(calibration_runs, instrument, offset_file_name, grouping_
                               OutputWorkspace=offsets_ws_name, **get_det_offset_params)
 
     rebinned_tof = mantid.ConvertUnits(InputWorkspace=rebinned, Target="TOF")
-    aligned = mantid.AlignDetectors(InputWorkspace=rebinned_tof, CalibrationFile=offset_file)
+    mantid.ApplyDiffCal(InstrumentWorkspace=rebinned_tof, CalibrationFile=offset_file)
+    aligned = mantid.ConvertUnits(InputWorkspace=rebinned_tof, Target="dSpacing")
+    mantid.ApplyDiffCal(InstrumentWorkspace=aligned, ClearCalibration=True)
 
     grouping_file = os.path.join(calibration_dir, grouping_file_name)
     focused = mantid.DiffractionFocussing(InputWorkspace=aligned, GroupingFileName=grouping_file,


### PR DESCRIPTION
**Description of work.**

There are some calls to the deprecated AlignDetectors in the ISIS powder scripts (in the calibration methods) that I'd not noticed when originally moving the AlignDetectors functionality into ConvertUnits. They're in the methods to create a calibration which aren't run as often as the focus method.

I've replaced these with "ApplyDiffCal + ConvertUnits + ApplyDiffCal" to avoid users getting a message saying there was an error (the deprecation warning) while running a calibration

**To test:**

Unzip the following zip file somewhere on your local machine:
[PEARLCalibrationTest.zip](https://github.com/mantidproject/mantid/files/6554711/PEARLCalibrationTest.zip)

Change paths in the following script to match where you unzipped the files. Run the script and check no deprecation warning or any other error created. Requires access to the ISIS data archive:
```
from mantid.simpleapi import *
import matplotlib.pyplot as plt
import numpy as np
from isis_powder.pearl import Pearl

pearl_focus = Pearl(user_name="Calib",
                           output_directory=r"C:\PEARL tests\output",   #directory above cycle number 
                           config_file=r"C:\PEARL tests\Calibration.yaml",
                           calibration_directory=r"C:\PEARL tests\Calibration_files",
                           calibration_mapping_file=r"C:\PEARL tests\Calibration_files\pearl_run_mapping.yaml")


pearl_focus.create_cal(run_number="115245-115251") #CeO2 run numbers here
```

No linked issue

*This does not require release notes* because **the deprecation of AlignDetectors was done in this release in #30163 and that is already covered in the release notes**

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
