### PR TITLE
Fix crash in ConvertToMD for invalidated goniometer

### DIFF
--- a/Framework/MDAlgorithms/src/MDWSDescription.cpp
+++ b/Framework/MDAlgorithms/src/MDWSDescription.cpp
@@ -122,7 +122,7 @@ void MDWSDescription::buildFromMatrixWS(const API::MatrixWorkspace_sptr &pWS, co
 void MDWSDescription::setWS(API::MatrixWorkspace_sptr otherMatrixWS) { m_InWS = std::move(otherMatrixWS); }
 /// Method checks if input workspace has defined goniometer
 bool MDWSDescription::hasGoniometer() const {
-  if (m_InWS)
+  if ((m_InWS != nullptr) && (m_InWS->run().getNumGoniometers()))
     return m_InWS->run().getGoniometer().isDefined();
   else
     return false;

--- a/Framework/MDAlgorithms/src/MDWSDescription.cpp
+++ b/Framework/MDAlgorithms/src/MDWSDescription.cpp
@@ -122,7 +122,7 @@ void MDWSDescription::buildFromMatrixWS(const API::MatrixWorkspace_sptr &pWS, co
 void MDWSDescription::setWS(API::MatrixWorkspace_sptr otherMatrixWS) { m_InWS = std::move(otherMatrixWS); }
 /// Method checks if input workspace has defined goniometer
 bool MDWSDescription::hasGoniometer() const {
-  if ((m_InWS != nullptr) && (m_InWS->run().getNumGoniometers()))
+  if ((m_InWS != nullptr) && (m_InWS->run().getNumGoniometers() > 0))
     return m_InWS->run().getGoniometer().isDefined();
   else
     return false;

--- a/docs/source/release/v6.2.0/direct_geometry.rst
+++ b/docs/source/release/v6.2.0/direct_geometry.rst
@@ -32,5 +32,6 @@ BugFixes
 - Fixed a bug in the :ref:`Crystal Field Python Interface` which prevented the application of IntensityScaling factors
 - Peaks are (re)set upon rebuilding the single spectrum function as a multi-spectrum function
   due to the physical properties. This re-setting peaks is needed to maintain the intended ties.
+- A bug has been fixed in :ref:`ConvertToMD <algm-ConvertToMD>` that sometimes crashes Mantid when files are summed together.
 
 :ref:`Release 6.2.0 <v6.2.0>`


### PR DESCRIPTION
**Description of work.**
Fixes a bug in ConvertToMD that causes Mantid to crash. If multiple files are loaded together with `+`, the goniometer is invalidated.

**Report to:** @granrothge 


**To test:**
The following script crashes current version. One can uncomment the `SetGoniometer` line, and everything will be fine (even though one does not need goniometer for |Q|)

```python
from mantid.simpleapi import *

iws=Load(Filename='HYS13657+13658', LoadMonitors=False)
#SetGoniometer(iws, '0,0,1,0,1')
DGSdict={}
DGSdict['SampleInputWorkspace'] = iws
DGSdict['IncidentEnergyGuess']=50.
DGSdict['UseIncidentEnergyGuess']=True
DGSdict['TimeZeroGuess']=40.
DGSdict['EnergyTransferRange']=[-50.0,0.5,50.0] 
DGSdict['OutputWorkspace']='split'

DgsReduction(**DGSdict)
minvals,maxvals=ConvertToMDMinMaxGlobal('split','|Q|','Direct')
ConvertToMD('split',QDimensions='|Q|',dEAnalysisMode='Direct',MinValues=minvals,MaxValues=maxvals,OutputWorkspace='MD')
```
The new version should work fine, even without the SetGoniometer line. Data is from systemtests

*There is no associated issue.*


<!-- Ensure the base of this PR is correct (e.g. release-next or master)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
