### PR TITLE
Segmentation fault in reduction with logging redirection on Mantid 6.0

### DIFF
--- a/Framework/PythonInterface/CMakeLists.txt
+++ b/Framework/PythonInterface/CMakeLists.txt
@@ -7,7 +7,7 @@ if(CMAKE_COMPILER_IS_GNUCXX
    AND Boost_MINOR_VERSION GREATER "63"
    AND Boost_MINOR_VERSION LESS "66"
 )
-  # Several bugs in boost 1.64-1.65 prevent python modues from loading on gcc
+  # Several bugs in boost 1.64-1.65 prevent python modules from loading on gcc
   # without this definition:   https://github.com/boostorg/python/issues/131
   add_definitions(-DBOOST_PYTHON_USE_GCC_SYMBOL_VISIBILITY)
 endif()

--- a/Framework/PythonInterface/core/inc/MantidPythonInterface/core/PythonStdoutChannel.h
+++ b/Framework/PythonInterface/core/inc/MantidPythonInterface/core/PythonStdoutChannel.h
@@ -18,7 +18,9 @@
 #pragma once
 
 #include "MantidPythonInterface/core/DllConfig.h"
+#include "MantidPythonInterface/core/WrapPython.h"
 #include <Poco/ConsoleChannel.h>
+#include <iostream>
 
 namespace Poco {
 
@@ -27,4 +29,27 @@ public:
   /// Constructor for PythonStdoutChannel
   PythonStdoutChannel();
 };
+
+/// std::ostream that redirects to PySys_WriteStdout
+class MANTID_PYTHONINTERFACE_CORE_DLL PyOstream {
+public:
+  PyOstream() : m_ostream(new PyStdoutBuf){};
+  std::ostream m_ostream;
+
+private:
+  /// https://stackoverflow.com/questions/772355/how-to-inherit-from-stdostream
+  class PyStdoutBuf : public std::streambuf {
+  protected:
+    int overflow(int c) override {
+      PySys_WriteStdout("%c", c);
+      return 0;
+    }
+  };
+};
+
+class MANTID_PYTHONINTERFACE_CORE_DLL PyStdoutChannel : public PyOstream, public ConsoleChannel {
+public:
+  PyStdoutChannel();
+};
+
 } // namespace Poco

--- a/Framework/PythonInterface/core/inc/MantidPythonInterface/core/PythonStdoutChannel.h
+++ b/Framework/PythonInterface/core/inc/MantidPythonInterface/core/PythonStdoutChannel.h
@@ -33,11 +33,14 @@ public:
 /// std::ostream that redirects to PySys_WriteStdout
 class MANTID_PYTHONINTERFACE_CORE_DLL PyOstream {
 public:
-  PyOstream() : m_ostream(new PyStdoutBuf){};
+  PyOstream() : m_ostream(new PyStdoutBuf) {
+    m_ostream.setf(std::ios::unitbuf); // unbuffered output
+  }
   std::ostream m_ostream;
 
 private:
   /// https://stackoverflow.com/questions/772355/how-to-inherit-from-stdostream
+  /// Also much better implemented in pybind11::iostream::pythonbuff
   class PyStdoutBuf : public std::streambuf {
   protected:
     int overflow(int c) override {

--- a/Framework/PythonInterface/core/inc/MantidPythonInterface/core/PythonStdoutChannel.h
+++ b/Framework/PythonInterface/core/inc/MantidPythonInterface/core/PythonStdoutChannel.h
@@ -25,13 +25,14 @@
 // 3rd-party includes
 #include "MantidKernel/StdoutChannel.h"
 #include <Poco/ConsoleChannel.h>
-#include <pybind11/iostream.h>
+//#include <pybind11/iostream.h>
 
 // standard includes
 #include <iostream>
 
 namespace Poco {
 
+/* /// Store in case class PythonStdoutChannel is not up to the task and needs to be replace with this class
 class MANTID_PYTHONINTERFACE_CORE_DLL PyBindStdoutChannel : public StdoutChannel {
 
 public:
@@ -41,6 +42,7 @@ public:
 private:
   pybind11::scoped_ostream_redirect m_redirect;
 };
+*/
 
 class MANTID_PYTHONINTERFACE_CORE_DLL PythonStdoutChannel : public ConsoleChannel {
 public:
@@ -60,10 +62,10 @@ private:
   class PyStdoutBuf : public std::streambuf {
   protected:
     int overflow(int c) override {
-      Mantid::PythonInterface::GlobalInterpreterLock gil;
+      Mantid::PythonInterface::GlobalInterpreterLock gil; // acquire the GIL
       PySys_WriteStdout("%c", c);
       return 0;
-    }
+    } // release the GIL
   };
 };
 

--- a/Framework/PythonInterface/core/inc/MantidPythonInterface/core/PythonStdoutChannel.h
+++ b/Framework/PythonInterface/core/inc/MantidPythonInterface/core/PythonStdoutChannel.h
@@ -17,13 +17,30 @@
 
 #pragma once
 
+// local includes
 #include "MantidPythonInterface/core/DllConfig.h"
 #include "MantidPythonInterface/core/GlobalInterpreterLock.h"
 #include "MantidPythonInterface/core/WrapPython.h"
+
+// 3rd-party includes
+#include "MantidKernel/StdoutChannel.h"
 #include <Poco/ConsoleChannel.h>
+#include <pybind11/iostream.h>
+
+// standard includes
 #include <iostream>
 
 namespace Poco {
+
+class MANTID_PYTHONINTERFACE_CORE_DLL PyBindStdoutChannel : public StdoutChannel {
+
+public:
+  /// Constructor for PythonStdoutChannel
+  PyBindStdoutChannel() : StdoutChannel() {}
+
+private:
+  pybind11::scoped_ostream_redirect m_redirect;
+};
 
 class MANTID_PYTHONINTERFACE_CORE_DLL PythonStdoutChannel : public ConsoleChannel {
 public:

--- a/Framework/PythonInterface/core/inc/MantidPythonInterface/core/PythonStdoutChannel.h
+++ b/Framework/PythonInterface/core/inc/MantidPythonInterface/core/PythonStdoutChannel.h
@@ -37,7 +37,8 @@ public:
   PythonStdoutChannel();
 };
 
-/* /// Store in case class PythonStdoutChannel is not up to the task and needs to be replaced with this class
+/*
+// TODO: this channel should replace PythonStdoutChannel when we adopt pybind11 because of robust GIL management
 class MANTID_PYTHONINTERFACE_CORE_DLL PyBindStdoutChannel : public StdoutChannel {
 
 public:

--- a/Framework/PythonInterface/core/inc/MantidPythonInterface/core/PythonStdoutChannel.h
+++ b/Framework/PythonInterface/core/inc/MantidPythonInterface/core/PythonStdoutChannel.h
@@ -19,7 +19,6 @@
 
 // local includes
 #include "MantidPythonInterface/core/DllConfig.h"
-#include "MantidPythonInterface/core/GlobalInterpreterLock.h"
 #include "MantidPythonInterface/core/WrapPython.h"
 
 // 3rd-party includes

--- a/Framework/PythonInterface/core/inc/MantidPythonInterface/core/PythonStdoutChannel.h
+++ b/Framework/PythonInterface/core/inc/MantidPythonInterface/core/PythonStdoutChannel.h
@@ -18,6 +18,7 @@
 #pragma once
 
 #include "MantidPythonInterface/core/DllConfig.h"
+#include "MantidPythonInterface/core/GlobalInterpreterLock.h"
 #include "MantidPythonInterface/core/WrapPython.h"
 #include <Poco/ConsoleChannel.h>
 #include <iostream>
@@ -42,6 +43,7 @@ private:
   class PyStdoutBuf : public std::streambuf {
   protected:
     int overflow(int c) override {
+      Mantid::PythonInterface::GlobalInterpreterLock gil;
       PySys_WriteStdout("%c", c);
       return 0;
     }

--- a/Framework/PythonInterface/core/inc/MantidPythonInterface/core/PythonStdoutChannel.h
+++ b/Framework/PythonInterface/core/inc/MantidPythonInterface/core/PythonStdoutChannel.h
@@ -24,10 +24,6 @@
 // 3rd-party includes
 #include "MantidKernel/StdoutChannel.h"
 #include <Poco/ConsoleChannel.h>
-//#include <pybind11/iostream.h>
-
-// standard includes
-#include <iostream>
 
 namespace Poco {
 

--- a/Framework/PythonInterface/core/inc/MantidPythonInterface/core/PythonStdoutChannel.h
+++ b/Framework/PythonInterface/core/inc/MantidPythonInterface/core/PythonStdoutChannel.h
@@ -33,9 +33,7 @@ public:
 /// std::ostream that redirects to PySys_WriteStdout
 class MANTID_PYTHONINTERFACE_CORE_DLL PyOstream {
 public:
-  PyOstream() : m_ostream(new PyStdoutBuf) {
-    m_ostream.setf(std::ios::unitbuf); // unbuffered output
-  }
+  PyOstream() : m_ostream(new PyStdoutBuf) {}
   std::ostream m_ostream;
 
 private:

--- a/Framework/PythonInterface/core/inc/MantidPythonInterface/core/PythonStdoutChannel.h
+++ b/Framework/PythonInterface/core/inc/MantidPythonInterface/core/PythonStdoutChannel.h
@@ -32,7 +32,13 @@
 
 namespace Poco {
 
-/* /// Store in case class PythonStdoutChannel is not up to the task and needs to be replace with this class
+class MANTID_PYTHONINTERFACE_CORE_DLL PythonStdoutChannel : public ConsoleChannel {
+public:
+  /// Constructor for PythonStdoutChannel
+  PythonStdoutChannel();
+};
+
+/* /// Store in case class PythonStdoutChannel is not up to the task and needs to be replaced with this class
 class MANTID_PYTHONINTERFACE_CORE_DLL PyBindStdoutChannel : public StdoutChannel {
 
 public:
@@ -43,35 +49,5 @@ private:
   pybind11::scoped_ostream_redirect m_redirect;
 };
 */
-
-class MANTID_PYTHONINTERFACE_CORE_DLL PythonStdoutChannel : public ConsoleChannel {
-public:
-  /// Constructor for PythonStdoutChannel
-  PythonStdoutChannel();
-};
-
-/// std::ostream that redirects to PySys_WriteStdout
-class MANTID_PYTHONINTERFACE_CORE_DLL PyOstream {
-public:
-  PyOstream() : m_ostream(new PyStdoutBuf) {}
-  std::ostream m_ostream;
-
-private:
-  /// https://stackoverflow.com/questions/772355/how-to-inherit-from-stdostream
-  /// Also much better implemented in pybind11::iostream::pythonbuff
-  class PyStdoutBuf : public std::streambuf {
-  protected:
-    int overflow(int c) override {
-      Mantid::PythonInterface::GlobalInterpreterLock gil; // acquire the GIL
-      PySys_WriteStdout("%c", c);
-      return 0;
-    } // release the GIL
-  };
-};
-
-class MANTID_PYTHONINTERFACE_CORE_DLL PyStdoutChannel : public PyOstream, public ConsoleChannel {
-public:
-  PyStdoutChannel();
-};
 
 } // namespace Poco

--- a/Framework/PythonInterface/core/src/PythonStdoutChannel.cpp
+++ b/Framework/PythonInterface/core/src/PythonStdoutChannel.cpp
@@ -16,18 +16,16 @@
 namespace { // anonymous namespace
 
 // https://stackoverflow.com/questions/772355/how-to-inherit-from-stdostream
-class PyStdoutSink : private std::streambuf, public std::ostream {
-public:
-  PyStdoutSink() : std::ostream(this) {}
-
-private:
+class PyStdoutBuf : public std::streambuf {
+protected:
   int overflow(int c) override {
     PySys_WriteStdout("%c", c);
     return 0;
   }
 };
 
-PyStdoutSink pyOstream = PyStdoutSink();
+auto pyStreambuf = new PyStdoutBuf;
+auto pyOstream = std::ostream(pyStreambuf);
 } // anonymous namespace
 
 namespace Poco {

--- a/Framework/PythonInterface/core/src/PythonStdoutChannel.cpp
+++ b/Framework/PythonInterface/core/src/PythonStdoutChannel.cpp
@@ -21,6 +21,7 @@ public:
   typedef boost::iostreams::sink_tag category;
 
   std::streamsize write(const char *s, std::streamsize n) {
+    Mantid::PythonInterface::GlobalInterpreterLock gil; // acquire the GIL
     // PySys_WriteStdout truncates to 1000 chars
     static const std::streamsize MAXSIZE = 1000;
 
@@ -28,16 +29,16 @@ public:
     PySys_WriteStdout((boost::format("%%.%1%s") % written).str().c_str(), s);
 
     return written;
-  }
+  } // release the GIL
 };
 
 // wrapper of that sink to be a stream
 PyStdoutSink pyStdoutSinkInstance = PyStdoutSink(); // needs to be initialized separately
-boost::iostreams::stream<PyStdoutSink> PyStdout(pyStdoutSinkInstance);
+boost::iostreams::stream<PyStdoutSink> PyStdoutStream(pyStdoutSinkInstance);
 
 } // anonymous namespace
 
 namespace Poco {
-PythonStdoutChannel::PythonStdoutChannel() : ConsoleChannel(PyStdout) {}
+PythonStdoutChannel::PythonStdoutChannel() : ConsoleChannel(PyStdoutStream) {}
 PyStdoutChannel::PyStdoutChannel() : PyStdoutChannel::PyOstream(), ConsoleChannel(m_ostream) {}
 } // namespace Poco

--- a/Framework/PythonInterface/core/src/PythonStdoutChannel.cpp
+++ b/Framework/PythonInterface/core/src/PythonStdoutChannel.cpp
@@ -4,14 +4,18 @@
 //   NScD Oak Ridge National Laboratory, European Spallation Source,
 //   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
 // SPDX - License - Identifier: GPL - 3.0 +
+
+// local includes
 #include "MantidPythonInterface/core/PythonStdoutChannel.h"
+
+// 3rd-party includes
+#include "MantidPythonInterface/core/GlobalInterpreterLock.h"
 #include "MantidPythonInterface/core/WrapPython.h"
-
-#include <iostream> // streamsize
-
 #include <boost/format.hpp>
 #include <boost/iostreams/categories.hpp> // sink_tag
 #include <boost/iostreams/stream.hpp>
+
+#include <iostream> // streamsize
 
 namespace { // anonymous namespace
 

--- a/Framework/PythonInterface/core/src/PythonStdoutChannel.cpp
+++ b/Framework/PythonInterface/core/src/PythonStdoutChannel.cpp
@@ -40,5 +40,4 @@ boost::iostreams::stream<PyStdoutSink> PyStdoutStream(pyStdoutSinkInstance);
 
 namespace Poco {
 PythonStdoutChannel::PythonStdoutChannel() : ConsoleChannel(PyStdoutStream) {}
-PyStdoutChannel::PyStdoutChannel() : PyStdoutChannel::PyOstream(), ConsoleChannel(m_ostream) {}
 } // namespace Poco

--- a/Framework/PythonInterface/mantid/kernel/src/kernel.cpp.in
+++ b/Framework/PythonInterface/mantid/kernel/src/kernel.cpp.in
@@ -53,7 +53,8 @@ BOOST_PYTHON_MODULE(_kernel) {
     new Poco::Instantiator<Poco::PythonStdoutChannel, Poco::Channel>);
   Poco::LoggingFactory::defaultFactory().registerChannelClass(
       "PyStdoutChannel", new Poco::Instantiator<Poco::PyStdoutChannel, Poco::Channel>);
-
+  Poco::LoggingFactory::defaultFactory().registerChannelClass(
+      "PyBindStdoutChannel", new Poco::Instantiator<Poco::PyBindStdoutChannel, Poco::Channel>);
   def("version_str", &Mantid::Kernel::MantidVersion::version,
       "Returns the Mantid version string in the form \"major.minor.patch\"");
   def("release_notes_url", &Mantid::Kernel::MantidVersion::releaseNotes,

--- a/Framework/PythonInterface/mantid/kernel/src/kernel.cpp.in
+++ b/Framework/PythonInterface/mantid/kernel/src/kernel.cpp.in
@@ -51,9 +51,7 @@ BOOST_PYTHON_MODULE(_kernel) {
   Poco::LoggingFactory::defaultFactory().registerChannelClass(
     "PythonStdoutChannel",
     new Poco::Instantiator<Poco::PythonStdoutChannel, Poco::Channel>);
-  Poco::LoggingFactory::defaultFactory().registerChannelClass(
-      "PyStdoutChannel", new Poco::Instantiator<Poco::PyStdoutChannel, Poco::Channel>);
-  /* // Store in case class PythonStdoutChannel is not up to the task and needs to be replace with this class
+  /* // Store in case class PythonStdoutChannel is not up to the task and needs to be replaced with this class
   Poco::LoggingFactory::defaultFactory().registerChannelClass(
       "PyBindStdoutChannel", new Poco::Instantiator<Poco::PyBindStdoutChannel, Poco::Channel>);
       */

--- a/Framework/PythonInterface/mantid/kernel/src/kernel.cpp.in
+++ b/Framework/PythonInterface/mantid/kernel/src/kernel.cpp.in
@@ -53,8 +53,11 @@ BOOST_PYTHON_MODULE(_kernel) {
     new Poco::Instantiator<Poco::PythonStdoutChannel, Poco::Channel>);
   Poco::LoggingFactory::defaultFactory().registerChannelClass(
       "PyStdoutChannel", new Poco::Instantiator<Poco::PyStdoutChannel, Poco::Channel>);
+  /* // Store in case class PythonStdoutChannel is not up to the task and needs to be replace with this class
   Poco::LoggingFactory::defaultFactory().registerChannelClass(
       "PyBindStdoutChannel", new Poco::Instantiator<Poco::PyBindStdoutChannel, Poco::Channel>);
+      */
+
   def("version_str", &Mantid::Kernel::MantidVersion::version,
       "Returns the Mantid version string in the form \"major.minor.patch\"");
   def("release_notes_url", &Mantid::Kernel::MantidVersion::releaseNotes,

--- a/Framework/PythonInterface/mantid/kernel/src/kernel.cpp.in
+++ b/Framework/PythonInterface/mantid/kernel/src/kernel.cpp.in
@@ -51,6 +51,8 @@ BOOST_PYTHON_MODULE(_kernel) {
   Poco::LoggingFactory::defaultFactory().registerChannelClass(
     "PythonStdoutChannel",
     new Poco::Instantiator<Poco::PythonStdoutChannel, Poco::Channel>);
+  Poco::LoggingFactory::defaultFactory().registerChannelClass(
+      "PyStdoutChannel", new Poco::Instantiator<Poco::PyStdoutChannel, Poco::Channel>);
 
   def("version_str", &Mantid::Kernel::MantidVersion::version,
       "Returns the Mantid version string in the form \"major.minor.patch\"");

--- a/Framework/PythonInterface/mantid/kernel/src/kernel.cpp.in
+++ b/Framework/PythonInterface/mantid/kernel/src/kernel.cpp.in
@@ -51,10 +51,11 @@ BOOST_PYTHON_MODULE(_kernel) {
   Poco::LoggingFactory::defaultFactory().registerChannelClass(
     "PythonStdoutChannel",
     new Poco::Instantiator<Poco::PythonStdoutChannel, Poco::Channel>);
-  /* // Store in case class PythonStdoutChannel is not up to the task and needs to be replaced with this class
+  /*
+  // TODO: this channel should replace PythonStdoutChannel when we adopt pybind11 because of robust GIL  management
   Poco::LoggingFactory::defaultFactory().registerChannelClass(
       "PyBindStdoutChannel", new Poco::Instantiator<Poco::PyBindStdoutChannel, Poco::Channel>);
-      */
+  */
 
   def("version_str", &Mantid::Kernel::MantidVersion::version,
       "Returns the Mantid version string in the form \"major.minor.patch\"");

--- a/Framework/PythonInterface/test/cpp/CMakeLists.txt
+++ b/Framework/PythonInterface/test/cpp/CMakeLists.txt
@@ -5,6 +5,7 @@ set(TEST_FILES
     IPeakFunctionAdapterTest.h
     PropertyWithValueFactoryTest.h
     PythonAlgorithmInstantiatorTest.h
+    PythonStdoutChannelTest.h
     PySequenceToVectorTest.h
     RunPythonScriptTest.h
     ToPyListTest.h)

--- a/Framework/PythonInterface/test/cpp/PythonStdoutChannelTest.h
+++ b/Framework/PythonInterface/test/cpp/PythonStdoutChannelTest.h
@@ -14,10 +14,10 @@
 #include "MantidPythonInterface/core/GlobalInterpreterLock.h"
 #include <Poco/AutoPtr.h>
 #include <Poco/Logger.h>
+#include <boost/filesystem.hpp>
 #include <cxxtest/TestSuite.h>
 
 // standard
-#include <filesystem>
 #include <fstream>
 
 using Mantid::PythonInterface::GlobalInterpreterLock;
@@ -64,7 +64,7 @@ public:
     std::string script = "import sys\n"
                          "stdout_old = sys.stdout\n"                          // backup the standard file descriptor
                          "sys.stdout = open('TEMPFILE', 'w', buffering=1)\n"; // redirection, small buffe needed
-    auto tmpFilePath = std::filesystem::temp_directory_path() / "testPySysWriteStdout.txt";
+    auto tmpFilePath = boost::filesystem::temp_directory_path() / "testPySysWriteStdout.txt";
     replaceSubstring(script, "TEMPFILE", tmpFilePath.string());
     PyRun_SimpleString(script.c_str()); // execute the python script
 
@@ -84,7 +84,7 @@ public:
     std::getline(logFile, message);
     TS_ASSERT_EQUALS(message, loggedMessage)
     logFile.close();
-    std::filesystem::remove(tmpFilePath);
+    boost::filesystem::remove(tmpFilePath);
 
     // restore the channel
     Poco::Logger::root().setChannel(channelOld);

--- a/Framework/PythonInterface/test/cpp/PythonStdoutChannelTest.h
+++ b/Framework/PythonInterface/test/cpp/PythonStdoutChannelTest.h
@@ -21,8 +21,6 @@
 #include <fstream>
 
 using Mantid::PythonInterface::GlobalInterpreterLock;
-using Poco::PyBindStdoutChannel;
-using Poco::PyStdoutChannel;
 using Poco::PythonStdoutChannel;
 
 class PythonStdoutChannelTest : public CxxTest::TestSuite {
@@ -34,29 +32,9 @@ public:
 
   void testConstructor() { PythonStdoutChannel(); }
 
-  void testStream() {
-    // set the root logger's channel to a PyStdoutChannel
-    Poco::Channel *channelOld = Poco::Logger::root().getChannel();
-    Poco::AutoPtr<Poco::PyStdoutChannel> channelNew(new PyStdoutChannel);
-    Poco::Logger::root().setChannel(channelNew);
-
-    // substitute channel's stream buffer with the buffer of a string stream
-    std::stringstream recorder;
-    std::streambuf *bufferNew = recorder.rdbuf();
-    channelNew->m_ostream.rdbuf(bufferNew); // now channel will output to recorder's string object
-
-    // log a message with the root logger. It should be stored in recorder's string object
-    Mantid::Kernel::Logger log("");
-    log.error() << "Error Message\n";
-    TS_ASSERT_EQUALS(recorder.str(), "Error Message\n")
-
-    // restore the channel
-    Poco::Logger::root().setChannel(channelOld);
-  }
-
   /// write log message to a file via redirection of python sys.stdout
   void testPySysWriteStdout() {
-    // set the root logger's channel to a PyStdoutChannel
+    // set the root logger's channel to a PythonStdoutChannel
     Poco::Channel *channelOld = Poco::Logger::root().getChannel();
     Poco::AutoPtr<Poco::PythonStdoutChannel> channelNew(new PythonStdoutChannel);
     Poco::Logger::root().setChannel(channelNew);
@@ -69,10 +47,10 @@ public:
     replaceSubstring(script, "TEMPFILE", tmpFilePath.string());
     PyRun_SimpleString(script.c_str()); // execute the python script
 
-    // log a message with the root logger that now uses the PyStdoutChannel
+    // log a message with the root logger that now uses the PythonStdoutChannel
     Mantid::Kernel::Logger log("");
     std::string loggedMessage("Error Message");
-    log.error() << loggedMessage << "\n"; // log -> PySys_WriteStdout -> sys.stdout -> tmpFile
+    log.error() << loggedMessage << "\n";
 
     // Now reassign the standard file descriptor to sys.stdout
     std::string revert = "sys.stdout.close()\n"       // close tmpFile

--- a/Framework/PythonInterface/test/cpp/PythonStdoutChannelTest.h
+++ b/Framework/PythonInterface/test/cpp/PythonStdoutChannelTest.h
@@ -41,8 +41,8 @@ public:
 
     // redirect python's sys.stdout to a temporary file, using a python script
     std::string script = "import sys\n"
-                         "stdout_old = sys.stdout\n"                          // backup the standard file descriptor
-                         "sys.stdout = open('TEMPFILE', 'w', buffering=1)\n"; // redirection, small buffe needed
+                         "stdout_old = sys.stdout\n"                           // backup the standard file descriptor
+                         "sys.stdout = open(r'TEMPFILE', 'w', buffering=1)\n"; // redirection, small buffer needed
     auto tmpFilePath = boost::filesystem::temp_directory_path() / "testPySysWriteStdout.txt";
     replaceSubstring(script, "TEMPFILE", tmpFilePath.string());
     PyRun_SimpleString(script.c_str()); // execute the python script

--- a/Framework/PythonInterface/test/cpp/PythonStdoutChannelTest.h
+++ b/Framework/PythonInterface/test/cpp/PythonStdoutChannelTest.h
@@ -6,12 +6,18 @@
 // SPDX - License - Identifier: GPL - 3.0 +
 #pragma once
 
+// local
+#include "MantidPythonInterface/core/PythonStdoutChannel.h"
+
+// 3rd party
 #include "MantidKernel/Logger.h"
 #include "MantidPythonInterface/core/GlobalInterpreterLock.h"
-#include "MantidPythonInterface/core/PythonStdoutChannel.h"
 #include <Poco/AutoPtr.h>
 #include <Poco/Logger.h>
 #include <cxxtest/TestSuite.h>
+
+// standard
+#include <filesystem>
 #include <fstream>
 
 using Mantid::PythonInterface::GlobalInterpreterLock;
@@ -49,8 +55,6 @@ public:
 
   /// write log message to a file via redirection of python sys.stdout
   void testPySysWriteStdout() {
-    GlobalInterpreterLock gil; // acquire the GIL, then release it upon calling destructor ~GlobalInterpreterLock
-
     // set the root logger's channel to a PyStdoutChannel
     Poco::Channel *channelOld = Poco::Logger::root().getChannel();
     Poco::AutoPtr<Poco::PyStdoutChannel> channelNew(new PyStdoutChannel);
@@ -59,89 +63,32 @@ public:
     // redirect python's sys.stdout to a temporary file, using a python script
     std::string script = "import sys\n"
                          "stdout_old = sys.stdout\n"                          // backup the standard file descriptor
-                         "sys.stdout = open('TEMPFILE', 'w')\n"               // redirection statement
-                         "python_state = open('/tmp/python_state.txt','w')\n" // helper file to check some variables
-                         "python_state.write('1 stdout_old = ' + str(stdout_old) + ' ; ')\n"
-                         "python_state.write('2 sys.stdout = ' + str(sys.stdout) + ' ; ')\n";
-    const std::string tmpFile("/tmp/testPySysWriteStdout.txt"); // TODO: create a temporary file instead
-    replaceSubstring(script, "TEMPFILE", tmpFile);
+                         "sys.stdout = open('TEMPFILE', 'w', buffering=1)\n"; // redirection, small buffe needed
+    auto tmpFilePath = std::filesystem::temp_directory_path() / "testPySysWriteStdout.txt";
+    replaceSubstring(script, "TEMPFILE", tmpFilePath.string());
     PyRun_SimpleString(script.c_str()); // execute the python script
 
     // log a message with the root logger that now uses the PyStdoutChannel
     Mantid::Kernel::Logger log("");
-    std::string loggedMessage("Error Message\n");
-    log.error() << loggedMessage; // log -> PySys_WriteStdout -> sys.stdout -> tmpFile
-
-    // flush as many buffers I can think of!
-    log.flush();
-    channelNew->m_ostream.flush();
-    std::streambuf *pyBuf = channelNew->m_ostream.rdbuf();
-    pyBuf->pubsync(); // https://stackoverflow.com/questions/25833193/c-how-to-flush-stdstringbuf
+    std::string loggedMessage("Error Message");
+    log.error() << loggedMessage << "\n"; // log -> PySys_WriteStdout -> sys.stdout -> tmpFile
 
     // Now reassign the standard file descriptor to sys.stdout
-    std::string revert = "python_state.write('3 sys.stdout = ' + str(sys.stdout) + ' ; ')\n"
-                         "sys.stdout.flush()\n" // flushing as much as I can think of
-                         "sys.stdout.close()\n" // close tmpFile
-                         "python_state.write('4 sys.stdout closed? = ' + str(sys.stdout.closed) + ' ; ')\n"
-                         "sys.stdout = stdout_old\n" // reassign original file descriptor
-                         "python_state.write('5 sys.stdout = ' + str(sys.stdout) + ' ; ')\n"
-                         "python_state.close()";
+    std::string revert = "sys.stdout.close()\n"       // close tmpFile
+                         "sys.stdout = stdout_old\n"; // reassign original file descriptor
     PyRun_SimpleString(revert.c_str());
 
     // Fetch the log message from tmpFile
-    std::ifstream logFile(tmpFile);
-    logFile.open(tmpFile);
-    logFile.seekg(0, std::ios::beg);
+    std::ifstream logFile(tmpFilePath.string());
     std::string message;
-    // PROBLEM: at this point, /tmp/testPySysWriteStdout.txt exists but nothing has been yet written to it
     std::getline(logFile, message);
-    logFile.close();
     TS_ASSERT_EQUALS(message, loggedMessage)
+    logFile.close();
+    std::filesystem::remove(tmpFilePath);
 
     // restore the channel
     Poco::Logger::root().setChannel(channelOld);
     std::cout << "It is finished!\n";
-  } // PROBLEM: at this point, "Error Message\n" is written to /tmp/testPySysWriteStdout.txt !
-
-  void testPysys() {
-    // set the root logger's channel to a PyStdoutChannel
-    Poco::Channel *channelOld = Poco::Logger::root().getChannel();
-    Poco::AutoPtr<Poco::PyStdoutChannel> channelNew(new PyStdoutChannel);
-    Poco::Logger::root().setChannel(channelNew);
-
-    // https://stackoverflow.com/questions/4307187/how-to-catch-python-stdout-in-c-code
-    // redirect python's sys.stdout to the buffer of a string stream
-    std::string script = "import sys\n\
-     class CatchOut:\n\
-        def __init__(self):\n\
-           self.value = ''\n\
-        def write(self, txt):\n\
-           self.value += txt\n\
-     fisher = CatchOut()\n\
-     sys.stdout = fisher\n\
-     open('/tmp/junk.txt', 'w').write('hello')\n\
-    "; // python code that will record whatever is sent to sys.stdout into catchOut.value
-
-    Py_Initialize();
-    PyObject *pythonModule = PyImport_AddModule("__main__"); // create main module
-    PyRun_SimpleString(script.c_str());                      // invoke code to redirect
-    std::string scriptOther = "open('/tmp/junkOther.txt', 'w').write('hello')\n";
-    PyRun_SimpleString(scriptOther.c_str());
-    // log a message with the root logger. It should be stored in fisher.value
-    Mantid::Kernel::Logger log("");
-    log.error() << "Error Message\n";
-
-    // Retrieve the contents of fisher.value
-    PyObject *fisher = PyObject_GetAttrString(pythonModule, "fisher"); // get our fisher python object
-    PyErr_Print();                                                     // make python print any errors
-    PyObject *value = PyObject_GetAttrString(fisher, "value");
-    const char *cError = PyUnicode_AsUTF8(value);
-    Py_Finalize();
-
-    TS_ASSERT_EQUALS(cError, "Error Message\n")
-
-    // restore the channel
-    Poco::Logger::root().setChannel(channelOld);
   }
 
 private:

--- a/Framework/PythonInterface/test/cpp/PythonStdoutChannelTest.h
+++ b/Framework/PythonInterface/test/cpp/PythonStdoutChannelTest.h
@@ -11,7 +11,6 @@
 
 // 3rd party
 #include "MantidKernel/Logger.h"
-#include "MantidPythonInterface/core/GlobalInterpreterLock.h"
 #include <Poco/AutoPtr.h>
 #include <Poco/Logger.h>
 #include <boost/filesystem.hpp>
@@ -20,7 +19,6 @@
 // standard
 #include <fstream>
 
-using Mantid::PythonInterface::GlobalInterpreterLock;
 using Poco::PythonStdoutChannel;
 
 class PythonStdoutChannelTest : public CxxTest::TestSuite {

--- a/Framework/PythonInterface/test/cpp/PythonStdoutChannelTest.h
+++ b/Framework/PythonInterface/test/cpp/PythonStdoutChannelTest.h
@@ -86,9 +86,7 @@ public:
     logFile.close();
     boost::filesystem::remove(tmpFilePath);
 
-    // restore the channel
-    Poco::Logger::root().setChannel(channelOld);
-    std::cout << "It is finished!\n";
+    Poco::Logger::root().setChannel(channelOld); // restore the channel
   }
 
 private:

--- a/Framework/PythonInterface/test/cpp/PythonStdoutChannelTest.h
+++ b/Framework/PythonInterface/test/cpp/PythonStdoutChannelTest.h
@@ -21,6 +21,7 @@
 #include <fstream>
 
 using Mantid::PythonInterface::GlobalInterpreterLock;
+using Poco::PyBindStdoutChannel;
 using Poco::PyStdoutChannel;
 using Poco::PythonStdoutChannel;
 
@@ -32,6 +33,7 @@ public:
   static void destroySuite(PythonStdoutChannelTest *suite) { delete suite; }
 
   void testConstructor() { PyStdoutChannel(); }
+  void testConstructor2() { PyBindStdoutChannel(); }
 
   void testStream() {
     // set the root logger's channel to a PyStdoutChannel
@@ -85,6 +87,42 @@ public:
     TS_ASSERT_EQUALS(message, loggedMessage)
     logFile.close();
     boost::filesystem::remove(tmpFilePath);
+
+    Poco::Logger::root().setChannel(channelOld); // restore the channel
+  }
+
+  /// write log message to a file via redirection of python sys.stdout
+  void testPySysWriteStdout2() {
+    // set the root logger's channel to a PyStdoutChannel
+    Poco::Channel *channelOld = Poco::Logger::root().getChannel();
+    Poco::AutoPtr<Poco::PyBindStdoutChannel> channelNew(new PyBindStdoutChannel);
+    Poco::Logger::root().setChannel(channelNew);
+
+    // redirect python's sys.stdout to a temporary file, using a python script
+    std::string script = "import sys\n"
+                         "stdout_old = sys.stdout\n"                          // backup the standard file descriptor
+                         "sys.stdout = open('TEMPFILE', 'w', buffering=1)\n"; // redirection, small buffe needed
+    auto tmpFilePath = boost::filesystem::temp_directory_path() / "testPySysWriteStdout.txt";
+    replaceSubstring(script, "TEMPFILE", tmpFilePath.string());
+    PyRun_SimpleString(script.c_str()); // execute the python script
+
+    // log a message with the root logger that now uses the PyStdoutChannel
+    Mantid::Kernel::Logger log("");
+    std::string loggedMessage("Error Message");
+    log.error() << loggedMessage << "\n"; // log -> PySys_WriteStdout -> sys.stdout -> tmpFile
+
+    // Now reassign the standard file descriptor to sys.stdout
+    std::string revert = "sys.stdout.close()\n"       // close tmpFile
+                         "sys.stdout = stdout_old\n"; // reassign original file descriptor
+    PyRun_SimpleString(revert.c_str());
+
+    // Fetch the log message from tmpFile
+    std::ifstream logFile(tmpFilePath.string());
+    std::string message;
+    std::getline(logFile, message);
+    TS_ASSERT_EQUALS(message, loggedMessage)
+    logFile.close();
+    // boost::filesystem::remove(tmpFilePath);
 
     Poco::Logger::root().setChannel(channelOld); // restore the channel
   }

--- a/Framework/PythonInterface/test/cpp/PythonStdoutChannelTest.h
+++ b/Framework/PythonInterface/test/cpp/PythonStdoutChannelTest.h
@@ -1,0 +1,155 @@
+// Mantid Repository : https://github.com/mantidproject/mantid
+//
+// Copyright &copy; 2018 ISIS Rutherford Appleton Laboratory UKRI,
+//   NScD Oak Ridge National Laboratory, European Spallation Source,
+//   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+// SPDX - License - Identifier: GPL - 3.0 +
+#pragma once
+
+#include "MantidKernel/Logger.h"
+#include "MantidPythonInterface/core/GlobalInterpreterLock.h"
+#include "MantidPythonInterface/core/PythonStdoutChannel.h"
+#include <Poco/AutoPtr.h>
+#include <Poco/Logger.h>
+#include <cxxtest/TestSuite.h>
+#include <fstream>
+
+using Mantid::PythonInterface::GlobalInterpreterLock;
+using Poco::PyStdoutChannel;
+using Poco::PythonStdoutChannel;
+
+class PythonStdoutChannelTest : public CxxTest::TestSuite {
+public:
+  // This pair of boilerplate methods prevent the suite being created statically
+  // This means the constructor isn't called when running other tests
+  static PythonStdoutChannelTest *createSuite() { return new PythonStdoutChannelTest(); }
+  static void destroySuite(PythonStdoutChannelTest *suite) { delete suite; }
+
+  void testConstructor() { PyStdoutChannel(); }
+
+  void testStream() {
+    // set the root logger's channel to a PyStdoutChannel
+    Poco::Channel *channelOld = Poco::Logger::root().getChannel();
+    Poco::AutoPtr<Poco::PyStdoutChannel> channelNew(new PyStdoutChannel);
+    Poco::Logger::root().setChannel(channelNew);
+
+    // substitute channel's stream buffer with the buffer of a string stream
+    std::stringstream recorder;
+    std::streambuf *bufferNew = recorder.rdbuf();
+    channelNew->m_ostream.rdbuf(bufferNew); // now channel will output to recorder's string object
+
+    // log a message with the root logger. It should be stored in recorder's string object
+    Mantid::Kernel::Logger log("");
+    log.error() << "Error Message\n";
+    TS_ASSERT_EQUALS(recorder.str(), "Error Message\n")
+
+    // restore the channel
+    Poco::Logger::root().setChannel(channelOld);
+  }
+
+  /// write log message to a file via redirection of python sys.stdout
+  void testPySysWriteStdout() {
+    GlobalInterpreterLock gil; // acquire the GIL, then release it upon calling destructor ~GlobalInterpreterLock
+
+    // set the root logger's channel to a PyStdoutChannel
+    Poco::Channel *channelOld = Poco::Logger::root().getChannel();
+    Poco::AutoPtr<Poco::PyStdoutChannel> channelNew(new PyStdoutChannel);
+    Poco::Logger::root().setChannel(channelNew);
+
+    // redirect python's sys.stdout to a temporary file, using a python script
+    std::string script = "import sys\n"
+                         "stdout_old = sys.stdout\n"                          // backup the standard file descriptor
+                         "sys.stdout = open('TEMPFILE', 'w')\n"               // redirection statement
+                         "python_state = open('/tmp/python_state.txt','w')\n" // helper file to check some variables
+                         "python_state.write('1 stdout_old = ' + str(stdout_old) + ' ; ')\n"
+                         "python_state.write('2 sys.stdout = ' + str(sys.stdout) + ' ; ')\n";
+    const std::string tmpFile("/tmp/testPySysWriteStdout.txt"); // TODO: create a temporary file instead
+    replaceSubstring(script, "TEMPFILE", tmpFile);
+    PyRun_SimpleString(script.c_str()); // execute the python script
+
+    // log a message with the root logger that now uses the PyStdoutChannel
+    Mantid::Kernel::Logger log("");
+    std::string loggedMessage("Error Message\n");
+    log.error() << loggedMessage; // log -> PySys_WriteStdout -> sys.stdout -> tmpFile
+
+    // flush as many buffers I can think of!
+    log.flush();
+    channelNew->m_ostream.flush();
+    std::streambuf *pyBuf = channelNew->m_ostream.rdbuf();
+    pyBuf->pubsync(); // https://stackoverflow.com/questions/25833193/c-how-to-flush-stdstringbuf
+
+    // Now reassign the standard file descriptor to sys.stdout
+    std::string revert = "python_state.write('3 sys.stdout = ' + str(sys.stdout) + ' ; ')\n"
+                         "sys.stdout.flush()\n" // flushing as much as I can think of
+                         "sys.stdout.close()\n" // close tmpFile
+                         "python_state.write('4 sys.stdout closed? = ' + str(sys.stdout.closed) + ' ; ')\n"
+                         "sys.stdout = stdout_old\n" // reassign original file descriptor
+                         "python_state.write('5 sys.stdout = ' + str(sys.stdout) + ' ; ')\n"
+                         "python_state.close()";
+    PyRun_SimpleString(revert.c_str());
+
+    // Fetch the log message from tmpFile
+    std::ifstream logFile(tmpFile);
+    logFile.open(tmpFile);
+    logFile.seekg(0, std::ios::beg);
+    std::string message;
+    // PROBLEM: at this point, /tmp/testPySysWriteStdout.txt exists but nothing has been yet written to it
+    std::getline(logFile, message);
+    logFile.close();
+    TS_ASSERT_EQUALS(message, loggedMessage)
+
+    // restore the channel
+    Poco::Logger::root().setChannel(channelOld);
+    std::cout << "It is finished!\n";
+  } // PROBLEM: at this point, "Error Message\n" is written to /tmp/testPySysWriteStdout.txt !
+
+  void testPysys() {
+    // set the root logger's channel to a PyStdoutChannel
+    Poco::Channel *channelOld = Poco::Logger::root().getChannel();
+    Poco::AutoPtr<Poco::PyStdoutChannel> channelNew(new PyStdoutChannel);
+    Poco::Logger::root().setChannel(channelNew);
+
+    // https://stackoverflow.com/questions/4307187/how-to-catch-python-stdout-in-c-code
+    // redirect python's sys.stdout to the buffer of a string stream
+    std::string script = "import sys\n\
+     class CatchOut:\n\
+        def __init__(self):\n\
+           self.value = ''\n\
+        def write(self, txt):\n\
+           self.value += txt\n\
+     fisher = CatchOut()\n\
+     sys.stdout = fisher\n\
+     open('/tmp/junk.txt', 'w').write('hello')\n\
+    "; // python code that will record whatever is sent to sys.stdout into catchOut.value
+
+    Py_Initialize();
+    PyObject *pythonModule = PyImport_AddModule("__main__"); // create main module
+    PyRun_SimpleString(script.c_str());                      // invoke code to redirect
+    std::string scriptOther = "open('/tmp/junkOther.txt', 'w').write('hello')\n";
+    PyRun_SimpleString(scriptOther.c_str());
+    // log a message with the root logger. It should be stored in fisher.value
+    Mantid::Kernel::Logger log("");
+    log.error() << "Error Message\n";
+
+    // Retrieve the contents of fisher.value
+    PyObject *fisher = PyObject_GetAttrString(pythonModule, "fisher"); // get our fisher python object
+    PyErr_Print();                                                     // make python print any errors
+    PyObject *value = PyObject_GetAttrString(fisher, "value");
+    const char *cError = PyUnicode_AsUTF8(value);
+    Py_Finalize();
+
+    TS_ASSERT_EQUALS(cError, "Error Message\n")
+
+    // restore the channel
+    Poco::Logger::root().setChannel(channelOld);
+  }
+
+private:
+  bool replaceSubstring(std::string &templatedString, const std::string &target, const std::string &replacement) {
+    size_t start_pos = templatedString.find(target);
+    if (start_pos == std::string::npos)
+      return false;
+    templatedString.replace(start_pos, target.length(), replacement);
+    return true;
+  }
+};


### PR DESCRIPTION
Companion to PR #31861  
**Description of issue**  
See [SANS771](https://code.ornl.gov/sns-hfir-scse/sans/sans-backend/-/issues/771)

**Description of work.**  
- [x] Acquire GIL for the `PythonStdoutChannel` class
- [x] unit test
- [x] No release notes necessary because these changes don't change the public API

**To test:**
open the workbench and run the script(s) of your choice, inserting the following lines at the very beginning:
```python
from mantid.kernel import ConfigService
ConfigService.setString('logging.channels.consoleChannel.class', 'PythonStdoutChannel')
```
The script(s) should run as usual

*There is no associated issue.*

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
