### PR TITLE
Fix Ipython errors

### DIFF
--- a/qt/python/mantidqt/utils/asynchronous.py
+++ b/qt/python/mantidqt/utils/asynchronous.py
@@ -137,7 +137,7 @@ class BlockingAsyncTaskWithCallback(AsyncTask):
         self.success_cb = create_callback(success_cb)
         self.error_cb = create_callback(error_cb)
 
-        self.recv = _Receiver(success_cb=self.success_cb, error_cb=self.error_cb)
+        self.recv = _Receiver(success_cb=success_cb, error_cb=error_cb)
         self.task = AsyncTask(target, args, kwargs, success_cb=self.recv.on_success, error_cb=self.recv.on_error)
 
     def start(self):


### PR DESCRIPTION
**Description of work.**
This PR fixes some errors occuring when using IPython to `import numpy` or other python operations such as `a=3`. The problem was introduced in #31587 .

**To test:**
Open Ipython and try import numpy and other python operations.

<!-- Instructions for testing. -->

*There is no associated issue.*

*This does not require release notes* because **it is a regression since the last release.**

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
