### PR TITLE
Split Comboboxes in EA auto tab

### DIFF
--- a/scripts/Muon/GUI/ElementalAnalysis2/auto_widget/ea_auto_tab_presenter.py
+++ b/scripts/Muon/GUI/ElementalAnalysis2/auto_widget/ea_auto_tab_presenter.py
@@ -93,17 +93,12 @@ class EAAutoTabPresenter(object):
         show_peaks_options = {}
         show_matches_options = {}
         all_runs = list(find_peak_workspaces)
+
         for run in all_runs:
             group_ws = retrieve_ws(run)
             workspace_names = group_ws.getNames()
             for name in workspace_names:
-                if name.endswith(REFITTED_PEAKS_WS_SUFFIX):
-                    if name.split(";")[0] in show_peaks_options:
-                        show_peaks_options[name.split(";")[0]] = [name]
-                    else:
-                        show_peaks_options[name.split(";")[0]].append(name)
-                    continue
-                if name.endswith(PEAKS_WS_SUFFIX):
+                if name.endswith(REFITTED_PEAKS_WS_SUFFIX) or name.endswith(PEAKS_WS_SUFFIX):
                     if name.split(";")[0] not in show_peaks_options:
                         show_peaks_options[name.split(";")[0]] = [name]
                     else:
@@ -116,7 +111,7 @@ class EAAutoTabPresenter(object):
                     else:
                         show_matches_options[name.split(";")[0]].extend(matches_group.getNames())
 
-        self.view.add_options_to_find_peak_comboboxes(find_peak_workspaces)
+        self.view.add_options_to_find_peak_combobox(find_peak_workspaces)
         self.view.add_options_to_show_peak_combobox(show_peaks_options)
         self.view.add_options_to_show_matches_combobox(show_matches_options)
 

--- a/scripts/Muon/GUI/ElementalAnalysis2/auto_widget/ea_auto_tab_presenter.py
+++ b/scripts/Muon/GUI/ElementalAnalysis2/auto_widget/ea_auto_tab_presenter.py
@@ -81,13 +81,18 @@ class EAAutoTabPresenter(object):
         Checks all tables in load run's groups and add to show peaks and show matches combobox
         """
         group_names = self.context.group_context.group_names
-        all_runs = []
+        find_peak_workspaces = {}
+
         for group in group_names:
-            all_runs.append(self.model.split_run_and_detector(group)[0])
+            group_workspace, detector = self.model.split_run_and_detector(group)
+            if group_workspace not in find_peak_workspaces:
+                find_peak_workspaces[group_workspace] = ["All"]
+
+            find_peak_workspaces[group_workspace].append(detector)
 
         show_peaks_options = []
         show_matches_option = []
-        all_runs = list(set(all_runs))
+        all_runs = list(find_peak_workspaces)
         for run in all_runs:
             group_ws = retrieve_ws(run)
             workspace_names = group_ws.getNames()
@@ -102,7 +107,7 @@ class EAAutoTabPresenter(object):
                     matches_group = retrieve_ws(name)
                     show_matches_option += matches_group.getNames()
 
-        self.view.add_options_to_find_peak_combobox(sorted(group_names + all_runs))
+        self.view.add_options_to_find_peak_comboboxes(find_peak_workspaces)
         self.view.add_options_to_show_peak_combobox(sorted(show_peaks_options))
         self.view.add_options_to_show_matches_combobox(sorted(show_matches_option))
 

--- a/scripts/Muon/GUI/ElementalAnalysis2/auto_widget/ea_auto_tab_presenter.py
+++ b/scripts/Muon/GUI/ElementalAnalysis2/auto_widget/ea_auto_tab_presenter.py
@@ -5,8 +5,6 @@
 #   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
 # SPDX - License - Identifier: GPL - 3.0 +
 from Muon.GUI.ElementalAnalysis2.auto_widget.ea_auto_table import EAAutoPopupTable
-from Muon.GUI.ElementalAnalysis2.auto_widget.ea_auto_tab_model import REFITTED_PEAKS_WS_SUFFIX, PEAKS_WS_SUFFIX, \
-    MATCH_GROUP_WS_SUFFIX
 from mantidqt.utils.observer_pattern import GenericObserver
 from Muon.GUI.Common.ADSHandler.ADS_calls import retrieve_ws, check_if_workspace_exist
 from Muon.GUI.Common import message_box
@@ -80,36 +78,27 @@ class EAAutoTabPresenter(object):
         Checks context for loaded workspaces and add to values find peak combobox
         Checks all tables in load run's groups and add to show peaks and show matches combobox
         """
-        group_names = self.context.group_context.group_names
         find_peak_workspaces = {}
-
-        for group in group_names:
-            group_workspace, detector = self.model.split_run_and_detector(group)
-            if group_workspace not in find_peak_workspaces:
-                find_peak_workspaces[group_workspace] = ["All"]
-
-            find_peak_workspaces[group_workspace].append(detector)
-
         show_peaks_options = {}
         show_matches_options = {}
-        all_runs = list(find_peak_workspaces)
 
-        for run in all_runs:
-            group_ws = retrieve_ws(run)
-            workspace_names = group_ws.getNames()
-            for name in workspace_names:
-                if name.endswith(REFITTED_PEAKS_WS_SUFFIX) or name.endswith(PEAKS_WS_SUFFIX):
-                    if name.split(";")[0] not in show_peaks_options:
-                        show_peaks_options[name.split(";")[0]] = [name]
-                    else:
-                        show_peaks_options[name.split(";")[0]].append(name)
-                    continue
-                if name.endswith(MATCH_GROUP_WS_SUFFIX):
-                    matches_group = retrieve_ws(name)
-                    if name.split(";")[0] not in show_matches_options:
-                        show_matches_options[name.split(";")[0]] = matches_group.getNames()
-                    else:
-                        show_matches_options[name.split(";")[0]].extend(matches_group.getNames())
+        for group in self.context.group_context.groups:
+            run = group.run_number
+            if run not in find_peak_workspaces:
+                find_peak_workspaces[run] = ["All"]
+
+            find_peak_workspaces[run].append(group.detector)
+
+            if group.is_peak_table_present():
+                if run not in show_peaks_options:
+                    show_peaks_options[run] = []
+                show_peaks_options[run].append(group.get_peak_table(run))
+
+            if group.is_matches_table_present():
+                if run not in show_matches_options:
+                    show_matches_options[run] = []
+                matches_group_workspace = retrieve_ws(group.get_matches_table(run))
+                show_matches_options[run].extend(matches_group_workspace.getNames())
 
         self.view.add_options_to_find_peak_combobox(find_peak_workspaces)
         self.view.add_options_to_show_peak_combobox(show_peaks_options)

--- a/scripts/Muon/GUI/ElementalAnalysis2/auto_widget/ea_auto_tab_view.py
+++ b/scripts/Muon/GUI/ElementalAnalysis2/auto_widget/ea_auto_tab_view.py
@@ -149,7 +149,9 @@ class EAAutoTabView(QtWidgets.QWidget):
 
         self.show_peaks_table_combobox = QtWidgets.QComboBox(self)
         self.show_peaks_group_table_combobox = QtWidgets.QComboBox(self)
+        self.show_peaks_group_table_combobox.setSizePolicy(size_policy)
         self.show_peaks_table_button = QtWidgets.QPushButton(" Show peaks ", self)
+        self.show_peaks_table_button.setSizePolicy(size_policy)
 
         self.show_peaks_hlayout.addWidget(self.show_peaks_group_table_combobox)
         self.show_peaks_hlayout.addWidget(self.show_peaks_table_combobox)
@@ -157,7 +159,9 @@ class EAAutoTabView(QtWidgets.QWidget):
 
         self.show_matches_table_combobox = QtWidgets.QComboBox(self)
         self.show_matches_group_table_combobox = QtWidgets.QComboBox(self)
+        self.show_matches_group_table_combobox.setSizePolicy(size_policy)
         self.show_matches_table_button = QtWidgets.QPushButton(" Show matches ", self)
+        self.show_matches_table_button.setSizePolicy(size_policy)
 
         self.show_matches_hlayout.addWidget(self.show_matches_group_table_combobox)
         self.show_matches_hlayout.addWidget(self.show_matches_table_combobox)

--- a/scripts/Muon/GUI/ElementalAnalysis2/auto_widget/ea_auto_tab_view.py
+++ b/scripts/Muon/GUI/ElementalAnalysis2/auto_widget/ea_auto_tab_view.py
@@ -209,11 +209,11 @@ class EAAutoTabView(QtWidgets.QWidget):
 
         return parameters
 
-    def add_options_to_find_peak_comboboxes(self, workspaces):
+    def add_options_to_find_peak_combobox(self, workspaces):
         self.find_peaks_workspaces = workspaces
-        self.update_find_peak_comboboxes()
+        self.update_find_peak_combobox()
 
-    def update_find_peak_comboboxes(self):
+    def update_find_peak_combobox(self):
         self.group_combobox.clear()
         self.group_combobox.addItems(sorted(list(self.find_peaks_workspaces)))
         self.on_group_combobox_changed()

--- a/scripts/Muon/GUI/ElementalAnalysis2/auto_widget/ea_auto_tab_view.py
+++ b/scripts/Muon/GUI/ElementalAnalysis2/auto_widget/ea_auto_tab_view.py
@@ -24,11 +24,13 @@ class EAAutoTabView(QtWidgets.QWidget):
         super(EAAutoTabView, self).__init__(parent)
 
         self.find_peaks_workspaces = {}
+        self.show_matches_options = {}
+        self.show_peaks_options = {}
         self.match_table = match_table
         self.find_peaks_notifier = GenericObservable()
         self.show_peaks_table_notifier = GenericObservable()
-        self.show_match_table_notifier = GenericObservable()
-        self.clear_match_table_notifier = GenericObservable()
+        self.show_matches_table_notifier = GenericObservable()
+        self.clear_matches_table_notifier = GenericObservable()
 
         self.setup_interface_layout()
         self.setup_horizontal_layouts()
@@ -63,13 +65,13 @@ class EAAutoTabView(QtWidgets.QWidget):
         self.vertical_layout = QtWidgets.QVBoxLayout(self)
         self.vertical_layout.setObjectName("verticalLayout")
 
-        self.clear_match_table_button = QtWidgets.QPushButton("Clear Table", self)
+        self.clear_matches_table_button = QtWidgets.QPushButton("Clear Table", self)
         size_policy = QtWidgets.QSizePolicy(QtWidgets.QSizePolicy.Fixed, QtWidgets.QSizePolicy.Fixed)
         size_policy.setHorizontalStretch(0)
         size_policy.setVerticalStretch(0)
-        size_policy.setHeightForWidth(self.clear_match_table_button.sizePolicy().hasHeightForWidth())
-        self.clear_match_table_button.setSizePolicy(size_policy)
-        self.clear_match_table_button.setToolTip("Removes all rows in table")
+        size_policy.setHeightForWidth(self.clear_matches_table_button.sizePolicy().hasHeightForWidth())
+        self.clear_matches_table_button.setSizePolicy(size_policy)
+        self.clear_matches_table_button.setToolTip("Removes all rows in table")
 
         self.vertical_layout.addItem(self.select_workspace_hlayout)
         self.vertical_layout.addItem(self.find_peaks_parameter_hlayout1)
@@ -78,7 +80,7 @@ class EAAutoTabView(QtWidgets.QWidget):
         self.vertical_layout.addWidget(self.peak_info_label)
         self.vertical_layout.addItem(self.show_peaks_hlayout)
         self.vertical_layout.addWidget(self.match_table)
-        self.vertical_layout.addWidget(self.clear_match_table_button)
+        self.vertical_layout.addWidget(self.clear_matches_table_button)
         self.vertical_layout.addItem(self.show_matches_hlayout)
 
         self.setLayout(self.vertical_layout)
@@ -108,20 +110,24 @@ class EAAutoTabView(QtWidgets.QWidget):
         self.find_peaks_parameter_hlayout1.addWidget(self.threshold_label)
         self.find_peaks_parameter_hlayout1.addWidget(self.threshold_line_edit)
 
-        self.plot_peaks_label = QtWidgets.QLabel("Plot Peaks", self)
+        self.plot_peaks_label = QtWidgets.QLabel("  Plot Peaks  ", self)
         self.plot_peaks_checkbox = QtWidgets.QCheckBox(self)
         self.default_peak_label = QtWidgets.QLabel("  Use default peak widths ?  ", self)
         self.default_peak_checkbox = QtWidgets.QCheckBox(self)
+
         size_policy = QtWidgets.QSizePolicy(QtWidgets.QSizePolicy.Fixed, QtWidgets.QSizePolicy.Fixed)
         size_policy.setHorizontalStretch(0)
         size_policy.setVerticalStretch(0)
+
         self.default_peak_label.setSizePolicy(size_policy)
         self.default_peak_checkbox.setSizePolicy(size_policy)
+
         self.plot_peaks_label.setSizePolicy(size_policy)
         self.plot_peaks_checkbox.setSizePolicy(size_policy)
 
-        self.find_peaks_parameter_hlayout2.addWidget(self.default_peak_checkbox)
-        self.find_peaks_parameter_hlayout2.addWidget(self.default_peak_label)
+        self.find_peaks_parameter_hlayout2.addWidget(self.default_peak_checkbox, alignment=QtCore.Qt.AlignLeft)
+        self.find_peaks_parameter_hlayout2.addWidget(self.default_peak_label, alignment=QtCore.Qt.AlignLeft)
+        self.find_peaks_parameter_hlayout2.insertStretch(-1, 1)
         self.find_peaks_parameter_hlayout2.addWidget(self.plot_peaks_label, alignment=QtCore.Qt.AlignRight)
         self.find_peaks_parameter_hlayout2.addWidget(self.plot_peaks_checkbox, alignment=QtCore.Qt.AlignRight)
 
@@ -142,24 +148,30 @@ class EAAutoTabView(QtWidgets.QWidget):
         self.find_peaks_parameter_hlayout3.addWidget(self.estimate_width_line_edit)
 
         self.show_peaks_table_combobox = QtWidgets.QComboBox(self)
+        self.show_peaks_group_table_combobox = QtWidgets.QComboBox(self)
         self.show_peaks_table_button = QtWidgets.QPushButton(" Show peaks ", self)
 
+        self.show_peaks_hlayout.addWidget(self.show_peaks_group_table_combobox)
         self.show_peaks_hlayout.addWidget(self.show_peaks_table_combobox)
         self.show_peaks_hlayout.addWidget(self.show_peaks_table_button)
 
-        self.show_match_table_combobox = QtWidgets.QComboBox(self)
-        self.show_match_table_button = QtWidgets.QPushButton(" Show matches ", self)
+        self.show_matches_table_combobox = QtWidgets.QComboBox(self)
+        self.show_matches_group_table_combobox = QtWidgets.QComboBox(self)
+        self.show_matches_table_button = QtWidgets.QPushButton(" Show matches ", self)
 
-        self.show_matches_hlayout.addWidget(self.show_match_table_combobox)
-        self.show_matches_hlayout.addWidget(self.show_match_table_button)
+        self.show_matches_hlayout.addWidget(self.show_matches_group_table_combobox)
+        self.show_matches_hlayout.addWidget(self.show_matches_table_combobox)
+        self.show_matches_hlayout.addWidget(self.show_matches_table_button)
 
     def setup_buttons(self):
         self.find_peaks_button.clicked.connect(self.find_peaks_notifier.notify_subscribers)
         self.show_peaks_table_button.clicked.connect(self.show_peaks_table_notifier.notify_subscribers)
-        self.show_match_table_button.clicked.connect(self.show_match_table_notifier.notify_subscribers)
-        self.clear_match_table_button.clicked.connect(self.clear_match_table_notifier.notify_subscribers)
+        self.show_matches_table_button.clicked.connect(self.show_matches_table_notifier.notify_subscribers)
+        self.clear_matches_table_button.clicked.connect(self.clear_matches_table_notifier.notify_subscribers)
         self.default_peak_checkbox.clicked.connect(self.on_default_peak_checkbox_changed)
         self.group_combobox.currentIndexChanged.connect(self.on_group_combobox_changed)
+        self.show_peaks_group_table_combobox.currentIndexChanged.connect(self.on_show_peaks_combobox_changed)
+        self.show_matches_group_table_combobox.currentIndexChanged.connect(self.on_show_matches_combobox_changed)
 
     def get_parameters_for_find_peaks(self):
         parameters = {}
@@ -207,12 +219,16 @@ class EAAutoTabView(QtWidgets.QWidget):
         self.on_group_combobox_changed()
 
     def add_options_to_show_peak_combobox(self, options):
-        self.show_peaks_table_combobox.clear()
-        self.show_peaks_table_combobox.addItems(options)
+        self.show_peaks_group_table_combobox.clear()
+        self.show_peaks_options = options
+        self.show_peaks_group_table_combobox.addItems(sorted(list(options)))
+        self.on_show_peaks_combobox_changed()
 
     def add_options_to_show_matches_combobox(self, options):
-        self.show_match_table_combobox.clear()
-        self.show_match_table_combobox.addItems(options)
+        self.show_matches_group_table_combobox.clear()
+        self.show_matches_options = options
+        self.show_matches_group_table_combobox.addItems(sorted(list(options)))
+        self.on_show_matches_combobox_changed()
 
     def setup_intial_parameters(self):
         self.min_energy_line_edit.setText(MIN_ENERGY)
@@ -257,3 +273,17 @@ class EAAutoTabView(QtWidgets.QWidget):
             return
         detectors = self.find_peaks_workspaces[group_workspace]
         self.detector_combobox.addItems(detectors)
+
+    def on_show_peaks_combobox_changed(self):
+        self.show_peaks_table_combobox.clear()
+        group_workspace = self.show_peaks_group_table_combobox.currentText()
+        if not group_workspace:
+            return
+        self.show_peaks_table_combobox.addItems(self.show_peaks_options[group_workspace])
+
+    def on_show_matches_combobox_changed(self):
+        self.show_matches_table_combobox.clear()
+        group_workspace = self.show_matches_group_table_combobox.currentText()
+        if not group_workspace:
+            return
+        self.show_matches_table_combobox.addItems(self.show_matches_options[group_workspace])

--- a/scripts/Muon/GUI/ElementalAnalysis2/auto_widget/ea_auto_tab_view.py
+++ b/scripts/Muon/GUI/ElementalAnalysis2/auto_widget/ea_auto_tab_view.py
@@ -110,8 +110,7 @@ class EAAutoTabView(QtWidgets.QWidget):
 
         self.plot_peaks_label = QtWidgets.QLabel("Plot Peaks", self)
         self.plot_peaks_checkbox = QtWidgets.QCheckBox(self)
-        self.default_peak_label = QtWidgets.QLabel(" "
-                                                   "Use default peak widths ? ", self)
+        self.default_peak_label = QtWidgets.QLabel("  Use default peak widths ?  ", self)
         self.default_peak_checkbox = QtWidgets.QCheckBox(self)
         size_policy = QtWidgets.QSizePolicy(QtWidgets.QSizePolicy.Fixed, QtWidgets.QSizePolicy.Fixed)
         size_policy.setHorizontalStretch(0)

--- a/scripts/Muon/GUI/ElementalAnalysis2/ea_group.py
+++ b/scripts/Muon/GUI/ElementalAnalysis2/ea_group.py
@@ -27,6 +27,9 @@ class EAGroup(object):
         self.rebin_option = None
         self._counts_workspace = {}
         self._counts_workspace_rebin = {}
+        self._peak_table = {}
+        self._matches_table = {}
+        self.update_counts_workspace(str(group_name), run_number)
 
     @property
     def workspace(self):
@@ -88,7 +91,8 @@ class EAGroup(object):
             self._counts_workspace.update({run_object: MuonWorkspaceWrapper(counts_workspace)})
 
     def update_counts_workspace(self, counts_workspace, run):
-        self._counts_workspace.update({run: MuonWorkspaceWrapper(counts_workspace)})
+        run_object = MuonRun(run)
+        self._counts_workspace.update({run_object: MuonWorkspaceWrapper(counts_workspace)})
 
     def get_rebined_or_unbinned_version_of_workspace_if_it_exists(self, name):
         for key, value in self._counts_workspace.items():
@@ -100,3 +104,25 @@ class EAGroup(object):
                 return self._counts_workspace[key].workspace_name
 
         return None
+
+    def update_peak_table(self, run, table):
+        run_object = MuonRun(run)
+        self._peak_table.update({run_object: MuonWorkspaceWrapper(table)})
+
+    def update_matches_table(self, run, table):
+        run_object = MuonRun(run)
+        self._matches_table.update({run_object: MuonWorkspaceWrapper(table)})
+
+    def get_peak_table(self, run):
+        run_object = MuonRun(run)
+        return self._peak_table[run_object].workspace_name
+
+    def get_matches_table(self, run):
+        run_object = MuonRun(run)
+        return self._matches_table[run_object].workspace_name
+
+    def is_peak_table_present(self):
+        return bool(self._peak_table)
+
+    def is_matches_table_present(self):
+        return bool(self._matches_table)

--- a/scripts/Muon/GUI/ElementalAnalysis2/grouping_widget/ea_grouping_table_widget_presenter.py
+++ b/scripts/Muon/GUI/ElementalAnalysis2/grouping_widget/ea_grouping_table_widget_presenter.py
@@ -133,11 +133,6 @@ class EAGroupingTablePresenter(object):
             self.notify_data_changed()
             return
 
-        try:
-            self.update_model_from_view()
-        except ValueError as error:
-            self._view.warning_popup(error)
-
     def update_model_from_view(self):
         table = self._view.get_table_contents()
         self._model.clear_groups()

--- a/scripts/test/Muon/elemental_analysis_2/EA_auto_tab/ea_auto_tab_model_test.py
+++ b/scripts/test/Muon/elemental_analysis_2/EA_auto_tab/ea_auto_tab_model_test.py
@@ -2,13 +2,23 @@ import unittest
 import unittest.mock as mock
 from mantid.simpleapi import CreateEmptyTableWorkspace, DeleteWorkspace
 from Muon.GUI.ElementalAnalysis2.auto_widget.ea_auto_tab_model import EAAutoTabModel
+from Muon.GUI.ElementalAnalysis2.context.context import ElementalAnalysisContext
+from Muon.GUI.ElementalAnalysis2.context.ea_group_context import EAGroupContext
+from Muon.GUI.ElementalAnalysis2.ea_group import EAGroup
 from mantid.api import mtd
 
 
 class EAAutoTabModelTest(unittest.TestCase):
 
     def setUp(self):
-        self.model = EAAutoTabModel(None)
+        workspaces = ["9999; Detector 1", "9999; Detector 2", "9999; Detector 3", "9999; Detector 4"]
+        self.group_context = EAGroupContext()
+        for group_name in workspaces:
+            self.group_context.add_group(EAGroup(group_name, group_name.split(";")[1].strip(),
+                                                 group_name.split(";")[0].strip()))
+
+        self.context = ElementalAnalysisContext(None, self.group_context)
+        self.model = EAAutoTabModel(self.context)
 
     @staticmethod
     def delete_if_present(workspace):
@@ -80,6 +90,7 @@ class EAAutoTabModelTest(unittest.TestCase):
         "Muon.GUI.ElementalAnalysis2.auto_widget.ea_auto_tab_model.EAAutoTabModel._run_peak_matching_algorithm")
     def test_run_peak_algorithms_with_group(self, mock_peak_matching, mock_run_find_peak, mock_retrieve_ws):
         # setup
+        self.group_context = mock.Mock()
         mock_group = mock.Mock()
         mock_group.getNames.return_value = ["9999; Detector 1", "9999; Detector 2"]
         parameters = {"workspace": "9999"}
@@ -104,8 +115,8 @@ class EAAutoTabModelTest(unittest.TestCase):
                                                                       mock_retrieve_ws):
         # setup
         mock_group = mock.Mock()
-        mock_group.getNames.return_value = ['9997; Detector 3', '9997; Detector 4']
-        parameters = {"workspace": "9997"}
+        mock_group.getNames.return_value = ['9999; Detector 3', '9999; Detector 4']
+        parameters = {"workspace": "9999"}
         mock_retrieve_ws.return_value = mock_group
         mock_run_find_peak.return_value = True
 
@@ -113,18 +124,21 @@ class EAAutoTabModelTest(unittest.TestCase):
         self.model._run_peak_algorithms(parameters)
 
         # Assert statements
-        mock_retrieve_ws.assert_called_with("9997")
-        mock_run_find_peak.assert_has_calls([mock.call({'workspace': '9997; Detector 3'}, mock_group, True),
-                                             mock.call({'workspace': '9997; Detector 4'}, mock_group, True)])
+        mock_retrieve_ws.assert_called_with("9999")
+        mock_run_find_peak.assert_has_calls([mock.call({'workspace': '9999; Detector 3'}, mock_group, True),
+                                             mock.call({'workspace': '9999; Detector 4'}, mock_group, True)])
         mock_peak_matching.assert_not_called()
 
     @mock.patch("Muon.GUI.ElementalAnalysis2.auto_widget.ea_auto_tab_model.retrieve_ws")
+    @mock.patch("Muon.GUI.ElementalAnalysis2.auto_widget.ea_auto_tab_model.remove_ws")
     @mock.patch("Muon.GUI.ElementalAnalysis2.auto_widget.ea_auto_tab_model.find_peak_algorithm")
-    def test_run_find_peak_algo_with_default_peaks_and_no_errors(self, mock_find_peaks, mock_retrieve_ws):
+    def test_run_find_peak_algo_with_default_peaks_and_no_errors(self, mock_find_peaks, mock_remove_ws,
+                                                                 mock_retrieve_ws):
         # setup
-        workspace = "9997; Detector 1"
+        workspace = "9999; Detector 1"
         number_of_peaks = 3
         mock_group = mock.Mock()
+        mock_group.name.return_value = "9999"
         mock_table = mock.Mock()
         mock_table.rowCount.return_value = number_of_peaks
         mock_retrieve_ws.return_value = mock_table
@@ -134,22 +148,24 @@ class EAAutoTabModelTest(unittest.TestCase):
 
         # Assert statements
         mock_find_peaks.assert_called_once_with(workspace, 3, 10, 1000, 1, 0.5, 1, 2.5)
-        mock_group.add.assert_has_calls([mock.call(workspace + "_with_errors"),
-                                         mock.call(workspace + "_refitted_peaks"),
-                                         mock.call(workspace + "_peaks")])
-        self.assertEqual(mock_table.rowCount.call_count, 2)
+        mock_group.add.assert_called_once_with(workspace + "_peaks")
+        self.assertEqual(mock_table.rowCount.call_count, 1)
         self.assertEqual(self.model.current_peak_table_info["workspace"], workspace)
         self.assertEqual(self.model.current_peak_table_info["number_of_peaks"], number_of_peaks)
-        self.assertEqual(mock_retrieve_ws.call_count, 2)
+        self.assertEqual(mock_retrieve_ws.call_count, 1)
+        self.assertEqual(mock_remove_ws.call_count, 2)
         self.assertEqual(ignore_peak_matching, False)
 
     @mock.patch("Muon.GUI.ElementalAnalysis2.auto_widget.ea_auto_tab_model.retrieve_ws")
+    @mock.patch("Muon.GUI.ElementalAnalysis2.auto_widget.ea_auto_tab_model.remove_ws")
     @mock.patch("Muon.GUI.ElementalAnalysis2.auto_widget.ea_auto_tab_model.find_peak_algorithm")
-    def test_run_find_peak_algo_without_default_peaks_and_no_errors(self, mock_find_peaks, mock_retrieve_ws):
+    def test_run_find_peak_algo_without_default_peaks_and_no_errors(self, mock_find_peaks, mock_remove_ws,
+                                                                    mock_retrieve_ws):
         # setup
-        workspace = "9997; Detector 2"
+        workspace = "9999; Detector 2"
         number_of_peaks = 5
         mock_group = mock.Mock()
+        mock_group.name.return_value = "9999"
         mock_table = mock.Mock()
         mock_table.rowCount.return_value = number_of_peaks
         mock_retrieve_ws.return_value = mock_table
@@ -160,23 +176,24 @@ class EAAutoTabModelTest(unittest.TestCase):
 
         # Assert statements
         mock_find_peaks.assert_called_once_with(workspace, 3, 1, 200, 4, 0.3, 1.5, 2)
-        mock_group.add.assert_has_calls([mock.call(workspace + "_with_errors"),
-                                         mock.call(workspace + "_refitted_peaks"),
-                                         mock.call(workspace + "_peaks")])
-        self.assertEqual(mock_table.rowCount.call_count, 2)
+        mock_group.add.assert_called_once_with(workspace + "_peaks")
+        self.assertEqual(mock_table.rowCount.call_count, 1)
         self.assertEqual(self.model.current_peak_table_info["workspace"], workspace)
         self.assertEqual(self.model.current_peak_table_info["number_of_peaks"], number_of_peaks)
-        self.assertEqual(mock_retrieve_ws.call_count, 2)
+        self.assertEqual(mock_retrieve_ws.call_count, 1)
+        self.assertEqual(mock_remove_ws.call_count, 2)
         self.assertEqual(ignore_peak_matching, False)
 
     @mock.patch("Muon.GUI.ElementalAnalysis2.auto_widget.ea_auto_tab_model.retrieve_ws")
+    @mock.patch("Muon.GUI.ElementalAnalysis2.auto_widget.ea_auto_tab_model.remove_ws")
     @mock.patch("Muon.GUI.ElementalAnalysis2.auto_widget.ea_auto_tab_model.find_peak_algorithm")
-    def test_run_find_peak_algo_with_default_peaks_and_errors(self, mock_find_peaks, mock_retrieve_ws):
+    def test_run_find_peak_algo_with_default_peaks_and_errors(self, mock_find_peaks, mock_remove_ws, mock_retrieve_ws):
         # setup
-        workspace = "9997; Detector 3"
+        workspace = "9999; Detector 3"
         number_of_peaks = 0
         mock_group = mock.Mock()
         mock_table = mock.Mock()
+        mock_table.name.return_value = "mock_value"
         mock_table.rowCount.return_value = number_of_peaks
         mock_retrieve_ws.return_value = mock_table
 
@@ -186,18 +203,20 @@ class EAAutoTabModelTest(unittest.TestCase):
 
         # Assert statements
         mock_find_peaks.assert_called_once_with(workspace, 3, 50, 4000, 1.5, 0.1, 0.5, 1.5)
-        mock_group.add.assert_has_calls([mock.call(workspace + "_with_errors")])
-        self.assertEqual(mock_table.rowCount.call_count, 2)
-        self.assertEqual(mock_table.delete.call_count, 2)
+        self.assertEqual(mock_table.rowCount.call_count, 1)
+        self.assertEqual(mock_table.delete.call_count, 1)
         self.assertEqual(self.model.current_peak_table_info["workspace"], workspace)
         self.assertEqual(self.model.current_peak_table_info["number_of_peaks"], number_of_peaks)
-        self.assertEqual(mock_retrieve_ws.call_count, 2)
+        self.assertEqual(mock_retrieve_ws.call_count, 1)
+        self.assertEqual(mock_remove_ws.call_count, 2)
 
     @mock.patch("Muon.GUI.ElementalAnalysis2.auto_widget.ea_auto_tab_model.retrieve_ws")
+    @mock.patch("Muon.GUI.ElementalAnalysis2.auto_widget.ea_auto_tab_model.remove_ws")
     @mock.patch("Muon.GUI.ElementalAnalysis2.auto_widget.ea_auto_tab_model.find_peak_algorithm")
-    def test_run_find_peak_algo_with_default_peaks_and_delay_errors(self, mock_find_peaks, mock_retrieve_ws):
+    def test_run_find_peak_algo_with_default_peaks_and_delay_errors(self, mock_find_peaks, mock_remove_ws,
+                                                                    mock_retrieve_ws):
         # setup
-        workspace = "9997; Detector 4"
+        workspace = "9999; Detector 4"
         number_of_peaks = 0
         mock_group = mock.Mock()
         mock_table = mock.Mock()
@@ -209,12 +228,12 @@ class EAAutoTabModelTest(unittest.TestCase):
 
         # Assert statements
         mock_find_peaks.assert_called_once_with(workspace, 3, 5, 100, 1.5, 0.1, 0.7, 1.5)
-        mock_group.add.assert_has_calls([mock.call(workspace + "_with_errors")])
-        self.assertEqual(mock_table.rowCount.call_count, 2)
-        self.assertEqual(mock_table.delete.call_count, 2)
+        self.assertEqual(mock_table.rowCount.call_count, 1)
+        self.assertEqual(mock_table.delete.call_count, 1)
         self.assertEqual(self.model.current_peak_table_info["workspace"], workspace)
         self.assertEqual(self.model.current_peak_table_info["number_of_peaks"], number_of_peaks)
-        self.assertEqual(mock_retrieve_ws.call_count, 2)
+        self.assertEqual(mock_retrieve_ws.call_count, 1)
+        self.assertEqual(mock_remove_ws.call_count, 2)
         self.assertEqual(ignore_peak_matching, True)
         self.assertEqual(self.model.warnings.get(), f"No peaks found in {workspace} try reducing acceptance threshold")
 
@@ -224,7 +243,8 @@ class EAAutoTabModelTest(unittest.TestCase):
     def test_run_peak_matching_algo(self, mock_update_match_table, mock_group_workspaces, mock_peak_matching):
         # setup
         mock_group = mock.Mock()
-        workspace = "9997; Detector 4"
+        mock_group.name.return_value = "9999"
+        workspace = "9999; Detector 4"
         match_table_names = [workspace + "_all_matches", workspace + "_primary_matches",
                              workspace + "_secondary_matches",
                              workspace + "_all_matches_sorted_by_energy", workspace + "_likelihood"]

--- a/scripts/test/Muon/elemental_analysis_2/EA_grouping_tab/elemental_analysis_grouping_table_presenter_test.py
+++ b/scripts/test/Muon/elemental_analysis_2/EA_grouping_tab/elemental_analysis_grouping_table_presenter_test.py
@@ -166,7 +166,6 @@ class GroupingTablePresenterTest(unittest.TestCase):
 
         # Tests
         self.presenter._view.get_table_item.assert_has_calls([mock.call(1, 5), mock.call(1, 0)])
-        self.assertEqual(self.presenter.update_model_from_view.call_count, 1)
         self.assertEqual(self.presenter.notify_data_changed.call_count, 0)
         self.assertEqual(self.presenter.update_view_from_model.call_count, 0)
         self.assertEqual(mock_text.call_count, 2)
@@ -186,7 +185,6 @@ class GroupingTablePresenterTest(unittest.TestCase):
 
         # Tests
         self.presenter._view.get_table_item.assert_has_calls([mock.call(4, 5), mock.call(4, 0)])
-        self.assertEqual(self.presenter.update_model_from_view.call_count, 1)
         self.assertEqual(self.presenter.notify_data_changed.call_count, 0)
         self.assertEqual(self.presenter.update_view_from_model.call_count, 0)
         self.assertEqual(mock_text.call_count, 2)


### PR DESCRIPTION
**Description of work.**
All comboboxes where users can select a workspace or table have been split into 2 comboboxes sorting them by their runs

**Report to:** Adrian Hillier


**To test:**
1. Before starting Mantid go to https://github.com/mantidproject/mantid/blob/master/Framework/Properties/Mantid.properties.template#L24 , add Muon/Elemental_Analysis_2.py to the end of the line and build Mantid.

2. Download the test files from PR #29958 and add to User Directories.

3. Open the elemental analysis 2 GUI and load 9997.

4. Open the automatic tab and next to the find peak button there should be 2 comboboxes on the left the first combobox  should show 9997 and the second combobox should show All ,detector 1, detector 2, detector 3, detector 4.
5. Load 9998 and in the first combox there should be 9997 and 9998 in the first combobox.
6. Removing a detector in the grouping table causes that option to not be available in second combobox when run is selected
7. When any tables are produced they are sorted by run number in comboboxes beside show matches and show peaks button

Fixes #31729 . 


*This does not require release notes* because Elemental analysis GUI is not yet visible to users in Mantid Workbench

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
