### PR TITLE
Properly handle ADS clear in EnggDiffUI data_model

### DIFF
--- a/docs/source/release/v6.2.0/diffraction.rst
+++ b/docs/source/release/v6.2.0/diffraction.rst
@@ -46,6 +46,7 @@ Bugfixes
 - Sequential fitting in the EngDiff UI now uses the output of the last successful fit (as opposed to the previous fit) as the initial parameters for the next fit.
 - An empty Engineering Diffraction interface is no longer saved if the user saves a project having previously had the interface open at some point in that session
 - The help button on the Engineering Diffraction interface points to the correct page, having been broken in the last release
+- Using the Clear button on the Workspace widget while using the Fitting tab no longer causes issues when you try to load runs back in.
 
 
 Single Crystal Diffraction

--- a/scripts/Engineering/gui/engineering_diffraction/tabs/fitting/data_handling/data_model.py
+++ b/scripts/Engineering/gui/engineering_diffraction/tabs/fitting/data_handling/data_model.py
@@ -205,7 +205,6 @@ class FittingDataModel(object):
             self._fit_results[wsname] = {'model': fit_prop['properties']['Function'],
                                          'status': fit_prop['status']}
             self._fit_results[wsname]['results'] = defaultdict(list)  # {function_param: [[Y1, E1], [Y2,E2],...] }
-            self._fit_results[wsname]
             fnames = [x.split('=')[-1] for x in findall('name=[^,]*', fit_prop['properties']['Function'])]
             # get num params for each function (first elem empty as str begins with 'name=')
             # need to remove ties and constraints which are enclosed in ()
@@ -341,6 +340,10 @@ class FittingDataModel(object):
 
     def get_sample_log_from_ws(self, ws_name, log_name):
         return self._loaded_workspaces[ws_name].getSampleDetails().getLogData(log_name).value
+
+    def set_log_workspaces_none(self):
+        # to be used in the event of Ads clear, as trying to reference the deleted grp ws results in an error
+        self._log_workspaces = None
 
     def _convert_TOF_to_d(self, tof, ws_name):
         diff_consts = self._get_diff_constants(ws_name)

--- a/scripts/Engineering/gui/engineering_diffraction/tabs/fitting/data_handling/data_presenter.py
+++ b/scripts/Engineering/gui/engineering_diffraction/tabs/fitting/data_handling/data_presenter.py
@@ -90,6 +90,9 @@ class FittingDataPresenter(object):
 
     def clear_workspaces(self):
         self.get_loaded_workspaces().clear()
+        self.get_bgsub_workspaces().clear()
+        self.get_bg_params().clear()
+        self.model.set_log_workspaces_none()
         self.plotted.clear()
         self.row_numbers.clear()
         self._repopulate_table()
@@ -103,6 +106,12 @@ class FittingDataPresenter(object):
 
     def get_loaded_workspaces(self):
         return self.model.get_loaded_workspaces()
+
+    def get_bgsub_workspaces(self):
+        return self.model.get_bgsub_workspaces()
+
+    def get_bg_params(self):
+        return self.model.get_bg_params()
 
     def restore_table(self):  # used when the interface is being restored from a save or crash
         self._repopulate_table()


### PR DESCRIPTION
**Description of work.**
There was a bug where the callback in the model in the event of the ADS being cleared did not properly reset the fields of the model, causing errors if the user tried to load more runs in the interface after clearing the ADS. This PR adds a few extra bits to the callback to sort this problem

**To test:**
1. Open up the interface and load up some focused runs in the fitting tab
2. Click clear above the workspace widget
3. Try to load the some files again, there should be no error and the interface should work as normal

Fixes #30045 . 

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or master)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
