### PR TITLE
Add PowderReduceP2D_reference.p2d to exclusions LoadLotsOfFiles test

### DIFF
--- a/Testing/SystemTests/tests/framework/LoadLotsOfFiles.py
+++ b/Testing/SystemTests/tests/framework/LoadLotsOfFiles.py
@@ -125,6 +125,7 @@ BANNED_FILES = ['80_tubes_Top_and_Bottom_April_2015.xml',
                 'BioSANS_exp61_scan0004_0001_Iq.txt',
                 'test_data_Iq.txt',
                 'BioSANS_test_data_Iq.txt'
+                'PowderReduceP2D_reference.p2d'
                 ]
 
 EXPECTED_EXT = '.expected'


### PR DESCRIPTION
**Description of work.**
Fixes a failing system test due to loading a new reference file in the test LoadLotsOfFiles. This reference is just used to compare the output of an algorithm (using compare ascii) and is not supposed to be a target of any loader. 



**To test:**
Build pass
Run the LoadLotsOfFiles system test on Windows on Linux (you need a lot of RAM for this test)



There is no associated issue.


This does not require release notes because its a developer facing change. 

<!-- Ensure the base of this PR is correct (e.g. release-next or master)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
