### PR TITLE
Conda: Ensure compatibility with different python versions

### DIFF
--- a/buildconfig/CMake/Bootstrap.cmake
+++ b/buildconfig/CMake/Bootstrap.cmake
@@ -166,6 +166,7 @@ endfunction()
 
 # Find python interpreter
 set(MINIMUM_PYTHON_VERSION 3.6)
+set(Python3_ROOT_DIR $ENV{CONDA_PREFIX})
 find_package(Python ${MINIMUM_PYTHON_VERSION} REQUIRED
              COMPONENTS Interpreter Development NumPy)
 # If anything external uses find_package(PythonInterp) then make sure it finds the correct version and executable


### PR DESCRIPTION
**Description of work.**
If you installed the latest miniconda3/mambaforge/miniforge with Python 3.9 it causes issues during CMake configuring where CMakecan't find the intended version of python (Which is python 3.8) and Numpy.

**To test:**
Only visible in Linux at the moment.
CentOS/RHEL 7 currently has a bug in test compilations but will work for this.

Install conda using the latest Mambaforge-Linux-x86_64.sh: https://github.com/conda-forge/miniforge/releases (this uses Python 3.9 by default)
Create the mantid conda environment using this command:
`conda env create -f {SOURCE}/mantid-development-linux.yml`
Run: `conda activate mantid`
Make a new build directory
Inside this new directory run CMake using this command
`cmake {SOURCE} -GNinja`
As long as the CMake finishes then this was a success.

*There is no associated issue.*

*This does not require release notes* because **This is not user facing**


<!-- Ensure the base of this PR is correct (e.g. release-next or master)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
