### PR TITLE
Instrument View: Add virtual d'tor to mock classes

### DIFF
--- a/qt/widgets/instrumentview/test/InstrumentWidget/MockGLDisplay.h
+++ b/qt/widgets/instrumentview/test/InstrumentWidget/MockGLDisplay.h
@@ -19,6 +19,7 @@ namespace MantidQt::MantidWidgets {
 
 class MockGLDisplay : public IGLDisplay {
 public:
+  virtual ~MockGLDisplay() = default;
   MOCK_METHOD(void, setSurface, (std::shared_ptr<ProjectionSurface>), (override));
   MOCK_METHOD(std::shared_ptr<ProjectionSurface>, getSurface, (), (override));
   MOCK_METHOD(void, updateView, (bool), (override));

--- a/qt/widgets/instrumentview/test/InstrumentWidget/MockInstrumentDisplay.h
+++ b/qt/widgets/instrumentview/test/InstrumentWidget/MockInstrumentDisplay.h
@@ -21,6 +21,7 @@ namespace MantidQt::MantidWidgets {
 
 class MockInstrumentDisplay : public IInstrumentDisplay {
 public:
+  virtual ~MockInstrumentDisplay() = default;
   MOCK_METHOD(int, currentIndex, (), (const, override));
   MOCK_METHOD(QWidget *, currentWidget, (), (const, override));
   MOCK_METHOD(void, setCurrentIndex, (int), (const, override));

--- a/qt/widgets/instrumentview/test/InstrumentWidget/MockProjectionSurface.h
+++ b/qt/widgets/instrumentview/test/InstrumentWidget/MockProjectionSurface.h
@@ -14,6 +14,7 @@ namespace MantidQt::MantidWidgets {
 class MockProjectionSurface : public ProjectionSurface {
 public:
   MockProjectionSurface() : ProjectionSurface(nullptr) {}
+  virtual ~MockProjectionSurface() = default;
   MOCK_METHOD(void, init, (), (override));
   MOCK_METHOD(void, componentSelected, (size_t), (override));
   MOCK_METHOD(void, getSelectedDetectors, (std::vector<size_t> &), (override));

--- a/qt/widgets/instrumentview/test/InstrumentWidget/MockQtConnect.h
+++ b/qt/widgets/instrumentview/test/InstrumentWidget/MockQtConnect.h
@@ -12,6 +12,7 @@
 namespace MantidQt::MantidWidgets {
 class MockQtConnect : public QtConnect {
 public:
+  virtual ~MockQtConnect() = default;
   MOCK_METHOD(void, connect, (QObject *, const char *, QObject *, const char *), (const, override));
   MOCK_METHOD(void, connect, (QObject *, const char *, QObject *, const char *, Qt::ConnectionType), (const, override));
 };

--- a/qt/widgets/instrumentview/test/InstrumentWidget/MockQtDisplay.h
+++ b/qt/widgets/instrumentview/test/InstrumentWidget/MockQtDisplay.h
@@ -16,6 +16,7 @@ namespace MantidQt::MantidWidgets {
 
 class MockQtDisplay : public IQtDisplay {
 public:
+  virtual ~MockQtDisplay() = default;
   MOCK_METHOD(void, setSurface, (std::shared_ptr<ProjectionSurface>), (override));
   MOCK_METHOD(std::shared_ptr<ProjectionSurface>, getSurface, (), (override));
   MOCK_METHOD(void, updateView, (bool), (override));

--- a/qt/widgets/instrumentview/test/InstrumentWidget/MockStackedLayout.h
+++ b/qt/widgets/instrumentview/test/InstrumentWidget/MockStackedLayout.h
@@ -15,6 +15,7 @@ class QWidget;
 namespace MantidQt::MantidWidgets {
 class MockStackedLayout : public IStackedLayout {
 public:
+  virtual ~MockStackedLayout() = default;
   MOCK_METHOD(int, addWidget, (QWidget *), (override));
   MOCK_METHOD(int, currentIndex, (), (const, override));
   MOCK_METHOD(QWidget *, currentWidget, (), (const, override));


### PR DESCRIPTION
**Description of work.**
Adds the virtual destructor to the mock classes to avoid a bug with
older XCode versions. This is because GMock inherits from these classes
when using Strict/Nice mocks.

**To test:**
- Check OSX builds pass

<!-- Instructions for testing. -->

Regression fix from #31739 


<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or master)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
