### PR TITLE
Set QT layer for Error Reporter on BigSur

### DIFF
--- a/qt/applications/workbench/workbench/app/start.py
+++ b/qt/applications/workbench/workbench/app/start.py
@@ -15,6 +15,7 @@ from functools import partial
 from mantid.api import FrameworkManagerImpl
 from mantid.kernel import ConfigService, UsageService, version_str as mantid_version_str
 from mantidqt.utils.qt import plugins
+import mantidqt.utils.qt as qtutils
 
 # Find Qt plugins for development builds on some platforms
 plugins.setup_library_paths()
@@ -87,17 +88,7 @@ def initialize():
         import asyncio
         asyncio.set_event_loop_policy(asyncio.WindowsSelectorEventLoopPolicy())
     if sys.platform == 'darwin':
-        # Force layer-backing on macOS >= Big Sur (11)
-        # or the application hangs
-        # A fix inside Qt is yet to be released:
-        # https://codereview.qt-project.org/gitweb?p=qt/qtbase.git;a=commitdiff;h=c5d904639dbd690a36306e2b455610029704d821
-        # A complication with Big Sur numbering means we check for 10.16 and 11:
-        #   https://eclecticlight.co/2020/08/13/macos-version-numbering-isnt-so-simple/
-        from distutils.version import LooseVersion
-        import platform
-        mac_vers = LooseVersion(platform.mac_ver()[0])
-        if mac_vers >= '11' or mac_vers == '10.16':
-            os.environ['QT_MAC_WANTS_LAYER'] = '1'
+        qtutils.force_layer_backing_BigSur()
 
     app = qapplication()
 

--- a/qt/python/mantidqt/dialogs/errorreports/main.py
+++ b/qt/python/mantidqt/dialogs/errorreports/main.py
@@ -7,6 +7,7 @@
 import argparse
 import importlib
 import sys
+import os
 
 import mantid
 from qtpy import QT_VERSION
@@ -30,6 +31,20 @@ def main() -> int:
 
     # Qt resources must be imported before QApplication starts
     importlib.import_module(f'mantidqt.dialogs.errorreports.resources_qt{QT_VERSION[0]}')
+
+    if sys.platform == 'darwin':
+        # Force layer-backing on macOS >= Big Sur (11)
+        # or the application hangs
+        # A fix inside Qt is yet to be released:
+        # https://codereview.qt-project.org/gitweb?p=qt/qtbase.git;a=commitdiff;h=c5d904639dbd690a36306e2b455610029704d821
+        # A complication with Big Sur numbering means we check for 10.16 and 11:
+        #   https://eclecticlight.co/2020/08/13/macos-version-numbering-isnt-so-simple/
+        from distutils.version import LooseVersion
+        import platform
+        mac_vers = LooseVersion(platform.mac_ver()[0])
+        if mac_vers >= '11' or mac_vers == '10.16':
+            os.environ['QT_MAC_WANTS_LAYER'] = '1'
+        print('############\nDANIEL WAS HERE\n##############\n')
 
     from qtpy.QtWidgets import QApplication
     app = QApplication(sys.argv)

--- a/qt/python/mantidqt/dialogs/errorreports/main.py
+++ b/qt/python/mantidqt/dialogs/errorreports/main.py
@@ -7,7 +7,6 @@
 import argparse
 import importlib
 import sys
-import os
 
 import mantid
 from qtpy import QT_VERSION
@@ -15,6 +14,7 @@ from qtpy.QtCore import QCoreApplication
 
 from mantidqt.dialogs.errorreports.presenter import ErrorReporterPresenter
 from mantidqt.dialogs.errorreports.report import CrashReportPage
+import mantidqt.utils.qt as qtutils
 
 
 def main() -> int:
@@ -33,18 +33,7 @@ def main() -> int:
     importlib.import_module(f'mantidqt.dialogs.errorreports.resources_qt{QT_VERSION[0]}')
 
     if sys.platform == 'darwin':
-        # Force layer-backing on macOS >= Big Sur (11)
-        # or the application hangs
-        # A fix inside Qt is yet to be released:
-        # https://codereview.qt-project.org/gitweb?p=qt/qtbase.git;a=commitdiff;h=c5d904639dbd690a36306e2b455610029704d821
-        # A complication with Big Sur numbering means we check for 10.16 and 11:
-        #   https://eclecticlight.co/2020/08/13/macos-version-numbering-isnt-so-simple/
-        from distutils.version import LooseVersion
-        import platform
-        mac_vers = LooseVersion(platform.mac_ver()[0])
-        if mac_vers >= '11' or mac_vers == '10.16':
-            os.environ['QT_MAC_WANTS_LAYER'] = '1'
-        print('############\nDANIEL WAS HERE\n##############\n')
+        qtutils.force_layer_backing_BigSur()
 
     from qtpy.QtWidgets import QApplication
     app = QApplication(sys.argv)

--- a/qt/python/mantidqt/utils/qt/__init__.py
+++ b/qt/python/mantidqt/utils/qt/__init__.py
@@ -10,6 +10,7 @@
 """A selection of utility functions related to Qt functionality
 """
 # stdlib modules
+import os
 import os.path as osp
 from contextlib import contextmanager
 from importlib import import_module
@@ -210,3 +211,17 @@ def ensure_widget_is_on_screen(widget):
         y = desktop_geom.bottom() - widget_geom.height()
     window_pos = QPoint(x, y)
     widget.move(window_pos)
+
+
+def force_layer_backing_BigSur():
+    # Force layer-backing on macOS >= Big Sur (11)
+    # or the application hangs
+    # A fix inside Qt is yet to be released:
+    # https://codereview.qt-project.org/gitweb?p=qt/qtbase.git;a=commitdiff;h=c5d904639dbd690a36306e2b455610029704d821
+    # A complication with Big Sur numbering means we check for 10.16 and 11:
+    #   https://eclecticlight.co/2020/08/13/macos-version-numbering-isnt-so-simple/
+    from distutils.version import LooseVersion
+    import platform
+    mac_vers = LooseVersion(platform.mac_ver()[0])
+    if mac_vers >= '11' or mac_vers == '10.16':
+        os.environ['QT_MAC_WANTS_LAYER'] = '1'


### PR DESCRIPTION
**Description of work.**

Adds the fix from https://github.com/mantidproject/mantid/pull/31159/files for setting the QT layer on BigSur to the ErrorReporter.

**To test:**

- Open MantidWorkbench on MacOS BigSur
- Run the segfault algorithm, with `DryRun = False`
- Workbench will close (hard crash) and **check that the error reporter successfully launches!**
- Also, try to send in the error report (add your name to it!), currently I'm getting this error `http request returned status 0`, which is probably a separate issue with BigSur talking to the server. 

Fixes #31658


<!-- Ensure the base of this PR is correct (e.g. release-next or master)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
