### PR TITLE
Revert "Code editor close tab icon, forced to material design (#31751)"

### DIFF
--- a/docs/source/release/v6.2.0/mantidworkbench.rst
+++ b/docs/source/release/v6.2.0/mantidworkbench.rst
@@ -9,7 +9,6 @@ New and Improved
 ----------------
 
 - Peaks can now be added or removed from a PeaksWorkspace using the :ref:`peaks overlay <sliceviewer_peaks_overlay>` in :ref:`sliceviewer`.
-- Improved cross-platform theming by using the same icon on all platforms for closing editor tabs.
 
 Bugfixes
 --------

--- a/qt/python/mantidqt/widgets/codeeditor/multifileinterpreter.py
+++ b/qt/python/mantidqt/widgets/codeeditor/multifileinterpreter.py
@@ -13,10 +13,9 @@ from os import linesep
 
 # 3rd party imports
 from qtpy.QtCore import Qt, Slot, Signal
-from qtpy.QtWidgets import QVBoxLayout, QWidget, QTabBar, QPushButton
+from qtpy.QtWidgets import QVBoxLayout, QWidget
 
 # local imports
-from mantidqt.icons import get_icon
 from mantidqt.widgets.codeeditor.interpreter import PythonFileInterpreter
 from mantidqt.widgets.codeeditor.scriptcompatibility import add_mantid_api_import, mantid_api_import_needed
 from mantidqt.widgets.codeeditor.tab_widget.codeeditor_tab_view import CodeEditorTabWidget
@@ -155,14 +154,6 @@ class MultiPythonFileInterpreter(QWidget):
         if content is not None:
             line_count = content.count(linesep)
             interpreter.editor.setCursorPosition(line_count,0)
-
-        # Replace close button with mdi.close icon to improve OS visual consistency
-        close_button = QPushButton(self)
-        close_button.setFlat(True)
-        close_button.setIcon(get_icon("mdi.close", "black", 1.35))
-        close_button.clicked.connect(lambda tab_index=tab_idx: self.close_tab(tab_index))
-        self._tabs.tabBar().setTabButton(tab_idx, QTabBar.RightSide, close_button)
-
         return tab_idx
 
     def abort_current(self):

--- a/qt/python/mantidqt/widgets/codeeditor/tab_widget/codeeditor_tab_view.py
+++ b/qt/python/mantidqt/widgets/codeeditor/tab_widget/codeeditor_tab_view.py
@@ -154,6 +154,7 @@ class CodeEditorTabWidget(QTabWidget):
 
         if Qt.MiddleButton == event.button():
             self.tabCloseRequested.emit(self.last_tab_clicked)
+
         QTabWidget(self).mousePressEvent(event)
 
     def tab_was_clicked(self, tab_index):


### PR DESCRIPTION
**Description of work.**

This reverts commit 0b4b23080c34ab6f9249ce2e057cd909fbd57514.

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

**To test:**

See #31651 for bug listed and check it is fixed after these fixes.

<!-- alternative
*There is no associated issue.*
-->

<!-- delete this if you added release notes
*This does not require release notes* because **it reverts a regression**
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or master)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
