### PR TITLE
Add a unit test for ISIS and fix bug in ConvertToMDMinMaxLocal

### DIFF
--- a/Framework/Crystal/test/CentroidPeaksTest.h
+++ b/Framework/Crystal/test/CentroidPeaksTest.h
@@ -89,7 +89,7 @@ public:
     TS_ASSERT_EQUALS(retVal->getInstrument()->getName(), "MINITOPAZ");
     std::map<int, Geometry::IDetector_const_sptr> dets;
     retVal->getInstrument()->getDetectors(dets);
-    TS_ASSERT_EQUALS(dets.size(), 100 * 100);
+    TS_ASSERT_EQUALS(dets.size(), 100 * 100 + 2);
 
     return retVal;
   }

--- a/Framework/Crystal/test/NormaliseVanadiumTest.h
+++ b/Framework/Crystal/test/NormaliseVanadiumTest.h
@@ -89,7 +89,7 @@ EventWorkspace_sptr createDiffractionEventWorkspace(int numEvents) {
   TS_ASSERT_EQUALS(retVal->getInstrument()->getName(), "MINITOPAZ");
   std::map<int, Geometry::IDetector_const_sptr> dets;
   retVal->getInstrument()->getDetectors(dets);
-  TS_ASSERT_EQUALS(dets.size(), 100 * 100);
+  TS_ASSERT_EQUALS(dets.size(), 100 * 100 + 2);
 
   return retVal;
 }

--- a/Framework/Crystal/test/NormaliseVanadiumTest.h
+++ b/Framework/Crystal/test/NormaliseVanadiumTest.h
@@ -53,7 +53,7 @@ EventWorkspace_sptr createDiffractionEventWorkspace(int numEvents) {
   loadInst->initialize();
   loadInst->setPropertyValue("Filename", "unit_testing/MINITOPAZ_Definition.xml");
   loadInst->setProperty<MatrixWorkspace_sptr>("Workspace", retVal);
-  loadInst->setProperty("RewriteSpectraMap", Mantid::Kernel::OptionalBool(true));
+  loadInst->setProperty("RewriteSpectraMap", Mantid::Kernel::OptionalBool(false));
   loadInst->execute();
   delete loadInst;
   // Populate the instrument parameters in this workspace - this works around

--- a/Framework/Crystal/test/PeakIntegrationTest.h
+++ b/Framework/Crystal/test/PeakIntegrationTest.h
@@ -92,7 +92,7 @@ public:
     TS_ASSERT_EQUALS(retVal->getInstrument()->getName(), "MINITOPAZ");
     std::map<int, Geometry::IDetector_const_sptr> dets;
     retVal->getInstrument()->getDetectors(dets);
-    TS_ASSERT_EQUALS(dets.size(), 100 * 100);
+    TS_ASSERT_EQUALS(dets.size(), 100 * 100 + 2);
 
     return retVal;
   }

--- a/Framework/MDAlgorithms/src/ConvertToMDMinMaxLocal.cpp
+++ b/Framework/MDAlgorithms/src/ConvertToMDMinMaxLocal.cpp
@@ -134,22 +134,23 @@ void ConvertToMDMinMaxLocal::findMinMaxValues(MDWSDescription &WSDescription, MD
   pQtransf->initialize(WSDescription);
 
   //
-  auto nHist = static_cast<long>(inWS->getNumberHistograms());
+  auto nSpectra = WSDescription.m_PreprDetTable->getLogs()->getPropertyValueAsType<uint32_t>("ActualDetectorsNum");
   auto detIDMap = WSDescription.m_PreprDetTable->getColVector<size_t>("detIDMap");
+  auto sp2detMap = WSDescription.m_PreprDetTable->getColVector<size_t>("spec2detMap");
 
   // vector to place transformed coordinates;
   std::vector<coord_t> locCoord(nDims);
 
   pQtransf->calcGenericVariables(locCoord, nDims);
   // PRAGMA_OMP(parallel for reduction(||:rangeChanged))
-  for (long i = 0; i < nHist; i++) {
+  for (size_t i = 0; i < nSpectra; i++) {
     // get valid spectrum number
     size_t iSpctr = detIDMap[i];
 
     // update unit conversion according to current spectra
-    unitsConverter.updateConversion(iSpctr);
+    unitsConverter.updateConversion(i);
     // update coordinate transformation according to the spectra
-    pQtransf->calcYDepCoordinates(locCoord, iSpctr);
+    pQtransf->calcYDepCoordinates(locCoord, i);
 
     // get the range of the input data in the spectra
     auto source_range = inWS->getSpectrum(iSpctr).getXDataRange();
@@ -160,7 +161,7 @@ void ConvertToMDMinMaxLocal::findMinMaxValues(MDWSDescription &WSDescription, MD
     double x1 = unitsConverter.convertUnits(source_range.first);
     double x2 = unitsConverter.convertUnits(source_range.second);
 
-    std::vector<double> range = pQtransf->getExtremumPoints(x1, x2, iSpctr);
+    std::vector<double> range = pQtransf->getExtremumPoints(x1, x2, i);
     // transform coordinates
     for (double &k : range) {
 

--- a/Framework/MDAlgorithms/test/ConvertToDiffractionMDWorkspace3Test.h
+++ b/Framework/MDAlgorithms/test/ConvertToDiffractionMDWorkspace3Test.h
@@ -169,7 +169,7 @@ public:
     do_test_MINITOPAZ(TOF, 1, false, true, 399);
   }
 
-  void test_MINITOPAZ_autoExtents() {
+  void do_test_MINITOPAZ_autoExtents(std::string targetUnitName) {
 
     int numEventsPer = 100;
     EventWorkspace_sptr in_ws = Mantid::DataObjects::MDEventsTestHelper::createDiffractionEventWorkspace(numEventsPer);
@@ -178,6 +178,9 @@ public:
     AnalysisDataService::Instance().addOrReplace("inputWS", in_ws);
     FrameworkManager::Instance().exec("Rebin", 8, "InputWorkspace", "inputWS", "OutputWorkspace", "inputWS", "Params",
                                       "0, 500, 16e3", "PreserveEvents", "0");
+
+    FrameworkManager::Instance().exec("ConvertUnits", 6, "InputWorkspace", "inputWS", "OutputWorkspace", "inputWS",
+                                      "Target", targetUnitName.c_str());
 
     ConvertToDiffractionMDWorkspace3 alg;
     TS_ASSERT_THROWS_NOTHING(alg.initialize())
@@ -204,5 +207,12 @@ public:
     dim = ws->getDimension(2);
     TS_ASSERT_DELTA(dim->getMinimum(), 0, 1e-3);
     TS_ASSERT_DELTA(dim->getMaximum(), 0.705, 1e-3);
+  }
+
+  void test_MINITOPAZ_autoExtents_TOF() { do_test_MINITOPAZ_autoExtents("TOF"); }
+
+  void test_MINITOPAZ_autoExtents_dSpacing() {
+    // ISIS use ConvertToDiffractionMDWorkspace on workspaces with dSpacing units
+    do_test_MINITOPAZ_autoExtents("dSpacing");
   }
 };

--- a/Framework/TestHelpers/src/MDEventsTestHelper.cpp
+++ b/Framework/TestHelpers/src/MDEventsTestHelper.cpp
@@ -71,7 +71,7 @@ EventWorkspace_sptr createDiffractionEventWorkspace(int numEvents, int numPixels
   double binDelta = 10.0;
 
   auto retVal = std::make_shared<EventWorkspace>();
-  retVal->initialize(numPixels, 1, 1);
+  retVal->initialize(numPixels + 2, 1, 1);
 
   // --------- Load the instrument -----------
   const std::string filename = FileFinder::Instance().getFullPath("unit_testing/MINITOPAZ_Definition.xml");
@@ -82,11 +82,15 @@ EventWorkspace_sptr createDiffractionEventWorkspace(int numEvents, int numPixels
 
   DateAndTime run_start("2010-01-01T00:00:00");
 
+  // create spectra for monitors
+  retVal->getSpectrum(0).addDetectorID(-1);
+  retVal->getSpectrum(1).addDetectorID(-2);
+
   for (int pix = 0; pix < numPixels; pix++) {
     for (int i = 0; i < numEvents; i++) {
-      retVal->getSpectrum(pix) += Types::Event::TofEvent((i + 0.5) * binDelta, run_start + double(i));
+      retVal->getSpectrum(pix + 2) += Types::Event::TofEvent((i + 0.5) * binDelta, run_start + double(i));
     }
-    retVal->getSpectrum(pix).addDetectorID(pix);
+    retVal->getSpectrum(pix + 2).addDetectorID(pix);
   }
 
   // Create the x-axis for histogramming.
@@ -112,7 +116,7 @@ EventWorkspace_sptr createDiffractionEventWorkspace(int numEvents, int numPixels
                              "instrument loaded.");
   Mantid::detid2det_map dets;
   retVal->getInstrument()->getDetectors(dets);
-  if (dets.size() != 100 * 100)
+  if (dets.size() != 100 * 100 + 2)
     throw std::runtime_error("MDEventsTestHelper::"
                              "createDiffractionEventWorkspace(): Wrong "
                              "instrument size.");

--- a/docs/source/release/v6.2.0/framework.rst
+++ b/docs/source/release/v6.2.0/framework.rst
@@ -52,5 +52,6 @@ Bugfixes
 ########
 
 - Added parser for input Names to :ref:`algm-CreateMDHistoWorkspace` to allow inputs such as `Names='[H,0,0],[0,K,0],[0,0,L]'`.
+- Fixed bug in :ref:`algm-ConvertToMDMinMaxLocal` where wrong min max calculated if the workspace includes monitor spectra or spectra without any detectors
 
 :ref:`Release 6.2.0 <v6.2.0>`

--- a/instrument/unit_testing/MINITOPAZ_Definition.xml
+++ b/instrument/unit_testing/MINITOPAZ_Definition.xml
@@ -31,6 +31,19 @@ This is a mini version similar to TOPAZ but used for unit testing.
   </component>
   <type name="sample-position" is="SamplePos"/>
 
+  <!--MONITORS-->
+  <component type="monitors" idlist="monitors">
+    <location/>
+  </component>
+  <type name="monitors">
+    <component type="monitor">
+      <location z="-2.488" name="monitor1"/>
+    </component>
+    <component type="monitor">
+      <location z="1.049" name="monitor2"/>
+    </component>
+  </type>
+
 <!--- Make a single panel:
 	0.5 meters from sample, along the +X axis (0.5,0,0) center coord
 	0.5 meters wide and high.
@@ -60,5 +73,22 @@ This is a mini version similar to TOPAZ but used for unit testing.
     <algebra val="pixel-shape"/>
   </type>
 
+  <!-- Shape for Monitors-->
+  <!-- TODO: Update to real shape -->
+  <type is="monitor" name="monitor">
+    <cylinder id="some-shape">
+      <centre-of-bottom-base p="0.0" r="0.0" t="0.0"/>
+      <axis y="0.0" x="0.0" z="1.0"/>
+      <radius val="0.01"/>
+      <height val="0.03"/>
+    </cylinder>
+    <algebra val="some-shape"/>
+  </type>
+
+  <!--MONITOR IDs-->
+  <idlist idname="monitors">
+    <id val="-1"/>
+    <id val="-2"/>
+  </idlist>
 </instrument>
 


### PR DESCRIPTION
**Description of work.**

Add extra unit test to ConvertToDiffractionMDWorkspace3Test to cover ISIS use case for ConvertToDiffractionMDWorkspace where initial workspace has units of dSpacing. This gap caused a bug to slip through that was spotted by a user's manual testing just before the 6.1 release.

The bug only occurred on workspaces where some of the spectra had missing detectors or were monitors. So I've updated the MINI_TOPAZ instrument definition used in the ConvertToDiffractionMDWorkspace tests by adding two monitors.

Also fix bug in ConvertToMDMinMaxLocal (which is called as a child algorithm from ConvertToDiffractionMDWorkspace) where there's a mix up between the workspace index and the detector index used to look up stuff from the table workspace created by PreprocessDetectorsToMD. These two indexes aren't the same if there are spectra without detectors or spectra pointing at monitors. The consequence of this was that the wrong unit conversion parameters were used if the workspace had monitor spectra that weren't at the bottom of the spectra list.

Note - I think there are other algorithms that have the same mixup but I'll create a separate issue for this:
- SaveIsawQvector
- IntegrateEIlipsoidsTwoStep
- IntegrateEllipsoids
- ConvertToMD::copyMetaData

Also the use of std::numeric_limits<uint64_t>::quiet_NaN() in PreprocessDetectorsToMD isn't very helpful. It's used as the default value for the table workspace columns that hold indices eg spectrum index or detector index. quiet_NaN is actually "0" for the int types which is a valid index. This means the mix up above is harder to spot.

**To test:**

Code review and check Jenkins tests all pass

Fixes #31697.

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
