### PR TITLE
Lr71 subtract bkgd (ornl-next)

### DIFF
--- a/Framework/PythonInterface/plugins/algorithms/LRScalingFactors.py
+++ b/Framework/PythonInterface/plugins/algorithms/LRScalingFactors.py
@@ -477,7 +477,8 @@ class LRScalingFactors(PythonAlgorithm):
                                                 PeakRange=peak_range,
                                                 BackgroundRange=background_range,
                                                 LowResolutionRange=low_res_range,
-                                                OutputWorkspace=str(workspace))
+                                                OutputWorkspace=str(workspace),
+                                                ErrorWeighting=True)
 
         # Normalize by current proton charge
         # Note that the background subtraction will use an error weighted mean

--- a/Framework/PythonInterface/plugins/algorithms/LRSubtractAverageBackground.py
+++ b/Framework/PythonInterface/plugins/algorithms/LRSubtractAverageBackground.py
@@ -86,7 +86,7 @@ class LRSubtractAverageBackground(PythonAlgorithm):
                               XPixelMax=x_max,
                               YPixelMin=bck_min,
                               YPixelMax=peak_min - 1,
-                              ErrorWeighting = True,
+                              ErrorWeighting = False,
                               SumPixels=True, NormalizeSum=True)
 
         right_bck = None
@@ -99,7 +99,7 @@ class LRSubtractAverageBackground(PythonAlgorithm):
                                XPixelMax=x_max,
                                YPixelMin=peak_max + 1,
                                YPixelMax=bck_max,
-                               ErrorWeighting = True,
+                               ErrorWeighting = False,
                                SumPixels=True, NormalizeSum=True)
 
         if right_bck is not None and left_bck is not None:
@@ -117,7 +117,7 @@ class LRSubtractAverageBackground(PythonAlgorithm):
                              XPixelMax=x_max,
                              YPixelMin=bck_min,
                              YPixelMax=bck_max,
-                             ErrorWeighting = True,
+                             ErrorWeighting = False,
                              SumPixels=True, NormalizeSum=True)
 
         output_name = self.getPropertyValue("OutputWorkspace")

--- a/Framework/PythonInterface/plugins/algorithms/LRSubtractAverageBackground.py
+++ b/Framework/PythonInterface/plugins/algorithms/LRSubtractAverageBackground.py
@@ -36,6 +36,9 @@ class LRSubtractAverageBackground(PythonAlgorithm):
                                               IntArrayLengthValidator(2), direction=Direction.Input),
                              "Pixel range defining the low-resolution axis to integrate over")
         self.declareProperty("SumPeak", False, doc="If True, the resulting peak will be summed")
+        self.declareProperty("ErrorWeighting", False,
+                             "If True, a weighted average is used to to estimate the background. "
+                             "Otherwise, a simple average is used.")
         detector_list = ["2D-Detector", "LinearDetector"]
         self.declareProperty("TypeOfDetector", "2D-Detector", StringListValidator(detector_list), doc="The type of detector used")
         self.declareProperty(WorkspaceProperty("OutputWorkspace", "", Direction.Output), "The workspace to check.")
@@ -77,6 +80,7 @@ class LRSubtractAverageBackground(PythonAlgorithm):
                 raise RuntimeError("Instrument does not have parameter number-of-y-pixels")
 
         left_bck = None
+        use_weighted_error = self.getProperty('ErrorWeighting').value
         if peak_min > bck_min:
             left_bck = RefRoi(InputWorkspace=workspace, IntegrateY=False,
                               NXPixel=number_of_pixels_x,
@@ -86,7 +90,7 @@ class LRSubtractAverageBackground(PythonAlgorithm):
                               XPixelMax=x_max,
                               YPixelMin=bck_min,
                               YPixelMax=peak_min - 1,
-                              ErrorWeighting = False,
+                              ErrorWeighting=use_weighted_error,
                               SumPixels=True, NormalizeSum=True)
 
         right_bck = None
@@ -99,7 +103,7 @@ class LRSubtractAverageBackground(PythonAlgorithm):
                                XPixelMax=x_max,
                                YPixelMin=peak_max + 1,
                                YPixelMax=bck_max,
-                               ErrorWeighting = False,
+                               ErrorWeighting=use_weighted_error,
                                SumPixels=True, NormalizeSum=True)
 
         if right_bck is not None and left_bck is not None:
@@ -117,7 +121,7 @@ class LRSubtractAverageBackground(PythonAlgorithm):
                              XPixelMax=x_max,
                              YPixelMin=bck_min,
                              YPixelMax=bck_max,
-                             ErrorWeighting = False,
+                             ErrorWeighting=use_weighted_error,
                              SumPixels=True, NormalizeSum=True)
 
         output_name = self.getPropertyValue("OutputWorkspace")

--- a/Framework/PythonInterface/plugins/algorithms/LiquidsReflectometryReduction.py
+++ b/Framework/PythonInterface/plugins/algorithms/LiquidsReflectometryReduction.py
@@ -416,7 +416,8 @@ class LiquidsReflectometryReduction(PythonAlgorithm):
                                                     PeakRange=peak_range,
                                                     BackgroundRange=background_range,
                                                     LowResolutionRange=[x_min, x_max],
-                                                    OutputWorkspace=str(workspace))
+                                                    OutputWorkspace=str(workspace),
+                                                    ErrorWeighting=True)
         else:
             # If we don't subtract the background, we still have to integrate
             # over the low resolution axis

--- a/Framework/Reflectometry/src/ReflectometryBackgroundSubtraction.cpp
+++ b/Framework/Reflectometry/src/ReflectometryBackgroundSubtraction.cpp
@@ -169,6 +169,7 @@ void ReflectometryBackgroundSubtraction::calculatePixelBackground(const MatrixWo
   // will need to change if ISIS reflectometry get a 2D detector
   LRBgd->setProperty("LowResolutionRange", "0,0");
   LRBgd->setProperty("TypeOfDetector", "LinearDetector");
+  LRBgd->setProperty("ErrorWeighting", true);
   LRBgd->execute();
 
   Workspace_sptr outputWS = LRBgd->getProperty("OutputWorkspace");

--- a/docs/source/release/v6.2.0/reflectometry.rst
+++ b/docs/source/release/v6.2.0/reflectometry.rst
@@ -9,4 +9,12 @@ Reflectometry Changes
     putting new features at the top of the section, followed by
     improvements, followed by bug fixes.
 
+Reflectometry
+-------------
+
+Improvements
+############
+- :ref:`LRSubtractAverageBackground <algm-LRSubtractAverageBackground-v1>` now optionally uses weighted error for background with new input property ErrorWeighting.
+
 :ref:`Release 6.2.0 <v6.2.0>`
+


### PR DESCRIPTION
**Description of work.**

In Mantid algorithm LRSubtractAverageBackground,, add a new input property 'WeightedBackground' and set default to False

Keep all the callers of LRSubtractAverageBackground the current status, i.e., to set WeightedBackground True.

By this, there shall be no change in testing result.

This is the implementation of ORNL REFL #76

**To test:**

- Make sure all the builds are passed.
- Visual check the changes.

This is the ORNL twin for https://github.com/mantidproject/mantid/pull/32010

<!-- Instructions for testing. -->

Fixes #xxxx. <!-- and fix #xxxx or close #xxxx xor resolves #xxxx -->
<!-- alternative
*There is no associated issue.*
-->

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or master)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
