### PR TITLE
Fix cmake variable case to find OpenSSL on non-conda builds

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -18,7 +18,7 @@
                 "USE_PYTHON_DYNAMIC_LIB": "OFF",
                 "Qt5_DIR": "$env{CONDA_PREFIX}/lib/cmake/qt5",
                 "HDF5_ROOT": "$env{CONDA_PREFIX}",
-                "OPENSSL_ROOT": "$env{CONDA_PREFIX}"
+                "OpenSSL_ROOT": "$env{CONDA_PREFIX}"
             }
         }
     ]

--- a/buildconfig/CMake/DarwinSetup.cmake
+++ b/buildconfig/CMake/DarwinSetup.cmake
@@ -124,9 +124,9 @@ set(PLUGINS_DIR plugins)
 # Mac-specific installation setup
 # ##############################################################################
 # use homebrew OpenSSL package
-if(NOT OPENSSL_ROOT)
-  set(OPENSSL_ROOT /usr/local/opt/openssl)
-endif(NOT OPENSSL_ROOT)
+if(NOT OpenSSL_ROOT)
+  set(OpenSSL_ROOT /usr/local/opt/openssl)
+endif()
 
 if(NOT HDF5_ROOT)
     set(HDF5_ROOT /usr/local/opt/hdf5) # Only for homebrew!


### PR DESCRIPTION
**Description of work.**

See commit description for details.

Fixes a regression from #31728.

**To test:**

* On mac, in a clean build directory, run cmake and it should completely successfully.  The current master version stops on finding `OpenSSL`.

*There is no associated issue.*

*This does not require release notes* because **it fixes a regression in builds.**

<!-- Ensure the base of this PR is correct (e.g. release-next or master)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
