### PR TITLE
Add missing SANS test back to CMake lists

### DIFF
--- a/scripts/SANS/sans/user_file/toml_parsers/toml_v1_parser.py
+++ b/scripts/SANS/sans/user_file/toml_parsers/toml_v1_parser.py
@@ -253,7 +253,7 @@ class _TomlV1ParserImpl(TomlParserImplBase):
         events_binning = self.get_val(["events", "binning"], reduction_dict, default="")
         if (events_binning and len(events_binning.split(',')) != 3) or \
                 self.instrument is SANSInstrument.ZOOM and not events_binning:
-            raise ValueError("Events.binning: Three comma separated values are required")
+            raise ValueError(f"Events.binning: Three comma separated values are required, got '{events_binning}'")
         self.compatibility.time_rebin_string = events_binning
 
         merge_range_dict = self.get_val(["merged", "merge_range"], reduction_dict)
@@ -376,7 +376,7 @@ class _TomlV1ParserImpl(TomlParserImplBase):
 
         # Mandatory as its subtle if missing
         monitor_spec_num = monitor_dict["spectrum_number"]
-        background = self.get_val("background", monitor_dict, )
+        background = self.get_val("background", monitor_dict)
 
         self.normalize_to_monitor.incident_monitor = monitor_spec_num
 

--- a/scripts/test/SANS/user_file/CMakeLists.txt
+++ b/scripts/test/SANS/user_file/CMakeLists.txt
@@ -11,4 +11,5 @@ check_tests_valid(${CMAKE_CURRENT_SOURCE_DIR} ${TEST_PY_FILES})
 pyunittest_add_test(${CMAKE_CURRENT_SOURCE_DIR} python.SANS.user_file
                     ${TEST_PY_FILES})
 
+add_subdirectory(toml_parsers)
 add_subdirectory(txt_parsers)

--- a/scripts/test/SANS/user_file/toml_parsers/CMakeLists.txt
+++ b/scripts/test/SANS/user_file/toml_parsers/CMakeLists.txt
@@ -1,7 +1,7 @@
 set(TEST_PY_FILES
     toml_parser_test.py
     toml_v1_parser_test.py
-    TomlV1ParserTest.py
+    toml_v1_schema_test.py
 )
 
 add_subdirectory(parser_helpers)

--- a/scripts/test/SANS/user_file/toml_parsers/parser_helpers/CMakeLists.txt
+++ b/scripts/test/SANS/user_file/toml_parsers/parser_helpers/CMakeLists.txt
@@ -3,8 +3,5 @@ set(TEST_PY_FILES
     wavelength_parser_test.py
 )
 
-add_subdirectory(parser_helpers)
-
 check_tests_valid(${CMAKE_CURRENT_SOURCE_DIR} ${TEST_PY_FILES})
-
 pyunittest_add_test(${CMAKE_CURRENT_SOURCE_DIR} python.SANS.user_file.txt_parsers ${TEST_PY_FILES})

--- a/scripts/test/SANS/user_file/toml_parsers/parser_helpers/wavelength_parser_test.py
+++ b/scripts/test/SANS/user_file/toml_parsers/parser_helpers/wavelength_parser_test.py
@@ -14,29 +14,29 @@ from sans.user_file.parser_helpers.wavelength_parser import parse_range_waveleng
 
 class WavelengthParserTest(unittest.TestCase):
     def test_parse_range_wavelength(self):
-        wav_start, wav_stop = parse_range_wavelength("2:2:10")
+        wav_full_range, wav_pairs = parse_range_wavelength("2:2:10")
         # 2-10 in steps of 2
-        self.assertEqual([2.0, 2.0, 4.0, 6.0, 8.0], wav_start)
-        self.assertEqual([10.0, 4.0, 6.0, 8.0, 10.0], wav_stop)
+        self.assertEqual((2.0, 10.0), wav_full_range)
+        self.assertEqual([(2., 4.), (4., 6.), (6., 8.), (8., 10.), (2., 10.)], wav_pairs)
 
     def test_parse_range_wavelength_dashes(self):
-        wav_start, wav_stop = parse_range_wavelength("2-5, 6-10")
-        self.assertEqual([2.0, 2.0, 6.0], wav_start)
-        self.assertEqual([10.0, 5.0, 10.0], wav_stop)
+        wav_full_range, wav_pairs = parse_range_wavelength("2-5, 6-10")
+        self.assertEqual((2., 10.), wav_full_range)
+        self.assertEqual([(2., 5.), (6., 10.), (2., 10.)], wav_pairs)
 
         # Should also handle flipped
-        wav_start, wav_stop = parse_range_wavelength("6-10, 2-5")
-        self.assertEqual([2.0, 6.0, 2.0], wav_start)
-        self.assertEqual([10.0, 10.0, 5.0], wav_stop)
+        wav_full_range, wav_pairs = parse_range_wavelength("6-10, 2-5")
+        self.assertEqual((2., 10.), wav_full_range)
+        self.assertEqual([(6., 10.), (2., 5.), (2., 10.)], wav_pairs)
 
     def test_wavelength_multiple_commas(self):
         # This is a legacy input which isn't documented in the current GUI
         # but some scientists still use from the older SANS GUI
 
         # Equiv to 1-3, 3-5, 5-7, 7-11
-        wav_start, wav_stop = parse_range_wavelength("1,3 ,5, 7,11")  # Random spacing intentional
-        self.assertEqual([1.0, 1.0, 3.0, 5.0, 7.0], wav_start)
-        self.assertEqual([11.0, 3.0, 5.0, 7.0, 11.0], wav_stop)
+        wav_full_range, wav_pairs = parse_range_wavelength("1,3 ,5, 7,11")  # Random spacing intentional
+        self.assertEqual((1., 11.), wav_full_range)
+        self.assertEqual([(1., 3.), (3., 5.), (5., 7.), (7., 11.), (1., 11.0)], wav_pairs)
 
     @staticmethod
     def _get_wavelength_objs():
@@ -47,8 +47,8 @@ class WavelengthParserTest(unittest.TestCase):
     def _assert_wav_objs(self, state_objs: DuplicateWavelengthStates,
                          wav_high, wav_low, range_type, step_size=None):
         for i in state_objs.iterate_fields():
-            self.assertEqual(wav_high, i.wavelength_high)
-            self.assertEqual(wav_low, i.wavelength_low)
+            self.assertEqual(wav_high, i.wavelength_interval.wavelength_full_range[1])
+            self.assertEqual(wav_low, i.wavelength_interval.wavelength_full_range[0])
             self.assertEqual(range_type, i.wavelength_step_type)
             if step_size:
                 self.assertEqual(step_size, i.wavelength_interval.wavelength_step)
@@ -61,17 +61,20 @@ class WavelengthParserTest(unittest.TestCase):
         wav_objs = self._get_wavelength_objs()
         WavelengthTomlParser(input_dict).set_wavelength_details(wav_objs)
 
-        self._assert_wav_objs(wav_objs, wav_low=[1.0], wav_high=[10.0],
+        self._assert_wav_objs(wav_objs, wav_low=1.0, wav_high=10.0,
                               range_type=RangeStepType.LIN, step_size=2.0)
 
     def test_rangelin_wavelength_setting(self):
         input_dict = {"binning": {"wavelength": {"type": "RangeLin",
-                                                 "binning": "1-3,4-6"}}}
+                                                 "binning": "1-3,4-6",
+                                                 "step": "0.5"}}}
         wav_objs = self._get_wavelength_objs()
         WavelengthTomlParser(input_dict).set_wavelength_details(wav_objs)
 
         self._assert_wav_objs(wav_objs, range_type=RangeStepType.RANGE_LIN,
-                              wav_low=[1.0, 1.0, 4.0], wav_high=[6.0, 3.0, 6.0])
+                              wav_low=1., wav_high=6.)
+        self.assertEqual([(1., 3.), (4., 6.), (1., 6.0)],  wav_objs.wavelength.wavelength_interval.selected_ranges)
+        self.assertEqual(0.5, wav_objs.wavelength.wavelength_interval.wavelength_step)
 
     def test_can_handle_no_wavelength(self):
         input_dict = {"binning": {"another_field": None}}

--- a/scripts/test/SANS/user_file/toml_parsers/toml_v1_parser_test.py
+++ b/scripts/test/SANS/user_file/toml_parsers/toml_v1_parser_test.py
@@ -111,8 +111,7 @@ class TomlV1ParserTest(unittest.TestCase):
         for bin_type in ["Lin", "Log"]:
             wavelength_dict = {"binning": {"wavelength": {"start": 1.1, "step": 0.1, "stop": 2.2, "type": bin_type}}}
             wavelength = self._setup_parser(wavelength_dict).get_state_wavelength()
-            self.assertEqual([1.1], wavelength.wavelength_low)
-            self.assertEqual([2.2], wavelength.wavelength_high)
+            self.assertEqual((1.1, 2.2), wavelength.wavelength_interval.wavelength_full_range)
             self.assertEqual(0.1, wavelength.wavelength_interval.wavelength_step)
             self.assertEqual(RangeStepType(bin_type), wavelength.wavelength_step_type)
 
@@ -146,7 +145,7 @@ class TomlV1ParserTest(unittest.TestCase):
 
         events_dict = top_level_dict["reduction"]["events"]
 
-        expected_binning = "expected_binning"
+        expected_binning = "1,1,10"
         events_dict["binning"] = expected_binning
 
         parsed_obj = self._setup_parser(top_level_dict)
@@ -353,11 +352,6 @@ class TomlV1ParserTest(unittest.TestCase):
         self.assertEqual({'2': 800}, calc_transmission.background_TOF_monitor_stop)
 
         top_level_dict["normalisation"]["selected_monitor"] = "NotThere"
-        with self.assertRaises(KeyError):
-            self._setup_parser(top_level_dict)
-
-        del a2_dict["background"]
-        top_level_dict["normalisation"]["selected_monitor"] = "A2"
         with self.assertRaises(KeyError):
             self._setup_parser(top_level_dict)
 

--- a/scripts/test/SANS/user_file/toml_parsers/toml_v1_schema_test.py
+++ b/scripts/test/SANS/user_file/toml_parsers/toml_v1_schema_test.py
@@ -6,8 +6,8 @@
 # SPDX - License - Identifier: GPL - 3.0 +
 import unittest
 
-from mantid.py3compat import mock
-from sans.user_file.toml_parsers.toml_v1_schema import TomlSchemaV1Validator
+from unittest import mock
+from sans.user_file.toml_parsers.toml_v1_schema import TomlSchemaV1Validator, TomlValidationError
 
 
 class SchemaV1ValidatorTest(unittest.TestCase):
@@ -39,19 +39,19 @@ class SchemaV1ValidatorTest(unittest.TestCase):
     def test_throws_if_unrecognised_top_level_key(self):
         for i in [{"NotRecognised": None}, {"Foo": {"Bar": None}}]:
             obj = TomlSchemaV1Validator(i)
-            with self.assertRaises(KeyError):
+            with self.assertRaises(TomlValidationError):
                 obj.validate()
 
     def test_all_unknown_keys_mentioned(self):
         obj = TomlSchemaV1Validator({"A": None, "B": None})
-        with self.assertRaises(KeyError) as e:
+        with self.assertRaises(TomlValidationError) as e:
             obj.validate()
             self.assertTrue("A" in e)
             self.assertTrue("B" in e)
 
     def test_sub_key_checked(self):
         obj = TomlSchemaV1Validator({"instrument": "Foo"})
-        with self.assertRaises(KeyError):
+        with self.assertRaises(TomlValidationError):
             obj.validate()
 
     def test_valid_key_accepted(self):
@@ -69,5 +69,9 @@ class SchemaV1ValidatorTest(unittest.TestCase):
         obj = TomlSchemaV1Validator(valid_example)
         self.assertIsNone(obj.validate())
 
-        with self.assertRaises(KeyError):
+        with self.assertRaises(TomlValidationError):
             TomlSchemaV1Validator(invalid_example).validate()
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
**Description of work.**
Whilst running Pytest locally I noticed some tests were broken. In short
we haven't been running these due to various CMake issues, so I've added
them back / fixed up.

In most cases it's because of refactoring work that things have broken.
In one or two other cases the strictness of the validation has been
reduced based on user feedback, so the extra tests aren't required
anymore.

Long term we should look into tooling to detect "lost" tests and
automatically error a build until they are added in correctly

**To test:**
- Code Review
- Ensure tests pass


*There is no associated issue.*


<!-- Ensure the base of this PR is correct (e.g. release-next or master)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
