### PR TITLE
Conda linux preset

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -42,7 +42,7 @@
             "generator": "Ninja",
             "cacheVariables": {
                 "CMAKE_PREFIX_PATH": "$env{CONDA_PREFIX}",
-		"CONDA_BUILD": true,
+                "CONDA_BUILD": true,
                 "CMAKE_FIND_USE_SYSTEM_ENVIRONMENT_PATH": "FALSE",
                 "CMAKE_FIND_USE_CMAKE_ENVIRONMENT_PATH": "FALSE",
                 "CMAKE_BUILD_TYPE": "Debug"

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -31,8 +31,7 @@
             "cacheVariables": {
                 "CMAKE_PREFIX_PATH": "$env{CONDA_PREFIX}",
                 "CONDA_BUILD": true,
-                "HDF5_DIR": "$env{CONDA_PREFIX}/Library/cmake/hdf5",
-                "CMAKE_BUILD_TYPE": "Debug"
+                "HDF5_DIR": "$env{CONDA_PREFIX}/Library/cmake/hdf5"
             }
         },
         {

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -18,7 +18,8 @@
                 "USE_PYTHON_DYNAMIC_LIB": "OFF",
                 "Qt5_DIR": "$env{CONDA_PREFIX}/lib/cmake/qt5",
                 "HDF5_ROOT": "$env{CONDA_PREFIX}",
-                "OpenSSL_ROOT": "$env{CONDA_PREFIX}"
+                "OpenSSL_ROOT": "$env{CONDA_PREFIX}",
+                "CMAKE_BUILD_TYPE": "Debug"
             }
         },
         {
@@ -30,9 +31,23 @@
             "cacheVariables": {
                 "CMAKE_PREFIX_PATH": "$env{CONDA_PREFIX}",
                 "CONDA_BUILD": true,
-                "HDF5_DIR": "$env{CONDA_PREFIX}/Library/cmake/hdf5"
+                "HDF5_DIR": "$env{CONDA_PREFIX}/Library/cmake/hdf5",
+                "CMAKE_BUILD_TYPE": "Debug"
+            }
+        },
+        {
+            "name": "linux",
+            "displayName": "linux",
+            "description": "Default build options for a linux conda build",
+            "binaryDir": "${sourceDir}/build",
+            "generator": "Ninja",
+            "cacheVariables": {
+                "CMAKE_PREFIX_PATH": "$env{CONDA_PREFIX}",
+                "HDF5_DIR": "$env{CONDA_PREFIX}/Library/cmake/hdf5",
+                "CMAKE_FIND_USE_SYSTEM_ENVIRONMENT_PATH": "FALSE",
+                "CMAKE_FIND_USE_CMAKE_ENVIRONMENT_PATH": "FALSE",
+                "CMAKE_BUILD_TYPE": "Debug"
             }
         }
-
     ]
 }

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -43,7 +43,7 @@
             "generator": "Ninja",
             "cacheVariables": {
                 "CMAKE_PREFIX_PATH": "$env{CONDA_PREFIX}",
-                "HDF5_DIR": "$env{CONDA_PREFIX}/Library/cmake/hdf5",
+		"CONDA_BUILD": true,
                 "CMAKE_FIND_USE_SYSTEM_ENVIRONMENT_PATH": "FALSE",
                 "CMAKE_FIND_USE_CMAKE_ENVIRONMENT_PATH": "FALSE",
                 "CMAKE_BUILD_TYPE": "Debug"

--- a/buildconfig/CMake/FindPoco.cmake
+++ b/buildconfig/CMake/FindPoco.cmake
@@ -22,7 +22,7 @@ find_library ( POCO_LIB_NETSSL_DEBUG NAMES PocoNetSSLd )
 function( add_poco_lib POCO_LIB_MODULE POCO_DEBUG_LIB_MODULE )
   # Add poco library to list and also the corresponding debug library if it is available
 
-  if ( EXISTS "${POCO_DEBUG_LIB_MODULE}" )
+  if ( EXISTS "${POCO_DEBUG_LIB_MODULE}" AND NOT ${CONDA_BUILD})
     set ( POCO_LIBRARIES ${POCO_LIBRARIES}
         optimized ${POCO_LIB_MODULE}
         debug ${POCO_DEBUG_LIB_MODULE}

--- a/buildconfig/CMake/QScintillaFindImpl.cmake
+++ b/buildconfig/CMake/QScintillaFindImpl.cmake
@@ -38,7 +38,7 @@ function (find_qscintilla qt_version)
       libqt5scintilla2
       libqscintilla2-qt5
       qt5scintilla2
-      libqscintilla2_qt5.dylib
+      libqscintilla2_qt5
       qscintilla2
       libqscintilla2
     )
@@ -66,20 +66,24 @@ function (find_qscintilla qt_version)
       PATHS ${_qsci_include_paths}
       NO_DEFAULT_PATH
   )
+
   set ( _library_var QSCINTILLA_QT${qt_version}_LIBRARY )
   if ( ${CMAKE_SYSTEM_NAME} MATCHES "Darwin" )
-    set ( _default_path_opt NO_DEFAULT_PATH )
+    set (_opt_outs NO_DEFAULT_PATH )
+  elseif (${CONDA_BUILD})
+    set (_opt_outs NO_CMAKE_SYSTEM_PATH)
   endif()
+
   find_library ( ${_library_var}
     NAMES ${_qsci_lib_names}
     PATHS ${_qsci_lib_paths}
-    ${_default_path_opt}
+    ${_opt_outs}
   )
   set ( _library_var_debug QSCINTILLA_QT${qt_version}_LIBRARY_DEBUG )
   find_library ( ${_library_var_debug}
     NAMES ${_qsci_lib_names_debug}
     PATHS ${_qsci_lib_paths}
-    ${_default_path_opt}
+    ${_opt_outs}
   )
 
   if ( ${_include_var} AND ${_library_var} )

--- a/qt/widgets/common/src/MuonPeriodInfo.cpp
+++ b/qt/widgets/common/src/MuonPeriodInfo.cpp
@@ -40,7 +40,7 @@ using namespace Mantid::API;
 std::string MuonPeriodInfo::readSampleLog(MatrixWorkspace_sptr ws, const std::string &logName) {
   try {
     return ws->run().getLogData(logName)->value();
-  } catch (std::runtime_error) {
+  } catch (const std::runtime_error &) {
     Logger("MuonPeriodInfo").warning("Workspace does not contain " + logName);
     return "";
   }


### PR DESCRIPTION
**Description of work.**
Adds a Linux preset to line up with the other OSs and handles some issues in CentOS7

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

**To test:**
Create a mantid-developer conda environment if you don't already have it:
- Install Mambaforge
- Run `conda env create -f {SOURCE_DIR}/mantid-development-linux.yml`
- Activate it with `conda activate mantid-developer`
- Then in your source directory run `cmake --preset=linux`
- cd into `build`
- Then build source using `ninja`
With no errors or linking issues this is fine, there is at least 1 or 2 expected warnings to appear depending on the Linux Distro

<!-- Instructions for testing. -->

Fixes #31871 <!-- and fix #xxxx or close #xxxx xor resolves #xxxx -->
<!-- alternative
*There is no associated issue.*
-->


*This does not require release notes* because **Developer facing**


<!-- Ensure the base of this PR is correct (e.g. release-next or master)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
