### PR TITLE
Add .gcov files to list of exclusions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -77,6 +77,9 @@ local.properties
 #Test results
 *.log
 
+#Coverage results
+*.gcov
+
 # Build results
 build/
 /[Rr]elease/


### PR DESCRIPTION
**Description of work.**
Exclude .gcov files which are generated alongside the *.cpp files when
building the coverage target.

**To test:**
- Touch a random file name with an extension ending *.gcov anywhere in the source directory
- `git status` should not show this

<!-- Instructions for testing. -->

There is no associated issue.

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or master)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
