### PR TITLE
Fix ConvertToDiffractionMDWorkspace for dSpacing workspaces

### DIFF
--- a/Framework/MDAlgorithms/src/PreprocessDetectorsToMD.cpp
+++ b/Framework/MDAlgorithms/src/PreprocessDetectorsToMD.cpp
@@ -239,6 +239,7 @@ void PreprocessDetectorsToMD::processDetectorsPositions(const API::MatrixWorkspa
     detId[i] = std::numeric_limits<int32_t>::quiet_NaN();
     detIDMap[i] = std::numeric_limits<uint64_t>::quiet_NaN();
     L2[i] = std::numeric_limits<double>::quiet_NaN();
+    DIFC[i] = std::numeric_limits<double>::quiet_NaN();
     TwoTheta[i] = std::numeric_limits<double>::quiet_NaN();
     Azimuthal[i] = std::numeric_limits<double>::quiet_NaN();
     //     detMask[i]  = true;


### PR DESCRIPTION
**Description of work.**

Fix problem where ConvertToDiffractionMDWorkspace was failing with an error when source workspace had units of dSpacing

Problem occurred in ConvertToMDMinMaxLocal specifically which was called as child algorithm from ConvertToDiffractionMDWorkspace

Have populated DIFC with default value of nan to align it with behaviour for l2. Monitors and spectra without detectors get this default because of the "continue" on L247. This stops the code hitting a validation check in dSpacing::validateParams which was checking for non-zero DIFC. The validation was added as part of #30163

Would be nice to tidy up the logic in UnitsConversionHelper::getConversionRange around monitors so that we don't pass nan parameters into unit classes and expect nans back but just doing cautious fix for now so can sort out for release. Eventually would be better to not do unit conversion for monitor spectra if we know they're going to fail.

Will review the tests for ConvertToDiffractionMDWorkspace\ConvertToMDMinMaxLocal  later on to see how this wasn't caught when #30163 was merged

**Report to:** Pascal Manuel

**To test:**

Run script that Richard added to attached issue. Check it completes successfully

Fixes #31685 

*This does not require release notes* because **fixes bug introduced in this release**

<!-- Ensure the base of this PR is correct (e.g. release-next or master)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
