### PR TITLE
Fix errors in LeadPressureCalc algorithm

### DIFF
--- a/Framework/PythonInterface/plugins/algorithms/LeadPressureCalc.py
+++ b/Framework/PythonInterface/plugins/algorithms/LeadPressureCalc.py
@@ -16,12 +16,12 @@ TOL = 0.01
 # this calculation taken from the EOS equations in [1]
 def calculate_pressure(d_spacing, temp):
     v00 = 121.41813  # zero pressure unit cell volume at (0) (A^3)
-    a = 1.0584E-02  # volume fit parameter
+    a = 1.0582E-02  # volume fit parameter
     b = 3.493E-06  # volume fit parameter
-    k00 = 41.731  # zero pressure bulk modulus at (0) (GPa)
-    c = -2.5444E-02  # bulk modulus fit parameter
-    d = -2.7567E-06  # bulk modulus fit parameter
-    k00p = 5.3925  # K' at (0)
+    k00 = 41.7253509951022  # zero pressure bulk modulus at (0) (GPa)
+    c = -2.54374974975855E-02  # bulk modulus fit parameter
+    d = -2.7567006420938E-06  # bulk modulus fit parameter
+    k00p = 5.3944  # K' at (0)
     e = 0.00111  # K' fit parameter
     k00pp = -0.3272  # K'' at (0)
     v_calc = (np.sqrt(3) * d_spacing) ** 3  # unit cell volume (A^3)

--- a/Framework/PythonInterface/plugins/algorithms/LeadPressureCalc.py
+++ b/Framework/PythonInterface/plugins/algorithms/LeadPressureCalc.py
@@ -19,7 +19,7 @@ def calculate_pressure(d_spacing, temp):
     a = 1.0584E-02  # volume fit parameter
     b = 3.493E-06  # volume fit parameter
     k00 = 41.731  # zero pressure bulk modulus at (0) (GPa)
-    c = -2.5444E-05  # bulk modulus fit parameter
+    c = -2.5444E-02  # bulk modulus fit parameter
     d = -2.7567E-06  # bulk modulus fit parameter
     k00p = 5.3925  # K' at (0)
     e = 0.00111  # K' fit parameter
@@ -28,13 +28,13 @@ def calculate_pressure(d_spacing, temp):
     ltemp = temp - 300
 
     v_quad = (v00 + a * ltemp + b * (ltemp ** 2))
-    k_quad = (k00 + c * ltemp + d * (ltemp ** 2))
-    factor = k00p + e * temp
+    k_quad = (k00 + (c * ltemp) + (d * (ltemp ** 2)))
+    factor = k00p + (e * temp)
 
     return 1.5 * k_quad * (((v_calc / v_quad) ** (-2 / 3)) - 1) * (1 + ((v_calc / v_quad) ** (-2 / 3) - 1)) ** (5 / 2) \
-        * (1 + ((3 / 2) * (factor - 4) * ((((v_calc / v_quad) ** (-2 / 3)) - 1) / 2)))\
-        + ((3 / 2) * (((k_quad*k00pp) + (factor - 4) * (factor - 3) + (35 / 9))
-                      * ((((v_calc / v_quad) ** (-2 / 3))-1) / 2) ** 2))
+        * ((1 + ((3 / 2) * (factor - 4) * ((((v_calc / v_quad) ** (-2 / 3)) - 1) / 2)))
+           + ((3 / 2) * (((k_quad * k00pp) + (factor - 4) * (factor - 3) + (35 / 9))
+                         * ((((v_calc / v_quad) ** (-2 / 3)) - 1) / 2) ** 2)))
 
 
 class LeadPressureCalc(PythonAlgorithm):

--- a/Framework/PythonInterface/test/python/plugins/algorithms/LeadPressureCalcTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/LeadPressureCalcTest.py
@@ -73,6 +73,20 @@ class LeadPressureCalcTest(unittest.TestCase):
         self.assertEqual(len(ws.toDict().keys()), 3)
         self.assertNotIn("Pressure Target (GPa)", ws.row(0).keys())
 
+    def test_high_d_low_t(self):
+        d = 2.865
+        temp = 385
+        LeadPressureCalc(d, temp)
+        ws = mtd['LeadPressureCalcResults']
+        self.assertAlmostEqual(0.048, ws.row(0)["Calculated Pressure (GPa)"], 3)
+
+    def test_high_t_low_d(self):
+        d = 2.635
+        temp = 490
+        LeadPressureCalc(d, temp)
+        ws = mtd['LeadPressureCalcResults']
+        self.assertAlmostEqual(20.274, ws.row(0)["Calculated Pressure (GPa)"], 1)  # calc err +- 2.426
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
**Description of work.**
Fix errors found in LeadPressureCalc by Chris Ridley. Specifically, the EOS c constant was out by e3, and there was incorrect bracketing in the calculation.

Unit tests updated with externally calculated results.

**Report to:** Chris Ridley


**To test:**
Ensure unit tests pass

*There is no associated issue.*


<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or master)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
