### PR TITLE
Sliceviewer cursor tracking fix for MDHistograms

### DIFF
--- a/docs/source/release/v6.2.0/framework.rst
+++ b/docs/source/release/v6.2.0/framework.rst
@@ -55,5 +55,6 @@ Improvements
 
 Bugfixes
 ########
+- Fix cursor tracking from getting stuck and displaying incorrect signals when viewing MDHistogram workspaces in :ref:`sliceviewer`.
 
 :ref:`Release 6.2.0 <v6.2.0>`

--- a/docs/source/release/v6.2.0/mantidworkbench.rst
+++ b/docs/source/release/v6.2.0/mantidworkbench.rst
@@ -13,6 +13,4 @@ New and Improved
 Bugfixes
 --------
 
-- Fix cursor tracking from getting stuck and displaying incorrect signals when viewing MDHistogram workspaces in :ref:`sliceviewer`.
-
 :ref:`Release 6.2.0 <v6.2.0>`

--- a/docs/source/release/v6.2.0/mantidworkbench.rst
+++ b/docs/source/release/v6.2.0/mantidworkbench.rst
@@ -13,4 +13,6 @@ New and Improved
 Bugfixes
 --------
 
+- Fix cursor tracking from getting stuck and displaying incorrect signals when viewing MDHistogram workspaces in :ref:`sliceviewer`.
+
 :ref:`Release 6.2.0 <v6.2.0>`

--- a/qt/python/mantidqt/widgets/sliceviewer/imageinfowidget.py
+++ b/qt/python/mantidqt/widgets/sliceviewer/imageinfowidget.py
@@ -26,12 +26,15 @@ ImageInfoWidget = import_qt('.._common', 'mantidqt.widgets', 'ImageInfoWidget')
 
 class ImageInfoTracker(CursorTracker):
     def __init__(self, image: Union[AxesImage, QuadMesh], transform: NonOrthogonalTransform,
-                 do_transform: bool, widget: ImageInfoWidget, cursor_transform):
+                 do_transform: bool, widget: ImageInfoWidget, cursor_transform: tuple = None):
         """
         Update the image that the widget refers too.
         :param: An AxesImage or Mesh instance to track
         :param: transpose_xy: If true the cursor position should be transposed
                 before sending to the table update
+        :param do_transform: Flag to perform transform for QuadMesh images
+        :param widget: ImageInfoWidget instance
+        :param cursor_transform: Full axes limits to use for mouse coord transform to use instead of image extents
         """
         super().__init__(image_axes=image.axes, autoconnect=False)
         self._image = image

--- a/qt/python/mantidqt/widgets/sliceviewer/imageinfowidget.py
+++ b/qt/python/mantidqt/widgets/sliceviewer/imageinfowidget.py
@@ -13,6 +13,7 @@ import numpy as np
 from mantidqt.utils.qt import import_qt
 from matplotlib.collections import QuadMesh
 from matplotlib.image import AxesImage
+from matplotlib.transforms import Bbox
 
 from .lineplots import CursorTracker, cursor_info
 from .transform import NonOrthogonalTransform
@@ -25,7 +26,7 @@ ImageInfoWidget = import_qt('.._common', 'mantidqt.widgets', 'ImageInfoWidget')
 
 class ImageInfoTracker(CursorTracker):
     def __init__(self, image: Union[AxesImage, QuadMesh], transform: NonOrthogonalTransform,
-                 do_transform: bool, widget: ImageInfoWidget):
+                 do_transform: bool, widget: ImageInfoWidget, cursor_transform):
         """
         Update the image that the widget refers too.
         :param: An AxesImage or Mesh instance to track
@@ -37,6 +38,10 @@ class ImageInfoTracker(CursorTracker):
         self.transform = transform
         self.do_transform = do_transform
         self._widget = widget
+        self._cursor_transform = None
+        if cursor_transform is not None:
+            self._cursor_transform = Bbox([[cursor_transform[1][0], cursor_transform[0][0]],
+                                           [cursor_transform[1][1], cursor_transform[0][1]]])
 
         if hasattr(image, 'get_extent'):
             self.on_cursor_at = self._on_cursor_at_axesimage
@@ -59,7 +64,7 @@ class ImageInfoTracker(CursorTracker):
         if self._image is None:
             return
 
-        cinfo = cursor_info(self._image, xdata, ydata)
+        cinfo = cursor_info(self._image, xdata, ydata, full_bbox=self._cursor_transform)
         if cinfo is not None:
             arr, _, (i, j) = cinfo
             if (0 <= i < arr.shape[0]) and (0 <= j < arr.shape[1]) and not np.ma.is_masked(arr[i, j]):

--- a/qt/python/mantidqt/widgets/sliceviewer/lineplots.py
+++ b/qt/python/mantidqt/widgets/sliceviewer/lineplots.py
@@ -397,12 +397,13 @@ CursorInfo = namedtuple("CursorInfo", ("array", "extent", "point"))
 
 
 @lru_cache(maxsize=32)
-def cursor_info(image: AxesImage, xdata: float, ydata: float, full_bbox=None) -> Optional[CursorInfo]:
+def cursor_info(image: AxesImage, xdata: float, ydata: float, full_bbox: Bbox = None) -> Optional[CursorInfo]:
     """Return information on the image for the given position in
     data coordinates.
     :param image: An instance of an image type
     :param xdata: X data coordinate of cursor
     :param xdata: Y data coordinate of cursor
+    :param full_bbox: Bbox of full workspace dimension to use for transforming mouse position
     :return: None if point is not valid on the image else return CursorInfo type
     """
     extent = image.get_extent()
@@ -413,6 +414,10 @@ def cursor_info(image: AxesImage, xdata: float, ydata: float, full_bbox=None) ->
     if full_bbox is None:
         trans = BboxTransform(boxin=data_extent, boxout=array_extent)
     else:
+        # If the view is zoomed in and the slice is changed, then the image extents
+        # and data extents change. This causes the cursor to be transformed to the
+        # wrong point for certain MDH workspaces (since it cannot be dynamically rebinned).
+        # This will use the full WS data dimensions to do the transformation
         trans = BboxTransform(boxin=full_bbox, boxout=array_extent)
     point = trans.transform_point([ydata, xdata])
     if any(np.isnan(point)):

--- a/qt/python/mantidqt/widgets/sliceviewer/lineplots.py
+++ b/qt/python/mantidqt/widgets/sliceviewer/lineplots.py
@@ -397,7 +397,7 @@ CursorInfo = namedtuple("CursorInfo", ("array", "extent", "point"))
 
 
 @lru_cache(maxsize=32)
-def cursor_info(image: AxesImage, xdata: float, ydata: float) -> Optional[CursorInfo]:
+def cursor_info(image: AxesImage, xdata: float, ydata: float, full_bbox=None) -> Optional[CursorInfo]:
     """Return information on the image for the given position in
     data coordinates.
     :param image: An instance of an image type
@@ -410,7 +410,10 @@ def cursor_info(image: AxesImage, xdata: float, ydata: float) -> Optional[Cursor
     arr = image.get_array()
     data_extent = Bbox([[ymin, xmin], [ymax, xmax]])
     array_extent = Bbox([[0, 0], arr.shape[:2]])
-    trans = BboxTransform(boxin=data_extent, boxout=array_extent)
+    if full_bbox is None:
+        trans = BboxTransform(boxin=data_extent, boxout=array_extent)
+    else:
+        trans = BboxTransform(boxin=full_bbox, boxout=array_extent)
     point = trans.transform_point([ydata, xdata])
     if any(np.isnan(point)):
         return None

--- a/qt/python/mantidqt/widgets/sliceviewer/view.py
+++ b/qt/python/mantidqt/widgets/sliceviewer/view.py
@@ -65,6 +65,7 @@ class SliceViewerDataView(QWidget):
         self._line_plots = None
         self._image_info_tracker = None
         self._region_selection_on = False
+        self._orig_lims = None
 
         # Dimension widget
         self.dimensions_layout = QGridLayout()
@@ -262,6 +263,7 @@ class SliceViewerDataView(QWidget):
         extent = self.image.get_extent()
         self.ax.set_xlim(extent[0], extent[1])
         self.ax.set_ylim(extent[2], extent[3])
+        self._orig_lims = self.get_axes_limits()
 
         self.draw_plot()
 
@@ -384,7 +386,8 @@ class SliceViewerDataView(QWidget):
         self._image_info_tracker = ImageInfoTracker(image=self.image,
                                                     transform=self.nonortho_transform,
                                                     do_transform=self.nonorthogonal_mode,
-                                                    widget=self.image_info_widget)
+                                                    widget=self.image_info_widget,
+                                                    cursor_transform=self._orig_lims)
 
         if state:
             self._image_info_tracker.connect()
@@ -462,7 +465,6 @@ class SliceViewerDataView(QWidget):
             return self.image.get_full_extent()
         else:
             return None
-
 
     def set_axes_limits(self, xlim, ylim):
         """

--- a/qt/python/mantidqt/widgets/sliceviewer/view.py
+++ b/qt/python/mantidqt/widgets/sliceviewer/view.py
@@ -254,8 +254,6 @@ class SliceViewerDataView(QWidget):
                                     transpose=self.dimensions.transpose,
                                     norm=self.colorbar.get_norm(),
                                     **kwargs)
-        self.on_track_cursor_state_change(self.track_cursor_checked())
-
         # ensure the axes data limits are updated to match the
         # image. For example if the axes were zoomed and the
         # swap dimensions was clicked we need to restore the
@@ -263,7 +261,11 @@ class SliceViewerDataView(QWidget):
         extent = self.image.get_extent()
         self.ax.set_xlim(extent[0], extent[1])
         self.ax.set_ylim(extent[2], extent[3])
+        # Set the original data limits which get passed to the ImageInfoWidget so that
+        # the mouse projection to data space is correct for MDH workspaces when zoomed/changing slices
         self._orig_lims = self.get_axes_limits()
+
+        self.on_track_cursor_state_change(self.track_cursor_checked())
 
         self.draw_plot()
 


### PR DESCRIPTION
**Description of work.**

If an MDHistogram workspace was loaded in sliceviewer and the user zoomed in on a portion of the image then changed slices, the cursor tracking widget would display incorrect values. This would also cause the mouse cursor to get "stuck" when viewing over parts of datasets.

This adds the original axes limits to the cursor tracker widget, so that the mouse transformation can use those instead of the image extents when zoomed in.

**To test:**

To observe the incorrect behavior before this fix, repeat these instructions using the current version of mantidworkbench.

```
n = 25 * 25 * 25
ws=CreateMDHistoWorkspace(Dimensionality=3, 
                        Extents='-4,4,-6,6, -1,1',\
                        SignalInput = [0.0] * n, 
                        ErrorInput = [1.0] * n,\
                        NumberOfBins='25,25,25',
                        Names='Dim1,Dim2,Dim3',
                        Units='MomentumTransfer,MomentumTransfer,MomentumTransfer')
EvaluateFunction('name=UserFunctionMD,Formula=sin(x)*sin(y)','ws', OutputWorkspace='ws')
```
- Open `ws` in sliceviewer.
- Zoom in to a region of the data. Pick a spot and move your cursor over it. Note the signal value in the cursor tracker widget.
- Without zooming out, change the slice and move your cursor back to the same spot. This should match the value from the previous slice. However, this will be incorrect if using the current release of `mantidworkbench`.

Test with real data:
```
LoadWANDSCD(IPTS=23858, RunNumbers=145309, OutputWorkspace='norm', Grouping='4x4')
LoadWANDSCD(IPTS=24695, RunNumbers='226469-228269', OutputWorkspace='data', Grouping='4x4')
ConvertWANDSCDtoQ(InputWorkspace='data',
                  NormalisationWorkspace='norm',
                  OutputWorkspace='out',
                  Frame='HKL',
                  UProj='1,0,0',
                  VProj='-1,2,0',
                  Wproj='0,0,1',
                  BinningDim0='-4,4,1200',
                  BinningDim1='-6,6,1200',
                  BinningDim2='-1,1,128')
```
Plot the `out` workspace in sliceviewer. Change slices until data is viewed, then zoom into a region. Change forward a slice, and move your cursor over the entire dataset. The cursor should track all data correctly. If using the current `mantidworkbench`, the cursor might get "stuck" over some parts of the data.


Version into `ornl-next`: #32053

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
