### PR TITLE
Improve usability of run loading on fitting tab of Engineering Diffraction UI

### DIFF
--- a/docs/source/release/v6.2.0/diffraction.rst
+++ b/docs/source/release/v6.2.0/diffraction.rst
@@ -57,6 +57,7 @@ Improvements
 - The cropping/region of interest selection for Calibration/Focusing is now chosen only on the Calibration tab, to avoid confusion and duplication of input.
 - The region of interest for Calibration/Focusing can now be selected with a user-supplied custom calibration file.
 - The Focused Run Files input box defaults to the last runs focused on the Focus tab, even if multiple runs were focussed
+- The usability of the file finder on the Fitting tab has been improved by the addition of file filters based on unit and/or bank
 
 Bugfixes
 ########

--- a/qt/python/mantidqt/_common.sip
+++ b/qt/python/mantidqt/_common.sip
@@ -1033,6 +1033,8 @@ public:
     void setLastDirectory(const QString &lastDir);
     void setUseNativeWidget(bool native);
     void setProxyModel(QAbstractProxyModel* /Transfer/);
+    void readSettings(const QString &group);
+    void saveSettings(const QString &group);
 
 signals:
     void fileTextChanged(const QString & /*_t1*/);

--- a/qt/python/mantidqt/_common.sip
+++ b/qt/python/mantidqt/_common.sip
@@ -1031,6 +1031,8 @@ public:
     void findFiles(bool isModified);
     void isOptional(bool);
     void setLastDirectory(const QString &lastDir);
+    void setUseNativeWidget(bool native);
+    void setProxyModel(QAbstractProxyModel* /Transfer/);
 
 signals:
     void fileTextChanged(const QString & /*_t1*/);

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/FileFinderWidget.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/FileFinderWidget.h
@@ -11,6 +11,7 @@
 #include "MantidQtWidgets/Common/MantidWidget.h"
 #include "ui_FileFinderWidget.h"
 #include <QComboBox>
+#include <QFileDialog>
 #include <QMessageBox>
 #include <QSettings>
 #include <QString>
@@ -147,6 +148,8 @@ public:
   void setLastDirectory(const QString &lastDir) { m_lastDir = lastDir; }
   /// Set an arbitrary validator on the line edit
   void setTextValidator(const QValidator *validator);
+  void setUseNativeWidget(bool /*native*/);
+  void setProxyModel(QAbstractProxyModel *proxyModel);
 
 signals:
   /// Emitted when the file text changes
@@ -267,7 +270,12 @@ private:
   FindFilesThreadPoolManager m_pool;
   /// Handle to any results found
   FindFilesSearchResults m_cachedResults;
+  /// non-native QFileDialog
+  QFileDialog m_dialog;
+  /// flag to control use of m_dialog
+  bool m_useNativeDialog;
 };
+
 } // namespace API
 } // namespace MantidQt
 

--- a/qt/widgets/common/src/FileFinderWidget.cpp
+++ b/qt/widgets/common/src/FileFinderWidget.cpp
@@ -777,38 +777,35 @@ QString FileFinderWidget::openFileDialog() {
     m_fileFilter = createFileFilter();
   }
 
-  if (m_isForDirectory) {
-    QString file;
-    if (!m_useNativeDialog) {
+  if (!m_useNativeDialog) {
+    if (m_isForDirectory) {
+      m_dialog.setOption(QFileDialog::DontResolveSymlinks, false);
       m_dialog.setFileMode(QFileDialog::Directory);
-      m_dialog.setDirectory(dir);
-      m_dialog.exec();
-      filenames = m_dialog.selectedFiles();
-    } else
-      file = QFileDialog::getExistingDirectory(this, "Select directory", dir);
-    if (!file.isEmpty())
-      filenames.append(file);
-  } else if (m_allowMultipleFiles) {
-    if (!m_useNativeDialog) {
+    } else {
       m_dialog.setNameFilter(m_fileFilter);
-      m_dialog.setDirectory(dir);
-      m_dialog.exec();
-      filenames = m_dialog.selectedFiles();
-    } else
+      m_dialog.setOption(QFileDialog::DontResolveSymlinks);
+      if (m_allowMultipleFiles)
+        m_dialog.setFileMode(QFileDialog::ExistingFiles);
+      else
+        m_dialog.setFileMode(QFileDialog::ExistingFile);
+    }
+    m_dialog.setDirectory(dir);
+    m_dialog.exec();
+    filenames = m_dialog.selectedFiles();
+  } else {
+    if (m_isForDirectory) {
+      QString file = QFileDialog::getExistingDirectory(this, "Select directory", dir);
+      if (!file.isEmpty())
+        filenames.append(file);
+    } else if (m_allowMultipleFiles) {
       filenames = QFileDialog::getOpenFileNames(this, "Open file", dir, m_fileFilter, nullptr,
                                                 QFileDialog::DontResolveSymlinks);
-  } else {
-    QString file;
-    if (!m_useNativeDialog) {
-      m_dialog.setFileMode(QFileDialog::ExistingFile);
-      m_dialog.setDirectory(dir);
-      m_dialog.exec();
-      QString file = m_dialog.selectedFiles()[0];
-    } else
-      file =
+    } else {
+      QString file =
           QFileDialog::getOpenFileName(this, "Open file", dir, m_fileFilter, nullptr, QFileDialog::DontResolveSymlinks);
-    if (!file.isEmpty())
-      filenames.append(file);
+      if (!file.isEmpty())
+        filenames.append(file);
+    }
   }
 
   if (filenames.isEmpty()) {

--- a/qt/widgets/common/src/FileFinderWidget.cpp
+++ b/qt/widgets/common/src/FileFinderWidget.cpp
@@ -790,8 +790,8 @@ QString FileFinderWidget::openFileDialog() {
         m_dialog.setFileMode(QFileDialog::ExistingFile);
     }
     m_dialog.setDirectory(dir);
-    m_dialog.exec();
-    filenames = m_dialog.selectedFiles();
+    if (m_dialog.exec())
+      filenames = m_dialog.selectedFiles();
   } else {
     if (m_isForDirectory) {
       QString file = QFileDialog::getExistingDirectory(this, "Select directory", dir);

--- a/qt/widgets/common/src/FileFinderWidget.cpp
+++ b/qt/widgets/common/src/FileFinderWidget.cpp
@@ -962,6 +962,7 @@ void FileFinderWidget::setTextValidator(const QValidator *validator) { m_uiForm.
 void FileFinderWidget::setUseNativeWidget(bool native) {
   m_useNativeDialog = native;
   m_dialog.setOption(QFileDialog::DontUseNativeDialog);
+  m_dialog.setOption(QFileDialog::ReadOnly);
 }
 
 void FileFinderWidget::setProxyModel(QAbstractProxyModel *proxyModel) { m_dialog.setProxyModel(proxyModel); }

--- a/qt/widgets/common/src/FileFinderWidget.cpp
+++ b/qt/widgets/common/src/FileFinderWidget.cpp
@@ -42,8 +42,8 @@ FileFinderWidget::FileFinderWidget(QWidget *parent)
     : MantidWidget(parent), m_findRunFiles(true), m_isForDirectory(false), m_allowMultipleFiles(false),
       m_isOptional(false), m_multiEntry(false), m_buttonOpt(Text), m_fileProblem(""), m_entryNumProblem(""),
       m_algorithmProperty(""), m_fileExtensions(), m_extsAsSingleOption(true), m_liveButtonState(Hide),
-      m_showValidator(true), m_foundFiles(), m_lastFoundFiles(), m_lastDir(), m_fileFilter(), m_pool(),
-      m_useNativeDialog(true), m_dialog() {
+      m_showValidator(true), m_foundFiles(), m_lastFoundFiles(), m_lastDir(), m_fileFilter(), m_pool(), m_dialog(),
+      m_useNativeDialog(true) {
 
   m_uiForm.setupUi(this);
 

--- a/scripts/Engineering/gui/engineering_diffraction/presenter.py
+++ b/scripts/Engineering/gui/engineering_diffraction/presenter.py
@@ -82,6 +82,7 @@ class EngineeringDiffractionPresenter(object):
 
     def handle_close(self):
         self.fitting_presenter.data_widget.ads_observer.unsubscribe()
+        self.fitting_presenter.data_widget.view.saveSettings()
         self.fitting_presenter.plot_widget.view.ensure_fit_dock_closed()
 
     def open_help_window(self):

--- a/scripts/Engineering/gui/engineering_diffraction/tabs/fitting/data_handling/data_model.py
+++ b/scripts/Engineering/gui/engineering_diffraction/tabs/fitting/data_handling/data_model.py
@@ -6,7 +6,7 @@
 # SPDX - License - Identifier: GPL - 3.0 +
 from os import path
 
-from mantid.simpleapi import Load, logger, EnggEstimateFocussedBackground, ConvertUnits, Minus, AverageLogData, \
+from mantid.simpleapi import Load, logger, EnggEstimateFocussedBackground, Minus, AverageLogData, \
     CreateEmptyTableWorkspace, GroupWorkspaces, DeleteWorkspace, DeleteTableRows, RenameWorkspace, CreateWorkspace
 from Engineering.gui.engineering_diffraction.settings.settings_helper import get_setting
 from Engineering.gui.engineering_diffraction.tabs.common import output_settings
@@ -53,17 +53,15 @@ class FittingDataModel(object):
                     f"Failed to restore workspace: {ws_name}. Error: {e}. \n Continuing loading of other files.")
         self.update_log_workspace_group()
 
-    def load_files(self, filenames_string, xunit):
+    def load_files(self, filenames_string):
         self._last_added = []
         filenames = [name.strip() for name in filenames_string.split(",")]
         for filename in filenames:
-            ws_name = self._generate_workspace_name(filename, xunit)
+            ws_name = self._generate_workspace_name(filename)
             if ws_name not in self._loaded_workspaces:
                 try:
                     if not ADS.doesExist(ws_name):
                         ws = Load(filename, OutputWorkspace=ws_name)
-                        # temporary fix to ensure unit of ws matches unit box (which will soon be removed)
-                        ConvertUnits(InputWorkspace=ws, OutputWorkspace=ws_name, Target=xunit)
                     else:
                         ws = ADS.retrieve(ws_name)
                     if ws.getNumberHistograms() == 1:
@@ -376,10 +374,11 @@ class FittingDataModel(object):
         [ws_table.setCell(irow, icol, row[icol]) for icol in range(0, len(row))]
 
     @staticmethod
-    def _generate_workspace_name(filepath, xunit):
+    def _generate_workspace_name(filepath):
         wsname = path.splitext(path.split(filepath)[1])[0]
         # remove unit from fname if present as will convert unit to xunit in combo box temporarily until it is removed
         # Once combo box removed we can get unit from workspace post-loading (and call RenameWorkspace)
-        if wsname.endswith('_TOF') or wsname.endswith('_dSpacing'):
-            wsname = '_'.join(wsname.split('_')[0:-1])
-        return wsname + '_' + xunit
+        #if wsname.endswith('_TOF') or wsname.endswith('_dSpacing'):
+        #    wsname = '_'.join(wsname.split('_')[0:-1])
+        #return wsname + '_' + xunit
+        return wsname

--- a/scripts/Engineering/gui/engineering_diffraction/tabs/fitting/data_handling/data_model.py
+++ b/scripts/Engineering/gui/engineering_diffraction/tabs/fitting/data_handling/data_model.py
@@ -376,9 +376,4 @@ class FittingDataModel(object):
     @staticmethod
     def _generate_workspace_name(filepath):
         wsname = path.splitext(path.split(filepath)[1])[0]
-        # remove unit from fname if present as will convert unit to xunit in combo box temporarily until it is removed
-        # Once combo box removed we can get unit from workspace post-loading (and call RenameWorkspace)
-        #if wsname.endswith('_TOF') or wsname.endswith('_dSpacing'):
-        #    wsname = '_'.join(wsname.split('_')[0:-1])
-        #return wsname + '_' + xunit
         return wsname

--- a/scripts/Engineering/gui/engineering_diffraction/tabs/fitting/data_handling/data_presenter.py
+++ b/scripts/Engineering/gui/engineering_diffraction/tabs/fitting/data_handling/data_presenter.py
@@ -30,7 +30,8 @@ class FittingDataPresenter(object):
         self.view.set_on_seq_fit_clicked(self._start_seq_fit)
         self.view.set_on_serial_fit_clicked(self._start_serial_fit)
         self.view.set_on_table_cell_changed(self._handle_table_cell_changed)
-        self.view.set_on_xunit_changed(self._log_xunit_change)
+        self.view.set_on_bank_changed(self._update_file_filter)
+        self.view.set_on_xunit_changed(self._update_file_filter)
         self.view.set_table_selection_changed(self._handle_selection_changed)
 
         # Observable Setup
@@ -60,13 +61,13 @@ class FittingDataPresenter(object):
         ws_list = self.model.get_ws_list()
         self.fit_all_started_notifier.notify_subscribers(ws_list, do_sequential=False)
 
-    def _log_xunit_change(self, xunit):
-        logger.notice("Subsequent files will be loaded with the x-axis unit:\t{}".format(xunit))
+    def _update_file_filter(self, bank, xunit):
+        self.view.update_file_filter(bank, xunit)
 
-    def on_load_clicked(self, xunit):
+    def on_load_clicked(self):
         if self._validate():
             filenames = self._get_filenames()
-            self._start_load_worker(filenames, xunit)
+            self._start_load_worker(filenames)
 
     def remove_workspace(self, ws_name):
         if ws_name in self.get_loaded_workspaces():
@@ -116,12 +117,12 @@ class FittingDataPresenter(object):
     def restore_table(self):  # used when the interface is being restored from a save or crash
         self._repopulate_table()
 
-    def _start_load_worker(self, filenames, xunit):
+    def _start_load_worker(self, filenames):
         """
         Load one to many files into mantid that are tracked by the interface.
         :param filenames: Comma separated list of filenames to load
         """
-        self.worker = AsyncTask(self.model.load_files, (filenames, xunit),
+        self.worker = AsyncTask(self.model.load_files, (filenames,),
                                 error_cb=self._on_worker_error,
                                 finished_cb=self._emit_enable_load_button_signal,
                                 success_cb=self._on_worker_success)

--- a/scripts/Engineering/gui/engineering_diffraction/tabs/fitting/data_handling/data_view.py
+++ b/scripts/Engineering/gui/engineering_diffraction/tabs/fitting/data_handling/data_view.py
@@ -8,7 +8,7 @@ from qtpy import QtWidgets, QtCore
 from os import path
 
 from mantidqt.utils.qt import load_ui
-from Engineering.gui.engineering_diffraction.tabs.common import path_handling
+from Engineering.common import path_handling
 from fnmatch import fnmatch
 from os.path import splitext
 

--- a/scripts/Engineering/gui/engineering_diffraction/tabs/fitting/data_handling/data_view.py
+++ b/scripts/Engineering/gui/engineering_diffraction/tabs/fitting/data_handling/data_view.py
@@ -8,6 +8,7 @@ from qtpy import QtWidgets, QtCore
 from os import path
 
 from mantidqt.utils.qt import load_ui
+from Engineering.gui.engineering_diffraction.tabs.common import path_handling
 
 Ui_data, _ = load_ui(__file__, "data_widget.ui")
 
@@ -31,13 +32,15 @@ class FileFilterProxyModel (QtCore.QSortFilterProxyModel):
 class FittingDataView(QtWidgets.QWidget, Ui_data):
     sig_enable_load_button = QtCore.Signal(bool)
     sig_enable_inspect_bg_button = QtCore.Signal(bool)
-    proxy_model = FileFilterProxyModel()
+    proxy_model = None
 
     def __init__(self, parent=None):
         super(FittingDataView, self).__init__(parent)
         self.setupUi(self)
         # file finder
+        self.finder_data.readSettings(path_handling.INTERFACES_SETTINGS_GROUP + '/' + path_handling.ENGINEERING_PREFIX)
         self.finder_data.setUseNativeWidget(False)
+        self.proxy_model = FileFilterProxyModel()
         self.finder_data.setProxyModel(self.proxy_model)
         self.finder_data.setLabelText("Focused Run Files")
         self.finder_data.isForRunFiles(False)
@@ -45,6 +48,9 @@ class FittingDataView(QtWidgets.QWidget, Ui_data):
         self.finder_data.setFileExtensions([".nxs"])
         # xunit combo box
         self.setup_xunit_combobox()
+
+    def saveSettings(self):
+        self.finder_data.saveSettings(path_handling.INTERFACES_SETTINGS_GROUP + '/' + path_handling.ENGINEERING_PREFIX)
 
     # =================
     # Slot Connectors
@@ -181,10 +187,12 @@ class FittingDataView(QtWidgets.QWidget, Ui_data):
             self.get_table_item(row, col).setCheckState(QtCore.Qt.Unchecked)
 
     def update_file_filter(self, bank, xunit):
-        if bank == "North":
+        if bank == "1 (North)":
             self.proxy_model.text_filter = "bank_1"
-        elif bank == "South":
+        elif bank == "2 (South)":
             self.proxy_model.text_filter = "bank_2"
+        else:
+            self.proxy_model.text_filter = ""
         if xunit != "":
             self.proxy_model.text_filter += "_" + xunit
 

--- a/scripts/Engineering/gui/engineering_diffraction/tabs/fitting/data_handling/data_view.py
+++ b/scripts/Engineering/gui/engineering_diffraction/tabs/fitting/data_handling/data_view.py
@@ -50,6 +50,8 @@ class FittingDataView(QtWidgets.QWidget, Ui_data):
         self.finder_data.isForRunFiles(False)
         self.finder_data.allowMultipleFiles(True)
         self.finder_data.setFileExtensions([".nxs"])
+        # xunit combo box
+        self.setup_xunit_combobox()
         self.update_file_filter(self.combo_bank.currentText(), self.combo_xunit.currentText())
 
     def saveSettings(self):
@@ -233,3 +235,13 @@ class FittingDataView(QtWidgets.QWidget, Ui_data):
 
     def is_searching(self):
         return self.finder_data.isSearching()
+
+    # =================
+    # Internal Setup
+    # =================
+
+    def setup_xunit_combobox(self):
+        self.combo_xunit.setEditable(False)
+        # make TOF default
+        index = self.combo_xunit.findText("TOF")
+        self.combo_xunit.setCurrentIndex(index)

--- a/scripts/Engineering/gui/engineering_diffraction/tabs/fitting/data_handling/data_view.py
+++ b/scripts/Engineering/gui/engineering_diffraction/tabs/fitting/data_handling/data_view.py
@@ -8,7 +8,7 @@ from qtpy import QtWidgets, QtCore
 from os import path
 
 from mantidqt.utils.qt import load_ui
-from Engineering.common import path_handling
+from Engineering.gui.engineering_diffraction.tabs.common import output_settings
 from fnmatch import fnmatch
 from os.path import splitext
 
@@ -42,7 +42,7 @@ class FittingDataView(QtWidgets.QWidget, Ui_data):
         super(FittingDataView, self).__init__(parent)
         self.setupUi(self)
         # file finder
-        self.finder_data.readSettings(path_handling.INTERFACES_SETTINGS_GROUP + '/' + path_handling.ENGINEERING_PREFIX)
+        self.finder_data.readSettings(output_settings.INTERFACES_SETTINGS_GROUP + '/' + output_settings.ENGINEERING_PREFIX)
         self.finder_data.setUseNativeWidget(False)
         self.proxy_model = FileFilterProxyModel()
         self.finder_data.setProxyModel(self.proxy_model)
@@ -55,7 +55,7 @@ class FittingDataView(QtWidgets.QWidget, Ui_data):
         self.update_file_filter(self.combo_bank.currentText(), self.combo_xunit.currentText())
 
     def saveSettings(self):
-        self.finder_data.saveSettings(path_handling.INTERFACES_SETTINGS_GROUP + '/' + path_handling.ENGINEERING_PREFIX)
+        self.finder_data.saveSettings(output_settings.INTERFACES_SETTINGS_GROUP + '/' + output_settings.ENGINEERING_PREFIX)
 
     # =================
     # Slot Connectors

--- a/scripts/Engineering/gui/engineering_diffraction/tabs/fitting/data_handling/data_view.py
+++ b/scripts/Engineering/gui/engineering_diffraction/tabs/fitting/data_handling/data_view.py
@@ -48,6 +48,7 @@ class FittingDataView(QtWidgets.QWidget, Ui_data):
         self.finder_data.setFileExtensions([".nxs"])
         # xunit combo box
         self.setup_xunit_combobox()
+        self.update_file_filter(self.combo_bank.currentText(), self.combo_xunit.currentText())
 
     def saveSettings(self):
         self.finder_data.saveSettings(path_handling.INTERFACES_SETTINGS_GROUP + '/' + path_handling.ENGINEERING_PREFIX)

--- a/scripts/Engineering/gui/engineering_diffraction/tabs/fitting/data_handling/data_widget.ui
+++ b/scripts/Engineering/gui/engineering_diffraction/tabs/fitting/data_handling/data_widget.ui
@@ -63,14 +63,21 @@ QGroupBox:title {
         <item row="0" column="0" colspan="4">
          <widget class="FileFinderWidget" name="finder_data" native="true"/>
         </item>
-        <item row="2" column="3">
+        <item row="3" column="3">
          <widget class="QPushButton" name="button_load">
           <property name="text">
            <string>Load</string>
           </property>
          </widget>
         </item>
-        <item row="2" column="1">
+          <item row="1" column="0">
+           <widget class="QLabel" name="filterLabel">
+            <property name="text">
+             <string>File Filters:</string>
+            </property>
+           </widget>
+          </item>
+        <item row="1" column="1">
          <widget class="QComboBox" name="combo_xunit">
           <item>
            <property name="text">
@@ -84,33 +91,33 @@ QGroupBox:title {
           </item>
          </widget>
         </item>
-        <item row="2" column="2">
+        <item row="1" column="2">
          <widget class="QComboBox" name="combo_bank">
           <item>
            <property name="text">
-            <string></string>
+            <string>All</string>
            </property>
           </item>
           <item>
            <property name="text">
-            <string>North</string>
+            <string>1 (North)</string>
            </property>
           </item>
           <item>
            <property name="text">
-            <string>South</string>
+            <string>2 (South)</string>
            </property>
           </item>
          </widget>
         </item>
-        <item row="2" column="0">
+        <item row="3" column="2">
          <widget class="QCheckBox" name="check_addToPlot">
           <property name="text">
            <string>Add to Plot</string>
           </property>
          </widget>
         </item>
-        <item row="1" column="0" colspan="3">
+        <item row="2" column="0" colspan="4">
          <widget class="Line" name="line">
           <property name="minimumSize">
            <size>

--- a/scripts/Engineering/gui/engineering_diffraction/tabs/fitting/data_handling/data_widget.ui
+++ b/scripts/Engineering/gui/engineering_diffraction/tabs/fitting/data_handling/data_widget.ui
@@ -60,10 +60,10 @@ QGroupBox:title {
      <layout class="QGridLayout" name="gridLayout_2">
       <item row="0" column="0">
        <layout class="QGridLayout" name="gridLayout">
-        <item row="0" column="0" colspan="3">
+        <item row="0" column="0" colspan="4">
          <widget class="FileFinderWidget" name="finder_data" native="true"/>
         </item>
-        <item row="2" column="2">
+        <item row="2" column="3">
          <widget class="QPushButton" name="button_load">
           <property name="text">
            <string>Load</string>
@@ -80,6 +80,25 @@ QGroupBox:title {
           <item>
            <property name="text">
             <string>dSpacing</string>
+           </property>
+          </item>
+         </widget>
+        </item>
+        <item row="2" column="2">
+         <widget class="QComboBox" name="combo_bank">
+          <item>
+           <property name="text">
+            <string></string>
+           </property>
+          </item>
+          <item>
+           <property name="text">
+            <string>North</string>
+           </property>
+          </item>
+          <item>
+           <property name="text">
+            <string>South</string>
            </property>
           </item>
          </widget>

--- a/scripts/Engineering/gui/engineering_diffraction/tabs/fitting/data_handling/data_widget.ui
+++ b/scripts/Engineering/gui/engineering_diffraction/tabs/fitting/data_handling/data_widget.ui
@@ -73,12 +73,20 @@ QGroupBox:title {
           <item row="1" column="0">
            <widget class="QLabel" name="filterLabel">
             <property name="text">
-             <string>File Filters:</string>
+             <string>Browse Filters:</string>
             </property>
            </widget>
           </item>
-        <item row="1" column="1">
+        <item row="1" column="2">
          <widget class="QComboBox" name="combo_xunit">
+          <property name="toolTip">
+           <string>Units filter </string>
+          </property>
+          <item>
+           <property name="text">
+            <string>All</string>
+           </property>
+          </item>
           <item>
            <property name="text">
             <string>TOF</string>
@@ -91,8 +99,11 @@ QGroupBox:title {
           </item>
          </widget>
         </item>
-        <item row="1" column="2">
+        <item row="1" column="3">
          <widget class="QComboBox" name="combo_bank">
+          <property name="toolTip">
+           <string>Bank filter </string>
+          </property>
           <item>
            <property name="text">
             <string>All</string>

--- a/scripts/Engineering/gui/engineering_diffraction/tabs/fitting/data_handling/test/test_data_presenter.py
+++ b/scripts/Engineering/gui/engineering_diffraction/tabs/fitting/data_handling/test/test_data_presenter.py
@@ -49,10 +49,10 @@ class FittingDataPresenterTest(unittest.TestCase):
         self.view.get_filenames_to_load.return_value = "/a/file/to/load.txt, /another/one.nxs"
         self.model.load_files = "mocked model method"
 
-        self.presenter.on_load_clicked(xunit="TOF")
+        self.presenter.on_load_clicked()
 
         mock_worker.assert_called_with("mocked model method",
-                                       ("/a/file/to/load.txt, /another/one.nxs", "TOF"),
+                                       ("/a/file/to/load.txt, /another/one.nxs",),
                                        error_cb=self.presenter._on_worker_error,
                                        finished_cb=self.presenter._emit_enable_load_button_signal,
                                        success_cb=self.presenter._on_worker_success)
@@ -63,7 +63,7 @@ class FittingDataPresenterTest(unittest.TestCase):
         self.view.is_searching.return_value = True
         self.view.get_filenames_valid.return_value = True
 
-        self.presenter.on_load_clicked(xunit="TOF")
+        self.presenter.on_load_clicked()
 
         self.assertEqual(0, mock_worker.call_count)
         self.assertEqual(0, self.view.get_filenames_to_load.call_count)
@@ -75,7 +75,7 @@ class FittingDataPresenterTest(unittest.TestCase):
         self.view.is_searching.return_value = False
         self.view.get_filenames_valid.return_value = False
 
-        self.presenter.on_load_clicked(xunit="TOF")
+        self.presenter.on_load_clicked()
 
         self.assertEqual(0, mock_worker.call_count)
         self.assertEqual(0, self.view.get_filenames_to_load.call_count)

--- a/scripts/Engineering/gui/engineering_diffraction/test/engineering_diffraction_io_test.py
+++ b/scripts/Engineering/gui/engineering_diffraction/test/engineering_diffraction_io_test.py
@@ -125,7 +125,7 @@ class EngineeringDiffractionEncoderTest(unittest.TestCase):
                          test_dic)
 
     def test_loaded_workspaces_encode(self):
-        self.presenter.fitting_presenter.data_widget.presenter.model.load_files(TEST_FILE, 'TOF')
+        self.presenter.fitting_presenter.data_widget.presenter.model.load_files(TEST_FILE)
         self.fitprop_browser.read_current_fitprop.return_value = None
         test_dic = self.encoder.encode(self.mock_view)
         self.assertEqual({'encoder_version': IO_VERSION, 'current_tab': 0, 'data_loaded_workspaces': [TEST_WS],
@@ -134,7 +134,7 @@ class EngineeringDiffractionEncoderTest(unittest.TestCase):
                           'background_params': {'ENGINX_277208_focused_bank_2_TOF': []}}, test_dic)
 
     def test_background_params_encode(self):
-        self.presenter.fitting_presenter.data_widget.presenter.model.load_files(TEST_FILE, 'TOF')
+        self.presenter.fitting_presenter.data_widget.presenter.model.load_files(TEST_FILE)
         self.fitprop_browser.read_current_fitprop.return_value = None
         self.presenter.fitting_presenter.data_widget.model._bg_params = {TEST_WS: [True, 70, 4000, True]}
         test_dic = self.encoder.encode(self.mock_view)
@@ -144,7 +144,7 @@ class EngineeringDiffractionEncoderTest(unittest.TestCase):
                           'background_params': {TEST_WS: [True, 70, 4000, True]}}, test_dic)
 
     def test_fits_encode(self):
-        self.presenter.fitting_presenter.data_widget.presenter.model.load_files(TEST_FILE, 'TOF')
+        self.presenter.fitting_presenter.data_widget.presenter.model.load_files(TEST_FILE)
         self.presenter.fitting_presenter.data_widget.presenter.model._fit_results = FIT_RESULTS
         self.fitprop_browser.read_current_fitprop.return_value = FIT_DICT
         self.fitprop_browser.plotDiff.return_value = True

--- a/scripts/Engineering/gui/engineering_diffraction/test/engineering_diffraction_io_test.py
+++ b/scripts/Engineering/gui/engineering_diffraction/test/engineering_diffraction_io_test.py
@@ -31,7 +31,7 @@ from Engineering.gui.engineering_diffraction.settings.settings_presenter import 
 
 IO_VERSION = 1
 TEST_FILE = "ENGINX_277208_focused_bank_2.nxs"
-TEST_WS = 'ENGINX_277208_focused_bank_2_TOF'
+TEST_WS = 'ENGINX_277208_focused_bank_2'
 FIT_WS = TEST_WS + '_Workspace'
 FIT_DICT = {'peak_centre_params': ['Gaussian_PeakCentre', 'Gaussian_PeakCentre'],
             'properties': {'InputWorkspace': TEST_WS, 'Output': TEST_WS,
@@ -131,7 +131,7 @@ class EngineeringDiffractionEncoderTest(unittest.TestCase):
         self.assertEqual({'encoder_version': IO_VERSION, 'current_tab': 0, 'data_loaded_workspaces': [TEST_WS],
                           'plotted_workspaces': [], 'fit_properties': None, 'fit_results': {},
                           'settings_dict': SETTINGS_DICT,
-                          'background_params': {'ENGINX_277208_focused_bank_2_TOF': []}}, test_dic)
+                          'background_params': {'ENGINX_277208_focused_bank_2': []}}, test_dic)
 
     def test_background_params_encode(self):
         self.presenter.fitting_presenter.data_widget.presenter.model.load_files(TEST_FILE)
@@ -153,7 +153,7 @@ class EngineeringDiffractionEncoderTest(unittest.TestCase):
         self.assertEqual({'encoder_version': IO_VERSION, 'current_tab': 0, 'data_loaded_workspaces': [TEST_WS],
                           'plotted_workspaces': [FIT_WS], 'fit_properties': FIT_DICT, 'fit_results': FIT_RESULTS,
                           'plot_diff': 'True', 'settings_dict': SETTINGS_DICT,
-                          'background_params': {'ENGINX_277208_focused_bank_2_TOF': []}}, test_dic)
+                          'background_params': {'ENGINX_277208_focused_bank_2': []}}, test_dic)
 
 
 @start_qapplication


### PR DESCRIPTION
**Description of work.**

The File Finder widget on the Fitting tab has been updated to filter the files shown in the Browse dialog based on two combo boxes. The combo boxes allow the user to specify a unit (TOF or dSpacing) and\or a grouping (basically North or South bank):

![image](https://user-images.githubusercontent.com/56295817/126459236-d49a3690-5553-423c-8921-dbcf0662f013.png)

In order to get this to work a switch has been added to the FileFinderWidget that is fed through to the underlying QFileDialog object. QFileDialog can be set to use either a Qt file browse dialog or the OS-native file dialog. The Qt version is easier to customise and you can add custom file filters to it. On Windows at least it looks a bit more dated than the OS native dialog but hopefully overall this is an improvement. The switch is a method called FileFinderWidget::setUseNativeWidget

Note - there was already a unit dropdown prior to this PR. It used to drive a unit conversion into whatever unit was selected. This has been repurposed as a file filter and the unit conversion has been removed. The unit conversion feature is a hangover from an earlier version of the Focus tab where it used to output files in TOF only. The focussing now outputs TOF and dSpacing data so there's no longer a need for any unit conversion to occur

**To test:**

It's easiest to test if you have some focused data files already generated for a few runs. You'll need ISIS data archive access:

1. Go to Calibration tab
2. Fill in vanadium 236516 ceria 193749 
3. Hit Calibrate
4. Go to Focus tab
5. Enter 299080-299084
6. Hit Focus

Having done this go to the Fitting tab
Hit Browse
Based on an earlier PR (#32016) the folder should default to the folder where the focussing outputs the files. If for any reason this isn't what you see, go to the Engineering_Mantid\Focus folder in your user area (~ on linux or `C:\Users\<fedid>\ `on Windows)
You should see the set of focused .nxs files you just generated:

![image](https://user-images.githubusercontent.com/56295817/126462178-df307957-64d5-4d18-9026-bddced079c7f.png)

Observe that you only see a subset of file based on the choices made on the TOF or Grouping combo boxes

Finally, worth checking I've not broken the file finder widget by going to another user interface that uses eg Indirect, Corrections UI

Fixes #31690. 


---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
