### PR TITLE
Required initialization of PyStdoutSink

### DIFF
--- a/Framework/PythonInterface/core/src/PythonStdoutChannel.cpp
+++ b/Framework/PythonInterface/core/src/PythonStdoutChannel.cpp
@@ -31,7 +31,8 @@ public:
 };
 
 // wrapper of that sink to be a stream
-boost::iostreams::stream<PyStdoutSink> PyStdout;
+PyStdoutSink pyStdoutSinkInstance = PyStdoutSink(); // needs to be initialized separately
+boost::iostreams::stream<PyStdoutSink> PyStdout(pyStdoutSinkInstance);
 
 } // anonymous namespace
 


### PR DESCRIPTION
Companion to PR #31715

**Description of work.**
- [x] Implement fix suggested by  https://stackoverflow.com/questions/20849357/boost-iostreams-assertion-failure

**To test:**
Launch mantid_install_dir/bin/mantidpython and enter the following commands in the IPython console:
```python
from mantid.kernel import ConfigService, logger
ConfigService.setString('logging.channels.consoleChannel.class', 'PythonStdoutChannel')
logger.error('Message')
```
The output should be the following line:
```
Python-[Error] Message
```
Now build the master branch and repeat. The output should be 
```
python3: /usr/include/boost/iostreams/detail/optional.hpp:55: T& boost::iostreams::detail::optional<T>::operator*() [with T = boost::iostreams::detail::concept_adapter<{anonymous}::PyStdoutSink>]: Assertion `initialized_' failed.
```

*There is no associated issue.*

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
