### PR TITLE
Additional integration methods for HB3AIntegrateDetectorPeaks

### DIFF
--- a/Framework/PythonInterface/plugins/algorithms/HB3AAdjustSampleNorm.py
+++ b/Framework/PythonInterface/plugins/algorithms/HB3AAdjustSampleNorm.py
@@ -277,7 +277,7 @@ class HB3AAdjustSampleNorm(PythonAlgorithm):
         else:
             norm_data = CloneMDWorkspace(data)
 
-        if self.getProperty("ScaleByMotorStep").value:
+        if self.getProperty("ScaleByMotorStep").value and self.getProperty("OutputType").value != "Detector":
             run = data.getExperimentInfo(0).run()
             scan_log = 'omega' if np.isclose(run.getTimeAveragedStd('phi'), 0.0) else 'phi'
             scan_axis = run[scan_log].value

--- a/Framework/PythonInterface/plugins/algorithms/HB3AIntegrateDetectorPeaks.py
+++ b/Framework/PythonInterface/plugins/algorithms/HB3AIntegrateDetectorPeaks.py
@@ -101,7 +101,7 @@ class HB3AIntegrateDetectorPeaks(PythonAlgorithm):
         optmize_q = self.getProperty("OptimizeQVector").value
         output_fit = self.getProperty("OutputFitResults").value
 
-        if output_fit:
+        if output_fit and method != "Counts":
             fit_results = WorkspaceGroup()
             AnalysisDataService.addOrReplace(outWS+"_fit_results", fit_results)
 

--- a/Framework/PythonInterface/plugins/algorithms/HB3AIntegrateDetectorPeaks.py
+++ b/Framework/PythonInterface/plugins/algorithms/HB3AIntegrateDetectorPeaks.py
@@ -7,8 +7,8 @@
 from mantid.api import (AlgorithmFactory, IPeaksWorkspaceProperty,
                         PythonAlgorithm, PropertyMode, ADSValidator,
                         WorkspaceGroup)
-from mantid.kernel import (Direction, IntArrayProperty, IntBoundedValidator,
-                           Property, IntArrayLengthValidator, StringArrayProperty,
+from mantid.kernel import (Direction, EnabledWhenProperty, IntArrayProperty, IntBoundedValidator,
+                           Property, PropertyCriterion, IntArrayLengthValidator, StringArrayProperty,
                            StringListValidator)
 from mantid.simpleapi import (mtd, IntegrateMDHistoWorkspace,
                               CreatePeaksWorkspace, DeleteWorkspace,
@@ -46,10 +46,13 @@ class HB3AIntegrateDetectorPeaks(PythonAlgorithm):
         self.declareProperty("NumBackgroundPts", direction=Direction.Input, defaultValue=3,
                              validator=IntBoundedValidator(lower=0),
                              doc="Number of background points from beginning and end of scan to use for background estimation")
+        self.setPropertySettings("NumBackgroundPts", EnabledWhenProperty("Method", PropertyCriterion.IsEqualTo, "Counts"))
 
         self.declareProperty("N", direction=Direction.Input, defaultValue=2,
                              validator=IntBoundedValidator(lower=0),
                              doc="Set of measurements around motor position (+/- N/2*FWHM)")
+        self.setPropertySettings("N",
+                                 EnabledWhenProperty("Method", PropertyCriterion.IsEqualTo, "CountsWithFitting"))
 
         self.declareProperty(IntArrayProperty("LowerLeft", [128, 128], IntArrayLengthValidator(2),
                                               direction=Direction.Input), doc="Region of interest lower-left corner, in detector pixels")

--- a/Framework/PythonInterface/plugins/algorithms/HB3AIntegrateDetectorPeaks.py
+++ b/Framework/PythonInterface/plugins/algorithms/HB3AIntegrateDetectorPeaks.py
@@ -71,7 +71,8 @@ class HB3AIntegrateDetectorPeaks(PythonAlgorithm):
         self.declareProperty("ApplyLorentz", True, doc="If to apply Lorentz Correction to intensity")
 
         self.declareProperty("OutputFitResults", False, doc="This will output the fitting result workspace and a ROI workspace")
-
+        self.setPropertySettings("OutputFitResults",
+                                 EnabledWhenProperty("Method", PropertyCriterion.IsNotEqualTo, "Counts"))
         self.declareProperty("OptimizeQVector", True,
                              doc="This will convert the data to q and optimize the peak location using CentroidPeaksdMD")
 
@@ -194,7 +195,7 @@ class HB3AIntegrateDetectorPeaks(PythonAlgorithm):
 
                 CombinePeaksWorkspaces(outWS, __tmp_pw, OutputWorkspace=outWS, EnableLogging=False)
 
-                if output_fit:
+                if output_fit and method != "Counts":
                     fit_results.addWorkspace(RenameWorkspace(tmp_inWS + '_Workspace', outWS + "_" + inWS + '_Workspace',
                                                              EnableLogging=False))
                     fit_results.addWorkspace(

--- a/Framework/PythonInterface/plugins/algorithms/HB3AIntegrateDetectorPeaks.py
+++ b/Framework/PythonInterface/plugins/algorithms/HB3AIntegrateDetectorPeaks.py
@@ -48,10 +48,10 @@ class HB3AIntegrateDetectorPeaks(PythonAlgorithm):
                              doc="Number of background points from beginning and end of scan to use for background estimation")
         self.setPropertySettings("NumBackgroundPts", EnabledWhenProperty("Method", PropertyCriterion.IsEqualTo, "Counts"))
 
-        self.declareProperty("N", direction=Direction.Input, defaultValue=2,
+        self.declareProperty("NumIntegrationPts", direction=Direction.Input, defaultValue=2,
                              validator=IntBoundedValidator(lower=0),
-                             doc="Set of measurements around motor position (+/- N/2*FWHM)")
-        self.setPropertySettings("N",
+                             doc="Controls integration range (+/- NumIntegrationPts/2*FWHM) defined around motor positions")
+        self.setPropertySettings("NumIntegrationPts",
                                  EnabledWhenProperty("Method", PropertyCriterion.IsEqualTo, "CountsWithFitting"))
 
         self.declareProperty(IntArrayProperty("LowerLeft", [128, 128], IntArrayLengthValidator(2),
@@ -89,7 +89,7 @@ class HB3AIntegrateDetectorPeaks(PythonAlgorithm):
 
         method = self.getProperty("Method").value
         n_bkgr_pts = self.getProperty("NumBackgroundPts").value
-        n = self.getProperty("N").value
+        n_int_pts = self.getProperty("NumIntegrationPts").value
         scale = self.getProperty("ScaleFactor").value
         chisqmax = self.getProperty("ChiSqMax").value
         signalNoiseMin = self.getProperty("SignalNoiseMin").value
@@ -156,8 +156,8 @@ class HB3AIntegrateDetectorPeaks(PythonAlgorithm):
                                           Axis2=f'{peak_centre},0,1,0,-1',
                                           EnableLogging=False)
                     elif method == "CountsWithFitting":
-                        y = y[slice(np.searchsorted(x, peak_centre - 2.3548 * sigma * n / 2),
-                                    np.searchsorted(x, peak_centre + 2.3548 * sigma * n / 2))]
+                        y = y[slice(np.searchsorted(x, peak_centre - 2.3548 * sigma * n_int_pts / 2),
+                                    np.searchsorted(x, peak_centre + 2.3548 * sigma * n_int_pts / 2))]
                         # subtract out the fitted flat background
                         integrated_intensity = (y.sum() - B * y.size) * scan_step
                         integrated_intensity_error = np.sum(np.sqrt(y)) * scan_step

--- a/Framework/PythonInterface/plugins/algorithms/HB3AIntegrateDetectorPeaks.py
+++ b/Framework/PythonInterface/plugins/algorithms/HB3AIntegrateDetectorPeaks.py
@@ -7,8 +7,9 @@
 from mantid.api import (AlgorithmFactory, IPeaksWorkspaceProperty,
                         PythonAlgorithm, PropertyMode, ADSValidator,
                         WorkspaceGroup)
-from mantid.kernel import (Direction, IntArrayProperty, Property,
-                           IntArrayLengthValidator, StringArrayProperty)
+from mantid.kernel import (Direction, IntArrayProperty, IntBoundedValidator,
+                           Property, IntArrayLengthValidator, StringArrayProperty,
+                           StringListValidator)
 from mantid.simpleapi import (mtd, IntegrateMDHistoWorkspace,
                               CreatePeaksWorkspace, DeleteWorkspace,
                               AnalysisDataService, SetGoniometer,
@@ -37,6 +38,18 @@ class HB3AIntegrateDetectorPeaks(PythonAlgorithm):
     def PyInit(self):
         self.declareProperty(StringArrayProperty("InputWorkspace", direction=Direction.Input, validator=ADSValidator()),
                              doc="Workspace or comma-separated workspace list containing input MDHisto scan data.")
+
+        self.declareProperty("Method", direction=Direction.Input, defaultValue="Fitted",
+                             validator=StringListValidator(["Counts", "CountsWithFitting", "Fitted"]),
+                             doc="Integration method to use")
+
+        self.declareProperty("NumBackgroundPts", direction=Direction.Input, defaultValue=3,
+                             validator=IntBoundedValidator(lower=0),
+                             doc="Number of background points from beginning and end of scan to use for background estimation")
+
+        self.declareProperty("N", direction=Direction.Input, defaultValue=2,
+                             validator=IntBoundedValidator(lower=0),
+                             doc="Set of measurements around motor position (+/- N/2*FWHM)")
 
         self.declareProperty(IntArrayProperty("LowerLeft", [128, 128], IntArrayLengthValidator(2),
                                               direction=Direction.Input), doc="Region of interest lower-left corner, in detector pixels")

--- a/Framework/PythonInterface/test/python/plugins/algorithms/HB3AIntegrateDetectorPeaksTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/HB3AIntegrateDetectorPeaksTest.py
@@ -38,7 +38,7 @@ class HB3ADetectorPeaksTest(unittest.TestCase):
         self.assertAlmostEqual(peak0.getK(), 0, places=1)
         self.assertAlmostEqual(peak0.getL(), 6, places=1)
         self.assertAlmostEqual(peak0.getIntensity(), 961.6164, delta=1e-5)
-        self.assertAlmostEqual(peak0.getSigmaIntensity(), 10.479567, delta=1e-5)
+        self.assertAlmostEqual(peak0.getSigmaIntensity(), 10.479567, delta=3e-2)
         self.assertAlmostEqual(peak0.getWavelength(), 1.008)
         self.assertAlmostEqual(peak0.getAzimuthal(), -np.pi, delta=2e-5)
         self.assertAlmostEqual(peak0.getScattering(),
@@ -81,7 +81,7 @@ class HB3ADetectorPeaksTest(unittest.TestCase):
                                delta=1e-2)
         self.assertAlmostEqual(peak0.getSigmaIntensity(),
                                10.479567 * np.sin(np.deg2rad(mtd["data"].getExperimentInfo(0).run()['2theta'].value[0])),
-                               delta=1e-2)
+                               delta=2e-2)
 
         # Optimize Q vector, will change Q-sample but the integration
         # should be the same except the Lorentz correction since the
@@ -92,7 +92,7 @@ class HB3ADetectorPeaksTest(unittest.TestCase):
         peak0 = peaks.getPeak(0)
         lorentz = abs(np.cos(peak0.getAzimuthal()) * np.sin(peak0.getScattering()))
         self.assertAlmostEqual(peak0.getIntensity(), 961.6164021216964 * lorentz, delta=1e-2)
-        self.assertAlmostEqual(peak0.getSigmaIntensity(), 10.479567046232615 * lorentz, delta=1e-2)
+        self.assertAlmostEqual(peak0.getSigmaIntensity(), 10.479567046232615 * lorentz, delta=2e-2)
         q_sample = peak0.getQSampleFrame()
         for i in range(3):
             self.assertNotAlmostEqual(q_sample[i], expected_q_sample[i])
@@ -119,7 +119,7 @@ class HB3ADetectorPeaksTest(unittest.TestCase):
         self.assertAlmostEqual(peak0.getK(), 0, places=1)
         self.assertAlmostEqual(peak0.getL(), 6, places=1)
         self.assertAlmostEqual(peak0.getIntensity(), 932.24967, delta=1e-5)
-        self.assertAlmostEqual(peak0.getSigmaIntensity(), 29.10343, delta=1e-5)
+        self.assertAlmostEqual(peak0.getSigmaIntensity(), 29.10343, delta=3e-2)
         self.assertAlmostEqual(peak0.getWavelength(), 1.008)
         self.assertAlmostEqual(peak0.getAzimuthal(), -np.pi, delta=2e-5)
         self.assertAlmostEqual(peak0.getScattering(),
@@ -142,7 +142,7 @@ class HB3ADetectorPeaksTest(unittest.TestCase):
                                delta=1e-2)
         self.assertAlmostEqual(peak0.getSigmaIntensity(),
                                29.10343 * np.sin(np.deg2rad(mtd["data"].getExperimentInfo(0).run()['2theta'].value[0])),
-                               delta=1e-2)
+                               delta=2e-2)
 
         peaks = HB3AIntegrateDetectorPeaks("data", Method="Counts", ApplyLorentz=True, OptimizeQVector=True)
         self.assertEqual(peaks.getNumberPeaks(), 1)
@@ -150,7 +150,7 @@ class HB3ADetectorPeaksTest(unittest.TestCase):
         peak0 = peaks.getPeak(0)
         lorentz = abs(np.cos(peak0.getAzimuthal()) * np.sin(peak0.getScattering()))
         self.assertAlmostEqual(peak0.getIntensity(), 932.24967 * lorentz, delta=1e-2)
-        self.assertAlmostEqual(peak0.getSigmaIntensity(), 29.10343 * lorentz, delta=1e-2)
+        self.assertAlmostEqual(peak0.getSigmaIntensity(), 29.10343 * lorentz, delta=2e-2)
         q_sample = peak0.getQSampleFrame()
         for i in range(3):
             self.assertNotAlmostEqual(q_sample[i], expected_q_sample[i])
@@ -167,7 +167,7 @@ class HB3ADetectorPeaksTest(unittest.TestCase):
         self.assertAlmostEqual(peak0.getK(), 0, places=1)
         self.assertAlmostEqual(peak0.getL(), 6, places=1)
         self.assertAlmostEqual(peak0.getIntensity(), 969.778546, delta=1e-5)
-        self.assertAlmostEqual(peak0.getSigmaIntensity(), 24.776354, delta=1e-5)
+        self.assertAlmostEqual(peak0.getSigmaIntensity(), 24.776354, delta=3e-2)
         self.assertAlmostEqual(peak0.getWavelength(), 1.008)
         self.assertAlmostEqual(peak0.getAzimuthal(), -np.pi, delta=2e-5)
         self.assertAlmostEqual(peak0.getScattering(),
@@ -191,7 +191,7 @@ class HB3ADetectorPeaksTest(unittest.TestCase):
                                delta=1e-2)
         self.assertAlmostEqual(peak0.getSigmaIntensity(),
                                24.776354 * np.sin(np.deg2rad(mtd["data"].getExperimentInfo(0).run()['2theta'].value[0])),
-                               delta=1e-2)
+                               delta=2e-2)
 
         peaks = HB3AIntegrateDetectorPeaks("data", Method="CountsWithFitting", ApplyLorentz=True, OptimizeQVector=True,
                                            ChiSqMax=100)
@@ -200,7 +200,7 @@ class HB3ADetectorPeaksTest(unittest.TestCase):
         peak0 = peaks.getPeak(0)
         lorentz = abs(np.cos(peak0.getAzimuthal()) * np.sin(peak0.getScattering()))
         self.assertAlmostEqual(peak0.getIntensity(), 969.778546 * lorentz, delta=1e-2)
-        self.assertAlmostEqual(peak0.getSigmaIntensity(), 24.776354 * lorentz, delta=1e-2)
+        self.assertAlmostEqual(peak0.getSigmaIntensity(), 24.776354 * lorentz, delta=2e-2)
         q_sample = peak0.getQSampleFrame()
         for i in range(3):
             self.assertNotAlmostEqual(q_sample[i], expected_q_sample[i])

--- a/Framework/PythonInterface/test/python/plugins/algorithms/HB3AIntegrateDetectorPeaksTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/HB3AIntegrateDetectorPeaksTest.py
@@ -122,6 +122,36 @@ class HB3ADetectorPeaksTest(unittest.TestCase):
         self.assertAlmostEqual(peak0.getScattering(),
                                np.deg2rad(data.getExperimentInfo(0).run()['2theta'].value[0]), delta=1e-5)
 
+        q_sample = peak0.getQSampleFrame()
+        expected_q_sample = data.getExperimentInfo(0).sample().getOrientedLattice().qFromHKL(peak0.getHKL())
+        for i in range(3):
+            self.assertAlmostEqual(q_sample[i], expected_q_sample[i])
+
+        # Lorentz correction should scale the intensity by `sin(2theta)`
+        peaks = HB3AIntegrateDetectorPeaks(data, Method="Counts", ApplyLorentz=True, OptimizeQVector=False)
+        self.assertEqual(peaks.getNumberPeaks(), 1)
+
+        peak0 = peaks.getPeak(0)
+        self.assertAlmostEqual(peak0.getScattering(),
+                               np.deg2rad(data.getExperimentInfo(0).run()['2theta'].value[0]), delta=1e-5)
+        self.assertAlmostEqual(peak0.getIntensity(),
+                               932.24967 * np.sin(np.deg2rad(data.getExperimentInfo(0).run()['2theta'].value[0])),
+                               delta=1e-2)
+        self.assertAlmostEqual(peak0.getSigmaIntensity(),
+                               29.10343 * np.sin(np.deg2rad(data.getExperimentInfo(0).run()['2theta'].value[0])),
+                               delta=1e-2)
+
+        peaks = HB3AIntegrateDetectorPeaks(data, Method="Counts", ApplyLorentz=True, OptimizeQVector=True)
+        self.assertEqual(peaks.getNumberPeaks(), 1)
+
+        peak0 = peaks.getPeak(0)
+        lorentz = abs(np.cos(peak0.getAzimuthal()) * np.sin(peak0.getScattering()))
+        self.assertAlmostEqual(peak0.getIntensity(), 932.24967 * lorentz, delta=1e-2)
+        self.assertAlmostEqual(peak0.getSigmaIntensity(), 29.10343 * lorentz, delta=1e-2)
+        q_sample = peak0.getQSampleFrame()
+        for i in range(3):
+            self.assertNotAlmostEqual(q_sample[i], expected_q_sample[i])
+
         DeleteWorkspace(data)
         DeleteWorkspace(peaks)
 
@@ -142,6 +172,38 @@ class HB3ADetectorPeaksTest(unittest.TestCase):
         self.assertAlmostEqual(peak0.getAzimuthal(), -np.pi, delta=2e-5)
         self.assertAlmostEqual(peak0.getScattering(),
                                np.deg2rad(data.getExperimentInfo(0).run()['2theta'].value[0]), delta=1e-5)
+
+        q_sample = peak0.getQSampleFrame()
+        expected_q_sample = data.getExperimentInfo(0).sample().getOrientedLattice().qFromHKL(peak0.getHKL())
+        for i in range(3):
+            self.assertAlmostEqual(q_sample[i], expected_q_sample[i])
+
+        # Lorentz correction should scale the intensity by `sin(2theta)`
+        peaks = HB3AIntegrateDetectorPeaks(data, Method="CountsWithFitting", ApplyLorentz=True, OptimizeQVector=False,
+                                           ChiSqMax=100)
+        self.assertEqual(peaks.getNumberPeaks(), 1)
+
+        peak0 = peaks.getPeak(0)
+        self.assertAlmostEqual(peak0.getScattering(),
+                               np.deg2rad(data.getExperimentInfo(0).run()['2theta'].value[0]), delta=1e-5)
+        self.assertAlmostEqual(peak0.getIntensity(),
+                               969.778546 * np.sin(np.deg2rad(data.getExperimentInfo(0).run()['2theta'].value[0])),
+                               delta=1e-2)
+        self.assertAlmostEqual(peak0.getSigmaIntensity(),
+                               24.776354 * np.sin(np.deg2rad(data.getExperimentInfo(0).run()['2theta'].value[0])),
+                               delta=1e-2)
+
+        peaks = HB3AIntegrateDetectorPeaks(data, Method="CountsWithFitting", ApplyLorentz=True, OptimizeQVector=True,
+                                           ChiSqMax=100)
+        self.assertEqual(peaks.getNumberPeaks(), 1)
+
+        peak0 = peaks.getPeak(0)
+        lorentz = abs(np.cos(peak0.getAzimuthal()) * np.sin(peak0.getScattering()))
+        self.assertAlmostEqual(peak0.getIntensity(), 969.778546 * lorentz, delta=1e-2)
+        self.assertAlmostEqual(peak0.getSigmaIntensity(), 24.776354 * lorentz, delta=1e-2)
+        q_sample = peak0.getQSampleFrame()
+        for i in range(3):
+            self.assertNotAlmostEqual(q_sample[i], expected_q_sample[i])
 
         DeleteWorkspace(data)
         DeleteWorkspace(peaks)

--- a/Framework/PythonInterface/test/python/plugins/algorithms/HB3AIntegrateDetectorPeaksTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/HB3AIntegrateDetectorPeaksTest.py
@@ -106,7 +106,7 @@ class HB3ADetectorPeaksTest(unittest.TestCase):
         DeleteWorkspace(peaks)
 
     def testIntegratePeaksCounts(self):
-        data = HB3AAdjustSampleNorm("HB3A_data.nxs", OutputType="Detector", NormaliseBy="None", ScaleByMotorStep=True)
+        data = HB3AAdjustSampleNorm("HB3A_data.nxs", OutputType="Detector", NormaliseBy="None", ScaleByMotorStep=False)
 
         peaks = HB3AIntegrateDetectorPeaks(data, Method="Counts", ApplyLorentz=False, OptimizeQVector=False)
         self.assertEqual(peaks.getNumberPeaks(), 1)
@@ -115,8 +115,8 @@ class HB3ADetectorPeaksTest(unittest.TestCase):
         self.assertAlmostEqual(peak0.getH(), 0, places=1)
         self.assertAlmostEqual(peak0.getK(), 0, places=1)
         self.assertAlmostEqual(peak0.getL(), 6, places=1)
-        self.assertAlmostEqual(peak0.getIntensity(), 97.05851, delta=1e-5)
-        self.assertAlmostEqual(peak0.getSigmaIntensity(), 8.492146, delta=1e-5)
+        self.assertAlmostEqual(peak0.getIntensity(), 932.24967, delta=1e-5)
+        self.assertAlmostEqual(peak0.getSigmaIntensity(), 29.10343, delta=1e-5)
         self.assertAlmostEqual(peak0.getWavelength(), 1.008)
         self.assertAlmostEqual(peak0.getAzimuthal(), -np.pi, delta=2e-5)
         self.assertAlmostEqual(peak0.getScattering(),
@@ -126,17 +126,18 @@ class HB3ADetectorPeaksTest(unittest.TestCase):
         DeleteWorkspace(peaks)
 
     def testIntegratePeaksCountsWithFitting(self):
-        data = HB3AAdjustSampleNorm("HB3A_data.nxs", OutputType="Detector", NormaliseBy="None", ScaleByMotorStep=True)
+        data = HB3AAdjustSampleNorm("HB3A_data.nxs", OutputType="Detector", NormaliseBy="None", ScaleByMotorStep=False)
 
-        peaks = HB3AIntegrateDetectorPeaks(data, Method="CountsWithFitting", ApplyLorentz=False, OptimizeQVector=False)
+        peaks = HB3AIntegrateDetectorPeaks(data, Method="CountsWithFitting", ApplyLorentz=False, OptimizeQVector=False,
+                                           ChiSqMax=100)
         self.assertEqual(peaks.getNumberPeaks(), 1)
 
         peak0 = peaks.getPeak(0)
         self.assertAlmostEqual(peak0.getH(), 0, places=1)
         self.assertAlmostEqual(peak0.getK(), 0, places=1)
         self.assertAlmostEqual(peak0.getL(), 6, places=1)
-        self.assertAlmostEqual(peak0.getIntensity(), 96.27564, delta=1e-5)
-        self.assertAlmostEqual(peak0.getSigmaIntensity(), 8.193698, delta=1e-5)
+        self.assertAlmostEqual(peak0.getIntensity(), 969.778546, delta=1e-5)
+        self.assertAlmostEqual(peak0.getSigmaIntensity(), 24.776354, delta=1e-5)
         self.assertAlmostEqual(peak0.getWavelength(), 1.008)
         self.assertAlmostEqual(peak0.getAzimuthal(), -np.pi, delta=2e-5)
         self.assertAlmostEqual(peak0.getScattering(),

--- a/Framework/PythonInterface/test/python/plugins/algorithms/HB3AIntegrateDetectorPeaksTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/HB3AIntegrateDetectorPeaksTest.py
@@ -6,25 +6,31 @@
 # SPDX - License - Identifier: GPL - 3.0 +
 import unittest
 import numpy as np
-from mantid.simpleapi import HB3AIntegrateDetectorPeaks, HB3AAdjustSampleNorm, DeleteWorkspace
+from mantid.simpleapi import HB3AIntegrateDetectorPeaks, HB3AAdjustSampleNorm, DeleteWorkspace, mtd
 
 
 class HB3ADetectorPeaksTest(unittest.TestCase):
 
-    def testIntegratePeaksFitted(self):
-        data = HB3AAdjustSampleNorm("HB3A_data.nxs", OutputType="Detector", NormaliseBy="None")
+    @classmethod
+    def setUpClass(cls):
+        HB3AAdjustSampleNorm("HB3A_data.nxs", OutputType="Detector", NormaliseBy="None", OutputWorkspace="data")
 
+    @classmethod
+    def tearDownClass(cls):
+        DeleteWorkspace("data")
+
+    def testIntegratePeaksFitted(self):
         # ChiSq is larger than maximum
-        peaks = HB3AIntegrateDetectorPeaks(data, ChiSqMax=10, ApplyLorentz=False, OptimizeQVector=False)
+        peaks = HB3AIntegrateDetectorPeaks("data", ChiSqMax=10, ApplyLorentz=False, OptimizeQVector=False)
         self.assertEqual(peaks.getNumberPeaks(), 0)
 
-        # Singal/Noise ratio is lower than requestsd
-        peaks = HB3AIntegrateDetectorPeaks(data, ChiSqMax=100, SignalNoiseMin=100,
+        # Signal/Noise ratio is lower than requested
+        peaks = HB3AIntegrateDetectorPeaks("data", ChiSqMax=100, SignalNoiseMin=100,
                                            ApplyLorentz=False, OptimizeQVector=False)
         self.assertEqual(peaks.getNumberPeaks(), 0)
 
         # Actually fit peak in this one
-        peaks = HB3AIntegrateDetectorPeaks(data, ChiSqMax=100, ApplyLorentz=False, OptimizeQVector=False)
+        peaks = HB3AIntegrateDetectorPeaks("data", ChiSqMax=100, ApplyLorentz=False, OptimizeQVector=False)
         self.assertEqual(peaks.getNumberPeaks(), 1)
 
         peak0 = peaks.getPeak(0)
@@ -36,15 +42,15 @@ class HB3ADetectorPeaksTest(unittest.TestCase):
         self.assertAlmostEqual(peak0.getWavelength(), 1.008)
         self.assertAlmostEqual(peak0.getAzimuthal(), -np.pi, delta=2e-5)
         self.assertAlmostEqual(peak0.getScattering(),
-                               np.deg2rad(data.getExperimentInfo(0).run()['2theta'].value[0]), delta=1e-5)
+                               np.deg2rad(mtd["data"].getExperimentInfo(0).run()['2theta'].value[0]), delta=1e-5)
 
         q_sample = peak0.getQSampleFrame()
-        expected_q_sample = data.getExperimentInfo(0).sample().getOrientedLattice().qFromHKL(peak0.getHKL())
+        expected_q_sample = mtd["data"].getExperimentInfo(0).sample().getOrientedLattice().qFromHKL(peak0.getHKL())
         for i in range(3):
             self.assertAlmostEqual(q_sample[i], expected_q_sample[i])
 
         # Try with larger ROI, should get slightly different intensity
-        peaks = HB3AIntegrateDetectorPeaks(data, ChiSqMax=100, LowerLeft=[0,0], UpperRight=[512,512],
+        peaks = HB3AIntegrateDetectorPeaks("data", ChiSqMax=100, LowerLeft=[0,0], UpperRight=[512,512],
                                            ApplyLorentz=False, OptimizeQVector=False)
         self.assertEqual(peaks.getNumberPeaks(), 1)
 
@@ -57,30 +63,30 @@ class HB3ADetectorPeaksTest(unittest.TestCase):
         self.assertAlmostEqual(peak0.getWavelength(), 1.008)
         self.assertAlmostEqual(peak0.getAzimuthal(), -np.pi, delta=2e-5)
         self.assertAlmostEqual(peak0.getScattering(),
-                               np.deg2rad(data.getExperimentInfo(0).run()['2theta'].value[0]), delta=1e-5)
+                               np.deg2rad(mtd["data"].getExperimentInfo(0).run()['2theta'].value[0]), delta=1e-5)
 
         q_sample = peak0.getQSampleFrame()
         for i in range(3):
             self.assertAlmostEqual(q_sample[i], expected_q_sample[i])
 
         # Lorentz correction should scale the intensity by `sin(2theta)`
-        peaks = HB3AIntegrateDetectorPeaks(data, ChiSqMax=100, ApplyLorentz=True, OptimizeQVector=False)
+        peaks = HB3AIntegrateDetectorPeaks("data", ChiSqMax=100, ApplyLorentz=True, OptimizeQVector=False)
         self.assertEqual(peaks.getNumberPeaks(), 1)
 
         peak0 = peaks.getPeak(0)
         self.assertAlmostEqual(peak0.getScattering(),
-                               np.deg2rad(data.getExperimentInfo(0).run()['2theta'].value[0]), delta=1e-5)
+                               np.deg2rad(mtd["data"].getExperimentInfo(0).run()['2theta'].value[0]), delta=1e-5)
         self.assertAlmostEqual(peak0.getIntensity(),
-                               961.6164 * np.sin(np.deg2rad(data.getExperimentInfo(0).run()['2theta'].value[0])),
+                               961.6164 * np.sin(np.deg2rad(mtd["data"].getExperimentInfo(0).run()['2theta'].value[0])),
                                delta=1e-2)
         self.assertAlmostEqual(peak0.getSigmaIntensity(),
-                               10.479567 * np.sin(np.deg2rad(data.getExperimentInfo(0).run()['2theta'].value[0])),
+                               10.479567 * np.sin(np.deg2rad(mtd["data"].getExperimentInfo(0).run()['2theta'].value[0])),
                                delta=1e-2)
 
         # Optimize Q vector, will change Q-sample but the integration
         # should be the same except the Lorentz correction since the
         # scattering angle is changed
-        peaks = HB3AIntegrateDetectorPeaks(data, ChiSqMax=100, ApplyLorentz=True, OptimizeQVector=True)
+        peaks = HB3AIntegrateDetectorPeaks("data", ChiSqMax=100, ApplyLorentz=True, OptimizeQVector=True)
         self.assertEqual(peaks.getNumberPeaks(), 1)
 
         peak0 = peaks.getPeak(0)
@@ -92,7 +98,7 @@ class HB3ADetectorPeaksTest(unittest.TestCase):
             self.assertNotAlmostEqual(q_sample[i], expected_q_sample[i])
 
         # Try StartX and EndX, should just change the peak intensity slightly
-        peaks = HB3AIntegrateDetectorPeaks(data, ChiSqMax=100, ApplyLorentz=False, OptimizeQVector=False,
+        peaks = HB3AIntegrateDetectorPeaks("data", ChiSqMax=100, ApplyLorentz=False, OptimizeQVector=False,
                                            StartX=12.6, EndX=100)
         self.assertEqual(peaks.getNumberPeaks(), 1)
         peak0 = peaks.getPeak(0)
@@ -102,13 +108,10 @@ class HB3ADetectorPeaksTest(unittest.TestCase):
         self.assertAlmostEqual(peak0.getIntensity(), 960.977625, delta=1e-5)
         self.assertAlmostEqual(peak0.getSigmaIntensity(), 10.621905, delta=1e-5)
 
-        DeleteWorkspace(data)
         DeleteWorkspace(peaks)
 
     def testIntegratePeaksCounts(self):
-        data = HB3AAdjustSampleNorm("HB3A_data.nxs", OutputType="Detector", NormaliseBy="None", ScaleByMotorStep=False)
-
-        peaks = HB3AIntegrateDetectorPeaks(data, Method="Counts", ApplyLorentz=False, OptimizeQVector=False)
+        peaks = HB3AIntegrateDetectorPeaks("data", Method="Counts", ApplyLorentz=False, OptimizeQVector=False)
         self.assertEqual(peaks.getNumberPeaks(), 1)
 
         peak0 = peaks.getPeak(0)
@@ -120,28 +123,28 @@ class HB3ADetectorPeaksTest(unittest.TestCase):
         self.assertAlmostEqual(peak0.getWavelength(), 1.008)
         self.assertAlmostEqual(peak0.getAzimuthal(), -np.pi, delta=2e-5)
         self.assertAlmostEqual(peak0.getScattering(),
-                               np.deg2rad(data.getExperimentInfo(0).run()['2theta'].value[0]), delta=1e-5)
+                               np.deg2rad(mtd["data"].getExperimentInfo(0).run()['2theta'].value[0]), delta=1e-5)
 
         q_sample = peak0.getQSampleFrame()
-        expected_q_sample = data.getExperimentInfo(0).sample().getOrientedLattice().qFromHKL(peak0.getHKL())
+        expected_q_sample = mtd["data"].getExperimentInfo(0).sample().getOrientedLattice().qFromHKL(peak0.getHKL())
         for i in range(3):
             self.assertAlmostEqual(q_sample[i], expected_q_sample[i])
 
         # Lorentz correction should scale the intensity by `sin(2theta)`
-        peaks = HB3AIntegrateDetectorPeaks(data, Method="Counts", ApplyLorentz=True, OptimizeQVector=False)
+        peaks = HB3AIntegrateDetectorPeaks("data", Method="Counts", ApplyLorentz=True, OptimizeQVector=False)
         self.assertEqual(peaks.getNumberPeaks(), 1)
 
         peak0 = peaks.getPeak(0)
         self.assertAlmostEqual(peak0.getScattering(),
-                               np.deg2rad(data.getExperimentInfo(0).run()['2theta'].value[0]), delta=1e-5)
+                               np.deg2rad(mtd["data"].getExperimentInfo(0).run()['2theta'].value[0]), delta=1e-5)
         self.assertAlmostEqual(peak0.getIntensity(),
-                               932.24967 * np.sin(np.deg2rad(data.getExperimentInfo(0).run()['2theta'].value[0])),
+                               932.24967 * np.sin(np.deg2rad(mtd["data"].getExperimentInfo(0).run()['2theta'].value[0])),
                                delta=1e-2)
         self.assertAlmostEqual(peak0.getSigmaIntensity(),
-                               29.10343 * np.sin(np.deg2rad(data.getExperimentInfo(0).run()['2theta'].value[0])),
+                               29.10343 * np.sin(np.deg2rad(mtd["data"].getExperimentInfo(0).run()['2theta'].value[0])),
                                delta=1e-2)
 
-        peaks = HB3AIntegrateDetectorPeaks(data, Method="Counts", ApplyLorentz=True, OptimizeQVector=True)
+        peaks = HB3AIntegrateDetectorPeaks("data", Method="Counts", ApplyLorentz=True, OptimizeQVector=True)
         self.assertEqual(peaks.getNumberPeaks(), 1)
 
         peak0 = peaks.getPeak(0)
@@ -152,13 +155,10 @@ class HB3ADetectorPeaksTest(unittest.TestCase):
         for i in range(3):
             self.assertNotAlmostEqual(q_sample[i], expected_q_sample[i])
 
-        DeleteWorkspace(data)
         DeleteWorkspace(peaks)
 
     def testIntegratePeaksCountsWithFitting(self):
-        data = HB3AAdjustSampleNorm("HB3A_data.nxs", OutputType="Detector", NormaliseBy="None", ScaleByMotorStep=False)
-
-        peaks = HB3AIntegrateDetectorPeaks(data, Method="CountsWithFitting", ApplyLorentz=False, OptimizeQVector=False,
+        peaks = HB3AIntegrateDetectorPeaks("data", Method="CountsWithFitting", ApplyLorentz=False, OptimizeQVector=False,
                                            ChiSqMax=100)
         self.assertEqual(peaks.getNumberPeaks(), 1)
 
@@ -171,29 +171,29 @@ class HB3ADetectorPeaksTest(unittest.TestCase):
         self.assertAlmostEqual(peak0.getWavelength(), 1.008)
         self.assertAlmostEqual(peak0.getAzimuthal(), -np.pi, delta=2e-5)
         self.assertAlmostEqual(peak0.getScattering(),
-                               np.deg2rad(data.getExperimentInfo(0).run()['2theta'].value[0]), delta=1e-5)
+                               np.deg2rad(mtd["data"].getExperimentInfo(0).run()['2theta'].value[0]), delta=1e-5)
 
         q_sample = peak0.getQSampleFrame()
-        expected_q_sample = data.getExperimentInfo(0).sample().getOrientedLattice().qFromHKL(peak0.getHKL())
+        expected_q_sample = mtd["data"].getExperimentInfo(0).sample().getOrientedLattice().qFromHKL(peak0.getHKL())
         for i in range(3):
             self.assertAlmostEqual(q_sample[i], expected_q_sample[i])
 
         # Lorentz correction should scale the intensity by `sin(2theta)`
-        peaks = HB3AIntegrateDetectorPeaks(data, Method="CountsWithFitting", ApplyLorentz=True, OptimizeQVector=False,
+        peaks = HB3AIntegrateDetectorPeaks("data", Method="CountsWithFitting", ApplyLorentz=True, OptimizeQVector=False,
                                            ChiSqMax=100)
         self.assertEqual(peaks.getNumberPeaks(), 1)
 
         peak0 = peaks.getPeak(0)
         self.assertAlmostEqual(peak0.getScattering(),
-                               np.deg2rad(data.getExperimentInfo(0).run()['2theta'].value[0]), delta=1e-5)
+                               np.deg2rad(mtd["data"].getExperimentInfo(0).run()['2theta'].value[0]), delta=1e-5)
         self.assertAlmostEqual(peak0.getIntensity(),
-                               969.778546 * np.sin(np.deg2rad(data.getExperimentInfo(0).run()['2theta'].value[0])),
+                               969.778546 * np.sin(np.deg2rad(mtd["data"].getExperimentInfo(0).run()['2theta'].value[0])),
                                delta=1e-2)
         self.assertAlmostEqual(peak0.getSigmaIntensity(),
-                               24.776354 * np.sin(np.deg2rad(data.getExperimentInfo(0).run()['2theta'].value[0])),
+                               24.776354 * np.sin(np.deg2rad(mtd["data"].getExperimentInfo(0).run()['2theta'].value[0])),
                                delta=1e-2)
 
-        peaks = HB3AIntegrateDetectorPeaks(data, Method="CountsWithFitting", ApplyLorentz=True, OptimizeQVector=True,
+        peaks = HB3AIntegrateDetectorPeaks("data", Method="CountsWithFitting", ApplyLorentz=True, OptimizeQVector=True,
                                            ChiSqMax=100)
         self.assertEqual(peaks.getNumberPeaks(), 1)
 
@@ -205,7 +205,6 @@ class HB3ADetectorPeaksTest(unittest.TestCase):
         for i in range(3):
             self.assertNotAlmostEqual(q_sample[i], expected_q_sample[i])
 
-        DeleteWorkspace(data)
         DeleteWorkspace(peaks)
 
 

--- a/Framework/PythonInterface/test/python/plugins/algorithms/HB3AIntegrateDetectorPeaksTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/HB3AIntegrateDetectorPeaksTest.py
@@ -20,17 +20,18 @@ class HB3ADetectorPeaksTest(unittest.TestCase):
         DeleteWorkspace("data")
 
     def testIntegratePeaksFitted(self):
+        data = mtd["data"]
         # ChiSq is larger than maximum
-        peaks = HB3AIntegrateDetectorPeaks("data", ChiSqMax=10, ApplyLorentz=False, OptimizeQVector=False)
+        peaks = HB3AIntegrateDetectorPeaks(data, ChiSqMax=10, ApplyLorentz=False, OptimizeQVector=False)
         self.assertEqual(peaks.getNumberPeaks(), 0)
 
         # Signal/Noise ratio is lower than requested
-        peaks = HB3AIntegrateDetectorPeaks("data", ChiSqMax=100, SignalNoiseMin=100,
+        peaks = HB3AIntegrateDetectorPeaks(data, ChiSqMax=100, SignalNoiseMin=100,
                                            ApplyLorentz=False, OptimizeQVector=False)
         self.assertEqual(peaks.getNumberPeaks(), 0)
 
         # Actually fit peak in this one
-        peaks = HB3AIntegrateDetectorPeaks("data", ChiSqMax=100, ApplyLorentz=False, OptimizeQVector=False)
+        peaks = HB3AIntegrateDetectorPeaks(data, ChiSqMax=100, ApplyLorentz=False, OptimizeQVector=False)
         self.assertEqual(peaks.getNumberPeaks(), 1)
 
         peak0 = peaks.getPeak(0)
@@ -42,15 +43,15 @@ class HB3ADetectorPeaksTest(unittest.TestCase):
         self.assertAlmostEqual(peak0.getWavelength(), 1.008)
         self.assertAlmostEqual(peak0.getAzimuthal(), -np.pi, delta=2e-5)
         self.assertAlmostEqual(peak0.getScattering(),
-                               np.deg2rad(mtd["data"].getExperimentInfo(0).run()['2theta'].value[0]), delta=1e-5)
+                               np.deg2rad(data.getExperimentInfo(0).run()['2theta'].value[0]), delta=1e-5)
 
         q_sample = peak0.getQSampleFrame()
-        expected_q_sample = mtd["data"].getExperimentInfo(0).sample().getOrientedLattice().qFromHKL(peak0.getHKL())
+        expected_q_sample = data.getExperimentInfo(0).sample().getOrientedLattice().qFromHKL(peak0.getHKL())
         for i in range(3):
             self.assertAlmostEqual(q_sample[i], expected_q_sample[i])
 
         # Try with larger ROI, should get slightly different intensity
-        peaks = HB3AIntegrateDetectorPeaks("data", ChiSqMax=100, LowerLeft=[0,0], UpperRight=[512,512],
+        peaks = HB3AIntegrateDetectorPeaks(data, ChiSqMax=100, LowerLeft=[0,0], UpperRight=[512,512],
                                            ApplyLorentz=False, OptimizeQVector=False)
         self.assertEqual(peaks.getNumberPeaks(), 1)
 
@@ -63,30 +64,30 @@ class HB3ADetectorPeaksTest(unittest.TestCase):
         self.assertAlmostEqual(peak0.getWavelength(), 1.008)
         self.assertAlmostEqual(peak0.getAzimuthal(), -np.pi, delta=2e-5)
         self.assertAlmostEqual(peak0.getScattering(),
-                               np.deg2rad(mtd["data"].getExperimentInfo(0).run()['2theta'].value[0]), delta=1e-5)
+                               np.deg2rad(data.getExperimentInfo(0).run()['2theta'].value[0]), delta=1e-5)
 
         q_sample = peak0.getQSampleFrame()
         for i in range(3):
             self.assertAlmostEqual(q_sample[i], expected_q_sample[i])
 
         # Lorentz correction should scale the intensity by `sin(2theta)`
-        peaks = HB3AIntegrateDetectorPeaks("data", ChiSqMax=100, ApplyLorentz=True, OptimizeQVector=False)
+        peaks = HB3AIntegrateDetectorPeaks(data, ChiSqMax=100, ApplyLorentz=True, OptimizeQVector=False)
         self.assertEqual(peaks.getNumberPeaks(), 1)
 
         peak0 = peaks.getPeak(0)
         self.assertAlmostEqual(peak0.getScattering(),
-                               np.deg2rad(mtd["data"].getExperimentInfo(0).run()['2theta'].value[0]), delta=1e-5)
+                               np.deg2rad(data.getExperimentInfo(0).run()['2theta'].value[0]), delta=1e-5)
         self.assertAlmostEqual(peak0.getIntensity(),
-                               961.6164 * np.sin(np.deg2rad(mtd["data"].getExperimentInfo(0).run()['2theta'].value[0])),
+                               961.6164 * np.sin(np.deg2rad(data.getExperimentInfo(0).run()['2theta'].value[0])),
                                delta=1e-2)
         self.assertAlmostEqual(peak0.getSigmaIntensity(),
-                               10.479567 * np.sin(np.deg2rad(mtd["data"].getExperimentInfo(0).run()['2theta'].value[0])),
+                               10.479567 * np.sin(np.deg2rad(data.getExperimentInfo(0).run()['2theta'].value[0])),
                                delta=2e-2)
 
         # Optimize Q vector, will change Q-sample but the integration
         # should be the same except the Lorentz correction since the
         # scattering angle is changed
-        peaks = HB3AIntegrateDetectorPeaks("data", ChiSqMax=100, ApplyLorentz=True, OptimizeQVector=True)
+        peaks = HB3AIntegrateDetectorPeaks(data, ChiSqMax=100, ApplyLorentz=True, OptimizeQVector=True)
         self.assertEqual(peaks.getNumberPeaks(), 1)
 
         peak0 = peaks.getPeak(0)
@@ -98,7 +99,7 @@ class HB3ADetectorPeaksTest(unittest.TestCase):
             self.assertNotAlmostEqual(q_sample[i], expected_q_sample[i])
 
         # Try StartX and EndX, should just change the peak intensity slightly
-        peaks = HB3AIntegrateDetectorPeaks("data", ChiSqMax=100, ApplyLorentz=False, OptimizeQVector=False,
+        peaks = HB3AIntegrateDetectorPeaks(data, ChiSqMax=100, ApplyLorentz=False, OptimizeQVector=False,
                                            StartX=12.6, EndX=100)
         self.assertEqual(peaks.getNumberPeaks(), 1)
         peak0 = peaks.getPeak(0)
@@ -111,7 +112,8 @@ class HB3ADetectorPeaksTest(unittest.TestCase):
         DeleteWorkspace(peaks)
 
     def testIntegratePeaksCounts(self):
-        peaks = HB3AIntegrateDetectorPeaks("data", Method="Counts", ApplyLorentz=False, OptimizeQVector=False)
+        data = mtd["data"]
+        peaks = HB3AIntegrateDetectorPeaks(data, Method="Counts", ApplyLorentz=False, OptimizeQVector=False)
         self.assertEqual(peaks.getNumberPeaks(), 1)
 
         peak0 = peaks.getPeak(0)
@@ -123,28 +125,28 @@ class HB3ADetectorPeaksTest(unittest.TestCase):
         self.assertAlmostEqual(peak0.getWavelength(), 1.008)
         self.assertAlmostEqual(peak0.getAzimuthal(), -np.pi, delta=2e-5)
         self.assertAlmostEqual(peak0.getScattering(),
-                               np.deg2rad(mtd["data"].getExperimentInfo(0).run()['2theta'].value[0]), delta=1e-5)
+                               np.deg2rad(data.getExperimentInfo(0).run()['2theta'].value[0]), delta=1e-5)
 
         q_sample = peak0.getQSampleFrame()
-        expected_q_sample = mtd["data"].getExperimentInfo(0).sample().getOrientedLattice().qFromHKL(peak0.getHKL())
+        expected_q_sample = data.getExperimentInfo(0).sample().getOrientedLattice().qFromHKL(peak0.getHKL())
         for i in range(3):
             self.assertAlmostEqual(q_sample[i], expected_q_sample[i])
 
         # Lorentz correction should scale the intensity by `sin(2theta)`
-        peaks = HB3AIntegrateDetectorPeaks("data", Method="Counts", ApplyLorentz=True, OptimizeQVector=False)
+        peaks = HB3AIntegrateDetectorPeaks(data, Method="Counts", ApplyLorentz=True, OptimizeQVector=False)
         self.assertEqual(peaks.getNumberPeaks(), 1)
 
         peak0 = peaks.getPeak(0)
         self.assertAlmostEqual(peak0.getScattering(),
-                               np.deg2rad(mtd["data"].getExperimentInfo(0).run()['2theta'].value[0]), delta=1e-5)
+                               np.deg2rad(data.getExperimentInfo(0).run()['2theta'].value[0]), delta=1e-5)
         self.assertAlmostEqual(peak0.getIntensity(),
-                               932.24967 * np.sin(np.deg2rad(mtd["data"].getExperimentInfo(0).run()['2theta'].value[0])),
+                               932.24967 * np.sin(np.deg2rad(data.getExperimentInfo(0).run()['2theta'].value[0])),
                                delta=1e-2)
         self.assertAlmostEqual(peak0.getSigmaIntensity(),
-                               29.10343 * np.sin(np.deg2rad(mtd["data"].getExperimentInfo(0).run()['2theta'].value[0])),
+                               29.10343 * np.sin(np.deg2rad(data.getExperimentInfo(0).run()['2theta'].value[0])),
                                delta=2e-2)
 
-        peaks = HB3AIntegrateDetectorPeaks("data", Method="Counts", ApplyLorentz=True, OptimizeQVector=True)
+        peaks = HB3AIntegrateDetectorPeaks(data, Method="Counts", ApplyLorentz=True, OptimizeQVector=True)
         self.assertEqual(peaks.getNumberPeaks(), 1)
 
         peak0 = peaks.getPeak(0)
@@ -158,7 +160,8 @@ class HB3ADetectorPeaksTest(unittest.TestCase):
         DeleteWorkspace(peaks)
 
     def testIntegratePeaksCountsWithFitting(self):
-        peaks = HB3AIntegrateDetectorPeaks("data", Method="CountsWithFitting", ApplyLorentz=False, OptimizeQVector=False,
+        data = mtd["data"]
+        peaks = HB3AIntegrateDetectorPeaks(data, Method="CountsWithFitting", ApplyLorentz=False, OptimizeQVector=False,
                                            ChiSqMax=100)
         self.assertEqual(peaks.getNumberPeaks(), 1)
 
@@ -171,29 +174,29 @@ class HB3ADetectorPeaksTest(unittest.TestCase):
         self.assertAlmostEqual(peak0.getWavelength(), 1.008)
         self.assertAlmostEqual(peak0.getAzimuthal(), -np.pi, delta=2e-5)
         self.assertAlmostEqual(peak0.getScattering(),
-                               np.deg2rad(mtd["data"].getExperimentInfo(0).run()['2theta'].value[0]), delta=1e-5)
+                               np.deg2rad(data.getExperimentInfo(0).run()['2theta'].value[0]), delta=1e-5)
 
         q_sample = peak0.getQSampleFrame()
-        expected_q_sample = mtd["data"].getExperimentInfo(0).sample().getOrientedLattice().qFromHKL(peak0.getHKL())
+        expected_q_sample = data.getExperimentInfo(0).sample().getOrientedLattice().qFromHKL(peak0.getHKL())
         for i in range(3):
             self.assertAlmostEqual(q_sample[i], expected_q_sample[i])
 
         # Lorentz correction should scale the intensity by `sin(2theta)`
-        peaks = HB3AIntegrateDetectorPeaks("data", Method="CountsWithFitting", ApplyLorentz=True, OptimizeQVector=False,
+        peaks = HB3AIntegrateDetectorPeaks(data, Method="CountsWithFitting", ApplyLorentz=True, OptimizeQVector=False,
                                            ChiSqMax=100)
         self.assertEqual(peaks.getNumberPeaks(), 1)
 
         peak0 = peaks.getPeak(0)
         self.assertAlmostEqual(peak0.getScattering(),
-                               np.deg2rad(mtd["data"].getExperimentInfo(0).run()['2theta'].value[0]), delta=1e-5)
+                               np.deg2rad(data.getExperimentInfo(0).run()['2theta'].value[0]), delta=1e-5)
         self.assertAlmostEqual(peak0.getIntensity(),
-                               969.778546 * np.sin(np.deg2rad(mtd["data"].getExperimentInfo(0).run()['2theta'].value[0])),
+                               969.778546 * np.sin(np.deg2rad(data.getExperimentInfo(0).run()['2theta'].value[0])),
                                delta=1e-2)
         self.assertAlmostEqual(peak0.getSigmaIntensity(),
-                               24.776354 * np.sin(np.deg2rad(mtd["data"].getExperimentInfo(0).run()['2theta'].value[0])),
+                               24.776354 * np.sin(np.deg2rad(data.getExperimentInfo(0).run()['2theta'].value[0])),
                                delta=2e-2)
 
-        peaks = HB3AIntegrateDetectorPeaks("data", Method="CountsWithFitting", ApplyLorentz=True, OptimizeQVector=True,
+        peaks = HB3AIntegrateDetectorPeaks(data, Method="CountsWithFitting", ApplyLorentz=True, OptimizeQVector=True,
                                            ChiSqMax=100)
         self.assertEqual(peaks.getNumberPeaks(), 1)
 

--- a/Framework/PythonInterface/test/python/plugins/algorithms/HB3AIntegrateDetectorPeaksTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/HB3AIntegrateDetectorPeaksTest.py
@@ -11,7 +11,7 @@ from mantid.simpleapi import HB3AIntegrateDetectorPeaks, HB3AAdjustSampleNorm, D
 
 class HB3ADetectorPeaksTest(unittest.TestCase):
 
-    def testIntegratePeaks(self):
+    def testIntegratePeaksFitted(self):
         data = HB3AAdjustSampleNorm("HB3A_data.nxs", OutputType="Detector", NormaliseBy="None")
 
         # ChiSq is larger than maximum
@@ -101,6 +101,46 @@ class HB3ADetectorPeaksTest(unittest.TestCase):
         self.assertAlmostEqual(peak0.getL(), 6, places=1)
         self.assertAlmostEqual(peak0.getIntensity(), 960.977625, delta=1e-5)
         self.assertAlmostEqual(peak0.getSigmaIntensity(), 10.621905, delta=1e-5)
+
+        DeleteWorkspace(data)
+        DeleteWorkspace(peaks)
+
+    def testIntegratePeaksCounts(self):
+        data = HB3AAdjustSampleNorm("HB3A_data.nxs", OutputType="Detector", NormaliseBy="None", ScaleByMotorStep=True)
+
+        peaks = HB3AIntegrateDetectorPeaks(data, Method="Counts", ApplyLorentz=False, OptimizeQVector=False)
+        self.assertEqual(peaks.getNumberPeaks(), 1)
+
+        peak0 = peaks.getPeak(0)
+        self.assertAlmostEqual(peak0.getH(), 0, places=1)
+        self.assertAlmostEqual(peak0.getK(), 0, places=1)
+        self.assertAlmostEqual(peak0.getL(), 6, places=1)
+        self.assertAlmostEqual(peak0.getIntensity(), 97.05851, delta=1e-5)
+        self.assertAlmostEqual(peak0.getSigmaIntensity(), 8.492146, delta=1e-5)
+        self.assertAlmostEqual(peak0.getWavelength(), 1.008)
+        self.assertAlmostEqual(peak0.getAzimuthal(), -np.pi, delta=2e-5)
+        self.assertAlmostEqual(peak0.getScattering(),
+                               np.deg2rad(data.getExperimentInfo(0).run()['2theta'].value[0]), delta=1e-5)
+
+        DeleteWorkspace(data)
+        DeleteWorkspace(peaks)
+
+    def testIntegratePeaksCountsWithFitting(self):
+        data = HB3AAdjustSampleNorm("HB3A_data.nxs", OutputType="Detector", NormaliseBy="None", ScaleByMotorStep=True)
+
+        peaks = HB3AIntegrateDetectorPeaks(data, Method="CountsWithFitting", ApplyLorentz=False, OptimizeQVector=False)
+        self.assertEqual(peaks.getNumberPeaks(), 1)
+
+        peak0 = peaks.getPeak(0)
+        self.assertAlmostEqual(peak0.getH(), 0, places=1)
+        self.assertAlmostEqual(peak0.getK(), 0, places=1)
+        self.assertAlmostEqual(peak0.getL(), 6, places=1)
+        self.assertAlmostEqual(peak0.getIntensity(), 96.27564, delta=1e-5)
+        self.assertAlmostEqual(peak0.getSigmaIntensity(), 8.193698, delta=1e-5)
+        self.assertAlmostEqual(peak0.getWavelength(), 1.008)
+        self.assertAlmostEqual(peak0.getAzimuthal(), -np.pi, delta=2e-5)
+        self.assertAlmostEqual(peak0.getScattering(),
+                               np.deg2rad(data.getExperimentInfo(0).run()['2theta'].value[0]), delta=1e-5)
 
         DeleteWorkspace(data)
         DeleteWorkspace(peaks)

--- a/docs/source/algorithms/HB3AIntegrateDetectorPeaks-v1.rst
+++ b/docs/source/algorithms/HB3AIntegrateDetectorPeaks-v1.rst
@@ -21,7 +21,7 @@ detector scan, either omega or chi in degrees.
 There are three different methods for integrating the input workspace:
 simple counts summation, simple counts summation with fitted background,
 and a fitted model, which are described in detail at
-:ref:`HFIR Single Crystal Reduction`.
+:ref:`HFIR Single Crystal Reduction <interface-HFIR-Single-Crystal-Reduction>`.
 
 When using `Method=Counts`, the background is estimated by averaging
 data from the first and last scans. The number of scans to include
@@ -33,7 +33,7 @@ just like `Method=Fitting`. However, the peak intensity is instead
 approximated by summing the detector counts over a specific set of
 measurements that are defined by the motor positions in the range of
 :math:`\pm \frac{N}{2} \text{FWHM}`, where `N` is controlled with the
-`NumIntegrationPts` option. The background is removed over the same
+`WidthScale` option. The background is removed over the same
 range using the fitted flat background.
 
 For `Method=Fitted`, the reduced workspace is fitted using

--- a/docs/source/algorithms/HB3AIntegrateDetectorPeaks-v1.rst
+++ b/docs/source/algorithms/HB3AIntegrateDetectorPeaks-v1.rst
@@ -14,15 +14,36 @@ reduction workflow, using :ref:`HB3AAdjustSampleNorm
 <algm-HB3AAdjustSampleNorm>` with `OutputType=Detector` which can be
 seen below in the example usage.
 
-This will reduced the input workspace using the region of interest
+This will reduce the input workspace using the region of interest
 provided to create a 1-dimension workspace with an axis that is the
-detector scan, either omega or chi in degrees. This reduced workspace
-is then fitted using :ref:`Fit <algm-Fit>` with a :ref:`flat
-background <func-FlatBackground>` and a :ref:`Gaussian
-<func-Gaussian>`, then the area of the Gaussian is used as the peak
-intensity and added to the output workspace. An optionally fitting
-range of the scan axis can be provided with `StartX` and `EndX` in
-degrees.
+detector scan, either omega or chi in degrees.
+
+There are three different methods for integrating the input workspace:
+simple counts summation, simple counts summation with fitted background,
+and a fitted model, which are described in detail at
+:ref:`HFIR Single Crystal Reduction`.
+
+When using `Method=Counts`, the background is estimated by averaging
+data from the first and last scans. The number of scans to include
+in the background estimation can be specified with `NumBackgroundPts`.
+
+For `Method=CountsWithFitting`, the input is fit to a :ref:`Gaussian
+<func-Gaussian>` with a :ref:`flat background <func-FlatBackground>`,
+just like `Method=Fitting`. However, the peak intensity is instead
+approximated by summing the detector counts over a specific set of
+measurements that are defined by the motor positions in the range of
+:math:`\pm \frac{N}{2} \text{FWHM}`, where `N` is controlled with the
+`NumIntegrationPts` option. The background is removed over the same
+range using the fitted flat background.
+
+For `Method=Fitted`, the reduced workspace is fitted using
+:ref:`Fit <algm-Fit>` with a :ref:`flat background <func-FlatBackground>`
+and a :ref:`Gaussian <func-Gaussian>`, then the area of the Gaussian is
+used as the peak intensity and added to the output workspace.
+
+An optional fitting range of the scan axis can be provided with
+`StartX` and `EndX` in degrees, which is applicable for the
+`CountsWithFitting` and `Fitted` methods.
 
 The `OptimizeQVector` option will convert the input data into Q and
 use :ref:`CentroidPeaksdMD <algm-CentroidPeaksMD>` to find the

--- a/docs/source/interfaces/diffraction/HFIR Single Crystal Reduction.rst
+++ b/docs/source/interfaces/diffraction/HFIR Single Crystal Reduction.rst
@@ -1,3 +1,5 @@
+.. _interface-HFIR-Single-Crystal-Reduction:
+
 HFIR Single Crystal Reduction Interface
 =======================================
 

--- a/docs/source/release/v6.2.0/diffraction.rst
+++ b/docs/source/release/v6.2.0/diffraction.rst
@@ -36,6 +36,7 @@ New features
 - New algorithm :ref:`ApplyInstrumentToPeaks <algm-ApplyInstrumentToPeaks>` to update the instrument of peaks within a PeaksWorkspace.
 - New plotting script that provides diagnostic plots of SCDCalibratePanels output.
 - New plotting script that provides diagnositc plots of SCDCalibratePanels2 on a per panel/bank basis.
+- Added two integration methods to :ref:`HB3AIntegrateDetectorPeaks <algm-HB3AIntegrateDetectorPeaks>` for simple cuboid integration with and without fitted background.
 - New algorithm :ref:`ConvertPeaksWorkspace <algm-ConvertPeaksWorkspace>` for quick conversion between PeaksWorkspace and LeanElasticPeaksWorkspace.
 
 Improvements


### PR DESCRIPTION
**Description of work.**

Adds two new integration methods to the `HB3AIntegrateDetectorPeaks` algorithm for integrating by simple count summation subtracting estimated background ("Counts" method) and simple count summation over a specific set of data subtracting fitted background ("CountsWithFitting" method). The existing integration method calculated peak intensities directly from a Gaussian fit, and can be used with `Method="Fitting"`.

These methods are described in more detail [here.](https://docs.mantidproject.org/nightly/interfaces/diffraction/HFIR%20Single%20Crystal%20Reduction.html#peak-integration)

**To test:**

<!-- Instructions for testing. -->

Verify the new unit tests: `ctest -R "HB3AIntegrateDetectorPeaks"`


<!-- Ensure the base of this PR is correct (e.g. release-next or master)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

Version into `ornl-next`: #31961  

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
