### PR TITLE
Use the same comparison function for sorting/equality of MDEvents

### DIFF
--- a/Framework/MDAlgorithms/inc/MantidMDAlgorithms/CompareMDWorkspaces.h
+++ b/Framework/MDAlgorithms/inc/MantidMDAlgorithms/CompareMDWorkspaces.h
@@ -41,8 +41,6 @@ private:
 
   template <typename T> void compare(T a, T b, const std::string &message);
 
-  template <typename T> inline void compareTol(T a, T b, const std::string &message);
-
   template <typename MDE, size_t nd> void compare2Boxes(API::IMDNode *box1, API::IMDNode *box2, size_t ibox);
 
   Mantid::API::IMDWorkspace_sptr inWS2;
@@ -50,8 +48,9 @@ private:
   /// Result string
   std::string m_result;
 
-  /// Tolerance
+  /// Tolerances
   double m_tolerance = 0.0;
+  double m_mdeventTolerance = 0.0;
 
   /// Is CheckEvents true
   bool m_CheckEvents = true;

--- a/Testing/SystemTests/tests/framework/CompareMDWorkspacesTest.py
+++ b/Testing/SystemTests/tests/framework/CompareMDWorkspacesTest.py
@@ -63,8 +63,10 @@ class CompareMDWorkspacesTest(systemtesting.MantidSystemTest):
                     OutputWorkspace='md_2')
 
         # compare md1 and md2
-        self.compare_result_1 = CompareMDWorkspaces(Workspace1='md_1', Workspace2='md_2',
-                                                    Tolerance=0.000001, CheckEvents=True,
+        self.compare_result_1 = CompareMDWorkspaces(Workspace1='md_1',
+                                                    Workspace2='md_2',
+                                                    Tolerance=1e-6,
+                                                    CheckEvents=True,
                                                     IgnoreBoxID=False)
 
         # merge some MD workspaces
@@ -77,14 +79,13 @@ class CompareMDWorkspacesTest(systemtesting.MantidSystemTest):
         # create merge3
         merged_3 = md_1 + md_1
         # compare
-        self.compare_result_3 = CompareMDWorkspaces(Workspace1=merged_1, Workspace2=merged_3, CheckEvents=True,
-                                                    Tolerance=1E-14)
+        self.compare_result_3 = CompareMDWorkspaces(Workspace1=merged_1, Workspace2=merged_3, CheckEvents=True, Tolerance=1e-14)
 
     def validate(self):
         # compare result 1
         self.assertTrue(self.compare_result_1 is not None)
         self.assertTrue(self.compare_result_1.Equals is False)
-        self.assertTrue(self.compare_result_1.Result.endswith(' 54'))
+        self.assertTrue('54' in self.compare_result_1.Result)
 
         # compare result 2
         self.assertTrue(self.compare_result_2 is not None)
@@ -93,4 +94,4 @@ class CompareMDWorkspacesTest(systemtesting.MantidSystemTest):
         # compare result 3
         self.assertTrue(self.compare_result_3 is not None)
         self.assertTrue(self.compare_result_3.Equals is False)
-        self.assertTrue(self.compare_result_3.Result.endswith(' 66'))
+        self.assertTrue('66' in self.compare_result_3.Result)


### PR DESCRIPTION
**Description of work.**

Fix inconsistency in comparing events while sorting and checking for equality in CompareMDWorkspaces.

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

**To test:**

* Run the `ConvertHFIRSCDtoMDE_HB3A_Test` it should pass.

*There is no associated issue.*

*This does not require release notes* because **this fixes a regression**

<!-- Ensure the base of this PR is correct (e.g. release-next or master)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
