### PR TITLE
Improved panel orientation calibration for SCDCalibratePanels2

### DIFF
--- a/Framework/Crystal/inc/MantidCrystal/SCDCalibratePanels2.h
+++ b/Framework/Crystal/inc/MantidCrystal/SCDCalibratePanels2.h
@@ -99,8 +99,8 @@ private:
   Mantid::API::MatrixWorkspace_sptr getIdealQSampleAsHistogram1D(Mantid::API::IPeaksWorkspace_sptr pws);
 
   /// Helper functions for adjusting components
-  void adjustComponent(double dx, double dy, double dz, double rvx, double rvy, double rvz, double rang,
-                       std::string cmptName, Mantid::API::IPeaksWorkspace_sptr &pws);
+  void adjustComponent(double dx, double dy, double dz, double drx, double dry, double drz, std::string cmptName,
+                       Mantid::API::IPeaksWorkspace_sptr &pws);
 
   /// Generate a Table workspace to store the calibration results
   Mantid::API::ITableWorkspace_sptr generateCalibrationTable(std::shared_ptr<Geometry::Instrument> &instrument);

--- a/Framework/Crystal/inc/MantidCrystal/SCDCalibratePanels2ObjFunc.h
+++ b/Framework/Crystal/inc/MantidCrystal/SCDCalibratePanels2ObjFunc.h
@@ -51,7 +51,7 @@ private:
                                                              std::string componentName,
                                                              Mantid::API::IPeaksWorkspace_sptr &pws) const;
 
-  Mantid::API::IPeaksWorkspace_sptr rotateInstrumentComponentBy(double rotVx, double rotVy, double rotVz, double rotAng,
+  Mantid::API::IPeaksWorkspace_sptr rotateInstrumentComponentBy(double rotX, double rotY, double rotZ,
                                                                 std::string componentName,
                                                                 Mantid::API::IPeaksWorkspace_sptr &pws) const;
 };

--- a/Framework/Crystal/inc/MantidCrystal/SCDCalibratePanels2ObjFunc.h
+++ b/Framework/Crystal/inc/MantidCrystal/SCDCalibratePanels2ObjFunc.h
@@ -44,7 +44,7 @@ private:
 
   const bool LOGCHILDALG{false};
   const Mantid::Kernel::V3D UNSET_HKL{0, 0, 0};
-  const double PI{3.1415926535897932384626433832795028841971693993751058209};
+  // const double PI{3.1415926535897932384626433832795028841971693993751058209};
 
   /// helper functions
   Mantid::API::IPeaksWorkspace_sptr moveInstruentComponentBy(double deltaX, double deltaY, double deltaZ,

--- a/Framework/Crystal/src/SCDCalibratePanels2.cpp
+++ b/Framework/Crystal/src/SCDCalibratePanels2.cpp
@@ -614,7 +614,7 @@ void SCDCalibratePanels2::optimizeBanks(IPeaksWorkspace_sptr pws, IPeaksWorkspac
     // logging
     V3D dtrans(dx, dy, dz);
     V3D drots(drx, dry, drz);
-    calilog << "-- Fit " << bn << " results using " << nBankPeaks << " peaks:\n "
+    calilog << "-- Fit " << bn << " results using " << nBankPeaks << " peaks:\n"
             << "    d(x,y,z) = " << dtrans << "\n"
             << "    r(x,y,z) = " << drots << "\n"
             << "    chi2/DOF = " << chi2OverDOF << "\n";

--- a/Framework/Crystal/src/SCDCalibratePanels2.cpp
+++ b/Framework/Crystal/src/SCDCalibratePanels2.cpp
@@ -414,7 +414,7 @@ void SCDCalibratePanels2::optimizeL1(IPeaksWorkspace_sptr pws, IPeaksWorkspace_s
   //-- bounds&constraints def
   std::ostringstream tie_str;
   tie_str << "DeltaX=0.0,DeltaY=0.0,"
-          << "Theta=1.0,Phi=0.0,DeltaRotationAngle=0.0";
+          << "RotX=0.0,RotY=0.0,RotZ=0.0";
   if (!tuneSamplepos) {
     tie_str << ",DeltaSampleX=0.0,DeltaSampleY=0.0,DeltaSampleZ=0.0";
   }
@@ -661,7 +661,7 @@ void SCDCalibratePanels2::optimizeT0(IPeaksWorkspace_sptr pws, IPeaksWorkspace_s
   //-- bounds&constraints def
   std::ostringstream tie_str;
   tie_str << "DeltaX=0.0,DeltaY=0.0,DeltaZ=0.0,"
-          << "Theta=0.0,Phi=0.0,DeltaRotationAngle=0.0,"
+          << "RotX=0.0,RotY=0.0,RotZ=0.0,"
           << "DeltaSampleX=0.0,DeltaSampleY=0.0,DeltaSampleZ=0.0";
   std::ostringstream constraint_str;
   double r_dT0 = getProperty("SearchRadiusT0");
@@ -719,7 +719,7 @@ void SCDCalibratePanels2::optimizeSamplePos(IPeaksWorkspace_sptr pws, IPeaksWork
   //-- bounds&constraints def
   std::ostringstream tie_str;
   tie_str << "DeltaX=0.0,DeltaY=0.0,DeltaZ=0.0,"
-          << "Theta=0.0,Phi=0.0,DeltaRotationAngle=0.0,"
+          << "RotX=0.0,RotY=0.0,RotZ=0.0,"
           << "DeltaT0=" << m_T0;
   std::ostringstream constraint_str;
   double r_dsp = getProperty("SearchRadiusSamplePos");

--- a/Framework/Crystal/src/SCDCalibratePanels2.cpp
+++ b/Framework/Crystal/src/SCDCalibratePanels2.cpp
@@ -926,10 +926,19 @@ MatrixWorkspace_sptr SCDCalibratePanels2::getIdealQSampleAsHistogram1D(IPeaksWor
     V3D qv = ubmatrix * pws->getPeak(i).getIntHKL();
     qv *= 2 * PI;
     // qv = qv / qv.norm();
+    double wgt = 1.0;
+    if (pws->getPeak(i).getSigmaIntensity() > 0.0) {
+      wgt = 1.0 / pws->getPeak(i).getSigmaIntensity();
+    } else if (pws->getPeak(i).getIntensity() > 0.0) {
+      wgt = 1.0 / pws->getPeak(i).getIntensity();
+    } else if (pws->getPeak(i).getBinCount()) {
+      wgt = 1.0 / pws->getPeak(i).getBinCount();
+    }
+    // make 1dhist
     for (int j = 0; j < 3; ++j) {
       xvector[i * 3 + j] = i * 3 + j;
       yvector[i * 3 + j] = qv[j];
-      evector[i * 3 + j] = 1;
+      evector[i * 3 + j] = wgt;
     }
   }
 

--- a/Framework/Crystal/src/SCDCalibratePanels2.cpp
+++ b/Framework/Crystal/src/SCDCalibratePanels2.cpp
@@ -487,9 +487,9 @@ void SCDCalibratePanels2::optimizeL1(IPeaksWorkspace_sptr pws, IPeaksWorkspace_s
   }
 
   // apply the cali results (for output cali table and file)
-  adjustComponent(0.0, 0.0, dL1_optimized, 1.0, 0.0, 0.0, 0.0, pws->getInstrument()->getSource()->getName(), pws);
+  adjustComponent(0.0, 0.0, dL1_optimized, 0.0, 0.0, 0.0, pws->getInstrument()->getSource()->getName(), pws);
   m_T0 = dT0_optimized;
-  adjustComponent(dsx_optimized, dsy_optimized, dsz_optimized, 1.0, 0.0, 0.0, 0.0, "sample-position", pws);
+  adjustComponent(dsx_optimized, dsy_optimized, dsz_optimized, 0.0, 0.0, 0.0, "sample-position", pws);
   // logging
   int npks = pws->getNumberPeaks();
   calilog << "-- Fit L1 results using " << npks << " peaks:\n"
@@ -754,7 +754,7 @@ void SCDCalibratePanels2::optimizeSamplePos(IPeaksWorkspace_sptr pws, IPeaksWork
   }
 
   // apply the calibration results to pws for ouptut file
-  adjustComponent(dsx_optimized, dsy_optimized, dsz_optimized, 1.0, 0.0, 0.0, 0.0, "sample-position", pws);
+  adjustComponent(dsx_optimized, dsy_optimized, dsz_optimized, 0.0, 0.0, 0.0, "sample-position", pws);
   int npks = pws->getNumberPeaks();
   // logging
   calilog << "-- Tune SamplePos results using " << npks << " peaks:\n"

--- a/Framework/Crystal/src/SCDCalibratePanels2.cpp
+++ b/Framework/Crystal/src/SCDCalibratePanels2.cpp
@@ -560,7 +560,7 @@ void SCDCalibratePanels2::optimizeBanks(IPeaksWorkspace_sptr pws, IPeaksWorkspac
                      << -searchRadiusRot << "<RotY<" << searchRadiusRot << ","  // constrain rotation around Y-axis
                      << -searchRadiusRot << "<RotZ<" << searchRadiusRot << ","; // constrain rotation around Z-axis
     }
-    if (searchRadiusTran) {
+    if (searchRadiusTran < 1e-16) {
       tie_str << ",DeltaX=0.0,DeltaY=0.0,DeltaZ=0.0";
     } else {
       constraint_str << -searchRadiusTran << "<DeltaX<" << searchRadiusTran << "," // restrict tranlastion along X
@@ -960,7 +960,7 @@ MatrixWorkspace_sptr SCDCalibratePanels2::getIdealQSampleAsHistogram1D(IPeaksWor
     for (int j = 0; j < 3; ++j) {
       xvector[i * 3 + j] = i * 3 + j;
       yvector[i * 3 + j] = qv[j];
-      evector[i * 3 + j] = wgt * qv.norm();
+      evector[i * 3 + j] = wgt;
     }
   }
 

--- a/Framework/Crystal/src/SCDCalibratePanels2ObjFunc.cpp
+++ b/Framework/Crystal/src/SCDCalibratePanels2ObjFunc.cpp
@@ -39,16 +39,14 @@ DECLARE_FUNCTION(SCDCalibratePanels2ObjFunc)
 /// Core functions ///
 /// ---------------///
 SCDCalibratePanels2ObjFunc::SCDCalibratePanels2ObjFunc() {
-  // parameters
-  declareParameter("DeltaX", 0.0, "relative shift along X");
-  declareParameter("DeltaY", 0.0, "relative shift along Y");
-  declareParameter("DeltaZ", 0.0, "relative shift along Z");
-  // rotation axis is defined as (1, theta, phi)
-  // https://en.wikipedia.org/wiki/Spherical_coordinate_system
-  declareParameter("Theta", PI / 4, "Polar coordinates theta in radians");
-  declareParameter("Phi", PI / 4, "Polar coordinates phi in radians");
-  // rotation angle
-  declareParameter("DeltaRotationAngle", 0.0, "angle of relative rotation in degree");
+  // parameters for translation
+  declareParameter("DeltaX", 0.0, "relative shift along X in meter");
+  declareParameter("DeltaY", 0.0, "relative shift along Y in meter");
+  declareParameter("DeltaZ", 0.0, "relative shift along Z in meter");
+  // parameters for rotation
+  declareParameter("RotX", 0.0, "relative rotation around X in degree");
+  declareParameter("RotY", 0.0, "relative rotation around Y in degree");
+  declareParameter("RotZ", 0.0, "relative rotation around Z in degree");
   // TOF offset for all peaks
   // NOTE: need to have a non-zero value here
   declareParameter("DeltaT0", 0.1, "delta of TOF");
@@ -92,21 +90,14 @@ void SCDCalibratePanels2ObjFunc::function1D(double *out, const double *xValues, 
   const double dx = getParameter("DeltaX");
   const double dy = getParameter("DeltaY");
   const double dz = getParameter("DeltaZ");
-  //-- delta in rotation/orientation as angle axis pair
-  //   using polar coordinates to ensure a unit vector
-  //   (r, theta, phi) where r=1
-  const double theta = getParameter("Theta");
-  const double phi = getParameter("Phi");
-  // compute the rotation axis
-  double vx = sin(theta) * cos(phi);
-  double vy = sin(theta) * sin(phi);
-  double vz = cos(theta);
-  //
-  const double drotang = getParameter("DeltaRotationAngle");
+  //-- delta in rotation
+  const double drx = getParameter("RotX");
+  const double dry = getParameter("RotY");
+  const double drz = getParameter("RotZ");
   //-- delta in TOF
   //  NOTE: The T0 here is a universal offset for all peaks
   double dT0 = getParameter("DeltaT0");
-  //
+  //-- delta of sample position
   const double dsx = getParameter("DeltaSampleX");
   const double dsy = getParameter("DeltaSampleY");
   const double dsz = getParameter("DeltaSampleZ");
@@ -129,18 +120,18 @@ void SCDCalibratePanels2ObjFunc::function1D(double *out, const double *xValues, 
   bool calibrateT0 = (m_cmpt == "none/sixteenpack") || (m_cmpt == "none");
   // we don't need to move the instrument if we are calibrating T0
   if (!calibrateT0) {
-    // rotation
-    pws = rotateInstrumentComponentBy(vx, vy, vz, drotang, m_cmpt, pws);
-
     // translation
     pws = moveInstruentComponentBy(dx, dy, dz, m_cmpt, pws);
+
+    // rotation
+    pws = rotateInstrumentComponentBy(drx, dry, drz, m_cmpt, pws);
   }
 
   // tweak sample position
   pws = moveInstruentComponentBy(dsx, dsy, dsz, "sample-position", pws);
 
   // calculate residual
-  // double residual = 0.0;
+  double residual = 0.0;
   for (int i = 0; i < pws->getNumberPeaks(); ++i) {
     // use the provided cached tofs
     const double tof = m_tofs[i];
@@ -165,25 +156,25 @@ void SCDCalibratePanels2ObjFunc::function1D(double *out, const double *xValues, 
       out[i * 3 + j] = qv[j];
 
     // check the difference between n and target
-    // auto ubm = pws->sample().getOrientedLattice().getUB();
-    // V3D qv_target = ubm * pws->getPeak(i).getIntHKL();
-    // qv_target *= 2 * PI;
-    // V3D delta_qv = qv - qv_target;
-    // residual += delta_qv.norm2();
+    auto ubm = pws->sample().getOrientedLattice().getUB();
+    V3D qv_target = ubm * pws->getPeak(i).getIntHKL();
+    qv_target *= 2 * PI;
+    V3D delta_qv = qv - qv_target;
+    residual += delta_qv.norm2();
   }
 
   n_iter += 1;
 
-  // V3D dtrans = V3D(dx, dy, dz);
-  // V3D rotaxis = V3D(vx, vy, vz);
-  // residual /= pws->getNumberPeaks();
-  // std::ostringstream msgiter;
-  // msgiter.precision(8);
-  // msgiter << "residual@iter_" << n_iter << ": " << residual << "\n"
-  //         << "-- (dx, dy, dz) = " << dtrans << "\n"
-  //         << "-- ang@axis = " << drotang << "@" << rotaxis << "\n"
-  //         << "-- dT0 = " << dT0 << "\n\n";
-  // g_log.notice() << msgiter.str();
+  V3D dtrans = V3D(dx, dy, dz);
+  V3D drots = V3D(drx, dry, drz);
+  residual /= pws->getNumberPeaks();
+  std::ostringstream msgiter;
+  msgiter.precision(8);
+  msgiter << "residual@iter_" << n_iter << ": " << residual << "\n"
+          << "-- (dx, dy, dz) = " << dtrans << "\n"
+          << "-- (drx, dry, drz) = " << drots << "\n"
+          << "-- dT0 = " << dT0 << "\n\n";
+  g_log.notice() << msgiter.str();
 }
 
 // -------///
@@ -224,29 +215,52 @@ IPeaksWorkspace_sptr SCDCalibratePanels2ObjFunc::moveInstruentComponentBy(double
 /**
  * @brief Rotate the instrument by angle axis
  *
- * @param rotVx  :: x of rotation axis
- * @param rotVy  :: y of rotation axis
- * @param rotVz  :: z of rotation axis
- * @param rotAng  :: rotation angle (in degree)
+ * @param rotX  :: rotate around X
+ * @param rotY  :: rotate around Y
+ * @param rotZ  :: rotate around Z
  * @param componentName  :: component name
  * @param pws  :: peak workspace
  * @return IPeaksWorkspace_sptr
  */
-IPeaksWorkspace_sptr SCDCalibratePanels2ObjFunc::rotateInstrumentComponentBy(double rotVx, double rotVy, double rotVz,
-                                                                             double rotAng, std::string componentName,
+IPeaksWorkspace_sptr SCDCalibratePanels2ObjFunc::rotateInstrumentComponentBy(double rotX, double rotY, double rotZ,
+                                                                             std::string componentName,
                                                                              IPeaksWorkspace_sptr &pws) const {
   // rotate
   IAlgorithm_sptr rot_alg = Mantid::API::AlgorithmFactory::Instance().create("RotateInstrumentComponent", -1);
-  //
+  // around X
   rot_alg->initialize();
   rot_alg->setChild(true);
   rot_alg->setLogging(LOGCHILDALG);
   rot_alg->setProperty("Workspace", pws);
   rot_alg->setProperty("ComponentName", componentName);
-  rot_alg->setProperty("X", rotVx);
-  rot_alg->setProperty("Y", rotVy);
-  rot_alg->setProperty("Z", rotVz);
-  rot_alg->setProperty("Angle", rotAng);
+  rot_alg->setProperty("X", 1.0);
+  rot_alg->setProperty("Y", 0.0);
+  rot_alg->setProperty("Z", 0.0);
+  rot_alg->setProperty("Angle", rotX);
+  rot_alg->setProperty("RelativeRotation", true);
+  rot_alg->executeAsChildAlg();
+  // around Y
+  rot_alg->initialize();
+  rot_alg->setChild(true);
+  rot_alg->setLogging(LOGCHILDALG);
+  rot_alg->setProperty("Workspace", pws);
+  rot_alg->setProperty("ComponentName", componentName);
+  rot_alg->setProperty("X", 0.0);
+  rot_alg->setProperty("Y", 1.0);
+  rot_alg->setProperty("Z", 0.0);
+  rot_alg->setProperty("Angle", rotY);
+  rot_alg->setProperty("RelativeRotation", true);
+  rot_alg->executeAsChildAlg();
+  // around Z
+  rot_alg->initialize();
+  rot_alg->setChild(true);
+  rot_alg->setLogging(LOGCHILDALG);
+  rot_alg->setProperty("Workspace", pws);
+  rot_alg->setProperty("ComponentName", componentName);
+  rot_alg->setProperty("X", 0.0);
+  rot_alg->setProperty("Y", 0.0);
+  rot_alg->setProperty("Z", 1.0);
+  rot_alg->setProperty("Angle", rotZ);
   rot_alg->setProperty("RelativeRotation", true);
   rot_alg->executeAsChildAlg();
 

--- a/Framework/Crystal/src/SCDCalibratePanels2ObjFunc.cpp
+++ b/Framework/Crystal/src/SCDCalibratePanels2ObjFunc.cpp
@@ -131,7 +131,7 @@ void SCDCalibratePanels2ObjFunc::function1D(double *out, const double *xValues, 
   pws = moveInstruentComponentBy(dsx, dsy, dsz, "sample-position", pws);
 
   // calculate residual
-  double residual = 0.0;
+  // double residual = 0.0;
   for (int i = 0; i < pws->getNumberPeaks(); ++i) {
     // use the provided cached tofs
     const double tof = m_tofs[i];
@@ -156,25 +156,25 @@ void SCDCalibratePanels2ObjFunc::function1D(double *out, const double *xValues, 
       out[i * 3 + j] = qv[j];
 
     // check the difference between n and target
-    auto ubm = pws->sample().getOrientedLattice().getUB();
-    V3D qv_target = ubm * pws->getPeak(i).getIntHKL();
-    qv_target *= 2 * PI;
-    V3D delta_qv = qv - qv_target;
-    residual += delta_qv.norm2();
+    // auto ubm = pws->sample().getOrientedLattice().getUB();
+    // V3D qv_target = ubm * pws->getPeak(i).getIntHKL();
+    // qv_target *= 2 * PI;
+    // V3D delta_qv = qv - qv_target;
+    // residual += delta_qv.norm2();
   }
 
   n_iter += 1;
 
-  V3D dtrans = V3D(dx, dy, dz);
-  V3D drots = V3D(drx, dry, drz);
-  residual /= pws->getNumberPeaks();
-  std::ostringstream msgiter;
-  msgiter.precision(8);
-  msgiter << "residual@iter_" << n_iter << ": " << residual << "\n"
-          << "-- (dx, dy, dz) = " << dtrans << "\n"
-          << "-- (drx, dry, drz) = " << drots << "\n"
-          << "-- dT0 = " << dT0 << "\n\n";
-  g_log.notice() << msgiter.str();
+  // V3D dtrans = V3D(dx, dy, dz);
+  // V3D drots = V3D(drx, dry, drz);
+  // residual /= pws->getNumberPeaks();
+  // std::ostringstream msgiter;
+  // msgiter.precision(8);
+  // msgiter << "residual@iter_" << n_iter << ": " << residual << "\n"
+  //         << "-- (dx, dy, dz) = " << dtrans << "\n"
+  //         << "-- (drx, dry, drz) = " << drots << "\n"
+  //         << "-- dT0 = " << dT0 << "\n\n";
+  // g_log.notice() << msgiter.str();
 }
 
 // -------///

--- a/docs/source/release/v6.2.0/diffraction.rst
+++ b/docs/source/release/v6.2.0/diffraction.rst
@@ -35,7 +35,7 @@ New features
 Improvements
 ############
 - Find detector in peaks will check which det is closer when dealing with peak-in-gap situation for tube-type detectors.
-- Existing :ref:`SCDCalibratePanels2 <algm-SCDCalibratePanels2>` now provides better calibration of panel orientation for flat panel detectors.
+- Existing :ref:`SCDCalibratePanels <algm-SCDCalibratePanels-v2>` now provides better calibration of panel orientation for flat panel detectors.
 
 Bugfixes
 ########

--- a/docs/source/release/v6.2.0/diffraction.rst
+++ b/docs/source/release/v6.2.0/diffraction.rst
@@ -35,6 +35,7 @@ New features
 Improvements
 ############
 - Find detector in peaks will check which det is closer when dealing with peak-in-gap situation for tube-type detectors.
+- Existing :ref:`SCDCalibratePanels2 <algm-SCDCalibratePanels2>` now provides better calibration of panel orientation for flat panel detectors.
 
 Bugfixes
 ########


### PR DESCRIPTION
**Description of work.**

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

- Related Gitlab story: [SCD334](https://code.ornl.gov/sns-hfir-scse/diffraction/single-crystal/single-crystal-diffraction/-/issues/334)
- This is #31599 into `master`

**To test:**

- use the following script to generate a synthetic data based on TOPAZ geometry

```python
from mantid.simpleapi import *
from mantid.geometry import CrystalStructure
import matplotlib.pyplot as plt
import numpy as np

from collections import namedtuple

def convert(dictionary):
    return namedtuple('GenericDict', dictionary.keys())(**dictionary)

lc_natrolite = {
    "a": 18.29,  # A
    "b": 18.64,  # A
    "c": 6.56,  # A
    "alpha": 90,  # deg
    "beta": 90,  # deg
    "gamma": 90,  # deg
}
natrolite = convert(lc_natrolite)

CreateSimulationWorkspace(
    Instrument='TOPAZ',
    BinParams='1,100,10000',
    UnitX='TOF',
    OutputWorkspace='cws',
)
cws = mtd['cws']

# Set the UB matrix for the sample
# u, v is the critical part, we can start with the
# ideal position
SetUB(
    Workspace="cws",
    u='1,0,0',  # vector along k_i, when goniometer is at 0
    v='0,1,0',  # in-plane vector normal to k_i, when goniometer is at 0
    **lc_natrolite,
)

# Generate predicted peak workspace
dspacings = convert({'min': 1.0, 'max': 10.0})
wavelengths = convert({'min': 0.8, 'max': 2.9})

# Collect peaks over a range of omegas
CreatePeaksWorkspace(OutputWorkspace='pws')
omegas = range(0, 180, 3)

for omega in omegas:
    SetGoniometer(
        Workspace="cws",
        Axis0=f"{omega},0,1,0,1",
    )

    PredictPeaks(
        InputWorkspace='cws',
        WavelengthMin=wavelengths.min,
        wavelengthMax=wavelengths.max,
        MinDSpacing=dspacings.min,
        MaxDSpacing=dspacings.max,
        ReflectionCondition='All-face centred',
        OutputWorkspace='_pws',
    )

    CombinePeaksWorkspaces(
        LHSWorkspace="_pws",
        RHSWorkspace="pws",
        OutputWorkspace="pws",
    )

IndexPeaks("pws")
```
- isolate one bank (using bank47 as an example) and move the instrument off the correct position (engineering position)
```python
FilterPeaks(InputWorkspace='pws', OutputWorkspace='pws_bank47', FilterVariable='h^2+k^2+l^2', FilterValue=0, Operator='>', BankName='bank47')
MoveInstrumentComponent(Workspace='pws_bank47', ComponentName='bank47', X=0.01, Y=0.01, Z=-0.03)
RotateInstrumentComponent(Workspace='pws_bank47', ComponentName='bank47', X=1, Angle=0.5)
RotateInstrumentComponent(Workspace='pws_bank47', ComponentName='bank47', Y=1, Angle=0.2)
RotateInstrumentComponent(Workspace='pws_bank47', ComponentName='bank47', Z=1, Angle=0.1)
```

- invoke SCDCalibratePanels2
```python
SCDCalibratePanels(
PeakWorkspace='pws_bank47', 
CalibrateL1=False,
CalibrateBanks=True, 
ToleranceRotBank=1e-08,
OutputWorkspace='pws_caliL1', 
VerboseOutput=True)
```
which should provide an output like the following
```
** Calibrating L2 and orientation (bank) as requested
-- Fit bank47 results using 452 peaks:
    d(x,y,z) = [-0.0100763,-0.00998758,0.0299996]
    r(x,y,z) = [-0.495348,-0.181907,-0.0881157]
    chi2/DOF = 1.55534e-06
```

> since we translate bank47 off its correct location by (0.01, 0.01, -0.03), `SCDCalibratePanels2` is telling us to move bank47 by (-0.0100763,-0.00998758,0.0299996) to get closer to the correct location (which if slightly off when compared with the answer).

> since we rotate bank47 by EulerAngle (0.5,0.2,0.1) (convention XYZ) to move off the correct orientation, `SCDCalibratePanels2` is telling us to rotate by (-0.495348,-0.181907,-0.0881157) to bring it to the correct orientation (which is also slightly off)


<!-- Instructions for testing. -->
<!-- and fix #xxxx or close #xxxx xor resolves #xxxx -->
<!-- alternative
*There is no associated issue.*
-->

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or master)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
