### PR TITLE
Update linux VSCode debug instructions

### DIFF
--- a/dev-docs/source/VSCode.rst
+++ b/dev-docs/source/VSCode.rst
@@ -168,10 +168,7 @@ To debug C++ and start directly into the Workbench, add this to the configuratio
       "args": ["Path/To/Build/Directory/bin/workbench", "&&","gdb","/usr/bin/python3","$!"], // $! gets the process ID
       "stopAtEntry": false,
       "cwd": "Path/To/Build/Directory/bin", // this should point to bin inside the build directory
-      "environment": [
-        {"name":"LD_PRELOAD", "value": "/usr/lib/x86_64-linux-gnu/libjemalloc.so.1"},
-        {"name":"PYTHONPATH", "value": "Path/To/Build/Directory/bin:${env:PYTHONPATH}"}
-      ],
+      "environment": [],
       "externalConsole": true,
       "MIMode": "gdb",
       "preLaunchTask": "Build Mantid",
@@ -184,7 +181,16 @@ To debug C++ and start directly into the Workbench, add this to the configuratio
       ]
     }
 
-The correct value for the ``LD_PRELOAD`` environment variable can be found in Path/To/Build/Directory/bin/launch_mantidworkbench.sh.
+If this fails, try adding the following environment variables:
+
+.. code-block:: javascript
+
+      "environment": [
+        {"name":"LD_PRELOAD", "value": "/usr/lib/x86_64-linux-gnu/libjemalloc.so.1"},
+        {"name":"PYTHONPATH", "value": "Path/To/Build/Directory/bin:${env:PYTHONPATH}"}
+      ],
+
+where the correct value for the ``LD_PRELOAD`` environment variable can be found in Path/To/Build/Directory/bin/launch_mantidworkbench.sh.
 
 
 **Windows:**

--- a/dev-docs/source/VSCode.rst
+++ b/dev-docs/source/VSCode.rst
@@ -168,8 +168,11 @@ To debug C++ and start directly into the Workbench, add this to the configuratio
       "args": ["Path/To/Build/Directory/bin/workbench", "&&","gdb","/usr/bin/python3","$!"], // $! gets the process ID
       "stopAtEntry": false,
       "cwd": "Path/To/Build/Directory/bin", // this should point to bin inside the build directory
-      "environment": [],
-      "externalConsole": false,
+      "environment": [
+        {"name":"LD_PRELOAD", "value": "/usr/lib/x86_64-linux-gnu/libjemalloc.so.1"},
+        {"name":"PYTHONPATH", "value": "Path/To/Build/Directory/bin:${env:PYTHONPATH}"}
+      ],
+      "externalConsole": true,
       "MIMode": "gdb",
       "preLaunchTask": "Build Mantid",
       "setupCommands": [
@@ -181,6 +184,7 @@ To debug C++ and start directly into the Workbench, add this to the configuratio
       ]
     }
 
+The correct value for the ``LD_PRELOAD`` environment variable can be found in Path/To/Build/Directory/bin/launch_mantidworkbench.sh.
 
 
 **Windows:**


### PR DESCRIPTION
**Description of work.**
Added a couple of extra lines to the instructions for setting up a debug configuration in Visual Studio Code on Linux.

**To test:**
- Build the dev docs
- Open <build-dir>/dev-docs/html/VSCode.html
- Copy the configuration under
"*To debug C++ and start directly into the Workbench, add this to the configuration...*"
to your VSCode launch.json list of configurations and edit it accordingly
- Check that the configuuration runs correctly

*There is no associated issue.*

*This does not require release notes* because it is an update to the dev docs.

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
