### PR TITLE
Project Save: Plots should dynamically fill tick properties based on if values are present

### DIFF
--- a/qt/python/mantidqt/project/plotssaver.py
+++ b/qt/python/mantidqt/project/plotssaver.py
@@ -283,48 +283,51 @@ class PlotsSaver(object):
         yaxis_major_kw = ax.yaxis._major_tick_kw
         yaxis_minor_kw = ax.yaxis._minor_tick_kw
 
-        return {
+        tick_dict = {
             "xaxis": {
                 "major": {
                     "bottom": xaxis_major_kw['tick1On'],
                     "top": xaxis_major_kw['tick2On'],
                     "labelbottom": xaxis_major_kw['label1On'],
-                    "labeltop": xaxis_major_kw['label2On'],
-                    "direction": xaxis_major_kw['tickdir'],
-                    "width": xaxis_major_kw['width'],
-                    "size": xaxis_major_kw['size']
+                    "labeltop": xaxis_major_kw['label2On']
                 },
                 "minor": {
                     "bottom": xaxis_minor_kw['tick1On'],
                     "top": xaxis_minor_kw['tick2On'],
                     "labelbottom": xaxis_minor_kw['label1On'],
-                    "labeltop": xaxis_minor_kw['label2On'],
-                    "direction": xaxis_minor_kw['tickdir'],
-                    "width": xaxis_minor_kw['width'],
-                    "size": xaxis_minor_kw['size']
-                },
+                    "labeltop": xaxis_minor_kw['label2On']
+                }
             },
             "yaxis": {
                 "major": {
                     "left": yaxis_major_kw['tick1On'],
                     "right": yaxis_major_kw['tick2On'],
                     "labelleft": yaxis_major_kw['label1On'],
-                    "labelright": yaxis_major_kw['label2On'],
-                    "direction": yaxis_major_kw['tickdir'],
-                    "width": yaxis_major_kw['width'],
-                    "size": yaxis_major_kw['size']
+                    "labelright": yaxis_major_kw['label2On']
                 },
                 "minor": {
                     "left": yaxis_minor_kw['tick1On'],
                     "right": yaxis_minor_kw['tick2On'],
                     "labelleft": yaxis_minor_kw['label1On'],
-                    "labelright": yaxis_minor_kw['label2On'],
-                    "direction": yaxis_minor_kw['tickdir'],
-                    "width": yaxis_minor_kw['width'],
-                    "size": yaxis_minor_kw['size']
-                },
+                    "labelright": yaxis_minor_kw['label2On']
+                }
             }
         }
+        # Set none guaranteed variables in tick_dict
+        for axis in tick_dict:
+            for size in tick_dict[axis]:
+                # Setup keyword dict for given axis and size (major/minor)
+                keyword_dict_variable_name = f"{axis}_{size}_kw"
+                keyword_dict = locals()[keyword_dict_variable_name]
+
+                if "tickdir" in keyword_dict:
+                    tick_dict[axis][size]["direction"] = keyword_dict["tickdir"]
+                if "size" in keyword_dict:
+                    tick_dict[axis][size]["size"] = keyword_dict["size"]
+                if "width" in keyword_dict:
+                    tick_dict[axis][size]["width"] = keyword_dict["width"]
+
+        return tick_dict
 
     @staticmethod
     def get_dict_from_spine_widths(ax):


### PR DESCRIPTION
**Description of work.**
Sometimes, parts of the expected tick parameters weren't present for whatever reason, now they are dynamically checked and added, so that they only get saved if they are, which actually allows none default plots to save.

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

**To test:**
- Load OSIRIS00100321 from our UnitTest data
- Open a plot for any of the spectrums for the loaded workspace
- Save out the project
- Restart workbench
- Load the project
- Everything should save and load fine, with no errors to do with plotting in the message log.

- Try again but with some different more random workspace

<!-- Instructions for testing. -->

Fixes #31655 <!-- and fix #xxxx or close #xxxx xor resolves #xxxx -->
<!-- alternative
*There is no associated issue.*
-->

*This does not require release notes* because **This is a regression from this release**

<!-- Ensure the base of this PR is correct (e.g. release-next or master)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
