### PR TITLE
SCDCalibratePanels2 allows small optimization results

### DIFF
--- a/Framework/Crystal/src/SCDCalibratePanels2.cpp
+++ b/Framework/Crystal/src/SCDCalibratePanels2.cpp
@@ -107,29 +107,22 @@ void SCDCalibratePanels2::init() {
   // ----- L1 -----
   // --------------
   declareProperty("CalibrateL1", true, "Change the L1(source to sample) distance");
-  declareProperty("ToleranceL1", 5e-4, mustBeNonNegative, "Delta L1 below this value (in meter) is treated as 0.0");
   declareProperty("SearchRadiusL1", 0.1, mustBeNonNegative,
                   "Search radius of delta L1 in meters, which is used to constrain optimization search space"
                   "when calibrating L1");
   // editability
-  setPropertySettings("ToleranceL1", std::make_unique<EnabledWhenProperty>("CalibrateL1", IS_EQUAL_TO, "1"));
   setPropertySettings("SearchRadiusL1", std::make_unique<EnabledWhenProperty>("CalibrateL1", IS_EQUAL_TO, "1"));
   // grouping
   setPropertyGroup("CalibrateL1", CALIBRATION);
-  setPropertyGroup("ToleranceL1", CALIBRATION);
   setPropertyGroup("SearchRadiusL1", CALIBRATION);
   // ----------------
   // ----- bank -----
   // ----------------
   declareProperty("CalibrateBanks", false, "Calibrate position and orientation of each bank.");
-  declareProperty("ToleranceTransBank", 1e-6, mustBeNonNegative,
-                  "Delta translation of bank (in meter) below this value is treated as 0.0");
   declareProperty(
       "SearchRadiusTransBank", 5e-2, mustBeNonNegative,
       "This is the search radius (in meter) when calibrating component translations, used to constrain optimization"
       "search space when calibration translation of banks");
-  declareProperty("ToleranceRotBank", 1e-3, mustBeNonNegative,
-                  "Misorientation of bank (in deg) below this value is treated as 0.0");
   declareProperty("SearchradiusRotXBank", 1.0, mustBeNonNegative,
                   "This is the search radius (in deg) when calibrating component reorientation, used to constrain "
                   "optimization search space");
@@ -140,10 +133,8 @@ void SCDCalibratePanels2::init() {
                   "This is the search radius (in deg) when calibrating component reorientation, used to constrain "
                   "optimization search space");
   // editability
-  setPropertySettings("ToleranceTransBank", std::make_unique<EnabledWhenProperty>("CalibrateBanks", IS_EQUAL_TO, "1"));
   setPropertySettings("SearchRadiusTransBank",
                       std::make_unique<EnabledWhenProperty>("CalibrateBanks", IS_EQUAL_TO, "1"));
-  setPropertySettings("ToleranceRotBank", std::make_unique<EnabledWhenProperty>("CalibrateBanks", IS_EQUAL_TO, "1"));
   setPropertySettings("SearchradiusRotXBank",
                       std::make_unique<EnabledWhenProperty>("CalibrateBanks", IS_EQUAL_TO, "1"));
   setPropertySettings("SearchradiusRotYBank",
@@ -152,9 +143,7 @@ void SCDCalibratePanels2::init() {
                       std::make_unique<EnabledWhenProperty>("CalibrateBanks", IS_EQUAL_TO, "1"));
   // grouping
   setPropertyGroup("CalibrateBanks", CALIBRATION);
-  setPropertyGroup("ToleranceTransBank", CALIBRATION);
   setPropertyGroup("SearchRadiusTransBank", CALIBRATION);
-  setPropertyGroup("ToleranceRotBank", CALIBRATION);
   setPropertyGroup("SearchradiusRotXBank", CALIBRATION);
   setPropertyGroup("SearchradiusRotYBank", CALIBRATION);
   setPropertyGroup("SearchradiusRotZBank", CALIBRATION);
@@ -162,33 +151,24 @@ void SCDCalibratePanels2::init() {
   // ----- T0 -----
   // --------------
   declareProperty("CalibrateT0", false, "Calibrate the T0 (initial TOF)");
-  declareProperty("ToleranceT0", 1e-3, mustBeNonNegative,
-                  "Shift of initial TOF (in ms) below this value is treated as 0.0");
   declareProperty("SearchRadiusT0", 10.0, mustBeNonNegative,
                   "Search radius of T0 (in ms), used to constrain optimization search space");
   // editability
-  setPropertySettings("ToleranceT0", std::make_unique<EnabledWhenProperty>("CalibrateT0", IS_EQUAL_TO, "1"));
   setPropertySettings("SearchRadiusT0", std::make_unique<EnabledWhenProperty>("CalibrateT0", IS_EQUAL_TO, "1"));
   // grouping
   setPropertyGroup("CalibrateT0", CALIBRATION);
-  setPropertyGroup("ToleranceT0", CALIBRATION);
   setPropertyGroup("SearchRadiusT0", CALIBRATION);
   // ---------------------
   // ----- samplePos -----
   // ---------------------
   declareProperty("TuneSamplePosition", false, "Fine tunning sample position");
-  declareProperty("ToleranceSamplePos", 1e-6, mustBeNonNegative,
-                  "Sample position change (in meter) below this value is treated as 0.0");
   declareProperty("SearchRadiusSamplePos", 0.1, mustBeNonNegative,
                   "Search radius of sample position change (in meters), used to constrain optimization search space");
   // editability
-  setPropertySettings("ToleranceSamplePos",
-                      std::make_unique<EnabledWhenProperty>("TuneSamplePosition", IS_EQUAL_TO, "1"));
   setPropertySettings("SearchRadiusSamplePos",
                       std::make_unique<EnabledWhenProperty>("TuneSamplePosition", IS_EQUAL_TO, "1"));
   // grouping
   setPropertyGroup("TuneSamplePosition", CALIBRATION);
-  setPropertyGroup("ToleranceSamplePos", CALIBRATION);
   setPropertyGroup("SearchRadiusSamplePos", CALIBRATION);
 
   // Output options group
@@ -465,7 +445,6 @@ void SCDCalibratePanels2::optimizeL1(IPeaksWorkspace_sptr pws, IPeaksWorkspace_s
   ITableWorkspace_sptr rst = fitL1_alg->getProperty("OutputParameters");
   // get results for L1
   double dL1_optimized = rst->getRef<double>("Value", 2);
-  double tor_dL1 = getProperty("ToleranceL1");
 
   // get results for T0 (optional)
   double dT0_optimized = rst->getRef<double>("Value", 6);

--- a/Framework/Crystal/src/SCDCalibratePanels2.cpp
+++ b/Framework/Crystal/src/SCDCalibratePanels2.cpp
@@ -466,19 +466,10 @@ void SCDCalibratePanels2::optimizeL1(IPeaksWorkspace_sptr pws, IPeaksWorkspace_s
   // get results for L1
   double dL1_optimized = rst->getRef<double>("Value", 2);
   double tor_dL1 = getProperty("ToleranceL1");
-  if (std::abs(dL1_optimized) < std::abs(tor_dL1)) {
-    calilog << "-- Fit L1 results below tolerance, zero it\n";
-    dL1_optimized = 0.0;
-  }
+
   // get results for T0 (optional)
   double dT0_optimized = rst->getRef<double>("Value", 6);
-  double tor_dT0 = getProperty("ToleranceT0");
-  if (caliT0) {
-    if (std::abs(dT0_optimized) < std::abs(tor_dT0)) {
-      calilog << "-- Fit dT0 = " << dT0_optimized << " is below tolerance(" << tor_dT0 << "), zero it\n";
-      dT0_optimized = 0.0;
-    }
-  }
+
   // get results for sample pos
   // NOTE:
   //    if samplePos is not part of calibration, we will get zeros here, which means zero
@@ -486,18 +477,6 @@ void SCDCalibratePanels2::optimizeL1(IPeaksWorkspace_sptr pws, IPeaksWorkspace_s
   double dsx_optimized = rst->getRef<double>("Value", 7);
   double dsy_optimized = rst->getRef<double>("Value", 8);
   double dsz_optimized = rst->getRef<double>("Value", 9);
-  double tor_dsp = getProperty("ToleranceSamplePos");
-  tor_dsp = std::abs(tor_dsp);
-  if (tuneSamplepos) {
-    if ((std::abs(dsx_optimized) < tor_dsp) && (std::abs(dsy_optimized) < tor_dsp) &&
-        (std::abs(dsz_optimized) < tor_dsp)) {
-      calilog << "-- Tune SamplePos = (" << dsx_optimized << "," << dsy_optimized << "," << dsz_optimized
-              << ") is below tolerance (" << tor_dsp << "), zero it\n";
-      dsx_optimized = 0.0;
-      dsy_optimized = 0.0;
-      dsz_optimized = 0.0;
-    }
-  }
 
   // apply the cali results (for output cali table and file)
   adjustComponent(0.0, 0.0, dL1_optimized, 0.0, 0.0, 0.0, pws->getInstrument()->getSource()->getName(), pws);
@@ -619,76 +598,11 @@ void SCDCalibratePanels2::optimizeBanks(IPeaksWorkspace_sptr pws, IPeaksWorkspac
     double drz = rstFitBank->getRef<double>("Value", 5);
 
     //-- step 4: update the instrument with optimization results
-    //           if the fit results are above the tolerance/threshold
     std::string bn = bankname;
     std::ostringstream calilog;
     if (pws->getInstrument()->getName().compare("CORELLI") == 0) {
       bn.append("/sixteenpack");
     }
-    // check if translation results need zeroing
-    double tolerance_translation = getProperty("ToleranceTransBank");
-    tolerance_translation = std::abs(tolerance_translation);
-    // NOTE:
-    // if the translation vector is effectively a zero vector, we should make it a
-    // proper one.
-    if ((std::abs(dx) < tolerance_translation) && // is dx<tor?
-        (std::abs(dy) < tolerance_translation) && // is dy<tor?
-        (std::abs(dz) < tolerance_translation)    // is dz<tor?
-    ) {
-      calilog << "-- Fit " << bn << " translation below tolerance, zero (dx, dy, dz)\n";
-      dx = 0.0;
-      dy = 0.0;
-      dz = 0.0;
-    }
-    // NOTE:
-    // if the translation vector has one component that is hitting the search bounds, the
-    // optimization setting is too tight and we should inform the users about this issue,
-    // and cowardly reject this results by zero the vector
-    double ddx = std::abs(std::abs(dx) - searchRadiusTran);
-    double ddy = std::abs(std::abs(dy) - searchRadiusTran);
-    double ddz = std::abs(std::abs(dz) - searchRadiusTran);
-    if ((ddx < tolerance_translation) || // is dx too close to search bounds?
-        (ddy < tolerance_translation) || // is dy too close to search bounds?
-        (ddz < tolerance_translation)    // is dz too close to search bounds?
-    ) {
-      calilog << "-- Fit " << bn << " translation hitting search bounds, please increase bounds.\n"
-              << "       also, cowardly refusing calibration results by zeroing (dx, dy, dz)\n";
-      dx = 0.0;
-      dy = 0.0;
-      dz = 0.0;
-    }
-
-    // check if rotation results need zeroing
-    double tolerance_rotation = getProperty("ToleranceRotBank");
-    tolerance_rotation = std::abs(tolerance_rotation);
-    // NOTE:
-    // if all components of the Euler angle vector is pratically zero, let's make it official
-    if ((std::abs(drx) < tolerance_rotation) && //
-        (std::abs(dry) < tolerance_rotation) && //
-        (std::abs(drz) < tolerance_rotation)    //
-    ) {
-      calilog << "-- Fit " << bn << " rotatoin below tolerance, zero (drx, dry, drz)\n";
-      drx = 0.0;
-      dry = 0.0;
-      drz = 0.0;
-    }
-    // NOTE:
-    // if any components of the resulting Euler angle is hitting the search bounds, we should warn
-    // the user (so that they can increase search bounds) and cowardly refuse the calibration results
-    double ddrx = std::abs(std::abs(drx) - searchRadiusRotX);
-    double ddry = std::abs(std::abs(dry) - searchRadiusRotY);
-    double ddrz = std::abs(std::abs(drz) - searchRadiusRotZ);
-    if ((ddrx < tolerance_rotation) || // is rotx hitting the search bounds?
-        (ddry < tolerance_rotation) || // is roty hitting the search bounds?
-        (ddrz < tolerance_rotation)    // is rotz hitting the search bounds?
-    ) {
-      calilog << "-- Fit " << bn << " rotation hitting bounds, please increase search radius.\n"
-              << "       also, cowardly refusing calibration results by zeroing (drx, dry, drz)\n";
-      drx = 0.0;
-      dry = 0.0;
-      drz = 0.0;
-    }
-
     // update instrument for output
     adjustComponent(dx, dy, dz, drx, dry, drz, bn, pws);
     // logging
@@ -757,15 +671,10 @@ void SCDCalibratePanels2::optimizeT0(IPeaksWorkspace_sptr pws, IPeaksWorkspace_s
   fitT0_alg->executeAsChildAlg();
 
   //-- parse output
+  std::ostringstream calilog;
   double chi2OverDOF = fitT0_alg->getProperty("OutputChi2overDoF");
   ITableWorkspace_sptr rst = fitT0_alg->getProperty("OutputParameters");
   double dT0_optimized = rst->getRef<double>("Value", 6);
-  double tor_dT0 = getProperty("ToleranceT0");
-  std::ostringstream calilog;
-  if (std::abs(dT0_optimized) < std::abs(tor_dT0)) {
-    calilog << "-- Fit dT0 = " << dT0_optimized << " is below tolerance(" << tor_dT0 << "), zero it\n";
-    dT0_optimized = 0.0;
-  }
 
   // apply calibration results (for output file and caliTable)
   m_T0 = dT0_optimized;
@@ -816,22 +725,12 @@ void SCDCalibratePanels2::optimizeSamplePos(IPeaksWorkspace_sptr pws, IPeaksWork
   fitSamplePos_alg->executeAsChildAlg();
 
   //-- parse output
+  std::ostringstream calilog;
   double chi2OverDOF = fitSamplePos_alg->getProperty("OutputChi2overDoF");
   ITableWorkspace_sptr rst = fitSamplePos_alg->getProperty("OutputParameters");
   double dsx_optimized = rst->getRef<double>("Value", 7);
   double dsy_optimized = rst->getRef<double>("Value", 8);
   double dsz_optimized = rst->getRef<double>("Value", 9);
-  double tor_dsp = getProperty("ToleranceSamplePos");
-  tor_dsp = std::abs(tor_dsp);
-  std::ostringstream calilog;
-  if ((std::abs(dsx_optimized) < tor_dsp) && (std::abs(dsy_optimized) < tor_dsp) &&
-      (std::abs(dsz_optimized) < tor_dsp)) {
-    calilog << "-- Tune SamplePos = (" << dsx_optimized << "," << dsy_optimized << "," << dsz_optimized
-            << ") is below tolerance (" << tor_dsp << "), zero it\n";
-    dsx_optimized = 0.0;
-    dsy_optimized = 0.0;
-    dsz_optimized = 0.0;
-  }
 
   // apply the calibration results to pws for ouptut file
   adjustComponent(dsx_optimized, dsy_optimized, dsz_optimized, 0.0, 0.0, 0.0, "sample-position", pws);

--- a/docs/source/release/v6.2.0/diffraction.rst
+++ b/docs/source/release/v6.2.0/diffraction.rst
@@ -40,6 +40,7 @@ Improvements
 - Find detector in peaks will check which det is closer when dealing with peak-in-gap situation for tube-type detectors.
 - Existing :ref:`SCDCalibratePanels <algm-SCDCalibratePanels-v2>` now provides better calibration of panel orientation for flat panel detectors.
 - Existing :ref:`MaskPeaksWorkspace <algm-MaskPeaksWorkspace-v1>` now also supports tube-type detectors used at the CORELLI instrument.
+- Existing :ref:`SCDCalibratePanels <algm-SCDCalibratePanels-v2>` now retains the value of small optimization results instead of zeroing them.
 
 Bugfixes
 ########


### PR DESCRIPTION
**Description of work.**

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

- Original Gitlab Defect: [SCD364](https://code.ornl.gov/sns-hfir-scse/diffraction/single-crystal/single-crystal-diffraction/-/issues/364)
- This is #31823 into `master`

The original `SCDCalibratePanels2` allows users to set a tolerance for each type of optimization output such that optimization results fall below the tolerance will be forced to zero.
However, this arbitrary zeroing output is preventing the instrument scientists to test out different optimization workflow, which the alternation of the output are causing various unintended side effects.
This PR removes the tolerance settings in the API such that `SCDCalibratePanels2` will stop sanitizing the optimization output.

**To test:**

- Use the following script to generate a synthetic data based on TOPAZ
```python
from mantid.simpleapi import *
from mantid.geometry import CrystalStructure
import matplotlib.pyplot as plt
import numpy as np

from collections import namedtuple

def convert(dictionary):
    return namedtuple('GenericDict', dictionary.keys())(**dictionary)

lc_natrolite = {
    "a": 18.29,  # A
    "b": 18.64,  # A
    "c": 6.56,  # A
    "alpha": 90,  # deg
    "beta": 90,  # deg
    "gamma": 90,  # deg
}
natrolite = convert(lc_natrolite)

CreateSimulationWorkspace(
    Instrument='TOPAZ',
    BinParams='1,100,10000',
    UnitX='TOF',
    OutputWorkspace='cws',
)
cws = mtd['cws']

# Set the UB matrix for the sample
# u, v is the critical part, we can start with the
# ideal position
SetUB(
    Workspace="cws",
    u='1,0,0',  # vector along k_i, when goniometer is at 0
    v='0,1,0',  # in-plane vector normal to k_i, when goniometer is at 0
    **lc_natrolite,
)

# Generate predicted peak workspace
dspacings = convert({'min': 1.0, 'max': 10.0})
wavelengths = convert({'min': 0.8, 'max': 2.9})

# Collect peaks over a range of omegas
CreatePeaksWorkspace(OutputWorkspace='pws')
omegas = range(0, 180, 3)

for omega in omegas:
    SetGoniometer(
        Workspace="cws",
        Axis0=f"{omega},0,1,0,1",
    )

    PredictPeaks(
        InputWorkspace='cws',
        WavelengthMin=wavelengths.min,
        wavelengthMax=wavelengths.max,
        MinDSpacing=dspacings.min,
        MaxDSpacing=dspacings.max,
        ReflectionCondition='All-face centred',
        OutputWorkspace='_pws',
    )

    CombinePeaksWorkspaces(
        LHSWorkspace="_pws",
        RHSWorkspace="pws",
        OutputWorkspace="pws",
    )

IndexPeaks("pws")
```
- invoke `SCDCalibratePanels2`
```python

SCDCalibratePanels(
  PeakWorkspace='pws', 
  RecalculateUB=False,
  a=18.29, b=18.64, c=6.56, alpha=90, beta=90, gamma=90,
  CalibrateBanks=True, 
  SearchRadiusTransBank=0.1, 
  SearchradiusRotXBank=90, 
  SearchradiusRotYBank=0, 
  SearchradiusRotZBank=90,
  CalibrateT0=True,
  TuneSamplePosition=True,
  OutputWorkspace='pws_caliL1', 
  DetCalFilename='SCDCalibrate2.DetCal',
  VerboseOutput=True,
)

```
Now you should be able to see output like the following
```
-- Fit bank33 results using 492 peaks:
    d(x,y,z) = [0.00023357,-2.10413e-06,-8.85945e-05]
    r(x,y,z) = [-0.125668,0,0.00455821]
    chi2/DOF = 1.43927e-06
```
where `ry=0` is due to the intput setting `  SearchradiusRotYBank=0`, and the other outputs are directly from the optimizer without any additional sanitation.

<!-- Instructions for testing. -->

<!-- and fix #xxxx or close #xxxx xor resolves #xxxx -->
<!-- alternative
*There is no associated issue.*
-->

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or master)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
