### PR TITLE
Fix documentation warnings and bad rendering

### DIFF
--- a/Framework/Algorithms/inc/MantidAlgorithms/CorelliCalibrationApply.h
+++ b/Framework/Algorithms/inc/MantidAlgorithms/CorelliCalibrationApply.h
@@ -37,7 +37,7 @@ public:
 
   /// Extra help info
   const std::vector<std::string> seeAlso() const override {
-    return {"CorelliPowderCalibrationGenerate", "CorelliCalibrationDatabase", "CorelliPowderCalibrationLoad"};
+    return {"CorelliPowderCalibrationCreate", "CorelliCalibrationDatabase"};
   };
 
 private:

--- a/Framework/Algorithms/inc/MantidAlgorithms/CorelliCalibrationDatabase.h
+++ b/Framework/Algorithms/inc/MantidAlgorithms/CorelliCalibrationDatabase.h
@@ -106,7 +106,7 @@ public:
 
   /// Extra help info
   const std::vector<std::string> seeAlso() const override {
-    return {"CorelliPowderCalibrationCreate", "CorelliPowderCalibrationLoad", "CorelliCalibrationApply"};
+    return {"CorelliPowderCalibrationCreate", "CorelliCalibrationApply"};
   };
 
   const std::string summary() const override {

--- a/Framework/PythonInterface/plugins/algorithms/PelicanReduction.py
+++ b/Framework/PythonInterface/plugins/algorithms/PelicanReduction.py
@@ -241,7 +241,7 @@ class PelicanReduction(PythonAlgorithm):
         return 'Performs an inelastic energy transfer reduction for ANSTO Pelican geometry data.'
 
     def seeAlso(self):
-        return ["NA"]
+        return []
 
     def name(self):
         return "PelicanReduction"

--- a/docs/source/algorithms/D7AbsoluteCrossSections-v1.rst
+++ b/docs/source/algorithms/D7AbsoluteCrossSections-v1.rst
@@ -99,7 +99,7 @@ where :math:`c_{0} = \text{cos}^{2} \alpha` and :math:`c_{4} = \text{cos}^{2} (\
 
 .. math::
 
-   N = \frac{1}{12} \cdot \left(2 \cdot \left( \left(\frac{\text{d}\sigma_{x}}{\text{d}\Omega}\right)_{\text{nsf}} + \left(\frac{\text{d}\sigma_{y}}{\text{d}\Omega}\right)_{\text{nsf}} + 2 \cdot \left(\frac{\text{d}\sigma_{z}}{\text{d}\Omega}\right)_{\text{nsf}} + \left(\frac{\text{d}\sigma_{x+y}}{\text{d}\Omega}\right)_{\text{nsf}} + \left(\frac{\text{d}\sigma_{x-y}}{\text{d}\Omega}\right)_{\text{nsf}} \right) \\ - \left( \left(\frac{\text{d}\sigma_{x}}{\text{d}\Omega}\right)_{\text{sf}} + \left(\frac{\text{d}\sigma_{y}}{\text{d}\Omega}\right)_{\text{sf}} + \left(\frac{\text{d}\sigma_{z}}{\text{d}\Omega}\right)_{\text{sf}} + \left(\frac{\text{d}\sigma_{x+y}}{\text{d}d\Omega}\right)_{\text{sf}} + \left(\frac{\text{d}\sigma_{x-y}}{\text{d}\Omega}\right)_{\text{sf}} \right) \right)
+   N = \frac{1}{12} \cdot \left(2 \cdot \left( \left(\frac{\text{d}\sigma_{x}}{\text{d}\Omega}\right)_{\text{nsf}} + \left(\frac{\text{d}\sigma_{y}}{\text{d}\Omega}\right)_{\text{nsf}} + 2 \cdot \left(\frac{\text{d}\sigma_{z}}{\text{d}\Omega}\right)_{\text{nsf}} + \left(\frac{\text{d}\sigma_{x+y}}{\text{d}\Omega}\right)_{\text{nsf}} + \left(\frac{\text{d}\sigma_{x-y}}{\text{d}\Omega}\right)_{\text{nsf}} \right) \right. \\ - \left. \left( \left(\frac{\text{d}\sigma_{x}}{\text{d}\Omega}\right)_{\text{sf}} + \left(\frac{\text{d}\sigma_{y}}{\text{d}\Omega}\right)_{\text{sf}} + \left(\frac{\text{d}\sigma_{z}}{\text{d}\Omega}\right)_{\text{sf}} + \left(\frac{\text{d}\sigma_{x+y}}{\text{d}d\Omega}\right)_{\text{sf}} + \left(\frac{\text{d}\sigma_{x-y}}{\text{d}\Omega}\right)_{\text{sf}} \right) \right)
 
 .. math::
 

--- a/docs/source/tutorials/extending_mantid_with_python/advanced_fit_behaviours/01_fit_stability.rst
+++ b/docs/source/tutorials/extending_mantid_with_python/advanced_fit_behaviours/01_fit_stability.rst
@@ -9,22 +9,22 @@ are declared. In some cases, however, the fit can be unstable in one or more
 of the parameters. As an example consider a Gaussian:
 
 .. math::
-    \LARGE Ae^{-\frac{(x-c)^2}{2σ^2}}
+    Ae^{-\frac{(x-c)^2}{2\sigma^2}}
 
 The simple function fits over 3 parameters:
 
 #. ``A`` - Amplitude
 #. ``c`` - Peak centre
-#. ``σ`` - Measure of the width
+#. ``\sigma`` - Measure of the width
 
-However, the :math:`\Large\frac{1}{σ^2}` dependence causes the fit to become
-unstable if the σ parameter is varied by the minimization routine. A more
-stable fit can be achieved by fitting in :math:`\Large\frac{1}{σ^2}`.
+However, the :math:`\frac{1}{\sigma^2}` dependence causes the fit to become
+unstable if the \sigma parameter is varied by the minimization routine. A more
+stable fit can be achieved by fitting in :math:`\frac{1}{\sigma^2}`.
 
-We could just naively change the **σ** parameter to :math:`\Large\frac{1}{σ^2}`
+We could just naively change the **\sigma** parameter to :math:`\frac{1}{\sigma^2}`
 and fit over this. The function is now much less user-friendly though as we
-still want to think terms of the values of **A**, **c**, **σ** and not **A**,
-**c**, :math:`\Large\frac{1}{σ^2}`.
+still want to think terms of the values of **A**, **c**, **\sigma** and not **A**,
+**c**, :math:`\frac{1}{\sigma^2}`.
 
 Our optimisation framework actually works with the concept of active
 parameters, where we allow the fitting to proceed over different parameter

--- a/docs/source/tutorials/extending_mantid_with_python/advanced_fit_behaviours/05_exercise_6.rst
+++ b/docs/source/tutorials/extending_mantid_with_python/advanced_fit_behaviours/05_exercise_6.rst
@@ -12,9 +12,9 @@ The peak can be fairly well approximated using a Lorentz function:
 
 .. math::
 
-    \LARGE \frac{A}{π}(\frac{\frac{Γ}{2}}{(x-c)^2 + (\frac{Γ}{2})^2})
+    \frac{A}{\pi}(\frac{\frac{\Gamma}{2}}{(x-c)^2 + (\frac{\Gamma}{2})^2})
 
-where ``A`` is the amplitude, ``Γ`` is the full width at half maximum and
+where ``A`` is the amplitude, ``\Gamma`` is the full width at half maximum and
 ``c`` is the peak centre. We will first define this as a simple 1D function
 and then improve it to use the peak function capabilities.
 
@@ -51,11 +51,11 @@ are as follows:
 
 .. math::
 
-    \LARGE A \longrightarrow \frac{2}{π}\frac{Γ}{Γ^2 + 4(x - c)^2}
+    A \longrightarrow \frac{2}{\pi}\frac{\Gamma}{\Gamma^2 + 4(x - c)^2}
 
-    \LARGE c \longrightarrow \frac{A}{π}\frac{Γ(x - c)}{[\{\frac{Γ}{2}\}^2 + (x - c)^2]^2}
+    c \longrightarrow \frac{A}{\pi}\frac{\Gamma(x - c)}{[\{\frac{\Gamma}{2}\}^2 + (x - c)^2]^2}
 
-    \LARGE Γ \longrightarrow - \frac{2A}{π}\frac{Γ^2 - 4(x - c)^2}{[Γ^2 + 4(x - c)^2]^2}
+    \Gamma \longrightarrow - \frac{2A}{\pi}\frac{\Gamma^2 - 4(x - c)^2}{[\Gamma^2 + 4(x - c)^2]^2}
 
 Re-run the fit using the above steps.
 


### PR DESCRIPTION
Fix several documentation warnings and bad documentation rendering. 

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

**To test:**

Build `docs-qthelp` and `docs-html`. Check that there are no warnings. Check if the modified pages render correctly, both in the browser and in the workbench help

*There is no associated issue.*


*This does not require release notes* because most of the defects were introduced in the current release

<!-- Ensure the base of this PR is correct (e.g. release-next or master)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
