### PR TITLE
Catch exceptions by reference (ornl-next)

### DIFF
--- a/Framework/API/test/PreviewManagerTest.h
+++ b/Framework/API/test/PreviewManagerTest.h
@@ -65,6 +65,7 @@ public:
     TS_ASSERT_EQUALS(preview.type(), IPreview::PreviewType::SVIEW);
   }
   void test_get_preview_by_non_existent_name() {
-    TS_ASSERT_THROWS(PreviewManager::Instance().getPreview("TestFacility", "SANS", "BasicPreview2"), std::runtime_error)
+    TS_ASSERT_THROWS(PreviewManager::Instance().getPreview("TestFacility", "SANS", "BasicPreview2"),
+                     const std::runtime_error &)
   }
 };

--- a/qt/scientific_interfaces/Indirect/test/IndirectFitOutputModelTest.h
+++ b/qt/scientific_interfaces/Indirect/test/IndirectFitOutputModelTest.h
@@ -144,8 +144,8 @@ public:
   }
 
   void test_getParameters_throws_if_no_fitted_data_correct_value() {
-    TS_ASSERT_THROWS(m_model->getParameters(FitDomainIndex{0}), std::invalid_argument);
-    TS_ASSERT_THROWS(m_model->getParameters(FitDomainIndex{6}), std::invalid_argument);
+    TS_ASSERT_THROWS(m_model->getParameters(FitDomainIndex{0}), const std::invalid_argument &);
+    TS_ASSERT_THROWS(m_model->getParameters(FitDomainIndex{6}), const std::invalid_argument &);
   }
 
   void test_getResultLocaton() {

--- a/qt/scientific_interfaces/Indirect/test/IndirectFittingModelTest.h
+++ b/qt/scientific_interfaces/Indirect/test/IndirectFittingModelTest.h
@@ -769,7 +769,7 @@ public:
     auto model = createModelWithSingleWorkspace("wsName", 1);
     auto foo = model->createDisplayName(TableDatasetIndex{0});
 
-    TS_ASSERT_THROWS(model->createDisplayName(TableDatasetIndex{1}), std::runtime_error);
+    TS_ASSERT_THROWS(model->createDisplayName(TableDatasetIndex{1}), const std::runtime_error &);
   }
 
   void test_createDisplayName_produces_correct_format() {


### PR DESCRIPTION
gcc9 found some new catch-by-reference items to warn. This fixes them.

This changes are already in `master` so there is no associated PR.

**To test:**

If the builds pass, it is good to go.

*There is no associated issue.*

*This does not require release notes* because it is an internal change to quiet compiler warnings.

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
