### PR TITLE
Store last used RB number on Engineering Diffraction interface

### DIFF
--- a/docs/source/release/v6.2.0/diffraction.rst
+++ b/docs/source/release/v6.2.0/diffraction.rst
@@ -35,6 +35,7 @@ New features
 ############
 - New setting for default peak function to fit in the Engineering Diffraction interface (initial default is :ref:`BackToBackExponential <func-BackToBackExponential>`).
 - Added serial fit capability to fitting tab in EngDiff UI - this fits all loaded workspaces with same initial parameters.
+- The last used RB number is now saved for the next session
 
 Improvements
 ############

--- a/scripts/Engineering/gui/engineering_diffraction/engineering_diffraction.py
+++ b/scripts/Engineering/gui/engineering_diffraction/engineering_diffraction.py
@@ -60,6 +60,10 @@ class EngineeringDiffractionGui(QtWidgets.QMainWindow, Ui_main_window):
         self.set_on_instrument_changed(self.presenter.focus_presenter.set_instrument_override)
         self.set_on_rb_num_changed(self.presenter.focus_presenter.set_rb_num)
 
+        # load previous rb number if saved, create mechanism to save
+        self.set_rb_no(self.presenter.get_saved_rb_number())
+        self.set_on_rb_num_changed(self.presenter.set_saved_rb_number)
+
         # Usage Reporting
         try:
             import mantid
@@ -103,6 +107,9 @@ class EngineeringDiffractionGui(QtWidgets.QMainWindow, Ui_main_window):
 
     def get_rb_no(self):
         return self.lineEdit_RBNumber.text()
+
+    def set_rb_no(self, text) -> None:
+        self.lineEdit_RBNumber.setText(text)
 
     def set_on_help_clicked(self, slot):
         self.pushButton_help.clicked.connect(slot)

--- a/scripts/Engineering/gui/engineering_diffraction/presenter.py
+++ b/scripts/Engineering/gui/engineering_diffraction/presenter.py
@@ -5,8 +5,8 @@
 #   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
 # SPDX - License - Identifier: GPL - 3.0 +
 
+from .tabs.common import path_handling
 from .tabs.common import CalibrationObserver
-from .tabs.common.path_handling import get_run_number_from_path
 from .tabs.calibration.model import CalibrationModel
 from .tabs.calibration.view import CalibrationView
 from .tabs.calibration.presenter import CalibrationPresenter
@@ -18,6 +18,7 @@ from .tabs.fitting.presenter import FittingPresenter
 from .settings.settings_model import SettingsModel
 from .settings.settings_view import SettingsView
 from .settings.settings_presenter import SettingsPresenter
+from .settings.settings_helper import get_setting, set_setting
 
 from mantidqt.interfacemanager import InterfaceManager
 from mantidqt.utils.observer_pattern import GenericObservable
@@ -90,6 +91,15 @@ class EngineeringDiffractionPresenter(object):
 
     def update_calibration(self, calibration):
         instrument = calibration.get_instrument()
-        van_no = get_run_number_from_path(calibration.get_vanadium(), instrument)
-        sample_no = get_run_number_from_path(calibration.get_sample(), instrument)
+        van_no = path_handling.get_run_number_from_path(calibration.get_vanadium(), instrument)
+        sample_no = path_handling.get_run_number_from_path(calibration.get_sample(), instrument)
         self.statusbar_observable.notify_subscribers(f"V: {van_no}, CeO2: {sample_no}, Instrument: {instrument}")
+
+    @staticmethod
+    def get_saved_rb_number() -> str:
+        rb_number = get_setting(path_handling.INTERFACES_SETTINGS_GROUP, path_handling.ENGINEERING_PREFIX, "rb_number")
+        return rb_number
+
+    @staticmethod
+    def set_saved_rb_number(rb_number) -> None:
+        set_setting(path_handling.INTERFACES_SETTINGS_GROUP, path_handling.ENGINEERING_PREFIX, "rb_number", rb_number)

--- a/scripts/Engineering/gui/engineering_diffraction/settings/settings_presenter.py
+++ b/scripts/Engineering/gui/engineering_diffraction/settings/settings_presenter.py
@@ -11,7 +11,7 @@ from mantidqt.utils.observer_pattern import Observable
 CALIB_FOLDER = path.join(path.dirname(path.dirname(path.dirname(getcwd()))), "calib")
 DEFAULT_FULL_INST_CALIB = "ENGINX_full_instrument_calibration_193749.nxs"
 SETTINGS_DICT = {"save_location": str, "full_calibration": str, "recalc_vanadium": bool, "logs": str,
-                 "primary_log": str, "sort_ascending": bool, "default_peak": str}
+                 "primary_log": str, "sort_ascending": bool, "default_peak": str, "rb_number": str}
 
 DEFAULT_SETTINGS = {
     "full_calibration": path.join(CALIB_FOLDER, DEFAULT_FULL_INST_CALIB),
@@ -21,7 +21,8 @@ DEFAULT_SETTINGS = {
         ['Temp_1', 'W_position', 'X_position', 'Y_position', 'Z_position', 'stress', 'strain', 'stressrig_go']),
     "primary_log": 'strain',
     "sort_ascending": True,
-    "default_peak": "BackToBackExponential"
+    "default_peak": "BackToBackExponential",
+    "rb_number": ""
 }
 
 ALL_LOGS = ','.join(

--- a/scripts/Engineering/gui/engineering_diffraction/settings/settings_presenter.py
+++ b/scripts/Engineering/gui/engineering_diffraction/settings/settings_presenter.py
@@ -11,7 +11,7 @@ from mantidqt.utils.observer_pattern import Observable
 CALIB_FOLDER = path.join(path.dirname(path.dirname(path.dirname(getcwd()))), "calib")
 DEFAULT_FULL_INST_CALIB = "ENGINX_full_instrument_calibration_193749.nxs"
 SETTINGS_DICT = {"save_location": str, "full_calibration": str, "recalc_vanadium": bool, "logs": str,
-                 "primary_log": str, "sort_ascending": bool, "default_peak": str, "rb_number": str}
+                 "primary_log": str, "sort_ascending": bool, "default_peak": str}
 
 DEFAULT_SETTINGS = {
     "full_calibration": path.join(CALIB_FOLDER, DEFAULT_FULL_INST_CALIB),
@@ -21,8 +21,7 @@ DEFAULT_SETTINGS = {
         ['Temp_1', 'W_position', 'X_position', 'Y_position', 'Z_position', 'stress', 'strain', 'stressrig_go']),
     "primary_log": 'strain',
     "sort_ascending": True,
-    "default_peak": "BackToBackExponential",
-    "rb_number": ""
+    "default_peak": "BackToBackExponential"
 }
 
 ALL_LOGS = ','.join(


### PR DESCRIPTION
**Description of work.**
The most recently RB number, which specifies an individual user, is now saved after entry and loaded back into the field when the interface is loaded.

**To test:**
1. Open the interface and fill in the rb number field
2. Close the interface
3. Reopen it, see if the number is there

Fixes #31908 . <!-- and fix #xxxx or close #xxxx xor resolves #xxxx -->
<!-- alternative
*There is no associated issue.*
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or master)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
