### PR TITLE
Enable fine control for SCDCalibratePanels

### DIFF
--- a/Framework/Crystal/inc/MantidCrystal/SCDCalibratePanels2.h
+++ b/Framework/Crystal/inc/MantidCrystal/SCDCalibratePanels2.h
@@ -12,6 +12,7 @@
 #include "MantidDataObjects/TableWorkspace.h"
 
 #include <boost/container/flat_set.hpp>
+#include <limits>
 
 namespace Mantid {
 namespace Crystal {
@@ -128,6 +129,7 @@ private:
   bool LOGCHILDALG{true};
   const int MINIMUM_PEAKS_PER_BANK{6};
   const double PI{3.1415926535897932384626433832795028841971693993751058209};
+  static constexpr double Tolerance = std::numeric_limits<double>::epsilon();
 
   // Column names and types
   const std::string calibrationTableColumnNames[8] = {"ComponentName",    "Xposition",        "Yposition",

--- a/Framework/Crystal/src/SCDCalibratePanels2.cpp
+++ b/Framework/Crystal/src/SCDCalibratePanels2.cpp
@@ -58,25 +58,25 @@ void SCDCalibratePanels2::init() {
                   "Workspace of Indexed Peaks");
 
   // Lattice constant group
-  auto mustBePositive = std::make_shared<BoundedValidator<double>>();
-  mustBePositive->setLower(0.0);
+  auto mustBeNonNegative = std::make_shared<BoundedValidator<double>>();
+  mustBeNonNegative->setLower(0.0);
   declareProperty("RecalculateUB", true, "Recalculate UB matrix using given lattice constants");
-  declareProperty("a", EMPTY_DBL(), mustBePositive,
+  declareProperty("a", EMPTY_DBL(), mustBeNonNegative,
                   "Lattice Parameter a (Leave empty to use lattice constants "
                   "in peaks workspace)");
-  declareProperty("b", EMPTY_DBL(), mustBePositive,
+  declareProperty("b", EMPTY_DBL(), mustBeNonNegative,
                   "Lattice Parameter b (Leave empty to use lattice constants "
                   "in peaks workspace)");
-  declareProperty("c", EMPTY_DBL(), mustBePositive,
+  declareProperty("c", EMPTY_DBL(), mustBeNonNegative,
                   "Lattice Parameter c (Leave empty to use lattice constants "
                   "in peaks workspace)");
-  declareProperty("alpha", EMPTY_DBL(), mustBePositive,
+  declareProperty("alpha", EMPTY_DBL(), mustBeNonNegative,
                   "Lattice Parameter alpha in degrees (Leave empty to use "
                   "lattice constants in peaks workspace)");
-  declareProperty("beta", EMPTY_DBL(), mustBePositive,
+  declareProperty("beta", EMPTY_DBL(), mustBeNonNegative,
                   "Lattice Parameter beta in degrees (Leave empty to use "
                   "lattice constants in peaks workspace)");
-  declareProperty("gamma", EMPTY_DBL(), mustBePositive,
+  declareProperty("gamma", EMPTY_DBL(), mustBeNonNegative,
                   "Lattice Parameter gamma in degrees (Leave empty to use "
                   "lattice constants in peaks workspace)");
   const std::string LATTICE("Lattice Constants");
@@ -107,8 +107,8 @@ void SCDCalibratePanels2::init() {
   // ----- L1 -----
   // --------------
   declareProperty("CalibrateL1", true, "Change the L1(source to sample) distance");
-  declareProperty("ToleranceL1", 5e-4, mustBePositive, "Delta L1 below this value (in meter) is treated as 0.0");
-  declareProperty("SearchRadiusL1", 0.1, mustBePositive,
+  declareProperty("ToleranceL1", 5e-4, mustBeNonNegative, "Delta L1 below this value (in meter) is treated as 0.0");
+  declareProperty("SearchRadiusL1", 0.1, mustBeNonNegative,
                   "Search radius of delta L1 in meters, which is used to constrain optimization search space"
                   "when calibrating L1");
   // editability
@@ -122,21 +122,21 @@ void SCDCalibratePanels2::init() {
   // ----- bank -----
   // ----------------
   declareProperty("CalibrateBanks", false, "Calibrate position and orientation of each bank.");
-  declareProperty("ToleranceTransBank", 1e-6, mustBePositive,
+  declareProperty("ToleranceTransBank", 1e-6, mustBeNonNegative,
                   "Delta translation of bank (in meter) below this value is treated as 0.0");
   declareProperty(
-      "SearchRadiusTransBank", 5e-2, mustBePositive,
+      "SearchRadiusTransBank", 5e-2, mustBeNonNegative,
       "This is the search radius (in meter) when calibrating component translations, used to constrain optimization"
       "search space when calibration translation of banks");
-  declareProperty("ToleranceRotBank", 1e-3, mustBePositive,
+  declareProperty("ToleranceRotBank", 1e-3, mustBeNonNegative,
                   "Misorientation of bank (in deg) below this value is treated as 0.0");
-  declareProperty("SearchradiusRotXBank", 1.0, mustBePositive,
+  declareProperty("SearchradiusRotXBank", 1.0, mustBeNonNegative,
                   "This is the search radius (in deg) when calibrating component reorientation, used to constrain "
                   "optimization search space");
-  declareProperty("SearchradiusRotYBank", 1.0, mustBePositive,
+  declareProperty("SearchradiusRotYBank", 1.0, mustBeNonNegative,
                   "This is the search radius (in deg) when calibrating component reorientation, used to constrain "
                   "optimization search space");
-  declareProperty("SearchradiusRotZBank", 1.0, mustBePositive,
+  declareProperty("SearchradiusRotZBank", 1.0, mustBeNonNegative,
                   "This is the search radius (in deg) when calibrating component reorientation, used to constrain "
                   "optimization search space");
   // editability
@@ -162,9 +162,9 @@ void SCDCalibratePanels2::init() {
   // ----- T0 -----
   // --------------
   declareProperty("CalibrateT0", false, "Calibrate the T0 (initial TOF)");
-  declareProperty("ToleranceT0", 1e-3, mustBePositive,
+  declareProperty("ToleranceT0", 1e-3, mustBeNonNegative,
                   "Shift of initial TOF (in ms) below this value is treated as 0.0");
-  declareProperty("SearchRadiusT0", 10.0, mustBePositive,
+  declareProperty("SearchRadiusT0", 10.0, mustBeNonNegative,
                   "Search radius of T0 (in ms), used to constrain optimization search space");
   // editability
   setPropertySettings("ToleranceT0", std::make_unique<EnabledWhenProperty>("CalibrateT0", IS_EQUAL_TO, "1"));
@@ -177,9 +177,9 @@ void SCDCalibratePanels2::init() {
   // ----- samplePos -----
   // ---------------------
   declareProperty("TuneSamplePosition", false, "Fine tunning sample position");
-  declareProperty("ToleranceSamplePos", 1e-6, mustBePositive,
+  declareProperty("ToleranceSamplePos", 1e-6, mustBeNonNegative,
                   "Sample position change (in meter) below this value is treated as 0.0");
-  declareProperty("SearchRadiusSamplePos", 0.1, mustBePositive,
+  declareProperty("SearchRadiusSamplePos", 0.1, mustBeNonNegative,
                   "Search radius of sample position change (in meters), used to constrain optimization search space");
   // editability
   setPropertySettings("ToleranceSamplePos",
@@ -574,25 +574,25 @@ void SCDCalibratePanels2::optimizeBanks(IPeaksWorkspace_sptr pws, IPeaksWorkspac
             << "DeltaT0=" << m_T0;
     std::ostringstream constraint_str;
     // rot x
-    if (searchRadiusRotX < 1e-16) {
+    if (searchRadiusRotX < Tolerance) {
       tie_str << ",RotX=0.0";
     } else {
       constraint_str << -searchRadiusRotX << "<RotX<" << searchRadiusRotX << ",";
     }
     // rot y
-    if (searchRadiusRotY < 1e-16) {
+    if (searchRadiusRotY < Tolerance) {
       tie_str << ",RotY=0.0";
     } else {
       constraint_str << -searchRadiusRotY << "<RotY<" << searchRadiusRotY << ",";
     }
     // rot z
-    if (searchRadiusRotZ < 1e-16) {
+    if (searchRadiusRotZ < Tolerance) {
       tie_str << ",RotZ=0.0";
     } else {
       constraint_str << -searchRadiusRotZ << "<RotZ<" << searchRadiusRotZ << ","; // constrain rotation around Z-axis
     }
     // translation
-    if (searchRadiusTran < 1e-16) {
+    if (searchRadiusTran < Tolerance) {
       tie_str << ",DeltaX=0.0,DeltaY=0.0,DeltaZ=0.0";
     } else {
       constraint_str << -searchRadiusTran << "<DeltaX<" << searchRadiusTran << "," // restrict tranlastion along X
@@ -644,9 +644,9 @@ void SCDCalibratePanels2::optimizeBanks(IPeaksWorkspace_sptr pws, IPeaksWorkspac
     // if the translation vector has one component that is hitting the search bounds, the
     // optimization setting is too tight and we should inform the users about this issue,
     // and cowardly reject this results by zero the vector
-    double ddx = std::abs(dx - searchRadiusTran);
-    double ddy = std::abs(dy - searchRadiusTran);
-    double ddz = std::abs(dz - searchRadiusTran);
+    double ddx = std::abs(std::abs(dx) - searchRadiusTran);
+    double ddy = std::abs(std::abs(dy) - searchRadiusTran);
+    double ddz = std::abs(std::abs(dz) - searchRadiusTran);
     if ((ddx < tolerance_translation) || // is dx too close to search bounds?
         (ddy < tolerance_translation) || // is dy too close to search bounds?
         (ddz < tolerance_translation) || // is dz too close to search bounds?
@@ -675,14 +675,14 @@ void SCDCalibratePanels2::optimizeBanks(IPeaksWorkspace_sptr pws, IPeaksWorkspac
     // NOTE:
     // if any components of the resulting Euler angle is hitting the search bounds, we should warn
     // the user (so that they can increase search bounds) and cowardly refuse the calibration results
-    double ddrx = std::abs(drx - searchRadiusRotX);
-    double ddry = std::abs(dry - searchRadiusRotY);
-    double ddrz = std::abs(drz - searchRadiusRotZ);
+    double ddrx = std::abs(std::abs(drx) - searchRadiusRotX);
+    double ddry = std::abs(std::abs(dry) - searchRadiusRotY);
+    double ddrz = std::abs(std::abs(drz) - searchRadiusRotZ);
     if ((ddrx < tolerance_rotation) || // is rotx hitting the search bounds?
         (ddry < tolerance_rotation) || // is roty hitting the search bounds?
         (ddrz < tolerance_rotation) || // is rotz hitting the search bounds?
         false) {
-      calilog << "-- Fit " << bn << " rotatoin hitting bounds, please increase search radius.\n"
+      calilog << "-- Fit " << bn << " rotation hitting bounds, please increase search radius.\n"
               << "       also, cowardly refusing calibration results by zeroing (drx, dry, drz)\n";
       drx = 0.0;
       dry = 0.0;

--- a/Framework/Crystal/src/SCDCalibratePanels2.cpp
+++ b/Framework/Crystal/src/SCDCalibratePanels2.cpp
@@ -633,8 +633,8 @@ void SCDCalibratePanels2::optimizeBanks(IPeaksWorkspace_sptr pws, IPeaksWorkspac
     // proper one.
     if ((std::abs(dx) < tolerance_translation) && // is dx<tor?
         (std::abs(dy) < tolerance_translation) && // is dy<tor?
-        (std::abs(dz) < tolerance_translation) && // is dz<tor?
-        true) {
+        (std::abs(dz) < tolerance_translation)    // is dz<tor?
+    ) {
       calilog << "-- Fit " << bn << " translation below tolerance, zero (dx, dy, dz)\n";
       dx = 0.0;
       dy = 0.0;
@@ -649,8 +649,8 @@ void SCDCalibratePanels2::optimizeBanks(IPeaksWorkspace_sptr pws, IPeaksWorkspac
     double ddz = std::abs(std::abs(dz) - searchRadiusTran);
     if ((ddx < tolerance_translation) || // is dx too close to search bounds?
         (ddy < tolerance_translation) || // is dy too close to search bounds?
-        (ddz < tolerance_translation) || // is dz too close to search bounds?
-        false) {
+        (ddz < tolerance_translation)    // is dz too close to search bounds?
+    ) {
       calilog << "-- Fit " << bn << " translation hitting search bounds, please increase bounds.\n"
               << "       also, cowardly refusing calibration results by zeroing (dx, dy, dz)\n";
       dx = 0.0;
@@ -665,8 +665,8 @@ void SCDCalibratePanels2::optimizeBanks(IPeaksWorkspace_sptr pws, IPeaksWorkspac
     // if all components of the Euler angle vector is pratically zero, let's make it official
     if ((std::abs(drx) < tolerance_rotation) && //
         (std::abs(dry) < tolerance_rotation) && //
-        (std::abs(drz) < tolerance_rotation) && //
-        true) {
+        (std::abs(drz) < tolerance_rotation)    //
+    ) {
       calilog << "-- Fit " << bn << " rotatoin below tolerance, zero (drx, dry, drz)\n";
       drx = 0.0;
       dry = 0.0;
@@ -680,8 +680,8 @@ void SCDCalibratePanels2::optimizeBanks(IPeaksWorkspace_sptr pws, IPeaksWorkspac
     double ddrz = std::abs(std::abs(drz) - searchRadiusRotZ);
     if ((ddrx < tolerance_rotation) || // is rotx hitting the search bounds?
         (ddry < tolerance_rotation) || // is roty hitting the search bounds?
-        (ddrz < tolerance_rotation) || // is rotz hitting the search bounds?
-        false) {
+        (ddrz < tolerance_rotation)    // is rotz hitting the search bounds?
+    ) {
       calilog << "-- Fit " << bn << " rotation hitting bounds, please increase search radius.\n"
               << "       also, cowardly refusing calibration results by zeroing (drx, dry, drz)\n";
       drx = 0.0;

--- a/docs/source/release/v6.2.0/diffraction.rst
+++ b/docs/source/release/v6.2.0/diffraction.rst
@@ -17,6 +17,7 @@ New features
 Improvements
 ############
 - :ref:`SCDCalibratePanels <algm-SCDCalibratePanels-v2>` major interface update along with enabling the calibration of T0 and sample position.
+- :ref:`SCDCalibratePanels <algm-SCDCalibratePanels-v2>` minor interface update that allows fine control of bank rotation calibration.
 
 Bugfixes
 ########


### PR DESCRIPTION
**Description of work.**

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

- Original Gitlab user story: [SCD347](https://code.ornl.gov/sns-hfir-scse/diffraction/single-crystal/single-crystal-diffraction/-/issues/347)
- This is #31700 into `master`

This PR introduce two minor improvements to current SCDCalibratePanels
- User can now specify different search bounds for different rotation axis (setting a bounds to 0 will remove the corresponding feature from calibration process)
- The optimizer will cowardly reject any calibration results that are too close to the search bounds, and recommend the user to increase search bounds.

**To test:**
- use the code snippet from #31598 to generate a synthetic peaks workspace
```python
from mantid.simpleapi import *
from mantid.geometry import CrystalStructure
import matplotlib.pyplot as plt
import numpy as np

from collections import namedtuple

def convert(dictionary):
    return namedtuple('GenericDict', dictionary.keys())(**dictionary)

lc_natrolite = {
    "a": 18.29,  # A
    "b": 18.64,  # A
    "c": 6.56,  # A
    "alpha": 90,  # deg
    "beta": 90,  # deg
    "gamma": 90,  # deg
}
natrolite = convert(lc_natrolite)

CreateSimulationWorkspace(
    Instrument='TOPAZ',
    BinParams='1,100,10000',
    UnitX='TOF',
    OutputWorkspace='cws',
)
cws = mtd['cws']

# Set the UB matrix for the sample
# u, v is the critical part, we can start with the
# ideal position
SetUB(
    Workspace="cws",
    u='1,0,0',  # vector along k_i, when goniometer is at 0
    v='0,1,0',  # in-plane vector normal to k_i, when goniometer is at 0
    **lc_natrolite,
)

# Generate predicted peak workspace
dspacings = convert({'min': 1.0, 'max': 10.0})
wavelengths = convert({'min': 0.8, 'max': 2.9})

# Collect peaks over a range of omegas
CreatePeaksWorkspace(OutputWorkspace='pws')
omegas = range(0, 180, 3)

for omega in omegas:
    SetGoniometer(
        Workspace="cws",
        Axis0=f"{omega},0,1,0,1",
    )

    PredictPeaks(
        InputWorkspace='cws',
        WavelengthMin=wavelengths.min,
        wavelengthMax=wavelengths.max,
        MinDSpacing=dspacings.min,
        MaxDSpacing=dspacings.max,
        ReflectionCondition='All-face centred',
        OutputWorkspace='_pws',
    )

    CombinePeaksWorkspaces(
        LHSWorkspace="_pws",
        RHSWorkspace="pws",
        OutputWorkspace="pws",
    )

IndexPeaks("pws")
```

- Call `SCDCalibratePanels` GUI to see the new controls
![image](https://user-images.githubusercontent.com/5064852/120545361-8c4c2300-c3bc-11eb-9c86-0621f481e5a6.png)

- To see the new warning message, set a high `ToleranceRotBank` so that SCDCalibratePanels will reject all bank rotation calibration results and warn the users to increase the search bounds (see example below)
```bash
SCDCalibratePanels-[Notice] -- Fit bank38 rotatoin hitting bounds, please increase search radius.
SCDCalibratePanels-[Notice]        also, cowardly refusing calibration results by zeroing (drx, dry, drz)
SCDCalibratePanels-[Notice] -- Fit bank38 results using 759 peaks:
SCDCalibratePanels-[Notice]     d(x,y,z) = [-0.000133734,1.63025e-06,4.67217e-05]
SCDCalibratePanels-[Notice]     r(x,y,z) = [0,0,0]
SCDCalibratePanels-[Notice]     chi2/DOF = 2.54708e-06
```

> In practice, the tolerance should be a value close to zero and the bounds should an estimated value that is close to the theoretical solution.

<!-- Instructions for testing. -->

<!-- and fix #xxxx or close #xxxx xor resolves #xxxx -->
<!-- alternative
*There is no associated issue.*
-->

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or master)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
