### PR TITLE
Rename WorkspaceSelectorView to CyclicDataSelectorView

### DIFF
--- a/scripts/Muon/GUI/Common/corrections_tab_widget/corrections_view.py
+++ b/scripts/Muon/GUI/Common/corrections_tab_widget/corrections_view.py
@@ -8,7 +8,7 @@ from mantidqt.utils.observer_pattern import GenericObserver
 from mantidqt.utils.qt import load_ui
 
 from Muon.GUI.Common.corrections_tab_widget.dead_time_corrections_view import DeadTimeCorrectionsView
-from Muon.GUI.Common.fitting_widgets.basic_fitting.workspace_selector_view import WorkspaceSelectorView
+from Muon.GUI.Common.data_selectors.cyclic_data_selector_view import CyclicDataSelectorView
 from Muon.GUI.Common.message_box import warning
 
 from qtpy.QtWidgets import QWidget
@@ -26,10 +26,9 @@ class CorrectionsView(widget, ui_form):
         super(CorrectionsView, self).__init__(parent)
         self.setupUi(self)
 
-        self.run_selector = WorkspaceSelectorView(self)
-        self.run_selector.set_workspace_combo_box_label("Runs :")
-        self.run_selector.workspace_combo_box_label.setMinimumWidth(50)
-        self.run_selector.workspace_combo_box_label.setMaximumWidth(50)
+        self.run_selector = CyclicDataSelectorView(self)
+        self.run_selector.set_data_combo_box_label("Runs :")
+        self.run_selector.set_data_combo_box_label_width(50)
         self.run_selector_layout.addWidget(self.run_selector)
 
         self.dead_time_corrections_view = DeadTimeCorrectionsView(self)

--- a/scripts/Muon/GUI/Common/data_selectors/__init__.py
+++ b/scripts/Muon/GUI/Common/data_selectors/__init__.py
@@ -1,0 +1,6 @@
+# Mantid Repository : https://github.com/mantidproject/mantid
+#
+# Copyright &copy; 2021 ISIS Rutherford Appleton Laboratory UKRI,
+#   NScD Oak Ridge National Laboratory, European Spallation Source,
+#   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+# SPDX - License - Identifier: GPL - 3.0 +

--- a/scripts/Muon/GUI/Common/data_selectors/cyclic_data_selector.ui
+++ b/scripts/Muon/GUI/Common/data_selectors/cyclic_data_selector.ui
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ui version="4.0">
- <class>workspace_selector</class>
- <widget class="QWidget" name="workspace_selector">
+ <class>cyclic_data_selector</class>
+ <widget class="QWidget" name="cyclic_data_selector">
   <property name="geometry">
    <rect>
     <x>0</x>
@@ -27,7 +27,7 @@
     <number>0</number>
    </property>
    <item>
-    <widget class="QLabel" name="workspace_combo_box_label">
+    <widget class="QLabel" name="data_combo_box_label">
      <property name="minimumSize">
       <size>
        <width>250</width>
@@ -41,7 +41,7 @@
       </size>
      </property>
      <property name="text">
-      <string>Select Workspace</string>
+      <string>Select Data</string>
      </property>
     </widget>
    </item>

--- a/scripts/Muon/GUI/Common/data_selectors/cyclic_data_selector_view.py
+++ b/scripts/Muon/GUI/Common/data_selectors/cyclic_data_selector_view.py
@@ -9,25 +9,25 @@ from mantidqt.utils.qt import load_ui
 from qtpy.QtCore import Qt
 from qtpy.QtWidgets import QWidget
 
-ui_form, base_widget = load_ui(__file__, "workspace_selector.ui")
+ui_form, base_widget = load_ui(__file__, "cyclic_data_selector.ui")
 
 
-class WorkspaceSelectorView(ui_form, base_widget):
+class CyclicDataSelectorView(ui_form, base_widget):
     """
-    The WorkspaceSelectorView is the cyclic workspace selector combobox, and is used to choose the workspace that
-    is currently active in an interface.
+    The CyclicDataSelectorView is a combobox used for selecting data with << and >> buttons which allow you to cycle
+    through each data item.
     """
 
     def __init__(self, parent: QWidget = None):
-        """Initialize the WorkspaceSelectorView."""
-        super(WorkspaceSelectorView, self).__init__(parent)
+        """Initialize the CyclicDataSelectorView."""
+        super(CyclicDataSelectorView, self).__init__(parent)
         self.setupUi(self)
 
         self.increment_parameter_display_button.clicked.connect(self.increment_dataset_name_combo_box)
         self.decrement_parameter_display_button.clicked.connect(self.decrement_dataset_name_combo_box)
 
     def set_slot_for_dataset_changed(self, slot) -> None:
-        """Connect the slot for the display workspace combo box being changed."""
+        """Connect the slot for the combo box being changed."""
         self.dataset_name_combo_box.currentIndexChanged.connect(slot)
 
     @property
@@ -46,7 +46,7 @@ class WorkspaceSelectorView(ui_form, base_widget):
             self.dataset_name_combo_box.currentIndexChanged.emit(self.dataset_name_combo_box.currentIndex())
 
     def update_dataset_name_combo_box(self, dataset_names: list) -> None:
-        """Update the data in the parameter display combo box."""
+        """Update the data in the combo box."""
         old_name = self.dataset_name_combo_box.currentText()
 
         self.update_dataset_names_combo_box(dataset_names)
@@ -62,7 +62,7 @@ class WorkspaceSelectorView(ui_form, base_widget):
         self.dataset_name_combo_box.currentIndexChanged.emit(new_index)
 
     def update_dataset_names_combo_box(self, dataset_names: list) -> None:
-        """Update the datasets displayed in the dataset name combobox."""
+        """Update the datasets displayed in the combobox."""
         self.dataset_name_combo_box.blockSignals(True)
         self.dataset_name_combo_box.clear()
         self.dataset_name_combo_box.addItems(dataset_names)
@@ -70,7 +70,7 @@ class WorkspaceSelectorView(ui_form, base_widget):
         self.dataset_name_combo_box.blockSignals(False)
 
     def update_dataset_names_combo_box_tooltips(self) -> None:
-        """Update the tooltips for the dataset name combobox."""
+        """Update the tooltips for the combobox."""
         for i, dataset_name in enumerate(self.dataset_names):
             self.dataset_name_combo_box.setItemData(i, dataset_name, Qt.ToolTipRole)
 
@@ -116,6 +116,11 @@ class WorkspaceSelectorView(ui_form, base_widget):
         current_index = self.dataset_name_combo_box.currentIndex()
         return current_index if current_index != -1 else None
 
-    def set_workspace_combo_box_label(self, text: str) -> None:
-        """Sets the label text next to the workspace selector combobox."""
-        self.workspace_combo_box_label.setText(text)
+    def set_data_combo_box_label(self, text: str) -> None:
+        """Sets the label text next to the data selector combobox."""
+        self.data_combo_box_label.setText(text)
+
+    def set_data_combo_box_label_width(self, width: int) -> None:
+        """Sets the width of the label next to the data selector combobox."""
+        self.run_selector.data_combo_box_label.setMinimumWidth(width)
+        self.run_selector.data_combo_box_label.setMaximumWidth(width)

--- a/scripts/Muon/GUI/Common/data_selectors/cyclic_data_selector_view.py
+++ b/scripts/Muon/GUI/Common/data_selectors/cyclic_data_selector_view.py
@@ -122,5 +122,5 @@ class CyclicDataSelectorView(ui_form, base_widget):
 
     def set_data_combo_box_label_width(self, width: int) -> None:
         """Sets the width of the label next to the data selector combobox."""
-        self.run_selector.data_combo_box_label.setMinimumWidth(width)
-        self.run_selector.data_combo_box_label.setMaximumWidth(width)
+        self.data_combo_box_label.setMinimumWidth(width)
+        self.data_combo_box_label.setMaximumWidth(width)

--- a/scripts/Muon/GUI/Common/fitting_widgets/basic_fitting/basic_fitting_view.py
+++ b/scripts/Muon/GUI/Common/fitting_widgets/basic_fitting/basic_fitting_view.py
@@ -10,7 +10,7 @@ from mantidqt.utils.qt import load_ui
 
 from Muon.GUI.Common.fitting_widgets.basic_fitting.fit_controls_view import FitControlsView
 from Muon.GUI.Common.fitting_widgets.basic_fitting.fit_function_options_view import FitFunctionOptionsView
-from Muon.GUI.Common.fitting_widgets.basic_fitting.workspace_selector_view import WorkspaceSelectorView
+from Muon.GUI.Common.data_selectors.cyclic_data_selector_view import CyclicDataSelectorView
 from Muon.GUI.Common.message_box import warning
 
 from qtpy.QtWidgets import QWidget
@@ -29,7 +29,7 @@ class BasicFittingView(ui_form, base_widget):
         self.setupUi(self)
 
         self.fit_controls = FitControlsView(self)
-        self.workspace_selector = WorkspaceSelectorView(self)
+        self.workspace_selector = CyclicDataSelectorView(self)
         self.fit_function_options = FitFunctionOptionsView(self)
 
         self.fit_controls_layout.addWidget(self.fit_controls)
@@ -95,7 +95,7 @@ class BasicFittingView(ui_form, base_widget):
 
     def set_workspace_combo_box_label(self, text: str) -> None:
         """Sets the label text next to the workspace selector combobox."""
-        self.workspace_selector.set_workspace_combo_box_label(text)
+        self.workspace_selector.set_data_combo_box_label(text)
 
     def set_datasets_in_function_browser(self, dataset_names: list) -> None:
         """Sets the datasets stored in the FunctionBrowser."""

--- a/scripts/Muon/GUI/Common/fitting_widgets/general_fitting/general_fitting_view.py
+++ b/scripts/Muon/GUI/Common/fitting_widgets/general_fitting/general_fitting_view.py
@@ -70,13 +70,13 @@ class GeneralFittingView(BasicFittingView):
     def switch_to_simultaneous(self) -> None:
         """Switches the view to simultaneous fit mode."""
         super().switch_to_simultaneous()
-        self.set_data_combo_box_label(SIMULTANEOUS_FIT_LABEL)
+        self.set_workspace_combo_box_label(SIMULTANEOUS_FIT_LABEL)
         self.general_fitting_options.enable_simultaneous_fit_options()
 
     def switch_to_single(self) -> None:
         """Switches the view to single fit mode."""
         super().switch_to_single()
-        self.set_data_combo_box_label(SINGLE_FIT_LABEL)
+        self.set_workspace_combo_box_label(SINGLE_FIT_LABEL)
         self.general_fitting_options.disable_simultaneous_fit_options()
 
     def disable_simultaneous_fit_options(self) -> None:

--- a/scripts/Muon/GUI/Common/fitting_widgets/general_fitting/general_fitting_view.py
+++ b/scripts/Muon/GUI/Common/fitting_widgets/general_fitting/general_fitting_view.py
@@ -70,13 +70,13 @@ class GeneralFittingView(BasicFittingView):
     def switch_to_simultaneous(self) -> None:
         """Switches the view to simultaneous fit mode."""
         super().switch_to_simultaneous()
-        self.set_workspace_combo_box_label(SIMULTANEOUS_FIT_LABEL)
+        self.set_data_combo_box_label(SIMULTANEOUS_FIT_LABEL)
         self.general_fitting_options.enable_simultaneous_fit_options()
 
     def switch_to_single(self) -> None:
         """Switches the view to single fit mode."""
         super().switch_to_single()
-        self.set_workspace_combo_box_label(SINGLE_FIT_LABEL)
+        self.set_data_combo_box_label(SINGLE_FIT_LABEL)
         self.general_fitting_options.disable_simultaneous_fit_options()
 
     def disable_simultaneous_fit_options(self) -> None:

--- a/scripts/Muon/GUI/Common/fitting_widgets/model_fitting/model_fitting_data_selector_view.py
+++ b/scripts/Muon/GUI/Common/fitting_widgets/model_fitting/model_fitting_data_selector_view.py
@@ -5,7 +5,7 @@
 #   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
 # SPDX - License - Identifier: GPL - 3.0 +
 from mantidqt.utils.qt import load_ui
-from Muon.GUI.Common.fitting_widgets.basic_fitting.workspace_selector_view import WorkspaceSelectorView
+from Muon.GUI.Common.data_selectors.cyclic_data_selector_view import CyclicDataSelectorView
 
 from qtpy.QtWidgets import QWidget
 
@@ -23,8 +23,8 @@ class ModelFittingDataSelectorView(ui_form, base_widget):
         super(ModelFittingDataSelectorView, self).__init__(parent)
         self.setupUi(self)
 
-        self.result_table_selector = WorkspaceSelectorView(self)
-        self.result_table_selector.set_workspace_combo_box_label("Results table")
+        self.result_table_selector = CyclicDataSelectorView(self)
+        self.result_table_selector.set_data_combo_box_label("Results table")
         self.result_table_selector_layout.addWidget(self.result_table_selector)
 
     def set_slot_for_results_table_changed(self, slot) -> None:

--- a/scripts/test/Muon/CMakeLists.txt
+++ b/scripts/test/Muon/CMakeLists.txt
@@ -12,6 +12,7 @@ set ( TEST_PY_FILES
    corrections_tab_widget/dead_time_corrections_model_test.py
    corrections_tab_widget/dead_time_corrections_presenter_test.py
    corrections_tab_widget/dead_time_corrections_view_test.py
+   data_selectors/cyclic_data_selector_view_test.py
    elemental_analysis/elemental_analysis_test.py
    elemental_analysis/name_generator_test.py
    elemental_analysis/detectors_presenter_test.py
@@ -49,7 +50,6 @@ set ( TEST_PY_FILES
    fitting_widgets/basic_fitting/basic_fitting_view_test.py
    fitting_widgets/basic_fitting/fit_controls_view_test.py
    fitting_widgets/basic_fitting/fit_function_options_view_test.py
-   fitting_widgets/basic_fitting/workspace_selector_view_test.py
    fitting_widgets/general_fitting/general_fitting_model_test.py
    fitting_widgets/general_fitting/general_fitting_presenter_test.py
    fitting_widgets/general_fitting/general_fitting_options_view_test.py

--- a/scripts/test/Muon/data_selectors/__init__.py
+++ b/scripts/test/Muon/data_selectors/__init__.py
@@ -1,0 +1,6 @@
+# Mantid Repository : https://github.com/mantidproject/mantid
+#
+# Copyright &copy; 2021 ISIS Rutherford Appleton Laboratory UKRI,
+#   NScD Oak Ridge National Laboratory, European Spallation Source,
+#   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+# SPDX - License - Identifier: GPL - 3.0 +

--- a/scripts/test/Muon/data_selectors/cyclic_data_selector_view_test.py
+++ b/scripts/test/Muon/data_selectors/cyclic_data_selector_view_test.py
@@ -9,16 +9,16 @@ import unittest
 from mantidqt.utils.qt.testing import start_qapplication
 from mantidqt.utils.qt.testing.qt_widget_finder import QtWidgetFinder
 
-from Muon.GUI.Common.fitting_widgets.basic_fitting.workspace_selector_view import WorkspaceSelectorView
+from Muon.GUI.Common.data_selectors.cyclic_data_selector_view import CyclicDataSelectorView
 
 from qtpy.QtWidgets import QApplication
 
 
 @start_qapplication
-class WorkspaceSelectorViewTest(unittest.TestCase, QtWidgetFinder):
+class CyclicDataSelectorViewTest(unittest.TestCase, QtWidgetFinder):
 
     def setUp(self):
-        self.view = WorkspaceSelectorView()
+        self.view = CyclicDataSelectorView()
         self.view.show()
         self.assert_widget_created()
 

--- a/scripts/test/Muon/fitting_widgets/general_fitting/general_fitting_view_test.py
+++ b/scripts/test/Muon/fitting_widgets/general_fitting/general_fitting_view_test.py
@@ -101,12 +101,12 @@ class GeneralFittingViewTest(unittest.TestCase, QtWidgetFinder):
 
     def test_that_switch_to_simultaneous_will_change_the_relevant_label(self):
         self.view.switch_to_simultaneous()
-        self.assertEqual(self.view.workspace_selector.workspace_combo_box_label.text(), SIMULTANEOUS_FIT_LABEL)
+        self.assertEqual(self.view.workspace_selector.data_combo_box_label.text(), SIMULTANEOUS_FIT_LABEL)
 
     def test_that_switch_to_single_will_change_the_relevant_label(self):
         self.view.switch_to_simultaneous()
         self.view.switch_to_single()
-        self.assertEqual(self.view.workspace_selector.workspace_combo_box_label.text(), SINGLE_FIT_LABEL)
+        self.assertEqual(self.view.workspace_selector.data_combo_box_label.text(), SINGLE_FIT_LABEL)
 
     def test_that_setup_fit_by_specifier_will_add_fit_specifiers_to_the_relevant_checkbox(self):
         fit_specifiers = ["long", "fwd", "bwd"]


### PR DESCRIPTION
**Description of work.**
This PR renames the `WorkspaceSelectorView` to be the `CyclicDataSelectorView` because it can be used more generically than just for workspaces.

**To test:**
Try doing some fitting on Muon Analysis. Also do some dead time corrections.

Fixes #31875

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
