### PR TITLE
Code editor close tab icon, forced to material design

### DIFF
--- a/docs/source/release/v6.2.0/mantidworkbench.rst
+++ b/docs/source/release/v6.2.0/mantidworkbench.rst
@@ -9,6 +9,7 @@ New and Improved
 ----------------
 
 - Peaks can now be added or removed from a PeaksWorkspace using the :ref:`peaks overlay <sliceviewer_peaks_overlay>` in :ref:`sliceviewer`.
+- Improved cross-platform theming by forcing a material design icon for closing editor tabs.
 
 Bugfixes
 --------

--- a/docs/source/release/v6.2.0/mantidworkbench.rst
+++ b/docs/source/release/v6.2.0/mantidworkbench.rst
@@ -9,7 +9,7 @@ New and Improved
 ----------------
 
 - Peaks can now be added or removed from a PeaksWorkspace using the :ref:`peaks overlay <sliceviewer_peaks_overlay>` in :ref:`sliceviewer`.
-- Improved cross-platform theming by forcing a material design icon for closing editor tabs.
+- Improved cross-platform theming by using the same icon on all platforms for closing editor tabs.
 
 Bugfixes
 --------

--- a/qt/python/mantidqt/widgets/codeeditor/multifileinterpreter.py
+++ b/qt/python/mantidqt/widgets/codeeditor/multifileinterpreter.py
@@ -13,9 +13,10 @@ from os import linesep
 
 # 3rd party imports
 from qtpy.QtCore import Qt, Slot, Signal
-from qtpy.QtWidgets import QVBoxLayout, QWidget
+from qtpy.QtWidgets import QVBoxLayout, QWidget, QTabBar, QPushButton
 
 # local imports
+from mantidqt.icons import get_icon
 from mantidqt.widgets.codeeditor.interpreter import PythonFileInterpreter
 from mantidqt.widgets.codeeditor.scriptcompatibility import add_mantid_api_import, mantid_api_import_needed
 from mantidqt.widgets.codeeditor.tab_widget.codeeditor_tab_view import CodeEditorTabWidget
@@ -154,6 +155,14 @@ class MultiPythonFileInterpreter(QWidget):
         if content is not None:
             line_count = content.count(linesep)
             interpreter.editor.setCursorPosition(line_count,0)
+
+        # Replace the button on the tab bar so icon isn't weird.
+        close_button = QPushButton(self)
+        close_button.setFlat(True)
+        close_button.setIcon(get_icon("mdi.close", "black", 1.35))
+        close_button.clicked.connect(lambda tab_index=tab_idx: self.close_tab(tab_index))
+        self._tabs.tabBar().setTabButton(tab_idx, QTabBar.RightSide, close_button)
+
         return tab_idx
 
     def abort_current(self):

--- a/qt/python/mantidqt/widgets/codeeditor/multifileinterpreter.py
+++ b/qt/python/mantidqt/widgets/codeeditor/multifileinterpreter.py
@@ -156,7 +156,7 @@ class MultiPythonFileInterpreter(QWidget):
             line_count = content.count(linesep)
             interpreter.editor.setCursorPosition(line_count,0)
 
-        # Replace the button on the tab bar so icon isn't weird.
+        # Replace close button with mdi.close icon to improve OS visual consistency
         close_button = QPushButton(self)
         close_button.setFlat(True)
         close_button.setIcon(get_icon("mdi.close", "black", 1.35))

--- a/qt/python/mantidqt/widgets/codeeditor/tab_widget/codeeditor_tab_view.py
+++ b/qt/python/mantidqt/widgets/codeeditor/tab_widget/codeeditor_tab_view.py
@@ -154,7 +154,6 @@ class CodeEditorTabWidget(QTabWidget):
 
         if Qt.MiddleButton == event.button():
             self.tabCloseRequested.emit(self.last_tab_clicked)
-        
         QTabWidget(self).mousePressEvent(event)
 
     def tab_was_clicked(self, tab_index):

--- a/qt/python/mantidqt/widgets/codeeditor/tab_widget/codeeditor_tab_view.py
+++ b/qt/python/mantidqt/widgets/codeeditor/tab_widget/codeeditor_tab_view.py
@@ -152,6 +152,9 @@ class CodeEditorTabWidget(QTabWidget):
         if self.last_tab_clicked < 0:
             return
 
+        if Qt.MiddleButton == event.button():
+            self.tabCloseRequested.emit(self.last_tab_clicked)
+        
         QTabWidget(self).mousePressEvent(event)
 
     def tab_was_clicked(self, tab_index):

--- a/qt/python/mantidqt/widgets/codeeditor/tab_widget/codeeditor_tab_view.py
+++ b/qt/python/mantidqt/widgets/codeeditor/tab_widget/codeeditor_tab_view.py
@@ -152,9 +152,6 @@ class CodeEditorTabWidget(QTabWidget):
         if self.last_tab_clicked < 0:
             return
 
-        if Qt.MiddleButton == event.button():
-            self.tabCloseRequested.emit(self.last_tab_clicked)
-
         QTabWidget(self).mousePressEvent(event)
 
     def tab_was_clicked(self, tab_index):


### PR DESCRIPTION
**Description of work.**
The majority of icons in Workbench are material design. Icons that aren't material design icons, are from 

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

**To test:**
On Windows:
- Open workbench
- Then notice that the code editor tabs, tab close button looks like this:
![image](https://user-images.githubusercontent.com/24723609/121379519-02f89b80-c93c-11eb-8c84-572da600a2f0.png)

On MacOS:
- Open workbench
- Then notice that the code editor tabs, tab close button looks like this:
![image](https://user-images.githubusercontent.com/24723609/121379519-02f89b80-c93c-11eb-8c84-572da600a2f0.png)

On Linux in Conda:
- Activate the mantid conda development environment
- Compile mantid with it
- Then notice that the code editor tabs, tab close button looks like this:
![image](https://user-images.githubusercontent.com/24723609/121379519-02f89b80-c93c-11eb-8c84-572da600a2f0.png)

On Linux none Conda:
- Open workbench
- Then notice that the code editor tabs, tab close button looks like this:
![image](https://user-images.githubusercontent.com/24723609/121379519-02f89b80-c93c-11eb-8c84-572da600a2f0.png)

<!-- Instructions for testing. -->

Fixes #31651 <!-- and fix #xxxx or close #xxxx xor resolves #xxxx -->
<!-- alternative
*There is no associated issue.*
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or master)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
