### PR TITLE
Muon quickedit gets its initial values from context

### DIFF
--- a/docs/source/release/v6.2.0/muon.rst
+++ b/docs/source/release/v6.2.0/muon.rst
@@ -13,6 +13,7 @@ Improvements
 
 - It is now possible to do a vertical resize of the plot in Muon Analysis and Frequency Domain Analysis.
 - The plotting has been updated for better stability.
+- The plotting now has autoscale active by default.
 
 Elemental Analysis
 ------------------

--- a/scripts/Muon/GUI/Common/contexts/plotting_context.py
+++ b/scripts/Muon/GUI/Common/contexts/plotting_context.py
@@ -28,7 +28,7 @@ class PlottingContext(object):
         self._default_ylim = [-10, 10]
         self._xlim_all = self._default_xlim
         self._ylim_all = self._default_ylim
-        self._autoscale_all = False
+        self._autoscale_all = True
         self._errors_all = False
         self._min_y_range = 2.0
         self._y_axis_margin = 20.

--- a/scripts/Muon/GUI/Common/plot_widget/plotting_canvas/plotting_canvas_presenter.py
+++ b/scripts/Muon/GUI/Common/plot_widget/plotting_canvas/plotting_canvas_presenter.py
@@ -167,6 +167,13 @@ class PlottingCanvasPresenter(PlottingCanvasPresenterInterface):
         self._options_presenter.connect_plot_selection(self._handle_subplot_changed_in_quick_edit_widget)
         self.range_changed_observer = GenericObserver(self.update_range)
         self._view.add_range_changed_subscriber(self.range_changed_observer)
+        self.set_quickedit_from_context()
+
+    def set_quickedit_from_context(self):
+        self._options_presenter.set_autoscale(self._context.get_autoscale_all)
+        self._options_presenter.set_errors(self._context.get_error_all)
+        self._options_presenter.set_plot_x_range(self._context.get_xlim_all)
+        self._options_presenter.set_plot_y_range(self._context.get_ylim_all)
 
     def _handle_subplot_changed_in_quick_edit_widget(self):
         selected_subplots, indices = self._get_selected_subplots_from_quick_edit_widget()

--- a/scripts/test/Muon/plotting_canvas/plotting_canvas_presenter_test.py
+++ b/scripts/test/Muon/plotting_canvas/plotting_canvas_presenter_test.py
@@ -52,6 +52,26 @@ class PlottingCanvasPresenterTest(unittest.TestCase):
     def tearDown(self):
         AnalysisDataService.Instance().clear()
 
+    def test_set_quickedit_from_context(self):
+        state = True
+        ylims = [0,10]
+        xlims = [5, 15]
+        self.context.set_error_all(state)
+        self.context.set_autoscale_all(state)
+        self.context.update_ylim_all(ylime)
+        self.context.update_xlim_all(xlims)
+
+        self.options.set_autoscale = mock.Mock()
+        self.options.set_errors = mock.Mock()
+        self.options.set_plot_x_range = mock.Mock()
+        self.options.set_plot_y_range = mock.Mock()
+
+        self.presenter.set_quickedit_from_context()
+        self.options.set_autoscale.assert_called_once_with(state)
+        self.options.set_errors.assert_called_once_with(state)
+        self.options.set_plot_x_range.assert_called_once_with(xlims)
+        self.options.set_plot_y_range.assert_called_once_with(ylims)
+
     def test_plot_workspaces_removes_workspace_from_plot_if_hold_on_false(self):
         ws_names = ["MUSR6220"]
         ws_indices = [0]
@@ -365,6 +385,7 @@ class PlottingCanvasPresenterTest(unittest.TestCase):
         self.view.redraw_figure = mock.Mock()
         self.view.set_axis_xlimits = mock.Mock()
         self.view.set_axis_ylimits = mock.Mock()
+        self.view.get_axis_limits = mock.Mock(return_value=(xlims[0], xlims[1], ylims[0], ylims[1]))
         self.presenter._get_selected_subplots_from_quick_edit_widget = mock.Mock(return_value=(ws_names, ws_indices))
         self.context.get_xlim = mock.Mock()
         self.context.get_ylim = mock.Mock()

--- a/scripts/test/Muon/plotting_canvas/plotting_canvas_presenter_test.py
+++ b/scripts/test/Muon/plotting_canvas/plotting_canvas_presenter_test.py
@@ -67,10 +67,10 @@ class PlottingCanvasPresenterTest(unittest.TestCase):
         self.options.set_plot_y_range = mock.Mock()
 
         self.presenter.set_quickedit_from_context()
-        self.options.set_autoscale.assert_called_once_with(state)
-        self.options.set_errors.assert_called_once_with(state)
-        self.options.set_plot_x_range.assert_called_once_with(xlims)
-        self.options.set_plot_y_range.assert_called_once_with(ylims)
+        self.options.set_autoscale.assert_called_with(state)
+        self.options.set_errors.assert_called_with(state)
+        self.options.set_plot_x_range.assert_called_with(xlims)
+        self.options.set_plot_y_range.assert_called_with(ylims)
 
     def test_plot_workspaces_removes_workspace_from_plot_if_hold_on_false(self):
         ws_names = ["MUSR6220"]

--- a/scripts/test/Muon/plotting_canvas/plotting_canvas_presenter_test.py
+++ b/scripts/test/Muon/plotting_canvas/plotting_canvas_presenter_test.py
@@ -408,8 +408,8 @@ class PlottingCanvasPresenterTest(unittest.TestCase):
         self.presenter._handle_subplot_changed_in_quick_edit_widget()
 
         self.options.set_plot_x_range.assert_called_once_with(xlims)
-        self.options.set_plot_y_range.assert_called_once_with(ylims)
-        self.options.set_autoscale.assert_called_once_with(False)
+        self.options.set_plot_y_range.assert_called_with(ylims)
+        self.options.set_autoscale.assert_called_once_with(True)
         self.options.set_errors.assert_called_once_with(False)
 
     def test_handle_subplot_changed_specific_sub_plot(self):

--- a/scripts/test/Muon/plotting_canvas/plotting_canvas_presenter_test.py
+++ b/scripts/test/Muon/plotting_canvas/plotting_canvas_presenter_test.py
@@ -58,7 +58,7 @@ class PlottingCanvasPresenterTest(unittest.TestCase):
         xlims = [5, 15]
         self.context.set_error_all(state)
         self.context.set_autoscale_all(state)
-        self.context.update_ylim_all(ylime)
+        self.context.update_ylim_all(ylims)
         self.context.update_xlim_all(xlims)
 
         self.options.set_autoscale = mock.Mock()


### PR DESCRIPTION
**Description of work.**
When the quickedit is created, it will now get the initial values from the context. Making it easier to change the default settings in the future. 


<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

**To test:**
Open frequency domain analysis
Load some data
Use the quick edit and make sure it behaves as expected
Do a transform 
Use the quick edit and make sure it behaves as expected

<!-- Instructions for testing. -->

There is no associated issue.


<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
-->
In the release notes.
<!-- Ensure the base of this PR is correct (e.g. release-next or master)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
