### PR TITLE
Add Yappi proflier option to main

### DIFF
--- a/dev-docs/source/ProfilingOverview.rst
+++ b/dev-docs/source/ProfilingOverview.rst
@@ -26,6 +26,27 @@ E.g: ``path/to/install/bin/workbench --profile path/to/outputFile.prof``
 This profile can then either be sent to the developers upon request or be analysed using the python module `snakeviz <https://pypi.org/project/snakeviz/>`_.
 
 
+Profiling with Yappi
+--------------------
+
+cProfile can only profile the current thread, this makes it useful for diagnosing PyQt performance issues (such as random hangs when a user does something), but poor for diagnosing workflow algorithm issues.
+
+`Yappi (Yet Another Python Profiler) <https://pypi.org/project/yappi/>`_ is multithreading aware. cProfile which will show everything up to the exec, or run call. Yappi will profile the thread and show any slow points within the separate thread.
+
+*Note: This will not with QThreads and may crash or be unable to profile inside. It is recommended you migrate workers by inheriting from IQtAsync, see async_qt_adaptor.py for details.  Using native threading enables tooling, makes testing simple and produces readable stack traces.*
+
+To use Yappi instead of cProfile simple append `--yappi` to the list of arguments after profile, e.g.:
+
+.. code:: shell
+
+   # If you do not have yappi installed
+   python3 -m pip install yappi --user
+   # Run with Yappi profiler
+   ./MantidWorkbench --profile name_of_profile.out --yappi
+
+KCachegrind can be used to view profiling data, see :doc:`ProfilingWithValgrind` for more details on usage.
+
+
 Profiling an algorithm
 ----------------------
 

--- a/qt/applications/workbench/workbench/app/main.py
+++ b/qt/applications/workbench/workbench/app/main.py
@@ -7,6 +7,7 @@
 #  This file is part of the mantid workbench.
 import argparse
 import os
+
 from mantid import __version__ as mtd_version
 import warnings
 
@@ -27,6 +28,9 @@ def main():
     parser.add_argument('--profile',
                         action='store',
                         help='Run workbench with execution profiling. Specify a path for the output file.')
+    parser.add_argument('--yappi',
+                        action='store_true',
+                        help='Profile using Yappi instead of cProfile to capture multi-threaded execution.')
     parser.add_argument('--error-on-warning',
                         action='store_true',
                         help='Convert python warnings to exceptions')
@@ -46,15 +50,36 @@ def main():
         os.environ["PYTHONWARNINGS"] = "error" # Also affect subprocesses
 
     if options.profile:
-        import cProfile
         output_path = os.path.abspath(os.path.expanduser(options.profile))
-        if os.path.exists(os.path.dirname(output_path)):
-            cProfile.runctx('start(options)', globals(), locals(), filename=output_path)
-        else:
+        if not os.path.exists(os.path.dirname(output_path)):
             raise ValueError("Invalid path given for profile output. "
                              "Please specify and existing directory and filename.")
+        if options.yappi:
+            _enable_yappi_profiling(output_path, options)
+        else:
+            _enable_cprofile_profiling(output_path, options)
     else:
         start(options)
+
+
+def _enable_yappi_profiling(output_path, options):
+    import yappi
+    # Dont use wall time as Qt event loop runs for entire duration
+    yappi.set_clock_type('cpu')
+    yappi.start(builtins=False, profile_threads=True, profile_greenlets=True)
+    try:
+        start(options)
+    finally:
+        # Qt will try to sys.exit so wrap in finally block before we go down
+        print(f"Saving kcachegrind to {output_path}")
+        yappi.stop()
+        prof_data = yappi.get_func_stats()
+        prof_data.save(output_path, type='callgrind')
+
+
+def _enable_cprofile_profiling(output_path, options):
+    import cProfile
+    cProfile.runctx('start(options)', globals(), locals(), filename=output_path)
 
 
 def start(options):


### PR DESCRIPTION
**Description of work.**
Adds Yappi as an option to the list of profilers, the primary benefit
is being able to profile across multithreaded code. This works very well
with kcachegrind to visualise hot-spots within Python workflow
algorithms.

**To test:**
- Using the docs instructions run Mantid with `yappi` enabled
- Try running the following in the scripting window (which runs async):
```python
for i in range(100):
    ws = CreateSampleWorkspace()
```
- Open output in KCacheGrind, the output should be sane


Part of #27895 

This does not require release notes because it's a developer only change, and currently we don't get users to run with profiling.
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or master)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
