### PR TITLE
Fix broken help link in engineering diffraction interface

### DIFF
--- a/docs/source/release/v6.2.0/diffraction.rst
+++ b/docs/source/release/v6.2.0/diffraction.rst
@@ -25,6 +25,15 @@ Bugfixes
 
 Engineering Diffraction
 -----------------------
+New features
+############
+
+Improvements
+############
+
+Bugfixes
+########
+- The help button on the Engineering Diffraction interface points to the correct page, having been broken in the last release
 
 Single Crystal Diffraction
 --------------------------

--- a/scripts/Engineering/gui/engineering_diffraction/presenter.py
+++ b/scripts/Engineering/gui/engineering_diffraction/presenter.py
@@ -30,6 +30,7 @@ class EngineeringDiffractionPresenter(object):
         self.fitting_presenter = None
         self.settings_presenter = None
 
+        self.doc_folder = "diffraction"
         self.doc = "Engineering Diffraction"
 
         # Setup observers
@@ -82,7 +83,7 @@ class EngineeringDiffractionPresenter(object):
         self.fitting_presenter.plot_widget.view.ensure_fit_dock_closed()
 
     def open_help_window(self):
-        InterfaceManager().showCustomInterfaceHelp(self.doc)
+        InterfaceManager().showCustomInterfaceHelp(self.doc, self.doc_folder)
 
     def open_settings(self):
         self.settings_presenter.show()


### PR DESCRIPTION
**Description of work.**
The help button in the Engineering Diffraction interface had been broken when the engineering interfaces docs were moved into a sub folder. This adds that sub folder to the path of the help

**To test:**
1. Make sure the help on the interface opens correctly

Fixes #31672 . <!-- and fix #xxxx or close #xxxx xor resolves #xxxx -->
<!-- alternative
*There is no associated issue.*
-->

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or master)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
