### PR TITLE
Run pre-commit on files with Instrument in name

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,7 @@
 default_language_version:
   python: python3
 
-exclude: ^$|instrument
+exclude: ^$|instrument/
 
 repos:
 


### PR DESCRIPTION
**Description of work.**

Pre-commit exclude regex is too aggressive, matching files with
Instrument anywhere in the name. This fixes it to correctly only match
the instrument directory.

This is marked high priority as anything with instrument in the name is not being checked by our pre-commit CI currently

**To test:**
- Checkout this PR
- Touch a cpp file such as `BaseCustomInstrumentView.cpp` and run `pre-commit run` to check that it appears as passed instead of skipped
- Touch a file in `instrument/` and check it's ignored (XML should be skipped)

<!-- Ensure the base of this PR is correct (e.g. release-next or master)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
