### PR TITLE
Reinstate citardauq formula in d spacing unit

### DIFF
--- a/Framework/Kernel/test/UnitTest.h
+++ b/Framework/Kernel/test/UnitTest.h
@@ -598,12 +598,12 @@ public:
         d.fromTOF(x, y, 1.0, 1, {{UnitParams::difc, 2.0}, {UnitParams::difa, 3.0}, {UnitParams::tzero, 1.0}}))
     TS_ASSERT_DELTA(x[0], 1.0 / 3.0, 0.0001)
     TS_ASSERT(yy == y)
-    // a>0 and c=0 - currently gives negative root rather than zero, will fix later
-    /*x[0] = 1.0;
+    // a>0 and c=0
+    x[0] = 1.0;
     TS_ASSERT_THROWS_NOTHING(
         d.fromTOF(x, y, 1.0, 1, {{UnitParams::difc, 2.0}, {UnitParams::difa, 3.0}, {UnitParams::tzero, 1.0}}))
     TS_ASSERT_DELTA(x[0], 0.0, 0.0001)
-    TS_ASSERT(yy == y)*/
+    TS_ASSERT(yy == y)
     // a<0 and c=0
     x[0] = 1.0;
     TS_ASSERT_THROWS_NOTHING(
@@ -620,6 +620,11 @@ public:
     TS_ASSERT_THROWS(
         d.fromTOF(x, y, 1.0, 1, {{UnitParams::difc, 2.0}, {UnitParams::difa, -3.0}, {UnitParams::tzero, 1.0}}),
         const std::runtime_error &)
+    x[0] = 10000.0;
+    TS_ASSERT_THROWS_NOTHING(
+        d.fromTOF(x, y, 1.0, 1, {{UnitParams::difc, 20000.0}, {UnitParams::difa, -1E-10}, {UnitParams::tzero, 1.0}}))
+    TS_ASSERT_DELTA(x[0], 0.49995, 0.0001)
+    TS_ASSERT(yy == y)
     // Finally check some c>0 for completeness - unlikely to happen
     // a>0 and c>0
     x[0] = 1.0;


### PR DESCRIPTION
**Description of work.**

As part of an earlier bug fix the formula for solving the quadratic equation to go from TOF to dSpacing was changed. It was originally the following citardauq formula but was replaced with the "classic" quadratic formula. 

![image (7)](https://user-images.githubusercontent.com/56295817/121679564-60155e00-cab0-11eb-8445-047e65389d1f.png)

Now that the unit tests have been tightened up in https://github.com/mantidproject/mantid/pull/31764, this change is to reinstate the citardauq formula because it is less subject to floating point rounding errors. In most cases the terms b and sqrt(b^2-4ac) are close to each other and the "classic" quadratic formula calculated the difference between these in the numerator. The citardauq formula also works for a=0 which is often the case

**To test:**

Run the following script and check it completes. It includes two unit conversions:

- The first unit conversion is an example where in the 6.1 release the code was picking the wrong root. This bug has already been fixed but included a check here just to be sure. 
- The second unit conversion is one that was previously subject to a rounding error. The difa term is v nearly zero so the result should be simple "(tof-tzero)/difc":

```
# import mantid algorithms, numpy and matplotlib
from mantid.simpleapi import *
import matplotlib.pyplot as plt
import numpy as np

from mantid.kernel import DeltaEModeType, UnitConversion, UnitParams, UnitParametersMap

params = UnitParametersMap()
params[UnitParams.difa] = -3.40183
params[UnitParams.difc] = 9808
params[UnitParams.tzero] = -3.28734

dSpacing = UnitConversion.run('TOF', 'dSpacing', 2030.72, 0., DeltaEModeType.Elastic, params)
# two positive roots at 0.207397 and 2882.950. Should pick smallest positive root
assert abs(dSpacing - 0.207397) <= 0.0001
print("dSpacing=" + str(dSpacing))

params[UnitParams.difa] = -1E-10
params[UnitParams.difc] = 20000
params[UnitParams.tzero] = 1

dSpacing = UnitConversion.run('TOF', 'dSpacing', 10000, 0., DeltaEModeType.Elastic, params)
# result was previously 0.4911
assert abs(dSpacing - 0.49995) <= 0.0001
print("dSpacing=" + str(dSpacing))
```

Fixes #31770.

*This does not require release notes* because **earlier bug fix in https://github.com/mantidproject/mantid/pull/31734 has release note and this change brings behaviour closer to previous release**

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
