### PR TITLE
Interruption point after sleep

### DIFF
--- a/Framework/LiveData/src/MonitorLiveData.cpp
+++ b/Framework/LiveData/src/MonitorLiveData.cpp
@@ -133,8 +133,6 @@ void MonitorLiveData::exec() {
 
   // Keep going until you get cancelled
   while (true) {
-    // Exit if the user presses cancel
-    this->interruption_point();
 
     DateAndTime now = DateAndTime::getCurrentTime();
     double seconds = DateAndTime::secondsFromDuration(now - lastTime);
@@ -145,6 +143,9 @@ void MonitorLiveData::exec() {
 
     // Sleep for 50 msec
     Poco::Thread::sleep(50);
+
+    // Exit if the user presses cancel
+    this->interruption_point();
 
     if (seconds > UpdateEvery) {
       lastTime = now;

--- a/Framework/LiveData/test/MonitorLiveDataTest.h
+++ b/Framework/LiveData/test/MonitorLiveDataTest.h
@@ -157,7 +157,7 @@ public:
     Poco::ActiveResult<bool> res1 = alg1->executeAsync();
     Poco::Thread::sleep(50);
     while (alg1->m_chunkNumber < stopAtChunk)
-      Poco::Thread::sleep(10);
+      Poco::Thread::sleep(5);
     return true;
   }
 


### PR DESCRIPTION
**Description of work.**

Now a thread checks for the cancel signal invoked by another
thread after its sleep time, instead of checking before sleep as it was
until now. This change is not expected to affect adversely anything.
This change is done in the hope that MonitorLiveDataTest failures of os-x
the build will disappear or at least significantly go down relative to the current
frequency of failures

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

<!-- alternative
*There is no associated issue.*
-->

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or master)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
