### PR TITLE
Conda: IPyKernel version rollback

### DIFF
--- a/mantid-developer-linux.yml
+++ b/mantid-developer-linux.yml
@@ -14,7 +14,7 @@ dependencies:
   - gsl=2.6 # Keep gsl a specific version to reduce changes in our fitting
   - h5py>=2.10.0,<3 # Pinned back due to api differences
   - hdf5=1.10.*
-  - ipykernel<6 # Added a hard dependency to deal with an issue caused by ipykernel in v6
+  - ipykernel<6 # Added as hard dependency only to deal with an issue with ipykernel v6 and incompatibility with qtconsole/workbench, was previously a soft dependency that was allowed to update to v6 by qtconsole, at present it stops workbench from loading.
   - jemalloc>=5.2.1
   - jsoncpp>=1.9.4,<2
   - librdkafka>=1.6.0

--- a/mantid-developer-linux.yml
+++ b/mantid-developer-linux.yml
@@ -14,6 +14,7 @@ dependencies:
   - gsl=2.6 # Keep gsl a specific version to reduce changes in our fitting
   - h5py>=2.10.0,<3 # Pinned back due to api differences
   - hdf5=1.10.*
+  - ipykernel<6 # Added a hard dependency to deal with an issue caused by ipykernel in v6
   - jemalloc>=5.2.1
   - jsoncpp>=1.9.4,<2
   - librdkafka>=1.6.0

--- a/mantid-developer-linux.yml
+++ b/mantid-developer-linux.yml
@@ -14,6 +14,7 @@ dependencies:
   - gsl=2.6 # Keep gsl a specific version to reduce changes in our fitting
   - h5py>=2.10.0,<3 # Pinned back due to api differences
   - hdf5=1.10.*
+  - ipykernel=5.5.5 # Added a hard dependency to deal with an issue caused by ipykernel in v6
   - jemalloc>=5.2.1
   - jsoncpp>=1.9.4,<2
   - librdkafka>=1.6.0

--- a/mantid-developer-osx.yml
+++ b/mantid-developer-osx.yml
@@ -13,7 +13,7 @@ dependencies:
   - gsl=2.6 # Keep gsl a specific version to reduce changes in our fitting
   - h5py>=2.10.0,<3 # Pinned back due to api differences
   - hdf5=1.10.*
-  - ipykernel<6 # Added a hard dependency to deal with an issue caused by ipykernel in v6
+  - ipykernel<6 # Added as hard dependency only to deal with an issue with ipykernel v6 and incompatibility with qtconsole/workbench, was previously a soft dependency that was allowed to update to v6 by qtconsole, at present it stops workbench from loading.
   - jemalloc>=5.2.1
   - jsoncpp>=1.9.4,<2
   - librdkafka>=1.6.0


### PR DESCRIPTION
**Description of work.**
IPykernel (for jupyter console/notebooks) released version 6.0.0 and it causes an issue when launching mantidworkbench, so adding a hard dependancy on the kernel being below 6

**To test:**
- Create the linux conda environment
- Build and launch mantid
<!-- Instructions for testing. -->

*There is no associated issue.*

*This does not require release notes* because **Developer facing**

<!-- Ensure the base of this PR is correct (e.g. release-next or master)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
