### PR TITLE
Add minimum width for central Muon & FDA widgets

### DIFF
--- a/docs/source/release/v6.2.0/muon.rst
+++ b/docs/source/release/v6.2.0/muon.rst
@@ -39,6 +39,7 @@ Improvements
 - The plotting now has autoscale active by default.
 - Added a table to store phasequads in the phase tab, phasequads also no longer automatically delete themselves
   when new data is loaded
+- The labels on the tabs in the GUIs will now show in full
 
 ALC
 ---

--- a/scripts/Muon/GUI/FrequencyDomainAnalysis/frequency_domain_analysis.py
+++ b/scripts/Muon/GUI/FrequencyDomainAnalysis/frequency_domain_analysis.py
@@ -134,7 +134,6 @@ class FrequencyAnalysisGui(QtWidgets.QMainWindow):
         self.help_widget = HelpWidget(self.context.window_title)
 
         central_widget = QtWidgets.QWidget()
-        central_widget.setMinimumWidth(590)
         vertical_layout = QtWidgets.QVBoxLayout()
 
         vertical_layout.addWidget(self.load_widget.load_widget_view)
@@ -202,6 +201,8 @@ class FrequencyAnalysisGui(QtWidgets.QMainWindow):
         self.tabs.addTabWithOrder(self.results_tab.results_tab_view, 'Results')
         self.transform_finished_observer = GenericObserverWithArgPassing(self.handle_transform_performed)
         self.tabs.set_slot_for_tab_changed(self.handle_tab_changed)
+        self.tabs.setElideMode(QtCore.Qt.ElideNone)
+        self.tabs.setUsesScrollButtons(False)
 
     def handle_tab_changed(self):
         index = self.tabs.currentIndex()

--- a/scripts/Muon/GUI/FrequencyDomainAnalysis/frequency_domain_analysis.py
+++ b/scripts/Muon/GUI/FrequencyDomainAnalysis/frequency_domain_analysis.py
@@ -134,6 +134,7 @@ class FrequencyAnalysisGui(QtWidgets.QMainWindow):
         self.help_widget = HelpWidget(self.context.window_title)
 
         central_widget = QtWidgets.QWidget()
+        central_widget.setMinimumWidth(590)
         vertical_layout = QtWidgets.QVBoxLayout()
 
         vertical_layout.addWidget(self.load_widget.load_widget_view)

--- a/scripts/Muon/GUI/MuonAnalysis/muon_analysis_2.py
+++ b/scripts/Muon/GUI/MuonAnalysis/muon_analysis_2.py
@@ -140,6 +140,7 @@ class MuonAnalysisGui(QtWidgets.QMainWindow):
         vertical_layout.addWidget(self.tabs)
         vertical_layout.addWidget(self.help_widget.view)
         central_widget.setLayout(vertical_layout)
+        central_widget.setMinimumWidth(730)
 
         self.setCentralWidget(central_widget)
         self.setWindowTitle(self.context.window_title)

--- a/scripts/Muon/GUI/MuonAnalysis/muon_analysis_2.py
+++ b/scripts/Muon/GUI/MuonAnalysis/muon_analysis_2.py
@@ -140,7 +140,6 @@ class MuonAnalysisGui(QtWidgets.QMainWindow):
         vertical_layout.addWidget(self.tabs)
         vertical_layout.addWidget(self.help_widget.view)
         central_widget.setLayout(vertical_layout)
-        central_widget.setMinimumWidth(730)
 
         self.setCentralWidget(central_widget)
         self.setWindowTitle(self.context.window_title)
@@ -195,6 +194,8 @@ class MuonAnalysisGui(QtWidgets.QMainWindow):
         self.tabs.addTabWithOrder(self.results_tab.results_tab_view, 'Results')
         self.tabs.addTabWithOrder(self.model_fitting_tab.model_fitting_tab_view, 'Model Fitting')
         self.tabs.set_slot_for_tab_changed(self.handle_tab_changed)
+        self.tabs.setElideMode(QtCore.Qt.ElideNone)
+        self.tabs.setUsesScrollButtons(False)
 
     def handle_tab_changed(self):
         index = self.tabs.currentIndex()


### PR DESCRIPTION
**Description of work.**
The tab widget for Muon Analysis and Frequency Doman Analysis GUIs have been resized to allow the labels for each tab to be fully visible. This was raised by Instrument Scientists at a Muon Project Delivery Board meeting.

**Report to:** Muon Project Delivery Board

**To test:**
1. Open Muon Analysis
2. Check that the label for each tab is readable (see screenshot below as an example)

![Screenshot (10)](https://user-images.githubusercontent.com/55837273/127004787-a6ec1620-e2d7-4632-bee7-539d5f0e6bf2.png)


3. Open Frequency Domain Analysis
4. Check that the label for each tab is readable

*There is no associated issue.*

*This does not require release notes* because **it is a minor resizing of the GUI**

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
