### PR TITLE
Set default inputs on Fitting tab in Engineering UI to be the list of runs last focused

### DIFF
--- a/docs/source/release/v6.2.0/diffraction.rst
+++ b/docs/source/release/v6.2.0/diffraction.rst
@@ -44,6 +44,7 @@ Improvements
 - The workflows for Calibration and Focusing in the EnggDiffraction GUI and EnginX scripts have been replaced to make use of faster, better tested C++ algorithms (PDCalibration) - as a result the following algorithms have been deprecated, and will likely be removed entirely in the next release: EnggCalibrate, EnggCalibrateFull, EnggFocus, EnggVanadiumCorrections.
 - The cropping/region of interest selection for Calibration/Focusing is now chosen only on the Calibration tab, to avoid confusion and duplication of input.
 - The region of interest for Calibration/Focusing can now be selected with a user-supplied custom calibration file.
+- The Focused Run Files input box defaults to the last runs focused on the Focus tab, even if multiple runs were focussed
 
 Bugfixes
 ########

--- a/scripts/Engineering/gui/engineering_diffraction/tabs/fitting/data_handling/data_presenter.py
+++ b/scripts/Engineering/gui/engineering_diffraction/tabs/fitting/data_handling/data_presenter.py
@@ -44,7 +44,7 @@ class FittingDataPresenter(object):
         self.fit_enabled_observer = GenericObserverWithArgPassing(self.set_fit_enabled)
         self.fit_all_done_observer = GenericObserverWithArgPassing(self.fit_completed)
         self.focus_run_observer = GenericObserverWithArgPassing(
-            self.view.set_file_last)
+            self.view.set_default_files)
 
     def set_fit_enabled(self, fit_enabled):
         self.view.set_fit_buttons_enabled(fit_enabled)

--- a/scripts/Engineering/gui/engineering_diffraction/tabs/fitting/data_handling/data_view.py
+++ b/scripts/Engineering/gui/engineering_diffraction/tabs/fitting/data_handling/data_view.py
@@ -68,12 +68,16 @@ class FittingDataView(QtWidgets.QWidget, Ui_data):
     # Component Setters
     # =================
 
-    def set_file_last(self, filepath):
-        if not filepath:
+    def set_default_files(self, filepaths):
+        if not filepaths:
             return
-        self.finder_data.setUserInput(filepath)
-        directory, discard = path.split(filepath)
-        self.finder_data.setLastDirectory(directory)
+        self.finder_data.setUserInput(",".join(filepaths))
+        directories = set()
+        for filepath in filepaths:
+            directory, discard = path.split(filepath)
+            directories.add(directory)
+        if len(directories) == 1:
+            self.finder_data.setLastDirectory(directory)
 
     def set_load_button_enabled(self, enabled):
         self.button_load.setEnabled(enabled)

--- a/scripts/Engineering/gui/engineering_diffraction/tabs/focus/model.py
+++ b/scripts/Engineering/gui/engineering_diffraction/tabs/focus/model.py
@@ -29,11 +29,10 @@ SOUTH_BANK_CAL = "EnginX_SouthBank.cal"
 class FocusModel(object):
 
     def __init__(self):
-        self._last_path = None
-        self._last_path_ws = None
+        self._last_focused_files = []
 
-    def get_last_path(self):
-        return self._last_path
+    def get_last_focused_files(self):
+        return self._last_focused_files
 
     def focus_run(self, sample_paths: list, vanadium_path: str, plot_output: bool, instrument: str, rb_num: str,
                   regions_dict: dict) -> None:
@@ -73,6 +72,7 @@ class FocusModel(object):
 
         # loop over samples provided, focus each over region(s) specified in regions_dict
         output_workspaces = []  # List of collated workspaces to plot.
+        self._last_focused_files = []
         for sample_path in sample_paths:
             sample_workspace = path_handling.load_workspace(sample_path)
             run_no = path_handling.get_run_number_from_path(sample_path, instrument)
@@ -154,9 +154,9 @@ class FocusModel(object):
         ApplyDiffCal(InstrumentWorkspace=focused_sample, CalibrationWorkspace=region_calib)
         # set bankid for use in fit tab
         run = focused_sample.getRun()
-        if region_calib == "engggui_calibration_bank_1":
+        if region_calib.name() == "engggui_calibration_bank_1":
             run.addProperty("bankid", 1, True)
-        elif region_calib == "engggui_calibration_bank_2":
+        elif region_calib.name() == "engggui_calibration_bank_2":
             run.addProperty("bankid", 2, True)
         else:
             run.addProperty("bankid", 3, True)
@@ -267,9 +267,6 @@ class FocusModel(object):
         if rb_num:
             output_path = path.join(path_handling.get_output_path(), 'User', rb_num, 'Focus')
             logger.notice(f"\n\nFocus files also saved to: \"{output_path}\"\n\n")
-        self._last_path = output_path
-        if self._last_path and self._last_path_ws:
-            self._last_path = path.join(self._last_path, self._last_path_ws)
 
     def _save_focused_output_files_as_gss(self, instrument, sample_path, bank, sample_workspace,
                                           rb_num, unit):
@@ -292,7 +289,8 @@ class FocusModel(object):
             nexus_output_path = path.join(
                 path_handling.get_output_path(), "User", rb_num, "Focus", file_name)
             SaveNexus(InputWorkspace=sample_workspace, Filename=nexus_output_path)
-        self._last_path_ws = file_name
+        if unit == "TOF":
+            self._last_focused_files.append(nexus_output_path)
 
     def _save_focused_output_files_as_topas_xye(self, instrument, sample_path, bank,
                                                 sample_workspace, rb_num, unit):

--- a/scripts/Engineering/gui/engineering_diffraction/tabs/focus/presenter.py
+++ b/scripts/Engineering/gui/engineering_diffraction/tabs/focus/presenter.py
@@ -64,7 +64,7 @@ class FocusPresenter(object):
 
     def _on_worker_success(self):
         self.emit_enable_button_signal()
-        self.focus_run_notifier.notify_subscribers(self.model.get_last_path())
+        self.focus_run_notifier.notify_subscribers(self.model.get_last_focused_files())
 
     def set_instrument_override(self, instrument):
         instrument = INSTRUMENT_DICT[instrument]

--- a/scripts/Engineering/gui/engineering_diffraction/tabs/focus/test/test_focus_model.py
+++ b/scripts/Engineering/gui/engineering_diffraction/tabs/focus/test/test_focus_model.py
@@ -199,7 +199,7 @@ class FocusModelTest(unittest.TestCase):
         self.model._save_output("ENGINX", "Path/To/ENGINX000123.whatever", "North",
                                 mocked_workspace, None)
 
-        self.assertEqual(self.model._last_path, output_file)
+        self.assertEqual(self.model._last_focused_files[0], output_file)
 
     @patch(file_path + ".SaveFocusedXYE")
     @patch(file_path + ".SaveGSS")
@@ -215,7 +215,7 @@ class FocusModelTest(unittest.TestCase):
         self.model._save_output("ENGINX", "Path/To/ENGINX000123.whatever", "North",
                                 mocked_workspace, rb_num)
 
-        self.assertEqual(self.model._last_path, output_file)
+        self.assertEqual(self.model._last_focused_files[0], output_file)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
**Description of work.**

Set the default inputs on the Fitting tab of the Engineering diffraction user interface to be the list of runs last focused. It previously defaulted to a single value equal to the last run focused if a list was specified during focussing.

Also fix bug in setting the bank column of the table on the Fitting tab. This previously showed "3" in situations where it should have been 1 or 2

**To test:**

Open engineering diffraction user interface:

1. Start on Calibration tab and generate calibration using vanadium 236516 ceria 193749. Leave other inputs as default
2. Move to Focus tab and focus some data eg files 314946-314947 (requires archive access)
3. Move to the Fitting tab and note the input edit box called "Focused Run Files" is already populated. Hit Load and check that multiple files are loaded. You should get 4 files loaded, two for each run

Fixes #31906. 

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
