### PR TITLE
Sequential Fitting in Muon FDA interface

### DIFF
--- a/docs/source/release/v6.2.0/muon.rst
+++ b/docs/source/release/v6.2.0/muon.rst
@@ -5,6 +5,14 @@ MuSR Changes
 .. contents:: Table of Contents
    :local:
 
+Frequency Domain Analysis
+-------------------------
+
+New Features
+############
+
+- The Frequency Domain Analysis interface now allows you to perform a sequential fit using the Sequential Fitting tab.
+
 Muon Analysis
 -------------
 

--- a/qt/python/mantidqt/utils/testing/mocks/mock_sequentialtable.py
+++ b/qt/python/mantidqt/utils/testing/mocks/mock_sequentialtable.py
@@ -23,6 +23,7 @@ class MockSequentialTableModel(object):
     def __init__(self):
         self.set_fit_parameters_and_values = mock.MagicMock()
         self.set_fit_quality = mock.MagicMock()
+        self.get_workspace_name_information = mock.MagicMock()
         self.get_run_information = mock.MagicMock()
         self.get_group_information = mock.MagicMock()
         self.rowCount = mock.MagicMock()

--- a/scripts/Muon/GUI/Common/dock/dockable_tabs.py
+++ b/scripts/Muon/GUI/Common/dock/dockable_tabs.py
@@ -52,7 +52,16 @@ class DetachableTabWidget(QtWidgets.QTabWidget):
     def addTabWithOrder(self, tab, name):
         self.tab_order.append(name)
         self.attached_tab_names.append(name)
+        self.addTab(tab, name)
+
+    def addTab(self, tab, name):
         super(DetachableTabWidget, self).addTab(tab, name)
+        self.setTabToolTip(self.indexOf(tab), name)
+
+    def insertTab(self, to_index, widget, *args):
+        index = super(DetachableTabWidget, self).insertTab(to_index, widget, *args)
+        self.setTabToolTip(to_index, args[-1])
+        return index
 
     def set_slot_for_tab_changed(self, slot):
         self.currentChanged.connect(slot)

--- a/scripts/Muon/GUI/Common/fitting_widgets/basic_fitting/basic_fitting_model.py
+++ b/scripts/Muon/GUI/Common/fitting_widgets/basic_fitting/basic_fitting_model.py
@@ -829,7 +829,7 @@ class BasicFittingModel:
         for name in self.fitting_context.dataset_names:
             runs.append(get_run_numbers_as_string_from_workspace_name(name, self.context.data_context.instrument))
             groups_and_pairs.append(get_group_or_pair_from_name(name))
-        return runs, groups_and_pairs
+        return self.fitting_context.dataset_names, runs, groups_and_pairs
 
     def get_all_fit_function_parameter_values_for(self, fit_function: IFunction) -> list:
         """Returns the values of the fit function parameters."""

--- a/scripts/Muon/GUI/Common/fitting_widgets/basic_fitting/basic_fitting_presenter.py
+++ b/scripts/Muon/GUI/Common/fitting_widgets/basic_fitting/basic_fitting_presenter.py
@@ -51,6 +51,8 @@ class BasicFittingPresenter:
         self.instrument_changed_observer = GenericObserver(self.handle_instrument_changed)
         self.selected_group_pair_observer = GenericObserver(self.handle_selected_group_pair_changed)
         self.double_pulse_observer = GenericObserverWithArgPassing(self.handle_pulse_type_changed)
+        self.sequential_fit_finished_observer = GenericObserver(self.handle_sequential_fit_finished)
+        self.fit_parameter_updated_observer = GenericObserver(self.update_fit_function_in_view_from_model)
 
         self.fsg_model = None
         self.fsg_view = None
@@ -294,6 +296,11 @@ class BasicFittingPresenter:
         """Handle the Fit to raw data checkbox state change."""
         if self._check_rebin_options():
             self.model.fit_to_raw = self.view.fit_to_raw
+
+    def handle_sequential_fit_finished(self) -> None:
+        """Handles when a sequential fit has been performed and has finished executing in the sequential fitting tab."""
+        self.update_fit_function_in_view_from_model()
+        self.update_fit_statuses_and_chi_squared_in_view_from_model()
 
     def clear_undo_data(self) -> None:
         """Clear all the previously saved undo fit functions and other data."""

--- a/scripts/Muon/GUI/Common/fitting_widgets/general_fitting/general_fitting_model.py
+++ b/scripts/Muon/GUI/Common/fitting_widgets/general_fitting/general_fitting_model.py
@@ -443,20 +443,24 @@ class GeneralFittingModel(BasicFittingModel):
         elif self.fitting_context.simultaneous_fit_by == "Group/Pair":
             return self._get_runs_groups_and_pairs_for_simultaneous_fit_by_groups_and_pairs()
         else:
-            return [], []
+            return [], [], []
 
     def _get_runs_groups_and_pairs_for_simultaneous_fit_by_runs(self):
         """Returns the runs and group/pairs for the selected data in simultaneous fit by runs mode."""
         runs = self._get_selected_runs()
         groups_and_pairs = [get_group_or_pair_from_name(name) for name in self.fitting_context.dataset_names]
-        return runs, [";".join(groups_and_pairs)] * len(runs)
+        workspace_names = [";".join(self.get_fit_workspace_names_from_groups_and_runs([run], groups_and_pairs))
+                           for run in runs]
+        return workspace_names, runs, [";".join(groups_and_pairs)] * len(runs)
 
     def _get_runs_groups_and_pairs_for_simultaneous_fit_by_groups_and_pairs(self):
         """Returns the runs and group/pairs for the selected data in simultaneous fit by group/pairs mode."""
         runs = [get_run_numbers_as_string_from_workspace_name(name, self.context.data_context.instrument)
                 for name in self.fitting_context.dataset_names]
         groups_and_pairs = self._get_selected_groups_and_pairs()
-        return [";".join(runs)] * len(groups_and_pairs), groups_and_pairs
+        workspace_names = [";".join(self.get_fit_workspace_names_from_groups_and_runs(runs, [group_and_pair]))
+                           for group_and_pair in groups_and_pairs]
+        return workspace_names, [";".join(runs)] * len(groups_and_pairs), groups_and_pairs
 
     def get_all_fit_functions(self) -> list:
         """Returns all the fit functions for the current fitting mode."""

--- a/scripts/Muon/GUI/Common/fitting_widgets/general_fitting/general_fitting_presenter.py
+++ b/scripts/Muon/GUI/Common/fitting_widgets/general_fitting/general_fitting_presenter.py
@@ -5,7 +5,7 @@
 #   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
 # SPDX - License - Identifier: GPL - 3.0 +
 from mantid.api import IFunction
-from mantidqt.utils.observer_pattern import GenericObserver, GenericObservable
+from mantidqt.utils.observer_pattern import GenericObservable
 
 from Muon.GUI.Common.fitting_widgets.basic_fitting.basic_fitting_presenter import BasicFittingPresenter
 from Muon.GUI.Common.fitting_widgets.general_fitting.general_fitting_model import GeneralFittingModel
@@ -23,8 +23,6 @@ class GeneralFittingPresenter(BasicFittingPresenter):
 
         self.fitting_mode_changed_notifier = GenericObservable()
         self.simultaneous_fit_by_specifier_changed = GenericObservable()
-
-        self.fit_parameter_updated_observer = GenericObserver(self.update_fit_function_in_view_from_model)
 
         self.model.context.gui_context.add_non_calc_subscriber(self.double_pulse_observer)
 

--- a/scripts/Muon/GUI/Common/fitting_widgets/tf_asymmetry_fitting/tf_asymmetry_fitting_model.py
+++ b/scripts/Muon/GUI/Common/fitting_widgets/tf_asymmetry_fitting/tf_asymmetry_fitting_model.py
@@ -8,18 +8,14 @@ from mantid import AlgorithmManager, logger
 from mantid.api import IFunction
 from mantid.simpleapi import CopyLogs, ConvertFitFunctionForMuonTFAsymmetry
 
-from Muon.GUI.Common.ADSHandler.workspace_naming import (check_phasequad_name, create_fitted_workspace_name,
+from Muon.GUI.Common.ADSHandler.workspace_naming import (create_fitted_workspace_name,
                                                          create_multi_domain_fitted_workspace_name,
-                                                         get_diff_asymmetry_name, get_group_asymmetry_name,
-                                                         get_group_or_pair_from_name, get_pair_asymmetry_name,
-                                                         get_pair_phasequad_name,
-                                                         get_run_numbers_as_string_from_workspace_name)
+                                                         get_group_or_pair_from_name)
 from Muon.GUI.Common.contexts.fitting_contexts.tf_asymmetry_fitting_context import TFAsymmetryFittingContext
 from Muon.GUI.Common.contexts.muon_context import MuonContext
 from Muon.GUI.Common.fitting_widgets.basic_fitting.basic_fitting_model import DEFAULT_SINGLE_FIT_FUNCTION
 from Muon.GUI.Common.fitting_widgets.general_fitting.general_fitting_model import GeneralFittingModel
 from Muon.GUI.Common.utilities.algorithm_utils import run_CalculateMuonAsymmetry
-from Muon.GUI.Common.utilities.run_string_utils import run_list_to_string
 from Muon.GUI.Common.utilities.workspace_utils import StaticWorkspaceWrapper
 
 DEFAULT_NORMALISATION = 0.0
@@ -262,16 +258,6 @@ class TFAsymmetryFittingModel(GeneralFittingModel):
         self.fitting_context.normalisations_for_undo = []
         self.fitting_context.normalisations_fixed_for_undo = []
 
-    def get_all_fit_functions(self) -> list:
-        """Returns all the fit functions for the current fitting mode."""
-        if self.fitting_context.tf_asymmetry_mode:
-            if self.fitting_context.simultaneous_fitting_mode:
-                return [self.fitting_context.tf_asymmetry_simultaneous_function]
-            else:
-                return self.fitting_context.tf_asymmetry_single_functions
-        else:
-            return super().get_all_fit_functions()
-
     def get_fit_function_parameters(self) -> list:
         """Returns the names of the fit parameters in the fit functions."""
         parameters = super().get_fit_function_parameters()
@@ -283,35 +269,6 @@ class TFAsymmetryFittingModel(GeneralFittingModel):
                 return ["N0"] + parameters
         else:
             return parameters
-
-    def get_all_fit_function_parameter_values_for(self, fit_function: IFunction) -> list:
-        """Returns the values of the fit function parameters. Also returns the normalisation for TF Asymmetry mode."""
-        if self.fitting_context.tf_asymmetry_mode:
-            if self.fitting_context.simultaneous_fitting_mode:
-                return self._get_all_fit_function_parameter_values_for_tf_simultaneous_function(fit_function)
-            else:
-                return self._get_all_fit_function_parameter_values_for_tf_single_function(fit_function)
-        else:
-            parameter_values, _ = self.get_fit_function_parameter_values(fit_function)
-            return parameter_values
-
-    def _get_all_fit_function_parameter_values_for_tf_single_function(self, tf_single_function: IFunction) -> list:
-        """Returns the required parameters values including normalisation from a TF asymmetry single function."""
-        normal_single_function = self._get_normal_fit_function_from(tf_single_function)
-        parameter_values, _ = self.get_fit_function_parameter_values(normal_single_function)
-        return [self._get_normalisation_from_tf_fit_function(tf_single_function)] + parameter_values
-
-    def _get_all_fit_function_parameter_values_for_tf_simultaneous_function(self, tf_simultaneous_function: IFunction) -> list:
-        """Returns the required parameters values including normalisation from a TF asymmetry simultaneous function."""
-        all_parameters = []
-        for domain_index in range(self.fitting_context.number_of_datasets):
-            all_parameters += [self._get_normalisation_from_tf_fit_function(tf_simultaneous_function, domain_index)]
-
-            tf_domain_function = self.get_domain_tf_asymmetry_fit_function(tf_simultaneous_function, domain_index)
-            normal_domain_function = self._get_normal_fit_function_from(tf_domain_function)
-            parameter_values, _ = self.get_fit_function_parameter_values(normal_domain_function)
-            all_parameters += parameter_values
-        return all_parameters
 
     def _add_normalisation_to_parameters_for_simultaneous_fitting(self, parameters, get_normalisation_func):
         """Returns the names of the fit parameters in the fit functions including the normalisation for simultaneous."""
@@ -333,24 +290,6 @@ class TFAsymmetryFittingModel(GeneralFittingModel):
     def _get_normalisation_function_parameter_for_simultaneous_domain(domain_index: int) -> str:
         """Returns the normalisation parameter for a specific domain as seen in the MultiDomainFunction."""
         return f"f{domain_index}.{NORMALISATION_PARAMETER}"
-
-    @staticmethod
-    def get_fit_function_parameter_values(fit_function: IFunction) -> list:
-        """Get all the parameter values within a given fit function."""
-        parameters, errors = [], []
-        if fit_function is not None:
-            for i in range(fit_function.nParams()):
-                parameters.append(fit_function.getParameterValue(i))
-                errors.append(fit_function.getError(i))
-        return parameters, errors
-
-    @staticmethod
-    def _set_fit_function_parameter_values(fit_function: IFunction, parameter_values: list, errors: list = None) -> None:
-        """Set the parameter values within a fit function."""
-        for i in range(fit_function.nParams()):
-            fit_function.setParameter(i, parameter_values[i])
-            if errors is not None:
-                fit_function.setError(i, errors[i])
 
     def _get_normal_fit_function_from(self, tf_asymmetry_function: IFunction) -> IFunction:
         """Returns the ordinary fit function embedded within the TF Asymmetry fit function."""
@@ -722,6 +661,61 @@ class TFAsymmetryFittingModel(GeneralFittingModel):
     Methods used by the Sequential Fitting Tab
     """
 
+    def validate_sequential_fit(self, workspace_names: list) -> str:
+        """Validates that the provided data is valid. It returns a message if the data is invalid."""
+        message = super().validate_sequential_fit(workspace_names)
+        if message != "":
+            return message
+        else:
+            return self._check_tf_asymmetry_compliance(workspace_names)
+
+    def _check_tf_asymmetry_compliance(self, workspace_names: list) -> str:
+        """Checks that the workspace names provided are TF Asymmetry compliant."""
+        tf_compliant, non_compliant_names = self.check_datasets_are_tf_asymmetry_compliant(workspace_names)
+        if self.fitting_context.tf_asymmetry_mode and not tf_compliant:
+            return f"Only Groups can be fitted in TF Asymmetry mode. Please unselect the following Pairs/Diffs in " \
+                   f"the grouping tab: {non_compliant_names}"
+        else:
+            return ""
+
+    def get_all_fit_function_parameter_values_for(self, fit_function: IFunction) -> list:
+        """Returns the values of the fit function parameters. Also returns the normalisation for TF Asymmetry mode."""
+        if self.fitting_context.tf_asymmetry_mode:
+            if self.fitting_context.simultaneous_fitting_mode:
+                return self._get_all_fit_function_parameter_values_for_tf_simultaneous_function(fit_function)
+            else:
+                return self._get_all_fit_function_parameter_values_for_tf_single_function(fit_function)
+        else:
+            return super().get_all_fit_function_parameter_values_for(fit_function)
+
+    def _get_all_fit_function_parameter_values_for_tf_single_function(self, tf_single_function: IFunction) -> list:
+        """Returns the required parameters values including normalisation from a TF asymmetry single function."""
+        normal_single_function = self._get_normal_fit_function_from(tf_single_function)
+        parameter_values, _ = self.get_fit_function_parameter_values(normal_single_function)
+        return [self._get_normalisation_from_tf_fit_function(tf_single_function)] + parameter_values
+
+    def _get_all_fit_function_parameter_values_for_tf_simultaneous_function(self, tf_simultaneous_function: IFunction) -> list:
+        """Returns the required parameters values including normalisation from a TF asymmetry simultaneous function."""
+        all_parameters = []
+        for domain_index in range(self.fitting_context.number_of_datasets):
+            all_parameters += [self._get_normalisation_from_tf_fit_function(tf_simultaneous_function, domain_index)]
+
+            tf_domain_function = self.get_domain_tf_asymmetry_fit_function(tf_simultaneous_function, domain_index)
+            normal_domain_function = self._get_normal_fit_function_from(tf_domain_function)
+            parameter_values, _ = self.get_fit_function_parameter_values(normal_domain_function)
+            all_parameters += parameter_values
+        return all_parameters
+
+    def get_all_fit_functions(self) -> list:
+        """Returns all the fit functions for the current fitting mode."""
+        if self.fitting_context.tf_asymmetry_mode:
+            if self.fitting_context.simultaneous_fitting_mode:
+                return [self.fitting_context.tf_asymmetry_simultaneous_function]
+            else:
+                return self.fitting_context.tf_asymmetry_single_functions
+        else:
+            return super().get_all_fit_functions()
+
     def _parse_parameter_values(self, all_parameter_values: list):
         """Separate the parameter values into the normalisations and ordinary parameter values."""
         if not self.fitting_context.tf_asymmetry_mode:
@@ -749,10 +743,7 @@ class TFAsymmetryFittingModel(GeneralFittingModel):
         """Updates the function parameter values for the given dataset names."""
         parameter_values, normalisations = self._parse_parameter_values(parameter_values)
 
-        if self.fitting_context.simultaneous_fitting_mode:
-            self._update_fit_function_parameters_for_simultaneous_fit(dataset_names, parameter_values)
-        else:
-            self._update_fit_function_parameters_for_single_fit(dataset_names, parameter_values)
+        super().update_ws_fit_function_parameters(dataset_names, parameter_values)
 
         if self.fitting_context.tf_asymmetry_mode:
             self._update_tf_fit_function_normalisation(dataset_names, normalisations)
@@ -767,10 +758,7 @@ class TFAsymmetryFittingModel(GeneralFittingModel):
 
     def _update_fit_function_parameters_for_single_fit(self, dataset_names: list, parameter_values: list) -> None:
         """Updates the function parameters for the given dataset names if in single fit mode."""
-        for name in dataset_names:
-            fit_function = self.get_single_fit_function_for(name)
-            if fit_function is not None:
-                self._set_fit_function_parameter_values(fit_function, parameter_values)
+        super()._update_fit_function_parameters_for_single_fit(dataset_names, parameter_values)
 
         if self.fitting_context.tf_asymmetry_mode:
             self._update_tf_fit_function_parameters_for_single_fit(dataset_names, parameter_values)
@@ -786,7 +774,7 @@ class TFAsymmetryFittingModel(GeneralFittingModel):
 
     def _update_fit_function_parameters_for_simultaneous_fit(self, dataset_names: list, parameter_values: list) -> None:
         """Updates the function parameters for the given dataset names if in simultaneous fit mode."""
-        self._set_fit_function_parameter_values(self.fitting_context.simultaneous_fit_function, parameter_values)
+        super()._update_fit_function_parameters_for_simultaneous_fit(dataset_names, parameter_values)
 
         if self.fitting_context.tf_asymmetry_mode:
             self._update_tf_fit_function_parameters_for_simultaneous_fit(dataset_names, parameter_values)
@@ -801,66 +789,6 @@ class TFAsymmetryFittingModel(GeneralFittingModel):
                 self._set_parameter_values_in_tf_asymmetry_simultaneous_function_domain(
                     self.tf_asymmetry_simultaneous_function, dataset_names.index(name), parameter_values,
                     number_parameters_per_domain)
-
-    def get_fit_workspace_names_from_groups_and_runs(self, runs: list, groups_and_pairs: list) -> list:
-        """Returns the workspace names to use for the given runs and groups/pairs."""
-        workspace_names = []
-        for run in runs:
-            for group_or_pair in groups_and_pairs:
-                workspace_names += self._get_workspace_name_from_run_and_group_or_pair(run, group_or_pair)
-        return workspace_names
-
-    def _get_workspace_name_from_run_and_group_or_pair(self, run: str, group_or_pair: str) -> list:
-        """Returns the workspace name to use for the given run and group/pair."""
-        fit_to_raw = self.fitting_context.fit_to_raw
-        if check_phasequad_name(group_or_pair) and group_or_pair in self.context.group_pair_context.selected_pairs:
-            return [get_pair_phasequad_name(self.context, group_or_pair, run, not fit_to_raw)]
-        elif group_or_pair in self.context.group_pair_context.selected_pairs:
-            return [get_pair_asymmetry_name(self.context, group_or_pair, run, not fit_to_raw)]
-        elif group_or_pair in self.context.group_pair_context.selected_diffs:
-            return [get_diff_asymmetry_name(self.context, group_or_pair, run, not fit_to_raw)]
-        elif group_or_pair in self.context.group_pair_context.selected_groups:
-            period_string = run_list_to_string(self.context.group_pair_context[group_or_pair].periods)
-            return [get_group_asymmetry_name(self.context, group_or_pair, run, period_string, not fit_to_raw)]
-        else:
-            return []
-
-    def get_runs_groups_and_pairs_for_fits(self):
-        """Returns the runs and group/pairs corresponding to the selected dataset names."""
-        if not self.fitting_context.simultaneous_fitting_mode:
-            return self._get_runs_groups_and_pairs_for_single_fit()
-        else:
-            return self._get_runs_groups_and_pairs_for_simultaneous_fit()
-
-    def _get_runs_groups_and_pairs_for_single_fit(self) -> tuple:
-        """Returns the runs and group/pairs corresponding to the selected dataset names in single fitting mode."""
-        runs, groups_and_pairs = [], []
-        for name in self.fitting_context.dataset_names:
-            runs.append(get_run_numbers_as_string_from_workspace_name(name, self.context.data_context.instrument))
-            groups_and_pairs.append(get_group_or_pair_from_name(name))
-        return runs, groups_and_pairs
-
-    def _get_runs_groups_and_pairs_for_simultaneous_fit(self) -> tuple:
-        """Returns the runs and group/pairs corresponding to the selected dataset names in simultaneous fitting mode."""
-        if self.fitting_context.simultaneous_fit_by == "Run":
-            return self._get_runs_groups_and_pairs_for_simultaneous_fit_by_runs()
-        elif self.fitting_context.simultaneous_fit_by == "Group/Pair":
-            return self._get_runs_groups_and_pairs_for_simultaneous_fit_by_groups_and_pairs()
-        else:
-            return [], []
-
-    def _get_runs_groups_and_pairs_for_simultaneous_fit_by_runs(self):
-        """Returns the runs and group/pairs for the selected data in simultaneous fit by runs mode."""
-        runs = self._get_selected_runs()
-        groups_and_pairs = [get_group_or_pair_from_name(name) for name in self.fitting_context.dataset_names]
-        return runs, [";".join(groups_and_pairs)] * len(runs)
-
-    def _get_runs_groups_and_pairs_for_simultaneous_fit_by_groups_and_pairs(self):
-        """Returns the runs and group/pairs for the selected data in simultaneous fit by group/pairs mode."""
-        runs = [get_run_numbers_as_string_from_workspace_name(name, self.context.data_context.instrument)
-                for name in self.fitting_context.dataset_names]
-        groups_and_pairs = self._get_selected_groups_and_pairs()
-        return [";".join(runs)] * len(groups_and_pairs), groups_and_pairs
 
     def perform_sequential_fit(self, workspaces: list, parameter_values: list, use_initial_values: bool = False):
         """Performs a sequential fit of the workspace names provided for the current fitting mode.

--- a/scripts/Muon/GUI/Common/fitting_widgets/tf_asymmetry_fitting/tf_asymmetry_fitting_presenter.py
+++ b/scripts/Muon/GUI/Common/fitting_widgets/tf_asymmetry_fitting/tf_asymmetry_fitting_presenter.py
@@ -5,7 +5,6 @@
 #   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
 # SPDX - License - Identifier: GPL - 3.0 +
 from mantid.api import IFunction
-from mantidqt.utils.observer_pattern import GenericObserver
 
 from Muon.GUI.Common.fitting_widgets.general_fitting.general_fitting_presenter import GeneralFittingPresenter
 from Muon.GUI.Common.fitting_widgets.tf_asymmetry_fitting.tf_asymmetry_fitting_model import TFAsymmetryFittingModel
@@ -21,8 +20,6 @@ class TFAsymmetryFittingPresenter(GeneralFittingPresenter):
     def __init__(self, view: TFAsymmetryFittingView, model: TFAsymmetryFittingModel):
         """Initialize the TFAsymmetryFittingPresenter. Sets up the slots and event observers."""
         super(TFAsymmetryFittingPresenter, self).__init__(view, model)
-
-        self.sequential_fit_finished_observer = GenericObserver(self.handle_sequential_fit_finished)
 
         self.view.set_slot_for_fitting_type_changed(self.handle_tf_asymmetry_mode_changed)
         self.view.set_slot_for_normalisation_changed(self.handle_normalisation_changed)
@@ -92,11 +89,6 @@ class TFAsymmetryFittingPresenter(GeneralFittingPresenter):
     def handle_fix_normalisation_changed(self, is_fixed: bool) -> None:
         """Handles when the value of the current normalisation has been fixed or unfixed."""
         self.model.toggle_fix_current_normalisation(is_fixed)
-
-    def handle_sequential_fit_finished(self) -> None:
-        """Handles when a sequential fit has been performed and has finished executing in the sequential fitting tab."""
-        self.update_fit_function_in_view_from_model()
-        self.update_fit_statuses_and_chi_squared_in_view_from_model()
 
     def update_and_reset_all_data(self) -> None:
         """Updates the various data displayed in the fitting widget. Resets and clears previous fit information."""

--- a/scripts/Muon/GUI/Common/seq_fitting_tab_widget/QSequentialTableModel.py
+++ b/scripts/Muon/GUI/Common/seq_fitting_tab_widget/QSequentialTableModel.py
@@ -144,10 +144,6 @@ class QSequentialTableModel(QAbstractTableModel):
         if not workspace_names or not runs or not group_and_pairs:
             return
         self.beginInsertRows(QModelIndex(), 0, len(runs) - 1)
-        from mantid import logger
-        logger.warning(str(workspace_names))
-        logger.warning(str(runs))
-        logger.warning(str(group_and_pairs))
         for i in range(len(runs)):
             self._defaultData.insert(i, [workspace_names[i], runs[i], group_and_pairs[i], default_fit_status,
                                          default_chi_squared])
@@ -166,6 +162,10 @@ class QSequentialTableModel(QAbstractTableModel):
         self.setData(index, quality, Qt.EditRole)
         index = self.index(row, FIT_QUALITY_COLUMN)
         self.setData(index, chi_squared, Qt.EditRole)
+
+    def get_workspace_name_information(self, row):
+        index = self.index(row, WORKSPACE_COLUMN)
+        return self.data(index, Qt.DisplayRole)
 
     def get_run_information(self, row):
         index = self.index(row, RUN_COLUMN)

--- a/scripts/Muon/GUI/Common/seq_fitting_tab_widget/QSequentialTableModel.py
+++ b/scripts/Muon/GUI/Common/seq_fitting_tab_widget/QSequentialTableModel.py
@@ -6,11 +6,12 @@
 # SPDX - License - Identifier: GPL - 3.0 +
 from qtpy.QtCore import QAbstractTableModel, Qt, Signal, QModelIndex
 
-default_table_columns = ["Run", "Group/Pairs", "Fit status", "Chi squared"]
-RUN_COLUMN = 0
-GROUP_COLUMN = 1
-FIT_STATUS_COLUMN = 2
-FIT_QUALITY_COLUMN = 3
+default_table_columns = ["Workspace", "Run", "Group/Pairs", "Fit status", "Chi squared"]
+WORKSPACE_COLUMN = 0
+RUN_COLUMN = 1
+GROUP_COLUMN = 2
+FIT_STATUS_COLUMN = 3
+FIT_QUALITY_COLUMN = 4
 NUM_DEFAULT_COLUMNS = len(default_table_columns)
 default_fit_status = "No fit"
 default_chi_squared = 0.0
@@ -138,13 +139,18 @@ class QSequentialTableModel(QAbstractTableModel):
         for row in range(self.rowCount()):
             self._parameterData[row][parameter_index] = parameter_value
 
-    def set_fit_workspaces(self, runs, group_and_pairs):
+    def set_fit_workspaces(self, workspace_names, runs, group_and_pairs):
         self.clear_fit_workspaces()
-        if not runs or not group_and_pairs:
+        if not workspace_names or not runs or not group_and_pairs:
             return
         self.beginInsertRows(QModelIndex(), 0, len(runs) - 1)
+        from mantid import logger
+        logger.warning(str(workspace_names))
+        logger.warning(str(runs))
+        logger.warning(str(group_and_pairs))
         for i in range(len(runs)):
-            self._defaultData.insert(i, [runs[i], group_and_pairs[i], default_fit_status, default_chi_squared])
+            self._defaultData.insert(i, [workspace_names[i], runs[i], group_and_pairs[i], default_fit_status,
+                                         default_chi_squared])
         self.endInsertRows()
 
     def set_run_information(self, row, run):

--- a/scripts/Muon/GUI/Common/seq_fitting_tab_widget/SequentialTableWidget.py
+++ b/scripts/Muon/GUI/Common/seq_fitting_tab_widget/SequentialTableWidget.py
@@ -5,7 +5,8 @@
 #   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
 # SPDX - License - Identifier: GPL - 3.0 +
 from Muon.GUI.Common.seq_fitting_tab_widget.QSequentialTableView import QSequentialTableView
-from Muon.GUI.Common.seq_fitting_tab_widget.QSequentialTableModel import QSequentialTableModel
+from Muon.GUI.Common.seq_fitting_tab_widget.QSequentialTableModel import (QSequentialTableModel, GROUP_COLUMN,
+                                                                          RUN_COLUMN, WORKSPACE_COLUMN)
 from Muon.GUI.Common.seq_fitting_tab_widget.SequentialTableDelegates import FIT_STATUSES
 from collections import namedtuple
 
@@ -26,6 +27,15 @@ class SequentialTableWidget(object):
 
     def block_signals(self, state):
         self._view.blockSignals(state)
+
+    def hide_workspace_column(self):
+        self._view.hideColumn(WORKSPACE_COLUMN)
+
+    def hide_run_column(self):
+        self._view.hideColumn(RUN_COLUMN)
+
+    def hide_group_column(self):
+        self._view.hideColumn(GROUP_COLUMN)
 
     def get_number_of_fits(self):
         return self._model.number_of_fits

--- a/scripts/Muon/GUI/Common/seq_fitting_tab_widget/SequentialTableWidget.py
+++ b/scripts/Muon/GUI/Common/seq_fitting_tab_widget/SequentialTableWidget.py
@@ -93,6 +93,9 @@ class SequentialTableWidget(object):
             rows += [model.row()]
         return rows
 
+    def get_workspace_names_from_row(self, row):
+        return self._model.get_workspace_name_information(row)
+
     def get_workspace_info_from_row(self, row):
         if row > self._model.rowCount():
             return WorkspaceInfo([], [])

--- a/scripts/Muon/GUI/Common/seq_fitting_tab_widget/SequentialTableWidget.py
+++ b/scripts/Muon/GUI/Common/seq_fitting_tab_widget/SequentialTableWidget.py
@@ -56,9 +56,9 @@ class SequentialTableWidget(object):
         self._model.set_fit_quality(row, quality, chi_squared)
         self.block_signals(False)
 
-    def set_fit_workspaces(self, runs, group_and_pairs):
+    def set_fit_workspaces(self, workspace_names, runs, group_and_pairs):
         self.block_signals(True)
-        self._model.set_fit_workspaces(runs, group_and_pairs)
+        self._model.set_fit_workspaces(workspace_names, runs, group_and_pairs)
         self.block_signals(False)
 
     def set_selection_to_last_row(self):

--- a/scripts/Muon/GUI/Common/seq_fitting_tab_widget/seq_fitting_tab_presenter.py
+++ b/scripts/Muon/GUI/Common/seq_fitting_tab_widget/seq_fitting_tab_presenter.py
@@ -145,19 +145,10 @@ class SeqFittingTabPresenter(object):
             self._update_parameter_values_in_fitting_model_for_row(row)
 
     def validate_sequential_fit(self, workspace_names):
-        if self.model.get_active_fit_function() is None or len(workspace_names) == 0:
-            self.view.warning_popup("No data or fit function selected for fitting.")
-            return False
-        else:
-            return self._check_tf_asymmetry_compliance(self._flatten_workspace_names(workspace_names))
-
-    def _check_tf_asymmetry_compliance(self, workspace_names):
-        tf_compliant, non_compliant_names = self.model.check_datasets_are_tf_asymmetry_compliant(workspace_names)
-        if self.model.tf_asymmetry_mode and not tf_compliant:
-            self.view.warning_popup(f"Only Groups can be fitted in TF Asymmetry mode. Please unselect the following "
-                                    f"Pairs/Diffs in the grouping tab: {non_compliant_names}")
-            return False
-        return True
+        message = self.model.validate_sequential_fit(workspace_names)
+        if message != "":
+            self.view.warning_popup(message)
+        return message == ""
 
     @staticmethod
     def _flatten_workspace_names(workspaces: list) -> list:

--- a/scripts/Muon/GUI/Common/seq_fitting_tab_widget/seq_fitting_tab_presenter.py
+++ b/scripts/Muon/GUI/Common/seq_fitting_tab_widget/seq_fitting_tab_presenter.py
@@ -171,9 +171,4 @@ class SeqFittingTabPresenter(object):
         self.selected_sequential_fit_notifier.notify_subscribers(fit_information)
 
     def get_workspaces_for_row_in_fit_table(self, row):
-        runs, group_and_pairs = self.view.fit_table.get_workspace_info_from_row(row)
-        separated_runs = runs.split(';')
-        separated_group_and_pairs = group_and_pairs.split(';')
-        workspace_names = self.model.get_fit_workspace_names_from_groups_and_runs(separated_runs,
-                                                                                  separated_group_and_pairs)
-        return workspace_names
+        return self.view.fit_table.get_workspace_names_from_row(row).split("/")

--- a/scripts/Muon/GUI/Common/seq_fitting_tab_widget/seq_fitting_tab_presenter.py
+++ b/scripts/Muon/GUI/Common/seq_fitting_tab_widget/seq_fitting_tab_presenter.py
@@ -67,8 +67,8 @@ class SeqFittingTabPresenter(object):
             self.view.fit_table.set_parameter_values_for_row(row, parameter_values)
 
     def handle_selected_workspaces_changed(self):
-        runs, groups_and_pairs = self.model.get_runs_groups_and_pairs_for_fits()
-        self.view.fit_table.set_fit_workspaces(runs, groups_and_pairs)
+        workspace_names, runs, groups_and_pairs = self.model.get_runs_groups_and_pairs_for_fits()
+        self.view.fit_table.set_fit_workspaces(workspace_names, runs, groups_and_pairs)
         self.handle_fit_function_updated()
 
     def handle_fit_selected_pressed(self):

--- a/scripts/Muon/GUI/Common/seq_fitting_tab_widget/seq_fitting_tab_widget.py
+++ b/scripts/Muon/GUI/Common/seq_fitting_tab_widget/seq_fitting_tab_widget.py
@@ -4,6 +4,7 @@
 #   NScD Oak Ridge National Laboratory, European Spallation Source,
 #   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
 # SPDX - License - Identifier: GPL - 3.0 +
+from Muon.GUI.Common.contexts.frequency_domain_analysis_context import FrequencyDomainAnalysisContext
 from Muon.GUI.Common.seq_fitting_tab_widget.seq_fitting_tab_view import SeqFittingTabView
 from Muon.GUI.Common.seq_fitting_tab_widget.seq_fitting_tab_presenter import SeqFittingTabPresenter
 
@@ -29,5 +30,12 @@ class SeqFittingTabWidget(object):
 
         self.seq_fitting_tab_view.fit_table.set_slot_for_key_up_down_pressed(
             self.seq_fitting_tab_presenter.handle_fit_selected_in_table)
+
+        is_frequency_domain = isinstance(context, FrequencyDomainAnalysisContext)
+        if is_frequency_domain:
+            self.seq_fitting_tab_view.fit_table.hide_run_column()
+            self.seq_fitting_tab_view.fit_table.hide_group_column()
+        else:
+            self.seq_fitting_tab_view.fit_table.hide_workspace_column()
 
         context.deleted_plots_notifier.add_subscriber(self.seq_fitting_tab_presenter.selected_workspaces_observer)

--- a/scripts/Muon/GUI/FrequencyDomainAnalysis/frequency_domain_analysis.py
+++ b/scripts/Muon/GUI/FrequencyDomainAnalysis/frequency_domain_analysis.py
@@ -216,6 +216,7 @@ class FrequencyAnalysisGui(QtWidgets.QMainWindow):
     def handle_transform_performed(self, new_data_workspace_name):
         self.fitting_tab.fitting_tab_presenter.handle_new_data_loaded()
         self.fitting_tab.fitting_tab_presenter.set_selected_dataset(new_data_workspace_name)
+        self.seq_fitting_tab.seq_fitting_tab_presenter.handle_selected_workspaces_changed()
 
     def setup_disable_notifier(self):
 

--- a/scripts/Muon/GUI/FrequencyDomainAnalysis/frequency_domain_analysis.py
+++ b/scripts/Muon/GUI/FrequencyDomainAnalysis/frequency_domain_analysis.py
@@ -28,6 +28,7 @@ from Muon.GUI.Common.grouping_tab_widget.grouping_tab_widget import GroupingTabW
 from Muon.GUI.Common.help_widget.help_widget_presenter import HelpWidget
 from Muon.GUI.Common.home_tab.home_tab_widget import HomeTabWidget
 from Muon.GUI.Common.muon_load_data import MuonLoadData
+from Muon.GUI.Common.seq_fitting_tab_widget.seq_fitting_tab_widget import SeqFittingTabWidget
 from Muon.GUI.FrequencyDomainAnalysis.Transform.transform_widget import TransformWidget
 from Muon.GUI.FrequencyDomainAnalysis.FFT.fft_widget import FFTWidget
 from Muon.GUI.FrequencyDomainAnalysis.MaxEnt.maxent_widget import MaxEntWidget
@@ -101,7 +102,6 @@ class FrequencyAnalysisGui(QtWidgets.QMainWindow):
             frequency_context=self.frequency_context)
 
         # create the dockable widget
-        self.fitting_tab = FittingTabWidget(self.context, self)
         self.plot_widget = FrequencyAnalysisPlotWidget(self.context, parent=self)
 
         self.dockable_plot_widget_window = PlottingDockWidget(parent=self,
@@ -122,13 +122,10 @@ class FrequencyAnalysisGui(QtWidgets.QMainWindow):
         self.corrections_tab = CorrectionsTabWidget(self.context, self)
         self.home_tab = HomeTabWidget(self.context, self)
         self.phase_tab = PhaseTabWidget(self.context, self)
-        self.transform = TransformWidget(
-            self.context,
-            FFTWidget,
-            MaxEntWidget,
-            parent=self)
-        self.results_tab = ResultsTabWidget(
-            self.context.fitting_context, self.context, self)
+        self.transform = TransformWidget(self.context, FFTWidget, MaxEntWidget, parent=self)
+        self.fitting_tab = FittingTabWidget(self.context, self)
+        self.seq_fitting_tab = SeqFittingTabWidget(self.context, self.fitting_tab.fitting_tab_model, self)
+        self.results_tab = ResultsTabWidget(self.context.fitting_context, self.context, self)
 
         self.setup_tabs()
         self.help_widget = HelpWidget(self.context.window_title)
@@ -198,6 +195,7 @@ class FrequencyAnalysisGui(QtWidgets.QMainWindow):
         self.tabs.addTabWithOrder(self.phase_tab.phase_table_view, 'Phase Table')
         self.tabs.addTabWithOrder(self.transform.widget, 'Transform')
         self.tabs.addTabWithOrder(self.fitting_tab.fitting_tab_view, 'Fitting')
+        self.tabs.addTabWithOrder(self.seq_fitting_tab.seq_fitting_tab_view, 'Sequential Fitting')
         self.tabs.addTabWithOrder(self.results_tab.results_tab_view, 'Results')
         self.transform_finished_observer = GenericObserverWithArgPassing(self.handle_transform_performed)
         self.tabs.set_slot_for_tab_changed(self.handle_tab_changed)
@@ -208,7 +206,7 @@ class FrequencyAnalysisGui(QtWidgets.QMainWindow):
         index = self.tabs.currentIndex()
         if TAB_ORDER[index] in ["Home", "Grouping", "Phase Table"]:  # Plot all the selected data
             plot_mode = self.plot_widget.data_index
-        elif TAB_ORDER[index] in ["Fitting", "Transform"]:  # Plot the displayed workspace
+        elif TAB_ORDER[index] in ["Fitting", "Sequential Fitting", "Transform"]:  # Plot the displayed workspace
             plot_mode = self.plot_widget.frequency_index
         else:
             return

--- a/scripts/Muon/GUI/FrequencyDomainAnalysis/frequency_domain_analysis.py
+++ b/scripts/Muon/GUI/FrequencyDomainAnalysis/frequency_domain_analysis.py
@@ -229,6 +229,8 @@ class FrequencyAnalysisGui(QtWidgets.QMainWindow):
 
         self.disable_notifier.add_subscriber(self.fitting_tab.fitting_tab_view.disable_tab_observer)
 
+        self.disable_notifier.add_subscriber(self.seq_fitting_tab.seq_fitting_tab_presenter.disable_tab_observer)
+
         self.disable_notifier.add_subscriber(self.phase_tab.phase_table_presenter.disable_tab_observer)
 
         self.disable_notifier.add_subscriber(self.results_tab.results_tab_presenter.disable_tab_observer)
@@ -244,6 +246,8 @@ class FrequencyAnalysisGui(QtWidgets.QMainWindow):
         self.enable_notifier.add_subscriber(self.corrections_tab.corrections_tab_view.enable_tab_observer)
 
         self.enable_notifier.add_subscriber(self.fitting_tab.fitting_tab_view.enable_tab_observer)
+
+        self.enable_notifier.add_subscriber(self.seq_fitting_tab.seq_fitting_tab_presenter.enable_tab_observer)
 
         self.enable_notifier.add_subscriber(self.phase_tab.phase_table_presenter.enable_tab_observer)
 
@@ -275,6 +279,9 @@ class FrequencyAnalysisGui(QtWidgets.QMainWindow):
         self.load_widget.load_widget.loadNotifier.add_subscriber(
             self.plot_widget.raw_mode.new_data_observer)
 
+        self.load_widget.load_widget.loadNotifier.add_subscriber(
+            self.seq_fitting_tab.seq_fitting_tab_presenter.disable_tab_observer)
+
     def setup_gui_variable_observers(self):
         self.context.gui_context.gui_variables_notifier.add_subscriber(
             self.grouping_tab_widget.group_tab_presenter.gui_variables_observer)
@@ -299,7 +306,22 @@ class FrequencyAnalysisGui(QtWidgets.QMainWindow):
             [self.transform.GroupPairObserver,
              self.plot_widget.data_mode.added_group_or_pair_observer])
 
+        self.fitting_tab.fitting_tab_presenter.fit_function_changed_notifier.add_subscriber(
+            self.seq_fitting_tab.seq_fitting_tab_presenter.fit_function_updated_observer)
+
+        self.fitting_tab.fitting_tab_presenter.fit_parameter_changed_notifier.add_subscriber(
+            self.seq_fitting_tab.seq_fitting_tab_presenter.fit_parameter_updated_observer)
+
+        self.seq_fitting_tab.seq_fitting_tab_presenter.fit_parameter_changed_notifier.add_subscriber(
+            self.fitting_tab.fitting_tab_presenter.fit_parameter_updated_observer)
+
+        self.seq_fitting_tab.seq_fitting_tab_presenter.sequential_fit_finished_notifier.add_subscriber(
+            self.fitting_tab.fitting_tab_presenter.sequential_fit_finished_observer)
+
         self.fitting_tab.fitting_tab_presenter.selected_fit_results_changed.add_subscriber(
+            self.plot_widget.fit_mode.plot_selected_fit_observer)
+
+        self.seq_fitting_tab.seq_fitting_tab_presenter.selected_sequential_fit_notifier.add_subscriber(
             self.plot_widget.fit_mode.plot_selected_fit_observer)
 
         self.phase_tab.phase_table_presenter.selected_phasequad_changed_notifier.add_subscriber(
@@ -307,6 +329,9 @@ class FrequencyAnalysisGui(QtWidgets.QMainWindow):
 
         self.phase_tab.phase_table_presenter.selected_phasequad_changed_notifier.add_subscriber(
             self.transform.GroupPairObserver)
+
+        self.phase_tab.phase_table_presenter.selected_phasequad_changed_notifier.add_subscriber(
+            self.seq_fitting_tab.seq_fitting_tab_presenter.selected_workspaces_observer)
 
     def setup_grouping_changed_observers(self):
         self.grouping_tab_widget.group_tab_presenter.groupingNotifier.add_subscriber(
@@ -394,6 +419,9 @@ class FrequencyAnalysisGui(QtWidgets.QMainWindow):
         for observer in self.plot_widget.data_changed_observers:
             self.grouping_tab_widget.group_tab_presenter.calculation_finished_notifier.add_subscriber(observer)
             self.phase_tab.phase_table_presenter.calculation_finished_notifier.add_subscriber(observer)
+
+        self.grouping_tab_widget.group_tab_presenter.calculation_finished_notifier.add_subscriber(
+            self.seq_fitting_tab.seq_fitting_tab_presenter.selected_workspaces_observer)
 
         self.grouping_tab_widget.group_tab_presenter.calculation_finished_notifier.add_subscriber(
             self.corrections_tab.corrections_tab_presenter.pre_process_and_grouping_complete_observer)

--- a/scripts/test/Muon/fitting_widgets/basic_fitting/basic_fitting_model_test.py
+++ b/scripts/test/Muon/fitting_widgets/basic_fitting/basic_fitting_model_test.py
@@ -11,6 +11,8 @@ from mantid.api import AnalysisDataService, FrameworkManager, FunctionFactory
 from mantid.simpleapi import CreateEmptyTableWorkspace, CreateSampleWorkspace
 
 from Muon.GUI.Common.fitting_widgets.basic_fitting.basic_fitting_model import BasicFittingModel, DEFAULT_START_X
+from Muon.GUI.Common.muon_pair import MuonPair
+from Muon.GUI.Common.muon_base_pair import MuonBasePair
 from Muon.GUI.Common.test_helpers.context_setup import setup_context
 from Muon.GUI.Common.utilities.workspace_utils import StaticWorkspaceWrapper
 
@@ -24,7 +26,7 @@ class BasicFittingModelTest(unittest.TestCase):
     def setUp(self):
         context = setup_context()
         self.model = BasicFittingModel(context, context.fitting_context)
-        self.dataset_names = ["Name1", "Name2"]
+        self.dataset_names = ["EMU20884; Group; fwd; Asymmetry", "EMU20884; Group; top; Asymmetry"]
         self.fit_function = FunctionFactory.createFunction("FlatBackground")
         self.single_fit_functions = [self.fit_function.clone(), self.fit_function.clone()]
 
@@ -58,7 +60,7 @@ class BasicFittingModelTest(unittest.TestCase):
         self.model.start_xs = [2.0, 3.0]
         self.model.end_xs = [4.0, 5.0]
 
-        self.model.dataset_names = ["NewName", "Name1"]
+        self.model.dataset_names = ["NewName", "EMU20884; Group; fwd; Asymmetry"]
 
         self.assertEqual(self.model.start_xs, [2.0, 3.0])
         self.assertEqual(self.model.end_xs, [4.0, 5.0])
@@ -71,7 +73,7 @@ class BasicFittingModelTest(unittest.TestCase):
         self.model.start_xs = [2.0, 3.0]
         self.model.end_xs = [4.0, 5.0]
 
-        self.model.dataset_names = ["Name1", "Name2", "Name3"]
+        self.model.dataset_names = ["EMU20884; Group; fwd; Asymmetry", "EMU20884; Group; top; Asymmetry", "Name3"]
 
         self.assertEqual(self.model.start_xs, [2.0, 3.0, 3.0])
         self.assertEqual(self.model.end_xs, [4.0, 5.0, 5.0])
@@ -81,7 +83,7 @@ class BasicFittingModelTest(unittest.TestCase):
         self.model.start_xs = [2.0, 3.0]
         self.model.end_xs = [4.0, 5.0]
 
-        self.model.dataset_names = ["Name2"]
+        self.model.dataset_names = ["EMU20884; Group; top; Asymmetry"]
 
         self.assertEqual(self.model.start_xs, [3.0])
         self.assertEqual(self.model.end_xs, [5.0])
@@ -93,7 +95,7 @@ class BasicFittingModelTest(unittest.TestCase):
         self.model.fitting_context.exclude_start_xs = [2.2, 4.2]
         self.model.fitting_context.exclude_end_xs = [2.5, 4.5]
 
-        self.model.dataset_names = ["Name2"]
+        self.model.dataset_names = ["EMU20884; Group; top; Asymmetry"]
 
         self.assertEqual(self.model.fitting_context.exclude_start_xs, [5.0])
         self.assertEqual(self.model.fitting_context.exclude_end_xs, [5.0])
@@ -105,7 +107,7 @@ class BasicFittingModelTest(unittest.TestCase):
         self.model.fitting_context.exclude_start_xs = [2.2, 2.2]
         self.model.fitting_context.exclude_end_xs = [2.5, 2.5]
 
-        self.model.dataset_names = ["Name2", "Name3", "Name4"]
+        self.model.dataset_names = ["EMU20884; Group; top; Asymmetry", "Name3", "Name4"]
 
         self.assertEqual(self.model.fitting_context.exclude_start_xs, [2.2, 2.2, 4.0])
         self.assertEqual(self.model.fitting_context.exclude_end_xs, [2.5, 2.5, 4.0])
@@ -117,7 +119,7 @@ class BasicFittingModelTest(unittest.TestCase):
         self.model.fitting_context.exclude_start_xs = [2.2, 2.2]
         self.model.fitting_context.exclude_end_xs = [2.5, 2.5]
 
-        self.model.dataset_names = ["Name2", "Name3"]
+        self.model.dataset_names = ["EMU20884; Group; top; Asymmetry", "Name3"]
 
         self.assertEqual(self.model.fitting_context.exclude_start_xs, [2.2, 2.2])
         self.assertEqual(self.model.fitting_context.exclude_end_xs, [2.5, 2.5])
@@ -267,8 +269,8 @@ class BasicFittingModelTest(unittest.TestCase):
         self.model.dataset_names = self.dataset_names
         self.model.single_fit_functions = [self.fit_function, None]
 
-        fit_function1 = self.model.get_single_fit_function_for("Name1")
-        fit_function2 = self.model.get_single_fit_function_for("Name2")
+        fit_function1 = self.model.get_single_fit_function_for("EMU20884; Group; fwd; Asymmetry")
+        fit_function2 = self.model.get_single_fit_function_for("EMU20884; Group; top; Asymmetry")
 
         self.assertEqual(str(fit_function1), "name=FlatBackground,A0=0")
         self.assertEqual(fit_function2, None)
@@ -460,7 +462,7 @@ class BasicFittingModelTest(unittest.TestCase):
         self.model.dataset_names = self.dataset_names
         self.model.current_dataset_index = 1
 
-        self.assertEqual(self.model.get_active_workspace_names(), ["Name2"])
+        self.assertEqual(self.model.get_active_workspace_names(), ["EMU20884; Group; top; Asymmetry"])
 
     def test_that_get_active_fit_results_returns_an_empty_list_if_there_are_no_datasets(self):
         self.assertEqual(self.model.get_active_fit_results(), [])
@@ -624,7 +626,8 @@ class BasicFittingModelTest(unittest.TestCase):
         # The last two datasets are the same as the previously loaded datasets. This means their functions should be
         # reused for these last two single fit functions. The first two single fit functions are completely new, and so
         # are just given a copy of the previous currently selected function (i.e. A0=1).
-        self.model.dataset_names = ["New Name1", "New Name2", "Name1", "Name2"]
+        self.model.dataset_names = ["New Name1", "New Name2", "EMU20884; Group; fwd; Asymmetry",
+                                    "EMU20884; Group; top; Asymmetry"]
 
         self.assertEqual(str(self.model.single_fit_functions[0]), "name=FlatBackground,A0=1")
         self.assertEqual(str(self.model.single_fit_functions[1]), "name=FlatBackground,A0=1")
@@ -639,13 +642,13 @@ class BasicFittingModelTest(unittest.TestCase):
         self.model.single_fit_functions[1].setParameter("A0", 5)
 
         # This dataset is the second dataset previously and so the A0=5 fit function should be reused.
-        self.model.dataset_names = ["Name2"]
+        self.model.dataset_names = ["EMU20884; Group; top; Asymmetry"]
         self.assertEqual(str(self.model.single_fit_functions[0]), "name=FlatBackground,A0=5")
 
     def test_that_x_limits_of_current_dataset_will_return_the_x_limits_of_the_workspace(self):
         self.model.dataset_names = self.dataset_names
         workspace = CreateSampleWorkspace()
-        AnalysisDataService.addOrReplace("Name1", workspace)
+        AnalysisDataService.addOrReplace("EMU20884; Group; fwd; Asymmetry", workspace)
 
         x_lower, x_upper = self.model.x_limits_of_workspace(self.model.current_dataset_name)
 
@@ -663,6 +666,102 @@ class BasicFittingModelTest(unittest.TestCase):
 
         self.assertEqual(x_lower, 0.0)
         self.assertEqual(x_upper, 15.0)
+
+    """
+    Tests for functions used by the Sequential fitting tab.
+    """
+
+    def test_that_get_runs_groups_and_pairs_for_fits_will_attempt_to_get_the_runs_groups_and_pairs_when_in_single_fit_mode(self):
+        self.mock_context_instrument = mock.PropertyMock(return_value="EMU")
+        type(self.model.context.data_context).instrument = self.mock_context_instrument
+
+        self.model.dataset_names = self.dataset_names
+
+        workspace_names, runs, groups_and_pairs = self.model.get_runs_groups_and_pairs_for_fits()
+        self.assertEqual(workspace_names, self.dataset_names)
+        self.assertEqual(runs, ["20884", "20884"])
+        self.assertEqual(groups_and_pairs, ["fwd", "top"])
+
+    def test_that_get_fit_function_parameter_values_will_return_the_parameter_values_in_the_specified_function(self):
+        self.assertEqual(self.model.get_fit_function_parameter_values(self.single_fit_functions[0])[0], [0.0])
+
+    def test_that_update_ws_fit_function_parameters_will_update_the_parameters_for_the_specified_dataset_in_single_mode(self):
+        self.model.dataset_names = self.dataset_names
+        self.model.single_fit_functions = self.single_fit_functions
+
+        self.model.update_ws_fit_function_parameters(self.model.dataset_names[:1], [1.0])
+
+        self.assertEqual(self.model.get_fit_function_parameter_values(self.model.single_fit_functions[0])[0], [1.0])
+        self.assertEqual(self.model.get_fit_function_parameter_values(self.model.single_fit_functions[1])[0], [0.0])
+
+    def test_get_fit_workspace_names_from_groups_and_runs_when_fit_to_raw_is_false(self):
+        self.model.fit_to_raw = False
+        self.model.context.data_context.instrument = "MUSR"
+
+        self.model.context.group_pair_context.add_pair(MuonPair("long", "f", "b", 1.0))
+        self.model.context.group_pair_context.add_pair(MuonPair("long2", "f", "b", 2.0))
+        self.model.context.group_pair_context.add_pair(MuonBasePair("phase_Re_"))
+        self.model.context.group_pair_context.add_pair(MuonBasePair("phase_Im_"))
+        self.model.context.group_pair_context.add_pair(MuonBasePair("phase2_Re_"))
+        self.model.context.group_pair_context.add_pair(MuonBasePair("phase2_Im_"))
+        self.model.context.group_pair_context.add_pair_to_selected_pairs("long")
+        self.model.context.group_pair_context.add_pair_to_selected_pairs("phase_Re_")
+        self.model.context.group_pair_context.add_pair_to_selected_pairs("phase2_Im_")
+
+        selection = ["long", "long2", "phase_Re_", "phase_Im_", "phase2_Re_", "phase2_Im_"]
+        result = self.model.get_fit_workspace_names_from_groups_and_runs([1, 2, 3], selection)
+
+        self.assertEqual(["MUSR1; Pair Asym; long; Rebin; MA",
+                          "MUSR1; PhaseQuad; phase_Re_; Rebin; MA",
+                          "MUSR1; PhaseQuad; phase2_Im_; Rebin; MA",
+                          "MUSR2; Pair Asym; long; Rebin; MA",
+                          "MUSR2; PhaseQuad; phase_Re_; Rebin; MA",
+                          "MUSR2; PhaseQuad; phase2_Im_; Rebin; MA",
+                          "MUSR3; Pair Asym; long; Rebin; MA",
+                          "MUSR3; PhaseQuad; phase_Re_; Rebin; MA",
+                          "MUSR3; PhaseQuad; phase2_Im_; Rebin; MA"], result)
+
+    def test_get_fit_workspace_names_from_groups_and_runs_when_fit_to_raw_is_true(self):
+        self.model.fit_to_raw = True
+        self.model.context.data_context.instrument = "MUSR"
+
+        self.model.context.group_pair_context.add_pair(MuonPair("long", "f", "b", 1.0))
+        self.model.context.group_pair_context.add_pair(MuonPair("long2", "f", "b", 2.0))
+        self.model.context.group_pair_context.add_pair(MuonBasePair("phase_Re_"))
+        self.model.context.group_pair_context.add_pair(MuonBasePair("phase_Im_"))
+        self.model.context.group_pair_context.add_pair(MuonBasePair("phase2_Re_"))
+        self.model.context.group_pair_context.add_pair(MuonBasePair("phase2_Im_"))
+        self.model.context.group_pair_context.add_pair_to_selected_pairs("long")
+        self.model.context.group_pair_context.add_pair_to_selected_pairs("phase_Re_")
+        self.model.context.group_pair_context.add_pair_to_selected_pairs("phase2_Im_")
+
+        selection = ["long", "long2", "phase_Re_", "phase_Im_", "phase2_Re_", "phase2_Im_"]
+        result = self.model.get_fit_workspace_names_from_groups_and_runs([1, 2, 3], selection)
+
+        self.assertEqual(["MUSR1; Pair Asym; long; MA",
+                          "MUSR1; PhaseQuad; phase_Re_; MA",
+                          "MUSR1; PhaseQuad; phase2_Im_; MA",
+                          "MUSR2; Pair Asym; long; MA",
+                          "MUSR2; PhaseQuad; phase_Re_; MA",
+                          "MUSR2; PhaseQuad; phase2_Im_; MA",
+                          "MUSR3; Pair Asym; long; MA",
+                          "MUSR3; PhaseQuad; phase_Re_; MA",
+                          "MUSR3; PhaseQuad; phase2_Im_; MA"], result)
+
+    def test_that_validate_sequential_fit_returns_an_empty_message_when_the_data_provided_is_valid_in_normal_fitting(self):
+        self.model.dataset_names = self.dataset_names
+        self.model.single_fit_functions = self.single_fit_functions
+
+        message = self.model.validate_sequential_fit([self.model.dataset_names])
+
+        self.assertEqual(message, "")
+
+    def test_that_validate_sequential_fit_returns_an_error_message_when_no_fit_function_is_selected(self):
+        self.model.dataset_names = self.dataset_names
+
+        message = self.model.validate_sequential_fit([self.model.dataset_names])
+
+        self.assertEqual(message, "No data or fit function selected for fitting.")
 
 
 if __name__ == '__main__':

--- a/scripts/test/Muon/fitting_widgets/general_fitting/general_fitting_model_test.py
+++ b/scripts/test/Muon/fitting_widgets/general_fitting/general_fitting_model_test.py
@@ -488,6 +488,49 @@ class GeneralFittingModelTest(unittest.TestCase):
 
         self.assertEqual(str(self.model.simultaneous_fit_function), "name=FlatBackground,A0=5")
 
+    """
+    Tests for functions used by the Sequential fitting tab.
+    """
+
+    def test_that_get_runs_groups_and_pairs_for_fits_will_attempt_to_get_it_by_runs_when_in_simultaneous_fitting_mode(self):
+        self.model._get_runs_groups_and_pairs_for_simultaneous_fit_by_runs = mock.Mock(return_value=(["62260"], ["fwd;bwd;long"]))
+        self.model.simultaneous_fitting_mode = True
+        self.model.simultaneous_fit_by = "Run"
+
+        runs, groups_and_pairs = self.model.get_runs_groups_and_pairs_for_fits()
+        self.assertEqual(runs, ["62260"])
+        self.assertEqual(groups_and_pairs, ["fwd;bwd;long"])
+
+        self.model._get_runs_groups_and_pairs_for_simultaneous_fit_by_runs.assert_called_once_with()
+
+    def test_that_get_runs_groups_and_pairs_for_fits_will_attempt_to_get_it_by_groups_when_in_simultaneous_fitting_mode(self):
+        self.model._get_runs_groups_and_pairs_for_simultaneous_fit_by_groups_and_pairs = \
+            mock.Mock(return_value=(["62260;62261;62262"], ["fwd", "bwd"]))
+        self.model.simultaneous_fitting_mode = True
+        self.model.simultaneous_fit_by = "Group/Pair"
+
+        runs, groups_and_pairs = self.model.get_runs_groups_and_pairs_for_fits()
+        self.assertEqual(runs, ["62260;62261;62262"])
+        self.assertEqual(groups_and_pairs, ["fwd", "bwd"])
+
+        self.model._get_runs_groups_and_pairs_for_simultaneous_fit_by_groups_and_pairs.assert_called_once_with()
+
+    def test_that_get_fit_function_parameter_values_will_return_the_parameter_values_in_the_specified_function(self):
+        self.assertEqual(self.model.get_fit_function_parameter_values(self.simultaneous_fit_function)[0], [0.0, 0.0])
+
+    def test_that_update_ws_fit_function_parameters_will_update_the_parameters_when_in_simultaneous_mode(self):
+        self.model.dataset_names = self.dataset_names
+        self.model.simultaneous_fit_function = self.simultaneous_fit_function
+        self.model.simultaneous_fitting_mode = True
+
+        self.model.update_ws_fit_function_parameters(self.model.dataset_names[:1], [1.0, 0.0])
+        self.assertEqual(self.model.get_fit_function_parameter_values(self.model.simultaneous_fit_function),
+                         ([1.0, 0.0], [0.0, 0.0]))
+
+        self.model.update_ws_fit_function_parameters(self.model.dataset_names[1:], [1.0, 2.0])
+        self.assertEqual(self.model.get_fit_function_parameter_values(self.model.simultaneous_fit_function),
+                         ([1.0, 2.0], [0.0, 0.0]))
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/scripts/test/Muon/fitting_widgets/tf_asymmetry_fitting/tf_asymmetry_fitting_model_test.py
+++ b/scripts/test/Muon/fitting_widgets/tf_asymmetry_fitting/tf_asymmetry_fitting_model_test.py
@@ -754,6 +754,40 @@ class TFAsymmetryFittingModelTest(unittest.TestCase):
         self.model.dataset_names = self.dataset_names
         self.assertTrue(not self.model._are_same_workspaces_as_the_datasets(dataset_names))
 
+    def test_that_validate_sequential_fit_returns_an_empty_message_when_the_data_provided_is_valid_in_normal_fitting(self):
+        self.model.dataset_names = self.dataset_names
+        self.model.single_fit_functions = self.single_fit_functions
+
+        message = self.model.validate_sequential_fit([self.model.dataset_names])
+
+        self.assertEqual(message, "")
+
+    def test_that_validate_sequential_fit_returns_an_error_message_when_no_fit_function_is_selected(self):
+        self.model.dataset_names = self.dataset_names
+
+        message = self.model.validate_sequential_fit([self.model.dataset_names])
+
+        self.assertEqual(message, "No data or fit function selected for fitting.")
+
+    def test_that_validate_sequential_fit_returns_an_empty_message_when_the_data_provided_is_valid_in_tf_fitting(self):
+        self.model.dataset_names = ["EMU20884; Group; bottom; Asymmetry", "EMU20884; Group; top; Asymmetry"]
+        self.model.single_fit_functions = self.single_fit_functions
+        self.model.tf_asymmetry_mode = True
+
+        message = self.model.validate_sequential_fit([self.model.dataset_names])
+
+        self.assertEqual(message, "")
+
+    def test_that_validate_sequential_fit_returns_an_error_message_for_pair_data_in_tf_asymmetry_fitting_mode(self):
+        self.model.dataset_names = ["EMU20884; Pair Asym; bottom; Asymmetry", "EMU20884; Pair Asym; top; Asymmetry"]
+        self.model.single_fit_functions = self.single_fit_functions
+        self.model.tf_asymmetry_mode = True
+
+        message = self.model.validate_sequential_fit([self.model.dataset_names])
+
+        self.assertEqual(message, "Only Groups can be fitted in TF Asymmetry mode. "
+                                  "Please unselect the following Pairs/Diffs in the grouping tab: 'bottom', 'top'")
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/scripts/test/Muon/fitting_widgets/tf_asymmetry_fitting/tf_asymmetry_fitting_model_test.py
+++ b/scripts/test/Muon/fitting_widgets/tf_asymmetry_fitting/tf_asymmetry_fitting_model_test.py
@@ -11,8 +11,6 @@ from mantid.api import FrameworkManager, FunctionFactory
 from mantid.simpleapi import CreateSampleWorkspace
 
 from Muon.GUI.Common.fitting_widgets.tf_asymmetry_fitting.tf_asymmetry_fitting_model import TFAsymmetryFittingModel
-from Muon.GUI.Common.muon_pair import MuonPair
-from Muon.GUI.Common.muon_base_pair import MuonBasePair
 from Muon.GUI.Common.test_helpers.context_setup import setup_context
 
 
@@ -563,67 +561,6 @@ class TFAsymmetryFittingModelTest(unittest.TestCase):
         self.assertEqual(parameter_values, [5.0, 6.0, 7.0, 8.0])
         self.assertEqual(normalisations, [1.234, 2.234])
 
-    def test_that_get_runs_groups_and_pairs_for_fits_will_attempt_to_get_the_runs_groups_and_pairs_when_in_single_fit_mode(self):
-        self.mock_context_instrument = mock.PropertyMock(return_value="EMU")
-        type(self.model.context.data_context).instrument = self.mock_context_instrument
-
-        self.model.dataset_names = self.dataset_names
-
-        workspace_names, runs, groups_and_pairs = self.model.get_runs_groups_and_pairs_for_fits()
-        self.assertEqual(workspace_names, self.dataset_names)
-        self.assertEqual(runs, ["20884", "20884"])
-        self.assertEqual(groups_and_pairs, ["fwd", "top"])
-
-    def test_that_get_runs_groups_and_pairs_for_fits_will_attempt_to_get_it_by_runs_when_in_simultaneous_fitting_mode(self):
-        self.model._get_runs_groups_and_pairs_for_simultaneous_fit_by_runs = mock.Mock(return_value=(["62260"], ["fwd;bwd;long"]))
-        self.model.simultaneous_fitting_mode = True
-        self.model.simultaneous_fit_by = "Run"
-
-        runs, groups_and_pairs = self.model.get_runs_groups_and_pairs_for_fits()
-        self.assertEqual(runs, ["62260"])
-        self.assertEqual(groups_and_pairs, ["fwd;bwd;long"])
-
-        self.model._get_runs_groups_and_pairs_for_simultaneous_fit_by_runs.assert_called_once_with()
-
-    def test_that_get_runs_groups_and_pairs_for_fits_will_attempt_to_get_it_by_groups_when_in_simultaneous_fitting_mode(self):
-        self.model._get_runs_groups_and_pairs_for_simultaneous_fit_by_groups_and_pairs = \
-            mock.Mock(return_value=(["62260;62261;62262"], ["fwd", "bwd"]))
-        self.model.simultaneous_fitting_mode = True
-        self.model.simultaneous_fit_by = "Group/Pair"
-
-        runs, groups_and_pairs = self.model.get_runs_groups_and_pairs_for_fits()
-        self.assertEqual(runs, ["62260;62261;62262"])
-        self.assertEqual(groups_and_pairs, ["fwd", "bwd"])
-
-        self.model._get_runs_groups_and_pairs_for_simultaneous_fit_by_groups_and_pairs.assert_called_once_with()
-
-    def test_that_get_fit_function_parameter_values_will_return_the_parameter_values_in_the_specified_function(self):
-        self.assertEqual(self.model.get_fit_function_parameter_values(self.single_fit_functions[0])[0], [0.0])
-        self.assertEqual(self.model.get_fit_function_parameter_values(self.simultaneous_fit_function)[0], [0.0, 0.0])
-
-    def test_that_update_ws_fit_function_parameters_will_update_the_parameters_for_the_specified_dataset_in_single_mode(self):
-        self.model.dataset_names = self.dataset_names
-        self.model.single_fit_functions = self.single_fit_functions
-        self.model.simultaneous_fitting_mode = False
-
-        self.model.update_ws_fit_function_parameters(self.model.dataset_names[:1], [1.0])
-
-        self.assertEqual(self.model.get_fit_function_parameter_values(self.model.single_fit_functions[0])[0], [1.0])
-        self.assertEqual(self.model.get_fit_function_parameter_values(self.model.single_fit_functions[1])[0], [0.0])
-
-    def test_that_update_ws_fit_function_parameters_will_update_the_parameters_when_in_simultaneous_mode(self):
-        self.model.dataset_names = self.dataset_names
-        self.model.simultaneous_fit_function = self.simultaneous_fit_function
-        self.model.simultaneous_fitting_mode = True
-
-        self.model.update_ws_fit_function_parameters(self.model.dataset_names[:1], [1.0, 0.0])
-        self.assertEqual(self.model.get_fit_function_parameter_values(self.model.simultaneous_fit_function),
-                         ([1.0, 0.0], [0.0, 0.0]))
-
-        self.model.update_ws_fit_function_parameters(self.model.dataset_names[1:], [1.0, 2.0])
-        self.assertEqual(self.model.get_fit_function_parameter_values(self.model.simultaneous_fit_function),
-                         ([1.0, 2.0], [0.0, 0.0]))
-
     def test_that_update_ws_fit_function_parameters_will_update_the_parameters_when_in_TF_asymmetry_simultaneous_mode(self):
         normalisation1, normalisation2 = 1.345, 2.345
         param1, param2 = 3.345, 4.345
@@ -637,60 +574,6 @@ class TFAsymmetryFittingModelTest(unittest.TestCase):
         self.model.update_ws_fit_function_parameters(self.dataset_names, [normalisation1, param1, normalisation2, param2])
         self.assertEqual(self.model.get_fit_function_parameter_values(self.model.tf_asymmetry_simultaneous_function)[0],
                          [normalisation1, 0.0, param1, 0.2, 0.2, normalisation2, 0.0, param2, 0.2, 0.2])
-
-    def test_get_fit_workspace_names_from_groups_and_runs_when_fit_to_raw_is_false(self):
-        self.model.fit_to_raw = False
-        self.model.context.data_context.instrument = "MUSR"
-
-        self.model.context.group_pair_context.add_pair(MuonPair("long", "f", "b", 1.0))
-        self.model.context.group_pair_context.add_pair(MuonPair("long2", "f", "b", 2.0))
-        self.model.context.group_pair_context.add_pair(MuonBasePair("phase_Re_"))
-        self.model.context.group_pair_context.add_pair(MuonBasePair("phase_Im_"))
-        self.model.context.group_pair_context.add_pair(MuonBasePair("phase2_Re_"))
-        self.model.context.group_pair_context.add_pair(MuonBasePair("phase2_Im_"))
-        self.model.context.group_pair_context.add_pair_to_selected_pairs("long")
-        self.model.context.group_pair_context.add_pair_to_selected_pairs("phase_Re_")
-        self.model.context.group_pair_context.add_pair_to_selected_pairs("phase2_Im_")
-
-        selection = ["long", "long2", "phase_Re_", "phase_Im_", "phase2_Re_", "phase2_Im_"]
-        result = self.model.get_fit_workspace_names_from_groups_and_runs([1, 2, 3], selection)
-
-        self.assertEqual(["MUSR1; Pair Asym; long; Rebin; MA",
-                          "MUSR1; PhaseQuad; phase_Re_; Rebin; MA",
-                          "MUSR1; PhaseQuad; phase2_Im_; Rebin; MA",
-                          "MUSR2; Pair Asym; long; Rebin; MA",
-                          "MUSR2; PhaseQuad; phase_Re_; Rebin; MA",
-                          "MUSR2; PhaseQuad; phase2_Im_; Rebin; MA",
-                          "MUSR3; Pair Asym; long; Rebin; MA",
-                          "MUSR3; PhaseQuad; phase_Re_; Rebin; MA",
-                          "MUSR3; PhaseQuad; phase2_Im_; Rebin; MA"], result)
-
-    def test_get_fit_workspace_names_from_groups_and_runs_when_fit_to_raw_is_true(self):
-        self.model.fit_to_raw = True
-        self.model.context.data_context.instrument = "MUSR"
-
-        self.model.context.group_pair_context.add_pair(MuonPair("long", "f", "b", 1.0))
-        self.model.context.group_pair_context.add_pair(MuonPair("long2", "f", "b", 2.0))
-        self.model.context.group_pair_context.add_pair(MuonBasePair("phase_Re_"))
-        self.model.context.group_pair_context.add_pair(MuonBasePair("phase_Im_"))
-        self.model.context.group_pair_context.add_pair(MuonBasePair("phase2_Re_"))
-        self.model.context.group_pair_context.add_pair(MuonBasePair("phase2_Im_"))
-        self.model.context.group_pair_context.add_pair_to_selected_pairs("long")
-        self.model.context.group_pair_context.add_pair_to_selected_pairs("phase_Re_")
-        self.model.context.group_pair_context.add_pair_to_selected_pairs("phase2_Im_")
-
-        selection = ["long", "long2", "phase_Re_", "phase_Im_", "phase2_Re_", "phase2_Im_"]
-        result = self.model.get_fit_workspace_names_from_groups_and_runs([1, 2, 3], selection)
-
-        self.assertEqual(["MUSR1; Pair Asym; long; MA",
-                          "MUSR1; PhaseQuad; phase_Re_; MA",
-                          "MUSR1; PhaseQuad; phase2_Im_; MA",
-                          "MUSR2; Pair Asym; long; MA",
-                          "MUSR2; PhaseQuad; phase_Re_; MA",
-                          "MUSR2; PhaseQuad; phase2_Im_; MA",
-                          "MUSR3; Pair Asym; long; MA",
-                          "MUSR3; PhaseQuad; phase_Re_; MA",
-                          "MUSR3; PhaseQuad; phase2_Im_; MA"], result)
 
     def test_that_perform_sequential_fit_will_call_the_correct_functions_when_not_in_tf_asymmetry_mode(self):
         workspaces = [self.dataset_names[:1], self.dataset_names[1:]]
@@ -753,21 +636,6 @@ class TFAsymmetryFittingModelTest(unittest.TestCase):
         dataset_names = self.dataset_names + ["EMU20884; Group; bottom; Asymmetry"]
         self.model.dataset_names = self.dataset_names
         self.assertTrue(not self.model._are_same_workspaces_as_the_datasets(dataset_names))
-
-    def test_that_validate_sequential_fit_returns_an_empty_message_when_the_data_provided_is_valid_in_normal_fitting(self):
-        self.model.dataset_names = self.dataset_names
-        self.model.single_fit_functions = self.single_fit_functions
-
-        message = self.model.validate_sequential_fit([self.model.dataset_names])
-
-        self.assertEqual(message, "")
-
-    def test_that_validate_sequential_fit_returns_an_error_message_when_no_fit_function_is_selected(self):
-        self.model.dataset_names = self.dataset_names
-
-        message = self.model.validate_sequential_fit([self.model.dataset_names])
-
-        self.assertEqual(message, "No data or fit function selected for fitting.")
 
     def test_that_validate_sequential_fit_returns_an_empty_message_when_the_data_provided_is_valid_in_tf_fitting(self):
         self.model.dataset_names = ["EMU20884; Group; bottom; Asymmetry", "EMU20884; Group; top; Asymmetry"]

--- a/scripts/test/Muon/fitting_widgets/tf_asymmetry_fitting/tf_asymmetry_fitting_model_test.py
+++ b/scripts/test/Muon/fitting_widgets/tf_asymmetry_fitting/tf_asymmetry_fitting_model_test.py
@@ -564,13 +564,15 @@ class TFAsymmetryFittingModelTest(unittest.TestCase):
         self.assertEqual(normalisations, [1.234, 2.234])
 
     def test_that_get_runs_groups_and_pairs_for_fits_will_attempt_to_get_the_runs_groups_and_pairs_when_in_single_fit_mode(self):
-        self.model._get_runs_groups_and_pairs_for_single_fit = mock.Mock(return_value=(["62260"], ["fwd", "bwd"]))
+        self.mock_context_instrument = mock.PropertyMock(return_value="EMU")
+        type(self.model.context.data_context).instrument = self.mock_context_instrument
 
-        runs, groups_and_pairs = self.model.get_runs_groups_and_pairs_for_fits()
-        self.assertEqual(runs, ["62260"])
-        self.assertEqual(groups_and_pairs, ["fwd", "bwd"])
+        self.model.dataset_names = self.dataset_names
 
-        self.model._get_runs_groups_and_pairs_for_single_fit.assert_called_once_with()
+        workspace_names, runs, groups_and_pairs = self.model.get_runs_groups_and_pairs_for_fits()
+        self.assertEqual(workspace_names, self.dataset_names)
+        self.assertEqual(runs, ["20884", "20884"])
+        self.assertEqual(groups_and_pairs, ["fwd", "top"])
 
     def test_that_get_runs_groups_and_pairs_for_fits_will_attempt_to_get_it_by_runs_when_in_simultaneous_fitting_mode(self):
         self.model._get_runs_groups_and_pairs_for_simultaneous_fit_by_runs = mock.Mock(return_value=(["62260"], ["fwd;bwd;long"]))

--- a/scripts/test/Muon/seq_fitting_tab_widget/seq_fitting_tab_presenter_test.py
+++ b/scripts/test/Muon/seq_fitting_tab_widget/seq_fitting_tab_presenter_test.py
@@ -54,15 +54,16 @@ class SeqFittingTabPresenterTest(unittest.TestCase):
         return fit_function
 
     def test_handle_workspaces_changed_correctly_updates_view_from_model(self):
+        workspaces = ["EMU2224; Group; bwd; MA", "EMU2224; Group; fwd; MA", "EMU2224; Group; top; MA"]
         run_list = ["2224", "2225"]
         group_pair_list = ["fwd", "bwd"]
         self.presenter.model.get_runs_groups_and_pairs_for_fits = mock.MagicMock(
-            return_value=[run_list, group_pair_list])
+            return_value=[workspaces, run_list, group_pair_list])
 
         self.presenter.handle_selected_workspaces_changed()
 
         self.presenter.model.get_runs_groups_and_pairs_for_fits.assert_called_once()
-        self.view.fit_table.set_fit_workspaces.assert_called_with(run_list, group_pair_list)
+        self.view.fit_table.set_fit_workspaces.assert_called_with(workspaces, run_list, group_pair_list)
 
     def test_handle_fit_function_changed_correctly_updates_fit_table_parameters(self):
         parameters = ['A', 'Sigma', 'Frequency', 'Phi']
@@ -101,7 +102,7 @@ class SeqFittingTabPresenterTest(unittest.TestCase):
         self._setup_test_fit_function([0.2, 0.1, 0, 0])
         self.presenter.get_workspaces_for_row_in_fit_table = mock.MagicMock(return_value=[workspace])
         self.view.fit_table.get_fit_parameter_values_from_row = mock.MagicMock(return_value=parameter_values)
-        self.model.check_datasets_are_tf_asymmetry_compliant = mock.MagicMock(return_value=(True, ""))
+        self.presenter.validate_sequential_fit = mock.MagicMock(return_value=True)
 
         self.presenter.handle_fit_selected_pressed()
 
@@ -149,7 +150,7 @@ class SeqFittingTabPresenterTest(unittest.TestCase):
         self.view.fit_table.get_number_of_fits = mock.MagicMock(return_value=number_of_entries)
         self.view.fit_table.get_fit_parameter_values_from_row = mock.Mock(return_value=parameters_values)
         self.presenter.get_workspaces_for_row_in_fit_table = mock.MagicMock(return_value=workspaces)
-        self.model.check_datasets_are_tf_asymmetry_compliant = mock.MagicMock(return_value=(True, ""))
+        self.presenter.validate_sequential_fit = mock.MagicMock(return_value=True)
 
         self.presenter.handle_sequential_fit_pressed()
 
@@ -189,13 +190,12 @@ class SeqFittingTabPresenterTest(unittest.TestCase):
         self.view.seq_fit_button.setEnabled.assert_called_once_with(True)
 
     def test_get_workspaces_for_row_in_fit_table_calls_model_correctly(self):
-        run = "2224"
-        groups = "bwd;fwd;top"
-        self.view.fit_table.get_workspace_info_from_row = mock.MagicMock(return_value=[run, groups])
+        workspaces = "EMU2224; Group; bwd; MA/EMU2224; Group; fwd; MA/EMU2224; Group; top; MA"
+        self.view.fit_table.get_workspace_names_from_row = mock.MagicMock(return_value=workspaces)
 
-        self.presenter.get_workspaces_for_row_in_fit_table(0)
+        workspace_names = self.presenter.get_workspaces_for_row_in_fit_table(0)
 
-        self.model.get_fit_workspace_names_from_groups_and_runs.assert_called_once_with([run], ["bwd", "fwd", "top"])
+        self.assertEqual(workspace_names, workspaces.split("/"))
 
     def test_handle_fit_selected_in_table_retrieves_correct_workspaces(self):
         selected_rows = [0, 2, 5]
@@ -211,7 +211,7 @@ class SeqFittingTabPresenterTest(unittest.TestCase):
 
     def test_workspace_deleted_in_ads_updates_fit_table(self):
         self.presenter.model.get_runs_groups_and_pairs_for_fits = mock.MagicMock(
-            return_value=[[], []])
+            return_value=[[], [], []])
 
         workspace = CreateSampleWorkspace(OutputWorkspace="test")
         DeleteWorkspace(workspace)

--- a/scripts/test/Muon/seq_fitting_tab_widget/sequential_table_test.py
+++ b/scripts/test/Muon/seq_fitting_tab_widget/sequential_table_test.py
@@ -194,7 +194,7 @@ class SequentialTableModelTest(unittest.TestCase):
 
     def test_set_fit_parameter_values_for_column(self):
         parameter_value = 1.5
-        column = 5
+        column = 6
 
         self.model.set_fit_parameter_values_for_column(column, parameter_value)
 

--- a/scripts/test/Muon/seq_fitting_tab_widget/sequential_table_test.py
+++ b/scripts/test/Muon/seq_fitting_tab_widget/sequential_table_test.py
@@ -80,6 +80,13 @@ class SequentialTableWidgetTest(unittest.TestCase):
         self.model.get_run_information.assert_not_called()
         self.model.get_group_information.assert_not_called()
 
+    def test_get_workspace_names_from_row_correctly_queries_model(self):
+        row = 1
+
+        self.table_widget.get_workspace_names_from_row(row)
+
+        self.model.get_workspace_name_information.assert_called_once_with(row)
+
 
 class SequentialTableModelTest(unittest.TestCase):
     def setUp(self):

--- a/scripts/test/Muon/seq_fitting_tab_widget/sequential_table_test.py
+++ b/scripts/test/Muon/seq_fitting_tab_widget/sequential_table_test.py
@@ -5,7 +5,9 @@
 #   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
 # SPDX - License - Identifier: GPL - 3.0 +
 import unittest
-from Muon.GUI.Common.seq_fitting_tab_widget.QSequentialTableModel import QSequentialTableModel, default_table_columns
+from Muon.GUI.Common.seq_fitting_tab_widget.QSequentialTableModel import (QSequentialTableModel, default_table_columns,
+                                                                          FIT_STATUS_COLUMN, FIT_QUALITY_COLUMN,
+                                                                          GROUP_COLUMN, RUN_COLUMN, WORKSPACE_COLUMN)
 from mantidqt.utils.testing.mocks.mock_sequentialtable import MockSequentialTableModel, MockSequentialTableView
 from Muon.GUI.Common.seq_fitting_tab_widget.SequentialTableWidget import SequentialTableWidget
 from mantidqt.utils.testing.mocks.mock_qt import MockQModelIndex
@@ -83,7 +85,8 @@ class SequentialTableModelTest(unittest.TestCase):
     def setUp(self):
         self.model = QSequentialTableModel()
 
-        self.workspace_data = [["2223", "bwd", "No Fit", 0], ["2223", "fwd", "No Fit", 0]]
+        self.workspace_data = [["EMU2223; Group; bwd; MA", "2223", "bwd", "No Fit", 0],
+                               ["EMU2223; Group; fwd; MA", "2223", "fwd", "No Fit", 0]]
         self.parameter_data = [[0, 1, 2], [3, 4, 5]]
         self.parameters = ["param1", "param2", "param3"]
         self.setup_test_data()
@@ -159,11 +162,11 @@ class SequentialTableModelTest(unittest.TestCase):
 
     def test_reset_fit_data_correctly_resets_to_default(self):
         for row in range(self.model.rowCount()):
-            self.model._defaultData[row][2] = 'test'
+            self.model._defaultData[row][FIT_STATUS_COLUMN] = 'test'
 
         self.model.reset_fit_quality()
 
-        self.assertEqual(self.get_column_data(2), ['No fit', 'No fit'])
+        self.assertEqual(self.get_column_data(FIT_STATUS_COLUMN), ['No fit', 'No fit'])
 
     def test_set_fit_parameters(self):
         parameters = ["new_param1", "new_param2", "new_param3"]
@@ -192,15 +195,28 @@ class SequentialTableModelTest(unittest.TestCase):
         self.assertEqual(self.model._parameterData[1][1], parameter_value)
 
     def test_set_fit_workspaces(self):
+        new_workspaces = ["EMU2224; Group; top; MA", "EMU2224; bottom; bwd; MA"]
         new_runs = ['2224', '2224']
         new_groups = ['top', 'bottom']
 
-        self.model.set_fit_workspaces(new_runs, new_groups)
+        self.model.set_fit_workspaces(new_workspaces, new_runs, new_groups)
 
         for row in range(len(new_runs)):
-            self.assertEqual(self.model.data(self.model.createIndex(row, 0), Qt.DisplayRole), new_runs[row])
-            self.assertEqual(self.model.data(self.model.createIndex(row, 1), Qt.DisplayRole), new_groups[row])
-            self.assertEqual(self.model.data(self.model.createIndex(row, 2), Qt.DisplayRole), 'No fit')
+            self.assertEqual(self.model.data(self.model.createIndex(row, WORKSPACE_COLUMN), Qt.DisplayRole),
+                             new_workspaces[row])
+            self.assertEqual(self.model.data(self.model.createIndex(row, RUN_COLUMN), Qt.DisplayRole), new_runs[row])
+            self.assertEqual(self.model.data(self.model.createIndex(row, GROUP_COLUMN), Qt.DisplayRole), new_groups[row])
+            self.assertEqual(self.model.data(self.model.createIndex(row, FIT_STATUS_COLUMN), Qt.DisplayRole), 'No fit')
+
+    def test_get_workspace_name_information_returns_the_expected_data(self):
+        new_workspaces = ["EMU2224; Group; top; MA", "EMU2224; bottom; bwd; MA"]
+        new_runs = ['2224', '2224']
+        new_groups = ['top', 'bottom']
+
+        self.model.set_fit_workspaces(new_workspaces, new_runs, new_groups)
+
+        for i in range(len(new_workspaces)):
+            self.assertEqual(self.model.get_workspace_name_information(i), new_workspaces[i])
 
     def test_set_run_information(self):
         new_run = '2225'
@@ -208,7 +224,7 @@ class SequentialTableModelTest(unittest.TestCase):
 
         self.model.set_run_information(row, new_run)
 
-        self.assertEqual(self.model.data(self.model.createIndex(row, 0), Qt.DisplayRole), new_run)
+        self.assertEqual(self.model.data(self.model.createIndex(row, RUN_COLUMN), Qt.DisplayRole), new_run)
 
     def test_set_group_information(self):
         new_group = 'long'
@@ -216,7 +232,7 @@ class SequentialTableModelTest(unittest.TestCase):
 
         self.model.set_group_information(row, new_group)
 
-        self.assertEqual(self.model.data(self.model.createIndex(row, 1), Qt.DisplayRole), new_group)
+        self.assertEqual(self.model.data(self.model.createIndex(row, GROUP_COLUMN), Qt.DisplayRole), new_group)
 
     def test_set_fit_quality(self):
         fit_quality = 'success'
@@ -225,8 +241,8 @@ class SequentialTableModelTest(unittest.TestCase):
 
         self.model.set_fit_quality(row, fit_quality, chi_squared)
 
-        self.assertEqual(self.model.data(self.model.createIndex(row, 2), Qt.DisplayRole), fit_quality)
-        self.assertEqual(self.model.data(self.model.createIndex(row, 3), Qt.DisplayRole), chi_squared)
+        self.assertEqual(self.model.data(self.model.createIndex(row, FIT_STATUS_COLUMN), Qt.DisplayRole), fit_quality)
+        self.assertEqual(self.model.data(self.model.createIndex(row, FIT_QUALITY_COLUMN), Qt.DisplayRole), chi_squared)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
**Description of work.**
This PR adds a Sequential Fitting tab to the FDA interface. It is one of the WIMDA replacement requirements.

**To test:**
Open FDA and load `MUSR62260`
Calculate FFT
Do some normal fitting on the Fitting tab
Then try fitting on the Sequential fitting tab

Also make sure sequential fitting still works in the Muon Analysis GUI

Fixes #32036

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
