### PR TITLE
Fix stringop-truncation compiling with GCC 9.3

### DIFF
--- a/Framework/Kernel/src/NexusHDF5Descriptor.cpp
+++ b/Framework/Kernel/src/NexusHDF5Descriptor.cpp
@@ -96,19 +96,16 @@ herr_t readStringAttribute(hid_t attr, char **data) {
 /**
  * Reads a string attribute of N-dimensions
  * @param attr input HDF5 attribute handler
- * @param data output attribute data
  * @return
  */
-std::pair<std::string, herr_t> readStringAttributeN(hid_t attr, char *data) {
-  std::string dataString(data);
-  herr_t iRet;
+std::pair<std::string, herr_t> readStringAttributeN(hid_t attr) {
   char *vdat = NULL;
-  iRet = readStringAttribute(attr, &vdat);
+  const auto iRet = readStringAttribute(attr, &vdat);
+  std::string attrData;
   if (iRet >= 0) {
-    dataString = vdat;
-    free(vdat);
+    attrData = vdat;
   }
-  return std::pair<std::string, herr_t>(dataString, iRet);
+  return std::make_pair(attrData, iRet);
 }
 
 void getGroup(hid_t groupID, std::map<std::string, std::set<std::string>> &allEntries) {
@@ -124,14 +121,9 @@ void getGroup(hid_t groupID, std::map<std::string, std::set<std::string>> &allEn
       return attribute;
     }
 
-    hid_t type = H5T_C_S1;
-    hid_t atype = H5Tcopy(type);
-    char data[128];
-    H5Tset_size(atype, sizeof(data));
-    auto pairData = readStringAttributeN(attributeID, data);
+    auto pairData = readStringAttributeN(attributeID);
     // already null terminated in readStringAttributeN
     attribute = pairData.first;
-    H5Tclose(atype);
     H5Aclose(attributeID);
 
     return attribute;

--- a/Framework/Kernel/src/NexusHDF5Descriptor.cpp
+++ b/Framework/Kernel/src/NexusHDF5Descriptor.cpp
@@ -109,7 +109,7 @@ std::pair<std::string, herr_t> readStringAttributeN(hid_t attr, char *data) {
     dataString = vdat;
     free(vdat);
   }
-  return std::pair<std::string, herr_t>(data, iRet);
+  return std::pair<std::string, herr_t>(dataString, iRet);
 }
 
 void getGroup(hid_t groupID, std::map<std::string, std::set<std::string>> &allEntries) {

--- a/Framework/Kernel/src/NexusHDF5Descriptor.cpp
+++ b/Framework/Kernel/src/NexusHDF5Descriptor.cpp
@@ -100,16 +100,16 @@ herr_t readStringAttribute(hid_t attr, char **data) {
  * @param maxlen
  * @return
  */
-herr_t readStringAttributeN(hid_t attr, char *data, int maxlen) {
+std::pair<std::string, herr_t> readStringAttributeN(hid_t attr, char *data) {
+  std::string dataString(data);
   herr_t iRet;
   char *vdat = NULL;
   iRet = readStringAttribute(attr, &vdat);
   if (iRet >= 0) {
-    strncpy(data, vdat, maxlen);
+    dataString = vdat;
     free(vdat);
   }
-  data[maxlen - 1] = '\0';
-  return iRet;
+  return std::pair<std::string, herr_t>(data, iRet);
 }
 
 void getGroup(hid_t groupID, std::map<std::string, std::set<std::string>> &allEntries) {
@@ -129,9 +129,9 @@ void getGroup(hid_t groupID, std::map<std::string, std::set<std::string>> &allEn
     hid_t atype = H5Tcopy(type);
     char data[128];
     H5Tset_size(atype, sizeof(data));
-    readStringAttributeN(attributeID, data, sizeof(data));
+    auto pairData = readStringAttributeN(attributeID, data);
     // already null terminated in readStringAttributeN
-    attribute = std::string(data);
+    attribute = pairData.first;
     H5Tclose(atype);
     H5Aclose(attributeID);
 

--- a/Framework/Kernel/src/NexusHDF5Descriptor.cpp
+++ b/Framework/Kernel/src/NexusHDF5Descriptor.cpp
@@ -97,7 +97,6 @@ herr_t readStringAttribute(hid_t attr, char **data) {
  * Reads a string attribute of N-dimensions
  * @param attr input HDF5 attribute handler
  * @param data output attribute data
- * @param maxlen
  * @return
  */
 std::pair<std::string, herr_t> readStringAttributeN(hid_t attr, char *data) {


### PR DESCRIPTION
**Description of work.**
There is a warning when compiling with GCC 9.3, this fixes that warning.

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

**To test:**
CI passes and code review. 
<!-- Instructions for testing. -->

Fixes #31717 <!-- and fix #xxxx or close #xxxx xor resolves #xxxx -->
<!-- alternative
*There is no associated issue.*
-->


*This does not require release notes* because **Developer Facing Only**


<!-- Ensure the base of this PR is correct (e.g. release-next or master)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
