### PR TITLE
Exclude Range during Fit in Muon interfaces

### DIFF
--- a/Framework/Muon/src/CalculateMuonAsymmetry.cpp
+++ b/Framework/Muon/src/CalculateMuonAsymmetry.cpp
@@ -65,6 +65,10 @@ void CalculateMuonAsymmetry::init() {
 
   declareProperty("StartX", 0.1, "The lower limit for calculating the asymmetry (an X value).");
   declareProperty("EndX", 15.0, "The upper limit for calculating the asymmetry  (an X value).");
+  declareProperty(std::make_unique<ArrayProperty<double>>("Exclude", ""),
+                  "A list of pairs of real numbers, defining the regions to "
+                  "exclude from the fit for all spectra.");
+
   declareProperty(std::make_unique<API::FunctionProperty>("InputFunction"), "The fitting function to be converted.");
 
   std::vector<std::string> minimizerOptions = API::FuncMinimizerFactory::Instance().getKeys();
@@ -250,6 +254,7 @@ std::vector<double> CalculateMuonAsymmetry::getNormConstants(const std::vector<s
   std::vector<double> norms;
   double startX = getProperty("StartX");
   double endX = getProperty("EndX");
+  std::string exclude = getProperty("Exclude");
   int maxIterations = getProperty("MaxIterations");
   auto minimizer = getProperty("Minimizer");
   API::IAlgorithm_sptr fit;
@@ -284,6 +289,7 @@ std::vector<double> CalculateMuonAsymmetry::getNormConstants(const std::vector<s
   fit->setProperty("InputWorkspace", wsNames[0]);
   fit->setProperty("StartX", startX);
   fit->setProperty("EndX", endX);
+  fit->setProperty("Exclude", exclude);
   fit->setProperty("WorkspaceIndex", 0);
 
   if (wsNames.size() > 1) {

--- a/Framework/Muon/src/CalculateMuonAsymmetry.cpp
+++ b/Framework/Muon/src/CalculateMuonAsymmetry.cpp
@@ -22,6 +22,7 @@
 #include "MantidAPI/MultiDomainFunction.h"
 #include "MantidAPI/Run.h"
 
+#include "MantidKernel/ArrayOrderedPairsValidator.h"
 #include "MantidKernel/ArrayProperty.h"
 #include "MantidKernel/BoundedValidator.h"
 #include "MantidKernel/ListValidator.h"
@@ -65,9 +66,10 @@ void CalculateMuonAsymmetry::init() {
 
   declareProperty("StartX", 0.1, "The lower limit for calculating the asymmetry (an X value).");
   declareProperty("EndX", 15.0, "The upper limit for calculating the asymmetry  (an X value).");
-  declareProperty(std::make_unique<ArrayProperty<double>>("Exclude", ""),
-                  "A list of pairs of real numbers, defining the regions to "
-                  "exclude from the fit for all spectra.");
+  declareProperty(
+      std::make_unique<ArrayProperty<double>>("Exclude", std::make_shared<ArrayOrderedPairsValidator<double>>()),
+      "A list of pairs of real numbers, defining the regions to "
+      "exclude from the fit for all spectra.");
 
   declareProperty(std::make_unique<API::FunctionProperty>("InputFunction"), "The fitting function to be converted.");
 

--- a/docs/source/release/v6.2.0/muon.rst
+++ b/docs/source/release/v6.2.0/muon.rst
@@ -26,6 +26,11 @@ BugFixes
 Muon Analysis and Frequency Domain Analysis
 -------------------------------------------
 
+New Features
+############
+
+- It is now possible to Exclude a range from a fit range when doing a fit on the Fitting tab.
+
 Improvements
 ############
 

--- a/docs/source/release/v6.2.0/muon.rst
+++ b/docs/source/release/v6.2.0/muon.rst
@@ -61,5 +61,6 @@ Algorithms
 ##########
 
 - Updated :ref:`LoadMuonLog <algm-LoadMuonLog>` to read units for most log values.
+- It is now possible to exclude a fit range when executing the :ref:`CalculateMuonAsymmetry <algm-CalculateMuonAsymmetry>` algorithm.
 
 :ref:`Release 6.2.0 <v6.2.0>`

--- a/scripts/Muon/GUI/Common/ADSHandler/workspace_naming.py
+++ b/scripts/Muon/GUI/Common/ADSHandler/workspace_naming.py
@@ -281,7 +281,7 @@ def create_covariance_matrix_name(input_workspace_name, function_name):
 
 
 def create_model_fitting_parameter_combination_name(result_table_name, x_parameter, y_parameter):
-    return result_table_name + "; " + x_parameter + " vs " + y_parameter
+    return result_table_name + "; " + y_parameter + " vs " + x_parameter
 
 
 def create_model_fitting_parameters_group_name(results_table_name):

--- a/scripts/Muon/GUI/Common/contexts/fitting_contexts/basic_fitting_context.py
+++ b/scripts/Muon/GUI/Common/contexts/fitting_contexts/basic_fitting_context.py
@@ -45,6 +45,10 @@ class BasicFittingContext(FittingContext):
         self._start_xs: list = []
         self._end_xs: list = []
 
+        self._exclude_range: bool = False
+        self._exclude_start_xs: list = []
+        self._exclude_end_xs: list = []
+
         self._minimizer: str = ""
         self._evaluation_type: str = ""
         self._fit_to_raw: bool = True
@@ -262,6 +266,42 @@ class BasicFittingContext(FittingContext):
             raise RuntimeError(f"The provided number of end Xs is not equal to the number of datasets.")
 
         self._end_xs = end_xs
+
+    @property
+    def exclude_range(self) -> bool:
+        """Returns true if the Exclude Range option is on in the context."""
+        return self._exclude_range
+
+    @exclude_range.setter
+    def exclude_range(self, exclude_range_on: bool) -> None:
+        """Sets whether the Exclude Range option is on in the context."""
+        self._exclude_range = exclude_range_on
+
+    @property
+    def exclude_start_xs(self) -> list:
+        """Returns the exclude start Xs stored by the context."""
+        return self._exclude_start_xs
+
+    @exclude_start_xs.setter
+    def exclude_start_xs(self, start_xs: list) -> None:
+        """Sets the exclude start Xs stored by the context."""
+        if len(start_xs) != self.number_of_datasets:
+            raise RuntimeError(f"The provided number of exclude start Xs is not equal to the number of datasets.")
+
+        self._exclude_start_xs = start_xs
+
+    @property
+    def exclude_end_xs(self) -> list:
+        """Returns the exclude end Xs stored by the context."""
+        return self._exclude_end_xs
+
+    @exclude_end_xs.setter
+    def exclude_end_xs(self, end_xs: list) -> None:
+        """Sets the exclude end Xs stored by the context."""
+        if len(end_xs) != self.number_of_datasets:
+            raise RuntimeError(f"The provided number of exclude end Xs is not equal to the number of datasets.")
+
+        self._exclude_end_xs = end_xs
 
     @property
     def minimizer(self) -> str:

--- a/scripts/Muon/GUI/Common/fitting_widgets/basic_fitting/basic_fitting_model.py
+++ b/scripts/Muon/GUI/Common/fitting_widgets/basic_fitting/basic_fitting_model.py
@@ -16,7 +16,7 @@ from Muon.GUI.Common.contexts.fitting_contexts.basic_fitting_context import Basi
 from Muon.GUI.Common.contexts.fitting_contexts.fitting_context import FitInformation
 from Muon.GUI.Common.contexts.muon_context import MuonContext
 from Muon.GUI.Common.utilities.algorithm_utils import run_Fit
-from Muon.GUI.Common.utilities.workspace_data_utils import x_limits_of_workspace
+from Muon.GUI.Common.utilities.workspace_data_utils import check_exclude_start_and_end_x_is_valid, x_limits_of_workspace
 from Muon.GUI.Common.utilities.workspace_utils import StaticWorkspaceWrapper
 
 import math
@@ -167,9 +167,9 @@ class BasicFittingModel:
         return self.fitting_context.exclude_range
 
     @exclude_range.setter
-    def exclude_range(self, exclude_range_on: bool) -> None:
+    def exclude_range(self, exclude_range_state: bool) -> None:
         """Sets whether the Exclude Range option is on in the context."""
-        self.fitting_context.exclude_range = exclude_range_on
+        self.fitting_context.exclude_range = exclude_range_state
 
     @property
     def current_exclude_start_x(self) -> float:
@@ -479,7 +479,7 @@ class BasicFittingModel:
         self.fitting_context.end_xs = [self.current_end_x] * self.fitting_context.number_of_datasets
 
     def _reset_exclude_start_and_end_xs(self) -> None:
-        """Resets the exclude start and end Xs stored by the context."""
+        """Resets the exclude start and end Xs. Default exclude range is to have exclude_start_x == exclude_end_x."""
         self.fitting_context.exclude_start_xs = [self.current_end_x] * self.fitting_context.number_of_datasets
         self.fitting_context.exclude_end_xs = [self.current_end_x] * self.fitting_context.number_of_datasets
 
@@ -528,20 +528,7 @@ class BasicFittingModel:
         new_exclude_start_x = exclude_start_xs[dataset_index] if dataset_index < len(exclude_start_xs) else end_x
         new_exclude_end_x = exclude_end_xs[dataset_index] if dataset_index < len(exclude_end_xs) else end_x
 
-        return self._check_new_exclude_start_and_end_x(start_x, end_x, new_exclude_start_x, new_exclude_end_x)
-
-    @staticmethod
-    def _check_new_exclude_start_and_end_x(start_x: float, end_x: float, new_exclude_start_x: float,
-                                           new_exclude_end_x: float) -> tuple:
-        """Check that the new exclude start and end X are valid. If not they are adjusted."""
-        if new_exclude_start_x < start_x or new_exclude_start_x > end_x:
-            new_exclude_start_x = end_x
-        if new_exclude_end_x < start_x or new_exclude_end_x > end_x:
-            new_exclude_end_x = end_x
-
-        if new_exclude_start_x > new_exclude_end_x:
-            new_exclude_start_x, new_exclude_end_x = new_exclude_end_x, new_exclude_start_x
-        return new_exclude_start_x, new_exclude_end_x
+        return check_exclude_start_and_end_x_is_valid(start_x, end_x, new_exclude_start_x, new_exclude_end_x)
 
     def _get_new_functions_using_existing_datasets(self, new_dataset_names: list) -> list:
         """Returns the functions to use for the new datasets. It tries to use the existing functions if possible."""

--- a/scripts/Muon/GUI/Common/fitting_widgets/basic_fitting/basic_fitting_presenter.py
+++ b/scripts/Muon/GUI/Common/fitting_widgets/basic_fitting/basic_fitting_presenter.py
@@ -13,7 +13,9 @@ from Muon.GUI.Common.fitting_widgets.basic_fitting.basic_fitting_model import Ba
 from Muon.GUI.Common.fitting_widgets.basic_fitting.basic_fitting_view import BasicFittingView
 from Muon.GUI.Common.thread_model import ThreadModel
 from Muon.GUI.Common.thread_model_wrapper import ThreadModelWrapperWithOutput
-from Muon.GUI.Common.utilities.workspace_data_utils import check_start_x_is_valid, check_end_x_is_valid
+from Muon.GUI.Common.utilities.workspace_data_utils import (check_exclude_start_x_is_valid,
+                                                            check_exclude_end_x_is_valid, check_start_x_is_valid,
+                                                            check_end_x_is_valid)
 
 
 class BasicFittingPresenter:
@@ -262,16 +264,18 @@ class BasicFittingPresenter:
 
     def handle_exclude_start_x_updated(self) -> None:
         """Handle when the exclude start X is changed."""
-        exclude_start_x, exclude_end_x = self._check_exclude_start_x_is_valid(self.view.exclude_start_x,
-                                                                              self.view.exclude_end_x,
-                                                                              self.model.current_exclude_start_x)
+        exclude_start_x, exclude_end_x = check_exclude_start_x_is_valid(self.view.start_x, self.view.end_x,
+                                                                        self.view.exclude_start_x,
+                                                                        self.view.exclude_end_x,
+                                                                        self.model.current_exclude_start_x)
         self.update_exclude_start_and_end_x_in_view_and_model(exclude_start_x, exclude_end_x)
 
     def handle_exclude_end_x_updated(self) -> None:
         """Handle when the exclude end X is changed."""
-        exclude_start_x, exclude_end_x = self._check_exclude_end_x_is_valid(self.view.exclude_start_x,
-                                                                            self.view.exclude_end_x,
-                                                                            self.model.current_exclude_end_x)
+        exclude_start_x, exclude_end_x = check_exclude_end_x_is_valid(self.view.start_x, self.view.end_x,
+                                                                      self.view.exclude_start_x,
+                                                                      self.view.exclude_end_x,
+                                                                      self.model.current_exclude_end_x)
         self.update_exclude_start_and_end_x_in_view_and_model(exclude_start_x, exclude_end_x)
 
     def handle_use_rebin_changed(self) -> None:
@@ -427,39 +431,3 @@ class BasicFittingPresenter:
             self.view.warning_popup("No rebin options specified.")
             return False
         return True
-
-    def _check_exclude_start_x_is_valid(self, view_exclude_start_x: float, view_exclude_end_x: float,
-                                        model_exclude_start_x: float) -> float:
-        """Check that the exclude start x is valid. If it isn't, the exclude range is adjusted to be valid."""
-        x_lower, x_upper = self.view.start_x, self.view.end_x
-        if view_exclude_start_x < x_lower:
-            new_start_x, new_end_x = x_lower, view_exclude_end_x
-        elif view_exclude_start_x > x_upper:
-            if not self.model.is_equal_to_n_decimals(view_exclude_end_x, x_upper, 3):
-                new_start_x, new_end_x = view_exclude_end_x, x_upper
-            else:
-                new_start_x, new_end_x = model_exclude_start_x, view_exclude_end_x
-        elif view_exclude_start_x > view_exclude_end_x:
-            new_start_x, new_end_x = view_exclude_end_x, view_exclude_start_x
-        else:
-            new_start_x, new_end_x = view_exclude_start_x, view_exclude_end_x
-
-        return new_start_x, new_end_x
-
-    def _check_exclude_end_x_is_valid(self, view_exclude_start_x: float, view_exclude_end_x: float,
-                                      model_exclude_end_x: float):
-        """Check that the exclude end x is valid. If it isn't, the exclude range is adjusted to be valid."""
-        x_lower, x_upper = self.view.start_x, self.view.end_x
-        if view_exclude_end_x < x_lower:
-            if not self.model.is_equal_to_n_decimals(view_exclude_start_x, x_lower, 3):
-                new_start_x, new_end_x = x_lower, view_exclude_start_x
-            else:
-                new_start_x, new_end_x = view_exclude_start_x, model_exclude_end_x
-        elif view_exclude_end_x > x_upper:
-            new_start_x, new_end_x = view_exclude_start_x, x_upper
-        elif view_exclude_end_x < view_exclude_start_x:
-            new_start_x, new_end_x = view_exclude_end_x, view_exclude_start_x
-        else:
-            new_start_x, new_end_x = view_exclude_start_x, view_exclude_end_x
-
-        return new_start_x, new_end_x

--- a/scripts/Muon/GUI/Common/fitting_widgets/basic_fitting/basic_fitting_view.py
+++ b/scripts/Muon/GUI/Common/fitting_widgets/basic_fitting/basic_fitting_view.py
@@ -283,6 +283,10 @@ class BasicFittingView(ui_form, base_widget):
         """Hides the Fit Raw checkbox in the fitting options."""
         self.fit_function_options.hide_fit_raw_checkbox()
 
+    def hide_evaluate_function_as_checkbox(self) -> None:
+        """Hides the Evaluate Function as checkbox in the fitting options."""
+        self.fit_function_options.hide_evaluate_function_as_checkbox()
+
     def set_start_and_end_x_labels(self, start_x_label: str, end_x_label: str) -> None:
         """Sets the labels to use for the start and end X labels in the fit options table."""
         self.fit_function_options.set_start_and_end_x_labels(start_x_label, end_x_label)

--- a/scripts/Muon/GUI/Common/fitting_widgets/basic_fitting/basic_fitting_view.py
+++ b/scripts/Muon/GUI/Common/fitting_widgets/basic_fitting/basic_fitting_view.py
@@ -81,6 +81,18 @@ class BasicFittingView(ui_form, base_widget):
         """Connect the slot for the end x option."""
         self.fit_function_options.set_slot_for_end_x_updated(slot)
 
+    def set_slot_for_exclude_range_state_changed(self, slot) -> None:
+        """Connect the slot for the exclude range checkbox."""
+        self.fit_function_options.set_slot_for_exclude_range_state_changed(slot)
+
+    def set_slot_for_exclude_start_x_updated(self, slot) -> None:
+        """Connect the slot for the exclude start x option."""
+        self.fit_function_options.set_slot_for_exclude_start_x_updated(slot)
+
+    def set_slot_for_exclude_end_x_updated(self, slot) -> None:
+        """Connect the slot for the exclude end x option."""
+        self.fit_function_options.set_slot_for_exclude_end_x_updated(slot)
+
     def set_slot_for_minimizer_changed(self, slot) -> None:
         """Connect the slot for changing the Minimizer."""
         self.fit_function_options.set_slot_for_minimizer_changed(slot)
@@ -183,6 +195,31 @@ class BasicFittingView(ui_form, base_widget):
         self.fit_function_options.end_x = value
 
     @property
+    def exclude_range(self) -> bool:
+        """Returns true if the Exclude Range option is ticked."""
+        return self.fit_function_options.exclude_range
+
+    @property
+    def exclude_start_x(self) -> float:
+        """Returns the start X for the excluded region."""
+        return self.fit_function_options.exclude_start_x
+
+    @exclude_start_x.setter
+    def exclude_start_x(self, value: float) -> None:
+        """Sets the selected exclude start X."""
+        self.fit_function_options.exclude_start_x = value
+
+    @property
+    def exclude_end_x(self) -> float:
+        """Returns the end X for the excluded region."""
+        return self.fit_function_options.exclude_end_x
+
+    @exclude_end_x.setter
+    def exclude_end_x(self, value: float) -> None:
+        """Sets the selected exclude end X."""
+        self.fit_function_options.exclude_end_x = value
+
+    @property
     def evaluation_type(self) -> str:
         """Returns the selected evaluation type."""
         return self.fit_function_options.evaluation_type
@@ -238,6 +275,10 @@ class BasicFittingView(ui_form, base_widget):
         """Switches the view to single fit mode."""
         self.fit_function_options.switch_to_single()
 
+    def hide_exclude_range_checkbox(self) -> None:
+        """Hides the Exclude Range checkbox in the fitting options."""
+        self.fit_function_options.hide_exclude_range_checkbox()
+
     def hide_fit_raw_checkbox(self) -> None:
         """Hides the Fit Raw checkbox in the fitting options."""
         self.fit_function_options.hide_fit_raw_checkbox()
@@ -245,6 +286,10 @@ class BasicFittingView(ui_form, base_widget):
     def set_start_and_end_x_labels(self, start_x_label: str, end_x_label: str) -> None:
         """Sets the labels to use for the start and end X labels in the fit options table."""
         self.fit_function_options.set_start_and_end_x_labels(start_x_label, end_x_label)
+
+    def set_exclude_start_and_end_x_visible(self, visible: bool) -> None:
+        """Sets whether the exclude start and end x options are visible."""
+        self.fit_function_options.set_exclude_start_and_end_x_visible(visible)
 
     def disable_view(self) -> None:
         """Disable all widgets in this fitting widget."""

--- a/scripts/Muon/GUI/Common/fitting_widgets/basic_fitting/fit_function_options_view.py
+++ b/scripts/Muon/GUI/Common/fitting_widgets/basic_fitting/fit_function_options_view.py
@@ -287,6 +287,10 @@ class FitFunctionOptionsView(ui_form, base_widget):
         """Hides the Fit Raw checkbox in the fitting options."""
         self.fit_options_table.hideRow(RAW_DATA_TABLE_ROW)
 
+    def hide_evaluate_function_as_checkbox(self) -> None:
+        """Hides the Evaluate Function as checkbox in the fitting options."""
+        self.fit_options_table.hideRow(EVALUATE_AS_TABLE_ROW)
+
     def set_start_and_end_x_labels(self, start_x_label: str, end_x_label: str) -> None:
         """Sets the labels to use for the start and end X labels in the fit options table."""
         table_utils.setRowName(self.fit_options_table, START_X_TABLE_ROW, start_x_label)

--- a/scripts/Muon/GUI/Common/fitting_widgets/general_fitting/general_fitting_model.py
+++ b/scripts/Muon/GUI/Common/fitting_widgets/general_fitting/general_fitting_model.py
@@ -351,6 +351,8 @@ class GeneralFittingModel(BasicFittingModel):
         params["InputWorkspace"] = dataset_names
         params["StartX"] = self.fitting_context.start_xs
         params["EndX"] = self.fitting_context.end_xs
+        if self.fitting_context.exclude_range:
+            params["Exclude"] = list(zip(self.fitting_context.exclude_start_xs, self.fitting_context.exclude_end_xs))
         return params
 
     def _add_simultaneous_fit_results_to_ADS_and_context(self, input_workspace_names: list, parameter_table,

--- a/scripts/Muon/GUI/Common/fitting_widgets/tf_asymmetry_fitting/tf_asymmetry_fitting_model.py
+++ b/scripts/Muon/GUI/Common/fitting_widgets/tf_asymmetry_fitting/tf_asymmetry_fitting_model.py
@@ -661,6 +661,9 @@ class TFAsymmetryFittingModel(GeneralFittingModel):
                   "EndX": self.current_end_x,
                   "Minimizer": self.fitting_context.minimizer}
 
+        if self.fitting_context.exclude_range:
+            params["Exclude"] = [self.current_exclude_start_x, self.current_exclude_end_x]
+
         if self._double_pulse_enabled():
             params.update(self._get_common_double_pulse_parameters())
         return params

--- a/scripts/Muon/GUI/Common/model_fitting_tab_widget/model_fitting_tab_widget.py
+++ b/scripts/Muon/GUI/Common/model_fitting_tab_widget/model_fitting_tab_widget.py
@@ -18,6 +18,7 @@ class ModelFittingTabWidget(object):
         self.model_fitting_tab_view = ModelFittingView(parent)
         self.model_fitting_tab_view.hide_exclude_range_checkbox()
         self.model_fitting_tab_view.hide_fit_raw_checkbox()
+        self.model_fitting_tab_view.hide_evaluate_function_as_checkbox()
         self.model_fitting_tab_model = ModelFittingModel(context, context.model_fitting_context)
         self.model_fitting_tab_presenter = ModelFittingPresenter(self.model_fitting_tab_view,
                                                                  self.model_fitting_tab_model)

--- a/scripts/Muon/GUI/Common/model_fitting_tab_widget/model_fitting_tab_widget.py
+++ b/scripts/Muon/GUI/Common/model_fitting_tab_widget/model_fitting_tab_widget.py
@@ -16,6 +16,7 @@ class ModelFittingTabWidget(object):
 
     def __init__(self, context, parent):
         self.model_fitting_tab_view = ModelFittingView(parent)
+        self.model_fitting_tab_view.hide_exclude_range_checkbox()
         self.model_fitting_tab_view.hide_fit_raw_checkbox()
         self.model_fitting_tab_model = ModelFittingModel(context, context.model_fitting_context)
         self.model_fitting_tab_presenter = ModelFittingPresenter(self.model_fitting_tab_view,

--- a/scripts/Muon/GUI/Common/test_helpers/fitting_mock_setup.py
+++ b/scripts/Muon/GUI/Common/test_helpers/fitting_mock_setup.py
@@ -6,6 +6,11 @@
 # SPDX - License - Identifier: GPL - 3.0 +
 from unittest import mock
 
+from Muon.GUI.Common.fitting_widgets.basic_fitting.basic_fitting_model import BasicFittingModel
+from Muon.GUI.Common.fitting_widgets.basic_fitting.basic_fitting_presenter import BasicFittingPresenter
+from Muon.GUI.Common.fitting_widgets.basic_fitting.basic_fitting_view import BasicFittingView
+from Muon.GUI.Common.thread_model import ThreadModel
+
 
 def add_mock_methods_to_basic_fitting_view(view):
     # Mock the methods of the view
@@ -76,6 +81,7 @@ def add_mock_methods_to_basic_fitting_presenter(presenter):
     presenter.selected_fit_results_changed.notify_subscribers = mock.Mock()
     presenter.fit_function_changed_notifier.notify_subscribers = mock.Mock()
     presenter.fit_parameter_changed_notifier.notify_subscribers = mock.Mock()
+    presenter.update_exclude_start_and_end_x_in_view_and_model = mock.Mock()
     return presenter
 
 
@@ -130,3 +136,107 @@ def add_mock_methods_to_model_fitting_model(model, dataset_names, current_datase
 def add_mock_methods_to_model_fitting_presenter(presenter):
     presenter = add_mock_methods_to_basic_fitting_presenter(presenter)
     return presenter
+
+
+class MockBasicFitting:
+
+    def _setup_mock_view(self):
+        self.view = mock.Mock(spec=BasicFittingView)
+        self.view = add_mock_methods_to_basic_fitting_view(self.view)
+
+        # Mock the properties of the view
+        self.mock_view_minimizer = mock.PropertyMock(return_value=self.minimizer)
+        type(self.view).minimizer = self.mock_view_minimizer
+        self.mock_view_evaluation_type = mock.PropertyMock(return_value=self.evaluation_type)
+        type(self.view).evaluation_type = self.mock_view_evaluation_type
+        self.mock_view_fit_to_raw = mock.PropertyMock(return_value=self.fit_to_raw)
+        type(self.view).fit_to_raw = self.mock_view_fit_to_raw
+        self.mock_view_fit_object = mock.PropertyMock(return_value=self.fit_function)
+        type(self.view).fit_object = self.mock_view_fit_object
+        self.mock_view_start_x = mock.PropertyMock(return_value=self.start_x)
+        type(self.view).start_x = self.mock_view_start_x
+        self.mock_view_end_x = mock.PropertyMock(return_value=self.end_x)
+        type(self.view).end_x = self.mock_view_end_x
+        self.mock_view_exclude_range = mock.PropertyMock(return_value=True)
+        type(self.view).exclude_range = self.mock_view_exclude_range
+        self.mock_view_exclude_start_x = mock.PropertyMock(return_value=self.start_x)
+        type(self.view).exclude_start_x = self.mock_view_exclude_start_x
+        self.mock_view_exclude_end_x = mock.PropertyMock(return_value=self.end_x)
+        type(self.view).exclude_end_x = self.mock_view_exclude_end_x
+        self.mock_view_plot_guess = mock.PropertyMock(return_value=self.plot_guess)
+        type(self.view).plot_guess = self.mock_view_plot_guess
+        self.mock_view_function_name = mock.PropertyMock(return_value=self.function_name)
+        type(self.view).function_name = self.mock_view_function_name
+
+    def _setup_mock_model(self):
+        self.model = mock.Mock(spec=BasicFittingModel)
+        self.model = add_mock_methods_to_basic_fitting_model(self.model, self.dataset_names, self.current_dataset_index,
+                                                             self.fit_function, self.start_x, self.end_x,
+                                                             self.fit_status, self.chi_squared)
+
+        # Mock the properties of the model
+        self.mock_model_current_dataset_index = mock.PropertyMock(return_value=self.current_dataset_index)
+        type(self.model).current_dataset_index = self.mock_model_current_dataset_index
+        self.mock_model_dataset_names = mock.PropertyMock(return_value=self.dataset_names)
+        type(self.model).dataset_names = self.mock_model_dataset_names
+        self.mock_model_current_dataset_name = mock.PropertyMock(return_value=
+                                                                 self.dataset_names[self.current_dataset_index])
+        type(self.model).current_dataset_name = self.mock_model_current_dataset_name
+        self.mock_model_number_of_datasets = mock.PropertyMock(return_value=len(self.dataset_names))
+        type(self.model).number_of_datasets = self.mock_model_number_of_datasets
+        self.mock_model_start_xs = mock.PropertyMock(return_value=[self.start_x] * len(self.dataset_names))
+        type(self.model).start_xs = self.mock_model_start_xs
+        self.mock_model_current_start_x = mock.PropertyMock(return_value=self.start_x)
+        type(self.model).current_start_x = self.mock_model_current_start_x
+        self.mock_model_end_xs = mock.PropertyMock(return_value=[self.end_x] * len(self.dataset_names))
+        type(self.model).end_xs = self.mock_model_end_xs
+        self.mock_model_current_end_x = mock.PropertyMock(return_value=self.end_x)
+        type(self.model).current_end_x = self.mock_model_current_end_x
+        self.mock_model_exclude_range = mock.PropertyMock(return_value=True)
+        type(self.model).exclude_range = self.mock_model_exclude_range
+        self.mock_model_current_exclude_start_x = mock.PropertyMock(return_value=self.start_x)
+        type(self.model).current_exclude_start_x = self.mock_model_current_exclude_start_x
+        self.mock_model_current_exclude_end_x = mock.PropertyMock(return_value=self.end_x)
+        type(self.model).current_exclude_end_x = self.mock_model_current_exclude_end_x
+        self.mock_model_plot_guess = mock.PropertyMock(return_value=self.plot_guess)
+        type(self.model).plot_guess = self.mock_model_plot_guess
+        self.mock_model_minimizer = mock.PropertyMock(return_value=self.minimizer)
+        type(self.model).minimizer = self.mock_model_minimizer
+        self.mock_model_evaluation_type = mock.PropertyMock(return_value=self.evaluation_type)
+        type(self.model).evaluation_type = self.mock_model_evaluation_type
+        self.mock_model_fit_to_raw = mock.PropertyMock(return_value=self.fit_to_raw)
+        type(self.model).fit_to_raw = self.mock_model_fit_to_raw
+        self.mock_model_single_fit_functions = mock.PropertyMock(return_value=self.single_fit_functions)
+        type(self.model).single_fit_functions = self.mock_model_single_fit_functions
+        self.mock_model_current_single_fit_function = mock.PropertyMock(return_value=self.fit_function)
+        type(self.model).current_single_fit_function = self.mock_model_current_single_fit_function
+        self.mock_model_single_fit_functions_cache = mock.PropertyMock(return_value=self.fit_function)
+        type(self.model).single_fit_functions_cache = self.mock_model_single_fit_functions_cache
+        self.mock_model_fit_statuses = mock.PropertyMock(return_value=[self.fit_status] * len(self.dataset_names))
+        type(self.model).fit_statuses = self.mock_model_fit_statuses
+        self.mock_model_current_fit_status = mock.PropertyMock(return_value=self.fit_status)
+        type(self.model).current_fit_status = self.mock_model_current_fit_status
+        self.mock_model_chi_squared = mock.PropertyMock(return_value=[self.chi_squared] * len(self.dataset_names))
+        type(self.model).chi_squared = self.mock_model_chi_squared
+        self.mock_model_current_chi_squared = mock.PropertyMock(return_value=self.chi_squared)
+        type(self.model).current_chi_squared = self.mock_model_current_chi_squared
+        self.mock_model_function_name = mock.PropertyMock(return_value=self.function_name)
+        type(self.model).function_name = self.mock_model_function_name
+        self.mock_model_function_name_auto_update = mock.PropertyMock(return_value=True)
+        type(self.model).function_name_auto_update = self.mock_model_function_name_auto_update
+        self.mock_model_simultaneous_fitting_mode = mock.PropertyMock(return_value=False)
+        type(self.model).simultaneous_fitting_mode = self.mock_model_simultaneous_fitting_mode
+        self.mock_model_global_parameters = mock.PropertyMock(return_value=[])
+        type(self.model).global_parameters = self.mock_model_global_parameters
+        self.mock_model_do_rebin = mock.PropertyMock(return_value=False)
+        type(self.model).do_rebin = self.mock_model_do_rebin
+
+    def _setup_presenter(self):
+        self.presenter = BasicFittingPresenter(self.view, self.model)
+        self.presenter = add_mock_methods_to_basic_fitting_presenter(self.presenter)
+
+        # Mock the fit result property
+        self.presenter.fitting_calculation_model = mock.Mock(spec=ThreadModel)
+        self.mock_presenter_get_fit_results = mock.PropertyMock(return_value=(self.fit_function, self.fit_status,
+                                                                              self.chi_squared))
+        type(self.presenter.fitting_calculation_model).result = self.mock_presenter_get_fit_results

--- a/scripts/Muon/GUI/Common/test_helpers/fitting_mock_setup.py
+++ b/scripts/Muon/GUI/Common/test_helpers/fitting_mock_setup.py
@@ -18,6 +18,9 @@ def add_mock_methods_to_basic_fitting_view(view):
     view.set_slot_for_function_parameter_changed = mock.Mock()
     view.set_slot_for_start_x_updated = mock.Mock()
     view.set_slot_for_end_x_updated = mock.Mock()
+    view.set_slot_for_exclude_range_state_changed = mock.Mock()
+    view.set_slot_for_exclude_start_x_updated = mock.Mock()
+    view.set_slot_for_exclude_end_x_updated = mock.Mock()
     view.set_slot_for_minimizer_changed = mock.Mock()
     view.set_slot_for_evaluation_type_changed = mock.Mock()
     view.set_slot_for_use_raw_changed = mock.Mock()
@@ -34,6 +37,7 @@ def add_mock_methods_to_basic_fitting_view(view):
     view.switch_to_simultaneous = mock.Mock()
     view.switch_to_single = mock.Mock()
     view.disable_view = mock.Mock()
+    view.set_exclude_start_and_end_x_visible = mock.Mock()
     return view
 
 

--- a/scripts/Muon/GUI/Common/utilities/algorithm_utils.py
+++ b/scripts/Muon/GUI/Common/utilities/algorithm_utils.py
@@ -140,11 +140,13 @@ def run_Fit(parameters_dict, alg):
     alg.setRethrows(True)
     alg.setProperty('CreateOutput', True)
     pruned_parameter_dict = {key: value for key, value in parameters_dict.items() if
-                             key not in ['InputWorkspace', 'StartX', 'EndX']}
+                             key not in ['InputWorkspace', 'StartX', 'EndX', 'Exclude']}
     alg.setProperties(pruned_parameter_dict)
     alg.setProperty('InputWorkspace', parameters_dict['InputWorkspace'])
     alg.setProperty('StartX', parameters_dict['StartX'])
     alg.setProperty('EndX', parameters_dict['EndX'])
+    if 'Exclude' in parameters_dict:
+        alg.setProperty('Exclude', parameters_dict['Exclude'])
     alg.execute()
     return alg.getProperty("OutputWorkspace").valueAsStr, alg.getProperty(
         "OutputParameters").valueAsStr, alg.getProperty(
@@ -158,7 +160,7 @@ def run_simultaneous_Fit(parameters_dict, alg):
     alg.setRethrows(True)
     alg.setProperty('CreateOutput', True)
     pruned_parameter_dict = {key: value for key,value in parameters_dict.items() if
-                             key not in ['InputWorkspace', 'StartX', 'EndX']}
+                             key not in ['InputWorkspace', 'StartX', 'EndX', 'Exclude']}
     alg.setProperties(pruned_parameter_dict)
 
     for index, input_workspace in enumerate(parameters_dict['InputWorkspace']):
@@ -166,6 +168,8 @@ def run_simultaneous_Fit(parameters_dict, alg):
         alg.setProperty('InputWorkspace' + index_str, input_workspace)
         alg.setProperty('StartX' + index_str, parameters_dict['StartX'][index])
         alg.setProperty('EndX' + index_str, parameters_dict['EndX'][index])
+        if 'Exclude' in parameters_dict:
+            alg.setProperty('Exclude' + index_str, parameters_dict['Exclude'][index])
 
     alg.execute()
 

--- a/scripts/Muon/GUI/Common/utilities/workspace_data_utils.py
+++ b/scripts/Muon/GUI/Common/utilities/workspace_data_utils.py
@@ -93,3 +93,16 @@ def check_exclude_end_x_is_valid(x_lower: float, x_upper: float, view_exclude_st
     """Check that the exclude end x is valid. If it isn't, the exclude range is adjusted to be valid."""
     return _check_end_x_is_valid(x_lower, x_upper, view_exclude_start_x, view_exclude_end_x, model_exclude_end_x,
                                  check_is_equal=False)
+
+
+def check_exclude_start_and_end_x_is_valid(x_lower: float, x_upper: float, exclude_start_x: float,
+                                           exclude_end_x: float) -> tuple:
+    """Check that the new exclude start and end X are valid. If not they are adjusted."""
+    if exclude_start_x < x_lower or exclude_start_x > x_upper:
+        exclude_start_x = x_upper
+    if exclude_end_x < x_lower or exclude_end_x > x_upper:
+        exclude_end_x = x_upper
+
+    if exclude_start_x > exclude_end_x:
+        exclude_start_x, exclude_end_x = exclude_end_x, exclude_start_x
+    return exclude_start_x, exclude_end_x

--- a/scripts/Muon/GUI/Common/utilities/workspace_data_utils.py
+++ b/scripts/Muon/GUI/Common/utilities/workspace_data_utils.py
@@ -29,9 +29,9 @@ def is_equal_to_n_decimals(value1: float, value2: float, n_decimals: int) -> boo
     return f"{value1:.{n_decimals}f}" == f"{value2:.{n_decimals}f}"
 
 
-def check_start_x_is_valid(workspace_name: str, view_start_x: float, view_end_x: float, model_start_x: float) -> tuple:
-    """Checks that the new start X is valid. If it isn't, the start and end X is adjusted."""
-    x_lower, x_upper = x_limits_of_workspace(workspace_name)
+def _check_start_x_is_valid(x_lower: float, x_upper: float, view_start_x: float, view_end_x: float,
+                            model_start_x: float, check_is_equal: bool = True) -> tuple:
+    """Check that the start x is valid. If it isn't, the exclude range is adjusted to be valid."""
     if view_start_x < x_lower:
         new_start_x, new_end_x = x_lower, view_end_x
     elif view_start_x > x_upper:
@@ -41,7 +41,7 @@ def check_start_x_is_valid(workspace_name: str, view_start_x: float, view_end_x:
             new_start_x, new_end_x = model_start_x, view_end_x
     elif view_start_x > view_end_x:
         new_start_x, new_end_x = view_end_x, view_start_x
-    elif view_start_x == view_end_x:
+    elif check_is_equal and view_start_x == view_end_x:
         new_start_x, new_end_x = model_start_x, view_end_x
     else:
         new_start_x, new_end_x = view_start_x, view_end_x
@@ -49,9 +49,9 @@ def check_start_x_is_valid(workspace_name: str, view_start_x: float, view_end_x:
     return new_start_x, new_end_x
 
 
-def check_end_x_is_valid(workspace_name: str, view_start_x: float, view_end_x: float, model_end_x: float) -> tuple:
-    """Checks that the new end X is valid. If it isn't, the start and end X is adjusted."""
-    x_lower, x_upper = x_limits_of_workspace(workspace_name)
+def _check_end_x_is_valid(x_lower: float, x_upper: float, view_start_x: float, view_end_x: float, model_end_x: float,
+                          check_is_equal: bool = True) -> tuple:
+    """Check that the exclude end x is valid. If it isn't, the exclude range is adjusted to be valid."""
     if view_end_x < x_lower:
         if not is_equal_to_n_decimals(view_start_x, x_lower, 3):
             new_start_x, new_end_x = x_lower, view_start_x
@@ -61,9 +61,35 @@ def check_end_x_is_valid(workspace_name: str, view_start_x: float, view_end_x: f
         new_start_x, new_end_x = view_start_x, x_upper
     elif view_end_x < view_start_x:
         new_start_x, new_end_x = view_end_x, view_start_x
-    elif view_end_x == view_start_x:
+    elif check_is_equal and view_end_x == view_start_x:
         new_start_x, new_end_x = view_start_x, model_end_x
     else:
         new_start_x, new_end_x = view_start_x, view_end_x
 
     return new_start_x, new_end_x
+
+
+def check_start_x_is_valid(workspace_name: str, view_start_x: float, view_end_x: float, model_start_x: float) -> tuple:
+    """Checks that the new start X is valid. If it isn't, the start and end X is adjusted."""
+    x_lower, x_upper = x_limits_of_workspace(workspace_name)
+    return _check_start_x_is_valid(x_lower, x_upper, view_start_x, view_end_x, model_start_x)
+
+
+def check_end_x_is_valid(workspace_name: str, view_start_x: float, view_end_x: float, model_end_x: float) -> tuple:
+    """Checks that the new end X is valid. If it isn't, the start and end X is adjusted."""
+    x_lower, x_upper = x_limits_of_workspace(workspace_name)
+    return _check_end_x_is_valid(x_lower, x_upper, view_start_x, view_end_x, model_end_x)
+
+
+def check_exclude_start_x_is_valid(x_lower: float, x_upper: float, view_exclude_start_x: float,
+                                   view_exclude_end_x: float, model_exclude_start_x: float) -> tuple:
+    """Check that the exclude start x is valid. If it isn't, the exclude range is adjusted to be valid."""
+    return _check_start_x_is_valid(x_lower, x_upper, view_exclude_start_x, view_exclude_end_x, model_exclude_start_x,
+                                   check_is_equal=False)
+
+
+def check_exclude_end_x_is_valid(x_lower: float, x_upper: float, view_exclude_start_x: float, view_exclude_end_x: float,
+                                 model_exclude_end_x: float) -> tuple:
+    """Check that the exclude end x is valid. If it isn't, the exclude range is adjusted to be valid."""
+    return _check_end_x_is_valid(x_lower, x_upper, view_exclude_start_x, view_exclude_end_x, model_exclude_end_x,
+                                 check_is_equal=False)

--- a/scripts/test/Muon/ADSHandler/workspace_naming_test.py
+++ b/scripts/test/Muon/ADSHandler/workspace_naming_test.py
@@ -127,7 +127,7 @@ class WorkspaceNamingTest(unittest.TestCase):
 
         name = create_model_fitting_parameter_combination_name(results_table_name, x_parameter, y_parameter)
 
-        self.assertEqual(name, "Result1; A0 vs A1")
+        self.assertEqual(name, "Result1; A1 vs A0")
 
     def test_create_model_fitting_parameters_group_name(self):
         results_table_name = "Result1"

--- a/scripts/test/Muon/basic_fitting_context_test.py
+++ b/scripts/test/Muon/basic_fitting_context_test.py
@@ -37,6 +37,9 @@ class BasicFittingContextTest(unittest.TestCase):
         self.assertEqual(self.fitting_context.current_dataset_index, None)
         self.assertEqual(self.fitting_context.start_xs, [])
         self.assertEqual(self.fitting_context.end_xs, [])
+        self.assertEqual(self.fitting_context.exclude_range, False)
+        self.assertEqual(self.fitting_context.exclude_start_xs, [])
+        self.assertEqual(self.fitting_context.exclude_end_xs, [])
         self.assertEqual(self.fitting_context.single_fit_functions, [])
         self.assertEqual(self.fitting_context.dataset_indices_for_undo, [])
         self.assertEqual(self.fitting_context.single_fit_functions_for_undo, [])
@@ -73,6 +76,16 @@ class BasicFittingContextTest(unittest.TestCase):
         self.fitting_context.dataset_names = self.dataset_names
         with self.assertRaises(RuntimeError):
             self.fitting_context.end_xs = [1.0, 2.0, 3.0]
+
+    def test_that_exclude_start_xs_will_raise_if_the_number_of_xs_is_greater_than_or_equal_to_the_number_of_datasets(self):
+        self.fitting_context.dataset_names = self.dataset_names
+        with self.assertRaises(RuntimeError):
+            self.fitting_context.exclude_start_xs = [1.0, 2.0, 3.0]
+
+    def test_that_exclude_end_xs_will_raise_if_the_number_of_xs_is_greater_than_or_equal_to_the_number_of_datasets(self):
+        self.fitting_context.dataset_names = self.dataset_names
+        with self.assertRaises(RuntimeError):
+            self.fitting_context.exclude_end_xs = [1.0, 2.0, 3.0]
 
     def test_that_single_fit_functions_will_raise_if_the_num_of_funcs_is_greater_than_or_equal_to_the_num_of_datasets(self):
         self.fitting_context.dataset_names = ["Name1"]

--- a/scripts/test/Muon/fitting_widgets/basic_fitting/basic_fitting_model_test.py
+++ b/scripts/test/Muon/fitting_widgets/basic_fitting/basic_fitting_model_test.py
@@ -85,6 +85,18 @@ class BasicFittingModelTest(unittest.TestCase):
         self.assertEqual(self.model.start_xs, [3.0])
         self.assertEqual(self.model.end_xs, [5.0])
 
+    def test_that_newly_loaded_datasets_will_reset_the_existing_exclude_xs_when_there_are_fewer_new_datasets(self):
+        self.model.dataset_names = self.dataset_names
+        self.model.start_xs = [2.0, 3.0]
+        self.model.end_xs = [4.0, 5.0]
+        self.model.fitting_context.exclude_start_xs = [2.2, 4.2]
+        self.model.fitting_context.exclude_end_xs = [2.5, 4.5]
+
+        self.model.dataset_names = ["Name2"]
+
+        self.assertEqual(self.model.fitting_context.exclude_start_xs, [5.0])
+        self.assertEqual(self.model.fitting_context.exclude_end_xs, [5.0])
+
     def test_that_current_dataset_index_will_raise_if_the_index_is_greater_than_or_equal_to_the_number_of_datasets(self):
         self.model.dataset_names = self.dataset_names
         with self.assertRaises(RuntimeError):
@@ -172,6 +184,17 @@ class BasicFittingModelTest(unittest.TestCase):
         self.model.current_end_x = 4.0
 
         self.assertEqual(self.model.end_xs, [10.0, 11.0])
+
+    def test_that_the_current_exclude_start_x_and_end_x_will_return_the_selected_exclude_end_x(self):
+        self.model.dataset_names = self.dataset_names
+        self.model.start_xs = [0.0, 1.0]
+        self.model.end_xs = [5.0, 6.0]
+        self.model.fitting_context.exclude_start_xs = [0.1, 1.1]
+        self.model.fitting_context.exclude_end_xs = [4.5, 5.5]
+        self.model.current_dataset_index = 1
+
+        self.assertEqual(self.model.current_exclude_start_x, 1.1)
+        self.assertEqual(self.model.current_exclude_end_x, 5.5)
 
     def test_that_setting_the_dataset_names_will_reset_the_start_and_end_xs(self):
         self.model.dataset_names = self.dataset_names

--- a/scripts/test/Muon/fitting_widgets/basic_fitting/basic_fitting_model_test.py
+++ b/scripts/test/Muon/fitting_widgets/basic_fitting/basic_fitting_model_test.py
@@ -97,6 +97,30 @@ class BasicFittingModelTest(unittest.TestCase):
         self.assertEqual(self.model.fitting_context.exclude_start_xs, [5.0])
         self.assertEqual(self.model.fitting_context.exclude_end_xs, [5.0])
 
+    def test_that_newly_loaded_datasets_will_reuse_the_existing_exclude_xs_when_there_are_more_new_datasets(self):
+        self.model.dataset_names = self.dataset_names
+        self.model.start_xs = [2.0, 2.0]
+        self.model.end_xs = [4.0, 4.0]
+        self.model.fitting_context.exclude_start_xs = [2.2, 2.2]
+        self.model.fitting_context.exclude_end_xs = [2.5, 2.5]
+
+        self.model.dataset_names = ["Name2", "Name3", "Name4"]
+
+        self.assertEqual(self.model.fitting_context.exclude_start_xs, [2.2, 2.2, 4.0])
+        self.assertEqual(self.model.fitting_context.exclude_end_xs, [2.5, 2.5, 4.0])
+
+    def test_that_newly_loaded_datasets_will_reuse_the_existing_exclude_xs_when_there_are_equal_num_datasets(self):
+        self.model.dataset_names = self.dataset_names
+        self.model.start_xs = [2.0, 2.0]
+        self.model.end_xs = [4.0, 4.0]
+        self.model.fitting_context.exclude_start_xs = [2.2, 2.2]
+        self.model.fitting_context.exclude_end_xs = [2.5, 2.5]
+
+        self.model.dataset_names = ["Name2", "Name3"]
+
+        self.assertEqual(self.model.fitting_context.exclude_start_xs, [2.2, 2.2])
+        self.assertEqual(self.model.fitting_context.exclude_end_xs, [2.5, 2.5])
+
     def test_that_current_dataset_index_will_raise_if_the_index_is_greater_than_or_equal_to_the_number_of_datasets(self):
         self.model.dataset_names = self.dataset_names
         with self.assertRaises(RuntimeError):

--- a/scripts/test/Muon/fitting_widgets/basic_fitting/basic_fitting_presenter_test.py
+++ b/scripts/test/Muon/fitting_widgets/basic_fitting/basic_fitting_presenter_test.py
@@ -9,17 +9,10 @@ from unittest import mock
 
 from mantid.api import FrameworkManager, FunctionFactory
 from mantidqt.widgets.fitscriptgenerator import FittingMode
-
-from Muon.GUI.Common.fitting_widgets.basic_fitting.basic_fitting_model import BasicFittingModel
-from Muon.GUI.Common.fitting_widgets.basic_fitting.basic_fitting_presenter import BasicFittingPresenter
-from Muon.GUI.Common.fitting_widgets.basic_fitting.basic_fitting_view import BasicFittingView
-from Muon.GUI.Common.test_helpers.fitting_mock_setup import (add_mock_methods_to_basic_fitting_model,
-                                                             add_mock_methods_to_basic_fitting_presenter,
-                                                             add_mock_methods_to_basic_fitting_view)
-from Muon.GUI.Common.thread_model import ThreadModel
+from Muon.GUI.Common.test_helpers.fitting_mock_setup import MockBasicFitting
 
 
-class BasicFittingPresenterTest(unittest.TestCase):
+class BasicFittingPresenterTest(unittest.TestCase, MockBasicFitting):
 
     @classmethod
     def setUpClass(cls):
@@ -444,117 +437,6 @@ class BasicFittingPresenterTest(unittest.TestCase):
         self.mock_view_start_x.assert_called_once_with(self.start_x)
         self.mock_model_current_end_x.assert_called_once_with()
         self.mock_view_end_x.assert_called_once_with(self.end_x)
-
-    def _setup_mock_view(self):
-        self.view = mock.Mock(spec=BasicFittingView)
-        self.view = add_mock_methods_to_basic_fitting_view(self.view)
-
-        # Mock the properties of the view
-        self.mock_view_minimizer = mock.PropertyMock(return_value=self.minimizer)
-        type(self.view).minimizer = self.mock_view_minimizer
-        self.mock_view_evaluation_type = mock.PropertyMock(return_value=self.evaluation_type)
-        type(self.view).evaluation_type = self.mock_view_evaluation_type
-        self.mock_view_fit_to_raw = mock.PropertyMock(return_value=self.fit_to_raw)
-        type(self.view).fit_to_raw = self.mock_view_fit_to_raw
-        self.mock_view_fit_object = mock.PropertyMock(return_value=self.fit_function)
-        type(self.view).fit_object = self.mock_view_fit_object
-        self.mock_view_start_x = mock.PropertyMock(return_value=self.start_x)
-        type(self.view).start_x = self.mock_view_start_x
-        self.mock_view_end_x = mock.PropertyMock(return_value=self.end_x)
-        type(self.view).end_x = self.mock_view_end_x
-        self.mock_view_exclude_range = mock.PropertyMock(return_value=True)
-        type(self.view).exclude_range = self.mock_view_exclude_range
-        self.mock_view_exclude_start_x = mock.PropertyMock(return_value=self.start_x)
-        type(self.view).exclude_start_x = self.mock_view_exclude_start_x
-        self.mock_view_exclude_end_x = mock.PropertyMock(return_value=self.end_x)
-        type(self.view).exclude_end_x = self.mock_view_exclude_end_x
-        self.mock_view_plot_guess = mock.PropertyMock(return_value=self.plot_guess)
-        type(self.view).plot_guess = self.mock_view_plot_guess
-        self.mock_view_function_name = mock.PropertyMock(return_value=self.function_name)
-        type(self.view).function_name = self.mock_view_function_name
-
-    def _setup_mock_model(self):
-        self.model = mock.Mock(spec=BasicFittingModel)
-        self.model = add_mock_methods_to_basic_fitting_model(self.model, self.dataset_names, self.current_dataset_index,
-                                                             self.fit_function, self.start_x, self.end_x,
-                                                             self.fit_status, self.chi_squared)
-
-        # Mock the properties of the model
-        self.mock_model_current_dataset_index = mock.PropertyMock(return_value=self.current_dataset_index)
-        type(self.model).current_dataset_index = self.mock_model_current_dataset_index
-        self.mock_model_dataset_names = mock.PropertyMock(return_value=self.dataset_names)
-        type(self.model).dataset_names = self.mock_model_dataset_names
-        self.mock_model_current_dataset_name = mock.PropertyMock(return_value=
-                                                                 self.dataset_names[self.current_dataset_index])
-        type(self.model).current_dataset_name = self.mock_model_current_dataset_name
-        self.mock_model_number_of_datasets = mock.PropertyMock(return_value=len(self.dataset_names))
-        type(self.model).number_of_datasets = self.mock_model_number_of_datasets
-        self.mock_model_start_xs = mock.PropertyMock(return_value=[self.start_x] * len(self.dataset_names))
-        type(self.model).start_xs = self.mock_model_start_xs
-        self.mock_model_current_start_x = mock.PropertyMock(return_value=self.start_x)
-        type(self.model).current_start_x = self.mock_model_current_start_x
-        self.mock_model_end_xs = mock.PropertyMock(return_value=[self.end_x] * len(self.dataset_names))
-        type(self.model).end_xs = self.mock_model_end_xs
-        self.mock_model_current_end_x = mock.PropertyMock(return_value=self.end_x)
-        type(self.model).current_end_x = self.mock_model_current_end_x
-        self.mock_model_exclude_range = mock.PropertyMock(return_value=True)
-        type(self.model).exclude_range = self.mock_model_exclude_range
-        self.mock_model_current_exclude_start_x = mock.PropertyMock(return_value=self.start_x)
-        type(self.model).current_exclude_start_x = self.mock_model_current_exclude_start_x
-        self.mock_model_current_exclude_end_x = mock.PropertyMock(return_value=self.end_x)
-        type(self.model).current_exclude_end_x = self.mock_model_current_exclude_end_x
-        self.mock_model_plot_guess = mock.PropertyMock(return_value=self.plot_guess)
-        type(self.model).plot_guess = self.mock_model_plot_guess
-        self.mock_model_minimizer = mock.PropertyMock(return_value=self.minimizer)
-        type(self.model).minimizer = self.mock_model_minimizer
-        self.mock_model_evaluation_type = mock.PropertyMock(return_value=self.evaluation_type)
-        type(self.model).evaluation_type = self.mock_model_evaluation_type
-        self.mock_model_fit_to_raw = mock.PropertyMock(return_value=self.fit_to_raw)
-        type(self.model).fit_to_raw = self.mock_model_fit_to_raw
-        self.mock_model_single_fit_functions = mock.PropertyMock(return_value=self.single_fit_functions)
-        type(self.model).single_fit_functions = self.mock_model_single_fit_functions
-        self.mock_model_current_single_fit_function = mock.PropertyMock(return_value=self.fit_function)
-        type(self.model).current_single_fit_function = self.mock_model_current_single_fit_function
-        self.mock_model_single_fit_functions_cache = mock.PropertyMock(return_value=self.fit_function)
-        type(self.model).single_fit_functions_cache = self.mock_model_single_fit_functions_cache
-        self.mock_model_fit_statuses = mock.PropertyMock(return_value=[self.fit_status] * len(self.dataset_names))
-        type(self.model).fit_statuses = self.mock_model_fit_statuses
-        self.mock_model_current_fit_status = mock.PropertyMock(return_value=self.fit_status)
-        type(self.model).current_fit_status = self.mock_model_current_fit_status
-        self.mock_model_chi_squared = mock.PropertyMock(return_value=[self.chi_squared] * len(self.dataset_names))
-        type(self.model).chi_squared = self.mock_model_chi_squared
-        self.mock_model_current_chi_squared = mock.PropertyMock(return_value=self.chi_squared)
-        type(self.model).current_chi_squared = self.mock_model_current_chi_squared
-        self.mock_model_function_name = mock.PropertyMock(return_value=self.function_name)
-        type(self.model).function_name = self.mock_model_function_name
-        self.mock_model_function_name_auto_update = mock.PropertyMock(return_value=True)
-        type(self.model).function_name_auto_update = self.mock_model_function_name_auto_update
-        self.mock_model_simultaneous_fitting_mode = mock.PropertyMock(return_value=False)
-        type(self.model).simultaneous_fitting_mode = self.mock_model_simultaneous_fitting_mode
-        self.mock_model_global_parameters = mock.PropertyMock(return_value=[])
-        type(self.model).global_parameters = self.mock_model_global_parameters
-        self.mock_model_do_rebin = mock.PropertyMock(return_value=False)
-        type(self.model).do_rebin = self.mock_model_do_rebin
-
-    def _setup_presenter(self):
-        self.presenter = BasicFittingPresenter(self.view, self.model)
-        self.presenter = add_mock_methods_to_basic_fitting_presenter(self.presenter)
-
-        # Mock the fit result property
-        self.presenter.fitting_calculation_model = mock.Mock(spec=ThreadModel)
-        self.mock_presenter_get_fit_results = mock.PropertyMock(return_value=(self.fit_function, self.fit_status,
-                                                                              self.chi_squared))
-        type(self.presenter.fitting_calculation_model).result = self.mock_presenter_get_fit_results
-
-        # Mock unimplemented methods and notifiers
-        self.presenter.handle_fitting_finished = mock.Mock()
-        self.presenter.update_and_reset_all_data = mock.Mock()
-        self.presenter.disable_editing_notifier.notify_subscribers = mock.Mock()
-        self.presenter.enable_editing_notifier.notify_subscribers = mock.Mock()
-        self.presenter.selected_fit_results_changed.notify_subscribers = mock.Mock()
-        self.presenter.fit_function_changed_notifier.notify_subscribers = mock.Mock()
-        self.presenter.fit_parameter_changed_notifier.notify_subscribers = mock.Mock()
-        self.presenter.update_exclude_start_and_end_x_in_view_and_model = mock.Mock()
 
 
 if __name__ == '__main__':

--- a/scripts/test/Muon/fitting_widgets/basic_fitting/basic_fitting_presenter_test.py
+++ b/scripts/test/Muon/fitting_widgets/basic_fitting/basic_fitting_presenter_test.py
@@ -60,6 +60,9 @@ class BasicFittingPresenterTest(unittest.TestCase):
         self.assertEqual(self.view.set_slot_for_function_parameter_changed.call_count, 1)
         self.assertEqual(self.view.set_slot_for_start_x_updated.call_count, 1)
         self.assertEqual(self.view.set_slot_for_end_x_updated.call_count, 1)
+        self.assertEqual(self.view.set_slot_for_exclude_range_state_changed.call_count, 1)
+        self.assertEqual(self.view.set_slot_for_exclude_start_x_updated.call_count, 1)
+        self.assertEqual(self.view.set_slot_for_exclude_end_x_updated.call_count, 1)
         self.assertEqual(self.view.set_slot_for_minimizer_changed.call_count, 1)
         self.assertEqual(self.view.set_slot_for_evaluation_type_changed.call_count, 1)
         self.assertEqual(self.view.set_slot_for_use_raw_changed.call_count, 1)
@@ -308,6 +311,35 @@ class BasicFittingPresenterTest(unittest.TestCase):
 
         self.mock_view_end_x.assert_called_with(15.0)
 
+    def test_that_handle_exclude_range_state_changed_will_update_the_model_and_view(self):
+        self.presenter.handle_exclude_range_state_changed()
+
+        self.mock_view_exclude_range.assert_called_once_with()
+        self.mock_model_exclude_range.assert_has_calls([mock.call(True), mock.call()])
+        self.view.set_exclude_start_and_end_x_visible.assert_called_once_with(True)
+
+    def test_that_handle_exclude_start_x_updated_will_check_the_exclude_start_x_is_valid_before_updating_it(self):
+        self.presenter._check_exclude_start_x_is_valid = mock.Mock(return_value=(self.start_x, self.end_x))
+
+        self.presenter.handle_exclude_start_x_updated()
+
+        self.mock_view_exclude_start_x.assert_called_once_with()
+        self.mock_view_exclude_end_x.assert_called_once_with()
+        self.mock_model_current_exclude_start_x.assert_called_once_with()
+        self.presenter._check_exclude_start_x_is_valid.assert_called_once_with(self.start_x, self.end_x, self.start_x)
+        self.presenter.update_exclude_start_and_end_x_in_view_and_model.assert_called_once_with(self.start_x, self.end_x)
+
+    def test_that_handle_exclude_end_x_updated_will_check_the_exclude_end_x_is_valid_before_updating_it(self):
+        self.presenter._check_exclude_end_x_is_valid = mock.Mock(return_value=(self.start_x, self.end_x))
+
+        self.presenter.handle_exclude_end_x_updated()
+
+        self.mock_view_exclude_start_x.assert_called_once_with()
+        self.mock_view_exclude_end_x.assert_called_once_with()
+        self.mock_model_current_exclude_end_x.assert_called_once_with()
+        self.presenter._check_exclude_end_x_is_valid.assert_called_once_with(self.start_x, self.end_x, self.end_x)
+        self.presenter.update_exclude_start_and_end_x_in_view_and_model.assert_called_once_with(self.start_x, self.end_x)
+
     def test_that_handle_use_rebin_changed_will_not_update_the_model_if_the_rebin_check_fails(self):
         self.presenter._check_rebin_options = mock.Mock(return_value=False)
 
@@ -430,6 +462,12 @@ class BasicFittingPresenterTest(unittest.TestCase):
         type(self.view).start_x = self.mock_view_start_x
         self.mock_view_end_x = mock.PropertyMock(return_value=self.end_x)
         type(self.view).end_x = self.mock_view_end_x
+        self.mock_view_exclude_range = mock.PropertyMock(return_value=True)
+        type(self.view).exclude_range = self.mock_view_exclude_range
+        self.mock_view_exclude_start_x = mock.PropertyMock(return_value=self.start_x)
+        type(self.view).exclude_start_x = self.mock_view_exclude_start_x
+        self.mock_view_exclude_end_x = mock.PropertyMock(return_value=self.end_x)
+        type(self.view).exclude_end_x = self.mock_view_exclude_end_x
         self.mock_view_plot_guess = mock.PropertyMock(return_value=self.plot_guess)
         type(self.view).plot_guess = self.mock_view_plot_guess
         self.mock_view_function_name = mock.PropertyMock(return_value=self.function_name)
@@ -459,6 +497,12 @@ class BasicFittingPresenterTest(unittest.TestCase):
         type(self.model).end_xs = self.mock_model_end_xs
         self.mock_model_current_end_x = mock.PropertyMock(return_value=self.end_x)
         type(self.model).current_end_x = self.mock_model_current_end_x
+        self.mock_model_exclude_range = mock.PropertyMock(return_value=True)
+        type(self.model).exclude_range = self.mock_model_exclude_range
+        self.mock_model_current_exclude_start_x = mock.PropertyMock(return_value=self.start_x)
+        type(self.model).current_exclude_start_x = self.mock_model_current_exclude_start_x
+        self.mock_model_current_exclude_end_x = mock.PropertyMock(return_value=self.end_x)
+        type(self.model).current_exclude_end_x = self.mock_model_current_exclude_end_x
         self.mock_model_plot_guess = mock.PropertyMock(return_value=self.plot_guess)
         type(self.model).plot_guess = self.mock_model_plot_guess
         self.mock_model_minimizer = mock.PropertyMock(return_value=self.minimizer)
@@ -510,6 +554,7 @@ class BasicFittingPresenterTest(unittest.TestCase):
         self.presenter.selected_fit_results_changed.notify_subscribers = mock.Mock()
         self.presenter.fit_function_changed_notifier.notify_subscribers = mock.Mock()
         self.presenter.fit_parameter_changed_notifier.notify_subscribers = mock.Mock()
+        self.presenter.update_exclude_start_and_end_x_in_view_and_model = mock.Mock()
 
 
 if __name__ == '__main__':

--- a/scripts/test/Muon/fitting_widgets/basic_fitting/basic_fitting_presenter_test.py
+++ b/scripts/test/Muon/fitting_widgets/basic_fitting/basic_fitting_presenter_test.py
@@ -318,26 +318,26 @@ class BasicFittingPresenterTest(unittest.TestCase):
         self.mock_model_exclude_range.assert_has_calls([mock.call(True), mock.call()])
         self.view.set_exclude_start_and_end_x_visible.assert_called_once_with(True)
 
-    def test_that_handle_exclude_start_x_updated_will_check_the_exclude_start_x_is_valid_before_updating_it(self):
-        self.presenter._check_exclude_start_x_is_valid = mock.Mock(return_value=(self.start_x, self.end_x))
+    @mock.patch("Muon.GUI.Common.utilities.workspace_data_utils.check_exclude_start_x_is_valid")
+    def test_that_handle_exclude_start_x_updated_will_check_the_exclude_start_x_is_valid_before_updating_it(self, mock_check):
+        mock_check.return_value = (self.start_x, self.end_x)
 
         self.presenter.handle_exclude_start_x_updated()
 
-        self.mock_view_exclude_start_x.assert_called_once_with()
-        self.mock_view_exclude_end_x.assert_called_once_with()
+        self.mock_view_exclude_start_x.assert_called_with()
+        self.mock_view_exclude_end_x.assert_called_with()
         self.mock_model_current_exclude_start_x.assert_called_once_with()
-        self.presenter._check_exclude_start_x_is_valid.assert_called_once_with(self.start_x, self.end_x, self.start_x)
         self.presenter.update_exclude_start_and_end_x_in_view_and_model.assert_called_once_with(self.start_x, self.end_x)
 
-    def test_that_handle_exclude_end_x_updated_will_check_the_exclude_end_x_is_valid_before_updating_it(self):
-        self.presenter._check_exclude_end_x_is_valid = mock.Mock(return_value=(self.start_x, self.end_x))
+    @mock.patch("Muon.GUI.Common.utilities.workspace_data_utils.check_exclude_end_x_is_valid")
+    def test_that_handle_exclude_end_x_updated_will_check_the_exclude_end_x_is_valid_before_updating_it(self, mock_check):
+        mock_check.return_value = (self.start_x, self.end_x)
 
         self.presenter.handle_exclude_end_x_updated()
 
-        self.mock_view_exclude_start_x.assert_called_once_with()
-        self.mock_view_exclude_end_x.assert_called_once_with()
+        self.mock_view_exclude_start_x.assert_called_with()
+        self.mock_view_exclude_end_x.assert_called_with()
         self.mock_model_current_exclude_end_x.assert_called_once_with()
-        self.presenter._check_exclude_end_x_is_valid.assert_called_once_with(self.start_x, self.end_x, self.end_x)
         self.presenter.update_exclude_start_and_end_x_in_view_and_model.assert_called_once_with(self.start_x, self.end_x)
 
     def test_that_handle_use_rebin_changed_will_not_update_the_model_if_the_rebin_check_fails(self):

--- a/scripts/test/Muon/fitting_widgets/basic_fitting/basic_fitting_view_test.py
+++ b/scripts/test/Muon/fitting_widgets/basic_fitting/basic_fitting_view_test.py
@@ -11,7 +11,11 @@ from mantidqt.utils.qt.testing import start_qapplication
 from mantidqt.utils.qt.testing.qt_widget_finder import QtWidgetFinder
 
 from Muon.GUI.Common.fitting_widgets.basic_fitting.basic_fitting_view import BasicFittingView
-from Muon.GUI.Common.fitting_widgets.basic_fitting.fit_function_options_view import RAW_DATA_TABLE_ROW
+from Muon.GUI.Common.fitting_widgets.basic_fitting.fit_function_options_view import (EVALUATE_AS_TABLE_ROW,
+                                                                                     EXCLUDE_RANGE_TABLE_ROW,
+                                                                                     EXCLUDE_START_X_TABLE_ROW,
+                                                                                     EXCLUDE_END_X_TABLE_ROW,
+                                                                                     RAW_DATA_TABLE_ROW)
 
 from qtpy.QtWidgets import QApplication
 
@@ -74,6 +78,27 @@ class BasicFittingViewTest(unittest.TestCase, QtWidgetFinder):
         self.view.show()
 
         self.assertTrue(self.view.fit_function_options.fit_options_table.isRowHidden(RAW_DATA_TABLE_ROW))
+
+    def test_that_the_view_has_been_initialized_with_the_exclude_range_start_and_end_x_options_not_visible(self):
+        self.view = BasicFittingView()
+        self.view.show()
+
+        self.assertTrue(self.view.fit_function_options.fit_options_table.isRowHidden(EXCLUDE_START_X_TABLE_ROW))
+        self.assertTrue(self.view.fit_function_options.fit_options_table.isRowHidden(EXCLUDE_END_X_TABLE_ROW))
+
+    def test_that_hide_exclude_range_checkbox_will_hide_the_exclude_range_table_row(self):
+        self.view = BasicFittingView()
+        self.view.hide_exclude_range_checkbox()
+        self.view.show()
+
+        self.assertTrue(self.view.fit_function_options.fit_options_table.isRowHidden(EXCLUDE_RANGE_TABLE_ROW))
+
+    def test_that_hide_evaluate_function_as_checkbox_will_hide_the_evaluate_function_table_row(self):
+        self.view = BasicFittingView()
+        self.view.hide_evaluate_function_as_checkbox()
+        self.view.show()
+
+        self.assertTrue(self.view.fit_function_options.fit_options_table.isRowHidden(EVALUATE_AS_TABLE_ROW))
 
     def test_that_update_fit_status_labels_will_display_no_fit_if_the_success_list_is_empty(self):
         fit_status, chi_squared = "success", 1.1

--- a/scripts/test/Muon/fitting_widgets/model_fitting/model_fitting_model_test.py
+++ b/scripts/test/Muon/fitting_widgets/model_fitting/model_fitting_model_test.py
@@ -111,7 +111,7 @@ class ModelFittingModelTest(unittest.TestCase):
 
     def test_that_parameter_combination_workspace_name_returns_the_expected_name_for_the_provided_parameters(self):
         self.model.result_table_names = self.result_table_names
-        self.assertEqual(self.model.parameter_combination_workspace_name("A0", "A1"), "Result1; A0 vs A1")
+        self.assertEqual(self.model.parameter_combination_workspace_name("A0", "A1"), "Result1; A1 vs A0")
 
     def test_that_parameter_combination_workspace_name_returns_none_when_there_are_no_results_tables(self):
         self.assertEqual(self.model.parameter_combination_workspace_name("A0", "A1"), None)


### PR DESCRIPTION
**Description of work.**
This PR adds the ability to exclude a range when doing a fit in the Muon Analysis and FDA interfaces.

**To test:**
1. Open the Muon Analysis interface
2. Load MUSR62260
3. Go to the Fitting tab
4. Add a GausOsc function and set Frequency parameter to 1.0
4. Tick `Exclude Range` in the fitting options
5. Change the `Exclude Start X` to 2.0
6. Click `Fit`, and it should be poor. Click `Undo Fit`
7. Now untick the `Exclude Range`, click `Fit` and the provided fit is better.

This shows that a range is indeed being excluded for the first fit, causing a poor fit (in this case).

Fixes #32018

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
