### PR TITLE
Fix systemtest runner bug

### DIFF
--- a/Testing/SystemTests/lib/systemtests/systemtesting.py
+++ b/Testing/SystemTests/lib/systemtests/systemtesting.py
@@ -1074,6 +1074,7 @@ class TestManager(object):
 
     def executeTests(self, tests_done=None):
         # Get the defined tests
+        status_dict = dict()
         for suite in self._tests:
             if self.__shouldTest(suite):
                 suite.execute(self._runner, self._exclude_in_pr_builds)
@@ -1090,13 +1091,12 @@ class TestManager(object):
                     suite.reportResults(self._reporters, tests_done.value)
             else:
                 # tests_done=None indicates running tests on parent thread, no need to worry about the Lock
-                status_dict = dict()
                 if not self._clean:
                     sum_tests = self._passedTests + self._skippedTests + self._failedTests
                     suite.reportResults(self._reporters, sum_tests)
-                    status_dict.update(suite.getMapResultNameToStatus())
-                return status_dict
+                status_dict.update(suite.getMapResultNameToStatus())
             self._lastTestRun += 1
+        return status_dict
 
     def replaceRunner(self, new_runner):
         self._runner = new_runner

--- a/buildconfig/Jenkins/systemtests
+++ b/buildconfig/Jenkins/systemtests
@@ -101,7 +101,7 @@ find ${default_save_directory} -name "*-mismatch*" -delete
 # Run. Use SYSTEST_NPROCS over BUILD_THREADS if defined
 BUILD_THREADS=${BUILD_THREADS:-1}
 SYSTEST_NPROCS=${SYSTEST_NPROCS:-$BUILD_THREADS}
-echo "Running system tests with ${SYSTEST_NPROCS} cores."
+echo "The list of system tests will be split and executed over ${SYSTEST_NPROCS} processes."
 
 PKGDIR=${WORKSPACE}/build
 ${X11_RUNNER} "${X11_RUNNER_ARGS}" python3 $WORKSPACE/Testing/SystemTests/scripts/InstallerTests.py -o -d $PKGDIR -j ${SYSTEST_NPROCS} $EXTRA_ARGS


### PR DESCRIPTION
**Description of work.**

Fixes a bug introduced in #31557 where a counter was not incremented leading to all system tests being reported as skipped if run in the main process.

Also clarifies a logging message regarding how tests are executed.

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

**To test:**

* Run a single test: `systemtest -R CodeConventions` and it should report as passed and not skipped
* Run several tests: `systemtest -R "CodeConventions|WorkbenchStartup"` and both should report as successful
* Introduce an error into 1 of the tests and re-run the above checks and a the failure should be reported
* Do the above but add `-j4` to the command line to run in multiple processes

*There is no associated issue.*

*This does not require release notes* because **it is a regression in a developer tool.**

<!-- Ensure the base of this PR is correct (e.g. release-next or master)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
