### PR TITLE
Swap MuonGroupingAsymmetry For EstimateMuonAsymmetryFromCounts In Muon Analysis

### DIFF
--- a/scripts/Muon/GUI/Common/calculate_pair_and_group.py
+++ b/scripts/Muon/GUI/Common/calculate_pair_and_group.py
@@ -7,7 +7,6 @@
 import Muon.GUI.Common.utilities.algorithm_utils as algorithm_utils
 from Muon.GUI.Common.utilities.run_string_utils import run_list_to_string
 from Muon.GUI.Common.muon_pair import MuonPair
-from Muon.GUI.Common.ADSHandler.workspace_naming import get_group_data_workspace_name, get_run_numbers_as_string_from_workspace_name
 from typing import Iterable
 
 
@@ -31,9 +30,7 @@ def calculate_pair_data(pair: MuonPair, forward_group: str, backward_group: str,
 
 def estimate_group_asymmetry_data(context, group, run, rebin, workspace_name, unormalised_workspace_name, periods):
     params = _get_EstimateMuonAsymmetryFromCounts_parameters(context, group, run, periods)
-    params["InputWorkspace"] = get_group_data_workspace_name(
-        context, group.name,get_run_numbers_as_string_from_workspace_name(
-            workspace_name, context.data_context.instrument), "", rebin)
+    params["InputWorkspace"] = workspace_name.replace("Asymmetry", "Counts")
     group_asymmetry, group_asymmetry_unnorm = \
         algorithm_utils.run_EstimateMuonAsymmetryFromCounts(params, workspace_name, unormalised_workspace_name)
 

--- a/scripts/Muon/GUI/Common/calculate_pair_and_group.py
+++ b/scripts/Muon/GUI/Common/calculate_pair_and_group.py
@@ -31,10 +31,9 @@ def calculate_pair_data(pair: MuonPair, forward_group: str, backward_group: str,
 
 def estimate_group_asymmetry_data(context, group, run, rebin, workspace_name, unormalised_workspace_name, periods):
     params = _get_EstimateMuonAsymmetryFromCounts_parameters(context, group, run, periods)
-    params["InputWorkspace"] = get_group_data_workspace_name(context, group.name,
-                                                             get_run_numbers_as_string_from_workspace_name(
-                                                                 workspace_name, context.data_context.instrument), "",
-                                                             rebin)
+    params["InputWorkspace"] = get_group_data_workspace_name(
+        context, group.name,get_run_numbers_as_string_from_workspace_name(
+            workspace_name, context.data_context.instrument), "", rebin)
     group_asymmetry, group_asymmetry_unnorm = \
         algorithm_utils.run_EstimateMuonAsymmetryFromCounts(params, workspace_name, unormalised_workspace_name)
 
@@ -110,29 +109,6 @@ def _setup_rebin_options(context, pre_process_params, run):
 
 def _get_MuonGroupingCounts_parameters(group, periods):
     params = {}
-    params["SummedPeriods"] = periods
-
-    if group:
-        params["GroupName"] = group.name
-        params["Grouping"] = ",".join([str(i) for i in group.detectors])
-
-    return params
-
-
-def _get_MuonGroupingAsymmetry_parameters(context, group, run, periods):
-    params = {}
-
-    if 'GroupRangeMin' in context.gui_context:
-        params['AsymmetryTimeMin'] = context.gui_context['GroupRangeMin']
-    else:
-        params['AsymmetryTimeMin'] = context.data_context.get_loaded_data_for_run(run)["FirstGoodData"]
-
-    if 'GroupRangeMax' in context.gui_context:
-        params['AsymmetryTimeMax'] = context.gui_context['GroupRangeMax']
-    else:
-        params['AsymmetryTimeMax'] = max(
-            context.data_context.get_loaded_data_for_run(run)['OutputWorkspace'][0].workspace.dataX(0))
-
     params["SummedPeriods"] = periods
 
     if group:

--- a/scripts/Muon/GUI/Common/utilities/algorithm_utils.py
+++ b/scripts/Muon/GUI/Common/utilities/algorithm_utils.py
@@ -60,23 +60,6 @@ def run_MuonPairingAsymmetry(parameter_dict, workspace_name):
     return workspace_name
 
 
-def run_MuonGroupingAsymmetry(parameter_dict, workspace_name, unormalised_workspace_name):
-    """
-    Apply the MuonGroupingCounts algorithm with the properties supplied through
-    the input dictionary of {property_name:property_value} pairs.
-    Returns the calculated workspace name.
-    """
-    alg = mantid.AlgorithmManager.create("MuonGroupingAsymmetry")
-    alg.initialize()
-    alg.setAlwaysStoreInADS(True)
-    alg.setRethrows(True)
-    alg.setProperty("OutputWorkspace", workspace_name)
-    alg.setProperty("OutputUnNormWorkspace", unormalised_workspace_name)
-    alg.setProperties(parameter_dict)
-    alg.execute()
-    return workspace_name, unormalised_workspace_name
-
-
 def run_EstimateMuonAsymmetryFromCounts(parameter_dict, workspace_name, unormalised_workspace_name):
     """
         Apply the run_EstimateMuonAsymmetryFromCounts algorithm with the properties supplied through

--- a/scripts/Muon/GUI/Common/utilities/algorithm_utils.py
+++ b/scripts/Muon/GUI/Common/utilities/algorithm_utils.py
@@ -77,6 +77,23 @@ def run_MuonGroupingAsymmetry(parameter_dict, workspace_name, unormalised_worksp
     return workspace_name, unormalised_workspace_name
 
 
+def run_EstimateMuonAsymmetryFromCounts(parameter_dict, workspace_name, unormalised_workspace_name):
+    """
+        Apply the run_EstimateMuonAsymmetryFromCounts algorithm with the properties supplied through
+        the input dictionary of {property_name:property_value} pairs.
+        Returns the calculated workspace name.
+    """
+    alg = mantid.AlgorithmManager.create("EstimateMuonAsymmetryFromCounts")
+    alg.initialize()
+    alg.setAlwaysStoreInADS(True)
+    alg.setRethrows(True)
+    alg.setProperty("OutputWorkspace", workspace_name)
+    alg.setProperty("OutputUnNormWorkspace", unormalised_workspace_name)
+    alg.setProperties(parameter_dict)
+    alg.execute()
+    return workspace_name, unormalised_workspace_name
+
+
 def run_CalMuonDetectorPhases(parameter_dict, alg, fitted_workspace_name):
     alg.initialize()
     alg.setAlwaysStoreInADS(True)

--- a/scripts/test/Muon/grouping_tab/calculate_pair_and_group_test.py
+++ b/scripts/test/Muon/grouping_tab/calculate_pair_and_group_test.py
@@ -30,8 +30,8 @@ class TestCalculateMuonGroupPair(unittest.TestCase):
 
         params = _get_EstimateMuonAsymmetryFromCounts_parameters(context, group, run, periods)
 
-        self.assertEquals(params, {'StartX': 15.0,
-                                   'EndX': 0.0,
+        self.assertEquals(params, {'StartX': 0.0,
+                                   'EndX': 15.0,
                                    'OutputUnNormData': True})
 
     def test_parameters_correct_for_pairing_asymmetry(self):

--- a/scripts/test/Muon/grouping_tab/calculate_pair_and_group_test.py
+++ b/scripts/test/Muon/grouping_tab/calculate_pair_and_group_test.py
@@ -7,7 +7,7 @@
 import unittest
 from unittest import mock
 from Muon.GUI.Common.calculate_pair_and_group import _get_MuonGroupingCounts_parameters, \
-    _get_MuonGroupingAsymmetry_parameters, _get_MuonPairingAsymmetry_parameters
+    _get_MuonPairingAsymmetry_parameters, _get_EstimateMuonAsymmetryFromCounts_parameters
 from Muon.GUI.Common.muon_group import MuonGroup
 from Muon.GUI.Common.muon_pair import MuonPair
 
@@ -28,13 +28,11 @@ class TestCalculateMuonGroupPair(unittest.TestCase):
         context = mock.MagicMock()
         context.gui_context = {'GroupRangeMin': 0.0, 'GroupRangeMax': 15.0}
 
-        params = _get_MuonGroupingAsymmetry_parameters(context, group, run, periods)
+        params = _get_EstimateMuonAsymmetryFromCounts_parameters(context, group, run, periods)
 
-        self.assertEquals(params, {'AsymmetryTimeMax': 15.0,
-                                   'AsymmetryTimeMin': 0.0,
-                                   'GroupName': 'fwd',
-                                   'Grouping': '1,2,3,4,5',
-                                   'SummedPeriods': [1]})
+        self.assertEquals(params, {'StartX': 15.0,
+                                   'EndX': 0.0,
+                                   'OutputUnNormData': True})
 
     def test_parameters_correct_for_pairing_asymmetry(self):
         pair = MuonPair('long1', 'group_1', 'group2', 1.0)


### PR DESCRIPTION
**Description of work.**
replaced call to MuonGroupingAsymmetry with EstimateMuonAsymmetryFromCounts instead

**To test:**
Try and load some data such as MUSR62260
When doing a fit check values are the roughly same on this PR and on master

<!-- Instructions for testing. -->

Fixes #32033 

*This does not require release notes* because **no functionality has changed**

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
