### PR TITLE
Fix virtual destructor warning for IAlgorirthmProgressWidget*

### DIFF
--- a/qt/widgets/common/inc/MantidQtWidgets/Common/AlgorithmProgress/IAlgorithmProgressWidget.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/AlgorithmProgress/IAlgorithmProgressWidget.h
@@ -12,6 +12,7 @@ namespace MantidWidgets {
 class IAlgorithmProgressWidget {
 public:
   IAlgorithmProgressWidget() = default;
+  virtual ~IAlgorithmProgressWidget() = default;
 
   virtual void algorithmStarted() = 0;
   virtual void algorithmEnded() = 0;

--- a/qt/widgets/common/test/AlgorithmProgress/MockAlgorithmProgressDialogWidget.h
+++ b/qt/widgets/common/test/AlgorithmProgress/MockAlgorithmProgressDialogWidget.h
@@ -20,5 +20,6 @@ class QWidget;
 
 class MockAlgorithmProgressDialogWidget : public IAlgorithmProgressDialogWidget {
 public:
+  virtual ~MockAlgorithmProgressDialogWidget() = default;
   MOCK_METHOD((std::pair<QTreeWidgetItem *, QProgressBar *>), addAlgorithm, (Mantid::API::IAlgorithm_sptr), (override));
 };

--- a/qt/widgets/common/test/AlgorithmProgress/MockAlgorithmProgressWidget.h
+++ b/qt/widgets/common/test/AlgorithmProgress/MockAlgorithmProgressWidget.h
@@ -19,6 +19,7 @@ class QWidget;
 
 class MockAlgorithmProgressWidget : public IAlgorithmProgressWidget {
 public:
+  virtual ~MockAlgorithmProgressWidget() = default;
   MOCK_METHOD(void, algorithmStarted, (), (override));
   MOCK_METHOD(void, algorithmEnded, (), (override));
   MOCK_METHOD(void, updateProgress, (const double, const QString &, const double, const int), (override));


### PR DESCRIPTION
**Description of work.**
Fixes the virtual destructor warning, this fix originally was two parts but now is one:

- Correctly add a virtual dtor to IAlgorithmProgressWidget

Note: I cannot reproduce them locally with a different XCode version, so this is a speculative fix

**To test:**
- Check the OSX job does not have the following warning: `delete called on non-final 'MockAlgorithmProgressWidget' that has virtual functions but non-virtual destructor`

*There is no associated issue.*

*This does not require release notes* because it is a regression on Master affecting builds

<!-- Ensure the base of this PR is correct (e.g. release-next or master)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
