### PR TITLE
Change workflow diagrams from `.png` to `.svg`

### DIFF
--- a/docs/source/release/v6.2.0/mantidworkbench.rst
+++ b/docs/source/release/v6.2.0/mantidworkbench.rst
@@ -14,6 +14,7 @@ New and Improved
     :width: 500px
     :align: center
 
+- Workflow diagrams in help pages are now ``.svg`` rather than ``.png``
 - Peaks can now be added or removed from a PeaksWorkspace using the :ref:`peaks overlay <sliceviewer_peaks_overlay>` in :ref:`sliceviewer`.
 - The list of eligible workspaces in the `WorkspaceSelector` can now be sorted by name
 - New widget and workbench plugin: `WorkspaceCalculator`, allows to perform binary operations and scaling by a floating number on workspaces;

--- a/docs/sphinxext/mantiddoc/directives/diagram.py
+++ b/docs/sphinxext/mantiddoc/directives/diagram.py
@@ -86,7 +86,7 @@ class DiagramDirective(BaseDirective):
                 "Diagrams need to be referred to by their filename, including '.dot' extension.")
 
         in_path = os.path.join(env.srcdir, "diagrams", diagram_name)
-        out_path = os.path.join(diagrams_dir, diagram_name[:-4] + ".png")
+        out_path = os.path.join(diagrams_dir, diagram_name[:-4] + ".svg")
 
         #Generate the diagram
         try:
@@ -97,7 +97,7 @@ class DiagramDirective(BaseDirective):
 
         out_src = Template(in_src).substitute(STYLE)
         out_src = out_src.encode()
-        gviz = subprocess.Popen([dot_executable, "-Tpng", "-o", out_path], stdin=subprocess.PIPE)
+        gviz = subprocess.Popen([dot_executable, "-Tsvg", "-o", out_path], stdin=subprocess.PIPE)
         gviz.communicate(input=out_src)
         gviz.wait()
 


### PR DESCRIPTION
This makes them scale better in web browsers and smaller on disk.

**To test:**

Build the `docs-qtassistant` and `docs-qthelp` targets and see that the workflow diagrams render in the help system. `AlignAndFocusPowder` is an example.

*There is no associated issue.*

The version into `ornl-next` is #32054.

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
