### PR TITLE
Set total number of tests in single-threaded quite mode

### DIFF
--- a/Testing/SystemTests/lib/systemtests/systemtesting.py
+++ b/Testing/SystemTests/lib/systemtests/systemtesting.py
@@ -545,7 +545,14 @@ class ResultReporter(object):
         '''Initialize a class instance, e.g. connect to a database'''
         self._total_number_of_tests = total_number_of_tests
         self._maximum_name_length = maximum_name_length
-        pass
+
+    @property
+    def total_number_of_tests(self):
+        return self._total_number_of_tests
+
+    @total_number_of_tests.setter
+    def total_number_of_tests(self, ntests):
+        self._total_number_of_tests = ntests
 
     def dispatchResults(self, result, number_of_completed_tests):
         raise NotImplementedError(
@@ -609,7 +616,6 @@ class TextResultReporter(ResultReporter):
         The default text reporter prints to standard out
         '''
         self.printResultsToConsole(result, number_of_completed_tests)
-        return
 
 
 # A class to report results as junit xml
@@ -850,7 +856,7 @@ class TestManager(object):
     def __init__(self,
                  mantid_config,
                  runner=None,
-                 output=[TextResultReporter()],
+                 output=None,
                  quiet=False,
                  testsInclude=None,
                  testsExclude=None,
@@ -864,7 +870,7 @@ class TestManager(object):
 
         # Runners and reporters
         self._runner = runner
-        self._reporters = output
+        self._reporters = output if output is not None else [TextResultReporter()]
         for r in self._reporters:
             r._quiet = quiet
             r._output_on_failure = output_on_failure
@@ -917,6 +923,9 @@ class TestManager(object):
             print('No tests were found in the test directory {0}. Please ensure all test classes sub class '
                   'systemtesting.MantidSystemTest.'.format(self._config.testDir))
             exit(2)
+
+        for reporter in self._reporters:
+            reporter.total_number_of_tests = test_stats[0]
 
         return mod_counts, mod_tests, mod_sub_directories, test_stats, mod_required_files, data_file_lock_status
 


### PR DESCRIPTION
**Description of work.**

If `--quiet` was passed to the system tests runner without
-j2 then the total number of tests was not set and remained
at 0. The print output then had a divide by zero error when
trying to compute the percentage of tests that had passed


<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

**To test:**

* Before this change try running: `./systemtest -C Debug -R CodeConventions --quiet` -> a divide by zero error appeared as seen in this [Jenkins](https://builds.mantidproject.org/view/Master%20Pipeline/job/master_systemtests-ubuntu-18.04/512/console) job
* Merge this change and the number of tests reported should be accurate. Try different combinations of tests, e.g `-R "CodeConventions|Startup"` and check the numbers

*There is no associated issue.*

*This does not require release notes* because **it is an internal fix**

<!-- Ensure the base of this PR is correct (e.g. release-next or master)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
