### PR TITLE
Fix Crash In FDA When Calculating MaxEnt

### DIFF
--- a/scripts/Muon/GUI/FrequencyDomainAnalysis/plot_widget/plot_freq_fit_pane_model.py
+++ b/scripts/Muon/GUI/FrequencyDomainAnalysis/plot_widget/plot_freq_fit_pane_model.py
@@ -4,7 +4,7 @@
 #   NScD Oak Ridge National Laboratory, European Spallation Source,
 #   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
 from Muon.GUI.Common.plot_widget.fit_pane.plot_fit_pane_model import PlotFitPaneModel
-from Muon.GUI.Common.ADSHandler.workspace_naming import (FFT_STR,
+from Muon.GUI.Common.ADSHandler.workspace_naming import (FFT_STR, MAXENT_STR,
                                                          get_fft_component_from_workspace_name,
                                                          get_group_or_pair_from_name,
                                                          get_run_numbers_as_string_from_workspace_name)

--- a/scripts/test/Muon/plot_fit_panes/plot_freq_fit_pane_model_test.py
+++ b/scripts/test/Muon/plot_fit_panes/plot_freq_fit_pane_model_test.py
@@ -50,6 +50,18 @@ class PlotFreqFitPaneModelTest(unittest.TestCase):
         self.assertEqual(ws, ["test", "test", "unit", "unit"])
         self.assertEqual(indices, [1,2,1,2])
 
+    def test_get_fft_label(self):
+        ws_name = 'FFT; Re MUSR62260; Pair Asym; long; FD_Re'
+        self.assertEqual(';FFT;Re', self.model._get_freq_lebel(ws_name))
+
+    def test_get_maxent_label(self):
+        ws_name = 'MUSR62260_raw_data FD; MaxEnt'
+        self.assertEqual(';MaxEnt', self.model._get_freq_lebel(ws_name))
+
+    def test_get_label_when_not_fft_or_maxent(self):
+        ws_name = 'test'
+        self.assertEqual('', self.model._get_freq_lebel(ws_name))
+
 
 if __name__ == '__main__':
     unittest.main(buffer=False, verbosity=2)


### PR DESCRIPTION
**Description of work.**
There was a missing import of the MAXENT_STR. I have added unit tests to check this.

**To test:**
Open frequency Domain Analysis GUI
Load MUSR62260 or another run
Go to the transform tab
Change FFT to MaxEnt
Click Calculate
The calculation should be successful

*There is no associated issue.*

*This does not require release notes* because **this fixes a bug introduced this release**

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
