### PR TITLE
Add instrument display adaptor to wrap Qt and GL

### DIFF
--- a/qt/widgets/instrumentview/CMakeLists.txt
+++ b/qt/widgets/instrumentview/CMakeLists.txt
@@ -107,6 +107,7 @@ set(
   inc/MantidQtWidgets/InstrumentView/GridTextureFace.h
 
   inc/MantidQtWidgets/InstrumentView/IGLDisplay.h
+  inc/MantidQtWidgets/InstrumentView/IStackedLayout.h
   inc/MantidQtWidgets/InstrumentView/IInstrumentDisplay.h
   inc/MantidQtWidgets/InstrumentView/IQtDisplay.h
 
@@ -139,6 +140,7 @@ set(
   inc/MantidQtWidgets/InstrumentView/RotationSurface.h
   inc/MantidQtWidgets/InstrumentView/Shape2D.h
   inc/MantidQtWidgets/InstrumentView/Shape2DCollection.h
+  inc/MantidQtWidgets/InstrumentView/StackedLayout.h
   inc/MantidQtWidgets/InstrumentView/QtDisplay.h
   inc/MantidQtWidgets/InstrumentView/UCorrectionDialog.h
   inc/MantidQtWidgets/InstrumentView/UnwrappedCylinder.h

--- a/qt/widgets/instrumentview/CMakeLists.txt
+++ b/qt/widgets/instrumentview/CMakeLists.txt
@@ -106,8 +106,9 @@ set(
   inc/MantidQtWidgets/InstrumentView/GLObject.h
   inc/MantidQtWidgets/InstrumentView/GridTextureFace.h
 
-  inc/MantidQtWidgets/InstrumentView/IQtDisplay.h
   inc/MantidQtWidgets/InstrumentView/IGLDisplay.h
+  inc/MantidQtWidgets/InstrumentView/IInstrumentDisplay.h
+  inc/MantidQtWidgets/InstrumentView/IQtDisplay.h
 
   inc/MantidQtWidgets/InstrumentView/InstrumentActor.h
   inc/MantidQtWidgets/InstrumentView/InstrumentDisplay.h

--- a/qt/widgets/instrumentview/CMakeLists.txt
+++ b/qt/widgets/instrumentview/CMakeLists.txt
@@ -63,7 +63,6 @@ set(
   inc/MantidQtWidgets/InstrumentView/BaseCustomInstrumentView.h
   inc/MantidQtWidgets/InstrumentView/CollapsiblePanel.h
   inc/MantidQtWidgets/InstrumentView/InstrumentActor.h
-  inc/MantidQtWidgets/InstrumentView/InstrumentDisplay.h
   inc/MantidQtWidgets/InstrumentView/InstrumentTreeModel.h
   inc/MantidQtWidgets/InstrumentView/InstrumentTreeWidget.h
   inc/MantidQtWidgets/InstrumentView/InstrumentWidget.h
@@ -103,6 +102,7 @@ set(
   inc/MantidQtWidgets/InstrumentView/DetXMLFile.h
   inc/MantidQtWidgets/InstrumentView/DllOption.h
   inc/MantidQtWidgets/InstrumentView/GLColor.h
+  inc/MantidQtWidgets/InstrumentView/GLDisplay.h
   inc/MantidQtWidgets/InstrumentView/GLObject.h
   inc/MantidQtWidgets/InstrumentView/GridTextureFace.h
 
@@ -110,6 +110,7 @@ set(
   inc/MantidQtWidgets/InstrumentView/IGLDisplay.h
 
   inc/MantidQtWidgets/InstrumentView/InstrumentActor.h
+  inc/MantidQtWidgets/InstrumentView/InstrumentDisplay.h
   inc/MantidQtWidgets/InstrumentView/InstrumentTreeModel.h
   inc/MantidQtWidgets/InstrumentView/InstrumentTreeWidget.h
   inc/MantidQtWidgets/InstrumentView/InstrumentWidget.h
@@ -122,7 +123,6 @@ set(
   inc/MantidQtWidgets/InstrumentView/InstrumentWidgetTab.h
   inc/MantidQtWidgets/InstrumentView/InstrumentWidgetTreeTab.h
   inc/MantidQtWidgets/InstrumentView/InstrumentWidgetTypes.h
-  inc/MantidQtWidgets/InstrumentView/GLDisplay.h
   inc/MantidQtWidgets/InstrumentView/MaskBinsData.h
   inc/MantidQtWidgets/InstrumentView/OpenGLError.h
   inc/MantidQtWidgets/InstrumentView/PanelsSurface.h

--- a/qt/widgets/instrumentview/CMakeLists.txt
+++ b/qt/widgets/instrumentview/CMakeLists.txt
@@ -15,6 +15,7 @@ set(
   src/GLColor.cpp
   src/GLObject.cpp
   src/InstrumentActor.cpp
+  src/InstrumentDisplay.cpp
   src/InstrumentTreeModel.cpp
   src/InstrumentTreeWidget.cpp
   src/InstrumentWidget.cpp
@@ -62,6 +63,7 @@ set(
   inc/MantidQtWidgets/InstrumentView/BaseCustomInstrumentView.h
   inc/MantidQtWidgets/InstrumentView/CollapsiblePanel.h
   inc/MantidQtWidgets/InstrumentView/InstrumentActor.h
+  inc/MantidQtWidgets/InstrumentView/InstrumentDisplay.h
   inc/MantidQtWidgets/InstrumentView/InstrumentTreeModel.h
   inc/MantidQtWidgets/InstrumentView/InstrumentTreeWidget.h
   inc/MantidQtWidgets/InstrumentView/InstrumentWidget.h

--- a/qt/widgets/instrumentview/inc/MantidQtWidgets/InstrumentView/IInstrumentDisplay.h
+++ b/qt/widgets/instrumentview/inc/MantidQtWidgets/InstrumentView/IInstrumentDisplay.h
@@ -11,6 +11,9 @@
 
 #include <memory>
 
+// Qt Forward Declarations
+class QStackedLayout;
+
 namespace MantidQt::MantidWidgets {
 
 class IInstrumentDisplay {
@@ -25,5 +28,8 @@ public:
   virtual IQtDisplay *getQtDisplay() const = 0;
 
   virtual void installEventFilter(QObject *obj) = 0;
+
+private:
+  virtual QStackedLayout *createLayout(QWidget *) const = 0;
 };
 } // namespace MantidQt::MantidWidgets

--- a/qt/widgets/instrumentview/inc/MantidQtWidgets/InstrumentView/IInstrumentDisplay.h
+++ b/qt/widgets/instrumentview/inc/MantidQtWidgets/InstrumentView/IInstrumentDisplay.h
@@ -29,8 +29,5 @@ public:
   virtual IQtDisplay *getQtDisplay() const = 0;
 
   virtual void installEventFilter(QObject *obj) = 0;
-
-private:
-  virtual IStackedLayout *createLayout(QWidget *) const = 0;
 };
 } // namespace MantidQt::MantidWidgets

--- a/qt/widgets/instrumentview/inc/MantidQtWidgets/InstrumentView/IInstrumentDisplay.h
+++ b/qt/widgets/instrumentview/inc/MantidQtWidgets/InstrumentView/IInstrumentDisplay.h
@@ -17,6 +17,10 @@ class IInstrumentDisplay {
 public:
   virtual ~IInstrumentDisplay() = default;
 
+  virtual int currentIndex() const = 0;
+  virtual QWidget *currentWidget() const = 0;
+  virtual void setCurrentIndex(int val) const = 0;
+
   virtual IGLDisplay *getGLDisplay() const = 0;
   virtual IQtDisplay *getQtDisplay() const = 0;
 

--- a/qt/widgets/instrumentview/inc/MantidQtWidgets/InstrumentView/IInstrumentDisplay.h
+++ b/qt/widgets/instrumentview/inc/MantidQtWidgets/InstrumentView/IInstrumentDisplay.h
@@ -6,26 +6,20 @@
 // SPDX - License - Identifier: GPL - 3.0 +
 #pragma once
 
-#include "DllOption.h"
 #include "IGLDisplay.h"
-#include "IInstrumentDisplay.h"
 #include "IQtDisplay.h"
 
 #include <memory>
 
 namespace MantidQt::MantidWidgets {
 
-class EXPORT_OPT_MANTIDQT_INSTRUMENTVIEW InstrumentDisplay : public IInstrumentDisplay {
+class IInstrumentDisplay {
 public:
-  InstrumentDisplay(std::unique_ptr<IGLDisplay> glDisplay, std::unique_ptr<IQtDisplay> qtDisplay);
+  virtual ~IInstrumentDisplay() = default;
 
-  IGLDisplay *getGLDisplay() const override;
-  IQtDisplay *getQtDisplay() const override;
+  virtual IGLDisplay *getGLDisplay() const = 0;
+  virtual IQtDisplay *getQtDisplay() const = 0;
 
-  void installEventFilter(QObject *obj) override;
-
-private:
-  std::unique_ptr<IGLDisplay> m_glDisplay;
-  std::unique_ptr<IQtDisplay> m_qtDisplay;
+  virtual void installEventFilter(QObject *obj) = 0;
 };
 } // namespace MantidQt::MantidWidgets

--- a/qt/widgets/instrumentview/inc/MantidQtWidgets/InstrumentView/IStackedLayout.h
+++ b/qt/widgets/instrumentview/inc/MantidQtWidgets/InstrumentView/IStackedLayout.h
@@ -12,6 +12,8 @@ namespace MantidQt::MantidWidgets {
 
 class IStackedLayout {
 public:
+  virtual ~IStackedLayout() = default;
+
   virtual int addWidget(QWidget *) = 0;
   virtual int currentIndex() const = 0;
   virtual QWidget *currentWidget() const = 0;

--- a/qt/widgets/instrumentview/inc/MantidQtWidgets/InstrumentView/IStackedLayout.h
+++ b/qt/widgets/instrumentview/inc/MantidQtWidgets/InstrumentView/IStackedLayout.h
@@ -6,31 +6,15 @@
 // SPDX - License - Identifier: GPL - 3.0 +
 #pragma once
 
-#include "IGLDisplay.h"
-#include "IQtDisplay.h"
-#include "IStackedLayout.h"
-
-#include <memory>
-
-// Qt Forward Declarations
-class QStackedLayout;
+class QWidget;
 
 namespace MantidQt::MantidWidgets {
 
-class IInstrumentDisplay {
+class IStackedLayout {
 public:
-  virtual ~IInstrumentDisplay() = default;
-
+  virtual int addWidget(QWidget *) = 0;
   virtual int currentIndex() const = 0;
   virtual QWidget *currentWidget() const = 0;
-  virtual void setCurrentIndex(int val) const = 0;
-
-  virtual IGLDisplay *getGLDisplay() const = 0;
-  virtual IQtDisplay *getQtDisplay() const = 0;
-
-  virtual void installEventFilter(QObject *obj) = 0;
-
-private:
-  virtual IStackedLayout *createLayout(QWidget *) const = 0;
+  virtual void setCurrentIndex(int) = 0;
 };
 } // namespace MantidQt::MantidWidgets

--- a/qt/widgets/instrumentview/inc/MantidQtWidgets/InstrumentView/InstrumentDisplay.h
+++ b/qt/widgets/instrumentview/inc/MantidQtWidgets/InstrumentView/InstrumentDisplay.h
@@ -21,6 +21,8 @@ public:
   IGLDisplay *getGLDisplay() const;
   IQtDisplay *getQtDisplay() const;
 
+  void installEventFilter(QObject *obj);
+
 private:
   std::unique_ptr<IGLDisplay> m_glDisplay;
   std::unique_ptr<IQtDisplay> m_qtDisplay;

--- a/qt/widgets/instrumentview/inc/MantidQtWidgets/InstrumentView/InstrumentDisplay.h
+++ b/qt/widgets/instrumentview/inc/MantidQtWidgets/InstrumentView/InstrumentDisplay.h
@@ -10,11 +10,10 @@
 #include "IGLDisplay.h"
 #include "IInstrumentDisplay.h"
 #include "IQtDisplay.h"
+#include "IStackedLayout.h"
 
 #include <memory>
-
 // Qt forward declarations
-class QStackedLayout;
 class QWidget;
 
 namespace MantidQt::MantidWidgets {
@@ -33,12 +32,12 @@ public:
   void installEventFilter(QObject *obj) override;
 
 private:
-  QStackedLayout *createLayout(QWidget *parent) const override;
+  IStackedLayout *createLayout(QWidget *parent) const override;
 
   std::unique_ptr<IGLDisplay> m_glDisplay;
   std::unique_ptr<IQtDisplay> m_qtDisplay;
 
   /// Stacked layout managing m_glDisplay and m_qtDisplay
-  QStackedLayout *m_instrumentDisplayLayout;
+  IStackedLayout *m_instrumentDisplayLayout;
 };
 } // namespace MantidQt::MantidWidgets

--- a/qt/widgets/instrumentview/inc/MantidQtWidgets/InstrumentView/InstrumentDisplay.h
+++ b/qt/widgets/instrumentview/inc/MantidQtWidgets/InstrumentView/InstrumentDisplay.h
@@ -13,11 +13,18 @@
 
 #include <memory>
 
+// Qt forward declarations
+class QStackedLayout;
+
 namespace MantidQt::MantidWidgets {
 
 class EXPORT_OPT_MANTIDQT_INSTRUMENTVIEW InstrumentDisplay : public IInstrumentDisplay {
 public:
-  InstrumentDisplay(std::unique_ptr<IGLDisplay> glDisplay, std::unique_ptr<IQtDisplay> qtDisplay);
+  InstrumentDisplay(std::unique_ptr<IGLDisplay> glDisplay, std::unique_ptr<IQtDisplay> qtDisplay, QWidget *parent);
+
+  int currentIndex() const override;
+  QWidget *currentWidget() const override;
+  void setCurrentIndex(int val) const override;
 
   IGLDisplay *getGLDisplay() const override;
   IQtDisplay *getQtDisplay() const override;
@@ -25,7 +32,12 @@ public:
   void installEventFilter(QObject *obj) override;
 
 private:
+  void createStackedLayout(QWidget *parent);
+
   std::unique_ptr<IGLDisplay> m_glDisplay;
   std::unique_ptr<IQtDisplay> m_qtDisplay;
+
+  /// Stacked layout managing m_glDisplay and m_qtDisplay
+  QStackedLayout *m_instrumentDisplayLayout;
 };
 } // namespace MantidQt::MantidWidgets

--- a/qt/widgets/instrumentview/inc/MantidQtWidgets/InstrumentView/InstrumentDisplay.h
+++ b/qt/widgets/instrumentview/inc/MantidQtWidgets/InstrumentView/InstrumentDisplay.h
@@ -15,6 +15,7 @@
 
 // Qt forward declarations
 class QStackedLayout;
+class QWidget;
 
 namespace MantidQt::MantidWidgets {
 
@@ -32,7 +33,7 @@ public:
   void installEventFilter(QObject *obj) override;
 
 private:
-  void createStackedLayout(QWidget *parent);
+  QStackedLayout *createLayout(QWidget *parent) const override;
 
   std::unique_ptr<IGLDisplay> m_glDisplay;
   std::unique_ptr<IQtDisplay> m_qtDisplay;

--- a/qt/widgets/instrumentview/inc/MantidQtWidgets/InstrumentView/InstrumentDisplay.h
+++ b/qt/widgets/instrumentview/inc/MantidQtWidgets/InstrumentView/InstrumentDisplay.h
@@ -32,8 +32,6 @@ public:
   void installEventFilter(QObject *obj) override;
 
 private:
-  IStackedLayout *createLayout(QWidget *parent) const override;
-
   std::unique_ptr<IGLDisplay> m_glDisplay;
   std::unique_ptr<IQtDisplay> m_qtDisplay;
 

--- a/qt/widgets/instrumentview/inc/MantidQtWidgets/InstrumentView/InstrumentDisplay.h
+++ b/qt/widgets/instrumentview/inc/MantidQtWidgets/InstrumentView/InstrumentDisplay.h
@@ -1,0 +1,28 @@
+// Mantid Repository : https://github.com/mantidproject/mantid
+//
+// Copyright &copy; 2021 ISIS Rutherford Appleton Laboratory UKRI,
+//   NScD Oak Ridge National Laboratory, European Spallation Source,
+//   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+// SPDX - License - Identifier: GPL - 3.0 +
+#pragma once
+
+#include "DllOption.h"
+#include "IGLDisplay.h"
+#include "IQtDisplay.h"
+
+#include <memory>
+
+namespace MantidQt::MantidWidgets {
+
+class EXPORT_OPT_MANTIDQT_INSTRUMENTVIEW InstrumentDisplay {
+public:
+  InstrumentDisplay(std::unique_ptr<IGLDisplay> glDisplay, std::unique_ptr<IQtDisplay> qtDisplay);
+
+  IGLDisplay *getGLDisplay() const;
+  IQtDisplay *getQtDisplay() const;
+
+private:
+  std::unique_ptr<IGLDisplay> m_glDisplay;
+  std::unique_ptr<IQtDisplay> m_qtDisplay;
+};
+} // namespace MantidQt::MantidWidgets

--- a/qt/widgets/instrumentview/inc/MantidQtWidgets/InstrumentView/InstrumentDisplay.h
+++ b/qt/widgets/instrumentview/inc/MantidQtWidgets/InstrumentView/InstrumentDisplay.h
@@ -20,8 +20,8 @@ namespace MantidQt::MantidWidgets {
 
 class EXPORT_OPT_MANTIDQT_INSTRUMENTVIEW InstrumentDisplay : public IInstrumentDisplay {
 public:
-  InstrumentDisplay(std::unique_ptr<IGLDisplay> glDisplay, std::unique_ptr<IQtDisplay> qtDisplay, QWidget *parent);
-
+  InstrumentDisplay(QWidget *parent, std::unique_ptr<IGLDisplay> glDisplay = nullptr,
+                    std::unique_ptr<IQtDisplay> qtDisplay = nullptr, std::unique_ptr<IStackedLayout> layout = nullptr);
   int currentIndex() const override;
   QWidget *currentWidget() const override;
   void setCurrentIndex(int val) const override;
@@ -38,6 +38,6 @@ private:
   std::unique_ptr<IQtDisplay> m_qtDisplay;
 
   /// Stacked layout managing m_glDisplay and m_qtDisplay
-  IStackedLayout *m_instrumentDisplayLayout;
+  std::unique_ptr<IStackedLayout> m_instrumentDisplayLayout;
 };
 } // namespace MantidQt::MantidWidgets

--- a/qt/widgets/instrumentview/inc/MantidQtWidgets/InstrumentView/InstrumentWidget.h
+++ b/qt/widgets/instrumentview/inc/MantidQtWidgets/InstrumentView/InstrumentWidget.h
@@ -304,8 +304,7 @@ protected:
   bool m_useOpenGL;
   /// 3D view or unwrapped
   SurfaceType m_surfaceType;
-  /// Stacked layout managing m_glDisplay and m_qtDisplay
-  QStackedLayout *m_instrumentDisplayLayout;
+
   /// spectra index id
   int mSpectraIDSelected;
   /// detector id

--- a/qt/widgets/instrumentview/inc/MantidQtWidgets/InstrumentView/InstrumentWidget.h
+++ b/qt/widgets/instrumentview/inc/MantidQtWidgets/InstrumentView/InstrumentWidget.h
@@ -63,6 +63,7 @@ class ProjectionSurface;
 
 namespace Detail {
 struct Dependencies {
+  std::unique_ptr<IInstrumentDisplay> instrumentDisplay = nullptr;
   std::unique_ptr<IQtDisplay> qtDisplay = nullptr;
   std::unique_ptr<IGLDisplay> glDisplay = nullptr;
   std::unique_ptr<QtConnect> qtConnect = std::make_unique<QtConnect>();
@@ -288,7 +289,7 @@ protected:
   InstrumentWidgetPickTab *m_pickTab;
   XIntegrationControl *m_xIntegration;
 
-  InstrumentDisplay m_instrumentDisplay;
+  std::unique_ptr<IInstrumentDisplay> m_instrumentDisplay;
 
   // Context menu actions
   QAction *m_clearPeakOverlays, *m_clearAlignment;

--- a/qt/widgets/instrumentview/inc/MantidQtWidgets/InstrumentView/InstrumentWidget.h
+++ b/qt/widgets/instrumentview/inc/MantidQtWidgets/InstrumentView/InstrumentWidget.h
@@ -9,6 +9,7 @@
 #include "DllOption.h"
 #include "IGLDisplay.h"
 #include "IQtDisplay.h"
+#include "InstrumentDisplay.h"
 #include "InstrumentWidgetTypes.h"
 #include "QtConnect.h"
 #include "UnwrappedSurface.h"
@@ -286,10 +287,8 @@ protected:
   InstrumentWidgetTreeTab *m_treeTab;
   InstrumentWidgetPickTab *m_pickTab;
   XIntegrationControl *m_xIntegration;
-  /// The OpenGL widget to display the instrument
-  std::unique_ptr<IGLDisplay> m_glDisplay;
-  /// The simple widget to display the instrument
-  std::unique_ptr<IQtDisplay> m_qtDisplay;
+
+  InstrumentDisplay m_instrumentDisplay;
 
   // Context menu actions
   QAction *m_clearPeakOverlays, *m_clearAlignment;

--- a/qt/widgets/instrumentview/inc/MantidQtWidgets/InstrumentView/QtDisplay.h
+++ b/qt/widgets/instrumentview/inc/MantidQtWidgets/InstrumentView/QtDisplay.h
@@ -23,7 +23,7 @@ class ProjectionSurface;
 class QtDisplay final : public IQtDisplay {
 public:
   /// Constructor
-  explicit QtDisplay(QWidget *parent);
+  explicit QtDisplay(QWidget *parent = nullptr);
   ~QtDisplay() override;
   /// Assign a surface to draw on
   void setSurface(std::shared_ptr<ProjectionSurface> surface) override;

--- a/qt/widgets/instrumentview/inc/MantidQtWidgets/InstrumentView/StackedLayout.h
+++ b/qt/widgets/instrumentview/inc/MantidQtWidgets/InstrumentView/StackedLayout.h
@@ -1,0 +1,26 @@
+// Mantid Repository : https://github.com/mantidproject/mantid
+//
+// Copyright &copy; 2021 ISIS Rutherford Appleton Laboratory UKRI,
+//   NScD Oak Ridge National Laboratory, European Spallation Source,
+//   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+// SPDX - License - Identifier: GPL - 3.0 +
+#pragma once
+
+#include "IStackedLayout.h"
+
+#include <QStackedLayout>
+
+class QWidget;
+
+namespace MantidQt::MantidWidgets {
+
+class StackedLayout : public IStackedLayout, public QStackedLayout {
+public:
+  StackedLayout(QWidget *parent) : QStackedLayout(parent) {}
+
+  virtual int addWidget(QWidget *parent) override { return QStackedLayout::addWidget(parent); }
+  virtual int currentIndex() const override { return QStackedLayout::currentIndex(); }
+  virtual QWidget *currentWidget() const override { return QStackedLayout::currentWidget(); }
+  virtual void setCurrentIndex(int val) override { QStackedLayout::setCurrentIndex(val); }
+};
+} // namespace MantidQt::MantidWidgets

--- a/qt/widgets/instrumentview/inc/MantidQtWidgets/InstrumentView/StackedLayout.h
+++ b/qt/widgets/instrumentview/inc/MantidQtWidgets/InstrumentView/StackedLayout.h
@@ -14,7 +14,7 @@ class QWidget;
 
 namespace MantidQt::MantidWidgets {
 
-class StackedLayout : public IStackedLayout, public QStackedLayout {
+class StackedLayout final : public IStackedLayout, public QStackedLayout {
 public:
   StackedLayout(QWidget *parent) : QStackedLayout(parent) {}
 

--- a/qt/widgets/instrumentview/src/InstrumentDisplay.cpp
+++ b/qt/widgets/instrumentview/src/InstrumentDisplay.cpp
@@ -5,11 +5,19 @@
 //   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
 // SPDX - License - Identifier: GPL - 3.0
 #include "MantidQtWidgets/InstrumentView/InstrumentDisplay.h"
+#include "MantidQtWidgets/InstrumentView/GLDisplay.h"
+#include "MantidQtWidgets/InstrumentView/QtDisplay.h"
 
 namespace MantidQt::MantidWidgets {
 
 InstrumentDisplay::InstrumentDisplay(std::unique_ptr<IGLDisplay> glDisplay, std::unique_ptr<IQtDisplay> qtDisplay)
-    : m_glDisplay(std::move(glDisplay)), m_qtDisplay(std::move(qtDisplay)) {}
+    : m_glDisplay(std::move(glDisplay)), m_qtDisplay(std::move(qtDisplay)) {
+  if (!m_glDisplay)
+    m_glDisplay = std::make_unique<GLDisplay>();
+
+  if (!m_qtDisplay)
+    m_qtDisplay = std::make_unique<QtDisplay>();
+}
 
 IGLDisplay *InstrumentDisplay::getGLDisplay() const { return m_glDisplay.get(); }
 

--- a/qt/widgets/instrumentview/src/InstrumentDisplay.cpp
+++ b/qt/widgets/instrumentview/src/InstrumentDisplay.cpp
@@ -1,0 +1,17 @@
+//+ Mantid Repository : https://github.com/mantidproject/mantid
+//
+// Copyright &copy; 2021 ISIS Rutherford Appleton Laboratory UKRI,
+//   NScD Oak Ridge National Laboratory, European Spallation Source,
+//   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+// SPDX - License - Identifier: GPL - 3.0
+#include "MantidQtWidgets/InstrumentView/InstrumentDisplay.h"
+
+namespace MantidQt::MantidWidgets {
+
+InstrumentDisplay::InstrumentDisplay(std::unique_ptr<IGLDisplay> glDisplay, std::unique_ptr<IQtDisplay> qtDisplay)
+    : m_glDisplay(std::move(glDisplay)), m_qtDisplay(std::move(qtDisplay)) {}
+
+IGLDisplay *InstrumentDisplay::getGLDisplay() const { return m_glDisplay.get(); }
+
+IQtDisplay *InstrumentDisplay::getQtDisplay() const { return m_qtDisplay.get(); }
+} // namespace MantidQt::MantidWidgets

--- a/qt/widgets/instrumentview/src/InstrumentDisplay.cpp
+++ b/qt/widgets/instrumentview/src/InstrumentDisplay.cpp
@@ -45,7 +45,4 @@ void InstrumentDisplay::installEventFilter(QObject *obj) {
   m_glDisplay->qtInstallEventFilter(obj);
   m_qtDisplay->qtInstallEventFilter(obj);
 }
-
-IStackedLayout *InstrumentDisplay::createLayout(QWidget *parent) const { return new StackedLayout(parent); }
-
 } // namespace MantidQt::MantidWidgets

--- a/qt/widgets/instrumentview/src/InstrumentDisplay.cpp
+++ b/qt/widgets/instrumentview/src/InstrumentDisplay.cpp
@@ -6,9 +6,12 @@
 // SPDX - License - Identifier: GPL - 3.0
 #include "MantidQtWidgets/InstrumentView/InstrumentDisplay.h"
 #include "MantidQtWidgets/InstrumentView/GLDisplay.h"
+#include "MantidQtWidgets/InstrumentView/IStackedLayout.h"
 #include "MantidQtWidgets/InstrumentView/QtDisplay.h"
+#include "MantidQtWidgets/InstrumentView/StackedLayout.h"
 
-#include <QStackedLayout>
+class QObject;
+class QWidget;
 
 namespace MantidQt::MantidWidgets {
 
@@ -21,7 +24,6 @@ InstrumentDisplay::InstrumentDisplay(std::unique_ptr<IGLDisplay> glDisplay, std:
   if (!m_qtDisplay)
     m_qtDisplay = std::make_unique<QtDisplay>();
 
-  // TODO test this
   m_instrumentDisplayLayout = createLayout(parent);
   m_instrumentDisplayLayout->addWidget(getGLDisplay());
   m_instrumentDisplayLayout->addWidget(getQtDisplay());
@@ -42,6 +44,6 @@ void InstrumentDisplay::installEventFilter(QObject *obj) {
   m_qtDisplay->qtInstallEventFilter(obj);
 }
 
-QStackedLayout *InstrumentDisplay::createLayout(QWidget *parent) const { return new QStackedLayout(parent); }
+IStackedLayout *InstrumentDisplay::createLayout(QWidget *parent) const { return new StackedLayout(parent); }
 
 } // namespace MantidQt::MantidWidgets

--- a/qt/widgets/instrumentview/src/InstrumentDisplay.cpp
+++ b/qt/widgets/instrumentview/src/InstrumentDisplay.cpp
@@ -22,7 +22,7 @@ InstrumentDisplay::InstrumentDisplay(std::unique_ptr<IGLDisplay> glDisplay, std:
     m_qtDisplay = std::make_unique<QtDisplay>();
 
   // TODO test this
-  m_instrumentDisplayLayout = new QStackedLayout(parent);
+  m_instrumentDisplayLayout = createLayout(parent);
   m_instrumentDisplayLayout->addWidget(getGLDisplay());
   m_instrumentDisplayLayout->addWidget(getQtDisplay());
 }
@@ -41,4 +41,7 @@ void InstrumentDisplay::installEventFilter(QObject *obj) {
   m_glDisplay->qtInstallEventFilter(obj);
   m_qtDisplay->qtInstallEventFilter(obj);
 }
+
+QStackedLayout *InstrumentDisplay::createLayout(QWidget *parent) const { return new QStackedLayout(parent); }
+
 } // namespace MantidQt::MantidWidgets

--- a/qt/widgets/instrumentview/src/InstrumentDisplay.cpp
+++ b/qt/widgets/instrumentview/src/InstrumentDisplay.cpp
@@ -22,4 +22,9 @@ InstrumentDisplay::InstrumentDisplay(std::unique_ptr<IGLDisplay> glDisplay, std:
 IGLDisplay *InstrumentDisplay::getGLDisplay() const { return m_glDisplay.get(); }
 
 IQtDisplay *InstrumentDisplay::getQtDisplay() const { return m_qtDisplay.get(); }
+
+void InstrumentDisplay::installEventFilter(QObject *obj) {
+  m_glDisplay->qtInstallEventFilter(obj);
+  m_qtDisplay->qtInstallEventFilter(obj);
+}
 } // namespace MantidQt::MantidWidgets

--- a/qt/widgets/instrumentview/src/InstrumentDisplay.cpp
+++ b/qt/widgets/instrumentview/src/InstrumentDisplay.cpp
@@ -8,16 +8,29 @@
 #include "MantidQtWidgets/InstrumentView/GLDisplay.h"
 #include "MantidQtWidgets/InstrumentView/QtDisplay.h"
 
+#include <QStackedLayout>
+
 namespace MantidQt::MantidWidgets {
 
-InstrumentDisplay::InstrumentDisplay(std::unique_ptr<IGLDisplay> glDisplay, std::unique_ptr<IQtDisplay> qtDisplay)
+InstrumentDisplay::InstrumentDisplay(std::unique_ptr<IGLDisplay> glDisplay, std::unique_ptr<IQtDisplay> qtDisplay,
+                                     QWidget *parent)
     : m_glDisplay(std::move(glDisplay)), m_qtDisplay(std::move(qtDisplay)) {
   if (!m_glDisplay)
     m_glDisplay = std::make_unique<GLDisplay>();
 
   if (!m_qtDisplay)
     m_qtDisplay = std::make_unique<QtDisplay>();
+
+  m_instrumentDisplayLayout = new QStackedLayout(parent);
+  m_instrumentDisplayLayout->addWidget(getGLDisplay());
+  m_instrumentDisplayLayout->addWidget(getQtDisplay());
 }
+
+int InstrumentDisplay::currentIndex() const { return m_instrumentDisplayLayout->currentIndex(); }
+
+QWidget *InstrumentDisplay::currentWidget() const { return m_instrumentDisplayLayout->currentWidget(); }
+
+void InstrumentDisplay::setCurrentIndex(int val) const { m_instrumentDisplayLayout->setCurrentIndex(val); }
 
 IGLDisplay *InstrumentDisplay::getGLDisplay() const { return m_glDisplay.get(); }
 

--- a/qt/widgets/instrumentview/src/InstrumentDisplay.cpp
+++ b/qt/widgets/instrumentview/src/InstrumentDisplay.cpp
@@ -15,16 +15,18 @@ class QWidget;
 
 namespace MantidQt::MantidWidgets {
 
-InstrumentDisplay::InstrumentDisplay(std::unique_ptr<IGLDisplay> glDisplay, std::unique_ptr<IQtDisplay> qtDisplay,
-                                     QWidget *parent)
-    : m_glDisplay(std::move(glDisplay)), m_qtDisplay(std::move(qtDisplay)) {
+InstrumentDisplay::InstrumentDisplay(QWidget *parent, std::unique_ptr<IGLDisplay> glDisplay,
+                                     std::unique_ptr<IQtDisplay> qtDisplay, std::unique_ptr<IStackedLayout> layout)
+    : m_glDisplay(std::move(glDisplay)), m_qtDisplay(std::move(qtDisplay)),
+      m_instrumentDisplayLayout(std::move(layout)) {
   if (!m_glDisplay)
     m_glDisplay = std::make_unique<GLDisplay>();
 
   if (!m_qtDisplay)
     m_qtDisplay = std::make_unique<QtDisplay>();
 
-  m_instrumentDisplayLayout = createLayout(parent);
+  if (!m_instrumentDisplayLayout)
+    m_instrumentDisplayLayout = std::make_unique<StackedLayout>(parent);
   m_instrumentDisplayLayout->addWidget(getGLDisplay());
   m_instrumentDisplayLayout->addWidget(getQtDisplay());
 }

--- a/qt/widgets/instrumentview/src/InstrumentDisplay.cpp
+++ b/qt/widgets/instrumentview/src/InstrumentDisplay.cpp
@@ -21,6 +21,7 @@ InstrumentDisplay::InstrumentDisplay(std::unique_ptr<IGLDisplay> glDisplay, std:
   if (!m_qtDisplay)
     m_qtDisplay = std::make_unique<QtDisplay>();
 
+  // TODO test this
   m_instrumentDisplayLayout = new QStackedLayout(parent);
   m_instrumentDisplayLayout->addWidget(getGLDisplay());
   m_instrumentDisplayLayout->addWidget(getQtDisplay());

--- a/qt/widgets/instrumentview/src/InstrumentWidget.cpp
+++ b/qt/widgets/instrumentview/src/InstrumentWidget.cpp
@@ -121,7 +121,7 @@ InstrumentWidget::InstrumentWidget(const QString &wsName, QWidget *parent, bool 
       m_qtConnect(std::move(deps.qtConnect)) {
   if (!m_instrumentDisplay) {
     m_instrumentDisplay =
-        std::make_unique<InstrumentDisplay>(std::move(deps.glDisplay), std::move(deps.qtDisplay), this);
+        std::make_unique<InstrumentDisplay>(this, std::move(deps.glDisplay), std::move(deps.qtDisplay));
   }
 
   setFocusPolicy(Qt::StrongFocus);

--- a/qt/widgets/instrumentview/src/InstrumentWidget.cpp
+++ b/qt/widgets/instrumentview/src/InstrumentWidget.cpp
@@ -128,12 +128,11 @@ InstrumentWidget::InstrumentWidget(const QString &wsName, QWidget *parent, bool 
   controlPanelLayout->addWidget(mControlsTab);
   controlPanelLayout->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
 
-  m_instrumentDisplay.getGLDisplay()->qtInstallEventFilter(this);
+  m_instrumentDisplay.installEventFilter(this);
+
   m_instrumentDisplay.getGLDisplay()->setMinimumWidth(600);
   m_qtConnect->connect(this, SIGNAL(enableLighting(bool)), m_instrumentDisplay.getGLDisplay(),
                        SLOT(enableLighting(bool)));
-
-  m_instrumentDisplay.getQtDisplay()->qtInstallEventFilter(this);
 
   QWidget *aWidget = new QWidget(this);
   m_instrumentDisplayLayout = new QStackedLayout(aWidget);

--- a/qt/widgets/instrumentview/src/InstrumentWidget.cpp
+++ b/qt/widgets/instrumentview/src/InstrumentWidget.cpp
@@ -119,9 +119,11 @@ InstrumentWidget::InstrumentWidget(const QString &wsName, QWidget *parent, bool 
       mViewChanged(false), m_blocked(false), m_instrumentDisplayContextMenuOn(false),
       m_stateOfTabs(std::vector<std::pair<std::string, bool>>{}), m_wsReplace(false), m_help(nullptr),
       m_qtConnect(std::move(deps.qtConnect)) {
+
+  QWidget *aWidget = new QWidget(this);
   if (!m_instrumentDisplay) {
     m_instrumentDisplay =
-        std::make_unique<InstrumentDisplay>(this, std::move(deps.glDisplay), std::move(deps.qtDisplay));
+        std::make_unique<InstrumentDisplay>(aWidget, std::move(deps.glDisplay), std::move(deps.qtDisplay));
   }
 
   setFocusPolicy(Qt::StrongFocus);
@@ -138,8 +140,6 @@ InstrumentWidget::InstrumentWidget(const QString &wsName, QWidget *parent, bool 
   m_instrumentDisplay->getGLDisplay()->setMinimumWidth(600);
   m_qtConnect->connect(this, SIGNAL(enableLighting(bool)), m_instrumentDisplay->getGLDisplay(),
                        SLOT(enableLighting(bool)));
-
-  QWidget *aWidget = new QWidget(this);
 
   controlPanelLayout->addWidget(aWidget);
 

--- a/qt/widgets/instrumentview/src/InstrumentWidget.cpp
+++ b/qt/widgets/instrumentview/src/InstrumentWidget.cpp
@@ -112,10 +112,10 @@ public:
  */
 InstrumentWidget::InstrumentWidget(const QString &wsName, QWidget *parent, bool resetGeometry, bool autoscaling,
                                    double scaleMin, double scaleMax, bool setDefaultView, Dependencies deps)
-    : QWidget(parent), WorkspaceObserver(), m_glDisplay(std::move(deps.glDisplay)),
-      m_qtDisplay(std::move(deps.qtDisplay)), m_workspaceName(wsName), m_instrumentActor(nullptr),
-      m_surfaceType(FULL3D), m_savedialog_dir(QString::fromStdString(
-                                 Mantid::Kernel::ConfigService::Instance().getString("defaultsave.directory"))),
+    : QWidget(parent), WorkspaceObserver(), m_instrumentDisplay(std::move(deps.glDisplay), std::move(deps.qtDisplay)),
+      m_workspaceName(wsName), m_instrumentActor(nullptr), m_surfaceType(FULL3D),
+      m_savedialog_dir(
+          QString::fromStdString(Mantid::Kernel::ConfigService::Instance().getString("defaultsave.directory"))),
       mViewChanged(false), m_blocked(false), m_instrumentDisplayContextMenuOn(false),
       m_stateOfTabs(std::vector<std::pair<std::string, bool>>{}), m_wsReplace(false), m_help(nullptr),
       m_qtConnect(std::move(deps.qtConnect)) {
@@ -128,22 +128,17 @@ InstrumentWidget::InstrumentWidget(const QString &wsName, QWidget *parent, bool 
   controlPanelLayout->addWidget(mControlsTab);
   controlPanelLayout->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
 
-  // Create the display widget
-  if (!m_glDisplay)
-    m_glDisplay = std::make_unique<GLDisplay>();
-  m_glDisplay->qtInstallEventFilter(this);
-  m_glDisplay->setMinimumWidth(600);
-  m_qtConnect->connect(this, SIGNAL(enableLighting(bool)), m_glDisplay.get(), SLOT(enableLighting(bool)));
+  m_instrumentDisplay.getGLDisplay()->qtInstallEventFilter(this);
+  m_instrumentDisplay.getGLDisplay()->setMinimumWidth(600);
+  m_qtConnect->connect(this, SIGNAL(enableLighting(bool)), m_instrumentDisplay.getGLDisplay(),
+                       SLOT(enableLighting(bool)));
 
-  // Create simple display widget
-  if (!m_qtDisplay)
-    m_qtDisplay = std::make_unique<QtDisplay>();
-  m_qtDisplay->qtInstallEventFilter(this);
+  m_instrumentDisplay.getQtDisplay()->qtInstallEventFilter(this);
 
   QWidget *aWidget = new QWidget(this);
   m_instrumentDisplayLayout = new QStackedLayout(aWidget);
-  m_instrumentDisplayLayout->addWidget(m_glDisplay.get());
-  m_instrumentDisplayLayout->addWidget(m_qtDisplay.get());
+  m_instrumentDisplayLayout->addWidget(m_instrumentDisplay.getGLDisplay());
+  m_instrumentDisplayLayout->addWidget(m_instrumentDisplay.getQtDisplay());
 
   controlPanelLayout->addWidget(aWidget);
 
@@ -827,9 +822,9 @@ void InstrumentWidget::saveImage(QString filename) {
   }
 
   if (isGLEnabled()) {
-    m_glDisplay->saveToFile(filename);
+    m_instrumentDisplay.getGLDisplay()->saveToFile(filename);
   } else {
-    m_qtDisplay->saveToFile(filename);
+    m_instrumentDisplay.getQtDisplay()->saveToFile(filename);
   }
 }
 
@@ -862,8 +857,8 @@ void InstrumentWidget::setInfoText(const QString &text) { mInteractionInfo->setT
 void InstrumentWidget::saveSettings() {
   QSettings settings;
   settings.beginGroup(InstrumentWidgetSettingsGroup);
-  if (m_glDisplay)
-    settings.setValue("BackgroundColor", m_glDisplay->currentBackgroundColor());
+  if (m_instrumentDisplay.getGLDisplay())
+    settings.setValue("BackgroundColor", m_instrumentDisplay.getGLDisplay()->currentBackgroundColor());
   auto surface = getSurface();
   if (surface) {
     // if surface is null istrument view wasn't created and there is nothing to
@@ -893,7 +888,7 @@ void InstrumentWidget::finishHandle(const Mantid::API::IAlgorithm *alg) {
   UNUSED_ARG(alg);
   emit needSetIntegrationRange(m_instrumentActor->minBinValue(), m_instrumentActor->maxBinValue());
   // m_instrumentActor->update();
-  // m_glDisplay->refreshView();
+  // m_instrumentDisplay.getGLDisplay()->refreshView();
 }
 
 void InstrumentWidget::changeScaleType(int type) {
@@ -1028,14 +1023,15 @@ void InstrumentWidget::dropEvent(QDropEvent *e) {
 }
 
 /**
- * Filter events directed to m_glDisplay and ContextMenuEvent in
+ * Filter events directed to m_instrumentDisplay.getGLDisplay() and ContextMenuEvent in
  * particular.
  * @param obj :: Object which events will be filtered.
  * @param ev :: An ingoing event.
  */
 bool InstrumentWidget::eventFilter(QObject *obj, QEvent *ev) {
   if (ev->type() == QEvent::ContextMenu &&
-      (dynamic_cast<GLDisplay *>(obj) == m_glDisplay.get() || dynamic_cast<QtDisplay *>(obj) == m_qtDisplay.get()) &&
+      (dynamic_cast<GLDisplay *>(obj) == m_instrumentDisplay.getGLDisplay() ||
+       dynamic_cast<QtDisplay *>(obj) == m_instrumentDisplay.getQtDisplay()) &&
       getSurface() && getSurface()->canShowContextMenu()) {
     // an ugly way of preventing the curve in the pick tab's miniplot
     // disappearing when
@@ -1163,8 +1159,8 @@ void InstrumentWidget::setShowPeakRelativeIntensity(bool on) {
  * @param color :: New background colour.
  */
 void InstrumentWidget::setBackgroundColor(const QColor &color) {
-  if (m_glDisplay)
-    m_glDisplay->setBackgroundColor(color);
+  if (m_instrumentDisplay.getGLDisplay())
+    m_instrumentDisplay.getGLDisplay()->setBackgroundColor(color);
 }
 
 /**
@@ -1179,10 +1175,10 @@ QString InstrumentWidget::getSurfaceInfoText() const {
  * Get pointer to the projection surface
  */
 ProjectionSurface_sptr InstrumentWidget::getSurface() const {
-  if (m_glDisplay) {
-    return m_glDisplay->getSurface();
-  } else if (m_qtDisplay) {
-    return m_qtDisplay->getSurface();
+  if (m_instrumentDisplay.getGLDisplay()) {
+    return m_instrumentDisplay.getGLDisplay()->getSurface();
+  } else if (m_instrumentDisplay.getQtDisplay()) {
+    return m_instrumentDisplay.getQtDisplay()->getSurface();
   }
   return ProjectionSurface_sptr();
 }
@@ -1195,13 +1191,13 @@ bool MantidQt::MantidWidgets::InstrumentWidget::isWsBeingReplaced() const { retu
  */
 void InstrumentWidget::setSurface(ProjectionSurface *surface) {
   ProjectionSurface_sptr sharedSurface(surface);
-  if (m_glDisplay) {
-    m_glDisplay->setSurface(sharedSurface);
-    m_glDisplay->update();
+  if (m_instrumentDisplay.getGLDisplay()) {
+    m_instrumentDisplay.getGLDisplay()->setSurface(sharedSurface);
+    m_instrumentDisplay.getGLDisplay()->update();
   }
-  if (m_qtDisplay) {
-    m_qtDisplay->setSurface(sharedSurface);
-    m_qtDisplay->qtUpdate();
+  if (m_instrumentDisplay.getQtDisplay()) {
+    m_instrumentDisplay.getQtDisplay()->setSurface(sharedSurface);
+    m_instrumentDisplay.getQtDisplay()->qtUpdate();
   }
   auto *unwrappedSurface = dynamic_cast<UnwrappedSurface *>(surface);
   if (unwrappedSurface) {
@@ -1219,10 +1215,10 @@ QSize InstrumentWidget::glWidgetDimensions() {
     return QSize(w->width() * devicePixelRatio, w->height() * devicePixelRatio);
   };
 #endif
-  if (m_glDisplay)
-    return sizeinLogicalPixels(m_glDisplay.get());
-  else if (m_qtDisplay)
-    return sizeinLogicalPixels(m_qtDisplay.get());
+  if (m_instrumentDisplay.getGLDisplay())
+    return sizeinLogicalPixels(m_instrumentDisplay.getGLDisplay());
+  else if (m_instrumentDisplay.getQtDisplay())
+    return sizeinLogicalPixels(m_instrumentDisplay.getQtDisplay());
   else
     return QSize(0, 0);
 }
@@ -1232,20 +1228,22 @@ QSize InstrumentWidget::glWidgetDimensions() {
 /// interaction
 ///   mode of the surface.
 void InstrumentWidget::updateInstrumentView(bool picking) {
-  if (m_glDisplay && m_instrumentDisplayLayout->currentWidget() == dynamic_cast<QWidget *>(m_glDisplay.get())) {
-    m_glDisplay->updateView(picking);
+  if (m_instrumentDisplay.getGLDisplay() &&
+      m_instrumentDisplayLayout->currentWidget() == dynamic_cast<QWidget *>(m_instrumentDisplay.getGLDisplay())) {
+    m_instrumentDisplay.getGLDisplay()->updateView(picking);
   } else {
-    m_qtDisplay->updateView(picking);
+    m_instrumentDisplay.getQtDisplay()->updateView(picking);
   }
 }
 
 /// Recalculate the colours and redraw the instrument view
 void InstrumentWidget::updateInstrumentDetectors() {
   QApplication::setOverrideCursor(QCursor(Qt::WaitCursor));
-  if (m_glDisplay && m_instrumentDisplayLayout->currentWidget() == dynamic_cast<QWidget *>(m_glDisplay.get())) {
-    m_glDisplay->updateDetectors();
+  if (m_instrumentDisplay.getGLDisplay() &&
+      m_instrumentDisplayLayout->currentWidget() == dynamic_cast<QWidget *>(m_instrumentDisplay.getGLDisplay())) {
+    m_instrumentDisplay.getGLDisplay()->updateDetectors();
   } else {
-    m_qtDisplay->updateDetectors();
+    m_instrumentDisplay.getQtDisplay()->updateDetectors();
   }
   QApplication::restoreOverrideCursor();
 }

--- a/qt/widgets/instrumentview/src/InstrumentWidget.cpp
+++ b/qt/widgets/instrumentview/src/InstrumentWidget.cpp
@@ -120,7 +120,8 @@ InstrumentWidget::InstrumentWidget(const QString &wsName, QWidget *parent, bool 
       m_stateOfTabs(std::vector<std::pair<std::string, bool>>{}), m_wsReplace(false), m_help(nullptr),
       m_qtConnect(std::move(deps.qtConnect)) {
   if (!m_instrumentDisplay) {
-    m_instrumentDisplay = std::make_unique<InstrumentDisplay>(std::move(deps.glDisplay), std::move(deps.qtDisplay));
+    m_instrumentDisplay =
+        std::make_unique<InstrumentDisplay>(std::move(deps.glDisplay), std::move(deps.qtDisplay), this);
   }
 
   setFocusPolicy(Qt::StrongFocus);
@@ -139,9 +140,6 @@ InstrumentWidget::InstrumentWidget(const QString &wsName, QWidget *parent, bool 
                        SLOT(enableLighting(bool)));
 
   QWidget *aWidget = new QWidget(this);
-  m_instrumentDisplayLayout = new QStackedLayout(aWidget);
-  m_instrumentDisplayLayout->addWidget(m_instrumentDisplay->getGLDisplay());
-  m_instrumentDisplayLayout->addWidget(m_instrumentDisplay->getQtDisplay());
 
   controlPanelLayout->addWidget(aWidget);
 
@@ -1232,7 +1230,7 @@ QSize InstrumentWidget::glWidgetDimensions() {
 ///   mode of the surface.
 void InstrumentWidget::updateInstrumentView(bool picking) {
   if (m_instrumentDisplay->getGLDisplay() &&
-      m_instrumentDisplayLayout->currentWidget() == dynamic_cast<QWidget *>(m_instrumentDisplay->getGLDisplay())) {
+      m_instrumentDisplay->currentWidget() == dynamic_cast<QWidget *>(m_instrumentDisplay->getGLDisplay())) {
     m_instrumentDisplay->getGLDisplay()->updateView(picking);
   } else {
     m_instrumentDisplay->getQtDisplay()->updateView(picking);
@@ -1243,7 +1241,7 @@ void InstrumentWidget::updateInstrumentView(bool picking) {
 void InstrumentWidget::updateInstrumentDetectors() {
   QApplication::setOverrideCursor(QCursor(Qt::WaitCursor));
   if (m_instrumentDisplay->getGLDisplay() &&
-      m_instrumentDisplayLayout->currentWidget() == dynamic_cast<QWidget *>(m_instrumentDisplay->getGLDisplay())) {
+      m_instrumentDisplay->currentWidget() == dynamic_cast<QWidget *>(m_instrumentDisplay->getGLDisplay())) {
     m_instrumentDisplay->getGLDisplay()->updateDetectors();
   } else {
     m_instrumentDisplay->getQtDisplay()->updateDetectors();
@@ -1262,10 +1260,10 @@ void InstrumentWidget::deletePeaksWorkspace(const Mantid::API::IPeaksWorkspace_s
  */
 void InstrumentWidget::selectOpenGLDisplay(bool yes) {
   int widgetIndex = yes ? 0 : 1;
-  const int oldIndex = m_instrumentDisplayLayout->currentIndex();
+  const int oldIndex = m_instrumentDisplay->currentIndex();
   if (oldIndex == widgetIndex)
     return;
-  m_instrumentDisplayLayout->setCurrentIndex(widgetIndex);
+  m_instrumentDisplay->setCurrentIndex(widgetIndex);
   auto surface = getSurface();
   if (surface) {
     surface->updateView();

--- a/qt/widgets/instrumentview/src/InstrumentWidget.cpp
+++ b/qt/widgets/instrumentview/src/InstrumentWidget.cpp
@@ -1,9 +1,9 @@
-// Mantid Repository : https://github.com/mantidproject/mantid
+//+ Mantid Repository : https://github.com/mantidproject/mantid
 //
 // Copyright &copy; 2018 ISIS Rutherford Appleton Laboratory UKRI,
 //   NScD Oak Ridge National Laboratory, European Spallation Source,
 //   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
-// SPDX - License - Identifier: GPL - 3.0 +
+// SPDX - License - Identifier: GPL - 3.0
 #include "MantidQtWidgets/InstrumentView/InstrumentWidget.h"
 #include "MantidGeometry/Instrument/ComponentInfo.h"
 #include "MantidGeometry/Instrument/DetectorInfo.h"
@@ -130,14 +130,14 @@ InstrumentWidget::InstrumentWidget(const QString &wsName, QWidget *parent, bool 
 
   // Create the display widget
   if (!m_glDisplay)
-    m_glDisplay = std::make_unique<GLDisplay>(this);
+    m_glDisplay = std::make_unique<GLDisplay>();
   m_glDisplay->qtInstallEventFilter(this);
   m_glDisplay->setMinimumWidth(600);
   m_qtConnect->connect(this, SIGNAL(enableLighting(bool)), m_glDisplay.get(), SLOT(enableLighting(bool)));
 
   // Create simple display widget
   if (!m_qtDisplay)
-    m_qtDisplay = std::make_unique<QtDisplay>(this);
+    m_qtDisplay = std::make_unique<QtDisplay>();
   m_qtDisplay->qtInstallEventFilter(this);
 
   QWidget *aWidget = new QWidget(this);

--- a/qt/widgets/instrumentview/test/CMakeLists.txt
+++ b/qt/widgets/instrumentview/test/CMakeLists.txt
@@ -7,6 +7,7 @@ set(
   PlotFitAnalysisPaneModelTest.h
   PlotFitAnalysisPanePresenterTest.h
 
+  InstrumentWidget/InstrumentDisplayTest.h
   InstrumentWidget/InstrumentWidgetTest.h
 )
 

--- a/qt/widgets/instrumentview/test/InstrumentWidget/InstrumentDisplayTest.h
+++ b/qt/widgets/instrumentview/test/InstrumentWidget/InstrumentDisplayTest.h
@@ -1,0 +1,47 @@
+// Mantid Repository : https://github.com/mantidproject/mantid
+//
+// Copyright &copy; 2021 ISIS Rutherford Appleton Laboratory UKRI,
+//   NScD Oak Ridge National Laboratory, European Spallation Source,
+//   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+// SPDX - License - Identifier: GPL - 3.0 +
+#pragma once
+
+#include "IGLDisplay.h"
+#include "IQtDisplay.h"
+#include "InstrumentDisplay.h"
+#include "MockGLDisplay.h"
+#include "MockQtDisplay.h"
+
+#include <QObject>
+
+#include <cxxtest/TestSuite.h>
+#include <gmock/gmock.h>
+#include <memory>
+
+using namespace MantidQt::MantidWidgets;
+using namespace testing;
+
+class InstrumentDisplayTest : public CxxTest::TestSuite {
+public:
+  static InstrumentDisplayTest *createSuite() { return new InstrumentDisplayTest(); }
+  static void destroySuite(InstrumentDisplayTest *suite) { delete suite; }
+
+  using QtMock = MockQtDisplay;
+  using GLMock = MockGLDisplay;
+
+  void test_install_event_filter() {
+    auto qtMock = makeQtDisplay();
+    auto glMock = makeGLDisplay();
+    EXPECT_CALL(*qtMock, qtInstallEventFilter(IsNull())).Times(1);
+    EXPECT_CALL(*glMock, qtInstallEventFilter(IsNull())).Times(1);
+    auto instDisplay = makeInstDisplay(std::move(glMock), std::move(qtMock));
+    instDisplay.installEventFilter(nullptr);
+  }
+
+private:
+  std::unique_ptr<QtMock> makeQtDisplay() const { return std::make_unique<QtMock>(); }
+  std::unique_ptr<GLMock> makeGLDisplay() { return std::make_unique<GLMock>(); }
+  InstrumentDisplay makeInstDisplay(std::unique_ptr<GLMock> glMock, std::unique_ptr<QtMock> qtMock) {
+    return InstrumentDisplay(std::move(glMock), std::move(qtMock));
+  }
+};

--- a/qt/widgets/instrumentview/test/InstrumentWidget/InstrumentDisplayTest.h
+++ b/qt/widgets/instrumentview/test/InstrumentWidget/InstrumentDisplayTest.h
@@ -22,17 +22,6 @@
 using namespace MantidQt::MantidWidgets;
 using namespace testing;
 
-class FakeInstrumentDisplay : public InstrumentDisplay {
-public:
-  FakeInstrumentDisplay(MockStackedLayout &mockLayout, std::unique_ptr<IGLDisplay> glDisplay,
-                        std::unique_ptr<IQtDisplay> qtDisplay)
-      : InstrumentDisplay(std::move(glDisplay), std::move(qtDisplay), nullptr), m_mockLayout(mockLayout) {}
-  IStackedLayout *createLayout(QWidget *) const override { return &m_mockLayout; }
-
-private:
-  MockStackedLayout &m_mockLayout;
-};
-
 class InstrumentDisplayTest : public CxxTest::TestSuite {
 public:
   static InstrumentDisplayTest *createSuite() { return new InstrumentDisplayTest(); }
@@ -54,17 +43,17 @@ public:
     auto qtMock = makeQtDisplay();
     auto glMock = makeGLDisplay();
 
-    StrictMock<MockStackedLayout> mock;
-    EXPECT_CALL(mock, addWidget(glMock.get())).Times(1);
-    EXPECT_CALL(mock, addWidget(qtMock.get())).Times(1);
+    auto layoutMock = std::make_unique<MockStackedLayout>();
+    EXPECT_CALL(*layoutMock, addWidget(Eq(glMock.get()))).Times(1);
+    EXPECT_CALL(*layoutMock, addWidget(Eq(qtMock.get()))).Times(1);
 
-    FakeInstrumentDisplay fixture(mock, std::move(glMock), std::move(qtMock));
+    InstrumentDisplay fixture(nullptr, std::move(glMock), std::move(qtMock), std::move(layoutMock));
   }
 
 private:
   std::unique_ptr<QtMock> makeQtDisplay() const { return std::make_unique<QtMock>(); }
   std::unique_ptr<GLMock> makeGLDisplay() { return std::make_unique<GLMock>(); }
   InstrumentDisplay makeInstDisplay(std::unique_ptr<GLMock> glMock, std::unique_ptr<QtMock> qtMock) {
-    return InstrumentDisplay(std::move(glMock), std::move(qtMock), nullptr);
+    return InstrumentDisplay(nullptr, std::move(glMock), std::move(qtMock), nullptr);
   }
 };

--- a/qt/widgets/instrumentview/test/InstrumentWidget/InstrumentDisplayTest.h
+++ b/qt/widgets/instrumentview/test/InstrumentWidget/InstrumentDisplayTest.h
@@ -42,6 +42,6 @@ private:
   std::unique_ptr<QtMock> makeQtDisplay() const { return std::make_unique<QtMock>(); }
   std::unique_ptr<GLMock> makeGLDisplay() { return std::make_unique<GLMock>(); }
   InstrumentDisplay makeInstDisplay(std::unique_ptr<GLMock> glMock, std::unique_ptr<QtMock> qtMock) {
-    return InstrumentDisplay(std::move(glMock), std::move(qtMock));
+    return InstrumentDisplay(std::move(glMock), std::move(qtMock), nullptr);
   }
 };

--- a/qt/widgets/instrumentview/test/InstrumentWidget/InstrumentWidgetTest.h
+++ b/qt/widgets/instrumentview/test/InstrumentWidget/InstrumentWidgetTest.h
@@ -100,7 +100,6 @@ public:
     auto displayMock = makeDisplay();
     EXPECT_CALL(*glMock, updateDetectors()).Times(1);
     EXPECT_CALL(*displayMock, currentWidget()).Times(1).WillOnce(Return(glMock.get()));
-    // ON_CALL(*displayMock, currentIndex()).WillByDefault(Return(0));
 
     auto widget = construct(std::move(displayMock), qtMock.get(), glMock.get(), makeConnect());
     widget.updateInstrumentDetectors();
@@ -112,8 +111,6 @@ public:
     auto displayMock = makeDisplay();
     EXPECT_CALL(*qtMock, updateDetectors()).Times(1);
     EXPECT_CALL(*displayMock, currentWidget()).Times(1).WillOnce(Return(qtMock.get()));
-    // ON_CALL(*displayMock, currentIndex()).WillByDefault(Return(0));
-
     auto widget = construct(std::move(displayMock), qtMock.get(), glMock.get(), makeConnect());
     widget.updateInstrumentDetectors();
   }
@@ -142,6 +139,59 @@ public:
 
     auto widget = construct(std::move(displayMock), qtMock.get(), glMock.get(), makeConnect());
     widget.updateInstrumentDetectors();
+  }
+
+  void test_update_instrument_view_gl_display_selected() {
+    for (bool expected : {true, false}) {
+      auto qtMock = makeQtDisplay();
+      auto glMock = makeGL();
+      auto displayMock = makeDisplay();
+      EXPECT_CALL(*glMock, updateView(expected)).Times(1);
+      EXPECT_CALL(*displayMock, currentWidget()).Times(1).WillOnce(Return(glMock.get()));
+      auto widget = construct(std::move(displayMock), qtMock.get(), glMock.get(), makeConnect());
+      widget.updateInstrumentView(expected);
+    }
+  }
+
+  void test_update_instrument_view_qt_display_selected() {
+    for (bool expected : {true, false}) {
+      auto qtMock = makeQtDisplay();
+      auto glMock = makeGL();
+      auto displayMock = makeDisplay();
+      EXPECT_CALL(*qtMock, updateView(expected)).Times(1);
+      EXPECT_CALL(*displayMock, currentWidget()).Times(1).WillOnce(Return(qtMock.get()));
+      auto widget = construct(std::move(displayMock), qtMock.get(), glMock.get(), makeConnect());
+      widget.updateInstrumentView(expected);
+    }
+  }
+
+  void test_update_instrument_view_gl_disabled() {
+    // When GL is disabled, but somehow we still have a GL Display, we expect an update on that
+    for (bool expected : {true, false}) {
+      setGl(false);
+      auto qtMock = makeQtDisplay();
+      auto glMock = makeGL();
+      auto displayMock = makeDisplay();
+      EXPECT_CALL(*glMock, updateView(expected)).Times(1);
+      EXPECT_CALL(*displayMock, currentWidget()).Times(1).WillOnce(Return(glMock.get()));
+
+      auto widget = construct(std::move(displayMock), qtMock.get(), glMock.get(), makeConnect());
+      widget.updateInstrumentView(expected);
+    }
+  }
+
+  void test_update_instrument_view_gl_disabled_qt_display_selected() {
+    for (bool expected : {true, false}) {
+      setGl(false);
+      auto qtMock = makeQtDisplay();
+      auto glMock = makeGL();
+      auto displayMock = makeDisplay();
+      EXPECT_CALL(*qtMock, updateView(expected)).Times(1);
+      EXPECT_CALL(*displayMock, currentWidget()).Times(1).WillOnce(Return(qtMock.get()));
+
+      auto widget = construct(std::move(displayMock), qtMock.get(), glMock.get(), makeConnect());
+      widget.updateInstrumentView(expected);
+    }
   }
 
 private:

--- a/qt/widgets/instrumentview/test/InstrumentWidget/InstrumentWidgetTest.h
+++ b/qt/widgets/instrumentview/test/InstrumentWidget/InstrumentWidgetTest.h
@@ -94,7 +94,7 @@ public:
     widget.saveImage(inputName);
   }
 
-  void test_update_instrument_detectors_gl_enabled() {
+  void test_update_instrument_detectors_gl_display_selected() {
     auto qtMock = makeQtDisplay();
     auto glMock = makeGL();
     auto displayMock = makeDisplay();
@@ -106,7 +106,33 @@ public:
     widget.updateInstrumentDetectors();
   }
 
+  void test_update_instrument_detectors_qt_display_selected() {
+    auto qtMock = makeQtDisplay();
+    auto glMock = makeGL();
+    auto displayMock = makeDisplay();
+    EXPECT_CALL(*qtMock, updateDetectors()).Times(1);
+    EXPECT_CALL(*displayMock, currentWidget()).Times(1).WillOnce(Return(qtMock.get()));
+    // ON_CALL(*displayMock, currentIndex()).WillByDefault(Return(0));
+
+    auto widget = construct(std::move(displayMock), qtMock.get(), glMock.get(), makeConnect());
+    widget.updateInstrumentDetectors();
+  }
+
   void test_update_instrument_detectors_gl_disabled() {
+    // When GL is disabled, but somehow we still have a GL Display, we expect an update on that
+    // This is likely a bug, but we are ensuring bug-compatibility
+    setGl(false);
+    auto qtMock = makeQtDisplay();
+    auto glMock = makeGL();
+    auto displayMock = makeDisplay();
+    EXPECT_CALL(*glMock, updateDetectors()).Times(1);
+    EXPECT_CALL(*displayMock, currentWidget()).Times(1).WillOnce(Return(glMock.get()));
+
+    auto widget = construct(std::move(displayMock), qtMock.get(), glMock.get(), makeConnect());
+    widget.updateInstrumentDetectors();
+  }
+
+  void test_update_instrument_detectors_gl_disabled_qt_display_selected() {
     setGl(false);
     auto qtMock = makeQtDisplay();
     auto glMock = makeGL();

--- a/qt/widgets/instrumentview/test/InstrumentWidget/InstrumentWidgetTest.h
+++ b/qt/widgets/instrumentview/test/InstrumentWidget/InstrumentWidgetTest.h
@@ -59,14 +59,14 @@ public:
   void test_constructor() {
     auto qtMock = makeQtDisplay();
     auto glMock = makeGL();
-    auto instance = construct(makeDisplay(), qtMock.release(), glMock.release(), makeConnect());
+    auto instance = construct(makeDisplay(), qtMock.get(), glMock.get(), makeConnect());
   }
 
   void test_constructor_gl_disabled() {
     setGl(false);
     auto qtMock = makeQtDisplay();
     auto glMock = makeGL();
-    auto instance = construct(makeDisplay(), qtMock.release(), glMock.release(), makeConnect());
+    auto instance = construct(makeDisplay(), qtMock.get(), glMock.get(), makeConnect());
   }
 
   void test_save_image_gl_enabled() {
@@ -77,7 +77,7 @@ public:
     auto glMock = makeGL();
     EXPECT_CALL(*glMock, saveToFile(expectedName)).Times(1);
 
-    auto widget = construct(makeDisplay(), qtMock.release(), glMock.release(), makeConnect());
+    auto widget = construct(makeDisplay(), qtMock.get(), glMock.get(), makeConnect());
     widget.saveImage(inputName);
   }
 
@@ -90,16 +90,19 @@ public:
     auto glMock = makeGL();
     EXPECT_CALL(*qtMock, saveToFile(expectedName)).Times(1);
 
-    auto widget = construct(makeDisplay(), qtMock.release(), glMock.release(), makeConnect());
+    auto widget = construct(makeDisplay(), qtMock.get(), glMock.get(), makeConnect());
     widget.saveImage(inputName);
   }
 
   void test_update_instrument_detectors_gl_enabled() {
     auto qtMock = makeQtDisplay();
     auto glMock = makeGL();
+    auto displayMock = makeDisplay();
     EXPECT_CALL(*glMock, updateDetectors()).Times(1);
+    EXPECT_CALL(*displayMock, currentWidget()).Times(1).WillOnce(Return(glMock.get()));
+    // ON_CALL(*displayMock, currentIndex()).WillByDefault(Return(0));
 
-    auto widget = construct(makeDisplay(), qtMock.release(), glMock.release(), makeConnect());
+    auto widget = construct(std::move(displayMock), qtMock.get(), glMock.get(), makeConnect());
     widget.updateInstrumentDetectors();
   }
 
@@ -107,9 +110,11 @@ public:
     setGl(false);
     auto qtMock = makeQtDisplay();
     auto glMock = makeGL();
+    auto displayMock = makeDisplay();
     EXPECT_CALL(*qtMock, updateDetectors()).Times(1);
+    EXPECT_CALL(*displayMock, currentWidget()).Times(1).WillOnce(Return(qtMock.get()));
 
-    auto widget = construct(makeDisplay(), qtMock.release(), glMock.release(), makeConnect());
+    auto widget = construct(std::move(displayMock), qtMock.get(), glMock.get(), makeConnect());
     widget.updateInstrumentDetectors();
   }
 

--- a/qt/widgets/instrumentview/test/InstrumentWidget/MockInstrumentDisplay.h
+++ b/qt/widgets/instrumentview/test/InstrumentWidget/MockInstrumentDisplay.h
@@ -27,8 +27,5 @@ public:
   MOCK_METHOD(IGLDisplay *, getGLDisplay, (), (const, override));
   MOCK_METHOD(IQtDisplay *, getQtDisplay, (), (const, override));
   MOCK_METHOD(void, installEventFilter, (QObject * obj), (override));
-
-  // Private methods
-  MOCK_METHOD(IStackedLayout *, createLayout, (QWidget *), (const, override));
 };
 } // namespace MantidQt::MantidWidgets

--- a/qt/widgets/instrumentview/test/InstrumentWidget/MockInstrumentDisplay.h
+++ b/qt/widgets/instrumentview/test/InstrumentWidget/MockInstrumentDisplay.h
@@ -17,6 +17,9 @@ namespace MantidQt::MantidWidgets {
 
 class MockInstrumentDisplay : public IInstrumentDisplay {
 public:
+  MOCK_METHOD(int, currentIndex, (), (const, override));
+  MOCK_METHOD(QWidget *, currentWidget, (), (const, override));
+  MOCK_METHOD(void, setCurrentIndex, (int), (const, override));
   MOCK_METHOD(IGLDisplay *, getGLDisplay, (), (const, override));
   MOCK_METHOD(IQtDisplay *, getQtDisplay, (), (const, override));
   MOCK_METHOD(void, installEventFilter, (QObject * obj), (override));

--- a/qt/widgets/instrumentview/test/InstrumentWidget/MockInstrumentDisplay.h
+++ b/qt/widgets/instrumentview/test/InstrumentWidget/MockInstrumentDisplay.h
@@ -6,26 +6,19 @@
 // SPDX - License - Identifier: GPL - 3.0 +
 #pragma once
 
-#include "DllOption.h"
 #include "IGLDisplay.h"
 #include "IInstrumentDisplay.h"
 #include "IQtDisplay.h"
 
+#include <gmock/gmock.h>
 #include <memory>
 
 namespace MantidQt::MantidWidgets {
 
-class EXPORT_OPT_MANTIDQT_INSTRUMENTVIEW InstrumentDisplay : public IInstrumentDisplay {
+class MockInstrumentDisplay : public IInstrumentDisplay {
 public:
-  InstrumentDisplay(std::unique_ptr<IGLDisplay> glDisplay, std::unique_ptr<IQtDisplay> qtDisplay);
-
-  IGLDisplay *getGLDisplay() const override;
-  IQtDisplay *getQtDisplay() const override;
-
-  void installEventFilter(QObject *obj) override;
-
-private:
-  std::unique_ptr<IGLDisplay> m_glDisplay;
-  std::unique_ptr<IQtDisplay> m_qtDisplay;
+  MOCK_METHOD(IGLDisplay *, getGLDisplay, (), (const, override));
+  MOCK_METHOD(IQtDisplay *, getQtDisplay, (), (const, override));
+  MOCK_METHOD(void, installEventFilter, (QObject * obj), (override));
 };
 } // namespace MantidQt::MantidWidgets

--- a/qt/widgets/instrumentview/test/InstrumentWidget/MockInstrumentDisplay.h
+++ b/qt/widgets/instrumentview/test/InstrumentWidget/MockInstrumentDisplay.h
@@ -13,6 +13,9 @@
 #include <gmock/gmock.h>
 #include <memory>
 
+class QStackedLayout;
+class QWidget;
+
 namespace MantidQt::MantidWidgets {
 
 class MockInstrumentDisplay : public IInstrumentDisplay {
@@ -23,5 +26,8 @@ public:
   MOCK_METHOD(IGLDisplay *, getGLDisplay, (), (const, override));
   MOCK_METHOD(IQtDisplay *, getQtDisplay, (), (const, override));
   MOCK_METHOD(void, installEventFilter, (QObject * obj), (override));
+
+  // Private methods
+  MOCK_METHOD(QStackedLayout *, createLayout, (QWidget *), (const, override));
 };
 } // namespace MantidQt::MantidWidgets

--- a/qt/widgets/instrumentview/test/InstrumentWidget/MockStackedLayout.h
+++ b/qt/widgets/instrumentview/test/InstrumentWidget/MockStackedLayout.h
@@ -6,29 +6,18 @@
 // SPDX - License - Identifier: GPL - 3.0 +
 #pragma once
 
-#include "IGLDisplay.h"
-#include "IInstrumentDisplay.h"
-#include "IQtDisplay.h"
+#include "IStackedLayout.h"
 
 #include <gmock/gmock.h>
-#include <memory>
 
-class IStackedLayout;
-class QStackedLayout;
 class QWidget;
 
 namespace MantidQt::MantidWidgets {
-
-class MockInstrumentDisplay : public IInstrumentDisplay {
+class MockStackedLayout : public IStackedLayout {
 public:
+  MOCK_METHOD(int, addWidget, (QWidget *), (override));
   MOCK_METHOD(int, currentIndex, (), (const, override));
   MOCK_METHOD(QWidget *, currentWidget, (), (const, override));
-  MOCK_METHOD(void, setCurrentIndex, (int), (const, override));
-  MOCK_METHOD(IGLDisplay *, getGLDisplay, (), (const, override));
-  MOCK_METHOD(IQtDisplay *, getQtDisplay, (), (const, override));
-  MOCK_METHOD(void, installEventFilter, (QObject * obj), (override));
-
-  // Private methods
-  MOCK_METHOD(IStackedLayout *, createLayout, (QWidget *), (const, override));
+  MOCK_METHOD(void, setCurrentIndex, (int), (override));
 };
 } // namespace MantidQt::MantidWidgets


### PR DESCRIPTION
**Description of work**
This PR creates an InstrumentDisplay class which wraps the QtDisplay and GLDisplay members of InstrumentWidget. This is part of work to make these components modular and usable elsewhere.

**To test:**

<!-- Instructions for testing. -->

- Load some data e.g. `ws=Load('GEM40979')`
- Open Instrument Viewer 
- Test with GL both enabled and disabled
- Ensure everything still works as expected.

Part of #31739

*This does not require release notes* because **it concerns tests/refactoring only**


---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
