### PR TITLE
Open Covariance Matrix from a button in Muon Analysis and FDA

### DIFF
--- a/docs/source/release/v6.2.0/muon.rst
+++ b/docs/source/release/v6.2.0/muon.rst
@@ -30,6 +30,7 @@ New Features
 ############
 
 - It is now possible to Exclude a range from a fit range when doing a fit on the Fitting tab.
+- Added a 'Covariance Matrix' button to the Fitting tab that can be used to open and inspect the normalised covariance parameters of a fit.
 
 Improvements
 ############

--- a/scripts/Muon/GUI/Common/fitting_widgets/basic_fitting/basic_fitting_model.py
+++ b/scripts/Muon/GUI/Common/fitting_widgets/basic_fitting/basic_fitting_model.py
@@ -106,6 +106,15 @@ class BasicFittingModel:
         """Sets the currently selected dataset name to have a different name."""
         self.fitting_context.dataset_names[self.fitting_context.current_dataset_index] = name
 
+    def current_normalised_covariance_matrix(self) -> StaticWorkspaceWrapper:
+        """Returns the Normalised Covariance matrix for the currently selected data."""
+        return self._get_normalised_covariance_matrix_for(self.get_active_workspace_names(),
+                                                          self.fitting_context.function_name)
+
+    def has_normalised_covariance_matrix(self) -> bool:
+        """Returns true if a Normalised Covariance matrix exists for the currently selected dataset."""
+        return self.current_normalised_covariance_matrix() is not None
+
     @property
     def number_of_datasets(self) -> int:
         """Returns the number of datasets stored by the model."""
@@ -701,6 +710,11 @@ class BasicFittingModel:
         """Creates the FitPlotInformation storing fit data to be plotted in the plot widget."""
         return [FitPlotInformation(input_workspaces=workspace_names,
                                    fit=self._get_fit_results_from_context(workspace_names, function_name))]
+
+    def _get_normalised_covariance_matrix_for(self, workspace_names: list, function_name: str) -> StaticWorkspaceWrapper:
+        """Returns the Normalised Covariance Matrix associated with some input workspaces and a function name."""
+        fit = self._get_fit_results_from_context(workspace_names, function_name)
+        return fit.covariance_workspace if fit is not None else None
 
     def _get_fit_results_from_context(self, workspace_names: list, function_name: str) -> FitInformation:
         """Gets the fit results from the context using the workspace names and function name."""

--- a/scripts/Muon/GUI/Common/fitting_widgets/basic_fitting/basic_fitting_presenter.py
+++ b/scripts/Muon/GUI/Common/fitting_widgets/basic_fitting/basic_fitting_presenter.py
@@ -60,6 +60,7 @@ class BasicFittingPresenter:
         self.view.set_slot_for_plot_guess_changed(self.handle_plot_guess_changed)
         self.view.set_slot_for_fit_name_changed(self.handle_function_name_changed_by_user)
         self.view.set_slot_for_dataset_changed(self.handle_dataset_name_changed)
+        self.view.set_slot_for_covariance_matrix_clicked(self.handle_covariance_matrix_clicked)
         self.view.set_slot_for_function_structure_changed(self.handle_function_structure_changed)
         self.view.set_slot_for_function_parameter_changed(
             lambda function_index, parameter: self.handle_function_parameter_changed(function_index, parameter))
@@ -206,6 +207,12 @@ class BasicFittingPresenter:
 
         self.update_plot_fit()
         self.update_plot_guess()
+
+    def handle_covariance_matrix_clicked(self) -> None:
+        """Handle when the Covariance Matrix button is clicked."""
+        covariance_matrix = self.model.current_normalised_covariance_matrix()
+        if covariance_matrix is not None:
+            self.view.show_normalised_covariance_matrix(covariance_matrix.workspace, covariance_matrix.workspace_name)
 
     def handle_function_name_changed_by_user(self) -> None:
         """Handle when the fit name is changed by the user."""

--- a/scripts/Muon/GUI/Common/fitting_widgets/basic_fitting/basic_fitting_presenter.py
+++ b/scripts/Muon/GUI/Common/fitting_widgets/basic_fitting/basic_fitting_presenter.py
@@ -132,6 +132,7 @@ class BasicFittingPresenter:
 
         self.update_fit_function_in_view_from_model()
         self.update_fit_statuses_and_chi_squared_in_view_from_model()
+        self.update_covariance_matrix_button()
 
         self.update_plot_fit()
         self.update_plot_guess()
@@ -176,6 +177,7 @@ class BasicFittingPresenter:
         self.update_fit_function_in_model(fit_function)
 
         self.update_fit_statuses_and_chi_squared_in_view_from_model()
+        self.update_covariance_matrix_button()
         self.update_fit_function_in_view_from_model()
 
         self.update_plot_fit()
@@ -198,6 +200,7 @@ class BasicFittingPresenter:
         self.model.current_dataset_index = self.view.current_dataset_index
 
         self.update_fit_statuses_and_chi_squared_in_view_from_model()
+        self.update_covariance_matrix_button()
         self.update_fit_function_in_view_from_model()
         self.update_start_and_end_x_in_view_from_model()
 
@@ -356,6 +359,10 @@ class BasicFittingPresenter:
         self.view.update_local_fit_status_and_chi_squared(self.model.current_fit_status,
                                                           self.model.current_chi_squared)
         self.view.update_global_fit_status(self.model.fit_statuses, self.model.current_dataset_index)
+
+    def update_covariance_matrix_button(self) -> None:
+        """Updates the covariance matrix button to be enabled if a covariance matrix exists for the selected data."""
+        self.view.set_covariance_button_enabled(self.model.has_normalised_covariance_matrix())
 
     def update_start_and_end_x_in_view_from_model(self) -> None:
         """Updates the start and end x in the view using the current values in the model."""

--- a/scripts/Muon/GUI/Common/fitting_widgets/basic_fitting/basic_fitting_view.py
+++ b/scripts/Muon/GUI/Common/fitting_widgets/basic_fitting/basic_fitting_view.py
@@ -4,7 +4,7 @@
 #   NScD Oak Ridge National Laboratory, European Spallation Source,
 #   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
 # SPDX - License - Identifier: GPL - 3.0 +
-from mantid.api import IFunction
+from mantid.api import IFunction, ITableWorkspace
 from mantidqt.utils.observer_pattern import GenericObserver
 from mantidqt.utils.qt import load_ui
 
@@ -60,6 +60,10 @@ class BasicFittingView(ui_form, base_widget):
     def set_slot_for_dataset_changed(self, slot) -> None:
         """Connect the slot for the display workspace combo box being changed."""
         self.workspace_selector.set_slot_for_dataset_changed(slot)
+
+    def set_slot_for_covariance_matrix_clicked(self, slot) -> None:
+        """Connect the slot for the Covariance Matrix button being clicked."""
+        self.fit_function_options.set_slot_for_covariance_matrix_clicked(slot)
 
     def set_slot_for_fit_name_changed(self, slot) -> None:
         """Connect the slot for the fit name being changed by the user."""
@@ -298,6 +302,10 @@ class BasicFittingView(ui_form, base_widget):
     def set_covariance_button_enabled(self, enabled: bool) -> None:
         """Sets whether the Covariance Matrix button is enabled or not."""
         self.fit_function_options.set_covariance_button_enabled(enabled)
+
+    def show_normalised_covariance_matrix(self, covariance_ws: ITableWorkspace, workspace_name: str) -> None:
+        """Shows the normalised covariance matrix in a separate table display window."""
+        self.fit_function_options.show_normalised_covariance_matrix(covariance_ws, workspace_name)
 
     def disable_view(self) -> None:
         """Disable all widgets in this fitting widget."""

--- a/scripts/Muon/GUI/Common/fitting_widgets/basic_fitting/basic_fitting_view.py
+++ b/scripts/Muon/GUI/Common/fitting_widgets/basic_fitting/basic_fitting_view.py
@@ -295,6 +295,10 @@ class BasicFittingView(ui_form, base_widget):
         """Sets whether the exclude start and end x options are visible."""
         self.fit_function_options.set_exclude_start_and_end_x_visible(visible)
 
+    def set_covariance_button_enabled(self, enabled: bool) -> None:
+        """Sets whether the Covariance Matrix button is enabled or not."""
+        self.fit_function_options.set_covariance_button_enabled(enabled)
+
     def disable_view(self) -> None:
         """Disable all widgets in this fitting widget."""
         self.setEnabled(False)

--- a/scripts/Muon/GUI/Common/fitting_widgets/basic_fitting/fit_function_options.ui
+++ b/scripts/Muon/GUI/Common/fitting_widgets/basic_fitting/fit_function_options.ui
@@ -98,7 +98,7 @@
      </widget>
     </widget>
    </item>
-   <item row="0" column="0">
+   <item row="0" column="0" colspan="2">
     <widget class="QFrame" name="frame">
      <layout class="QHBoxLayout" name="horizontalLayout_2">
       <property name="leftMargin">
@@ -164,6 +164,16 @@
          </size>
         </property>
        </spacer>
+      </item>
+      <item>
+       <widget class="QPushButton" name="covariance_matrix_button">
+        <property name="toolTip">
+         <string>Open the Normalised Covariance Matrix</string>
+        </property>
+        <property name="text">
+         <string>Covariance Matrix</string>
+        </property>
+       </widget>
       </item>
      </layout>
     </widget>

--- a/scripts/Muon/GUI/Common/fitting_widgets/basic_fitting/fit_function_options_view.py
+++ b/scripts/Muon/GUI/Common/fitting_widgets/basic_fitting/fit_function_options_view.py
@@ -4,9 +4,10 @@
 #   NScD Oak Ridge National Laboratory, European Spallation Source,
 #   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
 # SPDX - License - Identifier: GPL - 3.0 +
-from mantid.api import IFunction
+from mantid.api import IFunction, ITableWorkspace
 from mantidqt.utils.qt import load_ui
 from mantidqt.widgets.functionbrowser import FunctionBrowser
+from mantidqt.widgets.workspacedisplay.table.presenter import TableWorkspaceDisplay
 
 from Muon.GUI.Common.utilities import table_utils
 
@@ -59,6 +60,10 @@ class FitFunctionOptionsView(ui_form, base_widget):
         self.function_browser.setErrorsEnabled(True)
         self.function_browser.hideGlobalCheckbox()
         self.function_browser.setStretchLastColumn(True)
+
+    def set_slot_for_covariance_matrix_clicked(self, slot) -> None:
+        """Connect the slot for the Covariance Matrix button being clicked."""
+        self.covariance_matrix_button.clicked.connect(slot)
 
     def set_slot_for_fit_name_changed(self, slot) -> None:
         """Connect the slot for the fit name being changed by the user."""
@@ -310,6 +315,11 @@ class FitFunctionOptionsView(ui_form, base_widget):
     def set_covariance_button_enabled(self, enabled: bool) -> None:
         """Sets whether the Covariance Matrix button is enabled or not."""
         self.covariance_matrix_button.setEnabled(enabled)
+
+    def show_normalised_covariance_matrix(self, covariance_ws: ITableWorkspace, workspace_name: str) -> None:
+        """Shows the normalised covariance matrix in a separate table display window."""
+        table_display = TableWorkspaceDisplay(covariance_ws, parent=self, name=workspace_name)
+        table_display.show_view()
 
     def _setup_fit_options_table(self) -> None:
         """Setup the fit options table with the appropriate options."""

--- a/scripts/Muon/GUI/Common/fitting_widgets/basic_fitting/fit_function_options_view.py
+++ b/scripts/Muon/GUI/Common/fitting_widgets/basic_fitting/fit_function_options_view.py
@@ -307,6 +307,10 @@ class FitFunctionOptionsView(ui_form, base_widget):
             self.fit_options_table.hideRow(EXCLUDE_START_X_TABLE_ROW)
             self.fit_options_table.hideRow(EXCLUDE_END_X_TABLE_ROW)
 
+    def set_covariance_button_enabled(self, enabled: bool) -> None:
+        """Sets whether the Covariance Matrix button is enabled or not."""
+        self.covariance_matrix_button.setEnabled(enabled)
+
     def _setup_fit_options_table(self) -> None:
         """Setup the fit options table with the appropriate options."""
         self.fit_options_table.setRowCount(8)

--- a/scripts/Muon/GUI/Common/test_helpers/fitting_mock_setup.py
+++ b/scripts/Muon/GUI/Common/test_helpers/fitting_mock_setup.py
@@ -19,6 +19,7 @@ def add_mock_methods_to_basic_fitting_view(view):
     view.set_slot_for_undo_fit_clicked = mock.Mock()
     view.set_slot_for_plot_guess_changed = mock.Mock()
     view.set_slot_for_fit_name_changed = mock.Mock()
+    view.set_slot_for_covariance_matrix_clicked = mock.Mock()
     view.set_slot_for_function_structure_changed = mock.Mock()
     view.set_slot_for_function_parameter_changed = mock.Mock()
     view.set_slot_for_start_x_updated = mock.Mock()
@@ -43,6 +44,8 @@ def add_mock_methods_to_basic_fitting_view(view):
     view.switch_to_single = mock.Mock()
     view.disable_view = mock.Mock()
     view.set_exclude_start_and_end_x_visible = mock.Mock()
+    view.set_covariance_button_enabled = mock.Mock()
+    view.show_normalised_covariance_matrix = mock.Mock()
     return view
 
 
@@ -69,6 +72,7 @@ def add_mock_methods_to_basic_fitting_model(model, dataset_names, current_datase
     model.get_workspace_names_to_display_from_context = mock.Mock(return_value=dataset_names)
     model.perform_fit = mock.Mock(return_value=(fit_function, fit_status, chi_squared))
     model.number_of_undos = mock.Mock(return_value=1)
+    model.has_normalised_covariance_matrix = mock.Mock(return_value=True)
     return model
 
 
@@ -145,6 +149,8 @@ class MockBasicFitting:
         self.view = add_mock_methods_to_basic_fitting_view(self.view)
 
         # Mock the properties of the view
+        self.mock_view_current_dataset_index = mock.PropertyMock(return_value=self.current_dataset_index)
+        type(self.view).current_dataset_index = self.mock_view_current_dataset_index
         self.mock_view_minimizer = mock.PropertyMock(return_value=self.minimizer)
         type(self.view).minimizer = self.mock_view_minimizer
         self.mock_view_evaluation_type = mock.PropertyMock(return_value=self.evaluation_type)

--- a/scripts/test/Muon/fitting_widgets/basic_fitting/basic_fitting_model_test.py
+++ b/scripts/test/Muon/fitting_widgets/basic_fitting/basic_fitting_model_test.py
@@ -8,10 +8,11 @@ import unittest
 from unittest import mock
 
 from mantid.api import AnalysisDataService, FrameworkManager, FunctionFactory
-from mantid.simpleapi import CreateSampleWorkspace
+from mantid.simpleapi import CreateEmptyTableWorkspace, CreateSampleWorkspace
 
 from Muon.GUI.Common.fitting_widgets.basic_fitting.basic_fitting_model import BasicFittingModel, DEFAULT_START_X
 from Muon.GUI.Common.test_helpers.context_setup import setup_context
+from Muon.GUI.Common.utilities.workspace_utils import StaticWorkspaceWrapper
 
 
 class BasicFittingModelTest(unittest.TestCase):
@@ -463,6 +464,27 @@ class BasicFittingModelTest(unittest.TestCase):
 
     def test_that_get_active_fit_results_returns_an_empty_list_if_there_are_no_datasets(self):
         self.assertEqual(self.model.get_active_fit_results(), [])
+
+    def test_that_current_normalised_covariance_matrix_returns_none_when_there_are_no_fits(self):
+        self.assertEqual(self.model.current_normalised_covariance_matrix(), None)
+
+    def test_that_current_normalised_covariance_matrix_will_return_a_statix_workspace_wrapper_when_a_fit_exists(self):
+        ws = CreateEmptyTableWorkspace()
+        wrapper = StaticWorkspaceWrapper("CovarianceMatrix", ws)
+        self.model._get_normalised_covariance_matrix_for = mock.Mock(return_value=wrapper)
+
+        covariance_wrapper = self.model.current_normalised_covariance_matrix()
+        self.assertEqual(covariance_wrapper, wrapper)
+
+    def test_that_has_normalised_covariance_matrix_returns_false_when_there_is_not_a_covariance_matrix(self):
+        self.assertTrue(not self.model.has_normalised_covariance_matrix())
+
+    def test_that_has_normalised_covariance_matrix_returns_true_when_there_is_not_a_covariance_matrix(self):
+        ws = CreateEmptyTableWorkspace()
+        wrapper = StaticWorkspaceWrapper("CovarianceMatrix", ws)
+        self.model._get_normalised_covariance_matrix_for = mock.Mock(return_value=wrapper)
+
+        self.assertTrue(self.model.has_normalised_covariance_matrix())
 
     def test_update_plot_guess_will_evaluate_the_function(self):
         guess_workspace_name = "__frequency_domain_analysis_fitting_guessName1"

--- a/scripts/test/Muon/fitting_widgets/basic_fitting/fit_function_options_view_test.py
+++ b/scripts/test/Muon/fitting_widgets/basic_fitting/fit_function_options_view_test.py
@@ -7,11 +7,13 @@
 import unittest
 
 from mantid.api import FrameworkManager, FunctionFactory
+from mantid.simpleapi import CreateEmptyTableWorkspace
 from mantidqt.utils.qt.testing import start_qapplication
 from mantidqt.utils.qt.testing.qt_widget_finder import QtWidgetFinder
 
 from Muon.GUI.Common.fitting_widgets.basic_fitting.fit_function_options_view import (FitFunctionOptionsView,
                                                                                      RAW_DATA_TABLE_ROW)
+from Muon.GUI.Common.utilities.workspace_utils import StaticWorkspaceWrapper
 
 from qtpy.QtWidgets import QApplication
 
@@ -160,6 +162,22 @@ class FitFunctionOptionsViewTest(unittest.TestCase, QtWidgetFinder):
         self.view.function_name = new_function_name
 
         self.assertEqual(self.view.function_name, new_function_name)
+
+    def test_that_set_covariance_button_enabled_can_disable_the_covariance_button(self):
+        self.assertTrue(self.view.covariance_matrix_button.isEnabled())
+        self.view.set_covariance_button_enabled(False)
+        self.assertTrue(not self.view.covariance_matrix_button.isEnabled())
+
+    def test_that_set_covariance_button_enabled_can_enable_the_covariance_button(self):
+        self.view.set_covariance_button_enabled(False)
+        self.view.set_covariance_button_enabled(True)
+        self.assertTrue(self.view.covariance_matrix_button.isEnabled())
+
+    def test_that_show_normalised_covariance_matrix_will_not_raise_an_error(self):
+        ws = CreateEmptyTableWorkspace()
+        wrapper = StaticWorkspaceWrapper("CovarianceMatrix", ws)
+
+        self.view.show_normalised_covariance_matrix(wrapper.workspace, wrapper.workspace_name)
 
 
 if __name__ == '__main__':

--- a/scripts/test/Muon/fitting_widgets/general_fitting/general_fitting_presenter_test.py
+++ b/scripts/test/Muon/fitting_widgets/general_fitting/general_fitting_presenter_test.py
@@ -169,24 +169,6 @@ class GeneralFittingPresenterTest(unittest.TestCase):
         self.presenter.clear_undo_data.assert_called_once_with()
         self.presenter.simultaneous_fit_by_specifier_changed.notify_subscribers.assert_called_once_with()
 
-    def test_that_handle_dataset_name_changed_will_update_the_model_and_view(self):
-        self.presenter.update_fit_statuses_and_chi_squared_in_view_from_model = mock.Mock()
-        self.presenter.update_fit_function_in_view_from_model = mock.Mock()
-        self.presenter.update_start_and_end_x_in_view_from_model = mock.Mock()
-
-        self.presenter.handle_dataset_name_changed()
-
-        self.mock_view_current_dataset_index.assert_called_once_with()
-        self.mock_model_current_dataset_index.assert_called_once_with(self.current_dataset_index)
-
-        self.presenter.update_fit_statuses_and_chi_squared_in_view_from_model.assert_called_once_with()
-        self.presenter.update_fit_function_in_view_from_model.assert_called_once_with()
-        self.presenter.update_start_and_end_x_in_view_from_model.assert_called_once_with()
-
-        self.model.update_plot_guess.assert_called_once_with()
-
-        self.presenter.selected_fit_results_changed.notify_subscribers.assert_called_once_with([])
-
     def test_that_set_selected_dataset_will_set_the_dataset_name_in_the_view(self):
         dataset_name = "Name2"
 


### PR DESCRIPTION
**Description of work.**
This PR adds a button to the Fitting tab in MA and FDA (and also to Model fitting in MA) which will open the Normalised Covariance Matrix of the selected fit when clicked.

This is a requirement for the WIMDA Replacement project.

**To test:**
Open MA and load `MUSR62260`
Go to Fitting Tab and notice the `Covariance Matrix` button is disabled
Add a GausOsc function, and do a fit
The `Covariance Matrix` button becomes enabled.
Click the button and the covariance matrix should open.
Switch to a different dataset using `>>` and see the button is disabled. Switch back to the dataset with a fit and see the button becomes enabled again.
Undo the fit and the button should become disabled.

Fixes #32046

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
