### PR TITLE
Make all FqFit functions available in FqFitTab

### DIFF
--- a/qt/scientific_interfaces/Indirect/IndirectDataAnalysisFqFitTab.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectDataAnalysisFqFitTab.cpp
@@ -55,6 +55,7 @@ IndirectDataAnalysisFqFitTab::IndirectDataAnalysisFqFitTab(QWidget *parent)
   setOutputOptionsView(m_uiForm->ovOutputOptionsView);
 
   m_uiForm->dockArea->m_fitPropertyBrowser->setFunctionTemplateBrowser(templateBrowser);
+  templateBrowser->updateAvailableFunctions(availableFits.at(DataType::ALL));
   setFitPropertyBrowser(m_uiForm->dockArea->m_fitPropertyBrowser);
   m_uiForm->dockArea->m_fitPropertyBrowser->setHiddenProperties(FQFIT_HIDDEN_PROPS);
 


### PR DESCRIPTION
Previously when in single fit FqFit tab would change the avialable functions based on if EISF or width was loaded, now with only multiple we want all functions available regardless.

**To test:**

1. Open Indirect Data Analysis FqFit
2. Check that the fit functions available contain EISF functions as well as width functions.
3. load width data.
4. check that width funtions fit to the data
5. load EISF data.
6. check that EISF function fit to the data.
7. load both types and check that all functions are still available and can run even if the fit is not good.

*There is no associated issue.*

*This does not require release notes* because **It fixes an issue introduced in this release**

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
