### PR TITLE
Memory Widget use main GUI thread fix

### DIFF
--- a/qt/python/mantidqt/widgets/memorywidget/memorypresenter.py
+++ b/qt/python/mantidqt/widgets/memorywidget/memorypresenter.py
@@ -56,7 +56,7 @@ class MemoryPresenter(object):
         """
         if self.update_allowed:
             mem_used_percent, mem_used, mem_avail = get_memory_info()
-            self.view.set_value(mem_used_percent, mem_used, mem_avail)
+            self.view.invoke_set_value(mem_used_percent, mem_used, mem_avail)
 
     def cancel_memory_update(self):
         """

--- a/qt/python/mantidqt/widgets/memorywidget/memoryview.py
+++ b/qt/python/mantidqt/widgets/memorywidget/memoryview.py
@@ -7,8 +7,7 @@
 #  This file is part of the mantid workbench.
 #
 from qtpy.QtWidgets import QWidget, QProgressBar
-from qtpy.QtCore import Qt
-from PyQt5.QtCore import pyqtSlot, pyqtSignal
+from qtpy.QtCore import Qt, Slot, Signal
 
 NORMAL_STYLE = """
 QProgressBar::chunk {
@@ -48,7 +47,7 @@ def from_critical_to_normal(critical: int, current_value: int, new_value: int) -
 
 
 class MemoryView(QWidget):
-    set_value = pyqtSignal(int, float, float)
+    set_value = Signal(int, float, float)
     """
     Initializes and updates the view of memory(progress) bar.
     """
@@ -75,7 +74,7 @@ class MemoryView(QWidget):
     def invoke_set_value(self, new_value: int, mem_used: float, mem_avail: float):
         self.set_value.emit(new_value, mem_used, mem_avail)
 
-    @pyqtSlot(int, float, float)
+    @Slot(int, float, float)
     def _set_value(self, new_value, mem_used, mem_avail):
         """
         Receives memory usage information passed by memory presenter

--- a/qt/python/mantidqt/widgets/memorywidget/memoryview.py
+++ b/qt/python/mantidqt/widgets/memorywidget/memoryview.py
@@ -7,8 +7,8 @@
 #  This file is part of the mantid workbench.
 #
 from qtpy.QtWidgets import QWidget, QProgressBar
-from qtpy.QtCore import Qt, QMetaObject, Q_ARG
-from PyQt5.QtCore import pyqtSlot
+from qtpy.QtCore import Qt
+from PyQt5.QtCore import pyqtSlot, pyqtSignal
 
 NORMAL_STYLE = """
 QProgressBar::chunk {
@@ -48,15 +48,16 @@ def from_critical_to_normal(critical: int, current_value: int, new_value: int) -
 
 
 class MemoryView(QWidget):
+    set_value = pyqtSignal(int, float, float)
     """
     Initializes and updates the view of memory(progress) bar.
     """
     def __init__(self, parent):
         super(MemoryView, self).__init__(parent)
-
         self.critical = CRITICAL_PERCENTAGE
         self.memory_bar = QProgressBar(self)
         self.memory_bar.setAlignment(Qt.AlignCenter)
+        self.set_value.connect(self._set_value)
 
     def set_bar_color(self, current_value: int, new_value: int):
         """
@@ -72,10 +73,7 @@ class MemoryView(QWidget):
             pass
 
     def invoke_set_value(self, new_value: int, mem_used: float, mem_avail: float):
-        new_value = Q_ARG(int, new_value)
-        mem_used = Q_ARG(float, mem_used)
-        mem_avail = Q_ARG(float, mem_avail)
-        QMetaObject.invokeMethod(self, "_set_value", Qt.AutoConnection, new_value, mem_used, mem_avail)
+        self.set_value.emit(new_value, mem_used, mem_avail)
 
     @pyqtSlot(int, float, float)
     def _set_value(self, new_value, mem_used, mem_avail):

--- a/qt/python/mantidqt/widgets/memorywidget/memoryview.py
+++ b/qt/python/mantidqt/widgets/memorywidget/memoryview.py
@@ -6,9 +6,9 @@
 # SPDX - License - Identifier: GPL - 3.0 +
 #  This file is part of the mantid workbench.
 #
-#
 from qtpy.QtWidgets import QWidget, QProgressBar
-from qtpy.QtCore import Qt
+from qtpy.QtCore import Qt, QMetaObject, Q_ARG
+from PyQt5.QtCore import pyqtSlot
 
 NORMAL_STYLE = """
 QProgressBar::chunk {
@@ -71,7 +71,14 @@ class MemoryView(QWidget):
         else:
             pass
 
-    def set_value(self, new_value: int, mem_used: float, mem_avail: float):
+    def invoke_set_value(self, new_value: int, mem_used: float, mem_avail: float):
+        new_value = Q_ARG(int, new_value)
+        mem_used = Q_ARG(float, mem_used)
+        mem_avail = Q_ARG(float, mem_avail)
+        QMetaObject.invokeMethod(self, "_set_value", Qt.AutoConnection, new_value, mem_used, mem_avail)
+
+    @pyqtSlot(int, float, float)
+    def _set_value(self, new_value, mem_used, mem_avail):
         """
         Receives memory usage information passed by memory presenter
         and updates the displayed content as well as the style if needed

--- a/qt/python/mantidqt/widgets/memorywidget/test/test_memorypresenter.py
+++ b/qt/python/mantidqt/widgets/memorywidget/test/test_memorypresenter.py
@@ -31,7 +31,7 @@ class MemoryPresenterTest(unittest.TestCase):
         self.view.memory_bar = mock.Mock()
         self.view.memory_bar.value.return_value = 0
         self.view.set_bar_color = mock.Mock()
-        self.view.set_value = mock.Mock()
+        self.view.invoke_set_value = mock.Mock()
 
     def test_presenter(self):
         self.presenter.cancel_memory_update()
@@ -45,7 +45,7 @@ class MemoryPresenterTest(unittest.TestCase):
     def test_memory_usage_is_updated_based_on_a_constant(self):
         # Sleep for just longer than the default so the test can run
         time.sleep(TIME_INTERVAL_MEMORY_USAGE_UPDATE + 0.5)
-        self.assertGreater(self.view.set_value.call_count, 1)
+        self.assertGreater(self.view.invoke_set_value.call_count, 1)
 
 
 if __name__ == "__main__":

--- a/qt/python/mantidqt/widgets/memorywidget/test/test_memoryview.py
+++ b/qt/python/mantidqt/widgets/memorywidget/test/test_memoryview.py
@@ -1,0 +1,21 @@
+# Mantid Repository : https://github.com/mantidproject/mantid
+#
+# Copyright &copy; 2021 ISIS Rutherford Appleton Laboratory UKRI,
+#   NScD Oak Ridge National Laboratory, European Spallation Source,
+#   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+# SPDX - License - Identifier: GPL - 3.0 +
+import unittest
+from unittest import mock
+
+from mantidqt.utils.qt.testing import start_qapplication
+from mantidqt.utils.qt.testing.qt_assertions_helper import QtAssertionsHelper
+from mantidqt.widgets.memorywidget.memoryview import MemoryView
+
+
+@start_qapplication
+class MemoryViewTest(unittest.TestCase, QtAssertionsHelper):
+    def setUp(self):
+        self.view = MemoryView(None)
+
+    def test_invoke_set_value_connects_slot_set_value(self):
+        self.assert_connected_once(self.view, self.view.set_value)


### PR DESCRIPTION
**Description of work.**
At present on Windows Debug it's catching an assertion where a thread is calling Qt specific functions, which is problematic because this should happen on the main GUI thread.

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

**To test:**
(Check on Windows)
- Launch workbench
- Open a large workspace
- The memory widget should update

<!-- Instructions for testing. -->

Fixes #31667 <!-- and fix #xxxx or close #xxxx xor resolves #xxxx -->
<!-- alternative
*There is no associated issue.*
-->

*This does not require release notes* because **It's a regression**

<!-- Ensure the base of this PR is correct (e.g. release-next or master)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
