### PR TITLE
Renamed all files and tests to IndirectFitDataTablePresenter

### DIFF
--- a/qt/scientific_interfaces/Indirect/CMakeLists.txt
+++ b/qt/scientific_interfaces/Indirect/CMakeLists.txt
@@ -36,7 +36,6 @@ set(
         IndirectDataAnalysisTab.cpp
         IndirectDataReduction.cpp
         IndirectDataReductionTab.cpp
-        IndirectDataTablePresenter.cpp
         IndirectDataValidationHelper.cpp
         IndirectDiffractionReduction.cpp
         IndirectDockWidgetArea.cpp
@@ -44,6 +43,7 @@ set(
         IndirectFitAnalysisTab.cpp
         IndirectFitData.cpp
         IndirectFitDataPresenter.cpp
+	IndirectFitDataTablePresenter.cpp
         IndirectFitDataView.cpp
         IndirectFitOutputOptionsModel.cpp
         IndirectFitOutputOptionsPresenter.cpp
@@ -134,12 +134,12 @@ set(
         IndirectDataAnalysisTab.h
         IndirectDataReduction.h
         IndirectDataReductionTab.h
-        IndirectDataTablePresenter.h
         IndirectDockWidgetArea.h
         IndirectDiffractionReduction.h
         IndirectEditResultsDialog.h
         IndirectFitAnalysisTab.h
         IndirectFitDataPresenter.h
+	IndirectFitDataTablePresenter.h
         IndirectFitDataView.h
         IndirectFitOutputOptionsPresenter.h
         IndirectFitOutputOptionsView.h

--- a/qt/scientific_interfaces/Indirect/ConvFitDataTablePresenter.cpp
+++ b/qt/scientific_interfaces/Indirect/ConvFitDataTablePresenter.cpp
@@ -28,7 +28,7 @@ namespace CustomInterfaces {
 namespace IDA {
 
 ConvFitDataTablePresenter::ConvFitDataTablePresenter(ConvFitModel *model, QTableWidget *dataTable)
-    : IndirectDataTablePresenter(model->getFitDataModel(), dataTable, convFitHeaders()) {
+    : IndirectFitDataTablePresenter(model->getFitDataModel(), dataTable, convFitHeaders()) {
   auto header = dataTable->horizontalHeader();
 #if QT_VERSION < QT_VERSION_CHECK(5, 0, 0)
   header->setResizeMode(1, QHeaderView::Stretch);
@@ -48,7 +48,7 @@ int ConvFitDataTablePresenter::excludeColumn() const { return 5; }
 std::string ConvFitDataTablePresenter::getResolutionName(FitDomainIndex row) const { return getString(row, 1); }
 
 void ConvFitDataTablePresenter::addTableEntry(FitDomainIndex row) {
-  IndirectDataTablePresenter::addTableEntry(row);
+  IndirectFitDataTablePresenter::addTableEntry(row);
 
   auto resolutionVector = m_model->getResolutionsForFit();
   const auto name = resolutionVector.at(row.value).first;

--- a/qt/scientific_interfaces/Indirect/ConvFitDataTablePresenter.h
+++ b/qt/scientific_interfaces/Indirect/ConvFitDataTablePresenter.h
@@ -7,7 +7,7 @@
 #pragma once
 
 #include "ConvFitModel.h"
-#include "IndirectDataTablePresenter.h"
+#include "IndirectFitDataTablePresenter.h"
 
 #include <QTableWidget>
 
@@ -21,7 +21,7 @@ namespace IDA {
 /**
   Presenter for a table of convolution fitting data.
 */
-class DLLExport ConvFitDataTablePresenter : public IndirectDataTablePresenter {
+class DLLExport ConvFitDataTablePresenter : public IndirectFitDataTablePresenter {
   Q_OBJECT
 public:
   ConvFitDataTablePresenter(ConvFitModel *model, QTableWidget *dataTable);

--- a/qt/scientific_interfaces/Indirect/FqFitDataTablePresenter.cpp
+++ b/qt/scientific_interfaces/Indirect/FqFitDataTablePresenter.cpp
@@ -28,7 +28,7 @@ namespace CustomInterfaces {
 namespace IDA {
 
 FqFitDataTablePresenter::FqFitDataTablePresenter(FqFitModel *model, QTableWidget *dataTable)
-    : IndirectDataTablePresenter(model->getFitDataModel(), dataTable, FqFitHeaders()) {
+    : IndirectFitDataTablePresenter(model->getFitDataModel(), dataTable, FqFitHeaders()) {
   auto header = dataTable->horizontalHeader();
 #if QT_VERSION < QT_VERSION_CHECK(5, 0, 0)
   header->setResizeMode(1, QHeaderView::Stretch);
@@ -46,7 +46,7 @@ int FqFitDataTablePresenter::endXColumn() const { return 4; }
 int FqFitDataTablePresenter::excludeColumn() const { return 5; }
 
 void FqFitDataTablePresenter::addTableEntry(FitDomainIndex row) {
-  IndirectDataTablePresenter::addTableEntry(row);
+  IndirectFitDataTablePresenter::addTableEntry(row);
 
   auto subIndices = m_model->getSubIndices(row);
   const auto workspace = m_model->getWorkspace(subIndices.first);

--- a/qt/scientific_interfaces/Indirect/FqFitDataTablePresenter.h
+++ b/qt/scientific_interfaces/Indirect/FqFitDataTablePresenter.h
@@ -7,7 +7,7 @@
 #pragma once
 
 #include "FqFitModel.h"
-#include "IndirectDataTablePresenter.h"
+#include "IndirectFitDataTablePresenter.h"
 
 #include <QTableWidget>
 
@@ -21,7 +21,7 @@ namespace IDA {
 /**
   Presenter for a table of data containing Widths/EISF.
 */
-class DLLExport FqFitDataTablePresenter : public IndirectDataTablePresenter {
+class DLLExport FqFitDataTablePresenter : public IndirectFitDataTablePresenter {
   Q_OBJECT
 public:
   FqFitDataTablePresenter(FqFitModel *model, QTableWidget *dataTable);

--- a/qt/scientific_interfaces/Indirect/IndirectFitDataPresenter.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectFitDataPresenter.cpp
@@ -16,10 +16,11 @@ namespace IDA {
 
 IndirectFitDataPresenter::IndirectFitDataPresenter(IIndirectFittingModel *model, IIndirectFitDataView *view)
     : IndirectFitDataPresenter(
-          model, view, std::make_unique<IndirectDataTablePresenter>(model->getFitDataModel(), view->getDataTable())) {}
+          model, view,
+          std::make_unique<IndirectFitDataTablePresenter>(model->getFitDataModel(), view->getDataTable())) {}
 
 IndirectFitDataPresenter::IndirectFitDataPresenter(IIndirectFittingModel *model, IIndirectFitDataView *view,
-                                                   std::unique_ptr<IndirectDataTablePresenter> tablePresenter)
+                                                   std::unique_ptr<IndirectFitDataTablePresenter> tablePresenter)
     : m_model(model), m_view(view), m_tablePresenter(std::move(tablePresenter)) {
   observeReplace(true);
 

--- a/qt/scientific_interfaces/Indirect/IndirectFitDataPresenter.h
+++ b/qt/scientific_interfaces/Indirect/IndirectFitDataPresenter.h
@@ -8,7 +8,7 @@
 
 #include "IAddWorkspaceDialog.h"
 #include "IIndirectFitDataView.h"
-#include "IndirectDataTablePresenter.h"
+#include "IndirectFitDataTablePresenter.h"
 #include "IndirectFitDataView.h"
 #include "IndirectFittingModel.h"
 #include "MantidQtWidgets/Common/IndexTypes.h"
@@ -82,7 +82,7 @@ signals:
 
 protected:
   IndirectFitDataPresenter(IIndirectFittingModel *model, IIndirectFitDataView *view,
-                           std::unique_ptr<IndirectDataTablePresenter> tablePresenter);
+                           std::unique_ptr<IndirectFitDataTablePresenter> tablePresenter);
   IIndirectFitDataView const *getView() const;
   void addData(IAddWorkspaceDialog const *dialog);
   virtual void addDataToModel(IAddWorkspaceDialog const *dialog);
@@ -106,7 +106,7 @@ private:
   std::unique_ptr<IAddWorkspaceDialog> m_addWorkspaceDialog;
   IIndirectFittingModel *m_model;
   IIndirectFitDataView *m_view;
-  std::unique_ptr<IndirectDataTablePresenter> m_tablePresenter;
+  std::unique_ptr<IndirectFitDataTablePresenter> m_tablePresenter;
 };
 
 } // namespace IDA

--- a/qt/scientific_interfaces/Indirect/IndirectFitDataTablePresenter.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectFitDataTablePresenter.cpp
@@ -4,7 +4,7 @@
 //   NScD Oak Ridge National Laboratory, European Spallation Source,
 //   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
 // SPDX - License - Identifier: GPL - 3.0 +
-#include "IndirectDataTablePresenter.h"
+#include "IndirectFitDataTablePresenter.h"
 
 #include "MantidQtWidgets/Common/SignalBlocker.h"
 
@@ -81,11 +81,11 @@ namespace MantidQt {
 namespace CustomInterfaces {
 namespace IDA {
 
-IndirectDataTablePresenter::IndirectDataTablePresenter(IIndirectFitDataTableModel *model, QTableWidget *dataTable)
-    : IndirectDataTablePresenter(model, dataTable, defaultHeaders()) {}
+IndirectFitDataTablePresenter::IndirectFitDataTablePresenter(IIndirectFitDataTableModel *model, QTableWidget *dataTable)
+    : IndirectFitDataTablePresenter(model, dataTable, defaultHeaders()) {}
 
-IndirectDataTablePresenter::IndirectDataTablePresenter(IIndirectFitDataTableModel *model, QTableWidget *dataTable,
-                                                       const QStringList &headers)
+IndirectFitDataTablePresenter::IndirectFitDataTablePresenter(IIndirectFitDataTableModel *model, QTableWidget *dataTable,
+                                                             const QStringList &headers)
     : m_model(model), m_dataTable(dataTable) {
 
   setHorizontalHeaders(headers);
@@ -95,29 +95,29 @@ IndirectDataTablePresenter::IndirectDataTablePresenter(IIndirectFitDataTableMode
   connect(m_dataTable, SIGNAL(cellChanged(int, int)), this, SLOT(handleCellChanged(int, int)));
 }
 
-bool IndirectDataTablePresenter::isTableEmpty() const { return m_dataTable->rowCount() == 0; }
+bool IndirectFitDataTablePresenter::isTableEmpty() const { return m_dataTable->rowCount() == 0; }
 
-int IndirectDataTablePresenter::workspaceIndexColumn() const { return 1; }
+int IndirectFitDataTablePresenter::workspaceIndexColumn() const { return 1; }
 
-int IndirectDataTablePresenter::startXColumn() const { return 2; }
+int IndirectFitDataTablePresenter::startXColumn() const { return 2; }
 
-int IndirectDataTablePresenter::endXColumn() const { return 3; }
+int IndirectFitDataTablePresenter::endXColumn() const { return 3; }
 
-int IndirectDataTablePresenter::excludeColumn() const { return 4; }
+int IndirectFitDataTablePresenter::excludeColumn() const { return 4; }
 
-double IndirectDataTablePresenter::getDouble(FitDomainIndex row, int column) const {
+double IndirectFitDataTablePresenter::getDouble(FitDomainIndex row, int column) const {
   return getText(row, column).toDouble();
 }
 
-std::string IndirectDataTablePresenter::getString(FitDomainIndex row, int column) const {
+std::string IndirectFitDataTablePresenter::getString(FitDomainIndex row, int column) const {
   return getText(row, column).toStdString();
 }
 
-QString IndirectDataTablePresenter::getText(FitDomainIndex row, int column) const {
+QString IndirectFitDataTablePresenter::getText(FitDomainIndex row, int column) const {
   return m_dataTable->item(static_cast<int>(row.value), column)->text();
 }
 
-void IndirectDataTablePresenter::removeSelectedData() {
+void IndirectFitDataTablePresenter::removeSelectedData() {
   auto selectedIndices = m_dataTable->selectionModel()->selectedIndexes();
   std::sort(selectedIndices.begin(), selectedIndices.end());
   for (auto item = selectedIndices.end(); item != selectedIndices.begin();) {
@@ -127,7 +127,7 @@ void IndirectDataTablePresenter::removeSelectedData() {
   updateTableFromModel();
 }
 
-void IndirectDataTablePresenter::updateTableFromModel() {
+void IndirectFitDataTablePresenter::updateTableFromModel() {
   ScopedFalse _signalBlock(m_emitCellChanged);
   m_dataTable->setRowCount(0);
   for (auto domainIndex = FitDomainIndex{0}; domainIndex < m_model->getNumberOfDomains(); domainIndex++) {
@@ -135,7 +135,7 @@ void IndirectDataTablePresenter::updateTableFromModel() {
   }
 }
 
-void IndirectDataTablePresenter::handleCellChanged(int irow, int column) {
+void IndirectFitDataTablePresenter::handleCellChanged(int irow, int column) {
   if (!m_emitCellChanged) {
     return;
   }
@@ -150,33 +150,33 @@ void IndirectDataTablePresenter::handleCellChanged(int irow, int column) {
   }
 }
 
-void IndirectDataTablePresenter::setModelStartXAndEmit(double startX, FitDomainIndex row) {
+void IndirectFitDataTablePresenter::setModelStartXAndEmit(double startX, FitDomainIndex row) {
   auto subIndices = m_model->getSubIndices(row);
   m_model->setStartX(startX, subIndices.first, subIndices.second);
   emit startXChanged(startX, subIndices.first, subIndices.second);
 }
 
-void IndirectDataTablePresenter::setModelEndXAndEmit(double endX, FitDomainIndex row) {
+void IndirectFitDataTablePresenter::setModelEndXAndEmit(double endX, FitDomainIndex row) {
   auto subIndices = m_model->getSubIndices(row);
   m_model->setEndX(endX, subIndices.first, subIndices.second);
   emit endXChanged(endX, subIndices.first, subIndices.second);
 }
 
-void IndirectDataTablePresenter::setModelExcludeAndEmit(const std::string &exclude, FitDomainIndex row) {
+void IndirectFitDataTablePresenter::setModelExcludeAndEmit(const std::string &exclude, FitDomainIndex row) {
   auto subIndices = m_model->getSubIndices(row);
   m_model->setExcludeRegion(exclude, subIndices.first, subIndices.second);
   emit excludeRegionChanged(exclude, subIndices.first, subIndices.second);
 }
 
-void IndirectDataTablePresenter::clearTable() { m_dataTable->setRowCount(0); }
+void IndirectFitDataTablePresenter::clearTable() { m_dataTable->setRowCount(0); }
 
-void IndirectDataTablePresenter::setColumnValues(int column, const QString &value) {
+void IndirectFitDataTablePresenter::setColumnValues(int column, const QString &value) {
   MantidQt::API::SignalBlocker blocker(m_dataTable);
   for (int i = 0; i < m_dataTable->rowCount(); ++i)
     m_dataTable->item(i, column)->setText(value);
 }
 
-void IndirectDataTablePresenter::setHorizontalHeaders(const QStringList &headers) {
+void IndirectFitDataTablePresenter::setHorizontalHeaders(const QStringList &headers) {
   m_dataTable->setColumnCount(headers.size());
   m_dataTable->setHorizontalHeaderLabels(headers);
 
@@ -188,7 +188,7 @@ void IndirectDataTablePresenter::setHorizontalHeaders(const QStringList &headers
 #endif
 }
 
-void IndirectDataTablePresenter::addTableEntry(FitDomainIndex row) {
+void IndirectFitDataTablePresenter::addTableEntry(FitDomainIndex row) {
   m_dataTable->insertRow(static_cast<int>(row.value));
   const auto &name = m_model->getWorkspace(row)->getName();
   auto cell = std::make_unique<QTableWidgetItem>(QString::fromStdString(name));
@@ -213,11 +213,11 @@ void IndirectDataTablePresenter::addTableEntry(FitDomainIndex row) {
   setCell(std::move(cell), row.value, excludeColumn());
 }
 
-void IndirectDataTablePresenter::setCell(std::unique_ptr<QTableWidgetItem> cell, FitDomainIndex row, int column) {
+void IndirectFitDataTablePresenter::setCell(std::unique_ptr<QTableWidgetItem> cell, FitDomainIndex row, int column) {
   m_dataTable->setItem(static_cast<int>(row.value), column, cell.release());
 }
 
-void IndirectDataTablePresenter::setCellText(const QString &text, FitDomainIndex row, int column) {
+void IndirectFitDataTablePresenter::setCellText(const QString &text, FitDomainIndex row, int column) {
   m_dataTable->item(static_cast<int>(row.value), column)->setText(text);
 }
 

--- a/qt/scientific_interfaces/Indirect/IndirectFitDataTablePresenter.h
+++ b/qt/scientific_interfaces/Indirect/IndirectFitDataTablePresenter.h
@@ -25,10 +25,10 @@ using DataPositionType = IndexCollectionType<TableDatasetIndex, FitDomainIndex>;
 /**
   Presenter for a table of indirect fitting data.
 */
-class MANTIDQT_INDIRECT_DLL IndirectDataTablePresenter : public QObject {
+class MANTIDQT_INDIRECT_DLL IndirectFitDataTablePresenter : public QObject {
   Q_OBJECT
 public:
-  IndirectDataTablePresenter(IIndirectFitDataTableModel *model, QTableWidget *dataTable);
+  IndirectFitDataTablePresenter(IIndirectFitDataTableModel *model, QTableWidget *dataTable);
 
   bool isTableEmpty() const;
 
@@ -48,7 +48,7 @@ private slots:
   // void updateAllFittingRangeFrom(int row, int column);
 
 protected:
-  IndirectDataTablePresenter(IIndirectFitDataTableModel *model, QTableWidget *dataTable, const QStringList &headers);
+  IndirectFitDataTablePresenter(IIndirectFitDataTableModel *model, QTableWidget *dataTable, const QStringList &headers);
   std::string getString(FitDomainIndex row, int column) const;
 
   virtual void addTableEntry(FitDomainIndex row);

--- a/qt/scientific_interfaces/Indirect/test/CMakeLists.txt
+++ b/qt/scientific_interfaces/Indirect/test/CMakeLists.txt
@@ -9,7 +9,7 @@ set(
   FqFitModelTest.h
   IDAFunctionParameterEstimationTest.h
   IndirectDataValidationHelperTest.h
-  IndirectDataTablePresenterTest.h
+  IndirectFitDataTablePresenterTest.h
   IndirectFitAnalysisTabTest.h
   IndirectFitDataPresenterTest.h
   IndirectFitDataTest.h

--- a/qt/scientific_interfaces/Indirect/test/IndirectFitDataPresenterTest.h
+++ b/qt/scientific_interfaces/Indirect/test/IndirectFitDataPresenterTest.h
@@ -10,9 +10,9 @@
 #include <gmock/gmock.h>
 
 #include "IIndirectFitDataView.h"
-#include "IndirectDataTablePresenterTest.h"
 #include "IndirectFitDataPresenter.h"
 #include "IndirectFitDataTableModel.h"
+#include "IndirectFitDataTablePresenterTest.h"
 #include "IndirectFitDataView.h"
 #include "IndirectFittingModel.h"
 #include "ParameterEstimation.h"

--- a/qt/scientific_interfaces/Indirect/test/IndirectFitDataTablePresenterTest.h
+++ b/qt/scientific_interfaces/Indirect/test/IndirectFitDataTablePresenterTest.h
@@ -9,7 +9,7 @@
 #include <cxxtest/TestSuite.h>
 #include <gmock/gmock.h>
 
-#include "IndirectDataTablePresenter.h"
+#include "IndirectFitDataTablePresenter.h"
 #include "IndirectFittingModel.h"
 
 #include "MantidAPI/FrameworkManager.h"
@@ -106,19 +106,19 @@ public:
 
 GNU_DIAG_ON_SUGGEST_OVERRIDE
 
-class IndirectDataTablePresenterTest : public CxxTest::TestSuite {
+class IndirectFitDataTablePresenterTest : public CxxTest::TestSuite {
 public:
   /// Needed to make sure everything is initialized
-  IndirectDataTablePresenterTest() { FrameworkManager::Instance(); }
+  IndirectFitDataTablePresenterTest() { FrameworkManager::Instance(); }
 
-  static IndirectDataTablePresenterTest *createSuite() { return new IndirectDataTablePresenterTest(); }
+  static IndirectFitDataTablePresenterTest *createSuite() { return new IndirectFitDataTablePresenterTest(); }
 
-  static void destroySuite(IndirectDataTablePresenterTest *suite) { delete suite; }
+  static void destroySuite(IndirectFitDataTablePresenterTest *suite) { delete suite; }
 
   void setUp() override {
     m_model = std::make_unique<NiceMock<MockIndirectDataTableModel>>();
     m_table = createEmptyTableWidget(5, 5);
-    m_presenter = std::make_unique<IndirectDataTablePresenter>(std::move(m_model.get()), std::move(m_table.get()));
+    m_presenter = std::make_unique<IndirectFitDataTablePresenter>(std::move(m_model.get()), std::move(m_table.get()));
 
     SetUpADSWithWorkspace ads("WorkspaceName", createWorkspace(5));
     m_model->addWorkspace("WorkspaceName");
@@ -212,5 +212,5 @@ private:
 
   std::unique_ptr<QTableWidget> m_table;
   std::unique_ptr<MockIndirectDataTableModel> m_model;
-  std::unique_ptr<IndirectDataTablePresenter> m_presenter;
+  std::unique_ptr<IndirectFitDataTablePresenter> m_presenter;
 };


### PR DESCRIPTION
Renamed all instances of IndirectDataTablePresenter in Indirect to IndirectFitDataTablePresenter. This included updating relevant tests and cmake lists.


**To test:**

1. Open Mantid
2. Open Interface >> Indirect >> Data Analysis
3. Navigate to F(Q) Fit Tab and then the Multiple Input tab.
4. Click add workspace and load data with both Width and EISF but only add the width
5. Choose a parameter Name from drop down menu and click add - there should be no error
6. repeat step 5, choosing a different parameter name from the list, and click add - there should be no error.

Fixes #31709 

This does not require release notes because it does not modify or add new functionality for the user




---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
