### PR TITLE
Speed up performance of ApplyDiffCal on large instruments

### DIFF
--- a/Framework/DataHandling/src/ApplyDiffCal.cpp
+++ b/Framework/DataHandling/src/ApplyDiffCal.cpp
@@ -192,6 +192,7 @@ void ApplyDiffCal::exec() {
     Column_const_sptr tzeroColumn = m_calibrationWS->getColumn("tzero");
 
     auto detids = instrument->getDetectorIDs();
+    std::sort(detids.begin(), detids.end());
 
     for (size_t i = 0; i < m_calibrationWS->rowCount(); ++i) {
       auto detid = static_cast<detid_t>((*detIdColumn)[i]);
@@ -199,9 +200,7 @@ void ApplyDiffCal::exec() {
       double difa = (*difaColumn)[i];
       double tzero = (*tzeroColumn)[i];
 
-      // auto det = instrument->getDetector(detid);
-      auto it = std::find(detids.begin(), detids.end(), detid);
-      if (it != detids.end()) {
+      if (std::binary_search(detids.begin(), detids.end(), detid)) {
         // found the detector
         auto det = instrument->getDetector(detid);
         paramMap.addDouble(det->getComponentID(), "DIFC", difc);

--- a/docs/source/release/v6.2.0/diffraction.rst
+++ b/docs/source/release/v6.2.0/diffraction.rst
@@ -19,6 +19,7 @@ Improvements
 - :ref:`SCDCalibratePanels <algm-SCDCalibratePanels-v2>` major interface update along with enabling the calibration of T0 and sample position.
 - :ref:`SCDCalibratePanels <algm-SCDCalibratePanels-v2>` minor interface update that allows fine control of bank rotation calibration.
 - :ref:`SNAPReduce <algm-SNAPReduce-v1>` permits saving selected property names and values to file, to aid autoreduction.
+- improve performance of :ref:`ApplyDiffCal <algm-ApplyDiffCal>` on large instruments eg WISH. This in turn improves the performance of :ref:`AlignAndFocusPowder <algm-AlignAndFocusPowder>`
 
 Bugfixes
 ########


### PR DESCRIPTION
**Description of work.**

There was a problem in ApplyDiffCal if the .cal file contained a detid that wasn't in the workspace's instrument definition. This was fixed in https://github.com/mantidproject/mantid/pull/31438 (@KedoKudo thanks for fixing). The check on detid is slow though on the WISH instrument which has a lot of detectors (~780k). So this change speeds it up

**To test:**

Run the following script, checks it runs successfully and observe it's faster. I suggest doing on a release build to see realistic timings. The input .raw and .cal files are in the Testing\Data\SystemTest directory:

```
ws=Load(r"WISH00040503.raw", SpectrumMin=97286, SpectrumMax=116741)
LoadDiffCal(filename=r"WISH\input\Cal\WISH_cycle_15_4_noends_10to10_dodgytube_removed_feb2016.cal",
            InstrumentName="WISH",
            WorkspaceName="WISH_diff")
focus=AlignAndFocusPowder(ws, CalibrationWorkspace="WISH_diff_cal", GroupingWorkspace="WISH_diff_group",
                                                Params="-0.00063",Dspacing=True)
```
For me the run time of the AlignAndFocusPowder step (which calls ApplyDiffCal) is about 15 seconds after the change vs 1 min 30 seconds before the change

Fixes #31752.

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
