### PR TITLE
Bug in colorfill plot

### DIFF
--- a/qt/applications/workbench/workbench/plotting/figuremanager.py
+++ b/qt/applications/workbench/workbench/plotting/figuremanager.py
@@ -186,7 +186,6 @@ class FigureManagerWorkbench(FigureManagerBase, QObject):
         self.window.closing.connect(canvas.close_event)
         self.window.closing.connect(self.destroy)
         self.window.visibility_changed.connect(self.fig_visibility_changed)
-        self.window.resized.connect(self.on_resize)
 
         self.window.setWindowTitle("Figure %d" % num)
         canvas.figure.set_label("Figure %d" % num)
@@ -344,18 +343,6 @@ class FigureManagerWorkbench(FigureManagerBase, QObject):
             # It seems that when the python session is killed,
             # Gcf can get destroyed before the Gcf.destroy
             # line is run, leading to a useless AttributeError.
-
-    def on_resize(self):
-        """
-        Triggered when the plot window is resized. This method updates the plot
-        layout to fit the actual size.
-        """
-        if self.canvas:
-            try:
-                self.canvas.figure.tight_layout()
-            except:
-                pass
-            self.canvas.draw_idle()
 
     def launch_plot_options(self):
         self.plot_options_dialog = PlotConfigDialogPresenter(self.canvas.figure, parent=self.window)

--- a/qt/python/mantidqt/widgets/superplot/presenter.py
+++ b/qt/python/mantidqt/widgets/superplot/presenter.py
@@ -31,6 +31,7 @@ class SuperplotPresenter:
 
         if self.parent:
             self.parent.plot_updated.connect(self.on_plot_updated)
+            self.parent.resized.connect(self.on_resize)
 
         self._model.sig_workspace_deleted.connect(self.on_workspace_deleted)
         self._model.sig_workspace_renamed.connect(self.on_workspace_renamed)
@@ -87,6 +88,16 @@ class SuperplotPresenter:
                 pass
         self._view.close()
         del self._model
+
+    def on_resize(self):
+        """
+        Triggered when the window/dockwidgets is(are) resized.
+        """
+        try:
+            self._canvas.figure.tight_layout()
+        except:
+            pass
+        self._canvas.draw_idle()
 
     def _sync_with_current_plot(self):
         """

--- a/qt/python/mantidqt/widgets/superplot/presenter.py
+++ b/qt/python/mantidqt/widgets/superplot/presenter.py
@@ -95,7 +95,7 @@ class SuperplotPresenter:
         """
         try:
             self._canvas.figure.tight_layout()
-        except:
+        except ValueError:
             pass
         self._canvas.draw_idle()
 
@@ -168,7 +168,7 @@ class SuperplotPresenter:
         if visible:
             try:
                 self._canvas.figure.tight_layout()
-            except:
+            except ValueError:
                 pass
             self._canvas.draw_idle()
 
@@ -341,7 +341,7 @@ class SuperplotPresenter:
             axes.set_axis_on()
             try:
                 figure.tight_layout()
-            except:
+            except ValueError:
                 pass
             legend = axes.legend()
             if legend:

--- a/qt/python/mantidqt/widgets/superplot/presenter.py
+++ b/qt/python/mantidqt/widgets/superplot/presenter.py
@@ -339,7 +339,10 @@ class SuperplotPresenter:
 
         if selection or plotted_data:
             axes.set_axis_on()
-            figure.tight_layout()
+            try:
+                figure.tight_layout()
+            except:
+                pass
             legend = axes.legend()
             if legend:
                 legend_set_draggable(legend, True)

--- a/qt/python/mantidqt/widgets/superplot/view.py
+++ b/qt/python/mantidqt/widgets/superplot/view.py
@@ -134,6 +134,11 @@ class SuperplotViewSide(QDockWidget):
 
     UI = "side_dock_widget.ui"
 
+    """
+    Sent when the widget is resized.
+    """
+    resized = Signal()
+
     def __init__(self, parent=None):
         super().__init__(parent)
         self.here = os.path.dirname(os.path.realpath(__file__))
@@ -151,10 +156,22 @@ class SuperplotViewSide(QDockWidget):
                                                   "WorkspaceGroup",
                                                   "EventWorkspace"])
 
+    def resizeEvent(self, event):
+        """
+        Override QDockWidget::resizeEvent.
+        """
+        super().resizeEvent(event)
+        self.resized.emit()
+
 
 class SuperplotViewBottom(QDockWidget):
 
     UI = "bottom_dock_widget.ui"
+
+    """
+    Sent when the widget is resized.
+    """
+    resized = Signal()
 
     def __init__(self, parent=None):
         super().__init__(parent)
@@ -177,6 +194,13 @@ class SuperplotViewBottom(QDockWidget):
         elif event.key() == Qt.Key_Space:
             self.holdButton.click()
 
+    def resizeEvent(self, event):
+        """
+        Override QDockWidget::resizeEvent.
+        """
+        super().resizeEvent(event)
+        self.resized.emit()
+
 
 class SuperplotView(QWidget):
 
@@ -195,6 +219,7 @@ class SuperplotView(QWidget):
         side.addButton.clicked.connect(self._presenter.on_add_button_clicked)
         side.workspacesList.itemSelectionChanged.connect(
                 self._presenter.on_workspace_selection_changed)
+        side.resized.connect(self._presenter.on_resize)
         bottom = self._bottom_view
         bottom.holdButton.clicked.connect(
                 self._presenter.on_hold_button_clicked)
@@ -204,6 +229,7 @@ class SuperplotView(QWidget):
                 self._presenter.on_spectrum_spin_box_changed)
         bottom.modeComboBox.currentTextChanged.connect(
                 self._presenter.on_mode_changed)
+        bottom.resized.connect(self._presenter.on_resize)
 
     def get_side_widget(self):
         return self._side_view


### PR DESCRIPTION
**Description of work.**

The resize slot introduced in #31375 has been removed from the plot figure. Calling `tight_layout()` on a clolorfill plot was causing the issue.

**To test:**

Follow the issues instructions.

Fixes #31946 

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
