### PR TITLE
Fixes for CrystalFieldMultiSite objects created by combination of CrystalField objects

### DIFF
--- a/docs/source/interfaces/indirect/Crystal Field Python Interface.rst
+++ b/docs/source/interfaces/indirect/Crystal Field Python Interface.rst
@@ -527,19 +527,14 @@ Intensity scaling for multiple ions
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 For multiple ions there are two options for creating a `CrystalFieldMultiSite` object. Either two `CrystalField` objects
 are combined or a `CrystalFieldMultiSite` object is created directly.
-Please note that the first `CrystalField` object with a scaling factor is set as ion0 when combining two `CrystalField`
-objects::
+The following example::
 
     cf = cf1 + 0.5*cf2
 
-creates a `CrystalFieldMultiSite` object with `cf2` as ion0 and `cf1` as ion1. It is worth mentioning that in case of two
-`CrystalField` objects with a scaling factor the scaling factor of the second object is ignored::
+creates a `CrystalFieldMultiSite` object with `cf1` as ion0 and `cf2` as ion1. It is also possible to have scaling factors
+for both `CrystalField` objects::
 
     cf = 2*cf1 + 3*cf2
-
-results in the same `CrystalFieldMultiSite` object as::
-
-    cf = 2*cf1 + cf2
 
 After combining `CrystalField` objects to a `CrystalFieldMultiSite` object further changes to the original `CrystalField`
 objects are not reflected in the `CrystalFieldMultiSite` object. Furthermore, the `CrystalFieldMultiSite` object does not
@@ -564,7 +559,7 @@ results in the following `CrystalFieldMultiSite` object and tie::
     cfms = CrystalFieldMultiSite(Ions=['Ce', 'Pr'], Symmetries=['C2v', 'C2v'], Temperatures=[44.0], FWHMs=[1.1], abundances=[2.0, 1.0]
                                 parameters={'ion0.B20':0.377,'ion0.B22':3.9,'ion0.B40':-0.03,'ion0.B42':-0.116,'ion0.B44':-0.125,
                                             'ion1.B20':0.377,'ion1.B22':3.9,'ion1.B40':-0.03,'ion1.B42':-0.116,'ion1.B44':-0.125})
-    cfms.ties({'ion0.IntensityScaling' : '0.5*ion1.IntensityScaling'})
+    cfms.ties({'ion1.IntensityScaling' : '0.5*ion0.IntensityScaling'})
 
 In addition to creating the equivalent `CrystalFieldMultiSite` object the coefficient is used to set a tie for the
 `IntensityScaling` parameter of ion0 relative to the `IntensityScaling` parameter of ion1. For the tie the coefficient of
@@ -574,8 +569,7 @@ expression are stored as `abundances`.
 Creating the `CrystalFieldMultiSite` object directly allows for more flexibility. First of all, instead of setting values
 for `abundances` it is possible to set the tie directly. Furthermore, if no ties for `IntensityScaling` are required this can
 be achieved by not defining any `abundances` in the constructor. Without a tie the `IntensityScaling` parameters for each ion
-can be set individually. Please note that setting values for `IntensityScaling` in the `CrystalFieldMultiSite` constructor
-will fix the respective parameter to the specified value and not just initialize it as for the `CrystalField` object..
+can be set individually to an initial value and might vary during the fitting process.
 
 Multiple ions fitted to multiple spectra
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -596,7 +590,7 @@ Creating the `CrystalFieldMultiSite` object directly allows to set each of the `
                                             'ion0.IntensityScaling':3.0, 'ion1.IntensityScaling':2.0,
                                             'sp0.IntensityScaling':1.5, 'sp1.IntensityScaling':0.007})
 
-As in the single spectra case `IntensityScaling` values are fixed to the set value or to 1 if there is no setting. The
+As in the single spectra case `IntensityScaling` values are initial values and default to 1 if there is no setting. The
 ties can either be added directly or by adding the corresponding `abundances` with a value per ion in the constructor.
 
 

--- a/docs/source/interfaces/indirect/Crystal Field Python Interface.rst
+++ b/docs/source/interfaces/indirect/Crystal Field Python Interface.rst
@@ -583,7 +583,7 @@ When fitting multiple ions to multiple spectra the `IntensityScaling` factor is 
 of the respective ion and the respective spectrum.
 
 The `IntensityScaling` factors for the spectra are preserved from the `CrystalField` objects in the combination. If only
-one of the `CrystalField` objects has `IntensityScaling` values set these used for the `CrystalFieldMultiSite` object.
+one of the `CrystalField` objects has `IntensityScaling` values set these are used for the `CrystalFieldMultiSite` object.
 In case of different settings for the original `CrystalField` objects the values for the object defining ion0 are used
 and a warning about this mismatch displayed.
 

--- a/docs/source/interfaces/indirect/Crystal Field Python Interface.rst
+++ b/docs/source/interfaces/indirect/Crystal Field Python Interface.rst
@@ -536,6 +536,8 @@ for both `CrystalField` objects::
 
     cf = 2*cf1 + 3*cf2
 
+The scaling factors are also used as the `IntensityScaling` setting for the respective ion.
+
 After combining `CrystalField` objects to a `CrystalFieldMultiSite` object further changes to the original `CrystalField`
 objects are not reflected in the `CrystalFieldMultiSite` object. Furthermore, the `CrystalFieldMultiSite` object does not
 have a set function for `IntensityScaling` parameters. As a consequence, it is not possible to set these parameters later
@@ -544,8 +546,7 @@ as for the `CrystalField` object.
 Multiple ions fitted to a single spectrum
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 When combining two `CrystalField` objects for a single spectrum to a `CrystalFieldMultiSite` object the original values
-for `IntensityScaling` are ignored. Since only the coefficient of the first object is used, the 'IntensityScaling' for ion1
-always defaults to 1::
+for `IntensityScaling` are ignored::
 
     params = {'B20': 0.377, 'B22': 3.9, 'B40': -0.03, 'B42': -0.116, 'B44': -0.125,
           'Temperature': [44.0], 'FWHM': [1.1], 'IntensityScaling': [0.2]}
@@ -558,11 +559,12 @@ results in the following `CrystalFieldMultiSite` object and tie::
     from CrystalField import CrystalFieldMultiSite
     cfms = CrystalFieldMultiSite(Ions=['Ce', 'Pr'], Symmetries=['C2v', 'C2v'], Temperatures=[44.0], FWHMs=[1.1], abundances=[2.0, 1.0]
                                 parameters={'ion0.B20':0.377,'ion0.B22':3.9,'ion0.B40':-0.03,'ion0.B42':-0.116,'ion0.B44':-0.125,
-                                            'ion1.B20':0.377,'ion1.B22':3.9,'ion1.B40':-0.03,'ion1.B42':-0.116,'ion1.B44':-0.125})
+                                            'ion1.B20':0.377,'ion1.B22':3.9,'ion1.B40':-0.03,'ion1.B42':-0.116,'ion1.B44':-0.125,
+                                            `ion0.IntensityScaling`:2.0,`ion1.IntensityScaling`:1.0})
     cfms.ties({'ion1.IntensityScaling' : '0.5*ion0.IntensityScaling'})
 
 In addition to creating the equivalent `CrystalFieldMultiSite` object the coefficient is used to set a tie for the
-`IntensityScaling` parameter of ion0 relative to the `IntensityScaling` parameter of ion1. For the tie the coefficient of
+`IntensityScaling` parameter of ion1 relative to the `IntensityScaling` parameter of ion0. For the tie the coefficient of
 the respective ion is divided by the coefficient of the ion with the greatest coefficient. The coefficients from the combining
 expression are stored as `abundances`.
 

--- a/scripts/Inelastic/CrystalField/fitting.py
+++ b/scripts/Inelastic/CrystalField/fitting.py
@@ -1201,7 +1201,22 @@ class CrystalFieldSite(object):
                     params['sp'+str(x)+'.IntensityScaling'] = self.crystalField.IntensityScaling[x]
             if differentIntensities:
                 warnings.warn('Mismatch between IntensityScaling values of CrystalField objects', RuntimeWarning)
-        # Preserve fixes and ties
+        # Preserve ties and fixes
+        ties = {}
+        fixes = []
+        ties, fixes = self.getTiesAndFixes(other)
+        if self.crystalField.ResolutionModel is None:
+            FWHM = [self.crystalField._getFWHM(x) for x in range(self.crystalField.NumberOfSpectra)]
+            return CrystalFieldMultiSite(Ions=ions, Symmetries=symmetries, Temperatures=temperatures, FWHM=FWHM,
+                                         abundances=abundances, parameters=params, ties=ties,
+                                         fixedParameters = fixes)
+        else:
+            return CrystalFieldMultiSite(Ions=ions, Symmetries=symmetries, Temperatures=temperatures,
+                                         ResolutionModel=self.crystalField.ResolutionModel,
+                                         abundances=abundances, parameters=params, ties=ties,
+                                         fixedParameters = fixes)
+
+    def getTiesAndFixes(self, other):
         ties = {}
         fixes = []
         for prefix, obj in {'ion0.':self.crystalField, 'ion1.':other}.items():
@@ -1216,16 +1231,7 @@ class CrystalFieldSite(object):
                 if parName not in self.crystalField.field_parameter_names:
                     continue
                 fixes.append(prefix + parName)
-        if self.crystalField.ResolutionModel is None:
-            FWHM = [self.crystalField._getFWHM(x) for x in range(self.crystalField.NumberOfSpectra)]
-            return CrystalFieldMultiSite(Ions=ions, Symmetries=symmetries, Temperatures=temperatures, FWHM=FWHM,
-                                         abundances=abundances, parameters=params, ties=ties,
-                                         fixedParameters = fixes)
-        else:
-            return CrystalFieldMultiSite(Ions=ions, Symmetries=symmetries, Temperatures=temperatures,
-                                         ResolutionModel=self.crystalField.ResolutionModel,
-                                         abundances=abundances, parameters=params, ties=ties,
-                                         fixedParameters = fixes)
+        return ties, fixes
 
 
 #pylint: disable=too-few-public-methods

--- a/scripts/Inelastic/CrystalField/fitting.py
+++ b/scripts/Inelastic/CrystalField/fitting.py
@@ -1003,7 +1003,7 @@ class CrystalField(object):
     def __add__(self, other):
         from CrystalField.CrystalFieldMultiSite import CrystalFieldMultiSite
         if isinstance(other, CrystalFieldMultiSite):
-            return (1.0*self).__radd__(other)
+            return (other).__radd__(self)
         elif isinstance(other, CrystalFieldSite):
             return (1.0*self).__add__(other)
         if isinstance(other, CrystalField):
@@ -1174,7 +1174,7 @@ class CrystalFieldSite(object):
             abundances = [self.abundance, other.abundance]
             other = other.crystalField
         elif isinstance(other, CrystalFieldMultiSite):
-            return self.__radd__(other)
+            return other.__radd__(self)
         else:
             raise TypeError('Unsupported operand type(s) for +: CrystalFieldSite and %s' % other.__class__.__name__)
         ions = [self.crystalField.Ion, other.Ion]

--- a/scripts/Inelastic/CrystalField/fitting.py
+++ b/scripts/Inelastic/CrystalField/fitting.py
@@ -1003,7 +1003,7 @@ class CrystalField(object):
     def __add__(self, other):
         from CrystalField.CrystalFieldMultiSite import CrystalFieldMultiSite
         if isinstance(other, CrystalFieldMultiSite):
-            return other.__radd__(self)
+            return (1.0*self).__radd__(other)
         elif isinstance(other, CrystalFieldSite):
             return (1.0*self).__add__(other)
         if isinstance(other, CrystalField):
@@ -1174,7 +1174,7 @@ class CrystalFieldSite(object):
             abundances = [self.abundance, other.abundance]
             other = other.crystalField
         elif isinstance(other, CrystalFieldMultiSite):
-            return other.__radd__(self)
+            return self.__radd__(other)
         else:
             raise TypeError('Unsupported operand type(s) for +: CrystalFieldSite and %s' % other.__class__.__name__)
         ions = [self.crystalField.Ion, other.Ion]
@@ -1184,6 +1184,8 @@ class CrystalFieldSite(object):
         for bparam in CrystalField.field_parameter_names:
             params['ion0.' + bparam] = self.crystalField[bparam]
             params['ion1.' + bparam] = other[bparam]
+        params['ion0.IntensityScaling'] = abundances[0]
+        params['ion1.IntensityScaling'] = abundances[1]
         # Check IntensityScaling settings in original objects
         # If only one has IntensityScaling settings use these for CrystalFieldMultiSite object
         # Warn if both objects have IntensityScaling settings and these are not equal

--- a/scripts/test/CrystalFieldMultiSiteTest.py
+++ b/scripts/test/CrystalFieldMultiSiteTest.py
@@ -622,7 +622,14 @@ class CrystalFieldMultiSiteTests(unittest.TestCase):
         cf1 = CrystalField('Ce', 'C2v', **params)
         cf2 = CrystalField('Pr', 'C2v', **params)
         cf = cf1 + cf2
-        self.assertTrue(cf.function.isFixed("ion0.B21"))
+        self.assertTrue(cf.function.isFixed(cf.function.getParameterIndex("ion0.BmolX")))
+        self.assertTrue(cf.function.isFixed(cf.function.getParameterIndex("ion0.B21")))
+        self.assertTrue(cf.function.isFixed(cf.function.getParameterIndex("ion0.B43")))
+        self.assertTrue(cf.function.isFixed(cf.function.getParameterIndex("ion0.IB65")))
+        self.assertTrue(cf.function.isFixed(cf.function.getParameterIndex("ion1.BmolZ")))
+        self.assertTrue(cf.function.isFixed(cf.function.getParameterIndex("ion1.B41")))
+        self.assertTrue(cf.function.isFixed(cf.function.getParameterIndex("ion1.B66")))
+        self.assertTrue(cf.function.isFixed(cf.function.getParameterIndex("ion1.IB62")))
 
 
 if __name__ == '__main__':

--- a/scripts/test/CrystalFieldMultiSiteTest.py
+++ b/scripts/test/CrystalFieldMultiSiteTest.py
@@ -615,6 +615,15 @@ class CrystalFieldMultiSiteTests(unittest.TestCase):
         self.assertTrue('ion1.IntensityScaling=0.8*ion2.IntensityScaling' in ties)
         self.assertTrue('ion3.IntensityScaling=0.1*ion2.IntensityScaling' in ties)
 
+    def test_multi_ion_ties_and_fixes(self):
+        from CrystalField import CrystalField
+        params = {'B20': 0.37737, 'B22': 3.9770, 'B40': -0.031787, 'B42': -0.11611, 'B44': -0.12544,
+                  'Temperature': 44.0, 'FWHM': 1.1}
+        cf1 = CrystalField('Ce', 'C2v', **params)
+        cf2 = CrystalField('Pr', 'C2v', **params)
+        cf = cf1 + cf2
+        self.assertTrue(cf.function.isFixed("ion0.B21"))
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
**Description of work.**

These changes ensure that scaling factors, ties and fixed parameters are preserved when combining CrystalField objects to a CrystalFieldMultiSite object. 

Fixes #[31851](https://github.com/mantidproject/mantid/issues/31851) and #[31854](https://github.com/mantidproject/mantid/issues/31854)

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
