### PR TITLE
Prevent duplicate spectra in Indirect F(Q)Fit Multiple Table

### DIFF
--- a/docs/source/release/v6.2.0/indirect_geometry.rst
+++ b/docs/source/release/v6.2.0/indirect_geometry.rst
@@ -5,6 +5,10 @@ Indirect Geometry Changes
 .. contents:: Table of Contents
    :local:
 
+Bug Fixes
+#########
+- A bug has been fixed in Indirect data analysis on the F(Q)Fit tab, Multiple Input tab that allowed duplicate spectra to be added.
+
 .. warning:: **Developers:** Sort changes under appropriate heading
     putting new features at the top of the section, followed by
     improvements, followed by bug fixes.

--- a/qt/scientific_interfaces/Indirect/FqFitDataPresenter.cpp
+++ b/qt/scientific_interfaces/Indirect/FqFitDataPresenter.cpp
@@ -35,7 +35,7 @@ FqFitDataPresenter::FqFitDataPresenter(FqFitModel *model, IIndirectFitDataView *
   showParameterComboBoxes();
 }
 
-void FqFitDataPresenter::handleSampleLoaded(const QString &workspaceName, FqFitParameters parameters) {
+void FqFitDataPresenter::handleSampleLoaded(const QString &workspaceName, FqFitParameters &parameters) {
   setModelWorkspace(workspaceName);
   updateAvailableParameterTypes(parameters);
   updateAvailableParameters(parameters);
@@ -78,11 +78,11 @@ void FqFitDataPresenter::updateActiveDataIndex() { m_dataIndex = m_fqFitModel->g
 
 void FqFitDataPresenter::updateActiveDataIndex(int index) { m_dataIndex = index; }
 
-void FqFitDataPresenter::updateAvailableParameters(FqFitParameters parameters) {
+void FqFitDataPresenter::updateAvailableParameters(FqFitParameters &parameters) {
   updateAvailableParameters(m_cbParameterType->currentText(), parameters);
 }
 
-void FqFitDataPresenter::updateAvailableParameters(const QString &type, FqFitParameters parameters) {
+void FqFitDataPresenter::updateAvailableParameters(const QString &type, FqFitParameters &parameters) {
   if (type == "Width")
     setAvailableParameters(parameters.widths);
   else if (type == "EISF")
@@ -94,7 +94,7 @@ void FqFitDataPresenter::updateAvailableParameters(const QString &type, FqFitPar
     setSingleModelSpectrum(m_cbParameter->currentIndex());
 }
 
-void FqFitDataPresenter::updateAvailableParameterTypes(FqFitParameters parameters) {
+void FqFitDataPresenter::updateAvailableParameterTypes(FqFitParameters &parameters) {
   MantidQt::API::SignalBlocker blocker(m_cbParameterType);
   m_cbParameterType->clear();
   for (const auto &type : getParameterTypes(parameters))
@@ -117,7 +117,7 @@ void FqFitDataPresenter::setAvailableParameters(const std::vector<std::string> &
 
 void FqFitDataPresenter::setParameterLabel(const QString &parameter) { m_lbParameter->setText(parameter + ":"); }
 
-void FqFitDataPresenter::handleParameterTypeChanged(const QString &parameter, FqFitParameters parameter1) {
+void FqFitDataPresenter::handleParameterTypeChanged(const QString &parameter, FqFitParameters &parameter1) {
   m_lbParameter->setText(parameter + ":");
   updateAvailableParameters(parameter, parameter1);
   emit dataChanged();
@@ -157,12 +157,12 @@ void FqFitDataPresenter::updateParameterOptions(FqFitAddWorkspaceDialog *dialog,
     dialog->setParameterNames({});
 }
 
-void FqFitDataPresenter::updateParameterTypes(FqFitAddWorkspaceDialog *dialog, FqFitParameters parameters) {
+void FqFitDataPresenter::updateParameterTypes(FqFitAddWorkspaceDialog *dialog, FqFitParameters &parameters) {
   setDataIndexToCurrentWorkspace(dialog);
   dialog->setParameterTypes(getParameterTypes(parameters));
 }
 
-std::vector<std::string> FqFitDataPresenter::getParameterTypes(FqFitParameters parameters) const {
+std::vector<std::string> FqFitDataPresenter::getParameterTypes(FqFitParameters &parameters) const {
   std::vector<std::string> types;
   if (!parameters.widths.empty())
     types.emplace_back("Width");

--- a/qt/scientific_interfaces/Indirect/FqFitDataPresenter.cpp
+++ b/qt/scientific_interfaces/Indirect/FqFitDataPresenter.cpp
@@ -36,8 +36,8 @@ FqFitDataPresenter::FqFitDataPresenter(FqFitModel *model, IIndirectFitDataView *
 }
 
 void FqFitDataPresenter::handleSampleLoaded(const QString &workspaceName) {
-  const auto workspaceName1 = workspaceName.toStdString();
-  auto workspace = Mantid::API::AnalysisDataService::Instance().retrieveWS<MatrixWorkspace>(workspaceName1);
+  auto workspace =
+      Mantid::API::AnalysisDataService::Instance().retrieveWS<MatrixWorkspace>(workspaceName.toStdString());
   auto parameters = m_fqFitModel->createFqFitParameters(workspace.get());
   setModelWorkspace(workspaceName);
   updateAvailableParameterTypes(parameters);
@@ -126,11 +126,11 @@ void FqFitDataPresenter::handleParameterTypeChanged(const QString &parameter) {
   m_notifier.notify([&dataType](IFQFitObserver &obs) { obs.updateAvailableFunctions(availableFits.at(dataType)); });
 }
 
-void FqFitDataPresenter::setDialogParameterNames(FqFitAddWorkspaceDialog *dialog, const std::string &workspace) {
+void FqFitDataPresenter::setDialogParameterNames(FqFitAddWorkspaceDialog *dialog, const std::string &workspaceName) {
   FqFitParameters parameters;
   try {
-    auto workspace1 = Mantid::API::AnalysisDataService::Instance().retrieveWS<MatrixWorkspace>(workspace);
-    parameters = m_fqFitModel->createFqFitParameters(workspace1.get());
+    auto workspace = Mantid::API::AnalysisDataService::Instance().retrieveWS<MatrixWorkspace>(workspaceName);
+    parameters = m_fqFitModel->createFqFitParameters(workspace.get());
     dialog->enableParameterSelection();
   } catch (const std::invalid_argument &) {
     dialog->disableParameterSelection();

--- a/qt/scientific_interfaces/Indirect/FqFitDataPresenter.cpp
+++ b/qt/scientific_interfaces/Indirect/FqFitDataPresenter.cpp
@@ -183,7 +183,7 @@ void FqFitDataPresenter::addDataToModel(IAddWorkspaceDialog const *dialog) {
     setDataIndexToCurrentWorkspace(fqFitDialog);
     // here we can say that we are in multiple mode so we can append the spectra
     // to the current one and then setspectra
-    // setModelSpectrum(fqFitDialog->parameterNameIndex());
+    setModelSpectrum(fqFitDialog->parameterNameIndex());
     updateActiveDataIndex();
   }
 }

--- a/qt/scientific_interfaces/Indirect/FqFitDataPresenter.cpp
+++ b/qt/scientific_interfaces/Indirect/FqFitDataPresenter.cpp
@@ -183,7 +183,7 @@ void FqFitDataPresenter::addDataToModel(IAddWorkspaceDialog const *dialog) {
     setDataIndexToCurrentWorkspace(fqFitDialog);
     // here we can say that we are in multiple mode so we can append the spectra
     // to the current one and then setspectra
-    setModelSpectrum(fqFitDialog->parameterNameIndex());
+    // setModelSpectrum(fqFitDialog->parameterNameIndex());
     updateActiveDataIndex();
   }
 }

--- a/qt/scientific_interfaces/Indirect/FqFitDataPresenter.cpp
+++ b/qt/scientific_interfaces/Indirect/FqFitDataPresenter.cpp
@@ -26,7 +26,7 @@ FqFitDataPresenter::FqFitDataPresenter(FqFitModel *model, IIndirectFitDataView *
   connect(this, SIGNAL(requestedAddWorkspaceDialog()), this, SLOT(updateActiveDataIndex()));
 
   connect(cbParameterType, SIGNAL(currentIndexChanged(const QString &)), this,
-          SLOT(handleParameterTypeChanged(const QString &, FqFitParameters parameter)));
+          SLOT(handleParameterTypeChanged(const QString &)));
   connect(cbParameter, SIGNAL(currentIndexChanged(int)), this, SLOT(handleSpectrumSelectionChanged(int)));
 
   updateParameterSelectionEnabled();
@@ -41,7 +41,7 @@ void FqFitDataPresenter::handleSampleLoaded(const QString &workspaceName) {
   auto parameters = m_fqFitModel->createFqFitParameters(workspace.get());
   setModelWorkspace(workspaceName);
   updateAvailableParameterTypes(parameters);
-  updateAvailableParameters(parameters);
+  updateAvailableParameters();
   updateParameterSelectionEnabled();
   setModelSpectrum(0);
   emit dataChanged();
@@ -81,15 +81,13 @@ void FqFitDataPresenter::updateActiveDataIndex() { m_dataIndex = m_fqFitModel->g
 
 void FqFitDataPresenter::updateActiveDataIndex(int index) { m_dataIndex = index; }
 
-void FqFitDataPresenter::updateAvailableParameters(FqFitParameters &parameters) {
-  updateAvailableParameters(m_cbParameterType->currentText(), parameters);
-}
+void FqFitDataPresenter::updateAvailableParameters() { updateAvailableParameters(m_cbParameterType->currentText()); }
 
-void FqFitDataPresenter::updateAvailableParameters(const QString &type, FqFitParameters &parameters) {
+void FqFitDataPresenter::updateAvailableParameters(const QString &type) {
   if (type == "Width")
-    setAvailableParameters(parameters.widths);
+    setAvailableParameters(m_fqFitModel->getWidths(TableDatasetIndex{0}));
   else if (type == "EISF")
-    setAvailableParameters(parameters.eisf);
+    setAvailableParameters(m_fqFitModel->getEISF(TableDatasetIndex{0}));
   else
     setAvailableParameters({});
 
@@ -120,9 +118,9 @@ void FqFitDataPresenter::setAvailableParameters(const std::vector<std::string> &
 
 void FqFitDataPresenter::setParameterLabel(const QString &parameter) { m_lbParameter->setText(parameter + ":"); }
 
-void FqFitDataPresenter::handleParameterTypeChanged(const QString &parameter, FqFitParameters &parameter1) {
+void FqFitDataPresenter::handleParameterTypeChanged(const QString &parameter) {
   m_lbParameter->setText(parameter + ":");
-  updateAvailableParameters(parameter, parameter1);
+  updateAvailableParameters(parameter);
   emit dataChanged();
   auto dataType = parameter == QString("Width") ? DataType::WIDTH : DataType::EISF;
   m_notifier.notify([&dataType](IFQFitObserver &obs) { obs.updateAvailableFunctions(availableFits.at(dataType)); });

--- a/qt/scientific_interfaces/Indirect/FqFitDataPresenter.cpp
+++ b/qt/scientific_interfaces/Indirect/FqFitDataPresenter.cpp
@@ -35,7 +35,10 @@ FqFitDataPresenter::FqFitDataPresenter(FqFitModel *model, IIndirectFitDataView *
   showParameterComboBoxes();
 }
 
-void FqFitDataPresenter::handleSampleLoaded(const QString &workspaceName, FqFitParameters &parameters) {
+void FqFitDataPresenter::handleSampleLoaded(const QString &workspaceName) {
+  const auto workspaceName1 = workspaceName.toStdString();
+  auto workspace = Mantid::API::AnalysisDataService::Instance().retrieveWS<MatrixWorkspace>(workspaceName1);
+  auto parameters = m_fqFitModel->createFqFitParameters(workspace.get());
   setModelWorkspace(workspaceName);
   updateAvailableParameterTypes(parameters);
   updateAvailableParameters(parameters);

--- a/qt/scientific_interfaces/Indirect/FqFitDataPresenter.h
+++ b/qt/scientific_interfaces/Indirect/FqFitDataPresenter.h
@@ -30,9 +30,12 @@ public:
 private slots:
   void hideParameterComboBoxes();
   void showParameterComboBoxes();
-  void updateAvailableParameters(FqFitParameters &parameters);
+  /* void updateAvailableParameters(FqFitParameters &parameters);
+   void updateAvailableParameters(const QString &type, FqFitParameters &parameters);*/
+  void updateAvailableParameters();
+  void updateAvailableParameters(const QString &type);
+  // void updateAvailableParameterTypes();
   void updateAvailableParameterTypes(FqFitParameters &parameters);
-  void updateAvailableParameters(const QString &type, FqFitParameters &parameters);
   void updateParameterSelectionEnabled();
   void setParameterLabel(const QString &parameter);
   void dialogParameterTypeUpdated(FqFitAddWorkspaceDialog *dialog, const std::string &type);
@@ -41,7 +44,8 @@ private slots:
   void updateActiveDataIndex();
   void updateActiveDataIndex(int index);
   void setSingleModelSpectrum(int index);
-  void handleParameterTypeChanged(const QString &parameter, FqFitParameters &parameter1);
+  /* void handleParameterTypeChanged(const QString &parameter, FqFitParameters &parameter1);*/
+  void handleParameterTypeChanged(const QString &parameter);
   void handleSpectrumSelectionChanged(int parameterIndex);
   void handleMultipleInputSelected();
   void handleSingleInputSelected();

--- a/qt/scientific_interfaces/Indirect/FqFitDataPresenter.h
+++ b/qt/scientific_interfaces/Indirect/FqFitDataPresenter.h
@@ -30,9 +30,9 @@ public:
 private slots:
   void hideParameterComboBoxes();
   void showParameterComboBoxes();
-  void updateAvailableParameters(FqFitParameters parameters);
-  void updateAvailableParameterTypes(FqFitParameters parameters);
-  void updateAvailableParameters(const QString &type, FqFitParameters parameters);
+  void updateAvailableParameters(FqFitParameters &parameters);
+  void updateAvailableParameterTypes(FqFitParameters &parameters);
+  void updateAvailableParameters(const QString &type, FqFitParameters &parameters);
   void updateParameterSelectionEnabled();
   void setParameterLabel(const QString &parameter);
   void dialogParameterTypeUpdated(FqFitAddWorkspaceDialog *dialog, const std::string &type);
@@ -41,7 +41,7 @@ private slots:
   void updateActiveDataIndex();
   void updateActiveDataIndex(int index);
   void setSingleModelSpectrum(int index);
-  void handleParameterTypeChanged(const QString &parameter, FqFitParameters parameter1);
+  void handleParameterTypeChanged(const QString &parameter, FqFitParameters &parameter1);
   void handleSpectrumSelectionChanged(int parameterIndex);
   void handleMultipleInputSelected();
   void handleSingleInputSelected();
@@ -50,7 +50,7 @@ signals:
   void spectrumChanged(WorkspaceIndex);
 
 protected slots:
-  void handleSampleLoaded(const QString &, FqFitParameters parameters);
+  void handleSampleLoaded(const QString &, FqFitParameters &parameters);
 
 private:
   void setAvailableParameters(const std::vector<std::string> &parameters);
@@ -58,8 +58,8 @@ private:
   void closeDialog() override;
   std::unique_ptr<IAddWorkspaceDialog> getAddWorkspaceDialog(QWidget *parent) const override;
   void updateParameterOptions(FqFitAddWorkspaceDialog *dialog, FqFitParameters parameters);
-  void updateParameterTypes(FqFitAddWorkspaceDialog *dialog, FqFitParameters parameters);
-  std::vector<std::string> getParameterTypes(FqFitParameters parameters) const;
+  void updateParameterTypes(FqFitAddWorkspaceDialog *dialog, FqFitParameters &parameters);
+  std::vector<std::string> getParameterTypes(FqFitParameters &parameters) const;
   void addWorkspace(IndirectFittingModel *model, const std::string &name);
   void setModelSpectrum(int index);
   void setDataIndexToCurrentWorkspace(IAddWorkspaceDialog const *dialog);

--- a/qt/scientific_interfaces/Indirect/FqFitDataPresenter.h
+++ b/qt/scientific_interfaces/Indirect/FqFitDataPresenter.h
@@ -54,7 +54,7 @@ protected slots:
 
 private:
   void setAvailableParameters(const std::vector<std::string> &parameters);
-  void addDataToModel(IAddWorkspaceDialog const *dialog);
+  void addDataToModel(IAddWorkspaceDialog const *dialog) override;
   void closeDialog() override;
   std::unique_ptr<IAddWorkspaceDialog> getAddWorkspaceDialog(QWidget *parent) const override;
   void updateParameterOptions(FqFitAddWorkspaceDialog *dialog, FqFitParameters parameters);

--- a/qt/scientific_interfaces/Indirect/FqFitDataPresenter.h
+++ b/qt/scientific_interfaces/Indirect/FqFitDataPresenter.h
@@ -30,9 +30,9 @@ public:
 private slots:
   void hideParameterComboBoxes();
   void showParameterComboBoxes();
-  void updateAvailableParameters();
-  void updateAvailableParameterTypes();
-  void updateAvailableParameters(const QString &type);
+  void updateAvailableParameters(FqFitParameters parameters);
+  void updateAvailableParameterTypes(FqFitParameters parameters);
+  void updateAvailableParameters(const QString &type, FqFitParameters parameters);
   void updateParameterSelectionEnabled();
   void setParameterLabel(const QString &parameter);
   void dialogParameterTypeUpdated(FqFitAddWorkspaceDialog *dialog, const std::string &type);
@@ -41,7 +41,7 @@ private slots:
   void updateActiveDataIndex();
   void updateActiveDataIndex(int index);
   void setSingleModelSpectrum(int index);
-  void handleParameterTypeChanged(const QString &parameter);
+  void handleParameterTypeChanged(const QString &parameter, FqFitParameters parameter1);
   void handleSpectrumSelectionChanged(int parameterIndex);
   void handleMultipleInputSelected();
   void handleSingleInputSelected();
@@ -50,16 +50,16 @@ signals:
   void spectrumChanged(WorkspaceIndex);
 
 protected slots:
-  void handleSampleLoaded(const QString &) override;
+  void handleSampleLoaded(const QString &, FqFitParameters parameters);
 
 private:
   void setAvailableParameters(const std::vector<std::string> &parameters);
-  void addDataToModel(IAddWorkspaceDialog const *dialog) override;
+  void addDataToModel(IAddWorkspaceDialog const *dialog);
   void closeDialog() override;
   std::unique_ptr<IAddWorkspaceDialog> getAddWorkspaceDialog(QWidget *parent) const override;
-  void updateParameterOptions(FqFitAddWorkspaceDialog *dialog);
-  void updateParameterTypes(FqFitAddWorkspaceDialog *dialog);
-  std::vector<std::string> getParameterTypes(TableDatasetIndex dataIndex) const;
+  void updateParameterOptions(FqFitAddWorkspaceDialog *dialog, FqFitParameters parameters);
+  void updateParameterTypes(FqFitAddWorkspaceDialog *dialog, FqFitParameters parameters);
+  std::vector<std::string> getParameterTypes(FqFitParameters parameters) const;
   void addWorkspace(IndirectFittingModel *model, const std::string &name);
   void setModelSpectrum(int index);
   void setDataIndexToCurrentWorkspace(IAddWorkspaceDialog const *dialog);

--- a/qt/scientific_interfaces/Indirect/FqFitDataPresenter.h
+++ b/qt/scientific_interfaces/Indirect/FqFitDataPresenter.h
@@ -30,11 +30,8 @@ public:
 private slots:
   void hideParameterComboBoxes();
   void showParameterComboBoxes();
-  /* void updateAvailableParameters(FqFitParameters &parameters);
-   void updateAvailableParameters(const QString &type, FqFitParameters &parameters);*/
   void updateAvailableParameters();
   void updateAvailableParameters(const QString &type);
-  // void updateAvailableParameterTypes();
   void updateAvailableParameterTypes(FqFitParameters &parameters);
   void updateParameterSelectionEnabled();
   void setParameterLabel(const QString &parameter);
@@ -44,7 +41,6 @@ private slots:
   void updateActiveDataIndex();
   void updateActiveDataIndex(int index);
   void setSingleModelSpectrum(int index);
-  /* void handleParameterTypeChanged(const QString &parameter, FqFitParameters &parameter1);*/
   void handleParameterTypeChanged(const QString &parameter);
   void handleSpectrumSelectionChanged(int parameterIndex);
   void handleMultipleInputSelected();

--- a/qt/scientific_interfaces/Indirect/FqFitDataPresenter.h
+++ b/qt/scientific_interfaces/Indirect/FqFitDataPresenter.h
@@ -50,7 +50,7 @@ signals:
   void spectrumChanged(WorkspaceIndex);
 
 protected slots:
-  void handleSampleLoaded(const QString &, FqFitParameters &parameters);
+  void handleSampleLoaded(const QString &) override;
 
 private:
   void setAvailableParameters(const std::vector<std::string> &parameters);

--- a/qt/scientific_interfaces/Indirect/FqFitModel.cpp
+++ b/qt/scientific_interfaces/Indirect/FqFitModel.cpp
@@ -317,6 +317,20 @@ bool FqFitModel::isMultiFit() const {
   return !allWorkspacesEqual(getWorkspace(TableDatasetIndex{0}));
 }
 
+std::vector<std::string> FqFitModel::getWidths(TableDatasetIndex dataIndex) const {
+  const auto parameters = findFqFitParameters(dataIndex);
+  if (parameters != m_fqFitParameters.end())
+    return parameters->second.widths;
+  return std::vector<std::string>();
+}
+
+std::vector<std::string> FqFitModel::getEISF(TableDatasetIndex dataIndex) const {
+  const auto parameters = findFqFitParameters(dataIndex);
+  if (parameters != m_fqFitParameters.end())
+    return parameters->second.eisf;
+  return std::vector<std::string>();
+}
+
 boost::optional<std::size_t> FqFitModel::getWidthSpectrum(std::size_t widthIndex, TableDatasetIndex dataIndex) const {
   const auto parameters = findFqFitParameters(dataIndex);
   if (parameters != m_fqFitParameters.end() && parameters->second.widthSpectra.size() > widthIndex)

--- a/qt/scientific_interfaces/Indirect/FqFitModel.cpp
+++ b/qt/scientific_interfaces/Indirect/FqFitModel.cpp
@@ -208,7 +208,7 @@ void FqFitModel::addWorkspace(const std::string &workspaceName, const int &spect
     throw std::invalid_argument("Workspace contains only one data point.");
 
   const auto hwhmWorkspace = createHWHMWorkspace(workspace, name, single_spectra);
-  IndirectFittingModel::addWorkspace(hwhmWorkspace->getName(), FunctionModelSpectra(spectra));
+  IndirectFittingModel::addWorkspace(hwhmWorkspace->getName(), FunctionModelSpectra(""));
 }
 
 void FqFitModel::removeWorkspace(TableDatasetIndex index) {
@@ -301,18 +301,6 @@ bool FqFitModel::isMultiFit() const {
   if (getNumberOfWorkspaces() == TableDatasetIndex{0})
     return false;
   return !allWorkspacesEqual(getWorkspace(TableDatasetIndex{0}));
-}
-
-std::vector<std::string> FqFitModel::getWidths(FqFitParameters parameters) const {
-  if (!parameters.widths.empty())
-    return parameters.widths;
-  return std::vector<std::string>();
-}
-
-std::vector<std::string> FqFitModel::getEISF(FqFitParameters parameters) const {
-  if (!parameters.eisf.empty())
-    return parameters.eisf;
-  return std::vector<std::string>();
 }
 
 boost::optional<std::size_t> FqFitModel::getWidthSpectrum(std::size_t widthIndex, TableDatasetIndex dataIndex) const {

--- a/qt/scientific_interfaces/Indirect/FqFitModel.cpp
+++ b/qt/scientific_interfaces/Indirect/FqFitModel.cpp
@@ -199,7 +199,6 @@ void FqFitModel::addWorkspace(const std::string &workspaceName, const int &spect
   const auto name = getHWHMName(workspace->getName());
   const auto parameters = addFqFitParameters(workspace.get(), name);
   const auto spectrum = getSpectrum(parameters);
-  // std::string spectra = std::to_string(parameters.widthSpectra[spectrum_index]);
   const std::vector<std::size_t> single_spectra = {parameters.widthSpectra[spectrum_index]};
   if (!spectrum)
     throw std::invalid_argument("Workspace contains no Width or EISF spectra.");
@@ -208,6 +207,21 @@ void FqFitModel::addWorkspace(const std::string &workspaceName, const int &spect
     throw std::invalid_argument("Workspace contains only one data point.");
 
   const auto hwhmWorkspace = createHWHMWorkspace(workspace, name, single_spectra);
+  IndirectFittingModel::addWorkspace(hwhmWorkspace->getName(), FunctionModelSpectra(""));
+}
+
+void FqFitModel::addWorkspace(const std::string &workspaceName) {
+  auto workspace = Mantid::API::AnalysisDataService::Instance().retrieveWS<MatrixWorkspace>(workspaceName);
+  const auto name = getHWHMName(workspace->getName());
+  const auto parameters = addFqFitParameters(workspace.get(), name);
+  const auto spectrum = getSpectrum(parameters);
+  if (!spectrum)
+    throw std::invalid_argument("Workspace contains no Width or EISF spectra.");
+
+  if (workspace->y(0).size() == 1)
+    throw std::invalid_argument("Workspace contains only one data point.");
+
+  const auto hwhmWorkspace = createHWHMWorkspace(workspace, name, parameters.widthSpectra);
   IndirectFittingModel::addWorkspace(hwhmWorkspace->getName(), FunctionModelSpectra(""));
 }
 

--- a/qt/scientific_interfaces/Indirect/FqFitModel.cpp
+++ b/qt/scientific_interfaces/Indirect/FqFitModel.cpp
@@ -282,8 +282,8 @@ void FqFitModel::setActiveEISF(std::size_t eisfIndex, TableDatasetIndex dataInde
              // existing spectra list.
       auto spectra_vec = std::vector<std::size_t>({eisfSpectra[eisfIndex]});
       auto spectra = getSpectra(dataIndex);
-      for (size_t i = 0; i < spectra.size().value; i++) {
-        spectra_vec.push_back(spectra[i].value);
+      for (auto i : spectra) {
+        spectra_vec.push_back(i.value);
       }
       setSpectra(createSpectra(spectra_vec), dataIndex);
     }

--- a/qt/scientific_interfaces/Indirect/FqFitModel.cpp
+++ b/qt/scientific_interfaces/Indirect/FqFitModel.cpp
@@ -199,7 +199,7 @@ void FqFitModel::addWorkspace(const std::string &workspaceName, const int &spect
   const auto name = getHWHMName(workspace->getName());
   const auto parameters = addFqFitParameters(workspace.get(), name);
   const auto spectrum = getSpectrum(parameters);
-  std::string spectra = std::to_string(parameters.widthSpectra[spectrum_index]);
+  // std::string spectra = std::to_string(parameters.widthSpectra[spectrum_index]);
   const std::vector<std::size_t> single_spectra = {parameters.widthSpectra[spectrum_index]};
   if (!spectrum)
     throw std::invalid_argument("Workspace contains no Width or EISF spectra.");

--- a/qt/scientific_interfaces/Indirect/FqFitModel.h
+++ b/qt/scientific_interfaces/Indirect/FqFitModel.h
@@ -24,6 +24,7 @@ public:
   FqFitModel();
   using IndirectFittingModel::addWorkspace;
   void addWorkspace(const std::string &workspaceName, const int &spectrum_index);
+  void addWorkspace(const std::string &workspaceName) override;
   void removeWorkspace(TableDatasetIndex index) override;
   bool isMultiFit() const override;
 

--- a/qt/scientific_interfaces/Indirect/FqFitModel.h
+++ b/qt/scientific_interfaces/Indirect/FqFitModel.h
@@ -26,10 +26,12 @@ public:
   void addWorkspace(const std::string &workspaceName, const int &spectrum_index);
   void addWorkspace(const std::string &workspaceName) override;
   void removeWorkspace(TableDatasetIndex index) override;
+
   bool isMultiFit() const override;
 
   std::string getFitParameterName(TableDatasetIndex dataIndex, WorkspaceIndex spectrum) const;
-
+  std::vector<std::string> getWidths(TableDatasetIndex dataIndex) const;
+  std::vector<std::string> getEISF(TableDatasetIndex dataIndex) const;
   boost::optional<std::size_t> getWidthSpectrum(std::size_t widthIndex, TableDatasetIndex dataIndex) const;
   boost::optional<std::size_t> getEISFSpectrum(std::size_t eisfIndex, TableDatasetIndex dataIndex) const;
   void setActiveWidth(std::size_t widthIndex, TableDatasetIndex dataIndex, bool single = true);

--- a/qt/scientific_interfaces/Indirect/FqFitModel.h
+++ b/qt/scientific_interfaces/Indirect/FqFitModel.h
@@ -23,13 +23,15 @@ class MANTIDQT_INDIRECT_DLL FqFitModel : public IndirectFittingModel {
 public:
   FqFitModel();
   using IndirectFittingModel::addWorkspace;
-
   void addWorkspace(const std::string &workspaceName, const int &spectrum_index);
   void removeWorkspace(TableDatasetIndex index) override;
-
   bool isMultiFit() const override;
 
   std::string getFitParameterName(TableDatasetIndex dataIndex, WorkspaceIndex spectrum) const;
+
+  std::vector<std::string> getWidths(FqFitParameters parameters) const;
+  std::vector<std::string> getEISF(FqFitParameters parameters) const;
+
   boost::optional<std::size_t> getWidthSpectrum(std::size_t widthIndex, TableDatasetIndex dataIndex) const;
   boost::optional<std::size_t> getEISFSpectrum(std::size_t eisfIndex, TableDatasetIndex dataIndex) const;
   void setActiveWidth(std::size_t widthIndex, TableDatasetIndex dataIndex, bool single = true);

--- a/qt/scientific_interfaces/Indirect/FqFitModel.h
+++ b/qt/scientific_interfaces/Indirect/FqFitModel.h
@@ -24,21 +24,17 @@ public:
   FqFitModel();
   using IndirectFittingModel::addWorkspace;
 
-  void addWorkspace(const std::string &workspaceName) override;
+  void addWorkspace(const std::string &workspaceName, const int &spectrum_index);
   void removeWorkspace(TableDatasetIndex index) override;
-
-  bool zeroWidths(TableDatasetIndex dataIndex) const;
-  bool zeroEISF(TableDatasetIndex dataIndex) const;
 
   bool isMultiFit() const override;
 
   std::string getFitParameterName(TableDatasetIndex dataIndex, WorkspaceIndex spectrum) const;
-  std::vector<std::string> getWidths(TableDatasetIndex dataIndex) const;
-  std::vector<std::string> getEISF(TableDatasetIndex dataIndex) const;
   boost::optional<std::size_t> getWidthSpectrum(std::size_t widthIndex, TableDatasetIndex dataIndex) const;
   boost::optional<std::size_t> getEISFSpectrum(std::size_t eisfIndex, TableDatasetIndex dataIndex) const;
   void setActiveWidth(std::size_t widthIndex, TableDatasetIndex dataIndex, bool single = true);
   void setActiveEISF(std::size_t eisfIndex, TableDatasetIndex dataIndex, bool single = true);
+  FqFitParameters createFqFitParameters(Mantid::API::MatrixWorkspace *workspace);
 
 private:
   bool allWorkspacesEqual(const Mantid::API::MatrixWorkspace_sptr &workspace) const;

--- a/qt/scientific_interfaces/Indirect/FqFitModel.h
+++ b/qt/scientific_interfaces/Indirect/FqFitModel.h
@@ -29,9 +29,6 @@ public:
 
   std::string getFitParameterName(TableDatasetIndex dataIndex, WorkspaceIndex spectrum) const;
 
-  std::vector<std::string> getWidths(FqFitParameters parameters) const;
-  std::vector<std::string> getEISF(FqFitParameters parameters) const;
-
   boost::optional<std::size_t> getWidthSpectrum(std::size_t widthIndex, TableDatasetIndex dataIndex) const;
   boost::optional<std::size_t> getEISFSpectrum(std::size_t eisfIndex, TableDatasetIndex dataIndex) const;
   void setActiveWidth(std::size_t widthIndex, TableDatasetIndex dataIndex, bool single = true);

--- a/qt/scientific_interfaces/Indirect/test/FqFitModelTest.h
+++ b/qt/scientific_interfaces/Indirect/test/FqFitModelTest.h
@@ -64,36 +64,6 @@ public:
     TS_ASSERT_EQUALS(m_model->getNumberOfWorkspaces(), TableDatasetIndex{0});
   }
 
-  void test_that_zeroWidths_returns_false_if_the_workspace_contains_widths() {
-    addWorkspacesToModel(m_workspace);
-    TS_ASSERT(!m_model->zeroWidths(TableDatasetIndex{0}));
-  }
-
-  void test_that_zeroWidths_returns_true_if_the_workspace_contains_no_widths() {
-    auto const workspace2 = createWorkspaceWithTextAxis(2, getNoWidthLabels());
-    m_ads->addOrReplace("Name2", workspace2);
-    addWorkspacesToModel(m_workspace);
-
-    TS_ASSERT_THROWS(addWorkspacesToModel(workspace2), std::invalid_argument const &);
-    TS_ASSERT(m_model->zeroWidths(TableDatasetIndex{1}));
-    TS_ASSERT(m_model->getWidths(TableDatasetIndex{1}).empty());
-    TS_ASSERT(!m_model->getWidthSpectrum(0, TableDatasetIndex{1}));
-  }
-
-  void test_that_zeroEISF_returns_false_if_the_workspace_contains_EISFs() {
-    addWorkspacesToModel(m_workspace);
-    TS_ASSERT(!m_model->zeroEISF(TableDatasetIndex{0}));
-  }
-
-  void test_that_zeroEISF_returns_true_if_the_workspace_contains_no_EISFs() {
-    auto const workspace2 = createWorkspaceWithTextAxis(2, getNoEISFLabels());
-    m_ads->addOrReplace("Name2", workspace2);
-
-    addWorkspacesToModel(m_workspace, workspace2);
-
-    TS_ASSERT(m_model->zeroEISF(TableDatasetIndex{1}));
-  }
-
   void test_that_isMultiFit_returns_false_if_the_model_contains_one_workspace() {
     addWorkspacesToModel(m_workspace);
     TS_ASSERT(!m_model->isMultiFit());
@@ -121,29 +91,6 @@ public:
     TS_ASSERT_EQUALS(
         m_model->getFitParameterName(TableDatasetIndex{0}, MantidQt::CustomInterfaces::IDA::WorkspaceIndex{2}),
         "f1.FWHM");
-  }
-
-  void test_that_getWidths_will_return_the_width_parameter_names() {
-    addWorkspacesToModel(m_workspace);
-
-    TS_ASSERT_EQUALS(m_model->getWidths(TableDatasetIndex{0})[0], "f1.Width");
-    TS_ASSERT_EQUALS(m_model->getWidths(TableDatasetIndex{0})[1], "f1.FWHM");
-  }
-
-  void test_that_getEISF_will_return_an_empty_vector_if_there_are_no_EISFs() {
-    auto const workspace2 = createWorkspaceWithTextAxis(2, getNoEISFLabels());
-    m_ads->addOrReplace("Name2", workspace2);
-
-    addWorkspacesToModel(m_workspace, workspace2);
-
-    TS_ASSERT(m_model->getEISF(TableDatasetIndex{1}).empty());
-  }
-
-  void test_that_getEISF_will_return_the_EISF_parameter_names() {
-    addWorkspacesToModel(m_workspace);
-
-    TS_ASSERT_EQUALS(m_model->getEISF(TableDatasetIndex{0})[0], "f0.EISF");
-    TS_ASSERT_EQUALS(m_model->getEISF(TableDatasetIndex{0})[1], "f1.EISF");
   }
 
   void test_that_getWidthSpectrum_will_return_the_width_spectrum_number() {

--- a/qt/scientific_interfaces/Indirect/test/FqFitModelTest.h
+++ b/qt/scientific_interfaces/Indirect/test/FqFitModelTest.h
@@ -23,8 +23,6 @@ namespace {
 
 std::vector<std::string> getParameterLabels() { return {"f0.EISF", "f1.Width", "f1.FWHM", "f1.EISF"}; }
 
-std::vector<std::string> getNoWidthLabels() { return {"f0.EISF", "f1.EISF"}; }
-
 std::vector<std::string> getNoEISFLabels() { return {"f1.Width", "f1.FWHM"}; }
 
 } // namespace

--- a/qt/scientific_interfaces/Indirect/test/FqFitModelTest.h
+++ b/qt/scientific_interfaces/Indirect/test/FqFitModelTest.h
@@ -93,13 +93,14 @@ public:
         "f1.FWHM");
   }
 
-  void test_that_getWidth_will_return_an_empty_vector_if_there_are_no_Widths() {
+  void test_that_zeroWidths_returns_true_if_the_workspace_contains_no_widths() {
     auto const workspace2 = createWorkspaceWithTextAxis(2, getNoWidthLabels());
     m_ads->addOrReplace("Name2", workspace2);
+    addWorkspacesToModel(m_workspace);
 
-    addWorkspacesToModel(m_workspace, workspace2);
-
+    TS_ASSERT_THROWS(addWorkspacesToModel(workspace2), std::invalid_argument const &);
     TS_ASSERT(m_model->getWidths(TableDatasetIndex{1}).empty());
+    TS_ASSERT(!m_model->getWidthSpectrum(0, TableDatasetIndex{1}));
   }
 
   void test_that_getWidths_will_return_the_width_parameter_names() {

--- a/qt/scientific_interfaces/Indirect/test/FqFitModelTest.h
+++ b/qt/scientific_interfaces/Indirect/test/FqFitModelTest.h
@@ -23,6 +23,8 @@ namespace {
 
 std::vector<std::string> getParameterLabels() { return {"f0.EISF", "f1.Width", "f1.FWHM", "f1.EISF"}; }
 
+std::vector<std::string> getNoWidthLabels() { return {"f0.EISF", "f1.EISF"}; }
+
 std::vector<std::string> getNoEISFLabels() { return {"f1.Width", "f1.FWHM"}; }
 
 } // namespace
@@ -91,11 +93,29 @@ public:
         "f1.FWHM");
   }
 
+  void test_that_getWidth_will_return_an_empty_vector_if_there_are_no_Widths() {
+    auto const workspace2 = createWorkspaceWithTextAxis(2, getNoWidthLabels());
+    m_ads->addOrReplace("Name2", workspace2);
+
+    addWorkspacesToModel(m_workspace, workspace2);
+
+    TS_ASSERT(m_model->getWidths(TableDatasetIndex{1}).empty());
+  }
+
   void test_that_getWidths_will_return_the_width_parameter_names() {
     addWorkspacesToModel(m_workspace);
 
     TS_ASSERT_EQUALS(m_model->getWidths(TableDatasetIndex{0})[0], "f1.Width");
     TS_ASSERT_EQUALS(m_model->getWidths(TableDatasetIndex{0})[1], "f1.FWHM");
+  }
+
+  void test_that_getEISF_will_return_an_empty_vector_if_there_are_no_EISFs() {
+    auto const workspace2 = createWorkspaceWithTextAxis(2, getNoEISFLabels());
+    m_ads->addOrReplace("Name2", workspace2);
+
+    addWorkspacesToModel(m_workspace, workspace2);
+
+    TS_ASSERT(m_model->getEISF(TableDatasetIndex{1}).empty());
   }
 
   void test_that_getEISF_will_return_the_EISF_parameter_names() {

--- a/qt/scientific_interfaces/Indirect/test/FqFitModelTest.h
+++ b/qt/scientific_interfaces/Indirect/test/FqFitModelTest.h
@@ -93,6 +93,20 @@ public:
         "f1.FWHM");
   }
 
+  void test_that_getWidths_will_return_the_width_parameter_names() {
+    addWorkspacesToModel(m_workspace);
+
+    TS_ASSERT_EQUALS(m_model->getWidths(TableDatasetIndex{0})[0], "f1.Width");
+    TS_ASSERT_EQUALS(m_model->getWidths(TableDatasetIndex{0})[1], "f1.FWHM");
+  }
+
+  void test_that_getEISF_will_return_the_EISF_parameter_names() {
+    addWorkspacesToModel(m_workspace);
+
+    TS_ASSERT_EQUALS(m_model->getEISF(TableDatasetIndex{0})[0], "f0.EISF");
+    TS_ASSERT_EQUALS(m_model->getEISF(TableDatasetIndex{0})[1], "f1.EISF");
+  }
+
   void test_that_getWidthSpectrum_will_return_the_width_spectrum_number() {
     addWorkspacesToModel(m_workspace);
 


### PR DESCRIPTION
**Description of work.**
Code altered to prevent spectra duplicates in the F(Q)Fit Multiple Spectra Table. Removed obsolete methods and tests.

**To test:**

Test 1
1) Open Indirect Data Analysis
2) go to the F(Q) fit tab and switch to multiple input mode.
3) click add workspace, browse to a suitable file and open
4) Add different Width and EISF parameters to the table. Try adding ones that have already been added - should not duplicate them.

Test 2
1) Open Indirect Data Analysis
2) go to the F(Q) fit tab and stay on the single input tab
3) click on browse, find a suitable file and open
4) Check that the Fit Parameter and Width/EISF drop downs work.

Fixes #29244  

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
