### PR TITLE
Quiet python warnings on startup of workbench (ornlnext)

### DIFF
--- a/qt/applications/workbench/workbench/app/mainwindow.py
+++ b/qt/applications/workbench/workbench/app/mainwindow.py
@@ -68,8 +68,8 @@ def _get_splash_image():
 
 SPLASH = QSplashScreen(_get_splash_image(), Qt.WindowStaysOnTopHint)
 SPLASH.show()
-SPLASH.showMessage("Starting...", Qt.AlignBottom | Qt.AlignLeft
-                   | Qt.AlignAbsolute, QColor(Qt.black))
+SPLASH.showMessage("Starting...", int(Qt.AlignBottom | Qt.AlignLeft
+                   | Qt.AlignAbsolute), QColor(Qt.black))
 # The event loop has not started - force event processing
 QApplication.processEvents(QEventLoop.AllEvents)
 
@@ -226,7 +226,7 @@ class MainWindow(QMainWindow):
         if not self.splash:
             return
         if msg:
-            self.splash.showMessage(msg, Qt.AlignBottom | Qt.AlignLeft | Qt.AlignAbsolute,
+            self.splash.showMessage(msg, int(Qt.AlignBottom | Qt.AlignLeft | Qt.AlignAbsolute),
                                     QColor(Qt.black))
         QApplication.processEvents(QEventLoop.AllEvents)
 
@@ -391,7 +391,8 @@ class MainWindow(QMainWindow):
         for reg_list in registers_to_run.values():
             for register in reg_list:
                 file_path = os.path.join(interface_dir, register)
-                self.interface_executor.execute(open(file_path).read(), file_path)
+                with open(file_path) as handle:
+                    self.interface_executor.execute(handle.read(), file_path)
 
     def redirect_python_warnings(self):
         """By default the warnings module writes warnings to sys.stderr. stderr is assumed to be

--- a/qt/applications/workbench/workbench/config/fonts.py
+++ b/qt/applications/workbench/workbench/config/fonts.py
@@ -18,15 +18,13 @@ import sys
 from qtpy.QtGui import QFont, QFontDatabase
 
 
-def is_ubuntu():
+def is_ubuntu() -> bool:
     """Return True if we're running an Ubuntu distro else return False"""
     # platform.linux_distribution doesn't exist in Python 3.5
     if sys.platform.startswith('linux') and osp.isfile('/etc/lsb-release'):
-        release_info = open('/etc/lsb-release').read()
-        if 'Ubuntu' in release_info:
-            return True
-        else:
-            return False
+        with open('/etc/lsb-release') as handle:
+            release_info = handle.read()
+            return bool('Ubuntu' in release_info)
     else:
         return False
 


### PR DESCRIPTION
These are minor issues having to do with types (yes, I know it is python) and leaving dangling file references.

**To test:**

Start up `mantidworkbench --error-on-warning` and see that it no longer drops out with a stacktrace.

*There is no associated issue.*

*This does not require release notes* because it is quieting minor python warnings and does not change functionality.

The version into `master` is #32029.

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
