### PR TITLE
Add missing icon for Windows Apps & features list.

### DIFF
--- a/buildconfig/CMake/NSIS.template.in
+++ b/buildconfig/CMake/NSIS.template.in
@@ -697,7 +697,7 @@ Section "-Core installation"
 
   ; Optional registration
   Push "DisplayIcon"
-  Push "$INSTDIR\@CPACK_NSIS_INSTALLED_ICON_NAME@"
+  Push "$INSTDIR\Uninstall.exe"
   Call ConditionalAddToRegisty
   Push "HelpLink"
   Push "@CPACK_NSIS_HELP_LINK@"

--- a/docs/source/release/v6.2.0/mantidworkbench.rst
+++ b/docs/source/release/v6.2.0/mantidworkbench.rst
@@ -21,5 +21,6 @@ Bugfixes
 - Fixed missing 'on top' windowing behaviour for the matrix and table workspace data displays.
 - Sliceviewer now doesn't normalise basis vectors for HKL data such that Bragg peaks appear at integer HKL for cuts along e.g. HH0
 - Fixed a bug where parameters wouldn't update in the fit property browser when fitting a single function with ties.
+- Added missing icon for the uninstaller in Windows "Apps & features" list.
 
 :ref:`Release 6.2.0 <v6.2.0>`


### PR DESCRIPTION
**Description of work.**
There was no icon for the application in either the "Apps & features" list or add/remove programs list for Windows. The icon has been added.

**To test:**
- Download and install the MantidUnstable installer built by the Windows Jenkins build:
https://builds.mantidproject.org/job/pull_requests-windows/44719/
- Go to the "Apps & features" list (search for it in the Start menu)
- Verify that the icon is there for MantidUnstable
- Go to the "Control Panel" and click "Uninstall a program" (under "Programs")
- Verify that the icon is there for MantidUnstable

Fixes #31654 .


---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
