### PR TITLE
Muon Analysis - Change name of covariance matrices

### DIFF
--- a/scripts/Muon/GUI/Common/fitting_widgets/basic_fitting/basic_fitting_model.py
+++ b/scripts/Muon/GUI/Common/fitting_widgets/basic_fitting/basic_fitting_model.py
@@ -21,6 +21,7 @@ import math
 import re
 from typing import List, NamedTuple
 
+COVARIANCE_MATRIX_WS_NAME_APPENDAGE = "_NormalisedCovarianceMatrix"
 DEFAULT_CHI_SQUARED = 0.0
 DEFAULT_FIT_STATUS = None
 DEFAULT_SINGLE_FIT_FUNCTION = None
@@ -668,7 +669,8 @@ class BasicFittingModel:
         table_name, table_directory = create_parameter_table_name(input_workspace, self.function_name)
 
         self._add_workspace_to_ADS(output_workspace, workspace_name, workspace_directory)
-        self._add_workspace_to_ADS(covariance_matrix, workspace_name + '_CovarianceMatrix', table_directory)
+        self._add_workspace_to_ADS(covariance_matrix, workspace_name + COVARIANCE_MATRIX_WS_NAME_APPENDAGE,
+                                   table_directory)
 
         return workspace_name, table_name, table_directory
 

--- a/scripts/Muon/GUI/Common/fitting_widgets/general_fitting/general_fitting_model.py
+++ b/scripts/Muon/GUI/Common/fitting_widgets/general_fitting/general_fitting_model.py
@@ -12,7 +12,8 @@ from Muon.GUI.Common.ADSHandler.workspace_naming import (create_fitted_workspace
                                                          create_parameter_table_name,
                                                          get_run_numbers_as_string_from_workspace_name)
 from Muon.GUI.Common.contexts.muon_context import MuonContext
-from Muon.GUI.Common.fitting_widgets.basic_fitting.basic_fitting_model import BasicFittingModel
+from Muon.GUI.Common.fitting_widgets.basic_fitting.basic_fitting_model import (BasicFittingModel,
+                                                                               COVARIANCE_MATRIX_WS_NAME_APPENDAGE)
 from Muon.GUI.Common.utilities.algorithm_utils import run_simultaneous_Fit
 
 
@@ -353,7 +354,8 @@ class GeneralFittingModel(BasicFittingModel):
 
         self._add_workspace_to_ADS(output_workspace, workspace_names, "")
         workspace_names = self._rename_members_of_fitted_workspace_group(input_workspace_names, workspace_names)
-        self._add_workspace_to_ADS(covariance_matrix, workspace_names[0] + "_CovarianceMatrix", table_directory)
+        self._add_workspace_to_ADS(covariance_matrix, workspace_names[0] + COVARIANCE_MATRIX_WS_NAME_APPENDAGE,
+                                   table_directory)
 
         return workspace_names, table_name, table_directory
 


### PR DESCRIPTION
**Description of work.**
This PR changes the end of the covariance matrix names from `_CovarianceMatrix` to `_NormalisedCovarianceMatrix`.

**To test:**
1. Open Muon Analysis interface
2. Load MUSR `62260-2`
3. Go to Fitting tab
4. Add a `GausOsc` function
5. Click `Fit`
6. Look inside the workspace group, and one of the workspace names should end with `_NormalisedCovarianceMatrix`

Fixes #31185

*This does not require release notes* because **its a very minor change**

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
