### PR TITLE
Muon Background Subtraction - Minus the background from the counts

### DIFF
--- a/scripts/Muon/GUI/Common/ADSHandler/muon_workspace_wrapper.py
+++ b/scripts/Muon/GUI/Common/ADSHandler/muon_workspace_wrapper.py
@@ -15,9 +15,11 @@ def _add_workspace_to_group(group_name, workspace_name):
         workspaces_to_group = AnalysisDataService.retrieve(group_name).getNames()
     else:
         workspaces_to_group = []
-    workspaces_to_group.append(workspace_name)
-    WorkspaceGroupDefinition().add_workspaces_to_group(group_name, workspaces_to_group)
-    WorkspaceGroupDefinition().execute_grouping()
+
+    if workspace_name not in workspaces_to_group:
+        workspaces_to_group.append(workspace_name)
+        WorkspaceGroupDefinition().add_workspaces_to_group(group_name, workspaces_to_group)
+        WorkspaceGroupDefinition().execute_grouping()
 
 
 class MuonWorkspaceWrapper(object):

--- a/scripts/Muon/GUI/Common/calculate_pair_and_group.py
+++ b/scripts/Muon/GUI/Common/calculate_pair_and_group.py
@@ -10,7 +10,7 @@ from Muon.GUI.Common.muon_pair import MuonPair
 from typing import Iterable
 
 
-def calculate_group_data(context, group, run, rebin, workspace_name, periods):
+def calculate_group_data(context, group, run, workspace_name, periods):
     processed_data = get_pre_process_workspace_name(run, context.data_context.instrument)
 
     params = _get_MuonGroupingCounts_parameters(group, periods)
@@ -28,7 +28,7 @@ def calculate_pair_data(pair: MuonPair, forward_group: str, backward_group: str,
     return pair_data
 
 
-def estimate_group_asymmetry_data(context, group, run, rebin, workspace_name, unormalised_workspace_name, periods):
+def estimate_group_asymmetry_data(context, group, run, workspace_name, unormalised_workspace_name, periods):
     params = _get_EstimateMuonAsymmetryFromCounts_parameters(context, group, run, periods)
     params["InputWorkspace"] = workspace_name.replace("Asymmetry", "Counts")
     group_asymmetry, group_asymmetry_unnorm = \

--- a/scripts/Muon/GUI/Common/contexts/corrections_context.py
+++ b/scripts/Muon/GUI/Common/contexts/corrections_context.py
@@ -33,7 +33,7 @@ class CorrectionsContext:
 
     # The background corrections mode can be 'None', 'Auto' or 'Manual'
     background_corrections_mode: str = BACKGROUND_MODE_NONE
-    selected_function: str = FLAT_BACKGROUND
+    selected_function: str = FLAT_BACKGROUND_AND_EXP_DECAY
     selected_group: str = GROUPS_ALL
     show_all_runs: bool = False
 

--- a/scripts/Muon/GUI/Common/contexts/corrections_context.py
+++ b/scripts/Muon/GUI/Common/contexts/corrections_context.py
@@ -36,6 +36,7 @@ class CorrectionsContext:
     selected_function: str = FLAT_BACKGROUND_AND_EXP_DECAY
     selected_group: str = GROUPS_ALL
     show_all_runs: bool = False
+    show_rebin_data: bool = False
 
     # The background corrections data in each row of the table is mapped to its corresponding Run and Group
     # i.e. dict(tuple(run, group): BackgroundCorrectionData)

--- a/scripts/Muon/GUI/Common/contexts/corrections_context.py
+++ b/scripts/Muon/GUI/Common/contexts/corrections_context.py
@@ -36,7 +36,6 @@ class CorrectionsContext:
     selected_function: str = FLAT_BACKGROUND_AND_EXP_DECAY
     selected_group: str = GROUPS_ALL
     show_all_runs: bool = False
-    show_rebin_data: bool = False
 
     # The background corrections data in each row of the table is mapped to its corresponding Run and Group
     # i.e. dict(tuple(run, group): BackgroundCorrectionData)

--- a/scripts/Muon/GUI/Common/contexts/muon_context.py
+++ b/scripts/Muon/GUI/Common/contexts/muon_context.py
@@ -15,7 +15,7 @@ from Muon.GUI.Common.calculate_pair_and_group import calculate_group_data, calcu
     estimate_group_asymmetry_data, run_pre_processing
 from Muon.GUI.Common.utilities.run_string_utils import run_list_to_string, run_string_to_list
 from Muon.GUI.Common.utilities.algorithm_utils import run_PhaseQuad, split_phasequad, rebin_ws, apply_deadtime, \
-    calculate_diff_data, run_crop_workspace
+    run_minus, run_crop_workspace
 import Muon.GUI.Common.ADSHandler.workspace_naming as wsName
 from Muon.GUI.Common.ADSHandler.ADS_calls import retrieve_ws
 from Muon.GUI.Common.contexts.muon_group_pair_context import get_default_grouping
@@ -118,7 +118,7 @@ class MuonContext(object):
             return None
         run_as_string = run_list_to_string(run)
         output_workspace_name = get_diff_asymmetry_name(self, diff.name, run_as_string, rebin=rebin)
-        return calculate_diff_data(diff, positive_workspace_name, negative_workspace_name, output_workspace_name)
+        return run_minus(positive_workspace_name, negative_workspace_name, output_workspace_name)
 
     def calculate_pair(self, pair: MuonPair, run: List[int], rebin: bool=False):
         try:

--- a/scripts/Muon/GUI/Common/contexts/muon_context.py
+++ b/scripts/Muon/GUI/Common/contexts/muon_context.py
@@ -147,9 +147,6 @@ class MuonContext(object):
         output_workspace_name = get_pair_asymmetry_name(self, pair.name, run_as_string, rebin=rebin)
         return calculate_pair_data(pair, forward_group_workspace_name, backward_group_workspace_name, output_workspace_name)
 
-    def show_all_groups(self):
-        self.calculate_all_groups()
-
     def show_group(self, run, group):
         run_as_string = run_list_to_string(run)
         group_name = group.name

--- a/scripts/Muon/GUI/Common/contexts/muon_context.py
+++ b/scripts/Muon/GUI/Common/contexts/muon_context.py
@@ -198,12 +198,12 @@ class MuonContext(object):
             name = get_diff_asymmetry_name(self, diff_name, run_as_string, rebin=True)
             self.group_pair_context[diff_name].show_rebin(run, directory + name)
 
-    def calculate_all_groups(self):
-        self._calculate_groups(rebin=False)
+    def calculate_all_counts(self):
+        self._calculate_all_counts(rebin=False)
         if self._do_rebin():
-            self._calculate_groups(rebin=True)
+            self._calculate_all_counts(rebin=True)
 
-    def _calculate_groups(self, rebin):
+    def _calculate_all_counts(self, rebin):
         for run in self._data_context.current_runs:
             run_pre_processing(context=self, run=run, rebin=rebin)
             for group in self._group_pair_context.groups:

--- a/scripts/Muon/GUI/Common/corrections_tab_widget/background_corrections_model.py
+++ b/scripts/Muon/GUI/Common/corrections_tab_widget/background_corrections_model.py
@@ -436,20 +436,19 @@ class BackgroundCorrectionsModel:
         last_good_data = self._context.last_good_data(run_list)
 
         if last_good_data != 0.0:
-            return self._get_x_range_from(self._context.first_good_data(run_list), last_good_data)
+            return self._get_range_for_second_half_of_data(self._context.first_good_data(run_list), last_good_data)
         else:
             return self._get_x_range_from_counts_workspace(run, group)
-
-    @staticmethod
-    def _get_x_range_from(first_good_data: float, last_good_data: float) -> tuple:
-        """Get the default start and end X from the first and last good data, and the time zero."""
-        return (last_good_data - first_good_data) / 2.0 + first_good_data, last_good_data
 
     def _get_x_range_from_counts_workspace(self, run: str, group: str) -> tuple:
         """Get the default start and end X from the counts workspace corresponding to the provided run and group."""
         x_lower, x_upper = self.x_limits_of_workspace(run, group)
-        x_mid = (x_upper - x_lower) / 2.0 + x_lower
-        return x_mid, x_upper
+        return self._get_range_for_second_half_of_data(x_lower, x_upper)
+
+    @staticmethod
+    def _get_range_for_second_half_of_data(x_lower: float, x_upper: float) -> tuple:
+        """Returns an x range representing the second half of the data range provided."""
+        return (x_upper - x_lower) / 2.0 + x_lower, x_upper
 
     def x_limits_of_workspace(self, run: str, group: str) -> tuple:
         """Returns the x data limits of the workspace associated with the provided Run and Group."""

--- a/scripts/Muon/GUI/Common/corrections_tab_widget/background_corrections_model.py
+++ b/scripts/Muon/GUI/Common/corrections_tab_widget/background_corrections_model.py
@@ -14,7 +14,6 @@ from Muon.GUI.Common.contexts.corrections_context import (BACKGROUND_MODE_NONE, 
 from Muon.GUI.Common.contexts.muon_context import MuonContext
 from Muon.GUI.Common.corrections_tab_widget.corrections_model import CorrectionsModel
 from Muon.GUI.Common.utilities.algorithm_utils import run_Fit, run_minus
-from Muon.GUI.Common.utilities.run_string_utils import run_string_to_list
 from Muon.GUI.Common.utilities.workspace_data_utils import x_limits_of_workspace
 from Muon.GUI.Common.utilities.workspace_utils import StaticWorkspaceWrapper
 
@@ -182,53 +181,6 @@ class BackgroundCorrectionsModel:
         run_minus(correction_data.uncorrected_counts_workspace.workspace_copy(),
                   correction_data.create_background_workspace(),
                   correction_data.uncorrected_counts_workspace.workspace_name)
-
-    def calculate_asymmetry_workspaces_for(self, runs: list, groups: list) -> None:
-        """Creates the asymmetry workspaces for the runs and groups provided using the Counts workspaces in the ADS."""
-        for run, group in zip(runs, groups):
-            self._create_asymmetry_workspace_for(run, group)
-
-    def _create_asymmetry_workspace_for(self, run: str, group: str) -> None:
-        """Creates the asymmetry workspace for a run and group using its corresponding Counts workspace in the ADS."""
-        run_list = run_string_to_list(run)
-        group_object = self._context.group_pair_context[group]
-        if run_list is not None and group_object is not None:
-            self._context.calculate_asymmetry_for(run_list, group_object)
-            self._context.show_group(run_list, group_object)
-
-    def calculate_pairs_for(self, runs: list, groups: list) -> list:
-        """Calculates the Pair Asymmetry workspaces which are concerned with the provided Runs and Groups."""
-        self._context.update_phasequads()
-
-        # Remove duplicates from the list
-        runs = list(dict.fromkeys(runs))
-
-        pairs = self._context.find_pairs_containing_groups(groups)
-        self._calculate_pairs_for(runs, pairs)
-        return [pair.name for pair in pairs]
-
-    def _calculate_pairs_for(self, runs: list, pairs: list) -> None:
-        """Calculates the Pair Asymmetry workspaces for the provided runs and pairs."""
-        for run in runs:
-            run_list = run_string_to_list(run)
-            for pair_object in pairs:
-                self._context.calculate_pair_for(run_list, pair_object)
-                self._context.show_pair(run_list, pair_object)
-
-    def calculate_diffs_for(self, runs: list, groups_and_pairs: list) -> None:
-        """Calculates the Diff Asymmetry workspaces which are concerned with the provided Runs and Groups/Pairs."""
-        # Remove duplicates from the list
-        runs = list(dict.fromkeys(runs))
-
-        self._calculate_diffs_for(runs, self._context.find_diffs_containing_groups_or_pairs(groups_and_pairs))
-
-    def _calculate_diffs_for(self, runs: list, diffs: list) -> None:
-        """Calculates the Diff Asymmetry workspaces for the provided runs and diffs."""
-        for run in runs:
-            run_list = run_string_to_list(run)
-            for diff_object in diffs:
-                self._context.calculate_diff_for(run_list, diff_object)
-                self._context.show_diff(run_list, diff_object)
 
     def _handle_background_fit_output(self, correction_data: BackgroundCorrectionData, function: IFunction,
                                       fit_status: str, chi_squared: float) -> None:

--- a/scripts/Muon/GUI/Common/corrections_tab_widget/background_corrections_model.py
+++ b/scripts/Muon/GUI/Common/corrections_tab_widget/background_corrections_model.py
@@ -275,15 +275,16 @@ class BackgroundCorrectionsModel:
 
     def _add_background_correction_data_for(self, previous_data: dict, run: str, group: str) -> None:
         """Add background correction data for the provided Run and Group."""
-        run_group = tuple([run, group])
-        background_data = self._create_background_correction_data(previous_data, run_group)
-
         workspace_name = self.get_counts_workspace_name(run, group, False)
         rebin_workspace_name = self.get_counts_workspace_name(run, group, True) if self.do_rebin() else None
 
-        self._corrections_context.background_correction_data[run_group] = background_data
-        self._corrections_context.background_correction_data[run_group].setup_uncorrected_workspace(workspace_name,
-                                                                                                    rebin_workspace_name)
+        if workspace_name is not None:
+            run_group = tuple([run, group])
+            background_data = self._create_background_correction_data(previous_data, run_group)
+
+            self._corrections_context.background_correction_data[run_group] = background_data
+            self._corrections_context.background_correction_data[run_group].setup_uncorrected_workspace(
+                workspace_name, rebin_workspace_name)
 
     def _create_background_correction_data(self, previous_data: dict, run_group: tuple) -> BackgroundCorrectionData:
         """Creates the BackgroundCorrectionData for a newly loaded data. It tries to reuse previous data."""

--- a/scripts/Muon/GUI/Common/corrections_tab_widget/background_corrections_model.py
+++ b/scripts/Muon/GUI/Common/corrections_tab_widget/background_corrections_model.py
@@ -196,14 +196,16 @@ class BackgroundCorrectionsModel:
             self._context.calculate_asymmetry_for(run_list, group_object)
             self._context.show_group(run_list, group_object)
 
-    def calculate_pairs_for(self, runs: list, groups: list) -> None:
+    def calculate_pairs_for(self, runs: list, groups: list) -> list:
         """Calculates the Pair Asymmetry workspaces which are concerned with the provided Runs and Groups."""
         self._context.update_phasequads()
 
         # Remove duplicates from the list
         runs = list(dict.fromkeys(runs))
 
-        self._calculate_pairs_for(runs, self._context.find_pairs_containing_groups(groups))
+        pairs = self._context.find_pairs_containing_groups(groups)
+        self._calculate_pairs_for(runs, pairs)
+        return [pair.name for pair in pairs]
 
     def _calculate_pairs_for(self, runs: list, pairs: list) -> None:
         """Calculates the Pair Asymmetry workspaces for the provided runs and pairs."""
@@ -212,6 +214,21 @@ class BackgroundCorrectionsModel:
             for pair_object in pairs:
                 self._context.calculate_pair_for(run_list, pair_object)
                 self._context.show_pair(run_list, pair_object)
+
+    def calculate_diffs_for(self, runs: list, groups_and_pairs: list) -> None:
+        """Calculates the Diff Asymmetry workspaces which are concerned with the provided Runs and Groups/Pairs."""
+        # Remove duplicates from the list
+        runs = list(dict.fromkeys(runs))
+
+        self._calculate_diffs_for(runs, self._context.find_diffs_containing_groups_or_pairs(groups_and_pairs))
+
+    def _calculate_diffs_for(self, runs: list, diffs: list) -> None:
+        """Calculates the Diff Asymmetry workspaces for the provided runs and diffs."""
+        for run in runs:
+            run_list = run_string_to_list(run)
+            for diff_object in diffs:
+                self._context.calculate_diff_for(run_list, diff_object)
+                self._context.show_diff(run_list, diff_object)
 
     def _handle_background_fit_output(self, correction_data: BackgroundCorrectionData, function: IFunction,
                                       fit_status: str, chi_squared: float) -> None:

--- a/scripts/Muon/GUI/Common/corrections_tab_widget/background_corrections_model.py
+++ b/scripts/Muon/GUI/Common/corrections_tab_widget/background_corrections_model.py
@@ -31,13 +31,22 @@ class BackgroundCorrectionData:
     """
     uncorrected_workspace_name: str
     workspace_name: str
+    uncorrected_rebin_workspace_name: str
+    rebin_workspace_name: str
+
+    use_raw: bool
+    rebin_fixed_step: int
+
     start_x: float
     end_x: float
     flat_background: IFunction
     exp_decay: IFunction
     status: str = "No background correction"
 
-    def __init__(self, start_x: float, end_x: float, flat_background: IFunction = None, exp_decay: IFunction = None):
+    def __init__(self, use_raw: bool, rebin_fixed_step: int, start_x: float, end_x: float,
+                 flat_background: IFunction = None, exp_decay: IFunction = None):
+        self.use_raw = use_raw
+        self.rebin_fixed_step = rebin_fixed_step
         self.start_x = start_x
         self.end_x = end_x
         self.setup_functions(flat_background, exp_decay)
@@ -57,17 +66,27 @@ class BackgroundCorrectionData:
             self.exp_decay.setParameter("Lambda", DEFAULT_LAMBDA_VALUE)
             self.exp_decay.fixParameter("Lambda")
 
-    def setup_uncorrected_workspace(self, workspace_name: str) -> None:
+    def setup_uncorrected_workspace(self, workspace_name: str, rebin_workspace_name: str) -> None:
         """Clones the Counts workspace into a hidden workspace in the ADS."""
         self.workspace_name = workspace_name
         self.uncorrected_workspace_name = f"__{workspace_name}_uncorrected"
 
         run_clone_workspace({"InputWorkspace": self.workspace_name, "OutputWorkspace": self.uncorrected_workspace_name})
 
+        self.rebin_workspace_name = rebin_workspace_name
+        if self.rebin_workspace_name is not None:
+            self.uncorrected_rebin_workspace_name = f"__{rebin_workspace_name}_uncorrected"
+            run_clone_workspace({"InputWorkspace": self.rebin_workspace_name,
+                                 "OutputWorkspace": self.uncorrected_rebin_workspace_name})
+
     def reset(self) -> None:
         """Resets the background correction data by replacing the corrected data with the original uncorrected data."""
         self.setup_functions()
         run_clone_workspace({"InputWorkspace": self.uncorrected_workspace_name, "OutputWorkspace": self.workspace_name})
+
+        if self.rebin_workspace_name is not None:
+            run_clone_workspace({"InputWorkspace": self.uncorrected_rebin_workspace_name,
+                                 "OutputWorkspace": self.rebin_workspace_name})
 
     def calculate_background(self, fit_function: IFunction) -> None:
         """Calculates the background in the counts workspace."""
@@ -78,8 +97,9 @@ class BackgroundCorrectionData:
 
     def _get_parameters_for_background_fit(self, fit_function: IFunction) -> dict:
         """Gets the parameters to use for the background Fit."""
+        input_name = self.uncorrected_workspace_name if self._use_raw_data() else self.uncorrected_rebin_workspace_name
         return {"Function": fit_function,
-                "InputWorkspace": self.uncorrected_workspace_name,
+                "InputWorkspace": input_name,
                 "StartX": self.start_x,
                 "EndX": self.end_x,
                 "CreateOutput": False,
@@ -94,26 +114,52 @@ class BackgroundCorrectionData:
             self.setup_functions()
             self.status = f"Correction skipped - {fit_status}"
         else:
-            if isinstance(function, CompositeFunction):
-                self.flat_background = function.getFunction(0).clone()
-                self.exp_decay = function.getFunction(1).clone()
-            else:
-                self.flat_background = function.clone()
+            self._handle_background_fit_output_success(function)
 
-            self.status = "Correction success"
+    def _handle_background_fit_output_success(self, function: IFunction) -> None:
+        """Handles the output of a successful background fit."""
+        if isinstance(function, CompositeFunction):
+            background = function.getFunction(0).getParameterValue(BACKGROUND_PARAM)
+            background_error = function.getFunction(0).getError(BACKGROUND_PARAM)
+        else:
+            background = function.getParameterValue(BACKGROUND_PARAM)
+            background_error = function.getError(BACKGROUND_PARAM)
+
+        if not self._use_raw_data():
+            background /= self.rebin_fixed_step
+            background_error /= self.rebin_fixed_step
+
+        self.flat_background = FunctionFactory.createFunction("FlatBackground")
+        self.flat_background.setParameter(BACKGROUND_PARAM, background)
+        self.flat_background.setError(BACKGROUND_PARAM, background_error)
+        self.status = "Correction success"
 
     def perform_background_subtraction(self) -> None:
         """Performs the background subtraction on the counts workspace, and then generates the asymmetry workspace."""
-        run_minus(self.uncorrected_workspace_name, self._create_background_workspace(), self.workspace_name)
+        run_minus(self.uncorrected_workspace_name, self._create_background_workspace(rebin=False), self.workspace_name)
+        if self.rebin_workspace_name is not None:
+            run_minus(self.uncorrected_rebin_workspace_name, self._create_background_workspace(rebin=True),
+                      self.rebin_workspace_name)
 
-    def _create_background_workspace(self) -> Workspace:
+    def _create_background_workspace(self, rebin: bool) -> Workspace:
         """Creates the background workspace to use for the background subtraction."""
-        return run_create_single_valued_workspace(self._get_parameters_for_creating_background_workspace())
+        return run_create_single_valued_workspace(self._get_parameters_for_creating_background_workspace(rebin))
 
-    def _get_parameters_for_creating_background_workspace(self) -> dict:
-        return {"DataValue": self.flat_background.getParameterValue(BACKGROUND_PARAM),
-                "ErrorValue": self.flat_background.getError(BACKGROUND_PARAM),
+    def _get_parameters_for_creating_background_workspace(self, rebin: bool) -> dict:
+        """Returns the parameters to use when creating a single valued background workspace."""
+        background = self.flat_background.getParameterValue(BACKGROUND_PARAM)
+        background_error = self.flat_background.getError(BACKGROUND_PARAM)
+        if rebin:
+            background *= self.rebin_fixed_step
+            background_error *= self.rebin_fixed_step
+
+        return {"DataValue": background,
+                "ErrorValue": background_error,
                 "OutputWorkspace": TEMPORARY_BACKGROUND_WORKSPACE_NAME}
+
+    def _use_raw_data(self) -> bool:
+        """Returns true if the raw data should be used to calculate the background."""
+        return self.use_raw or self.rebin_fixed_step == 0
 
 
 class BackgroundCorrectionsModel:
@@ -147,10 +193,6 @@ class BackgroundCorrectionsModel:
         """Sets whether all runs should be shown or not."""
         self._corrections_context.show_all_runs = show_all
 
-    def set_show_rebin_data(self, show_rebin_data: bool) -> None:
-        """Sets whether the rebin corrected data should be shown or not."""
-        self._corrections_context.show_rebin_data = show_rebin_data
-
     def all_runs(self) -> list:
         """Returns a list of all loaded runs."""
         return self._context.get_runs(RUNS_ALL)
@@ -159,29 +201,35 @@ class BackgroundCorrectionsModel:
         """Returns the group names found in the group/pair context."""
         return self._context.group_pair_context.group_names
 
-    def set_start_x(self, run: str, group: str, rebin: bool, start_x: float) -> None:
+    def set_use_raw(self, run: str, group: str, use_raw: bool) -> None:
+        """Sets whether the background should be calculated using the raw data or rebinned data."""
+        run_group = tuple([run, group])
+        if run_group in self._corrections_context.background_correction_data:
+            self._corrections_context.background_correction_data[run_group].use_raw = use_raw
+
+    def set_start_x(self, run: str, group: str, start_x: float) -> None:
         """Sets the Start X associated with the provided Run and Group."""
-        run_group = tuple([run, group, rebin])
+        run_group = tuple([run, group])
         if run_group in self._corrections_context.background_correction_data:
             self._corrections_context.background_correction_data[run_group].start_x = start_x
 
-    def start_x(self, run: str, group: str, rebin: bool) -> float:
+    def start_x(self, run: str, group: str) -> float:
         """Returns the Start X associated with the provided Run and Group."""
-        run_group = tuple([run, group, rebin])
+        run_group = tuple([run, group])
         if run_group in self._corrections_context.background_correction_data:
             return self._corrections_context.background_correction_data[run_group].start_x
 
         raise RuntimeError(f"The provided run and group could not be found ({run}, {group}).")
 
-    def set_end_x(self, run: str, group: str, rebin: bool, end_x: float) -> None:
+    def set_end_x(self, run: str, group: str, end_x: float) -> None:
         """Sets the End X associated with the provided Run and Group."""
-        run_group = tuple([run, group, rebin])
+        run_group = tuple([run, group])
         if run_group in self._corrections_context.background_correction_data:
             self._corrections_context.background_correction_data[run_group].end_x = end_x
 
-    def end_x(self, run: str, group: str, rebin: bool) -> float:
+    def end_x(self, run: str, group: str) -> float:
         """Returns the End X associated with the provided Run and Group."""
-        run_group = tuple([run, group, rebin])
+        run_group = tuple([run, group])
         if run_group in self._corrections_context.background_correction_data:
             return self._corrections_context.background_correction_data[run_group].end_x
 
@@ -189,12 +237,11 @@ class BackgroundCorrectionsModel:
 
     def all_runs_and_groups(self) -> tuple:
         """Returns all the runs and groups stored in the context. The list indices of the runs and groups correspond."""
-        runs, groups, rebins = [], [], []
+        runs, groups = [], []
         for run_group in self._corrections_context.background_correction_data.keys():
             runs.append(run_group[0])
             groups.append(run_group[1])
-            rebins.append(run_group[2])
-        return runs, groups, rebins
+        return runs, groups
 
     def clear_background_corrections_data(self) -> None:
         """Clears the background correction data dictionary."""
@@ -212,32 +259,37 @@ class BackgroundCorrectionsModel:
         groups = self.group_names()
         for run in self._corrections_model.run_number_strings():
             for group in groups:
-                self._add_background_correction_data_for(previous_data, run, group, rebin=False)
-                if self._context._do_rebin():
-                    self._add_background_correction_data_for(previous_data, run, group, rebin=True)
+                self._add_background_correction_data_for(previous_data, run, group)
 
-    def _add_background_correction_data_for(self, previous_data: dict, run: str, group: str, rebin: bool) -> None:
-        """Add background correction data for the provided Run, Group and Rebin status."""
-        run_group = tuple([run, group, rebin])
+    def _add_background_correction_data_for(self, previous_data: dict, run: str, group: str) -> None:
+        """Add background correction data for the provided Run and Group."""
+        run_group = tuple([run, group])
         background_data = self._create_background_correction_data(previous_data, run_group)
 
-        workspace_name = self.get_counts_workspace_name(run, group, rebin)
+        workspace_name = self.get_counts_workspace_name(run, group, False)
+        rebin_workspace_name = self.get_counts_workspace_name(run, group, True) if self._context._do_rebin() else None
+
         self._corrections_context.background_correction_data[run_group] = background_data
-        self._corrections_context.background_correction_data[run_group].setup_uncorrected_workspace(workspace_name)
+        self._corrections_context.background_correction_data[run_group].setup_uncorrected_workspace(workspace_name,
+                                                                                                    rebin_workspace_name)
 
     def _create_background_correction_data(self, previous_data: dict, run_group: tuple) -> BackgroundCorrectionData:
         """Creates the BackgroundCorrectionData for a newly loaded data. It tries to reuse previous data."""
-        run, group, rebin = run_group
+        rebin_fixed = int(self._context.gui_context["RebinFixed"]) if "RebinFixed" in self._context.gui_context else 0
+
+        run, group = run_group
         if run_group in previous_data:
             data = previous_data[run_group]
-            return BackgroundCorrectionData(data.start_x, data.end_x, data.flat_background, data.exp_decay)
+            return BackgroundCorrectionData(data.use_raw, rebin_fixed, data.start_x, data.end_x, data.flat_background,
+                                            data.exp_decay)
         else:
             for key, value in previous_data.items():
                 if key[1] == group:
-                    return BackgroundCorrectionData(value.start_x, value.end_x, value.flat_background, value.exp_decay)
+                    return BackgroundCorrectionData(value.use_raw, rebin_fixed, value.start_x, value.end_x,
+                                                    value.flat_background, value.exp_decay)
 
-        start_x, end_x = self.default_x_range(run, group, rebin)
-        return BackgroundCorrectionData(start_x, end_x)
+        start_x, end_x = self.default_x_range(run, group)
+        return BackgroundCorrectionData(True, rebin_fixed, start_x, end_x)
 
     def reset_background_subtraction_data(self) -> None:
         """Resets the calculated background functions and corrected counts data in the ADS."""
@@ -251,12 +303,12 @@ class BackgroundCorrectionsModel:
             self._run_background_correction(self._corrections_context.background_correction_data[run_group])
         return self.all_runs_and_groups()
 
-    def run_background_correction_for(self, run: str, group: str, rebin: bool) -> None:
+    def run_background_correction_for(self, run: str, group: str) -> None:
         """Calculates the background for some data using a Fit."""
-        run_group = tuple([run, group, rebin])
+        run_group = tuple([run, group])
         if run_group in self._corrections_context.background_correction_data:
             self._run_background_correction(self._corrections_context.background_correction_data[run_group])
-        return [run], [group], [rebin]
+        return [run], [group]
 
     def _run_background_correction(self, correction_data: BackgroundCorrectionData) -> None:
         """Calculates the background for some data using a Fit."""
@@ -279,29 +331,25 @@ class BackgroundCorrectionsModel:
 
     def selected_correction_data(self) -> tuple:
         """Returns lists of the selected correction data to display in the view."""
-        runs, groups, rebins, start_xs, end_xs, backgrounds, background_errors, statuses = \
+        runs, groups, use_raws, start_xs, end_xs, backgrounds, background_errors, statuses = \
             self._selected_correction_data_for(self._selected_runs(), self._selected_groups())
-        return runs, groups, rebins, start_xs, end_xs, backgrounds, background_errors, statuses
+        return runs, groups, use_raws, start_xs, end_xs, backgrounds, background_errors, statuses
 
     def _selected_correction_data_for(self, selected_runs: list, selected_groups: list) -> tuple:
         """Returns lists of the selected correction data to display in the view."""
-        runs_list, groups_list, rebin_list, start_xs, end_xs, backgrounds, background_errors, statuses = [], [], [], [], \
-                                                                                                         [], [], [], []
+        runs_list, groups_list, use_raws, start_xs, end_xs, backgrounds, background_errors, statuses = [], [], [], [], \
+                                                                                                       [], [], [], []
         for run_group, correction_data in self._corrections_context.background_correction_data.items():
             if run_group[0] in selected_runs and run_group[1] in selected_groups:
-                rebinned = run_group[2]
-                if rebinned and not self._corrections_context.show_rebin_data:
-                    continue
-
                 runs_list.append(run_group[0])
                 groups_list.append(run_group[1])
-                rebin_list.append(rebinned)
+                use_raws.append(correction_data.use_raw)
                 start_xs.append(correction_data.start_x)
                 end_xs.append(correction_data.end_x)
                 backgrounds.append(correction_data.flat_background.getParameterValue(BACKGROUND_PARAM))
                 background_errors.append(correction_data.flat_background.getError(BACKGROUND_PARAM))
                 statuses.append(correction_data.status)
-        return runs_list, groups_list, rebin_list, start_xs, end_xs, backgrounds, background_errors, statuses
+        return runs_list, groups_list, use_raws, start_xs, end_xs, backgrounds, background_errors, statuses
 
     def _selected_runs(self) -> list:
         """Returns a list containing the run number strings that are currently selected."""
@@ -315,7 +363,7 @@ class BackgroundCorrectionsModel:
         selected_group = self._corrections_context.selected_group
         return self.group_names() if selected_group == GROUPS_ALL else [selected_group]
 
-    def get_counts_workspace_name(self, run_string: str, group: str, rebin: bool) -> str:
+    def get_counts_workspace_name(self, run_string: str, group: str, rebin: bool = False) -> str:
         """Returns the name of the counts workspace associated with the provided run string and group."""
         run_list = self._context.get_runs(run_string)
         workspace_list = []
@@ -323,7 +371,7 @@ class BackgroundCorrectionsModel:
             workspace_list = self._context.group_pair_context.get_group_counts_workspace_names(run_list[0], [group], rebin)
         return workspace_list[0] if len(workspace_list) > 0 else None
 
-    def default_x_range(self, run: str, group: str, rebin: bool) -> tuple:
+    def default_x_range(self, run: str, group: str) -> tuple:
         """Returns the x range to use by default for the background corrections. It is the second half of the data."""
         run_list = run_string_to_list(run)
         last_good_data = self._context.last_good_data(run_list)
@@ -331,19 +379,19 @@ class BackgroundCorrectionsModel:
         if last_good_data != 0.0:
             return self._get_x_range_from(self._context.first_good_data(run_list), last_good_data)
         else:
-            return self._get_x_range_from_counts_workspace(run, group, rebin)
+            return self._get_x_range_from_counts_workspace(run, group)
 
     @staticmethod
     def _get_x_range_from(first_good_data: float, last_good_data: float) -> tuple:
         """Get the default start and end X from the first and last good data, and the time zero."""
         return (last_good_data - first_good_data) / 2.0 + first_good_data, last_good_data
 
-    def _get_x_range_from_counts_workspace(self, run: str, group: str, rebin: bool) -> tuple:
+    def _get_x_range_from_counts_workspace(self, run: str, group: str) -> tuple:
         """Get the default start and end X from the counts workspace corresponding to the provided run and group."""
-        x_lower, x_upper = self.x_limits_of_workspace(run, group, rebin)
+        x_lower, x_upper = self.x_limits_of_workspace(run, group)
         x_mid = (x_upper - x_lower) / 2.0 + x_lower
         return x_mid, x_upper
 
-    def x_limits_of_workspace(self, run: str, group: str, rebin: bool) -> tuple:
+    def x_limits_of_workspace(self, run: str, group: str) -> tuple:
         """Returns the x data limits of the workspace associated with the provided Run and Group."""
-        return x_limits_of_workspace(self.get_counts_workspace_name(run, group, rebin))
+        return x_limits_of_workspace(self.get_counts_workspace_name(run, group, False))

--- a/scripts/Muon/GUI/Common/corrections_tab_widget/background_corrections_model.py
+++ b/scripts/Muon/GUI/Common/corrections_tab_widget/background_corrections_model.py
@@ -222,7 +222,7 @@ class BackgroundCorrectionsModel:
 
     def _create_background_correction_data(self, previous_data: dict, run_group: tuple) -> BackgroundCorrectionData:
         """Creates the BackgroundCorrectionData for a newly loaded data. It tries to reuse previous data."""
-        run, group, _ = run_group
+        run, group, rebin = run_group
         if run_group in previous_data:
             data = previous_data[run_group]
             return BackgroundCorrectionData(data.start_x, data.end_x, data.flat_background, data.exp_decay)
@@ -231,7 +231,7 @@ class BackgroundCorrectionsModel:
                 if key[1] == group:
                     return BackgroundCorrectionData(value.start_x, value.end_x, value.flat_background, value.exp_decay)
 
-        start_x, end_x = self.default_x_range(run, group)
+        start_x, end_x = self.default_x_range(run, group, rebin)
         return BackgroundCorrectionData(start_x, end_x)
 
     def reset_background_subtraction_data(self) -> None:
@@ -318,12 +318,12 @@ class BackgroundCorrectionsModel:
             workspace_list = self._context.group_pair_context.get_group_counts_workspace_names(run_list[0], [group], rebin)
         return workspace_list[0] if len(workspace_list) > 0 else None
 
-    def default_x_range(self, run: str, group: str) -> tuple:
+    def default_x_range(self, run: str, group: str, rebin: bool) -> tuple:
         """Returns the x range to use by default for the background corrections. It is the second half of the data."""
-        x_lower, x_upper = self.x_limits_of_workspace(run, group)
+        x_lower, x_upper = self.x_limits_of_workspace(run, group, rebin)
         x_mid = round((x_upper - x_lower)/2.0)
         return x_mid, x_upper
 
-    def x_limits_of_workspace(self, run: str, group: str) -> tuple:
+    def x_limits_of_workspace(self, run: str, group: str, rebin: bool) -> tuple:
         """Returns the x data limits of the workspace associated with the provided Run and Group."""
-        return x_limits_of_workspace(self.get_counts_workspace_name(run, group, False))
+        return x_limits_of_workspace(self.get_counts_workspace_name(run, group, rebin))

--- a/scripts/Muon/GUI/Common/corrections_tab_widget/background_corrections_model.py
+++ b/scripts/Muon/GUI/Common/corrections_tab_widget/background_corrections_model.py
@@ -7,7 +7,7 @@
 from mantid.py36compat import dataclass
 
 from mantid.api import AlgorithmManager, FunctionFactory, IFunction, Workspace
-from mantid.simpleapi import CreateWorkspace
+from mantid.simpleapi import CreateSingleValuedWorkspace
 from Muon.GUI.Common.ADSHandler.ADS_calls import add_ws_to_ads, retrieve_ws
 from Muon.GUI.Common.contexts.corrections_context import (BACKGROUND_MODE_NONE, FLAT_BACKGROUND,
                                                           FLAT_BACKGROUND_AND_EXP_DECAY, RUNS_ALL, GROUPS_ALL)
@@ -48,8 +48,8 @@ class BackgroundCorrectionData:
     def create_background_workspace(self) -> Workspace:
         background = self.flat_background.getParameterValue(BACKGROUND_PARAM)
         background_error = self.flat_background.getError(BACKGROUND_PARAM)
-        background_workspace = CreateWorkspace(DataX=[0.0], DataY=[background], DataE=[background_error],
-                                               StoreInADS=False)
+        background_workspace = CreateSingleValuedWorkspace(DataValue=background, ErrorValue=background_error,
+                                                           StoreInADS=False)
         return background_workspace
 
 

--- a/scripts/Muon/GUI/Common/corrections_tab_widget/background_corrections_model.py
+++ b/scripts/Muon/GUI/Common/corrections_tab_widget/background_corrections_model.py
@@ -360,6 +360,14 @@ class BackgroundCorrectionsModel:
 
         raise RuntimeError("The selected background function is not recognised.")
 
+    def are_all_corrections_successful(self) -> bool:
+        """Returns true if all the background corrections were applied successfully."""
+        if not self.is_background_mode_none():
+            for correction_data in self._corrections_context.background_correction_data.values():
+                if "skipped" in correction_data.status:
+                    return False
+        return True
+
     def selected_correction_data(self) -> tuple:
         """Returns lists of the selected correction data to display in the view."""
         runs, groups, use_raws, start_xs, end_xs, backgrounds, background_errors, statuses = \

--- a/scripts/Muon/GUI/Common/corrections_tab_widget/background_corrections_model.py
+++ b/scripts/Muon/GUI/Common/corrections_tab_widget/background_corrections_model.py
@@ -57,6 +57,7 @@ class BackgroundCorrectionData:
             self.flat_background = flat_background.clone()
         else:
             self.flat_background = FunctionFactory.createFunction("FlatBackground")
+            self.flat_background.addConstraints("A0>0")
 
         if exp_decay is not None:
             self.exp_decay = exp_decay.clone()
@@ -129,7 +130,6 @@ class BackgroundCorrectionData:
             background /= self.rebin_fixed_step
             background_error /= self.rebin_fixed_step
 
-        self.flat_background = FunctionFactory.createFunction("FlatBackground")
         self.flat_background.setParameter(BACKGROUND_PARAM, background)
         self.flat_background.setError(BACKGROUND_PARAM, background_error)
         self.status = "Correction success"

--- a/scripts/Muon/GUI/Common/corrections_tab_widget/background_corrections_model.py
+++ b/scripts/Muon/GUI/Common/corrections_tab_widget/background_corrections_model.py
@@ -57,7 +57,6 @@ class BackgroundCorrectionData:
             self.flat_background = flat_background.clone()
         else:
             self.flat_background = FunctionFactory.createFunction("FlatBackground")
-            self.flat_background.addConstraints("A0>0")
 
         if exp_decay is not None:
             self.exp_decay = exp_decay.clone()
@@ -373,13 +372,21 @@ class BackgroundCorrectionsModel:
             correction_data.flat_background.setError(BACKGROUND_PARAM, background_error)
         return correction_data
 
-    def are_all_corrections_successful(self) -> bool:
-        """Returns true if all the background corrections were applied successfully."""
+    def get_warning_for_correction_tab(self) -> bool:
+        """Returns a message if not all the background corrections were applied successfully."""
         if not self.is_background_mode_none():
             for correction_data in self._corrections_context.background_correction_data.values():
                 if "skipped" in correction_data.status:
-                    return False
-        return True
+                    return "Background corrections skipped for some domains."
+        return ""
+
+    def any_negative_backgrounds(self) -> bool:
+        """Returns true if a negative background exists in one of the background corrected domains."""
+        if not self.is_background_mode_none():
+            for correction_data in self._corrections_context.background_correction_data.values():
+                if correction_data.flat_background.getParameterValue(BACKGROUND_PARAM) < 0.0:
+                    return True
+        return False
 
     def selected_correction_data(self) -> tuple:
         """Returns lists of the selected correction data to display in the view."""

--- a/scripts/Muon/GUI/Common/corrections_tab_widget/background_corrections_model.py
+++ b/scripts/Muon/GUI/Common/corrections_tab_widget/background_corrections_model.py
@@ -196,6 +196,23 @@ class BackgroundCorrectionsModel:
             self._context.calculate_asymmetry_for(run_list, group_object)
             self._context.show_group(run_list, group_object)
 
+    def calculate_pairs_for(self, runs: list, groups: list) -> None:
+        """Calculates the Pair Asymmetry workspaces which are concerned with the provided Runs and Groups."""
+        self._context.update_phasequads()
+
+        # Remove duplicates from the list
+        runs = list(dict.fromkeys(runs))
+
+        self._calculate_pairs_for(runs, self._context.find_pairs_containing_groups(groups))
+
+    def _calculate_pairs_for(self, runs: list, pairs: list) -> None:
+        """Calculates the Pair Asymmetry workspaces for the provided runs and pairs."""
+        for run in runs:
+            run_list = run_string_to_list(run)
+            for pair_object in pairs:
+                self._context.calculate_pair_for(run_list, pair_object)
+                self._context.show_pair(run_list, pair_object)
+
     def _handle_background_fit_output(self, correction_data: BackgroundCorrectionData, function: IFunction,
                                       fit_status: str, chi_squared: float) -> None:
         """Handles the output of the background fit."""

--- a/scripts/Muon/GUI/Common/corrections_tab_widget/background_corrections_model.py
+++ b/scripts/Muon/GUI/Common/corrections_tab_widget/background_corrections_model.py
@@ -135,6 +135,10 @@ class BackgroundCorrectionsModel:
         """Sets whether all runs should be shown or not."""
         self._corrections_context.show_all_runs = show_all
 
+    def set_show_rebin_data(self, show_rebin_data: bool) -> None:
+        """Sets whether the rebin corrected data should be shown or not."""
+        self._corrections_context.show_rebin_data = show_rebin_data
+
     def all_runs(self) -> list:
         """Returns a list of all loaded runs."""
         return self._context.get_runs(RUNS_ALL)
@@ -263,9 +267,13 @@ class BackgroundCorrectionsModel:
                                                                                                          [], [], [], []
         for run_group, correction_data in self._corrections_context.background_correction_data.items():
             if run_group[0] in selected_runs and run_group[1] in selected_groups:
+                rebinned = run_group[2]
+                if rebinned and not self._corrections_context.show_rebin_data:
+                    continue
+
                 runs_list.append(run_group[0])
                 groups_list.append(run_group[1])
-                rebin_list.append(run_group[2])
+                rebin_list.append(rebinned)
                 start_xs.append(correction_data.start_x)
                 end_xs.append(correction_data.end_x)
                 backgrounds.append(correction_data.flat_background.getParameterValue(BACKGROUND_PARAM))

--- a/scripts/Muon/GUI/Common/corrections_tab_widget/background_corrections_presenter.py
+++ b/scripts/Muon/GUI/Common/corrections_tab_widget/background_corrections_presenter.py
@@ -110,7 +110,8 @@ class BackgroundCorrectionsPresenter:
         self._corrections_presenter.set_tab_warning(self.model.get_warning_for_correction_tab())
         if self.model.any_negative_backgrounds():
             self._corrections_presenter.warning_popup("A negative background has been calculated in Auto correction "
-                                                      "mode.\n\nIf this is not expected then please use Manual mode.")
+                                                      "mode.\n\nIf this is not expected then please use Manual mode,"
+                                                      " or adjust the fitting range.")
 
     def _handle_start_or_end_x_changed(self, get_new_x_range) -> None:
         """Handles when a Start X or End X is changed using an appropriate getter to get the new x range."""

--- a/scripts/Muon/GUI/Common/corrections_tab_widget/background_corrections_presenter.py
+++ b/scripts/Muon/GUI/Common/corrections_tab_widget/background_corrections_presenter.py
@@ -131,8 +131,7 @@ class BackgroundCorrectionsPresenter:
     def _run_background_corrections_for_all(self) -> None:
         """Runs the background corrections for all stored data in the corrections context."""
         if self.model.is_background_mode_none():
-            self.model.reset_background_function_data()
-            self._update_displayed_corrections_data()
+            self._perform_background_corrections(self.model.reset_background_subtraction_data)
         else:
             self._perform_background_corrections(self.model.run_background_correction_for_all)
 

--- a/scripts/Muon/GUI/Common/corrections_tab_widget/background_corrections_presenter.py
+++ b/scripts/Muon/GUI/Common/corrections_tab_widget/background_corrections_presenter.py
@@ -4,7 +4,7 @@
 #   NScD Oak Ridge National Laboratory, European Spallation Source,
 #   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
 # SPDX - License - Identifier: GPL - 3.0 +
-from Muon.GUI.Common.contexts.corrections_context import BACKGROUND_MODE_NONE, FLAT_BACKGROUND
+from Muon.GUI.Common.contexts.corrections_context import BACKGROUND_MODE_NONE, FLAT_BACKGROUND_AND_EXP_DECAY
 from Muon.GUI.Common.corrections_tab_widget.background_corrections_model import BackgroundCorrectionsModel
 from Muon.GUI.Common.corrections_tab_widget.background_corrections_view import BackgroundCorrectionsView
 from Muon.GUI.Common.utilities.workspace_data_utils import check_start_x_is_valid, check_end_x_is_valid
@@ -36,9 +36,9 @@ class BackgroundCorrectionsPresenter:
     def handle_instrument_changed(self) -> None:
         """User changes the selected instrument."""
         self.model.set_background_correction_mode(BACKGROUND_MODE_NONE)
-        self.model.set_selected_function(FLAT_BACKGROUND)
+        self.model.set_selected_function(FLAT_BACKGROUND_AND_EXP_DECAY)
         self.view.background_correction_mode = BACKGROUND_MODE_NONE
-        self.view.selected_function = FLAT_BACKGROUND
+        self.view.selected_function = FLAT_BACKGROUND_AND_EXP_DECAY
         self.model.clear_background_corrections_data()
 
     def handle_pre_process_and_counts_calculated(self) -> None:

--- a/scripts/Muon/GUI/Common/corrections_tab_widget/background_corrections_presenter.py
+++ b/scripts/Muon/GUI/Common/corrections_tab_widget/background_corrections_presenter.py
@@ -80,16 +80,11 @@ class BackgroundCorrectionsPresenter:
         """Handles when the Use Raw check box is ticked or unticked in the table."""
         runs, groups = self._selected_runs_and_groups()
         use_raw = self.view.selected_use_raw()
-        if not use_raw and self.model.do_rebin():
-            for run, group in zip(runs, groups):
-                self.view.set_use_raw(run, group, use_raw)
-                self.model.set_use_raw(run, group, use_raw)
+        for run, group in zip(runs, groups):
+            self.view.set_use_raw(run, group, use_raw)
+            self.model.set_use_raw(run, group, use_raw)
 
-            self._perform_background_corrections_for(runs, groups)
-        else:
-            runs, groups = self.view.selected_run_and_group()
-            self.view.set_use_raw(runs[0], groups[0], True)
-            self._corrections_presenter.warning_popup("There is no rebinned data to use for background corrections.")
+        self._perform_background_corrections_for(runs, groups)
 
     def handle_start_x_changed(self) -> None:
         """Handles when a Start X table cell is changed."""
@@ -136,7 +131,7 @@ class BackgroundCorrectionsPresenter:
         runs, groups, use_raws, start_xs, end_xs, backgrounds, background_errors, statuses = \
             self.model.selected_correction_data()
         self.view.populate_corrections_table(runs, groups, use_raws, start_xs, end_xs, backgrounds, background_errors,
-                                             statuses)
+                                             statuses, self.model.is_rebin_fixed_selected())
 
     def _update_start_and_end_x_in_view_and_model(self, run: str, group: str, start_x: float, end_x: float) -> None:
         """Updates the start and end x in the model using the provided values."""

--- a/scripts/Muon/GUI/Common/corrections_tab_widget/background_corrections_presenter.py
+++ b/scripts/Muon/GUI/Common/corrections_tab_widget/background_corrections_presenter.py
@@ -108,6 +108,9 @@ class BackgroundCorrectionsPresenter:
         """Handle when the background corrections has finished."""
         self._update_displayed_corrections_data()
 
+        message = "Background corrections skipped for some domains." if not self.model.are_all_corrections_successful() else ""
+        self._corrections_presenter.set_tab_warning(message)
+
     def _handle_start_or_end_x_changed(self, get_new_x_range) -> None:
         """Handles when a Start X or End X is changed using an appropriate getter to get the new x range."""
         runs, groups = self._selected_runs_and_groups()

--- a/scripts/Muon/GUI/Common/corrections_tab_widget/background_corrections_presenter.py
+++ b/scripts/Muon/GUI/Common/corrections_tab_widget/background_corrections_presenter.py
@@ -183,7 +183,9 @@ class BackgroundCorrectionsPresenter:
         """Calculates the Asymmetry workspaces, Pairs and Diffs only for the provided runs and groups."""
         # Calculates the Asymmetry workspaces for the corresponding runs and groups that have just been corrected
         self.model.calculate_asymmetry_workspaces_for(runs, groups)
-        # self.model.calculate_pairs_and_diffs_for(runs, groups)
+        # Calculates the Pair Asymmetry workspaces for pairs formed from one or more groups which have been corrected
+        self.model.calculate_pairs_for(runs, groups)
+        # self.model.calculate_diffs_for(runs, groups)
 
     def _create_calculation_thread(self, callback, *args) -> ThreadModel:
         """Create a thread for calculations."""

--- a/scripts/Muon/GUI/Common/corrections_tab_widget/background_corrections_presenter.py
+++ b/scripts/Muon/GUI/Common/corrections_tab_widget/background_corrections_presenter.py
@@ -89,25 +89,27 @@ class BackgroundCorrectionsPresenter:
 
     def _handle_start_or_end_x_changed(self, get_new_x_range) -> None:
         """Handles when a Start X or End X is changed using an appropriate getter to get the new x range."""
-        runs, groups = self._selected_runs_and_groups()
-        for run, group in zip(runs, groups):
-            new_start_x, new_end_x = get_new_x_range(run, group)
-            self._update_start_and_end_x_in_view_and_model(run, group, new_start_x, new_end_x)
+        runs, groups, rebins = self._selected_runs_and_groups()
+        for run, group, rebin in zip(runs, groups, rebins):
+            new_start_x, new_end_x = get_new_x_range(run, group, rebin)
+            self._update_start_and_end_x_in_view_and_model(run, group, rebin, new_start_x, new_end_x)
 
         if len(runs) == 1:
-            self._perform_background_corrections(self.model.run_background_correction_for, runs[0], groups[0])
+            self._perform_background_corrections(self.model.run_background_correction_for, runs[0], groups[0], rebins[0])
         elif len(runs) > 1:
             self._perform_background_corrections(self.model.run_background_correction_for_all)
 
-    def _get_new_x_range_when_start_x_changed(self, run: str, group: str) -> tuple:
+    def _get_new_x_range_when_start_x_changed(self, run: str, group: str, rebin: bool) -> tuple:
         """Returns the new x range for a domain when the start X has been changed."""
-        return check_start_x_is_valid(self.model.get_counts_workspace_name(run, group), self.view.selected_start_x(),
-                                      self.model.end_x(run, group), self.model.start_x(run, group))
+        return check_start_x_is_valid(self.model.get_counts_workspace_name(run, group, rebin),
+                                      self.view.selected_start_x(), self.model.end_x(run, group, rebin),
+                                      self.model.start_x(run, group, rebin))
 
-    def _get_new_x_range_when_end_x_changed(self, run: str, group: str) -> tuple:
+    def _get_new_x_range_when_end_x_changed(self, run: str, group: str, rebin: bool) -> tuple:
         """Returns the new x range for a domain when the end X has been changed."""
-        return check_end_x_is_valid(self.model.get_counts_workspace_name(run, group), self.model.start_x(run, group),
-                                    self.view.selected_end_x(), self.model.end_x(run, group))
+        return check_end_x_is_valid(self.model.get_counts_workspace_name(run, group, rebin),
+                                    self.model.start_x(run, group, rebin), self.view.selected_end_x(),
+                                    self.model.end_x(run, group, rebin))
 
     def _run_background_corrections_for_all(self) -> None:
         """Runs the background corrections for all stored data in the corrections context."""
@@ -118,16 +120,17 @@ class BackgroundCorrectionsPresenter:
 
     def _update_displayed_corrections_data(self) -> None:
         """Updates the displayed corrections data using the data stored in the model."""
-        runs, groups, start_xs, end_xs, backgrounds, background_errors, statuses = self.model.selected_correction_data()
-        self.view.populate_corrections_table(runs, groups, start_xs, end_xs, backgrounds, background_errors, statuses)
+        runs, groups, rebins, start_xs, end_xs, backgrounds, background_errors, statuses = \
+            self.model.selected_correction_data()
+        self.view.populate_corrections_table(runs, groups, rebins, start_xs, end_xs, backgrounds, background_errors, statuses)
 
-    def _update_start_and_end_x_in_view_and_model(self, run: str, group: str, start_x: float, end_x: float) -> None:
+    def _update_start_and_end_x_in_view_and_model(self, run: str, group: str, rebin: bool, start_x: float, end_x: float) -> None:
         """Updates the start and end x in the model using the provided values."""
-        if self.view.is_run_group_displayed(run, group):
-            self.view.set_start_x(run, group, start_x)
-            self.view.set_end_x(run, group, end_x)
-        self.model.set_start_x(run, group, start_x)
-        self.model.set_end_x(run, group, end_x)
+        if self.view.is_run_group_displayed(run, group, rebin):
+            self.view.set_start_x(run, group, rebin, start_x)
+            self.view.set_end_x(run, group, rebin, end_x)
+        self.model.set_start_x(run, group, rebin, start_x)
+        self.model.set_end_x(run, group, rebin, end_x)
 
     def _perform_background_corrections(self, calculation_func, *args) -> None:
         """Creates a matrix workspace for each possible parameter combination to be used for fitting."""

--- a/scripts/Muon/GUI/Common/corrections_tab_widget/background_corrections_presenter.py
+++ b/scripts/Muon/GUI/Common/corrections_tab_widget/background_corrections_presenter.py
@@ -45,8 +45,8 @@ class BackgroundCorrectionsPresenter:
         self.view.selected_function = FLAT_BACKGROUND
         self.model.clear_background_corrections_data()
 
-    def handle_pre_process_and_grouping_complete(self) -> None:
-        """Handles when MuonPreProcess and grouping has been completed."""
+    def handle_pre_process_and_counts_calculated(self) -> None:
+        """Handles when MuonPreProcess and counts workspaces have been calculated."""
         self.model.populate_background_corrections_data()
         self._run_background_corrections_for_all()
 

--- a/scripts/Muon/GUI/Common/corrections_tab_widget/background_corrections_presenter.py
+++ b/scripts/Muon/GUI/Common/corrections_tab_widget/background_corrections_presenter.py
@@ -184,8 +184,9 @@ class BackgroundCorrectionsPresenter:
         # Calculates the Asymmetry workspaces for the corresponding runs and groups that have just been corrected
         self.model.calculate_asymmetry_workspaces_for(runs, groups)
         # Calculates the Pair Asymmetry workspaces for pairs formed from one or more groups which have been corrected
-        self.model.calculate_pairs_for(runs, groups)
-        # self.model.calculate_diffs_for(runs, groups)
+        pairs = self.model.calculate_pairs_for(runs, groups)
+        # Calculates the Diff Asymmetry workspaces formed from one or more groups/pairs which have been corrected
+        self.model.calculate_diffs_for(runs, groups + pairs)
 
     def _create_calculation_thread(self, callback, *args) -> ThreadModel:
         """Create a thread for calculations."""

--- a/scripts/Muon/GUI/Common/corrections_tab_widget/background_corrections_presenter.py
+++ b/scripts/Muon/GUI/Common/corrections_tab_widget/background_corrections_presenter.py
@@ -83,8 +83,7 @@ class BackgroundCorrectionsPresenter:
         runs, groups = self._selected_runs_and_groups()
         use_raw = self.view.selected_use_raw()
         for run, group in zip(runs, groups):
-            self.view.set_use_raw(run, group, use_raw)
-            self.model.set_use_raw(run, group, use_raw)
+            self._update_use_raw_in_view_and_model(run, group, use_raw)
 
         self._perform_background_corrections_for(runs, groups)
 
@@ -146,8 +145,14 @@ class BackgroundCorrectionsPresenter:
         self.view.populate_corrections_table(runs, groups, use_raws, start_xs, end_xs, backgrounds, background_errors,
                                              statuses, self.model.is_rebin_fixed_selected())
 
+    def _update_use_raw_in_view_and_model(self, run: str, group: str, use_raw: bool) -> None:
+        """Updates the Use Raw option in the view and model using the provided value."""
+        if self.view.is_run_group_displayed(run, group):
+            self.view.set_use_raw(run, group, use_raw)
+        self.model.set_use_raw(run, group, use_raw)
+
     def _update_start_and_end_x_in_view_and_model(self, run: str, group: str, start_x: float, end_x: float) -> None:
-        """Updates the start and end x in the model using the provided values."""
+        """Updates the start and end x in the view and model using the provided values."""
         if self.view.is_run_group_displayed(run, group):
             self.view.set_start_x(run, group, start_x)
             self.view.set_end_x(run, group, end_x)

--- a/scripts/Muon/GUI/Common/corrections_tab_widget/background_corrections_presenter.py
+++ b/scripts/Muon/GUI/Common/corrections_tab_widget/background_corrections_presenter.py
@@ -107,8 +107,10 @@ class BackgroundCorrectionsPresenter:
         """Handle when the background corrections has finished."""
         self._update_displayed_corrections_data()
 
-        message = "Background corrections skipped for some domains." if not self.model.are_all_corrections_successful() else ""
-        self._corrections_presenter.set_tab_warning(message)
+        self._corrections_presenter.set_tab_warning(self.model.get_warning_for_correction_tab())
+        if self.model.any_negative_backgrounds():
+            self._corrections_presenter.warning_popup("A negative background has been calculated in Auto correction "
+                                                      "mode.\n\nIf this is not expected then please use Manual mode.")
 
     def _handle_start_or_end_x_changed(self, get_new_x_range) -> None:
         """Handles when a Start X or End X is changed using an appropriate getter to get the new x range."""

--- a/scripts/Muon/GUI/Common/corrections_tab_widget/background_corrections_presenter.py
+++ b/scripts/Muon/GUI/Common/corrections_tab_widget/background_corrections_presenter.py
@@ -80,11 +80,16 @@ class BackgroundCorrectionsPresenter:
         """Handles when the Use Raw check box is ticked or unticked in the table."""
         runs, groups = self._selected_runs_and_groups()
         use_raw = self.view.selected_use_raw()
-        for run, group in zip(runs, groups):
-            self.view.set_use_raw(run, group, use_raw)
-            self.model.set_use_raw(run, group, use_raw)
+        if not use_raw and self.model.do_rebin():
+            for run, group in zip(runs, groups):
+                self.view.set_use_raw(run, group, use_raw)
+                self.model.set_use_raw(run, group, use_raw)
 
-        self._perform_background_corrections_for(runs, groups)
+            self._perform_background_corrections_for(runs, groups)
+        else:
+            runs, groups = self.view.selected_run_and_group()
+            self.view.set_use_raw(runs[0], groups[0], True)
+            self._corrections_presenter.warning_popup("There is no rebinned data to use for background corrections.")
 
     def handle_start_x_changed(self) -> None:
         """Handles when a Start X table cell is changed."""

--- a/scripts/Muon/GUI/Common/corrections_tab_widget/background_corrections_presenter.py
+++ b/scripts/Muon/GUI/Common/corrections_tab_widget/background_corrections_presenter.py
@@ -4,6 +4,7 @@
 #   NScD Oak Ridge National Laboratory, European Spallation Source,
 #   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
 # SPDX - License - Identifier: GPL - 3.0 +
+from Muon.GUI.Common.ADSHandler.ADS_calls import retrieve_ws
 from Muon.GUI.Common.contexts.corrections_context import BACKGROUND_MODE_NONE, FLAT_BACKGROUND_AND_EXP_DECAY
 from Muon.GUI.Common.corrections_tab_widget.background_corrections_model import BackgroundCorrectionsModel
 from Muon.GUI.Common.corrections_tab_widget.background_corrections_view import BackgroundCorrectionsView
@@ -28,6 +29,7 @@ class BackgroundCorrectionsPresenter:
         self.view.set_slot_for_use_raw_changed(self.handle_use_raw_changed)
         self.view.set_slot_for_start_x_changed(self.handle_start_x_changed)
         self.view.set_slot_for_end_x_changed(self.handle_end_x_changed)
+        self.view.set_slot_for_show_fit_output_clicked(lambda row: self.handle_show_fit_output_clicked(row))
 
     def initialize_model_options(self) -> None:
         """Initialise the model with the default fitting options."""
@@ -93,6 +95,14 @@ class BackgroundCorrectionsPresenter:
     def handle_end_x_changed(self) -> None:
         """Handles when a End X table cell is changed."""
         self._handle_start_or_end_x_changed(self._get_new_x_range_when_end_x_changed)
+
+    def handle_show_fit_output_clicked(self, row_index: int) -> None:
+        """Handles when the Show Output button is clicked in one of the table rows."""
+        run, group = self.view.get_run_and_group_for_row(row_index)
+        parameter_table_name, covariance_matrix_name = self.model.create_background_output_workspaces_for(run, group)
+        if parameter_table_name is not None and covariance_matrix_name is not None:
+            self.view.show_table_workspace_display(retrieve_ws(parameter_table_name), "Parameter Table")
+            self.view.show_table_workspace_display(retrieve_ws(covariance_matrix_name), "Normalised Covariance Matrix")
 
     def handle_background_corrections_for_all_finished(self) -> None:
         """Handle when the background corrections has finished."""

--- a/scripts/Muon/GUI/Common/corrections_tab_widget/background_corrections_presenter.py
+++ b/scripts/Muon/GUI/Common/corrections_tab_widget/background_corrections_presenter.py
@@ -25,6 +25,7 @@ class BackgroundCorrectionsPresenter:
         self.view.set_slot_for_select_function_combo_box_changed(self.handle_select_function_combo_box_changed)
         self.view.set_slot_for_group_combo_box_changed(self.handle_selected_group_changed)
         self.view.set_slot_for_show_all_runs(self.handle_show_all_runs_ticked)
+        self.view.set_slot_for_show_rebin_data(self.handle_show_rebin_data_ticked)
         self.view.set_slot_for_start_x_changed(self.handle_start_x_changed)
         self.view.set_slot_for_end_x_changed(self.handle_end_x_changed)
 
@@ -73,6 +74,11 @@ class BackgroundCorrectionsPresenter:
     def handle_show_all_runs_ticked(self) -> None:
         """Handles when the show all runs check box is ticked or unticked."""
         self.model.set_show_all_runs(self.view.show_all_runs)
+        self._update_displayed_corrections_data()
+
+    def handle_show_rebin_data_ticked(self):
+        """Handles when the show rebin data check box is ticked or unticked."""
+        self.model.set_show_rebin_data(self.view.show_rebin_data)
         self._update_displayed_corrections_data()
 
     def handle_start_x_changed(self) -> None:

--- a/scripts/Muon/GUI/Common/corrections_tab_widget/background_corrections_presenter.py
+++ b/scripts/Muon/GUI/Common/corrections_tab_widget/background_corrections_presenter.py
@@ -7,8 +7,6 @@
 from Muon.GUI.Common.contexts.corrections_context import BACKGROUND_MODE_NONE, FLAT_BACKGROUND
 from Muon.GUI.Common.corrections_tab_widget.background_corrections_model import BackgroundCorrectionsModel
 from Muon.GUI.Common.corrections_tab_widget.background_corrections_view import BackgroundCorrectionsView
-from Muon.GUI.Common.thread_model import ThreadModel
-from Muon.GUI.Common.thread_model_wrapper import ThreadModelWrapperWithOutput
 from Muon.GUI.Common.utilities.workspace_data_utils import check_start_x_is_valid, check_end_x_is_valid
 
 
@@ -22,8 +20,6 @@ class BackgroundCorrectionsPresenter:
         self.view = view
         self.model = model
         self._corrections_presenter = corrections_presenter
-
-        self.thread_success = True
 
         self.view.set_slot_for_mode_combo_box_changed(self.handle_mode_combo_box_changed)
         self.view.set_slot_for_select_function_combo_box_changed(self.handle_select_function_combo_box_changed)
@@ -87,33 +83,9 @@ class BackgroundCorrectionsPresenter:
         """Handles when a End X table cell is changed."""
         self._handle_start_or_end_x_changed(self._get_new_x_range_when_end_x_changed)
 
-    def handle_thread_calculation_started(self) -> None:
-        """Handles when a calculation on a thread has started."""
-        self._corrections_presenter.disable_editing_notifier.notify_subscribers()
-        self.thread_success = True
-
     def handle_background_corrections_for_all_finished(self) -> None:
-        """Handle when the background corrections for all has finished."""
-        self._corrections_presenter.enable_editing_notifier.notify_subscribers()
-        if not self.thread_success:
-            return
-
+        """Handle when the background corrections has finished."""
         self._update_displayed_corrections_data()
-
-        corrected_runs_and_groups = self.thread_model_wrapper.result
-        if corrected_runs_and_groups is not None:
-            self._perform_asymmetry_pairs_and_diffs_calculation(*corrected_runs_and_groups)
-
-    def handle_thread_error(self, error: str) -> None:
-        """Handle when an error occurs while doing calculations on a thread."""
-        self._corrections_presenter.disable_editing_notifier.notify_subscribers()
-        self.thread_success = False
-        self._corrections_presenter.warning_popup(error)
-
-    def handle_asymmetry_pairs_and_diffs_calc_finished(self) -> None:
-        """Handle when the calculation of Asymmetry, Pairs and Diffs has finished finished."""
-        self._corrections_presenter.enable_editing_notifier.notify_subscribers()
-        self._corrections_presenter.asymmetry_pair_and_diff_calculations_finished_notifier.notify_subscribers()
 
     def _handle_start_or_end_x_changed(self, get_new_x_range) -> None:
         """Handles when a Start X or End X is changed using an appropriate getter to get the new x range."""
@@ -160,38 +132,15 @@ class BackgroundCorrectionsPresenter:
     def _perform_background_corrections(self, calculation_func, *args) -> None:
         """Creates a matrix workspace for each possible parameter combination to be used for fitting."""
         try:
-            self.correction_calculation_thread = self._create_calculation_thread(calculation_func, *args)
-            self.correction_calculation_thread.threadWrapperSetUp(self.handle_thread_calculation_started,
-                                                                  self.handle_background_corrections_for_all_finished,
-                                                                  self.handle_thread_error)
+            self.correction_calculation_thread = self._corrections_presenter.create_calculation_thread(calculation_func,
+                                                                                                       *args)
+            self.correction_calculation_thread.threadWrapperSetUp(
+                self._corrections_presenter.handle_thread_calculation_started,
+                self._corrections_presenter.handle_background_corrections_for_all_finished,
+                self._corrections_presenter.handle_thread_error)
             self.correction_calculation_thread.start()
         except ValueError as error:
             self._corrections_presenter.warning_popup(error)
-
-    def _perform_asymmetry_pairs_and_diffs_calculation(self, *args) -> None:
-        """Calculate the Asymmetry workspaces, Pairs and Diffs on a thread after background corrections are complete."""
-        try:
-            self.calculation_thread = self._create_calculation_thread(self._calculate_asymmetry_pairs_and_diffs, *args)
-            self.calculation_thread.threadWrapperSetUp(self.handle_thread_calculation_started,
-                                                       self.handle_asymmetry_pairs_and_diffs_calc_finished,
-                                                       self.handle_thread_error)
-            self.calculation_thread.start()
-        except ValueError as error:
-            self._corrections_presenter.warning_popup(error)
-
-    def _calculate_asymmetry_pairs_and_diffs(self, runs: list, groups: list) -> None:
-        """Calculates the Asymmetry workspaces, Pairs and Diffs only for the provided runs and groups."""
-        # Calculates the Asymmetry workspaces for the corresponding runs and groups that have just been corrected
-        self.model.calculate_asymmetry_workspaces_for(runs, groups)
-        # Calculates the Pair Asymmetry workspaces for pairs formed from one or more groups which have been corrected
-        pairs = self.model.calculate_pairs_for(runs, groups)
-        # Calculates the Diff Asymmetry workspaces formed from one or more groups/pairs which have been corrected
-        self.model.calculate_diffs_for(runs, groups + pairs)
-
-    def _create_calculation_thread(self, callback, *args) -> ThreadModel:
-        """Create a thread for calculations."""
-        self.thread_model_wrapper = ThreadModelWrapperWithOutput(callback, *args)
-        return ThreadModel(self.thread_model_wrapper)
 
     def _selected_runs_and_groups(self) -> tuple:
         """Returns the runs and groups to apply the parameter changes to."""

--- a/scripts/Muon/GUI/Common/corrections_tab_widget/background_corrections_view.py
+++ b/scripts/Muon/GUI/Common/corrections_tab_widget/background_corrections_view.py
@@ -174,7 +174,7 @@ class BackgroundCorrectionsView(widget, ui_form):
         if self._selected_row is not None:
             run = self.correction_options_table.item(self._selected_row, RUN_COLUMN_INDEX).text()
             group = self.correction_options_table.item(self._selected_row, GROUP_COLUMN_INDEX).text()
-            rebin = bool(self.correction_options_table.item(self._selected_row, REBIN_COLUMN_INDEX).text())
+            rebin = self.correction_options_table.item(self._selected_row, REBIN_COLUMN_INDEX).text() == "True"
             return [run], [group], [rebin]
         else:
             raise RuntimeError("There is no selected run/group table row.")

--- a/scripts/Muon/GUI/Common/corrections_tab_widget/background_corrections_view.py
+++ b/scripts/Muon/GUI/Common/corrections_tab_widget/background_corrections_view.py
@@ -72,6 +72,7 @@ class BackgroundCorrectionsView(widget, ui_form):
         self._selected_value: str = None
 
         self.set_background_correction_options_visible(False)
+        self.set_function_combo_box_tooltips()
 
         self._handle_use_raw_changed = None
         self._handle_start_x_changed = None
@@ -114,6 +115,13 @@ class BackgroundCorrectionsView(widget, ui_form):
         self.show_all_runs_checkbox.setVisible(visible)
         self.apply_table_changes_to_all_checkbox.setVisible(visible)
         self.correction_options_table.setVisible(visible)
+
+    def set_function_combo_box_tooltips(self) -> None:
+        """Update the tooltips for the combobox."""
+        self.function_combo_box.setItemData(0, "A0 >= 0 (constraint)\n"
+                                               "A = 1e6 (initial value)\n"
+                                               "Lambda = 1.0/2.2 (fixed)", Qt.ToolTipRole)
+        self.function_combo_box.setItemData(1, "A0 >= 0 (constraint)", Qt.ToolTipRole)
 
     @property
     def background_correction_mode(self) -> str:

--- a/scripts/Muon/GUI/Common/corrections_tab_widget/background_corrections_view.py
+++ b/scripts/Muon/GUI/Common/corrections_tab_widget/background_corrections_view.py
@@ -21,6 +21,8 @@ A0_COLUMN_INDEX = 5
 A0_ERROR_COLUMN_INDEX = 6
 STATUS_COLUMN_INDEX = 7
 
+USE_RAW_TOOLTIP = "Calculate the background using the raw data or the rebinned data."
+
 
 class DoubleItemDelegate(QStyledItemDelegate):
     """
@@ -239,8 +241,8 @@ class BackgroundCorrectionsView(widget, ui_form):
             self.correction_options_table.insertRow(row)
             self.correction_options_table.setItem(row, RUN_COLUMN_INDEX, self._create_table_item(run, False))
             self.correction_options_table.setItem(row, GROUP_COLUMN_INDEX, self._create_table_item(group, False))
-            self.correction_options_table.setItem(row, USE_RAW_COLUMN_INDEX, self._create_bool_table_item(use_raw,
-                                                                                                          enabled=use_raw_enabled))
+            self.correction_options_table.setItem(row, USE_RAW_COLUMN_INDEX,
+                                                  self._create_bool_table_item(use_raw, use_raw_enabled, USE_RAW_TOOLTIP))
             self.correction_options_table.setItem(row, START_X_COLUMN_INDEX, self._create_double_table_item(start_x))
             self.correction_options_table.setItem(row, END_X_COLUMN_INDEX, self._create_double_table_item(end_x))
             self.correction_options_table.setItem(row, A0_COLUMN_INDEX,
@@ -290,9 +292,10 @@ class BackgroundCorrectionsView(widget, ui_form):
         elif column == END_X_COLUMN_INDEX:
             self._handle_end_x_changed()
 
-    def _create_bool_table_item(self, state: bool, enabled: bool = True) -> QTableWidgetItem:
+    def _create_bool_table_item(self, state: bool, enabled: bool = True, tooltip: str = "") -> QTableWidgetItem:
         """Creates a check box table widget item with an initial boolean state."""
         item = self._create_table_item("")
+        item.setToolTip(tooltip)
         if enabled:
             item.setFlags(Qt.ItemIsUserCheckable | Qt.ItemIsEnabled)
         else:

--- a/scripts/Muon/GUI/Common/corrections_tab_widget/background_corrections_view.py
+++ b/scripts/Muon/GUI/Common/corrections_tab_widget/background_corrections_view.py
@@ -90,6 +90,10 @@ class BackgroundCorrectionsView(widget, ui_form):
         """Connect the slot for the Show All Runs check box."""
         self.show_all_runs_checkbox.stateChanged.connect(slot)
 
+    def set_slot_for_show_rebin_data(self, slot) -> None:
+        """Connect the slot for the Show All Runs check box."""
+        self.show_rebin_data_checkbox.stateChanged.connect(slot)
+
     def set_slot_for_start_x_changed(self, slot) -> None:
         """Sets the slot for when a start x table cell is changed."""
         self._handle_start_x_changed = slot
@@ -106,6 +110,7 @@ class BackgroundCorrectionsView(widget, ui_form):
         self.group_combo_box.setVisible(visible)
         self.show_all_runs_checkbox.setVisible(visible)
         self.apply_table_changes_to_all_checkbox.setVisible(visible)
+        self.show_rebin_data_checkbox.setVisible(visible)
         self.correction_options_table.setVisible(visible)
 
     @property
@@ -158,6 +163,11 @@ class BackgroundCorrectionsView(widget, ui_form):
     def show_all_runs(self) -> bool:
         """Returns true if all the runs should be shown."""
         return self.show_all_runs_checkbox.isChecked()
+
+    @property
+    def show_rebin_data(self) -> bool:
+        """Returns true if the rebinned data should be shown."""
+        return self.show_rebin_data_checkbox.isChecked()
 
     def selected_run_and_group(self) -> tuple:
         """Returns the Run and Group that is in the same row as the selected table cell."""

--- a/scripts/Muon/GUI/Common/corrections_tab_widget/background_corrections_view.py
+++ b/scripts/Muon/GUI/Common/corrections_tab_widget/background_corrections_view.py
@@ -126,10 +126,10 @@ class BackgroundCorrectionsView(widget, ui_form):
 
     def set_function_combo_box_tooltips(self) -> None:
         """Update the tooltips for the combobox."""
-        self.function_combo_box.setItemData(0, "A0 >= 0 (constraint)\n"
+        self.function_combo_box.setItemData(0, "Flat Background + Exp Decay\n"
                                                "A = 1e6 (initial value)\n"
                                                "Lambda = 1.0/2.2 (fixed)", Qt.ToolTipRole)
-        self.function_combo_box.setItemData(1, "A0 >= 0 (constraint)", Qt.ToolTipRole)
+        self.function_combo_box.setItemData(1, "Flat Background", Qt.ToolTipRole)
 
     @property
     def background_correction_mode(self) -> str:

--- a/scripts/Muon/GUI/Common/corrections_tab_widget/background_corrections_view.py
+++ b/scripts/Muon/GUI/Common/corrections_tab_widget/background_corrections_view.py
@@ -73,9 +73,6 @@ class BackgroundCorrectionsView(widget, ui_form):
         self._handle_start_x_changed = None
         self._handle_end_x_changed = None
 
-        # Disable the background mode combo box while background corrections is still in development
-        self.mode_combo_box.setEnabled(False)
-
     def set_slot_for_mode_combo_box_changed(self, slot) -> None:
         """Connect the slot for the Background corrections mode combo box."""
         self.mode_combo_box.currentIndexChanged.connect(slot)

--- a/scripts/Muon/GUI/Common/corrections_tab_widget/background_corrections_view.py
+++ b/scripts/Muon/GUI/Common/corrections_tab_widget/background_corrections_view.py
@@ -109,7 +109,6 @@ class BackgroundCorrectionsView(widget, ui_form):
         self.show_all_runs_checkbox.setVisible(visible)
         self.apply_table_changes_to_all_checkbox.setVisible(visible)
         self.correction_options_table.setVisible(visible)
-        self.background_info_label.setVisible(not visible)
 
     @property
     def background_correction_mode(self) -> str:

--- a/scripts/Muon/GUI/Common/corrections_tab_widget/background_corrections_view.py
+++ b/scripts/Muon/GUI/Common/corrections_tab_widget/background_corrections_view.py
@@ -7,6 +7,8 @@
 from mantid.api import ITableWorkspace
 from mantidqt.utils.qt import load_ui
 from mantidqt.widgets.workspacedisplay.table.presenter import TableWorkspaceDisplay
+from Muon.GUI.Common.utilities.table_utils import (create_checkbox_table_item, create_double_table_item,
+                                                   create_string_table_item)
 
 from qtpy.QtCore import Qt
 from qtpy.QtGui import QDoubleValidator, QPalette
@@ -260,18 +262,18 @@ class BackgroundCorrectionsView(widget, ui_form):
                                                                                              statuses):
             row = self.correction_options_table.rowCount()
             self.correction_options_table.insertRow(row)
-            self.correction_options_table.setItem(row, RUN_COLUMN_INDEX, self._create_table_item(run, False))
-            self.correction_options_table.setItem(row, GROUP_COLUMN_INDEX, self._create_table_item(group, False))
+            self.correction_options_table.setItem(row, RUN_COLUMN_INDEX, create_string_table_item(run, False))
+            self.correction_options_table.setItem(row, GROUP_COLUMN_INDEX, create_string_table_item(group, False))
             self.correction_options_table.setItem(row, USE_RAW_COLUMN_INDEX,
-                                                  self._create_bool_table_item(use_raw, use_raw_enabled, USE_RAW_TOOLTIP))
-            self.correction_options_table.setItem(row, START_X_COLUMN_INDEX, self._create_double_table_item(start_x))
-            self.correction_options_table.setItem(row, END_X_COLUMN_INDEX, self._create_double_table_item(end_x))
+                                                  create_checkbox_table_item(use_raw, use_raw_enabled, USE_RAW_TOOLTIP))
+            self.correction_options_table.setItem(row, START_X_COLUMN_INDEX, create_double_table_item(start_x))
+            self.correction_options_table.setItem(row, END_X_COLUMN_INDEX, create_double_table_item(end_x))
             self.correction_options_table.setItem(row, A0_COLUMN_INDEX,
-                                                  self._create_double_table_item(background, enabled=False))
+                                                  create_double_table_item(background, enabled=False))
             self.correction_options_table.setItem(row, A0_ERROR_COLUMN_INDEX,
-                                                  self._create_double_table_item(background_error, enabled=False))
+                                                  create_double_table_item(background_error, enabled=False))
             self.correction_options_table.setItem(row, STATUS_COLUMN_INDEX,
-                                                  self._create_table_item(status, False, alignment=Qt.AlignVCenter))
+                                                  create_string_table_item(status, False, alignment=Qt.AlignVCenter))
             self.correction_options_table.setCellWidget(row, SHOW_MATRIX_COLUMN_INDEX,
                                                         self.create_show_fit_output_button_for_row(row))
         self.correction_options_table.blockSignals(False)
@@ -327,47 +329,12 @@ class BackgroundCorrectionsView(widget, ui_form):
         button.clicked.connect(lambda _: self.handle_show_fit_output_clicked(row_index))
         return button
 
-    def _create_bool_table_item(self, state: bool, enabled: bool = True, tooltip: str = "") -> QTableWidgetItem:
-        """Creates a check box table widget item with an initial boolean state."""
-        item = self._create_table_item("")
-        item.setToolTip(tooltip)
-        if enabled:
-            item.setFlags(Qt.ItemIsUserCheckable | Qt.ItemIsEnabled)
-        else:
-            item.setFlags(item.flags() ^ Qt.ItemIsEnabled)
-        if state:
-            item.setCheckState(Qt.Checked)
-        else:
-            item.setCheckState(Qt.Unchecked)
-        return item
-
-    def _create_double_table_item(self, value: float, editable: bool = True, enabled: bool = True) -> QTableWidgetItem:
-        """Creates a table item for the corrections options table from a float."""
-        return self._create_table_item(self._float_to_str(value), editable, enabled)
-
-    def _create_table_item(self, text: str, editable: bool = True, enabled: bool = True,
-                           alignment: int = Qt.AlignCenter) -> QTableWidgetItem:
-        """Creates a table item for the corrections options table from a string."""
-        item = QTableWidgetItem(text)
-        item.setTextAlignment(alignment)
-        item = self._set_table_item_flags(item, editable, enabled)
-        return item
-
-    @staticmethod
-    def _set_table_item_flags(item: QTableWidgetItem, editable: bool, enabled: bool) -> QTableWidgetItem:
-        """Sets the flags for a table widget item."""
-        if not editable:
-            item.setFlags(item.flags() ^ Qt.ItemIsEditable)
-        if not enabled:
-            item.setFlags(item.flags() ^ Qt.ItemIsEnabled)
-        return item
-
     def _set_table_item_value_for(self, run: str, group: str, column_index: int, value: float) -> None:
         """Sets the End X associated with the provided Run and Group."""
         row_index = self._table_row_index_of(run, group)
 
         self.correction_options_table.blockSignals(True)
-        self.correction_options_table.setItem(row_index, column_index, self._create_double_table_item(value))
+        self.correction_options_table.setItem(row_index, column_index, create_double_table_item(value))
         self.correction_options_table.blockSignals(False)
 
     def _table_item_value_for(self, run: str, group: str, column_index: int) -> str:
@@ -395,10 +362,5 @@ class BackgroundCorrectionsView(widget, ui_form):
         if self._selected_row is not None and self._selected_column is not None:
             self.correction_options_table.blockSignals(True)
             self.correction_options_table.setItem(self._selected_row, self._selected_column,
-                                                  self._create_double_table_item(value))
+                                                  create_double_table_item(value))
             self.correction_options_table.blockSignals(False)
-
-    @staticmethod
-    def _float_to_str(value: float) -> str:
-        """Converts a float to a string with three decimal places."""
-        return f"{value:.3f}"

--- a/scripts/Muon/GUI/Common/corrections_tab_widget/background_corrections_view.ui
+++ b/scripts/Muon/GUI/Common/corrections_tab_widget/background_corrections_view.ui
@@ -41,18 +41,6 @@ color: grey; }
       <property name="topMargin">
        <number>20</number>
       </property>
-      <item row="3" column="3">
-       <widget class="QComboBox" name="group_combo_box">
-        <property name="toolTip">
-         <string>Select the Group to show data for</string>
-        </property>
-        <item>
-         <property name="text">
-          <string>All</string>
-         </property>
-        </item>
-       </widget>
-      </item>
       <item row="1" column="1">
        <widget class="QLabel" name="mode_label">
         <property name="minimumSize">
@@ -89,23 +77,6 @@ color: grey; }
         </property>
         <property name="text">
          <string>Show data for:</string>
-        </property>
-       </widget>
-      </item>
-      <item row="3" column="2">
-       <widget class="QCheckBox" name="show_all_runs_checkbox">
-        <property name="toolTip">
-         <string>Tick to show data for all the runs</string>
-        </property>
-        <property name="text">
-         <string>All Runs</string>
-        </property>
-       </widget>
-      </item>
-      <item row="3" column="4">
-       <widget class="QCheckBox" name="show_rebin_data_checkbox">
-        <property name="text">
-         <string>Rebin data</string>
         </property>
        </widget>
       </item>
@@ -153,7 +124,7 @@ background-color: #c7e0ff;
         </column>
         <column>
          <property name="text">
-          <string>Rebin</string>
+          <string>Use Raw</string>
          </property>
         </column>
         <column>
@@ -213,6 +184,28 @@ background-color: #c7e0ff;
         <item>
          <property name="text">
           <string>Auto</string>
+         </property>
+        </item>
+       </widget>
+      </item>
+      <item row="3" column="2">
+       <widget class="QCheckBox" name="show_all_runs_checkbox">
+        <property name="toolTip">
+         <string>Tick to show data for all the runs</string>
+        </property>
+        <property name="text">
+         <string>All Runs</string>
+        </property>
+       </widget>
+      </item>
+      <item row="3" column="3" colspan="2">
+       <widget class="QComboBox" name="group_combo_box">
+        <property name="toolTip">
+         <string>Select the Group to show data for</string>
+        </property>
+        <item>
+         <property name="text">
+          <string>All</string>
          </property>
         </item>
        </widget>

--- a/scripts/Muon/GUI/Common/corrections_tab_widget/background_corrections_view.ui
+++ b/scripts/Muon/GUI/Common/corrections_tab_widget/background_corrections_view.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>473</width>
-    <height>274</height>
+    <height>296</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -41,6 +41,41 @@ color: grey; }
       <property name="topMargin">
        <number>20</number>
       </property>
+      <item row="3" column="1">
+       <widget class="QLabel" name="show_data_for_label">
+        <property name="minimumSize">
+         <size>
+          <width>200</width>
+          <height>0</height>
+         </size>
+        </property>
+        <property name="text">
+         <string>Show data for:</string>
+        </property>
+       </widget>
+      </item>
+      <item row="3" column="2">
+       <widget class="QCheckBox" name="show_all_runs_checkbox">
+        <property name="toolTip">
+         <string>Tick to show data for all the runs</string>
+        </property>
+        <property name="text">
+         <string>All Runs</string>
+        </property>
+       </widget>
+      </item>
+      <item row="3" column="3">
+       <widget class="QComboBox" name="group_combo_box">
+        <property name="toolTip">
+         <string>Select the Group to show data for</string>
+        </property>
+        <item>
+         <property name="text">
+          <string>All</string>
+         </property>
+        </item>
+       </widget>
+      </item>
       <item row="2" column="2" colspan="2">
        <widget class="QComboBox" name="function_combo_box">
         <property name="toolTip">
@@ -57,31 +92,6 @@ color: grey; }
          </property>
         </item>
        </widget>
-      </item>
-      <item row="3" column="3">
-       <widget class="QComboBox" name="group_combo_box">
-        <property name="toolTip">
-         <string>Select the Group to show data for</string>
-        </property>
-        <item>
-         <property name="text">
-          <string>All</string>
-         </property>
-        </item>
-       </widget>
-      </item>
-      <item row="7" column="2">
-       <spacer name="verticalSpacer">
-        <property name="orientation">
-         <enum>Qt::Vertical</enum>
-        </property>
-        <property name="sizeHint" stdset="0">
-         <size>
-          <width>20</width>
-          <height>40</height>
-         </size>
-        </property>
-       </spacer>
       </item>
       <item row="2" column="1">
        <widget class="QLabel" name="select_function_label">
@@ -111,6 +121,19 @@ color: grey; }
           <string>Auto</string>
          </property>
         </item>
+       </widget>
+      </item>
+      <item row="4" column="1" colspan="3">
+       <widget class="QCheckBox" name="apply_table_changes_to_all_checkbox">
+        <property name="toolTip">
+         <string>Apply all changes made in the table to all of the domains, including domains not currently displayed</string>
+        </property>
+        <property name="text">
+         <string>Apply parameter changes to all domains</string>
+        </property>
+        <property name="checked">
+         <bool>true</bool>
+        </property>
        </widget>
       </item>
       <item row="5" column="1" colspan="3">
@@ -192,58 +215,6 @@ background-color: #c7e0ff;
         </property>
         <property name="text">
          <string>Background:</string>
-        </property>
-       </widget>
-      </item>
-      <item row="6" column="2" colspan="2">
-       <widget class="QLabel" name="background_info_label">
-        <property name="minimumSize">
-         <size>
-          <width>180</width>
-          <height>0</height>
-         </size>
-        </property>
-        <property name="text">
-         <string>No background correction</string>
-        </property>
-        <property name="alignment">
-         <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-        </property>
-       </widget>
-      </item>
-      <item row="4" column="1" colspan="3">
-       <widget class="QCheckBox" name="apply_table_changes_to_all_checkbox">
-        <property name="toolTip">
-         <string>Apply all changes made in the table to all of the domains, including domains not currently displayed</string>
-        </property>
-        <property name="text">
-         <string>Apply parameter changes to all domains</string>
-        </property>
-        <property name="checked">
-         <bool>true</bool>
-        </property>
-       </widget>
-      </item>
-      <item row="3" column="2">
-       <widget class="QCheckBox" name="show_all_runs_checkbox">
-        <property name="toolTip">
-         <string>Tick to show data for all the runs</string>
-        </property>
-        <property name="text">
-         <string>All Runs</string>
-        </property>
-       </widget>
-      </item>
-      <item row="3" column="1">
-       <widget class="QLabel" name="show_data_for_label">
-        <property name="minimumSize">
-         <size>
-          <width>200</width>
-          <height>0</height>
-         </size>
-        </property>
-        <property name="text">
-         <string>Show data for:</string>
         </property>
        </widget>
       </item>

--- a/scripts/Muon/GUI/Common/corrections_tab_widget/background_corrections_view.ui
+++ b/scripts/Muon/GUI/Common/corrections_tab_widget/background_corrections_view.ui
@@ -152,6 +152,11 @@ background-color: #c7e0ff;
           <string>Status</string>
          </property>
         </column>
+        <column>
+         <property name="text">
+          <string>Fit Output</string>
+         </property>
+        </column>
        </widget>
       </item>
       <item row="2" column="2" colspan="3">

--- a/scripts/Muon/GUI/Common/corrections_tab_widget/background_corrections_view.ui
+++ b/scripts/Muon/GUI/Common/corrections_tab_widget/background_corrections_view.ui
@@ -41,6 +41,44 @@ color: grey; }
       <property name="topMargin">
        <number>20</number>
       </property>
+      <item row="3" column="3">
+       <widget class="QComboBox" name="group_combo_box">
+        <property name="toolTip">
+         <string>Select the Group to show data for</string>
+        </property>
+        <item>
+         <property name="text">
+          <string>All</string>
+         </property>
+        </item>
+       </widget>
+      </item>
+      <item row="1" column="1">
+       <widget class="QLabel" name="mode_label">
+        <property name="minimumSize">
+         <size>
+          <width>200</width>
+          <height>0</height>
+         </size>
+        </property>
+        <property name="text">
+         <string>Background:</string>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="1">
+       <widget class="QLabel" name="select_function_label">
+        <property name="minimumSize">
+         <size>
+          <width>200</width>
+          <height>0</height>
+         </size>
+        </property>
+        <property name="text">
+         <string>Select Function:</string>
+        </property>
+       </widget>
+      </item>
       <item row="3" column="1">
        <widget class="QLabel" name="show_data_for_label">
         <property name="minimumSize">
@@ -64,79 +102,14 @@ color: grey; }
         </property>
        </widget>
       </item>
-      <item row="3" column="3">
-       <widget class="QComboBox" name="group_combo_box">
-        <property name="toolTip">
-         <string>Select the Group to show data for</string>
-        </property>
-        <item>
-         <property name="text">
-          <string>All</string>
-         </property>
-        </item>
-       </widget>
-      </item>
-      <item row="2" column="2" colspan="2">
-       <widget class="QComboBox" name="function_combo_box">
-        <property name="toolTip">
-         <string>Select a fit function to use for the corrections</string>
-        </property>
-        <item>
-         <property name="text">
-          <string>Flat Background + Exp Decay</string>
-         </property>
-        </item>
-        <item>
-         <property name="text">
-          <string>Flat Background</string>
-         </property>
-        </item>
-       </widget>
-      </item>
-      <item row="2" column="1">
-       <widget class="QLabel" name="select_function_label">
-        <property name="minimumSize">
-         <size>
-          <width>200</width>
-          <height>0</height>
-         </size>
-        </property>
+      <item row="3" column="4">
+       <widget class="QCheckBox" name="show_rebin_data_checkbox">
         <property name="text">
-         <string>Select Function:</string>
+         <string>Rebin data</string>
         </property>
        </widget>
       </item>
-      <item row="1" column="2" colspan="2">
-       <widget class="QComboBox" name="mode_combo_box">
-        <property name="toolTip">
-         <string>Select the mode to use to perform background corrections</string>
-        </property>
-        <item>
-         <property name="text">
-          <string>None</string>
-         </property>
-        </item>
-        <item>
-         <property name="text">
-          <string>Auto</string>
-         </property>
-        </item>
-       </widget>
-      </item>
-      <item row="4" column="1" colspan="3">
-       <widget class="QCheckBox" name="apply_table_changes_to_all_checkbox">
-        <property name="toolTip">
-         <string>Apply all changes made in the table to all of the domains, including domains not currently displayed</string>
-        </property>
-        <property name="text">
-         <string>Apply parameter changes to all domains</string>
-        </property>
-        <property name="checked">
-         <bool>true</bool>
-        </property>
-       </widget>
-      </item>
-      <item row="5" column="1" colspan="3">
+      <item row="5" column="1" colspan="4">
        <widget class="QTableWidget" name="correction_options_table">
         <property name="styleSheet">
          <string notr="true">QTableWidget {
@@ -210,16 +183,50 @@ background-color: #c7e0ff;
         </column>
        </widget>
       </item>
-      <item row="1" column="1">
-       <widget class="QLabel" name="mode_label">
-        <property name="minimumSize">
-         <size>
-          <width>200</width>
-          <height>0</height>
-         </size>
+      <item row="2" column="2" colspan="3">
+       <widget class="QComboBox" name="function_combo_box">
+        <property name="toolTip">
+         <string>Select a fit function to use for the corrections</string>
+        </property>
+        <item>
+         <property name="text">
+          <string>Flat Background + Exp Decay</string>
+         </property>
+        </item>
+        <item>
+         <property name="text">
+          <string>Flat Background</string>
+         </property>
+        </item>
+       </widget>
+      </item>
+      <item row="1" column="2" colspan="3">
+       <widget class="QComboBox" name="mode_combo_box">
+        <property name="toolTip">
+         <string>Select the mode to use to perform background corrections</string>
+        </property>
+        <item>
+         <property name="text">
+          <string>None</string>
+         </property>
+        </item>
+        <item>
+         <property name="text">
+          <string>Auto</string>
+         </property>
+        </item>
+       </widget>
+      </item>
+      <item row="4" column="1" colspan="4">
+       <widget class="QCheckBox" name="apply_table_changes_to_all_checkbox">
+        <property name="toolTip">
+         <string>Apply all changes made in the table to all of the domains, including domains not currently displayed</string>
         </property>
         <property name="text">
-         <string>Background:</string>
+         <string>Apply parameter changes to all domains</string>
+        </property>
+        <property name="checked">
+         <bool>true</bool>
         </property>
        </widget>
       </item>

--- a/scripts/Muon/GUI/Common/corrections_tab_widget/background_corrections_view.ui
+++ b/scripts/Muon/GUI/Common/corrections_tab_widget/background_corrections_view.ui
@@ -83,12 +83,12 @@ color: grey; }
         </property>
         <item>
          <property name="text">
-          <string>Flat Background</string>
+          <string>Flat Background + Exp Decay</string>
          </property>
         </item>
         <item>
          <property name="text">
-          <string>Flat Background + Exp Decay</string>
+          <string>Flat Background</string>
          </property>
         </item>
        </widget>

--- a/scripts/Muon/GUI/Common/corrections_tab_widget/background_corrections_view.ui
+++ b/scripts/Muon/GUI/Common/corrections_tab_widget/background_corrections_view.ui
@@ -180,6 +180,11 @@ background-color: #c7e0ff;
         </column>
         <column>
          <property name="text">
+          <string>Rebin</string>
+         </property>
+        </column>
+        <column>
+         <property name="text">
           <string>Start X</string>
          </property>
         </column>

--- a/scripts/Muon/GUI/Common/corrections_tab_widget/corrections_model.py
+++ b/scripts/Muon/GUI/Common/corrections_tab_widget/corrections_model.py
@@ -4,9 +4,8 @@
 #   NScD Oak Ridge National Laboratory, European Spallation Source,
 #   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
 # SPDX - License - Identifier: GPL - 3.0 +
-from Muon.GUI.Common.contexts.corrections_context import CorrectionsContext
-from Muon.GUI.Common.contexts.muon_data_context import MuonDataContext
-from Muon.GUI.Common.utilities.run_string_utils import run_list_to_string
+from Muon.GUI.Common.contexts.muon_context import MuonContext
+from Muon.GUI.Common.utilities.run_string_utils import run_list_to_string, run_string_to_list
 
 
 class CorrectionsModel:
@@ -14,10 +13,11 @@ class CorrectionsModel:
     The CorrectionsModel calculates Dead Time corrections and Background corrections.
     """
 
-    def __init__(self, data_context: MuonDataContext, corrections_context: CorrectionsContext):
+    def __init__(self, context: MuonContext):
         """Initialize the CorrectionsModel with empty data."""
-        self._data_context = data_context
-        self._corrections_context = corrections_context
+        self._context = context
+        self._data_context = context.data_context
+        self._corrections_context = context.corrections_context
 
     @property
     def number_of_run_strings(self) -> int:
@@ -42,3 +42,58 @@ class CorrectionsModel:
     def current_run_string(self) -> str:
         """Returns the currently selected run string from the context."""
         return self._corrections_context.current_run_string
+
+    """
+    After the background corrections are performed on the Counts; the Group Asymmetry, Pair Asymmetry and Diff Asymmetry
+    workspaces need to be recalculated. The following functions are used for this recalculation. These functions allow
+    us to perform the recalculation of the asymmetries only for the necessary runs and groups that have just been
+    count-corrected.
+    """
+
+    def calculate_asymmetry_workspaces_for(self, runs: list, groups: list) -> None:
+        """Creates the asymmetry workspaces for the runs and groups provided using the Counts workspaces in the ADS."""
+        for run, group in zip(runs, groups):
+            self._create_asymmetry_workspace_for(run, group)
+
+    def _create_asymmetry_workspace_for(self, run: str, group: str) -> None:
+        """Creates the asymmetry workspace for a run and group using its corresponding Counts workspace in the ADS."""
+        run_list = run_string_to_list(run)
+        group_object = self._context.group_pair_context[group]
+        if run_list is not None and group_object is not None:
+            self._context.calculate_asymmetry_for(run_list, group_object)
+            self._context.show_group(run_list, group_object)
+
+    def calculate_pairs_for(self, runs: list, groups: list) -> list:
+        """Calculates the Pair Asymmetry workspaces which are concerned with the provided Runs and Groups."""
+        self._context.update_phasequads()
+
+        pairs = self._context.find_pairs_containing_groups(groups)
+        self._calculate_pairs_for(self._remove_duplicates(runs), pairs)
+
+        return [pair.name for pair in pairs]
+
+    def _calculate_pairs_for(self, runs: list, pairs: list) -> None:
+        """Calculates the Pair Asymmetry workspaces for the provided runs and pairs."""
+        for run in runs:
+            run_list = run_string_to_list(run)
+            for pair_object in pairs:
+                self._context.calculate_pair_for(run_list, pair_object)
+                self._context.show_pair(run_list, pair_object)
+
+    def calculate_diffs_for(self, runs: list, groups_and_pairs: list) -> None:
+        """Calculates the Diff Asymmetry workspaces which are concerned with the provided Runs and Groups/Pairs."""
+        diffs = self._context.find_diffs_containing_groups_or_pairs(groups_and_pairs)
+        self._calculate_diffs_for(self._remove_duplicates(runs), diffs)
+
+    def _calculate_diffs_for(self, runs: list, diffs: list) -> None:
+        """Calculates the Diff Asymmetry workspaces for the provided runs and diffs."""
+        for run in runs:
+            run_list = run_string_to_list(run)
+            for diff_object in diffs:
+                self._context.calculate_diff_for(run_list, diff_object)
+                self._context.show_diff(run_list, diff_object)
+
+    @staticmethod
+    def _remove_duplicates(list_with_duplicates: list) -> list:
+        """Removes the duplicate entries in a list."""
+        return list(dict.fromkeys(list_with_duplicates))

--- a/scripts/Muon/GUI/Common/corrections_tab_widget/corrections_model.py
+++ b/scripts/Muon/GUI/Common/corrections_tab_widget/corrections_model.py
@@ -50,18 +50,18 @@ class CorrectionsModel:
     count-corrected.
     """
 
-    def calculate_asymmetry_workspaces_for(self, runs: list, groups: list) -> None:
+    def calculate_asymmetry_workspaces_for(self, runs: list, groups: list, rebins: list) -> None:
         """Creates the asymmetry workspaces for the runs and groups provided using the Counts workspaces in the ADS."""
-        for run, group in zip(runs, groups):
-            self._create_asymmetry_workspace_for(run, group)
+        for run, group, rebin in zip(runs, groups, rebins):
+            self._create_asymmetry_workspace_for(run, group, rebin)
 
-    def _create_asymmetry_workspace_for(self, run: str, group: str) -> None:
+    def _create_asymmetry_workspace_for(self, run: str, group: str, rebin: bool) -> None:
         """Creates the asymmetry workspace for a run and group using its corresponding Counts workspace in the ADS."""
         run_list = run_string_to_list(run)
         group_object = self._context.group_pair_context[group]
         if run_list is not None and group_object is not None:
-            self._context.calculate_asymmetry_for(run_list, group_object)
-            self._context.show_group(run_list, group_object)
+            self._context.calculate_asymmetry_for(run_list, group_object, rebin)
+            self._context.show_group(run_list, group_object, rebin)
 
     def calculate_pairs_for(self, runs: list, groups: list) -> list:
         """Calculates the Pair Asymmetry workspaces which are concerned with the provided Runs and Groups."""

--- a/scripts/Muon/GUI/Common/corrections_tab_widget/corrections_model.py
+++ b/scripts/Muon/GUI/Common/corrections_tab_widget/corrections_model.py
@@ -50,18 +50,21 @@ class CorrectionsModel:
     count-corrected.
     """
 
-    def calculate_asymmetry_workspaces_for(self, runs: list, groups: list, rebins: list) -> None:
+    def calculate_asymmetry_workspaces_for(self, runs: list, groups: list) -> None:
         """Creates the asymmetry workspaces for the runs and groups provided using the Counts workspaces in the ADS."""
-        for run, group, rebin in zip(runs, groups, rebins):
-            self._create_asymmetry_workspace_for(run, group, rebin)
+        for run, group in zip(runs, groups):
+            self._create_asymmetry_workspace_for(run, group)
 
-    def _create_asymmetry_workspace_for(self, run: str, group: str, rebin: bool) -> None:
+    def _create_asymmetry_workspace_for(self, run: str, group: str) -> None:
         """Creates the asymmetry workspace for a run and group using its corresponding Counts workspace in the ADS."""
         run_list = run_string_to_list(run)
         group_object = self._context.group_pair_context[group]
         if run_list is not None and group_object is not None:
-            self._context.calculate_asymmetry_for(run_list, group_object, rebin)
-            self._context.show_group(run_list, group_object, rebin)
+            self._context.calculate_asymmetry_for(run_list, group_object, rebin=False)
+            self._context.show_group(run_list, group_object, rebin=False)
+            if self._context._do_rebin():
+                self._context.calculate_asymmetry_for(run_list, group_object, rebin=True)
+                self._context.show_group(run_list, group_object, rebin=True)
 
     def calculate_pairs_for(self, runs: list, groups: list) -> list:
         """Calculates the Pair Asymmetry workspaces which are concerned with the provided Runs and Groups."""

--- a/scripts/Muon/GUI/Common/corrections_tab_widget/corrections_presenter.py
+++ b/scripts/Muon/GUI/Common/corrections_tab_widget/corrections_presenter.py
@@ -120,8 +120,8 @@ class CorrectionsPresenter(QObject):
 
         corrected_runs_and_groups = self.thread_model_wrapper.result
         if corrected_runs_and_groups is not None:
-            runs, groups, rebins = corrected_runs_and_groups
-            self._perform_asymmetry_pairs_and_diffs_calculation(runs, groups, rebins)
+            runs, groups = corrected_runs_and_groups
+            self._perform_asymmetry_pairs_and_diffs_calculation(runs, groups)
 
     def handle_asymmetry_pairs_and_diffs_calc_finished(self) -> None:
         """Handle when the calculation of Asymmetry, Pairs and Diffs has finished finished."""
@@ -149,10 +149,10 @@ class CorrectionsPresenter(QObject):
         except ValueError as error:
             self.view.warning_popup(error)
 
-    def _calculate_asymmetry_pairs_and_diffs(self, runs: list, groups: list, rebins: list) -> None:
+    def _calculate_asymmetry_pairs_and_diffs(self, runs: list, groups: list) -> None:
         """Calculates the Asymmetry workspaces, Pairs and Diffs only for the provided runs and groups."""
         # Calculates the Asymmetry workspaces for the corresponding runs and groups that have just been corrected
-        self.model.calculate_asymmetry_workspaces_for(runs, groups, rebins)
+        self.model.calculate_asymmetry_workspaces_for(runs, groups)
         # Calculates the Pair Asymmetry workspaces for pairs formed from one or more groups which have been corrected
         pairs = self.model.calculate_pairs_for(runs, groups)
         # Calculates the Diff Asymmetry workspaces formed from one or more groups/pairs which have been corrected

--- a/scripts/Muon/GUI/Common/corrections_tab_widget/corrections_presenter.py
+++ b/scripts/Muon/GUI/Common/corrections_tab_widget/corrections_presenter.py
@@ -120,8 +120,8 @@ class CorrectionsPresenter(QObject):
 
         corrected_runs_and_groups = self.thread_model_wrapper.result
         if corrected_runs_and_groups is not None:
-            runs, groups = corrected_runs_and_groups
-            self._perform_asymmetry_pairs_and_diffs_calculation(runs, groups)
+            runs, groups, rebins = corrected_runs_and_groups
+            self._perform_asymmetry_pairs_and_diffs_calculation(runs, groups, rebins)
 
     def handle_asymmetry_pairs_and_diffs_calc_finished(self) -> None:
         """Handle when the calculation of Asymmetry, Pairs and Diffs has finished finished."""
@@ -149,10 +149,10 @@ class CorrectionsPresenter(QObject):
         except ValueError as error:
             self.view.warning_popup(error)
 
-    def _calculate_asymmetry_pairs_and_diffs(self, runs: list, groups: list) -> None:
+    def _calculate_asymmetry_pairs_and_diffs(self, runs: list, groups: list, rebins: list) -> None:
         """Calculates the Asymmetry workspaces, Pairs and Diffs only for the provided runs and groups."""
         # Calculates the Asymmetry workspaces for the corresponding runs and groups that have just been corrected
-        self.model.calculate_asymmetry_workspaces_for(runs, groups)
+        self.model.calculate_asymmetry_workspaces_for(runs, groups, rebins)
         # Calculates the Pair Asymmetry workspaces for pairs formed from one or more groups which have been corrected
         pairs = self.model.calculate_pairs_for(runs, groups)
         # Calculates the Diff Asymmetry workspaces formed from one or more groups/pairs which have been corrected

--- a/scripts/Muon/GUI/Common/corrections_tab_widget/corrections_presenter.py
+++ b/scripts/Muon/GUI/Common/corrections_tab_widget/corrections_presenter.py
@@ -52,6 +52,7 @@ class CorrectionsPresenter(QObject):
 
         self.enable_editing_notifier = GenericObservable()
         self.disable_editing_notifier = GenericObservable()
+        self.set_tab_warning_notifier = GenericObservable()
         self.perform_corrections_notifier = GenericObservable()
         self.asymmetry_pair_and_diff_calculations_finished_notifier = GenericObservable()
 
@@ -166,3 +167,7 @@ class CorrectionsPresenter(QObject):
     def warning_popup(self, message: str) -> None:
         """Displays a warning message."""
         self.view.warning_popup(message)
+
+    def set_tab_warning(self, message: str) -> None:
+        """Sets a warning message as the tooltip of the corrections tab."""
+        self.view.set_tab_warning(message)

--- a/scripts/Muon/GUI/Common/corrections_tab_widget/corrections_presenter.py
+++ b/scripts/Muon/GUI/Common/corrections_tab_widget/corrections_presenter.py
@@ -120,7 +120,8 @@ class CorrectionsPresenter(QObject):
 
         corrected_runs_and_groups = self.thread_model_wrapper.result
         if corrected_runs_and_groups is not None:
-            self._perform_asymmetry_pairs_and_diffs_calculation(*corrected_runs_and_groups)
+            runs, groups = corrected_runs_and_groups
+            self._perform_asymmetry_pairs_and_diffs_calculation(runs, groups)
 
     def handle_asymmetry_pairs_and_diffs_calc_finished(self) -> None:
         """Handle when the calculation of Asymmetry, Pairs and Diffs has finished finished."""

--- a/scripts/Muon/GUI/Common/corrections_tab_widget/corrections_presenter.py
+++ b/scripts/Muon/GUI/Common/corrections_tab_widget/corrections_presenter.py
@@ -131,7 +131,7 @@ class CorrectionsPresenter(QObject):
         """Handle when an error occurs while doing calculations on a thread."""
         self.disable_editing_notifier.notify_subscribers()
         self.thread_success = False
-        self.warning_popup(error)
+        self.view.warning_popup(error)
 
     def current_run_string(self) -> str:
         """Returns the currently selected run string."""
@@ -146,7 +146,7 @@ class CorrectionsPresenter(QObject):
                                                        self.handle_thread_error)
             self.calculation_thread.start()
         except ValueError as error:
-            self._corrections_presenter.warning_popup(error)
+            self.view.warning_popup(error)
 
     def _calculate_asymmetry_pairs_and_diffs(self, runs: list, groups: list) -> None:
         """Calculates the Asymmetry workspaces, Pairs and Diffs only for the provided runs and groups."""

--- a/scripts/Muon/GUI/Common/corrections_tab_widget/corrections_presenter.py
+++ b/scripts/Muon/GUI/Common/corrections_tab_widget/corrections_presenter.py
@@ -13,6 +13,8 @@ from Muon.GUI.Common.corrections_tab_widget.corrections_model import Corrections
 from Muon.GUI.Common.corrections_tab_widget.corrections_view import CorrectionsView
 from Muon.GUI.Common.corrections_tab_widget.dead_time_corrections_model import DeadTimeCorrectionsModel
 from Muon.GUI.Common.corrections_tab_widget.dead_time_corrections_presenter import DeadTimeCorrectionsPresenter
+from Muon.GUI.Common.thread_model import ThreadModel
+from Muon.GUI.Common.thread_model_wrapper import ThreadModelWrapperWithOutput
 
 from qtpy.QtCore import QMetaObject, QObject, Slot
 
@@ -27,6 +29,8 @@ class CorrectionsPresenter(QObject):
         super(CorrectionsPresenter, self).__init__()
         self.view = view
         self.model = model
+
+        self.thread_success = True
 
         self.dead_time_model = DeadTimeCorrectionsModel(model, context.data_context, context.corrections_context)
         self.dead_time_presenter = DeadTimeCorrectionsPresenter(self.view.dead_time_view, self.dead_time_model, self)
@@ -101,9 +105,62 @@ class CorrectionsPresenter(QObject):
         self.dead_time_presenter.handle_pre_process_and_counts_calculated()
         self.background_presenter.handle_pre_process_and_counts_calculated()
 
+    def handle_thread_calculation_started(self) -> None:
+        """Handles when a calculation on a thread has started."""
+        self.disable_editing_notifier.notify_subscribers()
+        self.thread_success = True
+
+    def handle_background_corrections_for_all_finished(self) -> None:
+        """Handle when the background corrections for all has finished."""
+        self.enable_editing_notifier.notify_subscribers()
+        if not self.thread_success:
+            return
+
+        self.background_presenter.handle_background_corrections_for_all_finished()
+
+        corrected_runs_and_groups = self.thread_model_wrapper.result
+        if corrected_runs_and_groups is not None:
+            self._perform_asymmetry_pairs_and_diffs_calculation(*corrected_runs_and_groups)
+
+    def handle_asymmetry_pairs_and_diffs_calc_finished(self) -> None:
+        """Handle when the calculation of Asymmetry, Pairs and Diffs has finished finished."""
+        self.enable_editing_notifier.notify_subscribers()
+        self.asymmetry_pair_and_diff_calculations_finished_notifier.notify_subscribers()
+
+    def handle_thread_error(self, error: str) -> None:
+        """Handle when an error occurs while doing calculations on a thread."""
+        self.disable_editing_notifier.notify_subscribers()
+        self.thread_success = False
+        self.warning_popup(error)
+
     def current_run_string(self) -> str:
         """Returns the currently selected run string."""
         return self.model.current_run_string()
+
+    def _perform_asymmetry_pairs_and_diffs_calculation(self, *args) -> None:
+        """Calculate the Asymmetry workspaces, Pairs and Diffs on a thread after background corrections are complete."""
+        try:
+            self.calculation_thread = self.create_calculation_thread(self._calculate_asymmetry_pairs_and_diffs, *args)
+            self.calculation_thread.threadWrapperSetUp(self.handle_thread_calculation_started,
+                                                       self.handle_asymmetry_pairs_and_diffs_calc_finished,
+                                                       self.handle_thread_error)
+            self.calculation_thread.start()
+        except ValueError as error:
+            self._corrections_presenter.warning_popup(error)
+
+    def _calculate_asymmetry_pairs_and_diffs(self, runs: list, groups: list) -> None:
+        """Calculates the Asymmetry workspaces, Pairs and Diffs only for the provided runs and groups."""
+        # Calculates the Asymmetry workspaces for the corresponding runs and groups that have just been corrected
+        self.model.calculate_asymmetry_workspaces_for(runs, groups)
+        # Calculates the Pair Asymmetry workspaces for pairs formed from one or more groups which have been corrected
+        pairs = self.model.calculate_pairs_for(runs, groups)
+        # Calculates the Diff Asymmetry workspaces formed from one or more groups/pairs which have been corrected
+        self.model.calculate_diffs_for(runs, groups + pairs)
+
+    def create_calculation_thread(self, callback, *args) -> ThreadModel:
+        """Create a thread for calculations."""
+        self.thread_model_wrapper = ThreadModelWrapperWithOutput(callback, *args)
+        return ThreadModel(self.thread_model_wrapper)
 
     def warning_popup(self, message: str) -> None:
         """Displays a warning message."""

--- a/scripts/Muon/GUI/Common/corrections_tab_widget/corrections_presenter.py
+++ b/scripts/Muon/GUI/Common/corrections_tab_widget/corrections_presenter.py
@@ -44,7 +44,7 @@ class CorrectionsPresenter(QObject):
         self.instrument_changed_observer = GenericObserver(self.handle_instrument_changed)
         self.load_observer = GenericObserver(self.handle_runs_loaded)
         self.group_change_observer = GenericObserver(self.handle_groups_changed)
-        self.pre_process_and_grouping_complete_observer = GenericObserver(self.handle_pre_process_and_grouping_complete)
+        self.pre_process_and_counts_calculated_observer = GenericObserver(self.handle_pre_process_and_counts_calculated)
 
         self.enable_editing_notifier = GenericObservable()
         self.disable_editing_notifier = GenericObservable()
@@ -95,10 +95,10 @@ class CorrectionsPresenter(QObject):
         self.dead_time_presenter.handle_run_selector_changed()
         self.background_presenter.handle_run_selector_changed()
 
-    def handle_pre_process_and_grouping_complete(self) -> None:
-        """Handles when MuonPreProcess and grouping has been completed."""
-        self.dead_time_presenter.handle_pre_process_and_grouping_complete()
-        self.background_presenter.handle_pre_process_and_grouping_complete()
+    def handle_pre_process_and_counts_calculated(self) -> None:
+        """Handles when MuonPreProcess and counts workspaces have been calculated."""
+        self.dead_time_presenter.handle_pre_process_and_counts_calculated()
+        self.background_presenter.handle_pre_process_and_counts_calculated()
 
     def current_run_string(self) -> str:
         """Returns the currently selected run string."""

--- a/scripts/Muon/GUI/Common/corrections_tab_widget/corrections_presenter.py
+++ b/scripts/Muon/GUI/Common/corrections_tab_widget/corrections_presenter.py
@@ -49,6 +49,7 @@ class CorrectionsPresenter(QObject):
         self.enable_editing_notifier = GenericObservable()
         self.disable_editing_notifier = GenericObservable()
         self.perform_corrections_notifier = GenericObservable()
+        self.asymmetry_pair_and_diff_calculations_finished_notifier = GenericObservable()
 
     def initialize_model_options(self) -> None:
         """Initialise the model with the default fitting options."""

--- a/scripts/Muon/GUI/Common/corrections_tab_widget/corrections_tab_widget.py
+++ b/scripts/Muon/GUI/Common/corrections_tab_widget/corrections_tab_widget.py
@@ -17,7 +17,7 @@ class CorrectionsTabWidget(object):
 
     def __init__(self, context, parent):
         self.corrections_tab_view = CorrectionsView(parent)
-        self.corrections_tab_model = CorrectionsModel(context.data_context, context.corrections_context)
+        self.corrections_tab_model = CorrectionsModel(context)
         self.corrections_tab_presenter = CorrectionsPresenter(self.corrections_tab_view, self.corrections_tab_model,
                                                               context)
 

--- a/scripts/Muon/GUI/Common/corrections_tab_widget/corrections_view.py
+++ b/scripts/Muon/GUI/Common/corrections_tab_widget/corrections_view.py
@@ -30,13 +30,13 @@ class CorrectionsView(widget, ui_form):
         self.run_selector = CyclicDataSelectorView(self)
         self.run_selector.set_data_combo_box_label("Runs :")
         self.run_selector.set_data_combo_box_label_width(50)
-        self.run_selector_layout.addWidget(self.run_selector)
+        self.corrections_layout.addWidget(self.run_selector, 1)
 
         self.dead_time_corrections_view = DeadTimeCorrectionsView(self)
-        self.dead_time_layout.addWidget(self.dead_time_corrections_view)
+        self.corrections_layout.addWidget(self.dead_time_corrections_view, 1)
 
         self.background_corrections_view = BackgroundCorrectionsView(self)
-        self.background_layout.addWidget(self.background_corrections_view)
+        self.corrections_layout.addWidget(self.background_corrections_view, 10)
 
         self.disable_tab_observer = GenericObserver(self.disable_view)
         self.enable_tab_observer = GenericObserver(self.enable_view)

--- a/scripts/Muon/GUI/Common/corrections_tab_widget/corrections_view.py
+++ b/scripts/Muon/GUI/Common/corrections_tab_widget/corrections_view.py
@@ -26,6 +26,7 @@ class CorrectionsView(widget, ui_form):
         """Initializes the CorrectionsView."""
         super(CorrectionsView, self).__init__(parent)
         self.setupUi(self)
+        self.parent = parent
 
         self.run_selector = CyclicDataSelectorView(self)
         self.run_selector.set_data_combo_box_label("Runs :")
@@ -52,6 +53,11 @@ class CorrectionsView(widget, ui_form):
     def background_view(self) -> BackgroundCorrectionsView:
         """Returns the background corrections view."""
         return self.background_corrections_view
+
+    def set_tab_warning(self, message: str) -> None:
+        """Sets a warning message as the tooltip of the corrections tab."""
+        if self.parent is not None:
+            self.parent.set_tab_warning("Corrections", message)
 
     def set_slot_for_run_selector_changed(self, slot) -> None:
         """Connect the slot for the Run Selector combobox"""

--- a/scripts/Muon/GUI/Common/corrections_tab_widget/corrections_view.ui
+++ b/scripts/Muon/GUI/Common/corrections_tab_widget/corrections_view.ui
@@ -15,13 +15,7 @@
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
    <item>
-    <layout class="QGridLayout" name="run_selector_layout"/>
-   </item>
-   <item>
-    <layout class="QGridLayout" name="dead_time_layout"/>
-   </item>
-   <item>
-    <layout class="QGridLayout" name="background_layout"/>
+    <layout class="QVBoxLayout" name="corrections_layout"/>
    </item>
   </layout>
  </widget>

--- a/scripts/Muon/GUI/Common/corrections_tab_widget/dead_time_corrections_presenter.py
+++ b/scripts/Muon/GUI/Common/corrections_tab_widget/dead_time_corrections_presenter.py
@@ -106,8 +106,8 @@ class DeadTimeCorrectionsPresenter:
                 else:
                     self._corrections_presenter.warning_popup(error)
 
-    def handle_pre_process_and_grouping_complete(self) -> None:
-        """Handles when MuonPreProcess and grouping has been completed."""
+    def handle_pre_process_and_counts_calculated(self) -> None:
+        """Handles when MuonPreProcess and counts workspaces have been calculated."""
         self.update_dead_time_info_text_in_view()
 
     def update_dead_time_info_text_in_view(self) -> None:

--- a/scripts/Muon/GUI/Common/dock/dockable_tabs.py
+++ b/scripts/Muon/GUI/Common/dock/dockable_tabs.py
@@ -10,8 +10,6 @@ from qtpy import QtWidgets, QtCore, QtGui, PYQT4
 from qtpy.QtCore import Slot
 from qtpy.QtGui import QIcon
 
-INVALID_TAB_ICON = icons.get_icon("mdi.asterisk", "red", 0.5)
-
 """
 Original code by user Blackwood, Jan 2018.
 https://stackoverflow.com/questions/47267195/in-pyqt4-is-it-possible-to-detach-tabs-from-a-qtabwidget
@@ -41,6 +39,9 @@ class DetachableTabWidget(QtWidgets.QTabWidget):
         self.tab_order = []
         self.attached_tab_names = []
 
+        self.valid_tab_icon = QIcon()
+        self.invalid_tab_icon = icons.get_icon("mdi.asterisk", "red", 0.5)
+
         # Close all detached tabs if the application is closed explicitly
         # QtGui.qApp.aboutToQuit.connect(self.close_detached_tabs)  # @UndefinedVariable
 
@@ -49,7 +50,7 @@ class DetachableTabWidget(QtWidgets.QTabWidget):
 
     def set_tab_warning(self, index: int, message: str) -> None:
         """Adds a tooltip to a tab with a warning message."""
-        self.setTabIcon(index, INVALID_TAB_ICON if message != "" else QIcon())
+        self.setTabIcon(index, self.invalid_tab_icon if message != "" else self.valid_tab_icon)
         self.setTabToolTip(index, message)
 
     def setMovable(self, movable):

--- a/scripts/Muon/GUI/Common/dock/dockable_tabs.py
+++ b/scripts/Muon/GUI/Common/dock/dockable_tabs.py
@@ -4,8 +4,13 @@
 #   NScD Oak Ridge National Laboratory, European Spallation Source,
 #   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
 # SPDX - License - Identifier: GPL - 3.0 +
+from mantidqt import icons
+
 from qtpy import QtWidgets, QtCore, QtGui, PYQT4
 from qtpy.QtCore import Slot
+from qtpy.QtGui import QIcon
+
+INVALID_TAB_ICON = icons.get_icon("mdi.asterisk", "red", 0.5)
 
 """
 Original code by user Blackwood, Jan 2018.
@@ -41,6 +46,11 @@ class DetachableTabWidget(QtWidgets.QTabWidget):
 
     def closeEvent(self, event):
         self.close_detached_tabs()
+
+    def set_tab_warning(self, index: int, message: str) -> None:
+        """Adds a tooltip to a tab with a warning message."""
+        self.setTabIcon(index, INVALID_TAB_ICON if message != "" else QIcon())
+        self.setTabToolTip(index, message)
 
     def setMovable(self, movable):
         """

--- a/scripts/Muon/GUI/Common/grouping_tab_widget/grouping_tab_widget_model.py
+++ b/scripts/Muon/GUI/Common/grouping_tab_widget/grouping_tab_widget_model.py
@@ -40,8 +40,8 @@ class GroupingTabModel(object):
         try:
             workspace = self._groups_and_pairs[group_name].workspace[MuonRun(run)].workspace
         except AttributeError:
-            workspace = self._context.calculate_group(group_name, run, rebin=False)
-            self._groups_and_pairs[group_name].update_counts_workspace(workspace, MuonRun(run))
+            workspace = self._context.calculate_counts(run, group_name, rebin=False)
+            self._groups_and_pairs[group_name].update_counts_workspace(MuonRun(run), workspace)
         return workspace
 
     @property

--- a/scripts/Muon/GUI/Common/grouping_tab_widget/grouping_tab_widget_model.py
+++ b/scripts/Muon/GUI/Common/grouping_tab_widget/grouping_tab_widget_model.py
@@ -103,7 +103,7 @@ class GroupingTabModel(object):
         # Calculates the counts workspaces and then triggers the background correction process. The corrections are
         # performed, the Asymmetry workspaces generated based off the corrected counts, and then the pairs and diffs
         # are calculated.
-        self._context.calculate_all_groups()
+        self._context.calculate_all_counts()
 
     def clear_groups(self):
         self._groups_and_pairs.clear_groups()

--- a/scripts/Muon/GUI/Common/grouping_tab_widget/grouping_tab_widget_model.py
+++ b/scripts/Muon/GUI/Common/grouping_tab_widget/grouping_tab_widget_model.py
@@ -99,10 +99,11 @@ class GroupingTabModel(object):
     def selected_groups_and_pairs(self):
         return self._groups_and_pairs.selected_groups_and_pairs
 
-    def show_all_groups_and_pairs(self):
-        self._context.show_all_groups()
-        self._context.show_all_pairs()
-        self._context.show_all_diffs()
+    def calculate_all_data(self):
+        # Calculates the counts workspaces and then triggers the background correction process. The corrections are
+        # performed, the Asymmetry workspaces generated based off the corrected counts, and then the pairs and diffs
+        # are calculated.
+        self._context.calculate_all_groups()
 
     def clear_groups(self):
         self._groups_and_pairs.clear_groups()

--- a/scripts/Muon/GUI/Common/grouping_tab_widget/grouping_tab_widget_presenter.py
+++ b/scripts/Muon/GUI/Common/grouping_tab_widget/grouping_tab_widget_presenter.py
@@ -57,7 +57,7 @@ class GroupingTabPresenter(object):
         self.pairing_table_widget.on_data_changed(self.pair_table_changed)
         self.enable_editing_notifier = GroupingTabPresenter.EnableEditingNotifier(self)
         self.disable_editing_notifier = GroupingTabPresenter.DisableEditingNotifier(self)
-        self.calculation_finished_notifier = GenericObservable()
+        self.counts_calculation_finished_notifier = GenericObservable()
 
         self.guessAlphaObserver = GroupingTabPresenter.GuessAlphaObserver(self)
         self.pairing_table_widget.guessAlphaNotifier.add_subscriber(self.guessAlphaObserver)
@@ -214,7 +214,7 @@ class GroupingTabPresenter(object):
         self.pairing_table_widget.enable_editing()
 
     def calculate_all_data(self):
-        self._model.show_all_groups_and_pairs()
+        self._model.calculate_all_data()
 
     def handle_update_all_clicked(self):
         self.update_thread = self.create_update_thread()
@@ -230,7 +230,7 @@ class GroupingTabPresenter(object):
     def handle_update_finished(self):
         self.enable_editing()
         self.groupingNotifier.notify_subscribers()
-        self.calculation_finished_notifier.notify_subscribers()
+        self.counts_calculation_finished_notifier.notify_subscribers()
 
     def handle_default_grouping_button_clicked(self):
         status = self._model.reset_groups_and_pairs_to_default()

--- a/scripts/Muon/GUI/Common/grouping_tab_widget/grouping_tab_widget_presenter.py
+++ b/scripts/Muon/GUI/Common/grouping_tab_widget/grouping_tab_widget_presenter.py
@@ -252,6 +252,7 @@ class GroupingTabPresenter(object):
         self.diff_table.update_view_from_model()
         self.pairing_table_widget.update_view_from_model()
         self.update_description_text_to_empty()
+        self.groupingNotifier.notify_subscribers()
 
     def handle_new_data_loaded(self):
         self.period_info_widget.clear()

--- a/scripts/Muon/GUI/Common/grouping_table_widget/grouping_table_widget_presenter.py
+++ b/scripts/Muon/GUI/Common/grouping_table_widget/grouping_table_widget_presenter.py
@@ -78,8 +78,9 @@ class GroupingTablePresenter(object):
 
     def validate_detector_ids(self, text):
         try:
-            if re.match(run_utils.run_string_regex, text):
-                return self._validate_detector_ids_list(run_utils.run_string_to_list(text, False))
+            if re.match(run_utils.run_string_regex, text) and \
+                    self._validate_detector_ids_list(run_utils.run_string_to_list(text, False)):
+                return True
         except OverflowError:
             pass
 

--- a/scripts/Muon/GUI/Common/home_tab/home_tab_model.py
+++ b/scripts/Muon/GUI/Common/home_tab/home_tab_model.py
@@ -17,8 +17,3 @@ class HomeTabModel(object):
 
     def loaded_instrument(self):
         return self._data.instrument
-
-    def show_all_data(self):
-        self._context.show_raw_data()
-        self._context.show_all_groups()
-        self._context.show_all_pairs()

--- a/scripts/Muon/GUI/Common/muon_group.py
+++ b/scripts/Muon/GUI/Common/muon_group.py
@@ -114,19 +114,19 @@ class MuonGroup(object):
         run_object not in self._asymmetry_estimate_rebin_unormalised or \
             self._asymmetry_estimate_rebin_unormalised[run_object].show(asym_name_unnorm)
 
-    def update_workspaces(self, run, counts_workspace, asymmetry_workspace, asymmetry_workspace_unnorm, rebin):
-        run_object = MuonRun(run)
+    def update_counts_workspace(self, run: MuonRun, counts_workspace, rebin=False):
         if rebin:
-            self._counts_workspace_rebin.update({run_object: MuonWorkspaceWrapper(counts_workspace)})
-            self._asymmetry_estimate_rebin.update({run_object: MuonWorkspaceWrapper(asymmetry_workspace)})
-            self._asymmetry_estimate_rebin_unormalised.update({run_object: MuonWorkspaceWrapper(asymmetry_workspace_unnorm)})
+            self._counts_workspace_rebin.update({run: MuonWorkspaceWrapper(counts_workspace)})
         else:
-            self._counts_workspace.update({run_object: MuonWorkspaceWrapper(counts_workspace)})
-            self._asymmetry_estimate.update({run_object: MuonWorkspaceWrapper(asymmetry_workspace)})
-            self._asymmetry_estimate_unormalised.update({run_object: MuonWorkspaceWrapper(asymmetry_workspace_unnorm)})
+            self._counts_workspace.update({run: MuonWorkspaceWrapper(counts_workspace)})
 
-    def update_counts_workspace(self, counts_workspace, run):
-        self._counts_workspace.update({run: MuonWorkspaceWrapper(counts_workspace)})
+    def update_asymmetry_workspace(self, run: MuonRun, asymmetry_workspace, asymmetry_workspace_unnorm, rebin=False):
+        if rebin:
+            self._asymmetry_estimate_rebin.update({run: MuonWorkspaceWrapper(asymmetry_workspace)})
+            self._asymmetry_estimate_rebin_unormalised.update({run: MuonWorkspaceWrapper(asymmetry_workspace_unnorm)})
+        else:
+            self._asymmetry_estimate.update({run: MuonWorkspaceWrapper(asymmetry_workspace)})
+            self._asymmetry_estimate_unormalised.update({run: MuonWorkspaceWrapper(asymmetry_workspace_unnorm)})
 
     def get_asymmetry_workspace_names(self, runs):
         workspace_list = []

--- a/scripts/Muon/GUI/Common/test_helpers/general_test_helpers.py
+++ b/scripts/Muon/GUI/Common/test_helpers/general_test_helpers.py
@@ -6,6 +6,7 @@
 # SPDX - License - Identifier: GPL - 3.0 +
 from mantid.simpleapi import CreateWorkspace
 from Muon.GUI.Common.ADSHandler.muon_workspace_wrapper import MuonWorkspaceWrapper
+from Muon.GUI.Common.muon_base import MuonRun
 from Muon.GUI.Common.muon_group import MuonGroup
 
 
@@ -22,17 +23,17 @@ def create_group_populated_by_two_workspace():
     asymmetry_workspace_22222 = CreateWorkspace([0], [0])
     asymmetry_workspace_unnorm_22222 = CreateWorkspace([0], [0])
 
-    group.update_workspaces([22222], counts_workspace_22222, asymmetry_workspace_22222,
-                            asymmetry_workspace_unnorm_22222,
-                            False)
+    group.update_counts_workspace(MuonRun([22222]), counts_workspace_22222, False)
+    group.update_asymmetry_workspace(MuonRun([22222]), asymmetry_workspace_22222, asymmetry_workspace_unnorm_22222, False)
+
     group.show_raw([22222], 'counts_name_22222', 'asymmetry_name_22222', 'asymmetry_name_22222_unnorm')
     counts_workspace_33333 = CreateWorkspace([0], [0])
     asymmetry_workspace_33333 = CreateWorkspace([0], [0])
     asymmetry_workspace_unnorm_33333 = CreateWorkspace([0], [0])
 
-    group.update_workspaces([33333], counts_workspace_33333, asymmetry_workspace_33333,
-                            asymmetry_workspace_unnorm_33333,
-                            False)
+    group.update_counts_workspace(MuonRun([33333]), counts_workspace_33333, False)
+    group.update_asymmetry_workspace(MuonRun([33333]), asymmetry_workspace_33333, asymmetry_workspace_unnorm_33333, False)
+
     group.show_raw([33333], 'counts_name_33333', 'asymmetry_name_33333', 'asymmetry_name_33333_unnorm')
 
     return group
@@ -44,17 +45,17 @@ def create_group_populated_by_two_rebinned_workspaces():
     asymmetry_workspace_22222 = CreateWorkspace([0], [0])
     asymmetry_workspace_unnorm_22222 = CreateWorkspace([0], [0])
 
-    group.update_workspaces([22222], counts_workspace_22222, asymmetry_workspace_22222,
-                            asymmetry_workspace_unnorm_22222,
-                            True)
+    group.update_counts_workspace(MuonRun([22222]), counts_workspace_22222, True)
+    group.update_asymmetry_workspace(MuonRun([22222]), asymmetry_workspace_22222, asymmetry_workspace_unnorm_22222, True)
+
     group.show_rebin([22222], 'counts_name_22222_rebin', 'asymmetry_name_22222_rebin', 'asymmetry_name_22222_unnorm')
     counts_workspace_33333 = CreateWorkspace([0], [0])
     asymmetry_workspace_33333 = CreateWorkspace([0], [0])
     asymmetry_workspace_unnorm_33333 = CreateWorkspace([0], [0])
 
-    group.update_workspaces([33333], counts_workspace_33333, asymmetry_workspace_33333,
-                            asymmetry_workspace_unnorm_33333,
-                            True)
+    group.update_counts_workspace(MuonRun([33333]), counts_workspace_33333, True)
+    group.update_asymmetry_workspace(MuonRun([33333]), asymmetry_workspace_33333, asymmetry_workspace_unnorm_33333, True)
+
     group.show_rebin([33333], 'counts_name_33333_rebin', 'asymmetry_name_33333_rebin', 'asymmetry_name_33333_unnorm')
 
     return group
@@ -65,33 +66,30 @@ def create_group_populated_by_two_binned_and_two_unbinned_workspaces():
     counts_workspace_22222 = CreateWorkspace([0], [0])
     asymmetry_workspace_22222 = CreateWorkspace([0], [0])
     asymmetry_workspace_unnorm_22222 = CreateWorkspace([0], [0])
-    group.update_workspaces([22222], counts_workspace_22222, asymmetry_workspace_22222, asymmetry_workspace_unnorm_22222
-                            , False)
+    group.update_counts_workspace(MuonRun([22222]), counts_workspace_22222, False)
+    group.update_asymmetry_workspace(MuonRun([22222]), asymmetry_workspace_22222, asymmetry_workspace_unnorm_22222, False)
     group.show_raw([22222], 'counts_name_22222', 'asymmetry_name_22222', 'asymmetry_name_22222_unnorm')
     counts_workspace_33333 = CreateWorkspace([0], [0])
     asymmetry_workspace_33333 = CreateWorkspace([0], [0])
     asymmetry_workspace_unnorm_33333 = CreateWorkspace([0], [0])
 
-    group.update_workspaces([33333], counts_workspace_33333, asymmetry_workspace_33333,
-                            asymmetry_workspace_unnorm_33333,
-                            False)
+    group.update_counts_workspace(MuonRun([33333]), counts_workspace_33333, False)
+    group.update_asymmetry_workspace(MuonRun([33333]), asymmetry_workspace_33333, asymmetry_workspace_unnorm_33333, False)
     group.show_raw([33333], 'counts_name_33333', 'asymmetry_name_33333', 'asymmetry_name_33333_unnorm')
 
     counts_workspace_22222 = CreateWorkspace([0], [0])
     asymmetry_workspace_22222 = CreateWorkspace([0], [0])
     asymmetry_workspace_unnorm_22222 = CreateWorkspace([0], [0])
 
-    group.update_workspaces([22222], counts_workspace_22222, asymmetry_workspace_22222,
-                            asymmetry_workspace_unnorm_22222,
-                            True)
+    group.update_counts_workspace(MuonRun([22222]), counts_workspace_22222, True)
+    group.update_asymmetry_workspace(MuonRun([22222]), asymmetry_workspace_22222, asymmetry_workspace_unnorm_22222, True)
     group.show_rebin([22222], 'counts_name_22222_rebin', 'asymmetry_name_22222_rebin', 'asymmetry_name_22222_unnorm')
     counts_workspace_33333 = CreateWorkspace([0], [0])
     asymmetry_workspace_33333 = CreateWorkspace([0], [0])
     asymmetry_workspace_unnorm_33333 = CreateWorkspace([0], [0])
 
-    group.update_workspaces([33333], counts_workspace_33333, asymmetry_workspace_33333,
-                            asymmetry_workspace_unnorm_33333,
-                            True)
+    group.update_counts_workspace(MuonRun([33333]), counts_workspace_33333, True)
+    group.update_asymmetry_workspace(MuonRun([33333]), asymmetry_workspace_33333, asymmetry_workspace_unnorm_33333, True)
     group.show_rebin([33333], 'counts_name_33333_rebin', 'asymmetry_name_33333_rebin', 'asymmetry_name_22222_unnorm')
 
     return group

--- a/scripts/Muon/GUI/Common/utilities/algorithm_utils.py
+++ b/scripts/Muon/GUI/Common/utilities/algorithm_utils.py
@@ -307,13 +307,13 @@ def apply_deadtime(ws, output, table):
     return alg.getProperty("OutputWorkspace").valueAsStr
 
 
-def calculate_diff_data(diff, positive_workspace_name, negative_workspace_name, output):
+def run_minus(lhs_workspace, rhs_workspace, output_name):
     alg = mantid.AlgorithmManager.create("Minus")
     alg.initialize()
     alg.setAlwaysStoreInADS(True)
-    alg.setProperty("LHSWorkspace", positive_workspace_name)
-    alg.setProperty("RHSWorkspace", negative_workspace_name)
-    alg.setProperty("OutputWorkspace", output)
+    alg.setProperty("LHSWorkspace", lhs_workspace)
+    alg.setProperty("RHSWorkspace", rhs_workspace)
+    alg.setProperty("OutputWorkspace", output_name)
     alg.execute()
     return alg.getProperty("OutputWorkspace").valueAsStr
 

--- a/scripts/Muon/GUI/Common/utilities/algorithm_utils.py
+++ b/scripts/Muon/GUI/Common/utilities/algorithm_utils.py
@@ -336,3 +336,11 @@ def run_create_single_valued_workspace(parameter_dict):
     alg.setProperties(parameter_dict)
     alg.execute()
     return alg.getProperty("OutputWorkspace").valueAsStr
+
+
+def run_clone_workspace(parameter_dict):
+    alg = mantid.AlgorithmManager.create("CloneWorkspace")
+    alg.initialize()
+    alg.setProperties(parameter_dict)
+    alg.execute()
+    return alg.getProperty("OutputWorkspace").valueAsStr

--- a/scripts/Muon/GUI/Common/utilities/algorithm_utils.py
+++ b/scripts/Muon/GUI/Common/utilities/algorithm_utils.py
@@ -328,3 +328,11 @@ def run_crop_workspace(ws, start, end):
     alg.setProperty("XMax", end)
     alg.execute()
     return alg.getProperty("OutputWorkspace").valueAsStr
+
+
+def run_create_single_valued_workspace(parameter_dict):
+    alg = mantid.AlgorithmManager.create("CreateSingleValuedWorkspace")
+    alg.initialize()
+    alg.setProperties(parameter_dict)
+    alg.execute()
+    return alg.getProperty("OutputWorkspace").valueAsStr

--- a/scripts/Muon/GUI/Common/utilities/table_utils.py
+++ b/scripts/Muon/GUI/Common/utilities/table_utils.py
@@ -85,6 +85,41 @@ def setRowName(table, row, name, col=0):
     table.setItem(row, col, text)
 
 
+def set_table_item_flags(item: QtWidgets.QTableWidgetItem, editable: bool, enabled: bool) -> QtWidgets.QTableWidgetItem:
+    if not editable:
+        item.setFlags(item.flags() ^ QtCore.Qt.ItemIsEditable)
+    if not enabled:
+        item.setFlags(item.flags() ^ QtCore.Qt.ItemIsEnabled)
+    return item
+
+
+def create_string_table_item(text: str, editable: bool = True, enabled: bool = True, alignment: int = QtCore.Qt.AlignCenter) \
+        -> QtWidgets.QTableWidgetItem:
+    item = QtWidgets.QTableWidgetItem(text)
+    item.setTextAlignment(alignment)
+    item = set_table_item_flags(item, editable, enabled)
+    return item
+
+
+def create_double_table_item(value: float, editable: bool = True, enabled: bool = True, decimals: int = 3) \
+        -> QtWidgets.QTableWidgetItem:
+    return create_string_table_item(f"{value:.{decimals}f}", editable, enabled)
+
+
+def create_checkbox_table_item(state: bool, enabled: bool = True, tooltip: str = "") -> QtWidgets.QTableWidgetItem:
+    item = QtWidgets.QTableWidgetItem()
+    item.setToolTip(tooltip)
+    if enabled:
+        item.setFlags(QtCore.Qt.ItemIsUserCheckable | QtCore.Qt.ItemIsEnabled)
+    else:
+        item.setFlags(item.flags() ^ QtCore.Qt.ItemIsEnabled)
+    if state:
+        item.setCheckState(QtCore.Qt.Checked)
+    else:
+        item.setCheckState(QtCore.Qt.Unchecked)
+    return item
+
+
 def addComboToTable(table,row,options,col=1):
     combo=QtWidgets.QComboBox()
     combo.addItems(options)
@@ -104,15 +139,9 @@ def addDoubleToTable(table, value, row, col=1, minimum=0.0):
 
 
 def addCheckBoxToTable(table,state,row,col=1):
-    box = QtWidgets.QTableWidgetItem()
-    box.setFlags(QtCore.Qt.ItemIsUserCheckable | QtCore.Qt.ItemIsEnabled)
-    if state:
-        box.setCheckState(QtCore.Qt.Checked)
-    else:
-        box.setCheckState(QtCore.Qt.Unchecked)
-
-    table.setItem(row,col, box)
-    return box
+    item = create_checkbox_table_item(state)
+    table.setItem(row, col, item)
+    return item
 
 
 def addCheckBoxWidgetToTable(table,state,row,col=1):

--- a/scripts/Muon/GUI/FrequencyDomainAnalysis/Transform/transform_widget.py
+++ b/scripts/Muon/GUI/FrequencyDomainAnalysis/Transform/transform_widget.py
@@ -19,7 +19,7 @@ class TransformWidget(QtWidgets.QWidget):
         self._fft = fft_widget(load=context, parent=self)
         self._maxent = maxent_widget(context=context, parent=self)
         self._selector = TransformSelectionWidget(parent=self)
-        self.LoadObserver = LoadObserver(self)
+        self.load_observer = LoadObserver(self)
         self.context = context
         self.instrumentObserver = instrumentObserver(self)
         self.GroupPairObserver = GenericObserver(self.handle_new_group_pair)

--- a/scripts/Muon/GUI/FrequencyDomainAnalysis/frequency_domain_analysis.py
+++ b/scripts/Muon/GUI/FrequencyDomainAnalysis/frequency_domain_analysis.py
@@ -424,7 +424,8 @@ class FrequencyAnalysisGui(QtWidgets.QMainWindow):
 
     def setup_asymmetry_pair_and_diff_calculations_finished_notifier(self):
         for observer in self.plot_widget.data_changed_observers:
-            self.corrections_tab.corrections_tab_presenter.counts_calculation_finished_notifier.add_subscriber(observer)
+            self.corrections_tab.corrections_tab_presenter.asymmetry_pair_and_diff_calculations_finished_notifier.\
+                add_subscriber(observer)
             self.phase_tab.phase_table_presenter.calculation_finished_notifier.add_subscriber(observer)
 
         self.corrections_tab.corrections_tab_presenter.asymmetry_pair_and_diff_calculations_finished_notifier.add_subscriber(

--- a/scripts/Muon/GUI/FrequencyDomainAnalysis/frequency_domain_analysis.py
+++ b/scripts/Muon/GUI/FrequencyDomainAnalysis/frequency_domain_analysis.py
@@ -420,7 +420,7 @@ class FrequencyAnalysisGui(QtWidgets.QMainWindow):
 
     def setup_counts_calculation_finished_notifier(self):
         self.grouping_tab_widget.group_tab_presenter.counts_calculation_finished_notifier.add_subscriber(
-            self.corrections_tab.corrections_tab_presenter.pre_process_and_grouping_complete_observer)
+            self.corrections_tab.corrections_tab_presenter.pre_process_and_counts_calculated_observer)
 
     def setup_asymmetry_pair_and_diff_calculations_finished_notifier(self):
         for observer in self.plot_widget.data_changed_observers:

--- a/scripts/Muon/GUI/FrequencyDomainAnalysis/frequency_domain_analysis.py
+++ b/scripts/Muon/GUI/FrequencyDomainAnalysis/frequency_domain_analysis.py
@@ -172,7 +172,9 @@ class FrequencyAnalysisGui(QtWidgets.QMainWindow):
         self.setup_phase_table_changed_notifier()
         self.setup_fitting_notifier()
 
-        self.setup_on_recalculation_finished_notifier()
+        self.setup_counts_calculation_finished_notifier()
+
+        self.setup_asymmetry_pair_and_diff_calculations_finished_notifier()
 
         self.transform.set_up_calculation_observers(
             self.fitting_tab.fitting_tab_view.enable_tab_observer,
@@ -416,16 +418,17 @@ class FrequencyAnalysisGui(QtWidgets.QMainWindow):
         self.load_widget.load_widget.load_run_widget.disable_notifier.add_subscriber(
             self.transform.disable_observer)
 
-    def setup_on_recalculation_finished_notifier(self):
+    def setup_counts_calculation_finished_notifier(self):
+        self.grouping_tab_widget.group_tab_presenter.counts_calculation_finished_notifier.add_subscriber(
+            self.corrections_tab.corrections_tab_presenter.pre_process_and_grouping_complete_observer)
+
+    def setup_asymmetry_pair_and_diff_calculations_finished_notifier(self):
         for observer in self.plot_widget.data_changed_observers:
-            self.grouping_tab_widget.group_tab_presenter.calculation_finished_notifier.add_subscriber(observer)
+            self.corrections_tab.corrections_tab_presenter.counts_calculation_finished_notifier.add_subscriber(observer)
             self.phase_tab.phase_table_presenter.calculation_finished_notifier.add_subscriber(observer)
 
-        self.grouping_tab_widget.group_tab_presenter.calculation_finished_notifier.add_subscriber(
+        self.corrections_tab.corrections_tab_presenter.asymmetry_pair_and_diff_calculations_finished_notifier.add_subscriber(
             self.seq_fitting_tab.seq_fitting_tab_presenter.selected_workspaces_observer)
-
-        self.grouping_tab_widget.group_tab_presenter.calculation_finished_notifier.add_subscriber(
-            self.corrections_tab.corrections_tab_presenter.pre_process_and_grouping_complete_observer)
 
     def setup_phase_quad_changed_notifier(self):
         self.phase_tab.phase_table_presenter.phasequad_calculation_complete_notifier.add_subscriber(

--- a/scripts/Muon/GUI/FrequencyDomainAnalysis/frequency_domain_analysis.py
+++ b/scripts/Muon/GUI/FrequencyDomainAnalysis/frequency_domain_analysis.py
@@ -206,7 +206,7 @@ class FrequencyAnalysisGui(QtWidgets.QMainWindow):
 
     def handle_tab_changed(self):
         index = self.tabs.currentIndex()
-        if TAB_ORDER[index] in ["Home", "Grouping", "Phase Table"]:  # Plot all the selected data
+        if TAB_ORDER[index] in ["Home", "Grouping", "Corrections", "Phase Table"]:  # Plot all the selected data
             plot_mode = self.plot_widget.data_index
         elif TAB_ORDER[index] in ["Fitting", "Sequential Fitting", "Transform"]:  # Plot the displayed workspace
             plot_mode = self.plot_widget.frequency_index

--- a/scripts/Muon/GUI/FrequencyDomainAnalysis/frequency_domain_analysis.py
+++ b/scripts/Muon/GUI/FrequencyDomainAnalysis/frequency_domain_analysis.py
@@ -275,9 +275,6 @@ class FrequencyAnalysisGui(QtWidgets.QMainWindow):
             self.corrections_tab.corrections_tab_presenter.load_observer)
 
         self.load_widget.load_widget.loadNotifier.add_subscriber(
-            self.transform.LoadObserver)
-
-        self.load_widget.load_widget.loadNotifier.add_subscriber(
             self.phase_tab.phase_table_presenter.run_change_observer)
 
         self.load_widget.load_widget.loadNotifier.add_subscriber(
@@ -431,6 +428,9 @@ class FrequencyAnalysisGui(QtWidgets.QMainWindow):
             self.corrections_tab.corrections_tab_presenter.asymmetry_pair_and_diff_calculations_finished_notifier.\
                 add_subscriber(observer)
             self.phase_tab.phase_table_presenter.calculation_finished_notifier.add_subscriber(observer)
+
+        self.corrections_tab.corrections_tab_presenter.asymmetry_pair_and_diff_calculations_finished_notifier.add_subscriber(
+            self.transform.load_observer)
 
         self.corrections_tab.corrections_tab_presenter.asymmetry_pair_and_diff_calculations_finished_notifier.add_subscriber(
             self.seq_fitting_tab.seq_fitting_tab_presenter.selected_workspaces_observer)

--- a/scripts/Muon/GUI/FrequencyDomainAnalysis/frequency_domain_analysis.py
+++ b/scripts/Muon/GUI/FrequencyDomainAnalysis/frequency_domain_analysis.py
@@ -220,6 +220,10 @@ class FrequencyAnalysisGui(QtWidgets.QMainWindow):
         self.fitting_tab.fitting_tab_presenter.set_selected_dataset(new_data_workspace_name)
         self.seq_fitting_tab.seq_fitting_tab_presenter.handle_selected_workspaces_changed()
 
+    def set_tab_warning(self, tab_name: str, message: str):
+        """Sets a warning message as the tooltip of the provided tab."""
+        self.tabs.set_tab_warning(TAB_ORDER.index(tab_name), message)
+
     def setup_disable_notifier(self):
 
         self.disable_notifier.add_subscriber(self.home_tab.home_tab_widget.disable_observer)

--- a/scripts/Muon/GUI/MuonAnalysis/muon_analysis_2.py
+++ b/scripts/Muon/GUI/MuonAnalysis/muon_analysis_2.py
@@ -168,7 +168,9 @@ class MuonAnalysisGui(QtWidgets.QMainWindow):
 
         self.setup_fitting_notifier()
 
-        self.setup_on_recalulation_finished_notifier()
+        self.setup_counts_calculation_finished_notifier()
+
+        self.setup_asymmetry_pair_and_diff_calculations_finished_notifier()
 
         self.setup_results_notifier()
 
@@ -441,18 +443,19 @@ class MuonAnalysisGui(QtWidgets.QMainWindow):
         self.load_widget.load_widget.load_run_widget.disable_notifier.add_subscriber(
             self.fitting_tab.fitting_tab_view.disable_tab_observer)
 
-    def setup_on_recalulation_finished_notifier(self):
-        self.grouping_tab_widget.group_tab_presenter.calculation_finished_notifier.add_subscriber(
+    def setup_counts_calculation_finished_notifier(self):
+        self.grouping_tab_widget.group_tab_presenter.counts_calculation_finished_notifier.add_subscriber(
             self.corrections_tab.corrections_tab_presenter.pre_process_and_counts_calculated_observer)
 
-        self.grouping_tab_widget.group_tab_presenter.calculation_finished_notifier.add_subscriber(
+    def setup_asymmetry_pair_and_diff_calculations_finished_notifier(self):
+        self.corrections_tab.corrections_tab_presenter.asymmetry_pair_and_diff_calculations_finished_notifier.add_subscriber(
             self.fitting_tab.fitting_tab_presenter.input_workspace_observer)
 
-        self.grouping_tab_widget.group_tab_presenter.calculation_finished_notifier.add_subscriber(
+        self.corrections_tab.corrections_tab_presenter.asymmetry_pair_and_diff_calculations_finished_notifier.add_subscriber(
             self.seq_fitting_tab.seq_fitting_tab_presenter.selected_workspaces_observer)
 
         for observer in self.plot_widget.data_changed_observers:
-            self.grouping_tab_widget.group_tab_presenter.calculation_finished_notifier.add_subscriber(observer)
+            self.corrections_tab.corrections_tab_presenter.asymmetry_pair_and_diff_calculations_finished_notifier.add_subscriber(observer)
             self.phase_tab.phase_table_presenter.calculation_finished_notifier.add_subscriber(observer)
 
     def setup_phase_quad_changed_notifier(self):

--- a/scripts/Muon/GUI/MuonAnalysis/muon_analysis_2.py
+++ b/scripts/Muon/GUI/MuonAnalysis/muon_analysis_2.py
@@ -213,6 +213,10 @@ class MuonAnalysisGui(QtWidgets.QMainWindow):
             return
         self.plot_widget.set_plot_view(plot_mode)
 
+    def set_tab_warning(self, tab_name: str, message: str):
+        """Sets a warning message as the tooltip of the provided tab."""
+        self.tabs.set_tab_warning(TAB_ORDER.index(tab_name), message)
+
     def setup_disable_notifier(self):
 
         self.disable_notifier.add_subscriber(

--- a/scripts/Muon/GUI/MuonAnalysis/muon_analysis_2.py
+++ b/scripts/Muon/GUI/MuonAnalysis/muon_analysis_2.py
@@ -202,7 +202,7 @@ class MuonAnalysisGui(QtWidgets.QMainWindow):
     def handle_tab_changed(self):
         index = self.tabs.currentIndex()
         # the plot mode indicies are from the order the plots are stored
-        if TAB_ORDER[index] in ["Home", "Grouping", "Phase Table"]:  # Plot all the selected data
+        if TAB_ORDER[index] in ["Home", "Grouping", "Corrections", "Phase Table"]:  # Plot all the selected data
             plot_mode = self.plot_widget.data_index
         # Plot the displayed workspace
         elif TAB_ORDER[index] in ["Fitting", "Sequential Fitting"]:

--- a/scripts/Muon/GUI/MuonAnalysis/muon_analysis_2.py
+++ b/scripts/Muon/GUI/MuonAnalysis/muon_analysis_2.py
@@ -443,7 +443,7 @@ class MuonAnalysisGui(QtWidgets.QMainWindow):
 
     def setup_on_recalulation_finished_notifier(self):
         self.grouping_tab_widget.group_tab_presenter.calculation_finished_notifier.add_subscriber(
-            self.corrections_tab.corrections_tab_presenter.pre_process_and_grouping_complete_observer)
+            self.corrections_tab.corrections_tab_presenter.pre_process_and_counts_calculated_observer)
 
         self.grouping_tab_widget.group_tab_presenter.calculation_finished_notifier.add_subscriber(
             self.fitting_tab.fitting_tab_presenter.input_workspace_observer)

--- a/scripts/Muon/GUI/MuonAnalysis/muon_analysis_2.py
+++ b/scripts/Muon/GUI/MuonAnalysis/muon_analysis_2.py
@@ -448,14 +448,15 @@ class MuonAnalysisGui(QtWidgets.QMainWindow):
             self.corrections_tab.corrections_tab_presenter.pre_process_and_counts_calculated_observer)
 
     def setup_asymmetry_pair_and_diff_calculations_finished_notifier(self):
-        self.corrections_tab.corrections_tab_presenter.asymmetry_pair_and_diff_calculations_finished_notifier.add_subscriber(
-            self.fitting_tab.fitting_tab_presenter.input_workspace_observer)
+        self.corrections_tab.corrections_tab_presenter.asymmetry_pair_and_diff_calculations_finished_notifier.\
+            add_subscriber(self.fitting_tab.fitting_tab_presenter.input_workspace_observer)
 
-        self.corrections_tab.corrections_tab_presenter.asymmetry_pair_and_diff_calculations_finished_notifier.add_subscriber(
-            self.seq_fitting_tab.seq_fitting_tab_presenter.selected_workspaces_observer)
+        self.corrections_tab.corrections_tab_presenter.asymmetry_pair_and_diff_calculations_finished_notifier.\
+            add_subscriber(self.seq_fitting_tab.seq_fitting_tab_presenter.selected_workspaces_observer)
 
         for observer in self.plot_widget.data_changed_observers:
-            self.corrections_tab.corrections_tab_presenter.asymmetry_pair_and_diff_calculations_finished_notifier.add_subscriber(observer)
+            self.corrections_tab.corrections_tab_presenter.asymmetry_pair_and_diff_calculations_finished_notifier.\
+                add_subscriber(observer)
             self.phase_tab.phase_table_presenter.calculation_finished_notifier.add_subscriber(observer)
 
     def setup_phase_quad_changed_notifier(self):

--- a/scripts/test/Muon/corrections_context_test.py
+++ b/scripts/test/Muon/corrections_context_test.py
@@ -100,9 +100,12 @@ class CorrectionsContextTest(unittest.TestCase):
     def test_that_the_background_correction_data_can_be_set_as_expected(self):
         run_group = tuple(["84447", "fwd"])
         start_x, end_x = 15.0, 30.0
-        self.corrections_context.background_correction_data[run_group] = BackgroundCorrectionData(start_x, end_x)
+        self.corrections_context.background_correction_data[run_group] = BackgroundCorrectionData(True, 5, start_x,
+                                                                                                  end_x)
 
         self.assertTrue(run_group in self.corrections_context.background_correction_data)
+        self.assertEqual(self.corrections_context.background_correction_data[run_group].use_raw, True)
+        self.assertEqual(self.corrections_context.background_correction_data[run_group].rebin_fixed_step, 5)
         self.assertEqual(self.corrections_context.background_correction_data[run_group].start_x, start_x)
         self.assertEqual(self.corrections_context.background_correction_data[run_group].end_x, end_x)
 

--- a/scripts/test/Muon/corrections_context_test.py
+++ b/scripts/test/Muon/corrections_context_test.py
@@ -25,7 +25,7 @@ class CorrectionsContextTest(unittest.TestCase):
         self.assertEqual(self.corrections_context.dead_time_table_name_from_ads, None)
 
         self.assertEqual(self.corrections_context.background_corrections_mode, "None")
-        self.assertEqual(self.corrections_context.selected_function, "Flat Background")
+        self.assertEqual(self.corrections_context.selected_function, "Flat Background + Exp Decay")
         self.assertEqual(self.corrections_context.selected_group, "All")
         self.assertEqual(self.corrections_context.show_all_runs, False)
 

--- a/scripts/test/Muon/corrections_tab_widget/background_corrections_model_test.py
+++ b/scripts/test/Muon/corrections_tab_widget/background_corrections_model_test.py
@@ -24,7 +24,7 @@ class BackgroundCorrectionsModelTest(unittest.TestCase):
 
     def setUp(self):
         context = setup_context()
-        self.corrections_model = CorrectionsModel(context.data_context, context.corrections_context)
+        self.corrections_model = CorrectionsModel(context)
         self.model = BackgroundCorrectionsModel(self.corrections_model, context)
         self.model.clear_background_corrections_data()
 
@@ -218,7 +218,7 @@ class BackgroundCorrectionsModelTest(unittest.TestCase):
         self.assertEqual(a0s, [self.fitted_a0] * 4)
         self.assertEqual(a0_errors, [self.fitted_a0_error] * 4)
 
-        self.model.reset_background_function_data()
+        self.model.reset_background_subtraction_data()
 
         _, _, _, _, a0s, a0_errors, _ = self.model.selected_correction_data()
 
@@ -247,6 +247,10 @@ class BackgroundCorrectionsModelTest(unittest.TestCase):
     def _populate_background_corrections_data(self, mock_retrieve_ws):
         workspace = CreateSampleWorkspace()
         mock_retrieve_ws.return_value = workspace
+
+        workspace_name = f"HIFI84447; Group; fwd; Counts; MA"
+        self.model.get_counts_workspace_name = mock.Mock(return_value=workspace_name)
+
         self.corrections_model.run_number_strings = mock.Mock(return_value=self.runs)
         self.mock_group_names = mock.PropertyMock(return_value=self.groups)
         type(self.model._context.group_pair_context).group_names = self.mock_group_names

--- a/scripts/test/Muon/corrections_tab_widget/background_corrections_model_test.py
+++ b/scripts/test/Muon/corrections_tab_widget/background_corrections_model_test.py
@@ -192,7 +192,10 @@ class BackgroundCorrectionsModelTest(unittest.TestCase):
             self.model.set_start_x(run, group, 0.0)
             self.model.set_end_x(run, group, 1.0)
 
-        self.model.run_background_correction_for_all()
+        runs, groups = self.model.run_background_correction_for_all()
+
+        self.assertEqual(runs, self.runs)
+        self.assertEqual(groups, self.groups)
 
     def test_that_run_background_correction_for_all_will_cause_an_exception_when_the_start_and_end_x_are_out_of_range(self):
         self._populate_background_corrections_data()
@@ -211,19 +214,23 @@ class BackgroundCorrectionsModelTest(unittest.TestCase):
 
         self._populate_background_corrections_data()
 
-        self.model.run_background_correction_for_all()
+        runs, groups = self.model.run_background_correction_for_all()
 
         _, _, _, _, a0s, a0_errors, _ = self.model.selected_correction_data()
 
         self.assertEqual(a0s, [self.fitted_a0] * 4)
         self.assertEqual(a0_errors, [self.fitted_a0_error] * 4)
+        self.assertEqual(runs, self.runs)
+        self.assertEqual(groups, self.groups)
 
-        self.model.reset_background_subtraction_data()
+        runs, groups = self.model.reset_background_subtraction_data()
 
         _, _, _, _, a0s, a0_errors, _ = self.model.selected_correction_data()
 
         self.assertEqual(a0s, [0.0] * 4)
         self.assertEqual(a0_errors, [0.0] * 4)
+        self.assertEqual(runs, self.runs)
+        self.assertEqual(groups, self.groups)
 
     def test_that_run_background_correction_for_will_run_without_error_when_the_start_and_end_x_is_good(self):
         run, group = "84447", "bwd"
@@ -232,7 +239,10 @@ class BackgroundCorrectionsModelTest(unittest.TestCase):
         self.model.set_start_x(run, group, 0.0)
         self.model.set_end_x(run, group, 1.0)
 
-        self.model.run_background_correction_for(run, group)
+        runs, groups = self.model.run_background_correction_for(run, group)
+
+        self.assertEqual(runs, [run])
+        self.assertEqual(groups, [group])
 
     def test_that_run_background_correction_for_will_cause_an_exception_when_the_start_and_end_x_are_out_of_range(self):
         run, group = "84447", "bwd"

--- a/scripts/test/Muon/corrections_tab_widget/background_corrections_model_test.py
+++ b/scripts/test/Muon/corrections_tab_widget/background_corrections_model_test.py
@@ -32,7 +32,7 @@ class BackgroundCorrectionsModelTest(unittest.TestCase):
 
         self.runs = ["84447", "84447", "84447", "84447"]
         self.groups = ["fwd", "bwd", "top", "bottom"]
-        self.rebins = [False, False, False, False]
+        self.use_raws = [True, True, True, True]
         self.start_xs = [15.0] * 4
         self.end_xs = [30.0] * 4
         self.a0s = [0.0] * 4
@@ -54,7 +54,6 @@ class BackgroundCorrectionsModelTest(unittest.TestCase):
         self.assertEqual(self.model._corrections_context.selected_function, "Flat Background + Exp Decay")
         self.assertEqual(self.model._corrections_context.selected_group, "All")
         self.assertEqual(self.model._corrections_context.show_all_runs, False)
-        self.assertEqual(self.model._corrections_context.show_rebin_data, False)
 
     def test_that_set_background_correction_mode_will_set_the_background_mode_as_expected(self):
         self.model.set_background_correction_mode("Auto")
@@ -85,8 +84,9 @@ class BackgroundCorrectionsModelTest(unittest.TestCase):
         self.model.x_limits_of_workspace = mock.Mock(return_value=(0.0, 30.0))
         self._populate_background_corrections_data()
 
-        for run, group, rebin in zip(self.runs, self.groups, self.rebins):
-            correction_data = self.model._corrections_context.background_correction_data[tuple([run, group, rebin])]
+        for run, group in zip(self.runs, self.groups):
+            correction_data = self.model._corrections_context.background_correction_data[tuple([run, group])]
+            self.assertEqual(correction_data.use_raw, True)
             self.assertEqual(correction_data.start_x, 15.0)
             self.assertEqual(correction_data.end_x, 30.0)
             self.assertEqual(correction_data.flat_background.getParameterValue("A0"), 0.0)
@@ -97,41 +97,41 @@ class BackgroundCorrectionsModelTest(unittest.TestCase):
 
         self._populate_background_corrections_data()
 
-        self.model.set_start_x(run, "fwd", False, 5.0)
-        self.model.set_start_x(run, "bwd", False, 6.0)
-        self.model.set_start_x(run, "top", False, 7.0)
-        self.model.set_start_x(run, "bottom", False, 8.0)
+        self.model.set_start_x(run, "fwd", 5.0)
+        self.model.set_start_x(run, "bwd", 6.0)
+        self.model.set_start_x(run, "top", 7.0)
+        self.model.set_start_x(run, "bottom", 8.0)
 
-        self.assertEqual(self.model.start_x(run, "fwd", False), 5.0)
-        self.assertEqual(self.model.start_x(run, "bwd", False), 6.0)
-        self.assertEqual(self.model.start_x(run, "top", False), 7.0)
-        self.assertEqual(self.model.start_x(run, "bottom", False), 8.0)
+        self.assertEqual(self.model.start_x(run, "fwd"), 5.0)
+        self.assertEqual(self.model.start_x(run, "bwd"), 6.0)
+        self.assertEqual(self.model.start_x(run, "top"), 7.0)
+        self.assertEqual(self.model.start_x(run, "bottom"), 8.0)
 
     def test_that_set_end_x_will_set_the_end_x_in_the_background_correction_data_for_a_specific_domain(self):
         run = "84447"
 
         self._populate_background_corrections_data()
 
-        self.model.set_end_x(run, "fwd", False, 5.0)
-        self.model.set_end_x(run, "bwd", False, 6.0)
-        self.model.set_end_x(run, "top", False, 7.0)
-        self.model.set_end_x(run, "bottom", False, 8.0)
+        self.model.set_end_x(run, "fwd", 5.0)
+        self.model.set_end_x(run, "bwd", 6.0)
+        self.model.set_end_x(run, "top", 7.0)
+        self.model.set_end_x(run, "bottom", 8.0)
 
-        self.assertEqual(self.model.end_x(run, "fwd", False), 5.0)
-        self.assertEqual(self.model.end_x(run, "bwd", False), 6.0)
-        self.assertEqual(self.model.end_x(run, "top", False), 7.0)
-        self.assertEqual(self.model.end_x(run, "bottom", False), 8.0)
+        self.assertEqual(self.model.end_x(run, "fwd"), 5.0)
+        self.assertEqual(self.model.end_x(run, "bwd"), 6.0)
+        self.assertEqual(self.model.end_x(run, "top"), 7.0)
+        self.assertEqual(self.model.end_x(run, "bottom"), 8.0)
 
     def test_that_selected_correction_data_returns_all_correction_data_if_all_runs_and_groups_are_selected(self):
         self.model.x_limits_of_workspace = mock.Mock(return_value=(0.0, 30.0))
         self.model.set_show_all_runs(True)
 
         self._populate_background_corrections_data()
-        runs, groups, rebins, start_xs, end_xs, a0s, a0_errors, statuses = self.model.selected_correction_data()
+        runs, groups, use_raws, start_xs, end_xs, a0s, a0_errors, statuses = self.model.selected_correction_data()
 
         self.assertEqual(runs, self.runs)
         self.assertEqual(groups, self.groups)
-        self.assertEqual(rebins, self.rebins)
+        self.assertEqual(use_raws, self.use_raws)
         self.assertEqual(start_xs, self.start_xs)
         self.assertEqual(end_xs, self.end_xs)
         self.assertEqual(a0s, self.a0s)
@@ -141,17 +141,16 @@ class BackgroundCorrectionsModelTest(unittest.TestCase):
     def test_that_selected_correction_data_returns_all_correction_data_for_a_specific_run_and_group(self):
         run = "84447"
         group = "bwd"
-        rebin = False
         self.model.x_limits_of_workspace = mock.Mock(return_value=(0.0, 30.0))
         self.model.set_selected_group(group)
         self.corrections_model.set_current_run_string(run)
 
         self._populate_background_corrections_data()
-        runs, groups, rebins, start_xs, end_xs, a0s, a0_errors, statuses = self.model.selected_correction_data()
+        runs, groups, use_raws, start_xs, end_xs, a0s, a0_errors, statuses = self.model.selected_correction_data()
 
         self.assertEqual(runs, [run])
         self.assertEqual(groups, [group])
-        self.assertEqual(rebins, [rebin])
+        self.assertEqual(use_raws, [True])
         self.assertEqual(start_xs, [15.0])
         self.assertEqual(end_xs, [30.0])
         self.assertEqual(a0s, [0.0])
@@ -161,35 +160,33 @@ class BackgroundCorrectionsModelTest(unittest.TestCase):
     def test_that_all_runs_and_groups_returns_the_expected_run_and_group_lists(self):
         self._populate_background_corrections_data()
 
-        runs, groups, rebins = self.model.all_runs_and_groups()
+        runs, groups = self.model.all_runs_and_groups()
         self.assertEqual(runs, self.runs)
         self.assertEqual(groups, self.groups)
-        self.assertEqual(rebins, self.rebins)
 
     def test_that_all_runs_and_groups_returns_empty_lists_when_no_correction_data_exists(self):
-        runs, groups, rebins = self.model.all_runs_and_groups()
+        runs, groups = self.model.all_runs_and_groups()
         self.assertEqual(runs, [])
         self.assertEqual(groups, [])
-        self.assertEqual(rebins, [])
 
     def test_that_x_limits_of_workspace_will_return_the_x_limits_of_the_workspace(self):
-        run, group, rebin = "84447", "top", False
+        run, group = "84447", "top"
         workspace_name = f"HIFI{run}; Group; {group}; Counts; MA"
         self.model.get_counts_workspace_name = mock.Mock(return_value=workspace_name)
 
         CreateSampleWorkspace(OutputWorkspace=workspace_name)
 
-        x_lower, x_upper = self.model.x_limits_of_workspace(run, group, rebin)
+        x_lower, x_upper = self.model.x_limits_of_workspace(run, group)
 
         self.assertEqual(x_lower, 0.0)
         self.assertEqual(x_upper, 20000.0)
 
     def test_that_x_limits_of_workspace_will_return_the_default_x_values_if_there_are_no_workspaces_loaded(self):
-        run, group, rebin = "84447", "top", False
+        run, group = "84447", "top"
         workspace_name = f"HIFI{run}; Group; {group}; Counts; MA"
         self.model.get_counts_workspace_name = mock.Mock(return_value=workspace_name)
 
-        x_lower, x_upper = self.model.x_limits_of_workspace(run, group, rebin)
+        x_lower, x_upper = self.model.x_limits_of_workspace(run, group)
 
         self.assertEqual(x_lower, DEFAULT_X_LOWER)
         self.assertEqual(x_upper, DEFAULT_X_UPPER)
@@ -198,22 +195,21 @@ class BackgroundCorrectionsModelTest(unittest.TestCase):
         self.model.set_selected_function("Flat Background")
         self._populate_background_corrections_data()
 
-        for run, group, rebin in zip(self.runs, self.groups, self.rebins):
-            self.model.set_start_x(run, group, rebin, 0.0)
-            self.model.set_end_x(run, group, rebin, 1.0)
+        for run, group in zip(self.runs, self.groups):
+            self.model.set_start_x(run, group, 0.0)
+            self.model.set_end_x(run, group, 1.0)
 
-        runs, groups, rebins = self.model.run_background_correction_for_all()
+        runs, groups = self.model.run_background_correction_for_all()
 
         self.assertEqual(runs, self.runs)
         self.assertEqual(groups, self.groups)
-        self.assertEqual(rebins, self.rebins)
 
     def test_that_run_background_correction_for_all_will_cause_an_exception_when_the_start_and_end_x_are_out_of_range(self):
         self._populate_background_corrections_data()
 
-        for run, group, rebin in zip(self.runs, self.groups, self.rebins):
-            self.model.set_start_x(run, group, rebin, 20.0)
-            self.model.set_end_x(run, group, rebin, 25.0)
+        for run, group in zip(self.runs, self.groups):
+            self.model.set_start_x(run, group, 20.0)
+            self.model.set_end_x(run, group, 25.0)
 
         self.assertRaises(ValueError, self.model.run_background_correction_for_all)
 
@@ -225,7 +221,7 @@ class BackgroundCorrectionsModelTest(unittest.TestCase):
 
         self._populate_background_corrections_data()
 
-        runs, groups, rebins = self.model.run_background_correction_for_all()
+        runs, groups = self.model.run_background_correction_for_all()
 
         _, _, _, _, _, a0s, a0_errors, _ = self.model.selected_correction_data()
 
@@ -233,9 +229,8 @@ class BackgroundCorrectionsModelTest(unittest.TestCase):
         self.assertEqual(a0_errors, [self.fitted_a0_error] * 4)
         self.assertEqual(runs, self.runs)
         self.assertEqual(groups, self.groups)
-        self.assertEqual(rebins, self.rebins)
 
-        runs, groups, rebins = self.model.reset_background_subtraction_data()
+        runs, groups = self.model.reset_background_subtraction_data()
 
         _, _, _, _, _, a0s, a0_errors, _ = self.model.selected_correction_data()
 
@@ -243,30 +238,28 @@ class BackgroundCorrectionsModelTest(unittest.TestCase):
         self.assertEqual(a0_errors, [0.0] * 4)
         self.assertEqual(runs, self.runs)
         self.assertEqual(groups, self.groups)
-        self.assertEqual(rebins, self.rebins)
 
     def test_that_run_background_correction_for_will_run_without_error_when_the_start_and_end_x_is_good(self):
-        run, group, rebin = "84447", "bwd", False
+        run, group = "84447", "bwd"
         self.model.set_selected_function("Flat Background")
         self._populate_background_corrections_data()
 
-        self.model.set_start_x(run, group, rebin, 0.0)
-        self.model.set_end_x(run, group, rebin, 1.0)
+        self.model.set_start_x(run, group, 0.0)
+        self.model.set_end_x(run, group, 1.0)
 
-        runs, groups, rebins = self.model.run_background_correction_for(run, group, rebin)
+        runs, groups = self.model.run_background_correction_for(run, group)
 
         self.assertEqual(runs, [run])
         self.assertEqual(groups, [group])
-        self.assertEqual(rebins, [rebin])
 
     def test_that_run_background_correction_for_will_cause_an_exception_when_the_start_and_end_x_are_out_of_range(self):
-        run, group, rebin = "84447", "bwd", False
+        run, group = "84447", "bwd"
         self._populate_background_corrections_data()
 
-        self.model.set_start_x(run, group, rebin, 20.0)
-        self.model.set_end_x(run, group, rebin, 25.0)
+        self.model.set_start_x(run, group, 20.0)
+        self.model.set_end_x(run, group, 25.0)
 
-        self.assertRaises(ValueError, self.model.run_background_correction_for, run, group, rebin)
+        self.assertRaises(ValueError, self.model.run_background_correction_for, run, group)
 
     def _populate_background_corrections_data(self):
         workspace_name = "HIFI84447; Group; fwd; Counts; MA"

--- a/scripts/test/Muon/corrections_tab_widget/background_corrections_model_test.py
+++ b/scripts/test/Muon/corrections_tab_widget/background_corrections_model_test.py
@@ -253,12 +253,10 @@ class BackgroundCorrectionsModelTest(unittest.TestCase):
 
         self.assertRaises(ValueError, self.model.run_background_correction_for, run, group)
 
-    @mock.patch("Muon.GUI.Common.corrections_tab_widget.background_corrections_model.retrieve_ws")
-    def _populate_background_corrections_data(self, mock_retrieve_ws):
-        workspace = CreateSampleWorkspace()
-        mock_retrieve_ws.return_value = workspace
+    def _populate_background_corrections_data(self):
+        workspace_name = "HIFI84447; Group; fwd; Counts; MA"
+        CreateSampleWorkspace(OutputWorkspace=workspace_name)
 
-        workspace_name = f"HIFI84447; Group; fwd; Counts; MA"
         self.model.get_counts_workspace_name = mock.Mock(return_value=workspace_name)
 
         self.corrections_model.run_number_strings = mock.Mock(return_value=self.runs)

--- a/scripts/test/Muon/corrections_tab_widget/background_corrections_presenter_test.py
+++ b/scripts/test/Muon/corrections_tab_widget/background_corrections_presenter_test.py
@@ -44,9 +44,9 @@ class BackgroundCorrectionsPresenterTest(unittest.TestCase):
         self.presenter.handle_instrument_changed()
 
         self.model.set_background_correction_mode.assert_called_once_with("None")
-        self.model.set_selected_function.assert_called_once_with("Flat Background")
+        self.model.set_selected_function.assert_called_once_with("Flat Background + Exp Decay")
         self.mock_view_background_correction_mode.assert_called_once_with("None")
-        self.mock_view_selected_function.assert_called_once_with("Flat Background")
+        self.mock_view_selected_function.assert_called_once_with("Flat Background + Exp Decay")
 
     def test_that_handle_pre_process_and_counts_calculated_will_populate_the_background_corrections_data(self):
         self.presenter.handle_pre_process_and_counts_calculated()

--- a/scripts/test/Muon/corrections_tab_widget/background_corrections_presenter_test.py
+++ b/scripts/test/Muon/corrections_tab_widget/background_corrections_presenter_test.py
@@ -48,11 +48,11 @@ class BackgroundCorrectionsPresenterTest(unittest.TestCase):
         self.mock_view_background_correction_mode.assert_called_once_with("None")
         self.mock_view_selected_function.assert_called_once_with("Flat Background")
 
-    def test_that_handle_pre_process_and_grouping_complete_will_populate_the_background_corrections_data(self):
-        self.presenter.handle_pre_process_and_grouping_complete()
+    def test_that_handle_pre_process_and_counts_calculated_will_populate_the_background_corrections_data(self):
+        self.presenter.handle_pre_process_and_counts_calculated()
 
         self.model.populate_background_corrections_data.assert_called_once_with()
-        self.presenter._update_displayed_corrections_data.assert_called_once_with()
+        self.presenter._run_background_corrections_for_all.assert_called_once_with()
 
     def test_that_handle_groups_changed_will_populate_the_group_selector(self):
         self.presenter.handle_groups_changed()
@@ -165,6 +165,7 @@ class BackgroundCorrectionsPresenterTest(unittest.TestCase):
 
         self.presenter._update_displayed_corrections_data = mock.Mock()
         self.presenter._handle_start_or_end_x_changed = mock.Mock()
+        self.presenter._run_background_corrections_for_all = mock.Mock()
 
 
 if __name__ == '__main__':

--- a/scripts/test/Muon/corrections_tab_widget/background_corrections_view_test.py
+++ b/scripts/test/Muon/corrections_tab_widget/background_corrections_view_test.py
@@ -50,7 +50,6 @@ class BackgroundCorrectionsViewTest(unittest.TestCase, QtWidgetFinder):
         self.assertTrue(self.view.show_all_runs_checkbox.isHidden())
         self.assertTrue(self.view.apply_table_changes_to_all_checkbox.isHidden())
         self.assertTrue(self.view.correction_options_table.isHidden())
-        self.assertTrue(not self.view.background_info_label.isHidden())
 
     def test_that_set_background_correction_options_visible_will_make_the_correction_options_visible(self):
         self.view.set_background_correction_options_visible(True)
@@ -62,7 +61,6 @@ class BackgroundCorrectionsViewTest(unittest.TestCase, QtWidgetFinder):
         self.assertTrue(not self.view.show_all_runs_checkbox.isHidden())
         self.assertTrue(not self.view.apply_table_changes_to_all_checkbox.isHidden())
         self.assertTrue(not self.view.correction_options_table.isHidden())
-        self.assertTrue(self.view.background_info_label.isHidden())
 
     def test_that_background_correction_mode_will_return_and_set_the_correction_mode_as_expected(self):
         self.assertEqual(self.view.background_correction_mode, "None")

--- a/scripts/test/Muon/corrections_tab_widget/background_corrections_view_test.py
+++ b/scripts/test/Muon/corrections_tab_widget/background_corrections_view_test.py
@@ -15,7 +15,7 @@ from mantidqt.utils.qt.testing.qt_widget_finder import QtWidgetFinder
 from Muon.GUI.Common.corrections_tab_widget.background_corrections_view import (BackgroundCorrectionsView,
                                                                                 RUN_COLUMN_INDEX,
                                                                                 GROUP_COLUMN_INDEX,
-                                                                                REBIN_COLUMN_INDEX,
+                                                                                USE_RAW_COLUMN_INDEX,
                                                                                 A0_COLUMN_INDEX,
                                                                                 A0_ERROR_COLUMN_INDEX,
                                                                                 STATUS_COLUMN_INDEX)
@@ -33,12 +33,13 @@ class BackgroundCorrectionsViewTest(unittest.TestCase, QtWidgetFinder):
 
         self.runs = ["84447", "84447", "84447", "84447"]
         self.groups = ["fwd", "bwd", "top", "bottom"]
-        self.rebins = [False, False, False, False]
+        self.use_raws = [True, True, True, True]
         self.start_xs = [5.0, 6.0, 7.0, 8.0]
         self.end_xs = [9.0, 10.0, 11.0, 12.0]
         self.a0s = [0.0, 0.0, 0.1, 0.1]
         self.a0_errors = [0.0, 0.0, 0.0, 0.0]
         self.statuses = ["Corrections success", "Corrections success", "Corrections success", "Corrections skipped"]
+        self.use_raw_enabled = False
 
     def tearDown(self):
         self.assertTrue(self.view.close())
@@ -96,13 +97,13 @@ class BackgroundCorrectionsViewTest(unittest.TestCase, QtWidgetFinder):
         self.assertTrue(not self.view.apply_table_changes_to_all())
 
     def test_that_is_run_group_displayed_returns_false_if_a_run_and_group_does_not_exist(self):
-        self.assertTrue(not self.view.is_run_group_displayed("FakeRun", "FakeGroup", False))
+        self.assertTrue(not self.view.is_run_group_displayed("FakeRun", "FakeGroup"))
 
     def test_that_is_run_group_displayed_returns_true_if_a_run_and_group_does_not_exist(self):
-        self.view.populate_corrections_table(self.runs, self.groups, self.rebins, self.start_xs, self.end_xs, self.a0s,
-                                             self.a0_errors, self.statuses)
-        for run, group, rebin in zip(self.runs, self.groups, self.rebins):
-            self.assertTrue(self.view.is_run_group_displayed(run, group, rebin))
+        self.view.populate_corrections_table(self.runs, self.groups, self.use_raws, self.start_xs, self.end_xs, self.a0s,
+                                             self.a0_errors, self.statuses, self.use_raw_enabled)
+        for run, group in zip(self.runs, self.groups):
+            self.assertTrue(self.view.is_run_group_displayed(run, group))
 
     def test_that_populate_group_selector_will_populate_the_group_selector_with_the_first_entry_being_all(self):
         self.view.populate_group_selector(self.groups)
@@ -118,19 +119,17 @@ class BackgroundCorrectionsViewTest(unittest.TestCase, QtWidgetFinder):
         self.assertEqual(self.view.selected_group, "bwd")
 
     def test_that_populate_corrections_table_will_display_the_data_provided_in_the_table(self):
-        self.view.populate_corrections_table(self.runs, self.groups, self.rebins, self.start_xs, self.end_xs, self.a0s,
-                                             self.a0_errors, self.statuses)
+        self.view.populate_corrections_table(self.runs, self.groups, self.use_raws, self.start_xs, self.end_xs, self.a0s,
+                                             self.a0_errors, self.statuses, self.use_raw_enabled)
 
         for row_i in range(self.view.correction_options_table.rowCount()):
             self.assertEqual(self.view.correction_options_table.item(row_i, RUN_COLUMN_INDEX).text(), self.runs[row_i])
             self.assertEqual(self.view.correction_options_table.item(row_i, GROUP_COLUMN_INDEX).text(),
                              self.groups[row_i])
-            self.assertEqual(self.view.correction_options_table.item(row_i, REBIN_COLUMN_INDEX).text(),
-                             str(self.rebins[row_i]))
-            self.assertEqual(self.view.start_x(self.runs[row_i], self.groups[row_i], self.rebins[row_i]),
-                             self.start_xs[row_i])
-            self.assertEqual(self.view.end_x(self.runs[row_i], self.groups[row_i], self.rebins[row_i]),
-                             self.end_xs[row_i])
+            self.assertEqual(self.view.correction_options_table.item(row_i, USE_RAW_COLUMN_INDEX).checkState(),
+                             Qt.Checked)
+            self.assertEqual(self.view.start_x(self.runs[row_i], self.groups[row_i]), self.start_xs[row_i])
+            self.assertEqual(self.view.end_x(self.runs[row_i], self.groups[row_i]), self.end_xs[row_i])
             self.assertEqual(self.view.correction_options_table.item(row_i, A0_COLUMN_INDEX).text(),
                              f"{self.a0s[row_i]:.3f}")
             self.assertEqual(self.view.correction_options_table.item(row_i, A0_ERROR_COLUMN_INDEX).text(),
@@ -140,66 +139,66 @@ class BackgroundCorrectionsViewTest(unittest.TestCase, QtWidgetFinder):
 
     def test_that_set_start_x_will_set_the_start_x_for_a_specific_run_and_group(self):
         run = "84447"
-        self.view.populate_corrections_table(self.runs, self.groups, self.rebins, self.start_xs, self.end_xs, self.a0s,
-                                             self.a0_errors, self.statuses)
+        self.view.populate_corrections_table(self.runs, self.groups, self.use_raws, self.start_xs, self.end_xs, self.a0s,
+                                             self.a0_errors, self.statuses, self.use_raw_enabled)
 
-        self.view.set_start_x(run, "fwd", False, 1.1)
-        self.view.set_start_x(run, "bwd", False, 2.2)
-        self.view.set_start_x(run, "top", False, 3.3)
-        self.view.set_start_x(run, "bottom", False, 4.4)
+        self.view.set_start_x(run, "fwd", 1.1)
+        self.view.set_start_x(run, "bwd", 2.2)
+        self.view.set_start_x(run, "top", 3.3)
+        self.view.set_start_x(run, "bottom", 4.4)
 
-        self.assertEqual(self.view.start_x(run, "fwd", False), 1.1)
-        self.assertEqual(self.view.start_x(run, "bwd", False), 2.2)
-        self.assertEqual(self.view.start_x(run, "top", False), 3.3)
-        self.assertEqual(self.view.start_x(run, "bottom", False), 4.4)
+        self.assertEqual(self.view.start_x(run, "fwd"), 1.1)
+        self.assertEqual(self.view.start_x(run, "bwd"), 2.2)
+        self.assertEqual(self.view.start_x(run, "top"), 3.3)
+        self.assertEqual(self.view.start_x(run, "bottom"), 4.4)
 
     def test_that_set_end_x_will_set_the_end_x_for_a_specific_run_and_group(self):
         run = "84447"
-        self.view.populate_corrections_table(self.runs, self.groups, self.rebins, self.start_xs, self.end_xs, self.a0s,
-                                             self.a0_errors, self.statuses)
+        self.view.populate_corrections_table(self.runs, self.groups, self.use_raws, self.start_xs, self.end_xs, self.a0s,
+                                             self.a0_errors, self.statuses, self.use_raw_enabled)
 
-        self.view.set_end_x(run, "fwd", False, 1.1)
-        self.view.set_end_x(run, "bwd", False, 2.2)
-        self.view.set_end_x(run, "top", False, 3.3)
-        self.view.set_end_x(run, "bottom", False, 4.4)
+        self.view.set_end_x(run, "fwd", 1.1)
+        self.view.set_end_x(run, "bwd", 2.2)
+        self.view.set_end_x(run, "top", 3.3)
+        self.view.set_end_x(run, "bottom", 4.4)
 
-        self.assertEqual(self.view.end_x(run, "fwd", False), 1.1)
-        self.assertEqual(self.view.end_x(run, "bwd", False), 2.2)
-        self.assertEqual(self.view.end_x(run, "top", False), 3.3)
-        self.assertEqual(self.view.end_x(run, "bottom", False), 4.4)
+        self.assertEqual(self.view.end_x(run, "fwd"), 1.1)
+        self.assertEqual(self.view.end_x(run, "bwd"), 2.2)
+        self.assertEqual(self.view.end_x(run, "top"), 3.3)
+        self.assertEqual(self.view.end_x(run, "bottom"), 4.4)
 
     def test_that_selected_run_and_group_will_raise_if_there_is_no_group_selected(self):
-        self.view.populate_corrections_table(self.runs, self.groups, self.rebins, self.start_xs, self.end_xs, self.a0s,
-                                             self.a0_errors, self.statuses)
+        self.view.populate_corrections_table(self.runs, self.groups, self.use_raws, self.start_xs, self.end_xs, self.a0s,
+                                             self.a0_errors, self.statuses, self.use_raw_enabled)
         self.assertRaises(RuntimeError, self.view.selected_run_and_group)
 
     def test_that_selected_run_and_group_will_return_the_run_and_group_of_the_selected_row(self):
-        self.view.populate_corrections_table(self.runs, self.groups, self.rebins, self.start_xs, self.end_xs, self.a0s,
-                                             self.a0_errors, self.statuses)
+        self.view.populate_corrections_table(self.runs, self.groups, self.use_raws, self.start_xs, self.end_xs, self.a0s,
+                                             self.a0_errors, self.statuses, self.use_raw_enabled)
 
         self._select_table_cell(2, 0)
-        self.assertEqual(self.view.selected_run_and_group(), (["84447"], ["top"], [False]))
+        self.assertEqual(self.view.selected_run_and_group(), (["84447"], ["top"]))
 
     def test_that_selected_start_x_will_raise_if_there_is_no_row_selected(self):
-        self.view.populate_corrections_table(self.runs, self.groups, self.rebins, self.start_xs, self.end_xs, self.a0s,
-                                             self.a0_errors, self.statuses)
+        self.view.populate_corrections_table(self.runs, self.groups, self.use_raws, self.start_xs, self.end_xs, self.a0s,
+                                             self.a0_errors, self.statuses, self.use_raw_enabled)
         self.assertRaises(RuntimeError, self.view.selected_start_x)
 
     def test_that_selected_start_x_will_return_the_start_x_of_the_selected_row(self):
-        self.view.populate_corrections_table(self.runs, self.groups, self.rebins, self.start_xs, self.end_xs, self.a0s,
-                                             self.a0_errors, self.statuses)
+        self.view.populate_corrections_table(self.runs, self.groups, self.use_raws, self.start_xs, self.end_xs, self.a0s,
+                                             self.a0_errors, self.statuses, self.use_raw_enabled)
 
         self._select_table_cell(2, 0)
         self.assertEqual(self.view.selected_start_x(), 7.0)
 
     def test_that_selected_end_x_will_raise_if_there_is_no_row_selected(self):
-        self.view.populate_corrections_table(self.runs, self.groups, self.rebins, self.start_xs, self.end_xs, self.a0s,
-                                             self.a0_errors, self.statuses)
+        self.view.populate_corrections_table(self.runs, self.groups, self.use_raws, self.start_xs, self.end_xs, self.a0s,
+                                             self.a0_errors, self.statuses, self.use_raw_enabled)
         self.assertRaises(RuntimeError, self.view.selected_end_x)
 
     def test_that_selected_end_x_will_return_the_end_x_of_the_selected_row(self):
-        self.view.populate_corrections_table(self.runs, self.groups, self.rebins, self.start_xs, self.end_xs, self.a0s,
-                                             self.a0_errors, self.statuses)
+        self.view.populate_corrections_table(self.runs, self.groups, self.use_raws, self.start_xs, self.end_xs, self.a0s,
+                                             self.a0_errors, self.statuses, self.use_raw_enabled)
 
         self._select_table_cell(2, 0)
         self.assertEqual(self.view.selected_end_x(), 11.0)

--- a/scripts/test/Muon/corrections_tab_widget/corrections_model_test.py
+++ b/scripts/test/Muon/corrections_tab_widget/corrections_model_test.py
@@ -87,13 +87,15 @@ class CorrectionsModelTest(unittest.TestCase):
     def test_that_calculate_asymmetry_workspaces_for_will_calculate_the_expected_asymmetry_workspace(self):
         self.context.calculate_all_counts()
 
-        self.model.calculate_asymmetry_workspaces_for([f"{self.run_number}", f"{self.run_number}"], ["fwd", "bwd"])
+        self.model.calculate_asymmetry_workspaces_for([f"{self.run_number}", f"{self.run_number}"], ["fwd", "bwd"],
+                                                      [False, False])
 
         self._assert_workspaces_exist(["EMU19489; Group; fwd; Asymmetry; MA", "EMU19489; Group; bwd; Asymmetry; MA"])
 
     def test_that_calculate_pairs_for_will_calculate_the_expected_pair_asymmetry_workspaces(self):
         self.context.calculate_all_counts()
-        self.model.calculate_asymmetry_workspaces_for([f"{self.run_number}", f"{self.run_number}"], ["fwd", "bwd"])
+        self.model.calculate_asymmetry_workspaces_for([f"{self.run_number}", f"{self.run_number}"], ["fwd", "bwd"],
+                                                      [False, False])
 
         pair_names = self.model.calculate_pairs_for([f"{self.run_number}"], ["bwd"])
 
@@ -105,7 +107,8 @@ class CorrectionsModelTest(unittest.TestCase):
         self.context.group_pair_context.add_diff(diff)
 
         self.context.calculate_all_counts()
-        self.model.calculate_asymmetry_workspaces_for([f"{self.run_number}", f"{self.run_number}"], ["fwd", "bwd"])
+        self.model.calculate_asymmetry_workspaces_for([f"{self.run_number}", f"{self.run_number}"], ["fwd", "bwd"],
+                                                      [False, False])
 
         self.model.calculate_diffs_for([f"{self.run_number}"], ["bwd"])
 

--- a/scripts/test/Muon/corrections_tab_widget/corrections_model_test.py
+++ b/scripts/test/Muon/corrections_tab_widget/corrections_model_test.py
@@ -7,10 +7,12 @@
 import unittest
 from unittest import mock
 
-from mantid.api import AnalysisDataService, FrameworkManager
+from mantid.api import AnalysisDataService, FileFinder, FrameworkManager
 
 from Muon.GUI.Common.corrections_tab_widget.corrections_model import CorrectionsModel
+from Muon.GUI.Common.muon_diff import MuonDiff
 from Muon.GUI.Common.test_helpers.context_setup import setup_context
+from Muon.GUI.Common.utilities.load_utils import load_workspace_from_filename
 
 
 class CorrectionsModelTest(unittest.TestCase):
@@ -20,10 +22,22 @@ class CorrectionsModelTest(unittest.TestCase):
         FrameworkManager.Instance()
 
     def setUp(self):
-        context = setup_context()
-        self.model = CorrectionsModel(context)
+        self.filepath = FileFinder.findRuns('EMU00019489.nxs')[0]
+        self.load_result, self.run_number, self.filename, _ = load_workspace_from_filename(self.filepath)
+
+        self.context = setup_context()
+        self.context.gui_context.update({'RebinType': 'None'})
+        self.model = CorrectionsModel(self.context)
         self.runs = [[84447], [84448], [84449]]
         self.coadd_runs = [[84447, 84448, 84449]]
+
+        self.context.data_context.instrument = 'EMU'
+        self.context.data_context._loaded_data.add_data(workspace=self.load_result, run=[self.run_number],
+                                                        filename=self.filename, instrument='EMU')
+        self.context.data_context.current_runs = [[self.run_number]]
+        self.context.data_context.update_current_data()
+        self.context.group_pair_context.reset_group_and_pairs_to_default(
+            self.load_result['OutputWorkspace'][0].workspace, 'EMU', '', 1)
 
     def _setup_for_multiple_runs(self):
         self.mock_current_runs = mock.PropertyMock(return_value=self.runs)
@@ -69,6 +83,38 @@ class CorrectionsModelTest(unittest.TestCase):
         self.model.set_current_run_string("84447-84449")
 
         self.assertEqual(self.model.current_runs(), [84447, 84448, 84449])
+
+    def test_that_calculate_asymmetry_workspaces_for_will_calculate_the_expected_asymmetry_workspace(self):
+        self.context.calculate_all_counts()
+
+        self.model.calculate_asymmetry_workspaces_for([f"{self.run_number}", f"{self.run_number}"], ["fwd", "bwd"])
+
+        self._assert_workspaces_exist(["EMU19489; Group; fwd; Asymmetry; MA", "EMU19489; Group; bwd; Asymmetry; MA"])
+
+    def test_that_calculate_pairs_for_will_calculate_the_expected_pair_asymmetry_workspaces(self):
+        self.context.calculate_all_counts()
+        self.model.calculate_asymmetry_workspaces_for([f"{self.run_number}", f"{self.run_number}"], ["fwd", "bwd"])
+
+        pair_names = self.model.calculate_pairs_for([f"{self.run_number}"], ["bwd"])
+
+        self.assertEqual(pair_names, ["long"])
+        self._assert_workspaces_exist(["EMU19489; Pair Asym; long; MA"])
+
+    def test_that_calculate_diffs_for_will_calculate_the_expected_diff_asymmetry_workspaces(self):
+        diff = MuonDiff('group_diff', 'fwd', 'bwd')
+        self.context.group_pair_context.add_diff(diff)
+
+        self.context.calculate_all_counts()
+        self.model.calculate_asymmetry_workspaces_for([f"{self.run_number}", f"{self.run_number}"], ["fwd", "bwd"])
+
+        self.model.calculate_diffs_for([f"{self.run_number}"], ["bwd"])
+
+        self._assert_workspaces_exist(["EMU19489; Diff; group_diff; Asymmetry; MA"])
+
+    def _assert_workspaces_exist(self, workspace_names: list):
+        ads_list = AnalysisDataService.getObjectNames()
+        for workspace_name in workspace_names:
+            self.assertTrue(workspace_name in ads_list)
 
 
 if __name__ == '__main__':

--- a/scripts/test/Muon/corrections_tab_widget/corrections_model_test.py
+++ b/scripts/test/Muon/corrections_tab_widget/corrections_model_test.py
@@ -87,15 +87,13 @@ class CorrectionsModelTest(unittest.TestCase):
     def test_that_calculate_asymmetry_workspaces_for_will_calculate_the_expected_asymmetry_workspace(self):
         self.context.calculate_all_counts()
 
-        self.model.calculate_asymmetry_workspaces_for([f"{self.run_number}", f"{self.run_number}"], ["fwd", "bwd"],
-                                                      [False, False])
+        self.model.calculate_asymmetry_workspaces_for([f"{self.run_number}", f"{self.run_number}"], ["fwd", "bwd"])
 
         self._assert_workspaces_exist(["EMU19489; Group; fwd; Asymmetry; MA", "EMU19489; Group; bwd; Asymmetry; MA"])
 
     def test_that_calculate_pairs_for_will_calculate_the_expected_pair_asymmetry_workspaces(self):
         self.context.calculate_all_counts()
-        self.model.calculate_asymmetry_workspaces_for([f"{self.run_number}", f"{self.run_number}"], ["fwd", "bwd"],
-                                                      [False, False])
+        self.model.calculate_asymmetry_workspaces_for([f"{self.run_number}", f"{self.run_number}"], ["fwd", "bwd"])
 
         pair_names = self.model.calculate_pairs_for([f"{self.run_number}"], ["bwd"])
 
@@ -107,8 +105,7 @@ class CorrectionsModelTest(unittest.TestCase):
         self.context.group_pair_context.add_diff(diff)
 
         self.context.calculate_all_counts()
-        self.model.calculate_asymmetry_workspaces_for([f"{self.run_number}", f"{self.run_number}"], ["fwd", "bwd"],
-                                                      [False, False])
+        self.model.calculate_asymmetry_workspaces_for([f"{self.run_number}", f"{self.run_number}"], ["fwd", "bwd"])
 
         self.model.calculate_diffs_for([f"{self.run_number}"], ["bwd"])
 

--- a/scripts/test/Muon/corrections_tab_widget/corrections_model_test.py
+++ b/scripts/test/Muon/corrections_tab_widget/corrections_model_test.py
@@ -21,7 +21,7 @@ class CorrectionsModelTest(unittest.TestCase):
 
     def setUp(self):
         context = setup_context()
-        self.model = CorrectionsModel(context.data_context, context.corrections_context)
+        self.model = CorrectionsModel(context)
         self.runs = [[84447], [84448], [84449]]
         self.coadd_runs = [[84447, 84448, 84449]]
 

--- a/scripts/test/Muon/corrections_tab_widget/corrections_presenter_test.py
+++ b/scripts/test/Muon/corrections_tab_widget/corrections_presenter_test.py
@@ -20,6 +20,7 @@ class CorrectionsPresenterTest(unittest.TestCase):
         self.current_run_string = "84447"
         self.run_strings = ["84447", "84448", "84449"]
         self.groups = ["fwd", "bwd", "bottom", "top"]
+        self.rebins = [False, False, False, False]
 
         self._setup_mock_view()
         self._setup_mock_model()
@@ -117,7 +118,8 @@ class CorrectionsPresenterTest(unittest.TestCase):
         self.presenter.enable_editing_notifier.notify_subscribers.assert_called_once_with()
         self.presenter.background_presenter.handle_background_corrections_for_all_finished.assert_called_once_with()
         self.mock_presenter_correction_results.assert_called_once_with()
-        self.presenter._perform_asymmetry_pairs_and_diffs_calculation.assert_called_once_with(self.run_strings, self.groups)
+        self.presenter._perform_asymmetry_pairs_and_diffs_calculation.assert_called_once_with(self.run_strings,
+                                                                                              self.groups, self.rebins)
 
     def test_that_handle_asymmetry_pairs_and_diffs_calc_finished_calls_the_expected_notifiers(self):
         self.presenter.handle_asymmetry_pairs_and_diffs_calc_finished()
@@ -178,7 +180,7 @@ class CorrectionsPresenterTest(unittest.TestCase):
 
         # Mock the correction result property
         self.presenter.thread_model_wrapper = mock.Mock(spec=ThreadModel)
-        self.mock_presenter_correction_results = mock.PropertyMock(return_value=(self.run_strings, self.groups))
+        self.mock_presenter_correction_results = mock.PropertyMock(return_value=(self.run_strings, self.groups, self.rebins))
         type(self.presenter.thread_model_wrapper).result = self.mock_presenter_correction_results
 
 

--- a/scripts/test/Muon/corrections_tab_widget/corrections_presenter_test.py
+++ b/scripts/test/Muon/corrections_tab_widget/corrections_presenter_test.py
@@ -11,6 +11,7 @@ from Muon.GUI.Common.corrections_tab_widget.corrections_model import Corrections
 from Muon.GUI.Common.corrections_tab_widget.corrections_presenter import CorrectionsPresenter
 from Muon.GUI.Common.corrections_tab_widget.corrections_view import CorrectionsView
 from Muon.GUI.Common.test_helpers.context_setup import setup_context
+from Muon.GUI.Common.thread_model import ThreadModel
 
 
 class CorrectionsPresenterTest(unittest.TestCase):
@@ -18,6 +19,7 @@ class CorrectionsPresenterTest(unittest.TestCase):
     def setUp(self):
         self.current_run_string = "84447"
         self.run_strings = ["84447", "84448", "84449"]
+        self.groups = ["fwd", "bwd", "bottom", "top"]
 
         self._setup_mock_view()
         self._setup_mock_model()
@@ -105,6 +107,31 @@ class CorrectionsPresenterTest(unittest.TestCase):
         self.presenter.handle_groups_changed()
         self.presenter.background_presenter.handle_groups_changed.assert_called_once_with()
 
+    def test_that_handle_thread_calculation_started_notifies_to_disable_editing(self):
+        self.presenter.handle_thread_calculation_started()
+        self.presenter.disable_editing_notifier.notify_subscribers.assert_called_once_with()
+
+    def test_that_handle_background_corrections_for_all_finished_calls_the_expected_methods(self):
+        self.presenter.handle_background_corrections_for_all_finished()
+
+        self.presenter.enable_editing_notifier.notify_subscribers.assert_called_once_with()
+        self.presenter.background_presenter.handle_background_corrections_for_all_finished.assert_called_once_with()
+        self.mock_presenter_correction_results.assert_called_once_with()
+        self.presenter._perform_asymmetry_pairs_and_diffs_calculation.assert_called_once_with(self.run_strings, self.groups)
+
+    def test_that_handle_asymmetry_pairs_and_diffs_calc_finished_calls_the_expected_notifiers(self):
+        self.presenter.handle_asymmetry_pairs_and_diffs_calc_finished()
+
+        self.presenter.enable_editing_notifier.notify_subscribers.assert_called_once_with()
+        self.presenter.asymmetry_pair_and_diff_calculations_finished_notifier.notify_subscribers.assert_called_once_with()
+
+    def test_that_handle_thread_error_will_attempt_to_show_a_warning_popup(self):
+        error = "This is an error message."
+        self.presenter.handle_thread_error(error)
+
+        self.presenter.disable_editing_notifier.notify_subscribers.assert_called_once_with()
+        self.view.warning_popup.assert_called_once_with(error)
+
     def _setup_mock_view(self):
         self.view = mock.Mock(spec=CorrectionsView)
 
@@ -127,6 +154,9 @@ class CorrectionsPresenterTest(unittest.TestCase):
     def _setup_presenter(self):
         self.context = setup_context()
         self.presenter = CorrectionsPresenter(self.view, self.model, self.context)
+        self.presenter.disable_editing_notifier = mock.Mock()
+        self.presenter.enable_editing_notifier = mock.Mock()
+        self.presenter.asymmetry_pair_and_diff_calculations_finished_notifier = mock.Mock()
 
         self.presenter.dead_time_presenter.initialize_model_options = mock.Mock()
         self.presenter.dead_time_presenter.handle_ads_clear_or_remove_workspace_event = mock.Mock()
@@ -140,10 +170,16 @@ class CorrectionsPresenterTest(unittest.TestCase):
         self.presenter.background_presenter.handle_run_selector_changed = mock.Mock()
         self.presenter.background_presenter.handle_groups_changed = mock.Mock()
         self.presenter.background_presenter.handle_pre_process_and_counts_calculated = mock.Mock()
+        self.presenter.background_presenter.handle_background_corrections_for_all_finished = mock.Mock()
 
         self.presenter._handle_selected_table_is_invalid = mock.Mock()
-
         self.presenter._notify_perform_dead_time_corrections = mock.Mock()
+        self.presenter._perform_asymmetry_pairs_and_diffs_calculation = mock.Mock()
+
+        # Mock the correction result property
+        self.presenter.thread_model_wrapper = mock.Mock(spec=ThreadModel)
+        self.mock_presenter_correction_results = mock.PropertyMock(return_value=(self.run_strings, self.groups))
+        type(self.presenter.thread_model_wrapper).result = self.mock_presenter_correction_results
 
 
 if __name__ == '__main__':

--- a/scripts/test/Muon/corrections_tab_widget/corrections_presenter_test.py
+++ b/scripts/test/Muon/corrections_tab_widget/corrections_presenter_test.py
@@ -96,10 +96,10 @@ class CorrectionsPresenterTest(unittest.TestCase):
         self.presenter.dead_time_presenter.handle_run_selector_changed.assert_called_once_with()
         self.presenter.background_presenter.handle_run_selector_changed.assert_called_once_with()
 
-    def test_that_handle_pre_process_and_grouping_complete_will_update_the_dead_time_label_in_the_view(self):
-        self.presenter.handle_pre_process_and_grouping_complete()
-        self.presenter.dead_time_presenter.handle_pre_process_and_grouping_complete.assert_called_once_with()
-        self.presenter.background_presenter.handle_pre_process_and_grouping_complete.assert_called_once_with()
+    def test_that_handle_pre_process_and_counts_calculated_will_update_the_dead_time_label_in_the_view(self):
+        self.presenter.handle_pre_process_and_counts_calculated()
+        self.presenter.dead_time_presenter.handle_pre_process_and_counts_calculated.assert_called_once_with()
+        self.presenter.background_presenter.handle_pre_process_and_counts_calculated.assert_called_once_with()
 
     def test_that_handle_groups_changed_will_notify_the_background_corrections_presenter(self):
         self.presenter.handle_groups_changed()
@@ -132,14 +132,14 @@ class CorrectionsPresenterTest(unittest.TestCase):
         self.presenter.dead_time_presenter.handle_ads_clear_or_remove_workspace_event = mock.Mock()
         self.presenter.dead_time_presenter.handle_instrument_changed = mock.Mock()
         self.presenter.dead_time_presenter.handle_run_selector_changed = mock.Mock()
-        self.presenter.dead_time_presenter.handle_pre_process_and_grouping_complete = mock.Mock()
+        self.presenter.dead_time_presenter.handle_pre_process_and_counts_calculated = mock.Mock()
 
         self.presenter.background_presenter.initialize_model_options = mock.Mock()
         self.presenter.background_presenter.handle_instrument_changed = mock.Mock()
         self.presenter.background_presenter.handle_runs_loaded = mock.Mock()
         self.presenter.background_presenter.handle_run_selector_changed = mock.Mock()
         self.presenter.background_presenter.handle_groups_changed = mock.Mock()
-        self.presenter.background_presenter.handle_pre_process_and_grouping_complete = mock.Mock()
+        self.presenter.background_presenter.handle_pre_process_and_counts_calculated = mock.Mock()
 
         self.presenter._handle_selected_table_is_invalid = mock.Mock()
 

--- a/scripts/test/Muon/corrections_tab_widget/corrections_presenter_test.py
+++ b/scripts/test/Muon/corrections_tab_widget/corrections_presenter_test.py
@@ -20,7 +20,6 @@ class CorrectionsPresenterTest(unittest.TestCase):
         self.current_run_string = "84447"
         self.run_strings = ["84447", "84448", "84449"]
         self.groups = ["fwd", "bwd", "bottom", "top"]
-        self.rebins = [False, False, False, False]
 
         self._setup_mock_view()
         self._setup_mock_model()
@@ -119,7 +118,7 @@ class CorrectionsPresenterTest(unittest.TestCase):
         self.presenter.background_presenter.handle_background_corrections_for_all_finished.assert_called_once_with()
         self.mock_presenter_correction_results.assert_called_once_with()
         self.presenter._perform_asymmetry_pairs_and_diffs_calculation.assert_called_once_with(self.run_strings,
-                                                                                              self.groups, self.rebins)
+                                                                                              self.groups)
 
     def test_that_handle_asymmetry_pairs_and_diffs_calc_finished_calls_the_expected_notifiers(self):
         self.presenter.handle_asymmetry_pairs_and_diffs_calc_finished()
@@ -180,7 +179,7 @@ class CorrectionsPresenterTest(unittest.TestCase):
 
         # Mock the correction result property
         self.presenter.thread_model_wrapper = mock.Mock(spec=ThreadModel)
-        self.mock_presenter_correction_results = mock.PropertyMock(return_value=(self.run_strings, self.groups, self.rebins))
+        self.mock_presenter_correction_results = mock.PropertyMock(return_value=(self.run_strings, self.groups))
         type(self.presenter.thread_model_wrapper).result = self.mock_presenter_correction_results
 
 

--- a/scripts/test/Muon/corrections_tab_widget/dead_time_corrections_model_test.py
+++ b/scripts/test/Muon/corrections_tab_widget/dead_time_corrections_model_test.py
@@ -23,7 +23,7 @@ class DeadTimeCorrectionsModelTest(unittest.TestCase):
 
     def setUp(self):
         context = setup_context()
-        self.corrections_model = CorrectionsModel(context.data_context, context.corrections_context)
+        self.corrections_model = CorrectionsModel(context)
         self.model = DeadTimeCorrectionsModel(self.corrections_model, context.data_context, context.corrections_context)
         self.runs = [[84447], [84448], [84449]]
         self.coadd_runs = [[84447, 84448, 84449]]

--- a/scripts/test/Muon/corrections_tab_widget/dead_time_corrections_presenter_test.py
+++ b/scripts/test/Muon/corrections_tab_widget/dead_time_corrections_presenter_test.py
@@ -189,10 +189,10 @@ class DeadTimeCorrectionsPresenterTest(unittest.TestCase):
         self.assertEqual(self.view.populate_dead_time_workspace_selector.call_count, 1)
         self.view.switch_to_using_a_dead_time_table_workspace.assert_called_once_with(filename)
 
-    def test_that_handle_pre_process_and_grouping_complete_will_update_the_dead_time_label_in_the_view(self):
+    def test_that_handle_pre_process_and_counts_calculated_will_update_the_dead_time_label_in_the_view(self):
         self.presenter.update_dead_time_info_text_in_view = mock.Mock()
 
-        self.presenter.handle_pre_process_and_grouping_complete()
+        self.presenter.handle_pre_process_and_counts_calculated()
 
         self.presenter.update_dead_time_info_text_in_view.assert_called_once_with()
 

--- a/scripts/test/Muon/fft_presenter_context_interaction_test.py
+++ b/scripts/test/Muon/fft_presenter_context_interaction_test.py
@@ -54,6 +54,7 @@ class FFTPresenterTest(unittest.TestCase):
 
         self.run_list = [22725]
         self.groups = [MuonGroup(group) for group in GROUP_LIST]
+        self.rebins = [False] * len(self.groups)
         self.pairs = [MuonPair(EXAMPLE_PAIR, 'top', 'bottom', alpha=0.75)]
 
         self.presenter = fft_presenter.FFTPresenter(
@@ -78,9 +79,9 @@ class FFTPresenterTest(unittest.TestCase):
 
     def _calculate_all_data(self):
         self.context.calculate_all_counts()
-        for group in self.groups:
-            self.context.calculate_asymmetry_for(self.run_list, group)
-            self.context.show_group(self.run_list, group)
+        for group, rebin in zip(self.groups, self.rebins):
+            self.context.calculate_asymmetry_for(self.run_list, group, rebin)
+            self.context.show_group(self.run_list, group, rebin)
         for pair in self.pairs:
             self.context.calculate_pair_for(self.run_list, pair)
             self.context.show_pair(self.run_list, pair)
@@ -142,6 +143,8 @@ class FFTPresenterTest(unittest.TestCase):
 
     def test_handle_use_raw_data_changed_when_rebin_set(self):
         self.context.gui_context.update({'RebinType': 'Fixed', 'RebinFixed': 2})
+        self.groups = [MuonGroup(group) for group in GROUP_LIST] * 2
+        self.rebins = [False] * len(GROUP_LIST) + [True] * len(GROUP_LIST)
         self._calculate_all_data()
         self.view.set_raw_checkbox_state(False)
 

--- a/scripts/test/Muon/fft_presenter_context_interaction_test.py
+++ b/scripts/test/Muon/fft_presenter_context_interaction_test.py
@@ -7,6 +7,7 @@
 import unittest
 from unittest import mock
 
+from Muon.GUI.Common.muon_group import MuonGroup
 from Muon.GUI.Common.muon_pair import MuonPair
 from Muon.GUI.Common.test_helpers.context_setup import setup_context
 from Muon.GUI.Common.utilities import load_utils
@@ -51,6 +52,10 @@ class FFTPresenterTest(unittest.TestCase):
         self.model1 = fft_model.FFTModel()
         self.model = fft_model.FFTWrapper
 
+        self.run_list = [22725]
+        self.groups = [MuonGroup(group) for group in GROUP_LIST]
+        self.pairs = [MuonPair(EXAMPLE_PAIR, 'top', 'bottom', alpha=0.75)]
+
         self.presenter = fft_presenter.FFTPresenter(
             self.view, self.model, self.context)
 
@@ -61,10 +66,8 @@ class FFTPresenterTest(unittest.TestCase):
         self.context.data_context.current_runs = [[22725]]
 
         self.context.update_current_data()
-        test_pair = MuonPair(EXAMPLE_PAIR, 'top', 'bottom', alpha=0.75)
-        self.context.group_pair_context.add_pair(pair=test_pair)
-        self.context.show_all_groups()
-        self.context.show_all_pairs()
+        self.context.group_pair_context.add_pair(pair=self.pairs[0])
+        self._calculate_all_data()
         self.context.group_pair_context._selected_groups = GROUP_LIST
         self.context.group_pair_context._selected_pairs = [EXAMPLE_PAIR]
 
@@ -72,6 +75,15 @@ class FFTPresenterTest(unittest.TestCase):
 
     def tearDown(self):
         self.view = None
+
+    def _calculate_all_data(self):
+        self.context.calculate_all_groups()
+        for group in self.groups:
+            self.context.calculate_asymmetry_for(self.run_list, group)
+            self.context.show_group(self.run_list, group)
+        for pair in self.pairs:
+            self.context.calculate_pair_for(self.run_list, pair)
+            self.context.show_pair(self.run_list, pair)
 
     def test_getWorkspaceNames_sets_workspace_and_imaginary_workspace_list_correctly(self):
         self.presenter.getWorkspaceNames()
@@ -130,8 +142,7 @@ class FFTPresenterTest(unittest.TestCase):
 
     def test_handle_use_raw_data_changed_when_rebin_set(self):
         self.context.gui_context.update({'RebinType': 'Fixed', 'RebinFixed': 2})
-        self.context.show_all_groups()
-        self.context.show_all_pairs()
+        self._calculate_all_data()
         self.view.set_raw_checkbox_state(False)
 
         self.assertEqual(retrieve_combobox_info(self.view.ws),

--- a/scripts/test/Muon/fft_presenter_context_interaction_test.py
+++ b/scripts/test/Muon/fft_presenter_context_interaction_test.py
@@ -77,7 +77,7 @@ class FFTPresenterTest(unittest.TestCase):
         self.view = None
 
     def _calculate_all_data(self):
-        self.context.calculate_all_groups()
+        self.context.calculate_all_counts()
         for group in self.groups:
             self.context.calculate_asymmetry_for(self.run_list, group)
             self.context.show_group(self.run_list, group)

--- a/scripts/test/Muon/muon_context_test.py
+++ b/scripts/test/Muon/muon_context_test.py
@@ -62,15 +62,13 @@ class MuonContextTest(unittest.TestCase):
         self.group_pair_context.reset_group_and_pairs_to_default(self.load_result['OutputWorkspace'][0].workspace,
                                                                  'EMU', '', 1)
 
+        self.run_list = [19489]
+        self.groups = [MuonGroup("bwd"), MuonGroup("fwd")]
+        self.pairs = [MuonPair("long", "bwd", "fwd")]
+
     def tearDown(self):
         ConfigService['MantidOptions.InvisibleWorkspaces'] = 'False'
         self.context.ads_observer.unsubscribe()
-
-    def populate_ADS(self):
-        self.context.calculate_all_groups()
-        self.context.show_all_groups()
-        self.context.calculate_all_pairs()
-        self.context.show_all_pairs()
 
     def add_group_diff(self):
         diff = MuonDiff('group_diff', 'fwd', 'bwd')
@@ -83,6 +81,18 @@ class MuonContextTest(unittest.TestCase):
         diff = MuonDiff('pair_diff', 'long', 'long2', 'pair')
         self.group_pair_context.add_diff(diff)
         return diff
+
+    def _calculate_data_for(self, run_list: list, groups: list = [], pairs: list = [], diffs: list = []):
+        self.context.calculate_all_groups()
+        for group in groups:
+            self.context.calculate_asymmetry_for(run_list, group)
+            self.context.show_group(run_list, group)
+        for pair in pairs:
+            self.context.calculate_pair_for(run_list, pair)
+            self.context.show_pair(run_list, pair)
+        for diff in diffs:
+            self.context.calculate_diff_for(run_list, diff)
+            self.context.show_diff(run_list, diff)
 
     def _assert_list_in_ADS(self, workspace_name_list):
         ads_list = AnalysisDataService.getObjectNames()
@@ -115,8 +125,10 @@ class MuonContextTest(unittest.TestCase):
     def test_calculate_group_calculates_group_for_given_run(self):
         # Generate the pre_process_data workspace
         run_pre_processing(self.context, [self.run_number], rebin=False)
-        counts_workspace, asymmetry_workspace, group_asymmetry_unormalised = self.context.calculate_group(MuonGroup('fwd'),
-                                                                                                          run=[19489])
+
+        group = MuonGroup('fwd')
+        counts_workspace = self.context.calculate_counts(self.run_list, group)
+        asymmetry_workspace, group_asymmetry_unormalised = self.context.calculate_asymmetry(self.run_list, group)
 
         self.assertEqual(counts_workspace, 'EMU19489; Group; fwd; Counts; MA')
         self.assertEqual(asymmetry_workspace, 'EMU19489; Group; fwd; Asymmetry; MA')
@@ -125,42 +137,50 @@ class MuonContextTest(unittest.TestCase):
     def test_calculate_group_with_no_relevant_periods_returns_none(self):
         # Generate the pre_process_data workspace
         run_pre_processing(self.context, [self.run_number], rebin=False)
-        counts_workspace, asymmetry_workspace, group_asymmetry_unormalised = self.context.calculate_group(MuonGroup('fwd', periods=(3,4)),
-                                                                                                          run=[19489])
+
+        group = MuonGroup('fwd', periods=(3, 4))
+        counts_workspace = self.context.calculate_counts(self.run_list, group)
+        asymmetry_workspaces = self.context.calculate_asymmetry(self.run_list, group)
 
         self.assertEqual(counts_workspace, None)
-        self.assertEqual(asymmetry_workspace, None)
-        self.assertEqual(group_asymmetry_unormalised, None)
+        self.assertEqual(asymmetry_workspaces, None)
 
     def test_calculate_pair_calculates_pair_for_given_run(self):
-        self.context.show_all_groups()
+        self._calculate_data_for(self.run_list, self.groups)
+
         long = MuonPair('long', 'fwd', 'bwd')
-        pair_asymmetry = self.context.calculate_pair(long, [19489], False)
+        pair_asymmetry = self.context.calculate_pair(long, self.run_list, False)
 
         self.assertEqual(pair_asymmetry, 'EMU19489; Pair Asym; long; MA')
 
     def test_calculate_pair_returns_nothing_if_relevant_groups_do_not_exist(self):
-        self.context.show_all_groups()
+        self._calculate_data_for(self.run_list, self.groups)
+
         long = MuonPair('long', 'fwd', 'bwd')
-        pair_asymmetry = self.context.calculate_pair(long, [19489], True)
+        pair_asymmetry = self.context.calculate_pair(long, self.run_list, True)
 
         self.assertEqual(pair_asymmetry, None)
 
     def test_calculate_group_diff_calculates_diff_for_given_run(self):
-        self.context.show_all_groups()
+        self._calculate_data_for(self.run_list, self.groups)
+
         diff = MuonDiff('diff', 'fwd', 'bwd')
-        diff_asymmetry = self.context.calculate_diff(diff, [19489], False)
+        diff_asymmetry = self.context.calculate_diff(diff, self.run_list, False)
 
         self.assertEqual(diff_asymmetry, 'EMU19489; Diff; diff; Asymmetry; MA')
 
     def test_calculate_pair_diff_calculates_diff_for_given_run(self):
         diff = self.add_pair_diff()
-        self.populate_ADS()
-        diff_asymmetry = self.context.calculate_diff(diff, [19489], False)
-        self.assertEqual(diff_asymmetry, 'EMU19489; Diff; pair_diff; Asymmetry; MA')
+
+        pairs = [MuonPair("long", "bwd", "fwd"), MuonPair("long2", "bwd", "fwd")]
+        diffs = [diff]
+
+        self._calculate_data_for(self.run_list, self.groups, pairs, diffs)
+
+        self._assert_list_in_ADS(['EMU19489; Diff; pair_diff; Asymmetry; MA'])
 
     def test_calculate_group_diff_returns_nothing_if_relevant_groups_do_not_exist(self):
-        self.context.show_all_groups()
+        self.context.calculate_all_groups()
         diff = MuonDiff('diff', 'fwd', 'bwd')
         diff_asymmetry = self.context.calculate_diff(diff, [19489], True)
 
@@ -168,12 +188,12 @@ class MuonContextTest(unittest.TestCase):
 
     def test_calculate_pair_diff_returns_nothing_if_relevant_pairs_do_not_exist(self):
         diff = self.add_pair_diff()
-        self.populate_ADS()
+        self.context.calculate_all_groups()
         diff_asymmetry = self.context.calculate_diff(diff, [19489], True)
         self.assertEqual(diff_asymmetry, None)
 
-    def test_show_all_groups_calculates_and_shows_all_groups(self):
-        self.context.show_all_groups()
+    def test_all_groups_are_calculated_as_expected(self):
+        self._calculate_data_for(self.run_list, self.groups)
 
         self._assert_list_in_ADS(['__EMU19489; Group; bwd; Asymmetry; MA_unnorm',
                                   '__EMU19489; Group; fwd; Asymmetry; MA_unnorm',
@@ -185,7 +205,7 @@ class MuonContextTest(unittest.TestCase):
         self.gui_context['RebinType'] = 'Fixed'
         self.gui_context['RebinFixed'] = 2
 
-        self.context.show_all_groups()
+        self._calculate_data_for(self.run_list, self.groups)
 
         self._assert_list_in_ADS(['__EMU19489; Group; bwd; Asymmetry; MA_unnorm',
                                   '__EMU19489; Group; bwd; Asymmetry; Rebin; MA_unnorm',
@@ -198,8 +218,7 @@ class MuonContextTest(unittest.TestCase):
                                   'EMU19489; Group; fwd; Counts; MA', 'EMU19489; Group; fwd; Counts; Rebin; MA'])
 
     def test_show_all_pairs_calculates_and_shows_all_pairs(self):
-        self.context.show_all_groups()
-        self.context.show_all_pairs()
+        self._calculate_data_for(self.run_list, self.groups, self.pairs)
 
         self._assert_list_in_ADS(['EMU19489 MA', 'EMU19489; Pair Asym; long; MA'])
 
@@ -207,18 +226,18 @@ class MuonContextTest(unittest.TestCase):
         self.gui_context['RebinType'] = 'Fixed'
         self.gui_context['RebinFixed'] = 2
 
-        self.context.show_all_groups()
-        self.context.show_all_pairs()
+        self._calculate_data_for(self.run_list, self.groups, self.pairs)
 
         self._assert_list_in_ADS(['EMU19489 MA', 'EMU19489; Pair Asym; long; MA',
                                   'EMU19489; Pair Asym; long; Rebin; MA'])
 
     def test_that_show_all_calculates_and_shows_all_diffs(self):
-        self.add_group_diff()
-        self.add_pair_diff()
-        self.context.show_all_groups()
-        self.context.show_all_pairs()
-        self.context.show_all_diffs()
+        group_diff = self.add_group_diff()
+        pair_diff = self.add_pair_diff()
+
+        pairs = [MuonPair("long", "bwd", "fwd"), MuonPair("long2", "bwd", "fwd")]
+        diffs = [group_diff, pair_diff]
+        self._calculate_data_for(self.run_list, self.groups, pairs, diffs)
 
         self._assert_list_in_ADS(['EMU19489 MA', 'EMU19489; Diff; group_diff; Asymmetry; MA',
                                   'EMU19489; Diff; pair_diff; Asymmetry; MA'])
@@ -227,11 +246,12 @@ class MuonContextTest(unittest.TestCase):
         self.gui_context['RebinType'] = 'Fixed'
         self.gui_context['RebinFixed'] = 2
 
-        self.add_group_diff()
-        self.add_pair_diff()
-        self.context.show_all_groups()
-        self.context.show_all_pairs()
-        self.context.show_all_diffs()
+        group_diff = self.add_group_diff()
+        pair_diff = self.add_pair_diff()
+
+        pairs = [MuonPair("long", "bwd", "fwd"), MuonPair("long2", "bwd", "fwd")]
+        diffs = [group_diff, pair_diff]
+        self._calculate_data_for(self.run_list, self.groups, pairs, diffs)
 
         self._assert_list_in_ADS(['EMU19489 MA', 'EMU19489; Diff; group_diff; Asymmetry; MA',
                                   'EMU19489; Diff; group_diff; Asymmetry; Rebin; MA',
@@ -292,7 +312,8 @@ class MuonContextTest(unittest.TestCase):
         self.assertEqual(deadtime_table, 'deadtime_table_name')
 
     def test_get_workspace_names_returns_all_stored_workspaces_if_all_selected(self):
-        self.populate_ADS()
+        self._calculate_data_for(self.run_list, self.groups, self.pairs)
+
         workspace_list = self.context.get_names_of_workspaces_to_fit('19489', 'fwd, bwd, long')
 
         self.assertEqual(Counter(workspace_list),
@@ -300,13 +321,14 @@ class MuonContextTest(unittest.TestCase):
                                   'EMU19489; Pair Asym; long; MA']))
 
     def test_get_workspace_names_returns_nothing_if_no_parameters_passed(self):
-        self.populate_ADS()
+        self._calculate_data_for(self.run_list, self.groups)
         workspace_list = self.context.get_names_of_workspaces_to_fit()
 
         self.assertEqual(workspace_list, [])
 
     def test_get_workspaces_names_copes_with_bad_groups(self):
-        self.populate_ADS()
+        self._calculate_data_for(self.run_list, self.groups, self.pairs)
+
         workspace_list = self.context.get_names_of_workspaces_to_fit('19489', 'fwd, bwd, long, random, wrong')
 
         self.assertEqual(Counter(workspace_list),
@@ -314,7 +336,7 @@ class MuonContextTest(unittest.TestCase):
                                   'EMU19489; Pair Asym; long; MA']))
 
     def test_get_workspaces_names_copes_with_non_existent_runs(self):
-        self.populate_ADS()
+        self._calculate_data_for(self.run_list, self.groups, self.pairs)
 
         workspace_list = self.context.get_names_of_workspaces_to_fit('19489, 22222', 'fwd, bwd, long')
 
@@ -323,7 +345,7 @@ class MuonContextTest(unittest.TestCase):
                                   'EMU19489; Pair Asym; long; MA']))
 
     def test_that_run_ranged_correctly_parsed(self):
-        self.populate_ADS()
+        self._calculate_data_for(self.run_list, self.groups, self.pairs)
 
         workspace_list = self.context.get_names_of_workspaces_to_fit('19489-95', 'fwd, bwd, long')
 
@@ -331,38 +353,13 @@ class MuonContextTest(unittest.TestCase):
                          Counter(['EMU19489; Group; fwd; Asymmetry; MA', 'EMU19489; Group; bwd; Asymmetry; MA',
                                   'EMU19489; Pair Asym; long; MA']))
 
-    def test_calculate_all_pairs(self):
-        self.context._calculate_pairs = mock.Mock()
-        self.context._do_rebin = mock.Mock(return_value=False)
-
-        self.context.calculate_all_pairs()
-        self.context._calculate_pairs.assert_called_with(rebin=False)
-        self.assertEqual(self.context._calculate_pairs.call_count,1)
-
     def test_calculate_all_groups(self):
         self.context._calculate_groups = mock.Mock()
         self.context._do_rebin = mock.Mock(return_value=False)
 
         self.context.calculate_all_groups()
         self.context._calculate_groups.assert_called_with(rebin=False)
-        self.assertEqual(self.context._calculate_groups.call_count,1)
-
-    def test_calculate_all_diffs(self):
-        self.context._calculate_diffs = mock.Mock()
-        self.context._do_rebin = mock.Mock(return_value=False)
-
-        self.context.calculate_all_diffs()
-        self.context._calculate_diffs.assert_called_with(rebin=False)
-        self.assertEqual(self.context._calculate_diffs.call_count, 1)
-
-    def test_calculate_all_pairs_rebin(self):
-        self.context._calculate_pairs = mock.Mock()
-        self.context._do_rebin = mock.Mock(return_value=True)
-
-        self.context.calculate_all_pairs()
-        self.context._calculate_pairs.assert_any_call(rebin=False)
-        self.context._calculate_pairs.assert_called_with(rebin=True)
-        self.assertEqual(self.context._calculate_pairs.call_count,2)
+        self.assertEqual(self.context._calculate_groups.call_count, 1)
 
     def test_calculate_all_groups_rebin(self):
         self.context._calculate_groups = mock.Mock()
@@ -373,14 +370,64 @@ class MuonContextTest(unittest.TestCase):
         self.context._calculate_groups.assert_called_with(rebin=True)
         self.assertEqual(self.context._calculate_groups.call_count,2)
 
-    def test_calculate_all_diffs_rebin(self):
-        self.context._calculate_diffs = mock.Mock()
+    def test_that_calculate_asymmetry_for_calls_the_expected_methods(self):
+        self.context._calculate_asymmetry_for = mock.Mock()
+        self.context._do_rebin = mock.Mock(return_value=False)
+
+        group = MuonGroup("fwd")
+        self.context.calculate_asymmetry_for(self.run_list, group)
+        self.context._calculate_asymmetry_for.assert_called_with(self.run_list, group, rebin=False)
+        self.assertEqual(self.context._calculate_asymmetry_for.call_count, 1)
+
+    def test_that_calculate_asymmetry_for_calls_the_expected_methods_for_rebin(self):
+        self.context._calculate_asymmetry_for = mock.Mock()
         self.context._do_rebin = mock.Mock(return_value=True)
 
-        self.context.calculate_all_diffs()
-        self.context._calculate_diffs.assert_any_call(rebin=False)
-        self.context._calculate_diffs.assert_called_with(rebin=True)
-        self.assertEqual(self.context._calculate_diffs.call_count, 2)
+        group = MuonGroup("fwd")
+        self.context.calculate_asymmetry_for(self.run_list, group)
+        self.context._calculate_asymmetry_for.assert_any_call(self.run_list, group, rebin=False)
+        self.context._calculate_asymmetry_for.assert_called_with(self.run_list, group, rebin=True)
+        self.assertEqual(self.context._calculate_asymmetry_for.call_count, 2)
+
+    def test_that_calculate_pair_for_calls_the_expected_methods(self):
+        self.context._calculate_pair_for = mock.Mock()
+        self.context._do_rebin = mock.Mock(return_value=False)
+
+        pair = MuonPair("long", "fwd", "bwd")
+        self.context.calculate_pair_for(self.run_list, pair)
+        self.context._calculate_pair_for.assert_called_with(self.run_list, pair, rebin=False)
+        self.assertEqual(self.context._calculate_pair_for.call_count, 1)
+
+    def test_that_calculate_pair_for_calls_the_expected_methods_for_rebin(self):
+        self.context._calculate_pair_for = mock.Mock()
+        self.context._do_rebin = mock.Mock(return_value=True)
+
+        pair = MuonPair("long", "fwd", "bwd")
+        self.context.calculate_pair_for(self.run_list, pair)
+        self.context._calculate_pair_for.assert_any_call(self.run_list, pair, rebin=False)
+        self.context._calculate_pair_for.assert_called_with(self.run_list, pair, rebin=True)
+        self.assertEqual(self.context._calculate_pair_for.call_count, 2)
+
+    def test_that_calculate_diff_for_calls_the_expected_methods(self):
+        self.context._calculate_diff_for = mock.Mock()
+        self.context._do_rebin = mock.Mock(return_value=False)
+
+        diff = self.add_group_diff()
+
+        self.context.calculate_diff_for(self.run_list, diff)
+        self.context._calculate_diff_for.assert_called_with(self.run_list, diff, rebin=False)
+        self.assertEqual(self.context._calculate_diff_for.call_count, 1)
+
+    def test_that_calculate_diff_for_calls_the_expected_methods_for_rebin(self):
+        self.context._calculate_diff_for = mock.Mock()
+        self.context._do_rebin = mock.Mock(return_value=True)
+
+        diff = self.add_group_diff()
+
+        self.context.calculate_diff_for(self.run_list, diff)
+        self.context._calculate_diff_for.assert_any_call(self.run_list, diff, rebin=False)
+        self.context._calculate_diff_for.assert_called_with(self.run_list, diff, rebin=True)
+        self.assertEqual(self.context._calculate_diff_for.call_count, 2)
 
     def test_update_phasequads(self):
         phasequad = MuonPhasequad("test", "test_table")
@@ -390,7 +437,7 @@ class MuonContextTest(unittest.TestCase):
         self.assertEqual("test", self.context.group_pair_context._phasequad[0].name)
         self.assertEqual(1, len(self.context.group_pair_context._phasequad))
 
-        self.context._update_phasequads(False)
+        self.context.update_phasequads()
 
         self.assertEqual(["long", "test_Re_", "test_Im_"], self.context.group_pair_context.pair_names)
         self.assertEqual("test", self.context.group_pair_context._phasequad[0].name)

--- a/scripts/test/Muon/muon_context_with_frequency_test.py
+++ b/scripts/test/Muon/muon_context_with_frequency_test.py
@@ -54,7 +54,7 @@ class MuonContextWithFrequencyTest(unittest.TestCase):
         ConfigService['MantidOptions.InvisibleWorkspaces'] = 'False'
 
     def _calculate_all_data(self):
-        self.context.calculate_all_groups()
+        self.context.calculate_all_counts()
         for group in self.groups:
             self.context.calculate_asymmetry_for(self.run_list, group)
             self.context.show_group(self.run_list, group)

--- a/scripts/test/Muon/muon_context_with_frequency_test.py
+++ b/scripts/test/Muon/muon_context_with_frequency_test.py
@@ -48,6 +48,7 @@ class MuonContextWithFrequencyTest(unittest.TestCase):
 
         self.run_list = [19489]
         self.groups = [MuonGroup("bwd"), MuonGroup("fwd")]
+        self.rebins = [False, False]
         self.pairs = [MuonPair("long", "bwd", "fwd")]
 
     def tearDown(self):
@@ -55,9 +56,9 @@ class MuonContextWithFrequencyTest(unittest.TestCase):
 
     def _calculate_all_data(self):
         self.context.calculate_all_counts()
-        for group in self.groups:
-            self.context.calculate_asymmetry_for(self.run_list, group)
-            self.context.show_group(self.run_list, group)
+        for group, rebin in zip(self.groups, self.rebins):
+            self.context.calculate_asymmetry_for(self.run_list, group, rebin)
+            self.context.show_group(self.run_list, group, rebin)
         for pair in self.pairs:
             self.context.calculate_pair_for(self.run_list, pair)
             self.context.show_pair(self.run_list, pair)

--- a/scripts/test/Muon/muon_context_with_frequency_test.py
+++ b/scripts/test/Muon/muon_context_with_frequency_test.py
@@ -14,6 +14,8 @@ from mantid.simpleapi import CreateWorkspace
 from collections import Counter
 from Muon.GUI.Common.utilities.load_utils import load_workspace_from_filename
 from Muon.GUI.Common.ADSHandler.muon_workspace_wrapper import MuonWorkspaceWrapper
+from Muon.GUI.Common.muon_group import MuonGroup
+from Muon.GUI.Common.muon_pair import MuonPair
 from Muon.GUI.Common.test_helpers.context_setup import setup_context
 
 
@@ -44,14 +46,24 @@ class MuonContextWithFrequencyTest(unittest.TestCase):
         self.group_pair_context.reset_group_and_pairs_to_default(self.load_result['OutputWorkspace'][0].workspace,
                                                                  'EMU', '', 1)
 
+        self.run_list = [19489]
+        self.groups = [MuonGroup("bwd"), MuonGroup("fwd")]
+        self.pairs = [MuonPair("long", "bwd", "fwd")]
+
     def tearDown(self):
         ConfigService['MantidOptions.InvisibleWorkspaces'] = 'False'
 
-    def populate_ADS(self):
+    def _calculate_all_data(self):
         self.context.calculate_all_groups()
-        self.context.show_all_groups()
-        self.context.calculate_all_pairs()
-        self.context.show_all_pairs()
+        for group in self.groups:
+            self.context.calculate_asymmetry_for(self.run_list, group)
+            self.context.show_group(self.run_list, group)
+        for pair in self.pairs:
+            self.context.calculate_pair_for(self.run_list, pair)
+            self.context.show_pair(self.run_list, pair)
+
+    def populate_ADS(self):
+        self._calculate_all_data()
         CreateWorkspace([0], [0], OutputWorkspace='EMU19489; PhaseQuad; PhaseTable EMU19489')
         self.context.phase_context.add_phase_quad(
             MuonWorkspaceWrapper('EMU19489; PhaseQuad; PhaseTable EMU19489'), '19489')

--- a/scripts/test/Muon/muon_group_pair_context_test.py
+++ b/scripts/test/Muon/muon_group_pair_context_test.py
@@ -7,6 +7,7 @@
 import unittest
 
 from Muon.GUI.Common.contexts.muon_group_pair_context import MuonGroupPairContext
+from Muon.GUI.Common.muon_base import MuonRun
 from Muon.GUI.Common.muon_diff import MuonDiff
 from Muon.GUI.Common.muon_group import MuonGroup
 from Muon.GUI.Common.muon_pair import MuonPair
@@ -234,7 +235,8 @@ class MuonGroupPairContextTest(unittest.TestCase):
         self.context.add_group(group_1)
         self.context.add_group(group_2)
         self.context.add_group(group_3)
-        group_1.update_workspaces([62260], 'group_1_counts', 'group_1_asym', 'group_1_asym_unorm', False)
+        group_1.update_counts_workspace(MuonRun([62260]), 'group_1_counts', False)
+        group_1.update_asymmetry_workspace(MuonRun([62260]), 'group_1_asym', 'group_1_asym_unorm', False)
         workspace_name_list = self.context.get_group_workspace_names(runs = [[62260]], groups=['group_1'], rebin=False)
 
         group_name, run = self.context.get_group_pair_name_and_run_from_workspace_name(workspace_name_list[0])
@@ -249,7 +251,8 @@ class MuonGroupPairContextTest(unittest.TestCase):
         self.context.add_group(group_1)
         self.context.add_group(group_2)
         self.context.add_group(group_3)
-        group_1.update_workspaces([62260, 62261], 'group_1_counts', 'group_1_asym', 'group_1_asym_unorm', False)
+        group_1.update_counts_workspace(MuonRun([62260, 62261]), 'group_1_counts', False)
+        group_1.update_asymmetry_workspace(MuonRun([62260, 62261]), 'group_1_asym', 'group_1_asym_unorm', False)
         workspace_name_list = self.context.get_group_workspace_names(runs = [[62260, 62261]], groups=['group_1'], rebin=False)
 
         group_name, run = self.context.get_group_pair_name_and_run_from_workspace_name(workspace_name_list[0])
@@ -264,7 +267,8 @@ class MuonGroupPairContextTest(unittest.TestCase):
         self.context.add_group(group_1)
         self.context.add_group(group_2)
         self.context.add_group(group_3)
-        group_1.update_workspaces([62260, 62261], 'group_1_counts', 'group_1_asym', 'group_1_asym_unorm', False)
+        group_1.update_counts_workspace(MuonRun([62260, 62261]), 'group_1_counts', False)
+        group_1.update_asymmetry_workspace(MuonRun([62260, 62261]), 'group_1_asym', 'group_1_asym_unorm', False)
         workspace_name_list = self.context.get_group_workspace_names(runs = [[62260, 62261]], groups=['group_1'], rebin=False)
 
         group_name, run = self.context.get_group_pair_name_and_run_from_workspace_name(workspace_name_list[0] + '; Fit Seq Flatbackground')


### PR DESCRIPTION
**Description of work.**
This PR applies the calculated background to the Counts data using the `Minus` algorithm. The Asymmetry data is then updated as it uses the Counts data to be calculated.

**To test:**
1. Open Muon Analysis and load PSI data
2. Go Corrections tab. Select `Auto` background corrections
3. Try the following combinations. Check that the loaded data is corrected accordingly:
 - `Auto` with `Flat Background` between `5.0` and `9.8` should show `Correction skipped`
 - `Auto` with `Flat Background + Exp Decay` between `5.0` and `9.8` should show `Correction success`
 - `Auto` with `Flat Background` between `0` and `0.14` should show `Correction success` for timezero set to 0.0


Fixes #31816

*This does not require release notes* because **the full background corrections feature is not yet complete.**. Release notes will be added in a future PR.

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
