### PR TITLE
Diagnostic plots (per panel) to evaluate the calibration results from SCDCalibratePanels2

### DIFF
--- a/docs/source/release/v6.2.0/diffraction.rst
+++ b/docs/source/release/v6.2.0/diffraction.rst
@@ -34,6 +34,7 @@ New features
 - New algorithm :ref:`HB3AIntegrateDetectorPeaks <algm-HB3AIntegrateDetectorPeaks>` for integrating four-circle data from HB3A in detector space.
 - New algorithm :ref:`ApplyInstrumentToPeaks <algm-ApplyInstrumentToPeaks>` to update the instrument of peaks within a PeaksWorkspace.
 - New plotting script that provides diagnostic plots of SCDCalibratePanels output.
+- New plotting script that provides diagnositc plots of SCDCalibratePanels2 on a per panel/bank basis.
 
 Improvements
 ############

--- a/scripts/SCD_Reduction/SCDCalibratePanels2PanelDiagnostics.py
+++ b/scripts/SCD_Reduction/SCDCalibratePanels2PanelDiagnostics.py
@@ -1,0 +1,133 @@
+#!/usr/bin/env python
+# Mantid Repository : https://github.com/mantidproject/mantid
+#
+# Copyright &copy; 2018 ISIS Rutherford Appleton Laboratory UKRI,
+#   NScD Oak Ridge National Laboratory, European Spallation Source,
+#   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+# SPDX - License - Identifier: GPL - 3.0 +
+"""
+This module provides a new set of visualization tools to analyze the calibration
+results from SCDCalibratePanels2 (on a per bank base).
+"""
+
+import logging
+import numpy as np
+from typing import List, Dict, Union
+from mantid.dataobjects import PeaksWorkspace
+from mantid.simpleapi import mtd, FilterPeaks
+
+
+def get_plot_data(
+    pws: PeaksWorkspace,
+    banknames: List[str],
+) -> Dict[str, np.ndarray]:
+    """
+    Gather data for Panel diagnostics
+
+    @param pws: target PeaksWorkspace, must have an instrument attached
+    @param banknames: list of bank names to gather
+    """
+    pltdata = {}
+    oriented_lattice = pws.sample().getOrientedLattice()
+    # det info
+    pltdata["banknames"] = np.array(
+        [pws.row(i)["BankName"] for i in range(pws.getNumberPeaks()) if pws.row(i)["BankName"] in banknames])
+    pltdata["cols"] = np.array(
+        [pws.row(i)["Col"] for i in range(pws.getNumberPeaks()) if pws.row(i)["BankName"] in banknames])
+    pltdata["rows"] = np.array(
+        [pws.row(i)["Row"] for i in range(pws.getNumberPeaks()) if pws.row(i)["BankName"] in banknames])
+    # compute chi2_qsample
+    qsample = [pws.getPeak(i).getQSampleFrame() for i in range(pws.getNumberPeaks()) if pws.row(i)["BankName"] in banknames]
+    qsample_ideal = [
+        np.array(oriented_lattice.qFromHKL(pws.getPeak(i).getIntHKL())) for i in range(pws.getNumberPeaks())
+        if pws.row(i)["BankName"] in banknames
+    ]
+    pltdata["chi2_qsample"] = np.array([((qs - qs0)**2 / np.linalg.norm(qs0)**2).sum() for qs, qs0 in zip(qsample, qsample_ideal)])
+    # compute chi2_dspacing
+    dspacing = [pws.getPeak(i).getDSpacing() for i in range(pws.getNumberPeaks()) if pws.row(i)["BankName"] in banknames]
+    dspacing_ideal = [
+        oriented_lattice.d(pws.getPeak(i).getIntHKL()) for i in range(pws.getNumberPeaks())
+        if pws.row(i)["BankName"] in banknames
+    ]
+    pltdata["chi2_dspacing"] = np.array([(d / d0 - 1)**2 for d, d0 in zip(dspacing, dspacing_ideal)])
+    return pltdata
+
+
+def SCDCalibratePanels2PanelDiagnosticsPlot(
+    peaksWorkspace_engineering: Union[PeaksWorkspace, str],
+    peaksWorkspace_calibrated: Union[PeaksWorkspace, str],
+    banknames: Union[str, List[str]] = None,
+    generate_report: bool = True,
+    use_logscale: bool = True,
+    config: Dict[str, str] = {
+        "prefix": "fig",
+        "type": "png",
+        "saveto": ".",
+        "mode": "boxplot",
+    },
+    showPlots: bool = True,
+) -> List[Dict[str, np.ndarray]]:
+    """
+    Visualization of the diagnostic for SCDCalibratePanels2 on a per
+    panel (bank) basis.
+
+    @param peaksWorkspace: peaks workspace with calibrated instrument applied
+    @param banknames: bank(s) for diagnostics
+    @param generate_report: toggle on report generation, default is True.
+    @param use_logscale: use log scale to plot Chi2, default is True.
+    @param config: plot configuration dictionary
+            type: ["png", "pdf", "jpeg"]
+            mode: ["boxplot", "overlay"]
+    @param showPlots: open diagnostics plots after generating them.
+    """
+    # parse input
+    pws_eng = mtd[peaksWorkspace_engineering] if isinstance(peaksWorkspace_engineering, str) else peaksWorkspace_engineering
+    logging.info(f"Peaksworkspace at negineering position: {peaksWorkspace_engineering.name()}.")
+    pws_cal = mtd[peaksWorkspace_calibrated] if isinstance(peaksWorkspace_calibrated, str) else peaksWorkspace_calibrated
+    logging.info(f"Peaksworkspace at calibrated position: {peaksWorkspace_calibrated.name()}.")
+    #
+    if config["type"].lower() == "png" and generate_report:
+        logging.warning(f"Report must be in PDF format, ignoring type from config dict")
+    # remove non-index peaks
+    logging.info("Excluding non-index peaks")
+    tmp_eng = FilterPeaks(
+        InputWorkspace=pws_eng,
+        Operator='>',
+        FilterVariable='h^2+k^2+l^2',
+        FilterValue=0,
+    )
+    tmp_cal = FilterPeaks(
+        InputWorkspace=pws_cal,
+        Operator='>',
+        FilterVariable='h^2+k^2+l^2',
+        FilterValue=0,
+    )
+
+    # process all banks if banknames is None
+    if banknames is None:
+        # NOTE: SCDCalibratePanels will not change the assigned the bank name, therefore only need to
+        #       query the bankname from tmp_cal
+        banknames = set([tmp_cal.row(i)["BankName"] for i in range(tmp_cal.getNumberPeaks())])
+    elif isinstance(banknames, str):
+        banknames = [me.strip() for me in banknames.split(",")]
+    else:
+        pass
+
+    # prepare plotting data
+    # NOTE: take advantage of the table structure
+    logging.info("Prepare plotting data")
+    pltdata_eng = get_plot_data(tmp_eng, banknames)
+    pltdata_cal = get_plot_data(tmp_cal, banknames)
+
+    # generate plots
+    logging.info("Generating plots")
+
+    # close backend handle
+    if not showPlots:
+        plt.close("all")
+
+    return [pltdata_eng, pltdata_cal]
+
+
+if __name__ == "__main__":
+    pass

--- a/scripts/SCD_Reduction/SCDCalibratePanels2PanelDiagnostics.py
+++ b/scripts/SCD_Reduction/SCDCalibratePanels2PanelDiagnostics.py
@@ -153,6 +153,8 @@ def bank_overlay(
     # prep
     if generate_report:
         pp = PdfPages(os.path.join(saveto, figname))
+    else:
+        figname = os.path.join(saveto, "{}_" + figname)
     # compute the delta
     pltdata_delta = calc_overlay_delta(
         pltdata_eng=pltdata_eng,
@@ -211,6 +213,12 @@ def bank_overlay(
         ip2 = InsetPosition(ax_delta, [1.05, 0, 0.05, 1])
         cax_delta.set_axes_locator(ip2)
         fig.colorbar(view_delta, cax=cax_delta, ax=[ax_delta])
+
+        # save the image
+        if generate_report:
+            fig.savefig(pp, format="pdf")
+        else:
+            fig.savefig(figname.format(bn))
 
         # display
         if show_plots:
@@ -386,4 +394,4 @@ def SCDCalibratePanels2PanelDiagnosticsPlot(
 
 
 if __name__ == "__main__":
-    pass
+    logging.warning("This module cannot be run as a script.")

--- a/scripts/SCD_Reduction/SCDCalibratePanels2PanelDiagnostics.py
+++ b/scripts/SCD_Reduction/SCDCalibratePanels2PanelDiagnostics.py
@@ -10,11 +10,130 @@ This module provides a new set of visualization tools to analyze the calibration
 results from SCDCalibratePanels2 (on a per bank base).
 """
 
+import os
 import logging
 import numpy as np
-from typing import List, Dict, Union
+import matplotlib.pyplot as plt
+from matplotlib.backends.backend_pdf import PdfPages
+from typing import List, Tuple, Dict, Union
 from mantid.dataobjects import PeaksWorkspace
-from mantid.simpleapi import mtd, FilterPeaks
+from mantid.simpleapi import mtd
+
+
+def bank_boxplot(
+    pltdata_eng: Dict[str, np.ndarray],
+    pltdata_cal: Dict[str, np.ndarray],
+    figname: str = None,
+    saveto: str = ".",
+    use_logscale: bool = True,
+    show_plots: bool = True,
+) -> None:
+    """
+    Generate scatter plots of chi2 computed based on the
+    given calibrated instrument.
+    Both Chi2(q) and Chi2(d) are used to evaluate the Chi2
+    results on each bank.
+
+    @param pltdata_eng: plot data collected at engineering position.
+    @param pltdata_cal: plot data collected at calibrated position.
+    @param figname: figure name.
+    @param saveto: directory to save the output
+    @param use_logscale: use log scale to plot Chi2, default is True.
+    """
+    # prep data
+    chi2qs_eng, chi2ds_eng, _, bn_num_eng = get_boxplot_data(pltdata_eng)
+    chi2qs_cal, chi2ds_cal, _, bn_num_cal = get_boxplot_data(pltdata_cal)
+
+    #
+    fig = plt.figure(figsize=(12, 4))
+    # -------
+    # qsample
+    # -------
+    ax_qs = fig.add_subplot(2, 1, 1)
+    #
+    box_eng = ax_qs.boxplot(chi2qs_eng, positions=bn_num_eng, notch=True, showfliers=False)
+    for _, lines in box_eng.items():
+        for line in lines:
+            line.set_color('b')
+            line.set_linestyle(":")
+    #
+    box_cal = ax_qs.boxplot(chi2qs_cal, positions=bn_num_cal, notch=True, showfliers=False)
+    for _, lines in box_cal.items():
+        for line in lines:
+            line.set_color('r')
+    #
+    ax_qs.set_xlabel(r'[bank no.]')
+    ax_qs.set_ylabel(r'$\chi^2(Q)$')
+    ax_qs.set_title(r'Goodness of fit')
+    if use_logscale:
+        ax_qs.set_yscale("log")
+    ax_qs.legend(
+        [box_eng["boxes"][0], box_cal["boxes"][0]],
+        ["engineering", "calibration"],
+        loc='lower right',
+    )
+    # --------
+    # dspacing
+    # --------
+    ax_ds = fig.add_subplot(2, 1, 2)
+    box_eng = ax_ds.boxplot(chi2ds_eng, positions=bn_num_eng, notch=True, showfliers=False)
+    for _, lines in box_eng.items():
+        for line in lines:
+            line.set_color('b')
+            line.set_linestyle(":")
+    box_cal = ax_ds.boxplot(chi2ds_cal, positions=bn_num_cal, notch=True, showfliers=False)
+    for _, lines in box_cal.items():
+        for line in lines:
+            line.set_color('r')
+    ax_ds.set_xlabel(r'[bank no.]')
+    ax_ds.set_ylabel(r'$\chi^2(d)$')
+    if use_logscale:
+        ax_ds.set_yscale("log")
+    ax_ds.legend(
+        [box_eng["boxes"][0], box_cal["boxes"][0]],
+        ["engineering", "calibration"],
+        loc='lower right',
+    )
+
+    # save figure
+    # NOTE: save first, then display to avoid weird corruption of written figure
+    fig.savefig(os.path.join(saveto, figname))
+    # display
+    if show_plots:
+        fig.show()
+    # notify users
+    logging.info(f"Figure {figname} is saved to {saveto}.")
+
+
+def get_boxplot_data(pltdata: Dict[str, np.ndarray]) -> Tuple[list, list, np.ndarray, np.ndarray]:
+    """
+    Helper function to organize the plot data for box plot
+
+    @param pltdata: input dict containing plot data
+
+    @return chi2qs: list
+            chi2ds: list
+            bn_str: np.ndarray (1, N_bank)
+            bn_num: np.ndarray (1, N_bank)
+    """
+    bn_str = np.unique(pltdata["banknames"])
+    bn_num = np.array([int(bn.replace("bank", "")) for bn in bn_str])
+    chi2qs = [pltdata["chi2_qsample"][np.where(pltdata["banknames"] == bn)] for bn in bn_str]
+    chi2ds = [pltdata["chi2_dspacing"][np.where(pltdata["banknames"] == bn)] for bn in bn_str]
+    return chi2qs, chi2ds, bn_str, bn_num
+
+
+def bank_overlay(
+    pltdata_eng: Dict[str, np.ndarray],
+    pltdata_cal: Dict[str, np.ndarray],
+    generate_report: bool = True,
+    use_logscale: bool = True,
+) -> None:
+    """
+    """
+    pp = PdfPages('test.pdf')
+    pp.close()
+    pass
 
 
 def get_plot_data(
@@ -30,12 +149,9 @@ def get_plot_data(
     pltdata = {}
     oriented_lattice = pws.sample().getOrientedLattice()
     # det info
-    pltdata["banknames"] = np.array(
-        [pws.row(i)["BankName"] for i in range(pws.getNumberPeaks()) if pws.row(i)["BankName"] in banknames])
-    pltdata["cols"] = np.array(
-        [pws.row(i)["Col"] for i in range(pws.getNumberPeaks()) if pws.row(i)["BankName"] in banknames])
-    pltdata["rows"] = np.array(
-        [pws.row(i)["Row"] for i in range(pws.getNumberPeaks()) if pws.row(i)["BankName"] in banknames])
+    pltdata["banknames"] = np.array([pws.row(i)["BankName"] for i in range(pws.getNumberPeaks()) if pws.row(i)["BankName"] in banknames])
+    pltdata["cols"] = np.array([pws.row(i)["Col"] for i in range(pws.getNumberPeaks()) if pws.row(i)["BankName"] in banknames])
+    pltdata["rows"] = np.array([pws.row(i)["Row"] for i in range(pws.getNumberPeaks()) if pws.row(i)["BankName"] in banknames])
     # compute chi2_qsample
     qsample = [pws.getPeak(i).getQSampleFrame() for i in range(pws.getNumberPeaks()) if pws.row(i)["BankName"] in banknames]
     qsample_ideal = [
@@ -46,8 +162,7 @@ def get_plot_data(
     # compute chi2_dspacing
     dspacing = [pws.getPeak(i).getDSpacing() for i in range(pws.getNumberPeaks()) if pws.row(i)["BankName"] in banknames]
     dspacing_ideal = [
-        oriented_lattice.d(pws.getPeak(i).getIntHKL()) for i in range(pws.getNumberPeaks())
-        if pws.row(i)["BankName"] in banknames
+        oriented_lattice.d(pws.getPeak(i).getIntHKL()) for i in range(pws.getNumberPeaks()) if pws.row(i)["BankName"] in banknames
     ]
     pltdata["chi2_dspacing"] = np.array([(d / d0 - 1)**2 for d, d0 in zip(dspacing, dspacing_ideal)])
     return pltdata
@@ -61,7 +176,7 @@ def SCDCalibratePanels2PanelDiagnosticsPlot(
     use_logscale: bool = True,
     config: Dict[str, str] = {
         "prefix": "fig",
-        "type": "png",
+        "type": "pdf",
         "saveto": ".",
         "mode": "boxplot",
     },
@@ -81,27 +196,10 @@ def SCDCalibratePanels2PanelDiagnosticsPlot(
     @param showPlots: open diagnostics plots after generating them.
     """
     # parse input
-    pws_eng = mtd[peaksWorkspace_engineering] if isinstance(peaksWorkspace_engineering, str) else peaksWorkspace_engineering
+    tmp_eng = mtd[peaksWorkspace_engineering] if isinstance(peaksWorkspace_engineering, str) else peaksWorkspace_engineering
     logging.info(f"Peaksworkspace at negineering position: {peaksWorkspace_engineering.name()}.")
-    pws_cal = mtd[peaksWorkspace_calibrated] if isinstance(peaksWorkspace_calibrated, str) else peaksWorkspace_calibrated
+    tmp_cal = mtd[peaksWorkspace_calibrated] if isinstance(peaksWorkspace_calibrated, str) else peaksWorkspace_calibrated
     logging.info(f"Peaksworkspace at calibrated position: {peaksWorkspace_calibrated.name()}.")
-    #
-    if config["type"].lower() == "png" and generate_report:
-        logging.warning(f"Report must be in PDF format, ignoring type from config dict")
-    # remove non-index peaks
-    logging.info("Excluding non-index peaks")
-    tmp_eng = FilterPeaks(
-        InputWorkspace=pws_eng,
-        Operator='>',
-        FilterVariable='h^2+k^2+l^2',
-        FilterValue=0,
-    )
-    tmp_cal = FilterPeaks(
-        InputWorkspace=pws_cal,
-        Operator='>',
-        FilterVariable='h^2+k^2+l^2',
-        FilterValue=0,
-    )
 
     # process all banks if banknames is None
     if banknames is None:
@@ -121,6 +219,23 @@ def SCDCalibratePanels2PanelDiagnosticsPlot(
 
     # generate plots
     logging.info("Generating plots")
+    #
+    if config["mode"] == "boxplot":
+        logging.info("Mode -> boxplot for chi2")
+        # call the plotter
+        bank_boxplot(
+            pltdata_eng=pltdata_eng,
+            pltdata_cal=pltdata_cal,
+            figname=f"{config['prefix']}.{config['type']}",
+            saveto=config["saveto"],
+            use_logscale=use_logscale,
+            show_plots=showPlots,
+        )
+    elif config["mode"] == "overlay":
+        logging.info("Mode -> overlay chi2 on bank")
+        pass
+    else:
+        raise ValueError(f"Unsupported mode detected, only support boxplot and overlay.")
 
     # close backend handle
     if not showPlots:

--- a/scripts/SCD_Reduction/SCDCalibratePanels2PanelDiagnostics.py
+++ b/scripts/SCD_Reduction/SCDCalibratePanels2PanelDiagnostics.py
@@ -15,6 +15,8 @@ import logging
 import numpy as np
 import matplotlib.pyplot as plt
 from matplotlib.backends.backend_pdf import PdfPages
+from matplotlib.colors import LogNorm, SymLogNorm
+from mpl_toolkits.axes_grid1.inset_locator import InsetPosition
 from typing import List, Tuple, Dict, Union
 from mantid.dataobjects import PeaksWorkspace
 from mantid.simpleapi import mtd
@@ -23,6 +25,7 @@ from mantid.simpleapi import mtd
 def bank_boxplot(
     pltdata_eng: Dict[str, np.ndarray],
     pltdata_cal: Dict[str, np.ndarray],
+    figsize: np.ndarray,
     figname: str = None,
     saveto: str = ".",
     use_logscale: bool = True,
@@ -36,16 +39,18 @@ def bank_boxplot(
 
     @param pltdata_eng: plot data collected at engineering position.
     @param pltdata_cal: plot data collected at calibrated position.
+    @param figsize: figure size, e.g. (12, 4)
     @param figname: figure name.
     @param saveto: directory to save the output
     @param use_logscale: use log scale to plot Chi2, default is True.
+    @param show_plots: show plots interactively
     """
     # prep data
     chi2qs_eng, chi2ds_eng, _, bn_num_eng = get_boxplot_data(pltdata_eng)
     chi2qs_cal, chi2ds_cal, _, bn_num_cal = get_boxplot_data(pltdata_cal)
 
     #
-    fig = plt.figure(figsize=(12, 4))
+    fig = plt.figure(figsize=figsize)
     # -------
     # qsample
     # -------
@@ -62,7 +67,6 @@ def bank_boxplot(
         for line in lines:
             line.set_color('r')
     #
-    ax_qs.set_xlabel(r'[bank no.]')
     ax_qs.set_ylabel(r'$\chi^2(Q)$')
     ax_qs.set_title(r'Goodness of fit')
     if use_logscale:
@@ -126,14 +130,121 @@ def get_boxplot_data(pltdata: Dict[str, np.ndarray]) -> Tuple[list, list, np.nda
 def bank_overlay(
     pltdata_eng: Dict[str, np.ndarray],
     pltdata_cal: Dict[str, np.ndarray],
+    figsize: np.ndarray,
     generate_report: bool = True,
+    figname: str = None,
+    saveto: str = ".",
     use_logscale: bool = True,
+    show_plots: bool = True,
 ) -> None:
     """
+    Plot the Chi2_QSample directly on top of bank to visualize how calibration is affecting
+    different regions of the bank.
+
+    @param pltdata_eng: plot data collected at engineering position.
+    @param pltdata_cal: plot data collected at calibrated position.
+    @param figsize: figure size, e.g. (14, 10)
+    @param generate_report: combine all figures into one PDF file
+    @param figname: figure name.
+    @param saveto: directory to save the output
+    @param use_logscale: use log scale to plot Chi2, default is True.
+    @param show_plots: show plots interactively
     """
-    pp = PdfPages('test.pdf')
-    pp.close()
-    pass
+    # prep
+    if generate_report:
+        pp = PdfPages(os.path.join(saveto, figname))
+    # compute the delta
+    pltdata_delta = calc_overlay_delta(
+        pltdata_eng=pltdata_eng,
+        pltdata_cal=pltdata_cal,
+    )
+
+    # get per bank data
+    bn_str = np.unique(pltdata_eng["banknames"])
+    for bn in bn_str:
+        # engineering
+        chi2qs_eng = pltdata_eng["chi2_qsample"][np.where(pltdata_eng["banknames"] == bn)]
+        row_eng = pltdata_eng["rows"][np.where(pltdata_eng["banknames"] == bn)]
+        col_eng = pltdata_eng["cols"][np.where(pltdata_eng["banknames"] == bn)]
+        # calibration
+        chi2qs_cal = pltdata_cal["chi2_qsample"][np.where(pltdata_cal["banknames"] == bn)]
+        row_cal = pltdata_cal["rows"][np.where(pltdata_cal["banknames"] == bn)]
+        col_cal = pltdata_cal["cols"][np.where(pltdata_cal["banknames"] == bn)]
+        #
+        chi2qs_min = min(chi2qs_eng.min(), chi2qs_cal.min())
+        chi2qs_max = max(chi2qs_eng.max(), chi2qs_cal.max())
+        # delta
+        chi2qs_delta = pltdata_delta["chi2_qsample"][np.where(pltdata_delta["banknames"] == bn)]
+        row_delta = pltdata_delta["rows"][np.where(pltdata_delta["banknames"] == bn)]
+        col_delta = pltdata_delta["cols"][np.where(pltdata_delta["banknames"] == bn)]
+        delta_range = max(abs(chi2qs_delta.min()), abs(chi2qs_delta.max())) * 10
+        # plotting
+        fig, (ax_eng, ax_cal, cax, ax_delta, cax_delta) = plt.subplots(
+            ncols=5,
+            figsize=figsize,
+            gridspec_kw={"width_ratios": [1, 1, 0.05, 1, 0.05]},
+        )
+        fig.suptitle(bn)
+        ax_eng.set_title(r"$\chi^2(Q)_{eng}$")
+        ax_cal.set_title(r"$\chi^2(Q)_{cal}$")
+        ax_delta.set_title(r"$\chi^2(Q)_{cal} - \chi^2(Q)_{eng}$")
+        fig.subplots_adjust(wspace=0.3)
+        if use_logscale:
+            view_eng = ax_eng.scatter(col_eng, row_eng, c=chi2qs_eng, vmin=chi2qs_min, vmax=chi2qs_max, norm=LogNorm())
+            _ = ax_cal.scatter(col_cal, row_cal, c=chi2qs_cal, vmin=chi2qs_min, vmax=chi2qs_max, norm=LogNorm())
+            view_delta = ax_delta.scatter(col_delta,
+                                          row_delta,
+                                          c=chi2qs_delta,
+                                          vmin=-delta_range,
+                                          vmax=delta_range,
+                                          norm=SymLogNorm(linthresh=abs(chi2qs_delta.min()) / 10),
+                                          cmap="bwr")
+        else:
+            view_eng = ax_eng.scatter(col_eng, row_eng, c=chi2qs_eng, vmin=chi2qs_min, vmax=chi2qs_max)
+            _ = ax_cal.scatter(col_cal, row_cal, c=chi2qs_cal, vmin=chi2qs_min, vmax=chi2qs_max)
+            view_delta = ax_delta.scatter(col_delta, row_delta, c=chi2qs_delta, vmin=-delta_range, vmax=delta_range, cmap="bwr")
+        # colorbar 1
+        ip = InsetPosition(ax_cal, [1.05, 0, 0.05, 1])
+        cax.set_axes_locator(ip)
+        fig.colorbar(view_eng, cax=cax, ax=[ax_eng, ax_cal])
+        # colorbar 2
+        ip2 = InsetPosition(ax_delta, [1.05, 0, 0.05, 1])
+        cax_delta.set_axes_locator(ip2)
+        fig.colorbar(view_delta, cax=cax_delta, ax=[ax_delta])
+
+        # display
+        if show_plots:
+            fig.show()
+
+    # close file handle if necessary
+    if generate_report:
+        pp.close()
+
+
+def calc_overlay_delta(
+    pltdata_eng: Dict[str, np.ndarray],
+    pltdata_cal: Dict[str, np.ndarray],
+) -> Dict[str, np.ndarray]:
+    """
+    Return a dictionary containing the pair wise relative difference
+
+    @param pltdata_eng: plot data collected at engineering position.
+    @param pltdata_cal: plot data collected at calibrated position.
+
+    @returns: dict
+    """
+    pltdata_delta = {}
+
+    detids = np.intersect1d(pltdata_eng["detid"], pltdata_cal["detid"])
+
+    for lb in ["banknames", "cols", "rows"]:
+        pltdata_delta[lb] = np.array([pltdata_eng[lb][np.where(pltdata_eng["detid"] == detid)][0] for detid in detids])
+    # compute the delta
+    qs_eng = [pltdata_eng["chi2_qsample"][np.where(pltdata_eng["detid"] == detid)][0] for detid in detids]
+    qs_cal = [pltdata_cal["chi2_qsample"][np.where(pltdata_cal["detid"] == detid)][0] for detid in detids]
+    pltdata_delta["chi2_qsample"] = np.array([(q1 - q0) for q0, q1 in zip(qs_eng, qs_cal)])
+
+    return pltdata_delta
 
 
 def get_plot_data(
@@ -152,6 +263,7 @@ def get_plot_data(
     pltdata["banknames"] = np.array([pws.row(i)["BankName"] for i in range(pws.getNumberPeaks()) if pws.row(i)["BankName"] in banknames])
     pltdata["cols"] = np.array([pws.row(i)["Col"] for i in range(pws.getNumberPeaks()) if pws.row(i)["BankName"] in banknames])
     pltdata["rows"] = np.array([pws.row(i)["Row"] for i in range(pws.getNumberPeaks()) if pws.row(i)["BankName"] in banknames])
+    pltdata["detid"] = np.array([pws.row(i)["DetID"] for i in range(pws.getNumberPeaks()) if pws.row(i)["BankName"] in banknames])
     # compute chi2_qsample
     qsample = [pws.getPeak(i).getQSampleFrame() for i in range(pws.getNumberPeaks()) if pws.row(i)["BankName"] in banknames]
     qsample_ideal = [
@@ -172,13 +284,13 @@ def SCDCalibratePanels2PanelDiagnosticsPlot(
     peaksWorkspace_engineering: Union[PeaksWorkspace, str],
     peaksWorkspace_calibrated: Union[PeaksWorkspace, str],
     banknames: Union[str, List[str]] = None,
+    mode: str = "boxplot",
     generate_report: bool = True,
     use_logscale: bool = True,
     config: Dict[str, str] = {
         "prefix": "fig",
-        "type": "pdf",
+        "type": "png",
         "saveto": ".",
-        "mode": "boxplot",
     },
     showPlots: bool = True,
 ) -> List[Dict[str, np.ndarray]]:
@@ -186,8 +298,10 @@ def SCDCalibratePanels2PanelDiagnosticsPlot(
     Visualization of the diagnostic for SCDCalibratePanels2 on a per
     panel (bank) basis.
 
-    @param peaksWorkspace: peaks workspace with calibrated instrument applied
+    @param peaksWorkspace_engineering: peaks workspace with engineering instrument applied
+    @param peaksWorkspace_calibrated: peaks workspace with calibrated instrument applied
     @param banknames: bank(s) for diagnostics
+    @param mode: plotting mode [boxplot, overlay]
     @param generate_report: toggle on report generation, default is True.
     @param use_logscale: use log scale to plot Chi2, default is True.
     @param config: plot configuration dictionary
@@ -200,6 +314,20 @@ def SCDCalibratePanels2PanelDiagnosticsPlot(
     logging.info(f"Peaksworkspace at negineering position: {peaksWorkspace_engineering.name()}.")
     tmp_cal = mtd[peaksWorkspace_calibrated] if isinstance(peaksWorkspace_calibrated, str) else peaksWorkspace_calibrated
     logging.info(f"Peaksworkspace at calibrated position: {peaksWorkspace_calibrated.name()}.")
+
+    # set default config for incomplete config dict
+    if "prefix" not in config.keys():
+        config["prefix"] = "fig"
+    if "type" not in config.keys():
+        config["type"] = "png"
+    if "saveto" not in config.keys():
+        config["saveto"] = "."
+    # some hidden keywords
+    if "figsize" not in config.keys():
+        if mode == "boxplot":
+            config["figsize"] = (12, 4)
+        else:
+            config["figsize"] = (14, 10)
 
     # process all banks if banknames is None
     if banknames is None:
@@ -220,20 +348,33 @@ def SCDCalibratePanels2PanelDiagnosticsPlot(
     # generate plots
     logging.info("Generating plots")
     #
-    if config["mode"] == "boxplot":
+    if mode.lower() == "boxplot":
         logging.info("Mode -> boxplot for chi2")
         # call the plotter
         bank_boxplot(
             pltdata_eng=pltdata_eng,
             pltdata_cal=pltdata_cal,
+            figsize=np.array(config["figsize"]),
             figname=f"{config['prefix']}.{config['type']}",
             saveto=config["saveto"],
             use_logscale=use_logscale,
             show_plots=showPlots,
         )
-    elif config["mode"] == "overlay":
+    elif mode.lower() == "overlay":
+        if generate_report:
+            logging.warning("Requested report, use PDF as output format.")
+            config['type'] = 'pdf'
         logging.info("Mode -> overlay chi2 on bank")
-        pass
+        bank_overlay(
+            pltdata_eng=pltdata_eng,
+            pltdata_cal=pltdata_cal,
+            figsize=np.array(config["figsize"]),
+            generate_report=generate_report,
+            figname=f"{config['prefix']}.{config['type']}",
+            saveto=config["saveto"],
+            use_logscale=use_logscale,
+            show_plots=showPlots,
+        )
     else:
         raise ValueError(f"Unsupported mode detected, only support boxplot and overlay.")
 


### PR DESCRIPTION
**Description of work.**

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

- Original Gitlab User Story: [SCD351](https://code.ornl.gov/sns-hfir-scse/diffraction/single-crystal/single-crystal-diffraction/-/issues/351)
- This is #31870 into `master`

This PR introduces a new plotting script that will generate two types of plots to visualize the calibration output from `SCDCalibratePanels2`.

> more details can be found in testing section.


**To test:**

- Similar to other PRs related to `SCDCalibratePanels2`, we are starting off by generating a synthetic PeaksWorkspace
```python
from mantid.simpleapi import *
from mantid.geometry import CrystalStructure
import matplotlib.pyplot as plt
import numpy as np

from collections import namedtuple

def convert(dictionary):
    return namedtuple('GenericDict', dictionary.keys())(**dictionary)

lc_natrolite = {
    "a": 18.29,  # A
    "b": 18.64,  # A
    "c": 6.56,  # A
    "alpha": 90,  # deg
    "beta": 90,  # deg
    "gamma": 90,  # deg
}
natrolite = convert(lc_natrolite)

CreateSimulationWorkspace(
    Instrument='TOPAZ',
    BinParams='1,100,10000',
    UnitX='TOF',
    OutputWorkspace='cws',
)
cws = mtd['cws']

# Set the UB matrix for the sample
# u, v is the critical part, we can start with the
# ideal position
SetUB(
    Workspace="cws",
    u='1,0,0',  # vector along k_i, when goniometer is at 0
    v='0,1,0',  # in-plane vector normal to k_i, when goniometer is at 0
    **lc_natrolite,
)

# Generate predicted peak workspace
dspacings = convert({'min': 1.0, 'max': 10.0})
wavelengths = convert({'min': 0.8, 'max': 2.9})

# Collect peaks over a range of omegas
CreatePeaksWorkspace(OutputWorkspace='pws')
omegas = range(0, 180, 3)

for omega in omegas:
    SetGoniometer(
        Workspace="cws",
        Axis0=f"{omega},0,1,0,1",
    )

    PredictPeaks(
        InputWorkspace='cws',
        WavelengthMin=wavelengths.min,
        wavelengthMax=wavelengths.max,
        MinDSpacing=dspacings.min,
        MaxDSpacing=dspacings.max,
        ReflectionCondition='All-face centred',
        OutputWorkspace='_pws',
    )

    CombinePeaksWorkspaces(
        LHSWorkspace="_pws",
        RHSWorkspace="pws",
        OutputWorkspace="pws",
    )

IndexPeaks("pws")
```

- invoke `SCDCalibratePanels2` to get the calibration results
```pyhton
SCDCalibratePanels(
  PeakWorkspace='pws', 
  RecalculateUB=False,
  a=18.29, b=18.64, c=6.56, alpha=90, beta=90, gamma=90,
  CalibrateBanks=True, 
  SearchRadiusTransBank=0.1, 
  SearchradiusRotXBank=90, 
  SearchradiusRotYBank=90, 
  SearchradiusRotZBank=90,
  CalibrateT0=True,
  TuneSamplePosition=True,
  OutputWorkspace='pws_caliL1', 
  DetCalFilename='SCDCalibrate2.DetCal',
  VerboseOutput=True,
)
```

- Clone and applied the calibration results
```python
CloneWorkspace(InputWorkspace='pws', OutputWorkspace='pws_cali')
LoadIsawDetCal(InputWorkspace='pws_cali', Filename='SCDCalibrate2.DetCal')
ApplyInstrumentToPeaks(InputWorkspace='pws_cali', InstrumentWorkspace='pws_cali', OutputWorkspace='pws_cali')
```

- Visualize the calibration output using boxplot
```python
from SCD_Reduction.SCDCalibratePanels2PanelDiagnostics import SCDCalibratePanels2PanelDiagnosticsPlot
SCDCalibratePanels2PanelDiagnosticsPlot(
    pws,
    pws_cali,
    mode="boxplot",
)
```
which gives us
![image](https://user-images.githubusercontent.com/5064852/123104418-eca31300-d404-11eb-993f-d113c090524f.png)

- Visualize the calibration output using overlay plot
```python
SCDCalibratePanels2PanelDiagnosticsPlot(
    pws,
    pws_cali,
#     banknames="bank58",
    mode="overlay",
    config={
        "figsize": (12, 3.5),
   },
)
```
which gives us a report file ([report.pdf](https://github.com/mantidproject/mantid/files/6702145/report.pdf)) containing figures like below
![image](https://user-images.githubusercontent.com/5064852/123105194-98e4f980-d405-11eb-918f-0474619570ae.png)

> depending on the instrument geometry, user might want to adjust the figure size so that the overlay plot matches the actual instrument aspect ratio (if desired)

> it is also possible to only view a subset of the banks by setting the parameter `banknames`, which can be either a string of banknames separated by comma, or a list of banknames.

> there are other paramters in the `config`, which can be used to further adjust the output (for most common cases, it is not necessary to adjust them)



<!-- Instructions for testing. -->

<!-- and fix #xxxx or close #xxxx xor resolves #xxxx -->
<!-- alternative
*There is no associated issue.*
-->

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or master)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
