### PR TITLE
Add virtual destructor to interface type

### DIFF
--- a/qt/widgets/common/inc/MantidQtWidgets/Common/AlgorithmProgress/IAlgorithmProgressDialogWidget.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/AlgorithmProgress/IAlgorithmProgressDialogWidget.h
@@ -26,6 +26,7 @@ namespace MantidQt {
 namespace MantidWidgets {
 class IAlgorithmProgressDialogWidget {
 public:
+  virtual ~IAlgorithmProgressDialogWidget() = default;
   /// Adds an algorithm to the dialog. Returns the item in the tree widget, and
   /// the progress bar within it
   virtual std::pair<QTreeWidgetItem *, QProgressBar *> addAlgorithm(Mantid::API::IAlgorithm_sptr alg) = 0;


### PR DESCRIPTION
**Description of work.**

Adds a virtual destructor to an interface type so that `delete` does the correct thing on a type inheriting it. 

A warning recently cropped up about this on master on clang: [https://builds.mantidproject.org/job/master_clean-osx/1681/consoleText](https://builds.mantidproject.org/job/master_clean-osx/1681/consoleText)

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

**To test:**

* Code review
* If you have a mac then compiling `MantidQtWidgetsCommonTestQt5` with clang should no longer show the warning


*There is no associated issue.*

*This does not require release notes* because **it is an internal issue.**


<!-- Ensure the base of this PR is correct (e.g. release-next or master)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
