### PR TITLE
Handle IOErrors saving .csv files

### DIFF
--- a/docs/source/release/v6.2.0/sans.rst
+++ b/docs/source/release/v6.2.0/sans.rst
@@ -18,6 +18,7 @@ New
 Bugfixes
 --------
 
+- The ISIS SANS Interface will now display an error, instead of an unexpected error, if the user does not have permission to save a CSV file to the requested location.
 
 Improvements
 ############

--- a/scripts/SANS/sans/gui_logic/presenter/run_tab_presenter.py
+++ b/scripts/SANS/sans/gui_logic/presenter/run_tab_presenter.py
@@ -720,10 +720,14 @@ class RunTabPresenter(PresenterCommon):
             filename = self.display_save_file_box("Save table as", default_filename, "*.csv")
             filename = self._get_filename_to_save(filename)
 
-            if filename:
-                self.sans_logger.information("Starting export of table. Filename: {}".format(filename))
+            if not filename:
+                return
+            self.sans_logger.information("Starting export of table. Filename: {}".format(filename))
+            try:
                 self._csv_parser.save_batch_file(rows=non_empty_rows, file_path=filename)
-                self.sans_logger.information("Table exporting finished.")
+            except (PermissionError, IOError) as e:
+                self.display_errors(error=e, context_msg="Failed to save the .csv file.", use_error_name=True)
+            self.sans_logger.information("Table exporting finished.")
 
     def on_multiperiod_changed(self, show_periods):
         if show_periods:

--- a/scripts/test/SANS/gui_logic/run_tab_presenter_test.py
+++ b/scripts/test/SANS/gui_logic/run_tab_presenter_test.py
@@ -558,6 +558,17 @@ class RunTabPresenterTest(unittest.TestCase):
         self.assertEqual(self._mock_csv_parser.save_batch_file.call_count, 1,
                          "_save_batch_file should have been called but was not")
 
+    def test_save_csv_handles_exceptions(self):
+        for exception in [PermissionError(), IOError()]:
+            self.presenter.display_errors = mock.Mock()
+            self._mock_csv_parser.save_batch_file.side_effect = exception
+            self._mock_table.get_non_empty_rows.return_value = BATCH_FILE_TEST_CONTENT_1
+            self._mock_model.batch_file = ""
+            self.presenter.display_save_file_box = mock.Mock(return_value="mocked_file_path")
+
+            self.presenter.on_export_table_clicked()
+            self.presenter.display_errors.assert_called_once()
+
     def test_that_table_not_exported_if_table_is_empty(self):
         self.presenter._export_table = mock.MagicMock()
         self._mock_table.get_non_empty_rows.return_value = []


### PR DESCRIPTION
**Description of work.**
Adds handling for Permission and IOErrors (such as no disk space). These
currently raise an uncaught exception, as there is no handler in the GUI
layer

**To test:**
- Create a folder somewhere
- On Linux: `chmod -w yourFolderName`
- On Windows: Go to folder Properties -> Permissions -> Remove write permission
- Try to create a file outside of Mantid, the write should be denied
- Open Mantid
- Open ISIS SANS
- Open the MaskFile.toml (or .txt) from the `ISIS Training Data/LoqDemo`
- Enter a random set of numbers (123) in the top left row/column of the table
- Hit the save icon for the table (looks like an arrow pointing to a file icon)
- Try to save to said folder, it should give a sensible error message

Fixes: #30009 

<!-- Ensure the base of this PR is correct (e.g. release-next or master)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
