### PR TITLE
Tighten up the unit tests for parabolic TOF to d

### DIFF
--- a/Framework/Kernel/test/UnitTest.h
+++ b/Framework/Kernel/test/UnitTest.h
@@ -584,19 +584,57 @@ public:
     TS_ASSERT_THROWS_NOTHING(d.fromTOF(x, y, 1.0, 1, {{UnitParams::difc, difc}}))
     TS_ASSERT_DELTA(x[0], 2.065172, 0.000001)
     TS_ASSERT(yy == y)
+    x[0] = 1.0;
+    TS_ASSERT_THROWS(d.fromTOF(x, y, 1.0, 1, {{UnitParams::difc, -1.0}}), const std::runtime_error &)
   }
 
   void testdSpacing_fromTOFWithDIFATZERO() {
+    // solves the quadratic ax^2 + bx + c =0
+    // where a=difa, b=difc, c=tzero-tof
+    // a>0 and c<0
     std::vector<double> x(1, 2.0), y(1, 1.0);
     std::vector<double> yy = y;
     TS_ASSERT_THROWS_NOTHING(
         d.fromTOF(x, y, 1.0, 1, {{UnitParams::difc, 2.0}, {UnitParams::difa, 3.0}, {UnitParams::tzero, 1.0}}))
     TS_ASSERT_DELTA(x[0], 1.0 / 3.0, 0.0001)
     TS_ASSERT(yy == y)
+    // a>0 and c=0 - currently gives negative root rather than zero, will fix later
+    /*x[0] = 1.0;
+    TS_ASSERT_THROWS_NOTHING(
+        d.fromTOF(x, y, 1.0, 1, {{UnitParams::difc, 2.0}, {UnitParams::difa, 3.0}, {UnitParams::tzero, 1.0}}))
+    TS_ASSERT_DELTA(x[0], 0.0, 0.0001)
+    TS_ASSERT(yy == y)*/
+    // a<0 and c=0
     x[0] = 1.0;
     TS_ASSERT_THROWS_NOTHING(
         d.fromTOF(x, y, 1.0, 1, {{UnitParams::difc, 3.0}, {UnitParams::difa, -2.0}, {UnitParams::tzero, 1.0}}))
     TS_ASSERT_DELTA(x[0], 1.5, 0.0001)
+    TS_ASSERT(yy == y)
+    // a<0 and c<0 - two positive roots
+    x[0] = 2.0;
+    TS_ASSERT_THROWS_NOTHING(
+        d.fromTOF(x, y, 1.0, 1, {{UnitParams::difc, 3.0}, {UnitParams::difa, -2.0}, {UnitParams::tzero, 1.0}}))
+    TS_ASSERT_DELTA(x[0], 0.5, 0.0001)
+    TS_ASSERT(yy == y)
+    x[0] = 2.0;
+    TS_ASSERT_THROWS(
+        d.fromTOF(x, y, 1.0, 1, {{UnitParams::difc, 2.0}, {UnitParams::difa, -3.0}, {UnitParams::tzero, 1.0}}),
+        const std::runtime_error &)
+    // Finally check some c>0 for completeness - unlikely to happen
+    // a>0 and c>0
+    x[0] = 1.0;
+    TS_ASSERT_THROWS(
+        d.fromTOF(x, y, 1.0, 1, {{UnitParams::difc, 2.0}, {UnitParams::difa, 1.0}, {UnitParams::tzero, 2.0}}),
+        const std::runtime_error &)
+    x[0] = 1.0;
+    TS_ASSERT_THROWS(
+        d.fromTOF(x, y, 1.0, 1, {{UnitParams::difc, 2.0}, {UnitParams::difa, 2.0}, {UnitParams::tzero, 2.0}}),
+        const std::runtime_error &)
+    // a<0 and c>0
+    x[0] = 1.0;
+    TS_ASSERT_THROWS_NOTHING(
+        d.fromTOF(x, y, 1.0, 1, {{UnitParams::difc, 2.0}, {UnitParams::difa, -3.0}, {UnitParams::tzero, 2.0}}))
+    TS_ASSERT_DELTA(x[0], 1.0, 0.0001)
     TS_ASSERT(yy == y)
   }
 


### PR DESCRIPTION
**Description of work.**

Following problem found with TOF to d conversion when DIFA!=0 (#31734), add some further unit tests to the dSpacing class to try out the different combinations of the quadratic coefficients: 

TOF = DIFA * d^2 + DIFC * d + TZERO

You'll see there's one new unit test commented out. This is because I found a small issue with difa>0, tzero-tof=0 where negative root is returned instead of zero but this is an edge case that's unlikely to happen so will fix in separate issue so that I can baseline current functionality against this set of unit tests

**To test:**

Code review and check Jenkins jobs pass

Fixes #31769. 


*This does not require release notes* because **no functional change - new tests only**

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
