### PR TITLE
Make simulation files loadable via Load

### DIFF
--- a/Framework/DataHandling/inc/MantidDataHandling/LoadMcStasNexus.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/LoadMcStasNexus.h
@@ -7,7 +7,7 @@
 #pragma once
 
 #include "MantidAPI/IFileLoader.h"
-#include "MantidKernel/NexusDescriptor.h"
+#include "MantidKernel/NexusHDF5Descriptor.h"
 #include "MantidKernel/System.h"
 
 namespace Mantid {
@@ -15,7 +15,7 @@ namespace DataHandling {
 
 /** LoadMcStasNexus : TODO: DESCRIPTION
  */
-class DLLExport LoadMcStasNexus : public API::IFileLoader<Kernel::NexusDescriptor> {
+class DLLExport LoadMcStasNexus : public API::IFileLoader<Kernel::NexusHDF5Descriptor> {
 public:
   const std::string name() const override;
   /// Summary of algorithms purpose
@@ -26,7 +26,7 @@ public:
   const std::string category() const override;
 
   /// Returns a confidence value that this algorithm can load a file
-  int confidence(Kernel::NexusDescriptor &descriptor) const override;
+  int confidence(Kernel::NexusHDF5Descriptor &descriptor) const override;
 
 private:
   void init() override;

--- a/Framework/DataHandling/src/LoadMcStasNexus.cpp
+++ b/Framework/DataHandling/src/LoadMcStasNexus.cpp
@@ -47,6 +47,7 @@ int LoadMcStasNexus::confidence(Kernel::NexusHDF5Descriptor &descriptor) const {
   int confidence(0);
   const auto entries = descriptor.getAllEntries();
   for (const auto &[nx_class, grouped_entries] : entries) {
+    UNUSED_ARG(nx_class);
     for (const auto &path : grouped_entries) {
       // Mccode writes an information dataset so can be reasonably confident if we find it
       if (std::regex_search(path, std::regex("information$"))) {

--- a/Framework/DataHandling/src/LoadMcStasNexus.cpp
+++ b/Framework/DataHandling/src/LoadMcStasNexus.cpp
@@ -18,7 +18,6 @@
 // clang-format on
 
 #include <boost/algorithm/string.hpp>
-#include <regex>
 
 namespace Mantid {
 namespace DataHandling {
@@ -45,12 +44,13 @@ const std::string LoadMcStasNexus::category() const { return "DataHandling\\Nexu
  */
 int LoadMcStasNexus::confidence(Kernel::NexusHDF5Descriptor &descriptor) const {
   int confidence(0);
-  const auto entries = descriptor.getAllEntries();
+  const auto &entries = descriptor.getAllEntries();
+  const static auto target_dataset = "information";
   for (const auto &[nx_class, grouped_entries] : entries) {
     UNUSED_ARG(nx_class);
     for (const auto &path : grouped_entries) {
       // Mccode writes an information dataset so can be reasonably confident if we find it
-      if (std::regex_search(path, std::regex("information$"))) {
+      if (boost::ends_with(path, target_dataset)) {
         confidence = 40;
         break;
       }

--- a/Framework/DataHandling/test/LoadMcStasNexusTest.h
+++ b/Framework/DataHandling/test/LoadMcStasNexusTest.h
@@ -16,6 +16,7 @@
 // These includes seem to make the difference between initialization of the
 // workspace names (workspace2D/1D etc), instrument classes and not for this
 // test case.
+#include "MantidDataHandling/Load.h"
 #include "MantidDataHandling/LoadInstrument.h"
 #include "MantidDataObjects/WorkspaceSingleValue.h"
 #include <Poco/Path.h>
@@ -49,6 +50,7 @@ public:
     // specify name of file to load workspace from
     inputFile = "mcstas.h5";
     algToBeTested.setPropertyValue("Filename", inputFile);
+    auto des = NexusDescriptor(inputFile, true);
 
     TS_ASSERT_THROWS_NOTHING(algToBeTested.execute());
     TS_ASSERT(algToBeTested.isExecuted());
@@ -65,6 +67,30 @@ public:
 
     AnalysisDataService::Instance().remove(outputSpace + "_1");
     AnalysisDataService::Instance().remove(outputSpace + "_2");
+  }
+
+  void test_run_via_load() {
+    // We are verifying that the confidence information provided by the loader is good
+    std::string inputFile = "mcstas.h5";
+    Load loader;
+    loader.initialize();
+    loader.setChild(true);
+    loader.setProperty("Filename", inputFile);
+    loader.setPropertyValue("OutputWorkspace", "dummy");
+    TS_ASSERT_EQUALS(loader.getPropertyValue("LoaderName"), "LoadMcStasNexus");
+    loader.execute();
+    Workspace_sptr out = loader.getProperty("OutputWorkspace");
+    auto asMatrixOut = std::dynamic_pointer_cast<MatrixWorkspace>(out);
+  }
+
+  void test_cannot_run_via_load() {
+    // We are verifying that the confidence information provided by the loader is idenfiying unsuitable files
+    std::string inputFile = "POLREF00014966.nxs";
+    Load loader;
+    loader.initialize();
+    loader.setChild(true);
+    loader.setProperty("Filename", inputFile);
+    TS_ASSERT_DIFFERS(loader.getPropertyValue("LoaderName"), "LoadMcStasNexus");
   }
 
 private:

--- a/Framework/DataHandling/test/LoadMcStasNexusTest.h
+++ b/Framework/DataHandling/test/LoadMcStasNexusTest.h
@@ -50,7 +50,6 @@ public:
     // specify name of file to load workspace from
     inputFile = "mcstas.h5";
     algToBeTested.setPropertyValue("Filename", inputFile);
-    auto des = NexusDescriptor(inputFile, true);
 
     TS_ASSERT_THROWS_NOTHING(algToBeTested.execute());
     TS_ASSERT(algToBeTested.isExecuted());


### PR DESCRIPTION
Problems fixed.

* `LoadMcStasNexus` does not provide confidence information, so gets ignored by Load
* Loader does not use correct file descriptor for the file types it works on