### PR TITLE
refs #31947 muon nxs1 loads most log units

### DIFF
--- a/Framework/DataHandling/src/LoadMuonLog.cpp
+++ b/Framework/DataHandling/src/LoadMuonLog.cpp
@@ -114,6 +114,7 @@ void LoadMuonLog::addLogValueFromIndex(MuonNexusReader &nxload, const int &index
     for (int j = 0; j < nxload.getLogLength(index); j++) {
       nxload.getLogStringValues(index, j, logTime, logValue);
       l_PropertyString->addValue(logTime, logValue);
+      l_PropertyString->setUnits(nxload.logUnits(index));
     }
   } else {
     double logValue;
@@ -121,6 +122,7 @@ void LoadMuonLog::addLogValueFromIndex(MuonNexusReader &nxload, const int &index
     for (int j = 0; j < nxload.getLogLength(index); j++) {
       nxload.getLogValues(index, j, logTime, logValue);
       l_PropertyDouble->addValue(logTime, logValue);
+      l_PropertyDouble->setUnits(nxload.logUnits(index));
     }
   }
 

--- a/Framework/DataHandling/test/LoadMuonLogTest.h
+++ b/Framework/DataHandling/test/LoadMuonLogTest.h
@@ -80,6 +80,9 @@ public:
     TimeSeriesProperty<double> *l_timeSeriesDouble = dynamic_cast<TimeSeriesProperty<double> *>(l_property);
     timeSeriesString = l_timeSeriesDouble->value();
     TS_ASSERT_EQUALS(timeSeriesString.substr(0, 24), "2006-Nov-21 07:03:08  50");
+
+    l_property = output->run().getLogData(std::string("Temp_Cryostat"));
+    TS_ASSERT_EQUALS(l_property->units(), "K");
   }
 
 private:

--- a/Framework/Nexus/inc/MantidNexus/MuonNexusReader.h
+++ b/Framework/Nexus/inc/MantidNexus/MuonNexusReader.h
@@ -36,6 +36,8 @@ private:
   int m_nexusLogCount = 0;             ///< number of NXlog sections read from file
   std::vector<bool> m_logType;         ///< true if i'th log is numeric
   std::vector<std::string> m_logNames; ///< stores name read from file
+  std::vector<std::string> m_logUnits;
+
   void openFirstNXentry(NeXus::File &handle);
   bool readMuonLogData(NeXus::File &handle);               ///< method to read the fields of open NXlog section
   std::vector<std::vector<float>> m_logValues,             ///< array of values for i'th NXlog section
@@ -81,6 +83,7 @@ public:
   void getLogStringValues(const int &logNumber, const int &logSequence, std::time_t &logTime,
                           std::string &value); ///< get logSequence pair of logNumber string log
   bool logTypeNumeric(const int i) const;      ///< true if i'th log is of numeric type
+  std::string logUnits(const int i) const;
   // following ISISRAW.h
   int t_nsp1 = 0; ///< number of spectra in time regime 1
   int t_ntc1 = 0; ///< number of time channels in time regime 1

--- a/Framework/Nexus/src/MuonNexusReader.cpp
+++ b/Framework/Nexus/src/MuonNexusReader.cpp
@@ -296,16 +296,19 @@ bool MuonNexusReader::readMuonLogData(NeXus::File &handle) {
   std::vector<float> values;
   std::vector<std::string> stringValues;
   bool isNumeric(false);
+  std::string units = "";
 
   NeXus::Info info = handle.getInfo();
   if (info.type == NX_FLOAT32 && info.dims.size() == 1) {
     isNumeric = true;
     boost::scoped_array<float> dataVals(new float[info.dims[0]]);
+    handle.getAttr("units", units);
     handle.getData(dataVals.get());
     values.assign(dataVals.get(), dataVals.get() + info.dims[0]);
     stringValues.resize(info.dims[0]); // Leave empty
   } else if (info.type == NX_CHAR && info.dims.size() == 2) {
     boost::scoped_array<char> dataVals(new char[info.dims[0] * info.dims[1] + 1]);
+    handle.getAttr("units", units);
     handle.getData(dataVals.get());
     dataVals[info.dims[0] * info.dims[1]] = 0;
     for (int i = 0; i < info.dims[0]; ++i) {
@@ -343,7 +346,7 @@ bool MuonNexusReader::readMuonLogData(NeXus::File &handle) {
 
   std::vector<float> tmp(timeVals.get(), timeVals.get() + info.dims[0]);
   m_logTimes.emplace_back(tmp);
-
+  m_logUnits.emplace_back(units);
   m_logType.emplace_back(isNumeric);
   m_logValues.emplace_back(values);
   m_logStringValues.emplace_back(stringValues);
@@ -378,6 +381,8 @@ void MuonNexusReader::getLogStringValues(const int &logNumber, const int &logSeq
 int MuonNexusReader::numberOfLogs() const { return (m_nexusLogCount); }
 
 int MuonNexusReader::getLogLength(const int i) const { return (static_cast<int>(m_logTimes[i].size())); }
+
+std::string MuonNexusReader::logUnits(const int i) const { return (m_logUnits[i]); }
 
 bool MuonNexusReader::logTypeNumeric(const int i) const { return (m_logType[i]); }
 

--- a/docs/source/release/v6.2.0/muon.rst
+++ b/docs/source/release/v6.2.0/muon.rst
@@ -21,4 +21,9 @@ Improvements
 ############
 - Updated :ref:`LoadElementalAnalysisData <algm-LoadElementalAnalysisData>` algorithm to include Poisson errors for the counts data.
 
+Algorithms
+##########
+
+- Updated :ref:`LoadMuonLog <algm-LoadMuonLog>` to read units for most log values.
+
 :ref:`Release 6.2.0 <v6.2.0>`


### PR DESCRIPTION
The muon files (nxs version 1) were not reading in any units for the sample logs. This PR adds most of the sample log units (it does not add them to things such as sample temp).  

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

**To test:**
Load some muon data (e.g MUSR 62260)
Check that some sample logs have units
<!-- Instructions for testing. -->

Fixes #31947. <!-- and fix #xxxx or close #xxxx xor resolves #xxxx -->
<!-- alternative
*There is no associated issue.*
-->

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or master)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
