### PR TITLE
Increase the d-spacing tolerance in AlignComponents validation

### DIFF
--- a/Framework/PythonInterface/plugins/algorithms/AlignComponents.py
+++ b/Framework/PythonInterface/plugins/algorithms/AlignComponents.py
@@ -273,7 +273,7 @@ class AlignComponents(PythonAlgorithm):
             return round(the_number, precision - len(str(int(the_number))))
 
         for column_name, peak_position in zip(column_names, sorted(peak_positions)):
-            if (float(column_name[1:]) - with_precision(peak_position, 5)) > 1.e-5:
+            if (float(column_name[1:]) - with_precision(peak_position, 5)) > 1.e-3:
                 issues['PeakCentersTofTable'] = f'{column_name} and {peak_position} differ up to precision 5'
 
         maskWS: MaskWorkspace = self.getProperty("MaskWorkspace").value


### PR DESCRIPTION
Companion to #31704 

Avoids the corner case of d-spacing=14.3245 and the column name @14.235

*There is no associated issue.*

*This does not require release notes because it's a small fix for a found corner case*

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
