### PR TITLE
Fix beam centre val handling

### DIFF
--- a/docs/source/release/v6.2.0/sans.rst
+++ b/docs/source/release/v6.2.0/sans.rst
@@ -20,6 +20,7 @@ Bugfixes
 --------
 
 - The ISIS SANS Interface will now display an error, instead of an unexpected error, if the user does not have permission to save a CSV file to the requested location.
+- The ISIS SANS interface will no longer throw an uncaught exception when a user tries to enter row information without loading a Mask/TOML file.
 
 Improvements
 ############

--- a/docs/source/release/v6.2.0/sans.rst
+++ b/docs/source/release/v6.2.0/sans.rst
@@ -21,6 +21,7 @@ Bugfixes
 
 - The ISIS SANS Interface will now display an error, instead of an unexpected error, if the user does not have permission to save a CSV file to the requested location.
 - The ISIS SANS interface will no longer throw an uncaught exception when a user tries to enter row information without loading a Mask/TOML file.
+- The ISIS SANS beam centre finder correctly accepts zero values (0.0) and won't try to replace them with empty strings.
 
 Improvements
 ############

--- a/scripts/SANS/sans/gui_logic/models/beam_centre_model.py
+++ b/scripts/SANS/sans/gui_logic/models/beam_centre_model.py
@@ -169,7 +169,7 @@ class BeamCentreModel(object):
     @property
     @apply_selective_view_scaling
     def lab_pos_1(self):
-        return self._lab_pos_1 if self._lab_pos_1 else ''
+        return self._lab_pos_1 if self._lab_pos_1 is not None else ''
 
     @lab_pos_1.setter
     @undo_selective_view_scaling
@@ -179,7 +179,7 @@ class BeamCentreModel(object):
     @property
     @apply_selective_view_scaling
     def lab_pos_2(self):
-        return self._lab_pos_2 if self._lab_pos_2 else ''
+        return self._lab_pos_2 if self._lab_pos_2 is not None else ''
 
     @lab_pos_2.setter
     @undo_selective_view_scaling
@@ -189,7 +189,7 @@ class BeamCentreModel(object):
     @property
     @apply_selective_view_scaling
     def hab_pos_1(self):
-        return self._hab_pos_1 if self._hab_pos_1 else ''
+        return self._hab_pos_1 if self._hab_pos_1 is not None else ''
 
     @hab_pos_1.setter
     @undo_selective_view_scaling
@@ -199,7 +199,7 @@ class BeamCentreModel(object):
     @property
     @apply_selective_view_scaling
     def hab_pos_2(self):
-        return self._hab_pos_2 if self._hab_pos_2 else ''
+        return self._hab_pos_2 if self._hab_pos_2 is not None else ''
 
     @hab_pos_2.setter
     @undo_selective_view_scaling

--- a/scripts/SANS/sans/gui_logic/presenter/beam_centre_presenter.py
+++ b/scripts/SANS/sans/gui_logic/presenter/beam_centre_presenter.py
@@ -13,8 +13,6 @@ from ui.sans_isis.beam_centre import BeamCentre
 
 
 class BeamCentrePresenter(object):
-    DECIMAL_PLACES_CENTRE_POS = 3
-
     class ConcreteBeamCentreListener(BeamCentre.BeamCentreListener):
         def __init__(self, presenter):
             self._presenter = presenter
@@ -58,10 +56,10 @@ class BeamCentrePresenter(object):
         # Enable button
         self._view.set_run_button_to_normal()
         # Update Centre Positions in model and GUI
-        self._view.lab_pos_1 = round(float(self._beam_centre_model.lab_pos_1), self.DECIMAL_PLACES_CENTRE_POS)
-        self._view.lab_pos_2 = round(float(self._beam_centre_model.lab_pos_2), self.DECIMAL_PLACES_CENTRE_POS)
-        self._view.hab_pos_1 = round(float(self._beam_centre_model.hab_pos_1), self.DECIMAL_PLACES_CENTRE_POS)
-        self._view.hab_pos_2 = round(float(self._beam_centre_model.hab_pos_2), self.DECIMAL_PLACES_CENTRE_POS)
+        self._view.lab_pos_1 = self._round(self._beam_centre_model.lab_pos_1)
+        self._view.lab_pos_2 = self._round(self._beam_centre_model.lab_pos_2)
+        self._view.hab_pos_1 = self._round(self._beam_centre_model.hab_pos_1)
+        self._view.hab_pos_2 = self._round(self._beam_centre_model.hab_pos_2)
 
     def on_processing_error_centre_finder(self, error):
         self._logger.warning("There has been an error. See more: {}".format(error))
@@ -130,14 +128,14 @@ class BeamCentrePresenter(object):
         lab_pos_1 = self._beam_centre_model.lab_pos_1
         lab_pos_2 = self._beam_centre_model.lab_pos_2
 
-        hab_pos_1 = self._beam_centre_model.hab_pos_1 if self._beam_centre_model.hab_pos_1 else lab_pos_1
-        hab_pos_2 = self._beam_centre_model.hab_pos_2 if self._beam_centre_model.hab_pos_2 else lab_pos_2
+        hab_pos_1 = self._beam_centre_model.hab_pos_1 if self._beam_centre_model.hab_pos_1 == '' else lab_pos_1
+        hab_pos_2 = self._beam_centre_model.hab_pos_2 if self._beam_centre_model.hab_pos_2 == '' else lab_pos_2
 
-        self._view.lab_pos_1 = round(float(lab_pos_1), self.DECIMAL_PLACES_CENTRE_POS)
-        self._view.lab_pos_2 = round(float(lab_pos_2), self.DECIMAL_PLACES_CENTRE_POS)
+        self._view.lab_pos_1 = self._round(lab_pos_1)
+        self._view.lab_pos_2 = self._round(lab_pos_2)
 
-        self._view.hab_pos_1 = round(float(hab_pos_1), self.DECIMAL_PLACES_CENTRE_POS)
-        self._view.hab_pos_2 = round(float(hab_pos_2), self.DECIMAL_PLACES_CENTRE_POS)
+        self._view.hab_pos_1 = self._round(hab_pos_1)
+        self._view.hab_pos_2 = self._round(hab_pos_2)
 
     def update_hab_selected(self):
         self._beam_centre_model.update_hab = True
@@ -173,6 +171,14 @@ class BeamCentrePresenter(object):
         attribute = getattr(state_model, attribute_name)
         if attribute or isinstance(attribute, bool):  # We need to be careful here. We don't want to set empty strings, or None, but we want to set boolean values. # noqa
             setattr(self._view, attribute_name, attribute)
+
+    def _round(self, val):
+        DECIMAL_PLACES_CENTRE_POS = 3
+        try:
+            val = float(val)
+        except ValueError:
+            return val
+        return round(val, DECIMAL_PLACES_CENTRE_POS)
 
     def _validate_radius_values(self):
         min_value = getattr(self._view, "r_min_line_edit").text()

--- a/scripts/test/SANS/gui_logic/beam_centre_model_test.py
+++ b/scripts/test/SANS/gui_logic/beam_centre_model_test.py
@@ -98,6 +98,17 @@ class BeamCentreModelTest(unittest.TestCase):
         self.beam_centre_model.lab_pos_1 = 'a'
         self.assertEqual(self.beam_centre_model.lab_pos_1, 'a')
 
+    def test_scaling_ignores_zero_vals(self):
+        self.beam_centre_model.lab_pos_1 = 0.0
+        self.beam_centre_model.lab_pos_2 = 0.0
+        self.beam_centre_model.hab_pos_1 = 0.0
+        self.beam_centre_model.hab_pos_2 = 0.0
+
+        self.assertEqual(0.0, self.beam_centre_model.lab_pos_1)
+        self.assertEqual(0.0, self.beam_centre_model.lab_pos_2)
+        self.assertEqual(0.0, self.beam_centre_model.hab_pos_1)
+        self.assertEqual(0.0, self.beam_centre_model.hab_pos_2)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/scripts/test/SANS/gui_logic/beam_centre_presenter_test.py
+++ b/scripts/test/SANS/gui_logic/beam_centre_presenter_test.py
@@ -88,6 +88,14 @@ class BeamCentrePresenterTest(unittest.TestCase):
         self.assertEqual(self.BeamCentreModel.hab_pos_2, self.view.hab_pos_2)
         self.view.set_run_button_to_normal.assert_called_once_with()
 
+    def test_on_update_positions_handles_strings(self):
+        self.BeamCentreModel.lab_pos_1 = "foo"
+        self.BeamCentreModel.lab_pos_2 = ""
+        self.presenter.update_centre_positions()
+
+        self.assertEqual("foo", self.view.lab_pos_1)
+        self.assertEqual("", self.view.lab_pos_2)
+
     def test_that_update_hab_selected_enabled_hab_and_disabled_lab(self):
         self.presenter.set_view(self.view)
         self.presenter.update_hab_selected()


### PR DESCRIPTION
**Description of work.**
Fixes two bugs noticed by a user / myself trialling stuff

- An empty mask file with a row entry throws
- 0.0 values were replaced in the beam centre finder

**To test:**

- Open the ISIS SANS GUI
- If you have a mark file pre-populated click mask file then cancel, then close the interface (important)
- Reopen the interface so a mask file is not pre-populated
- Enter a numeric value on the first row in the first column
- Click anywhere, no exception should be thrown
---
- Download the ISIS Training dataset
- Open the mask file (TOML or txt) from `loqdemo`
- Open the batch file (.csv) in the same folder
- Go to beam centre finder
- Enter 0.0 for the four Centre Position boxes (HAB and LAB)
- Hit run, it will fail to converge
- Check that it's still 0.0 and not an empty box

There is no associated issue - I can't seem to find the issue for 0.0 from the user, I'll like it when I do find it

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
