### PR TITLE
Binary Operations check if LHS is an EventWorkspace instead of output

### DIFF
--- a/Framework/Algorithms/src/BinaryOperation.cpp
+++ b/Framework/Algorithms/src/BinaryOperation.cpp
@@ -161,7 +161,9 @@ void BinaryOperation::exec() {
 
   // Get the output workspace
   m_out = getProperty(outputPropName());
-  m_eout = std::dynamic_pointer_cast<EventWorkspace>(m_out);
+  if (m_elhs) {
+    m_eout = std::dynamic_pointer_cast<EventWorkspace>(m_out);
+  }
 
   // Make a check of what will be needed to setup the workspaces, based on the
   // input types.

--- a/Framework/Algorithms/src/BinaryOperation.cpp
+++ b/Framework/Algorithms/src/BinaryOperation.cpp
@@ -159,12 +159,6 @@ void BinaryOperation::exec() {
     }
   }
 
-  // Get the output workspace
-  m_out = getProperty(outputPropName());
-  if (m_elhs) {
-    m_eout = std::dynamic_pointer_cast<EventWorkspace>(m_out);
-  }
-
   // Make a check of what will be needed to setup the workspaces, based on the
   // input types.
   this->checkRequirements();
@@ -182,6 +176,12 @@ void BinaryOperation::exec() {
     ostr << "The two workspaces are not compatible for algorithm " << this->name();
     g_log.error() << ostr.str() << '\n';
     throw std::invalid_argument(ostr.str());
+  }
+
+  // Get the output workspace
+  m_out = getProperty(outputPropName());
+  if (m_elhs) {
+    m_eout = std::dynamic_pointer_cast<EventWorkspace>(m_out);
   }
 
   // Is the output going to be an EventWorkspace?

--- a/docs/source/release/v6.2.0/mantidworkbench.rst
+++ b/docs/source/release/v6.2.0/mantidworkbench.rst
@@ -34,5 +34,6 @@ Bugfixes
 - Fixed a bug where parameters wouldn't update in the fit property browser when fitting a single function with ties.
 - Fixed a bug retrieving algorithm history from a workspace when the retrieval methods were chained together.
 - Added missing icon for the uninstaller in Windows "Apps & features" list.
+- Fixed a bug where output workspaces of different types would interfere with successive calls to binary operations, such as multiply.
 
 :ref:`Release 6.2.0 <v6.2.0>`


### PR DESCRIPTION
Fixes a bug when calling `Multiply` with a `SingleValue` workspace successively reusing the output workspace. If in the first call to `Multiply` the output workspace is an `Event` workspace and this is reused as the output for the next call, the second call to `Multiply` would [behave as if the output were an event workspace](https://github.com/mantidproject/mantid/blob/6eb3ca868991930a40a5b05ce931ad565e04c633/Framework/Algorithms/src/BinaryOperation.cpp#L448), even if it [isn't supposed to](https://docs.mantidproject.org/nightly/algorithms/Multiply-v1.html#operations-on-eventworkspaces-vs-workspace2ds). e.g.

```
from mantid.simpleapi import *
from mantid.api import IEventWorkspace
from mantid.api import AnalysisDataService as ADS

ews = CreateSampleWorkspace('Event')
ws = CreateSampleWorkspace()
svws = CreateSingleValuedWorkspace(2)

Multiply(ews, svws, OutputWorkspace='out')  # EventWS * SVWS = EventWs
print(isinstance(ADS.retrieve('out'), IEventWorkspace))  # Should be True

Multiply(ws, svws, OutputWorkspace='out')  # WS2D * SVWS = WS2D
print(isinstance(ADS.retrieve('out'), IEventWorkspace))  # Should be False
```
This PR checks whether the left hand workspace is an event workspace, as this is the only instance where `Multiply` would result in an event workspace, rather than relying on the type of the output workspace - which persists between calls.

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

**To test:**
1. Ensure the above script prints `True False`
2. Check it fixes the original issue described in #31820 
3. Check this hasn't broken any of the other binary operations, particularly with event workspaces.

Fixes #31820. <!-- and fix #xxxx or close #xxxx xor resolves #xxxx -->
<!-- alternative
*There is no associated issue.*
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or master)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
