### PR TITLE
Pd261 cross correlation max bin shift param

### DIFF
--- a/Framework/API/inc/MantidAPI/FunctionDomain1D.h
+++ b/Framework/API/inc/MantidAPI/FunctionDomain1D.h
@@ -77,12 +77,16 @@ public:
   FunctionDomain1DVector(const double startX, const double endX, const size_t n);
   /// Constructor.
   FunctionDomain1DVector(const std::vector<double> &xvalues);
+  /// No-copy constructor.
+  FunctionDomain1DVector(std::vector<double> &&xvalues);
   /// Constructor.
   FunctionDomain1DVector(std::vector<double>::const_iterator from, std::vector<double>::const_iterator to);
   /// Copy constructor.
   FunctionDomain1DVector(const FunctionDomain1DVector &);
   /// Copy assignment operator.
   FunctionDomain1DVector &operator=(const FunctionDomain1DVector &);
+  /// Get the underlying vector
+  std::vector<double> getVector() { return m_X; }
 
 protected:
   std::vector<double> m_X; ///< vector of function arguments

--- a/Framework/API/src/FunctionDomain1D.cpp
+++ b/Framework/API/src/FunctionDomain1D.cpp
@@ -55,7 +55,7 @@ FunctionDomain1DVector::FunctionDomain1DVector(std::vector<double> &&xvalues) : 
   if (xvalues.empty()) {
     throw std::invalid_argument("FunctionDomain1D cannot have zero size.");
   }
-  m_X = std::move( xvalues );
+  m_X = std::move(xvalues);
   /* clear the invalidated object */
   xvalues.clear();
   resetData(&m_X[0], m_X.size());

--- a/Framework/API/src/FunctionDomain1D.cpp
+++ b/Framework/API/src/FunctionDomain1D.cpp
@@ -48,6 +48,20 @@ FunctionDomain1DVector::FunctionDomain1DVector(const std::vector<double> &xvalue
 }
 
 /**
+ * Create a domain from a vector using move semantics - no copy overhead.
+ * @param xvalues :: Vector with function arguments to be moved from.
+ */
+FunctionDomain1DVector::FunctionDomain1DVector(std::vector<double> &&xvalues) : FunctionDomain1D(nullptr, 0) {
+  if (xvalues.empty()) {
+    throw std::invalid_argument("FunctionDomain1D cannot have zero size.");
+  }
+  m_X = std::move( xvalues );
+  /* clear the invalidated object */
+  xvalues.clear();
+  resetData(&m_X[0], m_X.size());
+}
+
+/**
  * Create a domain from a part of a vector.
  * @param from :: Iterator to start copying values from.
  * @param to :: Iterator to the end of the data.

--- a/Framework/Algorithms/CMakeLists.txt
+++ b/Framework/Algorithms/CMakeLists.txt
@@ -786,6 +786,7 @@ set(TEST_FILES
     CropWorkspaceRaggedTest.h
     CropWorkspaceTest.h
     CrossCorrelateTest.h
+    CrossCorrelateTestData.h
     CuboidGaugeVolumeAbsorptionTest.h
     CylinderAbsorptionTest.h
     DeadTimeCorrectionTest.h

--- a/Framework/Algorithms/CMakeLists.txt
+++ b/Framework/Algorithms/CMakeLists.txt
@@ -786,7 +786,6 @@ set(TEST_FILES
     CropWorkspaceRaggedTest.h
     CropWorkspaceTest.h
     CrossCorrelateTest.h
-    CrossCorrelateTestData.h
     CuboidGaugeVolumeAbsorptionTest.h
     CylinderAbsorptionTest.h
     DeadTimeCorrectionTest.h

--- a/Framework/Algorithms/src/CreateSampleWorkspace.cpp
+++ b/Framework/Algorithms/src/CreateSampleWorkspace.cpp
@@ -438,10 +438,8 @@ std::vector<double> CreateSampleWorkspace::evalFunction(const std::string &funct
   FunctionValues fv(fd);
   func_sptr->function(fd, fv);
 
-  std::vector<double> results;
-  results.resize(xSize);
+  auto results = fv.toVector();
   for (size_t x = 0; x < xSize; ++x) {
-    results[x] = fv.getCalculated(x);
     if (noiseScale != 0) {
       results[x] += ((m_randGen->nextValue() - 0.5) * noiseScale);
     }

--- a/Framework/Algorithms/src/CrossCorrelate.cpp
+++ b/Framework/Algorithms/src/CrossCorrelate.cpp
@@ -120,15 +120,13 @@ void CrossCorrelate::exec() {
   // Indexes of all spectra in range
   std::vector<size_t> indexes(boost::make_counting_iterator(wsIndexMin), boost::make_counting_iterator(wsIndexMax + 1));
 
-  std::ostringstream message;
   if (numSpectra == 0) {
-    message << "No Workspaces in range between" << wsIndexMin << " and " << wsIndexMax;
+    std::ostringstream message;
+    message << "No spectra in range between" << wsIndexMin << " and " << wsIndexMax;
     throw std::runtime_error(message.str());
   }
   // Output messageage information
-  message << "There are " << numSpectra << " Workspaces in the range\n";
-  g_log.information(message.str());
-  message.str("");
+  g_log.information() << "There are " << numSpectra << " spectra in the range\n";
 
   // checdataIndex that the data range specified madataIndexes sense
   if (xmin >= xmax)
@@ -157,9 +155,7 @@ void CrossCorrelate::exec() {
   std::vector<double> referenceEVector(referenceSpectraE.cbegin() + rangeStartCorrection,
                                        referenceSpectraE.cbegin() + (rangeEndCorrection - 1));
 
-  message << "min max " << referenceXVector.front() << " " << referenceXVector.back();
-  g_log.information(message.str());
-  message.str("");
+  g_log.information() << "min max " << referenceXVector.front() << " " << referenceXVector.back() << '\n';
 
   // Now start the real stuff
   // Create a 2DWorkspace that will hold the result

--- a/Framework/Algorithms/src/CrossCorrelate.cpp
+++ b/Framework/Algorithms/src/CrossCorrelate.cpp
@@ -172,7 +172,7 @@ void CrossCorrelate::exec() {
     shiftCorrection = std::max(0.0, abs((-numReferenceY + 2) - (numReferenceY - 2)) - maxBins) / 2;
   }
 
-  const int numPoints = 2 * numReferenceY - shiftCorrection - 3;
+  const int numPoints = 2 * (numReferenceY - shiftCorrection) - 3;
   if (numPoints < 1)
     throw std::runtime_error("Range is not valid");
 
@@ -187,11 +187,8 @@ void CrossCorrelate::exec() {
   bool isDistribution = inputWS->isDistribution();
 
   auto &outX = out->mutableX(0);
-  for (int i = 0; i < shiftCorrection; ++i) {
-    outX[i] = std::nan("");
-  }
-  for (int i = shiftCorrection; i < static_cast<int>(outX.size()); ++i) {
-    outX[i] = static_cast<double>(i - numReferenceY + 2);
+  for (int i = 0; i < static_cast<int>(outX.size()); ++i) {
+    outX[i] = static_cast<double>(i - (numReferenceY - shiftCorrection) + 2);
   }
 
   // Initialise the progress reporting object
@@ -246,8 +243,9 @@ void CrossCorrelate::exec() {
         val += (x * y);
         err2 += x * x * yE + y * y * xE;
       }
-      outY[dataIndex + numReferenceY - 2] = (val * normalisation);
-      outE[dataIndex + numReferenceY - 2] = sqrt(val * val * normalisationE2 + normalisation * normalisation * err2);
+      outY[dataIndex + numReferenceY - shiftCorrection - 2] = (val * normalisation);
+      outE[dataIndex + numReferenceY - shiftCorrection - 2] =
+          sqrt(val * val * normalisationE2 + normalisation * normalisation * err2);
     }
     // Update progress information
     m_progress->report();

--- a/Framework/Algorithms/src/CrossCorrelate.cpp
+++ b/Framework/Algorithms/src/CrossCorrelate.cpp
@@ -169,7 +169,7 @@ void CrossCorrelate::exec() {
     // convert dspacing to bins, where maxDSpaceShift is at least 0.1
     const auto maxBins = std::max(0.0 + maxDSpaceShift * 2, 0.1) / inputWS->getDimension(0)->getBinWidth();
     // calc range based on max bins
-    shiftCorrection = std::max(0.0, abs((-numReferenceY + 2) - (numReferenceY - 2)) - maxBins) / 2;
+    shiftCorrection = (int)std::max(0.0, abs((-numReferenceY + 2) - (numReferenceY - 2)) - maxBins) / 2;
   }
 
   const int numPoints = 2 * (numReferenceY - shiftCorrection) - 3;

--- a/Framework/Algorithms/src/CrossCorrelate.cpp
+++ b/Framework/Algorithms/src/CrossCorrelate.cpp
@@ -8,6 +8,7 @@
 // Includes
 //----------------------------------------------------------------------
 #include "MantidAlgorithms/CrossCorrelate.h"
+#include "MantidAPI/HistogramValidator.h"
 #include "MantidAPI/NumericAxis.h"
 #include "MantidAPI/RawCountValidator.h"
 #include "MantidAPI/SpectraAxis.h"
@@ -67,6 +68,7 @@ using namespace HistogramData;
 void CrossCorrelate::init() {
   auto wsValidator = std::make_shared<CompositeValidator>();
   wsValidator->add<API::WorkspaceUnitValidator>("dSpacing");
+  wsValidator->add<API::HistogramValidator>();
   wsValidator->add<API::RawCountValidator>();
 
   // Input and output workspaces
@@ -211,6 +213,11 @@ void CrossCorrelate::exec() {
     // Now rebin on the grid of referenceSpectra
     std::vector<double> tempY(numReferenceY);
     std::vector<double> tempE(numReferenceY);
+
+    g_log.information("sizing :" + std::to_string(numReferenceY) + " " + std::to_string(referenceXVector.size()));
+    g_log.information("old y size :" + std::to_string(inputYVector.size()));
+    g_log.information("old e size :" + std::to_string(inputEVector.size()));
+    g_log.information("old x size :" + std::to_string(inputXVector.size()));
     VectorHelper::rebin(inputXVector.rawData(), inputYVector.rawData(), inputEVector.rawData(), referenceXVector, tempY,
                         tempE, isDistribution);
     const auto tempVar = subtractMean(tempY, tempE);

--- a/Framework/Algorithms/src/CrossCorrelate.cpp
+++ b/Framework/Algorithms/src/CrossCorrelate.cpp
@@ -1,7 +1,7 @@
 // Mantid Repository : https://github.com/mantidproject/mantid
 //
 // Copyright &copy; 2018 ISIS Rutherford Appleton Laboratory UKRI,
-//   NScD Oak Ridge National Laboratory, European Spallation Source,
+//   NScD OadataIndex Ridge National Laboratory, European Spallation Source,
 //   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
 // SPDX - License - Identifier: GPL - 3.0 +
 //----------------------------------------------------------------------
@@ -69,12 +69,12 @@ void CrossCorrelate::init() {
   wsValidator->add<API::WorkspaceUnitValidator>("dSpacing");
   wsValidator->add<API::RawCountValidator>();
 
-  // Input and output workspaces
+  // Input and output wordataIndexspaces
   declareProperty(
       std::make_unique<WorkspaceProperty<MatrixWorkspace>>("InputWorkspace", "", Direction::Input, wsValidator),
-      "A 2D workspace with X values of d-spacing");
+      "A 2D wordataIndexspace with X values of d-spacing");
   declareProperty(std::make_unique<WorkspaceProperty<MatrixWorkspace>>("OutputWorkspace", "", Direction::Output),
-                  "The name of the output workspace");
+                  "The name of the output wordataIndexspace");
 
   auto mustBePositive = std::make_shared<BoundedValidator<int>>();
   mustBePositive->setLower(0);
@@ -82,12 +82,12 @@ void CrossCorrelate::init() {
   declareProperty("ReferenceSpectra", 0, mustBePositive,
                   "The Workspace Index of the spectra to correlate all other "
                   "spectra against. ");
-  // Spectra in the range [min to max] will be cross correlated to reference.
+  // Spectra in the range [min to max] will be cross correlated to referenceSpectra.
   declareProperty("WorkspaceIndexMin", 0, mustBePositive,
-                  "The workspace index of the first member of the range of "
+                  "The wordataIndexspace index of the first member of the range of "
                   "spectra to cross-correlate against.");
   declareProperty("WorkspaceIndexMax", 0, mustBePositive,
-                  " The workspace index of the last member of the range of "
+                  " The wordataIndexspace index of the last member of the range of "
                   "spectra to cross-correlate against.");
   // max is .1
   declareProperty("MaxDSpaceShift", EMPTY_DBL(), "Optional float for maximum shift to calculate (in d-spacing)");
@@ -103,151 +103,149 @@ void CrossCorrelate::init() {
 void CrossCorrelate::exec() {
   MatrixWorkspace_const_sptr inputWS = getProperty("InputWorkspace");
   double maxDSpaceShift = getProperty("MaxDSpaceShift");
-
-  int reference = getProperty("ReferenceSpectra");
-  const auto index_ref = static_cast<size_t>(reference);
-
-  // check that the data range specified makes sense
+  int referenceSpectra = getProperty("ReferenceSpectra");
   double xmin = getProperty("XMin");
   double xmax = getProperty("XMax");
+  const int wsIndexMin = getProperty("WorkspaceIndexMin");
+  const int wsIndexMax = getProperty("WorkspaceIndexMax");
+
+  const auto index_ref = static_cast<size_t>(referenceSpectra);
+
+  if (wsIndexMin >= wsIndexMax)
+    throw std::runtime_error("Must specify WorkspaceIndexMin<WorkspaceIndexMax");
+  // Get the number of spectra in range wsIndexMin to wsIndexMax
+  int numSpectra = 1 + wsIndexMax - wsIndexMin;
+  // Indexes of all spectra in range
+  std::vector<size_t> indexes(boost::make_counting_iterator(wsIndexMin), boost::make_counting_iterator(wsIndexMax + 1));
+
+  std::ostringstream message;
+  if (numSpectra == 0) {
+    message << "No Workspaces in range between" << wsIndexMin << " and " << wsIndexMax;
+    throw std::runtime_error(message.str());
+  }
+  // Output messageage information
+  message << "There are " << numSpectra << " Workspaces in the range\n";
+  g_log.information(message.str());
+  message.str("");
+
+  // checdataIndex that the data range specified madataIndexes sense
   if (xmin >= xmax)
     throw std::runtime_error("Must specify xmin < xmax");
 
-  // Now check if the range between x_min and x_max is valid
-  auto &referenceX = inputWS->x(index_ref);
+  // TadataIndexe a copy of  the referenceSpectra spectrum
+  auto &referenceSpectraE = inputWS->e(index_ref);
+  auto &referenceSpectraX = inputWS->x(index_ref);
+  auto &referenceSpectraY = inputWS->y(index_ref);
+  // Now checdataIndex if the range between x_min and x_max is valid
   using std::placeholders::_1;
-  auto minIt = std::find_if(referenceX.cbegin(), referenceX.cend(), std::bind(std::greater<double>(), _1, xmin));
-  if (minIt == referenceX.cend())
+  auto rangeStart =
+      std::find_if(referenceSpectraX.cbegin(), referenceSpectraX.cend(), std::bind(std::greater<double>(), _1, xmin));
+  if (rangeStart == referenceSpectraX.cend())
     throw std::runtime_error("No data above XMin");
-  auto maxIt = std::find_if(minIt, referenceX.cend(), std::bind(std::greater<double>(), _1, xmax));
-  if (minIt == maxIt)
+  auto rangeEnd = std::find_if(rangeStart, referenceSpectraX.cend(), std::bind(std::greater<double>(), _1, xmax));
+  if (rangeStart == rangeEnd)
     throw std::runtime_error("Range is not valid");
 
-  MantidVec::difference_type difminIt = std::distance(referenceX.cbegin(), minIt);
-  MantidVec::difference_type difmaxIt = std::distance(referenceX.cbegin(), maxIt);
-  // Now loop on the spectra in the range spectra_min and spectra_max and get
-  // valid spectra
+  MantidVec::difference_type rangeStartCorrection = std::distance(referenceSpectraX.cbegin(), rangeStart);
+  MantidVec::difference_type rangeEndCorrection = std::distance(referenceSpectraX.cbegin(), rangeEnd);
 
-  const int specmin = getProperty("WorkspaceIndexMin");
-  const int specmax = getProperty("WorkspaceIndexMax");
-  if (specmin >= specmax)
-    throw std::runtime_error("Must specify WorkspaceIndexMin<WorkspaceIndexMax");
-  // Get the number of spectra in range specmin to specmax
-  int nspecs = 1 + specmax - specmin;
-  // Indexes of all spectra in range
-  std::vector<size_t> indexes(boost::make_counting_iterator(specmin), boost::make_counting_iterator(specmax + 1));
+  const std::vector<double> referenceXVector(rangeStart, rangeEnd);
+  std::vector<double> referenceYVector(referenceSpectraY.cbegin() + rangeStartCorrection,
+                                       referenceSpectraY.cbegin() + (rangeEndCorrection - 1));
+  std::vector<double> referenceEVector(referenceSpectraE.cbegin() + rangeStartCorrection,
+                                       referenceSpectraE.cbegin() + (rangeEndCorrection - 1));
 
-  std::ostringstream mess;
-  if (nspecs == 0) {
-    mess << "No Workspaces in range between" << specmin << " and " << specmax;
-    throw std::runtime_error(mess.str());
-  }
-
-  // Output message information
-  mess << "There are " << nspecs << " Workspaces in the range\n";
-  g_log.information(mess.str());
-  mess.str("");
-
-  // Take a copy of  the reference spectrum
-  auto &referenceY = inputWS->y(index_ref);
-  auto &referenceE = inputWS->e(index_ref);
-
-  const std::vector<double> refX(minIt, maxIt);
-  std::vector<double> refY(referenceY.cbegin() + difminIt, referenceY.cbegin() + (difmaxIt - 1));
-  std::vector<double> refE(referenceE.cbegin() + difminIt, referenceE.cbegin() + (difmaxIt - 1));
-
-  mess << "min max " << refX.front() << " " << refX.back();
-  g_log.information(mess.str());
-  mess.str("");
+  message << "min max " << referenceXVector.front() << " " << referenceXVector.back();
+  g_log.information(message.str());
+  message.str("");
 
   // Now start the real stuff
   // Create a 2DWorkspace that will hold the result
-  const auto nY = static_cast<int>(refY.size());
-  const int npoints = 2 * nY - 3;
-  if (npoints < 1)
+  const auto numReferenceY = static_cast<int>(referenceYVector.size());
+  const int numPoints = 2 * numReferenceY - 3;
+  if (numPoints < 1)
     throw std::runtime_error("Range is not valid");
 
-  MatrixWorkspace_sptr out = create<HistoWorkspace>(*inputWS, nspecs, Points(npoints));
+  MatrixWorkspace_sptr out = create<HistoWorkspace>(*inputWS, numSpectra, Points(numPoints));
 
-  const auto refVar = subtractMean(refY, refE);
+  const auto referenceVariance = subtractMean(referenceYVector, referenceEVector);
 
-  const double refNorm = 1.0 / sqrt(refVar.y);
-  double refNormE = 0.5 * pow(refNorm, 3) * sqrt(refVar.e);
+  const double referenceNorm = 1.0 / sqrt(referenceVariance.y);
+  double referenceNormE = 0.5 * pow(referenceNorm, 3) * sqrt(referenceVariance.e);
 
   // Now copy the other spectra
-  bool is_distrib = inputWS->isDistribution();
+  bool isDistribution = inputWS->isDistribution();
 
   auto &outX = out->mutableX(0);
   for (int i = 0; i < static_cast<int>(outX.size()); ++i) {
-    outX[i] = static_cast<double>(i - nY + 2);
+    outX[i] = static_cast<double>(i - numReferenceY + 2);
   }
   // Initialise the progress reporting object
-  m_progress = std::make_unique<Progress>(this, 0.0, 1.0, nspecs);
+  m_progress = std::make_unique<Progress>(this, 0.0, 1.0, numSpectra);
   PARALLEL_FOR_IF(Kernel::threadSafe(*inputWS, *out))
-  for (int i = 0; i < nspecs; ++i) // Now loop on all spectra
+  for (int currentSpecIndex = 0; currentSpecIndex < numSpectra; ++currentSpecIndex) // Now loop on all spectra
   {
     PARALLEL_START_INTERUPT_REGION
-    size_t wsIndex = indexes[i]; // Get the ws index from the table
+    size_t wsIndex = indexes[currentSpecIndex]; // Get the ws index from the table
     // Copy spectra info from input Workspace
-    out->getSpectrum(i).copyInfoFrom(inputWS->getSpectrum(wsIndex));
+    out->getSpectrum(currentSpecIndex).copyInfoFrom(inputWS->getSpectrum(wsIndex));
 
-    out->setSharedX(i, out->sharedX(0));
+    out->setSharedX(currentSpecIndex, out->sharedX(0));
 
-    // Get temp references
-    const auto &iX = inputWS->x(wsIndex);
-    const auto &iY = inputWS->y(wsIndex);
-    const auto &iE = inputWS->e(wsIndex);
-    // Copy Y,E data of spec(i) to temp vector
-    // Now rebin on the grid of reference spectrum
-    std::vector<double> tempY(nY);
-    std::vector<double> tempE(nY);
-    VectorHelper::rebin(iX.rawData(), iY.rawData(), iE.rawData(), refX, tempY, tempE, is_distrib);
+    // Get temp referenceSpectras
+    const auto &inputXVector = inputWS->x(wsIndex);
+    const auto &inputYVector = inputWS->y(wsIndex);
+    const auto &inputEVector = inputWS->e(wsIndex);
+    // Copy Y,E data of spec(currentSpecIndex) to temp vector
+    // Now rebin on the grid of referenceSpectra
+    std::vector<double> tempY(numReferenceY);
+    std::vector<double> tempE(numReferenceY);
+    VectorHelper::rebin(inputXVector.rawData(), inputYVector.rawData(), inputEVector.rawData(), referenceXVector, tempY,
+                        tempE, isDistribution);
     const auto tempVar = subtractMean(tempY, tempE);
 
     // Calculate the normalisation constant
     const double tempNorm = 1.0 / sqrt(tempVar.y);
     const double tempNormE = 0.5 * pow(tempNorm, 3) * sqrt(tempVar.e);
-    const double normalisation = refNorm * tempNorm;
-    const double normalisationE2 = pow((refNorm * tempNormE), 2) + pow((tempNorm * refNormE), 2);
-    // Get reference to the ouput spectrum
-    auto &outY = out->mutableY(i);
-    auto &outE = out->mutableE(i);
+    const double normalisation = referenceNorm * tempNorm;
+    const double normalisationE2 = pow((referenceNorm * tempNormE), 2) + pow((tempNorm * referenceNormE), 2);
+    // Get referenceSpectr to the ouput spectrum
+    auto &outY = out->mutableY(currentSpecIndex);
+    auto &outE = out->mutableE(currentSpecIndex);
 
     // max the shift
     int shiftCorrection = 0;
     if (maxDSpaceShift != EMPTY_DBL()) {
       // convert dspacing to bins, where maxDSpaceShift is at least 0.1
-      const auto maxBins = std::max(0.0 + maxDSpaceShift, 0.1) / (maxIt - minIt);
+      const auto maxBins = std::max(0.0 + maxDSpaceShift, 0.1) / (rangeEnd - rangeStart);
       // calc range based on max bins
-      shiftCorrection = abs(abs((-nY + 2) - (nY - 2)) - maxBins) / 2;
+      shiftCorrection = abs(abs((-numReferenceY + 2) - (numReferenceY - 2)) - maxBins) / 2;
     }
 
-    for (int k = -nY + 2 + shiftCorrection; k <= nY - 2 - shiftCorrection; ++k) {
-      const int kp = abs(k);
+    for (int dataIndex = -numReferenceY + 2 + shiftCorrection; dataIndex <= numReferenceY - 2 - shiftCorrection;
+         ++dataIndex) {
+      const int dataIndexP = abs(dataIndex);
       double val = 0, err2 = 0, x, y, xE, yE;
-      for (int j = nY - 1 - kp; j >= 0; --j) {
-        if (k >= 0) {
-          x = refY[j];
-          y = tempY[j + kp];
-          xE = refE[j];
-          yE = tempE[j + kp];
+      for (int j = numReferenceY - 1 - dataIndexP; j >= 0; --j) {
+        if (dataIndex >= 0) {
+          x = referenceYVector[j];
+          y = tempY[j + dataIndexP];
+          xE = referenceEVector[j];
+          yE = tempE[j + dataIndexP];
         } else {
           x = tempY[j];
-          y = refY[j + kp];
+          y = referenceYVector[j + dataIndexP];
           xE = tempE[j];
-          yE = refE[j + kp];
+          yE = referenceEVector[j + dataIndexP];
         }
         val += (x * y);
         err2 += x * x * yE + y * y * xE;
       }
-      outY[k + nY - 2] = (val * normalisation);
-      outE[k + nY - 2] = sqrt(val * val * normalisationE2 + normalisation * normalisation * err2);
+      outY[dataIndex + numReferenceY - 2] = (val * normalisation);
+      outE[dataIndex + numReferenceY - 2] = sqrt(val * val * normalisationE2 + normalisation * normalisation * err2);
     }
     // Update progress information
-    // double prog=static_cast<double>(i)/nspecs;
-    // progress(prog);
     m_progress->report();
-    // interruption_point();
     PARALLEL_END_INTERUPT_REGION
   }
   PARALLEL_CHECK_INTERUPT_REGION

--- a/Framework/Algorithms/src/CrossCorrelate.cpp
+++ b/Framework/Algorithms/src/CrossCorrelate.cpp
@@ -185,7 +185,7 @@ void CrossCorrelate::exec() {
   int shiftCorrection = 0;
   if (maxDSpaceShift != EMPTY_DBL()) {
     // convert dspacing to bins, where maxDSpaceShift is at least 0.1
-    const auto maxBins = std::max(0.0 + maxDSpaceShift * 2, 0.1) / (xmax - xmin) * (rangeEnd - rangeStart);
+    const auto maxBins = std::max(0.0 + maxDSpaceShift * 2, 0.1) / inputWS->getDimension(0)->getBinWidth();
     // calc range based on max bins
     shiftCorrection = std::max(0.0, abs((-numReferenceY + 2) - (numReferenceY - 2)) - maxBins) / 2;
   }

--- a/Framework/Algorithms/src/CrossCorrelate.cpp
+++ b/Framework/Algorithms/src/CrossCorrelate.cpp
@@ -91,11 +91,11 @@ void CrossCorrelate::init() {
   declareProperty("WorkspaceIndexMax", 0, mustBePositive,
                   " The workspace index of the last member of the range of "
                   "spectra to cross-correlate against.");
-  // max is .1
-  declareProperty("MaxDSpaceShift", EMPTY_DBL(), "Optional float for maximum shift to calculate (in d-spacing)");
   // Only the data in the range X_min, X_max will be used
   declareProperty("XMin", 0.0, "The starting point of the region to be cross correlated.");
   declareProperty("XMax", 0.0, "The ending point of the region to be cross correlated.");
+  // max is .1
+  declareProperty("MaxDSpaceShift", EMPTY_DBL(), "Optional float for maximum shift to calculate (in d-spacing)");
 }
 
 /** Executes the algorithm

--- a/Framework/Algorithms/src/CrossCorrelate.cpp
+++ b/Framework/Algorithms/src/CrossCorrelate.cpp
@@ -187,7 +187,7 @@ void CrossCorrelate::exec() {
     // convert dspacing to bins, where maxDSpaceShift is at least 0.1
     const auto maxBins = std::max(0.0 + maxDSpaceShift * 2, 0.1) / (xmax - xmin) * (rangeEnd - rangeStart);
     // calc range based on max bins
-    shiftCorrection = abs(abs((-numReferenceY + 2) - (numReferenceY - 2)) - maxBins) / 2;
+    shiftCorrection = std::max(0.0, abs((-numReferenceY + 2) - (numReferenceY - 2)) - maxBins) / 2;
   }
 
   // Initialise the progress reporting object

--- a/Framework/Algorithms/src/CrossCorrelate.cpp
+++ b/Framework/Algorithms/src/CrossCorrelate.cpp
@@ -167,7 +167,8 @@ void CrossCorrelate::exec() {
     if (xmax - xmin < maxDSpaceShift)
       g_log.warning() << "maxDSpaceShift(" << std::to_string(maxDSpaceShift)
                       << ") is larger than specified range of xmin(" << xmin << ") to xmax(" << xmax
-                      << "), please make it smaller or removed it entirely!";
+                      << "), please make it smaller or removed it entirely!"
+                      << "\n";
 
     // convert dspacing to bins, where maxDSpaceShift is at least 0.1
     const auto maxBins = std::max(0.0 + maxDSpaceShift * 2, 0.1) / inputWS->getDimension(0)->getBinWidth();

--- a/Framework/Algorithms/src/CrossCorrelate.cpp
+++ b/Framework/Algorithms/src/CrossCorrelate.cpp
@@ -202,9 +202,7 @@ void CrossCorrelate::exec() {
     size_t wsIndex = indexes[currentSpecIndex]; // Get the ws index from the table
     // Copy spectra info from input Workspace
     out->getSpectrum(currentSpecIndex).copyInfoFrom(inputWS->getSpectrum(wsIndex));
-
     out->setSharedX(currentSpecIndex, out->sharedX(0));
-
     // Get temp referenceSpectras
     const auto &inputXVector = inputWS->x(wsIndex);
     const auto &inputYVector = inputWS->y(wsIndex);
@@ -214,10 +212,10 @@ void CrossCorrelate::exec() {
     std::vector<double> tempY(numReferenceY);
     std::vector<double> tempE(numReferenceY);
 
-    g_log.information("sizing :" + std::to_string(numReferenceY) + " " + std::to_string(referenceXVector.size()));
-    g_log.information("old y size :" + std::to_string(inputYVector.size()));
-    g_log.information("old e size :" + std::to_string(inputEVector.size()));
-    g_log.information("old x size :" + std::to_string(inputXVector.size()));
+    // g_log.information("sizing :" + std::to_string(numReferenceY) + " " + std::to_string(referenceXVector.size()));
+    // g_log.information("old y size :" + std::to_string(inputYVector.size()));
+    // g_log.information("old e size :" + std::to_string(inputEVector.size()));
+    // g_log.information("old x size :" + std::to_string(inputXVector.size()));
     VectorHelper::rebin(inputXVector.rawData(), inputYVector.rawData(), inputEVector.rawData(), referenceXVector, tempY,
                         tempE, isDistribution);
     const auto tempVar = subtractMean(tempY, tempE);

--- a/Framework/Algorithms/src/CrossCorrelate.cpp
+++ b/Framework/Algorithms/src/CrossCorrelate.cpp
@@ -130,7 +130,7 @@ void CrossCorrelate::exec() {
 
   // checdataIndex that the data range specified madataIndexes sense
   if (xmin >= xmax)
-    throw std::runtime_error("Must specify xmin < xmax");
+    throw std::runtime_error("Must specify xmin < xmax, " + std::to_string(xmin) + " vs " + std::to_string(xmax));
 
   // TadataIndexe a copy of  the referenceSpectra spectrum
   auto &referenceSpectraE = inputWS->e(index_ref);
@@ -164,6 +164,11 @@ void CrossCorrelate::exec() {
   // max the shift
   int shiftCorrection = 0;
   if (maxDSpaceShift != EMPTY_DBL()) {
+    if (xmax - xmin < maxDSpaceShift)
+      g_log.warning() << "maxDSpaceShift(" << std::to_string(maxDSpaceShift)
+                      << ") is larger than specified range of xmin(" << xmin << ") to xmax(" << xmax
+                      << "), please make it smaller or removed it entirely!";
+
     // convert dspacing to bins, where maxDSpaceShift is at least 0.1
     const auto maxBins = std::max(0.0 + maxDSpaceShift * 2, 0.1) / inputWS->getDimension(0)->getBinWidth();
     // calc range based on max bins
@@ -208,10 +213,6 @@ void CrossCorrelate::exec() {
     std::vector<double> tempY(numReferenceY);
     std::vector<double> tempE(numReferenceY);
 
-    // g_log.information("sizing :" + std::to_string(numReferenceY) + " " + std::to_string(referenceXVector.size()));
-    // g_log.information("old y size :" + std::to_string(inputYVector.size()));
-    // g_log.information("old e size :" + std::to_string(inputEVector.size()));
-    // g_log.information("old x size :" + std::to_string(inputXVector.size()));
     VectorHelper::rebin(inputXVector.rawData(), inputYVector.rawData(), inputEVector.rawData(), referenceXVector, tempY,
                         tempE, isDistribution);
     const auto tempVar = subtractMean(tempY, tempE);

--- a/Framework/Algorithms/src/CrossCorrelate.cpp
+++ b/Framework/Algorithms/src/CrossCorrelate.cpp
@@ -1,7 +1,7 @@
 // Mantid Repository : https://github.com/mantidproject/mantid
 //
 // Copyright &copy; 2018 ISIS Rutherford Appleton Laboratory UKRI,
-//   NScD OadataIndex Ridge National Laboratory, European Spallation Source,
+//   NScD Oak Ridge National Laboratory, European Spallation Source,
 //   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
 // SPDX - License - Identifier: GPL - 3.0 +
 //----------------------------------------------------------------------
@@ -69,12 +69,12 @@ void CrossCorrelate::init() {
   wsValidator->add<API::WorkspaceUnitValidator>("dSpacing");
   wsValidator->add<API::RawCountValidator>();
 
-  // Input and output wordataIndexspaces
+  // Input and output workspaces
   declareProperty(
       std::make_unique<WorkspaceProperty<MatrixWorkspace>>("InputWorkspace", "", Direction::Input, wsValidator),
-      "A 2D wordataIndexspace with X values of d-spacing");
+      "A 2D workspace with X values of d-spacing");
   declareProperty(std::make_unique<WorkspaceProperty<MatrixWorkspace>>("OutputWorkspace", "", Direction::Output),
-                  "The name of the output wordataIndexspace");
+                  "The name of the output workspace");
 
   auto mustBePositive = std::make_shared<BoundedValidator<int>>();
   mustBePositive->setLower(0);
@@ -84,10 +84,10 @@ void CrossCorrelate::init() {
                   "spectra against. ");
   // Spectra in the range [min to max] will be cross correlated to referenceSpectra.
   declareProperty("WorkspaceIndexMin", 0, mustBePositive,
-                  "The wordataIndexspace index of the first member of the range of "
+                  "The workspace index of the first member of the range of "
                   "spectra to cross-correlate against.");
   declareProperty("WorkspaceIndexMax", 0, mustBePositive,
-                  " The wordataIndexspace index of the last member of the range of "
+                  " The workspace index of the last member of the range of "
                   "spectra to cross-correlate against.");
   // max is .1
   declareProperty("MaxDSpaceShift", EMPTY_DBL(), "Optional float for maximum shift to calculate (in d-spacing)");

--- a/Framework/Algorithms/test/CMakeLists.txt
+++ b/Framework/Algorithms/test/CMakeLists.txt
@@ -56,6 +56,7 @@ if(CXXTEST_FOUND)
                         ${MANTIDLIBS}
                         Algorithms
                         DataHandling
+                        CurveFitting
                         Nexus
                         ${BCRYPT}
                         gmock

--- a/Framework/Algorithms/test/CrossCorrelateTest.h
+++ b/Framework/Algorithms/test/CrossCorrelateTest.h
@@ -12,6 +12,21 @@
 #include "MantidHistogramData/LinearGenerator.h"
 #include "MantidTestHelpers/WorkspaceCreationHelper.h"
 
+/* Trying to add minimal working set of function libraries - whittle them down */
+#include "MantidAPI/CompositeFunction.h"
+#include "MantidAPI/Expression.h"
+#include "MantidAPI/FrameworkManager.h"
+#include "MantidAPI/FunctionFactory.h"
+#include "MantidAPI/IBackgroundFunction.h"
+#include "MantidAPI/IConstraint.h"
+#include "MantidAPI/IFunction1D.h"
+#include "MantidAPI/IPeakFunction.h"
+#include "MantidAPI/MultiDomainFunction.h"
+#include "MantidAPI/ParamFunction.h"
+#include "MantidKernel/System.h"
+#include "MantidCurveFitting/Functions/Gaussian.h"
+/* end of minimal working set */
+
 using namespace Mantid;
 using namespace Mantid::Algorithms;
 using namespace Mantid::API;
@@ -26,6 +41,182 @@ public:
   // running other tests
   static CrossCorrelateTest *createSuite() { return new CrossCorrelateTest(); }
   static void destroySuite(CrossCorrelateTest *suite) { delete suite; }
+
+  void dump_vector( std::vector< double > const &v, std::string header_line )
+  {
+    std::cout << header_line << std::endl;
+    for( double i : v )
+    {
+      std::cout << " " << i;
+    }
+    std::cout << std::endl;
+  }
+
+  /* parameterize everything */
+  /* Updated workflow */
+  void test_sanity_0()
+  {
+    /* Create a composite function */
+    /* parameterize Height and Sigma with default values in that string */
+    auto function = std::make_shared<API::CompositeFunction>();
+    function->addFunction( 
+      std::dynamic_pointer_cast<IPeakFunction>(
+        API::FunctionFactory::Instance()
+        .createInitialized("name=Gaussian,Height=10,Sigma=4")));
+    
+    /* create the workspace */
+    int const domain_radius = 10;
+
+    std::vector< double > symmetric_domain( domain_radius * 2 + 1 );
+
+    int num_signals = 4;
+
+    const MatrixWorkspace_sptr workspace =
+    createWorkspace<Workspace2D>( num_signals, symmetric_domain.size(), symmetric_domain.size() );
+
+    /* populate initial domain */
+    std::iota( symmetric_domain.begin(), symmetric_domain.end(), -1 * domain_radius );
+    FunctionDomain1DVector domain( std::move( symmetric_domain ) );
+    /* move after clear */
+    symmetric_domain.clear();
+
+    /* populate range */
+    FunctionValues values( domain );
+    function->function( domain, values );
+
+    /* destroy FunctionValues object and get underlying data primitive */
+    auto co_domain = std::move( values.toVector() );
+
+    /* destroy FunctionDomain1DVector and get underlying data primitive */
+    symmetric_domain = std::move( domain.getVector() );
+
+    dump_vector( symmetric_domain, "domain:" );
+    dump_vector( co_domain, "co-domain:" );
+
+    /* HistogramX - rawData() gets const ref to the vector, mutableX() gets assignable vector */
+    auto &x_data = workspace->mutableX( 0 );
+    x_data.assign( symmetric_domain.cbegin(), symmetric_domain.cend() );
+
+    /* HistogramY */
+    auto &y_data = workspace->mutableY( 0 );
+    y_data.assign( co_domain.cbegin(), co_domain.cend() );
+
+    /* apply domain modifications */
+    /* adjust the symmetric domain */
+    int translation = 5;
+    std::vector< double > translated_domain;
+    std::transform( symmetric_domain.begin(),
+                    symmetric_domain.end(),
+                    std::back_inserter( translated_domain ),
+                    [ translation ]( double d ) -> double { return d + translation; } );
+    
+    /* calculate function values and put in the workspace */
+
+    /* apply domain scaling */
+    int scale_factor = 5;
+    std::vector< double > scaled_domain;
+    std::transform( symmetric_domain.begin(),
+                    symmetric_domain.end(),
+                    std::back_inserter( scaled_domain ),
+                    [ scale_factor ]( double d ) -> double { return scale_factor * d; } );
+
+    /* apply co-domain scaling - then define a class that will handle all this and sets up
+       defaults */
+    workspace->mutableX( 1 ) = workspace->mutableX( 0 );
+    workspace->mutableY( 1 ) = scale_factor * workspace->mutableY( 0 );
+
+    /* Captain! Get it out of there and check that the values look right */
+    auto &data_codomain_scaled = workspace->mutableY( 1 ).rawData();
+    auto &data_domain_scaled = workspace->mutableX( 1 ).rawData();
+    dump_vector( data_domain_scaled, "scaled domain:" );
+    dump_vector( data_codomain_scaled, "scaled co-domain:" );
+
+    /* create new HistogramY and HistogramX and put them in the workspace */
+
+    /* what will the class need to do? 
+     * initialize a function object - parameter string
+     * initialize a workspace - number of workspaces inferred from initializer list length
+       iterate through mod objects, set them according to the operation specified, skip
+       the reference. Make note of the reference so you can get the HistogramY
+     * define a modify object and a scoped enum to have type and value
+     * define a function that handles each type of mod object possibility
+     * define a function that takes in a vector domain and returns a vector codomain
+     * constructor takes in a default-valued initializer list of mod objects?
+       */
+
+    TS_ASSERT_EQUALS( 0, 1 );
+  }
+
+  /* create raw & gaussian workspaces, get stuff out of them */
+  /* initial workflow */
+  void test_sanity()
+  {
+    /* function will extend domain_radius in positive and negative directions from 0 */
+    int const domain_radius = 10;
+    /* add one for the origin - change name to symmetric range */
+    std::vector< double > domain( domain_radius * 2 + 1 );
+    std::iota( domain.begin(), domain.end(), -1 * domain_radius );
+
+    /* matrix workspace creation */
+    int num_signals = 4;
+    const MatrixWorkspace_sptr workspace =
+    createWorkspace<Workspace2D>( num_signals, domain.size(), domain.size() );
+
+    /* HistogramX */
+    auto &x_data = workspace->mutableX( 0 );
+
+    /* HistogramY */
+    auto &y_data = workspace->mutableY( 0 );
+    
+    /* Old code below - use new code above */
+
+    /* Create a function - specify parameter string too? */
+    API::IPeakFunction_sptr gaussian_function =
+      std::dynamic_pointer_cast<IPeakFunction>(
+        API::FunctionFactory::Instance().createFunction("Gaussian"));
+
+    bool test = gaussian_function == nullptr;
+
+
+    /* create domain and allocate co-domain */
+    FunctionDomain1DVector domain_embedded( domain.cbegin(), domain.cend() );
+    FunctionValues values( domain_embedded );
+
+    /* create function */
+    auto function_embedded = std::make_shared<API::CompositeFunction>();
+    function_embedded->addFunction( gaussian_function );
+
+    /* compute co-domain */
+    function_embedded->function( domain_embedded, values );
+
+    /* Does this need to be point data or bin data? Assuming point because easier... */
+
+    x_data.assign( domain.cbegin(), domain.cend() );
+    std::vector< double > values_raw = values.toVector();
+    y_data.assign( values_raw.cbegin(), values_raw.cend() );
+
+    /* shift and scale domain and recompute */
+    double scale = 2;
+    double shift = 2;
+    std::transform( domain.begin(),
+                    domain.end(),
+                    domain.begin(),
+                    [ scale, shift ]( double x ) -> double
+                    {
+                      return x * scale + shift;
+                    } );
+
+    FunctionDomain1DVector domain_modified( domain.cbegin(), domain.cend() );
+
+    function_embedded->function( domain_modified, values );
+
+    /* Assign to a matrix workspace */
+
+    /* shift and scale codomain */
+    /* Assign to the matrix workspace */
+    /* Make all of this object oriented */
+    TS_ASSERT_EQUALS( values[0], values[0] );
+  }
 
   void testValidInput() {
     // setup and run the algorithm (includes basic checks)
@@ -116,6 +307,8 @@ private:
     for (size_t j = 0; j < nBins; ++j) {
       yValues[j] = 0.3 + 10.0 * exp(-0.5 * pow(xValues[j] - 2.5, 2.0) / sigmaSq);
     }
+
+    /* Captain! */
 
     // create the workspace
     const int nHist = 2;

--- a/Framework/Algorithms/test/CrossCorrelateTest.h
+++ b/Framework/Algorithms/test/CrossCorrelateTest.h
@@ -13,6 +13,7 @@
 #include "MantidAPI/IConstraint.h"
 #include "MantidAPI/ParamFunction.h"
 #include "MantidAlgorithms/CrossCorrelate.h"
+#include "MantidCurveFitting/Functions/Gaussian.h"
 #include "MantidHistogramData/LinearGenerator.h"
 #include "MantidTestHelpers/WorkspaceCreationHelper.h"
 
@@ -24,6 +25,17 @@ using namespace Mantid::API;
 using namespace Mantid::DataObjects;
 using Mantid::HistogramData::BinEdges;
 using Mantid::HistogramData::CountStandardDeviations;
+
+namespace {
+// THIS CODE IS COMPLETELY UNNECESSARY, BUT MAKE THE FUNCTION FACTORY WORK
+class HackyGaussian : public Gaussian {
+public:
+  ~HackyGaussian() override {}
+  std::string name() const override { return "Gaussian"; }
+};
+
+DECLARE_FUNCTION(HackyGaussian)
+} // namespace
 
 class CrossCorrelateTest : public CxxTest::TestSuite {
 public:

--- a/Framework/Algorithms/test/CrossCorrelateTest.h
+++ b/Framework/Algorithms/test/CrossCorrelateTest.h
@@ -202,10 +202,7 @@ private:
     // create the x-axis
     BinEdges xEdges(NUM_BINS + 1, HistogramData::LinearGenerator(D_MIN, D_DELTA));
     auto xPoints = HistogramData::Points(xEdges);
-
-    std::vector<double> TOFvalues;
-    std::transform(cbegin(xPoints), cend(xPoints), std::back_inserter(TOFvalues),
-                   [](double d) -> double { return d * 1434.66 + d * d * -1.88 + 2.25; });
+    std::vector<double> xValues(cbegin(xPoints), cend(xPoints));
 
     // create the uncertainties
     CountStandardDeviations e1(NUM_BINS, sqrt(3.0)); // arbitrary
@@ -219,7 +216,7 @@ private:
     for (int spectrumIndex = 0; spectrumIndex < NUM_HIST; ++spectrumIndex) {
       auto compositefunction = CrossCorrelateTestData::createCompositeB2BExp(shape, spectrumIndex);
       ws->setBinEdges(spectrumIndex, xEdges);
-      ws->setCounts(spectrumIndex, CrossCorrelateTestData::evaluateFunction(compositefunction, TOFvalues));
+      ws->setCounts(spectrumIndex, CrossCorrelateTestData::evaluateFunction(compositefunction, xValues));
     }
     ws->rebuildSpectraMapping();
 

--- a/Framework/Algorithms/test/CrossCorrelateTest.h
+++ b/Framework/Algorithms/test/CrossCorrelateTest.h
@@ -91,10 +91,13 @@ public:
     const MatrixWorkspace_const_sptr outWS = runAlgorithm(alg, inWS);
 
     // test that the expected peak of crossCorrelateTestData is correct
+    // but also check for the expected/not expected existence of other peaks
+    // perhaps traversal is unnecessary?
     const auto yVector = outWS->y(0);
+    const auto xVector = outWS->x(0);
     const int yLength = (int)yVector.size();
     double peakVal = -DBL_MAX;
-    int peakIndex = std::nan("");
+    int peakIndex = 0;
     for (int i = 0; i < yLength; ++i) {
       if (yVector[i] > peakVal) {
         peakVal = yVector[i];
@@ -104,6 +107,7 @@ public:
 
     // if the peak index matches up then we are good.
     TS_ASSERT_EQUALS(peakIndex, yLength / 2);
+    TS_ASSERT_EQUALS(peakIndex, xVector[B2BEXP_POSITION_220]);
   }
 
   void testInputXLength2() {
@@ -189,7 +193,7 @@ private:
       ws->setBinEdges(spectrumIndex, xEdges);
       ws->setCounts(spectrumIndex, evaluateFunction(compositefunction, xValues));
     }
-
+    ws->rebuildSpectraMapping();
     return ws;
   }
 
@@ -199,9 +203,7 @@ private:
       alg.initialize();
     alg.setChild(true);
     alg.setProperty("OutputWorkspace", "outWS");
-    alg.setProperty("ReferenceSpectra", 0);
-    alg.setProperty("WorkspaceIndexMin", 0);
-    alg.setProperty("WorkspaceIndexMax", 1);
+    alg.setProperty("WorkspaceIndexMax", 4);
     alg.setProperty("XMin", xmin);
     alg.setProperty("XMax", xmax);
   }

--- a/Framework/Algorithms/test/CrossCorrelateTest.h
+++ b/Framework/Algorithms/test/CrossCorrelateTest.h
@@ -8,13 +8,13 @@
 
 #include <cxxtest/TestSuite.h>
 
-#include "MantidAlgorithms/CrossCorrelate.h"
-#include "MantidHistogramData/LinearGenerator.h"
-#include "MantidTestHelpers/WorkspaceCreationHelper.h"
 #include "MantidAPI/Expression.h"
 #include "MantidAPI/IBackgroundFunction.h"
 #include "MantidAPI/IConstraint.h"
 #include "MantidAPI/ParamFunction.h"
+#include "MantidAlgorithms/CrossCorrelate.h"
+#include "MantidHistogramData/LinearGenerator.h"
+#include "MantidTestHelpers/WorkspaceCreationHelper.h"
 
 #include "CrossCorrelateTestData.h"
 
@@ -25,7 +25,6 @@ using namespace Mantid::DataObjects;
 using Mantid::HistogramData::BinEdges;
 using Mantid::HistogramData::CountStandardDeviations;
 
-
 class CrossCorrelateTest : public CxxTest::TestSuite {
 public:
   // This pair of boilerplate methods prevent the suite being
@@ -35,28 +34,26 @@ public:
   static void destroySuite(CrossCorrelateTest *suite) { delete suite; }
 
   /* print default test gaussian data */
-  void test_default_gaussian_data()
-  {
+  void test_default_gaussian_data() {
     CrossCorrelateTestData test_data;
 
     test_data.print_workspace();
 
     MatrixWorkspace_sptr m = test_data.get_workspace();
 
-    TS_ASSERT_EQUALS( true, m != nullptr );
+    TS_ASSERT_EQUALS(true, m != nullptr);
   }
 
   /* currently, there is something wrong with this - codomain is always zero */
   /* print default test b2bExp data */
-  void test_default_b2bExp()
-  {
-    CrossCorrelateTestData test_data( CrossCorrelateTestData::b2bexp_default_111 );
+  void test_default_b2bExp() {
+    CrossCorrelateTestData test_data(CrossCorrelateTestData::b2bexp_default_111);
 
     test_data.print_workspace();
 
     MatrixWorkspace_sptr m = test_data.get_workspace();
 
-    TS_ASSERT_EQUALS( true, m != nullptr );
+    TS_ASSERT_EQUALS(true, m != nullptr);
   }
 
   void testValidInput() {

--- a/Framework/Algorithms/test/CrossCorrelateTest.h
+++ b/Framework/Algorithms/test/CrossCorrelateTest.h
@@ -11,21 +11,12 @@
 #include "MantidAlgorithms/CrossCorrelate.h"
 #include "MantidHistogramData/LinearGenerator.h"
 #include "MantidTestHelpers/WorkspaceCreationHelper.h"
-
-/* Trying to add minimal working set of function libraries - whittle them down */
-#include "MantidAPI/CompositeFunction.h"
 #include "MantidAPI/Expression.h"
-#include "MantidAPI/FrameworkManager.h"
-#include "MantidAPI/FunctionFactory.h"
 #include "MantidAPI/IBackgroundFunction.h"
 #include "MantidAPI/IConstraint.h"
-#include "MantidAPI/IFunction1D.h"
-#include "MantidAPI/IPeakFunction.h"
-#include "MantidAPI/MultiDomainFunction.h"
 #include "MantidAPI/ParamFunction.h"
-#include "MantidKernel/System.h"
-#include "MantidCurveFitting/Functions/Gaussian.h"
-/* end of minimal working set */
+
+#include "CrossCorrelateTestData.h"
 
 using namespace Mantid;
 using namespace Mantid::Algorithms;
@@ -33,6 +24,7 @@ using namespace Mantid::API;
 using namespace Mantid::DataObjects;
 using Mantid::HistogramData::BinEdges;
 using Mantid::HistogramData::CountStandardDeviations;
+
 
 class CrossCorrelateTest : public CxxTest::TestSuite {
 public:
@@ -42,180 +34,29 @@ public:
   static CrossCorrelateTest *createSuite() { return new CrossCorrelateTest(); }
   static void destroySuite(CrossCorrelateTest *suite) { delete suite; }
 
-  void dump_vector( std::vector< double > const &v, std::string header_line )
+  /* print default test gaussian data */
+  void test_default_gaussian_data()
   {
-    std::cout << header_line << std::endl;
-    for( double i : v )
-    {
-      std::cout << " " << i;
-    }
-    std::cout << std::endl;
+    CrossCorrelateTestData test_data;
+
+    test_data.print_workspace();
+
+    MatrixWorkspace_sptr m = test_data.get_workspace();
+
+    TS_ASSERT_EQUALS( true, m != nullptr );
   }
 
-  /* parameterize everything */
-  /* Updated workflow */
-  void test_sanity_0()
+  /* currently, there is something wrong with this - codomain is always zero */
+  /* print default test b2bExp data */
+  void test_default_b2bExp()
   {
-    /* Create a composite function */
-    /* parameterize Height and Sigma with default values in that string */
-    auto function = std::make_shared<API::CompositeFunction>();
-    function->addFunction( 
-      std::dynamic_pointer_cast<IPeakFunction>(
-        API::FunctionFactory::Instance()
-        .createInitialized("name=Gaussian,Height=10,Sigma=4")));
-    
-    /* create the workspace */
-    int const domain_radius = 10;
+    CrossCorrelateTestData test_data( CrossCorrelateTestData::b2bexp_default_111 );
 
-    std::vector< double > symmetric_domain( domain_radius * 2 + 1 );
+    test_data.print_workspace();
 
-    int num_signals = 4;
+    MatrixWorkspace_sptr m = test_data.get_workspace();
 
-    const MatrixWorkspace_sptr workspace =
-    createWorkspace<Workspace2D>( num_signals, symmetric_domain.size(), symmetric_domain.size() );
-
-    /* populate initial domain */
-    std::iota( symmetric_domain.begin(), symmetric_domain.end(), -1 * domain_radius );
-    FunctionDomain1DVector domain( std::move( symmetric_domain ) );
-    /* move after clear */
-    symmetric_domain.clear();
-
-    /* populate range */
-    FunctionValues values( domain );
-    function->function( domain, values );
-
-    /* destroy FunctionValues object and get underlying data primitive */
-    auto co_domain = std::move( values.toVector() );
-
-    /* destroy FunctionDomain1DVector and get underlying data primitive */
-    symmetric_domain = std::move( domain.getVector() );
-
-    dump_vector( symmetric_domain, "domain:" );
-    dump_vector( co_domain, "co-domain:" );
-
-    /* HistogramX - rawData() gets const ref to the vector, mutableX() gets assignable vector */
-    auto &x_data = workspace->mutableX( 0 );
-    x_data.assign( symmetric_domain.cbegin(), symmetric_domain.cend() );
-
-    /* HistogramY */
-    auto &y_data = workspace->mutableY( 0 );
-    y_data.assign( co_domain.cbegin(), co_domain.cend() );
-
-    /* apply domain modifications */
-    /* adjust the symmetric domain */
-    int translation = 5;
-    std::vector< double > translated_domain;
-    std::transform( symmetric_domain.begin(),
-                    symmetric_domain.end(),
-                    std::back_inserter( translated_domain ),
-                    [ translation ]( double d ) -> double { return d + translation; } );
-    
-    /* calculate function values and put in the workspace */
-
-    /* apply domain scaling */
-    int scale_factor = 5;
-    std::vector< double > scaled_domain;
-    std::transform( symmetric_domain.begin(),
-                    symmetric_domain.end(),
-                    std::back_inserter( scaled_domain ),
-                    [ scale_factor ]( double d ) -> double { return scale_factor * d; } );
-
-    /* apply co-domain scaling - then define a class that will handle all this and sets up
-       defaults */
-    workspace->mutableX( 1 ) = workspace->mutableX( 0 );
-    workspace->mutableY( 1 ) = scale_factor * workspace->mutableY( 0 );
-
-    /* Captain! Get it out of there and check that the values look right */
-    auto &data_codomain_scaled = workspace->mutableY( 1 ).rawData();
-    auto &data_domain_scaled = workspace->mutableX( 1 ).rawData();
-    dump_vector( data_domain_scaled, "scaled domain:" );
-    dump_vector( data_codomain_scaled, "scaled co-domain:" );
-
-    /* create new HistogramY and HistogramX and put them in the workspace */
-
-    /* what will the class need to do? 
-     * initialize a function object - parameter string
-     * initialize a workspace - number of workspaces inferred from initializer list length
-       iterate through mod objects, set them according to the operation specified, skip
-       the reference. Make note of the reference so you can get the HistogramY
-     * define a modify object and a scoped enum to have type and value
-     * define a function that handles each type of mod object possibility
-     * define a function that takes in a vector domain and returns a vector codomain
-     * constructor takes in a default-valued initializer list of mod objects?
-       */
-
-    TS_ASSERT_EQUALS( 0, 1 );
-  }
-
-  /* create raw & gaussian workspaces, get stuff out of them */
-  /* initial workflow */
-  void test_sanity()
-  {
-    /* function will extend domain_radius in positive and negative directions from 0 */
-    int const domain_radius = 10;
-    /* add one for the origin - change name to symmetric range */
-    std::vector< double > domain( domain_radius * 2 + 1 );
-    std::iota( domain.begin(), domain.end(), -1 * domain_radius );
-
-    /* matrix workspace creation */
-    int num_signals = 4;
-    const MatrixWorkspace_sptr workspace =
-    createWorkspace<Workspace2D>( num_signals, domain.size(), domain.size() );
-
-    /* HistogramX */
-    auto &x_data = workspace->mutableX( 0 );
-
-    /* HistogramY */
-    auto &y_data = workspace->mutableY( 0 );
-    
-    /* Old code below - use new code above */
-
-    /* Create a function - specify parameter string too? */
-    API::IPeakFunction_sptr gaussian_function =
-      std::dynamic_pointer_cast<IPeakFunction>(
-        API::FunctionFactory::Instance().createFunction("Gaussian"));
-
-    bool test = gaussian_function == nullptr;
-
-
-    /* create domain and allocate co-domain */
-    FunctionDomain1DVector domain_embedded( domain.cbegin(), domain.cend() );
-    FunctionValues values( domain_embedded );
-
-    /* create function */
-    auto function_embedded = std::make_shared<API::CompositeFunction>();
-    function_embedded->addFunction( gaussian_function );
-
-    /* compute co-domain */
-    function_embedded->function( domain_embedded, values );
-
-    /* Does this need to be point data or bin data? Assuming point because easier... */
-
-    x_data.assign( domain.cbegin(), domain.cend() );
-    std::vector< double > values_raw = values.toVector();
-    y_data.assign( values_raw.cbegin(), values_raw.cend() );
-
-    /* shift and scale domain and recompute */
-    double scale = 2;
-    double shift = 2;
-    std::transform( domain.begin(),
-                    domain.end(),
-                    domain.begin(),
-                    [ scale, shift ]( double x ) -> double
-                    {
-                      return x * scale + shift;
-                    } );
-
-    FunctionDomain1DVector domain_modified( domain.cbegin(), domain.cend() );
-
-    function_embedded->function( domain_modified, values );
-
-    /* Assign to a matrix workspace */
-
-    /* shift and scale codomain */
-    /* Assign to the matrix workspace */
-    /* Make all of this object oriented */
-    TS_ASSERT_EQUALS( values[0], values[0] );
+    TS_ASSERT_EQUALS( true, m != nullptr );
   }
 
   void testValidInput() {
@@ -307,8 +148,6 @@ private:
     for (size_t j = 0; j < nBins; ++j) {
       yValues[j] = 0.3 + 10.0 * exp(-0.5 * pow(xValues[j] - 2.5, 2.0) / sigmaSq);
     }
-
-    /* Captain! */
 
     // create the workspace
     const int nHist = 2;

--- a/Framework/Algorithms/test/CrossCorrelateTest.h
+++ b/Framework/Algorithms/test/CrossCorrelateTest.h
@@ -26,16 +26,14 @@ using namespace Mantid::DataObjects;
 using Mantid::HistogramData::BinEdges;
 using Mantid::HistogramData::CountStandardDeviations;
 
-namespace {
 // THIS CODE IS COMPLETELY UNNECESSARY, BUT MAKE THE FUNCTION FACTORY WORK
-class DLLExport HackyGaussian : public Gaussian {
+class HackyGaussian : public Gaussian {
 public:
   ~HackyGaussian() override {}
   std::string name() const override { return "Gaussian"; }
 };
 
 DECLARE_FUNCTION(HackyGaussian)
-} // namespace
 
 class CrossCorrelateTest : public CxxTest::TestSuite {
 public:

--- a/Framework/Algorithms/test/CrossCorrelateTest.h
+++ b/Framework/Algorithms/test/CrossCorrelateTest.h
@@ -87,8 +87,8 @@ public:
     auto inputWS = makeFakeWorkspace3Peaks(PeakShapeEnum::GAUSSIAN);
     TS_ASSERT(inputWS != nullptr);
 
-    const MatrixWorkspace_const_sptr inWS = setupAlgorithm(alg, inputWS, 0.0, 4.0, 5);
-    const MatrixWorkspace_const_sptr outWS = runAlgorithm(alg, inWS);
+    setupAlgorithm(alg, 0.0, 4.0, inputWS, 5);
+    const MatrixWorkspace_const_sptr outWS = runAlgorithm(alg, inputWS);
 
     // test that the expected peak of crossCorrelateTestData is correct
     // but also check for the expected/not expected existence of other peaks
@@ -214,22 +214,20 @@ private:
     // create the workspace
     const MatrixWorkspace_sptr inWS = makeFakeWorkspace();
 
-    setupAlgorithmPropsBasic(alg, xmin, xmax);
-    alg.setProperty("InputWorkspace", inWS);
+    setupAlgorithm(alg, xmin, xmax, inWS);
 
     return inWS;
   }
 
   // Initialise the algorithm and set the properties, using the provided ws as input
-  MatrixWorkspace_const_sptr setupAlgorithm(CrossCorrelate &alg, const MatrixWorkspace_sptr inWS, const double xmin,
-                                            const double xmax, const double maxDSpaceShift) {
+  void setupAlgorithm(CrossCorrelate &alg, const double xmin, const double xmax, const MatrixWorkspace_sptr inWS,
+                      const double maxDSpaceShift = 0.) {
 
     // create the workspace
     setupAlgorithmPropsBasic(alg, xmin, xmax);
     alg.setProperty("InputWorkspace", inWS);
-    alg.setProperty("MaxDspaceShift", maxDSpaceShift);
-
-    return inWS;
+    if (maxDSpaceShift > 0.)
+      alg.setProperty("MaxDspaceShift", maxDSpaceShift);
   }
 
   // Run the algorithm and do some basic checks. Returns the output workspace.

--- a/Framework/Algorithms/test/CrossCorrelateTest.h
+++ b/Framework/Algorithms/test/CrossCorrelateTest.h
@@ -205,9 +205,9 @@ private:
     // loop over the spectra
     // which spectra is which is coded in createcompositeB2BExp
     for (int spectrumIndex = 0; spectrumIndex < NUM_HIST; ++spectrumIndex) {
-      auto compositefunction = CrossCorrelateTestData::createCompositeB2BExp(shape, spectrumIndex);
+      auto compositefunction = createCompositeB2BExp(shape, spectrumIndex);
       ws->setBinEdges(spectrumIndex, xEdges);
-      ws->setCounts(spectrumIndex, CrossCorrelateTestData::evaluateFunction(compositefunction, TOFvalues));
+      ws->setCounts(spectrumIndex, evaluateFunction(compositefunction, TOFvalues));
     }
     ws->rebuildSpectraMapping();
 

--- a/Framework/Algorithms/test/CrossCorrelateTest.h
+++ b/Framework/Algorithms/test/CrossCorrelateTest.h
@@ -97,13 +97,23 @@ public:
     auto inputWS = makeFakeWorkspace3Peaks();
     TS_ASSERT(inputWS != nullptr);
 
-    test_data.print_workspace();
-
-    TS_ASSERT_LESS_THAN(2, test_data.get_workspace()->y(0).size());
-    TS_ASSERT_EQUALS(test_data.get_workspace()->y(0).size(), test_data.get_workspace()->x(0).size() - 1);
-    TS_ASSERT_EQUALS(test_data.get_workspace()->y(0).size(), test_data.get_workspace()->e(0).size())
-    const MatrixWorkspace_const_sptr inWS = setupAlgorithm(alg, test_data.get_workspace(), 0.0, 4.0, 5);
+    const MatrixWorkspace_const_sptr inWS = setupAlgorithm(alg, inputWS, 0.0, 4.0, 5);
     const MatrixWorkspace_const_sptr outWS = runAlgorithm(alg, inWS);
+
+    // test that the expected peak of crossCorrelateTestData is correct
+    const auto yVector = outWS->y(0);
+    const int yLength = (int)yVector.size();
+    double peakVal = -DBL_MAX;
+    int peakIndex = std::nan("");
+    for (int i = 0; i < yLength; ++i) {
+      if (yVector[i] > peakVal) {
+        peakVal = yVector[i];
+        peakIndex = i;
+      }
+    }
+
+    // if the peak index matches up then we are good.
+    TS_ASSERT_EQUALS(peakIndex, yLength / 2);
   }
 
   void testInputXLength2() {
@@ -218,8 +228,7 @@ private:
     return inWS;
   }
 
-  // Initialise the algorithm and set the properties. Creates a fake workspace
-  // for the input and returns it.
+  // Initialise the algorithm and set the properties, using the provided ws as input
   MatrixWorkspace_const_sptr setupAlgorithm(CrossCorrelate &alg, const MatrixWorkspace_sptr inWS, const double xmin,
                                             const double xmax, const double maxDSpaceShift) {
 

--- a/Framework/Algorithms/test/CrossCorrelateTest.h
+++ b/Framework/Algorithms/test/CrossCorrelateTest.h
@@ -95,19 +95,13 @@ public:
     // perhaps traversal is unnecessary?
     const auto yVector = outWS->y(0);
     const auto xVector = outWS->x(0);
-    const int yLength = (int)yVector.size();
-    double peakVal = -DBL_MAX;
-    int peakIndex = 0;
-    for (int i = 0; i < yLength; ++i) {
-      if (yVector[i] > peakVal) {
-        peakVal = yVector[i];
-        peakIndex = i;
-      }
-    }
+    const auto peakIter = std::max_element(yVector.cbegin(), yVector.cend());
+    const auto peakIndex = static_cast<size_t>(peakIter - yVector.cbegin());
 
     // if the peak index matches up then we are good.
-    TS_ASSERT_EQUALS(peakIndex, yLength / 2);
-    TS_ASSERT_EQUALS(peakIndex, xVector[B2BEXP_POSITION_220]);
+    TS_ASSERT_EQUALS(peakIndex, yVector.size() / 2); // probably doesn't matter
+    TS_ASSERT_EQUALS(outWS->x(0)[peakIndex], 0.);
+    // TODO check other spectra
   }
 
   void testInputXLength2() {
@@ -197,13 +191,13 @@ private:
     return ws;
   }
 
-  void setupAlgorithmPropsBasic(CrossCorrelate &alg, const double xmin, const double xmax) {
+  void setupAlgorithmPropsBasic(CrossCorrelate &alg, const double xmin, const double xmax, const size_t numSpectra) {
     // set up the algorithm
     if (!alg.isInitialized())
       alg.initialize();
     alg.setChild(true);
     alg.setProperty("OutputWorkspace", "outWS");
-    alg.setProperty("WorkspaceIndexMax", 4);
+    alg.setProperty("WorkspaceIndexMax", static_cast<int>(numSpectra - 1));
     alg.setProperty("XMin", xmin);
     alg.setProperty("XMax", xmax);
   }
@@ -224,7 +218,7 @@ private:
                       const double maxDSpaceShift = 0.) {
 
     // create the workspace
-    setupAlgorithmPropsBasic(alg, xmin, xmax);
+    setupAlgorithmPropsBasic(alg, xmin, xmax, inWS->getNumberHistograms());
     alg.setProperty("InputWorkspace", inWS);
     if (maxDSpaceShift > 0.)
       alg.setProperty("MaxDspaceShift", maxDSpaceShift);

--- a/Framework/Algorithms/test/CrossCorrelateTest.h
+++ b/Framework/Algorithms/test/CrossCorrelateTest.h
@@ -172,7 +172,12 @@ private:
 
     // create the x-axis
     BinEdges xEdges(NUM_BINS + 1, HistogramData::LinearGenerator(D_MIN, D_DELTA));
-    std::vector<double> xValues(cbegin(xEdges), cend(xEdges) - 1);
+    auto xPoints = HistogramData::Points(xEdges);
+
+    std::vector<double> TOFvalues;
+    std::transform(cbegin(xPoints), cend(xPoints), std::back_inserter(TOFvalues),
+                   [](double d) -> double { return d * 1434.66 + d * d * -1.88 + 2.25; });
+
     // create the uncertainties
     CountStandardDeviations e1(NUM_BINS, sqrt(3.0)); // arbitrary
 
@@ -185,9 +190,10 @@ private:
     for (int spectrumIndex = 0; spectrumIndex < NUM_HIST; ++spectrumIndex) {
       auto compositefunction = createCompositeB2BExp(shape, spectrumIndex);
       ws->setBinEdges(spectrumIndex, xEdges);
-      ws->setCounts(spectrumIndex, evaluateFunction(compositefunction, xValues));
+      ws->setCounts(spectrumIndex, evaluateFunction(compositefunction, TOFvalues));
     }
     ws->rebuildSpectraMapping();
+
     return ws;
   }
 

--- a/Framework/Algorithms/test/CrossCorrelateTest.h
+++ b/Framework/Algorithms/test/CrossCorrelateTest.h
@@ -28,7 +28,7 @@ using Mantid::HistogramData::CountStandardDeviations;
 
 namespace {
 // THIS CODE IS COMPLETELY UNNECESSARY, BUT MAKE THE FUNCTION FACTORY WORK
-class HackyGaussian : public Gaussian {
+class DLLExport HackyGaussian : public Gaussian {
 public:
   ~HackyGaussian() override {}
   std::string name() const override { return "Gaussian"; }

--- a/Framework/Algorithms/test/CrossCorrelateTest.h
+++ b/Framework/Algorithms/test/CrossCorrelateTest.h
@@ -205,9 +205,9 @@ private:
     // loop over the spectra
     // which spectra is which is coded in createcompositeB2BExp
     for (int spectrumIndex = 0; spectrumIndex < NUM_HIST; ++spectrumIndex) {
-      auto compositefunction = createCompositeB2BExp(shape, spectrumIndex);
+      auto compositefunction = CrossCorrelateTestData::createCompositeB2BExp(shape, spectrumIndex);
       ws->setBinEdges(spectrumIndex, xEdges);
-      ws->setCounts(spectrumIndex, evaluateFunction(compositefunction, TOFvalues));
+      ws->setCounts(spectrumIndex, CrossCorrelateTestData::evaluateFunction(compositefunction, TOFvalues));
     }
     ws->rebuildSpectraMapping();
 

--- a/Framework/Algorithms/test/CrossCorrelateTest.h
+++ b/Framework/Algorithms/test/CrossCorrelateTest.h
@@ -170,7 +170,7 @@ private:
     const double D_MAX{2.3};
     const double D_DELTA{0.01};
     const int NUM_BINS = static_cast<int>((D_MAX - D_MIN) / D_DELTA);
-    const int NUM_HIST{1}; // TODO change to 4
+    const int NUM_HIST{2}; // TODO change to 4
 
     // create the x-axis
     BinEdges xEdges(NUM_BINS + 1, HistogramData::LinearGenerator(D_MIN, D_DELTA));

--- a/Framework/Algorithms/test/CrossCorrelateTest.h
+++ b/Framework/Algorithms/test/CrossCorrelateTest.h
@@ -104,6 +104,19 @@ public:
     TS_ASSERT_DELTA(outY1[0], -1.0, 1e-6);
   }
 
+  void testMaxDSpaceShift() {
+    CrossCorrelate alg;
+    CrossCorrelateTestData test_data;
+
+    test_data.print_workspace();
+
+    TS_ASSERT_LESS_THAN(2, test_data.get_workspace()->y(0).size());
+    TS_ASSERT_EQUALS(test_data.get_workspace()->y(0).size(), test_data.get_workspace()->x(0).size() - 1);
+    TS_ASSERT_EQUALS(test_data.get_workspace()->y(0).size(), test_data.get_workspace()->e(0).size())
+    const MatrixWorkspace_const_sptr inWS = setupAlgorithm(alg, test_data.get_workspace(), 0.0, 4.0, 5);
+    const MatrixWorkspace_const_sptr outWS = runAlgorithm(alg, inWS);
+  }
+
   void testInputXLength2() {
     // this throws because at least 3 X values are required
     CrossCorrelate alg;
@@ -163,6 +176,18 @@ private:
     return ws;
   }
 
+  void setupAlgorithmPropsBasic(CrossCorrelate &alg, const double xmin, const double xmax) {
+    // set up the algorithm
+    if (!alg.isInitialized())
+      alg.initialize();
+    alg.setChild(true);
+    alg.setProperty("OutputWorkspace", "outWS");
+    alg.setProperty("ReferenceSpectra", 0);
+    alg.setProperty("WorkspaceIndexMin", 0);
+    alg.setProperty("WorkspaceIndexMax", 1);
+    alg.setProperty("XMin", xmin);
+    alg.setProperty("XMax", xmax);
+  }
   // Initialise the algorithm and set the properties. Creates a fake workspace
   // for the input and returns it.
   MatrixWorkspace_const_sptr setupAlgorithm(CrossCorrelate &alg, const double xmin, const double xmax) {
@@ -170,17 +195,21 @@ private:
     // create the workspace
     const MatrixWorkspace_sptr inWS = makeFakeWorkspace();
 
-    // set up the algorithm
-    if (!alg.isInitialized())
-      alg.initialize();
-    alg.setChild(true);
+    setupAlgorithmPropsBasic(alg, xmin, xmax);
     alg.setProperty("InputWorkspace", inWS);
-    alg.setProperty("OutputWorkspace", "outWS");
-    alg.setProperty("ReferenceSpectra", 0);
-    alg.setProperty("WorkspaceIndexMin", 0);
-    alg.setProperty("WorkspaceIndexMax", 1);
-    alg.setProperty("XMin", xmin);
-    alg.setProperty("XMax", xmax);
+
+    return inWS;
+  }
+
+  // Initialise the algorithm and set the properties. Creates a fake workspace
+  // for the input and returns it.
+  MatrixWorkspace_const_sptr setupAlgorithm(CrossCorrelate &alg, const MatrixWorkspace_sptr inWS, const double xmin,
+                                            const double xmax, const double maxDSpaceShift) {
+
+    // create the workspace
+    setupAlgorithmPropsBasic(alg, xmin, xmax);
+    alg.setProperty("InputWorkspace", inWS);
+    alg.setProperty("MaxDspaceShift", maxDSpaceShift);
 
     return inWS;
   }

--- a/Framework/Algorithms/test/CrossCorrelateTestData.h
+++ b/Framework/Algorithms/test/CrossCorrelateTestData.h
@@ -209,10 +209,10 @@ std::vector<double> CrossCorrelateTestData::apply_function(std::vector<double> &
   function->function(domain_oop, co_domain_oop);
 
   /* invalidate FunctionDomain1DVector and get underlying data primitive */
-  domain = std::move(domain_oop.getVector());
+  domain = domain_oop.getVector();
 
   /* invalidate FunctionValues object and get underlying data primitive */
-  auto co_domain = std::move(co_domain_oop.toVector());
+  auto co_domain = co_domain_oop.toVector();
 
   return co_domain;
 }

--- a/Framework/Algorithms/test/CrossCorrelateTestData.h
+++ b/Framework/Algorithms/test/CrossCorrelateTestData.h
@@ -103,7 +103,7 @@ const double B2BEXP_POSITION_311 = 1.07577;
 enum class PeakIndex : int { POS_111, POS_220, POS_311 };
 
 std::shared_ptr<IFunction> createPeakFunction(const PeakShapeEnum shape, const PeakIndex peak_index,
-                                              const double intensity, const double position) {
+                                              const double intensity, const double d) {
   std::stringstream peak;
   if (shape == PeakShapeEnum::B2BEXP) {
     peak << "name=Bk2BkExpConvPV,";
@@ -116,10 +116,10 @@ std::shared_ptr<IFunction> createPeakFunction(const PeakShapeEnum shape, const P
     } else {
       throw std::runtime_error("Developer forgot a peak index");
     }
-    peak << ",Intensity=" << intensity << ",X0=" << position;
+    peak << ",Intensity=" << intensity << ",X0=" << d * 1434.66 + d * d * -1.88 + 2.25;
   } else if (shape == PeakShapeEnum::GAUSSIAN) {
     // all Gaussians are hard coded to same arbitrary width
-    peak << "name=Gaussian,Sigma=0.1,Height=" << intensity << ",PeakCentre=" << position;
+    peak << "name=Gaussian,Sigma=10,Height=" << intensity << ",PeakCentre=" << d * 1434.66 + d * d * -1.88 + 2.25;
   }
 
   return FunctionFactory::Instance().createInitialized(peak.str());
@@ -139,7 +139,7 @@ CompositeFunction_sptr createCompositeB2BExp(const PeakShapeEnum shape, const in
 
   // values for reference spectrum that may be changed for the others
   double shift_in_d{0.};
-  double scale_in_d{0.};
+  double scale_in_d{1.};
   double horizontal_shift{0.};
   double height_111{100.};
   double height_220{200.};
@@ -175,7 +175,7 @@ CompositeFunction_sptr createCompositeB2BExp(const PeakShapeEnum shape, const in
   if (horizontal_shift > 0.) {
     std::stringstream background;
     background << "name=FlatBackground,A0=" << horizontal_shift;
-    FunctionFactory::Instance().createInitialized(background.str());
+    function->addFunction(FunctionFactory::Instance().createInitialized(background.str()));
   }
 
   return function;

--- a/Framework/Algorithms/test/CrossCorrelateTestData.h
+++ b/Framework/Algorithms/test/CrossCorrelateTestData.h
@@ -20,9 +20,10 @@ using namespace Mantid::Kernel;
 using namespace Mantid::DataObjects;
 using Mantid::CurveFitting::Functions::Gaussian;
 
+enum class PeakShapeEnum : int { B2BEXP, GAUSSIAN };
+
 namespace { // anonymous
 /*
-
 Code to generate parameters for b2bexpconvpv:
 
   import numpy as np
@@ -90,12 +91,9 @@ Code to generate parameters for b2bexpconvpv:
 */
 
 // these are intentionally missing "Intensity" and "X0" (center)
-const std::string B2BEXP_SHAPE_111 = "name=Bk2BkExpConvPV,Alpha=0.03842,Beta=0.06335,Sigma2=37.33017,Gamma = "
-                                     "6.23432,Intensity=100";
-const std::string B2BEXP_SHAPE_220 = "name=Bk2BkExpConvPV,Alpha=0.06274,Beta=0.09550,Sigma2=18.78430,Gamma=3."
-                                     "81773";
-const std::string B2BEXP_SHAPE_311 = "name=Bk2BkExpConvPV,Alpha=0.07357,Beta=0.12883,Sigma2=15.37579,Gamma=3."
-                                     "25575,Intensity=100";
+const std::string B2BEXP_SHAPE_111 = "Alpha=0.03842,Beta=0.06335,Sigma2=37.33017,Gamma=6.23432";
+const std::string B2BEXP_SHAPE_220 = "Alpha=0.06274,Beta=0.09550,Sigma2=18.78430,Gamma=3.81773";
+const std::string B2BEXP_SHAPE_311 = "Alpha=0.07357,Beta=0.12883,Sigma2=15.37579,Gamma=3.25575";
 
 const double B2BEXP_POSITION_111 = 2.05995;
 const double B2BEXP_POSITION_220 = 1.26146;
@@ -103,72 +101,86 @@ const double B2BEXP_POSITION_311 = 1.07577;
 
 enum class PeakIndex : int { POS_111, POS_220, POS_311 };
 
-std::shared_ptr<IFunction> createPeakFunction(const PeakIndex peak_index, const double intensity,
-                                              const double position) {
+std::shared_ptr<IFunction> createPeakFunction(const PeakShapeEnum shape, const PeakIndex peak_index,
+                                              const double intensity, const double position) {
   std::stringstream peak;
-  if (peak_index == PeakIndex::POS_111) {
-    peak << B2BEXP_SHAPE_111;
-  } else if (peak_index == PeakIndex::POS_220) {
-    peak << B2BEXP_SHAPE_220;
-  } else if (peak_index == PeakIndex::POS_311) {
-    peak << B2BEXP_SHAPE_311;
-  } else {
-    throw std::runtime_error("Developer forgot a peak index");
+  if (shape == PeakShapeEnum::B2BEXP) {
+    peak << "name=Bk2BkExpConvPV,";
+    if (peak_index == PeakIndex::POS_111) {
+      peak << B2BEXP_SHAPE_111;
+    } else if (peak_index == PeakIndex::POS_220) {
+      peak << B2BEXP_SHAPE_220;
+    } else if (peak_index == PeakIndex::POS_311) {
+      peak << B2BEXP_SHAPE_311;
+    } else {
+      throw std::runtime_error("Developer forgot a peak index");
+    }
+    peak << ",Intensity=" << intensity << ",X0=" << position;
+  } else if (shape == PeakShapeEnum::GAUSSIAN) {
+    // all Gaussians are hard coded to same arbitrary width
+    peak << "name=Gaussian,Sigma=0.1,Height=" << intensity << ",PeakCentre=" << position;
   }
-  peak << ",Intensity=" << intensity << ",X0=" << position;
 
   return FunctionFactory::Instance().createInitialized(peak.str());
 }
 
 std::vector<double> evaluateFunction(std::shared_ptr<IFunction> function, std::vector<double> &xValues) {
-  FunctionDomain1DVector fd(xValues);
-  FunctionValues fv(fd);
-  function->function(fd, fv);
-  return fv.toVector();
+  FunctionDomain1DVector domain(xValues);
+  FunctionValues values(domain);
+  function->function(domain, values);
+  return values.toVector();
 }
 
 } // anonymous namespace
 
-CompositeFunction_sptr createCompositeB2BExp(const int spectrumIndex) {
+CompositeFunction_sptr createCompositeB2BExp(const PeakShapeEnum shape, const int spectrumIndex) {
   CompositeFunction_sptr function = std::make_shared<CompositeFunction>();
 
   // values for reference spectrum that may be changed for the others
   double shift_in_d{0.};
+  double scale_in_d{0.};
+  double horizontal_shift{0.};
   double height_111{100.};
   double height_220{200.};
   double height_311{300.};
-  if (spectrumIndex == 0) {
+  if (spectrumIndex == 0) { // expected value = 0.
     // reference spectrum
-  } else if (spectrumIndex == 1) {
-    // horizontal shift in the data
+  } else if (spectrumIndex == 1) { // expected value = .1
+    // additive shift in d-spacing from the reference
     // peak heights are unchanged
     shift_in_d = .1;
+  } else if (spectrumIndex == 2) { // expected value = ???
+                                   // multiplicative shift in d-spacing from the reference
+                                   // peak heights are unchanged
+    scale_in_d = 1.1;
+  } else if (spectrumIndex == 3) { // expected value = 0.
+    // shifted vertically by  a constant
+    horizontal_shift = 40.;
+  } else if (spectrumIndex == 4) { // expected value = 0.
+    // scaled version of the reference - done via peak heights
+    height_111 *= 2;
+    height_220 *= 2;
+    height_311 *= 2;
   } else {
     throw std::runtime_error("Logic for this spectrum index has not been written");
   }
 
-  function->addFunction(createPeakFunction(PeakIndex::POS_111, height_111, B2BEXP_POSITION_111 + shift_in_d));
-  function->addFunction(createPeakFunction(PeakIndex::POS_220, height_220, B2BEXP_POSITION_220 + shift_in_d));
-  function->addFunction(createPeakFunction(PeakIndex::POS_311, height_311, B2BEXP_POSITION_311 + shift_in_d));
+  function->addFunction(
+      createPeakFunction(shape, PeakIndex::POS_111, height_111, scale_in_d * B2BEXP_POSITION_111 + shift_in_d));
+  function->addFunction(
+      createPeakFunction(shape, PeakIndex::POS_220, height_220, scale_in_d * B2BEXP_POSITION_220 + shift_in_d));
+  function->addFunction(
+      createPeakFunction(shape, PeakIndex::POS_311, height_311, scale_in_d * B2BEXP_POSITION_311 + shift_in_d));
+  if (horizontal_shift > 0.) {
+    std::stringstream background;
+    background << "name=FlatBackground,A0=" << horizontal_shift;
+    FunctionFactory::Instance().createInitialized(background.str());
+  }
 
   return function;
 }
 
-/* define the types of transforms that can be applied to
-   a 1D function */
-enum class transforms : int { domain_scale, domain_translate, co_domain_scale, co_domain_translate };
-
-/* define a supported transformation with type and scalar amount */
-class TransformSpecifier {
-
-public:
-  TransformSpecifier(transforms const type, double scalar) : transform_type(type), scalar(scalar) {}
-
-  transforms const transform_type;
-
-  double scalar;
-};
-
+// THIS CODE IS COMPLETELY UNNECESSARY, BUT MAKE THE FUNCTION FACTORY WORK
 // Algorithm to force Gaussian1D to be run by simplex algorithm
 class SimplexGaussian : public Gaussian {
 public:
@@ -185,210 +197,3 @@ protected:
 };
 
 DECLARE_FUNCTION(SimplexGaussian)
-/*
-  Create fake data to test cross correlation
-
-  This class creates a matrix workspace with a reference function in the
-  first index and subsequent indices containing a transformed version of
-  the reference function.
-
-  The transform at index "i" for 1 < i < len( l ) contains
-  the reference function transformed according to the specification
-  in l[ i - 1 ] where "l" is the initializer list constructor argument.
-
-  use get_workspace() to get the workspace
-*/
-class CrossCorrelateTestData {
-public:
-  inline static std::string const gaussian_default = "name=Gaussian,Height=20,Sigma=4";
-
-  /* Specify default values */
-  CrossCorrelateTestData(std::string function_specifier = gaussian_default, int domain_radius = 20,
-                         std::initializer_list<class TransformSpecifier> l = {
-                             // TransformSpecifier(transforms::domain_translate, 10),
-                             // TransformSpecifier(transforms::domain_scale, 10),
-                             // TransformSpecifier(transforms::co_domain_translate, 10),
-                             // TransformSpecifier(transforms::co_domain_scale, 10)
-                         });
-
-  MatrixWorkspace_sptr get_workspace() { return workspace; }
-
-  /* debugging function - print to stdout */
-  void print_workspace();
-
-  /* methods */
-private:
-  /* generates the co-domain given the domain */
-  std::vector<double> apply_function(std::vector<double> &domain);
-
-  /* offset domain by a constant before applying a function */
-  std::vector<double> translate_domain(std::vector<double> const &domain, double translation);
-
-  /* scale domain by a constant factor before applying a function */
-  std::vector<double> scale_domain(std::vector<double> const &domain, double scale_factor);
-
-  /* scaling and translation of the co-domain can occur after the function has
-     already
-     been evaluated by manipulating the entries in the workspace: */
-  void translate_co_domain(int reference_index, int target_index, double translation);
-
-  void scale_co_domain(int reference_index, int target_index, double scale_factor);
-
-  /* assign at given index */
-  void assign_to_workspace(int workspace_index, std::vector<double> const &domain,
-                           std::vector<double> const &co_domain);
-
-  /* print a vector */
-  void dump_vector(std::vector<double> const &v, std::string header_line);
-
-  /* variables */
-private:
-  /* this object's deliverable */
-  MatrixWorkspace_sptr workspace;
-
-  /* function to map domain to co-domain */
-  std::shared_ptr<CompositeFunction> function;
-
-  /* function extends this far from the origin in either direction */
-  int const domain_radius;
-
-  /* number of functions in the workspace */
-  size_t const num_functions;
-};
-
-/* it will move and unmove this vector */
-std::vector<double> CrossCorrelateTestData::apply_function(std::vector<double> &domain) {
-  FunctionDomain1DVector domain_oop(std::move(domain));
-  /* move after clear */
-  domain.clear();
-
-  /* populate range */
-  FunctionValues co_domain_oop(domain_oop);
-  function->function(domain_oop, co_domain_oop);
-
-  /* invalidate FunctionDomain1DVector and get underlying data primitive */
-  domain = domain_oop.getVector();
-
-  /* invalidate FunctionValues object and get underlying data primitive */
-  auto co_domain = co_domain_oop.toVector();
-
-  return co_domain;
-}
-
-std::vector<double> CrossCorrelateTestData::translate_domain(std::vector<double> const &domain, double translation) {
-  std::vector<double> translated_domain;
-
-  std::transform(domain.begin(), domain.end(), std::back_inserter(translated_domain),
-                 [translation](double d) -> double { return d + translation; });
-
-  return translated_domain;
-}
-
-std::vector<double> CrossCorrelateTestData::scale_domain(std::vector<double> const &domain, double scale_factor) {
-  std::vector<double> scaled_domain;
-
-  std::transform(domain.begin(), domain.end(), std::back_inserter(scaled_domain),
-                 [scale_factor](double d) -> double { return scale_factor * d; });
-
-  return scaled_domain;
-}
-
-/* scaling and translation of the co-domain can occur after the function has
-   already
-   been evaluated by manipulating the entries in the workspace */
-void CrossCorrelateTestData::translate_co_domain(int reference_index, int target_index, double translation) {
-  workspace->mutableX(target_index) = workspace->mutableX(reference_index);
-  auto reference_y = workspace->mutableY(reference_index);
-  reference_y += translation;
-  workspace->mutableY(target_index) = reference_y;
-}
-
-void CrossCorrelateTestData::scale_co_domain(int reference_index, int target_index, double scale_factor) {
-  workspace->mutableX(target_index) = workspace->mutableX(reference_index);
-  workspace->mutableY(target_index) = scale_factor * workspace->mutableY(reference_index);
-}
-
-void CrossCorrelateTestData::assign_to_workspace(int workspace_index, std::vector<double> const &domain,
-                                                 std::vector<double> const &co_domain) {
-  auto &x_data = workspace->mutableX(workspace_index);
-  x_data.assign(domain.cbegin(), domain.cend());
-
-  auto &y_data = workspace->mutableY(workspace_index);
-  y_data.assign(co_domain.cbegin(), co_domain.cend());
-}
-
-void CrossCorrelateTestData::dump_vector(std::vector<double> const &v, std::string header_line) {
-  std::cout << header_line << std::endl;
-  for (double i : v) {
-    std::cout << " " << i;
-  }
-  std::cout << std::endl;
-}
-
-void CrossCorrelateTestData::print_workspace() {
-  for (int i = 0; i < static_cast<int>(num_functions); ++i) {
-    std::cout << "workspace: " << i << std::endl;
-    std::vector<double> const &domain = workspace->mutableX(i).rawData();
-    std::vector<double> const &co_domain = workspace->mutableY(i).rawData();
-    dump_vector(domain, "domain:");
-    dump_vector(co_domain, "co_domain:");
-  }
-}
-
-CrossCorrelateTestData::CrossCorrelateTestData(std::string function_specifier, int domain_radius,
-                                               std::initializer_list<class TransformSpecifier> l)
-    : domain_radius(domain_radius), num_functions(l.size() + 1) {
-  /* allocate the workspace but do not populate yet */
-  int domain_size = this->domain_radius * 2 + 1;
-
-  /* domain will represent points not bins, so the domain and co-domain are
-     of identical size (as opposed to domain being co_domain_size + 1 ) */
-  workspace = createWorkspace<Workspace2D>(l.size() + 1, domain_size, domain_size);
-
-  /* create the function that will operate on a discrete domain */
-  function = std::make_shared<API::CompositeFunction>();
-  const auto functionInstance = API::FunctionFactory::Instance().createInitialized(function_specifier);
-  function->addFunction(std::dynamic_pointer_cast<IPeakFunction>(functionInstance));
-
-  /* create discrete domain */
-  std::vector<double> symmetric_domain(domain_size);
-  std::iota(symmetric_domain.begin(), symmetric_domain.end(), -1 * domain_radius);
-
-  /* create the reference spectrum at the first index */
-  std::vector<double> co_domain = apply_function(symmetric_domain);
-  assign_to_workspace(0, symmetric_domain, co_domain);
-
-  std::vector<double> errorDomain(co_domain.size(), 0.0);
-  workspace->mutableE(0).assign(errorDomain.begin(), errorDomain.end());
-
-  // workspace = convertToHistogram(workspace);
-
-  /* iterate through the initializer list and handle all the objects */
-  int workspace_index = 1;
-  for (auto &s : l) {
-    /* scale domain, recompute co-domain, assign to workspace index */
-    if (s.transform_type == transforms::domain_scale) {
-      std::vector<double> scaled_domain = scale_domain(symmetric_domain, s.scalar);
-      std::vector<double> scaled_co_domain = apply_function(scaled_domain);
-      assign_to_workspace(workspace_index, scaled_domain, scaled_co_domain);
-    }
-
-    /* translate domain, recompute co-domain, assign to workspace index */
-    else if (s.transform_type == transforms::domain_translate) {
-      std::vector<double> translated_domain = translate_domain(symmetric_domain, s.scalar);
-      std::vector<double> translated_co_domain = apply_function(translated_domain);
-      assign_to_workspace(workspace_index, translated_domain, translated_co_domain);
-    } else if (s.transform_type == transforms::co_domain_scale) {
-      scale_co_domain(0, workspace_index, s.scalar);
-    } else if (s.transform_type == transforms::co_domain_translate) {
-      translate_co_domain(0, workspace_index, s.scalar);
-    } else {
-      std::cout << "unrecognized transform type" << std::endl;
-      exit(0);
-    }
-
-    ++workspace_index;
-  }
-
-  workspace->getAxis(0)->setUnit("dSpacing");
-}

--- a/Framework/Algorithms/test/CrossCorrelateTestData.h
+++ b/Framework/Algorithms/test/CrossCorrelateTestData.h
@@ -132,13 +132,24 @@ std::vector<double> evaluateFunction(std::shared_ptr<IFunction> function, std::v
 CompositeFunction_sptr createCompositeB2BExp(const int spectrumIndex) {
   CompositeFunction_sptr function = std::make_shared<CompositeFunction>();
 
-  if (spectrumIndex > 0) {
+  // values for reference spectrum that may be changed for the others
+  double shift_in_d{0.};
+  double height_111{100.};
+  double height_220{200.};
+  double height_311{300.};
+  if (spectrumIndex == 0) {
+    // reference spectrum
+  } else if (spectrumIndex == 1) {
+    // horizontal shift in the data
+    // peak heights are unchanged
+    shift_in_d = .1;
+  } else {
     throw std::runtime_error("Logic for this spectrum index has not been written");
   }
 
-  function->addFunction(createPeakFunction(PeakIndex::POS_111, 100, B2BEXP_POSITION_111));
-  function->addFunction(createPeakFunction(PeakIndex::POS_220, 100, B2BEXP_POSITION_220));
-  function->addFunction(createPeakFunction(PeakIndex::POS_311, 100, B2BEXP_POSITION_311));
+  function->addFunction(createPeakFunction(PeakIndex::POS_111, height_111, B2BEXP_POSITION_111 + shift_in_d));
+  function->addFunction(createPeakFunction(PeakIndex::POS_220, height_220, B2BEXP_POSITION_220 + shift_in_d));
+  function->addFunction(createPeakFunction(PeakIndex::POS_311, height_311, B2BEXP_POSITION_311 + shift_in_d));
 
   return function;
 }

--- a/Framework/Algorithms/test/CrossCorrelateTestData.h
+++ b/Framework/Algorithms/test/CrossCorrelateTestData.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <cxxtest/TestSuite.h>
 #include <initializer_list>
 
 #include "MantidAPI/CompositeFunction.h"
@@ -124,78 +125,69 @@ std::shared_ptr<IFunction> createPeakFunction(const PeakShapeEnum shape, const P
   std::cout << peak.str() << std::endl;
   return FunctionFactory::Instance().createInitialized(peak.str());
 }
-
-std::vector<double> evaluateFunction(std::shared_ptr<IFunction> function, std::vector<double> &xValues) {
-  FunctionDomain1DVector domain(xValues);
-  FunctionValues values(domain);
-  function->function(domain, values);
-  return values.toVector();
-}
-
 } // anonymous namespace
 
-CompositeFunction_sptr createCompositeB2BExp(const PeakShapeEnum shape, const int spectrumIndex) {
-  CompositeFunction_sptr function = std::make_shared<CompositeFunction>();
-
-  // values for reference spectrum that may be changed for the others
-  double shift_in_d{0.};
-  double scale_in_d{1.};
-  double horizontal_shift{0.};
-  double height_111{100.};
-  double height_220{200.};
-  double height_311{300.};
-
-  if (spectrumIndex == 0) { // expected value = 0.
-    // reference spectrum
-  } else if (spectrumIndex == 1) { // expected value = .1, or about 10 bins
-    // additive shift in d-spacing from the reference
-    // peak heights are unchanged
-    shift_in_d = .1;
-  } else if (spectrumIndex == 2) { // expected value = ???
-                                   // multiplicative shift in d-spacing from the reference
-                                   // peak heights are unchanged
-    scale_in_d = 1.1;
-  } else if (spectrumIndex == 3) { // expected value = 0.
-    // shifted vertically by  a constant
-    horizontal_shift = 40.;
-  } else if (spectrumIndex == 4) { // expected value = 0.
-    // scaled version of the reference - done via peak heights
-    height_111 *= 2;
-    height_220 *= 2;
-    height_311 *= 2;
-  } else {
-    throw std::runtime_error("Logic for this spectrum index has not been written");
-  }
-
-  function->addFunction(
-      createPeakFunction(shape, PeakIndex::POS_111, height_111, scale_in_d * B2BEXP_POSITION_111 + shift_in_d));
-  function->addFunction(
-      createPeakFunction(shape, PeakIndex::POS_220, height_220, scale_in_d * B2BEXP_POSITION_220 + shift_in_d));
-  function->addFunction(
-      createPeakFunction(shape, PeakIndex::POS_311, height_311, scale_in_d * B2BEXP_POSITION_311 + shift_in_d));
-  if (horizontal_shift > 0.) {
-    std::stringstream background;
-    background << "name=FlatBackground,A0=" << horizontal_shift;
-    function->addFunction(FunctionFactory::Instance().createInitialized(background.str()));
-  }
-
-  return function;
-}
-
-// THIS CODE IS COMPLETELY UNNECESSARY, BUT MAKE THE FUNCTION FACTORY WORK
-// Algorithm to force Gaussian1D to be run by simplex algorithm
-class SimplexGaussian : public Gaussian {
+class CrossCorrelateTestData : public CxxTest::TestSuite {
 public:
-  ~SimplexGaussian() override {}
-  std::string name() const override { return "Gaussian"; }
+  static CrossCorrelateTestData *createSuite() { return new CrossCorrelateTestData(); }
+  static void destroySuite(CrossCorrelateTestData *suite) { delete suite; }
 
-protected:
-  void functionDerivMW(Jacobian *out, const double *xValues, const size_t nData) {
-    UNUSED_ARG(out);
-    UNUSED_ARG(xValues);
-    UNUSED_ARG(nData);
-    throw Exception::NotImplementedError("No derivative function provided");
+  static CompositeFunction_sptr createCompositeB2BExp(const PeakShapeEnum shape, const int spectrumIndex) {
+    CompositeFunction_sptr function = std::make_shared<CompositeFunction>();
+
+    // values for reference spectrum that may be changed for the others
+    double shift_in_d{0.};
+    double scale_in_d{1.};
+    double horizontal_shift{0.};
+    double height_111{100.};
+    double height_220{200.};
+    double height_311{300.};
+
+    if (spectrumIndex == 0) { // expected value = 0.
+      // reference spectrum
+    } else if (spectrumIndex == 1) { // expected value = .1, or about 10 bins
+      // additive shift in d-spacing from the reference
+      // peak heights are unchanged
+      shift_in_d = .1;
+    } else if (spectrumIndex == 2) { // expected value = ???
+                                     // multiplicative shift in d-spacing from the reference
+                                     // peak heights are unchanged
+      scale_in_d = 1.1;
+    } else if (spectrumIndex == 3) { // expected value = 0.
+      // shifted vertically by  a constant
+      horizontal_shift = 40.;
+    } else if (spectrumIndex == 4) { // expected value = 0.
+      // scaled version of the reference - done via peak heights
+      height_111 *= 2;
+      height_220 *= 2;
+      height_311 *= 2;
+    } else {
+      throw std::runtime_error("Logic for this spectrum index has not been written");
+    }
+
+    function->addFunction(
+        createPeakFunction(shape, PeakIndex::POS_111, height_111, scale_in_d * B2BEXP_POSITION_111 + shift_in_d));
+    function->addFunction(
+        createPeakFunction(shape, PeakIndex::POS_220, height_220, scale_in_d * B2BEXP_POSITION_220 + shift_in_d));
+    function->addFunction(
+        createPeakFunction(shape, PeakIndex::POS_311, height_311, scale_in_d * B2BEXP_POSITION_311 + shift_in_d));
+    if (horizontal_shift > 0.) {
+      std::stringstream background;
+      background << "name=FlatBackground,A0=" << horizontal_shift;
+      function->addFunction(FunctionFactory::Instance().createInitialized(background.str()));
+    }
+
+    return function;
+  }
+  static std::vector<double> evaluateFunction(std::shared_ptr<IFunction> function, std::vector<double> &xValues) {
+    FunctionDomain1DVector domain(xValues);
+    FunctionValues values(domain);
+    function->function(domain, values);
+    return values.toVector();
+  }
+
+  void testDataGenerator() {
+    const auto result = createCompositeB2BExp(PeakShapeEnum::B2BEXP, 0);
+    TS_ASSERT(result != nullptr);
   }
 };
-
-DECLARE_FUNCTION(SimplexGaussian)

--- a/Framework/Algorithms/test/CrossCorrelateTestData.h
+++ b/Framework/Algorithms/test/CrossCorrelateTestData.h
@@ -8,9 +8,9 @@
 #include "MantidAPI/IFunction1D.h"
 #include "MantidAPI/IPeakFunction.h"
 #include "MantidAPI/MultiDomainFunction.h"
-#include "MantidKernel/System.h"
-#include "MantidCurveFitting/Functions/Gaussian.h"
 #include "MantidCurveFitting/Functions/Bk2BkExpConvPV.h"
+#include "MantidCurveFitting/Functions/Gaussian.h"
+#include "MantidKernel/System.h"
 #include "MantidTestHelpers/WorkspaceCreationHelper.h"
 
 using namespace Mantid;
@@ -19,29 +19,17 @@ using namespace Mantid::DataObjects;
 
 /* define the types of transforms that can be applied to
    a 1D function */
-enum class transforms : int
-{
-  domain_scale,
-  domain_translate,
-  co_domain_scale,
-  co_domain_translate
-};
+enum class transforms : int { domain_scale, domain_translate, co_domain_scale, co_domain_translate };
 
 /* define a supported transformation with type and scalar amount */
-class TransformSpecifier
-{
+class TransformSpecifier {
 
-  public:
+public:
+  TransformSpecifier(transforms const type, double scalar) : transform_type(type), scalar(scalar) {}
 
-    TransformSpecifier( transforms const type, double scalar )
-      :
-      transform_type( type ),
-      scalar( scalar )
-    { }
+  transforms const transform_type;
 
-    transforms const transform_type;
-
-    double scalar;
+  double scalar;
 };
 
 /*
@@ -52,314 +40,270 @@ class TransformSpecifier
   the reference function.
 
   The transform at index "i" for 1 < i < len( l ) contains
-  the reference function transformed according to the specification 
+  the reference function transformed according to the specification
   in l[ i - 1 ] where "l" is the initializer list constructor argument.
 
   use get_workspace() to get the workspace
 */
-class CrossCorrelateTestData
-{
-  public:
+class CrossCorrelateTestData {
+public:
+  inline static std::string const gaussian_default = "name=Gaussian,Height=20,Sigma=4";
 
-    inline static std::string const gaussian_default = "name=Gaussian,Height=20,Sigma=4";
+  /*
 
-    /*
-     
-    Code to generate parameters for b2bexpconvpv:
+  Code to generate parameters for b2bexpconvpv:
 
-      import numpy as np
+    import numpy as np
 
-      diam_d = {"111": 2.05995, "220": 1.26146, "311": 1.07577}
+    diam_d = {"111": 2.05995, "220": 1.26146, "311": 1.07577}
 
-      alp = 0.791431E-01
-      beta0 = 0.580874E-01
-      beta1 = 0.947427E-01
-      sig0 = 0.0E+00
-      sig1 = 0.157741E+03
-      sig2 = 0.402182E+02
-      gamma1 = 0.302644E+01
+    alp = 0.791431E-01
+    beta0 = 0.580874E-01
+    beta1 = 0.947427E-01
+    sig0 = 0.0E+00
+    sig1 = 0.157741E+03
+    sig2 = 0.402182E+02
+    gamma1 = 0.302644E+01
 
+    print("===============================================")
+    print("Back-to-back shape parameters for diamond peaks")
+    print("===============================================")
+    for key, item in diam_d.items():
+      A = alp / item
+      B = beta0 + beta1 / item**4
+      S = np.sqrt(sig0 + sig1 * item**2 + sig2 * item**4)
+      Gamma = gamma1 * item
+
+      print("\n--------------------")
+      print("({0:3s})".format(key))
+      print("--------------------")
+      print("A = {0:<10.5F}".format(A))
+      print("B = {0:<10.5F}".format(B))
+      print("S = {0:<10.5F}".format(S))
+      print("Gamma = {0:<10.5F}".format(Gamma))
       print("===============================================")
-      print("Back-to-back shape parameters for diamond peaks")
-      print("===============================================")
-      for key, item in diam_d.items():
-        A = alp / item
-        B = beta0 + beta1 / item**4
-        S = np.sqrt(sig0 + sig1 * item**2 + sig2 * item**4)
-        Gamma = gamma1 * item
 
-        print("\n--------------------")
-        print("({0:3s})".format(key))
-        print("--------------------")
-        print("A = {0:<10.5F}".format(A))
-        print("B = {0:<10.5F}".format(B))
-        print("S = {0:<10.5F}".format(S))
-        print("Gamma = {0:<10.5F}".format(Gamma))
-        print("===============================================")
+    Result:
 
-      Result:
+      ===============================================
+      Back-to-back shape parameters for diamond peaks
+      ===============================================
 
-        ===============================================
-        Back-to-back shape parameters for diamond peaks
-        ===============================================
+      --------------------
+      (111)
+      --------------------
+      A = 0.03842
+      B = 0.06335
+      S = 37.33017
+      Gamma = 6.23432
+      ===============================================
 
-        --------------------
-        (111)
-        --------------------
-        A = 0.03842   
-        B = 0.06335   
-        S = 37.33017  
-        Gamma = 6.23432   
-        ===============================================
+      --------------------
+      (220)
+      --------------------
+      A = 0.06274
+      B = 0.09550
+      S = 18.78430
+      Gamma = 3.81773
+      ===============================================
 
-        --------------------
-        (220)
-        --------------------
-        A = 0.06274   
-        B = 0.09550   
-        S = 18.78430  
-        Gamma = 3.81773   
-        ===============================================
+      --------------------
+      (311)
+      --------------------
+      A = 0.07357
+      B = 0.12883
+      S = 15.37579
+      Gamma = 3.25575
+      ===============================================
+  */
 
-        --------------------
-        (311)
-        --------------------
-        A = 0.07357   
-        B = 0.12883   
-        S = 15.37579  
-        Gamma = 3.25575   
-        ===============================================
-    */
+  inline static std::string const b2bexp_default_111 =
+      "name=Bk2BkExpConvPV,Alpha=0.03842,Beta=0.06335,Sigma2=37.33017,Gamma = "
+      "6.23432,Intensity=100";
+  inline static std::string const b2bexp_default_220 =
+      "name=Bk2BkExpConvPV,Alpha=0.06274,Beta=0.09550,Sigma2=18.78430,Gamma=3."
+      "81773,Intensity=100";
+  inline static std::string const b2bexp_default_311 =
+      "name=Bk2BkExpConvPV,Alpha=0.07357,Beta=0.12883,Sigma2=15.37579,Gamma=3."
+      "25575,Intensity=100";
 
-    inline static std::string const b2bexp_default_111 = "name=Bk2BkExpConvPV,Alpha=0.03842,Beta=0.06335,Sigma2=37.33017,Gamma = 6.23432,Intensity=100";
-    inline static std::string const b2bexp_default_220 = "name=Bk2BkExpConvPV,Alpha=0.06274,Beta=0.09550,Sigma2=18.78430,Gamma=3.81773,Intensity=100"; 
-    inline static std::string const b2bexp_default_311 = "name=Bk2BkExpConvPV,Alpha=0.07357,Beta=0.12883,Sigma2=15.37579,Gamma=3.25575,Intensity=100";  
+  /* Specify default values */
+  CrossCorrelateTestData(std::string function_specifier = gaussian_default, int domain_radius = 20,
+                         std::initializer_list<class TransformSpecifier> l = {
+                             TransformSpecifier(transforms::domain_translate, 2),
+                             TransformSpecifier(transforms::domain_scale, 2),
+                             TransformSpecifier(transforms::co_domain_translate, 2),
+                             TransformSpecifier(transforms::co_domain_scale, 2)});
 
-    /* Specify default values */
-    CrossCorrelateTestData( std::string function_specifier = gaussian_default,
-                            int domain_radius = 20,
-                            std::initializer_list< class TransformSpecifier > l =
-                            { 
-                              TransformSpecifier( transforms::domain_translate, 2 ),
-                              TransformSpecifier( transforms::domain_scale, 2 ),
-                              TransformSpecifier( transforms::co_domain_translate, 2 ),
-                              TransformSpecifier( transforms::co_domain_scale, 2 )
-                            }
-                          );
+  MatrixWorkspace_sptr get_workspace() { return workspace; }
 
-    MatrixWorkspace_sptr get_workspace() { return workspace; }
-
-    /* debugging function - print to stdout */
-    void print_workspace();
+  /* debugging function - print to stdout */
+  void print_workspace();
 
   /* methods */
-  private:
+private:
+  /* generates the co-domain given the domain */
+  std::vector<double> apply_function(std::vector<double> &domain);
 
-    /* generates the co-domain given the domain */
-    std::vector< double > apply_function( std::vector< double > &domain );
+  /* offset domain by a constant before applying a function */
+  std::vector<double> translate_domain(std::vector<double> const &domain, double translation);
 
-    /* offset domain by a constant before applying a function */
-    std::vector< double > translate_domain( std::vector< double > const &domain,
-                                            double translation );
+  /* scale domain by a constant factor before applying a function */
+  std::vector<double> scale_domain(std::vector<double> const &domain, double scale_factor);
 
-    /* scale domain by a constant factor before applying a function */
-    std::vector< double > scale_domain( std::vector< double > const &domain,
-                                        double scale_factor );
+  /* scaling and translation of the co-domain can occur after the function has
+     already
+     been evaluated by manipulating the entries in the workspace: */
+  void translate_co_domain(int reference_index, int target_index, double translation);
 
-    /* scaling and translation of the co-domain can occur after the function has already
-       been evaluated by manipulating the entries in the workspace: */
-    void translate_co_domain( int reference_index, int target_index, double translation );
+  void scale_co_domain(int reference_index, int target_index, double scale_factor);
 
-    void scale_co_domain( int reference_index, int target_index, double scale_factor );
+  /* assign at given index */
+  void assign_to_workspace(int workspace_index, std::vector<double> const &domain,
+                           std::vector<double> const &co_domain);
 
-    /* assign at given index */
-    void assign_to_workspace( int workspace_index,
-                              std::vector< double > const &domain,
-                              std::vector< double > const &co_domain );
-
-    /* print a vector */
-    void dump_vector( std::vector< double > const &v, std::string header_line );
+  /* print a vector */
+  void dump_vector(std::vector<double> const &v, std::string header_line);
 
   /* variables */
-  private:
+private:
+  /* this object's deliverable */
+  MatrixWorkspace_sptr workspace;
 
-    /* this object's deliverable */
-    MatrixWorkspace_sptr workspace; 
+  /* function to map domain to co-domain */
+  std::shared_ptr<CompositeFunction> function;
 
-    /* function to map domain to co-domain */
-    std::shared_ptr< CompositeFunction > function;
+  /* function extends this far from the origin in either direction */
+  int const domain_radius;
 
-    /* function extends this far from the origin in either direction */
-    int const domain_radius;
-
-    /* number of functions in the workspace */
-    size_t const num_functions;
+  /* number of functions in the workspace */
+  size_t const num_functions;
 };
 
 /* it will move and unmove this vector */
-std::vector< double > CrossCorrelateTestData::apply_function( std::vector< double > &domain )
-{
-  FunctionDomain1DVector domain_oop( std::move( domain ) );
+std::vector<double> CrossCorrelateTestData::apply_function(std::vector<double> &domain) {
+  FunctionDomain1DVector domain_oop(std::move(domain));
   /* move after clear */
   domain.clear();
 
   /* populate range */
-  FunctionValues co_domain_oop( domain_oop );
-  function->function( domain_oop, co_domain_oop );
+  FunctionValues co_domain_oop(domain_oop);
+  function->function(domain_oop, co_domain_oop);
 
   /* invalidate FunctionDomain1DVector and get underlying data primitive */
-  domain = std::move( domain_oop.getVector() );
+  domain = std::move(domain_oop.getVector());
 
   /* invalidate FunctionValues object and get underlying data primitive */
-  auto co_domain = std::move( co_domain_oop.toVector() );
+  auto co_domain = std::move(co_domain_oop.toVector());
 
   return co_domain;
 }
 
-std::vector< double > CrossCorrelateTestData::translate_domain( std::vector< double > const &domain,
-                                                                double translation )
-{
-  std::vector< double > translated_domain;
+std::vector<double> CrossCorrelateTestData::translate_domain(std::vector<double> const &domain, double translation) {
+  std::vector<double> translated_domain;
 
-  std::transform( domain.begin(),
-                  domain.end(),
-                  std::back_inserter( translated_domain ),
-                  [ translation ]( double d ) -> double
-                  { return d + translation; } );
+  std::transform(domain.begin(), domain.end(), std::back_inserter(translated_domain),
+                 [translation](double d) -> double { return d + translation; });
 
   return translated_domain;
 }
 
-std::vector< double > CrossCorrelateTestData::scale_domain( std::vector< double > const &domain,
-                                                            double scale_factor )
-{
-  std::vector< double > scaled_domain;
+std::vector<double> CrossCorrelateTestData::scale_domain(std::vector<double> const &domain, double scale_factor) {
+  std::vector<double> scaled_domain;
 
-  std::transform( domain.begin(),
-                  domain.end(),
-                  std::back_inserter( scaled_domain ),
-                  [ scale_factor ]( double d ) -> double
-                  { return scale_factor * d; } );
+  std::transform(domain.begin(), domain.end(), std::back_inserter(scaled_domain),
+                 [scale_factor](double d) -> double { return scale_factor * d; });
 
   return scaled_domain;
 }
 
-/* scaling and translation of the co-domain can occur after the function has already
+/* scaling and translation of the co-domain can occur after the function has
+   already
    been evaluated by manipulating the entries in the workspace */
-void CrossCorrelateTestData::translate_co_domain( int reference_index, int target_index, double translation )
-{
-  workspace->mutableX( target_index ) = workspace->mutableX( reference_index );
-  auto reference_y = workspace->mutableY( reference_index );
+void CrossCorrelateTestData::translate_co_domain(int reference_index, int target_index, double translation) {
+  workspace->mutableX(target_index) = workspace->mutableX(reference_index);
+  auto reference_y = workspace->mutableY(reference_index);
   reference_y += translation;
-  workspace->mutableY( target_index ) = reference_y;
+  workspace->mutableY(target_index) = reference_y;
 }
 
-void CrossCorrelateTestData::scale_co_domain( int reference_index, int target_index, double scale_factor )
-{
-  workspace->mutableX( target_index ) = workspace->mutableX( reference_index );
-  workspace->mutableY( target_index ) = scale_factor * workspace->mutableY( reference_index );
+void CrossCorrelateTestData::scale_co_domain(int reference_index, int target_index, double scale_factor) {
+  workspace->mutableX(target_index) = workspace->mutableX(reference_index);
+  workspace->mutableY(target_index) = scale_factor * workspace->mutableY(reference_index);
 }
 
-void CrossCorrelateTestData::assign_to_workspace( int workspace_index,
-                              std::vector< double > const &domain,
-                              std::vector< double > const &co_domain )
-{
-  auto &x_data = workspace->mutableX( workspace_index );
-  x_data.assign( domain.cbegin(), domain.cend() );
+void CrossCorrelateTestData::assign_to_workspace(int workspace_index, std::vector<double> const &domain,
+                                                 std::vector<double> const &co_domain) {
+  auto &x_data = workspace->mutableX(workspace_index);
+  x_data.assign(domain.cbegin(), domain.cend());
 
-  auto &y_data = workspace->mutableY( workspace_index );
-  y_data.assign( co_domain.cbegin(), co_domain.cend() );
+  auto &y_data = workspace->mutableY(workspace_index);
+  y_data.assign(co_domain.cbegin(), co_domain.cend());
 }
 
-void CrossCorrelateTestData::dump_vector( std::vector< double > const &v, std::string header_line )
-{
+void CrossCorrelateTestData::dump_vector(std::vector<double> const &v, std::string header_line) {
   std::cout << header_line << std::endl;
-  for( double i : v )
-  {
+  for (double i : v) {
     std::cout << " " << i;
   }
   std::cout << std::endl;
 }
 
-void CrossCorrelateTestData::print_workspace()
-{
-  for( int i = 0; i < static_cast<int>(num_functions); ++i )
-  {
+void CrossCorrelateTestData::print_workspace() {
+  for (int i = 0; i < static_cast<int>(num_functions); ++i) {
     std::cout << "workspace: " << i << std::endl;
-    std::vector< double > const &domain = workspace->mutableX( i ).rawData();
-    std::vector< double > const &co_domain = workspace->mutableY( i ).rawData();
-    dump_vector( domain, "domain:" );
-    dump_vector( co_domain, "co_domain:" );
+    std::vector<double> const &domain = workspace->mutableX(i).rawData();
+    std::vector<double> const &co_domain = workspace->mutableY(i).rawData();
+    dump_vector(domain, "domain:");
+    dump_vector(co_domain, "co_domain:");
   }
 }
 
-CrossCorrelateTestData::CrossCorrelateTestData( std::string function_specifier,
-                                                int domain_radius,
-                                                std::initializer_list< class TransformSpecifier > l )
-  :
-  domain_radius( domain_radius ),
-  num_functions( l.size() + 1 )
-{
+CrossCorrelateTestData::CrossCorrelateTestData(std::string function_specifier, int domain_radius,
+                                               std::initializer_list<class TransformSpecifier> l)
+    : domain_radius(domain_radius), num_functions(l.size() + 1) {
   /* allocate the workspace but do not populate yet */
   int domain_size = domain_radius * 2 + 1;
 
   /* domain will represent points not bins, so the domain and co-domain are
      of identical size (as opposed to domain being co_domain_size + 1 ) */
-  workspace =
-  createWorkspace<Workspace2D>( l.size() + 1, domain_size, domain_size );
+  workspace = createWorkspace<Workspace2D>(l.size() + 1, domain_size, domain_size);
 
   /* create the function that will operate on a discrete domain */
   function = std::make_shared<API::CompositeFunction>();
-  function->addFunction( 
-    std::dynamic_pointer_cast<IPeakFunction>(
-      API::FunctionFactory::Instance()
-      .createInitialized( function_specifier )));
+  function->addFunction(
+      std::dynamic_pointer_cast<IPeakFunction>(API::FunctionFactory::Instance().createInitialized(function_specifier)));
 
   /* create discrete domain */
-  std::vector< double > symmetric_domain( domain_size );
-  std::iota( symmetric_domain.begin(), symmetric_domain.end(), -1 * domain_radius );
+  std::vector<double> symmetric_domain(domain_size);
+  std::iota(symmetric_domain.begin(), symmetric_domain.end(), -1 * domain_radius);
 
   /* create the reference spectrum at the first index */
-  std::vector< double > co_domain =
-  apply_function( symmetric_domain );
-  assign_to_workspace( 0, symmetric_domain, co_domain );
+  std::vector<double> co_domain = apply_function(symmetric_domain);
+  assign_to_workspace(0, symmetric_domain, co_domain);
 
   /* iterate through the initializer list and handle all the objects */
   int workspace_index = 1;
-  for( auto &s : l )
-  {
+  for (auto &s : l) {
     /* scale domain, recompute co-domain, assign to workspace index */
-    if( s.transform_type == transforms::domain_scale )
-    {
-      std::vector< double > scaled_domain = scale_domain( symmetric_domain, s.scalar );
-      std::vector< double > scaled_co_domain = 
-      apply_function( scaled_domain );
-      assign_to_workspace( workspace_index, scaled_domain, scaled_co_domain );
+    if (s.transform_type == transforms::domain_scale) {
+      std::vector<double> scaled_domain = scale_domain(symmetric_domain, s.scalar);
+      std::vector<double> scaled_co_domain = apply_function(scaled_domain);
+      assign_to_workspace(workspace_index, scaled_domain, scaled_co_domain);
     }
 
     /* translate domain, recompute co-domain, assign to workspace index */
-    else if( s.transform_type == transforms::domain_translate )
-    {
-      std::vector< double > translated_domain = translate_domain( symmetric_domain, s.scalar );
-      std::vector< double > translated_co_domain =
-      apply_function( translated_domain );
-      assign_to_workspace( workspace_index, translated_domain, translated_co_domain );
-    }
-
-    else if( s.transform_type == transforms::co_domain_scale )
-    {
-      scale_co_domain( 0, workspace_index, s.scalar );
-    }
-    
-    else if( s.transform_type == transforms::co_domain_translate )
-    {
-      translate_co_domain( 0, workspace_index, s.scalar );
-    }
-
-    else
-    {
+    else if (s.transform_type == transforms::domain_translate) {
+      std::vector<double> translated_domain = translate_domain(symmetric_domain, s.scalar);
+      std::vector<double> translated_co_domain = apply_function(translated_domain);
+      assign_to_workspace(workspace_index, translated_domain, translated_co_domain);
+    } else if (s.transform_type == transforms::co_domain_scale) {
+      scale_co_domain(0, workspace_index, s.scalar);
+    } else if (s.transform_type == transforms::co_domain_translate) {
+      translate_co_domain(0, workspace_index, s.scalar);
+    } else {
       std::cout << "unrecognized transform type" << std::endl;
-      exit( 0 );
+      exit(0);
     }
 
     ++workspace_index;

--- a/Framework/Algorithms/test/CrossCorrelateTestData.h
+++ b/Framework/Algorithms/test/CrossCorrelateTestData.h
@@ -8,6 +8,7 @@
 #include "MantidAPI/IFunction1D.h"
 #include "MantidAPI/IPeakFunction.h"
 #include "MantidAPI/MultiDomainFunction.h"
+#include "MantidAlgorithms/ConvertToHistogram.h"
 #include "MantidCurveFitting/Functions/Bk2BkExpConvPV.h"
 #include "MantidCurveFitting/Functions/Gaussian.h"
 #include "MantidKernel/System.h"
@@ -324,6 +325,20 @@ void CrossCorrelateTestData::print_workspace() {
   }
 }
 
+MatrixWorkspace_sptr convertToHistogram(const MatrixWorkspace_sptr inWS) {
+  Algorithms::ConvertToHistogram alg;
+
+  // setup alg
+  alg.initialize();
+  alg.setRethrows(true);
+  alg.setProperty("InputWorkspace", inWS);
+  alg.setProperty("OutputWorkspace", "outWS");
+
+  // run alg
+  alg.execute();
+  return alg.getProperty("OutputWorkspace");
+}
+
 CrossCorrelateTestData::CrossCorrelateTestData(std::string function_specifier, int domain_radius,
                                                std::initializer_list<class TransformSpecifier> l)
     : domain_radius(domain_radius), num_functions(l.size() + 1) {
@@ -349,8 +364,6 @@ CrossCorrelateTestData::CrossCorrelateTestData(std::string function_specifier, i
 
   std::vector<double> errorDomain(co_domain.size(), 0.0);
   workspace->mutableE(0).assign(errorDomain.begin(), errorDomain.end());
-
-  // workspace = convertToHistogram(workspace);
 
   /* iterate through the initializer list and handle all the objects */
   int workspace_index = 1;
@@ -380,4 +393,5 @@ CrossCorrelateTestData::CrossCorrelateTestData(std::string function_specifier, i
   }
 
   workspace->getAxis(0)->setUnit("dSpacing");
+  // workspace = convertToHistogram(workspace);
 }

--- a/Framework/Algorithms/test/CrossCorrelateTestData.h
+++ b/Framework/Algorithms/test/CrossCorrelateTestData.h
@@ -1,0 +1,354 @@
+#pragma once
+
+#include <initializer_list>
+
+#include "MantidAPI/CompositeFunction.h"
+#include "MantidAPI/FrameworkManager.h"
+#include "MantidAPI/FunctionFactory.h"
+#include "MantidAPI/IFunction1D.h"
+#include "MantidAPI/IPeakFunction.h"
+#include "MantidAPI/MultiDomainFunction.h"
+#include "MantidKernel/System.h"
+#include "MantidCurveFitting/Functions/Gaussian.h"
+#include "MantidCurveFitting/Functions/Bk2BkExpConvPV.h"
+#include "MantidTestHelpers/WorkspaceCreationHelper.h"
+
+using namespace Mantid;
+using namespace Mantid::API;
+using namespace Mantid::DataObjects;
+
+/* define the types of transforms that can be applied to
+   a 1D function */
+enum class transforms : int
+{
+  domain_scale,
+  domain_translate,
+  co_domain_scale,
+  co_domain_translate
+};
+
+/* define a supported transformation with type and scalar amount */
+class TransformSpecifier
+{
+
+  public:
+
+    TransformSpecifier( transforms const type, double scalar )
+      :
+      transform_type( type ),
+      scalar( scalar )
+    { }
+
+    transforms const transform_type;
+
+    double scalar;
+};
+
+/*
+  Create fake data to test cross correlation
+
+  This class creates a matrix workspace with a reference function in the
+  first index and subsequent indices containing a transformed version of
+  the reference function.
+
+  The transform at index "i" for 1 < i < len( l ) contains
+  the reference function transformed according to the specification 
+  in l[ i - 1 ] where "l" is the initializer list constructor argument.
+
+  use get_workspace() to get the workspace
+*/
+class CrossCorrelateTestData
+{
+  public:
+
+    inline static std::string const gaussian_default = "name=Gaussian,Height=20,Sigma=4";
+
+    /*
+Code to generate parameters for b2bexpconvpv:
+
+       import numpy as np
+
+       diam_d = {"111": 2.05995, "220": 1.26146, "311": 1.07577}
+
+       alp = 0.791431E-01
+       beta0 = 0.580874E-01
+       beta1 = 0.947427E-01
+       sig0 = 0.0E+00
+       sig1 = 0.157741E+03
+       sig2 = 0.402182E+02
+
+       print("===============================================")
+       print("Back-to-back shape parameters for diamond peaks")
+       print("===============================================")
+       for key, item in diam_d.items():
+       A = alp / item
+       B = beta0 + beta1 / item**4
+       S = np.sqrt(sig0 + sig1 * item**2 + sig2 * item**4)
+       print("\n--------------------")
+       print("({0:3s})".format(key))
+       print("--------------------")
+       print("A = {0:<10.5F}".format(A))
+       print("B = {0:<10.5F}".format(B))
+       print("S = {0:<10.5F}".format(S))
+       print("===============================================")
+
+Result:
+       --------------------
+       (111)
+       --------------------
+       A = 0.03842   
+       B = 0.06335   
+       S = 37.33017  
+       ===============================================
+
+       --------------------
+       (220)
+       --------------------
+       A = 0.06274   
+       B = 0.09550   
+       S = 18.78430  
+       ===============================================
+
+       --------------------
+       (311)
+       --------------------
+       A = 0.07357   
+       B = 0.12883   
+       S = 15.37579  
+       ===============================================
+
+    */
+    inline static std::string const b2bexp_default_111 = "name=Bk2BkExpConvPV,Alpha=0.03842,Beta=0.06335,Sigma2=37.33017";
+    inline static std::string const b2bexp_default_220 = "name=Bk2BkExpConvPV,Alpha=0.06274,Beta=0.09550,Sigma2=18.78430"; 
+    inline static std::string const b2bexp_default_311 = "name=Bk2BkExpConvPV,Alpha=0.07357,Beta=0.12883,Sigma2=15.37579";  
+
+    /* Specify default values */
+    CrossCorrelateTestData( std::string function_specifier = gaussian_default,
+                            int domain_radius = 20,
+                            std::initializer_list< class TransformSpecifier > l =
+                            { 
+                              TransformSpecifier( transforms::domain_translate, 2 ),
+                              TransformSpecifier( transforms::domain_scale, 2 ),
+                              TransformSpecifier( transforms::co_domain_translate, 2 ),
+                              TransformSpecifier( transforms::co_domain_scale, 2 )
+                            }
+                          );
+
+    MatrixWorkspace_sptr get_workspace() { return workspace; }
+
+    /* debugging function - print to stdout */
+    void print_workspace();
+
+  /* methods */
+  private:
+
+    /* generates the co-domain given the domain */
+    std::vector< double > apply_function( std::vector< double > &domain );
+
+    /* offset domain by a constant before applying a function */
+    std::vector< double > translate_domain( std::vector< double > const &domain,
+                                            double translation );
+
+    /* scale domain by a constant factor before applying a function */
+    std::vector< double > scale_domain( std::vector< double > const &domain,
+                                        double scale_factor );
+
+    /* scaling and translation of the co-domain can occur after the function has already
+       been evaluated by manipulating the entries in the workspace: */
+    void translate_co_domain( int reference_index, int target_index, double translation );
+
+    void scale_co_domain( int reference_index, int target_index, double scale_factor );
+
+    /* assign at given index */
+    void assign_to_workspace( int workspace_index,
+                              std::vector< double > const &domain,
+                              std::vector< double > const &co_domain );
+
+    /* print a vector */
+    void dump_vector( std::vector< double > const &v, std::string header_line );
+
+  /* variables */
+  private:
+
+    /* this object's deliverable */
+    MatrixWorkspace_sptr workspace; 
+
+    /* function to map domain to co-domain */
+    std::shared_ptr< CompositeFunction > function;
+
+    /* function extends this far from the origin in either direction */
+    int const domain_radius;
+
+    /* number of functions in the workspace */
+    size_t const num_functions;
+};
+
+/* it will move and unmove this vector */
+std::vector< double > CrossCorrelateTestData::apply_function( std::vector< double > &domain )
+{
+  FunctionDomain1DVector domain_oop( std::move( domain ) );
+  /* move after clear */
+  domain.clear();
+
+  /* populate range */
+  FunctionValues co_domain_oop( domain_oop );
+  function->function( domain_oop, co_domain_oop );
+
+  /* invalidate FunctionDomain1DVector and get underlying data primitive */
+  domain = std::move( domain_oop.getVector() );
+
+  /* invalidate FunctionValues object and get underlying data primitive */
+  auto co_domain = std::move( co_domain_oop.toVector() );
+
+  return co_domain;
+}
+
+std::vector< double > CrossCorrelateTestData::translate_domain( std::vector< double > const &domain,
+                                                                double translation )
+{
+  std::vector< double > translated_domain;
+
+  std::transform( domain.begin(),
+                  domain.end(),
+                  std::back_inserter( translated_domain ),
+                  [ translation ]( double d ) -> double
+                  { return d + translation; } );
+
+  return translated_domain;
+}
+
+std::vector< double > CrossCorrelateTestData::scale_domain( std::vector< double > const &domain,
+                                                            double scale_factor )
+{
+  std::vector< double > scaled_domain;
+
+  std::transform( domain.begin(),
+                  domain.end(),
+                  std::back_inserter( scaled_domain ),
+                  [ scale_factor ]( double d ) -> double
+                  { return scale_factor * d; } );
+
+  return scaled_domain;
+}
+
+/* scaling and translation of the co-domain can occur after the function has already
+   been evaluated by manipulating the entries in the workspace */
+void CrossCorrelateTestData::translate_co_domain( int reference_index, int target_index, double translation )
+{
+  workspace->mutableX( target_index ) = workspace->mutableX( reference_index );
+  auto reference_y = workspace->mutableY( reference_index );
+  reference_y += translation;
+  workspace->mutableY( target_index ) = reference_y;
+}
+
+void CrossCorrelateTestData::scale_co_domain( int reference_index, int target_index, double scale_factor )
+{
+  workspace->mutableX( target_index ) = workspace->mutableX( reference_index );
+  workspace->mutableY( target_index ) = scale_factor * workspace->mutableY( reference_index );
+}
+
+void CrossCorrelateTestData::assign_to_workspace( int workspace_index,
+                              std::vector< double > const &domain,
+                              std::vector< double > const &co_domain )
+{
+  auto &x_data = workspace->mutableX( workspace_index );
+  x_data.assign( domain.cbegin(), domain.cend() );
+
+  auto &y_data = workspace->mutableY( workspace_index );
+  y_data.assign( co_domain.cbegin(), co_domain.cend() );
+}
+
+void CrossCorrelateTestData::dump_vector( std::vector< double > const &v, std::string header_line )
+{
+  std::cout << header_line << std::endl;
+  for( double i : v )
+  {
+    std::cout << " " << i;
+  }
+  std::cout << std::endl;
+}
+
+void CrossCorrelateTestData::print_workspace()
+{
+  for( int i = 0; i < static_cast<int>(num_functions); ++i )
+  {
+    std::cout << "workspace: " << i << std::endl;
+    std::vector< double > const &domain = workspace->mutableX( i ).rawData();
+    std::vector< double > const &co_domain = workspace->mutableY( i ).rawData();
+    dump_vector( domain, "domain:" );
+    dump_vector( co_domain, "co_domain:" );
+  }
+}
+
+CrossCorrelateTestData::CrossCorrelateTestData( std::string function_specifier,
+                                                int domain_radius,
+                                                std::initializer_list< class TransformSpecifier > l )
+  :
+  domain_radius( domain_radius ),
+  num_functions( l.size() + 1 )
+{
+  /* allocate the workspace but do not populate yet */
+  int domain_size = domain_radius * 2 + 1;
+
+  /* domain will represent points not bins, so the domain and co-domain are
+     of identical size (as opposed to domain being co_domain_size + 1 ) */
+  workspace =
+  createWorkspace<Workspace2D>( l.size() + 1, domain_size, domain_size );
+
+  /* create the function that will operate on a discrete domain */
+  function = std::make_shared<API::CompositeFunction>();
+  function->addFunction( 
+    std::dynamic_pointer_cast<IPeakFunction>(
+      API::FunctionFactory::Instance()
+      .createInitialized( function_specifier )));
+
+  /* create discrete domain */
+  std::vector< double > symmetric_domain( domain_size );
+  std::iota( symmetric_domain.begin(), symmetric_domain.end(), -1 * domain_radius );
+
+  /* create the reference spectrum at the first index */
+  std::vector< double > co_domain =
+  apply_function( symmetric_domain );
+  assign_to_workspace( 0, symmetric_domain, co_domain );
+
+  /* iterate through the initializer list and handle all the objects */
+  int workspace_index = 1;
+  for( auto &s : l )
+  {
+    /* scale domain, recompute co-domain, assign to workspace index */
+    if( s.transform_type == transforms::domain_scale )
+    {
+      std::vector< double > scaled_domain = scale_domain( symmetric_domain, s.scalar );
+      std::vector< double > scaled_co_domain = 
+      apply_function( scaled_domain );
+      assign_to_workspace( workspace_index, scaled_domain, scaled_co_domain );
+    }
+
+    /* translate domain, recompute co-domain, assign to workspace index */
+    else if( s.transform_type == transforms::domain_translate )
+    {
+      std::vector< double > translated_domain = translate_domain( symmetric_domain, s.scalar );
+      std::vector< double > translated_co_domain =
+      apply_function( translated_domain );
+      assign_to_workspace( workspace_index, translated_domain, translated_co_domain );
+    }
+
+    else if( s.transform_type == transforms::co_domain_scale )
+    {
+      scale_co_domain( 0, workspace_index, s.scalar );
+    }
+    
+    else if( s.transform_type == transforms::co_domain_translate )
+    {
+      translate_co_domain( 0, workspace_index, s.scalar );
+    }
+
+    else
+    {
+      std::cout << "unrecognized transform type" << std::endl;
+      exit( 0 );
+    }
+
+    ++workspace_index;
+  }
+}

--- a/Framework/Algorithms/test/CrossCorrelateTestData.h
+++ b/Framework/Algorithms/test/CrossCorrelateTestData.h
@@ -64,63 +64,76 @@ class CrossCorrelateTestData
     inline static std::string const gaussian_default = "name=Gaussian,Height=20,Sigma=4";
 
     /*
-Code to generate parameters for b2bexpconvpv:
+     
+    Code to generate parameters for b2bexpconvpv:
 
-       import numpy as np
+      import numpy as np
 
-       diam_d = {"111": 2.05995, "220": 1.26146, "311": 1.07577}
+      diam_d = {"111": 2.05995, "220": 1.26146, "311": 1.07577}
 
-       alp = 0.791431E-01
-       beta0 = 0.580874E-01
-       beta1 = 0.947427E-01
-       sig0 = 0.0E+00
-       sig1 = 0.157741E+03
-       sig2 = 0.402182E+02
+      alp = 0.791431E-01
+      beta0 = 0.580874E-01
+      beta1 = 0.947427E-01
+      sig0 = 0.0E+00
+      sig1 = 0.157741E+03
+      sig2 = 0.402182E+02
+      gamma1 = 0.302644E+01
 
-       print("===============================================")
-       print("Back-to-back shape parameters for diamond peaks")
-       print("===============================================")
-       for key, item in diam_d.items():
-       A = alp / item
-       B = beta0 + beta1 / item**4
-       S = np.sqrt(sig0 + sig1 * item**2 + sig2 * item**4)
-       print("\n--------------------")
-       print("({0:3s})".format(key))
-       print("--------------------")
-       print("A = {0:<10.5F}".format(A))
-       print("B = {0:<10.5F}".format(B))
-       print("S = {0:<10.5F}".format(S))
-       print("===============================================")
+      print("===============================================")
+      print("Back-to-back shape parameters for diamond peaks")
+      print("===============================================")
+      for key, item in diam_d.items():
+        A = alp / item
+        B = beta0 + beta1 / item**4
+        S = np.sqrt(sig0 + sig1 * item**2 + sig2 * item**4)
+        Gamma = gamma1 * item
 
-Result:
-       --------------------
-       (111)
-       --------------------
-       A = 0.03842   
-       B = 0.06335   
-       S = 37.33017  
-       ===============================================
+        print("\n--------------------")
+        print("({0:3s})".format(key))
+        print("--------------------")
+        print("A = {0:<10.5F}".format(A))
+        print("B = {0:<10.5F}".format(B))
+        print("S = {0:<10.5F}".format(S))
+        print("Gamma = {0:<10.5F}".format(Gamma))
+        print("===============================================")
 
-       --------------------
-       (220)
-       --------------------
-       A = 0.06274   
-       B = 0.09550   
-       S = 18.78430  
-       ===============================================
+      Result:
 
-       --------------------
-       (311)
-       --------------------
-       A = 0.07357   
-       B = 0.12883   
-       S = 15.37579  
-       ===============================================
+        ===============================================
+        Back-to-back shape parameters for diamond peaks
+        ===============================================
 
+        --------------------
+        (111)
+        --------------------
+        A = 0.03842   
+        B = 0.06335   
+        S = 37.33017  
+        Gamma = 6.23432   
+        ===============================================
+
+        --------------------
+        (220)
+        --------------------
+        A = 0.06274   
+        B = 0.09550   
+        S = 18.78430  
+        Gamma = 3.81773   
+        ===============================================
+
+        --------------------
+        (311)
+        --------------------
+        A = 0.07357   
+        B = 0.12883   
+        S = 15.37579  
+        Gamma = 3.25575   
+        ===============================================
     */
-    inline static std::string const b2bexp_default_111 = "name=Bk2BkExpConvPV,Alpha=0.03842,Beta=0.06335,Sigma2=37.33017";
-    inline static std::string const b2bexp_default_220 = "name=Bk2BkExpConvPV,Alpha=0.06274,Beta=0.09550,Sigma2=18.78430"; 
-    inline static std::string const b2bexp_default_311 = "name=Bk2BkExpConvPV,Alpha=0.07357,Beta=0.12883,Sigma2=15.37579";  
+
+    inline static std::string const b2bexp_default_111 = "name=Bk2BkExpConvPV,Alpha=0.03842,Beta=0.06335,Sigma2=37.33017,Gamma = 6.23432,Intensity=100";
+    inline static std::string const b2bexp_default_220 = "name=Bk2BkExpConvPV,Alpha=0.06274,Beta=0.09550,Sigma2=18.78430,Gamma=3.81773,Intensity=100"; 
+    inline static std::string const b2bexp_default_311 = "name=Bk2BkExpConvPV,Alpha=0.07357,Beta=0.12883,Sigma2=15.37579,Gamma=3.25575,Intensity=100";  
 
     /* Specify default values */
     CrossCorrelateTestData( std::string function_specifier = gaussian_default,

--- a/Framework/Algorithms/test/CrossCorrelateTestData.h
+++ b/Framework/Algorithms/test/CrossCorrelateTestData.h
@@ -1,6 +1,5 @@
 #pragma once
 
-#include <cxxtest/TestSuite.h>
 #include <initializer_list>
 
 #include "MantidAPI/CompositeFunction.h"
@@ -125,69 +124,78 @@ std::shared_ptr<IFunction> createPeakFunction(const PeakShapeEnum shape, const P
   std::cout << peak.str() << std::endl;
   return FunctionFactory::Instance().createInitialized(peak.str());
 }
+
+std::vector<double> evaluateFunction(std::shared_ptr<IFunction> function, std::vector<double> &xValues) {
+  FunctionDomain1DVector domain(xValues);
+  FunctionValues values(domain);
+  function->function(domain, values);
+  return values.toVector();
+}
+
 } // anonymous namespace
 
-class CrossCorrelateTestData : public CxxTest::TestSuite {
+CompositeFunction_sptr createCompositeB2BExp(const PeakShapeEnum shape, const int spectrumIndex) {
+  CompositeFunction_sptr function = std::make_shared<CompositeFunction>();
+
+  // values for reference spectrum that may be changed for the others
+  double shift_in_d{0.};
+  double scale_in_d{1.};
+  double horizontal_shift{0.};
+  double height_111{100.};
+  double height_220{200.};
+  double height_311{300.};
+
+  if (spectrumIndex == 0) { // expected value = 0.
+    // reference spectrum
+  } else if (spectrumIndex == 1) { // expected value = .1, or about 10 bins
+    // additive shift in d-spacing from the reference
+    // peak heights are unchanged
+    shift_in_d = .1;
+  } else if (spectrumIndex == 2) { // expected value = ???
+                                   // multiplicative shift in d-spacing from the reference
+                                   // peak heights are unchanged
+    scale_in_d = 1.1;
+  } else if (spectrumIndex == 3) { // expected value = 0.
+    // shifted vertically by  a constant
+    horizontal_shift = 40.;
+  } else if (spectrumIndex == 4) { // expected value = 0.
+    // scaled version of the reference - done via peak heights
+    height_111 *= 2;
+    height_220 *= 2;
+    height_311 *= 2;
+  } else {
+    throw std::runtime_error("Logic for this spectrum index has not been written");
+  }
+
+  function->addFunction(
+      createPeakFunction(shape, PeakIndex::POS_111, height_111, scale_in_d * B2BEXP_POSITION_111 + shift_in_d));
+  function->addFunction(
+      createPeakFunction(shape, PeakIndex::POS_220, height_220, scale_in_d * B2BEXP_POSITION_220 + shift_in_d));
+  function->addFunction(
+      createPeakFunction(shape, PeakIndex::POS_311, height_311, scale_in_d * B2BEXP_POSITION_311 + shift_in_d));
+  if (horizontal_shift > 0.) {
+    std::stringstream background;
+    background << "name=FlatBackground,A0=" << horizontal_shift;
+    function->addFunction(FunctionFactory::Instance().createInitialized(background.str()));
+  }
+
+  return function;
+}
+
+// THIS CODE IS COMPLETELY UNNECESSARY, BUT MAKE THE FUNCTION FACTORY WORK
+// Algorithm to force Gaussian1D to be run by simplex algorithm
+class SimplexGaussian : public Gaussian {
 public:
-  static CrossCorrelateTestData *createSuite() { return new CrossCorrelateTestData(); }
-  static void destroySuite(CrossCorrelateTestData *suite) { delete suite; }
+  ~SimplexGaussian() override {}
+  std::string name() const override { return "Gaussian"; }
 
-  static CompositeFunction_sptr createCompositeB2BExp(const PeakShapeEnum shape, const int spectrumIndex) {
-    CompositeFunction_sptr function = std::make_shared<CompositeFunction>();
-
-    // values for reference spectrum that may be changed for the others
-    double shift_in_d{0.};
-    double scale_in_d{1.};
-    double horizontal_shift{0.};
-    double height_111{100.};
-    double height_220{200.};
-    double height_311{300.};
-
-    if (spectrumIndex == 0) { // expected value = 0.
-      // reference spectrum
-    } else if (spectrumIndex == 1) { // expected value = .1, or about 10 bins
-      // additive shift in d-spacing from the reference
-      // peak heights are unchanged
-      shift_in_d = .1;
-    } else if (spectrumIndex == 2) { // expected value = ???
-                                     // multiplicative shift in d-spacing from the reference
-                                     // peak heights are unchanged
-      scale_in_d = 1.1;
-    } else if (spectrumIndex == 3) { // expected value = 0.
-      // shifted vertically by  a constant
-      horizontal_shift = 40.;
-    } else if (spectrumIndex == 4) { // expected value = 0.
-      // scaled version of the reference - done via peak heights
-      height_111 *= 2;
-      height_220 *= 2;
-      height_311 *= 2;
-    } else {
-      throw std::runtime_error("Logic for this spectrum index has not been written");
-    }
-
-    function->addFunction(
-        createPeakFunction(shape, PeakIndex::POS_111, height_111, scale_in_d * B2BEXP_POSITION_111 + shift_in_d));
-    function->addFunction(
-        createPeakFunction(shape, PeakIndex::POS_220, height_220, scale_in_d * B2BEXP_POSITION_220 + shift_in_d));
-    function->addFunction(
-        createPeakFunction(shape, PeakIndex::POS_311, height_311, scale_in_d * B2BEXP_POSITION_311 + shift_in_d));
-    if (horizontal_shift > 0.) {
-      std::stringstream background;
-      background << "name=FlatBackground,A0=" << horizontal_shift;
-      function->addFunction(FunctionFactory::Instance().createInitialized(background.str()));
-    }
-
-    return function;
-  }
-  static std::vector<double> evaluateFunction(std::shared_ptr<IFunction> function, std::vector<double> &xValues) {
-    FunctionDomain1DVector domain(xValues);
-    FunctionValues values(domain);
-    function->function(domain, values);
-    return values.toVector();
-  }
-
-  void testDataGenerator() {
-    const auto result = createCompositeB2BExp(PeakShapeEnum::B2BEXP, 0);
-    TS_ASSERT(result != nullptr);
+protected:
+  void functionDerivMW(Jacobian *out, const double *xValues, const size_t nData) {
+    UNUSED_ARG(out);
+    UNUSED_ARG(xValues);
+    UNUSED_ARG(nData);
+    throw Exception::NotImplementedError("No derivative function provided");
   }
 };
+
+DECLARE_FUNCTION(SimplexGaussian)

--- a/Framework/Algorithms/test/CrossCorrelateTestData.h
+++ b/Framework/Algorithms/test/CrossCorrelateTestData.h
@@ -24,6 +24,10 @@ using Mantid::CurveFitting::Functions::Gaussian;
 
 enum class PeakShapeEnum : int { B2BEXP, GAUSSIAN };
 
+const double DIFC = 1434.66;
+const double DIFA = -1.88;
+const double T0 = 2.25;
+
 namespace { // anonymous
 /*
 Code to generate parameters for b2bexpconvpv:
@@ -117,10 +121,10 @@ std::shared_ptr<IFunction> createPeakFunction(const PeakShapeEnum shape, const P
     } else {
       throw std::runtime_error("Developer forgot a peak index");
     }
-    peak << ",Intensity=" << intensity << ",X0=" << d * 1434.66 + d * d * -1.88 + 2.25;
+    peak << ",Intensity=" << intensity << ",X0=" << d * DIFC + d * d * DIFA + T0;
   } else if (shape == PeakShapeEnum::GAUSSIAN) {
     // all Gaussians are hard coded to same arbitrary width
-    peak << "name=Gaussian,Sigma=10,Height=" << intensity << ",PeakCentre=" << d * 1434.66 + d * d * -1.88 + 2.25;
+    peak << "name=Gaussian,Sigma=10,Height=" << intensity << ",PeakCentre=" << d * DIFC + d * d * DIFA + T0;
   }
   std::cout << peak.str() << std::endl;
   return FunctionFactory::Instance().createInitialized(peak.str());
@@ -180,7 +184,11 @@ public:
     return function;
   }
   static std::vector<double> evaluateFunction(std::shared_ptr<IFunction> function, std::vector<double> &xValues) {
-    FunctionDomain1DVector domain(xValues);
+    std::vector<double> TOFvalues;
+    std::transform(xValues.begin(), xValues.end(), std::back_inserter(TOFvalues),
+                   [](double d) -> double { return d * DIFC + d * d * DIFA + T0; });
+
+    FunctionDomain1DVector domain(TOFvalues);
     FunctionValues values(domain);
     function->function(domain, values);
     return values.toVector();

--- a/Framework/Algorithms/test/CrossCorrelateTestData.h
+++ b/Framework/Algorithms/test/CrossCorrelateTestData.h
@@ -281,7 +281,7 @@ CrossCorrelateTestData::CrossCorrelateTestData(std::string function_specifier, i
                                                std::initializer_list<class TransformSpecifier> l)
     : domain_radius(domain_radius), num_functions(l.size() + 1) {
   /* allocate the workspace but do not populate yet */
-  int domain_size = domain_radius * 2 + 1;
+  int domain_size = this->domain_radius * 2 + 1;
 
   /* domain will represent points not bins, so the domain and co-domain are
      of identical size (as opposed to domain being co_domain_size + 1 ) */

--- a/Framework/Algorithms/test/CrossCorrelateTestData.h
+++ b/Framework/Algorithms/test/CrossCorrelateTestData.h
@@ -121,7 +121,7 @@ std::shared_ptr<IFunction> createPeakFunction(const PeakShapeEnum shape, const P
     // all Gaussians are hard coded to same arbitrary width
     peak << "name=Gaussian,Sigma=10,Height=" << intensity << ",PeakCentre=" << d * 1434.66 + d * d * -1.88 + 2.25;
   }
-
+  std::cout << peak.str() << std::endl;
   return FunctionFactory::Instance().createInitialized(peak.str());
 }
 
@@ -144,9 +144,10 @@ CompositeFunction_sptr createCompositeB2BExp(const PeakShapeEnum shape, const in
   double height_111{100.};
   double height_220{200.};
   double height_311{300.};
+
   if (spectrumIndex == 0) { // expected value = 0.
     // reference spectrum
-  } else if (spectrumIndex == 1) { // expected value = .1
+  } else if (spectrumIndex == 1) { // expected value = .1, or about 10 bins
     // additive shift in d-spacing from the reference
     // peak heights are unchanged
     shift_in_d = .1;

--- a/docs/source/algorithms/CrossCorrelate-v1.rst
+++ b/docs/source/algorithms/CrossCorrelate-v1.rst
@@ -12,6 +12,8 @@ Description
 Compute the cross correlation function for a range of spectra with
 respect to a reference spectrum.
 
+.. math:: c_{fg}(r) = \frac{1}{\sigma_f \sigma_g} \int (f(x) - \mu_f) (g(x+r)-\mu_g) dx
+
 This is use in powder diffraction experiments when trying to estimate
 the offset of one spectra with respect to another one. The spectra are
 converted in d-spacing and then interpolate on the X-axis of the

--- a/docs/source/release/v6.2.0/framework.rst
+++ b/docs/source/release/v6.2.0/framework.rst
@@ -15,6 +15,11 @@ Concepts
 Algorithms
 ----------
 
+Improvements
+############
+
+- :ref:`CrossCorrelate <algm-CrossCorrelate>` has additional parameter to set the maximum d-space shift during cross correlation
+
 Fit Functions
 -------------
 - new method `IPeakFunction::intensityError` calculates the error in the integrated intensity of the peak due to uncertainties in the values of the fit parameters.


### PR DESCRIPTION
**Description of work.**
PR addresses [this defect](https://code.ornl.gov/sns-hfir-scse/diffraction/powder/powder-diffraction/-/issues/261)

- [x] `Framework/Algorithms/src/CrossCorrelate.cpp ` modified
- [x] pr against `ornl-next` #31855

Companion to PR ornl-next [![GitHub issue/pull request detail](https://img.shields.io/github/issues/detail/state/mantidproject/mantid/31855)](https://github.com/mantidproject/mantid/pull/31855)

Contains chances from #31578 and #31592

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

**To test:**

Launch Mantid workbench and run the following script from the UI:
```
# import mantid algorithms, numpy and matplotlib
from mantid.simpleapi import *
import matplotlib.pyplot as plt
import numpy as np


#Create a workspace with 2 spectra with five bins of width 0.5
ws = CreateSampleWorkspace(BankPixelWidth=1, XUnit='dSpacing', XMax=5, BinWidth=0.25)
ws = ScaleX(InputWorkspace='ws', Factor=0.5, Operation='Add', IndexMin=1, IndexMax=1)
# Run algorithm  CrossCorrelate
OutputWorkspace = CrossCorrelate(InputWorkspace='ws', WorkspaceIndexMax=1, XMin=2, XMax=4, MaxDSpaceShift=100)

# Show workspaces
print("AutoCorrelation {}".format(OutputWorkspace.readY(0)))
print("CrossCorrelation {}".format(OutputWorkspace.readY(1)))
```
Then right click OutputWorkspace and generate a spectrum. Adjust `MaxDSpaceShift` parameter passed to `CorssCorrelate`, run the script again, and confirm the reflected change in the graph is correct\.

EDIT: Please refer to Ross' example below for a more complex test.
```
myFunc = "name=LinearBackground, A0=10;name=Gaussian, PeakCentre=2, Height=10, Sigma=0.1;name=Gaussian, PeakCentre=10, Height=10, Sigma=0.1;name=Gaussian, PeakCentre=12, Height=10, Sigma=0.1"
ws = CreateSampleWorkspace("Histogram","User Defined", myFunc, BankPixelWidth=1, XUnit='dSpacing', XMax=20, BinWidth=0.01)
ws = ScaleX(InputWorkspace='ws', Factor=0.25, Operation='Add', IndexMin=1, IndexMax=1)
OutputWorkspace = CrossCorrelate(InputWorkspace='ws', WorkspaceIndexMax=1, XMin=2, XMax=18, MaxDSpaceShift=5)
```

#### Release Notes

Framework Release Notes 6.2

* CrossCorrelate has additional parameter to set the maximum d-space shift during cross correlation


#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
