### PR TITLE
Fix IDA fit not appending spectra to workspace if data from that workspace has already been added

### DIFF
--- a/docs/source/release/v6.2.0/indirect_geometry.rst
+++ b/docs/source/release/v6.2.0/indirect_geometry.rst
@@ -14,4 +14,9 @@ New Features
 
 - Fit functions `ElasticIsoRotDiff` and `InelasticIsoRotDiff` have been made available in the ConvFit tab in the Indirect Data Analysis
 
+Bug Fixes
+#########
+
+- A bug has been fixed that stopped additional spectra to be added to Indirect Data Analysis if spectra from that workspace had already been added.
+
 :ref:`Release 6.2.0 <v6.2.0>`

--- a/qt/scientific_interfaces/Indirect/IndirectFitDataTableModel.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectFitDataTableModel.cpp
@@ -179,7 +179,7 @@ void IndirectFitDataTableModel::addWorkspace(const std::string &workspaceName, c
 void IndirectFitDataTableModel::addWorkspace(Mantid::API::MatrixWorkspace_sptr workspace,
                                              const FunctionModelSpectra &spectra) {
   if (!m_fittingData->empty()) {
-    for (auto fitData : *m_fittingData) {
+    for (auto &fitData : *m_fittingData) {
       if (equivalentWorkspaces(workspace, fitData.workspace())) {
         fitData.combine(IndirectFitData(workspace, spectra));
         return;


### PR DESCRIPTION
**Description of work.**

This PR fixes a bug that prevented additional spectra to be added to IDA multiple input if spectra had already been added from that workspace.

No associated Issue.


**To test:**

1. open Indirect Data Analysis.
2. In MSD Fit, I(Q,t) Fit, and ConvFit:
3. go to multpile input.
4. load a single spectra from a workspace
5. check that you can add more spectra from that workspace without issue.

<!-- Instructions for testing. -->

*There is no associated issue.*

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
