### PR TITLE
Change path to path suffixes in lib3mf finder

### DIFF
--- a/Framework/DataHandling/CMakeLists.txt
+++ b/Framework/DataHandling/CMakeLists.txt
@@ -690,9 +690,9 @@ if(ENABLE_LIB3MF)
   target_link_libraries(DataHandling LINK_PRIVATE
                         ${LIB3MF_LIBRARIES})
   if (CONDA_BUILD)
-  target_include_directories(DataHandling PUBLIC ${LIB3MF_INCLUDE_DIR})
+    target_include_directories(DataHandling PUBLIC ${LIB3MF_INCLUDE_DIR})
   else()
-  target_include_directories(DataHandling PUBLIC ${LIB3MF_INCLUDE_DIR}/lib3mf)
+    target_include_directories(DataHandling PUBLIC ${LIB3MF_INCLUDE_DIR}/lib3mf)
   endif()
 endif()
 

--- a/buildconfig/CMake/FindLib3mf.cmake
+++ b/buildconfig/CMake/FindLib3mf.cmake
@@ -3,7 +3,7 @@
 # LIB3MF_LIBRARIES libraries to link against
 # LIB3MF_FOUND If false, do not try to use LIB3MF
 
-find_path ( LIB3MF_INCLUDE_DIR Bindings/Cpp/lib3mf_abi.hpp PATHS include/lib3mf HINTS $ENV{CONDA_PREFIX}/Library/include)
+find_path ( LIB3MF_INCLUDE_DIR Bindings/Cpp/lib3mf_abi.hpp PATHS_SUFFIXES lib3mf HINTS $ENV{CONDA_PREFIX}/Library/include)
 
 find_library ( LIB3MF_LIB lib3mf )
 find_library ( LIB3MF_LIB_DEBUG lib3mf_d )


### PR DESCRIPTION
**Description of work.**
This PR fixes an issue finding the include directory of lib3mf on windows.


<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

**To test:**
Test the builds complete

<!-- Instructions for testing. -->

*There is no associated issue.*

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or master)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
