### PR TITLE
Add back to back exponential usage example to PDCalibration

### DIFF
--- a/docs/source/algorithms/PDCalibration-v1.rst
+++ b/docs/source/algorithms/PDCalibration-v1.rst
@@ -93,6 +93,36 @@ Output:
 
   The calibrated difc at detid 40896 is 5523.060327692842
 
+**Example - PDCalibration with BackToBackExponential fit function**
+
+.. code-block:: python
+
+   Load(Filename=r'ENGINX00193749.nxs', OutputWorkspace='193749')
+   dpks = (1.913220892, 1.631600313,
+           1.562138267, 1.352851554, 1.104598643)
+
+   # initial values for GSAS parameters A, B, S are in ENGINX parameters .xml
+   # use log binning
+   PDCalibration(InputWorkspace='193749',
+                 TofBinning=[10000,-0.0005,46000],
+                 PeakPositions=dpks,
+                 PeakWindow = 0.03,
+                 MinimumPeakHeight = 0.5,
+                 PeakFunction = 'BackToBackExponential',
+                 CalibrationParameters = 'DIFC',
+                 OutputCalibrationTable='cal_B2B_DIFC_chisqTrue',
+                 DiagnosticWorkspaces = 'diag_B2B_DIFC_chisqTrue',
+                 UseChiSq = True)
+
+   # Print the result
+   print("The calibrated difc at detid {detid} is {difc}".format(**mtd['cal_B2B_DIFC_chisqTrue'].row(1000)))
+
+Output:
+
+.. code-block:: none
+
+  The calibrated difc at detid 108041 is 16834.952770921267
+
 .. categories::
 
 .. sourcelink::

--- a/docs/source/algorithms/PDCalibration-v1.rst
+++ b/docs/source/algorithms/PDCalibration-v1.rst
@@ -95,6 +95,8 @@ Output:
 
 **Example - PDCalibration with BackToBackExponential fit function**
 
+The following example shows how to use PDCalibration with the BackToBackExponential fit function. The fit works best if sensible initial values for the parameters are specified in an instrument definition or parameter file (for more details, see the :ref:`fitting parameters <Using fitting parameter>` documentation):
+
 .. code-block:: python
 
    Load(Filename=r'ENGINX00193749.nxs', OutputWorkspace='193749')


### PR DESCRIPTION
**Description of work.**

Added a further usage example to the PDCalibration documentation showing use with the BackToBackExponential peak function

**To test:**

Review change and check Jenkins doc tests pass

Fixes #31800. 

*This does not require release notes* because **there's no functional change**

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
