### PR TITLE
Add Coverage Timeout Options to buildscript

### DIFF
--- a/buildconfig/Jenkins/bash_modules/enable_coverage.sh
+++ b/buildconfig/Jenkins/bash_modules/enable_coverage.sh
@@ -1,9 +1,7 @@
 #!/bin/bash
 
 function enable_coverage(){
-    # Appends any coverage settings to the current CMake String passed as a param
-    local EXISTING_OPTS="$1"
-
+    # Returns any coverage settings as a string
     if [[ ${JOB_NAME} == *coverage* ]]; then
         local COVERAGE=ON
         # Since we currently don't support passing a timeout, hardcode it for coverage jobs
@@ -13,7 +11,7 @@ function enable_coverage(){
         local TIMEOUT=300
     fi
 
-    local OPTS="$EXISTING_OPTS -DCOVERAGE=${COVERAGE} -DTESTING_TIMEOUT=${TIMEOUT}"
+    local OPTS="-DCOVERAGE=${COVERAGE} -DTESTING_TIMEOUT=${TIMEOUT}"
     echo "$OPTS"
 }
 

--- a/buildconfig/Jenkins/bash_modules/enable_coverage.sh
+++ b/buildconfig/Jenkins/bash_modules/enable_coverage.sh
@@ -1,7 +1,8 @@
 #!/bin/bash
 
 function enable_coverage(){
-    # Appends any coverage settings to the current CMake String
+    # Appends any coverage settings to the current CMake String passed as a param
+    local EXISTING_OPTS="$1"
 
     if [[ ${JOB_NAME} == *coverage* ]]; then
         local COVERAGE=ON
@@ -12,9 +13,8 @@ function enable_coverage(){
         local TIMEOUT=300
     fi
 
-
-    local cmake_string="$1 -DCOVERAGE=${COVERAGE} -DTESTING_TIMEOUT=${TIMEOUT}"
-    echo "$cmake_string"
+    local OPTS="$EXISTING_OPTS -DCOVERAGE=${COVERAGE} -DTESTING_TIMEOUT=${TIMEOUT}"
+    echo "$OPTS"
 }
 
 

--- a/buildconfig/Jenkins/bash_modules/enable_coverage.sh
+++ b/buildconfig/Jenkins/bash_modules/enable_coverage.sh
@@ -5,12 +5,15 @@ function enable_coverage(){
 
     if [[ ${JOB_NAME} == *coverage* ]]; then
         local COVERAGE=ON
+        # Since we currently don't support passing a timeout, hardcode it for coverage jobs
+        local TIMEOUT=1200  # Seconds, 4x normal 300 second job
     else
         local COVERAGE=OFF
+        local TIMEOUT=300
     fi
 
 
-    local cmake_string="$1 -DCOVERAGE=${COVERAGE}"
+    local cmake_string="$1 -DCOVERAGE=${COVERAGE} -DTESTING_TIMEOUT=${TIMEOUT}"
     echo "$cmake_string"
 }
 

--- a/buildconfig/Jenkins/bash_modules/enable_coverage.sh
+++ b/buildconfig/Jenkins/bash_modules/enable_coverage.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+function enable_coverage(){
+    # Appends any coverage settings to the current CMake String
+
+    if [[ ${JOB_NAME} == *coverage* ]]; then
+        local COVERAGE=ON
+    else
+        local COVERAGE=OFF
+    fi
+
+
+    local cmake_string="$1 -DCOVERAGE=${COVERAGE}"
+    echo "$cmake_string"
+}
+
+
+

--- a/buildconfig/Jenkins/bash_modules/enable_coverage.sh
+++ b/buildconfig/Jenkins/bash_modules/enable_coverage.sh
@@ -14,6 +14,3 @@ function enable_coverage(){
     local OPTS="-DCOVERAGE=${COVERAGE} -DTESTING_TIMEOUT=${TIMEOUT}"
     echo "$OPTS"
 }
-
-
-

--- a/buildconfig/Jenkins/bash_modules/enable_static_analysis.sh
+++ b/buildconfig/Jenkins/bash_modules/enable_static_analysis.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+function enable_static_analysis(){
+
+
+    if [[ ${JOB_NAME} == *address* ]]; then
+        local SANITIZER="Address"
+
+    elif [[ ${JOB_NAME} == *memory* ]]; then
+        local SANITIZER="memory"
+
+    elif [[ ${JOB_NAME} == *thread* ]]; then
+        local SANITIZER="thread"
+
+    elif [[ ${JOB_NAME} == *undefined* ]]; then
+        local SANITIZER="undefined"
+    fi
+
+    if [[ -n $SANITIZER ]]; then
+        OPTS="-DUSE_SANITIZER=${SANITIZER}"
+    else
+        OPTS=""
+    fi
+    echo $OPTS
+}

--- a/buildconfig/Jenkins/bash_modules/strip_newlines.sh
+++ b/buildconfig/Jenkins/bash_modules/strip_newlines.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+function strip_newlines(){
+    # Strips whitespace from a given input
+    # Adapted from https://stackoverflow.com/a/19345966
+    echo $1|tr -d '\n'
+}

--- a/buildconfig/Jenkins/buildscript
+++ b/buildconfig/Jenkins/buildscript
@@ -115,8 +115,8 @@ if [[ ${JOB_NAME} == *clean* || ${JOB_NAME} == *clang_tidy* ]]; then
 fi
 
 CMAKE_OPTS=""
-source $MODULES_DIR/enable_coverage.sh
-CMAKE_OPTS=$(enable_coverage $CMAKE_OPTS)
+source "$MODULES_DIR/enable_coverage.sh"
+CMAKE_OPTS="$CMAKE_OPTS $(enable_coverage)"
 
 if [[ ${JOB_NAME} == *pull_requests* ]]; then
     PRBUILD=true
@@ -308,18 +308,10 @@ fi
 # Figure out if were doing a sanitizer build and setup any steps we need
 ###############################################################################
 
-if [[ ${JOB_NAME} == *address* ]]; then
-    SANITIZER_FLAGS="-DUSE_SANITIZER=Address"
+source "$MODULES_DIR/enable_static_analysis.sh"
+SANITIZER_FLAGS=$(enable_static_analysis)
+CMAKE_OPTS="$CMAKE_OPTS $SANITIZER_FLAGS"
 
-elif [[ ${JOB_NAME} == *memory* ]]; then
-    SANITIZER_FLAGS="-DUSE_SANITIZER=memory"
-
-elif [[ ${JOB_NAME} == *thread* ]]; then
-    SANITIZER_FLAGS="-DUSE_SANITIZER=thread"
-
-elif [[ ${JOB_NAME} == *undefined* ]]; then
-    SANITIZER_FLAGS="-DUSE_SANITIZER=undefined"
-fi
 
 if [[ -n "${SANITIZER_FLAGS}" ]]; then
     # Force build to RelWithDebInfo
@@ -339,6 +331,14 @@ if [ -e $BUILD_DIR/CMakeCache.txt ]; then
     CMAKE_GENERATOR=""
 fi
 
+##############################################################################
+# Prep CMake Options
+##############################################################################
+source "$MODULES_DIR/strip_newlines.sh"
+# Echo will append a "\n" which CMake then splits into two seperate invocations
+CMAKE_OPTS=$(strip_newlines "$CMAKE_OPTS")
+
+
 ###############################################################################
 # Work in the build directory
 ###############################################################################
@@ -353,7 +353,7 @@ rm -f -- *.dmg *.rpm *.deb *.tar.gz *.tar.xz
 ###############################################################################
 # CMake configuration
 ###############################################################################
-$SCL_ENABLE "${CMAKE_EXE} ${CMAKE_GENERATOR} ${CMAKE_OPTS} -DCMAKE_BUILD_TYPE=${BUILD_CONFIG} -DENABLE_PRECOMMIT=OFF -DENABLE_CPACK=ON -DENABLE_MANTIDPLOT=OFF -DMANTID_DATA_STORE=${MANTID_DATA_STORE} -DDOCS_HTML=ON -DENABLE_CONDA=ON -DCOLORED_COMPILER_OUTPUT=OFF ${DIST_FLAGS} ${PACKAGINGVARS} ${CLANGTIDYVAR} ${SANITIZER_FLAGS} .."
+$SCL_ENABLE "${CMAKE_EXE} ${CMAKE_GENERATOR} -DCMAKE_BUILD_TYPE=${BUILD_CONFIG} ${CMAKE_OPTS} -DENABLE_PRECOMMIT=OFF -DENABLE_CPACK=ON -DENABLE_MANTIDPLOT=OFF -DMANTID_DATA_STORE=${MANTID_DATA_STORE} -DDOCS_HTML=ON -DENABLE_CONDA=ON -DCOLORED_COMPILER_OUTPUT=OFF ${DIST_FLAGS} ${PACKAGINGVARS} ${CLANGTIDYVAR} .."
 
 ###############################################################################
 # Coverity build should exit early

--- a/buildconfig/Jenkins/buildscript
+++ b/buildconfig/Jenkins/buildscript
@@ -13,6 +13,7 @@
 shopt -s nocasematch
 
 SCRIPT_DIR=$(dirname "$0")
+MODULES_DIR="$SCRIPT_DIR/bash_modules"
 XVFB_SERVER_NUM=101
 ULIMIT_CORE_ORIG=$(ulimit -c)
 
@@ -113,11 +114,9 @@ if [[ ${JOB_NAME} == *clean* || ${JOB_NAME} == *clang_tidy* ]]; then
     CLEANBUILD=true
 fi
 
-if [[ ${JOB_NAME} == *coverage* ]]; then
-    COVERAGE=ON
-else
-    COVERAGE=OFF
-fi
+CMAKE_OPTS=""
+source $MODULES_DIR/enable_coverage.sh
+CMAKE_OPTS=$(enable_coverage $CMAKE_OPTS)
 
 if [[ ${JOB_NAME} == *pull_requests* ]]; then
     PRBUILD=true
@@ -354,7 +353,7 @@ rm -f -- *.dmg *.rpm *.deb *.tar.gz *.tar.xz
 ###############################################################################
 # CMake configuration
 ###############################################################################
-$SCL_ENABLE "${CMAKE_EXE} ${CMAKE_GENERATOR} -DCMAKE_BUILD_TYPE=${BUILD_CONFIG} -DENABLE_PRECOMMIT=OFF -DCOVERAGE=${COVERAGE} -DENABLE_CPACK=ON -DENABLE_MANTIDPLOT=OFF -DMANTID_DATA_STORE=${MANTID_DATA_STORE} -DDOCS_HTML=ON -DENABLE_CONDA=ON -DCOLORED_COMPILER_OUTPUT=OFF ${DIST_FLAGS} ${PACKAGINGVARS} ${CLANGTIDYVAR} ${SANITIZER_FLAGS} .."
+$SCL_ENABLE "${CMAKE_EXE} ${CMAKE_GENERATOR} ${CMAKE_OPTS} -DCMAKE_BUILD_TYPE=${BUILD_CONFIG} -DENABLE_PRECOMMIT=OFF -DENABLE_CPACK=ON -DENABLE_MANTIDPLOT=OFF -DMANTID_DATA_STORE=${MANTID_DATA_STORE} -DDOCS_HTML=ON -DENABLE_CONDA=ON -DCOLORED_COMPILER_OUTPUT=OFF ${DIST_FLAGS} ${PACKAGINGVARS} ${CLANGTIDYVAR} ${SANITIZER_FLAGS} .."
 
 ###############################################################################
 # Coverity build should exit early


### PR DESCRIPTION
**Description of work.**
- Breaks up some of the build script into modular form
- Adds coverage timeout
- Move static analysis too, just to display how modules work

Currently our coverage jobs are failing as the 300 second timeout is too low in debug mode. As they are run nightly we can bump the time to 1200 seconds (20 minutes per test) and see if the build servers have enough time.

In the long-term I hope to move more out of our big buildscript and into individual modules we use for maintainability.

**To test:**
- cd to Mantid directory
- `export WORKSPACE=$(pwd)`
- `export JOB_NAME=coverage_debu`
- Run `buildconfig/Jenkins/buildscript`
- This will fail trying to build (number of threads is not specified), check that in `*source_dir*/build` that coverage is on
- `export JOB_NAME=address`
- Re-run `buildconfig/Jenkins/buildscript`
- Again this will fail, check that coverage is off, but USE_SANITIZER is set to address with the build mode on RelWithDebInfo

<!-- Ensure the base of this PR is correct (e.g. release-next or master)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
