### PR TITLE
Various minor warning fixes

### DIFF
--- a/Framework/API/src/MatrixWorkspace.cpp
+++ b/Framework/API/src/MatrixWorkspace.cpp
@@ -1649,7 +1649,7 @@ signal_t MatrixWorkspace::getSignalAtCoord(const coord_t *coords,
   const auto &yVals = this->y(wi);
   double yBinSize(1.0); // only applies for volume normalization & numeric axis
   if (normalization == VolumeNormalization && ax1->isNumeric()) {
-    size_t uVI; // unused vertical index.
+    size_t uVI = 0; // unused vertical index.
     double currentVertical = ax1->operator()(wi, uVI);
     if (wi + 1 == nhist && nhist > 1) // On the boundary, look back to get diff
     {

--- a/Framework/API/test/MuParserUtilsTest.h
+++ b/Framework/API/test/MuParserUtilsTest.h
@@ -28,7 +28,7 @@ public:
 private:
   static bool extraOneVarFunctionsDefined(const mu::Parser &parser) {
     const auto functionMap = parser.GetFunDef();
-    for (const auto pair : MuParserUtils::MUPARSER_ONEVAR_FUNCTIONS) {
+    for (const auto &pair : MuParserUtils::MUPARSER_ONEVAR_FUNCTIONS) {
       const auto iterator = functionMap.find(pair.first);
       if (iterator == functionMap.end()) {
         return false;
@@ -55,7 +55,7 @@ private:
     }
     // Note: the keys in constantMap are values in MUPARSER_CONSTANTS and
     // vice versa.
-    for (const auto constant : MuParserUtils::MUPARSER_CONSTANTS) {
+    for (const auto &constant : MuParserUtils::MUPARSER_CONSTANTS) {
       const auto iterator = constantMap.find(constant.second);
       if (iterator == constantMap.end()) {
         return false;

--- a/Framework/Algorithms/test/GenerateIPythonNotebookTest.h
+++ b/Framework/Algorithms/test/GenerateIPythonNotebookTest.h
@@ -98,7 +98,7 @@ public:
     }
 
     // Check that the expected lines do appear in the output
-    for (auto const expected_line : result) {
+    for (auto const &expected_line : result) {
       TS_ASSERT(std::find(notebookLines.cbegin(), notebookLines.cend(), expected_line) != notebookLines.cend())
     }
 

--- a/qt/widgets/common/src/FunctionModel.cpp
+++ b/qt/widgets/common/src/FunctionModel.cpp
@@ -217,7 +217,7 @@ QStringList FunctionModel::getAttributeNames() const {
   QStringList names;
   if (hasFunction()) {
     const auto attributeNames = getCurrentFunction()->getAttributeNames();
-    for (auto const name : attributeNames) {
+    for (auto const &name : attributeNames) {
       names << QString::fromStdString(name);
     }
   }


### PR DESCRIPTION
**Description of work.**

Minor warning fixes for copy instead of ref, and an uninitialised var.
This is only present on newer compilers, but I've finally got annoyed enough locally to fix them

**To test:**
- Code review
- Tests should pass

There is no associated issue.

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or master)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
