### PR TITLE
Fix bug with mantid 3d plotting

### DIFF
--- a/Framework/PythonInterface/mantid/plots/mantidaxes.py
+++ b/Framework/PythonInterface/mantid/plots/mantidaxes.py
@@ -1222,6 +1222,9 @@ class MantidAxes(Axes):
         else:
             self.minorticks_off()
 
+    def grid_on(self):
+        return self.xaxis._major_tick_kw.get('gridOn', False) and self.yaxis._major_tick_kw.get('gridOn', False)
+
     # ------------------ Private api --------------------------------------------------------
 
     def _attach_colorbar(self, mappable, colorbar):
@@ -1311,6 +1314,9 @@ class MantidAxes3D(Axes3D):
     def autoscale(self, *args, **kwargs):
         super().autoscale(*args, **kwargs)
         self._set_overflowing_data_to_nan()
+
+    def grid_on(self):
+        return self._draw_grid
 
     def _set_overflowing_data_to_nan(self, axis_index=None):
         """

--- a/qt/applications/workbench/workbench/plotting/propertiesdialog.py
+++ b/qt/applications/workbench/workbench/plotting/propertiesdialog.py
@@ -176,7 +176,7 @@ class AxisEditor(PropertiesEditorBase):
         self._memento = memento
         memento.min, memento.max = getattr(self.axes, 'get_{}lim'.format(self.axis_id))()
         memento.log = getattr(self.axes, 'get_{}scale'.format(self.axis_id))() != 'linear'
-        memento.grid = self.axis._major_tick_kw['gridOn']
+        memento.grid = self.axis.grid_on() if hasattr(self.axis, 'grid_on') else self.axis._major_tick_kw.get('gridOn', False)
         if type(self.axis.get_major_formatter()) is ScalarFormatter:
             memento.formatter = 'Decimal Format'
         elif type(self.axis.get_major_formatter()) is LogFormatterSciNotation:

--- a/qt/applications/workbench/workbench/plotting/toolbar.py
+++ b/qt/applications/workbench/workbench/plotting/toolbar.py
@@ -264,7 +264,10 @@ class WorkbenchNavigationToolbar(NavigationToolbar2QT):
         # Toggle grid on/off button in case plot is created from a script.
         is_major_grid_on = False
         for ax in fig.get_axes():
-            is_major_grid_on = ax.xaxis._major_tick_kw['gridOn'] and ax.yaxis._major_tick_kw['gridOn']
+            if hasattr(ax, 'grid_on'):
+                is_major_grid_on = ax.grid_on()
+            else:
+                is_major_grid_on = ax.xaxis._major_tick_kw.get('gridOn', False) and ax.yaxis._major_tick_kw.get('gridOn', False)
             # If ANY of the axes have no grid, set the button to unchecked.
             if not is_major_grid_on:
                 break


### PR DESCRIPTION

**Description of work.**
For a set of 3d axes there is no variable `gridOn` in the dictionary, meaning we get a python error. Unfortunately there doesn't seem to be a nice way of determining whether the grid on, without accessing some private data of the axes class. The fix for now is to specialise the calls for mantid axes (projection=mantid and projection=mantid3d).

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

**To test:**

- `ws = CreateSampleWorkspace()`
- Make 2d and 3d plots checking the grid functionality works
- Make a 2d plot turn the grid on -> copy to script -> paste the script -> check it produces a plot with a grid

<!-- Instructions for testing. -->

*There is no associated issue.*

*This does not require release notes because it fixes an issue introduced this release.
<!-- Ensure the base of this PR is correct (e.g. release-next or master)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
