### PR TITLE
Allow MaksPeaksWorkspace to process data from CORELLI

### DIFF
--- a/Framework/Crystal/src/MaskPeaksWorkspace.cpp
+++ b/Framework/Crystal/src/MaskPeaksWorkspace.cpp
@@ -247,13 +247,37 @@ void MaskPeaksWorkspace::getTofRange(double &tofMin, double &tofMax, const doubl
     tofMax = tofPeak + m_tofMax;
   }
 }
+
+/**
+ * @brief
+ *
+ * @param bankName
+ * @param col
+ * @param row
+ * @return int
+ */
 int MaskPeaksWorkspace::findPixelID(const std::string &bankName, int col, int row) {
   Geometry::Instrument_const_sptr Iptr = m_inputW->getInstrument();
   std::shared_ptr<const IComponent> parent = Iptr->getComponentByName(bankName);
+
   if (parent->type() == "RectangularDetector") {
     std::shared_ptr<const RectangularDetector> RDet = std::dynamic_pointer_cast<const RectangularDetector>(parent);
 
     std::shared_ptr<Detector> pixel = RDet->getAtXY(col, row);
+    return pixel->getID();
+  } else if (Iptr->getName().compare("CORELLI") == 0) {
+    // Checking for CORELLI
+    // pixel full name example
+    //      /CORELLI/A row/bank10/sixteenpack/tube10/pixel23
+    //                                ^ the extra layer that makes CORELLI different from WISH
+    std::ostringstream pixelString;
+    pixelString << parent->getFullName() // /CORELLI/A row/bank10
+                << "/sixteenpack"        // /sixteenpack
+                << "/tube" << col        // /tube10
+                << "/pixel" << row;      // /pixel23
+    std::shared_ptr<const Geometry::IComponent> component = Iptr->getComponentByName(pixelString.str());
+    std::shared_ptr<const Detector> pixel = std::dynamic_pointer_cast<const Detector>(component);
+    //
     return pixel->getID();
   } else {
     std::string bankName0 = bankName;

--- a/Framework/Crystal/src/MaskPeaksWorkspace.cpp
+++ b/Framework/Crystal/src/MaskPeaksWorkspace.cpp
@@ -185,6 +185,8 @@ void MaskPeaksWorkspace::retrieveProperties() {
 size_t MaskPeaksWorkspace::getWkspIndex(const detid2index_map &pixel_to_wi, const Geometry::IComponent_const_sptr &comp,
                                         const int x, const int y) {
   Geometry::RectangularDetector_const_sptr det = std::dynamic_pointer_cast<const Geometry::RectangularDetector>(comp);
+  Geometry::Instrument_const_sptr Iptr = m_inputW->getInstrument();
+
   if (det) {
     if (x >= det->xpixels() || x < 0 || y >= det->ypixels() || y < 0)
       return EMPTY_INT();
@@ -212,15 +214,40 @@ size_t MaskPeaksWorkspace::getWkspIndex(const detid2index_map &pixel_to_wi, cons
     std::shared_ptr<const Geometry::ICompAssembly> asmb =
         std::dynamic_pointer_cast<const Geometry::ICompAssembly>(comp);
     asmb->getChildren(children, false);
+
     std::shared_ptr<const Geometry::ICompAssembly> asmb2 =
         std::dynamic_pointer_cast<const Geometry::ICompAssembly>(children[0]);
     std::vector<Geometry::IComponent_const_sptr> grandchildren;
     asmb2->getChildren(grandchildren, false);
+
     auto NROWS = static_cast<int>(grandchildren.size());
     auto NCOLS = static_cast<int>(children.size());
+
+    std::ostringstream msg;
+    if (Iptr->getName().compare("CORELLI") == 0) {
+      msg << "Instrument is CORELLI\n";
+      // CORELLI has one extra layer than WISH
+      std::shared_ptr<const Geometry::ICompAssembly> asmb3 =
+          std::dynamic_pointer_cast<const Geometry::ICompAssembly>(grandchildren[0]);
+      std::vector<Geometry::IComponent_const_sptr> greatgrandchildren;
+      asmb3->getChildren(greatgrandchildren, false);
+      // update for CORELLI
+      NCOLS = static_cast<int>(grandchildren.size());
+      NROWS = static_cast<int>(greatgrandchildren.size());
+    } else {
+      msg << "Instrument is WISH\n";
+    }
+
     // Wish pixels and tubes start at 1 not 0
-    if (x - 1 >= NCOLS || x - 1 < 0 || y - 1 >= NROWS || y - 1 < 0)
+    if (x - 1 >= NCOLS || x - 1 < 0 || y - 1 >= NROWS || y - 1 < 0) {
+      // useful for future dev in plan
+      // msg << "--(x,y) = (" << x << "," << y << ")\n"
+      //     << "--NCOLS = " << NCOLS << "\n"
+      //     << "--NROWS = " << NROWS << "\n";
+      // g_log.warning() << msg.str();
       return EMPTY_INT();
+    }
+
     std::string bankName = comp->getName();
     auto it = pixel_to_wi.find(findPixelID(bankName, x, y));
     if (it == pixel_to_wi.end())

--- a/docs/source/algorithms/MaskPeaksWorkspace-v1.rst
+++ b/docs/source/algorithms/MaskPeaksWorkspace-v1.rst
@@ -10,9 +10,12 @@ Description
 -----------
 
 Mask pixels in an Workspace close to peak positions from a
-PeaksWorkspace. Peaks could come from ISAW diamond stripping routine for
-SNAP data. Only works on Workspaces and for instruments with
-RectangularDetector's.
+PeaksWorkspace.
+Peaks could come from ISAW diamond stripping routine for
+SNAP data.
+This algorithm was originally developed for instruments with
+RectangularDetector's, but is now adapted to work for tube type
+detector of the two instruments (WISH and CORELLI).
 
 Usage
 -----
@@ -33,6 +36,11 @@ Usage
     #This will mask out the data in the event workspace relating to the peaks
     MaskPeaksWorkspace(ws,wsPeaks)
 
+Note
+-----
+
+Running the algorithm will trigger a deprecation warning regarding the `SpectraList`.
+This is a known issue and will be addressed at a later date.
 
 .. categories::
 

--- a/docs/source/release/v6.2.0/diffraction.rst
+++ b/docs/source/release/v6.2.0/diffraction.rst
@@ -38,6 +38,7 @@ Improvements
 ############
 - Find detector in peaks will check which det is closer when dealing with peak-in-gap situation for tube-type detectors.
 - Existing :ref:`SCDCalibratePanels <algm-SCDCalibratePanels-v2>` now provides better calibration of panel orientation for flat panel detectors.
+- Existing :ref:`MaskPeaksWorkspace <algm-MaskPeaksWorkspace-v1>` now also supports tube-type detectors used at the CORELLI instrument.
 
 Bugfixes
 ########


### PR DESCRIPTION
**Description of work.**

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

- Original Gitlab Defect: [SCD337](https://code.ornl.gov/sns-hfir-scse/diffraction/single-crystal/single-crystal-diffraction/-/issues/337)
- This is #31791  into `master`

Algorithm `MaksPeaksWorkspace` was originally developed to work for rectangular detectors only, which was later adapted to work for data from WISH as well.
This PR enables this algorithms for CORELLI, which is an instrument similar to WISH but with a slightly different hierarchical structure of sub-components.

**To test:**

Due to the large size of the testing data set, it is recommended to perform the following test on the analysis cluster at ORNL.

- Gain access to the testing data located at `/SNS/CORELLI/IPTS-26011/nexus/CORELLI_145931.nxs.h5`
- Load and process the raw data with the following script
```python
LoadEventNexus(Filename='/SNS/CORELLI/IPTS-26011/nexus/CORELLI_145931.nxs.h5', OutputWorkspace='145931')

ConvertToMD(InputWorkspace='145931', 
            QDimensions='Q3D', 
	    dEAnalysisMode='Elastic', 
            Q3DFrames='Q_lab', 
            LorentzCorrection=True, 
	    OutputWorkspace='145931_MD')

FindPeaksMD(InputWorkspace='145931_MD', 
            PeakDistanceThreshold=0.5, 
            DensityThresholdFactor=600, 
            OutputWorkspace='145931_MD_Peaks', 
            EdgePixels=3)
``` 
- Run the updated `MaskPeaksWorkspace` with the data using the script below
```python
MaskPeaksWorkspace(InputWorkspace='145931', 
                   InPeaksWorkspace='145931_MD_Peaks', 
                   XMin=-4, 
                   XMax=4, 
                   YMin=-4, 
                   YMax=4, 
                   TOFMin=0, 
                   TOFMax=300)
```

Except for a few deprecation warning regarding `SpectraList` (which will be addressed at a later time), the masking should finish without any error.

<!-- Instructions for testing. -->

<!-- and fix #xxxx or close #xxxx xor resolves #xxxx -->
<!-- alternative
*There is no associated issue.*
-->

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or master)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
