### PR TITLE
Muon Corrections Tab - Auto Background Corrections

### DIFF
--- a/scripts/Muon/GUI/Common/contexts/corrections_context.py
+++ b/scripts/Muon/GUI/Common/contexts/corrections_context.py
@@ -10,6 +10,15 @@ from Muon.GUI.Common.muon_load_data import MuonLoadData
 DEAD_TIME_FROM_FILE = "FromFile"
 DEAD_TIME_FROM_ADS = "FromADS"
 
+BACKGROUND_MODE_NONE = "None"
+BACKGROUND_MODE_AUTO = "Auto"
+
+FLAT_BACKGROUND = "Flat Background"
+FLAT_BACKGROUND_AND_EXP_DECAY = "Flat Background + Exp Decay"
+
+RUNS_ALL = "All"
+GROUPS_ALL = "All"
+
 
 @dataclass
 class CorrectionsContext:
@@ -19,12 +28,13 @@ class CorrectionsContext:
     current_run_string: str = None
 
     # The 'dead_time_source' can be "FromFile", "FromADS" or None.
-    dead_time_source: str = None
+    dead_time_source: str = DEAD_TIME_FROM_FILE
     dead_time_table_name_from_ads: str = None
 
     # The background corrections mode can be 'None', 'Auto' or 'Manual'
-    background_corrections_mode: str = "None"
-    selected_group: str = "All"
+    background_corrections_mode: str = BACKGROUND_MODE_NONE
+    selected_function: str = FLAT_BACKGROUND
+    selected_group: str = GROUPS_ALL
     show_all_runs: bool = False
 
     # The background corrections data in each row of the table is mapped to its corresponding Run and Group

--- a/scripts/Muon/GUI/Common/contexts/corrections_context.py
+++ b/scripts/Muon/GUI/Common/contexts/corrections_context.py
@@ -22,6 +22,15 @@ class CorrectionsContext:
     dead_time_source: str = None
     dead_time_table_name_from_ads: str = None
 
+    # The background corrections mode can be 'None', 'Auto' or 'Manual'
+    background_corrections_mode: str = "None"
+    selected_group: str = "All"
+    show_all_runs: bool = False
+
+    # The background corrections data in each row of the table is mapped to its corresponding Run and Group
+    # i.e. dict(tuple(run, group): BackgroundCorrectionData)
+    background_correction_data = {}
+
     def __init__(self, load_data: MuonLoadData):
         """Initialize the CorrectionsContext and pass in MuonLoadData so that we can access dead time tables."""
         self._loaded_data = load_data

--- a/scripts/Muon/GUI/Common/contexts/muon_group_pair_context.py
+++ b/scripts/Muon/GUI/Common/contexts/muon_group_pair_context.py
@@ -343,9 +343,11 @@ class MuonGroupPairContext(object):
     def get_group_counts_workspace_names(self, runs, groups, rebin=False):
         workspace_names = []
         for group_name in groups:
-            name = self[group_name].get_counts_workspace_for_run(runs, rebin)
-            if name is not None:
+            try:
+                name = self[group_name].get_counts_workspace_for_run(runs, rebin)
                 workspace_names.append(name)
+            except KeyError:
+                continue
         return workspace_names
 
     def get_group_workspace_names(self, runs, groups, rebin):

--- a/scripts/Muon/GUI/Common/contexts/muon_group_pair_context.py
+++ b/scripts/Muon/GUI/Common/contexts/muon_group_pair_context.py
@@ -340,6 +340,14 @@ class MuonGroupPairContext(object):
                 return False
         return True
 
+    def get_group_counts_workspace_names(self, runs, groups, rebin=False):
+        workspace_names = []
+        for group_name in groups:
+            name = self[group_name].get_counts_workspace_for_run(runs, rebin)
+            if name is not None:
+                workspace_names.append(name)
+        return workspace_names
+
     def get_group_workspace_names(self, runs, groups, rebin):
         workspace_list = []
 

--- a/scripts/Muon/GUI/Common/corrections_tab_widget/background_corrections_model.py
+++ b/scripts/Muon/GUI/Common/corrections_tab_widget/background_corrections_model.py
@@ -1,0 +1,178 @@
+# Mantid Repository : https://github.com/mantidproject/mantid
+#
+# Copyright &copy; 2021 ISIS Rutherford Appleton Laboratory UKRI,
+#   NScD Oak Ridge National Laboratory, European Spallation Source,
+#   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+# SPDX - License - Identifier: GPL - 3.0 +
+from mantid.py36compat import dataclass
+
+from Muon.GUI.Common.ADSHandler.ADS_calls import check_if_workspace_exist, retrieve_ws
+from Muon.GUI.Common.contexts.corrections_context import CorrectionsContext
+from Muon.GUI.Common.contexts.muon_context import MuonContext
+from Muon.GUI.Common.corrections_tab_widget.corrections_model import CorrectionsModel
+
+DEFAULT_START_X = 5.0
+DEFAULT_END_X = 15.0
+DEFAULT_X_LOWER = 0.0
+DEFAULT_X_UPPER = 100.0
+X_OFFSET = 0.001
+
+
+@dataclass
+class BackgroundCorrectionData:
+    start_x: float = DEFAULT_START_X
+    end_x: float = DEFAULT_END_X
+    a0: float = 0.0
+    a0_error: float = 0.0
+
+
+class BackgroundCorrectionsModel:
+    """
+    The BackgroundCorrectionsModel calculates Background corrections.
+    """
+
+    def __init__(self, corrections_model: CorrectionsModel, context: MuonContext,
+                 corrections_context: CorrectionsContext):
+        """Initialize the BackgroundCorrectionsModel with empty data."""
+        self._corrections_model = corrections_model
+        self._context = context
+        self._corrections_context = corrections_context
+
+    def set_background_correction_mode(self, mode: str) -> None:
+        """Sets the current background correction mode in the context."""
+        self._corrections_context.background_corrections_mode = mode
+
+    def set_selected_group(self, group: str) -> None:
+        """Sets the currently selected Group in the context."""
+        self._corrections_context.selected_group = group
+
+    def set_show_all_runs(self, show_all: bool) -> None:
+        """Sets whether all runs should be shown or not."""
+        self._corrections_context.show_all_runs = show_all
+
+    def all_runs(self) -> list:
+        """Returns a list of all loaded runs."""
+        return self._context.get_runs("All")
+
+    def group_names(self) -> list:
+        """Returns the group names found in the group/pair context."""
+        return self._context.group_pair_context.group_names
+
+    def set_start_x(self, run: str, group: str, start_x: float) -> None:
+        """Sets the Start X associated with the provided Run and Group."""
+        run_group = tuple([run, group])
+        if run_group in self._corrections_context.background_correction_data:
+            self._corrections_context.background_correction_data[run_group].start_x = start_x
+
+    def start_x(self, run: str, group: str) -> float:
+        """Returns the Start X associated with the provided Run and Group."""
+        run_group = tuple([run, group])
+        if run_group in self._corrections_context.background_correction_data:
+            return self._corrections_context.background_correction_data[run_group].start_x
+        return DEFAULT_START_X
+
+    def set_end_x(self, run: str, group: str, end_x: float) -> None:
+        """Sets the End X associated with the provided Run and Group."""
+        run_group = tuple([run, group])
+        if run_group in self._corrections_context.background_correction_data:
+            self._corrections_context.background_correction_data[run_group].end_x = end_x
+
+    def end_x(self, run: str, group: str) -> float:
+        """Returns the End X associated with the provided Run and Group."""
+        run_group = tuple([run, group])
+        if run_group in self._corrections_context.background_correction_data:
+            return self._corrections_context.background_correction_data[run_group].end_x
+        return DEFAULT_END_X
+
+    @staticmethod
+    def is_equal_to_n_decimals(value1: float, value2: float, n_decimals: int) -> bool:
+        """Checks that two floats are equal up to n decimal places."""
+        return f"{value1:.{n_decimals}f}" == f"{value2:.{n_decimals}f}"
+
+    def populate_background_corrections_data(self) -> None:
+        self._corrections_context.background_correction_data = {}
+        groups = self.group_names()
+        for run in self._corrections_model.run_number_strings():
+            for group in groups:
+                self._corrections_context.background_correction_data[tuple([run, group])] = BackgroundCorrectionData()
+
+    def selected_correction_data(self) -> tuple:
+        """Returns lists of the selected correction data to display in the view."""
+        runs, groups, start_xs, end_xs = self._selected_correction_data_for(self._selected_runs(),
+                                                                            self._selected_groups())
+        return runs, groups, start_xs, end_xs
+
+    def _selected_correction_data_for(self, selected_runs: list, selected_groups: list) -> tuple:
+        """Returns lists of the selected correction data to display in the view."""
+        runs_list, groups_list, start_xs, end_xs = [], [], [], []
+        for run_group, correction_data in self._corrections_context.background_correction_data.items():
+            if run_group[0] in selected_runs and run_group[1] in selected_groups:
+                runs_list.append(run_group[0])
+                groups_list.append(run_group[1])
+                start_xs.append(correction_data.start_x)
+                end_xs.append(correction_data.end_x)
+        return runs_list, groups_list, start_xs, end_xs
+
+    def _selected_runs(self) -> list:
+        """Returns a list containing the run number strings that are currently selected."""
+        if self._corrections_context.show_all_runs:
+            return self._corrections_model.run_number_strings()
+        else:
+            return self._corrections_context.current_run_string
+
+    def _selected_groups(self) -> list:
+        """Returns a list of selected group names."""
+        selected_group = self._corrections_context.selected_group
+        return self.group_names() if selected_group == "All" else [selected_group]
+
+    def _get_counts_workspace_name(self, run_string: str, group: str) -> str:
+        """Returns the name of the counts workspace associated with the provided run string and group."""
+        run_list = self._context.get_runs(run_string)
+        if len(run_list) > 0:
+            workspace_list = self._context.group_pair_context.get_group_counts_workspace_names(run_list[0], [group])
+        return workspace_list[0] if len(workspace_list) > 0 else None
+
+    def x_limits_of_workspace(self, run: str, group: str) -> tuple:
+        """Returns the x data limits of the workspace associated with the provided Run and Group."""
+        return self._x_limits_of_workspace(self._get_counts_workspace_name(run, group))
+
+    @staticmethod
+    def _x_limits_of_workspace(workspace_name: str) -> tuple:
+        """Returns the x data limits of a provided workspace."""
+        if workspace_name is not None and check_if_workspace_exist(workspace_name):
+            x_data = retrieve_ws(workspace_name).dataX(0)
+            if len(x_data) > 0:
+                x_data.sort()
+                x_lower, x_higher = x_data[0], x_data[-1]
+                if x_lower == x_higher:
+                    return x_lower - X_OFFSET, x_higher + X_OFFSET
+                return x_lower, x_higher
+        return DEFAULT_X_LOWER, DEFAULT_X_UPPER
+
+    # def get_workspace_names_to_display_from_context(self) -> list:
+    #     """Returns the workspace names to display in the view based on the selected run and group options."""
+    #     runs = self._selected_runs()
+    #     groups = self._selected_groups()
+    #     if runs is not None and len(groups) > 0:
+    #         return self._get_workspace_names_to_display_from_context(runs, groups)
+    #     return []
+    #
+    # def _get_workspace_names_to_display_from_context(self, runs: list, groups: list) -> list:
+    #     """Returns the workspace names to display in the view based on the selected run and group options."""
+    #     workspace_names = []
+    #     for run in runs:
+    #         workspace_names += self._context.group_pair_context.get_group_counts_workspace_names(run, groups)
+    #     return workspace_names
+    #
+    # def _selected_runs(self) -> list:
+    #     """Returns a list containing the run numbers that are currently selected."""
+    #     if self._corrections_context.show_all_runs:
+    #         runs_string = "All"
+    #     else:
+    #         runs_string = self._corrections_context.current_run_string
+    #     return self._context.get_runs(runs_string) if runs_string is not None else []
+    #
+    # def _selected_groups(self) -> list:
+    #     """Returns a list of selected group names."""
+    #     selected_group = self._corrections_context.selected_group
+    #     return self.group_names() if selected_group == "All" else [selected_group]

--- a/scripts/Muon/GUI/Common/corrections_tab_widget/background_corrections_model.py
+++ b/scripts/Muon/GUI/Common/corrections_tab_widget/background_corrections_model.py
@@ -8,8 +8,8 @@ from mantid.py36compat import dataclass
 
 from mantid.api import FunctionFactory, IFunction
 from Muon.GUI.Common.ADSHandler.ADS_calls import check_if_workspace_exist, retrieve_ws
-from Muon.GUI.Common.contexts.corrections_context import (CorrectionsContext, BACKGROUND_MODE_NONE,
-                                                          FLAT_BACKGROUND_AND_EXP_DECAY, RUNS_ALL, GROUPS_ALL)
+from Muon.GUI.Common.contexts.corrections_context import (CorrectionsContext, BACKGROUND_MODE_NONE, RUNS_ALL,
+                                                          GROUPS_ALL)
 from Muon.GUI.Common.contexts.muon_context import MuonContext
 from Muon.GUI.Common.corrections_tab_widget.corrections_model import CorrectionsModel
 
@@ -54,10 +54,6 @@ class BackgroundCorrectionsModel:
     def set_selected_function(self, selected_function: str) -> None:
         """Sets the currently selected function which is displayed in the function combo box."""
         self._corrections_context.selected_function = selected_function
-
-    def is_exp_decay_selected(self) -> bool:
-        """Returns true if the currently selected function includes an exp decay."""
-        return self._corrections_context.selected_function == FLAT_BACKGROUND_AND_EXP_DECAY
 
     def set_selected_group(self, group: str) -> None:
         """Sets the currently selected Group in the context."""
@@ -116,13 +112,13 @@ class BackgroundCorrectionsModel:
 
     def selected_correction_data(self) -> tuple:
         """Returns lists of the selected correction data to display in the view."""
-        runs, groups, start_xs, end_xs, a0s, heights, lifetimes = self._selected_correction_data_for(
+        runs, groups, start_xs, end_xs, a0s, a0_errors = self._selected_correction_data_for(
             self._selected_runs(), self._selected_groups())
-        return runs, groups, start_xs, end_xs, a0s, heights, lifetimes
+        return runs, groups, start_xs, end_xs, a0s, a0_errors
 
     def _selected_correction_data_for(self, selected_runs: list, selected_groups: list) -> tuple:
         """Returns lists of the selected correction data to display in the view."""
-        runs_list, groups_list, start_xs, end_xs, a0s, heights, lifetimes = [], [], [], [], [], [], []
+        runs_list, groups_list, start_xs, end_xs, a0s, a0_errors = [], [], [], [], [], []
         for run_group, correction_data in self._corrections_context.background_correction_data.items():
             if run_group[0] in selected_runs and run_group[1] in selected_groups:
                 runs_list.append(run_group[0])
@@ -130,16 +126,15 @@ class BackgroundCorrectionsModel:
                 start_xs.append(correction_data.start_x)
                 end_xs.append(correction_data.end_x)
                 a0s.append(correction_data.flat_background.getParameterValue("A0"))
-                heights.append(correction_data.exp_decay.getParameterValue("Height"))
-                lifetimes.append(correction_data.exp_decay.getParameterValue("Lifetime"))
-        return runs_list, groups_list, start_xs, end_xs, a0s, heights, lifetimes
+                a0_errors.append(correction_data.flat_background.getError("A0"))
+        return runs_list, groups_list, start_xs, end_xs, a0s, a0_errors
 
     def _selected_runs(self) -> list:
         """Returns a list containing the run number strings that are currently selected."""
         if self._corrections_context.show_all_runs:
             return self._corrections_model.run_number_strings()
         else:
-            return self._corrections_context.current_run_string
+            return [self._corrections_context.current_run_string]
 
     def _selected_groups(self) -> list:
         """Returns a list of selected group names."""

--- a/scripts/Muon/GUI/Common/corrections_tab_widget/background_corrections_model.py
+++ b/scripts/Muon/GUI/Common/corrections_tab_widget/background_corrections_model.py
@@ -13,8 +13,6 @@ from Muon.GUI.Common.corrections_tab_widget.corrections_model import Corrections
 from Muon.GUI.Common.utilities.workspace_data_utils import x_limits_of_workspace
 
 BACKGROUND_PARAM = "A0"
-DEFAULT_X_LOWER = 0.0
-DEFAULT_X_UPPER = 100.0
 
 
 @dataclass
@@ -99,11 +97,6 @@ class BackgroundCorrectionsModel:
 
         raise RuntimeError(f"The provided run and group could not be found ({run}, {group}).")
 
-    @staticmethod
-    def is_equal_to_n_decimals(value1: float, value2: float, n_decimals: int) -> bool:
-        """Checks that two floats are equal up to n decimal places."""
-        return f"{value1:.{n_decimals}f}" == f"{value2:.{n_decimals}f}"
-
     def clear_background_corrections_data(self) -> None:
         """Clears the background correction data dictionary."""
         self._corrections_context.background_correction_data = {}
@@ -150,7 +143,7 @@ class BackgroundCorrectionsModel:
         selected_group = self._corrections_context.selected_group
         return self.group_names() if selected_group == GROUPS_ALL else [selected_group]
 
-    def _get_counts_workspace_name(self, run_string: str, group: str) -> str:
+    def get_counts_workspace_name(self, run_string: str, group: str) -> str:
         """Returns the name of the counts workspace associated with the provided run string and group."""
         run_list = self._context.get_runs(run_string)
         workspace_list = []
@@ -166,4 +159,4 @@ class BackgroundCorrectionsModel:
 
     def x_limits_of_workspace(self, run: str, group: str) -> tuple:
         """Returns the x data limits of the workspace associated with the provided Run and Group."""
-        return x_limits_of_workspace(self._get_counts_workspace_name(run, group), (DEFAULT_X_LOWER, DEFAULT_X_UPPER))
+        return x_limits_of_workspace(self.get_counts_workspace_name(run, group))

--- a/scripts/Muon/GUI/Common/corrections_tab_widget/background_corrections_model.py
+++ b/scripts/Muon/GUI/Common/corrections_tab_widget/background_corrections_model.py
@@ -20,6 +20,9 @@ X_OFFSET = 0.001
 
 @dataclass
 class BackgroundCorrectionData:
+    """
+    The background correction data associated with a specific group of a run.
+    """
     start_x: float = DEFAULT_START_X
     end_x: float = DEFAULT_END_X
     a0: float = 0.0
@@ -90,6 +93,7 @@ class BackgroundCorrectionsModel:
         return f"{value1:.{n_decimals}f}" == f"{value2:.{n_decimals}f}"
 
     def populate_background_corrections_data(self) -> None:
+        """Populates the background correction data dictionary when runs are initially loaded into the interface."""
         self._corrections_context.background_correction_data = {}
         groups = self.group_names()
         for run in self._corrections_model.run_number_strings():

--- a/scripts/Muon/GUI/Common/corrections_tab_widget/background_corrections_model.py
+++ b/scripts/Muon/GUI/Common/corrections_tab_widget/background_corrections_model.py
@@ -169,31 +169,3 @@ class BackgroundCorrectionsModel:
                     return x_lower - X_OFFSET, x_higher + X_OFFSET
                 return x_lower, x_higher
         return DEFAULT_X_LOWER, DEFAULT_X_UPPER
-
-    # def get_workspace_names_to_display_from_context(self) -> list:
-    #     """Returns the workspace names to display in the view based on the selected run and group options."""
-    #     runs = self._selected_runs()
-    #     groups = self._selected_groups()
-    #     if runs is not None and len(groups) > 0:
-    #         return self._get_workspace_names_to_display_from_context(runs, groups)
-    #     return []
-    #
-    # def _get_workspace_names_to_display_from_context(self, runs: list, groups: list) -> list:
-    #     """Returns the workspace names to display in the view based on the selected run and group options."""
-    #     workspace_names = []
-    #     for run in runs:
-    #         workspace_names += self._context.group_pair_context.get_group_counts_workspace_names(run, groups)
-    #     return workspace_names
-    #
-    # def _selected_runs(self) -> list:
-    #     """Returns a list containing the run numbers that are currently selected."""
-    #     if self._corrections_context.show_all_runs:
-    #         runs_string = RUNS_ALL
-    #     else:
-    #         runs_string = self._corrections_context.current_run_string
-    #     return self._context.get_runs(runs_string) if runs_string is not None else []
-    #
-    # def _selected_groups(self) -> list:
-    #     """Returns a list of selected group names."""
-    #     selected_group = self._corrections_context.selected_group
-    #     return self.group_names() if selected_group == GROUPS_ALL else [selected_group]

--- a/scripts/Muon/GUI/Common/corrections_tab_widget/background_corrections_model.py
+++ b/scripts/Muon/GUI/Common/corrections_tab_widget/background_corrections_model.py
@@ -8,7 +8,8 @@ from mantid.py36compat import dataclass
 
 from mantid.api import FunctionFactory, IFunction
 from Muon.GUI.Common.ADSHandler.ADS_calls import check_if_workspace_exist, retrieve_ws
-from Muon.GUI.Common.contexts.corrections_context import CorrectionsContext
+from Muon.GUI.Common.contexts.corrections_context import (CorrectionsContext, BACKGROUND_MODE_NONE,
+                                                          FLAT_BACKGROUND_AND_EXP_DECAY, RUNS_ALL, GROUPS_ALL)
 from Muon.GUI.Common.contexts.muon_context import MuonContext
 from Muon.GUI.Common.corrections_tab_widget.corrections_model import CorrectionsModel
 
@@ -46,6 +47,18 @@ class BackgroundCorrectionsModel:
         """Sets the current background correction mode in the context."""
         self._corrections_context.background_corrections_mode = mode
 
+    def is_background_mode_none(self) -> bool:
+        """Returns true if the current background correction mode is none."""
+        return self._corrections_context.background_corrections_mode == BACKGROUND_MODE_NONE
+
+    def set_selected_function(self, selected_function: str) -> None:
+        """Sets the currently selected function which is displayed in the function combo box."""
+        self._corrections_context.selected_function = selected_function
+
+    def is_exp_decay_selected(self) -> bool:
+        """Returns true if the currently selected function includes an exp decay."""
+        return self._corrections_context.selected_function == FLAT_BACKGROUND_AND_EXP_DECAY
+
     def set_selected_group(self, group: str) -> None:
         """Sets the currently selected Group in the context."""
         self._corrections_context.selected_group = group
@@ -56,7 +69,7 @@ class BackgroundCorrectionsModel:
 
     def all_runs(self) -> list:
         """Returns a list of all loaded runs."""
-        return self._context.get_runs("All")
+        return self._context.get_runs(RUNS_ALL)
 
     def group_names(self) -> list:
         """Returns the group names found in the group/pair context."""
@@ -131,7 +144,7 @@ class BackgroundCorrectionsModel:
     def _selected_groups(self) -> list:
         """Returns a list of selected group names."""
         selected_group = self._corrections_context.selected_group
-        return self.group_names() if selected_group == "All" else [selected_group]
+        return self.group_names() if selected_group == GROUPS_ALL else [selected_group]
 
     def _get_counts_workspace_name(self, run_string: str, group: str) -> str:
         """Returns the name of the counts workspace associated with the provided run string and group."""
@@ -175,7 +188,7 @@ class BackgroundCorrectionsModel:
     # def _selected_runs(self) -> list:
     #     """Returns a list containing the run numbers that are currently selected."""
     #     if self._corrections_context.show_all_runs:
-    #         runs_string = "All"
+    #         runs_string = RUNS_ALL
     #     else:
     #         runs_string = self._corrections_context.current_run_string
     #     return self._context.get_runs(runs_string) if runs_string is not None else []
@@ -183,4 +196,4 @@ class BackgroundCorrectionsModel:
     # def _selected_groups(self) -> list:
     #     """Returns a list of selected group names."""
     #     selected_group = self._corrections_context.selected_group
-    #     return self.group_names() if selected_group == "All" else [selected_group]
+    #     return self.group_names() if selected_group == GROUPS_ALL else [selected_group]

--- a/scripts/Muon/GUI/Common/corrections_tab_widget/background_corrections_presenter.py
+++ b/scripts/Muon/GUI/Common/corrections_tab_widget/background_corrections_presenter.py
@@ -35,13 +35,17 @@ class BackgroundCorrectionsPresenter:
         self.model.set_background_correction_mode(BACKGROUND_MODE_NONE)
         self.view.background_correction_mode = BACKGROUND_MODE_NONE
 
+    def handle_runs_loaded(self) -> None:
+        """Handles when new run numbers are loaded into the interface."""
+        self.model.populate_background_corrections_data()
+
     def handle_groups_changed(self) -> None:
         """Handles when the selected groups have changed in the grouping tab."""
         self.view.populate_group_selector(self.model.group_names())
 
     def handle_run_selector_changed(self) -> None:
         """Handles when the run selector is changed."""
-        self._populate_corrections_table()
+        self._update_displayed_corrections_data()
 
     def handle_mode_combo_box_changed(self) -> None:
         """Handles when the background corrections mode is changed."""
@@ -79,10 +83,6 @@ class BackgroundCorrectionsPresenter:
 
         self.model.set_start_x(run, group, self.view.start_x(run, group))
         self.model.set_end_x(run, group, self.view.end_x(run, group))
-
-    def _populate_corrections_table(self) -> None:
-        self.model.populate_background_corrections_data()
-        self._update_displayed_corrections_data()
 
     def _update_displayed_corrections_data(self) -> None:
         """Updates the displayed corrections data using the data stored in the model."""

--- a/scripts/Muon/GUI/Common/corrections_tab_widget/background_corrections_presenter.py
+++ b/scripts/Muon/GUI/Common/corrections_tab_widget/background_corrections_presenter.py
@@ -86,8 +86,8 @@ class BackgroundCorrectionsPresenter:
 
     def _update_displayed_corrections_data(self) -> None:
         """Updates the displayed corrections data using the data stored in the model."""
-        runs, groups, start_xs, end_xs = self.model.selected_correction_data()
-        self.view.populate_corrections_table(runs, groups, start_xs, end_xs)
+        runs, groups, start_xs, end_xs, a0s, heights, lifetimes = self.model.selected_correction_data()
+        self.view.populate_corrections_table(runs, groups, start_xs, end_xs, a0s, heights, lifetimes)
 
     def _check_start_x_is_valid_for(self, run: str, group: str) -> None:
         """Checks that the new start X is valid. If it isn't, the start and end X is adjusted."""

--- a/scripts/Muon/GUI/Common/corrections_tab_widget/background_corrections_presenter.py
+++ b/scripts/Muon/GUI/Common/corrections_tab_widget/background_corrections_presenter.py
@@ -38,10 +38,12 @@ class BackgroundCorrectionsPresenter:
         self.model.set_selected_function(FLAT_BACKGROUND)
         self.view.background_correction_mode = BACKGROUND_MODE_NONE
         self.view.selected_function = FLAT_BACKGROUND
+        self.model.clear_background_corrections_data()
 
-    def handle_runs_loaded(self) -> None:
-        """Handles when new run numbers are loaded into the interface."""
+    def handle_pre_process_and_grouping_complete(self) -> None:
+        """Handles when MuonPreProcess and grouping has been completed."""
         self.model.populate_background_corrections_data()
+        self._update_displayed_corrections_data()
 
     def handle_groups_changed(self) -> None:
         """Handles when the selected groups have changed in the grouping tab."""

--- a/scripts/Muon/GUI/Common/corrections_tab_widget/background_corrections_presenter.py
+++ b/scripts/Muon/GUI/Common/corrections_tab_widget/background_corrections_presenter.py
@@ -1,0 +1,134 @@
+# Mantid Repository : https://github.com/mantidproject/mantid
+#
+# Copyright &copy; 2021 ISIS Rutherford Appleton Laboratory UKRI,
+#   NScD Oak Ridge National Laboratory, European Spallation Source,
+#   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+# SPDX - License - Identifier: GPL - 3.0 +
+from Muon.GUI.Common.corrections_tab_widget.background_corrections_model import BackgroundCorrectionsModel
+from Muon.GUI.Common.corrections_tab_widget.background_corrections_view import (BackgroundCorrectionsView,
+                                                                                BACKGROUND_MODE_NONE)
+
+
+class BackgroundCorrectionsPresenter:
+    """
+    The BackgroundCorrectionsPresenter has a BackgroundCorrectionsView and BackgroundCorrectionsModel.
+    """
+
+    def __init__(self, view: BackgroundCorrectionsView,  model: BackgroundCorrectionsModel, corrections_presenter):
+        """Initialize the DeadTimeCorrectionsPresenter. Sets up the slots and event observers."""
+        self.view = view
+        self.model = model
+        self._corrections_presenter = corrections_presenter
+
+        self.view.set_slot_for_mode_combo_box_changed(self.handle_mode_combo_box_changed)
+        self.view.set_slot_for_group_combo_box_changed(self.handle_selected_group_changed)
+        self.view.set_slot_for_show_all_runs(self.handle_show_all_runs_ticked)
+        self.view.set_slot_for_start_x_changed(self.handle_start_x_changed)
+        self.view.set_slot_for_end_x_changed(self.handle_end_x_changed)
+
+    def initialize_model_options(self) -> None:
+        """Initialise the model with the default fitting options."""
+        self.model.set_background_correction_mode(BACKGROUND_MODE_NONE)
+
+    def handle_instrument_changed(self) -> None:
+        """User changes the selected instrument."""
+        self.model.set_background_correction_mode(BACKGROUND_MODE_NONE)
+        self.view.background_correction_mode = BACKGROUND_MODE_NONE
+
+    def handle_groups_changed(self) -> None:
+        """Handles when the selected groups have changed in the grouping tab."""
+        self.view.populate_group_selector(self.model.group_names())
+
+    def handle_run_selector_changed(self) -> None:
+        """Handles when the run selector is changed."""
+        self._populate_corrections_table()
+
+    def handle_mode_combo_box_changed(self) -> None:
+        """Handles when the background corrections mode is changed."""
+        self.view.set_background_correction_options_visible(not self.view.is_mode_none())
+
+        if self.view.is_mode_auto():
+            self._handle_mode_auto_selected()
+
+    def _handle_mode_auto_selected(self) -> None:
+        """Handles when the background corrections mode is changed to 'Auto'."""
+        pass
+
+    def handle_selected_group_changed(self) -> None:
+        """Handles when the selected group has changed."""
+        self.model.set_selected_group(self.view.selected_group)
+        self._update_displayed_corrections_data()
+
+    def handle_show_all_runs_ticked(self) -> None:
+        """Handles when the show all runs check box is ticked or unticked."""
+        self.model.set_show_all_runs(self.view.show_all_runs)
+        self._update_displayed_corrections_data()
+
+    def handle_start_x_changed(self) -> None:
+        """Handles when a Start X table cell is changed."""
+        run, group = self.view.selected_run_and_group()
+        self._check_start_x_is_valid_for(run, group)
+
+        self.model.set_start_x(run, group, self.view.start_x(run, group))
+        self.model.set_end_x(run, group, self.view.end_x(run, group))
+
+    def handle_end_x_changed(self) -> None:
+        """Handles when a End X table cell is changed."""
+        run, group = self.view.selected_run_and_group()
+        self._check_end_x_is_valid_for(run, group)
+
+        self.model.set_start_x(run, group, self.view.start_x(run, group))
+        self.model.set_end_x(run, group, self.view.end_x(run, group))
+
+    def _populate_corrections_table(self) -> None:
+        self.model.populate_background_corrections_data()
+        self._update_displayed_corrections_data()
+
+    def _update_displayed_corrections_data(self) -> None:
+        """Updates the displayed corrections data using the data stored in the model."""
+        runs, groups, start_xs, end_xs = self.model.selected_correction_data()
+        self.view.populate_corrections_table(runs, groups, start_xs, end_xs)
+
+    def _check_start_x_is_valid_for(self, run: str, group: str) -> None:
+        """Checks that the new start X is valid. If it isn't, the start and end X is adjusted."""
+        x_lower, x_upper = self.model.x_limits_of_workspace(run, group)
+
+        view_start_x = self.view.start_x(run, group)
+        view_end_x = self.view.end_x(run, group)
+        model_start_x = self.model.start_x(run, group)
+
+        if view_start_x < x_lower:
+            self.view.set_start_x(run, group, x_lower)
+        elif view_start_x > x_upper:
+            if not self.model.is_equal_to_n_decimals(view_end_x, x_upper, 3):
+                self.view.set_start_x(run, group, view_end_x)
+                self.view.set_end_x(run, group, x_upper)
+            else:
+                self.view.set_start_x(run, group, model_start_x)
+        elif view_start_x > view_end_x:
+            self.view.set_start_x(run, group, view_end_x)
+            self.view.set_end_x(run, group, view_start_x)
+        elif view_start_x == view_end_x:
+            self.view.set_start_x(run, group, model_start_x)
+
+    def _check_end_x_is_valid_for(self, run: str, group: str) -> None:
+        """Checks that the new end X is valid. If it isn't, the start and end X is adjusted."""
+        x_lower, x_upper = self.model.x_limits_of_workspace(run, group)
+
+        view_start_x = self.view.start_x(run, group)
+        view_end_x = self.view.end_x(run, group)
+        model_end_x = self.model.end_x(run, group)
+
+        if view_end_x < x_lower:
+            if not self.model.is_equal_to_n_decimals(view_start_x, x_lower, 3):
+                self.view.set_start_x(run, group, x_lower)
+                self.view.set_end_x(run, group, view_start_x)
+            else:
+                self.view.set_end_x(run, group, model_end_x)
+        elif view_end_x > x_upper:
+            self.view.set_end_x(run, group, x_upper)
+        elif view_end_x < view_start_x:
+            self.view.set_start_x(run, group, view_end_x)
+            self.view.set_end_x(run, group, view_start_x)
+        elif view_end_x == view_start_x:
+            self.view.set_end_x(run, group, model_end_x)

--- a/scripts/Muon/GUI/Common/corrections_tab_widget/background_corrections_presenter.py
+++ b/scripts/Muon/GUI/Common/corrections_tab_widget/background_corrections_presenter.py
@@ -4,9 +4,9 @@
 #   NScD Oak Ridge National Laboratory, European Spallation Source,
 #   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
 # SPDX - License - Identifier: GPL - 3.0 +
+from Muon.GUI.Common.contexts.corrections_context import BACKGROUND_MODE_NONE, FLAT_BACKGROUND
 from Muon.GUI.Common.corrections_tab_widget.background_corrections_model import BackgroundCorrectionsModel
-from Muon.GUI.Common.corrections_tab_widget.background_corrections_view import (BackgroundCorrectionsView,
-                                                                                BACKGROUND_MODE_NONE)
+from Muon.GUI.Common.corrections_tab_widget.background_corrections_view import BackgroundCorrectionsView
 
 
 class BackgroundCorrectionsPresenter:
@@ -21,6 +21,7 @@ class BackgroundCorrectionsPresenter:
         self._corrections_presenter = corrections_presenter
 
         self.view.set_slot_for_mode_combo_box_changed(self.handle_mode_combo_box_changed)
+        self.view.set_slot_for_select_function_combo_box_changed(self.handle_select_function_combo_box_changed)
         self.view.set_slot_for_group_combo_box_changed(self.handle_selected_group_changed)
         self.view.set_slot_for_show_all_runs(self.handle_show_all_runs_ticked)
         self.view.set_slot_for_start_x_changed(self.handle_start_x_changed)
@@ -28,12 +29,15 @@ class BackgroundCorrectionsPresenter:
 
     def initialize_model_options(self) -> None:
         """Initialise the model with the default fitting options."""
-        self.model.set_background_correction_mode(BACKGROUND_MODE_NONE)
+        self.model.set_background_correction_mode(self.view.background_correction_mode)
+        self.model.set_selected_function(self.view.selected_function)
 
     def handle_instrument_changed(self) -> None:
         """User changes the selected instrument."""
         self.model.set_background_correction_mode(BACKGROUND_MODE_NONE)
+        self.model.set_selected_function(FLAT_BACKGROUND)
         self.view.background_correction_mode = BACKGROUND_MODE_NONE
+        self.view.selected_function = FLAT_BACKGROUND
 
     def handle_runs_loaded(self) -> None:
         """Handles when new run numbers are loaded into the interface."""
@@ -49,14 +53,13 @@ class BackgroundCorrectionsPresenter:
 
     def handle_mode_combo_box_changed(self) -> None:
         """Handles when the background corrections mode is changed."""
-        self.view.set_background_correction_options_visible(not self.view.is_mode_none())
+        self.model.set_background_correction_mode(self.view.background_correction_mode)
+        self.view.set_background_correction_options_visible(not self.model.is_background_mode_none())
 
-        if self.view.is_mode_auto():
-            self._handle_mode_auto_selected()
-
-    def _handle_mode_auto_selected(self) -> None:
-        """Handles when the background corrections mode is changed to 'Auto'."""
-        pass
+    def handle_select_function_combo_box_changed(self) -> None:
+        """Handles when the selected function is changed."""
+        self.model.set_selected_function(self.view.selected_function)
+        self.view.set_exp_decay_parameters_visible(self.model.is_exp_decay_selected())
 
     def handle_selected_group_changed(self) -> None:
         """Handles when the selected group has changed."""

--- a/scripts/Muon/GUI/Common/corrections_tab_widget/background_corrections_presenter.py
+++ b/scripts/Muon/GUI/Common/corrections_tab_widget/background_corrections_presenter.py
@@ -90,8 +90,8 @@ class BackgroundCorrectionsPresenter:
 
     def _update_displayed_corrections_data(self) -> None:
         """Updates the displayed corrections data using the data stored in the model."""
-        runs, groups, start_xs, end_xs, a0s, a0_errors = self.model.selected_correction_data()
-        self.view.populate_corrections_table(runs, groups, start_xs, end_xs, a0s, a0_errors)
+        runs, groups, start_xs, end_xs, backgrounds, background_errors = self.model.selected_correction_data()
+        self.view.populate_corrections_table(runs, groups, start_xs, end_xs, backgrounds, background_errors)
 
     def _check_start_x_is_valid_for(self, run: str, group: str) -> None:
         """Checks that the new start X is valid. If it isn't, the start and end X is adjusted."""

--- a/scripts/Muon/GUI/Common/corrections_tab_widget/background_corrections_presenter.py
+++ b/scripts/Muon/GUI/Common/corrections_tab_widget/background_corrections_presenter.py
@@ -59,7 +59,6 @@ class BackgroundCorrectionsPresenter:
     def handle_select_function_combo_box_changed(self) -> None:
         """Handles when the selected function is changed."""
         self.model.set_selected_function(self.view.selected_function)
-        self.view.set_exp_decay_parameters_visible(self.model.is_exp_decay_selected())
 
     def handle_selected_group_changed(self) -> None:
         """Handles when the selected group has changed."""
@@ -89,8 +88,8 @@ class BackgroundCorrectionsPresenter:
 
     def _update_displayed_corrections_data(self) -> None:
         """Updates the displayed corrections data using the data stored in the model."""
-        runs, groups, start_xs, end_xs, a0s, heights, lifetimes = self.model.selected_correction_data()
-        self.view.populate_corrections_table(runs, groups, start_xs, end_xs, a0s, heights, lifetimes)
+        runs, groups, start_xs, end_xs, a0s, a0_errors = self.model.selected_correction_data()
+        self.view.populate_corrections_table(runs, groups, start_xs, end_xs, a0s, a0_errors)
 
     def _check_start_x_is_valid_for(self, run: str, group: str) -> None:
         """Checks that the new start X is valid. If it isn't, the start and end X is adjusted."""

--- a/scripts/Muon/GUI/Common/corrections_tab_widget/background_corrections_view.py
+++ b/scripts/Muon/GUI/Common/corrections_tab_widget/background_corrections_view.py
@@ -162,12 +162,13 @@ class BackgroundCorrectionsView(widget, ui_form):
         """Returns the Start X associated with the provided Run and Group."""
         return float(self._table_item_value_for(run, group, END_X_COLUMN_INDEX))
 
-    def populate_corrections_table(self, runs: list, groups: list, start_xs: list, end_xs: list, a0s: list,
-                                   a0_errors: list) -> None:
+    def populate_corrections_table(self, runs: list, groups: list, start_xs: list, end_xs: list, backgrounds: list,
+                                   background_errors: list) -> None:
         """Populates the background corrections table with the provided data."""
         self.correction_options_table.blockSignals(True)
         self.correction_options_table.setRowCount(0)
-        for run, group, start_x, end_x, a0, a0_error in zip(runs, groups, start_xs, end_xs, a0s, a0_errors):
+        for run, group, start_x, end_x, background, background_error in zip(runs, groups, start_xs, end_xs, backgrounds,
+                                                                            background_errors):
             row = self.correction_options_table.rowCount()
             self.correction_options_table.insertRow(row)
             self.correction_options_table.setItem(row, RUN_COLUMN_INDEX, self._create_table_item(run, False))
@@ -175,9 +176,9 @@ class BackgroundCorrectionsView(widget, ui_form):
             self.correction_options_table.setItem(row, START_X_COLUMN_INDEX, self._create_double_table_item(start_x))
             self.correction_options_table.setItem(row, END_X_COLUMN_INDEX, self._create_double_table_item(end_x))
             self.correction_options_table.setItem(row, A0_COLUMN_INDEX,
-                                                  self._create_double_table_item(a0, enabled=False))
+                                                  self._create_double_table_item(background, enabled=False))
             self.correction_options_table.setItem(row, A0_ERROR_COLUMN_INDEX,
-                                                  self._create_double_table_item(a0_error, enabled=False))
+                                                  self._create_double_table_item(background_error, enabled=False))
         self.correction_options_table.blockSignals(False)
 
     def _setup_corrections_table(self) -> None:

--- a/scripts/Muon/GUI/Common/corrections_tab_widget/background_corrections_view.py
+++ b/scripts/Muon/GUI/Common/corrections_tab_widget/background_corrections_view.py
@@ -17,8 +17,7 @@ GROUP_COLUMN_INDEX = 1
 START_X_COLUMN_INDEX = 2
 END_X_COLUMN_INDEX = 3
 A0_COLUMN_INDEX = 4
-HEIGHT_COLUMN_INDEX = 5
-LIFETIME_COLUMN_INDEX = 6
+A0_ERROR_COLUMN_INDEX = 5
 
 
 class DoubleItemDelegate(QStyledItemDelegate):
@@ -47,14 +46,13 @@ class BackgroundCorrectionsView(widget, ui_form):
         self._selected_column: int = None
         self._selected_value: str = None
 
-        self.set_exp_decay_parameters_visible(False)
         self.set_background_correction_options_visible(False)
 
         self._handle_start_x_changed = None
         self._handle_end_x_changed = None
 
         # Disable the background mode combo box while background corrections in still in development
-        self.mode_combo_box.setEnabled(False)
+        # self.mode_combo_box.setEnabled(False)
 
     def set_slot_for_mode_combo_box_changed(self, slot) -> None:
         """Connect the slot for the Background corrections mode combo box."""
@@ -88,11 +86,6 @@ class BackgroundCorrectionsView(widget, ui_form):
         self.group_combo_box.setVisible(visible)
         self.show_all_runs_checkbox.setVisible(visible)
         self.correction_options_table.setVisible(visible)
-
-    def set_exp_decay_parameters_visible(self, visible: bool) -> None:
-        """Sets the Exp Decay parameters in the table widget as visible or hidden."""
-        self.correction_options_table.setColumnHidden(HEIGHT_COLUMN_INDEX, not visible)
-        self.correction_options_table.setColumnHidden(LIFETIME_COLUMN_INDEX, not visible)
 
     @property
     def background_correction_mode(self) -> str:
@@ -170,12 +163,11 @@ class BackgroundCorrectionsView(widget, ui_form):
         return float(self._table_item_value_for(run, group, END_X_COLUMN_INDEX))
 
     def populate_corrections_table(self, runs: list, groups: list, start_xs: list, end_xs: list, a0s: list,
-                                   heights: list, lifetimes: list) -> None:
+                                   a0_errors: list) -> None:
         """Populates the background corrections table with the provided data."""
         self.correction_options_table.blockSignals(True)
         self.correction_options_table.setRowCount(0)
-        for run, group, start_x, end_x, a0, height, lifetime in zip(runs, groups, start_xs, end_xs, a0s, heights,
-                                                                    lifetimes):
+        for run, group, start_x, end_x, a0, a0_error in zip(runs, groups, start_xs, end_xs, a0s, a0_errors):
             row = self.correction_options_table.rowCount()
             self.correction_options_table.insertRow(row)
             self.correction_options_table.setItem(row, RUN_COLUMN_INDEX, self._create_table_item(run, False))
@@ -184,10 +176,8 @@ class BackgroundCorrectionsView(widget, ui_form):
             self.correction_options_table.setItem(row, END_X_COLUMN_INDEX, self._create_double_table_item(end_x))
             self.correction_options_table.setItem(row, A0_COLUMN_INDEX,
                                                   self._create_double_table_item(a0, enabled=False))
-            self.correction_options_table.setItem(row, HEIGHT_COLUMN_INDEX,
-                                                  self._create_double_table_item(height, enabled=False))
-            self.correction_options_table.setItem(row, LIFETIME_COLUMN_INDEX,
-                                                  self._create_double_table_item(lifetime, enabled=False))
+            self.correction_options_table.setItem(row, A0_ERROR_COLUMN_INDEX,
+                                                  self._create_double_table_item(a0_error, enabled=False))
         self.correction_options_table.blockSignals(False)
 
     def _setup_corrections_table(self) -> None:
@@ -195,8 +185,7 @@ class BackgroundCorrectionsView(widget, ui_form):
         self._setup_double_item_delegate(START_X_COLUMN_INDEX)
         self._setup_double_item_delegate(END_X_COLUMN_INDEX)
         self._setup_double_item_delegate(A0_COLUMN_INDEX)
-        self._setup_double_item_delegate(HEIGHT_COLUMN_INDEX)
-        self._setup_double_item_delegate(LIFETIME_COLUMN_INDEX)
+        self._setup_double_item_delegate(A0_ERROR_COLUMN_INDEX)
 
         self.correction_options_table.cellChanged.connect(lambda row, column:
                                                           self._on_corrections_table_cell_changed(row, column))

--- a/scripts/Muon/GUI/Common/corrections_tab_widget/background_corrections_view.py
+++ b/scripts/Muon/GUI/Common/corrections_tab_widget/background_corrections_view.py
@@ -51,7 +51,7 @@ class BackgroundCorrectionsView(widget, ui_form):
         self._handle_start_x_changed = None
         self._handle_end_x_changed = None
 
-        # Disable the background mode combo box while background corrections in still in development
+        # Disable the background mode combo box while background corrections is still in development
         self.mode_combo_box.setEnabled(False)
 
     def set_slot_for_mode_combo_box_changed(self, slot) -> None:

--- a/scripts/Muon/GUI/Common/corrections_tab_widget/background_corrections_view.py
+++ b/scripts/Muon/GUI/Common/corrections_tab_widget/background_corrections_view.py
@@ -7,7 +7,8 @@
 from mantidqt.utils.qt import load_ui
 
 from qtpy.QtCore import Qt
-from qtpy.QtWidgets import QTableWidgetItem, QWidget
+from qtpy.QtGui import QDoubleValidator
+from qtpy.QtWidgets import QLineEdit, QStyledItemDelegate, QTableWidgetItem, QWidget
 
 ui_form, widget = load_ui(__file__, "background_corrections_view.ui")
 
@@ -18,6 +19,17 @@ RUN_COLUMN_INDEX = 0
 GROUP_COLUMN_INDEX = 1
 START_X_COLUMN_INDEX = 2
 END_X_COLUMN_INDEX = 3
+
+
+class DoubleItemDelegate(QStyledItemDelegate):
+    """
+    An item delegate that has a QDoubleValidator to validate the data provided.
+    """
+
+    def createEditor(self, parent, option, index):
+        line_edit = QLineEdit(parent)
+        line_edit.setValidator(QDoubleValidator())
+        return line_edit
 
 
 class BackgroundCorrectionsView(widget, ui_form):
@@ -157,6 +169,11 @@ class BackgroundCorrectionsView(widget, ui_form):
 
     def _setup_corrections_table(self) -> None:
         """Setup the correction options table to have a good layout."""
+        self.correction_options_table.setItemDelegateForColumn(START_X_COLUMN_INDEX,
+                                                               DoubleItemDelegate(self.correction_options_table))
+        self.correction_options_table.setItemDelegateForColumn(END_X_COLUMN_INDEX,
+                                                               DoubleItemDelegate(self.correction_options_table))
+
         self.correction_options_table.cellChanged.connect(lambda row, column:
                                                           self._on_corrections_table_cell_changed(row, column))
         self.correction_options_table.itemClicked.connect(lambda item: self._on_item_clicked(item))

--- a/scripts/Muon/GUI/Common/corrections_tab_widget/background_corrections_view.py
+++ b/scripts/Muon/GUI/Common/corrections_tab_widget/background_corrections_view.py
@@ -52,7 +52,7 @@ class BackgroundCorrectionsView(widget, ui_form):
         self._handle_end_x_changed = None
 
         # Disable the background mode combo box while background corrections in still in development
-        # self.mode_combo_box.setEnabled(False)
+        self.mode_combo_box.setEnabled(False)
 
     def set_slot_for_mode_combo_box_changed(self, slot) -> None:
         """Connect the slot for the Background corrections mode combo box."""

--- a/scripts/Muon/GUI/Common/corrections_tab_widget/background_corrections_view.py
+++ b/scripts/Muon/GUI/Common/corrections_tab_widget/background_corrections_view.py
@@ -22,7 +22,7 @@ A0_ERROR_COLUMN_INDEX = 5
 
 class DoubleItemDelegate(QStyledItemDelegate):
     """
-    An item delegate that has a QDoubleValidator to validate the data provided.
+    An item delegate that has a QDoubleValidator. The __init__ is the default QStyledItemDelegate __init__.
     """
 
     def createEditor(self, parent, option, index):

--- a/scripts/Muon/GUI/Common/corrections_tab_widget/background_corrections_view.py
+++ b/scripts/Muon/GUI/Common/corrections_tab_widget/background_corrections_view.py
@@ -53,6 +53,9 @@ class BackgroundCorrectionsView(widget, ui_form):
         self._handle_start_x_changed = None
         self._handle_end_x_changed = None
 
+        # Disable the background mode combo box while background corrections in still in development
+        self.mode_combo_box.setEnabled(False)
+
     def set_slot_for_mode_combo_box_changed(self, slot) -> None:
         """Connect the slot for the Background corrections mode combo box."""
         self.mode_combo_box.currentIndexChanged.connect(slot)

--- a/scripts/Muon/GUI/Common/corrections_tab_widget/background_corrections_view.py
+++ b/scripts/Muon/GUI/Common/corrections_tab_widget/background_corrections_view.py
@@ -12,9 +12,6 @@ from qtpy.QtWidgets import QLineEdit, QStyledItemDelegate, QTableWidgetItem, QWi
 
 ui_form, widget = load_ui(__file__, "background_corrections_view.ui")
 
-BACKGROUND_MODE_NONE = "None"
-BACKGROUND_MODE_AUTO = "Auto"
-
 RUN_COLUMN_INDEX = 0
 GROUP_COLUMN_INDEX = 1
 START_X_COLUMN_INDEX = 2
@@ -50,6 +47,7 @@ class BackgroundCorrectionsView(widget, ui_form):
         self._selected_column: int = None
         self._selected_value: str = None
 
+        self.set_exp_decay_parameters_visible(False)
         self.set_background_correction_options_visible(False)
 
         self._handle_start_x_changed = None
@@ -58,6 +56,10 @@ class BackgroundCorrectionsView(widget, ui_form):
     def set_slot_for_mode_combo_box_changed(self, slot) -> None:
         """Connect the slot for the Background corrections mode combo box."""
         self.mode_combo_box.currentIndexChanged.connect(slot)
+
+    def set_slot_for_select_function_combo_box_changed(self, slot) -> None:
+        """Connect the slot for the Select Function combo box changing."""
+        self.function_combo_box.currentIndexChanged.connect(slot)
 
     def set_slot_for_group_combo_box_changed(self, slot) -> None:
         """Connect the slot for the Group selector combo box changing."""
@@ -84,6 +86,11 @@ class BackgroundCorrectionsView(widget, ui_form):
         self.show_all_runs_checkbox.setVisible(visible)
         self.correction_options_table.setVisible(visible)
 
+    def set_exp_decay_parameters_visible(self, visible: bool) -> None:
+        """Sets the Exp Decay parameters in the table widget as visible or hidden."""
+        self.correction_options_table.setColumnHidden(HEIGHT_COLUMN_INDEX, not visible)
+        self.correction_options_table.setColumnHidden(LIFETIME_COLUMN_INDEX, not visible)
+
     @property
     def background_correction_mode(self) -> str:
         """Returns the currently selected background correction mode."""
@@ -96,13 +103,17 @@ class BackgroundCorrectionsView(widget, ui_form):
         if index != -1:
             self.mode_combo_box.setCurrentIndex(index)
 
-    def is_mode_none(self) -> bool:
-        """Returns true if the corrections mode is 'None'."""
-        return self.mode_combo_box.currentText() == BACKGROUND_MODE_NONE
+    @property
+    def selected_function(self) -> str:
+        """Returns the currently selected function in the combo box."""
+        return str(self.function_combo_box.currentText())
 
-    def is_mode_auto(self) -> bool:
-        """Returns true if the corrections mode is 'Auto'."""
-        return self.mode_combo_box.currentText() == BACKGROUND_MODE_AUTO
+    @selected_function.setter
+    def selected_function(self, function: str) -> None:
+        """Sets the currently selected function in the combo box."""
+        index = self.function_combo_box.findText(function)
+        if index != -1:
+            self.function_combo_box.setCurrentIndex(index)
 
     def populate_group_selector(self, groups: list) -> None:
         """Populates the group selector combo box."""

--- a/scripts/Muon/GUI/Common/corrections_tab_widget/background_corrections_view.py
+++ b/scripts/Muon/GUI/Common/corrections_tab_widget/background_corrections_view.py
@@ -1,0 +1,228 @@
+# Mantid Repository : https://github.com/mantidproject/mantid
+#
+# Copyright &copy; 2021 ISIS Rutherford Appleton Laboratory UKRI,
+#   NScD Oak Ridge National Laboratory, European Spallation Source,
+#   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+# SPDX - License - Identifier: GPL - 3.0 +
+from mantidqt.utils.qt import load_ui
+
+from qtpy.QtCore import Qt
+from qtpy.QtWidgets import QTableWidgetItem, QWidget
+
+ui_form, widget = load_ui(__file__, "background_corrections_view.ui")
+
+BACKGROUND_MODE_NONE = "None"
+BACKGROUND_MODE_AUTO = "Auto"
+
+RUN_COLUMN_INDEX = 0
+GROUP_COLUMN_INDEX = 1
+START_X_COLUMN_INDEX = 2
+END_X_COLUMN_INDEX = 3
+
+
+class BackgroundCorrectionsView(widget, ui_form):
+    """
+    The BackgroundCorrectionsView contains the widgets allowing a Background correction.
+    """
+
+    def __init__(self, parent: QWidget = None):
+        """Initializes the DeadTimeCorrectionsView."""
+        super(BackgroundCorrectionsView, self).__init__(parent)
+        self.setupUi(self)
+
+        self._setup_corrections_table()
+        self._selected_row: int = None
+        self._selected_column: int = None
+        self._selected_value: str = None
+
+        self.set_background_correction_options_visible(False)
+
+        self._handle_start_x_changed = None
+        self._handle_end_x_changed = None
+
+    def set_slot_for_mode_combo_box_changed(self, slot) -> None:
+        """Connect the slot for the Background corrections mode combo box."""
+        self.mode_combo_box.currentIndexChanged.connect(slot)
+
+    def set_slot_for_group_combo_box_changed(self, slot) -> None:
+        """Connect the slot for the Group selector combo box changing."""
+        self.group_combo_box.currentIndexChanged.connect(slot)
+
+    def set_slot_for_show_all_runs(self, slot) -> None:
+        """Connect the slot for the Show All Runs check box."""
+        self.show_all_runs_checkbox.stateChanged.connect(slot)
+
+    def set_slot_for_start_x_changed(self, slot) -> None:
+        """Sets the slot for when a start x table cell is changed."""
+        self._handle_start_x_changed = slot
+
+    def set_slot_for_end_x_changed(self, slot) -> None:
+        """Sets the slot for when a end x table cell is changed."""
+        self._handle_end_x_changed = slot
+
+    def set_background_correction_options_visible(self, visible: bool) -> None:
+        """Sets the Background corrections widgets as being visible or hidden."""
+        self.select_function_label.setVisible(visible)
+        self.function_combo_box.setVisible(visible)
+        self.group_label.setVisible(visible)
+        self.group_combo_box.setVisible(visible)
+        self.show_all_runs_checkbox.setVisible(visible)
+        self.correction_options_table.setVisible(visible)
+
+    @property
+    def background_correction_mode(self) -> str:
+        """Returns the currently selected background correction mode."""
+        return str(self.mode_combo_box.currentText())
+
+    @background_correction_mode.setter
+    def background_correction_mode(self, mode: str) -> None:
+        """Sets the currently selected background correction mode."""
+        index = self.mode_combo_box.findText(mode)
+        if index != -1:
+            self.mode_combo_box.setCurrentIndex(index)
+
+    def is_mode_none(self) -> bool:
+        """Returns true if the corrections mode is 'None'."""
+        return self.mode_combo_box.currentText() == BACKGROUND_MODE_NONE
+
+    def is_mode_auto(self) -> bool:
+        """Returns true if the corrections mode is 'Auto'."""
+        return self.mode_combo_box.currentText() == BACKGROUND_MODE_AUTO
+
+    def populate_group_selector(self, groups: list) -> None:
+        """Populates the group selector combo box."""
+        old_group = self.group_combo_box.currentText()
+
+        self.group_combo_box.blockSignals(True)
+
+        self.group_combo_box.clear()
+        self.group_combo_box.addItems(["All"] + groups)
+
+        new_index = self.group_combo_box.findText(old_group)
+        self.group_combo_box.setCurrentIndex(new_index if new_index != -1 else 0)
+
+        self.group_combo_box.blockSignals(False)
+
+        # Signal is emitted manually in case the index has not changed (but the loaded dataset may be different)
+        self.group_combo_box.currentIndexChanged.emit(new_index)
+
+    @property
+    def selected_group(self) -> str:
+        """Returns the currently selected Group."""
+        return str(self.group_combo_box.currentText())
+
+    @property
+    def show_all_runs(self) -> bool:
+        """Returns true if all the runs should be shown."""
+        return self.show_all_runs_checkbox.isChecked()
+
+    def selected_run_and_group(self) -> tuple:
+        """Returns the Run and Group that is in the same row as the selected table cell."""
+        if self._selected_row is not None:
+            run = self.correction_options_table.item(self._selected_row, RUN_COLUMN_INDEX).text()
+            group = self.correction_options_table.item(self._selected_row, GROUP_COLUMN_INDEX).text()
+            return run, group
+        return None, None
+
+    def set_start_x(self, run: str, group: str, start_x: float) -> None:
+        """Sets the Start X associated with the provided Run and Group."""
+        self._set_table_item_value_for(run, group, START_X_COLUMN_INDEX, start_x)
+
+    def start_x(self, run: str, group: str) -> float:
+        """Returns the Start X associated with the provided Run and Group."""
+        return float(self._table_item_value_for(run, group, START_X_COLUMN_INDEX))
+
+    def set_end_x(self, run: str, group: str, end_x: float) -> None:
+        """Sets the End X associated with the provided Run and Group."""
+        self._set_table_item_value_for(run, group, END_X_COLUMN_INDEX, end_x)
+
+    def end_x(self, run: str, group: str) -> float:
+        """Returns the Start X associated with the provided Run and Group."""
+        return float(self._table_item_value_for(run, group, END_X_COLUMN_INDEX))
+
+    def populate_corrections_table(self, runs: list, groups: list, start_xs: list, end_xs: list) -> None:
+        """Populates the background corrections table with the provided data."""
+        self.correction_options_table.blockSignals(True)
+        self.correction_options_table.setRowCount(0)
+        for run, group, start_x, end_x in zip(runs, groups, start_xs, end_xs):
+            row_index = self.correction_options_table.rowCount()
+            self.correction_options_table.insertRow(row_index)
+            self.correction_options_table.setItem(row_index, RUN_COLUMN_INDEX, self._create_table_item(run, False))
+            self.correction_options_table.setItem(row_index, GROUP_COLUMN_INDEX, self._create_table_item(group, False))
+            self.correction_options_table.setItem(row_index, START_X_COLUMN_INDEX,
+                                                  self._create_table_item(self._float_to_str(start_x)))
+            self.correction_options_table.setItem(row_index, END_X_COLUMN_INDEX,
+                                                  self._create_table_item(self._float_to_str(end_x)))
+        self.correction_options_table.blockSignals(False)
+
+    def _setup_corrections_table(self) -> None:
+        """Setup the correction options table to have a good layout."""
+        self.correction_options_table.cellChanged.connect(lambda row, column:
+                                                          self._on_corrections_table_cell_changed(row, column))
+        self.correction_options_table.itemClicked.connect(lambda item: self._on_item_clicked(item))
+
+    def _on_item_clicked(self, item: QTableWidgetItem) -> None:
+        """Handles when a table cell is clicked."""
+        self._selected_row = item.row()
+        self._selected_column = item.column()
+        self._selected_value = item.text()
+
+    def _on_corrections_table_cell_changed(self, _: int, column: int) -> None:
+        """Handles when a cells value is changed in the corrections table."""
+        self._format_selection()
+
+        if column == START_X_COLUMN_INDEX:
+            self._handle_start_x_changed()
+        elif column == END_X_COLUMN_INDEX:
+            self._handle_end_x_changed()
+
+    @staticmethod
+    def _create_table_item(text: str, editable: bool = True) -> QTableWidgetItem:
+        """Creates a table item for the corrections options table."""
+        item = QTableWidgetItem(text)
+        item.setTextAlignment(Qt.AlignCenter)
+        if not editable:
+            item.setFlags(item.flags() ^ Qt.ItemIsEditable)
+        return item
+
+    def _set_table_item_value_for(self, run: str, group: str, column_index: int, value: float) -> None:
+        """Sets the End X associated with the provided Run and Group."""
+        row_index = self._table_row_index_of(run, group)
+
+        self.correction_options_table.blockSignals(True)
+        self.correction_options_table.setItem(row_index, column_index,
+                                              self._create_table_item(self._float_to_str(value)))
+        self.correction_options_table.blockSignals(False)
+
+    def _table_item_value_for(self, run: str, group: str, column_index: int) -> str:
+        """Returns the value in a table cell for the provided Run, Group and column index."""
+        row_index = self._table_row_index_of(run, group)
+        return self.correction_options_table.item(row_index, column_index).text() if row_index is not None else None
+
+    def _table_row_index_of(self, run: str, group: str) -> int:
+        """Returns the row index of the provided Run and Group."""
+        for row_index in range(self.correction_options_table.rowCount()):
+            row_run = self.correction_options_table.item(row_index, RUN_COLUMN_INDEX).text()
+            row_group = self.correction_options_table.item(row_index, GROUP_COLUMN_INDEX).text()
+            if row_run == run and row_group == group:
+                return row_index
+        return None
+
+    def _format_selection(self) -> None:
+        """Formats the selected cell to have the expected number of decimal places."""
+        if self._selected_row is not None and self._selected_column is not None:
+            value = float(self.correction_options_table.item(self._selected_row, self._selected_column).text())
+            self._set_selected_value(value)
+
+    def _set_selected_value(self, value: float) -> None:
+        """Sets the currently selected cell to the float value provided."""
+        if self._selected_row is not None and self._selected_column is not None:
+            self.correction_options_table.blockSignals(True)
+            self.correction_options_table.setItem(self._selected_row, self._selected_column,
+                                                  self._create_table_item(self._float_to_str(value)))
+            self.correction_options_table.blockSignals(False)
+
+    @staticmethod
+    def _float_to_str(value: float) -> str:
+        """Converts a float to a string with three decimal places."""
+        return f"{value:.3f}"

--- a/scripts/Muon/GUI/Common/corrections_tab_widget/background_corrections_view.ui
+++ b/scripts/Muon/GUI/Common/corrections_tab_widget/background_corrections_view.ui
@@ -41,86 +41,7 @@ color: grey; }
       <property name="topMargin">
        <number>20</number>
       </property>
-      <item row="5" column="1" colspan="2">
-       <widget class="QLabel" name="background_info_label">
-        <property name="minimumSize">
-         <size>
-          <width>180</width>
-          <height>0</height>
-         </size>
-        </property>
-        <property name="text">
-         <string>No background correction</string>
-        </property>
-        <property name="alignment">
-         <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-        </property>
-       </widget>
-      </item>
-      <item row="3" column="0">
-       <widget class="QLabel" name="group_label">
-        <property name="minimumSize">
-         <size>
-          <width>200</width>
-          <height>0</height>
-         </size>
-        </property>
-        <property name="text">
-         <string>Group :</string>
-        </property>
-       </widget>
-      </item>
-      <item row="2" column="0">
-       <widget class="QLabel" name="select_function_label">
-        <property name="minimumSize">
-         <size>
-          <width>200</width>
-          <height>0</height>
-         </size>
-        </property>
-        <property name="text">
-         <string>Select Function :</string>
-        </property>
-       </widget>
-      </item>
-      <item row="2" column="1" colspan="2">
-       <widget class="QComboBox" name="function_combo_box">
-        <property name="toolTip">
-         <string>Select a table which is loaded into the ADS.</string>
-        </property>
-        <item>
-         <property name="text">
-          <string>Flat Background</string>
-         </property>
-        </item>
-        <item>
-         <property name="text">
-          <string>Flat Background + Exp Decay</string>
-         </property>
-        </item>
-       </widget>
-      </item>
-      <item row="1" column="0">
-       <widget class="QLabel" name="mode_label">
-        <property name="minimumSize">
-         <size>
-          <width>200</width>
-          <height>0</height>
-         </size>
-        </property>
-        <property name="text">
-         <string>Background :</string>
-        </property>
-       </widget>
-      </item>
-      <item row="3" column="2">
-       <widget class="QCheckBox" name="show_all_runs_checkbox">
-        <property name="text">
-         <string>Show All Runs</string>
-        </property>
-       </widget>
-      </item>
-      <item row="4" column="0" colspan="3">
+      <item row="5" column="1" colspan="3">
        <widget class="QTableWidget" name="correction_options_table">
         <property name="styleSheet">
          <string notr="true">QTableWidget {
@@ -184,7 +105,66 @@ background-color: #c7e0ff;
         </column>
        </widget>
       </item>
-      <item row="1" column="1" colspan="2">
+      <item row="6" column="2" colspan="2">
+       <widget class="QLabel" name="background_info_label">
+        <property name="minimumSize">
+         <size>
+          <width>180</width>
+          <height>0</height>
+         </size>
+        </property>
+        <property name="text">
+         <string>No background correction</string>
+        </property>
+        <property name="alignment">
+         <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="1">
+       <widget class="QLabel" name="mode_label">
+        <property name="minimumSize">
+         <size>
+          <width>200</width>
+          <height>0</height>
+         </size>
+        </property>
+        <property name="text">
+         <string>Background :</string>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="1">
+       <widget class="QLabel" name="select_function_label">
+        <property name="minimumSize">
+         <size>
+          <width>200</width>
+          <height>0</height>
+         </size>
+        </property>
+        <property name="text">
+         <string>Select Function :</string>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="2" colspan="2">
+       <widget class="QComboBox" name="function_combo_box">
+        <property name="toolTip">
+         <string>Select a table which is loaded into the ADS.</string>
+        </property>
+        <item>
+         <property name="text">
+          <string>Flat Background</string>
+         </property>
+        </item>
+        <item>
+         <property name="text">
+          <string>Flat Background + Exp Decay</string>
+         </property>
+        </item>
+       </widget>
+      </item>
+      <item row="1" column="2" colspan="2">
        <widget class="QComboBox" name="mode_combo_box">
         <item>
          <property name="text">
@@ -198,16 +178,7 @@ background-color: #c7e0ff;
         </item>
        </widget>
       </item>
-      <item row="3" column="1">
-       <widget class="QComboBox" name="group_combo_box">
-        <item>
-         <property name="text">
-          <string>All</string>
-         </property>
-        </item>
-       </widget>
-      </item>
-      <item row="6" column="1">
+      <item row="7" column="2">
        <spacer name="verticalSpacer">
         <property name="orientation">
          <enum>Qt::Vertical</enum>
@@ -219,6 +190,35 @@ background-color: #c7e0ff;
          </size>
         </property>
        </spacer>
+      </item>
+      <item row="3" column="3">
+       <widget class="QComboBox" name="group_combo_box">
+        <item>
+         <property name="text">
+          <string>All</string>
+         </property>
+        </item>
+       </widget>
+      </item>
+      <item row="3" column="1">
+       <widget class="QCheckBox" name="show_all_runs_checkbox">
+        <property name="minimumSize">
+         <size>
+          <width>200</width>
+          <height>0</height>
+         </size>
+        </property>
+        <property name="text">
+         <string>Show All Runs</string>
+        </property>
+       </widget>
+      </item>
+      <item row="3" column="2">
+       <widget class="QLabel" name="group_label">
+        <property name="text">
+         <string>Group :</string>
+        </property>
+       </widget>
       </item>
      </layout>
     </widget>

--- a/scripts/Muon/GUI/Common/corrections_tab_widget/background_corrections_view.ui
+++ b/scripts/Muon/GUI/Common/corrections_tab_widget/background_corrections_view.ui
@@ -179,12 +179,7 @@ background-color: #c7e0ff;
         </column>
         <column>
          <property name="text">
-          <string>Height</string>
-         </property>
-        </column>
-        <column>
-         <property name="text">
-          <string>Lifetime</string>
+          <string>A0 Error</string>
          </property>
         </column>
        </widget>

--- a/scripts/Muon/GUI/Common/corrections_tab_widget/background_corrections_view.ui
+++ b/scripts/Muon/GUI/Common/corrections_tab_widget/background_corrections_view.ui
@@ -217,7 +217,12 @@ background-color: #c7e0ff;
         </column>
         <column>
          <property name="text">
-          <string>A0 Error</string>
+          <string>Height</string>
+         </property>
+        </column>
+        <column>
+         <property name="text">
+          <string>Lifetime</string>
          </property>
         </column>
        </widget>

--- a/scripts/Muon/GUI/Common/corrections_tab_widget/background_corrections_view.ui
+++ b/scripts/Muon/GUI/Common/corrections_tab_widget/background_corrections_view.ui
@@ -1,0 +1,232 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>background_corrections_view</class>
+ <widget class="QWidget" name="background_corrections_view">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>473</width>
+    <height>263</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Form</string>
+  </property>
+  <layout class="QGridLayout" name="gridLayout">
+   <item row="0" column="0">
+    <widget class="QGroupBox" name="groupBox">
+     <property name="styleSheet">
+      <string notr="true">QGroupBox {
+border: 1px solid grey;
+border-radius: 10px;
+margin-top: 1ex;
+margin-right: 0ex
+}
+
+QGroupBox:title {
+subcontrol-origin: margin;
+padding: 0 3px;
+subcontrol-position: top center;
+padding-top: 0px;
+padding-bottom: 0px;
+padding-right: 10px;
+color: grey; }
+</string>
+     </property>
+     <property name="title">
+      <string>Background Correction</string>
+     </property>
+     <layout class="QGridLayout" name="gridLayout_2">
+      <property name="topMargin">
+       <number>14</number>
+      </property>
+      <item row="5" column="1" colspan="2">
+       <widget class="QLabel" name="background_info_label">
+        <property name="minimumSize">
+         <size>
+          <width>180</width>
+          <height>0</height>
+         </size>
+        </property>
+        <property name="text">
+         <string>No background correction</string>
+        </property>
+        <property name="alignment">
+         <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="1" colspan="2">
+       <widget class="QComboBox" name="mode_combo_box">
+        <item>
+         <property name="text">
+          <string>None</string>
+         </property>
+        </item>
+        <item>
+         <property name="text">
+          <string>Auto</string>
+         </property>
+        </item>
+       </widget>
+      </item>
+      <item row="2" column="1" colspan="2">
+       <widget class="QComboBox" name="function_combo_box">
+        <property name="toolTip">
+         <string>Select a table which is loaded into the ADS.</string>
+        </property>
+        <item>
+         <property name="text">
+          <string>Flat Background</string>
+         </property>
+        </item>
+        <item>
+         <property name="text">
+          <string>Flat Background + Exp Decay</string>
+         </property>
+        </item>
+       </widget>
+      </item>
+      <item row="2" column="0">
+       <widget class="QLabel" name="select_function_label">
+        <property name="minimumSize">
+         <size>
+          <width>200</width>
+          <height>0</height>
+         </size>
+        </property>
+        <property name="maximumSize">
+         <size>
+          <width>200</width>
+          <height>16777215</height>
+         </size>
+        </property>
+        <property name="text">
+         <string>Select Function :</string>
+        </property>
+       </widget>
+      </item>
+      <item row="3" column="0">
+       <widget class="QLabel" name="group_label">
+        <property name="minimumSize">
+         <size>
+          <width>200</width>
+          <height>0</height>
+         </size>
+        </property>
+        <property name="maximumSize">
+         <size>
+          <width>200</width>
+          <height>16777215</height>
+         </size>
+        </property>
+        <property name="text">
+         <string>Group :</string>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="0">
+       <widget class="QLabel" name="mode_label">
+        <property name="minimumSize">
+         <size>
+          <width>200</width>
+          <height>0</height>
+         </size>
+        </property>
+        <property name="maximumSize">
+         <size>
+          <width>200</width>
+          <height>16777215</height>
+         </size>
+        </property>
+        <property name="text">
+         <string>Background :</string>
+        </property>
+       </widget>
+      </item>
+      <item row="3" column="1">
+       <widget class="QComboBox" name="group_combo_box">
+        <item>
+         <property name="text">
+          <string>All</string>
+         </property>
+        </item>
+       </widget>
+      </item>
+      <item row="3" column="2">
+       <widget class="QCheckBox" name="show_all_runs_checkbox">
+        <property name="text">
+         <string>Show All Runs</string>
+        </property>
+       </widget>
+      </item>
+      <item row="4" column="0" colspan="3">
+       <widget class="QTableWidget" name="correction_options_table">
+        <property name="styleSheet">
+         <string notr="true">QTableWidget {
+font-size: 8pt;
+ border: 1px solid #828790;
+}
+
+QTableWidget::item:selected {
+background-color: #c7e0ff;
+color: #000000;
+}
+
+QTableWidget::item:hover {
+background-color: #c7e0ff;
+}</string>
+        </property>
+        <property name="selectionMode">
+         <enum>QAbstractItemView::SingleSelection</enum>
+        </property>
+        <attribute name="horizontalHeaderDefaultSectionSize">
+         <number>80</number>
+        </attribute>
+        <attribute name="horizontalHeaderStretchLastSection">
+         <bool>true</bool>
+        </attribute>
+        <attribute name="verticalHeaderVisible">
+         <bool>false</bool>
+        </attribute>
+        <column>
+         <property name="text">
+          <string>Run</string>
+         </property>
+        </column>
+        <column>
+         <property name="text">
+          <string>Group</string>
+         </property>
+        </column>
+        <column>
+         <property name="text">
+          <string>Start X</string>
+         </property>
+        </column>
+        <column>
+         <property name="text">
+          <string>End X</string>
+         </property>
+        </column>
+        <column>
+         <property name="text">
+          <string>A0</string>
+         </property>
+        </column>
+        <column>
+         <property name="text">
+          <string>A0 Error</string>
+         </property>
+        </column>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections/>
+</ui>

--- a/scripts/Muon/GUI/Common/corrections_tab_widget/background_corrections_view.ui
+++ b/scripts/Muon/GUI/Common/corrections_tab_widget/background_corrections_view.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>473</width>
-    <height>263</height>
+    <height>251</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -39,7 +39,7 @@ color: grey; }
      </property>
      <layout class="QGridLayout" name="gridLayout_2">
       <property name="topMargin">
-       <number>14</number>
+       <number>20</number>
       </property>
       <item row="5" column="1" colspan="2">
        <widget class="QLabel" name="background_info_label">
@@ -57,18 +57,30 @@ color: grey; }
         </property>
        </widget>
       </item>
-      <item row="1" column="1" colspan="2">
-       <widget class="QComboBox" name="mode_combo_box">
-        <item>
-         <property name="text">
-          <string>None</string>
-         </property>
-        </item>
-        <item>
-         <property name="text">
-          <string>Auto</string>
-         </property>
-        </item>
+      <item row="3" column="0">
+       <widget class="QLabel" name="group_label">
+        <property name="minimumSize">
+         <size>
+          <width>200</width>
+          <height>0</height>
+         </size>
+        </property>
+        <property name="text">
+         <string>Group :</string>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="0">
+       <widget class="QLabel" name="select_function_label">
+        <property name="minimumSize">
+         <size>
+          <width>200</width>
+          <height>0</height>
+         </size>
+        </property>
+        <property name="text">
+         <string>Select Function :</string>
+        </property>
        </widget>
       </item>
       <item row="2" column="1" colspan="2">
@@ -88,44 +100,6 @@ color: grey; }
         </item>
        </widget>
       </item>
-      <item row="2" column="0">
-       <widget class="QLabel" name="select_function_label">
-        <property name="minimumSize">
-         <size>
-          <width>200</width>
-          <height>0</height>
-         </size>
-        </property>
-        <property name="maximumSize">
-         <size>
-          <width>200</width>
-          <height>16777215</height>
-         </size>
-        </property>
-        <property name="text">
-         <string>Select Function :</string>
-        </property>
-       </widget>
-      </item>
-      <item row="3" column="0">
-       <widget class="QLabel" name="group_label">
-        <property name="minimumSize">
-         <size>
-          <width>200</width>
-          <height>0</height>
-         </size>
-        </property>
-        <property name="maximumSize">
-         <size>
-          <width>200</width>
-          <height>16777215</height>
-         </size>
-        </property>
-        <property name="text">
-         <string>Group :</string>
-        </property>
-       </widget>
-      </item>
       <item row="1" column="0">
        <widget class="QLabel" name="mode_label">
         <property name="minimumSize">
@@ -134,24 +108,9 @@ color: grey; }
           <height>0</height>
          </size>
         </property>
-        <property name="maximumSize">
-         <size>
-          <width>200</width>
-          <height>16777215</height>
-         </size>
-        </property>
         <property name="text">
          <string>Background :</string>
         </property>
-       </widget>
-      </item>
-      <item row="3" column="1">
-       <widget class="QComboBox" name="group_combo_box">
-        <item>
-         <property name="text">
-          <string>All</string>
-         </property>
-        </item>
        </widget>
       </item>
       <item row="3" column="2">
@@ -226,6 +185,42 @@ background-color: #c7e0ff;
          </property>
         </column>
        </widget>
+      </item>
+      <item row="1" column="1" colspan="2">
+       <widget class="QComboBox" name="mode_combo_box">
+        <item>
+         <property name="text">
+          <string>None</string>
+         </property>
+        </item>
+        <item>
+         <property name="text">
+          <string>Auto</string>
+         </property>
+        </item>
+       </widget>
+      </item>
+      <item row="3" column="1">
+       <widget class="QComboBox" name="group_combo_box">
+        <item>
+         <property name="text">
+          <string>All</string>
+         </property>
+        </item>
+       </widget>
+      </item>
+      <item row="6" column="1">
+       <spacer name="verticalSpacer">
+        <property name="orientation">
+         <enum>Qt::Vertical</enum>
+        </property>
+        <property name="sizeHint" stdset="0">
+         <size>
+          <width>20</width>
+          <height>40</height>
+         </size>
+        </property>
+       </spacer>
       </item>
      </layout>
     </widget>

--- a/scripts/Muon/GUI/Common/corrections_tab_widget/background_corrections_view.ui
+++ b/scripts/Muon/GUI/Common/corrections_tab_widget/background_corrections_view.ui
@@ -137,6 +137,9 @@ QTableWidget::item:hover {
 background-color: #c7e0ff;
 }</string>
         </property>
+        <property name="alternatingRowColors">
+         <bool>true</bool>
+        </property>
         <property name="selectionMode">
          <enum>QAbstractItemView::SingleSelection</enum>
         </property>

--- a/scripts/Muon/GUI/Common/corrections_tab_widget/corrections_presenter.py
+++ b/scripts/Muon/GUI/Common/corrections_tab_widget/corrections_presenter.py
@@ -31,7 +31,7 @@ class CorrectionsPresenter(QObject):
         self.dead_time_model = DeadTimeCorrectionsModel(model, context.data_context, context.corrections_context)
         self.dead_time_presenter = DeadTimeCorrectionsPresenter(self.view.dead_time_view, self.dead_time_model, self)
 
-        self.background_model = BackgroundCorrectionsModel(model, context, context.corrections_context)
+        self.background_model = BackgroundCorrectionsModel(model, context)
         self.background_presenter = BackgroundCorrectionsPresenter(self.view.background_view, self.background_model,
                                                                    self)
 
@@ -44,7 +44,7 @@ class CorrectionsPresenter(QObject):
         self.instrument_changed_observer = GenericObserver(self.handle_instrument_changed)
         self.load_observer = GenericObserver(self.handle_runs_loaded)
         self.group_change_observer = GenericObserver(self.handle_groups_changed)
-        self.corrections_complete_observer = GenericObserver(self.handle_corrections_complete)
+        self.pre_process_and_grouping_complete_observer = GenericObserver(self.handle_pre_process_and_grouping_complete)
 
         self.enable_editing_notifier = GenericObservable()
         self.disable_editing_notifier = GenericObservable()
@@ -85,8 +85,6 @@ class CorrectionsPresenter(QObject):
         else:
             self.view.enable_view()
 
-        self.background_presenter.handle_runs_loaded()
-
     def handle_groups_changed(self) -> None:
         """Handles when the selected groups have changed in the grouping tab."""
         self.background_presenter.handle_groups_changed()
@@ -97,9 +95,10 @@ class CorrectionsPresenter(QObject):
         self.dead_time_presenter.handle_run_selector_changed()
         self.background_presenter.handle_run_selector_changed()
 
-    def handle_corrections_complete(self) -> None:
-        """When the corrections have been calculated, update the displayed correction data."""
-        self.dead_time_presenter.handle_corrections_complete()
+    def handle_pre_process_and_grouping_complete(self) -> None:
+        """Handles when MuonPreProcess and grouping has been completed."""
+        self.dead_time_presenter.handle_pre_process_and_grouping_complete()
+        self.background_presenter.handle_pre_process_and_grouping_complete()
 
     def current_run_string(self) -> str:
         """Returns the currently selected run string."""

--- a/scripts/Muon/GUI/Common/corrections_tab_widget/corrections_presenter.py
+++ b/scripts/Muon/GUI/Common/corrections_tab_widget/corrections_presenter.py
@@ -85,6 +85,8 @@ class CorrectionsPresenter(QObject):
         else:
             self.view.enable_view()
 
+        self.background_presenter.handle_runs_loaded()
+
     def handle_groups_changed(self) -> None:
         """Handles when the selected groups have changed in the grouping tab."""
         self.background_presenter.handle_groups_changed()

--- a/scripts/Muon/GUI/Common/corrections_tab_widget/corrections_presenter.py
+++ b/scripts/Muon/GUI/Common/corrections_tab_widget/corrections_presenter.py
@@ -7,6 +7,8 @@
 from mantidqt.utils.observer_pattern import GenericObservable, GenericObserver, GenericObserverWithArgPassing
 
 from Muon.GUI.Common.contexts.muon_context import MuonContext
+from Muon.GUI.Common.corrections_tab_widget.background_corrections_model import BackgroundCorrectionsModel
+from Muon.GUI.Common.corrections_tab_widget.background_corrections_presenter import BackgroundCorrectionsPresenter
 from Muon.GUI.Common.corrections_tab_widget.corrections_model import CorrectionsModel
 from Muon.GUI.Common.corrections_tab_widget.corrections_view import CorrectionsView
 from Muon.GUI.Common.corrections_tab_widget.dead_time_corrections_model import DeadTimeCorrectionsModel
@@ -29,6 +31,10 @@ class CorrectionsPresenter(QObject):
         self.dead_time_model = DeadTimeCorrectionsModel(model, context.data_context, context.corrections_context)
         self.dead_time_presenter = DeadTimeCorrectionsPresenter(self.view.dead_time_view, self.dead_time_model, self)
 
+        self.background_model = BackgroundCorrectionsModel(model, context, context.corrections_context)
+        self.background_presenter = BackgroundCorrectionsPresenter(self.view.background_view, self.background_model,
+                                                                   self)
+
         self.initialize_model_options()
 
         self.view.set_slot_for_run_selector_changed(self.handle_run_selector_changed)
@@ -37,6 +43,7 @@ class CorrectionsPresenter(QObject):
             self.handle_ads_clear_or_remove_workspace_event)
         self.instrument_changed_observer = GenericObserver(self.handle_instrument_changed)
         self.load_observer = GenericObserver(self.handle_runs_loaded)
+        self.group_change_observer = GenericObserver(self.handle_groups_changed)
         self.corrections_complete_observer = GenericObserver(self.handle_corrections_complete)
 
         self.enable_editing_notifier = GenericObservable()
@@ -46,6 +53,7 @@ class CorrectionsPresenter(QObject):
     def initialize_model_options(self) -> None:
         """Initialise the model with the default fitting options."""
         self.dead_time_presenter.initialize_model_options()
+        self.background_presenter.initialize_model_options()
 
     def handle_ads_clear_or_remove_workspace_event(self, _: str = None) -> None:
         """Handle when there is a clear or remove workspace event in the ADS."""
@@ -60,6 +68,7 @@ class CorrectionsPresenter(QObject):
     def _handle_instrument_changed(self) -> None:
         """Handles when new run numbers are loaded from the GUI thread."""
         self.dead_time_presenter.handle_instrument_changed()
+        self.background_presenter.handle_instrument_changed()
 
     def handle_runs_loaded(self) -> None:
         """Handles when new run numbers are loaded. QMetaObject is required so its executed on the GUI thread."""
@@ -76,10 +85,15 @@ class CorrectionsPresenter(QObject):
         else:
             self.view.enable_view()
 
+    def handle_groups_changed(self) -> None:
+        """Handles when the selected groups have changed in the grouping tab."""
+        self.background_presenter.handle_groups_changed()
+
     def handle_run_selector_changed(self) -> None:
         """Handles when the run selector is changed."""
         self.model.set_current_run_string(self.view.current_run_string())
         self.dead_time_presenter.handle_run_selector_changed()
+        self.background_presenter.handle_run_selector_changed()
 
     def handle_corrections_complete(self) -> None:
         """When the corrections have been calculated, update the displayed correction data."""

--- a/scripts/Muon/GUI/Common/corrections_tab_widget/corrections_view.py
+++ b/scripts/Muon/GUI/Common/corrections_tab_widget/corrections_view.py
@@ -7,6 +7,7 @@
 from mantidqt.utils.observer_pattern import GenericObserver
 from mantidqt.utils.qt import load_ui
 
+from Muon.GUI.Common.corrections_tab_widget.background_corrections_view import BackgroundCorrectionsView
 from Muon.GUI.Common.corrections_tab_widget.dead_time_corrections_view import DeadTimeCorrectionsView
 from Muon.GUI.Common.data_selectors.cyclic_data_selector_view import CyclicDataSelectorView
 from Muon.GUI.Common.message_box import warning
@@ -34,6 +35,9 @@ class CorrectionsView(widget, ui_form):
         self.dead_time_corrections_view = DeadTimeCorrectionsView(self)
         self.dead_time_layout.addWidget(self.dead_time_corrections_view)
 
+        self.background_corrections_view = BackgroundCorrectionsView(self)
+        self.background_layout.addWidget(self.background_corrections_view)
+
         self.disable_tab_observer = GenericObserver(self.disable_view)
         self.enable_tab_observer = GenericObserver(self.enable_view)
 
@@ -43,6 +47,11 @@ class CorrectionsView(widget, ui_form):
     def dead_time_view(self) -> DeadTimeCorrectionsView:
         """Returns the dead time corrections view."""
         return self.dead_time_corrections_view
+
+    @property
+    def background_view(self) -> BackgroundCorrectionsView:
+        """Returns the background corrections view."""
+        return self.background_corrections_view
 
     def set_slot_for_run_selector_changed(self, slot) -> None:
         """Connect the slot for the Run Selector combobox"""

--- a/scripts/Muon/GUI/Common/corrections_tab_widget/corrections_view.ui
+++ b/scripts/Muon/GUI/Common/corrections_tab_widget/corrections_view.ui
@@ -23,19 +23,6 @@
    <item>
     <layout class="QGridLayout" name="background_layout"/>
    </item>
-   <item>
-    <spacer name="verticalSpacer">
-     <property name="orientation">
-      <enum>Qt::Vertical</enum>
-     </property>
-     <property name="sizeHint" stdset="0">
-      <size>
-       <width>20</width>
-       <height>40</height>
-      </size>
-     </property>
-    </spacer>
-   </item>
   </layout>
  </widget>
  <resources/>

--- a/scripts/Muon/GUI/Common/corrections_tab_widget/dead_time_corrections_presenter.py
+++ b/scripts/Muon/GUI/Common/corrections_tab_widget/dead_time_corrections_presenter.py
@@ -106,8 +106,8 @@ class DeadTimeCorrectionsPresenter:
                 else:
                     self._corrections_presenter.warning_popup(error)
 
-    def handle_corrections_complete(self) -> None:
-        """When the corrections have been calculated, update the displayed dead time averages."""
+    def handle_pre_process_and_grouping_complete(self) -> None:
+        """Handles when MuonPreProcess and grouping has been completed."""
         self.update_dead_time_info_text_in_view()
 
     def update_dead_time_info_text_in_view(self) -> None:

--- a/scripts/Muon/GUI/Common/corrections_tab_widget/dead_time_corrections_view.ui
+++ b/scripts/Muon/GUI/Common/corrections_tab_widget/dead_time_corrections_view.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>475</width>
-    <height>140</height>
+    <height>157</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -39,7 +39,7 @@ color: grey; }
      </property>
      <layout class="QGridLayout" name="gridLayout_2">
       <property name="topMargin">
-       <number>14</number>
+       <number>20</number>
       </property>
       <item row="2" column="0">
        <widget class="QLabel" name="dead_time_workspace_label">
@@ -47,12 +47,6 @@ color: grey; }
          <size>
           <width>200</width>
           <height>0</height>
-         </size>
-        </property>
-        <property name="maximumSize">
-         <size>
-          <width>200</width>
-          <height>16777215</height>
          </size>
         </property>
         <property name="text">
@@ -68,12 +62,6 @@ color: grey; }
           <height>0</height>
          </size>
         </property>
-        <property name="maximumSize">
-         <size>
-          <width>200</width>
-          <height>16777215</height>
-         </size>
-        </property>
         <property name="text">
          <string>Other file :</string>
         </property>
@@ -85,12 +73,6 @@ color: grey; }
          <size>
           <width>200</width>
           <height>0</height>
-         </size>
-        </property>
-        <property name="maximumSize">
-         <size>
-          <width>200</width>
-          <height>16777215</height>
          </size>
         </property>
         <property name="text">

--- a/scripts/Muon/GUI/Common/fitting_widgets/basic_fitting/basic_fitting_model.py
+++ b/scripts/Muon/GUI/Common/fitting_widgets/basic_fitting/basic_fitting_model.py
@@ -526,11 +526,6 @@ class BasicFittingModel:
         """Returns only the workspace names that exist in the ADS."""
         return [workspace_name for workspace_name in workspace_names if check_if_workspace_exist(workspace_name)]
 
-    @staticmethod
-    def is_equal_to_n_decimals(value1: float, value2: float, n_decimals: int) -> bool:
-        """Checks that two floats are equal up to n decimal places."""
-        return f"{value1:.{n_decimals}f}" == f"{value2:.{n_decimals}f}"
-
     def get_selected_runs_groups_and_pairs(self) -> tuple:
         """Returns the runs, groups and pairs to use for single fit mode."""
         return "All", self._get_selected_groups_and_pairs()

--- a/scripts/Muon/GUI/Common/fitting_widgets/basic_fitting/basic_fitting_model.py
+++ b/scripts/Muon/GUI/Common/fitting_widgets/basic_fitting/basic_fitting_model.py
@@ -16,6 +16,7 @@ from Muon.GUI.Common.contexts.fitting_contexts.basic_fitting_context import Basi
 from Muon.GUI.Common.contexts.fitting_contexts.fitting_context import FitInformation
 from Muon.GUI.Common.contexts.muon_context import MuonContext
 from Muon.GUI.Common.utilities.algorithm_utils import run_Fit
+from Muon.GUI.Common.utilities.workspace_data_utils import x_limits_of_workspace
 from Muon.GUI.Common.utilities.workspace_utils import StaticWorkspaceWrapper
 
 import math
@@ -26,7 +27,6 @@ DEFAULT_CHI_SQUARED = 0.0
 DEFAULT_FIT_STATUS = None
 DEFAULT_SINGLE_FIT_FUNCTION = None
 DEFAULT_START_X = 0.0
-X_OFFSET = 0.001
 
 
 def get_function_name_for_composite(composite: CompositeFunction) -> str:
@@ -376,15 +376,7 @@ class BasicFittingModel:
 
     def x_limits_of_workspace(self, workspace_name: str) -> tuple:
         """Returns the x data limits of a provided workspace or the current dataset."""
-        if workspace_name is not None and check_if_workspace_exist(workspace_name):
-            x_data = retrieve_ws(workspace_name).dataX(0)
-            if len(x_data) > 0:
-                x_data.sort()
-                x_lower, x_higher = x_data[0], x_data[-1]
-                if x_lower == x_higher:
-                    return x_lower - X_OFFSET, x_higher + X_OFFSET
-                return x_lower, x_higher
-        return self.current_start_x, self.current_end_x
+        return x_limits_of_workspace(workspace_name, (self.current_start_x, self.current_end_x))
 
     def update_plot_guess(self) -> None:
         """Updates the guess plot using the current dataset and function."""

--- a/scripts/Muon/GUI/Common/fitting_widgets/model_fitting/model_fitting_model.py
+++ b/scripts/Muon/GUI/Common/fitting_widgets/model_fitting/model_fitting_model.py
@@ -14,6 +14,7 @@ from Muon.GUI.Common.ADSHandler.workspace_naming import (create_model_fitting_pa
 from Muon.GUI.Common.contexts.fitting_contexts.model_fitting_context import ModelFittingContext
 from Muon.GUI.Common.contexts.muon_context import MuonContext
 from Muon.GUI.Common.fitting_widgets.basic_fitting.basic_fitting_model import BasicFittingModel
+from Muon.GUI.Common.utilities.workspace_data_utils import is_equal_to_n_decimals
 
 
 class ModelFittingModel(BasicFittingModel):
@@ -195,11 +196,12 @@ class ModelFittingModel(BasicFittingModel):
                    and self._lists_are_equal(workspace.dataE(0), y_errors)
         return False
 
-    def _lists_are_equal(self, list1: list, list2: list) -> bool:
+    @staticmethod
+    def _lists_are_equal(list1: list, list2: list) -> bool:
         """Returns true if the two lists containing x, y or error data are equal to five decimal places."""
         if len(list1) != len(list2):
             return False
-        return all([self.is_equal_to_n_decimals(i, j, 5) for i, j in zip(list1, list2)])
+        return all([is_equal_to_n_decimals(i, j, 5) for i, j in zip(list1, list2)])
 
     @staticmethod
     def _convert_str_column_values_to_int(parameter_name: str, parameter_values: list) -> list:

--- a/scripts/Muon/GUI/Common/muon_group.py
+++ b/scripts/Muon/GUI/Common/muon_group.py
@@ -51,10 +51,13 @@ class MuonGroup(object):
     if the workspace does not exist will raise a KeyError
     """
     def get_counts_workspace_for_run(self, run, rebin):
-        if rebin:
+        muon_run = MuonRun(run)
+        if rebin and muon_run in self._counts_workspace_rebin:
             return self._counts_workspace_rebin[MuonRun(run)].workspace_name
-        else:
+        elif muon_run in self._counts_workspace:
             return self._counts_workspace[MuonRun(run)].workspace_name
+        else:
+            return None
 
     def get_asymmetry_workspace_for_run(self, run, rebin):
         if rebin:

--- a/scripts/Muon/GUI/Common/muon_group.py
+++ b/scripts/Muon/GUI/Common/muon_group.py
@@ -51,13 +51,10 @@ class MuonGroup(object):
     if the workspace does not exist will raise a KeyError
     """
     def get_counts_workspace_for_run(self, run, rebin):
-        muon_run = MuonRun(run)
-        if rebin and muon_run in self._counts_workspace_rebin:
+        if rebin:
             return self._counts_workspace_rebin[MuonRun(run)].workspace_name
-        elif muon_run in self._counts_workspace:
-            return self._counts_workspace[MuonRun(run)].workspace_name
         else:
-            return None
+            return self._counts_workspace[MuonRun(run)].workspace_name
 
     def get_asymmetry_workspace_for_run(self, run, rebin):
         if rebin:

--- a/scripts/Muon/GUI/Common/utilities/workspace_data_utils.py
+++ b/scripts/Muon/GUI/Common/utilities/workspace_data_utils.py
@@ -6,10 +6,12 @@
 # SPDX - License - Identifier: GPL - 3.0 +
 from Muon.GUI.Common.ADSHandler.ADS_calls import check_if_workspace_exist, retrieve_ws
 
+DEFAULT_X_LOWER = 0.0
+DEFAULT_X_UPPER = 100.0
 X_OFFSET = 0.001
 
 
-def x_limits_of_workspace(workspace_name: str, default_limits: tuple) -> tuple:
+def x_limits_of_workspace(workspace_name: str, default_limits: tuple = (DEFAULT_X_LOWER, DEFAULT_X_UPPER)) -> tuple:
     """Returns the x data limits of a provided workspace."""
     if workspace_name is not None and check_if_workspace_exist(workspace_name):
         x_data = retrieve_ws(workspace_name).dataX(0)
@@ -20,3 +22,48 @@ def x_limits_of_workspace(workspace_name: str, default_limits: tuple) -> tuple:
                 return x_lower - X_OFFSET, x_higher + X_OFFSET
             return x_lower, x_higher
     return default_limits
+
+
+def is_equal_to_n_decimals(value1: float, value2: float, n_decimals: int) -> bool:
+    """Checks that two floats are equal up to n decimal places."""
+    return f"{value1:.{n_decimals}f}" == f"{value2:.{n_decimals}f}"
+
+
+def check_start_x_is_valid(workspace_name: str, view_start_x: float, view_end_x: float, model_start_x: float) -> tuple:
+    """Checks that the new start X is valid. If it isn't, the start and end X is adjusted."""
+    x_lower, x_upper = x_limits_of_workspace(workspace_name)
+    if view_start_x < x_lower:
+        new_start_x, new_end_x = x_lower, view_end_x
+    elif view_start_x > x_upper:
+        if not is_equal_to_n_decimals(view_end_x, x_upper, 3):
+            new_start_x, new_end_x = view_end_x, x_upper
+        else:
+            new_start_x, new_end_x = model_start_x, view_end_x
+    elif view_start_x > view_end_x:
+        new_start_x, new_end_x = view_end_x, view_start_x
+    elif view_start_x == view_end_x:
+        new_start_x, new_end_x = model_start_x, view_end_x
+    else:
+        new_start_x, new_end_x = view_start_x, view_end_x
+
+    return new_start_x, new_end_x
+
+
+def check_end_x_is_valid(workspace_name: str, view_start_x: float, view_end_x: float, model_end_x: float) -> tuple:
+    """Checks that the new end X is valid. If it isn't, the start and end X is adjusted."""
+    x_lower, x_upper = x_limits_of_workspace(workspace_name)
+    if view_end_x < x_lower:
+        if not is_equal_to_n_decimals(view_start_x, x_lower, 3):
+            new_start_x, new_end_x = x_lower, view_start_x
+        else:
+            new_start_x, new_end_x = view_start_x, model_end_x
+    elif view_end_x > x_upper:
+        new_start_x, new_end_x = view_start_x, x_upper
+    elif view_end_x < view_start_x:
+        new_start_x, new_end_x = view_end_x, view_start_x
+    elif view_end_x == view_start_x:
+        new_start_x, new_end_x = view_start_x, model_end_x
+    else:
+        new_start_x, new_end_x = view_start_x, view_end_x
+
+    return new_start_x, new_end_x

--- a/scripts/Muon/GUI/Common/utilities/workspace_data_utils.py
+++ b/scripts/Muon/GUI/Common/utilities/workspace_data_utils.py
@@ -1,0 +1,22 @@
+# Mantid Repository : https://github.com/mantidproject/mantid
+#
+# Copyright &copy; 2021 ISIS Rutherford Appleton Laboratory UKRI,
+#   NScD Oak Ridge National Laboratory, European Spallation Source,
+#   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+# SPDX - License - Identifier: GPL - 3.0 +
+from Muon.GUI.Common.ADSHandler.ADS_calls import check_if_workspace_exist, retrieve_ws
+
+X_OFFSET = 0.001
+
+
+def x_limits_of_workspace(workspace_name: str, default_limits: tuple) -> tuple:
+    """Returns the x data limits of a provided workspace."""
+    if workspace_name is not None and check_if_workspace_exist(workspace_name):
+        x_data = retrieve_ws(workspace_name).dataX(0)
+        if len(x_data) > 0:
+            x_data.sort()
+            x_lower, x_higher = x_data[0], x_data[-1]
+            if x_lower == x_higher:
+                return x_lower - X_OFFSET, x_higher + X_OFFSET
+            return x_lower, x_higher
+    return default_limits

--- a/scripts/Muon/GUI/FrequencyDomainAnalysis/frequency_domain_analysis.py
+++ b/scripts/Muon/GUI/FrequencyDomainAnalysis/frequency_domain_analysis.py
@@ -393,7 +393,7 @@ class FrequencyAnalysisGui(QtWidgets.QMainWindow):
             self.phase_tab.phase_table_presenter.calculation_finished_notifier.add_subscriber(observer)
 
         self.grouping_tab_widget.group_tab_presenter.calculation_finished_notifier.add_subscriber(
-            self.corrections_tab.corrections_tab_presenter.corrections_complete_observer)
+            self.corrections_tab.corrections_tab_presenter.pre_process_and_grouping_complete_observer)
 
     def setup_phase_quad_changed_notifier(self):
         self.phase_tab.phase_table_presenter.phasequad_calculation_complete_notifier.add_subscriber(

--- a/scripts/Muon/GUI/MuonAnalysis/muon_analysis_2.py
+++ b/scripts/Muon/GUI/MuonAnalysis/muon_analysis_2.py
@@ -438,7 +438,7 @@ class MuonAnalysisGui(QtWidgets.QMainWindow):
 
     def setup_on_recalulation_finished_notifier(self):
         self.grouping_tab_widget.group_tab_presenter.calculation_finished_notifier.add_subscriber(
-            self.corrections_tab.corrections_tab_presenter.corrections_complete_observer)
+            self.corrections_tab.corrections_tab_presenter.pre_process_and_grouping_complete_observer)
 
         self.grouping_tab_widget.group_tab_presenter.calculation_finished_notifier.add_subscriber(
             self.fitting_tab.fitting_tab_presenter.input_workspace_observer)

--- a/scripts/Muon/GUI/MuonAnalysis/muon_analysis_2.py
+++ b/scripts/Muon/GUI/MuonAnalysis/muon_analysis_2.py
@@ -354,6 +354,9 @@ class MuonAnalysisGui(QtWidgets.QMainWindow):
             self.home_tab.home_tab_widget.groupingObserver)
 
         self.grouping_tab_widget.group_tab_presenter.groupingNotifier.add_subscriber(
+            self.corrections_tab.corrections_tab_presenter.group_change_observer)
+
+        self.grouping_tab_widget.group_tab_presenter.groupingNotifier.add_subscriber(
             self.phase_tab.phase_table_presenter.group_change_observer)
 
     def setup_corrections_changed_observers(self):

--- a/scripts/test/Muon/CMakeLists.txt
+++ b/scripts/test/Muon/CMakeLists.txt
@@ -6,6 +6,7 @@ set ( TEST_PY_FILES
    base_pane/base_pane_presenter_test.py
    basic_fitting_context_test.py
    corrections_context_test.py
+   corrections_tab_widget/background_corrections_model_test.py
    corrections_tab_widget/background_corrections_view_test.py
    corrections_tab_widget/corrections_model_test.py
    corrections_tab_widget/corrections_presenter_test.py

--- a/scripts/test/Muon/CMakeLists.txt
+++ b/scripts/test/Muon/CMakeLists.txt
@@ -6,6 +6,7 @@ set ( TEST_PY_FILES
    base_pane/base_pane_presenter_test.py
    basic_fitting_context_test.py
    corrections_context_test.py
+   corrections_tab_widget/background_corrections_view_test.py
    corrections_tab_widget/corrections_model_test.py
    corrections_tab_widget/corrections_presenter_test.py
    corrections_tab_widget/corrections_view_test.py

--- a/scripts/test/Muon/CMakeLists.txt
+++ b/scripts/test/Muon/CMakeLists.txt
@@ -7,6 +7,7 @@ set ( TEST_PY_FILES
    basic_fitting_context_test.py
    corrections_context_test.py
    corrections_tab_widget/background_corrections_model_test.py
+   corrections_tab_widget/background_corrections_presenter_test.py
    corrections_tab_widget/background_corrections_view_test.py
    corrections_tab_widget/corrections_model_test.py
    corrections_tab_widget/corrections_presenter_test.py

--- a/scripts/test/Muon/corrections_context_test.py
+++ b/scripts/test/Muon/corrections_context_test.py
@@ -19,7 +19,7 @@ class CorrectionsContextTest(unittest.TestCase):
 
     def test_that_the_context_has_been_instantiated_with_the_expected_context_data(self):
         self.assertEqual(self.corrections_context.current_run_string, None)
-        self.assertEqual(self.corrections_context.dead_time_source, None)
+        self.assertEqual(self.corrections_context.dead_time_source, "FromFile")
         self.assertEqual(self.corrections_context.dead_time_table_name_from_ads, None)
 
     def test_that_the_current_run_string_can_be_set_as_expected(self):

--- a/scripts/test/Muon/corrections_context_test.py
+++ b/scripts/test/Muon/corrections_context_test.py
@@ -8,6 +8,7 @@ import unittest
 from unittest import mock
 
 from Muon.GUI.Common.contexts.corrections_context import CorrectionsContext
+from Muon.GUI.Common.corrections_tab_widget.background_corrections_model import BackgroundCorrectionData
 from Muon.GUI.Common.muon_load_data import MuonLoadData
 
 
@@ -19,8 +20,14 @@ class CorrectionsContextTest(unittest.TestCase):
 
     def test_that_the_context_has_been_instantiated_with_the_expected_context_data(self):
         self.assertEqual(self.corrections_context.current_run_string, None)
+
         self.assertEqual(self.corrections_context.dead_time_source, "FromFile")
         self.assertEqual(self.corrections_context.dead_time_table_name_from_ads, None)
+
+        self.assertEqual(self.corrections_context.background_corrections_mode, "None")
+        self.assertEqual(self.corrections_context.selected_function, "Flat Background")
+        self.assertEqual(self.corrections_context.selected_group, "All")
+        self.assertEqual(self.corrections_context.show_all_runs, False)
 
     def test_that_the_current_run_string_can_be_set_as_expected(self):
         run_string = "62260"
@@ -69,6 +76,34 @@ class CorrectionsContextTest(unittest.TestCase):
         self.corrections_context.dead_time_table_name_from_ads = table_from_ads
 
         self.assertEqual(self.corrections_context.current_dead_time_table_name_for_run("MUSR", [62265]), None)
+
+    def test_that_the_background_corrections_mode_can_be_set_as_expected(self):
+        background_corrections_mode = "Auto"
+        self.corrections_context.background_corrections_mode = background_corrections_mode
+        self.assertEqual(self.corrections_context.background_corrections_mode, background_corrections_mode)
+
+    def test_that_the_selected_function_can_be_set_as_expected(self):
+        selected_function = "Flat Background + Exp Decay"
+        self.corrections_context.selected_function = selected_function
+        self.assertEqual(self.corrections_context.selected_function, selected_function)
+
+    def test_that_the_selected_group_can_be_set_as_expected(self):
+        selected_group = "fwd"
+        self.corrections_context.selected_group = selected_group
+        self.assertEqual(self.corrections_context.selected_group, selected_group)
+
+    def test_that_show_all_runs_can_be_set_as_expected(self):
+        show_all_runs = True
+        self.corrections_context.show_all_runs = show_all_runs
+        self.assertEqual(self.corrections_context.show_all_runs, show_all_runs)
+
+    def test_that_the_background_correction_data_can_be_set_as_expected(self):
+        run_group = tuple(["84447", "fwd"])
+        self.corrections_context.background_correction_data[run_group] = BackgroundCorrectionData()
+
+        self.assertTrue(run_group in self.corrections_context.background_correction_data)
+        self.assertEqual(self.corrections_context.background_correction_data[run_group].start_x, 5.0)
+        self.assertEqual(self.corrections_context.background_correction_data[run_group].end_x, 15.0)
 
 
 if __name__ == '__main__':

--- a/scripts/test/Muon/corrections_context_test.py
+++ b/scripts/test/Muon/corrections_context_test.py
@@ -99,11 +99,12 @@ class CorrectionsContextTest(unittest.TestCase):
 
     def test_that_the_background_correction_data_can_be_set_as_expected(self):
         run_group = tuple(["84447", "fwd"])
-        self.corrections_context.background_correction_data[run_group] = BackgroundCorrectionData()
+        start_x, end_x = 15.0, 30.0
+        self.corrections_context.background_correction_data[run_group] = BackgroundCorrectionData(start_x, end_x)
 
         self.assertTrue(run_group in self.corrections_context.background_correction_data)
-        self.assertEqual(self.corrections_context.background_correction_data[run_group].start_x, 5.0)
-        self.assertEqual(self.corrections_context.background_correction_data[run_group].end_x, 15.0)
+        self.assertEqual(self.corrections_context.background_correction_data[run_group].start_x, start_x)
+        self.assertEqual(self.corrections_context.background_correction_data[run_group].end_x, end_x)
 
 
 if __name__ == '__main__':

--- a/scripts/test/Muon/corrections_tab_widget/background_corrections_model_test.py
+++ b/scripts/test/Muon/corrections_tab_widget/background_corrections_model_test.py
@@ -1,0 +1,182 @@
+# Mantid Repository : https://github.com/mantidproject/mantid
+#
+# Copyright &copy; 2021 ISIS Rutherford Appleton Laboratory UKRI,
+#   NScD Oak Ridge National Laboratory, European Spallation Source,
+#   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+# SPDX - License - Identifier: GPL - 3.0 +
+import unittest
+from unittest import mock
+
+from mantid.api import AnalysisDataService, FrameworkManager
+from mantid.simpleapi import CreateSampleWorkspace
+
+from Muon.GUI.Common.corrections_tab_widget.corrections_model import CorrectionsModel
+from Muon.GUI.Common.corrections_tab_widget.background_corrections_model import (BackgroundCorrectionsModel,
+                                                                                 DEFAULT_START_X, DEFAULT_END_X,
+                                                                                 DEFAULT_X_LOWER, DEFAULT_X_UPPER)
+from Muon.GUI.Common.test_helpers.context_setup import setup_context
+
+
+class BackgroundCorrectionsModelTest(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        FrameworkManager.Instance()
+
+    def setUp(self):
+        context = setup_context()
+        self.corrections_model = CorrectionsModel(context.data_context, context.corrections_context)
+        self.model = BackgroundCorrectionsModel(self.corrections_model, context, context.corrections_context)
+
+        self.runs = ["84447", "84447", "84447", "84447"]
+        self.groups = ["fwd", "bwd", "top", "bottom"]
+        self.start_xs = [DEFAULT_START_X] * 4
+        self.end_xs = [DEFAULT_END_X] * 4
+        self.a0s = [0.0] * 4
+        self.a0_errors = [0.0] * 4
+
+    def tearDown(self):
+        self.model = None
+        AnalysisDataService.clear()
+
+    def test_that_the_model_and_context_has_been_initialized_with_the_expected_data(self):
+        self.assertTrue(self.model.is_background_mode_none())
+        self.assertEqual(self.model._corrections_context.selected_function, "Flat Background")
+        self.assertEqual(self.model._corrections_context.selected_group, "All")
+        self.assertEqual(self.model._corrections_context.background_correction_data, {})
+        self.assertEqual(self.model._corrections_context.show_all_runs, False)
+
+    def test_that_set_background_correction_mode_will_set_the_background_mode_as_expected(self):
+        self.model.set_background_correction_mode("Auto")
+        self.assertTrue(not self.model.is_background_mode_none())
+
+    def test_that_set_selected_function_will_set_the_selected_function_in_the_context(self):
+        function = "Flat Background + Exp Decay"
+
+        self.model.set_selected_function(function)
+
+        self.assertEqual(self.model._corrections_context.selected_function, function)
+
+    def test_that_set_selected_group_will_set_the_selected_group_in_the_context(self):
+        group = "fwd"
+
+        self.model.set_selected_group(group)
+
+        self.assertEqual(self.model._corrections_context.selected_group, group)
+
+    def test_that_set_show_all_runs_will_set_show_all_runs_to_true(self):
+        show_all_runs = True
+
+        self.model.set_show_all_runs(show_all_runs)
+
+        self.assertEqual(self.model._corrections_context.show_all_runs, show_all_runs)
+
+    def test_that_is_equal_to_n_decimals_will_return_false_if_the_two_numbers_are_not_equal_to_the_given_dp(self):
+        value1, value2 = 1.001, 1.0015
+        self.assertTrue(not self.model.is_equal_to_n_decimals(value1, value2, 3))
+
+    def test_that_is_equal_to_n_decimals_will_return_true_if_the_two_numbers_are_equal_to_the_given_dp(self):
+        value1, value2 = 1.001, 1.0014
+        self.assertTrue(self.model.is_equal_to_n_decimals(value1, value2, 3))
+
+    def test_that_populate_background_corrections_data_will_populate_default_background_correction_data(self):
+        self._populate_background_corrections_data()
+
+        for run, group in zip(self.runs, self.groups):
+            correction_data = self.model._corrections_context.background_correction_data[tuple([run, group])]
+            self.assertEqual(correction_data.start_x, DEFAULT_START_X)
+            self.assertEqual(correction_data.end_x, DEFAULT_END_X)
+            self.assertEqual(correction_data.flat_background.getParameterValue("A0"), 0.0)
+            self.assertEqual(correction_data.flat_background.getError("A0"), 0.0)
+
+    def test_that_set_start_x_will_set_the_start_x_in_the_background_correction_data_for_a_specific_domain(self):
+        run = "84447"
+
+        self._populate_background_corrections_data()
+
+        self.model.set_start_x(run, "fwd", 5.0)
+        self.model.set_start_x(run, "bwd", 6.0)
+        self.model.set_start_x(run, "top", 7.0)
+        self.model.set_start_x(run, "bottom", 8.0)
+
+        self.assertEqual(self.model.start_x(run, "fwd"), 5.0)
+        self.assertEqual(self.model.start_x(run, "bwd"), 6.0)
+        self.assertEqual(self.model.start_x(run, "top"), 7.0)
+        self.assertEqual(self.model.start_x(run, "bottom"), 8.0)
+
+    def test_that_set_end_x_will_set_the_end_x_in_the_background_correction_data_for_a_specific_domain(self):
+        run = "84447"
+
+        self._populate_background_corrections_data()
+
+        self.model.set_end_x(run, "fwd", 5.0)
+        self.model.set_end_x(run, "bwd", 6.0)
+        self.model.set_end_x(run, "top", 7.0)
+        self.model.set_end_x(run, "bottom", 8.0)
+
+        self.assertEqual(self.model.end_x(run, "fwd"), 5.0)
+        self.assertEqual(self.model.end_x(run, "bwd"), 6.0)
+        self.assertEqual(self.model.end_x(run, "top"), 7.0)
+        self.assertEqual(self.model.end_x(run, "bottom"), 8.0)
+
+    def test_that_selected_correction_data_returns_all_correction_data_if_all_runs_and_groups_are_selected(self):
+        self.model.set_show_all_runs(True)
+
+        self._populate_background_corrections_data()
+        runs, groups, start_xs, end_xs, a0s, a0_errors = self.model.selected_correction_data()
+
+        self.assertEqual(runs, self.runs)
+        self.assertEqual(groups, self.groups)
+        self.assertEqual(start_xs, self.start_xs)
+        self.assertEqual(end_xs, self.end_xs)
+        self.assertEqual(a0s, self.a0s)
+        self.assertEqual(a0_errors, self.a0_errors)
+
+    def test_that_selected_correction_data_returns_all_correction_data_for_a_specific_run_and_group(self):
+        run = "84447"
+        group = "bwd"
+        self.model.set_selected_group(group)
+        self.corrections_model.set_current_run_string(run)
+
+        self._populate_background_corrections_data()
+        runs, groups, start_xs, end_xs, a0s, a0_errors = self.model.selected_correction_data()
+
+        self.assertEqual(runs, [run])
+        self.assertEqual(groups, [group])
+        self.assertEqual(start_xs, [5.0])
+        self.assertEqual(end_xs, [15.0])
+        self.assertEqual(a0s, [0.0])
+        self.assertEqual(a0_errors, [0.0])
+
+    def test_that_x_limits_of_workspace_will_return_the_x_limits_of_the_workspace(self):
+        run, group = "84447", "top"
+        workspace_name = f"HIFI{run}; Group; {group}; Counts; MA"
+        self.model._get_counts_workspace_name = mock.Mock(return_value=workspace_name)
+
+        CreateSampleWorkspace(OutputWorkspace=workspace_name)
+
+        x_lower, x_upper = self.model.x_limits_of_workspace(run, group)
+
+        self.assertEqual(x_lower, 0.0)
+        self.assertEqual(x_upper, 20000.0)
+
+    def test_that_x_limits_of_workspace_will_return_the_default_x_values_if_there_are_no_workspaces_loaded(self):
+        run, group = "84447", "top"
+        workspace_name = f"HIFI{run}; Group; {group}; Counts; MA"
+        self.model._get_counts_workspace_name = mock.Mock(return_value=workspace_name)
+
+        x_lower, x_upper = self.model.x_limits_of_workspace(run, group)
+
+        self.assertEqual(x_lower, DEFAULT_X_LOWER)
+        self.assertEqual(x_upper, DEFAULT_X_UPPER)
+
+    def _populate_background_corrections_data(self):
+        self.corrections_model.run_number_strings = mock.Mock(return_value=self.runs)
+        self.mock_group_names = mock.PropertyMock(return_value=self.groups)
+        type(self.model._context.group_pair_context).group_names = self.mock_group_names
+
+        self.model.populate_background_corrections_data()
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/scripts/test/Muon/corrections_tab_widget/background_corrections_model_test.py
+++ b/scripts/test/Muon/corrections_tab_widget/background_corrections_model_test.py
@@ -12,7 +12,6 @@ from mantid.simpleapi import CreateSampleWorkspace
 
 from Muon.GUI.Common.corrections_tab_widget.corrections_model import CorrectionsModel
 from Muon.GUI.Common.corrections_tab_widget.background_corrections_model import (BackgroundCorrectionsModel,
-                                                                                 DEFAULT_START_X, DEFAULT_END_X,
                                                                                  DEFAULT_X_LOWER, DEFAULT_X_UPPER)
 from Muon.GUI.Common.test_helpers.context_setup import setup_context
 
@@ -26,12 +25,13 @@ class BackgroundCorrectionsModelTest(unittest.TestCase):
     def setUp(self):
         context = setup_context()
         self.corrections_model = CorrectionsModel(context.data_context, context.corrections_context)
-        self.model = BackgroundCorrectionsModel(self.corrections_model, context, context.corrections_context)
+        self.model = BackgroundCorrectionsModel(self.corrections_model, context)
+        self.model.clear_background_corrections_data()
 
         self.runs = ["84447", "84447", "84447", "84447"]
         self.groups = ["fwd", "bwd", "top", "bottom"]
-        self.start_xs = [DEFAULT_START_X] * 4
-        self.end_xs = [DEFAULT_END_X] * 4
+        self.start_xs = [15.0] * 4
+        self.end_xs = [30.0] * 4
         self.a0s = [0.0] * 4
         self.a0_errors = [0.0] * 4
 
@@ -43,7 +43,6 @@ class BackgroundCorrectionsModelTest(unittest.TestCase):
         self.assertTrue(self.model.is_background_mode_none())
         self.assertEqual(self.model._corrections_context.selected_function, "Flat Background")
         self.assertEqual(self.model._corrections_context.selected_group, "All")
-        self.assertEqual(self.model._corrections_context.background_correction_data, {})
         self.assertEqual(self.model._corrections_context.show_all_runs, False)
 
     def test_that_set_background_correction_mode_will_set_the_background_mode_as_expected(self):
@@ -80,12 +79,13 @@ class BackgroundCorrectionsModelTest(unittest.TestCase):
         self.assertTrue(self.model.is_equal_to_n_decimals(value1, value2, 3))
 
     def test_that_populate_background_corrections_data_will_populate_default_background_correction_data(self):
+        self.model.x_limits_of_workspace = mock.Mock(return_value=(0.0, 30.0))
         self._populate_background_corrections_data()
 
         for run, group in zip(self.runs, self.groups):
             correction_data = self.model._corrections_context.background_correction_data[tuple([run, group])]
-            self.assertEqual(correction_data.start_x, DEFAULT_START_X)
-            self.assertEqual(correction_data.end_x, DEFAULT_END_X)
+            self.assertEqual(correction_data.start_x, 15.0)
+            self.assertEqual(correction_data.end_x, 30.0)
             self.assertEqual(correction_data.flat_background.getParameterValue("A0"), 0.0)
             self.assertEqual(correction_data.flat_background.getError("A0"), 0.0)
 
@@ -120,6 +120,7 @@ class BackgroundCorrectionsModelTest(unittest.TestCase):
         self.assertEqual(self.model.end_x(run, "bottom"), 8.0)
 
     def test_that_selected_correction_data_returns_all_correction_data_if_all_runs_and_groups_are_selected(self):
+        self.model.x_limits_of_workspace = mock.Mock(return_value=(0.0, 30.0))
         self.model.set_show_all_runs(True)
 
         self._populate_background_corrections_data()
@@ -135,6 +136,7 @@ class BackgroundCorrectionsModelTest(unittest.TestCase):
     def test_that_selected_correction_data_returns_all_correction_data_for_a_specific_run_and_group(self):
         run = "84447"
         group = "bwd"
+        self.model.x_limits_of_workspace = mock.Mock(return_value=(0.0, 30.0))
         self.model.set_selected_group(group)
         self.corrections_model.set_current_run_string(run)
 
@@ -143,8 +145,8 @@ class BackgroundCorrectionsModelTest(unittest.TestCase):
 
         self.assertEqual(runs, [run])
         self.assertEqual(groups, [group])
-        self.assertEqual(start_xs, [5.0])
-        self.assertEqual(end_xs, [15.0])
+        self.assertEqual(start_xs, [15.0])
+        self.assertEqual(end_xs, [30.0])
         self.assertEqual(a0s, [0.0])
         self.assertEqual(a0_errors, [0.0])
 

--- a/scripts/test/Muon/corrections_tab_widget/background_corrections_model_test.py
+++ b/scripts/test/Muon/corrections_tab_widget/background_corrections_model_test.py
@@ -11,9 +11,9 @@ from mantid.api import AnalysisDataService, FrameworkManager
 from mantid.simpleapi import CreateSampleWorkspace
 
 from Muon.GUI.Common.corrections_tab_widget.corrections_model import CorrectionsModel
-from Muon.GUI.Common.corrections_tab_widget.background_corrections_model import (BackgroundCorrectionsModel,
-                                                                                 DEFAULT_X_LOWER, DEFAULT_X_UPPER)
+from Muon.GUI.Common.corrections_tab_widget.background_corrections_model import BackgroundCorrectionsModel
 from Muon.GUI.Common.test_helpers.context_setup import setup_context
+from Muon.GUI.Common.utilities.workspace_data_utils import DEFAULT_X_LOWER, DEFAULT_X_UPPER
 
 
 class BackgroundCorrectionsModelTest(unittest.TestCase):
@@ -69,14 +69,6 @@ class BackgroundCorrectionsModelTest(unittest.TestCase):
         self.model.set_show_all_runs(show_all_runs)
 
         self.assertEqual(self.model._corrections_context.show_all_runs, show_all_runs)
-
-    def test_that_is_equal_to_n_decimals_will_return_false_if_the_two_numbers_are_not_equal_to_the_given_dp(self):
-        value1, value2 = 1.001, 1.0015
-        self.assertTrue(not self.model.is_equal_to_n_decimals(value1, value2, 3))
-
-    def test_that_is_equal_to_n_decimals_will_return_true_if_the_two_numbers_are_equal_to_the_given_dp(self):
-        value1, value2 = 1.001, 1.0014
-        self.assertTrue(self.model.is_equal_to_n_decimals(value1, value2, 3))
 
     def test_that_populate_background_corrections_data_will_populate_default_background_correction_data(self):
         self.model.x_limits_of_workspace = mock.Mock(return_value=(0.0, 30.0))
@@ -153,7 +145,7 @@ class BackgroundCorrectionsModelTest(unittest.TestCase):
     def test_that_x_limits_of_workspace_will_return_the_x_limits_of_the_workspace(self):
         run, group = "84447", "top"
         workspace_name = f"HIFI{run}; Group; {group}; Counts; MA"
-        self.model._get_counts_workspace_name = mock.Mock(return_value=workspace_name)
+        self.model.get_counts_workspace_name = mock.Mock(return_value=workspace_name)
 
         CreateSampleWorkspace(OutputWorkspace=workspace_name)
 
@@ -165,7 +157,7 @@ class BackgroundCorrectionsModelTest(unittest.TestCase):
     def test_that_x_limits_of_workspace_will_return_the_default_x_values_if_there_are_no_workspaces_loaded(self):
         run, group = "84447", "top"
         workspace_name = f"HIFI{run}; Group; {group}; Counts; MA"
-        self.model._get_counts_workspace_name = mock.Mock(return_value=workspace_name)
+        self.model.get_counts_workspace_name = mock.Mock(return_value=workspace_name)
 
         x_lower, x_upper = self.model.x_limits_of_workspace(run, group)
 

--- a/scripts/test/Muon/corrections_tab_widget/background_corrections_presenter_test.py
+++ b/scripts/test/Muon/corrections_tab_widget/background_corrections_presenter_test.py
@@ -1,0 +1,177 @@
+# Mantid Repository : https://github.com/mantidproject/mantid
+#
+# Copyright &copy; 2021 ISIS Rutherford Appleton Laboratory UKRI,
+#   NScD Oak Ridge National Laboratory, European Spallation Source,
+#   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+# SPDX - License - Identifier: GPL - 3.0 +
+import unittest
+from unittest import mock
+
+from Muon.GUI.Common.corrections_tab_widget.background_corrections_model import BackgroundCorrectionsModel
+from Muon.GUI.Common.corrections_tab_widget.background_corrections_presenter import BackgroundCorrectionsPresenter
+from Muon.GUI.Common.corrections_tab_widget.background_corrections_view import BackgroundCorrectionsView
+
+
+class BackgroundCorrectionsPresenterTest(unittest.TestCase):
+
+    def setUp(self):
+        self.runs = ["84447", "84447", "84447", "84447"]
+        self.groups = ["fwd", "bwd", "top", "bottom"]
+        self.selected_run = "84447"
+        self.selected_group = "fwd"
+        self.start_x = 5.0
+        self.end_x = 15.0
+
+        self._setup_mock_view()
+        self._setup_mock_model()
+        self._setup_presenter()
+
+    def tearDown(self):
+        self.presenter = None
+        self.model = None
+        self.view = None
+
+    def test_that_the_slots_are_set_in_the_view(self):
+        self.assertEqual(self.view.set_slot_for_mode_combo_box_changed.call_count, 1)
+        self.assertEqual(self.view.set_slot_for_select_function_combo_box_changed.call_count, 1)
+        self.assertEqual(self.view.set_slot_for_group_combo_box_changed.call_count, 1)
+        self.assertEqual(self.view.set_slot_for_show_all_runs.call_count, 1)
+        self.assertEqual(self.view.set_slot_for_start_x_changed.call_count, 1)
+        self.assertEqual(self.view.set_slot_for_end_x_changed.call_count, 1)
+
+    def test_that_handle_instrument_changed_will_reset_the_background_correction_mode(self):
+        self.presenter.handle_instrument_changed()
+
+        self.model.set_background_correction_mode.assert_called_once_with("None")
+        self.model.set_selected_function.assert_called_once_with("Flat Background")
+        self.mock_view_background_correction_mode.assert_called_once_with("None")
+        self.mock_view_selected_function.assert_called_once_with("Flat Background")
+
+    def test_that_handle_runs_loaded_will_populate_the_background_corrections_data(self):
+        self.presenter.handle_runs_loaded()
+        self.model.populate_background_corrections_data.assert_called_once_with()
+
+    def test_that_handle_groups_changed_will_populate_the_group_selector(self):
+        self.presenter.handle_groups_changed()
+
+        self.model.group_names.assert_called_once_with()
+        self.view.populate_group_selector.assert_called_once_with(self.groups)
+
+    def test_that_handle_run_selector_changed_will_attempt_to_update_the_displayed_corrections_data(self):
+        self.presenter.handle_run_selector_changed()
+        self.presenter._update_displayed_corrections_data.assert_called_once_with()
+
+    def test_that_handle_mode_combo_box_changed_will_update_the_model_and_view(self):
+        self.presenter.handle_mode_combo_box_changed()
+
+        self.mock_view_background_correction_mode.assert_called_once_with()
+        self.model.set_background_correction_mode.assert_called_once_with("None")
+        self.model.is_background_mode_none.assert_called_once_with()
+        self.view.set_background_correction_options_visible.assert_called_once_with(False)
+
+    def test_that_handle_select_function_combo_box_changed_will_update_the_model(self):
+        self.presenter.handle_select_function_combo_box_changed()
+
+        self.mock_view_selected_function.assert_called_once_with()
+        self.model.set_selected_function.assert_called_once_with("Flat Background")
+
+    def test_that_handle_selected_group_changed_will_update_the_model(self):
+        self.presenter.handle_selected_group_changed()
+
+        self.mock_view_selected_group.assert_called_once_with()
+        self.model.set_selected_group.assert_called_once_with("All")
+
+        self.presenter._update_displayed_corrections_data.assert_called_once_with()
+
+    def test_that_handle_show_all_runs_ticked_will_update_the_model(self):
+        self.presenter.handle_show_all_runs_ticked()
+
+        self.mock_view_show_all_runs.assert_called_once_with()
+        self.model.set_show_all_runs.assert_called_once_with(False)
+
+        self.presenter._update_displayed_corrections_data.assert_called_once_with()
+
+    def test_that_handle_start_x_changed_will_validate_the_start_x_before_updating_the_xs_in_the_model(self):
+        self.presenter.handle_start_x_changed()
+
+        self.view.selected_run_and_group.assert_called_once_with()
+        self.presenter._check_start_x_is_valid_for.assert_called_once_with(self.selected_run, self.selected_group)
+
+        self.view.start_x.assert_called_once_with(self.selected_run, self.selected_group)
+        self.model.set_start_x.assert_called_once_with(self.selected_run, self.selected_group, self.start_x)
+
+        self.view.end_x.assert_called_once_with(self.selected_run, self.selected_group)
+        self.model.set_end_x.assert_called_once_with(self.selected_run, self.selected_group, self.end_x)
+
+    def test_that_handle_end_x_changed_will_validate_the_end_x_before_updating_the_xs_in_the_model(self):
+        self.presenter.handle_end_x_changed()
+
+        self.view.selected_run_and_group.assert_called_once_with()
+        self.presenter._check_end_x_is_valid_for.assert_called_once_with(self.selected_run, self.selected_group)
+
+        self.view.start_x.assert_called_once_with(self.selected_run, self.selected_group)
+        self.model.set_start_x.assert_called_once_with(self.selected_run, self.selected_group, self.start_x)
+
+        self.view.end_x.assert_called_once_with(self.selected_run, self.selected_group)
+        self.model.set_end_x.assert_called_once_with(self.selected_run, self.selected_group, self.end_x)
+
+    def _setup_mock_view(self):
+        self.view = mock.Mock(spec=BackgroundCorrectionsView)
+
+        self.view.set_slot_for_mode_combo_box_changed = mock.Mock()
+        self.view.set_slot_for_select_function_combo_box_changed = mock.Mock()
+        self.view.set_slot_for_group_combo_box_changed = mock.Mock()
+        self.view.set_slot_for_show_all_runs = mock.Mock()
+        self.view.set_slot_for_start_x_changed = mock.Mock()
+        self.view.set_slot_for_end_x_changed = mock.Mock()
+
+        self.view.set_background_correction_options_visible = mock.Mock()
+        self.view.populate_group_selector = mock.Mock()
+        self.view.set_start_x = mock.Mock()
+        self.view.set_end_x = mock.Mock()
+        self.view.populate_corrections_table = mock.Mock()
+
+        self.view.selected_run_and_group = mock.Mock(return_value=tuple([self.selected_run, self.selected_group]))
+        self.view.start_x = mock.Mock(return_value=self.start_x)
+        self.view.end_x = mock.Mock(return_value=self.end_x)
+
+        # Mock the properties of the view
+        self.mock_view_background_correction_mode = mock.PropertyMock(return_value="None")
+        type(self.view).background_correction_mode = self.mock_view_background_correction_mode
+
+        self.mock_view_selected_function = mock.PropertyMock(return_value="Flat Background")
+        type(self.view).selected_function = self.mock_view_selected_function
+
+        self.mock_view_selected_group = mock.PropertyMock(return_value="All")
+        type(self.view).selected_group = self.mock_view_selected_group
+
+        self.mock_view_show_all_runs = mock.PropertyMock(return_value=False)
+        type(self.view).show_all_runs = self.mock_view_show_all_runs
+
+    def _setup_mock_model(self):
+        self.model = mock.Mock(spec=BackgroundCorrectionsModel)
+
+        self.model.set_background_correction_mode = mock.Mock()
+        self.model.set_selected_function = mock.Mock()
+        self.model.set_selected_group = mock.Mock()
+        self.model.set_show_all_runs = mock.Mock()
+        self.model.set_start_x = mock.Mock()
+        self.model.set_end_x = mock.Mock()
+        self.model.group_names = mock.Mock(return_value=self.groups)
+        self.model.is_background_mode_none = mock.Mock(return_value=True)
+
+        self.model.populate_background_corrections_data = mock.Mock()
+
+    def _setup_presenter(self):
+        self.corrections_presenter = mock.Mock()
+        self.corrections_presenter.warning_popup = mock.Mock()
+
+        self.presenter = BackgroundCorrectionsPresenter(self.view, self.model, self.corrections_presenter)
+
+        self.presenter._update_displayed_corrections_data = mock.Mock()
+        self.presenter._check_start_x_is_valid_for = mock.Mock()
+        self.presenter._check_end_x_is_valid_for = mock.Mock()
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/scripts/test/Muon/corrections_tab_widget/background_corrections_presenter_test.py
+++ b/scripts/test/Muon/corrections_tab_widget/background_corrections_presenter_test.py
@@ -15,6 +15,7 @@ from Muon.GUI.Common.corrections_tab_widget.background_corrections_view import B
 class BackgroundCorrectionsPresenterTest(unittest.TestCase):
 
     def setUp(self):
+        self.workspace_name = "HIFI84447; Group; fwd; Counts; MA"
         self.runs = ["84447", "84447", "84447", "84447"]
         self.groups = ["fwd", "bwd", "top", "bottom"]
         self.selected_run = "84447"
@@ -98,11 +99,13 @@ class BackgroundCorrectionsPresenterTest(unittest.TestCase):
 
         self.presenter._update_displayed_corrections_data.assert_called_once_with()
 
-    def test_that_handle_start_x_changed_will_validate_the_start_x_before_updating_the_xs_in_the_model(self):
+    @mock.patch("Muon.GUI.Common.utilities.workspace_data_utils.check_start_x_is_valid")
+    def test_that_handle_start_x_changed_will_validate_the_start_x_before_updating_the_xs_in_the_model(self,
+                                                                                                       mock_check_start_x):
+        mock_check_start_x.return_value = (self.start_x, self.end_x)
         self.presenter.handle_start_x_changed()
 
         self.view.selected_run_and_group.assert_called_once_with()
-        self.presenter._check_start_x_is_valid_for.assert_called_once_with(self.selected_run, self.selected_group)
 
         self.view.start_x.assert_called_once_with(self.selected_run, self.selected_group)
         self.model.set_start_x.assert_called_once_with(self.selected_run, self.selected_group, self.start_x)
@@ -110,11 +113,12 @@ class BackgroundCorrectionsPresenterTest(unittest.TestCase):
         self.view.end_x.assert_called_once_with(self.selected_run, self.selected_group)
         self.model.set_end_x.assert_called_once_with(self.selected_run, self.selected_group, self.end_x)
 
-    def test_that_handle_end_x_changed_will_validate_the_end_x_before_updating_the_xs_in_the_model(self):
+    @mock.patch("Muon.GUI.Common.utilities.workspace_data_utils.check_end_x_is_valid")
+    def test_that_handle_end_x_changed_will_validate_the_end_x_before_updating_the_xs_in_the_model(self, mock_check_end_x):
+        mock_check_end_x.return_value = (self.start_x, self.end_x)
         self.presenter.handle_end_x_changed()
 
         self.view.selected_run_and_group.assert_called_once_with()
-        self.presenter._check_end_x_is_valid_for.assert_called_once_with(self.selected_run, self.selected_group)
 
         self.view.start_x.assert_called_once_with(self.selected_run, self.selected_group)
         self.model.set_start_x.assert_called_once_with(self.selected_run, self.selected_group, self.start_x)
@@ -166,6 +170,7 @@ class BackgroundCorrectionsPresenterTest(unittest.TestCase):
         self.model.set_end_x = mock.Mock()
         self.model.group_names = mock.Mock(return_value=self.groups)
         self.model.is_background_mode_none = mock.Mock(return_value=True)
+        self.model.get_counts_workspace_name = mock.Mock(return_value=self.workspace_name)
 
         self.model.populate_background_corrections_data = mock.Mock()
 
@@ -176,8 +181,6 @@ class BackgroundCorrectionsPresenterTest(unittest.TestCase):
         self.presenter = BackgroundCorrectionsPresenter(self.view, self.model, self.corrections_presenter)
 
         self.presenter._update_displayed_corrections_data = mock.Mock()
-        self.presenter._check_start_x_is_valid_for = mock.Mock()
-        self.presenter._check_end_x_is_valid_for = mock.Mock()
 
 
 if __name__ == '__main__':

--- a/scripts/test/Muon/corrections_tab_widget/background_corrections_presenter_test.py
+++ b/scripts/test/Muon/corrections_tab_widget/background_corrections_presenter_test.py
@@ -64,17 +64,22 @@ class BackgroundCorrectionsPresenterTest(unittest.TestCase):
         self.presenter._update_displayed_corrections_data.assert_called_once_with()
 
     def test_that_handle_mode_combo_box_changed_will_update_the_model_and_view(self):
+        self.assertEqual(self.view.background_correction_mode, "None")
+        self.assertTrue(self.model.is_background_mode_none())
+
         self.presenter.handle_mode_combo_box_changed()
 
-        self.mock_view_background_correction_mode.assert_called_once_with()
+        self.mock_view_background_correction_mode.assert_called_with()
         self.model.set_background_correction_mode.assert_called_once_with("None")
-        self.model.is_background_mode_none.assert_called_once_with()
+        self.model.is_background_mode_none.assert_called_with()
         self.view.set_background_correction_options_visible.assert_called_once_with(False)
 
     def test_that_handle_select_function_combo_box_changed_will_update_the_model(self):
+        self.assertEqual(self.view.selected_function, "Flat Background")
+
         self.presenter.handle_select_function_combo_box_changed()
 
-        self.mock_view_selected_function.assert_called_once_with()
+        self.mock_view_selected_function.assert_called_with()
         self.model.set_selected_function.assert_called_once_with("Flat Background")
 
     def test_that_handle_selected_group_changed_will_update_the_model(self):

--- a/scripts/test/Muon/corrections_tab_widget/background_corrections_presenter_test.py
+++ b/scripts/test/Muon/corrections_tab_widget/background_corrections_presenter_test.py
@@ -47,9 +47,11 @@ class BackgroundCorrectionsPresenterTest(unittest.TestCase):
         self.mock_view_background_correction_mode.assert_called_once_with("None")
         self.mock_view_selected_function.assert_called_once_with("Flat Background")
 
-    def test_that_handle_runs_loaded_will_populate_the_background_corrections_data(self):
-        self.presenter.handle_runs_loaded()
+    def test_that_handle_pre_process_and_grouping_complete_will_populate_the_background_corrections_data(self):
+        self.presenter.handle_pre_process_and_grouping_complete()
+
         self.model.populate_background_corrections_data.assert_called_once_with()
+        self.presenter._update_displayed_corrections_data.assert_called_once_with()
 
     def test_that_handle_groups_changed_will_populate_the_group_selector(self):
         self.presenter.handle_groups_changed()

--- a/scripts/test/Muon/corrections_tab_widget/background_corrections_view_test.py
+++ b/scripts/test/Muon/corrections_tab_widget/background_corrections_view_test.py
@@ -1,0 +1,165 @@
+# Mantid Repository : https://github.com/mantidproject/mantid
+#
+# Copyright &copy; 2021 ISIS Rutherford Appleton Laboratory UKRI,
+#   NScD Oak Ridge National Laboratory, European Spallation Source,
+#   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+# SPDX - License - Identifier: GPL - 3.0 +
+import unittest
+
+from qtpy.QtTest import QTest
+from qtpy.QtCore import Qt, QPoint
+
+from mantidqt.utils.qt.testing import start_qapplication
+from mantidqt.utils.qt.testing.qt_widget_finder import QtWidgetFinder
+
+from Muon.GUI.Common.corrections_tab_widget.background_corrections_view import (BackgroundCorrectionsView,
+                                                                                RUN_COLUMN_INDEX,
+                                                                                GROUP_COLUMN_INDEX,
+                                                                                A0_COLUMN_INDEX,
+                                                                                A0_ERROR_COLUMN_INDEX)
+
+from qtpy.QtWidgets import QApplication
+
+
+@start_qapplication
+class BackgroundCorrectionsViewTest(unittest.TestCase, QtWidgetFinder):
+
+    def setUp(self):
+        self.view = BackgroundCorrectionsView()
+        self.view.show()
+        self.assert_widget_created()
+
+        self.runs = ["84447", "84447", "84447", "84447"]
+        self.groups = ["fwd", "bwd", "top", "bottom"]
+        self.start_xs = [5.0, 6.0, 7.0, 8.0]
+        self.end_xs = [9.0, 10.0, 11.0, 12.0]
+        self.a0s = [0.0, 0.0, 0.1, 0.1]
+        self.a0_errors = [0.0, 0.0, 0.0, 0.0]
+
+    def tearDown(self):
+        self.assertTrue(self.view.close())
+        QApplication.sendPostedEvents()
+
+    def test_that_the_view_has_been_initialized_with_most_background_correction_options_invisible(self):
+        self.assertTrue(self.view.select_function_label.isHidden())
+        self.assertTrue(self.view.function_combo_box.isHidden())
+        self.assertTrue(self.view.group_label.isHidden())
+        self.assertTrue(self.view.group_combo_box.isHidden())
+        self.assertTrue(self.view.show_all_runs_checkbox.isHidden())
+        self.assertTrue(self.view.correction_options_table.isHidden())
+
+    def test_that_set_background_correction_options_visible_will_make_the_correction_options_visible(self):
+        self.view.set_background_correction_options_visible(True)
+
+        self.assertTrue(not self.view.select_function_label.isHidden())
+        self.assertTrue(not self.view.function_combo_box.isHidden())
+        self.assertTrue(not self.view.group_label.isHidden())
+        self.assertTrue(not self.view.group_combo_box.isHidden())
+        self.assertTrue(not self.view.show_all_runs_checkbox.isHidden())
+        self.assertTrue(not self.view.correction_options_table.isHidden())
+
+    def test_that_background_correction_mode_will_return_and_set_the_correction_mode_as_expected(self):
+        self.assertEqual(self.view.background_correction_mode, "None")
+
+        self.view.background_correction_mode = "Auto"
+        self.assertEqual(self.view.background_correction_mode, "Auto")
+
+    def test_that_background_correction_mode_will_not_raise_if_the_option_provided_does_not_exist(self):
+        self.assertEqual(self.view.background_correction_mode, "None")
+
+        self.view.background_correction_mode = "FakeMode"
+        self.assertEqual(self.view.background_correction_mode, "None")
+
+    def test_that_selected_function_will_return_and_set_the_selected_function_as_expected(self):
+        self.assertEqual(self.view.selected_function, "Flat Background")
+
+        self.view.selected_function = "Flat Background + Exp Decay"
+        self.assertEqual(self.view.selected_function, "Flat Background + Exp Decay")
+
+    def test_that_selected_function_will_not_raise_if_the_function_option_provided_does_not_exist(self):
+        self.assertEqual(self.view.selected_function, "Flat Background")
+
+        self.view.selected_function = "Fake Function"
+        self.assertEqual(self.view.selected_function, "Flat Background")
+
+    def test_that_populate_group_selector_will_populate_the_group_selector_with_the_first_entry_being_all(self):
+        self.view.populate_group_selector(self.groups)
+
+        self.assertEqual([self.view.group_combo_box.itemText(i) for i in range(self.view.group_combo_box.count())],
+                         ["All"] + self.groups)
+
+    def test_that_selected_group_returns_the_selected_group_from_the_group_combo_box(self):
+        self.view.populate_group_selector(self.groups)
+
+        self.view.group_combo_box.setCurrentIndex(2)
+
+        self.assertEqual(self.view.selected_group, "bwd")
+
+    def test_that_populate_corrections_table_will_display_the_data_provided_in_the_table(self):
+        self.view.populate_corrections_table(self.runs, self.groups, self.start_xs, self.end_xs, self.a0s,
+                                             self.a0_errors)
+
+        for row_i in range(self.view.correction_options_table.rowCount()):
+            self.assertEqual(self.view.correction_options_table.item(row_i, RUN_COLUMN_INDEX).text(), self.runs[row_i])
+            self.assertEqual(self.view.correction_options_table.item(row_i, GROUP_COLUMN_INDEX).text(),
+                             self.groups[row_i])
+            self.assertEqual(self.view.start_x(self.runs[row_i], self.groups[row_i]), self.start_xs[row_i])
+            self.assertEqual(self.view.end_x(self.runs[row_i], self.groups[row_i]), self.end_xs[row_i])
+            self.assertEqual(self.view.correction_options_table.item(row_i, A0_COLUMN_INDEX).text(),
+                             f"{self.a0s[row_i]:.3f}")
+            self.assertEqual(self.view.correction_options_table.item(row_i, A0_ERROR_COLUMN_INDEX).text(),
+                             f"{self.a0_errors[row_i]:.3f}")
+
+    def test_that_set_start_x_will_set_the_start_x_for_a_specific_run_and_group(self):
+        run = "84447"
+        self.view.populate_corrections_table(self.runs, self.groups, self.start_xs, self.end_xs, self.a0s,
+                                             self.a0_errors)
+
+        self.view.set_start_x(run, "fwd", 1.1)
+        self.view.set_start_x(run, "bwd", 2.2)
+        self.view.set_start_x(run, "top", 3.3)
+        self.view.set_start_x(run, "bottom", 4.4)
+
+        self.assertEqual(self.view.start_x(run, "fwd"), 1.1)
+        self.assertEqual(self.view.start_x(run, "bwd"), 2.2)
+        self.assertEqual(self.view.start_x(run, "top"), 3.3)
+        self.assertEqual(self.view.start_x(run, "bottom"), 4.4)
+
+    def test_that_set_end_x_will_set_the_end_x_for_a_specific_run_and_group(self):
+        run = "84447"
+        self.view.populate_corrections_table(self.runs, self.groups, self.start_xs, self.end_xs, self.a0s,
+                                             self.a0_errors)
+
+        self.view.set_end_x(run, "fwd", 1.1)
+        self.view.set_end_x(run, "bwd", 2.2)
+        self.view.set_end_x(run, "top", 3.3)
+        self.view.set_end_x(run, "bottom", 4.4)
+
+        self.assertEqual(self.view.end_x(run, "fwd"), 1.1)
+        self.assertEqual(self.view.end_x(run, "bwd"), 2.2)
+        self.assertEqual(self.view.end_x(run, "top"), 3.3)
+        self.assertEqual(self.view.end_x(run, "bottom"), 4.4)
+
+    def test_that_selected_run_and_group_will_return_none_if_there_is_no_group_selected(self):
+        self.view.populate_corrections_table(self.runs, self.groups, self.start_xs, self.end_xs, self.a0s,
+                                             self.a0_errors)
+        self.assertEqual(self.view.selected_run_and_group(), (None, None))
+
+    def test_that_selected_run_and_group_will_return_the_run_and_group_of_the_selected_row(self):
+        self.view.populate_corrections_table(self.runs, self.groups, self.start_xs, self.end_xs, self.a0s,
+                                             self.a0_errors)
+
+        self._select_table_cell(2, 0)
+        self.assertEqual(self.view.selected_run_and_group(), ("84447", "top"))
+
+    def _select_table_cell(self, row, column):
+        x = int(self.view.correction_options_table.columnViewportPosition(column)
+                + self.view.correction_options_table.columnWidth(column) / 2)
+        y = int(self.view.correction_options_table.rowViewportPosition(row)
+                + self.view.correction_options_table.rowHeight(row) / 2)
+
+        QTest.mouseClick(self.view.correction_options_table.viewport(), Qt.LeftButton, Qt.NoModifier, QPoint(x, y))
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/scripts/test/Muon/corrections_tab_widget/corrections_presenter_test.py
+++ b/scripts/test/Muon/corrections_tab_widget/corrections_presenter_test.py
@@ -50,6 +50,7 @@ class CorrectionsPresenterTest(unittest.TestCase):
     def test_that_handle_instrument_changed_will_reset_the_dead_time_source_and_attempt_a_recalculation(self):
         self.presenter.handle_instrument_changed()
         self.presenter.dead_time_presenter.handle_instrument_changed.assert_called_once_with()
+        self.presenter.background_presenter.handle_instrument_changed.assert_called_once_with()
 
     def test_that_handle_runs_loaded_will_update_the_runs_in_the_model_and_view(self):
         self.model.run_number_strings = mock.Mock(return_value=self.run_strings)
@@ -62,6 +63,7 @@ class CorrectionsPresenterTest(unittest.TestCase):
         self.view.current_run_string.assert_called_once_with()
         self.model.set_current_run_string.assert_called_once_with(self.current_run_string)
         self.mock_model_number_of_run_strings.assert_called_once_with()
+        self.presenter.background_presenter.handle_runs_loaded.assert_called_once_with()
 
     def test_that_handle_runs_loaded_will_disable_the_view_if_there_are_no_runs_loaded(self):
         run_strings = []
@@ -75,6 +77,7 @@ class CorrectionsPresenterTest(unittest.TestCase):
 
         self.mock_model_number_of_run_strings.assert_called_once_with()
         self.view.disable_view.assert_called_once_with()
+        self.presenter.background_presenter.handle_runs_loaded.assert_called_once_with()
 
     def test_that_handle_runs_loaded_will_enable_the_view_if_there_are_runs_loaded(self):
         self.model.run_number_strings = mock.Mock(return_value=self.run_strings)
@@ -84,6 +87,7 @@ class CorrectionsPresenterTest(unittest.TestCase):
 
         self.mock_model_number_of_run_strings.assert_called_once_with()
         self.view.enable_view.assert_called_once_with()
+        self.presenter.background_presenter.handle_runs_loaded.assert_called_once_with()
 
     def test_that_handle_run_selector_changed_will_update_the_run_string_in_the_model(self):
         self.view.current_run_string = mock.Mock(return_value=self.current_run_string)
@@ -93,10 +97,15 @@ class CorrectionsPresenterTest(unittest.TestCase):
         self.view.current_run_string.assert_called_once_with()
         self.model.set_current_run_string.assert_called_once_with(self.current_run_string)
         self.presenter.dead_time_presenter.handle_run_selector_changed.assert_called_once_with()
+        self.presenter.background_presenter.handle_run_selector_changed.assert_called_once_with()
 
     def test_that_handle_corrections_complete_will_update_the_dead_time_label_in_the_view(self):
         self.presenter.handle_corrections_complete()
         self.presenter.dead_time_presenter.handle_corrections_complete.assert_called_once_with()
+
+    def test_that_handle_groups_changed_will_notify_the_background_corrections_presenter(self):
+        self.presenter.handle_groups_changed()
+        self.presenter.background_presenter.handle_groups_changed.assert_called_once_with()
 
     def _setup_mock_view(self):
         self.view = mock.Mock(spec=CorrectionsView)
@@ -126,6 +135,12 @@ class CorrectionsPresenterTest(unittest.TestCase):
         self.presenter.dead_time_presenter.handle_instrument_changed = mock.Mock()
         self.presenter.dead_time_presenter.handle_run_selector_changed = mock.Mock()
         self.presenter.dead_time_presenter.handle_corrections_complete = mock.Mock()
+
+        self.presenter.background_presenter.initialize_model_options = mock.Mock()
+        self.presenter.background_presenter.handle_instrument_changed = mock.Mock()
+        self.presenter.background_presenter.handle_runs_loaded = mock.Mock()
+        self.presenter.background_presenter.handle_run_selector_changed = mock.Mock()
+        self.presenter.background_presenter.handle_groups_changed = mock.Mock()
 
         self.presenter._handle_selected_table_is_invalid = mock.Mock()
 

--- a/scripts/test/Muon/corrections_tab_widget/corrections_presenter_test.py
+++ b/scripts/test/Muon/corrections_tab_widget/corrections_presenter_test.py
@@ -63,7 +63,6 @@ class CorrectionsPresenterTest(unittest.TestCase):
         self.view.current_run_string.assert_called_once_with()
         self.model.set_current_run_string.assert_called_once_with(self.current_run_string)
         self.mock_model_number_of_run_strings.assert_called_once_with()
-        self.presenter.background_presenter.handle_runs_loaded.assert_called_once_with()
 
     def test_that_handle_runs_loaded_will_disable_the_view_if_there_are_no_runs_loaded(self):
         run_strings = []
@@ -77,7 +76,6 @@ class CorrectionsPresenterTest(unittest.TestCase):
 
         self.mock_model_number_of_run_strings.assert_called_once_with()
         self.view.disable_view.assert_called_once_with()
-        self.presenter.background_presenter.handle_runs_loaded.assert_called_once_with()
 
     def test_that_handle_runs_loaded_will_enable_the_view_if_there_are_runs_loaded(self):
         self.model.run_number_strings = mock.Mock(return_value=self.run_strings)
@@ -87,7 +85,6 @@ class CorrectionsPresenterTest(unittest.TestCase):
 
         self.mock_model_number_of_run_strings.assert_called_once_with()
         self.view.enable_view.assert_called_once_with()
-        self.presenter.background_presenter.handle_runs_loaded.assert_called_once_with()
 
     def test_that_handle_run_selector_changed_will_update_the_run_string_in_the_model(self):
         self.view.current_run_string = mock.Mock(return_value=self.current_run_string)
@@ -99,9 +96,10 @@ class CorrectionsPresenterTest(unittest.TestCase):
         self.presenter.dead_time_presenter.handle_run_selector_changed.assert_called_once_with()
         self.presenter.background_presenter.handle_run_selector_changed.assert_called_once_with()
 
-    def test_that_handle_corrections_complete_will_update_the_dead_time_label_in_the_view(self):
-        self.presenter.handle_corrections_complete()
-        self.presenter.dead_time_presenter.handle_corrections_complete.assert_called_once_with()
+    def test_that_handle_pre_process_and_grouping_complete_will_update_the_dead_time_label_in_the_view(self):
+        self.presenter.handle_pre_process_and_grouping_complete()
+        self.presenter.dead_time_presenter.handle_pre_process_and_grouping_complete.assert_called_once_with()
+        self.presenter.background_presenter.handle_pre_process_and_grouping_complete.assert_called_once_with()
 
     def test_that_handle_groups_changed_will_notify_the_background_corrections_presenter(self):
         self.presenter.handle_groups_changed()
@@ -134,13 +132,14 @@ class CorrectionsPresenterTest(unittest.TestCase):
         self.presenter.dead_time_presenter.handle_ads_clear_or_remove_workspace_event = mock.Mock()
         self.presenter.dead_time_presenter.handle_instrument_changed = mock.Mock()
         self.presenter.dead_time_presenter.handle_run_selector_changed = mock.Mock()
-        self.presenter.dead_time_presenter.handle_corrections_complete = mock.Mock()
+        self.presenter.dead_time_presenter.handle_pre_process_and_grouping_complete = mock.Mock()
 
         self.presenter.background_presenter.initialize_model_options = mock.Mock()
         self.presenter.background_presenter.handle_instrument_changed = mock.Mock()
         self.presenter.background_presenter.handle_runs_loaded = mock.Mock()
         self.presenter.background_presenter.handle_run_selector_changed = mock.Mock()
         self.presenter.background_presenter.handle_groups_changed = mock.Mock()
+        self.presenter.background_presenter.handle_pre_process_and_grouping_complete = mock.Mock()
 
         self.presenter._handle_selected_table_is_invalid = mock.Mock()
 

--- a/scripts/test/Muon/corrections_tab_widget/dead_time_corrections_presenter_test.py
+++ b/scripts/test/Muon/corrections_tab_widget/dead_time_corrections_presenter_test.py
@@ -189,10 +189,10 @@ class DeadTimeCorrectionsPresenterTest(unittest.TestCase):
         self.assertEqual(self.view.populate_dead_time_workspace_selector.call_count, 1)
         self.view.switch_to_using_a_dead_time_table_workspace.assert_called_once_with(filename)
 
-    def test_that_handle_corrections_complete_will_update_the_dead_time_label_in_the_view(self):
+    def test_that_handle_pre_process_and_grouping_complete_will_update_the_dead_time_label_in_the_view(self):
         self.presenter.update_dead_time_info_text_in_view = mock.Mock()
 
-        self.presenter.handle_corrections_complete()
+        self.presenter.handle_pre_process_and_grouping_complete()
 
         self.presenter.update_dead_time_info_text_in_view.assert_called_once_with()
 

--- a/scripts/test/Muon/fitting_widgets/basic_fitting/basic_fitting_presenter_test.py
+++ b/scripts/test/Muon/fitting_widgets/basic_fitting/basic_fitting_presenter_test.py
@@ -266,7 +266,7 @@ class BasicFittingPresenterTest(unittest.TestCase):
 
     def test_that_handle_start_x_updated_will_attempt_to_update_the_start_x_in_the_model(self):
         self.presenter.handle_start_x_updated()
-        self.mock_model_current_start_x.assert_called_once_with(self.start_x)
+        self.mock_model_current_start_x.assert_called_with(self.start_x)
 
     def test_that_handle_start_x_updated_will_reset_the_start_x_if_it_equals_the_end_x(self):
         self.mock_view_start_x = mock.PropertyMock(return_value=self.end_x)
@@ -274,31 +274,31 @@ class BasicFittingPresenterTest(unittest.TestCase):
 
         self.presenter.handle_start_x_updated()
 
-        calls = [mock.call(), mock.call(), mock.call(), mock.call(), mock.call(0.0), mock.call()]
-        self.mock_view_start_x.assert_has_calls(calls)
+        self.mock_view_start_x.assert_called_with(0.0)
 
-    def test_that_handle_start_x_updated_will_use_the_min_start_x_when_the_set_start_x_is_too_small(self):
+    @mock.patch("Muon.GUI.Common.utilities.workspace_data_utils.x_limits_of_workspace")
+    def test_that_handle_start_x_updated_will_use_the_min_start_x_when_the_set_start_x_is_too_small(self, mock_x_limits):
         x_lower = 3.0
+        mock_x_limits.return_value = (x_lower, self.end_x)
         self.model.x_limits_of_workspace = mock.Mock(return_value=(x_lower, self.end_x))
 
         self.presenter.handle_start_x_updated()
 
-        calls = [mock.call(), mock.call(3.0), mock.call()]
-        self.mock_view_start_x.assert_has_calls(calls)
+        self.mock_view_start_x.assert_called_with(3.0)
 
-    def test_that_handle_start_x_updated_will_use_the_max_start_x_when_the_set_start_x_is_too_large(self):
+    @mock.patch("Muon.GUI.Common.utilities.workspace_data_utils.x_limits_of_workspace")
+    def test_that_handle_start_x_updated_will_use_the_max_start_x_when_the_set_start_x_is_too_large(self, mock_x_limits):
         x_upper = -0.1
-        self.model.x_limits_of_workspace = mock.Mock(return_value=(self.start_x, x_upper))
+        mock_x_limits.return_value = (self.start_x, x_upper)
         self.model.is_equal_to_n_decimals = mock.Mock(return_value=False)
 
         self.presenter.handle_start_x_updated()
 
-        calls = [mock.call(), mock.call(), mock.call(15.0), mock.call()]
-        self.mock_view_start_x.assert_has_calls(calls)
+        self.mock_view_start_x.assert_called_with(15.0)
 
     def test_that_handle_end_x_updated_will_attempt_to_update_the_end_x_in_the_model(self):
         self.presenter.handle_end_x_updated()
-        self.mock_model_current_end_x.assert_called_once_with(self.end_x)
+        self.mock_model_current_end_x.assert_called_with(self.end_x)
 
     def test_that_handle_end_x_updated_will_reset_the_end_x_if_it_equals_the_end_x(self):
         self.mock_view_end_x = mock.PropertyMock(return_value=self.start_x)
@@ -306,8 +306,7 @@ class BasicFittingPresenterTest(unittest.TestCase):
 
         self.presenter.handle_end_x_updated()
 
-        calls = [mock.call(), mock.call(), mock.call(), mock.call(), mock.call(15.0), mock.call()]
-        self.mock_view_end_x.assert_has_calls(calls)
+        self.mock_view_end_x.assert_called_with(15.0)
 
     def test_that_handle_use_rebin_changed_will_not_update_the_model_if_the_rebin_check_fails(self):
         self.presenter._check_rebin_options = mock.Mock(return_value=False)


### PR DESCRIPTION
**Description of work.**
This PR creates the visual aspects of the `None` and `Auto` mode for background corrections in the Muon analysis and FDA interfaces. No background subtractions are calculated at the moment, this will be done separately.

**To test:**
1. Comment out line 55 of `background_corrections_view.py`
2. Open Muon Analysis and load HIFI84447-8 for example
2. Change the mode to `Auto`
3. Try `Show all runs`
4. Try selecting different groups. Make sure the relevant data is displayed in the table
5. Try entering Start Xs and End Xs

6. Try same stuff on FDA. Does the default start and end X need to be different for FDA?


Part of #31816

*This does not require release notes* because **release notes will be added later when all background corrections modes are added.**

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
