### PR TITLE
Fix for muon freqruency domain fitting data selection

### DIFF
--- a/scripts/Muon/GUI/Common/contexts/frequency_domain_analysis_context.py
+++ b/scripts/Muon/GUI/Common/contexts/frequency_domain_analysis_context.py
@@ -43,7 +43,7 @@ class FrequencyDomainAnalysisContext(MuonContext):
             runs='All', group_and_pair=groups_and_pairs, rebin=not use_raw)
         return workspace_options
 
-    def get_names_of_workspaces_to_fit(self, runs='', group_and_pair='',
+    def get_workspace_names_for(self, runs='', group_and_pair='',
                                        phasequad=False, rebin=False):
 
         return self.get_names_of_frequency_domain_workspaces_to_fit(
@@ -51,10 +51,12 @@ class FrequencyDomainAnalysisContext(MuonContext):
 
     def get_names_of_frequency_domain_workspaces_to_fit(
             self, runs='', group_and_pair='', frequency_type="None"):
-        group, pair = self.get_group_and_pair(group_and_pair)
         run_list = self.get_runs(runs)
-        names = self._frequency_context.get_frequency_workspace_names(
-            run_list, group, pair, frequency_type)
+        names=[]
+        for group_pair in group_and_pair:
+            group, pair = self.get_group_and_pair(group_pair)
+            names += self._frequency_context.get_frequency_workspace_names(
+                run_list, group, pair, frequency_type)
         return names
 
     def get_names_of_time_domain_workspaces_to_fit(

--- a/scripts/test/Muon/muon_context_with_frequency_test.py
+++ b/scripts/test/Muon/muon_context_with_frequency_test.py
@@ -61,21 +61,21 @@ class MuonContextWithFrequencyTest(unittest.TestCase):
 
     def test_get_workspace_names_returns_no_time_domain_workspaces(self):
         self.populate_ADS()
-        workspace_list = self.context.get_names_of_workspaces_to_fit('19489', 'fwd, bwd, long', True)
+        workspace_list = self.context.get_workspace_names_for('19489', 'fwd, bwd, long', True)
         self.assertEqual(Counter(workspace_list),
                          Counter())
 
     def test_get_workspace_names_returns_nothing_if_no_parameters_passed(self):
         self.populate_ADS()
         self.context._frequency_context.plot_type = "All"
-        workspace_list = self.context.get_names_of_workspaces_to_fit()
+        workspace_list = self.context.get_workspace_names_for()
 
         self.assertEqual(workspace_list, [])
 
     def test_get_workspaces_names_copes_with_no_freq_runs(self):
         self.populate_ADS()
         self.context._frequency_context.plot_type = "All"
-        workspace_list = self.context.get_names_of_workspaces_to_fit(runs='19489', group_and_pair='fwd, bwd, long, random, wrong',
+        workspace_list = self.context.get_workspace_names_for(runs='19489', group_and_pair='fwd, bwd, long, random, wrong',
                                                                      phasequad=True)
 
         self.assertEqual(Counter(workspace_list),
@@ -84,7 +84,7 @@ class MuonContextWithFrequencyTest(unittest.TestCase):
     def test_call_freq_workspace_names(self):
         self.context.get_names_of_frequency_domain_workspaces_to_fit = mock.Mock()
         self.context._frequency_context.plot_type = "All"
-        self.context.get_names_of_workspaces_to_fit(runs='19489', group_and_pair='fwd, bwd')
+        self.context.get_workspace_names_for(runs='19489', group_and_pair='fwd, bwd')
         self.context.get_names_of_frequency_domain_workspaces_to_fit.assert_called_once_with(runs='19489', group_and_pair='fwd, bwd',
                                                                                              frequency_type="All")
 


### PR DESCRIPTION
**Description of work.**
This is a quick fix for the frequency domain analysis (FDA) GUI no longer allowing the user to fit to frequency data.

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

**To test:**

<!-- Instructions for testing. -->

Open FDA
Load MUSR 62260
Go to the transform tab and do a few transforms (different groups selected)
Switch to MaxEnt and press calculate
Go to fitting and make sure that all of the FFT (Re, Im and mod) and MaxEnt data is in the selector and no  time domain data.


There is no associated issue.

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
-->
This is not in the release notes as it fixes a bug that was introduced last week.

<!-- Ensure the base of this PR is correct (e.g. release-next or master)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
