### PR TITLE
Sliceviewer to call BinMD with NormalizeBasisVectors=False for HKL data

### DIFF
--- a/docs/source/release/v6.2.0/mantidworkbench.rst
+++ b/docs/source/release/v6.2.0/mantidworkbench.rst
@@ -15,5 +15,6 @@ Bugfixes
 --------
 
 - Scroll bars added to about dialog if screen resolution is too low.
+- Sliceviewer now doesn't normalise basis vectors for HKL data such that Bragg peaks appear at integer HKL for cuts along e.g. HH0
 
 :ref:`Release 6.2.0 <v6.2.0>`

--- a/qt/python/mantidqt/widgets/sliceviewer/model.py
+++ b/qt/python/mantidqt/widgets/sliceviewer/model.py
@@ -545,6 +545,8 @@ def _roi_binmd_parameters(workspace, slicepoint: Sequence[Optional[float]],
     ws_basis = np.eye(ndims)
     output_extents, output_bins = [], []
     params = {'AxisAligned': False}
+    if workspace.getSpecialCoordinateSystem() == SpecialCoordinateSystem.HKL:
+        params['NormalizeBasisVectors'] = False  # Default is True
     for n in range(ndims):
         dimension = workspace.getDimension(n)
         basis_vec_n = _to_str(ws_basis[:, n])


### PR DESCRIPTION
**Description of work.**

One line change to call BinMD with `NormalizeBasisVector = False` when MD object is HKL. This so that Bragg peaks in the HHL plane are plotted at integer HKL.

**To test:**
(1) Run this script
```
ws = CreateMDWorkspace(Dimensions='3', Extents='-3,3,-3,3,-3,3',
                       Names='H,K,L', Units='r.l.u.,r.l.u.,r.l.u.',
                       Frames='HKL,HKL,HKL',
                       SplitInto='2', SplitThreshold='10')
# add fake Bragg peaks for primitive lattice in data
for h in range(-3,4):
    for k in range(-3,4):
        for l in range(-3,4):
            hkl = ",".join([str(x) for x in [h,k,l]])
            FakeMDEventData(ws, PeakParams='1e+02,' + hkl + ',0.02', RandomSeed='3873875')
 
BinMD(InputWorkspace=ws, AxisAligned=False,
    BasisVector0='[00L],r.l.u.,0,0,1', 
    BasisVector1='[HH0],r.l.u.,1,1,0',
    BasisVector2='[-HH0],r.l.u.,-1,1,0',
    OutputExtents='-4,4,-4,4,-0.25,0.25', 
    OutputBins='101,101,1', OutputWorkspace='BinMD_out', NormalizeBasisVectors=False)
```
(2) Zoom in to check Bragg peaks are at y=1 not y=sqrt(2) - see expected screenshot in original issue

Fixes #31827


<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or master)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
