### PR TITLE
Silence validation for WorkspaceCalculatorWidget

### DIFF
--- a/qt/python/mantidqt/widgets/workspacecalculator/model.py
+++ b/qt/python/mantidqt/widgets/workspacecalculator/model.py
@@ -14,7 +14,6 @@ from mantid.simpleapi import (CloneWorkspace, CreateSingleValuedWorkspace,
                               WeightedMean, WeightedMeanMD)
 from mantid.api import WorkspaceGroup, AlgorithmManager
 from mantid.dataobjects import MDHistoWorkspace, WorkspaceSingleValue
-from mantid.kernel import logger as log
 
 
 class WorkspaceCalculatorModel:
@@ -89,12 +88,10 @@ class WorkspaceCalculatorModel:
         for entry in mtd[group_name]:
             if isinstance(entry, MDHistoWorkspace):
                 if md_check is not None and not md_check:
-                    log.error(multi_dim_err_msg)
                     return multi_dim_err_msg
                 md_check = True
             else:
                 if md_check:
-                    log.error(multi_dim_err_msg)
                     return multi_dim_err_msg
                 md_check = False
         if info == 'LHS':
@@ -115,15 +112,12 @@ class WorkspaceCalculatorModel:
         else:
             if self._md_lhs and (not isinstance(mtd[self._lhs_ws], MDHistoWorkspace)
                                  and not isinstance(mtd[self._lhs_ws], WorkspaceSingleValue)):
-                log.error(multi_dim_err_msg)
                 err_msg = multi_dim_err_msg
             if self._md_lhs and (not isinstance(mtd[self._lhs_ws], MDHistoWorkspace)
                                  and not isinstance(mtd[self._lhs_ws], WorkspaceSingleValue)):
-                log.error(multi_dim_err_msg)
                 err_msg = multi_dim_err_msg
         if (self._md_lhs != self._md_rhs and (not isinstance(mtd[self._lhs_ws], WorkspaceSingleValue)
                                               and not isinstance(mtd[self._rhs_ws], WorkspaceSingleValue))):
-            log.error(multi_dim_err_msg)
             err_msg = multi_dim_err_msg
         return err_msg == str(), err_msg
 
@@ -132,8 +126,6 @@ class WorkspaceCalculatorModel:
             mtd[ws]
         except KeyError:
             err_msg = "The {} input workspace does not exist.".format(info)
-            if ws is not None:
-                log.error(err_msg)
             return False, err_msg
         if isinstance(mtd[ws], WorkspaceGroup):
             err_msg = self._check_group_for_md(ws, info)

--- a/qt/python/mantidqt/widgets/workspacecalculator/presenter.py
+++ b/qt/python/mantidqt/widgets/workspacecalculator/presenter.py
@@ -10,7 +10,6 @@
 
 from .model import WorkspaceCalculatorModel
 from .view import WorkspaceCalculatorView
-from mantid.kernel import logger as log
 
 
 class WorkspaceCalculator():
@@ -36,8 +35,7 @@ class WorkspaceCalculator():
         try:
             parameters['lhs_scale'] = float(self.view.lhs_scaling.text())
             parameters['rhs_scale'] = float(self.view.rhs_scaling.text())
-        except ValueError as err:
-            log.error(str(err))
+        except ValueError:
             return
         parameters['lhs_ws'] = self.view.lhs_ws.currentText()
         parameters['rhs_ws'] = self.view.rhs_ws.currentText()


### PR DESCRIPTION
It has been noticed that the error logs from the `WorkspaceCalculatorWidget` are showing up on ADS clear event, even if no interaction with the widget has taken place. There is a suspected automatic selection of a a workspace present in the ADS in one of `WorkspaceSelector`'s, which on a clear event fails validation, as it does not exist, and yields an error message. 

The proposed solution is removal of the error logs altogether from the `WorkspaceSelectorWidget` and depending on the commucation of issues through asterisk tooltip located next to `WorkspaceSelector`'s.

**To test:**

<!-- Instructions for testing. -->

Fixes #31863 . <!-- and fix #xxxx or close #xxxx xor resolves #xxxx -->
<!-- alternative
*There is no associated issue.*
-->

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or master)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
