### PR TITLE
Create mesh for CSGObject to plot Sample Shapes

### DIFF
--- a/Framework/PythonInterface/mantid/geometry/src/Exports/CSGObject.cpp
+++ b/Framework/PythonInterface/mantid/geometry/src/Exports/CSGObject.cpp
@@ -33,10 +33,10 @@ GET_POINTER_SPECIALIZATION(CSGObject)
 boost::python::object wrapMeshWithNDArray(const CSGObject *self) {
   // PyArray_SimpleNewFromData doesn't interact well with smart pointers so use raw pointer
 
-  auto localTriangulator = new GeometryTriangulator(self);
-  auto vertices = localTriangulator->getTriangleVertices();
-  auto triangles = localTriangulator->getTriangleFaces();
-  size_t numberTriangles = localTriangulator->numTriangleFaces();
+  auto localTriangulator = GeometryTriangulator(self);
+  const auto &vertices = localTriangulator.getTriangleVertices();
+  const auto &triangles = localTriangulator.getTriangleFaces();
+  const size_t &numberTriangles = localTriangulator.numTriangleFaces();
   npy_intp dims[3] = {static_cast<int>(numberTriangles), 3, 3};
   auto *meshCoords = new double[dims[0] * dims[1] * dims[2]];
   for (size_t corner_index = 0; corner_index < triangles.size(); ++corner_index) {
@@ -45,7 +45,7 @@ boost::python::object wrapMeshWithNDArray(const CSGObject *self) {
     } // for each coordinate of that corner
   }   // for each corner of the triangle
 
-  PyObject *ndarray = Impl::wrapWithNDArray(meshCoords, 3, dims, NumpyWrapMode::ReadOnly, OwnershipMode::Python);
+  PyObject *ndarray = Impl::wrapWithNDArray(meshCoords, 3, dims, NumpyWrapMode::ReadWrite, OwnershipMode::Python);
   return object(handle<>(ndarray));
 }
 

--- a/Framework/PythonInterface/mantid/geometry/src/Exports/CSGObject.cpp
+++ b/Framework/PythonInterface/mantid/geometry/src/Exports/CSGObject.cpp
@@ -5,17 +5,49 @@
 //   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
 // SPDX - License - Identifier: GPL - 3.0 +
 #include "MantidGeometry/Objects/CSGObject.h"
+#include "MantidGeometry/Rendering/GeometryTriangulator.h"
+#include "MantidPythonInterface/core/Converters/NDArrayTypeIndex.h"
+#include "MantidPythonInterface/core/Converters/WrapWithNDArray.h"
 #include "MantidPythonInterface/core/GetPointer.h"
+
 #include <boost/python/class.hpp>
 #include <boost/python/copy_const_reference.hpp>
 #include <boost/python/register_ptr_to_python.hpp>
+#include <boost/python/self.hpp>
+#include <boost/python/suite/indexing/vector_indexing_suite.hpp>
 
+#include <numpy/arrayobject.h>
+
+#define PY_ARRAY_UNIQUE_SYMBOL GEOMETRY_ARRAY_API
+#define NO_IMPORT_ARRAY
+
+using Mantid::Geometry::IObject;
+using namespace Mantid::PythonInterface::Converters;
 using Mantid::Geometry::BoundingBox;
 using Mantid::Geometry::CSGObject;
-using Mantid::Geometry::IObject;
+using Mantid::Geometry::detail::GeometryTriangulator;
 using namespace boost::python;
 
 GET_POINTER_SPECIALIZATION(CSGObject)
+
+boost::python::object wrapMeshWithNDArray(const CSGObject *self) {
+  // PyArray_SimpleNewFromData doesn't interact well with smart pointers so use raw pointer
+
+  auto localTriangulator = new GeometryTriangulator(self);
+  auto vertices = localTriangulator->getTriangleVertices();
+  auto triangles = localTriangulator->getTriangleFaces();
+  size_t numberTriangles = localTriangulator->numTriangleFaces();
+  npy_intp dims[3] = {static_cast<int>(numberTriangles), 3, 3};
+  auto *meshCoords = new double[dims[0] * dims[1] * dims[2]];
+  for (size_t corner_index = 0; corner_index < triangles.size(); ++corner_index) {
+    for (size_t xyz = 0; xyz < 3; xyz++) {
+      meshCoords[3 * corner_index + xyz] = vertices[3 * triangles[corner_index] + xyz];
+    } // for each coordinate of that corner
+  }   // for each corner of the triangle
+
+  PyObject *ndarray = Impl::wrapWithNDArray(meshCoords, 3, dims, NumpyWrapMode::ReadOnly, OwnershipMode::Python);
+  return object(handle<>(ndarray));
+}
 
 void export_Object() {
   register_ptr_to_python<std::shared_ptr<CSGObject>>();
@@ -26,5 +58,6 @@ void export_Object() {
 
       .def("getShapeXML", &CSGObject::getShapeXML, arg("self"), "Returns the XML that was used to create this shape.")
 
-      .def("volume", &CSGObject::volume, arg("self"), "Returns the volume of this shape.");
+      .def("volume", &CSGObject::volume, arg("self"), "Returns the volume of this shape.")
+      .def("getMesh", &wrapMeshWithNDArray, (arg("self")), "Get the vertices, grouped by triangles, from mesh");
 }

--- a/Framework/PythonInterface/mantid/geometry/src/Exports/MeshObject.cpp
+++ b/Framework/PythonInterface/mantid/geometry/src/Exports/MeshObject.cpp
@@ -28,9 +28,9 @@ GET_POINTER_SPECIALIZATION(MeshObject)
 
 boost::python::object wrapMeshWithNDArray(MeshObject &self) {
   // PyArray_SimpleNewFromData doesn't interact well with smart pointers so use raw pointer
-  auto vertices = self.getV3Ds();
-  auto triangles = self.getTriangles();
-  size_t numberTriangles = triangles.size() / 3;
+  const auto &vertices = self.getV3Ds();
+  const auto &triangles = self.getTriangles();
+  const size_t &numberTriangles = triangles.size() / 3;
   npy_intp dims[3] = {static_cast<int>(numberTriangles), 3, 3};
   auto *meshCoords = new double[dims[0] * dims[1] * dims[2]];
   for (size_t iTriangle = 0; iTriangle < numberTriangles; ++iTriangle) {
@@ -41,7 +41,7 @@ boost::python::object wrapMeshWithNDArray(MeshObject &self) {
       } // for each coordinate of that corner
     }   // for each corner of the triangle
   }     // for each triangle
-  PyObject *ndarray = Impl::wrapWithNDArray(meshCoords, 3, dims, NumpyWrapMode::ReadOnly, OwnershipMode::Python);
+  PyObject *ndarray = Impl::wrapWithNDArray(meshCoords, 3, dims, NumpyWrapMode::ReadWrite, OwnershipMode::Python);
 
   return boost::python::object(handle<>(ndarray));
 }

--- a/docs/source/release/v6.2.0/framework.rst
+++ b/docs/source/release/v6.2.0/framework.rst
@@ -21,6 +21,7 @@ Fit Functions
 
 Data Objects
 ------------
+- **Sample shapes which are CSGObjects can now be plotted. Shapes can also be merged, such as a sphere with a cylindrical hole. For more details see** :ref:`Mesh_Plots`.
 
 Python
 ------


### PR DESCRIPTION
**Description of work.**

A mesh can now be created for CSGObjects  to plot Sample Shapes, such as spheres + cylinders and shapes can be merged.

Refs #30607 

**To test:**

- Run the script below
- Edit `SetSample(...)` to use the xml strings in the script for different shapes, and check that sphere, cylinder and a sphere with a cylindrical hole in work!
- Feel free to try some weird and wonderful shapes and combinations of shapes: https://docs.mantidproject.org/nightly/concepts/HowToDefineGeometricShape.html#howtodefinegeometricshape


```
# import mantid algorithms, numpy and matplotlib
from mantid.simpleapi import *
import matplotlib.pyplot as plt
import numpy as np
from mpl_toolkits.mplot3d.art3d import Poly3DCollection
from mantid.api import AnalysisDataService as ADS


# A fake host workspace, replace this with your real one.
ws = CreateSampleWorkspace()

cuboid_xml = " \
<cuboid id='some-cuboid'> \
  <height val='20.0'  /> \
  <width val='50.0' />  \
  <depth  val='20.0' />  \
  <centre x='100.0' y='100.0' z='100.0'  />  \
  <rotation x='60' y='90' z='217' /> \
</cuboid>  \
<algebra val='some-cuboid' /> \
"

sphere_xml = " \
<sphere id='some-sphere'> \
    <centre x='0.0'  y='0.0' z='0.0' /> \
    <radius val='0.5' /> \
</sphere> \
<algebra val='some-sphere' /> \
"

cylinder_xml = " \
<cylinder id='some-cylinder'> \
  <centre-of-bottom-base r='0.0' t='0.0' p='0.0' />  \
  <axis x='0.0' y='0.2' z='0' /> \
  <radius val='1' /> \
  <height val='10.2' /> \
</cylinder> \
<algebra val='some-cylinder' /> \
"

merge_xml = ' \
<cylinder id="stick"> \
  <centre-of-bottom-base x="-0.5" y="0.0" z="0.0" /> \
  <axis x="1.0" y="0.0" z="0.0" /> \
  <radius val="0.2" /> \
  <height val="1.0" /> \
</cylinder> \
\
<sphere id="some-sphere"> \
  <centre x="0.0"  y="0.0" z="0.0" /> \
  <radius val="0.5" /> \
</sphere> \
\
<algebra val="some-sphere (#stick)" /> \
'

flat_circle = " \
<cylinder id=\"pixel-shape\"> \
  <centre-of-bottom-base x=\"0\" y=\"-0.0001\" z=\"0\"/> \
  <axis x=\"0\" y=\"1\" z=\"0\"/><radius val=\"0.004\"/> \
  <height val=\"0.0002\"/> \
</cylinder>"

# Set sample geometry of workspace to this CSG object
SetSample(ws, Geometry={'Shape': 'CSG', 'Value': cuboid_xml})

sample = ws.sample()
shape = sample.getShape()
mesh = shape.getMesh()

facecolors = ['royalblue','b','red','firebrick', 'gold', 'orange','green', 'darkgreen','grey','black', 'purple', 'mediumorchid']

mesh_polygon_a = Poly3DCollection(mesh, facecolors = facecolors, edgecolors='green', linewidths=0.1, alpha = 0.5)
'''Problem based on order of being added!'''

fig, axes = plt.subplots(subplot_kw={'projection':'mantid3d'})
axes.add_collection3d(mesh_polygon_a)

# Auto scale to the mesh size
axes_lims = mesh.flatten()
axes.auto_scale_xyz(axes_lims, axes_lims, axes_lims)

axes.set_title('Sample Shape: Cuboid')
axes.set_xlabel('X / m')
axes.set_ylabel('Y / m')
axes.set_zlabel('Z / m')

plt.show()
```

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
