### PR TITLE
Add unit tests for instrument viewer 

### DIFF
--- a/qt/widgets/instrumentview/inc/MantidQtWidgets/InstrumentView/IMantidGLWidget.h
+++ b/qt/widgets/instrumentview/inc/MantidQtWidgets/InstrumentView/IMantidGLWidget.h
@@ -35,6 +35,10 @@ public:
   virtual QColor currentBackgroundColor() const = 0;
   virtual void saveToFile(const QString &filename) = 0;
 
+  // Qt overrides
+  virtual void qtInstallEventFilter(QObject *arg) { installEventFilter(arg); }
+  virtual void qtUpdate() { update(); }
+  virtual void qtSetMinimumWidth(int arg) { setMinimumWidth(arg); }
 public slots:
   virtual void enableLighting(bool /*on*/) = 0;
   virtual void updateView(bool picking = true) = 0;

--- a/qt/widgets/instrumentview/inc/MantidQtWidgets/InstrumentView/ISimpleWidget.h
+++ b/qt/widgets/instrumentview/inc/MantidQtWidgets/InstrumentView/ISimpleWidget.h
@@ -33,6 +33,10 @@ public:
   virtual void updateDetectors() = 0;
   /// Save the image into a file
   virtual void saveToFile(const QString &filename) = 0;
+
+  // Qt overrides
+  virtual void qtInstallEventFilter(QObject *arg) { installEventFilter(arg); }
+  virtual void qtUpdate() { update(); }
 };
 } // namespace MantidWidgets
 } // namespace MantidQt

--- a/qt/widgets/instrumentview/inc/MantidQtWidgets/InstrumentView/InstrumentWidget.h
+++ b/qt/widgets/instrumentview/inc/MantidQtWidgets/InstrumentView/InstrumentWidget.h
@@ -10,6 +10,7 @@
 #include "IMantidGLWidget.h"
 #include "ISimpleWidget.h"
 #include "InstrumentWidgetTypes.h"
+#include "QtConnect.h"
 #include "UnwrappedSurface.h"
 
 #include "MantidAPI/AlgorithmObserver.h"
@@ -98,7 +99,8 @@ public:
   explicit InstrumentWidget(const QString &wsName, QWidget *parent = nullptr, bool resetGeometry = true,
                             bool autoscaling = true, double scaleMin = 0.0, double scaleMax = 0.0,
                             bool setDefaultView = true, std::unique_ptr<ISimpleWidget> simpleDisplay = nullptr,
-                            std::unique_ptr<IMantidGLWidget> instrumentDisplay = nullptr);
+                            std::unique_ptr<IMantidGLWidget> instrumentDisplay = nullptr,
+                            std::unique_ptr<QtConnect> qtConnect = std::make_unique<QtConnect>());
   ~InstrumentWidget() override;
   QString getWorkspaceName() const;
   std::string getWorkspaceNameStdString() const;
@@ -344,6 +346,9 @@ private:
   bool m_wsReplace;
   QPushButton *m_help;
   QVBoxLayout *m_mainLayout;
+
+  /// Wrapper around Qt connect function so we can mock it
+  std::unique_ptr<QtConnect> m_qtConnect;
 };
 
 } // namespace MantidWidgets

--- a/qt/widgets/instrumentview/inc/MantidQtWidgets/InstrumentView/InstrumentWidget.h
+++ b/qt/widgets/instrumentview/inc/MantidQtWidgets/InstrumentView/InstrumentWidget.h
@@ -97,7 +97,7 @@ public:
 
   explicit InstrumentWidget(const QString &wsName, QWidget *parent = nullptr, bool resetGeometry = true,
                             bool autoscaling = true, double scaleMin = 0.0, double scaleMax = 0.0,
-                            bool setDefaultView = true);
+                            bool setDefaultView = true, std::unique_ptr<ISimpleWidget> simpleDisplay = nullptr);
   ~InstrumentWidget() override;
   QString getWorkspaceName() const;
   std::string getWorkspaceNameStdString() const;
@@ -278,7 +278,7 @@ protected:
   /// The OpenGL widget to display the instrument
   IMantidGLWidget *m_InstrumentDisplay;
   /// The simple widget to display the instrument
-  ISimpleWidget *m_simpleDisplay;
+  std::unique_ptr<ISimpleWidget> m_simpleDisplay;
 
   // Context menu actions
   QAction *m_clearPeakOverlays, *m_clearAlignment;

--- a/qt/widgets/instrumentview/inc/MantidQtWidgets/InstrumentView/InstrumentWidget.h
+++ b/qt/widgets/instrumentview/inc/MantidQtWidgets/InstrumentView/InstrumentWidget.h
@@ -97,7 +97,8 @@ public:
 
   explicit InstrumentWidget(const QString &wsName, QWidget *parent = nullptr, bool resetGeometry = true,
                             bool autoscaling = true, double scaleMin = 0.0, double scaleMax = 0.0,
-                            bool setDefaultView = true, std::unique_ptr<ISimpleWidget> simpleDisplay = nullptr);
+                            bool setDefaultView = true, std::unique_ptr<ISimpleWidget> simpleDisplay = nullptr,
+                            std::unique_ptr<IMantidGLWidget> instrumentDisplay = nullptr);
   ~InstrumentWidget() override;
   QString getWorkspaceName() const;
   std::string getWorkspaceNameStdString() const;
@@ -276,7 +277,7 @@ protected:
   InstrumentWidgetPickTab *m_pickTab;
   XIntegrationControl *m_xIntegration;
   /// The OpenGL widget to display the instrument
-  IMantidGLWidget *m_InstrumentDisplay;
+  std::unique_ptr<IMantidGLWidget> m_InstrumentDisplay;
   /// The simple widget to display the instrument
   std::unique_ptr<ISimpleWidget> m_simpleDisplay;
 

--- a/qt/widgets/instrumentview/inc/MantidQtWidgets/InstrumentView/QtConnect.h
+++ b/qt/widgets/instrumentview/inc/MantidQtWidgets/InstrumentView/QtConnect.h
@@ -1,0 +1,26 @@
+// Mantid Repository : https://github.com/mantidproject/mantid
+//
+// Copyright &copy; 2021 ISIS Rutherford Appleton Laboratory UKRI,
+//   NScD Oak Ridge National Laboratory, European Spallation Source,
+//   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+// SPDX - License - Identifier: GPL - 3.0
+
+#pragma once
+
+#include <QObject>
+
+namespace MantidQt::MantidWidgets {
+
+struct QtConnect {
+  virtual ~QtConnect() = default;
+
+  virtual void connect(QObject *sender, const char *signal, QObject *receiver, const char *slot) const {
+    QObject::connect(sender, signal, receiver, slot);
+  }
+
+  virtual void connect(QObject *sender, const char *signal, QObject *receiver, const char *slot,
+                       Qt::ConnectionType type) const {
+    QObject::connect(sender, signal, receiver, slot, type);
+  }
+};
+} // namespace MantidQt::MantidWidgets

--- a/qt/widgets/instrumentview/src/InstrumentWidget.cpp
+++ b/qt/widgets/instrumentview/src/InstrumentWidget.cpp
@@ -140,7 +140,7 @@ InstrumentWidget::InstrumentWidget(const QString &wsName, QWidget *parent, bool 
   // Create simple display widget
   if (!m_simpleDisplay)
     m_simpleDisplay = std::make_unique<SimpleWidget>(this);
-  m_simpleDisplay->installEventFilter(this);
+  m_simpleDisplay->qtInstallEventFilter(this);
 
   QWidget *aWidget = new QWidget(this);
   m_instrumentDisplayLayout = new QStackedLayout(aWidget);
@@ -1264,7 +1264,7 @@ void InstrumentWidget::setSurface(ProjectionSurface *surface) {
   }
   if (m_simpleDisplay) {
     m_simpleDisplay->setSurface(sharedSurface);
-    m_simpleDisplay->update();
+    m_simpleDisplay->qtUpdate();
   }
   auto *unwrappedSurface = dynamic_cast<UnwrappedSurface *>(surface);
   if (unwrappedSurface) {

--- a/qt/widgets/instrumentview/test/InstrumentWidget/InstrumentWidgetTest.h
+++ b/qt/widgets/instrumentview/test/InstrumentWidget/InstrumentWidgetTest.h
@@ -13,16 +13,19 @@
 #include "MockSimpleWidget.h"
 
 #include <cxxtest/TestSuite.h>
+#include <gmock/gmock.h>
 #include <memory>
 
 using namespace MantidQt::MantidWidgets;
-
+using testing::StrictMock;
 class InstrumentWidgetTest : public CxxTest::TestSuite {
 public:
-  void setUp() override {
-    std::unique_ptr<ISimpleWidget> simpleFixture = std::make_unique<MockSimpleWidget>();
-    std::unique_ptr<IMantidGLWidget> glFixture = std::make_unique<MockMantidGLWidget>();
-  }
+  using MockedSimple = StrictMock<MockSimpleWidget>;
 
-  void test_stub() { TS_ASSERT(true); }
+  void test_constructor() {
+    auto simpleFixture = std::make_unique<MockedSimple>();
+
+    // InstrumentWidget(args,  std::move(simpleFixture));
+    //    EXPECT_CALL(*simpleFixture, getSurface()).Times(1);
+  }
 };

--- a/qt/widgets/instrumentview/test/InstrumentWidget/InstrumentWidgetTest.h
+++ b/qt/widgets/instrumentview/test/InstrumentWidget/InstrumentWidgetTest.h
@@ -43,6 +43,8 @@ public:
     auto simpleFixture = std::make_unique<StrictMock<MockSimpleWidget>>();
     EXPECT_CALL(*simpleFixture, setSurface(_)).Times(1);
     EXPECT_CALL(*simpleFixture, updateView(IsTrue())).Times(1);
+    EXPECT_CALL(*simpleFixture, qtInstallEventFilter(_)).Times(1);
+    EXPECT_CALL(*simpleFixture, qtUpdate()).Times(1);
 
     InstrumentWidget("test_ws", nullptr, true, true, 0.0, 0.0, true, std::move(simpleFixture));
   }

--- a/qt/widgets/instrumentview/test/InstrumentWidget/InstrumentWidgetTest.h
+++ b/qt/widgets/instrumentview/test/InstrumentWidget/InstrumentWidgetTest.h
@@ -55,12 +55,24 @@ public:
   }
 
   void test_constructor() { auto instance = construct(makeSimple(), makeGL(), makeConnect()); }
+
   void test_constructor_gl_disabled() {
     setGl(false);
     auto instance = construct(makeSimple(), makeGL(), makeConnect());
   }
 
-  void test_save_image_simple_widget() {
+  void test_save_image_gl_enabled() {
+    const auto inputName = QString::fromStdString("testFilename");
+    const auto expectedName = inputName + ".png";
+
+    auto glMock = makeGL();
+    EXPECT_CALL(*glMock, saveToFile(expectedName)).Times(1);
+
+    auto widget = construct(makeSimple(), std::move(glMock), makeConnect());
+    widget.saveImage(inputName);
+  }
+
+  void test_save_image_gl_disabled() {
     setGl(false);
     const auto inputName = QString::fromStdString("testFilename");
     const auto expectedName = inputName + ".png";
@@ -72,7 +84,15 @@ public:
     widget.saveImage(inputName);
   }
 
-  void test_update_instrument_detectors() {
+  void test_update_instrument_detectors_gl_enabled() {
+    auto glMock = makeGL();
+    EXPECT_CALL(*glMock, updateDetectors()).Times(1);
+
+    auto widget = construct(makeSimple(), std::move(glMock), makeConnect());
+    widget.updateInstrumentDetectors();
+  }
+
+  void test_update_instrument_detectors_gl_disabled() {
     setGl(false);
     auto simpleMock = makeSimple();
     EXPECT_CALL(*simpleMock, updateDetectors()).Times(1);

--- a/qt/widgets/instrumentview/test/InstrumentWidget/InstrumentWidgetTest.h
+++ b/qt/widgets/instrumentview/test/InstrumentWidget/InstrumentWidgetTest.h
@@ -11,6 +11,7 @@
 #include "InstrumentWidget.h"
 
 #include "MockMantidGLWidget.h"
+#include "MockProjectionSurface.h"
 #include "MockSimpleWidget.h"
 
 #include "MantidAPI/AnalysisDataService.h"

--- a/qt/widgets/instrumentview/test/InstrumentWidget/InstrumentWidgetTest.h
+++ b/qt/widgets/instrumentview/test/InstrumentWidget/InstrumentWidgetTest.h
@@ -54,6 +54,14 @@ public:
     widget.saveImage(inputName);
   }
 
+  void test_update_instrument_detectors() {
+    auto simpleMock = makeSimple();
+    EXPECT_CALL(*simpleMock, updateDetectors()).Times(1);
+
+    auto widget = construct(std::move(simpleMock));
+    widget.updateInstrumentDetectors();
+  }
+
 private:
   std::unique_ptr<SimpleMock> makeSimple() const { return std::make_unique<SimpleMock>(); }
 

--- a/qt/widgets/instrumentview/test/InstrumentWidget/MockMantidGLWidget.h
+++ b/qt/widgets/instrumentview/test/InstrumentWidget/MockMantidGLWidget.h
@@ -29,5 +29,10 @@ public:
   MOCK_METHOD(QColor, currentBackgroundColor, (), (const, override));
   MOCK_METHOD(void, enableLighting, (bool), (override));
   MOCK_METHOD(void, componentSelected, (size_t), (override));
+
+  // Qt overrides
+  MOCK_METHOD(void, qtInstallEventFilter, (QObject *), (override));
+  MOCK_METHOD(void, qtUpdate, (), (override));
+  MOCK_METHOD(void, qtSetMinimumWidth, (int), (override));
 };
 } // namespace MantidQt::MantidWidgets

--- a/qt/widgets/instrumentview/test/InstrumentWidget/MockProjectionSurface.h
+++ b/qt/widgets/instrumentview/test/InstrumentWidget/MockProjectionSurface.h
@@ -1,0 +1,24 @@
+// Mantid Repository : https://github.com/mantidproject/mantid
+//
+// Copyright &copy; 2021 ISIS Rutherford Appleton Laboratory UKRI,
+//   NScD Oak Ridge National Laboratory, European Spallation Source,
+//   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+// SPDX - License - Identifier: GPL - 3.0 +
+#pragma once
+
+#include "MantidGLWidget.h"
+#include "ProjectionSurface.h"
+#include <gmock/gmock.h>
+
+namespace MantidQt::MantidWidgets {
+class MockProjectionSurface : public ProjectionSurface {
+public:
+  MockProjectionSurface() : ProjectionSurface(nullptr) {}
+  MOCK_METHOD(void, init, (), (override));
+  MOCK_METHOD(void, componentSelected, (size_t), (override));
+  MOCK_METHOD(void, getSelectedDetectors, (std::vector<size_t> &), (override));
+  MOCK_METHOD(void, getMaskedDetectors, (std::vector<size_t> &), (const, override));
+  MOCK_METHOD(void, drawSurface, (MantidGLWidget *, bool), (const, override));
+  MOCK_METHOD(void, changeColorMap, (), (override));
+};
+} // namespace MantidQt::MantidWidgets

--- a/qt/widgets/instrumentview/test/InstrumentWidget/MockQtConnect.h
+++ b/qt/widgets/instrumentview/test/InstrumentWidget/MockQtConnect.h
@@ -1,0 +1,18 @@
+// Mantid Repository : https://github.com/mantidproject/mantid
+//
+// Copyright &copy; 2021 ISIS Rutherford Appleton Laboratory UKRI,
+//   NScD Oak Ridge National Laboratory, European Spallation Source,
+//   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+// SPDX - License - Identifier: GPL - 3.0 +
+#pragma once
+
+#include "QtConnect.h"
+#include <gmock/gmock.h>
+
+namespace MantidQt::MantidWidgets {
+class MockQtConnect : public QtConnect {
+public:
+  MOCK_METHOD(void, connect, (QObject *, const char *, QObject *, const char *), (const, override));
+  MOCK_METHOD(void, connect, (QObject *, const char *, QObject *, const char *, Qt::ConnectionType), (const, override));
+};
+} // namespace MantidQt::MantidWidgets

--- a/qt/widgets/instrumentview/test/InstrumentWidget/MockSimpleWidget.h
+++ b/qt/widgets/instrumentview/test/InstrumentWidget/MockSimpleWidget.h
@@ -8,7 +8,8 @@
 #pragma once
 
 #include "ISimpleWidget.h"
-#include "MantidKernel/WarningSuppressions.h"
+
+#include <QObject>
 #include <gmock/gmock.h>
 
 namespace MantidQt::MantidWidgets {
@@ -22,5 +23,7 @@ public:
   MOCK_METHOD(void, saveToFile, (const QString &), (override));
 
   // Qt overrides
+  MOCK_METHOD(void, qtInstallEventFilter, (QObject *), (override));
+  MOCK_METHOD(void, qtUpdate, (), (override));
 };
 } // namespace MantidQt::MantidWidgets


### PR DESCRIPTION
**Description of work.**

- This PR adds unit tests for calls to the SimpleWidget and MantidGLWidget members of instrument viewer. 
- It adds a class that allows us to mock Qt connect calls and adds tests for these too.

**To test:**

- Load some data, open Instrument Viewer and play around with the different views. Ensure everything is working as expected.
- Toggle the GL option in the Mantid settings and re-test.

Fixes #31763

*This does not require release notes* because **it concerns unit tests only**

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
