### PR TITLE
Don't save empty Engineering Diffraction GUI after close

### DIFF
--- a/docs/source/release/v6.2.0/diffraction.rst
+++ b/docs/source/release/v6.2.0/diffraction.rst
@@ -34,6 +34,7 @@ Improvements
 Bugfixes
 ########
 - Sequential fitting in the EngDiff UI now uses the output of the last successful fit (as opposed to the previous fit) as the initial parameters for the next fit.
+- An empty Engineering Diffraction interface is no longer saved if the user saves a project having previously had the interface open at some point in that session
 
 
 Single Crystal Diffraction

--- a/scripts/Engineering/gui/engineering_diffraction/engineering_diffraction.py
+++ b/scripts/Engineering/gui/engineering_diffraction/engineering_diffraction.py
@@ -33,6 +33,7 @@ class EngineeringDiffractionGui(QtWidgets.QMainWindow, Ui_main_window):
         self.setupUi(self)
         self.tabs = self.tab_main
         self.setFocusPolicy(QtCore.Qt.StrongFocus)
+        self.setAttribute(QtCore.Qt.WA_DeleteOnClose)
 
         self.btn_settings.setIcon(get_icon("mdi.settings", "black", 1.2))
 


### PR DESCRIPTION
**Description of work.**
Previously, if the user had opened and closed the Engineering Diffraction GUI, and then saved a project in the same session, the GUI would be saved as part of that project and subsequently reopened when the project was loaded. This PR adds the DeleteOnClose attribute to the GUI to avoid this problem.

**To test:**
1. Open up the engineering diffraction gui, and save a project with it open
2. Close it then save another project
3. Load the first project, make sure it loads
4. Load the second project, make sure it does not

Fixes #31653 . <!-- and fix #xxxx or close #xxxx xor resolves #xxxx -->
<!-- alternative
*There is no associated issue.*
-->


<!-- Ensure the base of this PR is correct (e.g. release-next or master)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
